### PR TITLE
Support HTTP code 304 (Not Modified)

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -431,6 +431,11 @@ namespace Xamarin.Android.Net
 					redirectState.Method = HttpMethod.Get;
 					break;
 
+				case HttpStatusCode.NotModified:       // 304
+					disposeRet = false;
+					return true; // Not much happening here, just return and let the client decide
+						     // what to do with the response
+
 				case HttpStatusCode.TemporaryRedirect: // 307
 					break;
 


### PR DESCRIPTION
If the server responds with this code we should handle it by reading the headers
and content (if any, there should be no content) and return to the caller.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=52521