### PR TITLE
[create-vsix] Escape the branch name in the .vsix filename

### DIFF
--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -102,7 +102,7 @@
       <_Branch>$(_Branch.Replace ('\', '-'))</_Branch>
     </PropertyGroup>
     <PropertyGroup>
-      <VsixPath Condition=" '$(VsixPath)' == '' ">..\..\bin\Build$(Configuration)\$(AssemblyName)-OSS-$(ProductVersion).$(XAVersionCommitCount)_$(XAVersionBranch)_$(XAVersionHash).vsix</VsixPath>    
+      <VsixPath Condition=" '$(VsixPath)' == '' ">..\..\bin\Build$(Configuration)\$(AssemblyName)-OSS-$(ProductVersion).$(XAVersionCommitCount)_$(_Branch)_$(XAVersionHash).vsix</VsixPath>
     </PropertyGroup>
   </Target>
   <Target Name="_CopyToBuildConfiguration"


### PR DESCRIPTION
The xamarin-android-pr-builder Jenkins job is configured to create and
upload the `Xamarin.Android.Sdk*.vsix` files for PR jobs.

By default -- unless the `$(VsixPath)` MSBuild property is overridden
-- the resulting filename will include the name of the branch that
triggered the build.

PR branch names will include `/`, e.g. `pr/729/merge`.

This was properly considered in commit a08cd80a by replacing `/` and
`\` with `-` in the branch name, resulting in e.g. `pr-729-merge`.

Unfortunately commit 611bb66e broke this, by replacing the use of the
corrected `$(_Branch)` value with `$(XAVersionBranch`, which could
contain anything.

The result is that a PR build will create the .vsix file:

	Copying file from "bin/Debug/Xamarin.Android.Sdk.vsix" to "../../bin/BuildDebug/Xamarin.Android.Sdk-OSS-7.4.99.80_pr/729/merge_ca6f84f.vsix".

but Jenkins won't actually upload the file, because it's only looking
for files matching the glob:

	xamarin-android/bin/Build*/Xamarin.Android.Sdk*.vsix

and the embedded `/` within the filename doesn't match.