### PR TITLE
[build] Revert improved branch name construction

### DIFF
--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -1,6 +1,6 @@
 PRODUCT_VERSION   = $(shell $(MSBUILD) $(MSBUILD_FLAGS) /p:DoNotLoadOSProperties=True /nologo /v:minimal /t:GetProductVersion build-tools/scripts/Info.targets | tr -d '[[:space:]]')
 
-GIT_BRANCH        = $(shell LANG=C git branch --contains HEAD | grep -E -v '\(.*detached.*\)' | sed 's/^. //' | head -1 | tr -d '[[:space:]]' | tr -C a-zA-Z0-9- _ )
+GIT_BRANCH        = $(shell LANG=C git rev-parse --abbrev-ref HEAD | tr -d '[[:space:]]' | tr -C a-zA-Z0-9- _)
 GIT_COMMIT        = $(shell LANG=C git log --no-color --first-parent -n1 --pretty=format:%h)
 
 # In which commit did $(PRODUCT_VERSION) change? 00000000 if uncommitted

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitBranch.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitBranch.cs
@@ -41,19 +41,12 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 
 		protected override string GenerateCommandLineCommands ()
 		{
-			return "branch --contains HEAD";
+			return "rev-parse --abbrev-ref HEAD";
 		}
 
 		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
 		{
-			if (singleLine?.Length > 0 && singleLine [0] == '*')
-				singleLine = singleLine.Substring (1);
-			singleLine  = singleLine?.Trim ();
 			if (string.IsNullOrEmpty (singleLine))
-				return;
-			if (singleLine.StartsWith ("(") && singleLine.Contains ("detached at") && singleLine.EndsWith (")"))
-				return;
-			if (Branch != null)
 				return;
 			Branch  = singleLine;
 		}


### PR DESCRIPTION
Commits badec2b4 and 3f41f7e7 *attempted* to improve determination of
branch names when running on Jenkins, but they failed;
`git branch --contains HEAD` also failed to provide any meaningful
branch names when building on Jenkins. The end result of which was
that, instead of meaingles `HEAD` being detected as the branch name,
`""` (the empty string) was being detected instead!

This is not better. :-(

Improved reading of the Jenkins documentation (thanks @alanmcgovern!)
directed us to the [Check out to specific local branch][0] option,
which looks like it'll allow `git rev-parse` to work as desired.

Revert commits badec2b4 and 3f41f7e7 so that `git rev-parse` is once
again used to determine branch names.

[0]: http://stackoverflow.com/questions/39297783/detached-head-w-jenkins-git-plugin-and-branch-specifier