### PR TITLE
[Xamarin.Android.Build.Tasks] Fix the Resource only build.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -628,6 +628,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <PropertyGroup>
 	<_OnResolveMonoAndroidSdks>
 		_ResolveMonoAndroidSdks
+		;_ValidateAndroidPackageProperties
 		;$(_AfterResolveMonoAndroidSdks)
 	</_OnResolveMonoAndroidSdks>
 </PropertyGroup>


### PR DESCRIPTION
The UpdateAndroidResources build Task is broken. The refactor
which moved `_ValidatePackageProperties` did not take into
account the face that UpdateAndroidResources does NOT call
`Build`.

This commit fixes this issue by ensuring that `_ValidatePackageProperties`
is called once we have Resolved the SDK which is what we do for every
build regardless.