### PR TITLE
[create-vsix] Improve compatibility with commercial .vsix

### DIFF
--- a/build-tools/create-vsix/create-vsix.csproj
+++ b/build-tools/create-vsix/create-vsix.csproj
@@ -17,14 +17,19 @@
     <IncludeCopyLocalReferencesInVSIXContainer>False</IncludeCopyLocalReferencesInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>False</IncludeDebugSymbolsInLocalVSIXDeployment>
     <IncludeDebugSymbolsInVSIXContainer>False</IncludeDebugSymbolsInVSIXContainer>
-    <IsProductComponent Condition=" '$(IsProductComponent)' == '' ">False</IsProductComponent>
+    <IsExperimental Condition=" '$(IsExperimental)' == '' ">true</IsExperimental>
+    <IsProductComponent Condition=" '$(IsProductComponent)' == '' ">True</IsProductComponent>
     <_BuildVsix Condition=" '$(CreateVsixContainer)' == 'True' And Exists ('$(VsSDKInstall)') ">True</_BuildVsix>
     <_BuildVsix Condition=" '$(_BuildVsix)' == '' ">False</_BuildVsix>
+    <ExtensionInstallationFolder>Xamarin.Android.Sdk</ExtensionInstallationFolder>
     <OutputPath>bin\$(Configuration)</OutputPath>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <ItemGroup>
-    <Content Include="Resources\AndroidSdkPackage.ico" />
+    <Content Include="Resources\AndroidSdkPackage.ico">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <Content Include="Xamarin.Android.Sdk.pkgdef">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>True</IncludeInVSIX>

--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -27,15 +27,14 @@
       Returns="@(MSBuild);@(ReferenceAssemblies)">
     <ItemGroup>
       <MSBuild Include="$(LibDir)xbuild\**\*.*" />
-      <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\lib\host-*\**\*.*" />
+      <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\lib\host-Darwin\**\*.*" />
+      <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\lib\host-Linux\**\*.*" />
       <MSBuild>
         <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">%(RecursiveDir)</VSIXSubPath>
       </MSBuild>
-      <MSBuild Include="$(LibDir)xbuild\Xamarin\Android\lib\host-mxe-Win64\*.*" />
       <MSBuild>
         <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Xamarin/Android</VSIXSubPath>
       </MSBuild>
-      <MSBuild Include="$(LibDir)xbuild\Xamarin\Android\lib\host-win\*.*" />
       <MSBuild>
         <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Xamarin/Android/lib/host-win</VSIXSubPath>
       </MSBuild>
@@ -45,7 +44,6 @@
       </MSBuild>
       <MSBuild Include="..\..\bin\$(Configuration)\lib\mandroid\**\*.*" />
       <MSBuild Remove="..\..\bin\$(Configuration)\lib\mandroid\**\*.d.exe" />
-      <MSBuild Remove="..\..\bin\$(Condition)\lib\mandroid\host-Darwin\**\*.*" />
       <MSBuild>
         <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Xamarin/Android/%(RecursiveDir)</VSIXSubPath>
       </MSBuild>
@@ -81,15 +79,11 @@
       DependsOnTargets="GetXAVersionInfo"
       Returns="$(VsixVersion)">
     <PropertyGroup>
-      <VsixVersion>$(ProductVersion).$(_XACommitCount)</VsixVersion>
+      <VsixVersion>$(ProductVersion).$(XAVersionCommitCount)</VsixVersion>
     </PropertyGroup>
   </Target>
   <Target Name="GetIsExperimental"
       Returns="$(IsExperimental)">
-    <PropertyGroup>
-      <IsExperimental>true</IsExperimental>
-      <IsExperimental Condition=" '$(IsProductComponent)' == 'True' ">false</IsExperimental>
-    </PropertyGroup>
   </Target>
   <Target Name="_CreateDependencies"
       DependsOnTargets="GetXAVersionInfo"

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -138,6 +138,7 @@ create-vsix:
 		MONO_IOMAP=all MONO_OPTIONS=--arch=64 msbuild $(MSBUILD_FLAGS) /p:Configuration=$(conf) /p:CreateVsixContainer=True \
 			build-tools/create-vsix/create-vsix.csproj \
 			$(if $(VSIX),"/p:VsixPath=$(VSIX)") \
