### PR TITLE
[Mono.Android] Define JavaCollection before ICollection

### DIFF
--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -75,6 +75,20 @@
       <Private>False</Private>
     </Reference>
   </ItemGroup>
+  <Import Project="$(JavaInteropFullPath)\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems" Label="Shared" Condition="Exists('$(JavaInteropFullPath)\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems')" />
+  <Import Project="..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems')" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <ImplicitlyExpandDesignTimeFacades>False</ImplicitlyExpandDesignTimeFacades>
+    <IntermediateOutputPath>$(IntermediateOutputPath)android-$(AndroidApiLevel)\</IntermediateOutputPath>
+  </PropertyGroup>
+  <Import Project="Mono.Android.targets" />
+  <PropertyGroup>
+    <JavaCallableWrapperAbsAssembly>$([System.IO.Path]::GetFullPath ('$(OutputPath)$(AssemblyName).dll'))</JavaCallableWrapperAbsAssembly>
+    <JavaCallableWrapperAfterTargets>CoreBuild</JavaCallableWrapperAfterTargets>
+  </PropertyGroup>
+  <Import Project="..\..\build-tools\scripts\JavaCallableWrappers.targets" />
+  <Import Project="$(IntermediateOutputPath)mcw\Mono.Android.projitems" Condition="Exists('$(IntermediateOutputPath)mcw\Mono.Android.projitems')" />
   <ItemGroup>
     <Compile Include="Android\IncludeAndroidResourcesFromAttribute.cs" />
     <Compile Include="Android\LinkerSafeAttribute.cs" />
@@ -311,20 +325,6 @@
     <Compile Include="Xamarin.Android.Net\AuthModuleDigest.cs" />
     <Compile Include="Xamarin.Android.Net\IAndroidAuthenticationModule.cs" />
   </ItemGroup>
-  <Import Project="$(JavaInteropFullPath)\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems" Label="Shared" Condition="Exists('$(JavaInteropFullPath)\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems')" />
-  <Import Project="..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems')" />
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <ImplicitlyExpandDesignTimeFacades>False</ImplicitlyExpandDesignTimeFacades>
-    <IntermediateOutputPath>$(IntermediateOutputPath)android-$(AndroidApiLevel)\</IntermediateOutputPath>
-  </PropertyGroup>
-  <Import Project="Mono.Android.targets" />
-  <PropertyGroup>
-    <JavaCallableWrapperAbsAssembly>$([System.IO.Path]::GetFullPath ('$(OutputPath)$(AssemblyName).dll'))</JavaCallableWrapperAbsAssembly>
-    <JavaCallableWrapperAfterTargets>CoreBuild</JavaCallableWrapperAfterTargets>
-  </PropertyGroup>
-  <Import Project="..\..\build-tools\scripts\JavaCallableWrappers.targets" />
-  <Import Project="$(IntermediateOutputPath)mcw\Mono.Android.projitems" Condition="Exists('$(IntermediateOutputPath)mcw\Mono.Android.projitems')" />
   <ItemGroup>
     <ProjectReference Include="..\..\build-tools\api-merge\api-merge.csproj">
       <Project>{3FC3E78B-F7D4-42EA-BBE8-4535DF42BFF8}</Project>

--- a/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/Xamarin.Android.McwGen-Tests.csproj
+++ b/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/Xamarin.Android.McwGen-Tests.csproj
@@ -76,6 +76,7 @@
   </ItemGroup>
   <ItemGroup>
     <XamarinTestJar Include="java\com\xamarin\android\Bxc4288.java" />
+    <XamarinTestJar Include="java\com\xamarin\android\Bxc58383.java" />
     <XamarinTestJar Include="java\com\xamarin\android\CallMethodFromCtor.java" />
     <XamarinTestJar Include="java\com\xamarin\android\CallNonvirtualBase.java" />
     <XamarinTestJar Include="java\com\xamarin\android\CallNonvirtualDerived.java" />

--- a/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/java/com/xamarin/android/Bxc58383.java
+++ b/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/java/com/xamarin/android/Bxc58383.java
@@ -1,0 +1,7 @@
+package com.xamarin.android;
+
+public class Bxc58383
+    extends java.util.HashMap
+    implements java.util.Map
+{
+}


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=58303

Background: It is possible for a Java type to have
"aliasing bindings": two or more managed types which claim to bind
the same Java type:

	// C#
	namespace Android.Runtime {
	  [Register ("java/util/HashMap", DoNotRegisterAcw=true)]
	  partial class JavaDictionary {
	  }
	}
	namespace Java.Util {
	  [Register ("java/util/HashMap", DoNotRegisterAcw=true)]
	  partial class HashMap {
	  }
	}

These can't be realistically forbidden.

Enter a new-to-bind Java type:

	// Java
	public class Bxc58383 extends java.util.HashMap implements java.util.Map {
	}

In order to bind the above `Bxc58383` type, `generator` needs to
determine the appropriate binding type to use for `java.util.HashMap`.
`generator`'s approach to supporting aliasing types is (largely) to
ignore the problem (almost) entirely: There Can Be Only One™ mapping
from a Java type to a managed type, so `generator` needs to pick one.
It does so by using the *last* definition encountered in the assembly.

Consequently, for the above set of C# declarations, when `generator`
needs to find the managed type which binds `java.util.HashMap`,
`Java.Util.HashMap` will be chosen, as it is the last declared type.

Unfortunately, "real life" is a bit more complicated:
`Mono.Android.dll` is made up of *thousands* of files, and the order
of types within an assembly is a compiler implementation detail.
As such...the current `Mono.Android.dll` has `JavaDictionary` defined
*after* `HashMap`:

	# output truncated for relevance
	$ monodis --typedef bin/Debug/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v7.1/Mono.Android.dll | grep 'Dictionary\|HashMap'
	1270: Java.Util.Dictionary (flist=12611, mlist=29569, flags=0x100081, extends=0x20b8)
	1287: Java.Util.HashMap (flist=12662, mlist=29806, flags=0x100001, extends=0x1388)
	3992: Android.Runtime.JavaDictionary (flist=32135, mlist=85344, flags=0x100001, extends=0x20b8)

Because `JavaDictionary` is defined *after* `HashMap`, and both of
those types have `[Register]` attributes which declare that they bind
the *same* Java type, the result is that the binding of `Bxc58383` is
horrifically broken:

	// C#
	partial class Bxc58383 : global::Android.Runtime.JavaDictionary, global::Java.Util.IMap {
	}

Unfortunately, `JavaDictionary` doesn't itself implement `IMap`, so:

	error CS0535: 'Bxc58383' does not implement interface member 'IMap.ContainsKey(Object)'

along with 10 other related errors.

Update the `src/Mono.Android` build process so that `JavaDictionary`
and related types will be defined within `Mono.Android.dll` *before*
all the generated types. This allows `HashMap` to be defined last,
allowing `Bxc58383` to be bound without error:

	# output truncated
	$ monodis --typedef bin/Debug/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v7.1/Mono.Android.dll | grep 'Dictionary\|HashMap'
	3703: Android.Runtime.JavaDictionary (flist=34089, mlist=78134, flags=0x100001, extends=0x4e08)
	4170: Java.Util.Dictionary (flist=39685, mlist=91737, flags=0x100081, extends=0x4e08)
	4187: Java.Util.HashMap (flist=39736, mlist=91974, flags=0x100001, extends=0x40d8)