### PR TITLE
Build LLVM cross-compilers on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ UBUNTU_DEPS          = \
 	gcc-mingw-w64 \
 	git \
 	libtool \
+	libz-mingw-w64-dev \
 	libzip4 \
 	linux-libc-dev \
 	make \

--- a/build-tools/mono-runtimes/mono-runtimes.projitems
+++ b/build-tools/mono-runtimes/mono-runtimes.projitems
@@ -152,7 +152,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <_MonoRuntime Include="host-mxe-Win64" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    <_MonoRuntime Include="host-mxe-Win64" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':linux-Win64:'))">
       <Ar>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-ar</Ar>
       <As>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-as</As>
       <Cc>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-gcc</Cc>
@@ -168,6 +168,29 @@
       <RanLib>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-ranlib</RanLib>
       <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-strip</Strip>
       <ConfigureFlags>PATH="$PATH:$(AndroidMxeFullPath)\bin" --host=$(MingwCommandPrefix64) --target=$(MingwCommandPrefix64) --disable-boehm --enable-mcs-build=no --enable-nls=no --enable-maintainer-mode --with-monodroid --disable-llvm ac_cv_header_zlib_h=no ac_cv_search_dlopen=no</ConfigureFlags>
+      <NativeLibraryExtension>dll</NativeLibraryExtension>
+      <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
+      <OutputProfilerFilename></OutputProfilerFilename>
+      <OutputMonoBtlsFilename></OutputMonoBtlsFilename>
+      <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
+      <DoBuild>True</DoBuild>
+    </_MonoRuntime>
+    <_MonoRuntime Include="host-mxe-Win32" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':linux-Win32:'))">
+      <Ar>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-ar</Ar>
+      <As>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-as</As>
+      <Cc>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-gcc</Cc>
+      <Cpp></Cpp>
+      <CFlags>$(_HostWin32CFlags)</CFlags>
+      <Cxx>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-g++</Cxx>
+      <CxxFlags>$(_HostWin32CFlags)</CxxFlags>
+      <CxxCpp></CxxCpp>
+      <DllTool>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-dlltool</DllTool>
+      <Ld>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-ld</Ld>
+      <LdFlags></LdFlags>
+      <Objdump>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-objdump</Objdump>
+      <RanLib>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-ranlib</RanLib>
+      <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-strip</Strip>
+      <ConfigureFlags>PATH="$PATH:$(AndroidMxeFullPath)\bin" --host=$(MingwCommandPrefix32) --target=$(MingwCommandPrefix32) --disable-boehm --enable-mcs-build=no --enable-nls=no --enable-maintainer-mode --with-monodroid --disable-llvm ac_cv_header_zlib_h=no ac_cv_search_dlopen=no</ConfigureFlags>
       <NativeLibraryExtension>dll</NativeLibraryExtension>
       <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
       <OutputProfilerFilename></OutputProfilerFilename>
@@ -251,7 +274,7 @@
       <InstallPath>bin/</InstallPath>
     </_LlvmRuntime>
 
-    <_LlvmRuntime Include="llvmwin32" Condition=" '$(_LlvmNeeded)' != '' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:')) ">
+    <_LlvmRuntime Include="llvmwin32" Condition=" '$(_LlvmNeeded)' != '' And ($(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':linux-Win32:'))) ">
       <BuildDir>build-win32</BuildDir>
       <Prefix>$(_LlvmPrefixWin32)</Prefix>
       <ConfigureFlags>$(_LlvmConfigureFlagsWin32)</ConfigureFlags>
@@ -262,7 +285,7 @@
       <InstallPath>lib/mandroid/</InstallPath>
     </_LlvmRuntime>
 
-    <_LlvmRuntime Include="llvmwin64" Condition=" '$(_LlvmNeeded)' != '' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:')) ">
+    <_LlvmRuntime Include="llvmwin64" Condition=" '$(_LlvmNeeded)' != '' And ($(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':linux-Win64:'))) ">
       <BuildDir>build-win64</BuildDir>
       <Prefix>$(_LlvmPrefixWin64)</Prefix>
       <ConfigureFlags>$(_LlvmConfigureFlagsWin64)</ConfigureFlags>
@@ -280,9 +303,9 @@
       <JitArch>armeabi</JitArch>
       <Ar>ar</Ar>
       <As>as</As>
-      <Cc>$(HostCc)</Cc>
+      <Cc>$(HostCc32)</Cc>
       <CFlags>$(_CrossCFlags)</CFlags>
-      <Cxx>$(HostCxx)</Cxx>
+      <Cxx>$(HostCxx32)</Cxx>
       <CxxCpp>cpp</CxxCpp>
       <CxxFlags>$(_CrossCXXFlags)</CxxFlags>
       <Ld>ld</Ld>

