### PR TITLE
[build] Support building *from clean* with `msbuild` (Take 2!)

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -27,7 +27,6 @@
     <ManagedRuntime Condition=" '$(ManagedRuntime)' == '' And '$(OS)' != 'Windows_NT' ">mono</ManagedRuntime>
     <ManagedRuntimeArgs Condition=" '$(ManagedRuntimeArgs)' == '' And '$(ManagedRuntime)' == 'mono' ">--debug=casts</ManagedRuntimeArgs>
     <MonoSgenBridgeVersion Condition=" '$(MonoSgenBridgeVersion)' == '' ">5</MonoSgenBridgeVersion>
-    <TargetFrameworkRootPath>$(MSBuildThisFileDirectory)bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
     <HOME Condition=" '$(HOME)' == '' ">$(HOMEDRIVE)$(HOMEPATH)</HOME>
     <AndroidApiLevel Condition=" '$(AndroidApiLevel)' == '' ">25</AndroidApiLevel>
     <AndroidFrameworkVersion Condition=" '$(AndroidFrameworkVersion)' == '' ">v7.1</AndroidFrameworkVersion>

--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -67,12 +67,12 @@
 
     <UnzipDirectoryChildren
         HostOS="$(HostOS)"
-        SourceFiles="@(AndroidSdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity)')"
+        SourceFiles="@(_PlatformAndroidSdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity)')"
         DestinationFolder="$(AndroidToolchainDirectory)\sdk"
     />
     <UnzipDirectoryChildren
         HostOS="$(HostOS)"
-        SourceFiles="@(AndroidNdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity)')"
+        SourceFiles="@(_PlatformAndroidNdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity)')"
         DestinationFolder="$(AndroidToolchainDirectory)\ndk"
     />
     <UnzipDirectoryChildren

--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -96,6 +96,7 @@
     <MakeDir Directories="$(_LlvmOutputDirTop)\%(_LlvmRuntime.BuildDir)" />
     <Exec
         Command="%(_LlvmRuntime.ConfigureEnvironment) $(LlvmSourceFullPath)\configure %(_LlvmRuntime.ConfigureFlags)"
+        IgnoreStandardErrorWarningFormat="True"
         WorkingDirectory="$(_LlvmOutputDirTop)\%(_LlvmRuntime.BuildDir)"
     />
     <Touch
@@ -114,6 +115,7 @@
           Condition=" '$(_LlvmNeeded)' != '' ">
     <Exec
         Command="%(_LlvmRuntime.BuildEnvironment) make $(MakeConcurrency) all install"
+        IgnoreStandardErrorWarningFormat="True"
         WorkingDirectory="$(_LlvmOutputDirTop)\%(_LlvmRuntime.BuildDir)"
         />
     <Touch
@@ -149,6 +151,7 @@
     <MakeDir Directories="$(IntermediateOutputPath)\%(_MonoRuntime.Identity)" />
     <Exec
         Command="$(MonoSourceFullPath)\configure LDFLAGS=&quot;%(_MonoRuntime.LdFlags)&quot; CFLAGS=&quot;%(_MonoRuntime.CFlags)&quot; CXXFLAGS=&quot;%(_MonoRuntime.CxxFlags)&quot; CC=&quot;%(_MonoRuntime.Cc)&quot; CXX=&quot;%(_MonoRuntime.Cxx)&quot; CPP=&quot;%(_MonoRuntime.Cpp)&quot; CXXCPP=&quot;%(_MonoRuntime.CxxCpp)&quot; LD=&quot;%(_MonoRuntime.Ld)&quot; AR=&quot;%(_MonoRuntime.Ar)&quot; AS=&quot;%(_MonoRuntime.As)&quot; RANLIB=&quot;%(_MonoRuntime.RanLib)&quot; STRIP=&quot;%(_MonoRuntime.Strip)&quot; DLLTOOL=&quot;%(_MonoRuntime.DllTool)&quot; OBJDUMP=&quot;%(_MonoRuntime.Objdump)&quot; --cache-file=..\%(_MonoRuntime.Identity).config.cache %(_MonoRuntime.ConfigureFlags)"
+        IgnoreStandardErrorWarningFormat="True"
         WorkingDirectory="$(IntermediateOutputPath)\%(_MonoRuntime.Identity)"
     />
     <Touch
@@ -232,6 +235,7 @@
     <Exec
         Condition=" '%(_MonoRuntime.DoBuild)' == 'true' "
         Command="make $(MakeConcurrency) # %(_MonoRuntime.Identity)"
