### PR TITLE
[Xamarin.Android.Build.Tasks] Switch to use $(Optimize) to control which runtime is installed.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -186,10 +186,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidUseSharedRuntime Condition=" '$(AndroidUseSharedRuntime)' == ''">False</AndroidUseSharedRuntime>
 
 	<AndroidExplicitCrunch Condition=" '$(AndroidExplicitCrunch)' == '' ">False</AndroidExplicitCrunch>
-	<AndroidUseDebugRuntime Condition="'$(AndroidUseDebugRuntime)' == '' And '$(AndroidUseSharedRuntime)' == 'False' And '$(EmbedAssembliesIntoApk)' == 'True' And ('$(DebugSymbols)' != 'True' Or '$(DebugType)' != 'Full' Or '$(DebugType)' != 'Embedded')" >False</AndroidUseDebugRuntime>
+	<AndroidUseDebugRuntime Condition="'$(AndroidUseDebugRuntime)' == '' And '$(Optimize)' == 'True'" >False</AndroidUseDebugRuntime>
 	<AndroidUseDebugRuntime Condition="'$(AndroidUseDebugRuntime)' == ''" >True</AndroidUseDebugRuntime>
 
-	<MonoSymbolArchive Condition=" '$(MonoSymbolArchive)' == '' And '$(AndroidUseSharedRuntime)' == 'False' And '$(EmbedAssembliesIntoApk)' == 'True' And '$(DebugSymbols)' == 'True' And ('$(DebugType)' == 'PdbOnly' Or '$(DebugType)' == 'Portable')" >True</MonoSymbolArchive>  
+	<MonoSymbolArchive Condition=" '$(MonoSymbolArchive)' == '' And '$(AndroidUseSharedRuntime)' == 'False' And '$(EmbedAssembliesIntoApk)' == 'True' And '$(DebugSymbols)' == 'True' And '$(Optimize)' == 'True'" >True</MonoSymbolArchive>  
 	<MonoSymbolArchive Condition=" '$(MonoSymbolArchive)' == '' ">False</MonoSymbolArchive>
 
 	<BundleAssemblies Condition="'$(BundleAssemblies)' == ''">False</BundleAssemblies>
@@ -263,7 +263,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </PropertyGroup>
 
 <Choose>
-	<When Condition=" '$(DebugSymbols)' != '' And $(DebugSymbols) And '$(DebugType)' != '' And ('$(DebugType)' == 'Full' Or '$(DebugType)' == 'Embedded') ">
+	<When Condition=" '$(DebugSymbols)' != '' And $(DebugSymbols) And '$(DebugType)' != '' And '$(Optimize)' == 'False' ">
 		<PropertyGroup>
 			<AndroidIncludeDebugSymbols>True</AndroidIncludeDebugSymbols>
 		</PropertyGroup>


### PR DESCRIPTION
Context https://bugzilla.xamarin.com/show_bug.cgi?id=53787
Context https://bugzilla.xamarin.com/show_bug.cgi?id=53900

In mono 4.9 DebugType Full|Portable|PdbOnly are all the same thing.
So we cannot reliably use those values to control which runtime is
installed in the package.

Instead we should use $(Optimize) which is only used on Release
configurations (why Optimize a debug build!).

This commit switches over to using $(Optimize) to control the debug/release
runtime.
