### PR TITLE
[mono-runtimes] Install $prefix/lib/mandroid/cil-strip.exe

### DIFF
--- a/build-tools/bundle/bundle-path.targets
+++ b/build-tools/bundle/bundle-path.targets
@@ -24,7 +24,7 @@
   <Target Name="GetBundleFileName"
       DependsOnTargets="_GetHashes">
     <PropertyGroup>
-      <XABundleFileName>bundle-v10-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
+      <XABundleFileName>bundle-v11-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
     </PropertyGroup>
   </Target>
 </Project>

--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -41,6 +41,7 @@
       _BuildRuntimes;
       _InstallRuntimes;
       _InstallBcl;
+      _InstallCilStrip;
       _InstallMonoDoc;
       _InstallMonoSymbolicate;
       _ConfigureCrossRuntimes;
@@ -323,6 +324,15 @@
     />
     <Touch Files="@(_InstallMonoPosixHelperOutput);@(_InstallUnstrippedMonoPosixHelperOutput)" />
   </Target>
+  <Target Name="_InstallCilStrip"
+      Inputs="$(_MonoOutputDir)\mono-cil-strip.exe"
+      Outputs="$(_MandroidDir)\cil-strip.exe">
+    <MakeDir Directories="$(_MandroidDir)" />
+    <Copy
+        SourceFiles="$(_MonoOutputDir)\mono-cil-strip.exe"
+        DestinationFiles="$(_MandroidDir)\cil-strip.exe"
+    />
+  </Target>
   <Target Name="_InstallMonoDoc"
       Inputs="@(_MonoDocCopyItems);$(_MonoOutputDir)\mdoc.exe"
       Outputs="@(_MonoDocInstalledItems)">
@@ -333,6 +343,9 @@
     />
     <Exec
         Command="$(RemapAssemblyRefTool) &quot;$(_MonoOutputDir)\mdoc.exe&quot; &quot;$(_MandroidDir)\mdoc.exe&quot; Mono.Cecil &quot;$(_MandroidDir)\Xamarin.Android.Cecil.dll&quot;"
+    />
+    <Touch
+        Files="@(_MonoDocInstalledItems)"
     />
   </Target>
   <Target Name="_InstallMonoSymbolicate"


### PR DESCRIPTION
`cil-strip.exe` is used by the `<CilStrip/>` task in
`Xamarin.Android.Build.Tasks.dll`, and is just a renamed copy of
`mono-cil-strip.exe`.

Additionally, update the `_InstallMonoDoc` target to always `<Touch/>`
the created files. This is to keep the `_InstallMonoDoc` task from
constantly re-executing for me when running `xbuild /t:ForceBuild`:

	Target _InstallMonoDoc needs to be built as input file
	'.../xamarin-android/external/mono/mcs/class/lib/net_4_x/mdoc.exe'
	is newer than output file
	'../../bin/Debug//lib/mandroid/monodoc.dll.config'