### PR TITLE
[Mono.Android] Fix `generator.exe` invocation

### DIFF
--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -49,7 +49,7 @@
       Outputs="$(IntermediateOutputPath)android-$(AndroidApiLevel)\Mono.Android.projitems">
     <MakeDir Directories="$(IntermediateOutputPath)android-$(AndroidApiLevel)" />
     <PropertyGroup>
-      <Generator>..\..\external\Java.Interop\bin\$(Configuration)\generator.exe</Generator>
+      <Generator>$(OutputPath)..\..\..\mandroid\generator.exe</Generator>
       <_ApiLevel>--api-level=$(AndroidApiLevel)</_ApiLevel>
       <_Out>-o "$(IntermediateOutputPath)android-$(AndroidApiLevel)"</_Out>
       <_Codegen>--codegen-target=XAJavaInterop1</_Codegen>


### PR DESCRIPTION
Commits daddcdf3 and 474dc748 broke the `src/Mono.Android` build
because they changed the location of `generator.exe` from
`external/Java.Interop/bin/$(Configuration)/generator.exe` to
`bin/$(Configuration)/lib/mandroid/generator.exe`.

Without `generator.exe`, *there is no* `Mono.Android` build, so it
failed, along with everything that depends on `Mono.Android`.

Correct the path to `generator.exe`.