### PR TITLE
Add support for AOT cross-compiler builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.userprefs
 bin
 Configuration.Override.props
+Configuration.OperatingSystem.props
 msfinal.pub
 obj
 packages

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,7 @@
 	path = external/LibZipSharp
 	url = https://github.com/grendello/LibZipSharp.git
 	branch = master
+[submodule "external/llvm"]
+	path = external/llvm
+	url = https://github.com/mono/llvm.git
+	branch = master

--- a/Configuration.Override.props.in
+++ b/Configuration.Override.props.in
@@ -19,6 +19,23 @@
     <AndroidSupportedTargetJitAbis>armeabi:armeabi-v7a:arm64-v8a:x86:x86_64</AndroidSupportedTargetJitAbis>
 
     <!--
+        Colon-separated list of ABIs to build AOT cross-compilers for. Note that there is no configuration
+        to build the armeabi-v7a cross-compiler. This is intentional as the ARMv6 cross-compiler takes care
+        of that target as well.
+        There doesn't need to be any parity between the AOT targets and the JIT ABIs above.
+        Supported targets are:
+
+          - armeabi
+          - win-armeabi
+          - arm64
+          - win-arm64
+          - x86
+          - win-x86
+          - x86_64
+          - win-x86_64
+    -->
+    <AndroidSupportedTargetAotAbis>armeabi:win-armeabi:arm64:win-arm64:x86:win-x86:x86_64:win-x86_64</AndroidSupportedTargetAotAbis>
+    <!--
       Colon-separated list of ABIs to build a "host" mono JIT for.
       The host JIT is used for the Xamarin Studio Designer, among other things.
       Supported ABIs include:

--- a/Configuration.props
+++ b/Configuration.props
@@ -7,12 +7,23 @@
       Project="$(MSBuildThisFileDirectory)Configuration.Override.props"
       Condition="Exists('$(MSBuildThisFileDirectory)Configuration.Override.props')"
   />
+
+  <!--
+      Note: this file *must* be imported *after* Configuration.Override.props
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)Configuration.OperatingSystem.props" />
   <PropertyGroup>
     <HostOS Condition=" '$(HostOS)' == '' And '$(OS)' == 'Windows_NT' ">Windows</HostOS>
-    <HostOS Condition=" '$(HostOS)' == '' And '$(OS)' == 'Unix' And Exists ('/Applications') ">Darwin</HostOS>
-    <HostOS Condition=" '$(HostOS)' == '' And '$(OS)' == 'Unix' ">Linux</HostOS>
+    <HostCc Condition=" '$(HostCc)' == '' ">$(HostCc64)</HostCc>
+    <HostCxx Condition=" '$(HostCxx)' == '' ">$(HostCxx64)</HostCxx>
+    <HostCc Condition=" '$(HostCc)' == '' ">$(HostCc32)</HostCc>
+    <HostCxx Condition=" '$(HostCxx)' == '' ">$(HostCxx32)</HostCxx>
     <HostCc Condition=" '$(HostCc)' == '' ">cc</HostCc>
     <HostCxx Condition=" '$(HostCxx)' == '' ">c++</HostCxx>
+    <HostCcName Condition=" '$(HostCcName)' == '' ">cc</HostCcName>
+    <HostCxxName Condition=" '$(HostCxxName)' == '' ">c++</HostCxxName>
+    <NeedMxe Condition=" '$(HostOS)' == 'Darwin' ">true</NeedMxe>
+    <MakeConcurrency Condition=" '$(MakeConcurrency)' == '' And '$(HostCpuCount)' != '' ">-j$(HostCpuCount)</MakeConcurrency>
     <ManagedRuntime Condition=" '$(ManagedRuntime)' == '' And '$(OS)' != 'Windows_NT' ">mono</ManagedRuntime>
     <TargetFrameworkRootPath>$(MSBuildThisFileDirectory)bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
     <HOME Condition=" '$(HOME)' == '' ">$(HOMEDRIVE)$(HOMEPATH)</HOME>
@@ -20,12 +31,14 @@
     <AndroidFrameworkVersion Condition=" '$(AndroidFrameworkVersion)' == '' ">v6.0</AndroidFrameworkVersion>
     <AndroidToolchainCacheDirectory Condition=" '$(AndroidToolchainCacheDirectory)' == '' ">$(HOME)\android-archives</AndroidToolchainCacheDirectory>
     <AndroidToolchainDirectory Condition=" '$(AndroidToolchainDirectory)' == '' ">$(HOME)\android-toolchain</AndroidToolchainDirectory>
-    <AndroidMxeInstallPrefix Condition=" '$(AndroidMxeInstallPrefix)' == '' ">$(AndroidToolchainDirectory)\mxe</AndroidMxeInstallPrefix>
+    <AndroidMxeInstallPrefix Condition=" '$(AndroidMxeInstallPrefix)' == '' And '$(NeedMxe)' == 'true' ">$(AndroidToolchainDirectory)\mxe</AndroidMxeInstallPrefix>
+    <AndroidMxeInstallPrefix Condition=" '$(HostOS)' == 'Linux' ">\usr</AndroidMxeInstallPrefix>
     <AndroidSdkDirectory>$(AndroidToolchainDirectory)\sdk</AndroidSdkDirectory>
     <AndroidNdkDirectory>$(AndroidToolchainDirectory)\ndk</AndroidNdkDirectory>
     <AndroidSupportedHostJitAbis Condition=" '$(AndroidSupportedHostJitAbis)' == '' ">$(HostOS)</AndroidSupportedHostJitAbis>
     <AndroidSupportedTargetJitAbis Condition=" '$(AndroidSupportedTargetJitAbis)' == '' ">armeabi-v7a</AndroidSupportedTargetJitAbis>
     <JavaInteropSourceDirectory Condition=" '$(JavaInteropSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\Java.Interop</JavaInteropSourceDirectory>
+    <LlvmSourceDirectory Condition=" '$(LlvmSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\llvm</LlvmSourceDirectory>
     <MonoSourceDirectory>$(MSBuildThisFileDirectory)external\mono</MonoSourceDirectory>
     <OpenTKSourceDirectory>$(MSBuildThisFileDirectory)external\opentk</OpenTKSourceDirectory>
     <LibZipSourceDirectory Condition=" '$(LibZipSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\libzip</LibZipSourceDirectory>
@@ -37,10 +50,16 @@
     <AllSupportedTargetAndroidAbis>$(AllSupported32BitTargetAndroidAbis);$(AllSupported64BitTargetAndroidAbis)</AllSupportedTargetAndroidAbis>
   </PropertyGroup>
   <PropertyGroup>
+    <_MingwPrefixTail Condition=" '$(HostOS)' == 'Darwin' ">.static</_MingwPrefixTail>
+    <MingwCommandPrefix32>i686-w64-mingw32$(_MingwPrefixTail)</MingwCommandPrefix32>
+    <MingwCommandPrefix64>x86_64-w64-mingw32$(_MingwPrefixTail)</MingwCommandPrefix64>
+  </PropertyGroup>
+  <PropertyGroup>
     <AndroidMxeFullPath>$([System.IO.Path]::GetFullPath ('$(AndroidMxeInstallPrefix)'))</AndroidMxeFullPath>
     <AndroidNdkFullPath>$([System.IO.Path]::GetFullPath ('$(AndroidNdkDirectory)'))</AndroidNdkFullPath>
     <AndroidSdkFullPath>$([System.IO.Path]::GetFullPath ('$(AndroidSdkDirectory)'))</AndroidSdkFullPath>
     <JavaInteropFullPath>$([System.IO.Path]::GetFullPath ('$(JavaInteropSourceDirectory)'))</JavaInteropFullPath>
+    <LlvmSourceFullPath>$([System.IO.Path]::GetFullPath ('$(LlvmSourceDirectory)'))</LlvmSourceFullPath>
     <MonoSourceFullPath>$([System.IO.Path]::GetFullPath ('$(MonoSourceDirectory)'))</MonoSourceFullPath>
     <SqliteSourceFullPath>$([System.IO.Path]::GetFullPath ('$(SqliteSourceDirectory)'))</SqliteSourceFullPath>
     <OpenTKSourceFullPath>$([System.IO.Path]::GetFullPath ('$(OpenTKSourceDirectory)'))</OpenTKSourceFullPath>
@@ -73,4 +92,11 @@
   <ItemGroup>
     <AndroidSupportedTargetJitAbi Include="$(AndroidSupportedTargetJitAbisSplit)" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <AndroidSupportedTargetAotAbisForConditionalChecks>$(AndroidSupportedTargetAotAbis)</AndroidSupportedTargetAotAbisForConditionalChecks>
+    <AndroidSupportedTargetAotAbisForConditionalChecks Condition=" !$(AndroidSupportedTargetAotAbisForConditionalChecks.EndsWith (':')) "   >$(AndroidSupportedTargetAotAbisForConditionalChecks):</AndroidSupportedTargetAotAbisForConditionalChecks>
+    <AndroidSupportedTargetAotAbisForConditionalChecks Condition=" !$(AndroidSupportedTargetAotAbisForConditionalChecks.StartsWith (':')) " >:$(AndroidSupportedTargetAotAbisForConditionalChecks)</AndroidSupportedTargetAotAbisForConditionalChecks>
+    <AndroidSupportedTargetAotAbisSplit>$(AndroidSupportedTargetAotAbis.Split(':'))</AndroidSupportedTargetAotAbisSplit>
+  </PropertyGroup>
 </Project>

--- a/Documentation/binfmt_misc-warning-Linux.txt
+++ b/Documentation/binfmt_misc-warning-Linux.txt
@@ -1,0 +1,23 @@
+*************** WARNING ***************
+
+Your Linux appears to have support for binfmt_misc kernel module enabled.
+The module makes it possible to execute non-Linux binaries if the appropriate
+interpreter for the given format is available.
+Your machine is configured to handle Windows PE executables either via Mono or
+Wine. It will make the Xamarin.Android build fail IF you choose to build the
+Windows cross-compilers by enabling the 'mxe-Win32' or 'mxe-Win64' host targets.
+
+You can disable the binfmt_misc module by issuing the following command as root
+before building Xamarin.Android:
+
+   echo 0 > /proc/sys/fs/binfmt_misc/status
+
+and re-enable it after building wiht the following command:
+
+   echo 1 > /proc/sys/fs/binfmt_misc/status
+
+If you are on Ubuntu then you can disable just the CLI (Mono) and Wine interpreters
+by issuing the following commands as root:
+
+   update-binfmts --disable cli
+   update-binfmts --disable wine

