### PR TITLE
[Xamarin.Android.Build.Utilities] Fixed AndroidSdkBase.ValidateAndroi…

### DIFF
--- a/src/Xamarin.Android.Build.Utilities/Sdks/AndroidSdkBase.cs
+++ b/src/Xamarin.Android.Build.Utilities/Sdks/AndroidSdkBase.cs
@@ -119,25 +119,33 @@ namespace Xamarin.Android.Build.Utilities
 		/// </summary>
 		public bool ValidateAndroidNdkLocation (string loc)
 		{
-			return !string.IsNullOrEmpty (loc) && File.Exists (Path.Combine (loc, NdkStack));
+			return !string.IsNullOrEmpty (loc) && FindExecutableInDirectory(NdkStack, loc).Any();
 		}
 
 		protected IEnumerable<string> FindExecutableInPath (string executable)
 		{
 			var path = Environment.GetEnvironmentVariable ("PATH");
 			var pathDirs = path.Split (new char[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
-			var pathExt = Environment.GetEnvironmentVariable ("PATHEXT");
-			var pathExts = pathExt?.Split (new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
 
 			foreach (var dir in pathDirs) {
-				if (File.Exists (Path.Combine (dir, (executable))))
-					yield return dir;
-				if (pathExts == null)
-					continue;
-				foreach (var ext in pathExts)
-					if (File.Exists (Path.Combine (dir, Path.ChangeExtension (executable, ext))))
-						yield return dir;
+				foreach (var directory in FindExecutableInDirectory(executable, dir)) {
+					yield return directory;
+				}
 			}
+		}
+		
+		protected IEnumerable<string> FindExecutableInDirectory(string executable, string dir)
+		{			
+			var pathExt = Environment.GetEnvironmentVariable ("PATHEXT");
+			var pathExts = pathExt?.Split (new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+			
+			if (File.Exists (Path.Combine (dir, (executable))))
+				yield return dir;
+			if (pathExts == null)
+				yield break;
+			foreach (var ext in pathExts)
+				if (File.Exists (Path.Combine (dir, Path.ChangeExtension (executable, ext))))
+					yield return dir;
 		}
 
 		protected string NullIfEmpty (string s)


### PR DESCRIPTION
Fixes a bug we discovered on our own, I didn't find any such mentions of this bug in bugzilla yet.

Recently, there was a change in the Android NDK where ndk-stack.exe was renamed to ndk-stack.cmd. A fix was pulled recently (https://github.com/xamarin/xamarin-android/pull/136) to fix this problem when providing it through Visual Studio. However, if you call it straight from the command line with the parameter /p:AndroidNdkDirectory=<dir>, this code will not be called, it will call ValidateAndroidNdkLocation(string) instead, which will fail because it looks only for ndk-stack.exe. 

This commit updates the code in ValidateAndroidNdkLocation(string) to use the same logic from FindExecutableInPath(). I had to split it in two functions, one to search a specific directory, and one to search for every directory in %PATH%.