### PR TITLE
[Xamarin.Android.Build.Tests] Fix the tests to pick up the correct runtime.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.OSS.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.OSS.cs
@@ -72,6 +72,19 @@ namespace Xamarin.Android.Build.Tests
 			//new Object [] { true, true },
 		};
 
+		static object [] RuntimeChecks = new object [] {
+			new object[] {
+				/* supportedAbi */     new string[] { "armeabi-v7a"},
+				/* optimize */         true ,
+				/* expectedResult */   "release",
+			},
+			new object[] {
+				/* supportedAbi */     new string[] { "armeabi-v7a"},
+				/* optimize */         false ,
+				/* expectedResult */   "debug",
+			},
+		};
+
 		static object [] SequencePointChecks = new object [] {
 			new object[] {
 				/* isRelease */          false,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -989,21 +989,6 @@ namespace App1
 			}
 		}
 
-#pragma warning disable 414
-		static object [] RuntimeChecks = new object [] {
-			new object[] {
-				/* supportedAbi */     new string[] { "armeabi-v7a"},
-				/* optimize */         true ,
-				/* expectedResult */   "release",
-			},
-			new object[] {
-				/* supportedAbi */     new string[] { "armeabi-v7a"},
-				/* optimize */         false ,
-				/* expectedResult */   "debug",
-			},
-		};
-#pragma warning restore 414
-
 		[Test]
 		[TestCaseSource ("RuntimeChecks")]
 		public void CheckWhichRuntimeIsIncluded (string [] supportedAbi, bool optimize, string expectedRuntime)
@@ -1024,7 +1009,7 @@ namespace App1
 						Assert.IsNotNull (inApkRuntime, "Could not find the actual runtime used.");
 						Assert.AreEqual (runtime.Size, inApkRuntime.Size, "expected {0} got {1}", expectedRuntime, inApkRuntime.Runtime);
 						inApk = ZipHelper.ReadFileFromZip (apk, string.Format ("lib/{0}/libmono-profiler-log.so", abi));
-						if (!optimize) {
+						if (string.Compare (expectedRuntime, "debug", StringComparison.OrdinalIgnoreCase) == 0) {
 							Assert.IsNotNull (inApk, "libmono-profiler-log.so should exist in the apk.");
 						} else {
 							Assert.IsNull (inApk, "libmono-profiler-log.so should not exist in the apk.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Diagnostics;
@@ -119,17 +119,21 @@ namespace Xamarin.ProjectTools
 		public RuntimeInfo [] GetSupportedRuntimes ()
 		{
 			var runtimeInfo = new List<RuntimeInfo> ();
-			var outdir = FrameworkLibDirectory;
-			var path = Path.Combine (outdir, RunXBuild ? Path.Combine ("xbuild", "Xamarin", "Android", "lib") : "");
+			string outdir = FrameworkLibDirectory;
+			string path = Path.Combine (outdir, RunXBuild ? Path.Combine ("xbuild", "Xamarin", "Android", "lib") : "");
 			foreach (var file in Directory.EnumerateFiles (path, "libmono-android.*.*.so", SearchOption.AllDirectories)) {
-				var items = Path.GetFileName (file).Split (new char [] { '.' });
-				if (items.Length != 4)
+				string fullFilePath = Path.GetFullPath (file);
+				DirectoryInfo parentDir = Directory.GetParent (fullFilePath);
+				if (parentDir == null)
 					continue;
-				var fi = new FileInfo (file);
+				string[] items = Path.GetFileName (fullFilePath).Split ('.' );
+				if (items.Length != 3)
+					continue;
+				var fi = new FileInfo (fullFilePath);
 				runtimeInfo.Add (new RuntimeInfo () {
 					Name = "libmonodroid.so",
 					Runtime = items [1], // release|debug
-					Abi = items [2], // armaebi|x86|arm64-v8a
+					Abi = parentDir.Name, // armaebi|x86|arm64-v8a
 					Size = (int)fi.Length, // int
 				});
 			}


### PR DESCRIPTION
There was a change (05aebd78) in the naming of the libmono-android.*.so files.
It used to be that the name included the abi. But now we just get
files like

	libmono-android.debug.d.so
	libmono-android.release.so

These were not picking up the right runtime info in the tests. They
were getting an arch of 'd' because we expected files like

	libmono-android.debug.armeabi-v7a.so

So we need to update the ProjectBuilder which loads the data to
take this into account and use the Parent directory name for the
abi and to ignore the .d.so files.