### PR TITLE
[Xamarin.Android.Build.Tests] Add Test for AndroidTlsProvider

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -34,6 +34,43 @@ namespace Xamarin.Android.Build.Tests
 										"Nuget Package Xamarin.Android.Support.v4.21.0.3.0 should have been restored.");
 			}
 		}
+
+		static object [] TlsProviderTestCases =
+		{
+			// androidTlsProvider, isRelease, extpected
+			new object[] { "", true, false, },
+			new object[] { "default", true, false, },
+			new object[] { "legacy", true, false, },
+			new object[] { "btls", true, true, }
+		};
+
+
+		[Test]
+		[TestCaseSource ("TlsProviderTestCases")]
+		public void BuildWithTlsProvider (string androidTlsProvider, bool isRelease, bool expected)
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = isRelease,
+			};
+			using (var b = CreateApkBuilder (Path.Combine ("temp", $"BuildWithTlsProvider_{androidTlsProvider}_{isRelease}_{expected}"))) {
+				proj.SetProperty ("AndroidTlsProvider", androidTlsProvider);
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				var apk = Path.Combine(b.ProjectDirectory,
+					proj.IntermediateOutputPath,"android", "bin", "UnnamedProject.UnnamedProject.apk");
+				using (var zipFile = ZipHelper.OpenZip (apk)) {
+					if (expected) {
+						Assert.IsNotNull (ZipHelper.ReadFileFromZip (zipFile,
+						   "lib/armeabi-v7a/libmono-btls-shared.so"),
+						   "lib/armeabi-v7a/libmono-btls-shared.so should exist in the apk.");
+					}
+					else {
+						Assert.IsNull (ZipHelper.ReadFileFromZip (zipFile,
+						   "lib/armeabi-v7a/libmono-btls-shared.so"),
+						   "lib/armeabi-v7a/libmono-btls-shared.so should not exist in the apk.");
+					}
+				}
+			}
+		}
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -37,6 +37,10 @@
     <Reference Include="nunit.framework">
       <HintPath>..\..\..\..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="Ionic.Zip">
+      <HintPath>..\..\..\..\packages\Unofficial.Ionic.Zip.1.9.1.8\lib\Ionic.Zip.dll</HintPath>
+      <Private>False</Private>
+    </Reference>    
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Utilities\BaseTest.cs" />


### PR DESCRIPTION
This commit adds a unit test for the AndroidTlsProvider. It
makes sure that we include/exclude the libmono-btls-shared.so
depending on the setting provided.
