### PR TITLE
[mono-runtimes] Use correct MONO_PATH for MonoAotOffsetsDumper.exe

### DIFF
--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -365,8 +365,12 @@
         Command="make $(_AotOffsetsDumperName)"
         WorkingDirectory="$(_AotOffsetsDumperSourceDir)" 
     />
+    <PropertyGroup>
+      <_CppAbiDir Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">osx_32</_CppAbiDir>
+      <_CppAbiDir Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:'))">linux_64</_CppAbiDir>
+    </PropertyGroup>
     <Exec
-        Command="MONO_PATH=$(_AotOffsetsDumperSourceDir)\CppSharp $(ManagedRuntime) $(_AotOffsetsDumperSourceDir)\$(_AotOffsetsDumperName) --xamarin-android --android-ndk=&quot;$(AndroidNdkFullPath)&quot; --mono=&quot;$(MonoSourceFullPath)&quot; --monodroid=&quot;$(XamarinAndroidSourcePath)&quot; --abi=&quot;%(_MonoCrossRuntime.TargetAbi)&quot; --out=&quot;$(MSBuildThisFileDirectory)$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)&quot;"
+        Command="MONO_PATH=$(_AotOffsetsDumperSourceDir)\CppSharp\$(_CppAbiDir) $(ManagedRuntime) $(_AotOffsetsDumperSourceDir)\$(_AotOffsetsDumperName) --xamarin-android --android-ndk=&quot;$(AndroidNdkFullPath)&quot; --mono=&quot;$(MonoSourceFullPath)&quot; --monodroid=&quot;$(XamarinAndroidSourcePath)&quot; --abi=&quot;%(_MonoCrossRuntime.TargetAbi)&quot; --out=&quot;$(MSBuildThisFileDirectory)$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)&quot;"
         WorkingDirectory="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)"
     />
     <Touch


### PR DESCRIPTION
Commit 3428975c [broke the macOS build][0]

	Executing: .../MonoAotOffsetsDumper.exe ...
	Unhandled Exception:
	System.IO.FileNotFoundException: Could not load file or assembly
	'CppSharp.Generator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'
	or one of its dependencies.

The cause of the error is [`CppSharpBinaries/6466d5f7`][1], which
altered the directory structure of the CppSharpBinaries/60f763a9
*branch* (Yes, it's a branch!) from:

	CppSharpBinaries/CppSharp.Generator.dll

to:

	CppSharpBinaries/osx_32/CppSharp.Generator.dll

Since our `MONO_PATH` value wasn't updated, mono thus couldn't find
`CppSharp.Generator.dll`, hence the error.

Update our `MONO_PATH` value so that `CppSharp.Generator.dll` and
other dependencies can be found.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/170/
[1]: https://github.com/xamarin/CppSharpBinaries/commit/6466d5f7c70212fc56aac1a3d96f997935ba7dd7