### PR TITLE
[Configuration] Use `:`, not `,`, as ABI separator.

### DIFF
--- a/Configuration.Override.props.in
+++ b/Configuration.Override.props.in
@@ -7,16 +7,16 @@
     <AndroidFrameworkVersion>v6.0</AndroidFrameworkVersion>
 
     <!--
-      Comma-separated list of ABIs to build mono for.
+      Colon-separated list of ABIs to build mono for.
       Supported ABIs include:
       - armeabi
       - armeabi-v7a
       - arm64-v8a
       - x86
       - x86_64
-      Note: Why comma? Because ';' can't be specified on the command-line.
+      Note: Why colon? Because comma `,` and semicolon `;` can't be specified on the command-line.
       -->
-    <AndroidSupportedAbis>armeabi,armeabi-v7a,arm64-v8a,x86,x86_64</AndroidSupportedAbis>
+    <AndroidSupportedAbis>armeabi:armeabi-v7a:arm64-v8a:x86:x86_64</AndroidSupportedAbis>
 
     <!-- C and C++ compilers to emit host-native binaries -->
     <HostCc>clang</HostCc>

--- a/Configuration.props
+++ b/Configuration.props
@@ -19,7 +19,7 @@
     <AndroidMxeInstallPrefix Condition=" '$(AndroidMxeInstallPrefix)' == '' ">$(AndroidToolchainDirectory)\mxe</AndroidMxeInstallPrefix>
     <AndroidSdkDirectory>$(AndroidToolchainDirectory)\sdk</AndroidSdkDirectory>
     <AndroidNdkDirectory>$(AndroidToolchainDirectory)\ndk</AndroidNdkDirectory>
-    <AndroidSupportedAbis Condition=" '$(AndroidSupportedAbis)' == '' ">host-$(HostOS),armeabi-v7a</AndroidSupportedAbis>
+    <AndroidSupportedAbis Condition=" '$(AndroidSupportedAbis)' == '' ">host-$(HostOS):armeabi-v7a</AndroidSupportedAbis>
     <MonoSourceDirectory>$(MSBuildThisFileDirectory)external\mono</MonoSourceDirectory>
     <XamarinAndroidSourcePath>$(MSBuildThisFileDirectory)</XamarinAndroidSourcePath>
   </PropertyGroup>
@@ -28,11 +28,11 @@
   </PropertyGroup>
   <!--
     "Fixup" $(AndroidSupportedAbis) so that Condition attributes elsewhere
-    can use `,ABI-NAME,`, to avoid substring mismatches.
+    can use `:ABI-NAME:`, to avoid substring mismatches.
     -->
   <PropertyGroup>
     <AndroidSupportedAbisForConditionalChecks>$(AndroidSupportedAbis)</AndroidSupportedAbisForConditionalChecks>
-    <AndroidSupportedAbisForConditionalChecks Condition=" !$(AndroidSupportedAbisForConditionalChecks.EndsWith (',')) "   >$(AndroidSupportedAbisForConditionalChecks),</AndroidSupportedAbisForConditionalChecks>
-    <AndroidSupportedAbisForConditionalChecks Condition=" !$(AndroidSupportedAbisForConditionalChecks.StartsWith (',')) " >,$(AndroidSupportedAbisForConditionalChecks)</AndroidSupportedAbisForConditionalChecks>
+    <AndroidSupportedAbisForConditionalChecks Condition=" !$(AndroidSupportedAbisForConditionalChecks.EndsWith (':')) "   >$(AndroidSupportedAbisForConditionalChecks):</AndroidSupportedAbisForConditionalChecks>
+    <AndroidSupportedAbisForConditionalChecks Condition=" !$(AndroidSupportedAbisForConditionalChecks.StartsWith (':')) " >:$(AndroidSupportedAbisForConditionalChecks)</AndroidSupportedAbisForConditionalChecks>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Overridable MSBuild properties include:
     version which corresponds to `$(AndroidApiLevel)`. This is *usually* the
     Android version number with a leading `v`, e.g. `v4.0.3` for API-15.
 * `$(AndroidSupportedAbis)`: The Android ABIs to build for inclusion within
-    apps. This is a `,`-separated list of ABIs to build. Supported values are:
+    apps. This is a `:`-separated list of ABIs to build. Supported values are:
 
     * `armeabi`
     * `armeabi-v7a`
