### PR TITLE
Install N preview 4 which had changed platform directory.

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -34,9 +34,9 @@
       <HostOS>Darwin</HostOS>
       <DestDir>tools</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="platform-N_r01.zip">
+    <AndroidSdkItem Include="platform-24_r01.zip">
       <HostOS></HostOS>
-      <DestDir>platforms\android-N</DestDir>
+      <DestDir>platforms\android-24</DestDir>
     </AndroidSdkItem>
     <AndroidSdkItem Include="android-23_r01.zip">
       <HostOS></HostOS>


### PR DESCRIPTION
If the app tries to find the latest installed platform, it failed
to probe it because the directory has changed to android-24 from
android-N. Installing the latest preview fixes it.