### PR TITLE
[mono-runtimes] Add `CreateBundle` target.

### DIFF
--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -85,14 +85,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "libZipSharp", "external\Lib
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Drawing.Primitives", "src\System.Drawing.Primitives\System.Drawing.Primitives.csproj", "{C9FF2E4D-D927-479E-838B-647C16763F64}"
 EndProject
+Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "libzip-windows", "build-tools\libzip-windows\libzip-windows.mdproj", "{0DE278D6-000F-4001-BB98-187C0AF58A61}"
+EndProject
+Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "bundle", "build-tools\bundle\bundle.mdproj", "{1640725C-4DB8-4D8D-BC96-74E688A06EEF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|AnyCPU = Debug|AnyCPU
 		Release|AnyCPU = Release|AnyCPU
 		XAIntegrationDebug|AnyCPU = XAIntegrationDebug|AnyCPU
 		XAIntegrationRelease|AnyCPU = XAIntegrationRelease|AnyCPU
-		XAIntegrationDebug|Any CPU = XAIntegrationDebug|Any CPU
-		XAIntegrationRelease|Any CPU = XAIntegrationRelease|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
@@ -389,6 +391,22 @@ Global
 		{C9FF2E4D-D927-479E-838B-647C16763F64}.XAIntegrationDebug|AnyCPU.Build.0 = Debug|Any CPU
 		{C9FF2E4D-D927-479E-838B-647C16763F64}.XAIntegrationRelease|AnyCPU.ActiveCfg = Debug|Any CPU
 		{C9FF2E4D-D927-479E-838B-647C16763F64}.XAIntegrationRelease|AnyCPU.Build.0 = Debug|Any CPU
+		{0DE278D6-000F-4001-BB98-187C0AF58A61}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{0DE278D6-000F-4001-BB98-187C0AF58A61}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{0DE278D6-000F-4001-BB98-187C0AF58A61}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{0DE278D6-000F-4001-BB98-187C0AF58A61}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{0DE278D6-000F-4001-BB98-187C0AF58A61}.XAIntegrationDebug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{0DE278D6-000F-4001-BB98-187C0AF58A61}.XAIntegrationDebug|AnyCPU.Build.0 = Debug|Any CPU
+		{0DE278D6-000F-4001-BB98-187C0AF58A61}.XAIntegrationRelease|AnyCPU.ActiveCfg = Release|Any CPU
+		{0DE278D6-000F-4001-BB98-187C0AF58A61}.XAIntegrationRelease|AnyCPU.Build.0 = Release|Any CPU
+		{1640725C-4DB8-4D8D-BC96-74E688A06EEF}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{1640725C-4DB8-4D8D-BC96-74E688A06EEF}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{1640725C-4DB8-4D8D-BC96-74E688A06EEF}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{1640725C-4DB8-4D8D-BC96-74E688A06EEF}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{1640725C-4DB8-4D8D-BC96-74E688A06EEF}.XAIntegrationDebug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{1640725C-4DB8-4D8D-BC96-74E688A06EEF}.XAIntegrationDebug|AnyCPU.Build.0 = Debug|Any CPU
+		{1640725C-4DB8-4D8D-BC96-74E688A06EEF}.XAIntegrationRelease|AnyCPU.ActiveCfg = Release|Any CPU
+		{1640725C-4DB8-4D8D-BC96-74E688A06EEF}.XAIntegrationRelease|AnyCPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
@@ -429,6 +447,8 @@ Global
 		{900A0F71-BAAD-417A-8D1A-8D330297CDD0} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 		{E248B2CA-303B-4645-ADDC-9D4459D550FD} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{C9FF2E4D-D927-479E-838B-647C16763F64} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