@@ -52,9 +52,9 @@ Overridable MSBuild properties include:
     * `host-Linux`
     * `host-win64`: Cross-compile Windows 64-bit binaries from Unix.
 
-    The default value is `host-$(HostOS),armeabi-v7a`, where `$(HostOS)`
+    The default value is `host-$(HostOS):armeabi-v7a`, where `$(HostOS)`
     is based on probing various environment variables and filesystem locations.
-    On OS X, the default would be `host-Darwin,armeabi-v7a`.
+    On OS X, the default would be `host-Darwin:armeabi-v7a`.
 
 * `$(AndroidToolchainCacheDirectory)`: The directory to cache the downloaded
     Android NDK and SDK files. This value defaults to

--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -44,19 +44,19 @@
     </AndroidSdkItem>
   </ItemGroup>
   <ItemGroup>
-    <_NdkToolchain Include="arm-linux-androideabi-clang" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains(',armeabi,')) Or $(AndroidSupportedAbisForConditionalChecks.Contains(',armeabi-v7a,'))">
+    <_NdkToolchain Include="arm-linux-androideabi-clang" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains(':armeabi:')) Or $(AndroidSupportedAbisForConditionalChecks.Contains(':armeabi-v7a:'))">
       <Platform>android-4</Platform>
       <Arch>arm</Arch>
     </_NdkToolchain>
-    <_NdkToolchain Include="aarch64-linux-android-clang" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains(',arm64-v8a,'))">
+    <_NdkToolchain Include="aarch64-linux-android-clang" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains(':arm64-v8a:'))">
       <Platform>android-21</Platform>
       <Arch>arm64</Arch>
     </_NdkToolchain>
-    <_NdkToolchain Include="x86-clang" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains(',x86,'))">
+    <_NdkToolchain Include="x86-clang" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains(':x86:'))">
       <Platform>android-9</Platform>
       <Arch>x86</Arch>
     </_NdkToolchain>
-    <_NdkToolchain Include="x86_64-clang" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains(',x86_64,'))">
+    <_NdkToolchain Include="x86_64-clang" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains(':x86_64:'))">
       <Platform>android-21</Platform>
       <Arch>x86_64</Arch>
     </_NdkToolchain>
@@ -65,37 +65,37 @@
     <_RequiredProgram Include="$(ManagedRuntime)"   Condition=" '$(ManagedRuntime)' != '' " />
     <_RequiredProgram Include="$(HostCc)" />
     <_RequiredProgram Include="$(HostCxx)" />
-    <_RequiredProgram Include="7za"                 Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))">
+    <_RequiredProgram Include="7za"                 Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))">
       <Homebrew>p7zip</Homebrew>
     </_RequiredProgram>
     <_RequiredProgram Include="autoconf" />
     <_RequiredProgram Include="automake" />
-    <_RequiredProgram Include="cmake"               Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))" />
-    <_RequiredProgram Include="gdk-pixbuf-csource"  Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))">
+    <_RequiredProgram Include="cmake"               Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))" />
+    <_RequiredProgram Include="gdk-pixbuf-csource"  Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))">
       <Homebrew>gdk-pixbuf</Homebrew>
     </_RequiredProgram>
-    <_RequiredProgram Include="gettext"             Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))" />
-    <_RequiredProgram Include="glibtool"            Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))">
+    <_RequiredProgram Include="gettext"             Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))" />
+    <_RequiredProgram Include="glibtool"            Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))">
       <Homebrew>libtool</Homebrew>
     </_RequiredProgram>
-    <_RequiredProgram Include="gsed"                Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))">
+    <_RequiredProgram Include="gsed"                Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))">
       <Homebrew>gnu-sed</Homebrew>
     </_RequiredProgram>
-    <_RequiredProgram Include="intltoolize"         Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))">
+    <_RequiredProgram Include="intltoolize"         Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))">
       <Homebrew>intltool</Homebrew>
     </_RequiredProgram>
     <_RequiredProgram Include="make" />
-    <_RequiredProgram Include="pkg-config"          Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))">
+    <_RequiredProgram Include="pkg-config"          Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))">
       <Homebrew>pkg-config</Homebrew>
     </_RequiredProgram>
-    <_RequiredProgram Include="ruby"                Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))" />
-    <_RequiredProgram Include="scons"               Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))">
+    <_RequiredProgram Include="ruby"                Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))" />
+    <_RequiredProgram Include="scons"               Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))">
       <Homebrew>scons</Homebrew>
     </_RequiredProgram>
