### PR TITLE
[windows] alternative to `make prepare`

### DIFF
--- a/Documentation/DevelopmentTips.md
+++ b/Documentation/DevelopmentTips.md
@@ -101,6 +101,21 @@ Alternatively, if you're working on an `mscorlib.dll` bug:
 	  adb push external/mono/mcs/class/lib/monodroid/mscorlib.dll \
 	    /data/data/Mono.Android_Tests/files/.__override__
 
+# Windows Build Notes
+
+Currently Windows avoids many of the macOS dependencies by downloading a zip bundle
+of binaries previously built on macOS. This speeds up the build and enables
+development on Windows, in general.
+
+A simple way to ensure you have the needed dependencies on Windows is to install
+Visual Studio 2017 (> 15.3.x) along with the Xamarin workload. This will ensure you have
+the correct version of Xamarin.Android, the Android SDK, and Java needed.
+
+It also is worth noting that opening `Xamarin.Android.sln` in Visual Studio tends
+to hold file locks on output assemblies containing MSBuild tasks. Until there is a solution
+for this, it might be more advisable to use an editor like Visual Studio Code and build via
+the command-line.
+
 # Unit Tests
 
 The `xamarin-android` repo contains several unit tests:

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ Building Xamarin.Android requires:
 * [Autotools (`autoconf`, `automake`, etc.)](#autotools)
 * [The Android SDK and NDK](#ndk)
 
-The `make prepare` build step will check that all required dependencies
-are present. If you would like `make prepare` to automatically install
+The `make prepare` build step (or `PrepareWindows.targets` on Windows) will
+check that all required dependencies are present.
+If you would like `make prepare` to automatically install
 required dependencies, set the `$(AutoProvision)` MSBuild property to True
 and (if necessary) set the `$(AutoProvisionUsesSudo)` property to True.
 (This is not supported on all operating systems.)
@@ -204,8 +205,9 @@ Overridable MSBuild properties include:
 
 # Build
 
-At this point in time, building Xamarin.Android is only supported on OS X.
-We will work to improve this.
+Xamarin.Android can be built on Linux, macOS, and Windows.
+
+## Linux and macOS
 
 To build Xamarin.Android, first prepare the project:
 
@@ -231,6 +233,16 @@ Unit tests are build in a separate target:
 
     make all-tests
 
+## Windows
+
+To build Xamarin.Android, run:
+
+    msbuild build-tools\scripts\PrepareWindows.targets
+    msbuild Xamarin.Android.sln
+
+These are roughly the same as how `make prepare` and `make` are used on other platforms.
+
+_NOTE: there is not currently an equivalent of `make jenkins` or `make all-tests` on Windows._
 
 ## Linux build notes
 
@@ -290,6 +302,9 @@ If any program is still not found, try to ensure it's linked via:
 Once the build has finished, [`tools/scripts/xabuild`](tools/scripts/xabuild)
 may be used on Unix-like platforms to build projects.
 See the [Samples](#Samples) section for example usage.
+
+Windows users will need to use the `setup-windows.exe` tool as described in
+[`Documentation/UsingJenkinsBuildArtifacts.md`](Documentation/UsingJenkinsBuildArtifacts.md#oss-xamarinandroidzip-installation).
 
 # Using Jenkins Build Artifacts
 

--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Prepare" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <_TopDir>$(MSBuildThisFileDirectory)..\..</_TopDir>
+    <_NuGet>.nuget\NuGet.exe</_NuGet>
+  </PropertyGroup>
+  <ItemGroup>
+    <_ConfigurationFile Include="Windows-Configuration.OperatingSystem.props">
+      <Destination>$(_TopDir)\Configuration.OperatingSystem.props</Destination>
+    </_ConfigurationFile>
+    <_ConfigurationFile Include="Configuration.Java.Interop.Override.props">
+      <Destination>$(_TopDir)\external\Java.Interop\Configuration.Override.props</Destination>
+    </_ConfigurationFile>
+  </ItemGroup>
+  <UsingTask AssemblyFile="$(_TopDir)\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.JdkInfo" />
+  <Target Name="Prepare">
+    <Exec Command="git submodule update --init --recursive" WorkingDirectory="$(_TopDir)" />
+    <Copy
+        SourceFiles="@(_ConfigurationFile)"
+        DestinationFiles="@(_ConfigurationFile->'%(Destination)')"
+        SkipUnchangedFiles="True"
+    />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)..\xa-prep-tasks\xa-prep-tasks.csproj" />
+    <JdkInfo
+        AndroidSdkPath="$(AndroidSdkPath)"
+        AndroidNdkPath="$(AndroidNdkPath)"
+        JavaSdkPath="$(JavaSdkDirectory)"
+        Output="$(_TopDir)\external\Java.Interop\bin\BuildDebug\JdkInfo.props"
+    />
+    <Exec Command="$(_NuGet) restore Xamarin.Android.sln" WorkingDirectory="$(_TopDir)" />
+    <Exec Command="$(_NuGet) restore external\Java.Interop\Java.Interop.sln" WorkingDirectory="$(_TopDir)" />
+    <Exec Command="$(_NuGet) restore external\LibZipSharp\libZipSharp.sln" WorkingDirectory="$(_TopDir)" />
+  </Target>
+</Project>

--- a/build-tools/scripts/Windows-Configuration.OperatingSystem.props
+++ b/build-tools/scripts/Windows-Configuration.OperatingSystem.props
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <HostOS Condition=" '$(HostOS)' == '' ">Windows</HostOS>
+    <HostOsName Condition=" '$(HostOsName)' == '' ">Windows</HostOsName>
+    <HostOsRelease Condition=" '$(HostOsRelease)' == '' ">10</HostOsRelease>
+    <HostTriplet Condition=" '$(HostTriplet)' == '' ">x86_64-win32</HostTriplet>
+    <HostTriplet32 Condition=" '$(HostTriplet32)' == '' ">i386-win32</HostTriplet32>
+    <HostTriplet64 Condition=" '$(HostTriplet64)' == '' ">x86_64-win32</HostTriplet64>
+    <HostCpuCount Condition=" '$(HostCpuCount)' == '' ">$([System.Environment]::ProcessorCount)</HostCpuCount>
+    <HostBits Condition=" '$(HostBits)' == '' ">64</HostBits>
+  </PropertyGroup>
+</Project>

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/JdkInfo.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/JdkInfo.cs
@@ -1,0 +1,96 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xamarin.Android.Build.Utilities;
+
+namespace Xamarin.Android.BuildTools.PrepTasks
+{
+	public class JdkInfo : Task
+	{
+		[Required]
+		public ITaskItem Output { get; set; }
+
+		public string AndroidNdkPath { get; set; }
+
+		public string AndroidSdkPath { get; set; }
+
+		public string JavaSdkPath { get; set; }
+
+		public override bool Execute ()
+		{
+			Log.LogMessage (MessageImportance.Low, $"Task {nameof (JdkInfo)}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (Output)}: {Output}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (AndroidNdkPath)}: {AndroidNdkPath}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (AndroidSdkPath)}: {AndroidSdkPath}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (JavaSdkPath)}: {JavaSdkPath}");
+
+			AndroidLogger.Error += ErrorHandler;
+			AndroidLogger.Warning += WarningHandler;
+			AndroidLogger.Info += InfoHandler;
+			try {
+				AndroidSdk.Refresh (AndroidSdkPath, AndroidNdkPath, JavaSdkPath);
+
+				var javaSdkPath = AndroidSdk.JavaSdkPath;
+				if (string.IsNullOrEmpty(javaSdkPath)) {
+					Log.LogError ("JavaSdkPath is blank");
+					return false;
+				}
+
+				Log.LogMessage (MessageImportance.Low, $"  {nameof (AndroidSdk.JavaSdkPath)}: {javaSdkPath}");
+
+				var jvmPath = Path.Combine (javaSdkPath, "jre", "bin", "server", "jvm.dll");
+				if (!File.Exists (jvmPath)) {
+					Log.LogError ($"JdkJvmPath not found at {jvmPath}");
+					return false;
+				}
+
+				var javaIncludePath = Path.Combine (javaSdkPath, "include");
+				var includes = new List<string> { javaIncludePath };
+				includes.AddRange (Directory.GetDirectories (javaIncludePath)); //Include dirs such as "win32"
+
+				var includeXmlTags = new StringBuilder ();
+				foreach (var include in includes) {
+					includeXmlTags.AppendLine ($"<JdkIncludePath Include=\"{include}\" />");
+				}
+
+				Directory.CreateDirectory (Path.GetDirectoryName (Output.ItemSpec));
+				File.WriteAllText (Output.ItemSpec, $@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <Choose>
+    <When Condition="" '$(JdkJvmPath)' == '' "">
+      <PropertyGroup>
+        <JdkJvmPath>{jvmPath}</JdkJvmPath>
+      </PropertyGroup>
+      <ItemGroup>
+        {includeXmlTags}
+      </ItemGroup>
+    </When>
+  </Choose>
+</Project>");
+
+				return !Log.HasLoggedErrors;
+			}
+			finally {
+				AndroidLogger.Error -= ErrorHandler;
+				AndroidLogger.Warning -= WarningHandler;
+				AndroidLogger.Info -= InfoHandler;
+			}
+		}
+
+		private void ErrorHandler (string task, string message)
+		{
+			Log.LogError ($"{task}: {message}");
+		}
+
+		private void WarningHandler (string task, string message)
+		{
+			Log.LogWarning ($"{task}: {message}");
+		}
+
+		private void InfoHandler (string task, string message)
+		{
+			Log.LogMessage (MessageImportance.Low, $"{task}: {message}");
+		}
+	}
+}

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
@@ -43,6 +43,7 @@
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\GitCommitHash.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\GitCommitTime.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\HashFileContents.cs" />
+    <Compile Include="Xamarin.Android.BuildTools.PrepTasks\JdkInfo.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\PathToolTask.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\SystemUnzip.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\Which.cs" />
@@ -53,6 +54,12 @@
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\AcceptAndroidSdkLicenses.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\Sleep.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\ProcessLogcatTiming.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Xamarin.Android.Build.Utilities\Xamarin.Android.Build.Utilities.csproj">
+      <Project>{91713046-c358-4647-b162-ed4e1442f3d8}</Project>
+      <Name>Xamarin.Android.Build.Utilities</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="xa-prep-tasks.targets" />


### PR DESCRIPTION
On Windows you can now run `msbuild
build-tools\scripts\PrepareWindows.targets` to do the following:

- git submodule update --init --recursive
- download `.nuget/NuGet.exe`
- setup the required `.props` files for your system
  - This includes a new `JdkInfo` MSBuild task
- nuget restore

Also:
- updated README

[AppVeyor](https://ci.appveyor.com/project/jonathanpeppers/xamarin-android/build/49) can successfully build with two commands:
```
msbuild build-tools\scripts\PrepareWindows.targets
msbuild Xamarin.Android.sln
```