### PR TITLE
[android-toolchains, mono-runtimes] Build armeabi, arm64-v8a, x86, x86_64

### DIFF
--- a/Configuration.Override.props.in
+++ b/Configuration.Override.props.in
@@ -6,6 +6,18 @@
     <!-- The Xamarin.Android $(TargetFrameworkVersion) value that corresponds to $(AndroidApiLevel) -->
     <AndroidFrameworkVersion>v6.0</AndroidFrameworkVersion>
 
+    <!--
+      Comma-separated list of ABIs to build mono for.
+      Supported ABIs include:
+      - armeabi
+      - armeabi-v7a
+      - arm64-v8a
+      - x86
+      - x86_64
+      Note: Why comma? Because ';' can't be specified on the command-line.
+      -->
+    <AndroidSupportedAbis>armeabi,armeabi-v7a,arm64-v8a,x86,x86_64</AndroidSupportedAbis>
+
     <!-- C and C++ compilers to emit host-native binaries -->
     <HostCc>clang</HostCc>
     <HostCxx>clang++</HostCxx>

--- a/Configuration.props
+++ b/Configuration.props
@@ -18,5 +18,15 @@
     <AndroidToolchainDirectory Condition=" '$(AndroidToolchainDirectory)' == '' ">$(HOME)\android-toolchain</AndroidToolchainDirectory>
     <AndroidSdkDirectory>$(AndroidToolchainDirectory)\sdk</AndroidSdkDirectory>
     <AndroidNdkDirectory>$(AndroidToolchainDirectory)\ndk</AndroidNdkDirectory>
+    <AndroidSupportedAbis Condition=" '$(AndroidSupportedAbis)' == '' ">armeabi-v7a</AndroidSupportedAbis>
+  </PropertyGroup>
+  <!--
+    "Fixup" $(AndroidSupportedAbis) so that Condition attributes elsewhere
+    can use `,ABI-NAME,`, to avoid substring mismatches.
+    -->
+  <PropertyGroup>
+    <AndroidSupportedAbisForConditionalChecks>$(AndroidSupportedAbis)</AndroidSupportedAbisForConditionalChecks>
+    <AndroidSupportedAbisForConditionalChecks Condition=" !$(AndroidSupportedAbisForConditionalChecks.EndsWith (',')) "   >$(AndroidSupportedAbisForConditionalChecks),</AndroidSupportedAbisForConditionalChecks>
+    <AndroidSupportedAbisForConditionalChecks Condition=" !$(AndroidSupportedAbisForConditionalChecks.StartsWith (',')) " >,$(AndroidSupportedAbisForConditionalChecks)</AndroidSupportedAbisForConditionalChecks>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ Overridable MSBuild properties include:
 * `$(AndroidFrameworkVersion)`: The Xamarin.Android `$(TargetFrameworkVersion)`
     version which corresponds to `$(AndroidApiLevel)`. This is *usually* the
     Android version number with a leading `v`, e.g. `v4.0.3` for API-15.
+* `$(AndroidSupportedAbis)`: The Android ABIs to build for inclusion within
+    apps. This is a `,`-separated list of ABIs to build. Supported values are:
+
+    * `armeabi`
+    * `armeabi-v7a`
+    * `arm64-v8a`
+    * `x86`
+    * `x86_64`
+
+    The default value is `armeabi-v7a`.
+
 * `$(AndroidToolchainCacheDirectory)`: The directory to cache the downloaded
     Android NDK and SDK files. This value defaults to
     `$(HOME)\android-archives`.

--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -43,4 +43,22 @@
       <DestDir>platforms\android-23</DestDir>
     </AndroidSdkItem>
   </ItemGroup>
