### PR TITLE
Fix Java.Interop reference in Mono.Posix.csproj

### DIFF
--- a/src/Mono.Posix/Mono.Posix.csproj
+++ b/src/Mono.Posix/Mono.Posix.csproj
@@ -238,6 +238,14 @@
       <Name>Mono.Android</Name>
       <Private>False</Private>
     </ProjectReference>
+    <Reference Include="Java.Interop">
+      <HintPath>$(OutputPath)..\v1.0\Java.Interop.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Runtime">
+      <HintPath>$(OutputPath)..\v1.0\Facades\System.Runtime.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <PropertyGroup>
     <XANativeLibsDir>$(OutputPath)\..\..\..\xbuild\Xamarin\Android\lib</XANativeLibsDir>


### PR DESCRIPTION
Mono.Posix build failed because it recursively requires Java.Interop
reference (due to missing IJavaPeerable in the references).

Adding Java.Interop and System.Runtime fixes the issue (and this is
how Mono.Android builds, instead of adding <ProjectReference> ...).