### PR TITLE
Fix top level build

### DIFF
--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -59,6 +59,8 @@ Global
 		Release|AnyCPU = Release|AnyCPU
 		XAIntegrationDebug|Any CPU = XAIntegrationDebug|Any CPU
 		XAIntegrationRelease|Any CPU = XAIntegrationRelease|Any CPU
+		XAIntegrationDebug|AnyCPU = XAIntegrationDebug|AnyCPU
+		XAIntegrationRelease|AnyCPU = XAIntegrationRelease|AnyCPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
@@ -102,7 +104,6 @@ Global
 		{91713046-C358-4647-B162-ED4E1442F3D8}.XAIntegrationRelease|Any CPU.ActiveCfg = Debug|Any CPU
 		{91713046-C358-4647-B162-ED4E1442F3D8}.XAIntegrationRelease|Any CPU.Build.0 = Debug|Any CPU
 		{94BD81F7-B06F-4295-9636-F8A3B6BDC762}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
-		{94BD81F7-B06F-4295-9636-F8A3B6BDC762}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{94BD81F7-B06F-4295-9636-F8A3B6BDC762}.Release|AnyCPU.ActiveCfg = Release|Any CPU
 		{94BD81F7-B06F-4295-9636-F8A3B6BDC762}.Release|AnyCPU.Build.0 = Release|Any CPU
 		{94BD81F7-B06F-4295-9636-F8A3B6BDC762}.XAIntegrationDebug|Any CPU.ActiveCfg = XAIntegrationDebug|Any CPU
@@ -149,6 +150,18 @@ Global
 		{8A6CB07C-E493-4A4F-AB94-038645A27118}.XAIntegrationDebug|AnyCPU.Build.0 = Debug|Any CPU
 		{8A6CB07C-E493-4A4F-AB94-038645A27118}.XAIntegrationRelease|AnyCPU.ActiveCfg = Debug|Any CPU
 		{8A6CB07C-E493-4A4F-AB94-038645A27118}.XAIntegrationRelease|AnyCPU.Build.0 = Debug|Any CPU
+		{52C7D9B6-E8C8-47D0-9471-652D278D7D77}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{52C7D9B6-E8C8-47D0-9471-652D278D7D77}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{D18FCF91-8876-48A0-A693-2DC1E7D3D80A}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{D18FCF91-8876-48A0-A693-2DC1E7D3D80A}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{1268EADF-8344-431C-81F6-FCB7CBC99F49}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{1268EADF-8344-431C-81F6-FCB7CBC99F49}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{07BC4495-1267-4B78-9EA6-B76FEEA2A64A}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{07BC4495-1267-4B78-9EA6-B76FEEA2A64A}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{64CC4E44-CE3A-4319-BF3F-6CF8BD513870}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{64CC4E44-CE3A-4319-BF3F-6CF8BD513870}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{D48EE8D0-0A0A-4493-AEF5-DAF5F8CF86AD}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{D48EE8D0-0A0A-4493-AEF5-DAF5F8CF86AD}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{C03E6CF1-7460-4CDC-A4AB-292BBC0F61F2}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
 		{C03E6CF1-7460-4CDC-A4AB-292BBC0F61F2}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{C03E6CF1-7460-4CDC-A4AB-292BBC0F61F2}.Release|AnyCPU.ActiveCfg = Release|Any CPU

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -309,5 +309,10 @@
       <Name>jcw-gen</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\..\build-tools\mono-runtimes\mono-runtimes.mdproj">
+      <Project>{C03E6CF1-7460-4CDC-A4AB-292BBC0F61F2}</Project>
+      <Name>mono-runtimes</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="_BuildJavaInterop"
-      BeforeTargets="ResolveReferences"
+      BeforeTargets="BeforeResolveReferences"
       Inputs="..\..\external\Java.Interop\src\Java.Interop\Java.Interop.csproj"
       Outputs="$(OutputPath)\..\v1.0\Java.Interop.dll">
     <MSBuild


### PR DESCRIPTION
- Xamarin.Android.sln: Disable Java.Interop build from here. It is built
  from _BuildJavaInterop target
- Mono.Android.csproj: Add a ProjectReference to mono-runtimes project,
  but don't _use_ the reference. We just need it be built before
  Mono.Android, so that we can resolve against the built mscorlib and
  friends here.
- Mono.Android.targets: Mono.Android build was failing because it could
  not find the referenced Java.Interop.dll in ResolveAssemblyReferences.
  This was because _BuildJavaInterop was set to build
  `BeforeTargets=ResolveReferences`. But the _real_ resolution of
  references is done in targets defined in `ResolveReferencesDependsOn`.
  And that runs _before_ the `BeforeTargets`! Which means that
  _BuildJavaInterop was running too late!
  
  Solution: `BeforeTargets=BeforeResolveReferences` - JonP !
