### PR TITLE
[Xamarin.Android.Build.Tasks] Update the Aot task to use the correct msym parameters.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -326,7 +326,7 @@ namespace Xamarin.Android.Tasks
 						ldFlags,
 						QuoteFileName (SdkBinDirectory),
 						QuoteFileName (outdir),
-						sequencePointsMode == SequencePointsMode.Offline ? string.Format("gen-seq-points-file={0},", seqpointsFile) : string.Empty
+						sequencePointsMode == SequencePointsMode.Offline ? string.Format("msym-dir={0},", QuoteFileName(outdir)) : string.Empty
 					);
 
 					// Due to a Monodroid MSBuild bug we can end up with paths to assemblies that are not in the intermediate
@@ -382,8 +382,6 @@ namespace Xamarin.Android.Tasks
 			// the C code cannot parse all the license details, including the activation code that tell us which license level is allowed
 			// so we provide this out-of-band to the cross-compilers - this can be extended to communicate a few others bits as well
 			psi.EnvironmentVariables ["MONO_PATH"] = assembliesPath;
-			if (sequencePointsMode != SequencePointsMode.None)
-				psi.EnvironmentVariables ["MONO_DEBUG"] = "gen-compact-seq-points";
 
 			var proc = new Process ();
 			proc.OutputDataReceived += OnAotOutputData;


### PR DESCRIPTION
The mono team changed the way you tell the aot compiler to generate
the .msym files [1]. This old parameter has been replaced wtih a new
`msym-dir` parameter.

Rather than specifying the actual filename we now have to
specify the directory to output the data. Also note that the
.msym files don't end up in the root of this directory. You end up
with a bunch of hashed subdirectories which contain a .msym file
for each of the assemblies that is AoT'd.
Also note the MONO_DEBUG setting has also been deprecated.

Once this commit has been merged the Unit tests will need to be
updated to take into account the locations of the new files. That
PR will also include the required bump for this commit.

[1] https://github.com/mono/mono/tree/master/mcs/tools/mono-symbolicate