### PR TITLE
[enumification] fix NotificationVisibility enumification.

### DIFF
--- a/build-tools/enumification-helpers/methodmap.ext.csv
+++ b/build-tools/enumification-helpers/methodmap.ext.csv
@@ -1696,8 +1696,8 @@
 // 26, android.app.job, JobScheduler, enqueue, return, -it-was-not-enumified-at-api-level-21-
 26, android.app, NotificationChannel, getImportance, return, Android.App.NotificationImportance
 26, android.app, NotificationChannel, setImportance, importance, Android.App.NotificationImportance
-26, android.app, NotificationChannel, getLockScreenVisibility, return, Android.App.NotificationVisibility
-26, android.app, NotificationChannel, setLockScreenVisibility, lockScreenVisibility, Android.App.NotificationVisibility
+26, android.app, NotificationChannel, getLockscreenVisibility, return, Android.App.NotificationVisibility
+26, android.app, NotificationChannel, setLockscreenVisibility, lockscreenVisibility, Android.App.NotificationVisibility
 26, android.app, NotificationChannel, ctor, importance, Android.App.NotificationImportance
 26, android.app, PendingIntent, getForegroundService, flags, Android.App.PendingIntentFlags
 

--- a/src/Mono.Android/methodmap.csv
+++ b/src/Mono.Android/methodmap.csv
@@ -2292,8 +2292,8 @@
 // 26, android.app.job, JobScheduler, enqueue, return, -it-was-not-enumified-at-api-level-21-
 26, android.app, NotificationChannel, getImportance, return, Android.App.NotificationImportance
 26, android.app, NotificationChannel, setImportance, importance, Android.App.NotificationImportance
-26, android.app, NotificationChannel, getLockScreenVisibility, return, Android.App.NotificationVisibility
-26, android.app, NotificationChannel, setLockScreenVisibility, lockScreenVisibility, Android.App.NotificationVisibility
+26, android.app, NotificationChannel, getLockscreenVisibility, return, Android.App.NotificationVisibility
+26, android.app, NotificationChannel, setLockscreenVisibility, lockscreenVisibility, Android.App.NotificationVisibility
 26, android.app, NotificationChannel, ctor, importance, Android.App.NotificationImportance
 26, android.app, PendingIntent, getForegroundService, flags, Android.App.PendingIntentFlags
 


### PR DESCRIPTION
It was getLockscreenVisibility, not getLockScreenVisibility...

----

Do not merge it yet, let's see if run-api-compatibility-check actually reports the ABI breakage. It didn't for me...