### PR TITLE
[build] Support building *from clean* with `msbuild`

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -92,9 +92,8 @@
     <PropertyGroup>
       <_Script>$(AndroidToolchainDirectory)\ndk\build\tools\make-standalone-toolchain.sh</_Script>
       <_Install>@(_NdkToolchain->'$(AndroidToolchainDirectory)\toolchains\%(Identity)')</_Install>
-      <_Toolchain>@(_NdkToolchain->'%(Identity)')</_Toolchain>
     </PropertyGroup>
-    <Exec Command="bash &quot;$(_Script)&quot; --platform=%(_NdkToolchain.Platform) &quot;--install-dir=$(_Install)&quot; --arch=%(_NdkToolchain.Arch) --toolchain=$(_Toolchain)" />
+    <Exec Command="bash &quot;$(_Script)&quot; --platform=%(_NdkToolchain.Platform) &quot;--install-dir=$(_Install)&quot; --arch=%(_NdkToolchain.Arch) --toolchain=%(_NdkToolchain.Identity)" />
     <Touch
         Files="@(_NdkToolchain->'$(AndroidToolchainDirectory)\toolchains\%(Identity)\AndroidVersion.txt')"
         AlwaysCreate="False"

--- a/build-tools/scripts/msbuild.mk
+++ b/build-tools/scripts/msbuild.mk
@@ -1,0 +1,33 @@
+#
+# MSBuild Abstraction.
+#
+# Makefile targets which need to invoke MSBuild should use `$(MSBUILD)`,
+# not some specific MSBuild program such as `xbuild` or `msbuild`.
+#
+# Typical use will also include `$(MSBUILD_FLAGS)`, which provides the
+# Configuration and logging verbosity, as per $(CONFIGURATION) and $(V):
+#
+#   $(MSBUILD) $(MSBUILD_FLAGS) path/to/Project.csproj
+#
+# Inputs:
+#
+#   $(CONFIGURATION): Build configuration name, e.g. Debug or Release
+#   $(MSBUILD): The MSBuild program to use.
+#   $(MSBUILD_ARGS): Extra arguments to pass to $(MSBUILD); embedded into $(MSBUILD_FLAGS)
+#   $(V): Build verbosity
+#
+# Outputs:
+#
+#   $(MSBUILD): The MSBuild program to use. Defaults to `xbuild` unless overridden.
+#   $(MSBUILD_FLAGS): Additional MSBuild flags; contains $(CONFIGURATION), $(V), $(MSBUILD_ARGS).
+
+MSBUILD       = xbuild
+MSBUILD_FLAGS = /p:Configuration=$(CONFIGURATION) $(MSBUILD_ARGS)
+
+ifneq ($(V),0)
+MSBUILD_FLAGS += /v:diag
+endif   # $(V) != 0
+
+ifeq ($(MSBUILD),xbuild)
+MSBUILD_FLAGS += /p:_XABuildingWithXBuild=True
+endif	# msbuild

--- a/src/Mono.Android.Export/Mono.Android.Export.csproj
+++ b/src/Mono.Android.Export/Mono.Android.Export.csproj
@@ -46,6 +46,10 @@
       <HintPath>$(OutputPath)..\v1.0\System.Core.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="System.Runtime" Condition=" '$(_XABuildingWithXBuild)' != 'True' ">
+      <HintPath>$(OutputPath)..\v1.0\Facades\System.Runtime.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="System.Xml">
       <HintPath>$(OutputPath)..\v1.0\System.Xml.dll</HintPath>
       <Private>False</Private>

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -53,6 +53,10 @@
       <HintPath>$(OutputPath)..\v1.0\System.Net.Http.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="System.Runtime" Condition=" '$(_XABuildingWithXBuild)' != 'True' ">
+      <HintPath>$(OutputPath)..\v1.0\Facades\System.Runtime.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="System.Runtime.Serialization">
       <HintPath>$(OutputPath)..\v1.0\System.Runtime.Serialization.dll</HintPath>
       <Private>False</Private>

--- a/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
+++ b/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
@@ -13,6 +13,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AssemblyName>Mono.Data.Sqlite</AssemblyName>
     <SignAssembly>true</SignAssembly>
+    <NoStdLib>True</NoStdLib>
     <AndroidApplication>false</AndroidApplication>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
   </PropertyGroup>

