### PR TITLE
[Xamarin.Android.Build.Tasks] Path is too long

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -71,12 +71,14 @@ namespace Xamarin.Android.Tasks
 		public string ImportsDirectory { get; set; }
 		public string OutputImportDirectory { get; set; }
 		public bool UseShortFileNames { get; set; }
+		public string AssemblyIdentityMapFile { get; set; }
 
 		public string ResourceNameCaseMap { get; set; }
 
 		public bool ExplicitCrunch { get; set; }
 
 		Dictionary<string,string> resource_name_case_map = new Dictionary<string,string> ();
+		AssemblyIdentityMap assemblyMap = new AssemblyIdentityMap ();
 
 		bool ManifestIsUpToDate (string manifestFile)
 		{
@@ -197,6 +199,8 @@ namespace Xamarin.Android.Tasks
 				foreach (var arr in ResourceNameCaseMap.Split (';').Select (l => l.Split ('|')).Where (a => a.Length == 2))
 					resource_name_case_map [arr [1]] = arr [0]; // lowercase -> original
 
+			assemblyMap.Load (AssemblyIdentityMapFile);
+
 			ThreadingTasks.Parallel.ForEach (ManifestFiles, () => 0, DoExecute, (obj) => { Complete (); });
 
 			base.Execute ();
@@ -315,7 +319,7 @@ namespace Xamarin.Android.Tasks
 					return s.Substring (0, st + 1) + ExpandString (s.Substring (st + 1));
 				int ast = st + "${library.imports:".Length;
 				string aname = s.Substring (ast, ed - ast);
-				return s.Substring (0, st) + Path.Combine (OutputImportDirectory, UseShortFileNames ? MonoAndroidHelper.GetLibraryImportDirectoryNameForAssembly (aname) : aname, ImportsDirectory) + Path.DirectorySeparatorChar + ExpandString (s.Substring (ed + 1));
+				return s.Substring (0, st) + Path.Combine (OutputImportDirectory, UseShortFileNames ? assemblyMap.GetLibraryImportDirectoryNameForAssembly (aname) : aname, ImportsDirectory) + Path.DirectorySeparatorChar + ExpandString (s.Substring (ed + 1));
 			}
 			else
 				return s;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
