### PR TITLE
Fix Linux build wrt. libzip(sharp) support.

### DIFF
--- a/build-tools/libzip/libzip.mdproj
+++ b/build-tools/libzip/libzip.mdproj
@@ -13,9 +13,8 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>..\..\bin\$(Configuration)</OutputPath>
   </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <BuildDependsOn>
+    <BuildDependsOn Condition="'$(HostOS)' == 'Windows' OR '$(HostOS)' == 'Darwin'">
       ResolveReferences;
       _Configure;
       _Make
@@ -29,4 +28,5 @@
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
+  <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
 </Project>


### PR DESCRIPTION
So far libzip builds only for Mac and Windows (on Linux we could
just use local package) but the build steps expected existing binary.

We may end up to just build libzip later too.