### PR TITLE
[runtime] Add MonoMethodMessage::InitMessage to linker preserve list

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/PreserveLists/mscorlib.xml
+++ b/src/Xamarin.Android.Build.Tasks/Linker/PreserveLists/mscorlib.xml
@@ -315,7 +315,9 @@
 		<type fullname="System.Runtime.Remoting.Messaging.CallContext">
 			<method name="SetCurrentCallContext" />
 		</type>
-		<type fullname="System.Runtime.Remoting.Messaging.MonoMethodMessage" preserve="fields" />
+		<type fullname="System.Runtime.Remoting.Messaging.MonoMethodMessage" preserve="fields">
+			<method name="InitMessage" />
+		</type>
 		<type fullname="System.Runtime.Remoting.Proxies.RealProxy" preserve="fields">
 			<method name="PrivateInvoke" />
 			<method name="GetAppDomainTarget" />


### PR DESCRIPTION
It's called from the runtime mono_message_init method since
 Mono commit mono/mono@83f37161192b7735ffd04a4235253d790eefff99