### PR TITLE
[build] Allow building with `msbuild`.

### DIFF
--- a/Configuration.Override.props.in
+++ b/Configuration.Override.props.in
@@ -7,7 +7,7 @@
     <AndroidFrameworkVersion>v6.0</AndroidFrameworkVersion>
 
     <!--
-      Colon-separated list of ABIs to build mono for.
+      Colon-separated list of ABIs to build the mono JIT for.
       Supported ABIs include:
       - armeabi
       - armeabi-v7a
@@ -16,7 +16,18 @@
       - x86_64
       Note: Why colon? Because comma `,` and semicolon `;` can't be specified on the command-line.
       -->
-    <AndroidSupportedAbis>armeabi:armeabi-v7a:arm64-v8a:x86:x86_64</AndroidSupportedAbis>
+    <AndroidSupportedTargetJitAbis>armeabi:armeabi-v7a:arm64-v8a:x86:x86_64</AndroidSupportedTargetJitAbis>
+
+    <!--
+      Colon-separated list of ABIs to build a "host" mono JIT for.
+      The host JIT is used for the Xamarin Studio Designer, among other things.
+      Supported ABIs include:
+      - Darwin
+      - Linux
+      - mxe-Win64
+      Note: Why colon? Because comma `,` and semicolon `;` can't be specified on the command-line.
+      -->
+    <AndroidSupportedHostJitAbis>Darwin:mxe-Win64</AndroidSupportedHostJitAbis>
 
     <!-- C and C++ compilers to emit host-native binaries -->
     <HostCc>clang</HostCc>

--- a/Configuration.props
+++ b/Configuration.props
@@ -23,7 +23,8 @@
     <AndroidMxeInstallPrefix Condition=" '$(AndroidMxeInstallPrefix)' == '' ">$(AndroidToolchainDirectory)\mxe</AndroidMxeInstallPrefix>
     <AndroidSdkDirectory>$(AndroidToolchainDirectory)\sdk</AndroidSdkDirectory>
     <AndroidNdkDirectory>$(AndroidToolchainDirectory)\ndk</AndroidNdkDirectory>
-    <AndroidSupportedAbis Condition=" '$(AndroidSupportedAbis)' == '' ">host-$(HostOS):armeabi-v7a</AndroidSupportedAbis>
+    <AndroidSupportedHostJitAbis Condition=" '$(AndroidSupportedHostJitAbis)' == '' ">$(HostOS)</AndroidSupportedHostJitAbis>
+    <AndroidSupportedTargetJitAbis Condition=" '$(AndroidSupportedTargetJitAbis)' == '' ">armeabi-v7a</AndroidSupportedTargetJitAbis>
     <JavaInteropSourceDirectory Condition=" '$(JavaInteropSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\Java.Interop</JavaInteropSourceDirectory>
     <MonoSourceDirectory>$(MSBuildThisFileDirectory)external\mono</MonoSourceDirectory>
     <SqliteSourceDirectory Condition=" '$(SqliteSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\sqlite</SqliteSourceDirectory>
@@ -38,19 +39,30 @@
     <MonoSourceFullPath>$([System.IO.Path]::GetFullPath ('$(MonoSourceDirectory)'))</MonoSourceFullPath>
     <SqliteSourceFullPath>$([System.IO.Path]::GetFullPath ('$(SqliteSourceDirectory)'))</SqliteSourceFullPath>
   </PropertyGroup>
-  <ItemGroup>
-    <HostOSName Include="host-Darwin" />
-    <HostOSName Include="host-Linux" />
-    <HostOSName Include="host-win64" />
-  </ItemGroup>
   <!--
-    "Fixup" $(AndroidSupportedAbis) so that Condition attributes elsewhere
+    "Fixup" $(AndroidSupportedHostJitAbis) so that Condition attributes elsewhere
     can use `:ABI-NAME:`, to avoid substring mismatches.
     -->
   <PropertyGroup>
