### PR TITLE
[structure] Rework installation directory structure

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -20,6 +20,7 @@
   <PropertyGroup>
     <AutoProvision Condition=" '$(AutoProvision)' == '' ">False</AutoProvision>
     <AutoProvisionUsesSudo Condition=" '$(AutoProvisionUsesSudo)' == '' ">False</AutoProvisionUsesSudo>
+    <XAInstallPrefix Condition=" '$(XAInstallPrefix)' == '' ">$(MSBuildThisFileDirectory)\bin\$(Configuration)\lib\xamarin.android\</XAInstallPrefix>
     <HostOS Condition=" '$(HostOS)' == '' And '$(OS)' == 'Windows_NT' ">Windows</HostOS>
     <HostCc Condition=" '$(HostCc)' == '' ">$(HostCc64)</HostCc>
     <HostCxx Condition=" '$(HostCxx)' == '' ">$(HostCxx64)</HostCxx>

--- a/Documentation/DevelopmentTips.md
+++ b/Documentation/DevelopmentTips.md
@@ -45,7 +45,7 @@ For example, to rebuild Mono for armeabi-v7a:
 
 	$ make -C build-tools/mono-runtimes/obj/Debug/armeabi-v7a
 	
-	# This updates bin/$(Configuration)/lib/xbuild/Xamarin/Android/lib/armeabi-v7a/libmonosgen-2.0.so
+	# This updates bin/$(Configuration)/lib/xamarin.android/xbuild/Xamarin/Android/lib/armeabi-v7a/libmonosgen-2.0.so
 	$ xbuild /t:_InstallRuntimes build-tools/mono-runtimes/mono-runtimes.mdproj
 
 # How do I rebuild BCL assemblies?
@@ -65,7 +65,7 @@ varies based on the operating system you're building from:
 Once the assemblies have been rebuilt, they can be copied into the appropriate
 Xamarin.Android SDK directory by using the `_InstallBcl` target:
 
-	# This updates bin/$(Configuration)/lib/xbuild-frameworks/MonoAndroid/v1.0/ASSEMBLY.dll
+	# This updates bin/$(Configuration)/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v1.0/ASSEMBLY.dll
 	$ xbuild build-tools/mono-runtimes/mono-runtimes.mdproj /t:_InstallBcl
 
 # Update Directory

--- a/Documentation/UsingJenkinsBuildArtifacts.md
+++ b/Documentation/UsingJenkinsBuildArtifacts.md
@@ -156,9 +156,9 @@ For example (using the paths from [Android SDK Setup](#Android_SDK_Setup)):
 
 	msbuild /p:AndroidSdkDirectory="C:\xa-sdk\android-sdk" ^
 		/p:AndroidNdkDirectory="C:\xa-sdk\android-ndk\android-ndk-r14" ^
-		/p:MonoAndroidBinDirectory="C:\xa-sdk\oss-xamarin.android_v7.2.99.19_Darwin-x86_64_master_3b893cd\bin\Debug\lib\xbuild\Xamarin\Android" ^
-		/p:MonoAndroidToolsDirectory="C:\xa-sdk\oss-xamarin.android_v7.2.99.19_Darwin-x86_64_master_3b893cd\bin\Debug\lib\xbuild\Xamarin\Android" ^
-		/p:TargetFrameworkRootPath="C:\xa-sdk\oss-xamarin.android_v7.2.99.19_Darwin-x86_64_master_3b893cd\bin\Debug\lib\xbuild-frameworks" ^
+		/p:MonoAndroidBinDirectory="C:\xa-sdk\oss-xamarin.android_v7.2.99.19_Darwin-x86_64_master_3b893cd\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android" ^
+		/p:MonoAndroidToolsDirectory="C:\xa-sdk\oss-xamarin.android_v7.2.99.19_Darwin-x86_64_master_3b893cd\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android" ^
+		/p:TargetFrameworkRootPath="C:\xa-sdk\oss-xamarin.android_v7.2.99.19_Darwin-x86_64_master_3b893cd\bin\Debug\lib\xamarin.android\xbuild-frameworks" ^
 		/t:SignAndroidPackage ^
 		samples\HelloWorld\HelloWorld.csproj
 

--- a/Makefile
+++ b/Makefile
@@ -32,15 +32,16 @@ install::
 		echo "run 'make all' before you execute 'make install'!"; \
 		exit 1; \
 	fi
+	-mkdir -p "$(prefix)/bin"
 	-mkdir -p "$(prefix)/lib/mono/xbuild-frameworks"
 	-mkdir -p "$(prefix)/lib/xamarin.android"
 	-mkdir -p "$(prefix)/lib/mono/xbuild/Xamarin/"
-	cp -a "bin/$(CONFIGURATION)/." "$(prefix)/lib/xamarin.android/"
+	cp -a "bin/$(CONFIGURATION)/lib/xamarin.android/." "$(prefix)/lib/xamarin.android/"
 	cp tools/scripts/xabuild "$(prefix)/bin/xabuild"
 	-rm -rf "$(prefix)/lib/mono/xbuild/Xamarin/Android"
 	-rm -rf "$(prefix)/lib/mono/xbuild-frameworks/MonoAndroid"
-	ln -s "$(prefix)/lib/xamarin.android/lib/xbuild/Xamarin/Android/" "$(prefix)/lib/mono/xbuild/Xamarin/Android"
-	ln -s "$(prefix)/lib/xamarin.android/lib/xbuild-frameworks/MonoAndroid/" "$(prefix)/lib/mono/xbuild-frameworks/MonoAndroid"
+	ln -s "$(prefix)/lib/xamarin.android/xbuild/Xamarin/Android/" "$(prefix)/lib/mono/xbuild/Xamarin/Android"
+	ln -s "$(prefix)/lib/xamarin.android/xbuild-frameworks/MonoAndroid/" "$(prefix)/lib/mono/xbuild-frameworks/MonoAndroid"
 
 uninstall::
 	rm -rf "$(prefix)/lib/xamarin.android/" "$(prefix)/bin/xabuild"
@@ -90,7 +91,7 @@ prepare-external: prepare-deps
 	(cd $(call GetPath,JavaInterop) && make bin/BuildDebug/JdkInfo.props)
 
 prepare-props: prepare-external
-	cp Configuration.Java.Interop.Override.props external/Java.Interop/Configuration.Override.props
+	cp build-tools/scripts/Configuration.Java.Interop.Override.props external/Java.Interop/Configuration.Override.props
 	cp $(call GetPath,MonoSource)/mcs/class/msfinal.pub .
 
 prepare-msbuild: prepare-props

--- a/README.md
+++ b/README.md
@@ -320,13 +320,13 @@ The `bin\$(Configuration)` directory, e.g. `bin\Debug`, contains
 acts as a *local installation prefix*, in which the directory structure
 mirrors that of the OS X Xamarin.Android.framework directory structure:
 
-* `bin\$(Configuration)\lib\xbuild\Xamarin\Android`: MSBuild-related support
+* `bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android`: MSBuild-related support
     files and required runtimes used by the MSBuild tooling.
-* `bin\$(Configuration)\lib\xbuild-frameworks\MonoAndroid`: Xamarin.Android
+* `bin\$(Configuration)\lib\xamarin.android\xbuild-frameworks\MonoAndroid`: Xamarin.Android
     profiles.
-* `bin\$(Configuration)\lib\xbuild-frameworks\MonoAndroid\v1.0`: Xamarin.Android
+* `bin\$(Configuration)\lib\xamarin.android\xbuild-frameworks\MonoAndroid\v1.0`: Xamarin.Android
     Base Class Library assemblies such as `mscorlib.dll`.
-* `bin\$(Configuration)\lib\xbuild-frameworks\MonoAndroid\*`: Contains
+* `bin\$(Configuration)\lib\xamarin.android\xbuild-frameworks\MonoAndroid\*`: Contains
     `Mono.Android.dll` for a given Xamarin.Android `$(TargetFrameworkVersion)`.
 
 # Xamarin.Android `$(TargetFrameworkVersion)`s
@@ -354,7 +354,7 @@ For example, to generate `Mono.Android.dll` for API-19 (Android 4.4):
 
     cd src/Mono.Android
     xbuild /p:AndroidApiLevel=19 /p:AndroidFrameworkVersion=v4.4
-    # creates bin\Debug\lib\xbuild-frameworks\MonoAndroid\v4.4\Mono.Android.dll
+    # creates bin\Debug\lib\xamarin.android\xbuild-frameworks\MonoAndroid\v4.4\Mono.Android.dll
 
 <a name="Samples" />
 

--- a/build-tools/api-xml-adjuster/Makefile
+++ b/build-tools/api-xml-adjuster/Makefile
@@ -6,7 +6,7 @@ ANDROID_SDK_PATH=$(shell find ~/ -maxdepth 1 -name android-sdk-*)
 
 DOCS_DIR=~/android-toolchain/docs
 
-MANDROID = ../../bin/$(CONFIGURATION)/lib/mandroid
+MANDROID = ../../bin/$(CONFIGURATION)/lib/xamarin.anroid/xbuild/Xamarin/Android
 BUILDBIN = ../../bin/Build$(CONFIGURATION)
 
 CLASS_PARSE = $(MANDROID)/class-parse.exe
@@ -62,7 +62,7 @@ $(ANALYZED_XML): $(API_XML_TOOL) $(CLASS_PARSE_XML)
 	$(RUN_API_XML_TOOL) $(CLASS_PARSE_XML) $(ANALYZED_XML) || rm -f $(ANALYZED_XML)
 
 $(CLASS_PARSE):
-	cd $(JAVA_INTEROP_PATH)/tools/class-parse && $(XBUILD) /p:OutputPath=$(TOP)/out/lib/mandroid
+	cd $(JAVA_INTEROP_PATH)/tools/class-parse && $(XBUILD) /p:OutputPath=$(TOP)/out/lib/xamarin.android/xbuild/Xamarin.Android/
 
 $(API_XML_TOOL):
 	$(XBUILD)

--- a/build-tools/bundle/bundle-path.targets
+++ b/build-tools/bundle/bundle-path.targets
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.GitCommitHash" />
+  <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.HashFileContents" />
   <Target Name="_GetHashes">
     <GitCommitHash
         WorkingDirectory="$(LibZipSourceFullPath)"
@@ -20,11 +21,19 @@
         ToolExe="$(GitToolExe)">
       <Output TaskParameter="AbbreviatedCommitHash"   PropertyName="_MonoHash" />
     </GitCommitHash>
+    <!-- Files which contribute to the bundle "version" -->
+    <ItemGroup>
+      <VersionFile Include="..\mono-runtimes\mono-runtimes.*" />
+    </ItemGroup>
+    <HashFileContents
+        Files="@(VersionFile)">
+      <Output TaskParameter="AbbreviatedCompleteHash" PropertyName="_VersionHash"/>
+    </HashFileContents>
   </Target>
   <Target Name="GetBundleFileName"
       DependsOnTargets="_GetHashes">
     <PropertyGroup>
-      <XABundleFileName>bundle-v18-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
+      <XABundleFileName>bundle-v19-h$(_VersionHash)-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
     </PropertyGroup>
   </Target>
 </Project>

--- a/build-tools/bundle/bundle.targets
+++ b/build-tools/bundle/bundle.targets
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask AssemblyFile="$(_SourceTopDir)\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.Zip" />
-  <Import Project="..\mono-runtimes\mono-runtimes.props" />
-  <Import Project="..\mono-runtimes\mono-runtimes.projitems" />
   <Import Project="..\mono-runtimes\mono-runtimes.targets" />
   <Import Project="..\libzip\libzip.props" />
   <Import Project="..\libzip-windows\libzip-windows.props" />

--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -9,7 +9,7 @@
       $(PrepareForBuildDependsOn);
       AddContent
     </PrepareForBuildDependsOn>
-    <LibDir>..\..\bin\$(Configuration)\lib\</LibDir>
+    <LibDir>..\..\bin\$(Configuration)\lib\xamarin.android\</LibDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <MSBuild>
@@ -36,16 +36,17 @@
       </MSBuild>
       <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\lib\host-Darwin\**\*.*" />
       <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\lib\host-Linux\**\*.*" />
+      <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\Darwin\**\*.*" />
+      <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\Linux\**\*.*" />
       <MSBuild Include="..\..\src\Xamarin.Android.Build.Tasks\MSBuild\Xamarin\**\*.*" />
       <MSBuild>
         <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Xamarin/%(RecursiveDir)</VSIXSubPath>
       </MSBuild>
-      <MSBuild Include="..\..\bin\$(Configuration)\lib\mandroid\**\*.*" />
-      <MSBuild Remove="..\..\bin\$(Configuration)\lib\mandroid\**\*.d.exe" />
       <MSBuild>
         <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Xamarin/Android/%(RecursiveDir)</VSIXSubPath>
       </MSBuild>
       <MSBuild Remove="$(LibDir)xbuild\**\*.d.dll" />
+      <MSBuild Remove="$(LibDir)xbuild\**\*.d.exe" />
       <ReferenceAssemblies Include="$(LibDir)xbuild-frameworks\**\*.*" />
       <ReferenceAssemblies>
         <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Microsoft/Framework/%(RecursiveDir)</VSIXSubPath>

--- a/build-tools/libzip-windows/libzip-windows.mdproj
+++ b/build-tools/libzip-windows/libzip-windows.mdproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>..\..\bin\$(Configuration)</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>..\..\bin\$(Configuration)</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
   <PropertyGroup>
@@ -24,6 +24,7 @@
   <Import Project="libzip-windows.props" />
   <Import Project="libzip-windows.projitems" />
   <Import Project="libzip-windows.targets" />
+  <Import Project="..\libzip\libzip.targets" />
   <ItemGroup>
     <ProjectReference Include="..\android-toolchain\android-toolchain.mdproj">
       <Project>{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA}</Project>

--- a/build-tools/libzip-windows/libzip-windows.targets
+++ b/build-tools/libzip-windows/libzip-windows.targets
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\libzip\libzip.targets" />
 </Project>

--- a/build-tools/libzip/libzip.mdproj
+++ b/build-tools/libzip/libzip.mdproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>..\..\bin\$(Configuration)</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>..\..\bin\$(Configuration)</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
   <PropertyGroup>

--- a/build-tools/libzip/libzip.targets
+++ b/build-tools/libzip/libzip.targets
@@ -8,6 +8,7 @@
       _Configure;
       _Make
     </ForceBuildDependsOn>
+    <_LibZipOutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</_LibZipOutputPath>
   </PropertyGroup>
   <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
   <Target Name="Clean" />
@@ -29,7 +30,7 @@
     />
   </Target>
   <ItemGroup>
-    <Content Include="@(_LibZipTarget->'$(OutputPath)\lib\xbuild\Xamarin\Android\%(OutputLibrary)')">
+    <Content Include="@(_LibZipTarget->'$(_LibZipOutputPath)%(OutputLibrary)')">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
@@ -43,7 +44,7 @@
      /> 
     <Copy
         SourceFiles="@(_LibZipTarget->'$(IntermediateOutputPath)\%(Identity)\%(OutputLibraryPath)')"
-        DestinationFiles="@(_LibZipTarget->'$(OutputPath)\lib\xbuild\Xamarin\Android\%(OutputLibrary)')"
+        DestinationFiles="@(_LibZipTarget->'$(_LibZipOutputPath)%(OutputLibrary)')"
     />
     <Touch Files="@(Content)" />
   </Target>
@@ -73,6 +74,6 @@
   <Target Name="_CleanBinaries"
       AfterTargets="Clean">
     <RemoveDir Directories="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)" />
-    <Delete Files="@(_LibZipTarget->'$(OutputPath)\lib\xbuild\Xamarin\Android\%(OutputLibrary)')" />
+    <Delete Files="@(_LibZipTarget->'$(_LibZipOutputPath)%(OutputLibrary)')" />
   </Target>
 </Project>

--- a/build-tools/mono-runtimes/mono-runtimes.mdproj
+++ b/build-tools/mono-runtimes/mono-runtimes.mdproj
@@ -6,11 +6,12 @@
     <ItemType>GenericProject</ItemType>
     <ProjectGuid>{C03E6CF1-7460-4CDC-A4AB-292BBC0F61F2}</ProjectGuid>
   </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>..\..\bin\Debug</OutputPath>
+    <OutputPath>$(XAInstallPrefix)</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>..\..\bin\Release</OutputPath>
+    <OutputPath>$(XAInstallPrefix)</OutputPath>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
   <PropertyGroup>

--- a/build-tools/mono-runtimes/mono-runtimes.projitems
+++ b/build-tools/mono-runtimes/mono-runtimes.projitems
@@ -260,7 +260,8 @@
       <BuildEnvironment></BuildEnvironment>
       <ExeSuffix></ExeSuffix>
       <InstallBinaries>true</InstallBinaries>
-      <InstallPath>bin/</InstallPath>
+      <InstallPath Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">Darwin/</InstallPath>
+      <InstallPath Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:'))">Linux/</InstallPath>
     </_LlvmRuntime>
 
     <_LlvmRuntime Include="llvm64" Condition=" '$(_LlvmNeeded)' != '' And '$(_LlvmCanBuild64)' == 'yes' ">
@@ -271,7 +272,8 @@
       <BuildEnvironment></BuildEnvironment>
       <ExeSuffix></ExeSuffix>
       <InstallBinaries>true</InstallBinaries>
-      <InstallPath>bin/</InstallPath>
+      <InstallPath Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">Darwin/</InstallPath>
+      <InstallPath Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:'))">Linux/</InstallPath>
     </_LlvmRuntime>
 
     <_LlvmRuntime Include="llvmwin32" Condition=" '$(_LlvmNeeded)' != '' And ($(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':linux-Win32:'))) ">
@@ -282,7 +284,7 @@
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ExeSuffix>.exe</ExeSuffix>
       <InstallBinaries>true</InstallBinaries>
-      <InstallPath>lib/mandroid/</InstallPath>
+      <InstallPath></InstallPath>
     </_LlvmRuntime>
 
     <_LlvmRuntime Include="llvmwin64" Condition=" '$(_LlvmNeeded)' != '' And ($(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':linux-Win64:'))) ">
@@ -293,7 +295,7 @@
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ExeSuffix>.exe</ExeSuffix>
       <InstallBinaries>false</InstallBinaries>
-      <InstallPath>lib/mandroid/</InstallPath>
+      <InstallPath></InstallPath>
     </_LlvmRuntime>
   </ItemGroup>
 
@@ -318,7 +320,8 @@
       <ExeSuffix></ExeSuffix>
       <BuildEnvironment></BuildEnvironment>
       <ConfigureEnvironment></ConfigureEnvironment>
-      <InstallPath>bin/</InstallPath>
+      <InstallPath Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">Darwin/</InstallPath>
+      <InstallPath Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:'))">Linux/</InstallPath>
       <CrossMonoName>cross-arm</CrossMonoName>
     </_MonoCrossRuntime>
 
@@ -341,7 +344,8 @@
       <ExeSuffix></ExeSuffix>
       <BuildEnvironment></BuildEnvironment>
       <ConfigureEnvironment></ConfigureEnvironment>
-      <InstallPath>bin/</InstallPath>
+      <InstallPath Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">Darwin/</InstallPath>
+      <InstallPath Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:'))">Linux/</InstallPath>
       <CrossMonoName>cross-arm64</CrossMonoName>
     </_MonoCrossRuntime>
 
@@ -364,7 +368,8 @@
       <ExeSuffix></ExeSuffix>
       <BuildEnvironment></BuildEnvironment>
       <ConfigureEnvironment></ConfigureEnvironment>
-      <InstallPath>bin/</InstallPath>
+      <InstallPath Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">Darwin/</InstallPath>
+      <InstallPath Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:'))">Linux/</InstallPath>
       <CrossMonoName>cross-x86</CrossMonoName>
     </_MonoCrossRuntime>
 
@@ -387,7 +392,8 @@
       <ExeSuffix></ExeSuffix>
       <BuildEnvironment></BuildEnvironment>
       <ConfigureEnvironment></ConfigureEnvironment>
-      <InstallPath>bin/</InstallPath>
+      <InstallPath Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">Darwin/</InstallPath>
+      <InstallPath Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:'))">Linux/</InstallPath>
       <CrossMonoName>cross-x86_64</CrossMonoName>
     </_MonoCrossRuntime>
 
@@ -410,7 +416,7 @@
       <ExeSuffix>.exe</ExeSuffix>
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin32)</ConfigureEnvironment>
-      <InstallPath>lib/mandroid/</InstallPath>
+      <InstallPath></InstallPath>
       <CrossMonoName>cross-arm</CrossMonoName>
     </_MonoCrossRuntime>
 
@@ -433,7 +439,7 @@
       <ExeSuffix>.exe</ExeSuffix>
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin64)</ConfigureEnvironment>
-      <InstallPath>lib/mandroid/</InstallPath>
+      <InstallPath></InstallPath>
       <CrossMonoName>cross-arm64</CrossMonoName>
     </_MonoCrossRuntime>
 
