### PR TITLE
[jni] Ensure mono_class_from_name is called from a valid AppDomain context

### DIFF
--- a/src/monodroid/jni/monodroid-glue.c
+++ b/src/monodroid/jni/monodroid-glue.c
@@ -3031,13 +3031,13 @@ _monodroid_get_display_dpi (float *x_dpi, float *y_dpi)
 }
 
 static void
-lookup_bridge_info (MonoImage *image, const MonoJavaGCBridgeType *type, MonoJavaGCBridgeInfo *info)
+lookup_bridge_info (MonoDomain *domain, MonoImage *image, const MonoJavaGCBridgeType *type, MonoJavaGCBridgeInfo *info)
 {
-	info->klass             = mono.mono_class_from_name (image, type->namespace,    type->typename);
-	info->handle            = mono.mono_class_get_field_from_name (info->klass,     "handle");
-	info->handle_type       = mono.mono_class_get_field_from_name (info->klass,     "handle_type");
-	info->refs_added        = mono.mono_class_get_field_from_name (info->klass,     "refs_added");
-	info->weak_handle       = mono.mono_class_get_field_from_name (info->klass,     "weak_handle");
+	info->klass             = monodroid_get_class_from_image (&mono, domain, image, type->namespace, type->typename);
+	info->handle            = mono.mono_class_get_field_from_name (info->klass, "handle");
+	info->handle_type       = mono.mono_class_get_field_from_name (info->klass, "handle_type");
+	info->refs_added        = mono.mono_class_get_field_from_name (info->klass, "refs_added");
+	info->weak_handle       = mono.mono_class_get_field_from_name (info->klass, "weak_handle");
 }
 
 static void
@@ -3081,12 +3081,12 @@ init_android_runtime (MonoDomain *domain, JNIEnv *env, jobject loader)
 	image = mono.mono_assembly_get_image  (assm);
 
 	for (i = 0; i < NUM_GC_BRIDGE_TYPES; ++i) {
-		lookup_bridge_info (image, &mono_java_gc_bridge_types [i], &mono_java_gc_bridge_info [i]);
+		lookup_bridge_info (domain, image, &mono_java_gc_bridge_types [i], &mono_java_gc_bridge_info [i]);
 	}
 
-	runtime                             = mono.mono_class_from_name (image, "Android.Runtime", "JNIEnv");
+	runtime                             = monodroid_get_class_from_image (&mono, domain, image, "Android.Runtime", "JNIEnv");
 	method                              = mono.mono_class_get_method_from_name (runtime, "Initialize", 1);
