### PR TITLE
[Xamarin.Android.Build.Tasks] Add LogErrorFromException method to AsyncTask

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AsyncTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AsyncTask.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
 using System.Threading;
@@ -112,6 +113,14 @@ namespace Xamarin.Android.Tasks
 		protected void LogError (string message, params object[] messageArgs)
 		{
 			LogError (string.Format (message, messageArgs));
+		}
+
+		public void LogErrorFromException (Exception exception)
+		{
+			var sb = new StringBuilder ();
+			sb.Append (exception.Message);
+			sb.Append (exception.StackTrace);
+			LogError (sb.ToString ());
 		}
 
 		protected void LogCodedError (string code, string message, params object[] messageArgs)


### PR DESCRIPTION
This commit adds a new wrapper for the to the AsyncTask to allow
the easy logging of Exceptions. This will be used by the InstallPackageAssemblies task 
to log any exceptions it raises. We need to do this because that task is being turned into 
an AsyncTask and we need to replace the calls to Log.LogErrorFromException with the internal one that queue's the error for processing on the UI thread.
