### PR TITLE
[windows] Xamarin.Android.NUnitLite needs NoStdLib

### DIFF
--- a/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj
+++ b/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj
@@ -15,6 +15,7 @@
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <AndroidApplication>false</AndroidApplication>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
+    <NoStdLib>true</NoStdLib>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <Import Project="..\..\build-tools\scripts\MonoAndroidFramework.props" />


### PR DESCRIPTION
When running the build on Windows you see `FrameworkPathOverride =
\bin\Debug\lib\xamarin.android\xbuild-frameworksMonoAndroid\v1.0` get
set during the build. Turns out we need to set `NoStdLib` true since we
are using a custom `mscorlib.dll`. This prevents the path getting messed
up on Windows.