### PR TITLE
[Xamarin.Android.Build.Tasks] Follow-up to Bug 33052: "Invalid option" causes java.exe failure during build with multidex if username contains spaces

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
@@ -89,11 +89,12 @@ namespace Xamarin.Android.Tasks
 
 		void GenerateMainDexListBuilderCommands(CommandLineBuilder cmd)
 		{
+			var enclosingChar = OS.IsWindows ? "\"" : string.Empty;
 			var jars = JavaLibraries.Select (i => i.ItemSpec).Concat (new string [] { ClassesOutputDirectory });
 			cmd.AppendSwitchIfNotNull ("-Djava.ext.dirs=", Path.Combine (AndroidSdkBuildToolsPath, "lib"));
 			cmd.AppendSwitch ("com.android.multidex.MainDexListBuilder");
-			cmd.AppendSwitch (tempJar);
-			cmd.AppendSwitchUnquotedIfNotNull ("", "\"" + string.Join ($"{Path.PathSeparator}", jars) + "\"");
+			cmd.AppendSwitch ($"{enclosingChar}{tempJar}{enclosingChar}");
+			cmd.AppendSwitchUnquotedIfNotNull ("", $"{enclosingChar}" + string.Join ($"{Path.PathSeparator}", jars) + $"{enclosingChar}");
 			writeOutputToKeepFile = true;
 		}
 


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=57027

Commit 6829b7d1 added support for spaces in the SDK path.
However it neglected to support spaces in the temp path which
is used for the output jar. As a resilt we get the
"Invalid option" error from java.

This commit adds support for quoting the temp jar path in
order to avoid this issue.