### PR TITLE
[Xamarin.Android.Build.Tasks] "Processing" messages spam Android build output

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -52,7 +52,7 @@ namespace Xamarin.Android.Tasks
 
 			// Fix up each file
 			foreach (string file in xmls) {
-				Log.LogMessage (MessageImportance.High, "  Processing: {0}", file);
+				Log.LogDebugMessage ("  Processing: {0}", file);
 				var srcmodifiedDate = File.GetLastWriteTimeUtc (file);
 				var tmpdest = file + ".tmp";
 				MonoAndroidHelper.CopyIfChanged (file, tmpdest);


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=55561

The ConvertResourcesCases Task was blindly using a message
importanta of High for its processing messages. This was
causing the "processing" messages to spam the output even
during minimal verbosity.

This commit switches over to use LogDebugMessage.