### PR TITLE
[Xamarin.Android.Build.Tasks] Fix BuildBasicApplicationCheckMdbAndPortablePdb Unit Test

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
@@ -10,6 +10,7 @@ using Mono.Cecil;
 using System.IO;
 using MonoDroid.Tuner;
 using Mono.Linker;
+using Xamarin.Android.Tools;
 
 using Java.Interop.Tools.Cecil;
 using Java.Interop.Tools.Diagnostics;
@@ -170,7 +171,7 @@ namespace Xamarin.Android.Tasks
 					} catch (Exception) { // skip it, mdb sometimes fails to read and it's optional
 					}
 					var pdb = Path.ChangeExtension (copysrc, "pdb");
-					if (File.Exists (pdb))
+					if (File.Exists (pdb) && Files.IsPortablePdb (pdb))
 						MonoAndroidHelper.CopyIfChanged (pdb, Path.ChangeExtension (Path.Combine (copydst, filename), "pdb"));
 				}
 			} catch (ResolutionException ex) {


### PR DESCRIPTION
Commit 08fcb24 forgot to exclude non-portable pdb files when
it was copying the pdb's over.