--- a/README.md
+++ b/README.md
@@ -155,6 +155,23 @@ Then, you may do one of the following:
     because it generates sources, and those sources won't exist on the
     initial project load. Rebuild the project should this happen.
 
+## Linux build notes
+
+If you have the `binfmt_misc` module enabled with any of Mono or Wine installed and
+you plan to cross-build the Windows compilers and tools (by enabling the `mxe-Win32`
+or `mxe-Win64` host targets) as well as LLVM+AOT targets, you will need to disable 
+`binfmt_misc` for the duration of the build or the Mono/LLVM configure scripts will
+fail to detect they are cross-compiling and they will produce Windows PE executables
+for tools required by the build.
+
+To disable `binfmt_misc` you need to issue the following command as root:
+
+        echo 0 > /proc/sys/fs/binfmt_misc/status
+
+and to enable it again, issue the following command:
+
+        echo 1 > /proc/sys/fs/binfmt_misc/status
+
 # Build Output Directory Structure
 
 There are two configurations, `Debug` and `Release`, controlled by the

--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -80,58 +80,58 @@
     </AndroidSdkItem>
   </ItemGroup>
   <ItemGroup>
-    <_NdkToolchain Include="arm-linux-androideabi-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':armeabi:')) Or $(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':armeabi-v7a:'))">
+    <_NdkToolchain Include="arm-linux-androideabi-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':armeabi:')) Or $(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':armeabi-v7a:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-armeabi:'))">
       <Platform>android-4</Platform>
       <Arch>arm</Arch>
     </_NdkToolchain>
-    <_NdkToolchain Include="aarch64-linux-android-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':arm64-v8a:'))">
+    <_NdkToolchain Include="aarch64-linux-android-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':arm64-v8a:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-arm64:'))">
       <Platform>android-21</Platform>
       <Arch>arm64</Arch>
     </_NdkToolchain>
-    <_NdkToolchain Include="x86-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':x86:'))">
+    <_NdkToolchain Include="x86-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':x86:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-x86:'))">
       <Platform>android-9</Platform>
       <Arch>x86</Arch>
     </_NdkToolchain>
-    <_NdkToolchain Include="x86_64-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':x86_64:'))">
+    <_NdkToolchain Include="x86_64-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':x86_64:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-x86_64:'))">
       <Platform>android-21</Platform>
       <Arch>x86_64</Arch>
     </_NdkToolchain>
   </ItemGroup>
   <ItemGroup>
     <RequiredProgram Include="$(ManagedRuntime)"    Condition=" '$(ManagedRuntime)' != '' " />
-    <RequiredProgram Include="$(HostCc)" />
-    <RequiredProgram Include="$(HostCxx)" />
-    <RequiredProgram Include="7za"                  Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    <RequiredProgram Include="$(HostCcName)" />
+    <RequiredProgram Include="$(HostCxxName)" />
+    <RequiredProgram Include="7za"                  Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>p7zip</Homebrew>
     </RequiredProgram>
     <RequiredProgram Include="autoconf" />
     <RequiredProgram Include="automake" />
-    <RequiredProgram Include="cmake"                Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
-    <RequiredProgram Include="gdk-pixbuf-csource"   Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    <RequiredProgram Include="cmake"                Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
+    <RequiredProgram Include="gdk-pixbuf-csource"   Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>gdk-pixbuf</Homebrew>
     </RequiredProgram>
-    <RequiredProgram Include="gettext"              Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
-    <RequiredProgram Include="glibtool"             Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    <RequiredProgram Include="gettext"              Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
+    <RequiredProgram Include="glibtool"             Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>libtool</Homebrew>
     </RequiredProgram>
-    <RequiredProgram Include="gsed"                 Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    <RequiredProgram Include="gsed"                 Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>gnu-sed</Homebrew>
     </RequiredProgram>
-    <RequiredProgram Include="intltoolize"          Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    <RequiredProgram Include="intltoolize"          Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>intltool</Homebrew>
     </RequiredProgram>
     <RequiredProgram Include="make" />
-    <RequiredProgram Include="pkg-config"           Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    <RequiredProgram Include="pkg-config"           Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>pkg-config</Homebrew>
     </RequiredProgram>
-    <RequiredProgram Include="ruby"                 Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
-    <RequiredProgram Include="scons"                Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    <RequiredProgram Include="ruby"                 Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
+    <RequiredProgram Include="scons"                Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>scons</Homebrew>
     </RequiredProgram>
-    <RequiredProgram Include="wget"                 Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    <RequiredProgram Include="wget"                 Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>wget</Homebrew>
     </RequiredProgram>
-    <RequiredProgram Include="xz"                   Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    <RequiredProgram Include="xz"                   Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>xz</Homebrew>
     </RequiredProgram>
   </ItemGroup>

--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -86,15 +86,15 @@
     />
   </Target>
   <Target Name="_SetMxeToolchainMakefileTimeToLastCommitTimestamp"
-      Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:'))">
+      Condition=" '$(NeedMxe)' == 'true' And ($(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:')))">
     <Exec
         Command="touch -m -t `git log -1 --format=%25cd --date=format-local:%25Y%25m%25d%25H%25M.%25S` Makefile"
         WorkingDirectory="..\..\external\mxe"
     />
   </Target>
   <ItemGroup>
-    <_AndroidMxeToolchain Include="i686-w64-mingw32.static"   Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:'))" />
-    <_AndroidMxeToolchain Include="x86_64-w64-mingw32.static" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
+    <_AndroidMxeToolchain Include="$(MingwCommandPrefix32)" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:'))" />
+    <_AndroidMxeToolchain Include="$(MingwCommandPrefix64)" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
   </ItemGroup>
   <ItemGroup>
     <_AndroidMxeOutput Include="@(_AndroidMxeToolchain->'$(AndroidMxeFullPath)\bin\%(Identity)-gcc')" />
@@ -104,17 +104,17 @@
   </ItemGroup>
   <Target Name="_CreateMxeToolchains"
       DependsOnTargets="_SetMxeToolchainMakefileTimeToLastCommitTimestamp"
-      Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))"
+      Condition=" '$(NeedMxe)' == 'true' And ($(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:')))"
       Inputs="..\..\external\mxe\Makefile"
       Outputs="@(_AndroidMxeOutput)">
     <Exec
         Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:'))"
-        Command="make $(MAKEFLAGS) MXE_TARGETS=&quot;i686-w64-mingw32.static&quot; gcc cmake zlib PREFIX=&quot;$(AndroidMxeFullPath)&quot;"
+        Command="make $(MAKEFLAGS) MXE_TARGETS=&quot;$(MingwCommandPrefix32)&quot; gcc cmake zlib PREFIX=&quot;$(AndroidMxeFullPath)&quot;"
         WorkingDirectory="..\..\external\mxe"
     />
     <Exec
         Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))"
-        Command="make $(MAKEFLAGS) MXE_TARGETS=&quot;x86_64-w64-mingw32.static&quot; gcc cmake zlib PREFIX=&quot;$(AndroidMxeFullPath)&quot;"
+        Command="make $(MAKEFLAGS) MXE_TARGETS=&quot;$(MingwCommandPrefix64)&quot; gcc cmake zlib PREFIX=&quot;$(AndroidMxeFullPath)&quot;"
         WorkingDirectory="..\..\external\mxe"
     />
   </Target>

--- a/build-tools/mono-runtimes/mono-runtimes.mdproj
+++ b/build-tools/mono-runtimes/mono-runtimes.mdproj
@@ -16,11 +16,16 @@
   <PropertyGroup>
     <BuildDependsOn>
       ResolveReferences;
+      _BuildLlvm;
+      _InstallLlvm;
       _Autogen;
       _ConfigureRuntimes;
       _BuildRuntimes;
       _InstallRuntimes;
       _InstallBcl;
+      _ConfigureCrossRuntimes;
+      _BuildCrossRuntimes;
+      _InstallCrossRuntimes;
     </BuildDependsOn>
   </PropertyGroup>
   <Import Project="mono-runtimes.targets" />

--- a/build-tools/mono-runtimes/mono-runtimes.projitems
+++ b/build-tools/mono-runtimes/mono-runtimes.projitems
@@ -1,7 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+      Each _MonoRuntime is placed in its own ItemGroup to keep it together with the associated PropertyGroup that
+      creates properties which determine whether the runtime is to be only configured or also built. The distinction
+      is necessary because of the cross compiled runtime requirements. Namely, the cross compiled ones need to have a C
+      header with structure offsets generated and in order to do so, they need the runtime's config.h file. But if the
+      runtime is not enabled by the user it would be a waste of time to build it when the configuration stage is all
+      we need. The PropertyGroup is kept in this file so that it's clear what set of conditions triggers the given
+      runtime's build
+  -->
+  <PropertyGroup>
+    <_ArmeabiRuntimeConfigure Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':armeabi:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-armeabi:'))">true</_ArmeabiRuntimeConfigure>
+    <_ArmeabiRuntimeBuild Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':armeabi:'))">true</_ArmeabiRuntimeBuild>
+  </PropertyGroup>
   <ItemGroup>
-    <_MonoRuntime Include="armeabi" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':armeabi:'))">
+    <_MonoRuntime Include="armeabi" Condition=" '$(_ArmeabiRuntimeConfigure)' == 'true' ">
       <Ar>$(_ArmAr)</Ar>
       <As>$(_ArmAs)</As>
       <Cc>$(_ArmCc)</Cc>
@@ -20,7 +33,12 @@
       <NativeLibraryExtension>so</NativeLibraryExtension>
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
+      <DoBuild>$(_ArmeabiRuntimeBuild)</DoBuild>
     </_MonoRuntime>
+  </ItemGroup>
+
+  <!-- Cross compiler doesn't need this one, it uses the 'armeabi' build above. Thus no PropertyGroup here. -->
+  <ItemGroup>
     <_MonoRuntime Include="armeabi-v7a" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':armeabi-v7a:'))">
       <Ar>$(_ArmAr)</Ar>
       <As>$(_ArmAs)</As>
@@ -40,8 +58,16 @@
       <NativeLibraryExtension>so</NativeLibraryExtension>
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
+      <DoBuild>true</DoBuild>
     </_MonoRuntime>
