### PR TITLE
[mono-runtimes] Include the System.ValueTuple Facade

### DIFF
--- a/build-tools/bundle/bundle-path.targets
+++ b/build-tools/bundle/bundle-path.targets
@@ -24,7 +24,7 @@
   <Target Name="GetBundleFileName"
       DependsOnTargets="_GetHashes">
     <PropertyGroup>
-      <XABundleFileName>bundle-v16-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
+      <XABundleFileName>bundle-v17-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
     </PropertyGroup>
   </Target>
 </Project>

--- a/build-tools/mono-runtimes/ProfileAssemblies.projitems
+++ b/build-tools/mono-runtimes/ProfileAssemblies.projitems
@@ -124,6 +124,7 @@
     <MonoFacadeAssembly Include="System.Threading.Thread.dll" />
     <MonoFacadeAssembly Include="System.Threading.ThreadPool.dll" />
     <MonoFacadeAssembly Include="System.Threading.Timer.dll" />
+    <MonoFacadeAssembly Include="System.ValueTuple.dll" />
     <MonoFacadeAssembly Include="System.Xml.ReaderWriter.dll" />
     <MonoFacadeAssembly Include="System.Xml.XDocument.dll" />
     <MonoFacadeAssembly Include="System.Xml.XmlDocument.dll" />


### PR DESCRIPTION
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=55229

It appears that apps which use `System.ValueTuple.dll` with
Xamarin.Android 7.3 might not be properly distributing the
`System.ValueTuple.dll` facade assembly, in part because
*we don't have* a `System.ValueTuple.dll` facade assembly. (Oops.)

Update the `@(MonoFacadeAssembly)` group to match the Facade
assemblies which mono's 2017-02 branch currently creates.
This just adds `System.ValueTuple.dll`.