### PR TITLE
Make xabuild smarter in configuration detection

### DIFF
--- a/tools/scripts/xabuild
+++ b/tools/scripts/xabuild
@@ -41,6 +41,21 @@ if [ -z "$MSBUILD" ] ; then
 	MSBUILD=xbuild
 fi
 
+if [ -z "$CONFIGURATION" ]; then
+	for p in "$*"; do
+		case $p in
+			/property:Configuration=*|                                                   \
+			/p:Configuration=*|                                                          \
+			-p:Configuration=*|                                                          \
+			--property:Configuration=*) CONFIGURATION="`echo $p | cut -d '=' -f 2`" ;;
+		esac
+
+		if [ -n "$CONFIGURATION" ]; then
+			break
+		fi
+	done
+fi
+
 if [[ "$prefix" == */tools/scripts ]] ; then
 	Paths_targets="$prefix/../../build-tools/scripts/Paths.targets"
 	for c in "$CONFIGURATION" Debug Release ; do


### PR DESCRIPTION
`xabuild` determines the XA installation prefix by looking at the bin/{Debug,
Release} directories, in the specified order. If one wants to build a project in
the `Release` configuration and both `bin/Debug` and `bin/Release` are present,
`xabuild` will use `bin/Debug` as the prefix regardless of the configuration
passed to `{ms,x}build` with `/p:Configuration=Name`. Your project will still be
built in the specified configuration but XA assemblies etc will come from the
`Debug` build of XA - probably not the desired outcome. To work around it you
would need to invoke `xabuild` as follows:

   CONFIGURATION=Release xabuild /p:Configuration=Release my.csproj

which is unnecessarily verbose. This commit makes `xabuild` slightly smarter by
making it understand the `/p:Configuration` parameter and extracting the
configuration name from it and setting `CONFIGURATION` to this value for you.
This is done *only* if `CONFIGURATION` is not set when invoking `xabuild`