### PR TITLE
[build] Add $(JavaInteropSourceDirectory) MSBuild property

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -24,6 +24,7 @@
     <AndroidSdkDirectory>$(AndroidToolchainDirectory)\sdk</AndroidSdkDirectory>
     <AndroidNdkDirectory>$(AndroidToolchainDirectory)\ndk</AndroidNdkDirectory>
     <AndroidSupportedAbis Condition=" '$(AndroidSupportedAbis)' == '' ">host-$(HostOS):armeabi-v7a</AndroidSupportedAbis>
+    <JavaInteropSourceDirectory Condition=" '$(JavaInteropSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\Java.Interop</JavaInteropSourceDirectory>
     <MonoSourceDirectory>$(MSBuildThisFileDirectory)external\mono</MonoSourceDirectory>
     <SqliteSourceDirectory Condition=" '$(SqliteSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\sqlite</SqliteSourceDirectory>
     <XamarinAndroidSourcePath>$(MSBuildThisFileDirectory)</XamarinAndroidSourcePath>
@@ -33,6 +34,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <AndroidMxeFullPath>$([System.IO.Path]::GetFullPath ('$(AndroidMxeInstallPrefix)'))</AndroidMxeFullPath>
+    <JavaInteropFullPath>$([System.IO.Path]::GetFullPath ('$(JavaInteropSourceDirectory)'))</JavaInteropFullPath>
     <MonoSourceFullPath>$([System.IO.Path]::GetFullPath ('$(MonoSourceDirectory)'))</MonoSourceFullPath>
     <SqliteSourceFullPath>$([System.IO.Path]::GetFullPath ('$(SqliteSourceDirectory)'))</SqliteSourceFullPath>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Overridable MSBuild properties include:
     `$(HOME)\android-toolchain`.
 * `$(HostCc)`, `$(HostCxx)`: The C and C++ compilers to use to generate
     host-native binaries.
+* `$(JavaInteropSourceDirectory)`: The Java.Interop source directory to
+    build and reference projects from. By default, this is
+    `external/Java.Interop` directory, maintained by `git submodule update`.
 
 # Build Requirements
 

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -293,8 +293,8 @@
     <Compile Include="Xamarin.Android.Net\AuthModuleDigest.cs" />
     <Compile Include="Xamarin.Android.Net\IAndroidAuthenticationModule.cs" />
   </ItemGroup>
-  <Import Project="..\..\external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems" Label="Shared" Condition="Exists('..\..\external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems')" />
-  <Import Project="..\..\external\Java.Interop\src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\..\external\Java.Interop\src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems')" />
+  <Import Project="$(JavaInteropFullPath)\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems" Label="Shared" Condition="Exists('$(JavaInteropFullPath)\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems')" />
+  <Import Project="$(JavaInteropFullPath)\src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('$(JavaInteropFullPath)\src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems')" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="Mono.Android.targets" />
   <Import Project="$(IntermediateOutputPath)android-$(AndroidApiLevel)\Mono.Android.projitems" Condition="Exists('$(IntermediateOutputPath)android-$(AndroidApiLevel)\Mono.Android.projitems')" />
@@ -309,12 +309,12 @@
       <Name>jnienv-gen</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\..\external\Java.Interop\tools\generator\generator.csproj">
+    <ProjectReference Include="$(JavaInteropFullPath)\tools\generator\generator.csproj">
       <Project>{D14A1B5C-2060-4930-92BE-F7190256C735}</Project>
       <Name>generator</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\..\external\Java.Interop\tools\jcw-gen\jcw-gen.csproj">
+    <ProjectReference Include="$(JavaInteropFullPath)\tools\jcw-gen\jcw-gen.csproj">
       <Project>{52C7D9B6-E8C8-47D0-9471-652D278D7D77}</Project>
       <Name>jcw-gen</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -2,14 +2,14 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="_BuildJavaInterop"
       BeforeTargets="BeforeResolveReferences"
-      Inputs="..\..\external\Java.Interop\src\Java.Interop\Java.Interop.csproj"
+      Inputs="$(JavaInteropFullPath)\src\Java.Interop\Java.Interop.csproj"
       Outputs="$(OutputPath)\..\v1.0\Java.Interop.dll">
     <MSBuild
-        Projects="..\..\external\Java.Interop\src\Java.Interop\Java.Interop.csproj"
+        Projects="$(JavaInteropFullPath)\src\Java.Interop\Java.Interop.csproj"
         Properties="Configuration=XAIntegration$(Configuration)"
     />
     <ItemGroup>
-      <Assembly Include="..\..\external\Java.Interop\bin\XAIntegration$(Configuration)\*.dll*" />
+      <Assembly Include="$(JavaInteropFullPath)\bin\XAIntegration$(Configuration)\*.dll*" />
     </ItemGroup>
     <Copy
         SourceFiles="@(Assembly)"
@@ -89,7 +89,7 @@
     <MakeDir Directories="$(IntermediateOutputPath)android-$(AndroidApiLevel).jcw\bin" />
     <PropertyGroup>
       <OutputPathAbs>$(MSBuildProjectDirectory)\$(OutputPath)</OutputPathAbs>
