### PR TITLE
[monodroid] Build the host libmono-android* files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ prepare-external:
 	nuget restore $(SOLUTION)
 	nuget restore Xamarin.Android-Tests.sln
 	(cd $(call GetPath,JavaInterop) && nuget restore)
+	(cd $(call GetPath,JavaInterop) && make bin/BuildDebug/JdkInfo.props)
 
 prepare-props:
 	cp Configuration.Java.Interop.Override.props external/Java.Interop/Configuration.Override.props

--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -97,8 +97,11 @@
   <ItemGroup>
     <_AndroidMxeOutput Include="@(_AndroidMxeToolchain->'$(AndroidMxeFullPath)\bin\%(Identity)-gcc')" />
     <_AndroidMxeOutput Include="@(_AndroidMxeToolchain->'$(AndroidMxeFullPath)\bin\%(Identity)-cmake')" />
-    <_AndroidMxeOutput Include="@(_AndroidMxeToolchain->'$(AndroidMxeFullPath)\%(Identity)\lib\libz.a')" />
+    <_AndroidMxeOutput Include="@(_AndroidMxeToolchain->'$(AndroidMxeFullPath)\%(Identity)\include\dlfcn.h')" />
+    <_AndroidMxeOutput Include="@(_AndroidMxeToolchain->'$(AndroidMxeFullPath)\%(Identity)\include\pthread.h')" />
+    <_AndroidMxeOutput Include="@(_AndroidMxeToolchain->'$(AndroidMxeFullPath)\%(Identity)\include\sys\mman.h')" />
     <_AndroidMxeOutput Include="@(_AndroidMxeToolchain->'$(AndroidMxeFullPath)\%(Identity)\include\zlib.h')" />
+    <_AndroidMxeOutput Include="@(_AndroidMxeToolchain->'$(AndroidMxeFullPath)\%(Identity)\lib\libz.a')" />
   </ItemGroup>
   <Target Name="_CreateMxeToolchains"
       DependsOnTargets="_SetMxeToolchainMakefileTimeToLastCommitTimestamp"
@@ -107,13 +110,14 @@
       Outputs="@(_AndroidMxeOutput)">
     <Exec
         Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:'))"
-        Command="make $(MAKEFLAGS) MXE_TARGETS=&quot;$(MingwCommandPrefix32)&quot; gcc cmake zlib PREFIX=&quot;$(AndroidMxeFullPath)&quot;"
+        Command="make $(MAKEFLAGS) MXE_TARGETS=&quot;$(MingwCommandPrefix32)&quot; gcc cmake zlib pthreads dlfcn-win32 mman-win32 PREFIX=&quot;$(AndroidMxeFullPath)&quot;"
         WorkingDirectory="..\..\external\mxe"
     />
     <Exec
         Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))"
-        Command="make $(MAKEFLAGS) MXE_TARGETS=&quot;$(MingwCommandPrefix64)&quot; gcc cmake zlib PREFIX=&quot;$(AndroidMxeFullPath)&quot;"
+        Command="make $(MAKEFLAGS) MXE_TARGETS=&quot;$(MingwCommandPrefix64)&quot; gcc cmake zlib pthreads dlfcn-win32 mman-win32 PREFIX=&quot;$(AndroidMxeFullPath)&quot;"
         WorkingDirectory="..\..\external\mxe"
     />
+    <Touch Files="@(_AndroidMxeOutput)" />
   </Target>
 </Project>

--- a/src/monodroid/jni/Android.mk
+++ b/src/monodroid/jni/Android.mk
@@ -62,19 +62,6 @@ LOCAL_SRC_FILES := \
 	cpu-arch-detect.c \
 	monodroid-networkinfo.c
 
-jni/monodroid-glue.c: jni/config.include jni/machine.config.include
-
-$(LOCAL_PATH)/machine.config.include: $(LOCAL_PATH)/../machine.config.xml
-	(cat $< ; dd if=/dev/zero bs=1 count=1 2>/dev/null) > monodroid.machine.config
-	xxd -i monodroid.machine.config | sed 's/^unsigned /static const unsigned /g' > jni/machine.config.include
-	rm monodroid.machine.config
-
-$(LOCAL_PATH)/config.include: $(LOCAL_PATH)/../config.xml
-	(cat $< ; dd if=/dev/zero bs=1 count=1 2>/dev/null) > monodroid.config
-	xxd -i monodroid.config | sed 's/^unsigned /static const unsigned /g' > jni/config.include
-	rm monodroid.config
-
-
 include $(BUILD_SHARED_LIBRARY)
 
 

