### PR TITLE
[bundle] Create the bundle

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -7,7 +7,7 @@
       Outputs="$(OutputPath)\Xamarin.Android.Tools.BootstrapTasks.dll">
     <MSBuild
         Projects="..\..\src\Xamarin.Android.Tools.BootstrapTasks\Xamarin.Android.Tools.BootstrapTasks.csproj"
-        Properties="OutputPath=$(AndroidToolchainDirectory)"
+        Properties="OutputPath=$(AndroidToolchainDirectory)\"
     />
   </Target>
   <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"   TaskName="Xamarin.Android.BuildTools.PrepTasks.DownloadUri" />

--- a/build-tools/libzip/libzip.mdproj
+++ b/build-tools/libzip/libzip.mdproj
@@ -6,6 +6,17 @@
     <ItemType>GenericProject</ItemType>
     <ProjectGuid>{900A0F71-BAAD-417A-8D1A-8D330297CDD0}</ProjectGuid>
   </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
+  <PropertyGroup>
+    <OutputPath>..\..\bin\$(Configuration)</OutputPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
+  <PropertyGroup>
+    <BuildDependsOn Condition="'$(HostOS)' == 'Windows' OR '$(HostOS)' == 'Darwin'">
+      ResolveReferences;
+      _BuildUnlessCached
+    </BuildDependsOn>
+  </PropertyGroup>
   <Import Project="libzip.targets" />
   <ItemGroup>
     <ProjectReference Include="..\xa-prep-tasks\xa-prep-tasks.csproj">

--- a/build-tools/libzip/libzip.targets
+++ b/build-tools/libzip/libzip.targets
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\Configuration.props" />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>..\..\bin\$(Configuration)</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>..\..\bin\$(Configuration)</OutputPath>
-  </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
-  <PropertyGroup>
-    <BuildDependsOnLocal Condition="'$(HostOS)' == 'Windows' OR '$(HostOS)' == 'Darwin'">
-      ResolveReferences;
-      _BuildUnlessCached
-    </BuildDependsOnLocal>
-  </PropertyGroup>
   <Import Project="libzip.props" />
   <Import Project="libzip.projitems" />
   <Import Project="..\scripts\RequiredPrograms.targets" />
@@ -25,7 +11,7 @@
       _Make
     </ForceBuildDependsOn>
   </PropertyGroup>
-  <Target Name="Build" DependsOnTargets="$(BuildDependsOnLocal)" />
+  <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
   <Target Name="Clean" />
   <Target Name="_SetCMakeListsTxtTimeToLastCommitTimestamp">
     <Exec
@@ -45,7 +31,7 @@
     />
   </Target>
   <ItemGroup>
-    <Content Include="@(_LibZipTarget->'$(OutputPath)\lib\xbuild\Xamarin\Android\%(_LibZipTarget.OutputLibrary)')">
+    <Content Include="@(_LibZipTarget->'$(OutputPath)\lib\xbuild\Xamarin\Android\%(OutputLibrary)')">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
@@ -57,8 +43,10 @@
         Command="make"
         WorkingDirectory="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)"
      /> 
-    <Copy SourceFiles="@(_LibZipTarget->'$(IntermediateOutputPath)\%(Identity)\%(_LibZipTarget.OutputLibraryPath)')"
-        DestinationFiles="@(_LibZipTarget->'$(OutputPath)\lib\xbuild\Xamarin\Android\%(_LibZipTarget.OutputLibrary)')"/>
+    <Copy
+        SourceFiles="@(_LibZipTarget->'$(IntermediateOutputPath)\%(Identity)\%(OutputLibraryPath)')"
+        DestinationFiles="@(_LibZipTarget->'$(OutputPath)\lib\xbuild\Xamarin\Android\%(OutputLibrary)')"
+    />
     <Touch Files="@(Content)" />
   </Target>
   <Target Name="GetLibZipBundleItems">
@@ -75,11 +63,18 @@
       DependsOnTargets="_SetCMakeListsTxtTimeToLastCommitTimestamp;GetLibZipBundleItems"
       Inputs="$(LibZipSourceFullPath)\CMakeLists.txt"
       Outputs="@(BundleItem)">
-    <CallTarget Targets="ForceBuild" />
+    <PropertyGroup>
+      <_Now>$([System.DateTime]::Now.Ticks)</_Now>
+    </PropertyGroup>
+    <MSBuild
+        Projects="$(MSBuildThisFileDirectory)\libzip.mdproj"
+        Properties="_ForceXbuildToNotCacheTargets=$(_Now)"
+        Targets="ForceBuild"
+    />
   </Target>
   <Target Name="_CleanBinaries"
       AfterTargets="Clean">
     <RemoveDir Directories="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)" />