-    <_MonoRuntime Include="arm64-v8a" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':arm64-v8a:'))">
+  </ItemGroup>
+
+  <PropertyGroup>
+    <_Arm64RuntimeConfigure Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':arm64-v8a:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-arm64:'))">true</_Arm64RuntimeConfigure>
+    <_Arm64RuntimeBuild Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':arm64-v8a:'))">true</_Arm64RuntimeBuild>
+  </PropertyGroup>
+  <ItemGroup>
+    <_MonoRuntime Include="arm64-v8a" Condition=" '$(_Arm64RuntimeConfigure)' == 'true' ">
       <Ar>$(_Arm64Ar)</Ar>
       <As>$(_Arm64As)</As>
       <Cc>$(_Arm64Cc)</Cc>
@@ -60,8 +86,16 @@
       <NativeLibraryExtension>so</NativeLibraryExtension>
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
+      <DoBuild>$(_Arm64RuntimeBuild)</DoBuild>
     </_MonoRuntime>
-    <_MonoRuntime Include="x86" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':x86:'))">
+  </ItemGroup>
+
+  <PropertyGroup>
+    <_X86RuntimeConfigure Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':x86:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-x86:'))">true</_X86RuntimeConfigure>
+    <_X86RuntimeBuild Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':x86:'))">true</_X86RuntimeBuild>
+  </PropertyGroup>
+  <ItemGroup>
+    <_MonoRuntime Include="x86" Condition=" '$(_X86RuntimeConfigure)' == 'true' ">
       <Ar>$(_X86Ar)</Ar>
       <As>$(_X86As)</As>
       <Cc>$(_X86Cc)</Cc>
@@ -80,8 +114,16 @@
       <NativeLibraryExtension>so</NativeLibraryExtension>
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
+      <DoBuild>$(_X86RuntimeBuild)</DoBuild>
     </_MonoRuntime>
-    <_MonoRuntime Include="x86_64" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':x86_64:'))">
+  </ItemGroup>
+
+  <PropertyGroup>
+    <_X8664RuntimeConfigure Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':x86_64:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-x86_64:'))">true</_X8664RuntimeConfigure>
+    <_X8664RuntimeBuild Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':x86_64:'))">true</_X8664RuntimeBuild>
+  </PropertyGroup>
+  <ItemGroup>
+    <_MonoRuntime Include="x86_64" Condition=" '$(_X8664RuntimeConfigure)' == 'true' ">
       <Ar>$(_X86_64Ar)</Ar>
       <As>$(_X86_64As)</As>
       <Cc>$(_X86_64Cc)</Cc>
@@ -100,23 +142,27 @@
       <NativeLibraryExtension>so</NativeLibraryExtension>
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
+      <DoBuild>$(_X8664RuntimeBuild)</DoBuild>
     </_MonoRuntime>
+  </ItemGroup>
+
+  <ItemGroup>
     <_MonoRuntime Include="host-mxe-Win64" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
-      <Ar>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-ar</Ar>
-      <As>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-as</As>
-      <Cc>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-gcc</Cc>
+      <Ar>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-ar</Ar>
+      <As>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-as</As>
+      <Cc>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-gcc</Cc>
       <Cpp></Cpp>
       <CFlags>$(_HostWin64CFlags)</CFlags>
-      <Cxx>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-g++</Cxx>
+      <Cxx>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-g++</Cxx>
       <CxxFlags>$(_HostWin64CFlags)</CxxFlags>
       <CxxCpp></CxxCpp>
-      <DllTool>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-dlltool</DllTool>
-      <Ld>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-ld</Ld>
+      <DllTool>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-dlltool</DllTool>
+      <Ld>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-ld</Ld>
       <LdFlags></LdFlags>
-      <Objdump>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-objdump</Objdump>
-      <RanLib>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-ranlib</RanLib>
-      <Strip>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-strip</Strip>
-      <ConfigureFlags>PATH="$PATH:$(AndroidMxeFullPath)\bin" --host=x86_64-w64-mingw32.static --target=x86_64-w64-mingw32.static --disable-boehm --enable-mcs-build=no --enable-nls=no --enable-maintainer-mode --with-monodroid --disable-llvm ac_cv_header_zlib_h=no</ConfigureFlags>
+      <Objdump>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-objdump</Objdump>
+      <RanLib>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-ranlib</RanLib>
+      <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-strip</Strip>
+      <ConfigureFlags>PATH="$PATH:$(AndroidMxeFullPath)\bin" --host=$(MingwCommandPrefix64) --target=$(MingwCommandPrefix64) --disable-boehm --enable-mcs-build=no --enable-nls=no --enable-maintainer-mode --with-monodroid --disable-llvm ac_cv_header_zlib_h=no</ConfigureFlags>
       <NativeLibraryExtension>dll</NativeLibraryExtension>
       <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
       <OutputProfilerFilename></OutputProfilerFilename>
