### PR TITLE
[tools/scripts] Add mono-symbolicate to the build system.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -9,6 +9,7 @@
     <BuildDependsOn>
 		$(BuildDependsOn);
 		_CopyExtractedMultiDexJar;
+		_BuildMonoSymbolicate;
     </BuildDependsOn>
     <_AndroidSdkLocation>$(ANDROID_SDK_PATH)</_AndroidSdkLocation>
     <_AndroidSdkLocation Condition="'$(_AndroidSdkLocation)'==''">$(AndroidToolchainDirectory)\sdk</_AndroidSdkLocation>
@@ -55,5 +56,20 @@
     <Copy
       SourceFiles="$(_AndroidSdkLocation)\$(_SupportLicenseInAndroidSdk)"
       DestinationFiles="$(OutputPath)..\..\..\mandroid\MULTIDEX_JAR_LICENSE" />
+  </Target>
+
+  <Target Name="_BuildMonoSymbolicate">
+    <MSBuild
+        Projects="..\..\external\mono\mcs\tools\mono-symbolicate\monosymbolicate.csproj"
+        Properties="OutputPath=..\..\..\..\..\bin\$(Configuration)\lib\mandroid\;Configuration=$(Configuration);AssemblyName=mono-symbolicate"
+    />
+    <Copy
+        SourceFiles="..\..\tools\scripts\mono-symbolicate"
+        DestinationFiles="$(OutputPath)..\..\..\..\bin\mono-symbolicate"
+    />
+    <Copy
+        SourceFiles="..\..\tools\scripts\mono-symbolicate.cmd"
+        DestinationFiles="$(OutputPath)..\..\..\..\bin\mono-symbolicate.cmd"
+    />
   </Target>
 </Project>

--- a/tools/scripts/mono-symbolicate
+++ b/tools/scripts/mono-symbolicate
@@ -1,0 +1,6 @@
+#!/bin/sh
+BINDIR=`dirname "$0"`
+MANDROID_DIR="$BINDIR/../lib/mandroid"
+
+unset MONO_PATH
+exec mono $MONO_OPTIONS "$MANDROID_DIR/mono-symbolicate.exe" "$@"

--- a/tools/scripts/mono-symbolicate.cmd
+++ b/tools/scripts/mono-symbolicate.cmd
@@ -1,0 +1,2 @@
+@echo off
+%~dp0\..\lib\mandroid\mono-symbolicate.exe %*


### PR DESCRIPTION
We were missing mono-symbolicate as a result release builds would
often fail when it tries to symbolicate the assemblies.

This commit adds a new Target to build the mono-symbolicate.exe from
the mono tree and place it in

	bin\$(Configuration)\lib\mandroid

it also adds two scripts, one for unix based systems and one for windows.
These scripts will end up in

	bin\$(Configuration)\bin

and will be run by the build tasks from that location.