### PR TITLE
[tests] Run `adb logcat -d` if any .apk tests fail

### DIFF
--- a/build-tools/scripts/UnitTestApks.targets
+++ b/build-tools/scripts/UnitTestApks.targets
@@ -58,6 +58,12 @@
 
   <Target Name="ReleaseAndroidTarget">
     <Adb
+        Condition="'@(_FailedComponent)' != ''"
+        Arguments="$(_EmuTarget) logcat -d"
+        ToolExe="$(AdbToolExe)"
+        ToolPath="$(AdbToolPath)"
+    />
+    <Adb
         Condition=" '$(_EmuTarget)' != '' "
         Arguments="$(_EmuTarget) emu kill"
         ToolExe="$(AdbToolExe)"


### PR DESCRIPTION
As noted in commit 3b893cd4, [PR 445][0] was showing up as a
successful build, while none of the .apk tests ran.

Commit 3b893cd4 "improves" matters by ensuring that we flag this as an
error, instead of blithely ignoring it.

Unfortunately, knowing that there's an error doesn't help in
diagnosing what the error *is*. In the case of segmentation faults,
the `INSTRUMENTATION_RESULT` messages will *not* be helpful.

What *would* be helpful is `adb logcat` output, which we don't
capture.

Let's fix that: if an error occurs -- e.g.
`RunInstrumentationTests.FailedToRun` is a non-empty string, which is
collected in the `@(_FailedComponent)` item group -- then we should
run `adb logcat -d` before terminating the emulator. This will cause
the build and test log output to contain `adb logcat` output, which
may provide *some* additional context regarding .apk failures.

[0]: https://github.com/xamarin/xamarin-android/pull/445