### PR TITLE
[Xamrain.Anroid.Build.Tasks] Fix a problem with creating zip files with a large number of files.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
@@ -90,19 +90,14 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
-			// Archive them in a zip.
-			using (var stream = new MemoryStream ()) {
-				using (var zip = ZipArchive.Create (stream)) {
+			var outpath = Path.Combine (outDirInfo.Parent.FullName, "__AndroidLibraryProjects__.zip");
+
+			if (Files.ArchiveZip (outpath, f => {
+				using (var zip = new ZipArchiveEx (f)) {
 					zip.AddDirectory (OutputDirectory, outDirInfo.Name);
 				}
-				stream.Position = 0;
-				string outpath = Path.Combine (outDirInfo.Parent.FullName, "__AndroidLibraryProjects__.zip");
-				if (Files.ArchiveZip (outpath, f => {
-					using (var fs = new FileStream (f, FileMode.CreateNew)) {
-						stream.CopyTo (fs);
-					}
-				}))
-					Log.LogDebugMessage ("Saving contents to " + outpath);
+			})) {
+				Log.LogDebugMessage ("Saving contents to " + outpath);
 			}
 			return true;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateManagedLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateManagedLibraryResourceArchive.cs
@@ -104,20 +104,14 @@ namespace Xamarin.Android.Tasks
 				File.WriteAllText (Path.Combine (OutputDirectory, "__res_name_case_map.txt"), nameCaseMap.ToString ());
 			}
 
-			// Archive them in a zip.
-			using (var stream = new MemoryStream ()) {
-				using (var zip = ZipArchive.Create (stream)) {
-					Log.LogDebugMessage ($" {OutputDirectory} {outDirInfo.Name} ");
+			var outpath = Path.Combine (outDirInfo.Parent.FullName, "__AndroidLibraryProjects__.zip");
+
+			if (Files.ArchiveZip (outpath, f => {
+				using (var zip = new ZipArchiveEx (f)) {
 					zip.AddDirectory (OutputDirectory, outDirInfo.Name);
 				}
-				stream.Position = 0;
-				string outpath = Path.Combine (outDirInfo.Parent.FullName, "__AndroidLibraryProjects__.zip");
-				if (Files.ArchiveZip (outpath, f => {
-					using (var fs = new FileStream (f, FileMode.CreateNew)) {
-						stream.CopyTo (fs);
-					}
-				}))
-					Log.LogDebugMessage ("Saving contents to " + outpath);
+			})) {
+				Log.LogDebugMessage ("Saving contents to " + outpath);
 			}
 
 			return true;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateNativeLibraryArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateNativeLibraryArchive.cs
@@ -62,19 +62,14 @@ namespace Xamarin.Android.Tasks
 				MonoAndroidHelper.CopyIfChanged (lib.ItemSpec, Path.Combine (OutputDirectory, abi, Path.GetFileName (lib.ItemSpec)));
 			}
 
-			// Archive native libraries in a zip.
-			using (var stream = new MemoryStream ()) {
-				using (var zip = ZipArchive.Create (stream)) {
+			var outpath = Path.Combine (outDirInfo.Parent.FullName, "__AndroidNativeLibraries__.zip");
+
+			if (Files.ArchiveZip (outpath, f => {
+				using (var zip = new ZipArchiveEx (f)) {
 					zip.AddDirectory (OutputDirectory, outDirInfo.Name);
 				}
-				stream.Position = 0;
-				string outpath = Path.Combine (outDirInfo.Parent.FullName, "__AndroidNativeLibraries__.zip");
-				if (Files.ArchiveZip (outpath, f => {
-					using (var fs = new FileStream (f, FileMode.CreateNew)) {
-						stream.CopyTo (fs);
-					}
-				}))
-					Log.LogDebugMessage ("Saving contents to " + outpath);
+			})) {
+				Log.LogDebugMessage ("Saving contents to " + outpath);
 			}
 			
 			return true;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.IO;
+using Xamarin.Tools.Zip;
+
+namespace Xamarin.Android.Tasks
+{
+	public class ZipArchiveEx : IDisposable
+	{
+		ZipArchive zip;
+		string archive;
+
+		public ZipArchiveEx (string archive)
+		{
+			this.archive = archive;
+			zip = ZipArchive.Open (archive, FileMode.CreateNew);
+		}
+
+		void Flush ()
+		{
+			if (zip != null) {
+				zip.Close ();
+				zip.Dispose ();
+				zip = null;
+			}
+			// Requied to ensure that all the FileStream handles are disposed of. 
+			GC.Collect ();
+			zip = ZipArchive.Open (archive, FileMode.Open);
+		}
+
+		string ArchiveNameForFile (string filename, string directoryPathInZip)
+		{
+			if (string.IsNullOrEmpty (filename)) {
+				throw new ArgumentNullException (nameof (filename));
+			}
+			string pathName;
+			if (string.IsNullOrEmpty (directoryPathInZip)) {
+				pathName = Path.GetFileName (filename);
+			}
+			else {
+				pathName = Path.Combine (directoryPathInZip, Path.GetFileName (filename));
+			}
+			return pathName.Replace ("\\", "/");
+		}
+
+		void AddFiles (string folder, string folderInArchive)
+		{
+			int count = 0;
+			foreach (string fileName in Directory.GetFiles (folder, "*.*", SearchOption.TopDirectoryOnly)) {
+				var fi = new FileInfo (fileName);
+				if ((fi.Attributes & FileAttributes.Hidden) != 0)
+					continue;
+				zip.AddFile (fileName, ArchiveNameForFile (fileName, folderInArchive));
+				count++;
+				if (count == 50) {
+					Flush ();
+					count = 0;
+				}
+			}
+		}
+
+		public void AddDirectory (string folder, string folderInArchive)
+		{
+			AddFiles (folder, folderInArchive);
+			foreach (string dir in Directory.GetDirectories (folder, "*", SearchOption.AllDirectories)) {
+				var di = new DirectoryInfo (dir);
+				if ((di.Attributes & FileAttributes.Hidden) != 0)
+					continue;
+				var internalDir = dir.Replace ("./", string.Empty).Replace (folder, string.Empty);
+				string fullDirPath = folderInArchive + internalDir;
+				zip.CreateDirectory (fullDirPath);
+				AddFiles (dir, fullDirPath);
+			}
+		}
+
+		public void Close ()
+		{
+			if (zip != null) {
+				zip.Close ();
+			}
+		}
+
+		public void Dispose ()
+		{
+			Dispose(true);
+			GC.SuppressFinalize (this);
+		}
+
+		protected virtual void Dispose(bool disposing) {
+			if (disposing) {
+				if (zip != null) {
+					zip.Close ();
+					zip.Dispose ();
+					zip = null;
+				}
+			}	
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Linker\MonoDroid.Tuner\PreserveJavaTypeRegistrations.cs" />
     <Compile Include="Linker\MonoDroid.Tuner\RemoveAttributes.cs" />
     <Compile Include="Utilities\MSBuildExtensions.cs" />
+    <Compile Include="Utilities\ZipArchiveEx.cs" />
     <Compile Include="Mono.Android\ServiceAttribute.Partial.cs" />
     <Compile Include="$(LinkerSourceFullPath)\tuner\Mono.Tuner\AdjustVisibility.cs">
       <Link>Linker\Mono.Tuner\AdjustVisibility.cs</Link>


### PR DESCRIPTION
Currently we are hitting an issue where the following error is
produced.

	System.IO.IOException: Too many open files

This is because of the way in which libzip works. The creation of
the zip happens when the archive is closed. Until that point
file handles are kept open.. So if you keep adding files at
some point you are going to run out of file handled!

So this commit adds a ZipArchiveEx class which wraps the
creation of the archives. Every 50 files the archive is closed
and then reopend so more files can be added.
This works around the current limitation in the libzip library
itself. It would be really handy if libzip had a Flush method,
but unfortunately that is not available at this time.