### PR TITLE
[Xamarin.Android.Build.Tasks] F# is missing __ANDROID__ define (regression)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidDefineConstants.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidDefineConstants.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (C) 2011 Xamarin, Inc. All rights reserved.
 
 using System;
+using System.Linq;
 using System.Text;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -16,21 +18,22 @@ namespace Xamarin.Android.Tasks
 		public string ProductVersion         { get; set; }
 
 		[Output]
-		public string AndroidDefineConstants { get; set; }
+		public ITaskItem[] AndroidDefineConstants { get; set; }
 
 		public override bool Execute ()
 		{
-			var sb = new StringBuilder ();
+			var items = new List<ITaskItem> ();
 
 			if (!string.IsNullOrEmpty (ProductVersion)) {
-				sb.AppendFormat ("__XAMARIN_ANDROID_{0}__;", Regex.Replace (ProductVersion, "[^A-Za-z0-9]", "_"));
+				items.Add(new TaskItem ($"__XAMARIN_ANDROID_{Regex.Replace (ProductVersion, "[^A-Za-z0-9]", "_")}__"));
 			}
-			sb.Append ("__MOBILE__;__ANDROID__");
+			items.Add(new TaskItem ("__MOBILE__"));
+			items.Add(new TaskItem("__ANDROID__"));
 
 			for (int i = 1; i <= AndroidApiLevel; ++i)
-				sb.Append (";__ANDROID_").Append (i).Append ("__");
+				items.Add(new TaskItem ($"__ANDROID_{i}__"));
 
-			AndroidDefineConstants = sb.ToString ();
+			AndroidDefineConstants = items.ToArray ();
 
 			return true;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -822,12 +822,14 @@ because xbuild doesn't support framework reference assemblies.
 
 	<!-- Get the defined constants for this API Level -->
 	<GetAndroidDefineConstants AndroidApiLevel="$(_SupportedApiLevel)" ProductVersion="$(MonoAndroidVersion)">
-		<Output TaskParameter="AndroidDefineConstants" PropertyName="AndroidDefineConstants" />
+		<Output TaskParameter="AndroidDefineConstants" ItemName="AndroidDefineConstants" />
 	</GetAndroidDefineConstants>
 
-	<CreateProperty Value="$(DefineConstants);$(AndroidDefineConstants)">
+	<CreateProperty Value="$(DefineConstants);@(AndroidDefineConstants)">
 		<Output TaskParameter="Value" PropertyName="DefineConstants" />
 	</CreateProperty>
+
+	<Message Text="DefineConstants : $(DefineConstants)"/>
 </Target>
 
 <Target Name="AndroidPrepareForBuild" DependsOnTargets="$(_OnResolveMonoAndroidSdks)" />


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=56976

The latest versions of MSBuild were not happy with the way
we emitted the android constants. It was taking the ';' as
literal characters rather than seperators.

This commit converts the GetAndroidDefineConstants over to
use TaskItem's. Which fixes the issue.