### PR TITLE
[Xamarin.Android.Build.Tasks] Warning when building Forms app: MSB324 7 Found conflicts between different versions of the same dependent assembly

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -79,6 +79,12 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
 
+  <!-- Do not resolve from the GAC under any circumstances in Mobile -->
+  <PropertyGroup>
+    <AssemblySearchPaths>$([System.String]::Copy('$(AssemblySearchPaths)').Replace('{GAC}',''))</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="'$(MSBuildRuntimeVersion)' != ''">$(AssemblySearchPaths.Split(';'))</AssemblySearchPaths>
+  </PropertyGroup>
+	
   <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <GetReferenceAssemblyPathsDependsOn>_SetLatestTargetFrameworkVersion</GetReferenceAssemblyPathsDependsOn>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -279,6 +279,12 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	</Otherwise>
 </Choose>
 
+<!-- Do not resolve from the GAC under any circumstances in Mobile -->
+<PropertyGroup>
+	<AssemblySearchPaths>$([System.String]::Copy('$(AssemblySearchPaths)').Replace('{GAC}',''))</AssemblySearchPaths>
+	<AssemblySearchPaths Condition="'$(MSBuildRuntimeVersion)' != ''">$(AssemblySearchPaths.Split(';'))</AssemblySearchPaths>
+</PropertyGroup>
+
 <Target Name="_SeparateAppExtensionReferences">
 	<CreateItem Include="@(ProjectReference)" PreserveExistingMetadata="true" Condition="'%(Identity)' != '' AND '%(ProjectReference.IsAppExtension)' == 'true'">
 		<Output ItemName="_AppExtensionReference" TaskParameter="Include" />
@@ -2126,6 +2132,7 @@ because xbuild doesn't support framework reference assemblies.
   <ResolveAssemblyReference
       AllowedAssemblyExtensions="$(AllowedReferenceAssemblyFileExtensions)"
       AssemblyFiles="@(ResolvedUserAssemblies)"
+      AutoUnify="True"
       FindDependencies="True"
       FindRelatedFiles="False"
       FindSatellites="True"


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=44193

Recent changes to support .Net Standard resulted in builds
producing the following warnings

C:\Program Files (x86)\MSBuild\Xamarin\Android\Xamarin.Android.Common.targets(2113,3): warning MSB3247: Found conflicts between different versions of the same dependent assembly. In Visual Studio, double-click this warning (or select it and press Enter) to fix the conflicts; otherwise, add the following binding redirects to the "runtime" node in the application configuration file:   (MSB3247)

This is a result of Facade assemblies having different (lower)
version numbers to the ones which are used in the final app. It also
effects situations where the assemblies are picked out of the GAC rather
than the local framework directory (Mandroid/vX.0).

This commit adds code similar to what is used in the iOS/Mac
projects (xamarin-macios/3fcb2ed8) to remove the GAC search from the
search path for assemblies. This will ensure that we never pick out
a reference from the GAC for Android based projects.

It also adds the AutoUnify property to the ResolveAssemblyReferences
task to get rid of the warning when resolving _ResolveSatellitePaths.