### PR TITLE
[Xamarin.Android.Build.Tasks] Fix Native Library Archive

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateNativeLibraryArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateNativeLibraryArchive.cs
@@ -63,9 +63,11 @@ namespace Xamarin.Android.Tasks
 			}
 
 			// Archive native libraries in a zip.
-			using (var stream = new MemoryStream ())
-			using (var zip = new ZipArchive (stream, ZipArchiveMode.Create, true, new System.Text.UTF8Encoding (false))) {
-				zip.AddDirectory (OutputDirectory, outDirInfo.Name);
+			using (var stream = new MemoryStream ()) {
+				using (var zip = new ZipArchive (stream, ZipArchiveMode.Create, true, new System.Text.UTF8Encoding (false))) {
+					zip.AddDirectory (OutputDirectory, outDirInfo.Name);
+				}
+				stream.Position = 0;
 				string outpath = Path.Combine (outDirInfo.Parent.FullName, "__AndroidNativeLibraries__.zip");
 				if (Files.ArchiveZip (outpath, f => {
 					using (var fs = new FileStream (f, FileMode.CreateNew)) {


### PR DESCRIPTION
The commit 4ec06ac broke the Narive Library Archive
creation because the zip was not closed before we
write the stream to the file.

This commit fixes that issue.