### PR TITLE
switch to facebook proguard

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,3 +29,6 @@
 	path = external/llvm
 	url = https://github.com/mono/llvm.git
 	branch = master
+[submodule "external/proguard"]
+	path = external/proguard
+	url = https://github.com/facebook/proguard.git

--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -91,6 +91,8 @@ Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "bundle", "build-tools\bundl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xa-prep-tasks", "build-tools\xa-prep-tasks\xa-prep-tasks.csproj", "{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}"
 EndProject
+Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "proguard", "build-tools\proguard\proguard.mdproj", "{4B9D96BB-95AB-44E8-9F87-13B12C8BCED1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|AnyCPU = Debug|AnyCPU
@@ -417,6 +419,14 @@ Global
 		{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}.XAIntegrationDebug|AnyCPU.Build.0 = Debug|Any CPU
 		{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}.XAIntegrationRelease|AnyCPU.ActiveCfg = Debug|Any CPU
 		{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}.XAIntegrationRelease|AnyCPU.Build.0 = Debug|Any CPU
+		{4B9D96BB-95AB-44E8-9F87-13B12C8BCED1}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{4B9D96BB-95AB-44E8-9F87-13B12C8BCED1}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{4B9D96BB-95AB-44E8-9F87-13B12C8BCED1}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{4B9D96BB-95AB-44E8-9F87-13B12C8BCED1}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{4B9D96BB-95AB-44E8-9F87-13B12C8BCED1}.XAIntegrationDebug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{4B9D96BB-95AB-44E8-9F87-13B12C8BCED1}.XAIntegrationDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4B9D96BB-95AB-44E8-9F87-13B12C8BCED1}.XAIntegrationRelease|AnyCPU.ActiveCfg = Release|Any CPU
+		{4B9D96BB-95AB-44E8-9F87-13B12C8BCED1}.XAIntegrationRelease|Any CPU.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
@@ -460,6 +470,7 @@ Global
 		{0DE278D6-000F-4001-BB98-187C0AF58A61} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 		{1640725C-4DB8-4D8D-BC96-74E688A06EEF} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 		{7CE69551-BD73-4726-ACAA-AAF89C84BAF8} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
+		{4B9D96BB-95AB-44E8-9F87-13B12C8BCED1} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/build-tools/proguard/proguard.mdproj
+++ b/build-tools/proguard/proguard.mdproj
@@ -7,6 +7,10 @@
     <ProjectGuid>{4B9D96BB-95AB-44E8-9F87-13B12C8BCED1}</ProjectGuid>
     <OutputPath>..\..\bin\$(Configuration)</OutputPath>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+  </PropertyGroup>
 
   <Import Project="proguard.targets" />
 </Project>

--- a/build-tools/proguard/proguard.mdproj
+++ b/build-tools/proguard/proguard.mdproj
@@ -1,0 +1,12 @@
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ItemType>GenericProject</ItemType>
+    <ProjectGuid>{4B9D96BB-95AB-44E8-9F87-13B12C8BCED1}</ProjectGuid>
+    <OutputPath>..\..\bin\$(Configuration)</OutputPath>
+  </PropertyGroup>
+
+  <Import Project="proguard.targets" />
+</Project>

--- a/build-tools/proguard/proguard.targets
+++ b/build-tools/proguard/proguard.targets
@@ -1,0 +1,23 @@
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="..\..\Configuration.props" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
+
+  <Target Name="Build">
+    <Exec Command="ant -f ..\..\external\proguard\buildscripts\build.xml proguard" />
+    <Copy
+	SourceFiles="..\..\external\proguard\lib\proguard.jar"
+	DestinationFiles="$(OutputPath)\lib\mandroid\proguard.jar"
+	 />
+    <Copy
+	SourceFiles="..\..\external\proguard\LICENSE"
+	DestinationFiles="$(OutputPath)\lib\mandroid\PROGUARD_JAR_LICENSE.txt"
+	 />
+  </Target>
+  <Target Name="Clean">
+    <Delete Files="$(OutputPath)\lib\mandroid\PROGUARD_JAR_LICENSE.txt" />
+    <Delete Files="$(OutputPath)\lib\mandroid\proguard.jar" />
+    <Exec Command="ant -f ..\..\external\proguard\buildscripts\build.xml clean" />
+  </Target>
+</Project>
+

--- a/build-tools/proguard/proguard.targets
+++ b/build-tools/proguard/proguard.targets
@@ -7,16 +7,26 @@
     <Exec Command="ant -f ..\..\external\proguard\buildscripts\build.xml proguard" />
     <Copy
 	SourceFiles="..\..\external\proguard\lib\proguard.jar"
