### PR TITLE
[Xamarin.Android.Build.Tasks] Hitting "System.IO.IOException: Too many open files" when building a large app with AOT and all supported architectures (#493)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Xml.Linq;
 using NUnit.Framework;
 using Xamarin.ProjectTools;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/SolutionBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/SolutionBuilder.cs
@@ -10,17 +10,19 @@ namespace Xamarin.ProjectTools
 	{
 		public IList<XamarinProject> Projects { get; }
 		public string SolutionPath { get; set; }
+		public string SolutionName { get; set; }
 		public bool BuildSucceeded { get; set; }
 
-		public SolutionBuilder () : base()
+		public SolutionBuilder (string solutionName) : base()
 		{
+			SolutionName = solutionName;
 			Projects = new List<XamarinProject> ();
 		}
 
 		public void Save ()
 		{
 			foreach (var p in Projects) {
-				using (var pb = new ProjectBuilder (Path.Combine (Path.GetDirectoryName (SolutionPath), p.ProjectName))) {
+				using (var pb = new ProjectBuilder (Path.Combine (SolutionPath, p.ProjectName))) {
 					pb.Save (p);
 				}
 			}
@@ -47,27 +49,33 @@ namespace Xamarin.ProjectTools
 			}
 			sb.Append ("\tEndGlobalSection\n");
 			sb.Append ("EndGlobal\n");
-			File.WriteAllText (SolutionPath, sb.ToString ());
+			File.WriteAllText (Path.Combine (SolutionPath, SolutionName), sb.ToString ());
 		}
 
-		public bool Build ()
+		public bool BuildProject(XamarinProject project, string target = "Build")
 		{
-			Save ();
-			BuildSucceeded = BuildInternal (SolutionPath, "Build");
+			BuildSucceeded = BuildInternal(Path.Combine (SolutionPath, project.ProjectName, project.ProjectFilePath), target);
 			return BuildSucceeded;
 		}
 
-		public bool ReBuild ()
+		public bool Build (params string[] parameters)
 		{
 			Save ();
-			BuildSucceeded = BuildInternal (SolutionPath, "ReBuild");
+			BuildSucceeded = BuildInternal (Path.Combine (SolutionPath, SolutionName), "Build", parameters);
 			return BuildSucceeded;
 		}
 
-		public bool Clean ()
+		public bool ReBuild(params string[] parameters)
 		{
 			Save ();
-			BuildSucceeded = BuildInternal (SolutionPath, "Clean");
+			BuildSucceeded = BuildInternal(Path.Combine(SolutionPath, SolutionName), "ReBuild", parameters);
+			return BuildSucceeded;
+		}
+
+		public bool Clean(params string[] parameters)
+		{
+			Save ();
+			BuildSucceeded = BuildInternal(Path.Combine(SolutionPath, SolutionName), "Clean", parameters);
 			return BuildSucceeded;
 		}
 
@@ -75,7 +83,7 @@ namespace Xamarin.ProjectTools
 		{
 			if (disposing)
 				if (BuildSucceeded)
-					Directory.Delete (Path.GetDirectoryName (SolutionPath), recursive: true);
+					Directory.Delete (SolutionPath, recursive: true);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
@@ -1,21 +1,33 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using Xamarin.Tools.Zip;
 
 namespace Xamarin.Android.Tasks
 {
 	public class ZipArchiveEx : IDisposable
 	{
+
+		public static int ZipFlushLimit = 50;
+
 		ZipArchive zip;
 		string archive;
 
-		public ZipArchiveEx (string archive)
-		{
-			this.archive = archive;
-			zip = ZipArchive.Open (archive, FileMode.CreateNew);
+		public ZipArchive Archive {
+			get { return zip; }
 		}
 
-		void Flush ()
+		public ZipArchiveEx (string archive) : this (archive, FileMode.CreateNew)
+		{
+		}
+
+		public ZipArchiveEx(string archive, FileMode filemode)
+		{
+			this.archive = archive;
+			zip = ZipArchive.Open(archive, filemode);
+		}
+
+		public void Flush ()
 		{
 			if (zip != null) {
 				zip.Close ();
@@ -51,7 +63,7 @@ namespace Xamarin.Android.Tasks
 					continue;
 				zip.AddFile (fileName, ArchiveNameForFile (fileName, folderInArchive));
 				count++;
-				if (count == 50) {
+				if (count == ZipArchiveEx.ZipFlushLimit) {
 					Flush ();
 					count = 0;
 				}


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=53122

There is a problem with libzip in that is does not have an
API for Flushing the current items in memory to disk.
This was why ZipArchiveEx was introduced in commit 9166e036.
This commit reworks the BuildApk task to make sure of this
new functinality and to periodically flush the zip to disk.
This will reduce the chances of running out of memory.

It also adds a unit test which generates and builds an app
which has a large number of refernces and assets. This app
also gets AOT'd so it should be pushing the system to the limit.

Also added code to make sure the cross tools and llc have
execute permissions.

Added code to make sure we dispose of each process in the Aapt and
Aot tasks. This is to ensure any files or pipes these processed have
are removed as soon as possible.

Updated the unix-distribution-setup.targets to ensure that the cross-arm
tooling and llc have the correct execute permissions on MacOS and Linux.