### PR TITLE
[build] Improve branch name construction

### DIFF
--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -1,6 +1,6 @@
 PRODUCT_VERSION   = $(shell $(MSBUILD) $(MSBUILD_FLAGS) /p:DoNotLoadOSProperties=True /nologo /v:minimal /t:GetProductVersion build-tools/scripts/Info.targets | tr -d '[[:space:]]')
 
-GIT_BRANCH        = $(shell LANG=C git rev-parse --abbrev-ref HEAD | tr -d '[[:space:]]' | tr -C a-zA-Z0-9- _)
+GIT_BRANCH        = $(shell LANG=C git branch --contains HEAD | grep -E -v '\\(.*detached.*\\)' | sed 's/^. //' | head -1 | tr -d '[[:space:]]' | tr -C a-zA-Z0-9- _ )
 GIT_COMMIT        = $(shell LANG=C git log --no-color --first-parent -n1 --pretty=format:%h)
 
 # In which commit did $(PRODUCT_VERSION) change? 00000000 if uncommitted

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitBranch.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitBranch.cs
@@ -41,12 +41,19 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 
 		protected override string GenerateCommandLineCommands ()
 		{
-			return "rev-parse --abbrev-ref HEAD";
+			return "branch --contains HEAD";
 		}
 
 		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
 		{
+			if (singleLine?.Length > 0 && singleLine [0] == '*')
+				singleLine = singleLine.Substring (1);
+			singleLine  = singleLine?.Trim ();
 			if (string.IsNullOrEmpty (singleLine))
+				return;
+			if (singleLine.StartsWith ("(") && singleLine.Contains ("detached at") && singleLine.EndsWith (")"))
+				return;
+			if (Branch != null)
 				return;
 			Branch  = singleLine;
 		}


### PR DESCRIPTION
Two important parts of the build system rely on the git branch name
for "external" consumption:

* `make package-oss` uses the branch name in the `oss-xamarin.android`
    filename; see commit 1eebbe33.

* `src/Mono.Android` emits the branch name into the generated
    `Properties\AssemblyInfo.cs` within the
    `[assembly:AssemblyInformationalVersion]` value;
    see commit b620689d

Both of these uses used `git rev-parse --abbrev-ref HEAD` which
works...so long as you're *not* on a detached branch.

The problem is that when building on Jenkins, the build *is* on a
detached branch, as part of the build shenanigans involves
`git checkout -f COMMIT`. When on a detached branch,
`git rev-parse --abbrev-ref HEAD` *always* returns `HEAD`, meaning we
always think that the branch name is `HEAD`.

This results in filenames like:

	oss-xamarin.android_v7.1.99.86_Darwin-x86_64_HEAD_2ca4a32.zip

`HEAD` is not entirely useful there.

Instead of using `git rev-parse`, we'll instead use
`git branch --contains HEAD`. This (more?) reliably provides a useful
branch name, even on detached branches.