### PR TITLE
[jni] Store MonoJavaGCBridgeInfo per-domain when running on desktop.

### DIFF
--- a/src/monodroid/jni/util.c
+++ b/src/monodroid/jni/util.c
@@ -303,8 +303,8 @@ monodroid_property_set (struct DylibMono *mono, MonoDomain *domain, MonoProperty
 MonoDomain*
 monodroid_create_appdomain (struct DylibMono *mono, MonoDomain *parent_domain, const char *friendly_name, int shadow_copy)
 {
-	MonoClass *appdomain_setup_klass = monodroid_get_class_from_name (mono, parent_domain, "mscorlib", "System", "AppDomainSetup");
-	MonoClass *appdomain_klass = monodroid_get_class_from_name (mono, parent_domain, "mscorlib", "System", "AppDomain");
+	MonoClass *appdomain_setup_klass = monodroid_get_class_from_name (mono, parent_domain, "mscorlib", "System", "AppDomainSetup", NULL);
+	MonoClass *appdomain_klass = monodroid_get_class_from_name (mono, parent_domain, "mscorlib", "System", "AppDomain", NULL);
 	MonoMethod *create_domain = mono->mono_class_get_method_from_name (appdomain_klass, "CreateDomain", 3);
 	MonoProperty *shadow_copy_prop = mono->mono_class_get_property_from_name (appdomain_setup_klass, "ShadowCopyFiles");
 
@@ -368,7 +368,7 @@ create_directory (const char *pathname, int mode)
 }
 
 MonoClass*
-monodroid_get_class_from_name (struct DylibMono *mono, MonoDomain *domain, const char* assembly, const char *namespace, const char *type)
+monodroid_get_class_from_name (struct DylibMono *mono, MonoDomain *domain, const char* assembly, const char *namespace, const char *type, MonoImage **result_image)
 {
 	MonoAssembly *assm = NULL;
 	MonoImage *image = NULL;
@@ -383,6 +383,8 @@ monodroid_get_class_from_name (struct DylibMono *mono, MonoDomain *domain, const
 	if (assm != NULL) {
 		image = mono->mono_assembly_get_image (assm);
 		result = mono->mono_class_from_name (image, namespace, type);
+		if (result_image != NULL)
+			*result_image = image;
 	}
 
 	if (domain != current)

--- a/src/monodroid/jni/util.h
+++ b/src/monodroid/jni/util.h
@@ -105,7 +105,7 @@ struct        DylibMono;
 
 MonoAssembly    *monodroid_load_assembly (struct DylibMono *mono, MonoDomain *domain, const char *basename);
 void            *monodroid_runtime_invoke (struct DylibMono *mono, MonoDomain *domain, MonoMethod *method, void *obj, void **params, MonoObject **exc);
-MonoClass       *monodroid_get_class_from_name (struct DylibMono *mono, MonoDomain *domain, const char* assembly, const char *namespace, const char *type);
+MonoClass       *monodroid_get_class_from_name (struct DylibMono *mono, MonoDomain *domain, const char* assembly, const char *namespace, const char *type, MonoImage **return_image);
 MonoDomain      *monodroid_create_appdomain (struct DylibMono *mono, MonoDomain *parent_domain, const char *friendly_name, int shadow_copy);
 MonoClass       *monodroid_get_class_from_image (struct DylibMono *mono, MonoDomain *domain, MonoImage* image, const char *namespace, const char *type);
 


### PR DESCRIPTION
By enabling real shadow copying of assemblies for each domain created, we are technically loading isolated copies of every Mono.Android.dll type in those domains.

This ends up confusing the bridge code because the previous assumption that bridged base type would be common among domains is not true anymore. This ends up creating native crashes because the code is then trying to access those class info when their associated domain has already been disposed such as:

```
SIGSEGV (0xb) at pc=0x00000001362c6e13, pid=72483, tid=60171

Stack: [0x000070000268f000,0x000070000278f000],  sp=0x000070000278af60,  free space=1007k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libmonosgen-2.0.dylib+0x133e13]  mono_class_setup_fields+0x63
C  [libmonosgen-2.0.dylib+0x136136]  mono_class_init+0x386
C  [libmonosgen-2.0.dylib+0x140a6f]  mono_class_is_subclass_of+0x1f
C  [libmono-android.debug.so+0xa608]  gc_bridge_class_kind+0x48
```

Thus this commit alters the way the bridge info are stored by putting them on the existing `MonodroidBridgeProcessingInfo` struct that is maintained for each domain created when running on desktop. It also removes direct references to the shared `mono_java_gc_bridge_info` variable instead retrieving this information indirectly via `get_gc_bridge_index`.

For all of this to work properly, it relies on the fact that the GC bridge routines are called from the correct domain for the object queried which is retrieved via `mono_domain_get`.