### PR TITLE
[create-vsix] Windows native libs are in Xamarin/Android

### DIFF
--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -38,6 +38,7 @@
       <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\lib\host-Linux\**\*.*" />
       <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\Darwin\**\*.*" />
       <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\Linux\**\*.*" />
+      <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\**\*.dylib" />
       <MSBuild Include="..\..\src\Xamarin.Android.Build.Tasks\MSBuild\Xamarin\**\*.*" />
       <MSBuild>
         <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Xamarin/%(RecursiveDir)</VSIXSubPath>
@@ -45,9 +46,14 @@
       <MSBuild>
         <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Xamarin/Android/%(RecursiveDir)</VSIXSubPath>
       </MSBuild>
+      <MSBuild>
+        <VSIXSubPath Condition=" '%(VSIXSubPath)' == 'Xamarin/Android/lib/host-mxe-Win64/' ">Xamarin/Android/</VSIXSubPath>
+      </MSBuild>
       <MSBuild Remove="$(LibDir)xbuild\**\*.d.dll" />
       <MSBuild Remove="$(LibDir)xbuild\**\*.d.exe" />
       <ReferenceAssemblies Include="$(LibDir)xbuild-frameworks\**\*.*" />
+      <ReferenceAssemblies Remove="**\*.dylib" />
+      <ReferenceAssemblies Remove="**\libZipSharp*.*" />
       <ReferenceAssemblies>
         <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Microsoft/Framework/%(RecursiveDir)</VSIXSubPath>
       </ReferenceAssemblies>


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=58693

The Android Designer is not working as desired when using a
`monodroid`-generated `Xamarin.Android.Sdk.*.vsix` file, stating:

	Renderer >> WARNING: No Xamarin.Android support for custom controls detected. Disabling.

This message actually means that `libmono-android.debug.dll` can't be
found. On Windows, the designer expects `libmono-android.debug.dll` --
along with `libmonosgen-2.0.dll` -- to be installed into the
`$MSBuild/Xamarin/Android` directory.

Unfortunately, this wasn't the case; it was instead installed as:

	$MSBuild/Xamarin/Android/lib/host-mxe-Win64/libmono-android.debug.dll
	$MSBuild/Xamarin/Android/lib/host-win/libmono-android.debug.dll

Update `create-vsix.targets` so that the
`Xamarin/Android/lib/lib/host-mxe-Win64/*.*` files are installed into
the `$MSBuild/Xamarin/Android` directory, so that the Android Designer
can find these files.

Additionally, further cleanup the `.vsix` contents:

  * Don't include `*.dylib` files. Those are for use on macOS.
  * Don't include `libZipSharp`-related files in the
    `$ReferenceAssemblies` directory. `libZipSharp.dll` is not a
    mobile API -- and it wasn't being installed, anyway -- and it
    makes no sense to install `libZipSharp.dll.config` there.