### PR TITLE
[aot] enable LLVM/AOT configuration for aarch64

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -152,11 +152,6 @@ namespace Xamarin.Android.Tasks
 
 		static bool ValidateAotConfiguration (TaskLoggingHelper log, AndroidTargetArch arch, bool enableLLVM)
 		{
-			if (arch == AndroidTargetArch.Arm64 && enableLLVM) {
-				log.LogCodedError ("XA3004", "arm64-v8a architecture is not currently supported on LLVM AOT mode.");
-				return false;
-			}
-
 			if (arch == AndroidTargetArch.X86_64) {
 				log.LogCodedError ("XA3004", "x86_64 architecture is not currently supported on AOT mode.");
 				return false;


### PR DESCRIPTION
Verified with (on a HelloWorld app):

```
adb shell setprop debug.mono.env "'MONO_LOG_LEVEL=debug'"

12-16 14:45:21.469 19309 19309 D Mono    : AOT: loaded AOT Module for mscorlib.dll.
12-16 14:45:21.489 19309 19309 V Mono    : AOT: FOUND method System.OutOfMemoryException:.ctor (string) [0x7f71b8ec08 - 0x7f71b8ec50 0x7f71f26230]
12-16 14:45:21.489 19309 19309 V Mono    : AOT: FOUND method System.Exception:.cctor () [0x7f71b85cdc - 0x7f71b85d14 0x7f71f25c9c]
12-16 14:45:21.489 19309 19309 V Mono    : AOT: FOUND method System.Exception:Init () [0x7f71b84b38 - 0x7f71b84b94 0x7f71f25b54]
12-16 14:45:21.489 19309 19309 V Mono    : AOT: FOUND method System.NullReferenceException:.ctor (string) [0x7f71b8b444 - 0x7f71b8b48c 0x7f71f2615c]
12-16 14:45:21.489 19309 19309 V Mono    : AOT: FOUND method System.StackOverflowException:.ctor (string) [0x7f71b90c10 - 0x7f71b90c58 0x7f71f26373]
```

full log here:
https://gist.github.com/lewurm/da636a74e6ab0a399a63905a2af3b4c7


fixes https://bugzilla.xamarin.com/show_bug.cgi?id=28478



needs at least this runtime commit of the `mono-4.8.0-branch`:
https://github.com/mono/mono/commit/1e31bd78e69569c9e26a7d5018660ad389112b17