### PR TITLE
Use `-f` flag to xabuild, to turn relative paths absolute

### DIFF
--- a/tools/scripts/xabuild
+++ b/tools/scripts/xabuild
@@ -35,7 +35,7 @@
 #
 
 name=$(basename "$0")
-truepath=$(readlink "$0" || echo "$0")
+truepath=$(readlink -f "$0" || echo "$0")
 prefix="$(cd `dirname "${truepath}"` && pwd)"
 
 if [ -z "$MSBUILD" ] ; then


### PR DESCRIPTION
The build system dies if xabuild is a symlink pointing to the real xabuild with a *relative* path instead of an absolute one. The `-f` flag to readlink handles this.