### PR TITLE
[xa-prep-tasks] Use the Mono bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,14 @@ all-tests::
 
 prepare:: prepare-external prepare-props
 
+# $(call GetPath,path)
+GetPath   = $(shell $(MSBUILD) $(MSBUILD_FLAGS) /p:DoNotLoadOSProperties=True /nologo /v:minimal /t:Get$(1)FullPath build-tools/scripts/Paths.targets | tr -d '[[:space:]]' )
+
 prepare-external:
 	git submodule update --init --recursive
 	nuget restore $(SOLUTION)
 	nuget restore Xamarin.Android-Tests.sln
-	(cd `$(MSBUILD) $(MSBUILD_FLAGS) /p:DoNotLoadOSProperties=True /nologo /v:minimal /t:GetJavaInteropFullPath build-tools/scripts/Paths.targets` && nuget restore)
+	(cd $(call GetPath,JavaInterop) && nuget restore)
 
 prepare-props:
 	cp Configuration.Java.Interop.Override.props external/Java.Interop/Configuration.Override.props

--- a/README.md
+++ b/README.md
@@ -292,8 +292,14 @@ within `build-tools/mono-runtimes/obj/$(Configuration)/TARGET`.
 
 If you change sources within `external/mono`, a top-level `make`/`xbuild`
 invocation may not rebuild those mono native binaries. To explicitly rebuild
-Mono for a given target, run `make` from the relevant directory.
-For example, to rebuild Mono for armeabi-v7a:
+*all* Mono runtimes, use the `ForceBuild` target:
+
+	# Build and install all runtimes
+	$ xbuild /t:ForceBuild build-tools/mono-runtimes/mono-runtimes.mdproj
+
+To build Mono for a specific target, run `make` from the relevant directory
+and invoke the `_InstallRuntimes` target. For example, to rebuild
+Mono for armeabi-v7a:
 
 	$ cd build-tools/mono-runtimes
 	$ make -C obj/Debug/armeabi-v7a

--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -89,6 +89,8 @@ Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "libzip-windows", "build-too
 EndProject
 Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "bundle", "build-tools\bundle\bundle.mdproj", "{1640725C-4DB8-4D8D-BC96-74E688A06EEF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xa-prep-tasks", "build-tools\xa-prep-tasks\xa-prep-tasks.csproj", "{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|AnyCPU = Debug|AnyCPU
@@ -407,6 +409,14 @@ Global
 		{1640725C-4DB8-4D8D-BC96-74E688A06EEF}.XAIntegrationDebug|AnyCPU.Build.0 = Debug|Any CPU
 		{1640725C-4DB8-4D8D-BC96-74E688A06EEF}.XAIntegrationRelease|AnyCPU.ActiveCfg = Release|Any CPU
 		{1640725C-4DB8-4D8D-BC96-74E688A06EEF}.XAIntegrationRelease|AnyCPU.Build.0 = Release|Any CPU
+		{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}.XAIntegrationDebug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}.XAIntegrationDebug|AnyCPU.Build.0 = Debug|Any CPU
+		{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}.XAIntegrationRelease|AnyCPU.ActiveCfg = Debug|Any CPU
+		{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}.XAIntegrationRelease|AnyCPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
@@ -449,6 +459,7 @@ Global
 		{C9FF2E4D-D927-479E-838B-647C16763F64} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{0DE278D6-000F-4001-BB98-187C0AF58A61} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 		{1640725C-4DB8-4D8D-BC96-74E688A06EEF} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
+		{7CE69551-BD73-4726-ACAA-AAF89C84BAF8} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/build-tools/android-toolchain/android-toolchain.mdproj
+++ b/build-tools/android-toolchain/android-toolchain.mdproj
@@ -26,12 +26,15 @@
     </BuildDependsOn>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\xa-prep-tasks\xa-prep-tasks.csproj">
+      <Project>{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}</Project>
+      <Name>xa-prep-tasks</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\Xamarin.Android.Tools.BootstrapTasks\Xamarin.Android.Tools.BootstrapTasks.csproj">
       <Project>{E8492EFB-D14A-4F32-AA28-88848322ECEA}</Project>
       <Name>Xamarin.Android.Tools.BootstrapTasks</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-      <OutputItemType>Content</OutputItemType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -10,10 +10,8 @@
         Properties="OutputPath=$(AndroidToolchainDirectory)"
     />
   </Target>
-  <UsingTask AssemblyFile="$(OutputPath)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.CreateTemporaryDirectory" />
-  <UsingTask AssemblyFile="$(OutputPath)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.DownloadUri" />
-  <UsingTask AssemblyFile="$(OutputPath)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.UnzipDirectoryChildren" />
-  <UsingTask AssemblyFile="$(OutputPath)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.Which" />
+  <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"   TaskName="Xamarin.Android.BuildTools.PrepTasks.DownloadUri" />
+  <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.UnzipDirectoryChildren" />
   <Target Name="_DetermineItems">
     <CreateItem
         Include="@(AndroidSdkItem)"