--- a/src/Mono.Posix/Mono.Posix.csproj
+++ b/src/Mono.Posix/Mono.Posix.csproj
@@ -13,6 +13,7 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AssemblyName>Mono.Posix</AssemblyName>
     <SignAssembly>true</SignAssembly>
+    <NoStdLib>True</NoStdLib>
     <AndroidApplication>false</AndroidApplication>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
   </PropertyGroup>

--- a/src/System.Drawing.Primitives/System.Drawing.Primitives.csproj
+++ b/src/System.Drawing.Primitives/System.Drawing.Primitives.csproj
@@ -28,7 +28,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <NoStdLib>false</NoStdLib>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -36,7 +35,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <NoStdLib>false</NoStdLib>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -76,6 +76,8 @@
         DisabledWarnings="1699"
         References="$(OutputPath)..\..\..\..\lib\mandroid\Xamarin.Android.Cecil.dll"
         OutputAssembly="$(OutputPath)..\..\..\..\lib\mandroid\mono-symbolicate.exe"
+        ToolExe="$(CscToolExe)"
+        ToolPath="$(CscToolPath)"
     />
     <Copy
         SourceFiles="..\..\tools\scripts\mono-symbolicate"

--- a/src/Xamarin.Android.Tools.Aidl/Xamarin.Android.Tools.Aidl.csproj
+++ b/src/Xamarin.Android.Tools.Aidl/Xamarin.Android.Tools.Aidl.csproj
@@ -7,6 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.AndroidTools.Aidl</RootNamespace>
     <AssemblyName>Xamarin.Android.Tools.Aidl</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/b1f1370896047966319655ea2b19a6a243719742
Context: https://github.com/xamarin/xamarin-android/commit/452d405e32e0b92dc1958f8ee3b101aae35ec859
Context: https://github.com/xamarin/xamarin-android/commit/9a50c668a4466915f07efd2fd0794b39ed84ba8c
Context: https://github.com/xamarin/xamarin-android/commit/b89dc15d9bfeb2e6e03efbeb8e50895c372dbc5b

The `xamarin-android` repo [can't be built with msbuild][0]:

	src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj(348,3):
	error MSB4019: The imported project ".../bin/Debug/lib/xbuild/Xamarin/Android/Xamarin.Android.CSharp.targets"
	was not found. Confirm that the path in the <Import> declaration is correct, and that the file exists on disk.
	...
	src/Mono.Posix/Mono.Posix.csproj(236,3): error MSB4019: The imported
	project ".../bin/Debug/lib/xbuild/Xamarin/Android/Xamarin.Android.CSharp.targets"
	was not found. Confirm that the path in the <Import> declaration is correct, and that the file exists on disk.
	...
	src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj(183,3): error MSB4019:
	The imported project ".../bin/Debug/lib/xbuild/Xamarin/Android/Xamarin.Android.CSharp.targets"
	was not found. Confirm that the path in the <Import> declaration is correct, and that the file exists on disk.

Plus various other similar and different errors.

This is a bit of a problem as I'd like to build everthing with
MSBuild, particularly with a view toward future/eventual IDE
integration, but if things don't build with MSBuild *at all*...
That's a bit of a pickle.

But first, about those above errors...what's going on?

The short version is that `xbuild` has a "feature" that `msbuild`
lacks, and it's a feature that has been inadvertently relied on:

`xbuild` loads projects lazily.

This requires elaboration. :-)

A "solution" is a graph of projects with various dependencies, as
specified by the `.sln` file and MSBuild `@(ProjectReference)` items.
Reading this graph requires parsing the e.g. `.csproj` files to read
the `@(ProjectReference)` items to construct the graph so that
projects can be built in the proper order.

This is where `xbuild` and `msbuild` appear to differ:

* `xbuild` appears to use a "normal" XML parser to read project files
    when constructing the project graph.
* `msbuild` appears to "fully load" the project files into an internal
    object instance for further processing.

The difference between these approaches is visible when a project file
`<Import/>`s a file...which doesn't (yet!) exist.

Case in point: `Mono.Posix.csproj` needs to be a "normal"
Xamarin.Android project file, using the normal Xamarin.Android build
process, so that Android native libraries can be embedded into
`Mono.Posix.dll` for use by end-user applications. To do so, it needs
to `<Import/>` the Xamarin.Android MSBuild targets:

	<Import Project="$(OutputPath)\..\..\..\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" />

