### PR TITLE
Enable building LLVM cross-compilers on Linux

### DIFF
--- a/build-tools/mono-runtimes/mono-runtimes.projitems
+++ b/build-tools/mono-runtimes/mono-runtimes.projitems
@@ -276,7 +276,7 @@
       <InstallPath Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:'))">Linux/</InstallPath>
     </_LlvmRuntime>
 
-    <_LlvmRuntime Include="llvmwin32" Condition=" '$(_LlvmNeeded)' != '' And ($(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':linux-Win32:'))) ">
+    <_LlvmRuntime Include="llvmwin32" Condition=" '$(_LlvmNeededWindows32)' != '' ">
       <BuildDir>build-win32</BuildDir>
       <Prefix>$(_LlvmPrefixWin32)</Prefix>
       <ConfigureFlags>$(_LlvmConfigureFlagsWin32)</ConfigureFlags>
@@ -287,7 +287,7 @@
       <InstallPath></InstallPath>
     </_LlvmRuntime>
 
-    <_LlvmRuntime Include="llvmwin64" Condition=" '$(_LlvmNeeded)' != '' And ($(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':linux-Win64:'))) ">
+    <_LlvmRuntime Include="llvmwin64" Condition=" '$(_LlvmNeededWindows64)' != '' ">
       <BuildDir>build-win64</BuildDir>
       <Prefix>$(_LlvmPrefixWin64)</Prefix>
       <ConfigureFlags>$(_LlvmConfigureFlagsWin64)</ConfigureFlags>

--- a/build-tools/mono-runtimes/mono-runtimes.props
+++ b/build-tools/mono-runtimes/mono-runtimes.props
@@ -27,6 +27,9 @@
     <!-- LLVM -->
     <_LlvmNeeded Condition=" '$(AndroidSupportedTargetAotAbis)' != '' ">yes</_LlvmNeeded>
     <_LlvmCanBuild64 Condition=" '$(HostBits)' == '64' ">yes</_LlvmCanBuild64>
+    <_LlvmHaveWindowsAOT Condition=" $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-armeabi:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-arm64:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-x86:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-x86_64:'))">yes</_LlvmHaveWindowsAOT>
+    <_LlvmNeededWindows32 Condition=" '$(_LlvmNeeded)' != '' And '$(_LlvmHaveWindowsAOT)' == 'yes' And ($(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:'))) ">yes</_LlvmNeededWindows32>
+    <_LlvmNeededWindows64 Condition=" '$(_LlvmNeeded)' != '' And '$(_LlvmHaveWindowsAOT)' == 'yes' And '$(_LlvmCanBuild64)' == 'yes' And ($(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:'))) ">yes</_LlvmNeededWindows64>
     <_LlvmOutputDirTop>$(_CrossOutputDirTop)\llvm</_LlvmOutputDirTop>
 
     <_LlvmBuildDir32>$(_LlvmOutputDirTop)\build-32</_LlvmBuildDir32>

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -53,24 +53,19 @@ ALL_AOT_ABIS = \
 	arm64 \
 	x86 \
 	x86_64 \
-#
-# On Linux we now disable building of all the Windows cross-compiler/AOT environments.
-# This is because Linux builds don't use mxe and the system-provided mingw environment
-# is missing a handful of libraries required by libmonodroid and libzip-windows
-#
-# When/if CppSharp is fixed to work on Linux we can re-enable the code below
-#
+
 ifneq ($(OS),Linux)
 ALL_HOST_ABIS += \
 	mxe-Win32 \
 	mxe-Win64
-endif
+
 
 ALL_AOT_ABIS += \
 	win-armeabi \
 	win-arm64 \
 	win-x86 \
 	win-x86_64
+endif
 
 ifneq ($(OS),Linux)
 MONO_OPTIONS += --arch=64


### PR DESCRIPTION
Linux doesn't need to build MXE since the distributions we support at
this point have mingw packaged and we rely on the packages to provide
cross-compilation environment for Windows. Neither does Linux build
require the Mono Windows environments to be built.

Previously, when one enable the Windows LLVM build the Mono Windows
runtime was attempted to build as well. The attempt would fail since
some Windows-only libraries required by Mono/libmonodroid aren't available
as packages on Linux.

This commit disables building of Mono Windows runtimes while making it
possible to build the LLVM Windows cross compiler.