### PR TITLE
[Xamarin.Android.Build.Tasks] Unable to compile projects with certain characters or spaces when AOT+LLVM is enabled

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -438,7 +438,7 @@ namespace Xamarin.Android.Tasks
 			var stderr_completed = new ManualResetEvent (false);
 			var psi = new ProcessStartInfo () {
 				FileName = aotCompiler,
-				Arguments = aotOptions + " \"" + assembly + "\"",
+				Arguments = aotOptions + " " + assembly,
 				UseShellExecute = false,
 				RedirectStandardOutput = true,
 				RedirectStandardError = true,
@@ -480,7 +480,6 @@ namespace Xamarin.Android.Tasks
 					stdout_completed.WaitOne (TimeSpan.FromSeconds (30));
 				return proc.ExitCode == 0;
 			}
-			GC.Collect ();
 		}
 
 		void OnAotOutputData (object sender, DataReceivedEventArgs e)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -24,6 +24,18 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void BuildReleaseApplicationWithSpacesInPath ()
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				AotAssemblies = true,
+			};
+			using (var b = CreateApkBuilder (Path.Combine ("temp", "BuildReleaseAppWithA InIt(1)"))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
+		[Test]
 		public void BuildReleaseApplicationWithNugetPackages ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -89,7 +89,7 @@ namespace Xamarin.ProjectTools
 
 			var logger = buildLogFullPath == null
 				? string.Empty
-				: string.Format ("/noconsolelogger /flp1:LogFile={0};Encoding=UTF-8;Verbosity={1}",
+				: string.Format ("/noconsolelogger \"/flp1:LogFile={0};Encoding=UTF-8;Verbosity={1}\"",
 					buildLogFullPath, Verbosity.ToString ().ToLower ());
 
 			var start = DateTime.UtcNow;
@@ -133,11 +133,11 @@ namespace Xamarin.ProjectTools
 					psi.EnvironmentVariables ["XBUILD_FRAMEWORK_FOLDERS_PATH"] = Path.Combine (outdir, "lib", "xbuild-frameworks");
 					args.AppendFormat ("/p:MonoDroidInstallDirectory=\"{0}\" ", outdir);
 				}
-				args.AppendFormat ("/t:{0} {1}", target, Path.Combine (Root, projectOrSolution));
+				args.AppendFormat ("/t:{0} {1}", target, QuoteFileName (Path.Combine (Root, projectOrSolution)));
 			}
 			else {
 				args.AppendFormat ("{0} /t:{1} {2} /p:UseHostCompilerIfAvailable=false /p:BuildingInsideVisualStudio=true",
-					Path.Combine (Root, projectOrSolution), target, logger);
+					QuoteFileName(Path.Combine (Root, projectOrSolution)), target, logger);
 			}
 			if (parameters != null) {
 				foreach (var param in parameters) {
@@ -158,7 +158,7 @@ namespace Xamarin.ProjectTools
 			LastBuildTime = DateTime.UtcNow - start;
 
 			LastBuildOutput = String.Empty;
-			if (buildLogFullPath != null)
+			if (buildLogFullPath != null && File.Exists (buildLogFullPath))
 				LastBuildOutput += File.ReadAllText (buildLogFullPath);
 			LastBuildOutput += string.Format ("\n#stdout begin\n{0}\n#stdout end\n", p.StandardOutput.ReadToEnd ());
 			LastBuildOutput += string.Format ("\n#stderr begin\n{0}\n#stderr end\n", p.StandardError.ReadToEnd ());
@@ -171,6 +171,11 @@ namespace Xamarin.ProjectTools
 			}
 
 			return result;
+		}
+
+		string QuoteFileName (string fileName)
+		{
+			return fileName.Contains (" ") ? $"\"{fileName}\"" : fileName;
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=52644

It appears we were double double quoting the path to the assembly
which is to be AOT'd. This was causing a problem for the
tooling. This commit removes the additional quotes so
that we only quote the path once.

It also adds a unit test which has spaces (and brackets) in
the path and updates the test framework to allow to paths with
spaces.

And removes a call to GC.Collect which was unreachable code and 
therefore was not needed.