### PR TITLE
generate mono.android.dex files

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -52,6 +52,7 @@
     <AllSupported32BitTargetAndroidAbis>armeabi;armeabi-v7a;x86</AllSupported32BitTargetAndroidAbis>
     <AllSupported64BitTargetAndroidAbis>arm64-v8a;x86_64</AllSupported64BitTargetAndroidAbis>
     <AllSupportedTargetAndroidAbis>$(AllSupported32BitTargetAndroidAbis);$(AllSupported64BitTargetAndroidAbis)</AllSupportedTargetAndroidAbis>
+    <XABuildToolsVersion>25.0.1</XABuildToolsVersion>
   </PropertyGroup>
   <PropertyGroup>
     <_MingwPrefixTail Condition=" '$(HostOS)' == 'Darwin' ">.static</_MingwPrefixTail>

--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -8,9 +8,12 @@
     <AndroidNdkItem Include="android-ndk-r11c-linux-x86_64.zip">
       <HostOS>Linux</HostOS>
     </AndroidNdkItem>
-    <AndroidSdkItem Include="build-tools_r23-linux.zip">
+    <!--
+      $(XABuildToolsVersion) is defined in Configuration.props
+      -->
+    <AndroidSdkItem Include="build-tools_r$(XABuildToolsVersion)-linux.zip">
       <HostOS>Linux</HostOS>
-      <DestDir>build-tools\23.0.0</DestDir>
+      <DestDir>build-tools\$(XABuildToolsVersion)</DestDir>
     </AndroidSdkItem>
     <AndroidSdkItem Include="platform-tools_r23-linux.zip">
       <HostOS>Linux</HostOS>
@@ -23,9 +26,9 @@
     <AndroidNdkItem Include="android-ndk-r11c-darwin-x86_64.zip">
       <HostOS>Darwin</HostOS>
     </AndroidNdkItem>
-    <AndroidSdkItem Include="build-tools_r23-macosx.zip">
+    <AndroidSdkItem Include="build-tools_r$(XABuildToolsVersion)-macosx.zip">
       <HostOS>Darwin</HostOS>
-      <DestDir>build-tools\23.0.0</DestDir>
+      <DestDir>build-tools\$(XABuildToolsVersion)</DestDir>
     </AndroidSdkItem>
     <AndroidSdkItem Include="platform-tools_r23-macosx.zip">
       <HostOS>Darwin</HostOS>

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -168,6 +168,34 @@
         Command="jar cf &quot;$(OutputPath)mono.android.jar&quot; -C &quot;$(IntermediateOutputPath)jcw\bin&quot; ."
     />
   </Target>
+  <Target Name="_GenerateMonoAndroidDex16"
+      AfterTargets="_GenerateJavaCallableWrappers"
+      Condition="'$(JavacSourceVersion)' == '1.6'"
+      Inputs="$(OutputPath)mono.android.jar"
+      Outputs="$(OutputPath)mono.android.dex">
+    <Exec
+        Command="&quot;$(AndroidSdkDirectory)&quot;\build-tools\$(XABuildToolsVersion)\dx --dex --output=&quot;$(OutputPath)mono.android.dex&quot; &quot;$(OutputPath)mono.android.jar&quot;"
+    />
+  </Target>
+  <Target Name="_GenerateMonoAndroidDex18"
+      AfterTargets="_GenerateJavaCallableWrappers"
+      Condition="'$(JavacSourceVersion)' == '1.8'"
+      Inputs="$(OutputPath)mono.android.jar"
+      Outputs="$(OutputPath)mono.android.dex">
+    <MakeDir
+        Directories="$(IntermediateOutputPath)__dex"
+    />
+    <Exec
+        Command="java -jar &quot;$(AndroidSdkDirectory)&quot;\build-tools\$(XABuildToolsVersion)\jack.jar --output-dex=&quot;$(IntermediateOutputPath)__dex&quot; -cp &quot;$(AndroidToolchainDirectory)\sdk\platforms\android-$(AndroidApiLevel)\android.jar&quot; @&quot;$(IntermediateOutputPath)jcw\classes.txt&quot;"
+    />
+    <Copy
+        SourceFiles="$(IntermediateOutputPath)__dex\classes.dex"
+        DestinationFiles="$(OutputPath)mono.android.dex"
+    />
+    <RemoveDir
+        Directories="$(IntermediateOutputPath)__dex"
+    />
+  </Target>
   <Target Name="_GenerateFrameworkList"
       AfterTargets="CoreBuild"
       Inputs="$(OutputPath)$(AssemblyName).dll"


### PR DESCRIPTION
 - the jack.jar in build-tools 23 is broken, thus update to 25

 - possible issue when there is more than one build-tools version
   installed. in future we might add tasks to provide easy way to get
   build-tools path and dx, javac and java binaries or reuse the ones in src/Xamarin.Android.Build.Tasks/Tasks