### PR TITLE
Don't perform any Java net access on main thread

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -251,7 +251,7 @@ namespace Xamarin.Android.Net
 				await request.Content.CopyToAsync (httpConnection.OutputStream).ConfigureAwait (false);
 			}
 
-			var statusCode = (HttpStatusCode)httpConnection.ResponseCode;
+			var statusCode = await Task.Run (() => (HttpStatusCode)httpConnection.ResponseCode).ConfigureAwait (false);
 			var connectionUri = new Uri (httpConnection.URL.ToString ());
 
 			// If the request was redirected we need to put the new URL in the request


### PR DESCRIPTION
It appears that sometimes calling .ResponseCode on an instance
of the Java class HttpURLConnection will trigger network activity
and if the AndroidHttpCliendHandler was invoked on the main thread,
the activity will take place there as well and that causes Android
to throw the NetworkOnMainThreadException.

Wrap the offending code in a task to avoid the exception.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=44961