--- a/build-tools/bundle/bundle-path.targets
+++ b/build-tools/bundle/bundle-path.targets
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.GitCommitHash" />
+  <Target Name="_GetHashes">
+    <GitCommitHash
+        WorkingDirectory="$(LibZipSourceFullPath)"
+        ToolPath="$(GitToolPath)"
+        ToolExe="$(GitToolExe)">
+      <Output TaskParameter="AbbreviatedCommitHash"   PropertyName="_LibZipHash" />
+    </GitCommitHash>
+    <GitCommitHash
+        WorkingDirectory="$(LlvmSourceFullPath)"
+        ToolPath="$(GitToolPath)"
+        ToolExe="$(GitToolExe)">
+      <Output TaskParameter="AbbreviatedCommitHash"   PropertyName="_LlvmHash" />
+    </GitCommitHash>
+    <GitCommitHash
+        WorkingDirectory="$(MonoSourceFullPath)"
+        ToolPath="$(GitToolPath)"
+        ToolExe="$(GitToolExe)">
+      <Output TaskParameter="AbbreviatedCommitHash"   PropertyName="_MonoHash" />
+    </GitCommitHash>
+  </Target>
+  <Target Name="GetBundleFileName"
+      DependsOnTargets="_GetHashes">
+    <PropertyGroup>
+      <XABundleFileName>bundle-v2-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/build-tools/bundle/bundle.mdproj
+++ b/build-tools/bundle/bundle.mdproj
@@ -22,6 +22,11 @@
   </PropertyGroup>
   <Import Project="bundle.targets" />
   <ItemGroup>
+    <ProjectReference Include="..\xa-prep-tasks\xa-prep-tasks.csproj">
+      <Project>{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}</Project>
+      <Name>xa-prep-tasks</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
     <ProjectReference Include="..\android-toolchain\android-toolchain.mdproj">
       <Project>{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA}</Project>
       <Name>android-toolchain</Name>

--- a/build-tools/bundle/bundle.targets
+++ b/build-tools/bundle/bundle.targets
@@ -1,78 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask AssemblyFile="$(_SourceTopDir)\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.GetNugetPackageBasePath" />
-  <UsingTask AssemblyFile="$(_SourceTopDir)\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.GitCommitHash" />
   <UsingTask AssemblyFile="$(_SourceTopDir)\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.Zip" />
   <Import Project="..\mono-runtimes\mono-runtimes.props" />
   <Import Project="..\mono-runtimes\mono-runtimes.projitems" />
   <Import Project="..\mono-runtimes\mono-runtimes.targets" />
   <Import Project="..\libzip\libzip.props" />
   <Import Project="..\libzip\libzip.projitems" />
+  <Import Project="..\libzip\libzip.targets" />
   <Import Project="..\libzip-windows\libzip-windows.props" />
   <Import Project="..\libzip-windows\libzip-windows.projitems" />
-  <Target Name="_GetHashes">
-    <GitCommitHash
-        WorkingDirectory="$(LibZipSourceFullPath)"
-        ToolPath="$(GitToolPath)"
-        ToolExe="$(GitToolExe)">
-      <Output TaskParameter="AbbreviatedCommitHash"   PropertyName="_LibZipHash" />
-    </GitCommitHash>
-    <GitCommitHash
-        WorkingDirectory="$(LlvmSourceFullPath)"
-        ToolPath="$(GitToolPath)"
-        ToolExe="$(GitToolExe)">
-      <Output TaskParameter="AbbreviatedCommitHash"   PropertyName="_LlvmHash" />
-    </GitCommitHash>
-    <GitCommitHash
-        WorkingDirectory="$(MonoSourceFullPath)"
-        ToolPath="$(GitToolPath)"
-        ToolExe="$(GitToolExe)">
-      <Output TaskParameter="AbbreviatedCommitHash"   PropertyName="_MonoHash" />
-    </GitCommitHash>
-  </Target>
-  <Target Name="GetBundlePath"
-      DependsOnTargets="_GetHashes">
-    <PropertyGroup>
-      <_BundlePath>$(OutputPath)bundle-v2-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</_BundlePath>
-    </PropertyGroup>
-  </Target>
+  <Import Project="..\libzip-windows\libzip-windows.targets" />
+  <Import Project="bundle-path.targets" />
   <Target Name="Clean"
-      DependsOnTargets="_GetHashes">
-    <Delete Files="$(_BundlePath)" />
+      DependsOnTargets="GetBundleFileName">
+    <Delete Files="$(OutputPath)$(XABundleFileName)" />
   </Target>
   <Target Name="_GetArchiveItems"
-      DependsOnTargets="_GetRuntimesOutputItems">
-    <ItemGroup>
-      <_Archive Include="@(_BclInstalledItem)" />
-      <_Archive Include="$(OutputPath)lib\xbuild-frameworks\MonoAndroid\v1.0\Facades\*.dll*" />
-      <_Archive Include="$(OutputPath)lib\xbuild-frameworks\MonoAndroid\v1.0\RedistList\FrameworkList.xml" />
-      <_Archive Include="@(_InstallRuntimeOutput)" />
-      <_Archive Include="@(_InstallUnstrippedRuntimeOutput)" />
-      <_Archive Include="@(_InstallProfilerOutput)" />
-      <_Archive Include="@(_InstallUnstrippedProfilerOutput)" />
-      <_Archive Include="@(_InstallMonoPosixHelperOutput)" />
-      <_Archive Include="@(_InstallUnstrippedMonoPosixHelperOutput)" />
-      <_Archive Include="@(_RuntimeEglibHeaderOutput)" />
-      <_Archive Include="@(_LibZipTarget->'$(OutputPath)lib\xbuild\Xamarin\Android\%(OutputLibrary)')" />
-      <_Archive Include="@(_MonoConstsOutput)" />
-      <_Archive Include="$(OutputPath)%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
-          Condition=" '@(_MonoCrossRuntime)' != '' "
-      />
-      <_Archive Include="@(_LlvmRuntime->'$(OutputPath)bin\llc%(ExeSuffix)')"
-          Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' "
-      />
-      <_Archive Include="@(_LlvmRuntime->'$(OutputPath)bin\opt%(ExeSuffix)')"
-          Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' "
-      />
-    </ItemGroup>
+      DependsOnTargets="GetMonoBundleItems;GetLibZipBundleItems">
   </Target>
   <Target Name="CreateBundle"
