### PR TITLE
[Xamarin.Android.Build.Tasks] Remove Quotes from mono-symbolicate MakeDir call

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2270,7 +2270,7 @@ because xbuild doesn't support framework reference assemblies.
 
   <Copy SourceFiles="%(ApkFiles.FullPath)" DestinationFolder="$(OutDir)" />
 
-  <MakeDir Directories="&quot;$(OutDir)$(_AndroidPackage).apk.mSYM&quot;" Condition=" '$(AndroidManagedSymbols)' == 'True' " />
+  <MakeDir Directories="$(OutDir)$(_AndroidPackage).apk.mSYM" Condition=" '$(AndroidManagedSymbols)' == 'True' " />
   <Exec
     Command="&quot;$(_MonoAndroidBinDirectory)mono-symbolicate&quot; store-symbols &quot;$(OutDir)$(_AndroidPackage).apk.mSYM&quot; &quot;$(MonoAndroidIntermediate)android/assets&quot;"
     Condition=" '$(AndroidManagedSymbols)' == 'True' "


### PR DESCRIPTION
Turns out that the MSbuild task MakeDir handles quotes on
paths already. So there is no need to add them manually when
passing in a list of directories.

This also fixes the following error

	Unable to create directory ""bin\Release\App84.App84.apk.mSYM"". Illegal characters in path.