### PR TITLE
[proguard] Add @(ProjectReference) to android-toolchain.mdproj

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -33,10 +33,15 @@
     <ItemGroup>
       <_SdkStampFiles Include="@(_PlatformAntItem->'$(AntDirectory)\.stamp-%(Identity)')" />
     </ItemGroup>
+    <ItemGroup>
+      <_DownloadedItem Include="@(_PlatformAndroidSdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity)')" />
+      <_DownloadedItem Include="@(_PlatformAndroidNdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity)')" />
+      <_DownloadedItem Include="@(_PlatformAntItem->'$(AndroidToolchainCacheDirectory)\%(Identity)')" />
+    </ItemGroup>
   </Target>
   <Target Name="_DownloadItems"
       DependsOnTargets="_DetermineItems"
-      Outputs="@(_PlatformAndroidSdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity)');@(_PlatformAndroidNdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity)')">
+      Outputs="@(_DownloadedItem)">
     <MakeDir Directories="$(AndroidToolchainCacheDirectory)" />
     <DownloadUri
         SourceUris="@(_PlatformAndroidSdkItem->'$(AndroidUri)/%(RelUrl)%(Identity)');@(_PlatformAndroidNdkItem->'$(AndroidUri)/%(RelUrl)%(Identity)')"
@@ -49,7 +54,7 @@
   </Target>
   <Target Name="_UnzipFiles"
       DependsOnTargets="_DetermineItems"
-      Inputs="@(_PlatformAndroidSdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity)');@(_PlatformAntItem->'$(AndroidToolchainCacheDirectory)\%(Identity)')"
+      Inputs="@(_DownloadedItem)"
       Outputs="@(_SdkStampFiles);$(AndroidToolchainDirectory)\ndk\.stamp-ndk">
     <CreateItem
         Include="@(_PlatformAndroidSdkItem->'$(AndroidToolchainCacheDirectory)\%(_PlatformAndroidSdkItem.Identity)">

--- a/src/proguard/proguard.mdproj
+++ b/src/proguard/proguard.mdproj
@@ -19,4 +19,11 @@
     </BuildDependsOn>
   </PropertyGroup>
   <Import Project="proguard.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\build-tools\android-toolchain\android-toolchain.mdproj">
+      <Project>{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA}</Project>
+      <Name>android-toolchain</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
The [Linux build][0] is [broken][1]:

	Executing: /home/builder/android-toolchain/ant/bin/ant -verbose -f buildscripts/build.xml proguard
	...
	/tmp/tmp569f00ba.tmp: 1: /tmp/tmp569f00ba.tmp: /home/builder/android-toolchain/ant/bin/ant: not found

`proguard.mdproj` can't be built because `ant` can't be found.

This is particularly odd because commit aa3906e1 added support to
download and install `ant`, so *why isn't `ant` present*?!

Reading the log file was particularly annoying because I could find no
mention of `android-toolchain.mdproj` in the log file.

...which is of course the likely problem: `android-toolchain.mdproj`
*isn't being built*, which would explain why `ant` is missing!

Why isn't `android-toolchain.mdproj` being built before
`proguard.mdproj` is built? Because `proguard.mdproj` didn't contain
any `@(ProjectReference)`s so other projects are built earlier.

The fix: Add a `@(ProjectReference)` to `android-toolchain.mdproj`
within `proguard.mdproj`.

Additionally, cleanup `android-toolchain.mdproj` so that the
Ant-related files are listed as outputs of the `_DownloadItems`
target, by refactoring into a new `@(_DownloadedItem)` group.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-linux/248/
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-linux/248/consoleText