### PR TITLE
[Mono.Posix] Add @(ProjectReference) for Xamarin.Android.Build.Tasks

### DIFF
--- a/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
+++ b/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
@@ -165,9 +165,14 @@
     <EmbeddedNativeLibrary Include="@(_SupportedAbi-&gt;'..\sqlite-xamarin\src\main\libs\%(Identity)\libsqlite3_xamarin.so')" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\sqlite-xamarin/sqlite-xamarin.mdproj">
+    <ProjectReference Include="..\sqlite-xamarin\sqlite-xamarin.mdproj">
       <Project>{B8F799C5-D7CE-4E09-9CE6-BAA4173E7EC8}</Project>
       <Name>sqlite-xamarin</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="..\Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj">
+      <Project>{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}</Project>
+      <Name>Xamarin.Android.Build.Tasks</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>

--- a/src/Mono.Posix/Mono.Posix.csproj
+++ b/src/Mono.Posix/Mono.Posix.csproj
@@ -245,6 +245,11 @@
       <Name>Mono.Android</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj">
+      <Project>{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}</Project>
+      <Name>Xamarin.Android.Build.Tasks</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup>
     <XANativeLibsDir>$(OutputPath)\..\..\..\xbuild\Xamarin\Android\lib</XANativeLibsDir>


### PR DESCRIPTION
[@atsushieno is unable to build from a clean state on Linux][0],
because when `src/Mono.Posix` is built `class-parse.exe` can't be
found:

	error XA0020: Could not find mandroid!

(Yes, the error says `mandroid`, but it's the `$prefix/lib/mandroid`
directory it's complaining about, which contains `class-parse.exe`.)

This doesn't immediately make sense, because
`Xamarin.Android.Build.Tasks.csproj` has a `@(ProjectReference)` on
the `class-parse.csproj` project, and thus `class-parse.exe` *should*
exist...unless `Xamarin.Andorid.Build.Tasks.csproj` hasn't been built!

Indeed, `Mono.Posix.csproj` does *not* contain a `@(ProjectReference)`
on `Xamarin.Android.Build.Tasks.csproj`, and thus there is no
requirement known by MSBuild that `Xamarin.Android.Build.Tasks` be
built before `Mono.Posix`. This could explain why `class-parse.exe`
can't be found.

(Though this itself seems a tad odd, because if
`Xamarin.Android.Build.Tasks.csproj` wasn't built at all, then I'd
expect the `<Import/>` within `Mono.Posix.csproj` for
`$(OutputPath)\..\..\..\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets`
to fail *first*, but that's not the reported error...)

Fix the `Mono.Posix.csproj` and `Mono.Data.Sqlite.csproj` projects so
that they depend upon `Xamarin.Android.Build.Tasks.csproj`, to ensure
that build dependencies are roperly expressed.

[0]: https://gitter.im/xamarin/xamarin-android?at=575e94fa064b9e7266f204c3