### PR TITLE
[Xamarin.Android.Build.Tasks] Fix a regression in the Path seperator unit tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidUpdateResDir.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidUpdateResDir.cs
@@ -80,13 +80,13 @@ namespace Xamarin.Android.Tasks
 				
 				//compute the target path
 				string rel;
-				var logicalName = item.GetMetadata ("LogicalName");
+				var logicalName = item.GetMetadata ("LogicalName").Replace ('\\', Path.DirectorySeparatorChar);
 				if (item.GetMetadata ("IsWearApplicationResource") == "True") {
 					rel = item.ItemSpec.Substring (IntermediateDir.Length);
 				} else if (!string.IsNullOrEmpty (logicalName)) {
 					rel = logicalName;
 				} else {
-					rel = item.GetMetadata ("Link");
+					rel = item.GetMetadata ("Link").Replace ('\\', Path.DirectorySeparatorChar);
 					if (string.IsNullOrEmpty (rel)) {
 						rel = item.GetMetadata ("Identity");
 						if (!string.IsNullOrEmpty (ProjectDir)) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
@@ -72,7 +72,7 @@ namespace Xamarin.Android.Tasks
 					continue;
 
 				var name = item.ItemSpec.Substring (ResourceDirectory.Length);
-				var logical_name = item.GetMetadata ("LogicalName");
+				var logical_name = item.GetMetadata ("LogicalName").Replace ('\\', '/');
 
 				AddRename (name.Replace ('/', Path.DirectorySeparatorChar), logical_name.Replace ('/', Path.DirectorySeparatorChar));
 			}


### PR DESCRIPTION
No idea why this started happening. Its probably a change in
behaviour under Mono 4.4/.x version of xbuild. since it only
effects items using the "LogicalName" or "Link" meta data.
But the result is we get things like this in the Resource.Designer.cs

	static int drawable/foo = 123456789;

which is obviously a compilation problem for c#.
So to fix we add some processing of the metadata to replace
any "invalid" path seperators with valid ones.