### PR TITLE
[Xamarin.Android.Build.Tasks] Fix the inclusion of .config files in the Apk.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -278,7 +278,7 @@ namespace Xamarin.Android.Tasks
 				apk.AddFile (assembly.ItemSpec, "assemblies").CompressionLevel = CompressionLevel.None;
 				var config = Path.ChangeExtension (assembly.ItemSpec, "dll.config");
 				if (File.Exists (config))
-					apk.AddFile (config).CompressionLevel = CompressionLevel.None;
+					apk.AddFile (config, "assemblies").CompressionLevel = CompressionLevel.None;
 				// Try to add symbols if Debug
 				if (debug) {
 					var symbols = Path.ChangeExtension (assembly.ItemSpec, "dll.mdb");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2075,8 +2075,8 @@ because xbuild doesn't support framework reference assemblies.
     SkipUnchangedFiles="true" />
 
   <CopyConfigFiles
-    SourceFiles="@(_ResolvedFrameworkAssemblies)"
-    DestinationFiles="@(_ShrunkFrameworkAssemblies)" />
+    SourceFiles="@(_ResolvedFrameworkAssemblies->'%(Identity).config')"
+    DestinationFiles="@(_ShrunkFrameworkAssemblies->'%(Identity).config')" />
   
   <!-- Shrink Mono.Android.dll by removing attribute only needed for GenerateJavaStubs -->
   <RemoveRegisterAttribute


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=40804

There was an issue with including config files in the final apk when
using release builds. Firstly they were not even being picked up
because the CopyConfigFiles task was expecting a list of config files
not a list of assemblies which is what it was receiving.

Secondly the BuildApk task was not placing them in the assemblies
directory.

This commit fixes both of those issues.