+  <ItemGroup>
+    <_NdkToolchain Include="arm-linux-androideabi-clang" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains(',armeabi,')) Or $(AndroidSupportedAbisForConditionalChecks.Contains(',armeabi-v7a,'))">
+      <Platform>android-4</Platform>
+      <Arch>arm</Arch>
+    </_NdkToolchain>
+    <_NdkToolchain Include="aarch64-linux-android-clang" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains(',arm64-v8a,'))">
+      <Platform>android-21</Platform>
+      <Arch>arm64</Arch>
+    </_NdkToolchain>
+    <_NdkToolchain Include="x86-clang" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains(',x86,'))">
+      <Platform>android-9</Platform>
+      <Arch>x86</Arch>
+    </_NdkToolchain>
+    <_NdkToolchain Include="x86_64-clang" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains(',x86_64,'))">
+      <Platform>android-21</Platform>
+      <Arch>x86_64</Arch>
+    </_NdkToolchain>
+  </ItemGroup>
 </Project>

--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -68,26 +68,19 @@
         AlwaysCreate="True"
     />
   </Target>
-  <ItemGroup>
-    <_NdkToolchain Include="arm-linux-androideabi-clang">
-      <Platform>android-4</Platform>
-      <Arch>arm</Arch>
-    </_NdkToolchain>
-  </ItemGroup>
   <Target Name="_CreateNdkToolchains"
       Condition=" '$(OS)' == 'Unix' "
       Inputs="$(AndroidToolchainDirectory)\ndk\.stamp-ndk"
-      Outputs="@(_NdkToolchain->'$(AndroidToolchainDirectory)\.stamp-toolchains-%(Identity)')">
+      Outputs="@(_NdkToolchain->'$(AndroidToolchainDirectory)\toolchains\%(Identity)\AndroidVersion.txt')">
     <PropertyGroup>
       <_Script>$(AndroidToolchainDirectory)\ndk\build\tools\make-standalone-toolchain.sh</_Script>
       <_Install>@(_NdkToolchain->'$(AndroidToolchainDirectory)\toolchains\%(Identity)')</_Install>
-      <_Arch>@(_NdkToolchain->'%(Arch)')</_Arch>
       <_Toolchain>@(_NdkToolchain->'%(Identity)')</_Toolchain>
     </PropertyGroup>
-    <Exec Command="bash &quot;$(_Script)&quot; --platform=%(_NdkToolchain.Platform) &quot;--install-dir=$(_Install)&quot; --arch=$(_Arch) --toolchain=$(_Toolchain)" />
+    <Exec Command="bash &quot;$(_Script)&quot; --platform=%(_NdkToolchain.Platform) &quot;--install-dir=$(_Install)&quot; --arch=%(_NdkToolchain.Arch) --toolchain=$(_Toolchain)" />
     <Touch
-        Files="@(_NdkToolchain->'$(AndroidToolchainDirectory)\.stamp-toolchains-%(Identity)')"
-        AlwaysCreate="True"
+        Files="@(_NdkToolchain->'$(AndroidToolchainDirectory)\toolchains\%(Identity)\AndroidVersion.txt')"
+        AlwaysCreate="False"
     />
   </Target>
   <Target Name="_GetAndroidSdkDirectory">

