### PR TITLE
Get network information from Java

### DIFF
--- a/src/monodroid/jni/Android.mk
+++ b/src/monodroid/jni/Android.mk
@@ -59,7 +59,8 @@ LOCAL_SRC_FILES := \
 	zip/ioapi.c \
 	zip/unzip.c \
 	xamarin_getifaddrs.c \
-	cpu-arch-detect.c
+	cpu-arch-detect.c \
+	monodroid-networkinfo.c
 
 jni/monodroid-glue.c: jni/config.include jni/machine.config.include
 

--- a/src/monodroid/jni/monodroid-glue.h
+++ b/src/monodroid/jni/monodroid-glue.h
@@ -2,9 +2,11 @@
 #define __MONODROID_GLUE_H
 
 #include <stdio.h>
+#include <jni.h>
 
 MONO_API  int monodroid_get_system_property (const char *name, char **value);
 int monodroid_get_system_property_from_overrides (const char *name, char ** value);
+JNIEnv* get_jnienv (void);
 
 struct DylibMono;
 

--- a/src/monodroid/jni/monodroid-networkinfo.c
+++ b/src/monodroid/jni/monodroid-networkinfo.c
@@ -1,0 +1,123 @@
+/*
+ * monodroid-networkinfo.c
+ *
+ * Authors:
+ *      Marek Habersack <grendel@twistedcode.net>
+ *
+ * Copyright (C) 2016 Microsoft (http://microsoft.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include <assert.h>
+#include <pthread.h>
+#include <string.h>
+
+#include "monodroid.h"
+#include "logger.h"
+#include "monodroid-glue.h"
+#include "util.h"
+#include "dylib-mono.h"
+
+static pthread_once_t java_classes_once_control = PTHREAD_ONCE_INIT;
+static jclass NetworkInterface_class;
+static jmethodID NetworkInterface_getByName;
+static jmethodID NetworkInterface_isUp;
+static jmethodID NetworkInterface_supportsMulticast;
+
+static void
+java_classes_init (void)
+{
+	JNIEnv *env = get_jnienv ();
+	NetworkInterface_class = (*env)->FindClass (env, "java/net/NetworkInterface");
+	NetworkInterface_getByName = (*env)->GetStaticMethodID (env, NetworkInterface_class, "getByName", "(Ljava/lang/String;)Ljava/net/NetworkInterface;");
+	NetworkInterface_isUp = (*env)->GetMethodID (env, NetworkInterface_class, "isUp", "()Z");
+	NetworkInterface_supportsMulticast = (*env)->GetMethodID (env, NetworkInterface_class, "supportsMulticast", "()Z");
+}
+
+static mono_bool
+_monodroid_get_network_interface_state (const char *ifname, mono_bool *is_up, mono_bool *supports_multicast)
+{
+	if (!ifname || strlen (ifname) == 0 || (!is_up && !supports_multicast))
+		return FALSE;
+
+	mono_bool ret = TRUE;
+
+	if (is_up)
+		*is_up = FALSE;
+	if (supports_multicast)
+		*supports_multicast = FALSE;
+
+	pthread_once (&java_classes_once_control, java_classes_init);
+
+	if (!NetworkInterface_class || !NetworkInterface_getByName) {
+		if (!NetworkInterface_class)
+			log_warn (LOG_NET, "Failed to find the 'java.net.NetworkInterface' Java class");
+		if (!NetworkInterface_getByName)
+			log_warn (LOG_NET, "Failed to find the 'java.net.NetworkInterface.getByName' function");
+		log_warn (LOG_NET, "Unable to determine network interface state because of missing Java API");
+		goto leave;
+	}
+
+	JNIEnv *env = get_jnienv ();
+	jstring NetworkInterface_nameArg = (*env)->NewStringUTF (env, ifname);
+	jobject networkInterface = (*env)->CallStaticObjectMethod (env, NetworkInterface_class, NetworkInterface_getByName, NetworkInterface_nameArg);
+	(*env)->DeleteLocalRef (env, NetworkInterface_nameArg);
+
+	if (!networkInterface) {
+		log_warn (LOG_NET, "Failed to look up interface '%s' using Java API", ifname);
+		ret = FALSE;
+		goto leave;
+	}
+
+	if (is_up) {
+		if (!NetworkInterface_isUp) {
+			log_warn (LOG_NET, "Failed to find the 'java.net.NetworkInterface.isUp' function. Unable to determine interface operational state");
+			ret = FALSE;
+		} else
+			*is_up = (mono_bool)(*env)->CallBooleanMethod (env, networkInterface, NetworkInterface_isUp);
+	}
+
+	if (supports_multicast) {
+		if (!NetworkInterface_supportsMulticast) {
+			log_warn (LOG_NET, "Failed to find the 'java.net.NetworkInterface.supportsMulticast' function. Unable to determine whether interface supports multicast");
+			ret = FALSE;
+		} else
+			*supports_multicast = (mono_bool)(*env)->CallBooleanMethod (env, networkInterface, NetworkInterface_supportsMulticast);
+	}
+
+  leave:
+	if (!ret)
+		log_warn (LOG_NET, "Unable to determine interface '%s' state using Java API", ifname);
+	return ret;
+}
+
+/* !DO NOT REMOVE! Used by Mono BCL (System.Net.NetworkInformation.NetworkInterface) */
+MONO_API mono_bool
+_monodroid_get_network_interface_up_state (const char *ifname, mono_bool *is_up)
+{
+	return _monodroid_get_network_interface_state (ifname, is_up, NULL);
+}
+
+/* !DO NOT REMOVE! Used by Mono BCL (System.Net.NetworkInformation.NetworkInterface) */
+MONO_API mono_bool
+_monodroid_get_network_interface_supports_multicast (const char *ifname, mono_bool *supports_multicast)
+{
+	return _monodroid_get_network_interface_state (ifname, NULL, supports_multicast);
+}


### PR DESCRIPTION
With Android 7.0 (Nougat) it is no longer possible to read some
information about network interfaces from the /sys filesystem. Google
placed restrictions on two files used by the Mono BCL to read
information about the interface:

  /sys/class/net/[DEVICE]/flags
  /sys/class/net/[DEVICE]/operstate

The information we used to read from `flags` let us determine whether
the interface supports multicast and the `operstate` file provided us
with detailed information on the current device state.

Additionally, it is now impossible to read the hardware MAC address used
by any interface. This bit of information is also unavailable when using
the Java APIs and therefore applications running on devices with API
24 (and possibly newer) will not be able to access this information.

More details about the issue are available from the upstream Android
bug:

  https://code.google.com/p/android/issues/detail?id=205565

In order to obtain the required information, we now need to use the Java
APIs on devices with API 24+ and this commit implements the backend to
retrieve this information. It is done in C in order to avoid overhead of
creating mirror .NET objects when calling Java, thus saving time and
memory during an operation which may be performed by some applications
quite frequently.

Part of fix for https://bugzilla.xamarin.com/show_bug.cgi?id=44296