### PR TITLE
[Xamarin.Android.Build.Tasks] SlidingMenuExample project now fails to build against 15.4 with dozens of javac errors 'package foo does not exist'

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -246,6 +246,7 @@ namespace Xamarin.Android.Tasks
 								outfs.Write (data, 0, data.Length);
 							updated = true;
 						}
+						jars.Add (outjarFile);
 					}
 
 					// embedded AndroidResourceLibrary archive
@@ -264,6 +265,8 @@ namespace Xamarin.Android.Tasks
 						using (var zip = MonoAndroidHelper.ReadZipFile (finfo.FullName)) {
 							updated |= Files.ExtractAll (zip, importsDir, modifyCallback: (entryFullName) => {
 								return entryFullName.Replace ("library_project_imports/", "");
+							}, deleteCallback: (fileToDelete) => {
+								return !jars.Contains (fileToDelete);
 							}, forceUpdate: false);
 						}
 
@@ -292,10 +295,12 @@ namespace Xamarin.Android.Tasks
 						stamp.Create ().Close ();
 				}
 			}
-
-			foreach (var f in outdir.GetFiles ("*.jar")
-					.Select (fi => fi.FullName))
+			foreach (var f in outdir.GetFiles ("*.jar", SearchOption.AllDirectories)
+					.Select (fi => fi.FullName)) {
+				if (jars.Contains (f))
+					continue;
 				jars.Add (f);
+			}
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using Xamarin.ProjectTools;
 using NUnit.Framework;
 using System.IO;
@@ -274,6 +274,9 @@ namespace Com.Ipaulpro.Afilechooser {
 			binding.Jars.Add (new AndroidItem.LibraryProjectZip ("Jars\\mylibrary.aar") {
 				WebContent = "https://www.dropbox.com/s/astiqp8jo97x91h/mylibrary.aar?dl=1"
 			});
+			binding.Jars.Add (new AndroidItem.EmbeddedJar ("Jars\\svg-android.jar") {
+				WebContent = "https://www.dropbox.com/s/5ovudccigydohys/javaBindingIssue.jar?dl=1"
+			});
 			binding.SetProperty (binding.ActiveConfigurationProperties, "UseShortFileNames", useShortFileNames);
 			using (var bindingBuilder = CreateDllBuilder (Path.Combine ("temp", "BindingCheckHiddenFiles", "Binding"))) {
 				bindingBuilder.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
@@ -304,6 +307,8 @@ namespace Com.Ipaulpro.Afilechooser {
 						Path.Combine (dsStorePath, ".DS_Store"));
 					var _macOSStorePath = Path.Combine (dsStorePath, "_MACOSX");
 					Assert.IsFalse (Directory.Exists (_macOSStorePath), "{0} should NOT exist.", _macOSStorePath);
+					var svgJar = Path.Combine (dsStorePath, "svg-android.jar");
+					Assert.IsTrue (File.Exists (svgJar), $"{svgJar} should exist.");
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -201,7 +201,8 @@ namespace Xamarin.Android.Tools {
 			return ZipArchive.Open (filename, FileMode.Open, strictConsistencyChecks: strictConsistencyChecks);
 		}
 
-		public static bool ExtractAll(ZipArchive zip, string destination, Action<int, int> progressCallback = null, Func<string, string> modifyCallback = null, bool forceUpdate = true)
+		public static bool ExtractAll(ZipArchive zip, string destination, Action<int, int> progressCallback = null, Func<string, string> modifyCallback = null,
+			Func<string, bool> deleteCallback = null, bool forceUpdate = true)
 		{
 			int i = 0;
 			int total = (int)zip.EntryCount;
@@ -235,7 +236,7 @@ namespace Xamarin.Android.Tools {
 						outfile.EndsWith ("/__MACOSX", StringComparison.OrdinalIgnoreCase) ||
 						outfile.EndsWith ("/.DS_Store", StringComparison.OrdinalIgnoreCase))
 					continue;
-				if (!files.Contains (outfile)) {
+				if (!files.Contains (outfile) && !(deleteCallback?.Invoke (outfile) ?? true)) {
 					File.Delete (outfile);
 					updated = true;
 				}


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=58727

In commit 0667a2b6 we neglected to take into account that any
embedded libraries or environment files would be deleted when
the zip was extracted. Commit ea6b9b45 fixed the issue for the
Environment files. This commit will fix the issue for the .jar
files.

We also added a new test so this doesn't happen in future.