### PR TITLE
[build] Set $(TargetFrameworkRootPath)

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    Note: This file *must* be imported *after* `$(Configuration)` is set.
+    -->
   <Import
       Project="$(MSBuildThisFileDirectory)Configuration.Override.props"
       Condition="Exists('$(MSBuildThisFileDirectory)Configuration.Override.props')"
@@ -11,6 +14,7 @@
     <HostCc Condition=" '$(HostCc)' == '' ">cc</HostCc>
     <HostCxx Condition=" '$(HostCxx)' == '' ">c++</HostCxx>
     <ManagedRuntime Condition=" '$(ManagedRuntime)' == '' And '$(OS)' != 'Windows_NT' ">mono</ManagedRuntime>
+    <TargetFrameworkRootPath>$(MSBuildThisFileDirectory)bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
     <HOME Condition=" '$(HOME)' == '' ">$(HOMEDRIVE)$(HOMEPATH)</HOME>
     <AndroidApiLevel Condition=" '$(AndroidApiLevel)' == '' ">23</AndroidApiLevel>
     <AndroidFrameworkVersion Condition=" '$(AndroidFrameworkVersion)' == '' ">v6.0</AndroidFrameworkVersion>

--- a/src/Mono.Android/Test/Mono.Android-Tests.csproj
+++ b/src/Mono.Android/Test/Mono.Android-Tests.csproj
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\Configuration.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -17,7 +16,10 @@
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AssemblyName>Mono.Android-Tests</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <TargetFrameworkVersion>v4.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <Import Project="..\..\..\Configuration.props" />
+  <PropertyGroup>
+    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\..\Configuration.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,6 +9,7 @@
     <AssemblyName>Xamarin.Android.Build.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
+  <Import Project="..\..\..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\..\Configuration.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,6 +9,7 @@
     <AssemblyName>Xamarin.ProjectTools</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
+  <Import Project="..\..\..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -2,7 +2,6 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\external\Java.Interop\src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\..\external\Java.Interop\src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems')" />
   <Import Project="..\..\external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems" Label="Shared" Condition="Exists('..\..\external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems')" />
-  <Import Project="..\..\Configuration.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -14,6 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>

--- a/tools/api-xml-adjuster/api-xml-adjuster.csproj
+++ b/tools/api-xml-adjuster/api-xml-adjuster.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>api-xml-adjuster</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>


### PR DESCRIPTION
@atsushieno and I are trying to figure out why `src/Mono.Posix` builds
for me on OS X but fails for him in a (relatively) clean Linux
environment:

	CSC: error CS0518: The predefined type `System.Object' is not defined or imported

`System.Object` couldn't be found because `System.Runtime.dll` wasn't
being provided to the compiler.

Further investigation shows that the reason it built on OS X was
because OS X had a pre-existing system Xamarin.Android install, which
was being used to resolve framework directories:

	# Works on OS X:
	# Note: Mono.framework/External/xbuild-frameworks/MonoAndroid is a symlink
	#   into Xamarin.Android.framework, i.e. the system Xamarin.Android install
	Task "GetReferenceAssemblyPaths"
		Using task GetReferenceAssemblyPaths from Microsoft.Build.Tasks.GetReferenceAssemblyPaths, Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
		Looking for framework 'MonoAndroid,Version=v1.0' in root path '/Library/Frameworks/Mono.framework/External/xbuild-frameworks'
		Found framework definition list '/Library/Frameworks/Mono.framework/External/xbuild-frameworks/MonoAndroid/v1.0/RedistList/FrameworkList.xml' for framework 'MonoAndroid,Version=v1.0'
	Done executing task "GetReferenceAssemblyPaths"

	# Fails on Linux:
	Target _GetReferenceAssemblyPaths:
		warning : Unable to find framework corresponding to the target framework moniker 'MonoAndroid,Version=v1.0'. Framework assembly references will be resolved from the GAC, which might not be the intended behavior.

Turns Out™, the error can be reproduced on OS X by "removing" the
system Xamarin.Android install:

	$ cd /Library/Frameworks/Mono.framework/External/xbuild-frameworks
	$ sudo mv MonoAndroid _MonoAndroid

	Task "GetReferenceAssemblyPaths"
		Using task GetReferenceAssemblyPaths from Microsoft.Build.Tasks.GetReferenceAssemblyPaths, Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
		Looking for framework 'MonoAndroid,Version=v6.0' in root path '/Library/Frameworks/Mono.framework/External/xbuild-frameworks'
		Unable to find framework definition file '/Library/Frameworks/Mono.framework/External/xbuild-frameworks/MonoAndroid/v6.0/RedistList/FrameworkList.xml' for Target Framework Moniker 'MonoAndroid,Version=v6.0'
		Looking for framework 'MonoAndroid,Version=v6.0' in root path '/Library/Frameworks/Mono.framework/Versions/4.4.0/lib/mono/4.5/../xbuild-frameworks'
		Unable to find framework definition file '/Library/Frameworks/Mono.framework/Versions/4.4.0/lib/mono/4.5/../xbuild-frameworks/MonoAndroid/v6.0/RedistList/FrameworkList.xml' for Target Framework Moniker 'MonoAndroid,Version=v6.0'
		.../Microsoft.Common.targets:  warning : Unable to find framework corresponding to the target framework moniker 'MonoAndroid,Version=v6.0'. Framework assembly references will be resolved from the GAC, which might not be the intended behavior.
	Done executing task "GetReferenceAssemblyPaths"

(Not sure why it's looking for *v6.0*`, but it can't find the
framework at all, so that's consistent with Linux.)

The fix is to set the `$(TargetFrameworkRootPath)` MSBuild property,
which is provided to the [`GetReferenceAssemblyPaths.RootPath`][0]
property, and allows controlling which locations are searched for
frameworks.

Unfortunately, `$(TargetFrameworkRootPath)` needs to be set to
`bin\$(Configuration)\lib\xbuild-frameworks`, which means
`$(Configuration)` needs to be set *before*
`$(TargetFrameworkRootPath)` is set. Furthermore, since we want to set
`$(TargetFrameworkRootPath)` in `Configuration.props`, this means that
we need to audit all locations which import `Configuration.props` to
ensure that `$(Configuration)` is set before the import.

Add `$(TargetFrameworkRootPath)` to `Configuration.props`, and audit
all uses of `Configuration.props` to ensure `$(Configuration) is set.

[0]: https://msdn.microsoft.com/en-us/library/microsoft.build.tasks.getreferenceassemblypaths.rootpath.aspx