### PR TITLE
[create-vsix] Don't package files without an extension

### DIFF
--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -58,6 +58,23 @@
         <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Microsoft/Framework/%(RecursiveDir)</VSIXSubPath>
       </ReferenceAssemblies>
     </ItemGroup>
+    <!-- https://bugzilla.xamarin.com/show_bug.cgi?id=54804
+      Mono's `ZipPackage` mis-handles files w/o an extension,
+      causing VS to state that the .vsix is invalid.
+      Remove these files for now.
+      -->
+    <ItemGroup>
+      <_MSBuildFilesWithoutExtension
+          Condition=" '%(Extension)' == '' "
+          Include="@(MSBuild)"
+      />
+      <MSBuild Remove="@(_MSBuildFilesWithoutExtension)" />
+      <_ReferenceFilesWithoutExtension
+          Condition=" '%(Extension)' == '' "
+          Include="@(ReferenceAssemblies)"
+      />
+      <ReferenceAssemblies Remove="@(_ReferenceFilesWithoutExtension)" />
+    </ItemGroup>
     <ItemGroup>
       <Content Include="@(MSBuild)" />
       <Content Include="@(ReferenceAssemblies)" />


### PR DESCRIPTION
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=54804

Mono's `System.IO.Packaging.ZipPackage` implementation has a bug in
which adding files without an extension will result in
`[Content_Types].xml` containing a `//Default/@Extension` attribute
with no value.

Unfortunately, our created `Xamarin.Android.Sdk*.vsix` package
contains at least two such files:

* `bin/$(Configuration)/lib/xbuild/Xamarin/Android/Version`
* `bin/$(Configuration)/lib/mandroid/MULTIDEX_JAR_LICENSE`

The result is that, while we have a `.vsix` file, Visual Studio
refuses to install it:

> **Installation Failed**
> The file is not a valid VSIX package.

The install log says:

    System.Xml.XmlException: ‘Default’ tag requires a nonempty ‘Extension’ attribute. Line 1, position 618.

*As a workaround*, do not add any files lacking a file extension to
the `Xamarin.Android.Sdk*.vsix` file.