+			$(if $(EXPERIMENTAL),/p:IsExperimental="$(EXPERIMENTAL)") \
 			$(if $(PRODUCT_COMPONENT),/p:IsProductComponent="$(PRODUCT_COMPONENT)") \
 			$(if $(PACKAGE_VERSION),/p:ProductVersion="$(PACKAGE_VERSION)") \
 			$(if $(PACKAGE_HEAD_BRANCH),/p:XAVersionBranch="$(PACKAGE_HEAD_BRANCH)") \

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.targets
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.targets
@@ -19,6 +19,7 @@
       <_VersionCommitFile>..\..\bin\$(Configuration)\Version.commit</_VersionCommitFile>
       <_VersionRevFile>..\..\bin\$(Configuration)\Version.rev</_VersionRevFile>
       <_XAVersionFile>$(_XAPrefix)\Version</_XAVersionFile>
+      <_XAVersionTxtFile>$(_XAPrefix)\Version.txt</_XAVersionTxtFile>
       <_XAVersionCommitFile>$(_XAPrefix)\Version.commit</_XAVersionCommitFile>
       <_XAVersionRevFile>$(_XAPrefix)\Version.rev</_XAVersionRevFile>
     </PropertyGroup>
@@ -29,6 +30,11 @@
     />
     <WriteLinesToFile
         File="$(_XAVersionFile)"
+        Lines="$(ProductVersion)"
+        Overwrite="True"
+    />
+    <WriteLinesToFile
+        File="$(_XAVersionTxtFile)"
         Lines="$(ProductVersion)"
         Overwrite="True"
     />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -157,7 +157,11 @@
     <Copy
       SourceFiles="$(_SupportLicense)"
       DestinationFiles="$(OutputPath)..\..\..\mandroid\MULTIDEX_JAR_LICENSE" />
-    <Touch Files="$(OutputPath)..\..\..\mandroid\MULTIDEX_JAR_LICENSE" />
+    <Copy
+        SourceFiles="$(_SupportLicense)"
+        DestinationFiles="$(OutputPath)..\..\..\mandroid\MULTIDEX_JAR_LICENSE.txt"
+    />
+    <Touch Files="$(OutputPath)..\..\..\mandroid\MULTIDEX_JAR_LICENSE;$(OutputPath)..\..\..\mandroid\MULTIDEX_JAR_LICENSE.txt" />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
Reduce the number of differences between the `.vsix` file we build and
the `Xamarin.Android.Sdk*.vsix` file which is provided commercially:

* The `$(VsixVersion)` wasn't a valid version value; it was e.g.
    `7.3.99.` (note trailing `.`). This was caused by
    611bb66e, which removed `$(_XACommitCount)`, replacing it with
    `$(XAVersionCommitCount).

* Default to `$(IsProductComponent)`=True, and separate its logic from
    `$(IsExperimental)`. `$(IsProductComponent)` alters the value of
    the `packages[0].id` value within `catalog.json`: when
    `$(IsProductComponent)` is False, `packages[0].id *starts with*
    `Component`, e.g. `Component.Xamarin.Android.Sdk`, which is wrong.

    I'm still not sure why `$(IsProductComponent)` and
    `$(IsExperimental)` were previously tied together as they were.

* Set `$(ExtensionInstallationFolder)` so that the
    `packages[0].extensionDir` value within `catalog.json` doesn't
    contain a random filename. Previously, it would be e.g.:

        "extensionDir":"[installdir]\\Common7\\IDE\\Extensions/x11jqb13.6u5

    Setting `$(ExtensionInstallationFolder)` allows this to instead be:

        "extensionDir":"[installdir]\\Common7\\IDE\\Extensions/Xamarin.Android.Sdk

    TODO/Note: I suspect that the `Microsoft.VSSDK.BuildTools` code
    which creates `extensionDir` is using `Path.Combine()`, because
    we're getting a `.../Xamarin.Android.Sdk` value (`/` is used).
    The existing commercial package uses `\\` consistently.

    I don't know if this will be a problem.

* Set `%(Content.IncludeInVSIX)`=True for `AndroidSdkPackage.ico`, so
    that it is included in the `.vsix` file.

* Create the files
    `bin\$(Configuration)\lib\xbuild\Xamarin\Android\Version.txt` and
    `bin\$(Configuration)\lib\mandroid\MULTIDEX_JAR_LICENSE.txt`
    to work around Bug #54804 so that we have *some* form of
    `Version*` and `MULTIDEX_JAR_LICENSE` file within the `.vsix`.

* Review the `@(MSBuild)` items. Apparently this construct:

        <MSBuild Remove="host-*\**\*" />
        <MSBuild Include="host-mxe-Win64\*.*" />

    doesn't behave as intended: `host-mxe-Win64` is *not* added to the
    `.vsix`; the preceding `%(MSBuild.Remove)` takes precedence.

    Instead of removing "all bad" then adding the desired values, just
    remove the the undesirable values. (This means we might miss some,
    but at least this way we keep the values we want!)