+		{0DE278D6-000F-4001-BB98-187C0AF58A61} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
+		{1640725C-4DB8-4D8D-BC96-74E688A06EEF} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/build-tools/bundle/bundle.mdproj
+++ b/build-tools/bundle/bundle.mdproj
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ItemType>GenericProject</ItemType>
+    <ProjectGuid>{1640725C-4DB8-4D8D-BC96-74E688A06EEF}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">1
+    <OutputPath>..\..\bin\Debug</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <OutputPath>..\..\bin\Release</OutputPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
+  <PropertyGroup>
+    <BuildDependsOn>
+      ResolveReferences;
+      CreateBundle
+    </BuildDependsOn>
+  </PropertyGroup>
+  <Import Project="bundle.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\android-toolchain\android-toolchain.mdproj">
+      <Project>{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA}</Project>
+      <Name>android-toolchain</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="..\mono-runtimes\mono-runtimes.mdproj">
+      <Project>{C03E6CF1-7460-4CDC-A4AB-292BBC0F61F2}</Project>
+      <Name>mono-runtimes</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="..\libzip\libzip.mdproj">
+      <Project>{900A0F71-BAAD-417A-8D1A-8D330297CDD0}</Project>
+      <Name>libzip</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </ProjectReference>
+    <ProjectReference Include="..\libzip-windows\libzip-windows.mdproj">
+      <Project>{0DE278D6-000F-4001-BB98-187C0AF58A61}</Project>
+      <Name>libzip-windows</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/build-tools/bundle/bundle.targets
+++ b/build-tools/bundle/bundle.targets
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask AssemblyFile="$(_SourceTopDir)\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.GetNugetPackageBasePath" />
+  <UsingTask AssemblyFile="$(_SourceTopDir)\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.GitCommitHash" />
+  <UsingTask AssemblyFile="$(_SourceTopDir)\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.Zip" />
+  <Import Project="..\mono-runtimes\mono-runtimes.props" />
+  <Import Project="..\mono-runtimes\mono-runtimes.projitems" />
+  <Import Project="..\mono-runtimes\mono-runtimes.targets" />
+  <Import Project="..\libzip\libzip.props" />
+  <Import Project="..\libzip\libzip.projitems" />
+  <Import Project="..\libzip-windows\libzip-windows.props" />
+  <Import Project="..\libzip-windows\libzip-windows.projitems" />
+  <Target Name="_GetHashes">
+    <GitCommitHash
+        WorkingDirectory="$(LibZipSourceFullPath)"
+        ToolPath="$(GitToolPath)"
+        ToolExe="$(GitToolExe)">
+      <Output TaskParameter="AbbreviatedCommitHash"   PropertyName="_LibZipHash" />
+    </GitCommitHash>
+    <GitCommitHash
+        WorkingDirectory="$(LlvmSourceFullPath)"
+        ToolPath="$(GitToolPath)"
+        ToolExe="$(GitToolExe)">
+      <Output TaskParameter="AbbreviatedCommitHash"   PropertyName="_LlvmHash" />
+    </GitCommitHash>
+    <GitCommitHash
+        WorkingDirectory="$(MonoSourceFullPath)"
+        ToolPath="$(GitToolPath)"
+        ToolExe="$(GitToolExe)">
+      <Output TaskParameter="AbbreviatedCommitHash"   PropertyName="_MonoHash" />
+    </GitCommitHash>
+  </Target>
+  <Target Name="GetBundlePath"
+      DependsOnTargets="_GetHashes">
+    <PropertyGroup>
+      <_BundlePath>$(OutputPath)bundle-$(Configuration)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</_BundlePath>
+    </PropertyGroup>
+  </Target>
+  <Target Name="Clean"
+      DependsOnTargets="_GetHashes">
+    <Delete Files="$(_BundlePath)" />
+  </Target>
+  <Target Name="_GetArchiveItems"
+      DependsOnTargets="_GetRuntimesOutputItems">
+    <ItemGroup>
+      <_Archive Include="@(_BclInstalledItem)" />
+      <_Archive Include="$(OutputPath)lib\xbuild-frameworks\MonoAndroid\v1.0\Facades\*.dll*" />
+      <_Archive Include="$(OutputPath)lib\xbuild-frameworks\MonoAndroid\v1.0\RedistList\FrameworkList.xml" />
+      <_Archive Include="@(_InstallRuntimeOutput)" />
+      <_Archive Include="@(_InstallUnstrippedRuntimeOutput)" />
+      <_Archive Include="@(_InstallProfilerOutput)" />
+      <_Archive Include="@(_InstallUnstrippedProfilerOutput)" />
+      <_Archive Include="@(_InstallMonoPosixHelperOutput)" />
+      <_Archive Include="@(_InstallUnstrippedMonoPosixHelperOutput)" />
+      <_Archive Include="@(_LibZipTarget->'$(OutputPath)lib\xbuild\Xamarin\Android\%(OutputLibrary)')" />
+      <_Archive Include="$(OutputPath)%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
+          Condition=" '@(_MonoCrossRuntime)' != '' "
+      />
+      <_Archive Include="@(_LlvmRuntime->'$(OutputPath)bin\llc%(ExeSuffix)')"
+          Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' "
+      />
+      <_Archive Include="@(_LlvmRuntime->'$(OutputPath)bin\opt%(ExeSuffix)')"
+          Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' "
+      />
+    </ItemGroup>
+  </Target>
+  <Target Name="CreateBundle"
+      DependsOnTargets="GetBundlePath;_GetArchiveItems"
+      Inputs="@(_Archive)"
+      Outputs="$(_BundlePath)">
+    <Zip
+        File="$(_BundlePath)"
+        Entries="@(_Archive)"
+        Prefix="$(OutputPath)"
+    />
+  </Target>
+</Project>

