### PR TITLE
un-trigger LLVM builds when cross-build is disabled.

### DIFF
--- a/build-tools/mono-runtimes/mono-runtimes.props
+++ b/build-tools/mono-runtimes/mono-runtimes.props
@@ -25,7 +25,7 @@
     <_MingwTriplet64>x86_64-w64-mingw32$(_MingwPrefixTail)</_MingwTriplet64>
 
     <!-- LLVM -->
-    <_LlvmNeeded Condition=" '$(AndroidSupportedTargetAotAbis)' != '' ">yes</_LlvmNeeded>
+    <_LlvmNeeded Condition=" '$(AndroidBuildCross)' != 'false' And '$(AndroidSupportedTargetAotAbis)' != '' ">yes</_LlvmNeeded>
     <_LlvmCanBuild64 Condition=" '$(HostBits)' == '64' ">yes</_LlvmCanBuild64>
     <_LlvmOutputDirTop>$(_CrossOutputDirTop)\llvm</_LlvmOutputDirTop>
 

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -76,7 +76,8 @@ join-with = $(subst $(_space),$(1),$(strip $(2)))
 _MSBUILD_ARGS	= \
 	/p:AndroidSupportedTargetJitAbis=$(call join-with,:,$(ALL_JIT_ABIS)) \
 	/p:AndroidSupportedHostJitAbis=$(call join-with,:,$(ALL_HOST_ABIS)) \
-	/p:AndroidSupportedTargetAotAbis=$(call join-with,:,$(ALL_AOT_ABIS))
+	/p:AndroidSupportedTargetAotAbis=$(call join-with,:,$(ALL_AOT_ABIS)) \
+	/p:AndroidBuildCross=$(BUILD_CROSS)
 
 CONFIGURATIONS ?= Debug Release
 


### PR DESCRIPTION
cross-build has been blocking Linux builds:

		config.sub: too many arguments
		Try `config.sub --help' for more information.
		configure: error: /bin/bash /sources/monodroid/xamarin-android/external/llvm/autoconf/config.sub gcc -dumpmachine failed
		checking build system type...
		Tool sh execution finished.
	/sources/monodroid/xamarin-android/build-tools/mono-runtimes/mono-runtimes.targets: error : Command ' /sources/monodroid/xamarin-android/external/llvm/configure --build="gcc -dumpmachine" --enable-optimized --enable-assertions=no --enable-targets="arm,aarch64,x86" --prefix=/sources/monodroid/xamarin-android/build-tools/mono-runtimes/obj/Release//llvm/installed-32/usr --cache-file=/sources/monodroid/xamarin-android/build-tools/mono-runtimes/obj/Release//llvm32.config.cache CC="gcc -m32" CXX="g++ -m32"' exited with code: 1.