### PR TITLE
[Xamarin.Android.Build.Utilities] Xamarin can't find NDK 12b because ndk-stack.exe is now ndk-stack.cmd

### DIFF
--- a/src/Xamarin.Android.Build.Utilities/Sdks/AndroidSdkBase.cs
+++ b/src/Xamarin.Android.Build.Utilities/Sdks/AndroidSdkBase.cs
@@ -126,10 +126,18 @@ namespace Xamarin.Android.Build.Utilities
 		{
 			var path = Environment.GetEnvironmentVariable ("PATH");
 			var pathDirs = path.Split (new char[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+			var pathExt = Environment.GetEnvironmentVariable ("PATHEXT");
+			var pathExts = pathExt?.Split (new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
 
-			foreach (var dir in pathDirs)
+			foreach (var dir in pathDirs) {
 				if (File.Exists (Path.Combine (dir, (executable))))
 					yield return dir;
+				if (pathExts == null)
+					continue;
+				foreach (var ext in pathExts)
+					if (File.Exists (Path.Combine (dir, Path.ChangeExtension (executable, ext))))
+						yield return dir;
+			}
 		}
 
 		protected string NullIfEmpty (string s)


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=42566

In the latest NDK release google decided to change ndk-stack.exe to
nkd-stack.cmd. As a result our ndk discovery code failed on Windows.

This commit updates the code to look for all files with contain
one of the %PATHEXT% extentions.

	.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC

so that we are future proofed in case google decide to use .bat
next time.