### PR TITLE
[mxe] Add Windows cross-compiler support.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,7 @@
 	path = external/mono
 	url = https://github.com/mono/mono.git
 	branch = mono-4.5.0-branch
+[submodule "external/mxe"]
+	path = external/mxe
+	url = https://github.com/xamarin/mxe.git
+	branch = xamarin

--- a/Configuration.Override.props.in
+++ b/Configuration.Override.props.in
@@ -25,5 +25,6 @@
     <!-- These must be FULL PATHS -->
     <AndroidToolchainCacheDirectory>$(HOME)\android-archives</AndroidToolchainCacheDirectory>
     <AndroidToolchainDirectory>$(HOME)\android-toolchain</AndroidToolchainDirectory>
+    <AndroidMxeInstallPrefix>$(AndroidToolchainDirectory)\mxe</AndroidMxeInstallPrefix>
   </PropertyGroup>
 </Project>

--- a/Configuration.props
+++ b/Configuration.props
@@ -9,18 +9,22 @@
     <HostOS Condition=" '$(HostOS)' == '' And '$(OS)' == 'Unix' And Exists ('/Applications') ">Darwin</HostOS>
     <HostOS Condition=" '$(HostOS)' == '' And '$(OS)' == 'Unix' ">Linux</HostOS>
     <HostCc Condition=" '$(HostCc)' == '' ">clang</HostCc>
-    <HostCxx Condition=" '$(HostCc)' == '' ">clang++</HostCxx>
+    <HostCxx Condition=" '$(HostCxx)' == '' ">clang++</HostCxx>
     <ManagedRuntime Condition=" '$(ManagedRuntime)' == '' And '$(OS)' != 'Windows_NT' ">mono</ManagedRuntime>
     <HOME Condition=" '$(HOME)' == '' ">$(HOMEDRIVE)$(HOMEPATH)</HOME>
     <AndroidApiLevel Condition=" '$(AndroidApiLevel)' == '' ">23</AndroidApiLevel>
     <AndroidFrameworkVersion Condition=" '$(AndroidFrameworkVersion)' == '' ">v6.0</AndroidFrameworkVersion>
     <AndroidToolchainCacheDirectory Condition=" '$(AndroidToolchainCacheDirectory)' == '' ">$(HOME)\android-archives</AndroidToolchainCacheDirectory>
     <AndroidToolchainDirectory Condition=" '$(AndroidToolchainDirectory)' == '' ">$(HOME)\android-toolchain</AndroidToolchainDirectory>
+    <AndroidMxeInstallPrefix Condition=" '$(AndroidMxeInstallPrefix)' == '' ">$(AndroidToolchainDirectory)\mxe</AndroidMxeInstallPrefix>
     <AndroidSdkDirectory>$(AndroidToolchainDirectory)\sdk</AndroidSdkDirectory>
     <AndroidNdkDirectory>$(AndroidToolchainDirectory)\ndk</AndroidNdkDirectory>
-    <AndroidSupportedAbis Condition=" '$(AndroidSupportedAbis)' == '' ">armeabi-v7a</AndroidSupportedAbis>
+    <AndroidSupportedAbis Condition=" '$(AndroidSupportedAbis)' == '' ">host-$(HostOS),armeabi-v7a</AndroidSupportedAbis>
     <MonoSourceDirectory>$(MSBuildThisFileDirectory)external\mono</MonoSourceDirectory>
     <XamarinAndroidSourcePath>$(MSBuildThisFileDirectory)</XamarinAndroidSourcePath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AndroidMxeFullPath>$([System.IO.Path]::GetFullPath ('$(AndroidMxeInstallPrefix)'))</AndroidMxeFullPath>
   </PropertyGroup>
   <!--
     "Fixup" $(AndroidSupportedAbis) so that Condition attributes elsewhere

--- a/README.md
+++ b/README.md
@@ -41,7 +41,20 @@ Overridable MSBuild properties include:
     * `x86`
     * `x86_64`
 
