### PR TITLE
[Xamarin.Android.Build.Tasks] Use $(AndroidLatestApiLevel)

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -13,6 +13,11 @@
   />
   <PropertyGroup>
     <ProductVersion>7.3.99</ProductVersion>
+    <!-- *Latest* API level binding that we support; used when building src/Xamarin.Android.Build.Tasks -->
+    <AndroidLatestApiLevel>25</AndroidLatestApiLevel>
+    <AndroidLatestFrameworkVersion>v7.1</AndroidLatestFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup>
     <AutoProvision Condition=" '$(AutoProvision)' == '' ">False</AutoProvision>
     <AutoProvisionUsesSudo Condition=" '$(AutoProvisionUsesSudo)' == '' ">False</AutoProvisionUsesSudo>
     <HostOS Condition=" '$(HostOS)' == '' And '$(OS)' == 'Windows_NT' ">Windows</HostOS>
@@ -32,7 +37,6 @@
     <HOME Condition=" '$(HOME)' == '' ">$(HOMEDRIVE)$(HOMEPATH)</HOME>
     <AndroidApiLevel Condition=" '$(AndroidApiLevel)' == '' ">25</AndroidApiLevel>
     <AndroidPreviousFrameworkVersion Condition=" '$(AndroidPreviousFrameworkVersion)' == '' ">v1.0</AndroidPreviousFrameworkVersion>
-    <AndroidLatestFrameworkVersion>v7.1</AndroidLatestFrameworkVersion>
     <AndroidFrameworkVersion Condition=" '$(AndroidFrameworkVersion)' == '' ">$(AndroidLatestFrameworkVersion)</AndroidFrameworkVersion>
     <AndroidToolchainCacheDirectory Condition=" '$(AndroidToolchainCacheDirectory)' == '' ">$(HOME)\android-archives</AndroidToolchainCacheDirectory>
     <AndroidToolchainDirectory Condition=" '$(AndroidToolchainDirectory)' == '' ">$(HOME)\android-toolchain</AndroidToolchainDirectory>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <DefineConstants Condition="'$(__XA_NO_PREVIEW_L_SUPPORT__)' != ''">$(DefineConstants);XA_NO_PREVIEW_L_SUPPORT</DefineConstants>
-    <AndroidGeneratedClassDirectory Condition=" '$(AndroidGeneratedClassDirectory)' == '' ">..\..\src\Mono.Android\obj\$(Configuration)\android-$(AndroidApiLevel)\mcw</AndroidGeneratedClassDirectory>
+    <AndroidGeneratedClassDirectory Condition=" '$(AndroidGeneratedClassDirectory)' == '' ">..\..\src\Mono.Android\obj\$(Configuration)\android-$(AndroidLatestApiLevel)\mcw</AndroidGeneratedClassDirectory>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Build.Framework" />
@@ -408,27 +408,6 @@
     <Compile Include="..\Mono.Android\\Android.Content\GrantUriPermissionAttribute.cs">
       <Link>Mono.Android\GrantUriPermissionAttribute.cs</Link>
     </Compile>
-    <Compile Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.LaunchMode.cs">
-      <Link>Mono.Android\Android.Content.PM.LaunchMode.cs</Link>
-    </Compile>
-    <Compile Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.ScreenOrientation.cs">
-      <Link>Mono.Android\Android.Content.PM.ScreenOrientation.cs</Link>
-    </Compile>
-    <Compile Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.ConfigChanges.cs">
-      <Link>Mono.Android\Android.Content.PM.ConfigChanges.cs</Link>
-    </Compile>
-    <Compile Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.UiOptions.cs">
-      <Link>Mono.Android\Android.Content.PM.UiOptions.cs</Link>
-    </Compile>
-    <Compile Include="$(AndroidGeneratedClassDirectory)\Android.Views.SoftInput.cs">
-      <Link>Mono.Android\Android.Views.SoftInput.cs</Link>
-    </Compile>
-    <Compile Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.Protection.cs">
-      <Link>Mono.Android\Android.Content.PM.Protection.cs</Link>
-    </Compile>
-    <Compile Include="$(AndroidGeneratedClassDirectory)\Android.Views.LayoutDirection.cs">
-      <Link>Mono.Android\Android.Views.LayoutDirection.cs</Link>
-    </Compile>
     <Compile Include="..\Mono.Android\Android.Runtime\IntDefinitionAttribute.cs">
       <Link>Mono.Android\IntDefinitionAttribute.cs</Link>
     </Compile>