--- a/src/monodroid/monodroid.projitems
+++ b/src/monodroid/monodroid.projitems
@@ -3,4 +3,36 @@
   <ItemGroup>
     <RequiredProgram Include="xxd" />
   </ItemGroup>
+  <ItemGroup>
+    <_HostRuntime Include="host-Darwin" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">
+      <Cc>$(HostCc)</Cc>
+      <CFlags>$(_HostUnixCFlags) $(_HostDarwinCFlags) -DAPPLE_OS_X</CFlags>
+      <LdFlags>$(_HostUnixLdFlags)</LdFlags>
+      <ExtraSource>$(_UnixAdditionalSourceFiles)</ExtraSource>
+      <NativeLibraryExtension>dylib</NativeLibraryExtension>
+      <OutputDirectory>host-Darwin</OutputDirectory>
+      <Strip>strip</Strip>
+      <StripFlags>-S</StripFlags>
+    </_HostRuntime>
+    <_HostRuntime Include="host-Linux" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:'))">
+      <Cc>$(HostCc)</Cc>
+      <CFlags>$(_HostUnixCFlags) $(_HostLinuxCFlags) -D_GNU_SOURCE</CFlags>
+      <LdFlags>$(_HostUnixLdFlags)</LdFlags>
+      <ExtraSource>$(_UnixAdditionalSourceFiles)</ExtraSource>
+      <NativeLibraryExtension>so</NativeLibraryExtension>
+      <OutputDirectory>host-Linux</OutputDirectory>
+      <Strip>strip</Strip>
+      <StripFlags>-S</StripFlags>
+    </_HostRuntime>
+    <_HostRuntime Include="host-win" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+      <Cc>"$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-gcc"</Cc>
+      <CFlags>$(_HostCommonWinCFlags) $(_HostWin64CFlags)</CFlags>
+      <LdFlags>$(_HostCommonWinLdFlags)</LdFlags>
+      <ExtraSource></ExtraSource>
+      <NativeLibraryExtension>dll</NativeLibraryExtension>
+      <OutputDirectory>host-win</OutputDirectory>
+      <Strip>"$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-strip"</Strip>
+      <StripFlags>-S</StripFlags>
+    </_HostRuntime>
+  </ItemGroup>
 </Project>

--- a/src/monodroid/monodroid.props
+++ b/src/monodroid/monodroid.props
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_DebugCFlags>-ggdb3 -O0 -fno-omit-frame-pointer</_DebugCFlags>
+    <_ReleaseCFlags>-g -O2</_ReleaseCFlags>
+    <_CommonCFlags>@(JdkIncludePath->'-I%(Identity)', ' ') -Ijni -Ijni/zip "-I$(MonoSourceFullPath)\eglib\src" -std=c99 -DSGEN_BRIDGE_VERSION=$(MonoSgenBridgeVersion) -D_REENTRANT -DHAVE_CONFIG_H -DMONO_DLL_EXPORT -DJI_DLL_EXPORT -fno-strict-aliasing -ffunction-sections -fvisibility=hidden -Wformat -Werror=format-security</_CommonCFlags>
+    <_HostUnixCFlags>$(_CommonCFlags) -Wa,--noexecstack</_HostUnixCFlags>
+    <_HostUnixLdFlags>-Wall -lstdc++ -lz -shared -fpic</_HostUnixLdFlags>
+    <_HostCommonWinCFlags>$(_CommonCFlags) -DWINDOWS -DNTDDI_VERSION=NTDDI_VISTA -D_WIN32_WINNT=_WIN32_WINNT_VISTA -fomit-frame-pointer</_HostCommonWinCFlags>
+    <_HostCommonWinLdFlags>-Wall -lstdc++ -lz -shared -fpic -ldl -lmman -pthread -lwsock32 -lole32 -luuid</_HostCommonWinLdFlags>
+    <_UnixAdditionalSourceFiles>$(MonoSourceFullPath)\support\nl.c jni\debug.c jni\monodroid-networkinfo.c jni\xamarin_getifaddrs.c</_UnixAdditionalSourceFiles>
+  </PropertyGroup>
+  <PropertyGroup>
+    <_HostDarwinCFlags>-I..\..\bin\$(Configuration)\include\host-Darwin -I..\..\bin\$(Configuration)\include\host-Darwin\eglib</_HostDarwinCFlags>
+    <_HostLinuxCFlags>-I..\..\bin\$(Configuration)\include\host-Linux -I..\..\bin\$(Configuration)\include\host-Linux\eglib</_HostLinuxCFlags>
+    <_HostWin64CFlags>-I..\..\bin\$(Configuration)\include\host-mxe-Win64 -I..\..\bin\$(Configuration)\include\host-mxe-Win64\eglib</_HostWin64CFlags>
+  </PropertyGroup>
+</Project>

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -1,15 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(JavaInteropFullPath)\bin\BuildDebug\JdkInfo.props" />
+  <Import Project="monodroid.props" />
   <Import Project="monodroid.projitems" />
   <Import Project="..\..\build-tools\scripts\RequiredPrograms.targets" />
   <PropertyGroup>
     <_Conf>$(Configuration.ToLowerInvariant())</_Conf>
   </PropertyGroup>
   <ItemGroup>
