### PR TITLE
[javadoc-to-mdoc] Fix `$(OutputPath)` value

### DIFF
--- a/tools/javadoc2mdoc/javadoc2mdoc.csproj
+++ b/tools/javadoc2mdoc/javadoc2mdoc.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>javadoc-to-mdoc</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
   </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>


### PR DESCRIPTION
`javadoc2mdoc.csproj` was using the wrong `$(OutputPath)` value,
because it wasn't importing `Configuration.props`, and thus
`$(XAInstallPrefix)` was undefined.

Consequently, instead of `javadoc-to-mdoc.exe` being built into
`bin/$(Configuration)/lib/xamarin.android/xbuild/Xamarin/Android`, it
was instead built into `tools/javadoc2mdoc/xbuild/Xamarin/Android`.

Add the appropriate `<Import/>` so `javadoc-to-mdoc.exe` is placed
into the correct directory.