### PR TITLE
[tests] Avoid using `adb install -r`

### DIFF
--- a/build-tools/scripts/UnitTestApks.targets
+++ b/build-tools/scripts/UnitTestApks.targets
@@ -78,7 +78,7 @@
   <Target Name="DeployUnitTestApks"
       Condition=" '@(UnitTestApk)' != '' ">
     <Adb
-        Arguments="$(_AdbTarget) $(AdbOptions) install -r &quot;%(UnitTestApk.Identity)&quot;"
+        Arguments="$(_AdbTarget) $(AdbOptions) install &quot;%(UnitTestApk.Identity)&quot;"
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)"
     />

--- a/tests/RunApkTests.targets
+++ b/tests/RunApkTests.targets
@@ -16,6 +16,7 @@
   <PropertyGroup>
     <RunApkTestsDependsOn>
       AcquireAndroidTarget;
+      UndeployUnitTestApks;
       DeployUnitTestApks;
       RunUnitTestApks;
       ReleaseAndroidTarget


### PR DESCRIPTION
@xmcclure and I just spent *hours* trying to figure out why a
Xamarin.Android unit test was failing on her device, but nowhere else,
and -- further! -- how when she added *new* tests to the
`Xamarin.Android.JcwGen_Tests` package, the new tests and new debug
messages would never appear on `adb logcat`.

The result? An old install. *Apparently*,

	adb install -r bin/TestDebug/Xamarin.Android.JcwGen_Tests-Signed.apk

wasn't actually installing updated file contents.

Manually uninstalling the `Xamarin.Android.JcwGen_Tests` package and
installing a new `Xamarin.Android.JcwGen_Tests-Signed.apk` resulted in
all tests passing, as expected.

What this means *to me* is that `adb install -r` *can't be trusted*.
We pulled our hair out *for hours* trying to figure out why various
things didn't appear to work at all, and nothing worked because we
were never getting the new app on her device.

(Insert fuming here.)

Consequently, *avoid* `adb install -r`. Instead, update the
`$(RunApkTestsDependsOn)` property so that we always call the
`UndeployUnitTestApks` target before calling the `DeployUnitTestApks`
target, and update the `DeployUnitTestApks` target to use "normal"
`adb install` instead of `adb install -r`.