### PR TITLE
Ensure build log output in SDK resolution tasks.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadResolvedSdksCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadResolvedSdksCache.cs
@@ -86,6 +86,7 @@ namespace Xamarin.Android.Tasks
 		{
 			Log.LogDebugMessage ("Task ReadResolvedSdksCache");
 			Log.LogDebugMessage ("  CacheFile: {0}", CacheFile);
+			MonoAndroidHelper.InitializeAndroidLogger (Log);
 			if (!File.Exists (CacheFile)) {
 				Log.LogWarning ("{0} does not exist. No Resolved Sdks found", CacheFile);
 				return !Log.HasLoggedErrors;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -114,6 +114,8 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  UseLatestAndroidPlatformSdk: {0}", UseLatestAndroidPlatformSdk);
 			Log.LogDebugMessage ("  SequencePointsMode: {0}", SequencePointsMode);
 
+			MonoAndroidHelper.InitializeAndroidLogger (Log);
+
 			MonoAndroidHelper.RefreshAndroidSdk (AndroidSdkPath, AndroidNdkPath, JavaSdkPath);
 			MonoAndroidHelper.RefreshMonoDroidSdk (MonoAndroidToolsPath, MonoAndroidBinPath, ReferenceAssemblyPaths);
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -138,6 +138,14 @@ namespace Xamarin.Android.Tasks
 		{
 			return filePaths.Distinct (MonoAndroidHelper.SizeAndContentFileComparer.DefaultComparer);
 		}
+
+		internal static void InitializeAndroidLogger (TaskLoggingHelper log)
+		{
+			AndroidLogger.Error += (task, message) => log.LogError (task + " " + message);
+			AndroidLogger.Warning += (task, message) => log.LogWarning (task + " " + message);
+			AndroidLogger.Info += (task, message) => log.LogMessage (task + " " + message);
+			AndroidLogger.Debug += (task, message) => log.LogDebugMessage (task + " " + message);
+		}
 #endif
 
 		public static IEnumerable<string> DistinctFilesByContent (IEnumerable<string> filePaths)

--- a/src/Xamarin.Android.Build.Utilities/AndroidLogger.cs
+++ b/src/Xamarin.Android.Build.Utilities/AndroidLogger.cs
@@ -25,7 +25,8 @@ namespace Xamarin.Android.Build.Utilities
 					Info (task, format);
 				else
 					Info (task, String.Format (format, args));
-			}
+			} else
+				throw new InvalidOperationException ("Internal Error: should initialize Info");
 		}
 
 		public static void LogWarning (string format, params object[] args)
@@ -40,7 +41,8 @@ namespace Xamarin.Android.Build.Utilities
 					Warning (task, format);
 				else
 					Warning (task, String.Format (format, args));
-			}
+			} else
+				throw new InvalidOperationException ("Internal Error: should initialize Warning");
 		}
 
 		public static void LogError (string format, params object[] args)
@@ -61,7 +63,8 @@ namespace Xamarin.Android.Build.Utilities
 					Error (task, format);
 				else
 					Error (task, String.Format (format, args));
-			}
+			} else
+				throw new InvalidOperationException ("Internal Error: should initialize Error");
 		}
 
 		public static void LogDebug (string format, params object[] args)
@@ -76,13 +79,16 @@ namespace Xamarin.Android.Build.Utilities
 					Debug (task, format);
 				else
 					Debug (task, String.Format (format, args));
-			}
+			} else
+				throw new InvalidOperationException ("Internal Error: should initialize Debug");
 		}
 
 		public static void LogTask (AndroidTaskLog log)
 		{
 			if (Task != null)
 				Task (log);
+			else
+				throw new InvalidOperationException ("Internal Error: should initialize Task");
 		}
 	}
 


### PR DESCRIPTION
The logging stopped working during xamarin-android migration because
AndroidLogger simply ignored logging calls. It only resulted in
insufficient failure logs that later prevented diagnosing issues.

So from now on, setting event handlers is mandatory before logging
anything with AndroidLogger.

ReadResolvedSdksCache and ResolveSdksTask were the ones which used
the class in problematic way.