### PR TITLE
[Xamarin.ProjectTools] Always ref Microsoft.Build.Engine

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -33,7 +33,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build" />
-    <Reference Condition=" '$(OS)' != 'Unix' " Include="Microsoft.Build.Engine" />
+    <Reference Include="Microsoft.Build.Engine" />
     <Reference Include="System.Drawing" />
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\..\..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>


### PR DESCRIPTION
@borgdylan is reporting that xamarin-android isn't building for him
with a more recent mono/master build, because the
`Microsoft.Build.BuildEngine` namespace can't be resolved, because the
`Microsoft.Build.Engine.dll` assembly isn't being referenced.

`Microsoft.Build.Engine.dll` isn't being referenced because it's
Conditional so that it's only referenced on Windows.

I don't know why this is conditional to Windows, but
`Microsoft.Build.Engine.dll` exists *now*, so always use it.