### PR TITLE
[build] Improve Visual Studio for Mac support

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,17 +217,20 @@ is no existing git changes in the `external` folder.
 
 On the main repo, you can use `git status` to ensure a clean slate.
 
-Then, you may do one of the following:
+Next, run `make`:
 
-1. Run make:
+    make
 
-       make
+The default `make all` target will only build a *subset* of runtime ABIs
+and `$(TargetFrameworkVersion)`s. If you want a complete environment --
+*all* the ABIs, all the API levels -- then instead use:
 
-2. Load `Xamarin.Android.sln` into Xamarin Studio and Build the project.
+    make jenkins
 
-    *Note*: The `Mono.Android` project may *fail* on the first build
-    because it generates sources, and those sources won't exist on the
-    initial project load. Rebuild the project should this happen.
+Unit tests are build in a separate target:
+
+    make all-tests
+
 
 ## Linux build notes
 

--- a/build-tools/api-xml-adjuster/api-xml-adjuster.csproj
+++ b/build-tools/api-xml-adjuster/api-xml-adjuster.csproj
@@ -38,7 +38,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(JavaInteropFullPath)\src\Xamarin.Android.Tools.ApiXmlAdjuster\Xamarin.Android.Tools.ApiXmlAdjuster.csproj">
+    <ProjectReference Include="..\..\external\Java.Interop\src\Xamarin.Android.Tools.ApiXmlAdjuster\Xamarin.Android.Tools.ApiXmlAdjuster.csproj">
       <Project>{1268EADF-8344-431C-81F6-FCB7CBC99F49}</Project>
       <Name>Xamarin.Android.Tools.ApiXmlAdjuster</Name>
     </ProjectReference>

--- a/build-tools/remap-assembly-ref/remap-assembly-ref.csproj
+++ b/build-tools/remap-assembly-ref/remap-assembly-ref.csproj
@@ -29,7 +29,7 @@
   <Import Project="..\..\Configuration.props" />
   <ItemGroup>
     <Reference Include="System" />
-    <ProjectReference Include="$(JavaInteropFullPath)\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.csproj">
+    <ProjectReference Include="..\..\external\Java.Interop\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.csproj">
       <Project>{15945D4B-FF56-4BCC-B598-2718D199DD08}</Project>
       <Name>Xamarin.Android.Cecil</Name>
     </ProjectReference>  </ItemGroup>

--- a/src/Mono.Android.Export/Mono.Android.Export.csproj
+++ b/src/Mono.Android.Export/Mono.Android.Export.csproj
@@ -4,6 +4,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{B8105878-D423-4159-A3E7-028298281EC6}</ProjectGuid>
+    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>Mono.Android.Export</RootNamespace>
     <AssemblyName>Mono.Android.Export</AssemblyName>

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -4,6 +4,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{66CF299A-CE95-4131-BCD8-DB66E30C4BF7}</ProjectGuid>
+    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>Android</RootNamespace>
     <AssemblyName>Mono.Android</AssemblyName>
@@ -75,7 +76,7 @@
       <Private>False</Private>
     </Reference>
   </ItemGroup>
-  <Import Project="$(JavaInteropFullPath)\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems" Label="Shared" Condition="Exists('$(JavaInteropFullPath)\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems')" />
+  <Import Project="..\..\external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems" Label="Shared" Condition="Exists('..\..\external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems')" />
   <Import Project="..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems')" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
@@ -336,12 +337,12 @@
       <Name>jnienv-gen</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="$(JavaInteropFullPath)\tools\generator\generator.csproj">
+    <ProjectReference Include="..\..\external\Java.Interop\tools\generator\generator.csproj">
       <Project>{D14A1B5C-2060-4930-92BE-F7190256C735}</Project>
       <Name>generator</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="$(JavaInteropFullPath)\tools\jcw-gen\jcw-gen.csproj">
+    <ProjectReference Include="..\..\external\Java.Interop\tools\jcw-gen\jcw-gen.csproj">
       <Project>{52C7D9B6-E8C8-47D0-9471-652D278D7D77}</Project>
       <Name>jcw-gen</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -45,7 +45,7 @@
       <Project>{2DD1EE75-6D8D-4653-A800-0A24367F7F38}</Project>
       <Name>Xamarin.ProjectTools</Name>
     </ProjectReference>