-    <Delete Files="@(_LibZipTarget->'$(OutputPath)\lib\xbuild\Xamarin\Android\%(_LibZipTarget.OutputLibrary)')" />
+    <Delete Files="@(_LibZipTarget->'$(OutputPath)\lib\xbuild\Xamarin\Android\%(OutputLibrary)')" />
   </Target>
 </Project>

--- a/build-tools/mono-runtimes/mono-runtimes.mdproj
+++ b/build-tools/mono-runtimes/mono-runtimes.mdproj
@@ -6,6 +6,19 @@
     <ItemType>GenericProject</ItemType>
     <ProjectGuid>{C03E6CF1-7460-4CDC-A4AB-292BBC0F61F2}</ProjectGuid>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <OutputPath>..\..\bin\Debug</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <OutputPath>..\..\bin\Release</OutputPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
+  <PropertyGroup>
+    <BuildDependsOn>
+      ResolveReferences;
+      _BuildUnlessCached
+    </BuildDependsOn>
+  </PropertyGroup>
   <Import Project="mono-runtimes.targets" />
   <ItemGroup>
     <ProjectReference Include="..\xa-prep-tasks\xa-prep-tasks.csproj">

--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -1,19 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>..\..\bin\Debug</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>..\..\bin\Release</OutputPath>
-  </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
-  <PropertyGroup>
-    <BuildDepends>
-      ResolveReferences;
-      _BuildUnlessCached
-    </BuildDepends>
-  </PropertyGroup>
-  <Target Name="Build" DependsOnTargets="$(BuildDepends)" />
+  <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
   <PropertyGroup>
     <_SourceTopDir>..\..</_SourceTopDir>
     <_BclFrameworkDir>$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0</_BclFrameworkDir>
@@ -465,7 +452,14 @@
       DependsOnTargets="_SetAutogenShTimeToLastCommitTimestamp;GetMonoBundleItems"
       Inputs="$(MonoSourceFullPath)\autogen.sh;$(LlvmSourceFullPath)\Makefile.config.in"
       Outputs="@(BundleItem)">
-    <CallTarget Targets="ForceBuild" />
+    <PropertyGroup>
+      <_Now>$([System.DateTime]::Now.Ticks)</_Now>
+    </PropertyGroup>
+    <MSBuild
+        Projects="$(MSBuildThisFileDirectory)\mono-runtimes.mdproj"
+        Properties="_ForceXbuildToNotCacheTargets=$(_Now)"
+        Targets="ForceBuild"
+    />
   </Target>
   <Target Name="_CleanRuntimes"
       AfterTargets="Clean">


### PR DESCRIPTION
Using the mono bundle (29568117, 57b18c27, ffe39776) didn't work as
well as intended, because *using* the mono bundle requires that the
bundle (1) *exist*, and (2) contain expected outputs.

Neither of which is true:

	$ curl -o x.zip https://xamjenkinsartifact.blob.core.windows.net/xamarin-android/xamarin-android/bin/BuildDebug/bundle-v3-Debug-Darwin-libzip=1d8b1ac,llvm=8b1520c,mono=2c13a95.zip
	$ file x.zip
	x.zip: XML document text
	$ cat x.zip
	<?xml version="1.0" encoding="utf-8"?>
	<Error>
	  <Code>BlobNotFound</Code>
	  <Message>The specified blob does not exist.
	RequestId:f1722d1f-0001-0098-3fdd-fe4670000000
	Time:2016-08-25T14:31:09.4102289Z
	  </Message>
	</Error>

That is, the URL "exists", but it doesn't contain anything *useful*.

The bundle doesn't exist, in turn, because [*it isn't created*][0]:

	Project "/Users/builder/jenkins/workspace/xamarin-android/xamarin-android/build-tools/bundle/bundle.mdproj" (default target(s)):
	...
	Done building project "/Users/builder/jenkins/workspace/xamarin-android/xamarin-android/build-tools/bundle/bundle.mdproj".

What's *missing* from the log file is any mention of the
`CreateBundle` target, which *creates the bundle*. Since the
`CreateBundle` target isn't invoked, *there is no bundle*, and thus
there's *nothing to upload*, and thus there's *nothing to download*,
either.

Why isn't the `CreateBundle` target executed? Because of property
group "overwrites". But first, a step back.

Remember 57b18c27?