-	environment                         = mono.mono_class_from_name (image, "Android.Runtime", "AndroidEnvironment");
+	environment                         = monodroid_get_class_from_image (&mono, domain, image, "Android.Runtime", "AndroidEnvironment");
 
 	if (method == 0) {
 		log_fatal (LOG_DEFAULT, "INTERNAL ERROR: Unable to find Android.Runtime.JNIEnv.Initialize!");
@@ -3139,7 +3139,7 @@ get_android_runtime_class (MonoDomain *domain)
 {
 	MonoAssembly *assm = monodroid_load_assembly (&mono, domain, "Mono.Android");
 	MonoImage *image   = mono.mono_assembly_get_image (assm);
-	MonoClass *runtime = mono.mono_class_from_name (image, "Android.Runtime", "JNIEnv");
+	MonoClass *runtime = monodroid_get_class_from_image (&mono, domain, image, "Android.Runtime", "JNIEnv");
 
 	return runtime;
 }
@@ -3197,7 +3197,7 @@ register_packages (MonoDomain *domain, JNIEnv *env, jobjectArray assemblies)
 
 		image = mono.mono_assembly_get_image (a);
 
-		c = mono.mono_class_from_name (image, "Java.Interop", "__TypeRegistrations");
+		c = monodroid_get_class_from_image (&mono, domain, image, "Java.Interop", "__TypeRegistrations");
 		if (c == NULL)
 			continue;
 		m = mono.mono_class_get_method_from_name (c, "RegisterPackages", 0);

--- a/src/monodroid/jni/util.c
+++ b/src/monodroid/jni/util.c
@@ -358,6 +358,23 @@ monodroid_get_class_from_name (struct DylibMono *mono, MonoDomain *domain, const
 	return result;
 }
 
+MonoClass*
+monodroid_get_class_from_image (struct DylibMono *mono, MonoDomain *domain, MonoImage *image, const char *namespace, const char *type)
+{
+	MonoClass *result = NULL;
+	MonoDomain *current = mono->mono_domain_get ();
+
+	if (domain != current)
+		mono->mono_domain_set (domain, FALSE);
+
+	result = mono->mono_class_from_name (image, namespace, type);
+
+	if (domain != current)
+		mono->mono_domain_set (current, FALSE);
+
+	return result;
+}
+
 void create_public_directory (const char *dir)
 {
 #ifndef WINDOWS

--- a/src/monodroid/jni/util.h
+++ b/src/monodroid/jni/util.h
@@ -107,5 +107,6 @@ struct        DylibMono;
 MonoAssembly    *monodroid_load_assembly (struct DylibMono *mono, MonoDomain *domain, const char *basename);
 void            *monodroid_runtime_invoke (struct DylibMono *mono, MonoDomain *domain, MonoMethod *method, void *obj, void **params, MonoObject **exc);
 MonoClass       *monodroid_get_class_from_name (struct DylibMono *mono, MonoDomain *domain, const char* assembly, const char *namespace, const char *type);
+MonoClass       *monodroid_get_class_from_image (struct DylibMono *mono, MonoDomain *domain, MonoImage* image, const char *namespace, const char *type);
 
 #endif /* __MONODROID_UTIL_H__ */


### PR DESCRIPTION

Before this patch we would have instances where initializing a new domain context for the Android Designer would wrongly load some assemblies into the root appdomain instead of the one we created which meant they couldn't be unloaded anymore.

The reason is that despite loading most of the assemblies manually in the proper appdomain context, some assemblies were being loaded as a result of Mono's type resolution when calling `mono_class_from_name` which calls back into `open_from_update_dir` like so:

```
libmonosgen-2.0.dylib`add_assemblies_to_domain(domain=0x000000012d8137d0, ass=0x000000012d7988d0, ht=0x0000000000000000) + 20 at appdomain.c:1107
libmonosgen-2.0.dylib`mono_domain_fire_assembly_load(assembly=0x000000012d7988d0, user_data=0x0000000000000000) + 143 at appdomain.c:1161
libmonosgen-2.0.dylib`mono_assembly_invoke_load_hook(ass=0x000000012d7988d0) + 56 at assembly.c:1257
libmonosgen-2.0.dylib`mono_assembly_load_from_full(image=0x0000000125a06000, fname="/var/folders/sj/m6n49_qx5w3_9n7s0pdmc3gc0000gn/T/tmp6475adbe.tmp/Java.Interop.dll", status=0x000070000edf3ddc, refonly=0) + 829 at assembly.c:2024
libmonosgen-2.0.dylib`mono_assembly_open_full(filename="/var/folders/sj/m6n49_qx5w3_9n7s0pdmc3gc0000gn/T/tmp6475adbe.tmp/Java.Interop.dll", status=0x000070000edf3ddc, refonly=0) + 865 at assembly.c:1704
libmono-android.debug.so`open_from_update_dir(aname=0x000070000edf40d8, assemblies_path=0x0000000000000000, user_data=0x0000000000000000) + 493 at monodroid-glue.c:1922
libmonosgen-2.0.dylib`invoke_assembly_preload_hook(aname=0x000070000edf40d8, assemblies_path=0x0000000000000000) + 64 at assembly.c:1410
libmonosgen-2.0.dylib`mono_assembly_load_full_nosearch(aname=0x000070000edf40d8, basedir=0x0000000000000000, status=0x000070000edf40bc, refonly=0) + 238 at assembly.c:3254
libmonosgen-2.0.dylib`mono_assembly_load_full_internal(aname=0x000070000edf40d8, requesting=0x000000012d77da40, basedir=0x0000000000000000, status=0x000070000edf40bc, refonly=0) + 48 at assembly.c:3309
libmonosgen-2.0.dylib`mono_assembly_load_reference(image=0x0000000125a05800, index=1) + 475 at assembly.c:1168
libmonosgen-2.0.dylib`mono_class_from_typeref_checked(image=0x0000000125a05800, type_token=16777338, error=0x000070000edf4ad0) + 1236 at class.c:270
libmonosgen-2.0.dylib`mono_class_get_checked(image=0x0000000125a05800, type_token=16777338, error=0x000070000edf4ad0) + 278 at class.c:7438
libmonosgen-2.0.dylib`mono_class_get_and_inflate_typespec_checked(image=0x0000000125a05800, type_token=16777338, context=0x0000000000000000, error=0x000070000edf4ad0) + 48 at class.c:7400
libmonosgen-2.0.dylib`mono_metadata_interfaces_from_typedef_full(meta=0x0000000125a05800, index=33554665, interfaces=0x000070000edf4478, count=0x000070000edf4484, heap_alloc_result=0, context=0x0000000000000000, error=0x000070000edf4ad0) + 583 at metadata.c:4261
libmonosgen-2.0.dylib`mono_class_create_from_typedef(image=0x0000000125a05800, type_token=33554665, error=0x000070000edf4ad0) + 1458 at class.c:5857
libmonosgen-2.0.dylib`mono_class_get_checked(image=0x0000000125a05800, type_token=33554665, error=0x000070000edf4ad0) + 253 at class.c:7435
libmonosgen-2.0.dylib`mono_class_from_name_checked_aux(image=0x0000000125a05800, name_space="Java.Lang", name="Object", visited_images=0x000000012fb38210, error=0x000070000edf4ad0) + 1997 at class.c:7938
libmonosgen-2.0.dylib`mono_class_from_name_checked(image=0x0000000125a05800, name_space="Java.Lang", name="Object", error=0x000070000edf4ad0) + 78 at class.c:7964
libmonosgen-2.0.dylib`mono_class_from_name(image=0x0000000125a05800, name_space="Java.Lang", name="Object") + 44 at class.c:7990
```

In this case, the domain information is only retrieved at the `mono_domain_fire_assembly_load` function level which simply calls `mono_domain_get` returning the root domain in that case hence the issue.

Thus this commits adds another utility call `monodroid_get_class_from_image` which ensure class are loaded under a specific domain context so that if any type resolution happens to trigger an assembly load, it will do so under the proper appdomain context.