### PR TITLE
[msbuild] Add members used by monodroid_create_appdomain to linker whitelist

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/PreserveLists/mscorlib.xml
+++ b/src/Xamarin.Android.Build.Tasks/Linker/PreserveLists/mscorlib.xml
@@ -11,9 +11,12 @@
 			<method name="DoUnhandledException" />
 			<method name="InternalSetContext" />
 			<method name="GetMarshalledDomainObjRef" />
+			<method name="CreateDomain" />
 		</type>
 
-		<type fullname="System.AppDomainSetup" preserve="fields" />
+		<type fullname="System.AppDomainSetup" preserve="fields">
+			<method name="set_ShadowCopyFiles" />
+		</type>
 		<type fullname="System.AppDomainUnloadedException" />
 		<type fullname="System.ApplicationException" />
 		<type fullname="System.ArgIterator" />


### PR DESCRIPTION
Related to work done in PR: https://github.com/xamarin/xamarin-android/pull/359

If for some reason the designer starts loading a mscorlib that has been linked away, we tend to lose the `AppDomain.CreateDomain` function and `AppDomainSetup.ShadowCopyFiles` property that we use to setup and initialize the new domain which create a native crash.

Thus this commits add those entries into the linker white list for mscorlib which doesn't change immensely the resulting size of the linked mscorlib (~4kB extra).