### PR TITLE
[xabuild] Support using `msbuild` from mono 4.8+

### DIFF
--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -26,18 +26,16 @@
   <Target Name="AddContent"
       Returns="@(MSBuild);@(ReferenceAssemblies)">
     <ItemGroup>
-      <MSBuild Include="$(LibDir)xbuild\**\*.*" />
+      <MSBuild Include="$(LibDir)xbuild\Novell\**\*.*" />
+      <MSBuild>
+        <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Novell/%(RecursiveDir)</VSIXSubPath>
+      </MSBuild>
+      <MSBuild Include="$(LibDir)xbuild\Xamarin\**\*.*" />
+      <MSBuild>
+        <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Xamarin/%(RecursiveDir)</VSIXSubPath>
+      </MSBuild>
       <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\lib\host-Darwin\**\*.*" />
       <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\lib\host-Linux\**\*.*" />
-      <MSBuild>
-        <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">%(RecursiveDir)</VSIXSubPath>
-      </MSBuild>
-      <MSBuild>
-        <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Xamarin/Android</VSIXSubPath>
-      </MSBuild>
-      <MSBuild>
-        <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Xamarin/Android/lib/host-win</VSIXSubPath>
-      </MSBuild>
       <MSBuild Include="..\..\src\Xamarin.Android.Build.Tasks\MSBuild\Xamarin\**\*.*" />
       <MSBuild>
         <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Xamarin/%(RecursiveDir)</VSIXSubPath>

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -156,6 +156,16 @@ package-oss $(ZIP_OUTPUT):
 	if [ -d bin/Release/bin ] ; then cp tools/scripts/xabuild bin/Release/bin ; fi
 	if [ ! -d $(ZIP_OUTPUT_BASENAME) ] ; then mkdir $(ZIP_OUTPUT_BASENAME) ; fi
 	if [ ! -L $(ZIP_OUTPUT_BASENAME)/bin ] ; then ln -s ../bin $(ZIP_OUTPUT_BASENAME) ; fi
+	_exclude_list=".__exclude_list.txt"; \
+	ls -1d $(_BUNDLE_ZIPS_EXCLUDE) > "$$_exclude_list" 2>/dev/null ; \
+	for c in $(CONFIGURATIONS) ; do \
+		_sl="$(ZIP_OUTPUT_BASENAME)/bin/$$c/lib/xbuild/.__sys_links.txt"; \
+		if [ ! -f "$$_sl" ]; then continue; fi; \
+		for f in `cat $$_sl` ; do \
+			echo "$(ZIP_OUTPUT_BASENAME)/bin/$$c/lib/xbuild/$$f" >> "$$_exclude_list"; \
+		done; \
+	done; \
 	zip -r "$(ZIP_OUTPUT)" \
 		`ls -1d $(_BUNDLE_ZIPS_INCLUDE) 2>/dev/null` \
-		--exclude `ls -1d $(_BUNDLE_ZIPS_EXCLUDE) 2>/dev/null`
+		"-x@$$_exclude_list"
+	-rm ".__exclude_list.txt"

--- a/tools/scripts/xabuild
+++ b/tools/scripts/xabuild
@@ -1,26 +1,83 @@
 #!/bin/bash -e
 
+#
+# MSBuild wrapper to build Xamarin.Android apps from the command-line,
+# without pesky IDE interference.
+#
+# Supported MSBuild targets and properties:
+#   https://developer.xamarin.com/guides/android/under_the_hood/build_process/
+#
+# Overridable environment variables:
+#   ANDROID_NDK_PATH:
+#     Path to Android NDK.
+#     Defaults to `$(AndroidNdkDirectory)` in ../../Configuration.props.
+#   ANDROID_SDK_PATH:
+#     Path to Android SDK.
+#     Defaults to `$(AndroidNdkDirectory)` in ../../Configuration.props.
+#   CONFIGURATION:
+#     For in-source-tree invocations, the `bin/$(CONFIGURATION)` directory to
+#     use as the installation prefix. If not specified, defaults to `Debug`.
+#   MSBUILD:
+#     MSBuild engine to use. Defaults to `xbuild`, assumed to be in `$PATH`
+#   TARGETS_DIR:
+#     The MSBuild `$(MSBuildExtensionsPath)` root location.
+#     Defaults to `$prefix/lib/xbuild`.
+#
+# Examples:
+#   To create a .apk for the HelloWorld sample:
+#     tools/scripts/xabuild /t:SignAndroidPackage samples/HelloWorld/HelloWorld.csproj
+#
+#   To explicitly use `msbuild` for builds:
+#     MSBUILD=msbuild tools/scripts/xabuild /t:SignAndroidPackage samples/HelloWorld/HelloWorld.csproj
+#
+#   To explicitly use `xbuild` for builds:
+#     MSBUILD=xbuild tools/scripts/xabuild /t:SignAndroidPackage samples/HelloWorld/HelloWorld.csproj
+#
+
 name=$(basename "$0")
