### PR TITLE
[Xamarin.Android.Build.Tasks] !Embed Assemblies == Debug Runtime

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -188,7 +188,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidUseSharedRuntime Condition=" '$(AndroidUseSharedRuntime)' == '' Or '$(_XASupportsFastDev)' == 'False' ">False</AndroidUseSharedRuntime>
 
 	<AndroidExplicitCrunch Condition=" '$(AndroidExplicitCrunch)' == '' ">False</AndroidExplicitCrunch>
-	<AndroidUseDebugRuntime Condition="'$(AndroidUseDebugRuntime)' == '' And '$(Optimize)' == 'True'" >False</AndroidUseDebugRuntime>
+	<AndroidUseDebugRuntime
+			Condition="'$(AndroidUseDebugRuntime)' == '' And '$(EmbedAssembliesIntoApk)' == 'True' And '$(Optimize)' == 'True' "
+	>False</AndroidUseDebugRuntime>
 	<AndroidUseDebugRuntime Condition="'$(AndroidUseDebugRuntime)' == ''" >True</AndroidUseDebugRuntime>
 
 	<MonoSymbolArchive Condition=" '$(MonoSymbolArchive)' == '' And '$(AndroidUseSharedRuntime)' == 'False' And '$(EmbedAssembliesIntoApk)' == 'True' And '$(DebugSymbols)' == 'True' And '$(Optimize)' == 'True'" >True</MonoSymbolArchive>  
@@ -265,7 +267,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </PropertyGroup>
 
 <Choose>
-	<When Condition=" '$(DebugSymbols)' != '' And $(DebugSymbols) And '$(DebugType)' != '' And '$(Optimize)' != 'True' ">
+	<When Condition=" '$(DebugSymbols)' == 'True' And '$(DebugType)' != '' And ('$(EmbedAssembliesIntoApk)' == 'False' Or '$(Optimize)' != 'True') ">
 		<PropertyGroup>
 			<AndroidIncludeDebugSymbols>True</AndroidIncludeDebugSymbols>
 		</PropertyGroup>


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=56485

Scenario: Create an app, then change `$(Optimize)` in the Debug
configuration to be True, with `$(EmbedAssembliesIntoApk)`=False
(default for Debug configuration).

Build, deploy, run the app.

Expected results: it works!

Actual results: Not so much:

	F/monodroid: No assemblies found in '(null)' or '<unavailable>'.  Assuming this is part of Fast Deployment. Exiting..

What went wrong is Commit 1e0e0834: making `$(Optimize)` *the*
switch to control whether the Debug or Release runtime is used means
that a "Debug" configuration with `$(Optimize)`=True is treated as
requiring a *Release runtime*, which means the external assembly
directory isn't used and doesn't exist.

Attempt to address this by bringing `$(EmbedAssembliesIntoApk)` into
the picture: if it's False -- i.e. fast deployment -- then it
"overrides" the `$(Optimize)` value when it comes to the
`$(AndroidIncludeDebugSymbols)` property.

(The `$(AndroidIncludeDebugSymbols)` property controls whether the
Debug or Release runtime is used. Yes, this name doesn't make sense.)

This means for greater sanity we now need a truth table:

	Input Property:                                                      || Output Property
	DebugSymbols    | DebugType  | EmbedAssembliesIntoApk   | Optimize   || AndroidIncludeDebugSymbols
	================+============+==========================+============++===========================
	True              *any*        True                       True          False      (Release runtime)
	True              *any*        True                       False         True       (Debug runtime)
	True              *any*        False                      True          True       (Debug runtime)
	True              *any*        False                      False         True       (Debug runtime)
	True              *empty*      True                       True          True       (Debug runtime)
	True              *empty*      True                       False         True       (Debug runtime)
	True              *empty*      False                      True          True       (Debug runtime)
	True              *empty*      False                      False         True       (Debug runtime)
	False             -            -                          -             False      (Release runtime)

Question: Should `$(DebugSymbols)` *truly* be the controlling factor,
i.e. when `$(DebugSymbols)`=False the Release runtime is always used.

Additionally, update `$(AndroidUseDebugRuntime)` so that it also
takaes `$(EmbedAssembliesIntoApk)` into consideration.