### PR TITLE
Look for gdb in `android-sdk-tool/android-ndk/prebuilt/darwin-x86_64/bin/gdb`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
@@ -80,6 +80,15 @@ namespace Xamarin.Android.Tasks
 					toolPaths = new List<string>();
 				toolPaths.Add (path);
 			}
+			{
+				string path = Path.Combine (androidNdkPath, "prebuilt", AndroidSdk.AndroidNdkHostPlatform, "bin", tool);
+				if (File.Exists (path))
+					return path;
+				if (toolPaths == null)
+					toolPaths = new List<string>();
+				toolPaths.Add (path);
+                       }
+
 			Diagnostic.Error (5101,
 					"C compiler for target {0} was not found. Tried paths: \"{1}\"",
 					arch, string.Join ("; ", toolPaths));


### PR DESCRIPTION
The gdb tool is not in the previous folder anymore, so we need to look for it at this place too.