### PR TITLE
[build] Build Xamarin.Android.NUniteLite against v2.3

### DIFF
--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -105,7 +105,7 @@ framework-assemblies:
 	done
 	$(foreach conf, $(CONFIGURATIONS), \
 		rm -f bin/$(conf)/lib/xbuild-frameworks/MonoAndroid/v1.0/Xamarin.Android.NUnitLite.dll; \
-		$(MSBUILD) $(MSBUILD_FLAGS) src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj /p:Configuration=$(conf)   $(_MSBUILD_ARGS) /p:AndroidApiLevel=19 /p:AndroidFrameworkVersion=v4.4; )
+		$(MSBUILD) $(MSBUILD_FLAGS) src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj /p:Configuration=$(conf) $(_MSBUILD_ARGS) /p:AndroidApiLevel=$(firstword $(API_LEVELS)) /p:AndroidFrameworkVersion=$(firstword $(FRAMEWORKS)); )
 
 runtime-libraries:
 	$(foreach conf, $(CONFIGURATIONS), \


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=54785

The scenario: build `Xamarin.Android.NUnitLite.dll` against API-Y,
use it in an app using `Mono.Android.dll` API-X, X < Y.
(Specifically, build `Xamarin.Android.NUnitLite.dll` against API-19,
and the app against API-10.)

If you build this in a Release configuration, or otherwise attempt to
link the assemblies, Linking will fail:

	error XA2006: Could not resolve reference to
	'System.String Android.OS.Environment::get_DirectoryDocuments()'
	(defined in assembly 'Xamarin.Android.NUnitLite, Version=1.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065')
	with scope 'Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065'.

Commit 3ed220d5 fixed a similar issue wrt `BaseBundle`, but only
lowered `Y` to `19`. Since we still support Apps targeting API-10,
this is still problematic.

Update the `make framework-assemblies` target so that instead of
hardcoding the `Xamarin.Android.NUnitLite.dll` "rebuild" to use
API-19, instead use `$(firstword $(API_LEVELS))` -- which is currently
API-10/v2.3 -- so that as we "bump" up our minimum supported API level
we can progressively include API features.