### PR TITLE
[build] Don't install FSharp.Core assemblies

### DIFF
--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -21,14 +21,6 @@
     />
     <MonoDocCopyItem Include="monodoc.dll.config" />
   </ItemGroup>
-  <ItemGroup>
-    <FSharpItem Include="FSharp.Core.dll" />
-    <FSharpItem Include="FSharp.Core.optdata" />
-    <FSharpItem Include="FSharp.Core.sigdata" />
-  </ItemGroup>
-  <ItemGroup>
-    <_FSharpInstalledItems Include="@(FSharpItem->'$(_BclFrameworkDir)%(Identity)')" />
-  </ItemGroup>
   <UsingTask AssemblyFile="$(_SourceTopDir)\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.GetNugetPackageBasePath" />
   <ItemGroup>
     <_MonoDocCopyItems Include="@(MonoDocCopyItem->'$(_MonoOutputDir)\%(Identity)')" />
@@ -447,11 +439,7 @@
     <ItemGroup>
       <_PackageConfigFiles Include="$(_SourceTopDir)\src\Xamarin.Android.Build.Tasks\packages.config" />
     </ItemGroup>
-    <GetNugetPackageBasePath PackageConfigFiles="@(_PackageConfigFiles)" PackageName="FSharp.Core">
-      <Output TaskParameter="BasePath" PropertyName="_FSharpCorePackagePath" />
-    </GetNugetPackageBasePath>
     <ItemGroup>
-      <_FSharp Include="$(_SourceTopDir)\$(_FSharpCorePackagePath)\lib\portable-net45+monoandroid10+monotouch10+xamarinios10\FSharp.Core*" />
       <_Facades Include="$(_MonoProfileDir)\Facades\*.dll" />
     </ItemGroup>
     <Copy
@@ -461,13 +449,6 @@
     <Copy
         SourceFiles="@(_Facades)"
         DestinationFolder="$(_BclFrameworkDir)Facades"
-    />
-    <Copy
-        SourceFiles="@(_FSharp)"
-        DestinationFolder="$(_BclFrameworkDir)"
-    />
-    <Touch
-        Files="@(_FSharp->'$(_BclFrameworkDir)%(Filename)%(Extension)')"
     />
     <Touch
         Files="@(_BclInstalledItem)"
@@ -577,7 +558,6 @@
       <BundleItem Include="@(_MonoDocInstalledItems)" />
       <BundleItem Include="@(_MonoCilStripDest)" />
       <BundleItem Include="@(_MonoUtilityDest)" />
-      <BundleItem Include="@(_FSharpInstalledItems)" />
       <BundleItem Include="@(MonoFacadeAssembly->'$(_BclFrameworkDir)Facades\%(Identity)')" />
       <BundleItem Include="$(_BclFrameworkDir)RedistList\FrameworkList.xml" />
       <BundleItem Include="@(_InstallRuntimeOutput)" />

--- a/src/Xamarin.Android.Build.Tasks/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/packages.config
@@ -3,5 +3,4 @@
   <package id="FSharp.Compiler.CodeDom" version="0.9.4" targetFramework="net45" />
   <package id="FSharp.Compiler.CodeDom" version="1.0.0.1" targetFramework="net45" />
   <package id="Irony" version="0.9.1" targetFramework="net45" />
-  <package id="FSharp.Core" version="3.1.2.5" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=58689
Context: https://developer.xamarin.com/releases/android/xamarin.android_7/xamarin.android_7.4/#FSharpCore

We [removed `FSharp.Core.dll` from the commercial product][1]
because it's presence was actively breaking things (due to
still-not-understood changes around Visual Studio and MSBuild):

[1]: https://developer.xamarin.com/releases/android/xamarin.android_7/xamarin.android_7.4/#FSharpCore

> the `FSharp.Core.dll` distributed with Xamarin.Android is now being
> used in preference to the NuGet package, through no changes on the
> Xamarin.Android side of things. This means that the NuGet package
> cannot be used

Remove the `FSharp.Core` assemblies from the OSS side of things.

Developers wishing to use F# and the `FSharp.Core` assemblies should
use the [`FSharp.Core` NuGet package][2].

[2]: https://www.nuget.org/packages/FSharp.Core/