### PR TITLE
[Xamarin.Android.Build.Utilities] Check for both `Version.txt` and `Version`

### DIFF
--- a/src/Xamarin.Android.Build.Utilities/Sdks/MonoDroidSdkWindows.cs
+++ b/src/Xamarin.Android.Build.Utilities/Sdks/MonoDroidSdkWindows.cs
@@ -70,6 +70,7 @@ namespace Xamarin.Android.Build.Utilities
 		protected override IEnumerable<string> GetVersionFileLocations ()
 		{
 			yield return Path.GetFullPath (Path.Combine (RuntimePath, "Version"));
+			yield return Path.GetFullPath (Path.Combine (RuntimePath, "Version.txt"));
 		}
 	}
 }


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=56864

The scenario: use a `monodroid`-generated `.vsix` file, and attempt to
deploy a project to an Android target.

Result: it fails badly:

	System.ArgumentNullException: Value cannot be null.
	Parameter name: path1
	   at System.IO.Path.Combine(String path1, String path2, String path3, String path4)
	   at Xamarin.AndroidTools.PlatformPackage.GetPlatformPackageVersion(Int32 apiLevel, String& packageName)
	   at AndroidDeviceExtensions.<GetPackageVersionsAsync>d__33.MoveNext()
	--- End of stack trace from previous location where exception was thrown ---
	   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
	   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
	   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
	   at AndroidDeviceExtensions.<GetPackagesAsync>d__27.MoveNext()
	--- End of stack trace from previous location where exception was thrown ---
	   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
	   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
	   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
	   at Xamarin.AndroidTools.AndroidDeploySession.<RunAsync>d__101.MoveNext()
	--- End of stack trace from previous location where exception was thrown ---
	   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
	   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
	   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
	   at Xamarin.AndroidTools.AndroidDeploySession.<RunLoggedAsync>d__99.MoveNext()

The cause is that [`MonoDroidSdk.RuntimePath` is `null`][0] within
`PlatformPackage.GetPlatformPackageVersion()`.

@tondat [provides the execution sequence][1] which explains how this
could happen:

> @tondat:
>   in msbuild this is the sequence
>   https://github.com/xamarin/xamarin-android/blob/master/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets#L585
>   https://github.com/xamarin/xamarin-android/blob/master/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs#L131
>   https://github.com/xamarin/xamarin-android/blob/master/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs#L61
>   https://github.com/xamarin/androidtools/blob/master/Xamarin.AndroidTools/MonoDroidSdk.cs#L124
>   https://github.com/xamarin/androidtools/blob/master/Xamarin.AndroidTools/Sdks/MonoDroidSdkBase.cs#L67
> @kzu:
>   @jonpryor I think the Version.txt renaming might be causing *this* code path to run:
>   https://github.com/xamarin/androidtools/blob/master/Xamarin.AndroidTools/MonoDroidSdk.cs#L126-L135

The "Version.txt renaming" is referring to an attempt to work around
[Bug #54804][2] by [renaming `Version` to `Version.txt`][3]. In such
an environment, there is no `Version` file.

Which brings us to the link provided by @kzu, to
`MonoDroidSdk.Refresh()`: if the `Version` file can't be found and
parsed, then `MonoDroidSdk.Refresh()` calls `sdk.Reset()`, *clearing*
the paths that will be used.

This explains how `MonoDroidSdk.RuntimePath` could be `null`.

Improve `MonoDroidSdkBase` and `MonoDroidSdkWindows` so that
`MonoDroidSdkBase.GetVersionFileLocations()` returns both `Version`
and `Version.txt` values, which should enable support for
`monodroid`- and `xamarin-android`-generated `.vsix` files.

[0]: https://github.com/xamarin/androidtools/blob/b9d9640/Xamarin.AndroidTools/PlatformPackage.cs#L48
[1]: https://xamarinhq.slack.com/archives/C03CEGRUW/p1496168414334414
[2]: https://bugzilla.xamarin.com/show_bug.cgi?id=54804
[3]: xamarin/xamarin-android@a554422