### PR TITLE
[Mono.Android] Support building AndroidClientHandler with Roslyn

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -542,7 +542,8 @@ namespace Xamarin.Android.Net
 		/// <param name="conn">Pre-configured connection instance</param>
 		protected virtual Task SetupRequest (HttpRequestMessage request, HttpURLConnection conn)
 		{
-			return Task.Run (AssertSelf);
+			Action a = AssertSelf;
+			return Task.Run (a);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=53290

Building xamarin-android with Mono 4.9 and Roslyn results in a
compiler error on `AndroidClientHandler.cs`:

	Xamarin.Android.Net/AndroidClientHandler.cs(545,16):
	error CS0121: The call is ambiguous between the following methods or properties:
	'Task.Run(Action)' and 'Task.Run(Func<Task>)

The code in question:

	return Task.Run (AssertSelf);

(`AssertSelf()`, by the way, is `void AssertSelf()`, and is thus not
convertible to a `Func<Task>`...)

Fix this error by introducing an `Action` intermediate.