### PR TITLE
[mono-runtimes] Bundle Consts.cs, use correct opt.exe install location

### DIFF
--- a/build-tools/bundle/bundle.targets
+++ b/build-tools/bundle/bundle.targets
@@ -33,7 +33,7 @@
   <Target Name="GetBundlePath"
       DependsOnTargets="_GetHashes">
     <PropertyGroup>
-      <_BundlePath>$(OutputPath)bundle-v1-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</_BundlePath>
+      <_BundlePath>$(OutputPath)bundle-v2-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</_BundlePath>
     </PropertyGroup>
   </Target>
   <Target Name="Clean"
@@ -54,6 +54,7 @@
       <_Archive Include="@(_InstallUnstrippedMonoPosixHelperOutput)" />
       <_Archive Include="@(_RuntimeEglibHeaderOutput)" />
       <_Archive Include="@(_LibZipTarget->'$(OutputPath)lib\xbuild\Xamarin\Android\%(OutputLibrary)')" />
+      <_Archive Include="@(_MonoConstsOutput)" />
       <_Archive Include="$(OutputPath)%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
           Condition=" '@(_MonoCrossRuntime)' != '' "
       />

--- a/build-tools/mono-runtimes/mono-runtimes.projitems
+++ b/build-tools/mono-runtimes/mono-runtimes.projitems
@@ -228,6 +228,7 @@
       <BuildEnvironment></BuildEnvironment>
       <ExeSuffix></ExeSuffix>
       <InstallBinaries>true</InstallBinaries>
+      <InstallPath>bin/</InstallPath>
     </_LlvmRuntime>
 
     <_LlvmRuntime Include="llvm64" Condition=" '$(_LlvmNeeded)' != '' And '$(_LlvmCanBuild64)' == 'yes' ">
@@ -238,6 +239,7 @@
       <BuildEnvironment></BuildEnvironment>
       <ExeSuffix></ExeSuffix>
       <InstallBinaries>true</InstallBinaries>
+      <InstallPath>bin/</InstallPath>
     </_LlvmRuntime>
 
     <_LlvmRuntime Include="llvmwin32" Condition=" '$(_LlvmNeeded)' != '' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:')) ">
@@ -248,6 +250,7 @@
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ExeSuffix>.exe</ExeSuffix>
       <InstallBinaries>true</InstallBinaries>
+      <InstallPath>lib/mandroid/</InstallPath>
     </_LlvmRuntime>
 
     <_LlvmRuntime Include="llvmwin64" Condition=" '$(_LlvmNeeded)' != '' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:')) ">
@@ -258,6 +261,7 @@
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ExeSuffix>.exe</ExeSuffix>
       <InstallBinaries>false</InstallBinaries>
+      <InstallPath>lib/mandroid/</InstallPath>
     </_LlvmRuntime>
   </ItemGroup>
 

--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -85,10 +85,10 @@
       <_LlvmArchive Include="$(_LlvmOutputDirTop)\%(_LlvmRuntime.BuildDir)\Release\lib\*.a" />
 
       <_LlvmSourceBinary Include="@(_LlvmRuntime->'$(_LlvmOutputDirTop)\%(BuildDir)\Release\bin\opt%(ExeSuffix)')" Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' " />
-      <_LlvmTargetBinary Include="@(_LlvmRuntime->'$(OutputPath)\bin\opt%(ExeSuffix)')" Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' "/>
+      <_LlvmTargetBinary Include="@(_LlvmRuntime->'$(OutputPath)\%(InstallPath)opt%(ExeSuffix)')" Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' "/>
 
       <_LlvmSourceBinary Include="@(_LlvmRuntime->'$(_LlvmOutputDirTop)\%(BuildDir)\Release\bin\llc%(ExeSuffix)')" Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' " />
-      <_LlvmTargetBinary Include="@(_LlvmRuntime->'$(OutputPath)\bin\llc%(ExeSuffix)')" Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' " />
+      <_LlvmTargetBinary Include="@(_LlvmRuntime->'$(OutputPath)\%(InstallPath)llc%(ExeSuffix)')" Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' " />
     </ItemGroup>
   </Target>
 
@@ -206,6 +206,14 @@
           Condition=" '%(_MonoRuntime.DoBuild)' == 'True' "
           Include="@(_MonoRuntime->'$(OutputPath)include\%(Identity)\eglib\config.h');@(_MonoRuntime->'$(OutputPath)include\%(Identity)\eglib\eglib-config.h')"
       />
+      <_MonoConstsSource
+          Condition=" '%(_MonoRuntime.DoBuild)' == 'True' "
+          Include="$(MonoSourceFullPath)\mcs\build\common\Consts.cs"
+      />
+      <_MonoConstsOutput
+          Condition=" '%(_MonoRuntime.DoBuild)' == 'True' "
+          Include="$(OutputPath)include\Consts.cs"
+      />
       <_RuntimeBuildStamp       Condition=" '%(_MonoRuntime.DoBuild)' == 'true' " Include="@(_MonoRuntime->'$(IntermediateOutputPath)%(Identity)\.stamp')" />
     </ItemGroup>
   </Target>
@@ -237,6 +245,10 @@
     <Copy
         SourceFiles="@(_RuntimeEglibHeaderSource)"
         DestinationFiles="@(_RuntimeEglibHeaderOutput)"
+    />
+    <Copy
+        SourceFiles="@(_MonoConstsSource)"
+        DestinationFiles="@(_MonoConstsOutput)"
     />
     <Copy
         SourceFiles="@(_RuntimeSource)"

--- a/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
+++ b/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
@@ -173,7 +173,7 @@
     <Compile Include="$(MonoSourceDirectory)\mcs\build\common\Locale.cs">
       <Link>Locale.cs</Link>
     </Compile>
-    <Compile Include="$(MonoSourceDirectory)\mcs\build\common\Consts.cs">
+    <Compile Include="$(OutputPath)..\..\..\..\include\Consts.cs">
       <Link>Consts.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/Mono.Posix/Mono.Posix.csproj
+++ b/src/Mono.Posix/Mono.Posix.csproj
@@ -226,7 +226,7 @@
     <Compile Include="$(MonoSourceDirectory)\mcs\build\common\Locale.cs">
       <Link>Locale.cs</Link>
     </Compile>
-    <Compile Include="$(MonoSourceDirectory)\mcs\build\common\Consts.cs">
+    <Compile Include="$(OutputPath)..\..\..\..\include\Consts.cs">
       <Link>Consts.cs</Link>
     </Compile>
   </ItemGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/162

PR #162 tries to use the mono bundle (fbfd676c) to avoid rebuilding
mono on subsequent builds (when the mono commit hasn't changed), in
order to speed up the Jenkins build process (currently tracking at
~3.5 *hours* for a non-PR build...)

[PR #162 currently fails][0] when building `src/Mono.Data.Sqlite`:

	CSC: error CS2001: Source file `/Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/external/mono/mcs/build/common/Consts.cs' could not be found

Fix this error by copying `external/mono/mcs/build/common/Consts.cs`
into `bin/$(Configuration)/include`, and updating the `Consts.cs`
references within `Mono.Data.Sqlite.csproj` and `Mono.Posix.csproj` so
that they'll use the `include` copy.

This should allow us to use the bundle to build these projects.

Additionally, `llc.exe` and `opt.exe` are installed into
`$prefix/bin`, which isn't correct; `$prefix/bin` as a construct
doesn't exist on Windows. Install these into `$prefix/lib/mandroid`.

Update the bundle version to note these bundle changes.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-pr-builder/67/console