### PR TITLE
pass the ReadWrite parameter to the resolver

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/StripEmbeddedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/StripEmbeddedLibraries.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("StripEmbeddedLibraries Task");
 			Log.LogDebugTaskItems ("  Assemblies: ", Assemblies);
 
-			using (var res = new DirectoryAssemblyResolver (Log.LogWarning, true)) {
+			using (var res = new DirectoryAssemblyResolver (Log.LogWarning, true, new ReaderParameters { ReadWrite = true } )) {
 				return Execute (res);
 			}
 		}
@@ -83,7 +83,7 @@ namespace Xamarin.Android.Tasks
 						WriteSymbols = assembly.MainModule.HasSymbols
 					};
 
-					assembly.Write (assemblyPath, wp);
+					assembly.Write (wp);
 				}
 			}
 			return true;


### PR DESCRIPTION
 - fixes part of #44529

 - call Write without path to use the same stream to write the
   assembly