### PR TITLE
[api-compatibility] Fix warnings and ignored errors

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -14,8 +14,8 @@
   <PropertyGroup>
     <ProductVersion>7.4.99</ProductVersion>
     <!-- *Latest* API level binding that we support; used when building src/Xamarin.Android.Build.Tasks -->
-    <AndroidLatestApiLevel Condition="'$(AndroidLatestApiLevel)' == ''">25</AndroidLatestApiLevel>
-    <AndroidLatestFrameworkVersion Condition="'$(AndroidLatestFrameworkVersion)' == ''">v7.1</AndroidLatestFrameworkVersion>
+    <AndroidLatestApiLevel Condition="'$(AndroidLatestApiLevel)' == ''">26</AndroidLatestApiLevel>
+    <AndroidLatestFrameworkVersion Condition="'$(AndroidLatestFrameworkVersion)' == ''">v8.0</AndroidLatestFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <AutoProvision Condition=" '$(AutoProvision)' == '' ">False</AutoProvision>

--- a/tests/api-compatibility/api-compatibility.mk
+++ b/tests/api-compatibility/api-compatibility.mk
@@ -16,7 +16,6 @@ run-api-compatibility-tests: $(MONO_API_HTML) $(MONO_API_INFO)
 	make -C external/xamarin-android-api-compatibility check \
 		MONO_API_HTML="$(RUNTIME) $(abspath $(MONO_API_HTML))" \
 		MONO_API_INFO="$(RUNTIME) $(abspath $(MONO_API_INFO))" \
-		STABLE_FRAMEWORKS="$(STABLE_FRAMEWORKS)" \
 		XA_FRAMEWORK_DIR="$(abspath $(FRAMEWORK_DIR))"
 
 $(MONO_API_HTML): $(wildcard $(MONO_API_HTML_DIR)/*.cs) $(MONO_OPTIONS_SRC)


### PR DESCRIPTION
PR builds such as [**macOS+xbuild PR Builder** build 1365][0] are
emitting an error from `mono-api-info`, which isn't surfaced as an
error (hence the builds are still green):

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-pr-builder/1365/consoleText

	[ERROR] FATAL UNHANDLED EXCEPTION: Mono.Cecil.AssemblyResolutionException: Failed to resolve assembly: 'Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065'
	  at Mono.Cecil.BaseAssemblyResolver.Resolve (Mono.Cecil.AssemblyNameReference name, Mono.Cecil.ReaderParameters parameters) [0x0015e] in …/xamarin-android/external/Java.Interop/external/cecil/Mono.Cecil/BaseAssemblyResolver.cs:161

This error is raised when processing
`bin/Debug/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v1.0/Xamarin.Android.NUnitLite.dll`
because [`$(MONO_API_INFO_LIB_DIRS)`][1] contains
`-L .../MonoAndroid/v8.0`, but the PR builds are building v7.1, *not*
v8.0, and thus `Mono.Android.dll` isn't in a directory which is found.

[1]: https://github.com/xamarin/xamarin-android-api-compatibility/blob/49b5789/Makefile#L26-L29

`$(MONO_API_INFO_LIB_DIRS)` is wrong in turn because
`make run-api-compatibility-tests` was overriding
`$(STABLE_FRAMEWORKS)` to include frameworks which the PR build
doesn't build.

Update `make run-api-compatibility-tests` so that
`$(STABLE_FRAMEWORKS)` isn't overridden. This will allow
`xamarin-android-api-compatibility` to probe the frameworks based on
what's present, and construct `$(MONO_API_INFO_LIB_DIRS)` accordingly.

Additionally, xamarin-android master builds such as [build #538][2]
were also failing in an unreported manner:

[2]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/538/consoleText

	Mono.Cecil.AssemblyResolutionException: Failed to resolve assembly: '…/xamarin-android/bin/Debug/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v8.0/OpenTK-1.0.dll, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'
	  at Mono.Cecil.BaseAssemblyResolver.Resolve (Mono.Cecil.AssemblyNameReference name, Mono.Cecil.ReaderParameters parameters) [0x00164] in <336971fa838f4b15a2a3a9274b113045>:0
	  at CorCompare.AssemblyCollection.LoadAssembly (System.String assembly) [0x0002a] in <d46deda6cbab4407bacfbd3b1ee45bd0>:0
	Cannot load assembly file …/xamarin-android/bin/Debug/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v8.0/OpenTK-1.0.dll

The cause for this is that `OpenTK-1.0.dll` is built into the
`MonoAndroid/$(AndroidLatestFrameworkVersion)` framework directory,
and `Configuration.props` was setting
`$(AndroidLatestFrameworkVersion)` to v7.1 (API-25).

Update `$(AndroidLatestFrameworkVersion)` to v8.0, and
`$(AndroidLatestApiLevel)` to 26.