### PR TITLE
[Xamarin.Android.Build.Tasks] Crash - NetStandard library - could not load assembly during startup registration.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ TEST_APK_PROJECTS = \
 # Syntax: $(call BUILD_TEST_APK,path/to/project.csproj)
 define BUILD_TEST_APK
 	# Must use xabuild to ensure correct assemblies are resolved
-	MSBUILD="$(MSBUILD)" tools/scripts/xabuild /t:SignAndroidPackage $(1)
+	MSBUILD="$(MSBUILD)" tools/scripts/xabuild $(MSBUILD_FLAGS) /t:SignAndroidPackage $(1)
 endef	# BUILD_TEST_APK
 
 run-apk-tests:

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -273,6 +273,10 @@ namespace Xamarin.Android.Tasks
 
 			int count = 0;
 			foreach (ITaskItem assembly in ResolvedUserAssemblies) {
+
+				if (MonoAndroidHelper.IsReferenceAssembly (assembly.ItemSpec)) {
+					Log.LogWarning ($"{assembly.ItemSpec} is a reference assembly!");
+				}
 				// Add assembly
 				apk.Archive.AddFile (assembly.ItemSpec, GetTargetDirectory (assembly.ItemSpec) + "/"  + Path.GetFileName (assembly.ItemSpec), compressionMethod: CompressionMethod.Store);
 
@@ -305,6 +309,9 @@ namespace Xamarin.Android.Tasks
 			count = 0;
 			// Add framework assemblies
 			foreach (ITaskItem assembly in ResolvedFrameworkAssemblies) {
+				if (MonoAndroidHelper.IsReferenceAssembly (assembly.ItemSpec)) {
+					Log.LogWarning ($"{assembly.ItemSpec} is a reference assembly!");
+				}
 				apk.Archive.AddFile (assembly.ItemSpec, "assemblies/" + Path.GetFileName (assembly.ItemSpec), compressionMethod: CompressionMethod.Store);
 				var config = Path.ChangeExtension (assembly.ItemSpec, "dll.config");
 				AddAssemblyConfigEntry (apk, config);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -8,6 +8,7 @@ using System.Security.Cryptography;
 using Mono.Security.Cryptography;
 using Xamarin.Android.Build.Utilities;
 using Xamarin.Tools.Zip;
+using Mono.Cecil;
 
 #if MSBUILD
 using Microsoft.Build.Framework;
@@ -284,6 +285,14 @@ namespace Xamarin.Android.Tasks
 				return true;
 			}
 			return TargetFrameworkDirectories == null || !checkSdkPath ? false : ExistsInFrameworkPath (assembly);
+		}
+
+		public static bool IsReferenceAssembly (string assembly)
+		{
+			var a = AssemblyDefinition.ReadAssembly (assembly, new ReaderParameters() { InMemory = true, ReadSymbols = false, });
+			if (!a.HasCustomAttributes)
+				return false;
+			return a.CustomAttributes.Any (t => t.AttributeType.FullName == "System.Runtime.CompilerServices.ReferenceAssemblyAttribute");
 		}
 
 		public static bool ExistsInFrameworkPath (string assembly)

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1417,7 +1417,11 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_ResolveAssemblies">
 	<!--- Remove the ImplicitlyExpandDesignTimeFacades assemblies. We have already build the app there are not required for packaging  -->
 	<ItemGroup>
-		<FilteredAssemblies Include="@(ReferencePath)" Condition="'%(ReferencePath.ResolvedFrom)' != 'ImplicitlyExpandDesignTimeFacades'" />
+		<FilteredAssemblies Include="%(ReferenceCopyLocalPaths.Identity)"
+				Condition="'%(ReferenceCopyLocalPaths.ResolvedFrom)' != 'ImplicitlyExpandDesignTimeFacades' And '%(ReferenceCopyLocalPaths.Extension)' == '.dll' And '%(ReferenceCopyLocalPaths.DestinationSubDirectory)' == '' "/>
+		<!-- Fallback to @(ReferencePath) if @(ReferenceCopyLocalPaths) is empty. This is for xbuild support -->
+		<FilteredAssemblies Include="%(ReferencePath.Identity)"
+				Condition="'%(ReferencePath.ResolvedFrom)' != 'ImplicitlyExpandDesignTimeFacades' And '@(ReferenceCopyLocalPaths)' == '' "/>
 	</ItemGroup>
 	<!-- Find all the assemblies this app requires -->
 	<ResolveAssemblies


### PR DESCRIPTION
Context https://bugzilla.xamarin.com/show_bug.cgi?id=57342

The investigation in the bug suggests that we are pickin up a
reference assembly rather than a the actual implementation.
This is to do with the way netstandard nuget packages work, they
include both 'ref' and 'lib' folders.

In this case 'ref' was being included in the package rather than
'lib'. This commit alters the `_ResolveAssemblies` to use

	`@(ReferenceCopyLocalPaths)`

This ItemGroup is populated with the correct items.

We also add a new Warning to detect if we attempt to package a reference assembly.