### PR TITLE
[nunit] build X.A.NUnitLite.dll with API level 19

### DIFF
--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -103,6 +103,9 @@ framework-assemblies:
 			$(MSBUILD) $(MSBUILD_FLAGS) src/Mono.Android/Mono.Android.csproj /p:Configuration=$(conf)   $(_MSBUILD_ARGS) /p:AndroidApiLevel=$${a} /p:AndroidFrameworkVersion=$${CUR_VERSION} /p:AndroidPreviousFrameworkVersion=$${PREV_VERSION}; ) \
 		PREV_VERSION=$${CUR_VERSION}; \
 	done
+	$(foreach conf, $(CONFIGURATIONS), \
+		rm -f bin/$(conf)/lib/xbuild-frameworks/MonoAndroid/v1.0/Xamarin.Android.NUnitLite.dll; \
+		$(MSBUILD) $(MSBUILD_FLAGS) src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj /p:Configuration=$(conf)   $(_MSBUILD_ARGS) /p:AndroidApiLevel=19 /p:AndroidFrameworkVersion=v4.4; )
 
 runtime-libraries:
 	$(foreach conf, $(CONFIGURATIONS), \

--- a/src/Xamarin.Android.NUnitLite/Gui/Instrumentations/TestSuiteInstrumentation.cs
+++ b/src/Xamarin.Android.NUnitLite/Gui/Instrumentations/TestSuiteInstrumentation.cs
@@ -93,7 +93,11 @@ namespace Xamarin.Android.NUnitLite {
 
 		string GetResultsPath ()
 		{
-			var resultsPathFile = Context.GetExternalFilesDir (global::Android.OS.Environment.DirectoryDocuments);
+			Java.IO.File resultsPathFile = null;
+#if __ANDROID_19__
+			if (((int)Build.VERSION.SdkInt) >= 19)
+				resultsPathFile = Context.GetExternalFilesDir (global::Android.OS.Environment.DirectoryDocuments);
+#endif
 			var usePathFile = resultsPathFile != null && resultsPathFile.Exists ();
 			var resultsPath = usePathFile
 				? resultsPathFile.AbsolutePath

--- a/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj
+++ b/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj
@@ -353,7 +353,7 @@
       <Name>Mono.Android</Name>
       <Private>False</Private>
     </ProjectReference>
-    <ProjectReference Include="..\Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj">
+    <ProjectReference Condition=" '$(AndroidApiLevel)' >= 24 " Include="..\Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj">
       <Project>{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}</Project>
       <Name>Xamarin.Android.Build.Tasks</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>


### PR DESCRIPTION
 - current NUnitLite was built with latest API level. that was
   problematic, because it was referencing BaseBundle class, which is
   only available in API >= 21, see
   https://developer.android.com/reference/android/os/BaseBundle.html

 - so instead of using latest API, we now build it with API 19. that's
   the lowes API level we can use, because
   src/Xamarin.Android.NUnitLite/Gui/Instrumentations/TestSuiteInstrumentation.cs
   is using global::Android.OS.Environment.DirectoryDocuments which is
   avalable in API level >= 19, see
   https://developer.android.com/reference/android/os/Environment.html#DIRECTORY_DOCUMENTS

 - also the X.A.Build.Tasks project reference is now conditional,
   because it requires API level >= 24. it is OK, because we build it
   in leeroy-all rule with latest API level and default build uses
   latest API level too. the project reference itself is there to
   ensure the build ordering, so we can safely make it conditional

 - it fixes bugs #53418 and #53884