### PR TITLE
[xa-prep-tasks] implemented GitCommitTime task

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -106,10 +106,13 @@
   </Target>
   <Target Name="_SetMxeToolchainMakefileTimeToLastCommitTimestamp"
       Condition=" '$(NeedMxe)' == 'true' And ($(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:')))">
-    <Exec
-        Command="touch -m -t `git log -1 --format=%25cd --date=format-local:%25Y%25m%25d%25H%25M.%25S` Makefile"
+    <GitCommitTime
         WorkingDirectory="..\..\external\mxe"
-    />
+        ToolPath="$(GitToolPath)"
+        ToolExe="$(GitToolExe)">
+      <Output TaskParameter="Time" PropertyName="_MxeCommitTime" />
+    </GitCommitTime>
+    <Touch Files="..\..\external\mxe\Makefile" Time="$(_MxeCommitTime)" />
   </Target>
   <ItemGroup>
     <_AndroidMxeToolchain Include="$(MingwCommandPrefix32)" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:'))" />

--- a/build-tools/libzip/libzip.targets
+++ b/build-tools/libzip/libzip.targets
@@ -13,10 +13,13 @@
   <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
   <Target Name="Clean" />
   <Target Name="_SetCMakeListsTxtTimeToLastCommitTimestamp">
-    <Exec
-        Command="touch -m -t `git log -1 --format=%25cd --date=format-local:%25Y%25m%25d%25H%25M.%25S` CMakeLists.txt"
+    <GitCommitTime
         WorkingDirectory="$(LibZipSourceFullPath)"
-    />
+        ToolPath="$(GitToolPath)"
+        ToolExe="$(GitToolExe)">
+      <Output TaskParameter="Time" PropertyName="_LibZipCommitTime" />
+    </GitCommitTime>
+    <Touch Files="$(LibZipSourceFullPath)\CMakeLists.txt" Time="$(_LibZipCommitTime)" />
   </Target>
   <Target Name="_Configure"
       Condition=" '@(_LibZipTarget)' != '' "

--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.GitCommitTime" />
   <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
   <PropertyGroup>
     <_SourceTopDir>..\..</_SourceTopDir>
@@ -116,14 +117,20 @@
     />
   </ItemGroup>
   <Target Name="_SetAutogenShTimeToLastCommitTimestamp">
-    <Exec
-        Command="touch -m -t `git log -1 --format=%25cd --date=format-local:%25Y%25m%25d%25H%25M.%25S` autogen.sh"
+    <GitCommitTime
         WorkingDirectory="$(MonoSourceFullPath)"
-    />
-    <Exec
-        Command="touch -m -t `git log -1 --format=%25cd --date=format-local:%25Y%25m%25d%25H%25M.%25S` Makefile.config.in"
+        ToolPath="$(GitToolPath)"
+        ToolExe="$(GitToolExe)">
+      <Output TaskParameter="Time" PropertyName="_MonoCommitTime" />
+    </GitCommitTime>
+    <Touch Files="$(MonoSourceFullPath)\autogen.sh" Time="$(_MonoCommitTime)" />
+    <GitCommitTime
         WorkingDirectory="$(LlvmSourceFullPath)"
-    />
+        ToolPath="$(GitToolPath)"
+        ToolExe="$(GitToolExe)">
+      <Output TaskParameter="Time" PropertyName="_LlvmCommitTime" />
+    </GitCommitTime>
+    <Touch Files="$(LlvmSourceFullPath)\Makefile.config.in" Time="$(_LlvmCommitTime)" />
   </Target>
   <Target Name="_PrepareLlvmItems">
     <ItemGroup>

--- a/build-tools/scripts/RequiredPrograms.targets
+++ b/build-tools/scripts/RequiredPrograms.targets
@@ -3,6 +3,7 @@
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.DownloadUri" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.PrepareInstall" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.Which" />
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.GitCommitTime" />
   <Target Name="CheckForRequiredPrograms"
       Condition=" '@(RequiredProgram)' != '' "
       Inputs="@(RequiredProgram)"

--- a/build-tools/scripts/XAVersionInfo.targets
+++ b/build-tools/scripts/XAVersionInfo.targets
@@ -4,6 +4,7 @@
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.GitBranch" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.GitCommitHash" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.GitCommitsInRange" />
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.GitCommitTime" />
   <Target Name="GetXAVersionInfo">
     <GitBlame
         FileName="$(XamarinAndroidSourcePath)\Configuration.props"

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitCommitTime.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitCommitTime.cs
@@ -1,0 +1,46 @@
+﻿using System;
+
+using Microsoft.Build.Framework;
+
+namespace Xamarin.Android.BuildTools.PrepTasks
+{
+	public sealed class GitCommitTime : Git
+	{
+		[Output]
+		public string Time { get; set; }
+
+		protected override bool LogTaskMessages {
+			get { return false; }
+		}
+
+		public GitCommitTime ()
+		{
+		}
+
+		public override bool Execute ()
+		{
+			Log.LogMessage (MessageImportance.Low, $"Task {nameof (GitCommitTime)}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (WorkingDirectory)}: {WorkingDirectory.ItemSpec}");
+
+			base.Execute ();
+
+			Log.LogMessage (MessageImportance.Low, $"  [Output] {nameof (Time)}: {Time}");
+
+			return !Log.HasLoggedErrors;
+		}
+
+		protected override string GenerateCommandLineCommands ()
+		{
+			//NOTE: this command needs to return a string that is valid to pass to DateTime.Parse()
+			//	The <Touch> MSBuild task requires this: https://docs.microsoft.com/en-us/visualstudio/msbuild/touch-task
+			return "log -1 --format=%cd --date=format-local:\"%Y/%m/%d %H:%M:%S\"";
+		}
+
+		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
+		{
+			if (string.IsNullOrEmpty (singleLine))
+				return;
+			Time = singleLine;
+		}
+	}
+}

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -41,6 +41,7 @@
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\Git.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\GitBranch.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\GitCommitHash.cs" />
+    <Compile Include="Xamarin.Android.BuildTools.PrepTasks\GitCommitTime.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\HashFileContents.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\PathToolTask.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\SystemUnzip.cs" />

--- a/src/sqlite-xamarin/sqlite-xamarin.targets
+++ b/src/sqlite-xamarin/sqlite-xamarin.targets
@@ -1,9 +1,12 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="_SetReadmeTimeToLastCommitTimestamp">
-    <Exec
-        Command="touch -m -t `git log -1 --format=%25cd --date=format-local:%25Y%25m%25d%25H%25M.%25S` README.version"
+    <GitCommitTime
         WorkingDirectory="$(SqliteSourceFullPath)"
-    />
+        ToolPath="$(GitToolPath)"
+        ToolExe="$(GitToolExe)">
+      <Output TaskParameter="Time" PropertyName="_SqliteCommitTime" />
+    </GitCommitTime>
+    <Touch Files="$(SqliteSourceFullPath)\README.version" Time="$(_SqliteCommitTime)" />
   </Target>
   <ItemGroup>
     <!-- build outputs include (if enabled):


### PR DESCRIPTION
Context: #181 (in comments)

In several places throughout the build, we are running a command such
as the following, which will not work on Windows:
```
<Exec Command="touch -m -t `git log -1 --format=%25cd --date=format-local:%25Y%25m%25d%25H%25M.%25S` Makefile" />
```

The solution is to create an MSBuild task in xa-prep-tasks named
`GitCommitTime` that will work cross-platform. `GitCommitTime` returns
a string value that can be passed to the `Touch` MSBuild task.