### PR TITLE
[Xamarin.Android.Build.Tasks] Avoid $ANDROID_SDK_PATH in build

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -11,8 +11,7 @@
 		_CopyExtractedMultiDexJar;
 		_BuildMonoSymbolicateScripts;
     </BuildDependsOn>
-    <_AndroidSdkLocation>$(ANDROID_SDK_PATH)</_AndroidSdkLocation>
-    <_AndroidSdkLocation Condition="'$(_AndroidSdkLocation)'==''">$(AndroidToolchainDirectory)\sdk</_AndroidSdkLocation>
+    <_AndroidSdkLocation Condition="'$(_AndroidSdkLocation)'==''">$(AndroidSdkDirectory)</_AndroidSdkLocation>
     <_MultiDexAarInAndroidSdk>extras\android\m2repository\com\android\support\multidex\1.0.1\multidex-1.0.1.aar</_MultiDexAarInAndroidSdk>
     <_SupportLicense Condition="Exists('$(_AndroidSdkLocation)\extras\android\m2repository\NOTICE.txt')">$(_AndroidSdkLocation)\extras\android\m2repository\NOTICE.txt</_SupportLicense>
     <_SupportLicense Condition="Exists('$(_AndroidSdkLocation)\extras\android\m2repository\m2repository\NOTICE.txt')">$(_AndroidSdkLocation)\extras\android\m2repository\m2repository\NOTICE.txt</_SupportLicense>


### PR DESCRIPTION
A co-worker is encountering a build error within
`Xamarin.Android.Build.Tasks.targets` because it can't find the file
`$(_AndroidSdkLocation)/extras/android/m2repository/com/android/support/multidex/1.0.1/multidex-1.0.1.aar`,
which in turn happens becausee `$(_AndroidSdkLocation)` has the
wrong value.

`$(_AndroidSdkLocation)` has the wrong value because the
`$ANDROID_SDK_PATH` environment variable was set, overriding to
`$(_AndroidSdkLocation)` to an invalid location -- a location which
doesn't contain `multidex-1.0.1.aar`.

Allowing `$(_AndroidSdkLocation)` to be overridden in this fashion is
no longer required, so remove the ability for `$ANDROID_SDK_PATH` to
alter where `multidex-1.0.1.aar` is looked for.