### PR TITLE
[xa-prep-tasks] Support autoprovision with brew 1.2

### DIFF
--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/Which.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/Which.cs
@@ -142,11 +142,17 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 
 		Version GetCurrentVersion ()
 		{
-			string shell, format;
-			GetShell (out shell, out format);
-
 			var command = GetHostProperty (Program, "CurrentVersionCommand", HostOS, HostOSName)
 				?? Program.ItemSpec + " --version";
+
+			return GetProgramVersion (HostOS, command);
+		}
+
+		internal static Version GetProgramVersion (string hostOS, string command)
+		{
+			string shell, format;
+			GetShell (hostOS, out shell, out format);
+
 			var psi = new ProcessStartInfo (shell, string.Format (format, command)) {
 				CreateNoWindow = true,
 				UseShellExecute = false,
@@ -171,9 +177,9 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 				: new Version (curVersion);
 		}
 
-		void GetShell (out string shell, out string format)
+		static void GetShell (string hostOS, out string shell, out string format)
 		{
-			if (HostOS == "Windows") {
+			if (string.Equals (hostOS, "Windows", StringComparison.OrdinalIgnoreCase)) {
 				shell = "cmd.exe";
 				format = "/c \"{0}\"";
 				return;


### PR DESCRIPTION
We got a new macOS Jenkins machine, running brew 1.2. (Our other
machines have brew 1.0 installed.)

When attempting to build on this new machine, [things broke][0]:

	Executing: sudo brew install 'p7zip'
	Error: Running Homebrew as root is extremely dangerous. As Homebrew does not
	drop privileges on installation you are giving all build scripts full access
	to your system. As a result of the macOS sandbox not handling the root user
	correctly HOMEBREW_NO_SANDBOX has been set so the sandbox will not be used. If
	we have not merged a pull request to add privilege dropping by November 1st
	2016 running Homebrew as root will be disabled. No Homebrew maintainers plan
	to work on this functionality.

In short, using `sudo brew` doesn't work...on brew 1.2.

It's currently *required* to use `sudo brew` on brew 1.0.

After some crying, split this difference by running `brew --version`,
and only use `sudo brew` when using brew 1.0.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-pr-builder/942/