### PR TITLE
[Xamarin.Android.Build.Tasks] _CreateNativeLibraryArchive needs references

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1145,6 +1145,7 @@ because xbuild doesn't support framework reference assemblies.
   
 <Target Name="_CreateNativeLibraryArchive"
         Condition="@(EmbeddedNativeLibrary) != ''" 
+        DependsOnTargets="ResolveReferences"
         Inputs="@(EmbeddedNativeLibrary)"
         Outputs="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip">
     <CreateNativeLibraryArchive


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/7343965a0bbee3d192684dbb371789613bf5b830
Context: https://github.com/xamarin/xamarin-android/commit/743529c1cc8188724048755b30ccd7c4f681f5e5
Context: https://gitter.im/Microsoft/msbuild?at=58823bfd074f7be763f6aeaf
         ...through...
         https://gitter.im/Microsoft/msbuild?at=5882440d300f220a661148c8

We want to be able to build the xamarin-android repo via `msbuild`,
because `msbuild` may be the default build system in the "Cycle 10"
timeframe (please oh please oh please...) and because building with
`msbuild` is a prerequisite to sanely building on Windows, which would
be extremely handy for increasing our contributor base.

Unfortunately, [commit 743529c1 didn't fix all problems][0]:

	error MSB4018: The "CreateNativeLibraryArchive" task failed unexpectedly.
	error MSB4018: System.IO.FileNotFoundException: ../sqlite-xamarin/src/main/libs/armeabi-v7a/libsqlite3_xamarin.so does not exist
	...

The MSB4018 is a *symptom*, not a cause. The *cause* of the error is
twofold:

1. `Mono.Data.Sqlite.csproj` depends on build artifacts from building
    the `sqlite-xamarin.mdproj` project.
2. `sqlite-xamarin.mdproj` isn't being built before
    `Mono.Data.Sqlite.csproj`.

(2) is a bit of a head scratcher: `Mono.Data.Sqlite.csproj` has a
`@(ProjectReference)` including `sqlite-xamarin.mdproj`; surely that's
enough, right?

Wrong. `@(ProjectReference)` isn't "special"; it's just an item group,
interpreted by the `ResolveReferences` target.

The problem we're seeing here is that the `ResolveReferences` target
isn't executed before the `_CreateNativeLibraryArchive` target is
executed. Consequently `@(ProjectReference)` isn't handled *at all*
prior to the `_CreateNativeLibraryArchive` invocation, which is why
`sqlite-xamarin.mdproj` isn't built before `Mono.Data.Sqlite.csproj`.

(Why's this work on `xbuild`? No idea!)

Update the `_CreateNativeLibraryArchive` target to add a
`DependsOnTargets` value of `ResolveReferences`. This explicit target
references ensures that referenced projects (`sqlite-xamarin.mdproj`)
are resolved and built before the current project
(`Mono.Data.Sqlite.csproj`), allowing cross-references of build
artifacts in a sane(r) fashion.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-msbuild/99/consoleText