### PR TITLE
[Mono.Posix] Fix inclusion of libMonoPosixHelper.so

### DIFF
--- a/src/Mono.Posix/Mono.Posix.csproj
+++ b/src/Mono.Posix/Mono.Posix.csproj
@@ -260,19 +260,19 @@
     <XANativeLibsDir>$(OutputPath)\..\..\..\xbuild\Xamarin\Android\lib</XANativeLibsDir>
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\arm64-v8a\libMonoPosixHelper.so" Condition="$(AndroidSupportedTargetJitAbis.Contains (':arm64-v8a:'))">
+    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\arm64-v8a\libMonoPosixHelper.so" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':arm64-v8a:'))">
       <Link>MonoPosixHelper\arm64-v8a\libMonoPosixHelper.so</Link>
     </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\armeabi\libMonoPosixHelper.so" Condition="$(AndroidSupportedTargetJitAbis.Contains (':armeabi:'))">
+    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\armeabi\libMonoPosixHelper.so" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':armeabi:'))">
       <Link>MonoPosixHelper\armeabi\libMonoPosixHelper.so</Link>
     </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\armeabi-v7a\libMonoPosixHelper.so" Condition="$(AndroidSupportedTargetJitAbis.Contains (':armeabi-v7a:'))">
+    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\armeabi-v7a\libMonoPosixHelper.so" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':armeabi-v7a:'))">
       <Link>MonoPosixHelper\armeabi-v7a\libMonoPosixHelper.so</Link>
     </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\x86\libMonoPosixHelper.so" Condition="$(AndroidSupportedTargetJitAbis.Contains (':x86:'))">
+    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\x86\libMonoPosixHelper.so" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':x86:'))">
       <Link>MonoPosixHelper\x86\libMonoPosixHelper.so</Link>
     </EmbeddedNativeLibrary>
-    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\x86_64\libMonoPosixHelper.so" Condition="$(AndroidSupportedTargetJitAbis.Contains (':x86_64:'))">
+    <EmbeddedNativeLibrary Include="$(XANativeLibsDir)\x86_64\libMonoPosixHelper.so" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':x86_64:'))">
       <Link>MonoPosixHelper\x86_64\libMonoPosixHelper.so</Link>
     </EmbeddedNativeLibrary>
   </ItemGroup>


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=57808

`Mono.Posix.dll` is a "fat" assembly which uses the
`@(EmbeddedNativeLibrary)` Build action to include
`libMonoPosixHelper.so` for all supported ABIs. This build action is
handled by the build system to ensure that appropriate native
libraries, present in the assembly, are copied into the App.apk.

Commit 6bb10160 broke this by incorrectly replacing
`$(AndroidSupportedAbisForConditionalChecks)` use with
`$(AndroidSupportedTargetJitAbis)` use. The difference between these
two properties is that the former always begins and ends with `:`,
while the latter might not (user-provided?).

The breakage is visible in the [build log][0]:

	inflating: …/lib/xbuild/Xamarin/Android/lib/armeabi/libMonoPosixHelper.so
	inflating: …/lib/xbuild/Xamarin/Android/lib/armeabi-v7a/libMonoPosixHelper.so
	inflating: …/lib/xbuild/Xamarin/Android/lib/arm64-v8a/libMonoPosixHelper.so
	inflating: …/lib/xbuild/Xamarin/Android/lib/x86/libMonoPosixHelper.so
	inflating: …/lib/xbuild/Xamarin/Android/lib/x86_64/libMonoPosixHelper.so

in which we see that there 5 ABIs for `libMonoPosixHelper.so`.

Compare to the [resulting package][1]:

	$ monodis --presources bin/Debug/lib/xbuild-frameworks/MonoAndroid/v1.0/Mono.Posix.dll
	       0: __AndroidLibraryProjects__.zip (size 558)
	     238: __AndroidNativeLibraries__.zip (size 711546)

	$ monodis --mresources bin/Debug/lib/xbuild-frameworks/MonoAndroid/v1.0/Mono.Posix.dll

	$ unzip -l __AndroidNativeLibraries__.zip
	Archive:  __AndroidNativeLibraries__.zip
	  Length      Date    Time    Name
	---------  ---------- -----   ----
	        0  06-27-2017 09:48   native_library_imports/arm64-v8a/
	   763232  06-27-2017 09:48   native_library_imports/arm64-v8a/libMonoPosixHelper.so
	        0  06-27-2017 09:48   native_library_imports/armeabi-v7a/
	   865092  06-27-2017 09:48   native_library_imports/armeabi-v7a/libMonoPosixHelper.so
	        0  06-27-2017 09:48   native_library_imports/x86/
	   827784  06-27-2017 09:48   native_library_imports/x86/libMonoPosixHelper.so
	---------                     -------
	  2456108                     6 files

We start with 5 ABIs, and wind up with *3*.

Fix `Mono.Posix.csproj` to use
`$(AndroidSupportedAbisForConditionalChecks)`, as required.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/468/consoleText
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/468/Azure/processDownloadRequest/xamarin-android/oss-xamarin.android_v7.4.99.31_Darwin-x86_64_master_38d25e1.zip