### PR TITLE
[tests] Allow `RunUnitTestApks /p:TestFixture`

### DIFF
--- a/Documentation/DevelopmentTips.md
+++ b/Documentation/DevelopmentTips.md
@@ -97,26 +97,38 @@ For example:
 
 ### Running A Single Test Fixture
 
-`.apk`-based unit tests will look for a `suite` bundle key to determine which
-test fixture to execute. If no such value is provided, then all tests are
-executed.
+A single NUnit *Test Fixture* -- a class with the `[TestFixture]`
+custom attribute -- may be executed instead of executing *all* test fixtures.
 
-The value of the `suite` bundle key may be the full class name of a class
-with the `[TestFixture]` custom attribute.
+The `RunUnitTestApks` target accepts a `TestFixture` MSBuild property
+to specify the test fixture class to execute:
 
-When the `RunUnitTestApks` target runs, an `adb shell am instrument` command
-is printed:
+	$ tools/scripts/xabuild /t:RunUnitTestApks \
+	    /p:TestFixture=Xamarin.Android.LocaleTests.SatelliteAssemblyTests \
+	    tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj
 
-	Tool .../adb execution started with arguments:   shell am instrument  -w "Xamarin.Android.Locale_Tests/xamarin.android.localetests.TestInstrumentation"
+If using `Xamarin.Android.NUnitLite` for projects outside the `xamarin-android`
+repository, such as NUnit tests for a custom app, the `RunUnitTestApks` target
+will not exist. In such scenarios, the [`adb shell am`][adb-shell-am]
+`instrument` command can be used instead. It follows the format:
 
-Turn that into a correctly formatted shell command:
+[adb-shell-am]: https://developer.android.com/studio/command-line/adb.html#am
 
-	$ .../adb shell am instrument  -w "Xamarin.Android.Locale_Tests/xamarin.android.localetests.TestInstrumentation"
+	$ adb shell am instrument -e suite FIXTURE -w PACKAGE/INSTRUMENTATION
 
-Then insert `-e suite FIXTURE_TYPE` arguments before the `-w`:
+Where:
 
-	$ .../adb shell am instrument -e suite Xamarin.Android.LocaleTests.SatelliteAssemblyTests \
+* `FIXTURE` is the full *managed* class name of the NUnit test fixture to
+    execute.
+* `PACKAGE` is the Android package name containing the NUnit tests
+* `INSTRUMENTATION` is the *Java callable wrapper* class name to execute,
+    located within the Android package `PACKAGE`.
+
+For example:
+
+	$ adb shell am instrument -e suite Xamarin.Android.LocaleTests.SatelliteAssemblyTests \
 		-w "Xamarin.Android.Locale_Tests/xamarin.android.localetests.TestInstrumentation"
+
 
 # Testing Updated Assemblies
 

--- a/build-tools/scripts/UnitTestApks.targets
+++ b/build-tools/scripts/UnitTestApks.targets
@@ -101,6 +101,7 @@
         AdbOptions="$(AdbOptions)"
         Component="%(UnitTestApk.Package)/%(UnitTestApk.InstrumentationType)"
         NUnit2TestResultsFile="%(UnitTestApk.ResultsPath)"
+        TestFixture="$(TestFixture)"
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)">
       <Output TaskParameter="NUnit2TestResultsFile" PropertyName="_ResultsFile "/>

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
@@ -14,6 +14,8 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		public                  string              AdbTarget                   { get; set; }
 		public                  string              AdbOptions                  { get; set; }
 
+		public                  string              TestFixture                 { get; set; }
+
 		[Required]
 		public                  string              Component                   { get; set; }
 
@@ -55,6 +57,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				Log.LogMessage (MessageImportance.Low, $"    {a}:");
 			}
 			Log.LogMessage (MessageImportance.Low, $"  {nameof (NUnit2TestResultsFile)}: {NUnit2TestResultsFile}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (TestFixture)}: {TestFixture}");
 
 			executionState  = ExecuteState.RunInstrumentation;
 			base.Execute ();
@@ -82,6 +85,9 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 					args.Append (" -e \"").Append (kvp [0]).Append ("\" \"");
 					args.Append (kvp.Length > 1 ? kvp [1] : "");
 					args.Append ("\"");
+				}
+				if (!string.IsNullOrWhiteSpace (TestFixture)) {
+					args.Append (" -e suite \"").Append (TestFixture).Append ("\"");
 				}
 				return $"{AdbTarget} {AdbOptions} shell am instrument {args.ToString ()} -w \"{Component}\"";
 			case ExecuteState.PullFiles:


### PR DESCRIPTION
Allow providing an NUnit Test Fixture to execute for the on-device
`RunUnitTestApks` MSBuild target:

	$ tools/scripts/xabuild /t:RunUnitTestApks \
	    /p:TestFixture=Xamarin.Android.LocaleTests.SatelliteAssemblyTests \
	    tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj

This is simpler than needing to manually construct the command line.