### PR TITLE
Bundled multidex jar

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -78,6 +78,10 @@
       <HostOS></HostOS>
       <DestDir>platforms\android-24</DestDir>
     </AndroidSdkItem>
+    <AndroidSdkItem Include="android_m2repository_r16.zip">
+      <HostOS></HostOS>
+      <DestDir>extras\android\m2repository</DestDir>
+    </AndroidSdkItem>
   </ItemGroup>
   <ItemGroup>
     <_NdkToolchain Include="arm-linux-androideabi-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':armeabi:')) Or $(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':armeabi-v7a:'))">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="Xamarin.Android.Tools.BootstrapTasks.GenerateProfile" AssemblyFile="..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tools.BootstrapTasks.UnzipDirectoryChildren" AssemblyFile="..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" />
   <PropertyGroup>
     <_SharedRuntimeBuildPath Condition=" '$(_SharedRuntimeBuildPath)' == '' ">..\..\bin\$(Configuration)\lib\xbuild-frameworks\MonoAndroid\</_SharedRuntimeBuildPath>
     <_GeneratedProfileClass>$(IntermediateOutputPath)Profile.g.cs</_GeneratedProfileClass>
+    <BuildDependsOn>
+		$(BuildDependsOn);
+		_CopyExtractedMultiDexJar;
+    </BuildDependsOn>
+    <_AndroidSdkLocation>$(ANDROID_SDK_PATH)</_AndroidSdkLocation>
+    <_AndroidSdkLocation Condition="'$(_AndroidSdkLocation)'==''">$(AndroidToolchainDirectory)\sdk</_AndroidSdkLocation>
+    <_MultiDexAarInAndroidSdk>extras\android\m2repository\com\android\support\multidex\1.0.1\multidex-1.0.1.aar</_MultiDexAarInAndroidSdk>
   </PropertyGroup>
   <ItemGroup>
     <_SharedRuntimeAssemblies Include="$(_SharedRuntimeBuildPath)v1.0\*.dll;$(_SharedRuntimeBuildPath)$(AndroidFrameworkVersion)\*.dll"/>
@@ -18,5 +26,17 @@
         File="$(IntermediateOutputPath)$(CleanFile)"
         Lines="$(_GeneratedProfileClass)"
         Overwrite="false"/>
+  </Target>
+  
+  <Target Name="_CopyExtractedMultiDexJar"
+    Inputs="$(_AndroidSdkLocation)\$(_MultiDexAarInAndroidSdk)"
+    Outputs="$(OutputPath)..\..\..\mandroid\android-support-multidex.jar">
+    <UnzipDirectoryChildren
+      NoSubdirectory="true"
+      SourceFiles="$(_AndroidSdkLocation)\$(_MultiDexAarInAndroidSdk)"
+      DestinationFolder="$(IntermediateOutputPath)multidex-aar" />
+    <Copy
+      SourceFiles="$(IntermediateOutputPath)multidex-aar\classes.jar"
+      DestinationFiles="$(OutputPath)..\..\..\mandroid\android-support-multidex.jar" />
   </Target>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -12,6 +12,7 @@
     <_AndroidSdkLocation>$(ANDROID_SDK_PATH)</_AndroidSdkLocation>
     <_AndroidSdkLocation Condition="'$(_AndroidSdkLocation)'==''">$(AndroidToolchainDirectory)\sdk</_AndroidSdkLocation>
     <_MultiDexAarInAndroidSdk>extras\android\m2repository\com\android\support\multidex\1.0.1\multidex-1.0.1.aar</_MultiDexAarInAndroidSdk>
+    <_SupportLicenseInAndroidSdk>extras\android\m2repository\NOTICE.txt</_SupportLicenseInAndroidSdk>
   </PropertyGroup>
   <ItemGroup>
     <_SharedRuntimeAssemblies Include="$(_SharedRuntimeBuildPath)v1.0\*.dll;$(_SharedRuntimeBuildPath)$(AndroidFrameworkVersion)\*.dll"/>
@@ -29,8 +30,8 @@
   </Target>
   
   <Target Name="_CopyExtractedMultiDexJar"
-    Inputs="$(_AndroidSdkLocation)\$(_MultiDexAarInAndroidSdk)"
-    Outputs="$(OutputPath)..\..\..\mandroid\android-support-multidex.jar">
+    Inputs="$(_AndroidSdkLocation)\$(_MultiDexAarInAndroidSdk);$(_AndroidSdkLocation)\$(_SupportLicenseInAndroidSdk)"
+    Outputs="$(OutputPath)..\..\..\mandroid\android-support-multidex.jar;$(OutputPath)..\..\..\mandroid\MULTIDEX_JAR_LICENSE">
     <UnzipDirectoryChildren
       NoSubdirectory="true"
       SourceFiles="$(_AndroidSdkLocation)\$(_MultiDexAarInAndroidSdk)"
