### PR TITLE
Fix part of Mono.Posix build issue regarding MonoDroidSDK discovery.

### DIFF
--- a/src/Mono.Posix/Mono.Posix.csproj
+++ b/src/Mono.Posix/Mono.Posix.csproj
@@ -11,9 +11,8 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <AssemblyName>Mono.Posix</AssemblyName>
-    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -113,6 +113,8 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  TargetFrameworkVersion: {0}", TargetFrameworkVersion);
 			Log.LogDebugMessage ("  UseLatestAndroidPlatformSdk: {0}", UseLatestAndroidPlatformSdk);
 			Log.LogDebugMessage ("  SequencePointsMode: {0}", SequencePointsMode);
+			Log.LogDebugMessage ("  MonoAndroidToolsPath: {0}", MonoAndroidToolsPath);
+			Log.LogDebugMessage ("  MonoAndroidBinPath: {0}", MonoAndroidBinPath);
 
 			MonoAndroidHelper.InitializeAndroidLogger (Log);
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -58,7 +58,7 @@ namespace Xamarin.Android.Tasks
 		public static void RefreshMonoDroidSdk (string toolsPath, string binPath, string[] referenceAssemblyPaths)
 		{
 			MonoDroidSdk.Refresh (toolsPath, binPath,
-					(from   refPath in referenceAssemblyPaths
+					(from   refPath in referenceAssemblyPaths ?? new string [0]
 					 where  !string.IsNullOrEmpty (refPath)
 					 let    path = refPath.TrimEnd (Path.DirectorySeparatorChar)
 					 where  File.Exists (Path.Combine (path, "mscorlib.dll"))

--- a/src/Xamarin.Android.Build.Utilities/Sdks/MonoDroidSdkBase.cs
+++ b/src/Xamarin.Android.Build.Utilities/Sdks/MonoDroidSdkBase.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Android.Build.Utilities
 	abstract class MonoDroidSdkBase
 	{
 		protected readonly static string DebugRuntime = "Mono.Android.DebugRuntime-debug.apk";
-		protected readonly static string GeneratorExe = "generator.exe";
+		protected readonly static string ClassParseExe = "class-parse.exe";
 		protected readonly static string GeneratorScript = "generator";
 
 		// I can never remember the difference between SdkPath and anything else...
@@ -107,7 +107,7 @@ namespace Xamarin.Android.Build.Utilities
 		{
 			return !string.IsNullOrWhiteSpace (loc) &&
 				(File.Exists (Path.Combine (loc, DebugRuntime)) ||    // Normal/expected
-				 File.Exists (Path.Combine (loc, GeneratorExe)) ||    // Normal/expected
+				 File.Exists (Path.Combine (loc, ClassParseExe)) ||    // Normal/expected
 					File.Exists (Path.Combine (loc, "Ionic.Zip.dll")));  // Wrench builds
 		}
 

--- a/src/Xamarin.Android.Build.Utilities/Sdks/MonoDroidSdkUnix.cs
+++ b/src/Xamarin.Android.Build.Utilities/Sdks/MonoDroidSdkUnix.cs
@@ -34,7 +34,11 @@ namespace Xamarin.Android.Build.Utilities
 
 			// check also in the users folder
 			var personal = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
-			var additionalSearchPaths = new [] { Path.Combine (personal, @".xamarin.android/lib/mandroid") };
+			var additionalSearchPaths = new [] {
+				// for Mono.Posix and Mono.Data.Sqlite builds in xamarin-android.
+				monoAndroidPath = Path.GetFullPath (Path.Combine (new Uri (GetType ().Assembly.CodeBase).LocalPath, "..", "..", "..", "..", "..", "lib", "mandroid")),
+				Path.Combine (personal, @".xamarin.android/lib/mandroid")
+			};
 
 			return additionalSearchPaths.Concat (SearchPaths).FirstOrDefault (ValidateRuntime);
 		}


### PR DESCRIPTION
We can build xamarin-android on Linux only because we somehow had a
working monodroid setup with MONO_ANDROID_PATH. Hence, fresh build hits:

	bin/Debug/lib/xbuild/Xamarin/Android/Xamarin.Android.Common.targets:
	 error : Error executing task ResolveSdks: Value cannot be null.

Now that Mono.Posix and some other libs depends on existing SDK,
MonoDroidSdkUnix needs to also deal with bootstrap build.

So far, the SDK sanity check uses generator.exe which does not exist when
we are building Mono.Posix, so use class-parse.exe which exists instead.

Also we only build 6.0 and UseLatestSDK somehow tries to find 6.0.99 and
fails, so use 6.0 instead.