> I *assume* that this is due to `<CallTarget/>` being "flakey" within
> xbuild (it passes the file containing the target to `<MSBuild/>`!),
> and *somehow* in that "flakiness" `$(OutputPath)` doesn't end with
> `\`, *which it should*, because `Microsoft.Common.targets` will
> automatically append `\` to `$(OutputPath)`.

Let's elaborate on the "flakiness" of xbuild: The `<CallTarget/>` task
doesn't *just* invoke the specified target. Rather, xbuild will
*reload the file containing the target*, "stand-alone", and execute
the target. It's "as if" `<CallTarget/>` were implemented as:

	<MSBuild
	    Projects="*File-Containing-The-Target-To-Invoke*"
	    Targets="...Targets..."
	/>

Therein lies the problem: by convention, ~everything is using the
`$(BuildDependsOn)` property, and 29568117 altered
`mono-runtimes.targets` so that `$(BuildDependsOn)` would be
explicitly specified, but `mono-runtimes.targets` is `<Import/>`ed by
`bundle.targets`, thus *replacing* the *intended* definition of
`$(BuildDependsOn)` from `bundle.mdproj`.

Thus, `$(BuildDependsOn)` *didn't* include the `CreateBundle` target,
so the `CreateBundle` target was never executed, thus
*no bundle was created or uploaded*.

Doh!

The fix? Remove all use of `<CallTarget/>`. `<CallTarget/>` is a BUG.
Instead, *always* use `<MSBuild/>`, which allows specifying the
correct project file to build from (the `.mdproj`, in our case), so
that the correct "deferred" `ForceBuild` target can be invoked.

Unfortunately, [using the `<MSBuild/> task raised *another* issue][1]:

> this task uses the same MSBuild process to build the child projects.
> The list of already-built targets that can be skipped is shared
> between the parent and child builds.

This means that the
[child build *skips* running the `_GetRuntimesOutputItems` target][2],
which means that *everything breaks* because nothing is built, because
there are no `Inputs` or `Outputs` for anything.

	Target _BuildRuntimes:
	No input files were specified for target _BuildRuntimes, skipping.
	Done building target "_BuildRuntimes" in project "/Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/build-tools/mono-runtimes/mono-runtimes.mdproj".

We work around this issue by providing a
`$(_ForceXbuildToNotCacheTargets)` property to the `<MSBuild/>` task
with the value of `DateTime.Now.Ticks`, i.e. a ~constantly changing
value, which should *prevent* the target skipping. (We hope.)

*Additionally*, `msbuild` reported a few errors when referencing
`%(_LibZipTarget.OutputLibraryPath)` item metadata, so fix those
references.

Finally, another aspect of `<MSBuild/>` behavior arose:

The [`MSBuild.Properties`][1] parameter is equivalent to the
`msbuild /p:` parameter, which in turn means that the *value* is
*immutable*; it *can't* be changed (or fixed!) from `.targets` files.

The result being that `<MSBuild/>` use in
`android-toolchain.targets` is *fraught with peril*:

	<MSBuild
	    Projects="..\..\src\Xamarin.Android.Tools.BootstrapTasks\Xamarin.Android.Tools.BootstrapTasks.csproj"
	    Properties="OutputPath=$(AndroidToolchainDirectory)"
	/>

This *looks* reasonable, but `$(OutputPath)` is expected to end with
the directory separator char, and `Microsoft.Common.targets` *tries*
to ensure this:

	<OutputPath Condition="'$(OutputPath)' != '' and !HasTrailingSlash('$(OutputPath)')">$(OutputPath)\</OutputPath>

However, since `MSBuild.Properties` values are *immutable*, this
attempt to modify the `$(OutputPath)` property to end with a `\` has
*no effect*, which results in *bizarre* errors later:

	error MSB4062: The "Xamarin.Android.BuildTools.PrepTasks.DownloadUri" task
	could not be loaded from the assembly $HOME/android-toolchainxa-prep-tasks.dll.

Note the path, `$HOME/android-toolchainxa-prep-tasks.dll`. The path
*should* be `$HOME/android-toolchain/xa-prep-tasks.dll`. What's
missing is...the directory separator char after `$(OutputPath)`.

The fix? Explicitly provide the directory separator character in the
`<MSBuild/>` invocation:

	<MSBuild
	    Projects="..\..\src\Xamarin.Android.Tools.BootstrapTasks\Xamarin.Android.Tools.BootstrapTasks.csproj"
	    Properties="OutputPath=$(AndroidToolchainDirectory)\"
	/>

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/51/consoleText
[1]: https://msdn.microsoft.com/en-us/library/z7f65y0d.aspx
[2]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-pr-builder/131/consoleText