### PR TITLE
Add support for CancellationToken and Timeout in AndroidClientHandler

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -234,6 +234,15 @@ namespace Xamarin.Android.Net
 		{
 			if (Logger.LogNet)
 				Logger.Log (LogLevel.Info, LOG_APP, $"{this}.DoProcessRequest ()");
+
+			if(cancellationToken.IsCancellationRequested)
+			{
+				if(Logger.LogNet)
+					Logger.Log(LogLevel.Info, LOG_APP, " cancelled");
+
+				cancellationToken.ThrowIfCancellationRequested();
+			}
+
 			try {
 				if (Logger.LogNet)
 					Logger.Log (LogLevel.Info, LOG_APP, $"  connecting");
@@ -246,6 +255,16 @@ namespace Xamarin.Android.Net
 				// Wrap it nicely in a "standard" exception so that it's compatible with HttpClientHandler
 				throw new WebException (ex.Message, ex, WebExceptionStatus.ConnectFailure, null);
 			}
+
+			if(cancellationToken.IsCancellationRequested)
+			{
+				if(Logger.LogNet)
+					Logger.Log(LogLevel.Info, LOG_APP, " cancelled");
+
+				httpConnection.Disconnect();
+				cancellationToken.ThrowIfCancellationRequested();
+			}
+			cancellationToken.Register(httpConnection.Disconnect);
 
 			if (httpConnection.DoOutput) {
 				await request.Content.CopyToAsync (httpConnection.OutputStream).ConfigureAwait (false);


### PR DESCRIPTION
The `AndroidClientHandler` never polled the `CancellationToken`, it was just being passed through. This caused https://bugzilla.xamarin.com/show_bug.cgi?id=44673

The [HttpClient](https://github.com/mono/mono/blob/0bcbe39b148bb498742fc68416f8293ccd350fb6/mcs/class/System.Net.Http/System.Net.Http/HttpClient.cs#L270) uses this token to support the `Timeout` property.

I made the `httpConnection` disconnect when the token is cancelled so that the timeout value would be respected.