### PR TITLE
[aot] resolve platform library path correctly for x86_64

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -157,11 +157,6 @@ namespace Xamarin.Android.Tasks
 
 		static bool ValidateAotConfiguration (TaskLoggingHelper log, AndroidTargetArch arch, bool enableLLVM)
 		{
-			if (arch == AndroidTargetArch.X86_64) {
-				log.LogCodedError ("XA3004", "x86_64 architecture is not currently supported on AOT mode.");
-				return false;
-			}			
-
 			return true;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
@@ -105,7 +105,8 @@ namespace Xamarin.Android.Tasks
 
 		public static string GetNdkPlatformLibPath (string androidNdkPath, AndroidTargetArch arch, int level)
 		{
-			string path = Path.Combine (androidNdkPath, "platforms", "android-" + level, "arch-" + GetPlatformArch (arch), "usr", "lib");
+			string lib = arch == AndroidTargetArch.X86_64 ? "lib64" : "lib";
+			string path = Path.Combine (androidNdkPath, "platforms", "android-" + level, "arch-" + GetPlatformArch (arch), "usr", lib);
 			if (!Directory.Exists (path))
 				throw new InvalidOperationException (String.Format ("Platform library directory for target {0} and API Level {1} was not found. Expected path is \"{2}\"", arch, level, path));
 			return path;


### PR DESCRIPTION
Android NDK ships three different ABIs for x86_64 that we can link against:
```
% file platforms/android-21/arch-x86_64/usr/lib*/libc.so
platforms/android-21/arch-x86_64/usr/lib/libc.so:    ELF 32-bit LSB shared object, Intel 80386, version 1 (SYSV), dynamically linked, interpreter /system/bin/linker, not stripped
platforms/android-21/arch-x86_64/usr/lib64/libc.so:  ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /system/bin/linker64, not stripped
platforms/android-21/arch-x86_64/usr/libx32/libc.so: ELF 32-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /system/bin/linkerx32, not stripped
```

fixes https://bugzilla.xamarin.com/show_bug.cgi?id=51415


verified with a HelloWorld sample:
```
01-16 13:26:16.127  2740  2740 D Mono    : AOT: loaded AOT Module for mscorlib.dll.
01-16 13:26:16.132  2740  2740 V Mono    : AOT: FOUND method System.OutOfMemoryException:.ctor (string) [0x7ffed53ef160 - 0x7ffed53ef1a0 0x7ffed5735455]
01-16 13:26:16.138  2740  2740 V Mono    : AOT: FOUND method System.Exception:.cctor () [0x7ffed53e7360 - 0x7ffed53e7380 0x7ffed5734ee3]
01-16 13:26:16.139  2740  2740 V Mono    : AOT: FOUND method System.Exception:Init () [0x7ffed53e64d0 - 0x7ffed53e6520 0x7ffed5734d9b]
01-16 13:26:16.140  2740  2740 V Mono    : AOT: FOUND method System.NullReferenceException:.ctor (string) [0x7ffed53ec380 - 0x7ffed53ec3c0 0x7ffed5735395]
01-16 13:26:16.140  2740  2740 V Mono    : AOT: FOUND method System.StackOverflowException:.ctor (string) [0x7ffed53f0ae0 - 0x7ffed53f0b20 0x7ffed5735595]
```