### PR TITLE
Reorganize Xamarin.Android.NamingCustomAttributes.

### DIFF
--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -21,7 +21,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Java.Interop", "external\Ja
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "generator", "external\Java.Interop\tools\generator\generator.csproj", "{D14A1B5C-2060-4930-92BE-F7190256C735}"
 EndProject
-Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Xamarin.Android.NamingCustomAttributes", "external\Java.Interop\src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.shproj", "{74598F5C-B8CC-4CE6-8EE2-AB9CA1400076}"
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Java.Interop.NamingCustomAttributes", "external\Java.Interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.shproj", "{FE789F04-5E95-42C5-AEF1-E33F8DF06B3F}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Xamarin.Android.NamingCustomAttributes", "src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.shproj", "{74598F5C-B8CC-4CE6-8EE2-AB9CA1400076}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Java.Interop.Tools.TypeNameMappings", "external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.shproj", "{E706B6F2-5562-4765-8F07-8CF84A797B30}"
 EndProject
@@ -410,6 +412,7 @@ Global
 		{3FC3E78B-F7D4-42EA-BBE8-4535DF42BFF8} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 		{94BD81F7-B06F-4295-9636-F8A3B6BDC762} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{D14A1B5C-2060-4930-92BE-F7190256C735} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
+		{FE789F04-5E95-42C5-AEF1-E33F8DF06B3F} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{74598F5C-B8CC-4CE6-8EE2-AB9CA1400076} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{E706B6F2-5562-4765-8F07-8CF84A797B30} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{66CF299A-CE95-4131-BCD8-DB66E30C4BF7} = {04E3E11E-B47D-4599-8AFC-50515A95E715}

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -294,7 +294,7 @@
     <Compile Include="Xamarin.Android.Net\IAndroidAuthenticationModule.cs" />
   </ItemGroup>
   <Import Project="$(JavaInteropFullPath)\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems" Label="Shared" Condition="Exists('$(JavaInteropFullPath)\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems')" />
-  <Import Project="$(JavaInteropFullPath)\src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('$(JavaInteropFullPath)\src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems')" />
+  <Import Project="..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems')" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <IntermediateOutputPath>$(IntermediateOutputPath)android-$(AndroidApiLevel)\</IntermediateOutputPath>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -12,7 +12,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
-  <Import Project="$(JavaInteropFullPath)\src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('$(JavaInteropFullPath)\src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems')" />
+  <Import Project="..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems')" />
   <Import Project="$(JavaInteropFullPath)\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems" Label="Shared" Condition="Exists('$(JavaInteropFullPath)\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems')" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
