### PR TITLE
fix preserve attributes in the linker

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/ApplyPreserveAttribute.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/ApplyPreserveAttribute.cs
@@ -18,8 +18,6 @@ namespace MonoDroid.Tuner {
 		public override bool IsActiveFor (AssemblyDefinition assembly)
 		{
 			is_sdk = Profile.IsSdkAssembly (assembly);
-			if (is_sdk && assembly.Name.Name != "System.ServiceModel")
-				return false;
 			return Annotations.GetAction (assembly) == AssemblyAction.Link;
 		}
 		

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
@@ -78,6 +78,8 @@ namespace MonoDroid.Tuner
 			// monodroid tuner steps
 			pipeline.AppendStep (new SubStepDispatcher {
 				new ApplyPreserveAttribute (),
+			});
+			pipeline.AppendStep (new SubStepDispatcher {
 				new PreserveExportedTypes (),
 				new RemoveSecurity (),
 				new MarkJavaObjects (),


### PR DESCRIPTION
 - fixes #37491

 - we need to isolate apply preserve attributes substep from preserve
   runtime serialization substep, because substeps are run together
   (unlike linker steps). so we can endup applying incomplete
   DataContract and XmlSerialization lists in the preserve runtime
   serialization substep

 - do not limit apply preserve attributes to System.ServiceModel, we
   need the lists for all sdk assemblies