### PR TITLE
[build] Fix build caching, Xamarin Studio `libzip.mdproj` issues

### DIFF
--- a/build-tools/libzip/libzip.mdproj
+++ b/build-tools/libzip/libzip.mdproj
@@ -8,7 +8,10 @@
     <ForceBuildProjectFilePath>$(MSBuildThisFileFullPath)</ForceBuildProjectFilePath>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <OutputPath>..\..\bin\$(Configuration)</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>..\..\bin\$(Configuration)</OutputPath>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />

--- a/build-tools/mono-runtimes/ProfileAssemblies.projitems
+++ b/build-tools/mono-runtimes/ProfileAssemblies.projitems
@@ -140,13 +140,11 @@
     <MonoProfileAssembly Include="I18N.Rare.dll" />
     <MonoProfileAssembly Include="I18N.West.dll" />
     <MonoProfileAssembly Include="Microsoft.CSharp.dll" />
-    <MonoProfileAssembly Include="Mono.Cairo.dll" />
     <MonoProfileAssembly Include="Mono.CompilerServices.SymbolWriter.dll" />
     <MonoProfileAssembly Include="Mono.CSharp.dll" />
     <MonoProfileAssembly Include="Mono.Data.Tds.dll" />
     <MonoProfileAssembly Include="Mono.Security.dll" />
     <MonoProfileAssembly Include="mscorlib.dll" />
-    <MonoProfileAssembly Include="SMDiagnostics.dll" />
     <MonoProfileAssembly Include="System.ComponentModel.Composition.dll" />
     <MonoProfileAssembly Include="System.ComponentModel.DataAnnotations.dll" />
     <MonoProfileAssembly Include="System.Core.dll" />


### PR DESCRIPTION
[The Jenkins build isn't using the bundle file][0]:

	Target _BuildUnlessCached needs to be built as output file '../../bin/Debug//lib/xbuild-frameworks/MonoAndroid/v1.0/Mono.Cairo.dll' does not exist.

Another day, another "How did that ever work?!"

In particular, `Mono.Cairo.dll` was *never* built for the
Xamarin.Android profile, so *seriously*, how did the mono bundle,
"fixed" in 10b1c2a4, *actually work*?

Not only is `Mono.Cairo.dll` not built for the "monodroid" profile,
`SMDiagnostics.dll` is no longer built for MOBILE configurations
either.

Remove `Mono.Cairo.dll` and `SMDiagnostics.dll` from
`@(MonoProfileAssembly)`, which should allow the bundle to be used.

Xamarin Studio doesn't like `build-tools/libzip/libzip.mdproj`: it
refuses to load the project, stating:

> Invalid configuration mapping

This isn't a particularly helpful error. The *actual* issue is that
Xamarin Studio requires that an MSBuild project have
`<PropertyGroup/>`s with `Condition` attributes which correspond to a
"known" configuration. *It doesn't matter* that, in the case of
`libzip.mdproj`, *all* configurations use the same `$(OutputPath)`
property value, we still need separate Debug and Release configuration
sections in order to appease the Xamarin Studio masters.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/101/consoleText