### PR TITLE
[build] Build the monodroid-profile BCL assemblies reliably

### DIFF
--- a/build-tools/mono-runtimes/mono-runtimes.projitems
+++ b/build-tools/mono-runtimes/mono-runtimes.projitems
@@ -167,6 +167,7 @@
       <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
       <OutputProfilerFilename></OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
+      <DoBuild>True</DoBuild>
     </_MonoRuntime>
     <_MonoRuntime Include="host-Darwin" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">
       <Ar>ar</Ar>
@@ -186,6 +187,7 @@
       <NativeLibraryExtension>dylib</NativeLibraryExtension>
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
+      <DoBuild>True</DoBuild>
     </_MonoRuntime>
     <_MonoRuntime Include="host-Linux" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:'))">
       <Ar>ar</Ar>
@@ -204,6 +206,7 @@
       <NativeLibraryExtension>so</NativeLibraryExtension>
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
+      <DoBuild>True</DoBuild>
     </_MonoRuntime>
   </ItemGroup>
 
@@ -272,9 +275,8 @@
       <LdFlags></LdFlags>
       <RanLib>ranlib</RanLib>
       <Strip>strip -S</Strip>
-      <TargetAbi>$(_CrossArmTargetAbi)</TargetAbi>
-      <OffsetsHeader>$(_CrossArmTargetAbi).h</OffsetsHeader>
-      <ConfigureFlags>--target=armv5-linux-androideabi --cache-file=$(_CrossConfigureCachePrefix)arm.config.cache --with-cross-offsets=$(_CrossArmOffsetsHeaderFile) $(_CrossConfigureFlags) --with-llvm=$(_CrossDefaultLlvmPrefix)</ConfigureFlags>
+      <TargetAbi>armv5-none-linux-androideabi</TargetAbi>
+      <ConfigureFlags>--target=armv5-linux-androideabi --cache-file=$(_CrossConfigureCachePrefix)arm.config.cache --with-cross-offsets=armv5-none-linux-androideabi.h $(_CrossConfigureFlags) --with-llvm=$(_CrossDefaultLlvmPrefix)</ConfigureFlags>
       <ExeSuffix></ExeSuffix>
       <BuildEnvironment></BuildEnvironment>
       <ConfigureEnvironment></ConfigureEnvironment>
@@ -293,9 +295,8 @@
       <LdFlags></LdFlags>
       <RanLib>ranlib</RanLib>
       <Strip>strip -S</Strip>
-      <TargetAbi>$(_CrossArm64TargetAbi)</TargetAbi>
-      <OffsetsHeader>$(_CrossArm64TargetAbi).h</OffsetsHeader>
-      <ConfigureFlags>--target=aarch64-v8a-linux-android --cache-file=$(_CrossConfigureCachePrefix)arm64.config.cache --with-cross-offsets=$(_CrossArm64OffsetsHeaderFile) $(_CrossConfigureFlags) --with-llvm=$(_CrossDefaultLlvmPrefix)</ConfigureFlags>
+      <TargetAbi>aarch64-v8a-linux-android</TargetAbi>
+      <ConfigureFlags>--target=aarch64-v8a-linux-android --cache-file=$(_CrossConfigureCachePrefix)arm64.config.cache --with-cross-offsets=aarch64-v8a-linux-android.h $(_CrossConfigureFlags) --with-llvm=$(_CrossDefaultLlvmPrefix)</ConfigureFlags>
       <ExeSuffix></ExeSuffix>
       <BuildEnvironment></BuildEnvironment>
       <ConfigureEnvironment></ConfigureEnvironment>
@@ -314,9 +315,8 @@
       <LdFlags></LdFlags>
       <RanLib>ranlib</RanLib>
       <Strip>strip -S</Strip>
