### PR TITLE
[Mono.Android] Fix API Level 24 build regarding FileChannel.

### DIFF
--- a/src/Mono.Android/Java.Nio/FileChannel.cs
+++ b/src/Mono.Android/Java.Nio/FileChannel.cs
@@ -1,4 +1,4 @@
-#if ANDROID_25
+#if ANDROID_24
 
 using System;
 


### PR DESCRIPTION
It turned out that there had been a build failure that had been ignored
on the mac jenkins builders:

        obj/Debug/android-24/mcw/Java.Nio.Channels.FileChannel.cs(10,213): error CS0738: 'FileChannel' does not implement interface member 'ISeekableByteChannel.Position(long)'. 'FileChannel.Position(long)' cannot implement 'ISeekableByteChannel.Position(long)' because it does not have the matching return type of 'ISeekableByteChannel'.
        obj/Debug/android-24/mcw/Java.Nio.Channels.FileChannel.cs(10,213): error CS0738: 'FileChannel' does not implement interface member 'ISeekableByteChannel.Truncate(long)'. 'FileChannel.Truncate(long)' cannot implement 'ISeekableByteChannel.Truncate(long)' because it does not have the matching return type of 'ISeekableByteChannel'