### PR TITLE
[windows] changes to get bundle download working

### DIFF
--- a/build-tools/bundle/bundle-path.targets
+++ b/build-tools/bundle/bundle-path.targets
@@ -34,7 +34,8 @@
   <Target Name="GetBundleFileName"
       DependsOnTargets="_GetHashes">
     <PropertyGroup>
-      <XABundleFileName>bundle-v19-h$(_VersionHash)-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
+      <XABundleFileName Condition=" '$(HostOS)' != 'Windows' ">bundle-v19-h$(_VersionHash)-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
+      <XABundleFileName Condition=" '$(HostOS)' == 'Windows' ">bundle-v19-h$(_VersionHash)-$(Configuration)-Darwin-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
     </PropertyGroup>
   </Target>
 </Project>

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/SystemUnzip.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/SystemUnzip.cs
@@ -95,7 +95,8 @@ namespace Xamarin.Android.BuildTools.PrepTasks {
 
 			relativeDestDir = relativeDestDir?.Replace ('\\', Path.DirectorySeparatorChar);
 
-			if (string.Equals (HostOS, "Windows", StringComparison.OrdinalIgnoreCase)) {
+			bool isWindows = string.Equals (HostOS, "Windows", StringComparison.OrdinalIgnoreCase);
+			if (isWindows) {
 				ZipFile.ExtractToDirectory (sourceFile, nestedTemp, encoding);
 			} else {
 				var start = new ProcessStartInfo ("unzip", $"\"{sourceFile}\" -d \"{nestedTemp}\"") {
@@ -141,7 +142,16 @@ namespace Xamarin.Android.BuildTools.PrepTasks {
 					Directory.CreateDirectory (Path.GetDirectoryName (dest));
 					Log.LogMessage (MessageImportance.Low, $"mv '{file}' '{dest}'");
 					if (Directory.Exists (entry)) {
-						using (var p = Process.Start ("/bin/mv", $@"""{file}"" ""{dest}""")) {
+						ProcessStartInfo psi;
+						if (isWindows) {
+							psi = new ProcessStartInfo ("cmd", $@"/C move ""{file}"" ""{dest}""") {
+								CreateNoWindow = true,
+								UseShellExecute = false,
+							};
+						} else {
+							psi = new ProcessStartInfo ("/bin/mv", $@"""{file}"" ""{dest}""");
+						}
+						using (var p = Process.Start (psi)) {
 							p.WaitForExit ();
 						}
 					}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -147,6 +147,7 @@
     Inputs="$(_AndroidSdkLocation)\$(_MultiDexAarInAndroidSdk);$(_SupportLicense)"
     Outputs="$(OutputPath)android-support-multidex.jar;$(OutputPath)MULTIDEX_JAR_LICENSE">
     <UnzipDirectoryChildren
+      HostOS="$(HostOS)"
       NoSubdirectory="true"
       SourceFiles="$(_AndroidSdkLocation)\$(_MultiDexAarInAndroidSdk)"
       DestinationFolder="$(IntermediateOutputPath)multidex-aar" />


### PR DESCRIPTION
In the steps to getting Xamarin.Android to build on Windows, we are
first going to _require_ the bundle to be downloaded from a previous
Mac build. Since `$(HostOS)` will be `Windows`, we need to download the
`Darwin` bundle specifically on Windows.

Found a place that `UnzipDirectoryChildren` was not getting passed the
`$(HostOS)` variable appropriately in `Xamarin.Android.Build.Tasks.targets`.

And lastly, the `SystemUnzip` MSBuild task was using `/bin/mv` which
should use an equivalent Windows command instead. `cmd /C move` is a
reasonable alternative on Windows. Note that I did not run into any
`MAX_PATH` issues here.