### PR TITLE
[Xamarin.Android.Build.Tasks] Fixed F# Resource Designer compilation issues [DONT MERGE]

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
@@ -38,6 +38,15 @@ namespace Xamarin.Android.Tasks
 
 		public ITaskItem[] References { get; set; }
 
+		[Required]
+		public string IntermediateOutputPath { get; set; }
+
+		[Output]
+		public bool BuildResourceAssembly { get; set; }
+
+		[Output]
+		public string IntermediateDesignerFile { get; set; }
+
 		private Dictionary<string, string> resource_fixup = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase);
 
 		public override bool Execute ()
@@ -98,6 +107,14 @@ namespace Xamarin.Android.Tasks
 			bool isFSharp = string.Equals (language, "F#", StringComparison.OrdinalIgnoreCase);
 			bool isCSharp = string.Equals (language, "C#", StringComparison.OrdinalIgnoreCase);
 
+			if (isFSharp) {
+				language = "C#";
+				isCSharp = true;
+				NetResgenOutputFile = Path.Combine (IntermediateOutputPath, "Resource.Designer.cs");
+				IntermediateDesignerFile = NetResgenOutputFile;
+			}
+
+			BuildResourceAssembly = isFSharp;
 			// Let VB put this in the default namespace
 			if (isVB)
 				Namespace = string.Empty;
@@ -125,31 +142,25 @@ namespace Xamarin.Android.Tasks
 					.CreateImportMethods (assemblies);
 			}
 
-			AdjustConstructor (isFSharp, resources);
+			AdjustConstructor (resources);
 			foreach (var member in resources.Members)
 				if (member is CodeTypeDeclaration)
-					AdjustConstructor (isFSharp, (CodeTypeDeclaration) member);
+					AdjustConstructor ((CodeTypeDeclaration) member);
 
 			// Write out our Resources.Designer.cs file
 
-			WriteFile (NetResgenOutputFile, resources, language, isFSharp, isCSharp);
+			WriteFile (NetResgenOutputFile, resources, language, isCSharp, isFSharp);
+
+			Log.LogDebugMessage ($"[Output] BuildResourceAssembly : {BuildResourceAssembly}");
+			Log.LogDebugMessage ($"[Output] IntermediateDesignerFile : {IntermediateDesignerFile}");
 
 			return !Log.HasLoggedErrors;
 		}
 
 		// Remove private constructor in F#.
 		// Add static constructor. (but ignored in F#)