@@ -159,5 +205,227 @@
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- LLVM
+
+         Note: due to an xbuild bug we can't put property references inside item metadata that is to be used in the Target.Outputs attribute.
+         In this case the affected metadata item is BuildDir. Once the bug is fixed, we should replace the hard-coded values in BuildDir
+         metadata items with references to the appropriate $(_LlvmBuildDir*) properties. The properties in question are defined in the
+         mono-runtimes.props file.
+         At this moment the BuildDir item is treated as a *subdirectory* name and once the bug is fixed it will contain a full directory path - that
+         means mono-rutime.targets which use BuildDir (_ConfigureLlvm, BuildLlvm and _InstallLlvm) must be updated accordingly.
+    -->
+    <_LlvmRuntime Include="llvm32" Condition=" '$(_LlvmNeeded)' != '' ">
+      <BuildDir>build-32</BuildDir>
+      <Prefix>$(_LlvmPrefix32)</Prefix>
+      <ConfigureFlags>$(_LlvmConfigureFlags32)</ConfigureFlags>
+      <ConfigureEnvironment></ConfigureEnvironment>
+      <BuildEnvironment></BuildEnvironment>
+      <ExeSuffix></ExeSuffix>
+      <InstallBinaries>true</InstallBinaries>
+    </_LlvmRuntime>
+
+    <_LlvmRuntime Include="llvm64" Condition=" '$(_LlvmNeeded)' != '' And '$(_LlvmCanBuild64)' == 'yes' ">
+      <BuildDir>build-64</BuildDir>
+      <Prefix>$(_LlvmPrefix64)</Prefix>
+      <ConfigureFlags>$(_LlvmConfigureFlags64)</ConfigureFlags>
+      <ConfigureEnvironment></ConfigureEnvironment>
+      <BuildEnvironment></BuildEnvironment>
+      <ExeSuffix></ExeSuffix>
+      <InstallBinaries>true</InstallBinaries>
+    </_LlvmRuntime>
+
+    <_LlvmRuntime Include="llvmwin32" Condition=" '$(_LlvmNeeded)' != '' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:')) ">
+      <BuildDir>build-win32</BuildDir>
+      <Prefix>$(_LlvmPrefixWin32)</Prefix>
+      <ConfigureFlags>$(_LlvmConfigureFlagsWin32)</ConfigureFlags>
+      <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin32)</ConfigureEnvironment>
+      <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
+      <ExeSuffix>.exe</ExeSuffix>
+      <InstallBinaries>true</InstallBinaries>
+    </_LlvmRuntime>
+
+    <_LlvmRuntime Include="llvmwin64" Condition=" '$(_LlvmNeeded)' != '' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:')) ">
+      <BuildDir>build-win64</BuildDir>
+      <Prefix>$(_LlvmPrefixWin64)</Prefix>
+      <ConfigureFlags>$(_LlvmConfigureFlagsWin64)</ConfigureFlags>
+      <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin64)</ConfigureEnvironment>
+      <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
+      <ExeSuffix>.exe</ExeSuffix>
+      <InstallBinaries>false</InstallBinaries>
+    </_LlvmRuntime>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- cross compilers -->
+    <_MonoCrossRuntime Include="cross-arm" Condition="$(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':armeabi:'))">
+      <Ar>ar</Ar>
+      <As>as</As>
+      <Cc>$(HostCc)</Cc>
+      <CFlags>$(_CrossCFlags)</CFlags>
+      <Cxx>$(HostCxx)</Cxx>
+      <CxxCpp>cpp</CxxCpp>
+      <CxxFlags>$(_CrossCXXFlags)</CxxFlags>
+      <Ld>ld</Ld>
+      <LdFlags></LdFlags>
+      <RanLib>ranlib</RanLib>
+      <Strip>strip -S</Strip>
+      <TargetAbi>$(_CrossArmTargetAbi)</TargetAbi>
+      <OffsetsHeader>$(_CrossArmTargetAbi).h</OffsetsHeader>
+      <ConfigureFlags>--target=armv5-linux-androideabi --cache-file=$(_CrossConfigureCachePrefix)arm.config.cache --with-cross-offsets=$(_CrossArmOffsetsHeaderFile) $(_CrossConfigureFlags) --with-llvm=$(_CrossDefaultLlvmPrefix)</ConfigureFlags>
+      <ExeSuffix></ExeSuffix>
+      <BuildEnvironment></BuildEnvironment>
+      <ConfigureEnvironment></ConfigureEnvironment>
+      <CrossMonoName>cross-arm</CrossMonoName>
+    </_MonoCrossRuntime>
+
+    <_MonoCrossRuntime Include="cross-arm64" Condition="$(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':arm64:'))">
+      <Ar>ar</Ar>
+      <As>as</As>
+      <Cc>$(HostCc)</Cc>
+      <CFlags>$(_CrossCFlags)</CFlags>
+      <Cxx>$(HostCxx)</Cxx>
+      <CxxCpp>cpp</CxxCpp>
+      <CxxFlags>$(_CrossCXXFlags)</CxxFlags>
+      <Ld>ld</Ld>
+      <LdFlags></LdFlags>
+      <RanLib>ranlib</RanLib>
+      <Strip>strip -S</Strip>
+      <TargetAbi>$(_CrossArm64TargetAbi)</TargetAbi>
+      <OffsetsHeader>$(_CrossArm64TargetAbi).h</OffsetsHeader>
+      <ConfigureFlags>--target=aarch64-v8a-linux-android --cache-file=$(_CrossConfigureCachePrefix)arm64.config.cache --with-cross-offsets=$(_CrossArm64OffsetsHeaderFile) $(_CrossConfigureFlags) --with-llvm=$(_CrossDefaultLlvmPrefix)</ConfigureFlags>
+      <ExeSuffix></ExeSuffix>
+      <BuildEnvironment></BuildEnvironment>
+      <ConfigureEnvironment></ConfigureEnvironment>
+      <CrossMonoName>cross-arm64</CrossMonoName>
+    </_MonoCrossRuntime>
+
+    <_MonoCrossRuntime Include="cross-x86" Condition="$(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':x86:'))">
+      <Ar>ar</Ar>
+      <As>as</As>
+      <Cc>$(HostCc32)</Cc>
+      <CFlags>$(_CrossCFlags)</CFlags>
+      <Cxx>$(HostCxx32)</Cxx>
+      <CxxCpp>cpp</CxxCpp>
+      <CxxFlags>$(_CrossCXXFlags)</CxxFlags>
+      <Ld>ld</Ld>
+      <LdFlags></LdFlags>
+      <RanLib>ranlib</RanLib>
+      <Strip>strip -S</Strip>
+      <TargetAbi>$(_CrossX86TargetAbi)</TargetAbi>
+      <OffsetsHeader>$(_CrossX86TargetAbi).h</OffsetsHeader>
+      <ConfigureFlags>--target=i686-linux-android --cache-file=$(_CrossConfigureCachePrefix)x86.config.cache --with-cross-offsets=$(_CrossX86OffsetsHeaderFile) $(_CrossConfigureFlags)  --with-llvm=$(_LlvmPrefix32)</ConfigureFlags>
+      <ExeSuffix></ExeSuffix>
+      <BuildEnvironment></BuildEnvironment>
+      <ConfigureEnvironment></ConfigureEnvironment>
+      <CrossMonoName>cross-x86</CrossMonoName>
+    </_MonoCrossRuntime>
+
+    <_MonoCrossRuntime Include="cross-x86_64" Condition="$(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':x86_64:'))">
+      <Ar>ar</Ar>
+      <As>as</As>
+      <Cc>$(HostCc)</Cc>
+      <CFlags>$(_CrossCFlags)</CFlags>
+      <Cxx>$(HostCxx)</Cxx>
+      <CxxCpp>cpp</CxxCpp>
+      <CxxFlags>$(_CrossCXXFlags)</CxxFlags>
+      <Ld>ld</Ld>
+      <LdFlags></LdFlags>
+      <RanLib>ranlib</RanLib>
+      <Strip>strip -S</Strip>
+      <TargetAbi>$(_CrossX8664TargetAbi)</TargetAbi>
+      <OffsetsHeader>$(_CrossX8664TargetAbi).h</OffsetsHeader>
+      <ConfigureFlags>--target=x86_64-linux-android --cache-file=$(_CrossConfigureCachePrefix)x86_64.config.cache --with-cross-offsets=$(_CrossX8664OffsetsHeaderFile) $(_CrossConfigureFlags)  --with-llvm=$(_CrossDefaultLlvmPrefix)</ConfigureFlags>
+      <ExeSuffix></ExeSuffix>
+      <BuildEnvironment></BuildEnvironment>
+      <ConfigureEnvironment></ConfigureEnvironment>
+      <CrossMonoName>cross-x86_64</CrossMonoName>
+    </_MonoCrossRuntime>
+
+    <_MonoCrossRuntime Include="cross-arm-win" Condition="$(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-armeabi:'))">
+      <Ar>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-ar</Ar>
+      <As>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-as</As>
+      <Cc>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-gcc</Cc>
+      <CFlags>$(_CrossCFlagsWin) -static -static-libgcc</CFlags>
+      <Cxx>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-g++</Cxx>
+      <CxxCpp>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-cpp</CxxCpp>
+      <CxxFlags>$(_CrossCXXFlagsWin) -static -static-libgcc -static-libstdc++</CxxFlags>
+      <Ld>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-ld</Ld>
+      <LdFlags>-static -static-libgcc</LdFlags>
+      <RanLib>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-ranlib</RanLib>
+      <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-strip -S</Strip>
+      <TargetAbi>$(_CrossArmTargetAbi)</TargetAbi>
+      <OffsetsHeader>$(_CrossArmTargetAbi).h</OffsetsHeader>
+      <ConfigureFlags>--target=armv5-linux-androideabi --host="$(_CrossConfigureBuildHostWin32)" --cache-file=$(_CrossConfigureCachePrefix)arm-win.config.cache --with-cross-offsets=$(_CrossArmOffsetsHeaderFile) $(_CrossConfigureFlags) --with-llvm=$(_LlvmPrefixWin32)</ConfigureFlags>
+      <ExeSuffix>.exe</ExeSuffix>
+      <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
+      <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin32)</ConfigureEnvironment>
+      <CrossMonoName>cross-arm</CrossMonoName>
+    </_MonoCrossRuntime>
+
+    <_MonoCrossRuntime Include="cross-arm64-win" Condition="$(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-arm64:'))">
+      <Ar>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-ar</Ar>
+      <As>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-as</As>
+      <Cc>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-gcc</Cc>
+      <CFlags>$(_CrossCFlagsWin) -static -static-libgcc</CFlags>
+      <Cxx>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-g++</Cxx>
+      <CxxCpp>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-cpp</CxxCpp>
+      <CxxFlags>$(_CrossCXXFlagsWin) -static -static-libgcc</CxxFlags>
+      <Ld>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-ld</Ld>
+      <LdFlags>-static -static-libgcc -static-libstdc++</LdFlags>
+      <RanLib>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-ranlib</RanLib>
+      <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-strip -S</Strip>
+      <TargetAbi>$(_CrossArm64TargetAbi)</TargetAbi>
+      <OffsetsHeader>$(_CrossArm64TargetAbi).h</OffsetsHeader>
+      <ConfigureFlags>--target=aarch64-v8a-linux-android --host="$(_CrossConfigureBuildHostWin32)" --cache-file=$(_CrossConfigureCachePrefix)arm64-win.config.cache --with-cross-offsets=$(_CrossArm64OffsetsHeaderFile) $(_CrossConfigureFlags) --with-llvm=$(_LlvmPrefixWin32)</ConfigureFlags>
+      <ExeSuffix>.exe</ExeSuffix>
+      <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
+      <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin32)</ConfigureEnvironment>
+      <CrossMonoName>cross-arm64</CrossMonoName>
+    </_MonoCrossRuntime>
+
+    <_MonoCrossRuntime Include="cross-x86-win" Condition="$(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-x86:'))">
+      <Ar>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-ar</Ar>
+      <As>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-as</As>
+      <Cc>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-gcc</Cc>
+      <CFlags>$(_CrossCFlagsWin) -static -static-libgcc</CFlags>
+      <Cxx>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-g++</Cxx>
+      <CxxCpp>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-cpp</CxxCpp>
+      <CxxFlags>$(_CrossCXXFlagsWin) -static -static-libgcc</CxxFlags>
+      <Ld>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-ld</Ld>
+      <LdFlags>-static -static-libgcc -static-libstdc++</LdFlags>
+      <RanLib>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-ranlib</RanLib>
+      <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-strip -S</Strip>
+      <TargetAbi>$(_CrossX86TargetAbi)</TargetAbi>
+      <OffsetsHeader>$(_CrossX86TargetAbi).h</OffsetsHeader>
+      <ConfigureFlags>--target=i686-linux-android --host="$(_CrossConfigureBuildHostWin32)" --cache-file=$(_CrossConfigureCachePrefix)x86-win.config.cache --with-cross-offsets=$(_CrossX86OffsetsHeaderFile) $(_CrossConfigureFlags) --with-llvm=$(_LlvmPrefixWin32)</ConfigureFlags>
+      <ExeSuffix>.exe</ExeSuffix>
+      <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
+      <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin32)</ConfigureEnvironment>
+      <CrossMonoName>cross-x86</CrossMonoName>
+    </_MonoCrossRuntime>
+
+    <_MonoCrossRuntime Include="cross-x86_64-win" Condition="$(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-x86_64:'))">
+      <Ar>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-ar</Ar>
+      <As>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-as</As>
+      <Cc>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-gcc</Cc>
+      <CFlags>$(_CrossCFlagsWin) -static -static-libgcc</CFlags>
+      <Cxx>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-g++</Cxx>
+      <CxxCpp>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-cpp</CxxCpp>
+      <CxxFlags>$(_CrossCXXFlagsWin) -static -static-libgcc</CxxFlags>
+      <Ld>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-ld</Ld>
+      <LdFlags>-static -static-libgcc -static-libstdc++</LdFlags>
+      <RanLib>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-ranlib</RanLib>
+      <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-strip -S</Strip>
+      <TargetAbi>$(_CrossX8664TargetAbi)</TargetAbi>
+      <OffsetsHeader>$(_CrossX8664TargetAbi).h</OffsetsHeader>
+      <ConfigureFlags>--target=x86_64-linux-android --host="$(_CrossConfigureBuildHostWin64)" --cache-file=$(_CrossConfigureCachePrefix)x86_64-win.config.cache --with-cross-offsets=$(_CrossX8664OffsetsHeaderFile) $(_CrossConfigureFlags) --with-llvm=$(_LlvmPrefixWin64)</ConfigureFlags>
+      <ExeSuffix>.exe</ExeSuffix>
+      <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
+      <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin32)</ConfigureEnvironment>
+      <CrossMonoName>cross-x86_64</CrossMonoName>
+    </_MonoCrossRuntime>
   </ItemGroup>
 </Project>

--- a/build-tools/mono-runtimes/mono-runtimes.props
+++ b/build-tools/mono-runtimes/mono-runtimes.props
@@ -12,6 +12,120 @@
     <_TargetCxxFlags>$(_SecurityCFlags) -DMONODROID=1</_TargetCxxFlags>
     <_TargetLdFlags>-ldl -lm -llog -lc -lgcc</_TargetLdFlags>
   </PropertyGroup>
