### PR TITLE
Fix monodroid SDK detection that depended on non-existent file.

### DIFF
--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -67,6 +67,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Posix", "src\Mono.Posi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.EnterpriseServices", "src\System.EnterpriseServices\System.EnterpriseServices.csproj", "{2868FC32-A4E7-4008-87C8-2C7879CACB58}"
 EndProject
+Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "unix-distribution-setup", "build-tools\unix-distribution-setup\unix-distribution-setup.mdproj", "{2CF172E5-BDAE-4ABA-8BC8-08040ED3E77A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|AnyCPU = Debug|AnyCPU
@@ -280,6 +282,18 @@ Global
 		{2868FC32-A4E7-4008-87C8-2C7879CACB58}.XAIntegrationDebug|AnyCPU.Build.0 = Debug|Any CPU
 		{2868FC32-A4E7-4008-87C8-2C7879CACB58}.XAIntegrationRelease|AnyCPU.ActiveCfg = Debug|Any CPU
 		{2868FC32-A4E7-4008-87C8-2C7879CACB58}.XAIntegrationRelease|AnyCPU.Build.0 = Debug|Any CPU
+		{2CF172E5-BDAE-4ABA-8BC8-08040ED3E77A}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{2CF172E5-BDAE-4ABA-8BC8-08040ED3E77A}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{2CF172E5-BDAE-4ABA-8BC8-08040ED3E77A}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{2CF172E5-BDAE-4ABA-8BC8-08040ED3E77A}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{2CF172E5-BDAE-4ABA-8BC8-08040ED3E77A}.XAIntegrationDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2CF172E5-BDAE-4ABA-8BC8-08040ED3E77A}.XAIntegrationDebug|Any CPU.Build.0 = Debug|Any CPU
+		{2CF172E5-BDAE-4ABA-8BC8-08040ED3E77A}.XAIntegrationRelease|Any CPU.ActiveCfg = Debug|Any CPU
+		{2CF172E5-BDAE-4ABA-8BC8-08040ED3E77A}.XAIntegrationRelease|Any CPU.Build.0 = Debug|Any CPU
+		{2CF172E5-BDAE-4ABA-8BC8-08040ED3E77A}.XAIntegrationDebug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{2CF172E5-BDAE-4ABA-8BC8-08040ED3E77A}.XAIntegrationDebug|AnyCPU.Build.0 = Debug|Any CPU
+		{2CF172E5-BDAE-4ABA-8BC8-08040ED3E77A}.XAIntegrationRelease|AnyCPU.ActiveCfg = Debug|Any CPU
+		{2CF172E5-BDAE-4ABA-8BC8-08040ED3E77A}.XAIntegrationRelease|AnyCPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
@@ -311,6 +325,7 @@ Global
 		{40EAD437-216B-4DF4-8258-3F47E1672C3A} = {CAB438D8-B0F5-4AF0-BEBD-9E2ADBD7B483}
 		{83F00D30-0AC6-40D8-834B-DD39B6CAA8B3} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{2868FC32-A4E7-4008-87C8-2C7879CACB58} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
+		{2CF172E5-BDAE-4ABA-8BC8-08040ED3E77A} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/build-tools/unix-distribution-setup/unix-distribution-setup.mdproj
+++ b/build-tools/unix-distribution-setup/unix-distribution-setup.mdproj
@@ -1,0 +1,29 @@
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ItemType>GenericProject</ItemType>
+    <ProjectGuid>{2CF172E5-BDAE-4ABA-8BC8-08040ED3E77A}</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <OutputPath>..\..\bin\Debug\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <OutputPath>..\..\bin\Release\</OutputPath>
+  </PropertyGroup>
+
+  <Import Project="..\..\Configuration.props" />
+
+  <Target Name="Build">
+    <Copy SourceFiles="..\..\tools\scripts\generator" DestinationFiles="$(OutputPath)bin\generator" />
+    <Exec
+	Condition=" '$(HostOS)' != 'Windows' "
+	Command="chmod +x $(OutputPath)bin\generator" />
+  </Target>
+
+  <Target Name="Clean">
+    <Delete Files="$(OutputPath)bin\generator" />
+  </Target>
+</Project>
+

--- a/src/Xamarin.Android.Build.Utilities/Sdks/MonoDroidSdkUnix.cs
+++ b/src/Xamarin.Android.Build.Utilities/Sdks/MonoDroidSdkUnix.cs
@@ -24,8 +24,12 @@ namespace Xamarin.Android.Build.Utilities
 			string monoAndroidPath = Environment.GetEnvironmentVariable ("MONO_ANDROID_PATH");
 			if (!string.IsNullOrEmpty (monoAndroidPath)) {
 				string libMandroid = Path.Combine (monoAndroidPath, "lib", "mandroid");
-				if (Directory.Exists (libMandroid) && ValidateRuntime (libMandroid))
-					return libMandroid;
+				if (Directory.Exists (libMandroid)) {
+					if (ValidateRuntime (libMandroid))
+						return libMandroid;
+					AndroidLogger.LogInfo (null, "MONO_ANDROID_PATH points to {0}, but it is invalid.", monoAndroidPath);
+				} else
+					AndroidLogger.LogInfo (null, "MONO_ANDROID_PATH points to {0}, but it does not exist.", monoAndroidPath);
 			}
 
 			// check also in the users folder
@@ -38,7 +42,7 @@ namespace Xamarin.Android.Build.Utilities
 		protected override bool ValidateBin (string binPath)
 		{
 			return !string.IsNullOrWhiteSpace (binPath) &&
-				File.Exists (Path.Combine (binPath, "generator"));
+				File.Exists (Path.Combine (binPath, GeneratorScript));
 		}
 
 		protected override string FindFramework (string runtimePath)
@@ -64,8 +68,7 @@ namespace Xamarin.Android.Build.Utilities
 		protected override string FindBin (string runtimePath)
 		{
 			string binPath = Path.GetFullPath (Path.Combine (runtimePath, "..", "..", "bin"));
-			Console.WriteLine (binPath);
-			if (File.Exists (Path.Combine (binPath, "generator")))
+			if (File.Exists (Path.Combine (binPath, GeneratorScript)))
 				return binPath;
 			return null;
 		}

--- a/tools/scripts/generator
+++ b/tools/scripts/generator
@@ -1,0 +1,6 @@
+#!/bin/sh
+BINDIR=`dirname "$0"`
+MANDROID_DIR="$BINDIR/../lib/mandroid"
+
+unset MONO_PATH
+exec mono $MONO_OPTIONS "$MANDROID_DIR/generator.exe" "$@"


### PR DESCRIPTION
We don't build DebugRuntime apk in this new source set anymore, so
do not look for the file in our SDK sanity checker.

Additional warning logs are added because, we should do that.
(Otherwise we will keep ignorant of the actual cause of the
problem forever.)