### PR TITLE
[Xamarin.Android.Build.Task]: Add linker support to select the TLS Provider

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
@@ -89,6 +89,7 @@ namespace MonoDroid.Tuner
 				new RemoveAttributes (),
 				new PreserveDynamicTypes (),
 				new PreserveHttpAndroidClientHandler { HttpClientHandlerType = options.HttpClientHandlerType },
+				new PreserveTlsProvider { TlsProviderType = options.TlsProviderType },
 				new PreserveSoapHttpClients (),
 				new PreserveTypeConverters (),
 				new PreserveLinqExpressions (),

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/LinkerOptions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/LinkerOptions.cs
@@ -21,5 +21,6 @@ namespace MonoDroid.Tuner
 		public string ProguardConfiguration { get; set; }
 		public bool DumpDependencies { get; set; }
 		public string HttpClientHandlerType { get; set; }
+		public string TlsProviderType { get; set; }
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/PreserveTlsProvider.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/PreserveTlsProvider.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Mono.Tuner;
+
+namespace MonoDroid.Tuner
+{
+	public class PreserveTlsProvider : BaseSubStep
+	{
+		public string TlsProviderType { get; set; }
+
+		public override bool IsActiveFor (Mono.Cecil.AssemblyDefinition assembly)
+		{
+			return TlsProviderType != null && (assembly.Name.Name == "System" || assembly.Name.Name == "Mono.Android");
+		}
+
+		public override SubStepTargets Targets {
+			get { return SubStepTargets.Method; }
+		}
+
+		public override void ProcessMethod (MethodDefinition method)
+		{
+			if (method.Name == "CreateDefaultProviderImpl" && method.DeclaringType.FullName == "Mono.Net.Security.MonoTlsProviderFactory")
+				ProcessCreateProviderImpl (method);
+		}
+
+		protected AssemblyDefinition GetAssembly (string assemblyName)
+		{
+			AssemblyDefinition ad;
+			context.TryGetLinkedAssembly (assemblyName, out ad);
+			return ad;
+		}
+
+		protected TypeDefinition GetType (AssemblyDefinition assembly, string typeName)
+		{
+			return assembly.MainModule.GetType (typeName);
+		}
+
+		protected TypeDefinition GetType (string assemblyName, string typeName)
+		{
+			AssemblyDefinition ad = GetAssembly (assemblyName);
+			return ad == null ? null : GetType (ad, typeName);
+		}
+
+		bool MarkType (string assemblyName, string typeName)
+		{
+			var type = GetType (assemblyName, typeName);
+			if (type != null) {
+				context.Annotations.Mark (type);
+				context.Annotations.SetPreserve (type, Mono.Linker.TypePreserve.All);
+				return true;
+			}
+			return false;
+		}
+
+		string GetAssemblyNameFromTypeName (string typeName, out string simpleTypeName)
+		{
+			simpleTypeName = null;
+			var parts = typeName.Split (new char [] { ',' }, 2);
+			if (parts.Length != 2)
+				return null;
+
+			var anr = AssemblyNameReference.Parse (parts [1].Trim ());
+			if (anr == null)
+				return null;
+
+			simpleTypeName = parts [0].Trim ();
+			return anr.Name;
+		}
+
+		TypeDefinition GetTlsProvider (ModuleDefinition module)
+		{
+			string provider;
+			if (string.IsNullOrEmpty (TlsProviderType))
+				provider = "default";
+			else
+				provider = TlsProviderType;
+
+			TypeDefinition type;
+			switch (provider) {
+			case "btls":
+				type = module.GetType ("Mono.Btls.MonoBtlsProvider");
+				break;
+			case "legacy":
+			case "default":
+				type = module.GetType ("Mono.Net.Security.LegacyTlsProvider");
+				break;
+			default:
+				throw new InvalidOperationException (string.Format ("Unknown TlsProvider `{0}`.", provider));
+			}
+			if (type == null)
+				throw new InvalidOperationException (string.Format ("Cannot load TlsProvider `{0}`.", provider));
+			return type;
+		}
+
+		MethodDefinition FindDefaultCtor (TypeDefinition type)
+		{
+			foreach (var m in type.Methods) {
+				if (m.IsStatic || !m.IsConstructor || m.HasParameters)
+					continue;
+				return m;
+			}
+			return null;
+		}
+
+		MethodReference FindProviderConstructor (ModuleDefinition module)
+		{
+			var providerType = GetTlsProvider (module);
+			if (providerType == null)
+				return null;
+
+			var ctor = FindDefaultCtor (providerType);
+			if (ctor == null)
+				throw new InvalidOperationException ();
+
+			return module.ImportReference (ctor);
+		}
+
+		void ProcessCreateProviderImpl (MethodDefinition method)
+		{
+			var providerCtor = FindProviderConstructor (method.Module);
+			if (providerCtor == null)
+				return;
+
+			// re-write MonoTlsProviderFactory.CreateDefaultProviderImpl()
+			var body = new MethodBody (method);
+			var il = body.GetILProcessor ();
+			if (providerCtor != null)
+				il.Emit (OpCodes.Newobj, providerCtor);
+			else
+				il.Emit (OpCodes.Ldnull);
+			il.Emit (OpCodes.Ret);
+			method.Body = body;
+		}
+	}
+}
+

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
@@ -46,6 +46,8 @@ namespace Xamarin.Android.Tasks
 
 		public string HttpClientHandlerType { get; set; }
 
