### PR TITLE
[windows] fixes for JavaCallableWrappers.targets

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -67,6 +67,7 @@
     <AllSupportedTargetAndroidAbis>$(AllSupported32BitTargetAndroidAbis);$(AllSupported64BitTargetAndroidAbis)</AllSupportedTargetAndroidAbis>
     <XABuildToolsVersion>26-rc2</XABuildToolsVersion>
     <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">26.0.0-rc2</XABuildToolsFolder>
+    <PathSeparator>$([System.IO.Path]::PathSeparator)</PathSeparator>
   </PropertyGroup>
   <PropertyGroup>
     <_MingwPrefixTail Condition=" '$(HostOS)' == 'Darwin' ">.static</_MingwPrefixTail>

--- a/build-tools/scripts/JavaCallableWrappers.targets
+++ b/build-tools/scripts/JavaCallableWrappers.targets
@@ -9,7 +9,7 @@
       <OutputPathAbs Condition="$([System.IO.Path]::IsPathRooted($(OutputPath)))">$(OutputPath)</OutputPathAbs>
       <OutputPathAbs Condition=" '$(OutputPathAbs)' == '' ">$(MSBuildProjectDirectory)\$(OutputPath)</OutputPathAbs>
       <JcwGen>"$(XAInstallPrefix)xbuild\Xamarin\Android\jcw-gen.exe" -v10</JcwGen>
-      <_LibDirs>-L "$(OutputPathAbs)" -L "$(OutputPathAbs)..\v1.0\" -L "$(OutputPathAbs)..\v1.0\Facades"</_LibDirs>
+      <_LibDirs>-L "$(OutputPathAbs.TrimEnd('\'))" -L "$(OutputPathAbs)..\v1.0" -L "$(OutputPathAbs)..\v1.0\Facades"</_LibDirs>
       <_Out>-o "$(MSBuildProjectDirectory)\$(IntermediateOutputPath)jcw\src"</_Out>
     </PropertyGroup>
     <Exec
@@ -30,7 +30,7 @@
       <_MonoAndroidJar>$(OutputPath)mono.android.jar</_MonoAndroidJar>
     </PropertyGroup>
     <Exec
-        Command="javac $(_Target) $(_D) -bootclasspath $(_AndroidJar):&quot;$(_MonoAndroidJar)&quot; @$(IntermediateOutputPath)jcw\classes.txt"
+        Command="javac $(_Target) $(_D) -bootclasspath $(_AndroidJar)$(PathSeparator)&quot;$(_MonoAndroidJar)&quot; @$(IntermediateOutputPath)jcw\classes.txt"
     />
     <Exec
         Condition="Exists('$(_MonoAndroidJar)')"


### PR DESCRIPTION
When running `<Exec>` on Windows, a trailing slash on the end of a path
before a quote can actually escape the quote. This breaks a call to
`jcw-gen.exe` where a proper list of directories wasn’t getting passed
in.

There were also some failing `javac` calls on Windows. `javac` uses a
semi-colon to delimit jar files on Windows and a colon on Linux/MacOS.

Changes:
- `_LibDirs` needs to ensure there aren’t trailing slashes on
directories passed to `jcw-gen`
- Added a `PathSeparator` property in `Configuration.props` to use the
right delimiter on each platform