--- a/build-tools/mono-runtimes/mono-runtimes.props
+++ b/build-tools/mono-runtimes/mono-runtimes.props
@@ -7,7 +7,7 @@
     <_HostWinCFlags Condition=" '$(Configuration)' == 'Release' ">-g -O2 -DXAMARIN_PRODUCT_VERSION=0</_HostWinCFlags>
     <_BtlsConfigureFlags>--enable-dynamic-btls --with-btls-android-ndk=$(AndroidToolchainDirectory)\ndk</_BtlsConfigureFlags>
     <_CommonConfigureFlags>--without-ikvm-native --enable-maintainer-mode --with-profile2=no --with-profile4=no --with-profile4_5=no --with-monodroid --enable-nls=no --with-sigaltstack=yes --with-tls=pthread mono_cv_uscore=yes</_CommonConfigureFlags>
-    <_TargetConfigureFlags>$(_CommonConfigureFlags) --enable-minimal=ssa,portability,attach,verifier,full_messages,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,security,shared_handles --disable-mcs-build --disable-executables --disable-iconv $(_BtlsConfigureFlags)</_TargetConfigureFlags>
+    <_TargetConfigureFlags>$(_CommonConfigureFlags) --enable-minimal=ssa,portability,attach,verifier,full_messages,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,security,shared_handles --disable-mcs-build --disable-executables --disable-iconv --disable-boehm $(_BtlsConfigureFlags)</_TargetConfigureFlags>
     <_SecurityCFlags>-Wl,-z,now -Wl,-z,relro -Wl,-z,noexecstack -fstack-protector</_SecurityCFlags>
     <_TargetCFlags>$(_SecurityCFlags) -DMONODROID=1</_TargetCFlags>
     <_TargetCxxFlags>$(_SecurityCFlags) -DMONODROID=1</_TargetCxxFlags>
@@ -97,7 +97,10 @@
     <_CrossCFlagsWin>$(_CrossCFlags)</_CrossCFlagsWin>
     <_CrossCXXFlags>$(_CrossCommonCXXFlags)</_CrossCXXFlags>
     <_CrossCXXFlagsWin>$(_CrossCXXFlags)</_CrossCXXFlagsWin>
-    <_CrossConfigureFlags>--build=$(_CrossConfigureBuildHost) $(_CrossCommonConfigureFlags)</_CrossConfigureFlags>
+    <_CrossConfigureFlags32>--build=$(_CrossConfigureBuildHost32) $(_CrossCommonConfigureFlags)</_CrossConfigureFlags32>
+    <_CrossConfigureFlags64>--build=$(_CrossConfigureBuildHost64) $(_CrossCommonConfigureFlags)</_CrossConfigureFlags64>
+    <_CrossConfigureFlags Condition=" '$(HostBits)' == '64' " >$(_CrossConfigureFlags64)</_CrossConfigureFlags>
+    <_CrossConfigureFlags Condition=" '$(HostBits)' == '32' " >$(_CrossConfigureFlags32)</_CrossConfigureFlags>
 
     <_LlvmConfigureFlags32>--build="$(_CrossConfigureBuildHost)" $(_LlvmCommonConfigureFlags32)</_LlvmConfigureFlags32>
     <_LlvmConfigureFlags64>--build="$(_CrossConfigureBuildHost)" $(_LlvmCommonConfigureFlags64)</_LlvmConfigureFlags64>

--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -484,6 +484,7 @@
           Inputs="$(MonoSourceFullPath)\configure"
           Outputs="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)\Makefile;$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)\.stamp"
           Condition=" '@(_MonoCrossRuntime)' != '' ">
+    <Message Text="Configuring %(_MonoCrossRuntime.Identity) in $(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)"/>
     <MakeDir Directories="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)" />
     <Exec
         Command="%(_MonoCrossRuntime.ConfigureEnvironment) $(MonoSourceFullPath)\configure LDFLAGS=&quot;%(_MonoCrossRuntime.LdFlags)&quot; CFLAGS=&quot;%(_MonoCrossRuntime.CFlags)&quot; CXXFLAGS=&quot;%(_MonoCrossRuntime.CxxFlags)&quot; CC=&quot;%(_MonoCrossRuntime.Cc)&quot; CXX=&quot;%(_MonoCrossRuntime.Cxx)&quot; CPP=&quot;%(_MonoCrossRuntime.Cpp)&quot; CXXCPP=&quot;%(_MonoCrossRuntime.CxxCpp)&quot; LD=&quot;%(_MonoCrossRuntime.Ld)&quot; AR=&quot;%(_MonoCrossRuntime.Ar)&quot; AS=&quot;%(_MonoCrossRuntime.As)&quot; RANLIB=&quot;%(_MonoCrossRuntime.RanLib)&quot; STRIP=&quot;%(_MonoCrossRuntime.Strip)&quot; DLLTOOL=&quot;%(_MonoCrossRuntime.DllTool)&quot; OBJDUMP=&quot;%(_MonoCrossRuntime.Objdump)&quot; --cache-file=..\%(_MonoCrossRuntime.Identity).config.cache %(_MonoCrossRuntime.ConfigureFlags)"
@@ -499,7 +500,7 @@
   <Target Name="_GenerateCrossOffsetHeaderFiles"
       Inputs="$(MonoSourceFullPath)\configure"
       Outputs="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)\%(_MonoCrossRuntime.TargetAbi).h"
