### PR TITLE
[monodroid] Fix builds when `$(AndroidSupportedAbis)` contains host

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -26,6 +26,11 @@
   <PropertyGroup>
     <AndroidMxeFullPath>$([System.IO.Path]::GetFullPath ('$(AndroidMxeInstallPrefix)'))</AndroidMxeFullPath>
   </PropertyGroup>
+  <ItemGroup>
+    <HostOSName Include="host-Darwin" />
+    <HostOSName Include="host-Linux" />
+    <HostOSName Include="host-win64" />
+  </ItemGroup>
   <!--
     "Fixup" $(AndroidSupportedAbis) so that Condition attributes elsewhere
     can use `:ABI-NAME:`, to avoid substring mismatches.

--- a/src/monodroid/monodroid.projitems
+++ b/src/monodroid/monodroid.projitems
@@ -4,7 +4,7 @@
     <_SupportedAbis>$(AndroidSupportedAbis.Replace(':', ';'))</_SupportedAbis>
   </PropertyGroup>
   <ItemGroup>
-    <_MonoRuntime Include="$(_SupportedAbis)" />
+    <_MonoRuntime Include="$(_SupportedAbis)" Exclude="@(HostOSName)" />
   </ItemGroup>
   <ItemGroup>
     <_RequiredProgram Include="xxd" />

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -13,7 +13,7 @@
       Outputs="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).so')">
     <Which Program="%(_RequiredProgram.Identity)" Required="True" />
     <PropertyGroup>
-      <_AppAbi>$(AndroidSupportedAbis.Replace(':', ' '))</_AppAbi>
+      <_AppAbi>@(_MonoRuntime->'%(Identity)', ' ')</_AppAbi>
     </PropertyGroup>
     <WriteLinesToFile
         File="jni\Application.mk"


### PR DESCRIPTION
Commit 0c073f67 broke the src/monodroid build:

	src/monodroid/monodroid.targets: error : Cannot copy
	.../xamarin-android/src/monodroid/obj/local/host-Darwin/libmonodroid.so to
	.../xamarin-android/bin/Debug/lib/xbuild/Xamarin/Android/lib/host-Darwin/libmono-android.debug.d.so,
	as the source file doesn't exist.

This is because with 0c073f67, `$(AndroidSupportedAbis)` now contains
e.g. host-Darwin, which isn't a valid ABI name as far as `ndk-build`
is concerned.

Fix the src/monodroid build by excluding non-Android values.