### PR TITLE
[build] Include zip basename directory in build artifacts

### DIFF
--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -10,7 +10,8 @@ GIT_COMMIT        = $(shell LANG=C git log --no-color --first-parent -n1 --prett
 # "0" when commit hash is invalid (e.g. 00000000)
 -num-commits-since-version-change = $(shell LANG=C git log $(-commit-of-last-version-change)..HEAD --oneline 2>/dev/null | wc -l | sed 's/ //g')
 
-ZIP_OUTPUT        = oss-xamarin.android_v$(PRODUCT_VERSION).$(-num-commits-since-version-change)_$(OS)-$(OS_ARCH)_$(GIT_BRANCH)_$(GIT_COMMIT).zip
+ZIP_OUTPUT_BASENAME   = oss-xamarin.android_v$(PRODUCT_VERSION).$(-num-commits-since-version-change)_$(OS)-$(OS_ARCH)_$(GIT_BRANCH)_$(GIT_COMMIT)
+ZIP_OUTPUT            = $(ZIP_OUTPUT_BASENAME).zip
 
 
 # $(ALL_API_LEVELS) and $(ALL_FRAMEWORKS) must be kept in sync w/ each other
@@ -95,4 +96,6 @@ package-oss-name:
 package-oss $(ZIP_OUTPUT):
 	if [ -d bin/Debug/bin ]   ; then cp tools/scripts/xabuild bin/Debug/bin   ; fi
 	if [ -d bin/Release/bin ] ; then cp tools/scripts/xabuild bin/Release/bin ; fi
-	zip -r "$(ZIP_OUTPUT)" bin $(_BUNDLE_ZIPS:%=--exclude %)
+	if [ ! -d $(ZIP_OUTPUT_BASENAME) ] ; then mkdir $(ZIP_OUTPUT_BASENAME) ; fi
+	if [ ! -L $(ZIP_OUTPUT_BASENAME)/bin ] ; then ln -s ../bin $(ZIP_OUTPUT_BASENAME) ; fi
+	zip -r "$(ZIP_OUTPUT)" $(ZIP_OUTPUT_BASENAME) $(_BUNDLE_ZIPS:%=--exclude %)


### PR DESCRIPTION
Commit 1eebbe33 introduces generation of `oss-xamarin-android*.zip`
files when using the `make jenkins` target.

There's one "problem" with this file: a common convention for .zip
files is that they will contain a single directory named as the
basename of the .zip file itself:

	$ unzip -l foo-1.zip
	... foo-1/
	... foo-1/file1
	... foo-1/file2
	...

The benefit to this scheme is that if you have multiple "versions" of
the file, you can extract them without fear of file conflicts:

	# extracts into foo-1
	$ unzip foo-1.zip

	# extracts into foo-2
	$ unzip foo-2.zip

The `oss-xamarin-android*.zip` packages *didn't* follow this scheme:
instead, they contained the `bin` directory as it's top directory:

	$ unzip -l oss-xamarin.android_v7.0.99.2_Darwin-x86_64_HEAD_fbfd676.zip  | head -10
	Archive:  /Users/jon/Downloads/oss-xamarin.android_v7.0.99.2_Darwin-x86_64_HEAD_fbfd676.zip
	  Length     Date   Time    Name
	 --------    ----   ----    ----
	        0  08-10-16 21:46   bin/
	        0  08-10-16 23:40   bin/BuildDebug/
	    43008  08-10-16 20:10   bin/BuildDebug/api-merge.exe

This means you can't download and extract both
`oss-xamarin.android_v7.0.99.1*.zip` and
`oss-xamarin.android_v7.0.99.2*.zip` into the same directory -- not
without extra work -- which is counter to convention.

Fix the `make package-oss` target so that the zip's basename is
included in the directory structure:

	$ unzip -l oss-xamarin.android_v7.0.99.2_Darwin-x86_64_HEAD_fbfd676.zip  | head -10
	Archive:  /Users/jon/Downloads/oss-xamarin.android_v7.0.99.2_Darwin-x86_64_HEAD_fbfd676.zip
	  Length     Date   Time    Name
	 --------    ----   ----    ----
	        0  08-10-16 21:46   oss-xamarin.android_v7.0.99.2_Darwin-x86_64_HEAD_fbfd676/bin/
	        0  08-10-16 23:40   oss-xamarin.android_v7.0.99.2_Darwin-x86_64_HEAD_fbfd676/bin/BuildDebug/
	    43008  08-10-16 20:10   oss-xamarin.android_v7.0.99.2_Darwin-x86_64_HEAD_fbfd676/bin/BuildDebug/api-merge.exe