### PR TITLE
[Xamarin.Android.Build.Tasks] Error executing task ResolveAssemblyReference: Path is empty building certain projects on master

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -76,7 +76,7 @@ namespace Xamarin.Android.Tasks
 					if (assemblyDef == null)
 						throw new InvalidOperationException ("Failed to load assembly " + assembly.ItemSpec);
 					topAssemblyReferences.Add (assemblyDef);
-					assemblies.Add (assemblyDef.MainModule.FullyQualifiedName);
+					assemblies.Add (Path.GetFullPath (assemblyDef.MainModule.FullyQualifiedName));
 				}
 			} catch (Exception ex) {
 				Log.LogError ("Exception while loading assemblies: {0}", ex);


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=44528

Something changed between C6 and the current master of xbuild or mono.
Before adding a reference like so

	<Reference Include="Foo.dll" />

used to work without any issues. Now we get the following

	Error executing task ResolveAssemblyReference: Path is empty

This is because xbuild seems to interogate the path from the reference
and it gets an empty string. But apprarently this is a problem.

This commit adds a call to Path.GetFullPath when resolving the assemblies
to work around this problem.