### PR TITLE
[Xamarin.Android.Build.Tests] More fixes to the Build tests.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1573,6 +1573,8 @@ public class Test
 		public void BuildBasicApplicationCheckPdb ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty ("EmbedAssembliesIntoApk", true.ToString ());
+			proj.SetProperty ("AndroidUseSharedRuntime", false.ToString ());
 			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationCheckPdb", false, false)) {
 				b.Verbosity = LoggerVerbosity.Diagnostic;
 				var reference = new BuildItem.Reference ("PdbTestLibrary.dll") {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
@@ -31,17 +31,17 @@ namespace Xamarin.ProjectTools
 
 		public string GetIntermediaryPath (string file)
 		{
-			return Path.Combine (Builder.ProjectDirectory, IntermediateOutputPath, file.Replace ('/', Path.DirectorySeparatorChar));
+			return Path.Combine (Project.Root, Builder.ProjectDirectory, IntermediateOutputPath, file.Replace ('/', Path.DirectorySeparatorChar));
 		}
 		
 		public string GetIntermediaryAsText (string root, string file)
 		{
-			return File.ReadAllText (Path.Combine (root, GetIntermediaryPath (file)));
+			return File.ReadAllText (GetIntermediaryPath (file));
 		}
 
 		public string GetIntermediaryAsText (string file)
 		{
-			return File.ReadAllText (Path.Combine (Project.Root, GetIntermediaryPath (file)));
+			return File.ReadAllText (GetIntermediaryPath (file));
 		}
 
 		public bool IsTargetSkipped (string target)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -44,11 +44,11 @@ namespace Xamarin.ProjectTools
 				if (RunXBuild) {
 					var outdir = Environment.GetEnvironmentVariable ("XA_BUILD_OUTPUT_PATH");
 					if (String.IsNullOrEmpty(outdir))
-						outdir = Path.GetFullPath ("../../../../../../../out");
+						outdir = Path.GetFullPath (Path.Combine (Root, "..", "..", "..", "..", "..", "..", "..", "out"));
 					if (!Directory.Exists (Path.Combine (outdir, "lib")))
-						outdir = Path.GetFullPath (Path.Combine (Root, "..", "..", "..", "..", "..", "..", "bin", "Debug"));
+						outdir = Path.GetFullPath (Path.Combine (Root, "..", "..", "bin", "Debug"));
 					if (!Directory.Exists (Path.Combine (outdir, "lib")))
-						outdir = Path.GetFullPath (Path.Combine (Root, "..", "..", "..", "..", "..", "..", "bin", "Release"));
+						outdir = Path.GetFullPath (Path.Combine (Root, "..", "..", "bin", "Release"));
 					if (!Directory.Exists (outdir))
 						outdir = "/Library/Frameworks/Xamarin.Android.framework/Versions/Current";
 					return Path.Combine (outdir, "lib");
@@ -130,17 +130,8 @@ namespace Xamarin.ProjectTools
 				args.AppendFormat ("/p:AndroidNdkDirectory=\"{0}\" ", ndkPath);
 			}
 			if (RunXBuild) {
-				var outdir = Environment.GetEnvironmentVariable ("XA_BUILD_OUTPUT_PATH");
-				if (String.IsNullOrEmpty(outdir))
-					outdir = Path.GetFullPath ("../../../../../../../out");
-				
-				if (!Directory.Exists (Path.Combine (outdir, "lib", "xbuild")))
-					outdir = Path.GetFullPath (Path.Combine (Root, "..", "..", "bin", "Debug"));
-
-				if (!Directory.Exists (Path.Combine (outdir, "lib", "xbuild")))
-					outdir = Path.GetFullPath (Path.Combine (Root, "..", "..", "bin", "Release"));
-
-				var targetsdir = Path.Combine (outdir, "lib", "xbuild");
+				var outdir = Path.GetFullPath (Path.Combine (FrameworkLibDirectory, ".."));
+				var targetsdir = Path.Combine (FrameworkLibDirectory, "xbuild");
 				args.AppendFormat (" {0} ", logger);
 
 				if (Directory.Exists (targetsdir)) {


### PR DESCRIPTION
This commit fixes a number of issues to do with the Path
calculations make to find the "out" directory. Allot of
them were not taking the Root directory into account so
we ended up defaulting to the system directory some of the
time. This was also due to duplicated code one of which
had not been updated. So we unify that so it all uses the same
code now.