### PR TITLE
[xa-prep-tasks] fix bad Array.Copy call

### DIFF
--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/Which.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/Which.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 			FileExtensions  = new string [(pathExts?.Length ?? 0) + 1];
 			FileExtensions [0] = null;
 			if (pathExts != null) {
-				Array.Copy (pathExts, 0, FileExtensions, 1, pathExt.Length);
+				Array.Copy (pathExts, 0, FileExtensions, 1, pathExts.Length);
 			}
 		}
 


### PR DESCRIPTION
On Windows, `Array.Copy` will throw an `ArgumentException` for various Git
MSBuild tasks. Turns out the call is using the wrong variable: the
string instead of the array. I am not sure why this works on OSX, I
suspect Mono isn't validating input the same way as Windows and it
_happens_ to work.

NOTE: we could also just rename these two variable to have different names:
`pathExtEnv` and `pathExtSplit` or similar