### PR TITLE
regenerate dex files after generating JCW

### DIFF
--- a/build-tools/scripts/JavaCallableWrappers.targets
+++ b/build-tools/scripts/JavaCallableWrappers.targets
@@ -40,4 +40,12 @@
         Command="jar cf &quot;$(_MonoAndroidJar)&quot; -C &quot;$(IntermediateOutputPath)jcw\bin&quot; ."
     />
   </Target>
+  <Target Name="_GenerateMonoAndroidDex16"
+      AfterTargets="GenerateJavaCallableWrappers"
+      Inputs="$(OutputPath)mono.android.jar"
+      Outputs="$(OutputPath)mono.android.dex">
+    <Exec
+        Command="&quot;$(AndroidSdkDirectory)\build-tools\$(XABuildToolsFolder)\dx&quot; --dex --no-strict --output=&quot;$(OutputPath)mono.android.dex&quot; &quot;$(OutputPath)mono.android.jar&quot;"
+    />
+  </Target>
 </Project>

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -105,14 +105,6 @@
   <ItemGroup>
     <_CommonJavaSources Include="java\**\*.java" />
   </ItemGroup>
-  <Target Name="_GenerateMonoAndroidDex16"
-      AfterTargets="GenerateJavaCallableWrappers"
-      Inputs="$(OutputPath)mono.android.jar"
-      Outputs="$(OutputPath)mono.android.dex">
-    <Exec
-        Command="&quot;$(AndroidSdkDirectory)\build-tools\$(XABuildToolsFolder)\dx&quot; --dex --no-strict --output=&quot;$(OutputPath)mono.android.dex&quot; &quot;$(OutputPath)mono.android.jar&quot;"
-    />
-  </Target>
   <Target Name="_GenerateFrameworkList"
       BeforeTargets="GetTargetFrameworkProperties;GetReferenceAssemblyPaths;ResolveReferences"
       Inputs="$(MSBuildProjectFullPath)"


### PR DESCRIPTION
 - this is mostly for OpenTK, where we generate JCWs after
   mono.android's JCWs are already generated

 - fortunatelly we don't use jack anymore, only dx. that makes it much
   easier to do