### PR TITLE
[Xamarin.Android.Build.Tasks] Remove debug code

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -175,9 +175,7 @@ namespace Xamarin.Android.Tasks
 					AddZipEntry (apk, StubApplicationDataFile, string.Empty);
 			}
 			MonoAndroidHelper.CopyIfZipChanged (apkOutputPath + "new", apkOutputPath);
-			//File.Delete (apkOutputPath + "new");
-			File.Move (apkOutputPath + "new", apkOutputPath + DateTime.Now.ToShortTimeString ());
-
+			File.Delete (apkOutputPath + "new");
 		}
 
 		public override bool Execute ()


### PR DESCRIPTION
The commit 4ec06ac had some debug code in it that should not have
been included in the final patch. This commit removes it.