### PR TITLE
[Xamarin.Android.Build.Tasks]  [VS]Getting build error on Android F# app when using 'Array.take'.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -26,6 +26,9 @@
       BeforeTargets="CoreCompile"
       Inputs="@(_SharedRuntimeAssemblies)"
       Outputs="$(_GeneratedProfileClass)">
+    <ItemGroup>
+      <_SharedRuntimeAssemblies Remove="$(_SharedRuntimeBuildPath)v1.0\FSharp.Core.dll" />
+    </ItemGroup>
     <GenerateProfile Files="@(_SharedRuntimeAssemblies)" OutputFile="$(_GeneratedProfileClass)" />
     <WriteLinesToFile
         File="$(IntermediateOutputPath)$(CleanFile)"


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=43915

FSharp.Core was considered a "framework" assembly. As a result
even if the user referenced the latest nuget package the
build system would use the framework assembly.

This commit removes FSharp.Core from the list of framework
assemblies. This allows users to use the latest FSharp.Core
nuget without it being replaced.