-    <CFiles Include="jni\**\*.c" />
+    <_CFile Include="$(MonoSourceFullPath)\support\zlib-helper.c" />
+    <_CFile Include="jni\cpu-arch-detect.c" />
+    <_CFile Include="jni\dylib-mono.c" />
+    <_CFile Include="jni\embedded-assemblies.c" />
+    <_CFile Include="jni\jni.c" />
+    <_CFile Include="jni\logger.c" />
+    <_CFile Include="jni\monodroid-glue.c" />
+    <_CFile Include="jni\timezones.c" />
+    <_CFile Include="jni\util.c" />
+    <_CFile Include="jni\zip\ioapi.c" />
+    <_CFile Include="jni\zip\unzip.c" />
+  </ItemGroup>
+  <!-- These are referenced in %(_HostRuntime.ExtraSource) -->
+  <ItemGroup>
+    <_UnixCFile Include="$(MonoSourceFullPath)\support\nl.c" />
+    <_UnixCFile Include="jni\debug.c" />
+    <_UnixCFile Include="jni\monodroid-networkinfo.c" />
+    <_UnixCFile Include="jni\xamarin_getifaddrs.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <_EmbeddedBlob Include="config.xml">
+      <Config>monodroid.config</Config>
+      <Include>config.include</Include>
+    </_EmbeddedBlob>
+    <_EmbeddedBlob Include="machine.config.xml">
+      <Config>monodroid.machine.config</Config>
+      <Include>machine.config.include</Include>
+    </_EmbeddedBlob>
   </ItemGroup>
   <Target Name="_BuildRuntimes"
-      Inputs="@(CFiles);jni\Android.mk"
+      DependsOnTargets="_GenerateIncludeFiles;_BuildAndroidRuntimes;_BuildHostRuntimes">
+  </Target>
+  <Target Name="_GenerateIncludeFiles"
+      Inputs="@(_EmbeddedBlob)"
+      Outputs="@(_EmbeddedBlob->'jni\%(Include)')">
+    <Exec Command="(cat &quot;@(_EmbeddedBlob)&quot; ; dd if=/dev/zero bs=1 count=1 2>/dev/null) > %(_EmbeddedBlob.Config)" />
+    <Exec Command="xxd -i %(_EmbeddedBlob.Config) | sed 's/^unsigned /static const unsigned /g' > jni/%(_EmbeddedBlob.Include)" />
+    <Exec Command="rm %(_EmbeddedBlob.Config)" />
+  </Target>
+  <Target Name="_BuildAndroidRuntimes"
+      Inputs="@(_CFile);jni\Android.mk"
       Outputs="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.so')">
     <PropertyGroup>
       <_AppAbi>@(AndroidSupportedTargetJitAbi->'%(Identity)', ' ')</_AppAbi>
@@ -44,6 +83,7 @@
     />
   </Target>
   <Target Name="_CleanRuntimes"
+      DependsOnTargets="_GetBuildHostRuntimes"
       AfterTargets="Clean">
     <Exec
         Command="$(AndroidToolchainDirectory)\ndk\ndk-build $(_NdkBuildArgs) NDK_LIBS_OUT=./libs/Debug NDK_OUT=./obj/Debug  V=1 clean"