-      <JcwGen>..\..\external\Java.Interop\bin\$(Configuration)\jcw-gen.exe</JcwGen>
+      <JcwGen>$(JavaInteropFullPath)\bin\$(Configuration)\jcw-gen.exe</JcwGen>
       <_LibDirs>-L "$(OutputPathAbs)" -L "$(OutputPathAbs)..\v1.0\" -L "$(OutputPathAbs)..\v1.0\Facades"</_LibDirs>
       <_Assembly>"$(OutputPathAbs)$(AssemblyName).dll"</_Assembly>
       <_Out>-o "$(MSBuildProjectDirectory)\$(IntermediateOutputPath)android-$(AndroidApiLevel).jcw\src"</_Out>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\external\Java.Interop\src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\..\external\Java.Interop\src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems')" />
-  <Import Project="..\..\external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems" Label="Shared" Condition="Exists('..\..\external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -14,6 +12,8 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
+  <Import Project="$(JavaInteropFullPath)\src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('$(JavaInteropFullPath)\src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems')" />
+  <Import Project="$(JavaInteropFullPath)\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems" Label="Shared" Condition="Exists('$(JavaInteropFullPath)\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems')" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
@@ -478,7 +478,7 @@
     <Compile Include="..\Mono.Android\Android.Runtime\IntDefinitionAttribute.cs">
       <Link>Mono.Android\IntDefinitionAttribute.cs</Link>
     </Compile>
-    <Compile Include="..\..\external\Java.Interop\src\utils\StringRocks.cs">
+    <Compile Include="$(JavaInteropFullPath)\src\utils\StringRocks.cs">
       <Link>Utilities\StringRocks.cs</Link>
     </Compile>
     <Compile Include="..\..\external\mono\mcs\tools\tuner\Mono.Tuner\FilterAttributes.cs">
@@ -605,15 +605,15 @@
       <Project>{D27AD8F7-7710-40BE-B03B-55EFBEC13C44}</Project>
       <Name>Xamarin.Android.Tools.Aidl</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Tools.Diagnostics\Java.Interop.Tools.Diagnostics.csproj">
+    <ProjectReference Include="$(JavaInteropFullPath)\src\Java.Interop.Tools.Diagnostics\Java.Interop.Tools.Diagnostics.csproj">
       <Project>{64CC4E44-CE3A-4319-BF3F-6CF8BD513870}</Project>
       <Name>Java.Interop.Tools.Diagnostics</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil.csproj">
+    <ProjectReference Include="$(JavaInteropFullPath)\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil.csproj">
       <Project>{D48EE8D0-0A0A-4493-AEF5-DAF5F8CF86AD}</Project>
       <Name>Java.Interop.Tools.Cecil</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers.csproj">
+    <ProjectReference Include="$(JavaInteropFullPath)\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers.csproj">
       <Project>{D18FCF91-8876-48A0-A693-2DC1E7D3D80A}</Project>
       <Name>Java.Interop.Tools.JavaCallableWrappers</Name>
     </ProjectReference>
@@ -621,7 +621,7 @@
       <Project>{91713046-C358-4647-B162-ED4E1442F3D8}</Project>
       <Name>Xamarin.Android.Build.Utilities</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\external\Java.Interop\src\Xamarin.Android.Tools.Bytecode\Xamarin.Android.Tools.Bytecode.csproj">
+    <ProjectReference Include="$(JavaInteropFullPath)\src\Xamarin.Android.Tools.Bytecode\Xamarin.Android.Tools.Bytecode.csproj">
       <Project>{B17475BC-45A2-47A3-B8FC-62F3A0959EE0}</Project>
       <Name>Xamarin.Android.Tools.Bytecode</Name>
     </ProjectReference>
@@ -635,7 +635,7 @@
       <Name>Xamarin.Android.Tools.BootstrapTasks</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\..\external\Java.Interop\tools\class-parse\class-parse.csproj">
+    <ProjectReference Include="$(JavaInteropFullPath)\tools\class-parse\class-parse.csproj">
       <Project>{38C762AB-8FD1-44DE-9855-26AAE7129DC3}</Project>
       <Name>class-parse</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>

--- a/tools/api-xml-adjuster/api-xml-adjuster.csproj
+++ b/tools/api-xml-adjuster/api-xml-adjuster.csproj
@@ -38,7 +38,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\external\Java.Interop\src\Xamarin.Android.Tools.ApiXmlAdjuster\Xamarin.Android.Tools.ApiXmlAdjuster.csproj">
+    <ProjectReference Include="$(JavaInteropFullPath)\src\Xamarin.Android.Tools.ApiXmlAdjuster\Xamarin.Android.Tools.ApiXmlAdjuster.csproj">
       <Project>{1268EADF-8344-431C-81F6-FCB7CBC99F49}</Project>
       <Name>Xamarin.Android.Tools.ApiXmlAdjuster</Name>
     </ProjectReference>


### PR DESCRIPTION
Allow the Java.Interop checkout directory to be specified by
overriding the `$(JavaInteropSourceDirectory)` MSBuild property.

Project files should use the `$(JavaInteropFullPath)` MSBuild
property, which is computed as `Path.GetFullPath()` for the
`$(JavaInteropSourceDirectory)` value.

Normally `$(JavaInteropSourceDirectory)` wouldn't need to be
overridden; the current use case is to allow a CI-like environment
which grabs the latest commit of every referenced module to make sure
they all work together. (Note: such a "CI-like environment"
DOES NOT (yet) EXIST. This commit is to help *permit* such a thing.)