### PR TITLE
[fastdev] _SetupApplicationJavaClass must be after _ResolveAndroidSdks.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -597,7 +597,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	</CreateItem>
 </Target>
 
-<Target Name="_SetupApplicationJavaClass" AfterTargets="_SetLatestTargetFrameworkVersion">
+<Target Name="_SetupApplicationJavaClass" AfterTargets="_ResolveMonoAndroidSdks">
 	<PropertyGroup>
 		<AndroidApplicationJavaClass Condition="'$(AndroidApplicationJavaClass)' == '' And $(AndroidEnableMultiDex)">android.support.multidex.MultiDexApplication</AndroidApplicationJavaClass>
 		<AndroidApplicationJavaClass Condition="'$(AndroidApplicationJavaClass)' == ''">android.app.Application</AndroidApplicationJavaClass>


### PR DESCRIPTION
fastdev requires AdbToolPath which is initialized only after SDK tools
were properly set up.