### PR TITLE
[Xamarin.Android.Build.Tasks] Add a Fast path for removing fixed directories.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
@@ -54,9 +54,17 @@ namespace Xamarin.Android.Tasks {
 			
 			foreach (ITaskItem directory in directories) {
 				try {
-					MonoAndroidHelper.SetDirectoryWriteable (directory.GetMetadata ("FullPath"));
-					Directory.Delete (directory.GetMetadata ("FullPath"), true);
-					temporaryRemovedDirectories.Add (directory);
+					try {
+						// try to do a normal "fast" delete of the directory.
+						Directory.Delete (directory.GetMetadata ("FullPath"), true);
+						temporaryRemovedDirectories.Add (directory);
+					} catch {
+						// if that fails we probably have readonly files (or locked files)
+						// so try to make them writable and try again.
+						MonoAndroidHelper.SetDirectoryWriteable (directory.GetMetadata ("FullPath"));
+						Directory.Delete (directory.GetMetadata ("FullPath"), true);
+						temporaryRemovedDirectories.Add (directory);
+					}
 				}
 				catch (DirectoryNotFoundException ex) {
 					Log.LogErrorFromException (ex);


### PR DESCRIPTION
Currently we loop through ALL the files in a directory and check
them all to see if they are writeable. What this commit does is
change it so we only do that IF we error the first time we try to
delete the directory.

If we can delete the directory first we just do. If not we make sure
everything is writable, and then of we fail we throw the error as usual.