### PR TITLE
[Xamarin.Android.Build.Tasks] Make sure the cross-*.exe does not show a window when executed.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -378,6 +378,8 @@ namespace Xamarin.Android.Tasks
 				UseShellExecute = false,
 				RedirectStandardOutput = true,
 				RedirectStandardError = true,
+				CreateNoWindow=true,
+				WindowStyle=ProcessWindowStyle.Hidden,
 			};
 			
 			// we do not want options to be provided out of band to the cross compilers


### PR DESCRIPTION
Under Visual Studio when invoking the cross-*.exe's it seems to
create a new window. This commit updates the ProcessStartInfo
to make sure that we hide the window.