### PR TITLE
[jni] Specify a directory to match from when shadow-copying assemblies.

### DIFF
--- a/src/monodroid/jni/monodroid-glue.c
+++ b/src/monodroid/jni/monodroid-glue.c
@@ -2875,7 +2875,7 @@ create_domain (JNIEnv *env, jobjectArray runtimeApks, jstring assembly, jobject 
 	else {
 		MonoDomain* root_domain = mono.mono_get_root_domain ();
 		char *domain_name = monodroid_strdup_printf ("MonoAndroidDomain%d", GetAndroidSdkVersion (env, loader));
-		domain = monodroid_create_appdomain (&mono, root_domain, domain_name, /*shadow_copy:*/ 0);
+		domain = monodroid_create_appdomain (&mono, root_domain, domain_name, /*shadow_copy:*/ 1, /*shadow_directory:*/ override_dirs [0]);
 		free (domain_name);
 	}
 

--- a/src/monodroid/jni/util.h
+++ b/src/monodroid/jni/util.h
@@ -106,7 +106,7 @@ struct        DylibMono;
 MonoAssembly    *monodroid_load_assembly (struct DylibMono *mono, MonoDomain *domain, const char *basename);
 void            *monodroid_runtime_invoke (struct DylibMono *mono, MonoDomain *domain, MonoMethod *method, void *obj, void **params, MonoObject **exc);
 MonoClass       *monodroid_get_class_from_name (struct DylibMono *mono, MonoDomain *domain, const char* assembly, const char *namespace, const char *type);
-MonoDomain      *monodroid_create_appdomain (struct DylibMono *mono, MonoDomain *parent_domain, const char *friendly_name, int shadow_copy);
+MonoDomain      *monodroid_create_appdomain (struct DylibMono *mono, MonoDomain *parent_domain, const char *friendly_name, int shadow_copy, const char *shadow_directories);
 MonoClass       *monodroid_get_class_from_image (struct DylibMono *mono, MonoDomain *domain, MonoImage* image, const char *namespace, const char *type);
 
 #endif /* __MONODROID_UTIL_H__ */


### PR DESCRIPTION
Supersede https://github.com/xamarin/xamarin-android/pull/398

This commit adds an argument to the `monodroid_create_appdomain` function to set which directory should have the assemblies it contains shadow-copied by the runtime.

Since in debug mode XA is setup with two override directories that contains the assemblies to load, we can use this to our advantage to assign one of those directory as containing assemblies that should be shadow-copied and another where they won't be.

From the caller side, assemblies that are considered unique for the installed XA (essentially anything in the 1.0 moniker) can be ignored for shadow-copy.

In addition, due to the current limitations expressed in the above PR link with the GC bridge and multiple loaded Mono.Android.dll assemblies, we can also special-case for now that Mono.Android.dll should be loaded from one location and thus shared across all appdomains.