### PR TITLE
[Xamarin.Android.Build.Tasks] Hitting "System.IO.IOException: Too many open files" when building a large app with AOT and all supported architectures

### DIFF
--- a/build-tools/unix-distribution-setup/unix-distribution-setup.targets
+++ b/build-tools/unix-distribution-setup/unix-distribution-setup.targets
@@ -9,6 +9,14 @@
         Condition=" '$(HostOS)' != 'Windows' "
         Command="chmod +x $(OutputPath)bin\generator"
     />
+    <Exec
+        Condition=" '$(HostOS)' != 'Windows' "
+        Command="chmod +x $(OutputPath)bin\cross*"
+    />
+    <Exec
+        Condition=" '$(HostOS)' != 'Windows' "
+        Command="chmod +x $(OutputPath)bin\llc"
+    />
   </Target>
 
   <Target Name="Clean">

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -99,36 +99,37 @@ namespace Xamarin.Android.Tasks
 				WindowStyle = ProcessWindowStyle.Hidden,
 			};
 
-			var proc = new Process ();
-			proc.OutputDataReceived += (sender, e) => {
-				if (e.Data != null)
-					LogEventsFromTextOutput (e.Data, MessageImportance.Normal);
-				else
-					stdout_completed.Set ();
-			};
-			proc.ErrorDataReceived += (sender, e) => {
-				if (e.Data != null)
-					LogEventsFromTextOutput (e.Data, MessageImportance.Normal);
-				else
-					stderr_completed.Set ();
-			};
-			proc.StartInfo = psi;
-			proc.Start ();
-			proc.BeginOutputReadLine ();
-			proc.BeginErrorReadLine ();
-			Token.Register (() => {
-				try {
-					proc.Kill ();
-				} catch (Exception) {
-				}
-			});
-			LogDebugMessage ("Executing {0}", commandLine);
-			proc.WaitForExit ();
-			if (psi.RedirectStandardError)
-				stderr_completed.WaitOne (TimeSpan.FromSeconds (30));
-			if (psi.RedirectStandardOutput)
-				stdout_completed.WaitOne (TimeSpan.FromSeconds (30));
-			return proc.ExitCode == 0;
+			using (var proc = new Process ()) {
+				proc.OutputDataReceived += (sender, e) => {
+					if (e.Data != null)
+						LogEventsFromTextOutput (e.Data, MessageImportance.Normal);
+					else
+						stdout_completed.Set ();
+				};
+				proc.ErrorDataReceived += (sender, e) => {
+					if (e.Data != null)
+						LogEventsFromTextOutput (e.Data, MessageImportance.Normal);
+					else
+						stderr_completed.Set ();
+				};
+				proc.StartInfo = psi;
+				proc.Start ();
+				proc.BeginOutputReadLine ();
+				proc.BeginErrorReadLine ();
+				Token.Register (() => {
+					try {
+						proc.Kill ();
+					} catch (Exception) {
+					}
+				});
+				LogDebugMessage ("Executing {0}", commandLine);
+				proc.WaitForExit ();
+				if (psi.RedirectStandardError)
+					stderr_completed.WaitOne (TimeSpan.FromSeconds (30));
+				if (psi.RedirectStandardOutput)
+					stdout_completed.WaitOne (TimeSpan.FromSeconds (30));
+				return proc.ExitCode == 0;
+			}
 		}
 
 		bool ExecuteForAbi (string cmd, string currentResourceOutputFile)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -116,34 +116,44 @@ namespace Xamarin.Android.Tasks
 			ArchiveFileList files = new ArchiveFileList ();
 			if (apkInputPath != null)
 				File.Copy (apkInputPath, apkOutputPath + "new", overwrite: true);
