### PR TITLE
[Xamarin.Android.Build.Tasks] detect OS changes.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -999,6 +999,7 @@ because xbuild doesn't support framework reference assemblies.
 	<_PropertyCacheItems Include="AndroidUseLatestPlatformSdk=$(AndroidUseLatestPlatformSdk)" />
 	<_PropertyCacheItems Include="TargetFrameworkVersion=$(TargetFrameworkVersion)" />
 	<_PropertyCacheItems Include="AndroidCreatePackagePerAbi=$(AndroidCreatePackagePerAbi)" />
+	<_PropertyCacheItems Include="OS=$(OS)" />
 </ItemGroup>
 
 <Target Name="_ReadPropertiesCache">


### PR DESCRIPTION
If a user shares a project between Mac and Windows they
will probably get some errors. This is mainly because
the various cache's that are in place will contain
invalid paths.

This commit adds the $(OS) to the build.props file which
will allow us to detect if the OS changed.