### PR TITLE
[android-toolchain, tests] Install and use `ant`

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -37,6 +37,7 @@
     <AndroidMxeInstallPrefix Condition=" '$(HostOS)' == 'Linux' ">\usr</AndroidMxeInstallPrefix>
     <AndroidSdkDirectory>$(AndroidToolchainDirectory)\sdk</AndroidSdkDirectory>
     <AndroidNdkDirectory>$(AndroidToolchainDirectory)\ndk</AndroidNdkDirectory>
+    <AntDirectory>$(AndroidToolchainDirectory)\ant</AntDirectory>
     <AndroidSupportedHostJitAbis Condition=" '$(AndroidSupportedHostJitAbis)' == '' ">$(HostOS)</AndroidSupportedHostJitAbis>
     <AndroidSupportedTargetJitAbis Condition=" '$(AndroidSupportedTargetJitAbis)' == '' ">armeabi-v7a:x86</AndroidSupportedTargetJitAbis>
     <JavaInteropSourceDirectory Condition=" '$(JavaInteropSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\Java.Interop</JavaInteropSourceDirectory>

--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -2,6 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <AndroidUri Condition=" '$(AndroidUri)' == '' ">https://dl-ssl.google.com/android/repository</AndroidUri>
+    <AntUri Condition=" '$(AntUri)' == '' ">http://mirrors.ibiblio.org/apache/ant/binaries</AntUri>
   </PropertyGroup>
   <ItemGroup>
     <AndroidNdkItem Include="android-ndk-r11c-linux-x86_64.zip">
@@ -109,6 +110,11 @@
       <Platform>android-21</Platform>
       <Arch>x86_64</Arch>
     </_NdkToolchain>
+  </ItemGroup>
+  <ItemGroup>
+    <AntItem Include="apache-ant-1.9.7-bin.zip">
+      <HostOS></HostOS>
+    </AntItem>
   </ItemGroup>
   <ItemGroup>
     <RequiredProgram Include="$(ManagedRuntime)"    Condition=" '$(ManagedRuntime)' != '' " />

--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -23,8 +23,16 @@
         Condition=" '%(HostOS)' == '$(HostOS)' Or '%(HostOS)' == '' ">
 			<Output TaskParameter="Include" ItemName="_PlatformAndroidNdkItem"/>
     </CreateItem>
+    <CreateItem
+        Include="@(AntItem)"
+        Condition=" '%(HostOS)' == '$(HostOS)' Or '%(HostOS)' == '' ">
+      <Output TaskParameter="Include" ItemName="_PlatformAntItem"/>
+    </CreateItem>
     <ItemGroup>
         <_SdkStampFiles Include="@(_PlatformAndroidSdkItem->'$(AndroidToolchainDirectory)\sdk\.stamp-%(Identity)')" />
+    </ItemGroup>
+    <ItemGroup>
+      <_SdkStampFiles Include="@(_PlatformAntItem->'$(AntDirectory)\.stamp-%(Identity)')" />
     </ItemGroup>
   </Target>
   <Target Name="_DownloadItems"
@@ -35,10 +43,14 @@
         SourceUris="@(_PlatformAndroidSdkItem->'$(AndroidUri)/%(RelUrl)%(Identity)');@(_PlatformAndroidNdkItem->'$(AndroidUri)/%(RelUrl)%(Identity)')"
         DestinationFiles="@(_PlatformAndroidSdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity)');@(_PlatformAndroidNdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity)')"
     />
+    <DownloadUri
+        SourceUris="@(_PlatformAntItem->'$(AntUri)/%(RelUrl)%(Identity)')"
+        DestinationFiles="@(_PlatformAntItem->'$(AndroidToolchainCacheDirectory)\%(Identity)')"
+    />
   </Target>
   <Target Name="_UnzipFiles"
       DependsOnTargets="_DetermineItems"
-      Inputs="@(_PlatformAndroidSdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity)')"
+      Inputs="@(_PlatformAndroidSdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity)');@(_PlatformAntItem->'$(AndroidToolchainCacheDirectory)\%(Identity)')"
       Outputs="@(_SdkStampFiles);$(AndroidToolchainDirectory)\ndk\.stamp-ndk">
     <CreateItem
         Include="@(_PlatformAndroidSdkItem->'$(AndroidToolchainCacheDirectory)\%(_PlatformAndroidSdkItem.Identity)">
@@ -50,8 +62,8 @@
       <Output TaskParameter="Include" ItemName="_AndroidNdkItems"/>
     </CreateItem>
 
-    <RemoveDir Directories="$(AndroidToolchainDirectory)\sdk;$(AndroidToolchainDirectory)\ndk" />
-    <MakeDir Directories="$(AndroidToolchainDirectory)\sdk;$(AndroidToolchainDirectory)\ndk" />
+    <RemoveDir Directories="$(AndroidSdkDirectory);$(AndroidNdkDirectory);$(AntDirectory)" />
+    <MakeDir Directories="$(AndroidSdkDirectory);$(AndroidNdkDirectory);$(AntDirectory)" />
 
     <UnzipDirectoryChildren
         HostOS="$(HostOS)"
@@ -62,6 +74,11 @@
         HostOS="$(HostOS)"
         SourceFiles="@(AndroidNdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity)')"
         DestinationFolder="$(AndroidToolchainDirectory)\ndk"
+    />
+    <UnzipDirectoryChildren
+        HostOS="$(HostOS)"
+        SourceFiles="@(_PlatformAntItem->'$(AndroidToolchainCacheDirectory)\%(Identity)')"
+        DestinationFolder="$(AntDirectory)"
     />
     <Touch
         Files="@(_SdkStampFiles);$(AndroidToolchainDirectory)\ndk\.stamp-ndk"

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
@@ -47,7 +47,7 @@
         WorkingDirectory="java\JavaLib"
     />
     <Exec
-        Command="ant debug"
+        Command="$(AntDirectory)\bin\ant debug"
         WorkingDirectory="java\JavaLib"
     />
     <MakeDir Directories="$(OutputPath)" />


### PR DESCRIPTION
A "funny thing" happened with commit 6e48bca5:
[it built on the PR builder][0], but
[not on the main builder][1].

The cause of the breakage? The PR builders have `ant` installed and
available in `$PATH`; the main builder did not:

	.../xamarin-android/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets:
	error : Command 'ant debug' exited with code: 127.

Exit code 127 means "This program cannot be found."

This was fixed by installing `ant` on the build machine, but this
isn't a great answer, in part because README.md doesn't mention the
fact that `ant` is required for the build.

Extend the `android-toolchain` mechanism so that Apache Ant 1.9.7 is
downloaded and installed into the `$(AndroidToolchain)` directory.
This allows the build system to "know" and maintain it going forward.

Update `Xamarin.Android.LibraryProjectZip-LibBinding.targets` to use
`$(AndroidToolchain)\ant\bin\ant` instead of `ant` for builds.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-pr-builder/331/
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/167/