### PR TITLE
[msbuild] Fix Android N version identifier.

### DIFF
--- a/src/Xamarin.Android.Build.Utilities/AndroidVersion.cs
+++ b/src/Xamarin.Android.Build.Utilities/AndroidVersion.cs
@@ -101,7 +101,7 @@ namespace Xamarin.Android.Build.Utilities
 			new AndroidVersion (21, "5.0",   "Lollipop",                new Version (5, 0)),
 			new AndroidVersion (22, "5.1",   "Lollipop",                new Version (5, 1)),
 			new AndroidVersion (23, "6.0",   "Marshmallow",             new Version (6, 0)),
-			new AndroidVersion (24, "6.0.99",   "N Preview",             new Version (6, 0, 99)),
+			new AndroidVersion (24, "7.0",   "Nougat",                  new Version (7, 0)),
 		};
 	}
 }


### PR DESCRIPTION
Since we don't build 6.0.99 anymore, it simply fails to lookup Android N
because our MSBuild tasks still tries to find 6.0.99 because of this code.