### PR TITLE
[Xamarin.Android.Build.Tasks] [Smoke][VS 2017] Exception on deploying CheeseSquare sample

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1,4 +1,4 @@
-﻿﻿using System;
+﻿﻿﻿using System;
 using Xamarin.ProjectTools;
 using NUnit.Framework;
 using System.Linq;
@@ -107,6 +107,29 @@ using System.Runtime.CompilerServices;
 					first = items.First ();
 					Assert.IsTrue (items.All (x => x == first), "All Items should have matching values");
 				}
+			}
+		}
+
+		[Test]
+		public void CheckEmbeddedSupportLibraryResources ()
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				Packages = {
+					KnownPackages.SupportMediaCompat_25_4_0_1,
+					KnownPackages.SupportFragment_25_4_0_1,
+					KnownPackages.SupportCoreUtils_25_4_0_1,
+					KnownPackages.SupportCoreUI_25_4_0_1,
+					KnownPackages.SupportCompat_25_4_0_1,
+					KnownPackages.AndroidSupportV4_25_4_0_1,
+					KnownPackages.SupportV7AppCompat_25_4_0_1,
+				},
+				TargetFrameworkVersion = "v7.1",
+			};
+			using (var b = CreateApkBuilder ("temp/CheckEmbeddedSupportLibraryResources")) {
+				Assert.IsTrue (b.Build (proj), "First build should have succeeded.");
+				var Rdrawable = b.Output.GetIntermediaryPath (Path.Combine ("android", "bin", "classes", "android", "support", "v7", "appcompat", "R$drawable.class"));
+				Assert.IsTrue (File.Exists (Rdrawable), $"{Rdrawable} should exist");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -40,6 +40,15 @@ namespace Xamarin.ProjectTools
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v4.23.1.1.0\\lib\\MonoAndroid403\\Xamarin.Android.Support.v4.dll" }
 			}
 		};
+		public static Package AndroidSupportV4_25_4_0_1 = new Package () {
+			Id = "Xamarin.Android.Support.v4",
+			Version = "25.4.0.1",
+			TargetFramework = "MonoAndroid70",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.v4") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v4.25.4.0.1\\lib\\MonoAndroid70\\Xamarin.Android.Support.v4.dll" }
+			}
+		};
 		public static Package AndroidSupportV4Beta = new Package () {
 			Id = "Xamarin.Android.Support.v4",
 			Version = "21.0.0.0-beta1",
@@ -137,6 +146,60 @@ namespace Xamarin.ProjectTools
 			References = {
 				new BuildItem.Reference ("Xamarin.Android.Support.v7.AppCompat") {
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v7.AppCompat.23.1.1.0\\lib\\MonoAndroid403\\Xamarin.Android.Support.v7.AppCompat.dll" }
+			}
+		};
+		public static Package SupportV7AppCompat_25_4_0_1 = new Package {
+			Id = "Xamarin.Android.Support.v7.AppCompat",
+			Version = "25.4.0.1",
+			TargetFramework = "MonoAndroid70",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.v7.AppCompat") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v7.AppCompat.25.4.0.1\\lib\\MonoAndroid70\\Xamarin.Android.Support.v7.AppCompat.dll" }
+			}
+		};
+		public static Package SupportCompat_25_4_0_1 = new Package {
+			Id = "Xamarin.Android.Support.Compat",
+			Version = "25.4.0.1",
+			TargetFramework = "MonoAndroid70",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.Compat") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.Compat.25.4.0.1\\lib\\MonoAndroid70\\Xamarin.Android.Support.Compat.dll" }
+			}
+		};
+		public static Package SupportCoreUI_25_4_0_1 = new Package {
+			Id = "Xamarin.Android.Support.Core.UI",
+			Version = "25.4.0.1",
+			TargetFramework = "MonoAndroid70",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.Core.UI") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.Core.UI.25.4.0.1\\lib\\MonoAndroid70\\Xamarin.Android.Support.Core.UI.dll" }
+			}
+		};
+		public static Package SupportCoreUtils_25_4_0_1 = new Package {
+			Id = "Xamarin.Android.Support.Core.Utils",
+			Version = "25.4.0.1",
+			TargetFramework = "MonoAndroid70",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.Core.Utils") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.Core.Utils.25.4.0.1\\lib\\MonoAndroid70\\Xamarin.Android.Support.Core.Utils.dll" }
+			}
+		};
+		public static Package SupportFragment_25_4_0_1 = new Package {
+			Id = "Xamarin.Android.Support.Fragment",
+			Version = "25.4.0.1",
+			TargetFramework = "MonoAndroid70",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.Fragment") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.Fragment.25.4.0.1\\lib\\MonoAndroid70\\Xamarin.Android.Support.Fragment.dll" }
+			}
+		};
+		public static Package SupportMediaCompat_25_4_0_1 = new Package {
+			Id = "Xamarin.Android.Support.Media.Compat",
+			Version = "25.4.0.1",
+			TargetFramework = "MonoAndroid70",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.Media.Compat") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.Media.Compat.25.4.0.1\\lib\\MonoAndroid70\\Xamarin.Android.Support.Media.Compat.dll" }
 			}
 		};
 		public static Package SupportV7MediaRouter_21_0_3_0 = new Package {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1198,8 +1198,7 @@ because xbuild doesn't support framework reference assemblies.
 </PropertyGroup>
 
 <Target Name="_GenerateJavaDesignerForComponent"
-  Condition="'@(_AdditonalAndroidResourceCachePaths)' != ''"
-  Inputs="@(_AdditonalAndroidResourceCacheFiles)"
+  Inputs="@(_AdditonalAndroidResourceCacheFiles);@(_LibraryResourceDirectoryStamps)"
   Outputs="$(_AndroidComponentResgenFlagFile)"
   DependsOnTargets="$(_GenerateJavaDesignerForComponentDependsOnTargets)">
 
@@ -1208,7 +1207,7 @@ because xbuild doesn't support framework reference assemblies.
    ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
    OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)"
    UseShortFileNames="$(UseShortFileNames)"
-   ManifestFiles="@(_AdditonalAndroidResourceCachePaths->'%(Identity)\AndroidManifest.xml')"
+   ManifestFiles="@(_AdditonalAndroidResourceCachePaths->'%(Identity)\AndroidManifest.xml');@(LibraryResourceDirectories->'%(Identity)\..\AndroidManifest.xml')"
    ApplicationName="$(_AndroidPackage)"
    JavaPlatformJarPath="$(JavaPlatformJarPath)"
    NonConstantId="true"


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=58721

The initial problem seems to stem from the fact that for the
support library components now directly include the resources.
As a result the `_GenerateJavaResourcesForComponent` was not
running. This was because it was only running if
`_AdditonalAndroidResourceCachePaths` was not empty.
In this scenario it was always empty.

As a result none of the files like R.java files were generated
for the support libraries. The means the final .class files
did not have references for the R$drawable.foo identifiers.
This results in a crash.

So to fix the problem we need to start looking at the
`@(LibraryResourceDirectories)` to see if we have any
AndroidManifest.xml files. We should then process these
directories to ensure that the R.java files are created.
The finally compiled into the final applications.