### PR TITLE
[Xamarin.Android.Build.Tasks] ResolveAssemblies & Path.GetFullPath()

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -129,7 +129,7 @@ namespace Xamarin.Android.Tasks
 			indent += 2;
 			// Add this assembly
 			if (!topLevel && assemblies.All (a => new AssemblyNameDefinition (a, null).Name != assembly.Name.Name))
-				assemblies.Add (fqname);
+				assemblies.Add (Path.GetFullPath (fqname));
 
 			// Recurse into each referenced assembly
 			foreach (AssemblyNameReference reference in assembly.MainModule.AssemblyReferences) {
@@ -181,7 +181,7 @@ namespace Xamarin.Android.Tasks
 		string ResolveI18nAssembly (DirectoryAssemblyResolver resolver, string name)
 		{
 			var assembly = resolver.Resolve (AssemblyNameReference.Parse (name));
-			return assembly.MainModule.FullyQualifiedName;
+			return Path.GetFullPath (assembly.MainModule.FullyQualifiedName);
 		}
 	}
 }


### PR DESCRIPTION
It is very important that the `<ResolveAssemblies/>` task *not* return
duplicate assembly names. Unfortunately, this can occasionally happen,
because paths aren't always canonicalized:

	Task "ResolveAssemblies"
		Assemblies:
		  .../lib/xbuild-frameworks/MonoAndroid/v1.0/Java.Interop.dll
		  .../lib/xbuild-frameworks/MonoAndroid/v1.0//Facades/System.Runtime.dll
	...
		[Output] ResolvedAssemblies
		  .../lib/xbuild-frameworks/MonoAndroid/v1.0/Facades/System.Runtime.dll
		  .../lib/xbuild-frameworks/MonoAndroid/v1.0//Facades/System.Runtime.dll

The paths aren't canonicalized, resulting in *two*
`System.Runtime.dll` entries, which can cause issues later.

Fix the `<ResolveAssemblies/>` task to Use `Path.GetFullPath()` to
canonicalize all paths returned from the task.