### PR TITLE
[mono-runtimes] DO NOT USE `-ldl` on Windows.

### DIFF
--- a/build-tools/mono-runtimes/mono-runtimes.projitems
+++ b/build-tools/mono-runtimes/mono-runtimes.projitems
@@ -167,7 +167,7 @@
       <Objdump>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-objdump</Objdump>
       <RanLib>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-ranlib</RanLib>
       <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-strip</Strip>
-      <ConfigureFlags>PATH="$PATH:$(AndroidMxeFullPath)\bin" --host=$(MingwCommandPrefix64) --target=$(MingwCommandPrefix64) --disable-boehm --enable-mcs-build=no --enable-nls=no --enable-maintainer-mode --with-monodroid --disable-llvm ac_cv_header_zlib_h=no</ConfigureFlags>
+      <ConfigureFlags>PATH="$PATH:$(AndroidMxeFullPath)\bin" --host=$(MingwCommandPrefix64) --target=$(MingwCommandPrefix64) --disable-boehm --enable-mcs-build=no --enable-nls=no --enable-maintainer-mode --with-monodroid --disable-llvm ac_cv_header_zlib_h=no ac_cv_search_dlopen=no</ConfigureFlags>
       <NativeLibraryExtension>dll</NativeLibraryExtension>
       <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
       <OutputProfilerFilename></OutputProfilerFilename>


### PR DESCRIPTION
Fix a [Build][0] [Break][1]:

	mono-runtimes.targets: error : Cannot copy
	.../xamarin-android/build-tools/mono-runtimes/obj/Debug//host-mxe-Win64/mono/mini/.libs/libmonosgen-2.0.dll
	to
	.../xamarin-android/bin/Debug/lib/xbuild/Xamarin/Android/lib/host-mxe-Win64/libmonosgen-2.0.dll,
	as the source file doesn't exist.

This is caused by an earlier *warning* in the build log:

	*** Warning: linker path does not have real file for library -ldl.
	*** I have the capability to make that library automatically link in when
	*** you link to this library.  But I can only do this if you have a
	*** shared version of the library, which you do not appear to have
	*** because I did check the linker path looking for a file starting
	*** with libdl and none of the candidates passed a file format test
	*** using a file magic. Last file checked: /Users/jon/android-toolchain/mxe/x86_64-w64-mingw32.static/lib/libdl.a
	*** The inter-library dependencies that have been dropped here will be
	*** automatically added whenever a program is linked with this library
	*** or is declared to -dlopen it.
	*** Since this library must not contain undefined symbols,
	*** because either the platform does not support them or
	*** it was explicitly requested with -no-undefined,
	*** libtool will only create a static version of it.

Which means that when attempting to link `libmonosgen-2.0.dll`,
`-ldl` was provided. The problem there is that our MXE build provides
a `libdl.a` archive, but not exports for a `DL.DLL` Windows library.

What was *really* puzzling, to me, was that our internal system
builds, using the "same" setup: an MXE cross compiler.

Deeper investigation showed that our internal system and the public
system are *not* the same, in one crucial way. The internal setup has
*two* MXE builds, `mxe` and `mxe-full`. The difference between them is
that `mxe` is used to build `libmonosgen-2.0.dll`, while `mxe-full`
(1) adds the `dlfcn-win32` MXE "package", and (2) is used to build
`libmono-android*.dll`.

Thus the cause of the breakage is commit a9bd478a, which added
`dlfcn-win32` to the MXE build, but we *want* this change so that we
can build `src/monodroid` for Windows.

How do we split this difference?

There are two plausible solutions:

1. Have *two* MXE environments, just like we do internally. One would
    include the `dlfcn-win32` files, the other wouldn't.

2. Tell `configure` to *not* use `-ldl` on Windows.

(2) is far easier, and involves augmenting the Windows configure with:

	ac_cv_search_dlopen=no

This prevents the `-ldl` check from being done in the first place,
allowing xamarin-android to have a *single* MXE installation that is
usable for both `build-tools/mono-runtimes` and `src/monodroid`.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/135/
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/135/consoleText