### PR TITLE
[mono-runtimes] "Install" eglib headers into $prefix/include

### DIFF
--- a/build-tools/bundle/bundle.mdproj
+++ b/build-tools/bundle/bundle.mdproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{1640725C-4DB8-4D8D-BC96-74E688A06EEF}</ProjectGuid>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">1
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\..\bin\Debug</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/build-tools/bundle/bundle.targets
+++ b/build-tools/bundle/bundle.targets
@@ -33,7 +33,7 @@
   <Target Name="GetBundlePath"
       DependsOnTargets="_GetHashes">
     <PropertyGroup>
-      <_BundlePath>$(OutputPath)bundle-$(Configuration)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</_BundlePath>
+      <_BundlePath>$(OutputPath)bundle-v1-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</_BundlePath>
     </PropertyGroup>
   </Target>
   <Target Name="Clean"
@@ -52,6 +52,7 @@
       <_Archive Include="@(_InstallUnstrippedProfilerOutput)" />
       <_Archive Include="@(_InstallMonoPosixHelperOutput)" />
       <_Archive Include="@(_InstallUnstrippedMonoPosixHelperOutput)" />
+      <_Archive Include="@(_RuntimeEglibHeaderOutput)" />
       <_Archive Include="@(_LibZipTarget->'$(OutputPath)lib\xbuild\Xamarin\Android\%(OutputLibrary)')" />
       <_Archive Include="$(OutputPath)%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
           Condition=" '@(_MonoCrossRuntime)' != '' "

--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -198,6 +198,14 @@
           Condition=" '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputMonoPosixHelperFilename)' != '' "
           Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputMonoPosixHelperFilename).d.%(NativeLibraryExtension)')"
       />
+      <_RuntimeEglibHeaderSource
+          Condition=" '%(_MonoRuntime.DoBuild)' == 'True' "
+          Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\eglib\config.h');@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\eglib\src\eglib-config.h')"
+      />
+      <_RuntimeEglibHeaderOutput
+          Condition=" '%(_MonoRuntime.DoBuild)' == 'True' "
+          Include="@(_MonoRuntime->'$(OutputPath)include\%(Identity)\eglib\config.h');@(_MonoRuntime->'$(OutputPath)include\%(Identity)\eglib\eglib-config.h')"
+      />
       <_RuntimeBuildStamp       Condition=" '%(_MonoRuntime.DoBuild)' == 'true' " Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\.stamp')" />
     </ItemGroup>
   </Target>
@@ -221,6 +229,14 @@
     <MakeDir
         Condition=" '%(_MonoRuntime.DoBuild)' == 'true' "
         Directories="$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(_MonoRuntime.Identity)"
+    />
+    <MakeDir
+        Condition=" '%(_MonoRuntime.DoBuild)' == 'true' "
+        Directories="$(OutputPath)\include\%(_MonoRuntime.Identity)\eglib"
+    />
+    <Copy
+        SourceFiles="@(_RuntimeEglibHeaderSource)"
+        DestinationFiles="@(_RuntimeEglibHeaderOutput)"
     />
     <Copy
         SourceFiles="@(_RuntimeSource)"

--- a/src/monodroid/jni/Android.mk
+++ b/src/monodroid/jni/Android.mk
@@ -36,9 +36,7 @@ LOCAL_LDFLAGS   += \
 	-Wl,--no-undefined \
 
 LOCAL_C_INCLUDES	:= \
-	$(LOCAL_PATH)/../../../build-tools/mono-runtimes/obj/$(CONFIGURATION)/$(TARGET_ARCH_ABI) \
-	$(LOCAL_PATH)/../../../build-tools/mono-runtimes/obj/$(CONFIGURATION)/$(TARGET_ARCH_ABI)/eglib \
-	$(LOCAL_PATH)/../../../build-tools/mono-runtimes/obj/$(CONFIGURATION)/$(TARGET_ARCH_ABI)/eglib/src \
+	$(LOCAL_PATH)/../../../bin/$(CONFIGURATION)/include/$(TARGET_ARCH_ABI)/eglib \
 	$(LOCAL_PATH)/../../../external/mono/eglib/src \
 	$(LOCAL_PATH)/zip
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/162

