### PR TITLE
[Xamarin.Android.Build.Tasks] Yield Async Tasks while waiting.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AsyncTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AsyncTask.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Android.Tasks
 
 		public CancellationToken Token { get { return tcs.Token; } }
 
-		public bool YieldDuringExecution { get; set; }
+		public bool YieldDuringToolExecution { get; set; }
 
 		[Obsolete ("Do not use the Log.LogXXXX from within your Async task as it will Lock the Visual Studio UI. Use the this.LogXXXX methods instead.")]
 		private new TaskLoggingHelper Log
@@ -42,7 +42,7 @@ namespace Xamarin.Android.Tasks
 
 		public AsyncTask ()
 		{
-			YieldDuringExecution = false;
+			YieldDuringToolExecution = false;
 			UIThreadId = Thread.CurrentThread.ManagedThreadId;
 		}
 
@@ -250,7 +250,7 @@ namespace Xamarin.Android.Tasks
 				taskCancelled,
 				completed,
 			};
-			if (YieldDuringExecution && BuildEngine is IBuildEngine3)
+			if (YieldDuringToolExecution && BuildEngine is IBuildEngine3)
 				(BuildEngine as IBuildEngine3).Yield ();
 			try {
 				while (isRunning) {
@@ -277,7 +277,7 @@ namespace Xamarin.Android.Tasks
 
 			}
 			finally {
-				if (YieldDuringExecution && BuildEngine is IBuildEngine3)
+				if (YieldDuringToolExecution && BuildEngine is IBuildEngine3)
 					(BuildEngine as IBuildEngine3).Reacquire ();
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props
@@ -4,5 +4,6 @@
 		<_JavaInteropReferences>Java.Interop;System.Runtime</_JavaInteropReferences>
 		<DependsOnSystemRuntime Condition=" '$(DependsOnSystemRuntime)' == '' ">true</DependsOnSystemRuntime>
 		<CopyNuGetImplementations Condition=" '$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
+		<YieldDuringToolExecution Condition="'$(YieldDuringToolExecution)' == ''">true</YieldDuringToolExecution>
 	</PropertyGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -377,6 +377,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
    AndroidNdkDirectory="$(_AndroidNdkDirectory)"
    Assemblies="@(ReferencePath);@(ReferenceDependencyPaths)"
    CacheFile="$(_AndroidResourcePathsCache)"
+   YieldDuringToolExecution="$(YieldDuringToolExecution)"
    Condition=" '$(DesignTimeBuild)' == 'false' Or '$(DesignTimeBuild)' == '' "
   />
 </Target>
@@ -1212,6 +1213,7 @@ because xbuild doesn't support framework reference assemblies.
    ApiLevel="$(_AndroidTargetSdkVersion)"
    AndroidUseLatestPlatformSdk="$(AndroidUseLatestPlatformSdk)"
    ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
+   YieldDuringToolExecution="$(YieldDuringToolExecution)"
    ExplicitCrunch="$(AndroidExplicitCrunch)"
  />
  <Touch Files="$(_AndroidComponentResgenFlagFile)" AlwaysCreate="True" />
@@ -1280,6 +1282,7 @@ because xbuild doesn't support framework reference assemblies.
 		ApiLevel="$(_AndroidTargetSdkVersion)"
 		AndroidUseLatestPlatformSdk="$(AndroidUseLatestPlatformSdk)"
 		ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
+		YieldDuringToolExecution="$(YieldDuringToolExecution)"
 		ExplicitCrunch="$(AndroidExplicitCrunch)"
 		SupportedAbis="$(_BuildTargetAbis)"
 	/>
@@ -1793,6 +1796,7 @@ because xbuild doesn't support framework reference assemblies.
 	ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
     SupportedAbis="$(_BuildTargetAbis)"
     CreatePackagePerAbi="$(AndroidCreatePackagePerAbi)"
+    YieldDuringToolExecution="$(YieldDuringToolExecution)"
     ExplicitCrunch="$(AndroidExplicitCrunch)"
      />
   <Touch Files="$(_PackagedResources)" />
@@ -2203,6 +2207,7 @@ because xbuild doesn't support framework reference assemblies.
 	IntermediateAssemblyDir="$(MonoAndroidIntermediateAssemblyDir)"
 	LinkMode="$(AndroidLinkMode)"
 	AdditionalNativeLibraryReferences="@(_AdditionalNativeLibraryReferences)"
+	YieldDuringToolExecution="$(YieldDuringToolExecution)"
 	EnableLLVM="$(EnableLLVM)">
 	   <Output TaskParameter="NativeLibrariesReferences" ItemName="_AdditionalNativeLibraryReferences" />
   </Aot>


### PR DESCRIPTION
There is an on going problem in Visual Studio where the IDE
locks up during long running tasks. It turns out that we
have already implemented a solution for these tasks but never
enabled it.

The AsyncTask class has a property called `YieldDuringToolExecution`.
The purpose of this property is to left the MSBuild Engine know
that this process might take a while. So the MSBuild Node can get
on with other stuff while that is happening.

By default we have this property set to false. This value was never
changed because the required property was not set from the msbuild
targets.

This commit adds the appropriate code to the targets. But also includes
the ability to allow it to be turned off by the user if need be.