### PR TITLE
[Xamarin.Android.Build.Tasks] Add a new PrepareForBuild Target for unit tests

### DIFF
--- a/src/Mono.Android/Test/Mono.Android-Tests.targets
+++ b/src/Mono.Android/Test/Mono.Android-Tests.targets
@@ -11,7 +11,7 @@
   <Import Project="..\..\..\build-tools\scripts\UnitTestApks.targets" />
   <Target Name="BuildNativeLibs"
       BeforeTargets="Build"
-      DependsOnTargets="_ResolveMonoAndroidSdks"
+      DependsOnTargets="AndroidPrepareForBuild"
       Inputs="jni\reuse-threads.c;jni\Android.mk"
       Outputs="@(AndroidNativeLibrary)">
     <Error Text="Could not locate Android NDK." Condition="!Exists ('$(AndroidNdkDirectory)\ndk-build')" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -93,6 +93,8 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
   <Target Name="_ResolveMonoAndroidFramework" DependsOnTargets="GetReferenceAssemblyPaths" >
   </Target>
 
+  <Target Name="AndroidPrepareForBuild" DependsOnTargets="_ResolveMonoAndroidFramework" />
+
   <PropertyGroup>
     <GeneratedOutputPath Condition="'$(GeneratedOutputPath)' == ''">$(IntermediateOutputPath)generated\</GeneratedOutputPath>
     <ApiOutputFile Condition="'$(ApiOutputFile)' == ''">$(IntermediateOutputPath)api.xml</ApiOutputFile>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -830,6 +830,8 @@ because xbuild doesn't support framework reference assemblies.
 	</CreateProperty>
 </Target>
 
+<Target Name="AndroidPrepareForBuild" DependsOnTargets="_ResolveMonoAndroidFramework" />
+
 <!-- uploadflags.txt
 	- This file says which devices this package has been deployed to.
 	- Need to delete on rebuild so package will get redeployed. -->

--- a/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="BuildJars"
-      DependsOnTargets="_ResolveMonoAndroidSdks"
+      DependsOnTargets="AndroidPrepareForBuild"
       Inputs="@(InputJarSource)"
       Outputs="@(InputJar)">
     <MakeDir Directories="Jars\classes" />

--- a/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="BuildJars"
-      DependsOnTargets="_ResolveMonoAndroidSdks"
+      DependsOnTargets="AndroidPrepareForBuild"
       Inputs="@(InputJarSource)"
       Outputs="@(InputJar)">
     <MakeDir Directories="Jars\classes" />

--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.targets
@@ -3,17 +3,17 @@
   <Import Project="Xamarin.Android.JcwGen-Tests.projitems" />
   <Import Project="..\..\..\build-tools\scripts\UnitTestApks.targets" />
   <Target Name="BuildNativeLibs"
-      DependsOnTargets="_ResolveMonoAndroidSdks"
+      DependsOnTargets="AndroidPrepareForBuild"
       Inputs="jni\Android.mk;jni\timing.c"
       Outputs="@(AndroidNativeLibrary)">
     <Error
-        Condition="!Exists ('$(_AndroidNdkDirectory)\ndk-build')"
+        Condition="!Exists ('$(AndroidNdkDirectory)\ndk-build')"
         Text="Could not locate Android NDK."
     />
-    <Exec Command="&quot;$(_AndroidNdkDirectory)\ndk-build&quot;" />
+    <Exec Command="&quot;$(AndroidNdkDirectory)\ndk-build&quot;" />
   </Target>
   <Target Name="RunTests"
-      DependsOnTargets="_ValidateAndroidPackageProperties">
+      DependsOnTargets="AndroidPrepareForBuild">
     <Exec Command="&quot;$(_AndroidPlatformToolsDirectory)adb&quot; $(AdbTarget) $(AdbOptions) shell am instrument -w $(_AndroidPackage)/xamarin.android.jcwgentests.TestInstrumentation" />
   </Target>
   <Target Name="CleanLocal">

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="BuildNativeLibs"
-      DependsOnTargets="_ResolveMonoAndroidSdks"
+      DependsOnTargets="AndroidPrepareForBuild"
       Inputs="jni\simple-lib.c;jni\Android.mk"
       Outputs="@(AndroidNativeLibrary);$(OutputPath)\native-lib-1\NativeLib.zip">
     <Error
@@ -16,7 +16,7 @@
     />
   </Target>
   <Target Name="BuildNativeLibs2"
