### PR TITLE
Fix build on Linux

### DIFF
--- a/build-tools/libzip/libzip.mdproj
+++ b/build-tools/libzip/libzip.mdproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
   <PropertyGroup>
+    <BuildDependsOn/>
     <BuildDependsOn Condition="'$(HostOS)' == 'Windows' OR '$(HostOS)' == 'Darwin'">
       ResolveReferences;
       _BuildUnlessCached


### PR DESCRIPTION
On Linux the BuildDependsOn target would be undefined and
that causes xbuild to fail in many horrible ways.