### PR TITLE
make sure the TypeNameMapGenerator is disposed

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -266,11 +266,12 @@ namespace Xamarin.Android.Tasks
 
 		void WriteTypeMappings (List<TypeDefinition> types)
 		{
-			var gen = UseSharedRuntime
+			using (var gen = UseSharedRuntime
 				? new TypeNameMapGenerator (types, Log.LogDebugMessage)
-				: new TypeNameMapGenerator (ResolvedAssemblies.Select (p => p.ItemSpec), Log.LogDebugMessage);
-			UpdateWhenChanged (Path.Combine (OutputDirectory, "typemap.jm"), gen.WriteJavaToManaged);
-			UpdateWhenChanged (Path.Combine (OutputDirectory, "typemap.mj"), gen.WriteManagedToJava);
+			        : new TypeNameMapGenerator (ResolvedAssemblies.Select (p => p.ItemSpec), Log.LogDebugMessage)) {
+				UpdateWhenChanged (Path.Combine (OutputDirectory, "typemap.jm"), gen.WriteJavaToManaged);
+				UpdateWhenChanged (Path.Combine (OutputDirectory, "typemap.mj"), gen.WriteManagedToJava);
+			}
 		}
 
 		void UpdateWhenChanged (string path, Action<Stream> generator)


### PR DESCRIPTION
 - so that following tasks will not run into stream sharing
   (violation) issues as in #44529

 - bump Java.Interop to get:

    commit 40b75e9c4b7b986f3bb31254a4aab3d60e0ef74e
    Author: Radek Doulik <radekdoulik@users.noreply.github.com>
    Date:   Wed Sep 28 21:25:26 2016 +0200

        [Java.Interop.Tools.JavaCallableWrappers] Add TypeNameMapGenerator.Dispose() (#91)