-    The default value is `armeabi-v7a`.
+    Addtionally there are a set of "host" values. The "host ABI" is used
+    to build mono for the *currently executing operating system*, in
+    particular to build the base class libraries such as `mscorlib.dll`.
+    There can also be support for cross-compiling mono for a different
+    host, e.g. to build Windows `libmonosgen-2.0.dll` from OS X.
+    Supported host values include:
+
+    * `host-Darwin`
+    * `host-Linux`
+    * `host-win64`: Cross-compile Windows 64-bit binaries from Unix.
+
+    The default value is `host-$(HostOS),armeabi-v7a`, where `$(HostOS)`
+    is based on probing various environment variables and filesystem locations.
+    On OS X, the default would be `host-Darwin,armeabi-v7a`.
 
 * `$(AndroidToolchainCacheDirectory)`: The directory to cache the downloaded
     Android NDK and SDK files. This value defaults to

--- a/build-tools/android-toolchain/android-toolchain.mdproj
+++ b/build-tools/android-toolchain/android-toolchain.mdproj
@@ -18,9 +18,11 @@
     <BuildDependsOn>
 			ResolveReferences;
       _CopyBootstrapTasksAssembly;
+      _CheckForRequiredPrograms;
       _DownloadItems;
 			_UnzipFiles;
 			_CreateNdkToolchains;
+      _CreateMxeToolchains;
     </BuildDependsOn>
   </PropertyGroup>
   <ItemGroup>

--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -61,4 +61,42 @@
       <Arch>x86_64</Arch>
     </_NdkToolchain>
   </ItemGroup>
+  <ItemGroup>
+    <_RequiredProgram Include="$(ManagedRuntime)"   Condition=" '$(ManagedRuntime)' != '' " />
+    <_RequiredProgram Include="$(HostCc)" />
+    <_RequiredProgram Include="$(HostCxx)" />
+    <_RequiredProgram Include="7za"                 Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))">
+      <Homebrew>p7zip</Homebrew>
+    </_RequiredProgram>
+    <_RequiredProgram Include="autoconf" />
+    <_RequiredProgram Include="automake" />
+    <_RequiredProgram Include="cmake"               Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))" />
+    <_RequiredProgram Include="gdk-pixbuf-csource"  Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))">
+      <Homebrew>gdk-pixbuf</Homebrew>
+    </_RequiredProgram>
+    <_RequiredProgram Include="gettext"             Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))" />
+    <_RequiredProgram Include="glibtool"            Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))">
+      <Homebrew>libtool</Homebrew>
+    </_RequiredProgram>
+    <_RequiredProgram Include="gsed"                Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))">
+      <Homebrew>gnu-sed</Homebrew>
+    </_RequiredProgram>
+    <_RequiredProgram Include="intltoolize"         Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))">
+      <Homebrew>intltool</Homebrew>
+    </_RequiredProgram>
+    <_RequiredProgram Include="make" />
+    <_RequiredProgram Include="pkg-config"          Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))">
+      <Homebrew>pkg-config</Homebrew>
+    </_RequiredProgram>
+    <_RequiredProgram Include="ruby"                Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))" />
+    <_RequiredProgram Include="scons"               Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))">
+      <Homebrew>scons</Homebrew>
+    </_RequiredProgram>
+    <_RequiredProgram Include="wget"                Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))">
+      <Homebrew>wget</Homebrew>
+    </_RequiredProgram>
+    <_RequiredProgram Include="xz"                  Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))">
+      <Homebrew>xz</Homebrew>
+    </_RequiredProgram>
+  </ItemGroup>
 </Project>

--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -12,6 +12,22 @@
   <UsingTask AssemblyFile="$(OutputPath)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.CreateTemporaryDirectory" />
   <UsingTask AssemblyFile="$(OutputPath)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.DownloadUri" />
   <UsingTask AssemblyFile="$(OutputPath)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.UnzipDirectoryChildren" />
