### PR TITLE
_UpdateAndroidResgen constantly being called

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -778,5 +778,77 @@ namespace UnnamedProject
 					"Theme.xml was NOT removed from the intermediate directory");
 			}
 		}
+
+		[Test]
+		public void CheckDontUpdateResourceIfNotNeeded ()
+		{
+			var path = Path.Combine ("temp", "CheckDontUpdateResourceIfNotNeeded");
+			var foo = new BuildItem.Source ("Foo.cs") {
+				TextContent = () => @"using System;
+namespace Lib1 {
+	public class Foo {
+		public string GetFoo () {
+			return ""Foo"";
+		}
+	}
+}"
+			};
+			var theme = new AndroidItem.AndroidResource ("Resources\\values\\Theme.xml") {
+				TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
+<resources>
+	<color name=""theme_devicedefault_background"">#ffffffff</color>
+</resources>", 
+			};
+			var libProj = new XamarinAndroidLibraryProject () {
+				IsRelease = true,
+				ProjectName = "Lib1",
+				Sources = {
+					foo,
+				},
+				AndroidResources = {
+					theme,
+				},
+			};
+			var appProj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				ProjectName = "App1",
+				References = {
+					new BuildItem.ProjectReference (@"..\Lib1\Lib1.csproj", libProj.ProjectName, libProj.ProjectGuid),
+				},
+			};
+			using (var libBuilder = CreateDllBuilder (Path.Combine (path, libProj.ProjectName), false, false)) {
+				libBuilder.Verbosity = LoggerVerbosity.Diagnostic;
+				Assert.IsTrue (libBuilder.Build (libProj), "Library project should have built");
+				using (var appBuilder = CreateApkBuilder (Path.Combine (path, appProj.ProjectName), false, false)) {
+					appBuilder.Verbosity = LoggerVerbosity.Diagnostic;
+					Assert.IsTrue (appBuilder.Build (appProj), "Application Build should have succeeded.");
+					Assert.IsFalse (appBuilder.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "_UpdateAndroidResgen target not should be skipped.");
+					foo.Timestamp = DateTime.UtcNow;
+					Assert.IsTrue (libBuilder.Build (libProj, doNotCleanupOnUpdate: true, saveProject: false), "Library project should have built");
+					Assert.IsTrue (libBuilder.Output.IsTargetSkipped ("_AddLibraryProjectsEmbeddedResourceToProject"), "_AddLibraryProjectsEmbeddedResourceToProject should be skipped.");
+					Assert.IsTrue (appBuilder.Build (appProj, doNotCleanupOnUpdate: true, saveProject: false), "Application Build should have succeeded.");
+					Assert.IsTrue (appBuilder.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "_UpdateAndroidResgen target should be skipped.");
+					theme.TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
+<resources>
+	<color name=""theme_devicedefault_background"">#00000000</color>
+	<color name=""theme_devicedefault_background2"">#ffffffff</color>
+</resources>";
+					theme.Timestamp = DateTime.UtcNow;
+					Assert.IsTrue (libBuilder.Build (libProj, doNotCleanupOnUpdate: true, saveProject: false), "Library project should have built");
+					Assert.IsFalse (libBuilder.Output.IsTargetSkipped ("_AddLibraryProjectsEmbeddedResourceToProject"), "_AddLibraryProjectsEmbeddedResourceToProject should not be skipped.");
+					Assert.IsTrue (appBuilder.Build (appProj, doNotCleanupOnUpdate: true, saveProject: false), "Application Build should have succeeded.");
+					string text = File.ReadAllText (Path.Combine (Root, path, appProj.ProjectName, "Resources", "Resource.designer.cs"));
+					Assert.IsTrue (text.Contains ("theme_devicedefault_background2"), "Resource.designer.cs was not updated.");
+					Assert.IsFalse (appBuilder.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "_UpdateAndroidResgen target should NOT be skipped.");
+					theme.Deleted = true;
+					theme.Timestamp = DateTime.UtcNow;
+					Assert.IsTrue (libBuilder.Build (libProj, saveProject: true), "Library project should have built");
+					var themeFile = Path.Combine (Root, path, libProj.ProjectName, libProj.IntermediateOutputPath, "res", "values", "theme.xml");
+					Assert.IsTrue (!File.Exists (themeFile), $"{themeFile} should have been deleted.");
+					var archive = Path.Combine (Root, path, libProj.ProjectName, libProj.IntermediateOutputPath, "__AndroidLibraryProjects__.zip");
+					Assert.IsNull (ZipHelper.ReadFileFromZip (archive, "res/values/theme.xml"), "res/values/theme.xml should have been removed from __AndroidLibraryProjects__.zip");
+				}
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1045,7 +1045,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_GenerateAndroidResourceDir"
-	Inputs="$(MSBuildAllProjects);@(AndroidResource);$(_AndroidBuildPropertiesCache)"
+	Inputs="$(MSBuildProjectFullPath);$(MSBuildAllProjects);@(AndroidResource);$(_AndroidBuildPropertiesCache)"
 	Outputs="@(_AndroidResourceDest)"
 	DependsOnTargets="$(_OnResolveMonoAndroidSdks)">
 	<CopyAndConvertResources SourceFiles="@(AndroidResource)"
@@ -1062,7 +1062,9 @@ because xbuild doesn't support framework reference assemblies.
 		SkipUnchangedFiles="true"
 		Condition=" '$(AndroidExplicitCrunch)' != 'True' Or '$(AndroidApplication)' == '' Or !($(AndroidApplication))"
 	/>
-	<RemoveUnknownFiles Files="@(_AndroidResourceDest)" Directory="$(MonoAndroidResDirIntermediate)" RemoveDirectories="true" />
+	<RemoveUnknownFiles Files="@(_AndroidResourceDest)" Directory="$(MonoAndroidResDirIntermediate)" RemoveDirectories="true">
+		<Output ItemName="_AndroidResourceDestRemovedFiles" TaskParameter="RemovedFiles" />
+	</RemoveUnknownFiles>
 	<Touch Files="@(_AndroidResourceDest)"
 		Condition=" '$(AndroidExplicitCrunch)' != 'True' Or '$(AndroidApplication)' == '' Or !($(AndroidApplication))"
 	/>
@@ -1240,10 +1242,16 @@ because xbuild doesn't support framework reference assemblies.
 		_GenerateAndroidResourceDir;
 		_DefineBuildTargetAbis;
 	</_UpdateAndroidResgenDependsOnTargets>
+	<_UpdateAndroidResgenInputs>
+		$(MSBuildAllProjects);
+		@(_AndroidResourceDest);
+		@(_LibraryResourceDirectoryStamps);
+		@(_AdditonalAndroidResourceCachePaths->'%(Identity)\cache.stamp')
+	</_UpdateAndroidResgenInputs>
 </PropertyGroup>
 
 <Target Name="_UpdateAndroidResgen"
-	Inputs="$(MSBuildAllProjects);@(ReferencePath);@(ReferenceDependencyPaths);@(_AndroidResourceDest)"
+	Inputs="$(_UpdateAndroidResgenInputs)"
 	Outputs="$(_AndroidResgenFlagFile)"
 	DependsOnTargets="$(_UpdateAndroidResgenDependsOnTargets)">
 
@@ -1347,7 +1355,12 @@ because xbuild doesn't support framework reference assemblies.
 		AndroidResgenFlagFile="$(_AndroidResgenFlagFile)" />
 </Target>
 
-<Target Name="_AddLibraryProjectsEmbeddedResourceToProject">
+<Target Name="_AddLibraryProjectsEmbeddedResourceToProject"
+		Inputs="@(_AndroidResourceDest);@(AndroidAsset);@(AndroidJavaLibrary);@(AndroidJavaSource);@(_AndroidResourceDestRemovedFiles)"
+		Outputs="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip"
+		Condition=" '$(AndroidApplication)' != 'True' "
+	>
+
 	<!-- embed managed resources into dll as a zip archive, like AndroidLibraryProjectZip -->
 	<CreateManagedLibraryResourceArchive
 		OutputDirectory="$(IntermediateOutputPath)$(_LibraryProjectImportsDirectoryName)"
@@ -1358,6 +1371,7 @@ because xbuild doesn't support framework reference assemblies.
 		AndroidJavaLibraries="@(AndroidJavaLibrary)"
 		IsApplication="$(AndroidApplication)"
 		AndroidResourcesInThisExactProject="@(_AndroidResourceDest)"
+		RemovedAndroidResourceFiles="@(_AndroidResourceDestRemovedFiles)"
 	/>
 	<CreateItem
 		Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip"


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=58169

We have a bit of a problem with the way we deal with embedding
resources (i.e AndroidResource) into an Android dll.
The process usually goes as follows

1) Collect all the resources into an intermediate directory
	`%(IntermediateOutputPath)__libray_project_imports__`