-		void AdjustConstructor (bool isFSharp, CodeTypeDeclaration type)
+		void AdjustConstructor (CodeTypeDeclaration type)
 		{			
-			if (isFSharp) {
-				foreach (CodeTypeMember tm in type.Members) {
-					if (tm is CodeConstructor) {
-						type.Members.Remove (tm);
-						break;
-					}
-				}
-			}
-
 			var staticCtor = new CodeTypeConstructor () { Attributes = MemberAttributes.Static };
 			staticCtor.Statements.Add (
 				new CodeExpressionStatement (
@@ -162,11 +173,9 @@ namespace Xamarin.Android.Tasks
 			type.Members.Add (staticCtor);
 		}
 
-		private void WriteFile (string file, CodeTypeDeclaration resources, string language, bool isFSharp, bool isCSharp)
+		private void WriteFile (string file, CodeTypeDeclaration resources, string language, bool isCSharp, bool isFSharp)
 		{
-			CodeDomProvider provider = 
-				isFSharp ? new FSharp.Compiler.CodeDom.FSharpCodeProvider () :
-				CodeDomProvider.CreateProvider (language);
+			CodeDomProvider provider = CodeDomProvider.CreateProvider (language);
 
 			string code = null;
 			using (var o = new StringWriter ()) {
@@ -181,6 +190,24 @@ namespace Xamarin.Android.Tasks
 
 				if (resources != null)
 					ns.Types.Add (resources);
+
+				if (isFSharp) {
+					foreach (CodeTypeMember member in resources.Members) {
+						var codeType = member as CodeTypeDeclaration;
+						if (codeType == null || !codeType.IsClass)
+							continue;
+						var dec = new CodeTypeDeclaration (resources.Name + "_" + member.Name);
+						dec.IsClass = true;
+						dec.IsPartial = true;
+						dec.TypeAttributes = System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Sealed;
+						dec.BaseTypes.Add (new CodeTypeReference (resources.Name + "." + member.Name));
+						var codeAttrDecl = new CodeAttributeDeclaration (
+							"System.ObsoleteAttribute",
+							new CodeAttributeArgument (new CodePrimitiveExpression ($"You should use {resources.Name}.{member.Name} instead")));
+						dec.CustomAttributes.Add (codeAttrDecl);
+						ns.Types.Add (dec);
+					}
+				}
 
 				var unit = new CodeCompileUnit ();
 				unit.Namespaces.Add (ns);
@@ -201,23 +228,6 @@ namespace Xamarin.Android.Tasks
 					provider.GenerateCodeFromCompileUnit(new CodeSnippetCompileUnit("#pragma warning restore 1591"), o, options);
 
 				code = o.ToString ();
-
-				// post-processing for F#
-				if (isFSharp) {
-					code = code.Replace ("\r\n", "\n");
-					while (true) {
-						int skipLen = " = class".Length;
-						int idx = code.IndexOf (" = class");
-						if (idx < 0)
-							break;
-						int end = code.IndexOf ("        end");
-						string head = code.Substring (0, idx);
-						string mid = end < 0 ? code.Substring (idx) : code.Substring (idx + skipLen, end - idx - skipLen);
-						string last = end < 0 ? null : code.Substring (end + "        end".Length);
-						code = head + @" () =
-            static do Android.Runtime.ResourceIdManager.UpdateIdValues()" + mid + "\n" + last;
-					}
-				}
 			}
 			
 			var temp_o  = Path.Combine (Path.GetDirectoryName (file), "__" + Path.GetFileName (file) + ".new");

--- a/src/Xamarin.Android.Build.Tasks/Utilities/JavaResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/JavaResourceParser.cs
@@ -74,7 +74,7 @@ namespace Xamarin.Android.Tasks
 							TypeAttributes  = TypeAttributes.Public,
 						};
 						t.Members.Add (new CodeConstructor () {
-								Attributes  = MemberAttributes.Private,
+								Attributes  = MemberAttributes.Family,
 						});
 						g.Members.Add (t);
 						return g;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -466,6 +466,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		UpdateAndroidResources;
 		$(ApplicationResolveReferencesDependsOn);
 	</ResolveReferencesDependsOn>
+	<ResolveAssemblyReferencesDependsOn>
+		_GenerateResourceDesignerStub;
+		$(ResolveAssemblyReferencesDependsOn)
+	</ResolveAssemblyReferencesDependsOn>
 </PropertyGroup>
 
 <PropertyGroup Condition="'$(AndroidApplication)' != '' And $(AndroidApplication)">
@@ -992,8 +996,35 @@ because xbuild doesn't support framework reference assemblies.
 <!-- Resource Build -->
 
 <Target Name="UpdateAndroidResources"
-	DependsOnTargets="$(CoreResolveReferencesDependsOn);_CheckForDeletedResourceFile;_ComputeAndroidResourcePaths;_UpdateAndroidResgen;_AddLibraryProjectsEmbeddedResourceToProject;_GenerateJavaDesignerForComponent" />
+	DependsOnTargets="$(CoreResolveReferencesDependsOn);_CheckForDeletedResourceFile;_ComputeAndroidResourcePaths;_UpdateAndroidResgen;_UseCompiledDesignerAssembly;_AddLibraryProjectsEmbeddedResourceToProject;_GenerateJavaDesignerForComponent" />
 
+
+<Target Name="_GenerateResourceDesignerStub" Condition=" !Exists ('$(IntermediateOutputPath)Resource.Designer.dll') And '$(Language)' == 'F#' ">
+	<Touch Files="$(IntermediateOutputPath)\Resource.Designer.stub.cs" AlwaysCreate="True" />
+	<Csc
+		KeyFile="$(KeyFile)"
+		KeyContainer="$(KeyContainer)"
+		NoStandardLib="True"
+		NoConfig="True"
+		TargetType="library"
+		Platform="$(PlatformTarget)"
+		DefineConstants="$(DefineConstants)"
+		References="$(_XATargetFrameworkDirectories)System.dll;$(_XATargetFrameworkDirectories)System.Core.dll;$(_XATargetFrameworkDirectories)Java.Interop.dll;$(_XATargetFrameworkDirectories)mscorlib.dll"
+		Sources="$(IntermediateOutputPath)\Resource.Designer.stub.cs"
+		OutputAssembly="$(IntermediateOutputPath)Resource.Designer.dll"
+	/>
+	<ItemGroup>
+		<Reference Include="$(IntermediateOutputPath)Resource.Designer.dll" />
+	</ItemGroup>
+</Target>
+	
+<Target Name="_UseCompiledDesignerAssembly"
+	Condition=" Exists ('$(IntermediateOutputPath)Resource.Designer.dll') And '$(_BuildResourceAssembly)' == 'true' ">
+	<ItemGroup>
+		<ReferencePath Include="$(IntermediateOutputPath)Resource.Designer.dll" />
+		<Compile Remove="$(_AndroidResourceDesignerFile)" />
+	</ItemGroup>
+</Target>
 <!-- Handle a case where the designer file has been deleted, but the flag file still exists -->
 <Target Name="_CheckForDeletedResourceFile">
 	<Delete Files="$(_AndroidResgenFlagFile)"
@@ -1301,7 +1332,11 @@ because xbuild doesn't support framework reference assemblies.
 		AdditionalResourceDirectories="@(LibraryResourceDirectories)"
 		IsApplication="$(AndroidApplication)"
 		References="@(ReferencePath)"
-	/>
+		IntermediateOutputPath="$(IntermediateOutputPath)"
+	>
+		<Output TaskParameter="BuildResourceAssembly" PropertyName="_BuildResourceAssembly" />
+		<Output TaskParameter="IntermediateDesignerFile" PropertyName="_IntermediateDesignerFile" />
+	</GenerateResourceDesigner>
 
 	<!-- Only copy if the file contents changed, so users only get Reload? dialog for real changes -->
 	<CopyIfChanged
@@ -1312,6 +1347,19 @@ because xbuild doesn't support framework reference assemblies.
 
 	<!-- Delete our temporary directory -->
 	<RemoveDirFixed Directories="$(ResgenTemporaryDirectory)" />
+
+	<Csc Condition=" '$(_BuildResourceAssembly)' == 'true' "
+		KeyFile="$(KeyFile)"
+		KeyContainer="$(KeyContainer)"
+		NoStandardLib="True"
+		TargetType="library"
+		NoConfig="True"
+		Platform="$(PlatformTarget)"
+		DefineConstants="$(DefineConstants)"
+		References="@(ReferencePath);@(ReferenceDependencyPaths);$(_XATargetFrameworkDirectories)\Java.Interop.dll;$(_XATargetFrameworkDirectories)\mscorlib.dll"
+		Sources="$(_IntermediateDesignerFile)"
+		OutputAssembly="$(IntermediateOutputPath)Resource.Designer.dll"
+	/>
 	
 	<!-- If there are no _AndroidResource items, create a blank file -->
 	<CreateAndroidResourceStamp
@@ -2500,6 +2548,8 @@ because xbuild doesn't support framework reference assemblies.
 	<Delete Files="$(_AndroidLibraryImportsCache)" />
 	<Delete Files="$(_AndroidStaticResourcesFlag)" />
 	<Delete Files="$(_AndroidLibraryProjectImportsCache)" />
+	<Delete Files="$(IntermediateOutputPath)Resource.Designer.dll" />
+	<Delete Files="$(IntermediateOutputPath)\Resource.Designer.stub.cs" />
 </Target>
 
 <Target Name="_CollectMonoAndroidOutputs" DependsOnTargets="_ValidateAndroidPackageProperties">


### PR DESCRIPTION
The latest release of F# removed support for static fields. As a result
the Resource.Designer.fs file that wes being generated by our build
system no longer compiled.

This commit reworks the Designer.cs code to emit a C# assembly for
F# projects rather than just the code. This has the benifit of
us not having to produce F# code in the first place.

The new system works as follows.

1) GenerateResourceDesigner Task generates a Resources.Designer.xx file as normal
2) If the target project is F# that file is then compiled into a Resource.Designer.dll
3) The new .dll is then included in the @ReferencePaths ItemGroup
4) The Resource.Designer.xx is removed from the @Complie ItemGroup

If the project is C# or VS the Designer file is just included as normal.
