### PR TITLE
[Mono.Android] Manually dispose surfaced objects when shutting down android runtime.

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -297,7 +297,14 @@ namespace Android.Runtime {
 				Java.Lang.Thread.DefaultUncaughtExceptionHandler = uncaughtExceptionHandler.DefaultHandler;
 
 #if JAVA_INTEROP
-			// Close of the current JniEnvironment to avoid ObjectDisposedException after shutdown
+			/* Manually dispose surfaced objects and close the current JniEnvironment to
+			 * avoid ObjectDisposedException thrown on finalizer threads after shutdown
+			 */
+			foreach (var surfacedObject in Java.Interop.Runtime.GetSurfacedObjects ()) {
+				var obj = surfacedObject.Target as IDisposable;
+				if (obj != null)
+					obj.Dispose ();
+			}
 			JniEnvironment.Runtime.Dispose ();
 #endif // JAVA_INTEROP
 		}


### PR DESCRIPTION
When running the Android designer unit tests after bumping the XA dependency to 6fec07a73b, we started
getting the following style of exceptions:

```
 System.NullReferenceException: Object reference not set to an instance of an object
   at Java.Interop.JniEnvironmentInfo..ctor () <0x1261d58e0 + 0x00074> in <filename unknown>:0
   at Java.Interop.JniEnvironment.<Info>m__0 () <0x1261d5890 + 0x00033> in <filename unknown>:0
   at System.Threading.ThreadLocal`1[T].GetValueSlow () <0x1261d5720 + 0x0005d> in <filename unknown>:0
   at System.Threading.ThreadLocal`1[T].get_Value () <0x125616970 + 0x000bb> in <filename unknown>:0
   at Java.Interop.JniEnvironment.get_CurrentInfo () <0x1256168c0 + 0x00027> in <filename unknown>:0
   at Java.Interop.JniEnvironment.get_Runtime () <0x125616890 + 0x00010> in <filename unknown>:0
   at Java.Interop.JniObjectReference.Dispose (Java.Interop.JniObjectReference& reference) <0x12586d9b0 + 0x0006f> in <filename unknown>:0
   at Android.Runtime.JNIEnv.DeleteGlobalRef (System.IntPtr jobject) <0x1261d2ed0 + 0x00034> in <filename unknown>:0
   at Android.Util.IAttributeSetInvoker.Dispose (System.Boolean disposing) <0x1261d56d0 + 0x00032> in <filename unknown>:0
   at Java.Lang.Object.Finalize () <0x1261d5590 + 0x000d7> in <filename unknown>:0
```

And

```
 System.ObjectDisposedException: Cannot access a disposed object.
 Object name: 'The ThreadLocal object has been disposed.'.
   at System.Threading.ThreadLocal`1[T].GetValueSlow () <0x12720f400 + 0x0012e> in <filename unknown>:0
   at System.Threading.ThreadLocal`1[T].get_Value () <0x12425d970 + 0x000bb> in <filename unknown>:0
   at Java.Interop.JniEnvironment.get_CurrentInfo () <0x12425d8c0 + 0x00027> in <filename unknown>:0
   at Java.Interop.JniEnvironment.get_Runtime () <0x12425d890 + 0x00010> in <filename unknown>:0
   at Java.Interop.JniObjectReference.Dispose (Java.Interop.JniObjectReference& reference) <0x12449c9b0 + 0x0006f> in <filename unknown>:0
   at Android.Runtime.JNIEnv.DeleteGlobalRef (System.IntPtr jobject) <0x12720bed0 + 0x00034> in <filename unknown>:0
   at Android.Util.IAttributeSetInvoker.Dispose (System.Boolean disposing) <0x12720f3b0 + 0x00032> in <filename unknown>:0
   at Java.Lang.Object.Finalize () <0x12720e950 + 0x000d7> in <filename unknown>:0
```

We had previously experienced a similar issue with JniRuntime when it was processed on the finalizer thread. This
lead to the commit in monodroid@400103e8e0. Because finalizer processing has inherently random ordering, the same
issue is now happening with other objects.

Thus this commit ensure an ordering where Java.Lang.Object are manually disposed before the runtime is and that way
bypass any sort of finalization ordering concern as per JonP recommendation[1]

[1]  https://xamarinhq.slack.com/archives/android/p1467909101010748