-			using (var apk = ZipArchive.Open (apkOutputPath + "new", apkInputPath != null ? FileMode.Open : FileMode.Create )) {
-				apk.AddEntry ("NOTICE",
+			using (var apk = new ZipArchiveEx (apkOutputPath + "new", apkInputPath != null ? FileMode.Open : FileMode.Create )) {
+				apk.Archive.AddEntry ("NOTICE",
 						Assembly.GetExecutingAssembly ().GetManifestResourceStream ("NOTICE.txt"));
 
 				// Add classes.dx
-				apk.AddFiles (DalvikClasses, useFileDirectories: false);
+				apk.Archive.AddFiles (DalvikClasses, useFileDirectories: false);
 
 				if (EmbedAssemblies && !BundleAssemblies)
 					AddAssemblies (apk);
 
 				AddEnvironment (apk);
 				AddRuntimeLibraries (apk, supportedAbis);
+				apk.Flush();
 				AddNativeLibraries (files, supportedAbis);
+				apk.Flush();
 				AddAdditionalNativeLibraries (files, supportedAbis);
+				apk.Flush();
 				AddNativeLibrariesFromAssemblies (apk, supportedAbis);
+				apk.Flush();
 
 				foreach (ITaskItem typemap in TypeMappings) {
-					apk.AddFile (typemap.ItemSpec, Path.GetFileName(typemap.ItemSpec), compressionMethod: CompressionMethod.Store);
+					apk.Archive.AddFile (typemap.ItemSpec, Path.GetFileName(typemap.ItemSpec), compressionMethod: CompressionMethod.Store);
 				}
 
+				int count = 0;
 				foreach (var file in files) {
 					var item = Path.Combine (file.Item2, Path.GetFileName (file.Item1))
 						.Replace (Path.DirectorySeparatorChar, '/');
-					if (apk.ContainsEntry (item)) {
+					if (apk.Archive.ContainsEntry (item)) {
 						Log.LogWarning (null, "XA4301", null, file.Item1, 0, 0, 0, 0, "Apk already contains the item {0}; ignoring.", item);
 						continue;
 					}
-					apk.AddFile (file.Item1, item);
+					apk.Archive.AddFile (file.Item1, item);
+					count++;
+					if (count == ZipArchiveEx.ZipFlushLimit) {
+						apk.Flush();
+						count = 0;
+					}
 				}
 				if (_Debug)
 					AddGdbservers (apk, files, supportedAbis, debugServer);
@@ -160,6 +170,7 @@ namespace Xamarin.Android.Tasks
 				var jarFilePaths = libraryProjectJars.Concat (jarFiles != null ? jarFiles.Select (j => j.ItemSpec) : Enumerable.Empty<string> ());
 				jarFilePaths = MonoAndroidHelper.DistinctFilesByContent (jarFilePaths);
 
+				count = 0;
 				foreach (var jarFile in jarFilePaths) {
 					using (var jar = ZipArchive.Open (File.OpenRead (jarFile))) {
 						foreach (var jarItem in jar.Where (ze => !ze.IsDirectory && !ze.FullName.StartsWith ("META-INF") && !ze.FullName.EndsWith (".class") && !ze.FullName.EndsWith (".java") && !ze.FullName.EndsWith ("MANIFEST.MF"))) {
@@ -168,15 +179,20 @@ namespace Xamarin.Android.Tasks
 								jarItem.Extract (d);
 								data = d.ToArray ();
 							}
-							if (apk.Any (e => e.FullName == jarItem.FullName))
+							if (apk.Archive.Any (e => e.FullName == jarItem.FullName))
 								Log.LogMessage ("Warning: failed to add jar entry {0} from {1}: the same file already exists in the apk", jarItem.FullName, Path.GetFileName (jarFile));
 							else
-								apk.AddEntry (data, jarItem.FullName);
+								apk.Archive.AddEntry (data, jarItem.FullName);
 						}
+					}
+					count++;
+					if (count == ZipArchiveEx.ZipFlushLimit) {
+						apk.Flush();
+						count = 0;
 					}
 				}
 				if (StubApplicationDataFile != null && File.Exists (StubApplicationDataFile))
-					apk.AddFile (StubApplicationDataFile, Path.GetFileName (StubApplicationDataFile));
+					apk.Archive.AddFile (StubApplicationDataFile, Path.GetFileName (StubApplicationDataFile));
 			}
 			MonoAndroidHelper.CopyIfZipChanged (apkOutputPath + "new", apkOutputPath);
 			File.Delete (apkOutputPath + "new");
@@ -249,14 +265,15 @@ namespace Xamarin.Android.Tasks
 			return !Log.HasLoggedErrors;
 		}
 
-		private void AddAssemblies (ZipArchive apk)
+		private void AddAssemblies (ZipArchiveEx apk)
 		{
 			bool debug = _Debug;
 			bool use_shared_runtime = String.Equals (UseSharedRuntime, "true", StringComparison.OrdinalIgnoreCase);
 
+			int count = 0;
 			foreach (ITaskItem assembly in ResolvedUserAssemblies) {
 				// Add assembly
-				apk.AddFile (assembly.ItemSpec, GetTargetDirectory (assembly.ItemSpec) + "/"  + Path.GetFileName (assembly.ItemSpec), compressionMethod: CompressionMethod.Store);
+				apk.Archive.AddFile (assembly.ItemSpec, GetTargetDirectory (assembly.ItemSpec) + "/"  + Path.GetFileName (assembly.ItemSpec), compressionMethod: CompressionMethod.Store);
 
 				// Try to add config if exists
 				var config = Path.ChangeExtension (assembly.ItemSpec, "dll.config");
@@ -267,21 +284,27 @@ namespace Xamarin.Android.Tasks
 					var symbols = Path.ChangeExtension (assembly.ItemSpec, "dll.mdb");
 
 					if (File.Exists (symbols))
-						apk.AddFile (symbols, "assemblies/" + Path.GetFileName (symbols), compressionMethod: CompressionMethod.Store);
+						apk.Archive.AddFile (symbols, "assemblies/" + Path.GetFileName (symbols), compressionMethod: CompressionMethod.Store);
 
 					symbols = Path.ChangeExtension (assembly.ItemSpec, "pdb");
 
 					if (File.Exists (symbols))
-						apk.AddFile (symbols, "assemblies/" + Path.GetFileName (symbols), compressionMethod: CompressionMethod.Store);
+						apk.Archive.AddFile (symbols, "assemblies/" + Path.GetFileName (symbols), compressionMethod: CompressionMethod.Store);
+				}
+				count++;
+				if (count == ZipArchiveEx.ZipFlushLimit) {
+					apk.Flush();
+					count = 0;
 				}
 			}
 
 			if (use_shared_runtime)
 				return;
 
+			count = 0;
 			// Add framework assemblies
 			foreach (ITaskItem assembly in ResolvedFrameworkAssemblies) {
-				apk.AddFile (assembly.ItemSpec, "assemblies/" + Path.GetFileName (assembly.ItemSpec), compressionMethod: CompressionMethod.Store);
+				apk.Archive.AddFile (assembly.ItemSpec, "assemblies/" + Path.GetFileName (assembly.ItemSpec), compressionMethod: CompressionMethod.Store);
 				var config = Path.ChangeExtension (assembly.ItemSpec, "dll.config");
 				AddAssemblyConfigEntry (apk, config);
 				// Try to add symbols if Debug
@@ -289,17 +312,22 @@ namespace Xamarin.Android.Tasks
 					var symbols = Path.ChangeExtension (assembly.ItemSpec, "dll.mdb");
 
 					if (File.Exists (symbols))
-						apk.AddFile (symbols, "assemblies/" + Path.GetFileName (symbols), compressionMethod: CompressionMethod.Store);
+						apk.Archive.AddFile (symbols, "assemblies/" + Path.GetFileName (symbols), compressionMethod: CompressionMethod.Store);
 
 					symbols = Path.ChangeExtension (assembly.ItemSpec, "pdb");
 
 					if (File.Exists (symbols))
-						apk.AddFile (symbols, "assemblies/" + Path.GetFileName (symbols), compressionMethod: CompressionMethod.Store);
+						apk.Archive.AddFile (symbols, "assemblies/" + Path.GetFileName (symbols), compressionMethod: CompressionMethod.Store);
+				}
+				count++;
+				if (count == ZipArchiveEx.ZipFlushLimit) {
+					apk.Flush();
+					count = 0;
 				}
 			}
 		}
 
