### PR TITLE
[build-tools] Update library outputs to not include <abi> suffix

### DIFF
--- a/build-tools/mono-runtimes/mono-runtimes.projitems
+++ b/build-tools/mono-runtimes/mono-runtimes.projitems
@@ -15,9 +15,10 @@
       <RanLib>$(_ArmRanLib)</RanLib>
       <Strip>$(_ArmStrip)</Strip>
       <ConfigureFlags>--host=armv5-linux-androideabi $(_TargetConfigureFlags)</ConfigureFlags>
-      <OutputRuntime>libmonosgen-2.0.so</OutputRuntime>
-      <OutputProfiler>libmono-profiler-log.so</OutputProfiler>
-      <OutputMonoPosixHelper>libMonoPosixHelper.so</OutputMonoPosixHelper>
+      <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
+      <NativeLibraryExtension>so</NativeLibraryExtension>
+      <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
+      <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
     <_MonoRuntime Include="armeabi-v7a" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',armeabi-v7a,'))">
       <Ar>$(_ArmAr)</Ar>
@@ -33,9 +34,10 @@
       <RanLib>$(_ArmRanLib)</RanLib>
       <Strip>$(_ArmStrip)</Strip>
       <ConfigureFlags>--host=armv5-linux-androideabi $(_TargetConfigureFlags)</ConfigureFlags>
-      <OutputRuntime>libmonosgen-2.0.so</OutputRuntime>
-      <OutputProfiler>libmono-profiler-log.so</OutputProfiler>
-      <OutputMonoPosixHelper>libMonoPosixHelper.so</OutputMonoPosixHelper>
+      <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
+      <NativeLibraryExtension>so</NativeLibraryExtension>
+      <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
+      <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
     <_MonoRuntime Include="arm64-v8a" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',arm64-v8a,'))">
       <Ar>$(_Arm64Ar)</Ar>
@@ -51,9 +53,10 @@
       <RanLib>$(_Arm64RanLib)</RanLib>
       <Strip>$(_Arm64Strip)</Strip>
       <ConfigureFlags>--host=aarch64-linux-android $(_TargetConfigureFlags)</ConfigureFlags>
-      <OutputRuntime>libmonosgen-2.0.so</OutputRuntime>
-      <OutputProfiler>libmono-profiler-log.so</OutputProfiler>
-      <OutputMonoPosixHelper>libMonoPosixHelper.so</OutputMonoPosixHelper>
+      <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
+      <NativeLibraryExtension>so</NativeLibraryExtension>
+      <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
+      <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
     <_MonoRuntime Include="x86" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',x86,'))">
       <Ar>$(_X86Ar)</Ar>
@@ -69,9 +72,10 @@
       <RanLib>$(_X86RanLib)</RanLib>
       <Strip>$(_X86Strip)</Strip>
       <ConfigureFlags>--host=i686-linux-android $(_TargetConfigureFlags)</ConfigureFlags>
-      <OutputRuntime>libmonosgen-2.0.so</OutputRuntime>
-      <OutputProfiler>libmono-profiler-log.so</OutputProfiler>
-      <OutputMonoPosixHelper>libMonoPosixHelper.so</OutputMonoPosixHelper>
+      <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
+      <NativeLibraryExtension>so</NativeLibraryExtension>
+      <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
+      <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
     <_MonoRuntime Include="x86_64" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',x86_64,'))">
       <Ar>$(_X86_64Ar)</Ar>
@@ -87,9 +91,10 @@
       <RanLib>$(_X86_64RanLib)</RanLib>
       <Strip>$(_X86_64Strip)</Strip>
       <ConfigureFlags>--host=x86_64-linux-android $(_TargetConfigureFlags)</ConfigureFlags>
-      <OutputRuntime>libmonosgen-2.0.so</OutputRuntime>
-      <OutputProfiler>libmono-profiler-log.so</OutputProfiler>
-      <OutputMonoPosixHelper>libMonoPosixHelper.so</OutputMonoPosixHelper>
+      <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
+      <NativeLibraryExtension>so</NativeLibraryExtension>
+      <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
+      <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
     <_MonoRuntime Include="host-Darwin" Condition=" '$(HostOS)' == 'Darwin' ">
       <Ar>ar</Ar>
