### PR TITLE
[msbuild] add JavaDocJar build action.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Unzip.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Unzip.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xamarin.Tools.Zip;
+
+namespace Xamarin.Android.Tasks
+{
+	public class Unzip : Task
+	{
+		public ITaskItem [] Sources { get; set; }
+		public ITaskItem [] DestinationDirectories { get; set; }
+
+		public override bool Execute ()
+		{
+			Log.LogDebugMessage ("Unzip Task");
+			Log.LogDebugTaskItems ("  Sources: ", Sources);
+			Log.LogDebugTaskItems ("  DestinationDirectories: ", DestinationDirectories);
+
+			foreach (var pair in Sources.Zip (DestinationDirectories, (s, d) => new { Source = s, Destination = d })) {
+				if (!Directory.Exists (pair.Destination.ItemSpec))
+					Directory.CreateDirectory (pair.Destination.ItemSpec);
+				using (var z = ZipArchive.Open (pair.Source.ItemSpec, FileMode.Open))
+					z.ExtractAll (pair.Destination.ItemSpec);
+			}
+
+			return true;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -35,6 +35,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
   <UsingTask TaskName="Xamarin.Android.Tasks.CreateNativeLibraryArchive" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.ImportJavaDoc" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.MDoc" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.Unzip" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 
   <!--
   *******************************************
@@ -75,6 +76,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <AvailableItemName Include="LibraryProjectProperties" />
     <AvailableItemName Include="LibraryProjectZip" />
     <AvailableItemName Include="JavaDocIndex" />
+    <AvailableItemName Include="JavaDocJar" />
   </ItemGroup>
 
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
@@ -349,8 +351,23 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 		;_GetAdditionalResourcesFromAssemblies
 		;_ExtractLibraryProjectImports
 		;_GetLibraryImports
+		;_ExtractJavaDocJars
 	</ExportJarToXmlDependsOnTargets>
 </PropertyGroup>
+
+  <Target Name="_ExtractJavaDocJars"
+		Inputs="@(JavaDocJar)"
+		Outputs="@(JavaDocJar->'$(IntermediateOutputPath)javadocs\%(FileName).stamp')">
+		
+    <Unzip Sources="@(JavaDocJar)" DestinationDirectories="@(JavaDocJar->'$(IntermediateOutputPath)javadocs\%(FileName)')" />
+		
+    <Touch Files="@(JavaDocJar->'$(IntermediateOutputPath)javadocs\%(FileName).stamp')" />
+		
+    <CreateItem Include="@(JavaDocJar->'$(IntermediateOutputPath)javadocs\%(FileName)\index.html')">
+      <Output TaskParameter="Include" ItemName="JavaDocIndex" />
+    </CreateItem>
+		
+  </Target>
 
   <Target Name="ExportJarToXml"
           DependsOnTargets="$(ExportJarToXmlDependsOnTargets)"
@@ -540,6 +557,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <Delete Files="@(IntermediateAssembly->'$(IntermediateOutputPath)%(filename).xml')" />
     <RemoveDirFixed Directories="$(IntermediateOutputPath)docs" Condition="Exists ('$(IntermediateOutputPath)docs')" />
 
+    <RemoveDirFixed Directories="$(IntermediateOutputPath)javadocs" Condition="Exists ('$(IntermediateOutputPath)javadocs')" />
   </Target>
   
   <Target Name="CleanLibraryProjectIntermediaries">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -10,6 +10,7 @@
     <AssemblyName>Xamarin.Android.Build.Tasks</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <Import Project="..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems')" />
@@ -520,6 +521,7 @@
     <Compile Include="Utilities\Profile.cs" />
     <None Include="Xamarin.Android.Build.Tasks.targets" />
     <Compile Include="Linker\MonoDroid.Tuner\PreserveTlsProvider.cs" />
+    <Compile Include="Tasks\Unzip.cs" />
   </ItemGroup>
   <!-- MD doesn't handle MSBuildToolsPath yet
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Modern Android Java libraries ship with (library)-javadoc.jar, which is
based on how Maven builds documentation from the library sources using
javadoc (which are now most likely based on Java8 doclet).

Since it is annoying to manually extract the javadocs and specify its
"index.html" as JavaDocIndex build item, it is better to simply have
a new build action that we can just specify those -javadoc.jar files.