### PR TITLE
[monodroid] Search for libraries in `/app/lib/mono`

### DIFF
--- a/src/monodroid/jni/monodroid-glue.c
+++ b/src/monodroid/jni/monodroid-glue.c
@@ -95,6 +95,8 @@ static int android_api_level = 0;
 #define SYSTEM_LIB_PATH "/system/lib64"
 #elif ANDROID
 #define SYSTEM_LIB_PATH "/system/lib"
+#elif LINUX_FLATPAK
+#define SYSTEM_LIB_PATH "/app/lib/mono"
 #elif LINUX
 #define SYSTEM_LIB_PATH "/usr/lib"
 #elif APPLE_OS_X

--- a/src/monodroid/monodroid.projitems
+++ b/src/monodroid/monodroid.projitems
@@ -26,7 +26,7 @@
     </_HostRuntime>
     <_HostRuntime Include="host-win" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Cc>"$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-gcc"</Cc>
-      <CFlags>$(_HostCommonWinCFlags) $(_HostWin64CFlags)</CFlags>
+      <CFlags>$(_HostCommonWinCFlags) $(_HostWin64CFlags) $(_LinuxFlatPakBuild)</CFlags>
       <LdFlags>$(_HostCommonWinLdFlags)</LdFlags>
       <ExtraSource></ExtraSource>
       <NativeLibraryExtension>dll</NativeLibraryExtension>

--- a/src/monodroid/monodroid.props
+++ b/src/monodroid/monodroid.props
@@ -9,6 +9,7 @@
     <_HostCommonWinCFlags>$(_CommonCFlags) -DWINDOWS -DNTDDI_VERSION=NTDDI_VISTA -D_WIN32_WINNT=_WIN32_WINNT_VISTA -fomit-frame-pointer</_HostCommonWinCFlags>
     <_HostCommonWinLdFlags>-Wall -lstdc++ -lz -shared -fpic -ldl -lmman -pthread -lwsock32 -lole32 -luuid</_HostCommonWinLdFlags>
     <_UnixAdditionalSourceFiles>$(MonoSourceFullPath)\support\nl.c jni\debug.c jni\monodroid-networkinfo.c jni\xamarin_getifaddrs.c</_UnixAdditionalSourceFiles>
+    <_LinuxFlatPakBuild Condition="Exists('/.flatpak-info')" >-DLINUX_FLATPAK</_LinuxFlatPakBuild>
   </PropertyGroup>
   <PropertyGroup>
     <_HostDarwinCFlags>-I..\..\bin\$(Configuration)\include\host-Darwin -I..\..\bin\$(Configuration)\include\host-Darwin\eglib</_HostDarwinCFlags>


### PR DESCRIPTION
Supersedes: https://github.com/xamarin/xamarin-android/pull/269

When running within a Linux FlatPak runtime environment, native
libraries such as `libmonosgen-2.0.so` and `libmonodroid.so` should be
searched for within `/app/lib/mono`.