### PR TITLE
[Xamarin.Android.Build.Tasks] Unable to build projects with lint checks enabled against 15.3

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadResolvedSdksCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadResolvedSdksCache.cs
@@ -82,6 +82,9 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public string AndroidSequencePointsMode { get; set; }
 
+		[Output]
+		public string LintToolPath { get; set; }
+
 		public override bool Execute ()
 		{
 			MonoAndroidHelper.InitializeAndroidLogger (ErrorHandler, WarningHandler, InfoHandler, DebugHandler);
@@ -121,6 +124,7 @@ namespace Xamarin.Android.Tasks
 				.Select (e => e.Value)
 				.ToArray ();
 			AndroidSequencePointsMode = sdk.Element ("AndroidSequencePointsMode")?.Value ?? "None";
+			LintToolPath = sdk.Element ("LintToolPath")?.Value ?? Path.Combine (AndroidSdkPath, "tools");
 
 			Log.LogDebugMessage ("ResolveSdksTask Outputs:");
 			Log.LogDebugMessage ("  AndroidApiLevel: {0}", AndroidApiLevel);
@@ -137,6 +141,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  ZipAlignPath: {0}", ZipAlignPath);
 			Log.LogDebugMessage ("  SupportedApiLevel: {0}", SupportedApiLevel);
 			Log.LogDebugMessage ("  AndroidSequencePointsMode: {0}", AndroidSequencePointsMode);
+			Log.LogDebugMessage ("  LintToolPath: {0}", LintToolPath);
 
 			MonoAndroidHelper.TargetFrameworkDirectories	= ReferenceAssemblyPaths;
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -99,10 +99,14 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public string AndroidSequencePointsMode { get; set; }
 
+		[Output]
+		public string LintToolPath { get; set; }
+
 		static bool             IsWindows = Path.DirectorySeparatorChar == '\\';
 		static readonly string  ZipAlign  = IsWindows ? "zipalign.exe" : "zipalign";
 		static readonly string  Aapt      = IsWindows ? "aapt.exe" : "aapt";
 		static readonly string  Android   = IsWindows ? "android.bat" : "android";
+		static readonly string  Lint      = IsWindows ? "lint.bat" : "lint";
 
 
 		public override bool Execute ()
@@ -127,6 +131,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  SequencePointsMode: {0}", SequencePointsMode);
 			Log.LogDebugMessage ("  MonoAndroidToolsPath: {0}", MonoAndroidToolsPath);
 			Log.LogDebugMessage ("  MonoAndroidBinPath: {0}", MonoAndroidBinPath);
+			Log.LogDebugMessage ("  LintToolPath: {0}", LintToolPath);
 
 			MonoAndroidHelper.RefreshMonoDroidSdk (MonoAndroidToolsPath, MonoAndroidBinPath, ReferenceAssemblyPaths);
 			MonoAndroidHelper.RefreshAndroidSdk (AndroidSdkPath, AndroidNdkPath, JavaSdkPath);
@@ -160,6 +165,25 @@ namespace Xamarin.Android.Tasks
 
 			string toolsZipAlignPath = Path.Combine (AndroidSdkPath, "tools", ZipAlign);
 			bool findZipAlign = (string.IsNullOrEmpty (ZipAlignPath) || !Directory.Exists (ZipAlignPath)) && !File.Exists (toolsZipAlignPath);
+
+			var lintPaths = new string [] {
+				LintToolPath ?? string.Empty,
+				Path.Combine (AndroidSdkPath, "tools"),
+				Path.Combine (AndroidSdkPath, "tools", "bin"),
+			};
+
+			LintToolPath = null;
+			foreach ( var path in lintPaths) {
+				if (File.Exists (Path.Combine (path, Lint))) {
+					LintToolPath = path;
+					break;
+				}
+			}
+			if (string.IsNullOrEmpty (LintToolPath)) {
+				Log.LogCodedError ("XA5205", $"Cannot find {Lint} in the AndroidSdk. Please set via /p:LintToolPath.");
+				return false;
+			}
+
 
 			foreach (var dir in AndroidSdk.GetBuildToolsPaths (AndroidSdkBuildToolsVersion)) {
 				Log.LogDebugMessage ("Trying build-tools path: {0}", dir);
@@ -261,6 +285,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  ZipAlignPath: {0}", ZipAlignPath);
 			Log.LogDebugMessage ("  SupportedApiLevel: {0}", SupportedApiLevel);
 			Log.LogDebugMessage ("  AndroidSequencePointMode: {0}", AndroidSequencePointsMode);
+			Log.LogDebugMessage ("  LintToolPath: {0}", LintToolPath);
 
 			if (!string.IsNullOrEmpty (CacheFile)) {
 				Directory.CreateDirectory (Path.GetDirectoryName (CacheFile));
@@ -284,7 +309,8 @@ namespace Xamarin.Android.Tasks
 						new XElement ("ZipAlignPath", ZipAlignPath),
 						new XElement ("MonoAndroidIncludePath", MonoAndroidIncludePath),
 						new XElement ("SupportedApiLevel", SupportedApiLevel),
-						new XElement ("AndroidSequencePointsMode", AndroidSequencePointsMode.ToString ())
+						new XElement ("AndroidSequencePointsMode", AndroidSequencePointsMode.ToString ()),
+						new XElement ("LintToolPath", LintToolPath)
 					));
 				document.Save (CacheFile);
 			}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -588,6 +588,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 			ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)"
 			TargetFrameworkVersion="$(TargetFrameworkVersion)"
 			UseLatestAndroidPlatformSdk="$(AndroidUseLatestPlatformSdk)"