+
+  <!-- LLVM+cross common -->
+  <PropertyGroup>
+    <_CrossOutputDirTop>$([System.IO.Path]::GetFullPath ('$(IntermediateOutputPath)')</_CrossOutputDirTop>
+    <_MingwCc32>$(MingwCommandPrefix32)-gcc</_MingwCc32>
+    <_MingwCxx32>$(MingwCommandPrefix32)-g++</_MingwCxx32>
+    <_MingwCc64>$(MingwCommandPrefix64)-gcc</_MingwCc64>
+    <_MingwCxx64>$(MingwCommandPrefix64)-g++</_MingwCxx64>
+    <_MingwTriplet32>i686-w64-mingw32$(_MingwPrefixTail)</_MingwTriplet32>
+    <_MingwTriplet64>x86_64-w64-mingw32$(_MingwPrefixTail)</_MingwTriplet64>
+
+    <!-- LLVM -->
+    <_LlvmNeeded Condition=" '$(AndroidSupportedTargetAotAbis)' != '' ">yes</_LlvmNeeded>
+    <_LlvmCanBuild64 Condition=" '$(HostBits)' == '64' ">yes</_LlvmCanBuild64>
+    <_LlvmOutputDirTop>$(_CrossOutputDirTop)\llvm</_LlvmOutputDirTop>
+
+    <_LlvmBuildDir32>$(_LlvmOutputDirTop)\build-32</_LlvmBuildDir32>
+    <_LlvmBuildDir64>$(_LlvmOutputDirTop)\build-64</_LlvmBuildDir64>
+    <_LlvmPrefix32>$(_LlvmOutputDirTop)\installed-32\usr</_LlvmPrefix32>
+    <_LlvmPrefix64>$(_LlvmOutputDirTop)\installed-64\usr</_LlvmPrefix64>
+
+    <_LlvmBuildDirWin32>$(_LlvmOutputDirTop)\build-win32</_LlvmBuildDirWin32>
+    <_LlvmBuildDirWin64>$(_LlvmOutputDirTop)\build-win64</_LlvmBuildDirWin64>
+    <_LlvmPrefixWin32>$(_LlvmOutputDirTop)\installed-win32\usr</_LlvmPrefixWin32>
+    <_LlvmPrefixWin64>$(_LlvmOutputDirTop)\installed-win64\usr</_LlvmPrefixWin64>
+
+    <_LlvmCommonConfigureFlags>--enable-optimized --enable-assertions=no --enable-targets="arm,aarch64,x86"</_LlvmCommonConfigureFlags>
+    <_LlvmCommonConfigureFlags32>$(_LlvmCommonConfigureFlags) --prefix=$(_LlvmPrefix32) --cache-file=$(_CrossOutputDirTop)\llvm32.config.cache CC="$(HostCc32)" CXX="$(HostCxx32)"</_LlvmCommonConfigureFlags32>
+    <_LlvmCommonConfigureFlags64>$(_LlvmCommonConfigureFlags) --prefix=$(_LlvmPrefix64) --cache-file=$(_CrossOutputDirTop)\llvm64.config.cache CC="$(HostCc64)" CXX="$(HostCxx64)"</_LlvmCommonConfigureFlags64>
+
+    <_LlvmCommonConfigureFlagsWin>$(_LlvmCommonConfigureFlags) --disable-pthreads --disable-zlib</_LlvmCommonConfigureFlagsWin>
+    <_LlvmCommonConfigureFlagsWin32>$(_LlvmCommonConfigureFlagsWin) --prefix=$(_LlvmPrefixWin32) --with-llvm=$(_LlvmPrefix32) --cache-file=$(_CrossOutputDirTop)\llvm-win32.config.cache CC="$(_MingwCc32)" CXX="$(_MingwCxx32)"</_LlvmCommonConfigureFlagsWin32>
+    <_LlvmCommonConfigureFlagsWin64>$(_LlvmCommonConfigureFlagsWin) --prefix=$(_LlvmPrefixWin64) --with-llvm=$(_LlvmPrefix64) --cache-file=$(_CrossOutputDirTop)\llvm-win64.config.cache CC="$(_MingwCc64)" CXX="$(_MingwCxx64)"</_LlvmCommonConfigureFlagsWin64>
+
+    <!-- Cross compilers -->
+    <_AotOffsetsDumperName>MonoAotOffsetsDumper.exe</_AotOffsetsDumperName>
+    <_AotOffsetsDumperSourceDir>$(MonoSourceFullPath)\tools\offsets-tool</_AotOffsetsDumperSourceDir>
+    <_CrossDefaultLlvmPrefix Condition=" '$(_LlvmCanBuild64)' == 'yes' ">$(_LlvmPrefix64)</_CrossDefaultLlvmPrefix>
+    <_CrossDefaultLlvmPrefix Condition=" '$(_LlvmCanBuild64)' != 'yes' ">$(_LlvmPrefix32)</_CrossDefaultLlvmPrefix>
+    <_CrossOutputPrefix>$(_CrossOutputDirTop)\cross-</_CrossOutputPrefix>
+    <_CrossConfigureCachePrefix>$(_CrossOutputDirTop)cross-</_CrossConfigureCachePrefix>
+    <_CrossDebugCFlags Condition=" '$(Configuration)' == 'Debug'">-DDEBUG_CROSS</_CrossDebugCFlags>
+    <_CrossCommonCFlags>$(_CrossDebugCFlags) -DXAMARIN_PRODUCT_VERSION=0</_CrossCommonCFlags>
+    <_CrossCommonCXXFlags>$(_CrossCommonCFlags)</_CrossCommonCXXFlags>
+    <_CrossCommonConfigureFlags>--disable-boehm --enable-mcs-build=no --enable-nls=no --enable-maintainer-mode --enable-extension-module --with-tls=pthread</_CrossCommonConfigureFlags>
+  </PropertyGroup>
+
+  <!-- LLVM+cross OSX -->
+  <PropertyGroup Condition=" '$(HostOS)' == 'Darwin' ">
+    <_OSXMinVersion>-mmacosx-version-min=10.9</_OSXMinVersion>
+    <_CrossConfigureBuildHost32>$(HostTriplet32)</_CrossConfigureBuildHost32>
+    <_CrossConfigureBuildHost64>$(HostTriplet64)</_CrossConfigureBuildHost64>
+    <_CrossConfigureBuildHostWin32>$(_MingwTriplet32)</_CrossConfigureBuildHostWin32>
+    <_CrossConfigureBuildHostWin64>$(_MingwTriplet64)</_CrossConfigureBuildHostWin64>
+    <_CrossOSXCommonCompilerFlags>$(_OSXMinVersion)</_CrossOSXCommonCompilerFlags>
+    <_CrossCFlags>$(_CrossCommonCFlags) $(_CrossOSXCommonCompilerFlags)</_CrossCFlags>
+    <_CrossCFlagsWin>$(_CrossCommonCFlags)</_CrossCFlagsWin>
+    <_CrossCXXFlags>$(_CrossCommonCXXFlags) $(_CrossOSXCommonCompilerFlags) -stdlib=libc++</_CrossCXXFlags>
+    <_CrossCXXFlagsWin>$(_CrossCommonCXXFlags)</_CrossCXXFlagsWin>
+    <_CrossConfigureFlags32>--build=$(_CrossConfigureBuildHost32) $(_CrossCommonConfigureFlags)</_CrossConfigureFlags32>
+    <_CrossConfigureFlags64>--build=$(_CrossConfigureBuildHost64) $(_CrossCommonConfigureFlags)</_CrossConfigureFlags64>
+    <_CrossConfigureFlags>$(_CrossConfigureFlags64)</_CrossConfigureFlags>
+
+    <_LlvmStdlib>-stdlib=libc++</_LlvmStdlib>
+    <_LlvmExtraConfigureFlags>--enable-libcpp</_LlvmExtraConfigureFlags>
+    <_LlvmOsxCommonConfigureFlags>$(_LlvmExtraConfigureFlags) CXXFLAGS="$(_LlvmStdlib) $(_OSXMinVersion)" LDFLAGS="$(_OSXMinVersion)"</_LlvmOsxCommonConfigureFlags>
+    <_LlvmConfigureFlags32>--build="$(_CrossConfigureBuildHost32)" $(_LlvmOsxCommonConfigureFlags) $(_LlvmCommonConfigureFlags32)</_LlvmConfigureFlags32>
+    <_LlvmConfigureFlags64>--build="$(_CrossConfigureBuildHost64)" $(_LlvmOsxCommonConfigureFlags) $(_LlvmCommonConfigureFlags64)</_LlvmConfigureFlags64>
+    <_LlvmConfigureEnvironmentWin32>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</_LlvmConfigureEnvironmentWin32>
+    <_LlvmConfigureEnvironmentWin64>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</_LlvmConfigureEnvironmentWin64>
+    <_LlvmConfigureFlagsWin32>--host="$(_CrossConfigureBuildHostWin32)" $(_LlvmCommonConfigureFlagsWin32)</_LlvmConfigureFlagsWin32>
+    <_LlvmConfigureFlagsWin64>--host="$(_CrossConfigureBuildHostWin64)" $(_LlvmCommonConfigureFlagsWin64)</_LlvmConfigureFlagsWin64>
+  </PropertyGroup>
+
+  <!-- LLVM+cross Linux -->
+  <PropertyGroup Condition=" '$(HostOS)' == 'Linux' ">
+    <_CrossConfigureBuildHost>$(HostTriplet)</_CrossConfigureBuildHost>
+    <_CrossConfigureBuildHostWin32>$(_MingwTriplet32)</_CrossConfigureBuildHostWin32>
+    <_CrossConfigureBuildHostWin64>$(_MingwTriplet64)</_CrossConfigureBuildHostWin64>
+
+    <_CrossCFlags>$(_CrossCommonCFlags)</_CrossCFlags>
+    <_CrossCFlagsWin>$(_CrossCFlags)</_CrossCFlagsWin>
+    <_CrossCXXFlags>$(_CrossCommonCXXFlags)</_CrossCXXFlags>
+    <_CrossCXXFlagsWin>$(_CrossCXXFlags)</_CrossCXXFlagsWin>
+    <_CrossConfigureFlags>--build=$(_CrossConfigureBuildHost) $(_CrossCommonConfigureFlags)</_CrossConfigureFlags>
+
+    <_LlvmConfigureFlags32>--build="$(_CrossConfigureBuildHost)" $(_LlvmCommonConfigureFlags32)</_LlvmConfigureFlags32>
+    <_LlvmConfigureFlags64>--build="$(_CrossConfigureBuildHost)" $(_LlvmCommonConfigureFlags64)</_LlvmConfigureFlags64>
+    <_LlvmConfigureFlagsWin32>--host="$(_CrossConfigureBuildHostWin32)" $(_LlvmCommonConfigureFlagsWin32)</_LlvmConfigureFlagsWin32>
+    <_LlvmConfigureFlagsWin64>--host="$(_CrossConfigureBuildHostWin64)" $(_LlvmCommonConfigureFlagsWin64)</_LlvmConfigureFlagsWin64>
+  </PropertyGroup>
+
+  <!-- Cross-compilers settings -->
+  <PropertyGroup>
+      <_CrossArmTargetAbi>armv5-none-linux-androideabi</_CrossArmTargetAbi>
+      <_CrossArmOffsetsHeaderFile>armv5-none-linux-androideabi.h</_CrossArmOffsetsHeaderFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+      <_CrossArm64TargetAbi>aarch64-v8a-linux-android</_CrossArm64TargetAbi>
+      <_CrossArm64OffsetsHeaderFile>aarch64-v8a-linux-android.h</_CrossArm64OffsetsHeaderFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+      <_CrossX86TargetAbi>i686-none-linux-android</_CrossX86TargetAbi>
+      <_CrossX86OffsetsHeaderFile>i686-none-linux-android.h</_CrossX86OffsetsHeaderFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+      <_CrossX8664TargetAbi>x86_64-none-linux-android</_CrossX8664TargetAbi>
+      <_CrossX8664OffsetsHeaderFile>x86_64-none-linux-android.h</_CrossX8664OffsetsHeaderFile>
+  </PropertyGroup>
+
+  <!-- Mono runtimes settings -->
   <PropertyGroup>
     <_ArmNdkPlatformPath>$(AndroidToolchainDirectory)\ndk\platforms\android-4</_ArmNdkPlatformPath>
     <_ArmAr>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-ar</_ArmAr>

--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -72,6 +72,71 @@
         WorkingDirectory="$(MonoSourceFullPath)"
     />
   </Target>
+
+  <Target Name="_PrepareLlvmItems">
+    <ItemGroup>
+      <_LlvmSourceFile Include="$(LlvmSourceFullPath)\lib\**\*.cpp" />
+      <_LlvmHeaderFile Include="$(LlvmSourceFullPath)\lib\**\*.h" />
+      <_LlvmMakefileConfig Include="@(_LlvmRuntime->'$(_LlvmOutputDirTop)\%(BuildDir)\Makefile.config')" />
+      <_LlvmConfigureStamp Include="@(_LlvmRuntime->'$(_LlvmOutputDirTop)\%(BuildDir)\.stamp-configure')" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_LlvmArchive Include="$(_LlvmOutputDirTop)\%(_LlvmRuntime.BuildDir)\Release\lib\*.a" />
+
+      <_LlvmSourceBinary Include="@(_LlvmRuntime->'$(_LlvmOutputDirTop)\%(BuildDir)\Release\bin\opt%(ExeSuffix)')" Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' " />
+      <_LlvmTargetBinary Include="@(_LlvmRuntime->'$(OutputPath)\bin\opt%(ExeSuffix)')" Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' "/>
+
+      <_LlvmSourceBinary Include="@(_LlvmRuntime->'$(_LlvmOutputDirTop)\%(BuildDir)\Release\bin\llc%(ExeSuffix)')" Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' " />
+      <_LlvmTargetBinary Include="@(_LlvmRuntime->'$(OutputPath)\bin\llc%(ExeSuffix)')" Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' " />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_ConfigureLlvm"
+          DependsOnTargets="_PrepareLlvmItems"
+          Inputs="$(LlvmSourceFullPath)\Makefile.config.in;$(LlvmSourceFullPath)\configure;@(_LlvmSourceFile);@(_LlvmHeaderFile)"
+          Outputs="@(_LlvmMakefileConfig);@(_LlvmConfigureStamp)"
+          Condition=" $(_LlvmNeeded) != '' ">
+    <MakeDir Directories="$(_LlvmOutputDirTop)\%(_LlvmRuntime.BuildDir)" />
+    <Exec
+        Command="%(_LlvmRuntime.ConfigureEnvironment) $(LlvmSourceFullPath)\configure %(_LlvmRuntime.ConfigureFlags)"
+        WorkingDirectory="$(_LlvmOutputDirTop)\%(_LlvmRuntime.BuildDir)"
+    />
+    <Touch
+        Files="$(_LlvmOutputDirTop)\%(_LlvmRuntime.BuildDir)\Makefile.config"
+    />
+    <Touch
+        Files="$(_LlvmOutputDirTop)\%(_LlvmRuntime.BuildDir)\.stamp-configure"
+        AlwaysCreate="true"
+    />
+  </Target>
+  
+  <Target Name="_BuildLlvm"
+          DependsOnTargets="_ConfigureLlvm"
+          Inputs="@(_LlvmConfigureStamp);@(_LlvmSourceFile);@(_LlvmHeaderFile)"
+          Outputs="@(_LlvmArchive);@(_LlvmSourceBinary)"
+          Condition=" '$(_LlvmNeeded)' != '' ">
+    <Exec
+        Command="%(_LlvmRuntime.BuildEnvironment) make $(MakeConcurrency) all install"
+        WorkingDirectory="$(_LlvmOutputDirTop)\%(_LlvmRuntime.BuildDir)"
+        />
+    <Touch
+        Files="@(_LlvmArchive);@(_LlvmTargetBinary)"
+        />
+  </Target>
+
+  <Target Name="_InstallLlvm"
+          DependsOnTargets="_BuildLlvm"
+          Inputs="@(_LlvmSourceBinary)"
+          Outputs="@(_LlvmTargetBinary)"
+          Condition=" '$(_LlvmNeeded)' != '' ">
+    <Copy
+        SourceFiles="@(_LlvmSourceBinary)"
+        DestinationFolder="$(OutputPath)\bin" />
+    <Touch
+        Files="@(_LlvmTargetBinary)" />
+  </Target>
+
   <Target Name="_Autogen"
       DependsOnTargets="_SetAutogenShTimeToLastCommitTimestamp"
       Inputs="$(MonoSourceFullPath)\autogen.sh"
@@ -82,63 +147,71 @@
     />
   </Target>
   <Target Name="_ConfigureRuntimes"
+      DependsOnTargets="_BuildLlvm"
       Inputs="$(MonoSourceFullPath)\configure"
-      Outputs="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\Makefile')">
-    <MakeDir Directories="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)')" />
+      Outputs="$(IntermediateOutputPath)\%(_MonoRuntime.Identity)\Makefile">
+    <MakeDir Directories="$(IntermediateOutputPath)\%(_MonoRuntime.Identity)" />
     <Exec
         Command="$(MonoSourceFullPath)\configure LDFLAGS=&quot;%(_MonoRuntime.LdFlags)&quot; CFLAGS=&quot;%(_MonoRuntime.CFlags)&quot; CXXFLAGS=&quot;%(_MonoRuntime.CxxFlags)&quot; CC=&quot;%(_MonoRuntime.Cc)&quot; CXX=&quot;%(_MonoRuntime.Cxx)&quot; CPP=&quot;%(_MonoRuntime.Cpp)&quot; CXXCPP=&quot;%(_MonoRuntime.CxxCpp)&quot; LD=&quot;%(_MonoRuntime.Ld)&quot; AR=&quot;%(_MonoRuntime.Ar)&quot; AS=&quot;%(_MonoRuntime.As)&quot; RANLIB=&quot;%(_MonoRuntime.RanLib)&quot; STRIP=&quot;%(_MonoRuntime.Strip)&quot; DLLTOOL=&quot;%(_MonoRuntime.DllTool)&quot; OBJDUMP=&quot;%(_MonoRuntime.Objdump)&quot; --cache-file=..\%(_MonoRuntime.Identity).config.cache %(_MonoRuntime.ConfigureFlags)"
-        WorkingDirectory="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)')"
+        WorkingDirectory="$(IntermediateOutputPath)\%(_MonoRuntime.Identity)"
     />
     <Touch
-        Files="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\.stamp')"
+        Files="$(IntermediateOutputPath)\%(_MonoRuntime.Identity)\.stamp"
         AlwaysCreate="True"
     />
   </Target>
   <Target Name="_GetRuntimesOutputItems">
     <ItemGroup>
-      <_RuntimeLibraries                Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\mono\mini\.libs\%(OutputRuntimeFilename).%(NativeLibraryExtension)')" />
-      <_InstallRuntimesOutputs          Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntimeFilename).%(NativeLibraryExtension)')" />
-      <_InstallUnstrippedRuntimeOutputs Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntimeFilename).d.%(NativeLibraryExtension)')" />
+      <_RuntimeLibraries                Condition=" '%(_MonoRuntime.DoBuild)' == 'true' " Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\mono\mini\.libs\%(OutputRuntimeFilename).%(NativeLibraryExtension)')" />
+      <_InstallRuntimesOutputs          Condition=" '%(_MonoRuntime.DoBuild)' == 'true' " Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntimeFilename).%(NativeLibraryExtension)')" />
+      <_InstallUnstrippedRuntimeOutputs Condition=" '%(_MonoRuntime.DoBuild)' == 'true' " Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntimeFilename).d.%(NativeLibraryExtension)')" />
       <_RuntimeLibraries
