### PR TITLE
expose MonoAndroidHelper.InitializeAndroidLogger() to public.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -138,7 +138,7 @@ namespace Xamarin.Android.Tasks
 			return filePaths.Distinct (MonoAndroidHelper.SizeAndContentFileComparer.DefaultComparer);
 		}
 
-		internal static void InitializeAndroidLogger (TaskLoggingHelper log)
+		public static void InitializeAndroidLogger (TaskLoggingHelper log)
 		{
 			AndroidLogger.Error += (task, message) => log.LogError (task + " " + message);
 			AndroidLogger.Warning += (task, message) => log.LogWarning (task + " " + message);


### PR DESCRIPTION
We need this in the debugging targets which regressed wrt logging progress.