### PR TITLE
[android-toolchain] Fix the location of the android tools

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -29,7 +29,7 @@
       <HostOS>Darwin</HostOS>
       <DestDir>platform-tools</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="tools_r24.4.1-macosx.zip">
+    <AndroidSdkItem Include="android-sdk_r24.4.1-macosx.zip">
       <HostOS>Darwin</HostOS>
     </AndroidSdkItem>
     <AndroidSdkItem Include="platform-N_r01.zip">


### PR DESCRIPTION
The current directory structure for the android sdk does NOT
match the one that google creates. The tools are not in a
tools subdirectory when they should be. As a result things like
the sdkmanager do not run. It also causes problems for Xamarin Studio
since its looking for things in different places.

This commit fixes up the tools .zip that we download to make sure
the tools are extacted to the correct directory. This is because
the new zip file contains the tools directory within it rather than
just being a flat zip file. Also it is the recommended tools download
from google [1]

[1] http://developer.android.com/sdk/index.html#mac-tools