### PR TITLE
[Xamarin.Android.NUnitLite] Generate NUnit 2 XML test results

### DIFF
--- a/src/Xamarin.Android.NUnitLite/Gui/AndroidRunner.cs
+++ b/src/Xamarin.Android.NUnitLite/Gui/AndroidRunner.cs
@@ -316,13 +316,13 @@ namespace Xamarin.Android.NUnitLite
 			}
 		}
 
-		internal void Run (NUnitTest test, Context context)
+		internal TestResult Run (NUnitTest test, Context context)
 		{
 			if (!OpenWriter ("Run Everything", context))
-				return;
+				return null;
 
 			try {
-				Run (test);
+				return Run (test);
 			} finally {
 				int testCount = passed + failed + skipped + inconclusive;
 				Runner.Writer.WriteLine ("Tests run: {0}, Passed: {1}, Failed: {2}, Skipped: {3}, Inconclusive: {4}",


### PR DESCRIPTION
When running tests via `TestSuiteInstrumentation`, e.g. as is done
in [`Mono.Android-Tests`][0], write the test results to an
NUnit 2-formatted XML file and add the path to the XML file as a
`nunit2-results-path` bundle key:

	$ adb shell am instrument -w Mono.Android_Tests/xamarin.android.runtimetests.TestInstrumentation
	...
	INSTRUMENTATION_RESULT: nunit2-results-path=/storage/emulated/0/Android/data/Mono.Android_Tests/files/Documents/TestResults.xml

The value of the `nunit2-results-path` bundle key is the path to a
file that can be retrieved from the target device:

	$ adb pull /storage/emulated/0/Android/data/Mono.Android_Tests/files/Documents/TestResults.xml

Note that the app on-device may need to modify the `TestResults.xml`
path so that it *can* be `adb pull`ed; on pre-Android 6.0 devices, the
on-device paths may not match the off-device/`adb shell` paths.
The `$EMULATED_STORAGE_SOURCE` and `$EMULATED_STORAGE_TARGET`
environment variables can be u sed to determine the common root for
off-device vs. on-device paths:

	http://source.android.com/devices/storage/config.html
	http://source.android.com/devices/storage/config-example.html#android_5_x_emulated

[0]: https://github.com/xamarin/xamarin-android/blob/1b3a76c/src/Mono.Android/Test/Mono.Android-Tests.targets#L27