### PR TITLE
Copy FSharp support assemblies from nuget

### DIFF
--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\Configuration.props" />
+  <PropertyGroup>
+    <_SourceTopDir>..\..</_SourceTopDir>
+    <_BclFrameworkDir>$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0</_BclFrameworkDir>
+    <_MonoPath>$(_SourceTopDir)\external\mono</_MonoPath>
+  </PropertyGroup>
+  <UsingTask AssemblyFile="$(_SourceTopDir)\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.GetNugetPackageBasePath" />
+  <Import Project="$(_SourceTopDir)\Configuration.props" />
   <Import Project="mono-runtimes.props" />
   <Import Project="mono-runtimes.projitems" />
-  <PropertyGroup>
-    <_MonoPath>..\..\external\mono</_MonoPath>
-  </PropertyGroup>
   <Target Name="_Autogen"
       Inputs="$(_MonoPath)\autogen.sh"
       Outputs="$(_MonoPath)\configure">
@@ -74,23 +77,34 @@
   <Target Name="_InstallBcl"
       Inputs="$(_MonoPath)\mcs\class\lib\monodroid\mscorlib.dll"
       Outputs="$(OutputPath)lib\xbuild-frameworks\MonoAndroid\v1.0\mscorlib.dll;$(OutputPath)lib\xbuild-frameworks\MonoAndroid\v1.0\RedistList\FrameworkList.xml">
-    <MakeDir Directories="$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0" />
-    <MakeDir Directories="$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0\RedistList" />
-    <MakeDir Directories="$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0\Facades" />
+    <MakeDir Directories="$(_BclFrameworkDir)" />
+    <MakeDir Directories="$(_BclFrameworkDir)\RedistList" />
+    <MakeDir Directories="$(_BclFrameworkDir)\Facades" />
     <ItemGroup>
+      <_PackageConfigFiles Include="$(_SourceTopDir)\src\Xamarin.Android.Build.Tasks\packages.config" />
+    </ItemGroup>
+    <GetNugetPackageBasePath PackageConfigFiles="@(_PackageConfigFiles)" PackageName="FSharp.Core">
+      <Output TaskParameter="BasePath" PropertyName="_FSharpCorePackagePath" />
+    </GetNugetPackageBasePath>
+    <ItemGroup>
+      <_FSharp Include="$(_SourceTopDir)\$(_FSharpCorePackagePath)\lib\portable-net45+monoandroid10+monotouch10+xamarinios10\FSharp.Core*" />
       <_Assemblies Include="$(_MonoPath)\mcs\class\lib\monodroid\*.dll" />
       <_Facades Include="$(_MonoPath)\mcs\class\lib\monodroid\Facades\*.dll" />
     </ItemGroup>
     <Copy
         SourceFiles="@(_Assemblies)"
-        DestinationFolder="$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0"
+        DestinationFolder="$(_BclFrameworkDir)"
     />
     <Copy
         SourceFiles="@(_Facades)"
-        DestinationFolder="$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0\Facades"
+        DestinationFolder="$(_BclFrameworkDir)\Facades"
+    />
+    <Copy
+        SourceFiles="@(_FSharp)"
+        DestinationFolder="$(_BclFrameworkDir)"
     />
     <Touch
-        Files="$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0\mscorlib.dll"
+        Files="$(_BclFrameworkDir)\mscorlib.dll"
     />
     <ItemGroup>
       <FrameworkList Include="&lt;FileList Redist=&quot;MonoAndroid&quot; Name=&quot;Xamarin.Android Base Class Libraries&quot;&gt;" />

--- a/src/Xamarin.Android.Build.Tasks/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/packages.config
@@ -5,4 +5,5 @@
   <package id="Irony" version="0.9.1" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net45" />
   <package id="Unofficial.Ionic.Zip" version="1.9.1.8" targetFramework="net45" />
+  <package id="FSharp.Core" version="4.0.0.1" targetFramework="net45" />
 </packages>

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -30,12 +30,14 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\DownloadUri.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\UnzipDirectoryChildren.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GenerateProfile.cs" />
+    <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GetNugetPackageBasePath.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Xamarin.Android.Tools.BootstrapTasks.targets">

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GetNugetPackageBasePath.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GetNugetPackageBasePath.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	public class GetNugetPackageBasePath : Task
+	{
+		[Required]
+		public ITaskItem [] PackageConfigFiles { get; set; }
+
+		[Required]
+		public string PackageName { get; set; }
+
+		[Output]
+		public ITaskItem BasePath { get; set; }
+
+		public override bool Execute ()
+		{
+			Log.LogMessage (MessageImportance.Low, "Task GetNugetPackageBasePath");
+			Log.LogMessage (MessageImportance.Low, "\tPackageName : {0}", PackageName);
+			Log.LogMessage (MessageImportance.Low, "\tPackageConfigFiles : ");
+			foreach (ITaskItem file in PackageConfigFiles) {
+				Log.LogMessage (MessageImportance.Low, "\t\t{0}", file.ItemSpec);
+			}
+
+			Version latest = null;
+			foreach (string file in PackageConfigFiles.Select (x => Path.GetFullPath (x.ItemSpec)).Distinct ().OrderBy (x => x)) {
+				if (!File.Exists (file)) {
+					Log.LogWarning ("\tPackages config file {0} not found", file);
+					continue;
+				}
+
+				Version tmp = GetPackageVersion (file);
+				if (latest != null && latest >= tmp)
+					continue;
+				latest = tmp;
+			}
+
+			if (latest == null)
+				Log.LogError ("NuGet Package '{0}' not found", PackageName);
+			else
+				BasePath = new TaskItem (Path.Combine ("packages", $"{PackageName}.{latest}"));
+			Log.LogMessage (MessageImportance.Low, $"BasePath == {BasePath}");
+			return !Log.HasLoggedErrors;
+		}
+
+		Version GetPackageVersion (string packageConfigFile)
+		{
+			Version ret = null;
+			var doc = new XmlDocument ();
+			doc.Load (packageConfigFile);
+
+			XmlNodeList nodes = doc.DocumentElement.SelectNodes ($"./package[@id='{PackageName}']");
+			foreach (XmlNode n in nodes) {
+				var e = n as XmlElement;
+				if (e == null)
+					continue;
+
+				Version tmp;
+				if (!Version.TryParse (e.GetAttribute ("version"), out tmp))
+					continue;
+				if (ret != null && ret >= tmp)
+					continue;
+				ret = tmp;
+			}
+
+			return ret;
+		}
+	}
+}


### PR DESCRIPTION
Instead of building F# from sources as we've been doing
so far, we'll now use a nuget to get the binaries we require.
This makes the build time much shorter.