### PR TITLE
[build] add missing ;

### DIFF
--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -92,7 +92,7 @@ $(FRAMEWORK_ASSEMBLIES):
 
 $(RUNTIME_LIBRARIES):
 	$(foreach conf, $(CONFIGURATIONS), \
-		$(MSBUILD) $(MSBUILD_FLAGS) /p:Configuration=$(conf)   $(_MSBUILD_ARGS) $(SOLUTION) )
+		$(MSBUILD) $(MSBUILD_FLAGS) /p:Configuration=$(conf)   $(_MSBUILD_ARGS) $(SOLUTION); )
 
 opentk-jcw:
 	$(foreach a, $(API_LEVELS), \


### PR DESCRIPTION
 - without it we get xbuild complaining about too many project files
   as the commands are joined into one. like this:

    xbuild /p:Configuration=Debug /p:AutoProvision=True /p:AutoProvisionUsesSudo=True /p:PublicSign=true /v:diag /p:Configuration=Debug   /p:AndroidSupportedTargetJitAbis=armeabi:armeabi-v7a:arm64-v8a:x86:x86_64 /p:AndroidSupportedHostJitAbis=Darwin:mxe-Win32:mxe-Win64 /p:AndroidSupportedTargetAotAbis=armeabi:win-armeabi:arm64:win-arm64:x86:win-x86:x86_64:win-x86_64 Xamarin.Android.sln   xbuild /p:Configuration=Debug /p:AutoProvision=True /p:AutoProvisionUsesSudo=True /p:PublicSign=true /v:diag /p:Configuration=Release   /p:AndroidSupportedTargetJitAbis=armeabi:armeabi-v7a:arm64-v8a:x86:x86_64 /p:AndroidSupportedHostJitAbis=Darwin:mxe-Win32:mxe-Win64 /p:AndroidSupportedTargetAotAbis=armeabi:win-armeabi:arm64:win-arm64:x86:win-x86:x86_64:win-x86_64 Xamarin.Android.sln
    MSBUILD: error MSBUILD0004: Too many project files specified