### PR TITLE
[create-vsix] Fix creation under mono/2017-04

### DIFF
--- a/build-tools/create-vsix/create-vsix.csproj
+++ b/build-tools/create-vsix/create-vsix.csproj
@@ -62,7 +62,6 @@
     <DetokenizeVsixManifestFileDependsOn />
   </PropertyGroup>
   <Import Project="create-vsix.targets" />
-  <Import Project="..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets')" />
   <ItemGroup>
     <ProjectReference Include="..\xa-prep-tasks\xa-prep-tasks.csproj">
       <Project>{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}</Project>

--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -121,4 +121,34 @@
         DestinationFiles="$(VsixPath)"
     />
   </Target>
+  <!--
+    This *replaces* `Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets`
+    -->
+  <PropertyGroup>
+    <_TasksAssembly Condition=" Exists('$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll') ">$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll</_TasksAssembly>
+    <_TasksAssembly Condition=" '$(_TasksAssembly)' == '' ">$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll</_TasksAssembly>
+  </PropertyGroup>
+  <UsingTask TaskName="SetVsSDKEnvironmentVariables"
+      TaskFactory="CodeTaskFactory"
+      AssemblyFile="$(_TasksAssembly)">
+    <ParameterGroup>
+      <ProjectDirectory Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Code Type="Fragment" Language="cs">
+        var toolsPath = System.IO.Path.Combine(ProjectDirectory, "tools", "VSSDK", "bin");
+        System.Environment.SetEnvironmentVariable("VsSDKToolsPath",
+            System.IO.Path.GetFullPath(toolsPath),
+            EnvironmentVariableTarget.Process);
+        var schemaDir = System.IO.Path.Combine(ProjectDirectory, "tools", "VSSDK", "schemas");
+        System.Environment.SetEnvironmentVariable("VsSDKSchemaDir",
+            System.IO.Path.GetFullPath(schemaDir),
+            EnvironmentVariableTarget.Process);
+      </Code>
+    </Task>
+  </UsingTask>
+  <Target Name="SetVsSDKEnvironmentVariables"
+      BeforeTargets="GeneratePkgDef;VSCTCompile;VSIXNameProjectOutputGroup">
+    <SetVsSDKEnvironmentVariables ProjectDirectory="$(ThisPackageDirectory)" />
+  </Target>
 </Project>


### PR DESCRIPTION
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=56633

Commit 8cc4acb0 (or thereabouts) [broke `.vsix` file generation][0]:

	error MSB4174: The task factory "CodeTaskFactory" could not be found in the assembly
	"/Library/Frameworks/Mono.framework/Versions/5.2.0/lib/mono/msbuild/15.0/bin/Microsoft.Build.Tasks.v4.0.dll".

(This works in mono/2017-02, fails with mono/2017-04.)

Fix `.vsix` generation by *not using*
`Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets`,
and instead *copying and "fixing"* the contents of
`Microsoft.VSSDK.BuildTools.targets` into `create-vsix.targets`.
In particular, the corrected `<SetVsSDKEnvironmentVariables/>` task
uses `Microsoft.Build.Tasks.Core.dll`, *not*
`Microsoft.Build.Tasks.v4.0.dll`.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/392/consoleText