### PR TITLE
[Xamarin.Android.Build.Tests] Migrate most of the remaining unit tests for msbuild.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.OSS.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.OSS.cs
@@ -1,0 +1,152 @@
+﻿﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+using NUnit.Framework;
+using Xamarin.ProjectTools;
+
+namespace Xamarin.Android.Build.Tests
+{
+	public partial class BuildTest : BaseTest
+	{
+#pragma warning disable 414
+		static object [] AotChecks = new object [] {
+			new object[] {
+				/* supportedAbis */   "armeabi-v7a",
+				/* enableLLVM */      false,
+				/* expectedResult */  true,
+			},
+			new object[] {
+				/* supportedAbis */   "armeabi-v7a",
+				/* enableLLVM */      true,
+				/* expectedResult */  true,
+			},
+			new object[] {
+				/* supportedAbis */   "x86",
+				/* enableLLVM */      false,
+				/* expectedResult */  true,
+			},
+			new object[] {
+				/* supportedAbis */   "x86",
+				/* enableLLVM */      true,
+				/* expectedResult */  true,
+			},
+		};
+
+		static object [] ProguardChecks = new object [] {
+			new Object [] {
+				/* isRelease */ true,
+				/* enableProguard */ true,
+				/* useLatestSdk */ true,
+			},
+			new Object [] {
+				/* isRelease */ true,
+				/* enableProguard */ false,
+				/* useLatestSdk */ true,
+			},
+			new Object [] {
+				/* isRelease */ false,
+				/* enableProguard */ true,
+				/* useLatestSdk */ true,
+			},
+			new Object [] {
+				/* isRelease */ false,
+				/* enableProguard */ false,
+				/* useLatestSdk */ true,
+			},
+		};
+		static object [] TakeSimpleFlag = new object [] {
+			new Object [] { false },
+			// Disabled because Jack DOESN'T work
+			// re-enable once it does.
+			//new Object [] { true },
+		};
+		// useJackAndJill, useLatestSdk
+		static object [] JackFlagAndFxVersion = new object [] {
+			new Object [] { false, "v7.1" },
+			// Disabled because Jack DOESN'T work
+			// re-enable once it does.
+			//new Object [] { true, false },
+			//new Object [] { true, true },
+		};
+
+		static object [] SequencePointChecks = new object [] {
+			new object[] {
+				/* isRelease */          false,
+				/* monoSymbolArchive */  false ,
+				/* aotAssemblies */      false,
+				/* debugSymbols */       true,
+				/* debugType */          "Full",
+				/* embedMdb */           true, // because we don't use FastDev in the OSS repo
+				/* expectedRuntime */    "debug",
+			},
+			new object[] {
+				/* isRelease */          true,
+				/* monoSymbolArchive */  false,
+				/* aotAssemblies */      false,
+				/* debugSymbols */       true,
+				/* debugType */          "Full",
+				/* embedMdb */           false,
+				/* expectedRuntime */    "release",
+			},
+			new object[] {
+				/* isRelease */          true,
+				/* monoSymbolArchive */  true,
+				/* aotAssemblies */      false,
+				/* debugSymbols */       true,
+				/* debugType */          "Full",
+				/* embedMdb */           false,
+				/* expectedRuntime */    "release",
+			},
+			new object[] {
+				/* isRelease */          true,
+				/* monoSymbolArchive */  true ,
+				/* aotAssemblies */      false,
+				/* debugSymbols */       true,
+				/* debugType */          "PdbOnly",
+				/* embedMdb */           false,
+				/* expectedRuntime */    "release",
+			},
+			new object[] {
+				/* isRelease */          true,
+				/* monoSymbolArchive */  true ,
+				/* aotAssemblies */      true,
+				/* debugSymbols */       true,
+				/* debugType */          "PdbOnly",
+				/* embedMdb */           false,
+				/* expectedRuntime */    "release",
+			},
+			new object[] {
+				/* isRelease */          true,
+				/* monoSymbolArchive */  false ,
+				/* aotAssemblies */      false,
+				/* debugSymbols */       true,
+				/* debugType */          "PdbOnly",
+				/* embedMdb */           false,
+				/* expectedRuntime */    "release",
+			},
+			new object[] {
+				/* isRelease */          true,
+				/* monoSymbolArchive */  false ,
+				/* aotAssemblies */      true,
+				/* debugSymbols */       false,
+				/* debugType */          "",
+				/* embedMdb */           false,
+				/* expectedRuntime */    "release",
+			},
+			new object[] {
+				/* isRelease */          true,
+				/* monoSymbolArchive */  true ,
+				/* aotAssemblies */      true,
+				/* debugSymbols */       false,
+				/* debugType */          "",
+				/* embedMdb */           false,
+				/* expectedRuntime */    "release",
+			},
+		};
+#pragma warning restore 414
+	}
+}
+

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -10,8 +10,1445 @@ using Xamarin.ProjectTools;
 namespace Xamarin.Android.Build.Tests
 {
 	[Parallelizable (ParallelScope.Fixtures)]
-	public class BuildTest : BaseTest
+	public partial class BuildTest : BaseTest
 	{
+		[Test]
+		public void BuildBasicApplication ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			using (var b = CreateApkBuilder ("temp/BuildBasicApplication")) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
+		[Test]
+		public void BuildBasicApplicationRelease ()
+		{
+			var proj = new XamarinAndroidApplicationProject () { IsRelease = true };
+			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationRelease")) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
+		[Test]
+		[Category ("Minor")]
+		public void BuildBasicApplicationFSharp ()
+		{
+			var proj = new XamarinAndroidApplicationProject () { Language = XamarinAndroidProjectLanguage.FSharp };
+			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationFSharp")) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
+		[Test]
+		[Category ("Minor")]
+		public void BuildBasicApplicationReleaseFSharp ()
+		{
+			var proj = new XamarinAndroidApplicationProject () { Language = XamarinAndroidProjectLanguage.FSharp, IsRelease = true };
+			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationReleaseFSharp")) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
+		[Test]
+		public void BuildApplicationAndClean ([Values (false, true)] bool isRelease)
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = isRelease,
+			};
+			using (var b = CreateApkBuilder (Path.Combine ("temp", "BuildApplicationAndClean"))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
+				var files = Directory.GetFiles (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath), "*", SearchOption.AllDirectories)
+					.Where (x => !Path.GetFileName (x).StartsWith ("TemporaryGeneratedFile"));
+				Assert.AreEqual (0, files.Count (), "{0} should be Empty. Found {1}", proj.IntermediateOutputPath, string.Join (Environment.NewLine, files));
+				files = Directory.GetFiles (Path.Combine (Root, b.ProjectDirectory, proj.OutputPath), "*", SearchOption.AllDirectories)
+					.Where (x => !Path.GetFileName (x).StartsWith ("TemporaryGeneratedFile"));
+				Assert.AreEqual (0, files.Count (), "{0} should be Empty. Found {1}", proj.OutputPath, string.Join (Environment.NewLine, files));
+			}
+		}
+
+		[Test]
+		public void BuildApplicationWithLibraryAndClean ([Values (false, true)] bool isRelease)
+		{
+			var lib = new XamarinAndroidLibraryProject () {
+				IsRelease = isRelease,
+				ProjectName = "Library1",
+				OtherBuildItems = {
+					new AndroidItem.AndroidAsset ("Assets\\somefile.txt") {
+						TextContent =  () => "some readonly file...",
+						Attributes = FileAttributes.ReadOnly,
+					},
+				},
+			};
+			for (int i = 0; i < 1000; i++) {
+				lib.OtherBuildItems.Add (new AndroidItem.AndroidAsset (string.Format ("Assets\\somefile{0}.txt", i)) {
+					TextContent = () => "some readonly file...",
+					Attributes = FileAttributes.ReadOnly | FileAttributes.Normal,
+				});
+				lib.AndroidResources.Add (new AndroidItem.AndroidResource (string.Format ("Resources\\values\\Strings{0}.xml", i)) {
+					TextContent = () => string.Format (@"<?xml version=""1.0"" encoding=""utf-8""?>
+<resources>
+	<string name=""hello{0}"">Hello World, Click Me! {0}</string>
+</resources>", i++),
+					Attributes = FileAttributes.ReadOnly | FileAttributes.Normal,
+				});
+			}
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = isRelease,
+				ProjectName = "App1",
+				References = { new BuildItem ("ProjectReference", "..\\Library1\\Library1.csproj") },
+			};
+			var projectPath = Path.Combine ("temp", "BuildApplicationWithLibraryAndClean");
+			using (var libb = CreateDllBuilder (Path.Combine (projectPath, lib.ProjectName), false, false)) {
+				Assert.IsTrue (libb.Build (lib), "Build of library should have succeeded");
+				using (var b = CreateApkBuilder (Path.Combine (projectPath, proj.ProjectName), false, false)) {
+					Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+					//var fi = new FileInfo (Path.Combine (b.ProjectDirectory, proj.IntermediateOutputPath,
+					//	"__library_projects__", "Library1", "library_project_imports", ""));
+					//fi.Attributes != FileAttributes.ReadOnly;
+					Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
+					var fileCount = Directory.GetFiles (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath), "*", SearchOption.AllDirectories)
+						.Where (x => !Path.GetFileName (x).StartsWith ("TemporaryGeneratedFile")).Count ();
+					Assert.AreEqual (0, fileCount, "{0} should be Empty", proj.IntermediateOutputPath);
+					fileCount = Directory.GetFiles (Path.Combine (Root, b.ProjectDirectory, proj.OutputPath), "*", SearchOption.AllDirectories)
+						.Where (x => !Path.GetFileName (x).StartsWith ("TemporaryGeneratedFile")).Count ();
+					Assert.AreEqual (0, fileCount, "{0} should be Empty", proj.OutputPath);
+				}
+			}
+		}
+
+		[Test]
+		public void BuildMkBundleApplicationRelease ()
+		{
+			var proj = new XamarinAndroidApplicationProject () { IsRelease = true, BundleAssemblies = true };
+			using (var b = CreateApkBuilder ("temp/BuildMkBundleApplicationRelease", false)) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				var assemblies = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,
+					"bundles", "armeabi-v7a", "assemblies.o");
+				Assert.IsTrue (File.Exists (assemblies), "assemblies.o does not exist");
+				var libapp = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,
+					"bundles", "armeabi-v7a", "libmonodroid_bundle_app.so");
+				Assert.IsTrue (File.Exists (libapp), "libmonodroid_bundle_app.so does not exist");
+				var apk = Path.Combine (Root, b.ProjectDirectory,
+					proj.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
+				using (var zipFile = ZipHelper.OpenZip (apk)) {
+					Assert.IsNotNull (ZipHelper.ReadFileFromZip (zipFile,
+						"lib/armeabi-v7a/libmonodroid_bundle_app.so"),
+						"lib/armeabi-v7a/libmonodroid_bundle_app.so should be in the UnnamedProject.UnnamedProject.apk");
+					Assert.IsNull (ZipHelper.ReadFileFromZip (zipFile,
+						Path.Combine ("assemblies", "UnnamedProject.dll")),
+						"UnnamedProject.dll should not be in the UnnamedProject.UnnamedProject.apk");
+				}
+			}
+		}
+
+		[Test]
+		[Category ("Minor")]
+		public void BuildMkBundleApplicationReleaseAllAbi ()
+		{
+			var proj = new XamarinAndroidApplicationProject () { IsRelease = true, BundleAssemblies = true };
+			proj.SetProperty (KnownProperties.AndroidSupportedAbis, "armeabi-v7a;x86");
+			using (var b = CreateApkBuilder ("temp/BuildMkBundleApplicationReleaseAllAbi", false)) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				foreach (var abi in new string [] { "armeabi-v7a", "x86" }) {
+					var assemblies = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,
+						"bundles", abi, "assemblies.o");
+					Assert.IsTrue (File.Exists (assemblies), abi + " assemblies.o does not exist");
+					var libapp = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,
+						"bundles", abi, "libmonodroid_bundle_app.so");
+					Assert.IsTrue (File.Exists (libapp), abi + " libmonodroid_bundle_app.so does not exist");
+					var apk = Path.Combine (Root, b.ProjectDirectory,
+						proj.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
+					using (var zipFile = ZipHelper.OpenZip (apk)) {
+						Assert.IsNotNull (ZipHelper.ReadFileFromZip (zipFile,
+							"lib/" + abi + "/libmonodroid_bundle_app.so"),
+							"lib/{0}/libmonodroid_bundle_app.so should be in the UnnamedProject.UnnamedProject.apk", abi);
+						Assert.IsNull (ZipHelper.ReadFileFromZip (zipFile,
+							Path.Combine ("assemblies", "UnnamedProject.dll")),
+							"UnnamedProject.dll should not be in the UnnamedProject.UnnamedProject.apk");
+					}
+				}
+			}
+		}
+
+		[Test]
+		[TestCaseSource ("AotChecks")]
+		[Category ("Minor")]
+		public void BuildAotApplication (string supportedAbis, bool enableLLVM, bool expectedResult)
+		{
+			var path = Path.Combine ("temp", string.Format ("BuildAotApplication_{0}_{1}_{2}", supportedAbis, enableLLVM, expectedResult));
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				BundleAssemblies = false,
+				AotAssemblies = true,
+			};
+			proj.SetProperty (KnownProperties.TargetFrameworkVersion, "v5.1");
+			proj.SetProperty (KnownProperties.AndroidSupportedAbis, supportedAbis);
+			proj.SetProperty ("EnableLLVM", enableLLVM.ToString ());
+			using (var b = CreateApkBuilder (path)) {
+				b.ThrowOnBuildFailure = false;
+				b.Verbosity = LoggerVerbosity.Diagnostic;
+				Assert.AreEqual (expectedResult, b.Build (proj), "Build should have {0}.", expectedResult ? "succeeded" : "failed");
+				if (!expectedResult)
+					return;
+				foreach (var abi in supportedAbis.Split (new char [] { ';' })) {
+					var libapp = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,
+						"bundles", abi, "libmonodroid_bundle_app.so");
+					Assert.IsFalse (File.Exists (libapp), abi + " libmonodroid_bundle_app.so should not exist");
+					var assemblies = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,
+						"aot", abi, "libaot-UnnamedProject.dll.so");
+					Assert.IsTrue (File.Exists (assemblies), "{0} libaot-UnnamedProject.dll.so does not exist", abi);
+					var apk = Path.Combine (Root, b.ProjectDirectory,
+						proj.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
+					using (var zipFile = ZipHelper.OpenZip (apk)) {
+						Assert.IsNotNull (ZipHelper.ReadFileFromZip (zipFile,
+							string.Format ("lib/{0}/libaot-UnnamedProject.dll.so", abi)),
+							"lib/{0}/libaot-UnnamedProject.dll.so should be in the UnnamedProject.UnnamedProject.apk", abi);
+						Assert.IsNotNull (ZipHelper.ReadFileFromZip (zipFile,
+							"assemblies/UnnamedProject.dll"),
+							"UnnamedProject.dll should be in the UnnamedProject.UnnamedProject.apk");
+					}
+				}
+				Assert.AreEqual (expectedResult, b.Build (proj), "Second Build should have {0}.", expectedResult ? "succeeded" : "failed");
+				Assert.IsTrue (
+					b.LastBuildOutput.Contains ("Skipping target \"_CompileJava\" because"),
+					"the _CompileJava target should be skipped");
+				Assert.IsTrue (
+					b.LastBuildOutput.Contains ("Skipping target \"_BuildApkEmbed\" because"),
+					"the _BuildApkEmbed target should be skipped");
+			}
+		}
+
+		[Test]
+		[TestCaseSource ("AotChecks")]
+		[Category ("Minor")]
+		public void BuildAotApplicationAndBundle (string supportedAbis, bool enableLLVM, bool expectedResult)
+		{
+			var path = Path.Combine ("temp", string.Format ("BuildAotApplicationAndBundle_{0}_{1}_{2}", supportedAbis, enableLLVM, expectedResult));
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				BundleAssemblies = true,
+				AotAssemblies = true,
+			};
+			proj.SetProperty (KnownProperties.TargetFrameworkVersion, "v5.1");
+			proj.SetProperty (KnownProperties.AndroidSupportedAbis, supportedAbis);
+			proj.SetProperty ("EnableLLVM", enableLLVM.ToString ());
+			using (var b = CreateApkBuilder (path)) {
+				b.ThrowOnBuildFailure = false;
+				Assert.AreEqual (expectedResult, b.Build (proj), "Build should have {0}.", expectedResult ? "succeeded" : "failed");
+				if (!expectedResult)
+					return;
+				foreach (var abi in supportedAbis.Split (new char [] { ';' })) {
+					var libapp = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,
+						"bundles", abi, "libmonodroid_bundle_app.so");
+					Assert.IsTrue (File.Exists (libapp), abi + " libmonodroid_bundle_app.so does not exist");
+					var assemblies = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,
+						"aot", abi, "libaot-UnnamedProject.dll.so");
+					Assert.IsTrue (File.Exists (assemblies), "{0} libaot-UnnamedProject.dll.so does not exist", abi);
+					var apk = Path.Combine (Root, b.ProjectDirectory,
+						proj.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
+					using (var zipFile = ZipHelper.OpenZip (apk)) {
+						Assert.IsNotNull (ZipHelper.ReadFileFromZip (zipFile,
+							string.Format ("lib/{0}/libaot-UnnamedProject.dll.so", abi)),
+							"lib/{0}/libaot-UnnamedProject.dll.so should be in the UnnamedProject.UnnamedProject.apk", abi);
+						Assert.IsNull (ZipHelper.ReadFileFromZip (zipFile,
+							"assemblies/UnnamedProject.dll"),
+							"UnnamedProject.dll should not be in the UnnamedProject.UnnamedProject.apk");
+					}
+				}
+				Assert.AreEqual (expectedResult, b.Build (proj), "Second Build should have {0}.", expectedResult ? "succeeded" : "failed");
+				Assert.IsTrue (
+					b.LastBuildOutput.Contains ("Skipping target \"_CompileJava\" because"),
+					"the _CompileJava target should be skipped");
+				Assert.IsTrue (
+					b.LastBuildOutput.Contains ("Skipping target \"_BuildApkEmbed\" because"),
+					"the _BuildApkEmbed target should be skipped");
+			}
+		}
+
+		[Test]
+		[TestCaseSource ("ProguardChecks")]
+		public void BuildProguardEnabledProject (bool isRelease, bool enableProguard, bool useLatestSdk)
+		{
+			var proj = new XamarinAndroidApplicationProject () { IsRelease = isRelease, EnableProguard = enableProguard, UseLatestPlatformSdk = useLatestSdk, TargetFrameworkVersion = useLatestSdk ? "v7.1" : "v5.0" };
+			using (var b = CreateApkBuilder ("temp/BuildProguardEnabledProject")) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
+		XamarinAndroidApplicationProject CreateMultiDexRequiredApplication ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods.java") {
+				TextContent = () => "public class ManyMethods { \n"
+					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
+					+ "}",
+				Encoding = Encoding.ASCII
+			});
+			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods2.java") {
+				TextContent = () => "public class ManyMethods2 { \n"
+					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
+					+ "}",
+				Encoding = Encoding.ASCII
+			});
+			return proj;
+		}
+
+		[Test]
+		[Category ("Minor")]
+		public void BuildApplicationOver65536Methods ()
+		{
+			var proj = CreateMultiDexRequiredApplication ();
+			using (var b = CreateApkBuilder ("temp/BuildApplicationOver65536Methods")) {
+				b.ThrowOnBuildFailure = false;
+				Assert.IsFalse (b.Build (proj), "Without MultiDex option, build should fail");
+				b.Clean (proj);
+			}
+		}
+
+		[Test]
+		[TestCaseSource ("JackFlagAndFxVersion")]
+		public void BuildMultiDexApplication (bool useJackAndJill, string fxVersion)
+		{
+			var proj = CreateMultiDexRequiredApplication ();
+			proj.UseJackAndJill = useJackAndJill;
+			proj.TargetFrameworkVersion = fxVersion;
+			proj.UseLatestPlatformSdk = false;
+			proj.SetProperty ("AndroidEnableMultiDex", "True");
+
+			using (var b = CreateApkBuilder ("temp/BuildMultiDexApplication")) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsTrue (File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android/bin/classes.dex")),
+					"multidex-ed classes.zip exists");
+				Assert.IsTrue (b.LastBuildOutput.Contains (Path.Combine (fxVersion, "mono.android.jar")), fxVersion + "/mono.android.jar should be used.");
+			}
+		}
+
+		[Test]
+		public void MultiDexCustomMainDexFileList ()
+		{
+			var proj = CreateMultiDexRequiredApplication ();
+			proj.SetProperty ("AndroidEnableMultiDex", "True");
+			proj.OtherBuildItems.Add (new BuildItem ("MultiDexMainDexList", "mymultidex.keep") { TextContent = () => "MyTest", Encoding = Encoding.ASCII });
+			proj.OtherBuildItems.Add (new BuildItem ("AndroidJavaSource", "MyTest.java") { TextContent = () => "public class MyTest {}", Encoding = Encoding.ASCII });
+			var b = CreateApkBuilder ("temp/MultiDexCustomMainDexFileList");
+			b.ThrowOnBuildFailure = false;
+			Assert.IsTrue (b.Build (proj), "build should succeed. Run will fail.");
+			Assert.AreEqual ("MyTest", File.ReadAllText (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "multidex.keep")), "unexpected multidex.keep content");
+			b.Clean (proj);
+			b.Dispose ();
+		}
+
+		[Test]
+		public void CustomApplicationClassAndMultiDex ()
+		{
+			var proj = CreateMultiDexRequiredApplication ();
+			proj.SetProperty ("AndroidEnableMultiDex", "True");
+			proj.Sources.Add (new BuildItem ("Compile", "CustomApp.cs") { TextContent = () => @"
+using System;
+using Android.App;
+using Android.Runtime;
+namespace UnnamedProject {
+    [Application(Name = ""com.foxsports.test.CustomApp"")]
+    public class CustomApp : Application
+    {
+        public CustomApp(IntPtr handle, JniHandleOwnership ownerShip) :
+			base(handle, ownerShip)
+		{
+
+
+        }
+
+        public override void OnCreate()
+        {
+            base.OnCreate();
+        }
+    }
+}" });
+			using (var b = CreateApkBuilder ("temp/CustomApplicationClassAndMultiDex")) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
+		[Test]
+		public void BasicApplicationRepetitiveBuild ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			using (var b = CreateApkBuilder ("temp/BasicApplicationRepetitiveBuild", cleanupAfterSuccessfulBuild: false)) {
+				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
+				b.ThrowOnBuildFailure = false;
+				Assert.IsTrue (b.Build (proj), "first build failed");
+				var firstBuildTime = b.LastBuildTime;
+				Assert.IsTrue (b.Build (proj), "second build failed");
+				Assert.IsTrue (
+					firstBuildTime > b.LastBuildTime, "Second build ({0}) should have been faster than the first ({1})",
+					b.LastBuildTime, firstBuildTime
+				);
+				Assert.IsTrue (
+					b.LastBuildOutput.Contains ("Skipping target \"_Sign\" because"),
+					"the _Sign target should not run");
+				Assert.IsTrue (
+					b.LastBuildOutput.Contains ("Skipping target \"_StripEmbeddedLibraries\" because"),
+					"the _StripEmbeddedLibraries target should not run");
+				proj.AndroidResources.First ().Timestamp = null;
+				Assert.IsTrue (b.Build (proj), "third build failed");
+				Assert.IsFalse (
+					b.LastBuildOutput.Contains ("Skipping target \"_Sign\" because"),
+					"the _Sign target should run");
+			}
+		}
+
+		[Test]
+		public void BasicApplicationRepetitiveReleaseBuild ()
+		{
+			var proj = new XamarinAndroidApplicationProject () { IsRelease = true };
+			using (var b = CreateApkBuilder ("temp/BasicApplicationRepetitiveReleaseBuild", cleanupAfterSuccessfulBuild: false)) {
+				var foo = new BuildItem.Source ("Foo.cs") {
+					TextContent = () => @"using System;
+	namespace UnnamedProject {
+		public class Foo {
+		}
+	}"
+				};
+				proj.Sources.Add (foo);
+				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
+				b.ThrowOnBuildFailure = false;
+				Assert.IsTrue (b.Build (proj), "first build failed");
+				var firstBuildTime = b.LastBuildTime;
+				Assert.IsTrue (b.Build (proj), "second build failed");
+				Assert.IsTrue (
+					firstBuildTime > b.LastBuildTime, "Second build ({0}) should have been faster than the first ({1})",
+					b.LastBuildTime, firstBuildTime
+				);
+				Assert.IsTrue (
+					b.LastBuildOutput.Contains ("Skipping target \"_Sign\" because"),
+					"the _Sign target should not run");
+				Assert.IsTrue (
+					b.LastBuildOutput.Contains ("Skipping target \"_StripEmbeddedLibraries\" because"),
+					"the _StripEmbeddedLibraries target should not run");
+				Assert.IsTrue (
+					b.LastBuildOutput.Contains ("Skipping target \"_LinkAssembliesShrink\" because"),
+					"the _LinkAssembliesShrink target should not run");
+				foo.Timestamp = DateTime.UtcNow;
+				Assert.IsTrue (b.Build (proj), "third build failed");
+				Assert.IsTrue (b.LastBuildOutput.Contains ("Target CoreCompile needs to be built as input file ") ||
+		    b.LastBuildOutput.Contains ("Building target \"CoreCompile\" completely."),
+					"the Core Compile target should run");
+				Assert.IsFalse (
+					b.LastBuildOutput.Contains ("Skipping target \"_Sign\" because"),
+					"the _Sign target should run");
+			}
+		}
+
+		[Test]
+		public void BuildBasicApplicationCheckMdb ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationCheckMdb", false)) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsTrue (
+					File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android/assets/UnnamedProject.dll.mdb")) ||
+					File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android/assets/UnnamedProject.pdb")),
+					"UnnamedProject.dll.mdb must be copied to the Intermediate directory");
+			}
+		}
+
+		[Test]
+		public void BuildBasicApplicationCheckMdbRepeatBuild ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationCheckMdbRepeatBuild", false)) {
+				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsTrue (
+					File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android/assets/UnnamedProject.dll.mdb")) ||
+					File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android/assets/UnnamedProject.pdb")),
+					"UnnamedProject.dll.mdb must be copied to the Intermediate directory");
+				Assert.IsTrue (b.Build (proj), "second build failed");
+				Assert.IsTrue (
+					b.LastBuildOutput.Contains ("Skipping target \"_CopyMdbFiles\" because"),
+					"the _CopyMdbFiles target should be skipped");
+				Assert.IsTrue (
+					File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android/assets/UnnamedProject.dll.mdb")) ||
+					File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android/assets/UnnamedProject.pdb")),
+					"UnnamedProject.dll.mdb must be copied to the Intermediate directory");
+			}
+		}
+
+		[Test]
+		public void BuildBasicApplicationCheckMdbAndPortablePdb ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationCheckPdb")) {
+				b.Verbosity = LoggerVerbosity.Diagnostic;
+				var reference = new BuildItem.Reference ("PdbTestLibrary.dll") {
+					WebContent = "https://www.dropbox.com/s/s4br29kvuy8ygz1/PdbTestLibrary.dll?dl=1"
+				};
+				proj.References.Add (reference);
+				var pdb = new BuildItem.NoActionResource ("PdbTestLibrary.pdb") {
+					WebContent = "https://www.dropbox.com/s/033jif54ma0e01m/PdbTestLibrary.pdb?dl=1"
+				};
+				proj.References.Add (pdb);
+				var netStandardRef = new BuildItem.Reference ("NetStandard16.dll") {
+					WebContent = "https://www.dropbox.com/s/g7v0d4irzvaw5pl/NetStandard16.dll?dl=1"
+				};
+				proj.References.Add (netStandardRef);
+				var netStandardpdb = new BuildItem.NoActionResource ("NetStandard16.pdb") {
+					WebContent = "https://www.dropbox.com/s/m898ix2m2il631y/NetStandard16.pdb?dl=1"
+				};
+				proj.References.Add (netStandardpdb);
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				var pdbToMdbPath = Path.Combine (Root, b.ProjectDirectory, "PdbTestLibrary.dll.mdb");
+				Assert.IsTrue (
+					File.Exists (pdbToMdbPath),
+					"PdbTestLibrary.dll.mdb must be generated next to the .pdb");
+				Assert.IsTrue (
+					File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "assets", "UnnamedProject.dll.mdb")) ||
+					File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "assets", "UnnamedProject.pdb")),
+					"UnnamedProject.dll.mdb/UnnamedProject.pdb must be copied to the Intermediate directory");
+				Assert.IsFalse (
+					File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "assets", "PdbTestLibrary.pdb")),
+					"PdbTestLibrary.pdb must not be copied to Intermediate directory");
+				Assert.IsTrue (
+					File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "assets", "PdbTestLibrary.dll.mdb")),
+					"PdbTestLibrary.dll.mdb must be copied to Intermediate directory");
+				FileAssert.AreNotEqual (pdbToMdbPath,
+					Path.Combine (Root, b.ProjectDirectory, "PdbTestLibrary.pdb"),
+					"The .pdb should NOT match the .mdb");
+				Assert.IsTrue (
+					File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "assets", "NetStandard16.pdb")),
+					"NetStandard16.pdb must be copied to Intermediate directory");
+				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "second build failed");
+				Assert.IsTrue (
+					b.LastBuildOutput.Contains ("Skipping target \"_CopyMdbFiles\" because"),
+					"the _CopyMdbFiles target should be skipped");
+				var lastTime = File.GetLastAccessTimeUtc (pdbToMdbPath);
+				pdb.Timestamp = DateTime.UtcNow;
+				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "third build failed");
+				Assert.IsFalse (
+					b.LastBuildOutput.Contains ("Skipping target \"_CopyMdbFiles\" because"),
+					"the _CopyMdbFiles target should not be skipped");
+				Assert.Less (lastTime,
+					File.GetLastAccessTimeUtc (pdbToMdbPath),
+					"{0} should have been updated", pdbToMdbPath);
+			}
+		}
+
+		[Test]
+		public void BuildBasicApplicationCheckConfigFiles ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationCheckConfigFiles", false)) {
+				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
+				var config = new BuildItem.NoActionResource ("UnnamedProject.dll.config") {
+					TextContent = () => {
+						return "<?xml version='1.0' ?><configuration/>";
+					},
+					Metadata = {
+						{ "CopyToOutputDirectory", "PreserveNewest"},
+					}
+				};
+				proj.References.Add (config);
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsTrue (
+					File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android/assets/UnnamedProject.dll.config")),
+					"UnnamedProject.dll.config was must be copied to Intermediate directory");
+				Assert.IsTrue (b.Build (proj), "second build failed");
+				Assert.IsTrue (
+					b.LastBuildOutput.Contains ("Skipping target \"_CopyConfigFiles\" because"),
+					"the _CopyConfigFiles target should be skipped");
+			}
+		}
+
+		public void BuildApplicationCheckItEmitsAWarningWithContentItems ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			using (var b = CreateApkBuilder ("temp/BuildApplicationCheckItEmitsAWarningWithContentItems")) {
+				b.ThrowOnBuildFailure = false;
+				proj.AndroidResources.Add (new BuildItem.Content ("TestContent.txt") {
+					TextContent = () => "Test Content"
+				});
+				proj.AndroidResources.Add (new BuildItem.Content ("TestContent1.txt") {
+					TextContent = () => "Test Content 1"
+				});
+				Assert.IsTrue (b.Build (proj), "Build should have built successfully");
+				Assert.IsTrue (
+					b.LastBuildOutput.Contains ("TestContent.txt:  warning XA0101: @(Content) build action is not supported"),
+					"Build Output did not contain the correct error message");
+				Assert.IsTrue (
+					b.LastBuildOutput.Contains ("TestContent1.txt:  warning XA0101: @(Content) build action is not supported"),
+					"Build Output did not contain the correct error message");
+			}
+		}
+
+		[Test]
+		public void BuildApplicationCheckThatAddStaticResourcesTargetDoesNotRerun ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			using (var b = CreateApkBuilder ("temp/BuildApplicationCheckThatAddStaticResourcesTargetDoesNotRerun", false)) {
+				b.Verbosity = LoggerVerbosity.Diagnostic;
+				b.ThrowOnBuildFailure = false;
+				Assert.IsTrue (b.Build (proj), "Build should not have failed");
+				Assert.IsTrue (
+					b.LastBuildOutput.Contains ("Target _AddStaticResources needs to be built as output file") ||
+		    b.LastBuildOutput.Contains ("Building target \"_AddStaticResources\" completely."),
+					"The _AddStaticResources should have been run");
+				Assert.IsTrue (b.Build (proj), "Build should not have failed");
+				Assert.IsTrue (
+					b.LastBuildOutput.Contains ("Skipping target \"_AddStaticResources\" because"),
+					"The _AddStaticResources should NOT have been run");
+			}
+		}
+
+		[Test]
+		[Ignore ("Re enable when MergeResources work is complete")]
+		public void AaptErrorWhenDuplicateStringEntry ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationAaptErrorWithDuplicateEntry")) {
+				// Add a library project so that aapt gets multiple resource directory to include
+				proj.Packages.Add (KnownPackages.SupportV7CardView);
+				proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values\\ExtraStrings.xml") {
+					TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?><resources><string name=""Common.None"">None</string><string name=""Common.None"">None</string></resources>",
+				});
+
+				b.ThrowOnBuildFailure = false;
+				Assert.IsFalse (b.Build (proj), "Build should fail with an aapt error about duplicated string res entries");
+				StringAssert.Contains ("Resource entry Common.None is already defined", b.LastBuildOutput);
+				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded");
+			}
+		}
+
+		[Test]
+		public void CheckJavaError ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "TestMe.java") {
+				TextContent = () => "public classo TestMe { }",
+				Encoding = Encoding.ASCII
+			});
+			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "TestMe2.java") {
+				TextContent = () => "public class TestMe2 {" +
+					"public vod Test ()" +
+					"}",
+				Encoding = Encoding.ASCII
+			});
+			using (var b = CreateApkBuilder ("temp/CheckJavaError")) {
+				b.ThrowOnBuildFailure = false;
+				Assert.IsFalse (b.Build (proj), "Build should have failed.");
+				if (b.RunXBuild) {
+					var text = "TestMe.java(1,8):  javacerror :  error: class, interface, or enum expected";
+					if (b.RunningMSBuild)
+						text = "TestMe.java(1,8): javac error :  error: class, interface, or enum expected";
+					StringAssert.Contains (text, b.LastBuildOutput);
+				} else
+					StringAssert.Contains ("TestMe.java(1,8): javac.exe error :  error: class, interface, or enum expected", b.LastBuildOutput);
+				StringAssert.Contains ("TestMe2.java(1,41): error :  error: ';' expected", b.LastBuildOutput);
+				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
+			}
+		}
+
+		[Test]
+		/// <summary>
+		/// Based on issue raised in
+		/// https://bugzilla.xamarin.com/show_bug.cgi?id=28224
+		/// </summary>
+		public void XA5213IsRaisedWhenOutOfMemoryErrorIsThrown ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods.java") {
+				TextContent = () => "public class ManyMethods { \n"
+					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
+					+ "}",
+				Encoding = Encoding.ASCII
+			});
+			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods2.java") {
+				TextContent = () => "public class ManyMethods2 { \n"
+					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
+					+ "\n}",
+				Encoding = Encoding.ASCII
+			});
+			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods3.java") {
+				TextContent = () => "public class ManyMethods3 { \n"
+					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
+					+ "\n}",
+				Encoding = Encoding.ASCII
+			});
+			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods4.java") {
+				TextContent = () => "public class ManyMethods4 { \n"
+					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
+					+ "\n}",
+				Encoding = Encoding.ASCII
+			});
+			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods5.java") {
+				TextContent = () => "public class ManyMethods5 { \n"
+					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
+					+ "\n}",
+				Encoding = Encoding.ASCII
+			});
+			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods6.java") {
+				TextContent = () => "public class ManyMethods6 { \n"
+					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
+					+ "\n}",
+				Encoding = Encoding.ASCII
+			});
+			proj.Packages.Add (KnownPackages.AndroidSupportV4_21_0_3_0);
+			proj.Packages.Add (KnownPackages.SupportV7AppCompat_21_0_3_0);
+			proj.Packages.Add (KnownPackages.SupportV7MediaRouter_21_0_3_0);
+			proj.Packages.Add (KnownPackages.GooglePlayServices_22_0_0_2);
+			proj.SetProperty ("TargetFrameworkVersion", "v5.0");
+			proj.SetProperty ("AndroidEnableMultiDex", "True");
+			proj.SetProperty (proj.DebugProperties, "JavaMaximumHeapSize", "64m");
+			proj.SetProperty (proj.ReleaseProperties, "JavaMaximumHeapSize", "64m");
+			using (var b = CreateApkBuilder ("temp/XA5213IsRaisedWhenOutOfMemoryErrorIsThrown")) {
+				b.ThrowOnBuildFailure = false;
+				Assert.IsFalse (b.Build (proj), "Build should have failed.");
+				StringAssert.Contains ("XA5213", b.LastBuildOutput);
+				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
+			}
+		}
+
+		[Test]
+		/// <summary>
+		/// Based on issue raised in
+		/// https://bugzilla.xamarin.com/show_bug.cgi?id=28721
+		/// </summary>
+		public void DuplicateValuesInResourceCaseMap ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\layout\\test.axml") {
+				TextContent = () => {
+					return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<LinearLayout xmlns:android=\"http://schemas.android.com/apk/res/android\"\n    android:orientation=\"vertical\"\n    android:layout_width=\"fill_parent\"\n    android:layout_height=\"fill_parent\"\n    />";
+				}
+			});
+			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\layout\\test.axml") {
+				MetadataValues = "Link=Resources\\layout-xhdpi\\test.axml"
+			});
+			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\layout\\test.axml") {
+				MetadataValues = "Link=Resources\\layout-xhdpi\\Test.axml"
+			});
+			using (var b = CreateApkBuilder ("temp/DuplicateValuesInResourceCaseMap")) {
+				b.Verbosity = LoggerVerbosity.Diagnostic;
+				b.ThrowOnBuildFailure = false;
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
+			}
+		}
+
+		[Test]
+		public void CheckLintErrorsAndWarnings ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.UseLatestPlatformSdk = true;
+			proj.SetProperty ("AndroidLintEnabled", true.ToString ());
+			proj.SetProperty ("AndroidLintDisabledIssues", "StaticFieldLeak");
+			proj.SetProperty ("AndroidLintEnabledIssues", "");
+			proj.SetProperty ("AndroidLintCheckIssues", "");
+			proj.MainActivity = proj.DefaultMainActivity.Replace ("public class MainActivity : Activity", @"
+		[IntentFilter (new[] { Android.Content.Intent.ActionView },
+			Categories = new [] { Android.Content.Intent.CategoryDefault, Android.Content.Intent.CategoryBrowsable },
+			DataHost = ""mydomain.com"",
+			DataScheme = ""http""
+		)]
+		public class MainActivity : Activity
+			");
+			using (var b = CreateApkBuilder ("temp/CheckLintErrorsAndWarnings")) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				StringAssert.DoesNotContain ("XA0102", b.LastBuildOutput);
+				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
+			}
+		}
+
+		[Test]
+		public void CheckLintConfigMerging ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty ("AndroidLintEnabled", true.ToString ());
+			proj.OtherBuildItems.Add (new AndroidItem.AndroidLintConfig ("lint1.xml") {
+				TextContent = () => @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<lint>
+	<issue id=""NewApi"" severity=""warning"" />
+</lint>"
+			});
+			proj.OtherBuildItems.Add (new AndroidItem.AndroidLintConfig ("lint2.xml") {
+				TextContent = () => @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<lint>
+	<issue id=""MissingApplicationIcon"" severity=""ignore"" />
+</lint>"
+			});
+			using (var b = CreateApkBuilder ("temp/CheckLintConfigMerging", false, false)) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				var lintFile = Path.Combine (Root, "temp", "CheckLintConfigMerging", proj.IntermediateOutputPath, "lint.xml");
+				Assert.IsTrue (File.Exists (lintFile), "{0} should have been created.", lintFile);
+				var doc = XDocument.Load (lintFile);
+				Assert.IsNotNull (doc, "Document should have loaded successfully.");
+				Assert.IsNotNull (doc.Element ("lint"), "The xml file should have a lint element.");
+				Assert.IsNotNull (doc.Element ("lint")
+					.Elements ()
+					.Any (x => x.Name == "Issue" && x.Attribute ("id").Value == "MissingApplicationIcon"), "Element is missing");
+				Assert.IsNotNull (doc.Element ("lint")
+					.Elements ()
+					.Any (x => x.Name == "Issue" && x.Attribute ("id").Value == "NewApi"), "Element is missing");
+				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
+				Assert.IsFalse (File.Exists (lintFile), "{0} should have been deleted on clean.", lintFile);
+			}
+		}
+
+		[Test]
+		/// <summary>
+		/// Reference https://bugzilla.xamarin.com/show_bug.cgi?id=29568
+		/// </summary>
+		public void BuildLibraryWhichUsesResources ([Values (false, true)] bool isRelease)
+		{
+			var proj = new XamarinAndroidLibraryProject () { IsRelease = isRelease };
+			proj.Packages.Add (KnownPackages.AndroidSupportV4_22_1_1_1);
+			proj.Packages.Add (KnownPackages.SupportV7AppCompat_22_1_1_1);
+			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values\\Styles.xml") {
+				TextContent = () => @"<?xml version=""1.0"" encoding=""UTF-8"" ?>
+<resources>
+	<style name=""AppTheme"" parent=""Theme.AppCompat.Light.NoActionBar"" />
+</resources>"
+			});
+			proj.SetProperty ("TargetFrameworkVersion", "v5.0");
+			proj.SetProperty ("AndroidResgenClass", "Resource");
+			proj.SetProperty ("AndroidResgenFile", () => "Resources\\Resource.designer" + proj.Language.DefaultExtension);
+			using (var b = CreateDllBuilder ("temp/BuildLibraryWhichUsesResources")) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
+#pragma warning disable 414
+		static object [] AndroidStoreKeyTests = new object [] {
+						// isRelease, AndroidKeyStore, ExpectedResult
+			new object[] { false    , "False"        , "debug.keystore"},
+			new object[] { true     , "False"        , "debug.keystore"},
+			new object[] { false    , "True"         , "-keystore test.keystore"},
+			new object[] { true     , "True"         , "-keystore test.keystore"},
+			new object[] { false    , ""             , "debug.keystore"},
+			new object[] { true     , ""             , "debug.keystore"},
+		};
+#pragma warning restore 414
+
+		[Test]
+		[TestCaseSource ("AndroidStoreKeyTests")]
+		public void TestAndroidStoreKey (bool isRelease, string androidKeyStore, string expected)
+		{
+			byte [] data;
+			using (var stream = typeof (XamarinAndroidCommonProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Base.test.keystore")) {
+				data = new byte [stream.Length];
+				stream.Read (data, 0, (int)stream.Length);
+			}
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = isRelease
+			};
+			proj.SetProperty ("AndroidKeyStore", androidKeyStore);
+			proj.SetProperty ("AndroidSigningKeyStore", "test.keystore");
+			proj.SetProperty ("AndroidSigningStorePass", "android");
+			proj.SetProperty ("AndroidSigningKeyAlias", "mykey");
+			proj.SetProperty ("AndroidSigningKeyPass", "android");
+			proj.OtherBuildItems.Add (new BuildItem (BuildActions.None, "test.keystore") {
+				BinaryContent = () => data
+			});
+			using (var b = CreateApkBuilder (Path.Combine ("temp", "TestAndroidStoreKey"), false, false)) {
+				b.Verbosity = LoggerVerbosity.Diagnostic;
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				StringAssert.Contains (expected, b.LastBuildOutput,
+					"The Wrong keystore was used to sign the apk");
+			}
+		}
+
+#pragma warning disable 414
+		static object [] BuildApplicationWithJavaSourceChecks = new object [] {
+			new object[] {
+				/* isRelease */           false,
+				/* expectedResult */      true,
+			},
+			new object[] {
+				/* isRelease */           true,
+				/* expectedResult */      true,
+			},
+		};
+#pragma warning restore 414
+
+		[Test]
+		[TestCaseSource ("BuildApplicationWithJavaSourceChecks")]
+		public void BuildApplicationWithJavaSource (bool isRelease, bool expectedResult)
+		{
+			var path = String.Format ("temp/BuildApplicationWithJavaSource_{0}_{1}",
+				isRelease, expectedResult);
+			try {
+				var proj = new XamarinAndroidApplicationProject () {
+					IsRelease = isRelease,
+					OtherBuildItems = {
+						new BuildItem (AndroidBuildActions.AndroidJavaSource, "TestMe.java") {
+							TextContent = () => "public class TestMe { }",
+							Encoding = Encoding.ASCII
+						},
+					}
+				};
+				proj.SetProperty ("TargetFrameworkVersion", "v5.0");
+				using (var b = CreateApkBuilder (path)) {
+					b.Verbosity = LoggerVerbosity.Diagnostic;
+					b.ThrowOnBuildFailure = false;
+					Assert.AreEqual (expectedResult, b.Build (proj), "Build should have {0}", expectedResult ? "succeeded" : "failed");
+					if (expectedResult)
+						StringAssert.DoesNotContain ("XA9002", b.LastBuildOutput, "XA9002 should not have been raised");
+					else
+						StringAssert.Contains ("XA9002", b.LastBuildOutput, "XA9002 should have been raised");
+					Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
+				}
+			} finally {
+			}
+		}
+
+#pragma warning disable 414
+		static object [] RuntimeChecks = new object [] {
+			new object[] {
+				/* supportedAbi */     new string[] { "armeabi-v7a"},
+				/* optimize */         true ,
+				/* expectedResult */   "release",
+			},
+			new object[] {
+				/* supportedAbi */     new string[] { "armeabi-v7a"},
+				/* optimize */         false ,
+				/* expectedResult */   "debug",
+			},
+		};
+#pragma warning restore 414
+
+		[Test]
+		[TestCaseSource ("RuntimeChecks")]
+		public void CheckWhichRuntimeIsIncluded (string [] supportedAbi, bool optimize, string expectedRuntime)
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty (proj.ActiveConfigurationProperties, "Optimize", optimize);
+			using (var b = CreateApkBuilder (Path.Combine ("temp", "CheckWhichRuntimeIsIncluded"))) {
+				var runtimeInfo = b.GetSupportedRuntimes ();
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				var apkPath = Path.Combine (Root, b.ProjectDirectory,
+					proj.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
+				using (var apk = ZipHelper.OpenZip (apkPath)) {
+					foreach (var abi in supportedAbi) {
+						var runtime = runtimeInfo.FirstOrDefault (x => x.Abi == abi && x.Runtime == expectedRuntime);
+						Assert.IsNotNull (runtime, "Could not find the expected runtime.");
+						var inApk = ZipHelper.ReadFileFromZip (apk, String.Format ("lib/{0}/{1}", abi, runtime.Name));
+						var inApkRuntime = runtimeInfo.FirstOrDefault (x => x.Abi == abi && x.Size == inApk.Length);
+						Assert.IsNotNull (inApkRuntime, "Could not find the actual runtime used.");
+						Assert.AreEqual (runtime.Size, inApkRuntime.Size, "expected {0} got {1}", expectedRuntime, inApkRuntime.Runtime);
+						inApk = ZipHelper.ReadFileFromZip (apk, string.Format ("lib/{0}/libmono-profiler-log.so", abi));
+						if (!optimize) {
+							Assert.IsNotNull (inApk, "libmono-profiler-log.so should exist in the apk.");
+						} else {
+							Assert.IsNull (inApk, "libmono-profiler-log.so should not exist in the apk.");
+						}
+					}
+				}
+			}
+		}
+
+		[Test]
+		[TestCaseSource ("SequencePointChecks")]
+		public void CheckSequencePointGeneration (bool isRelease, bool monoSymbolArchive, bool aotAssemblies,
+			bool debugSymbols, string debugType, bool embedMdb, string expectedRuntime)
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = isRelease,
+				AotAssemblies = aotAssemblies
+			};
+			var abis = new string [] { "armeabi-v7a", "x86" };
+			proj.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
+			proj.SetProperty (proj.ActiveConfigurationProperties, "MonoSymbolArchive", monoSymbolArchive);
+			proj.SetProperty (proj.ActiveConfigurationProperties, "DebugSymbols", debugSymbols);
+			proj.SetProperty (proj.ActiveConfigurationProperties, "DebugType", debugType);
+			using (var b = CreateApkBuilder ("temp/SequencePointChecks", false, false)) {
+				b.Verbosity = LoggerVerbosity.Diagnostic;
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				var apk = Path.Combine (Root, b.ProjectDirectory,
+					proj.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
+				var msymarchive = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, proj.PackageName + ".apk.mSYM");
+				using (var zipFile = ZipHelper.OpenZip (apk)) {
+					var mdbExits = ZipHelper.ReadFileFromZip (zipFile, "assemblies/UnnamedProject.dll.mdb") != null ||
+						ZipHelper.ReadFileFromZip (zipFile, "assemblies/UnnamedProject.pdb") != null;
+					Assert.AreEqual (embedMdb, mdbExits,
+						"assemblies/UnnamedProject.dll.mdb or assemblies/UnnamedProject.pdb should{0}be in the UnnamedProject.UnnamedProject.apk", embedMdb ? " " : " not ");
+					if (aotAssemblies) {
+						foreach (var abi in abis) {
+							var assemblies = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,
+								"aot", abi, "libaot-UnnamedProject.dll.so");
+							var shouldExist = monoSymbolArchive && debugSymbols && debugType == "PdbOnly";
+							var symbolicateFile = Directory.GetFiles (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,
+								"aot", abi), "UnnamedProject.dll.msym", SearchOption.AllDirectories).FirstOrDefault ();
+							if (shouldExist)
+								Assert.IsNotNull (symbolicateFile, "UnnamedProject.dll.msym should exist");
+							else
+								Assert.IsNull (symbolicateFile, "{0} should not exist", symbolicateFile);
+							if (shouldExist) {
+								var foundMsyms = Directory.GetFiles (Path.Combine (msymarchive), "UnnamedProject.dll.msym", SearchOption.AllDirectories).Any ();
+								Assert.IsTrue (foundMsyms, "UnnamedProject.dll.msym should exist in the archive {0}", msymarchive);
+							}
+							Assert.IsTrue (File.Exists (assemblies), "{0} libaot-UnnamedProject.dll.so does not exist", abi);
+							Assert.IsNotNull (ZipHelper.ReadFileFromZip (zipFile,
+								string.Format ("lib/{0}/libaot-UnnamedProject.dll.so", abi)),
+								"lib/{0}/libaot-UnnamedProject.dll.so should be in the UnnamedProject.UnnamedProject.apk", abi);
+							Assert.IsNotNull (ZipHelper.ReadFileFromZip (zipFile,
+								"assemblies/UnnamedProject.dll"),
+								"UnnamedProject.dll should be in the UnnamedProject.UnnamedProject.apk");
+						}
+					}
+					var runtimeInfo = b.GetSupportedRuntimes ();
+					foreach (var abi in abis) {
+						var runtime = runtimeInfo.FirstOrDefault (x => x.Abi == abi && x.Runtime == expectedRuntime);
+						Assert.IsNotNull (runtime, "Could not find the expected runtime.");
+						var inApk = ZipHelper.ReadFileFromZip (apk, String.Format ("lib/{0}/{1}", abi, runtime.Name));
+						var inApkRuntime = runtimeInfo.FirstOrDefault (x => x.Abi == abi && x.Size == inApk.Length);
+						Assert.IsNotNull (inApkRuntime, "Could not find the actual runtime used.");
+						Assert.AreEqual (runtime.Size, inApkRuntime.Size, "expected {0} got {1}", expectedRuntime, inApkRuntime.Runtime);
+					}
+				}
+				b.Clean (proj);
+				Assert.IsTrue (!Directory.Exists (msymarchive), "{0} should have been deleted on Clean", msymarchive);
+			}
+		}
+
+		[Test]
+		public void BuildApplicationWithMonoEnvironment ([Values ("", "Normal", "Offline")] string sequencePointsMode)
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				OtherBuildItems = { new AndroidItem.AndroidEnvironment ("Mono.env") {
+						TextContent = () => "MONO_DEBUG=soft-breakpoints"
+					},
+				},
+			};
+			proj.SetProperty ("_AndroidSequencePointsMode", sequencePointsMode);
+			using (var b = CreateApkBuilder (Path.Combine ("temp", "BuildApplicationWithMonoEnvironment"))) {
+				b.Verbosity = LoggerVerbosity.Diagnostic;
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				var apk = Path.Combine (Root, b.ProjectDirectory,
+					proj.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
+				using (var zipFile = ZipHelper.OpenZip (apk)) {
+					var data = ZipHelper.ReadFileFromZip (zipFile, "environment");
+					Assert.IsNotNull (data, "environment should exist in the apk.");
+					var env = Encoding.ASCII.GetString (data);
+					var lines = env.Split (new char [] { '\n' });
+
+					Assert.IsTrue (lines.Any (x => x.Contains ("MONO_DEBUG") &&
+						x.Contains ("soft-breakpoints") &&
+						string.IsNullOrEmpty (sequencePointsMode) ? true : x.Contains ("gen-compact-seq-points")),
+						"The values from Mono.env should have been merged into environment");
+				}
+			}
+		}
+
+		[Test]
+		public void CheckMonoDebugIsAddedToEnvironment ([Values ("", "Normal", "Offline")] string sequencePointsMode)
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+			};
+			proj.SetProperty ("_AndroidSequencePointsMode", sequencePointsMode);
+			using (var b = CreateApkBuilder (Path.Combine ("temp", "CheckMonoDebugIsAddedToEnvironment"))) {
+				b.Verbosity = LoggerVerbosity.Diagnostic;
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				var apk = Path.Combine (Root, b.ProjectDirectory,
+					proj.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
+				using (var zipFile = ZipHelper.OpenZip (apk)) {
+					var data = ZipHelper.ReadFileFromZip (zipFile, "environment");
+					Assert.IsNotNull (data, "environment should exist in the apk.");
+					var env = Encoding.ASCII.GetString (data);
+					var lines = env.Split (new char [] { '\n' });
+
+					Assert.IsTrue (lines.Any (x =>
+						string.IsNullOrEmpty (sequencePointsMode)
+							? !x.Contains ("MONO_DEBUG")
+							: x.Contains ("MONO_DEBUG") && x.Contains ("gen-compact-seq-points")),
+						"environment {0} contain MONO_DEBUG=gen-compact-seq-points",
+						string.IsNullOrEmpty (sequencePointsMode) ? "should not" : "should");
+				}
+			}
+		}
+
+		[Test]
+		public void BuildWithNativeLibraries ([Values (true, false)] bool isRelease)
+		{
+			var dll = new XamarinAndroidLibraryProject () {
+				ProjectName = "Library1",
+				IsRelease = isRelease,
+				OtherBuildItems = {
+					new AndroidItem.EmbeddedNativeLibrary ("foo\\armeabi-v7a\\libtest.so") {
+						BinaryContent = () => new byte[10],
+						MetadataValues = "Link=libs\\armeabi-v7a\\libtest.so",
+					},
+					new AndroidItem.EmbeddedNativeLibrary ("foo\\x86\\libtest.so") {
+						BinaryContent = () => new byte[10],
+						MetadataValues = "Link=libs\\x86\\libtest.so",
+					},
+				},
+			};
+			var dll2 = new XamarinAndroidLibraryProject () {
+				ProjectName = "Library2",
+				IsRelease = isRelease,
+				OtherBuildItems = {
+					new AndroidItem.EmbeddedNativeLibrary ("foo\\armeabi-v7a\\libtest1.so") {
+						BinaryContent = () => new byte[10],
+						MetadataValues = "Link=libs\\armeabi-v7a\\libtest1.so",
+					},
+					new AndroidItem.EmbeddedNativeLibrary ("foo\\x86\\libtest1.so") {
+						BinaryContent = () => new byte[10],
+						MetadataValues = "Link=libs\\x86\\libtest1.so",
+					},
+				},
+			};
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = isRelease,
+				References = {
+					new BuildItem ("ProjectReference","..\\Library1\\Library1.csproj"),
+					new BuildItem ("ProjectReference","..\\Library2\\Library2.csproj"),
+				},
+				OtherBuildItems = {
+					new AndroidItem.AndroidNativeLibrary ("armeabi-v7a\\libRSSupport.so") {
+						BinaryContent = () => new byte[10],
+					},
+				},
+				Packages = {
+					KnownPackages.Xamarin_Android_Support_v8_RenderScript_23_1_1_0,
+				}
+			};
+			proj.SetProperty ("TargetFrameworkVersion", "v7.1");
+			proj.SetProperty (KnownProperties.AndroidSupportedAbis, "armeabi-v7a;x86");
+			var path = Path.Combine (Root, "temp", string.Format ("BuildWithNativeLibraries_{0}", isRelease));
+			using (var b1 = CreateDllBuilder (Path.Combine (path, dll2.ProjectName))) {
+				b1.Verbosity = LoggerVerbosity.Diagnostic;
+				Assert.IsTrue (b1.Build (dll2), "Build should have succeeded.");
+				using (var b = CreateDllBuilder (Path.Combine (path, dll.ProjectName))) {
+					b.Verbosity = LoggerVerbosity.Diagnostic;
+					Assert.IsTrue (b.Build (dll), "Build should have succeeded.");
+					using (var builder = CreateApkBuilder (Path.Combine (path, proj.ProjectName))) {
+						builder.Verbosity = LoggerVerbosity.Diagnostic;
+						Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
+						var apk = Path.Combine (Root, builder.ProjectDirectory,
+							proj.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
+						StringAssert.Contains ("XA4301", builder.LastBuildOutput, "warning about skipping libRSSupport.so should have been raised");
+						using (var zipFile = ZipHelper.OpenZip (apk)) {
+							var data = ZipHelper.ReadFileFromZip (zipFile, "lib/x86/libtest.so");
+							Assert.IsNotNull (data, "libtest.so for x86 should exist in the apk.");
+							data = ZipHelper.ReadFileFromZip (zipFile, "lib/armeabi-v7a/libtest.so");
+							Assert.IsNotNull (data, "libtest.so for armeabi-v7a should exist in the apk.");
+							data = ZipHelper.ReadFileFromZip (zipFile, "lib/x86/libtest1.so");
+							Assert.IsNotNull (data, "libtest1.so for x86 should exist in the apk.");
+							data = ZipHelper.ReadFileFromZip (zipFile, "lib/armeabi-v7a/libtest1.so");
+							Assert.IsNotNull (data, "libtest1.so for armeabi-v7a should exist in the apk.");
+							data = ZipHelper.ReadFileFromZip (zipFile, "lib/armeabi-v7a/libRSSupport.so");
+							Assert.IsNotNull (data, "libRSSupport.so for armeabi should exist in the apk.");
+						}
+					}
+				}
+			}
+			Directory.Delete (path, recursive: true);
+		}
+
+		[Test]
+		public void BuildWithExternalJavaLibrary ()
+		{
+			string multidex_jar = "$(MonoDroidInstallDirectory)\\lib\\mandroid\\android-support-multidex.jar";
+			var binding = new XamarinAndroidBindingProject () {
+				ProjectName = "BuildWithExternalJavaLibraryBinding",
+				Jars = { new AndroidItem.InputJar (() => multidex_jar), },
+				AndroidClassParser = "class-parse",
+			};
+			using (var bbuilder = CreateDllBuilder ("temp/BuildWithExternalJavaLibraryBinding", true, false)) {
+				Assert.IsTrue (bbuilder.Build (binding));
+				var proj = new XamarinAndroidApplicationProject () {
+					References = { new BuildItem ("ProjectReference", "..\\BuildWithExternalJavaLibraryBinding\\BuildWithExternalJavaLibraryBinding.csproj"), },
+					OtherBuildItems = { new BuildItem ("AndroidExternalJavaLibrary", multidex_jar) },
+					Sources = { new BuildItem ("Compile", "Foo.cs") {
+							TextContent = () => "public class Foo { public void X () { new Android.Support.Multidex.MultiDexApplication (); } }"
+						} },
+				};
+				using (var builder = CreateApkBuilder ("temp/BuildWithExternalJavaLibrary")) {
+					Assert.IsTrue (builder.Build (proj));
+				}
+			}
+		}
+
+		[Test]
+		public void CheckItemMetadata ([Values (true, false)] bool isRelease)
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = isRelease,
+				Imports = {
+					new Import (() => "My.Test.target") {
+						TextContent = () => @"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+	<Target Name=""CustomTarget"" AfterTargets=""UpdateAndroidAssets"" BeforeTargets=""UpdateAndroidInterfaceProxies"" >
+		<Message Text=""Foo""/>
+		<Message Text=""@(_AndroidAssetsDest->'%(CustomData)')"" />
+	</Target>
+	<Target Name=""CustomTarget2"" AfterTargets=""UpdateAndroidResources"" >
+		<Message Text=""@(_AndroidResourceDest->'%(CustomData)')"" />
+	</Target>
+</Project>
+						"
+					},
+				},
+				OtherBuildItems = {
+					new AndroidItem.AndroidAsset (() => "Assets\\foo.txt") {
+						TextContent = () => "Foo",
+						MetadataValues = "CustomData=AssetMetaDataOK"
+					},
+				}
+			};
+
+			var mainAxml = proj.AndroidResources.First (x => x.Include () == "Resources\\layout\\Main.axml");
+			mainAxml.MetadataValues = "CustomData=ResourceMetaDataOK";
+
+			using (var builder = CreateApkBuilder (string.Format ("temp/CheckItemMetadata_{0}", isRelease))) {
+				builder.Build (proj);
+				StringAssert.Contains ("AssetMetaDataOK", builder.LastBuildOutput, "Metadata was not copied for AndroidAsset");
+				StringAssert.Contains ("ResourceMetaDataOK", builder.LastBuildOutput, "Metadata was not copied for AndroidResource");
+			}
+		}
+
+		// Context https://bugzilla.xamarin.com/show_bug.cgi?id=29706
+		[Test]
+		public void CheckLogicalNamePathSeperators ([Values (false, true)] bool isRelease)
+		{
+			var illegalSeperator = IsWindows ? "/" : @"\";
+			var dll = new XamarinAndroidLibraryProject () {
+				ProjectName = "Library1",
+				IsRelease = isRelease,
+				AndroidResources = {
+					new AndroidItem.AndroidResource (() => "Resources\\Test\\Test2.png") {
+						BinaryContent = () => XamarinAndroidApplicationProject.icon_binary_mdpi,
+						MetadataValues = string.Format ("LogicalName=drawable{0}foo2.png", illegalSeperator)
+					},
+				},
+			};
+			var proj = new XamarinAndroidApplicationProject () {
+				ProjectName = "Application1",
+				IsRelease = isRelease,
+				AndroidResources = {
+					new AndroidItem.AndroidResource (() => "Resources\\Test\\Test.png") {
+						BinaryContent = () => XamarinAndroidApplicationProject.icon_binary_mdpi,
+						MetadataValues = string.Format ("LogicalName=drawable{0}foo.png", illegalSeperator)
+					},
+				},
+				References = {
+					new BuildItem ("ProjectReference","..\\Library1\\Library1.csproj"),
+				},
+			};
+			var path = Path.Combine ("temp", string.Format ("CheckLogicalNamePathSeperators_{0}", isRelease));
+			using (var b = CreateDllBuilder (Path.Combine (path, dll.ProjectName))) {
+				b.Verbosity = LoggerVerbosity.Diagnostic;
+				Assert.IsTrue (b.Build (dll), "Build should have succeeded.");
+				using (var builder = CreateApkBuilder (Path.Combine (path, proj.ProjectName), isRelease)) {
+					Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
+					StringAssert.Contains ("public const int foo = ", File.ReadAllText (Path.Combine (Root, builder.ProjectDirectory, "Resources", "Resource.designer.cs")));
+					StringAssert.Contains ("public const int foo2 = ", File.ReadAllText (Path.Combine (Root, builder.ProjectDirectory, "Resources", "Resource.designer.cs")));
+				}
+			}
+		}
+
+		[Test]
+		public void ApplicationJavaClassProperties ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty ("AndroidApplicationJavaClass", "android.test.mock.MockApplication");
+			var builder = CreateApkBuilder ("temp/ApplicationJavaClassProperties");
+			builder.Build (proj);
+			var appsrc = File.ReadAllText (Path.Combine (Root, builder.ProjectDirectory, "obj", "Debug", "android", "AndroidManifest.xml"));
+			Assert.IsTrue (appsrc.Contains ("android.test.mock.MockApplication"), "app class");
+			builder.Dispose ();
+		}
+
+		[Test]
+		public void ApplicationIdPlaceholder ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.AndroidManifest = proj.AndroidManifest.Replace ("</application>", "<provider android:name='${applicationId}' android:authorities='example' /></application>");
+			var builder = CreateApkBuilder ("temp/ApplicationIdPlaceholder");
+			builder.Build (proj);
+			var appsrc = File.ReadAllText (Path.Combine (Root, builder.ProjectDirectory, "obj", "Debug", "android", "AndroidManifest.xml"));
+			Assert.IsTrue (appsrc.Contains ("<provider android:name=\"UnnamedProject.UnnamedProject\""), "placeholder not replaced");
+			builder.Dispose ();
+		}
+
+		[Test]
+		public void ResourceExtraction ()
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				Packages = {
+					KnownPackages.AndroidSupportV4_23_1_1_0,
+					KnownPackages.SupportV7AppCompat_23_1_1_0,
+				},
+			};
+			proj.SetProperty ("TargetFrameworkVersion", "v5.0");
+			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
+				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
+				var targetAar = Path.Combine (CachePath, "Xamarin.Android.Support.v7.AppCompat", "23.1.1.0",
+					"content", "m2repository", "com", "android", "support", "appcompat-v7", "23.1.1", "appcompat-v7-23.1.1.aar");
+				if (File.Exists (targetAar)) {
+					File.Delete (targetAar);
+				}
+				var embedded = Path.Combine (CachePath, "Xamarin.Android.Support.v7.AppCompat", "23.1.1.0", "embedded");
+				if (Directory.Exists (embedded)) {
+					Directory.Delete (embedded, recursive: true);
+				}
+				Assert.IsTrue (builder.Build (proj), "Second Build should have succeeded");
+			}
+		}
+
+		[Test]
+		public void CheckTargetFrameworkVersion ([Values (true, false)] bool isRelease)
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = isRelease,
+			};
+			proj.SetProperty ("TargetFrameworkVersion", "v2.3");
+			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
+				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
+				StringAssert.Contains ($"TargetFrameworkVersion: v2.3", builder.LastBuildOutput, "TargetFrameworkVerson should be v2.3");
+				Assert.IsTrue (builder.Build (proj, parameters: new [] { "TargetFrameworkVersion=v4.4" }), "Build should have succeeded.");
+				StringAssert.Contains ($"TargetFrameworkVersion: v4.4", builder.LastBuildOutput, "TargetFrameworkVerson should be v4.4");
+
+			}
+		}
+
+#pragma warning disable 414
+		public static object [] GeneratorValidateEventNameArgs = new object [] {
+			new object [] { false, true, string.Empty, string.Empty },
+			new object [] { false, false, "<attr path=\"/api/package/class[@name='Test']/method[@name='setOn123Listener']\" name='eventName'>OneTwoThree</attr>", string.Empty },
+			new object [] { true, true, string.Empty, "String s" },
+		};
+#pragma warning restore 414
+
+		[Test]
+		[TestCaseSource ("GeneratorValidateEventNameArgs")]
+		public void GeneratorValidateEventName (bool failureExpected, bool warningExpected, string metadataFixup, string methodArgs)
+		{
+			string java = @"
+package com.xamarin.testing;
+
+public class Test
+{
+	public void setOnAbcListener (OnAbcListener listener)
+	{
+	}
+
+	public void setOn123Listener (On123Listener listener)
+	{
+	}
+
+	public interface OnAbcListener
+	{
+		public void onAbc ();
+	}
+
+	public interface On123Listener
+	{
+		public void onAbc (%%ARGS%%);
+	}
+}
+".Replace ("%%ARGS%%", methodArgs);
+			var path = Path.Combine (Root, "temp", "GeneratorValidateEventName");
+			var javaDir = Path.Combine (path, "java", "com", "xamarin", "testing");
+			if (Directory.Exists (javaDir))
+				Directory.Delete (javaDir, true);
+			Directory.CreateDirectory (javaDir);
+			var proj = new XamarinAndroidBindingProject () {
+				AndroidClassParser = "class-parse",
+			};
+			proj.MetadataXml = "<metadata>" + metadataFixup + "</metadata>";
+			proj.Jars.Add (new AndroidItem.EmbeddedJar (Path.Combine ("java", "test.jar")) {
+				BinaryContent = new JarContentBuilder () {
+					BaseDirectory = Path.Combine (path, "java"),
+					JavacFullPath = "javac",
+					JarFullPath = "jar",
+					JarFileName = "test.jar",
+					JavaSourceFileName = Path.Combine ("com", "xamarin", "testing", "Test.java"),
+					JavaSourceText = java
+				}.Build
+			});
+			using (var builder = CreateDllBuilder (path, false, false)) {
+				bool result = false;
+				try {
+					result = builder.Build (proj);
+					Assert.AreEqual (warningExpected, builder.LastBuildOutput.Contains ("warning BG8504"), "warning BG8504 is expected: " + warningExpected);
+				} catch (FailedBuildException) {
+					if (!failureExpected)
+						throw;
+				}
+				Assert.AreEqual (failureExpected, !result, "Should build fail?");
+			}
+		}
+
+#pragma warning disable 414
+		public static object [] GeneratorValidateMultiMethodEventNameArgs = new object [] {
+			new object [] { false, "BG8505", string.Empty, string.Empty },
+			new object [] { false, null, "<attr path=\"/api/package/interface[@name='Test.OnFooListener']/method[@name='on123']\" name='eventName'>One23</attr>", string.Empty },
+			new object [] { false, null, @"
+					<attr path=""/api/package/interface[@name='Test.OnFooListener']/method[@name='on123']"" name='eventName'>One23</attr>
+					<attr path=""/api/package/interface[@name='Test.OnFooListener']/method[@name='on123']"" name='argsType'>OneTwoThreeEventArgs</attr>
+				", "String s" },
+			new object [] { true, "BG8504", string.Empty, "String s" },
+		};
+#pragma warning restore 414
+
+		[Test]
+		[TestCaseSource ("GeneratorValidateMultiMethodEventNameArgs")]
+		public void GeneratorValidateMultiMethodEventName (bool failureExpected, string expectedWarning, string metadataFixup, string methodArgs)
+		{
+			string java = @"
+package com.xamarin.testing;
+
+public class Test
+{
+	public void setOnFooListener (OnFooListener listener)
+	{
+	}
+
+	public interface OnFooListener
+	{
+		public void onAbc ();
+		public void on123 (%%ARGS%%);
+	}
+}
+".Replace ("%%ARGS%%", methodArgs);
+			var path = Path.Combine (Root, "temp", "GeneratorValidateMultiMethodEventName");
+			var javaDir = Path.Combine (path, "java", "com", "xamarin", "testing");
+			if (Directory.Exists (javaDir))
+				Directory.Delete (javaDir, true);
+			Directory.CreateDirectory (javaDir);
+			var proj = new XamarinAndroidBindingProject () {
+				AndroidClassParser = "class-parse",
+			};
+			proj.MetadataXml = "<metadata>" + metadataFixup + "</metadata>";
+			proj.Jars.Add (new AndroidItem.EmbeddedJar (Path.Combine ("java", "test.jar")) {
+				BinaryContent = new JarContentBuilder () {
+					BaseDirectory = Path.Combine (path, "java"),
+					JavacFullPath = "javac",
+					JarFullPath = "jar",
+					JarFileName = "test.jar",
+					JavaSourceFileName = Path.Combine ("com", "xamarin", "testing", "Test.java"),
+					JavaSourceText = java
+				}.Build
+			});
+			using (var builder = CreateDllBuilder (path, false, false)) {
+				try {
+					builder.Build (proj);
+					if (failureExpected)
+						Assert.Fail ("Build should fail.");
+					if (expectedWarning == null)
+						Assert.IsFalse (builder.LastBuildOutput.Contains ("warning BG850"), "warning BG850* is NOT expected");
+					else
+						Assert.IsTrue (builder.LastBuildOutput.Contains ("warning " + expectedWarning), "warning " + expectedWarning + " is expected.");
+				} catch (FailedBuildException) {
+					if (!failureExpected)
+						throw;
+				}
+			}
+		}
+
 		[Test]
 		public void BuildReleaseApplication ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -56,4 +56,7 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="BuildTest.OSS.cs" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
We had a bunch of unit tests left over which need to be migrated.
This commit brings over most the those tests. Excluding Wear tests
since we don't install the wear api's by default, and tests to do
with FastDev.

We need a new BuildTest.OSS.cs file because we made the BuildTest
class partial. This allows us to pass in slightly different options
to the tests for the OSS repo. Mostly this is to do with the abi's
which are available. For example abi armeabi is NOT built by
default in this repo, but armeabi-v7a and x86 are.