### PR TITLE
[Xamarin.Android.Build.Tasks] [msbuild] [XVS 4.0] VS hangs/freezes when opening solutions containing Android Bindings Libraries that reference other libraries, during `GetAdditionalResourcesFromAssemblies.Execute()`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -118,6 +118,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 
   <PropertyGroup>
     <BuildDependsOn>
+      _SetupDesignTimeBuildForBuild;
       AddLibraryJarsToBind;
       $(BuildDependsOn);
       BuildDocumentation;
@@ -274,6 +275,12 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     </CreateProperty>
   </Target>
 
+  <Target Name="_SetupDesignTimeBuildForBuild">
+    <PropertyGroup>
+      <DesignTimeBuild Condition=" '$(DesignTimeBuild)' == '' ">false</DesignTimeBuild>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="_BuildAdditionalResourcesCache"
     Inputs="@(ReferencePath);@(ReferenceDependencyPaths)"
     Outputs="$(_AndroidResourcePathsCache)"
@@ -283,6 +290,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
       AndroidNdkDirectory="$(_AndroidNdkDirectory)"
       Assemblies="@(ReferencePath);@(ReferenceDependencyPaths)"
       CacheFile="$(IntermediateOutputPath)resourcepaths.cache"
+      Condition=" '$(DesignTimeBuild)' != 'true' "
     />
   </Target>
 


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=40982

The Binding targets had the same issue as the normal Common
targets for android projects. Commit d300845 added a new
target to set $(DesignTimeBuild) to false if it was not
set. This way when Visual studio does an intellisense build
we do not attempt to download additional resources.

This commit makes the same changes to the Bindings targets.