### PR TITLE
add PreserveHttpAndroidClientHandler substep

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
@@ -88,6 +88,7 @@ namespace MonoDroid.Tuner
 				new PreserveApplications (),
 				new RemoveAttributes (),
 				new PreserveDynamicTypes (),
+				new PreserveHttpAndroidClientHandler { HttpClientHandlerType = options.HttpClientHandlerType },
 				new PreserveSoapHttpClients (),
 				new PreserveTypeConverters (),
 				new PreserveLinqExpressions (),

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/LinkerOptions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/LinkerOptions.cs
@@ -20,5 +20,6 @@ namespace MonoDroid.Tuner
 		public I18nAssemblies I18nAssemblies { get; set; }
 		public string ProguardConfiguration { get; set; }
 		public bool DumpDependencies { get; set; }
+		public string HttpClientHandlerType { get; set; }
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/PreserveHttpAndroidClientHandler.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/PreserveHttpAndroidClientHandler.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using Mono.Cecil;
+using Mono.Tuner;
+
+namespace MonoDroid.Tuner
+{
+	public class PreserveHttpAndroidClientHandler : BaseSubStep
+	{
+		public string HttpClientHandlerType { get; set; }
+
+		public override bool IsActiveFor (Mono.Cecil.AssemblyDefinition assembly)
+		{
+			return HttpClientHandlerType != null && (assembly.Name.Name == "System.Net.Http" || assembly.Name.Name == "Mono.Android");
+		}
+
+		public override SubStepTargets Targets {
+			get { return SubStepTargets.Method; }
+		}
+
+		public override void ProcessMethod (MethodDefinition method)
+		{
+			if (method.Name == "GetDefaultHandler" && method.DeclaringType.FullName == "System.Net.Http.HttpClient")
+				Mark ();
+		}
+
+		protected AssemblyDefinition GetAssembly (string assemblyName)
+		{
+			AssemblyDefinition ad;
+			context.TryGetLinkedAssembly (assemblyName, out ad);
+			return ad;
+		}
+
+		protected TypeDefinition GetType (AssemblyDefinition assembly, string typeName)
+		{
+			return assembly.MainModule.GetType (typeName);
+		}
+
+		protected TypeDefinition GetType (string assemblyName, string typeName)
+		{
+			AssemblyDefinition ad = GetAssembly (assemblyName);
+			return ad == null ? null : GetType (ad, typeName);
+		}
+
+		bool MarkType (string assemblyName, string typeName)
+		{
+			var type = GetType (assemblyName, typeName);
+			if (type != null) {
+				context.Annotations.Mark (type);
+				context.Annotations.SetPreserve (type, Mono.Linker.TypePreserve.All);
+				return true;
+			}
+			return false;
+		}
+
+		string GetAssemblyNameFromTypeName (string typeName, out string simpleTypeName)
+		{
+			simpleTypeName = null;
+			var parts = typeName.Split (new char [] { ',' }, 2);
+			if (parts.Length != 2)
+				return null;
+
+			var anr = AssemblyNameReference.Parse (parts [1].Trim ());
+			if (anr == null)
+				return null;
+
+			simpleTypeName = parts [0].Trim ();
+			return anr.Name;
+		}
+
+		void Mark ()
+		{
+			var androidEnvironmentType = GetType ("Mono.Android", "Android.Runtime.AndroidEnvironment");
+			if (androidEnvironmentType != null) {
+				foreach (var method in androidEnvironmentType.Methods) {
+					if (method.Name == "GetHttpMessageHandler") {
+						context.Annotations.AddPreservedMethod (androidEnvironmentType, method);
+						break;
+					}
+				}
+			}
+
+			if (MarkType ("Mono.Android", HttpClientHandlerType))
+				return;
+
+			string simpleTypeName;
+			var assemblyName = GetAssemblyNameFromTypeName (HttpClientHandlerType, out simpleTypeName);
+			if (assemblyName != null && MarkType (assemblyName, simpleTypeName))
+				return;
+
+			foreach (var assembly in context.GetAssemblies ()) {
+				var clientTypeRef = assembly.MainModule.GetType (HttpClientHandlerType, true);
+				if (clientTypeRef == null)
+					continue;
+
+				var clientTypeDef = clientTypeRef.Resolve ();
+				if (clientTypeDef == null)
+					continue;
+
+				context.Annotations.Mark (clientTypeDef);
+				context.Annotations.SetPreserve (clientTypeDef, Mono.Linker.TypePreserve.All);
+				break;
+			}
+		}
+	}
+}
+

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
@@ -44,6 +44,8 @@ namespace Xamarin.Android.Tasks
 		public string OptionalDestinationDirectory { get; set; }
 		public string LinkOnlyNewerThan { get; set; }
 
+		public string HttpClientHandlerType { get; set; }
+
 		IEnumerable<AssemblyDefinition> GetRetainAssemblies (DirectoryAssemblyResolver res)
 		{
 			List<AssemblyDefinition> retainList = null;
@@ -74,6 +76,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  ProguardConfiguration: {0}", ProguardConfiguration);
 			Log.LogDebugMessage ("  DumpDependencies: {0}", DumpDependencies);
 			Log.LogDebugMessage ("  LinkOnlyNewerThan: {0}", LinkOnlyNewerThan);
+			Log.LogDebugMessage ("  HttpClientHandlerType: {0}", HttpClientHandlerType);
 
 			var rp = new ReaderParameters {
 				InMemory    = true,
@@ -104,6 +107,7 @@ namespace Xamarin.Android.Tasks
 			if (!options.LinkSdkOnly)
 				options.RetainAssemblies = GetRetainAssemblies (res);
 			options.DumpDependencies = DumpDependencies;
+			options.HttpClientHandlerType = HttpClientHandlerType;
 			
 			var skiplist = new List<string> ();
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Linker\MonoDroid.Tuner\Linker.cs" />
     <Compile Include="Linker\MonoDroid.Tuner\LinkerOptions.cs" />
     <Compile Include="Linker\MonoDroid.Tuner\MonoDroidMarkStep.cs" />
+    <Compile Include="Linker\MonoDroid.Tuner\PreserveHttpAndroidClientHandler.cs" />
     <Compile Include="Tasks\Aapt.cs" />
     <Compile Include="Tasks\AndroidZipAlign.cs" />
     <Compile Include="Tasks\BuildApk.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1583,7 +1583,8 @@ because xbuild doesn't support framework reference assemblies.
       ProguardConfiguration="$(_ProguardProjectConfiguration)"
       EnableProguard="$(AndroidEnableProguard)"
       DumpDependencies="$(LinkerDumpDependencies)"
-      ResolvedAssemblies="@(ResolvedAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')" />
+      ResolvedAssemblies="@(ResolvedAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
+      HttpClientHandlerType="$(AndroidHttpClientHandlerType)" />
 
     <!-- We have to use a flag instead of normal outputs because linking can delete unused assemblies -->
     <Touch Files="$(_AndroidLinkFlag)" AlwaysCreate="true" />


### PR DESCRIPTION
 - this should make $(AndroidHttpClientHandlerType) survive linking

 - implements linker part of
   https://trello.com/c/mW2fEFyN/110-xa-http-client-handler-type-and-linking