-      <TargetAbi>$(_CrossX86TargetAbi)</TargetAbi>
-      <OffsetsHeader>$(_CrossX86TargetAbi).h</OffsetsHeader>
-      <ConfigureFlags>--target=i686-linux-android --cache-file=$(_CrossConfigureCachePrefix)x86.config.cache --with-cross-offsets=$(_CrossX86OffsetsHeaderFile) $(_CrossConfigureFlags)  --with-llvm=$(_LlvmPrefix32)</ConfigureFlags>
+      <TargetAbi>i686-none-linux-android</TargetAbi>
+      <ConfigureFlags>--target=i686-linux-android --cache-file=$(_CrossConfigureCachePrefix)x86.config.cache --with-cross-offsets=i686-none-linux-android.h $(_CrossConfigureFlags)  --with-llvm=$(_LlvmPrefix32)</ConfigureFlags>
       <ExeSuffix></ExeSuffix>
       <BuildEnvironment></BuildEnvironment>
       <ConfigureEnvironment></ConfigureEnvironment>
@@ -335,9 +335,8 @@
       <LdFlags></LdFlags>
       <RanLib>ranlib</RanLib>
       <Strip>strip -S</Strip>
-      <TargetAbi>$(_CrossX8664TargetAbi)</TargetAbi>
-      <OffsetsHeader>$(_CrossX8664TargetAbi).h</OffsetsHeader>
-      <ConfigureFlags>--target=x86_64-linux-android --cache-file=$(_CrossConfigureCachePrefix)x86_64.config.cache --with-cross-offsets=$(_CrossX8664OffsetsHeaderFile) $(_CrossConfigureFlags)  --with-llvm=$(_CrossDefaultLlvmPrefix)</ConfigureFlags>
+      <TargetAbi>x86_64-none-linux-android</TargetAbi>
+      <ConfigureFlags>--target=x86_64-linux-android --cache-file=$(_CrossConfigureCachePrefix)x86_64.config.cache --with-cross-offsets=x86_64-none-linux-android.h $(_CrossConfigureFlags)  --with-llvm=$(_CrossDefaultLlvmPrefix)</ConfigureFlags>
       <ExeSuffix></ExeSuffix>
       <BuildEnvironment></BuildEnvironment>
       <ConfigureEnvironment></ConfigureEnvironment>
@@ -356,9 +355,8 @@
       <LdFlags>-static -static-libgcc</LdFlags>
       <RanLib>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-ranlib</RanLib>
       <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-strip -S</Strip>
-      <TargetAbi>$(_CrossArmTargetAbi)</TargetAbi>
-      <OffsetsHeader>$(_CrossArmTargetAbi).h</OffsetsHeader>
-      <ConfigureFlags>--target=armv5-linux-androideabi --host="$(_CrossConfigureBuildHostWin32)" --cache-file=$(_CrossConfigureCachePrefix)arm-win.config.cache --with-cross-offsets=$(_CrossArmOffsetsHeaderFile) $(_CrossConfigureFlags) --with-llvm=$(_LlvmPrefixWin32)</ConfigureFlags>
+      <TargetAbi>armv5-none-linux-androideabi</TargetAbi>
+      <ConfigureFlags>--target=armv5-linux-androideabi --host="$(_CrossConfigureBuildHostWin32)" --cache-file=$(_CrossConfigureCachePrefix)arm-win.config.cache --with-cross-offsets=armv5-none-linux-androideabi.h $(_CrossConfigureFlags) --with-llvm=$(_LlvmPrefixWin32)</ConfigureFlags>
       <ExeSuffix>.exe</ExeSuffix>
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin32)</ConfigureEnvironment>
@@ -377,9 +375,8 @@
       <LdFlags>-static -static-libgcc -static-libstdc++</LdFlags>
       <RanLib>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-ranlib</RanLib>
       <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-strip -S</Strip>
