### PR TITLE
Configuration.props: API Level settings must respect overrides.

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -14,8 +14,8 @@
   <PropertyGroup>
     <ProductVersion>7.4.99</ProductVersion>
     <!-- *Latest* API level binding that we support; used when building src/Xamarin.Android.Build.Tasks -->
-    <AndroidLatestApiLevel>25</AndroidLatestApiLevel>
-    <AndroidLatestFrameworkVersion>v7.1</AndroidLatestFrameworkVersion>
+    <AndroidLatestApiLevel Condition="'$(AndroidLatestApiLevel)' == ''">25</AndroidLatestApiLevel>
+    <AndroidLatestFrameworkVersion Condition="'$(AndroidLatestFrameworkVersion)' == ''">v7.1</AndroidLatestFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <AutoProvision Condition=" '$(AutoProvision)' == '' ">False</AutoProvision>


### PR DESCRIPTION
They lack Condition for emptiness check and prevents overrides.