### PR TITLE
[Xamarin.Android.Build.Tasks] Add support for Portable Pdb Files

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -268,6 +268,11 @@ namespace Xamarin.Android.Tasks
 
 					if (File.Exists (symbols))
 						apk.AddFile (symbols, "assemblies/" + Path.GetFileName (symbols), compressionMethod: CompressionMethod.Store);
+
+					symbols = Path.ChangeExtension (assembly.ItemSpec, "pdb");
+
+					if (File.Exists (symbols))
+						apk.AddFile (symbols, "assemblies/" + Path.GetFileName (symbols), compressionMethod: CompressionMethod.Store);
 				}
 			}
 
@@ -282,6 +287,11 @@ namespace Xamarin.Android.Tasks
 				// Try to add symbols if Debug
 				if (debug) {
 					var symbols = Path.ChangeExtension (assembly.ItemSpec, "dll.mdb");
+
+					if (File.Exists (symbols))
+						apk.AddFile (symbols, "assemblies/" + Path.GetFileName (symbols), compressionMethod: CompressionMethod.Store);
+
+					symbols = Path.ChangeExtension (assembly.ItemSpec, "pdb");
 
 					if (File.Exists (symbols))
 						apk.AddFile (symbols, "assemblies/" + Path.GetFileName (symbols), compressionMethod: CompressionMethod.Store);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CollectPdbFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CollectPdbFiles.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks
+{
+	public class CollectPdbFiles : Task
+	{
+		const uint ppdb_signature = 0x424a5342;
+
+		[Required]
+		public ITaskItem[] ResolvedAssemblies { get; set; }
+
+		[Output]
+		public ITaskItem[] PdbFiles { get; set; }
+
+		[Output]
+		public ITaskItem[] PortablePdbFiles { get; set; }
+
+		public override bool Execute () {
+
+			Log.LogDebugMessage ("CollectPdbFiles CollectPdbFiles");
+			Log.LogDebugTaskItems ("  ResolvedAssemblies:", ResolvedAssemblies);
+
+			var pdbFiles = new List<ITaskItem> ();
+			var portablePdbFiles = new List<ITaskItem> ();
+
+			foreach (var file in ResolvedAssemblies) {
+				var pdbFile = file.ItemSpec;
+
+				if (!File.Exists (pdbFile))
+					continue;
+
+				if (Files.IsPortablePdb (pdbFile)) {
+					portablePdbFiles.Add (file);
+				} else {
+					pdbFiles.Add (file);
+				}
+			}
+
+			PdbFiles = pdbFiles.ToArray ();
+			PortablePdbFiles = portablePdbFiles.ToArray ();
+
+			Log.LogDebugTaskItems ("  [Output] PdbFiles:", PdbFiles);
+			Log.LogDebugTaskItems ("  [Output] PortablePdbFiles:", PortablePdbFiles);
+
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
@@ -31,6 +31,9 @@ namespace Xamarin.Android.Tasks
 		public ITaskItem[] ResolvedAssemblies { get; set; }
 
 		[Required]
+		public ITaskItem [] PortablePdbFiles { get; set; }
+
+		[Required]
 		public ITaskItem[] LinkDescriptions { get; set; }
 
 		public string I18nAssemblies { get; set; }
@@ -74,6 +77,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  LinkSkip: {0}", LinkSkip);
 			Log.LogDebugTaskItems ("  LinkDescriptions:", LinkDescriptions);
 			Log.LogDebugTaskItems ("  ResolvedAssemblies:", ResolvedAssemblies);
+			Log.LogDebugTaskItems ("  PortablePdbFiles:", PortablePdbFiles);
 			Log.LogDebugMessage ("  EnableProguard: {0}", EnableProguard);
 			Log.LogDebugMessage ("  ProguardConfiguration: {0}", ProguardConfiguration);
 			Log.LogDebugMessage ("  DumpDependencies: {0}", DumpDependencies);
@@ -141,7 +145,14 @@ namespace Xamarin.Android.Tasks
 				Linker.Process (options, out link_context);
 
 				var copydst = OptionalDestinationDirectory ?? OutputDirectory;
-				
+
+				foreach (var pdb in PortablePdbFiles) {
+					var copysrc = pdb.ItemSpec;
+					var filename = Path.GetFileName (pdb.ItemSpec);
+
+					MonoAndroidHelper.CopyIfChanged (copysrc, Path.Combine (copydst, filename));
+				}
+
 				foreach (var assembly in ResolvedAssemblies) {
 					var copysrc = assembly.ItemSpec;
 					var filename = Path.GetFileName (assembly.ItemSpec);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -9,6 +9,7 @@ using Microsoft.Build.Utilities;
 using Mono.Cecil;
 using MonoDroid.Tuner;
 using System.IO;
+using Xamarin.Android.Tools;
 
 using Java.Interop.Tools.Cecil;
 
@@ -95,6 +96,11 @@ namespace Xamarin.Android.Tasks
 
 			ResolvedAssemblies = assemblies.Select (a => new TaskItem (a)).ToArray ();
 			ResolvedSymbols = assemblies.Select (a => a + ".mdb").Where (a => File.Exists (a)).Select (a => new TaskItem (a)).ToArray ();
+			ResolvedSymbols = ResolvedSymbols.Concat (
+					assemblies.Select (a => Path.ChangeExtension (a, "pdb"))
+					.Where (a => File.Exists (a) && Files.IsPortablePdb (a))
+					.Select (a => new TaskItem (a)))
+				.ToArray ();
 			ResolvedFrameworkAssemblies = ResolvedAssemblies.Where (p => MonoAndroidHelper.IsFrameworkAssembly (p.ItemSpec, true)).ToArray ();
 			ResolvedUserAssemblies = ResolvedAssemblies.Where (p => !MonoAndroidHelper.IsFrameworkAssembly (p.ItemSpec, true)).ToArray ();
 			ResolvedDoNotPackageAttributes = do_not_package_atts.ToArray ();

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -250,6 +250,22 @@ namespace Xamarin.Android.Tools {
 #endif
 			}
 		}
+
+		const uint ppdb_signature = 0x424a5342;
+
+		public static bool IsPortablePdb (string filename)
+		{
+			try {
+				using (var fs = new FileStream (filename, FileMode.Open, FileAccess.Read)) {
+					using (var br = new BinaryReader (fs)) {
+						return br.ReadUInt32 () == ppdb_signature;
+					}
+				}
+			}
+			catch {
+				return false;
+			}
+		}
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Tasks\BuildApk.cs" />
     <Compile Include="Tasks\CilStrip.cs" />
     <Compile Include="Tasks\ConvertDebuggingFiles.cs" />
+    <Compile Include="Tasks\CollectPdbFiles.cs" />
     <Compile Include="Tasks\CopyMdbFiles.cs" />
     <Compile Include="Tasks\Generator.cs" />
     <Compile Include="Tasks\JarToXml.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -33,6 +33,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.CheckForRemovedItems" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CheckTargetFrameworks" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CompileToDalvik" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.CollectPdbFiles" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ConvertDebuggingFiles" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ConvertResourcesCases" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CopyIfChanged" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -1507,10 +1508,11 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_CollectPdbFiles"
 		Inputs="@(ResolvedAssemblies->'%(RootDir)%(Directory)%(Filename).pdb')"
 		Outputs="@(ResolvedAssemblies->'%(RootDir)%(Directory)%(Filename)%(Extension).mdb')">
-	<GetFilesThatExist
-			Files="@(ResolvedAssemblies->'%(RootDir)%(Directory)%(Filename).pdb')">
-		<Output TaskParameter="FilesThatExist" ItemName="_ResolvedPdbFiles" />
-	</GetFilesThatExist>
+	<CollectPdbFiles
+			ResolvedAssemblies="@(ResolvedAssemblies->'%(RootDir)%(Directory)%(Filename).pdb')">
+		<Output TaskParameter="PdbFiles" ItemName="_ResolvedPdbFiles" />
+		<Output TaskParameter="PortablePdbFiles" ItemName="_ResolvedPortablePdbFiles" />
+	</CollectPdbFiles>
 </Target>
 
 <Target Name="_ConvertPdbFiles"
@@ -1521,16 +1523,16 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_CopyMdbFiles"
-		Inputs="@(_ResolvedMdbFiles)"
-		Outputs="@(_ResolvedMdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
+		Inputs="@(_ResolvedMdbFiles);@(_ResolvedPortablePdbFiles)"
+		Outputs="@(_ResolvedMdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)');@(_ResolvedPortablePdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
 		DependsOnTargets="_ConvertPdbFiles;_CollectMdbFiles" >
 	<CopyMdbFiles
-			SourceFiles="@(_ResolvedMdbFiles)"
-			DestinationFiles="@(_ResolvedMdbFiles->'$(OutputPath)%(Filename)%(Extension)')"
+			SourceFiles="@(_ResolvedMdbFiles);@(_ResolvedPortablePdbFiles)"
+			DestinationFiles="@(_ResolvedMdbFiles->'$(OutputPath)%(Filename)%(Extension)');@(_ResolvedPortablePdbFiles->'$(OutputPath)%(Filename)%(Extension)')"
 	/>
 	<Copy
-		SourceFiles="@(_ResolvedMdbFiles->'$(OutputPath)%(Filename)%(Extension)')"
-		DestinationFiles="@(_ResolvedMdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
+		SourceFiles="@(_ResolvedMdbFiles->'$(OutputPath)%(Filename)%(Extension)');@(_ResolvedPortablePdbFiles->'$(OutputPath)%(Filename)%(Extension)')"
+		DestinationFiles="@(_ResolvedMdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)');@(_ResolvedPortablePdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
 		SkipUnchangedFiles="true"
 	/>
 </Target>
@@ -1553,6 +1555,7 @@ because xbuild doesn't support framework reference assemblies.
       LinkDescriptions="@(LinkDescription)"
       DumpDependencies="$(LinkerDumpDependencies)"
       LinkOnlyNewerThan="$(_AndroidLinkFlag)"
+      PortablePdbFiles="@(_ResolvedPortablePdbFiles)"
       ResolvedAssemblies="@(ResolvedAssemblies)" />
 
 	<!-- We don't have to depend on flag file for NoShrink, but it is used to check timestamp -->
@@ -1583,6 +1586,7 @@ because xbuild doesn't support framework reference assemblies.
       ProguardConfiguration="$(_ProguardProjectConfiguration)"
       EnableProguard="$(AndroidEnableProguard)"
       DumpDependencies="$(LinkerDumpDependencies)"
+      PortablePdbFiles="@(_ResolvedPortablePdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
       ResolvedAssemblies="@(ResolvedAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
       HttpClientHandlerType="$(AndroidHttpClientHandlerType)"
       TlsProvider="$(AndroidTlsProvider)" />


### PR DESCRIPTION
This commit adds support for the new Portable Pdb Format.
When collecting the pdb's we look at the header to see if it
needs converting to mdb or not. PPdb's do NOT need to be
converted as the runtime can load them.