### PR TITLE
[Xamarin.Android.Build.Tasks] call `Disposable ()` for assembly and pass `ReadWrite`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveRegisterAttribute.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveRegisterAttribute.cs
@@ -24,13 +24,13 @@ namespace Xamarin.Android.Tasks
 
 			// Find Mono.Android.dll
 			var mono_android = ShrunkFrameworkAssemblies.First (f => Path.GetFileNameWithoutExtension (f.ItemSpec) == "Mono.Android").ItemSpec;
-			var assembly = AssemblyDefinition.ReadAssembly (mono_android);
+			using (var assembly = AssemblyDefinition.ReadAssembly (mono_android, new ReaderParameters { ReadWrite = true })) {
+				// Strip out [Register] attributes
+				foreach (TypeDefinition type in assembly.MainModule.Types)
+					ProcessType (type);
 
-			// Strip out [Register] attributes
-			foreach (TypeDefinition type in assembly.MainModule.Types)
-				ProcessType (type);
-
-			assembly.Write (mono_android);
+				assembly.Write ();
+			}
 			
 			return true;
 		}


### PR DESCRIPTION
this fix from https://github.com/xamarin/xamarin-android/pull/231 got lost in https://github.com/xamarin/xamarin-android/pull/233. doesn't depend on `java.interop` changes.