### PR TITLE
[Xamarin.Android.Build.Tasks] Add default for CopyNuGetImplementations

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props
@@ -3,5 +3,6 @@
 		<XamarinAndroidVersion>Unknown</XamarinAndroidVersion>
 		<_JavaInteropReferences>Java.Interop;System.Runtime</_JavaInteropReferences>
 		<DependsOnSystemRuntime Condition=" '$(DependsOnSystemRuntime)' == '' ">true</DependsOnSystemRuntime>
+		<CopyNuGetImplementations Condition=" '$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
For some reason the latest versions of nuget require this
property to be set in order for assemblies to end up in
the right place.