### PR TITLE
[Xamarin.Android.Build.Tasks] Ensure Android.App.Application.Context is set

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.api4.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.api4.java
@@ -27,7 +27,7 @@ public class MonoPackageManager {
 						android.content.Intent.ACTION_TIMEZONE_CHANGED
 				);
 				context.registerReceiver (new mono.android.app.NotifyTimeZoneChanges (), timezoneChangedFilter);
-				Context = context;
+				setContext (context);
 				
 				System.loadLibrary("monodroid");
 				Locale locale       = Locale.getDefault ();
@@ -57,6 +57,13 @@ public class MonoPackageManager {
 				
 				initialized = true;
 			}
+		}
+	}
+
+	public static void setContext (Context context)
+	{
+		if (Context == null) {
+			Context = context;
 		}
 	}
 

--- a/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.java
@@ -27,7 +27,7 @@ public class MonoPackageManager {
 						android.content.Intent.ACTION_TIMEZONE_CHANGED
 				);
 				context.registerReceiver (new mono.android.app.NotifyTimeZoneChanges (), timezoneChangedFilter);
-				Context = context;
+				setContext (context);
 				
 				System.loadLibrary("monodroid");
 				Locale locale       = Locale.getDefault ();
@@ -57,6 +57,13 @@ public class MonoPackageManager {
 				
 				initialized = true;
 			}
+		}
+	}
+
+	public static void setContext (Context context)
+	{
+		if (Context == null) {
+			Context = context;
 		}
 	}
 


### PR DESCRIPTION
The `Android.App.Application.Context` property returns the
process-global Application instance constructed as part of process
startup; it is the
[android.content.Context.getApplicationContext()][0] value.

The `Application.Context` property in turn is set by
[MonoRuntimeProvider.java][1] and [MonoPackageManager.java][2], which
unfortunately means it's tied into Android process startup
initialization order: during Android process startup, Android creates
the single Application instance, then creates the registered
ContentProvider instances, which eventually calls
`MonoRuntimeProvider.attachInfo()`, which would save the value that
`Application.Context` returns. The Context value provided to
`MonoRuntimeProvider.attachInfo()` was assumed to be the Application
instance.

This assumption is *not* correct prior to API-16.

Which means if an app registers a custom Application type:

	[Application]
	public partial class MyApp : Application {
		public MyApp (IntPtr h, JniHandleOwnership transfer)
			: base (h, transfer)
		{
		}
	}

Code which requires that `Application.Context` ISA `MyApp` instance
will fail on older Android platforms, API <= 15.

Which is bad.

To correct this, Java.Interop alters the Java Callable Generator logic
for Android.App.Application subclasses so that the generated
constructor always calls `mono.MonoPackageManager.setContext(this)`.
Bump the Java.Interop commit reference to use this support.

Next, provide the `mono.MonoPackageManager.setContext(Context)` method
so that the resulting Java Callable Wrapper will compile.

`MonoPackageManager.setContext(Context)`, in turn, is a set-once
method: it'll only preserve the first Context value provided, not any
others.

On all Android versions, since the Application instance is the first
instance created during startup, this will cause
`MonoPackageManager.Context` to refer to the correct Application
instance, and the later setContext() call in
`MonoPackageManager.LoadApplication()` will be ignored.

Alternatively, if NO `[Application]` type is provided, and instead
`$(AndroidApplicationJavaClass)` is used to specify a custom Java type
to use for the Application instance, then there won't be an
Application-generated Java Callable Wrapper, and
`MonoPackageManager.LoadApplication()` will instead store the Context
value provided to `MonoRuntimeProvider.attachInfo()`, providing that
in subsequent calls to the `Application.Context` property.

[0]: https://developer.android.com/reference/android/content/Context.html#getApplicationContext()
[1]: https://github.com/xamarin/java.interop/blob/38a1a2c/src/Java.Interop.Tools.JavaCallableWrappers/Resources/MonoRuntimeProvider.Bundled.java
[2]: https://github.com/xamarin/xamarin-android/blob/59ec488/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.java