PR #162 tries to use the mono bundle (fbfd676c) to avoid rebuilding
mono on subsequent builds (when the mono commit hasn't changed), in
order to speed up the Jenkins build process (currently tracking at
~3.5 *hours* for a non-PR build...)

[PR #162 currently fails][0] when building `src/monodroid`:

	Executing: /Users/builder/android-toolchain/ndk/ndk-build CONFIGURATION=Debug NDK_LIBS_OUT=./libs/Debug NDK_OUT=./obj/Debug V=1
	...
	[armeabi-v7a] Compile thumb  : monodroid <= nl.c
	/Users/builder/android-toolchain/ndk/toolchains/arm-linux-androideabi-4.9/prebuilt/darwin-x86_64/bin/arm-linux-androideabi-gcc -MMD -MP -MF ./obj/Debug/local/armeabi-v7a/objs/monodroid/__/__/__/external/mono/support/nl.o.d -fpic -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -march=armv7-a -mfpu=vfpv3-d16 -mfloat-abi=softfp -mthumb -Os -g -DNDEBUG -fomit-frame-pointer -fno-strict-aliasing -finline-limit=64 -Ijni/../../../build-tools/mono-runtimes/obj/Debug/armeabi-v7a -Ijni/../../../build-tools/mono-runtimes/obj/Debug/armeabi-v7a/eglib -Ijni/../../../build-tools/mono-runtimes/obj/Debug/armeabi-v7a/eglib/src -Ijni/../../../external/mono/eglib/src -Ijni/zip -Ijni -DANDROID -ggdb3 -O0 -fno-omit-frame-pointer -std=c99 -DHAVE_LINUX_NETLINK_H=1 -DHAVE_LINUX_RTNETLINK_H=1 -D_REENTRANT -DPLATFORM_ANDROID -DANDROID -DLINUX -Dlinux -D__linux_ -DHAVE_CONFIG_H -DJI_DLL_EXPORT -DMONO_DLL_EXPORT -I/libmonodroid/zip -I/include -I/include/eglib -mandroid -fno-strict-aliasing -ffunction-sections -fomit-frame-pointer -funswitch-loops -finline-limit=300 -fvisibility=hidden -fstack-protector -Wa,--noexecstack -Wformat -Werror=format-security -DDEBUG=1 -Wa,--noexecstack -Wformat -Werror=format-security    -isystem /Users/builder/android-toolchain/ndk/platforms/android-9/arch-arm/usr/include -c  jni/../../../external/mono/support/nl.c -o ./obj/Debug/local/armeabi-v7a/objs/monodroid/__/__/__/external/mono/support/nl.o
	In file included from jni/../../../external/mono/support/nl.h:3:0,
	                 from jni/../../../external/mono/support/nl.c:14:
	jni/../../../external/mono/eglib/src/glib.h:18:26: fatal error: eglib-config.h: No such file or directory
	 #include <eglib-config.h>
	                          ^
	compilation terminated.

`src/monodroid` fails to build because it requires build artifacts
located in
`build-tools/mono-runtimes/obj/$(Configuration)/%(Identity)/eglib`,
which doesn't exist when the mono bundle is being used (because we
never built mono! by design!)

Fix this issue by updating the `_InstallRuntimes` target in
`mono-runtimes.targets` to copy the generated eglib header files into
`bin/$(Configuration)/include/%(Identity)/eglib`, and update
`bundle.targets` so that the `include` directory is also included in
the mono bundle.

This should allow a future PR #162 fix to build, as all required
generated files will be present within the bundle.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-pr-builder/61/