### PR TITLE
[build] Fix the Linux build (Take 2?)

### DIFF
--- a/build-tools/scripts/MonoAndroidFramework.props
+++ b/build-tools/scripts/MonoAndroidFramework.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Note: ..\..\Configuration.props *must* be included FIRST -->
+  <PropertyGroup>
+    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
+    <TargetFrameworkRootPath>$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
+    <FrameworkPathOverride
+        Condition=" '$(FrameworkPathOverride)' == '' And '$(_XAFixMSBuildFrameworkPathOverride)' == 'True' "
+    >$(TargetFrameworkRootPath)\MonoAndroid\v1.0</FrameworkPathOverride>
+  </PropertyGroup>
+</Project>

--- a/build-tools/scripts/msbuild.mk
+++ b/build-tools/scripts/msbuild.mk
@@ -27,3 +27,10 @@ MSBUILD_FLAGS = /p:Configuration=$(CONFIGURATION) $(MSBUILD_ARGS)
 ifneq ($(V),0)
 MSBUILD_FLAGS += /v:diag
 endif   # $(V) != 0
+
+ifeq ($(MSBUILD),msbuild)
+_BROKEN_MSBUILD := $(shell if ! pkg-config --atleast-version=4.8 mono ; then echo Broken; fi )
+ifeq ($(_BROKEN_MSBUILD),Broken)
+MSBUILD_FLAGS += /p:_XAFixMSBuildFrameworkPathOverride=True
+endif   # $(_BROKEN_MSBUILD) == Broken
+endif   # $(MSBUILD) == msbuild

--- a/src/Mono.Android.Export/Mono.Android.Export.csproj
+++ b/src/Mono.Android.Export/Mono.Android.Export.csproj
@@ -7,11 +7,15 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Mono.Android.Export</RootNamespace>
     <AssemblyName>Mono.Android.Export</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
+  <PropertyGroup>
+    <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
+    <TargetFrameworkRootPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -52,6 +56,10 @@
     </Reference>
     <Reference Include="Java.Interop">
       <HintPath>$(OutputPath)..\v1.0\Java.Interop.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Runtime">
+      <HintPath>$(OutputPath)..\v1.0\Facades\System.Runtime.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -108,6 +116,9 @@
     <Compile Include="Mono.CodeGeneration\Exp.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <ImplicitlyExpandDesignTimeFacades>False</ImplicitlyExpandDesignTimeFacades>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Mono.Android\Mono.Android.csproj">
       <Project>{66CF299A-CE95-4131-BCD8-DB66E30C4BF7}</Project>

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -7,11 +7,15 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Android</RootNamespace>
     <AssemblyName>Mono.Android</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
+  <PropertyGroup>
+    <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
+    <TargetFrameworkRootPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -63,6 +67,10 @@
     </Reference>
     <Reference Include="Java.Interop">
       <HintPath>$(OutputPath)..\v1.0\Java.Interop.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Runtime">
+      <HintPath>$(OutputPath)..\v1.0\Facades\System.Runtime.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -302,6 +310,7 @@
   <Import Project="..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems')" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
+    <ImplicitlyExpandDesignTimeFacades>False</ImplicitlyExpandDesignTimeFacades>
     <IntermediateOutputPath>$(IntermediateOutputPath)android-$(AndroidApiLevel)\</IntermediateOutputPath>
   </PropertyGroup>
   <Import Project="Mono.Android.targets" />

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -197,7 +197,7 @@
     />
   </Target>
   <Target Name="_GenerateFrameworkList"
-      AfterTargets="CoreBuild"
+      BeforeTargets="ResolveReferences"
       Inputs="$(OutputPath)$(AssemblyName).dll"
       Outputs="$(OutputPath)RedistList\FrameworkList.xml">
    <MakeDir Directories="$(OutputPath)RedistList" />

--- a/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
+++ b/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
@@ -18,8 +18,8 @@
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
+  <Import Project="..\..\build-tools\scripts\MonoAndroidFramework.props" />
   <PropertyGroup>
-    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
     <AssemblyOriginatorKeyFile>$(MonoSourceFullPath)\mcs\class\mono.pub</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Mono.Posix/Mono.Posix.csproj
+++ b/src/Mono.Posix/Mono.Posix.csproj
@@ -18,8 +18,8 @@
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
+  <Import Project="..\..\build-tools\scripts\MonoAndroidFramework.props" />
   <PropertyGroup>
-    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
     <AssemblyOriginatorKeyFile>$(MonoSourceFullPath)\mcs\class\mono.pub</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/OpenTK-1.0/OpenTK.csproj
+++ b/src/OpenTK-1.0/OpenTK.csproj
@@ -23,8 +23,8 @@
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
+  <Import Project="..\..\build-tools\scripts\MonoAndroidFramework.props" />
   <PropertyGroup>
-    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
     <AssemblyOriginatorKeyFile>$(MonoSourceFullPath)\mcs\class\mono.pub</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Drawing.Primitives/System.Drawing.Primitives.csproj