@@ -489,6 +468,18 @@
     <Compile Include="Utilities\Profile.cs" />
     <Compile Include="Linker\MonoDroid.Tuner\PreserveTlsProvider.cs" />
     <Compile Include="Tasks\Unzip.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.LaunchMode.cs" />
+    <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.ScreenOrientation.cs" />
+    <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.ConfigChanges.cs" />
+    <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.UiOptions.cs" />
+    <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Views.SoftInput.cs" />
+    <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.Protection.cs" />
+    <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Views.LayoutDirection.cs" />
+    <Compile Include="@(_MonoAndroidEnum)">
+      <Link>Mono.Android\%(Filename)%(Extension)</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Xamarin.Android.Build.Tasks.targets" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -108,6 +108,16 @@
     <_SharedRuntimeAssemblies Include="$(_SharedRuntimeBuildPath)$(AndroidFrameworkVersion)\OpenTK.dll" />
     <_SharedRuntimeAssemblies Include="$(_SharedRuntimeBuildPath)$(AndroidFrameworkVersion)\OpenTK-1.0.dll" />
   </ItemGroup>
+  <Target Name="_GenerateMonoAndroidEnums"
+      BeforeTargets="CoreCompile"
+      Inputs="..\Mono.Android\obj\$(Configuration)\android-$(AndroidLatestApiLevel)\mcw\api.xml"
+      Outputs="@(_MonoAndroidEnum)">
+    <MSBuild
+        Condition=" !Exists ('%(_MonoAndroidEnum.Identity)') "
+        Projects="..\Mono.Android\Mono.Android.csproj"
+        Properties="Configuration=$(Configuration);AndroidApiLevel=$(AndroidLatestApiLevel);AndroidFrameworkVersion=$(AndroidLatestFrameworkVersion)"
+    />
+  </Target>
   <Target Name="_GenerateXACommonProps"
       DependsOnTargets="GetXAVersionInfo"
       BeforeTargets="DeployOutputFiles"


### PR DESCRIPTION
`src/Xamarin.Android.Build.Tasks` uses some *generated* files from
`src/Mono.Android`. Unfortunately, whether those files exist or not
depends on the value of `$(AndroidApiLevel)` and
`$(AndroidFrameworkVersion). For example, the
`Android.Views.LayoutDirection` enum was added in API-17, so if you
build *only* API 16 from a "clean" environment:

	$ git clean -xdf .
	$ make prepare
	$ xbuild Xamarin.Android.sln /p:AndroidApiLevel=16 /p:AndroidFrameworkVersion=v4.1
	# ...

Then [the build fails][0] because `Android.Views.LayoutDirection.cs`
[cannot be found][1]:

	CSC: error CS2001: Source file '.../xamarin-android/src/Xamarin.Android.Build.Tasks/../../src/Mono.Android/obj/Debug/android-16/mcw/Android.Views.LayoutDirection.cs' could not be found.

To improve build reliability, update the
`src/Xamarin.Android.Build.Tasks` project to instead rely on
`src/Mono.Android` build outputs based on the new
`$(AndroidLatestApiLevel)` MSBuild property, which corresponds to the
prior `$(AndroidLatestFrameworkVersion)` property (de6d8ef7).

If the required files don't exist, the new `_GenerateMonoAndroidEnums`
target will invoke `<MSBuild/>` on `Mono.Android.csproj` to cuase the
files to be created.

This allows the build system to be more reliable, ensuring that the
files which `Xamarin.Android.Build.Tasks.csproj` actually exist,
regardless of the possibly overridden values of the
`$(AndroidApiLevel)` and `$(AndroidFrameworkVersion)` properties.

[0]: https://gitter.im/xamarin/xamarin-android?at=58f23ee98e4b63533dcfcc60
[1]: https://pastebin.com/ha7Y0hjC