### PR TITLE
[monodroid] option to change path of /assemblies/ within APKs

### DIFF
--- a/src/monodroid/jni/embedded-assemblies.c
+++ b/src/monodroid/jni/embedded-assemblies.c
@@ -31,6 +31,7 @@ static  int                           bundled_assemblies_count;
 static  monodroid_should_register     should_register;
 static  void                         *should_register_data;
 static  int                           register_debug_symbols;
+static  char                         *assemblies_prefix = "assemblies/";
 
 static  struct TypeMappingInfo       *java_to_managed_maps;
 static  struct TypeMappingInfo       *managed_to_java_maps;
@@ -319,6 +320,13 @@ register_debug_symbols_for_assembly (struct DylibMono *mono, const char *entry_n
 	return 1;
 }
 
+MONO_API int
+monodroid_embedded_assemblies_set_assemblies_prefix (const char *prefix)
+{
+	assemblies_prefix = prefix;
+	return 0;
+}
+
 static int
 gather_bundled_assemblies_from_apk (
 		struct DylibMono      *mono,
@@ -388,7 +396,7 @@ gather_bundled_assemblies_from_apk (
 				add_type_mapping (&managed_to_java_maps, apk, cur_entry_name, ((const char*) mmap_info.area) + offset);
 				continue;
 			}
-			if (strncmp ("assemblies/", cur_entry_name, sizeof ("assemblies/")-1) != 0)
+			if (strncmp (assemblies_prefix, cur_entry_name, strlen (assemblies_prefix)-1) != 0)
 				continue;
 
 			// assemblies must be 4-byte aligned, or Bad Things happen
@@ -432,7 +440,7 @@ gather_bundled_assemblies_from_apk (
 			cur = (*bundle) [*bundle_count] = xcalloc (1, sizeof (MonoBundledAssembly));
 			++*bundle_count;
 
-			cur->name = monodroid_strdup_printf ("%s", strstr (cur_entry_name, "assemblies/") + sizeof ("assemblies"));
+			cur->name = monodroid_strdup_printf ("%s", strstr (cur_entry_name, assemblies_prefix) + strlen (assemblies_prefix));
 			cur->data = ((const unsigned char*) mmap_info.area) + offset;
 
 			// MonoBundledAssembly::size is const?!


### PR DESCRIPTION
- Needed for Embeddinator-4000 to export AAR files
- The best way to ship .NET assemblies within an AAR file was to place
them in /assets/assemblies
- When using the AAR in an Android Studio project, this places the
files into the final APK
- Embeddinator will call
`monodroid_embedded_assemblies_set_assemblies_prefix` during startup to
modify the path
- Details here:
https://mono.github.io/Embeddinator-4000/android-preliminary-research.html

WIP work on Embeddinator here: https://github.com/jonathanpeppers/Embeddinator-4000/commits/xamarin-android

Let me know if I need to change something. I would say I _almost_ know what I'm doing, maybe.