### PR TITLE
[linker] do not overwrite linked pdb files

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
@@ -31,9 +31,6 @@ namespace Xamarin.Android.Tasks
 		public ITaskItem[] ResolvedAssemblies { get; set; }
 
 		[Required]
-		public ITaskItem [] PortablePdbFiles { get; set; }
-
-		[Required]
 		public ITaskItem[] LinkDescriptions { get; set; }
 
 		public string I18nAssemblies { get; set; }
@@ -77,7 +74,6 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  LinkSkip: {0}", LinkSkip);
 			Log.LogDebugTaskItems ("  LinkDescriptions:", LinkDescriptions);
 			Log.LogDebugTaskItems ("  ResolvedAssemblies:", ResolvedAssemblies);
-			Log.LogDebugTaskItems ("  PortablePdbFiles:", PortablePdbFiles);
 			Log.LogDebugMessage ("  EnableProguard: {0}", EnableProguard);
 			Log.LogDebugMessage ("  ProguardConfiguration: {0}", ProguardConfiguration);
 			Log.LogDebugMessage ("  DumpDependencies: {0}", DumpDependencies);
@@ -146,13 +142,6 @@ namespace Xamarin.Android.Tasks
 
 				var copydst = OptionalDestinationDirectory ?? OutputDirectory;
 
-				foreach (var pdb in PortablePdbFiles) {
-					var copysrc = pdb.ItemSpec;
-					var filename = Path.GetFileName (pdb.ItemSpec);
-
-					MonoAndroidHelper.CopyIfChanged (copysrc, Path.Combine (copydst, filename));
-				}
-
 				foreach (var assembly in ResolvedAssemblies) {
 					var copysrc = assembly.ItemSpec;
 					var filename = Path.GetFileName (assembly.ItemSpec);
@@ -180,6 +169,9 @@ namespace Xamarin.Android.Tasks
 						MonoAndroidHelper.CopyIfChanged (assembly.ItemSpec + ".mdb", Path.Combine (copydst, filename + ".mdb"));
 					} catch (Exception) { // skip it, mdb sometimes fails to read and it's optional
 					}
+					var pdb = Path.ChangeExtension (copysrc, "pdb");
+					if (File.Exists (pdb))
+						MonoAndroidHelper.CopyIfChanged (pdb, Path.ChangeExtension (Path.Combine (copydst, filename), "pdb"));
 				}
 			} catch (ResolutionException ex) {
 				Diagnostic.Error (2006, ex, "Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.", ex.Member, ex.Member.Module.Assembly, ex.Scope);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1557,7 +1557,6 @@ because xbuild doesn't support framework reference assemblies.
       LinkDescriptions="@(LinkDescription)"
       DumpDependencies="$(LinkerDumpDependencies)"
       LinkOnlyNewerThan="$(_AndroidLinkFlag)"
-      PortablePdbFiles="@(_ResolvedPortablePdbFiles)"
       ResolvedAssemblies="@(ResolvedAssemblies)" />
 
 	<!-- We don't have to depend on flag file for NoShrink, but it is used to check timestamp -->
@@ -1588,7 +1587,6 @@ because xbuild doesn't support framework reference assemblies.
       ProguardConfiguration="$(_ProguardProjectConfiguration)"
       EnableProguard="$(AndroidEnableProguard)"
       DumpDependencies="$(LinkerDumpDependencies)"
-      PortablePdbFiles="@(_ResolvedPortablePdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
       ResolvedAssemblies="@(ResolvedAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
       HttpClientHandlerType="$(AndroidHttpClientHandlerType)"
       TlsProvider="$(AndroidTlsProvider)" />


### PR DESCRIPTION
 - we do not want to overwrite the files as the linked assemblies have
   different Guid (module mvid) and thus the original pdb's would be
   rejected by the pdb reader - the pdb heap contains the Guid to
   check if the pdb files is valid for the assembly

 - this fixes #56882 and hopefully all the recent debugging issues