### PR TITLE
[mono-runtimes] Fix bundle*.zip use

### DIFF
--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -5,11 +5,18 @@
     <_SourceTopDir>..\..</_SourceTopDir>
     <_BclFrameworkDir>$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0</_BclFrameworkDir>
     <_MandroidDir>$(OutputPath)\lib\mandroid</_MandroidDir>
+    <_DebugFileExt Condition=" '$(_DebugFileExt)' == '' ">.pdb</_DebugFileExt>
   </PropertyGroup>
   <ItemGroup>
     <MonoDocCopyItem Include="monodoc.dll" />
-    <MonoDocCopyItemOptional Include="monodoc.pdb" />
-    <MonoDocCopyItemOptional Include="monodoc.dll.mdb" />
+    <MonoDocCopyItem
+        Condition=" '$(_DebugFileExt)' == '.pdb'"
+        Include="monodoc.pdb"
+    />
+    <MonoDocCopyItem
+        Condition=" '$(_DebugFileExt)' == '.mdb'"
+        Include="monodoc.dll.mdb"
+    />
     <MonoDocCopyItem Include="monodoc.dll.config" />
   </ItemGroup>
   <ItemGroup>
@@ -22,6 +29,13 @@
   </ItemGroup>
   <UsingTask AssemblyFile="$(_SourceTopDir)\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.GetNugetPackageBasePath" />
   <Import Project="$(_SourceTopDir)\Configuration.props" />
+  <ItemGroup>
+    <_MonoDocCopyItems Include="@(MonoDocCopyItem->'$(_MonoOutputDir)\%(Identity)')" />
+  </ItemGroup>
+  <ItemGroup>
+    <_MonoDocInstalledItems Include="@(MonoDocCopyItem->'$(_MandroidDir)\%(Identity)')" />
+    <_MonoDocInstalledItems Include="$(_MandroidDir)\mdoc.exe" />
+  </ItemGroup>
   <PropertyGroup>
     <_MonoProfileDir>$(MonoSourceFullPath)\mcs\class\lib\monodroid</_MonoProfileDir>
     <_MonoOutputDir>$(MonoSourceFullPath)\mcs\class\lib\net_4_x</_MonoOutputDir>
@@ -327,26 +341,9 @@
         DestinationFiles="$(_MandroidDir)\cil-strip.exe"
     />
   </Target>
-  <Target Name="_GetMonodocItems" DependsOnTargets="_BuildRuntimes">
-    <ItemGroup>
-      <_MonoDocCopyItems Include="@(MonoDocCopyItem->'$(_MonoOutputDir)\%(Identity)')" />
-      <_MonoDocCopyItems
-          Condition=" Exists ('$(_MonoOutputDir)\%(Identity)') "
-          Include="@(MonoDocCopyItemOptional->'$(_MonoOutputDir)\%(Identity)')"
-      />
-
-      <_MonoDocInstalledItems Include="@(MonoDocCopyItem->'$(_MandroidDir)\%(Identity)')" />
-      <_MonoDocInstalledItems
-          Condition=" Exists ('$(_MonoOutputDir)\%(Identity)') "
-          Include="@(MonoDocCopyItemOptional->'$(_MandroidDir)\%(Identity)')"
-      />
-      <_MonoDocInstalledItems Include="$(_MandroidDir)\mdoc.exe" />
-    </ItemGroup>
-  </Target>
   <Target Name="_InstallMonoDoc"
       Inputs="@(_MonoDocCopyItems);$(_MonoOutputDir)\mdoc.exe"
-      Outputs="@(_MonoDocInstalledItems)"
-      DependsOnTargets="_GetMonodocItems">
+      Outputs="@(_MonoDocInstalledItems)">
     <MakeDir Directories="$(_MandroidDir)" />
     <Copy
         SourceFiles="@(_MonoDocCopyItems)"
@@ -498,7 +495,7 @@
     />
   </Target>
   <Target Name="GetMonoBundleItems"
-      DependsOnTargets="_GetRuntimesOutputItems;_GetMonodocItems;_PrepareLlvmItems">
+      DependsOnTargets="_GetRuntimesOutputItems;_PrepareLlvmItems">
     <ItemGroup>
       <BundleItem Include="@(_BclInstalledItem)" />
       <BundleItem Include="@(_MonoDocInstalledItems)" />

--- a/build-tools/scripts/MonoAndroidFramework.props
+++ b/build-tools/scripts/MonoAndroidFramework.props
@@ -4,8 +4,6 @@
   <PropertyGroup>
     <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
     <TargetFrameworkRootPath>$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
-    <FrameworkPathOverride
-        Condition=" '$(FrameworkPathOverride)' == '' And '$(_XAFixMSBuildFrameworkPathOverride)' == 'True' "
-    >$(TargetFrameworkRootPath)\MonoAndroid\v1.0</FrameworkPathOverride>
+    <FrameworkPathOverride>$(TargetFrameworkRootPath)\MonoAndroid\v1.0</FrameworkPathOverride>
   </PropertyGroup>
 </Project>