-
-if [ -z "$CONFIGURATION" ] ; then
-	CONFIGURATION=Debug
-fi
-
-xabuilddir="$(cd `dirname "$0"` && pwd)"
-
-if [[ "$xabuilddir" == */tools/scripts ]] ; then
-	topdir="$xabuilddir/../../bin/$CONFIGURATION"
-	Paths_targets="$xabuilddir/../../build-tools/scripts/Paths.targets"
-elif [[ "$xabuilddir" == */bin ]] ; then
-	topdir="$xabuilddir/.."
-else
-	(>&2 echo "$name: Could not determine location to Xamarin.Android locations.")
-	exit 1
-fi
+prefix="$(cd `dirname "$0"` && pwd)"
 
 if [ -z "$MSBUILD" ] ; then
 	MSBUILD=xbuild
 fi
+
+if [[ "$prefix" == */tools/scripts ]] ; then
+	Paths_targets="$prefix/../../build-tools/scripts/Paths.targets"
+	for c in "$CONFIGURATION" Debug Release ; do
+		if [ -z "$c" ]; then
+			continue
+		fi
+		if [ -d "$prefix/../../bin/$c" ]; then
+			real_prefix="$prefix/../../bin/$c"
+			break
+		fi
+	done
+	if [ -z "$real_prefix" ]; then
+		(>&2 echo "$name: Could not determine Xamarin.Android prefix.")
+		exit 1
+	fi
+	prefix="$real_prefix"
+elif [[ "$prefix" == */bin ]] ; then
+	prefix="$prefix/.."
+else
+	(>&2 echo "$name: Could not determine Xamarin.Android prefix.")
+	exit 1
+fi
+
+for t in "$TARGETS_DIR" "$prefix/lib/mono/xbuild" "$prefix/lib/xbuild" ; do
+	if [ -z "$t" -o ! -d "$t" ]; then
+		continue
+	fi
+	TARGETS_DIR="$t"
+	break
+done
+
+if [ ! -d "$TARGETS_DIR" ]; then
+	(>&2 echo "$name: Could not determine Xamarin.Android targets path.")
+fi
+export TARGETS_DIR
+export MONO_ANDROID_PATH="$prefix"
+
 
 if [ -z "$ANDROID_NDK_PATH" -a -f "$Paths_targets" ] ; then
 	ANDROID_NDK_PATH=$($MSBUILD /nologo /v:minimal /t:GetAndroidNdkFullPath "$Paths_targets")
@@ -34,23 +91,75 @@ if [ -z "$ANDROID_SDK_PATH" -a -f "$Paths_targets" ] ; then
 	export ANDROID_SDK_PATH
 fi
 
-if [ -z "$ANDROID_NDK_PATH" ] ; then
-	>&2 echo "$name: Could not determine Android NDK path. Please export the \$ANDROID_NDK_PATH environment variable."
-	exit 1
+declare -a XABUILD_FLAGS
+
+XABUILD_FLAGS=(
+	/p:MonoAndroidBinDirectory="$prefix/bin"
+	/p:MonoAndroidToolsDirectory="$prefix/lib/mandroid"
+	/p:MonoDroidInstallDirectory="$MONO_ANDROID_PATH"
+)
+
+if [ -n "$ANDROID_NDK_PATH" ] ; then
+	XABUILD_FLAGS+=(/p:AndroidNdkDirectory="$ANDROID_NDK_PATH")
+fi
+if [ -n "$ANDROID_SDK_PATH" ] ; then
+	XABUILD_FLAGS+=(/p:AndroidSdkDirectory="$ANDROID_SDK_PATH")
 fi
 
-if [ -z "$ANDROID_SDK_PATH" ] ; then
-	>&2 echo "$name: Could not determine Android SDK path. Please export the \$ANDROID_SDK_PATH environment variable."
-	exit 1
-fi
-
-export TARGETS_DIR="$topdir/lib/xbuild"
 export MSBuildExtensionsPath="$TARGETS_DIR"
-export MONO_ANDROID_PATH="$topdir"
-export XBUILD_FRAMEWORK_FOLDERS_PATH="$topdir/lib/xbuild-frameworks"
 
