### PR TITLE
[Mono.Android][linker] add IntDefinitionAttribute.JniField and removal rule.

### DIFF
--- a/src/Mono.Android/Android.Runtime/IntDefinitionAttribute.cs
+++ b/src/Mono.Android/Android.Runtime/IntDefinitionAttribute.cs
@@ -11,6 +11,7 @@ namespace Android.Runtime
 		}
 
 		public string ConstantMember { get; set; }
+		public string JniField { get; set; }
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/RemoveAttributes.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/RemoveAttributes.cs
@@ -24,6 +24,8 @@ namespace MonoDroid.Tuner {
 			// note: this also avoid calling FullName (which allocates a string)
 			var attr_type = attribute.Constructor.DeclaringType;
 			switch (attr_type.Name) {
+			case "IntDefinitionAttribute":
+				return attr_type.Namespace == "Android.Runtime";
 			case "ObsoleteAttribute":
 			// System.Mono*Attribute from mono/mcs/build/common/MonoTODOAttribute.cs
 			case "MonoDocumentationNoteAttribute":


### PR DESCRIPTION
This adds Java field information on every enumified constant.

The changes are twofolds: one in generator, one here.

It will help assembly reflection based tooling e.g. we won't need enum
mapping metadata when dealing with enum constants.