-          Condition=" '%(_MonoRuntime.OutputProfilerFilename)' != '' "
+          Condition=" '%(_MonoRuntime.DoBuild)' == 'true' And '%(_MonoRuntime.OutputProfilerFilename)' != '' "
           Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\mono\profiler\.libs\%(OutputProfilerFilename).%(NativeLibraryExtension)')"
       />
       <_InstallRuntimesOutputs
-          Condition=" '%(_MonoRuntime.OutputProfilerFilename)' != '' "
+          Condition=" '%(_MonoRuntime.DoBuild)' == 'true' And '%(_MonoRuntime.OutputProfilerFilename)' != '' "
           Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputProfilerFilename).%(NativeLibraryExtension)')"
       />
-      <_RuntimeLibraries        Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\support\.libs\%(OutputMonoPosixHelperFilename).%(NativeLibraryExtension)')" />
-      <_InstallRuntimesOutputs  Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputMonoPosixHelperFilename).%(NativeLibraryExtension)')" />
+      <_RuntimeLibraries        Condition=" '%(_MonoRuntime.DoBuild)' == 'true' " Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\support\.libs\%(OutputMonoPosixHelperFilename).%(NativeLibraryExtension)')" />
+      <_InstallRuntimesOutputs  Condition=" '%(_MonoRuntime.DoBuild)' == 'true' " Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputMonoPosixHelperFilename).%(NativeLibraryExtension)')" />
+      <_RuntimeBuildStamp       Condition=" '%(_MonoRuntime.DoBuild)' == 'true' " Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\.stamp')" />
     </ItemGroup>
   </Target>
   <Target Name="_BuildRuntimes"
       DependsOnTargets="_GetRuntimesOutputItems"