-    <ProjectReference Include="$(LibZipSharpSourceFullPath)\libZipSharp.csproj">
+    <ProjectReference Include="..\..\..\..\external\LibZipSharp\libZipSharp.csproj">
       <Project>{E248B2CA-303B-4645-ADDC-9D4459D550FD}</Project>
       <Name>libZipSharp</Name>
     </ProjectReference>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -151,7 +151,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(LibZipSharpSourceFullPath)\libZipSharp.csproj">
+    <ProjectReference Include="..\..\..\..\external\LibZipSharp\libZipSharp.csproj">
       <Project>{E248B2CA-303B-4645-ADDC-9D4459D550FD}</Project>
       <Name>libZipSharp</Name>
     </ProjectReference>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <Import Project="..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems')" />
-  <Import Project="$(JavaInteropFullPath)\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems" Label="Shared" Condition="Exists('$(JavaInteropFullPath)\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems')" />
+  <Import Project="..\..\external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems" Label="Shared" Condition="Exists('..\..\external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems')" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
@@ -423,7 +423,7 @@
     <Compile Include="..\Mono.Android\Android.Runtime\IntDefinitionAttribute.cs">
       <Link>Mono.Android\IntDefinitionAttribute.cs</Link>
     </Compile>
-    <Compile Include="$(JavaInteropFullPath)\src\utils\StringRocks.cs">
+    <Compile Include="..\..\external\Java.Interop\src\utils\StringRocks.cs">
       <Link>Utilities\StringRocks.cs</Link>
     </Compile>
     <Compile Include="$(LinkerSourceFullPath)\tuner\Mono.Tuner\FilterAttributes.cs">
@@ -573,15 +573,15 @@
       <Project>{D27AD8F7-7710-40BE-B03B-55EFBEC13C44}</Project>
       <Name>Xamarin.Android.Tools.Aidl</Name>
     </ProjectReference>
-    <ProjectReference Include="$(JavaInteropFullPath)\src\Java.Interop.Tools.Diagnostics\Java.Interop.Tools.Diagnostics.csproj">
+    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Tools.Diagnostics\Java.Interop.Tools.Diagnostics.csproj">
       <Project>{64CC4E44-CE3A-4319-BF3F-6CF8BD513870}</Project>
       <Name>Java.Interop.Tools.Diagnostics</Name>
     </ProjectReference>
-    <ProjectReference Include="$(JavaInteropFullPath)\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil.csproj">
+    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil.csproj">
       <Project>{D48EE8D0-0A0A-4493-AEF5-DAF5F8CF86AD}</Project>
       <Name>Java.Interop.Tools.Cecil</Name>
     </ProjectReference>
-    <ProjectReference Include="$(JavaInteropFullPath)\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers.csproj">
+    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers.csproj">
       <Project>{D18FCF91-8876-48A0-A693-2DC1E7D3D80A}</Project>
       <Name>Java.Interop.Tools.JavaCallableWrappers</Name>
     </ProjectReference>
@@ -589,7 +589,7 @@
       <Project>{91713046-C358-4647-B162-ED4E1442F3D8}</Project>
       <Name>Xamarin.Android.Build.Utilities</Name>
     </ProjectReference>
-    <ProjectReference Include="$(JavaInteropFullPath)\src\Xamarin.Android.Tools.Bytecode\Xamarin.Android.Tools.Bytecode.csproj">
+    <ProjectReference Include="..\..\external\Java.Interop\src\Xamarin.Android.Tools.Bytecode\Xamarin.Android.Tools.Bytecode.csproj">
       <Project>{B17475BC-45A2-47A3-B8FC-62F3A0959EE0}</Project>
       <Name>Xamarin.Android.Tools.Bytecode</Name>
     </ProjectReference>
@@ -621,15 +621,15 @@
       <Name>proguard</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="$(LibZipSharpSourceFullPath)\libZipSharp.csproj">
+    <ProjectReference Include="..\..\external\LibZipSharp\libZipSharp.csproj">
       <Project>{E248B2CA-303B-4645-ADDC-9D4459D550FD}</Project>
       <Name>libZipSharp</Name>
     </ProjectReference>
