### PR TITLE
[monodroid] Register .pdb files

### DIFF
--- a/src/monodroid/jni/embedded-assemblies.h
+++ b/src/monodroid/jni/embedded-assemblies.h
@@ -3,7 +3,7 @@
 
 struct DylibMono;
 
-/* filename is e.g. System.dll, System.dll.mdb */
+/* filename is e.g. System.dll, System.dll.mdb, System.pdb */
 typedef int (*monodroid_should_register)(const char *filename, void *user_data);
 
 /* invoked for each assembly/debug symbol file to determine if the apk_file entry should be used */

--- a/src/monodroid/jni/monodroid-glue.c
+++ b/src/monodroid/jni/monodroid-glue.c
@@ -1933,7 +1933,7 @@ open_from_update_dir (MonoAssemblyName *aname, char **assemblies_path, void *use
 				result = mono.mono_assembly_open_full (fullpath, NULL, 0);
 			free (fullpath);
 			if (result) {
-				// TODO: register .mdb file
+				// TODO: register .mdb, .pdb file
 				break;
 			}
 		}


### PR DESCRIPTION
Commit 4e30546f packages Portable PDB files within the `.apk`.
Unfortunately, that's only half the problem; the other half is
actually *using* those Portable PDB files to obtain file names and
line numbers in stack traces when an error occurs.

Unfortunately, 4e30546f doesn't do that:

	at Android.Runtime.JNIEnv.Initialize (Android.Runtime.JnienvInitializeArgs*) [0x00017] in <5c33cab7ebc54a57a6538722a2e3fcfb>:0

What's missing is a call to `mono_register_symfile_for_assembly()`
with the `.pdb` contents. Currently, this is only done for `.mdb`
files, so even though we package .pdb files, they're not used.

Update `register_debug_symbols_for_assembly()` and
`gather_bundled_assemblies_from_apk()` to check for `.pdb` files in
addition to `.mdb` files, and register the contents of `.pdb` files
for their associated assembly.