### PR TITLE
[Mono.Android] use previous framework version in RedistList

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -31,6 +31,7 @@
     <MonoSgenBridgeVersion Condition=" '$(MonoSgenBridgeVersion)' == '' ">5</MonoSgenBridgeVersion>
     <HOME Condition=" '$(HOME)' == '' ">$(HOMEDRIVE)$(HOMEPATH)</HOME>
     <AndroidApiLevel Condition=" '$(AndroidApiLevel)' == '' ">25</AndroidApiLevel>
+    <AndroidPreviousFrameworkVersion Condition=" '$(AndroidPreviousFrameworkVersion)' == '' ">v1.0</AndroidPreviousFrameworkVersion>
     <AndroidLatestFrameworkVersion>v7.1</AndroidLatestFrameworkVersion>
     <AndroidFrameworkVersion Condition=" '$(AndroidFrameworkVersion)' == '' ">$(AndroidLatestFrameworkVersion)</AndroidFrameworkVersion>
     <AndroidToolchainCacheDirectory Condition=" '$(AndroidToolchainCacheDirectory)' == '' ">$(HOME)\android-archives</AndroidToolchainCacheDirectory>

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -167,7 +167,7 @@
       Outputs="$(OutputPath)RedistList\FrameworkList.xml">
    <MakeDir Directories="$(OutputPath)RedistList" />
    <ItemGroup>
-     <FrameworkList Include="&lt;FileList Redist=&quot;MonoAndroid&quot; Name=&quot;Xamarin.Android $(AndroidFrameworkVersion) Support&quot; IncludeFramework=&quot;v1.0&quot;&gt;" />
+     <FrameworkList Include="&lt;FileList Redist=&quot;MonoAndroid&quot; Name=&quot;Xamarin.Android $(AndroidFrameworkVersion) Support&quot; IncludeFramework=&quot;$(AndroidPreviousFrameworkVersion)&quot;&gt;" />
      <FrameworkList Include="&lt;/FileList&gt;" />
    </ItemGroup>
    <WriteLinesToFile


### PR DESCRIPTION
 - we were setting v1.0 to IncludeFramework in
   RedistList/FrameworkList.xml for every framework. this caused
   issues with assembly resolution, with OpenTK-1.0.dll for example as
   it was not located in the v1.0 framework

 - now we set previous version (as we did before), so for example for
   v7.1 we set IncludeFramework to v7.0