### PR TITLE
[xa-prep-tasks] Improve error messages

### DIFF
--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/DownloadUri.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/DownloadUri.cs
@@ -72,6 +72,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks {
 				File.Move (tempPath, destinationFile);
 			}
 			catch (Exception e) {
+				Log.LogError ("Unable to download URL `{0}` to `{1}`: {2}", uri, destinationFile, e.Message);
 				Log.LogErrorFromException (e);
 			}
 		}

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/PrepareInstall.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/PrepareInstall.cs
@@ -86,7 +86,16 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 				return;
 			}
 			// TODO: other platforms
-			Log.LogError ($"Unsupported platform {HostOS}!");
+			var min = Program.GetMetadata ("MinimumVersion");
+			var ver = "";
+			if (!string.IsNullOrEmpty (min)) {
+				ver = $", version >= {min}";
+				var max = Program.GetMetadata ("MaximumVersion");
+				if (!string.IsNullOrEmpty (max)) {
+					ver += $" and <= {max}";
+				}
+			}
+			Log.LogError ($"Unsupported platform {HostOS}! Do not know how to install program `{Program.ItemSpec}`{ver}.");
 		}
 	}
 }


### PR DESCRIPTION
A new developer joined [the `xamarin-android` gitter channel][gitter]
and [ran into multiple issues][issues] trying to build Xamarin.Android
on antergos Linux.

The problems could be worked around. The problem is that the error
messages that were encountered were *not at all helpful*, thus
necessitating that diagnostic output be enabled so that we could
determine what was actually going wrong.

Two major error message deficiencies were encountered.

1. The `<PrepareInstall/>` output isn't useful on unknown platforms.
2. When URL downloads fail, the failing URL isn't printed.

The [`<PrepareInstall/>` output on antergos][prep] wasn't useful:

	error : Unsupported platform Linux!

Which program was missing? What should the user do?
(In this case, it was an invalid `javac` version; 1.7 was installed,
while 1.8 is required.)

Fix the `<PrepareInstall/>` task to instead generate:

	error : Unsupported platform Linux! Do not know how to install program `javac`, version >= 1.8.

The [URL download failure message][url] was similarly useless:

	Error: TrustFailure (The authentication or decryption has failed.)

I still have no idea why this error was being produced.

A reasonable workaround would be to manually download the required
files and put them in the expected location. Unfortunately, the above
error message doesn't let anyone know what URL couldn't be downloaded,
nor where the file is expected to be.

Improve the `<DownloadUri/>` exception handling to additionally print
out the source URL and target file before the exception is printed:

	Error: Unable to download URL `url...` to `path...`: TrustFailure (The authentication or decryption has failed.)
	Error: TrustFailure (The authentication or decryption has failed.)

The additional error message text will hopefully be sufficient to
allow developers to locally work around the issue, by manually
downloading the specified URL into the specified location, should that
be necessary.

[gitter]: https://gitter.im/xamarin/xamarin-android
[issues]: https://gitter.im/xamarin/xamarin-android?at=58b6f8e57ceae5376a583af2
[prep]: https://gist.github.com/tr0yspradling/43cb3386986e20a4a547fd981d41672b
[url]: https://gist.github.com/tr0yspradling/3981aff0b857248be9a7b52857e557a2