### PR TITLE
[Xamarin.Android.Build.Utilities] Get registry values from a custom registry key support for VS2017 SXS

### DIFF
--- a/src/Xamarin.Android.Build.Utilities/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Build.Utilities/Sdks/AndroidSdkWindows.cs
@@ -24,27 +24,36 @@ namespace Xamarin.Android.Build.Utilities
 		public override string NdkHostPlatform64Bit { get { return "windows-x86_64"; } }
 		public override string Javac { get; protected set; } = "javac.exe";
 
+		string GetMDRegistryKey ()
+		{
+			var regKey = Environment.GetEnvironmentVariable ("XAMARIN_ANDROID_REGKEY");
+			return string.IsNullOrWhiteSpace (regKey) ? MDREG_KEY : regKey;
+		}
+
 		public override string PreferedAndroidSdkPath {
 			get {
 				var wow = RegistryEx.Wow64.Key32;
-				if (CheckRegistryKeyForExecutable (RegistryEx.CurrentUser, MDREG_KEY, MDREG_ANDROID_SDK, wow, "platform-tools", Adb))
-					return RegistryEx.GetValueString (RegistryEx.CurrentUser, MDREG_KEY, MDREG_ANDROID_SDK, wow);
+				var regKey = GetMDRegistryKey ();
+				if (CheckRegistryKeyForExecutable (RegistryEx.CurrentUser, regKey, MDREG_ANDROID_SDK, wow, "platform-tools", Adb))
+					return RegistryEx.GetValueString (RegistryEx.CurrentUser, regKey, MDREG_ANDROID_SDK, wow);
 				return null;
 			}
 		}
 		public override string PreferedAndroidNdkPath {
 			get {
 				var wow = RegistryEx.Wow64.Key32;
-				if (CheckRegistryKeyForExecutable (RegistryEx.CurrentUser, MDREG_KEY, MDREG_ANDROID_NDK, wow, ".", NdkStack))
-					return RegistryEx.GetValueString (RegistryEx.CurrentUser, MDREG_KEY, MDREG_ANDROID_NDK, wow);
+				var regKey = GetMDRegistryKey ();
+				if (CheckRegistryKeyForExecutable (RegistryEx.CurrentUser, regKey, MDREG_ANDROID_NDK, wow, ".", NdkStack))
+					return RegistryEx.GetValueString (RegistryEx.CurrentUser, regKey, MDREG_ANDROID_NDK, wow);
 				return null;
 			}
 		}
 		public override string PreferedJavaSdkPath {
 			get {
 				var wow = RegistryEx.Wow64.Key32;
-				if (CheckRegistryKeyForExecutable (RegistryEx.CurrentUser, MDREG_KEY, MDREG_JAVA_SDK, wow, "bin", JarSigner))
-					return RegistryEx.GetValueString (RegistryEx.CurrentUser, MDREG_KEY, MDREG_JAVA_SDK, wow);
+				var regKey = GetMDRegistryKey ();
+				if (CheckRegistryKeyForExecutable (RegistryEx.CurrentUser, regKey, MDREG_JAVA_SDK, wow, "bin", JarSigner))
+					return RegistryEx.GetValueString (RegistryEx.CurrentUser, regKey, MDREG_JAVA_SDK, wow);
 				return null;
 			}
 		}
