### PR TITLE
[Xamarin.Android.Build.Tasks] AAPT packaging error ignored (part 2)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AsyncTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AsyncTask.cs
@@ -121,7 +121,7 @@ namespace Xamarin.Android.Tasks
 			LogError (code, string.Format (message, messageArgs));
 		}
 
-		protected void LogError (string code, string message)
+		protected void LogError (string code, string message, string file = null, int lineNumber = 0)
 		{
 			if (UIThreadId == Thread.CurrentThread.ManagedThreadId) {
 				#pragma warning disable 618
@@ -129,8 +129,8 @@ namespace Xamarin.Android.Tasks
 					subcategory: null,
 					errorCode: code,
 					helpKeyword: null,
-					file: null,
-					lineNumber: 0,
+					file: file,
+					lineNumber: lineNumber,
 					columnNumber: 0,
 					endLineNumber: 0,
 					endColumnNumber: 0,
@@ -144,8 +144,8 @@ namespace Xamarin.Android.Tasks
 				errorMessageQueue.Enqueue (new BuildErrorEventArgs (
 					subcategory: null,
 					code: code,
-					file: null,
-					lineNumber: 0,
+					file: file,
+					lineNumber: lineNumber,
 					columnNumber: 0,
 					endLineNumber: 0,
 					endColumnNumber: 0,
@@ -221,7 +221,7 @@ namespace Xamarin.Android.Tasks
 				while (errorMessageQueue.Count > 0) {
 					var args = (BuildErrorEventArgs)errorMessageQueue.Dequeue ();
 					#pragma warning disable 618
-					Log.LogCodedError (args.Code, args.Message);
+					Log.LogCodedError (args.Code, file: args.File, lineNumber: args.LineNumber, message: args.Message);
 					#pragma warning restore 618
 				}
 				errorDataAvailable.Reset ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -423,6 +423,53 @@ namespace UnnamedProject
 		}
 
 		[Test]
+		public void CheckAaptErrorRaisedForMissingResource ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			var main = proj.AndroidResources.First (x => x.Include () == "Resources\\layout\\Main.axml");
+			main.TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
+<LinearLayout xmlns:android=""http://schemas.android.com/apk/res/android""
+	android:orientation=""vertical""
+	android:layout_width=""fill_parent""
+	android:layout_height=""fill_parent""
+	>
+<Button  
+	android:id=""@id/myButton""
+	android:layout_width=""fill_parent"" 
+	android:layout_height=""wrap_content"" 
+	android:text=""@string/foo""
+	/>
+</LinearLayout>";
+			var projectPath = string.Format ("temp/CheckAaptErrorRaisedForMissingResource");
+			using (var b = CreateApkBuilder (Path.Combine (projectPath, "UnamedApp"), false, false)) {
+				b.Verbosity = LoggerVerbosity.Diagnostic;
+				b.ThrowOnBuildFailure = false;
+				Assert.IsFalse (b.Build (proj), "Build should have failed");
+				StringAssert.Contains ("APT0000: ", b.LastBuildOutput);
+				StringAssert.Contains ("2 Error(s)", b.LastBuildOutput);
+			}
+		}
+
+		[Test]
+		public void CheckAaptErrorRaisedForInvalidDirectoryName ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.AndroidResources.Add (new AndroidItem.AndroidResource("Resources\\booboo\\stuff.xml") {
+				TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
+<resources>
+</resources>"
+			});
+			var projectPath = string.Format ("temp/CheckAaptErrorRaisedForInvalidDirectoryName");
+			using (var b = CreateApkBuilder (Path.Combine (projectPath, "UnamedApp"), false, false)) {
+				b.Verbosity = LoggerVerbosity.Diagnostic;
+				b.ThrowOnBuildFailure = false;
+				Assert.IsFalse (b.Build (proj), "Build should have failed");
+				StringAssert.Contains ("APT0000: ", b.LastBuildOutput);
+				StringAssert.Contains ("1 Error(s)", b.LastBuildOutput);
+			}
+		}
+
+		[Test]
 		public void CheckAaptErrorRaisedForDuplicateResourceinApp ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -440,6 +487,7 @@ namespace UnnamedProject
 				b.ThrowOnBuildFailure = false;
 				Assert.IsFalse (b.Build (proj), "Build should have failed");
 				StringAssert.Contains ("APT0000: ", b.LastBuildOutput);
+				StringAssert.Contains ("1 Error(s)", b.LastBuildOutput);
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -108,19 +108,12 @@ namespace Bug12935
 				Assert.AreEqual ("sensorPortrait", screenOrientation.Value, "screenOrientation for targetSdkVersion 16 should have been sensorPortrait");
 
 				builder.Cleanup ();
+				builder.ThrowOnBuildFailure = false;
 				proj.TargetFrameworkVersion = "v4.0.3";
 				proj.AndroidManifest = string.Format (TargetSdkManifest, "15");
-				Assert.IsTrue (builder.Build (proj), "Build for TargetFrameworkVersion 15 should have succeeded");
-
-				doc = XDocument.Load (manifestFile);
-				usesSdk = doc.XPathSelectElement ("/manifest/uses-sdk");
-				Assert.IsNotNull (usesSdk, "Failed to read the uses-sdk element");
-				targetSdk = usesSdk.Attribute (targetSdkXName);
-				Assert.AreEqual ("15", targetSdk.Value, "targetSdkVersion should have been 15");
-				activityElement = doc.XPathSelectElement ("/manifest/application/activity");
-				Assert.IsNotNull (activityElement, "Failed to read the activity element");
-				screenOrientation = activityElement.Attribute (screenOrientationXName);
-				Assert.AreEqual ("sensorPortait", screenOrientation.Value, "screenOrientation for targetSdkVersion 15 should have been sensorPortait");
+				Assert.IsFalse (builder.Build (proj), "Build for TargetFrameworkVersion 15 should have failed");
+				StringAssert.Contains ("APT0000: ", builder.LastBuildOutput);
+				StringAssert.Contains ("1 Error(s)", builder.LastBuildOutput);
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MSBuildExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MSBuildExtensions.cs
@@ -111,6 +111,11 @@ namespace Xamarin.Android.Tasks
 			log.LogError (string.Empty, code, string.Empty, string.Empty, 0, 0, 0, 0, message, messageArgs);
 		}
 
+		public static void LogCodedError (this TaskLoggingHelper log, string code, string file, int lineNumber, string message, params object[] messageArgs)
+		{
+			log.LogError (string.Empty, code, string.Empty, file, lineNumber, 0, 0, 0, message, messageArgs);
+		}
+
 		public static void LogCodedWarning (this TaskLoggingHelper log, string code, string message, params object [] messageArgs)
 		{
 			log.LogWarning (


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=53054

The RegEx was fixed in commit 252fa10e. However that was not
the entire problem. Firstly there was a change of the aapt
process exiting before all the output was processed. Which would
mean could miss out on messages. Secondly occasionally just
logging High priority messages with an "error" format did NOT
result in that being turned into an error.

So we need to rework the code to raise actual Errors! along with
file and line numbers. This give us a consistent experience.

This highlighted a bug in one of the unit tests specifically Bug12935.
In this test we were expecting a build to work when targeting API
15 (v4.0.3) if it used the screenOrientation value of sensorPortait.
However it turns out that the google tooling has been reporting that
usage as an AAPT error for a loooong time. This bug however was masking
it.

So this commit also fixes up that test to make sure that the build
does fail with the appropriate error message.