### PR TITLE
Make Android.Runtime.JavaProxyThrowable inherit Java.Lang.Error

### DIFF
--- a/src/Mono.Android/Android.Runtime/JavaProxyThrowable.cs
+++ b/src/Mono.Android/Android.Runtime/JavaProxyThrowable.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Android.Runtime {
 
-	class JavaProxyThrowable : Java.Lang.Throwable {
+	class JavaProxyThrowable : Java.Lang.Error {
 
 		public  readonly Exception InnerException;
 


### PR DESCRIPTION
Android's Zygote process, responsible for starting and initializing
of every app as well as catching any application crashes (exceptions
not handled by the app, most of the time), special-cases application
exceptions of types Java.Lang.Error and Java.Lang.Exception (and their
derivatives) and this may cause issues with automatic crash reporting
recently added to the Google's Developer Console. The automatically collected
reports do not contain the full trace of our exceptions.

This change hopefully fixes the issue.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=56653