### PR TITLE
[Xamarin.Android.Build.Tasks] Multidex & $(Configuration)+spaces (#725)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
@@ -89,12 +89,15 @@ namespace Xamarin.Android.Tasks
 
 		void GenerateMainDexListBuilderCommands(CommandLineBuilder cmd)
 		{
-			var enclosingChar = OS.IsWindows ? "\"" : string.Empty;
+			var enclosingDoubleQuote = OS.IsWindows ? "\"" : string.Empty;
+			var enclosingQuote = OS.IsWindows ? string.Empty : "'";
 			var jars = JavaLibraries.Select (i => i.ItemSpec).Concat (new string [] { ClassesOutputDirectory });
 			cmd.AppendSwitchIfNotNull ("-Djava.ext.dirs=", Path.Combine (AndroidSdkBuildToolsPath, "lib"));
 			cmd.AppendSwitch ("com.android.multidex.MainDexListBuilder");
-			cmd.AppendSwitch ($"{enclosingChar}{tempJar}{enclosingChar}");
-			cmd.AppendSwitchUnquotedIfNotNull ("", $"{enclosingChar}" + string.Join ($"{Path.PathSeparator}", jars) + $"{enclosingChar}");
+			cmd.AppendSwitch ($"{enclosingDoubleQuote}{tempJar}{enclosingDoubleQuote}");
+			cmd.AppendSwitchUnquotedIfNotNull ("", $"{enclosingDoubleQuote}{enclosingQuote}" +
+				string.Join ($"{enclosingQuote}{Path.PathSeparator}{enclosingQuote}", jars) + 
+				$"{enclosingQuote}{enclosingDoubleQuote}");
 			writeOutputToKeepFile = true;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -300,9 +300,9 @@ printf ""%d"" x
 			}
 		}
 
-		XamarinAndroidApplicationProject CreateMultiDexRequiredApplication ()
+		XamarinAndroidApplicationProject CreateMultiDexRequiredApplication (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
 		{
-			var proj = new XamarinAndroidApplicationProject ();
+			var proj = new XamarinAndroidApplicationProject (debugConfigurationName, releaseConfigurationName);
 			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods.java") {
 				TextContent = () => "public class ManyMethods { \n"
 					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
@@ -327,6 +327,17 @@ printf ""%d"" x
 				b.ThrowOnBuildFailure = false;
 				Assert.IsFalse (b.Build (proj), "Without MultiDex option, build should fail");
 				b.Clean (proj);
+			}
+		}
+
+		[Test]
+		public void CreateMultiDexWithSpacesInConfig ()
+		{
+			var proj = CreateMultiDexRequiredApplication (releaseConfigurationName: "Test Config");
+			proj.IsRelease = true;
+			proj.SetProperty ("AndroidEnableMultiDex", "True");
+			using (var b = CreateApkBuilder ("temp/CreateMultiDexWithSpacesInConfig")) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}
 		}
 
