### PR TITLE
[build] Fix the Linux build

### DIFF
--- a/src/Mono.Android.Export/Mono.Android.Export.csproj
+++ b/src/Mono.Android.Export/Mono.Android.Export.csproj
@@ -7,11 +7,16 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Mono.Android.Export</RootNamespace>
     <AssemblyName>Mono.Android.Export</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
+  <PropertyGroup>
+    <ImplicitlyExpandDesignTimeFacades>True</ImplicitlyExpandDesignTimeFacades>
+    <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
+    <TargetFrameworkRootPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -7,11 +7,16 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Android</RootNamespace>
     <AssemblyName>Mono.Android</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
+  <PropertyGroup>
+    <ImplicitlyExpandDesignTimeFacades>True</ImplicitlyExpandDesignTimeFacades>
+    <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
+    <TargetFrameworkRootPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -197,7 +197,7 @@
     />
   </Target>
   <Target Name="_GenerateFrameworkList"
-      AfterTargets="CoreBuild"
+      BeforeTargets="ResolveReferences"
       Inputs="$(OutputPath)$(AssemblyName).dll"
       Outputs="$(OutputPath)RedistList\FrameworkList.xml">
    <MakeDir Directories="$(OutputPath)RedistList" />

--- a/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
+++ b/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
@@ -21,6 +21,7 @@
   <PropertyGroup>
     <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
     <AssemblyOriginatorKeyFile>$(MonoSourceFullPath)\mcs\class\mono.pub</AssemblyOriginatorKeyFile>
+    <TargetFrameworkRootPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Mono.Posix/Mono.Posix.csproj
+++ b/src/Mono.Posix/Mono.Posix.csproj
@@ -21,6 +21,7 @@
   <PropertyGroup>
     <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
     <AssemblyOriginatorKeyFile>$(MonoSourceFullPath)\mcs\class\mono.pub</AssemblyOriginatorKeyFile>
+    <TargetFrameworkRootPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/OpenTK-1.0/OpenTK.csproj
+++ b/src/OpenTK-1.0/OpenTK.csproj
@@ -26,6 +26,7 @@
   <PropertyGroup>
     <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
     <AssemblyOriginatorKeyFile>$(MonoSourceFullPath)\mcs\class\mono.pub</AssemblyOriginatorKeyFile>
+    <TargetFrameworkRootPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/System.Drawing.Primitives/System.Drawing.Primitives.csproj
+++ b/src/System.Drawing.Primitives/System.Drawing.Primitives.csproj
@@ -18,6 +18,7 @@
   <PropertyGroup>
     <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
     <AssemblyOriginatorKeyFile>$(MonoSourceFullPath)\mcs\class\mono.pub</AssemblyOriginatorKeyFile>
+    <TargetFrameworkRootPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj
+++ b/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj
@@ -17,6 +17,10 @@
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
+  <PropertyGroup>
+    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
+    <TargetFrameworkRootPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>


### PR DESCRIPTION
As feared, commit 743529c1's removal of `$(TargetFrameworkRootPath)`
[broke the Linux build][0]:

	Gui/Activities/TestSuiteActivity.cs(25,35): error CS0012: The type `System.IDisposable' is defined in an assembly that is not referenced.
	Consider adding a reference to assembly `System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'

macOS is unaffected as [it's unfortunately using System files][1]:

	Found framework definition list '/Library/Frameworks/Mono.framework/External/xbuild-frameworks/MonoAndroid/v1.0/RedistList/FrameworkList.xml' for framework 'MonoAndroid,Version=v1.0'

(Heavy sigh.)

Thus, our scenario: `msbuild` doesn't like setting
`$(TargetFrameworkRootPath)`, yet `$(TargetFrameworkRootPath)` needs
to be set for Linux to build, because Linux doesn't have a system-wide
Xamarin.Android install. (Not that we want to require a
Xamarin.Android install! But that's just why macOS is building...)

The fix? Split the difference, somewhat. We can't set
`$(TargetFrameworkRootPath)` for *everything*, but we *can* override
it for *specific projects*. Update `Mono.Data.Sqlite.csproj`,
`Mono.Posix.csproj`, `OpenTK.csproj`,
`System.Drawing.Primitives.csproj`, and
`Xamarin.Android.NUnitLite.csproj` to override
`$(TargetFrameworkRootPath)` appropriately, so that they resolve the
`MonoAndroid` framework assemblies from the internal build tree.

What's left is `Mono.Android.csproj` and `Mono.Android.Export.csproj`,
which don't `<Import/>` `Xamarin.Android.CSharp.targets`. These are
the projects that needed to "hack in" a `@(Reference)` to
`System.Runtime` in 7343965, which was removed in 743529c1. The fix is
more voodoo in each of them:

* Set `$(ImplicitlyExpandDesignTimeFacades)`=True, so `System.Runtime`
    can be found
* Set `$(TargetFrameworkIdentifier)`=MonoAndroid, so we're looking for
    the correct framework
* Set `$(TargetFrameworkRootPath)` so that the MonoAndroid framework
    can be found in the local build tree.
* Set `$(TargetFrameworkVersion)` to a valid MonoAndroid framework
    version number.

This allows `Mono.Android.Export.csproj`. `Mono.Android.csproj` needs
one more fix: in order for frameworks to be resolved from a "clean"
state, `RedistList\FrameworkList.xml` must exist before attempting to
resolve assemblies. Fix the `_GenerateFrameworkList` target so that
`FrameworkList.xml` is created *before* the `ResolveReferences`
target, thus allowing the `MonoAndroid,v7.1` framework to be found.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-linux/173/
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/207/consoleText