### PR TITLE
[api-xml-adjuster] Set $(OutputPath) to $prefix/lib/mandroid

### DIFF
--- a/tools/api-xml-adjuster/api-xml-adjuster.csproj
+++ b/tools/api-xml-adjuster/api-xml-adjuster.csproj
@@ -13,7 +13,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\bin\Debug</OutputPath>
+    <OutputPath>..\..\bin\Debug\lib\mandroid</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
-    <OutputPath>..\..\bin\Release</OutputPath>
+    <OutputPath>..\..\bin\Release\lib\mandroid</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ExternalConsole>true</ExternalConsole>


### PR DESCRIPTION
Change `$(OutputPath)` for `api-xml-adjuster.csproj` to be
`bin/$(Configuration)/lib/mandroid` instead of `bin/$(Configuration)`.

This is more in keeping with the Xamarin.Android install structure.