### PR TITLE
[build] Ensure submodules init'd before using them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,12 @@ endif
 all:
 	$(MSBUILD)
 
-prepare:: prepare-props
+prepare:: prepare-external prepare-props
+
+prepare-external:
 	git submodule update --init --recursive
 	nuget restore
-	(cd external/Java.Interop && nuget restore)
+	(cd `$(MSBUILD) /nologo /v:minimal /t:GetJavaInteropFullPath build-tools/scripts/Paths.targets` && nuget restore)
 
 prepare-props:
 	cp Configuration.Java.Interop.Override.props external/Java.Interop/Configuration.Override.props

--- a/build-tools/scripts/Paths.targets
+++ b/build-tools/scripts/Paths.targets
@@ -13,6 +13,12 @@
         Importance="High"
     />
   </Target>
+  <Target Name="GetJavaInteropFullPath">
+    <Message
+        Text="$(JavaInteropFullPath)"
+        Importance="High"
+    />
+  </Target>
   <Target Name="GetMonoSourceFullPath">
     <Message
         Text="$(MonoSourceFullPath)"


### PR DESCRIPTION
`make jenkins` after a fresh checkout was failing:

	$ make jenkins
	cp Configuration.Java.Interop.Override.props external/Java.Interop/Configuration.Override.props
	./build-tools/scripts/generate-os-info Configuration.OperatingSystem.props
	cp `xbuild /p:Configuration=Debug  /nologo /v:minimal /t:GetMonoSourceFullPath build-tools/scripts/Paths.targets`/mcs/class/msfinal.pub .
	cp: /Volumes/Seagate4TB/work/xamarin-android/external/mono/mcs/class/msfinal.pub: No such file or directory
	make: *** [prepare-props] Error 1

The reason it failed is because `make prepare-props` ran *before*
`git submodule update` ran, meaning the file
`external/mono/mcs/class/msfinal.pub` didn't exist yet.

Move the git submodule initialization logic into a new
`make prepare-external` target, which is run before
`make prepare-props`. This ensures that required files exist before
they are used.

Additionally, fix the `make prepare-external` logic so that if the
`$(JavaInteropSourceDirectory)` MSBuild property is overridden, we run
`nuget restore` from the appropriate directory.