### PR TITLE
[Mono.Android] Include the Android.Service.Quicksettings.TileState type

### DIFF
--- a/src/Mono.Android/Android.Service.Quicksettings/TileState.cs
+++ b/src/Mono.Android/Android.Service.Quicksettings/TileState.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Android.Service.Quicksettings {
   [Obsolete ("It was incorrectly generated and will be removed in the future version")]
   public enum TileState {

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -193,6 +193,7 @@
     <Compile Include="Android.Runtime\XAPeerMembers.cs" />
     <Compile Include="Android.Runtime\XmlPullParserReader.cs" />
     <Compile Include="Android.Runtime\XmlReaderPullParser.cs" />
+    <Compile Include="Android.Service.Quicksettings\TileState.cs" />
     <Compile Include="Android.Telephony\PhoneNumberUtils.cs" />
     <Compile Include="Android.Telephony\TelephonyManager.cs" />
     <Compile Include="Android.Test\MoreAsserts.cs" />


### PR DESCRIPTION
Commit 25663510 overlooked adding the `TileState` enum type to the
`Mono.Android.dll` build, meaning that the
`Android.Service.Quicksettings.TileState` type wasn't present in the
resulting assembly.

Add the `Android.Service.Quicksettings.TileState` enum to the build.