-      <TargetAbi>$(_CrossArm64TargetAbi)</TargetAbi>
-      <OffsetsHeader>$(_CrossArm64TargetAbi).h</OffsetsHeader>
-      <ConfigureFlags>--target=aarch64-v8a-linux-android --host="$(_CrossConfigureBuildHostWin32)" --cache-file=$(_CrossConfigureCachePrefix)arm64-win.config.cache --with-cross-offsets=$(_CrossArm64OffsetsHeaderFile) $(_CrossConfigureFlags) --with-llvm=$(_LlvmPrefixWin32)</ConfigureFlags>
+      <TargetAbi>aarch64-v8a-linux-android</TargetAbi>
+      <ConfigureFlags>--target=aarch64-v8a-linux-android --host="$(_CrossConfigureBuildHostWin32)" --cache-file=$(_CrossConfigureCachePrefix)arm64-win.config.cache --with-cross-offsets=aarch64-v8a-linux-android.h $(_CrossConfigureFlags) --with-llvm=$(_LlvmPrefixWin32)</ConfigureFlags>
       <ExeSuffix>.exe</ExeSuffix>
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin32)</ConfigureEnvironment>
@@ -398,9 +395,8 @@
       <LdFlags>-static -static-libgcc -static-libstdc++</LdFlags>
       <RanLib>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-ranlib</RanLib>
       <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-strip -S</Strip>
-      <TargetAbi>$(_CrossX86TargetAbi)</TargetAbi>
-      <OffsetsHeader>$(_CrossX86TargetAbi).h</OffsetsHeader>
-      <ConfigureFlags>--target=i686-linux-android --host="$(_CrossConfigureBuildHostWin32)" --cache-file=$(_CrossConfigureCachePrefix)x86-win.config.cache --with-cross-offsets=$(_CrossX86OffsetsHeaderFile) $(_CrossConfigureFlags) --with-llvm=$(_LlvmPrefixWin32)</ConfigureFlags>
+      <TargetAbi>i686-none-linux-android</TargetAbi>
+      <ConfigureFlags>--target=i686-linux-android --host="$(_CrossConfigureBuildHostWin32)" --cache-file=$(_CrossConfigureCachePrefix)x86-win.config.cache --with-cross-offsets=i686-none-linux-android.h $(_CrossConfigureFlags) --with-llvm=$(_LlvmPrefixWin32)</ConfigureFlags>
       <ExeSuffix>.exe</ExeSuffix>
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin32)</ConfigureEnvironment>
@@ -419,9 +415,8 @@
       <LdFlags>-static -static-libgcc -static-libstdc++</LdFlags>
       <RanLib>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-ranlib</RanLib>
       <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-strip -S</Strip>
-      <TargetAbi>$(_CrossX8664TargetAbi)</TargetAbi>
-      <OffsetsHeader>$(_CrossX8664TargetAbi).h</OffsetsHeader>
-      <ConfigureFlags>--target=x86_64-linux-android --host="$(_CrossConfigureBuildHostWin64)" --cache-file=$(_CrossConfigureCachePrefix)x86_64-win.config.cache --with-cross-offsets=$(_CrossX8664OffsetsHeaderFile) $(_CrossConfigureFlags) --with-llvm=$(_LlvmPrefixWin64)</ConfigureFlags>
+      <TargetAbi>x86_64-none-linux-android</TargetAbi>
+      <ConfigureFlags>--target=x86_64-linux-android --host="$(_CrossConfigureBuildHostWin64)" --cache-file=$(_CrossConfigureCachePrefix)x86_64-win.config.cache --with-cross-offsets=x86_64-none-linux-android.h $(_CrossConfigureFlags) --with-llvm=$(_LlvmPrefixWin64)</ConfigureFlags>
       <ExeSuffix>.exe</ExeSuffix>
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin32)</ConfigureEnvironment>

--- a/build-tools/mono-runtimes/mono-runtimes.props
+++ b/build-tools/mono-runtimes/mono-runtimes.props
@@ -104,27 +104,6 @@
     <_LlvmConfigureFlagsWin64>--host="$(_CrossConfigureBuildHostWin64)" $(_LlvmCommonConfigureFlagsWin64)</_LlvmConfigureFlagsWin64>
   </PropertyGroup>
 
