### PR TITLE
Fixed 'make' command on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,12 @@ linux-prepare::
 	if [ "x$$BINFMT_WARN" = "xyes" ]; then \
 		cat Documentation/binfmt_misc-warning-Linux.txt ; \
 	fi; \
+	if  [ -f build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO).sh ] || [ -f build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO)-$(LINUX_DISTRO_RELEASE).sh ]  &&  [ "$(NO_SUDO)" = "false" ]; then \
+		echo; \
+		echo "Installing build depedencies for $(LINUX_DISTRO)"; \
+		echo "Will use sudo, please provide your password as needed"; \
+		echo; \
+	fi; \
 	if [ -f build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO).sh ]; then \
 		sh build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO).sh; \
 	elif [ -f build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO)-$(LINUX_DISTRO_RELEASE).sh ]; then \

--- a/Makefile
+++ b/Makefile
@@ -45,12 +45,6 @@ linux-prepare::
 	if [ "x$$BINFMT_WARN" = "xyes" ]; then \
 		cat Documentation/binfmt_misc-warning-Linux.txt ; \
 	fi; \
-	if  [ -f build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO).sh ] || [ -f build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO)-$(LINUX_DISTRO_RELEASE).sh ]  &&  [ "$(NO_SUDO)" = "false" ]; then \
-		echo; \
-		echo "Installing build dependencies for $(LINUX_DISTRO)"; \
-		echo "Will use sudo, please provide your password as needed"; \
-		echo; \
-	fi; \
 	if [ -f build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO).sh ]; then \
 		sh build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO).sh; \
 	elif [ -f build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO)-$(LINUX_DISTRO_RELEASE).sh ]; then \

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ linux-prepare::
 	fi; \
 	if  [ -f build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO).sh ] || [ -f build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO)-$(LINUX_DISTRO_RELEASE).sh ]  &&  [ "$(NO_SUDO)" = "false" ]; then \
 		echo; \
-		echo "Installing build depedencies for $(LINUX_DISTRO)"; \
+		echo "Installing build dependencies for $(LINUX_DISTRO)"; \
 		echo "Will use sudo, please provide your password as needed"; \
 		echo; \
 	fi; \

--- a/Makefile
+++ b/Makefile
@@ -19,18 +19,18 @@ ifneq ($(MONO_OPTIONS),)
 export MONO_OPTIONS
 endif
 
-ifeq ($(OS),Linux)
-export LINUX_DISTRO         := $(shell lsb_release -i -s || true)
-export LINUX_DISTRO_RELEASE := $(shell lsb_release -r -s || true)
-prepare:: linux-prepare
-endif # $(OS)=Linux
-
 include build-tools/scripts/msbuild.mk
 all::
 	$(MSBUILD) $(MSBUILD_FLAGS) $(SOLUTION)
 
 all-tests::
 	MSBUILD="$(MSBUILD)" tools/scripts/xabuild $(MSBUILD_FLAGS) Xamarin.Android-Tests.sln
+	
+ifeq ($(OS),Linux)
+export LINUX_DISTRO         := $(shell lsb_release -i -s || true)
+export LINUX_DISTRO_RELEASE := $(shell lsb_release -r -s || true)
+prepare:: linux-prepare
+endif # $(OS)=Linux
 
 prepare:: prepare-msbuild
  	


### PR DESCRIPTION
Before when executing 'make' on a linux distribution, it'd execute 'make prepare' because the linux check was before the 'all' target