### PR TITLE
[xa-prep-tasks] Cap git hash length to 7 characters

### DIFF
--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitCommitHash.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitCommitHash.cs
@@ -11,6 +11,8 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 {
 	public sealed class GitCommitHash : Git
 	{
+		public                  int         RequiredHashLength          { get; set; } = 7;
+
 		[Output]
 		public                  string      AbbreviatedCommitHash       { get; set; }
 
@@ -43,7 +45,11 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 		{
 			if (string.IsNullOrEmpty (singleLine))
 				return;
-			AbbreviatedCommitHash   = singleLine;
+			if (singleLine.Length < RequiredHashLength) {
+				Log.LogError ("Abbreviated commit hash `{0}` is shorter than required length of {1} characters", singleLine, RequiredHashLength);
+				return;
+			}
+			AbbreviatedCommitHash = singleLine.Substring (0, RequiredHashLength);
 		}
 	}
 }


### PR DESCRIPTION
The `git` commit hash, as produced by `git log` and the
`<GitCommitHash/>` task, has an inconsistent length (!).

On my machine and on the Jenkins macOS machine, the output of
`git log --no-color --first-parent -n1 --pretty=format:%h` is
7 characters.

However, on co-worker's machines -- on macOS and with both the same
and different `git` versions -- the length of `git log ...` is instead
*8* characters or *11* characters.

This is problematic because the git commit hash is used in
`GetBundleFileName` -- in `build-tools/bundle/bundle-path.targets` --
to construct the `bundle*.zip` filename to download for build caching.
If the `<GitCommitHash/>` output differs, then the constructed
filename will differ, resulting in an HTTP-404 when trying to find the
cache, and thus an eventual (undesirable) mono build because we
couldn't download a prebuilt mono build.

Fix this by *truncating* the output of `<GitCommitHash/>` to 7
characters, ensuring that we'll be able to use existing bundle files.