### PR TITLE
[Xamarin.Android.Build.Tests] Fix some broken unit tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -155,7 +155,8 @@ namespace Xamarin.Android.Tasks
 			this.AndroidSdkPath = AndroidSdk.AndroidSdkPath;
 			this.JavaSdkPath = AndroidSdk.JavaSdkPath;
 
-			ValidateJavaVersion (TargetFrameworkVersion, AndroidSdkBuildToolsVersion);
+			if (!ValidateJavaVersion (TargetFrameworkVersion, AndroidSdkBuildToolsVersion))
+				return false;
 
 			if (string.IsNullOrEmpty (AndroidSdkPath)) {
 				Log.LogCodedError ("XA5205", "The Android SDK Directory could not be found. Please set via /p:AndroidSdkDirectory.");
@@ -336,7 +337,7 @@ namespace Xamarin.Android.Tasks
 			return Version.Parse (MinimumSupportedJavaVersion);
 		}
 
-		void ValidateJavaVersion (string targetFrameworkVersion, string buildToolsVersion)
+		bool ValidateJavaVersion (string targetFrameworkVersion, string buildToolsVersion)
 		{
 			Version requiredJavaForFrameworkVersion = GetJavaVersionForFramework (targetFrameworkVersion);
 			Version requiredJavaForBuildTools = GetJavaVersionForBuildTools (buildToolsVersion);
@@ -358,7 +359,7 @@ namespace Xamarin.Android.Tasks
 			} catch (Exception ex) {
 				Log.LogWarningFromException (ex);
 				Log.LogWarning ($"Failed to get the Java SDK version. Please ensure you have Java {required} or above installed.");
-				return;
+				return false;
 			}
 			var versionInfo = sb.ToString ();
 			var versionNumberMatch = javaVersionRegex.Match (versionInfo);
@@ -373,6 +374,7 @@ namespace Xamarin.Android.Tasks
 				}
 			} else
 				Log.LogWarning ($"Failed to get the Java SDK version. Found {versionInfo} but this does not seem to contain a valid version number.");
+			return !Log.HasLoggedErrors;
 		}
 
 		bool ValidateApiLevels ()

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -107,6 +107,18 @@ namespace Xamarin.Android.Build.Tests
 			return androidSdkDirectory;
 		}
 
+		protected string CreateFauxReferencesDirectory (string path, string[] versions)
+		{
+			string referencesDirectory = Path.Combine (Root, path);
+			Directory.CreateDirectory (referencesDirectory);
+			Directory.CreateDirectory (Path.Combine (referencesDirectory, "v1.0"));
+			File.WriteAllText (Path.Combine (referencesDirectory, "v1.0", "mscorlib.dll"), "");
+			foreach (var v in versions){
+				Directory.CreateDirectory (Path.Combine (referencesDirectory, v));
+			}
+			return referencesDirectory;
+		}
+
 		protected string CreateFauxJavaSdkDirectory (string path, string javaVersion, out string javaExe)
 		{
 			javaExe = IsWindows ? "Java.cmd" : "java.bash";


### PR DESCRIPTION
The BuildMultiDexApplication and the ValidateJavaVersion tests
were broken. ValidateJavaVersion required that all the tested target
frameworks were built. In xamarin-android this was not the case.
Only v1.0 and the latest supported one are built.
So we need to modify the ResolveSdksTask to abort early if the
Java Version checks fail.

Similarly the BuildMultiDexApplication was using a hard coded
target framework version. What we should be doing is getting
it to use the latest. But we need to cacluate that at runtime
so a new `LatestTargetFrameworkVersion` has been added to the
Builder. This is similar to the GetSupportedRuntimes () as it
caclulates the highest supported TargetFrameworkVersion.