@@ -1,0 +1,67 @@
+using System;
+
+using Android.Content.PM;
+using Android.Views;
+
+namespace Android.App
+{
+
+	[Serializable]
+	[AttributeUsage (AttributeTargets.Class, 
+			AllowMultiple=false, 
+			Inherited=false)]
+	public sealed partial class ActivityAttribute : Attribute {
+
+		public ActivityAttribute ()
+		{
+		}
+
+		public string                 Name                    {get; set;}
+
+#if ANDROID_20
+		public bool                   AllowEmbedded           {get; set;}
+#endif
+		public bool                   AllowTaskReparenting    {get; set;}
+		public bool                   AlwaysRetainTaskState   {get; set;}
+		public bool                   ClearTaskOnLaunch       {get; set;}
+		public ConfigChanges          ConfigurationChanges    {get; set;}
+		public bool                   Enabled                 {get; set;}
+		public bool                   ExcludeFromRecents      {get; set;}
+		public bool                   Exported                {get; set;}
+		public bool                   FinishOnTaskLaunch      {get; set;}
+#if ANDROID_11
+		public bool                   HardwareAccelerated     {get; set;}
+#endif
+		public string                 Icon                    {get; set;}
+		public string                 Label                   {get; set;}
+		public LaunchMode             LaunchMode              {get; set;}
+#if ANDROID_17
+		[Obsolete ("There is no //activity/@android:layoutDirection attribute. This was a mistake. " +
+				"Perhaps you wanted ConfigurationChanges=ConfigChanges.LayoutDirection?")]
+		public LayoutDirection        LayoutDirection         {get; set;}
+#endif
+		public bool                   MainLauncher            {get; set;}
+		public bool                   MultiProcess            {get; set;}
+		public bool                   NoHistory               {get; set;}
+#if ANDROID_16
+		public Type                   ParentActivity          {get; set;}
+#endif
+		public string                 Permission              {get; set;}
+		public string                 Process                 {get; set;}
+#if ANDROID_24
+		public bool                   ResizeableActivity      {get;set;}
+		public bool                   SupportsPictureInPicture {get;set;}
+#endif
+		public ScreenOrientation      ScreenOrientation       {get; set;}
+		public bool                   StateNotNeeded          {get; set;}
+		public string                 TaskAffinity            {get; set;}
+		public string                 Theme                   {get; set;}
+#if ANDROID_14
+		public UiOptions              UiOptions               {get; set;}
+#endif
+		public SoftInput              WindowSoftInputMode     {get; set;}
+#if ANDROID_15 // this is not documented on http://developer.android.com/guide/topics/manifest/activity-element.html but on https://developers.google.com/glass/develop/gdk/immersions
+		public bool                   Immersive               {get; set;}
+#endif
+	}
+}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ApplicationAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ApplicationAttribute.cs
@@ -1,0 +1,75 @@
+using System;
+
+using Android.Content.PM;
+using Android.Views;
+
+namespace Android.App {
+
+	[Serializable]
+	[AttributeUsage (AttributeTargets.Assembly | AttributeTargets.Class, 
+			AllowMultiple=false, 
+			Inherited=false)]
+	public sealed partial class ApplicationAttribute : Attribute {
+
+		public ApplicationAttribute ()
+		{
+		}
+
+		public string                 Name                    {get; set;}
+
+		public bool                   AllowBackup             {get; set;}
+		public bool                   AllowClearUserData      {get; set;}
+		public bool                   AllowTaskReparenting    {get; set;}
+#if ANDROID_8
+		public Type                   BackupAgent             {get; set;}
+#endif
+#if ANDROID_21
+		public string                 Banner                  {get; set;}
+#endif
+		public bool                   Debuggable              {get; set;}
+		public string                 Description             {get; set;}
+		public bool                   Enabled                 {get; set;}
+#if ANDROID_23
+		public bool                   ExtractNativeLibs       {get; set;}
+		public bool                   FullBackupContent       {get; set;}
+#endif
+#if ANDROID_11
+		public bool                   HardwareAccelerated     {get; set;}
+#endif
+		public bool                   HasCode                 {get; set;}
+		public string                 Icon                    {get; set;}
+		public bool                   KillAfterRestore        {get; set;}
+#if ANDROID_11
+		public bool                   LargeHeap               {get; set;}
+#endif
+		public string                 Label                   {get; set;}
+#if ANDROID_11
+		public string                 Logo                    {get; set;}
+#endif
+		public Type                   ManageSpaceActivity     {get; set;}
+		public string                 Permission              {get; set;}
+		public bool                   Persistent              {get; set;}
+		public string                 Process                 {get; set;}
+#if ANDROID_18
+		public string                 RequiredAccountType     {get; set;}
+#endif
+		public bool                   RestoreAnyVersion       {get; set;}
+#if ANDROID_18
+		public string                 RestrictedAccountType   {get; set;}
+#endif
+#if ANDROID_17
+		public bool                   SupportsRtl             {get; set;}
+#endif
+		public string                 TaskAffinity            {get; set;}
+		public string                 Theme                   {get; set;}
+#if ANDROID_14
+		public UiOptions              UiOptions               {get; set;}
+#endif
+#if ANDROID_10
+		public bool                   VMSafeMode              {get; set;}
+#endif
+#if ANDROID_24
+		public bool                   ResizeableActivity      {get; set;}
+#endif
+	}
+}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/InstrumentationAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/InstrumentationAttribute.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Android.App {
+
+	[Serializable]
+	[AttributeUsage (AttributeTargets.Assembly | AttributeTargets.Class, 
+			AllowMultiple=true, 
+			Inherited=false)]
+	public sealed partial class InstrumentationAttribute : Attribute {
+
+		public InstrumentationAttribute ()
+		{
+		}
+
+		public bool                   FunctionalTest  {get; set;}
+		public bool                   HandleProfiling {get; set;}
+		public string                 Icon            {get; set;}
+		public string                 Label           {get; set;}
+		public string                 Name            {get; set;}
+		public string                 TargetPackage   {get; set;}
+	}
+}
+

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ServiceAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ServiceAttribute.cs
@@ -1,0 +1,30 @@
+using System;
+
+using Android.Content.PM;
+using Android.Views;
+
+namespace Android.App {
+
+	[Serializable]
+	[AttributeUsage (AttributeTargets.Class, 
+			AllowMultiple=false, 
+			Inherited=false)]
+	public sealed partial class ServiceAttribute : Attribute {
+
+		public ServiceAttribute ()
+		{
+		}
+
+		public string                 Name                    {get; set;}
+
+		public bool                   Enabled                 {get; set;}
+		public bool                   Exported                {get; set;}
+		public string                 Icon                    {get; set;}
+#if ANDROID_16
+		public bool                   IsolatedProcess         {get; set;}
+#endif
+		public string                 Label                   {get; set;}
+		public string                 Permission              {get; set;}
+		public string                 Process                 {get; set;}
+	}
+}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.Content/BroadcastReceiverAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.Content/BroadcastReceiverAttribute.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Android.Content {
+
+	[Serializable]
+	[AttributeUsage (AttributeTargets.Class, 
+			AllowMultiple=false, 
+			Inherited=false)]
+	public partial class BroadcastReceiverAttribute : Attribute {
+
+		public BroadcastReceiverAttribute ()
+		{
+		}
+
+		public bool                   DirectBootAware         {get; set;}
+		public bool                   Enabled                 {get; set;}
+		public bool                   Exported                {get; set;}
+		public string                 Icon                    {get; set;}
+		public string                 Label                   {get; set;}
+		public string                 Name                    {get; set;}
+		public string                 Permission              {get; set;}
+		public string                 Process                 {get; set;}
+	}
+}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.Content/ContentProviderAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.Content/ContentProviderAttribute.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Android.Content {
+
+	[Serializable]
+	[AttributeUsage (AttributeTargets.Class, 
+			AllowMultiple=false, 
+			Inherited=false)]
+	public partial class ContentProviderAttribute : Attribute {
+
+		public ContentProviderAttribute (string[] authorities)
+		{
+			if (authorities == null)
+				throw new ArgumentNullException ("authorities");
+			if (authorities.Length < 1)
+				throw new ArgumentException ("At least one authority must be specified.", "authorities");
+			Authorities = authorities;
+		}
+
+		public string[]               Authorities             {get; private set;}
+		public bool                   Enabled                 {get; set;}
+		public bool                   Exported                {get; set;}
+		public bool                   GrantUriPermissions     {get; set;}
+		public string                 Icon                    {get; set;}
+		public int                    InitOrder               {get; set;}
+		public string                 Label                   {get; set;}
+		public bool                   MultiProcess            {get; set;}
+		public string                 Name                    {get; set;}
+		public string                 Permission              {get; set;}
+		public string                 Process                 {get; set;}
+		public string                 ReadPermission          {get; set;}
+		public bool                   Syncable                {get; set;}
+		public string                 WritePermission         {get; set;}
+	}
+}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.Runtime/RegisterAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.Runtime/RegisterAttribute.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace Android.Runtime {
+
+	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Property)]
+#if !JCW_ONLY_TYPE_NAMES
+	public
+#endif  // !JCW_ONLY_TYPE_NAMES
+	sealed class RegisterAttribute : Attribute {
+
+		string connector;
+		string name;
+		string signature;
+
+		public RegisterAttribute (string name)
+		{
+			this.name = name;
+		}
+
+		public RegisterAttribute (string name, string signature, string connector)
+			: this (name)
+		{
+			this.connector = connector;
+			this.signature = signature;
+		}
+
+		public string Connector {
+			get { return connector; }
+			set { connector = value; }
+		}
+
+		public string Name {
+			get { return name; }
+			set { name = value; }
+		}
+
+		public string Signature {
+			get { return signature; }
+			set { signature = value; }
+		}
+
+		public bool DoNotGenerateAcw {get; set;}
+
+		public int ApiSince {get; set;}
+	}
+}

