### PR TITLE
[build] fix 32bit targets cross compilation configure

### DIFF
--- a/build-tools/bundle/bundle-path.targets
+++ b/build-tools/bundle/bundle-path.targets
@@ -24,7 +24,7 @@
   <Target Name="GetBundleFileName"
       DependsOnTargets="_GetHashes">
     <PropertyGroup>
-      <XABundleFileName>bundle-v7-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
+      <XABundleFileName>bundle-v8-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
     </PropertyGroup>
   </Target>
 </Project>

--- a/build-tools/mono-runtimes/mono-runtimes.projitems
+++ b/build-tools/mono-runtimes/mono-runtimes.projitems
@@ -290,7 +290,7 @@
       <Strip>strip</Strip>
       <StripFlags>-S</StripFlags>
       <TargetAbi>armv5-none-linux-androideabi</TargetAbi>
-      <ConfigureFlags>--target=armv5-linux-androideabi --cache-file=$(_CrossConfigureCachePrefix)arm.config.cache --with-cross-offsets=armv5-none-linux-androideabi.h $(_CrossConfigureFlags) --with-llvm=$(_CrossDefaultLlvmPrefix)</ConfigureFlags>
+      <ConfigureFlags>--target=armv5-linux-androideabi --cache-file=$(_CrossConfigureCachePrefix)arm.config.cache --with-cross-offsets=armv5-none-linux-androideabi.h $(_CrossConfigureFlags32) --with-llvm=$(_LlvmPrefix32)</ConfigureFlags>
       <ExeSuffix></ExeSuffix>
       <BuildEnvironment></BuildEnvironment>
       <ConfigureEnvironment></ConfigureEnvironment>
@@ -334,7 +334,7 @@
       <Strip>strip</Strip>
       <StripFlags>-S</StripFlags>
       <TargetAbi>i686-none-linux-android</TargetAbi>
-      <ConfigureFlags>--target=i686-linux-android --cache-file=$(_CrossConfigureCachePrefix)x86.config.cache --with-cross-offsets=i686-none-linux-android.h $(_CrossConfigureFlags)  --with-llvm=$(_LlvmPrefix32)</ConfigureFlags>
+      <ConfigureFlags>--target=i686-linux-android --cache-file=$(_CrossConfigureCachePrefix)x86.config.cache --with-cross-offsets=i686-none-linux-android.h $(_CrossConfigureFlags32)  --with-llvm=$(_LlvmPrefix32)</ConfigureFlags>
       <ExeSuffix></ExeSuffix>
       <BuildEnvironment></BuildEnvironment>
       <ConfigureEnvironment></ConfigureEnvironment>
@@ -378,7 +378,7 @@
       <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-strip</Strip>
       <StripFlags>-S</StripFlags>
       <TargetAbi>armv5-none-linux-androideabi</TargetAbi>
-      <ConfigureFlags>--target=armv5-linux-androideabi --host="$(_CrossConfigureBuildHostWin32)" --cache-file=$(_CrossConfigureCachePrefix)arm-win.config.cache --with-cross-offsets=armv5-none-linux-androideabi.h $(_CrossConfigureFlags) --with-llvm=$(_LlvmPrefixWin32)</ConfigureFlags>
+      <ConfigureFlags>--target=armv5-linux-androideabi --host="$(_CrossConfigureBuildHostWin32)" --cache-file=$(_CrossConfigureCachePrefix)arm-win.config.cache --with-cross-offsets=armv5-none-linux-androideabi.h $(_CrossConfigureFlags32) --with-llvm=$(_LlvmPrefixWin32)</ConfigureFlags>
       <ExeSuffix>.exe</ExeSuffix>
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin32)</ConfigureEnvironment>
@@ -422,7 +422,7 @@
       <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-strip</Strip>
       <StripFlags>-S</StripFlags>
       <TargetAbi>i686-none-linux-android</TargetAbi>
-      <ConfigureFlags>--target=i686-linux-android --host="$(_CrossConfigureBuildHostWin32)" --cache-file=$(_CrossConfigureCachePrefix)x86-win.config.cache --with-cross-offsets=i686-none-linux-android.h $(_CrossConfigureFlags) --with-llvm=$(_LlvmPrefixWin32)</ConfigureFlags>
+      <ConfigureFlags>--target=i686-linux-android --host="$(_CrossConfigureBuildHostWin32)" --cache-file=$(_CrossConfigureCachePrefix)x86-win.config.cache --with-cross-offsets=i686-none-linux-android.h $(_CrossConfigureFlags32) --with-llvm=$(_LlvmPrefixWin32)</ConfigureFlags>
       <ExeSuffix>.exe</ExeSuffix>
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin32)</ConfigureEnvironment>


### PR DESCRIPTION
 - it looks like we cannot crosscompile to 32 bits with 64 bits tools,
   so we need to build 32 bits crosscompilers for 32 bits targets

 - otherwise we end up with errors like this one:

    /Users/builder/data/lanes/4285/2021a5bd/source/monodroid/out/bin/cross-arm --aot=outfile=/Users/builder/data/lanes/4285/2021a5bd/source/monodroid/tests/runtime/obj/Release/aot/armeabi-v7a/libaot-Mono.Android.dll.so,asmwriter,mtriple=armv7-linux-gnueabi,tool-prefix=/Users/builder/android-sdk-tool/android-ndk/toolchains/arm-linux-androideabi-4.9/prebuilt/darwin-x86_64/bin/arm-linux-androideabi-,ld-flags=,llvm-path=/Users/builder/data/lanes/4285/2021a5bd/source/monodroid/out/bin,temp-path=/Users/builder/data/lanes/4285/2021a5bd/source/monodroid/tests/runtime/obj/Release/aot/armeabi-v7a/Mono.Android.dll "/Users/builder/data/lanes/4285/2021a5bd/source/monodroid/tests/runtime/obj/Release/android/assets/shrunk/Mono.Android.dll"
    		[aot-compiler stderr] Can't cross-compile on 64-bit platforms to 32-bit architecture.
    		[aot-compiler stderr] Can't cross-compile on 64-bit platforms to 32-bit architecture.
    		[aot-compiler stderr] Can't cross-compile on 64-bit platforms to 32-bit architecture.

 - increase bundle version to force mono runtimes rebuild by jenkins