+  <UsingTask AssemblyFile="$(OutputPath)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.Which" />
+  <Target Name="_CheckForRequiredPrograms">
+    <Which Program="%(_RequiredProgram.Identity)" Required="True" />
+    <OnError ExecuteTargets="_PrintRequiredPrograms" />
+  </Target>
+  <Target Name="_PrintRequiredPrograms">
+    <Error
+        ContinueOnError="True"
+        Text="The following programs are required: @(_RequiredProgram->'%(Identity)', ' ')"
+    />
+    <Error
+        Condition=" '$(HostOS)' == 'Darwin' "
+        ContinueOnError="True"
+        Text="Please try running: brew install @(_RequiredProgram->'%(Homebrew)', ' ')`"
+    />
+  </Target>
   <Target Name="_DetermineItems">
     <CreateItem
         Include="@(AndroidSdkItem)"
@@ -94,5 +110,35 @@
         Text="$(AndroidToolchainDirectory)\ndk"
         Importance="High"
     />
+  </Target>
+  <Target Name="_SetMxeToolchainMakefileTimeToLastCommitTimestamp"
+      Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,')) Or $(AndroidSupportedAbisForConditionalChecks.Contains (',host-win32,'))">
+    <Exec
+        Command="touch -m -t `git log -1 --format=%25cd --date=format-local:%25Y%25m%25d%25H%25M.%25S` Makefile"
+        WorkingDirectory="..\..\external\mxe"
+    />
+  </Target>
+  <Target Name="_CreateMxeW32Toolchain"
+      DependsOnTargets="_SetMxeToolchainMakefileTimeToLastCommitTimestamp"
+      Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))"
+      Inputs="..\..\external\mxe\Makefile"
+      Outputs="$(AndroidMxeFullPath)\bin\i686-w64-mingw32.static-gcc">
+    <Exec
+        Command="make $(MAKEFLAGS) MXE_TARGETS=&quot;i686-w64-mingw32.static&quot; gcc PREFIX=&quot;$(AndroidMxeFullPath)&quot;"
+        WorkingDirectory="..\..\external\mxe"
+    />
+  </Target>
+  <Target Name="_CreateMxeW64Toolchain"
+      DependsOnTargets="_SetMxeToolchainMakefileTimeToLastCommitTimestamp"
+      Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))"
+      Inputs="..\..\external\mxe\Makefile"
+      Outputs="$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-gcc">
+    <Exec
+        Command="make $(MAKEFLAGS) MXE_TARGETS=&quot;x86_64-w64-mingw32.static&quot; gcc PREFIX=&quot;$(AndroidMxeFullPath)&quot;"
+        WorkingDirectory="..\..\external\mxe"
+    />
+  </Target>
+  <Target Name="_CreateMxeToolchains"
+      DependsOnTargets="_CreateMxeW32Toolchain;_CreateMxeW64Toolchain">
   </Target>
 </Project>

--- a/build-tools/mono-runtimes/mono-runtimes.projitems
+++ b/build-tools/mono-runtimes/mono-runtimes.projitems
@@ -12,6 +12,7 @@
       <CxxCpp>$(_ArmCxxCpp) $(_ArmCppFlags)</CxxCpp>
       <Ld>$(_ArmLd)</Ld>
       <LdFlags>$(_ArmLdFlags)</LdFlags>
+      <Objdump>$(_ArmObjdump)</Objdump>
       <RanLib>$(_ArmRanLib)</RanLib>
       <Strip>$(_ArmStrip)</Strip>
       <ConfigureFlags>--host=armv5-linux-androideabi $(_TargetConfigureFlags)</ConfigureFlags>
@@ -31,6 +32,7 @@
       <CxxCpp>$(_ArmCxxCpp) $(_ArmCppFlags)</CxxCpp>
       <Ld>$(_ArmLd)</Ld>
       <LdFlags>$(_ArmLdFlags)</LdFlags>
+      <Objdump>$(_ArmObjdump)</Objdump>
       <RanLib>$(_ArmRanLib)</RanLib>
       <Strip>$(_ArmStrip)</Strip>
       <ConfigureFlags>--host=armv5-linux-androideabi $(_TargetConfigureFlags)</ConfigureFlags>
@@ -50,6 +52,7 @@
       <CxxCpp>$(_Arm64CxxCpp) $(_Arm64CppFlags)</CxxCpp>
       <Ld>$(_Arm64Ld)</Ld>
       <LdFlags>$(_Arm64LdFlags)</LdFlags>
