### PR TITLE
[test] Check for "Unknown has vcpu" emulator message

### DIFF
--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
@@ -103,6 +103,10 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 					Log.LogError ($"Do you have another VM running on the machine? If so, please try exiting the VM and try again.");
 					sawError.Set ();
 				}
+				if (e.Data.StartsWith ("Unknown hax vcpu return", StringComparison.Ordinal)) {
+					Log.LogError ($"Emulator failed to start: `{e.Data}`. Please try again?");
+					sawError.Set ();
+				}
 			};
 
 			p.OutputDataReceived  += output;


### PR DESCRIPTION
The Jenkins emulator-based tests are hanging -- again (see also
db668ba) -- this time with a new message:

	[emulator stderr] Unknown hax vcpu return 1

I don't know what it means, other than "nothing is going to happen for
hours on end." Add an `emulator` stderr check for the above message,
and bail out early if it's seen so that we don't lose hours waiting
for a Job timeout to occur...