### PR TITLE
[build] Run `make prepare-deps` first

### DIFF
--- a/build-tools/dependencies/dependencies.projitems
+++ b/build-tools/dependencies/dependencies.projitems
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_DarwinMonoFramework>MonoFramework-MDK-4.8.0.489.macos10.xamarin.universal.pkg</_DarwinMonoFramework>
+    <_DarwinMonoFramework>MonoFramework-MDK-4.6.2.16.macos10.xamarin.universal.pkg</_DarwinMonoFramework>
     <_AptGetInstall>apt-get -f -u install</_AptGetInstall>
   </PropertyGroup>
   <ItemGroup>
@@ -60,7 +60,7 @@
       <MinimumVersion>4.4.0</MinimumVersion>
       <MaximumVersion>4.8.99</MaximumVersion>
       <CurrentVersionCommand>$(MSBuildThisFileDirectory)..\scripts\mono-version</CurrentVersionCommand>
-      <DarwinMinimumUrl>https://bosstoragemirror.blob.core.windows.net/wrench/mono-4.8.0/9a/9ac5bf2f0235ab75d2cc6be0866d6ca3ed302977/$(_DarwinMonoFramework)</DarwinMinimumUrl>
+      <DarwinMinimumUrl>https://bosstoragemirror.blob.core.windows.net/wrench/mono-4.6.0/ac/ac9e222cd99a3ba55a3232598bd53bd3c397f03f/$(_DarwinMonoFramework)</DarwinMinimumUrl>
       <DarwinInstall>installer -pkg "$(AndroidToolchainCacheDirectory)\$(_DarwinMonoFramework)" -target /</DarwinInstall>
     </RequiredProgram>
   </ItemGroup>


### PR DESCRIPTION
The PR builder is wedged. It needs a new mono, but it can't install a
new mono because `$(call GetPath,...)` returns an invalid value,
because `xbuild` always prints out a deprecation notice, screwing up
`$(call GetPath,Java.interop)` output.

Run `make prepare-deps` *first*, so that we can install a proper mono
before we try anything else.