--- a/build-tools/mono-runtimes/mono-runtimes.projitems
+++ b/build-tools/mono-runtimes/mono-runtimes.projitems
@@ -1,7 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <_MonoRuntime Include="armeabi-v7a">
+    <_MonoRuntime Include="armeabi" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',armeabi,'))">
+      <Ar>$(_ArmAr)</Ar>
+      <As>$(_ArmAs)</As>
+      <Cc>$(_ArmCc)</Cc>
+      <Cpp>$(_ArmCpp) $(_ArmCppFlags)</Cpp>
+      <CFlags>$(_ArmCFlags) -march=armv5te $(_TargetCFlags)</CFlags>
+      <Cxx>$(_ArmCxx)</Cxx>
+      <CxxFlags>$(_ArmCxxFlags) -march=armv5te $(_TargetCxxFlags)</CxxFlags>
+      <CxxCpp>$(_ArmCxxCpp) $(_ArmCppFlags)</CxxCpp>
+      <Ld>$(_ArmLd)</Ld>
+      <LdFlags>$(_ArmLdFlags)</LdFlags>
+      <RanLib>$(_ArmRanLib)</RanLib>
+      <Strip>$(_ArmStrip)</Strip>
+      <ConfigureFlags>--host=armv5-linux-androideabi $(_TargetConfigureFlags)</ConfigureFlags>
+      <OutputRuntime>libmonosgen-2.0.so</OutputRuntime>
+      <OutputProfiler>libmono-profiler-log.so</OutputProfiler>
+      <OutputMonoPosixHelper>libMonoPosixHelper.so</OutputMonoPosixHelper>
+    </_MonoRuntime>
+    <_MonoRuntime Include="armeabi-v7a" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',armeabi-v7a,'))">
       <Ar>$(_ArmAr)</Ar>
       <As>$(_ArmAs)</As>
       <Cc>$(_ArmCc)</Cc>
@@ -15,6 +33,60 @@
       <RanLib>$(_ArmRanLib)</RanLib>
       <Strip>$(_ArmStrip)</Strip>
       <ConfigureFlags>--host=armv5-linux-androideabi $(_TargetConfigureFlags)</ConfigureFlags>
+      <OutputRuntime>libmonosgen-2.0.so</OutputRuntime>
+      <OutputProfiler>libmono-profiler-log.so</OutputProfiler>
+      <OutputMonoPosixHelper>libMonoPosixHelper.so</OutputMonoPosixHelper>
+    </_MonoRuntime>
+    <_MonoRuntime Include="arm64-v8a" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',arm64-v8a,'))">
+      <Ar>$(_Arm64Ar)</Ar>
+      <As>$(_Arm64As)</As>
+      <Cc>$(_Arm64Cc)</Cc>
+      <Cpp>$(_Arm64Cpp) $(_Arm64CppFlags)</Cpp>
+      <CFlags>$(_Arm64CFlags) $(_TargetCFlags)</CFlags>
+      <Cxx>$(_Arm64Cxx)</Cxx>
+      <CxxFlags>$(_Arm64CxxFlags) $(_TargetCxxFlags) </CxxFlags>
+      <CxxCpp>$(_Arm64CxxCpp) $(_Arm64CppFlags)</CxxCpp>
+      <Ld>$(_Arm64Ld)</Ld>
+      <LdFlags>$(_Arm64LdFlags)</LdFlags>
+      <RanLib>$(_Arm64RanLib)</RanLib>
+      <Strip>$(_Arm64Strip)</Strip>
+      <ConfigureFlags>--host=aarch64-linux-android $(_TargetConfigureFlags)</ConfigureFlags>
+      <OutputRuntime>libmonosgen-2.0.so</OutputRuntime>
+      <OutputProfiler>libmono-profiler-log.so</OutputProfiler>
+      <OutputMonoPosixHelper>libMonoPosixHelper.so</OutputMonoPosixHelper>
+    </_MonoRuntime>
+    <_MonoRuntime Include="x86" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',x86,'))">
+      <Ar>$(_X86Ar)</Ar>
+      <As>$(_X86As)</As>
+      <Cc>$(_X86Cc)</Cc>
+      <Cpp>$(_X86Cpp) $(_X86CppFlags)</Cpp>
+      <CFlags>$(_X86CFlags) $(_TargetCFlags)</CFlags>
+      <Cxx>$(_X86Cxx)</Cxx>
+      <CxxFlags>$(_X86CxxFlags) $(_TargetCxxFlags) </CxxFlags>
+      <CxxCpp>$(_X86CxxCpp) $(_X86CppFlags)</CxxCpp>
+      <Ld>$(_X86Ld)</Ld>
+      <LdFlags>$(_X86LdFlags)</LdFlags>
+      <RanLib>$(_X86RanLib)</RanLib>
+      <Strip>$(_X86Strip)</Strip>
+      <ConfigureFlags>--host=i686-linux-android $(_TargetConfigureFlags)</ConfigureFlags>
+      <OutputRuntime>libmonosgen-2.0.so</OutputRuntime>
+      <OutputProfiler>libmono-profiler-log.so</OutputProfiler>
+      <OutputMonoPosixHelper>libMonoPosixHelper.so</OutputMonoPosixHelper>
+    </_MonoRuntime>
+    <_MonoRuntime Include="x86_64" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',x86_64,'))">
+      <Ar>$(_X86_64Ar)</Ar>
+      <As>$(_X86_64As)</As>
+      <Cc>$(_X86_64Cc)</Cc>
+      <Cpp>$(_X86_64Cpp) $(_X86_64CppFlags)</Cpp>
+      <CFlags>$(_X86_64CFlags) $(_TargetCFlags)</CFlags>
+      <Cxx>$(_X86_64Cxx)</Cxx>
+      <CxxFlags>$(_X86_64CxxFlags) $(_TargetCxxFlags) </CxxFlags>
+      <CxxCpp>$(_X86_64CxxCpp) $(_X86_64CppFlags)</CxxCpp>
+      <Ld>$(_X86_64Ld)</Ld>
+      <LdFlags>$(_X86_64LdFlags)</LdFlags>
+      <RanLib>$(_X86_64RanLib)</RanLib>
+      <Strip>$(_X86_64Strip)</Strip>
+      <ConfigureFlags>--host=x86_64-linux-android $(_TargetConfigureFlags)</ConfigureFlags>
       <OutputRuntime>libmonosgen-2.0.so</OutputRuntime>
       <OutputProfiler>libmono-profiler-log.so</OutputProfiler>
       <OutputMonoPosixHelper>libMonoPosixHelper.so</OutputMonoPosixHelper>

