### PR TITLE
[Xamarin.Android.Build.Tasks] Fix the creation of Library Resource Archive

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
@@ -90,10 +90,11 @@ namespace Xamarin.Android.Tasks
 			}
 
 			// Archive them in a zip.
-			using (var stream = new MemoryStream ())
-			using (var zip = new ZipArchive (stream, ZipArchiveMode.Create, true, new System.Text.UTF8Encoding (false))) {
-				zip.AddDirectory (OutputDirectory, outDirInfo.Name);
-
+			using (var stream = new MemoryStream ()) {
+				using (var zip = new ZipArchive (stream, ZipArchiveMode.Create, true, new System.Text.UTF8Encoding (false))) {
+					zip.AddDirectory (OutputDirectory, outDirInfo.Name);
+				}
+				stream.Position = 0;
 				string outpath = Path.Combine (outDirInfo.Parent.FullName, "__AndroidLibraryProjects__.zip");
 				if (Files.ArchiveZip (outpath, f => {
 					using (var fs = new FileStream (f, FileMode.CreateNew)) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateManagedLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateManagedLibraryResourceArchive.cs
@@ -105,10 +105,11 @@ namespace Xamarin.Android.Tasks
 			}
 
 			// Archive them in a zip.
-			using (var stream = new MemoryStream ())
-			using (var zip = new ZipArchive (stream, ZipArchiveMode.Create, true, new System.Text.UTF8Encoding (false))) {
-				zip.AddDirectory (OutputDirectory, outDirInfo.Name);
-
+			using (var stream = new MemoryStream ()) {
+				using (var zip = new ZipArchive (stream, ZipArchiveMode.Create, true, new System.Text.UTF8Encoding (false))) {
+					zip.AddDirectory (OutputDirectory, outDirInfo.Name);
+				}
+				stream.Position = 0;
 				string outpath = Path.Combine (outDirInfo.Parent.FullName, "__AndroidLibraryProjects__.zip");
 				if (Files.ArchiveZip (outpath, f => {
 					using (var fs = new FileStream (f, FileMode.CreateNew)) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveExtensions.cs
@@ -99,8 +99,8 @@ namespace Xamarin.Android.Tasks
 				archive.AddFile (fileName, root);
 			}
 			foreach (var dir in Directory.GetDirectories (folder)) {
-				var internalDir = Path.Combine (folderInArchive, dir.Replace ("./", string.Empty));
-				archive.AddDirectory (dir, internalDir);
+				var internalDir = dir.Replace ("./", string.Empty).Replace (folder, string.Empty);
+				archive.AddDirectory (dir, folderInArchive + internalDir);
 			}
 		}
 


### PR DESCRIPTION
The commit 4ec06ac9 broke the way resource archives are creating. Firstly
it was writting an empty zip file because we were not closing the zip after
adding the files BEFORE writing the stream to disk. So it had not been
flushed.

Secondaly the directory structure within the zip itself was incorrect. It
was adding files using the full path rather than the internal path that
we needed in the zip.

This commit fixes all of that.