### PR TITLE
[Xamarin.ProjectTools] Fix the Linux build.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -106,8 +106,15 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <Content Include="..\..\..\..\bin\$(Configuration)\lib\xbuild\Xamarin\Android\libzip.3.0.dylib">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    <Content
+        Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))"
+        Include="..\..\..\..\bin\$(Configuration)\lib\xbuild\Xamarin\Android\libzip.3.0.dylib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content
+        Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:')) And '$(_LinuxBuildLibZip)' == 'True' "
+        Include="..\..\..\..\bin\$(Configuration)\lib\xbuild\Xamarin\Android\libzip.so">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
[The Linux build is broken][0]:

	error : Cannot copy .../xamarin-android/bin/Debug/lib/xbuild/Xamarin/Android/libzip.3.0.dylib
	to .../xamarin-android/bin/TestDebug/libzip.3.0.dylib, as the source file doesn't exist.

This is (kinda, sorta) akin to commit fb068758, wherein
`Xamarin.ProjectTools.csproj` was specific to the macOS ("Darwin")
build, and thus was referencing a file that didn't exist on Linux.

Fix `Xamarin.ProjectTools.csproj` so that the appropriate `libzip`
native library is included, as appropriate for the host OS.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-linux/134/console