### PR TITLE
[mono-runtimes] Rebuild mono when mono changes.

### DIFF
--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -9,7 +9,14 @@
   <Import Project="$(_SourceTopDir)\Configuration.props" />
   <Import Project="mono-runtimes.props" />
   <Import Project="mono-runtimes.projitems" />
+  <Target Name="_SetAutogenShTimeToLastCommitTimestamp">
+    <Exec
+        Command="touch -m -t `git log -1 --format=%25cd --date=format-local:%25Y%25m%25d%25H%25M.%25S` autogen.sh"
+        WorkingDirectory="$(_MonoPath)"
+    />
+  </Target>
   <Target Name="_Autogen"
+      DependsOnTargets="_SetAutogenShTimeToLastCommitTimestamp"
       Inputs="$(_MonoPath)\autogen.sh"
       Outputs="$(_MonoPath)\configure">
     <Exec


### PR DESCRIPTION
The `mono-runtimes` project isn't resilient to mono changes, in large
part because of the `_Autogen` task: it only executes if `autogen.sh`
is newer than `configure`, and if it *doesn't* run, *nothing else*
is re-executed either.

Meaning if mono is bumped, e.g. in commit cebaba20, the "newly
updated" mono isn't necessarily rebuilt, because as far as the
`_Autogen` target is concerned, nothing has changed (unless there is a
commit which just happened to touch `autogen.sh`...which is a fairly
infrequent occurrence).

Add a new `_GetMonoTimestamp` target which *always* touch(1)es
`autogen.sh` to contain the timestamp of the most recent commit.
THat way, if (when) mono is updated, the timestamp of `autogen.sh`
will be updated to match, allowing mono to be properly rebuilt.
If mono *isn't* updated, the timestamp will be set to what it
previously was, and no rebuild will occur.