### PR TITLE
[Xamarin.Android.Build.Tasks] Fix the use of Aot on Windows.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -148,6 +148,14 @@ namespace Xamarin.Android.Tasks
 			return libPath;
 		}
 
+		static string GetShortPath (string path)
+		{
+			if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+				return QuoteFileName (path);
+			var shortPath = KernelEx.GetShortPathName (Path.GetDirectoryName (path));
+			return Path.Combine (shortPath, Path.GetFileName (path));
+		}
+
 		static string QuoteFileName(string fileName)
 		{
 			var builder = new CommandLineBuilder();
@@ -362,9 +370,9 @@ namespace Xamarin.Android.Tasks
 						Diagnostic.Error (5101, ex.Message);
 					}
 					var libs = new List<string>() {
-						QuoteFileName (Path.Combine(GetNdkToolchainLibraryDir(toolchainPath), "libgcc.a")),
-						QuoteFileName (Path.Combine(androidLibPath, "libc.so")),
-						QuoteFileName (Path.Combine(androidLibPath, "libm.so"))
+						GetShortPath (Path.Combine(GetNdkToolchainLibraryDir(toolchainPath), "libgcc.a")),
+						GetShortPath (Path.Combine(androidLibPath, "libc.so")),
+						GetShortPath (Path.Combine(androidLibPath, "libm.so"))
 					};
 					ldFlags = string.Join(";", libs);
 				}
@@ -385,17 +393,17 @@ namespace Xamarin.Android.Tasks
 					if (!string.IsNullOrEmpty (AotAdditionalArguments))
 						aotOptions.Add (AotAdditionalArguments);
 					if (sequencePointsMode == SequencePointsMode.Offline)
-						aotOptions.Add ("msym-dir=" + QuoteFileName (outdir));
+						aotOptions.Add ("msym-dir=" + GetShortPath (outdir));
 					if (AotMode != AotMode.Normal)
 						aotOptions.Add (AotMode.ToString ().ToLowerInvariant ());
 
-					aotOptions.Add ("outfile="     + QuoteFileName (outputFile));
+					aotOptions.Add ("outfile="     + GetShortPath (outputFile));
 					aotOptions.Add ("asmwriter");
 					aotOptions.Add ("mtriple="     + mtriple);
-					aotOptions.Add ("tool-prefix=" + QuoteFileName (toolPrefix));
+					aotOptions.Add ("tool-prefix=" + GetShortPath (toolPrefix));
 					aotOptions.Add ("ld-flags="    + ldFlags);
-					aotOptions.Add ("llvm-path="   + QuoteFileName (SdkBinDirectory));
-					aotOptions.Add ("temp-path="   + QuoteFileName (tempDir));
+					aotOptions.Add ("llvm-path="   + GetShortPath (SdkBinDirectory));
+					aotOptions.Add ("temp-path="   + GetShortPath (tempDir));
 
 					string aotOptionsStr = (EnableLLVM ? "--llvm " : "") + "--aot=" + string.Join (",", aotOptions);
 
@@ -419,7 +427,7 @@ namespace Xamarin.Android.Tasks
 					var assembliesPath = Path.GetFullPath (Path.GetDirectoryName (resolvedPath));
 					var assemblyPath = QuoteFileName (Path.GetFullPath (resolvedPath));
 
-					yield return new Config (assembliesPath, aotCompiler, aotOptionsStr, assemblyPath, outputFile);
+					yield return new Config (assembliesPath, QuoteFileName (aotCompiler), aotOptionsStr, assemblyPath, outputFile);
 				}
 			}
 		}


### PR DESCRIPTION
When running on windows if your ndk is in a path with spaces you
are in trouble. This is because the use of quoted paths causes the
cross compiler problems on windows. Specifically when dealing with
the LD_FLAGS that we pass to the compiler. It cannot handle the following

	ld_flags="foo";"bar"

because for some reason the quotes get messed up or stripped off.
We only quote paths which have spaces in them so if your ndk is in
a path this does not have spaces you will be fine.

One solution was to quote the entire --aot flag

	"--aot=<stuff>"

But that causes issues because the parse in the cross compiler was not
handling spaces correctly in that either. We ended up with errors like

	"Cannot find Path c:\Program"

So that was not an option.

BTW Visual Studio by default installs the ndk to Program Files (x86)...

oops.

This commit reworks the code to that on windows we user the
ShortPathName for the flags we pass to the aot compiler on windows.
This allow us to dispense with the quotes which cause us problems.
We already have a KernelEx class which contains the correct methods
so we just make use of them when we are not on a Unix based plaform.