--- a/build-tools/libzip-windows/libzip-windows.mdproj
+++ b/build-tools/libzip-windows/libzip-windows.mdproj
@@ -4,7 +4,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ItemType>GenericProject</ItemType>
-    <ProjectGuid>{900A0F71-BAAD-417A-8D1A-8D330297CDD0}</ProjectGuid>
+    <ProjectGuid>{0DE278D6-000F-4001-BB98-187C0AF58A61}</ProjectGuid>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -21,9 +21,16 @@
       _Make
     </BuildDependsOnLocal>
   </PropertyGroup>
-  <Import Project="libzip.props" />
-  <Import Project="libzip.projitems" />
-  <Import Project="libzip.targets" />
+  <Import Project="libzip-windows.props" />
+  <Import Project="libzip-windows.projitems" />
+  <Import Project="libzip-windows.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\android-toolchain\android-toolchain.mdproj">
+      <Project>{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA}</Project>
+      <Name>android-toolchain</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
   <Target Name="Build" DependsOnTargets="$(BuildDependsOnLocal)" />
   <Target Name="Clean" />
 </Project>

--- a/build-tools/libzip-windows/libzip-windows.projitems
+++ b/build-tools/libzip-windows/libzip-windows.projitems
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <_LibZipTarget Include="host-mxe-Win64" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+      <CMake>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-cmake</CMake>
+      <CMakeFlags></CMakeFlags>
+      <OutputLibrary>libzip.dll</OutputLibrary>
+      <OutputLibraryPath>lib/libzip.dll</OutputLibraryPath>
+    </_LibZipTarget>
+  </ItemGroup>
+</Project>

--- a/build-tools/libzip-windows/libzip-windows.props
+++ b/build-tools/libzip-windows/libzip-windows.props
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+  </PropertyGroup>
+</Project>

--- a/build-tools/libzip-windows/libzip-windows.targets
+++ b/build-tools/libzip-windows/libzip-windows.targets
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\libzip\libzip.targets" />
+</Project>

--- a/build-tools/libzip/libzip.projitems
+++ b/build-tools/libzip/libzip.projitems
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <_LibZipTarget Include="host-mxe-Win64" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
-      <CMake>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-cmake</CMake>
-      <CMakeFlags></CMakeFlags>
-      <OutputLibrary>libzip.dll</OutputLibrary>
-      <OutputLibraryPath>lib/libzip.dll</OutputLibraryPath>
-    </_LibZipTarget>
     <_LibZipTarget Include="host-Darwin" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">
       <CMake>cmake</CMake>
       <CMakeFlags>-DCMAKE_OSX_ARCHITECTURES=&quot;i386;x86_64&quot;</CMakeFlags>
