### PR TITLE
[Xamarin.Android.Net] Changes to CancellationToken support in AndroidClientHandler

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -265,7 +265,10 @@ namespace Xamarin.Android.Net
 			cancellationToken.Register (httpConnection.Disconnect);
 
 			if (httpConnection.DoOutput) {
-				await Task.WhenAny(request.Content.CopyToAsync (httpConnection.OutputStream),Task.Run(() => { cancellationToken.WaitHandle.WaitOne(); })).ConfigureAwait (false);
+				using (var stream = await request.Content.ReadAsStreamAsync())
+				{
+					await stream.CopyToAsync(httpConnection.OutputStream, 4096, cancellationToken).ConfigureAwait(false);
+				}
 			}
 
 			if (cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
These changes are meant to improve cancellation token support for the AndroidClientHandler.
Previously the ConnectAsync and CopyToAsync calls would delay cancellation until those methods finished running, which could take up to 30 seconds on slow connections or in case of a timeout.

1. ConnectAsync: Since ConnectAsync doesn't support cancellation through tokens it had to be wrapped in a WhenAny construction with a task that would be linked to the cancellation token.

2. CopyToAsync: By exposing the HttpContent as a stream using ReadAsStreamAsync method, the CopyToAsync overload which supports cancellation tokens can be used. 
