### PR TITLE
Default to the managed HTTP client handler

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -322,7 +322,7 @@ namespace Xamarin.Android.Tasks
 
 			const string defaultLogLevel = "MONO_LOG_LEVEL=info";
 			const string defaultMonoDebug = "MONO_DEBUG=gen-compact-seq-points";
-			const string defaultHttpMessageHandler = "XA_HTTP_CLIENT_HANDLER_TYPE=Xamarin.Android.Net.AndroidClientHandler";
+			const string defaultHttpMessageHandler = "XA_HTTP_CLIENT_HANDLER_TYPE=System.Net.Http.HttpClientHandler, System.Net.Http";
 			string xamarinBuildId = string.Format ("XAMARIN_BUILD_ID={0}", buildId);
 
 			if (Environments == null) {


### PR DESCRIPTION
Cycle 8 shouldn't use the new Android HttpClientHandler by default,
it should still default to the managed one.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=43635