### PR TITLE
[Xamarin.Android.Build.Tasks] Fix an issue where library projects can not be debugged.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
@@ -28,6 +28,7 @@ namespace MonoDroid.Tuner
 			}
 
 			if (changed) {
+				Context.SafeReadSymbols (assembly);
 				AssemblyAction action = Annotations.HasAction (assembly) ? Annotations.GetAction (assembly) : AssemblyAction.Skip;
 				if (action == AssemblyAction.Skip || action == AssemblyAction.Copy || action == AssemblyAction.Delete)
 					Annotations.SetAction (assembly, AssemblyAction.Save);


### PR DESCRIPTION
The linker was not producing ppdb files.
What is supposed to happen is the
linker if it changes a dll should emit a new pdb file
along with it. Because none of the assemblies were being
loaded with debug symbols. Hence no updated pdb.

So this commit loads the Symbols as part of the
linker process to ensure that we are able to emit the new
pdb when required. This is only done for files which
have been changed by the linker.