### PR TITLE
Assign class fields properly

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidHttpResponseMessage.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidHttpResponseMessage.cs
@@ -31,9 +31,10 @@ namespace Xamarin.Android.Net
 		public AndroidHttpResponseMessage ()
 		{}
 
-		public AndroidHttpResponseMessage (URL javaUrl, HttpURLConnection httpConnection) {
-			javaUrl = javaUrl;
-			httpConnection = httpConnection;
+		public AndroidHttpResponseMessage (URL javaUrl, HttpURLConnection httpConnection) 
+		{
+			this.javaUrl = javaUrl;
+			this.httpConnection = httpConnection;
 		}
 
 		protected override void Dispose (bool disposing)


### PR DESCRIPTION
Code failed to assign the class fields from constructor parameters. Make
sure the fields are assigned to properly.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=45311