### PR TITLE
[Xamarin.Android.Build.Tasks] Restore @(AndroidEnvironment)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -200,6 +200,9 @@ namespace Xamarin.Android.Tasks
 						resolvedResourceDirectories.Add (resDir);
 					if (Directory.Exists (assemblyDir))
 						resolvedAssetDirectories.Add (assemblyDir);
+					foreach (var env in Directory.EnumerateFiles (importsDir, "__AndroidEnvironment__*", SearchOption.TopDirectoryOnly)) {
+						resolvedEnvironments.Add (env);
+					}
 					continue;
 				}
 

--- a/tests/locales/Xamarin.Android.Locale-Tests/EnvironmentTests.cs
+++ b/tests/locales/Xamarin.Android.Locale-Tests/EnvironmentTests.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Android.LocaleTests
 		public void EnvironmentVariablesFromLibraryProjectsAreMerged ()
 		{
 			var v = Environment.GetEnvironmentVariable ("THIS_IS_MY_ENVIRONMENT");
-			Assert.AreEqual (v, "Well, hello there!");
+			Assert.AreEqual ("Well, hello there!", v);
 		}
 	}
 }


### PR DESCRIPTION
We have a failure within
`EnvironmentTests.EnvironmentVariablesFromLibraryProjectsAreMerged`
(commit ea6b9b45): the `@(AndroidEnvironment)` from the library
project is not merged into the App `.apk`:

	Expected: null
	But was:  "Well, hello there!"

(The arguments were in the wrong order. Oops.)

The cause for this is due to `<ResolveLibraryProjectImports/>`
attempts to avoid duplicate work; [from the build log][0]

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/526/consoleText

	Task "ResolveLibraryProjectImports"
	  Assemblies:
	    .../xamarin-android/bin/TestDebug//LibraryResources.dll
	  Skipped resource lookup for .../xamarin-android/bin/TestDebug/LibraryResources.dll: extracted files are up to date
		ResolvedEnvironmentFiles:

*Because* `LibraryResources.dll` was skipped, the
`@(AndroidEnvironment)` entries from `LibraryResources.dll` were also
skipped! Doh!

Update the `<ResolveLibraryProjectImports/>` task so that when
resource extraction for an assembly is skipped, we remember to add the
already-extracted `@(AndroidEnvironment)` values.