### PR TITLE
[Xamarin.Android.Build.Tasks] Install mono-symbolicate scripts

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -9,7 +9,7 @@
     <BuildDependsOn>
 		$(BuildDependsOn);
 		_CopyExtractedMultiDexJar;
-		_BuildMonoSymbolicate;
+		_BuildMonoSymbolicateScripts;
     </BuildDependsOn>
     <_AndroidSdkLocation>$(ANDROID_SDK_PATH)</_AndroidSdkLocation>
     <_AndroidSdkLocation Condition="'$(_AndroidSdkLocation)'==''">$(AndroidToolchainDirectory)\sdk</_AndroidSdkLocation>
@@ -59,17 +59,18 @@
       DestinationFiles="$(OutputPath)..\..\..\mandroid\MULTIDEX_JAR_LICENSE" />
   </Target>
 
-  <Target Name="_BuildMonoSymbolicate"
-      Inputs="$(MonoSourceFullPath)\mcs\tools\mono-symbolicate\mono-symbolicate.exe.sources"
-      Outputs="$(OutputPath)..\..\..\..\lib\mandroid\mono-symbolicate.exe"
-      >
+  <ItemGroup>
+    <_MonoSymbolicateScript             Include="mono-symbolicate;mono-symbolicate.cmd" />
+    <_MonoSymbolicateScriptSource       Include="@(_MonoSymbolicateScript->'..\..\tools\scripts\%(Identity)')" />
+    <_MonoSymbolicateScriptDestination  Include="@(_MonoSymbolicateScript->'$(OutputPath)..\..\..\..\bin\%(Identity)')" />
+  </ItemGroup>
+
+  <Target Name="_BuildMonoSymbolicateScripts"
+      Inputs="@(_MonoSymbolicateScriptSource)"
+      Outputs="@(_MonoSymbolicateScriptDestination)">
     <Copy
-        SourceFiles="..\..\tools\scripts\mono-symbolicate"
-        DestinationFiles="$(OutputPath)..\..\..\..\bin\mono-symbolicate"
-    />
-    <Copy
-        SourceFiles="..\..\tools\scripts\mono-symbolicate.cmd"
-        DestinationFiles="$(OutputPath)..\..\..\..\bin\mono-symbolicate.cmd"
+        SourceFiles="@(_MonoSymbolicateScriptSource)"
+        DestinationFiles="@(_MonoSymbolicateScriptDestination)"
     />
   </Target>
 </Project>


### PR DESCRIPTION
Commit 781a8540 [broke unit test execution][0], introducing failures
in the unit tests:

* `Xamarin.Android.Build.Tests.PackagingTest.CheckBuildIdIsUnique`
* `Xamarin.Android.Build.Tests.PackagingTest.CheckManagedSymbolsArchive(True,True,True)`

[The cause][1][^1] is shown in the `build.log` for the failing test:

	.../xamarin-android/bin/Debug/lib/xbuild/Xamarin/Android/Xamarin.Android.Common.targets: error :
	Command '".../bin/Debug/bin/mono-symbolicate" store-symbols "bin/Release/UnnamedProject.UnnamedProject.apk.mSYM" "obj/Release/android/assets"'
	exited with code: 127.

Exit code 127 is "No such file or directory", i.e. there is no
`bin/mono-symbolicate` file.

This is "odd", because the `_BuildMonoSymbolicate` target was kept in
`Xamarin.Android.Build.Tasks.targets` precisely so it *could* create
those files...

...[except the `_BuildMonoSymbolicate` target isn't executed][2]:

	Skipping target "_BuildMonoSymbolicate" because its outputs are up-to-date

Oops.

Thus we see the error of our ways: the `_BuildMonoSymbolicate`
target's input is `mono-symbolicate.exe.sources`, which isn't touched,
and it's output is `mono-symbolicate.exe`, which is now generated by
`mono-runtimes.targets`. These inputes and outputs need fixing to
ensure that the `mono-symbolicate` scripts are installed.

Rename the `_BuildMonoSymbolicate` target to
`_BuildMonoSymbolicateScripts`, and provide appropriate `Inputs` and
`Outputs` so that the scripts are installed. This fixes the tests.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/236/testReport/
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/ws/xamarin-android/bin/TestDebug/temp/CheckBuildIdIsUnique/build.log/*view*/
[2]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/236/consoleText

[^1]: Note that [the cause][1] link is "unstable"; it's a
  "workspace-relative" link, and may not exist from build to build.
  For future reference, to view those `build.log` files:

  1. Login to Jenkins
  2. Click the [Workspace](https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/ws/) link.
  3. Navigate to xamarin-android/bin/TestDebug/temp
  4. The `temp` directory contains project folders for the failing
      tests, including build logs.