### PR TITLE
[System.Drawing.Primitives] Add System.Drawing.Primitives.dll Facade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.userprefs
 bin
 Configuration.Override.props
+msfinal.pub
 obj
 packages
 .DS_Store

--- a/Configuration.props
+++ b/Configuration.props
@@ -38,6 +38,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <AndroidMxeFullPath>$([System.IO.Path]::GetFullPath ('$(AndroidMxeInstallPrefix)'))</AndroidMxeFullPath>
+    <AndroidNdkFullPath>$([System.IO.Path]::GetFullPath ('$(AndroidNdkDirectory)'))</AndroidNdkFullPath>
+    <AndroidSdkFullPath>$([System.IO.Path]::GetFullPath ('$(AndroidSdkDirectory)'))</AndroidSdkFullPath>
     <JavaInteropFullPath>$([System.IO.Path]::GetFullPath ('$(JavaInteropSourceDirectory)'))</JavaInteropFullPath>
     <MonoSourceFullPath>$([System.IO.Path]::GetFullPath ('$(MonoSourceDirectory)'))</MonoSourceFullPath>
     <SqliteSourceFullPath>$([System.IO.Path]::GetFullPath ('$(SqliteSourceDirectory)'))</SqliteSourceFullPath>

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ prepare::
 	nuget restore
 	(cd external/Java.Interop && nuget restore)
 	cp Configuration.Java.Interop.Override.props external/Java.Interop/Configuration.Override.props
+	cp `$(MSBUILD) /nologo /v:minimal /t:GetMonoSourceFullPath build-tools/scripts/Paths.targets`/mcs/class/msfinal.pub .
 
 ifeq ($(OS),Linux)
 UBUNTU_DEPS          = libzip4 curl openjdk-8-jdk git make automake autoconf libtool unzip vim-common clang lib32stdc++6 lib32z1

--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -83,6 +83,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTK", "src\OpenTK-1.0\Op
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "libZipSharp", "external\LibZipSharp\libZipSharp.csproj", "{E248B2CA-303B-4645-ADDC-9D4459D550FD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Drawing.Primitives", "src\System.Drawing.Primitives\System.Drawing.Primitives.csproj", "{C9FF2E4D-D927-479E-838B-647C16763F64}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|AnyCPU = Debug|AnyCPU
@@ -378,6 +380,14 @@ Global
 		{E248B2CA-303B-4645-ADDC-9D4459D550FD}.XAIntegrationDebug|Any CPU.Build.0 = Debug|Any CPU
 		{E248B2CA-303B-4645-ADDC-9D4459D550FD}.XAIntegrationRelease|Any CPU.ActiveCfg = Debug|Any CPU
 		{E248B2CA-303B-4645-ADDC-9D4459D550FD}.XAIntegrationRelease|Any CPU.Build.0 = Debug|Any CPU
+		{C9FF2E4D-D927-479E-838B-647C16763F64}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{C9FF2E4D-D927-479E-838B-647C16763F64}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{C9FF2E4D-D927-479E-838B-647C16763F64}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{C9FF2E4D-D927-479E-838B-647C16763F64}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{C9FF2E4D-D927-479E-838B-647C16763F64}.XAIntegrationDebug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{C9FF2E4D-D927-479E-838B-647C16763F64}.XAIntegrationDebug|AnyCPU.Build.0 = Debug|Any CPU
+		{C9FF2E4D-D927-479E-838B-647C16763F64}.XAIntegrationRelease|AnyCPU.ActiveCfg = Debug|Any CPU
+		{C9FF2E4D-D927-479E-838B-647C16763F64}.XAIntegrationRelease|AnyCPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
@@ -417,6 +427,7 @@ Global
 		{5EB9E888-E357-417E-9F39-DDEC195CE47F} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{900A0F71-BAAD-417A-8D1A-8D330297CDD0} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 		{E248B2CA-303B-4645-ADDC-9D4459D550FD} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
+		{C9FF2E4D-D927-479E-838B-647C16763F64} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -85,18 +85,6 @@
         AlwaysCreate="False"
     />
   </Target>
-  <Target Name="_GetAndroidSdkDirectory">
-    <Message
-        Text="$(AndroidToolchainDirectory)\sdk"
-        Importance="High"
-    />
-  </Target>
-  <Target Name="_GetAndroidNdkDirectory">
-    <Message
-        Text="$(AndroidToolchainDirectory)\ndk"
-        Importance="High"
-    />
-  </Target>
   <Target Name="_SetMxeToolchainMakefileTimeToLastCommitTimestamp"
       Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:'))">
     <Exec

--- a/build-tools/scripts/Paths.targets
+++ b/build-tools/scripts/Paths.targets
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\Configuration.props" />
+  <Target Name="GetAndroidNdkFullPath">
+    <Message
+        Text="$(AndroidNdkFullPath)"
+        Importance="High"
+    />
+  </Target>
+  <Target Name="GetAndroidSdkFullPath">
+    <Message
+        Text="$(AndroidSdkFullPath)"
+        Importance="High"
+    />
+  </Target>
+  <Target Name="GetMonoSourceFullPath">
+    <Message
+        Text="$(MonoSourceFullPath)"
+        Importance="High"
+    />
+  </Target>
+</Project>