@@ -19,8 +13,5 @@
       <OutputLibrary>libzip.so</OutputLibrary>
       <OutputLibraryPath>libzip.so</OutputLibraryPath>
     </_LibZipTarget>
-  </ItemGroup>
-  <ItemGroup>
-    <RequiredProgram Include="cmake" />
   </ItemGroup>
 </Project>

--- a/build-tools/libzip/libzip.targets
+++ b/build-tools/libzip/libzip.targets
@@ -1,12 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <_SourceTopDir>..\..</_SourceTopDir>
-  </PropertyGroup>
-  <UsingTask AssemblyFile="$(_SourceTopDir)\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.GetNugetPackageBasePath" />
-  <Import Project="libzip.props" />
-  <Import Project="libzip.projitems" />
-  <Import Project="..\scripts\RequiredPrograms.targets" />
+  <Target Name="_CheckForMake">
+    <Exec Command="make --help" />
+    <OnError ExecuteTargets="_PrintRequiredMake" />
+  </Target>
+  <Target Name="_PrintRequiredMake">
+    <Error Text="The `make` program is required, and could not be found in `$PATH`." />
+  </Target>
+  <Target Name="_CheckForCmake">
+    <Exec Command="cmake --help" />
+    <OnError ExecuteTargets="_PrintRequiredCmake" />
+  </Target>
+  <Target Name="_PrintRequiredCmake">
+    <Error Text="The `cmake` program is required, and could not be found in `$PATH`." />
+  </Target>
   <Target Name="_SetCMakeListsTxtTimeToLastCommitTimestamp">
     <Exec
         Command="touch -m -t `git log -1 --format=%25cd --date=format-local:%25Y%25m%25d%25H%25M.%25S` CMakeLists.txt"
@@ -14,23 +21,38 @@
     />
   </Target>
   <Target Name="_Configure"
-        DependsOnTargets="_SetCMakeListsTxtTimeToLastCommitTimestamp"
-        Inputs="$(LibZipSourceFullPath\CMakeLists.txt"
-        Outputs="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)\Makefile">
+      Condition=" '@(_LibZipTarget)' != '' "
+      DependsOnTargets="_SetCMakeListsTxtTimeToLastCommitTimestamp"
+      Inputs="$(LibZipSourceFullPath)\CMakeLists.txt"
+      Outputs="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)\Makefile">
+    <CallTarget Targets="_CheckForCmake" />
     <MakeDir Directories="@(_LibZipTarget->'$(IntermediateOutputPath)\%(Identity)')" /> 
     <Exec
         Command="%(_LibZipTarget.CMake) %(_LibZipTarget.CMakeFlags) $(LibZipSourceFullPath)"
         WorkingDirectory="@(_LibZipTarget->'$(IntermediateOutputPath)\%(Identity)')"
     />
   </Target>
+  <ItemGroup>
+    <Content Include="@(_LibZipTarget->'$(OutputPath)\lib\xbuild\Xamarin\Android\%(_LibZipTarget.OutputLibrary)')">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Target Name="_Make"
-        Inputs="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)\Makefile"
-        Outputs="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)\%(_LibZipTarget.OutputLibraryPath)">
+      Condition=" '@(_LibZipTarget)' != '' "
+      Inputs="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)\Makefile"
+      Outputs="@(Content)">
+    <CallTarget Targets="_CheckForMake" />
     <Exec
         Command="make"
         WorkingDirectory="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)"
      /> 
     <Copy SourceFiles="@(_LibZipTarget->'$(IntermediateOutputPath)\%(Identity)\%(_LibZipTarget.OutputLibraryPath)')"
         DestinationFiles="@(_LibZipTarget->'$(OutputPath)\lib\xbuild\Xamarin\Android\%(_LibZipTarget.OutputLibrary)')"/>
