### PR TITLE
[Mono.Android-Tests] Fix EnsureAndroidManifestIsUpdated test

### DIFF
--- a/src/Mono.Android/Test/Properties/AndroidManifest.xml
+++ b/src/Mono.Android/Test/Properties/AndroidManifest.xml
@@ -3,7 +3,7 @@
 	<uses-sdk android:minSdkVersion="10" />
 	<application android:label="Xamarin.Android.RuntimeTests" android:name="android.apptests.App">
 		<activity
-				android:name="xamarin.android.runtimetests.RenamedActivity"
+				android:name="android.apptests.RenamedActivity"
 				android:configChanges="keyboardHidden"
 		/>
 	</application>


### PR DESCRIPTION
`ApplicationTest.EnsureAndroidManifestIsUpdated()` was failing:

	Expected: KeyboardHidden
	  at Android.AppTests.ApplicationTest.EnsureAndroidManifestIsUpdated ()

First of all, what *is*
`ApplicationTest.EnsureAndroidManifestIsUpdated()` testing?

Prior to [Xamarin.Android 5.0][0], [Android Callable Wrapper (ACW)][1]
package names were generated by lowercasing the namespace name.
Xamarin.Android 5.0 changed this so that ACW package names were based
on the MD5 of the namespace name and the containing assembly, so that
assembly identity could be maintained. (For example, `A.dll` and
`B.dll` could each have an `Example.SomeType` class without stepping
on each other's toes.)

This change could potentially break a great many things, including in
particular hardcoded `AndroidManifest.xml` entries. To help alleviate
some of that pain, we also implemented support to update
`AndroidManifest.xml` to use the new/correct ACW names when a "legacy"
name was encountered.

This is what `ApplicationTest.EnsureAndroidManifestIsUpdated()` was
testing: `Properties\AndroidManifest.xml` would use the "legacy" name
for the `RenamedActivity` type, and we ensured that names were
correctly updated by using the Android `PackageManager` to query the
`ActivityInfo.ConfigChanges` value.

The cause of the failure was due to the open-source migration: the
namespaces in `src/Mono.Android/Test` were altered from what was in
the original proprietary repo ("cleanup!"), resulting in a *new*
"legacy" name for `RenamedActivity`, but `AndroidManifest.xml` wasn't
updated to use the correct "legacy" name.

Consequently the test broke, because the "wrong" ACW name being used.

Fix the test by updating `AndroidManifest.xml` to use the correct
"legacy" typename for `RenamedActivity`.

[0]: https://developer.xamarin.com/releases/android/xamarin.android_5/xamarin.android_5.1/#Android_Callable_Wrapper_Naming
[1]: https://developer.xamarin.com/guides/android/advanced_topics/java_integration_overview/android_callable_wrappers/