+		public string TlsProviderType { get; set; }
+
 		IEnumerable<AssemblyDefinition> GetRetainAssemblies (DirectoryAssemblyResolver res)
 		{
 			List<AssemblyDefinition> retainList = null;
@@ -77,6 +79,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  DumpDependencies: {0}", DumpDependencies);
 			Log.LogDebugMessage ("  LinkOnlyNewerThan: {0}", LinkOnlyNewerThan);
 			Log.LogDebugMessage ("  HttpClientHandlerType: {0}", HttpClientHandlerType);
+			Log.LogDebugMessage ("  TlsProviderType: {0}", TlsProviderType);
 
 			var rp = new ReaderParameters {
 				InMemory    = true,
@@ -108,6 +111,7 @@ namespace Xamarin.Android.Tasks
 				options.RetainAssemblies = GetRetainAssemblies (res);
 			options.DumpDependencies = DumpDependencies;
 			options.HttpClientHandlerType = HttpClientHandlerType;
+			options.TlsProviderType = TlsProviderType;
 			
 			var skiplist = new List<string> ();
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -530,6 +530,7 @@
     </Compile>
     <Compile Include="Utilities\Profile.cs" />
     <None Include="Xamarin.Android.Build.Tasks.targets" />
+    <Compile Include="Linker\MonoDroid.Tuner\PreserveTlsProvider.cs" />
   </ItemGroup>
   <!-- MD doesn't handle MSBuildToolsPath yet
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1584,7 +1584,8 @@ because xbuild doesn't support framework reference assemblies.
       EnableProguard="$(AndroidEnableProguard)"
       DumpDependencies="$(LinkerDumpDependencies)"
       ResolvedAssemblies="@(ResolvedAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
-      HttpClientHandlerType="$(AndroidHttpClientHandlerType)" />
+      HttpClientHandlerType="$(AndroidHttpClientHandlerType)"
+      TlsProviderType="$(AndroidTlsProviderType)" />
 
     <!-- We have to use a flag instead of normal outputs because linking can delete unused assemblies -->
     <Touch Files="$(_AndroidLinkFlag)" AlwaysCreate="true" />


### PR DESCRIPTION

* Bump Mono to mono-4.8.0-branch commit 90699022b6fed7fd273ba3379a2e3696bbd8956f.

* Add new PreserveTlsProvider step, which rewrites MonoTlsProviderFactory.CreateDefaultProviderImpl()
  to only include the selected TLS Provider.

* Added 'TlsProviderType' to <LinkAssemblies>.