### PR TITLE
[Xamarin.Android.Build.Utilities] AndroidSdkBase.ValidateAndroidSdkLocation fails on Windows

### DIFF
--- a/src/Xamarin.Android.Build.Utilities/Sdks/AndroidSdkBase.cs
+++ b/src/Xamarin.Android.Build.Utilities/Sdks/AndroidSdkBase.cs
@@ -110,7 +110,7 @@ namespace Xamarin.Android.Build.Utilities
 		/// </summary>
 		public bool ValidateAndroidSdkLocation (string loc)
 		{
-			return !string.IsNullOrEmpty (loc) && File.Exists (Path.Combine (Path.Combine (loc, "platform-tools"), Adb));
+			return !string.IsNullOrEmpty (loc) && FindExecutableInDirectory (Adb, Path.Combine (loc, "platform-tools")).Any ();
 		}
 
 		/// <summary>
@@ -118,7 +118,7 @@ namespace Xamarin.Android.Build.Utilities
 		/// </summary>
 		public virtual bool ValidateJavaSdkLocation (string loc)
 		{
-			return !string.IsNullOrEmpty (loc) && File.Exists (Path.Combine (Path.Combine (loc, "bin"), JarSigner));
+			return !string.IsNullOrEmpty (loc) && FindExecutableInDirectory (JarSigner, Path.Combine (loc, "bin")).Any ();
 		}
 
 		/// <summary>
@@ -171,6 +171,8 @@ namespace Xamarin.Android.Build.Utilities
 
 		string GetExecutablePath (string dir, string exe)
 		{
+			if (string.IsNullOrEmpty (dir))
+				return exe;
 			foreach (var e in Executables (exe))
 				if (File.Exists (Path.Combine (dir, e)))
 					return e;

--- a/src/Xamarin.Android.Build.Utilities/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Build.Utilities/Sdks/AndroidSdkWindows.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Xamarin.Android.Build.Utilities
 {
@@ -186,7 +187,7 @@ namespace Xamarin.Android.Build.Utilities
 				return false;
 			}
 
-			if (!File.Exists (Path.Combine (path, subdir, exe))) {
+			if (!FindExecutableInDirectory (exe, Path.Combine (path, subdir)).Any ()) {
 				AndroidLogger.LogInfo ("sdk", "  Key {0} found:\n    Path does not contain {1} in \\{2} ({3}).", key_name, exe, subdir, path);
 				return false;
 			}


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=43910

Both ValidateAndroidSdkLocation and ValidateJavaSdkLocation needed
to take into account possible extension changes for the files
being searched for. In this case we need to look for adb.exe
on windows not just adb.

The method FindExecutableInDirectory can be used to make sure
we scan for different extensions. So we have updated the
Android/Java Validation methods to use similar code to
ValidateAndroidNdkLocation.