### PR TITLE
[Xamarin.Android.Build.Utilities] Xamarin can't find NDK 12b because ndk-stack.exe is now ndk-stack.cmd

### DIFF
--- a/src/Xamarin.Android.Build.Utilities/Sdks/AndroidSdkBase.cs
+++ b/src/Xamarin.Android.Build.Utilities/Sdks/AndroidSdkBase.cs
@@ -34,18 +34,18 @@ namespace Xamarin.Android.Build.Utilities
 		public string AndroidToolsPathShort { get; private set; }
 		public string AndroidPlatformToolsPathShort { get; private set; }
 
-		public abstract string Adb { get; }
-		public abstract string Android { get; }
-		public abstract string Emulator { get; }
-		public abstract string Monitor { get; }
-		public abstract string ZipAlign { get; }
-		public abstract string JarSigner { get; }
-		public abstract string KeyTool { get; }
+		public virtual string Adb { get; protected set; } = "adb";
+		public virtual string Android { get; protected set; } = "android";
+		public virtual string Emulator { get; protected set; } = "emulator";
+		public virtual string Monitor { get; protected set; } = "monitor";
+		public virtual string ZipAlign { get; protected set; } = "zipalign";
+		public virtual string JarSigner { get; protected set; } = "jarsigner";
+		public virtual string KeyTool { get; protected set; } = "keytool";
 
-		public abstract string NdkStack { get; }
+		public virtual string NdkStack { get; protected set; } = "ndk-stack";
 		public abstract string NdkHostPlatform32Bit { get; }
 		public abstract string NdkHostPlatform64Bit { get; }
-		public abstract string Javac { get; }
+		public virtual string Javac { get; protected set; } = "javac";
 
 		public abstract string PreferedAndroidSdkPath { get; }
 		public abstract string PreferedAndroidNdkPath { get; }
@@ -81,6 +81,13 @@ namespace Xamarin.Android.Build.Utilities
 				IsNdk64Bit = Directory.EnumerateDirectories (toolchainsDir, "arm-linux-androideabi-*")
 					.Any (dir => Directory.Exists (Path.Combine (dir, "prebuilt", NdkHostPlatform64Bit)));
 			}
+			// we need to look for extensions other than the default .exe|.bat
+			// google have a habbit of changing them.
+			Adb = GetExecutablePath (AndroidPlatformToolsPath, Adb);
+			Android = GetExecutablePath (AndroidToolsPath, Android);
+			Emulator = GetExecutablePath (AndroidToolsPath, Emulator);
+			Monitor = GetExecutablePath (AndroidToolsPath, Monitor);
+			NdkStack = GetExecutablePath (AndroidNdkPath, NdkStack);
 		}
 
 		protected abstract IEnumerable<string> GetAllAvailableAndroidSdks ();
@@ -136,16 +143,22 @@ namespace Xamarin.Android.Build.Utilities
 		
 		protected IEnumerable<string> FindExecutableInDirectory(string executable, string dir)
 		{			
+			foreach (var exe in Executables (executable))
+				if (File.Exists (Path.Combine (dir, exe)))
+					yield return dir;
+		}
+
+		IEnumerable<string> Executables (string executable)
+		{
+			yield return executable;
 			var pathExt = Environment.GetEnvironmentVariable ("PATHEXT");
 			var pathExts = pathExt?.Split (new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
-			
-			if (File.Exists (Path.Combine (dir, (executable))))
-				yield return dir;
+
 			if (pathExts == null)
 				yield break;
+
 			foreach (var ext in pathExts)
-				if (File.Exists (Path.Combine (dir, Path.ChangeExtension (executable, ext))))
-					yield return dir;
+				yield return Path.ChangeExtension (executable, ext);
 		}
 
 		protected string NullIfEmpty (string s)
@@ -154,6 +167,14 @@ namespace Xamarin.Android.Build.Utilities
 				return s;
 
 			return null;
+		}
+
+		string GetExecutablePath (string dir, string exe)
+		{
+			foreach (var e in Executables (exe))
+				if (File.Exists (Path.Combine (dir, e)))
+					return e;
+			return exe;
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Utilities/Sdks/AndroidSdkUnix.cs
+++ b/src/Xamarin.Android.Build.Utilities/Sdks/AndroidSdkUnix.cs
@@ -8,23 +8,12 @@ namespace Xamarin.Android.Build.Utilities
 {
 	class AndroidSdkUnix : AndroidSdkBase
 	{
-		public override string Adb { get { return "adb"; } }
-		public override string Android { get { return "android"; } }
-		public override string Emulator { get { return "emulator"; } }
-		public override string Monitor { get { return "monitor"; } }
-		public override string ZipAlign { get { return "zipalign"; } }
-		public override string JarSigner { get { return "jarsigner"; } }
-		public override string KeyTool { get { return "keytool"; } }
-		public override string NdkStack { get { return "ndk-stack"; } }
-
 		public override string NdkHostPlatform32Bit {
 			get { return OS.IsMac ? "darwin-x86" : "linux-x86"; }
 		}
 		public override string NdkHostPlatform64Bit {
 			get { return OS.IsMac ? "darwin-x86_64" : "linux-x86_64"; }
 		}
-
-		public override string Javac { get { return "javac"; } }
 
 		public override string PreferedAndroidSdkPath { 
 			get {

--- a/src/Xamarin.Android.Build.Utilities/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Build.Utilities/Sdks/AndroidSdkWindows.cs
@@ -15,17 +15,13 @@ namespace Xamarin.Android.Build.Utilities
 		const string XAMARIN_ANDROID_INSTALLER_PATH = @"SOFTWARE\Xamarin\MonoAndroid";
 		const string XAMARIN_ANDROID_INSTALLER_KEY = "PrivateAndroidSdkPath";
 
-		public override string Adb { get { return "adb.exe"; } }
-		public override string Android { get { return "android.bat"; } }
-		public override string Emulator { get { return "emulator.exe"; } }
-		public override string Monitor { get { return "monitor.bat"; } }
-		public override string ZipAlign { get { return "zipalign.exe"; } }
-		public override string JarSigner { get { return "jarsigner.exe"; } }
-		public override string KeyTool { get { return "keytool.exe"; } }
-		public override string NdkStack { get { return "ndk-stack.exe"; } }
+		public override string ZipAlign { get; protected set; } = "zipalign.exe";
+		public override string JarSigner { get; protected set; } = "jarsigner.exe";
+		public override string KeyTool { get; protected set; } = "keytool.exe";
+
 		public override string NdkHostPlatform32Bit { get { return "windows"; } }
 		public override string NdkHostPlatform64Bit { get { return "windows-x86_64"; } }
-		public override string Javac { get { return "javac.exe"; } }
+		public override string Javac { get; protected set; } = "javac.exe";
 
 		public override string PreferedAndroidSdkPath {
 			get {


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=42566

The problem was that we did not UPDATE the ndk-stack.exe property
to be ndk-stack.cmd once we had verified that the ndk was valid.

This commit adds support for changing the ndk-stack extension to
one of the "known" extentions on Windows if it exists.