### PR TITLE
[create-vsix] Copy Xamarin.Android.Sdk.json to output dir

### DIFF
--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -109,6 +109,7 @@
     </PropertyGroup>
     <PropertyGroup>
       <VsixPath Condition=" '$(VsixPath)' == '' ">..\..\bin\Build$(Configuration)\$(AssemblyName)-OSS-$(ProductVersion).$(XAVersionCommitCount)_$(_Branch)_$(XAVersionHash).vsix</VsixPath>
+      <_VsixDir>$([System.IO.Path]::GetDirectoryName ($(VsixPath)))</_VsixDir>
     </PropertyGroup>
   </Target>
   <Target Name="_CopyToBuildConfiguration"
@@ -118,6 +119,10 @@
     <Copy
         SourceFiles="$(OutputPath)$(AssemblyName).vsix"
         DestinationFiles="$(VsixPath)"
+    />
+    <Copy
+        SourceFiles="$(OutputPath)Xamarin.Android.Sdk.json"
+        DestinationFolder="$(_VsixDir)"
     />
   </Target>
   <!--


### PR DESCRIPTION
Some internal workflows require the `Xamarin.Android.Sdk.json` file in
order to use the generated `.vsix`.

Copy the generated `Xamarin.Android.Sdk.json` file into the
directory that `$(VsixPath)` uses