@@ -456,7 +462,7 @@
       <ExeSuffix>.exe</ExeSuffix>
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin32)</ConfigureEnvironment>
-      <InstallPath>lib/mandroid/</InstallPath>
+      <InstallPath></InstallPath>
       <CrossMonoName>cross-x86</CrossMonoName>
     </_MonoCrossRuntime>
 
@@ -479,7 +485,7 @@
       <ExeSuffix>.exe</ExeSuffix>
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ConfigureEnvironment>$(_LlvmConfigureEnvironmentWin32)</ConfigureEnvironment>
-      <InstallPath>lib/mandroid/</InstallPath>
+      <InstallPath></InstallPath>
       <CrossMonoName>cross-x86_64</CrossMonoName>
     </_MonoCrossRuntime>
   </ItemGroup>

--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -3,8 +3,9 @@
   <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
   <PropertyGroup>
     <_SourceTopDir>..\..</_SourceTopDir>
-    <_BclFrameworkDir>$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0</_BclFrameworkDir>
-    <_MandroidDir>$(OutputPath)\lib\mandroid</_MandroidDir>
+    <_BclFrameworkDir>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\</_BclFrameworkDir>
+    <_MSBuildDir>$(XAInstallPrefix)xbuild\Xamarin\Android</_MSBuildDir>
+    <_OutputIncludeDir>..\..\bin\$(Configuration)\include\</_OutputIncludeDir>
     <_DebugFileExt Condition=" '$(_DebugFileExt)' == '' ">.pdb</_DebugFileExt>
   </PropertyGroup>
   <ItemGroup>
@@ -25,16 +26,15 @@
     <FSharpItem Include="FSharp.Core.sigdata" />
   </ItemGroup>
   <ItemGroup>
-    <_FSharpInstalledItems Include="@(FSharpItem->'$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0\%(Identity)')" />
+    <_FSharpInstalledItems Include="@(FSharpItem->'$(_BclFrameworkDir)%(Identity)')" />
   </ItemGroup>
   <UsingTask AssemblyFile="$(_SourceTopDir)\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.GetNugetPackageBasePath" />
-  <Import Project="$(_SourceTopDir)\Configuration.props" />
   <ItemGroup>
     <_MonoDocCopyItems Include="@(MonoDocCopyItem->'$(_MonoOutputDir)\%(Identity)')" />
   </ItemGroup>
   <ItemGroup>
-    <_MonoDocInstalledItems Include="@(MonoDocCopyItem->'$(_MandroidDir)\%(Identity)')" />
-    <_MonoDocInstalledItems Include="$(_MandroidDir)\mdoc.exe" />
+    <_MonoDocInstalledItems Include="@(MonoDocCopyItem->'$(_MSBuildDir)\%(Identity)')" />
+    <_MonoDocInstalledItems Include="$(_MSBuildDir)\mdoc.exe" />
   </ItemGroup>
   <PropertyGroup>
     <_MonoProfileDir>$(MonoSourceFullPath)\mcs\class\lib\monodroid</_MonoProfileDir>
@@ -79,16 +79,16 @@
     />
   </ItemGroup>
   <ItemGroup>
-    <_BclInstalledItem Include="@(_BclAssembly->'$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0\%(Identity)')" />
+    <_BclInstalledItem Include="@(_BclAssembly->'$(_BclFrameworkDir)%(Identity)')" />
     <_BclInstalledItem
         Condition=" '$(_DebugFileExt)' == '.mdb' "
-        Include="@(_BclAssembly->'$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0\%(Identity).mdb')"
-        Exclude="@(_BclExcludeDebugSymbols->'$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0\%(Identity).mdb')"
+        Include="@(_BclAssembly->'$(_BclFrameworkDir)%(Identity).mdb')"
+        Exclude="@(_BclExcludeDebugSymbols->'$(_BclFrameworkDir)%(Identity).mdb')"
     />
     <_BclInstalledItem
         Condition=" '$(_DebugFileExt)' == '.pdb' "
-        Include="@(_BclAssembly->'$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0\%(Filename).pdb')"
-        Exclude="@(_BclExcludeDebugSymbols->'$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0\%(Filename).pdb')"
+        Include="@(_BclAssembly->'$(_BclFrameworkDir)%(Filename).pdb')"
+        Exclude="@(_BclExcludeDebugSymbols->'$(_BclFrameworkDir)%(Filename).pdb')"
     />
   </ItemGroup>
   <ItemGroup>
@@ -97,14 +97,14 @@
   </ItemGroup>
   <ItemGroup>
     <_MonoUtilitySource Include="@(_MonoUtility->'$(_MonoOutputDir)\%(Identity)')" />
-    <_MonoUtilityDest   Include="@(_MonoUtility->'$(_MandroidDir)\%(Identity)')" />
+    <_MonoUtilityDest   Include="@(_MonoUtility->'$(_MSBuildDir)\%(Identity)')" />
     <_MonoUtilitySource
         Condition=" '$(_DebugFileExt)' == '.mdb'"
         Include="@(_MonoUtility->'$(_MonoOutputDir)\%(Identity).mdb')"
     />
     <_MonoUtilityDest
         Condition=" '$(_DebugFileExt)' == '.mdb'"
-        Include="@(_MonoUtility->'$(_MandroidDir)\%(Identity).mdb')"
+        Include="@(_MonoUtility->'$(_MSBuildDir)\%(Identity).mdb')"
     />
     <_MonoUtilitySource
         Condition=" '$(_DebugFileExt)' == '.pdb'"
@@ -112,7 +112,7 @@
     />
     <_MonoUtilityDest
         Condition=" '$(_DebugFileExt)' == '.pdb'"
-        Include="@(_MonoUtility->'$(_MandroidDir)\%(Filename).pdb')"
+        Include="@(_MonoUtility->'$(_MSBuildDir)\%(Filename).pdb')"
     />
   </ItemGroup>
   <Target Name="_SetAutogenShTimeToLastCommitTimestamp">
@@ -137,10 +137,10 @@
       <_LlvmArchive Include="$(_LlvmOutputDirTop)\%(_LlvmRuntime.BuildDir)\Release\lib\*.a" />
 
       <_LlvmSourceBinary Include="@(_LlvmRuntime->'$(_LlvmOutputDirTop)\%(BuildDir)\Release\bin\opt%(ExeSuffix)')" Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' " />
-      <_LlvmTargetBinary Include="@(_LlvmRuntime->'$(OutputPath)\%(InstallPath)opt%(ExeSuffix)')" Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' "/>
+      <_LlvmTargetBinary Include="@(_LlvmRuntime->'$(_MSBuildDir)\%(InstallPath)opt%(ExeSuffix)')" Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' "/>
 
       <_LlvmSourceBinary Include="@(_LlvmRuntime->'$(_LlvmOutputDirTop)\%(BuildDir)\Release\bin\llc%(ExeSuffix)')" Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' " />
-      <_LlvmTargetBinary Include="@(_LlvmRuntime->'$(OutputPath)\%(InstallPath)llc%(ExeSuffix)')" Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' " />
+      <_LlvmTargetBinary Include="@(_LlvmRuntime->'$(_MSBuildDir)\%(InstallPath)llc%(ExeSuffix)')" Condition=" '%(_LlvmRuntime.InstallBinaries)' == 'true' " />
     </ItemGroup>
   </Target>
 
@@ -223,11 +223,11 @@
       />
       <_InstallRuntimeOutput
           Condition=" '%(_MonoRuntime.DoBuild)' == 'True' "
-          Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntimeFilename).%(NativeLibraryExtension)')"
+          Include="@(_MonoRuntime->'$(_MSBuildDir)\lib\%(Identity)\%(OutputRuntimeFilename).%(NativeLibraryExtension)')"
       />
       <_InstallUnstrippedRuntimeOutput
           Condition=" '%(_MonoRuntime.DoBuild)' == 'True' "
-          Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputRuntimeFilename).d.%(NativeLibraryExtension)')"
+          Include="@(_MonoRuntime->'$(_MSBuildDir)\lib\%(Identity)\%(OutputRuntimeFilename).d.%(NativeLibraryExtension)')"
       />
       <_ProfilerSource
           Condition=" '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputProfilerFilename)' != '' "
@@ -235,11 +235,11 @@
       />
       <_InstallProfilerOutput
           Condition=" '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputProfilerFilename)' != '' "
-          Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputProfilerFilename).%(NativeLibraryExtension)')"
+          Include="@(_MonoRuntime->'$(_MSBuildDir)\lib\%(Identity)\%(OutputProfilerFilename).%(NativeLibraryExtension)')"
       />
       <_InstallUnstrippedProfilerOutput
           Condition=" '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputProfilerFilename)' != '' "
-          Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputProfilerFilename).d.%(NativeLibraryExtension)')"
+          Include="@(_MonoRuntime->'$(_MSBuildDir)\lib\%(Identity)\%(OutputProfilerFilename).d.%(NativeLibraryExtension)')"
       />
       <_MonoBtlsSource
           Condition=" '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputMonoBtlsFilename)' != '' "
@@ -247,11 +247,11 @@
       />
       <_InstallMonoBtlsOutput
           Condition=" '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputMonoBtlsFilename)' != '' "
-          Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputMonoBtlsFilename).%(NativeLibraryExtension)')"
+          Include="@(_MonoRuntime->'$(_MSBuildDir)\lib\%(Identity)\%(OutputMonoBtlsFilename).%(NativeLibraryExtension)')"
       />
       <_InstallUnstrippedMonoBtlsOutput
           Condition=" '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputMonoBtlsFilename)' != '' "
-          Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputMonoBtlsFilename).d.%(NativeLibraryExtension)')"
+          Include="@(_MonoRuntime->'$(_MSBuildDir)\lib\%(Identity)\%(OutputMonoBtlsFilename).d.%(NativeLibraryExtension)')"
       />
       <_MonoPosixHelperSource
           Condition=" '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputMonoPosixHelperFilename)' != '' "
@@ -259,11 +259,11 @@
       />
       <_InstallMonoPosixHelperOutput
           Condition=" '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputMonoPosixHelperFilename)' != '' "
-          Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputMonoPosixHelperFilename).%(NativeLibraryExtension)')"
+          Include="@(_MonoRuntime->'$(_MSBuildDir)\lib\%(Identity)\%(OutputMonoPosixHelperFilename).%(NativeLibraryExtension)')"
       />
       <_InstallUnstrippedMonoPosixHelperOutput
           Condition=" '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputMonoPosixHelperFilename)' != '' "
-          Include="@(_MonoRuntime->'$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(Identity)\%(OutputMonoPosixHelperFilename).d.%(NativeLibraryExtension)')"
+          Include="@(_MonoRuntime->'$(_MSBuildDir)\lib\%(Identity)\%(OutputMonoPosixHelperFilename).d.%(NativeLibraryExtension)')"
       />
       <_RuntimeEglibHeaderSource
           Condition=" '%(_MonoRuntime.DoBuild)' == 'True' "
@@ -271,7 +271,7 @@
       />
       <_RuntimeEglibHeaderOutput
           Condition=" '%(_MonoRuntime.DoBuild)' == 'True' "
-          Include="@(_MonoRuntime->'$(OutputPath)\include\%(Identity)\eglib\config.h');@(_MonoRuntime->'$(OutputPath)\include\%(Identity)\eglib\eglib-config.h')"
+          Include="@(_MonoRuntime->'$(_OutputIncludeDir)%(Identity)\eglib\config.h');@(_MonoRuntime->'$(_OutputIncludeDir)%(Identity)\eglib\eglib-config.h')"
       />
       <_MonoConstsSource
           Condition=" '%(_MonoRuntime.DoBuild)' == 'True' "
