### PR TITLE
[libzip] build 32bit version of libzip.dll as well

### DIFF
--- a/build-tools/bundle/bundle-path.targets
+++ b/build-tools/bundle/bundle-path.targets
@@ -24,7 +24,7 @@
   <Target Name="GetBundleFileName"
       DependsOnTargets="_GetHashes">
     <PropertyGroup>
-      <XABundleFileName>bundle-v9-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
+      <XABundleFileName>bundle-v10-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
     </PropertyGroup>
   </Target>
 </Project>

--- a/build-tools/libzip-windows/libzip-windows.projitems
+++ b/build-tools/libzip-windows/libzip-windows.projitems
@@ -4,6 +4,12 @@
     <_LibZipTarget Include="host-mxe-Win64" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <CMake>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-cmake</CMake>
       <CMakeFlags></CMakeFlags>
+      <OutputLibrary>x64/libzip.dll</OutputLibrary>
+      <OutputLibraryPath>lib/libzip.dll</OutputLibraryPath>
+    </_LibZipTarget>
+    <_LibZipTarget Include="host-mxe-Win32" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:'))">
+      <CMake>$(AndroidMxeFullPath)\bin\i686-w64-mingw32.static-cmake</CMake>
+      <CMakeFlags></CMakeFlags>
       <OutputLibrary>libzip.dll</OutputLibrary>
       <OutputLibraryPath>lib/libzip.dll</OutputLibraryPath>
     </_LibZipTarget>


### PR DESCRIPTION
 - note that the 64bit version was moved to the x64/ location
   (lib/xbuild/Xamarin/Android/x64/libzip.dll) and the 32bit version
   is now in its original location