### PR TITLE
[Xamarin.Android.Build.Tasks] Preserve Mono.RuntimeStructs/{HandleStackMark,MonoError}

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/PreserveLists/mscorlib.xml
+++ b/src/Xamarin.Android.Build.Tasks/Linker/PreserveLists/mscorlib.xml
@@ -402,6 +402,11 @@
 		-->
 		<type fullname="Mono.Runtime" />
 
+		<!-- marshal.c (mono_marshal_get_native_wrapper) -->
+		<type fullname="Mono.RuntimeStructs/HandleStackMark" />
+		<!-- marshal.c (mono_marshal_get_native_wrapper) -->
+		<type fullname="Mono.RuntimeStructs/MonoError" />
+
 		<type fullname="Mono.Interop.ComInteropProxy" feature="com" />
 		<type fullname="Mono.Interop.IDispatch" feature="com" />
 		<type fullname="Mono.Interop.IUnknown" feature="com" />


### PR DESCRIPTION
fix for:
```
08-22 11:26:37.931  3279  3279 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
08-22 11:26:37.931  3279  3279 F DEBUG   : Build fingerprint: 'samsung/zerofltespr/zerofltespr:6.0.1/MMB29K/G920PVPS3CPD2:user/release-keys'
08-22 11:26:37.931  3279  3279 F DEBUG   : Revision: '10'
08-22 11:26:37.931  3279  3279 F DEBUG   : ABI: 'arm'
08-22 11:26:37.931  3279  3279 F DEBUG   : pid: 2734, tid: 2734, name: .benchmarkagent  >>> com.xamarin.benchmarkagent <<<
08-22 11:26:37.931  3279  3279 F DEBUG   : signal 6 (SIGABRT), code -6 (SI_TKILL), fault addr --------
08-22 11:26:37.941  3279  3279 F DEBUG   : Abort message: 'Runtime critical type Mono.RuntimeStructs/HandleStackMark not found'
08-22 11:26:37.941  3279  3279 F DEBUG   :     r0 00000000  r1 00000aae  r2 00000006  r3 f7208b94
08-22 11:26:37.941  3279  3279 F DEBUG   :     r4 f7208b9c  r5 f7208b4c  r6 00000002  r7 0000010c
08-22 11:26:37.941  3279  3279 F DEBUG   :     r8 ee364ac8  r9 ee364a90  sl 00000001  fp ffcc11a0
08-22 11:26:37.941  3279  3279 F DEBUG   :     ip 00000006  sp ffcc1148  lr f6f65365  pc f6f67754  cpsr 400e0010
```

FWIW, fix from macios: https://github.com/xamarin/xamarin-macios/pull/616


cc @lambdageek 
