### PR TITLE
[Xamarin.Android.Build.Tasks] Fix libzip build on Linux

### DIFF
--- a/build-tools/libzip/libzip.mdproj
+++ b/build-tools/libzip/libzip.mdproj
@@ -16,8 +16,7 @@
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
   <PropertyGroup>
-    <BuildDependsOn />
-    <BuildDependsOn Condition="'$(HostOS)' == 'Windows' OR '$(HostOS)' == 'Darwin'">
+    <BuildDependsOn>
       ResolveReferences;
       _BuildUnlessCached
     </BuildDependsOn>

--- a/build-tools/libzip/libzip.projitems
+++ b/build-tools/libzip/libzip.projitems
@@ -11,7 +11,7 @@
       <CMake>cmake</CMake>
       <CMakeFlags></CMakeFlags>
       <OutputLibrary>libzip.so</OutputLibrary>
-      <OutputLibraryPath>libzip.so</OutputLibraryPath>
+      <OutputLibraryPath>lib/libzip.so</OutputLibraryPath>
     </_LibZipTarget>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- Remove an OS check preventing Linux from building the library
- Fix `OutputLibraryPath` for Linux