--- a/build-tools/mono-runtimes/mono-runtimes.props
+++ b/build-tools/mono-runtimes/mono-runtimes.props
@@ -4,11 +4,13 @@
     <_CommonCFlags Condition=" '$(Configuration)' == 'Debug' ">-ggdb3 -O0 -fno-omit-frame-pointer</_CommonCFlags>
     <_CommonCFlags Condition=" '$(Configuration)' == 'Release' ">-g -O2</_CommonCFlags>
     <_CommonConfigureFlags>--without-ikvm-native --enable-maintainer-mode --with-profile2=no --with-profile4=no --with-profile4_5=no --with-monodroid --enable-nls=no --with-sigaltstack=yes --with-tls=pthread mono_cv_uscore=yes</_CommonConfigureFlags>
-    <_TargetConfigureFlags>$(_CommonConfigureFlags) --enable-minimal=ssa,portability,attach,verifier,full_messages,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,security,shared_handles --disable-mcs-build --disable-executables</_TargetConfigureFlags>
+    <_TargetConfigureFlags>$(_CommonConfigureFlags) --enable-minimal=ssa,portability,attach,verifier,full_messages,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,security,shared_handles --disable-mcs-build --disable-executables --disable-iconv</_TargetConfigureFlags>
     <_SecurityCFlags>-Wl,-z,now -Wl,-z,relro -Wl,-z,noexecstack -fstack-protector</_SecurityCFlags>
     <_TargetCFlags>$(_SecurityCFlags) -DMONODROID=1</_TargetCFlags>
     <_TargetCxxFlags>$(_SecurityCFlags) -DMONODROID=1</_TargetCxxFlags>
     <_TargetLdFlags>-ldl -lm -llog -lc -lgcc</_TargetLdFlags>
+  </PropertyGroup>
+  <PropertyGroup>
     <_ArmNdkPlatformPath>$(AndroidToolchainDirectory)\ndk\platforms\android-4</_ArmNdkPlatformPath>
     <_ArmAr>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-ar</_ArmAr>
     <_ArmAs>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-as</_ArmAs>
