### PR TITLE
[Xamarin.Android.Build.Tasks] AOT+LLVM ndk requirement is not clearly stated when building against an older ndk version

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Android.Tasks
 			}
 
 			if (enableLLVM && (ndkVersion.Version < 10 || (ndkVersion.Version == 10 && ndkVersion.Revision[0] < 'd'))) {
-				log.LogMessage (MessageImportance.High,
+				log.LogCodedError ("XA3005",
 						"The detected Android NDK version is incompatible with the targeted LLVM configuration, " +
 						"please upgrade to NDK r10d or newer.");
 			}


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=31985

Rework the NdkUtils to log a coded error XA3005 if the user
has a Ndk which is incompatible with the current AOT+LLVM
setup