-    <_RequiredProgram Include="wget"                Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))">
+    <_RequiredProgram Include="wget"                Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))">
       <Homebrew>wget</Homebrew>
     </_RequiredProgram>
-    <_RequiredProgram Include="xz"                  Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))">
+    <_RequiredProgram Include="xz"                  Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))">
       <Homebrew>xz</Homebrew>
     </_RequiredProgram>
   </ItemGroup>

--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -112,7 +112,7 @@
     />
   </Target>
   <Target Name="_SetMxeToolchainMakefileTimeToLastCommitTimestamp"
-      Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,')) Or $(AndroidSupportedAbisForConditionalChecks.Contains (',host-win32,'))">
+      Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:')) Or $(AndroidSupportedAbisForConditionalChecks.Contains (':host-win32:'))">
     <Exec
         Command="touch -m -t `git log -1 --format=%25cd --date=format-local:%25Y%25m%25d%25H%25M.%25S` Makefile"
         WorkingDirectory="..\..\external\mxe"
@@ -120,7 +120,7 @@
   </Target>
   <Target Name="_CreateMxeW32Toolchain"
       DependsOnTargets="_SetMxeToolchainMakefileTimeToLastCommitTimestamp"
-      Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))"
+      Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))"
       Inputs="..\..\external\mxe\Makefile"
       Outputs="$(AndroidMxeFullPath)\bin\i686-w64-mingw32.static-gcc">
     <Exec
@@ -130,7 +130,7 @@
   </Target>
   <Target Name="_CreateMxeW64Toolchain"
       DependsOnTargets="_SetMxeToolchainMakefileTimeToLastCommitTimestamp"
-      Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))"
+      Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))"
       Inputs="..\..\external\mxe\Makefile"
       Outputs="$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-gcc">
     <Exec

--- a/build-tools/mono-runtimes/mono-runtimes.projitems
+++ b/build-tools/mono-runtimes/mono-runtimes.projitems
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <_MonoRuntime Include="armeabi" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',armeabi,'))">
+    <_MonoRuntime Include="armeabi" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':armeabi:'))">
       <Ar>$(_ArmAr)</Ar>
       <As>$(_ArmAs)</As>
       <Cc>$(_ArmCc)</Cc>
@@ -21,7 +21,7 @@
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
-    <_MonoRuntime Include="armeabi-v7a" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',armeabi-v7a,'))">
+    <_MonoRuntime Include="armeabi-v7a" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':armeabi-v7a:'))">
       <Ar>$(_ArmAr)</Ar>
       <As>$(_ArmAs)</As>
       <Cc>$(_ArmCc)</Cc>
@@ -41,7 +41,7 @@
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
-    <_MonoRuntime Include="arm64-v8a" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',arm64-v8a,'))">
+    <_MonoRuntime Include="arm64-v8a" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':arm64-v8a:'))">
       <Ar>$(_Arm64Ar)</Ar>
       <As>$(_Arm64As)</As>
       <Cc>$(_Arm64Cc)</Cc>
@@ -61,7 +61,7 @@
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
-    <_MonoRuntime Include="x86" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',x86,'))">
+    <_MonoRuntime Include="x86" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':x86:'))">
       <Ar>$(_X86Ar)</Ar>
       <As>$(_X86As)</As>
       <Cc>$(_X86Cc)</Cc>
@@ -81,7 +81,7 @@
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
-    <_MonoRuntime Include="x86_64" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',x86_64,'))">
+    <_MonoRuntime Include="x86_64" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':x86_64:'))">
       <Ar>$(_X86_64Ar)</Ar>
       <As>$(_X86_64As)</As>
       <Cc>$(_X86_64Cc)</Cc>
@@ -101,7 +101,7 @@
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
-    <_MonoRuntime Include="host-Win64" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-win64,'))">
+    <_MonoRuntime Include="host-Win64" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))">
       <Ar>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-ar</Ar>
       <As>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-as</As>
       <Cc>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-gcc</Cc>
@@ -122,7 +122,7 @@
       <OutputProfilerFilename></OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
-    <_MonoRuntime Include="host-Darwin" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-Darwin,'))">
+    <_MonoRuntime Include="host-Darwin" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-Darwin:'))">
       <Ar>ar</Ar>
       <As>as</As>
       <Cc>$(HostCc)</Cc>
