### PR TITLE
Bump to Java.Interop/master/3ef18c59

### DIFF
--- a/build-tools/scripts/JavaCallableWrappers.targets
+++ b/build-tools/scripts/JavaCallableWrappers.targets
@@ -7,7 +7,7 @@
     <MakeDir Directories="$(IntermediateOutputPath)jcw;$(IntermediateOutputPath)jcw\bin" />
     <PropertyGroup>
       <OutputPathAbs>$(MSBuildProjectDirectory)\$(OutputPath)</OutputPathAbs>
-      <JcwGen>"$(JavaInteropFullPath)\bin\$(Configuration)\jcw-gen.exe" -v10</JcwGen>
+      <JcwGen>"$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\lib\mandroid\jcw-gen.exe" -v10</JcwGen>
       <_LibDirs>-L "$(OutputPathAbs)" -L "$(OutputPathAbs)..\v1.0\" -L "$(OutputPathAbs)..\v1.0\Facades"</_LibDirs>
       <_Out>-o "$(MSBuildProjectDirectory)\$(IntermediateOutputPath)jcw\src"</_Out>
     </PropertyGroup>


### PR DESCRIPTION
Builds `jcw-gen.exe` into `bin/$(Configuration)/lib/mandroid`, so that
it will be distributed in future Xamarin.Android releases.

This is to simplify possible Java Callable Wrapper use and generation
by Embeddinator-4000.