### PR TITLE
[Xamarin.Android.Build.Tasks] Fix regression in Aapt Task

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1220,6 +1220,7 @@ because xbuild doesn't support framework reference assemblies.
 		_GetAdditionalResourcesFromAssemblies;
 		_CreateAdditionalResourceCache;
 		_GenerateAndroidResourceDir;
+		_DefineBuildTargetAbis;
 	</_UpdateAndroidResgenDependsOnTargets>
 </PropertyGroup>
 
@@ -1274,6 +1275,7 @@ because xbuild doesn't support framework reference assemblies.
 		AndroidUseLatestPlatformSdk="$(AndroidUseLatestPlatformSdk)"
 		ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
 		ExplicitCrunch="$(AndroidExplicitCrunch)"
+		SupportedAbis="$(_BuildTargetAbis)"
 	/>
 	
 	<CopyGeneratedJavaResourceClasses


### PR DESCRIPTION
Commit f93149eb introduced a regression where the abi specific
packages were NOT being produced. As a result when using
PackagePerAbi the build would fail.

Thie commit fixes that issue by ensuring that a package is
generated per abi when required.