### PR TITLE
[linker] fix #51340

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MonoDroidMarkStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MonoDroidMarkStep.cs
@@ -11,6 +11,7 @@ namespace MonoDroid.Tuner
 	class MonoDroidMarkStep : MarkStep
 	{
 		const string RegisterAttribute = "Android.Runtime.RegisterAttribute";
+		const string ICustomMarshalerName = "System.Runtime.InteropServices.ICustomMarshaler";
 
 		// If this is one of our infrastructure methods that has [Register], like:
 		// [Register ("hasWindowFocus", "()Z", "GetHasWindowFocusHandler")],
@@ -141,6 +142,15 @@ namespace MonoDroid.Tuner
 
 			if (type.Module.Assembly.Name.Name == "System.Core")
 				ProcessSystemCore (type);
+
+			if (type.HasMethods && type.HasInterfaces && type.Implements (ICustomMarshalerName)) {
+				foreach (MethodDefinition method in type.Methods) {
+					if (method.Name == "GetInstance" && method.IsStatic && method.HasParameters && method.Parameters.Count == 1 && method.ReturnType.FullName == ICustomMarshalerName && method.Parameters.First ().ParameterType.FullName == "System.String") {
+						MarkMethod (method);
+						break;
+					}
+				}
+			}
 
 			return type;
 		}


### PR DESCRIPTION
 - preserve the GetInstance method whenever the
   Mono.Unix.Native.FileNameMarshaler type is used

 - it avoids errors like:

         ReadlinkTest
         	ReadLink [FAIL] : System.ApplicationException : Custom marshaler 'FileNameMarshaler' does not implement a static GetInstance method that takes a single string parameter and returns an ICustomMarshaler.
         		  at (wrapper managed-to-native) Mono.Unix.Native.Syscall:readlinkat (int,string,byte[],ulong)
         		  at Mono.Unix.Native.Syscall.readlinkat (System.Int32 dirfd, System.String pathname, System.Byte[] buf) [0x0000a] in <75558c6e0e1f444f8a03d1c694a92a08>:0
         		  at MonoTests.Mono.Unix.ReadlinkTest.SetUp () [0x00007] in <9df8009b87984e1cb863e771d21f9f39>:0
         		  at (wrapper managed-to-native) System.Reflection.MonoMethod:InternalInvoke (System.Reflection.MonoMethod,object,object[],System.Exception&)
         		  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00038] in <9f55149ed93f4bad9226ce1d7634fe5b>:0
         	readlink_byte [FAIL] : System.ApplicationException : Custom marshaler 'FileNameMarshaler' does not implement a static GetInstance method that takes a single string parameter and returns an ICustomMarshaler.
         TearDown : System.ArgumentException : ** Unknown error code: 9**
           ----> Mono.Unix.UnixIOException : ** Unknown error code: 9** [EBADF].
         		  at (wrapper managed-to-native) Mono.Unix.Native.Syscall:readlinkat (int,string,byte[],ulong)
         		  at Mono.Unix.Native.Syscall.readlinkat (System.Int32 dirfd, System.String pathname, System.Byte[] buf) [0x0000a] in <75558c6e0e1f444f8a03d1c694a92a08>:0
         		  at MonoTests.Mono.Unix.ReadlinkTest.SetUp () [0x00007] in <9df8009b87984e1cb863e771d21f9f39>:0
         		  at (wrapper managed-to-native) System.Reflection.MonoMethod:InternalInvoke (System.Reflection.MonoMethod,object,object[],System.Exception&)
         		  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00038] in <9f55149ed93f4bad9226ce1d7634fe5b>:0
         		--TearDown
         		  at Mono.Unix.UnixMarshal.ThrowExceptionForLastError () [0x00006] in <75558c6e0e1f444f8a03d1c694a92a08>:0
         		  at MonoTests.Mono.Unix.ReadlinkTest.TearDown () [0x00011] in <9df8009b87984e1cb863e771d21f9f39>:0
         		  at (wrapper managed-to-native) System.Reflection.MonoMethod:InternalInvoke (System.Reflection.MonoMethod,object,object[],System.Exception&)
         		  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00038] in <9f55149ed93f4bad9226ce1d7634fe5b>:0
         		--UnixIOException