### PR TITLE
[mono-runtimes, monodroid] Fix Mono runtime building, dependencies

### DIFF
--- a/build-tools/mono-runtimes/mono-runtimes.projitems
+++ b/build-tools/mono-runtimes/mono-runtimes.projitems
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <_MonoRuntime Include="armeabi" Condition="$(AndroidSupportedTargetJitAbis.Contains (':armeabi:'))">
+    <_MonoRuntime Include="armeabi" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':armeabi:'))">
       <Ar>$(_ArmAr)</Ar>
       <As>$(_ArmAs)</As>
       <Cc>$(_ArmCc)</Cc>
@@ -21,7 +21,7 @@
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
-    <_MonoRuntime Include="armeabi-v7a" Condition="$(AndroidSupportedTargetJitAbis.Contains (':armeabi-v7a:'))">
+    <_MonoRuntime Include="armeabi-v7a" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':armeabi-v7a:'))">
       <Ar>$(_ArmAr)</Ar>
       <As>$(_ArmAs)</As>
       <Cc>$(_ArmCc)</Cc>
@@ -41,7 +41,7 @@
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
-    <_MonoRuntime Include="arm64-v8a" Condition="$(AndroidSupportedTargetJitAbis.Contains (':arm64-v8a:'))">
+    <_MonoRuntime Include="arm64-v8a" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':arm64-v8a:'))">
       <Ar>$(_Arm64Ar)</Ar>
       <As>$(_Arm64As)</As>
       <Cc>$(_Arm64Cc)</Cc>
@@ -61,7 +61,7 @@
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
-    <_MonoRuntime Include="x86" Condition="$(AndroidSupportedTargetJitAbis.Contains (':x86:'))">
+    <_MonoRuntime Include="x86" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':x86:'))">
       <Ar>$(_X86Ar)</Ar>
       <As>$(_X86As)</As>
       <Cc>$(_X86Cc)</Cc>
@@ -81,7 +81,7 @@
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
-    <_MonoRuntime Include="x86_64" Condition="$(AndroidSupportedTargetJitAbis.Contains (':x86_64:'))">
+    <_MonoRuntime Include="x86_64" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':x86_64:'))">
       <Ar>$(_X86_64Ar)</Ar>
       <As>$(_X86_64As)</As>
       <Cc>$(_X86_64Cc)</Cc>

--- a/src/monodroid/monodroid.mdproj
+++ b/src/monodroid/monodroid.mdproj
@@ -27,5 +27,10 @@
       <Name>android-toolchain</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\..\build-tools\mono-runtimes\mono-runtimes.mdproj">
+      <Project>{C03E6CF1-7460-4CDC-A4AB-292BBC0F61F2}</Project>
+      <Name>mono-runtimes</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Commit 6bb1016 "broke" `build-tools/mono-runtimes`, in that it didn't
build any Android target JIT ABIs, because it used the wrong MSBuild
property for the condition checks -- it used
`$(AndroidSupportedTargetJitAbis)`, not
`$(AndroidSupportedTargetJitAbisForConditionalChecks)`. Doh!

Fix that.

Additionally, `src/monodroid` needs to depend upon
`build-tools/mono-runtimes` because it depends upon eglib-config.h,
which is generated as part of the mono build. `src/monodroid` doens't
depend upon the generated `libmonosgen-2.0.so` file, but it *does*
depend upon the build tree.