### PR TITLE
[android-runtimes] Download Ant from `apache.org`

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <AndroidUri Condition=" '$(AndroidUri)' == '' ">https://dl-ssl.google.com/android/repository</AndroidUri>
-    <AntUri Condition=" '$(AntUri)' == '' ">http://mirrors.ibiblio.org/apache/ant/binaries</AntUri>
+    <AntUri Condition=" '$(AntUri)' == '' ">http://archive.apache.org/dist/ant/binaries</AntUri>
   </PropertyGroup>
   <ItemGroup>
     <AndroidNdkItem Include="android-ndk-r11c-linux-x86_64.zip">


### PR DESCRIPTION
The `ibiblio.org` servers we previously downloaded Ant from are no
longer hosting Ant -- `mirrors.ibiblio.org` doesn't accept HTTP
traffic, resulting in build errors:

	Error: ConnectFailure (Connection timed out)  at System.Net.HttpWebRequest.EndGetResponse (IAsyncResult asyncResult)

Something I had previously overlooked when reading the
[official Ant download page][0] is that it directs us to *mirrors*.
Incredibly (?), `mirrors.ibiblio.org` is still listed as a mirror,
even though it doesn't currently resolve.

In the meantime, we need to pick a new Ant download location.
There are two plausible locations:

1. Pick another mirror "at random"
2. Use the `apache.org` download location.

I'm sure Apache would *far* prefer people to use the mirrors; that's
why they have mirrors, after all.

However, as per commits 6c667719 and 2153ebe3, using the mirror is no
guarantee of *anything*, because those mirrors will *remove* "older"
versions when newer versions become available, which results in
"random breakage" if we're using a removed version.

Which brings us to (2),
<http://archive.apache.org/dist/ant/binaries/>. This location is
*also* the *archive*, containing all prior Ant versions.

Consequently, while using (2) will be less desirable from Apache's
perspective, it'll result in a more reliable build experience for us.

[0]: https://ant.apache.org/bindownload.cgi