### PR TITLE
Fix an issue where all the assemblies are added with the name assembies.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -127,7 +127,7 @@ namespace Xamarin.Android.Tasks
 				AddNativeLibrariesFromAssemblies (apk, supportedAbis);
 
 				foreach (ITaskItem typemap in TypeMappings) {
-					apk.AddFile (typemap.ItemSpec, compressionMethod: CompressionMethod.Store);
+					apk.AddFile (typemap.ItemSpec, Path.GetFileName(typemap.ItemSpec), compressionMethod: CompressionMethod.Store);
 				}
 
 				foreach (var file in files) {
@@ -249,7 +249,7 @@ namespace Xamarin.Android.Tasks
 
 			foreach (ITaskItem assembly in ResolvedUserAssemblies) {
 				// Add assembly
-				apk.AddFile (assembly.ItemSpec, GetTargetDirectory (assembly.ItemSpec), compressionMethod: CompressionMethod.Store);
+				apk.AddFile (assembly.ItemSpec, GetTargetDirectory (assembly.ItemSpec) + "/"  + Path.GetFileName (assembly.ItemSpec), compressionMethod: CompressionMethod.Store);
 
 				// Try to add config if exists
 				var config = Path.ChangeExtension (assembly.ItemSpec, "dll.config");
@@ -260,7 +260,7 @@ namespace Xamarin.Android.Tasks
 					var symbols = Path.ChangeExtension (assembly.ItemSpec, "dll.mdb");
 
 					if (File.Exists (symbols))
-						apk.AddFile (symbols, "assemblies", compressionMethod: CompressionMethod.Store);
+						apk.AddFile (symbols, "assemblies/" + Path.GetFileName (symbols), compressionMethod: CompressionMethod.Store);
 				}
 			}
 
@@ -269,7 +269,7 @@ namespace Xamarin.Android.Tasks
 
 			// Add framework assemblies
 			foreach (ITaskItem assembly in ResolvedFrameworkAssemblies) {
-				apk.AddFile (assembly.ItemSpec, "assemblies", compressionMethod: CompressionMethod.Store);
+				apk.AddFile (assembly.ItemSpec, "assemblies/" + Path.GetFileName (assembly.ItemSpec), compressionMethod: CompressionMethod.Store);
 				var config = Path.ChangeExtension (assembly.ItemSpec, "dll.config");
 				AddAssemblyConfigEntry (apk, config);
 				// Try to add symbols if Debug
@@ -277,7 +277,7 @@ namespace Xamarin.Android.Tasks
 					var symbols = Path.ChangeExtension (assembly.ItemSpec, "dll.mdb");
 
 					if (File.Exists (symbols))
-						apk.AddFile (symbols, "assemblies", compressionMethod: CompressionMethod.Store);
+						apk.AddFile (symbols, "assemblies/" + Path.GetFileName (symbols), compressionMethod: CompressionMethod.Store);
 				}
 			}
 		}


### PR DESCRIPTION
In the commit f3d62b6  which switches over to using libzip there was
an oversight. The new API needs the filename in the archive
not just the directory (like IonicZip did). As a result the code
was making ALL the assemblies have the same name.

This commit fixes that issue by appending the filename to the
"assemblies" path.