### PR TITLE
[javadoc-to-mdoc] workaround Java6 annotation parsing failure.

### DIFF
--- a/src/Xamarin.Android.Tools.JavadocImporter/DocumentSection.cs
+++ b/src/Xamarin.Android.Tools.JavadocImporter/DocumentSection.cs
@@ -317,6 +317,9 @@ namespace Xamarin.Android.Tools.JavaDocToMdoc
 
 		public JavaDocDocumentSection (XElement sectionNode)
 		{
+			if (sectionNode == null)
+				return; // Any derived classes might pass null element here. Since we cannot reject it here, we ignore the entire section.
+
 			section_node = sectionNode;
 			foreach (XElement pp in section_node.XPathSelectElements (".//dl/dt")) {
 				var b = pp.XPathSelectElement (SectionNameWrapperTag);
@@ -428,6 +431,8 @@ namespace Xamarin.Android.Tools.JavaDocToMdoc
 
 		public override IEnumerable<XNode> GetSummaryNodes ()
 		{
+			if (section_node == null)
+				return Enumerable.Empty<XNode> ();
 			var sumDL = section_node.Elements (XName.Get ("dd")).FirstOrDefault ();
 			return sumDL == null ? Enumerable.Empty<XNode> () :
 			sumDL.Nodes ().TakeWhile (n => !(n is XElement && ((XElement)n).Name.LocalName != "dl"))


### PR DESCRIPTION
Docs for Java6 annotations are not parsed as expected and causing
crash as https://bugzilla.xamarin.com/show_bug.cgi?id=55402 states.

Since we are not going to seriously work on Java6 documentation parser,
we just workaround the null issue.