-  <!-- Cross-compilers settings -->
-  <PropertyGroup>
-      <_CrossArmTargetAbi>armv5-none-linux-androideabi</_CrossArmTargetAbi>
-      <_CrossArmOffsetsHeaderFile>armv5-none-linux-androideabi.h</_CrossArmOffsetsHeaderFile>
-  </PropertyGroup>
-
-  <PropertyGroup>
-      <_CrossArm64TargetAbi>aarch64-v8a-linux-android</_CrossArm64TargetAbi>
-      <_CrossArm64OffsetsHeaderFile>aarch64-v8a-linux-android.h</_CrossArm64OffsetsHeaderFile>
-  </PropertyGroup>
-
-  <PropertyGroup>
-      <_CrossX86TargetAbi>i686-none-linux-android</_CrossX86TargetAbi>
-      <_CrossX86OffsetsHeaderFile>i686-none-linux-android.h</_CrossX86OffsetsHeaderFile>
-  </PropertyGroup>
-
-  <PropertyGroup>
-      <_CrossX8664TargetAbi>x86_64-none-linux-android</_CrossX8664TargetAbi>
-      <_CrossX8664OffsetsHeaderFile>x86_64-none-linux-android.h</_CrossX8664OffsetsHeaderFile>
-  </PropertyGroup>
-
   <!-- Mono runtimes settings -->
   <PropertyGroup>
     <_ArmNdkPlatformPath>$(AndroidToolchainDirectory)\ndk\platforms\android-4</_ArmNdkPlatformPath>

--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -40,7 +40,6 @@
       <_BclAssembly Include="System.Json.dll"/>
       <_BclAssembly Include="System.Net.dll"/>
       <_BclAssembly Include="System.Net.Http.dll"/>
-      <_BclAssembly Include="System.Net.Http.WebRequest.dll"/>
       <_BclAssembly Include="System.Net.Http.WinHttpHandler.dll"/>
       <_BclAssembly Include="System.Numerics.dll"/>
       <_BclAssembly Include="System.Numerics.Vectors.dll"/>
@@ -162,59 +161,106 @@
   </Target>
   <Target Name="_GetRuntimesOutputItems">
     <ItemGroup>
-      <_RuntimeLibraries                Condition=" '%(_MonoRuntime.DoBuild)' == 'true' " Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\mono\mini\.libs\%(OutputRuntimeFilename).%(NativeLibraryExtension)')" />
-      <_InstallRuntimesOutputs          Condition=" '%(_MonoRuntime.DoBuild)' == 'true' " Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntimeFilename).%(NativeLibraryExtension)')" />
-      <_InstallUnstrippedRuntimeOutputs Condition=" '%(_MonoRuntime.DoBuild)' == 'true' " Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntimeFilename).d.%(NativeLibraryExtension)')" />
-      <_RuntimeLibraries
-          Condition=" '%(_MonoRuntime.DoBuild)' == 'true' And '%(_MonoRuntime.OutputProfilerFilename)' != '' "
+      <_RuntimeSource
+          Condition=" '%(_MonoRuntime.DoBuild)' == 'True' "
+          Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\mono\mini\.libs\%(OutputRuntimeFilename).%(NativeLibraryExtension)')"
+      />
+      <_InstallRuntimeOutput
+          Condition=" '%(_MonoRuntime.DoBuild)' == 'True' "
+          Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntimeFilename).%(NativeLibraryExtension)')"
+      />
+      <_InstallUnstrippedRuntimeOutput
+          Condition=" '%(_MonoRuntime.DoBuild)' == 'True' "
+          Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntimeFilename).d.%(NativeLibraryExtension)')"
+      />
+      <_ProfilerSource
+          Condition=" '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputProfilerFilename)' != '' "
           Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\mono\profiler\.libs\%(OutputProfilerFilename).%(NativeLibraryExtension)')"
       />
