### PR TITLE
[MakeBundleNativeCodeExternal] pass `--i18n` flag to `mkbundle`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
@@ -111,6 +111,7 @@ namespace Xamarin.Android.Tasks
 				var clb = new CommandLineBuilder ();
 				clb.AppendSwitch ("--dos2unix=false");
 				clb.AppendSwitch ("--nomain");
+				clb.AppendSwitch ("--i18n none");
 				clb.AppendSwitch ("--style");
 				clb.AppendSwitch ("linux");
 				clb.AppendSwitch ("-c");


### PR DESCRIPTION

https://github.com/mono/mono/commit/50a4be2c5cbbbb6d88b14c0ec6179e562b7f6c36 introduces a regression in `xamarin-android` when using `mkbundle`:
```
'/Users/builder/data/lanes/1845/c6c9631e/source/benchmarker/tools/AndroidAgent/obj/Release/android/assets/shrunk/System.ServiceModel.Internals.dll'
    Target _BuildApkEmbed:
        [mkbundle stderr] ERROR: Cannot find assembly `I18N.West.dll'
        [mkbundle stderr] 
: error XA5102: Conversion from assembly to native code failed. Exit code 1
    Task "MakeBundleNativeCodeExternal" execution -- FAILED
    Done building target "_BuildApkEmbed" in project "/Users/builder/data/lanes/1845/c6c9631e/source/benchmarker/tools/AndroidAgent/AndroidAgent.csproj".-- FAILED
Done building project "/Users/builder/data/lanes/1845/c6c9631e/source/benchmarker/tools/AndroidAgent/AndroidAgent.csproj".-- FAILED

Build FAILED.
```


I tested the following settings (set with XS):

`<MandroidI18n>west</MandroidI18n>` -> `--i18n West`
`<MandroidI18n>west;cjk;mideast;other;rare</MandroidI18n>` -> `--i18n all`
`<MandroidI18n>rare;west</MandroidI18n>` -> `--i18n Rare,West`
`<MandroidI18n></MandroidI18n>` -> `--i18n none`
`<<<no property>>>` -> `--i18n none`

cc @jonpryor @akoeplinger @marek-safar @migueldeicaza 

PS: My C# foo sucks.  If you have suggestions for `ParseI18nFlags ()` let me know ;)

EDIT: opted in for a simpler solution.