### PR TITLE
[libmonodroid] Add more Windows/Unicode friendly wrapper for I/O operations.

### DIFF
--- a/src/monodroid/jni/monodroid-glue.c
+++ b/src/monodroid/jni/monodroid-glue.c
@@ -404,8 +404,8 @@ create_update_dir (char *override_dir)
 static int
 file_exists (const char *file)
 {
-	struct stat s;
-	if (stat (file, &s) == 0 && (s.st_mode & S_IFMT) == S_IFREG)
+	monodroid_stat_t s;
+	if (monodroid_stat (file, &s) == 0 && (s.st_mode & S_IFMT) == S_IFREG)
 		return 1;
 	return 0;
 }
@@ -419,8 +419,8 @@ file_executable (const char *file)
 	const int s_ixugo = S_IXUSR;
 #endif
 
-	struct stat s;
-	if (stat (file, &s) == 0 && (s.st_mode & S_IFMT) == S_IFREG && (s.st_mode & s_ixugo) != 0)
+	monodroid_stat_t s;
+	if (monodroid_stat (file, &s) == 0 && (s.st_mode & S_IFMT) == S_IFREG && (s.st_mode & s_ixugo) != 0)
 		return 1;
 	return 0;
 }
@@ -428,8 +428,8 @@ file_executable (const char *file)
 static int
 directory_exists (const char *directory)
 {
-	struct stat s;
-	if (stat (directory, &s) == 0 && (s.st_mode & S_IFMT) == S_IFDIR)
+	monodroid_stat_t s;
+	if (monodroid_stat (directory, &s) == 0 && (s.st_mode & S_IFMT) == S_IFDIR)
 		return 1;
 	return 0;
 }
@@ -521,13 +521,13 @@ setenv(const char *name, const char *value, int overwrite)
 static pthread_mutex_t readdir_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 static int
-readdir_r (DIR *dirp, struct dirent *entry, struct dirent **result)
+readdir_r (_WDIR *dirp, struct _wdirent *entry, struct _wdirent **result)
 {
 	int error_code = 0;
 
 	pthread_mutex_lock (&readdir_mutex);
 	errno = 0;
-	entry = readdir (dirp);
+	entry = _wreaddir (dirp);
 	*result = entry;
 
 	if (entry == NULL && errno != 0)
@@ -1743,21 +1743,22 @@ count_override_assemblies (void)
 	int i;
 
 	for (i = 0; i < MAX_OVERRIDES; ++i) {
-		DIR *dir;
-		struct dirent b, *e;
+		monodroid_dir_t *dir;
+		monodroid_dirent_t b, *e;
 
 		const char *dir_path = override_dirs [i];
+
 		if (dir_path == NULL || !directory_exists (dir_path))
 			continue;
 
-		if ((dir = opendir (dir_path)) == NULL)
+		if ((dir = monodroid_opendir (dir_path)) == NULL)
 			continue;
 
 		while (readdir_r (dir, &b, &e) == 0 && e) {
-			if (ends_with (e->d_name, ".dll"))
+			if (monodroid_dirent_hasextension (e, ".dll"))
 				++c;
 		}
-		closedir (dir);
+		monodroid_closedir (dir);
 	}
 
 	return c;

--- a/src/monodroid/jni/util.c
+++ b/src/monodroid/jni/util.c
@@ -392,6 +392,59 @@ monodroid_fopen (const char *filename, const char *mode)
 #endif // ndef WINDOWS
 }
 
+int
+monodroid_stat (const char *path, monodroid_stat_t *s)
+{
+	int result;
+
+#ifndef WINDOWS
+	result = stat (path, s);
+#else
+	wchar_t *wpath = utf8_to_utf16 (path);
+	result = _wstat (wpath, s);
+	free (wpath);
+#endif
+
+	return result;
+}
+
+monodroid_dir_t*
+monodroid_opendir (const char *filename)
+{
+#ifndef WINDOWS
+	return opendir (filename);
+#else
+	wchar_t *wfilename = utf8_to_utf16 (filename);
+	monodroid_dir_t *result = _wopendir (wfilename);
+	free (wfilename);
+	return result;
+#endif
+}
+
+int
+monodroid_closedir (monodroid_dir_t *dirp)
+{
+#ifndef WINDOWS
+	return closedir (dirp);
+#else
+	return _wclosedir (dirp);
+#endif
+
+}
+
+int
+monodroid_dirent_hasextension (monodroid_dirent_t *e, const char *extension)
+{
+#ifndef WINDOWS
+	return ends_with (e->d_name, extension);
+#else
+	char *mb_dname = utf16_to_utf8 (e->d_name);
+	int result = ends_with (mb_dname, extension);
+	free (mb_dname);
+	return result;
+#endif
+}
+
 #ifdef WINDOWS
 char*
 utf16_to_utf8 (const wchar_t *widestr)

--- a/src/monodroid/jni/util.h
+++ b/src/monodroid/jni/util.h
@@ -15,9 +15,20 @@
 #define MONODROID_PATH_SEPARATOR "/"
 #endif
 
+#if WINDOWS
+typedef struct _stat monodroid_stat_t;
+#define monodroid_dir_t _WDIR
+typedef struct _wdirent monodroid_dirent_t;
+#else
+typedef struct stat monodroid_stat_t;
+#define monodroid_dir_t DIR
+typedef struct dirent monodroid_dirent_t;
+#endif
+
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include <dirent.h>
 
 #include "dylib-mono.h"
 #include "monodroid.h"
@@ -37,6 +48,10 @@ MONO_API  int     recv_uninterrupted (int fd, void *buf, int len);
 int ends_with (const char *str, const char *end);
 char* path_combine(const char *path1, const char *path2);
 FILE *monodroid_fopen (const char* filename, const char* mode);
+int monodroid_stat (const char *path, monodroid_stat_t *s);
+monodroid_dir_t* monodroid_opendir (const char *filename);
+int monodroid_closedir (monodroid_dir_t *dirp);
+int monodroid_dirent_hasextension (monodroid_dirent_t *e, const char *extension);
 
 static inline void*
 _assert_valid_pointer (void *p, size_t size)


### PR DESCRIPTION
This allows libmono-android to parse and load assemblies in a directory containing special characters on Windows.

Previously the primitives (like `opendir` and `stat`) would fail to locate the various folder paths passed from Java due to not being UTF-8 aware.