### PR TITLE
[Xamarin.Android.Build.Tasks] Xamarin.Android "Clean" target does not remove old .mdb files for library projects after Xamarin 15.2 release (Mono 5.0), leading to out-of-date debugging symbols for Fast Deployment mode

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetFilesThatExist.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetFilesThatExist.cs
@@ -15,6 +15,8 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public ITaskItem[] Files { get; set; }
 
+		public ITaskItem [] IgnoreFiles { get; set; }
+
 		[Output]
 		public ITaskItem[] FilesThatExist { get; set; }
 
@@ -22,8 +24,10 @@ namespace Xamarin.Android.Tasks
 		{
 			Log.LogDebugMessage ("GetFilesThatExist Task");
 			Log.LogDebugTaskItems ("  Files", Files);
+			Log.LogDebugTaskItems ("  IgnoreFiles", IgnoreFiles);
 
-			FilesThatExist = Files.Where (p => File.Exists (p.ItemSpec)).ToArray ();
+			FilesThatExist = Files.Where (p => File.Exists (p.ItemSpec) &&
+					(!IgnoreFiles?.Contains (p, TaskItemComparer.DefaultComparer) ?? true)).ToArray ();
 
 			Log.LogDebugTaskItems ("  [Output] FilesThatExist", FilesThatExist);
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1497,9 +1497,12 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_CollectMdbFiles"
 		Inputs="@(ResolvedAssemblies->'%(RootDir)%(Directory)%(Filename)%(Extension)')"
-		Outputs="@(ResolvedAssemblies->'%(RootDir)%(Directory)%(Filename)%(Extension).mdb')">
+		Outputs="@(ResolvedAssemblies->'%(RootDir)%(Directory)%(Filename)%(Extension).mdb')"
+		DependsOnTargets="_CollectPdbFiles">
 	<GetFilesThatExist
-			Files="@(ResolvedAssemblies->'%(RootDir)%(Directory)%(Filename)%(Extension).mdb')">
+			Files="@(ResolvedAssemblies->'%(RootDir)%(Directory)%(Filename)%(Extension).mdb')"
+			IgnoreFiles="@(_ResolvedPortablePdbFiles->'%(RootDir)%(Directory)%(Filename).dll.mdb')"
+	>
 		<Output TaskParameter="FilesThatExist" ItemName="_ResolvedMdbFiles" />
 	</GetFilesThatExist>
 </Target>


### PR DESCRIPTION
Context https://bugzilla.xamarin.com/show_bug.cgi?id=57087

The latest mono has now switched over to using csc for its
compiler. So we no longer generate .mdb files but instead
generate portable .pdb files.

Our current system will favour mdb over ppdb. So this commit
adds a check so that we will ignore .mdb files if we have a
valid ppdb file present. While this does not fix the PCL
bug mentioned in 57087, it will prevent those stale .mdb
files making it into the final package or .__override__
directory.