### PR TITLE
[Mono.Data.Sqlite] Import from monodroid/6a8eb978.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 	path = external/mxe
 	url = https://github.com/xamarin/mxe.git
 	branch = xamarin
+[submodule "external/sqlite"]
+	path = external/sqlite
+	url = https://github.com/xamarin/sqlite.git

--- a/Configuration.props
+++ b/Configuration.props
@@ -21,10 +21,16 @@
     <AndroidNdkDirectory>$(AndroidToolchainDirectory)\ndk</AndroidNdkDirectory>
     <AndroidSupportedAbis Condition=" '$(AndroidSupportedAbis)' == '' ">host-$(HostOS):armeabi-v7a</AndroidSupportedAbis>
     <MonoSourceDirectory>$(MSBuildThisFileDirectory)external\mono</MonoSourceDirectory>
+    <SqliteSourceDirectory Condition=" '$(SqliteSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\sqlite</SqliteSourceDirectory>
     <XamarinAndroidSourcePath>$(MSBuildThisFileDirectory)</XamarinAndroidSourcePath>
+    <AllSupported32BitTargetAndroidAbis>armeabi;armeabi-v7a;x86</AllSupported32BitTargetAndroidAbis>
+    <AllSupported64BitTargetAndroidAbis>arm64-v8a;x86_64</AllSupported64BitTargetAndroidAbis>
+    <AllSupportedTargetAndroidAbis>$(AllSupported32BitTargetAndroidAbis);$(AllSupported64BitTargetAndroidAbis)</AllSupportedTargetAndroidAbis>
   </PropertyGroup>
   <PropertyGroup>
     <AndroidMxeFullPath>$([System.IO.Path]::GetFullPath ('$(AndroidMxeInstallPrefix)'))</AndroidMxeFullPath>
+    <MonoSourceFullPath>$([System.IO.Path]::GetFullPath ('$(MonoSourceDirectory)'))</MonoSourceFullPath>
+    <SqliteSourceFullPath>$([System.IO.Path]::GetFullPath ('$(SqliteSourceDirectory)'))</SqliteSourceFullPath>
   </PropertyGroup>
   <ItemGroup>
     <HostOSName Include="host-Darwin" />

--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -73,6 +73,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "class-parse", "external\Jav
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "logcat-parse", "external\Java.Interop\tools\logcat-parse\logcat-parse.csproj", "{7387E151-48E3-4885-B2CA-A74434A34045}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Data.Sqlite", "src\Mono.Data.Sqlite\Mono.Data.Sqlite.csproj", "{26781D3A-FF20-4F55-9824-C8A06AA9E484}"
+EndProject
+Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "sqlite-xamarin", "src\sqlite-xamarin\sqlite-xamarin.mdproj", "{B8F799C5-D7CE-4E09-9CE6-BAA4173E7EC8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|AnyCPU = Debug|AnyCPU
@@ -322,6 +326,30 @@ Global
 		{7387E151-48E3-4885-B2CA-A74434A34045}.XAIntegrationDebug|AnyCPU.Build.0 = Debug|Any CPU
 		{7387E151-48E3-4885-B2CA-A74434A34045}.XAIntegrationRelease|AnyCPU.ActiveCfg = Debug|Any CPU
 		{7387E151-48E3-4885-B2CA-A74434A34045}.XAIntegrationRelease|AnyCPU.Build.0 = Debug|Any CPU