+    <Touch Files="@(Content)" />
+  </Target>
+  <Target Name="_CleanBinaries"
+      AfterTargets="Clean">
+    <RemoveDir Directories="$(IntermediateOutputPath)\%(_LibZipTarget.Identity" />
+    <Delete Files="@(_LibZipTarget->'$(OutputPath)\lib\xbuild\Xamarin\Android\%(_LibZipTarget.OutputLibrary)')" />
   </Target>
 </Project>

--- a/build-tools/mono-runtimes/mono-runtimes.projitems
+++ b/build-tools/mono-runtimes/mono-runtimes.projitems
@@ -280,6 +280,7 @@
       <ExeSuffix></ExeSuffix>
       <BuildEnvironment></BuildEnvironment>
       <ConfigureEnvironment></ConfigureEnvironment>
+      <InstallPath>bin/</InstallPath>
       <CrossMonoName>cross-arm</CrossMonoName>
     </_MonoCrossRuntime>
 
@@ -300,6 +301,7 @@
       <ExeSuffix></ExeSuffix>
       <BuildEnvironment></BuildEnvironment>
       <ConfigureEnvironment></ConfigureEnvironment>
+      <InstallPath>bin/</InstallPath>
       <CrossMonoName>cross-arm64</CrossMonoName>
     </_MonoCrossRuntime>
 
@@ -320,6 +322,7 @@
       <ExeSuffix></ExeSuffix>
       <BuildEnvironment></BuildEnvironment>
       <ConfigureEnvironment></ConfigureEnvironment>
+      <InstallPath>bin/</InstallPath>
       <CrossMonoName>cross-x86</CrossMonoName>
     </_MonoCrossRuntime>
 
@@ -340,6 +343,7 @@
       <ExeSuffix></ExeSuffix>
       <BuildEnvironment></BuildEnvironment>
       <ConfigureEnvironment></ConfigureEnvironment>
+      <InstallPath>bin/</InstallPath>
       <CrossMonoName>cross-x86_64</CrossMonoName>
     </_MonoCrossRuntime>
 
@@ -360,6 +364,7 @@
       <ExeSuffix>.exe</ExeSuffix>
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin32)</ConfigureEnvironment>
+      <InstallPath>lib/mandroid/</InstallPath>
       <CrossMonoName>cross-arm</CrossMonoName>
     </_MonoCrossRuntime>
 
@@ -380,6 +385,7 @@
       <ExeSuffix>.exe</ExeSuffix>
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin32)</ConfigureEnvironment>
+      <InstallPath>lib/mandroid/</InstallPath>
       <CrossMonoName>cross-arm64</CrossMonoName>
     </_MonoCrossRuntime>
 
@@ -400,6 +406,7 @@
       <ExeSuffix>.exe</ExeSuffix>
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin32)</ConfigureEnvironment>
+      <InstallPath>lib/mandroid/</InstallPath>
       <CrossMonoName>cross-x86</CrossMonoName>
     </_MonoCrossRuntime>
 
@@ -420,6 +427,7 @@
       <ExeSuffix>.exe</ExeSuffix>
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin32)</ConfigureEnvironment>
+      <InstallPath>lib/mandroid/</InstallPath>
       <CrossMonoName>cross-x86_64</CrossMonoName>
     </_MonoCrossRuntime>
   </ItemGroup>

--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -366,15 +366,15 @@
   -->
   <Target Name="_InstallCrossRuntimes"
       Inputs="$(IntermediateOutputPath)%(_MonoCrossRuntime.Identity)\mono\mini\mono-sgen%(_MonoCrossRuntime.ExeSuffix)"
-      Outputs="$(OutputPath)bin\%(_MonoCrossRuntime.CrossMonoName)"
+      Outputs="$(OutputPath)%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
       Condition=" '@(_MonoCrossRuntime)' != '' ">
     <MakeDir Directories="$(OutputPath)bin\" />
     <Copy
         SourceFiles="$(IntermediateOutputPath)%(_MonoCrossRuntime.Identity)\mono\mini\mono-sgen%(_MonoCrossRuntime.ExeSuffix)"
-        DestinationFiles="$(OutputPath)bin\%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)" 
+        DestinationFiles="$(OutputPath)%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
     />
     <Touch
