### PR TITLE
[libzip] Add check for `cmake`.

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.mdproj
+++ b/build-tools/android-toolchain/android-toolchain.mdproj
@@ -16,12 +16,12 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <BuildDependsOn>
-			ResolveReferences;
+      ResolveReferences;
       _CopyBootstrapTasksAssembly;
-      _CheckForRequiredPrograms;
+      CheckForRequiredPrograms;
       _DownloadItems;
-			_UnzipFiles;
-			_CreateNdkToolchains;
+      _UnzipFiles;
+      _CreateNdkToolchains;
       _CreateMxeToolchains;
     </BuildDependsOn>
   </PropertyGroup>

--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -62,41 +62,41 @@
     </_NdkToolchain>
   </ItemGroup>
   <ItemGroup>
-    <_RequiredProgram Include="$(ManagedRuntime)"   Condition=" '$(ManagedRuntime)' != '' " />
-    <_RequiredProgram Include="$(HostCc)" />
-    <_RequiredProgram Include="$(HostCxx)" />
-    <_RequiredProgram Include="7za"                 Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    <RequiredProgram Include="$(ManagedRuntime)"    Condition=" '$(ManagedRuntime)' != '' " />
+    <RequiredProgram Include="$(HostCc)" />
+    <RequiredProgram Include="$(HostCxx)" />
+    <RequiredProgram Include="7za"                  Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>p7zip</Homebrew>
-    </_RequiredProgram>
-    <_RequiredProgram Include="autoconf" />
-    <_RequiredProgram Include="automake" />
-    <_RequiredProgram Include="cmake"               Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
-    <_RequiredProgram Include="gdk-pixbuf-csource"  Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    </RequiredProgram>
+    <RequiredProgram Include="autoconf" />
+    <RequiredProgram Include="automake" />
+    <RequiredProgram Include="cmake"                Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
+    <RequiredProgram Include="gdk-pixbuf-csource"   Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>gdk-pixbuf</Homebrew>
-    </_RequiredProgram>
-    <_RequiredProgram Include="gettext"             Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
-    <_RequiredProgram Include="glibtool"            Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    </RequiredProgram>
+    <RequiredProgram Include="gettext"              Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
+    <RequiredProgram Include="glibtool"             Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>libtool</Homebrew>
-    </_RequiredProgram>
-    <_RequiredProgram Include="gsed"                Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    </RequiredProgram>
+    <RequiredProgram Include="gsed"                 Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>gnu-sed</Homebrew>
-    </_RequiredProgram>
-    <_RequiredProgram Include="intltoolize"         Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    </RequiredProgram>
+    <RequiredProgram Include="intltoolize"          Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>intltool</Homebrew>
-    </_RequiredProgram>
-    <_RequiredProgram Include="make" />
-    <_RequiredProgram Include="pkg-config"          Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    </RequiredProgram>
+    <RequiredProgram Include="make" />
+    <RequiredProgram Include="pkg-config"           Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>pkg-config</Homebrew>
-    </_RequiredProgram>
-    <_RequiredProgram Include="ruby"                Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
-    <_RequiredProgram Include="scons"               Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    </RequiredProgram>
+    <RequiredProgram Include="ruby"                 Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
+    <RequiredProgram Include="scons"                Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>scons</Homebrew>
-    </_RequiredProgram>
-    <_RequiredProgram Include="wget"                Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    </RequiredProgram>
+    <RequiredProgram Include="wget"                 Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>wget</Homebrew>
-    </_RequiredProgram>
-    <_RequiredProgram Include="xz"                  Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    </RequiredProgram>
+    <RequiredProgram Include="xz"                   Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>xz</Homebrew>
-    </_RequiredProgram>
+    </RequiredProgram>
   </ItemGroup>
 </Project>

--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\Configuration.props" />
   <Import Project="android-toolchain.projitems" />
+  <Import Project="..\scripts\RequiredPrograms.targets" />
   <Target Name="_CopyBootstrapTasksAssembly"
       Outputs="$(OutputPath)\Xamarin.Android.Tools.BootstrapTasks.dll">
     <MSBuild
@@ -13,21 +14,6 @@
   <UsingTask AssemblyFile="$(OutputPath)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.DownloadUri" />
   <UsingTask AssemblyFile="$(OutputPath)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.UnzipDirectoryChildren" />
   <UsingTask AssemblyFile="$(OutputPath)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.Which" />
-  <Target Name="_CheckForRequiredPrograms">
-    <Which Program="%(_RequiredProgram.Identity)" Required="True" />
-    <OnError ExecuteTargets="_PrintRequiredPrograms" />
-  </Target>
-  <Target Name="_PrintRequiredPrograms">
-    <Error
-        ContinueOnError="True"
-        Text="The following programs are required: @(_RequiredProgram->'%(Identity)', ' ')"
-    />
-    <Error
-        Condition=" '$(HostOS)' == 'Darwin' "
-        ContinueOnError="True"
-        Text="Please try running: brew install @(_RequiredProgram->'%(Homebrew)', ' ')`"
-    />
-  </Target>
   <Target Name="_DetermineItems">
     <CreateItem
         Include="@(AndroidSdkItem)"

