### PR TITLE
[monodroid, tests] Export CreateZStream(); Fix tests

### DIFF
--- a/src/Mono.Android/Test/System.Net/SslTest.cs
+++ b/src/Mono.Android/Test/System.Net/SslTest.cs
@@ -27,7 +27,7 @@ namespace System.NetTests {
 			Exception  exception  = null;
 
 			var thread = new Thread (() => {
-				string url = "https://pipeline.internalx.com/";
+				string url = "https://tlstest-1.xamdev.com/";
 
 				var downloadTask = new WebClient ().DownloadDataTaskAsync (url);
 				var completeTask = downloadTask.ContinueWith (t => {

--- a/src/Mono.Android/Test/Xamarin.Android.Net/AndroidClientHandlerTests.cs
+++ b/src/Mono.Android/Test/Xamarin.Android.Net/AndroidClientHandlerTests.cs
@@ -164,15 +164,24 @@ namespace Xamarin.Android.NetTests {
     [Test]
     public void Sanity_Tls_1_2_Url_WithMonoClientHandlerFails ()
     {
+      var tlsProvider   = global::System.Environment.GetEnvironmentVariable ("XA_TLS_PROVIDER");
+      var supportTls1_2 = tlsProvider.Equals ("btls", StringComparison.OrdinalIgnoreCase);
       using (var c = new HttpClient (new HttpClientHandler ())) {
         try {
           var tr = c.GetAsync (Tls_1_2_Url);
           tr.Wait ();
           tr.Result.EnsureSuccessStatusCode ();
-          Assert.Fail ("SHOULD NOT BE REACHED: Mono's HttpClientHandler doesn't support TLS 1.2.");
+          if (!supportTls1_2) {
+            Assert.Fail ("SHOULD NOT BE REACHED: Mono's HttpClientHandler doesn't support TLS 1.2.");
+          }
         }
         catch (AggregateException e) {
-          Assert.IsTrue (e.InnerExceptions.Any (ie => ie is WebException));
+          if (supportTls1_2) {
+            Assert.Fail ("SHOULD NOT BE REACHED: BTLS is present, TLS 1.2 should work.");
+          }
+          if (!supportTls1_2) {
+            Assert.IsTrue (e.InnerExceptions.Any (ie => ie is WebException));
+          }
         }
       }
     }

--- a/src/Mono.Android/Test/Xamarin.Android.Net/HttpClientIntegrationTests.cs
+++ b/src/Mono.Android/Test/Xamarin.Android.Net/HttpClientIntegrationTests.cs
@@ -202,6 +202,7 @@ namespace Xamarin.Android.NetTests {
 				}
 			}
 		}
+
 #if TODO
 		[Test]
 		public void Send_Complete_Default ()
@@ -792,7 +793,7 @@ namespace Xamarin.Android.NetTests {
 				}
 			}
 		}
-#endif
+
 		[Test]
 		public void Send_Content_Get ()
 		{
@@ -893,6 +894,7 @@ namespace Xamarin.Android.NetTests {
 				}
 			}
 		}
+#endif  // TODO
 
 		[Test]
 		public void Send_Invalid ()

--- a/src/monodroid/jni/Android.mk
+++ b/src/monodroid/jni/Android.mk
@@ -37,17 +37,22 @@ LOCAL_LDFLAGS   += \
 	-Wl,--no-undefined \
 
 LOCAL_C_INCLUDES	:= \
+	$(LOCAL_PATH)/../../../bin/$(CONFIGURATION)/include \
 	$(LOCAL_PATH)/../../../bin/$(CONFIGURATION)/include/$(TARGET_ARCH_ABI)/eglib \
-	$(LOCAL_PATH)/../../../external/mono/eglib/src \
+	"$(MONO_PATH)/eglib/src" \
 	$(LOCAL_PATH)/zip
 
 LOCAL_LDLIBS    := -llog -lz -lstdc++
 
 LOCAL_MODULE    := monodroid
 
+# Note: `$(MONO_PATH)` *cannot* contain spaces, because we can't quote it.
+# Should we try to, `ndk-build` ignores the file with the warning:
+#   Android NDK: ".../mono/support/nl.c" ".../mono/support/zlib-helper.c"
+#   Android NDK: WARNING: Unsupported source file extensions in jni/Android.mk for module monodroid
 LOCAL_SRC_FILES := \
-	../../../external/mono/support/nl.c \
-	../../../external/mono/support/zlib-helper.c \
+	$(MONO_PATH)/support/nl.c \
+	$(MONO_PATH)/support/zlib-helper.c \
 	dylib-mono.c \
 	embedded-assemblies.c \
 	jni.c \

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -41,8 +41,9 @@
       DependsOnTargets="_GenerateIncludeFiles;_BuildAndroidRuntimes;_BuildHostRuntimes">
   </Target>
   <Target Name="_GenerateIncludeFiles"
-      Inputs="@(_EmbeddedBlob)"
-      Outputs="@(_EmbeddedBlob->'jni\%(Include)')">
+      Inputs="@(_EmbeddedBlob);jni/config.h"
+      Outputs="@(_EmbeddedBlob->'jni\%(Include)');$(OutputPath)\..\..\..\..\..\include\config.h">
+    <Copy SourceFiles="jni/config.h" DestinationFiles="$(OutputPath)\..\..\..\..\..\include\config.h" />
     <Exec Command="(cat &quot;@(_EmbeddedBlob)&quot; ; dd if=/dev/zero bs=1 count=1 2>/dev/null) > %(_EmbeddedBlob.Config)" />
     <Exec Command="xxd -i %(_EmbeddedBlob.Config) | sed 's/^unsigned /static const unsigned /g' > jni/%(_EmbeddedBlob.Include)" />
     <Exec Command="rm %(_EmbeddedBlob.Config)" />
@@ -52,7 +53,7 @@
       Outputs="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.so')">
     <PropertyGroup>
       <_AppAbi>@(AndroidSupportedTargetJitAbi->'%(Identity)', ' ')</_AppAbi>
-      <_NdkBuildArgs>CONFIGURATION=$(Configuration) SGEN_BRIDGE_VERSION=$(MonoSgenBridgeVersion)</_NdkBuildArgs>
+      <_NdkBuildArgs>CONFIGURATION=$(Configuration) SGEN_BRIDGE_VERSION=$(MonoSgenBridgeVersion) MONO_PATH="$(MonoSourceFullPath)"</_NdkBuildArgs>
     </PropertyGroup>
     <WriteLinesToFile
         File="jni\Application.mk"


### PR DESCRIPTION
PR build [#297][0] reported 8 failures. Fix two of them:

* `GzipStreamTest.Compression`
* `SslTest.SslWithinTasksShouldWork`

`GzipStreamTest.Compression` was failing because the symbol
`CreateZStream` couldn't be found:

	System.EntryPointNotFoundException : CreateZStream
	  at (wrapper managed-to-native) System.IO.Compression.DeflateStreamNative:CreateZStream (System.IO.Compression.CompressionMode,bool,System.IO.Compression.DeflateStreamNative/UnmanagedReadOrWrite,intptr
	  ...

`libmono-android*` is compiled with `-fvisibility=hidden` so that all
symbols are not exported from the native library by default. In order
for a symbol to be exported, the symbol needs to be annotated with:

	__attribute__ ((visibility ("default")))

`CreateZStream()` *looks* like it should be annotated like this:

	/* external/mono/support/zlib-helper.c */
	MONO_API ZStream *CreateZStream (gint compress, guchar gzip, read_write_func func, void *gchandle);

`MONO_API` is (usually) a macro that expands to
`__attribute__((visibility("default")))`, so one would think that this
would work.

The problem is that it *doesn't* work, and the reason is because no
header that `zlib-helper.c` includes provides a definition for
`MONO_API`, so it is insted defined as *nothing*. Consequently,
`CreateZStream` isn't exported, and code that requires it breaks.

The fix is twofold:

1. Update `$(LOCAL_C_INCLUDES)` within `src/monodroid/jni/Android.mk`
    so that `bin/$(Configuration)/include` is searched for header
    *first*.

2. Update the `_GenerateIncludeFiles` target within
    `src/monodroid/monodroid.targets` to copy a custom `config.h` into
    `bin/$(Configuration)/include`.

The custom `config.h` -- `src/monodroid/jni/config.h` -- ensures that
`MONO_API` has the correct value when `<config.h>` is included, which
is a header that `zlib-helper.c` includes, thus ensuring that
`CreateZStream()` is exported.

"While we're at it", update `Android.mk` so that instead of
"hard-coding" the relative path to the mono checkout, we instead use
`$(MONO_PATH)`, set to `$(MonoSourceFullPath)`.
(See e.g. d205cab2.)

The problem with the `SslTest.SslWithinTasksShouldWork` test was that
it was using a no longer maintained URL, `pipeline.internalx.com`.
Fix the test to instead use `tlstest-1.xamdev.com`.

Finally, update `HttpClientIntegrationTests.cs` to exclude the same
tests that we exclude internally, as many of those tests are "flaky"
or "unreliable": they'll pass sometimes, and fail others, and the
inconsistency is maddening.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-pr-builder/297/testReport/