-		void AddAssemblyConfigEntry (ZipArchive apk, string configFile)
+		void AddAssemblyConfigEntry (ZipArchiveEx apk, string configFile)
 		{
 			if (!File.Exists (configFile))
 				return;
@@ -309,7 +337,7 @@ namespace Xamarin.Android.Tasks
 				source.CopyTo (dest);
 				dest.WriteByte (0);
 				dest.Position = 0;
-				apk.AddEntry ("assemblies/" + Path.GetFileName (configFile), dest, compressionMethod: CompressionMethod.Store);
+				apk.Archive.AddEntry ("assemblies/" + Path.GetFileName (configFile), dest, compressionMethod: CompressionMethod.Store);
 			}
 		}
 
@@ -322,7 +350,7 @@ namespace Xamarin.Android.Tasks
 			return "assemblies";
 		}
 
-		void AddEnvironment (ZipArchive apk)
+		void AddEnvironment (ZipArchiveEx apk)
 		{
 			var environment = new StringWriter () {
 				NewLine = "\n",
@@ -395,7 +423,7 @@ namespace Xamarin.Android.Tasks
 					environment.WriteLine ("MONO_GC_PARAMS=major=marksweep");
 			}
 
-			apk.AddEntry ("environment", environment.ToString (),
+			apk.Archive.AddEntry ("environment", environment.ToString (),
 					new UTF8Encoding (encoderShouldEmitUTF8Identifier:false));
 		}
 
@@ -431,13 +459,13 @@ namespace Xamarin.Android.Tasks
 			return results;
 		}
 
