### PR TITLE
[build] Write a download message for missing dependencies

### DIFF
--- a/build-tools/scripts/RequiredPrograms.targets
+++ b/build-tools/scripts/RequiredPrograms.targets
@@ -32,6 +32,11 @@
         Text="Could not find required program '%(RequiredProgram.Identity)'."
     />
     <Error
+        ContinueOnError="True"
+        Condition=" '$(_ReportError)' == 'True' And '@(_DownloadUrl)' != '' "
+        Text="Please download `%(_DownloadUrl.Url)` into `$(AndroidToolchainCacheDirectory)\%(Filename)%(Extension)`."
+    />
+    <Error
         Condition=" '$(_ReportError)' == 'True' And '$(_InstallCommand)' != '' "
         Text="Could not find required program '%(RequiredProgram.Identity)'. Please run: $(_InstallCommand)"
     />


### PR DESCRIPTION
Commit 2063ab79 tried to improve error messages when required
dependencies are missing. Unfortunately, there was one case not
considered: when `$(AutoProvision)` is False, and a dependency to
install needs to be downloaded.

For example, take [PR 445][0], which requires an updated mono.
If the system mono is unsuported, the required mono hasn't already
been downloaded, and `$(AutoProvision)` is False, then the following
"helpful" error message is provided:

	error : Could not find required program 'mono'. Please run:
	installer -pkg "$HOME/android-archives/MonoFramework-MDK-4.8.0.489.macos10.xamarin.universal.pkg" -target /

If `MonoFramework-MDK-4.8.0.489.macos10.xamarin.universal.pkg` hasn't
already been downloaded, then the suggested command will fail.

This is not helpful. :-)

Thus, when `$(AutoProvision)` is False and URLs need to be downloaded,
then provide a message stating that:

	Please download
	`https://.../MonoFramework-MDK-4.8.0.489.macos10.xamarin.universal.pkg`
	into `$HOME/android-archives/MonoFramework-MDK-4.8.0.489.macos10.xamarin.universal.pkg`.

[0]: https://github.com/xamarin/xamarin-android/pull/445