### PR TITLE
[Xamarin.Android.Build.Tasks] .targets file should be an Inputs to cache-generating tasks

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -539,7 +539,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </Target>
 
 <Target Name="_BuildSdkCache"
-	Inputs="$(MSBuildProjectFullPath);$(_AndroidBuildPropertiesCache)"
+	Inputs="$(MSBuildProjectFullPath);$(_AndroidBuildPropertiesCache);$(MSBuildThisFileFullPath)"
 	Outputs="$(_AndroidSdksCache)"
 	DependsOnTargets="_GetReferenceAssemblyPaths">
 	<ResolveSdks


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=42671

When Xamarin.Android is updted we really should invalidate the
sdk cache just in case things changes/updated.

This commit adds the `Xamarin.Android.Common.targets` to the
list of inputs for the `_BuildSdkCache` target. This means if
the .targets file is newer than the Sdk cache it will auto
rebuild it.