+			LintToolPath="$(LintToolPath)"
 			ZipAlignPath="$(ZipAlignToolPath)">
 		<Output TaskParameter="AndroidApiLevel"           PropertyName="_AndroidApiLevel"           Condition="'$(_AndroidApiLevel)' == ''" />
 		<Output TaskParameter="AndroidApiLevelName"       PropertyName="_AndroidApiLevelName" />
@@ -605,6 +606,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		<Output TaskParameter="ZipAlignPath"              PropertyName="ZipAlignToolPath"           Condition="'$(ZipAlignToolPath)' == ''" />
 		<Output TaskParameter="AndroidSdkBuildToolsBinPath" PropertyName="AndroidSdkBuildToolsBinPath" Condition="'$(AndroidSdkBuildToolsBinPath)' == ''" />
 		<Output TaskParameter="AndroidSequencePointsMode"   PropertyName="_SequencePointsMode"         Condition="'$(_SequencePointsMode)' == ''" />
+		<Output TaskParameter="LintToolPath"              PropertyName="LintToolPath"               Condition="'$(LintToolPath)' == ''" />
 	</ResolveSdks>
 	<CreateProperty Value="$(TargetFrameworkIdentifier),Version=$(_TargetFrameworkVersion),Profile=$(TargetFrameworkProfile)">
 		<Output TaskParameter="Value" PropertyName="TargetFrameworkMoniker"
@@ -747,12 +749,6 @@ because xbuild doesn't support framework reference assemblies.
 	<CreateProperty Value="$(AndroidSdkBuildToolsBinPath)">
 		<Output TaskParameter="Value" PropertyName="ZipAlignToolPath"
 				Condition="'$(ZipAlignToolPath)' == ''"
-		/>
-	</CreateProperty>
-
-	<CreateProperty Value="$(_AndroidToolsDirectory)bin\" Condition="Exists ('$(_AndroidToolsDirectory)bin\')">
-		<Output TaskParameter="Value" PropertyName="LintToolPath"
-				Condition="'$(LintToolPath)' == ''"
 		/>
 	</CreateProperty>
 


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=57532

The Directory test from commit 9cf367f1 did not really work.
This is because the 'bin' directory existed prior to 25.3.0.
But the lint tool only moved in 25.3.0.

To fix this we are adding new code to the ResolveSdks Task. This
will find the correct location of the `lint` tool. It will also
use the `$(LintToolPath)` the user provides.

If the tool cannot be found an appropriate error message will
be raised.