### PR TITLE
[build] Auto-Provision Dependencies

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -13,6 +13,8 @@
   />
   <PropertyGroup>
     <ProductVersion>7.1.99</ProductVersion>
+    <AutoProvision Condition=" '$(AutoProvision)' == '' ">False</AutoProvision>
+    <AutoProvisionUsesSudo Condition=" '$(AutoProvisionUsesSudo)' == '' ">False</AutoProvisionUsesSudo>
     <HostOS Condition=" '$(HostOS)' == '' And '$(OS)' == 'Windows_NT' ">Windows</HostOS>
     <HostCc Condition=" '$(HostCc)' == '' ">$(HostCc64)</HostCc>
     <HostCxx Condition=" '$(HostCxx)' == '' ">$(HostCxx64)</HostCxx>

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ all::
 all-tests::
 	MSBUILD="$(MSBUILD)" tools/scripts/xabuild $(MSBUILD_FLAGS) Xamarin.Android-Tests.sln
 
-prepare:: prepare-external prepare-props prepare-msbuild
+prepare:: prepare-external prepare-props prepare-deps prepare-msbuild
 
 # $(call GetPath,path)
 GetPath   = $(shell $(MSBUILD) $(MSBUILD_FLAGS) /p:DoNotLoadOSProperties=True /nologo /v:minimal /t:Get$(1)FullPath build-tools/scripts/Paths.targets | tr -d '[[:space:]]' )
@@ -45,6 +45,9 @@ prepare-props:
 	cp Configuration.Java.Interop.Override.props external/Java.Interop/Configuration.Override.props
 	./build-tools/scripts/generate-os-info Configuration.OperatingSystem.props
 	cp `$(MSBUILD) $(MSBUILD_FLAGS) /nologo /v:minimal /t:GetMonoSourceFullPath build-tools/scripts/Paths.targets`/mcs/class/msfinal.pub .
+
+prepare-deps:
+	$(MSBUILD) $(MSBUILD_FLAGS) build-tools/dependencies/dependencies.mdproj
 
 prepare-msbuild:
 ifeq ($(MSBUILD),msbuild)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ and will override any default values specified in `Configuration.props`.
 
 Overridable MSBuild properties include:
 
