### PR TITLE
[Xamarin.Android.Build.Tasks] Move LintToolPath Check

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
@@ -179,6 +179,11 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugTaskItems ("  LibraryDirectories:", LibraryDirectories);
 			Log.LogDebugTaskItems ("  LibraryJars:", LibraryJars);
 
+			if (string.IsNullOrEmpty (ToolPath) || !File.Exists (GenerateFullPathToTool ())) {
+				Log.LogCodedError ("XA5205", $"Cannot find `{ToolName}` in the Android SDK. Please set its path via /p:LintToolPath.");
+				return false;
+			}
+
 			base.Execute ();
 
 			return !Log.HasLoggedErrors;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -179,11 +179,6 @@ namespace Xamarin.Android.Tasks
 					break;
 				}
 			}
-			if (string.IsNullOrEmpty (LintToolPath)) {
-				Log.LogCodedError ("XA5205", $"Cannot find {Lint} in the AndroidSdk. Please set via /p:LintToolPath.");
-				return false;
-			}
-
 
 			foreach (var dir in AndroidSdk.GetBuildToolsPaths (AndroidSdkBuildToolsVersion)) {
 				Log.LogDebugMessage ("Trying build-tools path: {0}", dir);


### PR DESCRIPTION
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=57532#c5

@pjcollins notes that if `lint` isn't installed *and isn't used*,
commit 010332d3 will generate a build error -- because `lint` can't be
found -- and this isn't necessarily warranted. It could be a backward
compatibility break.

Move the `lint` path check into the `<Lint/>` task so that we only
generate an XA5205 error if `lint` can't be found *and* we're
attempting to use `lint`.