+        IgnoreStandardErrorWarningFormat="True"
         WorkingDirectory="$(IntermediateOutputPath)\%(_MonoRuntime.Identity)"
     />
     <Touch
@@ -384,6 +388,7 @@
     <MakeDir Directories="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)" />
     <Exec
         Command="%(_MonoCrossRuntime.ConfigureEnvironment) $(MonoSourceFullPath)\configure LDFLAGS=&quot;%(_MonoCrossRuntime.LdFlags)&quot; CFLAGS=&quot;%(_MonoCrossRuntime.CFlags)&quot; CXXFLAGS=&quot;%(_MonoCrossRuntime.CxxFlags)&quot; CC=&quot;%(_MonoCrossRuntime.Cc)&quot; CXX=&quot;%(_MonoCrossRuntime.Cxx)&quot; CPP=&quot;%(_MonoCrossRuntime.Cpp)&quot; CXXCPP=&quot;%(_MonoCrossRuntime.CxxCpp)&quot; LD=&quot;%(_MonoCrossRuntime.Ld)&quot; AR=&quot;%(_MonoCrossRuntime.Ar)&quot; AS=&quot;%(_MonoCrossRuntime.As)&quot; RANLIB=&quot;%(_MonoCrossRuntime.RanLib)&quot; STRIP=&quot;%(_MonoCrossRuntime.Strip)&quot; DLLTOOL=&quot;%(_MonoCrossRuntime.DllTool)&quot; OBJDUMP=&quot;%(_MonoCrossRuntime.Objdump)&quot; --cache-file=..\%(_MonoCrossRuntime.Identity).config.cache %(_MonoCrossRuntime.ConfigureFlags)"
+        IgnoreStandardErrorWarningFormat="True"
         WorkingDirectory="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)"
     />
     <Touch
@@ -425,6 +430,7 @@
     <Message Text="Building %(_MonoCrossRuntime.Identity) in $(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)"/>
     <Exec
         Command="%(_MonoCrossRuntime.BuildEnvironment) make $(MakeConcurrency)"
+        IgnoreStandardErrorWarningFormat="True"
         WorkingDirectory="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)"
     />
     <Touch

--- a/build-tools/scripts/msbuild.mk
+++ b/build-tools/scripts/msbuild.mk
@@ -27,7 +27,3 @@ MSBUILD_FLAGS = /p:Configuration=$(CONFIGURATION) $(MSBUILD_ARGS)
 ifneq ($(V),0)
 MSBUILD_FLAGS += /v:diag
 endif   # $(V) != 0
-
-ifeq ($(MSBUILD),xbuild)
-MSBUILD_FLAGS += /p:_XABuildingWithXBuild=True
-endif	# msbuild

--- a/src/Mono.Android.Export/Mono.Android.Export.csproj
+++ b/src/Mono.Android.Export/Mono.Android.Export.csproj
@@ -46,10 +46,6 @@
       <HintPath>$(OutputPath)..\v1.0\System.Core.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System.Runtime" Condition=" '$(_XABuildingWithXBuild)' != 'True' ">
-      <HintPath>$(OutputPath)..\v1.0\Facades\System.Runtime.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System.Xml">
       <HintPath>$(OutputPath)..\v1.0\System.Xml.dll</HintPath>
       <Private>False</Private>

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -53,10 +53,6 @@
       <HintPath>$(OutputPath)..\v1.0\System.Net.Http.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System.Runtime" Condition=" '$(_XABuildingWithXBuild)' != 'True' ">