-		void AddNativeLibrary (ZipArchive apk, string abi, string filename)
+		void AddNativeLibrary (ZipArchiveEx apk, string abi, string filename)
 		{
 			var path    = Path.Combine (MSBuildXamarinAndroidDirectory, "lib", abi, filename);
-			apk.AddEntry (string.Format ("lib/{0}/{1}", abi, filename), File.OpenRead (path));
+			apk.Archive.AddEntry (string.Format ("lib/{0}/{1}", abi, filename), File.OpenRead (path));
 		}
 
-		void AddProfilers (ZipArchive apk, string abi)
+		void AddProfilers (ZipArchiveEx apk, string abi)
 		{
 			if (!string.IsNullOrEmpty (AndroidEmbedProfilers)) {
 				foreach (var profiler in ParseProfilers (AndroidEmbedProfilers)) {
@@ -447,7 +475,7 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		void AddBtlsLibs (ZipArchive apk, string abi)
+		void AddBtlsLibs (ZipArchiveEx apk, string abi)
 		{
 			if (string.Compare ("btls", TlsProvider, StringComparison.OrdinalIgnoreCase) == 0) {
 				AddNativeLibrary (apk, abi, "libmono-btls-shared.so");
@@ -457,14 +485,14 @@ namespace Xamarin.Android.Tasks
 			//  * "legacy":
 		}
 
-		void AddRuntimeLibraries (ZipArchive apk, string supportedAbis)
+		void AddRuntimeLibraries (ZipArchiveEx apk, string supportedAbis)
 		{
 			bool use_shared_runtime = String.Equals (UseSharedRuntime, "true", StringComparison.OrdinalIgnoreCase);
 			var abis = supportedAbis.Split (new char[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
 			foreach (var abi in abis) {
 				string library = string.Format ("libmono-android.{0}.so", _Debug ? "debug" : "release");
 				var path = Path.Combine (MSBuildXamarinAndroidDirectory, "lib", abi, library);
-				apk.AddEntry (string.Format ("lib/{0}/libmonodroid.so", abi), File.OpenRead (path));
+				apk.Archive.AddEntry (string.Format ("lib/{0}/libmonodroid.so", abi), File.OpenRead (path));
 				if (!use_shared_runtime) {
 					// include the sgen
 					AddNativeLibrary (apk, abi, "libmonosgen-2.0.so");
@@ -474,8 +502,9 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		void AddNativeLibrariesFromAssemblies (ZipArchive apk, string supportedAbis)
+		void AddNativeLibrariesFromAssemblies (ZipArchiveEx apk, string supportedAbis)
 		{
+			int count = 0;
 			var abis = supportedAbis.Split (new char[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
 			using (var res = new DirectoryAssemblyResolver (Console.WriteLine, loadDebugSymbols: false)) {
 			foreach (var assembly in EmbeddedNativeLibraryAssemblies)
@@ -493,18 +522,23 @@ namespace Xamarin.Android.Tasks
 									if (e.IsDirectory)
 										continue;
 									var key = e.FullName.Replace ("native_library_imports", "lib");
-									if (apk.Any (k => k.FullName == key)) {
+									if (apk.Archive.Any (k => k.FullName == key)) {
 										Log.LogCodedWarning ("4301", "Apk already contains the item {0}; ignoring.", key);
 										continue;
 									}
 									using (var s = new MemoryStream ()) {
 										e.Extract (s);
 										s.Position = 0;
-										apk.AddEntry (s.ToArray (), key);
+										apk.Archive.AddEntry (s.ToArray (), key);
 									}
 								}
 							}
 						}
+					}
+					count++;
+					if (count == ZipArchiveEx.ZipFlushLimit) {
+						apk.Flush();
+						count = 0;
 					}
 				}
 			}
@@ -566,11 +600,12 @@ namespace Xamarin.Android.Tasks
 			files.Add (new Tuple<string, string> (path, string.Format ("lib/{0}", abi)));
 		}
 
-		private void AddGdbservers (ZipArchive apk, ArchiveFileList files, string supportedAbis, AndroidDebugServer debugServer)
+		private void AddGdbservers (ZipArchiveEx apk, ArchiveFileList files, string supportedAbis, AndroidDebugServer debugServer)
 		{
 			if (string.IsNullOrEmpty (AndroidNdkDirectory))
 				return;
 
+			int count = 0;
 			foreach (var sabi in supportedAbis.Split (new char[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)) {
 				var arch = GdbPaths.GetArchFromAbi (sabi);
 				var abi  = GdbPaths.GetAbiFromArch (arch);
@@ -585,7 +620,12 @@ namespace Xamarin.Android.Tasks
 				if (!File.Exists (debugServerPath))
 					continue;
 				Log.LogDebugMessage ("Adding {0} debug server '{1}' to the APK as '{2}'", sabi, debugServerPath, entryName);
-				apk.AddEntry (entryName, File.OpenRead (debugServerPath));
+				apk.Archive.AddEntry (entryName, File.OpenRead (debugServerPath));
+				count++;
+				if (count == ZipArchiveEx.ZipFlushLimit) {
+					apk.Flush();
+					count = 0;
+				}
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -17,8 +17,8 @@ namespace Xamarin.Android.Build.Tests
 		public void AllProjectsHaveSameOutputDirectory()
 		{
 			var testPath = Path.Combine ("temp", "AllProjectsHaveSameOutputDirectory");
-			var sb = new SolutionBuilder () {
-				SolutionPath = Path.Combine (Root, testPath, "AllProjectsHaveSameOutputDirectory.sln"),
+			var sb = new SolutionBuilder("AllProjectsHaveSameOutputDirectory.sln") {
+				SolutionPath = Path.Combine (Root, testPath),
 				Verbosity = LoggerVerbosity.Diagnostic,
 			};
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/SolutionBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/SolutionBuilder.cs
@@ -10,17 +10,19 @@ namespace Xamarin.ProjectTools
 	{
 		public IList<XamarinProject> Projects { get; }
 		public string SolutionPath { get; set; }
+		public string SolutionName { get; set; }
 		public bool BuildSucceeded { get; set; }
 
-		public SolutionBuilder () : base()
+		public SolutionBuilder (string solutionName) : base()
 		{
+			SolutionName = solutionName;
 			Projects = new List<XamarinProject> ();
 		}
 
 		public void Save ()
 		{
 			foreach (var p in Projects) {
-				using (var pb = new ProjectBuilder (Path.Combine (Path.GetDirectoryName (SolutionPath), p.ProjectName))) {
+				using (var pb = new ProjectBuilder (Path.Combine (SolutionPath, p.ProjectName))) {
 					pb.Save (p);
 				}
 			}
@@ -47,27 +49,33 @@ namespace Xamarin.ProjectTools
 			}
 			sb.Append ("\tEndGlobalSection\n");
 			sb.Append ("EndGlobal\n");
-			File.WriteAllText (SolutionPath, sb.ToString ());
+			File.WriteAllText (Path.Combine (SolutionPath, SolutionName), sb.ToString ());
 		}
 
-		public bool Build ()
+		public bool BuildProject(XamarinProject project, string target = "Build")
 		{
-			Save ();
-			BuildSucceeded = BuildInternal (SolutionPath, "Build");
+			BuildSucceeded = BuildInternal(Path.Combine (SolutionPath, project.ProjectName, project.ProjectFilePath), target);
 			return BuildSucceeded;
 		}
 
-		public bool ReBuild ()
+		public bool Build (params string[] parameters)
 		{
 			Save ();
-			BuildSucceeded = BuildInternal (SolutionPath, "ReBuild");
+			BuildSucceeded = BuildInternal (Path.Combine (SolutionPath, SolutionName), "Build", parameters);
 			return BuildSucceeded;
 		}
 
-		public bool Clean ()
+		public bool ReBuild(params string[] parameters)
 		{
 			Save ();
-			BuildSucceeded = BuildInternal (SolutionPath, "Clean");
+			BuildSucceeded = BuildInternal(Path.Combine(SolutionPath, SolutionName), "ReBuild", parameters);
+			return BuildSucceeded;
+		}
+
+		public bool Clean(params string[] parameters)
+		{
+			Save ();
+			BuildSucceeded = BuildInternal(Path.Combine(SolutionPath, SolutionName), "Clean", parameters);
 			return BuildSucceeded;
 		}
 
@@ -75,7 +83,7 @@ namespace Xamarin.ProjectTools
 		{
 			if (disposing)
 				if (BuildSucceeded)
-					Directory.Delete (Path.GetDirectoryName (SolutionPath), recursive: true);
+					Directory.Delete (SolutionPath, recursive: true);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
@@ -1,21 +1,33 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using Xamarin.Tools.Zip;
 
 namespace Xamarin.Android.Tasks
 {
 	public class ZipArchiveEx : IDisposable
 	{
+
+		public static int ZipFlushLimit = 50;
+
 		ZipArchive zip;
 		string archive;
 
-		public ZipArchiveEx (string archive)
-		{
-			this.archive = archive;
-			zip = ZipArchive.Open (archive, FileMode.CreateNew);
+		public ZipArchive Archive {
+			get { return zip; }
 		}
 
-		void Flush ()
+		public ZipArchiveEx (string archive) : this (archive, FileMode.CreateNew)
+		{
+		}
+
+		public ZipArchiveEx(string archive, FileMode filemode)
+		{
+			this.archive = archive;
+			zip = ZipArchive.Open(archive, filemode);
+		}
+
+		public void Flush ()
 		{
 			if (zip != null) {
 				zip.Close ();
@@ -51,7 +63,7 @@ namespace Xamarin.Android.Tasks
 					continue;
 				zip.AddFile (fileName, ArchiveNameForFile (fileName, folderInArchive));
 				count++;
-				if (count == 50) {
+				if (count == ZipArchiveEx.ZipFlushLimit) {
 					Flush ();
 					count = 0;
 				}


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=53122

There is a problem with libzip in that is does not have an
API for Flushing the current items in memory to disk.
This was why ZipArchiveEx was introduced in commit 9166e03.
This commit reworks the BuildApk task to make sure of this
new functinality and to periodically flush the zip to disk.
This will reduce the chances of running out of memory.

It also adds a unit test which generates and builds an app
which has a large number of refernces and assets. This app
also gets AOT'd so it should be pushing the system to the limit.

Also added code to make sure the cross tools and llc have
execute permissions.

Added code to make sure we dispose of each process in the Aapt and
Aot tasks. This is to ensure any files or pipes these processed have
are removed as soon as possible.

Updated the unix-distribution-setup.targets to ensure that the cross-arm
tooling and llc have the correct execute permissions on MacOS and Linux.