-	DestinationFiles="$(OutputPath)\lib\mandroid\proguard.jar"
+	DestinationFiles="$(OutputPath)\lib\mandroid\proguard\lib\proguard.jar"
+	 />
+    <Copy
+	SourceFiles="..\..\external\proguard\bin\proguard.bat"
+	DestinationFiles="$(OutputPath)\lib\mandroid\proguard\bin\proguard.bat"
+	 />
+    <Copy
+	SourceFiles="..\..\external\proguard\bin\proguard.sh"
+	DestinationFiles="$(OutputPath)\lib\mandroid\proguard\bin\proguard.sh"
 	 />
     <Copy
 	SourceFiles="..\..\external\proguard\LICENSE"
-	DestinationFiles="$(OutputPath)\lib\mandroid\PROGUARD_JAR_LICENSE.txt"
+	DestinationFiles="$(OutputPath)\lib\mandroid\proguard\PROGUARD_LICENSE.txt"
 	 />
   </Target>
   <Target Name="Clean">
-    <Delete Files="$(OutputPath)\lib\mandroid\PROGUARD_JAR_LICENSE.txt" />
-    <Delete Files="$(OutputPath)\lib\mandroid\proguard.jar" />
+    <Delete Files="$(OutputPath)\lib\mandroid\proguard\PROGUARD_LICENSE.txt" />
+    <Delete Files="$(OutputPath)\lib\mandroid\proguard\lib\proguard.jar" />
+    <Delete Files="$(OutputPath)\lib\mandroid\proguard\bin\proguard.sh" />
+    <Delete Files="$(OutputPath)\lib\mandroid\proguard\bin\proguard.bat" />
     <Exec Command="ant -f ..\..\external\proguard\buildscripts\build.xml clean" />
   </Target>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
@@ -18,6 +18,9 @@ namespace Xamarin.Android.Tasks
 		public string ClassesOutputDirectory { get; set; }
 
 		[Required]
+		public string ProguardHome { get; set; }
+
+		[Required]
 		public ITaskItem[] JavaLibraries { get; set; }
 		
 		public string MultiDexMainDexListFile { get; set; }
@@ -32,6 +35,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugTaskItems ("  CustomMainDexListFiles:", CustomMainDexListFiles);
 			Log.LogDebugMessage ("  ToolExe: {0}", ToolExe);
 			Log.LogDebugMessage ("  ToolPath: {0}", ToolPath);
+			Log.LogDebugMessage ("  ProguardHome: {0}", ProguardHome);
 			
 			if (CustomMainDexListFiles != null && CustomMainDexListFiles.Any ()) {
 				var content = string.Concat (CustomMainDexListFiles.Select (i => File.ReadAllText (i.ItemSpec)));
@@ -70,13 +74,15 @@ namespace Xamarin.Android.Tasks
 			return Path.Combine (ToolPath, ToolExe);
 		}
 
-		// Windows seems to need special care.
 		protected override StringDictionary EnvironmentOverride {
 			get {
 				var sd = base.EnvironmentOverride ?? new StringDictionary ();
+				// Windows seems to need special care.
 				var opts = sd.ContainsKey ("JAVA_TOOL_OPTIONS") ? sd ["JAVA_TOOL_OPTIONS"] : null;
 				opts += " -Dfile.encoding=UTF8";
 				sd ["JAVA_TOOL_OPTIONS"] = opts;
+
+				sd ["PROGUARD_HOME"] = ProguardHome;
 				return sd;
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Jack.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Jack.cs
@@ -21,6 +21,9 @@ namespace Xamarin.Android.Tasks
 		public string JavaPlatformJackPath { get; set; }
 
 		[Required]
+		public string AndroidSdkDirectory { get; set; }
+
+		[Required]
 		public string [] InputJackFiles { get; set; }
 
 		[Required]
@@ -112,7 +115,7 @@ namespace Xamarin.Android.Tasks
 					// skip invalid lines
 				}
 				var configs = ProguardConfigurationFiles
-					.Replace ("{sdk.dir}", Path.GetDirectoryName (Path.GetDirectoryName (ProguardJarPath)) + Path.DirectorySeparatorChar)
+					.Replace ("{sdk.dir}", AndroidSdkDirectory + Path.DirectorySeparatorChar)
 					.Replace ("{intermediate.common.xamarin}", ProguardCommonXamarinConfiguration)
 					.Replace ("{intermediate.references}", ProguardGeneratedReferenceConfiguration)
 					.Replace ("{intermediate.application}", ProguardGeneratedApplicationConfiguration)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
@@ -186,6 +186,9 @@ namespace Xamarin.Android.Tasks
 				cmd.AppendSwitchIfNotNull ("-printusage ", PrintUsageOutput);
 				cmd.AppendSwitchIfNotNull ("-printmapping ", PrintMappingOutput);
 			}
+
+			// http://stackoverflow.com/questions/5701126/compile-with-proguard-gives-exception-local-variable-type-mismatch#7587680
+			cmd.AppendSwitch ("-optimizations !code/allocation/variable");
 			
 			return cmd.ToString ();
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
@@ -28,6 +28,9 @@ namespace Xamarin.Android.Tasks
 		public string JavaPlatformJarPath { get; set; }
 
 		[Required]
