### PR TITLE
[Xamarin.Android.Build.Tasks] Default $(AndroidClassParser) is jar2xml

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -61,7 +61,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <MonoAndroidVersion>v5.0</MonoAndroidVersion>
     <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == '' And '$(AndroidUseLatestPlatformSdk)' == 'False'">v2.3</TargetFrameworkVersion>
 	<UseShortFileNames Condition="'$(UseShortFileNames)' != 'True'">False</UseShortFileNames>
-	<AndroidClassParser Condition="'$(AndroidClassParser)' == ''">class-parse</AndroidClassParser>
+    <AndroidClassParser Condition=" '$(AndroidClassParser)' == '' ">jar2xml</AndroidClassParser>
   </PropertyGroup>
   
   <!-- Get our Build Actions to show up in VS -->

--- a/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding.csproj
+++ b/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding.csproj
@@ -13,6 +13,7 @@
     <AssemblyName>Xamarin.Android.FixJavaAbstractMethod-Binding</AssemblyName>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
+    <AndroidClassParser>class-parse</AndroidClassParser>
   </PropertyGroup>
   <Import Project="..\..\..\Configuration.props" />
   <PropertyGroup>

--- a/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding.csproj
+++ b/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding.csproj
@@ -13,6 +13,7 @@
     <AssemblyName>Xamarin.Android.FixJavaAbstractMethod-Binding</AssemblyName>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
+    <AndroidClassParser>class-parse</AndroidClassParser>
   </PropertyGroup>
   <Import Project="..\..\..\Configuration.props" />
   <PropertyGroup>

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.csproj
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.csproj
@@ -13,6 +13,7 @@
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
     <AssemblyName>AndroidLibBinding</AssemblyName>
+    <AndroidClassParser>class-parse</AndroidClassParser>
   </PropertyGroup>
   <Import Project="..\..\..\Configuration.props" />
   <PropertyGroup>

--- a/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/Xamarin.Android.McwGen-Tests.csproj
+++ b/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/Xamarin.Android.McwGen-Tests.csproj
@@ -13,6 +13,7 @@
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AssemblyName>Xamarin.Android.McwGen-Tests</AssemblyName>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
+    <AndroidClassParser>class-parse</AndroidClassParser>
   </PropertyGroup>
   <Import Project="..\..\..\Configuration.props" />
   <PropertyGroup>

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib1/Xamarin.Android.BindingResolveImportLib1.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib1/Xamarin.Android.BindingResolveImportLib1.csproj
@@ -13,6 +13,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
+    <AndroidClassParser>class-parse</AndroidClassParser>
   </PropertyGroup>
   <Import Project="..\..\..\Configuration.props" />
   <PropertyGroup>

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib2/Xamarin.Android.BindingResolveImportLib2.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib2/Xamarin.Android.BindingResolveImportLib2.csproj
@@ -12,6 +12,7 @@
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
     <AssemblyName>Xamarin.Android.BindingResolveImportLib2</AssemblyName>
     <UseShortFileNames>True</UseShortFileNames>
+    <AndroidClassParser>class-parse</AndroidClassParser>
   </PropertyGroup>
   <Import Project="..\..\..\Configuration.props" />
   <PropertyGroup>

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib3/Xamarin.Android.BindingResolveImportLib3.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib3/Xamarin.Android.BindingResolveImportLib3.csproj
@@ -14,6 +14,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidApplication>True</AndroidApplication>
     <UseShortFileNames>True</UseShortFileNames>
+    <AndroidClassParser>class-parse</AndroidClassParser>
   </PropertyGroup>
   <Import Project="..\..\..\Configuration.props" />
   <PropertyGroup>

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib4/Xamarin.Android.BindingResolveImportLib4.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib4/Xamarin.Android.BindingResolveImportLib4.csproj
@@ -11,6 +11,7 @@
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
     <AssemblyName>Xamarin.Android.BindingResolveImportLib4</AssemblyName>
+    <AndroidClassParser>class-parse</AndroidClassParser>
   </PropertyGroup>
   <Import Project="..\..\..\Configuration.props" />
   <PropertyGroup>


### PR DESCRIPTION
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=45203
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=47582
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=48588

In an ideal world, we'd use `class-parse` to parse `.jar` files when
producing binding assemblies, as `class-parse` is significantly better
and more reliable that `jar2xml`.

...then we hit the problem of "compatibility": there is a reasonable
expectation that currently existing projects will continue to build in
new product versions. It would anger developers if they upgraded
Xamarin.Android and then their binding projects no longer built.

Which is precisely what *will* happen if we change the default
`$(AndroidClassParser)` value to `class-parse`, as per
Bugs #45203, #47582, and #48588: `class-parse` does a much better job
at finding Java types and members, which means *more* types and
members are present in `class-parse` output (compared to `jar2xml`),
which means there's a higher likelihood of encountering `generator`
bugs. These bugs were likely previously worked around when using
`jar2xml`, but *requiring* that those same projects be fixed *again*
is a bridge too far.

Meaning `class-parse` needs to be an "opt-in" feature, not an
"opt-out" feature.

Change the default `$(AndroidClassParser)` value to `jar2xml` so that
existing projects continue to use `jar2xml` when binding.

We will update the default template for *new* projects to use
`class-parse` in the IDEs, so *new* projects will get improved
behavior.