### PR TITLE
[Mono.Android] fix bug #44391 - AtomicInteger had weird property gett…

### DIFF
--- a/src/Mono.Android/Java.Util.Concurrent.Atomic/AtomicInteger.cs
+++ b/src/Mono.Android/Java.Util.Concurrent.Atomic/AtomicInteger.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Java.Util.Concurrent.Atomic
+{
+	public partial class AtomicInteger
+	{
+		[Obsolete ("This property was generated for getAndDecrement() method, while it does not make sense. It will be removed in the future version")]
+		public int AndDecrement {
+			get { return GetAndDecrement (); }
+		}
+		[Obsolete ("This property was generated for getAndIncrement() method, while it does not make sense. It will be removed in the future version")]
+		public int AndIncrement {
+			get { return GetAndIncrement (); }
+		}
+	}
+}
+

--- a/src/Mono.Android/Java.Util.Concurrent.Atomic/AtomicLong.cs
+++ b/src/Mono.Android/Java.Util.Concurrent.Atomic/AtomicLong.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Java.Util.Concurrent.Atomic
+{
+	public partial class AtomicLong
+	{
+		[Obsolete ("This property was generated for getAndDecrement() method, while it does not make sense. It will be removed in the future version")]
+		public long AndDecrement {
+			get { return GetAndDecrement (); }
+		}
+		[Obsolete ("This property was generated for getAndIncrement() method, while it does not make sense. It will be removed in the future version")]
+		public long AndIncrement {
+			get { return GetAndIncrement (); }
+		}
+	}
+}
+

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -263,6 +263,8 @@
     <Compile Include="Java.Nio\CharBuffer.cs" />
     <Compile Include="Java.Security\IdentityScope.cs" />
     <Compile Include="Java.Util\Spliterators.cs" />
+    <Compile Include="Java.Util.Concurrent.Atomic\AtomicInteger.cs" />
+    <Compile Include="Java.Util.Concurrent.Atomic\AtomicLong.cs" />
     <Compile Include="Javax.Microedition.Khronos.Egl\EGLContext.cs" />
     <Compile Include="Org.Apache.Http.Impl.Conn\DefaultClientConnection.cs" />
     <Compile Include="Org.Apache.Http.Impl.Cookie\BasicClientCookie.cs" />

--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1157,6 +1157,9 @@
   -->
   <remove-node path="/api/package[@name='java.awt.font']/class[@name='NumericShaper']/method[@name='getContextualShaper' and @merge.SourceFile = 'Profiles/api-24.xml.in']" />
   <remove-node path="/api/package[@name='java.awt.font']/class[@name='NumericShaper']/method[@name='getShaper' and @merge.SourceFile = 'Profiles/api-24.xml.in']" />
+  <!-- FIXME: our product had inconsistent metadata fixup duplicates, but the xamarin-android migration from monodroid caused extraneous directory structural changes which broke build to fix this issue. To workaround the problem, these two extraneous metadata fixup lines are added. They should be removed in the future. -->
+  <remove-node path="/api/package[@name='java.awt.font']/class[@name='NumericShaper']/method[@name='getContextualShaper' and @merge.SourceFile = 'api-24.xml.in']" />
+  <remove-node path="/api/package[@name='java.awt.font']/class[@name='NumericShaper']/method[@name='getShaper' and @merge.SourceFile = 'api-24.xml.in']" />
 
   <!-- StringBuffer.Append(bool) is newly added, and it causes override
     resolution conflict with base AbstractStringBuilder. However, that "forcibly exposed internal-only" class returned AbstractStringBuilder itself, which doesn't match the expected return type. For this case, we need to modify the internal type.
@@ -1309,4 +1312,10 @@
   <attr path="/api/package[@name='android.provider']/class[@name='ContactsContract.CommonDataKinds.Organization']/field[@name='PHONETIC_NAME_STYLE']" name="managedName">PhoneticNameStyleField</attr>
   <attr path="/api/package[@name='android.provider']/class[@name='ContactsContract.CommonDataKinds.StructuredName']/field[@name='PHONETIC_NAME_STYLE']" name="managedName">PhoneticNameStyleField</attr>
 
+  <!-- bug #44391 -->
+  <attr path="/api/package[@name='java.util.concurrent.atomic']/class[@name='AtomicInteger']/method[@name='getAndDecrement']" name="propertyName"></attr>
+  <attr path="/api/package[@name='java.util.concurrent.atomic']/class[@name='AtomicInteger']/method[@name='getAndIncrement']" name="propertyName"></attr>
+  <attr path="/api/package[@name='java.util.concurrent.atomic']/class[@name='AtomicLong']/method[@name='getAndDecrement']" name="propertyName"></attr>
+  <attr path="/api/package[@name='java.util.concurrent.atomic']/class[@name='AtomicLong']/method[@name='getAndIncrement']" name="propertyName"></attr>
+  
 </metadata>


### PR DESCRIPTION
…ers.

`AtomicInteger` has getAndIncrement() and getAndDecrement() methods, and
they were automatically converted to AndIncrement / AndDecrement properties
(which are obviously along with the generation rule, but don't make sense).

Disable propertization on those methods.

Transitive obsoleted properties are added for future removal.

And metadata had wrong relative path specification which broke our
product build, so remove them.