### PR TITLE
[Xamarin.Android.Build.Tasks] Corruption of zips if build stopped

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -188,9 +188,9 @@ namespace Xamarin.Android.Tools {
 			return hashes;
 		}
 
-		public static ZipArchive ReadZipFile (string filename)
+		public static ZipArchive ReadZipFile (string filename, bool strictConsistencyChecks = false)
 		{
-			return ZipArchive.Open (filename, FileMode.Open);
+			return ZipArchive.Open (filename, FileMode.Open, strictConsistencyChecks: strictConsistencyChecks);
 		}
 
 		public static void ExtractAll(ZipArchive zip, string destination, Action<int, int> progressCallback = null)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -324,6 +324,17 @@ namespace Xamarin.Android.Tasks
 			return Files.ReadZipFile (filename);
 		}
 
+		public static bool IsValidZip (string filename)
+		{
+			try {
+				using (var zip = Files.ReadZipFile (filename, strictConsistencyChecks: true)) {
+				}
+			} catch (ZipIOException) {
+				return false;
+			}
+			return true;
+		}
+
 		public static string HashFile (string filename)
 		{
 			return Files.HashFile (filename);


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=41123
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=41608

The current implementation of GetAdditionalResourcesFromAssemblies
does not support resuming a download. It also does not support
validating a zip file prior to extracting it.

This commit modifies the download process to detect partial
downloads and to attept to resume them. It does this by making
use of the http `Range` header. This gives the server the offset
it needs to restart the download. If we detect a partial zip
we send the current file size to the server so that we can
resume it. If the server returns that is cannot resume we will
then delete the local file and try a full download again.

We also make use of the LibZipSharp capability to validate the
zip on opening so ensure it is extractable. In the case where it
is not we attempt to download/resume the zip.

Another issue was that if the download does NOT succeed we still
wrote out the Cache file. As a result on the following build if the
download failed the app would skip the download and attempt a normal
build (which would fail).

The fix here is to only write the cache file IF and ONLY IF we manage
to succeed in downloading the required resources. If the file does not
exist then the download will be resumed the next time around.