### PR TITLE
bump Java.Interop/f44a11f6 and use its cecil library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ prepare-external:
 	git submodule update --init --recursive
 	nuget restore $(SOLUTION)
 	nuget restore Xamarin.Android-Tests.sln
-	(cd $(call GetPath,JavaInterop) && nuget restore)
+	(cd $(call GetPath,JavaInterop) && make prepare)
 	(cd $(call GetPath,JavaInterop) && make bin/BuildDebug/JdkInfo.props)
 
 prepare-props:

--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -91,6 +91,10 @@ Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "bundle", "build-tools\bundl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xa-prep-tasks", "build-tools\xa-prep-tasks\xa-prep-tasks.csproj", "{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Android.Cecil", "external\Java.Interop\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.csproj", "{15945D4B-FF56-4BCC-B598-2718D199DD08}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Android.Cecil.Mdb", "external\Java.Interop\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.Mdb.csproj", "{C0487169-8F81-497F-919E-EB42B1D0243F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|AnyCPU = Debug|AnyCPU
@@ -417,6 +421,22 @@ Global
 		{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}.XAIntegrationDebug|AnyCPU.Build.0 = Debug|Any CPU
 		{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}.XAIntegrationRelease|AnyCPU.ActiveCfg = Debug|Any CPU
 		{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}.XAIntegrationRelease|AnyCPU.Build.0 = Debug|Any CPU
+		{15945D4B-FF56-4BCC-B598-2718D199DD08}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{15945D4B-FF56-4BCC-B598-2718D199DD08}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{15945D4B-FF56-4BCC-B598-2718D199DD08}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{15945D4B-FF56-4BCC-B598-2718D199DD08}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{15945D4B-FF56-4BCC-B598-2718D199DD08}.XAIntegrationDebug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{15945D4B-FF56-4BCC-B598-2718D199DD08}.XAIntegrationDebug|AnyCPU.Build.0 = Debug|Any CPU
+		{15945D4B-FF56-4BCC-B598-2718D199DD08}.XAIntegrationRelease|AnyCPU.ActiveCfg = Debug|Any CPU
+		{15945D4B-FF56-4BCC-B598-2718D199DD08}.XAIntegrationRelease|AnyCPU.Build.0 = Debug|Any CPU
+		{C0487169-8F81-497F-919E-EB42B1D0243F}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{C0487169-8F81-497F-919E-EB42B1D0243F}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{C0487169-8F81-497F-919E-EB42B1D0243F}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{C0487169-8F81-497F-919E-EB42B1D0243F}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{C0487169-8F81-497F-919E-EB42B1D0243F}.XAIntegrationDebug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{C0487169-8F81-497F-919E-EB42B1D0243F}.XAIntegrationDebug|AnyCPU.Build.0 = Debug|Any CPU
+		{C0487169-8F81-497F-919E-EB42B1D0243F}.XAIntegrationRelease|AnyCPU.ActiveCfg = Debug|Any CPU
+		{C0487169-8F81-497F-919E-EB42B1D0243F}.XAIntegrationRelease|AnyCPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
@@ -460,6 +480,8 @@ Global
 		{0DE278D6-000F-4001-BB98-187C0AF58A61} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 		{1640725C-4DB8-4D8D-BC96-74E688A06EEF} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 		{7CE69551-BD73-4726-ACAA-AAF89C84BAF8} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
+		{15945D4B-FF56-4BCC-B598-2718D199DD08} = {864062D3-A415-4A6F-9324-5820237BA058}
+		{C0487169-8F81-497F-919E-EB42B1D0243F} = {864062D3-A415-4A6F-9324-5820237BA058}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -42,18 +42,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
-    <Reference Include="Mono.Cecil">
-      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
-    </Reference>
     <Reference Include="Irony">
       <HintPath>..\..\packages\Irony.0.9.1\lib\net40\Irony.dll</HintPath>
     </Reference>
@@ -644,6 +632,14 @@
     <ProjectReference Include="$(LibZipSharpSourceFullPath)\libZipSharp.csproj">
       <Project>{E248B2CA-303B-4645-ADDC-9D4459D550FD}</Project>
       <Name>libZipSharp</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(JavaInteropFullPath)\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.csproj">
+      <Project>{15945D4B-FF56-4BCC-B598-2718D199DD08}</Project>
+      <Name>Xamarin.Android.Cecil</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(JavaInteropFullPath)\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.Mdb.csproj">
+      <Project>{C0487169-8F81-497F-919E-EB42B1D0243F}</Project>
+      <Name>Xamarin.Android.Cecil.Mdb</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/packages.config
@@ -3,6 +3,5 @@
   <package id="FSharp.Compiler.CodeDom" version="0.9.4" targetFramework="net45" />
   <package id="FSharp.Compiler.CodeDom" version="1.0.0.1" targetFramework="net45" />
   <package id="Irony" version="0.9.1" targetFramework="net45" />
-  <package id="Mono.Cecil" version="0.10.0-beta1-v2" targetFramework="net40" />
   <package id="FSharp.Core" version="3.1.2.5" targetFramework="net45" />
 </packages>

--- a/src/Xamarin.Android.Tools.Aidl/Xamarin.Android.Tools.Aidl.csproj
+++ b/src/Xamarin.Android.Tools.Aidl/Xamarin.Android.Tools.Aidl.csproj
@@ -29,23 +29,12 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="Mono.Cecil">
-      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
-    </Reference>
     <Reference Include="Irony">
       <HintPath>..\..\packages\Irony.0.9.1\lib\net40\Irony.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
+  <Import Project="..\..\Configuration.props" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Compile Include="AidlAst.cs" />
@@ -57,5 +46,11 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(JavaInteropFullPath)\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.csproj">
+      <Project>{15945D4B-FF56-4BCC-B598-2718D199DD08}</Project>
+      <Name>Xamarin.Android.Cecil</Name>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/src/Xamarin.Android.Tools.Aidl/packages.config
+++ b/src/Xamarin.Android.Tools.Aidl/packages.config
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Irony" version="0.9.1" targetFramework="net40" />
-  <package id="Mono.Cecil" version="0.10.0-beta1-v2" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Updated all the projects to use the `Xamarin.Android.Cecil` library
instead of `Mono.Cecil` nuget package.