### PR TITLE
[bridge] Bump bridge version to 5 as it's what mono 4.8 uses.

### DIFF
--- a/src/monodroid/jni/dylib-mono.h
+++ b/src/monodroid/jni/dylib-mono.h
@@ -121,7 +121,7 @@ typedef uint8_t  mono_byte;
 #endif
 
 enum {
-	SGEN_BRIDGE_VERSION = 4
+	SGEN_BRIDGE_VERSION = 5
 };
 
 typedef enum {


### PR DESCRIPTION
Depends on  https://github.com/xamarin/monodroid/pull/499