### PR TITLE
Don't use Uri.EscapeUriString ()

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -190,7 +190,7 @@ namespace Xamarin.Android.Net
 				Method = request.Method
 			};
 			while (true) {
-				URL java_url = new URL (Uri.EscapeUriString (redirectState.NewUrl.ToString ()));
+				URL java_url = new URL (redirectState.NewUrl.OriginalString);
 				URLConnection java_connection = java_url.OpenConnection ();
 				HttpURLConnection httpConnection = await SetupRequestInternal (request, java_connection);
 				HttpResponseMessage response = await ProcessRequest (request, java_url, httpConnection, cancellationToken, redirectState);


### PR DESCRIPTION
The method encodes everything, including ampersands in the query
part of the URI. Instead follow advice given in

https://github.com/xamarin/xamarin-android/commit/3675c5c6a6a5b9f0c65106e7ab5b08358c5fc82a#commitcomment-19000414

and use .OriginalString to let the caller handle encoding.

Updates fix committed in 3675c5c6a6a5b9f0c65106e7ab5b08358c5fc82a
for https://bugzilla.xamarin.com/show_bug.cgi?id=43411