### PR TITLE
[msbuild] Add new AndroidSkipJavacVersionCheck property.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AdjustJavacVersionArguments.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AdjustJavacVersionArguments.cs
@@ -16,6 +16,8 @@ namespace Xamarin.Android.Tasks
 
 		public bool EnableMultiDex { get; set; }
 
+		public bool SkipJavacVersionCheck { get; set; }
+
 		[Output]
 		public string TargetVersion { get; set; }
 
@@ -32,6 +34,10 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("ToolExe: {0}", ToolExe);
 			Log.LogDebugMessage ("EnableProguard: {0}", EnableProguard);
 			Log.LogDebugMessage ("EnableMultiDex: {0}", EnableMultiDex);
+			Log.LogDebugMessage ("SkipJavacVersionCheck: {0}", SkipJavacVersionCheck);
+
+			if (SkipJavacVersionCheck)
+				return true;
 
 			// so far only proguard matters.
 			if (!EnableProguard && !EnableMultiDex)

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -177,7 +177,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<MonoAndroidVersion>v$(_XAMajorVersionNumber).0</MonoAndroidVersion>
 	<AndroidUpdateResourceReferences Condition="'$(AndroidUpdateResourceReferences)' == ''">True</AndroidUpdateResourceReferences>
 	<EmbedAssembliesIntoApk Condition="'$(EmbedAssembliesIntoApk)' == ''">True</EmbedAssembliesIntoApk>
-
+	<AndroidSkipJavacVersionCheck Condition="'$(AndroidSkipJavacVersionCheck)' == ''">False</AndroidSkipJavacVersionCheck>
 
 	<!-- Ahead-of-time compilation properties -->
 	<AndroidAotMode Condition=" '$(AndroidAotMode)' == '' And '$(AotAssemblies)' == 'True' ">Normal</AndroidAotMode>
@@ -1825,6 +1825,7 @@ because xbuild doesn't support framework reference assemblies.
 		Condition="'$(JavacTargetVersion)'=='' or '$(JavacSourceVersion)' == ''"
 		ToolPath="$(JavacToolPath)"
 	    ToolExe="$(JavacToolExe)"
+	    SkipJavacVersionCheck="$(AndroidSkipJavacVersionCheck)"
 	    EnableProguard="$(AndroidEnableProguard)"
 	    EnableMultiDex="$(AndroidEnableMultiDex)">
 	    <Output TaskParameter="TargetVersion" PropertyName="JavacTargetVersion" />


### PR DESCRIPTION
We check javac version and adjust source compatibility to 1.7 if the
version is 1.8, and proguard or multidex is used (because, they are
incompatible with Java8).

This, being the mandatory behavior is, however, problematic.

When we supply custom proguard as a NuGet package to resolve the Java8
incompatibility issue, we still expect Java8 is used (otherwise,
support library applications do not compile). But the above prevents that.

So, skip javac version check when AndroidSkipJavacVersionCheck property
is 'True'.

My facebook proguard NuGet package already has this property as true
in its MSBuild props file. So you can add this in your Android 7.0+
project and enable proguard or multidex, once you get this change merged.
https://www.nuget.org/packages/name.atsushieno.proguard.facebook/5.3.2.2