### PR TITLE
[Xamarin.Android.Build.Tasks] Fix source profiler library name.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -424,7 +424,7 @@ namespace Xamarin.Android.Tasks
 			var root = Path.GetDirectoryName (typeof(BuildApk).Assembly.Location);
 			if (!string.IsNullOrEmpty (AndroidEmbedProfilers)) {
 				foreach (var profiler in ParseProfilers (AndroidEmbedProfilers)) {
-					var library = string.Format ("libmono-profiler-{1}.{0}.so", abi, profiler);
+					var library = string.Format ("libmono-profiler-{0}.so", profiler);
 					var path = Path.Combine (root, "lib", abi, library);
 					apk.AddEntry (string.Format ("lib/{0}/libmono-profiler-{1}.so", abi, profiler), File.OpenRead (path));
 				}


### PR DESCRIPTION
The `_InstallRuntimes` target in
`build-tools/mono-runtimes/mono-runtimes.targets` copies over
`libmono-profiler-log.so` into
`bin/$(Configuration)/lib/xbuild/Xamarin/Android/lib/ABI/libmono-profiler-log.so`.

Unfortunately, the `<BuildApk/>` task looks for
`libmono-profiler-log.ABI.so`, which is a file that doesn't exist.

Result: If `BuildApk.AndroidEmbedProfilers` is not the empty string
and/or `BuildApk.Debug` is "true" (`$(AndroidIncludeDebugSymbols)` is
True, e.g. `$(DebugSymbols)` is True and `$(DebugType)` is Full), then
the build breaks:

	Error executing task BuildApk: Could not find file
	".../bin/Debug/lib/xbuild/Xamarin/Android/lib/armeabi-v7a/libmono-profiler-log.armeabi-v7a.so".

Fix the source filename so that profilers can be properly embedded.