### PR TITLE
[xa-prep-tasks] HashFileContents should exclude line endings

### DIFF
--- a/build-tools/mono-runtimes/mono-runtimes.props
+++ b/build-tools/mono-runtimes/mono-runtimes.props
@@ -16,7 +16,7 @@
 
   <!-- LLVM+cross common -->
   <PropertyGroup>
-    <_CrossOutputDirTop>$([System.IO.Path]::GetFullPath ('$(IntermediateOutputPath)')</_CrossOutputDirTop>
+    <_CrossOutputDirTop>$([System.IO.Path]::GetFullPath ('$(IntermediateOutputPath)'))</_CrossOutputDirTop>
     <_MingwCc32>$(MingwCommandPrefix32)-gcc</_MingwCc32>
     <_MingwCxx32>$(MingwCommandPrefix32)-g++</_MingwCxx32>
     <_MingwCc64>$(MingwCommandPrefix64)-gcc</_MingwCc64>


### PR DESCRIPTION
`.gitattributes` is changing the line endings for MSBuild project files,
which causes a different hash to be generated on Windows than Mac.

Changes:
- Read the file into a `MemoryStream` ignoring `\r` or `\n` characters
- Generate the hash from the `MemoryStream` instead of the `FileStream`
- Added missing closing parentheses in `mono-runtimes.props`

The changes on this PR generate the same hash, `0bedb1b1`, on both platforms.