-      DependsOnTargets="GetBundlePath;_GetArchiveItems"
-      Inputs="@(_Archive)"
-      Outputs="$(_BundlePath)">
+      DependsOnTargets="GetBundleFileName;_GetArchiveItems"
+      Inputs="@(BundleItem)"
+      Outputs="$(OutputPath)$(XABundleFileName)">
     <Zip
-        File="$(_BundlePath)"
-        Entries="@(_Archive)"
+        Entries="@(BundleItem)"
+        File="$(OutputPath)$(XABundleFileName)"
         Prefix="$(OutputPath)"
     />
   </Target>

--- a/build-tools/libzip-windows/libzip-windows.mdproj
+++ b/build-tools/libzip-windows/libzip-windows.mdproj
@@ -17,8 +17,7 @@
   <PropertyGroup>
     <BuildDependsOnLocal Condition="'$(HostOS)' == 'Windows' OR '$(HostOS)' == 'Darwin'">
       ResolveReferences;
-      _Configure;
-      _Make
+      _BuildUnlessCached
     </BuildDependsOnLocal>
   </PropertyGroup>
   <Import Project="libzip-windows.props" />

--- a/build-tools/libzip/libzip.mdproj
+++ b/build-tools/libzip/libzip.mdproj
@@ -17,13 +17,19 @@
   <PropertyGroup>
     <BuildDependsOnLocal Condition="'$(HostOS)' == 'Windows' OR '$(HostOS)' == 'Darwin'">
       ResolveReferences;
-      _Configure;
-      _Make
+      _BuildUnlessCached
     </BuildDependsOnLocal>
   </PropertyGroup>
   <Import Project="libzip.props" />
   <Import Project="libzip.projitems" />
   <Import Project="libzip.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\xa-prep-tasks\xa-prep-tasks.csproj">
+      <Project>{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}</Project>
+      <Name>xa-prep-tasks</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
   <Target Name="Build" DependsOnTargets="$(BuildDependsOnLocal)" />
   <Target Name="Clean" />
 </Project>

--- a/build-tools/libzip/libzip.projitems
+++ b/build-tools/libzip/libzip.projitems
@@ -14,4 +14,8 @@
       <OutputLibraryPath>libzip.so</OutputLibraryPath>
     </_LibZipTarget>
   </ItemGroup>
+  <ItemGroup>
+    <RequiredProgram Include="cmake" />
+    <RequiredProgram Include="make" />
+  </ItemGroup>
 </Project>

--- a/build-tools/libzip/libzip.targets
+++ b/build-tools/libzip/libzip.targets
@@ -1,19 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="_CheckForMake">
-    <Exec Command="make --help" />
-    <OnError ExecuteTargets="_PrintRequiredMake" />
-  </Target>
-  <Target Name="_PrintRequiredMake">
-    <Error Text="The `make` program is required, and could not be found in `$PATH`." />
-  </Target>
-  <Target Name="_CheckForCmake">
-    <Exec Command="cmake --help" />
-    <OnError ExecuteTargets="_PrintRequiredCmake" />
-  </Target>
-  <Target Name="_PrintRequiredCmake">
-    <Error Text="The `cmake` program is required, and could not be found in `$PATH`." />
-  </Target>
+  <Import Project="..\scripts\RequiredPrograms.targets" />
+  <PropertyGroup>
+    <ForceBuildDependsOn>
+      _SetCMakeListsTxtTimeToLastCommitTimestamp;
+      CheckForRequiredPrograms;
+      _Configure;
+      _Make
+    </ForceBuildDependsOn>
+  </PropertyGroup>
   <Target Name="_SetCMakeListsTxtTimeToLastCommitTimestamp">
     <Exec
         Command="touch -m -t `git log -1 --format=%25cd --date=format-local:%25Y%25m%25d%25H%25M.%25S` CMakeLists.txt"
@@ -25,7 +20,6 @@
       DependsOnTargets="_SetCMakeListsTxtTimeToLastCommitTimestamp"
       Inputs="$(LibZipSourceFullPath)\CMakeLists.txt"
       Outputs="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)\Makefile">
-    <CallTarget Targets="_CheckForCmake" />
     <MakeDir Directories="@(_LibZipTarget->'$(IntermediateOutputPath)\%(Identity)')" /> 
     <Exec
         Command="%(_LibZipTarget.CMake) %(_LibZipTarget.CMakeFlags) $(LibZipSourceFullPath)"