@@ -38,5 +39,8 @@
     <Copy
       SourceFiles="$(IntermediateOutputPath)multidex-aar\classes.jar"
       DestinationFiles="$(OutputPath)..\..\..\mandroid\android-support-multidex.jar" />
+    <Copy
+      SourceFiles="$(_AndroidSdkLocation)\$(_SupportLicenseInAndroidSdk)"
+      DestinationFiles="$(OutputPath)..\..\..\mandroid\MULTIDEX_JAR_LICENSE" />
   </Target>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -195,7 +195,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<DeployExternal Condition="'$(DeployExternal)' == ''">False</DeployExternal>
 	<UseShortFileNames Condition="'$(UseShortFileNames)' != 'True'">False</UseShortFileNames>
 
-	<AndroidMultiDexSupportJar>extras\android\support\multidex\library\libs\android-support-multidex.jar</AndroidMultiDexSupportJar>
+	<!-- Obsolete build property: should be removed in the future releases -->
+	<AndroidMultiDexSupportJar></AndroidMultiDexSupportJar>
 		
 	<AndroidSupportedAbis Condition=" '$(AndroidSupportedAbis)' == '' ">armeabi-v7a</AndroidSupportedAbis>
 
@@ -1072,7 +1073,11 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_AddMultiDexDependencyJars">
 	<CreateItem Include="$(AndroidSdkDirectory)\$(AndroidMultiDexSupportJar)"
-		Condition="'$(AndroidEnableMultiDex)' == 'True'">
+		Condition="'$(AndroidEnableMultiDex)' == 'True' AND '$(AndroidMultiDexSupportJar)' != ''">
+      <Output TaskParameter="Include" ItemName="AndroidJavaLibrary" />
+	</CreateItem>
+	<CreateItem Include="$(MonoAndroidToolsDirectory)\android-support-multidex.jar"
+		Condition="'$(AndroidEnableMultiDex)' == 'True' AND '$(AndroidMultiDexSupportJar)' == ''">
       <Output TaskParameter="Include" ItemName="AndroidJavaLibrary" />
 	</CreateItem>
 </Target>

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/UnzipDirectoryChildren.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/UnzipDirectoryChildren.cs
@@ -29,6 +29,8 @@ namespace Xamarin.Android.Tools.BootstrapTasks {
 		[Required]
 		public  ITaskItem       DestinationFolder   { get; set; }
 
+		public bool NoSubdirectory { get; set; }
+
 		public override bool Execute ()
 		{
 			Log.LogMessage (MessageImportance.Low, "Unzip:");
@@ -101,7 +103,9 @@ namespace Xamarin.Android.Tools.BootstrapTasks {
 				p.WaitForExit ();
 			}
 
-			foreach (var dir in Directory.EnumerateDirectories (nestedTemp, "*")) {
+			var dirs = NoSubdirectory ? new string [] { nestedTemp } : Directory.EnumerateDirectories (nestedTemp, "*");
+
+			foreach (var dir in dirs) {
 				foreach (var fse in Directory.EnumerateFileSystemEntries (dir)) {
 					var name    = Path.GetFileName (fse);
 					var destDir = string.IsNullOrEmpty (relativeDestDir)


### PR DESCRIPTION
We need to switch multidex support library from obsolete support package to m2repository. (Because current one in use is, obsoleted. Those who set custom Android SDK cannot find it because they don't know much about Android SDK...)

Switching to m2repository is not that simple. There is no android-support-multidex.jar anymore. So far I can think of two solution options described below:

1: bundle android-support-multidex.jar in the resulting SDK just as a binary. It is the safest, most reliable and almost backward compatible solution. We'll just have to copy the jar to bin/Debug/lib/mandroid.
  - Optionally, extract jar from m2repository instead of having binary checkin (which is almost harmless because it's just 21kb, but still needs some MSBuild targets hack that is messy anyways).

2: implement all below:
  - Add m2repository download to android-sdk-tool and xamarin-android/build-tools/android-toolchains. It is not very complicated.
  - Make changes to Xamarin.Android.Common.targets in MSBuild tasks in xamarin-android to do either of below (note that both likely need to be implemented in a new Task):
    - extract the jar from the relevant aar, cache it, and add it as AndroidJavaLibrary as it used to do.
    - implement additional build item support that we can retrieve only part of an aar, like we have in Binding library support.
  - Implement additional clean step to ensure that the jar is removed.
  - Add tests to ensure that ALL ABOVE works.

I believe there is no reason to chose option 2 in terms of implementation/QA cost. Just take the easier option.