+      <Objdump>$(_Arm64Objdump)</Objdump>
       <RanLib>$(_Arm64RanLib)</RanLib>
       <Strip>$(_Arm64Strip)</Strip>
       <ConfigureFlags>--host=aarch64-linux-android $(_TargetConfigureFlags)</ConfigureFlags>
@@ -69,6 +72,7 @@
       <CxxCpp>$(_X86CxxCpp) $(_X86CppFlags)</CxxCpp>
       <Ld>$(_X86Ld)</Ld>
       <LdFlags>$(_X86LdFlags)</LdFlags>
+      <Objdump>$(_X86Objdump)</Objdump>
       <RanLib>$(_X86RanLib)</RanLib>
       <Strip>$(_X86Strip)</Strip>
       <ConfigureFlags>--host=i686-linux-android $(_TargetConfigureFlags)</ConfigureFlags>
@@ -89,6 +93,7 @@
       <Ld>$(_X86_64Ld)</Ld>
       <LdFlags>$(_X86_64LdFlags)</LdFlags>
       <RanLib>$(_X86_64RanLib)</RanLib>
+      <Objdump>$(_X86_64Objdump)</Objdump>
       <Strip>$(_X86_64Strip)</Strip>
       <ConfigureFlags>--host=x86_64-linux-android $(_TargetConfigureFlags)</ConfigureFlags>
       <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
@@ -96,7 +101,28 @@
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
-    <_MonoRuntime Include="host-Darwin" Condition=" '$(HostOS)' == 'Darwin' ">
+    <_MonoRuntime Include="host-Win64" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))">
+      <Ar>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-ar</Ar>
+      <As>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-as</As>
+      <Cc>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-gcc</Cc>
+      <Cpp></Cpp>
+      <CFlags>$(_HostWin64CFlags)</CFlags>
+      <Cxx>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-g++</Cxx>
+      <CxxFlags>$(_HostWin64CFlags)</CxxFlags>
+      <CxxCpp></CxxCpp>
+      <DllTool>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-dlltool</DllTool>
+      <Ld>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-ld</Ld>
+      <LdFlags></LdFlags>
+      <Objdump>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-objdump</Objdump>
+      <RanLib>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-ranlib</RanLib>
+      <Strip>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-strip</Strip>
+      <ConfigureFlags>PATH="$PATH:$(AndroidMxeFullPath)\bin" --host=x86_64-w64-mingw32.static --target=x86_64-w64-mingw32.static --disable-boehm --enable-mcs-build=no --enable-nls=no --enable-maintainer-mode --with-monodroid --disable-llvm</ConfigureFlags>
+      <NativeLibraryExtension>dll</NativeLibraryExtension>
+      <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
+      <OutputProfilerFilename></OutputProfilerFilename>
+      <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
+    </_MonoRuntime>
+    <_MonoRuntime Include="host-Darwin" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-Darwin,'))">
       <Ar>ar</Ar>
       <As>as</As>
       <Cc>$(HostCc)</Cc>
@@ -114,7 +140,7 @@
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
-    <_MonoRuntime Include="host-Linux" Condition=" '$(HostOS)' == 'Linux' ">
+    <_MonoRuntime Include="host-Linux" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-Linux,'))">
       <Ar>ar</Ar>
       <As>as</As>
       <Cc>$(HostCc)</Cc>

--- a/build-tools/mono-runtimes/mono-runtimes.props
+++ b/build-tools/mono-runtimes/mono-runtimes.props
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <_CommonCFlags Condition=" '$(Configuration)' == 'Debug' ">-ggdb3 -O0 -fno-omit-frame-pointer</_CommonCFlags>
     <_CommonCFlags Condition=" '$(Configuration)' == 'Release' ">-g -O2</_CommonCFlags>
