### PR TITLE
[Xamarin.Android.Build.Tasks] Uninformative ""aapt.exe" exited with code 1." and "The file "obj\Debug\android\bin\packaged_resources" does not exist" errors if drawable resource filename contains invalid character

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -335,7 +335,9 @@ namespace Xamarin.Android.Tasks
 
 			if (match.Success) {
 				var file = match.Groups["file"].Value;
-				var line = int.Parse (match.Groups["line"].Value) + 1;
+				int line = 0;
+				if (!string.IsNullOrEmpty (match.Groups["line"]?.Value))
+					line = int.Parse (match.Groups["line"].Value) + 1;
 				var error = match.Groups["message"].Value;
 
 				// Try to map back to the original resource file, so when the user

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidToolTask.cs
@@ -77,12 +77,13 @@ namespace Xamarin.Android.Tasks
 		//   res\layout\main.axml:7: error: No resource identifier found for attribute 'id2' in package 'android' (TaskId:22)
 		//   Resources/values/theme.xml(2): error APT0000: Error retrieving parent for item: No resource found that matches the given name '@android:style/Theme.AppCompat'.
 		//   Resources/values/theme.xml:2: error APT0000: Error retrieving parent for item: No resource found that matches the given name '@android:style/Theme.AppCompat'.
+		//   res/drawable/foo-bar.jpg: Invalid file name: must contain only [a-z0-9_.]
 		// Look for them and convert them to MSBuild compatible errors.
 		static Regex androidErrorRegex;
 		internal static Regex AndroidErrorRegex {
 			get {
 				if (androidErrorRegex == null)
-					androidErrorRegex = new Regex (@"^(?<file>.+?)(([:(](?<line>\d+)[:)]):?\s*(error)\s*(?<level>\w*(?=:))):?(?<message>.*)", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+					androidErrorRegex = new Regex (@"^(?<file>.+?)([:(](?<line>\d+)[:)])?:+\s*((error)\s*(?<level>\w*(?=:)):?)?(?<message>.*)", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 				return androidErrorRegex;
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -470,6 +470,23 @@ namespace UnnamedProject
 		}
 
 		[Test]
+		public void CheckAaptErrorRaisedForInvalidFileName ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\drawable\\icon-2.png") {
+				BinaryContent = () => XamarinAndroidCommonProject.icon_binary_hdpi,
+			});
+			var projectPath = string.Format ("temp/CheckAaptErrorRaisedForInvalidDirectoryName");
+			using (var b = CreateApkBuilder (Path.Combine (projectPath, "UnamedApp"), false, false)) {
+				b.Verbosity = LoggerVerbosity.Diagnostic;
+				b.ThrowOnBuildFailure = false;
+				Assert.IsFalse (b.Build (proj), "Build should have failed");
+				StringAssert.Contains ("Invalid file name:", b.LastBuildOutput);
+				StringAssert.Contains ("1 Error(s)", b.LastBuildOutput);
+			}
+		}
+
+		[Test]
 		public void CheckAaptErrorRaisedForDuplicateResourceinApp ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -487,7 +504,7 @@ namespace UnnamedProject
 				b.ThrowOnBuildFailure = false;
 				Assert.IsFalse (b.Build (proj), "Build should have failed");
 				StringAssert.Contains ("APT0000: ", b.LastBuildOutput);
-				StringAssert.Contains ("1 Error(s)", b.LastBuildOutput);
+				StringAssert.Contains ("2 Error(s)", b.LastBuildOutput);
 			}
 		}
 


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=36485

Under some conditions apps produces an error which does NOT
contain "error <something>:". As a result our regex was not picking
up some errors and was just printing the default error of

	"aapt.exe" exited with code 1

This commit updates the regex to allow for errors which do
not include "error <something>:". And adds a unit test for the
specific test case.