### PR TITLE
[Xamarin.Android.Build.Tasks] AAPT packaging error ignored

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidToolTask.cs
@@ -73,11 +73,16 @@ namespace Xamarin.Android.Tasks
 		/* This gets pre-pended to any filenames that we get from error strings */
 		protected string BaseDirectory { get; set; }
 
+		// Aapt errors looks like this:
+		//   res\layout\main.axml:7: error: No resource identifier found for attribute 'id2' in package 'android' (TaskId:22)
+		//   Resources/values/theme.xml(2): error APT0000: Error retrieving parent for item: No resource found that matches the given name '@android:style/Theme.AppCompat'.
+		//   Resources/values/theme.xml:2: error APT0000: Error retrieving parent for item: No resource found that matches the given name '@android:style/Theme.AppCompat'.
+		// Look for them and convert them to MSBuild compatible errors.
 		static Regex androidErrorRegex;
-		static Regex AndroidErrorRegex {
+		internal static Regex AndroidErrorRegex {
 			get {
 				if (androidErrorRegex == null)
-					androidErrorRegex = new Regex (@"^(\s*(?<file>[^:]+):(?<line>\d*)?:\s+)*(?<level>\w+)\s*:\s*(?<message>.*)", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+					androidErrorRegex = new Regex (@"^(?<file>.+?)(([:(](?<line>\d+)[:)]):?\s*(error)\s*(?<level>\w*(?=:))):?(?<message>.*)", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 				return androidErrorRegex;
 			}
 		}


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=53054

The regex used to detect android tool errors was incorrect.
It looks like newer versions of the android tooling use brakets
rather than colons to delimit the file and line numbers.

This commit reworks the regex so it works with both the old
format and the new format. It also reworks the code so we do
not have a duplicate regex in Aapt. The existing regex in
AndroidToolTask has been made internal so that other classes
can use it. Normally we would derive from AndroidToolTask, but
in the case of Aapt we wanted to derive from AsyncTask so we could
run multiple calls in parallel.

This commit also fixes a bug where if Aapt failed for what ever reason
the parellel tasks were not cancelled.