### PR TITLE
F# Android projects don't build when language is changed in XS fixes …

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
@@ -36,17 +36,17 @@ Copyright (C) 2012 Xamarin. All rights reserved.
 
     <!-- xbuild searches multiple MSBuildExtensionsPath32, but only in the Import element, so we can't determine this with a variable -->
     <Import
-      Condition="'$(Language)' == '' And Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')"
+      Condition="'$(Language)' != 'F#' And Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')"
       Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets" />
     <Import
-      Condition="'$(Language)' == '' And Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets')"
+      Condition="'$(Language)' != 'F#' And Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets')"
       Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets" />
     <Import
-      Condition="'$(Language)' == '' And Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets')"
+      Condition="'$(Language)' != 'F#' And Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets')"
       Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets" />
 
-    <Import Project="Xamarin.Android.Common.targets" />
 
+    <Import Project="Xamarin.Android.Common.targets" />
     <!--
     *******************************************
       Extensibility hook that allows VS to


### PR DESCRIPTION
F# projects don't build when lang is changed in XS

Setting the UI language in XS sets the msbuild variable `LANGUAGE = en`
(or whatever language you choose).

The Android F# targets check for the existence of this variable to
determine if Microsoft.FSharp.targets has been loaded.

Microsoft.FSharp.targets sets `<Language>F#</Language>` so it is better
to check for the presence of F# being set rather than checking to see
if it's not empty.

Fixes #43525 
