### PR TITLE
[msbuild] cleanup intermediate API dump for post-metadata-fixup state.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -515,6 +515,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 
     <Delete Files="$(ApiOutputFile)" />
     <Delete Files="$(ApiOutputFile).adjusted" />
+    <Delete Files="$(ApiOutputFile).fixed" />
     <Delete Files="$(_GeneratorStampFile)" />
 
     <RemoveDirFixed Directories="$(GeneratedOutputPath)" Condition="Exists ('$(GeneratedOutputPath)')" />


### PR DESCRIPTION
Seealso https://github.com/xamarin/java.interop/pull/51