### PR TITLE
[Xamarin.Android.Build.Tasks] Latest Xamarin.Facebook (4.22 as opposed to 4.16.1) breaks ability to install multiple apps due to ${ApplicationID} not replacing properly

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
@@ -90,6 +90,8 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
+			FixApplicationIdInManifests (OutputDirectory);
+
 			var outpath = Path.Combine (outDirInfo.Parent.FullName, "__AndroidLibraryProjects__.zip");
 
 			if (Files.ArchiveZip (outpath, f => {
@@ -100,6 +102,27 @@ namespace Xamarin.Android.Tasks
 				Log.LogDebugMessage ("Saving contents to " + outpath);
 			}
 			return true;
+		}
+
+		void FixApplicationIdInManifests (string directory)
+		{
+			var broken = new List<string> ();
+			string goodFile = null;
+			foreach (var file in Directory.EnumerateFiles (directory, "AndroidManifest.xml", SearchOption.AllDirectories)) {
+				string text = File.ReadAllText (file);
+				if (text.Contains (("dollar_openBracket_applicationId_closeBracket"))) {
+					broken.Add (file);
+				} else {
+					goodFile = file;
+				}
+			}
+			if (!string.IsNullOrEmpty (goodFile)) {
+				foreach (var file in broken) {
+					DateTime lastWriteTime = File.GetLastWriteTimeUtc (file);
+					File.Copy (goodFile, file, overwrite: true);
+					File.SetLastWriteTimeUtc (file, lastWriteTime);
+				}
+			}
 		}
 			
 		bool CopyLibraryContent (string projdir, bool isAar)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
@@ -90,8 +90,6 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
-			FixApplicationIdInManifests (OutputDirectory);
-
 			var outpath = Path.Combine (outDirInfo.Parent.FullName, "__AndroidLibraryProjects__.zip");
 
 			if (Files.ArchiveZip (outpath, f => {
@@ -102,27 +100,6 @@ namespace Xamarin.Android.Tasks
 				Log.LogDebugMessage ("Saving contents to " + outpath);
 			}
 			return true;
-		}
-
-		void FixApplicationIdInManifests (string directory)
-		{
-			var broken = new List<string> ();
-			string goodFile = null;
-			foreach (var file in Directory.EnumerateFiles (directory, "AndroidManifest.xml", SearchOption.AllDirectories)) {
-				string text = File.ReadAllText (file);
-				if (text.Contains (("dollar_openBracket_applicationId_closeBracket"))) {
-					broken.Add (file);
-				} else {
-					goodFile = file;
-				}
-			}
-			if (!string.IsNullOrEmpty (goodFile)) {
-				foreach (var file in broken) {
-					DateTime lastWriteTime = File.GetLastWriteTimeUtc (file);
-					File.Copy (goodFile, file, overwrite: true);
-					File.SetLastWriteTimeUtc (file, lastWriteTime);
-				}
-			}
 		}
 			
 		bool CopyLibraryContent (string projdir, bool isAar)
@@ -150,6 +127,9 @@ namespace Xamarin.Android.Tasks
 					if (!File.Exists (dstpath))
 						MonoAndroidHelper.CopyIfChanged (file, dstpath);
 				}
+				dstdir = Path.Combine (OutputDirectory, "aapt");
+				Directory.CreateDirectory (dstdir);
+				MonoAndroidHelper.CopyIfChanged (Path.Combine (projdir, "AndroidManifest.xml"), Path.Combine (dstdir, "AndroidManifest.xml"));
 			}
 			return true;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -844,8 +844,7 @@ namespace Xamarin.Android.Tasks {
 			ms.Position = 0;
 			var s = new StreamReader (ms).ReadToEnd ();
 			if (ApplicationName != null)
-				s = s.Replace ("${applicationId}", ApplicationName)
-					.Replace ("dollar_openBracket_applicationId_closeBracket", ApplicationName);
+				s = s.Replace ("${applicationId}", ApplicationName);
 			if (Placeholders != null)
 				foreach (var entry in Placeholders.Select (e => e.Split (new char [] {'='}, 2, StringSplitOptions.None))) {
 					if (entry.Length == 2)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -844,7 +844,8 @@ namespace Xamarin.Android.Tasks {
 			ms.Position = 0;
 			var s = new StreamReader (ms).ReadToEnd ();
 			if (ApplicationName != null)
-				s = s.Replace ("${applicationId}", ApplicationName);
+				s = s.Replace ("${applicationId}", ApplicationName)
+					.Replace ("dollar_openBracket_applicationId_closeBracket", ApplicationName);
 			if (Placeholders != null)
 				foreach (var entry in Placeholders.Select (e => e.Split (new char [] {'='}, 2, StringSplitOptions.None))) {
 					if (entry.Length == 2)


### PR DESCRIPTION
Context https://bugzilla.xamarin.com/show_bug.cgi?id=56690
Context https://bugzilla.xamarin.com/show_bug.cgi?id=51689

This is one weird issue. It appears that the AndroidManifest.xml
files in the .aar files contain the

	"dollar_openBracket_applicationId_closeBracket"

text. But... wait for it. Not all of the AndroidManifest.xml files
in the .aar do. So this appears to be a result of some weird
gradle issue. It does appear to be fixed in later versions but it
does mean that for certain versions of the .aar files they are
broken.

So to work around this issue we need to post process the zip file
we create in the library projects to make sure we pickup the
AndroidManifest.xml file which does not have the problem.

We also do some fixup when building the base apk to ensure that
the AndroidManifest.xml does NOT contain this text and that it
is correctly replaced with the applicaitonId (like we do for
{applicationId}).