### PR TITLE
[Xamarin.Android.Build.Tasks] NDK r12b+ is not supported

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
@@ -61,7 +61,7 @@ namespace Xamarin.Android.Tasks
 				if (MonoAndroidHelper.LogInternalExceptions)
 					Log.LogMessage (e.ToString ());
 			} catch (Exception ex) {
-				Log.LogMessage (MessageImportance.High, "Error: {0}", ex);
+				Log.LogErrorFromException (ex);
 			}
 			return !Log.HasLoggedErrors;
 		}
@@ -102,8 +102,7 @@ namespace Xamarin.Android.Tasks
 					return false;
 				}
 
-				// FIXME: it is kind of hacky, we should have something like NdkUtil.GetMinimumApiLevelFor(arch).
-				int level = NdkUtil.IsNdk64BitArch (arch) ? 21 : arch == AndroidTargetArch.Arm ? 4 : 9;
+				int level = NdkUtil.GetMinimumApiLevelFor (arch, AndroidNdkDirectory);
 				var outpath = Path.Combine (bundlepath, abi);
 				if (!Directory.Exists (outpath))
 					Directory.CreateDirectory (outpath);


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=48678

We had hardcoded the min api levels for each arch. However
google removed api 4 from the ndk platforms which causes this
error. We also did not raise the error we got. We kinda just
logged it..

This commit adds support for searching for the supported platform
instead of just blindly using one which may not exist.

We also changed the system to raise an Error if we get an exception
while running the build.