### PR TITLE
update to O preview 2 API.

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -63,8 +63,8 @@
     <AllSupported32BitTargetAndroidAbis>armeabi;armeabi-v7a;x86</AllSupported32BitTargetAndroidAbis>
     <AllSupported64BitTargetAndroidAbis>arm64-v8a;x86_64</AllSupported64BitTargetAndroidAbis>
     <AllSupportedTargetAndroidAbis>$(AllSupported32BitTargetAndroidAbis);$(AllSupported64BitTargetAndroidAbis)</AllSupportedTargetAndroidAbis>
-    <XABuildToolsVersion>26-rc1</XABuildToolsVersion>
-    <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">26.0.0-rc1</XABuildToolsFolder>
+    <XABuildToolsVersion>26-rc2</XABuildToolsVersion>
+    <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">26.0.0-rc2</XABuildToolsFolder>
   </PropertyGroup>
   <PropertyGroup>
     <_MingwPrefixTail Condition=" '$(HostOS)' == 'Darwin' ">.static</_MingwPrefixTail>

--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -15,15 +15,15 @@
       <HostOS>Linux</HostOS>
       <DestDir>build-tools\$(XABuildToolsFolder)</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="platform-tools_r26.0.0-rc1-linux.zip">
+    <AndroidSdkItem Include="platform-tools_r26.0.0-rc2-linux.zip">
       <HostOS>Linux</HostOS>
       <DestDir>platform-tools</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="sdk-tools-linux-3859397.zip">
+    <AndroidSdkItem Include="sdk-tools-linux-3952940.zip">
       <HostOS>Linux</HostOS>
       <DestDir>tools</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="emulator-linux-3887480.zip">
+    <AndroidSdkItem Include="emulator-linux-3965150.zip">
       <HostOS>Linux</HostOS>
       <DestDir>emulator</DestDir>
     </AndroidSdkItem>
@@ -34,15 +34,15 @@
       <HostOS>Darwin</HostOS>
       <DestDir>build-tools\$(XABuildToolsFolder)</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="platform-tools_r26.0.0-rc1-darwin.zip">
+    <AndroidSdkItem Include="platform-tools_r26.0.0-rc2-darwin.zip">
       <HostOS>Darwin</HostOS>
       <DestDir>platform-tools</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="sdk-tools-darwin-3859397.zip">
+    <AndroidSdkItem Include="sdk-tools-darwin-3952940.zip">
       <HostOS>Darwin</HostOS>
       <DestDir>tools</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="emulator-darwin-3887480.zip">
+    <AndroidSdkItem Include="emulator-darwin-3965150.zip">
       <HostOS>Darwin</HostOS>
       <DestDir>emulator</DestDir>
     </AndroidSdkItem>
@@ -94,7 +94,7 @@
       <HostOS></HostOS>
       <DestDir>platforms\android-25</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="platform-O_r01.zip">
+    <AndroidSdkItem Include="platform-O_r02.zip">
       <HostOS></HostOS>
       <DestDir>platforms\android-O</DestDir>
     </AndroidSdkItem>

--- a/build-tools/api-xml-adjuster/Makefile
+++ b/build-tools/api-xml-adjuster/Makefile
@@ -49,10 +49,12 @@ clean-api-xml:
 
 $(CLASS_PARSE_XML): $(CLASS_PARSE) $(ANDROID_JAR) $(DOCS_DIR_CUR_LEVEL)
 	mkdir -p $(CLASS_PARSE_XML_DIR)
-	if [ $(LEVEL) -ge 24 ]; then \
+	if [ '$(LEVEL)' -eq 'O' ]; then \
 		$(RUN_CLASS_PARSE) $(ANDROID_JAR) -docspath=$(DOCS_DIR_CUR_LEVEL)/reference --docstype=droiddoc2 > $(CLASS_PARSE_XML) || rm -f $(CLASS_PARSE_XML) ;\
-	else \
+	elif [ $(LEVEL) -le 25 ]; then \
 		$(RUN_CLASS_PARSE) $(ANDROID_JAR) -docspath=$(DOCS_DIR_CUR_LEVEL)/reference --docstype=droiddoc > $(CLASS_PARSE_XML) || rm -f $(CLASS_PARSE_XML) ;\
+	else \
+		$(RUN_CLASS_PARSE) $(ANDROID_JAR) -docspath=$(DOCS_DIR_CUR_LEVEL)/reference --docstype=droiddoc2 > $(CLASS_PARSE_XML) || rm -f $(CLASS_PARSE_XML) ;\
 	fi
 
 $(ANALYZED_XML): $(API_XML_TOOL) $(CLASS_PARSE_XML)
@@ -71,7 +73,7 @@ DOCS_DIR_CUR_LEVEL: $(DOCS_DIR_CUR_LEVEL)
 
 define extract-docs
 	mkdir -p $(DOCS_DIR)
-	unzip -d $(DOCS_DIR) $1 || exit 1
+	unzip $1 || exit 1
 	mv $2 $@
 endef
 
