### PR TITLE
[Xamarin.Android.Build.Tasks] Make use of the ProductVersion information in the Common.props

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<XamarinAndroidVersion>Unknown</XamarinAndroidVersion>
+		<XamarinAndroidVersion>@PACKAGE_VERSION@-@PACKAGE_VERSION_BUILD@</XamarinAndroidVersion>
 		<_JavaInteropReferences>Java.Interop;System.Runtime</_JavaInteropReferences>
 		<DependsOnSystemRuntime Condition=" '$(DependsOnSystemRuntime)' == '' ">true</DependsOnSystemRuntime>
 		<CopyNuGetImplementations Condition=" '$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>


### PR DESCRIPTION
At [1] we already attempt to replace the Product and Version information
in the Xamarin.Android.Common.props.in file. However the props.in file
did not have the appropriate text to replace in it.

This commit fixes that issue so we get the correct information.

[1] https://github.com/xamarin/xamarin-android/blob/master/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets#L129