### PR TITLE
[Xamarin.Android.Build.Tasks] IDE0006 warning on File -> New CrossPlatform App

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Common/ImportAfter/Microsoft.Cpp.Android.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Common/ImportAfter/Microsoft.Cpp.Android.targets
@@ -52,7 +52,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
             <Output TaskParameter="TargetOutputs" ItemName="_NativeAndroidRecipeFiles"/>
         </MSBuild>
 
-        <MergeApkRecipelists RecipeFiles="@(_NativeAndroidRecipeFiles)" Condition="'@(_NativeAndroidRecipeFiles)' != ''">
+        <MergeApkRecipelists RecipeFiles="%(_NativeAndroidRecipeFiles.Identity)" Condition="'@(_NativeAndroidRecipeFiles)' != '' And Exists('%(_NativeAndroidRecipeFiles.Identity)')">
             <Output TaskParameter="SOLibPaths" ItemName="NativeLibraryPaths" />
             <Output TaskParameter="AndroidArchitecture" PropertyName="NativeLibraryAbi" />
             <Output TaskParameter="HasMismatchedConfigurations" PropertyName="NativeHasMismatchedConfigurations" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -295,6 +295,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 		Inputs="$(MSBuildProjectFullPath);$(_AndroidBuildPropertiesCache)"
 		Outputs="$(_AndroidLibraryProjectImportsCache)">
 	<ResolveLibraryProjectImports
+		ContinueOnError="$(DesignTimeBuild)"
 		CacheFile="$(_AndroidLibraryProjectImportsCache)"
 		Assemblies="@(ReferencePath);@(ReferenceDependencyPaths)"
 		ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1072,6 +1072,7 @@ because xbuild doesn't support framework reference assemblies.
 		Inputs="$(MSBuildProjectFullPath);@(ReferencePath);@(ReferenceDependencyPaths);$(_AndroidBuildPropertiesCache)"
 		Outputs="$(_AndroidLibraryProjectImportsCache)">
 	<ResolveLibraryProjectImports
+		ContinueOnError="$(DesignTimeBuild)"
 		CacheFile="$(_AndroidLibraryProjectImportsCache)"
 		Assemblies="@(ReferencePath);@(ReferenceDependencyPaths)"
 		ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
@@ -1324,6 +1325,7 @@ because xbuild doesn't support framework reference assemblies.
 
   <!-- Parse primary R.java and create Resources.Designer.cs -->
 	<GenerateResourceDesigner
+		ContinueOnError="$(DesignTimeBuild)"
 		NetResgenOutputFile="$(ResgenTemporaryDirectory)\$(AndroidResgenFilename)"
 		JavaResgenInputFile="$(_GeneratedPrimaryJavaResgenFile)"
 		Namespace="$(AndroidResgenNamespace)"


### PR DESCRIPTION
Context https://bugzilla.xamarin.com/show_bug.cgi?id=58448

Based on feedback from the VS team we now know that library
projects are NEVER built as part of a DesignTimeBuild :(.

Furthermore, if ANY error occurs during the DesignTimeBuild
VS throws a wobbly and does not initialise the project
correctly. The suggestion is to use `ContinueOnError` to
ignore the errors and allow the build to complete.