@@ -94,7 +94,7 @@ namespace Xamarin.Android.Tasks
 
 			if (Files.ArchiveZip (outpath, f => {
 				using (var zip = new ZipArchiveEx (f)) {
-					zip.AddDirectory (OutputDirectory, outDirInfo.Name);
+					zip.AddDirectory (OutputDirectory, "library_project_imports");
 				}
 			})) {
 				Log.LogDebugMessage ("Saving contents to " + outpath);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateManagedLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateManagedLibraryResourceArchive.cs
@@ -108,7 +108,7 @@ namespace Xamarin.Android.Tasks
 
 			if (Files.ArchiveZip (outpath, f => {
 				using (var zip = new ZipArchiveEx (f)) {
-					zip.AddDirectory (OutputDirectory, outDirInfo.Name);
+					zip.AddDirectory (OutputDirectory, "library_project_imports");
 				}
 			})) {
 				Log.LogDebugMessage ("Saving contents to " + outpath);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateNativeLibraryArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateNativeLibraryArchive.cs
@@ -66,7 +66,7 @@ namespace Xamarin.Android.Tasks
 
 			if (Files.ArchiveZip (outpath, f => {
 				using (var zip = new ZipArchiveEx (f)) {
-					zip.AddDirectory (OutputDirectory, outDirInfo.Name);
+					zip.AddDirectory (OutputDirectory, "native_library_imports");
 				}
 			})) {
 				Log.LogDebugMessage ("Saving contents to " + outpath);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -3,6 +3,7 @@ using Xamarin.ProjectTools;
 using NUnit.Framework;
 using System.IO;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace Xamarin.Android.Build.Tests
 {
@@ -263,7 +264,7 @@ namespace Com.Ipaulpro.Afilechooser {
 		}
 
 		[Test]
-		public void BindingCheckHiddenFiles ()
+		public void BindingCheckHiddenFiles ([Values (true, false)] bool useShortFileNames)
 		{
 			var binding = new XamarinAndroidBindingProject () {
 				UseLatestPlatformSdk = true,
@@ -273,15 +274,31 @@ namespace Com.Ipaulpro.Afilechooser {
 			binding.Jars.Add (new AndroidItem.LibraryProjectZip ("Jars\\mylibrary.aar") {
 				WebContent = "https://www.dropbox.com/s/astiqp8jo97x91h/mylibrary.aar?dl=1"
 			});
+			binding.SetProperty (binding.ActiveConfigurationProperties, "UseShortFileNames", useShortFileNames);
 			using (var bindingBuilder = CreateDllBuilder (Path.Combine ("temp", "BindingCheckHiddenFiles", "Binding"))) {
 				bindingBuilder.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
 				Assert.IsTrue (bindingBuilder.Build (binding), "binding build should have succeeded");
 				var proj = new XamarinAndroidApplicationProject ();
 				proj.OtherBuildItems.Add (new BuildItem ("ProjectReference", "..\\Binding\\UnnamedProject.csproj"));
+				proj.SetProperty (proj.ActiveConfigurationProperties, "UseShortFileNames", useShortFileNames);
 				using (var b = CreateApkBuilder (Path.Combine ("temp", "BindingCheckHiddenFiles", "App"))) {
 					Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-					var dsStorePath = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "__library_projects__",
-						"UnnamedProject", "library_project_imports");
+					var assemblyMap = b.Output.GetIntermediaryPath (Path.Combine ("lp", "map.cache"));
+					if (useShortFileNames)
+						Assert.IsTrue (File.Exists (assemblyMap), $"{assemblyMap} should exist.");
+					else
+						Assert.IsFalse (File.Exists (assemblyMap), $"{assemblyMap} should not exist.");
+					var assemblyIdentityMap = new List<string> ();
+					if (useShortFileNames) {
+						foreach (var s in File.ReadLines (assemblyMap)) {
+							assemblyIdentityMap.Add (s);
+						}
+					}
+					var assmeblyIdentity = useShortFileNames ? assemblyIdentityMap.IndexOf ("UnnamedProject").ToString () : "UnnamedProject";
+					var libaryImportsFolder = useShortFileNames ? "lp" : "__library_projects__";
+					var jlibs = useShortFileNames ? "jl" : "library_project_imports";
+					var dsStorePath = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, libaryImportsFolder,
+						assmeblyIdentity, jlibs);
 					Assert.IsTrue (Directory.Exists (dsStorePath), "{0} should exist.", dsStorePath);
 					Assert.IsFalse (File.Exists (Path.Combine (dsStorePath, ".DS_Store")), "{0} should NOT exist.",
 						Path.Combine (dsStorePath, ".DS_Store"));

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1741,6 +1741,54 @@ public class Test
 		}
 
 		[Test]
+		public void CheckLibraryImportsUpgrade ([Values(false, true)] bool useShortFileNames)
+		{
+			var path = Path.Combine ("temp", "CheckLibraryImportsUpgrade");
+			var libproj = new XamarinAndroidLibraryProject () {
+				IsRelease = true,
+				ProjectName = "Library1"
+			};
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				ProjectName = "App1",
+			};
+			proj.References.Add (new BuildItem ("ProjectReference", $"..\\Library1\\Library1.csproj"));
+			proj.SetProperty ("_AndroidLibrayProjectIntermediatePath", Path.Combine (proj.IntermediateOutputPath, "__library_projects__"));
+			proj.SetProperty (proj.ActiveConfigurationProperties, "UseShortFileNames", useShortFileNames);
+			using (var libb = CreateDllBuilder (Path.Combine (path, libproj.ProjectName), false, false)) {
+				Assert.IsTrue (libb.Build (libproj), "Build should have succeeded.");
+				using (var builder = CreateApkBuilder (Path.Combine (path, proj.ProjectName), false, false)) {
+					builder.Verbosity = LoggerVerbosity.Diagnostic;
+					Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
+					Assert.IsTrue (Directory.Exists (Path.Combine (Root, path, proj.ProjectName, proj.IntermediateOutputPath, "__library_projects__")),
+						"The __library_projects__ directory should exist.");
+					proj.RemoveProperty ("_AndroidLibrayProjectIntermediatePath");
+					Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
+					Assert.IsTrue (Directory.Exists (Path.Combine (Root, path, proj.ProjectName, proj.IntermediateOutputPath, "__library_projects__")),
+						"The __library_projects__ directory should exist.");
+					Assert.IsTrue (libb.Clean (libproj), "Clean should have succeeded.");
+					Assert.IsTrue (libb.Build (libproj), "Build should have succeeded.");
+					Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
+					var zipFile = libb.Output.GetIntermediaryPath ("__AndroidLibraryProjects__.zip");
+					Assert.IsTrue (File.Exists (zipFile));
+					using (var zip = ZipHelper.OpenZip (zipFile)) {
+						Assert.IsTrue (zip.ContainsEntry ("library_project_imports/__res_name_case_map.txt"), $"{zipFile} should contain a library_project_imports/__res_name_case_map.txt entry");
+					}
+					if (!useShortFileNames) {
+						Assert.IsTrue (Directory.Exists (Path.Combine (Root, path, proj.ProjectName, proj.IntermediateOutputPath, "__library_projects__")),
+							"The __library_projects__ directory should exist.");
+					} else {
+						Assert.IsFalse (Directory.Exists (Path.Combine (Root, path, proj.ProjectName, proj.IntermediateOutputPath, "__library_projects__")),
+							"The __library_projects__ directory should not exist.");
+						Assert.IsTrue (Directory.Exists (Path.Combine (Root, path, proj.ProjectName, proj.IntermediateOutputPath, "lp")),
+							"The lp directory should exist.");
+					}
+
+				}
+			}
+		}
+
+		[Test]
 		public void BuildAMassiveApp()
 		{
 			var testPath = Path.Combine("temp", "BuildAMassiveApp");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -80,7 +80,7 @@ public class TestMe {
 		}
 
 		[Test]
-		public void ResolveNativeLibrariesInManagedReferences ()
+		public void ResolveNativeLibrariesInManagedReferences ([Values(true, false)] bool useShortFileNames)
 		{
 			var lib = new XamarinAndroidLibraryProject () {
 				ProjectName = "Lib",
@@ -108,6 +108,7 @@ namespace Lib
 					},
 				},
 			};
+			lib.SetProperty (lib.ActiveConfigurationProperties, "UseShortFileNames", useShortFileNames);
 			var so = lib.OtherBuildItems.First (x => x.Include () == "libs/armeabi-v7a/libfoo.so");
 
 			var lib2 = new XamarinAndroidLibraryProject () {
@@ -139,7 +140,7 @@ namespace Lib2
 					},
 				},
 			};
-
+			lib2.SetProperty (lib.ActiveConfigurationProperties, "UseShortFileNames", useShortFileNames);
 			var path = Path.Combine (Root, "temp", "ResolveNativeLibrariesInManagedReferences");
 			using (var libbuilder = CreateDllBuilder (Path.Combine(path, "Lib"))) {
 
@@ -154,6 +155,7 @@ namespace Lib2
 							new BuildItem.ProjectReference (@"..\Lib2\Lib2.csproj", "Lib2", lib2.ProjectGuid),
 						}
 					};
+					app.SetProperty (app.ActiveConfigurationProperties, "UseShortFileNames", useShortFileNames);
 					using (var builder = CreateApkBuilder (Path.Combine (path, "App"))) {
 						builder.Verbosity = LoggerVerbosity.Diagnostic;
 						Assert.IsTrue (builder.Build (app), "app 1st. build failed");
@@ -171,7 +173,7 @@ namespace Lib2
 						Assert.IsNotNull (libfoo, "libfoo.so should exist in the .apk");
 
 						Assert.AreEqual (so.TextContent ().Length, new FileInfo (Path.Combine (Root, libbuilder.ProjectDirectory, lib.IntermediateOutputPath,
-							"native_library_imports", "armeabi-v7a", "libfoo.so")).Length,
+							useShortFileNames ? "nl" : "native_library_imports", "armeabi-v7a", "libfoo.so")).Length,
 							"intermediate size mismatch");
 						libfoo = ZipHelper.ReadFileFromZip (Path.Combine (Root, builder.ProjectDirectory, app.OutputPath, app.PackageName + ".apk"),
 							"lib/armeabi-v7a/libfoo.so");

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyIdentityMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyIdentityMap.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Xamarin.Android.Tasks
+{
+	internal class AssemblyIdentityMap
+	{
+		List<string> map = new List<string> ();
+
+		public void Load (string mapFile)
+		{
+			map.Clear ();
+			if (!File.Exists (mapFile))
+				return;
+			foreach (var s in File.ReadLines (mapFile)) {
+				if (!map.Contains (s))
+					map.Add (s);
+			}
+		}
+
+		public string GetLibraryImportDirectoryNameForAssembly (string assemblyIdentity)
+		{
+			if (map.Contains (assemblyIdentity)) {
+				return map.IndexOf (assemblyIdentity).ToString ();
+			}
+			map.Add (assemblyIdentity);
+			return map.IndexOf (assemblyIdentity).ToString ();
+		}
+
+		public void Save (string mapFile)
+		{
+			if (map.Count == 0)
+				return;
+			var sb = new StringBuilder ();
+			foreach (var item in map) {
+				sb.AppendLine (item);
+			}
+			File.WriteAllText (mapFile, sb.ToString ());
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -193,7 +193,7 @@ namespace Xamarin.Android.Tools {
 			return ZipArchive.Open (filename, FileMode.Open, strictConsistencyChecks: strictConsistencyChecks);
 		}
 
-		public static void ExtractAll(ZipArchive zip, string destination, Action<int, int> progressCallback = null)
+		public static void ExtractAll(ZipArchive zip, string destination, Action<int, int> progressCallback = null, Func<string, string> modifyCallback = null)
 		{
 			int i = 0;
 			int total = (int)zip.EntryCount;
@@ -202,14 +202,15 @@ namespace Xamarin.Android.Tools {
 						entry.FullName.EndsWith ("/__MACOSX", StringComparison.OrdinalIgnoreCase) ||
 						entry.FullName.EndsWith ("/.DS_Store", StringComparison.OrdinalIgnoreCase))
 					continue;
+				var fullName = modifyCallback?.Invoke (entry.FullName) ?? entry.FullName;
 				if (entry.IsDirectory) {
-					Directory.CreateDirectory (Path.Combine (destination, entry.FullName));
+					Directory.CreateDirectory (Path.Combine (destination, fullName));
 					continue;
 				}
 				if (progressCallback != null)
 					progressCallback (i++, total);
-				Directory.CreateDirectory (Path.Combine (destination, Path.GetDirectoryName (entry.FullName)));
-				entry.Extract (destination, entry.FullName);
+				Directory.CreateDirectory (Path.Combine (destination, Path.GetDirectoryName (fullName)));
+				entry.Extract (destination, fullName);
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -454,11 +454,6 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		public static string GetLibraryImportDirectoryNameForAssembly (string assemblyIdentName)
-		{
-			return string.Concat (new MD2Managed ().ComputeHash (Encoding.UTF8.GetBytes (assemblyIdentName)).Take (5).Select (b => b.ToString ("X02")));
-		}
-
 		public static Dictionary<string, string> LoadAcwMapFile (string acwPath)
 		{
 			var acw_map = new Dictionary<string, string> ();

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -61,7 +61,8 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
     <MonoAndroidVersion>v5.0</MonoAndroidVersion>
     <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == '' And '$(AndroidUseLatestPlatformSdk)' == 'False'">v2.3</TargetFrameworkVersion>
-	<UseShortFileNames Condition="'$(UseShortFileNames)' != 'True'">False</UseShortFileNames>
+    <UseShortFileNames Condition="'$(UseShortFileNames)' == ''">True</UseShortFileNames>
+    <UseShortGeneratorFileNames Condition="'$(UseShortGeneratorFileNames)' == ''">False</UseShortGeneratorFileNames>
     <AndroidClassParser Condition=" '$(AndroidClassParser)' == '' ">jar2xml</AndroidClassParser>
   </PropertyGroup>
   
@@ -102,19 +103,18 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <ApiOutputFile Condition="'$(ApiOutputFile)' == ''">$(IntermediateOutputPath)api.xml</ApiOutputFile>
     <_GeneratorStampFile>$(IntermediateOutputPath)generator.stamp</_GeneratorStampFile>
     <AndroidSequencePointsMode Condition=" '$(AndroidSequencePointsMode)' == ''">None</AndroidSequencePointsMode>
-    <!--
-    <_LibraryProjectImportsDirectoryName Condition="$(UseShortFileNames)">jlibs</_LibraryProjectImportsDirectoryName>
-    <_LibraryProjectImportsDirectoryName Condition="!$(UseShortFileNames)">library_project_imports</_LibraryProjectImportsDirectoryName>
-    <_NativeLibraryImportsDirectoryName Condition="$(UseShortFileNames)">libs</_NativeLibraryImportsDirectoryName>
-    <_NativeLibraryImportsDirectoryName Condition="!$(UseShortFileNames)">native_library_imports</_NativeLibraryImportsDirectoryName>
-    -->
-    <_LibraryProjectImportsDirectoryName>library_project_imports</_LibraryProjectImportsDirectoryName>
-	<_NativeLibraryImportsDirectoryName>native_library_imports</_NativeLibraryImportsDirectoryName>
+	<_LibraryProjectImportsDirectoryName Condition=" '$(_LibraryProjectImportsDirectoryName)'=='' And '$(UseShortFileNames)' == 'True' ">jl</_LibraryProjectImportsDirectoryName>
+	<_NativeLibraryImportsDirectoryName Condition=" '$(_NativeLibraryImportsDirectoryName)'=='' And '$(UseShortFileNames)' == 'True' ">nl</_NativeLibraryImportsDirectoryName>
+
+	<_LibraryProjectImportsDirectoryName Condition=" '$(_LibraryProjectImportsDirectoryName)'==''">library_project_imports</_LibraryProjectImportsDirectoryName>
+	<_NativeLibraryImportsDirectoryName Condition=" '$(_NativeLibraryImportsDirectoryName)'==''">native_library_imports</_NativeLibraryImportsDirectoryName>
 	<_AndroidResourcePathsCache>$(IntermediateOutputPath)resourcepaths.cache</_AndroidResourcePathsCache>
 	<_AndroidLibraryImportsCache>$(IntermediateOutputPath)libraryimports.cache</_AndroidLibraryImportsCache>
 	<_AndroidLibraryProjectImportsCache>$(IntermediateOutputPath)libraryprojectimports.cache</_AndroidLibraryProjectImportsCache>
-
-
+	<_AndroidLibrayProjectIntermediatePath Condition=" '$(_AndroidLibrayProjectIntermediatePath)' == '' And '$(UseShortFileNames)' == 'True' ">$(IntermediateOutputPath)lp\</_AndroidLibrayProjectIntermediatePath>
+	<_AndroidLibrayProjectIntermediatePath Condition=" '$(_AndroidLibrayProjectIntermediatePath)' == '' ">$(IntermediateOutputPath)__library_projects__\</_AndroidLibrayProjectIntermediatePath>
+	<_AndroidLibrayProjectAssemblyMapFile>$(_AndroidLibrayProjectIntermediatePath)map.cache</_AndroidLibrayProjectAssemblyMapFile>
+		
 	<!-- Prevent warnings about assembly version conflicts -->
 	<AutoUnifyAssemblyReferences>True</AutoUnifyAssemblyReferences>
 	<AutoGenerateBindingRedirects>False</AutoGenerateBindingRedirects>
@@ -318,7 +318,8 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 		ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
 		UseShortFileNames="$(UseShortFileNames)"
 		OutputDirectory="$(IntermediateOutputPath)"
-		OutputImportDirectory="$(IntermediateOutputPath)__library_projects__\">
+		AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
+		OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)">
 	</ResolveLibraryProjectImports>
 </Target>
 
@@ -333,7 +334,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 <Target Name="_BuildLibraryImportsCache"
 		Inputs="$(MSBuildProjectFullPath)"
 		Outputs="$(_AndroidLibraryImportsCache)">
-	<GetImportedLibraries TargetDirectory="$(IntermediateOutputPath)__library_projects__\"
+	<GetImportedLibraries TargetDirectory="$(_AndroidLibrayProjectIntermediatePath)"
 			CacheFile="$(_AndroidLibraryImportsCache)">
 		<Output TaskParameter="Jars" ItemName="ExtractedJarImports" />
 	</GetImportedLibraries>
@@ -418,7 +419,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
       Java7DocPaths="$(Java7DocPaths)"
       Java8DocPaths="$(Java8DocPaths)"
       JavaDocs="@(JavaDocIndex)"
-      LibraryProjectJars="$(IntermediateOutputPath)__library_projects__\*.jar"
+      LibraryProjectJars="$(_AndroidLibrayProjectIntermediatePath)\*.jar"
     />
 
   </Target>
@@ -451,7 +452,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
       TypeMappingReportFile="$(GeneratedOutputPath)type-mapping.txt"
       ToolPath="$(_MonoAndroidBinDirectory)"
       ToolExe="$(BindingsGeneratorToolExe)"
-      UseShortFileNames="$(UseShortFileNames)"
+      UseShortFileNames="$(UseShortGeneratorFileNames)"
     />
 
     <!-- Write a flag so we won't redo this target if nothing changed -->
@@ -567,10 +568,12 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <Delete Files="$(_AndroidResourcePathsCache)" />
     <Delete Files="$(_AndroidLibraryImportsCache)" />
     <Delete Files="$(_AndroidLibraryProjectImportsCache)" />
+    <Delete Files="$(_AndroidLibrayProjectAssemblyMapFile)" />
     <RemoveDirFixed Directories="$(IntermediateOutputPath)library_project_jars" Condition="Exists ('$(IntermediateOutputPath)library_project_jars')" />
     <RemoveDirFixed Directories="$(IntermediateOutputPath)library_project_annotations" Condition="Exists ('$(IntermediateOutputPath)library_project_annotations')" />
     <RemoveDirFixed Directories="$(IntermediateOutputPath)$(_LibraryProjectImportsDirectoryName)" Condition="Exists ('$(IntermediateOutputPath)$(_LibraryProjectImportsDirectoryName)')" />
     <RemoveDirFixed Directories="$(IntermediateOutputPath)__library_projects__" Condition="Exists ('$(IntermediateOutputPath)__library_projects__')"/>
+    <RemoveDirFixed Directories="$(_AndroidLibrayProjectIntermediatePath)" Condition="Exists ('$(_AndroidLibrayProjectIntermediatePath)')" />
   </Target>
 
   <Target Name="CleanNativeLibraryIntermediaries">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -474,6 +474,7 @@
     <Compile Include="Utilities\Profile.cs" />
     <Compile Include="Linker\MonoDroid.Tuner\PreserveTlsProvider.cs" />
     <Compile Include="Tasks\Unzip.cs" />
+    <Compile Include="Utilities\AssemblyIdentityMap.cs" />
   </ItemGroup>
   <ItemGroup>
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.LaunchMode.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -199,7 +199,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 	<BundleAssemblies Condition="'$(BundleAssemblies)' == ''">False</BundleAssemblies>
 	<DeployExternal Condition="'$(DeployExternal)' == ''">False</DeployExternal>
-	<UseShortFileNames Condition="'$(UseShortFileNames)' != 'True'">False</UseShortFileNames>
+	<UseShortFileNames Condition="'$(UseShortFileNames)' == ''">True</UseShortFileNames>
 
 	<!-- Obsolete build property: should be removed in the future releases -->
 	<AndroidMultiDexSupportJar></AndroidMultiDexSupportJar>
@@ -227,18 +227,18 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<!-- Chooses the native Android debug server, valid values are: gdbserver, llgs and ds2 -->
 	<AndroidGdbDebugServer Condition="'$(AndroidGdbDebugServer)' == ''">Gdb</AndroidGdbDebugServer>
 
-    <!--
-    <_LibraryProjectImportsDirectoryName Condition="'$(UseShortFileNames)' == 'true'">jlibs</_LibraryProjectImportsDirectoryName>
-    <_LibraryProjectImportsDirectoryName Condition="'$(UseShortFileNames)' != 'true'">library_project_imports</_LibraryProjectImportsDirectoryName>
-	<_NativeLibraryImportsDirectoryName Condition="'$(UseShortFileNames)' == 'true'">libs</_NativeLibraryImportsDirectoryName>
-	<_NativeLibraryImportsDirectoryName Condition="'$(UseShortFileNames)' != 'true'">native_library_imports</_NativeLibraryImportsDirectoryName>
-    -->
-    <_LibraryProjectImportsDirectoryName>library_project_imports</_LibraryProjectImportsDirectoryName>
-	<_NativeLibraryImportsDirectoryName>native_library_imports</_NativeLibraryImportsDirectoryName>
+	<_LibraryProjectImportsDirectoryName Condition=" '$(_LibraryProjectImportsDirectoryName)'=='' And '$(UseShortFileNames)' == 'True' ">jl</_LibraryProjectImportsDirectoryName>
+	<_NativeLibraryImportsDirectoryName Condition=" '$(_NativeLibraryImportsDirectoryName)'=='' And '$(UseShortFileNames)' == 'True' ">nl</_NativeLibraryImportsDirectoryName>
+
+	<_LibraryProjectImportsDirectoryName Condition=" '$(_LibraryProjectImportsDirectoryName)'==''">library_project_imports</_LibraryProjectImportsDirectoryName>
+	<_NativeLibraryImportsDirectoryName Condition=" '$(_NativeLibraryImportsDirectoryName)'==''">native_library_imports</_NativeLibraryImportsDirectoryName>
 	<_AndroidResourcePathsCache>$(IntermediateOutputPath)resourcepaths.cache</_AndroidResourcePathsCache>
 	<_AndroidLibraryImportsCache>$(IntermediateOutputPath)libraryimports.cache</_AndroidLibraryImportsCache>
 	<_AndroidLibraryProjectImportsCache>$(IntermediateOutputPath)libraryprojectimports.cache</_AndroidLibraryProjectImportsCache>
-	
+	<_AndroidLibrayProjectIntermediatePath Condition=" '$(_AndroidLibrayProjectIntermediatePath)' == '' And '$(UseShortFileNames)' == 'True' ">$(IntermediateOutputPath)lp\</_AndroidLibrayProjectIntermediatePath>
+	<_AndroidLibrayProjectIntermediatePath Condition=" '$(_AndroidLibrayProjectIntermediatePath)' == '' ">$(IntermediateOutputPath)__library_projects__\</_AndroidLibrayProjectIntermediatePath>
+	<_AndroidLibrayProjectAssemblyMapFile>$(_AndroidLibrayProjectIntermediatePath)map.cache</_AndroidLibrayProjectAssemblyMapFile>
+		
 	<!-- $(EnableProguard) is an obsolete property that should be removed at some stage. -->
 	<AndroidEnableProguard Condition="'$(AndroidEnableProguard)'==''">$(EnableProguard)</AndroidEnableProguard>
 	<AndroidEnableMultiDex Condition="'$(AndroidEnableMultiDex)'==''">False</AndroidEnableMultiDex>
@@ -1077,7 +1077,8 @@ because xbuild doesn't support framework reference assemblies.
 		ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
 		UseShortFileNames="$(UseShortFileNames)"
 		OutputDirectory="$(IntermediateOutputPath)"
-		OutputImportDirectory="$(IntermediateOutputPath)__library_projects__\">
+		AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
+		OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)">
 	</ResolveLibraryProjectImports>
 </Target>
 
@@ -1137,7 +1138,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_BuildLibraryImportsCache"
 		Inputs="$(MSBuildProjectFullPath);@(ReferencePath);@(ReferenceDependencyPaths);$(_AndroidBuildPropertiesCache)"
 		Outputs="$(_AndroidLibraryImportsCache)">
-	<GetImportedLibraries TargetDirectory="$(IntermediateOutputPath)__library_projects__\"
+	<GetImportedLibraries TargetDirectory="$(_AndroidLibrayProjectIntermediatePath)"
 			CacheFile="$(_AndroidLibraryImportsCache)">
 	</GetImportedLibraries>
 </Target>
@@ -1205,7 +1206,7 @@ because xbuild doesn't support framework reference assemblies.
  <!-- Run aapt to generate R.java for additional Android resources-->
  <Aapt
    ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
-   OutputImportDirectory="$(IntermediateOutputPath)__library_projects__\"
+   OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)"
    UseShortFileNames="$(UseShortFileNames)"
    ManifestFiles="@(_AdditonalAndroidResourceCachePaths->'%(Identity)\AndroidManifest.xml')"
    ApplicationName="$(_AndroidPackage)"
@@ -1221,6 +1222,7 @@ because xbuild doesn't support framework reference assemblies.
    ApiLevel="$(_AndroidTargetSdkVersion)"
    AndroidUseLatestPlatformSdk="$(AndroidUseLatestPlatformSdk)"
    ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
+   AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
    YieldDuringToolExecution="$(YieldDuringToolExecution)"
    ExplicitCrunch="$(AndroidExplicitCrunch)"
  />
@@ -1271,7 +1273,7 @@ because xbuild doesn't support framework reference assemblies.
 	<!-- Run aapt to generate R.java -->
 	<Aapt Condition="'$(_AndroidResourceDesignerFile)' != ''"
 		ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
-		OutputImportDirectory="$(IntermediateOutputPath)__library_projects__\"
+		OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)"
 		UseShortFileNames="$(UseShortFileNames)"
 		JavaPlatformJarPath="$(JavaPlatformJarPath)"
 		ManifestFiles="$(ResgenTemporaryDirectory)\AndroidManifest.xml"
@@ -1290,6 +1292,7 @@ because xbuild doesn't support framework reference assemblies.
 		ApiLevel="$(_AndroidTargetSdkVersion)"
 		AndroidUseLatestPlatformSdk="$(AndroidUseLatestPlatformSdk)"
 		ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
+		AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
 		YieldDuringToolExecution="$(YieldDuringToolExecution)"
 		ExplicitCrunch="$(AndroidExplicitCrunch)"
 		SupportedAbis="$(_BuildTargetAbis)"
@@ -1786,7 +1789,7 @@ because xbuild doesn't support framework reference assemblies.
   <!-- Create the base .apk with resources and assets -->
   <Aapt
 	ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
-	OutputImportDirectory="$(IntermediateOutputPath)__library_projects__\"
+	OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)"
 	UseShortFileNames="$(UseShortFileNames)"
     JavaPlatformJarPath="$(JavaPlatformJarPath)"
     ManifestFiles="$(IntermediateOutputPath)android\AndroidManifest.xml"
@@ -1806,6 +1809,7 @@ because xbuild doesn't support framework reference assemblies.
     ApiLevel="$(_AndroidTargetSdkVersion)"
     AndroidUseLatestPlatformSdk="$(AndroidUseLatestPlatformSdk)"
 	ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
+    AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
     SupportedAbis="$(_BuildTargetAbis)"
     CreatePackagePerAbi="$(AndroidCreatePackagePerAbi)"
     YieldDuringToolExecution="$(YieldDuringToolExecution)"
@@ -2417,6 +2421,7 @@ because xbuild doesn't support framework reference assemblies.
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)aidl" Condition="Exists ('$(MonoAndroidIntermediate)aidl')" />
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)bundles" Condition="Exists ('$(MonoAndroidIntermediate)bundles')" />
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)__library_projects__" Condition="Exists ('$(MonoAndroidIntermediate)__library_projects__')" />
+	<RemoveDirFixed Directories="$(_AndroidLibrayProjectIntermediatePath)" Condition="Exists ('$(_AndroidLibrayProjectIntermediatePath)')" />
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)$(_LibraryProjectImportsDirectoryName)" Condition="Exists ('$(MonoAndroidIntermediate)$(_LibraryProjectImportsDirectoryName)')" />
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)$(_NativeLibraryImportsDirectoryName)" Condition="Exists ('$(MonoAndroidIntermediate)$(_NativeLibraryImportsDirectoryName)')" />
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)assets" Condition="Exists ('$(MonoAndroidIntermediate)assets')" />
@@ -2445,6 +2450,7 @@ because xbuild doesn't support framework reference assemblies.
 	<Delete Files="$(_AndroidLibraryImportsCache)" />
 	<Delete Files="$(_AndroidStaticResourcesFlag)" />
 	<Delete Files="$(_AndroidLibraryProjectImportsCache)" />