+* `$(AutoProvision)`: Automatically install required dependencies, if possible.
+* `$(AutoProvisionUsesSudo)`: Use `sudo` when installing dependencies.
 * `$(AndroidApiLevel)`: The Android API level to bind in `src/Mono.Android`.
     This is an integer value, e.g. `15` for
     [API-15 (Android 4.0.3)](http://developer.android.com/about/versions/android-4.0.3.html).
@@ -113,6 +115,18 @@ Building Xamarin.Android requires:
 * [Autotools (`autoconf`, `automake`, etc.)](#autotools)
 * [`xxd`](#xxd)
 * [The Android SDK and NDK](#ndk)
+
+The `make prepare` build step will check that all required dependencies
+are present. If you would like `make prepare` to automatically install
+required dependencies, set the `$(AutoProvision)` MSBuild property to True
+and (if necessary) set the `$(AutoProvisionUsesSudo)` property to True.
+(This is not supported on all operating systems.)
+
+If `$(AutoProvision)` is False (the default) and a dependency is missing,
+then the build will fail and an error message will be displayed attempting
+to provide install instructions to obtain the missing dependency, e.g.:
+
+    error : Could not find required program '7za'. Please run: brew install 'p7zip'.
 
 <a name="mono-sdk" />
 ## Mono MDK

--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -97,6 +97,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Android.Cecil", "ex
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Android.Cecil.Mdb", "external\Java.Interop\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.Mdb.csproj", "{C0487169-8F81-497F-919E-EB42B1D0243F}"
 EndProject
+Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "dependencies", "build-tools\dependencies\dependencies.mdproj", "{C845ECC0-2ED3-498E-8EA8-02EF7AC6E9AD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|AnyCPU = Debug|AnyCPU
@@ -447,6 +449,14 @@ Global
 		{C876DA71-8573-4CEF-9149-716D72455ED4}.XAIntegrationDebug|AnyCPU.Build.0 = Debug|Any CPU
 		{C876DA71-8573-4CEF-9149-716D72455ED4}.XAIntegrationRelease|AnyCPU.ActiveCfg = Debug|Any CPU
 		{C876DA71-8573-4CEF-9149-716D72455ED4}.XAIntegrationRelease|AnyCPU.Build.0 = Debug|Any CPU
+		{C845ECC0-2ED3-498E-8EA8-02EF7AC6E9AD}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{C845ECC0-2ED3-498E-8EA8-02EF7AC6E9AD}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{C845ECC0-2ED3-498E-8EA8-02EF7AC6E9AD}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{C845ECC0-2ED3-498E-8EA8-02EF7AC6E9AD}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{C845ECC0-2ED3-498E-8EA8-02EF7AC6E9AD}.XAIntegrationDebug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{C845ECC0-2ED3-498E-8EA8-02EF7AC6E9AD}.XAIntegrationDebug|AnyCPU.Build.0 = Debug|Any CPU
+		{C845ECC0-2ED3-498E-8EA8-02EF7AC6E9AD}.XAIntegrationRelease|AnyCPU.ActiveCfg = Debug|Any CPU
+		{C845ECC0-2ED3-498E-8EA8-02EF7AC6E9AD}.XAIntegrationRelease|AnyCPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
@@ -493,6 +503,7 @@ Global
 		{15945D4B-FF56-4BCC-B598-2718D199DD08} = {864062D3-A415-4A6F-9324-5820237BA058}
 		{C0487169-8F81-497F-919E-EB42B1D0243F} = {864062D3-A415-4A6F-9324-5820237BA058}
 		{C876DA71-8573-4CEF-9149-716D72455ED4} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
+		{C845ECC0-2ED3-498E-8EA8-02EF7AC6E9AD} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -119,42 +119,4 @@
       <HostOS></HostOS>
     </AntItem>
   </ItemGroup>
-  <ItemGroup>
-    <RequiredProgram Include="$(ManagedRuntime)"    Condition=" '$(ManagedRuntime)' != '' " />
-    <RequiredProgram Include="$(HostCcName)" />
-    <RequiredProgram Include="$(HostCxxName)" />
-    <RequiredProgram Include="7za"                  Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
-      <Homebrew>p7zip</Homebrew>
-    </RequiredProgram>
-    <RequiredProgram Include="autoconf" />
-    <RequiredProgram Include="automake" />
-    <RequiredProgram Include="cmake"                Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
-    <RequiredProgram Include="gdk-pixbuf-csource"   Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
-      <Homebrew>gdk-pixbuf</Homebrew>
-    </RequiredProgram>
-    <RequiredProgram Include="gettext"              Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
-    <RequiredProgram Include="glibtool"             Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
-      <Homebrew>libtool</Homebrew>
-    </RequiredProgram>
-    <RequiredProgram Include="gsed"                 Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
-      <Homebrew>gnu-sed</Homebrew>
-    </RequiredProgram>
-    <RequiredProgram Include="intltoolize"          Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
-      <Homebrew>intltool</Homebrew>
-    </RequiredProgram>
-    <RequiredProgram Include="make" />
-    <RequiredProgram Include="pkg-config"           Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
-      <Homebrew>pkg-config</Homebrew>
-    </RequiredProgram>
-    <RequiredProgram Include="ruby"                 Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
-    <RequiredProgram Include="scons"                Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
-      <Homebrew>scons</Homebrew>
-    </RequiredProgram>
-    <RequiredProgram Include="wget"                 Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
-      <Homebrew>wget</Homebrew>
-    </RequiredProgram>
-    <RequiredProgram Include="xz"                   Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
-      <Homebrew>xz</Homebrew>
-    </RequiredProgram>
-  </ItemGroup>
 </Project>

--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -10,7 +10,6 @@
         Properties="OutputPath=$(AndroidToolchainDirectory)\"
     />
   </Target>
-  <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"   TaskName="Xamarin.Android.BuildTools.PrepTasks.DownloadUri" />
   <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.UnzipDirectoryChildren" />
   <Target Name="_DetermineItems">
     <CreateItem

--- a/build-tools/dependencies/dependencies.mdproj
+++ b/build-tools/dependencies/dependencies.mdproj
@@ -4,24 +4,21 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ItemType>GenericProject</ItemType>
-    <ProjectGuid>{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA}</ProjectGuid>
+    <ProjectGuid>{C845ECC0-2ED3-498E-8EA8-02EF7AC6E9AD}</ProjectGuid>
   </PropertyGroup>
-  <Import Project="android-toolchain.targets" />
+  <Import Project="..\..\Configuration.props" />
+  <Import Project="dependencies.targets" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>$(AndroidToolchainDirectory)</OutputPath>
+    <OutputPath>.\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>$(AndroidToolchainDirectory)</OutputPath>
+    <OutputPath>.\</OutputPath>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <BuildDependsOn>
       ResolveReferences;
-      _CopyBootstrapTasksAssembly;
-      _DownloadItems;
-      _UnzipFiles;
-      _CreateNdkToolchains;
-      _CreateMxeToolchains;
+      CheckForRequiredPrograms;
     </BuildDependsOn>
   </PropertyGroup>
   <ItemGroup>
@@ -30,18 +27,5 @@
       <Name>xa-prep-tasks</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\dependencies\dependencies.mdproj">
-      <Project>{C845ECC0-2ED3-498E-8EA8-02EF7AC6E9AD}</Project>
-      <Name>dependencies</Name>
-      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\Xamarin.Android.Tools.BootstrapTasks\Xamarin.Android.Tools.BootstrapTasks.csproj">
-      <Project>{E8492EFB-D14A-4F32-AA28-88848322ECEA}</Project>
-      <Name>Xamarin.Android.Tools.BootstrapTasks</Name>
-      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/build-tools/dependencies/dependencies.projitems
+++ b/build-tools/dependencies/dependencies.projitems
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_DarwinMonoFramework>MonoFramework-MDK-4.8.0.489.macos10.xamarin.universal.pkg</_DarwinMonoFramework>
+    <_AptGetInstall>apt-get -f -u install</_AptGetInstall>
+  </PropertyGroup>
+  <ItemGroup>
+    <RequiredProgram Include="$(HostCcName)" />
+    <RequiredProgram Include="$(HostCxxName)" />
+    <RequiredProgram Include="7za"                  Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+      <Homebrew>p7zip</Homebrew>
+    </RequiredProgram>
+    <RequiredProgram Include="autoconf">
+      <Homebrew>autoconf</Homebrew>
+    </RequiredProgram>
+    <RequiredProgram Include="automake">
+      <Homebrew>automake</Homebrew>
+    </RequiredProgram>
+    <RequiredProgram Include="cmake"                Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+      <Homebrew>cmake</Homebrew>
+    </RequiredProgram>
+    <RequiredProgram Include="gdk-pixbuf-csource"   Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+      <Homebrew>gdk-pixbuf</Homebrew>
+    </RequiredProgram>
+    <RequiredProgram Include="gettext"              Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+      <Homebrew>gettext</Homebrew>
+    </RequiredProgram>
+    <RequiredProgram Include="glibtool"             Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+      <Homebrew>libtool</Homebrew>
+    </RequiredProgram>
+    <RequiredProgram Include="gsed"                 Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+      <Homebrew>gnu-sed</Homebrew>
+    </RequiredProgram>
+    <RequiredProgram Include="intltoolize"          Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+      <Homebrew>intltool</Homebrew>
+    </RequiredProgram>
+    <RequiredProgram Include="javac">
+      <MinimumVersion>1.8</MinimumVersion>
+      <CurrentVersionCommand>$(MSBuildThisFileDirectory)..\scripts\javac-version</CurrentVersionCommand>
+      <UbuntuInstall>$(_AptGetInstall) openjdk-8-jdk</UbuntuInstall>
+    </RequiredProgram>
+    <RequiredProgram Include="make" />
+    <RequiredProgram Include="pkg-config"           Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+      <Homebrew>pkg-config</Homebrew>
+    </RequiredProgram>
+    <RequiredProgram Include="ruby"                 Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
+    <RequiredProgram Include="scons"                Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+      <Homebrew>scons</Homebrew>
+    </RequiredProgram>
+    <RequiredProgram Include="wget"                 Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+      <Homebrew>wget</Homebrew>
+    </RequiredProgram>
+    <RequiredProgram Include="xz"                   Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+      <Homebrew>xz</Homebrew>
+    </RequiredProgram>
+    <RequiredProgram Include="xxd">
+      <UbuntuInstall>$(_AptGetInstall) vim-common</UbuntuInstall>
+    </RequiredProgram>
+    <RequiredProgram Include="$(ManagedRuntime)"    Condition=" '$(ManagedRuntime)' != '' ">
+      <MinimumVersion>4.4.0</MinimumVersion>
+      <MaximumVersion>4.8.99</MaximumVersion>
+      <CurrentVersionCommand>$(MSBuildThisFileDirectory)..\scripts\mono-version</CurrentVersionCommand>
+      <DarwinMinimumUrl>https://bosstoragemirror.blob.core.windows.net/wrench/mono-4.8.0/9a/9ac5bf2f0235ab75d2cc6be0866d6ca3ed302977/$(_DarwinMonoFramework)</DarwinMinimumUrl>
+      <DarwinInstall>installer -pkg "$(AndroidToolchainCacheDirectory)\$(_DarwinMonoFramework)" -target /</DarwinInstall>
+    </RequiredProgram>
+  </ItemGroup>
+</Project>

--- a/build-tools/dependencies/dependencies.targets
+++ b/build-tools/dependencies/dependencies.targets
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="dependencies.projitems" />
+  <Import Project="..\scripts\RequiredPrograms.targets" />
+</Project>

--- a/build-tools/scripts/RequiredPrograms.targets
+++ b/build-tools/scripts/RequiredPrograms.targets
@@ -1,20 +1,48 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.DownloadUri" />
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.PrepareInstall" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.Which" />
   <Target Name="CheckForRequiredPrograms"
-      Condition=" '@(RequiredProgram)' != '' ">
-    <Which Program="%(RequiredProgram.Identity)" Required="True" />
-    <OnError ExecuteTargets="_PrintRequiredPrograms" />
-  </Target>
-  <Target Name="_PrintRequiredPrograms">
+      Condition=" '@(RequiredProgram)' != '' "
+      Inputs="@(RequiredProgram)"
+      Outputs="%(RequiredProgram.Identity)-BATCH">
+    <Which
+        HostOS="$(HostOS)"
+        HostOSName="$(HostOsName)"
+        Program="@(RequiredProgram)"
+        Required="False">
+      <Output TaskParameter="Location"        PropertyName="_Location" />
+    </Which>
+    <PropertyGroup>
+      <_ReportError Condition=" '$(_Location)' == '' And '$(AutoProvision)' == 'False' ">True</_ReportError>
+      <_ReportError Condition=" '$(_ReportError)' == '' ">False</_ReportError>
+    </PropertyGroup>
+    <PrepareInstall
+        Condition=" '$(_Location)' == '' "
+        HostOS="$(HostOS)"
+        HostOSName="$(HostOsName)"
+        Program="@(RequiredProgram)"
+        UseSudo="$(AutoProvisionUsesSudo)">
+      <Output TaskParameter="InstallCommand"  PropertyName="_InstallCommand" />
+      <Output TaskParameter="DownloadUrl"     ItemName="_DownloadUrl" />
+    </PrepareInstall>
     <Error
-        ContinueOnError="True"
-        Text="The following programs are required: @(RequiredProgram->'%(Identity)', ' ')"
+        Condition=" '$(_ReportError)' == 'True' And '$(_InstallCommand)' == '' "
+        Text="Could not find required program '%(RequiredProgram.Identity)'."
     />
     <Error
-        Condition=" '$(HostOS)' == 'Darwin' "
-        ContinueOnError="True"
-        Text="Please try running: brew install @(RequiredProgram->'%(Homebrew)', ' ')`"
+        Condition=" '$(_ReportError)' == 'True' And '$(_InstallCommand)' != '' "
+        Text="Could not find required program '%(RequiredProgram.Identity)'. Please run: $(_InstallCommand)"
+    />
+    <DownloadUri
+        Condition=" '$(AutoProvision)' == 'True' And '@(_DownloadUrl)' != '' "
+        SourceUris="%(_DownloadUrl.Url)"
+        DestinationFiles="@(_DownloadUrl->'$(AndroidToolchainCacheDirectory)\%(Filename)%(Extension)')"
+    />
+    <Exec
+        Condition=" '$(AutoProvision)' == 'True' And '$(_InstallCommand)' != '' "
+        Command="$(_InstallCommand)"
     />
   </Target>
 </Project>

--- a/build-tools/scripts/javac-version
+++ b/build-tools/scripts/javac-version
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+sysname=`uname`
+cmdname=`basename "$0"`
+exec javac -version 2>&1

--- a/build-tools/scripts/mono-version
+++ b/build-tools/scripts/mono-version
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+exec mono --version | head -1 | sed -E 's/^.*version ([^( ]+) \(.*$/\1/'

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/PrepareInstall.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/PrepareInstall.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.BuildTools.PrepTasks
+{
+	public class PrepareInstall : Task
+	{
+		[Required]
+		public  ITaskItem           Program             { get; set; }
+
+		public  bool                UseSudo             { get; set; }
+		public  string              HostOS              { get; set; }
+		public  string              HostOSName          { get; set; }
+
+		[Output]
+		public  string              InstallCommand      { get; set; }
+
+		[Output]
+		public  ITaskItem           DownloadUrl         { get; set; }
+
+		string Sudo {
+			get {return (UseSudo && HostOS != "Windows") ? "sudo " : "";}
+		}
+
+		public override bool Execute ()
+		{
+			Log.LogMessage (MessageImportance.Low, $"Task {nameof (PrepareInstall)}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (HostOS)}: {HostOS}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (HostOSName)}: {HostOSName}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (Program)}: {Program}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (UseSudo)}: {UseSudo}");
+
+			SetDownloadUrl ();
+			SetInstallCommand ();
+
+			Log.LogMessage (MessageImportance.Low, $"  [Output] {nameof (DownloadUrl)}: {DownloadUrl} [Url: {DownloadUrl?.GetMetadata ("Url")}]");
+			Log.LogMessage (MessageImportance.Low, $"  [Output] {nameof (InstallCommand)}: {InstallCommand}");
+
+			return !Log.HasLoggedErrors;
+		}
+
+		string GetHostProperty (string property)
+		{
+			return Which.GetHostProperty (Program, property, HostOS, HostOSName);
+		}
+
+		void SetDownloadUrl ()
+		{
+			var minUrl = GetHostProperty ("MinimumUrl");
+			if (string.IsNullOrEmpty (minUrl))
+				return;
+
+			DownloadUrl = new TaskItem (GetFilenameFromUrl (minUrl));
+			DownloadUrl.SetMetadata ("Url", minUrl);
+		}
+
+		string GetFilenameFromUrl (string url)
+		{
+			var u   = new Uri (url);
+			var p   = u.AbsolutePath;
+			var s   = p.LastIndexOf ('/');
+			if (s >= 0 && p.Length > (s+1)) {
+				return p.Substring (s+1);
+			}
+			return Program.ItemSpec + ".bin";
+		}
+
+		void SetInstallCommand ()
+		{
+			var install = GetHostProperty ("Install");
+			if (install != null) {
+				InstallCommand = Sudo + install;
+				return;
+			}
+			if (HostOS == "Darwin") {
+				var brew    = Program.GetMetadata ("Homebrew");
+				if (!string.IsNullOrEmpty (brew)) {
+					InstallCommand = $"{Sudo}brew install '{brew}'";
+				}
+				return;
+			}
+			// TODO: other platforms
+			Log.LogError ($"Unsupported platform {HostOS}!");
+		}
+	}
+}
+

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
@@ -47,6 +47,7 @@
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\GitBlame.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\GitCommitsInRange.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\ReplaceFileContents.cs" />
+    <Compile Include="Xamarin.Android.BuildTools.PrepTasks\PrepareInstall.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="xa-prep-tasks.targets" />

--- a/src/monodroid/monodroid.mdproj
+++ b/src/monodroid/monodroid.mdproj
@@ -17,7 +17,6 @@
   <PropertyGroup>
     <BuildDependsOn>
       ResolveReferences;
-      CheckForRequiredPrograms;
       _BuildRuntimes;
     </BuildDependsOn>
   </PropertyGroup>
@@ -26,6 +25,11 @@
     <ProjectReference Include="..\..\build-tools\android-toolchain\android-toolchain.mdproj">
       <Project>{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA}</Project>
       <Name>android-toolchain</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="..\..\build-tools\dependencies\dependencies.mdproj">
+      <Project>{C845ECC0-2ED3-498E-8EA8-02EF7AC6E9AD}</Project>
+      <Name>dependencies</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\..\build-tools\mono-runtimes\mono-runtimes.mdproj">

--- a/src/monodroid/monodroid.projitems
+++ b/src/monodroid/monodroid.projitems
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <RequiredProgram Include="xxd" />
-  </ItemGroup>
-  <ItemGroup>
     <_HostRuntime Include="host-Darwin" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">
       <Cc>$(HostCc)</Cc>
       <CFlags>$(_HostUnixCFlags) $(_HostDarwinCFlags) -DAPPLE_OS_X</CFlags>


### PR DESCRIPTION
The #runtime team is requesting that Xamarin.Android support
"auto-provisioning": the ability to track dependency *versions*, and
if there is a "version mismatch", *install* a dependency that
satisfies the minimum.

The primary use case is Mono itself: there is a desire to build
xamarin-android *itself* against mono/master, to see what breaks.
(Does the C# compiler break things? Does the JIT hang? etc.)

Extend the existing `@(RequiredProgram)` infrastructure to attempt to
support this:

* `%(RequiredProgram.MinimumVersion)`: The minimum program version
    that is supported.
* `%(RequiredProgram.MaximumVersion)`: The maximum program version
    that is supported.
* `%(RequiredProgram.CurrentVersionCommand)`: A command to execute to
    obtain the current program version.
    Defaults to `%(Identity) --version`.
* `%(RequiredProgram.MinimumUrl)`: URL to download "something" to use
    to obtain a version of the program that satisfies
    `%(MinimumVersion)`.
* `%(RequiredProgram.Install)`: Command to execute to install the
    minimum version of the program.

`%(RequiredProgram.CurrentVersionCommand)`,
`%(RequiredProgram.MinimumUrl)`, and `%(RequiredProgram.Install)` can
all be "overridden" for platform-specific values by prefixing the
value with `$(HostOSName)` or `$(HostOS)`. Thus, macOS-specific values
can be stored into e.g. `%(RequiredProgram.DarwinMinimumUrl)` and
`%(RequiredProgram.DarwinInstall)`.

Auto-Provisioning is controlled by the new `$(AutoProvision)`
property, which can be provided in `Configuration.Override.props`.
It defaults to `False`.

If the `$(AutoProvisionUsesSudo)` MSBuild property is True, then
`sudo` is used to invoke all install commands.