@@ -279,7 +279,7 @@
       />
       <_MonoConstsOutput
           Condition=" '%(_MonoRuntime.DoBuild)' == 'True' "
-          Include="$(OutputPath)\include\Consts.cs"
+          Include="$(_OutputIncludeDir)Consts.cs"
       />
       <_RuntimeBuildStamp       Condition=" '%(_MonoRuntime.DoBuild)' == 'true' " Include="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\.stamp')" />
     </ItemGroup>
@@ -300,15 +300,15 @@
   </Target>
   <Target Name="_InstallRuntimes"
       DependsOnTargets="_GetRuntimesOutputItems"
-      Inputs="@(_RuntimeSource);@(_ProfilerSource);@(_MonoPosixHelperSource)"
-      Outputs="@(_InstallRuntimeOutput);@(_InstallProfilerOutput);@(_InstallMonoPosixHelperOutput)">
+      Inputs="@(_RuntimeSource);@(_ProfilerSource);@(_MonoPosixHelperSource);@(_RuntimeEglibHeaderSource)"
+      Outputs="@(_InstallRuntimeOutput);@(_InstallProfilerOutput);@(_InstallMonoPosixHelperOutput);@(_RuntimeEglibHeaderOutput)">
     <MakeDir
         Condition=" '%(_MonoRuntime.DoBuild)' == 'true' "
-        Directories="$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(_MonoRuntime.Identity)"
+        Directories="$(_MSBuildDir)\lib\%(_MonoRuntime.Identity)"
     />
     <MakeDir
         Condition=" '%(_MonoRuntime.DoBuild)' == 'true' "
-        Directories="$(OutputPath)\include\%(_MonoRuntime.Identity)\eglib"
+        Directories="$(_OutputIncludeDir)%(_MonoRuntime.Identity)\eglib"
     />
     <Copy
         SourceFiles="@(_RuntimeEglibHeaderSource)"
@@ -332,7 +332,7 @@
     />
     <Exec
         Condition=" ('$(Configuration)' != 'Debug' Or '%(_MonoRuntime.NativeLibraryExtension)' == 'dll') And '%(_MonoRuntime.DoBuild)' == 'true' "
-        Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(_MonoRuntime.Identity)\%(_MonoRuntime.OutputRuntimeFilename).%(_MonoRuntime.NativeLibraryExtension)&quot;"
+        Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(_MSBuildDir)\lib\%(_MonoRuntime.Identity)\%(_MonoRuntime.OutputRuntimeFilename).%(_MonoRuntime.NativeLibraryExtension)&quot;"
     />
     <Touch Files="@(_InstallRuntimeOutput);@(_InstallUnstrippedRuntimeOutput)" />
 
@@ -346,7 +346,7 @@
     />
     <Exec
         Condition=" '$(Configuration)' != 'Debug' And '%(_MonoRuntime.DoBuild)' == 'true' And '%(_MonoRuntime.OutputProfilerFilename)' != '' "
-        Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(_MonoRuntime.Identity)\%(_MonoRuntime.OutputProfilerFilename).%(_MonoRuntime.NativeLibraryExtension)&quot;"
+        Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(_MSBuildDir)\lib\%(_MonoRuntime.Identity)\%(_MonoRuntime.OutputProfilerFilename).%(_MonoRuntime.NativeLibraryExtension)&quot;"
     />
     <Touch Files="@(_InstallProfilerOutput);@(_InstallUnstrippedProfilerOutput)" />
 
@@ -360,7 +360,7 @@
     />
     <Exec
         Condition=" '$(Configuration)' != 'Debug' And '%(_MonoRuntime.DoBuild)' == 'true' And '%(_MonoRuntime.OutputMonoBtlsFilename)' != '' "
-        Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(_MonoRuntime.Identity)\%(_MonoRuntime.OutputMonoBtlsFilename).%(_MonoRuntime.NativeLibraryExtension)&quot;"
+        Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(_MSBuildDir)\lib\%(_MonoRuntime.Identity)\%(_MonoRuntime.OutputMonoBtlsFilename).%(_MonoRuntime.NativeLibraryExtension)&quot;"
     />
     <Touch Files="@(_InstallMonoBtlsOutput);@(_InstallUnstrippedMonoBtlsOutput)" />
 
@@ -374,13 +374,13 @@
     />
     <Exec
         Condition=" '$(Configuration)' != 'Debug' And '%(_MonoRuntime.DoBuild)' == 'true' And '%(_MonoRuntime.OutputMonoPosixHelperFilename)' != '' "
-        Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(OutputPath)\lib\xbuild\Xamarin\Android\lib\%(_MonoRuntime.Identity)\%(_MonoRuntime.OutputMonoPosixHelperFilename).%(_MonoRuntime.NativeLibraryExtension)&quot;"
+        Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(_MSBuildDir)\lib\%(_MonoRuntime.Identity)\%(_MonoRuntime.OutputMonoPosixHelperFilename).%(_MonoRuntime.NativeLibraryExtension)&quot;"
     />
     <Touch Files="@(_InstallMonoPosixHelperOutput);@(_InstallUnstrippedMonoPosixHelperOutput)" />
   </Target>
   <ItemGroup>
     <_MonoCilStripSource  Include="$(_MonoOutputDir)\mono-cil-strip.exe" />
-    <_MonoCilStripDest    Include="$(_MandroidDir)\cil-strip.exe" />
+    <_MonoCilStripDest    Include="$(_MSBuildDir)\cil-strip.exe" />
     <_MonoCilStripSource
         Condition=" '$(_DebugFileExt)' == '.mdb' "
         Include="$(_MonoOutputDir)\mono-cil-strip.exe.mdb"
@@ -395,13 +395,13 @@
     />
     <_MonoCilStripDest
         Condition=" '$(_DebugFileExt)' == '.pdb' "
-        Include="$(_MandroidDir)\cil-strip.pdb"
+        Include="$(_MSBuildDir)\cil-strip.pdb"
     />
   </ItemGroup>
   <Target Name="_InstallCilStrip"
       Inputs="@(_MonoCilStripSource)"
       Outputs="@(_MonoCilStripDest)">
-    <MakeDir Directories="$(_MandroidDir)" />
+    <MakeDir Directories="$(_MSBuildDir)" />
     <Copy
         SourceFiles="@(_MonoCilStripSource)"
         DestinationFiles="@(_MonoCilStripDest)"
@@ -410,13 +410,13 @@
   <Target Name="_InstallMonoDoc"
       Inputs="@(_MonoDocCopyItems);$(_MonoOutputDir)\mdoc.exe"
       Outputs="@(_MonoDocInstalledItems)">
-    <MakeDir Directories="$(_MandroidDir)" />
+    <MakeDir Directories="$(_MSBuildDir)" />
     <Copy
         SourceFiles="@(_MonoDocCopyItems)"
-        DestinationFolder="$(_MandroidDir)"
+        DestinationFolder="$(_MSBuildDir)"
     />
     <Exec
-        Command="$(RemapAssemblyRefTool) &quot;$(_MonoOutputDir)\mdoc.exe&quot; &quot;$(_MandroidDir)\mdoc.exe&quot; Mono.Cecil &quot;$(_MandroidDir)\Xamarin.Android.Cecil.dll&quot;"
+        Command="$(RemapAssemblyRefTool) &quot;$(_MonoOutputDir)\mdoc.exe&quot; &quot;$(_MSBuildDir)\mdoc.exe&quot; Mono.Cecil &quot;..\..\bin\Build$(Configuration)\Xamarin.Android.Cecil.dll&quot;"
     />
     <Touch
         Files="@(_MonoDocInstalledItems)"
@@ -425,7 +425,7 @@
   <Target Name="_InstallMonoUtilities"
       Inputs="@(_MonoUtilitySource)"
       Outputs="@(_MonoUtilityDest)">
-    <MakeDir Directories="$(_MandroidDir)" />
+    <MakeDir Directories="$(_MSBuildDir)" />
     <Copy
         SourceFiles="@(_MonoUtilitySource)"
         DestinationFiles="@(_MonoUtilityDest)"
@@ -433,10 +433,10 @@
   </Target>
   <Target Name="_InstallBcl"
       Inputs="@(_BclProfileItems)"
-      Outputs="@(_BclInstalledItem);$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0\RedistList\FrameworkList.xml">
+      Outputs="@(_BclInstalledItem);$(_BclFrameworkDir)RedistList\FrameworkList.xml">
     <MakeDir Directories="$(_BclFrameworkDir)" />
-    <MakeDir Directories="$(_BclFrameworkDir)\RedistList" />
-    <MakeDir Directories="$(_BclFrameworkDir)\Facades" />
+    <MakeDir Directories="$(_BclFrameworkDir)RedistList" />
+    <MakeDir Directories="$(_BclFrameworkDir)Facades" />
     <ItemGroup>
       <_PackageConfigFiles Include="$(_SourceTopDir)\src\Xamarin.Android.Build.Tasks\packages.config" />
     </ItemGroup>
@@ -453,14 +453,14 @@
     />
     <Copy
         SourceFiles="@(_Facades)"
-        DestinationFolder="$(_BclFrameworkDir)\Facades"
+        DestinationFolder="$(_BclFrameworkDir)Facades"
     />
     <Copy
         SourceFiles="@(_FSharp)"
         DestinationFolder="$(_BclFrameworkDir)"
     />
     <Touch
-        Files="@(_FSharp->'$(_BclFrameworkDir)\%(Filename)%(Extension)')"
+        Files="@(_FSharp->'$(_BclFrameworkDir)%(Filename)%(Extension)')"
     />
     <Touch
         Files="@(_BclInstalledItem)"
@@ -470,7 +470,7 @@
       <FrameworkList Include="&lt;/FileList&gt;" />
     </ItemGroup>
     <WriteLinesToFile
-        File="$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0\RedistList\FrameworkList.xml"
+        File="$(_BclFrameworkDir)RedistList\FrameworkList.xml"
         Lines="@(FrameworkList)"
         Overwrite="True"
     />
@@ -545,23 +545,22 @@
   -->
   <Target Name="_InstallCrossRuntimes"
       Inputs="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)\mono\mini\mono-sgen%(_MonoCrossRuntime.ExeSuffix)"
-      Outputs="$(OutputPath)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
+      Outputs="$(_MSBuildDir)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
       Condition=" '@(_MonoCrossRuntime)' != '' ">
-    <MakeDir Directories="$(OutputPath)\bin\" />
     <Copy
         SourceFiles="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)\mono\mini\mono-sgen%(_MonoCrossRuntime.ExeSuffix)"
-        DestinationFiles="$(OutputPath)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
+        DestinationFiles="$(_MSBuildDir)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
     />
     <Copy
-        SourceFiles="$(OutputPath)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
-        DestinationFiles="$(OutputPath)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName).d%(_MonoCrossRuntime.ExeSuffix)"
+        SourceFiles="$(_MSBuildDir)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
+        DestinationFiles="$(_MSBuildDir)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName).d%(_MonoCrossRuntime.ExeSuffix)"
     />
     <Exec
         Condition=" '$(Configuration)' != 'Debug' Or '%(_MonoCrossRuntime.ExeSuffix)' == '.exe' "
-        Command="&quot;%(_MonoCrossRuntime.Strip)&quot; %(_MonoCrossRuntime.StripFlags) &quot;$(OutputPath)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)&quot;"
+        Command="&quot;%(_MonoCrossRuntime.Strip)&quot; %(_MonoCrossRuntime.StripFlags) &quot;$(_MSBuildDir)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)&quot;"
     />
     <Touch
-        Files="$(OutputPath)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
+        Files="$(_MSBuildDir)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
     />
   </Target>
   <Target Name="GetMonoBundleItems"
@@ -572,8 +571,8 @@
       <BundleItem Include="@(_MonoCilStripDest)" />
       <BundleItem Include="@(_MonoUtilityDest)" />
       <BundleItem Include="@(_FSharpInstalledItems)" />
-      <BundleItem Include="@(MonoFacadeAssembly->'$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0\Facades\%(Identity)')" />
-      <BundleItem Include="$(OutputPath)\lib\xbuild-frameworks\MonoAndroid\v1.0\RedistList\FrameworkList.xml" />
+      <BundleItem Include="@(MonoFacadeAssembly->'$(_BclFrameworkDir)Facades\%(Identity)')" />
+      <BundleItem Include="$(_BclFrameworkDir)RedistList\FrameworkList.xml" />
       <BundleItem Include="@(_InstallRuntimeOutput)" />
       <BundleItem Include="@(_InstallUnstrippedRuntimeOutput)" />
       <BundleItem Include="@(_InstallProfilerOutput)" />
@@ -585,10 +584,10 @@
       <BundleItem Include="@(_RuntimeEglibHeaderOutput)" />
       <BundleItem Include="@(_MonoConstsOutput)" />
       <BundleItem Include="@(_LlvmTargetBinary)" />
-      <BundleItem Include="$(OutputPath)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName).d%(_MonoCrossRuntime.ExeSuffix)"
+      <BundleItem Include="$(_MSBuildDir)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName).d%(_MonoCrossRuntime.ExeSuffix)"
           Condition=" '@(_MonoCrossRuntime)' != '' "
       />
-      <BundleItem Include="$(OutputPath)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
+      <BundleItem Include="$(_MSBuildDir)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
           Condition=" '@(_MonoCrossRuntime)' != '' "
       />
     </ItemGroup>

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -99,33 +99,33 @@ framework-assemblies:
 	$(foreach a, $(API_LEVELS), \
 		CUR_VERSION=`echo "$(ALL_FRAMEWORKS)"|tr -s " "|cut -d " " -s -f $(a)`; \
 		$(foreach conf, $(CONFIGURATIONS), \
-			REDIST_FILE=bin/$(conf)/lib/xbuild-frameworks/MonoAndroid/$${CUR_VERSION}/RedistList/FrameworkList.xml; \
+			REDIST_FILE=bin/$(conf)/lib/xamarin.android/xbuild-frameworks/MonoAndroid/$${CUR_VERSION}/RedistList/FrameworkList.xml; \
 			grep -q $${PREV_VERSION} $${REDIST_FILE}; \
 			if [ $$? -ne 0 ] ; then \
-				rm -f bin/$(conf)/lib/xbuild-frameworks/MonoAndroid/$${CUR_VERSION}/RedistList/FrameworkList.xml; \
+				rm -f bin/$(conf)/lib/xamarin.android/xbuild-frameworks/MonoAndroid/$${CUR_VERSION}/RedistList/FrameworkList.xml; \
 			fi; \
 			$(MSBUILD) $(MSBUILD_FLAGS) src/Mono.Android/Mono.Android.csproj /p:Configuration=$(conf) $(_MSBUILD_ARGS) \
 				/p:AndroidApiLevel=$(a) /p:AndroidPlatformId=$(word $(a), $(ALL_PLATFORM_IDS)) /p:AndroidFrameworkVersion=$${CUR_VERSION} \
 				/p:AndroidPreviousFrameworkVersion=$${PREV_VERSION}; ) \
 		PREV_VERSION=$${CUR_VERSION}; )
 	$(foreach conf, $(CONFIGURATIONS), \
-		rm -f bin/$(conf)/lib/xbuild-frameworks/MonoAndroid/v1.0/Xamarin.Android.NUnitLite.dll; \
+		rm -f bin/$(conf)/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v1.0/Xamarin.Android.NUnitLite.dll; \
 		$(MSBUILD) $(MSBUILD_FLAGS) src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj /p:Configuration=$(conf) $(_MSBUILD_ARGS) \
 			/p:AndroidApiLevel=$(firstword $(API_LEVELS)) /p:AndroidPlatformId=$(word $(firstword $(API_LEVELS)), $(ALL_PLATFORM_IDS)) /p:AndroidFrameworkVersion=$(firstword $(FRAMEWORKS)); )
 	_latest_framework=$$($(MSBUILD) /p:DoNotLoadOSProperties=True /nologo /v:minimal /t:GetAndroidLatestFrameworkVersion build-tools/scripts/Info.targets | tr -d '[[:space:]]') ; \
 	$(foreach conf, $(CONFIGURATIONS), \
-		rm -f "bin/$(conf)/lib/xbuild-frameworks/MonoAndroid/$$_latest_framework"/Mono.Android.Export.* ; \
+		rm -f "bin/$(conf)/lib/xamarin.android/xbuild-frameworks/MonoAndroid/$$_latest_framework"/Mono.Android.Export.* ; \
 		$(MSBUILD) $(MSBUILD_FLAGS) src/Mono.Android.Export/Mono.Android.Export.csproj /p:Configuration=$(conf) $(_MSBUILD_ARGS) \
 			/p:AndroidApiLevel=$(firstword $(API_LEVELS)) /p:AndroidPlatformId=$(word $(firstword $(API_LEVELS)), $(ALL_PLATFORM_IDS)) /p:AndroidFrameworkVersion=$(firstword $(FRAMEWORKS)); ) \
 	$(foreach conf, $(CONFIGURATIONS), \
-		rm -f "bin/$(conf)/lib/xbuild-frameworks/MonoAndroid/$$_latest_framework"/OpenTK-1.0.* ; \
+		rm -f "bin/$(conf)/lib/xamarin.android/xbuild-frameworks/MonoAndroid/$$_latest_framework"/OpenTK-1.0.* ; \
 		$(MSBUILD) $(MSBUILD_FLAGS) src/OpenTK-1.0/OpenTK.csproj /p:Configuration=$(conf) $(_MSBUILD_ARGS) \
 			/p:AndroidApiLevel=$(firstword $(API_LEVELS)) /p:AndroidPlatformId=$(word $(firstword $(API_LEVELS)), $(ALL_PLATFORM_IDS)) /p:AndroidFrameworkVersion=$(firstword $(FRAMEWORKS)); )
 
 opentk-jcw:
 	$(foreach a, $(API_LEVELS), \
 		$(foreach conf, $(CONFIGURATIONS), \
-			touch bin/$(conf)/lib/xbuild-frameworks/MonoAndroid/*/OpenTK-1.0.dll; \
+			touch bin/$(conf)/lib/xamarin.android/xbuild-frameworks/MonoAndroid/*/OpenTK-1.0.dll; \
 			$(MSBUILD) $(MSBUILD_FLAGS) src/OpenTK-1.0/OpenTK.csproj /t:GenerateJavaCallableWrappers /p:Configuration=$(conf) $(_MSBUILD_ARGS) \
 				/p:AndroidApiLevel=$(a) /p:AndroidPlatformId=$(word $(a), $(ALL_PLATFORM_IDS)) /p:AndroidFrameworkVersion=$(word $(a), $(ALL_FRAMEWORKS)); ))
 
