### PR TITLE
[tests] add 1 second sleep after adb wait-for-device command

### DIFF
--- a/build-tools/scripts/UnitTestApks.targets
+++ b/build-tools/scripts/UnitTestApks.targets
@@ -6,6 +6,7 @@
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.RunInstrumentationTests" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.StartAndroidEmulator" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.KillProcess" />
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.Sleep" />
 
   <PropertyGroup>
     <_TestImageName>XamarinAndroidUnitTestRunner</_TestImageName>
@@ -41,17 +42,23 @@
       <Output TaskParameter="AdbTarget" PropertyName="_EmuTarget" />
       <Output TaskParameter="EmulatorProcessId" PropertyName="_EmuPid" />
     </StartAndroidEmulator>
-    <Exec
+    <Sleep
         Condition=" '$(_ValidAdbTarget)' != 'True' "
-        Command="sleep 10"
+        Milliseconds="10000"
     />
     <Xamarin.Android.Tools.BootstrapTasks.Adb
+        EnvironmentVariables="ADB_TRACE=all"
         Condition=" '$(_ValidAdbTarget)' != 'True' "
         Arguments="$(_AdbTarget) wait-for-device"
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)"
     />
+    <Sleep
+        Condition=" '$(_ValidAdbTarget)' != 'True' "
+        Milliseconds="1000"
+    />
     <Xamarin.Android.Tools.BootstrapTasks.Adb
+        EnvironmentVariables="ADB_TRACE=all"
         Condition=" '$(_ValidAdbTarget)' != 'True' "
         Arguments="$(_EmuTarget) shell 'counter=0; while [ $counter -lt 60 ] &amp;&amp; [ &quot;`getprop sys.boot_completed`&quot; != &quot;1&quot; ]; do echo Waiting for device to fully boot; sleep 1; let &quot;counter++&quot;; done'"
         ToolExe="$(AdbToolExe)"

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/Sleep.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/Sleep.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Threading;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.BuildTools.PrepTasks
+{
+	public class Sleep : Task
+	{
+		public int Milliseconds { get; set; }
+
+		public override bool Execute ()
+		{
+			Log.LogMessage (MessageImportance.Normal, $"Going to sleep for {Milliseconds}ms");
+			Thread.Sleep (Milliseconds);
+
+			return true;
+		}
+	}
+}

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\ReplaceFileContents.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\PrepareInstall.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\AcceptAndroidSdkLicenses.cs" />
+    <Compile Include="Xamarin.Android.BuildTools.PrepTasks\Sleep.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="xa-prep-tasks.targets" />


### PR DESCRIPTION
 - looks like the adb's wait-for-device function sometime doesn't work
   perfectly and we are timeouting in our tests, which run on
   emulator, because adb gets stuck when executing next adb command