### PR TITLE
[build] Build Mono.Android.Export.dll for the *minimum* API level

### DIFF
--- a/build-tools/scripts/Info.targets
+++ b/build-tools/scripts/Info.targets
@@ -7,4 +7,10 @@
         Importance="High"
     />
   </Target>
+  <Target Name="GetAndroidLatestFrameworkVersion">
+    <Message
+        Text="$(AndroidLatestFrameworkVersion)"
+        Importance="High"
+    />
+  </Target>
 </Project>

--- a/src/OpenTK-1.0/OpenTK.csproj
+++ b/src/OpenTK-1.0/OpenTK.csproj
@@ -600,7 +600,7 @@
     <JavacSourceVersion Condition=" '$(JavacSourceVersion)' == '' And '$(AndroidApiLevel)' != '' And $(AndroidApiLevel) &gt; 23 ">1.8</JavacSourceVersion>
     <JavacSourceVersion Condition=" '$(JavacSourceVersion)' == '' ">1.6</JavacSourceVersion>
     <JavaCallableWrapperAbsAssembly>$(JavaCallableWrapperOutputPathAbs)$(AssemblyName).dll</JavaCallableWrapperAbsAssembly>
-    <JavaCallableWrapperAbsAssembly Condition="!Exists('$(JavaCallableWrapperAbsAssembly)')">$(MSBuildProjectDirectory)\..\..\bin\$(Configuration)\lib\xbuild-frameworks\MonoAndroid\$(AndroidLatestFrameworkVersion)\$(AssemblyName).dll</JavaCallableWrapperAbsAssembly>
+    <JavaCallableWrapperAbsAssembly Condition="!Exists('$(JavaCallableWrapperAbsAssembly)')">$(MSBuildProjectDirectory)\$(IntermediateOutputPath)\$(AssemblyName).dll</JavaCallableWrapperAbsAssembly>
   </PropertyGroup>
   <Import Project="..\..\build-tools\scripts\JavaCallableWrappers.targets" />
   <ItemGroup>


### PR DESCRIPTION
Build-time assembly resolution is...complicated, but to summarize
greatly, when `<Reference Include="Mono.Android.Export" />` is
resolved, the following locations are checked:

	$(TargetFrameworkRootPath)\$(TargetFrameworkVersion)\Mono.Android.Export.dll
	...included framework versions...
	$(TargetFrameworkRootPath)\v1.0\Mono.Android.Export.dll

The `...included framework versions...` list is controlled by the
`RedistList/FrameworkList.xml` files and their
`/FileList/@IncludeFramework` attribute value. For example,
`bin/Debug/lib/xbuild-frameworks/MonoAndroid/v7.1/RedistList/FrameworkList.xml`
may have a value of `v7.0` for the `IncludeFramework` attribute.
Checking `/FileList/@IncludeFramework` is done "recursively", and if
you have a build environment created by `make jenkins`, this will
"chain" through every supported framework version.

Thus, if `$(TargetFrameworkVersion)` is `v6.0`, then the following
directories may be checked to resolve `Mono.Android.Export.dll`:

	…/MonoAndroid/v6.0/Mono.Android.Export.dll
	…/MonoAndroid/v5.1/Mono.Android.Export.dll
	…/MonoAndroid/v5.0/Mono.Android.Export.dll
	…/MonoAndroid/v4.4.87/Mono.Android.Export.dll
	…/MonoAndroid/v4.4/Mono.Android.Export.dll
	…/MonoAndroid/v4.3/Mono.Android.Export.dll
	…/MonoAndroid/v4.2/Mono.Android.Export.dll
	…/MonoAndroid/v4.1/Mono.Android.Export.dll
	…/MonoAndroid/v4.0.3/Mono.Android.Export.dll
	…/MonoAndroid/v2.3/Mono.Android.Export.dll
	…/MonoAndroid/v1.0/Mono.Android.Export.dll

The first match is used.

Which presents a bit of a problem for e.g.
[Build #373's `oss-xamarin.android*.zip`][0] file, which is a build
tree prior to this change: It places `Mono.Android.Export.dll` into
the `$(AndroidLatestFrameworkVersion)` directory:

	$ unzip -l oss-xamarin.android_v7.3.99.35_Darwin-x86_64_master_767caad.zip | grep Mono.Android.Export.dll
	    77824  05-01-2017 21:30   oss-xamarin.android_v7.3.99.35_Darwin-x86_64_master_767caad/bin/Debug/lib/xbuild-frameworks/MonoAndroid/v7.1/Mono.Android.Export.dll
	    69632  05-01-2017 21:26   oss-xamarin.android_v7.3.99.35_Darwin-x86_64_master_767caad/bin/Release/lib/xbuild-frameworks/MonoAndroid/v7.1/Mono.Android.Export.dll

This is problematic because if the app's `$(TargetFrameworkVersion)`
value is *lower* than `v7.1`, then `Mono.Android.Export.dll`
*cannot be resolved*:

	$ xbuild /t:SignAndroidPackage /p:TargetFrameworkVersion=v5.0 ExampleUsingExport.csproj
	...
		error XA4210: You need to add a reference to Mono.Android.Export.dll when you use ExportAttribute or ExportFieldAttribute

...ouch. :-(

The correct fix is to update the `make framework-assemblies` target to
build `Mono.Android.Export.csproj` into the lowest supported
API-level, `$(firstword $(API_LEVELS))`. This would change the contents
of the above `oss-xamarin.android*.zip` file to instead contain:

	…/bin/Debug/lib/xbuild-frameworks/MonoAndroid/v2.3/Mono.Android.Export.dll
	…/bin/Release/lib/xbuild-frameworks/MonoAndroid/v2.3/Mono.Android.Export.dll

Since API-10 (v2.3) is the lowest supported API level, this allows
`Mono.Android.Export.dll` to be used in all supported framework
versions.

"While we're at it," remove the `make task-assemblies` and
`make runtime-libraries` targets, as these were redundent with -- and
ran the same commands as -- the `make leeroy-all` target.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/373/Azure/processDownloadRequest/xamarin-android/oss-xamarin.android_v7.3.99.35_Darwin-x86_64_master_767caad.zip