### PR TITLE
[Xamarin.Android.Build.Tasks] @(AndroidEnvironment) in lib dir

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -200,7 +200,7 @@ namespace Xamarin.Android.Tasks
 						resolvedResourceDirectories.Add (resDir);
 					if (Directory.Exists (assemblyDir))
 						resolvedAssetDirectories.Add (assemblyDir);
-					foreach (var env in Directory.EnumerateFiles (importsDir, "__AndroidEnvironment__*", SearchOption.TopDirectoryOnly)) {
+					foreach (var env in Directory.EnumerateFiles (outDirForDll, "__AndroidEnvironment__*", SearchOption.TopDirectoryOnly)) {
 						resolvedEnvironments.Add (env);
 					}
 					continue;


### PR DESCRIPTION
Commit 8a703c69 had the right idea, but read the
`__AndroidEnvironment__*` files from the *wrong directory*.
(This wasn't caught in the PR because, for never adequately explained
reasons, the PR *never ran on the required machine*.)

Specifically, commit 8a703c69 looks for `__AndroidEnvironment__*`
files within `{outDirForDll}/{ImportsDir}`, which would be e.g.
`obj/Debug/lp/0/jl`, which will *never* contain these files.

Previously extracted `__AndroidEnvironment__*` files need to instead
be looked for within the `outDirForDll` directory, e.g.
`obj/Debug/lp/0`.

Update the "cached" directory read logic to use the appropriate path.