### PR TITLE
[build] Don't use config.guess and use "$HOST_CC -dumpmachine" instead

### DIFF
--- a/build-tools/scripts/generate-os-info
+++ b/build-tools/scripts/generate-os-info
@@ -31,15 +31,10 @@ function getInfo_Linux()
     if [ -d /app ]; then
       OS_NAME="Flatpak"
       OS_RELEASE=`grep ^flatpak-version /.flatpak-info | cut -f2 -d'='`
-      local CONFIG_GUESS=/usr/share/libtool/build-aux/config.guess
     else
       lsb_release > /dev/null 2>&1 || die "Your Linux does not have a working 'lsb_release' command"
       OS_NAME="`lsb_release -is`"
       OS_RELEASE="`lsb_release -rs`"
-      local CONFIG_GUESS=/usr/share/misc/config.guess
-      if [ ! -x $CONFIG_GUESS ]; then
-          die "Your Linux does not have the '$CONFIG_GUESS' script. Missing the autotools-dev package?"
-      fi
     fi
 
     HOST_CPUS="`nproc`"
@@ -56,20 +51,21 @@ function getInfo_Linux()
         HOST_CXX=c++
     fi
 
+    HOST_TRIPLET="$HOST_CC -dumpmachine"
+
     if [ "x$ARCHITECTURE_BITS" = "x64" ]; then
         HOST_CC64="$HOST_CC"
         HOST_CXX64="$HOST_CXX"
         HOST_CC32="$HOST_CC -m32"
         HOST_CXX32="$HOST_CXX -m32"
-        HOST_TRIPLET32="`i386 $CONFIG_GUESS`"
-        HOST_TRIPLET64="`$CONFIG_GUESS`"
-        HOST_TRIPLET="$HOST_TRIPLET64"
+        HOST_TRIPLET32=`sed s/[^-]*-/i686-/ <<< "$HOST_TRIPLET"`
+        HOST_TRIPLET64="$HOST_TRIPLET"
     else
         HOST_CC32="$HOST_CC"
         HOST_CXX32="$HOST_CXX"
         HOST_CC64=false
         HOST_CXX64=false
-        HOST_TRIPLET32="`$CONFIG_GUESS`"
+        HOST_TRIPLET32="$HOST_TRIPLET"
         HOST_TRIPLET64="false"
         HOST_TRIPLET="$HOST_TRIPLET32"
     fi


### PR DESCRIPTION
The path to `config.guess` is dependent on distributions, so don't use `config.guess` and use `"$HOST_CC -dumpmachine"` instead. It is also better in point that it gives the result consistent with the compiler target. This change is based on the following assumptions:

* `$HOST_CC` provides` -dumpmachine` option.
GCC and clang provide the option. Some dependencies such as LLVM expect either will be used for compiling and it is likely to be safe to assume that.

* `$HOST_CC -dumpmachine` and `config.guess` returns the same result.
It is likely because it won't build if the target architecture is inconsistent.

* If the host architecture is 64-bit, it is compatible with i686.
It is likely to be safe to assume because `i386`, a command used before, also assumes the same condition.