@@ -17,11 +19,59 @@
     <_ArmCpp>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-cpp</_ArmCpp>
     <_ArmCppFlags>-I$(_ArmNdkPlatformPath)\arch-arm\usr\include\</_ArmCppFlags>
     <_ArmCxx>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-clang++</_ArmCxx>
-    <_ArmCxxFlags>-I$(_ArmNdkPlatformPath)\arch-arm\usr\include\</_ArmCxxFlags>
+    <_ArmCxxFlags>$(_ArmCFlags)</_ArmCxxFlags>
     <_ArmCxxCpp>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-cpp</_ArmCxxCpp>
     <_ArmLd>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-ld</_ArmLd>
     <_ArmLdFlags>$(_TargetLdFlags) -Wl,--fix-cortex-a8 -Wl,-rpath-link=$(_ArmNdkPlatformPath)\arch-arm\usr\lib,-dynamic-linker=/system/bin/linker -L$(_ArmNdkPlatformPath)\arch-arm\usr\lib</_ArmLdFlags>
     <_ArmRanLib>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-ranlib</_ArmRanLib>
     <_ArmStrip>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-strip</_ArmStrip>
+  </PropertyGroup>
+  <PropertyGroup>
+    <_Arm64NdkPlatformPath>$(AndroidToolchainDirectory)\ndk\platforms\android-21</_Arm64NdkPlatformPath>
+    <_Arm64Ar>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-ar</_Arm64Ar>
+    <_Arm64As>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-as</_Arm64As>
+    <_Arm64Cc>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-clang</_Arm64Cc>
+    <_Arm64CFlags>$(_CommonCFlags) -D__POSIX_VISIBLE=201002 -DSK_RELEASE -DNDEBUG -UDEBUG -fpic -DL_cuserid=9 -DANDROID64</_Arm64CFlags>
+    <_Arm64Cpp>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-cpp</_Arm64Cpp>
+    <_Arm64CppFlags>-I$(_Arm64NdkPlatformPath)\arch-arm64\usr\include</_Arm64CppFlags>
+    <_Arm64Cxx>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-clang++</_Arm64Cxx>
+    <_Arm64CxxFlags>$(_Arm64CFlags)</_Arm64CxxFlags>
+    <_Arm64CxxCpp>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-cpp</_Arm64CxxCpp>
+    <_Arm64Ld>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-ld</_Arm64Ld>
+    <_Arm64LdFlags>$(_TargetLdFlags) -Wl,-rpath-link=$(_Arm64NdkPlatformPath)\arch-arm64\usr\lib,-dynamic-linker=/system/bin/linker -L$(_Arm64NdkPlatformPath)\arch-arm64\usr\lib</_Arm64LdFlags>
+    <_Arm64RanLib>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-ranlib</_Arm64RanLib>
+    <_Arm64Strip>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-strip</_Arm64Strip>
+  </PropertyGroup>
+  <PropertyGroup>
+    <_X86NdkPlatformPath>$(AndroidToolchainDirectory)\ndk\platforms\android-9</_X86NdkPlatformPath>
+    <_X86Ar>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-ar</_X86Ar>
+    <_X86As>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-as</_X86As>
+    <_X86Cc>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-clang</_X86Cc>
+    <_X86CFlags>$(_CommonCFlags)</_X86CFlags>
+    <_X86Cpp>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-cpp</_X86Cpp>
+    <_X86CppFlags>-I$(_X86NdkPlatformPath)\arch-x86\usr\include</_X86CppFlags>
+    <_X86Cxx>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-clang++</_X86Cxx>
+    <_X86CxxFlags>$(_X86CFlags)</_X86CxxFlags>
+    <_X86CxxCpp>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-cpp</_X86CxxCpp>
+    <_X86Ld>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-ld</_X86Ld>
+    <_X86LdFlags>$(_TargetLdFlags) -Wl,-rpath-link=$(_X86NdkPlatformPath)\arch-x86\usr\lib,-dynamic-linker=/system/bin/linker -L$(_X86NdkPlatformPath)\arch-x86\usr\lib</_X86LdFlags>
+    <_X86RanLib>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-ranlib</_X86RanLib>
+    <_X86Strip>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-strip</_X86Strip>
+  </PropertyGroup>
+  <PropertyGroup>
+    <_X86_64NdkPlatformPath>$(AndroidToolchainDirectory)\ndk\platforms\android-21</_X86_64NdkPlatformPath>
+    <_X86_64Ar>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-ar</_X86_64Ar>
+    <_X86_64As>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-as</_X86_64As>
+    <_X86_64Cc>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-clang</_X86_64Cc>
+    <_X86_64CFlags>$(_CommonCFlags) -DL_cuserid=9</_X86_64CFlags>
+    <_X86_64Cpp>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-cpp</_X86_64Cpp>
+    <_X86_64CppFlags>-I$(_X86_64NdkPlatformPath)\arch-x86\usr\include</_X86_64CppFlags>
+    <_X86_64Cxx>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-clang++</_X86_64Cxx>
+    <_X86_64CxxFlags>$(_X86_64CFlags)</_X86_64CxxFlags>
+    <_X86_64CxxCpp>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-cpp</_X86_64CxxCpp>
+    <_X86_64Ld>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-ld</_X86_64Ld>
+    <_X86_64LdFlags>$(_TargetLdFlags) -Wl,-rpath-link=$(_X86_64NdkPlatformPath)\arch-x86_64\usr\lib,-dynamic-linker=/system/bin/linker -L$(_X86_64NdkPlatformPath)\arch-x86_64\usr\lib</_X86_64LdFlags>
+    <_X86_64RanLib>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-ranlib</_X86_64RanLib>
+    <_X86_64Strip>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-strip</_X86_64Strip>
   </PropertyGroup>
 </Project>

