### PR TITLE
[Xamarin.Android.Build.Tasks] Compare $(Optimize) to True

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -265,7 +265,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </PropertyGroup>
 
 <Choose>
-	<When Condition=" '$(DebugSymbols)' != '' And $(DebugSymbols) And '$(DebugType)' != '' And '$(Optimize)' == 'False' ">
+	<When Condition=" '$(DebugSymbols)' != '' And $(DebugSymbols) And '$(DebugType)' != '' And '$(Optimize)' != 'True' ">
 		<PropertyGroup>
 			<AndroidIncludeDebugSymbols>True</AndroidIncludeDebugSymbols>
 		</PropertyGroup>


### PR DESCRIPTION
We should treat an *unset* `$(Optimize)` MSBuild property "as if" it
were False, *not* True, meaning we should only compare the
`$(Optimize)` value against `True`, *never* `False`.

Thus, instead:

	'$(Optimize)' == 'False'

use:

	'$(Optimize)' == 'True'

This way, if (when) `$(Optimize)` isn't set at all, or is set to some
other "bizarre" value (`/p:Optimize=Maybe`?), we'll attempt to include
debug symbols instead of *excluding* debug symbols, etc.