+		{26781D3A-FF20-4F55-9824-C8A06AA9E484}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{26781D3A-FF20-4F55-9824-C8A06AA9E484}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{26781D3A-FF20-4F55-9824-C8A06AA9E484}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{26781D3A-FF20-4F55-9824-C8A06AA9E484}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{26781D3A-FF20-4F55-9824-C8A06AA9E484}.XAIntegrationDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{26781D3A-FF20-4F55-9824-C8A06AA9E484}.XAIntegrationDebug|Any CPU.Build.0 = Debug|Any CPU
+		{26781D3A-FF20-4F55-9824-C8A06AA9E484}.XAIntegrationRelease|Any CPU.ActiveCfg = Debug|Any CPU
+		{26781D3A-FF20-4F55-9824-C8A06AA9E484}.XAIntegrationRelease|Any CPU.Build.0 = Debug|Any CPU
+		{26781D3A-FF20-4F55-9824-C8A06AA9E484}.XAIntegrationDebug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{26781D3A-FF20-4F55-9824-C8A06AA9E484}.XAIntegrationDebug|AnyCPU.Build.0 = Debug|Any CPU
+		{26781D3A-FF20-4F55-9824-C8A06AA9E484}.XAIntegrationRelease|AnyCPU.ActiveCfg = Debug|Any CPU
+		{26781D3A-FF20-4F55-9824-C8A06AA9E484}.XAIntegrationRelease|AnyCPU.Build.0 = Debug|Any CPU
+		{B8F799C5-D7CE-4E09-9CE6-BAA4173E7EC8}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{B8F799C5-D7CE-4E09-9CE6-BAA4173E7EC8}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{B8F799C5-D7CE-4E09-9CE6-BAA4173E7EC8}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{B8F799C5-D7CE-4E09-9CE6-BAA4173E7EC8}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{B8F799C5-D7CE-4E09-9CE6-BAA4173E7EC8}.XAIntegrationDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8F799C5-D7CE-4E09-9CE6-BAA4173E7EC8}.XAIntegrationDebug|Any CPU.Build.0 = Debug|Any CPU
+		{B8F799C5-D7CE-4E09-9CE6-BAA4173E7EC8}.XAIntegrationRelease|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8F799C5-D7CE-4E09-9CE6-BAA4173E7EC8}.XAIntegrationRelease|Any CPU.Build.0 = Debug|Any CPU
+		{B8F799C5-D7CE-4E09-9CE6-BAA4173E7EC8}.XAIntegrationDebug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{B8F799C5-D7CE-4E09-9CE6-BAA4173E7EC8}.XAIntegrationDebug|AnyCPU.Build.0 = Debug|Any CPU
+		{B8F799C5-D7CE-4E09-9CE6-BAA4173E7EC8}.XAIntegrationRelease|AnyCPU.ActiveCfg = Debug|Any CPU
+		{B8F799C5-D7CE-4E09-9CE6-BAA4173E7EC8}.XAIntegrationRelease|AnyCPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
@@ -356,6 +384,8 @@ Global
 		{1A4B041A-842F-40B3-A50D-49E01D30BD18} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{38C762AB-8FD1-44DE-9855-26AAE7129DC3} = {864062D3-A415-4A6F-9324-5820237BA058}
 		{7387E151-48E3-4885-B2CA-A74434A34045} = {864062D3-A415-4A6F-9324-5820237BA058}
+		{26781D3A-FF20-4F55-9824-C8A06AA9E484} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
+		{B8F799C5-D7CE-4E09-9CE6-BAA4173E7EC8} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
+++ b/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{26781D3A-FF20-4F55-9824-C8A06AA9E484}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Mono.Data.Sqlite</RootNamespace>
+    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <AndroidResgenClass>Resource</AndroidResgenClass>
+    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
+    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <AssemblyName>Mono.Data.Sqlite</AssemblyName>
+    <SignAssembly>True</SignAssembly>
+    <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
+  </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
+  <PropertyGroup>
+    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
+    <AssemblyOriginatorKeyFile>$(MonoSourceFullPath)\mcs\class\mono.pub</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks\MonoAndroid\v1.0</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NET_4_0;NET_4_5;MONO;DISABLE_CAS_USE;SQLITE_STANDARD;MONODROID</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidLinkMode>None</AndroidLinkMode>
+    <ConsolePause>false</ConsolePause>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks\MonoAndroid\v1.0</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants>NET_4_0;NET_4_5;MONO;DISABLE_CAS_USE;SQLITE_STANDARD;MONODROID</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Transactions" />
+    <Reference Include="Mono.Android" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Mono.Data.Sqlite.dll.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(XamarinAndroidSourcePath)\src\Mono.Android\Android.Runtime\CPUArchitecture.cs">
+      <Link>Android.Runtime\CPUArchitecture.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Assembly\AssemblyInfo.cs">
+      <Link>Assembly\AssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\MonoPInvokeCallbackAttribute.cs">
+      <Link>Mono.Data.Sqlite_2.0\MonoPInvokeCallbackAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLite3.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLite3.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLite3_UTF16.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLite3_UTF16.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLiteBase.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLiteBase.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLiteCommandBuilder.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLiteCommandBuilder.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLiteCommand.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLiteCommand.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLiteConnection.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLiteConnection.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\LINQ\SQLiteConnection_Linq.cs">
+      <Link>Mono.Data.Sqlite_2.0\LINQ\SQLiteConnection_Linq.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLiteConnectionPool.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLiteConnectionPool.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLiteConnectionStringBuilder.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLiteConnectionStringBuilder.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLiteConvert.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLiteConvert.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLiteDataAdapter.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLiteDataAdapter.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLiteDataReader.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLiteDataReader.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SqliteDataSourceEnumerator.cs">
+      <Link>Mono.Data.Sqlite_2.0\SqliteDataSourceEnumerator.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLiteEnlistment.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLiteEnlistment.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLiteException.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLiteException.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLiteFactory.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLiteFactory.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\LINQ\SQLiteFactory_Linq.cs">
+      <Link>Mono.Data.Sqlite_2.0\LINQ\SQLiteFactory_Linq.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLiteFunctionAttribute.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLiteFunctionAttribute.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLiteFunction.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLiteFunction.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLiteKeyReader.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLiteKeyReader.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLiteMetaDataCollectionNames.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLiteMetaDataCollectionNames.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLiteParameterCollection.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLiteParameterCollection.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLiteParameter.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLiteParameter.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLiteStatement.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLiteStatement.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLiteTransaction.cs">
+      <Link>Mono.Data.Sqlite_2.0\SQLiteTransaction.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SR.Designer.cs">
+      <Link>Mono.Data.Sqlite_2.0\SR.Designer.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\UnsafeNativeMethods.cs">
+      <Link>Mono.Data.Sqlite_2.0\UnsafeNativeMethods.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\build\common\Locale.cs">
+      <Link>Locale.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceDirectory)\mcs\build\common\Consts.cs">
+      <Link>Consts.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$(OutputPath)\..\..\..\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+  <ItemGroup>
+    <_SupportedAbi Include="$(AllSupportedTargetAndroidAbis)" />
+    <EmbeddedNativeLibrary Include="@(_SupportedAbi-&gt;'..\sqlite-xamarin\src\main\libs\%(Identity)\libsqlite3_xamarin.so')" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\sqlite-xamarin/sqlite-xamarin.mdproj">
+      <Project>{B8F799C5-D7CE-4E09-9CE6-BAA4173E7EC8}</Project>
+      <Name>sqlite-xamarin</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/src/Mono.Data.Sqlite/Mono.Data.Sqlite.dll.config
+++ b/src/Mono.Data.Sqlite/Mono.Data.Sqlite.dll.config
@@ -1,0 +1,3 @@
+<configuration>
+  <dllmap dll="sqlite3" target="libsqlite3_xamarin.so" />
+</configuration>

