### PR TITLE
Always set TargetFrameworkRootPath in props as well as FrameworkPathOverride

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.After.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.After.targets
@@ -1,0 +1,20 @@
+<!--
+***********************************************************************************************
+Xamarin.Android.Bindings.Before.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+  created a backup copy.  Incorrect changes to this file will make it
+  impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (C) 2014 Xamarin. All rights reserved.
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Allows providing SDK-specific targets overrides -->
+  <PropertyGroup>
+    <XamarinAndroidSdkTargets>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Xamarin.Android.Sdk.targets'))\Xamarin.Android.Sdk.targets</XamarinAndroidSdkTargets>
+  </PropertyGroup>
+  <Import Project="$(XamarinAndroidSdkTargets)" Condition="'$(XamarinAndroidSdkTargetsImported)' != 'true' And Exists('$(XamarinAndroidSdkTargets)')"/>
+
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Common.After.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Common.After.targets
@@ -14,4 +14,10 @@ Copyright (C) 2014 Xamarin. All rights reserved.
     <Import Project="$(MSBuildThisFileDirectory)\Xamarin.Android.Common\ImportAfter\*"
             Condition="Exists('$(MSBuildThisFileDirectory)\Xamarin.Android.Common\ImportAfter')"/>
 
+    <!-- Allows providing SDK-specific targets overrides -->
+    <PropertyGroup>
+        <XamarinAndroidSdkTargets>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Xamarin.Android.Sdk.targets'))\Xamarin.Android.Sdk.targets</XamarinAndroidSdkTargets>
+    </PropertyGroup>
+    <Import Project="$(XamarinAndroidSdkTargets)" Condition="'$(XamarinAndroidSdkTargetsImported)' != 'true' And Exists('$(XamarinAndroidSdkTargets)')"/>
+
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Xamarin.Android.Sdk.props
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Xamarin.Android.Sdk.props
@@ -19,12 +19,14 @@ Copyright (C) 2011-2016 Xamarin. All rights reserved.
 		<VsInstallationID>$(DevEnvIni.Substring($(InstallationIDEqualsIndex), 8))</VsInstallationID>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(VsInstallRoot)' != ''">
+	<PropertyGroup>
 		<!-- Until VS2017+ includes its own ReferenceAssemblies outside of C:\Program Files (x86)\Reference Assemblies and into 
 			 the VsInstallRoot, we must override this ourselves for our SDKs -->
-		<TargetFrameworkRootPath Condition="'$(TargetFrameworkRootPath)' == ''">$(VsInstallRoot)\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\</TargetFrameworkRootPath>
+		<TargetFrameworkRootPath Condition="'$(VsInstallRoot)' != '' And '$(TargetFrameworkRootPath)' == ''">$(VsInstallRoot)\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\</TargetFrameworkRootPath>
+		<TargetFrameworkRootPath Condition="'$(VsInstallRoot)' == '' And '$(TargetFrameworkRootPath)' == ''">$(ProgramFiles)\Reference Assemblies\Microsoft\Framework\</TargetFrameworkRootPath>
+
+		<!-- We should always override the framework path so that XA resolves to its own mscorlib.dll -->
 		<FrameworkPathOverride>$(TargetFrameworkRootPath)MonoAndroid\v1.0</FrameworkPathOverride>
-		<XamarinAndroidSdkPropsImported>true</XamarinAndroidSdkPropsImported>
 	</PropertyGroup>
 
 	<Target Name="RedirectMonoAndroidSdkPaths" Condition="'$(VsInstallRoot)' != ''">
@@ -52,6 +54,10 @@ Copyright (C) 2011-2016 Xamarin. All rights reserved.
 			</Code>
 		</Task>
 	</UsingTask>
+
+	<PropertyGroup>
+		<XamarinAndroidSdkPropsImported>true</XamarinAndroidSdkPropsImported>
+	</PropertyGroup>
 
 	<!-- Allows providing Xamarin SDK-specific property overrides -->
 	<Import Project="Xamarin.Sdk.props" Condition="'$(XamarinSdkPropsImported)' != 'true' And Exists('Xamarin.Sdk.props')"/>

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Xamarin.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Xamarin.Android.Sdk.targets
@@ -1,0 +1,20 @@
+<!--
+***********************************************************************************************
+Xamarin.Android.Sdk.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+  created a backup copy.  Incorrect changes to this file will make it
+  impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (C) 2011-2016 Xamarin. All rights reserved.
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <XamarinAndroidSdkTargetsImported>true</XamarinAndroidSdkTargetsImported>
+  </PropertyGroup>
+
+  <!-- Allows providing Xamarin SDK-specific targets overrides -->
+	<Import Project="Xamarin.Sdk.targets" Condition="'$(XamarinSdkTargetsImported)' != 'true' And Exists('Xamarin.Sdk.targets')"/>
+</Project>


### PR DESCRIPTION
By doing this in props, we allow users to override the value if they choose to.

Also, if $(TargetFrameworkRootPath) isn't set by us, it's not set in the
project evaluation phase, so by the time we set $(FrameworkPathOverride)
it's still empty and wrong for VS2013/15.

The newly added Sdk.targets also allows us to add the global targets override
Xamarin.Sdk.targets to be consistent with the Xamarin.Sdk.props that we already
import. This allows IDEs to provide additional behavior as needed that is
cross-cutting across all Xamarin builds.