### PR TITLE
[Xamarin.Android.Build.Tasks] Add Items to _SharedRuntimeAssemblies to ensure they get included in Profile.g.cs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -7,6 +7,10 @@
   </PropertyGroup>
   <ItemGroup>
     <_SharedRuntimeAssemblies Include="$(_SharedRuntimeBuildPath)v1.0\*.dll;$(_SharedRuntimeBuildPath)$(AndroidFrameworkVersion)\*.dll"/>
+    <!-- These files are build after Xamarin.Android.Build.Tasks but MUST be included in Profile.g.cs -->
+    <_SharedRuntimeAssemblies Include="$(_SharedRuntimeBuildPath)$(AndroidFrameworkVersion)\Mono.Android.dll" />
+    <_SharedRuntimeAssemblies Include="$(_SharedRuntimeBuildPath)$(AndroidFrameworkVersion)\OpenTK.dll" />
+    <_SharedRuntimeAssemblies Include="$(_SharedRuntimeBuildPath)$(AndroidFrameworkVersion)\OpenTK-1.0.dll" />
   </ItemGroup>
 
   <Target Name="_GenerateProfileClass"


### PR DESCRIPTION
There was a bug where items like OpenTK and Mono.Android were not
being included in the Profile.g.cs file. As a result they were
not being picked up as framework assemblies. This resulted in
duplicate java classes being generated at build time.

This commit fixes this by manually adding the required items
to the _SharedRuntimeAssemblies ItemGroup. This works because
we don't do any file exists checks on the files in this ItemGroup.