### PR TITLE
[Xamarin.Android.Build.Tasks] Rework GetAdditionalResourcesFromAssemblies to not download in $(DesignTimeBuild)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -295,7 +295,8 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
       AndroidNdkDirectory="$(_AndroidNdkDirectory)"
       Assemblies="@(ReferencePath);@(ReferenceDependencyPaths)"
       CacheFile="$(IntermediateOutputPath)resourcepaths.cache"
-      Condition=" '$(DesignTimeBuild)' == 'false' Or '$(DesignTimeBuild)' == '' "
+      YieldDuringToolExecution="$(YieldDuringToolExecution)"
+      DesignTimeBuild="$(DesignTimeBuild)"
     />
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -264,6 +264,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<_AndroidSequencePointsMode Condition=" '$(MonoSymbolArchive)' == 'True' And '$(AndroidUseDebugRuntime)' == 'False' And '$(_AndroidSequencePointsMode)' == ''">Normal</_AndroidSequencePointsMode>
 	<_AndroidSequencePointsMode Condition=" '$(_AndroidSequencePointsMode)' == ''">None</_AndroidSequencePointsMode>
 	<_InstantRunEnabled Condition=" '$(_InstantRunEnabled)' == '' ">False</_InstantRunEnabled>
+	<_AndroidBuildPropertiesCache>$(IntermediateOutputPath)build.props</_AndroidBuildPropertiesCache>
 
 </PropertyGroup>
 
@@ -377,7 +378,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </Target>
 
 <Target Name="_BuildAdditionalResourcesCache"
-	Inputs="@(ReferencePath);@(ReferenceDependencyPaths);$(MSBuildProjectFullPath);$(NugetPackagesConfig)"
+	Inputs="@(ReferencePath);@(ReferenceDependencyPaths);$(MSBuildProjectFullPath);$(NugetPackagesConfig);$(_AndroidBuildPropertiesCache)"
 	Outputs="$(_AndroidResourcePathsCache)"
 	DependsOnTargets="$(_BeforeBuildAdditionalResourcesCache)"
 	>
@@ -387,7 +388,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
    Assemblies="@(ReferencePath);@(ReferenceDependencyPaths)"
    CacheFile="$(_AndroidResourcePathsCache)"
    YieldDuringToolExecution="$(YieldDuringToolExecution)"
-   Condition=" '$(DesignTimeBuild)' == 'false' Or '$(DesignTimeBuild)' == '' "
+   DesignTimeBuild="$(DesignTimeBuild)"
   />
 </Target>
 
@@ -979,7 +980,6 @@ because xbuild doesn't support framework reference assemblies.
 	<_AndroidLintConfigFile>$(IntermediateOutputPath)lint.xml</_AndroidLintConfigFile>
 	<_AndroidResourceDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == 'True' ">$(IntermediateOutputPath)$(_AndroidResourceDesigner)</_AndroidResourceDesignerFile>
 	<_AndroidResourceDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' != 'True' ">$(AndroidResgenFile)</_AndroidResourceDesignerFile>
-	<_AndroidBuildPropertiesCache>$(IntermediateOutputPath)build.props</_AndroidBuildPropertiesCache>
 	<_AndroidStaticResourcesFlag>$(IntermediateOutputPath)static.flag</_AndroidStaticResourcesFlag>
 	<_AndroidResourcesCacheFile>$(IntermediateOutputPath)mergeresources.cache</_AndroidResourcesCacheFile>
 </PropertyGroup>
@@ -1006,6 +1006,7 @@ because xbuild doesn't support framework reference assemblies.
 	<_PropertyCacheItems Include="TargetFrameworkVersion=$(TargetFrameworkVersion)" />
 	<_PropertyCacheItems Include="AndroidCreatePackagePerAbi=$(AndroidCreatePackagePerAbi)" />
 	<_PropertyCacheItems Include="OS=$(OS)" />
+	<_PropertyCacheItems Include="DesignTimeBuild=$(DesignTimeBuild)" />
 </ItemGroup>
 
 <Target Name="_ReadPropertiesCache">


### PR DESCRIPTION
Context https://bugzilla.xamarin.com/show_bug.cgi?id=57281

One of the problems we have with downloading content is the DesignTimeBuilds.
We CANNOT allow a DesignTimeBuild to download stuff from the internet.
It will lock up the IDE for however long it takes to get the data
and the user will have no indication as to what is going on.

That said.. in order to get intellisense working we need to make
sure that a default Xamarin.Forms project will at least build in
DesignTime mode.

So we have a problem. We cannot download stuff, but we need it to build.
Fortunately commit 4f10438c allowed the GetAdditionalResourcesFromAssemblies
Task to look in the android-sdk/extras folder to get its required
resources. So we can alter the Task to allow that part to happen, this
will extract the data to the correct location. But we will still make
sure that we do not download any additional data from the internet.

So providing the m2repository bits are installed in the android-sdk/extras
these changes will allow those to be extracted in a DesignTimeBuild.
The idea is those extras should be installed as part of the main installer,
which will allow the default project to build. Obviously if those extras
are not installed the build will still fail. But as already stated
that cannot be avoided.

We also added $(DesignTimeBuild) to the property cache files so we can
ensure that when we do switch to a main build we run GetAdditionalResourcesFromAssemblies
again.