### PR TITLE
[Xamarin.Android.Build.Tasks] Unable to run Multi-Dex

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
@@ -51,7 +51,8 @@ namespace Xamarin.Android.Tasks
 			EnvironmentVariables =
 				string.IsNullOrEmpty (MSBuildRuntimeType) || MSBuildRuntimeType == "Mono" ?
 				new string [] { "PROGUARD_HOME=" + ProguardHome } :
-				new string [] { "JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8", "PROGUARD_HOME=" + ProguardHome };
+				//TODO ReAdd the PROGUARD_HOME env variable once we are shipping our own proguard
+				new string [] { "JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8" };
 
 			return base.Execute ();
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
@@ -111,7 +111,8 @@ namespace Xamarin.Android.Tasks
 			EnvironmentVariables =
 				string.IsNullOrEmpty (MSBuildRuntimeType) || MSBuildRuntimeType == "Mono" ?
 				new string [] { "PROGUARD_HOME=" + ProguardHome } :
-				new string [] { "JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8", "PROGUARD_HOME=" + ProguardHome };
+				//TODO ReAdd the PROGUARD_HOME env variable once we are shipping our own proguard
+				new string [] { "JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8" };
 
 			return base.Execute ();
 		}


### PR DESCRIPTION
Commit a967b24 added a PROGUARD_HOME environment variable when
running Proguard and MultiDex. However it does break things on
windows. The problem is down to a bug in the Google proguard.bat
file where a " is in the wrong place. This results in the
following error.

	Unable to access jarfile C:\Program Files (x86)\Android\android-sdk\tools\proguard"\lib\proguard.jar -injars 'C:\Program'

Note the " in the wrong place. This does NOT occur if we allow
the android tooling to find proguard itself rather than specifying
a path (via the environment variable)

This commit removes the variable from the Windows
environment this seems to fix the issue.