-      <HintPath>$(OutputPath)..\v1.0\Facades\System.Runtime.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System.Runtime.Serialization">
       <HintPath>$(OutputPath)..\v1.0\System.Runtime.Serialization.dll</HintPath>
       <Private>False</Private>

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/UnzipDirectoryChildren.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/UnzipDirectoryChildren.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks {
 
 		public override bool Execute ()
 		{
-			Log.LogMessage (MessageImportance.Low, "Unzip:");
+			Log.LogMessage (MessageImportance.Low, $"{nameof (UnzipDirectoryChildren)}:");
 			Log.LogMessage (MessageImportance.Low, "  DestinationFolder: {0}", DestinationFolder.ItemSpec);
 			Log.LogMessage (MessageImportance.Low, "  EntryNameEncoding: {0}", EntryNameEncoding);
 			Log.LogMessage (MessageImportance.Low, "  SourceFiles:");

--- a/src/sqlite-xamarin/sqlite-xamarin.targets
+++ b/src/sqlite-xamarin/sqlite-xamarin.targets
@@ -9,7 +9,9 @@
       Inputs="$(SqliteSourceFullPath)\README.version"
       Outputs="src\stamp">
     <Exec Condition="!Exists('src')"
-        Command="$(AndroidSdkDirectory)\tools\android create project -g -n sqlitesample -p . -a MainActivity -t android-$(AndroidApiLevel) --package com.xamarin.sqlitesample -v 1.0.0" />
+        Command="$(AndroidSdkDirectory)\tools\android create project -g -n sqlitesample -p . -a MainActivity -t android-$(AndroidApiLevel) --package com.xamarin.sqlitesample -v 1.0.0"
+        IgnoreStandardErrorWarningFormat="True"
+    />
     <Copy Condition="!Exists('src\stamp')"
         SourceFiles="src-jni\Application.mk;src-jni\Android.mk"
         DestinationFiles="src\main\jni\Application.mk;src\main\jni\Android.mk" />


### PR DESCRIPTION
Commit 7343965a didn't succeed in actually building `xamarin-android`
with `msbuild` on our Jenkins bot. :-(

Time to take another stab at it.

As an added complication, my local `msbuild` behavior (mono 4.8)
differs from Jenkins' `msbuild` behavior (mono 4.4), specifically
around MSB3644. [On Jenkins][msb-96], it's a warning:

	warning MSB3644: The reference assemblies for framework ".NETFramework,Version=v4.5" were not found.

When I run locally, it's an *error*. Go figure.

Fixing the local error requires that I *remove* the
`$(TargetFrameworkRootPath)` MSBuild property from
`Configuration.props`, added in commit 255a569b. The issue is that
`$(TargetFrameworkRootPath)` is an *override*, an "absolute" override.
Thus, when e.g. building `Xamarin.Android.Build.Tasks.csproj`, the
`.NETFramework,Version=v4.5` framework -- and corresponding
`mscorlib.dll` -- cannot be resolved, and everything breaks.

(Which raises the wonderful question of whether removing
`$(TargetFrameworkRootPath)` will cause the Linux build to break
again, but we'll cross that bridge later...)

Removing `$(TargetFrameworkRootPath)` in turn requires that I remove
the explicit `@(Reference)`s to `System.Runtime` which commit
7343965a added when building under `xbuild`. This also means that we
no longer need the `$(_XABuildingWithXBuild)` property.
(The "history" eluded to in 7343965a? It's continuing! Argh!)

Additionally, fix the logging from the `<UnzipDirectoryChildren/>`
task so that it prints the *correct* task name, *not* `Unzip`.
(Seeing the wrong task name in log files makes things *confusing*.)

With my local `msbuild` faiklures fixed, we can turn our attention to
to the [errors reported on Jenkins][msb-96]. They are variations on
the same "form":

	# from build-tools/mono-runtimes
	.../external/mono/configure LDFLAGS=...
	...
	EXEC : error : /Applications/Xcode8.1-beta1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: unknown option character `-' in: --config

	# from src/sqlite-xamarin
	.../android create project -g -n sqlitesample -p . -a MainActivity -t android-25 --package com.xamarin.sqlitesample -v 1.0.0
	EXEC : error : Project folder '.' is not empty. Please consider using 'android update' instead.

The issue here is that MSBuild is "better" than xbuild: xbuild only
checks the process exit code for errors. The above
`android create project` command has en exit code of 0, i.e. it didn't
error...according to xbuild.

That said, when running [with xbuild][xb-203]:

	Task "Exec"
		Executing: .../android create project -g -n sqlitesample -p . -a MainActivity -t android-25 --package com.xamarin.sqlitesample -v 1.0.0
		Environment variables being passed to the tool:
		Error: Project folder '.' is not empty. Please consider using 'android update' instead
		...
	Done executing task "Exec"
	Task "Copy"
		...

Rephrased: `android create project ...` is emitting an "Error: ..."
*message*, but even when it emits that message the exit status is
still 0 (no error).

xbuild is only checking the exit status, and thus continues the build.

MSBuild not only checks the exit status, but *also* checks the command
*output*, looking for the string `error`. Because an "error" message
is printed, MSBuild flags this as an error, halting the build.

The fix? Set `Exec.IgnoreStandardErrorWarningFormat=True` on all
`<Exec/>` tasks which invoke **make**(1) or `configure` within
`build-tools/mono-runtimes` and `src/sqlite-xamarin`. Setting
`Exec.IgnoreStandardErrorWarningFormat=True` prevents the `<Exec/>`
task from scanning the task output for "error", causing `msbuild` to
behave like `xbuild` and only use the process exit code for errors.
This allows the build to continue.

[msb-96]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-msbuild/96/consoleText
[xb-203]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/203/consoleText