--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -75,7 +75,7 @@
   </Target>
   <Target Name="_ConfigureRuntimes"
       Inputs="$(_MonoPath)\configure"
-      Outputs="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\.stamp')">
+      Outputs="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\Makefile')">
     <MakeDir Directories="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)')" />
     <Exec
         Command="..\..\..\$(_MonoPath)\configure LDFLAGS=&quot;%(_MonoRuntime.LdFlags)&quot; CFLAGS=&quot;%(_MonoRuntime.CFlags)&quot; CXXFLAGS=&quot;%(_MonoRuntime.CxxFlags)&quot; CC=&quot;%(_MonoRuntime.Cc)&quot; CXX=&quot;%(_MonoRuntime.Cxx)&quot; CPP=&quot;%(_MonoRuntime.Cpp)&quot; CXXCPP=&quot;%(_MonoRuntime.CxxCpp)&quot; LD=&quot;%(_MonoRuntime.Ld)&quot; AR=&quot;%(_MonoRuntime.Ar)&quot; AS=&quot;%(_MonoRuntime.As)&quot; RANLIB=&quot;%(_MonoRuntime.RanLib)&quot; STRIP=&quot;%(_MonoRuntime.Strip)&quot; --cache-file=..\%(_MonoRuntime.Identity).config.cache %(_MonoRuntime.ConfigureFlags)"
@@ -113,7 +113,7 @@
         DestinationFiles="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntime)-unstripped')"
     />
     <Exec
-        Command="%(_MonoRuntime.Strip) &quot;@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntime)')&quot;"
+        Command="%(_MonoRuntime.Strip) &quot;$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntime)&quot;"
     />
     <Copy
         SourceFiles="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\mono\profiler\.libs\%(OutputProfiler)')"
@@ -160,7 +160,7 @@
         DestinationFolder="$(_BclFrameworkDir)"
     />
     <Touch
-        Files="$(_BclFrameworkDir)\mscorlib.dll"
+        Files="@(_BclInstalledItem)"
     />
     <ItemGroup>
       <FrameworkList Include="&lt;FileList Redist=&quot;MonoAndroid&quot; Name=&quot;Xamarin.Android Base Class Libraries&quot;&gt;" />
