### PR TITLE
[android-toolchain] Remove use of $(MAKEFLAGS)

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -134,12 +134,12 @@
       Outputs="@(_AndroidMxeOutput)">
     <Exec
         Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:'))"
-        Command="make $(MAKEFLAGS) MXE_TARGETS=&quot;$(MingwCommandPrefix32)&quot; gcc cmake zlib pthreads dlfcn-win32 mman-win32 PREFIX=&quot;$(AndroidMxeFullPath)&quot;"
+        Command="make MXE_TARGETS=&quot;$(MingwCommandPrefix32)&quot; gcc cmake zlib pthreads dlfcn-win32 mman-win32 PREFIX=&quot;$(AndroidMxeFullPath)&quot;"
         WorkingDirectory="..\..\external\mxe"
     />
     <Exec
         Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))"
-        Command="make $(MAKEFLAGS) MXE_TARGETS=&quot;$(MingwCommandPrefix64)&quot; gcc cmake zlib pthreads dlfcn-win32 mman-win32 PREFIX=&quot;$(AndroidMxeFullPath)&quot;"
+        Command="make MXE_TARGETS=&quot;$(MingwCommandPrefix64)&quot; gcc cmake zlib pthreads dlfcn-win32 mman-win32 PREFIX=&quot;$(AndroidMxeFullPath)&quot;"
         WorkingDirectory="..\..\external\mxe"
     />
     <Touch Files="@(_AndroidMxeOutput)" />


### PR DESCRIPTION
An attempt to [bump `external/mono/`][0] resulted in a
[build failure on a macOS machine][1]:

	Executing: make MSBUILD_ARGS=/p:AutoProvision=True/ /p:AutoProvisionUsesSudo=True V=1 MXE_TARGETS="i686-w64-mingw32.static" gcc cmake zlib pt hreads dlfcn-win32 mman-win32 PREFIX="/Users/builder/android-toolchain/mxe"
	make[1]: *** No rule to make target `/p:AutoProvisionUsesSudo=True'.  Stop.

(This happens on a macOS machine that hasn't previously
built+installed MXE which needs MXE in order to generate Windows
binaries, so auto-builds MXE...)

This error is due to the interraction of three separate choices:

 1. Jenkins is running:

        make prepare jenkins V=1 MSBUILD_ARGS="/p:AutoProvision=True /p:AutoProvisionUsesSudo=True"

 2. xbuild replaces `\` with `/`.

 3. The `_CreateMxeToolchains` target uses `make $(MAKEFLAGS)`.

Background: what is `$(MAKEFLAGS)`? `$(MAKEFLAGS)` is set by
**make**(1) and [contains the command-line flags to `make`][2].
It's value is shown elsewhere in the log file:

	MAKEFLAGS = MSBUILD_ARGS=/p:AutoProvision=True\ /p:AutoProvisionUsesSudo=True V=1

Note that `$(MAKEFLAGS)` contains a backslash: this is because of the
original command, which provides a space-containing value for
`$(MSBUILD_ARGS)`:

	MSBUILD_ARGS="/p:AutoProvision=True /p:AutoProvisionUsesSudo=True"

Instead of preserving the quotes, `make` instead replaces ` ` (space)
with `\ ` (backslash-space), which is perfectly valid:

	# MAKEFLAGS set "as if" we executed:
	make prepare jenkins V=1 MSBUILD_ARGS=/p:AutoProvision=True\ /p:AutoProvisionUsesSudo=True

The problem is when `xbuild` enters the picture: xbuild can't
differentiate between paths and...anything else, so for simplicity and
sanity it *always* replaces `\` with the directory-separtor-char,
which is `/` on macOS/Linux.

Unfortunately, this *completely* changes the semantics of the embedded
`MSBUILD_ARGS` value within `$(MAKEFLAGS)`: replacing `\ ` with `/ `
causes the `/p:AutoProvisionUsesSudo=True` to be treated as target by
`make`, and that target doesn't exist.

In theory, `xbuild` could be fixed to address this. In practice,
`xbuild` isn't getting any future work. `msbuild` *is* getting more
work, but this "corner case" is likely sufficiently complicated that
it might not ever get fixed.

Thus, the simple fix: Don't Do That™: remove use of `$(MAKEFLAGS)`.
It isn't needed in this invocation.

[0]: https://github.com/xamarin/xamarin-android/pull/600
[1]: https://jenkins.mono-project.com/job/xamarin-android-pr-builder/955
[2]: https://www.gnu.org/software/autoconf/manual/autoconf-2.63/html_node/The-Make-Macro-MAKEFLAGS.html