### PR TITLE
[Xamarin.Android.Build.Tasks] Make sure we remove .pdb files in $(OutputPath)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2361,10 +2361,10 @@ because xbuild doesn't support framework reference assemblies.
 <!-- Cleaning -->
 
 <Target Name="_CleanGeneratedDebuggingFiles">
-	<CreateItem Include="$(OutputPath)*.dll.mdb">
-		<Output TaskParameter="Include" ItemName="_OutputMdbFiles" />
-	</CreateItem>
-	<Delete Files="@(_OutputMdbFiles)"/>
+	<ItemGroup>
+		<_OutputDebugSymbolFiles Include="$(OutputPath)*.dll.mdb;$(OutputPath)*.pdb" />
+	</ItemGroup>
+	<Delete Files="@(_OutputDebugSymbolFiles)"/>
 </Target>
 
 <Target Name="_CleanMsymArchive">


### PR DESCRIPTION
We were not cleaning up .pdb files which existed in the $(OutputPath)
since the switch to mono 4.9