### PR TITLE
[Xamarin.Android.Build.Utilities] Look within FlatPak search paths (#41)

### DIFF
--- a/src/Xamarin.Android.Build.Utilities/Sdks/MonoDroidSdkUnix.cs
+++ b/src/Xamarin.Android.Build.Utilities/Sdks/MonoDroidSdkUnix.cs
@@ -16,6 +16,7 @@ namespace Xamarin.Android.Build.Utilities
 		readonly static string[] SearchPaths = {
 			"/Library/Frameworks/Xamarin.Android.framework/Versions/Current/lib/mandroid",
 			"/Developer/MonoAndroid/usr/lib/mandroid",
+			"/app/lib/mandroid",
 			"/opt/mono-android/lib/mandroid"
 		};
 


### PR DESCRIPTION
Add `/app/lib/mandroid` to directory search paths for FlatPak support.