### PR TITLE
[Xamarin.Android.Build.Tasks] Improve Aapt output processing

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -101,10 +101,16 @@ namespace Xamarin.Android.Tasks
 
 			var proc = new Process ();
 			proc.OutputDataReceived += (sender, e) => {
-				LogEventsFromTextOutput (e.Data, MessageImportance.Normal);
+				if (e.Data != null)
+					LogEventsFromTextOutput (e.Data, MessageImportance.Normal);
+				else
+					stdout_completed.Set ();
 			};
 			proc.ErrorDataReceived += (sender, e) => {
-				LogEventsFromTextOutput (e.Data, MessageImportance.Normal);
+				if (e.Data != null)
+					LogEventsFromTextOutput (e.Data, MessageImportance.Normal);
+				else
+					stderr_completed.Set ();
 			};
 			proc.StartInfo = psi;
 			proc.Start ();
@@ -119,9 +125,9 @@ namespace Xamarin.Android.Tasks
 			LogDebugMessage ("Executing {0}", commandLine);
 			proc.WaitForExit ();
 			if (psi.RedirectStandardError)
-				stderr_completed.WaitOne (TimeSpan.FromSeconds (1));
+				stderr_completed.WaitOne (TimeSpan.FromSeconds (30));
 			if (psi.RedirectStandardOutput)
-				stdout_completed.WaitOne (TimeSpan.FromSeconds (1));
+				stdout_completed.WaitOne (TimeSpan.FromSeconds (30));
 			return proc.ExitCode == 0;
 		}
 


### PR DESCRIPTION
The commit 049b2c8f added some ManualResetEvents to control
how we wait for the process to complete output. The problem
with that commit is that in the Output events we did not set
the events if they had completed (i.e we got null data).

This commit corrects that issue. We increased the timeout so that
event if the process is outputting allot of data we will still get
it.