### PR TITLE
[Xamarin.Android.Build.Tasks] android:debuggable="true" should not be set in RELEASE mode

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -296,5 +296,34 @@ namespace Bug12935
 				Assert.IsTrue (manifest.Contains ("AAAAAAAA"), "#1");
 			}
 		}
+
+		static object[] DebuggerAttributeCases = new object[] {
+			// DebugType, isRelease, extpected
+			new object[] { "", true, false, },
+			new object[] { "", false, true, },
+			new object[] { "None", true, false, },
+			new object[] { "None", false, false, },
+			new object[] { "PdbOnly", true, false, },
+			new object[] { "PdbOnly", false, true, },
+			new object[] { "Full", true, false, },
+			new object[] { "Full", false, true, },
+			new object[] { "Portable", true, false, },
+			new object[] { "Portable", false, true, },
+		};
+
+		[Test]
+		[TestCaseSource ("DebuggerAttributeCases")]
+		public void DebuggerAttribute (string debugType, bool isRelease, bool expected)
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = isRelease,
+			};
+			proj.SetProperty (isRelease ? proj.ReleaseProperties : proj.DebugProperties, "DebugType", debugType);
+			using (var builder = CreateApkBuilder (Path.Combine ("temp", $"DebuggerAttribute_{debugType}_{isRelease}_{expected}"), false, false)) {
+				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
+				var manifest = builder.Output.GetIntermediaryAsText (Root, Path.Combine ("android", "AndroidManifest.xml"));
+				Assert.AreEqual (expected, manifest.Contains ("android:debuggable=\"true\""), $"Manifest  {(expected ? "should" : "should not")} contain the andorid:debuggable attribute");
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=56075

Looks like there was a change to either the IDE or the template
for VS2017. Rather than leaving DebugType blank or not setting it
in the new project it gets a value of 'None'. As a result our code
which decides if this is a debug build, which only checks for ''
fails.

This commit adds a check for "None" and adds the appropriate unit tests.