### PR TITLE
Allow MonoGCBridgeSCC objects to have an empty User Peer list

### DIFF
--- a/src/Mono.Android/java/mono/android/GCUserPeer.java
+++ b/src/Mono.Android/java/mono/android/GCUserPeer.java
@@ -1,16 +1,16 @@
 package mono.android;
 
-class GCUserPeer {
+class GCUserPeer implements IGCUserPeer {
 	private java.util.ArrayList refList = null;
 
-	void monodroidAddReference (java.lang.Object obj)
+	public void monodroidAddReference (java.lang.Object obj)
 	{
 		if (refList == null)
 			refList = new java.util.ArrayList ();
 		refList.add (obj);
 	}
 
-	void monodroidClearReferences ()
+	public void monodroidClearReferences ()
 	{
 		if (refList != null)
 			refList.clear ();

--- a/src/Mono.Android/java/mono/android/GCUserPeer.java
+++ b/src/Mono.Android/java/mono/android/GCUserPeer.java
@@ -1,0 +1,19 @@
+package mono.android;
+
+class GCUserPeer {
+	private java.util.ArrayList refList = null;
+
+	void monodroidAddReference (java.lang.Object obj)
+	{
+		if (refList == null)
+			refList = new java.util.ArrayList ();
+		refList.add (obj);
+	}
+
+	void monodroidClearReferences ()
+	{
+		if (refList != null)
+			refList.clear ();
+	}
+}
+


### PR DESCRIPTION
Mono passes gc_cross_references a description of a graph. Each node in the graph has a list of User Peer objects which should be collected together in the upcoming GC. This list is required by both the spec and the current code to be nonempty. To enable new optimizations, the runtime team wants to modify the spec to allow the list to be empty. This patch makes that possible by creating a new temporary object of type GCUserPeer when a MonoGCBridgeSCC with an empty list is seen.

I think this patch should not be merged until tests with Mono have shown that this can actually produce a performance improvement. In the meantime you can test this with https://github.com/xmcclure/mono/tree/andi-phantom-test-1 and https://github.com/xmcclure/monodroid/commits/andi-phantom-test-1 .