### PR TITLE
[Xamarin.Android.Build.Tasks] Unable to locate assemblies when running certain projects in Release modes which don't have Optimize set to True

### DIFF
--- a/src/Mono.Android/java/mono/android/Runtime.java
+++ b/src/Mono.Android/java/mono/android/Runtime.java
@@ -6,7 +6,7 @@ public class Runtime {
 	{
 	}
 
-	public static native void init (String lang, String[] runtimeApks, String runtimeDataDir, String[] appDirs, ClassLoader loader, String externalStorageDir, String[] assemblies, String packageName);
+	public static native void init (String lang, String[] runtimeApks, String runtimeDataDir, String[] appDirs, ClassLoader loader, String[] externalStorageDirs, String[] assemblies, String packageName);
 	public static native void register (String managedType, java.lang.Class nativeClass, String methods);
 	public static native void notifyTimeZoneChanged ();
 	public static native int createNewContext (String[] runtimeApks, String[] assemblies, ClassLoader loader);

--- a/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.api4.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.api4.java
@@ -38,6 +38,13 @@ public class MonoPackageManager {
 				String cacheDir     = context.getCacheDir ().getAbsolutePath ();
 				String dataDir      = context.getApplicationInfo ().dataDir + "/lib";
 				ClassLoader loader  = context.getClassLoader ();
+				java.io.File external0 = android.os.Environment.getExternalStorageDirectory ();
+				String externalDir = new java.io.File (
+							external0,
+							"Android/data/" + context.getPackageName () + "/files/.__override__").getAbsolutePath ();
+				String externalLegacyDir = new java.io.File (
+							external0,
+							"../legacy/Android/data/" + context.getPackageName () + "/files/.__override__").getAbsolutePath ();
 
 				Runtime.init (
 						language,
@@ -49,9 +56,10 @@ public class MonoPackageManager {
 							dataDir,
 						},
 						loader,
-						new java.io.File (
-							android.os.Environment.getExternalStorageDirectory (),
-							"Android/data/" + context.getPackageName () + "/files/.__override__").getAbsolutePath (),
+						new String[] {
+							externalDir,
+							externalLegacyDir
+						},
 						MonoPackageManager_Resources.Assemblies,
 						context.getPackageName ());
 				

--- a/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.java
@@ -38,6 +38,13 @@ public class MonoPackageManager {
 				String cacheDir     = context.getCacheDir ().getAbsolutePath ();
 				String dataDir      = getNativeLibraryPath (context);
 				ClassLoader loader  = context.getClassLoader ();
+				java.io.File external0 = android.os.Environment.getExternalStorageDirectory ();
+				String externalDir = new java.io.File (
+							external0,
+							"Android/data/" + context.getPackageName () + "/files/.__override__").getAbsolutePath ();
+				String externalLegacyDir = new java.io.File (
+							external0,
+							"../legacy/Android/data/" + context.getPackageName () + "/files/.__override__").getAbsolutePath ();
 
 				Runtime.init (
 						language,
@@ -49,9 +56,10 @@ public class MonoPackageManager {
 							dataDir,
 						},
 						loader,
-						new java.io.File (
-							android.os.Environment.getExternalStorageDirectory (),
-							"Android/data/" + context.getPackageName () + "/files/.__override__").getAbsolutePath (),
+						new String[] {
+							externalDir,
+							externalLegacyDir
+						},
 						MonoPackageManager_Resources.Assemblies,
 						context.getPackageName ());
 				

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -279,6 +279,11 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 			<AndroidIncludeDebugSymbols>True</AndroidIncludeDebugSymbols>
 		</PropertyGroup>
 	</When>
+	<When Condition=" '$(EmbedAssembliesIntoApk)' == 'False' ">
+		<PropertyGroup>
+			<AndroidIncludeDebugSymbols>True</AndroidIncludeDebugSymbols>
+		</PropertyGroup>
+	</When>
 	<Otherwise>
 		<PropertyGroup>
 			<AndroidIncludeDebugSymbols>False</AndroidIncludeDebugSymbols>

--- a/src/monodroid/jni/mono_android_Runtime.h
+++ b/src/monodroid/jni/mono_android_Runtime.h
@@ -10,10 +10,10 @@ extern "C" {
 /*
  * Class:     mono_android_Runtime
  * Method:    init
- * Signature: (Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/ClassLoader;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)V
+ * Signature: (Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/ClassLoader;[Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)V
  */
 JNIEXPORT void JNICALL Java_mono_android_Runtime_init
-  (JNIEnv *, jclass, jstring, jobjectArray, jstring, jobjectArray, jobject, jstring, jobjectArray, jstring);
+  (JNIEnv *, jclass, jstring, jobjectArray, jstring, jobjectArray, jobject, jobjectArray, jobjectArray, jstring);
 
 /*
  * Class:     mono_android_Runtime

--- a/src/monodroid/jni/monodroid-glue.c
+++ b/src/monodroid/jni/monodroid-glue.c
@@ -329,7 +329,7 @@ monodroid_get_system_property (const char *name, char **value)
 #ifdef RELEASE
 #define MAX_OVERRIDES 1
 #else
-#define MAX_OVERRIDES 2
+#define MAX_OVERRIDES 3
 #endif
 static char* override_dirs [MAX_OVERRIDES];
 
@@ -410,6 +410,7 @@ get_primary_override_dir (JNIEnv *env, jstring home)
 
 static char *primary_override_dir;
 static char *external_override_dir;
+static char *external_legacy_override_dir;
 
 static void
 create_update_dir (char *override_dir)
@@ -651,6 +652,7 @@ get_libmonosgen_path ()
 	// external storage locations so we need to file copy the shared object to an internal
 	// storage location before loading it.
 	copy_monosgen_to_internal_location (primary_override_dir, external_override_dir);
+	copy_monosgen_to_internal_location (primary_override_dir, external_legacy_override_dir);
 
 	int i;
 	for (i = 0; i < MAX_OVERRIDES; ++i)
@@ -2512,6 +2514,7 @@ get_ds2_path ()
 	for (i = 0; i < sizeof (gdbservers)/sizeof (gdbservers [0]); ++i) {
 		file = monodroid_strdup_printf ("%s", gdbservers [i]);
 		copy_file_to_internal_location (primary_override_dir, external_override_dir, file);
+		copy_file_to_internal_location (primary_override_dir, external_legacy_override_dir, file);
 		free (file);
 	}
 
@@ -3893,7 +3896,7 @@ create_and_initialize_domain (JNIEnv* env, jobjectArray runtimeApks, jobjectArra
 }
 
 JNIEXPORT void JNICALL
-Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApks, jstring runtimeNativeLibDir, jobjectArray appDirs, jobject loader, jstring externalStorageDir, jobjectArray assemblies, jstring packageName)
+Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApks, jstring runtimeNativeLibDir, jobjectArray appDirs, jobject loader, jobjectArray externalStorageDirs, jobjectArray assemblies, jstring packageName)
 {
 	char *runtime_args = NULL;
 	char *connect_args;
@@ -3923,9 +3926,13 @@ Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobject
 	setup_environment (env, runtimeApks);
 
 	primary_override_dir = get_primary_override_dir (env, (*env)->GetObjectArrayElement (env, appDirs, 0));
-	esd = (*env)->GetStringUTFChars (env, externalStorageDir, NULL);
+	esd = (*env)->GetStringUTFChars (env, (*env)->GetObjectArrayElement (env, externalStorageDirs, 0), NULL);
 	external_override_dir = monodroid_strdup_printf ("%s", esd);
-	(*env)->ReleaseStringUTFChars (env, externalStorageDir, esd);
+	(*env)->ReleaseStringUTFChars (env, (*env)->GetObjectArrayElement (env, externalStorageDirs, 0), esd);
+
+	esd = (*env)->GetStringUTFChars (env, (*env)->GetObjectArrayElement (env, externalStorageDirs, 1), NULL);
+	external_legacy_override_dir = monodroid_strdup_printf ("%s", esd);
+	(*env)->ReleaseStringUTFChars (env, (*env)->GetObjectArrayElement (env, externalStorageDirs, 1), esd);
 
 	init_categories (primary_override_dir);
 	create_update_dir (primary_override_dir);
@@ -3937,6 +3944,7 @@ Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobject
 
 #ifndef RELEASE
 	override_dirs [1] = external_override_dir;
+	override_dirs [2] = external_legacy_override_dir;
 	for (i = 0; i < MAX_OVERRIDES; ++i) {
 		const char *p = override_dirs [i];
 		if (!directory_exists (p))


### PR DESCRIPTION
Context https://bugzilla.xamarin.com/show_bug.cgi?id=58580

Commit edabe8a reworked the build logic so that `$(Optimize)`
controls the deployment of the debug or release runtimes.

	Input Property:                                                      || Output Property
	DebugSymbols    | DebugType  | EmbedAssembliesIntoApk   | Optimize   || AndroidIncludeDebugSymbols
	================+============+==========================+============++===========================
	True              *any*        True                       True          False      (Release runtime)
	True              *any*        True                       False         True       (Debug runtime)
	True              *any*        False                      True          True       (Debug runtime)
	True              *any*        False                      False         True       (Debug runtime)
	True              *empty*      True                       True          True       (Debug runtime)
	True              *empty*      True                       False         True       (Debug runtime)
	True              *empty*      False                      True          True       (Debug runtime)
	True              *empty*      False                      False         True       (Debug runtime)
	False             -            -                          -             False      (Release runtime)
	*empty*           *any*        *empty*                    False         True       (Debug runtime)

In the senario in the bug `$(DebugSymols)` `$(EmbedAssembliesIntoApk)` are both empty.
As a result `$(EmbedAssembliesIntoApk)` gets a default value of 'False'.
But because `$(DebugSymols)` is empty we fall through the MSBuild case statement
and end up with `$(AndroidIncludeDebugSymbols)` = `True`. Which is NOT what we want in this case.
So if `$(EmbedAssembliesIntoApk)` we should always default `$(AndroidIncludeDebugSymbols)`
to false.

In addition there was a weird issue with the way we install debug apps.
If the app is using the Shared Runtime the deployment process sends a
broadcast to the Shared Runtime app which returns the external storage
directory. This tends to be something like

	/mnt/shell/emulated/0/

So when we deploy our debug assemblies we do so to a directory like

	/mnt/shell/emulated/0/Android/data/$(PackageName)/files/.__override__

This works as expected. Now if we try to debug an app without using the Shared
Runtime it will work as expected.. unless the Shared Runtime was not installed.
In this case the broadcast fails and we fall back to getting the external storage
using

	adb shell echo -b ${EXTERNAL_STORAGE}

This returns

	/mnt/shell/emulated/legacy

so we end up deploying the debug assemblies to

	/mnt/shell/emulated/legacy/Android/data/$(PackageName)/files/.__override__

So all is well and good. However problems start in our runtime and the
MonoPackageManager. We use

	android.os.Environment.getExternalStorageDirectory ();

to get the external storage directory. In this case it ALWAYS returns

	/mnt/shell/emulated/0/

So if we are debugging without the Shared Runtime being installed, we will
NEVER find the fast deployed assebmies. So the app will crash. The fix in
this case is to check both directories when we are running the debug
runtime.