+    <_HostWinCFlags Condition=" '$(Configuration)' == 'Debug' ">-ggdb3 -O0 -DXAMARIN_PRODUCT_VERSION=0</_HostWinCFlags>
+    <_HostWinCFlags Condition=" '$(Configuration)' == 'Release' ">-g -O2 -DXAMARIN_PRODUCT_VERSION=0</_HostWinCFlags>
     <_CommonConfigureFlags>--without-ikvm-native --enable-maintainer-mode --with-profile2=no --with-profile4=no --with-profile4_5=no --with-monodroid --enable-nls=no --with-sigaltstack=yes --with-tls=pthread mono_cv_uscore=yes</_CommonConfigureFlags>
     <_TargetConfigureFlags>$(_CommonConfigureFlags) --enable-minimal=ssa,portability,attach,verifier,full_messages,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,security,shared_handles --disable-mcs-build --disable-executables --disable-iconv</_TargetConfigureFlags>
     <_SecurityCFlags>-Wl,-z,now -Wl,-z,relro -Wl,-z,noexecstack -fstack-protector</_SecurityCFlags>
@@ -23,6 +25,7 @@
     <_ArmCxxCpp>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-cpp</_ArmCxxCpp>
     <_ArmLd>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-ld</_ArmLd>
     <_ArmLdFlags>$(_TargetLdFlags) -Wl,--fix-cortex-a8 -Wl,-rpath-link=$(_ArmNdkPlatformPath)\arch-arm\usr\lib,-dynamic-linker=/system/bin/linker -L$(_ArmNdkPlatformPath)\arch-arm\usr\lib</_ArmLdFlags>
+    <_ArmObjdump>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-objdump</_ArmObjdump>
     <_ArmRanLib>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-ranlib</_ArmRanLib>
     <_ArmStrip>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-strip</_ArmStrip>
   </PropertyGroup>
@@ -39,6 +42,7 @@
     <_Arm64CxxCpp>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-cpp</_Arm64CxxCpp>
     <_Arm64Ld>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-ld</_Arm64Ld>
     <_Arm64LdFlags>$(_TargetLdFlags) -Wl,-rpath-link=$(_Arm64NdkPlatformPath)\arch-arm64\usr\lib,-dynamic-linker=/system/bin/linker -L$(_Arm64NdkPlatformPath)\arch-arm64\usr\lib</_Arm64LdFlags>
+    <_Arm64Objdump>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-objdump</_Arm64Objdump>
     <_Arm64RanLib>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-ranlib</_Arm64RanLib>
     <_Arm64Strip>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-strip</_Arm64Strip>
   </PropertyGroup>
@@ -55,6 +59,7 @@
     <_X86CxxCpp>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-cpp</_X86CxxCpp>
     <_X86Ld>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-ld</_X86Ld>
     <_X86LdFlags>$(_TargetLdFlags) -Wl,-rpath-link=$(_X86NdkPlatformPath)\arch-x86\usr\lib,-dynamic-linker=/system/bin/linker -L$(_X86NdkPlatformPath)\arch-x86\usr\lib</_X86LdFlags>
+    <_X86Objdump>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-objdump</_X86Objdump>
     <_X86RanLib>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-ranlib</_X86RanLib>
     <_X86Strip>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-strip</_X86Strip>
   </PropertyGroup>
@@ -71,7 +76,11 @@
     <_X86_64CxxCpp>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-cpp</_X86_64CxxCpp>
     <_X86_64Ld>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-ld</_X86_64Ld>
     <_X86_64LdFlags>$(_TargetLdFlags) -Wl,-rpath-link=$(_X86_64NdkPlatformPath)\arch-x86_64\usr\lib,-dynamic-linker=/system/bin/linker -L$(_X86_64NdkPlatformPath)\arch-x86_64\usr\lib</_X86_64LdFlags>
+    <_X86_64Objdump>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-objdump</_X86_64Objdump>
     <_X86_64RanLib>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-ranlib</_X86_64RanLib>
     <_X86_64Strip>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-strip</_X86_64Strip>
+  </PropertyGroup>
+  <PropertyGroup>
+    <_HostWin64CFlags>$(_HostWinCFlags)</_HostWin64CFlags>
   </PropertyGroup>
 </Project>

--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -78,7 +78,7 @@
       Outputs="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\Makefile')">
     <MakeDir Directories="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)')" />
     <Exec
