### PR TITLE
[build] Trim oss-xamarin.android*.zip contents

### DIFF
--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -99,7 +99,12 @@ $(RUNTIME_LIBRARIES):
 	$(MSBUILD) $(MSBUILD_FLAGS) /p:Configuration=Debug   $(_MSBUILD_ARGS) $(SOLUTION)
 	$(MSBUILD) $(MSBUILD_FLAGS) /p:Configuration=Release $(_MSBUILD_ARGS) $(SOLUTION)
 
-_BUNDLE_ZIPS  = $(wildcard bin/*/bundle-*.zip)
+_BUNDLE_ZIPS_INCLUDE  = \
+	$(ZIP_OUTPUT_BASENAME)/bin/Debug \
+	$(ZIP_OUTPUT_BASENAME)/bin/Release
+
+_BUNDLE_ZIPS_EXCLUDE  = \
+	$(ZIP_OUTPUT_BASENAME)/bin/*/bundle-*.zip
 
 package-oss-name:
 	@echo ZIP_OUTPUT=$(ZIP_OUTPUT)
@@ -109,4 +114,6 @@ package-oss $(ZIP_OUTPUT):
 	if [ -d bin/Release/bin ] ; then cp tools/scripts/xabuild bin/Release/bin ; fi
 	if [ ! -d $(ZIP_OUTPUT_BASENAME) ] ; then mkdir $(ZIP_OUTPUT_BASENAME) ; fi
 	if [ ! -L $(ZIP_OUTPUT_BASENAME)/bin ] ; then ln -s ../bin $(ZIP_OUTPUT_BASENAME) ; fi
-	zip -r "$(ZIP_OUTPUT)" $(ZIP_OUTPUT_BASENAME) $(_BUNDLE_ZIPS:%=--exclude %)
+	zip -r "$(ZIP_OUTPUT)" \
+		$(wildcard $(_BUNDLE_ZIPS_INCLUDE)) \
+		$(patsubst %, --exclude %, $(wildcard $(_BUNDLE_ZIPS_EXCLUDE)))


### PR DESCRIPTION
Commit 1eebbe33 introduced generation of the
`oss-xamarin.android*.zip` files, containing the "redistributable"
output of an OSS Xamarin.Android build.

There was just one problem with it: the result is *huge*, containing
many files that aren't necessary.

What's "funny" is commit 1eebbe33 *tried* to exclude some of these
files...and failed:

	_BUNDLE_ZIPS  = $(wildcard bin/*/bundle-*.zip)
	package-oss $(ZIP_OUTPUT):
		# ...
		zip -r "$(ZIP_OUTPUT)" bin $(_BUNDLE_ZIPS:%=--exclude %)

We clearly wanted to *not* include the `bundle-*.zip` build artifacts
within `oss-xamarin.android*.zip` -- because `bundle-*.zip` is
*extracted*, and thus *already* included in the
`oss-xamarin.android*.zip` contents! -- but this effort *failed*:

	$ ls -lh oss-xamarin.android*.zip
	-rw-r--r--  1 jon  staff   1.4G Feb  7 15:32 oss-xamarin.android_v7.1.99.83_Darwin-x86_64_HEAD_1b023bd.zip

	$ unzip -l oss-xamarin.android_v7.1.99.83_Darwin-x86_64_HEAD_1b023bd.zip | grep bundle
	       68  02-07-2017 08:10   oss-xamarin.android_v7.1.99.83_Darwin-x86_64_HEAD_1b023bd/bin/BuildDebug/.extracted-bundle-v8-Debug-Darwin-libzip=1d8b1ac,llvm=8b1520c,mono=dd8ecf3.zip
	298201071  02-07-2017 08:10   oss-xamarin.android_v7.1.99.83_Darwin-x86_64_HEAD_1b023bd/bin/BuildDebug/bundle-v8-Debug-Darwin-libzip=1d8b1ac,llvm=8b1520c,mono=dd8ecf3.zip
	       70  02-07-2017 08:16   oss-xamarin.android_v7.1.99.83_Darwin-x86_64_HEAD_1b023bd/bin/BuildRelease/.extracted-bundle-v8-Release-Darwin-libzip=1d8b1ac,llvm=8b1520c,mono=dd8ecf3.zip
	141691518  02-07-2017 08:16   oss-xamarin.android_v7.1.99.83_Darwin-x86_64_HEAD_1b023bd/bin/BuildRelease/bundle-v8-Release-Darwin-libzip=1d8b1ac,llvm=8b1520c,mono=dd8ecf3.zip
	298201071  02-07-2017 08:16   oss-xamarin.android_v7.1.99.83_Darwin-x86_64_HEAD_1b023bd/bin/Debug/bundle-v8-Debug-Darwin-libzip=1d8b1ac,llvm=8b1520c,mono=dd8ecf3.zip
	141691518  02-07-2017 08:20   oss-xamarin.android_v7.1.99.83_Darwin-x86_64_HEAD_1b023bd/bin/Release/bundle-v8-Release-Darwin-libzip=1d8b1ac,llvm=8b1520c,mono=dd8ecf3.zip

Oof; ~880MB is consumed by `bundle-*.zip` files, *which aren't needed*.
This is in addition to the inclusion of the e.g. `BuildDebug` and
`TestDebug` directories, which aren't needed to use the product.
All this in a file which is 1.4 *gigabytes* in size!

This breakage is actually courtesy of commit b847e8fd, which tried to
improve `oss-xamarin.android*.zip` semantics, but in the process
*altered* the paths that `$(_BUNDLE_ZIPS)` was referencing.
Net effect: `$(_BUNDLE_ZIPS)` meant nothing, so everything was
included.

Rework the file inclusion and exclusion mechanisms so that we
explicitly *include* the `bin/Debug` and `bin/Release` directories,
then explicitly *exclude* the `bundle-*.zip` files within those
directories, ensuring that we use the correct paths.

The result should be an `oss-xamarin.android*.zip` file which is
closer to 600MB than 1.4GB.