@@ -140,7 +140,7 @@
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
-    <_MonoRuntime Include="host-Linux" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',host-Linux,'))">
+    <_MonoRuntime Include="host-Linux" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-Linux:'))">
       <Ar>ar</Ar>
       <As>as</As>
       <Cc>$(HostCc)</Cc>

--- a/src/Mono.Posix/Mono.Posix.csproj
+++ b/src/Mono.Posix/Mono.Posix.csproj
@@ -243,19 +243,19 @@
     <XANativeLibsDir>$(OutputPath)\..\..\..\xbuild\Xamarin\Android\lib</XANativeLibsDir>
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\arm64-v8a\libMonoPosixHelper.so" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',arm64-v8a,'))">
+    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\arm64-v8a\libMonoPosixHelper.so" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':arm64-v8a:'))">
       <Link>MonoPosixHelper\arm64-v8a\libMonoPosixHelper.so</Link>
     </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\armeabi\libMonoPosixHelper.so" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',armeabi,'))">
+    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\armeabi\libMonoPosixHelper.so" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':armeabi:'))">
       <Link>MonoPosixHelper\armeabi\libMonoPosixHelper.so</Link>
     </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\armeabi-v7a\libMonoPosixHelper.so" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',armeabi-v7a,'))">
+    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\armeabi-v7a\libMonoPosixHelper.so" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':armeabi-v7a:'))">
       <Link>MonoPosixHelper\armeabi-v7a\libMonoPosixHelper.so</Link>
     </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\x86\libMonoPosixHelper.so" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',x86,'))">
+    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\x86\libMonoPosixHelper.so" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (:x86:'))">
       <Link>MonoPosixHelper\x86\libMonoPosixHelper.so</Link>
     </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\x86_64\libMonoPosixHelper.so" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (',x86_64,'))">
+    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\x86_64\libMonoPosixHelper.so" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':x86_64:'))">
       <Link>MonoPosixHelper\x86_64\libMonoPosixHelper.so</Link>
     </EmbeddedNativeLibrary>
   </ItemGroup>

--- a/src/monodroid/monodroid.projitems
+++ b/src/monodroid/monodroid.projitems
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_SupportedAbis>$(AndroidSupportedAbis.Replace(',', ';')</_SupportedAbis>
+    <_SupportedAbis>$(AndroidSupportedAbis.Replace(':', ';'))</_SupportedAbis>
   </PropertyGroup>
   <ItemGroup>
     <_MonoRuntime Include="$(_SupportedAbis)" />

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -13,7 +13,7 @@
       Outputs="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).so')">
     <Which Program="%(_RequiredProgram.Identity)" Required="True" />
     <PropertyGroup>
-      <_AppAbi>$(AndroidSupportedAbis.Replace(',', ' ')</_AppAbi>
+      <_AppAbi>$(AndroidSupportedAbis.Replace(':', ' '))</_AppAbi>
     </PropertyGroup>
     <WriteLinesToFile
         File="jni\Application.mk"


### PR DESCRIPTION
Update `$(AndroidSupportedAbis)` and
`$(AndroidSupportedAbisForConditionalChecks)` to use `:` as the ABI
separator, not `,`.

`;` can't be used because xbuild and MSBuild don't like `;` as a
property value on the command-line.

Turns out, MSBuild doesn't like `,` within property values on the
command-line either, because it allows multiple MSBuild properties to
be specified via one `/p:` use:

	$ msbuild -help
	...
	  /property:<n>=<v>  Set or override these project-level properties. <n> is
	                     the property name, and <v> is the property value. Use a
	                     semicolon or a comma to separate multiple properties, or
	                     specify each property separately. (Short form: /p)
	                     Example:
	                       /property:WarningLevel=2;OutDir=bin\Debug\

This means that it's not possible to set `$(AndroidSupportedAbis)` to
e.g. `host-Darwin,armeabi-v8a` on the command-line *with MSBuild*.
(It is with xbuild, but this is arguably an xbuild compatibility bug!)

Since we want to be able to easily override the
`$(AndroidSupportedAbis)` value on the command-line for testing,
change the ABI separator character to `:` which is supported on both
xbuild and MSBuild:

	$ xbuild /p:AndroidSupportedAbis=host-Darwin:armeabi-v7a
	# works!