### PR TITLE
Be more granular with SDK and NDK stamp files

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -23,6 +23,9 @@
         Condition=" '%(HostOS)' == '$(HostOS)' Or '%(HostOS)' == '' ">
 			<Output TaskParameter="Include" ItemName="_PlatformAndroidNdkItem"/>
     </CreateItem>
+    <ItemGroup>
+        <_SdkStampFiles Include="@(_PlatformAndroidSdkItem->'$(AndroidToolchainDirectory)\sdk\.stamp-%(Identity)')" />
+    </ItemGroup>
   </Target>
   <Target Name="_DownloadItems"
       DependsOnTargets="_DetermineItems"
@@ -36,7 +39,7 @@
   <Target Name="_UnzipFiles"
       DependsOnTargets="_DetermineItems"
       Inputs="@(_PlatformAndroidSdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity)')"
-      Outputs="$(AndroidToolchainDirectory)\.stamp-sdk">
+      Outputs="@(_SdkStampFiles);$(AndroidToolchainDirectory)\ndk\.stamp-ndk">
     <CreateItem
         Include="@(_PlatformAndroidSdkItem->'$(AndroidToolchainCacheDirectory)\%(_PlatformAndroidSdkItem.Identity)">
       <Output TaskParameter="Include" ItemName="_AndroidSdkItems"/>
@@ -61,7 +64,7 @@
         DestinationFolder="$(AndroidToolchainDirectory)\ndk"
     />
     <Touch
-        Files="$(AndroidToolchainDirectory)\.stamp-sdk"
+        Files="@(_SdkStampFiles);$(AndroidToolchainDirectory)\ndk\.stamp-ndk"
         AlwaysCreate="True"
     />
   </Target>
@@ -73,7 +76,7 @@
   </ItemGroup>
   <Target Name="_CreateNdkToolchains"
       Condition=" '$(OS)' == 'Unix' "
-      Inputs="$(AndroidToolchainDirectory)\.stamp-sdk"
+      Inputs="$(AndroidToolchainDirectory)\ndk\.stamp-ndk"
       Outputs="@(_NdkToolchain->'$(AndroidToolchainDirectory)\.stamp-toolchains-%(Identity)')">
     <PropertyGroup>
       <_Script>$(AndroidToolchainDirectory)\ndk\build\tools\make-standalone-toolchain.sh</_Script>


### PR DESCRIPTION
Previously we used a single stamp file to detect
whether SDK/NDK need to be updated/recreate. This
worked fine if nobody touched the toolchain directory.
However, if any of the directories (sdk, ndk or anything in them)
were removed, build would *not* recreate the toolchain *unless*
the stamp file in the root folder would be deleted as well.

This patch creates a stamp file per component directory for all
the NDK and SDK components and thus the content will be restored
should the directory be removed.

It can be further improved, probably, by not removing the entire
directory prior to unzipping files as we do now but instead unpack
only those components that are missing.