### PR TITLE
[Xamarin.Android.Build.Tasks] [VS]Getting build error on Android F# app when using 'Array.take'.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -60,6 +60,9 @@
     <Reference Include="FSharp.Compiler.CodeDom">
       <HintPath>..\..\packages\FSharp.Compiler.CodeDom.1.0.0.1\lib\net40\FSharp.Compiler.CodeDom.dll</HintPath>
     </Reference>
+    <Reference Include="FSharp.Core">
+      <HintPath>..\..\packages\FSharp.Core.4.0.1.5\lib\net40\FSharp.Core.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(IntermediateOutputPath)Profile.g.cs" />

--- a/src/Xamarin.Android.Build.Tasks/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/packages.config
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FSharp.Compiler.CodeDom" version="0.9.4" targetFramework="net45" />
   <package id="FSharp.Compiler.CodeDom" version="1.0.0.1" targetFramework="net45" />
+  <package id="FSharp.Core" version="4.0.1.5" targetFramework="net45" />
   <package id="Irony" version="0.9.1" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net45" />
-  <package id="FSharp.Core" version="3.1.2.5" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=43915

The version of F# we shipped was too old and did not support
some of the newer features the users/testers were trying to use.
This commit updates F# to the latest stable version to fix those
issues.