### PR TITLE
[Xamarin.Android.Build.Tasks] Use `TlsProvider` consistently

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
@@ -89,7 +89,7 @@ namespace MonoDroid.Tuner
 				new RemoveAttributes (),
 				new PreserveDynamicTypes (),
 				new PreserveHttpAndroidClientHandler { HttpClientHandlerType = options.HttpClientHandlerType },
-				new PreserveTlsProvider { TlsProviderType = options.TlsProviderType },
+				new PreserveTlsProvider { TlsProvider = options.TlsProvider },
 				new PreserveSoapHttpClients (),
 				new PreserveTypeConverters (),
 				new PreserveLinqExpressions (),

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/LinkerOptions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/LinkerOptions.cs
@@ -21,6 +21,6 @@ namespace MonoDroid.Tuner
 		public string ProguardConfiguration { get; set; }
 		public bool DumpDependencies { get; set; }
 		public string HttpClientHandlerType { get; set; }
-		public string TlsProviderType { get; set; }
+		public string TlsProvider { get; set; }
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/PreserveTlsProvider.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/PreserveTlsProvider.cs
@@ -7,11 +7,11 @@ namespace MonoDroid.Tuner
 {
 	public class PreserveTlsProvider : BaseSubStep
 	{
-		public string TlsProviderType { get; set; }
+		public string TlsProvider { get; set; }
 
 		public override bool IsActiveFor (AssemblyDefinition assembly)
 		{
-			return TlsProviderType != null && assembly.Name.Name == "System";
+			return TlsProvider != null && assembly.Name.Name == "System";
 		}
 
 		public override SubStepTargets Targets {
@@ -27,10 +27,10 @@ namespace MonoDroid.Tuner
 		TypeDefinition GetTlsProvider (ModuleDefinition module)
 		{
 			string provider;
-			if (string.IsNullOrEmpty (TlsProviderType))
+			if (string.IsNullOrEmpty (TlsProvider))
 				provider = "default";
 			else
-				provider = TlsProviderType;
+				provider = TlsProvider;
 
 			TypeDefinition type;
 			switch (provider) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Android.Tasks
 
 		public string HttpClientHandlerType { get; set; }
 
-		public string TlsProviderType { get; set; }
+		public string TlsProvider { get; set; }
 
 		IEnumerable<AssemblyDefinition> GetRetainAssemblies (DirectoryAssemblyResolver res)
 		{
@@ -79,7 +79,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  DumpDependencies: {0}", DumpDependencies);
 			Log.LogDebugMessage ("  LinkOnlyNewerThan: {0}", LinkOnlyNewerThan);
 			Log.LogDebugMessage ("  HttpClientHandlerType: {0}", HttpClientHandlerType);
-			Log.LogDebugMessage ("  TlsProviderType: {0}", TlsProviderType);
+			Log.LogDebugMessage ("  TlsProvider: {0}", TlsProvider);
 
 			var rp = new ReaderParameters {
 				InMemory    = true,
@@ -111,7 +111,7 @@ namespace Xamarin.Android.Tasks
 				options.RetainAssemblies = GetRetainAssemblies (res);
 			options.DumpDependencies = DumpDependencies;
 			options.HttpClientHandlerType = HttpClientHandlerType;
-			options.TlsProviderType = TlsProviderType;
+			options.TlsProvider = TlsProvider;
 			
 			var skiplist = new List<string> ();
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1592,7 +1592,7 @@ because xbuild doesn't support framework reference assemblies.
       DumpDependencies="$(LinkerDumpDependencies)"
       ResolvedAssemblies="@(ResolvedAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
       HttpClientHandlerType="$(AndroidHttpClientHandlerType)"
-      TlsProviderType="$(AndroidTlsProviderType)" />
+      TlsProvider="$(AndroidTlsProvider)" />
 
     <!-- We have to use a flag instead of normal outputs because linking can delete unused assemblies -->
     <Touch Files="$(_AndroidLinkFlag)" AlwaysCreate="true" />


### PR DESCRIPTION
Commit 53bcf69f added `$(AndroidTlsProvider)` and related
`*TlsProvider` terminology.

Commit bc9d5ad1 added `$(AndroidTlsProviderType)` and related
`*TlsProviderType` terminology.

There's one "minor" problem: these are supposed to be the same
thing: a value to specify which TLS implementation
`System.Net.WebRequest` will use on-device, with values of `btls`,
`legacy`, and `default`.

We need to unify `$(AndroidTlsProvider) and
`$(AndroidTlsProviderType)`.

Next question: what do we unify them *to*? Look again at the possible
values: those are *not* types, at least not in the .NET sense, so a
`Type` suffix is inappropriate. We should thus unify on
`$(AndroidTlsProvider).`

Update `Xamarin.Android.Common.targets` and the various source files
so that `*TlsProviderType` naming is replaced with `*TlsProvider`
naming, allowing things to be more consistent.