### PR TITLE
[Xamarin.Android.Build.Tasks] Fix up _ResolveAssemblies to support the Designer

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1422,6 +1422,8 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_ResolveAssemblies">
 	<!--- Remove the ImplicitlyExpandDesignTimeFacades assemblies. We have already build the app there are not required for packaging  -->
 	<ItemGroup>
+		<FilteredAssemblies Include="$(OutDir)$(TargetFileName)"
+				Condition="Exists ('$(OutDir)$(TargetFileName)')" />
 		<FilteredAssemblies Include="%(ReferenceCopyLocalPaths.Identity)"
 				Condition="'%(ReferenceCopyLocalPaths.ResolvedFrom)' != 'ImplicitlyExpandDesignTimeFacades' And '%(ReferenceCopyLocalPaths.Extension)' == '.dll' And '%(ReferenceCopyLocalPaths.DestinationSubDirectory)' == '' "/>
 		<!-- Fallback to @(ReferencePath) if @(ReferenceCopyLocalPaths) is empty. This is for xbuild support -->
@@ -1430,7 +1432,7 @@ because xbuild doesn't support framework reference assemblies.
 	</ItemGroup>
 	<!-- Find all the assemblies this app requires -->
 	<ResolveAssemblies
-		Assemblies="$(OutDir)$(TargetFileName);@(FilteredAssemblies)"
+		Assemblies="@(FilteredAssemblies)"
 		I18nAssemblies="$(MandroidI18n)"
 		LinkMode="$(AndroidLinkMode)"
 		ReferenceAssembliesDirectory="$(TargetFrameworkDirectory)">


### PR DESCRIPTION
We are going to add a bunch of new targets for the designer.
This is so if we make changes to the file structure there will
be no need for the designer to alter code.

However we do need to alter the targets a bit. In this case we
only want to pass the `$(OutDir)$(TargetFileName)` if it exists.
Otherwise the task will error. In the case of the designer this
will happen quite allot because the project might not have been
built yet.