### PR TITLE
[msbuild] support custom proguard via ProguardToolPath for multidex etc.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Jack.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Jack.cs
@@ -21,6 +21,9 @@ namespace Xamarin.Android.Tasks
 		public string JavaPlatformJackPath { get; set; }
 
 		[Required]
+		public string AndroidSdkDirectory { get; set; }
+
+		[Required]
 		public string [] InputJackFiles { get; set; }
 
 		[Required]
@@ -112,7 +115,7 @@ namespace Xamarin.Android.Tasks
 					// skip invalid lines
 				}
 				var configs = ProguardConfigurationFiles
-					.Replace ("{sdk.dir}", Path.GetDirectoryName (Path.GetDirectoryName (ProguardJarPath)) + Path.DirectorySeparatorChar)
+					.Replace ("{sdk.dir}", AndroidSdkDirectory + Path.DirectorySeparatorChar)
 					.Replace ("{intermediate.common.xamarin}", ProguardCommonXamarinConfiguration)
 					.Replace ("{intermediate.references}", ProguardGeneratedReferenceConfiguration)
 					.Replace ("{intermediate.application}", ProguardGeneratedApplicationConfiguration)

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -742,14 +742,15 @@ because xbuild doesn't support framework reference assemblies.
 		/>
 	</CreateProperty>
 
-	<CreateProperty Value="$(AndroidSdkDirectory)\tools\proguard\lib\proguard.jar">
-		<Output TaskParameter="Value" PropertyName="ProguardJarPath"
-				Condition="'$(ProguardJarPath)' == ''"
-		/>
-	</CreateProperty>
 	<CreateProperty Value="$(AndroidSdkDirectory)\tools\proguard\">
 		<Output TaskParameter="Value" PropertyName="ProguardToolPath"
-				Condition="'$(UseProguard)' == 'True' And '$(ProguardToolPath)' == ''"
+				Condition="'$(ProguardToolPath)' == ''"
+		/>
+	</CreateProperty>
+
+	<CreateProperty Value="$(ProguardToolPath)lib\proguard.jar">
+		<Output TaskParameter="Value" PropertyName="ProguardJarPath"
+				Condition="'$(ProguardJarPath)' == ''"
 		/>
 	</CreateProperty>
 
@@ -1883,6 +1884,7 @@ because xbuild doesn't support framework reference assemblies.
     StubSourceDirectory="$(IntermediateOutputPath)android\src"
     JavaSourceFiles="@(AndroidJavaSource)"
     JavaPlatformJackPath="$(_JavaPlatformJackPath)"
+    AndroidSdkDirectory="$(_AndroidSdkDirectory)"
     InputJackFiles="@(_PreprocessedJavaLibrary)"
     OutputDexDirectory="$(IntermediateOutputPath)android\bin"
     ToolPath="$(JavaToolPath)"
@@ -2021,8 +2023,10 @@ because xbuild doesn't support framework reference assemblies.
   <Proguard
     Condition="'$(AndroidEnableProguard)' == 'True' and '$(_ProguardProjectConfiguration)' != ''"
     ProguardJarPath="$(ProguardJarPath)"
+    AndroidSdkDirectory="$(_AndroidSdkDirectory)"
     JavaToolPath="$(JavaToolPath)"
-    ToolPath="$(ProguardToolPath)"
+    MSBuildRuntimeType="$(MSBuildRuntimeType)"
+    ProguardToolPath="$(ProguardToolPath)"
     ToolExe="$(ProguardToolExe)"
     UseProguard="$(UseProguard)"
     JavaPlatformJarPath="$(JavaPlatformJarPath)"
@@ -2048,6 +2052,8 @@ because xbuild doesn't support framework reference assemblies.
     Condition="'$(AndroidEnableMultiDex)' == 'True' And '$(AndroidCustomMainDexListFile)' == ''"
     ToolPath="$(MainDexClassesToolPath)"
     ToolExe="$(MainDexClassesToolExe)"
+    MSBuildRuntimeType="$(MSBuildRuntimeType)"
+    ProguardHome="$(ProguardToolPath)"
     ClassesOutputDirectory="$(IntermediateOutputPath)android\bin\classes"
     JavaLibraries="@(_JavaLibrariesToCompile)"
     MultiDexMainDexListFile="$(_AndroidMainDexListFile)"


### PR DESCRIPTION
We had ProguardToolPath and it could be used for custom proguard tools,
which should be useful if we want to support Java8 based libraries which
doesn't work with the one in Android SDK. In theory.

In fact, it was not sufficient because proguard is also used by multidex.
To support multidex, we have to generate correct mainDexClasses rules
that should depend on Android SDK path, not proguard.

To support custom proguard, we need PROGUARD_HOME environment variable
in mainDexClasses(.bat). That actually uncovered another issue we had:
we were using ToolTask.EnvironmentOverride which is [Obsolete] and
converts every entry to lowercase, which can work on Windows but not
elsewhere i.e. even if we had PROGUARD_HOME, it became proguard_home(!)
Therefore we use ToolTask.EnvironmentVariables instead from now on.