### PR TITLE
[Xamarin.Android.Build.Tasks] Extend the Aot Task to allow the passing of additional arguments

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -60,6 +60,8 @@ namespace Xamarin.Android.Tasks
 
 		public string AndroidSequencePointsMode { get; set; }
 
+		public string AotAdditionalArguments { get; set; }
+
 		public ITaskItem[] AdditionalNativeLibraryReferences { get; set; }
 
 		[Output]
@@ -317,7 +319,7 @@ namespace Xamarin.Android.Tasks
 						Path.GetFileName (assembly.ItemSpec)));
 
 					string aotOptions = string.Format (
-						"{0}--aot={8}{1}outfile={2},asmwriter,mtriple={3},tool-prefix={4},ld-flags={5},llvm-path={6},temp-path={7}",
+						"{0}--aot={9}{8}{1}outfile={2},asmwriter,mtriple={3},tool-prefix={4},ld-flags={5},llvm-path={6},temp-path={7}",
 						EnableLLVM ? "--llvm " : string.Empty,
 						AotMode != AotMode.Normal ? string.Format("{0},", AotMode.ToString().ToLowerInvariant()) : string.Empty,
 						QuoteFileName (outputFile),
@@ -326,7 +328,8 @@ namespace Xamarin.Android.Tasks
 						ldFlags,
 						QuoteFileName (SdkBinDirectory),
 						QuoteFileName (outdir),
-						sequencePointsMode == SequencePointsMode.Offline ? string.Format("msym-dir={0},", QuoteFileName(outdir)) : string.Empty
+						sequencePointsMode == SequencePointsMode.Offline ? string.Format("msym-dir={0},", QuoteFileName(outdir)) : string.Empty,
+						AotAdditionalArguments != string.Empty ? string.Format ("{0},", AotAdditionalArguments) : string.Empty
 					);
 
 					// Due to a Monodroid MSBuild bug we can end up with paths to assemblies that are not in the intermediate

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2173,6 +2173,7 @@ because xbuild doesn't support framework reference assemblies.
 	SdkBinDirectory="$(MonoAndroidBinDirectory)"
 	SupportedAbis="$(_BuildTargetAbis)"
 	AndroidSequencePointsMode="$(_SequencePointsMode)"
+	AotAdditionalArguments="$(AndroidAotAdditionalArguments)"
 	ResolvedAssemblies="@(_ResolvedAssemblies)"
 	AotOutputDirectory="$(_AndroidAotBinDirectory)"
 	IntermediateAssemblyDir="$(MonoAndroidIntermediateAssemblyDir)"


### PR DESCRIPTION
Context https://bugzilla.xamarin.com/show_bug.cgi?id=43500

We need a way to pass additional arguments to the aot system.
This is so users can add additional parameters to tweak the
output. In the case of Bug 43500 we needed to be able to pass

	'no-write-symbols' or 'no-debug'

Rather than just hardcoding those values we now provide a

	$(AndroidAotAdditionalArguments)

msbuild property which defaults to empty but users can override
to pass any additional parameters that they need.