### PR TITLE
[Xamarin.Android.Build.Tasks] Possible memory leak of whole Task chain for SDK resolving

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadResolvedSdksCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadResolvedSdksCache.cs
@@ -84,9 +84,18 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
+			MonoAndroidHelper.InitializeAndroidLogger (ErrorHandler, WarningHandler, InfoHandler, DebugHandler);
+			try {
+				return RunTask ();
+			} finally {
+				MonoAndroidHelper.ClearAndroidLogger (ErrorHandler, WarningHandler, InfoHandler, DebugHandler);
+			}
+		}
+
+		public bool RunTask ()
+		{
 			Log.LogDebugMessage ("Task ReadResolvedSdksCache");
 			Log.LogDebugMessage ("  CacheFile: {0}", CacheFile);
-			MonoAndroidHelper.InitializeAndroidLogger (Log);
 			if (!File.Exists (CacheFile)) {
 				Log.LogWarning ("{0} does not exist. No Resolved Sdks found", CacheFile);
 				return !Log.HasLoggedErrors;
@@ -135,6 +144,26 @@ namespace Xamarin.Android.Tasks
 			MonoAndroidHelper.RefreshMonoDroidSdk (MonoAndroidToolsPath, MonoAndroidBinPath, ReferenceAssemblyPaths);
 
 			return !Log.HasLoggedErrors;
+		}
+
+		void ErrorHandler (string task, string message)
+		{
+			Log.LogError ($"{task} {message}");
+		}
+
+		void WarningHandler (string task, string message)
+		{
+			Log.LogWarning ($"{task} {message}");
+		}
+
+		void DebugHandler (string task, string message)
+		{
+			Log.LogDebugMessage ($"DEBUG {task} {message}");
+		}
+
+		void InfoHandler (string task, string message)
+		{
+			Log.LogMessage ($"{task} {message}");
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -106,6 +106,17 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
+			MonoAndroidHelper.InitializeAndroidLogger (ErrorHandler, WarningHandler, InfoHandler, DebugHandler);
+			try {
+				return RunTask();
+			}
+			finally {
+				MonoAndroidHelper.ClearAndroidLogger (ErrorHandler, WarningHandler, InfoHandler, DebugHandler);
+			}
+		}
+
+		public bool RunTask ()
+		{
 			Log.LogDebugMessage ("ResolveSdksTask:");
 			Log.LogDebugMessage ("  AndroidApiLevel: {0}", AndroidApiLevel);
 			Log.LogDebugMessage ("  AndroidSdkBuildToolsVersion: {0}", AndroidSdkBuildToolsVersion);
@@ -115,8 +126,6 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  SequencePointsMode: {0}", SequencePointsMode);
 			Log.LogDebugMessage ("  MonoAndroidToolsPath: {0}", MonoAndroidToolsPath);
 			Log.LogDebugMessage ("  MonoAndroidBinPath: {0}", MonoAndroidBinPath);
-
-			MonoAndroidHelper.InitializeAndroidLogger (Log);
 
 			MonoAndroidHelper.RefreshAndroidSdk (AndroidSdkPath, AndroidNdkPath, JavaSdkPath);
 			MonoAndroidHelper.RefreshMonoDroidSdk (MonoAndroidToolsPath, MonoAndroidBinPath, ReferenceAssemblyPaths);
@@ -385,6 +394,26 @@ namespace Xamarin.Android.Tasks
 					"Could not determine $(TargetFrameworkVersion) for API level '{0}.'",
 					AndroidApiLevel);
 			return null;
+		}
+
+		void ErrorHandler (string task, string message)
+		{
+			Log.LogError ($"{task} {message}");
+		}
+
+		void WarningHandler (string task, string message)
+		{
+			Log.LogWarning ($"{task} {message}");
+		}
+
+		void DebugHandler (string task, string message)
+		{
+			Log.LogDebugMessage ($"DEBUG {task} {message}");
+		}
+
+		void InfoHandler (string task, string message)
+		{
+			Log.LogMessage ($"{task} {message}");
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -138,14 +138,6 @@ namespace Xamarin.Android.Tasks
 			return filePaths.Distinct (MonoAndroidHelper.SizeAndContentFileComparer.DefaultComparer);
 		}
 
-		public static void InitializeAndroidLogger (TaskLoggingHelper log)
-		{
-			AndroidLogger.Error += (task, message) => log.LogError (task + " " + message);
-			AndroidLogger.Warning += (task, message) => log.LogWarning (task + " " + message);
-			AndroidLogger.Info += (task, message) => log.LogMessage (task + " " + message);
-			AndroidLogger.Debug += (task, message) => log.LogDebugMessage (task + " " + message);
-		}
-
 		public static void InitializeAndroidLogger (MessageHandler error, MessageHandler warning,
 			MessageHandler info, MessageHandler debug)
 		{
@@ -153,6 +145,15 @@ namespace Xamarin.Android.Tasks
 			AndroidLogger.Warning += warning;
 			AndroidLogger.Info += info;
 			AndroidLogger.Debug += debug;
+		}
+
+		public static void ClearAndroidLogger (MessageHandler error, MessageHandler warning,
+			MessageHandler info, MessageHandler debug)
+		{
+			AndroidLogger.Error -= error;
+			AndroidLogger.Warning -= warning;
+			AndroidLogger.Info -= info;
+			AndroidLogger.Debug -= debug;
 		}
 #endif
 


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=45018

The MSBuild Tasks setting the AndroidLogger event handlers were
not cleaning them up afterwards. This is not a problem on the
Command Line or in VS since the build Tasks are disposed of
once the build is complete. Or at least is appears to do so
in VS.

However in XS the entire build structure thing is kept in
memory. This appears to suggest that the event handers are
not removed and are constantly being set. Which in turn would
probably produce a memory leak.

This commit reworks the two Tasks which use these event handlers to
remove them after the task has completed.