### PR TITLE
[Xamarin.Android.Build.Tasks] Preserve collection interfaces

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/PreserveLists/mscorlib.xml
+++ b/src/Xamarin.Android.Build.Tasks/Linker/PreserveLists/mscorlib.xml
@@ -149,6 +149,9 @@
 
 		<type fullname="System.Collections.Generic.ICollection`1" />
 		<type fullname="System.Collections.Generic.IEnumerable`1" />
+		<type fullname="System.Collections.Generic.IEnumerator`1" />
+		<type fullname="System.Collections.Generic.IReadOnlyList`1" />
+		<type fullname="System.Collections.Generic.IReadOnlyCollection`1" />
 		<type fullname="System.Collections.Generic.IList`1" />
 		<type fullname="System.Collections.Generic.GenericEqualityComparer`1">
 			<method name=".ctor" />


### PR DESCRIPTION
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=50290

The `generic_icollection_class` condition (in
`external/mono/mono/metadata/class.c`) does not match the
`mscorlib.xml` descriptor file.

Preserve the following types so that the linker doesn't break things:

* `System.Collections.Generic.IEnumerator<T>`
* `System.Collections.Generic.IReadOnlyList<T>`
* `System.Collections.Generic.IReadOnlyCollection<T>`