### PR TITLE
[msbuild] bring back AndroidExternalJavaLibrary to Javac references.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/DetermineJavaLibrariesToCompile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/DetermineJavaLibrariesToCompile.cs
@@ -65,7 +65,8 @@ namespace Xamarin.Android.Tasks
 			jars          = jars.Where (j => distinct.Contains (j)).ToList ();
 
 			JavaLibrariesToCompile = jars.Where (j => !IsExcluded (j.ItemSpec)).ToArray ();
-			ReferenceJavaLibraries = jars.Except (JavaLibrariesToCompile).ToArray ();
+			ReferenceJavaLibraries = (ExternalJavaLibraries ?? Enumerable.Empty<ITaskItem> ())
+				.Concat (jars.Except (JavaLibrariesToCompile)).ToArray ();
 
 			Log.LogDebugTaskItems ("  JavaLibrariesToCompile:", JavaLibrariesToCompile);
 			Log.LogDebugTaskItems ("  ReferenceJavaLibraries:", ReferenceJavaLibraries);


### PR DESCRIPTION
This shold fix https://bugzilla.xamarin.com/show_bug.cgi?id=42091

When we fixed #27553 we reorganized the entire Java library resolution
step so that the build tasks could consistently resolve jars to package.
Sadly AndroidExternalJavaLibrary dropped out from the Javac reference
which should actually be different list than CompileToDalvik candidate.
This brings back AndroidExternalJavaLibrary to "reference-only" list.