### PR TITLE
[Xamarin.Android.Build.Tasks] Allow users to override $(AutoUnifyAssemblyReferences)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -209,8 +209,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">False</AndroidUseIntermediateDesignerFile>
 
 	<!-- Prevent warnings about assembly version conflicts -->
-	<AutoUnifyAssemblyReferences>True</AutoUnifyAssemblyReferences>
-	<AutoGenerateBindingRedirects>False</AutoGenerateBindingRedirects>
+	<AutoUnifyAssemblyReferences Condition="'$(AutoUnifyAssemblyReferences)' == ''">True</AutoUnifyAssemblyReferences>
+	<AutoGenerateBindingRedirects Condition="'$(AutoGenerateBindingRedirects)' == ''">False</AutoGenerateBindingRedirects>
 
 	<!-- The .NET SGEN tool cannot process Xamarin.Android assemblies because
 	     our mscorlib.dll isn't properly signed, as far as its concerned.
@@ -2122,7 +2122,7 @@ because xbuild doesn't support framework reference assemblies.
   <ResolveAssemblyReference
       AllowedAssemblyExtensions="$(AllowedReferenceAssemblyFileExtensions)"
       AssemblyFiles="@(ResolvedUserAssemblies)"
-      AutoUnify="True"
+      AutoUnify="$(AutoUnifyAssemblyReferences)"
       FindDependencies="True"
       FindRelatedFiles="False"
       FindSatellites="True"


### PR DESCRIPTION
Context https://bugzilla.xamarin.com/show_bug.cgi?id=51831

According to the bug report, AutoUnity on ResolveAssemblyReference is
causing the build to lock up. At this time the user is unable to alter
the behaviour to work around the issue. This commit updates the targets
to allow users to override $(AutoUnifyAssemblyReferences) by passing it
as a parameter to the build.

	msbuild foo.csproj /t:Build /p:AutoUnifyAssemblyReferences=False