-        Files="$(OutputPath)bin\%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)" 
+        Files="$(OutputPath)%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
     />
   </Target>
   <Target Name="_CleanRuntimes"

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -7,10 +7,13 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Android.Tools.BootstrapTasks</RootNamespace>
     <AssemblyName>Xamarin.Android.Tools.BootstrapTasks</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <Optimize>true</Optimize>
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>Full</DebugType>
+    <Optimize>False</Optimize>
     <OutputPath>..\..\bin\BuildDebug</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -24,6 +27,7 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
@@ -38,12 +42,26 @@
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\UnzipDirectoryChildren.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GenerateProfile.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GetNugetPackageBasePath.cs" />
+    <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Git.cs" />
+    <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GitBranch.cs" />
+    <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GitCommitHash.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Which.cs" />
+    <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Zip.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Xamarin.Android.Tools.BootstrapTasks.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\external\LibZipSharp\libZipSharp.csproj">
+      <Project>{E248B2CA-303B-4645-ADDC-9D4459D550FD}</Project>
+      <Name>libZipSharp</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\build-tools\libzip\libzip.mdproj">
+      <Project>{900A0F71-BAAD-417A-8D1A-8D330297CDD0}</Project>
+      <Name>libzip</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/Git.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/Git.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using Xamarin.Tools.Zip;
+
+using IOFile = System.IO.File;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	public class Git : ToolTask
+	{
+		[Required]
+		public                  ITaskItem       WorkingDirectory            { get; set; }
+
+		public                  string          Arguments                   { get; set; }
+
+		[Output]
+		public                  string[]        Output                      { get; set; }
+
+		protected   virtual     bool            LogTaskMessages {
+			get { return true; }
+		}
+
+		protected   override    string          ToolName {
+			get {
+				return "git" + (Path.DirectorySeparatorChar == '\\' ? ".exe" : "");
+			}
+		}
+
+		List<string> lines;
+		List<string> Lines {
+			get { return lines ?? (lines = new List<string> ()); }
+		}
+
+		public override bool Execute ()
+		{
+			if (LogTaskMessages) {
+				Log.LogMessage (MessageImportance.Low, $"Task {nameof (Git)}");
+				Log.LogMessage (MessageImportance.Low, $"  {nameof (WorkingDirectory)}: {WorkingDirectory.ItemSpec}");
+			}
+
+			base.Execute ();
+
+			Output  = Lines?.ToArray ();
+
+			if (LogTaskMessages) {
+				Log.LogMessage (MessageImportance.Low, $"  [Output] {nameof (Output)}:");
+				foreach (var line in (Output ?? new string [0]))
+					Log.LogMessage (MessageImportance.Low, $"    {line}");
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+
+		protected override string GenerateFullPathToTool ()
+		{
+			var app     = string.IsNullOrEmpty (ToolExe) ? ToolName: ToolExe;
+			var path    = !string.IsNullOrEmpty (ToolPath) ? ToolPath : GetDirectoryFromPath (app);
+			return Path.Combine (path, app);
+		}
+
+		string GetDirectoryFromPath (string app)
+		{
+			foreach (var p in Environment.GetEnvironmentVariable ("PATH").Split (new [] { Path.PathSeparator.ToString () }, StringSplitOptions.RemoveEmptyEntries)) {
+				if (File.Exists (Path.Combine (p, app))) {
+					return p;
+				}
+			}
+			return null;
+		}
+
+		protected override string GenerateCommandLineCommands ()
+		{
+			return Arguments;
+		}
+
+		protected override string GetWorkingDirectory ()
+		{
+			return WorkingDirectory.ItemSpec;
+		}
+
+		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
+		{
+			Lines.Add (singleLine);
+		}
+	}
+}
+

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GitBranch.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GitBranch.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using Xamarin.Tools.Zip;
+
+using IOFile = System.IO.File;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	public sealed class GitBranch : Git
+	{
+		[Output]
+		public                  string      Branch              { get; set; }
+
+		protected   override    bool        LogTaskMessages     {
+			get { return false; }
+		}
+
+		public GitBranch ()
+		{
+			// `git rev-parse --abbrev-ref HEAD` currently writes `HEAD` to stderr; no idea why.
+			LogStandardErrorAsError = false;
+		}
+
+		public override bool Execute ()
+		{
+			Log.LogMessage (MessageImportance.Low, $"Task {nameof (GitBranch)}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (WorkingDirectory)}: {WorkingDirectory.ItemSpec}");
+
+			base.Execute ();
+
+			Log.LogMessage (MessageImportance.Low, $"  [Output] {nameof (Branch)}: {Branch}");
+
+			return !Log.HasLoggedErrors;
+		}
+
+		protected override string GenerateCommandLineCommands ()
+		{
+			return "rev-parse --abbrev-ref HEAD";
+		}
+
+		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
+		{
+			if (string.IsNullOrEmpty (singleLine))
+				return;
+			Branch  = singleLine;
+		}
+	}
+}
+

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GitCommitHash.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GitCommitHash.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using Xamarin.Tools.Zip;
+
+using IOFile = System.IO.File;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	public sealed class GitCommitHash : Git
+	{
+		[Output]
+		public                  string      AbbreviatedCommitHash       { get; set; }
+
+		protected   override    bool        LogTaskMessages             {
+			get { return false; }
+		}
+
+		public GitCommitHash ()
+		{
+		}
+
+		public override bool Execute ()
+		{
+			Log.LogMessage (MessageImportance.Low, $"Task {nameof (GitCommitHash)}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (WorkingDirectory)}: {WorkingDirectory.ItemSpec}");
+
+			base.Execute ();
+
+			Log.LogMessage (MessageImportance.Low, $"  [Output] {nameof (AbbreviatedCommitHash)}: {AbbreviatedCommitHash}");
+
+			return !Log.HasLoggedErrors;
+		}
+
+		protected override string GenerateCommandLineCommands ()
+		{
+			return "log --no-color --first-parent -n1 --pretty=format:%h";
+		}
+
+		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
+		{
+			if (string.IsNullOrEmpty (singleLine))
+				return;
+			AbbreviatedCommitHash   = singleLine;
+		}
+	}
+}
+

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/Zip.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/Zip.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using Xamarin.Tools.Zip;
+
+using IOFile        = System.IO.File;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	public sealed class Zip : Task
+	{
+		[Required]
+		public  ITaskItem           File            { get; set; }
+
+		public  ITaskItem[]         Entries         { get; set; }
+
+		public  ITaskItem           Prefix          { get; set; }
+
+		public  bool                Overwrite       { get; set; }
+
+		public override bool Execute ()
+		{
+			Log.LogMessage (MessageImportance.Low, $"Task {nameof (Zip)}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (File)}: {File.ItemSpec}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (Entries)}:");
+			foreach (var p in Entries ?? new ITaskItem [0]) {
+				Log.LogMessage (MessageImportance.Low, $"    {p.ItemSpec}");
+			}
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (Overwrite)}: {Overwrite}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (Prefix)}: {Prefix?.ItemSpec}");
+
+			if (Overwrite) {
+				IOFile.Delete (File.ItemSpec);
+			}
+
+			var prefix  = Prefix == null ? null : Path.GetFullPath (Prefix.ItemSpec);
+			if (!string.IsNullOrEmpty (prefix) && !prefix.EndsWith (Path.DirectorySeparatorChar.ToString (), StringComparison.OrdinalIgnoreCase)) {
+				prefix  += Path.DirectorySeparatorChar;
+			}
+
+			using (var zip  = ZipArchive.Open (File.ItemSpec, FileMode.OpenOrCreate)) {
+				if (Entries == null)
+					return !Log.HasLoggedErrors;
+				foreach (var entry in Entries) {
+					if (!IOFile.Exists (entry.ItemSpec)) {
+						Log.LogWarning ($"Could not add file '{entry.ItemSpec}' to file '{File.ItemSpec}'. Skipping...");
+						continue;
+					}
+					var zipDir      = (string) null;
+					var entryPath   = Path.GetFullPath (entry.ItemSpec);
+					var entryDir    = Path.GetDirectoryName (entryPath);
+					if (prefix != null && entryDir.StartsWith (prefix, StringComparison.OrdinalIgnoreCase)) {
+						zipDir = entryDir.Substring (prefix.Length);
+					}
+					zip.AddFileToDirectory (entryPath, zipDir, useFileDirectory: false);
+				}
+			}
+			return !Log.HasLoggedErrors;
+		}
+	}
+}
+


