### PR TITLE
[Xamarin.Android.Build.Tasks] Aot task does not aot "shrunk" linked assemblies

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -252,18 +252,22 @@ namespace Xamarin.Android.Tasks
 				// Framework assemblies don't come from outside the SDK Path;
 				// user assemblies do
 				if (checkSdkPath && treatAsUser && TargetFrameworkDirectories != null) {
-					return TargetFrameworkDirectories
-						// TargetFrameworkDirectories will contain a "versioned" directory,
-						// e.g. $prefix/lib/xbuild-frameworks/MonoAndroid/v1.0.
-						// Trim off the version.
-						.Select (p => Path.GetDirectoryName (p.TrimEnd (Path.DirectorySeparatorChar)))
-						.Any (p => assembly.StartsWith (p));
+					return ExistsInFrameworkPath (assembly);
 				}
 #endif
 				return true;
 			}
+			return TargetFrameworkDirectories == null || !checkSdkPath ? false : ExistsInFrameworkPath (assembly);
+		}
 
-			return false;
+		public static bool ExistsInFrameworkPath (string assembly)
+		{
+			return TargetFrameworkDirectories
+					// TargetFrameworkDirectories will contain a "versioned" directory,
+					// e.g. $prefix/lib/xbuild-frameworks/MonoAndroid/v1.0.
+					// Trim off the version.
+					.Select (p => Path.GetDirectoryName (p.TrimEnd (Path.DirectorySeparatorChar)))
+					.Any (p => assembly.StartsWith (p));
 		}
 
 		public static bool IsForceRetainedAssembly (string assembly)

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -19,6 +19,7 @@
     <_SharedRuntimeAssemblies Include="@(MonoProfileAssembly->'$(_SharedRuntimeBuildPath)v1.0\%(Identity)')" />
     <_SharedRuntimeAssemblies Include="$(_SharedRuntimeBuildPath)v1.0\Mono.Data.Sqlite.dll" />
     <_SharedRuntimeAssemblies Include="$(_SharedRuntimeBuildPath)v1.0\Mono.Posix.dll" />
+    <_SharedRuntimeAssemblies Include="$(_SharedRuntimeBuildPath)v1.0\Java.Interop.dll" />
     <_SharedRuntimeAssemblies Include="$(_SharedRuntimeBuildPath)v1.0\System.EnterpriseServices.dll" />
     <_SharedRuntimeAssemblies Include="$(_SharedRuntimeBuildPath)$(AndroidFrameworkVersion)\Mono.Android.Export.dll" />
     <!-- These files are build after Xamarin.Android.Build.Tasks but MUST be included in Profile.g.cs -->

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2201,7 +2201,7 @@ because xbuild doesn't support framework reference assemblies.
 	SupportedAbis="$(_BuildTargetAbis)"
 	AndroidSequencePointsMode="$(_SequencePointsMode)"
 	AotAdditionalArguments="$(AndroidAotAdditionalArguments)"
-	ResolvedAssemblies="@(_ResolvedAssemblies)"
+	ResolvedAssemblies="@(_ResolvedUserAssemblies);@(_ShrunkFrameworkAssemblies)"
 	AotOutputDirectory="$(_AndroidAotBinDirectory)"
 	IntermediateAssemblyDir="$(MonoAndroidIntermediateAssemblyDir)"
 	LinkMode="$(AndroidLinkMode)"


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=32457

The Aot Task was NOT using the stripped assemblies for the AOT process.
This would probably result in code which had been removed being AOT'd.

This bug highlighted a few problems with the current system. Firstly
Java.Interop was NOT part of the SharedRumtime list. As a result it
was being picked up as a UserAssembly not a FrameworkAssembly. This
caused problems during the AoT task when it could not find the
Java.Interop.dll.

Secondly. The AoT Task itself was not making use of the

	@(_ShrunkFrameworkAssemblies)

ItemGroup. This group is updated with the list of framework
assemblies the app is using. Depending on whether the dll's are
shrunk or not this list is the one that contains the final files
that need to be used.

Thirdy there was an issue in the IsFrameworkAssembly Helper method
in MonoAndroidHelper. This issue ment that if an assembly was in one
of the framework directories but NOT in the SharedRuntimeAssemblies list
it would NOT be picked up as a framework assembly. This bug is what
highlighted that fact that Java.Interop was missing in the first place.