### PR TITLE
[Xamarin.Android.Build.Tests] Fix a weird error when compiling the wear tests.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Wear/Strings.xml
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Wear/Strings.xml
@@ -3,4 +3,10 @@
 	<string name="hello_rect">I\'m Rect. Tap Me!</string>
 	<string name="hello_round">I\'m Round. Tap Me!</string>
 	<string name="app_name">${PROJECT_NAME}</string>
+	<string name="auth_client_needs_enabling_title"></string>
+	<string name="auth_client_needs_installation_title"></string>
+	<string name="auth_client_needs_update_title"></string>
+	<string name="auth_client_play_services_err_notification_msg"></string>
+	<string name="auth_client_requested_by_msg"></string>
+	<string name="auth_client_using_bad_version_title"></string>
 </resources>


### PR DESCRIPTION
This fixes an error we are seeing in the unit test

	`warning: error APT0000: string 'auth_client_needs_enabling_title' has no default translation.`

It looks like there are a number of strings which are required to
have a default value (even if its blank).