### PR TITLE
[Xamarin.Android.Build.Tasks] Properly quote -libraryjars (#666)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
@@ -84,7 +84,7 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitch ("-dontoptimize");
 			cmd.AppendSwitch ("-dontobfuscate");
 			cmd.AppendSwitch ("-dontpreverify");
-			cmd.AppendSwitchIfNotNull ("-include ", $"'{Path.Combine (AndroidSdkBuildToolsPath, "mainDexClasses.rules")}'");
+			cmd.AppendSwitchUnquotedIfNotNull ("-include ", $"{enclosingChar}'{Path.Combine (AndroidSdkBuildToolsPath, "mainDexClasses.rules")}'{enclosingChar}");
 		}
 
 		void GenerateMainDexListBuilderCommands(CommandLineBuilder cmd)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
@@ -167,9 +167,11 @@ namespace Xamarin.Android.Tasks
 				.Select (s => s.Trim ())
 				.Where (s => !string.IsNullOrWhiteSpace (s));
 
+			var enclosingChar = OS.IsWindows ? "\"" : string.Empty;
+
 			foreach (var file in configs) {
 				if (File.Exists (file))
-					cmd.AppendSwitchIfNotNull ("-include ", file);
+					cmd.AppendSwitchUnquotedIfNotNull ("-include ", $"{enclosingChar}'{file}'{enclosingChar}");
 				else
 					Log.LogWarning ("Proguard configuration file '{0}' was not found.", file);
 			}
@@ -179,10 +181,9 @@ namespace Xamarin.Android.Tasks
 				foreach (var jarfile in ExternalJavaLibraries.Select (p => p.ItemSpec))
 					libjars.Add (jarfile);
 
-			var enclosingChar = OS.IsWindows ? "\"" : string.Empty;
 			cmd.AppendSwitchUnquotedIfNotNull ("-injars ", $"{enclosingChar}'" + string.Join ($"'{Path.PathSeparator}'", injars.Distinct ()) + $"'{enclosingChar}");
 
-			cmd.AppendSwitchIfNotNull ("-libraryjars ", $"{enclosingChar}'" + string.Join ($"'{Path.PathSeparator}'", libjars.Distinct ()) + $"'{enclosingChar}");
+			cmd.AppendSwitchUnquotedIfNotNull ("-libraryjars ", $"{enclosingChar}'" + string.Join ($"'{Path.PathSeparator}'", libjars.Distinct ()) + $"'{enclosingChar}");
 			
 			cmd.AppendSwitchIfNotNull ("-outjars ", ProguardJarOutput);
 


### PR DESCRIPTION
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=32861

Scenario: Build a project in Release configuration with
`$(AndroidEnableProguard)`=True on Windows.

Expected result: it works!

Actual result: It doesn't:

	C:\Program Files\Java\jdk1.8.0_131\\bin\java.exe -jar ...
	PROGUARD : error : C:\Program Files (Access is denied)

Commit 8467ad6c attempted to fix this by "double-quoting" the
`-libraryjars` option. Unfortunately, we inadvertantly *triple*-quoted
the value (!)

	-libraryjars "\"'C:\Program Files (x86)\Android\android-sdk\platforms\android-25\android.jar'\""

The `\"` is unexpected, and problematic. It *should* be:

	-libraryjars "'C:\Program Files (x86)\Android\android-sdk\platforms\android-25\android.jar'"

The "actual" cause -- other than inadequate testing, and a need to run
unit tests more frequently on Windows -- is that we used
`CommandLineBuilder.AppendSwitchIfNotNull()` with `-libraryjars`.
This is problematic because `AppendSwitchIfNotNull()` will "escape"
embedded double-quotes, which is what is introducing the `\"` quotes
and the 3rd level of quoting.

Use `CommandLineBuilder.AppendSwitchUnquotedIfNotNull()` instead, to
avoid the extra and erroneous quoting.

Additionally, `-include` needs double-quoting as well on Windows.
Fixup `-include` generation in the `<Proguard/>` and
`<CreateMultiDexMainDexClassList/>` tasks.