### PR TITLE
[Xamarin.Android.Build.Tasks] Add logging for PathToLongException to provide more information.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -263,13 +263,17 @@ namespace Xamarin.Android.Tasks
 						// temporarily extracted directory will look like:
 						//    __library_projects__/[dllname]/[library_project_imports | jlibs]/bin
 						using (var zip = MonoAndroidHelper.ReadZipFile (finfo.FullName)) {
-							updated |= Files.ExtractAll (zip, importsDir, modifyCallback: (entryFullName) => {
-								return entryFullName
-									.Replace ("library_project_imports\\","")
-									.Replace ("library_project_imports/", "");
-							}, deleteCallback: (fileToDelete) => {
-								return !jars.Contains (fileToDelete);
-							}, forceUpdate: false);
+							try {
+								updated |= Files.ExtractAll (zip, importsDir, modifyCallback: (entryFullName) => {
+									return entryFullName
+										.Replace ("library_project_imports\\","")
+										.Replace ("library_project_imports/", "");
+								}, deleteCallback: (fileToDelete) => {
+									return !jars.Contains (fileToDelete);
+								}, forceUpdate: false);
+							} catch (PathTooLongException ex) {
+								Log.LogErrorFromException (new PathTooLongException ($"Error extracting resources from \"{assemblyPath}\"", ex));
+							}
 						}
 
 						// We used to *copy* the resources to overwrite other resources,

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -225,7 +225,11 @@ namespace Xamarin.Android.Tools {
 				files.Add (outfile);
 				var dt = File.Exists (outfile) ? File.GetLastWriteTimeUtc (outfile) : DateTime.MinValue;
 				if (forceUpdate || entry.ModificationTime > dt) {
-					entry.Extract (destination, fullName, FileMode.OpenOrCreate);
+					try {
+						entry.Extract (destination, fullName, FileMode.OpenOrCreate);
+					} catch (PathTooLongException) {
+						throw new PathTooLongException ($"Could not extract \"{fullName}\" to \"{outfile}\". Path is too long.");
+					}
 					updated = true;
 				}
 			}


### PR DESCRIPTION
If we hit a PathToLongException when extracting embedded resources
we currently do not get any information about the file where
actually caused the problem.

This commit adds handling for that case so that the error message
includes the file and path of the file that was being extracted.