-        Command="..\..\..\$(_MonoPath)\configure LDFLAGS=&quot;%(_MonoRuntime.LdFlags)&quot; CFLAGS=&quot;%(_MonoRuntime.CFlags)&quot; CXXFLAGS=&quot;%(_MonoRuntime.CxxFlags)&quot; CC=&quot;%(_MonoRuntime.Cc)&quot; CXX=&quot;%(_MonoRuntime.Cxx)&quot; CPP=&quot;%(_MonoRuntime.Cpp)&quot; CXXCPP=&quot;%(_MonoRuntime.CxxCpp)&quot; LD=&quot;%(_MonoRuntime.Ld)&quot; AR=&quot;%(_MonoRuntime.Ar)&quot; AS=&quot;%(_MonoRuntime.As)&quot; RANLIB=&quot;%(_MonoRuntime.RanLib)&quot; STRIP=&quot;%(_MonoRuntime.Strip)&quot; --cache-file=..\%(_MonoRuntime.Identity).config.cache %(_MonoRuntime.ConfigureFlags)"
+        Command="..\..\..\$(_MonoPath)\configure LDFLAGS=&quot;%(_MonoRuntime.LdFlags)&quot; CFLAGS=&quot;%(_MonoRuntime.CFlags)&quot; CXXFLAGS=&quot;%(_MonoRuntime.CxxFlags)&quot; CC=&quot;%(_MonoRuntime.Cc)&quot; CXX=&quot;%(_MonoRuntime.Cxx)&quot; CPP=&quot;%(_MonoRuntime.Cpp)&quot; CXXCPP=&quot;%(_MonoRuntime.CxxCpp)&quot; LD=&quot;%(_MonoRuntime.Ld)&quot; AR=&quot;%(_MonoRuntime.Ar)&quot; AS=&quot;%(_MonoRuntime.As)&quot; RANLIB=&quot;%(_MonoRuntime.RanLib)&quot; STRIP=&quot;%(_MonoRuntime.Strip)&quot; DLLTOOL=&quot;%(_MonoRuntime.DllTool)&quot; OBJDUMP=&quot;%(_MonoRuntime.Objdump)&quot; --cache-file=..\%(_MonoRuntime.Identity).config.cache %(_MonoRuntime.ConfigureFlags)"
         WorkingDirectory="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)')"
     />
     <Touch
@@ -86,34 +86,37 @@
         AlwaysCreate="True"
     />
   </Target>
-  <ItemGroup>
-    <_RuntimeLibraries Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\mono\mini\.libs\%(OutputRuntimeFilename).%(NativeLibraryExtension)')" />
-    <_RuntimeLibraries Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\mono\profiler\.libs\%(OutputProfilerFilename).%(NativeLibraryExtension)')" />
-    <_RuntimeLibraries Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\support\.libs\%(OutputMonoPosixHelperFilename).%(NativeLibraryExtension)')" />
-  </ItemGroup>
+  <Target Name="_GetRuntimesOutputItems">
+    <ItemGroup>
+      <_RuntimeLibraries                Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\mono\mini\.libs\%(OutputRuntimeFilename).%(NativeLibraryExtension)')" />
+      <_InstallRuntimesOutputs          Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntimeFilename).%(NativeLibraryExtension)')" />
+      <_InstallUnstrippedRuntimeOutputs Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntimeFilename).d.%(NativeLibraryExtension)')" />
+      <_RuntimeLibraries
+          Condition=" '%(_MonoRuntime.OutputProfilerFilename)' != '' "
+          Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\mono\profiler\.libs\%(OutputProfilerFilename).%(NativeLibraryExtension)')"
+      />
+      <_InstallRuntimesOutputs
+          Condition=" '%(_MonoRuntime.OutputProfilerFilename)' != '' "
+          Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputProfilerFilename).%(NativeLibraryExtension)')"
+      />
+      <_RuntimeLibraries        Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\support\.libs\%(OutputMonoPosixHelperFilename).%(NativeLibraryExtension)')" />
+      <_InstallRuntimesOutputs  Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputMonoPosixHelperFilename).%(NativeLibraryExtension)')" />
+    </ItemGroup>
+  </Target>
   <Target Name="_BuildRuntimes"