-    <AndroidSupportedDeviceAbis>$([System.String]::Copy('$(AndroidSupportedAbis)').Replace (':', ';').Replace ('host-$(HostOS)', '').Replace (';;', ';')</AndroidSupportedDeviceAbis>
-    <AndroidSupportedAbisForConditionalChecks>$(AndroidSupportedAbis)</AndroidSupportedAbisForConditionalChecks>
-    <AndroidSupportedAbisForConditionalChecks Condition=" !$(AndroidSupportedAbisForConditionalChecks.EndsWith (':')) "   >$(AndroidSupportedAbisForConditionalChecks):</AndroidSupportedAbisForConditionalChecks>
-    <AndroidSupportedAbisForConditionalChecks Condition=" !$(AndroidSupportedAbisForConditionalChecks.StartsWith (':')) " >:$(AndroidSupportedAbisForConditionalChecks)</AndroidSupportedAbisForConditionalChecks>
+    <AndroidSupportedHostJitAbisForConditionalChecks>$(AndroidSupportedHostJitAbis)</AndroidSupportedHostJitAbisForConditionalChecks>
+    <AndroidSupportedHostJitAbisForConditionalChecks Condition=" !$(AndroidSupportedHostJitAbisForConditionalChecks.EndsWith (':')) "   >$(AndroidSupportedHostJitAbisForConditionalChecks):</AndroidSupportedHostJitAbisForConditionalChecks>
+    <AndroidSupportedHostJitAbisForConditionalChecks Condition=" !$(AndroidSupportedHostJitAbisForConditionalChecks.StartsWith (':')) " >:$(AndroidSupportedHostJitAbisForConditionalChecks)</AndroidSupportedHostJitAbisForConditionalChecks>
+    <AndroidSupportedHostJitAbisSplit>$(AndroidSupportedHostJitAbis.Split(':'))</AndroidSupportedHostJitAbisSplit>
   </PropertyGroup>
+  <ItemGroup>
+    <AndroidSupportedHostJitAbi Include="$(AndroidSupportedHostJitAbisSplit)" />
+  </ItemGroup>
+  <!--
+    "Fixup" $(AndroidSupportedTargetJitAbis) so that Condition attributes elsewhere
+    can use `:ABI-NAME:`, to avoid substring mismatches.
+    -->
+  <PropertyGroup>
+    <AndroidSupportedTargetJitAbisForConditionalChecks>$(AndroidSupportedTargetJitAbis)</AndroidSupportedTargetJitAbisForConditionalChecks>
+    <AndroidSupportedTargetJitAbisForConditionalChecks Condition=" !$(AndroidSupportedTargetJitAbisForConditionalChecks.EndsWith (':')) "   >$(AndroidSupportedTargetJitAbisForConditionalChecks):</AndroidSupportedTargetJitAbisForConditionalChecks>
+    <AndroidSupportedTargetJitAbisForConditionalChecks Condition=" !$(AndroidSupportedTargetJitAbisForConditionalChecks.StartsWith (':')) " >:$(AndroidSupportedTargetJitAbisForConditionalChecks)</AndroidSupportedTargetJitAbisForConditionalChecks>
+    <AndroidSupportedTargetJitAbisSplit>$(AndroidSupportedTargetJitAbis.Split(':'))</AndroidSupportedTargetJitAbisSplit>
+  </PropertyGroup>
+  <ItemGroup>
+    <AndroidSupportedTargetJitAbi Include="$(AndroidSupportedTargetJitAbisSplit)" />
+  </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -32,30 +32,30 @@ Overridable MSBuild properties include:
 * `$(AndroidFrameworkVersion)`: The Xamarin.Android `$(TargetFrameworkVersion)`
     version which corresponds to `$(AndroidApiLevel)`. This is *usually* the
     Android version number with a leading `v`, e.g. `v4.0.3` for API-15.
-* `$(AndroidSupportedAbis)`: The Android ABIs to build for inclusion within
-    apps. This is a `:`-separated list of ABIs to build. Supported values are:
+* `$(AndroidSupportedHostJitAbis)`: The Android ABIs for which to build a
+    host JIT *and* Xamarin.Android base class libraries (`mscorlib.dll`/etc.).
+    The "host JIT" is used e.g. with the Xamarin Studio Designer, to render
+    Xamarin.Android apps on the developer's machine.
+    There can also be support for cross-compiling mono for a different
+    host, e.g. to build Windows `libmonosgen-2.0.dll` from OS X.
+    Supported host values include:
+
+    * `Darwin`
+    * `Linux`
+    * `mxe-Win64`: Cross-compile Windows 64-bit binaries from Unix.
+
+    The default value is `$(HostOS)`, where `$(HostOS)` is based on probing
+    various environment variables and filesystem locations.
+    On OS X, the default would be `Darwin`.
+* `$(AndroidSupportedTargetJitAbis)`: The Android ABIs for which to build the
+    the Mono JIT for inclusion within apps. This is a `:`-separated list of
+    ABIs to build. Supported values are:
 
     * `armeabi`
     * `armeabi-v7a`
     * `arm64-v8a`
     * `x86`
     * `x86_64`
-
-    Addtionally there are a set of "host" values. The "host ABI" is used
-    to build mono for the *currently executing operating system*, in
-    particular to build the base class libraries such as `mscorlib.dll`.
-    There can also be support for cross-compiling mono for a different
-    host, e.g. to build Windows `libmonosgen-2.0.dll` from OS X.
-    Supported host values include:
-
-    * `host-Darwin`
-    * `host-Linux`
-    * `host-win64`: Cross-compile Windows 64-bit binaries from Unix.
-
-    The default value is `host-$(HostOS):armeabi-v7a`, where `$(HostOS)`
-    is based on probing various environment variables and filesystem locations.
-    On OS X, the default would be `host-Darwin:armeabi-v7a`.
-
 * `$(AndroidToolchainCacheDirectory)`: The directory to cache the downloaded
     Android NDK and SDK files. This value defaults to
     `$(HOME)\android-archives`.

--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -81,8 +81,6 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|AnyCPU = Debug|AnyCPU
 		Release|AnyCPU = Release|AnyCPU
-		XAIntegrationDebug|Any CPU = XAIntegrationDebug|Any CPU
-		XAIntegrationRelease|Any CPU = XAIntegrationRelease|Any CPU
 		XAIntegrationDebug|AnyCPU = XAIntegrationDebug|AnyCPU
 		XAIntegrationRelease|AnyCPU = XAIntegrationRelease|AnyCPU
 	EndGlobalSection

--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -44,19 +44,19 @@
     </AndroidSdkItem>
   </ItemGroup>
   <ItemGroup>
-    <_NdkToolchain Include="arm-linux-androideabi-clang" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains(':armeabi:')) Or $(AndroidSupportedAbisForConditionalChecks.Contains(':armeabi-v7a:'))">
+    <_NdkToolchain Include="arm-linux-androideabi-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':armeabi:')) Or $(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':armeabi-v7a:'))">
       <Platform>android-4</Platform>
       <Arch>arm</Arch>
     </_NdkToolchain>
