### PR TITLE
[netlink] Don't use process ID when opening netlink session

### DIFF
--- a/src/monodroid/jni/xamarin_getifaddrs.c
+++ b/src/monodroid/jni/xamarin_getifaddrs.c
@@ -301,7 +301,14 @@ open_netlink_session (netlink_session *session)
 
 	/* Fill out addresses */
 	session->us.nl_family = AF_NETLINK;
-	session->us.nl_pid = getpid ();
+
+	/* We have previously used `getpid()` here but it turns out that WebView/Chromium does the same
+	   and there can only be one session with the same PID. Setting it to 0 will cause the kernel to
+	   assign some PID that's unique and valid instead.
+
+	   See: https://bugzilla.xamarin.com/show_bug.cgi?id=41860
+	*/
+	session->us.nl_pid = 0;
 	session->us.nl_groups = 0;
 
 	session->them.nl_family = AF_NETLINK;


### PR DESCRIPTION
We have previously used `getpid()` when opening a netlink session  but it turns
out that WebView/Chromium does the same and keeps the session open. However,
there can only be one session with the same PID and so opening another one after
WebView instance is created in the application makes the netlink socket bind
fail with EADDRINUSE. Setting it to 0 will cause the kernel to assign some PID
that's unique and valid instead.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=41860