### PR TITLE
[Xamarin.Android.Build.Tasks] Improve the logic of GetAdditionalResourcesFromAssemblies' file validation

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
@@ -187,11 +187,21 @@ namespace Xamarin.Android.Tasks {
 		{
 			if (string.IsNullOrEmpty (sha1))
 				return true;
+
+			var hashFile = file + ".sha1";
+			if (File.Exists (hashFile) && string.Compare (File.ReadAllText (hashFile), sha1, StringComparison.InvariantCultureIgnoreCase) == 0)
+				return true;
+			
 			var hash = Xamarin.Android.Tools.Files.HashFile (file).Replace ("-", String.Empty);
 			Log.LogDebugMessage ("File :{0}", file);
 			Log.LogDebugMessage ("SHA1 : {0}", hash);
 			Log.LogDebugMessage ("Expected SHA1 : {0}", sha1);
-			return string.Compare (hash, sha1, StringComparison.InvariantCultureIgnoreCase) == 0;
+
+			var isValid = string.Compare (hash, sha1, StringComparison.InvariantCultureIgnoreCase) == 0;
+			if (isValid)
+				File.WriteAllText (hashFile, hash);
+
+			return isValid;
 		}
 
 		void DoDownload (long totalBytes, long offset, Stream responseStream, Stream outputStream, Action<long, long, int> progressCallback = null)


### PR DESCRIPTION
Validation of downloaded files in the
GetAdditionalResourcesFromAssemblies build task is currently rehashing
the same file several times during a build leading to increased build
times.

By storing the computed hash and reusing it in subsequent invocations
validation can be speed up drastically:

$ tail -n1 build_{orig,patched}.log
==> build_orig.log <==
Time Elapsed 00:07:50.9875230

==> build_patched.log <==
Time Elapsed 00:02:41.3661180