### PR TITLE
[Xamarin.Android.Build.Tasks] Add support for Generated Resources via…

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -5,5 +5,6 @@
 		<DependsOnSystemRuntime Condition=" '$(DependsOnSystemRuntime)' == '' ">true</DependsOnSystemRuntime>
 		<CopyNuGetImplementations Condition=" '$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
 		<YieldDuringToolExecution Condition="'$(YieldDuringToolExecution)' == ''">true</YieldDuringToolExecution>
+		<AndroidResourceGeneratorTargetName>UpdateGeneratedFiles</AndroidResourceGeneratorTargetName>
 	</PropertyGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -477,6 +477,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   </BuildDependsOn>
 </PropertyGroup>
 
+<PropertyGroup >
+  <CoreCompileDependsOn>UpdateGeneratedFiles;$(CoreCompileDependsOn)</CoreCompileDependsOn>
+</PropertyGroup>
+
 <PropertyGroup>
     <!-- no need to add those wear resources into C#, hence this order... -->
 	<CoreResolveReferencesDependsOn>
@@ -517,6 +521,11 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<CreateProperty Value="None" Condition="'$(AndroidLinkMode)' == 'SdkOnly' And '$(AndroidUseSharedRuntime)' == 'true'">
 		<Output TaskParameter="Value" PropertyName="AndroidLinkMode" />
 	</CreateProperty>
+</Target>
+
+<Target Name="UpdateGeneratedFiles"
+		DependsOnTargets="_RemoveLegacyDesigner;UpdateAndroidResources"
+	>
 </Target>
 
 <Target Name="_RemoveLegacyDesigner" Condition="'$(AndroidUseIntermediateDesignerFile)' == 'True'">


### PR DESCRIPTION
… Xamarin Studio

Context https://bugzilla.xamarin.com/show_bug.cgi?id=5870

One of the issues with the current resource designer implementation
is that it is not in the intermediate directory. As a result it is
always causing problems for Source control systems.

Additionally normal .net apps create generated files in the
intermediate directory and make use of the a target and make use
of "build time code generation" [1] by making use if the Generator
metadata in MSBuild. Visual studio already has support for this
however Xamarin Studio did not.

The issue with Xamarin Studio is now being solved. With this commit
we will introduce a new target UpdateGeneratedFiles which can be
used by both VS and XS to generate the Resource.Designer.xx file
in the intermediate directory.

All of this is current protected by the AndroidUseIntermediateDesignerFile
property which defaults to false.

[1] https://mhut.ch/journal/2015/06/30/build_time_code_generation_msbuild