### PR TITLE
[Xamarin.ProjectTools] Migrate changes from upstream to this Project Tools.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidItem.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidItem.cs
@@ -133,5 +133,16 @@ namespace Xamarin.ProjectTools
 			{
 			}
 		}
+		public class InputJar : BuildItem
+		{
+			public InputJar (string include)
+				: this (() => include)
+			{
+			}
+			public InputJar (Func<string> include)
+				: base (AndroidBuildActions.InputJar, include)
+			{
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/JarContentBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/JarContentBuilder.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace Xamarin.ProjectTools
+{
+	public class JarContentBuilder : ContentBuilder
+	{
+		public string BaseDirectory { get; set; }
+		public string JavacFullPath { get; set; }
+		public string JarFullPath { get; set; }
+		public string JarFileName { get; set; }
+		// It can support more than one file but we don't need compllicated one yet.
+		public string JavaSourceFileName { get; set; }
+		public string JavaSourceText { get; set; }
+
+		public override byte [] Build ()
+		{
+			var src = Path.Combine (BaseDirectory, JavaSourceFileName);
+			var jarfile = Path.Combine (BaseDirectory, JarFileName);
+			File.WriteAllText (src, JavaSourceText);
+			// It can support additional arguments but we don't need compllicated one yet.
+			var javacPsi = new ProcessStartInfo () {
+				FileName = JavacFullPath,
+				Arguments = JavaSourceFileName,
+				WorkingDirectory = BaseDirectory,
+				UseShellExecute = false,
+				RedirectStandardOutput = true,
+				RedirectStandardError = true,
+			};
+			var javacPs = Process.Start (javacPsi);
+			javacPs.WaitForExit ();
+			if (javacPs.ExitCode != 0)
+				throw new InvalidOperationException ("`Javac` command line tool did not successfully finish: " + javacPs.StandardError.ReadToEnd ());
+			if (File.Exists (jarfile))
+				File.Delete (jarfile);
+			var args = new string [] { "cvf", JarFileName };
+			var classes = Directory.GetFiles (Path.GetDirectoryName (src), "*.class", SearchOption.AllDirectories);
+			var jarPsi = new ProcessStartInfo () {
+				FileName = JarFullPath,
+				Arguments = string.Join (" ", args.Concat (classes.Select (c => c.Substring (BaseDirectory.Length + 1)).ToArray ())),
+				WorkingDirectory = BaseDirectory,
+				UseShellExecute = false,
+				RedirectStandardOutput = true,
+				RedirectStandardError = true,
+			};
+			var jarPs = Process.Start (jarPsi);
+			jarPs.WaitForExit ();
+			if (jarPs.ExitCode != 0)
+				throw new InvalidOperationException ("`Jar` command line tool did not successfully finish: " + jarPs.StandardError.ReadToEnd ());
+			Process.Start (jarPsi).WaitForExit ();
+			return File.ReadAllBytes (jarfile);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
@@ -39,6 +39,11 @@ namespace Xamarin.ProjectTools
 			return File.ReadAllText (Path.Combine (root, GetIntermediaryPath (file)));
 		}
 
+		public string GetIntermediaryAsText (string file)
+		{
+			return File.ReadAllText (Path.Combine (Project.Root, GetIntermediaryPath (file)));
+		}
+
 		public bool IsTargetSkipped (string target)
 		{
 			if (!Builder.LastBuildOutput.Contains (target))

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ContentBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ContentBuilder.cs
@@ -1,0 +1,8 @@
+﻿using System;
+namespace Xamarin.ProjectTools
+{
+	public abstract class ContentBuilder
+	{
+		public abstract byte [] Build ();
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -78,8 +78,9 @@
     <Compile Include="Android\ApkContents.cs" />
     <Compile Include="Common\BuildOutputFiles.cs" />
     <Compile Include="Utilities\FileSystemUtils.cs" />
+    <Compile Include="Android\JarContentBuilder.cs" />
+    <Compile Include="Common\ContentBuilder.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Folder Include="Common\" />
     <Folder Include="Android\" />
@@ -89,20 +90,48 @@
     <Folder Include="Utilities\" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Resources\Wear\LayoutMain.axml" />
-    <EmbeddedResource Include="Resources\Wear\LayoutRectMain.axml" />
-    <EmbeddedResource Include="Resources\Wear\LayoutRoundMain.axml" />
-    <EmbeddedResource Include="Resources\Wear\MainActivity.cs" />
-    <EmbeddedResource Include="Resources\Wear\Strings.xml" />
-    <EmbeddedResource Include="Resources\Base\AndroidManifest.xml" />
-    <EmbeddedResource Include="Resources\Base\Icon.png" />
-    <EmbeddedResource Include="Resources\Base\LayoutMain.axml" />
-    <EmbeddedResource Include="Resources\Base\MainActivity.cs" />
-    <EmbeddedResource Include="Resources\Base\MainActivity.fs" />
-    <EmbeddedResource Include="Resources\Base\AssemblyInfo.fs" />
-    <EmbeddedResource Include="Resources\Base\Image.9.png" />
-    <EmbeddedResource Include="Resources\Base\Image2.9.png" />
-    <EmbeddedResource Include="Resources\Base\test.keystore" />
+    <EmbeddedResource Include="Resources\Wear\LayoutMain.axml">
+      <LogicalName>Xamarin.ProjectTools.Resources.Wear.LayoutMain.axml</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\Wear\LayoutRectMain.axml">
+      <LogicalName>Xamarin.ProjectTools.Resources.Wear.LayoutRectMain.axml</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\Wear\LayoutRoundMain.axml">
+      <LogicalName>Xamarin.ProjectTools.Resources.Wear.LayoutRoundMain.axml</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\Wear\MainActivity.cs">
+      <LogicalName>Xamarin.ProjectTools.Resources.Wear.MainActivity.cs</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\Wear\Strings.xml">
+      <LogicalName>Xamarin.ProjectTools.Resources.Wear.Strings.xml</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\Base\AndroidManifest.xml">
+      <LogicalName>Xamarin.ProjectTools.Resources.Base.AndroidManifest.xml</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\Base\Icon.png">
+      <LogicalName>Xamarin.ProjectTools.Resources.Base.Icon.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\Base\LayoutMain.axml">
+      <LogicalName>Xamarin.ProjectTools.Resources.Base.LayoutMain.axml</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\Base\MainActivity.cs">
+      <LogicalName>Xamarin.ProjectTools.Resources.Base.MainActivity.cs</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\Base\MainActivity.fs">
+      <LogicalName>Xamarin.ProjectTools.Resources.Base.MainActivity.fs</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\Base\AssemblyInfo.fs">
+      <LogicalName>Xamarin.ProjectTools.Resources.Base.AssemblyInfo.fs</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\Base\Image.9.png">
+      <LogicalName>Xamarin.ProjectTools.Resources.Base.Image.9.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\Base\Image2.9.png">
+      <LogicalName>Xamarin.ProjectTools.Resources.Base.Image2.9.png</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\Base\test.keystore">
+      <LogicalName>Xamarin.ProjectTools.Resources.Base.test.keystore</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -123,4 +152,5 @@
       <Name>libZipSharp</Name>
     </ProjectReference>
   </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
As part of the code cleanup we want to use the Xamarin.ProjectTools
from this repo upstream. There are a few places where we had got out
of sync. This commit brings those changes over.