### PR TITLE
AndroidClientHandler handling request content

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidHttpResponseMessage.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidHttpResponseMessage.cs
@@ -9,11 +9,19 @@ namespace Xamarin.Android.Net
 	/// </summary>
 	public class AndroidHttpResponseMessage : HttpResponseMessage
 	{
+		URL javaUrl;
+		HttpURLConnection httpConnection;
+
 		/// <summary>
 		/// Set to the same value as <see cref="AndroidClientHandler.RequestedAuthentication"/>.
 		/// </summary>
 		/// <value>The requested authentication.</value>
 		public IList <AuthenticationData> RequestedAuthentication { get; internal set; }
+
+		public AndroidHttpResponseMessage (URL javaUrl, HttpURLConnection httpConnection) {
+			javaUrl = javaUrl;
+			httpConnection = httpConnection;
+		}
 
 		/// <summary>
 		/// Set to the same value as <see cref="AndroidClientHandler.RequestNeedsAuthorization"/>
@@ -21,6 +29,18 @@ namespace Xamarin.Android.Net
 		/// <value>The request needs authorization.</value>
 		public bool RequestNeedsAuthorization {
 			get { return RequestedAuthentication?.Count > 0; }
+		}
+
+		protected override void Dispose(bool disposing) {
+			base.Dispose(disposing);
+
+			if (javaUrl != null) {
+				javaUrl.Dispose ();
+			}
+
+			if (httpConnection != null) {
+				httpConnection.Dispose ();
+			}
 		}
 	}
 }


### PR DESCRIPTION
These changes are based on the AndroidClientHandler class before the modifications of  https://github.com/xamarin/xamarin-android/pull/44
I think that my changes are simplier, and the commented race condition, doesn't exists.

Other change I've made is to move the connection reference to the response class, this approach is better than holding the last connection in the handler. On the other hand, is pending to implement, dispose the connection if it fails while connecting.
