### PR TITLE
[Xamarin.Android.Build.Tasks] Seeing a new seemingly DesignTimeBuild related build failure when invoking the Rebuild msbuild target

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1013,7 +1013,7 @@ because xbuild doesn't support framework reference assemblies.
 	</ReadLinesFromFile>
 </Target>
 
-<Target Name="_CreatePropertiesCache" DependsOnTargets="_ReadPropertiesCache">
+<Target Name="_CreatePropertiesCache" DependsOnTargets="_SetupDesignTimeBuildForBuild;_ReadPropertiesCache">
 	<MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" />
 	<WriteLinesToFile
 		Condition="'@(_PropertiesCache)' != '@(_PropertyCacheItems)'" 


### PR DESCRIPTION
Context https://bugzilla.xamarin.com/show_bug.cgi?id=58682

The `$(DesignTimeBuild)` value was empty when running under mac.
This cuases the error

	error MSB4044: The "GetAdditionalResourcesFromAssemblies" task was not given a value for the required parameter "DesignTimeBuild".

So we need to make sure that the value is set before we get to
`GetAdditionalResourcesFromAssemblies`. The reason we got the error
is before we used `$(DesignTimeBuild)` only in conditionals. However
when moving to use it as a property of a task it cannot be empty.
So we need to make sure we call `_SetupDesignTimeBuildForBuild`
early in the build process.