### PR TITLE
[CodeGen-Binding] Use `com.android.tools.build:gradle:2.3.0`

### DIFF
--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/java/JavaLib/build.gradle
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/java/JavaLib/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.4.0-alpha3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Fix a [build][0] [break][1]:

	Executing: ./gradlew assembleDebug --stacktrace
	...
	The android gradle plugin version 2.4.0-alpha3 is too old, please update to the latest version.
	To override this check from the command line please set the ANDROID_DAILY_OVERRIDE environment variable to "ea6ce2cbbbfb0e0a68b85eb08916733d4367c4dd"
	FAILURE: Build failed with an exception

For a change, this break on Jenkins wasn't *directly* caused by a
commit; it was *indirectly* caused by commit 571546a1, which specified
`com.android.tools.build:gradle:2.4.0-alpha3`.

Turns Out™, `gradle:2.4.0-alpha3` has a builtin "expiration date",
*presumably* of 2017-Apr-30, meaning that when you build after the
expiration date, it doesn't actually build.

The result is the above error from `gradlew assembleDebug`.

The fix? Don't use preview packages if they can be avoided. The
`gradle:2.3.0` package appears to work Just Fine™, with the added
benefit that it's *not* a preview package.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/371/
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/371/consoleText