### PR TITLE
Make it possible to put Mono/XA runtime with debug symbols in APK

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -178,6 +178,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<MonoAndroidVersion>v$(_XAMajorVersionNumber).0</MonoAndroidVersion>
 	<AndroidUpdateResourceReferences Condition="'$(AndroidUpdateResourceReferences)' == ''">True</AndroidUpdateResourceReferences>
 	<EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' Or '$(_XASupportsFastDev)' == 'False' ">True</EmbedAssembliesIntoApk>
+	<AndroidPreferNativeLibrariesWithDebugSymbols Condition=" '$(AndroidPreferNativeLibrariesWithDebugSymbols)' == '' ">False</AndroidPreferNativeLibrariesWithDebugSymbols>
 	<AndroidSkipJavacVersionCheck Condition="'$(AndroidSkipJavacVersionCheck)' == ''">False</AndroidSkipJavacVersionCheck>
 	<AndroidBuildApplicationPackage Condition=" '$(AndroidBuildApplicationPackage)' == ''">False</AndroidBuildApplicationPackage>
 
@@ -2160,6 +2161,7 @@ because xbuild doesn't support framework reference assemblies.
     CreatePackagePerAbi="$(AndroidCreatePackagePerAbi)"
     UseSharedRuntime="$(AndroidUseSharedRuntime)"
     Debug="$(AndroidIncludeDebugSymbols)"
+    PreferNativeLibrariesWithDebugSymbols="$(AndroidPreferNativeLibrariesWithDebugSymbols)"
     TypeMappings="$(_AndroidTypeMappingJavaToManaged);$(_AndroidTypeMappingManagedToJava)"
     AndroidAotMode="$(AndroidAotMode)"
     EnableLLVM="$(EnableLLVM)"


### PR DESCRIPTION
The LLDB-based Mono debugger (https://github.com/mono/lldb-binaries) requires
non-stripped native libraries in the APK in order to be able to set breakpoints
in them. Unfortunately, right now Xamarin.Android doesn't support this because
in the past we downloaded all the symbols and non-stripped libraries to the
local, host, directory and used those for symbol lookup.

This commit adds support for embedding non-stripped versions of the native Mono and
Xamarin.Android libraries (Mono runtime, profiler, XA runtime) by way of
defining a new MSBuild property `AndroidPreferNativeLibrariesWithDebugSymbols` which is then
passed to the `BuildApk` task responsible for generating the APK. The property
defaults to `false` and has to be set on {x,ms}build command line using
`/p:AndroidPreferNativeLibrariesWithDebugSymbols=true` or in the process environment by exporting
`AndroidPreferNativeLibrariesWithDebugSymbols=true`

The reason to not automatically include the non-stripped versions in debug
builds is to avoid paying size penalty when the developer doesn't need to debug
the native libraries, which is in 99% of cases. At the same time the ability to
embed the non-stripped versions is not limited to the debug builds and this is
to allow finding issues in native XA code in all kinds of builds.