### PR TITLE
[build] `make leeroy` should build Xamarin.Android.sln

### DIFF
--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -78,9 +78,15 @@ TASK_ASSEMBLIES = $(foreach conf, $(CONFIGURATIONS), bin/$(conf)/lib/xbuild/Xama
 RUNTIME_LIBRARIES = $(foreach conf, $(CONFIGURATIONS), $(ALL_JIT_ABIS:%=bin/$(conf)/lib/xbuild/Xamarin/Android/lib/%/libmonosgen-2.0.so))
 FRAMEWORK_ASSEMBLIES = $(foreach conf, $(CONFIGURATIONS), $(FRAMEWORKS:%=bin/$(conf)/lib/xbuild-frameworks/MonoAndroid/%/Mono.Android.dll))
 
+.PHONY: leeroy jenkins leeroy-all
+
 jenkins: prepare leeroy $(ZIP_OUTPUT)
 
-leeroy: $(RUNTIME_LIBRARIES) $(TASK_ASSEMBLIES) $(FRAMEWORK_ASSEMBLIES) opentk-jcw
+leeroy: leeroy-all $(RUNTIME_LIBRARIES) $(TASK_ASSEMBLIES) $(FRAMEWORK_ASSEMBLIES) opentk-jcw
+
+leeroy-all:
+	$(foreach conf, $(CONFIGURATIONS), \
+		$(MSBUILD) $(MSBUILD_FLAGS) Xamarin.Android.sln /p:Configuration=$(conf) $(_MSBUILD_ARGS) ; )
 
 $(TASK_ASSEMBLIES): bin/%/lib/xbuild/Xamarin/Android/Xamarin.Android.Build.Tasks.dll:
 	$(MSBUILD) $(MSBUILD_FLAGS) /p:Configuration=$* $(_MSBUILD_ARGS) $(SOLUTION)


### PR DESCRIPTION
When building some internal repositories, we were encountering an
error due to an "inconsistent build environment":

	System.IO.FileNotFoundException: Could not load file or assembly
	'Xamarin.Android.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756'
	or one of its dependencies

Lots of head-scratching later, we still don't know what was *removing*
`external/Java.Interop/bin/Release/Xamarin.Android.Cecil.dll`, but to
some extent, *it doesn't matter* what removed it.

What matters is the sanity and consistency of the build tree.

The problem with `make leeroy` is that it tried to be "too smart for
its own good", just depending on *select* build artifacts, to prompt
`make` invocations to build those artifacts, *with the implication*
that *all the other* artifacts we needed would *also* be built.

This is sufficient for `make jenkins`, and similar environments where
you always start from a clean slate and build everything.

This is *not* sufficient for a developer tree. Because only "select"
outputs are known to make, *all other* outputs are ignored -- and
there are lots! -- and these other artifacts can be *important*.

We need a "known good" build tree. The only way to get that is to
build the top-level Xamarin.Android.sln, and `make leeroy` wasn't
ensuring that.

Update `make leeroy` to ensure that `Xamarin.Android.sln` is *always*
built. Worst case, it'll length build times.