### PR TITLE
Updated Build Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,6 @@ Building Xamarin.Android requires:
 * [Autotools (`autoconf`, `automake`, etc.)](#autotools)
 * [`xxd`](#xxd)
 * [The Android SDK and NDK](#ndk)
-* [`brew programs`](#brew)
-
 
 <a name="mono-sdk" />
 ## Mono MDK
@@ -169,33 +167,6 @@ URL to download files from is controlled by the `$(AndroidUri)` property.
 
 [android-toolchain.projitems]: build-tools/android-toolchain/android-toolchain.projitems
 
-<a name="brew" />
-## Brew Programs (If you are missing one or many programs on OSX)
-
-`brew install cmake`
-
-`brew install libtool`
-
-`brew install p7zip`
-
-`brew install gdk-pixbuf`
-
-`brew install gettext`
-
-`brew install coreutils findutils gnu-tar gnu-sed gawk gnutls gnu-indent gnu-getopt`
-
-`brew install intltool`
-
-`brew install scons`
-
-`brew install wget`
-
-`brew install xz`
-
-If any program is not found, try to ensure it's linked via:
-
-`brew link <package name>`
-
 # Build
 
 At this point in time, building Xamarin.Android is only supported on OS X.
@@ -206,7 +177,8 @@ To build Xamarin.Android, first prepare the project:
     make prepare
 
 This will perform `git submodule update`, and any other pre-build tasks
-that need to be performed. After this process is completed, ensure there is no existing git changes in the `external` folder.
+that need to be performed. After this process is completed, ensure there 
+is no existing git changes in the `external` folder.
 
 On the main repo, you can use `git status` to ensure a clean slate.
 
@@ -238,6 +210,35 @@ To disable `binfmt_misc` you need to issue the following command as root:
 and to enable it again, issue the following command:
 
         echo 1 > /proc/sys/fs/binfmt_misc/status
+        
+## Build Troubleshooting (OSX)
+
+If various programs are missing during the `build-tools/scripts/RequiredPrograms.targets`
+step, please follow this list of `brew` programs to install:
+ 
+### Brew Programs
+```
+brew install cmake
+brew install libtool
+brew install p7zip
+brew install gdk-pixbuf
+brew install gettext
+brew install coreutils
+brew install findutils
+brew install gnu-tar
+brew install gnu-sed
+brew install gawk
+brew install gnutls
+brew install gnu-indent
+brew install gnu-getopt
+brew install intltool
+brew install scons
+brew install wget
+brew install xz
+```
+If any program is still not found, try to ensure it's linked via:
+
+`brew link <package name>`
 
 # Build Output Directory Structure
 

--- a/README.md
+++ b/README.md
@@ -109,8 +109,7 @@ Building Xamarin.Android requires:
 * [Autotools (`autoconf`, `automake`, etc.)](#autotools)
 * [`xxd`](#xxd)
 * [The Android SDK and NDK](#ndk)
-* [`cmake`](#cmake)
-* [`libtool`](#libtool)
+* [`brew programs`](#brew)
 
 
 <a name="mono-sdk" />
@@ -170,19 +169,32 @@ URL to download files from is controlled by the `$(AndroidUri)` property.
 
 [android-toolchain.projitems]: build-tools/android-toolchain/android-toolchain.projitems
 
-<a name="cmake" />
-## cmake
-
-You might run into an issue with `cmake` not being available on your machine. Use `brew` to install `cmake`:
+<a name="brew" />
+## Brew Programs
 
 `brew install cmake`
 
-<a name="libtool" />
-## libtool
-
-You might run into an issue with `libtool` not being available on your machine. Use `brew` to install `libtool`:
-
 `brew install libtool`
+
+`brew install p7zip`
+
+`brew install gdk-pixbuf`
+
+`brew install gettext`
+
+`brew install coreutils findutils gnu-tar gnu-sed gawk gnutls gnu-indent gnu-getopt`
+
+`brew install intltool`
+
+`brew install scons`
+
+`brew install wget`
+
+`brew install xz`
+
+If any program is not found, try to ensure it's linked via:
+
+`brew link <package name>`
 
 # Build
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ URL to download files from is controlled by the `$(AndroidUri)` property.
 [android-toolchain.projitems]: build-tools/android-toolchain/android-toolchain.projitems
 
 <a name="brew" />
-## Brew Programs
+## Brew Programs (If you are missing one or many programs on OSX)
 
 `brew install cmake`
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ Building Xamarin.Android requires:
 * [Autotools (`autoconf`, `automake`, etc.)](#autotools)
 * [`xxd`](#xxd)
 * [The Android SDK and NDK](#ndk)
+* [`cmake`](#cmake)
+* [`libtool`](#libtool)
+
 
 <a name="mono-sdk" />
 ## Mono MDK
@@ -137,6 +140,10 @@ the Mono runtimes.
 
 On OS X, autotools are distributed with [Mono.framework][osx-mono].
 
+If you run into issues regarding `autoconf` or `automake` try to install it with `brew` via:
+
+`brew install automake`
+
 <a name="xxd" />
 ## `xxd`
 
@@ -163,6 +170,20 @@ URL to download files from is controlled by the `$(AndroidUri)` property.
 
 [android-toolchain.projitems]: build-tools/android-toolchain/android-toolchain.projitems
 
+<a name="cmake" />
+## cmake
+
+You might run into an issue with `cmake` not being available on your machine. Use `brew` to install `cmake`:
+
+`brew install cmake`
+
+<a name="libtool" />
+## libtool
+
+You might run into an issue with `libtool` not being available on your machine. Use `brew` to install `libtool`:
+
+`brew install libtool`
+
 # Build
 
 At this point in time, building Xamarin.Android is only supported on OS X.
@@ -173,7 +194,9 @@ To build Xamarin.Android, first prepare the project:
     make prepare
 
 This will perform `git submodule update`, and any other pre-build tasks
-that need to be performed.
+that need to be performed. After this process is completed, ensure there is no existing git changes in the `external` folder.
+
+On the main repo, you can use `git status` to ensure a clean slate.
 
 Then, you may do one of the following:
 


### PR DESCRIPTION
Added multiple tools that were not added on the initial build document that one might need on OSX to build xamarin-android. Adding these items via brew was the easiest way to get `make` to fully build the project.