+      DependsOnTargets="_GetRuntimesOutputItems"
       Inputs="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\.stamp')"
-      Outputs="@(_RuntimeLibraries);@(_BclProfileItems">
+      Outputs="@(_RuntimeLibraries);@(_BclProfileItems)">
     <Exec
         Command="make $(MAKEFLAGS) # %(_MonoRuntime.Identity)"
         WorkingDirectory="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)')"
     />
-    <ItemGroup>
-      <_MonoLibraries Include="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\mono\mini\.libs\%(OutputRuntimeFilename).%(NativeLibraryExtension)')" />
-      <_MonoLibraries Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\mono\profiler\.libs\%(OutputProfilerFilename).%(NativeLibraryExtension)')" />
-      <_MonoLibraries Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\support\.libs\%(OutputMonoPosixHelperFilename).%(NativeLibraryExtension)')" />
-    </ItemGroup>
     <Touch
-        Files="@(_MonoLibraries)"
+        Files="@(_RuntimeLibraries);@(_BclProfileItems)"
     />
   </Target>
-  <ItemGroup>
-    <_InstallRuntimesOutputs Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntimeFilename).%(NativeLibraryExtension)')" />
-    <_InstallRuntimesOutputs Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputProfilerFilename).%(NativeLibraryExtension)')" />
-    <_InstallRuntimesOutputs Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputMonoPosixHelperFilename).%(NativeLibraryExtension)')" />
-    <_InstallUnstrippedRuntimeOutputs Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntimeFilename).d.%(NativeLibraryExtension)')" />
-  </ItemGroup>
   <Target Name="_InstallRuntimes"
+      DependsOnTargets="_GetRuntimesOutputItems"
       Inputs="@(_RuntimeLibraries)"
       Outputs="@(_InstallRuntimesOutputs);@(_InstallUnstrippedRuntimeOutputs)">
     <MakeDir Directories="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)')" />

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -38,6 +38,7 @@
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\UnzipDirectoryChildren.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GenerateProfile.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GetNugetPackageBasePath.cs" />
+    <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Which.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Xamarin.Android.Tools.BootstrapTasks.targets">

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/Which.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/Which.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	public class Which : Task
+	{
+		[Required]
+		public  ITaskItem           Program             { get; set; }
+
+		public  ITaskItem[]         Directories         { get; set; }
+
+		public  bool                Required            { get; set; }
+
+		[Output]
+		public  ITaskItem           Location            { get; set; }
+
+		static  readonly    string[]    FileExtensions = new []{
+			null,
+			".bat",
+			".cmd",
+			".com",
+			".exe",
+		};
+
+		public override bool Execute ()
+		{
+			string[]    paths   = Directories?.Select (d => d.ItemSpec).ToArray ();
+			if (paths == null || paths.Length == 0) {
+				paths    = Environment.GetEnvironmentVariable ("PATH").Split (Path.PathSeparator);
+			}
+
+			Log.LogMessage (MessageImportance.Low, $"Task {nameof (Which)}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (Program)}: {Program}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (Directories)}:");
+			foreach (var p in paths) {
+				Log.LogMessage (MessageImportance.Low, $"    {p}");
+			}
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (Required)}: {Required}");
+
+			foreach (var path in paths) {
+				var p   = Path.Combine (path, Program.ItemSpec);
+				foreach (var ext in FileExtensions) {
+					var e   = Path.ChangeExtension (p, ext);
+					if (File.Exists (e)) {
+						Location = new TaskItem (e);
+						break;
+					}
+				}
+				if (Location != null)
+					break;
+			}
+
+			if (Location == null && Required) {
+				Log.LogError ("Could not find required program '{0}'.", Program.ItemSpec);
+			}
+
+			Log.LogMessage (MessageImportance.Low, $"  [Output] {nameof (Location)}: {Location?.ItemSpec}");
+
+			return !Log.HasLoggedErrors;
+		}
+	}
+}
+

