### PR TITLE
[mono-runtimes] Build mono-symbolicate.exe via mono

### DIFF
--- a/build-tools/bundle/bundle-path.targets
+++ b/build-tools/bundle/bundle-path.targets
@@ -24,7 +24,7 @@
   <Target Name="GetBundleFileName"
       DependsOnTargets="_GetHashes">
     <PropertyGroup>
-      <XABundleFileName>bundle-v8-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
+      <XABundleFileName>bundle-v9-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
     </PropertyGroup>
   </Target>
 </Project>

--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -42,6 +42,7 @@
       _InstallRuntimes;
       _InstallBcl;
       _InstallMonoDoc;
+      _InstallMonoSymbolicate;
       _ConfigureCrossRuntimes;
       _BuildCrossRuntimes;
       _InstallCrossRuntimes;
@@ -334,6 +335,24 @@
         Command="$(RemapAssemblyRefTool) &quot;$(_MonoOutputDir)\mdoc.exe&quot; &quot;$(_MandroidDir)\mdoc.exe&quot; Mono.Cecil &quot;$(_MandroidDir)\Xamarin.Android.Cecil.dll&quot;"
     />
   </Target>
+  <Target Name="_InstallMonoSymbolicate"
+      Inputs="$(_MonoOutputDir)\mono-symbolicate.exe"
+      Outputs="$(_MandroidDir)\mono-symbolicate.exe">
+    <MakeDir Directories="$(_MandroidDir)" />
+    <Copy
+        Condition=" Exists('$(_MonoOutputDir)\mono-symbolicate.exe.mdb') "
+        SourceFiles="$(_MonoOutputDir)\mono-symbolicate.exe.mdb"
+        DestinationFolder="$(_MandroidDir)"
+    />
+    <Copy
+        Condition=" Exists('$(_MonoOutputDir)\mono-symbolicate.pdb') "
+        SourceFiles="$(_MonoOutputDir)\mono-symbolicate.pdb"
+        DestinationFolder="$(_MandroidDir)"
+    />
+    <Exec
+        Command="$(RemapAssemblyRefTool) &quot;$(_MonoOutputDir)\mono-symbolicate.exe&quot; &quot;$(_MandroidDir)\mono-symbolicate.exe&quot; Mono.Cecil &quot;$(_MandroidDir)\Xamarin.Android.Cecil.dll&quot;"
+    />
+  </Target>
   <Target Name="_InstallBcl"
       Inputs="@(_BclProfileItems)"
       Outputs="@(_BclInstalledItem);$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0\RedistList\FrameworkList.xml">
@@ -459,6 +478,9 @@
     <ItemGroup>
       <BundleItem Include="@(_BclInstalledItem)" />
       <BundleItem Include="@(_MonoDocInstalledItems)" />
+      <BundleItem Include="$(_MandroidDir)\mono-symbolicate.exe" />
+      <BundleItem Include="$(_MandroidDir)\mono-symbolicate.exe.mdb"  Condition=" Exists ('$(_MandroidDir)\mono-symbolicate.exe.mdb') " />
+      <BundleItem Include="$(_MandroidDir)\mono-symbolicate.pdb"      Condition=" Exists ('$(_MandroidDir)\mono-symbolicate.pdb') " />
       <BundleItem Include="@(_FSharpInstalledItems)" />
       <BundleItem Include="@(MonoFacadeAssembly->'$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0\Facades\%(Identity)')" />
       <BundleItem Include="$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0\RedistList\FrameworkList.xml" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -63,26 +63,6 @@
       Inputs="$(MonoSourceFullPath)\mcs\tools\mono-symbolicate\mono-symbolicate.exe.sources"
       Outputs="$(OutputPath)..\..\..\..\lib\mandroid\mono-symbolicate.exe"
       >
-    <ReadLinesFromFile  
-            File="$(MonoSourceFullPath)\mcs\tools\mono-symbolicate\mono-symbolicate.exe.sources" >  
-        <Output  
-            TaskParameter="Lines"  
-            ItemName="SourceFiles"
-        />  
-    </ReadLinesFromFile>
-    <ItemGroup>
-        <FilteredSourceFiles Include="@(SourceFiles)" Condition=" '%(SourceFiles.Identity)' != '' " />
-    </ItemGroup>
-    <Csc
-        Sources="@(FilteredSourceFiles->'$(MonoSourceFullPath)\mcs\tools\mono-symbolicate\%(Identity)')"
-        DefineConstants="NET_4_0;NET_4_5;NET_4_6;MONO"
-        CodePage="65001"
-        DisabledWarnings="1699"
-        References="$(OutputPath)..\..\..\..\lib\xbuild\Xamarin\Android\Xamarin.Android.Cecil.dll"
-        OutputAssembly="$(OutputPath)..\..\..\..\lib\mandroid\mono-symbolicate.exe"
-        ToolExe="$(CscToolExe)"
-        ToolPath="$(CscToolPath)"
-    />
     <Copy
         SourceFiles="..\..\tools\scripts\mono-symbolicate"
         DestinationFiles="$(OutputPath)..\..\..\..\bin\mono-symbolicate"


### PR DESCRIPTION
Building `mono-symbolicate.exe` is fun [^0]. Commit 0147bc79 attempted
to build `mono-symbolicate` by using
`mono/mcs/tools/mono-symbolicate/monosymbolicate.csproj`.

This didn't actually work, though, as the resulting
`mono-symbolicate.exe` had an assembly reference to `Mono.Cecil.dll`,
which we don't distribute for [historical reasons][1]. This resulted
in commit 9b63344a, which attempted to "replicate" what mono's build
system did within the constructs of an MSBuild target and `<Csc/>`
task invocation.

While this "worked," it was brittle: it involved reading
`mono-symbolicate.exe.sources`, which can change -- necessitating yet
more chanegs (commit 1b023bde) -- and even that is inadequate, as
`mono-symbolicate.exe.sources` can contain *file globs*, which our
"read lines into a `<TaskItem/>`" voodoo doesn't support.

We want something that will more reliably build
`mono-symbolicate.exe`, something maintained by the #runtime team.
We *have* such a mechanism: `mono-symbolicate/Makefile`.
Why can't we use that?

We *couldn't* use it because, as mentioned previously, Mono's normal
build mechanisms will cause `mono-symbolicate.exe` to reference
`Mono.Cecil.dll`. However, we have an alternative now that we didn't
have in the time of commit 9b63344a: [`remap-assembly-ref.exe`][1].

Thus a new, hopefully more maintainable approach: Use mono's build
system to build `mono-symbolicate.exe`, then use
`remap-assembly-ref.exe` to remap `Mono.Cecil` to
`Xamarin.Android.Cecil.dll`.

[1]: https://github.com/xamarin/xamarin-android/commit/5a8e48eba8cc8d05ec4fef25ac074d00606f5a69

[^0]: Note: Not actually fun.
