### PR TITLE
[Xamarin.Android.Build.Tasks] Extract resources with S.I.C.ZipFile.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
@@ -9,7 +10,6 @@ using Mono.Cecil;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
 using System.Text.RegularExpressions;
-using Ionic.Zip;
 
 using Java.Interop.Tools.Cecil;
 
@@ -232,9 +232,7 @@ namespace Xamarin.Android.Tasks
 
 							// temporarily extracted directory will look like:
 							//    __library_projects__/[dllname]/[library_project_imports | jlibs]/bin
-							using (var zip = new ZipFile (finfo.FullName)) {
-								Files.ExtractAll (zip, outDirForDll);
-							}
+							ZipFile.ExtractToDirectory (finfo.FullName, outDirForDll);
 
 							// We used to *copy* the resources to overwrite other resources,
 							// which resulted in missing resource issue.

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -40,6 +40,8 @@
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
     <Reference Include="Mono.Cecil">


### PR DESCRIPTION
Ionic.Zip.dll, as provided by the Unofficial.Ionic.Zip 1.9.1.8 NuGet
package, is broken. [It hardcodes `\` as directory separator char][0],
which breaks all manner of things, and when we try to extract and
unzip embedded resources from assemblies, it fails:

	Error executing task ResolveLibraryProjectImports: System.ArgumentException: Path is empty
	  at System.IO.Directory.CreateDirectory (System.String path) <0x1a20ca0 + 0x0011c> in <filename unknown>:0
	  at Ionic.Zip.ZipEntry.InternalExtract (System.String baseDir, System.IO.Stream outstream, System.String password) <0x3af4b78 + 0x002e7> in <filename unknown>:0

I'm not sure *why* "path is empty" -- the callstack isn't very
helpful -- but it *is* empty, which means if a project references an
assembly which contains e.g. @(AndroidResource), everthing breaks.

Fix the `ResolveLibraryProjectImports` task so that instead of using
Ionic.Zip.dll to extract embedded resources we instead use
System.IO.Compression.ZipFile (in
System.IO.Compression.FileSystem.dll, new in .NET 4.5).

Note: *Other* uses of Ionic.Zip.dll are similarly suspect but
*are not fixed*. Fixing (removing?) Ionic.Zip.dll will be done later.

[0]: https://gitter.im/xamarin/xamarin-android?at=572d97caf36daf63798d6033