### PR TITLE
[msbuild] Detach API XML adjuster work from GenerateBindings task.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
@@ -14,13 +14,15 @@ namespace Xamarin.Android.Tasks
 {
 	public class BindingsGenerator : AndroidToolTask
 	{
+		public bool OnlyRunXmlAdjuster { get; set; }
+
+		public string XmlAdjusterOutput { get; set; }
+
 		[Required]
 		public string OutputDirectory { get; set; }
 
-		[Required]
 		public string EnumDirectory { get; set; }
 
-		[Required]
 		public string EnumMetadataDirectory { get; set; }
 
 		[Required]
@@ -29,7 +31,6 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string ApiXmlInput { get; set; }
 
-		[Required]
 		public string AssemblyName { get; set; }
 		
 		public string CodegenTarget { get; set; }
@@ -53,6 +54,7 @@ namespace Xamarin.Android.Tasks
 		public override bool Execute ()
 		{
 			Log.LogDebugMessage ("BindingsGenerator Task");
+			Log.LogDebugMessage ("  OnlyRunXmlAdjuster: {0}", OnlyRunXmlAdjuster);
 			Log.LogDebugMessage ("  OutputDirectory: {0}", OutputDirectory);
 			Log.LogDebugMessage ("  EnumDirectory: {0}", EnumDirectory);
 			Log.LogDebugMessage ("  EnumMetadataDirectory: {0}", EnumMetadataDirectory);
@@ -105,6 +107,10 @@ namespace Xamarin.Android.Tasks
 			var cmd = new CommandLineBuilder ();
 
 			cmd.AppendFileNameIfNotNull (ApiXmlInput);
+
+			if (OnlyRunXmlAdjuster)
+				cmd.AppendSwitch ("--only-xml-adjuster");
+			cmd.AppendSwitchIfNotNull ("--xml-adjuster-output=", XmlAdjusterOutput);
 
 			cmd.AppendSwitchIfNotNull ("--codegen-target=", CodegenTarget);
 			cmd.AppendSwitchIfNotNull ("--csdir=", OutputDirectory);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -362,12 +362,24 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <!-- Extract the API from the .jar file and store as .xml, using either class-parse or jar2xml -->
 	
     <ClassParse Condition="'$(AndroidClassParser)' == 'class-parse'"
-      OutputFile="$(ApiOutputFile)"
+      OutputFile="$(ApiOutputFile).class-parse"
       SourceJars="@(EmbeddedJar);@(InputJar)"
       JavaDocPaths="$(JavaDocPaths)"
       Java7DocPaths="$(Java7DocPaths)"
       Java8DocPaths="$(Java8DocPaths)"
       DroidDocPaths="$(DroidDocPaths)"
+    />
+
+    <BindingsGenerator Condition="'$(AndroidClassParser)' == 'class-parse'"
+      OnlyRunXmlAdjuster="true"
+      XmlAdjusterOutput="$(ApiOutputFile)"
+      OutputDirectory="$(GeneratedOutputPath)src"
+      AndroidApiLevel="$(_AndroidApiLevel)"
+      ApiXmlInput="$(ApiOutputFile).class-parse"
+      ReferencedManagedLibraries="@(ReferencePath);@(ReferenceDependencyPaths)"
+      MonoAndroidFrameworkDirectories="$(_TargetFrameworkDirectories)"
+      ToolPath="$(_MonoAndroidBinDirectory)"
+      ToolExe="$(BindingsGeneratorToolExe)"
     />
 
     <JarToXml Condition="'$(AndroidClassParser)' == 'jar2xml'"
@@ -515,6 +527,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 
     <Delete Files="$(ApiOutputFile)" />
     <Delete Files="$(ApiOutputFile).adjusted" />
+    <Delete Files="$(ApiOutputFile).class-parse" />
     <Delete Files="$(ApiOutputFile).fixed" />
     <Delete Files="$(ApiOutputFile).adjusted.fixed" />
     <Delete Files="$(_GeneratorStampFile)" />


### PR DESCRIPTION
DO NOT MERGE without merging https://github.com/xamarin/java.interop/pull/71

It splits API XML adjuster work from GenerateBindings and thus reduce
the need to run class-parse and/or API XML adjuster work in generator
and thus reduce the chance to load class-parse XML which is almost
twice as big as api-xml-adjuster outputs.

Therefore now ExportJarToXml task is consistent between jar2xml and
class-parse, which makes cache more efficient. Jars usually don't change
often, while Metadata.xml etc. that triggers GenerateBindings.