### PR TITLE
[Xamarin.Android.Build.Utilities] Allow the use of MONO_ANDROID_PATH on windows.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadResolvedSdksCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadResolvedSdksCache.cs
@@ -140,9 +140,9 @@ namespace Xamarin.Android.Tasks
 
 			MonoAndroidHelper.TargetFrameworkDirectories	= ReferenceAssemblyPaths;
 
-			MonoAndroidHelper.RefreshAndroidSdk (AndroidSdkPath, AndroidNdkPath, JavaSdkPath);
 			MonoAndroidHelper.RefreshMonoDroidSdk (MonoAndroidToolsPath, MonoAndroidBinPath, ReferenceAssemblyPaths);
-
+			MonoAndroidHelper.RefreshAndroidSdk (AndroidSdkPath, AndroidNdkPath, JavaSdkPath);
+			
 			return !Log.HasLoggedErrors;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -127,9 +127,9 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  MonoAndroidToolsPath: {0}", MonoAndroidToolsPath);
 			Log.LogDebugMessage ("  MonoAndroidBinPath: {0}", MonoAndroidBinPath);
 
-			MonoAndroidHelper.RefreshAndroidSdk (AndroidSdkPath, AndroidNdkPath, JavaSdkPath);
 			MonoAndroidHelper.RefreshMonoDroidSdk (MonoAndroidToolsPath, MonoAndroidBinPath, ReferenceAssemblyPaths);
-
+			MonoAndroidHelper.RefreshAndroidSdk (AndroidSdkPath, AndroidNdkPath, JavaSdkPath);
+			
 			// OS X:    $prefix/lib/mandroid
 			// Windows: %ProgramFiles(x86)%\MSBuild\Xamarin\Android
 			this.MonoAndroidToolsPath = MonoDroidSdk.RuntimePath;

--- a/src/Xamarin.Android.Build.Utilities/Sdks/MonoDroidSdkWindows.cs
+++ b/src/Xamarin.Android.Build.Utilities/Sdks/MonoDroidSdkWindows.cs
@@ -11,9 +11,8 @@ namespace Xamarin.Android.Build.Utilities
 		{
 			string monoAndroidPath = Environment.GetEnvironmentVariable ("MONO_ANDROID_PATH");
 			if (!string.IsNullOrEmpty (monoAndroidPath)) {
-				string libMandroid = Path.Combine (monoAndroidPath, "lib", "mandroid");
-				if (Directory.Exists (libMandroid) && ValidateRuntime (libMandroid))
-					return libMandroid;
+				if (Directory.Exists (monoAndroidPath) && ValidateRuntime (monoAndroidPath))
+					return monoAndroidPath;
 			}
 			string xamarinSdk = Path.Combine (OS.ProgramFilesX86, "MSBuild", "Xamarin", "Android");
 			return Directory.Exists (xamarinSdk)
@@ -22,6 +21,7 @@ namespace Xamarin.Android.Build.Utilities
 		}
 
 		static readonly string[] RuntimeToFrameworkPaths = new []{
+			Path.Combine ("..", "..", "..", "Common7", "IDE", "ReferenceAssemblies", "Microsoft", "Framework","MonoAndroid"),
 			Path.Combine ("..", "..", "..", "Reference Assemblies", "Microsoft", "Framework", "MonoAndroid"),
 			Path.Combine (OS.ProgramFilesX86, "Reference Assemblies", "Microsoft", "Framework", "MonoAndroid"),
 		};


### PR DESCRIPTION
We need to be able to support custom paths on wwindows as
well as Mac/Linux. However the directory structure is slightly
different. Windows does not have the tools in lib/mandroid but
in the root of the path.

This change allows us to use MONO_ANDROID_PATH on windows by
validating the Root of the path provided as well.

There are also changes to the location of the Reference Assemblies
which needed to be taken into account.

There was also a bug where if the AndroidSdk was created BEFORE
the MonoDroidSdk it was creating a MonoDroidsdk automatically.
This ment that we would be unable to update the paths.

This commit fixes those issues too.