### PR TITLE
[Mono.Android.Export] Include Java.Interop.DynamicCallbackCodeGenerator

### DIFF
--- a/src/Mono.Android.Export/Mono.Android.Export.csproj
+++ b/src/Mono.Android.Export/Mono.Android.Export.csproj
@@ -48,9 +48,18 @@
       <HintPath>$(OutputPath)..\v1.0\System.Xml.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Java.Interop">
+      <HintPath>$(OutputPath)..\v1.0\Java.Interop.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Runtime">
+      <HintPath>$(OutputPath)..\v1.0\Facades\System.Runtime.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="CallbackCode.cs" />
     <Compile Include="Mono.CodeGeneration\CodeAdd.cs" />
     <Compile Include="Mono.CodeGeneration\CodeAnd.cs" />
     <Compile Include="Mono.CodeGeneration\CodeArgument.cs" />


### PR DESCRIPTION
Mono.Android.Export.dll needs to include the
`Java.Interop.DynamicCallbackCodeGenerator` type for Mono.Android to
support `[Java.Interop.Export]` on method declarations, and the
`DynamicCallbackCodeGenerator` type was missing from
`Mono.Android.Export.dll`.

Include `Callback.cs` in the Mono.Android.Export.dll compilation so that
all required types are present to support `[Export]`.