### PR TITLE
[Xamarin.Android.Build.Tasks] System modal windows during release build

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AdjustJavacVersionArguments.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AdjustJavacVersionArguments.cs
@@ -41,6 +41,8 @@ namespace Xamarin.Android.Tasks
 				RedirectStandardOutput = true,
 				RedirectStandardError = true,
 				UseShellExecute = false,
+				CreateNoWindow = true,
+				WindowStyle = ProcessWindowStyle.Hidden,
 				};
 			var proc = Process.Start (psi);
 			proc.WaitForExit ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CilStrip.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CilStrip.cs
@@ -78,6 +78,8 @@ namespace Xamarin.Android.Tasks
 				UseShellExecute = false,
 				RedirectStandardOutput = true,
 				RedirectStandardError = true,
+				CreateNoWindow = true,
+				WindowStyle = ProcessWindowStyle.Hidden,
 			};
 
 			var proc = new Process ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
@@ -131,6 +131,8 @@ namespace Xamarin.Android.Tasks
 					UseShellExecute = false,
 					RedirectStandardOutput = true,
 					RedirectStandardError = true,
+					CreateNoWindow = true,
+					WindowStyle = ProcessWindowStyle.Hidden,
 				};
 				var gccNoQuotes = NdkUtil.GetNdkTool (AndroidNdkDirectory, arch, "gcc");
 				var gcc = '"' + gccNoQuotes + '"';

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -31,6 +31,8 @@ namespace Xamarin.Android.Tasks
 				UseShellExecute = false,
 				RedirectStandardOutput = true,
 				RedirectStandardError = true,
+				CreateNoWindow = true,
+				WindowStyle = ProcessWindowStyle.Hidden,
 			};
 			Process p = new Process ();
 			p.StartInfo = psi;


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=43287

Most of the ProcessStartInfo instances did NOT include

	CreateNoWindow=true
	WindowStyle=ProcessWindowStyle.Hidden

As a result on windows at least developers would see a
DOS prompt pop up during the build process. This is very
distracting. This commit fixes up the various uses to include
the new properties