### PR TITLE
[bundle] Bundle Consts.cs

### DIFF
--- a/build-tools/bundle/bundle-path.targets
+++ b/build-tools/bundle/bundle-path.targets
@@ -24,7 +24,7 @@
   <Target Name="GetBundleFileName"
       DependsOnTargets="_GetHashes">
     <PropertyGroup>
-      <XABundleFileName>bundle-v3-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
+      <XABundleFileName>bundle-v4-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
     </PropertyGroup>
   </Target>
 </Project>

--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -437,6 +437,7 @@
       <BundleItem Include="@(_InstallMonoPosixHelperOutput)" />
       <BundleItem Include="@(_InstallUnstrippedMonoPosixHelperOutput)" />
       <BundleItem Include="@(_RuntimeEglibHeaderOutput)" />
+      <BundleItem Include="@(_MonoConstsOutput)" />
       <BundleItem Include="@(_LlvmTargetBinary)" />
       <BundleItem Include="$(OutputPath)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
           Condition=" '@(_MonoCrossRuntime)' != '' "


### PR DESCRIPTION
Commit 29568117 inadvertently stopped bundling `include/Consts.cs`,
which is causing a [build break][0]:

	CSC: error CS2001: Source file
	`../../bin/Debug/lib/xbuild-frameworks/MonoAndroid/v1.0/../../../../include/Consts.cs'
	could not be found

Fix the `GetMonoBundleItems` target to include `Consts.cs`, and bump
the bundle version within `GetBundleFileName` so that a new bundle is
created and uploaded.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/78/