### PR TITLE
[Mono.Android-Tests] Test AssemblyInformationalVersionAttribute

### DIFF
--- a/src/Mono.Android/Test/Mono.Android-Tests.csproj
+++ b/src/Mono.Android/Test/Mono.Android-Tests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Java.Lang\ObjectTest.cs" />
     <Compile Include="Java.Interop\JnienvTest.cs" />
     <Compile Include="System\AppDomainTest.cs" />
+    <Compile Include="System\AssemblyInformationalVersionAttributeTest.cs" />
     <Compile Include="System\ExceptionTest.cs" />
     <Compile Include="System\TimeZoneTest.cs" />
     <Compile Include="System.IO\DriveInfoTest.cs" />

--- a/src/Mono.Android/Test/System/AssemblyInformationalVersionAttributeTest.cs
+++ b/src/Mono.Android/Test/System/AssemblyInformationalVersionAttributeTest.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading;
+
+using NUnit.Framework;
+
+namespace Xamarin.Android.RuntimeTests {
+
+	[TestFixture]
+	public class AssemblyInformationalVersionAttributeTest {
+
+		[Test]
+		public void VersionInformationExists ()
+		{
+			var attrs = (System.Reflection.AssemblyInformationalVersionAttribute[])
+			    typeof (Java.Lang.Object)
+			    .Assembly
+			    .GetCustomAttributes (typeof (System.Reflection.AssemblyInformationalVersionAttribute), inherit: true);
+			Assert.IsTrue (attrs != null,     "No AssemblyInformationalVersionAttribute values found: `null`!");
+			Assert.IsTrue (attrs.Length > 0,  "No AssemblyInformationalVersionAttribute values found: 0 length!");
+			string version = attrs [0].InformationalVersion;
+			Assert.IsFalse (string.IsNullOrWhiteSpace (version),  "No InformationalVersion provided!");
+			Assert.IsTrue (version.Contains ("; git-rev-head:"),  "No commit info!");
+			Assert.IsTrue (version.Contains ("; git-branch:"),    "No branch info!");
+		}
+	}
+}


### PR DESCRIPTION
Add a test for the contents of of
`AssemblyInformationalVersionAttribute.InformationalVersion`, which
was added in commit b620689d.