### PR TITLE
[Xamarin.Android.Build.Tasks] VS hangs when loading Forms solution with multiple Android binding projects

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -134,6 +134,11 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
       BuildDocumentation;
     </BuildDependsOn>
 
+    <CompileDependsOn>
+      _SetupDesignTimeBuildForCompile;
+      $(CompileDependsOn);
+    </CompileDependsOn>
+
     <ResolveReferencesDependsOn>
       $(ResolveReferencesDependsOn);
       AddBindingsToCompile;
@@ -284,7 +289,13 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
       <DesignTimeBuild Condition=" '$(DesignTimeBuild)' == '' ">false</DesignTimeBuild>
     </PropertyGroup>
   </Target>
-
+  
+  <Target Name="_SetupDesignTimeBuildForCompile">
+    <PropertyGroup>
+      <DesignTimeBuild Condition=" '$(DesignTimeBuild)' == '' ">true</DesignTimeBuild>
+    </PropertyGroup>
+  </Target>
+  
   <Target Name="_BuildAdditionalResourcesCache"
     Inputs="@(ReferencePath);@(ReferenceDependencyPaths)"
     Outputs="$(_AndroidResourcePathsCache)"
@@ -294,7 +305,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
       AndroidNdkDirectory="$(_AndroidNdkDirectory)"
       Assemblies="@(ReferencePath);@(ReferenceDependencyPaths)"
       CacheFile="$(IntermediateOutputPath)resourcepaths.cache"
-      Condition=" '$(DesignTimeBuild)' != 'true' "
+      Condition=" '$(DesignTimeBuild)' == 'false' Or '$(DesignTimeBuild)' == '' "
     />
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -368,6 +368,12 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		<DesignTimeBuild Condition=" '$(DesignTimeBuild)' == '' ">false</DesignTimeBuild>
 	</PropertyGroup>
 </Target>
+  
+<Target Name="_SetupDesignTimeBuildForCompile">
+	<PropertyGroup>
+		<DesignTimeBuild Condition=" '$(DesignTimeBuild)' == '' ">true</DesignTimeBuild>
+	</PropertyGroup>
+</Target>
 
 <Target Name="_BuildAdditionalResourcesCache"
 	Inputs="@(ReferencePath);@(ReferenceDependencyPaths);$(MSBuildProjectFullPath);$(NugetPackagesConfig)"
@@ -478,6 +484,13 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     $(BuildDependsOn);
   </BuildDependsOn>
 </PropertyGroup>
+  
+ <PropertyGroup>
+   <CompileDependsOn>
+     _SetupDesignTimeBuildForCompile;
+     $(CompileDependsOn);
+   </CompileDependsOn>
+ </PropertyGroup>
 
 <PropertyGroup>
     <!-- no need to add those wear resources into C#, hence this order... -->


### PR DESCRIPTION
Context https://bugzilla.xamarin.com/show_bug.cgi?id=56581

This fixes up the logic used for DesignTime builds. Rather than checking
for 'true' we should be checking for empty or false.

This matches the logic in the Xamarin.Android.Common.targets.

It also seems that `DesignTimeBuild` is not being set in VS2017
for Intellisense builds even though it should be [1].
That said the document in [1] does give us a work around which
will work.

DesignTimeBuilds DO NOT call the `Build` target. They instead call
other "DesignTime" targets directly. These in turn end up depending
on targets like `Compile` and `ResolveAssemblyReferences`.

So using this knowledge we can add an additional target to set the
`DesignTimeBuild` property if it is not set. We can inject this target
into the `CompileDependsOn` chain. With this in place if the `Compile`
target is called outside of a normal `Build` this new target will
set the DesignTimeBuild property to 'true' if it is not set already.

With our current `_SetupDesignTimeBuildForBuild` target already in place
as part of the `BuildDependsOn` chain we can ensure that for normal
builds that target is called first. This will set the property to 'false'
and ensure that when `_SetupDesignTimeBuildForCompile` is called later
in the build the property is already set.

We do not have to worry about putting any hooks into targets like
`ResolveAssemblyReferences` because they do not end up calling
`GetAdditionalResourcesFromAssemblies`.

This should fix this issue in cases where `DesignTimeBuild` is set by
the IDE as where it isn't. As long as the IDE Intellisense builds NEVER
call `Build` directly this will work.

[1] https://github.com/dotnet/project-system/blob/master/docs/design-time-builds.md