### PR TITLE
[emulator] wait for the emulator to fully boot

### DIFF
--- a/build-tools/scripts/UnitTestApks.targets
+++ b/build-tools/scripts/UnitTestApks.targets
@@ -51,6 +51,12 @@
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)"
     />
+    <Xamarin.Android.Tools.BootstrapTasks.Adb
+        Condition=" '$(_ValidAdbTarget)' != 'True' "
+        Arguments="$(_EmuTarget) shell 'counter=0; while [ $counter -lt 60 ] &amp;&amp; [ &quot;`getprop sys.boot_completed`&quot; != &quot;1&quot; ]; do echo Waiting for device to fully boot; sleep 1; let &quot;counter++&quot;; done'"
+        ToolExe="$(AdbToolExe)"
+        ToolPath="$(AdbToolPath)"
+    />
     <Message
         Condition=" '$(_EmuTarget)' != '' "
         Text="Launched Android emulator; `adb` target: '$(_AdbTarget)'"


### PR DESCRIPTION
 - so that we avoid issue like this (from Jenkins log):

         Task Adb
           Arguments: -s emulator-5570  uninstall "Mono.Android_Tests"
         Tool /Users/builder/android-toolchain/sdk/platform-tools/adb execution started with arguments: -s emulator-5570  uninstall "Mono.Android_Tests"
         Environment variables being passed to the tool:
         Error: Could not access the Package Manager.  Is the system running?