### PR TITLE
Encode the URL before sending to Java client

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -190,7 +190,7 @@ namespace Xamarin.Android.Net
 				Method = request.Method
 			};
 			while (true) {
-				URL java_url = new URL (redirectState.NewUrl.ToString ());
+				URL java_url = new URL (Uri.EscapeUriString (redirectState.NewUrl.ToString ()));
 				URLConnection java_connection = java_url.OpenConnection ();
 				HttpURLConnection httpConnection = await SetupRequestInternal (request, java_connection);
 				HttpResponseMessage response = await ProcessRequest (request, java_url, httpConnection, cancellationToken, redirectState);


### PR DESCRIPTION
It turns out that the .NET Uri class will not encode the URL
passed to it even if the original URL string contained the
encoded % sequences (e.g. %20) when ToString() is called on Uri
instance. Java client, in turn, doesn't encode the input either
and so we may get a bad request error code back from the server
since the URL part after a space (%20, possibly other horizontal
whitespace characters too) will be completely removed from the
URL when the Java client makes the request.

We now explicitly encode the URL before instantiating Java's URL
class.

Fixes bug https://bugzilla.xamarin.com/show_bug.cgi?id=43411