### PR TITLE
[mono-runtimes] Encode $(HostOS) into `host` build path.

### DIFF
--- a/build-tools/mono-runtimes/mono-runtimes.projitems
+++ b/build-tools/mono-runtimes/mono-runtimes.projitems
@@ -19,7 +19,7 @@
       <OutputProfiler>libmono-profiler-log.so</OutputProfiler>
       <OutputMonoPosixHelper>libMonoPosixHelper.so</OutputMonoPosixHelper>
     </_MonoRuntime>
-    <_MonoRuntime Include="host" Condition="'$(HostOS)'=='Darwin'">
+    <_MonoRuntime Include="host-Darwin" Condition=" '$(HostOS)' == 'Darwin' ">
       <Ar>ar</Ar>
       <As>as</As>
       <Cc>$(HostCc)</Cc>
@@ -36,11 +36,11 @@
       <OutputProfiler>libmono-profiler-log.dylib</OutputProfiler>
       <OutputMonoPosixHelper>libMonoPosixHelper.dylib</OutputMonoPosixHelper>
     </_MonoRuntime>
-    <_MonoRuntime Include="host" Condition="'$(HostOS)'=='Linux'">
+    <_MonoRuntime Include="host-Linux" Condition=" '$(HostOS)' == 'Linux' ">
       <Ar>ar</Ar>
       <As>as</As>
       <Cc>$(HostCc)</Cc>
-      <CFlags>$(_CommonCFlags) -mmacosx-version-min=10.9</CFlags>
+      <CFlags>$(_CommonCFlags)</CFlags>
       <Cxx>$(HostCxx)</Cxx>
       <CxxCpp>cpp</CxxCpp>
       <CxxFlags></CxxFlags>


### PR DESCRIPTION
Using `build-tools/mono-runtimes/obj/$(Configuration)/host` as the
mono build path for the "host" OS is problematic when the source tree
is shared amongst multiple different operating systems, e.g. if the
`xamarin-android` checkout is in Dropbox, and the "same" Dropbox
folder is shared between OS X and Linux.

There Can Be Only One™ host OS, as it were.

(This is presumably fine for non-host builds, as cross compoilers are
used, and the cross compilers should presumably compatible object code
across operating systems...)

Improve support for cross-OS source tree sharing, and encode
`$(HostOS)` into the build path, resulting in
`build-tools/mono-runtimes/obj/$(Configuration)/host-$(HostOS)`.
This would allow OS X and Linux to share source trees without stepping
on each others toes.

(Not currently encoded: OS architecture. There Can Be Only One™
"Linux" build tree with this setup...)