@@ -175,5 +175,6 @@
   <Target Name="_CleanRuntimes"
       AfterTargets="Clean">
     <RemoveDir Directories="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)')" />
+    <Delete Files="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity).config.cache')" />
   </Target>
 </Project>

--- a/src/monodroid/jni/.gitignore
+++ b/src/monodroid/jni/.gitignore
@@ -1,2 +1,3 @@
+Application.mk
 config.include
 machine.config.include

--- a/src/monodroid/jni/Application.mk
+++ b/src/monodroid/jni/Application.mk
@@ -1,2 +1,0 @@
-# Build both ARMv5TE and ARMv7-A machine code.
-APP_ABI := armeabi-v7a

--- a/src/monodroid/monodroid.projitems
+++ b/src/monodroid/monodroid.projitems
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_SupportedAbis>$(AndroidSupportedAbis.Replace(',', ';')</_SupportedAbis>
+  </PropertyGroup>
   <ItemGroup>
-    <_MonoRuntime Include="armeabi-v7a" />
+    <_MonoRuntime Include="$(_SupportedAbis)" />
   </ItemGroup>
 </Project>

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -8,8 +8,16 @@
     <CFiles Include="jni\**\*.c" />
   </ItemGroup>
   <Target Name="_BuildRuntimes"
-      Inputs="@(CFiles);jni\Android.mk;jni\Application.mk"
+      Inputs="@(CFiles);jni\Android.mk"
       Outputs="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).%(Identity).so')">
+    <PropertyGroup>
+      <_AppAbi>$(AndroidSupportedAbis.Replace(',', ' ')</_AppAbi>
+    </PropertyGroup>
+    <WriteLinesToFile
+        File="jni\Application.mk"
+        Lines="APP_ABI := $(_AppAbi)"
+        Overwrite="True"
+    />
     <Exec
         Command="$(AndroidToolchainDirectory)\ndk\ndk-build CONFIGURATION=$(Configuration) V=1"
     />
@@ -25,7 +33,7 @@
   <Target Name="_CleanRuntimes"
       AfterTargets="Clean">
     <RemoveDir Directories="obj\local;libs" />
-    <Delete Files="jni\config.include;jni\machine.config.include" />
+    <Delete Files="jni\config.include;jni\machine.config.include;jni\Application.mk" />
     <Delete Files="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).%(Identity).so')" />
     <Delete Files="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).%(Identity).d.so')" />
   </Target>


### PR DESCRIPTION
Commit 38dbfcaf mentions that commercial Xamarin.Android 6.0
provides Mono for five architectures, but "[i]n the interest of
expediency" only adds support to build *one* architecture:
armeabi-v7a (32-bit ARM v7).

It's time to fix that: add build system support for armeabi,
arm64-v8a, x86, and x86_64.

*However*, it takes *time* to build all those ABIs: on a 2013 6-core
Mac Pro, it takes ~29 minutes to build all five of those ABIs plus the
"host" ABI (for BCL assemblies), which is presumably 29 minutes that
very few people want to spend, and will be even longer in a variety of
build environments (virtual machines, slower hardware, etc.).

Which means we don't want to require that they all be built.

To better support this, add a new `$(AndroidSupportedAbis)` MSBuild
property which contains a comma-separated-and-wrapped list of ABIs to
support. This allows manually overriding the ABIs on the command-line:

	# build everything!
	$ xbuild '/p:AndroidSupportedAbis=armeabi,armeabi-v7a,arm64-v8a,x86,x86_64,

or setting a value within `Configuration.Override.props`:

	<PropertyGroup>
	  <!-- only build x86 -->
	  <AndroidSupportedAbis>x86,x86_64</AndroidSupportedAbis>
	</PropertyGroup>

The *default* continues to be just armeabi-v7a.
