### PR TITLE
[api-compatibility] Check API Compatibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -36,3 +36,7 @@
 	path = external/proguard
 	url = https://github.com/xamarin/proguard.git
 	branch = master
+[submodule "xamarin-android-api-compatibility"]
+	path = external/xamarin-android-api-compatibility
+	url = https://github.com/xamarin/xamarin-android-api-compatibility.git
+	branch = master

--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,11 @@ ifeq ($(USE_MSBUILD),1)
 		$(MSBUILD) $(MSBUILD_FLAGS) "$$proj"; \
 	done
 endif	# msbuild
-include build-tools/scripts/BuildEverything.mk
 
-run-all-tests: run-nunit-tests run-ji-tests run-apk-tests
+include build-tools/scripts/BuildEverything.mk
+include tests/api-compatibility/api-compatibility.mk
+
+run-all-tests: run-nunit-tests run-ji-tests run-apk-tests run-api-compatibility-tests
 
 clean:
 	$(MSBUILD) $(MSBUILD_FLAGS) /t:Clean Xamarin.Android.sln

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -23,7 +23,7 @@ ALL_PLATFORM_IDS  = 1 2 3 4 5 6 7 8 9 10    11  12  13  14  15      16    17    
 # supported api levels
 ALL_FRAMEWORKS    = _ _ _ _ _ _ _ _ _ v2.3  _   _   _   _   v4.0.3  v4.1  v4.2  v4.3  v4.4  v4.4.87   v5.0  v5.1  v6.0  v7.0  v7.1  v8.0
 API_LEVELS        =                   10                    15      16    17    18    19    20        21    22    23    24    25    26
-STABLE_API_LEVELS =                   10                    15      16    17    18    19    20        21    22    23    24
+STABLE_API_LEVELS =                   10                    15      16    17    18    19    20        21    22    23    24    25
 
 ## The preceding values *must* use SPACE, **not** TAB, to separate values.
 

--- a/tests/api-compatibility/Makefile
+++ b/tests/api-compatibility/Makefile
@@ -1,0 +1,8 @@
+all:
+	make -C ../../ run-api-compatibility-tests
+
+update:
+	make -C ../../ run-api-compatibility-tests-update-local
+
+update-system:
+	make -C ../../ run-api-compatibility-tests-update-system

--- a/tests/api-compatibility/api-compatibility.mk
+++ b/tests/api-compatibility/api-compatibility.mk
@@ -1,0 +1,32 @@
+# This file must be included from ../../Makefile
+
+CSC               = csc
+RUNTIME           = mono --debug
+
+MONO_PATH         = $(call GetPath,MonoSource)
+MONO_API_HTML_DIR = $(MONO_PATH)/mcs/tools/mono-api-html
+MONO_API_HTML     = bin/Build$(CONFIGURATION)/mono-api-html.exe
+MONO_API_INFO_DIR = $(MONO_PATH)/mcs/tools/corcompare
+MONO_API_INFO     = bin/Build$(CONFIGURATION)/mono-api-info.exe
+MONO_OPTIONS_SRC  = $(MONO_PATH)/mcs/class/Mono.Options/Mono.Options/Options.cs
+FRAMEWORK_DIR     = bin/$(CONFIGURATION)/lib/xbuild-frameworks/MonoAndroid
+
+
+run-api-compatibility-tests: $(MONO_API_HTML) $(MONO_API_INFO)
+	make -C external/xamarin-android-api-compatibility check \
+		MONO_API_HTML="$(RUNTIME) $(abspath $(MONO_API_HTML))" \
+		MONO_API_INFO="$(RUNTIME) $(abspath $(MONO_API_INFO))" \
+		STABLE_FRAMEWORKS="$(STABLE_FRAMEWORKS)" \
+		XA_FRAMEWORK_DIR="$(abspath $(FRAMEWORK_DIR))"
+
+$(MONO_API_HTML): $(wildcard $(MONO_API_HTML_DIR)/*.cs) $(MONO_OPTIONS_SRC)
+	$(CSC) -out:$@ $(wildcard $(MONO_API_HTML_DIR)/*.cs) \
+		$(MONO_OPTIONS_SRC) \
+		-r:System.Xml.dll -r:System.Xml.Linq.dll
+
+MONO_API_INFO_REFS  = \
+  bin/$(CONFIGURATION)/lib/mandroid/Xamarin.Android.Cecil.dll
+
+$(MONO_API_INFO): $(wildcard $(MONO_API_INFO_DIR)/*.cs) $(MONO_OPTIONS_SRC)
+	$(CSC) -out:$@ $^ /main:CorCompare.Driver \
+		$(MONO_API_INFO_REFS:%=-r:%)


### PR DESCRIPTION
Developers like API compatibility; it helps ensure that their
investment in our platform isn't a waste of time.

Add `tests/api-compatibility` and a new
`make run-api-compatibility-tests` target, part of
`make run-all-tests`, which compares the API of the assemblies in the
current build tree against a "known good" API description maintained
in `tests/api-compatibility/reference/*.xml.gz`, one `.xml.gz` file
per assembly that we are interested in.

The new [`xamarin-android-api-compatibility`][0] submodule contains
the current API description and Make targets to check and update the
API description. `xamarin-android-api-compatibility` uses the
utilities `mono-api-info` and `mono-api-html` to generate and compare
the API descriptions.

A submodule is used because the API descriptions can be quite large --
Mono.Android.xml is currently 54MB -- and we don't want the change
history on these files to "clog up" the xamarin-android repo.

[0]: https://github.com/xamarin/xamarin-android-api-compatibility