### PR TITLE
[Xamarin.Android.Build.Tasks] HttpClientHandler is default handler

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -327,7 +327,7 @@ namespace Xamarin.Android.Tasks
 
 			const string defaultLogLevel = "MONO_LOG_LEVEL=info";
 			const string defaultMonoDebug = "MONO_DEBUG=gen-compact-seq-points";
-			const string defaultHttpMessageHandler = "XA_HTTP_CLIENT_HANDLER_TYPE=Xamarin.Android.Net.AndroidClientHandler";
+			const string defaultHttpMessageHandler = "XA_HTTP_CLIENT_HANDLER_TYPE=System.Net.Http.HttpClientHandler, System.Net.Http";
 			const string defaultTlsProvider = "XA_TLS_PROVIDER=default";
 			string xamarinBuildId = string.Format ("XAMARIN_BUILD_ID={0}", buildId);
 


### PR DESCRIPTION
Change the default `HttpClientHandler` type from
`AndroidClientHandler` (back?) to `System.Net.Http.HttpClientHandler`.

**Background**: Mono contains a fully managed SSL support stack, but
this stack only supports TLS 1.0.

TLS 1.2 is increasingly becoming required.

There are three "high level" solutions to getting TLS 1.2 support:

1. Write a fully managed TLS 1.2 stack.

2. Use the "native" Android/Java APIs for TLS 1.2 support.

3. Use a native library for TLS 1.2 support.

(1), writing a fully managed TLS 1.2 stack, [has been done][0].
However, [this code hasn't been audited][1], and we're not confident
about the long term maintenance ramifications and security
implications. We thus don't plan on using this library.

(2) lives in [`AndroidClientHandler`][2]. Back in 2016-May, this is
how we thought we would be providing TLS 1.2 support "by default", and
the `<BuildApk/>` task was setting the `$XA_HTTP_CLIENT_HANDLER_TYPE`
environment variable so that `AndroidClientHandler` would be used,
unless overridden by the `$(AndroidHttpClientHandlerType)` MSBuild
property.

This default change didn't make it into the released commercial
offerings; Xamarin.Android 7.0 ("Cycle 8") used
`System.Net.Http.HttpClientHandler` as the default handler type.

(3) is [Boring SSL][3] ([previously mentioned][1]), and we currently
intend it to become the preferred default in the future. Boring SSL
uses the existing `HttpClientHandler`, and changes the internals of
how `HttpWebRequest` works.

`AndroidClientHandler` (2) thus will *not* become a default.
We see no point in changing the default `HttpClientHandler` type from
`HttpClientHandler` to `AndroidClientHandler` for one release, only to
change it back in the following release.

Revert the default `$XA_HTTP_CLIENT_HANDLER_TYPE` value to use
`System.Net.Http.HttpClientHandler`.

[0]: https://github.com/mono/mono-tls
[1]: http://tirania.org/blog/archive/2016/Sep-30.html
[2]: https://github.com/xamarin/xamarin-android/blob/d198cfd/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
[3]: https://boringssl.googlesource.com/boringssl/