### PR TITLE
Don't attempt to build libzip on some Linux systems

### DIFF
--- a/build-tools/libzip/libzip.projitems
+++ b/build-tools/libzip/libzip.projitems
@@ -7,7 +7,7 @@
       <OutputLibrary>libzip.3.0.dylib</OutputLibrary>
       <OutputLibraryPath>lib/libzip.3.0.dylib</OutputLibraryPath>
     </_LibZipTarget>
-    <_LibZipTarget Include="host-Linux" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:'))">
+    <_LibZipTarget Include="host-Linux" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:')) AND '$(_LinuxBuildLibZip)' == 'true' ">
       <CMake>cmake</CMake>
       <CMakeFlags></CMakeFlags>
       <OutputLibrary>libzip.so</OutputLibrary>

--- a/build-tools/libzip/libzip.props
+++ b/build-tools/libzip/libzip.props
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+      <_LinuxBuildLibZip Condition=" '$(_LinuxBuildLibZip)' == '' AND '$(HostOS)' == 'Linux' AND '$(HostOsName)' != 'Ubuntu' ">true</_LinuxBuildLibZip>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This currently prevents libzip from being built on Ubuntu
since that distribution has libzip in the archives and
the `make prepare` step installs the required archive.

Without this commit libzip was marked to be built but wasn't
*actually* built and that resulted in the error when building
the bootstrap tasks (output shortened):

xamarin-android/Xamarin.Android.sln (default targets) ->
(Build target) ->
xamarin-android/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj (default targets) ->
14.0/bin/Microsoft.Common.targets (_CopyDeployFilesToOutputDirectoryAlways target) ->

    14.0/bin/Microsoft.Common.targets: error : Cannot copy bin/Debug/lib/xbuild/Xamarin/Android/libzip.so to xamarin-android/bin/BuildDebug/libzip.so, as the source file doesn't exist.

If, for some reason (e.g. on a build-bot), one wants to ignore
the detection performed by code in this commit, one should
call {x,ms}build defining the _LinuxBuildLibZip property on
command line:

    {x,ms}build /p:_LinuxBuildLibZip=true