### PR TITLE
[tests] `make run-nunit-tests` needs to emit NUnit2 XML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,8 +142,9 @@ define RUN_NUNIT_TEST
 	$(RUNTIME) --runtime=v4.0.0 \
 		$(NUNIT_CONSOLE) $(NUNIT_EXTRA) $(1) \
 		$(if $(RUN),-run:$(RUN)) \
-		--result=TestResult-$(basename $(notdir $(1))).xml \
-		-output=bin/Test$(CONFIGURATION)/TestOutput-$(basename $(notdir $(1))).txt ;
+		--result="TestResult-$(basename $(notdir $(1))).xml;format=nunit2" \
+		-output=bin/Test$(CONFIGURATION)/TestOutput-$(basename $(notdir $(1))).txt \
+	|| true ;
 endef
 
 run-nunit-tests: $(NUNIT_TESTS)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/packages.config
@@ -2,5 +2,7 @@
 <packages>
   <package id="NUnit" version="3.2.1" targetFramework="net45" />
   <package id="Unofficial.Ionic.Zip" version="1.9.1.8" targetFramework="net45" />
+  <package id="NUnit.Console" version="3.2.1" />
   <package id="NUnit.ConsoleRunner" version="3.2.1" />
+  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.2.1" />
 </packages>

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CheckAdbTarget.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CheckAdbTarget.cs
@@ -55,12 +55,20 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
 		{
 			base.LogEventsFromTextOutput (singleLine, messageImportance);
-			// Log.LogMessage ($"# jonp: messageImportance={messageImportance};  line='{singleLine}'");
 			if (string.IsNullOrEmpty (singleLine))
 				return;
 			if (singleLine.Equals ("List of devices attached", StringComparison.OrdinalIgnoreCase))
 				return;
+			// Ignore stderr
 			if (messageImportance == MessageImportance.High)
+				return;
+			// Informational messages, e.g.
+			//  * daemon not running. starting it now on port 5037 *
+			//  * daemon started successfully *
+			if (singleLine.StartsWith ("* ", StringComparison.Ordinal))
+				return;
+			// Error messages, e.g.: error: device '(null)' not found
+			if (singleLine.StartsWith ("error: ", StringComparison.OrdinalIgnoreCase))
 				return;
 
 			if (string.IsNullOrEmpty (SdkVersion)) {

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
@@ -101,7 +101,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			if (!singleLine.Contains (TestResultsPathResult))
 				return;
 			var i = singleLine.IndexOf (TestResultsPathResult);
-			targetTestResultsPath   = singleLine.Substring (i + TestResultsPathResult.Length);
+			targetTestResultsPath   = singleLine.Substring (i + TestResultsPathResult.Length).Trim ();
 		}
 	}
 }


### PR DESCRIPTION
Now that we can run NUnit tests on-device (48e3fc26), the next step is
to start running unit tests on Jenkins, which is best done through the
`make run-all-tests` target.

...or so I thought.

In actuality, that's not *quite* right, because `make run-nunit-tests`
will bail on the first failure, which is not at all desirable. We want
to run *all* the tests, not just some subset of tests that pass.

Fix the `RUN_NUNIT_TEST` define so that an "error exit code" is
"ignored." This allows all NUnit-based tests to actually execute.

Even better, it means that the `make run-nunit-tests` target won't
fail, which means `make run-all-tests` can actually progress to
running `make run-apk-tests`, which were being skipped because the
`Xamarin.Android.Build.Tests.dll` tests had some failures.

<heavy sigh>

That's only half the problem on Jenkins. The other half is that the
Jenkins **Publish xUnit test result report** step, using the
**NUnit-Version N/A (default)** pattern, was failing because the XSLT
used to process the NUnit XML output was emitting invalid XML:

	<?xml version="1.0" encoding="UTF-8"?>
	  /Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/packages/NUnit.ConsoleRunner.3.2.1/tools/nunit3-console.exe bin/TestDebug/Xamarin.Android.Build.Tests.dll --result=TestResult-Xamarin.Android.Build.Tests.xml -output=bin/TestDebug/TestOutput-Xamarin.Android.Build.Tests.txt
	  ...

That's certainly not valid XML...

The problem here was that `nunit3-console.exe` was emitting
NUnit **3** XML output, while the Jenkins XSLT only supports
NUnit **2** output. The fix here is twofold:

1. Update `pakcages.config` to also install the `NUnit.Console`
    and `NUnit.Extension.NUnitV2ResultWriter` packages.

    (Only the `NUnit.Console` package should be required, as it
    depends on the latter, but for some reason referencing *just*
    `NUnit.Console` didn't cause `NUnit.Extension.NUnitV2ResultWriter`
    to be installed.)

2. Update the `nunit3-console.exe` invocation to specify the output
    format, which is a `;format=nunit2` *suffix* on `--result`:

        nunit3-console.exe "--result=TestResult.xml;format=nunit2" ...

(Using `;format=nunit2` *requires* the
`NUnit.Extension.NUnitV2ResultWriter` package.)

With all those changes in place, I *hope* Jenkins will be able to
(1) *run* all unit tests, and (2) *display* the results of those unit
tests in a nice, readable, graphical, form.