--- a/src/Xamarin.Android.NamingCustomAttributes/Java.Interop/ExportAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Java.Interop/ExportAttribute.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Java.Interop {
+
+	[Serializable]
+	[AttributeUsage (AttributeTargets.Method | AttributeTargets.Constructor, 
+			AllowMultiple=false, 
+			Inherited=false)]
+#if !JCW_ONLY_TYPE_NAMES
+	public
+#endif  // !JCW_ONLY_TYPE_NAMES
+	partial class ExportAttribute : Attribute {
+
+		public ExportAttribute ()
+		{
+		}
+		
+		public ExportAttribute (string name)
+		{
+			Name = name;
+		}
+
+		public string                 Name                    {get; private set;}
+		public string                 SuperArgumentsString    {get; set;}
+		public Type []                Throws                  {get; set;}
+		internal string []            ThrownNames             {get; set;} // msbuild internal use
+	}
+}
+
+

--- a/src/Xamarin.Android.NamingCustomAttributes/Java.Interop/ExportFieldAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Java.Interop/ExportFieldAttribute.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Java.Interop {
+
+	[Serializable]
+	[AttributeUsage (AttributeTargets.Method, 
+			AllowMultiple=false, 
+			Inherited=false)]
+#if !JCW_ONLY_TYPE_NAMES
+	public
+#endif  // !JCW_ONLY_TYPE_NAMES
+	partial class ExportFieldAttribute : Attribute {
+
+		public ExportFieldAttribute (string name)
+		{
+			Name = name;
+		}
+
+		public string                 Name                    {get; set;}
+	}
+}
+
+

