### PR TITLE
[Xamarin.Android.Build.Tasks] Update Property Cache to include $(AndroidCreatePackagePerAbi)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -193,6 +193,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  EmbedAssemblies: {0}", EmbedAssemblies);
 			Log.LogDebugMessage ("  AndroidAotMode: {0}", AndroidAotMode);
 			Log.LogDebugMessage ("  AndroidSequencePointsMode: {0}", AndroidSequencePointsMode);
+			Log.LogDebugMessage ("  CreatePackagePerAbi: {0}", CreatePackagePerAbi);
 			Log.LogDebugTaskItems ("  Environments:", Environments);
 			Log.LogDebugTaskItems ("  ResolvedUserAssemblies:", ResolvedUserAssemblies);
 			Log.LogDebugTaskItems ("  ResolvedFrameworkAssemblies:", ResolvedFrameworkAssemblies);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -961,6 +961,7 @@ because xbuild doesn't support framework reference assemblies.
 	<_PropertyCacheItems Include="AndroidManagedSymbols=$(AndroidManagedSymbols)" />
 	<_PropertyCacheItems Include="AndroidUseLatestPlatformSdk=$(AndroidUseLatestPlatformSdk)" />
 	<_PropertyCacheItems Include="TargetFrameworkVersion=$(TargetFrameworkVersion)" />
+	<_PropertyCacheItems Include="AndroidCreatePackagePerAbi=$(AndroidCreatePackagePerAbi)" />
 </ItemGroup>
 
 <Target Name="_ReadPropertiesCache">


### PR DESCRIPTION
There was an issue where if we change the value of $(AndroidCreatePackagePerAbi)
the task _CreateBaseApk was NOT being run if we had a previous
build. In addition were were not logging the value of that property
in the BuildApk task.