### PR TITLE
[Xamarin.Android.Build.Tests] Make sure the build.logs are included in the output.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,10 @@ define RUN_NUNIT_TEST
 		$(if $(RUN),-run:$(RUN)) \
 		--result="TestResult-$(basename $(notdir $(1))).xml;format=nunit2" \
 		-output=bin/Test$(CONFIGURATION)/TestOutput-$(basename $(notdir $(1))).txt \
-	|| true ;
+	|| true ; \
+	if [ -f "bin/Test$(CONFIGURATION)/TestOutput-$(basename $(notdir $(1))).txt" ] ; then \
+		cat bin/Test$(CONFIGURATION)/TestOutput-$(basename $(notdir $(1))).txt ; \
+	fi
 endef
 
 run-nunit-tests: $(NUNIT_TESTS)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -99,18 +99,27 @@ namespace Xamarin.Android.Build.Tests
 		[TearDown]
 		protected virtual void CleanupTest ()
 		{
-			if (TestContext.CurrentContext.Result.Outcome.Status == NUnit.Framework.Interfaces.TestStatus.Passed) {
-				if (TestContext.CurrentContext.Test.Properties ["Output"] == null)
+			if (TestContext.CurrentContext.Test.Properties ["Output"] == null)
 					return;
-				// find the "root" directory just below "temp" and clean from there because
-				// some tests create multiple subdirectories
-				var output = Path.GetFullPath (((string [])TestContext.CurrentContext.Test.Properties ["Output"]) [0]);
-				while (!Directory.GetParent (output).Name.EndsWith ("temp", StringComparison.OrdinalIgnoreCase)) {
+			// find the "root" directory just below "temp" and clean from there because
+			// some tests create multiple subdirectories
+			var output = Path.GetFullPath (((string [])TestContext.CurrentContext.Test.Properties ["Output"]) [0]);
+			while (!Directory.GetParent (output).Name.EndsWith ("temp", StringComparison.OrdinalIgnoreCase)) {
 					output = Directory.GetParent (output).FullName;
-				}
-				if (Directory.Exists (output)) {
-					FileSystemUtils.SetDirectoryWriteable (output);
-					Directory.Delete (output, recursive: true);
+			}
+			if (!Directory.Exists (output))
+				return;
+			if (TestContext.CurrentContext.Result.Outcome.Status == NUnit.Framework.Interfaces.TestStatus.Passed) {
+				FileSystemUtils.SetDirectoryWriteable (output);
+				Directory.Delete (output, recursive: true);
+			} else {
+				foreach (var file in Directory.GetFiles (Path.Combine (output), "build.log", SearchOption.AllDirectories)) {
+					TestContext.Out.WriteLine ("*************************************************************************");
+					TestContext.Out.WriteLine (file);
+					TestContext.Out.WriteLine ();
+					TestContext.Out.WriteLine (File.ReadAllText (file));
+					TestContext.Out.WriteLine ("*************************************************************************");
+					TestContext.Out.Flush ();
 				}
 			}
 		}


### PR DESCRIPTION
One of the problems with the jenkins build is the logs from the
failed tests are not available on the website. This commit makes
sure that any tests that did not pass have the build.log information
written to the TestContext.Out. On jenkins this is setup to
write to a file in the bin\Test$(Configuration) directory.
The Makefile has also been updated to write this information
to the output. This will allow the data to appear in the raw
output log.