@@ -104,9 +109,10 @@
       <RanLib>ranlib</RanLib>
       <Strip>strip -S</Strip>
       <ConfigureFlags>--enable-maintainer-mode --without-ikvm-native --with-monodroid --with-mcs-docs=no --disable-mono-debugger --with-profile2=no --with-profile4=no --with-profile4_5=yes --disable-boehm --enable-nls=no --disable-iconv</ConfigureFlags>
-      <OutputRuntime>libmonosgen-2.0.dylib</OutputRuntime>
-      <OutputProfiler>libmono-profiler-log.dylib</OutputProfiler>
-      <OutputMonoPosixHelper>libMonoPosixHelper.dylib</OutputMonoPosixHelper>
+      <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
+      <NativeLibraryExtension>dylib</NativeLibraryExtension>
+      <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
+      <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
     <_MonoRuntime Include="host-Linux" Condition=" '$(HostOS)' == 'Linux' ">
       <Ar>ar</Ar>
@@ -121,9 +127,10 @@
       <RanLib>ranlib</RanLib>
       <Strip>strip -S</Strip>
       <ConfigureFlags>--enable-maintainer-mode --without-ikvm-native --with-monodroid --with-mcs-docs=no --disable-mono-debugger --with-profile2=no --with-profile4=no --with-profile4_5=yes --disable-boehm --enable-nls=no --disable-iconv</ConfigureFlags>
-      <OutputRuntime>libmonosgen-2.0.so</OutputRuntime>
-      <OutputProfiler>libmono-profiler-log.so</OutputProfiler>
-      <OutputMonoPosixHelper>libMonoPosixHelper.so</OutputMonoPosixHelper>
+      <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
+      <NativeLibraryExtension>so</NativeLibraryExtension>
+      <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
+      <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
   </ItemGroup>
 </Project>

--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -86,48 +86,51 @@
         AlwaysCreate="True"
     />
   </Target>
+  <ItemGroup>
+    <_RuntimeLibraries Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\mono\mini\.libs\%(OutputRuntimeFilename).%(NativeLibraryExtension)')" />
+    <_RuntimeLibraries Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\mono\profiler\.libs\%(OutputProfilerFilename).%(NativeLibraryExtension)')" />
+    <_RuntimeLibraries Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\support\.libs\%(OutputMonoPosixHelperFilename).%(NativeLibraryExtension)')" />
+  </ItemGroup>
   <Target Name="_BuildRuntimes"
       Inputs="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\.stamp')"
-      Outputs="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\mono\mini\.libs\%(OutputRuntime)');@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\mono\profiler\.libs\%(OutputProfiler)');@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\support\.libs\%(OutputMonoPosixHelper)');@(_BclProfileItems)">
+      Outputs="@(_RuntimeLibraries);@(_BclProfileItems">
     <Exec
         Command="make $(MAKEFLAGS) # %(_MonoRuntime.Identity)"
         WorkingDirectory="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)')"
     />
+    <ItemGroup>
+      <_MonoLibraries Include="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\mono\mini\.libs\%(OutputRuntimeFilename).%(NativeLibraryExtension)')" />
+      <_MonoLibraries Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\mono\profiler\.libs\%(OutputProfilerFilename).%(NativeLibraryExtension)')" />
+      <_MonoLibraries Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\support\.libs\%(OutputMonoPosixHelperFilename).%(NativeLibraryExtension)')" />
+    </ItemGroup>
     <Touch
-        Files="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\mono\mini\.libs\%(OutputRuntime)');@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\mono\profiler\.libs\%(OutputProfiler)');@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\support\.libs\%(OutputMonoPosixHelper)')"
+        Files="@(_MonoLibraries)"
     />
   </Target>
+  <ItemGroup>
+    <_InstallRuntimesOutputs Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntimeFilename).%(NativeLibraryExtension)')" />
+    <_InstallRuntimesOutputs Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputProfilerFilename).%(NativeLibraryExtension)')" />
+    <_InstallRuntimesOutputs Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputMonoPosixHelperFilename).%(NativeLibraryExtension)')" />
+    <_InstallUnstrippedRuntimeOutputs Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntimeFilename).d.%(NativeLibraryExtension)')" />
+  </ItemGroup>
   <Target Name="_InstallRuntimes"
