### PR TITLE
[Xamarin.Android.Build.Tasks] Fix the AndroidPrepareForBuild Target.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -831,7 +831,7 @@ because xbuild doesn't support framework reference assemblies.
 	</CreateProperty>
 </Target>
 
-<Target Name="AndroidPrepareForBuild" DependsOnTargets="_ResolveMonoAndroidFramework" />
+<Target Name="AndroidPrepareForBuild" DependsOnTargets="_ResolveMonoAndroidSdks" />
 
 <!-- uploadflags.txt
 	- This file says which devices this package has been deployed to.


### PR DESCRIPTION
The AndroidPrepareForBuild target was not dependent on the correct
target. As a result propertoes which relate to the adb tool were
not be populated correctly.