### PR TITLE
[Xamarin.Android.Build.Tasks] APK environment file does not contain XA_HTTP_CLIENT_HANDLER_TYPE in windows builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -331,24 +331,13 @@ namespace Xamarin.Android.Tasks
 			const string defaultTlsProvider = "XA_TLS_PROVIDER=default";
 			string xamarinBuildId = string.Format ("XAMARIN_BUILD_ID={0}", buildId);
 
-			if (Environments == null) {
-				if (_Debug)
-					environment.WriteLine (defaultLogLevel);
-				if (sequencePointsMode != SequencePointsMode.None)
-					environment.WriteLine (defaultMonoDebug);
-				environment.WriteLine (xamarinBuildId);
-				apk.AddEntry ("environment", environment.ToString(),
-						new UTF8Encoding (encoderShouldEmitUTF8Identifier:false));
-				return;
-			}
-
 			bool haveLogLevel = false;
 			bool haveMonoDebug = false;
 			bool havebuildId = false;
 			bool haveHttpMessageHandler = false;
 			bool haveTlsProvider = false;
 
-			foreach (ITaskItem env in Environments) {
+			foreach (ITaskItem env in Environments ?? new TaskItem[0]) {
 				environment.WriteLine ("## Source File: {0}", env.ItemSpec);
 				foreach (string line in File.ReadLines (env.ItemSpec)) {
 					var lineToWrite = line;


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=44217

There is a slight oversight when we added the code to add the
default XA_HTTP_CLIENT_HANDLER_TYPE. If not environment files
were provided the default that was used did NOT include the
default XA_HTTP_CLIENT_HANDLER_TYPE.

In fact there were two code paths which dealt with defaults.
This commit removes the first code path which checks for a null
Environment array in favour of using the defaults which are added
at the end of the method. This means we maintain the defaults in
on place.