### PR TITLE
[tests] Run the Java.Interop unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ linux-prepare-$(LINUX_DISTRO)::
 linux-prepare-$(LINUX_DISTRO)-$(LINUX_DISTRO_RELEASE)::
 endif
 
-run-all-tests: run-nunit-tests run-apk-tests
+run-all-tests: run-nunit-tests run-ji-tests run-apk-tests
 
 clean:
 	$(MSBUILD) $(MSBUILD_FLAGS) /t:Clean Xamarin.Android.sln
@@ -164,6 +164,11 @@ endef
 
 run-nunit-tests: $(NUNIT_TESTS)
 	$(foreach t,$(NUNIT_TESTS), $(call RUN_NUNIT_TEST,$(t),1))
+
+run-ji-tests:
+	$(MAKE) -C "$(call GetPath,JavaInterop)" CONFIGURATION=$(CONFIGURATION) all
+	ANDROID_SDK_PATH="$(call GetPath,AndroidSdk)" $(MAKE) -C "$(call GetPath,JavaInterop)" CONFIGURATION=$(CONFIGURATION) run-all-tests || true
+	cp "$(call GetPath,JavaInterop)"/TestResult-*.xml .
 
 # .apk files to test on-device need to:
 # (1) Have their .csproj files listed here

--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -90,6 +90,10 @@
       <HostOS></HostOS>
       <DestDir>extras\android\m2repository</DestDir>
     </AndroidSdkItem>
+    <AndroidSdkItem Include="docs-24_r01.zip">
+      <HostOS></HostOS>
+      <DestDir>docs</DestDir>
+    </AndroidSdkItem>
     <AndroidSdkItem Include="sysimg_x86-21_r03.zip">
       <HostOS></HostOS>
       <RelUrl>sys-img/android/</RelUrl>


### PR DESCRIPTION
We'd like to run the Java.Interop unit tests as part of the
xamarin-android `make run-all-tests` target, for two rasons:

1. An extra layer of sanity checking, and
2. Some of the Java.Interop tests require an Android SDK.

In particular, the
`ParameterFixupTests.XmlDeclaration_FixedUpFromDocumentation()` test
from `Xamarin.Android.Tools.Bytecode-Tests.dll` attempts to read
Android documentation from `$ANDROID_SDK_PATH` to test parameter name
fixups.

However, Java.Interop doesn't install -- and thus can't readily
require -- an Android SDK, meaning this test is never executed as part
of the Java.Interop Jenkins process.

That test *can* be readily executed in xamarin-android, as it *does*
install an Android SDK, and thus its presence can be assumed.

Add a new `make run-ji-tests` target which runs the Java.Interop unit
tests, copying their test output into the same directory that the
other `TestResult-*.xml` files are placed, so that Jenkins can pick
them up for display.

Within the `make run-ji-tests` target, export the `ANDROID_SDK_PATH`
environment variable so that *all* the
`Xamarin.Android.Tools.Bytecode-Tests.dll` tests can execute.

Which introduces one problem: the
`Xamarin.Android.Tools.Bytecode-Tests.dll` tests require that
`$ANDROID_SDK_PATH` contain documentation...which we're not currently
installing.

Result: the `ParameterFixupTest` tests fail. :-(

Fix this conundrum by instaslling `docs-24_r01.zip` within
`$(AndroidSdkDirectory)`, allowing the tests to execute as intended.