### PR TITLE
[Xamarin.Android.Build.Tasks] Fix issues with Library Resource Extraction

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -232,7 +232,8 @@ namespace Xamarin.Android.Tasks
 
 							// temporarily extracted directory will look like:
 							//    __library_projects__/[dllname]/[library_project_imports | jlibs]/bin
-							ZipFile.ExtractToDirectory (finfo.FullName, outDirForDll);
+							using (var zip = MonoAndroidHelper.ReadZipFile (finfo.FullName))
+								Files.ExtractAll (zip, outDirForDll);
 
 							// We used to *copy* the resources to overwrite other resources,
 							// which resulted in missing resource issue.

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -198,9 +198,9 @@ namespace Xamarin.Android.Tools {
 			int i = 0;
 			int total = zip.Entries.Count;
 			foreach (var entry in zip.Entries) {
-
-				if (string.Equals(entry.FullName, "__MACOSX", StringComparison.OrdinalIgnoreCase) ||
-						string.Equals(entry.FullName, ".DS_Store", StringComparison.OrdinalIgnoreCase))
+				if (entry.FullName.Contains ("/__MACOSX/") ||
+						entry.FullName.EndsWith ("/__MACOSX", StringComparison.OrdinalIgnoreCase) ||
+						entry.FullName.EndsWith ("/.DS_Store", StringComparison.OrdinalIgnoreCase))
 					continue;
 				if (entry.IsDirectory ()) {
 					Directory.CreateDirectory (Path.Combine (destination, entry.FullName));
@@ -208,6 +208,7 @@ namespace Xamarin.Android.Tools {
 				}
 				if (progressCallback != null)
 					progressCallback (i++, total);
+				Directory.CreateDirectory (Path.Combine (destination, Path.GetDirectoryName (entry.FullName)));
 				entry.ExtractToFile (Path.Combine (destination, entry.FullName), overwrite: true);
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveExtensions.cs
@@ -74,7 +74,7 @@ namespace Xamarin.Android.Tasks
 
 		public static bool ContainsEntry (this ZipArchive archive, string entryName)
 		{
-			return archive.Entries.Any (x => string.Compare (x.Name, entryName, StringComparison.OrdinalIgnoreCase) == 0);
+			return archive.Entries.Any (x => string.Compare (x.FullName, entryName, StringComparison.OrdinalIgnoreCase) == 0);
 		}
 
 		public static bool IsDirectory (this ZipArchiveEntry entry)


### PR DESCRIPTION
Since the switch to System.IO.Compression we have a few
issues when dealing with resource extraction.

1) It was not ignoring __MACOSX or .DS_Store during extraction.
2) It was not correctly detecting duplicate zip entries.

This commit updates the code to correctly filter __MACOSX and
.DS_Store entries. It also changes the way we check if an entry
exists in the zip already. And finally it updates
ResolveLibraryProjectImports to use the Files.ExtractAll method.
This is because the standard ZipFile.ExtractToDirectory has no
way of filtering the output (so it includes __MACOSX and .DS_Store).