### PR TITLE
[libmonodroid] Add a debug.mono.gdbwait property.

### DIFF
--- a/src/monodroid/jni/monodroid-glue.c
+++ b/src/monodroid/jni/monodroid-glue.c
@@ -2223,6 +2223,8 @@ parse_gdb_options (void)
 	} else {
 		attach_gdb = TRUE;
 	}
+
+	free (val);
 }
 
 #if DEBUG


### PR DESCRIPTION
When this property is set, libmonodroid will wait in a loop for the native debugger to attach. The debugger can set a C variable to 0 to
break the wait after attaching. This is useful to support use cases where the debugger attaches to the process after it starts instead of
the debugger being started by libmonodroid.
The startup sequence should be:
* adb shell 'setprop debug.mono.gdbwait `date +%s`'
* adb shell 'am startup ...'
* <start debugger>
* <attach to process>
* p monodroid_gdb_wait=0