### PR TITLE
[F#] Use C# Resource.designer.cs file for F# [C10 MERGE ONLY]

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
@@ -98,6 +98,14 @@ namespace Xamarin.Android.Tasks
 			bool isFSharp = string.Equals (language, "F#", StringComparison.OrdinalIgnoreCase);
 			bool isCSharp = string.Equals (language, "C#", StringComparison.OrdinalIgnoreCase);
 
+
+			if (isFSharp)
+			{
+				language = "C#";
+				isCSharp = true;
+				NetResgenOutputFile = Path.ChangeExtension(NetResgenOutputFile, ".cs");
+			}
+
 			// Let VB put this in the default namespace
 			if (isVB)
 				Namespace = string.Empty;
@@ -126,31 +134,22 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
-			AdjustConstructor (isFSharp, resources);
+			AdjustConstructor (resources);
 			foreach (var member in resources.Members)
 				if (member is CodeTypeDeclaration)
-					AdjustConstructor (isFSharp, (CodeTypeDeclaration) member);
+					AdjustConstructor ((CodeTypeDeclaration) member);
 
 			// Write out our Resources.Designer.cs file
 
-			WriteFile (NetResgenOutputFile, resources, language, isFSharp, isCSharp);
+			WriteFile (NetResgenOutputFile, resources, language, isCSharp);
 
 			return !Log.HasLoggedErrors;
 		}
 
 		// Remove private constructor in F#.
 		// Add static constructor. (but ignored in F#)
-		void AdjustConstructor (bool isFSharp, CodeTypeDeclaration type)
+		void AdjustConstructor (CodeTypeDeclaration type)
 		{			
-			if (isFSharp) {
-				foreach (CodeTypeMember tm in type.Members) {
-					if (tm is CodeConstructor) {
-						type.Members.Remove (tm);
-						break;
-					}
-				}
-			}
-
 			var staticCtor = new CodeTypeConstructor () { Attributes = MemberAttributes.Static };
 			staticCtor.Statements.Add (
 				new CodeExpressionStatement (
@@ -163,11 +162,9 @@ namespace Xamarin.Android.Tasks
 			type.Members.Add (staticCtor);
 		}
 
-		private void WriteFile (string file, CodeTypeDeclaration resources, string language, bool isFSharp, bool isCSharp)
+		private void WriteFile (string file, CodeTypeDeclaration resources, string language, bool isCSharp)
 		{
-			CodeDomProvider provider = 
-				isFSharp ? new FSharp.Compiler.CodeDom.FSharpCodeProvider () :
-				CodeDomProvider.CreateProvider (language);
+			CodeDomProvider provider = CodeDomProvider.CreateProvider (language);
 
 			string code = null;
 			using (var o = new StringWriter ()) {
@@ -202,23 +199,6 @@ namespace Xamarin.Android.Tasks
 					provider.GenerateCodeFromCompileUnit(new CodeSnippetCompileUnit("#pragma warning restore 1591"), o, options);
 
 				code = o.ToString ();
-
-				// post-processing for F#
-				if (isFSharp) {
-					code = code.Replace ("\r\n", "\n");
-					while (true) {
-						int skipLen = " = class".Length;
-						int idx = code.IndexOf (" = class");
-						if (idx < 0)
-							break;
-						int end = code.IndexOf ("        end");
-						string head = code.Substring (0, idx);
-						string mid = end < 0 ? code.Substring (idx) : code.Substring (idx + skipLen, end - idx - skipLen);
-						string last = end < 0 ? null : code.Substring (end + "        end".Length);
-						code = head + @" () =
-            static do Android.Runtime.ResourceIdManager.UpdateIdValues()" + mid + "\n" + last;
-					}
-				}
 			}
 			
 			var temp_o  = Path.Combine (Path.GetDirectoryName (file), "__" + Path.GetFileName (file) + ".new");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -35,10 +35,11 @@ namespace Xamarin.ProjectTools
 
 		public XamarinAndroidApplicationProject ()
 		{
-			SetProperty ("AndroidApplication", "True");
+			var defaultExtension = Language.DefaultExtension == ".fs" ? ".cs" : Language.DefaultExtension;
 
+			SetProperty ("AndroidApplication", "True");
 			SetProperty ("AndroidResgenClass", "Resource");
-			SetProperty ("AndroidResgenFile", () => "Resources\\Resource.designer" + Language.DefaultExtension);
+			SetProperty ("AndroidResgenFile", () => "Resources\\Resource.designer" + defaultExtension);
 			SetProperty ("AndroidManifest", "Properties\\AndroidManifest.xml");
 			SetProperty (DebugProperties, "AndroidLinkMode", "None");
 			SetProperty (ReleaseProperties, "AndroidLinkMode", "SdkOnly");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
@@ -31,7 +31,7 @@ Copyright (C) 2012 Xamarin. All rights reserved.
              our mscorlib.dll isn't properly signed, as far as its concerned.
              Disable generation to avoid "bizarre" build errors. -->
         <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-        <_AndroidResourceDesigner>Resource.Designer.fs</_AndroidResourceDesigner>
+        <_AndroidResourceDesigner>Resource.Designer.cs</_AndroidResourceDesigner>
     </PropertyGroup>
 
     <!-- xbuild searches multiple MSBuildExtensionsPath32, but only in the Import element, so we can't determine this with a variable -->


### PR DESCRIPTION
Removes the use of F# CodeDOM for generating the resource
designer file for F#.

Instead, a [type provider](https://github.com/xamarin/Xamarin.Android.FSharp.ResourceProvider/blob/master/ResourceTypeProvider.fs)
is used at compile time (both xbuild and the IDE) that compiles the
C# code using CSharpCodeProvider and makes the types available to
the consuming F# project. The type provider is available as a NuGet
package and is included in the Android templates.

This is similar to #159, but uses an F# type provider to compile the C# instead of an msbuild task. The advantage of this method is that intellisense works in the IDE without having to change the IDE code.
