### PR TITLE
[Xamarin.Android.Build.Tasks] Look in the AndroidSdk/extras folder for .aar files

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Android.Tasks {
 		public ITaskItem[] Assemblies { get; set; }
 
 		[Required]
-		public string CacheFile { get; set;} 
+		public string CacheFile { get; set;}
 
 		string CachePath;
 		MD5 md5 = MD5.Create ();
@@ -318,7 +318,7 @@ namespace Xamarin.Android.Tasks {
 				if (string.IsNullOrEmpty (extraPath))
 					LogDebugMessage ("    reusing existing archive: {0}", file);
 				else
-					LogDebugMessage ("    found {0} in {1}", embeddedArchive, Path.Combine (AndroidSdkDirectory, extraPath));
+					LogDebugMessage ("    found `{0}` in `{1}`", embeddedArchive, Path.Combine (AndroidSdkDirectory, extraPath));
 			}
 
 			string contentDir = string.IsNullOrEmpty (extraPath) ? Path.Combine (destinationDir, "content") : Path.Combine (AndroidSdkDirectory, extraPath);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Android.Tasks {
 		public ITaskItem[] Assemblies { get; set; }
 
 		[Required]
-		public string CacheFile { get; set;}
+		public string CacheFile { get; set; }
 
 		string CachePath;
 		MD5 md5 = MD5.Create ();


### PR DESCRIPTION
The current Task always downloads data from google. This is regardless
of whether the files exist in the Android sdk directory already.
This commit changes the GetAdditionalResourcesFromAssemblies task
to look in the "extras" folder in the android sdk for the required
.aar file. This will mean if a user has an up to date sdk, there will
be almost no need to download the files from the internet.