### PR TITLE
[Xamarin.Android.Build.Tasks] Add an extension point for _CreateBaseApkDependsOnTargets.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1732,6 +1732,7 @@ because xbuild doesn't support framework reference assemblies.
 		_CheckDuplicateJavaLibraries;
 		_GetAdditionalResourcesFromAssemblies;
 		_CreateAdditionalResourceCache;
+		$(_AfterCreateBaseApkDependsOnTargets);
 	</_CreateBaseApkDependsOnTargets>
 	<_CreateBaseApkInputs>
 		$(MSBuildAllProjects)


### PR DESCRIPTION
We need an extension point to allow the debugging targets to
hock into the _CreateBaseApk target. This commit adds a new
property

	$(_AfterCreateBaseApkDependsOnTargets)

which the debugging system and set to add additional targets.
Normally we would do this via Before/After Targets but they
appear to be broken on xbuild.