### PR TITLE
[System.EnterpriseServices] Import from monodroid/84a3e6cb

### DIFF
--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -65,6 +65,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Android-Tests", "src\M
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Posix", "src\Mono.Posix\Mono.Posix.csproj", "{83F00D30-0AC6-40D8-834B-DD39B6CAA8B3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.EnterpriseServices", "src\System.EnterpriseServices\System.EnterpriseServices.csproj", "{2868FC32-A4E7-4008-87C8-2C7879CACB58}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|AnyCPU = Debug|AnyCPU
@@ -266,6 +268,18 @@ Global
 		{83F00D30-0AC6-40D8-834B-DD39B6CAA8B3}.XAIntegrationDebug|AnyCPU.Build.0 = Debug|Any CPU
 		{83F00D30-0AC6-40D8-834B-DD39B6CAA8B3}.XAIntegrationRelease|AnyCPU.ActiveCfg = Debug|Any CPU
 		{83F00D30-0AC6-40D8-834B-DD39B6CAA8B3}.XAIntegrationRelease|AnyCPU.Build.0 = Debug|Any CPU
+		{2868FC32-A4E7-4008-87C8-2C7879CACB58}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{2868FC32-A4E7-4008-87C8-2C7879CACB58}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{2868FC32-A4E7-4008-87C8-2C7879CACB58}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{2868FC32-A4E7-4008-87C8-2C7879CACB58}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{2868FC32-A4E7-4008-87C8-2C7879CACB58}.XAIntegrationDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2868FC32-A4E7-4008-87C8-2C7879CACB58}.XAIntegrationDebug|Any CPU.Build.0 = Debug|Any CPU
+		{2868FC32-A4E7-4008-87C8-2C7879CACB58}.XAIntegrationRelease|Any CPU.ActiveCfg = Debug|Any CPU
+		{2868FC32-A4E7-4008-87C8-2C7879CACB58}.XAIntegrationRelease|Any CPU.Build.0 = Debug|Any CPU
+		{2868FC32-A4E7-4008-87C8-2C7879CACB58}.XAIntegrationDebug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{2868FC32-A4E7-4008-87C8-2C7879CACB58}.XAIntegrationDebug|AnyCPU.Build.0 = Debug|Any CPU
+		{2868FC32-A4E7-4008-87C8-2C7879CACB58}.XAIntegrationRelease|AnyCPU.ActiveCfg = Debug|Any CPU
+		{2868FC32-A4E7-4008-87C8-2C7879CACB58}.XAIntegrationRelease|AnyCPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
@@ -296,6 +310,7 @@ Global
 		{53E4ABF0-1085-45F9-B964-DCAE4B819998} = {CAB438D8-B0F5-4AF0-BEBD-9E2ADBD7B483}
 		{40EAD437-216B-4DF4-8258-3F47E1672C3A} = {CAB438D8-B0F5-4AF0-BEBD-9E2ADBD7B483}
 		{83F00D30-0AC6-40D8-834B-DD39B6CAA8B3} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
+		{2868FC32-A4E7-4008-87C8-2C7879CACB58} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/src/System.EnterpriseServices/Properties/AssemblyInfo.cs
+++ b/src/System.EnterpriseServices/Properties/AssemblyInfo.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("System.EnterpriseServices")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("2.0.5")]
+[assembly: AssemblyFileVersion("2.0.5")]
+
+#if SIGN_ASSEMBLY
+[assembly: AssemblyKeyFile(@"../../../OpenTK.snk")]
+#endif

--- a/src/System.EnterpriseServices/System.EnterpriseServices.csproj
+++ b/src/System.EnterpriseServices/System.EnterpriseServices.csproj
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2868FC32-A4E7-4008-87C8-2C7879CACB58}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>System.EnterpriseServices</RootNamespace>
+    <AssemblyName>System.EnterpriseServices</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\bin\Debug\lib\xbuild-frameworks\MonoAndroid\v1.0</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <NoStdLib>true</NoStdLib>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\bin\Release\lib\xbuild-frameworks\MonoAndroid\v1.0</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <NoStdLib>true</NoStdLib>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib">
+    <HintPath>$(OutputPath)..\v1.0\mscorlib.dll</HintPath>
+    <Private>False</Private>
+  </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
System.EnterpriseServices.dll is an empty shell. It contains no types.
It isn't *directly* used by *anything*.

The entire reason it exists is so that Visual Studio (2010?)-
generated Web Services would compile, as the generated project would
contain an assembly reference to System.EnterpriseServices.dll, even
though that assembly wasn't actually *used*.

I suspect that this thread is relevant:

	http://lists.ximian.com/pipermail/monodroid/2010-October/001398.html

> I had the same problem, I fixed it by removing the reference to
> System.EnterpriseServices.dll.  That assembly isn't in MonoDroid P5
> and it falls back to your GAC to find it which causes chaos later.