--- a/src/Xamarin.Android.NamingCustomAttributes/Java.Interop/ExportParameterAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Java.Interop/ExportParameterAttribute.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Java.Interop {
+
+	[Serializable]
+	[AttributeUsage (AttributeTargets.Parameter | AttributeTargets.ReturnValue, 
+			AllowMultiple=false, 
+			Inherited=false)]
+#if !JCW_ONLY_TYPE_NAMES
+	public
+#endif  // !JCW_ONLY_TYPE_NAMES
+	partial class ExportParameterAttribute : Attribute {
+
+		public ExportParameterAttribute (ExportParameterKind kind)
+		{
+			Kind = kind;
+		}
+
+		public ExportParameterKind Kind { get; private set; }
+	}
+}
+
+

--- a/src/Xamarin.Android.NamingCustomAttributes/Java.Interop/ExportParameterKind.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Java.Interop/ExportParameterKind.cs
@@ -1,0 +1,12 @@
+namespace Java.Interop {
+#if !JCW_ONLY_TYPE_NAMES
+	public
+#endif  // !JCW_ONLY_TYPE_NAMES
+	enum ExportParameterKind {
+		Unspecified,
+		InputStream,
+		OutputStream,
+		XmlPullParser,
+		XmlResourceParser
+	}
+}

--- a/src/Xamarin.Android.NamingCustomAttributes/Xamarin.Android.NamingCustomAttributes.projitems
+++ b/src/Xamarin.Android.NamingCustomAttributes/Xamarin.Android.NamingCustomAttributes.projitems
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>{74598F5C-B8CC-4CE6-8EE2-AB9CA1400076}</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>Xamarin.Android.NamingCustomAttributes</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Android.Content\BroadcastReceiverAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Android.Content\ContentProviderAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Android.Runtime\RegisterAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop\ExportAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop\ExportFieldAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop\ExportParameterAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop\ExportParameterKind.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Android.App\ActivityAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Android.App\ApplicationAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Android.App\ServiceAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Android.App\InstrumentationAttribute.cs" />
+  </ItemGroup>
+</Project>

--- a/src/Xamarin.Android.NamingCustomAttributes/Xamarin.Android.NamingCustomAttributes.shproj
+++ b/src/Xamarin.Android.NamingCustomAttributes/Xamarin.Android.NamingCustomAttributes.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{74598F5C-B8CC-4CE6-8EE2-AB9CA1400076}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <Import Project="Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>


### PR DESCRIPTION
context: https://github.com/xamarin/java.interop/issues/58
dependent on: https://github.com/atsushieno/java.interop/commit/5583d26

Copypasting the changes on Java.Interop

	We have complicated module interdependency between this and xamarin-android,
	so this set of changes is to fix the situation.

	So far, here is the changeset summary:

	- Xamarin.Android.NamingCustomAttributes.shproj is moved to xamarin-android
	- there will be new Java.Interop.NamingCustomAttributes.shproj which is for
	  use in this repository. It will be shrinked in the later commits to have
	  only required bits in Java/Interop.

Now Xamarin.Android.sln has two NamingCustomAttributes.shproj: one for
imported and then slightly stripped version of the original shared project
in xamarin-android, and renamed and then significantly stripped version
in Java.Interop.

Build adjustment comes next.