### PR TITLE
[Xamarin.Android.Build.Tests] Move tests into a Shared Project so they can be reused upstream.

### DIFF
--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -113,8 +113,6 @@ Global
 		Release|AnyCPU = Release|AnyCPU
 		XAIntegrationDebug|AnyCPU = XAIntegrationDebug|AnyCPU
 		XAIntegrationRelease|AnyCPU = XAIntegrationRelease|AnyCPU
-		XAIntegrationDebug|Any CPU = XAIntegrationDebug|Any CPU
-		XAIntegrationRelease|Any CPU = XAIntegrationRelease|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU

--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -105,12 +105,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Android.Tools.Javad
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "javadoc2mdoc", "tools\javadoc2mdoc\javadoc2mdoc.csproj", "{A87352E6-CE7F-4346-B6B1-586AE931C0A7}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Xamarin.Android.Build.Tests.Shared", "src\Xamarin.Android.Build.Tasks\Tests\Xamarin.Android.Build.Tests\Xamarin.Android.Build.Tests.Shared.shproj", "{BD1D66BF-5AC7-4926-8EBE-B2198A112EB0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|AnyCPU = Debug|AnyCPU
 		Release|AnyCPU = Release|AnyCPU
 		XAIntegrationDebug|AnyCPU = XAIntegrationDebug|AnyCPU
 		XAIntegrationRelease|AnyCPU = XAIntegrationRelease|AnyCPU
+		XAIntegrationDebug|Any CPU = XAIntegrationDebug|Any CPU
+		XAIntegrationRelease|Any CPU = XAIntegrationRelease|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
@@ -537,6 +541,7 @@ Global
 		{8A6CB07C-E493-4A4F-AB94-038645A27118} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 		{E0890301-F75F-40E7-B008-54C28B3BA542} = {864062D3-A415-4A6F-9324-5820237BA058}
 		{A87352E6-CE7F-4346-B6B1-586AE931C0A7} = {864062D3-A415-4A6F-9324-5820237BA058}
+		{BD1D66BF-5AC7-4926-8EBE-B2198A112EB0} = {CAB438D8-B0F5-4AF0-BEBD-9E2ADBD7B483}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>{BD1D66BF-5AC7-4926-8EBE-B2198A112EB0}</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>Xamarin.Android.Build.Tests.Shared</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)AidlTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AndroidUpdateResourcesTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)BindingBuildTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)BuildAssetsTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)BuildTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)IncrementalBuildTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ManifestTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PackagingTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\BaseTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\BuildHelper.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="$(MSBuildThisFileDirectory)Utilities\" />
+  </ItemGroup>
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.shproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.shproj
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProjectGuid>{BD1D66BF-5AC7-4926-8EBE-B2198A112EB0}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <Import Project="Xamarin.Android.Build.Tests.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>Xamarin.Android.Build.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
   </PropertyGroup>
+  <Import Project="Xamarin.Android.Build.Tests.Shared.projitems" Label="Shared" Condition="Exists('Xamarin.Android.Build.Tests.Shared.projitems')" />
   <Import Project="..\..\..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -38,18 +39,6 @@
       <HintPath>..\..\..\..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Utilities\BaseTest.cs" />
-    <Compile Include="Utilities\BuildHelper.cs" />
-    <Compile Include="BuildTest.cs" />
-    <Compile Include="PackagingTest.cs" />
-    <Compile Include="AidlTest.cs" />
-    <Compile Include="BindingBuildTest.cs" />
-    <Compile Include="BuildAssetsTest.cs" />
-    <Compile Include="ManifestTest.cs" />
-    <Compile Include="AndroidUpdateResourcesTest.cs" />
-    <Compile Include="IncrementalBuildTest.cs" />
-  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.ProjectTools\Xamarin.ProjectTools.csproj">
@@ -66,6 +55,5 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
-    <Folder Include="Utilities\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Rather than have all the msbuild tests in an assembly this commit
moves them into a shared project. This means the source code for
the tests can be easily reused upstream. It also means we can make
use of things like partial classes to change the tests depending on
which repo we are running them from. For example having tests in this
repo only run in Release mode but have both Release and Debug upstream.