### PR TITLE
[Xamarin.Android.Build.Tasks] _CleanGeneratedDebuggingFiles target removes ALL .pdbs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertDebuggingFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertDebuggingFiles.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Collections.Generic;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Pdb2Mdb;
@@ -12,11 +13,15 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public ITaskItem[] Files { get; set; }
 
+		[Output]
+		public ITaskItem[] ConvertedFiles { get; set; }
+
 		public override bool Execute ()
 		{
 			Log.LogDebugMessage ("ConvertDebuggingFiles Task");
 			Log.LogDebugMessage ("  InputFiles: {0}", Files);
 
+			var convertedFiles = new List<ITaskItem> ();
 			foreach (var file in Files) {
 				var pdb = file.ToString ();
 
@@ -26,11 +31,13 @@ namespace Xamarin.Android.Tasks
 				try {
 					MonoAndroidHelper.SetWriteable (pdb);
 					Converter.Convert (Path.ChangeExtension (pdb, ".dll"));
+					convertedFiles.Add (new TaskItem (Path.ChangeExtension (pdb, ".dll")));
 				} catch (Exception ex) {
 					Log.LogWarningFromException (ex, true);
 				}
 			}
-
+			ConvertedFiles = convertedFiles.ToArray ();
+			Log.LogDebugTaskItems ("[Output] ConvertedFiles:", ConvertedFiles);
 			return true;
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1556,7 +1556,13 @@ because xbuild doesn't support framework reference assemblies.
 		Inputs="@(_ResolvedPdbFiles)"
 		Outputs="@(_ResolvedPdbFiles->'%(RootDir)%(Directory)%(Filename).dll.mdb')"
 		DependsOnTargets="_CollectPdbFiles">
-	<ConvertDebuggingFiles Files="@(_ResolvedPdbFiles)" />
+	<ConvertDebuggingFiles Files="@(_ResolvedPdbFiles)">
+		<Output TaskParameter="ConvertedFiles" ItemName="_ConvertedDebuggingFiles" />
+	</ConvertDebuggingFiles>
+	<WriteLinesToFile
+		File="$(IntermediateOutputPath)$(CleanFile)"
+		Lines="@(_ConvertedDebuggingFiles)"
+		Overwrite="false" />
 </Target>
 
 <Target Name="_CopyMdbFiles"
@@ -1565,13 +1571,20 @@ because xbuild doesn't support framework reference assemblies.
 		DependsOnTargets="_ConvertPdbFiles;_CollectMdbFiles" >
 	<CopyMdbFiles
 			SourceFiles="@(_ResolvedMdbFiles);@(_ResolvedPortablePdbFiles)"
-			DestinationFiles="@(_ResolvedMdbFiles->'$(OutputPath)%(Filename)%(Extension)');@(_ResolvedPortablePdbFiles->'$(OutputPath)%(Filename)%(Extension)')"
-	/>
+			DestinationFiles="@(_ResolvedMdbFiles->'$(OutputPath)%(Filename)%(Extension)');@(_ResolvedPortablePdbFiles->'$(OutputPath)%(Filename)%(Extension)')">
+		<Output TaskParameter="CopiedFiles" ItemName="_MdbFilesCopied" />
+	</CopyMdbFiles>
 	<Copy
-		SourceFiles="@(_ResolvedMdbFiles->'$(OutputPath)%(Filename)%(Extension)');@(_ResolvedPortablePdbFiles->'$(OutputPath)%(Filename)%(Extension)')"
-		DestinationFiles="@(_ResolvedMdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)');@(_ResolvedPortablePdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
-		SkipUnchangedFiles="true"
-	/>
+			SourceFiles="@(_ResolvedMdbFiles->'$(OutputPath)%(Filename)%(Extension)');@(_ResolvedPortablePdbFiles->'$(OutputPath)%(Filename)%(Extension)')"
+			DestinationFiles="@(_ResolvedMdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)');@(_ResolvedPortablePdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
+			SkipUnchangedFiles="true">
+		<Output TaskParameter="CopiedFiles" ItemName="_DebugFilesCopiedToLinkerSrc" />
+	</Copy>
+	<Touch Files="@(_DebugFilesCopiedToLinkerSrc)" />
+	<WriteLinesToFile
+		File="$(IntermediateOutputPath)$(CleanFile)"
+		Lines="@(_MdbFilesCopied);@(_DebugFilesCopiedToLinkerSrc)"
+		Overwrite="false" />
 </Target>
 	
 <Target Name="_LinkAssemblies"
@@ -2408,13 +2421,6 @@ because xbuild doesn't support framework reference assemblies.
 
 <!-- Cleaning -->
 
-<Target Name="_CleanGeneratedDebuggingFiles">
-	<ItemGroup>
-		<_OutputDebugSymbolFiles Include="$(OutputPath)*.dll.mdb;$(OutputPath)*.pdb" />
-	</ItemGroup>
-	<Delete Files="@(_OutputDebugSymbolFiles)"/>
-</Target>
-
 <Target Name="_CleanMsymArchive">
 	<GetAndroidPackageName ManifestFile="$(ProjectDir)$(AndroidManifest)" AssemblyName="$(AssemblyName)">
 		<Output TaskParameter="PackageName" PropertyName="_AndroidPackage" />
@@ -2429,7 +2435,7 @@ because xbuild doesn't support framework reference assemblies.
 	<Delete Files="@(_OutputDeploymentFiles)"/>
 </Target>
 
-<Target Name="_CleanMonoAndroidIntermediateDir" DependsOnTargets="_CleanGeneratedDebuggingFiles;_CleanGeneratedDeploymentFiles;_CleanMsymArchive">
+<Target Name="_CleanMonoAndroidIntermediateDir" DependsOnTargets="_CleanGeneratedDeploymentFiles;_CleanMsymArchive">
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)android" Condition="Exists ('$(MonoAndroidIntermediate)android')" />
 	<!-- FIXME: remove this extraneous rmdir after a few release cycles since we release the one we killed it. -->
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)assemblies" Condition="Exists ('$(MonoAndroidIntermediate)assemblies')" />


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=58646

Rather than just blindly delete ALL the debug files in the
`$(OutputPath)` we should be a bit more selective.

So instead we add the files to the

	`$(IntermediateOutputPath)$(CleanFile)`

so that they can be cleaned up automatically using the in
build xbuild/msbuild Clean systems.