### PR TITLE
Fixes Binding Library Not Updating with Newer AAR

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
@@ -140,8 +140,7 @@ namespace Xamarin.Android.Tasks
 			foreach (var file in Directory.GetFiles (srcdir)) {
 				if (file.EndsWith (".jar", StringComparison.OrdinalIgnoreCase)) {
 					var dstpath = Path.Combine (OutputJarsDirectory, Path.GetFileName (file));
-					if (!File.Exists (dstpath))
-						MonoAndroidHelper.CopyIfChanged (file, dstpath);
+					BMonoAndroidHelper.CopyIfChanged (file, dstpath);
 				} else if (file.EndsWith ("annotations.zip", StringComparison.OrdinalIgnoreCase)) {
 					var dstpath = Path.Combine (OutputAnnotationsDirectory, Path.GetFileName (file));
 					if (!File.Exists (dstpath))

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
@@ -129,8 +129,7 @@ namespace Xamarin.Android.Tasks
 				var dstdir = Path.Combine (OutputDirectory, "bin");
 				foreach (var file in Directory.GetFiles (projdir)) {
 					string dstpath = Path.Combine (dstdir, Path.GetFileName (file));
-					if (!File.Exists (dstpath))
-						MonoAndroidHelper.CopyIfChanged (file, dstpath);
+                    MonoAndroidHelper.CopyIfChanged (file, dstpath);
 				}
 			}
 			return true;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
@@ -129,7 +129,7 @@ namespace Xamarin.Android.Tasks
 				var dstdir = Path.Combine (OutputDirectory, "bin");
 				foreach (var file in Directory.GetFiles (projdir)) {
 					string dstpath = Path.Combine (dstdir, Path.GetFileName (file));
-                    MonoAndroidHelper.CopyIfChanged (file, dstpath);
+					MonoAndroidHelper.CopyIfChanged (file, dstpath);
 				}
 			}
 			return true;


### PR DESCRIPTION
- Currently there is an [issue](https://bugzilla.xamarin.com/show_bug.cgi?id=35488) when an AAR file is updated, but
  the Android Binding library does not regenerate the bindings.
  I believe this is caused while copying over the AAR file contents
  to the library_project_imports directory. Currently, the logic is to
  only attempt a copy if the file doesn't exist. However, I think the
  correct logic should be to copy if the file has changed.
- The result of this change is that my .JAR file, which resides inside
  of my .AAR file, will be correctly copied to the library_project_imports
  and the library_project_jars, and can be used to update the generated 
  bindings.
- This logic may also be incorrect in other places in the file.