### PR TITLE
[Xamarin.Android.Build.Tasks] Revert changes from f06bcbe2

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -186,7 +186,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidUseSharedRuntime Condition=" '$(AndroidUseSharedRuntime)' == ''">False</AndroidUseSharedRuntime>
 
 	<AndroidExplicitCrunch Condition=" '$(AndroidExplicitCrunch)' == '' ">False</AndroidExplicitCrunch>
-	<AndroidUseDebugRuntime Condition="'$(AndroidUseDebugRuntime)' == '' And '$(AndroidUseSharedRuntime)' == 'False' And '$(EmbedAssembliesIntoApk)' == 'True' And ('$(DebugSymbols)' != 'True' Or '$(DebugType)' != 'Full')" >False</AndroidUseDebugRuntime>
+	<AndroidUseDebugRuntime Condition="'$(AndroidUseDebugRuntime)' == '' And '$(AndroidUseSharedRuntime)' == 'False' And '$(EmbedAssembliesIntoApk)' == 'True' And ('$(DebugSymbols)' != 'True' Or '$(DebugType)' != 'Full' Or '$(DebugType)' != 'Embedded')" >False</AndroidUseDebugRuntime>
 	<AndroidUseDebugRuntime Condition="'$(AndroidUseDebugRuntime)' == ''" >True</AndroidUseDebugRuntime>
 
 	<MonoSymbolArchive Condition=" '$(MonoSymbolArchive)' == '' And '$(AndroidUseSharedRuntime)' == 'False' And '$(EmbedAssembliesIntoApk)' == 'True' And '$(DebugSymbols)' == 'True' And ('$(DebugType)' == 'PdbOnly' Or '$(DebugType)' == 'Portable')" >True</MonoSymbolArchive>  
@@ -263,16 +263,11 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </PropertyGroup>
 
 <Choose>
-	<When Condition=" '$(DebugSymbols)' != '' And $(DebugSymbols) And '$(DebugType)' != '' And '$(DebugType)' == 'Full' ">
+	<When Condition=" '$(DebugSymbols)' != '' And $(DebugSymbols) And '$(DebugType)' != '' And ('$(DebugType)' == 'Full' Or '$(DebugType)' == 'Embedded') ">
 		<PropertyGroup>
 			<AndroidIncludeDebugSymbols>True</AndroidIncludeDebugSymbols>
 		</PropertyGroup>
 	</When>
-	<When Condition=" '$(DebugSymbols)' != '' And $(DebugSymbols) And '$(DebugType)' != '' And ('$(DebugType)' == 'PdbOnly' Or '$(DebugType)' == 'Portable')">
-		<PropertyGroup>
-			<AndroidIncludeDebugSymbols>True</AndroidIncludeDebugSymbols>
-		</PropertyGroup>
-	</When>	
 	<When Condition=" '$(DebugSymbols)' != '' And $(DebugSymbols) And '$(DebugType)' == '' ">
 		<PropertyGroup>
 			<AndroidIncludeDebugSymbols>True</AndroidIncludeDebugSymbols>


### PR DESCRIPTION
The commit f06bcbe2 incorrectly changed the way we calculate
$(AndroidIncludeDebugSymbols). Tha t value should ONLY be
enabled if DebugType is Full or Embedded. I.e if we have a full
on debug build.

It turns out the source of the problem was the fact that msbuild
under OSX was completely ignoring the $(DebugType) property in
the csproj. This caused it to always default to 'portable' which
is NOT a full debug build.