### PR TITLE
Fix LLVM cross-compilers build on Linux

### DIFF
--- a/build-tools/scripts/generate-os-info
+++ b/build-tools/scripts/generate-os-info
@@ -51,7 +51,7 @@ function getInfo_Linux()
         HOST_CXX=c++
     fi
 
-    HOST_TRIPLET="$HOST_CC -dumpmachine"
+    HOST_TRIPLET="`$HOST_CC -dumpmachine`"
 
     if [ "x$ARCHITECTURE_BITS" = "x64" ]; then
         HOST_CC64="$HOST_CC"


### PR DESCRIPTION
The script to generate OS info for Linux missed backticks around
the command to output the machine triplet. This casued the

gcc -dumpmachine

to be passed as the triplet to LLVM's configure, thus breaking it.

Add the backticks, fix the build.