### PR TITLE
[android-toolchain] Use ant 1.9.9 as 1.9.8 isn't available

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -115,7 +115,7 @@
     </_NdkToolchain>
   </ItemGroup>
   <ItemGroup>
-    <AntItem Include="apache-ant-1.9.8-bin.zip">
+    <AntItem Include="apache-ant-1.9.9-bin.zip">
       <HostOS></HostOS>
     </AntItem>
   </ItemGroup>


### PR DESCRIPTION
Apache Ant sure is getting lots of updates...

Looking for Ant 1.9.8 [breaks the Linux build][0], apparently because
our Jenkins/Linux environment doesn't have a "stable"/reusable
`$HOME/android-archives` directory (presumably because it's built in a
chroot...).

	Downloading `http://mirrors.ibiblio.org/apache/ant/binaries/apache-ant-1.9.8-bin.zip` to `/home/builder/android-archives/.apache-ant-1.9.8-bin.zip.download
	android-toolchain.targets: error : 404 (Not Found)  at System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode ()

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-linux/207/consoleText