### PR TITLE
[xa-prep-tasks] Use `$(XARepositoryName)`

### DIFF
--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -144,6 +144,7 @@ create-vsix:
 			$(if $(EXPERIMENTAL),/p:IsExperimental="$(EXPERIMENTAL)") \
 			$(if $(PRODUCT_COMPONENT),/p:IsProductComponent="$(PRODUCT_COMPONENT)") \
 			$(if $(PACKAGE_VERSION),/p:ProductVersion="$(PACKAGE_VERSION)") \
+			$(if $(REPO_NAME),/p:XARepositoryName="$(REPO_NAME)") \
 			$(if $(PACKAGE_HEAD_BRANCH),/p:XAVersionBranch="$(PACKAGE_HEAD_BRANCH)") \
 			$(if $(PACKAGE_VERSION_REV),/p:XAVersionCommitCount="$(PACKAGE_VERSION_REV)") \
 			$(if $(COMMIT),/p:XAVersionHash="$(COMMIT)") ; )

--- a/build-tools/scripts/XAVersionInfo.targets
+++ b/build-tools/scripts/XAVersionInfo.targets
@@ -33,5 +33,8 @@
         ToolExe="$(GitToolExe)">
       <Output TaskParameter="Branch"                  PropertyName="XAVersionBranch"        Condition=" '$(XAVersionBranch)' == '' " />
     </GitBranch>
+    <PropertyGroup>
+      <XARepositoryName Condition=" '$(XARepositoryName)' == '' ">xamarin-android</XARepositoryName>
+    </PropertyGroup>
   </Target>
 </Project>

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.targets
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.targets
@@ -40,12 +40,12 @@
     />
     <WriteLinesToFile
         File="$(_VersionCommitFile)"
-        Lines="xamarin-android/$(XAVersionBranch)/$(XAVersionHash)"
+        Lines="$(XARepositoryName)/$(XAVersionBranch)/$(XAVersionHash)"
         Overwrite="True"
     />
     <WriteLinesToFile
         File="$(_XAVersionCommitFile)"
-        Lines="xamarin-android/$(XAVersionBranch)/$(XAVersionHash)"
+        Lines="$(XARepositoryName)/$(XAVersionBranch)/$(XAVersionHash)"
         Overwrite="True"
     />
     <WriteLinesToFile


### PR DESCRIPTION
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=57725

The generated `Version` files contain a repository name, e.g.
`Version.rev` may contain:

	xamarin-android/master/ccd083c3

This isn't entirely appropriate for the commercial Xamarin.Android
product, which is "rooted in" a different git repository.
The result is that commercial Xamarin.Android `Version.rev` files will
be "non-sensical", e.g.

	xamarin-android/HEAD/1a9979ed7

The above from the current `Xamarin.Android.Sdk.7.5.0.10.vsix` file,
and referencing a commit which does not exist within the
xamarin-android repo.

Introduce a new `$(XARepositoryName)`  MSBuild property which contains
the name of the git repo to embed into `Version.rev`. This will
default to `xamarin-android`, but allowing it to be overridden will
allow the commercial SDK to instead emit `monodroid/HEAD/1a9979ed7`.