@@ -53,13 +62,14 @@ namespace Xamarin.Android.Build.Utilities
 		{
 			var roots = new[] { RegistryEx.CurrentUser, RegistryEx.LocalMachine };
 			var wow = RegistryEx.Wow64.Key32;
+			var regKey = GetMDRegistryKey ();
 
 			AndroidLogger.LogInfo ("sdk", "Looking for Android SDK..");
 
 			// Check for the key the user gave us in the VS/addin options
 			foreach (var root in roots)
-				if (CheckRegistryKeyForExecutable (root, MDREG_KEY, MDREG_ANDROID_SDK, wow, "platform-tools", Adb))
-					yield return RegistryEx.GetValueString (root, MDREG_KEY, MDREG_ANDROID_SDK, wow);
+				if (CheckRegistryKeyForExecutable (root, regKey, MDREG_ANDROID_SDK, wow, "platform-tools", Adb))
+					yield return RegistryEx.GetValueString (root, regKey, MDREG_ANDROID_SDK, wow);
 
 			// Check for the key written by the Xamarin installer
 			if (CheckRegistryKeyForExecutable (RegistryEx.CurrentUser, XAMARIN_ANDROID_INSTALLER_PATH, XAMARIN_ANDROID_INSTALLER_KEY, wow, "platform-tools", Adb))
@@ -90,10 +100,11 @@ namespace Xamarin.Android.Build.Utilities
 			// check the user specified path
 			var roots = new[] { RegistryEx.CurrentUser, RegistryEx.LocalMachine };
 			const RegistryEx.Wow64 wow = RegistryEx.Wow64.Key32;
+			var regKey = GetMDRegistryKey ();
 
 			foreach (var root in roots) {
-				if (CheckRegistryKeyForExecutable (root, MDREG_KEY, MDREG_JAVA_SDK, wow, "bin", JarSigner))
-					return RegistryEx.GetValueString (root, MDREG_KEY, MDREG_JAVA_SDK, wow);
+				if (CheckRegistryKeyForExecutable (root, regKey, MDREG_JAVA_SDK, wow, "bin", JarSigner))
+					return RegistryEx.GetValueString (root, regKey, MDREG_JAVA_SDK, wow);
 			}
 
 			string subkey = @"SOFTWARE\JavaSoft\Java Development Kit";
@@ -129,13 +140,14 @@ namespace Xamarin.Android.Build.Utilities
 		{
 			var roots = new[] { RegistryEx.CurrentUser, RegistryEx.LocalMachine };
 			var wow = RegistryEx.Wow64.Key32;
+			var regKey = GetMDRegistryKey ();
 
 			AndroidLogger.LogInfo ("sdk", "Looking for Android NDK..");
 
 			// Check for the key the user gave us in the VS/addin options
 			foreach (var root in roots)
-				if (CheckRegistryKeyForExecutable (root, MDREG_KEY, MDREG_ANDROID_NDK, wow, ".", NdkStack))
-					yield return RegistryEx.GetValueString (root, MDREG_KEY, MDREG_ANDROID_NDK, wow);
+				if (CheckRegistryKeyForExecutable (root, regKey, MDREG_ANDROID_NDK, wow, ".", NdkStack))
+					yield return RegistryEx.GetValueString (root, regKey, MDREG_ANDROID_NDK, wow);
 
 			/*
 			// Check for the key written by the Xamarin installer
@@ -162,17 +174,20 @@ namespace Xamarin.Android.Build.Utilities
 
 		public override void SetPreferredAndroidSdkPath (string path)
 		{
-			RegistryEx.SetValueString (RegistryEx.CurrentUser, MDREG_KEY, MDREG_ANDROID_SDK, path ?? "", RegistryEx.Wow64.Key32);
+			var regKey = GetMDRegistryKey ();
+			RegistryEx.SetValueString (RegistryEx.CurrentUser, regKey, MDREG_ANDROID_SDK, path ?? "", RegistryEx.Wow64.Key32);
 		}
 
 		public override void SetPreferredJavaSdkPath (string path)
 		{
-			RegistryEx.SetValueString (RegistryEx.CurrentUser, MDREG_KEY, MDREG_JAVA_SDK, path ?? "", RegistryEx.Wow64.Key32);
+			var regKey = GetMDRegistryKey ();
+			RegistryEx.SetValueString (RegistryEx.CurrentUser, regKey, MDREG_JAVA_SDK, path ?? "", RegistryEx.Wow64.Key32);
 		}
 
 		public override void SetPreferredAndroidNdkPath (string path)
 		{
-			RegistryEx.SetValueString (RegistryEx.CurrentUser, MDREG_KEY, MDREG_ANDROID_NDK, path ?? "", RegistryEx.Wow64.Key32);
+			var regKey = GetMDRegistryKey ();
+			RegistryEx.SetValueString (RegistryEx.CurrentUser, regKey, MDREG_ANDROID_NDK, path ?? "", RegistryEx.Wow64.Key32);
 		}
 
 		#region Helper Methods


### PR DESCRIPTION
VS2017 introduce the possibility to install more than one instance.
We need to maintain the preferred path (javasdk, androidsdk, androidndk)
of XA isolated by VS installation instance.

If user has VS2015 and VS2017 (maybe more than 1 installed) the path
must be the reference to the installation path of each product
(javasdk, androidsdk, androidndk) for each version.

XA store it in the registry for whole Xamarin.
We needs to define an environment variable to set the regkey to be
used at the moment of resolve/store the preferred path.

VS and XA (msbuild targets), this environment variable is assigned
with a string that represents the registry key based on VS installation
id for VS2017 (XAMARIN_ANDROID_REGKEY=SOFTWARE\Xamarin\VisualStudio_{id}\Android).

VS2015 and previous continues working with the general regkey defined in XA (SOFTWARE\Novell\Mono for Android).