2) Create a zip file which contains all of those files
3) Embed that zip into the assembly when we compile.

This seems logical until you look at it from a repeat build
point of view. The senario is that a user changes some C# code
in the android dll. The build process currently does steps
1,2 for ALL changes. So we create a new zip and add that to
the dll. The result of which is as far as the application build
process is concerned its a new zip.. with new files. So we end up
running `_AddLibraryProjectsEmbeddedResourceToProject` and then
in turn `_UpdateAndroidResgen` which then in turn will probably
result in an apk build!

All of that happens even though we NEVER touched the resources, we only
touched the C# code.

So in order to fix this we need to look at things slightly differently.
Instead of creating a new zip each time we build, we should incrementally
update/refresh the one we have in the intermediate directory already.
This means not only just updating files but also REMOVING deleted files
from the existing zip file.

By doing this we can maintain the `ModifiedDate` values in the zip, which
can be used later in the build process to decide if thing were changed or
not.

So to implement this we need to change a few things. Firstly the task
`RemoveUnknownFiles` has been updated to output a new `RemovedFiles`
property. This is a ITaskItem which contains a list of the files that
were removed from the build. Next up `CreateManagedLibraryResourceArchive`
is modified to make use of this new data via the `RemovedAndroidResourceFiles`
property. We use this to delete files from the intermediate directory and
zip file which have been removed from the project.

We also update `CreateManagedLibraryResourceArchive` to make use of the
existing zip rather than creating a new one each time. As well as updating
the `Files.ExtractAll` to allow it to refresh files and remove item from the
zip which we do not expect.

The result of these changes means that changing C# code will result in the
existing zip from the previous build being used for resources. If we do
change a resource then only that item in the zip is refreshed.

These changes then filter down to the `ResolveLibraryProjectImports` task
which is responsible for maintaining the `__library_projects__` directory.
We update this task to make use of the new information available to us in
the zip file to ensure that we only update files which have been changed.
We also only update the .stamp file if we have changed files.

The last piece of the puzzle is to change the `_UpdateAndroidResgen` target
to NOT use the `@(ReferencePath);@(ReferenceDependencyPaths)` ItemGroups
as its inputs. If we leave this as is even if we update the C# code the target
will still run because the dll is newer than the `$(_AndroidResgenFlagFile)`.
So we alter this to use the various stamp files we produce to show the
resources were updated. This means that this task will run only when we have
a change.

A new unit test has been added to test out this entire process and to ensure that
the targets and things that should be updated and removed are.