--- a/src/sqlite-xamarin/.gitignore
+++ b/src/sqlite-xamarin/.gitignore
@@ -1,0 +1,7 @@
+.stamp
+build.gradle
+gradle/
+gradlew
+gradlew.bat
+src/
+

--- a/src/sqlite-xamarin/sqlite-xamarin.mdproj
+++ b/src/sqlite-xamarin/sqlite-xamarin.mdproj
@@ -1,0 +1,30 @@
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ItemType>GenericProject</ItemType>
+    <ProjectGuid>{B8F799C5-D7CE-4E09-9CE6-BAA4173E7EC8}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <OutputPath>..\..\bin\Debug\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <OutputPath>..\..\bin\Release\</OutputPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
+  <PropertyGroup>
+    <BuildDependsOn>
+      _CreateProject;
+      _NdkBuild;
+    </BuildDependsOn>
+  </PropertyGroup>
+  <Import Project="sqlite-xamarin.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\build-tools\android-toolchain\android-toolchain.mdproj">
+      <Project>{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA}</Project>
+      <Name>android-toolchain</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/src/sqlite-xamarin/sqlite-xamarin.targets
+++ b/src/sqlite-xamarin/sqlite-xamarin.targets
@@ -1,0 +1,41 @@
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="_SetReadmeTimeToLastCommitTimestamp">
+    <Exec
+        Command="touch -m -t `git log -1 --format=%25cd --date=format-local:%25Y%25m%25d%25H%25M.%25S` README.version"
+        WorkingDirectory="$(SqliteSourceFullPath)"
+    />
+  </Target>
+  <Target Name="_CreateProject"
+      Inputs="$(SqliteSourceFullPath)\README.version"
+      Outputs="src\stamp">
+    <Exec Condition="!Exists('src')"
+        Command="$(AndroidSdkDirectory)\tools\android create project -g -n sqlitesample -p . -a MainActivity -t android-$(AndroidApiLevel) --package com.xamarin.sqlitesample -v 1.0.0" />
+    <Copy Condition="!Exists('src\stamp')"
+        SourceFiles="src-jni\Application.mk;src-jni\Android.mk"
+        DestinationFiles="src\main\jni\Application.mk;src\main\jni\Android.mk" />
+    <Touch Files="src\stamp" AlwaysCreate="true" />
+  </Target>
+  <ItemGroup>
+    <_SupportedAbi Include="$(AllSupportedTargetAndroidAbis)" />
+    <!-- build outputs are:
+      src/main/libs/x86/libsqlite3_xamarin.so
+      src/main/libs/armeabi-v7a/libsqlite3_xamarin.so
+      src/main/libs/armeabi/libsqlite3_xamarin.so
+      src/main/libs/arm64-v8a/libsqlite3_xamarin.so
+      src/main/libs/x86_64/libsqlite3_xamarin.so
+      -->
+    <_LibSqliteXamarin Include="@(_SupportedAbi->'src\main\libs\%(Identity)\libsqlite3_xamarin.so')" />
+  </ItemGroup>
+  <Target Name="_NdkBuild"
+      Inputs="src\stamp"
+      Outputs="@(_LibSqliteXamarin)">
+    <Exec Command="$(AndroidNdkDirectory)\ndk-build SQLITE_SOURCE_DIR=&quot;$(SqliteSourceFullPath)&quot;"
+        WorkingDirectory="src\main\jni" />
+  </Target>
+  <Target Name="_CleanLibraries"
+      AfterTargets="Clean">
+    <Delete
+        Files="build.gradle;gradlew;gradlew.bat;local.properties" />
+    <RemoveDir Directories="gradle;src" />
+  </Target>
+</Project>

