### PR TITLE
[Xamarin.Android.Build.Tasks] [Symbolication] Managed assemblies and mdbs should be stored in MVID folders

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2270,16 +2270,9 @@ because xbuild doesn't support framework reference assemblies.
 
   <Copy SourceFiles="%(ApkFiles.FullPath)" DestinationFolder="$(OutDir)" />
 
-  <GetFilesThatExist
-      Condition="'$(AndroidManagedSymbols)' == 'True' "
-      Files="@(_ResolvedAssemblies->'%(Identity)');@(_ResolvedAssemblies->'%(Identity).mdb');@(_ResolvedAssemblies->'%(Identity).msym')">
-    <Output TaskParameter="FilesThatExist" ItemName="_SymbolicateArchiveAssemblies" />
-  </GetFilesThatExist>
-
-  <Copy Condition=" '$(AndroidManagedSymbols)' == 'True' And Exists('%(_SymbolicateArchiveAssemblies.Identity)') "
-    SourceFiles="@(_SymbolicateArchiveAssemblies)"
-    DestinationFolder="$(OutDir)$(_AndroidPackage).apk.msym"
-    SkipUnchangedFiles="true"
+  <Exec
+    Command="&quot;$(_MonoAndroidBinDirectory)mono-symbolicate&quot; store-symbols &quot;$(OutDir)$(_AndroidPackage).apk.msym&quot; &quot;$(MonoAndroidIntermediate)android/assets&quot;"
+    Condition=" '$(AndroidManagedSymbols)' == 'True' "
   />
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=43550

The mono-symbolication now provides a way to copy the assembly files
into the correct directories. Before we were just dumping them in
the root of the msym archive. But the spec changed so that each
assembly needed to be in its own MVID folder.

Rather than trying to figure out that we will do what the iOS team
has done. We call mono-symbolicate with the `store-symbols` parameter
passing it the msym archive directory and the directory where all
the intermediate msym files are.

This makes sure that the files are formatted and placed in the
correct places.