### PR TITLE
[tests] run runtime test in Release configuration and Release/AOT

### DIFF
--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ProcessLogcatTiming.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ProcessLogcatTiming.cs
@@ -103,7 +103,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 					Log.LogMessage (MessageImportance.Normal, $"Last timing message: {(last - start).TotalMilliseconds}ms");
 
 					if (ResultsFilename != null) {
-						using (var resultsFile = new StreamWriter (Path.Combine (Path.GetDirectoryName (ResultsFilename), $"Test-{ApplicationPackageName}-times.csv"))) {
+						using (var resultsFile = new StreamWriter (Path.Combine (Path.GetDirectoryName (ResultsFilename), $"{Path.GetFileNameWithoutExtension (ResultsFilename)}-times.csv"))) {
 							WriteValues (resultsFile, results.Keys);
 							WriteValues (resultsFile, results.Values);
 							resultsFile.Close ();

--- a/src/Mono.Android/Test/Mono.Android-Tests.projitems
+++ b/src/Mono.Android/Test/Mono.Android-Tests.projitems
@@ -4,7 +4,7 @@
     <UnitTestApk Include="$(OutputPath)Mono.Android_Tests-Signed.apk">
       <Package>Mono.Android_Tests</Package>
       <InstrumentationType>xamarin.android.runtimetests.TestInstrumentation</InstrumentationType>
-      <ResultsPath>$(MSBuildThisFileDirectory)..\..\..\TestResult-Mono.Android_Tests.xml</ResultsPath>
+      <ResultsPath>$(MSBuildThisFileDirectory)..\..\..\TestResult-Mono.Android_Tests-$(Configuration)$(_AotName).xml</ResultsPath>
     </UnitTestApk>
   </ItemGroup>
 </Project>

--- a/tests/RunApkTests.targets
+++ b/tests/RunApkTests.targets
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Project DefaultTargets="RunApkTests" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Configuration Condition=" '$(Condition)' == '' ">Debug</Configuration>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <OutputPath>$(MSBuildThisFileDirectory)..\bin\Test$(Configuration)\</OutputPath>
   </PropertyGroup>
   <Import Project="..\Configuration.props" />
+  <PropertyGroup>
+    <_AotName Condition=" '$(AotAssemblies)' == 'true' ">-Aot</_AotName>
+  </PropertyGroup>
   <!--
     Note that the `.csproj` for each `@(UnitTestApk)` entry *must* be added to
     `$(TEST_APK_PROJECTS)` in the toplevel Makefile so that the `.apk` is built.
     -->
   <Import Project="..\src\Mono.Android\Test\Mono.Android-Tests.projitems" />
-  <Import Project="..\tests\CodeGen-Binding\Xamarin.Android.JcwGen-Tests\Xamarin.Android.JcwGen-Tests.projitems" />
-  <Import Project="..\tests\locales\Xamarin.Android.Locale-Tests\Xamarin.Android.Locale-Tests.projitems" />
+  <Import Project="..\tests\CodeGen-Binding\Xamarin.Android.JcwGen-Tests\Xamarin.Android.JcwGen-Tests.projitems" Condition=" '$(Configuration)' == 'Debug' " />
+  <Import Project="..\tests\locales\Xamarin.Android.Locale-Tests\Xamarin.Android.Locale-Tests.projitems"  Condition=" '$(Configuration)' == 'Debug' " />
   <Import Project="..\build-tools\scripts\UnitTestApks.targets" />
   <PropertyGroup>
     <RunApkTestsDependsOn>


### PR DESCRIPTION
 - besides running in different configurations than default (Debug),
   we will also use the startup times measurements in the Jenkins
   plots

 - also fixes a typo in RunApkTests.targets, where supposedly
   'Condition' was used in place of 'Configuration'

 - modifies logcat timing file names, so that it is based on test
   results filename instead of just package name. that way we can have
   multiple timing results for the same test with various
   configurations