### PR TITLE
[Xamarin.Android.Build.Tasks] Support MultiDexApplication

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Generator/Generator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Generator/Generator.cs
@@ -12,12 +12,12 @@ namespace Xamarin.Android.Tasks
 {
 	class Generator
 	{
-		public static bool CreateJavaSources (TaskLoggingHelper log, IEnumerable<TypeDefinition> javaTypes, string outputPath, bool useSharedRuntime, bool generateOnCreateOverrides, bool hasExportReference)
+		public static bool CreateJavaSources (TaskLoggingHelper log, IEnumerable<TypeDefinition> javaTypes, string outputPath, string applicationJavaClass, bool useSharedRuntime, bool generateOnCreateOverrides, bool hasExportReference)
 		{
 			bool ok = true;
 			foreach (var t in javaTypes) {
 				try {
-					GenerateJavaSource (log, t, outputPath, useSharedRuntime, generateOnCreateOverrides, hasExportReference);
+					GenerateJavaSource (log, t, outputPath, applicationJavaClass, useSharedRuntime, generateOnCreateOverrides, hasExportReference);
 				} catch (XamarinAndroidException xae) {
 					ok = false;
 					log.LogError (
@@ -37,12 +37,13 @@ namespace Xamarin.Android.Tasks
 			return ok;
 		}
 
-		static void GenerateJavaSource (TaskLoggingHelper log, TypeDefinition t, string outputPath, bool useSharedRuntime, bool generateOnCreateOverrides, bool hasExportReference)
+		static void GenerateJavaSource (TaskLoggingHelper log, TypeDefinition t, string outputPath, string applicationJavaClass, bool useSharedRuntime, bool generateOnCreateOverrides, bool hasExportReference)
 		{
 			try {
 				var jti = new JavaCallableWrapperGenerator (t, log.LogWarning) {
 					UseSharedRuntime = useSharedRuntime,
 					GenerateOnCreateOverrides = generateOnCreateOverrides,
+					ApplicationJavaClass        = applicationJavaClass,
 				};
 
 				jti.Generate (outputPath);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -128,6 +128,7 @@ namespace Xamarin.Android.Tasks
 				Log,
 				java_types,
 				temp,
+				ApplicationJavaClass,
 				UseSharedRuntime,
 				int.Parse (AndroidSdkPlatform) <= 10,
 				ResolvedAssemblies.Any (assembly => Path.GetFileName (assembly.ItemSpec) == "Mono.Android.Export.dll"));


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=40976

There is a desire to *trivially* enable use of `MultiDexApplication`
by setting the `$(AndroidEnableMultiDex)` MSBuild property to True.
When False (the default), the normal Java Callable Wrapper (JCW) base
class naming logic would be used (e.g. use the `[Register]`ed type
name of the base class in the `extends` clause). This normal logic
hinders "trivial" use of MultiDexApplication, as it would require that
any custom `Android.App.Application` type be changed to instead
inherit `Android.Support.Multidex.MultiDexApplication`, and default
`MultiDexApplication` use is required to support other functionality
such as enhanced Fast Deployment.

Use the `$(AndroidApplicationJavaClass)` MSBuild property to control
which Java class should be used instead of `android.app.Application`
within generated Java Callable Wrappers. `$(AndroidEnableMultiDex)`
sets `$(AndroidApplicationJavaClass)` to the appropriate type.