@@ -159,10 +159,10 @@ package-oss $(ZIP_OUTPUT):
 	_exclude_list=".__exclude_list.txt"; \
 	ls -1d $(_BUNDLE_ZIPS_EXCLUDE) > "$$_exclude_list" 2>/dev/null ; \
 	for c in $(CONFIGURATIONS) ; do \
-		_sl="$(ZIP_OUTPUT_BASENAME)/bin/$$c/lib/xbuild/.__sys_links.txt"; \
+		_sl="$(ZIP_OUTPUT_BASENAME)/bin/$$c/lib/xamarin.android/xbuild/.__sys_links.txt"; \
 		if [ ! -f "$$_sl" ]; then continue; fi; \
 		for f in `cat $$_sl` ; do \
-			echo "$(ZIP_OUTPUT_BASENAME)/bin/$$c/lib/xbuild/$$f" >> "$$_exclude_list"; \
+			echo "$(ZIP_OUTPUT_BASENAME)/bin/$$c/lib/xamarin.android/xbuild/$$f" >> "$$_exclude_list"; \
 		done; \
 	done; \
 	zip -r "$(ZIP_OUTPUT)" \

--- a/build-tools/scripts/Configuration.Java.Interop.Override.props
+++ b/build-tools/scripts/Configuration.Java.Interop.Override.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <UtilityOutputFullPath>$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\lib\mandroid\</UtilityOutputFullPath>
+    <UtilityOutputFullPath>$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\</UtilityOutputFullPath>
   </PropertyGroup>
 </Project>

--- a/build-tools/scripts/JavaCallableWrappers.targets
+++ b/build-tools/scripts/JavaCallableWrappers.targets
@@ -6,8 +6,9 @@
       Outputs="$(OutputPath)mono.android.jar">
     <MakeDir Directories="$(IntermediateOutputPath)jcw;$(IntermediateOutputPath)jcw\bin" />
     <PropertyGroup>
-      <OutputPathAbs>$(MSBuildProjectDirectory)\$(OutputPath)</OutputPathAbs>
-      <JcwGen>"$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\lib\mandroid\jcw-gen.exe" -v10</JcwGen>
+      <OutputPathAbs Condition="$([System.IO.Path]::IsPathRooted($(OutputPath)))">$(OutputPath)</OutputPathAbs>
+      <OutputPathAbs Condition=" '$(OutputPathAbs)' == '' ">$(MSBuildProjectDirectory)\$(OutputPath)</OutputPathAbs>
+      <JcwGen>"$(XAInstallPrefix)xbuild\Xamarin\Android\jcw-gen.exe" -v10</JcwGen>
       <_LibDirs>-L "$(OutputPathAbs)" -L "$(OutputPathAbs)..\v1.0\" -L "$(OutputPathAbs)..\v1.0\Facades"</_LibDirs>
       <_Out>-o "$(MSBuildProjectDirectory)\$(IntermediateOutputPath)jcw\src"</_Out>
     </PropertyGroup>

--- a/build-tools/scripts/MonoAndroidFramework.props
+++ b/build-tools/scripts/MonoAndroidFramework.props
@@ -3,7 +3,7 @@
   <!-- Note: ..\..\Configuration.props *must* be included FIRST -->
   <PropertyGroup>
     <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
-    <TargetFrameworkRootPath>$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
+    <TargetFrameworkRootPath>$(XAInstallPrefix)xbuild-frameworks</TargetFrameworkRootPath>
     <FrameworkPathOverride>$(TargetFrameworkRootPath)\MonoAndroid\v1.0</FrameworkPathOverride>
   </PropertyGroup>
 </Project>

--- a/build-tools/unix-distribution-setup/unix-distribution-setup.targets
+++ b/build-tools/unix-distribution-setup/unix-distribution-setup.targets
@@ -1,23 +1,18 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Target Name="Build">
-    <Copy
-        SourceFiles="..\..\tools\scripts\generator"
-        DestinationFiles="$(OutputPath)bin\generator"
-    />
-    <Exec
-        Condition=" '$(HostOS)' != 'Windows' "
-        Command="chmod +x $(OutputPath)bin\generator"
-    />
+    <PropertyGroup>
+      <_CrossDir>$(OutputPath)lib\xamarin.android\xbuild\Xamarin\Android\$(HostOS)</_CrossDir>
+    </PropertyGroup>
     <ItemGroup>
-      <_ExecutableScript Include="$(OutputPath)bin\cross*" />
+      <_ExecutableScript Include="$(_CrossDir)\cross*" />
       <_ExecutableScript
-          Condition=" Exists('$(OutputPath)bin\llc') "
-          Include="$(OutputPath)bin\llc"
+          Condition=" Exists('$(_CrossDir)\llc') "
+          Include="$(_CrossDir)\llc"
       />
       <_ExecutableScript
-          Condition=" Exists('$(OutputPath)bin\opt') "
-          Include="$(OutputPath)bin\opt"
+          Condition=" Exists('$(_CrossDir)\opt') "
+          Include="$(_CrossDir)\opt"
       />
     </ItemGroup>
     <Exec
@@ -27,7 +22,6 @@
   </Target>
 
   <Target Name="Clean">
-    <Delete Files="$(OutputPath)bin\generator" />
   </Target>
 </Project>
 

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/HashFileContents.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/HashFileContents.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.BuildTools.PrepTasks
+{
+	public class HashFileContents : Task
+	{
+		[Required]
+		public      ITaskItem[]         Files                       { get; set; }
+
+
+		public      string              HashAlgorithm               { get; set; } = "SHA1";
+
+		public      int                 AbbreviatedHashLength       { get; set; } = 8;
+
+		[Output]
+		// Specifies %(Hashes.Target), %(Hashes.AbbreviatedHash). Hash is %(Hashes.Identity)).
+		public      ITaskItem[]         Hashes                      { get; set;  }
+
+		[Output]
+		public      string              CompleteHash                { get; set;  }
+
+		[Output]
+		public      string              AbbreviatedCompleteHash     { get; set; }
+
+		public override bool Execute ()
+		{
+			Log.LogMessage (MessageImportance.Low, $"Task {nameof (HashFileContents)}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (AbbreviatedHashLength)}: {AbbreviatedHashLength}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (HashAlgorithm)}: {HashAlgorithm}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (Files)}:");
+			foreach (var e in Files) {
+				Log.LogMessage (MessageImportance.Low, $"    {e.ItemSpec}");
+			}
+
+			ProcessFiles ();
+
+			Log.LogMessage (MessageImportance.Low, $"  [Output] {nameof (AbbreviatedCompleteHash)}: {AbbreviatedCompleteHash}");
+			Log.LogMessage (MessageImportance.Low, $"  [Output] {nameof (CompleteHash)}: {CompleteHash}");
+			Log.LogMessage (MessageImportance.Low, $"  [Output] {nameof (Hashes)}:");
+			foreach (var e in Hashes) {
+				Log.LogMessage (MessageImportance.Low, $"    {e.GetMetadata ("Target")}: {e.ItemSpec}:");
+			}
+			return !Log.HasLoggedErrors;
+		}
+
+		void ProcessFiles ()
+		{
+			var     hashes  = new List<TaskItem> (Files.Length);
+			byte[]  block   = new byte [4096];
+			using (var complete = System.Security.Cryptography.HashAlgorithm.Create (HashAlgorithm)) {
+				foreach (var file in Files) {
+					var hash    = ProcessFile (complete, block, file.ItemSpec);
+					var e       = new TaskItem (hash);
+					e.SetMetadata ("Target", Path.GetFullPath (file.ItemSpec));
+					e.SetMetadata ("AbbreviatedHash", hash.Substring (0, AbbreviatedHashLength));
+					hashes.Add (e);
+				}
+				complete.TransformFinalBlock (block, 0, 0);
+				CompleteHash            = FormatHash (complete.Hash);
+				AbbreviatedCompleteHash = CompleteHash.Substring (0, AbbreviatedHashLength);
+			}
+			Hashes = hashes.ToArray ();
+		}
+
+		string ProcessFile (HashAlgorithm complete, byte[] block, string path)
+		{
+			using (var fileHash = System.Security.Cryptography.HashAlgorithm.Create (HashAlgorithm))
+			using (var file = File.OpenRead (path)) {
+				int read;
+				while ((read = file.Read (block, 0, block.Length)) > 0) {
+					complete.TransformBlock (block, 0, read, block, 0);
+					fileHash.TransformBlock (block, 0, read, block, 0);
+				}
+				fileHash.TransformFinalBlock (block, 0, 0);
+				return FormatHash (fileHash.Hash);
+			}
+		}
+
+		string FormatHash (byte[] hash)
+		{
+			return string.Join ("", hash.Select (b => b.ToString ("x2")));
+		}
+	}
+}
+

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
@@ -41,6 +41,7 @@
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\Git.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\GitBranch.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\GitCommitHash.cs" />
+    <Compile Include="Xamarin.Android.BuildTools.PrepTasks\HashFileContents.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\PathToolTask.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\SystemUnzip.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\Which.cs" />

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.targets
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.targets
@@ -12,9 +12,8 @@
   <Target Name="_CreateVersion"
       DependsOnTargets="GetXAVersionInfo"
       AfterTargets="Build">
-    <MakeDir Directories="..\..\bin\$(Configuration)\lib\xbuild\Xamarin\Android" />
     <PropertyGroup>
-      <_XAPrefix>..\..\bin\$(Configuration)\lib\xbuild\Xamarin\Android</_XAPrefix>
+      <_XAPrefix>$(XAInstallPrefix)xbuild\Xamarin\Android</_XAPrefix>
       <_VersionFile>..\..\bin\$(Configuration)\Version</_VersionFile>
       <_VersionCommitFile>..\..\bin\$(Configuration)\Version.commit</_VersionCommitFile>
       <_VersionRevFile>..\..\bin\$(Configuration)\Version.rev</_VersionRevFile>
@@ -23,6 +22,7 @@
       <_XAVersionCommitFile>$(_XAPrefix)\Version.commit</_XAVersionCommitFile>
       <_XAVersionRevFile>$(_XAPrefix)\Version.rev</_XAVersionRevFile>
     </PropertyGroup>
+    <MakeDir Directories="$(_XAPrefix)" />
     <WriteLinesToFile
         File="$(_VersionFile)"
         Lines="$(ProductVersion)"

--- a/src/Mono.Android.Export/Mono.Android.Export.csproj
+++ b/src/Mono.Android.Export/Mono.Android.Export.csproj
@@ -14,13 +14,13 @@
   <PropertyGroup>
     <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
-    <TargetFrameworkRootPath>$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
+    <TargetFrameworkRootPath>$(XAInstallPrefix)xbuild-frameworks</TargetFrameworkRootPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\bin\Debug\lib\xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -31,7 +31,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\bin\Release\lib\xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -14,13 +14,13 @@
   <PropertyGroup>
     <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
-    <TargetFrameworkRootPath>$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\lib\xbuild-frameworks</TargetFrameworkRootPath>
+    <TargetFrameworkRootPath>$(XAInstallPrefix)xbuild-frameworks</TargetFrameworkRootPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\bin\Debug\lib\xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)\</OutputPath>
     <DefineConstants>DEBUG;JAVA_INTEROP;NET_2_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -32,7 +32,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\bin\Release\lib\xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)\</OutputPath>
     <DefineConstants>JAVA_INTEROP;NET_2_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -67,7 +67,7 @@
       Outputs="$(IntermediateOutputPath)mcw\Mono.Android.projitems">
     <MakeDir Directories="$(IntermediateOutputPath)mcw" />
     <PropertyGroup>
-      <Generator>"$(OutputPath)..\..\..\mandroid\generator.exe"</Generator>
+      <Generator>"$(XAInstallPrefix)xbuild\Xamarin\Android\generator.exe"</Generator>
       <_GenFlags>--public --product-version=7</_GenFlags>
       <_ApiLevel>--api-level=$(AndroidApiLevel)</_ApiLevel>
       <_Out>-o "$(IntermediateOutputPath)mcw"</_Out>

--- a/src/Mono.Android/Test/Mono.Android-Tests.csproj
+++ b/src/Mono.Android/Test/Mono.Android-Tests.csproj
@@ -98,7 +98,7 @@
     <AndroidResource Include="Resources\drawable\android_button.xml" />
     <AndroidResource Include="Resources\xml\XmlReaderResourceParser.xml" />
   </ItemGroup>
-  <Import Project="..\..\..\bin\$(Configuration)\lib\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+  <Import Project="..\..\..\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Import Project="Mono.Android-Tests.targets" />
   <ItemGroup>
     <ProjectReference Include="..\..\..\build-tools\android-toolchain\android-toolchain.mdproj">

--- a/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
+++ b/src/Mono.Data.Sqlite/Mono.Data.Sqlite.csproj
@@ -26,7 +26,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks\MonoAndroid\v1.0</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0</OutputPath>
     <DefineConstants>DEBUG;TRACE;NET_4_0;NET_4_5;MONO;DISABLE_CAS_USE;SQLITE_STANDARD;MONODROID</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -37,7 +37,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
-    <OutputPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks\MonoAndroid\v1.0</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
@@ -174,11 +174,11 @@
     <Compile Include="$(MonoSourceDirectory)\mcs\build\common\Locale.cs">
       <Link>Locale.cs</Link>
     </Compile>
-    <Compile Include="$(OutputPath)..\..\..\..\include\Consts.cs">
+    <Compile Include="..\..\bin\$(Configuration)\include\Consts.cs">
       <Link>Consts.cs</Link>
     </Compile>
   </ItemGroup>
-  <Import Project="$(OutputPath)\..\..\..\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+  <Import Project="$(XAInstallPrefix)xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <ItemGroup>
     <EmbeddedNativeLibrary Include="@(AndroidSupportedTargetJitAbi-&gt;'..\sqlite-xamarin\src\main\libs\%(Identity)\libsqlite3_xamarin.so')" />
   </ItemGroup>

