### PR TITLE
[Mono.Data.Sqlite] Don't compile MonoPInvokeCallbackAttribute.cs

### DIFF
--- a/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
+++ b/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
@@ -90,9 +90,6 @@
     <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Assembly\AssemblyInfo.cs">
       <Link>Assembly\AssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\MonoPInvokeCallbackAttribute.cs">
-      <Link>Mono.Data.Sqlite_2.0\MonoPInvokeCallbackAttribute.cs</Link>
-    </Compile>
     <Compile Include="$(MonoSourceDirectory)\mcs\class\Mono.Data.Sqlite\Mono.Data.Sqlite_2.0\SQLite3.cs">
       <Link>Mono.Data.Sqlite_2.0\SQLite3.cs</Link>
     </Compile>


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=52259

The #runtime team would like to build xamarin-android/master against
mono/master, in preparation for a future release. Unfortunately, that
attempt fails because mono/master changed the location of
`MonoPInvokeCallbackAttribute.cs` in [mono/09774416f][0].

As it happens™, Xamarin.Android's doesn't require
`MonoPInvokeCallbackAttribute.cs` in order to compile
`Mono.Data.Sqlite.dll`; use of the type is protected by
`#if MONOTOUCH` blocks, and Xamarin.Android doesn't define MONOTOUCH.

Remove inclusion of `MonoPInvokeCallbackAttribute.cs` so that
xamarin-android/master can build `Mono.Data.Sqlite.dll` against
mono/master's version of `mcs/class/Mono.Data.Sqlite`.

[0]: https://github.com/mono/mono/commit/09774416fd9032d1beef725f68856adc23d51ab8