-    <_NdkToolchain Include="aarch64-linux-android-clang" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains(':arm64-v8a:'))">
+    <_NdkToolchain Include="aarch64-linux-android-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':arm64-v8a:'))">
       <Platform>android-21</Platform>
       <Arch>arm64</Arch>
     </_NdkToolchain>
-    <_NdkToolchain Include="x86-clang" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains(':x86:'))">
+    <_NdkToolchain Include="x86-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':x86:'))">
       <Platform>android-9</Platform>
       <Arch>x86</Arch>
     </_NdkToolchain>
-    <_NdkToolchain Include="x86_64-clang" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains(':x86_64:'))">
+    <_NdkToolchain Include="x86_64-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':x86_64:'))">
       <Platform>android-21</Platform>
       <Arch>x86_64</Arch>
     </_NdkToolchain>
@@ -65,37 +65,37 @@
     <_RequiredProgram Include="$(ManagedRuntime)"   Condition=" '$(ManagedRuntime)' != '' " />
     <_RequiredProgram Include="$(HostCc)" />
     <_RequiredProgram Include="$(HostCxx)" />
-    <_RequiredProgram Include="7za"                 Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))">
+    <_RequiredProgram Include="7za"                 Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>p7zip</Homebrew>
     </_RequiredProgram>
     <_RequiredProgram Include="autoconf" />
     <_RequiredProgram Include="automake" />
