### PR TITLE
[build] Package build artifacts with `make jenkins`

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -12,6 +12,7 @@
       Condition=" '$(DoNotLoadOSProperties)' != 'True' "
   />
   <PropertyGroup>
+    <ProductVersion>7.0.99</ProductVersion>
     <HostOS Condition=" '$(HostOS)' == '' And '$(OS)' == 'Windows_NT' ">Windows</HostOS>
     <HostCc Condition=" '$(HostCc)' == '' ">$(HostCc64)</HostCc>
     <HostCxx Condition=" '$(HostCxx)' == '' ">$(HostCxx64)</HostCxx>

--- a/samples/HelloWorld/HelloWorld.csproj
+++ b/samples/HelloWorld/HelloWorld.csproj
@@ -16,7 +16,7 @@
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
-  <Import Project="..\..\..\Configuration.props" />
+  <Import Project="..\..\Configuration.props" />
   <PropertyGroup>
     <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
   </PropertyGroup>

--- a/tools/scripts/xabuild
+++ b/tools/scripts/xabuild
@@ -1,26 +1,53 @@
 #!/bin/bash -e
-topdir="$(cd `dirname "$0"`/../.. && pwd)"
+
+name=$(basename "$0")
 
 if [ -z "$CONFIGURATION" ] ; then
 	CONFIGURATION=Debug
+fi
+
+xabuilddir="$(cd `dirname "$0"` && pwd)"
+
+if [[ "$xabuilddir" == */tools/scripts ]] ; then
+	topdir="$xabuilddir/../../bin/$CONFIGURATION"
+	Paths_targets="$xabuilddir/../../build-tools/scripts/Paths.targets"
+elif [[ "$xabuilddir" == */bin ]] ; then
+	topdir="$xabuilddir/.."
+else
+	(>&2 echo "$name: Could not determine location to Xamarin.Android locations.")
+	exit 1
 fi
 
 if [ -z "$MSBUILD" ] ; then
 	MSBUILD=xbuild
 fi
 
-export TARGETS_DIR="$topdir/bin/$CONFIGURATION/lib/xbuild"
-export MSBuildExtensionsPath="$TARGETS_DIR" 
-export MONO_ANDROID_PATH="$topdir/bin/$CONFIGURATION"
-export XBUILD_FRAMEWORK_FOLDERS_PATH="$topdir/bin/$CONFIGURATION/lib/xbuild-frameworks"
-ANDROID_NDK_PATH=$(xbuild /nologo /v:minimal /t:GetAndroidNdkFullPath $topdir/build-tools/scripts/Paths.targets)
-ANDROID_SDK_PATH=$(xbuild /nologo /v:minimal /t:GetAndroidSdkFullPath $topdir/build-tools/scripts/Paths.targets)
+if [ -z "$ANDROID_NDK_PATH" -a -f "$Paths_targets" ] ; then
+	ANDROID_NDK_PATH=$($MSBUILD /nologo /v:minimal /t:GetAndroidNdkFullPath "$Paths_targets")
+	ANDROID_NDK_PATH=$(echo $ANDROID_NDK_PATH | sed 's/^\w*//g')
+	export ANDROID_NDK_PATH
+fi
 
-ANDROID_NDK_PATH=$(echo $ANDROID_NDK_PATH | sed 's/^\w*//g')
-ANDROID_SDK_PATH=$(echo $ANDROID_SDK_PATH | sed 's/^\w*//g')
+if [ -z "$ANDROID_SDK_PATH" -a -f "$Paths_targets" ] ; then
+	ANDROID_SDK_PATH=$($MSBUILD /nologo /v:minimal /t:GetAndroidSdkFullPath "$Paths_targets")
+	ANDROID_SDK_PATH=$(echo $ANDROID_SDK_PATH | sed 's/^\w*//g')
+	export ANDROID_SDK_PATH
+fi
 
-export ANDROID_NDK_PATH
-export ANDROID_SDK_PATH
+if [ -z "$ANDROID_NDK_PATH" ] ; then
+	>&2 echo "$name: Could not determine Android NDK path. Please export the \$ANDROID_NDK_PATH environment variable."
+	exit 1
+fi
+
+if [ -z "$ANDROID_SDK_PATH" ] ; then
+	>&2 echo "$name: Could not determine Android SDK path. Please export the \$ANDROID_SDK_PATH environment variable."
+	exit 1
+fi
+
+export TARGETS_DIR="$topdir/lib/xbuild"
+export MSBuildExtensionsPath="$TARGETS_DIR"
+export MONO_ANDROID_PATH="$topdir"
+export XBUILD_FRAMEWORK_FOLDERS_PATH="$topdir/lib/xbuild-frameworks"
 
 exec $MSBUILD /p:Configuration=$CONFIGURATION $MSBUILD_OPTIONS \
 	/p:AndroidNdkDirectory="$ANDROID_NDK_PATH" \


### PR DESCRIPTION
Update the `make jenkins` target to package up the `bin` directory for
(hopeful) use on other machines.

The generated package is named:

	oss-xamarin-android,branch=BRANCH,commit=COMMIT,version=VERSION.zip

where BRANCH is the git branch being built (usually `master`), COMMIT
is the git commit that was built, and VERSION contains the new
`$(ProductVersion)` MSBuild property along with the number of commits
since `$(ProductVersion)` was *changed*.

The package file is *not* an installer, just a ZIP package, but should
contain everything needed to *create* an installer.