### PR TITLE
[Xamarin.Android.Build.Tasks] Add new Helper method for MonoAndroidHelper.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -145,6 +145,15 @@ namespace Xamarin.Android.Tasks
 			AndroidLogger.Info += (task, message) => log.LogMessage (task + " " + message);
 			AndroidLogger.Debug += (task, message) => log.LogDebugMessage (task + " " + message);
 		}
+
+		public static void InitializeAndroidLogger (MessageHandler error, MessageHandler warning,
+			MessageHandler info, MessageHandler debug)
+		{
+			AndroidLogger.Error += error;
+			AndroidLogger.Warning += warning;
+			AndroidLogger.Info += info;
+			AndroidLogger.Debug += debug;
+		}
 #endif
 
 		public static IEnumerable<string> DistinctFilesByContent (IEnumerable<string> filePaths)


### PR DESCRIPTION
We want to be able to add just callback to the AndroidLogger, not just
hardcode it to only take an MSBuild TaskLogger. This commit adds a new
method which takes MessageHandler's for each of the event handlers
available on the AndroidLogger. This will allow us to just provide
Lambda expressions for the events.