### PR TITLE
[unix-distribution-setup] fix cross-less build.

### DIFF
--- a/build-tools/unix-distribution-setup/unix-distribution-setup.targets
+++ b/build-tools/unix-distribution-setup/unix-distribution-setup.targets
@@ -10,11 +10,11 @@
         Command="chmod +x $(OutputPath)bin\generator"
     />
     <Exec
-        Condition=" '$(HostOS)' != 'Windows' "
+        Condition=" '$(HostOS)' != 'Windows' And Exists( '$(OutputPath)bin\cross*' ) "
         Command="chmod +x $(OutputPath)bin\cross*"
     />
     <Exec
-        Condition=" '$(HostOS)' != 'Windows' "
+        Condition=" '$(HostOS)' != 'Windows' And Exists( '$(OutputPath)bin\llc' ) "
         Command="chmod +x $(OutputPath)bin\llc"
     />
   </Target>


### PR DESCRIPTION
On Linux you don't have cross build and the condition should not be
$(OS) != 'Windows'.