### PR TITLE
[Xamarin.Android.Build.Tasks] Seeing new AAPT0000 errors when building certain projects against master

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -368,7 +368,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
    AndroidNdkDirectory="$(_AndroidNdkDirectory)"
    Assemblies="@(ReferencePath);@(ReferenceDependencyPaths)"
    CacheFile="$(_AndroidResourcePathsCache)"
-   Condition=" '$(DesignTimeBuild)' != 'true' "
+   Condition=" '$(DesignTimeBuild)' == 'false' Or '$(DesignTimeBuild)' == '' "
   />
 </Target>
 


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=45137

This is a weird bug. When building from the commandline using
xbuild/msbuild or from VS the system behaves as it should do.
But when building from XS it seems the DesignTimeBuild value
is being reset to ''. This results in the required target
GetAdditionalResourcesFromAssemblies from being run when it should,
which results in the following errors

	error APT0000: No resource identifier found for attribute 'foo.foo'

This commit is part of another one which will be included in the
monodroid repo. It alters the condition of for the GetAdditionalResourcesFromAssemblies
target to let it run when $(DesignTimeBuild) is 'false' or ''.
Which means it will not run when the IDE's pass $(DesignTimeBuild) = 'true'
(which they currently do).