-    <_RequiredProgram Include="cmake"               Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))" />
-    <_RequiredProgram Include="gdk-pixbuf-csource"  Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))">
+    <_RequiredProgram Include="cmake"               Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
+    <_RequiredProgram Include="gdk-pixbuf-csource"  Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>gdk-pixbuf</Homebrew>
     </_RequiredProgram>
-    <_RequiredProgram Include="gettext"             Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))" />
-    <_RequiredProgram Include="glibtool"            Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))">
+    <_RequiredProgram Include="gettext"             Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
+    <_RequiredProgram Include="glibtool"            Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>libtool</Homebrew>
     </_RequiredProgram>
-    <_RequiredProgram Include="gsed"                Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))">
+    <_RequiredProgram Include="gsed"                Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>gnu-sed</Homebrew>
     </_RequiredProgram>
-    <_RequiredProgram Include="intltoolize"         Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))">
+    <_RequiredProgram Include="intltoolize"         Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>intltool</Homebrew>
     </_RequiredProgram>
     <_RequiredProgram Include="make" />
-    <_RequiredProgram Include="pkg-config"          Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))">
+    <_RequiredProgram Include="pkg-config"          Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>pkg-config</Homebrew>
     </_RequiredProgram>
-    <_RequiredProgram Include="ruby"                Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))" />
-    <_RequiredProgram Include="scons"               Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))">
+    <_RequiredProgram Include="ruby"                Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
+    <_RequiredProgram Include="scons"               Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>scons</Homebrew>
     </_RequiredProgram>
-    <_RequiredProgram Include="wget"                Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))">
+    <_RequiredProgram Include="wget"                Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>wget</Homebrew>
     </_RequiredProgram>
-    <_RequiredProgram Include="xz"                  Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))">
+    <_RequiredProgram Include="xz"                  Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>xz</Homebrew>
     </_RequiredProgram>
   </ItemGroup>

--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -112,7 +112,7 @@
     />
   </Target>
   <Target Name="_SetMxeToolchainMakefileTimeToLastCommitTimestamp"
-      Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:')) Or $(AndroidSupportedAbisForConditionalChecks.Contains (':host-win32:'))">
+      Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:'))">
     <Exec
         Command="touch -m -t `git log -1 --format=%25cd --date=format-local:%25Y%25m%25d%25H%25M.%25S` Makefile"
         WorkingDirectory="..\..\external\mxe"
@@ -120,7 +120,7 @@
   </Target>
   <Target Name="_CreateMxeW32Toolchain"
       DependsOnTargets="_SetMxeToolchainMakefileTimeToLastCommitTimestamp"
-      Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))"
+      Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))"
       Inputs="..\..\external\mxe\Makefile"
       Outputs="$(AndroidMxeFullPath)\bin\i686-w64-mingw32.static-gcc">
     <Exec
@@ -130,7 +130,7 @@
   </Target>
   <Target Name="_CreateMxeW64Toolchain"
       DependsOnTargets="_SetMxeToolchainMakefileTimeToLastCommitTimestamp"
-      Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))"
+      Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))"
       Inputs="..\..\external\mxe\Makefile"
       Outputs="$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-gcc">
     <Exec

--- a/build-tools/mono-runtimes/mono-runtimes.projitems
+++ b/build-tools/mono-runtimes/mono-runtimes.projitems
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <_MonoRuntime Include="armeabi" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':armeabi:'))">
+    <_MonoRuntime Include="armeabi" Condition="$(AndroidSupportedTargetJitAbis.Contains (':armeabi:'))">
       <Ar>$(_ArmAr)</Ar>
       <As>$(_ArmAs)</As>
       <Cc>$(_ArmCc)</Cc>
@@ -21,7 +21,7 @@
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
-    <_MonoRuntime Include="armeabi-v7a" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':armeabi-v7a:'))">
+    <_MonoRuntime Include="armeabi-v7a" Condition="$(AndroidSupportedTargetJitAbis.Contains (':armeabi-v7a:'))">
       <Ar>$(_ArmAr)</Ar>
       <As>$(_ArmAs)</As>
       <Cc>$(_ArmCc)</Cc>
