### PR TITLE
[Xamarin.Android.Build.Tests] Switch over to use the system Nuget.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,7 +6,6 @@ using System.Xml;
 using Microsoft.Build.Construction;
 using System.Diagnostics;
 using System.Text;
-using NuGet;
 
 namespace Xamarin.ProjectTools
 {
@@ -380,12 +379,10 @@ namespace Xamarin.ProjectTools
 			if (!Packages.Any ())
 				return;
 
-			IPackageRepository repo = PackageRepositoryFactory.Default.CreateRepository ("https://packages.nuget.org/api/v2");
-			PackageManager packageManager = new PackageManager (repo, Path.Combine (Root, directory, "..", "packages"));
-
-			foreach (var package in Packages) {
-				packageManager.InstallPackage (package.Id, new SemanticVersion (package.Version));
-			}
+			var psi = new ProcessStartInfo ("NuGet");
+			psi.Arguments = $"restore -PackagesDirectory {Path.Combine (Root, directory, "..", "packages")} {Path.Combine (Root, directory, "packages.config")}";
+			var process = Process.Start (psi);
+			process.WaitForExit ();
 		}
 
 		public string ProcessSourceTemplate (string source)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -38,9 +38,6 @@
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\..\..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Core">
-      <HintPath>..\..\..\..\packages\NuGet.Core.2.11.1\lib\net40-Client\NuGet.Core.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-	<package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
-	<package id="NuGet.Core" version="2.11.1" targetFramework="net45" />
-	<package id="Unofficial.Ionic.Zip" version="1.9.1.8" targetFramework="net45" />
+  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
We are starting to see Nuget packages only be available
from the v3 repositories. Our tests are using Nuget.Core v2.
But Nuget v3 does not have the same API as v2 if you want to
manually restore packages. In fact the api is "unstable" and it
not simple to use. What was a couple of lines of code now has to
be a mess of subclasses and other support files. The Nuget for
those have also exploded into a mass of 24+ packages.

So easiest solution is to use the installed version of Nuget to
restore the packages. This means it is (or should be) up to date
and will work with both v2 and v3.

I have tested this on windows and mac and it works ok.