--- a/src/Mono.Posix/Mono.Posix.csproj
+++ b/src/Mono.Posix/Mono.Posix.csproj
@@ -26,7 +26,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks\MonoAndroid\v1.0</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0</OutputPath>
     <DefineConstants>DEBUG;TRACE;NET_4_0;NET_4_5;MONO;DISABLE_CAS_USE;MONODROID</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
@@ -37,7 +37,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
-    <OutputPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks\MonoAndroid\v1.0</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
@@ -230,11 +230,11 @@
     <Compile Include="$(MonoSourceDirectory)\mcs\build\common\Locale.cs">
       <Link>Locale.cs</Link>
     </Compile>
-    <Compile Include="$(OutputPath)..\..\..\..\include\Consts.cs">
+    <Compile Include="..\..\bin\$(Configuration)\include\Consts.cs">
       <Link>Consts.cs</Link>
     </Compile>
   </ItemGroup>
-  <Import Project="$(OutputPath)\..\..\..\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+  <Import Project="$(XAInstallPrefix)xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <ItemGroup>
     <Folder Include="MonoPosixHelper\" />
     <Folder Include="Assembly\" />

--- a/src/OpenTK-1.0/OpenTK.csproj
+++ b/src/OpenTK-1.0/OpenTK.csproj
@@ -28,10 +28,10 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>..\..\bin\$(Configuration)\lib\xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)\OpenTK-1.0.xml</DocumentationFile>
+    <DocumentationFile>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)\OpenTK-1.0.xml</DocumentationFile>
     <AndroidLinkMode>None</AndroidLinkMode>
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
@@ -39,10 +39,10 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>..\..\bin\$(Configuration)\lib\xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)\OpenTK-1.0.xml</DocumentationFile>
+    <DocumentationFile>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\$(AndroidFrameworkVersion)\OpenTK-1.0.xml</DocumentationFile>
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Drawing.Primitives/System.Drawing.Primitives.mdproj
+++ b/src/System.Drawing.Primitives/System.Drawing.Primitives.mdproj
@@ -4,12 +4,13 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ItemType>GenericProject</ItemType>
     <ProjectGuid>{C9FF2E4D-D927-479E-838B-647C16763F64}</ProjectGuid>
-    <OutputPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks\MonoAndroid\v1.0\Facades</OutputPath>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\Facades</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\Facades</OutputPath>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
   <PropertyGroup>

--- a/src/System.EnterpriseServices/System.EnterpriseServices.csproj
+++ b/src/System.EnterpriseServices/System.EnterpriseServices.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\bin\Debug\lib\xbuild-frameworks\MonoAndroid\v1.0</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -26,7 +26,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
-    <OutputPath>..\..\bin\Release\lib\xbuild-frameworks\MonoAndroid\v1.0</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -42,9 +42,6 @@ namespace Xamarin.Android.Tasks
 		public string AndroidApiLevel { get; set; }
 
 		[Required]
-		public string SdkBinDirectory { get; set; }
-
-		[Required]
 		public ITaskItem[] ResolvedAssemblies { get; set; }
 
 		// Which ABIs to include native libs for
@@ -210,7 +207,6 @@ namespace Xamarin.Android.Tasks
 			LogDebugMessage ("  EnableLLVM: {0}", EnableLLVM);
 			LogDebugMessage ("  IntermediateAssemblyDir: {0}", IntermediateAssemblyDir);
 			LogDebugMessage ("  LinkMode: {0}", LinkMode);
-			LogDebugMessage ("  SdkBinDirectory: {0}", SdkBinDirectory);
 			LogDebugMessage ("  SupportedAbis: {0}", SupportedAbis);
 			LogDebugTaskItems ("  ResolvedAssemblies:", ResolvedAssemblies);
 			LogDebugTaskItems ("  AdditionalNativeLibraryReferences:", AdditionalNativeLibraryReferences);
@@ -293,6 +289,8 @@ namespace Xamarin.Android.Tasks
 			NdkUtil.NdkVersion ndkVersion;
 			bool hasNdkVersion = NdkUtil.GetNdkToolchainRelease (AndroidNdkDirectory, out ndkVersion);
 
