### PR TITLE
[create-vsix] Allow overriding the created .vsix filename

### DIFF
--- a/build-tools/create-vsix/create-vsix.csproj
+++ b/build-tools/create-vsix/create-vsix.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{94756FEB-1F64-411D-A18E-81B5158F776A}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Android.Sdk</RootNamespace>
-    <AssemblyName>Xamarin.Android.Sdk</AssemblyName>
+    <AssemblyName>Xamarin.Android.Sdk-OSS</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <CreateVsixContainer Condition=" '$(CreateVsixContainer)' == '' ">False</CreateVsixContainer>
     <CopyBuildOutputToOutputDirectory>False</CopyBuildOutputToOutputDirectory>

--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"   TaskName="Xamarin.Android.BuildTools.PrepTasks.GitBlame" />
-  <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"   TaskName="Xamarin.Android.BuildTools.PrepTasks.GitBranch" />
-  <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"   TaskName="Xamarin.Android.BuildTools.PrepTasks.GitCommitHash" />
-  <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"   TaskName="Xamarin.Android.BuildTools.PrepTasks.GitCommitsInRange" />
+  <Import Project="..\scripts\XAVersionInfo.targets" />
   <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"   TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
   <PropertyGroup>
     <!-- Don't ever deploy, since that won't work on Mac -->
@@ -81,7 +78,7 @@
     </ItemGroup>
   </Target>
   <Target Name="GetVsixVersion"
-      DependsOnTargets="_GetVersionInfo"
+      DependsOnTargets="GetXAVersionInfo"
       Returns="$(VsixVersion)">
     <PropertyGroup>
       <VsixVersion>$(ProductVersion).$(_XACommitCount)</VsixVersion>
@@ -94,57 +91,34 @@
       <IsExperimental Condition=" '$(IsProductComponent)' == 'True' ">false</IsExperimental>
     </PropertyGroup>
   </Target>
-  <Target Name="_GetVersionInfo">
-    <GitBlame
-        FileName="$(XamarinAndroidSourcePath)\Configuration.props"
-        LineFilter="&lt;ProductVersion&gt;"
-        WorkingDirectory="$(XamarinAndroidSourcePath)"
-        ToolPath="$(GitToolPath)"
-        ToolExe="$(GitToolExe)">
-      <Output TaskParameter="Commits"                 ItemName="_XAVersionCommit" />
-    </GitBlame>
-    <GitCommitsInRange
-        StartCommit="%(_XAVersionCommit.CommitHash)"
-        WorkingDirectory="$(XamarinAndroidSourcePath)"
-        ToolPath="$(GitToolPath)"
-        ToolExe="$(GitToolExe)">
-      <Output TaskParameter="CommitCount"             PropertyName="_XACommitCount" />
-    </GitCommitsInRange>
-    <GitCommitHash
-        WorkingDirectory="$(XamarinAndroidSourcePath)"
-        ToolPath="$(GitToolPath)"
-        ToolExe="$(GitToolExe)">
-      <Output TaskParameter="AbbreviatedCommitHash"   PropertyName="_XAHash" />
-    </GitCommitHash>
-    <GitBranch
-        WorkingDirectory="$(XamarinAndroidSourcePath)"
-        ToolPath="$(GitToolPath)"
-        ToolExe="$(GitToolExe)">
-      <Output TaskParameter="Branch"                  PropertyName="_XABranch" />
-    </GitBranch>
-  </Target>
   <Target Name="_CreateDependencies"
-      DependsOnTargets="_GetVersionInfo"
+      DependsOnTargets="GetXAVersionInfo"
       BeforeTargets="Build"
       Inputs="Xamarin.Android.Sdk.pkgdef.in"
       Outputs="Xamarin.Android.Sdk.pkgdef">
     <ReplaceFileContents
         SourceFile="Xamarin.Android.Sdk.pkgdef.in"
         DestinationFile="Xamarin.Android.Sdk.pkgdef"
-        Replacements="@PACKAGE_VERSION@=$(ProductVersion);@PACKAGE_VERSION_BUILD@=$(_XACommitCount);@PACKAGE_HEAD_REV@=$(_XAHash);@PACKAGE_HEAD_BRANCH@=$(_XABranch)">
+        Replacements="@PACKAGE_VERSION@=$(ProductVersion);@PACKAGE_VERSION_BUILD@=$(XAVersionCommitCount);@PACKAGE_HEAD_REV@=$(XAVersionHash);@PACKAGE_HEAD_BRANCH@=$(XAVersionBranch)">
     </ReplaceFileContents>
   </Target>
