### PR TITLE
[Xamarin.Android.Build.Tasks] Custom control "CardView" properties are not getting appearing in Properties Panel in VS.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -365,7 +365,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </Target>
 
 <Target Name="_BuildAdditionalResourcesCache"
-	Inputs="@(ReferencePath);@(ReferenceDependencyPaths)"
+	Inputs="@(ReferencePath);@(ReferenceDependencyPaths);$(MSBuildProjectFullPath)"
 	Outputs="$(_AndroidResourcePathsCache)"
 	DependsOnTargets="$(_BeforeBuildAdditionalResourcesCache)"
 	>


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=51604

In the case where a Reference is added to the project that
was NOT invaidating the Build Cache. As a result the list
of external Java Libraries was not being updated.