### PR TITLE
Fixed "Error executing task BuildApk: Sharing violation on path"

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -155,7 +155,7 @@ namespace Xamarin.Android.Tasks
 				jarFilePaths = MonoAndroidHelper.DistinctFilesByContent (jarFilePaths);
 
 				foreach (var jarFile in jarFilePaths) {
-					using (var jar = ZipArchive.Open (File.Open (jarFile, FileMode.Open))) {
+					using (var jar = ZipArchive.Open (File.OpenRead (jarFile))) {
 						foreach (var jarItem in jar.Where (ze => !ze.IsDirectory && !ze.FullName.StartsWith ("META-INF") && !ze.FullName.EndsWith (".class") && !ze.FullName.EndsWith (".java") && !ze.FullName.EndsWith ("MANIFEST.MF"))) {
 							byte [] data;
 							using (var d = new System.IO.MemoryStream ()) {


### PR DESCRIPTION
On a test project the error

	"Error executing task BuildApk: Sharing violation on path"

was raised during the BuildApk task. This was because the .jar file
in question was being opened for writing when it could have been
opened read only.