### PR TITLE
[windows] libzip-windows.mdproj can copy binaries from NuGet

### DIFF
--- a/build-tools/libzip-windows/libzip-windows.mdproj
+++ b/build-tools/libzip-windows/libzip-windows.mdproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
   <PropertyGroup>
-    <BuildDependsOnLocal Condition="'$(HostOS)' == 'Windows' OR '$(HostOS)' == 'Darwin'">
+    <BuildDependsOnLocal Condition=" '$(HostOS)' == 'Darwin' ">
       ResolveReferences;
       _BuildUnlessCached
     </BuildDependsOnLocal>
@@ -26,12 +26,12 @@
   <Import Project="libzip-windows.targets" />
   <Import Project="..\libzip\libzip.targets" />
   <ItemGroup>
-    <ProjectReference Include="..\android-toolchain\android-toolchain.mdproj">
+    <ProjectReference Include="..\android-toolchain\android-toolchain.mdproj" Condition=" '$(HostOS)' != 'Windows' ">
       <Project>{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA}</Project>
       <Name>android-toolchain</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
-  <Target Name="Build" DependsOnTargets="$(BuildDependsOnLocal)" />
+  <Target Name="Build" DependsOnTargets="$(BuildDependsOnLocal)" Condition=" '$(HostOS)' != 'Windows' " />
   <Target Name="Clean" />
 </Project>

--- a/build-tools/libzip-windows/libzip-windows.projitems
+++ b/build-tools/libzip-windows/libzip-windows.projitems
@@ -13,5 +13,17 @@
       <OutputLibrary>libzip.dll</OutputLibrary>
       <OutputLibraryPath>lib/libzip.dll</OutputLibraryPath>
     </_LibZipTarget>
+    <_NuGetBinary Include="..\..\external\LibZipSharp\bin\$(OS)\$(Configuration)\libzip.dll">
+      <Destination>libzip.dll</Destination>
+    </_NuGetBinary>
+    <_NuGetBinary Include="..\..\external\LibZipSharp\bin\$(OS)\$(Configuration)\zlib.dll">
+      <Destination>zlib.dll</Destination>
+    </_NuGetBinary>
+    <_NuGetBinary Include="..\..\external\LibZipSharp\bin\$(OS)\$(Configuration)\x64\libzip.dll">
+      <Destination>x64\libzip.dll</Destination>
+    </_NuGetBinary>
+    <_NuGetBinary Include="..\..\external\LibZipSharp\bin\$(OS)\$(Configuration)\x64\zlib.dll">
+      <Destination>x64\zlib.dll</Destination>
+    </_NuGetBinary>
   </ItemGroup>
 </Project>

--- a/build-tools/libzip-windows/libzip-windows.targets
+++ b/build-tools/libzip-windows/libzip-windows.targets
@@ -1,3 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="Build"
+      Condition=" '$(HostOS)' == 'Windows' "
+      Inputs="@(_NuGetBinary)"
+      Outputs="@(_NuGetBinary->'$(OutputPath)%(Destination)')">
+    <Copy 
+        SourceFiles="@(_NuGetBinary)"
+        DestinationFiles="@(_NuGetBinary->'$(OutputPath)%(Destination)')"
+        SkipUnchangedFiles="True"
+    />
+  </Target>
 </Project>

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -62,6 +62,11 @@
       <Name>libzip</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\..\build-tools\libzip-windows\libzip-windows.mdproj" Condition=" '$(HostOS)' == 'Windows' ">
+      <Project>{0DE278D6-000F-4001-BB98-187C0AF58A61}</Project>
+      <Name>libzip-windows</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
     <ProjectReference Include="..\..\build-tools\xa-prep-tasks\xa-prep-tasks.csproj">
       <Project>{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}</Project>
       <Name>xa-prep-tasks</Name>


### PR DESCRIPTION
LibZipSharp is pulling `libzip.dll` and `zlib.dll` from NuGet on
Windows, so we can use these in favor of building
`libzip-windows.mdproj`.

We also need to add a `<ProjectReference>` to `libzip-windows.mdproj` in
`Xamarin.Android.Tools.BootstrapTasks`.

Successful AppVeyor build [here](https://ci.appveyor.com/project/jonathanpeppers/xamarin-android/build/41), this should be the PR that gets
`msbuild Xamarin.Android.sln` working on Windows if you complete
the `make prepare` step manually.