@@ -41,7 +41,7 @@
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
-    <_MonoRuntime Include="arm64-v8a" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':arm64-v8a:'))">
+    <_MonoRuntime Include="arm64-v8a" Condition="$(AndroidSupportedTargetJitAbis.Contains (':arm64-v8a:'))">
       <Ar>$(_Arm64Ar)</Ar>
       <As>$(_Arm64As)</As>
       <Cc>$(_Arm64Cc)</Cc>
@@ -61,7 +61,7 @@
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
-    <_MonoRuntime Include="x86" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':x86:'))">
+    <_MonoRuntime Include="x86" Condition="$(AndroidSupportedTargetJitAbis.Contains (':x86:'))">
       <Ar>$(_X86Ar)</Ar>
       <As>$(_X86As)</As>
       <Cc>$(_X86Cc)</Cc>
@@ -81,7 +81,7 @@
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
-    <_MonoRuntime Include="x86_64" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':x86_64:'))">
+    <_MonoRuntime Include="x86_64" Condition="$(AndroidSupportedTargetJitAbis.Contains (':x86_64:'))">
       <Ar>$(_X86_64Ar)</Ar>
       <As>$(_X86_64As)</As>
       <Cc>$(_X86_64Cc)</Cc>
@@ -101,7 +101,7 @@
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
-    <_MonoRuntime Include="host-Win64" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-win64:'))">
+    <_MonoRuntime Include="host-mxe-Win64" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Ar>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-ar</Ar>
       <As>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-as</As>
       <Cc>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-gcc</Cc>
@@ -122,7 +122,7 @@
       <OutputProfilerFilename></OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
-    <_MonoRuntime Include="host-Darwin" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-Darwin:'))">
+    <_MonoRuntime Include="host-Darwin" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">
       <Ar>ar</Ar>
       <As>as</As>
       <Cc>$(HostCc)</Cc>
@@ -140,7 +140,7 @@
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
-    <_MonoRuntime Include="host-Linux" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':host-Linux:'))">
+    <_MonoRuntime Include="host-Linux" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:'))">
       <Ar>ar</Ar>
       <As>as</As>
       <Cc>$(HostCc)</Cc>

--- a/src/Mono.Android.Export/Mono.Android.Export.csproj
+++ b/src/Mono.Android.Export/Mono.Android.Export.csproj
@@ -36,15 +36,15 @@
       <HintPath>$(OutputPath)..\v1.0\mscorlib.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System.dll">
+    <Reference Include="System">
       <HintPath>$(OutputPath)..\v1.0\System.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System.Core.dll">
+    <Reference Include="System.Core">
       <HintPath>$(OutputPath)..\v1.0\System.Core.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System.Xml.dll">
+    <Reference Include="System.Xml">
       <HintPath>$(OutputPath)..\v1.0\System.Xml.dll</HintPath>
       <Private>False</Private>
     </Reference>

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -39,23 +39,23 @@
       <HintPath>$(OutputPath)..\v1.0\mscorlib.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System.dll">
+    <Reference Include="System">
       <HintPath>$(OutputPath)..\v1.0\System.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System.Core.dll">
+    <Reference Include="System.Core">
       <HintPath>$(OutputPath)..\v1.0\System.Core.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System.Net.Http.dll">
+    <Reference Include="System.Net.Http">
       <HintPath>$(OutputPath)..\v1.0\System.Net.Http.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System.Runtime.Serialization.dll">
+    <Reference Include="System.Runtime.Serialization">
       <HintPath>$(OutputPath)..\v1.0\System.Runtime.Serialization.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System.Xml.dll">
+    <Reference Include="System.Xml">
       <HintPath>$(OutputPath)..\v1.0\System.Xml.dll</HintPath>
       <Private>False</Private>
     </Reference>

--- a/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
+++ b/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
@@ -179,8 +179,7 @@
   </ItemGroup>
   <Import Project="$(OutputPath)\..\..\..\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <ItemGroup>
