### PR TITLE
[mono-runtimes] `cross-arm64.exe` must be a 64-bit app

### DIFF
--- a/build-tools/bundle/bundle-path.targets
+++ b/build-tools/bundle/bundle-path.targets
@@ -24,7 +24,7 @@
   <Target Name="GetBundleFileName"
       DependsOnTargets="_GetHashes">
     <PropertyGroup>
-      <XABundleFileName>bundle-v14-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
+      <XABundleFileName>bundle-v15-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
     </PropertyGroup>
   </Target>
 </Project>

--- a/build-tools/mono-runtimes/mono-runtimes.projitems
+++ b/build-tools/mono-runtimes/mono-runtimes.projitems
@@ -393,23 +393,23 @@
 
     <_MonoCrossRuntime Include="cross-arm64-win" Condition="$(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-arm64:'))">
       <JitArch>arm64-v8a</JitArch>
-      <Ar>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-ar</Ar>
-      <As>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-as</As>
-      <Cc>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-gcc</Cc>
+      <Ar>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-ar</Ar>
+      <As>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-as</As>
+      <Cc>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-gcc</Cc>
       <CFlags>$(_CrossCFlagsWin) -static -static-libgcc</CFlags>
-      <Cxx>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-g++</Cxx>
-      <CxxCpp>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-cpp</CxxCpp>
+      <Cxx>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-g++</Cxx>
+      <CxxCpp>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-cpp</CxxCpp>
       <CxxFlags>$(_CrossCXXFlagsWin) -static -static-libgcc</CxxFlags>
-      <Ld>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-ld</Ld>
+      <Ld>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-ld</Ld>
       <LdFlags>-static -static-libgcc -static-libstdc++</LdFlags>
-      <RanLib>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-ranlib</RanLib>
-      <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-strip</Strip>
+      <RanLib>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-ranlib</RanLib>
+      <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-strip</Strip>
       <StripFlags>-S</StripFlags>
       <TargetAbi>aarch64-v8a-linux-android</TargetAbi>
-      <ConfigureFlags>--target=aarch64-v8a-linux-android --host="$(_CrossConfigureBuildHostWin32)" --cache-file=$(_CrossConfigureCachePrefix)arm64-win.config.cache --with-cross-offsets=aarch64-v8a-linux-android.h $(_CrossConfigureFlags) --with-llvm=$(_LlvmPrefixWin32)</ConfigureFlags>
+      <ConfigureFlags>--target=aarch64-v8a-linux-android --host="$(_CrossConfigureBuildHostWin64)" --cache-file=$(_CrossConfigureCachePrefix)arm64-win.config.cache --with-cross-offsets=aarch64-v8a-linux-android.h $(_CrossConfigureFlags) --with-llvm=$(_LlvmPrefixWin64)</ConfigureFlags>
       <ExeSuffix>.exe</ExeSuffix>
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
-      <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin32)</ConfigureEnvironment>
+      <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin64)</ConfigureEnvironment>
       <InstallPath>lib/mandroid/</InstallPath>
       <CrossMonoName>cross-arm64</CrossMonoName>
     </_MonoCrossRuntime>


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=54353

When using `mono` as an AOT cross-compiler, mono's "bitness" needs to
match the "bitness" of the target ABI. For example, to generate AOT
native code for 32-bit armeabi, the "host" `mono` needs to run in a
32-bit process. Similarly, to generate AOT native code for 64-bit
aarch64-v8a ("arm64-v8a"), the "host" `mono` needs to run in a 64-bit
process.

Unfortunately...that wasn't the case:

	$ file bin/Debug/lib/mandroid/cross-arm64.exe
	bin/Debug/lib/mandroid/cross-arm64.exe: PE32 executable (console) Intel 80386, for MS Windows

The result is that when attempting to generate AOT native libraries
for arm64 *on Windows*, it would fail:

	$ xbuild /p:Configuration=Release /p:AndroidSupportedAbis=arm64-v8a /p:AotAssemblies=True /t:SignAndroidPackage Project.csproj
	...
	[aot-compiler stderr] Can't cross-compile on 32-bit platforms to 64-bit architecture.

(It would work on macOS, as `bin/Debug/bin/cross-arm64` is a 64-bit
executable, as is required.)

The fix is to correct the `@(_MonoCrossRuntime)` value for
`cross-arm64-win` so that it used the
`$(MingwCommandPrefix64)`-related values, *not* the
`$(MingwCommandPrefix32)`-related values. This ensures that we use
compiler settings to generate 64-bit binaries, resolving the error:

	$ file bin/Debug/lib/mandroid/cross-arm64.exe
	bin/Debug/lib/mandroid/cross-arm64.exe: PE32+ executable (console) x86-64, for MS Windows