### PR TITLE
[create-vsix] Allow XAVersion* properties to be overridden

### DIFF
--- a/build-tools/scripts/XAVersionInfo.targets
+++ b/build-tools/scripts/XAVersionInfo.targets
@@ -18,19 +18,19 @@
         WorkingDirectory="$(XamarinAndroidSourcePath)"
         ToolPath="$(GitToolPath)"
         ToolExe="$(GitToolExe)">
-      <Output TaskParameter="CommitCount"             PropertyName="XAVersionCommitCount" />
+      <Output TaskParameter="CommitCount"             PropertyName="XAVersionCommitCount"   Condition=" '$(XAVersionCommitCount)' == '' " />
     </GitCommitsInRange>
     <GitCommitHash
         WorkingDirectory="$(XamarinAndroidSourcePath)"
         ToolPath="$(GitToolPath)"
         ToolExe="$(GitToolExe)">
-      <Output TaskParameter="AbbreviatedCommitHash"   PropertyName="XAVersionHash" />
+      <Output TaskParameter="AbbreviatedCommitHash"   PropertyName="XAVersionHash"          Condition=" '$(XAVersionHash)' == '' " />
     </GitCommitHash>
     <GitBranch
         WorkingDirectory="$(XamarinAndroidSourcePath)"
         ToolPath="$(GitToolPath)"
         ToolExe="$(GitToolExe)">
-      <Output TaskParameter="Branch"                  PropertyName="XAVersionBranch" />
+      <Output TaskParameter="Branch"                  PropertyName="XAVersionBranch"        Condition=" '$(XAVersionBranch)' == '' " />
     </GitBranch>
   </Target>
 </Project>


### PR DESCRIPTION
(From the "how long have I been mistaken?" department...)

Commit 611bb66e attempted to easily allow overriding the MSBuild
properties `$(XAVersionBranch)`, `$(XAVersionCommitCount)`, and
`$(XAVersionHash)` -- among others -- by setting **make** variables:

	make create-vsix COMMIT=deadbeef
	# calls `msbuild create-vsix.csproj /p:XAVersionHash=deadbeef`

The problem? It didn't actually work.
`build-tools/create-vsix/Xamarin.Android.Sdk.pkgdef` would contain
e.g. `"PID"="7.3.99.60 (branch-name/8354bef4)`, *not*
e.g. `"PID"="7.3.99.60 (branch-name/deadbeef)`.

Since the entire point to "forwarding" these make variables and
overriding the MSBuild properties was to allow the commercial
Xamarin.Android builder to provide correct values from the `monodroid`
repo, this meant that the `monodroid`-generated values were completely
wrong, as they contained `xamarin-android` values.

Oops.

The *actual* cause of this bug is a [misunderstanding][0] on my part
of how MSBuild properties work.

>  1. Each property passed in on the command line becomes a
>     *global* property
>
> ...
>
>  4. Target execution begins. Programmatic values (outputs of
>     tasks, including the *CreateProperty* task) overwrite current
>     values for all properties, including global properties.

Rule (4) means that command-line properties are *not* immutable, as I
had previously believed -- in part because that's how `xbuild` behaved
(yet another `xbuild` bug?) -- which is why commit 611bb66e didn't
work as I had hoped.

The fix is to make `<Output/>` use conditional on whether the
`$(XAVersionBranch)`, `$(XAVersionCommitCount)`, and
`$(XAVersionHash)` properties have been overridden or not.
This permits intended behavior.

[0]: https://blogs.msdn.microsoft.com/aaronhallberg/2007/07/16/msbuild-property-evaluation/