### PR TITLE
[Xamarin.Android.Build.Tasks] State Error CS0117 'Resource.Attribute' does not contain a definition for 'actionBarSize'

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
@@ -121,7 +121,7 @@ namespace Xamarin.Android.Tasks
 						assemblyNames.Add (assemblyPath);
 					}
 					var assemblies = assemblyNames.Select (assembly => resolver.GetAssembly (assembly));
-					new ResourceDesignerImportGenerator (Namespace, resources)
+					new ResourceDesignerImportGenerator (Namespace, resources, Log)
 						.CreateImportMethods (assemblies);
 				}
 			}


### PR DESCRIPTION
Context https://bugzilla.xamarin.com/show_bug.cgi?id=39910

Under certain circumstances users can end up in a situation
where the Resource.Designer.xx file being generated will NOT
compile. This is normally down to a miss match between Nuget
packages like Xamarin.Forms and Android.Support libraries. It
is possible to have incpmpatible versions of Xamarin.Forms
(or other third party library like ZXing) which contain references
in the Resource.Designer.xx which DO NOT exist in the main application.

As a result when the code generator emits the code to set the field values
like

	global::ZXing.Mobile.Resource.Id.contentFrame = global::Bug39910Repro.Droid.Resource.Id.contentFrame;

you can get into a situation where "contentFrame" does NOT exist in
the app (in this case Bug39910Repro) Id class. This results in a
compilation error CS0117.

This commit makes sure the compilation error is removed by checking
that the target type exists before emitting the code. If the type does
NOT exist we will emit a Warning XA0106 which will inform the user
they might have a problem with the Nuget versions.

While this might not be ideal as it may result in runtime issues. It
seems to be preferable to compilation errors that stop a user completely.
Possible runtime issues might be errors in the android app because certain
resource id's do not exist or refer to different resources.