### PR TITLE
[Xamarin.Android.Build.Tasks] Fix the cleanup for .adjusted.fixed files

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -516,6 +516,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <Delete Files="$(ApiOutputFile)" />
     <Delete Files="$(ApiOutputFile).adjusted" />
     <Delete Files="$(ApiOutputFile).fixed" />
+    <Delete Files="$(ApiOutputFile).adjusted.fixed" />
     <Delete Files="$(_GeneratorStampFile)" />
 
     <RemoveDirFixed Directories="$(GeneratedOutputPath)" Condition="Exists ('$(GeneratedOutputPath)')" />


### PR DESCRIPTION
Generator when using class-parse was leaving behind a api.xml.adjusted.fixed
file in the Intermediate directory. This was causing one of the msbuild
unit tests to fail.

This commit updates the .targets to remove this file.