### PR TITLE
[create-vsix] Ensure registration shows up in Help/About

### DIFF
--- a/build-tools/create-vsix/AndroidSdkPackage.cs
+++ b/build-tools/create-vsix/AndroidSdkPackage.cs
@@ -1,0 +1,10 @@
+﻿using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.Shell;
+
+namespace Xamarin.Android.Sdk
+{
+    [Guid("d0e8d881-b09d-40bf-923b-b3efddc53c16")]
+    public class AndroidSdkPackage : Package
+    {
+    }
+}

--- a/build-tools/create-vsix/Xamarin.Android.Sdk.pkgdef.in
+++ b/build-tools/create-vsix/Xamarin.Android.Sdk.pkgdef.in
@@ -4,4 +4,8 @@
 "PID"="@PACKAGE_VERSION@.@PACKAGE_VERSION_BUILD@ (@PACKAGE_HEAD_BRANCH@/@PACKAGE_HEAD_REV@)"
 "ProductDetails"="#112"
 "LogoID"="#400"
-
+[$RootKey$\Packages\{d0e8d881-b09d-40bf-923b-b3efddc53c16}]
+@="AndroidSdkPackage"
+"InprocServer32"="$WinDir$\SYSTEM32\MSCOREE.DLL"
+"Class"="Xamarin.Android.Sdk.AndroidSdkPackage"
+"CodeBase"="$PackageFolder$\Xamarin.Android.Sdk.dll"

--- a/build-tools/create-vsix/create-vsix.csproj
+++ b/build-tools/create-vsix/create-vsix.csproj
@@ -7,13 +7,13 @@
     <ProjectGuid>{94756FEB-1F64-411D-A18E-81B5158F776A}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Android.Sdk</RootNamespace>
-    <AssemblyName>Xamarin.Android.Sdk-OSS</AssemblyName>
+    <AssemblyName>Xamarin.Android.Sdk</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <CreateVsixContainer Condition=" '$(CreateVsixContainer)' == '' ">False</CreateVsixContainer>
-    <CopyBuildOutputToOutputDirectory>False</CopyBuildOutputToOutputDirectory>
+    <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>False</CopyOutputSymbolsToOutputDirectory>
     <GeneratePkgDefFile>False</GeneratePkgDefFile>
-    <IncludeAssemblyInVSIXContainer>False</IncludeAssemblyInVSIXContainer>
+    <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeCopyLocalReferencesInVSIXContainer>False</IncludeCopyLocalReferencesInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>False</IncludeDebugSymbolsInLocalVSIXDeployment>
     <IncludeDebugSymbolsInVSIXContainer>False</IncludeDebugSymbolsInVSIXContainer>
@@ -26,6 +26,7 @@
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <ItemGroup>
+    <Compile Include="AndroidSdkPackage.cs" />
     <Content Include="Resources\AndroidSdkPackage.ico">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
@@ -47,6 +48,58 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="Xamarin.Android.Sdk.pkgdef.in" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.CoreUtility.15.0.26201\lib\net45\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Imaging, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Imaging.15.0.26201\lib\net45\Microsoft.VisualStudio.Imaging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.OLE.Interop.7.10.6070\lib\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.15.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.15.0.15.0.26201\lib\Microsoft.VisualStudio.Shell.15.0.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Framework.15.0.26201\lib\net45\Microsoft.VisualStudio.Shell.Framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Interop.7.10.6071\lib\Microsoft.VisualStudio.Shell.Interop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Interop.8.0.8.0.50727\lib\Microsoft.VisualStudio.Shell.Interop.8.0.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Interop.9.0.9.0.30729\lib\Microsoft.VisualStudio.Shell.Interop.9.0.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.TextManager.Interop.7.10.6070\lib\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.TextManager.Interop.8.0.8.0.50727\lib\Microsoft.VisualStudio.TextManager.Interop.8.0.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Threading.15.0.240\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Utilities.15.0.26201\lib\net45\Microsoft.VisualStudio.Utilities.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Validation, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Validation.15.0.82\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VsSDKInstall)\Microsoft.VsSDK.targets" Condition=" '$(_BuildVsix)' == 'True' " />

--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -103,7 +103,7 @@
       <_Branch>$(_Branch.Replace ('\', '-'))</_Branch>
     </PropertyGroup>
     <PropertyGroup>
-      <VsixPath Condition=" '$(VsixPath)' == '' ">..\..\bin\Build$(Configuration)\$(AssemblyName)-$(ProductVersion).$(XAVersionCommitCount)_$(XAVersionBranch)_$(XAVersionHash).vsix</VsixPath>
+      <VsixPath Condition=" '$(VsixPath)' == '' ">..\..\bin\Build$(Configuration)\$(AssemblyName)-OSS-$(ProductVersion).$(XAVersionCommitCount)_$(XAVersionBranch)_$(XAVersionHash).vsix</VsixPath>    
     </PropertyGroup>
   </Target>
   <Target Name="_CopyToBuildConfiguration"

--- a/build-tools/create-vsix/packages.config
+++ b/build-tools/create-vsix/packages.config
@@ -1,4 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.VisualStudio.CoreUtility" version="15.0.26201" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Imaging" version="15.0.26201" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6070" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Shell.15.0" version="15.0.26201" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Shell.Framework" version="15.0.26201" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Shell.Interop" version="7.10.6071" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.8.0" version="8.0.50727" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.9.0" version="9.0.30729" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6070" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50727" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Threading" version="15.0.240" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Utilities" version="15.0.26201" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Validation" version="15.0.82" targetFramework="net46" />
   <package id="Microsoft.VSSDK.BuildTools" version="15.0.26201" targetFramework="net46" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=56867

It turns out that having a *package* definition in the pkgdef
without a corresponding Package entry in the same file, makes
it impossible for VS to find the associated resources with the
given IDs (#400 for the icon, #110 and #112 for the name and
description).

It also turns out that even if were to do without the icon,
using plain strings for #110/112 doesn't work either, and the
package entry has to be there anyway, alongside the assembly
and code base.

Therefore, just add it to the VSIX payload so that VS can use
it to locate those resources for Help/About and nothing else.

Since we still tell the VSSDK targets *not* to create the PKGDEF
from the Package-derived class, this should still mean it's a
plain IL compilation for xbuild/MacOSX and hopefully it won't
break anything.

NOTE: the AssemblyName has to match what's in the PKGDEF, so
we made it match with the official one too. Since this assembly
name isn't used for anything at run-time, it's fine to leave it
as-is with no changes.

The new gazillion packages/references are needed just so the
AndroidSdkPackage class can inherit from Package as expected
by VS.