-      DependsOnTargets="_ResolveMonoAndroidSdks"
+      DependsOnTargets="AndroidPrepareForBuild"
       Inputs="simple2\jni\simple2-lib.c;simple2\jni\Android.mk"
       Outputs="@(AndroidNativeLibrary);$(OutputPath)\native-lib-2\NativeLib2.zip">
     <Error
@@ -39,7 +39,7 @@
     />
   </Target>
   <Target Name="BuildJavaLibs"
-      DependsOnTargets="_ResolveMonoAndroidSdks"
+      DependsOnTargets="AndroidPrepareForBuild"
       Inputs="java\JavaLib\project.properties"
       Outputs="$(OutputPath)JavaLib.zip">
     <Exec

--- a/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/Xamarin.Android.McwGen-Tests.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/Xamarin.Android.McwGen-Tests.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="BuildJars"
-      DependsOnTargets="_ResolveMonoAndroidSdks"
+      DependsOnTargets="AndroidPrepareForBuild"
       Inputs="@(XamarinTestJar);%(IgnoreJar.Source)"
       Outputs="@(EmbeddedJar);@(IgnoreJar)">
     <MakeDir Directories="$(OutputPath)xt-classes" />

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib2/Xamarin.Android.BindingResolveImportLib2.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib2/Xamarin.Android.BindingResolveImportLib2.csproj
@@ -83,9 +83,9 @@
     <RemoveDir Directories="Jars/bin" />
     <Delete Files="Jars/lib2.jar;Jars/com/xamarin/android/test/binding/resolveimport/Lib2.class" />
   </Target>
-  <Target Name="BuildNativeLibs" DependsOnTargets="_ResolveMonoAndroidSdks" Inputs="jni\timing.c;jni\Android.mk" Outputs="@(EmbeddedNativeLibrary)">
-    <Error Text="Could not locate Android NDK." Condition="!Exists ('$(_AndroidNdkDirectory)\ndk-build')" />
-    <Exec Command="&quot;$(_AndroidNdkDirectory)\ndk-build&quot;" />
+  <Target Name="BuildNativeLibs" DependsOnTargets="AndroidPrepareForBuild" Inputs="jni\timing.c;jni\Android.mk" Outputs="@(EmbeddedNativeLibrary)">
+    <Error Text="Could not locate Android NDK." Condition="!Exists ('$(AndroidNdkDirectory)\ndk-build')" />
+    <Exec Command="&quot;$(AndroidNdkDirectory)\ndk-build&quot;" />
   </Target>
   <Target Name="CleanNativeLibs">
     <RemoveDir Directories="obj\local;libs" />

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib4/Xamarin.Android.BindingResolveImportLib4.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib4/Xamarin.Android.BindingResolveImportLib4.csproj
@@ -81,9 +81,9 @@
     <RemoveDir Directories="Jars/bin" />
     <Delete Files="Jars/lib4.jar;Jars/com/xamarin/android/test/binding/resolveimport/Lib4.class" />
   </Target>
-  <Target Name="BuildNativeLibs" DependsOnTargets="_ResolveMonoAndroidSdks" Inputs="jni\timing.c;jni\Android.mk" Outputs="@(EmbeddedNativeLibrary)">
-    <Error Text="Could not locate Android NDK." Condition="!Exists ('$(_AndroidNdkDirectory)\ndk-build')" />
-    <Exec Command="&quot;$(_AndroidNdkDirectory)\ndk-build&quot;" />
+  <Target Name="BuildNativeLibs" DependsOnTargets="AndroidPrepareForBuild" Inputs="jni\timing.c;jni\Android.mk" Outputs="@(EmbeddedNativeLibrary)">
+    <Error Text="Could not locate Android NDK." Condition="!Exists ('$(AndroidNdkDirectory)\ndk-build')" />
+    <Exec Command="&quot;$(AndroidNdkDirectory)\ndk-build&quot;" />
   </Target>
   <Target Name="CleanNativeLibs">
     <RemoveDir Directories="obj\local;libs" />


### PR DESCRIPTION
Some of our unit tests dont need to build but do need to resolve
the android SDK and other properties. We did us the _ValidateAndroidPackageProperties
target to make sure all of the required properties were in place.

However commit 8337d21e altered the build process so that target is
run earlier in the build process. As a result the required properties
are not initialised.

This commit adds a new "PrepareForBuild" target which ensures that
the correct targets are run for tests.