+			var sdkBinDirectory = MonoAndroidHelper.GetOSBinPath ();
+
 			var abis = SupportedAbis.Split (new char[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
 			foreach (var abi in abis) {
 				string aotCompiler = "";
@@ -302,14 +300,14 @@ namespace Xamarin.Android.Tasks
 
 				switch (abi) {
 				case "armeabi":
-					aotCompiler = Path.Combine (SdkBinDirectory, "cross-arm");
+					aotCompiler = Path.Combine (sdkBinDirectory, "cross-arm");
 					outdir = Path.Combine (AotOutputDirectory, "armeabi");
 					mtriple = "armv5-linux-gnueabi";
 					arch = AndroidTargetArch.Arm;
 					break;
 
 				case "armeabi-v7a":
-					aotCompiler = Path.Combine (SdkBinDirectory, "cross-arm");
+					aotCompiler = Path.Combine (sdkBinDirectory, "cross-arm");
 					outdir = Path.Combine (AotOutputDirectory, "armeabi-v7a");
 					mtriple = "armv7-linux-gnueabi";
 					arch = AndroidTargetArch.Arm;
@@ -318,21 +316,21 @@ namespace Xamarin.Android.Tasks
 				case "arm64":
 				case "arm64-v8a":
 				case "aarch64":
-					aotCompiler = Path.Combine (SdkBinDirectory, "cross-arm64");
+					aotCompiler = Path.Combine (sdkBinDirectory, "cross-arm64");
 					outdir = Path.Combine (AotOutputDirectory, "arm64-v8a");
 					mtriple = "aarch64-linux-android";
 					arch = AndroidTargetArch.Arm64;
 					break;			
 
 				case "x86":
-					aotCompiler = Path.Combine (SdkBinDirectory, "cross-x86");
+					aotCompiler = Path.Combine (sdkBinDirectory, "cross-x86");
 					outdir = Path.Combine (AotOutputDirectory, "x86");
 					mtriple = "i686-linux-android";
 					arch = AndroidTargetArch.X86;
 					break;
 
 				case "x86_64":
-					aotCompiler = Path.Combine (SdkBinDirectory, "cross-x86_64");
+					aotCompiler = Path.Combine (sdkBinDirectory, "cross-x86_64");
 					outdir = Path.Combine (AotOutputDirectory, "x86_64");
 					mtriple = "x86_64-linux-android";
 					arch = AndroidTargetArch.X86_64;
@@ -402,7 +400,7 @@ namespace Xamarin.Android.Tasks
 					aotOptions.Add ("mtriple="     + mtriple);
 					aotOptions.Add ("tool-prefix=" + GetShortPath (toolPrefix));
 					aotOptions.Add ("ld-flags="    + ldFlags);
-					aotOptions.Add ("llvm-path="   + GetShortPath (SdkBinDirectory));
+					aotOptions.Add ("llvm-path="   + GetShortPath (sdkBinDirectory));
 					aotOptions.Add ("temp-path="   + GetShortPath (tempDir));
 
 					string aotOptionsStr = (EnableLLVM ? "--llvm " : "") + "--aot=" + string.Join (",", aotOptions);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -24,8 +24,6 @@ namespace Xamarin.Android.Tasks
 	{
 		public string AndroidNdkDirectory { get; set; }
 
-		public string SdkBinDirectory { get; set; }
-
 		[Required]
 		public string ApkInputPath { get; set; }
 		
@@ -616,6 +614,7 @@ namespace Xamarin.Android.Tasks
 			if (string.IsNullOrEmpty (AndroidNdkDirectory))
 				return;
 
+			var sdkBinDirectory = MonoAndroidHelper.GetOSBinPath ();
 			int count = 0;
 			foreach (var sabi in supportedAbis.Split (new char[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)) {
 				var arch = GdbPaths.GetArchFromAbi (sabi);
@@ -627,7 +626,7 @@ namespace Xamarin.Android.Tasks
 							string.Equals (f.Item2, "lib/" + sabi, StringComparison.Ordinal)))
 					continue;
 				var entryName = string.Format ("lib/{0}/{1}", sabi, debugServerFile);
-				var debugServerPath = GdbPaths.GetDebugServerPath (debugServer, arch, AndroidNdkDirectory, SdkBinDirectory);
+				var debugServerPath = GdbPaths.GetDebugServerPath (debugServer, arch, AndroidNdkDirectory, sdkBinDirectory);
 				if (!File.Exists (debugServerPath))
 					continue;
 				Log.LogDebugMessage ("Adding {0} debug server '{1}' to the APK as '{2}'", sabi, debugServerPath, entryName);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
@@ -147,7 +147,7 @@ namespace Xamarin.Android.Tasks
 		}
 
 		protected override string ToolName {
-			get { return OS.IsWindows ? "generator.exe" : "generator"; }
+			get { return "generator.exe"; }
 		}
 
 		protected override string GenerateFullPathToTool ()

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ImportJavaDoc.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ImportJavaDoc.cs
@@ -23,12 +23,14 @@ namespace Xamarin.Android.Tasks
 		public string OutputDocDirectory { get; set; }
 
 		protected override string ToolName {
-			get { return "javadoc-to-mdoc"; }
+			get { return "javadoc-to-mdoc.exe"; }
 		}
 
 		protected override string GenerateFullPathToTool ()
 		{
-			return MonoDroidSdk.JavaDocToMDocExe;
+			return Path.Combine (
+					Path.GetFullPath (Path.GetDirectoryName (GetType ().Assembly.Location)),
+					"javadoc-to-mdoc.exe");
 		}
 
 		protected override string GenerateCommandLineCommands ()

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MDoc.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MDoc.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Android.Tasks
 		public bool RunExport { get; set; }
 
 		protected override string ToolName {
-			get { return OS.IsWindows ? "mdoc.exe" : "mdoc"; }
+			get { return "mdoc.exe"; }
 		}
 
 		protected override string GenerateFullPathToTool ()

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -125,34 +125,23 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("ResolveSdksTask:");
 			Log.LogDebugMessage ("  AndroidApiLevel: {0}", AndroidApiLevel);
 			Log.LogDebugMessage ("  AndroidSdkBuildToolsVersion: {0}", AndroidSdkBuildToolsVersion);
+			Log.LogDebugMessage ($"  {nameof (AndroidSdkPath)}: {AndroidSdkPath}");
+			Log.LogDebugMessage ($"  {nameof (AndroidNdkPath)}: {AndroidNdkPath}");
 			Log.LogDebugTaskItems ("  ReferenceAssemblyPaths: ", ReferenceAssemblyPaths);
 			Log.LogDebugMessage ("  TargetFrameworkVersion: {0}", TargetFrameworkVersion);
 			Log.LogDebugMessage ("  UseLatestAndroidPlatformSdk: {0}", UseLatestAndroidPlatformSdk);
 			Log.LogDebugMessage ("  SequencePointsMode: {0}", SequencePointsMode);
-			Log.LogDebugMessage ("  MonoAndroidToolsPath: {0}", MonoAndroidToolsPath);
-			Log.LogDebugMessage ("  MonoAndroidBinPath: {0}", MonoAndroidBinPath);
 			Log.LogDebugMessage ("  LintToolPath: {0}", LintToolPath);
 
-			MonoAndroidHelper.RefreshMonoDroidSdk (MonoAndroidToolsPath, MonoAndroidBinPath, ReferenceAssemblyPaths);
-			MonoAndroidHelper.RefreshAndroidSdk (AndroidSdkPath, AndroidNdkPath, JavaSdkPath);
-			
-			// OS X:    $prefix/lib/mandroid
+			// OS X:    $prefix/lib/xamarin.android/xbuild/Xamarin/Android
 			// Windows: %ProgramFiles(x86)%\MSBuild\Xamarin\Android
-			this.MonoAndroidToolsPath = MonoDroidSdk.RuntimePath;
-
-			// OS X:    $prefix/bin
-			// Windows: %ProgramFiles(x86)%\MSBuild\Xamarin\Android
-			this.MonoAndroidBinPath = MonoDroidSdk.BinPath;
-
-			if (this.MonoAndroidBinPath == null) {
-				Log.LogCodedError ("XA0020", "Could not find mandroid!");
-				return false;
+			if (string.IsNullOrEmpty (MonoAndroidToolsPath)) {
+				MonoAndroidToolsPath  = Path.GetDirectoryName (typeof (ResolveSdks).Assembly.Location);
 			}
+			MonoAndroidBinPath  = MonoAndroidHelper.GetOSBinPath () + Path.DirectorySeparatorChar;
 
-			string include;
-			if (MonoAndroidToolsPath != null &&
-					Directory.Exists (include = Path.Combine (MonoAndroidToolsPath, "include")))
-				MonoAndroidIncludePath = include;
+			MonoAndroidHelper.RefreshMonoDroidSdk (MonoAndroidToolsPath, null, ReferenceAssemblyPaths);
+			MonoAndroidHelper.RefreshAndroidSdk (AndroidSdkPath, AndroidNdkPath, JavaSdkPath);
 
 			this.AndroidNdkPath = AndroidSdk.AndroidNdkPath;
 			this.AndroidSdkPath = AndroidSdk.AndroidSdkPath;
@@ -275,7 +264,6 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  JavaSdkPath: {0}", JavaSdkPath);
 			Log.LogDebugMessage ("  MonoAndroidBinPath: {0}", MonoAndroidBinPath);
 			Log.LogDebugMessage ("  MonoAndroidToolsPath: {0}", MonoAndroidToolsPath);
-			Log.LogDebugMessage ("  MonoAndroidIncludePath: {0}", MonoAndroidIncludePath);
 			Log.LogDebugMessage ("  TargetFrameworkVersion: {0}", TargetFrameworkVersion);
 			Log.LogDebugMessage ("  ZipAlignPath: {0}", ZipAlignPath);
 			Log.LogDebugMessage ("  SupportedApiLevel: {0}", SupportedApiLevel);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -229,7 +229,7 @@ namespace Com.Ipaulpro.Afilechooser {
 			binding.AndroidClassParser = "class-parse";
 			var multidexJar = Environment.OSVersion.Platform == PlatformID.Win32NT
 				? Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.ProgramFilesX86), "MSBuild", "Xamarin", "Android", "android-support-multidex.jar") 
-				: Path.Combine ("$(MonoDroidInstallDirectory)", "lib", "mandroid", "android-support-multidex.jar");
+				: Path.Combine ("$(MonoDroidInstallDirectory)", "lib", "xamarin.android", "xbuild", "Xamarin", "Android", "android-support-multidex.jar");
 			binding.Jars.Add (new AndroidItem.EmbeddedJar (() => multidexJar));
 			using (var bindingBuilder = CreateDllBuilder ("temp/BindingCustomJavaApplicationClass/MultiDexBinding")) {
 				bindingBuilder.Build (binding);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1231,7 +1231,7 @@ namespace App1
 		[Test]
 		public void BuildWithExternalJavaLibrary ()
 		{
-			string multidex_jar = "$(MonoDroidInstallDirectory)\\lib\\mandroid\\android-support-multidex.jar";
+			string multidex_jar = @"$(MonoDroidInstallDirectory)\lib\xamarin.android\xbuild\Xamarin\Android\android-support-multidex.jar";
 			var binding = new XamarinAndroidBindingProject () {
 				ProjectName = "BuildWithExternalJavaLibraryBinding",
 				Jars = { new AndroidItem.InputJar (() => multidex_jar), },
@@ -1764,9 +1764,9 @@ public class Test
 <Target Name=""_CheckAbis"" BeforeTargets=""_DefineBuildTargetAbis"">
 	<PropertyGroup>
 		<AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
-		<AndroidSupportedAbis Condition=""Exists('$(MSBuildThisFileDirectory)..\..\..\..\Debug\lib\xbuild\Xamarin\Android\lib\armeabi\libmono-android.release.so')"">$(AndroidSupportedAbis);armeabi</AndroidSupportedAbis>
-		<AndroidSupportedAbis Condition=""Exists('$(MSBuildThisFileDirectory)..\..\..\..\Debug\lib\xbuild\Xamarin\Android\lib\arm64-v8a\libmono-android.release.so')"">$(AndroidSupportedAbis);arm64-v8a</AndroidSupportedAbis>
-		<AndroidSupportedAbis Condition=""Exists('$(MSBuildThisFileDirectory)..\..\..\..\Debug\lib\xbuild\Xamarin\Android\lib\x86_64\libmono-android.release.so')"">$(AndroidSupportedAbis);x86_64</AndroidSupportedAbis>
+		<AndroidSupportedAbis Condition=""Exists('$(MSBuildThisFileDirectory)..\..\..\..\Debug\lib\xamarin.android\xbuild\Xamarin\Android\lib\armeabi\libmono-android.release.so')"">$(AndroidSupportedAbis);armeabi</AndroidSupportedAbis>
+		<AndroidSupportedAbis Condition=""Exists('$(MSBuildThisFileDirectory)..\..\..\..\Debug\lib\xamarin.android\xbuild\Xamarin\Android\lib\arm64-v8a\libmono-android.release.so')"">$(AndroidSupportedAbis);arm64-v8a</AndroidSupportedAbis>
+		<AndroidSupportedAbis Condition=""Exists('$(MSBuildThisFileDirectory)..\..\..\..\Debug\lib\xamarin.android\xbuild\Xamarin\Android\lib\x86_64\libmono-android.release.so')"">$(AndroidSupportedAbis);x86_64</AndroidSupportedAbis>
 	</PropertyGroup>
 	<Message Text=""$(AndroidSupportedAbis)"" />
 </Target>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -51,7 +51,7 @@ namespace Xamarin.ProjectTools
 						outdir = Path.GetFullPath (Path.Combine (Root, "..", "..", "bin", "Release"));
 					if (!Directory.Exists (outdir))
 						outdir = "/Library/Frameworks/Xamarin.Android.framework/Versions/Current";
-					return Path.Combine (outdir, "lib");
+					return Path.Combine (outdir, "lib", "xamarin.android");
 				}
 				else {
 					var x86 = Environment.GetFolderPath (Environment.SpecialFolder.ProgramFilesX86);
@@ -130,7 +130,7 @@ namespace Xamarin.ProjectTools
 				args.AppendFormat ("/p:AndroidNdkDirectory=\"{0}\" ", ndkPath);
 			}
 			if (RunXBuild) {
-				var outdir = Path.GetFullPath (Path.Combine (FrameworkLibDirectory, ".."));
+				var outdir = Path.GetFullPath (Path.Combine (FrameworkLibDirectory, "..", ".."));
 				var targetsdir = Path.Combine (FrameworkLibDirectory, "xbuild");
 				args.AppendFormat (" {0} ", logger);
 
@@ -140,7 +140,7 @@ namespace Xamarin.ProjectTools
 				}
 				if (Directory.Exists (outdir)) {
 					psi.EnvironmentVariables ["MONO_ANDROID_PATH"] = outdir;
-					psi.EnvironmentVariables ["XBUILD_FRAMEWORK_FOLDERS_PATH"] = Path.Combine (outdir, "lib", "xbuild-frameworks");
+					psi.EnvironmentVariables ["XBUILD_FRAMEWORK_FOLDERS_PATH"] = Path.Combine (outdir, "lib", "xamarin.android", "xbuild-frameworks");
 					args.AppendFormat ("/p:MonoDroidInstallDirectory=\"{0}\" ", outdir);
 				}
 				args.AppendFormat ("/t:{0} {1} /p:UseHostCompilerIfAvailable=false /p:BuildingInsideVisualStudio=true", target, QuoteFileName (Path.Combine (Root, projectOrSolution)));

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -134,12 +134,12 @@
     <None Include="packages.config" />
     <Content
         Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))"
-        Include="..\..\..\..\bin\$(Configuration)\lib\xbuild\Xamarin\Android\libzip.3.0.dylib">
+        Include="$(XAInstallPrefix)xbuild\Xamarin\Android\libzip.3.0.dylib">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content
         Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:')) And '$(_LinuxBuildLibZip)' == 'True' "
-        Include="..\..\..\..\bin\$(Configuration)\lib\xbuild\Xamarin\Android\libzip.so">
+        Include="$(XAInstallPrefix)xbuild\Xamarin\Android\libzip.so">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content
@@ -151,6 +151,18 @@
     <ProjectReference Include="$(LibZipSharpSourceFullPath)\libZipSharp.csproj">
       <Project>{E248B2CA-303B-4645-ADDC-9D4459D550FD}</Project>
       <Name>libZipSharp</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\build-tools\libzip\libzip.mdproj"
+        Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">
+      <Project>{900A0F71-BAAD-417A-8D1A-8D330297CDD0}</Project>
+      <Name>libzip</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\build-tools\libzip-windows\libzip-windows.mdproj"
+        Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+      <Project>{0DE278D6-000F-4001-BB98-187C0AF58A61}</Project>
+      <Name>libzip-windows</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -171,8 +171,6 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 			AndroidNdkPath="$(AndroidNdkDirectory)"
 			BuildingInsideVisualStudio="$(BuildingInsideVisualStudio)"
 			JavaSdkPath="$(JavaSdkDirectory)"
-			MonoAndroidBinPath="$(MonoAndroidBinDirectory)"
-			MonoAndroidToolsPath="$(MonoAndroidToolsDirectory)"
 			ProjectFilePath="$(MSBuildProjectFullPath)"
 			ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)"
 			TargetFrameworkVersion="$(TargetFrameworkVersion)"
@@ -187,8 +185,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 		<Output TaskParameter="AndroidSdkPath"            PropertyName="AndroidSdkDirectory"        Condition="'$(AndroidSdkDirectory)' == ''" />
 		<Output TaskParameter="AndroidSdkBuildToolsPath"  PropertyName="AndroidSdkBuildToolsPath"   Condition="'$(AndroidSdkBuildToolsPath)' == ''" />
 		<Output TaskParameter="JavaSdkPath"               PropertyName="JavaSdkDirectory"           Condition="'$(JavaSdkDirectory)' == ''" />
-		<Output TaskParameter="MonoAndroidToolsPath"      PropertyName="MonoAndroidToolsDirectory"  Condition="'$(MonoAndroidToolsDirectory)' == ''" />
-		<Output TaskParameter="MonoAndroidBinPath"        PropertyName="MonoAndroidBinDirectory"    Condition="'$(MonoAndroidBinDirectory)' == ''" />
+		<Output TaskParameter="MonoAndroidToolsPath"      PropertyName="MonoAndroidToolsDirectory" />
 		<Output TaskParameter="AndroidSdkBuildToolsBinPath" PropertyName="AndroidSdkBuildToolsBinPath" Condition="'$(AndroidSdkBuildToolsBinPath)' == ''" />
 	</ResolveSdks>
     <CreateProperty Value="$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion),Profile=$(TargetFrameworkProfile)">
@@ -209,26 +206,8 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
   <!-- Find all the needed SDKs -->
   <Target Name="_ResolveMonoAndroidSdks" DependsOnTargets="_ResolveMonoAndroidFramework">
 
-    <Error Text="Could not locate MonoAndroid SDK." Condition="'$(MonoAndroidToolsDirectory)'==''" />
     <Error Text="Could not locate Android SDK." Condition="'$(AndroidSdkDirectory)'==''" />
     <Error Text="Could not locate Java 6 or 7 SDK.  (Download from http://www.oracle.com/technetwork/java/javase/downloads.)" Condition="'$(JavaSdkDirectory)'==''" />
-
-    <!-- ensure a version of paths with trailing slashes even if overridden by /p:foo=bar -->
-    <CreateProperty Value="$(MonoAndroidToolsDirectory)">
-      <Output TaskParameter="Value" PropertyName="_MonoAndroidToolsDirectory"/>
-    </CreateProperty>
-    <CreateProperty Value="$(_MonoAndroidToolsDirectory)\">
-      <Output TaskParameter="Value" PropertyName="_MonoAndroidToolsDirectory"
-        Condition="!HasTrailingSlash('$(_MonoAndroidToolsDirectory)')" />
-    </CreateProperty>
-
-    <CreateProperty Value="$(MonoAndroidBinDirectory)">
-      <Output TaskParameter="Value" PropertyName="_MonoAndroidBinDirectory"/>
-    </CreateProperty>
-    <CreateProperty Value="$(_MonoAndroidBinDirectory)\">
-      <Output TaskParameter="Value" PropertyName="_MonoAndroidBinDirectory"
-        Condition="!HasTrailingSlash('$(_MonoAndroidBinDirectory)')" />
-    </CreateProperty>
 
     <CreateProperty Value="$(AndroidNdkDirectory)">
       <Output TaskParameter="Value" PropertyName="_AndroidNdkDirectory"/>
@@ -255,7 +234,6 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     </CreateProperty>
 
     <Message Text="MonoAndroid Tools: $(_MonoAndroidToolsDirectory)"/>
-	<Message Text="MonoAndroid Binaries: $(_MonoAndroidBinDirectory)"/>
     <Message Text="Android NDK: $(_AndroidNdkDirectory)"/>
     <Message Text="Android SDK: $(_AndroidSdkDirectory)"/>
     <Message Text="Java SDK: $(_JavaSdkDirectory)"/>
@@ -399,7 +377,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
       ApiXmlInput="$(ApiOutputFile).class-parse"
       ReferencedManagedLibraries="@(ReferencePath);@(ReferenceDependencyPaths)"
       MonoAndroidFrameworkDirectories="$(_TargetFrameworkDirectories)"
-      ToolPath="$(_MonoAndroidBinDirectory)"
+      ToolPath="$(MonoAndroidToolsDirectory)"
       ToolExe="$(BindingsGeneratorToolExe)"
     />
 
@@ -449,7 +427,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
       ReferencedManagedLibraries="@(ReferencePath);@(ReferenceDependencyPaths)"
       MonoAndroidFrameworkDirectories="$(_TargetFrameworkDirectories)"
       TypeMappingReportFile="$(GeneratedOutputPath)type-mapping.txt"
-      ToolPath="$(_MonoAndroidBinDirectory)"
+      ToolPath="$(MonoAndroidToolsDirectory)"
       ToolExe="$(BindingsGeneratorToolExe)"
       UseShortFileNames="$(UseShortFileNames)"
     />
@@ -513,7 +491,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     	References="@(ReferencePath);@(ReferenceDependencyPaths)"
     	TargetAssembly="@(IntermediateAssembly)"
     	OutputDocDirectory="$(IntermediateOutputPath)docs"
-		ToolPath="$(_MonoAndroidBinDirectory)"
+    	ToolPath="$(MonoAndroidToolsDirectory)"
 		ToolExe="$(MDocToolExe)"
     	 />
     <ImportJavaDoc
@@ -527,7 +505,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     	References="@(ReferencePath);@(ReferenceDependencyPaths)"
     	TargetAssembly="@(IntermediateAssembly)"
     	OutputDocDirectory="$(IntermediateOutputPath)docs"
-		ToolPath="$(_MonoAndroidBinDirectory)"
+    	ToolPath="$(MonoAndroidToolsDirectory)"
 		ToolExe="$(MDocToolExe)"
     	 />
     <!-- Then export .NET doc xml -->
@@ -535,7 +513,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     	RunExport="True"
     	TargetAssembly="@(IntermediateAssembly)"
     	OutputDocDirectory="$(IntermediateOutputPath)docs"
-		ToolPath="$(_MonoAndroidBinDirectory)"
+    	ToolPath="$(MonoAndroidToolsDirectory)"
 		ToolExe="$(MDocToolExe)"
     	 />
     <Copy

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>Xamarin.Android.Tasks</RootNamespace>
     <AssemblyName>Xamarin.Android.Build.Tasks</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
@@ -19,7 +19,7 @@
     <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
-    <OutputPath>..\..\bin\$(Configuration)\lib\xbuild\Xamarin\Android</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
     <DefineConstants Condition="'$(MonoDroidTiming)' == ''">TRACE;DEBUG;HAVE_CECIL;MSBUILD;ANDROID_24</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -27,7 +27,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType></DebugType>
     <Optimize>True</Optimize>
-    <OutputPath>..\..\bin\$(Configuration)\lib\xbuild\Xamarin\Android</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
     <DefineConstants>TRACE;HAVE_CECIL;MSBUILD;ANDROID_24</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -6,7 +6,7 @@
   <Import Project="..\..\build-tools\mono-runtimes\ProfileAssemblies.projitems" />
   <Import Project="..\..\build-tools\scripts\XAVersionInfo.targets" />
   <PropertyGroup>
-    <_SharedRuntimeBuildPath Condition=" '$(_SharedRuntimeBuildPath)' == '' ">..\..\bin\$(Configuration)\lib\xbuild-frameworks\MonoAndroid\</_SharedRuntimeBuildPath>
+    <_SharedRuntimeBuildPath Condition=" '$(_SharedRuntimeBuildPath)' == '' ">$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\</_SharedRuntimeBuildPath>
     <_GeneratedProfileClass>$(IntermediateOutputPath)Profile.g.cs</_GeneratedProfileClass>
     <BuildDependsOn>
       _GenerateXACommonProps;
@@ -145,37 +145,38 @@
   
   <Target Name="_CopyExtractedMultiDexJar"
     Inputs="$(_AndroidSdkLocation)\$(_MultiDexAarInAndroidSdk);$(_SupportLicense)"
-    Outputs="$(OutputPath)..\..\..\mandroid\android-support-multidex.jar;$(OutputPath)..\..\..\mandroid\MULTIDEX_JAR_LICENSE">
+    Outputs="$(OutputPath)android-support-multidex.jar;$(OutputPath)MULTIDEX_JAR_LICENSE">
     <UnzipDirectoryChildren
       NoSubdirectory="true"
       SourceFiles="$(_AndroidSdkLocation)\$(_MultiDexAarInAndroidSdk)"
       DestinationFolder="$(IntermediateOutputPath)multidex-aar" />
     <Copy
       SourceFiles="$(IntermediateOutputPath)multidex-aar\classes.jar"
-      DestinationFiles="$(OutputPath)..\..\..\mandroid\android-support-multidex.jar" />
-    <Touch Files="$(OutputPath)..\..\..\mandroid\android-support-multidex.jar" />
+      DestinationFiles="$(OutputPath)android-support-multidex.jar" />
+    <Touch Files="$(OutputPath)android-support-multidex.jar" />
     <Copy
       SourceFiles="$(_SupportLicense)"
-      DestinationFiles="$(OutputPath)..\..\..\mandroid\MULTIDEX_JAR_LICENSE" />
+      DestinationFiles="$(OutputPath)MULTIDEX_JAR_LICENSE" />
     <Copy
         SourceFiles="$(_SupportLicense)"
-        DestinationFiles="$(OutputPath)..\..\..\mandroid\MULTIDEX_JAR_LICENSE.txt"
+        DestinationFiles="$(OutputPath)MULTIDEX_JAR_LICENSE.txt"
     />
-    <Touch Files="$(OutputPath)..\..\..\mandroid\MULTIDEX_JAR_LICENSE;$(OutputPath)..\..\..\mandroid\MULTIDEX_JAR_LICENSE.txt" />
+    <Touch Files="$(OutputPath)MULTIDEX_JAR_LICENSE;$(OutputPath)MULTIDEX_JAR_LICENSE.txt" />
   </Target>
 
   <ItemGroup>
-    <_MonoSymbolicateScript             Include="mono-symbolicate;mono-symbolicate.cmd" />
-    <_MonoSymbolicateScriptSource       Include="@(_MonoSymbolicateScript->'..\..\tools\scripts\%(Identity)')" />
-    <_MonoSymbolicateScriptDestination  Include="@(_MonoSymbolicateScript->'$(OutputPath)..\..\..\..\bin\%(Identity)')" />
+    <_MonoSymbolicateScriptSource       Include="..\..\tools\scripts\mono-symbolicate" />
+    <_MonoSymbolicateScriptDestination  Include="$(OutputPath)$(HostOS)\mono-symbolicate" />
   </ItemGroup>
 
   <Target Name="_BuildMonoSymbolicateScripts"
       Inputs="@(_MonoSymbolicateScriptSource)"
       Outputs="@(_MonoSymbolicateScriptDestination)">
+    <MakeDir Directories="$(OutputPath)$(HostOS)" />
     <Copy
         SourceFiles="@(_MonoSymbolicateScriptSource)"
         DestinationFiles="@(_MonoSymbolicateScriptDestination)"
     />
+    <Exec Command="chmod +x @(_MonoSymbolicateScriptDestination->'%(Identity)', ' ')" />
   </Target>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -598,8 +598,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 			SequencePointsMode="$(_AndroidSequencePointsMode)"
 			BuildingInsideVisualStudio="$(BuildingInsideVisualStudio)"
 			JavaSdkPath="$(JavaSdkDirectory)"
-			MonoAndroidBinPath="$(MonoAndroidBinDirectory)"
-			MonoAndroidToolsPath="$(MonoAndroidToolsDirectory)"
 			ProjectFilePath="$(MSBuildProjectFullPath)"
 			ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)"
 			TargetFrameworkVersion="$(TargetFrameworkVersion)"
@@ -616,9 +614,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		<Output TaskParameter="AndroidSdkPath"            PropertyName="AndroidSdkDirectory"        Condition="'$(AndroidSdkDirectory)' == ''" />
 		<Output TaskParameter="AndroidSdkBuildToolsPath"  PropertyName="AndroidSdkBuildToolsPath"   Condition="'$(AndroidSdkBuildToolsPath)' == ''" />
 		<Output TaskParameter="JavaSdkPath"               PropertyName="JavaSdkDirectory"           Condition="'$(JavaSdkDirectory)' == ''" />
-		<Output TaskParameter="MonoAndroidToolsPath"      PropertyName="MonoAndroidToolsDirectory"  Condition="'$(MonoAndroidToolsDirectory)' == ''" />
-		<Output TaskParameter="MonoAndroidBinPath"        PropertyName="MonoAndroidBinDirectory"    Condition="'$(MonoAndroidBinDirectory)' == ''" />
-		<Output TaskParameter="MonoAndroidIncludePath"    PropertyName="MonoAndroidIncludeDirectory"	Condition="'$(MonoAndroidIncludeDirectory)' == ''" />
+		<Output TaskParameter="MonoAndroidToolsPath"      PropertyName="MonoAndroidToolsDirectory" />
+		<Output TaskParameter="MonoAndroidBinPath"        PropertyName="MonoAndroidBinDirectory" />
 		<Output TaskParameter="ZipAlignPath"              PropertyName="ZipAlignToolPath"           Condition="'$(ZipAlignToolPath)' == ''" />
 		<Output TaskParameter="AndroidSdkBuildToolsBinPath" PropertyName="AndroidSdkBuildToolsBinPath" Condition="'$(AndroidSdkBuildToolsBinPath)' == ''" />
 		<Output TaskParameter="AndroidSequencePointsMode"   PropertyName="_SequencePointsMode"         Condition="'$(_SequencePointsMode)' == ''" />
@@ -692,14 +689,6 @@ because xbuild doesn't support framework reference assemblies.
 		<Output TaskParameter="Value" PropertyName="_MonoAndroidToolsDirectory"
 			Condition="!HasTrailingSlash('$(_MonoAndroidToolsDirectory)')" />
 	</CreateProperty>
-
-	<CreateProperty Value="$(MonoAndroidBinDirectory)">
-		<Output TaskParameter="Value" PropertyName="_MonoAndroidBinDirectory"/>
-	</CreateProperty>
-	<CreateProperty Value="$(_MonoAndroidBinDirectory)\">
-		<Output TaskParameter="Value" PropertyName="_MonoAndroidBinDirectory"
-			Condition="!HasTrailingSlash('$(_MonoAndroidBinDirectory)')" />
-	</CreateProperty>
 	
 	<CreateProperty Value="$(AndroidNdkDirectory)">
 		<Output TaskParameter="Value" PropertyName="_AndroidNdkDirectory"/>
@@ -738,7 +727,6 @@ because xbuild doesn't support framework reference assemblies.
 	</CreateProperty>
 	
 	<Message Text="MonoAndroid Tools: $(_MonoAndroidToolsDirectory)"/>
-	<Message Text="MonoAndroid Binaries: $(_MonoAndroidBinDirectory)"/>
 	<Message Text="Android Platform API level: $(_AndroidApiLevel)"/>
 	<Message Text="TargetFrameworkVersion: $(_TargetFrameworkVersion)"/>
 	<Message Text="Android NDK: $(_AndroidNdkDirectory)"/>
@@ -2111,7 +2099,6 @@ because xbuild doesn't support framework reference assemblies.
 	AndroidAotMode="$(AndroidAotMode)"
 	AndroidNdkDirectory="$(_AndroidNdkDirectory)"
 	AndroidApiLevel="$(_AndroidApiLevel)"
-	SdkBinDirectory="$(MonoAndroidBinDirectory)"
 	SupportedAbis="$(_BuildTargetAbis)"
 	AndroidSequencePointsMode="$(_SequencePointsMode)"
 	AotAdditionalArguments="$(AndroidAotAdditionalArguments)"
@@ -2148,7 +2135,6 @@ because xbuild doesn't support framework reference assemblies.
   <BuildApk
     AndroidNdkDirectory="$(_AndroidNdkDirectory)"
     ApkInputPath="$(_PackagedResources)"
-    SdkBinDirectory="$(MonoAndroidBinDirectory)"
     ApkOutputPath="$(ApkFileIntermediate)"
     BundleAssemblies="$(BundleAssemblies)"
     BundleNativeLibraries="$(_BundleResultNativeLibraries)"
@@ -2218,7 +2204,7 @@ because xbuild doesn't support framework reference assemblies.
 
   <MakeDir Directories="$(OutDir)$(_AndroidPackage).apk.mSYM" Condition=" '$(MonoSymbolArchive)' == 'True' " />
   <Exec
-    Command="&quot;$(_MonoAndroidBinDirectory)mono-symbolicate&quot; store-symbols &quot;$(OutDir)$(_AndroidPackage).apk.mSYM&quot; &quot;$(MonoAndroidIntermediate)android/assets&quot;"
+    Command="&quot;$(MonoAndroidBinDirectory)mono-symbolicate&quot; store-symbols &quot;$(OutDir)$(_AndroidPackage).apk.mSYM&quot; &quot;$(MonoAndroidIntermediate)android/assets&quot;"
     Condition=" '$(MonoSymbolArchive)' == 'True' "
   />
 

--- a/src/Xamarin.Android.Build.Utilities/MonoDroidSdk.cs
+++ b/src/Xamarin.Android.Build.Utilities/MonoDroidSdk.cs
@@ -45,16 +45,7 @@ namespace Xamarin.Android.Build.Utilities
 			return sdk;
 		}
 
-		public static string RuntimePath { get { return GetSdk ().RuntimePath; } }
-
-		public static string BinPath { get { return GetSdk ().BinPath; } }
-
 		public static string FrameworkPath { get { return GetSdk ().BclPath; } }
-
-		[Obsolete ("Do not use.")]
-		public static string JavaDocToMDocExe {
-			get { return Path.Combine (BinPath, OS.IsWindows ? "javadoc-to-mdoc.exe" : "javadoc-to-mdoc"); }
-		}
 	}
 }
 