-  <Target Name="_CopyToBuildConfiguration"
-      DependsOnTargets="_GetVersionInfo"
-      Inputs="$(OutputPath)$(AssemblyName).vsix"
-      Outputs="..\..\bin\Build$(Configuration)\$(AssemblyName).vsix">
+  <Target Name="_GetVsixPath"
+      DependsOnTargets="GetXAVersionInfo">
     <PropertyGroup>
-      <_Branch>$(_XABranch.Replace ('/', '-'))</_Branch>
+      <_Branch>$(XAVersionBranch.Replace ('/', '-'))</_Branch>
       <_Branch>$(_Branch.Replace ('\', '-'))</_Branch>
     </PropertyGroup>
+    <PropertyGroup>
+      <VsixPath Condition=" '$(VsixPath)' == '' ">..\..\bin\Build$(Configuration)\$(AssemblyName)-$(ProductVersion).$(XAVersionCommitCount)_$(XAVersionBranch)_$(XAVersionHash).vsix</VsixPath>
+    </PropertyGroup>
+  </Target>
+  <Target Name="_CopyToBuildConfiguration"
+      DependsOnTargets="_GetVsixPath"
+      Inputs="$(OutputPath)$(AssemblyName).vsix"
+      Outputs="$(VsixPath)">
     <Copy
         SourceFiles="$(OutputPath)$(AssemblyName).vsix"
-        DestinationFiles="..\..\bin\Build$(Configuration)\$(AssemblyName)-$(ProductVersion).$(_XACommitCount)_$(_Branch)_$(_XAHash).vsix"
+        DestinationFiles="$(VsixPath)"
     />
   </Target>
 </Project>

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -130,7 +130,14 @@ _BUNDLE_ZIPS_EXCLUDE  = \
 
 create-vsix:
 	$(foreach conf, $(CONFIGURATIONS), \
-		MONO_IOMAP=all MONO_OPTIONS=--arch=64 msbuild $(MSBUILD_FLAGS) build-tools/create-vsix/create-vsix.csproj /p:Configuration=$(conf) /p:CreateVsixContainer=True ; )
+		MONO_IOMAP=all MONO_OPTIONS=--arch=64 msbuild $(MSBUILD_FLAGS) /p:Configuration=$(conf) /p:CreateVsixContainer=True \
+			build-tools/create-vsix/create-vsix.csproj \
+			$(if $(VSIX),"/p:VsixPath=$(VSIX)") \
+			$(if $(PRODUCT_COMPONENT),/p:IsProductComponent="$(PRODUCT_COMPONENT)") \
+			$(if $(PACKAGE_VERSION),/p:ProductVersion="$(PACKAGE_VERSION)") \
+			$(if $(PACKAGE_HEAD_BRANCH),/p:XAVersionBranch="$(PACKAGE_HEAD_BRANCH)") \
+			$(if $(PACKAGE_VERSION_REV),/p:XAVersionCommitCount="$(PACKAGE_VERSION_REV)") \
+			$(if $(COMMIT),/p:XAVersionHash="$(COMMIT)") ; )
 
 package-oss-name:
 	@echo ZIP_OUTPUT=$(ZIP_OUTPUT)


### PR DESCRIPTION
We want to use the `make create-vsix` target to create the commercial
`Xamarin.Android.Sdk.vsix` file, but we want it to have a different
filename, matching commit + commit count information from the internal
`monodroid` repo, not the xamarin-android repo.

Uppdate `create-vsix.csproj` to accept a new `$(VsixPath)` property,
which is the path of the .vsix file to create.

Update the default `$(VsixPath)` filename to be
`Xamarin.Android.Sdk-OSS*`, so that if a customer downloads both a
Jenkins OSS build and a commercial .vsix build, it will be easier to
differentiate between them. (The `.vsix` package name information is
*not* changed, thus it is not possible to concurrently have both the
commercial and OSS builds installed in the same VS 2017 SKU.)

Update the `make create-vsix` target so that the output path and other
MSBuild properties can more easily be overridden:

	make create-vsix CONFIGURATIONS=Debug VSIX=`pwd`/MyNewPackage.vsix

The `$(VSIX)` **make**(1) variable sets the `$(VsixPath)` MSBuild
property.

*Note*: the current-working-directory for `make create-vsix` is
`build-tools/create-vsix`; consequently, this command:

	make create-vsix CONFIGURATIONS=Debug VSIX=MyNewPackage.vsix

will create `./build-tools/create-vsix/MyNewPackage.vsix`, *not*
`./MyNewPackage.vsix`.