### PR TITLE
[Xamarin.Android.Build.Tasks] Create the mSYM directory before we try to add the files

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2270,6 +2270,7 @@ because xbuild doesn't support framework reference assemblies.
 
   <Copy SourceFiles="%(ApkFiles.FullPath)" DestinationFolder="$(OutDir)" />
 
+  <MakeDir Directories="&quot;$(OutDir)$(_AndroidPackage).apk.mSYM&quot;" Condition=" '$(AndroidManagedSymbols)' == 'True' " />
   <Exec
     Command="&quot;$(_MonoAndroidBinDirectory)mono-symbolicate&quot; store-symbols &quot;$(OutDir)$(_AndroidPackage).apk.mSYM&quot; &quot;$(MonoAndroidIntermediate)android/assets&quot;"
     Condition=" '$(AndroidManagedSymbols)' == 'True' "


### PR DESCRIPTION
The old way MSBuild used to handle creating the directory for us when
we copied the files over. mono-symbolicate does NOT, it expects
the directory to already exist. So we need to create it.