### PR TITLE
[tests] Improve reliability of emulator attach

### DIFF
--- a/build-tools/scripts/UnitTestApks.targets
+++ b/build-tools/scripts/UnitTestApks.targets
@@ -15,6 +15,7 @@
     <CheckAdbTarget
         Condition=" '$(RequireNewEmulator)' != 'True' "
         AdbTarget="$(AdbTarget)"
+        ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)">
       <Output TaskParameter="AdbTarget"     PropertyName="_AdbTarget" />
       <Output TaskParameter="IsValidTarget" PropertyName="_ValidAdbTarget"  />
@@ -39,9 +40,15 @@
       <Output TaskParameter="AdbTarget" PropertyName="_EmuTarget" />
       <Output TaskParameter="AdbProcess" PropertyName="_EmuProcess" />
     </StartAndroidEmulator>
+    <Exec
+        Condition=" '$(_ValidAdbTarget)' != 'True' "
+        Command="sleep 10"
+    />
     <Adb
         Condition=" '$(_ValidAdbTarget)' != 'True' "
         Arguments="$(_AdbTarget) wait-for-device"
+        ToolExe="$(AdbToolExe)"
+        ToolPath="$(AdbToolPath)"
     />
     <Message
         Condition=" '$(_EmuTarget)' != '' "
@@ -53,6 +60,8 @@
     <Adb
         Condition=" '$(_EmuTarget)' != '' "
         Arguments="$(_EmuTarget) emu kill"
+        ToolExe="$(AdbToolExe)"
+        ToolPath="$(AdbToolPath)"
     />
   </Target>
 


### PR DESCRIPTION
Sometimes [the PR builder won't launch the emulator][0]:

	Tool .../emulator execution started with arguments: -avd "XamarinAndroidUnitTestRunner" -port "5600"
	Task Adb
	  Arguments: -s emulator-5600 wait-for-device
	Task Adb
	  Arguments: -s emulator-5600  install -r ".../Mono.Android_Tests-Signed.apk"
	  error: device 'emulator-5600' not found
	...
	emulator: WARNING: Increasing RAM size to 1GB
	...

(Omitting lots of additional output...)

What *appears* to be happening is that emulator creation and launching
is occasionally happening *after* we attempt to install the `.apk`
onto the device, which doesn't really make sense.

Resort to the standby of the lazy: add a **sleep**(1) invocation
before we call `adb wait-for-device`, on the hopes that 10 seconds is
sufficient time to allow the emulator creation and launch to proceed
far enough for `adb wait-for-device` to actually *do something*, in
turn allowing `adb install` to likewise *do something*.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-pr-builder/300/console