-      <_InstallRuntimesOutputs
-          Condition=" '%(_MonoRuntime.DoBuild)' == 'true' And '%(_MonoRuntime.OutputProfilerFilename)' != '' "
+      <_InstallProfilerOutput
+          Condition=" '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputProfilerFilename)' != '' "
           Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputProfilerFilename).%(NativeLibraryExtension)')"
       />
-      <_RuntimeLibraries        Condition=" '%(_MonoRuntime.DoBuild)' == 'true' " Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\support\.libs\%(OutputMonoPosixHelperFilename).%(NativeLibraryExtension)')" />
-      <_InstallRuntimesOutputs  Condition=" '%(_MonoRuntime.DoBuild)' == 'true' " Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputMonoPosixHelperFilename).%(NativeLibraryExtension)')" />
+      <_InstallUnstrippedProfilerOutput
+          Condition=" '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputProfilerFilename)' != '' "
+          Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputProfilerFilename).d.%(NativeLibraryExtension)')"
+      />
+      <_MonoPosixHelperSource
+          Condition=" '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputMonoPosixHelperFilename)' != '' "
+          Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\support\.libs\%(OutputMonoPosixHelperFilename).%(NativeLibraryExtension)')"
+      />
+      <_InstallMonoPosixHelperOutput
+          Condition=" '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputMonoPosixHelperFilename)' != '' "
+          Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputMonoPosixHelperFilename).%(NativeLibraryExtension)')"
+      />
+      <_InstallUnstrippedMonoPosixHelperOutput
+          Condition=" '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputMonoPosixHelperFilename)' != '' "
+          Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputMonoPosixHelperFilename).d.%(NativeLibraryExtension)')"
+      />
       <_RuntimeBuildStamp       Condition=" '%(_MonoRuntime.DoBuild)' == 'true' " Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\.stamp')" />
     </ItemGroup>
   </Target>
   <Target Name="_BuildRuntimes"
       DependsOnTargets="_GetRuntimesOutputItems"
-      Inputs="%(_RuntimeBuildStamp.Identity)"
-      Outputs="%(_RuntimeLibraries.Identity);@(_BclProfileItems)">
+      Inputs="@(_RuntimeBuildStamp)"
+      Outputs="@(_RuntimeSource);@(_ProfilerSource);@(_MonoPosixHelperSource);@(_BclProfileItems)">
     <Exec
         Condition=" '%(_MonoRuntime.DoBuild)' == 'true' "
         Command="make $(MakeConcurrency) # %(_MonoRuntime.Identity)"
         WorkingDirectory="$(IntermediateOutputPath)\%(_MonoRuntime.Identity)"
     />
     <Touch
-        Files="%(_RuntimeLibraries.Identity);@(_BclProfileItems)"
+        Files="@(_RuntimeSource);@(_ProfilerSource);@(_MonoPosixHelperSource);@(_BclProfileItems)"
     />
   </Target>
   <Target Name="_InstallRuntimes"
       DependsOnTargets="_GetRuntimesOutputItems"
-      Inputs="%(_RuntimeLibraries.Identity)"
-      Outputs="%(_InstallRuntimesOutputs.Identity);%(_InstallUnstrippedRuntimeOutputs.Identity)">
+      Inputs="@(_RuntimeSource);@(_ProfilerSource);@(_MonoPosixHelperSource)"
+      Outputs="@(_InstallRuntimesOutput);@(_InstallProfilerOutput);@(_InstallMonoPosixHelperOutput)">
     <MakeDir
         Condition=" '%(_MonoRuntime.DoBuild)' == 'true' "
         Directories="$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(_MonoRuntime.Identity)"
-        />
-    <Copy
-        Condition=" '%(_MonoRuntime.DoBuild)' == 'true' "
-        SourceFiles="@(_RuntimeLibraries)"
-        DestinationFiles="@(_InstallRuntimesOutputs)"
     />
     <Copy
