### PR TITLE
Mono.Android-Tests should depend on NUnitLite.

### DIFF
--- a/src/Mono.Android/Test/Mono.Android-Tests.csproj
+++ b/src/Mono.Android/Test/Mono.Android-Tests.csproj
@@ -111,5 +111,11 @@
       <Private>False</Private>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\..\Xamarin.Android.NUnitLite\Xamarin.Android.NUnitLite.csproj">
+      <Name>Xamarin.Android.NUnitLite</Name>
+      <Project>{4D603AA3-3BFD-43C8-8050-0CD6C2601126}</Project>
+      <Private>False</Private>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The clean build failed because of the missing dependency (referenced
assembly is not found).