### PR TITLE
[msbuild] support AndroidManifest.xml placeholders.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -38,6 +38,7 @@ namespace Xamarin.Android.Tasks
 		public bool Debug { get; set; }
 		public string ApplicationName { get; set; }
 		public string PackageName { get; set; }
+		public string [] ManifestPlaceholders { get; set; }
 
 		public string AndroidSdkDir { get; set; }
 
@@ -77,6 +78,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugTaskItems ("  MergedManifestDocuments:", MergedManifestDocuments);
 			Log.LogDebugMessage ("  PackageNamingPolicy: {0}", PackageNamingPolicy);
 			Log.LogDebugMessage ("  ApplicationJavaClass: {0}", ApplicationJavaClass);
+			Log.LogDebugTaskItems ("  ManifestPlaceholders: ", ManifestPlaceholders);
 
 			try {
 				// We're going to do 3 steps here instead of separate tasks so
@@ -199,6 +201,7 @@ namespace Xamarin.Android.Tasks
 
 			manifest.PackageName = PackageName;
 			manifest.ApplicationName = ApplicationName ?? PackageName;
+			manifest.Placeholders = ManifestPlaceholders;
 			manifest.Assemblies.AddRange (assemblies);
 			manifest.Resolver = res;
 			manifest.SdkDir = AndroidSdkDir;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -47,6 +47,7 @@ namespace Xamarin.Android.Tasks {
 		public string PackageName { get; set; }
 		public List<string> Addons { get; private set; }
 		public string ApplicationName { get; set; }
+		public string [] Placeholders { get; set; }
 		public List<string> Assemblies { get; set; }
 		public DirectoryAssemblyResolver Resolver { get; set; }
 		public string SdkDir { get; set; }
@@ -780,7 +781,7 @@ namespace Xamarin.Android.Tasks {
 			using (var file = new StreamWriter (filename, false, new UTF8Encoding (false)))
 				Save (file);
 		}
-		
+
 		public void Save (System.IO.TextWriter stream)
 		{
 			var ms = new MemoryStream ();
@@ -790,6 +791,13 @@ namespace Xamarin.Android.Tasks {
 			var s = new StreamReader (ms).ReadToEnd ();
 			if (ApplicationName != null)
 				s = s.Replace ("${applicationId}", ApplicationName);
+			if (Placeholders != null)
+				foreach (var entry in Placeholders.Select (e => e.Split (new char [] {'='}, 2, StringSplitOptions.None))) {
+					if (entry.Length == 2)
+						s = s.Replace ("${" + entry [0] + "}", entry [1]);
+					else
+						log.LogWarning ("Invalid application placeholders (AndroidApplicationPlaceholders) value. Use 'key1=value1;key2=value2, ...' format. The specified value was: " + Placeholders);
+				}
 			stream.Write (s);
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -250,6 +250,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	
 	<_AndroidMainDexListFile>$(IntermediateOutputPath)multidex.keep</_AndroidMainDexListFile>
 	
+	<AndroidManifestPlaceholders Condition="'$(AndroidManifestPlaceholders)' == ''"></AndroidManifestPlaceholders>
+		
 	<_PackagedResources>$(IntermediateOutputPath)android\bin\packaged_resources</_PackagedResources>
 
 	<_Android32bitArchitectures>armeabi-v7a;armeabi;x86;mips</_Android32bitArchitectures>
@@ -1686,6 +1688,7 @@ because xbuild doesn't support framework reference assemblies.
 	AndroidSdkPlatform="$(_AndroidApiLevel)"
 	AndroidSdkDir="$(_AndroidSdkDirectory)"
 	PackageName="$(_AndroidPackage)"
+	ManifestPlaceholders="$(AndroidManifestPlaceholders)"
 	OutputDirectory="$(IntermediateOutputPath)android"
 	MergedAndroidManifestOutput="$(IntermediateOutputPath)android\AndroidManifest.xml"
     UseSharedRuntime="$(AndroidUseSharedRuntime)"


### PR DESCRIPTION
We only support ${applicationId} so far, but it seems to be used a lot as
https://developer.android.com/studio/build/manifest-build-variables.html

Since we are not using Gradle, we'd need something similar to it, which
is therefore MSBuild property.