### PR TITLE
update the error message to give more info about the unresolved ref

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
@@ -155,7 +155,7 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 			} catch (ResolutionException ex) {
-				Diagnostic.Error (2006, ex, "Reference to metadata item '{0}' (defined in '{1}') from '{1}' could not be resolved.", ex.Member, ex.Member.Module.Assembly, ex.Scope);
+				Diagnostic.Error (2006, ex, "Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.", ex.Member, ex.Member.Module.Assembly, ex.Scope);
 			}
 
 			return true;


### PR DESCRIPTION
 - fixes #43515

 - the message was missing the scope information (a typo?) and was a
   bit misleading. hopefully it will make more sense now

 - added note about forwarded types, as it is reached in scenarios
   like this:

     an app references an assembly lib1 containing type forwarder to
     type in another assembly lib2. when this other assembly lib2
     doesn't contain the type and the app doesn't reference that type
     directly, but only thru code in lib1, the compiler doesn't detect
     the type is missing. the linker OTOH will try to resolve the
     reference and the error is reached