### PR TITLE
[xa-prep-tasks] Only skip `sudo` for `brew` commands

### DIFF
--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/PrepareInstall.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/PrepareInstall.cs
@@ -25,6 +25,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 		public  ITaskItem           DownloadUrl         { get; set; }
 
 		string Sudo;
+		string SudoBrew;
 
 		public override bool Execute ()
 		{
@@ -54,8 +55,9 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 			if (!UseSudo || string.Equals ("Windows", HostOS, StringComparison.OrdinalIgnoreCase))
 				return;
 
+			Sudo    = "sudo ";
+
 			if (!string.Equals ("Darwin", HostOS, StringComparison.OrdinalIgnoreCase)) {
-				Sudo = "sudo ";
 				return;
 			}
 			string brewFilename;
@@ -65,7 +67,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 			}
 			var brewVersion	= Which.GetProgramVersion (HostOS, $"{brewPath} --version");
 			if (brewVersion < new Version (1, 1)) {
-				Sudo = "sudo ";
+				SudoBrew    = "sudo ";
 				return;
 			}
 		}
@@ -101,7 +103,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 			if (string.Equals (HostOS, "Darwin", StringComparison.OrdinalIgnoreCase)) {
 				var brew    = Program.GetMetadata ("Homebrew");
 				if (!string.IsNullOrEmpty (brew)) {
-					InstallCommand = $"{Sudo}brew install '{brew}'";
+					InstallCommand = $"{SudoBrew}brew install '{brew}'";
 				}
 				return;
 			}


### PR DESCRIPTION
Commit cbc65479 attempted to improve brew 1.2 support by *skipping*
use of `sudo` when brew 1.2 is detected.

The problem is that this impacts *all* install command use, not just
`brew install` command invocations. Consequently, when e.g. attempting
to install a new MonoFramework, things *fail* because `sudo` *isn't*
specified:

	$ make MSBUILD_ARGS="/p:AutoProvision=True /p:AutoProvisionUsesSudo=True"
	...
	Executing: installer -pkg ".../android-archives/MonoFramework-MDK-5.2.0.114.macos10.xamarin.universal.pkg" -target /

which promptly fails because that requires `sudo` to work.

Fix the `<PrepareInstall/>` task to only skip `sudo` use for *brew*
commands; non-`brew` commands should continue to get `sudo`.