### PR TITLE
Build both both debug and release libmono-android regardless of config.

### DIFF
--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -12,7 +12,7 @@
   </ItemGroup>
   <Target Name="_BuildRuntimes"
       Inputs="@(CFiles);jni\Android.mk"
-      Outputs="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).so')">
+      Outputs="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.so')">
     <PropertyGroup>
       <_AppAbi>@(AndroidSupportedTargetJitAbi->'%(Identity)', ' ')</_AppAbi>
     </PropertyGroup>
@@ -22,22 +22,41 @@
         Overwrite="True"
     />
     <Exec
-        Command="$(AndroidToolchainDirectory)\ndk\ndk-build CONFIGURATION=$(Configuration) V=1"
+        Command="$(AndroidToolchainDirectory)\ndk\ndk-build CONFIGURATION=$(Configuration) NDK_LIBS_OUT=./libs/Debug NDK_OUT=./obj/Debug V=1"
     />
     <Copy
-        SourceFiles="@(AndroidSupportedTargetJitAbi->'obj\local\%(Identity)\libmonodroid.so')"
-        DestinationFiles="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).d.so')"
+        SourceFiles="@(AndroidSupportedTargetJitAbi->'obj\Debug\local\%(Identity)\libmonodroid.so')"
+        DestinationFiles="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.d.so')"
     />
     <Copy
-        SourceFiles="@(AndroidSupportedTargetJitAbi->'libs\%(Identity)\libmonodroid.so')"
-        DestinationFiles="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).so')"
+        SourceFiles="@(AndroidSupportedTargetJitAbi->'libs\Debug\%(Identity)\libmonodroid.so')"
+        DestinationFiles="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.so')"
+    />
+    <Exec
+        Command="$(AndroidToolchainDirectory)\ndk\ndk-build CONFIGURATION=$(Configuration) NDK_LIBS_OUT=./libs/Release NDK_OUT=./obj/Release  V=1"
+    />
+    <Copy
+        SourceFiles="@(AndroidSupportedTargetJitAbi->'obj\Release\local\%(Identity)\libmonodroid.so')"
+        DestinationFiles="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.d.so')"
+    />
+    <Copy
+        SourceFiles="@(AndroidSupportedTargetJitAbi->'libs\Release\%(Identity)\libmonodroid.so')"
+        DestinationFiles="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.so')"
     />
   </Target>
   <Target Name="_CleanRuntimes"
       AfterTargets="Clean">
+    <Exec
+        Command="$(AndroidToolchainDirectory)\ndk\ndk-build CONFIGURATION=$(Configuration) NDK_LIBS_OUT=./libs/Debug NDK_OUT=./obj/Debug  V=1 clean"
+    />
+    <Exec
+        Command="$(AndroidToolchainDirectory)\ndk\ndk-build CONFIGURATION=$(Configuration) NDK_LIBS_OUT=./libs/Release NDK_OUT=./obj/Release  V=1 clean"
+    />
     <RemoveDir Directories="obj\local;libs" />
     <Delete Files="jni\config.include;jni\machine.config.include;jni\Application.mk" />
-    <Delete Files="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).so')" />
-    <Delete Files="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.$(_Conf).d.so')" />
+    <Delete Files="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.so')" />
+    <Delete Files="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.d.so')" />
+    <Delete Files="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.so')" />
+    <Delete Files="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.d.so')" />
   </Target>
 </Project>


### PR DESCRIPTION
Whether you build xamarin-android in debug mode or release mode
should not matter when user wants to build app either in debug or
release mode. Current build system builds only debug mono-android for
Debug configuration and release mono-android for Release configuration,
which only makes it useless and annoying to diagnose the issues that
depends on app build configuration.

Build both libmono-android regardless of xamarin-android builder's
configuration and make it work.