### PR TITLE
[Mono.Android] Roslyn String Interpolation Fixes

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -708,8 +708,10 @@ namespace Xamarin.Android.Net
 				return;
 			}
 
-			if (Logger.LogNet)
-				Logger.Log (LogLevel.Info, LOG_APP, $"Authentication header '{data.UseProxyAuthentication ? "Proxy-Authorization" : "Authorization"}' will be set to '{authorization.Message}'");
+			if (Logger.LogNet) {
+				var header  = data.UseProxyAuthentication ? "Proxy-Authorization" : "Authorization";
+				Logger.Log (LogLevel.Info, LOG_APP, $"Authentication header '{header}' will be set to '{authorization.Message}'");
+			}
 			httpConnection.SetRequestProperty (data.UseProxyAuthentication ? "Proxy-Authorization" : "Authorization", authorization.Message);
 		}
 


### PR DESCRIPTION
Roslyn doesn't like a "bar" `:` within string interpolations, as
[the `:` is used to separate the value from the string format][0]:

	// Note `:hh`, providing the format string "hh"
	Console.WriteLine($"Name = {name}, hours = {hours:hh}")

This causes problems with using the ternary operator:

	Console.WriteLine($"Name={name != null ? name : "unset"}");
	// error CS8076: Missing close delimiter '}' for interpolated expression started with '{'.

As it happens, this is (more or less) what
`AndroidClientHandler.HandlePreAuthentication()` was doing.
`mcs` allowed this; Roslyn does not.

...which is not to say that you can't use the ternary operator within
string interpolations; you just need to wrap in parens:

	Console.WriteLine($"Name={(name != null ? name : "unset")}");

Fix `AndroidClientHandler.cs` compilation under Roslyn.

[0]: https://msdn.microsoft.com/en-us/library/dn961160.aspx