### PR TITLE
[tests] Kill the emulator in ReleaseAndroidTarget

### DIFF
--- a/build-tools/scripts/UnitTestApks.targets
+++ b/build-tools/scripts/UnitTestApks.targets
@@ -5,6 +5,7 @@
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.CreateAndroidEmulator" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.RunInstrumentationTests" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.StartAndroidEmulator" />
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.KillProcess" />
 
   <PropertyGroup>
     <_TestImageName>XamarinAndroidUnitTestRunner</_TestImageName>
@@ -38,7 +39,7 @@
         ToolPath="$(EmulatorToolPath)">
       <Output TaskParameter="AdbTarget" PropertyName="_AdbTarget" />
       <Output TaskParameter="AdbTarget" PropertyName="_EmuTarget" />
-      <Output TaskParameter="AdbProcess" PropertyName="_EmuProcess" />
+      <Output TaskParameter="EmulatorProcessId" PropertyName="_EmuPid" />
     </StartAndroidEmulator>
     <Exec
         Condition=" '$(_ValidAdbTarget)' != 'True' "
@@ -66,6 +67,15 @@
     <Adb
         Condition=" '$(_EmuTarget)' != '' "
         Arguments="$(_EmuTarget) emu kill"
+        ToolExe="$(AdbToolExe)"
+        ToolPath="$(AdbToolPath)"
+    />
+    <KillProcess
+        Condition=" '$(_EmuTarget)' != '' "
+        ProcessId="$(_EmuPid)"
+    />
+    <Adb
+        Arguments="kill-server"
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)"
     />

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\StartAndroidEmulator.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\UnzipDirectoryChildren.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Zip.cs" />
+    <Compile Include="Xamarin.Android.Tools.BootstrapTasks\KillProcess.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(LibZipSharpSourceFullPath)\libZipSharp.csproj">

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/KillProcess.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/KillProcess.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using Xamarin.Android.BuildTools.PrepTasks;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	public class KillProcess : Task
+	{
+		[Required]
+		public                  int             ProcessId       {get; set;}
+
+		public override bool Execute()
+		{
+			Log.LogMessage(MessageImportance.Low, $"Task {nameof(KillProcess)}");
+			Log.LogMessage(MessageImportance.Low, $"  {nameof (ProcessId)}: {ProcessId}");
+
+			using (var p = Process.GetProcessById (ProcessId)) {
+				p.Kill ();
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		public                  string          AdbTarget       {get; set;}
 
 		[Output]
-		public                  Process         AdbProcess      {get; set;}
+		public                  int             EmulatorProcessId       {get; set;}
 
 		public                  string          AndroidSdkHome  {get; set;}
 		public                  string          Port            {get; set;}
@@ -75,6 +75,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				StartInfo = psi,
 			};
 			p.Start ();
+			EmulatorProcessId = p.Id;
 		}
 	}
 }


### PR DESCRIPTION
We've been noticing that emulator-based unit test execution is getting
"finicky", e.g. [PR Build #939][0]:

	Target AcquireAndroidTarget:
	Task "CheckAdbTarget"
	        Tool /Users/builder/android-toolchain/sdk/platform-tools/adb execution started with arguments:  shell getprop ro.build.version.sdk
	        Environment variables being passed to the tool:
	        21
	        Tool /Users/builder/android-toolchain/sdk/platform-tools/adb execution finished.
	          [Output] AdbTarget:
	          [Output] IsValidTarget: True
	Done executing task "CheckAdbTarget"

This means that there is already an Android device attached (emulator
or hardware...), as *something* is responding to `adb shell getprop`.

However...that attached device is b0rked:

	Target UndeployUnitTestApks:
	Task "Adb"
	        Task Adb
	          Arguments:   uninstall "Mono.Android_Tests"
	        Tool /Users/builder/android-toolchain/sdk/platform-tools/adb execution started with arguments:   uninstall "Mono.Android_Tests"
	        Environment variables being passed to the tool:
	        Error: Could not access the Package Manager.  Is the system running?
	        Tool /Users/builder/android-toolchain/sdk/platform-tools/adb execution finished.
	          [Output] Output:
	            Error: Could not access the Package Manager.  Is the system running?
	Done executing task "Adb"

*Every* attempt to "do something" with the device -- uninstall and
install packages, run applications, etc. -- results in the
"Could not access the Package Manager" error.

The device is dead, yet still present.

We want on-device unit test execution to be *reliable* (7450efcc).
It isn't, and that's very annoying.

Manual investigation of the Jenkins build machine after these errors
occur indicates that after `adb TARGET emu kill` executes (as part of
`make run-apk-tests`), the `emulator` process *is still running*.

Hopefully, that's the problem: the emulator process isn't dead.

Fix the problem by *killing* the process, with not-quite-extreme
prejudice, by invoking `Process.Kill()` on the
`System.Diagnostics.Process` instance that represents `emulator`.
(If that doesn't kill it, we'll need to escalate to extreme
`kill -9` prejudice.)

*For good measure*, run `adb kill-server` within
`ReleaseAndroidTarget`, to keep the `adb` daemone from outlasting it's
usefulness.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-pr-builder/939/