### PR TITLE
[Xamarin.Android.Build.Tasks] Fix the AndroidPrepareForbuild Target (…again).

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -831,7 +831,7 @@ because xbuild doesn't support framework reference assemblies.
 	</CreateProperty>
 </Target>
 
-<Target Name="AndroidPrepareForBuild" DependsOnTargets="_ResolveMonoAndroidSdks" />
+<Target Name="AndroidPrepareForBuild" DependsOnTargets="$(_OnResolveMonoAndroidSdks)" />
 
 <!-- uploadflags.txt
 	- This file says which devices this package has been deployed to.


### PR DESCRIPTION
Commit fb125dda did not use the correct target. As a result
`_ValidateAndroidPackageProperties` was not being run. The
runtime tests needed this in order to run the instrumentation.