### PR TITLE
[Xamarin.Android.Build.Tasks] Allow the cache'ing of the dex/jack compilation for support libraries. [DO NOT MERGE WIP]

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Dx.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Dx.cs
@@ -21,6 +21,8 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string OutputDexDirectory { get; set; }
 
+		public string OutputFileName { get; set; }
+
 		public string [] Jars { get; set; }
 
 		[Output]
@@ -48,13 +50,13 @@ namespace Xamarin.Android.Tasks
 			var md5 = System.Security.Cryptography.MD5.Create ();
 			foreach (var jar in Jars) {
 				context_jar = jar;
-				context_dex = Path.Combine (OutputDexDirectory, BitConverter.ToString (md5.ComputeHash (Encoding.UTF8.GetBytes (jar))) + Path.GetFileNameWithoutExtension (context_jar) + ".dex");
+				context_dex = Path.Combine (OutputDexDirectory, OutputFileName ?? BitConverter.ToString (md5.ComputeHash (Encoding.UTF8.GetBytes (jar))) + Path.GetFileNameWithoutExtension (context_jar) + ".dex");
 				retval &= base.Execute ();
 				outputJackFiles.Add (context_dex);
 			}
 			OutputDexFiles = outputJackFiles.ToArray ();
 
-			Log.LogDebugTaskItems ("  OutputJackFiles: ", OutputDexFiles);
+			Log.LogDebugTaskItems ("  OutputDexFiles: ", OutputDexFiles);
 			return retval;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetConvertedJavaLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetConvertedJavaLibraries.cs
@@ -28,9 +28,11 @@ namespace Xamarin.Android.Tasks
 			var md5 = MD5.Create ();
 			ConvertedFilesToBeGenerated =
 				(JarsToConvert ?? new string [0]).Select (
-					j => Path.Combine (OutputJackDirectory,
-					                   BitConverter.ToString (md5.ComputeHash (Encoding.UTF8.GetBytes (j))) + Path.ChangeExtension (Path.GetFileName (j), Extension)))
-				             .ToArray ();
+					j => File.Exists (Path.Combine (Path.GetDirectoryName (j), "xamarin_cache.jack"))
+						? Path.Combine (Path.GetDirectoryName (j), "xamarin_cache.jack")
+						: Path.Combine (OutputJackDirectory,
+							BitConverter.ToString (md5.ComputeHash (Encoding.UTF8.GetBytes (j))) + Path.ChangeExtension (Path.GetFileName (j), Extension)))
+					.ToArray ();
 			Log.LogDebugTaskItems ("  ConvertedFilesToBeGenerated:", ConvertedFilesToBeGenerated);
 			return true;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Jill.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Jill.cs
@@ -21,6 +21,8 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string OutputJackDirectory { get; set; }
 
+		public string OutputFileName { get; set; }
+
 		public string [] Jars { get; set; }
 
 		[Output]
@@ -47,8 +49,10 @@ namespace Xamarin.Android.Tasks
 			var outputJackFiles = new List<string> ();
 			var md5 = System.Security.Cryptography.MD5.Create ();
 			foreach (var jar in Jars) {
+				if (File.Exists (Path.Combine (Path.GetDirectoryName (jar), "xamarin_cache.jack")))
+					continue;
 				context_jar = jar;
-				context_jack = Path.Combine (OutputJackDirectory, BitConverter.ToString (md5.ComputeHash (Encoding.UTF8.GetBytes (jar))) + Path.GetFileNameWithoutExtension (context_jar) + ".jack");
+				context_jack = Path.Combine (OutputJackDirectory, OutputFileName ?? BitConverter.ToString (md5.ComputeHash (Encoding.UTF8.GetBytes (jar))) + Path.GetFileNameWithoutExtension (context_jar) + ".jack");
 				retval &= base.Execute ();
 				outputJackFiles.Add (context_jack);
 			}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2019,6 +2019,35 @@ because xbuild doesn't support framework reference assemblies.
   Condition="'$(UseJackAndJill)' == 'True'"
   DependsOnTargets="_CompileJavaWithJack" />
 
+<Target Name="_CreateAdditionalJavaLibraryJackCache"
+    Condition="'$(UseJackAndJill)' == 'True'"
+    Inputs="@(_AdditionalJavaLibraryReferences)"
+    Outputs="@(_AdditionalJavaLibraryReferences->'%(RootDir)%(Directory)xamarin_cache.jack')">
+  <Jill
+    Condition="'$(UseJackAndJill)' == 'True'"
+    OutputJackDirectory="%(RootDir)%(Directory)"
+    OutputFileName="xamarin_cache.jack"
+    Jars="%(_AdditionalJavaLibraryReferences.Identity)"
+    ToolPath="$(JavaToolPath)"
+    ToolExe="$(JavaToolExe)"
+    JillJarPath="$(JillJarPath)" />
+</Target>
+
+<Target Name="_CreateAdditionalJavaLibraryDxCache"
+    Condition="'$(UseJackAndJill)'!='True'"
+    Inputs="@(_AdditionalJavaLibraryReferences)"
+    Outputs="@(_AdditionalJavaLibraryReferences->'%(RootDir)%(Directory)xamarin_cache.jar')"
+>
+  <Dx
+    OutputDexDirectory="%(RootDir)%(Directory)"
+    OutputFileName="xamarin_cache.jar"
+    Jars="%(_AdditionalJavaLibraryReferences.Identity)"
+    ToolPath="$(JavaToolPath)"
+    ToolExe="$(JavaToolExe)"
+    DxJarPath="$(DxJarPath)"
+  />
+</Target>
+
 <Target Name="_CompileToDalvikWithDx"
   Condition="'$(UseJackAndJill)' != 'True'"
   DependsOnTargets="$(_CompileToDalvikDependsOnTargets)"
@@ -2092,7 +2121,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_CompileDex"
-		DependsOnTargets="_CompileToDalvikWithDx;_CompileToDalvikWithJack">
+		DependsOnTargets="_CreateAdditionalJavaLibraryDxCache;_CreateAdditionalJavaLibraryJackCache;_CompileToDalvikWithDx;_CompileToDalvikWithJack">
 
 	<ItemGroup>
 		<_DexFile Include="$(IntermediateOutputPath)android\bin\dex\*.dex" />


### PR DESCRIPTION
Support libraries mostly contain classes.jar which needs to be converted to
a .dex format (or the .jack format). This can take some time. If we
pre convert the support libraries and cache the results we can cut down
the build time. dx.jar has the capability to merge in other .jar files
which contain classes.dex instead of .class files.