### PR TITLE
[Xamarin.Android.Build.Tasks] Asyncify Aapt Task

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1187,35 +1187,19 @@ because xbuild doesn't support framework reference assemblies.
   Outputs="$(_AndroidComponentResgenFlagFile)"
   DependsOnTargets="$(_GenerateJavaDesignerForComponentDependsOnTargets)">
 
-<!--
-  This copy is required because the Aapt statement below will be Batched.
-  Aapt will be called for each Path in _AdditonalAndroidResourceCachePaths
-  this is beause of the ManifestFile and Contition properties being set to 
-
-  "%(_AdditonalAndroidResourceCachePaths.Identity)\AndroidManifest.xml"
-
-  the use of .Identify will cause the batch. However we do need ALL of the 
-  resource cache paths to be passed in to correctly resolve resources. If
-  we don't do this only the current "batched" path will be included. 
--->
- <ItemGroup>
-  <_AdditionalAndroidResourceCachePathsCopy Include="@(_AdditonalAndroidResourceCachePaths)"/>
- </ItemGroup>
-
  <!-- Run aapt to generate R.java for additional Android resources-->
  <Aapt
-   Condition="Exists('%(_AdditonalAndroidResourceCachePaths.Identity)\AndroidManifest.xml')"
    ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
    OutputImportDirectory="$(IntermediateOutputPath)__library_projects__\"
    UseShortFileNames="$(UseShortFileNames)"
-   ManifestFile="%(_AdditonalAndroidResourceCachePaths.Identity)\AndroidManifest.xml"
+   ManifestFiles="@(_AdditonalAndroidResourceCachePaths->'%(Identity)\AndroidManifest.xml')"
    ApplicationName="$(_AndroidPackage)"
    JavaPlatformJarPath="$(JavaPlatformJarPath)"
    NonConstantId="true"
    JavaDesignerOutputDirectory="$(IntermediateOutputPath)android\src"
    ResourceDirectory="$(MonoAndroidResDirIntermediate)"
    AdditionalResourceDirectories="@(LibraryResourceDirectories)"
-   AdditionalAndroidResourcePaths="@(_AdditionalAndroidResourceCachePathsCopy)"
+   AdditionalAndroidResourcePaths="@(_AdditonalAndroidResourceCachePaths)"
    AndroidComponentResgenFlagFile="$(_AndroidComponentResgenFlagFile)"
    ToolPath="$(AaptToolPath)"
    ToolExe="$(AaptToolExe)"
@@ -1273,7 +1257,7 @@ because xbuild doesn't support framework reference assemblies.
 		OutputImportDirectory="$(IntermediateOutputPath)__library_projects__\"
 		UseShortFileNames="$(UseShortFileNames)"
 		JavaPlatformJarPath="$(JavaPlatformJarPath)"
-		ManifestFile="$(ResgenTemporaryDirectory)\AndroidManifest.xml"
+		ManifestFiles="$(ResgenTemporaryDirectory)\AndroidManifest.xml"
 		PackageName="$(_AndroidPackage)"
 		ApplicationName="$(_AndroidPackage)"
 		ResourceDirectory="$(MonoAndroidResDirIntermediate)"
@@ -1777,7 +1761,7 @@ because xbuild doesn't support framework reference assemblies.
 	OutputImportDirectory="$(IntermediateOutputPath)__library_projects__\"
 	UseShortFileNames="$(UseShortFileNames)"
     JavaPlatformJarPath="$(JavaPlatformJarPath)"
-    ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
+    ManifestFiles="$(IntermediateOutputPath)android\AndroidManifest.xml"
     ResourceDirectory="$(MonoAndroidResDirIntermediate)"
     JavaDesignerOutputDirectory="$(AaptTemporaryDirectory)"
     ResourceOutputFile="$(_PackagedResources)"


### PR DESCRIPTION
We currently use MSBuild Batching to call the aapt tool
when processing the resources. This results in about 12 seperate
calls to aapt when building a standard Xamarin.Forms app.

The problem with Batching is that it is sequential. MSBuild and
xbuild are unable to run those batches in parallel. So this
commit reworks the Aapt task to be an AsyncTask. Which can take
multiple AndroidManifest files at once. It will then spin up
aapt in parallel rather than running them sequentially.

The difference between the two systems is clear

Using Batching:

6156.275 ms  Aapt  10 calls

Using Async:

3207.201 ms  Aapt  3 calls

This is a first build on a vanilla Xamarin.Form app with no changes.