--- a/src/Xamarin.Android.Build.Utilities/Sdks/MonoDroidSdkUnix.cs
+++ b/src/Xamarin.Android.Build.Utilities/Sdks/MonoDroidSdkUnix.cs
@@ -8,26 +8,31 @@ namespace Xamarin.Android.Build.Utilities
 	class MonoDroidSdkUnix : MonoDroidSdkBase
 	{
 		readonly static string[] RuntimeToFrameworkPaths = new[]{
+			// runtimePath=$prefix/lib/xamarin.android/xbuild/Xamarin/Android/
+			Path.Combine ("..", "..", "..", "xbuild-frameworks", "MonoAndroid"),
 			Path.Combine ("..", "..", "..", ".xamarin.android", "lib", "xbuild-frameworks", "MonoAndroid"),
 			Path.Combine ("..", "xbuild-frameworks", "MonoAndroid"),
 			Path.Combine ("..", "mono", "2.1"),
 		};
 
 		readonly static string[] SearchPaths = {
+			"/Library/Frameworks/Xamarin.Android.framework/Versions/Current/lib/xamarin.android/xbuild/Xamarin/Android",
 			"/Library/Frameworks/Xamarin.Android.framework/Versions/Current/lib/mandroid",
 			"/Developer/MonoAndroid/usr/lib/mandroid",
 			"/app/lib/mandroid",
-			"/opt/mono-android/lib/mandroid"
+			"/app/lib/xamarin.android/xbuild/Xamarin/Android",
+			"/opt/mono-android/lib/mandroid",
+			"/opt/mono-android/lib/xamarin.android/xbuild/Xamarin/Android",
 		};
 
 		protected override string FindRuntime ()
 		{
 			string monoAndroidPath = Environment.GetEnvironmentVariable ("MONO_ANDROID_PATH");
 			if (!string.IsNullOrEmpty (monoAndroidPath)) {
-				string libMandroid = Path.Combine (monoAndroidPath, "lib", "mandroid");
-				if (Directory.Exists (libMandroid)) {
-					if (ValidateRuntime (libMandroid))
-						return libMandroid;
+				string msbuildDir = Path.Combine (monoAndroidPath, "lib", "xamarin.android", "xbuild", "Xamarin", "Android");
+				if (Directory.Exists (msbuildDir)) {
+					if (ValidateRuntime (msbuildDir))
+						return msbuildDir;
 					AndroidLogger.LogInfo (null, "MONO_ANDROID_PATH points to {0}, but it is invalid.", monoAndroidPath);
 				} else
 					AndroidLogger.LogInfo (null, "MONO_ANDROID_PATH points to {0}, but it does not exist.", monoAndroidPath);
@@ -36,18 +41,11 @@ namespace Xamarin.Android.Build.Utilities
 			// check also in the users folder
 			var personal = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
 			var additionalSearchPaths = new [] {
-				// for Mono.Posix and Mono.Data.Sqlite builds in xamarin-android.
-				monoAndroidPath = Path.GetFullPath (Path.Combine (new Uri (GetType ().Assembly.CodeBase).LocalPath, "..", "..", "..", "..", "..", "lib", "mandroid")),
-				Path.Combine (personal, @".xamarin.android/lib/mandroid")
+				Path.GetFullPath (Path.GetDirectoryName (GetType ().Assembly.Location)),
+				Path.Combine (personal, @".xamarin.android/lib/xamarin.android/xbuild/Xamarin/Android")
 			};
 
 			return additionalSearchPaths.Concat (SearchPaths).FirstOrDefault (ValidateRuntime);
-		}
-
-		protected override bool ValidateBin (string binPath)
-		{
-			return !string.IsNullOrWhiteSpace (binPath) &&
-				File.Exists (Path.Combine (binPath, GeneratorScript));
 		}
 
 		protected override string FindFramework (string runtimePath)
@@ -70,33 +68,9 @@ namespace Xamarin.Android.Build.Utilities
 			return null;
 		}
 
-		protected override string FindBin (string runtimePath)
-		{
-			string binPath = Path.GetFullPath (Path.Combine (runtimePath, "..", "..", "bin"));
-			if (File.Exists (Path.Combine (binPath, GeneratorScript)))
-				return binPath;
-			return null;
-		}
-
-		protected override string FindInclude (string runtimePath)
-		{
-			string includeDir = Path.GetFullPath (Path.Combine (runtimePath, "..", "..", "include"));
-			if (Directory.Exists (includeDir))
-				return includeDir;
-			return null;
-		}
-
 		protected override string FindLibraries (string runtimePath)
 		{
 			return Path.GetFullPath (Path.Combine (runtimePath, ".."));
-		}
-
-		protected override IEnumerable<string> GetVersionFileLocations ()
-		{
-			yield return Path.GetFullPath (Path.Combine (RuntimePath, "..", "..", "Version"));
-			string sdkPath = Path.GetDirectoryName (Path.GetDirectoryName (RuntimePath));
-			if (Path.GetFileName (sdkPath) == "usr")
-				yield return Path.GetFullPath (Path.Combine (Path.GetDirectoryName (sdkPath), "Version"));
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Utilities/Sdks/MonoDroidSdkWindows.cs
+++ b/src/Xamarin.Android.Build.Utilities/Sdks/MonoDroidSdkWindows.cs
@@ -9,18 +9,20 @@ namespace Xamarin.Android.Build.Utilities
 	{
 		protected override string FindRuntime ()
 		{
-			string monoAndroidPath = Environment.GetEnvironmentVariable ("MONO_ANDROID_PATH");
-			if (!string.IsNullOrEmpty (monoAndroidPath)) {
-				if (Directory.Exists (monoAndroidPath) && ValidateRuntime (monoAndroidPath))
-					return monoAndroidPath;
-			}
-			string xamarinSdk = Path.Combine (OS.ProgramFilesX86, "MSBuild", "Xamarin", "Android");
-			return Directory.Exists (xamarinSdk)
-				? xamarinSdk
-					: OS.ProgramFilesX86 + @"\MSBuild\Novell";
+			var r = base.FindRuntime ();
+			if (r != null)
+				return r;
+			var paths = new []{
+				Path.GetFullPath (Path.GetDirectoryName (GetType ().Assembly.Location)),
+				Path.Combine (OS.ProgramFilesX86, "MSBuild", "Xamarin", "Android"),
+				Path.Combine (OS.ProgramFilesX86, "MSBuild", "Novell"),
+			};
+			return paths.FirstOrDefault (p => ValidateRuntime (p));
 		}
 
 		static readonly string[] RuntimeToFrameworkPaths = new []{
+			// runtimePath=$prefix/lib/xamarin.android/xbuild/Xamarin/Android/
+			Path.Combine ("..", "..", "..", "xbuild-frameworks", "MonoAndroid"),
 			Path.Combine ("..", "..", "..", "Common7", "IDE", "ReferenceAssemblies", "Microsoft", "Framework","MonoAndroid"),
 			Path.Combine ("..", "..", "..", "Reference Assemblies", "Microsoft", "Framework", "MonoAndroid"),
 			Path.Combine (OS.ProgramFilesX86, "Reference Assemblies", "Microsoft", "Framework", "MonoAndroid"),
@@ -46,30 +48,9 @@ namespace Xamarin.Android.Build.Utilities
 			return null;
 		}
 
-		protected override string FindBin (string runtimePath)
-		{
-			return runtimePath;
-		}
-
-		protected override bool ValidateBin (string binPath)
-		{
-			return !string.IsNullOrWhiteSpace (binPath) &&
-				File.Exists (Path.Combine (binPath, "generator.exe"));
-		}
-
-		protected override string FindInclude (string runtimePath)
-		{
-			return Path.GetFullPath (Path.Combine (runtimePath, "include"));
-		}
-
 		protected override string FindLibraries (string runtimePath)
 		{
 			return Path.GetFullPath (runtimePath);
-		}
-
-		protected override IEnumerable<string> GetVersionFileLocations ()
-		{
-			yield return Path.GetFullPath (Path.Combine (RuntimePath, "Version"));
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Utilities/Xamarin.Android.Build.Utilities.csproj
+++ b/src/Xamarin.Android.Build.Utilities/Xamarin.Android.Build.Utilities.csproj
@@ -9,11 +9,12 @@
     <AssemblyName>Xamarin.Android.Build.Utilities</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\bin\$(Configuration)\lib\xbuild\Xamarin\Android</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -22,7 +23,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\bin\$(Configuration)\lib\xbuild\Xamarin\Android</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj
+++ b/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj
@@ -22,7 +22,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\bin\Debug\lib\xbuild-frameworks\MonoAndroid\v1.0</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0</OutputPath>
     <DefineConstants>DEBUG;NUNITLITE;CLR_4_0;NET_4_5;__MOBILE__;MONOTOUCH</DefineConstants>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
     <ErrorReport>prompt</ErrorReport>
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
-    <OutputPath>..\..\bin\Release\lib\xbuild-frameworks\MonoAndroid\v1.0</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0</OutputPath>
     <DefineConstants>NUNITLITE;CLR_4_0;NET_4_5;__MOBILE__;MONOTOUCH</DefineConstants>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
     <ErrorReport>prompt</ErrorReport>

--- a/src/Xamarin.Android.Tools.Aidl/Xamarin.Android.Tools.Aidl.csproj
+++ b/src/Xamarin.Android.Tools.Aidl/Xamarin.Android.Tools.Aidl.csproj
@@ -9,11 +9,12 @@
     <AssemblyName>Xamarin.Android.Tools.Aidl</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
-    <OutputPath>..\..\bin\$(Configuration)\lib\xbuild\Xamarin\Android</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -22,7 +23,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>True</Optimize>
-    <OutputPath>..\..\bin\$(Configuration)\lib\xbuild\Xamarin\Android</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
@@ -35,7 +36,6 @@
       <Private>False</Private>
     </Reference>
   </ItemGroup>
-  <Import Project="..\..\Configuration.props" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Compile Include="AidlAst.cs" />

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -59,6 +59,7 @@
     <ProjectReference Include="..\..\build-tools\libzip\libzip.mdproj">
       <Project>{900A0F71-BAAD-417A-8D1A-8D330297CDD0}</Project>
       <Name>libzip</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\..\build-tools\xa-prep-tasks\xa-prep-tasks.csproj">
       <Project>{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}</Project>

--- a/src/monodroid/jni/Android.mk
+++ b/src/monodroid/jni/Android.mk
@@ -14,7 +14,6 @@ LOCAL_CFLAGS =	$(COMMON_CFLAGS) \
 	-DSGEN_BRIDGE_VERSION=$(SGEN_BRIDGE_VERSION) \
 	-D_REENTRANT -DPLATFORM_ANDROID -DANDROID -DLINUX -Dlinux -D__linux_ \
 	-DHAVE_CONFIG_H -DJI_DLL_EXPORT -DMONO_DLL_EXPORT \
-	-I$(topdir)/libmonodroid/zip -I$(BUILDDIR)/include -I$(BUILDDIR)/include/eglib \
 	-fno-strict-aliasing \
 	-ffunction-sections \
 	-fomit-frame-pointer \
@@ -36,6 +35,7 @@ LOCAL_LDFLAGS   += \
 	-Wl,--no-undefined \
 
 LOCAL_C_INCLUDES	:= \
+	$(LOCAL_PATH) \
 	$(LOCAL_PATH)/../../../bin/$(CONFIGURATION)/include \
 	$(LOCAL_PATH)/../../../bin/$(CONFIGURATION)/include/$(TARGET_ARCH_ABI)/eglib \
 	"$(MONO_PATH)/eglib/src" \

--- a/src/monodroid/monodroid.mdproj
+++ b/src/monodroid/monodroid.mdproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>..\..\bin\Debug\lib\xbuild\Xamarin\Android\lib</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\lib\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>..\..\bin\Release\lib\xbuild\Xamarin\Android\lib</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\lib\</OutputPath>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
   <PropertyGroup>

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -42,8 +42,8 @@
   </Target>
   <Target Name="_GenerateIncludeFiles"
       Inputs="@(_EmbeddedBlob);jni/config.h"
-      Outputs="@(_EmbeddedBlob->'jni\%(Include)');$(OutputPath)\..\..\..\..\..\include\config.h">
-    <Copy SourceFiles="jni/config.h" DestinationFiles="$(OutputPath)\..\..\..\..\..\include\config.h" />
+      Outputs="@(_EmbeddedBlob->'jni\%(Include)');$(MSBuildThisFileDirectory)bin\$(Configuration)\include\config.h">
+    <Copy SourceFiles="jni/config.h" DestinationFiles="$(MSBuildThisFileDirectory)bin\$(Configuration)\include\config.h" />
     <Exec Command="(cat &quot;@(_EmbeddedBlob)&quot; ; dd if=/dev/zero bs=1 count=1 2>/dev/null) > %(_EmbeddedBlob.Config)" />
     <Exec Command="xxd -i %(_EmbeddedBlob.Config) | sed 's/^unsigned /static const unsigned /g' > jni/%(_EmbeddedBlob.Include)" />
     <Exec Command="rm %(_EmbeddedBlob.Config)" />

--- a/src/netstandard/netstandard.mdproj
+++ b/src/netstandard/netstandard.mdproj
@@ -4,12 +4,13 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ItemType>GenericProject</ItemType>
     <ProjectGuid>{93614CB8-4564-43B9-93B0-4AF4B3B16AAE}</ProjectGuid>
-    <OutputPath>..\..\bin\$(Configuration)\lib\xbuild-frameworks\MonoAndroid\v1.0\Facades</OutputPath>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\Facades</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <OutputPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\Facades</OutputPath>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
   <PropertyGroup>

--- a/src/proguard/proguard.mdproj
+++ b/src/proguard/proguard.mdproj
@@ -4,12 +4,13 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ItemType>GenericProject</ItemType>
     <ProjectGuid>{4B9D96BB-95AB-44E8-9F87-13B12C8BCED1}</ProjectGuid>
-    <OutputPath>..\..\bin\$(Configuration)\lib\mandroid\proguard</OutputPath>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\proguard\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\proguard\</OutputPath>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
   <PropertyGroup>

--- a/tests/api-compatibility/api-compatibility.mk
+++ b/tests/api-compatibility/api-compatibility.mk
@@ -9,7 +9,7 @@ MONO_API_HTML     = bin/Build$(CONFIGURATION)/mono-api-html.exe
 MONO_API_INFO_DIR = $(MONO_PATH)/mcs/tools/corcompare
 MONO_API_INFO     = bin/Build$(CONFIGURATION)/mono-api-info.exe
 MONO_OPTIONS_SRC  = $(MONO_PATH)/mcs/class/Mono.Options/Mono.Options/Options.cs
-FRAMEWORK_DIR     = bin/$(CONFIGURATION)/lib/xbuild-frameworks/MonoAndroid
+FRAMEWORK_DIR     = bin/$(CONFIGURATION)/lib/xamarin.android/xbuild-frameworks/MonoAndroid
 
 
 run-api-compatibility-tests: $(MONO_API_HTML) $(MONO_API_INFO)
@@ -25,7 +25,7 @@ $(MONO_API_HTML): $(wildcard $(MONO_API_HTML_DIR)/*.cs) $(MONO_OPTIONS_SRC)
 		-r:System.Xml.dll -r:System.Xml.Linq.dll
 
 MONO_API_INFO_REFS  = \
-  bin/$(CONFIGURATION)/lib/mandroid/Xamarin.Android.Cecil.dll
+  bin/$(CONFIGURATION)/lib/xamarin.android/xbuild/Xamarin/Android/Xamarin.Android.Cecil.dll
 
 $(MONO_API_INFO): $(wildcard $(MONO_API_INFO_DIR)/*.cs) $(MONO_OPTIONS_SRC)
 	$(CSC) -out:$@ $^ /main:CorCompare.Driver \

--- a/tools/javadoc2mdoc/javadoc2mdoc.csproj
+++ b/tools/javadoc2mdoc/javadoc2mdoc.csproj
@@ -13,7 +13,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\bin\Debug\lib\mandroid</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
-    <OutputPath>..\..\bin\Release\lib\mandroid</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ExternalConsole>true</ExternalConsole>

--- a/tools/scripts/generator
+++ b/tools/scripts/generator
@@ -1,6 +1,0 @@
-#!/bin/sh
-BINDIR=`dirname "$0"`
-MANDROID_DIR="$BINDIR/../lib/mandroid"
-
-unset MONO_PATH
-exec mono $MONO_OPTIONS "$MANDROID_DIR/generator.exe" "$@"

--- a/tools/scripts/mono-symbolicate
+++ b/tools/scripts/mono-symbolicate
@@ -1,6 +1,6 @@
 #!/bin/sh
 BINDIR=`dirname "$0"`
-MANDROID_DIR="$BINDIR/../lib/mandroid"
+MANDROID_DIR="$BINDIR/.."
 
 unset MONO_PATH
 exec mono $MONO_OPTIONS "$MANDROID_DIR/mono-symbolicate.exe" "$@"

--- a/tools/scripts/mono-symbolicate.cmd
+++ b/tools/scripts/mono-symbolicate.cmd
@@ -1,2 +1,0 @@
-@echo off
-%~dp0\..\lib\mandroid\mono-symbolicate.exe %*

--- a/tools/scripts/xabuild
+++ b/tools/scripts/xabuild
@@ -21,7 +21,7 @@
 #     MSBuild engine to use. Defaults to `xbuild`, assumed to be in `$PATH`
 #   TARGETS_DIR:
 #     The MSBuild `$(MSBuildExtensionsPath)` root location.
-#     Defaults to `$prefix/lib/xbuild`.
+#     Defaults to `$prefix/lib/xamarin.android/xbuild`.
 #
 # Examples:
 #   To create a .apk for the HelloWorld sample:
@@ -72,16 +72,16 @@ if [[ "$prefix" == */tools/scripts ]] ; then
 		exit 1
 	fi
 	prefix="$real_prefix"
-	xa_prefix="$real_prefix"
+	xa_prefix="$real_prefix/lib/xamarin.android"
 elif [[ "$prefix" == */bin ]] ; then
 	prefix="$prefix/.."
-	xa_prefix="$prefix/../lib/xamarin.android"
+	xa_prefix="$prefix/lib/xamarin.android"
 else
 	(>&2 echo "$name: Could not determine Xamarin.Android prefix.")
 	exit 1
 fi
 
-for t in "$TARGETS_DIR" "$prefix/lib/mono/xbuild" "$prefix/lib/xbuild" ; do
+for t in "$TARGETS_DIR" "$prefix/lib/mono/xbuild" "$xa_prefix/xbuild" ; do
 	if [ -z "$t" -o ! -d "$t" ]; then
 		continue
 	fi
@@ -111,8 +111,7 @@ fi
 declare -a XABUILD_FLAGS
 
 XABUILD_FLAGS=(
-	/p:MonoAndroidBinDirectory="$xa_prefix/bin"
-	/p:MonoAndroidToolsDirectory="$xa_prefix/lib/mandroid"
+	/p:MonoAndroidToolsDirectory="$xa_prefix/xbuild/Xamarin/Android"
 	/p:MonoDroidInstallDirectory="$MONO_ANDROID_PATH"
 )
 
@@ -139,9 +138,9 @@ function GetXbuildDir()
 	read -r -d '' get_xbuild_dir_cmd <<-'EOF' || true
 		using System.IO;
 		var corlib_loc = typeof (int).Assembly.Location;
-		// e.g. /Library/Frameworks/Mono.framework/Versions/5.2.0/lib/mono/4.5
+		// e.g. corlib_dir=/Library/Frameworks/Mono.framework/Versions/5.2.0/lib/mono/4.5
 		var corlib_dir = Path.GetDirectoryName (corlib_loc);
-		// e.g. /Library/Frameworks/Mono.framework/Versions/5.2.0/lib/mono/xbuild
+		// e.g. xbuild_dir=/Library/Frameworks/Mono.framework/Versions/5.2.0/lib/mono/xbuild
 		var xbuild_dir = Path.Combine (corlib_dir, "..", "xbuild");
 		print (Path.GetFullPath (xbuild_dir));
 	EOF
@@ -156,7 +155,7 @@ function ConfigureLocalXbuild()
 	fi
 	xbuild_dir=`GetXbuildDir`
 	local sys_entry=`ls -1 "$xbuild_dir" | head -1`
-	if [ -d "$TARGETS_DIR/$sys_entry" ] ; then
+	if [ -f "$TARGETS_DIR/.__sys_links.txt" ] ; then
 		# already configured; bail
 		return 0
 	fi


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/253#discussion_r82862993

The *intention* is that Jenkins-produced `oss-xamarin.android*.zip`
artifacts be usable on Windows, so that side-by-side testing can be
perfomed without replacing the system installation. Usage is in
[UsingJenkinsBuildArtifacts.md](Documentation/UsingJenkinsBuildArtifacts).

This isn't *entirely* the case. It was *apparently* the case at the
time of commit 87ca2737, but things have bitrotten since, and/or the
support was always insufficient.

For example, 87ca2737 states that it should be possible to use
`msbuild /t:TargetFrameworkRootPath=...` to specify the
`lib\xbuild-frameworks` directory as the location to find
`Mono.Android` framework assemblies.

...and this works! So long as your project *only* uses Xamarin.Android
assemblies and projects.

PCL assemblies and projects do *not* fall under this umbrella.
Consequently, attempting to use PCL assemblies while overriding
`$(TargetFrameworkRootPath)` results in a gnarly error:

        error MSB3644: The reference assemblies for framework ".NETPortable,Version=v4.5,Profile=Profile259" were not found.

This significantly reduces the usefulness of
`oss-xamarin.android*.zip` on Windows. Fix this by altering the
`_GetReferenceAssemblyPaths` target to use
`$(XATargetFrameworkRootPath)`, not `$(TargetFrameworkRootPath)`.
This removes the need to override `$(TargetFrameworkRootPath)`.

Additionally, PR #253 mentions that, for filesystem organization, it
would be useful if the macOS/Linux directory structure --
`$prefix/bin`, `$prefix/lib/mandroid`,
`$prefix/lib/xbuild/Xamarin/Android`, `$prefix/lib/xbuild-frameworks`
-- more closely resembled the Windows directory structure of
`$MSBuild` and `$ReferenceAssemblies` (as seen in `.vsix` files).
This would turn macOS/Linux into using `$xa_prefix/xbuild` and
`$xa_prefix/xbuild-frameworks` directories.

`$prefix/bin` would only contain `xabuild`. What is currently in
`$prefix/lib/mandroid` would be merged with
`$xa_prefix/xbuild/Xamarin/Android`.

`$xa_prefix`, meanwhile, could become
`$prefix/lib/oss-xamarin.android`.

This would turn the current macOS structure:

        $prefix/bin/xabuild
        $prefix/bin/generator
        $prefix/bin/cross-arm
        $prefix/lib/mandroid/generator.exe
        $prefix/lib/xbuild-frameworks/MonoAndroid/v1.0/mscorlib.dll
        $prefix/lib/xbuild/Xamarin/Android/Xamarin.Android.Common.targets

Into:

        $prefix/bin/xabuild
        $prefix/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v1.0/mscorlib.dll
        $prefix/lib/xamarin.android/xbuild/Xamarin/Android/generator.exe
        $prefix/lib/xamarin.android/xbuild/Xamarin/Android/Xamarin.Android.Common.targets
        $prefix/lib/xamarin.android/xbuild/Xamarin/Android/Darwin/cross-arm

Other notes:

  * The `bundle-*.zip` filename has been has been changed to include a
    *hash* of the contents of various files, in particular
    `build-tools\mono-runtimes.*`. This was instigated via a
    conversation with @kumpera about making the filename more
    "idiot-proof": `mono-runtimes.props` contains *compiler flags*,
    and if any of those change, then *logically* the bundle should
    differ as well, as the mono runtimes may differ in significant
    ways. In theory, the `-v18` version should be used to track this,
    but this is a manual change, easy to overlook. The new `-hHASH`
    part of the filename should be more automagic.

    The new `<HashFileContents/>` task in `xa-prep-tasks.dll` is
    responsible for creating the hash value.

  * `Configuration.Java.Interop.Override.props` was moved into
    `build-tools/scripts`, becauase that would cleanup the root
    directory a bit.

  * OS-specific binaries are now placed into
    `$prefix/lib/xamarin.android/xbuild/Xamarin/Android/$(HostOS)`.
    On a theoretical plus side, this means that the same build
    directory can contain OS-specific binaries for multiple operating
    systems. (I don't know if anyone shares a build tree between e.g.
    macOS and Linux, but if anyone *does*...)

  * `$(MonoAndroidToolsDirectory)` should be considered *dead*, along
    with `$(MonoAndroidBinDirectory)`, as these should now *always*
    be the same directory as where `Xamarin.Android.Build.Tasks.dll`
    is located, or a `$(HostOS)` sub-directory.

  * `Xamarin.ProjectTools.csproj` needed to be updated to ensure that
    the build order was correct.

  * Remove all `[Obsolete]` and unreferenced members from
    `Xamarin.Android.Build.Utilities.dll`. There's too much in there,
    and it makes my head hurt trying to understand the
    interrelationships between it all. If it's not used, it's gone.

  * Work around an `xbuild`-ism: `%(_LlvmRuntime.InstallPath)` and
    `%(_MonoCrossRuntime.InstallPath)` *cannot* use MSBuild
    properties, e.g. `<InstallPath>$(HostOS)/</InstallPath>` doesn't
    work as desired; it's instead treated literally.
    Special-case `%(InstallPath)` until we fully migrate to MSBuild.