--- a/src/monodroid/monodroid.projitems
+++ b/src/monodroid/monodroid.projitems
@@ -6,4 +6,7 @@
   <ItemGroup>
     <_MonoRuntime Include="$(_SupportedAbis)" />
   </ItemGroup>
+  <ItemGroup>
+    <_RequiredProgram Include="xxd" />
+  </ItemGroup>
 </Project>

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.Which" />
   <Import Project="monodroid.projitems" />
   <PropertyGroup>
     <_Conf>$(Configuration.ToLowerInvariant())</_Conf>
@@ -10,6 +11,7 @@
   <Target Name="_BuildRuntimes"
       Inputs="@(CFiles);jni\Android.mk"
       Outputs="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).so')">
+    <Which Program="%(_RequiredProgram.Identity)" Required="True" />
     <PropertyGroup>
       <_AppAbi>$(AndroidSupportedAbis.Replace(',', ' ')</_AppAbi>
     </PropertyGroup>


### PR DESCRIPTION
Certain Xamarin.Android features require that Mono be built for
Windows, e.g. the [AOT compilers][aot] require a build of mono that
executes on Windows to generate the AOT native libraries.

Unfortunately, building Mono on Windows continues to be a massive
PITA. (Autotools on Windows requires Cygwin/mingw, running shell
scripts on Windows is painfully slow, it's all brittle, etc.)

To work around this pain, we instead build the Mono/Windows binaries
on OS X, via [MXE][mxe], which produces a gcc-based cross-compiler
which generates Windows binaries and is executable from Unix.
This in turn requires that we have MXE, so add a
`_CreateMxeToolchains` target to `android-toolchain.targets` which
will build MXE. The installation prefix for MXE can be overridden via
the new `$(AndroidMxeInstallPrefix)` MSBuild property; it defaults to
`$HOME/android-toolchain/mxe`.

Rework the `$(AndroidSupportedAbis)` MSBuild property so that it
must include the "host" ABI, and add support for a new `host-win64`
value which will use MXE to generate 64-bit Windows binaries for
libmonosgen-2.0.dll and libMonoPosixHelper.dll.

We can't always process `host-$(HostOS)` because of an xbuild bug.
The scenario is that if you want to just build `host-win64`, the
obvious thing to do is:

	cd build-tools/mono-runtimes
	xbuild /p:AndroidSupportedAbis=host-win64

Alas, if `host-$(HostOS)` is always processed, this inexplicably
causes `host-$(HostOS)` to be re-rebuilt, which (1) is a waste of
time, and (2) fails -- inexplicably -- in the `_BuildRuntimes` target
because make(1) thinks that the configure flags have somehow changed,
which currently makes no sense at all. (When can we move to MSBuild?)

Changing `$(AndroidSupportedAbis)` so that `host-$(HostOS)` is
explicitly processed instead of implicitly processed allows working
around the above xbuild bug, as `host-$(HostOS)` won't be implicitly
processed on every build, but only when required.

Additionally, we add a new <Which/> MSBuild task so that we can
determine of a particular process is in `$PATH`. This is useful
becuase listing requirements within README.md is a road to pain --
e.g. xxd(1) is required to build `src/monodroid` but if it's missing
it'll still *build* but you'll instead get a *linker* failure because
the `monodroid_config` and `monodroid_machine_config` symbols aren't
present. Building MXE requires that even more programs be present
within $PATH, so explicitly check for these so that *useful* error
messages can be generated instead of obscure ones.

Finally, a note about autotools and generating Windows native
libraries: creation of `.dll` files *requires* that an appropriate
objdump be present so it can determine if e.g. `libkernel32.a` is an
import library or an archive. If `x86_64-w64-mingw32.static-objdump`
isn't found -- e.g. because $PATH doesn't contain it -- then no `.dll`
files will be created, and much head scratching will occur.

To rectify this, override the OBJDUMP and DLLTOOL values when invoking
`configure` so that that full paths are used and `$PATH` use is
reduced.  (Who wants `x86_64-w64-mingw32.static-objdump` in `$PATH`?)

[aot]: https://developer.xamarin.com/releases/android/xamarin.android_5/xamarin.android_5.1/#AOT_Support
[mxe]: http://mxe.cc/