### PR TITLE
bump linker to get fix for #57645

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,6 +13,7 @@
 [submodule "external/linker"]
     path = external/linker
     url = https://github.com/mono/linker.git
+    branch = d15-4
 [submodule "external/llvm"]
     path = external/llvm
     url = https://github.com/mono/llvm.git


### PR DESCRIPTION
 - fixed by this commit:

    commit ee94279affccc16396cf97aac281e287515c866f
    Author: Radek Doulik <rodo@xamarin.com>
    Date:   Fri Jul 28 16:28:12 2017 +0200

        [linker] added workaround for invalid type forwards

         - fixes #57645

         - ignore invalid forwards of nested types of exported forwarded
           types, which were added by a bug in csc. description by Marek Safar
           from https://bugzilla.xamarin.com/show_bug.cgi?id=57645#c13

             Native csc (pre-Roslyn version) when encountered typeforwarded
             type it added automatically all its nested types including
             private/protected/internal ones.  This bug was fixed in Roslyn
             csc but there are still many assemblies compiled with native csc
             (pre VS2015) which can have typeforwarded typeref to a type which
             is not available because it's not included in public API.

         - ignoring these forwarders here should be harmless, because if these
           types were used somewhere in the application, the linker would fail
           in the mark step, when trying to resolve the typereference to them

         - also added throwing the LoadException in case of missing non-nested
           forwarded exported types, instead of just crashing with
           System.NullReferenceException