### PR TITLE
[Xamarin.Android.Build.Tasks] Set the right Application instance

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.api4.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.api4.java
@@ -22,12 +22,14 @@ public class MonoPackageManager {
 	public static void LoadApplication (Context context, ApplicationInfo runtimePackage, String[] apks)
 	{
 		synchronized (lock) {
+			if (context instanceof android.app.Application) {
+				Context = context;
+			}
 			if (!initialized) {
 				android.content.IntentFilter timezoneChangedFilter  = new android.content.IntentFilter (
 						android.content.Intent.ACTION_TIMEZONE_CHANGED
 				);
 				context.registerReceiver (new mono.android.app.NotifyTimeZoneChanges (), timezoneChangedFilter);
-				setContext (context);
 				
 				System.loadLibrary("monodroid");
 				Locale locale       = Locale.getDefault ();
@@ -62,9 +64,7 @@ public class MonoPackageManager {
 
 	public static void setContext (Context context)
 	{
-		if (Context == null) {
-			Context = context;
-		}
+		// Ignore; vestigial
 	}
 
 	public static String[] getAssemblies ()

--- a/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.java
@@ -22,12 +22,14 @@ public class MonoPackageManager {
 	public static void LoadApplication (Context context, ApplicationInfo runtimePackage, String[] apks)
 	{
 		synchronized (lock) {
+			if (context instanceof android.app.Application) {
+				Context = context;
+			}
 			if (!initialized) {
 				android.content.IntentFilter timezoneChangedFilter  = new android.content.IntentFilter (
 						android.content.Intent.ACTION_TIMEZONE_CHANGED
 				);
 				context.registerReceiver (new mono.android.app.NotifyTimeZoneChanges (), timezoneChangedFilter);
-				setContext (context);
 				
 				System.loadLibrary("monodroid");
 				Locale locale       = Locale.getDefault ();
@@ -62,9 +64,7 @@ public class MonoPackageManager {
 
 	public static void setContext (Context context)
 	{
-		if (Context == null) {
-			Context = context;
-		}
+		// Ignore; vestigial
 	}
 
 	static String getNativeLibraryPath (Context context)


### PR DESCRIPTION
The `Android.App.Application.Context` static property provides what
the Android API does not: global access to the global
android.app.Application instance created during process startup, which
exists for the lifetime of the process. The type of the value returned
by the property can be set using the `//application/@android:name`
attribute value within `AndroidManifest.xml`, or by using the
`[Android.App.Application]` custom attribute.

(Why provide such a property? Because it's extremely handy to be able
to lookup `Application` context paths/resources/etc. from static methods
without needing to provide an explicit `Context` instance...)

The value of the `Android.App.Application.Context` property in turn
comes from the Java-side `MonoPackageManager.Context` field, which was
set by `MonoPackageManager.setContext()`.

The problem is that on devices running API-15 and earlier, the
`MonoPackageManager.Context` field is *not* set to an instance of
the type specified in `AndroidManifest.xml`. Instead, the
`MonoPackageManager.Context` field was referring to a `ContextImpl`
instance created during Android process startup.

Commit 972336b0 attempted to fix this problem, but its analysis is
incorrect: the problem isn't with `MonoRuntimeProvider.attachInfo()`.

The problem is `MonoPackageManager.LoadApplication()` and the fact
that it can be invoked *multiple times*, and that it was preserving
the `Context` instance provided during the *first* invocation.

The other "missing" invocation? `Instrumentation.onCreate()` method
overrides, such as in
`src/Mono.Android/Test/Xamarin.Android.RuntimeTests/TestInstrumentation.cs`.

`Instrumentation` types -- when specified -- are always created *first*
on API <= 15, before any `Application` instance is created.

Thus, the actual startup ordering on API <= 15 is:

1. `android.app.ContextImpl` instance created.
2. `xamarin.android.runtimetests.TestInstrumentation` created.
3. `TestInstrumentation.onCreate()` invoked, provided (1).
4. `TestInstrumentation.onCreate()` calls
    `MonoPackageManager.LoadApplication()`, which initializes
    everything and stores (1) into `MonoPackageManager.Context`.
    // THIS WAS THE BUG, as (1) isn't (5).
5. `Application` instance is created.
6. `ContentProvider`s are created, including `MonoRuntimeProvider`.
7. `MonoRuntimeProvider.attachInfo()` invoked, provided (5).
8. `MonoRuntimeProvider.attachInfo()` invokes
    `MonoRuntimeProvider.LoadApplication()`, which did nothing.

Because `MonoPackageManager.LoadApplication()` would only preserve the
*first* `Context` instance provided, this would always be the
`ContextImpl` instance created in (1), not the `Application` instance
created in (5).

This is also why commit 972336b0 didn't work: it likewise would
preserve the first `Context` instance provided, which would be the
`ContextImpl` instance created in (1), and thus didn't fix anything.

But wait, there's more! It's not only an issue of
`MonoPackageManager.LoadApplication()` being invoked multiple times.
It's also that the *order* changes.

The startup ordering on API >= 16 is:

1. `Application` instance is created.
2. `ContentProvider`s are created, including `MonoRuntimeProvider`.
3. `MonoRuntimeProvider.attachInfo()` invoked, provided (1).
4. `MonoRuntimeProvider.attachInfo()` invokes
    `MonoPackageManager.LoadApplication()`, which initializes
    everything and stores (1) into `MonoPackageManager.Context`.
    // THIS WAS DESIRED!
5. `android.app.ContextImpl` instance created (?!)
6. `xamarin.android.runtimetests.TestInstrumentation` created.
7. `TestInstrumentation.onCreate()` invoked, provided (5).
8. `TestInstrumentation.onCreate()` invokes
    `MonoRuntimeProvider.LoadApplication()`, which does nothing.

Commit 972336b0 worked on API >= 16 because it preserved the first
`Context` instance provided to `MonoPackageManager.LoadApplication()`.
This same behavior is what broke API <= 15, because on API <= 15 it's
the *second* `Context` instance which is the `Application` instance.

Additionally, there is thus no actual need for custom Java Callable
Wrapper generation for Application constructors, but we'll preserve
that because it'll be annoying to update the Java.Interop repo.
Instead, just make `MonoPackageManager.setContext()` a no-op.
There is no plausible way to have the `Application` constructor help
here, especially when the `Application` type can be replaced with a
different type -- see also commit 28350a31 and
`$(AndroidApplicationJavaClass)`.

The fix is twofold:

1. Don't set `MonoPackageManager.Context` within the `!initialized`
    block, as it may be the second+
    `MonoPackageManager.LoadApplication()` invocation which provides the
    appropriate instance to preserve.

2. If we need an `Application` instance, REQUIRE IT.

Thus, we're changing this pattern:

	if (!initialized) {
		...
		Context = context;
		...
	}

to this one:

	if (context instanceof Application) {
		Context = context;
	}
	if (!initialized) {
		...
	}

This is potentially brittle, as it means if `android.app.ContextImpl`
ever inherits `Application` instead of Context, the check will store the
wrong instance. Hopefully Google won't do this.