--- a/src/System.Drawing.Primitives/Properties/AssemblyInfo.cs
+++ b/src/System.Drawing.Primitives/Properties/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Assembly forwards
+[assembly: TypeForwardedTo (typeof (System.Drawing.Point))]
+[assembly: TypeForwardedTo (typeof (System.Drawing.PointF))]
+[assembly: TypeForwardedTo (typeof (System.Drawing.Rectangle))]
+[assembly: TypeForwardedTo (typeof (System.Drawing.RectangleF))]
+[assembly: TypeForwardedTo (typeof (System.Drawing.Size))]
+[assembly: TypeForwardedTo (typeof (System.Drawing.SizeF))]

--- a/src/System.Drawing.Primitives/System.Drawing.Primitives.csproj
+++ b/src/System.Drawing.Primitives/System.Drawing.Primitives.csproj
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{C9FF2E4D-D927-479E-838B-647C16763F64}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>System.Drawing</RootNamespace>
+    <AssemblyName>System.Drawing.Primitives</AssemblyName>
+    <NoStdLib>true</NoStdLib>
+  </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
+  <PropertyGroup>
+    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
+    <AssemblyOriginatorKeyFile>$(MonoSourceFullPath)\mcs\class\mono.pub</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks\MonoAndroid\v1.0\Facades</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <NoStdLib>false</NoStdLib>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks\MonoAndroid\v1.0\Facades</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <NoStdLib>false</NoStdLib>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib">
+      <HintPath>$(OutputPath)..\mscorlib.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System">
+      <HintPath>$(OutputPath)..\System.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Core">
+      <HintPath>$(OutputPath)..\System.Core.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Xml">
+      <HintPath>$(OutputPath)..\System.Xml.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Java.Interop">
+      <HintPath>$(OutputPath)..\Java.Interop.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(MonoSourceFullPath)\mcs\class\Facades\System.Drawing.Primitives\AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(OutputPath)\..\..\..\..\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\Mono.Android\Mono.Android.csproj">
+      <Project>{66CF299A-CE95-4131-BCD8-DB66E30C4BF7}</Project>
+      <Name>Mono.Android</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj">
+      <Project>{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}</Project>
+      <Name>Xamarin.Android.Build.Tasks</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/tools/scripts/xabuild
+++ b/tools/scripts/xabuild
@@ -9,8 +9,8 @@ export TARGETS_DIR="$topdir/bin/$CONFIGURATION/lib/xbuild"
 export MSBuildExtensionsPath="$TARGETS_DIR" 
 export MONO_ANDROID_PATH="$topdir/bin/$CONFIGURATION"
 export XBUILD_FRAMEWORK_FOLDERS_PATH="$topdir/bin/$CONFIGURATION/lib/xbuild-frameworks"
-ANDROID_NDK_PATH=$(cd $topdir/build-tools/android-toolchain && xbuild /nologo /v:minimal /t:_GetAndroidNdkDirectory android-toolchain.targets)
-ANDROID_SDK_PATH=$(cd $topdir/build-tools/android-toolchain && xbuild /nologo /v:minimal /t:_GetAndroidSdkDirectory android-toolchain.targets)
+ANDROID_NDK_PATH=$(xbuild /nologo /v:minimal /t:GetAndroidNdkFullPath $topdir/build-tools/scripts/Paths.targets)
+ANDROID_SDK_PATH=$(xbuild /nologo /v:minimal /t:GetAndroidSdkFullPath $topdir/build-tools/scripts/Paths.targets)
 
 ANDROID_NDK_PATH=$(echo $ANDROID_NDK_PATH | sed 's/^\w*//g')
 ANDROID_SDK_PATH=$(echo $ANDROID_SDK_PATH | sed 's/^\w*//g')


### PR DESCRIPTION
Xamarin.Android needs to support [.NET Standard 1.6][0], which
mentions a [`System.Drawing.Primitives.dll` assembly][1] which has not
previously been supported or shipped.

`System.Drawing.Primitives.dll` contains `System.Drawing.Point` and
related typees, which Xamarin.Android places into `Mono.Android.dll`.

Add a new `System.Drawing.Primitives.dll` assembly to use as a
*facade assembly*, which contains [type forwarders][2] to
"redirect" the types from `System.Drawing.Primitives.dll` to the
corresponding types within `Mono.Android.dll`.

[0]: https://docs.microsoft.com/en-us/dotnet/articles/core/tutorials/libraries
[1]: https://github.com/dotnet/corefx/blob/master/Documentation/architecture/net-platform-standard.md#list-of-net-corefx-apis-and-their-associated-net-platform-standard-version
[2]: https://msdn.microsoft.com/en-us/library/ms404275(v=vs.110).aspx