### PR TITLE
Fix a pathing issue when creating the Proguard Input Jar

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
@@ -126,7 +126,7 @@ namespace Xamarin.Android.Tasks
 				File.Delete (ProguardJarInput);
 			using (var zip = ZipArchive.Open (ProguardJarInput, FileMode.Create)) {
 				foreach (var file in Directory.GetFiles (classesFullPath, "*", SearchOption.AllDirectories))
-					zip.AddFile (file, Path.GetDirectoryName (file.Substring (classesFullPath.Length)));
+					zip.AddFile (file, Path.Combine (Path.GetDirectoryName (file.Substring (classesFullPath.Length)), Path.GetFileName (file)));
 			}
 
 			var acwLines = File.ReadAllLines (AcwMapFile);


### PR DESCRIPTION
The switch over to using LibZipSharp means that the API
to ZipArchive.AddFile slightly changed. Wtih Ionic.Zip
you just needed to provide the target Directory in the zip.
With LibZipSharp you need to provide the full path in the
zip including the filename.

This commit fixes that issue.