### PR TITLE
[tests] Ensure emulator is killed

### DIFF
--- a/build-tools/scripts/UnitTestApks.targets
+++ b/build-tools/scripts/UnitTestApks.targets
@@ -60,22 +60,26 @@
   <Target Name="ReleaseAndroidTarget">
     <Adb
         Condition="'@(_FailedComponent)' != ''"
+        ContinueOnError="True"
         Arguments="$(_EmuTarget) logcat -d"
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)"
     />
     <Adb
         Condition=" '$(_EmuTarget)' != '' "
+        ContinueOnError="True"
         Arguments="$(_EmuTarget) emu kill"
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)"
     />
     <KillProcess
         Condition=" '$(_EmuTarget)' != '' "
+        ContinueOnError="True"
         ProcessId="$(_EmuPid)"
     />
     <Adb
         Arguments="kill-server"
+        ContinueOnError="True"
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)"
     />


### PR DESCRIPTION
A "funny thing" happened in [PR Build #958][0]: `adb` failed:

	Target ReleaseAndroidTarget:
	Task "Adb"
		...
		Tool /Users/builder/android-toolchain/sdk/platform-tools/adb execution started with arguments: -s emulator-5570 logcat -d
		...
	Task "Adb" execution -- FAILED

I have no idea why `adb` is failing, but *because* it failed, the
emulator was never shutdown and killed.

Add `ContinueOnError="True"` to most of the tasks within the
`ReleaseAndroidTarget` target to ensure that the emulator is shutdown
and killed.

[0]: https://jenkins.mono-project.com/job/xamarin-android-pr-builder/958/