### PR TITLE
[build] fix libmono-android build

### DIFF
--- a/src/monodroid/jni/Android.mk
+++ b/src/monodroid/jni/Android.mk
@@ -3,9 +3,9 @@ LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 
 ifeq ($(CONFIGURATION),Debug)
-COMMON_CFLAGS ?= -ggdb3 -O0 -fno-omit-frame-pointer
+COMMON_CFLAGS ?= -ggdb3 -O0 -fno-omit-frame-pointer -DDEBUG=1
 else
-COMMON_CFLAGS ?= -g -O2 -DRELEASE=1
+COMMON_CFLAGS ?= -g -O2
 endif
 
 LOCAL_CFLAGS =	$(COMMON_CFLAGS) \

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -71,6 +71,11 @@
         SourceFiles="@(AndroidSupportedTargetJitAbi->'libs\Debug\%(Identity)\libmonodroid.so')"
         DestinationFiles="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.so')"
     />
+    <WriteLinesToFile
+        File="jni\Application.mk"
+        Lines="APP_ABI := $(_AppAbi); APP_CFLAGS+=-DRELEASE=1"
+        Overwrite="True"
+    />
     <Exec
         Command="$(AndroidToolchainDirectory)\ndk\ndk-build $(_NdkBuildArgs) NDK_LIBS_OUT=./libs/Release NDK_OUT=./obj/Release  V=1"
     />


### PR DESCRIPTION
 - so that we endup with correct release and debug monodroid
   libraries, where release one has RELEASE=1 defined and debug one
   has not. Note that Release configuration libmono-android.debug.*so
   need to be build without RELEASE defined

 - use DEBUG=1 defines for Debug configuration builds