### PR TITLE
[Xamarin.Android.Build.Tasks] _CompileToDalvikWithDx invoked after modifying .cs file in a referenced library project

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -486,6 +486,8 @@ namespace Bug12935
             android:authorities='${applicationId}.FacebookInitProvider'
             android:name='.internal.FacebookInitProvider'
             android:exported='false' />
+        <meta-data android:name='android.support.VERSION' android:value='25.4.0' />
+        <meta-data android:name='android.support.VERSION' android:value='25.4.0' />
     </application>
 </manifest>
 ", encoding: System.Text.Encoding.UTF8);
@@ -522,6 +524,8 @@ namespace Bug12935
 						"${applicationId}.FacebookInitProvider was not replaced with com.xamarin.manifest.FacebookInitProvider");
 					Assert.IsTrue (manifest.Contains ("com.xamarin.test.internal.FacebookInitProvider"),
 						".internal.FacebookInitProvider was not replaced with com.xamarin.test.internal.FacebookInitProvider");
+					Assert.AreEqual (manifest.IndexOf ("meta-data", StringComparison.OrdinalIgnoreCase),
+					                 manifest.LastIndexOf ("meta-data", StringComparison.OrdinalIgnoreCase), "There should be only one meta-data element");
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -402,6 +402,16 @@ namespace Xamarin.Android.Tasks {
 			}
 		}
 
+		void RemoveDuplicateElements ()
+		{
+			var duplicates = doc.Descendants ()
+			                    .GroupBy (x => x.ToFullString ())
+					    .SelectMany (x => x.Skip (1));
+			foreach (var duplicate in duplicates)
+				duplicate.Remove ();
+			
+		}
+
 		IEnumerable<XNode> FixupNameElements(string packageName, IEnumerable<XNode> nodes)
 		{
 			foreach (var element in nodes.Select ( x => x as XElement).Where (x => x != null && ManifestAttributeFixups.ContainsKey (x.Name.LocalName))) {
@@ -839,6 +849,7 @@ namespace Xamarin.Android.Tasks {
 
 		public void Save (System.IO.TextWriter stream)
 		{
+			RemoveDuplicateElements ();
 			var ms = new MemoryStream ();
 			doc.Save (ms);
 			ms.Flush ();

--- a/src/Xamarin.Android.Build.Tasks/Utilities/XDocumentExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/XDocumentExtensions.cs
@@ -22,6 +22,11 @@ namespace Xamarin.Android.Tasks
 				e = e.Elements (p);
 			return e.Select (p => p.Value).ToArray ();
 		}
+
+		public static string ToFullString (this XElement element)
+		{
+			return element.ToString (SaveOptions.DisableFormatting);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=58865

In this case the problem was being caused by the fact that the
AndroidManifest.xml was constantly being modified. The item

	<meta-data android:name="android.support.VERSION" android:value="25.4.0" />

was constantly being duplicated in manifest. As a result it
was always newer and was triggering a change of build targets.

So we need to double check we are NOT adding 100% duplicate
values to the manifest.