### PR TITLE
preserve Link action for assemblies

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/PreserveDynamicTypes.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/PreserveDynamicTypes.cs
@@ -19,6 +19,14 @@ namespace Mono.Tuner {
 		bool preserve_dynamic;
 		List<AssemblyDefinition> saved = new List<AssemblyDefinition> ();
 
+		void PreserveLibrary (AssemblyDefinition assembly)
+		{
+			var action = Annotations.GetAction (assembly);
+			ResolveFromAssemblyStep.ProcessLibrary (context, assembly);
+			if (action == AssemblyAction.Link)
+				Annotations.SetAction (assembly, action);
+		}
+
 		public override void ProcessAssembly (AssemblyDefinition assembly)
 		{
 			// Preserve dynamic dependencies only when Microsoft.CSharp is referenced.
@@ -26,13 +34,13 @@ namespace Mono.Tuner {
 			case "Microsoft.CSharp":
 				preserve_dynamic = true;
 				foreach (var savedAssembly in saved)
-					ResolveFromAssemblyStep.ProcessLibrary (context, savedAssembly);
-				ResolveFromAssemblyStep.ProcessLibrary (context, assembly);
+					PreserveLibrary (savedAssembly);
+				PreserveLibrary (assembly);
 				break;
 			case "Mono.CSharp":
 			case "System.Core":
 				if (preserve_dynamic)
-					ResolveFromAssemblyStep.ProcessLibrary (context, assembly);
+					PreserveLibrary (assembly);
 				else
 					saved.Add (assembly);
 				break;


### PR DESCRIPTION
 - so that they are rewritten with the resolved references

 - fixes bug #42788

   the issue in this bug looks like this:

   [mscorlib]System.MonoTODOAttribute is referenced from
   System.Core.dll.

   because ResolveFromAssemblyStep.ProcessLibrary sets the action to
   Copy, the System.Core.dll is only copied from original place and
   not saved with resolved references.

   the System.MonoTODOAttribute resolves to reference inside the
   Microsoft.CSharp.dll assembly (where it is kept, it is stripped
   from mscorlib) and thus the reflection fails at runtime, when tries
   to load System.Core.dll assembly