### PR TITLE
[msbuild] JavaDocJar items should also be passed to ClassParse task.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ClassParse.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ClassParse.cs
@@ -31,10 +31,12 @@ namespace Xamarin.Android.Tasks
 
 		public ITaskItem [] DroidDoc2Paths { get; set; }
 
+		public ITaskItem [] JavaDocs { get; set; }
+
 		public IEnumerable<ITaskItem> DocsPaths {
 			get {
 				Func<ITaskItem[],IEnumerable<ITaskItem>> f = l => l ?? Enumerable.Empty<ITaskItem> ();
-				return f (JavaDocPaths).Concat (f (Java7DocPaths)).Concat (f (Java8DocPaths)).Concat (f (DroidDocPaths)).Concat (f (DroidDoc2Paths));
+				return f (JavaDocPaths).Concat (f (Java7DocPaths)).Concat (f (Java8DocPaths)).Concat (f (DroidDocPaths)).Concat (f (DroidDoc2Paths)).Concat (f (JavaDocs));
 			}
 		}
 
@@ -48,6 +50,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogTaskItems ("  Java8DocPaths: ", Java8DocPaths);
 			Log.LogTaskItems ("  DroidDocPaths: ", DroidDocPaths);
 			Log.LogTaskItems ("  DroidDoc2Paths: ", DroidDoc2Paths);
+			Log.LogTaskItems ("  JavaDocs: ", JavaDocs);
 
 			using (var output = new StreamWriter (OutputFile, append: false, 
 						encoding: new UTF8Encoding (encoderShouldEmitUTF8Identifier: false))) {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -387,6 +387,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
       Java7DocPaths="$(Java7DocPaths)"
       Java8DocPaths="$(Java8DocPaths)"
       DroidDocPaths="$(DroidDocPaths)"
+      JavaDocs="@(JavaDocJar->'$(IntermediateOutputPath)javadocs\%(FileName)')"
     />
 
     <BindingsGenerator Condition="'$(AndroidClassParser)' == 'class-parse'"


### PR DESCRIPTION
ClassParse implementation actually ignores the doclet types so this change
itself actually doesn't do anything (changes to Java.Interop is being
published too). So far it passes new jar-originated docs just like other
JavaDoc/DroidDoc properties.