### PR TITLE
[Xamarin.Android.Build.Tasks] Fix a stack overflow because LogError was calling itself.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -240,7 +240,7 @@ namespace Xamarin.Android.Tasks
 
 			NativeLibrariesReferences = nativeLibs.ToArray ();
 
-			LogDebugTaskItems ("Aot Outputs:");
+			LogDebugMessage ("Aot Outputs:");
 			LogDebugTaskItems ("  NativeLibrariesReferences: ", NativeLibrariesReferences);
 
 			return !Log.HasLoggedErrors;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AsyncTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AsyncTask.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Android.Tasks
 			completed.Set ();
 		}
 
-		public void LogDebugTaskItems (string message, params string[] items)
+		public void LogDebugTaskItems (string message, string[] items)
 		{
 			LogDebugMessage (message);
 
@@ -78,9 +78,19 @@ namespace Xamarin.Android.Tasks
 				LogDebugMessage ("    {0}", item.ItemSpec);
 		}
 
+		protected void LogMessage (string message)
+		{
+			LogMessage (message, importance: MessageImportance.Normal);
+		}
+
 		protected void LogMessage (string message, params object[] messageArgs)
 		{
 			LogMessage (string.Format (message, messageArgs));
+		}
+
+		protected void LogDebugMessage (string message)
+		{
+			LogMessage (message , importance: MessageImportance.Low);
 		}
 
 		protected void LogDebugMessage (string message, params object[] messageArgs)
@@ -111,14 +121,24 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
+		protected void LogError (string message)
+		{
+			LogError (code: null, message: message, file: null, lineNumber: 0);
+		}
+
 		protected void LogError (string message, params object[] messageArgs)
 		{
-			LogError (string.Format (message, messageArgs));
+			LogError (code: null, message: string.Format (message, messageArgs));
+		}
+
+		protected void LogCodedError (string code, string message)
+		{
+			LogError (code: code, message: message, file: null, lineNumber: 0);
 		}
 
 		protected void LogCodedError (string code, string message, params object[] messageArgs)
 		{
-			LogError (code, string.Format (message, messageArgs));
+			LogError (code: code, message: string.Format (message, messageArgs), file: null, lineNumber: 0);
 		}
 
 		protected void LogError (string code, string message, string file = null, int lineNumber = 0)


### PR DESCRIPTION
Commit 049b2c8f introduced some default parameters for the LogError
method on the AsyncTask. This inadvertently causes one of the other
methods to start calling itself. This commit explicitly adds the
optional parameter names to make sure the correct method is being
called. This is because ALL LogError methods need to go through the

	protected void LogError (string code, string message, string file = null, int lineNumber = 0)

because it handles queuing the error and making sure that the data
gets marshalled back to the UI thread for logging. Not using this
method would cause UI lockups in VS.