### PR TITLE
[build] Support building with system Mono 4.8

### DIFF
--- a/build-tools/dependencies/dependencies.projitems
+++ b/build-tools/dependencies/dependencies.projitems
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_DarwinMonoFramework>MonoFramework-MDK-4.6.2.16.macos10.xamarin.universal.pkg</_DarwinMonoFramework>
+    <_DarwinMonoFramework>MonoFramework-MDK-4.8.0.489.macos10.xamarin.universal.pkg</_DarwinMonoFramework>
     <_AptGetInstall>apt-get -f -u install</_AptGetInstall>
   </PropertyGroup>
   <ItemGroup>
@@ -58,9 +58,9 @@
     </RequiredProgram>
     <RequiredProgram Include="$(ManagedRuntime)"    Condition=" '$(ManagedRuntime)' != '' ">
       <MinimumVersion>4.4.0</MinimumVersion>
-      <MaximumVersion>4.6.99</MaximumVersion>
+      <MaximumVersion>4.8.99</MaximumVersion>
       <CurrentVersionCommand>$(MSBuildThisFileDirectory)..\scripts\mono-version</CurrentVersionCommand>
-      <DarwinMinimumUrl>https://bosstoragemirror.blob.core.windows.net/wrench/mono-4.6.0/ac/ac9e222cd99a3ba55a3232598bd53bd3c397f03f/$(_DarwinMonoFramework)</DarwinMinimumUrl>
+      <DarwinMinimumUrl>https://bosstoragemirror.blob.core.windows.net/wrench/mono-4.8.0/9a/9ac5bf2f0235ab75d2cc6be0866d6ca3ed302977/$(_DarwinMonoFramework)</DarwinMinimumUrl>
       <DarwinInstall>installer -pkg "$(AndroidToolchainCacheDirectory)\$(_DarwinMonoFramework)" -target /</DarwinInstall>
     </RequiredProgram>
   </ItemGroup>

--- a/build-tools/scripts/msbuild.mk
+++ b/build-tools/scripts/msbuild.mk
@@ -29,8 +29,12 @@ MSBUILD_FLAGS += /v:diag
 endif   # $(V) != 0
 
 ifeq ($(MSBUILD),msbuild)
+USE_MSBUILD   = 1
+endif   # $(MSBUILD) == msbuild
+
+ifeq ($(USE_MSBUILD),1)
 _BROKEN_MSBUILD := $(shell if ! pkg-config --atleast-version=4.8 mono ; then echo Broken; fi )
 ifeq ($(_BROKEN_MSBUILD),Broken)
 MSBUILD_FLAGS += /p:_XAFixMSBuildFrameworkPathOverride=True
 endif   # $(_BROKEN_MSBUILD) == Broken
-endif   # $(MSBUILD) == msbuild
+endif   # $(USE_MSBUILD) == 1

--- a/src/Mono.Android.Export/Mono.Android.Export.csproj
+++ b/src/Mono.Android.Export/Mono.Android.Export.csproj
@@ -14,7 +14,7 @@
   <PropertyGroup>
     <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
-    <TargetFrameworkRootPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
+    <TargetFrameworkRootPath>$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -13,8 +13,8 @@
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup>
     <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
-    <TargetFrameworkRootPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+    <TargetFrameworkRootPath>$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -197,8 +197,8 @@
     />
   </Target>
   <Target Name="_GenerateFrameworkList"
-      BeforeTargets="ResolveReferences"
-      Inputs="$(OutputPath)$(AssemblyName).dll"
+      BeforeTargets="GetTargetFrameworkProperties;GetReferenceAssemblyPaths;ResolveReferences"
+      Inputs="$(MSBuildProjectFullPath)"
       Outputs="$(OutputPath)RedistList\FrameworkList.xml">
    <MakeDir Directories="$(OutputPath)RedistList" />
    <ItemGroup>

--- a/src/monodroid/monodroid.projitems
+++ b/src/monodroid/monodroid.projitems
@@ -3,7 +3,7 @@
   <ItemGroup>
     <_HostRuntime Include="host-Darwin" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">
       <Cc>$(HostCc)</Cc>
-      <CFlags>$(_HostUnixCFlags) $(_HostDarwinCFlags) -DAPPLE_OS_X</CFlags>
+      <CFlags>@(JdkIncludePath->'-I%(Identity)', ' ') $(_HostUnixCFlags) $(_HostDarwinCFlags) -DAPPLE_OS_X</CFlags>
       <LdFlags>$(_HostUnixLdFlags)</LdFlags>
       <ExtraSource>$(_UnixAdditionalSourceFiles)</ExtraSource>
       <NativeLibraryExtension>dylib</NativeLibraryExtension>
@@ -13,7 +13,7 @@
     </_HostRuntime>
     <_HostRuntime Include="host-Linux" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:'))">
       <Cc>$(HostCc)</Cc>
-      <CFlags>$(_HostUnixCFlags) $(_HostLinuxCFlags) -D_GNU_SOURCE</CFlags>
+      <CFlags>@(JdkIncludePath->'-I%(Identity)', ' ') $(_HostUnixCFlags) $(_HostLinuxCFlags) -D_GNU_SOURCE</CFlags>
       <LdFlags>$(_HostUnixLdFlags)</LdFlags>
       <ExtraSource>$(_UnixAdditionalSourceFiles)</ExtraSource>
       <NativeLibraryExtension>so</NativeLibraryExtension>
@@ -23,7 +23,7 @@
     </_HostRuntime>
     <_HostRuntime Include="host-mxe-Win64" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Cc>"$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-gcc"</Cc>