@@ -1949,7 +1960,7 @@ public class Test
 							TextContent = () => @"using System;
 
 namespace "+ libName + @" {
-
+ 
 	public class " + libName + @" {
 		public static void Foo () {
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -33,7 +33,8 @@ namespace Xamarin.ProjectTools
 
 		}
 
-		public XamarinAndroidApplicationProject ()
+		public XamarinAndroidApplicationProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
+			: base (debugConfigurationName, releaseConfigurationName)
 		{
 			SetProperty ("AndroidApplication", "True");
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidBindingProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidBindingProject.cs
@@ -16,7 +16,8 @@ namespace Xamarin.ProjectTools
 		public IList<BuildItem> Jars { get; private set; }
 		public IList<BuildItem> Transforms { get; private set; }
 
-		public XamarinAndroidBindingProject ()
+		public XamarinAndroidBindingProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
+			: base (debugConfigurationName, releaseConfigurationName)
 		{
 			SetProperty ("MonoAndroidJavaPrefix", "Java");
 			SetProperty ("MonoAndroidTransformPrefix", "Transforms");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidCommonProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidCommonProject.cs
@@ -51,7 +51,8 @@ namespace Xamarin.ProjectTools
 			}
 		}
 
-		protected XamarinAndroidCommonProject ()
+		protected XamarinAndroidCommonProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
+			: base (debugConfigurationName, releaseConfigurationName)
 		{
 			AndroidResources = new List<BuildItem> ();
 			ItemGroupList.Add (AndroidResources);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidLibraryProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidLibraryProject.cs
@@ -15,7 +15,8 @@ namespace Xamarin.ProjectTools
 </resources>
 ";
 
-		public XamarinAndroidLibraryProject ()
+		public XamarinAndroidLibraryProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
+			: base (debugConfigurationName, releaseConfigurationName)
 		{
 			SetProperty ("AndroidApplication", "False");
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
@@ -9,7 +9,8 @@ namespace Xamarin.ProjectTools
 {
 	public abstract class XamarinAndroidProject : XamarinProject
 	{
-		protected XamarinAndroidProject ()
+		protected XamarinAndroidProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
+			: base (debugConfigurationName, releaseConfigurationName)
 		{
 			Language = XamarinAndroidProjectLanguage.CSharp;
 			TargetFrameworkVersion = Versions.Marshmallow;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidWearApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidWearApplicationProject.cs
@@ -24,7 +24,8 @@ namespace Xamarin.ProjectTools
 				default_layout_round_main = sr.ReadToEnd ();
 		}
 
-		public XamarinAndroidWearApplicationProject ()
+		public XamarinAndroidWearApplicationProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
+			: base (debugConfigurationName, releaseConfigurationName)
 		{
 			TargetFrameworkVersion = Versions.KitkatWatch;
 			UseLatestPlatformSdk = false;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -124,13 +124,13 @@ namespace Xamarin.ProjectTools
 				ndkPath = Path.GetFullPath (Path.Combine (androidSdkToolPath, "ndk"));
 			StringBuilder args = new StringBuilder ();
 			var psi = new ProcessStartInfo (MSBuildExe);
-			if (Directory.Exists (sdkPath)) {
-				args.AppendFormat ("/p:AndroidSdkDirectory=\"{0}\" ", sdkPath);
-			}
-			if (Directory.Exists (ndkPath)) {
-				args.AppendFormat ("/p:AndroidNdkDirectory=\"{0}\" ", ndkPath);
-			}
 			if (RunXBuild) {
+				if (Directory.Exists (sdkPath)) {
+					args.AppendFormat ("/p:AndroidSdkDirectory=\"{0}\" ", sdkPath);
+				}
+				if (Directory.Exists (ndkPath)) {
+					args.AppendFormat ("/p:AndroidNdkDirectory=\"{0}\" ", ndkPath);
+				}
 				var outdir = Path.GetFullPath (Path.Combine (FrameworkLibDirectory, ".."));
 				var targetsdir = Path.Combine (FrameworkLibDirectory, "xbuild");
 				args.AppendFormat (" {0} ", logger);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -19,9 +19,15 @@ namespace Xamarin.ProjectTools
 
 		public ProjectLanguage Language { get; set; }
 
-		protected XamarinProject ()
+		string debugConfigurationName;
+		string releaseConfigurationName;
+
+		protected XamarinProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
 		{
 			ProjectName = "UnnamedProject";
+
+			this.debugConfigurationName = debugConfigurationName;
+			this.releaseConfigurationName = releaseConfigurationName;
 
 			Sources = new List<BuildItem> ();
 			References = new List<BuildItem> ();
@@ -37,9 +43,9 @@ namespace Xamarin.ProjectTools
 			CommonProperties = new List<Property> ();
 			common = new PropertyGroup (null, CommonProperties);
 			DebugProperties = new List<Property> ();
-			debug = new PropertyGroup ("'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'", DebugProperties);
+			debug = new PropertyGroup ($"'$(Configuration)|$(Platform)' == '{debugConfigurationName}|AnyCPU'", DebugProperties);
 			ReleaseProperties = new List<Property> ();
-			release = new PropertyGroup ("'$(Configuration)|$(Platform)' == 'Release|AnyCPU'", ReleaseProperties);
+			release = new PropertyGroup ($"'$(Configuration)|$(Platform)' == '{releaseConfigurationName}|AnyCPU'", ReleaseProperties);
 
 			PropertyGroups = new List<PropertyGroup> ();
 			PropertyGroups.Add (common);
@@ -48,7 +54,7 @@ namespace Xamarin.ProjectTools
 
 			Packages = new List<Package> ();
 
-			SetProperty (KnownProperties.Configuration, "Debug", "'$(Configuration)' == ''");
+			SetProperty (KnownProperties.Configuration, debugConfigurationName, "'$(Configuration)' == ''");
 			SetProperty ("Platform", "AnyCPU", "'$(Platform)' == ''");
 			SetProperty ("ErrorReport", "prompt");
 			SetProperty ("WarningLevel", "4");
@@ -60,16 +66,16 @@ namespace Xamarin.ProjectTools
 			SetProperty (DebugProperties, "DebugSymbols", "true");
 			SetProperty (DebugProperties, "DebugType", "full");
 			SetProperty (DebugProperties, "Optimize", "false");
-			SetProperty (DebugProperties, KnownProperties.OutputPath, Path.Combine ("bin", "Debug"));
+			SetProperty (DebugProperties, KnownProperties.OutputPath, Path.Combine ("bin", debugConfigurationName));
 			SetProperty (DebugProperties, "DefineConstants", "DEBUG;");
-			SetProperty (DebugProperties, KnownProperties.IntermediateOutputPath, Path.Combine ("obj", "Debug"));
+			SetProperty (DebugProperties, KnownProperties.IntermediateOutputPath, Path.Combine ("obj", debugConfigurationName));
 
 			SetProperty (ReleaseProperties, "Optimize", "true");
 			SetProperty (ReleaseProperties, "ErrorReport", "prompt");
 			SetProperty (ReleaseProperties, "WarningLevel", "4");
 			SetProperty (ReleaseProperties, "ConsolePause", "false");
-			SetProperty (ReleaseProperties, KnownProperties.OutputPath, Path.Combine ("bin", "Release"));
-			SetProperty (ReleaseProperties, KnownProperties.IntermediateOutputPath, Path.Combine ("obj", "Release"));
+			SetProperty (ReleaseProperties, KnownProperties.OutputPath, Path.Combine ("bin", releaseConfigurationName));
+			SetProperty (ReleaseProperties, KnownProperties.IntermediateOutputPath, Path.Combine ("obj", releaseConfigurationName));
 
 			Sources.Add (new BuildItem.Source (() => "Properties\\AssemblyInfo" + Language.DefaultExtension) { TextContent = () => ProcessSourceTemplate (AssemblyInfo ?? Language.DefaultAssemblyInfo) });
 
@@ -102,8 +108,8 @@ namespace Xamarin.ProjectTools
 		public abstract string ProjectTypeGuid { get; }
 
 		public bool IsRelease {
-			get { return GetProperty (KnownProperties.Configuration) == "Release"; }
-			set { SetProperty ("Configuration", value ? "Release" : "Debug"); }
+			get { return GetProperty (KnownProperties.Configuration) == releaseConfigurationName; }
+			set { SetProperty ("Configuration", value ? releaseConfigurationName : debugConfigurationName); }
 		}
 
 		public IList<Property> ActiveConfigurationProperties {
@@ -277,6 +283,7 @@ namespace Xamarin.ProjectTools
 				list.Add (new ProjectResource () {
 					Path = import.Project (),
 					Content = import.TextContent == null ? null : import.TextContent (),
+					Encoding = System.Text.Encoding.UTF8,
 				});
 
 			return list;


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=58134

We did a ton of stuff to get multidex working correctly on Windows
in commit 6829b7d1. However it seems that if there are spaces in the
path on macOS, we get similar problems.

The solution is to add single quotes around the list of `.jar` files
when calling `MainDexListBuilder`. That seems pretty logical.
But... it breaks it on Windows (sigh). Because on Windows if we add
the single quotes, it stops working.

So we have to conditionally add the single quotes around the list
of jar files. Note this only applies when we call the `MainDexListBuilder`.
The single quotes seem to work ok when calling proguard..

Weird.

This commit also adds a unit test for this. However we needed to be
able to change the names of the Configurations "Debug", "Release".
So contructor arguments have been added to allow them to be overridden.
These will default to "Debug" and "Release" so that existing tests will
work as expected.