### PR TITLE
[Xamarin.Android.Build.Tasks] Preserve @(AndroidEnvironment)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -259,8 +259,8 @@ namespace Xamarin.Android.Tasks
 						// temporarily extracted directory will look like:
 						//    __library_projects__/[dllname]/[library_project_imports | jlibs]/bin
 						using (var zip = MonoAndroidHelper.ReadZipFile (finfo.FullName)) {
-							updated |= Files.ExtractAll (zip, outDirForDll, modifyCallback: (entryFullName) => {
-								return entryFullName.Replace ("library_project_imports", ImportsDirectory);
+							updated |= Files.ExtractAll (zip, importsDir, modifyCallback: (entryFullName) => {
+								return entryFullName.Replace ("library_project_imports/", "");
 							}, forceUpdate: false);
 						}
 

--- a/tests/locales/LibraryResources/Environment.txt
+++ b/tests/locales/LibraryResources/Environment.txt
@@ -1,0 +1,1 @@
+THIS_IS_MY_ENVIRONMENT=Well, hello there!

--- a/tests/locales/LibraryResources/LibraryResources.csproj
+++ b/tests/locales/LibraryResources/LibraryResources.csproj
@@ -52,6 +52,9 @@
   <ItemGroup>
     <AndroidResource Include="Resources\values\Strings.xml" />
   </ItemGroup>
+  <ItemGroup>
+    <AndroidEnvironment Include="Environment.txt" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <ItemGroup>
     <EmbeddedResource Include="strings.de-DE.resx" />

--- a/tests/locales/Xamarin.Android.Locale-Tests/EnvironmentTests.cs
+++ b/tests/locales/Xamarin.Android.Locale-Tests/EnvironmentTests.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Reflection;
+
+using NUnit.Framework;
+
+namespace Xamarin.Android.LocaleTests
+{
+	[TestFixture]
+	public class EnvironmentTests
+	{
+		[Test (Description="https://bugzilla.xamarin.com/show_bug.cgi?id=58673")]
+		public void EnvironmentVariablesFromLibraryProjectsAreMerged ()
+		{
+			var v = Environment.GetEnvironmentVariable ("THIS_IS_MY_ENVIRONMENT");
+			Assert.AreEqual (v, "Well, hello there!");
+		}
+	}
+}
+

--- a/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj
+++ b/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj
@@ -51,6 +51,7 @@
     <Reference Include="Xamarin.Android.NUnitLite" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EnvironmentTests.cs" />
     <Compile Include="MainActivity.cs" />
     <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=58673

The `@(AndroidEnvironment)` Build action is *supposed to be* usable on
Library projects. When used within a Library project, the
`@(AndroidEnvironment)` files are embedded into the assembly, and
during the App project build they are extracted and merged into the
`environment` file within the `.apk`.

Unfortunately, this behavior was potentially broken in commit
86888322, as if the Library assembly also contains the
`__AndroidLibraryProjects__.zip` embedded resource (e.g. the Library
project has a `@(AndroidResource)` Build action), the extraction of
the `__AndroidLibraryProjects__.zip` resource will inadvertently
remove the previously extracted `@(AndroidEnvironment)` files.

Oops.

Alter the paths provided to `Files.ExtractAll()` -- which was
directly responsible for deleting the environment files -- so that it
won't delete the environment files.

Update the `tests/locales` on-device unit tests to make use of a
Library-provided `@(AndroidEnvironment)`, and add a unit test which
reads the environment variable and asserts that the environment
variable has the expected value.