### PR TITLE
[Xamarin.Android.Build.Tasks] make sure `Disposable ()` is called for assembly

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveRegisterAttribute.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveRegisterAttribute.cs
@@ -24,13 +24,13 @@ namespace Xamarin.Android.Tasks
 
 			// Find Mono.Android.dll
 			var mono_android = ShrunkFrameworkAssemblies.First (f => Path.GetFileNameWithoutExtension (f.ItemSpec) == "Mono.Android").ItemSpec;
-			var assembly = AssemblyDefinition.ReadAssembly (mono_android);
+			using (var assembly = AssemblyDefinition.ReadAssembly (mono_android, new ReaderParameters { ReadWrite = true })) {
+				// Strip out [Register] attributes
+				foreach (TypeDefinition type in assembly.MainModule.Types)
+					ProcessType (type);
 
-			// Strip out [Register] attributes
-			foreach (TypeDefinition type in assembly.MainModule.Types)
-				ProcessType (type);
-
-			assembly.Write (mono_android);
+				assembly.Write ();
+			}
 			
 			return true;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/StripEmbeddedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/StripEmbeddedLibraries.cs
@@ -28,56 +28,57 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("StripEmbeddedLibraries Task");
 			Log.LogDebugTaskItems ("  Assemblies: ", Assemblies);
 
-			var res = new DirectoryAssemblyResolver (Log.LogWarning, true);
-			foreach (var assembly in Assemblies)
-				res.Load (Path.GetFullPath (assembly.ItemSpec));
+			using (var res = new DirectoryAssemblyResolver (Log.LogWarning, true)) {
+				foreach (var assembly in Assemblies)
+					res.Load (Path.GetFullPath (assembly.ItemSpec), new ReaderParameters { ReadWrite = true });
 
-			foreach (var assemblyName in Assemblies) {
-				var suffix = assemblyName.ItemSpec.EndsWith (".dll") ? String.Empty : ".dll";
-				string hintPath = assemblyName.GetMetadata ("HintPath").Replace (Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
-				string fileName = assemblyName.ItemSpec + suffix;
-				if (!String.IsNullOrEmpty (hintPath) && !File.Exists (hintPath)) // ignore invalid HintPath
-					hintPath = null;
-				string assemblyPath = String.IsNullOrEmpty (hintPath) ? fileName : hintPath;
-				if (MonoAndroidHelper.IsFrameworkAssembly (fileName) && !MonoAndroidHelper.FrameworkEmbeddedJarLookupTargets.Contains (Path.GetFileName (fileName)))
-					continue;
+				foreach (var assemblyName in Assemblies) {
+					var suffix = assemblyName.ItemSpec.EndsWith (".dll") ? String.Empty : ".dll";
+					string hintPath = assemblyName.GetMetadata ("HintPath").Replace (Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+					string fileName = assemblyName.ItemSpec + suffix;
+					if (!String.IsNullOrEmpty (hintPath) && !File.Exists (hintPath)) // ignore invalid HintPath
+						hintPath = null;
+					string assemblyPath = String.IsNullOrEmpty (hintPath) ? fileName : hintPath;
+					if (MonoAndroidHelper.IsFrameworkAssembly (fileName) && !MonoAndroidHelper.FrameworkEmbeddedJarLookupTargets.Contains (Path.GetFileName (fileName)))
+						continue;
 
-				var assembly = res.GetAssembly (assemblyPath);
-				bool assembly_modified = false;
-				foreach (var mod in assembly.Modules) {
-					// embedded jars
-					var resjars = mod.Resources.Where (r => r.Name.EndsWith (".jar", StringComparison.InvariantCultureIgnoreCase)).Select (r => (EmbeddedResource) r);
-					foreach (var resjar in resjars.ToArray ()) {
-						Log.LogDebugMessage ("    Stripped {0}", resjar.Name);
-						mod.Resources.Remove (resjar);
-						assembly_modified = true;
+					var assembly = res.GetAssembly (assemblyPath, new ReaderParameters { ReadWrite = true });
+					bool assembly_modified = false;
+					foreach (var mod in assembly.Modules) {
+						// embedded jars
+						var resjars = mod.Resources.Where (r => r.Name.EndsWith (".jar", StringComparison.InvariantCultureIgnoreCase)).Select (r => (EmbeddedResource) r);
+						foreach (var resjar in resjars.ToArray ()) {
+							Log.LogDebugMessage ("    Stripped {0}", resjar.Name);
+							mod.Resources.Remove (resjar);
+							assembly_modified = true;
+						}
+						// embedded AndroidNativeLibrary archive
+						var nativezip = mod.Resources.FirstOrDefault (r => r.Name == "__AndroidNativeLibraries__.zip") as EmbeddedResource;
+						if (nativezip != null) {
+							Log.LogDebugMessage ("    Stripped {0}", nativezip.Name);
+							mod.Resources.Remove (nativezip);
+							assembly_modified = true;
+						}
+						// embedded AndroidResourceLibrary archive
+						var reszip = mod.Resources.FirstOrDefault (r => r.Name == "__AndroidLibraryProjects__.zip") as EmbeddedResource;
+						if (reszip != null) {
+							Log.LogDebugMessage ("    Stripped {0}", reszip.Name);
+							mod.Resources.Remove (reszip);
+							assembly_modified = true;
+						}
 					}
-					// embedded AndroidNativeLibrary archive
-					var nativezip = mod.Resources.FirstOrDefault (r => r.Name == "__AndroidNativeLibraries__.zip") as EmbeddedResource;
-					if (nativezip != null) {
-						Log.LogDebugMessage ("    Stripped {0}", nativezip.Name);
-						mod.Resources.Remove (nativezip);
-						assembly_modified = true;
-					}
-					// embedded AndroidResourceLibrary archive
-					var reszip = mod.Resources.FirstOrDefault (r => r.Name == "__AndroidLibraryProjects__.zip") as EmbeddedResource;
-					if (reszip != null) {
-						Log.LogDebugMessage ("    Stripped {0}", reszip.Name);
-						mod.Resources.Remove (reszip);
-						assembly_modified = true;
-					}
-				}
-				if (assembly_modified) {
-					Log.LogDebugMessage ("    The stripped library is saved as {0}", assemblyPath);
+					if (assembly_modified) {
+						Log.LogDebugMessage ("    The stripped library is saved as {0}", assemblyPath);
 
-					// Output assembly needs to regenerate symbol file even if no IL/metadata was touched
-					// because Cecil still rewrites all assembly types in Cecil order (type A, nested types of A, type B, etc)
-					// and not in the original order causing symbols if original order doesn't match Cecil order
-					var wp = new WriterParameters () {
-						WriteSymbols = assembly.MainModule.HasSymbols
-					};
+						// Output assembly needs to regenerate symbol file even if no IL/metadata was touched
+						// because Cecil still rewrites all assembly types in Cecil order (type A, nested types of A, type B, etc)
+						// and not in the original order causing symbols if original order doesn't match Cecil order
+						var wp = new WriterParameters () {
+							WriteSymbols = assembly.MainModule.HasSymbols
+						};
 
-					assembly.Write (assemblyPath, wp);
+						assembly.Write (wp);
+					}
 				}
 			}
 			return true;


### PR DESCRIPTION
see https://github.com/jbevain/cecil/issues/291

This fixes the `Sharing violation` issue we've seen in the `RemoveRegisterAttribute` task. I also attempted to fix #44529.

Depends on https://github.com/xamarin/java.interop/pull/87, then this PR needs an update.