-    <_SupportedAbi Include="$(AndroidSupportedDeviceAbis)" />
-    <EmbeddedNativeLibrary Include="@(_SupportedAbi-&gt;'..\sqlite-xamarin\src\main\libs\%(Identity)\libsqlite3_xamarin.so')" />
+    <EmbeddedNativeLibrary Include="@(AndroidSupportedTargetJitAbi-&gt;'..\sqlite-xamarin\src\main\libs\%(Identity)\libsqlite3_xamarin.so')" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\sqlite-xamarin\sqlite-xamarin.mdproj">

--- a/src/Mono.Posix/Mono.Posix.csproj
+++ b/src/Mono.Posix/Mono.Posix.csproj
@@ -255,19 +255,19 @@
     <XANativeLibsDir>$(OutputPath)\..\..\..\xbuild\Xamarin\Android\lib</XANativeLibsDir>
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\arm64-v8a\libMonoPosixHelper.so" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':arm64-v8a:'))">
+    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\arm64-v8a\libMonoPosixHelper.so" Condition="$(AndroidSupportedTargetJitAbis.Contains (':arm64-v8a:'))">
       <Link>MonoPosixHelper\arm64-v8a\libMonoPosixHelper.so</Link>
     </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\armeabi\libMonoPosixHelper.so" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':armeabi:'))">
+    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\armeabi\libMonoPosixHelper.so" Condition="$(AndroidSupportedTargetJitAbis.Contains (':armeabi:'))">
       <Link>MonoPosixHelper\armeabi\libMonoPosixHelper.so</Link>
     </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\armeabi-v7a\libMonoPosixHelper.so" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':armeabi-v7a:'))">
+    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\armeabi-v7a\libMonoPosixHelper.so" Condition="$(AndroidSupportedTargetJitAbis.Contains (':armeabi-v7a:'))">
       <Link>MonoPosixHelper\armeabi-v7a\libMonoPosixHelper.so</Link>
     </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\x86\libMonoPosixHelper.so" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':x86:'))">
+    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\x86\libMonoPosixHelper.so" Condition="$(AndroidSupportedTargetJitAbis.Contains (':x86:'))">
       <Link>MonoPosixHelper\x86\libMonoPosixHelper.so</Link>
     </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\x86_64\libMonoPosixHelper.so" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains (':x86_64:'))">
+    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\x86_64\libMonoPosixHelper.so" Condition="$(AndroidSupportedTargetJitAbis.Contains (':x86_64:'))">
       <Link>MonoPosixHelper\x86_64\libMonoPosixHelper.so</Link>
     </EmbeddedNativeLibrary>
   </ItemGroup>

--- a/src/monodroid/monodroid.projitems
+++ b/src/monodroid/monodroid.projitems
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <_SupportedAbis>$(AndroidSupportedAbis.Replace(':', ';'))</_SupportedAbis>
-  </PropertyGroup>
-  <ItemGroup>
-    <_MonoRuntime Include="$(_SupportedAbis)" Exclude="@(HostOSName)" />
-  </ItemGroup>
   <ItemGroup>
     <_RequiredProgram Include="xxd" />
   </ItemGroup>

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.ValueToItems" />
   <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.Which" />
   <Import Project="monodroid.projitems" />
   <PropertyGroup>
@@ -10,10 +11,10 @@
   </ItemGroup>
   <Target Name="_BuildRuntimes"
       Inputs="@(CFiles);jni\Android.mk"
-      Outputs="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).so')">
+      Outputs="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).so')">
     <Which Program="%(_RequiredProgram.Identity)" Required="True" />
     <PropertyGroup>
-      <_AppAbi>@(_MonoRuntime->'%(Identity)', ' ')</_AppAbi>
+      <_AppAbi>@(AndroidSupportedTargetJitAbi->'%(Identity)', ' ')</_AppAbi>
     </PropertyGroup>
     <WriteLinesToFile
         File="jni\Application.mk"
@@ -24,19 +25,19 @@
         Command="$(AndroidToolchainDirectory)\ndk\ndk-build CONFIGURATION=$(Configuration) V=1"
     />
     <Copy
