### PR TITLE
[Xamarin.Android.Build.Tasks] Fix mono-symbolicte build.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -70,8 +70,11 @@
             ItemName="SourceFiles"
         />  
     </ReadLinesFromFile>
+    <ItemGroup>
+        <FilteredSourceFiles Include="@(SourceFiles)" Condition=" '%(SourceFiles.Identity)' != '' " />
+    </ItemGroup>
     <Csc
-        Sources="@(SourceFiles->'$(MonoSourceFullPath)\mcs\tools\mono-symbolicate\%(Identity)')"
+        Sources="@(FilteredSourceFiles->'$(MonoSourceFullPath)\mcs\tools\mono-symbolicate\%(Identity)')"
         DefineConstants="NET_4_0;NET_4_5;NET_4_6;MONO"
         CodePage="65001"
         DisabledWarnings="1699"


### PR DESCRIPTION
Turns out the sources file for mono-symbolicate can
contain empty lines.

This commit filters the source files we get and removes
any empty ones.