+	<Delete Files="$(_AndroidLibrayProjectAssemblyMapFile)" />
 </Target>
 
 <Target Name="_CollectMonoAndroidOutputs" DependsOnTargets="_ValidateAndroidPackageProperties">


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=30147

Windows (still) has a max path limit of 260 characters..
This can cause us a problem if the user creates a project in
a directory which already takes up most of that limit.. Like on
their Desktop!

This is because of the intermediate structure that was introduced
to handle embedding resources into the assemblies. The current
intermediate structure is as follows

	`$(IntermediateOutputPath)\__library_project_imports__\$(AssemblyName)\library_project_imports\`
	`$(IntermediateOutputPath)\__library_project_imports__\$(AssemblyName)\native_library_imports\`

Now consider that `$(AssemblyName)` can sometimes end up with something lile
"Xamarin.Android.Support.v7.AppCompat.21.0.3.0" you can easily see how we
start getting into trouble.

There was an attempt to fix this up a while ago (722dcc05) by introducing the
`$(UseShortFileNames)` property. However while this did introduce a
directory structure which was shorter is broke backwards compatability
with older versions of xamarin-android.

This is because of the structore of the zip files we that are embedded
into the assemblies. The current system just extracts the zip into
the `$(IntermediateOutputPath)\__library_project_imports__\$(AssemblyName)\`
directory and assumes that it contains a `library_project_imports` directory.

All the build tasks also assumed that as well.

So the fix needs to be done on a number of fronts. Firstly we need to
update the `$(_LibraryProjectImportsDirectoryName)` and
`$(_NativeLibraryImportsDirectoryName)` to be something shorter.
Next up we need to shorten "__library_project_imports__" to something
else verbose as well. This should cut down on the amount of the MAX_PATH
we chew up.

The real key to this is to NOT change the structure of the zip files in the
assemblies! So when we generate a zip from "jlibs" we make sure that the
folder in the zip is called "library_project_imports". And when we extract
the zip file we makle sure that "library_project_imports" is replaced by
the shorter name.
This will ensure that we are backward compatbile with older versions BUT
more importantly we get to use the shorter directory structure.
The files for native librarys are not extracted to disk but are extracted
from memory so as long as the structure remains the same i.e "native_library_imports"
that code does not need to change.

The other thing we need to do is to update ResolveLibraryProjectImports Task to
upgrade the system when it runs. So if we already have a "libraryprojectimports.cache"
in place we just use that as is. But if we re-run the ResolveLibraryProjectImports
task (due to a change or a clean build) we detect if we have the older structure in place
and just remove it.. Since we are going to regenerate the entire cache again anyway
we might as well start from scratch.

With this in place it becomes possible we can now enable `$(UseShortFileNames)`
by default!

So the new structure that is created is as follows

	`$(IntermediateOutputPath)\lp\<id>\jl`
	`$(IntermediateOutputPath)\lp\<id>\nl`

The <id> will be a single integer value which can be mapped to the source
assembly via a new map.cache file. This .cache file will contain a list of
assemblys. We use the `Index` of the assembly in the list to figure out
which cache directory to use.

	UnnamedProject
	Library1

In this case `Library1` would have an index of `1` and `UnnamedProject` will
be `0`. The old behaviour can be enabled by setting
`$(UseShortFileNames)` to `False`.

Note in order to keep existing bindings generator behaviour consistent,
the BindingsGenerator task will not use the `$(UseShortFileNames)`
property to control how it generates its .cs files. Instead a new
property

	`$(UseShortGeneratorFileNames)`

which can be used to control if the generator produces short names
(e.g 1.cs, 2.cs). This will be `False` by default.