@@ -41,7 +35,6 @@
       Condition=" '@(_LibZipTarget)' != '' "
       Inputs="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)\Makefile"
       Outputs="@(Content)">
-    <CallTarget Targets="_CheckForMake" />
     <Exec
         Command="make"
         WorkingDirectory="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)"
@@ -49,6 +42,22 @@
     <Copy SourceFiles="@(_LibZipTarget->'$(IntermediateOutputPath)\%(Identity)\%(_LibZipTarget.OutputLibraryPath)')"
         DestinationFiles="@(_LibZipTarget->'$(OutputPath)\lib\xbuild\Xamarin\Android\%(_LibZipTarget.OutputLibrary)')"/>
     <Touch Files="@(Content)" />
+  </Target>
+  <Target Name="GetLibZipBundleItems">
+    <ItemGroup>
+      <BundleItem Include="@(Content)" />
+    </ItemGroup>
+  </Target>
+  <Target Name="ForceBuild"
+      DependsOnTargets="GetLibZipBundleItems;$(ForceBuildDependsOn)"
+      Inputs="$(LibZipSourceFullPath)\CMakeLists.txt"
+      Outputs="@(BundleItem)">
+  </Target>
+  <Target Name="_BuildUnlessCached"
+      DependsOnTargets="_SetCMakeListsTxtTimeToLastCommitTimestamp;GetLibZipBundleItems"
+      Inputs="$(LibZipSourceFullPath)\CMakeLists.txt"
+      Outputs="@(BundleItem)">
+    <CallTarget Targets="ForceBuild" />
   </Target>
   <Target Name="_CleanBinaries"
       AfterTargets="Clean">

--- a/build-tools/mono-runtimes/mono-runtimes.mdproj
+++ b/build-tools/mono-runtimes/mono-runtimes.mdproj
@@ -6,30 +6,13 @@
     <ItemType>GenericProject</ItemType>
     <ProjectGuid>{C03E6CF1-7460-4CDC-A4AB-292BBC0F61F2}</ProjectGuid>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>..\..\bin\Debug</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>..\..\bin\Release</OutputPath>
-  </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <BuildDependsOn>
-      ResolveReferences;
-      _BuildLlvm;
-      _InstallLlvm;
-      _Autogen;
-      _ConfigureRuntimes;
-      _BuildRuntimes;
-      _InstallRuntimes;
-      _InstallBcl;
-      _ConfigureCrossRuntimes;
-      _BuildCrossRuntimes;
-      _InstallCrossRuntimes;
-    </BuildDependsOn>
-  </PropertyGroup>
   <Import Project="mono-runtimes.targets" />
   <ItemGroup>
+    <ProjectReference Include="..\xa-prep-tasks\xa-prep-tasks.csproj">
+      <Project>{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}</Project>
+      <Name>xa-prep-tasks</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
     <ProjectReference Include="..\android-toolchain\android-toolchain.mdproj">
       <Project>{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA}</Project>
       <Name>android-toolchain</Name>

--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <OutputPath>..\..\bin\Debug</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <OutputPath>..\..\bin\Release</OutputPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
+  <PropertyGroup>
+    <BuildDepends>
+      ResolveReferences;
+      _BuildUnlessCached
+    </BuildDepends>
+  </PropertyGroup>
+  <Target Name="Build" DependsOnTargets="$(BuildDepends)" />
   <PropertyGroup>
     <_SourceTopDir>..\..</_SourceTopDir>
     <_BclFrameworkDir>$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0</_BclFrameworkDir>
@@ -8,6 +22,20 @@
   <Import Project="$(_SourceTopDir)\Configuration.props" />
   <PropertyGroup>
     <_MonoProfileDir>$(MonoSourceFullPath)\mcs\class\lib\monodroid</_MonoProfileDir>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ForceBuildDependsOn>
+      _BuildLlvm;
+      _InstallLlvm;
+      _Autogen;
+      _ConfigureRuntimes;
+      _BuildRuntimes;
+      _InstallRuntimes;
+      _InstallBcl;
+      _ConfigureCrossRuntimes;
+      _BuildCrossRuntimes;
+      _InstallCrossRuntimes;
+    </ForceBuildDependsOn>
   </PropertyGroup>
   <Import Project="mono-runtimes.props" />
   <Import Project="mono-runtimes.projitems" />
@@ -71,8 +99,11 @@
         Command="touch -m -t `git log -1 --format=%25cd --date=format-local:%25Y%25m%25d%25H%25M.%25S` autogen.sh"
         WorkingDirectory="$(MonoSourceFullPath)"
     />
+    <Exec
+        Command="touch -m -t `git log -1 --format=%25cd --date=format-local:%25Y%25m%25d%25H%25M.%25S` Makefile.config.in"
+        WorkingDirectory="$(LlvmSourceFullPath)"
+    />
   </Target>
-
   <Target Name="_PrepareLlvmItems">
     <ItemGroup>
       <_LlvmSourceFile Include="$(LlvmSourceFullPath)\lib\**\*.cpp" />
@@ -405,6 +436,41 @@
     <Touch
         Files="$(OutputPath)%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
     />