-    <ProjectReference Include="$(JavaInteropFullPath)\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.csproj">
+    <ProjectReference Include="..\..\external\Java.Interop\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.csproj">
       <Project>{15945D4B-FF56-4BCC-B598-2718D199DD08}</Project>
       <Name>Xamarin.Android.Cecil</Name>
     </ProjectReference>
-    <ProjectReference Include="$(JavaInteropFullPath)\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.Mdb.csproj">
+    <ProjectReference Include="..\..\external\Java.Interop\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.Mdb.csproj">
       <Project>{C0487169-8F81-497F-919E-EB42B1D0243F}</Project>
       <Name>Xamarin.Android.Cecil.Mdb</Name>
     </ProjectReference>

--- a/src/Xamarin.Android.Tools.Aidl/Xamarin.Android.Tools.Aidl.csproj
+++ b/src/Xamarin.Android.Tools.Aidl/Xamarin.Android.Tools.Aidl.csproj
@@ -49,7 +49,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(JavaInteropFullPath)\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.csproj">
+    <ProjectReference Include="..\..\external\Java.Interop\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.csproj">
       <Project>{15945D4B-FF56-4BCC-B598-2718D199DD08}</Project>
       <Name>Xamarin.Android.Cecil</Name>
     </ProjectReference>

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -53,7 +53,7 @@
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\KillProcess.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(LibZipSharpSourceFullPath)\libZipSharp.csproj">
+    <ProjectReference Include="..\..\external\LibZipSharp\libZipSharp.csproj">
       <Project>{E248B2CA-303B-4645-ADDC-9D4459D550FD}</Project>
       <Name>libZipSharp</Name>
     </ProjectReference>

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(JavaInteropFullPath)\bin\BuildDebug\JdkInfo.props" />
+  <Import Project="..\..\external\Java.Interop\bin\BuildDebug\JdkInfo.props" />
   <Import Project="monodroid.props" />
   <Import Project="monodroid.projitems" />
   <Import Project="..\..\build-tools\scripts\RequiredPrograms.targets" />


### PR DESCRIPTION
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=58994

When loading `Xamarin.Android.sln` into Visual Studio for Mac, the
Solution Panel indicates an error on the `Mono.Android` and
`Mono.Android.Export` projects:

	Project does not support framework 'MonoAndroid,v1.0'.

Fix this warning by adding `$(ProjectTypeGuids)` to
`Mono.Android.csproj` and `Mono.Android.Export.csproj`.

Additionally, some projects such as
`src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj`
*do not build* within Visual Studio for Mac, because Visual Studio for
Mac doesn't appear to support the use of MSBuild properties within
`<Import/>`s -- at least not *our* property use. Specifically, this:

	<Import
	    Project="$(JavaInteropFullPath)\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems"
	    Label="Shared"
	    Condition="Exists('$(JavaInteropFullPath)\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems')"
	/>

is *completely ignored*, which results in multiple C# compiler errors
as types which are provided by that shared project cannot be found.

Appease Visual Studio for Mac by *removing* use of such properties
within `.csproj` files, and instead hardcoding relative paths.

Unfortunately this kills the idea from commit d205cab2:

> Allow the Java.Interop checkout directory to be specified by
> overriding the `$(JavaInteropSourceDirectory)` MSBuild property.
> ...
> Normally `$(JavaInteropSourceDirectory)` wouldn't need to be
> overridden; the current use case is to allow a CI-like environment
> which grabs the latest commit of every referenced module to make sure
> they all work together. (Note: such a "CI-like environment"
> DOES NOT (yet) EXIST. This commit is to help *permit* such a thing.)

Such a "CI-like environment" still doesn't exist, and is arguably
moot/silly, as Jenkins has an option to
**Update tracking submodules to tip of branch**, which is more-or-
less what was being advocated for here.

Using e.g. `$(JavaInteropFullPath)` -- the value of which was based
off of `$(JavaInteropSourceDirectory)` -- actively prevents
Visual Studio for Mac from building projects, so remove that use.

Finally, Visual Studio for Mac is *still* unable to do a toplevel
Build, even after all of these changes: Visual Studio for Mac doesn't
like `@(ProjectReference)` items which are `Condition`al, and we have
those all over the place (for now).

The changes in this commit *improve*, but **do not** "fix",
Visual Studio for Mac use.

Just build projects individually, with Command+K. :-)