-      Inputs="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\.stamp')"
-      Outputs="@(_RuntimeLibraries);@(_BclProfileItems)">
+      Inputs="%(_RuntimeBuildStamp.Identity)"
+      Outputs="%(_RuntimeLibraries.Identity);@(_BclProfileItems)">
     <Exec
-        Command="make $(MAKEFLAGS) # %(_MonoRuntime.Identity)"
-        WorkingDirectory="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)')"
+        Condition=" '%(_MonoRuntime.DoBuild)' == 'true' "
+        Command="make $(MakeConcurrency) # %(_MonoRuntime.Identity)"
+        WorkingDirectory="$(IntermediateOutputPath)\%(_MonoRuntime.Identity)"
     />
     <Touch
-        Files="@(_RuntimeLibraries);@(_BclProfileItems)"
+        Files="%(_RuntimeLibraries.Identity);@(_BclProfileItems)"
     />
   </Target>
   <Target Name="_InstallRuntimes"
       DependsOnTargets="_GetRuntimesOutputItems"
-      Inputs="@(_RuntimeLibraries)"
-      Outputs="@(_InstallRuntimesOutputs);@(_InstallUnstrippedRuntimeOutputs)">
-    <MakeDir Directories="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)')" />
+      Inputs="%(_RuntimeLibraries.Identity)"
+      Outputs="%(_InstallRuntimesOutputs.Identity);%(_InstallUnstrippedRuntimeOutputs.Identity)">
+    <MakeDir
+        Condition=" '%(_MonoRuntime.DoBuild)' == 'true' "
+        Directories="$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(_MonoRuntime.Identity)"
+        />
     <Copy
+        Condition=" '%(_MonoRuntime.DoBuild)' == 'true' "
         SourceFiles="@(_RuntimeLibraries)"
         DestinationFiles="@(_InstallRuntimesOutputs)"
     />
     <Copy
-        SourceFiles="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\mono\mini\.libs\%(OutputRuntimeFilename).%(NativeLibraryExtension)')"
-        DestinationFiles="@(_InstallUnstrippedRuntimeOutputs)"
+        Condition=" '%(_MonoRuntime.DoBuild)' == 'true' "
+        SourceFiles="$(IntermediateOutputPath)\%(_MonoRuntime.Identity)\mono\mini\.libs\%(_MonoRuntime.OutputRuntimeFilename).%(_MonoRuntime.NativeLibraryExtension)"
+        DestinationFiles="%(_InstallUnstrippedRuntimeOutputs.Identity)"
     />
     <Exec
-        Condition=" '$(Configuration)' != 'Debug' "
-        Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntimeFilename).%(NativeLibraryExtension)&quot;"
+        Condition=" '$(Configuration)' != 'Debug' And '%(_MonoRuntime.DoBuild)' == 'true' "
+        Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(_MonoRuntime.Identity)\%(_MonoRuntime.OutputRuntimeFilename).%(_MonoRuntime.NativeLibraryExtension)&quot;"
     />
     <Touch
         Files="@(_InstallRuntimesOutputs);@(_InstallUnstrippedRuntimeOutputs)"
@@ -186,9 +259,81 @@
         Overwrite="True"
     />
   </Target>
+
+  <!-- The condition below is to work around a bug in xbuild which attempts to batch
+       even if there are no _MonoCrossRuntime items and the Copy task fails
+  -->
+  <Target Name="_ConfigureCrossRuntimes"
+          DependsOnTargets="_BuildLlvm"
+          Inputs="$(MonoSourceFullPath)\configure"
+          Outputs="$(IntermediateOutputPath)%(_MonoCrossRuntime.Identity)\Makefile;$(IntermediateOutputPath)%(_MonoCrossRuntime.Identity)\.stamp"
+          Condition=" '@(_MonoCrossRuntime)' != '' ">
+    <MakeDir Directories="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)" />
+    <Exec
+        Command="%(_MonoCrossRuntime.ConfigureEnvironment) $(MonoSourceFullPath)\configure LDFLAGS=&quot;%(_MonoCrossRuntime.LdFlags)&quot; CFLAGS=&quot;%(_MonoCrossRuntime.CFlags)&quot; CXXFLAGS=&quot;%(_MonoCrossRuntime.CxxFlags)&quot; CC=&quot;%(_MonoCrossRuntime.Cc)&quot; CXX=&quot;%(_MonoCrossRuntime.Cxx)&quot; CPP=&quot;%(_MonoCrossRuntime.Cpp)&quot; CXXCPP=&quot;%(_MonoCrossRuntime.CxxCpp)&quot; LD=&quot;%(_MonoCrossRuntime.Ld)&quot; AR=&quot;%(_MonoCrossRuntime.Ar)&quot; AS=&quot;%(_MonoCrossRuntime.As)&quot; RANLIB=&quot;%(_MonoCrossRuntime.RanLib)&quot; STRIP=&quot;%(_MonoCrossRuntime.Strip)&quot; DLLTOOL=&quot;%(_MonoCrossRuntime.DllTool)&quot; OBJDUMP=&quot;%(_MonoCrossRuntime.Objdump)&quot; --cache-file=..\%(_MonoCrossRuntime.Identity).config.cache %(_MonoCrossRuntime.ConfigureFlags)"
+        WorkingDirectory="$(IntermediateOutputPath)%(_MonoCrossRuntime.Identity)"
+    />
+    <Touch
+        Files="$(IntermediateOutputPath)%(_MonoCrossRuntime.Identity)\.stamp"
+        AlwaysCreate="True"
+    />
+  </Target>
+  
+  <Target Name="_GenerateCrossOffsetHeaderFiles"
+      Inputs="$(MonoSourceFullPath)\configure"
+      Outputs="%(_MonoCrossRuntime.OffsetsHeader)"
+      Condition=" '$(HostOS)' != 'Linux' And '@(_MonoCrossRuntime)' != '' ">
+    <Exec
+        Command="make $(_AotOffsetsDumperName)"
+        WorkingDirectory="$(_AotOffsetsDumperSourceDir)" 
+    />
+    <Exec
+        Command="MONO_PATH=$(_AotOffsetsDumperSourceDir)\CppSharp $(ManagedRuntime) $(_AotOffsetsDumperSourceDir)\$(_AotOffsetsDumperName) --xamarin-android --android-ndk=&quot;$(AndroidNdkFullPath)&quot; --mono=&quot;$(MonoSourceFullPath)&quot; --monodroid=&quot;$(XamarinAndroidSourcePath)&quot; --abi=&quot;%(_MonoCrossRuntime.TargetAbi)&quot; --out=&quot;$(MSBuildThisFileDirectory)$(IntermediateOutputPath)%(_MonoCrossRuntime.Identity)&quot;"
+        WorkingDirectory="$(IntermediateOutputPath)%(_MonoCrossRuntime.Identity)" 
+    />
+    <Touch
+        Files="$(IntermediateOutputPath)%(_MonoCrossRuntime.Identity)\%(_MonoCrossRuntime.OffsetsHeaderFile)" 
+    />
+  </Target>
+
+
+  <!-- The condition below is to work around a bug in xbuild which attempts to batch
+       even if there are no _MonoCrossRuntime items and the Copy task fails
+  -->
+  <Target Name="_BuildCrossRuntimes"
+      DependsOnTargets="_GenerateCrossOffsetHeaderFiles"
+      Inputs="$(IntermediateOutputPath)%(_MonoCrossRuntime.Identity)\.stamp"
+      Outputs="$(IntermediateOutputPath)%(_MonoCrossRuntime.Identity)\mono\mini\mono-sgen%(_MonoCrossRuntime.ExeSuffix)"
+      Condition=" '@(_MonoCrossRuntime)' != '' ">
+    <Message Text="Building %(_MonoCrossRuntime.Identity) in $(IntermediateOutputPath)%(_MonoCrossRuntime.Identity)"/>
+    <Exec
+        Command="%(_MonoCrossRuntime.BuildEnvironment) make $(MakeConcurrency)"
+        WorkingDirectory="$(IntermediateOutputPath)%(_MonoCrossRuntime.Identity)"
+    />
+    <Touch
+        Files="$(IntermediateOutputPath)%(_MonoCrossRuntime.Identity)\mono\mini\mono-sgen%(_MonoCrossRuntime.ExeSuffix)"
+    />
+  </Target>
+
+  <!-- The condition below is to work around a bug in xbuild which attempts to batch
+       even if there are no _MonoCrossRuntime items and the Copy task fails
+  -->
+  <Target Name="_InstallCrossRuntimes"
+      Inputs="$(IntermediateOutputPath)%(_MonoCrossRuntime.Identity)\mono\mini\mono-sgen%(_MonoCrossRuntime.ExeSuffix)"
+      Outputs="$(OutputPath)bin\%(_MonoCrossRuntime.CrossMonoName)"
+      Condition=" '@(_MonoCrossRuntime)' != '' ">
+    <MakeDir Directories="$(OutputPath)bin\" />
+    <Copy
+        SourceFiles="$(IntermediateOutputPath)%(_MonoCrossRuntime.Identity)\mono\mini\mono-sgen%(_MonoCrossRuntime.ExeSuffix)"
+        DestinationFiles="$(OutputPath)bin\%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)" 
+    />
+    <Touch
+        Files="$(OutputPath)bin\%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)" 
+    />
+  </Target>
   <Target Name="_CleanRuntimes"
       AfterTargets="Clean">