-        Condition=" '%(_MonoRuntime.DoBuild)' == 'true' "
-        SourceFiles="$(IntermediateOutputPath)\%(_MonoRuntime.Identity)\mono\mini\.libs\%(_MonoRuntime.OutputRuntimeFilename).%(_MonoRuntime.NativeLibraryExtension)"
-        DestinationFiles="%(_InstallUnstrippedRuntimeOutputs.Identity)"
+        SourceFiles="@(_RuntimeSource)"
+        DestinationFiles="@(_InstallRuntimeOutput)"
+    />
+    <Copy
+        SourceFiles="@(_RuntimeSource)"
+        DestinationFiles="@(_InstallUnstrippedRuntimeOutput)"
     />
     <Exec
         Condition=" '$(Configuration)' != 'Debug' And '%(_MonoRuntime.DoBuild)' == 'true' "
         Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(_MonoRuntime.Identity)\%(_MonoRuntime.OutputRuntimeFilename).%(_MonoRuntime.NativeLibraryExtension)&quot;"
     />
+
+    <Copy
+        SourceFiles="@(_ProfilerSource)"
+        DestinationFiles="@(_InstallProfilerOutput)"
+    />
+    <Copy
+        SourceFiles="@(_ProfilerSource)"
+        DestinationFiles="@(_InstallUnstrippedProfilerOutput)"
+    />
+    <Exec
+        Condition=" '$(Configuration)' != 'Debug' And '%(_MonoRuntime.DoBuild)' == 'true' And '%(_MonoRuntime.OutputProfilerFilename)' != '' "
+        Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(_MonoRuntime.Identity)\%(_MonoRuntime.OutputProfilerFilename).%(_MonoRuntime.NativeLibraryExtension)&quot;"
+    />
+
+    <Copy
+        SourceFiles="@(_MonoPosixHelperSource)"
+        DestinationFiles="@(_InstallMonoPosixHelperOutput)"
+    />
+    <Copy
+        SourceFiles="@(_MonoPosixHelperSource)"
+        DestinationFiles="@(_InstallUnstrippedMonoPosixHelperOutput)"
+    />
+    <Exec
+        Condition=" '$(Configuration)' != 'Debug' And '%(_MonoRuntime.DoBuild)' == 'true' And '%(_MonoRuntime.OutputMonoPosixHelperFilename)' != '' "
+        Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(_MonoRuntime.Identity)\%(_MonoRuntime.OutputMonoPosixHelperFilename).%(_MonoRuntime.NativeLibraryExtension)&quot;"
+    />
     <Touch
-        Files="@(_InstallRuntimesOutputs);@(_InstallUnstrippedRuntimeOutputs)"
+        Files="@(_InstallRuntimesOutput);@(_InstallProfilerOutput);@(_InstallMonoPosixHelperOutput)"
     />
   </Target>
   <Target Name="_InstallBcl"
@@ -281,7 +327,7 @@
   
   <Target Name="_GenerateCrossOffsetHeaderFiles"
       Inputs="$(MonoSourceFullPath)\configure"
-      Outputs="%(_MonoCrossRuntime.OffsetsHeader)"
+      Outputs="$(IntermediateOutputPath)%(_MonoCrossRuntime.Identity)\%(_MonoCrossRuntime.TargetAbi).h"
       Condition=" '$(HostOS)' != 'Linux' And '@(_MonoCrossRuntime)' != '' ">
     <Exec
         Command="make $(_AotOffsetsDumperName)"

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -20,6 +20,7 @@ ALL_JIT_ABIS  = \
 
 ALL_HOST_ABIS = \
 	$(shell uname) \
+	mxe-Win32 \
 	mxe-Win64
 
 ALL_AOT_ABIS = \


