### PR TITLE
[Xamarin.Android.Build.Tasks] Fix incremental rebuilds (Take 2!)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -65,6 +65,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(IntermediateOutputPath)Profile.g.cs" />
     <Compile Include="Linker\LinkModes.cs" />
     <Compile Include="Generator\Generator.cs" />
     <Compile Include="Linker\MonoDroid.Tuner\FixAbstractMethodsStep.cs" />
@@ -532,11 +533,11 @@
     <Compile Include="Utilities\Profile.cs" />
     <None Include="Xamarin.Android.Build.Tasks.targets" />
   </ItemGroup>
-  <Import Project="Xamarin.Android.Build.Tasks.targets" />
   <!-- MD doesn't handle MSBuildToolsPath yet
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   -->
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="Xamarin.Android.Build.Tasks.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -9,14 +9,11 @@
     <_SharedRuntimeAssemblies Include="$(_SharedRuntimeBuildPath)v1.0\*.dll;$(_SharedRuntimeBuildPath)$(AndroidFrameworkVersion)\*.dll"/>
   </ItemGroup>
 
-  <Target Name="_GenerateProfileClass" BeforeTargets="CoreCompile"
-	  Inputs="@(_SharedRuntimeAssemblies)"
-	  Outputs="$(_GeneratedProfileClass)"
-	  >
+  <Target Name="_GenerateProfileClass"
+      BeforeTargets="CoreCompile"
+      Inputs="@(_SharedRuntimeAssemblies)"
+      Outputs="$(_GeneratedProfileClass)">
     <GenerateProfile Files="@(_SharedRuntimeAssemblies)" OutputFile="$(_GeneratedProfileClass)" />
-    <ItemGroup>
-        <Compile Include="$(_GeneratedProfileClass)" />
-    </ItemGroup>
     <WriteLinesToFile
         File="$(IntermediateOutputPath)$(CleanFile)"
         Lines="$(_GeneratedProfileClass)"


### PR DESCRIPTION
Rebuilding the Xamarin.Android.Build.Tasks project would fail:

	$ xbuild
	# works

	# "change a file
	$ touch Tasks/Aapt.cs

	# Rebuild; should work, right?
	$ xbuild
		Tasks/LinkAssemblies.cs(103,32): error CS0117: `Xamarin.Android.Tasks.Profile' does not contain a definition for `SharedRuntimeAssemblies'
		Utilities/MonoAndroidHelper.cs(230,16): error CS0117: `Xamarin.Android.Tasks.Profile' does not contain a definition for `SharedRuntimeAssemblies'

	# wat?

The problem was due to a3dfd4cd *and* 59ec488b:

1. In 59ec488b, `Xamarin.Android.Build.Tasks.targets` was included
    *before* including `$(MSBuildToolsPath)\Microsoft.CSharp.targets`.
    This meant that `$(IntermediateOutputPath)` wasn't set when
    `Xamarin.Android.Build.Tasks.targets` was imported, and thus
    `$(_GeneratedProfileClass)` contained no directory name.

2. In a3dfd4cd, the `@(Compile)` item group was only updated when the
    `_GenerateProfileClass` target was executed, which only happened
    when `$(_GeneratedProfileClass)` didn't exist. This is why it
    works on the initial build but not subsequent builds.

Things worked prior to a3dfd4cd because the `_Foo` target *always*
executed, and thus `@(Compile)` always contained the generated
Profile.g.cs file.

Fix the `<Import/>` ordering issue (1), and instead of updating
`@(Compile)` when the target executes, just add the generated file to
`@(Compile)` within Xamarin.Android.Build.Tasks.csproj (2).