### PR TITLE
[linker] Preserve TransparentProxy::StoreRemoteField

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/PreserveLists/mscorlib.xml
+++ b/src/Xamarin.Android.Build.Tasks/Linker/PreserveLists/mscorlib.xml
@@ -324,6 +324,7 @@
 		</type>
 		<type fullname="System.Runtime.Remoting.Proxies.TransparentProxy" preserve="fields">
 			<method name="LoadRemoteFieldNew" />
+			<method name="StoreRemoteField" />
 		</type>
 		<type fullname="System.Runtime.Remoting.RemotingServices">
 			<method name="SerializeCallData" />


### PR DESCRIPTION
It's called from the Mono runtime starting with mono/mono@6b8e96c