### PR TITLE
[libmonodroid] Fix context switching with multithread access.

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -60,6 +60,8 @@ namespace Android.Runtime {
 		internal  static  bool  PropagateExceptions;
 		static UncaughtExceptionHandler defaultUncaughtExceptionHandler;
 
+		static bool IsRunningOnDesktop;
+
 #if !JAVA_INTEROP
 		static JNIInvokeInterface invoke_iface;
 
@@ -155,7 +157,7 @@ namespace Android.Runtime {
 				return;
 			}
 
-			TypeManager.RegisterType (Java.Interop.TypeManager.GetClassName (jniClass), type);
+			TypeManager.RegisterType (Java.Interop.TypeManager.GetClassName (jniClass), type, ignoreExistingRegistration: IsRunningOnDesktop);
 
 			string[] methods = new string ((char*) methods_ptr, 0, methods_len).Split ('\n');
 			if (methods.Length == 0)
@@ -257,6 +259,7 @@ namespace Android.Runtime {
 			}
 
 			AllocObjectSupported = androidSdkVersion > 10;
+			IsRunningOnDesktop = Convert.ToBoolean (args->isRunningOnDesktop);
 
 			Java.Interop.Runtime.grefIGCUserPeer_class = args->grefIGCUserPeer;
 
@@ -282,7 +285,7 @@ namespace Android.Runtime {
 #endif
 			if (PropagateExceptions) {
 				defaultUncaughtExceptionHandler = new UncaughtExceptionHandler (Java.Lang.Thread.DefaultUncaughtExceptionHandler);
-				if (!Convert.ToBoolean (args->isRunningOnDesktop))
+				if (!IsRunningOnDesktop)
 					Java.Lang.Thread.DefaultUncaughtExceptionHandler = defaultUncaughtExceptionHandler;
 			}
 		}

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -60,7 +60,7 @@ namespace Android.Runtime {
 		internal  static  bool  PropagateExceptions;
 		static UncaughtExceptionHandler defaultUncaughtExceptionHandler;
 
-		static bool IsRunningOnDesktop;
+		internal static bool IsRunningOnDesktop;
 
 #if !JAVA_INTEROP
 		static JNIInvokeInterface invoke_iface;
@@ -157,7 +157,7 @@ namespace Android.Runtime {
 				return;
 			}
 
-			TypeManager.RegisterType (Java.Interop.TypeManager.GetClassName (jniClass), type, ignoreExistingRegistration: IsRunningOnDesktop);
+			TypeManager.RegisterType (Java.Interop.TypeManager.GetClassName (jniClass), type);
 
 			string[] methods = new string ((char*) methods_ptr, 0, methods_len).Split ('\n');
 			if (methods.Length == 0)

--- a/src/Mono.Android/Android.Runtime/TypeManager.cs
+++ b/src/Mono.Android/Android.Runtime/TypeManager.cs
@@ -13,9 +13,9 @@ namespace Android.Runtime {
 			return Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 		}
 
-		public static void RegisterType (string java_class, Type t)
+		public static void RegisterType (string java_class, Type t, bool ignoreExistingRegistration = false)
 		{
-			Java.Interop.TypeManager.RegisterType (java_class, t);
+			Java.Interop.TypeManager.RegisterType (java_class, t, ignoreExistingRegistration);
 		}
 
 		public static void RegisterPackage (string package, Converter<string, Type> lookup)

--- a/src/Mono.Android/Android.Runtime/TypeManager.cs
+++ b/src/Mono.Android/Android.Runtime/TypeManager.cs
@@ -13,9 +13,9 @@ namespace Android.Runtime {
 			return Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 		}
 
-		public static void RegisterType (string java_class, Type t, bool ignoreExistingRegistration = false)
+		public static void RegisterType (string java_class, Type t)
 		{
-			Java.Interop.TypeManager.RegisterType (java_class, t, ignoreExistingRegistration);
+			Java.Interop.TypeManager.RegisterType (java_class, t);
 		}
 
 		public static void RegisterPackage (string package, Converter<string, Type> lookup)

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -308,7 +308,7 @@ namespace Java.Interop {
 			return c.Invoke (new object[]{handle, transfer});
 		}
 
-		public static void RegisterType (string java_class, Type t, bool ignoreExistingRegistration = false)
+		public static void RegisterType (string java_class, Type t)
 		{
 			string jniFromType = JniTypeMapping.ToJniName (t);
 			lock (jniToManaged) {
@@ -318,7 +318,7 @@ namespace Java.Interop {
 					if (jniFromType != java_class) {
 						managedToJni.Add (t, java_class);
 					}
-				} else if (!ignoreExistingRegistration) {
+				} else if (!JNIEnv.IsRunningOnDesktop || t != typeof (Java.Interop.TypeManager)) {
 					// skip the registration and output a warning
 					Logger.Log (LogLevel.Warn, "monodroid", string.Format ("Type Registration Skipped for {0} to {1} ", java_class, t.ToString()));
 				}

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -308,7 +308,7 @@ namespace Java.Interop {
 			return c.Invoke (new object[]{handle, transfer});
 		}
 
-		public static void RegisterType (string java_class, Type t)
+		public static void RegisterType (string java_class, Type t, bool ignoreExistingRegistration = false)
 		{
 			string jniFromType = JniTypeMapping.ToJniName (t);
 			lock (jniToManaged) {
@@ -318,7 +318,7 @@ namespace Java.Interop {
 					if (jniFromType != java_class) {
 						managedToJni.Add (t, java_class);
 					}
-				} else {
+				} else if (!ignoreExistingRegistration) {
 					// skip the registration and output a warning
 					Logger.Log (LogLevel.Warn, "monodroid", string.Format ("Type Registration Skipped for {0} to {1} ", java_class, t.ToString()));
 				}


### PR DESCRIPTION
Previously, we were using the value of `mono_domain_get` and comparing it to our context corresponding appdomain instance to decide if we had to reset the Java TypeManager integration (called via the `reinitialize_android_runtime_type_manager` function).

When instantiating several sessions and refreshing them rapidly at the same time (which is something the Xamarin.Forms previewer does), we started noticing cases of objects being created in one domain and subsequently being used in another although the domain context should have been switched.

I tracked down the issue to TypeManager.java and the `n_activate` method which was, in this case, incorrectly allocating the managed peer in a different domain than it should.

The reason is because the designer hosts its different sessions in individual thread, contexts are locally created and used from different execution contexts. As `mono_domain_get` uses Mono's TLS to store which domain it's currently on, the function is *not* actually tracking a global domain usage from native code but rather a per-thread usage.

This meant that TypeManager.java `registerJniNatives` method was silently not being called because from the session thread point of view, it was already on the right domain and that in turn prevented subsequent type creation from happening in their rightful domain because the glue code between Java and managed hasn't been reset to tap into that domain.

Thus to achieve the desired effect, this commit introduces a new field to track which context ID was last selected so that we can make sure the Java integration is properly reset anytime it needs to be.