### PR TITLE
[msbuild] On Windows, we support setting the Debugger to MS or Xamarin

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Common/ImportAfter/Xamarin.Android.Windows.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Common/ImportAfter/Xamarin.Android.Windows.targets
@@ -9,6 +9,10 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+	<PropertyGroup>
+		<Debugger Condition="'$(Debugger)'==''">Xamarin</Debugger>
+	</PropertyGroup>
+
 	<Target Name="_RegisterMdbFilesWithFileWrites" BeforeTargets="IncrementalClean">  
 		<CreateItem Include="$(OutDir)*.dll.mdb;$(MonoAndroidIntermediateAssemblyDir)*.dll.mdb">  
 			<Output TaskParameter="Include" ItemName="_FilesToRegister" />  


### PR DESCRIPTION
On Windows, this property is used to specify a debugger other than the Xamarin one, 
in particular, the VC++ native debugger for Android.