### PR TITLE
[xabuild] Support `xabuild` as a symlink

### DIFF
--- a/tools/scripts/xabuild
+++ b/tools/scripts/xabuild
@@ -35,7 +35,8 @@
 #
 
 name=$(basename "$0")
-prefix="$(cd `dirname "$0"` && pwd)"
+truepath=$(readlink "$0" || echo "$0")
+prefix="$(cd `dirname "${truepath}"` && pwd)"
 
 if [ -z "$MSBUILD" ] ; then
 	MSBUILD=xbuild


### PR DESCRIPTION
When `xabuild` is a symlink, resolve `$prefix` *through* the symlink,
not strictly based on the value of `$0`.