--- a/build-tools/unix-distribution-setup/unix-distribution-setup.targets
+++ b/build-tools/unix-distribution-setup/unix-distribution-setup.targets
@@ -9,13 +9,16 @@
         Condition=" '$(HostOS)' != 'Windows' "
         Command="chmod +x $(OutputPath)bin\generator"
     />
+    <ItemGroup>
+      <_ExecutableScript Include="$(OutputPath)bin\cross*" />
+      <_ExecutableScript
+          Condition=" Exists('$(OutputPath)bin\llc') "
+          Include="$(OutputPath)bin\llc"
+      />
+    </ItemGroup>
     <Exec
-        Condition=" '$(HostOS)' != 'Windows' And Exists( '$(OutputPath)bin\cross*' ) "
-        Command="chmod +x $(OutputPath)bin\cross*"
-    />
-    <Exec
-        Condition=" '$(HostOS)' != 'Windows' And Exists( '$(OutputPath)bin\llc' ) "
-        Command="chmod +x $(OutputPath)bin\llc"
+        Condition=" '$(HostOS)' != 'Windows' And '@(_ExecutableScript)' != '' "
+        Command="chmod +x @(_ExecutableScript->'&quot;%(Identity)&quot;', ' ')"
     />
   </Target>
 


### PR DESCRIPTION
Commit 76be1fb1 (6e9a6612) broke `bundle*.zip` use. Consequently,
`bundle*.zip` *is not used*, resulting in *yuuuge* build times
(nearly 7 hours for full builds on macOS, over 2 hours for PRs!).

The `_BuildUnlessCached` target calls the `GetMonoBundleItems`
target, to determine whether the `ForceBuild` target -- which invokes
`_BuildRuntimes` and many other targets -- should be executed.
The `GetMonoBundleItems` returns all files which would be included in
`bundle*.zip`.

The cause of the break is that commit 6e9a6612 changed the
`GetMonoBundleItems` target to depend on the `_GetMonodocItems`
target, which in turn depended on the `_BuildRuntimes` target.

`_BuildRuntimes` is the target we want to avoid executing; it's the
target that builds mono, and thus can take an eternity (particularly
on the `xamarin-android` Jenkins lane, which builds **ALL THE ABIS**).

Adding `_GetMonodocItems` in this fashion thus means we never use the
cache, bceause in order to determine whether or not we can use the
cache we need to do all the work that the cache was intended to avoid.
Consider the [xamarin-android Build 312 log file][0]

	Building target "_BuildUnlessCached" in project ".../xamarin-android/build-tools/mono-runtimes/mono-runtimes.mdproj" (".../xamarin-android/build-tools/mono-runtimes/mono-runtimes.targets"); "Build" depends on it.
	...
	Building target "GetMonoBundleItems" in project ".../xamarin-android/build-tools/mono-runtimes/mono-runtimes.mdproj" (".../xamarin-android/build-tools/mono-runtimes/mono-runtimes.targets"); "_BuildUnlessCached" depends on it.
	...
	Building target "_GetMonodocItems" in project ".../xamarin-android/build-tools/mono-runtimes/mono-runtimes.mdproj" (".../xamarin-android/build-tools/mono-runtimes/mono-runtimes.targets"); "GetMonoBundleItems" depends on it.
	Building target "_BuildRuntimes" in project ".../xamarin-android/build-tools/mono-runtimes/mono-runtimes.mdproj" (".../xamarin-android/build-tools/mono-runtimes/mono-runtimes.targets"); "_GetMonodocItems" depends on it.

...and **BOOM**, we're not using `bundle*.zip` anymore.

The fix is to partially revert commit 6e9a6612, but the entire reason
6e9a6612 exists is because commit 76be1fb1 changes the default file
extension for debug symbols from `.mdb` to `.pdb`:

How should we know if we're emitting `.mdb` or `.pdb` symbols?

*A* way to know that is to actually build everything and see what is
generated, but that's...slow. Slow and undesirable. (That's what
6e9a6612 does!)

An alternate ("hacky") way to know is to rely on mono-specific
extensions, and spackle, and duct tape: Mono's `msbuild` sets the
`$(_DebugFileExt)` MSBuild property to the file extension of debug
symbols, with values of `.mdb` on Mono 4.6 through Mono 4.8, and a
value of `.pdb` on Mono 4.9.

In `build-tools/scripts/msbuild.mk`, we can probe the mono version and
attempt to come up with "sane" defaults, setting `$(_DebugFileExt)`
for `xbuild` invocations done via `make`.

We can thus rely on the `$(_DebugFileExt)` extension instead of costly
filesystem probing, allowing `bundle*.zip` to actually be used,
instead of ignored.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/312/consoleText