### PR TITLE
[jni] Refresh current domain after attaching thread to runtime when registering types.

### DIFF
--- a/src/monodroid/jni/monodroid-glue.c
+++ b/src/monodroid/jni/monodroid-glue.c
@@ -3989,6 +3989,8 @@ JNICALL Java_mono_android_Runtime_register (JNIEnv *env, jclass klass, jstring m
 	args [4] = &methods_len;
 
 	mono.mono_jit_thread_attach (domain);
+	// Refresh current domain as it might have been modified by the above call
+	domain = mono.mono_domain_get ();
 	monodroid_runtime_invoke (&mono, domain, registerType, NULL, args, NULL);
 
 	(*env)->ReleaseStringChars (env, managedType, managedType_ptr);


### PR DESCRIPTION
Change triggered by https://bugzilla.xamarin.com/show_bug.cgi?id=44448

It's possible for the register call to be called on a thread that hasn't been registered with Mono yet. As such, the `mono_domain_get` call will return NULL until `mono_jit_thread_attach` is invoked where domain information for the current thread becomes correct.

This is an issue because it means we invoke `monodroid_runtime_invoke` passing NULL as a bogus domain argument. This caused a crash with `mono_domain_set` as it doesn't support being passed a NULL domain.

This commit solves the problem by re-requesting the current domain after the `mono_jit_thread_attach` call. If the thread had been registered beforehand, this will essentially be a no-op as it should return the same domain again. If it hadn't, attaching the thread will have set the current domain to be the root appdomain which will be returned by `mono_domain_get` making our current domain variable now valid.