### PR TITLE
[Xamarin.Android.Build.Tasks] Fixed DesignTime build so it does not always run.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -177,6 +177,24 @@ namespace Xamarin.Android.Build.Tests
 					"{0} should have been updated", pdbToMdbPath);
 			}
 		}
+
+		[Test]
+		public void BuildInDesignTimeMode ()
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+			};
+			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name), false ,false)) {
+				builder.Verbosity = LoggerVerbosity.Diagnostic;
+				builder.Target = "UpdateAndroidResources";
+				builder.Build (proj, parameters: new string[] { "DesignTimeBuild=true" });
+				Assert.IsFalse (builder.Output.IsTargetSkipped ("_CreatePropertiesCache"), "target \"_CreatePropertiesCache\" should have been run.");
+				Assert.IsFalse (builder.Output.IsTargetSkipped ("_ResolveLibraryProjectImports"), "target \"_ResolveLibraryProjectImports\' should have been run.");
+				builder.Build (proj, parameters: new string[] { "DesignTimeBuild=true" });
+				Assert.IsFalse (builder.Output.IsTargetSkipped ("_CreatePropertiesCache"), "target \"_CreatePropertiesCache\" should have been run.");
+				Assert.IsTrue (builder.Output.IsTargetSkipped ("_ResolveLibraryProjectImports"), "target \"_ResolveLibraryProjectImports\' should have been skipped.");
+			}
+		}
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1020,7 +1020,7 @@ because xbuild doesn't support framework reference assemblies.
 <!-- Resource Build -->
 
 <Target Name="UpdateAndroidResources"
-	DependsOnTargets="$(CoreResolveReferencesDependsOn);_CheckForDeletedResourceFile;_ComputeAndroidResourcePaths;_UpdateAndroidResgen;_AddLibraryProjectsEmbeddedResourceToProject;_GenerateJavaDesignerForComponent" />
+	DependsOnTargets="$(CoreResolveReferencesDependsOn);_CreatePropertiesCache;_CheckForDeletedResourceFile;_ComputeAndroidResourcePaths;_UpdateAndroidResgen;_AddLibraryProjectsEmbeddedResourceToProject;_GenerateJavaDesignerForComponent" />
 
 <!-- Handle a case where the designer file has been deleted, but the flag file still exists -->
 <Target Name="_CheckForDeletedResourceFile">


### PR DESCRIPTION
There was a bug where the build.props file was not created as
part of a design time build. This usually occurs when the IDE's
call "UpdateAndroidResources". The reason is many of the Targets
have the build.props as part of their Inputs. So if an Input
does not exist then the entire target will run.

The fix is to make sure that the _CreatePropertiesCache target is
called as part of the designer builds. This will make sure that
build.props is created even if a design time build is run first.