@@ -82,7 +84,7 @@ docs-25_web.zip:
 	curl -L https://dl.dropboxusercontent.com/u/493047/2016/docs-25-web.zip > $@ || exit 1
 
 docs-O_web.zip:
-	curl -L https://www.dropbox.com/s/3xr11fpd08xpolg/docs-O-web.zip?dl=0 > $@ || exit 1
+	curl -L https://www.dropbox.com/s/35sty6h7oszc488/docs-api-O.zip?dl=0 > $@ || exit 1
 
 # API level 10 is Android v2.3.3; it's API level 9 (Android v2.3) with a few
 # bugfixes which don't impact the documentation.
@@ -123,6 +125,6 @@ $(DOCS_DIR)/docs-api-24: docs-24_r01.zip
 $(DOCS_DIR)/docs-api-25: docs-25_web.zip	# Google hadn't published docs component yet!
 	$(call extract-docs,$<,docs)
 
-docs-api-O: docs-O_web.zip	# No preview docs yet
+$(DOCS_DIR)/docs-api-O: docs-O_web.zip	# No preview docs yet
 	$(call extract-docs,$<,docs)
 

--- a/build-tools/api-xml-adjuster/README.md
+++ b/build-tools/api-xml-adjuster/README.md
@@ -30,3 +30,14 @@ MSBuild /t:Clean.
 It had existed as such, and it's not part of the build, no need to be
 built on Windows so far.
 
+
+## How do you get the docs archive for the preview APIs?
+
+Google publishes the docs SDK component only against the stable API,
+which means that preview API types are not included.
+That makes our parameter names retrieval impossible for the preview API.
+
+To workaround the issue, we create corresponding API docs zip archive
+from developer.android.com using the following tool:
+https://github.com/xamarin/components/tree/master/AndroidDocUtil
+

--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1322,11 +1322,16 @@
 
   <!-- Android O (API Level 26) -->
 
-  <attr path="/api/package[@name='android.view.autofill']" name="managedName">Android.Views.AutoFill</attr>
-  <attr path="/api/package[@name='android.view.textclassifier']" name="managedName">Android.Views.TextClassifiers</attr>
-  <attr path="/api/package[@name='java.nio.file']" name="managedName">Java.Nio.FileNio</attr>
-  <attr path="/api/package[@name='java.nio.file.attribute']" name="managedName">Java.Nio.FileNio.Attributes</attr>
-  <attr path="/api/package[@name='java.nio.file.spi']" name="managedName">Java.Nio.FileNio.Spi</attr>
+  <attr path="/api/package[@name='android.view.autofill']" name="managedName" api-since="26">Android.Views.AutoFill</attr>
+  <attr path="/api/package[@name='android.view.textclassifier']" name="managedName" api-since="26">Android.Views.TextClassifiers</attr>
+  <attr path="/api/package[@name='java.nio.file']" name="managedName" api-since="26">Java.Nio.FileNio</attr>
+  <attr path="/api/package[@name='java.nio.file.attribute']" name="managedName" api-since="26">Java.Nio.FileNio.Attributes</attr>
+  <attr path="/api/package[@name='java.nio.file.spi']" name="managedName" api-since="26">Java.Nio.FileNio.Spi</attr>
+
+  <!-- This is really annoying. We had introduced `AudioFocusRequest` enum type
+  in very early age of this product, and then Google introduced name conflicts.
+  (It's all Xamarin's fault to have introduced enumification, after all. -->
+  <attr path="/api/package[@name='android.media']/class[@name='AudioFocusRequest']" name="managedName" api-since="26">AudioFocusRequestClass</attr>
 
   <!-- FIXME: fix build and enable these packages -->
   <remove-node path="/api/package[@name='java.time']" api-since="26" />

--- a/src/Xamarin.Android.Tools.JavadocImporter/DocumentSection.cs
+++ b/src/Xamarin.Android.Tools.JavadocImporter/DocumentSection.cs
@@ -144,7 +144,7 @@ namespace Xamarin.Android.Tools.JavaDocToMdoc
 
 		XElement GetJavaDocSectionTable (XElement jd, string section)
 		{
-			return jd.Descendants ("table").FirstOrDefault (t => t.XPathSelectElement ("tr[string(th) = '" + section + "']") != null);
+			return jd.Descendants ("table").FirstOrDefault (t => t.XPathSelectElement ("tr/th[string(th) = '" + section + "']") != null);
 		}
 	}
 


### PR DESCRIPTION
Note that API Level 26 (O) is not built by default. To build it, you'll have to specify extra `make` arguments:

	make AndroidLatestApiLevel=26 AndroidLatestFrameworkVersion=v7.99.0 AndroidPlatformId=O


(I gave up resolving the uber-complicated MSBuild properties puzzle; changing one does not trigger required others, or triggering unwanted property changes, definitely not worthy of spending more than 3 days and nights.)