### PR TITLE
[xa-prep-tasks] Fix message for missing dependencies on Linux.

### DIFF
--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/PrepareInstall.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/PrepareInstall.cs
@@ -95,7 +95,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 					ver += $" and <= {max}";
 				}
 			}
-			Log.LogError ($"Unsupported platform {HostOS}! Do not know how to install program `{Program.ItemSpec}`{ver}.");
+			Log.LogError ($"Missing dependency detected. For {HostOS} we do not know how to install program `{Program.ItemSpec}`{ver}.");
 		}
 	}
 }


### PR DESCRIPTION
You cannot say "Unsupported platform Linux!" xamarin-android does build
on Linux. It is just xa-prep-tasks who is incapable of dealing with it.