### PR TITLE
[Xamarin.Android.Build.Tasks] [Cycle 7, VS 2013 only] "'System.ComponentModel.INotifyPropertyChanged' is defined in an assembly that is not referenced. You must add a reference to assembly 'System.ObjectModel" for Android projects that reference PCLs that use `INotifyPropertyChange`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props
@@ -2,5 +2,6 @@
 	<PropertyGroup>
 		<XamarinAndroidVersion>Unknown</XamarinAndroidVersion>
 		<_JavaInteropReferences>Java.Interop;System.Runtime</_JavaInteropReferences>
+		<DependsOnSystemRuntime Condition=" '$(DependsOnSystemRuntime)' == '' ">true</DependsOnSystemRuntime>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=41665

Xamarin.Android makes use of Java.Interop which relies on System.Runtime.dll.
However it seems that while VS2015 is great at auto picking up that
fact VS2013 is not. The task RefolveAssemblyReference (according to the docs)
does NOT set $(DependsOnSystemRuntime) when in the VS2013 tool chain.
As a result none of our custom PCL Facades tasks were running.

Adding the reference to System.ObjectModel.dll just hides the problem.
If a different assembly was required you'd end up with and error for that too.

The fix is to manually set $(DependsOnSystemRuntime) in our build targets.
Since we rely on System.Runtime now anyway it should be have any impact other
than to keep VS2013 happy.