### PR TITLE
Override SDK/NDK location uncoditionally for in-tree builds

### DIFF
--- a/tools/scripts/xabuild
+++ b/tools/scripts/xabuild
@@ -96,14 +96,11 @@ fi
 export TARGETS_DIR
 export MONO_ANDROID_PATH="$prefix"
 
-
-if [ -z "$ANDROID_NDK_PATH" -a -f "$Paths_targets" ] ; then
+if [ -f "$Paths_targets" ] ; then
 	ANDROID_NDK_PATH=$($MSBUILD /nologo /v:minimal /t:GetAndroidNdkFullPath "$Paths_targets")
 	ANDROID_NDK_PATH=$(echo $ANDROID_NDK_PATH | sed 's/^\w*//g')
 	export ANDROID_NDK_PATH
-fi
 
-if [ -z "$ANDROID_SDK_PATH" -a -f "$Paths_targets" ] ; then
 	ANDROID_SDK_PATH=$($MSBUILD /nologo /v:minimal /t:GetAndroidSdkFullPath "$Paths_targets")
 	ANDROID_SDK_PATH=$(echo $ANDROID_SDK_PATH | sed 's/^\w*//g')
 	export ANDROID_SDK_PATH


### PR DESCRIPTION
In-tree XA builds should always override ANDROID_{SDK,NDK}_PATH variables because
code that handles Android SDK components installation (in build/android-toolchain)
is destructive in that it first removes the entire SDK/NDK trees and installs
everything from scratch. This has bad effects if the developer's machine has a separate
SDK/NDK tree not managed by XA build system: build removes the directories but it
requires tools that were in them and, in effect, crashes.