+  </Target>
+  <Target Name="GetMonoBundleItems"
+      DependsOnTargets="_GetRuntimesOutputItems">
+    <ItemGroup>
+      <BundleItem Include="@(_BclInstalledItem)" />
+      <BundleItem Include="$(OutputPath)lib\xbuild-frameworks\MonoAndroid\v1.0\Facades\*.dll*" />
+      <BundleItem Include="$(OutputPath)lib\xbuild-frameworks\MonoAndroid\v1.0\RedistList\FrameworkList.xml" />
+      <BundleItem Include="@(_InstallRuntimeOutput)" />
+      <BundleItem Include="@(_InstallUnstrippedRuntimeOutput)" />
+      <BundleItem Include="@(_InstallProfilerOutput)" />
+      <BundleItem Include="@(_InstallUnstrippedProfilerOutput)" />
+      <BundleItem Include="@(_InstallMonoPosixHelperOutput)" />
+      <BundleItem Include="@(_InstallUnstrippedMonoPosixHelperOutput)" />
+      <BundleItem Include="@(_RuntimeEglibHeaderOutput)" />
+      <BundleItem Include="$(OutputPath)%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
+          Condition=" '@(_MonoCrossRuntime)' != '' "
+      />
+      <BundleItem Include="@(_LlvmRuntime->'$(OutputPath)%(InstallPath)llc%(ExeSuffix)')"
+          Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' "
+      />
+      <BundleItem Include="@(_LlvmRuntime->'$(OutputPath)%(InstallPath)opt%(ExeSuffix)')"
+          Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' "
+      />
+    </ItemGroup>
+  </Target>
+  <Target Name="ForceBuild"
+      DependsOnTargets="GetMonoBundleItems;$(ForceBuildDependsOn)"
+      Inputs="$(MonoSourceFullPath)\autogen.sh;$(LlvmSourceFullPath)\Makefile.config.in"
+      Outputs="@(BundleItem)">
+  </Target>
+  <Target Name="_BuildUnlessCached"
+      DependsOnTargets="_SetAutogenShTimeToLastCommitTimestamp;GetMonoBundleItems"
+      Inputs="$(MonoSourceFullPath)\autogen.sh;$(LlvmSourceFullPath)\Makefile.config.in"
+      Outputs="@(BundleItem)">
+    <CallTarget Targets="ForceBuild" />
   </Target>
   <Target Name="_CleanRuntimes"
       AfterTargets="Clean">

--- a/build-tools/scripts/Paths.targets
+++ b/build-tools/scripts/Paths.targets
@@ -19,6 +19,18 @@
         Importance="High"
     />
   </Target>
+  <Target Name="GetLibZipSourceFullPath">
+    <Message
+        Text="$(LibZipSourceFullPath)"
+        Importance="High"
+    />
+  </Target>
+  <Target Name="GetLlvmSourceFullPath">
+    <Message
+        Text="$(LlvmSourceFullPath)"
+        Importance="High"
+    />
+  </Target>
   <Target Name="GetMonoSourceFullPath">
     <Message
         Text="$(MonoSourceFullPath)"

--- a/build-tools/scripts/RequiredPrograms.targets
+++ b/build-tools/scripts/RequiredPrograms.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.Which" />
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.Which" />
   <Target Name="CheckForRequiredPrograms">
     <Which Program="%(RequiredProgram.Identity)" Required="True" />
     <OnError ExecuteTargets="_PrintRequiredPrograms" />

