### PR TITLE
[Xamarin.Android.Build.Tests] Fix DesignTimeBuild Test

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using Xamarin.ProjectTools;
 using NUnit.Framework;
 using System.Linq;
+using System.Threading;
 
 namespace Xamarin.Android.Build.Tests
 {
@@ -49,6 +50,12 @@ namespace Xamarin.Android.Build.Tests
 			get {
 				return Path.GetDirectoryName (new Uri (typeof (XamarinProject).Assembly.CodeBase).LocalPath);
 			}
+		}
+
+		protected void WaitFor(int milliseconds)
+		{
+			var pause = new ManualResetEvent(false);
+			pause.WaitOne(milliseconds);
 		}
 
 		protected static string RunAdbCommand (string command, bool ignoreErrors = true)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Diagnostics;
 using Microsoft.Build.Framework;
 using System.Text;
+using System.Collections.Generic;
 
 namespace Xamarin.ProjectTools
 {
@@ -97,7 +98,7 @@ namespace Xamarin.ProjectTools
 			return null;
 		}
 
-		protected bool BuildInternal (string projectOrSolution, string target, string [] parameters = null)
+		protected bool BuildInternal (string projectOrSolution, string target, string [] parameters = null, Dictionary<string, string> environmentVariables = null)
 		{
 			string buildLogFullPath = (!string.IsNullOrEmpty (BuildLogFile))
 				? Path.GetFullPath (Path.Combine (Root, Path.GetDirectoryName (projectOrSolution), BuildLogFile))
@@ -154,7 +155,13 @@ namespace Xamarin.ProjectTools
 					args.AppendFormat (" /p:{0}", param);
 				}
 			}
+			if (environmentVariables != null) {
+				foreach (var kvp in environmentVariables) {
+					psi.EnvironmentVariables[kvp.Key] = kvp.Value;
+				}
+			}
 			psi.Arguments = args.ToString ();
+			
 			psi.CreateNoWindow = true;
 			psi.UseShellExecute = false;
 			psi.RedirectStandardOutput = true;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -54,7 +54,7 @@ namespace Xamarin.ProjectTools
 				project.UpdateProjectFiles (ProjectDirectory, files, doNotCleanupOnUpdate);
 		}
 
-		public bool Build (XamarinProject project, bool doNotCleanupOnUpdate = false, string [] parameters = null, bool saveProject = true)
+		public bool Build (XamarinProject project, bool doNotCleanupOnUpdate = false, string [] parameters = null, bool saveProject = true, Dictionary<string, string> environmentVariables = null)
 		{
 			Save (project, doNotCleanupOnUpdate, saveProject);
 
@@ -62,7 +62,7 @@ namespace Xamarin.ProjectTools
 
 			project.NuGetRestore (ProjectDirectory, PackagesDirectory);
 
-			bool result = BuildInternal (Path.Combine (ProjectDirectory, project.ProjectFilePath), Target, parameters);
+			bool result = BuildInternal (Path.Combine (ProjectDirectory, project.ProjectFilePath), Target, parameters, environmentVariables);
 			built_before = true;
 
 			if (CleanupAfterSuccessfulBuild)
@@ -83,12 +83,12 @@ namespace Xamarin.ProjectTools
 			}
 		}
 
-		public bool UpdateAndroidResources (XamarinProject project, bool doNotCleanupOnUpdate = false, string [] parameters = null)
+		public bool UpdateAndroidResources (XamarinProject project, bool doNotCleanupOnUpdate = false, string [] parameters = null, Dictionary<string, string> environmentVariables = null)
 		{
 			var oldTarget = Target;
 			Target = "UpdateAndroidResources";
 			try {
-				return Build (project, doNotCleanupOnUpdate: doNotCleanupOnUpdate, parameters: parameters);
+				return Build (project, doNotCleanupOnUpdate: doNotCleanupOnUpdate, parameters: parameters, environmentVariables: environmentVariables);
 			}
 			finally {
 				Target = oldTarget;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -377,6 +377,12 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	</PropertyGroup>
 </Target>
 
+<PropertyGroup>
+	<_BeforeBuildAdditionalResourcesCache>
+		_CreatePropertiesCache;
+	</_BeforeBuildAdditionalResourcesCache>
+</PropertyGroup>
+
 <Target Name="_BuildAdditionalResourcesCache"
 	Inputs="@(ReferencePath);@(ReferenceDependencyPaths);$(MSBuildProjectFullPath);$(NugetPackagesConfig);$(_AndroidBuildPropertiesCache)"
 	Outputs="$(_AndroidResourcePathsCache)"


### PR DESCRIPTION
The test was using the global cache to store the downloaded files.
As a result if we get multiple tests/commits building at the
same time we end up deleting files half way through a test run.

So lets make use of a local cache for the test by using the
`XAMARIN_CACHEPATH` environment variable.