### PR TITLE
[tests] added task to process logcat output to measure startup times

### DIFF
--- a/build-tools/scripts/UnitTestApks.targets
+++ b/build-tools/scripts/UnitTestApks.targets
@@ -7,6 +7,7 @@
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.StartAndroidEmulator" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.KillProcess" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.Sleep" />
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.ProcessLogcatTiming" />
 
   <PropertyGroup>
     <_TestImageName>XamarinAndroidUnitTestRunner</_TestImageName>
@@ -53,6 +54,16 @@
         EnvironmentVariables="ADB_TRACE=all"
         Condition=" '$(_ValidAdbTarget)' != 'True' "
         Arguments="$(_EmuTarget) shell 'counter=0; while [ $counter -lt 60 ] &amp;&amp; [ &quot;`getprop sys.boot_completed`&quot; != &quot;1&quot; ]; do echo Waiting for device to fully boot; sleep 1; let &quot;counter++&quot;; done'"
+        ToolExe="$(AdbToolExe)"
+        ToolPath="$(AdbToolPath)"
+	/>
+    <Xamarin.Android.Tools.BootstrapTasks.Adb
+        Arguments="$(_AdbTarget) shell setprop debug.mono.log timing"
+        ToolExe="$(AdbToolExe)"
+        ToolPath="$(AdbToolPath)"
+    />
+    <Xamarin.Android.Tools.BootstrapTasks.Adb
+        Arguments="$(_AdbTarget) logcat -G 4M"
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)"
     />
@@ -134,5 +145,7 @@
         ToolPath="$(AdbToolPath)">
       <Output TaskParameter="FailedToRun" ItemName="_FailedComponent"/>
     </RunInstrumentationTests>
+    <Exec Command="&quot;$(AdbToolPath)\$(AdbToolExe)&quot; $(_AdbTarget) $(AdbOptions) logcat -v threadtime -d > test-logcat.txt" />
+    <ProcessLogcatTiming LogcatFilename="test-logcat.txt" ApplicationPackageName="%(UnitTestApk.Package)" ResultsFilename="%(UnitTestApk.ResultsPath)" />
   </Target>
 </Project>

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ProcessLogcatTiming.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ProcessLogcatTiming.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.BuildTools.PrepTasks
+{
+	public class ProcessLogcatTiming : Task
+	{
+		[Required]
+		public string LogcatFilename { get; set; }
+
+		[Required]
+		public string ApplicationPackageName { get; set; }
+
+		public string ResultsFilename { get; set; }
+
+		public override bool Execute ()
+		{
+			using (var reader = new StreamReader (LogcatFilename)) {
+				string line;
+				int pid = -1;
+				var procStartRegex = new Regex ($@"^(?<timestamp>\d+-\d+\s+[\d:\.]+)\s+.*ActivityManager: Start proc.*for added application {ApplicationPackageName}: pid=(?<pid>\d+)");
+				Regex timingRegex = null;
+				var runtimeInitRegex = new Regex (@"Runtime\.init: end native-to-managed");
+				DateTime start = DateTime.Now;
+				DateTime last = start;
+				DateTime initEnd = start;
+
+				while ((line = reader.ReadLine ()) != null) {
+					if (pid == -1) {
+						var match = procStartRegex.Match (line);
+						if (!match.Success)
+							continue;
+
+						last = start = ParseTime (match.Groups ["timestamp"].Value);
+						pid = Int32.Parse (match.Groups ["pid"].Value);
+						Log.LogMessage (MessageImportance.Low, $"Time:      0ms process start, application: '{ApplicationPackageName}' PID: {pid}");
+						timingRegex = new Regex ($@"^(?<timestamp>\d+-\d+\s+[\d:\.]+)\s+{pid}\s+.*I monodroid-timing:\s(?<message>.*)$");
+					} else {
+						var match = timingRegex.Match (line);
+						if (!match.Success)
+							continue;
+
+						var time = ParseTime (match.Groups ["timestamp"].Value);
+						var span = time - start;
+						Log.LogMessage (MessageImportance.Low, $"Time: {span.TotalMilliseconds.ToString ().PadLeft (6)}ms Message: {match.Groups ["message"].Value}");
+
+						match = runtimeInitRegex.Match (match.Groups ["message"].Value);
+						if (match.Success)
+							initEnd = time;
+						last = time;
+					}
+				}
+
+				if (pid != -1) {
+					Log.LogMessage (MessageImportance.Normal, " -- Performance summary --");
+					Log.LogMessage (MessageImportance.Normal, $"Runtime init end: {(initEnd - start).TotalMilliseconds}ms");
+					Log.LogMessage (MessageImportance.Normal, $"Last timing message: {(last - start).TotalMilliseconds}ms");
+
+					if (ResultsFilename != null)
+						File.WriteAllText (Path.Combine (Path.GetDirectoryName (ResultsFilename), $"Test-{ApplicationPackageName}-times.csv"),
+						                   $"init,last\n{(initEnd - start).TotalMilliseconds},{(last - start).TotalMilliseconds}");
+				} else
+					Log.LogWarning ("Wasn't able to collect the performance data");
+
+				reader.Close ();
+			}
+
+			return true;
+		}
+
+		static Regex timeRegex = new Regex (@"(?<month>\d+)-(?<day>\d+)\s+(?<hour>\d+):(?<minute>\d+):(?<second>\d+)\.(?<millisecond>\d+)");
+		DateTime ParseTime (string s)
+		{
+			var match = timeRegex.Match (s);
+			if (!match.Success)
+				throw new InvalidOperationException ($"Unable to parse time: '{s}'");
+
+			// we don't handle year boundary here as the logcat timestamp doesn't include year information
+			return new DateTime (DateTime.Now.Year,
+					     int.Parse (match.Groups ["month"].Value),
+					     int.Parse (match.Groups ["day"].Value),
+					     int.Parse (match.Groups ["hour"].Value),
+					     int.Parse (match.Groups ["minute"].Value),
+					     int.Parse (match.Groups ["second"].Value),
+					     int.Parse (match.Groups ["millisecond"].Value));
+		}
+	}
+}

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\PrepareInstall.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\AcceptAndroidSdkLicenses.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\Sleep.cs" />
+    <Compile Include="Xamarin.Android.BuildTools.PrepTasks\ProcessLogcatTiming.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="xa-prep-tasks.targets" />


### PR DESCRIPTION
 - setup emulator with bigger logcat buffers, enable debug timing
   output

 - dump logcat to file after test is run and process it with the new
   task

 - the task also creates csv files with data to be used by Jenkins,
   plot plugin