-        SourceFiles="@(_MonoRuntime->'obj\local\%(Identity)\libmonodroid.so')"
-        DestinationFiles="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).d.so')"
+        SourceFiles="@(AndroidSupportedTargetJitAbi->'obj\local\%(Identity)\libmonodroid.so')"
+        DestinationFiles="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).d.so')"
     />
     <Copy
-        SourceFiles="@(_MonoRuntime->'libs\%(Identity)\libmonodroid.so')"
-        DestinationFiles="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).so')"
+        SourceFiles="@(AndroidSupportedTargetJitAbi->'libs\%(Identity)\libmonodroid.so')"
+        DestinationFiles="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).so')"
     />
   </Target>
   <Target Name="_CleanRuntimes"
       AfterTargets="Clean">
     <RemoveDir Directories="obj\local;libs" />
     <Delete Files="jni\config.include;jni\machine.config.include;jni\Application.mk" />
-    <Delete Files="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).so')" />
-    <Delete Files="@(_MonoRuntime->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).d.so')" />
+    <Delete Files="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).so')" />
+    <Delete Files="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).d.so')" />
   </Target>
 </Project>

--- a/src/sqlite-xamarin/sqlite-xamarin.targets
+++ b/src/sqlite-xamarin/sqlite-xamarin.targets
@@ -16,7 +16,6 @@
     <Touch Files="src\stamp" AlwaysCreate="true" />
   </Target>
   <ItemGroup>
-    <_SupportedAbi Include="$(AndroidSupportedDeviceAbis)" />
     <!-- build outputs include (if enabled):
       src/main/libs/x86/libsqlite3_xamarin.so
       src/main/libs/armeabi-v7a/libsqlite3_xamarin.so
@@ -24,10 +23,10 @@
       src/main/libs/arm64-v8a/libsqlite3_xamarin.so
       src/main/libs/x86_64/libsqlite3_xamarin.so
       -->
-    <_LibSqliteXamarin Include="@(_SupportedAbi->'src\main\libs\%(Identity)\libsqlite3_xamarin.so')" />
+    <_LibSqliteXamarin Include="@(AndroidSupportedTargetJitAbi->'src\main\libs\%(Identity)\libsqlite3_xamarin.so')" />
   </ItemGroup>
   <PropertyGroup>
-	<_AppAbi>$([System.String]::Copy('$(AndroidSupportedDeviceAbis)').Replace (';', ' '))</_AppAbi>
+    <_AppAbi>$(AndroidSupportedTargetJitAbis.Replace (':', ' '))</_AppAbi>
   </PropertyGroup>
   <Target Name="_NdkBuild"
       Inputs="src\stamp"


### PR DESCRIPTION
Fix the solution and project files so that `msbuild` may be used to
build the solution instead of requiring `xbuild`.

There were a few issues that `msbuild` didn't like:

1. MSBuild doesn't like the "extra" configuration mappings in
    Xamarin.Android.sln.

2. MSBuild doesn't like the presence of `.dll` within `@(Reference)`
    entries. `<Reference Include="System.dll" />` is Bad™, so
    Don't Do That™.™.

3. Turning `$(AndroidSupportedAbis)` into an item group is...broken.

(1) and (2) are straightforward fixes. (3) requires some explanation.

`src/monodroid` needs to *only* build `libmonodroid.so` for the
non-"host" ABIs within `$(AndroidSupportedAbis)`. It needs this
restriction because non-selected ABIs may not be configured in
`$(AndroidNdkDirectory)`, and thus can't be built.

This *could* be done by following
`build-tools/mono-runtimes/mono-runtimes.projitems` and doing lots of
`Condition`s on `$(AndroidSupportedAbisForConditionalChecks)`:

	<_MonoRuntime Include="armeabi-v7a" Condition="$(AndroidSupportedAbisForConditionalChecks.Contains(':armeabi-v7a:'))" />
	...

However, that's kinda ugly when *all* we need is the ABI name, so
`monodroid.projitems` was "cute":

	<PropertyGroup>
		<_SupportedAbis>$(AndroidSupportedAbis.Replace(':', ';'))</_SupportedAbis>
	</PropertyGroup>
	<ItemGroup>
		<_MonoRuntime Include="$(_SupportedAbis)" Exclude="@(HostOSName)" />
	</ItemGroup>
	<!-- @(_MonoRuntime) is `armeabi-v7a` by default -->

