### PR TITLE
Add support for pre-loading app native libraries

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.java
@@ -31,6 +31,7 @@ public class MonoPackageManager {
 				);
 				context.registerReceiver (new mono.android.app.NotifyTimeZoneChanges (), timezoneChangedFilter);
 				
+				preloadAppNativeLibraries(context);
 				System.loadLibrary("monodroid");
 				Locale locale       = Locale.getDefault ();
 				String language     = locale.getLanguage () + "-" + locale.getCountry ();
@@ -77,6 +78,27 @@ public class MonoPackageManager {
 		if (android.os.Build.VERSION.SDK_INT >= 9)
 			return ainfo.nativeLibraryDir;
 		return ainfo.dataDir + "/lib";
+	}
+
+	static void preloadAppNativeLibraries(Context context) {
+		InputStream assetStream = null;
+		try {
+			assetStream = context.getAssets().open("ld_preload.txt");
+			BufferedReader reader = new BufferedReader(new InputStreamReader(assetStream));
+
+			String lib = null;
+			while ((lib = reader.readLine()) != null) {
+				try {
+					System.loadLibrary(lib);
+				} catch (Throwable t) {
+					Log.e("MonoPackageManager", "OOPS : " + t);
+				}
+			}
+		} catch (Throwable t) {
+
+		} finally {
+			try { assetStream.close(); } catch (Throwable t2) { }
+		}
 	}
 
 	public static String[] getAssemblies ()


### PR DESCRIPTION
* Libraries are listed one-per-line in 'ld_preload.txt' file bundled in Android assets

* Pre-loading of the libraries occurs before libmonodroid.so is loaded

* The primary use case here is to load a native crash manager (e.g., a custom-built libBreakpad.so) which can install its signal handlers (via ELF SHT_INIT_ARRAY ctors) below the Mono signal handlers