--- a/build-tools/xa-prep-tasks/Properties/AssemblyInfo.cs
+++ b/build-tools/xa-prep-tasks/Properties/AssemblyInfo.cs
@@ -1,0 +1,27 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle ("xapreptasks")]
+[assembly: AssemblyDescription ("")]
+[assembly: AssemblyConfiguration ("")]
+[assembly: AssemblyCompany ("Microsoft Corporation")]
+[assembly: AssemblyProduct ("")]
+[assembly: AssemblyCopyright ("Microsoft Corporation")]
+[assembly: AssemblyTrademark ("Microsoft")]
+[assembly: AssemblyCulture ("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion ("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]
+

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/DownloadUri.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/DownloadUri.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -9,7 +9,7 @@ using Microsoft.Build.Utilities;
 using TTask = System.Threading.Tasks.Task;
 using MTask = Microsoft.Build.Utilities.Task;
 
-namespace Xamarin.Android.Tools.BootstrapTasks {
+namespace Xamarin.Android.BuildTools.PrepTasks {
 
 	public class DownloadUri : MTask
 	{
@@ -58,12 +58,17 @@ namespace Xamarin.Android.Tools.BootstrapTasks {
 				Log.LogMessage (MessageImportance.Normal, $"Skipping uri '{uri}' as destination file already exists '{destinationFile}'.");
 				return;
 			}
-			Log.LogMessage (MessageImportance.Low, $"Downloading '{uri}'.");
+			var dp  = Path.GetDirectoryName (destinationFile);
+			var dn  = Path.GetFileName (destinationFile);
+			var tempPath    = Path.Combine (dp, "." + dn + ".download");
+
+			Log.LogMessage (MessageImportance.Low, $"Downloading `{uri}` to `{tempPath}`.");
 			using (var r = await client.GetAsync (uri))
-			using (var o = File.OpenWrite (destinationFile)) {
+			using (var o = File.OpenWrite (tempPath)) {
 				await r.Content.CopyToAsync (o);
 			}
+			Log.LogMessage (MessageImportance.Low, $"mv '{tempPath}' '{destinationFile}'.");
+			File.Move (tempPath, destinationFile);
 		}
 	}
 }
-

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/Git.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/Git.cs
@@ -8,11 +8,9 @@ using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
-using Xamarin.Tools.Zip;
-
 using IOFile = System.IO.File;
 
-namespace Xamarin.Android.Tools.BootstrapTasks
+namespace Xamarin.Android.BuildTools.PrepTasks
 {
 	public class Git : ToolTask
 	{

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitBranch.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitBranch.cs
@@ -8,11 +8,9 @@ using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
-using Xamarin.Tools.Zip;
-
 using IOFile = System.IO.File;
 
-namespace Xamarin.Android.Tools.BootstrapTasks
+namespace Xamarin.Android.BuildTools.PrepTasks
 {
 	public sealed class GitBranch : Git
 	{

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitCommitHash.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitCommitHash.cs
@@ -5,11 +5,9 @@ using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
-using Xamarin.Tools.Zip;
-
 using IOFile = System.IO.File;
 
-namespace Xamarin.Android.Tools.BootstrapTasks
+namespace Xamarin.Android.BuildTools.PrepTasks
 {
 	public sealed class GitCommitHash : Git
 	{

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/SystemUnzip.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/SystemUnzip.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using TTask = System.Threading.Tasks.Task;
+using MTask = Microsoft.Build.Utilities.Task;
+
+namespace Xamarin.Android.BuildTools.PrepTasks {
+
+	public class SystemUnzip : MTask
+	{
+		[Required]
+		public  ITaskItem[]     SourceFiles         { get; set; }
+
+		public  string          SourceEntryGlob     { get; set; }
+
+		public  string          EntryNameEncoding   { get; set; }
+
+		public  string          HostOS              { get; set; }
+
+		[Required]
+		public  ITaskItem       DestinationFolder   { get; set; }
+
+		string[]    SourceEntryGlobParts;
+
+		public override bool Execute ()
+		{
+			Log.LogMessage (MessageImportance.Low, $"{nameof (SystemUnzip)}:");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (DestinationFolder)}: {DestinationFolder.ItemSpec}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (EntryNameEncoding)}: {EntryNameEncoding}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (HostOS)}: {HostOS}");
+
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (SourceEntryGlob)}: {SourceEntryGlob}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (SourceFiles)}:");
+			for (int i = 0; i < SourceFiles.Length; ++i) {
+				var sf  = SourceFiles [i].ItemSpec;
+				var rp  = SourceFiles [i].GetMetadata ("DestDir");
+				rp      = string.IsNullOrEmpty (rp)
+					? ""
+					: " [ " + rp + " ]";
+				Log.LogMessage (MessageImportance.Low, "    {0}{1}", sf, rp);
+			}
+
+			if (File.Exists (DestinationFolder.ItemSpec)) {
+				Log.LogError ($"{nameof (DestinationFolder)} must be a directory!");
+				return false;
+			}
+
+			SourceEntryGlobParts    = (SourceEntryGlob ?? "*").Split ('/', '\\');
+
+			Directory.CreateDirectory (DestinationFolder.ItemSpec);
+
+			var tempDir = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
+			Directory.CreateDirectory (tempDir);
+			Log.LogMessage (MessageImportance.Low, $"  Extracting into temporary directory: {tempDir}");
+
+			var encoding = string.IsNullOrEmpty (EntryNameEncoding)
+				? null
+				: Encoding.GetEncoding (EntryNameEncoding);
+
+			var tasks = new TTask [SourceFiles.Length];
+			for (int i = 0; i < SourceFiles.Length; ++i) {
+				var td              = tempDir;
+				var sourceFile      = SourceFiles [i].ItemSpec;
+				var relativeDestDir = SourceFiles [i].GetMetadata ("DestDir");
+				var enc             = encoding;
+				var destFolder      = DestinationFolder.ItemSpec;
+				tasks [i] = TTask.Run (() => ExtractFile (td, sourceFile, relativeDestDir, destFolder, enc));
+			}
+
+			TTask.WaitAll (tasks);
+
+			Directory.Delete (tempDir, recursive: true);
+
+			return !Log.HasLoggedErrors;
+		}
+
+		// Ignore CS1998 because there's no async System.IO APIs to use here.
+		// Instead, we're using Tasks so that we can extract multiple files
+		// in parallel via Task.Run() and Task.WaitAll().
+#pragma warning disable 1998
+		async TTask ExtractFile (string tempDir, string sourceFile, string relativeDestDir, string destinationFolder, Encoding encoding)
+		{
+			var tempName = Path.GetRandomFileName ();
+			var nestedTemp = Path.Combine (tempDir, tempName);
+			Directory.CreateDirectory (nestedTemp);
+
+			relativeDestDir = relativeDestDir?.Replace ('\\', Path.DirectorySeparatorChar);
+
+			if (string.Equals (HostOS, "Windows", StringComparison.OrdinalIgnoreCase)) {
+				ZipFile.ExtractToDirectory (sourceFile, nestedTemp, encoding);
+			} else {
+				var start = new ProcessStartInfo ("unzip", $"\"{sourceFile}\" -d \"{nestedTemp}\"") {
+					CreateNoWindow = true,
+					UseShellExecute = false,
+				};
+				Log.LogMessage (MessageImportance.Low, $"unzip \"{sourceFile}\" -d \"{nestedTemp}\"");
+				var p = Process.Start (start);
+				p.WaitForExit ();
+			}
+
+			var entries = GetExtractedSourceEntries (nestedTemp);
+
+			// "merge" directories from `name`/within `sourceFile` and `destinationFolder`.
+			// If we did e.g. `mv foo/lib destination/lib` *and* `destination/lib` *already exists*,
+			// we'd create `destination/lib/lib`, which isn't intended.
+			// If we did e.g. `mv foo/lib destination`, **mv**(1) may *overwrite* `destination/lib`
+			// if it already exists, which *also* isn't intended.
+			// If `destination/lib/example` and `sourceFile` contains a `lib/another` entry,
+			// then we want to create a `destination/lib/another` file.
+			foreach (var entry in entries) {
+				var name    = Path.GetFileName (entry);
+				var destDir = string.IsNullOrEmpty (relativeDestDir)
+					? destinationFolder
+					: Path.Combine (destinationFolder, relativeDestDir);
+				destDir = Path.Combine (destDir, name);
+				foreach (var file in Directory.EnumerateFiles (entry, "*", SearchOption.AllDirectories)) {
+					var relPath = file.Substring (entry.Length + 1);
+					var dest    = Path.Combine (destDir, relPath);
+					Directory.CreateDirectory (Path.GetDirectoryName (dest));
+					Log.LogMessage (MessageImportance.Low, $"mv '{file}' '{dest}'");
+					if (Directory.Exists (entry))
+						Process.Start ("/bin/mv", $@"""{file}"" ""{dest}""").WaitForExit ();
+					else {
+						if (File.Exists (dest))
+							File.Delete (dest);
+						File.Move (file, dest);
+					}
+				}
+			}
+		}
+
+		IEnumerable<string> GetExtractedSourceEntries (string root)
+		{
+			var entries = Directory.EnumerateFileSystemEntries (root, SourceEntryGlobParts [0], SearchOption.TopDirectoryOnly);
+			for (int i = 1; i < SourceEntryGlobParts.Length; ++i) {
+				entries = entries
+					.SelectMany (e => Directory.EnumerateFileSystemEntries (e, SourceEntryGlobParts [i], SearchOption.TopDirectoryOnly));
+			}
+			return entries;
+		}
+#pragma warning restore 1998
+	}
+}
+

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/Which.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/Which.cs
@@ -5,7 +5,7 @@ using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
-namespace Xamarin.Android.Tools.BootstrapTasks
+namespace Xamarin.Android.BuildTools.PrepTasks
 {
 	public class Which : Task
 	{
@@ -19,13 +19,18 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		[Output]
 		public  ITaskItem           Location            { get; set; }
 
-		static  readonly    string[]    FileExtensions = new []{
-			null,
-			".bat",
-			".cmd",
-			".com",
-			".exe",
-		};
+		static  readonly    string[]    FileExtensions;
+
+		static Which ()
+		{
+			var pathExt     = Environment.GetEnvironmentVariable ("PATHEXT");
+			var pathExts    = pathExt?.Split (new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+			FileExtensions  = new string [(pathExts?.Length ?? 0) + 1];
+			FileExtensions [0] = null;
+			if (pathExts != null) {
+				Array.Copy (pathExts, 0, FileExtensions, 1, pathExt.Length);
+			}
+		}
 
 		public override bool Execute ()
 		{

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Xamarin.Android.BuildTools.PrepTasks</RootNamespace>
+    <AssemblyName>xa-prep-tasks</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\bin\BuildDebug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\bin\BuildRelease</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Xamarin.Android.BuildTools.PrepTasks\DownloadUri.cs" />
+    <Compile Include="Xamarin.Android.BuildTools.PrepTasks\Git.cs" />
+    <Compile Include="Xamarin.Android.BuildTools.PrepTasks\GitBranch.cs" />
+    <Compile Include="Xamarin.Android.BuildTools.PrepTasks\GitCommitHash.cs" />
+    <Compile Include="Xamarin.Android.BuildTools.PrepTasks\SystemUnzip.cs" />
+    <Compile Include="Xamarin.Android.BuildTools.PrepTasks\Which.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="xa-prep-tasks.targets" />
+</Project>

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.targets
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.targets
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask AssemblyFile="$(OutputPath)xa-prep-tasks.dll"   TaskName="Xamarin.Android.BuildTools.PrepTasks.DownloadUri" />
+  <UsingTask AssemblyFile="$(OutputPath)xa-prep-tasks.dll"   TaskName="Xamarin.Android.BuildTools.PrepTasks.SystemUnzip" />
+  <Import Project="..\bundle\bundle-path.targets" />
+  <PropertyGroup>
+    <_AzureBaseUri>https://xamjenkinsartifact.blob.core.windows.net/xamarin-android/xamarin-android/bin/</_AzureBaseUri>
+  </PropertyGroup>
+  <Target Name="_GetBundleOutputPath"
+      DependsOnTargets="GetBundleFileName">
+    <PropertyGroup>
+      <_BundlePath>$(OutputPath)$(XABundleFileName)</_BundlePath>
+    </PropertyGroup>
+  </Target>
+  <Target Name="_DownloadBundle"
+      DependsOnTargets="_GetBundleOutputPath"
+      Inputs=""
+      Outputs="$(_BundlePath)">
+    <DownloadUri
+        SourceUris="$(_AzureBaseUri)$(Configuration)/$(XABundleFileName)"
+        DestinationFiles="$(_BundlePath)"
+    />
+  </Target>
+  <Target Name="_ExtractBundle"
+      DependsOnTargets="_DownloadBundle"
+      Inputs="$(_BundlePath)"
+      Outputs="$(OutputPath).extracted-$(XABundleFileName)">
+    <SystemUnzip
+        SourceFiles="$(_BundlePath)"
+        HostOS="$(HostOS)"
+        DestinationFolder="..\..\bin\$(Configuration)"
+    />
+    <WriteLinesToFile
+        File="$(OutputPath).extracted-$(XABundleFileName)"
+        Lines="$(XABundleFileName)"
+        Overwrite="True"
+    />
+  </Target>
+  <Target Name="_DownloadAndExtractBundle"
+      AfterTargets="Build"
+      DependsOnTargets="_ExtractBundle">
+  </Target>
+</Project>

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -38,14 +38,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Xamarin.Android.Tools.BootstrapTasks\DownloadUri.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\UnzipDirectoryChildren.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GenerateProfile.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GetNugetPackageBasePath.cs" />
-    <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Git.cs" />
-    <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GitBranch.cs" />
-    <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GitCommitHash.cs" />
-    <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Which.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Zip.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.ValueToItems" />
-  <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.Which" />
   <Import Project="monodroid.projitems" />
   <Import Project="..\..\build-tools\scripts\RequiredPrograms.targets" />
   <PropertyGroup>


### PR DESCRIPTION
**DO NOT MERGE**

Before merging the bundle filename needs to be changed (see the TODO in the commit). I don't want to do this *yet* so that I can see if the *current* bundle is used by the PR bot. :-)

---

Context: https://github.com/xamarin/xamarin-android/commit/fbfd676c102c63e4e06e750857b178725e33450c

Stage 3 of the cunning plan is to (attempt to) use the mono bundle
introduced in commit fbfd676c.

This "simple" desire (ha!) re-raises the architectural project
dependency issue "solved" in fbfd676c, but first, a simple question:

What should download the mono bundle?

There are two plausible answers:

1. `make prepare` can (somehow) handle it.
2. MSBuild can (somehow) handle it.

Both are plausible. The problem with using `make` targets (1) is there
is increased potential for "duplication" -- duplication of the bundle
filename, downloading it, and extracting it. Plus, `make` isn't
"Windows friendly", in that GNU make isn't (normally) present with
Visual Studio. (`NMAKE` is, but the Makefiles in this project are not
compatible with `NMAKE`.)

Which brings us to MSBuild (2): can it handle the task?

To tackle that, we need to be able to have an MSBuild task project
which has *no dependencies*, so that it can download and extract the
mono bundle *before anything else runs*, as it may be downloading
contents which mean that other projects don't *need* to run.

The need for a "pre-bootstrap" task assembly -- called `xa-prep-tasks`
-- thus "undoes" *some* of the logic regarding `libzip-windows.mdproj`
and the `<Zip/>` task from fbfd676c: it isn't *possible* to rely on
`libzip` from a "pre-build" state, as `libzip` is one of the things in
the mono bundle, so now we need *two* "bootstrap" task assemblies:
one without a `libzip` dependency -- `xa-prep-tasks.dll` -- and one
*with* a `libzip` dependency --
`Xamarin.Android.Tools.BootstrapTasks.dll`

Move tasks which don't currently require `libzip` -- or won't in the
future, or laziness -- from `Xamarin.Android.Tools.BootstrapTasks.dll`
and move them into `xa-prep-tasks.dll`.

With that architectural compromise in place, add `xa-prep-tasks` as a
`@(ProjectReference)` to various projects to help ensure it's built
*first*, and rearchitect `bundle.mdproj` so that
`xa-prep-tasks.targets` and `bundle.targets` can use the same targets
to compute the bundle filename, now in
`build-tools/bundle/bundle-path.targets`.

Add a post-build step to `xa-prep-tasks.csproj` which downloads and
extracts the expected mono bundle.

One "problem" (feature?) is that the new `<SystemUnzip/>` task doesn't
report errors as errors when unzip'ing the file. This turns out to be
fine here because when downloading the mono bundle from Azure we don't
get a 404 *anyway* -- Azure instead returns an XML document containing
an error message (wat?!). We can thus ignore most error handling
entirely...though we're *also* ignoring any checking for invalid
downloads, which is something we should address in the future.

Update the varioous project files so that they won't attempt to
rebuild binaries that were present in the mono bundle.

Finally, the mono bundle isn't quite right, as it installs `llc.exe`
and `opt.exe` into `bin/`, not `lib/mandroid`. This was overlooked in
commit fbfd676c.

Add a version number to the bundle filename so that a unique filename
is used, thus ensuring that we attempt to download an updated mono
bundle in the future, and correct the `CreateBundle` target so that it
packages required files.