### PR TITLE
[Xamarin.Android.Build.Tasks] Dispose DirectoryAssemblyResolver instances

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckTargetFrameworks.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckTargetFrameworks.cs
@@ -23,9 +23,8 @@ namespace Xamarin.Android.Tasks
 		public string ProjectFile { get; set; } 
 
 		Dictionary<ITaskItem, int> apiLevels = new Dictionary<ITaskItem, int> ();
-		DirectoryAssemblyResolver res;
 
-		int ExtractApiLevel(ITaskItem ass)
+		int ExtractApiLevel(DirectoryAssemblyResolver res, ITaskItem ass)
 		{
 			Log.LogDebugMessage (ass.ItemSpec);
 			foreach (var ca in res.GetAssembly (ass.ItemSpec).CustomAttributes) {
@@ -51,13 +50,14 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  ProjectFile: {0}", ProjectFile);
 			Log.LogDebugTaskItems ("  ResolvedUserAssemblies: {0}", ResolvedAssemblies);
 
-			res = new DirectoryAssemblyResolver (Log.LogWarning, loadDebugSymbols: false);
-			foreach (var assembly in ResolvedAssemblies) {
-				res.Load (Path.GetFullPath (assembly.ItemSpec));
-				var apiLevel = ExtractApiLevel (assembly);
-				if (apiLevel > 0) {
-					Log.LogDebugMessage ("{0}={1}", Path.GetFileNameWithoutExtension (assembly.ItemSpec), apiLevel);
-					apiLevels.Add (assembly, apiLevel);
+			using (var res = new DirectoryAssemblyResolver (Log.LogWarning, loadDebugSymbols: false)) {
+				foreach (var assembly in ResolvedAssemblies) {
+					res.Load (Path.GetFullPath (assembly.ItemSpec));
+					var apiLevel = ExtractApiLevel (res, assembly);
+					if (apiLevel > 0) {
+						Log.LogDebugMessage ("{0}={1}", Path.GetFileNameWithoutExtension (assembly.ItemSpec), apiLevel);
+						apiLevels.Add (assembly, apiLevel);
+					}
 				}
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -79,7 +79,11 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  ApplicationJavaClass: {0}", ApplicationJavaClass);
 
 			try {
-				Run ();
+				// We're going to do 3 steps here instead of separate tasks so
+				// we can share the list of JLO TypeDefinitions between them
+				using (var res = new DirectoryAssemblyResolver (Log.LogWarning, loadDebugSymbols: true)) {
+					Run (res);
+				}
 			}
 			catch (XamarinAndroidException e) {
 				Log.LogCodedError (string.Format ("XA{0:0000}", e.Code), e.MessageWithoutCode);
@@ -90,17 +94,13 @@ namespace Xamarin.Android.Tasks
 			return !Log.HasLoggedErrors;
 		}
 
-		void Run ()
+		void Run (DirectoryAssemblyResolver res)
 		{
 			PackageNamingPolicy pnp;
 			JniType.PackageNamingPolicy = Enum.TryParse (PackageNamingPolicy, out pnp) ? pnp : PackageNamingPolicyEnum.LowercaseHash;
 			var temp = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
 			Directory.CreateDirectory (temp);
 
-			// We're going to do 3 steps here instead of separate tasks so
-			// we can share the list of JLO TypeDefinitions between them
-			var res = new DirectoryAssemblyResolver (Log.LogWarning, loadDebugSymbols:true);
-			
 			var selectedWhitelistAssemblies = new List<string> ();
 			
 			// Put every assembly we'll need in the resolver

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
@@ -363,28 +363,29 @@ namespace Xamarin.Android.Tasks {
 				? CachePath
 				: Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData), CacheBaseDir);
 
-				var resolver = new DirectoryAssemblyResolver (Log.LogWarning, loadDebugSymbols: false);
-				foreach (var assemblyItem in Assemblies) {
-					string fullPath = Path.GetFullPath (assemblyItem.ItemSpec);
-					if (assemblies.Contains (fullPath)) {
-						LogDebugMessage ("  Skip assembly: {0}, it was already processed", fullPath);
-						continue;
-					}
-					assemblies.Add (fullPath);
-					resolver.Load (fullPath);
-					// Append source file name (without the Xamarin. prefix or extension) to the base folder
-					// This would help avoid potential collisions.
-					foreach (var ca in resolver.GetAssembly (assemblyItem.ItemSpec).CustomAttributes) {
-						switch (ca.AttributeType.FullName) {
-						case "Android.IncludeAndroidResourcesFromAttribute":
-							AddAttributeValue (androidResources, ca, "XA5206", "{0}. Android resource directory {1} doesn't exist.", true, fullPath);
-							break;
-						case "Java.Interop.JavaLibraryReferenceAttribute":
-							AddAttributeValue (javaLibraries, ca, "XA5207", "{0}. Java library file {1} doesn't exist.", false, fullPath);
-							break;
-						case "Android.NativeLibraryReferenceAttribute":
-							AddAttributeValue (nativeLibraries, ca, "XA5210", "{0}. Native library file {1} doesn't exist.", false, fullPath);
-							break;
+				using (var resolver = new DirectoryAssemblyResolver (Log.LogWarning, loadDebugSymbols: false)) {
+					foreach (var assemblyItem in Assemblies) {
+						string fullPath = Path.GetFullPath (assemblyItem.ItemSpec);
+						if (assemblies.Contains (fullPath)) {
+							LogDebugMessage ("  Skip assembly: {0}, it was already processed", fullPath);
+							continue;
+						}
+						assemblies.Add (fullPath);
+						resolver.Load (fullPath);
+						// Append source file name (without the Xamarin. prefix or extension) to the base folder
+						// This would help avoid potential collisions.
+						foreach (var ca in resolver.GetAssembly (assemblyItem.ItemSpec).CustomAttributes) {
+							switch (ca.AttributeType.FullName) {
+							case "Android.IncludeAndroidResourcesFromAttribute":
+								AddAttributeValue (androidResources, ca, "XA5206", "{0}. Android resource directory {1} doesn't exist.", true, fullPath);
+								break;
+							case "Java.Interop.JavaLibraryReferenceAttribute":
+								AddAttributeValue (javaLibraries, ca, "XA5207", "{0}. Java library file {1} doesn't exist.", false, fullPath);
+								break;
+							case "Android.NativeLibraryReferenceAttribute":
+								AddAttributeValue (nativeLibraries, ca, "XA5210", "{0}. Native library file {1} doesn't exist.", false, fullPath);
+								break;
+							}
 						}
 					}
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
@@ -75,8 +75,16 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  DumpDependencies: {0}", DumpDependencies);
 			Log.LogDebugMessage ("  LinkOnlyNewerThan: {0}", LinkOnlyNewerThan);
 
-			var res = new DirectoryAssemblyResolver (Log.LogWarning, loadDebugSymbols: false);
-			
+			var rp = new ReaderParameters {
+				InMemory    = true,
+			};
+			using (var res = new DirectoryAssemblyResolver (Log.LogWarning, loadDebugSymbols: false, loadReaderParameters: rp)) {
+				return Execute (res);
+			}
+		}
+
+		bool Execute (DirectoryAssemblyResolver res)
+		{
 			// Put every assembly we'll need in the resolver
 			foreach (var assembly in ResolvedAssemblies) {
 				res.Load (Path.GetFullPath (assembly.ItemSpec));

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -71,7 +71,10 @@ namespace Xamarin.Android.Tasks
 			var resolvedResourceDirectories   = new List<string> ();
 			var resolvedAssetDirectories      = new List<string> ();
 			var resolvedEnvironmentFiles      = new List<string> ();
-			Extract (jars, resolvedResourceDirectories, resolvedAssetDirectories, resolvedEnvironmentFiles);
+
+			using (var resolver = new DirectoryAssemblyResolver (Log.LogWarning, loadDebugSymbols: false)) {
+				Extract (resolver, jars, resolvedResourceDirectories, resolvedAssetDirectories, resolvedEnvironmentFiles);
+			}
 
 			Jars                        = jars.ToArray ();
 			ResolvedResourceDirectories = resolvedResourceDirectories
@@ -133,6 +136,7 @@ namespace Xamarin.Android.Tasks
 
 		// Extracts library project contents under e.g. obj/Debug/[__library_projects__/*.jar | res/*/*]
 		void Extract (
+				DirectoryAssemblyResolver res,
 				ICollection<string> jars,
 				ICollection<string> resolvedResourceDirectories,
 				ICollection<string> resolvedAssetDirectories,
@@ -142,7 +146,6 @@ namespace Xamarin.Android.Tasks
 			if (!outdir.Exists)
 				outdir.Create ();
 
-			var res = new DirectoryAssemblyResolver (Log.LogWarning, loadDebugSymbols: false);
 			foreach (var assembly in Assemblies)
 				res.Load (assembly.ItemSpec);
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/StripEmbeddedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/StripEmbeddedLibraries.cs
@@ -28,7 +28,13 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("StripEmbeddedLibraries Task");
 			Log.LogDebugTaskItems ("  Assemblies: ", Assemblies);
 
-			var res = new DirectoryAssemblyResolver (Log.LogWarning, true);
+			using (var res = new DirectoryAssemblyResolver (Log.LogWarning, true)) {
+				return Execute (res);
+			}
+		}
+
+		bool Execute (DirectoryAssemblyResolver res)
+		{
 			foreach (var assembly in Assemblies)
 				res.Load (Path.GetFullPath (assembly.ItemSpec));
 


### PR DESCRIPTION
Supersedes: https://github.com/xamarin/xamarin-android/pull/231  
Requires: https://github.com/xamarin/java.interop/pull/88

Context: https://bugzilla.xamarin.com/show_bug.cgi?id=44529

Commit 1d658252 bumped to Cecil 0.10.0-beta1-v2 and
Java.Interop/a1d3ecc8, which likewise uses Cecil 0.10.0-beta1-v2.

Among the various API changes in Cecil 0.10.x vs. Cecil 0.9.x is a
change to `Mono.Cecil.IAssemblyResolver`, implemented by
`Java.Interop.Tools.Cecil.DirectoryAssemblyResolver`, to implement the
`IDisposable` interface.

Java.Interop/a1d3ecc8 added a `DirectoryAssemblyResolver.Dispose()`
method, but this method didn't *do* anything.

Cecil 0.10.0-beta1-v2 also has a *semantic* change vs. Cecil 0.9.x:
`AssemblyDefinition` is no longer a "purely in-memory" construct.
Instead, it holds a `System.IO.Stream` to the assembly it's reading
(unless `Mono.Cecil.ReaderParameters.InMemory` is `true`).

This semantic change means that an assembly can't be read from and
written to at the same time via different mechanisms, so long as there
is an `AssemblyDefinition` instance to that file.

Which brings us to (private) Bug #44529, in which an `IOException` is
thrown from the `<StripEmbeddedLibraries/>` task:

	Error executing task StripEmbeddedLibraries: System.IO.IOException: Sharing violation on path .../obj/Release/linksrc/Xamarin.Android.NUnitLite.dll
	  at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.Boolean anonymous, System.IO.FileOptions options) [0x0025f] in <253a3790b2c44512bbca8669ecfc1822>:0
	  at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share) [0x00000] in <253a3790b2c44512bbca8669ecfc1822>:0
	  at (wrapper remoting-invoke-with-check) System.IO.FileStream:.ctor (string,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare)
	  at Mono.Cecil.ModuleDefinition.GetFileStream (System.String fileName, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share) [0x00007] in :0
	  at Mono.Cecil.ModuleDefinition.Write (System.String fileName, Mono.Cecil.WriterParameters parameters) [0x00007] in :0
	  at Mono.Cecil.AssemblyDefinition.Write (System.String fileName, Mono.Cecil.WriterParameters parameters) [0x00001] in :0
	  at Xamarin.Android.Tasks.StripEmbeddedLibraries.Execute () [0x0034a] in <3d5202a5d4874a76a99388021bf1ab1a>:0

The underlying cause of the `IOException` is twofold:

1. `AssemblyDefinition` instances now hold a `FileStream` to the file
    they're reading from (and optionally writing to), and this
    `FileStream` will be kept open until
    `AssemblyDefinition.Dispose()` is called.

2. Nothing in `Xamarin.Android.Build.Tasks` calls
    `AssemblyDefinition.Dispose()`.

Nor should anything in `Xamarin.Android.Build.Tasks` call
`AssemblyDefinition.Dispose()`! (Almost) All `AssemblyDefinition`
instances are *cached* within `DirectoryAssemblyResolver` instances,
and nothing calls `DirectoryAssemblyResolver.Dispose()` either!
(Not that this matters *too* much, becuase
`DirectoryAssemblyResolver.Dispose()` is currently a no-op.)

There is no sane reasoning here: so long as we're using
`DirectoryAssemblyResolver`, we're going to have more files open
(compared to when Cecil 0.9.x was used), which can result in file
sharing problems and the above `IOException`.

The way foward is:

1. `Java.Interop.Tools.Cecil.DirectoryAssemblyResolver` needs to be
    updated so that
    [`DirectoryAssemblyResolver.Dispose()` is useful][0], i.e. that it
    will `Dispose()` of all held `AssemblyDefinition` instances.

2. Bump to Java.Interop/084e9f7f to pick up (1).

3. `Xamarin.Android.Build.Tasks.dll` needs to be updated so that
    `DirectoryAssemblyResolver.Dispose()` is used.

4. All code, in particular `Xamarin.Andorid.Build.Tasks.dll`, needs to
    be reviewed to ensure it doesn't do anything "stupid" with
    `AssemblyDefinition` instances and/or `DirectoryAssemblyResolver.`

    Examples of "stupid" things include:

    * `Dispose()`ing of the return value from
      `DirectoryAssemblyResolver.Load()`:

            resolver.Load (assemblyName).Dispose();

    * Treating `AssemblyDefinition` instances in a manner inconsistent
      with how `DirectoryAssemblyResolver` loads them.
      `DirectoryAssemblyResolver` will be getting a new constructor
      overload which takes an `Mono.Cecil.ReaderParameters` parameter;
      the default will be the default Cecil behavior, which is for
      read-only behavior. Thus, trying to use the `AssemblyDefinition`
      in a "write" context will fail:

            var r = new DirectoryAssemblyResolver (...);
            var a = r.Load (assemblyName);
            a.Write ();   // BOOM

[0]: https://github.com/xamarin/java.interop/pull/88