-    <RemoveDir Directories="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)')" />
-    <Delete Files="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity).config.cache')" />
+    <RemoveDir Directories="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)');@(_MonoCrossRuntime->'$(IntermediateOutputPath)\%(Identity)');$(_LlvmBuildDir32);$(_LlvmBuildDir64);$(_LlvmBuildDirWin32);$(_LlvmBuildDirWin64)" />
+    <Delete Files="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity).config.cache');$(_CrossOutputPrefix)*.config.cache;$(_CrossOutputDirTop)\llvm*.config.cache" />
   </Target>
 </Project>

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -22,6 +22,15 @@ ALL_HOST_ABIS = \
 	$(shell uname) \
 	mxe-Win64
 
+ALL_AOT_ABIS = \
+	armeabi \
+	win-armeabi \
+	arm64 \
+	win-arm64 \
+	x86 \
+	win-x86 \
+	x86_64 \
+	win-x86_64
 
 _space :=
 _space +=
@@ -33,7 +42,8 @@ join-with = $(subst $(_space),$(1),$(strip $(2)))
 
 _MSBUILD_ARGS	= \
 	/p:AndroidSupportedTargetJitAbis=$(call join-with,:,$(ALL_JIT_ABIS)) \
-	/p:AndroidSupportedHostJitAbis=$(call join-with,:,$(ALL_HOST_ABIS))
+	/p:AndroidSupportedHostJitAbis=$(call join-with,:,$(ALL_HOST_ABIS)) \
+	/p:AndroidSupportedTargetAotAbis=$(call join-with,:,$(ALL_AOT_ABIS))
 
 TASK_ASSEMBLIES = \
 	bin/Debug/lib/xbuild/Xamarin/Android/Xamarin.Android.Build.Tasks.dll    \

--- a/build-tools/scripts/generate-os-info
+++ b/build-tools/scripts/generate-os-info
@@ -1,0 +1,123 @@
+#!/bin/bash -e
+
+function die()
+{
+    echo $*
+    exit 1
+}
+
+#
+# *ALL* of the HOST_* variables found below must be set
+#
+# Notes:
+#
+#  HOST_CC and HOST_CXX are generic compiler names, without any parameters. The name is
+#  required by the build targets to check for the compiler presence on the system and
+#  the way the task is constructed it requires an existing binary name.
+#
+#  If your OS requires any specific variables, prefix them with the capitalized OS name,
+#  for instance `LINUX_MY_VARIABLE`
+#
+function getMingwSearchDir_Linux()
+{
+    echo `$1 -print-search-dirs | grep install: | cut -d ':' -f 2 | tr -d ' '`
+}
+
+function getInfo_Linux()
+{
+    local CONFIG_GUESS=/usr/share/misc/config.guess
+    local uses_clang=no
+    local compiler_version="`cc --version | tr -d '\n'`"
+
+    lsb_release > /dev/null 2>&1 || die "Your Linux does not have a working 'lsb_release' command"
+
+    if [ ! -x $CONFIG_GUESS ]; then
+        die "Your Linux does not have the '$CONFIG_GUESS' script. Missing the autotools-dev package?"
+    fi
+    OS_NAME="`lsb_release -is`"
+    OS_RELEASE="`lsb_release -rs`"
+    HOST_CPUS="`nproc`"
+
+    if echo $compiler_version | grep -i "Free Software Foundation" > /dev/null 2>&1; then
+        HOST_CC=gcc
+        HOST_CXX=g++
+    elif echo $compiler_version | grep -i clang > /dev/null 2>&1; then
+        uses_clang=yes
+        HOST_CC=clang
+        HOST_CXX=clang++
+    else
+        HOST_CC=cc
+        HOST_CXX=c++
+    fi
+
+    if [ "x$ARCHITECTURE_BITS" = "x64" ]; then
+        HOST_CC64="$HOST_CC"
+        HOST_CXX64="$HOST_CXX"
+        HOST_CC32="$HOST_CC -m32"
+        HOST_CXX32="$HOST_CXX -m32"
+        HOST_TRIPLET32="`i386 $CONFIG_GUESS`"
+        HOST_TRIPLET64="`$CONFIG_GUESS`"
+        HOST_TRIPLET="$HOST_TRIPLET64"
+    else
+        HOST_CC32="$HOST_CC"
+        HOST_CXX32="$HOST_CXX"
+        HOST_CC64=false
+        HOST_CXX64=false
+        HOST_TRIPLET32="`$CONFIG_GUESS`"
+        HOST_TRIPLET64="false"
+        HOST_TRIPLET="$HOST_TRIPLET32"
+    fi
+}
+
+function getInfo_Darwin()
+{
+    local PLIST_BUDDY=/usr/libexec/PlistBuddy
+    local VERSION_PLIST=/System/Library/CoreServices/SystemVersion.plist
+
+    if [ ! -x $PLIST_BUDDY ]; then
+        die "Your Mac does not have the '$PLIST_BUDDY' command"
+    fi
+    OS_NAME="`$PLIST_BUDDY -c 'Print :ProductName' $VERSION_PLIST`"
+    OS_RELEASE="`$PLIST_BUDDY -c 'Print :ProductVersion' $VERSION_PLIST`"
+    HOST_TRIPLET64=x86_64-apple-darwin11.2.0
+    HOST_TRIPLET32=i386-apple-darwin11.2.0
+    HOST_TRIPLET="$HOST_TRIPLET64"
+    HOST_CPUS="`sysctl hw.ncpu | cut -d ':' -f 2 | tr -d ' '`"
+    HOST_CC32="clang -m32"
+    HOST_CXX32="clang++ -m32"
+    HOST_CC64=clang
+    HOST_CXX64=clang++
+}
+
+if [ -z "$1" ]; then
+    die Usage: generate-os-info OUTPUT_FILE_PATH
+fi
+#
+# Generic values available across all Unix systems
+#
+ARCHITECTURE_BITS=`getconf LONG_BIT`
+OS_TYPE="`uname -s`"
+
+eval getInfo_$OS_TYPE || die "Your operating system is not supported."
+
+cat <<EOF > "$1"
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <HostOS Condition=" '\$(HostOS)' == '' ">$OS_TYPE</HostOS>
+        <HostOsName Condition=" '\$(HostOsName)' == '' ">$OS_NAME</HostOsName>
+        <HostOsRelease Condition=" '\$(HostOsRelease)' == '' ">$OS_RELEASE</HostOsRelease>
+        <HostTriplet Condition=" '\$(HostTriplet)' == '' ">$HOST_TRIPLET</HostTriplet>
+        <HostTriplet32 Condition=" '\$(HostTriplet32)' == '' ">$HOST_TRIPLET32</HostTriplet32>
+        <HostTriplet64 Condition=" '\$(HostTriplet64)' == '' ">$HOST_TRIPLET64</HostTriplet64>
+        <HostCpuCount Condition=" '\$(HostCpuCount)' == '' ">$HOST_CPUS</HostCpuCount>
+        <HostBits Condition=" '\$(HostBits)' == '' ">$ARCHITECTURE_BITS</HostBits>
+        <HostCcName Condition=" '\$(HostCcName)' == '' ">$HOST_CC</HostCcName>
+        <HostCxxName Condition=" '\$(HostCxxName)' == '' ">$HOST_CXX</HostCxxName>
+        <HostCc32 Condition=" '\$(HostCc32)' == '' ">$HOST_CC32</HostCc32>
+        <HostCc64 Condition=" '\$(HostCc64)' == '' ">$HOST_CC64</HostCc64>
+        <HostCxx32 Condition=" '\$(HostCxx32)' == '' ">$HOST_CXX32</HostCxx32>
+        <HostCxx64 Condition=" '\$(HostCxx64)' == '' ">$HOST_CXX64</HostCxx64>
+    </PropertyGroup>
+</Project>
+EOF


### PR DESCRIPTION
The commit implements building of LLVM and cross-compilers to support
Xamarin.Android/Mono AOT. LLVM and cross-compilers can be built for
both the host platform (Linux and OS/X at the moment) as well as
cross-compiled for 32-bit and 64-bit Windows platforms.

Windows builds are done with MXE toolchain on OS/X and with the packaged
mingw-w64 toolchain on Linux (tested on Ubuntu 16.04 ONLY).

Also introducing a new set of MSBuild properties that contain information
about the host system. Some of those properties (HostOS, HostCC, HostCXX
for instance) have been moved from Configuration.props to better support
auto-detection. A new script, build-tools/scripts/generate-os-info, is
invoked as part of `make prepare` to generate file that contains the
new properties. The generated file is required for the build to work and
is also host-specific (it mustn't be moved between different machines)

Cross compiler builds require access to a configured Mono build tree, in
order to generate C structure offsets header file that is used by the AOT
compilers to properly generate AOT-ed binaries. Therefore, even if a JIT
target is not enabled in the configuration, enabling a cross-compiler for
some target will configure Mono for that JIT target but it will NOT build
it, to save time. To facilitate this, the _MonoRuntimes items defined in
build-tools/mono-runtimes/mono-runtimes.projitems gain an additional metadata
item called `DoBuild` which will be set to `true` if the runtime actually needs
to be built, as opposed to just configured.

MXE builds are disabled on Linux as mingw-w64 works just fine.

A `make prepare` warning is issued for Linux hosts which have the binfmt_misc
module enabled and either Wine of Mono (cli) registered as PE32/PE32+ binary
interpreters. In such instance building of the Windows cross-compilers will
fail because Autotools determine whether software is being cross compiled by
building a test program and attempting to execute it. In normal circumstances
such an attempt will fail, but with Windows cross-compilation and either Wine
or Mono registered to handle the PE32 executables this attempt will succeed
thus causing the cross compilation detection to fail.

Currently to build cross compilers on Linux you need to generate the C structure
offsets header file on OS/X and copy the resulting headers to appropriate places
on Linux. The header files should be placed in

  build-tools/mono-runtimes/obj/Debug/cross-*/

directories. The header files are:

   {cross-arm,cross-arm-win}/aarch64-v8a-linux-android.h
   {cross-arm64,cross-arm64-win}/armv5-none-linux-androideabi.h
   {cross-x86,cross-x86-win}/i686-none-linux-android.h
   {cross-x86_64,cross-x86_64-win}/x86_64-none-linux-android.h

Offsets header generation doesn't work on Linux atm because of missing support
for it in the Mono utility used to generate the offsets. Hopefully this limitation
will be removed in the near future and a start-to-end build of everything will be
possible on Linux.

It is now mandatory to run at least `make prepare-props` before Xamarin.Android
can be built. The target generates the OS-specific props file which is required
by the build. `make prepare` depends on the target.