### PR TITLE
[Xamarin.Android.Build.Task] Fix --max-res-version for android-O

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
@@ -124,7 +124,7 @@ namespace Xamarin.Android.Tasks
 				);
 				return targetFrameworkVersion;
 			}
-			return target;
+			return targetSdkVersion;
 		}
 	}
 }


### PR DESCRIPTION
The aapt tool needs a --max-res-version which is a int, not
a string. Our current GetJavaPlafromJar was outputting a
TargetLevel of 'O' and not 26. This is because we were
returning the raw value we get from the manifest rather
than the one which gets 'O' replaced with 26.