### PR DESCRIPTION
Building Mono on Windows is a PITA, and commit 0c073f67 added support
to cross-compile Mono for Windows so that Mono could be built from
macOS or Linux.

The unstated goal of that work was to -- eventually -- build the Mono
runtimes *for Windows* on e.g. macOS, *bundle* those runtimes, and
then we could update the build process to *download* a pre-built
bundle of mono runtimes so that we can ~sanely build xamarin-android
on Windows without building *Mono* on Windows.

Part Two of this cunning plan involves creating the bundle of built
mono runtimes. This in turn got rather complicated because instead of
doing the *simple* thing of invoking **zip**(1), I instead wanted to
create and use a `<Zip/>` MSBuild task, as this would allow us to
specify in one place -- `mono-runtimes.targets` -- which files should
be bundled, instead of bundling e.g. everything in `bin/Debug`, which
would grab considerably more than just the mono bits.

Adding a `<Zip/>` task in turn involves determining which Zip
implementation to use, and what assembly to put it in; the obvious
answer is to use `libzip`/`libZipSharp.dll` and place it into
`Xamarin.Android.Tools.BootstrapTasks.dll` -- which is how we did it
-- but this answer was tricky, due to circular dependency problems:
`libzip.mdproj` depends on `android-runtimes.mdproj` which depends on
`Xamarin.Android.Tools.BootstrapTasks.dll`. Consequently, adding
`libzip.mdproj` as a dependency to
`Xamarin.Android.Tools.BootstrapTasks.dll` *doesn't work*.