-      Condition=" '$(HostOS)' != 'Linux' And '@(_MonoCrossRuntime)' != '' ">
+      Condition=" '@(_MonoCrossRuntime)' != '' ">
     <Exec
         Command="make $(_AotOffsetsDumperName)"
         WorkingDirectory="$(_AotOffsetsDumperSourceDir)" 

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -42,10 +42,15 @@ ALL_JIT_ABIS  = \
 ALL_HOST_ABIS = \
 	$(shell uname)
 
+ALL_AOT_ABIS = \
+	armeabi \
+	arm64 \
+	x86 \
+	x86_64 \
 #
-# On Linux we no disable building of all the cross-compiler/AOT environments.
-# This is because CppSharp as used in Mono to generate C headers with
-# runtime struct offsets doesn't work on Linux in the version used by Mono
+# On Linux we now disable building of all the Windows cross-compiler/AOT environments.
+# This is because Linux builds don't use mxe and the system-provided mingw environment
+# is missing a handful of libraries required by libmonodroid and libzip-windows
 #
 # When/if CppSharp is fixed to work on Linux we can re-enable the code below
 #
@@ -54,14 +59,10 @@ ALL_HOST_ABIS += \
 	mxe-Win32 \
 	mxe-Win64
 
-ALL_AOT_ABIS = \
-	armeabi \
+ALL_AOT_ABIS += \
 	win-armeabi \
-	arm64 \
 	win-arm64 \
-	x86 \
 	win-x86 \
-	x86_64 \
 	win-x86_64
 endif
 

--- a/src/monodroid/jni/util.c
+++ b/src/monodroid/jni/util.c
@@ -6,7 +6,7 @@
 #ifndef WINDOWS
 #include <sys/socket.h>
 #else
-#include <Winsock2.h>
+#include <winsock2.h>
 #endif
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/src/monodroid/monodroid.projitems
+++ b/src/monodroid/monodroid.projitems
@@ -21,14 +21,24 @@
       <Strip>strip</Strip>
       <StripFlags>-S</StripFlags>
     </_HostRuntime>
-    <_HostRuntime Include="host-mxe-Win64" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+    <_HostRuntime Include="host-mxe-Win64" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':linux-Win64:'))">
       <Cc>"$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-gcc"</Cc>
       <CFlags>@(JdkIncludePath->'-I%(Identity)', ' ') $(_HostCommonWinCFlags) $(_HostWin64CFlags) $(_LinuxFlatPakBuild)</CFlags>
       <LdFlags>$(_HostCommonWinLdFlags)</LdFlags>
       <ExtraSource></ExtraSource>
       <NativeLibraryExtension>dll</NativeLibraryExtension>
-      <OutputDirectory>host-win</OutputDirectory>
+      <OutputDirectory>host-mxe-Win64</OutputDirectory>
       <Strip>"$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-strip"</Strip>
+      <StripFlags>-S</StripFlags>
+    </_HostRuntime>
+    <_HostRuntime Include="host-mxe-Win32" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':linux-Win32:'))">
+      <Cc>"$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-gcc"</Cc>
+      <CFlags>@(JdkIncludePath->'-I%(Identity)', ' ') $(_HostCommonWinCFlags) $(_HostWin32CFlags) $(_LinuxFlatPakBuild)</CFlags>
+      <LdFlags>$(_HostCommonWinLdFlags)</LdFlags>
+      <ExtraSource></ExtraSource>
+      <NativeLibraryExtension>dll</NativeLibraryExtension>
+      <OutputDirectory>host-mxe-Win32</OutputDirectory>
+      <Strip>"$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-strip"</Strip>
       <StripFlags>-S</StripFlags>
     </_HostRuntime>
   </ItemGroup>

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -120,6 +120,7 @@
       DependsOnTargets="_GetBuildHostRuntimes"
       Inputs="@(_CFile);@(_UnixCFile)"
       Outputs="@(_HostRuntime->'$(OutputPath)%(OutputDirectory)\libmono-android.debug.%(NativeLibraryExtension)')">
+    <Message Text="Building host runtime %(_HostRuntime.Identity) in $(OutputPath)%(_HostRuntime.OutputDirectory)"/>
     <MakeDir Directories="$(OutputPath)%(_HostRuntime.OutputDirectory)" />
     <Exec
         Command="%(_HostRuntime.Cc) -o &quot;$(OutputPath)%(_HostRuntime.OutputDirectory)\libmono-android.debug.%(_HostRuntime.NativeLibraryExtension)&quot; $(_DebugCFlags) %(_HostRuntime.CFlags) @(_CFile->'%(Identity)', ' ') %(_HostRuntime.ExtraSource) %(_HostRuntime.LdFlags)"


### PR DESCRIPTION
Adds support to build all of the LLVM-based cross compilers on Linux and
thus makes it possible to use AOT on Linux.

Windows cross compilers can be built as well, but build of libmonodroid
or libzip-windows won't work because Linux doesn't use mxe and mingw
packaged for Linux doesn't come with a handful of libraries required for
the above builds to complete (mman, dlfcn, cmake and friends)