### PR TITLE
[api-xml-adjuster] extract docs archive under ~/android-toolchains by default.

### DIFF
--- a/build-tools/api-xml-adjuster/Makefile
+++ b/build-tools/api-xml-adjuster/Makefile
@@ -4,6 +4,8 @@ SHELL = /bin/bash
 
 ANDROID_SDK_PATH=$(shell find ~/ -maxdepth 1 -name android-sdk-*)
 
+DOCS_DIR=~/android-toolchain/docs
+
 MANDROID = ../../bin/$(CONFIGURATION)/lib/mandroid
 BUILDBIN = ../../bin/Build$(CONFIGURATION)
 
@@ -12,7 +14,6 @@ API_XML_TOOL = $(BUILDBIN)/api-xml-adjuster.exe
 RUNTIME = mono
 RUN_CLASS_PARSE = $(RUNTIME) $(CLASS_PARSE)
 RUN_API_XML_TOOL = $(RUNTIME) $(API_XML_TOOL)
-DOCS_DIR = .
 API_LEVELS = 10 15 16 17 18 19 20 21 22 23 24 25
 
 XML_OUTPUT_DIR = .
@@ -64,12 +65,13 @@ $(CLASS_PARSE):
 $(API_XML_TOOL):
 	$(XBUILD)
 
-DOCS_DIR_CUR_LEVEL: docs-api-$(LEVEL)
+DOCS_DIR_CUR_LEVEL: $(DOCS_DIR_CUR_LEVEL)
 
 # download and setup docs directory for each API profile
 
 define extract-docs
-	unzip $1 || exit 1
+	mkdir -p $(DOCS_DIR)
+	unzip -d $(DOCS_DIR) $1 || exit 1
 	mv $2 $@
 endef
 
@@ -81,40 +83,39 @@ docs-25_web.zip:
 
 # API level 10 is Android v2.3.3; it's API level 9 (Android v2.3) with a few
 # bugfixes which don't impact the documentation.
-docs-api-10: docs-2.3_r01-linux.zip
+$(DOCS_DIR)/docs-api-10: docs-2.3_r01-linux.zip
 	$(call extract-docs,$<,docs-2.3_r01-linux)
 
-docs-api-15: docs-15_r02.zip
+$(DOCS_DIR)/docs-api-15: docs-15_r02.zip
 	$(call extract-docs,$<,docs)
 
-docs-api-16: docs-16_r03.zip
+$(DOCS_DIR)/docs-api-16: docs-16_r03.zip
 	$(call extract-docs,$<,docs)
 
-docs-api-17: docs-17_r02.zip
+$(DOCS_DIR)/docs-api-17: docs-17_r02.zip
 	$(call extract-docs,$<,docs)
 
-docs-api-18: docs-18_r01.zip
+$(DOCS_DIR)/docs-api-18: docs-18_r01.zip
 	$(call extract-docs,$<,docs)
 
-docs-api-19: docs-19_r01.zip
+$(DOCS_DIR)/docs-api-19: docs-19_r01.zip
 	$(call extract-docs,$<,docs)
 
 # no 20 doc in final release either...
-docs-api-20: docs-21_r01.zip
+$(DOCS_DIR)/docs-api-20: docs-21_r01.zip
 	$(call extract-docs,$<,docs)
 
-docs-api-21: docs-21_r01.zip
+$(DOCS_DIR)/docs-api-21: docs-21_r01.zip
 	$(call extract-docs,$<,docs)
 
-docs-api-22: docs-22_r01.zip
+$(DOCS_DIR)/docs-api-22: docs-22_r01.zip
 	$(call extract-docs,$<,docs)
 
-docs-api-23: docs-23_r01.zip
+$(DOCS_DIR)/docs-api-23: docs-23_r01.zip
 	$(call extract-docs,$<,docs)
 
-docs-api-24: docs-24_r01.zip
+$(DOCS_DIR)/docs-api-24: docs-24_r01.zip
 	$(call extract-docs,$<,docs)
 
-docs-api-25: docs-25_web.zip	# Google hadn't published docs component yet!
+$(DOCS_DIR)/docs-api-25: docs-25_web.zip	# Google hadn't published docs component yet!
 	$(call extract-docs,$<,docs)
-


### PR DESCRIPTION
We (well, I) don't want to extract those docs under this directory and
mess global source search by these massive docs. Isolate them outside.