### PR TITLE
format-local does not exist in git 1.8.3

### DIFF
--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -96,11 +96,11 @@
   </ItemGroup>
   <Target Name="_SetAutogenShTimeToLastCommitTimestamp">
     <Exec
-        Command="touch -m -t `git log -1 --format=%25cd --date=format-local:%25Y%25m%25d%25H%25M.%25S` autogen.sh"
+        Command="touch -m --date=%22`git log -1 --format=%25cd --date=iso`%22 autogen.sh"
         WorkingDirectory="$(MonoSourceFullPath)"
     />
     <Exec
-        Command="touch -m -t `git log -1 --format=%25cd --date=format-local:%25Y%25m%25d%25H%25M.%25S` Makefile.config.in"
+        Command="touch -m --date=%22`git log -1 --format=%25cd --date=iso`%22 Makefile.config.in"
         WorkingDirectory="$(LlvmSourceFullPath)"
     />
   </Target>


### PR DESCRIPTION
to be able to set the modification date with older git versions (ie on EL 7) you should use another date option (iso)
