### PR TITLE
[linker] Preserve TransparentProxy::LoadRemoteFieldNew

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/PreserveLists/mscorlib.xml
+++ b/src/Xamarin.Android.Build.Tasks/Linker/PreserveLists/mscorlib.xml
@@ -322,7 +322,9 @@
 			<method name="PrivateInvoke" />
 			<method name="GetAppDomainTarget" />
 		</type>
-		<type fullname="System.Runtime.Remoting.Proxies.TransparentProxy" preserve="fields" />
+		<type fullname="System.Runtime.Remoting.Proxies.TransparentProxy" preserve="fields">
+			<method name="LoadRemoteFieldNew" />
+		</type>
 		<type fullname="System.Runtime.Remoting.RemotingServices">
 			<method name="SerializeCallData" />
 			<method name="DeserializeCallData" />


### PR DESCRIPTION
It's called from the Mono runtime starting with mono/mono@787e34ae2d4fda3ee3b95dfb448d4ac1182d0254