### PR TITLE
[monodroid] Create output directory for `libmono-android*`

### DIFF
--- a/src/monodroid/monodroid.projitems
+++ b/src/monodroid/monodroid.projitems
@@ -24,7 +24,7 @@
       <Strip>strip</Strip>
       <StripFlags>-S</StripFlags>
     </_HostRuntime>
-    <_HostRuntime Include="host-win" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    <_HostRuntime Include="host-mxe-Win64" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Cc>"$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-gcc"</Cc>
       <CFlags>$(_HostCommonWinCFlags) $(_HostWin64CFlags) $(_LinuxFlatPakBuild)</CFlags>
       <LdFlags>$(_HostCommonWinLdFlags)</LdFlags>

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -114,7 +114,7 @@
       DependsOnTargets="_GetBuildHostRuntimes"
       Inputs="@(_CFile);@(_UnixCFile)"
       Outputs="@(_HostRuntime->'$(OutputPath)%(OutputDirectory)\libmono-android.debug.%(NativeLibraryExtension)')">
-    <MakeDir Directories="%(_HostRuntime.OutputPath)" />
+    <MakeDir Directories="$(OutputPath)%(_HostRuntime.OutputDirectory)" />
     <Exec
         Command="%(_HostRuntime.Cc) -o &quot;$(OutputPath)%(_HostRuntime.OutputDirectory)\libmono-android.debug.%(_HostRuntime.NativeLibraryExtension)&quot; $(_DebugCFlags) %(_HostRuntime.CFlags) @(_CFile->'%(Identity)', ' ') %(_HostRuntime.ExtraSource) %(_HostRuntime.LdFlags)"
     />


### PR DESCRIPTION
Fix a [Build][0] [Break][1]:

	monodroid.targets: error : Command '"/Users/builder/android-toolchain/mxe/bin/x86_64-w64-mingw32.static-gcc"
	-o "../../bin/Debug/lib/xbuild/Xamarin/Android/lib/host-win/libmono-android.debug.dll"
	...'
	exited with code: 1.

The cause of the break is the `x86_64-w64-mingw32.static-gcc -o`
value: the `.../host-win` directory doesn't exist, because the
`<MakeDir/>` invocation in `_BuildHostRuntimes` was wrong:

	<!-- Bad! -->
	<MakeDir Directories="%(_HostRuntime.OutputPath)" />

Commit a9bd478a broke things; `%(_HostRuntime.OutputPath)` was a prior
version of the patch -- which didn't work (argh!) -- hence the use
elsewhere of `$(OutputPath)%(_HostRuntime.OutputDirectory)`.
Unfortunately, the `<MakeDir/>` was overlooked in the cleanup.

Fix the `<MakeDir/>` invocation to create the correct directory.

Additionally, place the mxe-Win64 binaries into
`bin/$(Configuration)/lib/xbuild/Xamarin/Android/lib/host-mxe-Win64`,
instead of `.../host-win`. This increases consistency with
`build-tools/mono-runtimes`, and provides a sensible way to provide
32-bit Windows binaries in the future, should we need to.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/139/
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/139/console