### PR TITLE
Implement HTTP redirections in managed code

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidHttpResponseMessage.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidHttpResponseMessage.cs
@@ -20,14 +20,6 @@ namespace Xamarin.Android.Net
 		/// <value>The requested authentication.</value>
 		public IList <AuthenticationData> RequestedAuthentication { get; internal set; }
 
-		public AndroidHttpResponseMessage ()
-		{}
-
-		public AndroidHttpResponseMessage (URL javaUrl, HttpURLConnection httpConnection) {
-			javaUrl = javaUrl;
-			httpConnection = httpConnection;
-		}
-
 		/// <summary>
 		/// Set to the same value as <see cref="AndroidClientHandler.RequestNeedsAuthorization"/>
 		/// </summary>
@@ -36,7 +28,16 @@ namespace Xamarin.Android.Net
 			get { return RequestedAuthentication?.Count > 0; }
 		}
 
-		protected override void Dispose(bool disposing) {
+		public AndroidHttpResponseMessage ()
+		{}
+
+		public AndroidHttpResponseMessage (URL javaUrl, HttpURLConnection httpConnection) {
+			javaUrl = javaUrl;
+			httpConnection = httpConnection;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
 			base.Dispose(disposing);
 
 			if (javaUrl != null) {


### PR DESCRIPTION
The "native" Java HTTP client doesn't support redirections from HTTP to
HTTPS URLs (why? Nobody knows) and also it has a hard-coded limit of 5
redirections. This commit implements handling of the HTTP redirection
status codes directly in the AndroidClientHandler class completely
bypassing the Java code.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=43151