### PR TITLE
Make Mono.Data.Sqlite smaller

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -42,6 +42,7 @@
     can use `:ABI-NAME:`, to avoid substring mismatches.
     -->
   <PropertyGroup>
+    <AndroidSupportedDeviceAbis>$([System.String]::Copy('$(AndroidSupportedAbis)').Replace (':', ';').Replace ('host-$(HostOS)', '').Replace (';;', ';')</AndroidSupportedDeviceAbis>
     <AndroidSupportedAbisForConditionalChecks>$(AndroidSupportedAbis)</AndroidSupportedAbisForConditionalChecks>
     <AndroidSupportedAbisForConditionalChecks Condition=" !$(AndroidSupportedAbisForConditionalChecks.EndsWith (':')) "   >$(AndroidSupportedAbisForConditionalChecks):</AndroidSupportedAbisForConditionalChecks>
     <AndroidSupportedAbisForConditionalChecks Condition=" !$(AndroidSupportedAbisForConditionalChecks.StartsWith (':')) " >:$(AndroidSupportedAbisForConditionalChecks)</AndroidSupportedAbisForConditionalChecks>

--- a/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
+++ b/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
@@ -161,7 +161,7 @@
   </ItemGroup>
   <Import Project="$(OutputPath)\..\..\..\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <ItemGroup>
-    <_SupportedAbi Include="$(AllSupportedTargetAndroidAbis)" />
+    <_SupportedAbi Include="$(AndroidSupportedDeviceAbis)" />
     <EmbeddedNativeLibrary Include="@(_SupportedAbi-&gt;'..\sqlite-xamarin\src\main\libs\%(Identity)\libsqlite3_xamarin.so')" />
   </ItemGroup>
   <ItemGroup>

--- a/src/sqlite-xamarin/sqlite-xamarin.targets
+++ b/src/sqlite-xamarin/sqlite-xamarin.targets
@@ -16,8 +16,8 @@
     <Touch Files="src\stamp" AlwaysCreate="true" />
   </Target>
   <ItemGroup>
-    <_SupportedAbi Include="$(AllSupportedTargetAndroidAbis)" />
-    <!-- build outputs are:
+    <_SupportedAbi Include="$(AndroidSupportedDeviceAbis)" />
+    <!-- build outputs include (if enabled):
       src/main/libs/x86/libsqlite3_xamarin.so
       src/main/libs/armeabi-v7a/libsqlite3_xamarin.so
       src/main/libs/armeabi/libsqlite3_xamarin.so
@@ -26,10 +26,13 @@
       -->
     <_LibSqliteXamarin Include="@(_SupportedAbi->'src\main\libs\%(Identity)\libsqlite3_xamarin.so')" />
   </ItemGroup>
+  <PropertyGroup>
+	<_AppAbi>$([System.String]::Copy('$(AndroidSupportedDeviceAbis)').Replace (';', ' '))</_AppAbi>
+  </PropertyGroup>
   <Target Name="_NdkBuild"
       Inputs="src\stamp"
       Outputs="@(_LibSqliteXamarin)">
-    <Exec Command="$(AndroidNdkDirectory)\ndk-build SQLITE_SOURCE_DIR=&quot;$(SqliteSourceFullPath)&quot;"
+    <Exec Command="$(AndroidNdkDirectory)\ndk-build SQLITE_SOURCE_DIR=&quot;$(SqliteSourceFullPath)&quot; APP_ABI=&quot;$(_AppAbi)&quot;"
         WorkingDirectory="src\main\jni" />
   </Target>
   <Target Name="_CleanLibraries"


### PR DESCRIPTION
Don't include all the shared sqlite3 libraries but only the ones that
correspond to the ABIs this particular build supports.

In order to make it possible a new property is introduced in
Configuration.props - AndroidSupportedDeviceAbis - which contains *just*
the target Android device ABIs without the `host-*` one. The extra
property is necessary because we don't want to include anything `host-*`
in the Android assemblies and, at the same time, we cannot use the
AndroidSupportedAbisForConditionalChecks property since it separates its
components with `:` to make conditionals easier and thus it would require
extra processing wherever we need just the list of the enabled ABIs.