### PR TITLE
[Mono.Android] Roslyn fixes

### DIFF
--- a/src/Mono.Android/Java.Interop/AndroidEventHelper.cs
+++ b/src/Mono.Android/Java.Interop/AndroidEventHelper.cs
@@ -10,7 +10,7 @@ namespace Java.Interop {
 				Func<TImplementor> creator,
 				Action<TInterface> setListener,
 				Action<TImplementor> add)
-			where TImplementor : TInterface, Java.Lang.Object
+			where TImplementor : Java.Lang.Object, TInterface
 		{
 			TImplementor impl = null;
 			if (implementor == null || (impl = (TImplementor) implementor.Target) == null) {
@@ -26,7 +26,7 @@ namespace Java.Interop {
 				Func<TImplementor, bool> empty,
 				Action<TInterface> setListener,
 				Action<TImplementor> remove)
-			where TImplementor : TInterface, Java.Lang.Object
+			where TImplementor : Java.Lang.Object, TInterface
 		{
 			TImplementor impl = null;
 			if (implementor == null || (impl = (TImplementor) implementor.Target) == null)

--- a/src/Mono.Android/Java.Interop/EventHelper.cs
+++ b/src/Mono.Android/Java.Interop/EventHelper.cs
@@ -9,7 +9,7 @@ namespace Java.Interop {
 				Func<TImplementor> creator,
 				Action<TInterface> setListener,
 				Action<TImplementor> add)
-			where TImplementor : TInterface, Java.Lang.Object
+			where TImplementor : Java.Lang.Object, TInterface
 		{
 			TImplementor impl = null;
 			if (implementor == null || (impl = (TImplementor) implementor.Target) == null) {
@@ -25,7 +25,7 @@ namespace Java.Interop {
 				Func<TImplementor, bool> empty,
 				Action<TInterface> unsetListener,
 				Action<TImplementor> remove)
-			where TImplementor : TInterface, Java.Lang.Object
+			where TImplementor : Java.Lang.Object, TInterface
 		{
 			TImplementor impl = null;
 			if (implementor == null || (impl = (TImplementor) implementor.Target) == null)


### PR DESCRIPTION
@borgdylan [reported][0] that building `src/Mono.Android` under Roslyn
resulted in compilation errors from e.g. `Java.Interop/EventHelper.cs`
because the order of type constraints was wrong:

	where TImplementor : TInterface, Java.Lang.Object

Fix the constraint ordering so that Roslyn can be used:

	where TImplementor : Java.Lang.Object, TInterface

[0]: https://gitter.im/xamarin/xamarin-android?at=5872856864d5fd7e16918848