### PR TITLE
[msbuild] Applications crashing with `System.DllNotFoundException: sqlite3` for projects that reference sqlite but don't use fastdev (#415)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -258,8 +258,7 @@ namespace Xamarin.Android.Tasks
 
 				// Try to add config if exists
 				var config = Path.ChangeExtension (assembly.ItemSpec, "dll.config");
-				if (File.Exists (config))
-					apk.AddFile (config, "assemblies").CompressionLevel = CompressionLevel.None;
+				AddAssemblyConfigEntry (apk, config);
 
 				// Try to add symbols if Debug
 				if (debug) {
@@ -277,8 +276,7 @@ namespace Xamarin.Android.Tasks
 			foreach (ITaskItem assembly in ResolvedFrameworkAssemblies) {
 				apk.AddFile (assembly.ItemSpec, "assemblies").CompressionLevel = CompressionLevel.None;
 				var config = Path.ChangeExtension (assembly.ItemSpec, "dll.config");
-				if (File.Exists (config))
-					apk.AddFile (config, "assemblies").CompressionLevel = CompressionLevel.None;
+				AddAssemblyConfigEntry (apk, config);
 				// Try to add symbols if Debug
 				if (debug) {
 					var symbols = Path.ChangeExtension (assembly.ItemSpec, "dll.mdb");
@@ -288,6 +286,21 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 		}
+
+		void AddAssemblyConfigEntry (ZipFile apk, string configFile)
+		{
+			if (!File.Exists (configFile))
+				return;
+
+			using (var source = File.OpenRead (configFile)) {
+				var dest = new MemoryStream ();
+				source.CopyTo (dest);
+				dest.WriteByte (0);
+				dest.Position = 0;
+				apk.AddEntry ("assemblies/" + Path.GetFileName (configFile), dest).CompressionLevel = CompressionLevel.None;
+			}
+		}
+
 		static string GetTargetDirectory (string path)
 		{
 			string culture, file;

--- a/src/monodroid/jni/dylib-mono.c
+++ b/src/monodroid/jni/dylib-mono.c
@@ -77,6 +77,7 @@ int monodroid_dylib_mono_init (struct DylibMono *mono_imports, const char *libmo
 	LOAD_SYMBOL(mono_class_get_namespace)
 	LOAD_SYMBOL(mono_class_is_subclass_of)
 	LOAD_SYMBOL(mono_class_vtable)
+	LOAD_SYMBOL(mono_config_for_assembly)
 	LOAD_SYMBOL(mono_config_parse_memory)
 	LOAD_SYMBOL(mono_counters_dump)
 	LOAD_SYMBOL(mono_counters_enable)

--- a/src/monodroid/jni/dylib-mono.h
+++ b/src/monodroid/jni/dylib-mono.h
@@ -192,6 +192,7 @@ typedef void*           (*monodroid_mono_class_get_field_from_name_fptr) (MonoCl
 typedef MonoClassField* (*monodroid_mono_class_get_fields_fptr) (MonoClass *arg0, void **arg1);
 typedef void*           (*monodroid_mono_class_get_method_from_name_fptr) (MonoClass *arg0, char *arg1, int arg2);
 typedef MonoVTable*     (*monodroid_mono_class_vtable_fptr) (MonoDomain *domain, MonoClass *class);
+typedef void            (*monodroid_mono_config_for_assembly_fptr) (MonoImage *assembly);
 typedef void            (*monodroid_mono_counters_dump_fptr) (int section_mask, FILE* outfile);
 typedef void            (*monodroid_mono_counters_enable_fptr) (int arg0);
 typedef void*           (*monodroid_mono_debug_init_fptr) (int format);
@@ -316,6 +317,7 @@ struct DylibMono {
 	monodroid_mono_check_corlib_version_fptr                mono_check_corlib_version;
 
 	monodroid_mono_add_internal_call_fptr                   mono_add_internal_call;
+	monodroid_mono_config_for_assembly_fptr                 mono_config_for_assembly;
 };
 
 MONO_API  struct  DylibMono*  monodroid_dylib_mono_new (const char *libmono_path);

--- a/src/monodroid/jni/embedded-assemblies.c
+++ b/src/monodroid/jni/embedded-assemblies.c
@@ -92,6 +92,7 @@ open_from_bundles (MonoAssemblyName *aname, char **assemblies_path, void *user_d
 			if (strcmp (e->name, name) == 0 &&
 					(image  = mono->mono_image_open_from_data_with_name ((char*) e->data, e->size, 0, NULL, ref_only, name)) != NULL &&
 					(a      = mono->mono_assembly_load_from_full (image, name, &status, ref_only)) != NULL) {
+				mono->mono_config_for_assembly (image);
 				break;
 			}
 		}


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=40804

There was an issue with the way the dll.config files were
extracted from the apk. They were including additional data
at the end of the xml because the files were not null
terminated.

This patch fixes the null termination for user included
config files and those included in the debug runtime.
It also adds method to extract the config file from the apk
(this was apparently missing too).