+		public string AndroidSdkDirectory { get; set; }
+
+		[Required]
 		public string ClassesOutputDirectory { get; set; }
 
 		[Required]
@@ -79,6 +82,7 @@ namespace Xamarin.Android.Tasks
 		public override bool Execute ()
 		{
 			Log.LogDebugMessage ("Proguard");
+			Log.LogDebugMessage ("  AndroidSdkDirectory: {0}", AndroidSdkDirectory);
 			Log.LogDebugMessage ("  JavaPlatformJarPath: {0}", JavaPlatformJarPath);
 			Log.LogDebugMessage ("  ClassesOutputDirectory: {0}", ClassesOutputDirectory);
 			Log.LogDebugMessage ("  AcwMapFile: {0}", AcwMapFile);
@@ -150,7 +154,7 @@ namespace Xamarin.Android.Tasks
 				GetType ().Assembly.GetManifestResourceStream ("proguard_xamarin.cfg").CopyTo (xamcfg);
 			
 			var configs = ProguardConfigurationFiles
-				.Replace ("{sdk.dir}", Path.GetDirectoryName (Path.GetDirectoryName (ProguardHome)) + Path.DirectorySeparatorChar)
+				.Replace ("{sdk.dir}", AndroidSdkDirectory + Path.DirectorySeparatorChar)
 				.Replace ("{intermediate.common.xamarin}", ProguardCommonXamarinConfiguration)
 				.Replace ("{intermediate.references}", ProguardGeneratedReferenceConfiguration)
 				.Replace ("{intermediate.application}", ProguardGeneratedApplicationConfiguration)

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -733,7 +733,7 @@ because xbuild doesn't support framework reference assemblies.
 		/>
 	</CreateProperty>
 
-	<CreateProperty Value="$(AndroidSdkDirectory)\tools\proguard\lib\proguard.jar">
+	<CreateProperty Value="$(MonoAndroidToolsDirectory)\proguard.jar">
 		<Output TaskParameter="Value" PropertyName="ProguardJarPath"
 				Condition="'$(ProguardJarPath)' == ''"
 		/>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -733,12 +733,12 @@ because xbuild doesn't support framework reference assemblies.
 		/>
 	</CreateProperty>
 
-	<CreateProperty Value="$(MonoAndroidToolsDirectory)\proguard.jar">
+	<CreateProperty Value="$(MonoAndroidToolsDirectory)\proguard\lib\proguard.jar">
 		<Output TaskParameter="Value" PropertyName="ProguardJarPath"
 				Condition="'$(ProguardJarPath)' == ''"
 		/>
 	</CreateProperty>
-	<CreateProperty Value="$(AndroidSdkDirectory)\tools\proguard\">
+	<CreateProperty Value="$(MonoAndroidToolsDirectory)\proguard\">
 		<Output TaskParameter="Value" PropertyName="ProguardToolPath"
 				Condition="'$(UseProguard)' == 'True' And '$(ProguardToolPath)' == ''"
 		/>
@@ -1872,6 +1872,7 @@ because xbuild doesn't support framework reference assemblies.
     StubSourceDirectory="$(IntermediateOutputPath)android\src"
     JavaSourceFiles="@(AndroidJavaSource)"
     JavaPlatformJackPath="$(_JavaPlatformJackPath)"
+    AndroidSdkDirectory="$(_AndroidSdkDirectory)"
     InputJackFiles="@(_PreprocessedJavaLibrary)"
     OutputDexDirectory="$(IntermediateOutputPath)android\bin"
     ToolPath="$(JavaToolPath)"
@@ -2010,6 +2011,7 @@ because xbuild doesn't support framework reference assemblies.
   <Proguard
     Condition="'$(AndroidEnableProguard)' == 'True' and '$(_ProguardProjectConfiguration)' != ''"
     ProguardJarPath="$(ProguardJarPath)"
+    AndroidSdkDirectory="$(_AndroidSdkDirectory)"
     JavaToolPath="$(JavaToolPath)"
     ToolPath="$(ProguardToolPath)"
     ToolExe="$(ProguardToolExe)"
@@ -2037,6 +2039,7 @@ because xbuild doesn't support framework reference assemblies.
     Condition="'$(AndroidEnableMultiDex)' == 'True' And '$(AndroidCustomMainDexListFile)' == ''"
     ToolPath="$(MainDexClassesToolPath)"
     ToolExe="$(MainDexClassesToolExe)"
+    ProguardHome="$(ProguardToolPath)"
     ClassesOutputDirectory="$(IntermediateOutputPath)android\bin\classes"
     JavaLibraries="@(_JavaLibrariesToCompile)"
     MultiDexMainDexListFile="$(_AndroidMainDexListFile)"


### PR DESCRIPTION
- it is based on proguard 5.2.1 which should be able to process Java8 bytecode.
- facebook proguard is reportedly 20%~ faster.

----

Note that this will result in distributing proguard.jar within our product that you'd like to discuss whether to go or not.