### PR TITLE
[Xamarin.Android.Build.Tasks] Set PROGUARD_HOME on Windows for related ToolTasks

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -470,12 +470,13 @@ namespace Xamarin.Android.Tasks
 
 		public static string [] GetProguardEnvironmentVaribles (string proguardHome)
 		{
+			string proguardHomeVariable = "PROGUARD_HOME=" + proguardHome;
+
 			return Environment.OSVersion.Platform == PlatformID.Unix ?
-				new string [] { "PROGUARD_HOME=" + proguardHome } :
-				//TODO ReAdd the PROGUARD_HOME env variable once we are shipping our own proguard
+				new string [] { proguardHomeVariable } :
 				// Windows seems to need special care, needs JAVA_TOOL_OPTIONS.
 				// On the other hand, xbuild has a bug and fails to parse '=' in the value, so we skip JAVA_TOOL_OPTIONS on Mono runtime.
-				new string [] { "JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8" };
+				new string [] { proguardHomeVariable, "JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8" };
 		}
 	}
 }


### PR DESCRIPTION
We had previously disabled passing this variable to both the 'Proguard' and 'CreateMultiDexMainDexClassList' ToolTasks on Windows.
I believe this is now needed (at least in the case of multidex) in order for mainDexClasses.bat invocations to find and use our proguard distribution.
My local testing shows that the 'ProguardHome' property is correctly being set to point to the new XA proguard distribution location [0],
and I believe all that is needed now is to ensure 'PROGUARD_HOME' is also set and passed to the invocations of the relevant tools on Windows.

[0] Windows has two possible distribution locations depending on the installer used, as shown below. The first for VS2015 and lower, the second for VS2017.
```
Task Parameter:ProguardHome=C:\Program Files (x86)\MSBuild\Xamarin\Android\proguard\
Task Parameter:ProguardHome=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\Xamarin\Android\proguard\
```