### PR TITLE
[android-toolchain] Fix the `_CreateMxeW32Toolchain` Condition.

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -92,27 +92,30 @@
         WorkingDirectory="..\..\external\mxe"
     />
   </Target>
-  <Target Name="_CreateMxeW32Toolchain"
+  <ItemGroup>
+    <_AndroidMxeToolchain Include="i686-w64-mingw32.static"   Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:'))" />
+    <_AndroidMxeToolchain Include="x86_64-w64-mingw32.static" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
+  </ItemGroup>
+  <ItemGroup>
+    <_AndroidMxeOutput Include="@(_AndroidMxeToolchain->'$(AndroidMxeFullPath)\bin\%(Identity)-gcc')" />
+    <_AndroidMxeOutput Include="@(_AndroidMxeToolchain->'$(AndroidMxeFullPath)\bin\%(Identity)-cmake')" />
+    <_AndroidMxeOutput Include="@(_AndroidMxeToolchain->'$(AndroidMxeFullPath)\%(Identity)\lib\libz.a')" />
+    <_AndroidMxeOutput Include="@(_AndroidMxeToolchain->'$(AndroidMxeFullPath)\%(Identity)\include\zlib.h')" />
+  </ItemGroup>
+  <Target Name="_CreateMxeToolchains"
       DependsOnTargets="_SetMxeToolchainMakefileTimeToLastCommitTimestamp"
-      Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))"
+      Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))"
       Inputs="..\..\external\mxe\Makefile"
-      Outputs="$(AndroidMxeFullPath)\bin\i686-w64-mingw32.static-gcc;$(AndroidMxeFullPath)\bin\i686-w64-mingw32.static-cmake">
+      Outputs="@(_AndroidMxeOutput)">
     <Exec
+        Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:'))"
         Command="make $(MAKEFLAGS) MXE_TARGETS=&quot;i686-w64-mingw32.static&quot; gcc cmake zlib PREFIX=&quot;$(AndroidMxeFullPath)&quot;"
         WorkingDirectory="..\..\external\mxe"
     />
-  </Target>
-  <Target Name="_CreateMxeW64Toolchain"
-      DependsOnTargets="_SetMxeToolchainMakefileTimeToLastCommitTimestamp"
-      Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))"
-      Inputs="..\..\external\mxe\Makefile"
-      Outputs="$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-gcc;$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-cmake">
     <Exec
+        Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))"
         Command="make $(MAKEFLAGS) MXE_TARGETS=&quot;x86_64-w64-mingw32.static&quot; gcc cmake zlib PREFIX=&quot;$(AndroidMxeFullPath)&quot;"
         WorkingDirectory="..\..\external\mxe"
     />
-  </Target>
-  <Target Name="_CreateMxeToolchains"
-      DependsOnTargets="_CreateMxeW32Toolchain;_CreateMxeW64Toolchain">
   </Target>
 </Project>


### PR DESCRIPTION
The `_CreateMxeW32Toolchain` target condition checked for
`:mxe-Win64:`, not `:mxe-Win32:`, which caused it to needlessly run
whenever `:mxe-Win64:` was set (spending extra time), while *not*
running when it was requested, i.e. when `:mxe-Win32:` was set.

Additionally, I previously had an MXE SNAFU wherein
`android-toolchain.targets` was updated to build `zlib`, but my local
build output *didn't contain `zlib` outputs*. This resulted in obscure
build errors and needless tearing out of limited hair, which could
have been avoided if the `zlib` outputs had been listed as outputs
that could be checked for.

Thus, rework the existing `_CreateMxeW32Toolchain` and
`_CreateMxeW64Toolchain` dichotomy, and instead introduce a new
`@(_AndroidMxeToolchain)` item group with conditional values based on
`$(AndroidSupportedHostJitAbisForConditionalChecks)`. This allows for
a more "extensible" output file format that doesn't needlessly copy
obscure identifiers like `i686-w64-mingw32.static` for output files.

`_CreateMxeW32Toolchain` and `_CreateMxeW64Toolchain` are dead; long
live `_CreateMxeToolchains`!