### PR TITLE
[Xamarin.Android.Build.Tests] Switch over to use the latest Nuget.

### DIFF
--- a/build-tools/xa-prep-tasks/xa-prep-tasks.targets
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.targets
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask AssemblyFile="$(OutputPath)xa-prep-tasks.dll"   TaskName="Xamarin.Android.BuildTools.PrepTasks.DownloadUri" />
   <UsingTask AssemblyFile="$(OutputPath)xa-prep-tasks.dll"   TaskName="Xamarin.Android.BuildTools.PrepTasks.SystemUnzip" />
@@ -6,6 +6,8 @@
   <Import Project="..\scripts\XAVersionInfo.targets" />
   <PropertyGroup>
     <_AzureBaseUri>https://xamjenkinsartifact.blob.core.windows.net/xamarin-android/xamarin-android/bin/</_AzureBaseUri>
+    <_NuGetUri>https://dist.nuget.org/win-x86-commandline/latest/nuget.exe</_NuGetUri>
+    <_NuGetPath>$(MSBuildThisFileDirectory)\..\..\.nuget</_NuGetPath>
   </PropertyGroup>
   <Target Name="_CreateVersion"
       DependsOnTargets="GetXAVersionInfo"
@@ -67,6 +69,17 @@
         DestinationFiles="$(_BundlePath)"
     />
   </Target>
+  <Target Name="_DownloadNuGet"
+	Inputs=""
+	Outputs="$(_NuGetPath)\NuGet.exe">
+    <MakeDir
+        Directories="$(_NuGetPath)"
+    />
+    <DownloadUri
+        SourceUris="$(_NuGetUri)"
+        DestinationFiles="$(_NuGetPath)\NuGet.exe"
+    />
+  </Target>
   <Target Name="_ExtractBundle"
       Condition=" Exists('$(_BundlePath)') "
       Inputs="$(_BundlePath)"
@@ -84,6 +97,6 @@
   </Target>
   <Target Name="_DownloadAndExtractBundle"
       AfterTargets="Build"
-      DependsOnTargets="_GetBundleOutputPath;_DownloadBundle;_ExtractBundle">
+      DependsOnTargets="_GetBundleOutputPath;_DownloadBundle;_ExtractBundle;_DownloadNuGet">
   </Target>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,7 +6,6 @@ using System.Xml;
 using Microsoft.Build.Construction;
 using System.Diagnostics;
 using System.Text;
-using NuGet;
 
 namespace Xamarin.ProjectTools
 {
@@ -380,12 +379,12 @@ namespace Xamarin.ProjectTools
 			if (!Packages.Any ())
 				return;
 
-			IPackageRepository repo = PackageRepositoryFactory.Default.CreateRepository ("https://packages.nuget.org/api/v2");
-			PackageManager packageManager = new PackageManager (repo, Path.Combine (Root, directory, "..", "packages"));
-
-			foreach (var package in Packages) {
-				packageManager.InstallPackage (package.Id, new SemanticVersion (package.Version));
-			}
+			var isWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+			var psi = new ProcessStartInfo (isWindows ? "NuGet.exe" : "mono") {
+				Arguments = $"{(isWindows ? "" : "\"" + Path.Combine (Root,"NuGet.exe") + "\"")} restore -PackagesDirectory \"{Path.Combine (Root, directory, "..", "packages")}\" \"{Path.Combine (Root, directory, "packages.config")}\"",
+			};
+			var process = Process.Start (psi);
+			process.WaitForExit ();
 		}
 
 		public string ProcessSourceTemplate (string source)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -37,9 +37,6 @@
     <Reference Include="System.Drawing" />
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\..\..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Core">
-      <HintPath>..\..\..\..\packages\NuGet.Core.2.11.1\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -143,6 +140,10 @@
     <Content
         Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:')) And '$(_LinuxBuildLibZip)' == 'True' "
         Include="..\..\..\..\bin\$(Configuration)\lib\xbuild\Xamarin\Android\libzip.so">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content
+        Include="..\..\..\..\.nuget\NuGet.exe">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-	<package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
-	<package id="NuGet.Core" version="2.11.1" targetFramework="net45" />
-	<package id="Unofficial.Ionic.Zip" version="1.9.1.8" targetFramework="net45" />
+  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
We are starting to see Nuget packages only be available
from the v3 repositories. Our tests are using Nuget.Core v2.
But Nuget v3 does not have the same API as v2 if you want to
manually restore packages. In fact the api is "unstable" and it
not simple to use. What was a couple of lines of code now has to
be a mess of subclasses and other support files. The Nuget for
those have also exploded into a mass of 24+ packages.

So easiest solution is to download the latest nuget.exe client
from nuget.org. This means it is (or should be) up to date
and will work with both v2 and v3. Rather than calling the API
manually for the unit tests we just shell out to restore the
packages.