### PR TITLE
[Xamarin.Android.Build.Tasks] [VS2017] Final API 26 error while build ing: Could not find android.jar for API Level 26

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -336,6 +336,12 @@ namespace Xamarin.Android.Tasks
 			if (UseLatestAndroidPlatformSdk) {
 				AndroidApiLevel         = GetMaxInstalledApiLevel ().ToString ();
 				SupportedApiLevel       = GetMaxSupportedApiLevel (AndroidApiLevel);
+				int maxInstalled, maxSupported = 0;
+				if (int.TryParse (AndroidApiLevel, out maxInstalled) && int.TryParse (SupportedApiLevel, out maxSupported) && maxInstalled > maxSupported) {
+					Log.LogDebugMessage ($"API Level {AndroidApiLevel} is greater than the maximum supported API level of {SupportedApiLevel}. " +
+						"Support for this API will be added in a future release.");
+					AndroidApiLevel = SupportedApiLevel;
+				}
 				TargetFrameworkVersion  = GetTargetFrameworkVersionFromApiLevel ();
 				return TargetFrameworkVersion != null;
 			}


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=57692

If we release a version of our software which only supports
API level 25 and the user installs API level 26, we end up
in a pickle with the following error

	`Could not find android.jar for API Level 26. This means the Android SDK platform for API Level 26 is not installed. Either install it in the Android SDK Manager (Tools > Open Android SDK Manager...), or change your Xamarin.Android project to target an API version that is installed. (%PATH_TO_ANDROID_HOME%\platforms\android-O\android.jar missing.)`

The fix is to check that the Max API Level we get from the
system is not greater than the Max API Level we support.
If it is we reset the Max API Level to the Max Supported one.
This means existing users can always use the UseLatest setting
without having to worry about a new API breaking their projects.