### PR TITLE
[Xamarin.Android.Build.Tasks] Archiving Android application is archiving old builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2271,6 +2271,7 @@ because xbuild doesn't support framework reference assemblies.
 		;@(ReferenceDependencyPaths)
 		;$(ApkFileIntermediate)
 		;$(_AndroidBuildPropertiesCache)
+		;@(ApkFiles)
 	</_CopyPackageInputs>
 </PropertyGroup>
 


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=48508

The problem here was the output from the BuildApk task was not
being included as an input for the task which copied the apk to
the output directory. So when it was being updated (i.e not created)
it was not being flagged as changed by the build system.