### PR TITLE
[monodroid] generate embedded blobs from an MSBuild task

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Building Xamarin.Android requires:
 * [Mono 4.4 or later](#mono-sdk)
 * [The Java Development Kit (JDK)](#jdk)
 * [Autotools (`autoconf`, `automake`, etc.)](#autotools)
-* [`xxd`](#xxd)
 * [The Android SDK and NDK](#ndk)
 
 The `make prepare` build step will check that all required dependencies
@@ -90,17 +89,6 @@ On OS X, autotools are distributed with [Mono.framework][osx-mono].
 If you run into issues regarding `autoconf` or `automake` try to install it with `brew` via:
 
     brew install automake
-
-<a name="xxd" />
-
-## `xxd`
-
-The [xxd][xxd] utility is used to build [src/monodroid](src/monodroid).
-It is installed by default on OS X. Linux users may need to separately
-install it; it may be part of the [**vim-common** package][sid-vim-common].
-
-[xxd]: http://linux.die.net/man/1/xxd
-[sid-vim-common]: https://packages.debian.org/sid/vim-common
 
 <a name="ndk" />
 

--- a/build-tools/dependencies/dependencies.projitems
+++ b/build-tools/dependencies/dependencies.projitems
@@ -53,9 +53,6 @@
     <RequiredProgram Include="xz"                   Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>xz</Homebrew>
     </RequiredProgram>
-    <RequiredProgram Include="xxd">
-      <UbuntuInstall>$(_AptGetInstall) vim-common</UbuntuInstall>
-    </RequiredProgram>
     <RequiredProgram Include="$(ManagedRuntime)"    Condition=" '$(ManagedRuntime)' != '' ">
       <MinimumVersion>$(MonoRequiredMinimumVersion)</MinimumVersion>
       <DarwinMinimumVersion>$(MonoRequiredDarwinMinimumVersion)</DarwinMinimumVersion>

--- a/build-tools/scripts/dependencies/linux-prepare-Arch.sh
+++ b/build-tools/scripts/dependencies/linux-prepare-Arch.sh
@@ -30,7 +30,6 @@ ARCH_DEPS="autoconf
 	unzip
 	which
 	zip
-	xxd
 	"
 if [ $NO_SUDO = "false" ]; then
 	sudo pacman -S --noconfirm --needed $ARCH_DEPS

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -43,6 +43,7 @@
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\CheckAdbTarget.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\CreateAndroidEmulator.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Emulator.cs" />
+    <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GenerateMonoDroidIncludes.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GenerateProfile.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GetNugetPackageBasePath.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\RunInstrumentationTests.cs" />

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateMonoDroidIncludes.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateMonoDroidIncludes.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.IO;
+using System.Globalization;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	public class GenerateMonoDroidIncludes : Task
+	{
+		[Required]
+		public ITaskItem [] SourceFiles { get; set; }
+
+		[Required]
+		public ITaskItem [] DestinationFiles { get; set; }
+
+		public override bool Execute ()
+		{
+			Log.LogMessage (MessageImportance.Low, $"Task {nameof (GenerateMonoDroidIncludes)}");
+
+			if (SourceFiles.Length != DestinationFiles.Length) {
+				Log.LogError ($"{nameof(SourceFiles)}.Length must equal {nameof(DestinationFiles)}.Length.");
+				return false;
+			}
+
+			Log.LogMessage (MessageImportance.Low, $"\t{nameof(SourceFiles)} : ");
+			for (int i = 0; i < SourceFiles.Length; i++) {
+				var source = SourceFiles [i];
+				var destination = DestinationFiles [i];
+				Log.LogMessage (MessageImportance.Low, "\t\t{0} -> {1}", source.ItemSpec, destination.ItemSpec);
+
+				var bytes = File.ReadAllBytes (source.ItemSpec);
+
+				//Should be equivalent of "xxd -i %(_EmbeddedBlob.Config) | sed 's/^unsigned /static const unsigned /g' > jni/%(_EmbeddedBlob.Include)"
+				using (var fs = File.Create (destination.ItemSpec))
+				using (var writer = new StreamWriter(fs)) {
+					var variableName = "monodroid_" + Path.GetFileNameWithoutExtension (source.ItemSpec).Replace ('.', '_');
+					writer.Write ("static const unsigned char ");
+					writer.Write (variableName);
+					writer.Write ("[] = {");
+
+					for (int j = 0; j < bytes.Length; j++) {
+						if (j != 0)
+							writer.Write (",");
+
+						//12 per line
+						if (j % 12 == 0) {
+							writer.WriteLine ();
+							writer.Write ("  ");
+						} else {
+							writer.Write (" ");
+						}
+
+						writer.Write ("0x");
+						writer.Write (bytes [j].ToString ("x2", CultureInfo.InvariantCulture));
+					}
+
+					//Needs to be a null-terminating string and include a trailing \0
+					writer.WriteLine (", 0x00");
+					writer.WriteLine ("};");
+
+					//Length
+					writer.Write ("static const unsigned int ");
+					writer.Write (variableName);
+					writer.Write ("_len = ");
+					writer.Write (bytes.Length + 1);
+					writer.WriteLine (";");
+				}
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -4,6 +4,7 @@
   <Import Project="monodroid.props" />
   <Import Project="monodroid.projitems" />
   <Import Project="..\..\build-tools\scripts\RequiredPrograms.targets" />
+  <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.GenerateMonoDroidIncludes" />
   <PropertyGroup>
     <_Conf>$(Configuration.ToLowerInvariant())</_Conf>
   </PropertyGroup>
@@ -28,25 +29,19 @@
     <_UnixCFile Include="jni\xamarin_getifaddrs.c" />
   </ItemGroup>
   <ItemGroup>
-    <_EmbeddedBlob Include="config.xml">
-      <Config>monodroid.config</Config>
-      <Include>config.include</Include>
-    </_EmbeddedBlob>
-    <_EmbeddedBlob Include="machine.config.xml">
-      <Config>monodroid.machine.config</Config>
-      <Include>machine.config.include</Include>
-    </_EmbeddedBlob>
+    <_EmbeddedBlobSource Include="config.xml" />
+    <_EmbeddedBlobDestination Include="jni\config.include" />
+    <_EmbeddedBlobSource Include="machine.config.xml" />
+    <_EmbeddedBlobDestination Include="jni\machine.config.include" />
   </ItemGroup>
   <Target Name="_BuildRuntimes"
       DependsOnTargets="_GenerateIncludeFiles;_BuildAndroidRuntimes;_BuildHostRuntimes">
   </Target>
   <Target Name="_GenerateIncludeFiles"
-      Inputs="@(_EmbeddedBlob);jni/config.h"
-      Outputs="@(_EmbeddedBlob->'jni\%(Include)');$(MSBuildThisFileDirectory)bin\$(Configuration)\include\config.h">
+      Inputs="@(_EmbeddedBlobSource);jni/config.h"
+      Outputs="@(_EmbeddedBlobDestination);$(MSBuildThisFileDirectory)bin\$(Configuration)\include\config.h">
     <Copy SourceFiles="jni/config.h" DestinationFiles="$(MSBuildThisFileDirectory)bin\$(Configuration)\include\config.h" />
-    <Exec Command="(cat &quot;@(_EmbeddedBlob)&quot; ; dd if=/dev/zero bs=1 count=1 2>/dev/null) > %(_EmbeddedBlob.Config)" />
-    <Exec Command="xxd -i %(_EmbeddedBlob.Config) | sed 's/^unsigned /static const unsigned /g' > jni/%(_EmbeddedBlob.Include)" />
-    <Exec Command="rm %(_EmbeddedBlob.Config)" />
+    <GenerateMonoDroidIncludes SourceFiles="@(_EmbeddedBlobSource)" DestinationFiles="@(_EmbeddedBlobDestination)" />
   </Target>
   <Target Name="_BuildAndroidRuntimes"
       Inputs="@(_CFile);jni\Android.mk"


### PR DESCRIPTION
`monodroid.mdproj` was generating `jni/config.include` and
`jni/machine.config.include`  using the `xxd` and `sed` commands, which
will not work on Windows.

Changes:
- Added a new MSBuild task, `GenerateMonoDroidIncludes` that replicates
the `xxd` output in C#
- Cleaned up the `<ItemGroup>` to have `@(_EmbeddedBlobSource)` and
`@(_EmbeddedBlobDestination)`
- We are no longer using `xxd` anywhere so this can be removed from
`dependencies.projitems`, `linux-prepare-Arch.sh`, and the `README`