-exec $MSBUILD /p:Configuration=$CONFIGURATION $MSBUILD_OPTIONS \
-	/p:AndroidNdkDirectory="$ANDROID_NDK_PATH" \
-	/p:AndroidSdkDirectory="$ANDROID_SDK_PATH" \
-	/p:MonoDroidInstallDirectory="$MONO_ANDROID_PATH" \
-	"$@"
+case "$MSBUILD" in
+	*msbuild*)
+		XABUILD_FLAGS+=(/p:TargetFrameworkRootPath="$TARGETS_DIR-frameworks")
+		;;
+	*xbuild*)
+		export XBUILD_FRAMEWORK_FOLDERS_PATH="$TARGETS_DIR-frameworks"
+		;;
+esac
+
+function GetXbuildDir()
+{
+	read -r -d '' get_xbuild_dir_cmd <<-'EOF' || true
+		using System.IO;
+		var corlib_loc = typeof (int).Assembly.Location;
+		// e.g. /Library/Frameworks/Mono.framework/Versions/5.2.0/lib/mono/4.5
+		var corlib_dir = Path.GetDirectoryName (corlib_loc);
+		// e.g. /Library/Frameworks/Mono.framework/Versions/5.2.0/lib/mono/xbuild
+		var xbuild_dir = Path.Combine (corlib_dir, "..", "xbuild");
+		print (Path.GetFullPath (xbuild_dir));
+	EOF
+	echo "$get_xbuild_dir_cmd" | csharp
+}
+
+function ConfigureLocalXbuild()
+{
+	if [ -d "$prefix/lib/mono" ]; then
+		# System installation, e.g. Linux?
+		return 0
+	fi
+	xbuild_dir=`GetXbuildDir`
+	local sys_entry=`ls -1 "$xbuild_dir" | head -1`
+	if [ -d "$TARGETS_DIR/$sys_entry" ] ; then
+		# already configured; bail
+		return 0
+	fi
+	local sys_links="$TARGETS_DIR/.__sys_links.txt"
+	echo ".__sys_links.txt" > "$sys_links"
+	local e
+	for e in "$xbuild_dir"/* ; do
+		local b=`basename "$e"`
+		if [ -e "$TARGETS_DIR/$b" -o -f "$TARGETS_DIR/$b" -o -L "$TARGETS_DIR/$b" ]; then
+			rm "$TARGETS_DIR/$b"
+		fi
+		ln -s "$e" "$TARGETS_DIR"
+		if [ -d "$e" ]; then
+			echo "$b"'/*' >> "$sys_links"
+		else
+			echo $b >> "$sys_links"
+		fi
+	done
+}
+
+ConfigureLocalXbuild
+
+exec $MSBUILD "${XABUILD_FLAGS[@]}" "$@"


### PR DESCRIPTION
`tools/scripts/xabuild` is an MSBuild wrapper to easily build
Xamarin.Android apps from the command-line, using the Xamarin.Android
binaries built in-tree; see e20863ea.

`xabuild` originally invoked `xbuild`; commit 6805d204 extended that
to support building with `msbuild` by setting the `MSBUILD`
environment variable:

        MSBUILD=msbuild .../tools/scripts/xabuild SomeProject.csproj

This use worked with Mono 4.4 and 4.6, but broke -- unnoticed -- in
Mono 4.8 and later. When attempting to use `msbuild` in more recent
mono versions, the build will fail, cryptically:

        xamarin-android/bin/Debug/lib/xbuild/Xamarin/Android/Xamarin.Android.Common.targets(1007,2):
        error MSB3191: Unable to create directory "/Debug/". Access to the path "/Debug/" is denied.

The directory `/Debug/` is mentioned because the
`$(BaseIntermediateOutputPath)` MSBuild property is not being set.
*Normally* we'd be creating e.g. `obj/Debug`, but without
`$(BaseIntermediateOutputPath)`, this becomes `/Debug`, and everything
breaks.

`$(BaseIntermediateOutputPath)` isn't set, in turn, because
`Microsoft.Common.props` isn't being imported.
`Microsoft.Common.props` isn't being imported because `xabuild`
overrides the `$MSBuildExtensionsPath` environment variable, and
MSBuild is trying to import
`$(MSBuildExtensionsPath)\...\Microsoft.Common.props`, which doesn't
exist when we've overridden `$MSBuildExtensionsPath` to use our
in-tree build location.

*A* fix for this *could* be *not overriding `$MSBuildExtensionsPath`*
when using `msbuild`. There is one problem with this, though: not
overriding `$MSBuildExtensionsPath` means that the `.targets` files in
e.g. `bin/Debug/lib/xbuild/Xamarin/Android` *will not be used*.
Instead, the *system* files are used, which is undesirable.

Unfortunatley, this means we need to continue overriding
`$MSBuildExtensionsPath`, *while* allowing e.g.
`$(MSBuildExtensionsPath)\...\Microsoft.Common.props` to be found.
Square this circle by *symlinking* everything in the *system*
`$MSBuildExtensionsPath` directory into our `$prefix/lib/xbuild`.

Symlinking all these files raises *another* issue: we *don't* want all
of these symlinks, *or their targets*, to be added to the
`oss-xamarin.android*.zip` files. Support this by creating a
`$prefix/lib/xbuild/.__sys_links.txt` file, which contains `zip -x`
patterns (hence the `/*` suffix for directories), one per line, and
update the `make package-oss` target to look for and exclude the
contents of these files so that we don't "pollute" the
`oss-xamarin.android*.zip` file with unnecessary contents.

Finally, some cleanups:

  * Only set `$XBUILD_FRAMEWORK_FOLDERS_PATH` when using `xbuild`.

  * Additionally, specify `$(TargetFrameworkRootPath)` on `msbuild`,
    as that actually works.

  * Always specify `$(MonoAndroidBinDirectory)` and
    `$(MonoAndroidToolsDirectory)`, as this mirrors the
    Windows usage instructions.

  * Don't *require* that `$ANDROID_NDK_PATH` and `$ANDROID_SDK_PATH` be
    set prior to executing `xabuild`, *or* that we be running in-tree
    (to use `Paths.targets`). The NDK, in particular, isn't always
    required, so forcing that it be set is annoying.

    The build process will error out appropriately if required
    directories cannot be found.