-      Inputs="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\mono\mini\.libs\%(OutputRuntime)');@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\mono\profiler\.libs\%(OutputProfiler)');@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\support\.libs\%(OutputMonoPosixHelper)')"
-      Outputs="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntime)');@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputProfiler)');@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputMonoPosixHelper)')">
+      Inputs="@(_RuntimeLibraries)"
+      Outputs="@(_InstallRuntimesOutputs);@(_InstallUnstrippedRuntimeOutputs)">
     <MakeDir Directories="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)')" />
     <Copy
-        SourceFiles="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\mono\mini\.libs\%(OutputRuntime)')"
-        DestinationFiles="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntime)')"
-    />
-    <Touch
-        Files="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntime)')"
+        SourceFiles="@(_RuntimeLibraries)"
+        DestinationFiles="@(_InstallRuntimesOutputs)"
     />
     <Copy
-        SourceFiles="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\mono\mini\.libs\%(OutputRuntime)')"
-        DestinationFiles="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntime)-unstripped')"
+        SourceFiles="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\mono\mini\.libs\%(OutputRuntimeFilename).%(NativeLibraryExtension)')"
+        DestinationFiles="@(_InstallUnstrippedRuntimeOutputs)"
     />
     <Exec
-        Command="%(_MonoRuntime.Strip) &quot;$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntime)&quot;"
-    />
-    <Copy
-        SourceFiles="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\mono\profiler\.libs\%(OutputProfiler)')"
-        DestinationFiles="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputProfiler)')"
+        Condition=" '$(Configuration)' != 'Debug' "
+        Command="&quot;%(_MonoRuntime.Strip)&quot; &quot;$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntimeFilename).%(NativeLibraryExtension)&quot;"
     />
     <Touch
-        Files="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputProfiler)')"
-    />
-    <Copy
-        SourceFiles="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\support\.libs\%(OutputMonoPosixHelper)')"
-        DestinationFiles="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputMonoPosixHelper)')"
-    />
-    <Touch
-        Files="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputMonoPosixHelper)')"
+        Files="@(_InstallRuntimesOutputs);@(_InstallUnstrippedRuntimeOutputs)"
     />
   </Target>
   <Target Name="_InstallBcl"

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -9,7 +9,7 @@
   </ItemGroup>
   <Target Name="_BuildRuntimes"
       Inputs="@(CFiles);jni\Android.mk"
-      Outputs="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).%(Identity).so')">
+      Outputs="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).so')">
     <PropertyGroup>
       <_AppAbi>$(AndroidSupportedAbis.Replace(',', ' ')</_AppAbi>
     </PropertyGroup>
@@ -23,18 +23,18 @@
     />
     <Copy
         SourceFiles="@(_MonoRuntime->'obj\local\%(Identity)\libmonodroid.so')"
-        DestinationFiles="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).%(Identity).d.so')"
+        DestinationFiles="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).d.so')"
     />
     <Copy
         SourceFiles="@(_MonoRuntime->'libs\%(Identity)\libmonodroid.so')"
-        DestinationFiles="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).%(Identity).so')"
+        DestinationFiles="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).so')"
     />
   </Target>
   <Target Name="_CleanRuntimes"
       AfterTargets="Clean">
     <RemoveDir Directories="obj\local;libs" />
     <Delete Files="jni\config.include;jni\machine.config.include;jni\Application.mk" />
-    <Delete Files="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).%(Identity).so')" />
-    <Delete Files="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).%(Identity).d.so')" />
+    <Delete Files="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).so')" />
+    <Delete Files="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).d.so')" />
   </Target>
 </Project>


### PR DESCRIPTION
The native libraries are output into an <abi> specific folder in

	lib/xbuild/Xamarin/Android/libs

As a result we really do not need to have an <abi> suffix as part
of the native library name. In additon the libmonosgen library was
having -unstripped appended to the end of the library so it was

	libmonosgen-2.0.so-unstripped

this looks a bit weird since it replaces the normal .so extension.
This has been removed.