+++ b/src/System.Drawing.Primitives/System.Drawing.Primitives.csproj
@@ -15,8 +15,8 @@
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
+  <Import Project="..\..\build-tools\scripts\MonoAndroidFramework.props" />
   <PropertyGroup>
-    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
     <AssemblyOriginatorKeyFile>$(MonoSourceFullPath)\mcs\class\mono.pub</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.EnterpriseServices/System.EnterpriseServices.csproj
+++ b/src/System.EnterpriseServices/System.EnterpriseServices.csproj
@@ -11,6 +11,8 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
+  <Import Project="..\..\build-tools\scripts\MonoAndroidFramework.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -40,4 +42,11 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\Mono.Android\Mono.Android.csproj">
+      <Project>{66CF299A-CE95-4131-BCD8-DB66E30C4BF7}</Project>
+      <Name>Mono.Android</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
 </Project>

--- a/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj
+++ b/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj
@@ -17,6 +17,7 @@
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
+  <Import Project="..\..\build-tools\scripts\MonoAndroidFramework.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>


### PR DESCRIPTION
As feared, commit 743529c1's removal of `$(TargetFrameworkRootPath)`
[broke the Linux build][0]:

        Gui/Activities/TestSuiteActivity.cs(25,35): error CS0012: The type `System.IDisposable' is defined in an assembly that is not referenced.
        Consider adding a reference to assembly `System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'

macOS is unaffected as [it's unfortunately using System files][1]:

        Found framework definition list '/Library/Frameworks/Mono.framework/External/xbuild-frameworks/MonoAndroid/v1.0/RedistList/FrameworkList.xml' for framework 'MonoAndroid,Version=v1.0'

(Heavy sigh.)

Thus, our scenario: `msbuild` doesn't like our setting
`$(TargetFrameworkRootPath)`, yet `$(TargetFrameworkRootPath)` needs
to be set for Linux+xbuild to work, because Linux+xbuild doesn't have
a system-wide Xamarin.Android install. (Not that we want to require a
Xamarin.Android install! But that's just why macOS is building...)

The fix? Split the difference, somewhat. We can't set
`$(TargetFrameworkRootPath)` for *everything*, but we *can* override
it for *specific projects*. Update `Mono.Data.Sqlite.csproj`,
`Mono.Posix.csproj`, `OpenTK.csproj`,
`System.Drawing.Primitives.csproj`,
`System.EnterpriseServices.csproj`, and
`Xamarin.Android.NUnitLite.csproj` to `<Import/>` the new
`build-tools/scripts/MonoAndroidFramework.props` file, which
overrides `$(TargetFrameworkRootPath)` and other MSBuild properties
appropriately, so that they resolve the `MonoAndroid` framework
assemblies from the internal build tree.

What's left is `Mono.Android.csproj` and `Mono.Android.Export.csproj`,
which don't `<Import/>` `Xamarin.Android.CSharp.targets`. These are
the projects that needed to "hack in" a `@(Reference)` to
`System.Runtime` in 7343965, which was removed in 743529c1. The fix is
more voodoo in each of them:

* Set `$(ImplicitlyExpandDesignTimeFacades)`=False and provide a
    `%(Reference.HintPath) value for `System.Runtime` so that it can
    be found. We *don't* want
    `$(ImplicitlyExpandDesignTimeFacades)`=True because that can cause
    all manner of madness on macOS, as it "implicitly expands
    facades", pulling in facades from *both* the internal build tree
    *and* the system-wide location. (Madness, and duplicate assembly
    reference errors, ensue.)
* Set `$(TargetFrameworkIdentifier)`=MonoAndroid, so we're looking for
    the correct framework.
* Set `$(TargetFrameworkRootPath)` so that the MonoAndroid framework
    can be found in the local build tree.
* Set `$(TargetFrameworkVersion)` to a valid MonoAndroid framework
    version number.

This allows `Mono.Android.Export.csproj`. `Mono.Android.csproj` needs
one more fix: in order for frameworks to be resolved from a "clean"
state, `RedistList\FrameworkList.xml` must exist before attempting to
resolve assemblies. Fix the `_GenerateFrameworkList` target so that
`FrameworkList.xml` is created *before* the `ResolveReferences`
target, thus allowing the `MonoAndroid,v7.1` framework to be found.

One more final tidbit: `MonoAndroidFramework.props` and `msbuild.mk`
in concert use (and set) the new
`$(_XAFixMSBuildFrameworkPathOverride)` MSBuild property, which is set
when:

1. `msbuild` is being used, and
2. Mono is a version prior to Mono 4.8.

The `msbuild` included in Mono prior to 4.8 has a known bug where
[`$(FrameworkOverridePath)` doesn't respect `$(TargetFrameworkRootPath)`][2].
Without this fix, *too many* `mscorlib.dll` files are used in various
parts of the build process (via `@(_ExplicitReference)`), which causes
yet more sadness.

When using `msbuild` prior to Mono 4.8, explicitly set the
`$(FrameworkOverridePath)` property to a valid value.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-linux/173/
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/207/consoleText
[2]: https://github.com/mono/msbuild/commit/9d7b4b5cf9ba50e3e26a202e3d3e0d35cc50da19