### PR TITLE
Don't use Uri.EscapeUriString ()

### DIFF
--- a/src/Mono.Android/Test/Xamarin.Android.Net/HttpClientIntegrationTests.cs
+++ b/src/Mono.Android/Test/Xamarin.Android.Net/HttpClientIntegrationTests.cs
@@ -598,6 +598,36 @@ namespace Xamarin.Android.NetTests {
 				}
 			}
 		}
+
+		[Test]
+		void UrlEscaping_Bug43411 ()
+		{
+			UrlEscaping_TestUrl ($"http://{TestHost}/?example=value%20_value", "#1");
+			UrlEscaping_TestUrl ($"http://{TestHost}/?query=anna%20%26%20lotte&param2=true", "#2");
+		}
+
+		void UrlEscaping_TestUrl (string url, string messagePrefix)
+		{
+			bool? failed = null;
+
+			var listener = CreateListener (l => {
+				failed = true;
+			});
+
+			using (listener) {
+				try {
+					var client = new HttpClient ();
+					var request = new HttpRequestMessage (HttpMethod.Get, url);
+
+					client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead).Wait ();
+					Assert.AreEqual (url, request.RequestUri.ToString (), $"{messagePrefix}-1");
+					Assert.IsNull (failed, $"{messagePrefix}-2");
+				} finally {
+					listener.Abort ();
+					listener.Close ();
+				}
+			}
+		}
 #if TODO
 		[Test]
 		public void Send_Complete_Content ()

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -169,6 +169,23 @@ namespace Xamarin.Android.Net
 			throw new ObjectDisposedException (nameof (AndroidClientHandler));
 		}
 
+		string EncodeUrl (Uri url)
+		{
+			if (url == null)
+				return String.Empty;
+
+			if (String.IsNullOrEmpty (url.Query))
+				return Uri.EscapeUriString (url.ToString ());
+
+			// UriBuilder takes care of encoding everything properly
+			var bldr = new UriBuilder (url);
+			if (url.IsDefaultPort)
+				bldr.Port = -1; // Avoids adding :80 or :443 to the host name in the result
+
+			// bldr.Uri.ToString () would ruin the good job UriBuilder did
+			return bldr.ToString ();
+		}
+
 		/// <summary>
 		/// Creates, configures and processes an asynchronous request to the indicated resource.
 		/// </summary>
@@ -190,7 +207,7 @@ namespace Xamarin.Android.Net
 				Method = request.Method
 			};
 			while (true) {
-				URL java_url = new URL (Uri.EscapeUriString (redirectState.NewUrl.ToString ()));
+				URL java_url = new URL (EncodeUrl (redirectState.NewUrl));
 				URLConnection java_connection = java_url.OpenConnection ();
 				HttpURLConnection httpConnection = await SetupRequestInternal (request, java_connection);
 				HttpResponseMessage response = await ProcessRequest (request, java_url, httpConnection, cancellationToken, redirectState);


### PR DESCRIPTION
The method encodes all the reserved and unreserved characters
in the URI which includes ampersands (among others) in the
query part of the URI. Instead of this, use UriBuilder which
properly encodes the entire URL, paying attention to individually
encoding each query parameter.

Updates fix committed in 3675c5c6a6a5b9f0c65106e7ab5b08358c5fc82a
for https://bugzilla.xamarin.com/show_bug.cgi?id=43411