### PR TITLE
[tests/Codegen-Binding] Use a variable for the Android SDK in the BuildJavaLibs 'gradlew' invocation

### DIFF
--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
@@ -42,12 +42,8 @@
       DependsOnTargets="AndroidPrepareForBuild"
       Inputs="java\JavaLib\project.properties"
       Outputs="$(OutputPath)JavaLib.zip">
-    <WriteLinesToFile
-        Overwrite="true"
-        File="java\JavaLib\local.properties"
-        Lines="sdk.dir=$(AndroidSdkDirectory)"
-    />
     <Exec
+        EnvironmentVariables="ANDROID_HOME=$(AndroidSdkDirectory)"
         Command=".\gradlew assembleDebug --stacktrace"
         WorkingDirectory="$(MSBuildThisFileDirectory)java\JavaLib"
     />


### PR DESCRIPTION
This fixes a 'gradlew' failure which is encountered on Windows only. Unfortunately, the 'gradlew' invocation prefixes the 'sdk.dir' value read from 'local.properties' with the path of the working directory.
As a result, we encounter a failure along the following lines on Windows:

```
    * What went wrong:
      A problem occurred configuring project ':library'.
      > The SDK directory 'C:\Users\xamarinqa\git\xamarin-android\tests\CodeGen-Binding\Xamarin.Android.LibraryProjectZip-LibBinding\java\JavaLib\C:Program Files (x86)Androidandroid-sdk' does not exist
```

This can be avoided by exporting ANDROID_HOME in the Exec portion of the BuildJavaLibs target, rather than writing this information to a file and expecting 'gradlew' to process it correctly.