### PR TITLE
[linker] fix #51339

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
@@ -105,7 +105,7 @@ namespace MonoDroid.Tuner
 
 			pipeline.AppendStep (new FixAbstractMethodsStep ());
 			pipeline.AppendStep (new MonoDroidMarkStep ());
-			pipeline.AppendStep (new SweepStep ());
+			pipeline.AppendStep (new MonoDroidSweepStep ());
 			pipeline.AppendStep (new CleanStep ());
 			// monodroid tuner steps
 			if (!string.IsNullOrWhiteSpace (options.ProguardConfiguration))

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MonoDroidSweepStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MonoDroidSweepStep.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using Mono.Cecil;
+
+using Java.Interop.Tools.Cecil;
+
+using Mono.Linker;
+using Mono.Linker.Steps;
+
+namespace MonoDroid.Tuner
+{
+	public class MonoDroidSweepStep : SweepStep
+	{
+		protected override void Process ()
+		{
+			base.Process ();
+
+			var assemblies = Context.GetAssemblies ();
+			foreach (var assembly in assemblies) {
+				AssemblyAction currentAction = Annotations.GetAction (assembly);
+
+				if ((currentAction == AssemblyAction.Link) || (currentAction == AssemblyAction.Save)) {
+					// if we save (only or by linking) then unmarked exports (e.g. forwarders) must be cleaned
+					// or they can point to nothing which will break later (e.g. when re-loading for stripping IL)
+					// reference: https://bugzilla.xamarin.com/show_bug.cgi?id=36577
+					if (assembly.MainModule.HasExportedTypes)
+						SweepUnmarked (assembly.MainModule.ExportedTypes);
+				}
+			}
+		}
+
+		void SweepUnmarked (IList list)
+		{
+			for (int i = 0; i < list.Count; i++)
+				if (!Annotations.IsMarked ((IMetadataTokenProvider) list [i]))
+					list.RemoveAt (i--);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Linker\MonoDroid.Tuner\Linker.cs" />
     <Compile Include="Linker\MonoDroid.Tuner\LinkerOptions.cs" />
     <Compile Include="Linker\MonoDroid.Tuner\MonoDroidMarkStep.cs" />
+    <Compile Include="Linker\MonoDroid.Tuner\MonoDroidSweepStep.cs" />
     <Compile Include="Linker\MonoDroid.Tuner\PreserveHttpAndroidClientHandler.cs" />
     <Compile Include="Tasks\Aapt.cs" />
     <Compile Include="Tasks\AndroidZipAlign.cs" />


### PR DESCRIPTION
 - backported part of changes from master linker repo
   (https://github.com/mono/linker/commit/e606d60b13c126b472263146e866cc4960984089
   and
   https://github.com/mono/linker/commit/bee5321df910fe078fe7d69935913bb36822b356)

 - we might add changes in ResolveFromXmlStep.cs as well, but I wanted
   to keep the changes small, so only added parts relevant to #51339

 - SweepUnmarked duplicates the SweepCollection from base class
   because of access rights. this patch is only for cycle9 branch and
   will not be used in master