### PR TITLE
[Xamarin.Android.Build.Tasks] Sample for Microsoft Intune is failing - System.NullReferenceException at IntuneMAMSampleAndroid.EntryActivity.OnCreate

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1244,7 +1244,8 @@ because xbuild doesn't support framework reference assemblies.
 		$(MSBuildAllProjects);
 		@(_AndroidResourceDest);
 		@(_LibraryResourceDirectoryStamps);
-		@(_AdditonalAndroidResourceCachePaths->'%(Identity)\cache.stamp')
+		@(_AdditonalAndroidResourceCachePaths->'%(Identity)\cache.stamp');
+		$(_AndroidBuildPropertiesCache)
 	</_UpdateAndroidResgenInputs>
 </PropertyGroup>
 


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=57279

The DesignTimeBuilds are causing a bit of a problem.
Because they are being run as soon as the project is loaded, it
does result in the `_UpdateAndroidResGen` thinking that the
resources are up to date. This results in the following

> find . -iname R.java | xargs grep EntryActivityStartButton
> ./IntuneMAMSampleAndroid/obj/AnyCPU/Debug/android/com/microsoft/intune/mam/R.java:        public static final int EntryActivityStartButton=0x7f070000;
> ./IntuneMAMSampleAndroid/obj/AnyCPU/Debug/android/microsoftintunemamsampleandroid/microsoftintunemamsampleandroid/R.java:        public static final int EntryActivityStartButton=0x7f070000;
> ./IntuneMAMSampleAndroid/obj/AnyCPU/Debug/android/src/android/support/v4/R.java:        public static int EntryActivityStartButton=0x7f0c0050;
> ./IntuneMAMSampleAndroid/obj/AnyCPU/Debug/android/src/android/support/v7/appcompat/R.java:        public static int EntryActivityStartButton=0x7f0c0050;
> ./IntuneMAMSampleAndroid/obj/AnyCPU/Debug/android/src/com/microsoft/intune/mam/R.java:        public static final int EntryActivityStartButton=0x7f0c0050;
> ./IntuneMAMSampleAndroid/obj/AnyCPU/Debug/android/src/microsoftintunemamsampleandroid/microsoftintunemamsampleandroid/R.java:        public static final int EntryActivityStartButton=0x7f0c0050;

Note that the `EntryActivityStartButton` value is different, they should all
be the same. This is because the `_UpdateAndroidResGen` target
was NOT running.

Fortunately commit 1cd582ec adds `$(DesignTimeBuild)` to the list
of properties in the `@(_PropertyCacheItems)` ItemGroup. So we can
now use the `$(_AndroidBuildPropertiesCache)` property to detect
when we are moving from a DesignTimeBuild into a normal Build.
This means the resources are then generated correctly.