### PR TITLE
[Configuration] Change default `$(HostCc)`, `$(HostCxx)` values

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -8,8 +8,8 @@
     <HostOS Condition=" '$(HostOS)' == '' And '$(OS)' == 'Windows_NT' ">Windows</HostOS>
     <HostOS Condition=" '$(HostOS)' == '' And '$(OS)' == 'Unix' And Exists ('/Applications') ">Darwin</HostOS>
     <HostOS Condition=" '$(HostOS)' == '' And '$(OS)' == 'Unix' ">Linux</HostOS>
-    <HostCc Condition=" '$(HostCc)' == '' ">clang</HostCc>
-    <HostCxx Condition=" '$(HostCxx)' == '' ">clang++</HostCxx>
+    <HostCc Condition=" '$(HostCc)' == '' ">cc</HostCc>
+    <HostCxx Condition=" '$(HostCxx)' == '' ">c++</HostCxx>
     <ManagedRuntime Condition=" '$(ManagedRuntime)' == '' And '$(OS)' != 'Windows_NT' ">mono</ManagedRuntime>
     <HOME Condition=" '$(HOME)' == '' ">$(HOMEDRIVE)$(HOMEPATH)</HOME>
     <AndroidApiLevel Condition=" '$(AndroidApiLevel)' == '' ">23</AndroidApiLevel>


### PR DESCRIPTION
As [Marek mentioned in PR 55][0], the default C and C++ compiler
program names should be `cc` and `c++`, not `clang` and `clang++`,
as `cc` and `c++` are more portable across various Unixes.

[0]: https://github.com/xamarin/xamarin-android/pull/55#discussion_r65967751