### PR TITLE
[Xamarin.Android.Build.Tasks] Custom control "CardView" properties are not getting appearing in Properties Panel in VS. Take 2

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
+using System.Xml.Linq;
 using NUnit.Framework;
 using Xamarin.ProjectTools;
 
@@ -69,6 +71,23 @@ namespace Xamarin.Android.Build.Tests
 						   "lib/armeabi-v7a/libmono-btls-shared.so should not exist in the apk.");
 					}
 				}
+			}
+		}
+
+		[Test]
+		public void BuildAfterAddingNuget ()
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				TargetFrameworkVersion = "7.1",
+			};
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
+				Assert.IsTrue (b.Build (proj), "first build should have succeeded.");
+				proj.Packages.Add (KnownPackages.SupportV7CardView_24_2_1);
+				b.Save (proj, doNotCleanupOnUpdate: true);
+				Assert.IsTrue (b.Build (proj), "second build should have succeeded.");
+				var doc = File.ReadAllText (Path.Combine (b.Root, b.ProjectDirectory, proj.IntermediateOutputPath, "resourcepaths.cache"));
+				Assert.IsTrue (doc.Contains ("Xamarin.Android.Support.v7.CardView/24.2.1"), "CardView should be resolved as a reference.");
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -103,6 +103,15 @@ namespace Xamarin.ProjectTools
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v7.CardView.21.0.3.0\\lib\\MonoAndroid403\\Xamarin.Android.Support.v7.CardView.dll" }
 			}
 		};
+		public static Package SupportV7CardView_24_2_1 = new Package {
+			Id = "Xamarin.Android.Support.v7.Cardview",
+			Version = "24.2.1",
+			TargetFramework = "MonoAndroid70",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.v7.CardView") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v7.CardView.24.2.1\\lib\\MonoAndroid70\\Xamarin.Android.Support.v7.CardView.dll" }
+			}
+		};
 		public static Package SupportV7AppCompat_21_0_3_0 = new Package {
 			Id = "Xamarin.Android.Support.v7.AppCompat",
 			Version = "21.0.3.0",

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -368,7 +368,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </Target>
 
 <Target Name="_BuildAdditionalResourcesCache"
-	Inputs="@(ReferencePath);@(ReferenceDependencyPaths);$(MSBuildProjectFullPath)"
+	Inputs="@(ReferencePath);@(ReferenceDependencyPaths);$(MSBuildProjectFullPath);$(NugetPackagesConfig)"
 	Outputs="$(_AndroidResourcePathsCache)"
 	DependsOnTargets="$(_BeforeBuildAdditionalResourcesCache)"
 	>
@@ -389,6 +389,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		<Output TaskParameter="IsResourceCacheValid" PropertyName="_IsResourceCacheValid" />
 	</ReadAdditionalResourcesFromAssemblyCache>
 	<Delete Files="$(_AndroidResourcePathsCache)" Condition=" '$(_IsResourceCacheValid)' == 'False' " />
+	<PropertyGroup>
+		<NugetPackagesConfig Condition="Exists('$(MSBuildProjectDirectory)\packages.config')">$(MSBuildProjectDirectory)\packages.config</NugetPackagesConfig>
+	</PropertyGroup>
 </Target>
 
 <Target Name="_GetAdditionalResourcesFromAssemblies"


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=51604

Adding a Nuget package to the project in the IDE does not
seem to be causing a build. It appears that the build system
thinks the project file is up to date.

This commit adds a check to see if the packages.config has changed
(if it exists). If it has changed then we need to rebuild the
referencepaths.cache again to ensure we include the new assemblies
resources.