(Question: Why use libzip? Why not use System.IO.Compression?
Answer: Because I'd like to be able to update the
`<UnzipDirectoryChildren/>` task to use `libzip` instead of
"shelling out" to **zip**(1) *like an animal*.)

Step 1 is removing the circular dependency. `libzip.mdproj` depends on
`android-runtimes.mdproj` because of MXE: `android-runtimes.mdproj`
configures the MXE build environment to generate a Windows
`libzip.dll` native library, if needed.

The fix: introduce a new `libzip-windows.mdproj` project which
performs the MXE-based build. This allows `libzip.mdproj` to no longer
depend on `android-runtimes.mdproj`; `libzip-windows.mdproj` does.
This also involves "refactoring" `libzip.mdproj` so that the build
logic can be shared with `libzip-windows.mdproj`.

Additionally, improve `libzip.mdproj` so that the native libraries are
also set as a `@(Content)` build action. This allows e.g.
`libzip.3.0.dylib` to be properly copied into `bin/BuildDebug`, as
that's the `$(OutputPath)` of
`Xamarin.Android.Tools.BootstrapTasks.csproj`.

Step 2 is adding `libZipSharp.csproj` as a `@(ProjectReference)` to
`Xamarin.Android.Tools.BootstrapTasks.csproj`. This requires bumping
`Xamarin.Android.Tools.BootstrapTasks.csproj` to target .NET 4.5.1,
which allows us to add the new `<Zip/>` task.

Step 3 is adding the new `CreateMonoBundle` target to
`mono-runtimes.targets`, which will create
`$(OutputPath)\mono-bundle-$(mono-hash).zip`.

Step 4 updates the `make jenkins` target so that `CreateMonoBundle` is
invoked as part of `make jenkins`.

Not yet done: *uploading* the `mono-bundle.zip` files anywhere, or
*using* the `mono-bundle$(mono-hash).zip` so that mono builds can be
skipped.