### PR TITLE
[Xamarin.Android.Build.Tasks] Give a proper warning when JDK 1.8 is required but not installed

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1788,6 +1788,101 @@ public class Test
 			}
 		}
 
+#pragma warning disable 414
+		static object [] validateJavaVersionTestCases = new object [] {
+			new object [] {
+				/*targetFrameworkVersion*/ "v7.1",
+				/*buildToolsVersion*/ "24.0.1",
+				/*JavaVersion*/ "1.8.0_101",
+				/*expectedResult*/ true,
+			},
+			new object [] {
+				/*targetFrameworkVersion*/ "v7.1",
+				/*buildToolsVersion*/ "24.0.1",
+				/*JavaVersion*/ "1.7.0_101",
+				/*expectedResult*/ false,
+			},
+			new object [] {
+				/*targetFrameworkVersion*/ "v7.1",
+				/*buildToolsVersion*/ "24.0.1",
+				/*JavaVersion*/ "1.6.0_101",
+				/*expectedResult*/ false,
+			},
+			new object [] {
+				/*targetFrameworkVersion*/ "v6.0",
+				/*buildToolsVersion*/ "24.0.1",
+				/*JavaVersion*/ "1.8.0_101",
+				/*expectedResult*/ true,
+			},
+			new object [] {
+				/*targetFrameworkVersion*/ "v6.0",
+				/*buildToolsVersion*/ "24.0.0",
+				/*JavaVersion*/ "1.7.0_101",
+				/*expectedResult*/ true,
+			},
+			new object [] {
+				/*targetFrameworkVersion*/ "v6.0",
+				/*buildToolsVersion*/ "24.0.0",
+				/*JavaVersion*/ "1.6.0_101",
+				/*expectedResult*/ false,
+			},
+			new object [] {
+				/*targetFrameworkVersion*/ "v5.0",
+				/*buildToolsVersion*/ "24.0.1",
+				/*JavaVersion*/ "1.8.0_101",
+				/*expectedResult*/ true,
+			},
+			new object [] {
+				/*targetFrameworkVersion*/ "v5.0",
+				/*buildToolsVersion*/ "24.0.0",
+				/*JavaVersion*/ "1.7.0_101",
+				/*expectedResult*/ true,
+			},
+			new object [] {
+				/*targetFrameworkVersion*/ "v5.0",
+				/*buildToolsVersion*/ "24.0.0",
+				/*JavaVersion*/ "1.6.0_101",
+				/*expectedResult*/ true,
+			},
+			new object [] {
+				/*targetFrameworkVersion*/ "v5.0",
+				/*buildToolsVersion*/ "24.0.1",
+				/*JavaVersion*/ "1.6.0_101",
+				/*expectedResult*/ false,
+			},
+			new object [] {
+				/*targetFrameworkVersion*/ "v7.1",
+				/*buildToolsVersion*/ "24.0.1",
+				/*JavaVersion*/ "1.6.x_101",
+				/*expectedResult*/ true,
+			},
+		};
+#pragma warning restore 414
+
+		[Test]
+		[TestCaseSource ("validateJavaVersionTestCases")]
+		public void ValidateJavaVersion (string targetFrameworkVersion, string buildToolsVersion, string javaVersion, bool expectedResult) 
+		{
+			var path = Path.Combine ("temp", $"ValidateJavaVersion_{targetFrameworkVersion}_{buildToolsVersion}_{javaVersion}");
+			string javaExe = "java";
+			var javaPath = CreateFauxJavaSdkDirectory (Path.Combine (path, "JavaSDK"), javaVersion, out javaExe);
+			var AndroidSdkDirectory = CreateFauxAndroidSdkDirectory (Path.Combine (path, "android-sdk"), buildToolsVersion);
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				TargetFrameworkVersion = targetFrameworkVersion,
+			};
+			using (var builder = CreateApkBuilder (Path.Combine (path, proj.ProjectName), false, false)) {
+				builder.ThrowOnBuildFailure = false;
+				builder.Target = "_SetLatestTargetFrameworkVersion";
+				Assert.AreEqual (expectedResult, builder.Build (proj, parameters: new string[] {
+					$"JavaSdkDirectory={javaPath}",
+					$"JavaToolExe={javaExe}",
+					$"AndroidSdkBuildToolsVersion={buildToolsVersion}",
+					$"AndroidSdkDirectory={AndroidSdkDirectory}",
+				} ), string.Format ("Build should have {0}", expectedResult ? "succeeded" : "failed"));
+			}
+		}
+
 		[Test]
 		public void BuildAMassiveApp()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -176,6 +176,9 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 			TargetFrameworkVersion="$(TargetFrameworkVersion)"
 			SequencePointsMode="$(AndroidSequencePointsMode)"
 			UseLatestAndroidPlatformSdk="$(AndroidUseLatestPlatformSdk)"
+			JavaToolExe="$(JavaToolExe)"
+			LatestSupportedJavaVersion="$(LatestSupportedJavaVersion)"
+			MinimumSupportedJavaVersion="$(MinimumSupportedJavaVersion)"
 	>
 		<Output TaskParameter="AndroidApiLevel"           PropertyName="_AndroidApiLevel"           Condition="'$(_AndroidApiLevel)' == ''" />
 		<Output TaskParameter="AndroidApiLevelName"       PropertyName="_AndroidApiLevelName" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -5,5 +5,7 @@
 		<DependsOnSystemRuntime Condition=" '$(DependsOnSystemRuntime)' == '' ">true</DependsOnSystemRuntime>
 		<CopyNuGetImplementations Condition=" '$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
 		<YieldDuringToolExecution Condition="'$(YieldDuringToolExecution)' == ''">true</YieldDuringToolExecution>
+		<LatestSupportedJavaVersion>1.8.0</LatestSupportedJavaVersion>
+		<MinimumSupportedJavaVersion>1.6.0</MinimumSupportedJavaVersion>
 	</PropertyGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -609,6 +609,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 			ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)"
 			TargetFrameworkVersion="$(TargetFrameworkVersion)"
 			UseLatestAndroidPlatformSdk="$(AndroidUseLatestPlatformSdk)"
+			JavaToolExe="$(JavaToolExe)"
+			LatestSupportedJavaVersion="$(LatestSupportedJavaVersion)"
+			MinimumSupportedJavaVersion="$(MinimumSupportedJavaVersion)"
 			LintToolPath="$(LintToolPath)"
 			ZipAlignPath="$(ZipAlignToolPath)">
 		<Output TaskParameter="AndroidApiLevel"           PropertyName="_AndroidApiLevel"           Condition="'$(_AndroidApiLevel)' == ''" />


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=51507

If a user has an older verison of Java installed they currently get
this kind of helpful error message.

	"Unsupported major.minor version 52.0"

While for the experienced user this might mean "Ah I need Java 1.8".
For the new users this is confusing.

This commit adds a new property in the Xamarin.Android.Common.props
called

	`$(MinimumRequiredJavaVersion)`

This will define the Minimum required version of Java we need.
It can be overridden on the command line or in the project is needed.

If this mimimum version is NOT met, we will error out. While it
might be nicers to issue a warning, this will eventually end up with
the above error anyway. So we might as well tell the user exactly what
is wrong.