### PR TITLE
[Xamarin.Android.Build.Tasks] [Symbolication] Android AOT msym files should not be stored in an `abi` specific folder

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2283,11 +2283,12 @@ because xbuild doesn't support framework reference assemblies.
   />
 
   <ItemGroup>
-    <_SymbolicateFiles Include="$(_AndroidAotBinDirectory)\**\*.msym" />
+    <_BuiltAbis Include="$(_BuildTargetAbis)" />
+    <_SymbolicateFiles Include="$(_AndroidAotBinDirectory)\%(_BuiltAbis.Identity)\**\*.msym" />
   </ItemGroup>
 
   <Copy Condition=" '$(AndroidManagedSymbols)' == 'True' And '%(_SymbolicateFiles.Filename)' != '' "
-    SourceFiles="$(_AndroidAotBinDirectory)\%(_SymbolicateFiles.RecursiveDir)%(_SymbolicateFiles.Filename)%(_SymbolicateFiles.Extension)"
+    SourceFiles="%(_SymbolicateFiles.Identity)"
     DestinationFolder="$(OutDir)$(_AndroidPackage).apk.msym\%(_SymbolicateFiles.RecursiveDir)"
     SkipUnchangedFiles="true"
   />


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=43549

The symbolication spec was changed to removed the abi specific
subfolders. The msym files are now stored in folders which use
an AOTID. As a result there is no need to store them in abi
folder to avoid clashes.