### PR TITLE
[Xamarin.Android.Build.Tasks] ProGuard fails with "error ... (Access is denied)" if Android SDK path contains a space

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
@@ -179,14 +179,12 @@ namespace Xamarin.Android.Tasks
 				foreach (var jarfile in ExternalJavaLibraries.Select (p => p.ItemSpec))
 					libjars.Add (jarfile);
 
-			cmd.AppendSwitch ("\"-injars");
-			cmd.AppendSwitch (string.Join (Path.PathSeparator.ToString (), injars.Distinct ().Select (s => '\'' + s + '\''))+"\"");
+			var enclosingChar = OS.IsWindows ? "\"" : string.Empty;
+			cmd.AppendSwitchUnquotedIfNotNull ("-injars ", $"{enclosingChar}'" + string.Join ($"'{Path.PathSeparator}'", injars.Distinct ()) + $"'{enclosingChar}");
+
+			cmd.AppendSwitchIfNotNull ("-libraryjars ", $"{enclosingChar}'" + string.Join ($"'{Path.PathSeparator}'", libjars.Distinct ()) + $"'{enclosingChar}");
 			
-			cmd.AppendSwitch ("\"-libraryjars");
-			cmd.AppendSwitch (string.Join (Path.PathSeparator.ToString (), libjars.Distinct ().Select (s => '\'' + s + '\''))+"\"");
-			
-			cmd.AppendSwitch ("-outjars");
-			cmd.AppendSwitch ('"' + ProguardJarOutput + '"');
+			cmd.AppendSwitchIfNotNull ("-outjars ", ProguardJarOutput);
 
 			if (EnableLogging) {
 				cmd.AppendSwitchIfNotNull ("-dump ", DumpOutput);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -272,7 +272,7 @@ namespace Xamarin.Android.Build.Tests
 		public void BuildProguardEnabledProject (bool isRelease, bool enableProguard, bool useLatestSdk)
 		{
 			var proj = new XamarinAndroidApplicationProject () { IsRelease = isRelease, EnableProguard = enableProguard, UseLatestPlatformSdk = useLatestSdk, TargetFrameworkVersion = useLatestSdk ? "v7.1" : "v5.0" };
-			using (var b = CreateApkBuilder ("temp/BuildProguardEnabledProject")) {
+			using (var b = CreateApkBuilder ("temp/BuildProguard Enabled Project(1)")) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}
 		}


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=32861

Commit 6829b7d1 added property support for spaces to the
CreateMultiDexMainDexClassList Task. However this commit
neglected to apply the same changes to the Proguard Task.
This commit does that. It reworks the processing of arguments
like `--injars` to match those which are used in
CreateMultiDexMainDexClassList. These have been tested on
windows and are known to work as expected.