### PR TITLE
[Xamarin.Android.Build.Tasks] Make use of --bundled-header when using mkbundle.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
@@ -111,6 +111,7 @@ namespace Xamarin.Android.Tasks
 				clb.AppendSwitch ("--dos2unix=false");
 				clb.AppendSwitch ("--nomain");
 				clb.AppendSwitch ("--i18n none");
+				clb.AppendSwitch ("--bundled-header");
 				clb.AppendSwitch ("--style");
 				clb.AppendSwitch ("linux");
 				clb.AppendSwitch ("-c");


### PR DESCRIPTION
We no longer build mkbundle manually. Instead we make use of the
system mono version. This commit makes sure we don't have a
dependency on having mono installed by using the --bundled-header
flag for mkbundle.

--bundled-header makes sure the generated code does not require
mono-config.h. This means it will compile without mono being
installed. Which is important on windows since most users will NOT
have mono.