### PR TITLE
[Xamarin.Android.Build.Tasks] Compatibility with existing projects

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Xamarin.Android.Sdk.props
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Xamarin.Android.Sdk.props
@@ -23,7 +23,7 @@ Copyright (C) 2011-2016 Xamarin. All rights reserved.
 		<!-- Until VS2017+ includes its own ReferenceAssemblies outside of C:\Program Files (x86)\Reference Assemblies and into 
 			 the VsInstallRoot, we must override this ourselves for our SDKs -->
 		<TargetFrameworkRootPath Condition="'$(TargetFrameworkRootPath)' == ''">$(VsInstallRoot)\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\</TargetFrameworkRootPath>
-		<FrameworkPathOverride Condition="'$(FrameworkPathOverride)' == ''">$(TargetFrameworkRootPath)MonoAndroid\v1.0</FrameworkPathOverride>
+		<FrameworkPathOverride>$(TargetFrameworkRootPath)MonoAndroid\v1.0</FrameworkPathOverride>
 		<XamarinAndroidSdkPropsImported>true</XamarinAndroidSdkPropsImported>
 	</PropertyGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -168,6 +168,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <!-- Version/fx properties -->
 <PropertyGroup>
 	<_XAMajorVersionNumber>1</_XAMajorVersionNumber>
+	<_XASupportsFastDev Condition=" Exists ('$(MSBuildThisFileDirectory)Xamarin.Android.Common.Debugging.targets') ">True</_XASupportsFastDev>
+	<_XASupportsFastDev Condition=" '$(_XASupportsFastDev)' == '' ">False</_XASupportsFastDev>
 	<AndroidApplication Condition="'$(AndroidApplication)' == ''">false</AndroidApplication>
 	<AndroidNeedsInternetPermission Condition="'$(AndroidNeedsInternetPermission)' == '' And '$(AndroidEmbedProfilers)' == ''">False</AndroidNeedsInternetPermission>
 	<AndroidNeedsInternetPermission Condition="'$(AndroidNeedsInternetPermission)' == '' And '$(AndroidEmbedProfilers)' != ''">True</AndroidNeedsInternetPermission>
@@ -175,7 +177,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">MonoAndroid</TargetFrameworkIdentifier>
 	<MonoAndroidVersion>v$(_XAMajorVersionNumber).0</MonoAndroidVersion>
 	<AndroidUpdateResourceReferences Condition="'$(AndroidUpdateResourceReferences)' == ''">True</AndroidUpdateResourceReferences>
-	<EmbedAssembliesIntoApk Condition="'$(EmbedAssembliesIntoApk)' == ''">True</EmbedAssembliesIntoApk>
+	<EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' Or '$(_XASupportsFastDev)' == 'False' ">True</EmbedAssembliesIntoApk>
 	<AndroidSkipJavacVersionCheck Condition="'$(AndroidSkipJavacVersionCheck)' == ''">False</AndroidSkipJavacVersionCheck>
 	<AndroidBuildApplicationPackage Condition=" '$(AndroidBuildApplicationPackage)' == ''">False</AndroidBuildApplicationPackage>
 
@@ -183,7 +185,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidAotMode Condition=" '$(AndroidAotMode)' == '' And '$(AotAssemblies)' == 'True' ">Normal</AndroidAotMode>
 	<AotAssemblies Condition=" '$(AndroidAotMode)' != '' ">True</AotAssemblies>
 	<AotAssemblies Condition=" '$(AotAssemblies)' == '' ">False</AotAssemblies>
-	<AndroidUseSharedRuntime Condition=" '$(AndroidUseSharedRuntime)' == ''">False</AndroidUseSharedRuntime>
+	<AndroidUseSharedRuntime Condition=" '$(AndroidUseSharedRuntime)' == '' Or '$(_XASupportsFastDev)' == 'False' ">False</AndroidUseSharedRuntime>
 
 	<AndroidExplicitCrunch Condition=" '$(AndroidExplicitCrunch)' == '' ">False</AndroidExplicitCrunch>
 	<AndroidUseDebugRuntime Condition="'$(AndroidUseDebugRuntime)' == '' And '$(Optimize)' == 'True'" >False</AndroidUseDebugRuntime>
@@ -2450,6 +2452,22 @@ because xbuild doesn't support framework reference assemblies.
     DependsOnTargets="AndroidPrepareForBuild">
   <WriteLinesToFile File="$(_LldbConfigFile)" Lines="PKG=$(_AndroidPackage)" Overwrite="true"/>
   <WriteLinesToFile File="$(_LldbConfigFile)" Lines="MANIFEST=$(IntermediateOutputPath)android\AndroidManifest.xml"/>
+</Target>
+
+<PropertyGroup>
+  <InstallDependsOnTargets>
+    SignAndroidPackage;
+    _Deploy
+  </InstallDependsOnTargets>
+</PropertyGroup>
+
+<Target Name="_Deploy">
+  <Exec Command="&quot;$(AdbToolPath)\adb&quot; install &quot;$(ApkFileSigned)&quot;" />
+</Target>
+
+<Target Name="Install"
+    Condition="'$(AndroidApplication)'!='' And $(AndroidApplication)"
+    DependsOnTargets="$(InstallDependsOnTargets)">
 </Target>
 
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Common.Debugging.targets"


### PR DESCRIPTION
Existing projects may (will) have already set the
`$(AndroidUseSharedRuntime)` and `$(EmbedAssembliesIntoApk)`
"incorrectly" for an OSS xamarin-android install, as the OSS repo does
not support "fast deployment" or the "shared runtime".

Consequently, if an existing project has e.g.
`$(AndroidUseSharedRuntime)`=True and/or
`$(EmbedAssembliesIntoApk)`=False, there will be "weird"
packaging-related errors, e.g.:

	jarsigner ... Scratch.App.apk
	jarsigner: unable to open jar file: .../Scratch.App.apk
	error MSB6006: "jarsigner.exe" exited with code 1.

or

> I managed to get a simple project building from command line,
> it’s crashing on startup

...oops?

Check for the existence of
`$(MSBuildThisFileDirectory)Xamarin.Android.Common.Debugging.targets`
to determine if we're operating in a "full"/"commercial" environment;
if that file is not present, then override the
`$(AndroidUseSharedRuntime)` and `$(EmbedAssembliesIntoApk)`
properties so that things can reliably work.

Additionally, provide a rudimentary `Install` target so that the
[documented `Install` target works][0], which is additionally helpful
as Visual Studio uses the `Install` target for deployment, so this
might actually allow VS2017 to install using the resulting `.vsix`.
The `Install` target merely invokes the `adb install` command; don't
expect any meaningful/useful IDE feedback.

[0]: https://developer.xamarin.com/guides/android/under_the_hood/build_process/#Build_Targets