### PR TITLE
Put SDK 'tools' component is in the right place

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -17,6 +17,7 @@
     </AndroidSdkItem>
     <AndroidSdkItem Include="tools_r24.4.1-linux.zip">
       <HostOS>Linux</HostOS>
+      <DestDir>tools</DestDir>
     </AndroidSdkItem>
     <AndroidNdkItem Include="android-ndk-r11c-darwin-x86_64.zip">
       <HostOS>Darwin</HostOS>
@@ -29,8 +30,9 @@
       <HostOS>Darwin</HostOS>
       <DestDir>platform-tools</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="android-sdk_r24.4.1-macosx.zip">
+    <AndroidSdkItem Include="tools_r24.4.1-macosx.zip">
       <HostOS>Darwin</HostOS>
+      <DestDir>tools</DestDir>
     </AndroidSdkItem>
     <AndroidSdkItem Include="platform-N_r01.zip">
       <HostOS></HostOS>


### PR DESCRIPTION
The tools archive was unpacked directly in the
$android_toolchain/sdk directory instead of placed in the
'tools' subdir.

Also, don't use the Android SDK archive for OSX because:

   * It doesn't exist at the same URL as the other archives and
     thus the download 404s (silently) and we end up without the
     tools directory on OSX
   * It contains the same files (only outdated) as the 'tools'
     SDK archive. Also, the 'tools' archive exists at the same
     URL as the other archives