### PR TITLE
Add support for redirect to url without protocol

### DIFF
--- a/src/Mono.Android/Test/Xamarin.Android.Net/AndroidClientHandlerTests.cs
+++ b/src/Mono.Android/Test/Xamarin.Android.Net/AndroidClientHandlerTests.cs
@@ -255,5 +255,18 @@ namespace Xamarin.Android.NetTests {
         }
       }
     }
+
+	  [Test]
+	  public void Redirect_Without_Protocol_Works()
+	  {
+		  var requestURI = new Uri ("http://tlstest.xamdev.com/redirect.php");
+		  var redirectedURI = new Uri ("http://tlstest.xamdev.com/redirect-301.html");
+		  using (var c = new HttpClient (CreateHandler ())) {
+			  var tr = c.GetAsync (requestURI);
+			  tr.Wait ();
+			  tr.Result.EnsureSuccessStatusCode ();
+			  Assert.AreEqual (redirectedURI, tr.Result.RequestMessage.RequestUri, "Invalid redirected URI");
+		  }
+	  }
   }
 }

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -466,10 +466,16 @@ namespace Xamarin.Android.Net
 			if (redirectState.RedirectCounter >= MaxAutomaticRedirections)
 				throw new WebException ($"Maximum automatic redirections exceeded (allowed {MaxAutomaticRedirections}, redirected {redirectState.RedirectCounter} times)");
 
-			Uri location = new Uri (locationHeader [0], UriKind.Absolute);
-			redirectState.NewUrl = location;
+			string redirectUrl = locationHeader [0];
+			string protocol = httpConnection.URL?.Protocol;
+			if (redirectUrl.StartsWith ("//", StringComparison.Ordinal)) {
+				// When redirecting to an URL without protocol, we use the protocol of previous request
+				// See https://tools.ietf.org/html/rfc3986#section-5 (example in section 5.4)
+				redirectUrl = protocol + ":" + redirectUrl;
+			}
+			redirectState.NewUrl = new Uri (redirectUrl, UriKind.Absolute);
 			if (Logger.LogNet)
-				Logger.Log (LogLevel.Debug, LOG_APP, $"Request redirected to {location}");
+				Logger.Log (LogLevel.Debug, LOG_APP, $"Request redirected to {redirectState.NewUrl}");
 
 			return true;
 		}


### PR DESCRIPTION
# **Supersedes https://github.com/xamarin/xamarin-android/pull/334** (retains authorship and dates, adds a test and some formatting changes)

This commit adds support for redirecting to urls that
do not specify a scheme. In such cases, the scheme
of the previous request is used.

For example, a request to http://example.com/redirect
may return a 301 redirect to //example.com/new_site.
In this case, we should keep speaking http and retrieve
http://example.com/new_site

Relative urls without protocol are supported according to RFC 3986,
so this commit adds a comment with a link to the RFC.