@@ -57,5 +97,44 @@
     <Delete Files="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.d.so')" />
     <Delete Files="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.so')" />
     <Delete Files="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.d.so')" />
+    <Delete Files="%(_EmbeddedBlob.Include)" />
+    <Delete
+        Files="@(_OutputDebugPath);@(_OutputDebugStripPath);@(_OutputReleasePath);@(_OutputReleaseStripPath)"
+    />
+  </Target>
+  <Target Name="_GetBuildHostRuntimes">
+    <ItemGroup>
+      <_OutputDebugPath         Include="$(OutputPath)%(_HostRuntime.OutputDirectory)\%(_HostRuntime.OutputBasename).debug.d.%(_HostRuntime.NativeLibraryExtension)" />
+      <_OutputDebugStripPath    Include="$(OutputPath)%(_HostRuntime.OutputDirectory)\%(_HostRuntime.OutputBasename).debug.%(_HostRuntime.NativeLibraryExtension)" />
+      <_OutputReleasePath       Include="$(OutputPath)%(_HostRuntime.OutputDirectory)\%(_HostRuntime.OutputBasename).release.d.%(_HostRuntime.NativeLibraryExtension)" />
+      <_OutputReleaseStripPath  Include="$(OutputPath)%(_HostRuntime.OutputDirectory)\%(_HostRuntime.OutputBasename).release.%(_HostRuntime.NativeLibraryExtension)" />
+    </ItemGroup>
+  </Target>
+  <Target Name="_BuildHostRuntimes"
+      DependsOnTargets="_GetBuildHostRuntimes"
+      Inputs="@(_CFile);@(_UnixCFile)"
+      Outputs="@(_HostRuntime->'$(OutputPath)%(OutputDirectory)\libmono-android.debug.%(NativeLibraryExtension)')">
+    <MakeDir Directories="%(_HostRuntime.OutputPath)" />
+    <Exec
+        Command="%(_HostRuntime.Cc) -o &quot;$(OutputPath)%(_HostRuntime.OutputDirectory)\libmono-android.debug.%(_HostRuntime.NativeLibraryExtension)&quot; $(_DebugCFlags) %(_HostRuntime.CFlags) @(_CFile->'%(Identity)', ' ') %(_HostRuntime.ExtraSource) %(_HostRuntime.LdFlags)"
+    />
+    <Copy
+        SourceFiles="@(_HostRuntime->'$(OutputPath)%(OutputDirectory)\libmono-android.debug.%(NativeLibraryExtension)')"
+        DestinationFiles="@(_HostRuntime->'$(OutputPath)%(OutputDirectory)\libmono-android.debug.d.%(NativeLibraryExtension)')"
+    />
+    <Exec
+        Command="%(_HostRuntime.Strip) %(_HostRuntime.StripFlags) &quot;$(OutputPath)%(_HostRuntime.OutputDirectory)\libmono-android.debug.%(_HostRuntime.NativeLibraryExtension)&quot;"
+    />
+
+    <Exec
+        Command="%(_HostRuntime.Cc) -o &quot;$(OutputPath)%(_HostRuntime.OutputDirectory)\libmono-android.release.%(_HostRuntime.NativeLibraryExtension)&quot; $(_ReleaseCFlags) %(_HostRuntime.CFlags) @(_CFile->'%(Identity)', ' ') %(_HostRuntime.ExtraSource) %(_HostRuntime.LdFlags)"
+    />
+    <Copy
+        SourceFiles="@(_HostRuntime->'$(OutputPath)%(OutputDirectory)\libmono-android.release.%(NativeLibraryExtension)')"
+        DestinationFiles="@(_HostRuntime->'$(OutputPath)%(OutputDirectory)\libmono-android.release.d.%(NativeLibraryExtension)')"
+    />
+    <Exec
+        Command="%(_HostRuntime.Strip) %(_HostRuntime.StripFlags) &quot;$(OutputPath)%(_HostRuntime.OutputDirectory)\libmono-android.release.%(_HostRuntime.NativeLibraryExtension)&quot;"
+    />
   </Target>
 </Project>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/269#issuecomment-254540565

Various features such as the Xamarin Studio Android Designer require a
`libmono-android.debug.dylib` file, built for the *host* OS, not for
an Android  target device.

Add build system support to build `libmono-android.*` for the host OS,
including an MXE-cross-compiled Windows host version.