--- a/src/sqlite-xamarin/src-jni/Android.mk
+++ b/src/sqlite-xamarin/src-jni/Android.mk
@@ -1,0 +1,61 @@
+# It is based on sqlite/dist/Android.mk with some changes.
+
+##
+##
+## Build the library
+##
+##
+
+LOCAL_PATH:= $(call my-dir)
+
+# NOTE the following flags,
+#   SQLITE_TEMP_STORE=3 causes all TEMP files to go into RAM. and thats the behavior we want
+#   SQLITE_ENABLE_FTS3   enables usage of FTS3 - NOT FTS1 or 2.
+#   SQLITE_DEFAULT_AUTOVACUUM=1  causes the databases to be subject to auto-vacuum
+minimal_sqlite_flags := \
+	-DNO_ANDROID_FUNCS=1 \
+	-DHAVE_POSIX_FALLOCATE=0 \
+	-DNDEBUG=1 \
+	-DHAVE_USLEEP=1 \
+	-DSQLITE_HAVE_ISNAN \
+	-DSQLITE_DEFAULT_JOURNAL_SIZE_LIMIT=1048576 \
+	-DSQLITE_THREADSAFE=2 \
+	-DSQLITE_TEMP_STORE=3 \
+	-DSQLITE_POWERSAFE_OVERWRITE=1 \
+	-DSQLITE_DEFAULT_FILE_FORMAT=4 \
+	-DSQLITE_DEFAULT_AUTOVACUUM=1 \
+	-DSQLITE_ENABLE_MEMORY_MANAGEMENT=1 \
+	-DSQLITE_ENABLE_FTS3 \
+	-DSQLITE_ENABLE_FTS3_BACKWARDS \
+	-DSQLITE_ENABLE_FTS4 \
+	-DSQLITE_OMIT_BUILTIN_TEST \
+	-DSQLITE_OMIT_COMPILEOPTION_DIAGS \
+	-DSQLITE_OMIT_LOAD_EXTENSION \
+	-DSQLITE_DEFAULT_FILE_PERMISSIONS=0600
+
+device_sqlite_flags := $(minimal_sqlite_flags) \
+    -DHAVE_MALLOC_H=1
+
+common_src_files := $(SQLITE_SOURCE_DIR)/dist/sqlite3.c
+
+# the device library
+include $(CLEAR_VARS)
+
+LOCAL_SRC_FILES := $(common_src_files)
+
+LOCAL_CFLAGS += $(device_sqlite_flags)
+
+LOCAL_SHARED_LIBRARIES := libdl
+
+LOCAL_MODULE:= libsqlite3_xamarin
+
+LOCAL_C_INCLUDES += $(call include-path-for, system-core)/cutils
+
+LOCAL_SHARED_LIBRARIES += liblog
+
+# include android specific methods
+#LOCAL_WHOLE_STATIC_LIBRARIES := libsqlite3_xamarin
+
+include $(BUILD_SHARED_LIBRARY)
+
+

--- a/src/sqlite-xamarin/src-jni/Application.mk
+++ b/src/sqlite-xamarin/src-jni/Application.mk
@@ -1,0 +1,1 @@
+APP_ABI := armeabi armeabi-v7a arm64-v8a x86 x86_64


### PR DESCRIPTION
Import `Mono.Data.Sqlite.dll` from monodroid/6a8eb978.

`Mono.Data.Sqlite.dll` needs to embed a version of SQLite because
Android N will only support allow using native libraries which are
[part of the Android NDK or are distributed with the application][0].
Consequently, the only way that `Mono.Data.Sqlite.dll` can be used is
if SQLite is "somehow" included within all apps which use
`Mono.Data.Sqlite.dll`, and the easiest way to do that is to compile
SQLite, naming the library `libsqlite3_xamarin.so` (for uniqueness),
and making use of the [`@(EmbeddedNativeLibrary)` build action][1].

[0]: https://web.archive.org/web/20160401151536/http://developer.android.com/preview/behavior-changes.html?utm_campaign=android_launch_n_030916&utm_source=anddev&utm_medium=blog#ndk
[1]: https://developer.xamarin.com/guides/android/under_the_hood/build_process/#AndroidNativeLibrary