This works...on xbuild, but *not* `msbuild`. Doh!

(`msbuild` is "smart" and doesn't treat the `;` as an item separator,
so if `$(AndroidSupportedAbis)` is `host-Darwin;armeabi-v7a` then
MSBuild treats the `;` as part of the filename -- NOT a filename
separator -- and `@(_MonoRuntime)` contains *one* item with
an `%(Identity)` of `host-Darwin;armeabi-v7a`. On the one hand, this
is kinda awesome and answers the question "how can you have a filename
that contains `;`?", but on the other hand it broke my project!)

The only fix I could think of was to use `.Split(':')`:

	<_MonoRuntime Include="$(AndroidSupportedAbis.Split(':'))" Exclude="@(HostOSName)" />

That provides desired behavior with `msbuild`, but `xbuild` doesn't
support it and appears to either *ignore* it, or treat it literally,
in that `@(_MonoRuntime)` would contain a *single* item with the
literal value `$(AndroidSupportedAbis.Split(':'))` (argh!).

Fortunately, there's a "cute" workaround: using `.Split()` within an
item's `Include` attribute doesn't work, but using `.Split()` within a
property group declaration *does* work:

    <PropertyGroup>
      <_SupportedAbis>$(AndroidSupportedAbis.Split(':'))</_SupportedAbis>
    </PropertyGroup>
    <ItemGroup>
      <_MonoRuntime Include="$(_SupportedAbis)" Exclude="@(HostOSName)" />
    </ItemGroup>
    <!-- @(_MonoRuntime) is `armeabi-v7a` by default -->

This implies that a property value isn't limited to string values, but
(as here) can be string *arrays*, which is interesting.

---

All that aside, while exploring the proper fix for (3) (it took a
remarkably long time to run across it), I decided to reconsider the
property and item arrangement here.

The prior approach was to have a single `$(AndroidSupportedAbis)`
MSBuild property which controlled *both* Android target ABIs and host
ABIs. This worked...but wasn't entirely scalable (separate moving
parts need to be kept in sync). Additionally, we need to add AOT
cross-compiler support, which logically would be controlled by the
same/similar mechanism, so a value of "build everything" would start
to look insane:

    msbuild /p:AndroidSupportedAbis=armeabi:armeabi-v7a:arm64-v8a:x86:x86_64:host-Darwin:host-Win64:cross-Darwin-arm:cross-Darwin-arm64:cross-Darwin-x86:cross-Darwin-x86_64:cross-Win64-arm:cross-Win64-arm64:cross-Win64-x86:cross-Win64-x86_64

And that's assuming I'm not missing anything, or that we don't add
MIPS support in the future, or...

Blech.

Furthermore, Xamarin.Android *already* uses
[`$(AndroidSupportedAbis)` in its build system][0], which means a
top-level override of `$(AndroidSupportedAbis)` would also impact all
projects which build `.apk` files, e.g.
`src/Mono.Android/Test/Mono.Android-Tests.csproj`, which might not be
desirable.

In short, I think we're overloading "Android supported ABIs," and it
should be split up into smaller, easier to rationalize, chunks.

Thus, leave `$(AndroidSupportedAbis)` to Xamarin.Android's tasks, and
replace it with *two* new properties:

* `$(AndroidSupportedHostJitAbis)`: The "host" ABIs to build.
* `$(AndroidSupportedTargetJitAbis)`: The "target" ABIs to build.

AOT support, when added, would use a new
`$(AndroidSupportedHostAotAbis)` property, thus keeping the set of
acceptable values small and more easily rationalizable.

Finally, "split up" these new Abis properties into corresponding Abi
item groups, to allow consistent and reusable "mapping" of ABI names
to filesystem locations, etc. The new `@(AndroidSupportedHostAotAbi)`
and `@(AndroidSupportedTargetJitAbi)` item groups are derived from
their corresponding values. (Note singular from plural in naming.)

[0]: https://developer.xamarin.com/guides/android/under_the_hood/build_process/#AndroidSupportedAbis