--- a/build-tools/libzip/libzip.mdproj
+++ b/build-tools/libzip/libzip.mdproj
@@ -17,6 +17,7 @@
   <PropertyGroup>
     <BuildDependsOnLocal Condition="'$(HostOS)' == 'Windows' OR '$(HostOS)' == 'Darwin'">
       ResolveReferences;
+      CheckForRequiredPrograms;
       _Configure;
       _Make
     </BuildDependsOnLocal>

--- a/build-tools/libzip/libzip.projitems
+++ b/build-tools/libzip/libzip.projitems
@@ -20,4 +20,7 @@
       <OutputLibraryPath>libzip.so</OutputLibraryPath>
     </_LibZipTarget>
   </ItemGroup>
+  <ItemGroup>
+    <RequiredProgram Include="cmake" />
+  </ItemGroup>
 </Project>

--- a/build-tools/libzip/libzip.targets
+++ b/build-tools/libzip/libzip.targets
@@ -6,6 +6,7 @@
   <UsingTask AssemblyFile="$(_SourceTopDir)\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.GetNugetPackageBasePath" />
   <Import Project="libzip.props" />
   <Import Project="libzip.projitems" />
+  <Import Project="..\scripts\RequiredPrograms.targets" />
   <Target Name="_SetCMakeListsTxtTimeToLastCommitTimestamp">
     <Exec
         Command="touch -m -t `git log -1 --format=%25cd --date=format-local:%25Y%25m%25d%25H%25M.%25S` CMakeLists.txt"

--- a/build-tools/scripts/RequiredPrograms.targets
+++ b/build-tools/scripts/RequiredPrograms.targets
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.Which" />
+  <Target Name="CheckForRequiredPrograms">
+    <Which Program="%(RequiredProgram.Identity)" Required="True" />
+    <OnError ExecuteTargets="_PrintRequiredPrograms" />
+  </Target>
+  <Target Name="_PrintRequiredPrograms">
+    <Error
+        ContinueOnError="True"
+        Text="The following programs are required: @(RequiredProgram->'%(Identity)', ' ')"
+    />
+    <Error
+        Condition=" '$(HostOS)' == 'Darwin' "
+        ContinueOnError="True"
+        Text="Please try running: brew install @(RequiredProgram->'%(Homebrew)', ' ')`"
+    />
+  </Target>
+</Project>

--- a/src/monodroid/monodroid.mdproj
+++ b/src/monodroid/monodroid.mdproj
@@ -17,6 +17,7 @@
   <PropertyGroup>
     <BuildDependsOn>
       ResolveReferences;
+      CheckForRequiredPrograms;
       _BuildRuntimes;
     </BuildDependsOn>
   </PropertyGroup>

--- a/src/monodroid/monodroid.projitems
+++ b/src/monodroid/monodroid.projitems
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <_RequiredProgram Include="xxd" />
+    <RequiredProgram Include="xxd" />
   </ItemGroup>
 </Project>

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -3,6 +3,7 @@
   <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.ValueToItems" />
   <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.Which" />
   <Import Project="monodroid.projitems" />
+  <Import Project="..\..\build-tools\scripts\RequiredPrograms.targets" />
   <PropertyGroup>
     <_Conf>$(Configuration.ToLowerInvariant())</_Conf>
   </PropertyGroup>
@@ -12,7 +13,6 @@
   <Target Name="_BuildRuntimes"
       Inputs="@(CFiles);jni\Android.mk"
       Outputs="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).so')">
-    <Which Program="%(_RequiredProgram.Identity)" Required="True" />
     <PropertyGroup>
       <_AppAbi>@(AndroidSupportedTargetJitAbi->'%(Identity)', ' ')</_AppAbi>
     </PropertyGroup>


### PR DESCRIPTION
If `cmake` isn't available in `$PATH`, the error is less than ideal:

	.../xamarin-android/build-tools/libzip/libzip.targets: error :
	Command 'cmake -DCMAKE_OSX_ARCHITECTURES="i386;x86_64" .../xamarin-android/external/libzip'
	exited with code: 127.

Whereby "less than ideal" I mean "wat?"

This is why we have the `<Which/>` task (commit 0c073f67), to provide
a better error messages.

Refactor out the `<Which/>` task execution into
`build-tools/scripts/RequiredPrograms.targets`, and change the
`@(_RequiredProgram)` item group to `@(RequiredProgram)` so that use
can be more consistent across projects, and add a check for `cmake` to
`build-tools/libzip` so that if `cmake` isn't installed we can get a
better error message:

	error : Could not find required program 'cmake'.