### PR TITLE
improve test performance measuring

### DIFF
--- a/build-tools/scripts/TimingDefinitions.txt
+++ b/build-tools/scripts/TimingDefinitions.txt
@@ -1,0 +1,6 @@
+# measure time of last monodroid-timing message appearance
+last=monodroid-timing:\s+(?<message>.*)$
+
+# measure time of runtime and JNIEnv initialization end
+init=monodroid-timing:\s+(?<message>Runtime\.init: end native-to-managed.*)$
+JNI.init=monodroid-timing:\s+(?<message>JNIEnv\.Initialize end:.*)$

--- a/build-tools/scripts/UnitTestApks.targets
+++ b/build-tools/scripts/UnitTestApks.targets
@@ -146,6 +146,10 @@
       <Output TaskParameter="FailedToRun" ItemName="_FailedComponent"/>
     </RunInstrumentationTests>
     <Exec Command="&quot;$(AdbToolPath)\$(AdbToolExe)&quot; $(_AdbTarget) $(AdbOptions) logcat -v threadtime -d > test-logcat.txt" />
-    <ProcessLogcatTiming LogcatFilename="test-logcat.txt" ApplicationPackageName="%(UnitTestApk.Package)" ResultsFilename="%(UnitTestApk.ResultsPath)" />
+    <PropertyGroup>
+      <_DefinitionsFilename Condition=" '%(UnitTestApk.TimingDefinitionsFilename)' == '' ">$(MSBuildThisFileDirectory)/TimingDefinitions.txt</_DefinitionsFilename>
+      <_DefinitionsFilename Condition=" '%(UnitTestApk.TimingDefinitionsFilename)' != '' ">%(UnitTestApk.TimingDefinitionsFilename)</_DefinitionsFilename>
+    </PropertyGroup>
+    <ProcessLogcatTiming LogcatFilename="test-logcat.txt" ApplicationPackageName="%(UnitTestApk.Package)" ResultsFilename="%(UnitTestApk.ResultsPath)" DefinitionsFilename="$(_DefinitionsFilename)" />
   </Target>
 </Project>

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -288,6 +288,11 @@ namespace Android.Runtime {
 				if (!IsRunningOnDesktop)
 					Java.Lang.Thread.DefaultUncaughtExceptionHandler = defaultUncaughtExceptionHandler;
 			}
+
+			if (Logger.LogTiming)
+				Logger.Log (LogLevel.Info,
+						"monodroid-timing",
+						"JNIEnv.Initialize end: " + (DateTime.UtcNow - new DateTime (1970, 1, 1)).TotalMilliseconds);
 		}
 
 		internal static void Exit ()


### PR DESCRIPTION
 - measure JNIEnv.Initialize end

 - added timing definitions file parameter to the ProcessLogcatTiming
   task. It contains data series labels and regex patterns to match
   logcat lines with timestamp, separated by semicolon. see
   build-tools/scripts/TimingDefinitions.txt as an example.

   if the pattern contains match named message, then the logger uses
   this match value instead of whole matched line (without timestamp)