### PR TITLE
[Xamarin.Android.Build.Tasks] Fix the location of the Xamarin.Android.Cecil.dll reference

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -74,7 +74,7 @@
         DefineConstants="NET_4_0;NET_4_5;NET_4_6;MONO"
         CodePage="65001"
         DisabledWarnings="1699"
-        References="$(OutputPath)..\..\..\..\lib\mandroid\Xamarin.Android.Cecil.dll"
+        References="$(OutputPath)..\..\..\..\lib\xbuild\Xamarin\Android\Xamarin.Android.Cecil.dll"
         OutputAssembly="$(OutputPath)..\..\..\..\lib\mandroid\mono-symbolicate.exe"
     />
     <Copy


### PR DESCRIPTION
When building from the internal repo the location of the Xamarin.Android.Cecil.dll
for mono-symbolicate is incorrect.
The file

	`$(OutputPath)..\..\..\..\lib\mandroid\Xamarin.Android.Cecil.dll`

does not exist. This commit updates the location to point to a loction that
does exist in both build systems.