### PR TITLE
[Xamarin.Android.Build.Utilities] Can't find JDK 1.8 when building from the command line

### DIFF
--- a/src/Xamarin.Android.Build.Utilities/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Build.Utilities/Sdks/AndroidSdkWindows.cs
@@ -119,14 +119,14 @@ namespace Xamarin.Android.Build.Utilities
 					AndroidLogger.LogInfo ("sdk", "  Key {0} found.", key_name);
 
 					// No matter what the CurrentVersion is, look for 1.6 or 1.7 or 1.8
-					if (CheckRegistryKeyForExecutable (RegistryEx.LocalMachine, subkey + "\\" + "1.6", "JavaHome", wow64, "bin", JarSigner))
-						return RegistryEx.GetValueString (RegistryEx.LocalMachine, subkey + "\\" + "1.6", "JavaHome", wow64);
+					if (CheckRegistryKeyForExecutable (RegistryEx.LocalMachine, subkey + "\\" + "1.8", "JavaHome", wow64, "bin", JarSigner))
+						return RegistryEx.GetValueString (RegistryEx.LocalMachine, subkey + "\\" + "1.8", "JavaHome", wow64);
 
 					if (CheckRegistryKeyForExecutable (RegistryEx.LocalMachine, subkey + "\\" + "1.7", "JavaHome", wow64, "bin", JarSigner))
 						return RegistryEx.GetValueString (RegistryEx.LocalMachine, subkey + "\\" + "1.7", "JavaHome", wow64);
 
-					if (CheckRegistryKeyForExecutable (RegistryEx.LocalMachine, subkey + "\\" + "1.8", "JavaHome", wow64, "bin", JarSigner))
-						return RegistryEx.GetValueString (RegistryEx.LocalMachine, subkey + "\\" + "1.8", "JavaHome", wow64);
+					if (CheckRegistryKeyForExecutable (RegistryEx.LocalMachine, subkey + "\\" + "1.6", "JavaHome", wow64, "bin", JarSigner))
+						return RegistryEx.GetValueString (RegistryEx.LocalMachine, subkey + "\\" + "1.6", "JavaHome", wow64);
 				}
 
 				AndroidLogger.LogInfo ("sdk", "  Key {0} not found.", key_name);


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=52928

The order of the default JDK search was in correct. We should be searching
for the latest JDK first since this is what the google tooling needs.

This commit switches the order in which we do the search