-      <CFlags>$(_HostCommonWinCFlags) $(_HostWin64CFlags) $(_LinuxFlatPakBuild)</CFlags>
+      <CFlags>@(JdkIncludePath->'-I%(Identity)', ' ') $(_HostCommonWinCFlags) $(_HostWin64CFlags) $(_LinuxFlatPakBuild)</CFlags>
       <LdFlags>$(_HostCommonWinLdFlags)</LdFlags>
       <ExtraSource></ExtraSource>
       <NativeLibraryExtension>dll</NativeLibraryExtension>

--- a/src/monodroid/monodroid.props
+++ b/src/monodroid/monodroid.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <_DebugCFlags>-ggdb3 -O0 -fno-omit-frame-pointer</_DebugCFlags>
     <_ReleaseCFlags>-g -O2</_ReleaseCFlags>
-    <_CommonCFlags>@(JdkIncludePath->'-I%(Identity)', ' ') -Ijni -Ijni/zip "-I$(MonoSourceFullPath)\eglib\src" -std=c99 -DSGEN_BRIDGE_VERSION=$(MonoSgenBridgeVersion) -D_REENTRANT -DHAVE_CONFIG_H -DMONO_DLL_EXPORT -DJI_DLL_EXPORT -fno-strict-aliasing -ffunction-sections -fvisibility=hidden -Wformat -Werror=format-security</_CommonCFlags>
+    <_CommonCFlags>-Ijni -Ijni/zip "-I$(MonoSourceFullPath)\eglib\src" -std=c99 -DSGEN_BRIDGE_VERSION=$(MonoSgenBridgeVersion) -D_REENTRANT -DHAVE_CONFIG_H -DMONO_DLL_EXPORT -DJI_DLL_EXPORT -fno-strict-aliasing -ffunction-sections -fvisibility=hidden -Wformat -Werror=format-security</_CommonCFlags>
     <_HostUnixCFlags>$(_CommonCFlags) -Wa,--noexecstack</_HostUnixCFlags>
     <_HostUnixLdFlags>-Wall -lstdc++ -lz -shared -fpic</_HostUnixLdFlags>
     <_HostCommonWinCFlags>$(_CommonCFlags) -DWINDOWS -DNTDDI_VERSION=NTDDI_VISTA -D_WIN32_WINNT=_WIN32_WINNT_VISTA -fomit-frame-pointer</_HostCommonWinCFlags>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/451
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=52673

Trying to build xamarin-android with Mono 4.8's `msbuild` had some
"interesting" results:

1. `src/Mono.Android/Mono.Android.csproj` failed to build.
2. `src/monodroid/monodroid.mdproj` failed to build.

`make prepare MSBUILD=msbuild` would fail within `Mono.Android.csproj`
with the error:

        error MSB3644: The reference assemblies for framework "MonoAndroid,Version=v7.1" were not found.

The problem appears to be in `msbuild`s
[`ToolLocationHelper.GetPathToReferenceAssembliesActual()`][0],
which has a `static` (*global*) cache that depends on filesystem
state. For reasons I'm still not clear on, MSBuild is trying to
resolve the `MonoAndroid,Version=v7.1` framework considerably earlier
than I would expect -- before the
`MonoAndroid\v7.1\RedistList\FrameworkList.xml` file is created --
and the results of that "early" lookup are *cached*.
Meaning when MSBuild tries to resolve that framework "later," it
*fails*, even though by that time it exists.

Fix this issue by:

1. Updating `//Target/@BeforeTargets` to be before
    `GetReferenceAssemblyPaths` to fix "local" builds
    (`cd src/Mono.Android; msbuild`). Keep the previous
    `ResolveReferences` value for Mono 4.4/4.6 compatibility,
    and also (try to) run before `GetTargetFrameworkProperties` in a
    feeble effort to fix the "MonoAndroid,Version=v7.1 is resolved too
    early" problem.

2. `$(TargetFrameworkRootPath)` can't be a relative path, as it
    doesn't work reliably with the `GetReferenceAssemblyPaths` target.
    (I don't know why it isn't reliable; it just doesn't work unless
    it's a full path, via `$(MSBuildThisFileDirectory)`.)

3. In `Mono.Android.csproj`, set `$(TargetFrameworkVersion)` to v1.0.
    Yes, this seems quite "wrong," but since the
    `MonoAndroid\v1.0\RedistList\FrameworkList.xml` file is created
    *much* earlier -- as part of `build-tools\mono-runtimes` -- this
    more reliably populates the MSBuild framework cache correctly.

Fortunately `Mono.Android.csproj` uses `$(AndroidFrameworkVersion)` in
`$(OutputPath)`, so setting `$(TargetFrameworkVersion)` doesn't appear
to break anything else...

Update `Makefile` so that `$(USE_MSBUILD)` can be explicitly set, in
addition to auto-detecting when `$(MSBUILD)` is `msbuild`:

        make prepare MSBUILD=path/to/msbuild USE_MSBUILD=1 V=1

`src/monodroid.mdproj` is another problem entirely, captured by
<https://bugzilla.xamarin.com/show_bug.cgi?id=52673>: when item
metadata references an MSBuild property which is derived from an item
group, Mono 4.8's `msbuild` doesn't propertly expand the item group
when referencing the item metadata.

In concrete terms, when building with Mono 4.8's `msbuild`,
`%(_HostRuntime.CFlags)` *did not contain* the values of
`@(JdkIncludePath)`. This in turn meant that `<jni.h>` couldn't be
found (!):

        jni/jni.c:7:10: fatal error: 'jni.h' file not found
        #include <jni.h>
                 ^

Workaround the problem by moving `@(JdkIncludePath)` use into
`%(_HostRuntime.CFlags)` *directly*, not indirectly through
`$(_CommonCFlags)`/`$(_HostUnixCFlags)`.

[0]: https://github.com/mono/msbuild/blob/ce25647/src/Utilities/ToolLocationHelper.cs#L2128-L2180
