### PR TITLE
[mono-runtimes] Fix @(BundleItem) timestamps

### DIFF
--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -218,7 +218,7 @@
   <Target Name="_InstallRuntimes"
       DependsOnTargets="_GetRuntimesOutputItems"
       Inputs="@(_RuntimeSource);@(_ProfilerSource);@(_MonoPosixHelperSource)"
-      Outputs="@(_InstallRuntimesOutput);@(_InstallProfilerOutput);@(_InstallMonoPosixHelperOutput)">
+      Outputs="@(_InstallRuntimeOutput);@(_InstallProfilerOutput);@(_InstallMonoPosixHelperOutput)">
     <MakeDir
         Condition=" '%(_MonoRuntime.DoBuild)' == 'true' "
         Directories="$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(_MonoRuntime.Identity)"
@@ -231,10 +231,14 @@
         SourceFiles="@(_RuntimeEglibHeaderSource)"
         DestinationFiles="@(_RuntimeEglibHeaderOutput)"
     />
+    <Touch Files="@(_RuntimeEglibHeaderOutput)" />
+
     <Copy
         SourceFiles="@(_MonoConstsSource)"
         DestinationFiles="@(_MonoConstsOutput)"
     />
+    <Touch Files="@(_MonoConstsOutput)" />
+
     <Copy
         SourceFiles="@(_RuntimeSource)"
         DestinationFiles="@(_InstallRuntimeOutput)"
@@ -247,6 +251,7 @@
         Condition=" '$(Configuration)' != 'Debug' And '%(_MonoRuntime.DoBuild)' == 'true' "
         Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(_MonoRuntime.Identity)\%(_MonoRuntime.OutputRuntimeFilename).%(_MonoRuntime.NativeLibraryExtension)&quot;"
     />
+    <Touch Files="@(_InstallRuntimeOutput);@(_InstallUnstrippedRuntimeOutput)" />
 
     <Copy
         SourceFiles="@(_ProfilerSource)"
@@ -260,6 +265,7 @@
         Condition=" '$(Configuration)' != 'Debug' And '%(_MonoRuntime.DoBuild)' == 'true' And '%(_MonoRuntime.OutputProfilerFilename)' != '' "
         Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(_MonoRuntime.Identity)\%(_MonoRuntime.OutputProfilerFilename).%(_MonoRuntime.NativeLibraryExtension)&quot;"
     />
+    <Touch Files="@(_InstallProfilerOutput);@(_InstallUnstrippedProfilerOutput)" />
 
     <Copy
         SourceFiles="@(_MonoBtlsSource)"
@@ -273,6 +279,7 @@
         Condition=" '$(Configuration)' != 'Debug' And '%(_MonoRuntime.DoBuild)' == 'true' And '%(_MonoRuntime.OutputMonoBtlsFilename)' != '' "
         Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(_MonoRuntime.Identity)\%(_MonoRuntime.OutputMonoBtlsFilename).%(_MonoRuntime.NativeLibraryExtension)&quot;"
     />
+    <Touch Files="@(_InstallMonoBtlsOutput);@(_InstallUnstrippedMonoBtlsOutput)" />
 
     <Copy
         SourceFiles="@(_MonoPosixHelperSource)"
@@ -286,9 +293,7 @@
         Condition=" '$(Configuration)' != 'Debug' And '%(_MonoRuntime.DoBuild)' == 'true' And '%(_MonoRuntime.OutputMonoPosixHelperFilename)' != '' "
         Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(_MonoRuntime.Identity)\%(_MonoRuntime.OutputMonoPosixHelperFilename).%(_MonoRuntime.NativeLibraryExtension)&quot;"
     />
-    <Touch
-        Files="@(_InstallRuntimesOutput);@(_InstallProfilerOutput);@(_InstallMonoPosixHelperOutput);@(_InstallMonoBtlsOutput)"
-    />
+    <Touch Files="@(_InstallMonoPosixHelperOutput);@(_InstallUnstrippedMonoPosixHelperOutput)" />
   </Target>
   <Target Name="_InstallBcl"
       Inputs="@(_BclProfileItems)"
@@ -414,6 +419,8 @@
       <BundleItem Include="@(_InstallUnstrippedRuntimeOutput)" />
       <BundleItem Include="@(_InstallProfilerOutput)" />
       <BundleItem Include="@(_InstallUnstrippedProfilerOutput)" />
+      <BundleItem Include="@(_InstallMonoBtlsOutput)" />
+      <BundleItem Include="@(_InstallUnstrippedMonoBtlsOutput)" />
       <BundleItem Include="@(_InstallMonoPosixHelperOutput)" />
       <BundleItem Include="@(_InstallUnstrippedMonoPosixHelperOutput)" />
       <BundleItem Include="@(_RuntimeEglibHeaderOutput)" />


### PR DESCRIPTION
The *intent* of the `_BuildUnlessCached` target within
`mono-runtimes.targets` is to (attempt to!) make building mono "free",
or at least, free *enough* so that other project files can have a
build-time dependency on `mono-runtimes.mdproj` so that build
artifacts can be (reasonably) consistent.

Unfortunately, that wasn't the case, with the net result being that:

	tools/scripts/xabuild /t:SignAndroidPackage src/Mono.Android/Test/*.csproj

would *constantly* attempt to re-build
`build-tools/mono-runtimes.mdproj`, adding (at least!) one minute as
we ran mono's `make`...to do nothing.

Why?

	Target _BuildUnlessCached needs to be built as input file '.../xamarin-android/external/mono/autogen.sh' is newer than output file '../../bin/Debug//include/armeabi-v7a/eglib/config.h'

The "problem" is that the `<Copy/>` task copies over the timestamp as
well, so even though we're (possibly) creating a new file, the
timestamp on the created file will match the source file.

Normally this is fine. In this case, we're dealing with `eglib`, which
is a "nested" ("delegated"?) `configure` invocation from mono's
`configure`. It *appears* that if (when) mono is updated, "normal"
mono subdirectories will "properly" honor `--enable-maintainer-mode`
and re-run mono's `configure`, which will in turn update the timstamp
on any `configure`-time generated files.

This doesn't appear to be the case for `mono/eglib`; when `mono` is
updated, `mono/eglib` does *not* re-run `configure`, and thus no
timestamps are updated to follow suit.

Fix this by *explicitly* `<Touch/>`ing all copied files so that we
ensure they have a "recent" timestamp ("now"), which should ensure
that the file's timestamp is newer than that of e.g. `autogen.sh`.

Additionally, there was a typo: Commit a5b324d1 used a
`@(_InstallRuntimesOutput)` item group, but there is no such item
group; it's actually `@(_InstallRuntimeOutput)` (no `s`).
Fixity fix this.

Finally, commit a5b324d1 forgot to add `libmono-btls-shared` to
`@(BundleItem)`, preventing it from being added to the bundle.
Fix this oversight.