### PR DESCRIPTION
Commit 37b5fd51 broke `make jenkins` (and possible `make all`?)
through the introduction of the `%(_MonoRuntime.DoBuild)` metadata:
`%(_MonoRuntime.DoBuild)` wasn't added everywhere required.
In particular, the `host-Darwin` item didn't gain `<DoBuild/>`,
meaning *`host-Darwin` wasn't built*. This in turn meant that the
monodroid BCL wasn't built (!) which caused a build break much later
within `src/Mono.Android`:

	Executing: mono .../xamarin-android/external/Java.Interop/bin/Debug/jcw-gen.exe
		-o ".../xamarin-android/src/Mono.Android/obj/Debug/android-23/jcw/src"
		-L ".../xamarin-androidg/lib/xbuild-frameworks/MonoAndroid/v6.0/"
		-L ".../xamarin-android/src/Mono.Android/../../bin/Debug/lib/xbuild-frameworks/MonoAndroid/v6.0/../v1.0/"
		-L ".../xamarin-android/src/Mono.Android/../../MonoAndroid/v6.0/../v1.0/Facades"
		".../xamarin-android/src/Mono.Android/../../bin/Debug/lib/xbuild-frameworks/MonoAndroid/v6.0/Mono.Android.dll"
	jcw-gen: Could not load assembly 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'. Perhaps it doesn't exist in the Mono for Android profile?

`mscorlib.dll` couldn't be found because it wasn't *built*, nor
installed into `bin/Debug/lib/xbuild-frameworks/MonoAndroid/v1.0`.

Additionally, fully building the AOT cross compilers requires adding
`mxe-Win32` to `$(ALL_HOST_ABIS)`, otherwise e.g. `win-armeabi` fails
to build because `arm_dpimacros.h` doesn't exist (as `arm_dpimacros.h`
is built by `mxe-Win32`):

	Error parsing '.../xamarin-android/external/mono/mono/metadata/metadata-cross-helpers.c'
	.../xamarin-android/external/mono/mono/arch/arm/arm-codegen.h(937,10): fatal: 'mono/arch/arm/arm_dpimacros.h' file not found
	Error parsing '.../xamarin-android/external/mono/mono/mini/mini-cross-helpers.c'
	.../xamarin-android/external/mono/mono/arch/arm/arm-codegen.h(937,10): fatal: 'mono/arch/arm/arm_dpimacros.h' file not found
	Unhandled Exception:
	System.Exception: Expected to find struct definition for MonoObject

Fix the `mono-runtimes.mdproj` build so that it doesn't re-execute
targets when not necessary, by "rolling" with xbuild limitations and
refactoring item groups as appropriate. In particular, xbuild doesn't
like referencing item metadata within a `//Target/@Outputs` that in
turn references a property group:

	<PropertyGroup>
		<V>Value</v>
	</PropertyGroup>
	<ItemGroup>
		<Item Include="Something">
			<Metadata>$(V)</Metadata>
		</Item>
	</ItemGroup>
	<Target Name="Example" Inputs="..."
			Outputs="%(Item.Metadata)">
		...
	</Target>

Whenever the `Example` target is run, it will *always* run, even if
`Value` exists, because `xbuild` perceives the
`//Target[@Name='Example']/@Outputs` value as being
`$(V)`, *not* `Value`, which is wonderfully broken.

To compensate, Don't Do That™; in particular, item metadata used
within `//Target/@Outputs` *must* be hardcoded and not contain a
property reference. This "hardcoding" removes the need for the
`$(_Cross*ffsetsHeaderFile)` properties, so remove them.

Remove `System.Net.Http.WebRequest.dll` from `@(_BclAssembly)`, as it
is no longer built in the monodroid profile; requiring it as an output
means that the "host" mono build is *always* built, which isn't needed.

Improve the `_BuildRuntimes` and `_InstallRuntimes` targets so that
their referenced files aren't *so* repetitive, in particular by
"splitting out" `@(_RuntimeLibraries)` into `@(_RuntimeSource)`,
`@(_ProfilerSource)`, and `@(_MonoPosixHelperSource)`. This allows
more intelligently `strip`ing the native libraries in the Release
configuration, while also maintaining generation of the `.d.so` files.