### PR TITLE
[Xamarin.Android.Build.Tasks] Applications crashing on startup due to java.io.IOException: No original dex files found

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -115,7 +115,7 @@ namespace Xamarin.Android.Tasks
 						Assembly.GetExecutingAssembly ().GetManifestResourceStream ("NOTICE.txt"));
 
 				// Add classes.dx
-				apk.AddFiles (DalvikClasses);
+				apk.AddFiles (DalvikClasses, useFileDirectories: false);
 
 				if (EmbedAssemblies && !BundleAssemblies)
 					AddAssemblies (apk);


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=42521

Recent changes to the AddFiles method in LibZipSharp ment that
the fix to strip the path of the classes.dex file was reverted.
This commit fixes that. We bump LibZipSharp to bring in a fix
where if we do not supply a path and useFilenamesPath is false
we only use the Filename for the zip.