In a clean build tree -- e.g. immediately after checkout --
*the above file does not exist*. `Xamarin.Android.CSharp.targets` is
installed into the above directory by
`src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj`
(via `%(None.CopyToOutputDirectory)` set to `PreserveNewest`), which
means that `Xamarin.Android.CSharp.targets` won't be available for
processing by `Mono.Posix.csproj` until *after*
`Xamarin.Android.Build.Tasks.csproj` has been built.

Under `xbuild`, this Just Works™: `Mono.Posix.csproj` has a
`@(ProjectReference)` to `Xamarin.Android.Build.Tasks.csproj`, so
`xbuild` loads `Mono.Posix.csproj` into an XML parser, extracts the
`@(ProjectReference)` items, and continues on its merry way *without*
evaluating the `<Import/>`s within `Mono.Posix.csproj`.

Under `msbuild`, this fails horrifically:
`Xamarin.Android.CSharp.targets` isn't in the expected directory,
and `msbuild` reports an MSB4019 error. MSBuild attempts to continue
(why?!), but nothing can actually build sanely.

There are two plausible fixes for this scenario:

1. Add a layer of indirection!

2. Abuse `make prepare`.

For option (1), see e.g. (b1f13708)
`build-tools/mono-runtimes/mono-runtimes.mdproj` and
`build-tools/mono-runtimes/mono-runtimes.targets`, in which the
`Build` target is altered so that nothing is done if the outputs
already exist; otherwise the `<MSBuild/>` task is used to invoke the
`ForceBuild` target. A similar thing could plausibly be done for
`Mono.Posix.csproj`, by creating a "proxy" project which is used by
`@(ProjectReference)` for determining the dependency graph, and the
"proxy" project then delegates to the "real" project.

I don't personally like this idea, as I'm not sure what it looks like
from the IDE. There would now be two projects instead of one for
*each* MSB4019 error, and there are *10* MSB4019 errors (now).

Option (2) involves altering `make prepare` so that when `msbuild` is
used, we explicitly build a set of projects *before*
`Xamarin.Android.sln` is built. This allows us to manually intervene
and build projects in an order which will appease `msbuild`s "eager"
resolving and loading of all referenced files.

This also works, is much simpler, and means we *don't* need to
introduce 10 additional project files simply to appease MSBuild.

Perhaps not surprisingly, that conceptual change -- the introduction
of `make prepare-msbuild` -- is *tiny* in this patch. Then we have
other `xbuild`-vs-`msbuild`-isms.

Bump to Java.Interop/65a0157f, as that commit is needed to build
cleanly with `msbuild`.

`android-toolchain.targets` can't use `$(_Toolchain)` because then
`%(_NdkToolchain.Identity)` isn't properly batched into the `<Exec/>`.
The result is a build error when invoking
`make-standalone-toolchain.sh` when it's invoked an additional time,
but without a corresponding `@(_NdkToolchain)`, so the command line is
just completely bizarro and fails.

`Mono.Data.Sqlite.csproj` and `Mono.Posix.csproj` need to set
`$(NoStdLib)` to True so that MSBuild doesn't add the *system*
`mscorlib.dll` when building the assemblies. When `$(NoStdLib)` is
False, the `<Csc/>`  task is executed referencing *two* `mscorlib.dll`
assemblies, and things go badly from there.

`System.Drawing.Primitives.csproj` *does* properly set `$(NoStdLib)`
to True, but then it *also* set it to False in the Debug and Release
sections (?!). Remove the extra -- and wrong! -- overrides.

`Xamarin.Android.Build.Tasks.targets` needs to provide
`$(CscToolPath)` and `$(CscToolExe)` to the `<Csc/>` task. Otherwise,
`msbuild` defaults to trying to invoke `csc.exe`, which doesn't exist
on mono 4.6, breaking the `_BuildMonoSymbolicate` target.

Finally, `System.Runtime`... We have a bit of a history of adding a
`@(Reference)` to `System.Runtime` (452d405e) and removing that same
reference (9a50c668, b89dc15d). The short version is that `xbuild`
errors if `System.Runtime` is referenced, while `msbuild` errors if
`System.Runtime` *isn't* referenced. #facepalm

"Fix" this by altering `$(MSBUILD_FLAGS)` so that when building with
`xbuild` the `$(_XABuildingWithXBuild)` property is True. We can then
make the `@(Reference)`s to `System.Runtime` conditional on our *not*
building with `xbuild`. (This might mean we don't build from the IDE
until it uses `msbuild`; I haven't tested this.)

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-msbuild/87/consoleText