### PR TITLE
[Xamarin.Android.Build.Tasks] Remove the use of the sdks.cache from Bindings

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -111,7 +111,6 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <_LibraryProjectImportsDirectoryName>library_project_imports</_LibraryProjectImportsDirectoryName>
 	<_NativeLibraryImportsDirectoryName>native_library_imports</_NativeLibraryImportsDirectoryName>
 	<_AndroidResourcePathsCache>$(IntermediateOutputPath)resourcepaths.cache</_AndroidResourcePathsCache>
-	<_AndroidSdksCache>$(IntermediateOutputPath)sdks.cache</_AndroidSdksCache>
 	<_AndroidLibraryImportsCache>$(IntermediateOutputPath)libraryimports.cache</_AndroidLibraryImportsCache>
 	<_AndroidLibraryProjectImportsCache>$(IntermediateOutputPath)libraryprojectimports.cache</_AndroidLibraryProjectImportsCache>
 
@@ -159,12 +158,8 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 	</GetReferenceAssemblyPaths>
 </Target>
 
-<Target Name="_BuildSdkCache"
-		Inputs="$(MSBuildProjectFullPath);$(_AndroidBuildPropertiesCache)"
-		Outputs="$(_AndroidSdksCache)"
-		DependsOnTargets="_GetReferenceAssemblyPaths">
+<Target Name="_SetLatestTargetFrameworkVersion" DependsOnTargets="_GetReferenceAssemblyPaths">
 	<ResolveSdks
-			CacheFile="$(_AndroidSdksCache)"
 			AndroidApiLevel="$(AndroidApiLevel)"
 			AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
 			AndroidSdkPath="$(AndroidSdkDirectory)"
@@ -177,14 +172,9 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 			ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)"
 			TargetFrameworkVersion="$(TargetFrameworkVersion)"
 			SequencePointsMode="$(AndroidSequencePointsMode)"
-			UseLatestAndroidPlatformSdk="$(AndroidUseLatestPlatformSdk)">
-	</ResolveSdks>
-</Target>
-
-<Target Name="_SetLatestTargetFrameworkVersion" DependsOnTargets="_BuildSdkCache">
-	<ReadResolvedSdksCache
-			CacheFile="$(_AndroidSdksCache)">
-		<Output TaskParameter="AndroidApiLevel"           PropertyName="_AndroidApiLevel" />
+			UseLatestAndroidPlatformSdk="$(AndroidUseLatestPlatformSdk)"
+	>
+		<Output TaskParameter="AndroidApiLevel"           PropertyName="_AndroidApiLevel"           Condition="'$(_AndroidApiLevel)' == ''" />
 		<Output TaskParameter="AndroidApiLevelName"       PropertyName="_AndroidApiLevelName" />
 		<Output TaskParameter="TargetFrameworkVersion"    PropertyName="_TargetFrameworkVersion" />
 		<Output TaskParameter="TargetFrameworkVersion"    PropertyName="TargetFrameworkVersion" />
@@ -195,7 +185,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 		<Output TaskParameter="MonoAndroidToolsPath"      PropertyName="MonoAndroidToolsDirectory"  Condition="'$(MonoAndroidToolsDirectory)' == ''" />
 		<Output TaskParameter="MonoAndroidBinPath"        PropertyName="MonoAndroidBinDirectory"    Condition="'$(MonoAndroidBinDirectory)' == ''" />
 		<Output TaskParameter="AndroidSdkBuildToolsBinPath" PropertyName="AndroidSdkBuildToolsBinPath" Condition="'$(AndroidSdkBuildToolsBinPath)' == ''" />
-	</ReadResolvedSdksCache>
+	</ResolveSdks>
     <CreateProperty Value="$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion),Profile=$(TargetFrameworkProfile)">
       <Output TaskParameter="Value" PropertyName="TargetFrameworkMoniker"
           Condition="'$(TargetFrameworkProfile)' != ''"
@@ -564,7 +554,6 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
   <Target Name="CleanLibraryProjectIntermediaries">
     <Delete Files="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip" />
     <Delete Files="$(_AndroidResourcePathsCache)" />
-    <Delete Files="$(_AndroidSdksCache)" />
     <Delete Files="$(_AndroidLibraryImportsCache)" />
     <Delete Files="$(_AndroidLibraryProjectImportsCache)" />
     <RemoveDirFixed Directories="$(IntermediateOutputPath)library_project_jars" Condition="Exists ('$(IntermediateOutputPath)library_project_jars')" />


### PR DESCRIPTION
We removed the creation of the sdks.cache from the Common.targets,
but neglected to remove them from Bindings.targets.