### PR TITLE
Revert "[build] Fix the Linux build"

### DIFF
--- a/src/Mono.Android.Export/Mono.Android.Export.csproj
+++ b/src/Mono.Android.Export/Mono.Android.Export.csproj
@@ -7,16 +7,11 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Mono.Android.Export</RootNamespace>
     <AssemblyName>Mono.Android.Export</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
-  <PropertyGroup>
-    <ImplicitlyExpandDesignTimeFacades>True</ImplicitlyExpandDesignTimeFacades>
-    <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
-    <TargetFrameworkRootPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -7,16 +7,11 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Android</RootNamespace>
     <AssemblyName>Mono.Android</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
-  <PropertyGroup>
-    <ImplicitlyExpandDesignTimeFacades>True</ImplicitlyExpandDesignTimeFacades>
-    <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
-    <TargetFrameworkRootPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -197,7 +197,7 @@
     />
   </Target>
   <Target Name="_GenerateFrameworkList"
-      BeforeTargets="ResolveReferences"
+      AfterTargets="CoreBuild"
       Inputs="$(OutputPath)$(AssemblyName).dll"
       Outputs="$(OutputPath)RedistList\FrameworkList.xml">
    <MakeDir Directories="$(OutputPath)RedistList" />

--- a/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
+++ b/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
@@ -21,7 +21,6 @@
   <PropertyGroup>
     <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
     <AssemblyOriginatorKeyFile>$(MonoSourceFullPath)\mcs\class\mono.pub</AssemblyOriginatorKeyFile>
-    <TargetFrameworkRootPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Mono.Posix/Mono.Posix.csproj
+++ b/src/Mono.Posix/Mono.Posix.csproj
@@ -21,7 +21,6 @@
   <PropertyGroup>
     <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
     <AssemblyOriginatorKeyFile>$(MonoSourceFullPath)\mcs\class\mono.pub</AssemblyOriginatorKeyFile>
-    <TargetFrameworkRootPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/OpenTK-1.0/OpenTK.csproj
+++ b/src/OpenTK-1.0/OpenTK.csproj
@@ -26,7 +26,6 @@
   <PropertyGroup>
     <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
     <AssemblyOriginatorKeyFile>$(MonoSourceFullPath)\mcs\class\mono.pub</AssemblyOriginatorKeyFile>
-    <TargetFrameworkRootPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/System.Drawing.Primitives/System.Drawing.Primitives.csproj
+++ b/src/System.Drawing.Primitives/System.Drawing.Primitives.csproj
@@ -18,7 +18,6 @@
   <PropertyGroup>
     <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
     <AssemblyOriginatorKeyFile>$(MonoSourceFullPath)\mcs\class\mono.pub</AssemblyOriginatorKeyFile>
-    <TargetFrameworkRootPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj
+++ b/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj
@@ -17,10 +17,6 @@
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
-  <PropertyGroup>
-    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
-    <TargetFrameworkRootPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>


### PR DESCRIPTION
Reverts xamarin/xamarin-android#394 (commit 61b21bce).

[It broke the build][b209]:

	Java.Lang/Object.cs(15,5): error CS0012: The type `System.IDisposable' is defined in an assembly that is not referenced.
    Consider adding a reference to assembly `System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'

Doubly odd, I *thought* that this had successfully gone through the
PR builder, but I can't find an actual PR build for this PR!

Revert the attempted Linux build fix. We want things building, which
will allow me time to investigate a better Linux fix.

[b209]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/209/