### PR TITLE
[windows] now can build android-toolchain.mdproj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ packages
 .nuget
 TestResult.xml
 TestResult-*.xml
+.vs/

--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -46,6 +46,25 @@
       <HostOS>Darwin</HostOS>
       <DestDir>emulator</DestDir>
     </AndroidSdkItem>
+    <AndroidNdkItem Include="android-ndk-r14b-windows-x86_64.zip">
+      <HostOS>Windows</HostOS>
+    </AndroidNdkItem>
+    <AndroidSdkItem Include="build-tools_r$(XABuildToolsVersion)-windows.zip">
+      <HostOS>Windows</HostOS>
+      <DestDir>build-tools\$(XABuildToolsFolder)</DestDir>
+    </AndroidSdkItem>
+    <AndroidSdkItem Include="platform-tools_r26.0.0-windows.zip">
+      <HostOS>Windows</HostOS>
+      <DestDir>platform-tools</DestDir>
+    </AndroidSdkItem>
+    <AndroidSdkItem Include="sdk-tools-windows-3952940.zip">
+      <HostOS>Windows</HostOS>
+      <DestDir>tools</DestDir>
+    </AndroidSdkItem>
+    <AndroidSdkItem Include="emulator-windows-3965150.zip">
+      <HostOS>Windows</HostOS>
+      <DestDir>emulator</DestDir>
+    </AndroidSdkItem>
     <AndroidSdkItem Include="android-2.3.3_r02-linux.zip">
       <HostOS></HostOS>
       <DestDir>platforms\android-10</DestDir>

--- a/build-tools/bundle/bundle.mdproj
+++ b/build-tools/bundle/bundle.mdproj
@@ -37,7 +37,7 @@
       <Name>mono-runtimes</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\libzip\libzip.mdproj">
+    <ProjectReference Include="..\libzip\libzip.mdproj" Condition=" '$(HostOS)' != 'Windows' ">
       <Project>{900A0F71-BAAD-417A-8D1A-8D330297CDD0}</Project>
       <Name>libzip</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>

--- a/build-tools/dependencies/dependencies.projitems
+++ b/build-tools/dependencies/dependencies.projitems
@@ -5,15 +5,15 @@
     <_AptGetInstall>apt-get -f -u install</_AptGetInstall>
   </PropertyGroup>
   <ItemGroup>
-    <RequiredProgram Include="$(HostCcName)" />
-    <RequiredProgram Include="$(HostCxxName)" />
+    <RequiredProgram Include="$(HostCcName)"        Condition=" '$(HostOS)' != 'Windows' " />
+    <RequiredProgram Include="$(HostCxxName)"       Condition=" '$(HostOS)' != 'Windows' " />
     <RequiredProgram Include="7za"                  Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>p7zip</Homebrew>
     </RequiredProgram>
-    <RequiredProgram Include="autoconf">
+    <RequiredProgram Include="autoconf"             Condition=" '$(HostOS)' != 'Windows' ">
       <Homebrew>autoconf</Homebrew>
     </RequiredProgram>
-    <RequiredProgram Include="automake">
+    <RequiredProgram Include="automake"             Condition=" '$(HostOS)' != 'Windows' ">
       <Homebrew>automake</Homebrew>
     </RequiredProgram>
     <RequiredProgram Include="cmake"                Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
@@ -36,10 +36,11 @@
     </RequiredProgram>
     <RequiredProgram Include="javac">
       <MinimumVersion>1.8</MinimumVersion>
-      <CurrentVersionCommand>$(MSBuildThisFileDirectory)..\scripts\javac-version</CurrentVersionCommand>
+      <CurrentVersionCommand                        Condition=" '$(HostOS)' != 'Windows' ">$(MSBuildThisFileDirectory)..\scripts\javac-version</CurrentVersionCommand>
+      <CurrentVersionCommand                        Condition=" '$(HostOS)' == 'Windows' ">javac -version 2&gt;&amp;1</CurrentVersionCommand>
       <UbuntuInstall>$(_AptGetInstall) openjdk-8-jdk</UbuntuInstall>
     </RequiredProgram>
-    <RequiredProgram Include="make" />
+    <RequiredProgram Include="make"                 Condition=" '$(HostOS)' != 'Windows' " />
     <RequiredProgram Include="pkg-config"           Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>pkg-config</Homebrew>
     </RequiredProgram>

--- a/build-tools/libzip/libzip.projitems
+++ b/build-tools/libzip/libzip.projitems
@@ -16,6 +16,6 @@
   </ItemGroup>
   <ItemGroup>
     <RequiredProgram Include="cmake" />
-    <RequiredProgram Include="make" />
+    <RequiredProgram Include="make" Condition=" '$(HostOS)' != 'Windows' " />
   </ItemGroup>
 </Project>

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/AcceptAndroidSdkLicenses.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/AcceptAndroidSdkLicenses.cs
@@ -16,7 +16,9 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 			var licdir = Path.Combine (Path.Combine (AndroidSdkDirectory, "licenses"));
 			Directory.CreateDirectory (licdir);
 
-			var psi = new ProcessStartInfo (Path.Combine (AndroidSdkDirectory, "tools", "bin", "sdkmanager"), "--licenses") { UseShellExecute = false, RedirectStandardInput = true };
+			string _;
+			var path = Which.GetProgramLocation ("sdkmanager", out _, new [] { Path.Combine (AndroidSdkDirectory, "tools", "bin") });
+			var psi = new ProcessStartInfo (path, "--licenses") { UseShellExecute = false, RedirectStandardInput = true };
 			var proc = Process.Start (psi);
 			for (int i = 0; i < 10; i++)
 				proc.StandardInput.WriteLine ('y');

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -57,7 +57,7 @@
       <Project>{E248B2CA-303B-4645-ADDC-9D4459D550FD}</Project>
       <Name>libZipSharp</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\build-tools\libzip\libzip.mdproj">
+    <ProjectReference Include="..\..\build-tools\libzip\libzip.mdproj" Condition=" '$(HostOS)' != 'Windows' ">
       <Project>{900A0F71-BAAD-417A-8D1A-8D330297CDD0}</Project>
       <Name>libzip</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>


### PR DESCRIPTION
Problems fixed on Windows:
- Many `RequiredPrograms` are n/a on Windows
- Setup `AndroidSdkItem` for Windows downloads
- `AcceptAndroidSdkLicenses` should run `.bat` file on Windows
- `UnzipDirectoryChildren` was running `/bin/mv` and hitting
`PathTooLongException` while using `ZipFile.ExtractToDirectory`
- references to `libzip.mdproj` are conditional on Windows, will be
getting `libzip` from NuGet in the future

UnzipDirectoryChildren:
- on Windows we are using `System.IO.Compression` to extract
directly into the destination and avoid `%TEMP%` to
workaround `MAX_PATH`
- Other platforms continue to use `unzip`, in order to preserve
file attributes

General changes:
- gitignore for VS 2017
- Bumped LibZipSharp

You can see a successful build I setup on [AppVeyor](https://ci.appveyor.com/project/jonathanpeppers/xamarin-android/build/12), which ran:
```
appveyor DownloadFile https://gist.githubusercontent.com/jonathanpeppers/50921eb6e839e1cb2f3975a01098f1a9/raw/e588b5222a7a06c1395614f5a2757d5adb4e4913/Configuration.OperatingSystem.props
git submodule update --init --recursive
nuget restore Xamarin.Android.sln
nuget restore external\LibZipSharp\libZipSharp.sln
msbuild build-tools\android-toolchain\android-toolchain.mdproj /v:detailed
```