### PR TITLE
[Xamarin.Android.Build.Tasks] Implement a Managed Resource Parser for DesignTime Builds on Windows.

### DIFF
--- a/Documentation/build_process.md
+++ b/Documentation/build_process.md
@@ -587,6 +587,12 @@ when packaing Release applications.
 
     Added in Xamarin.Android 7.2.
 
+-  **AndroidUseManagedDesignTimeResourceGenerator** &ndash; A boolean property which
+   will switch over the design time builds to use the managed resource parser rather
+   than `aapt`.
+
+    Added in Xamarin.Android 7.3. 
+
 ## Binding Project Build Properties
 
 The following MSBuild properties are used with

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -73,7 +73,7 @@ using System.Runtime.CompilerServices;
 					new BuildItem.ProjectReference (@"..\Lib1\Lib1.csproj", lib.ProjectName, lib.ProjectGuid),
 				},
 			};
-			proj.SetProperty ("_AndroidUseManagedDesignTimeResourceGenerator", "False");
+			proj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", "False");
 			using (var l = CreateDllBuilder (Path.Combine (path, lib.ProjectName), false, false)) {
 				using (var b = CreateApkBuilder (Path.Combine (path, proj.ProjectName), false, false)) {
 					l.Verbosity = LoggerVerbosity.Diagnostic;
@@ -430,7 +430,7 @@ namespace UnnamedProject
 				IsRelease = isRelease,
 			};
 			proj.SetProperty ("AndroidUseIntermediateDesignerFile", "True");
-			proj.SetProperty ("_AndroidUseManagedDesignTimeResourceGenerator", "False");
+			proj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", "False");
 			using (var b = CreateApkBuilder ("temp/CheckOldResourceDesignerIsNotUsed")) {
 				var designer = Path.Combine ("Resources", "Resource.designer" + proj.Language.DefaultDesignerExtension);
 				if (File.Exists (designer))
@@ -948,7 +948,7 @@ namespace Lib1 {
 				IsRelease = true,
 				ProjectName = "App1",
 			};
-			appProj.SetProperty ("_AndroidUseManagedDesignTimeResourceGenerator", "True");
+			appProj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", "True");
 			using (var appBuilder = CreateApkBuilder (Path.Combine (path, appProj.ProjectName))) {
 				appBuilder.Verbosity = LoggerVerbosity.Diagnostic;
 				appBuilder.Target = "Compile";
@@ -996,7 +996,7 @@ namespace Lib1 {
 					theme,
 				},
 			};
-			libProj.SetProperty ("_AndroidUseManagedDesignTimeResourceGenerator", "True");
+			libProj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", "True");
 			var appProj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 				ProjectName = "App1",
@@ -1013,7 +1013,7 @@ namespace Lib1 {
 					KnownPackages.SupportV7AppCompat_25_4_0_1,
 				},
 			};
-			appProj.SetProperty ("_AndroidUseManagedDesignTimeResourceGenerator", "True");
+			appProj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", "True");
 			using (var libBuilder = CreateDllBuilder (Path.Combine (path, libProj.ProjectName), false, false)) {
 				libBuilder.Verbosity = LoggerVerbosity.Diagnostic;
 				using (var appBuilder = CreateApkBuilder (Path.Combine (path, appProj.ProjectName), false, false)) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1760,6 +1760,7 @@ public class Test
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 			};
+			proj.SetProperty ("_AndroidUseManagedDesignTimeResourceGenerator", "False");
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name), false ,false)) {
 				builder.Verbosity = LoggerVerbosity.Diagnostic;
 				builder.Target = "UpdateAndroidResources";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1760,7 +1760,7 @@ public class Test
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 			};
-			proj.SetProperty ("_AndroidUseManagedDesignTimeResourceGenerator", "False");
+			proj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", "False");
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name), false ,false)) {
 				builder.Verbosity = LoggerVerbosity.Diagnostic;
 				builder.Target = "UpdateAndroidResources";

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -4,17 +4,17 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Xml.Linq;
+using System.Xml;
 
 namespace Xamarin.Android.Tasks
 {
 	class ManagedResourceParser : ResourceParser
 	{
 		CodeTypeDeclaration resources;
-		CodeTypeDeclaration layout, ids, drawable, strings, colors, dimension, raw, animation, attrib, boolean, ints, styleable, style;
+		CodeTypeDeclaration layout, ids, drawable, strings, colors, dimension, raw, animation, attrib, boolean, ints, styleable, style, arrays;
 		Dictionary<string, string> map;
 
-		void SortMembers(CodeTypeDeclaration decl)
+		void SortMembers (CodeTypeDeclaration decl)
 		{
 			CodeTypeMember [] members = new CodeTypeMember [decl.Members.Count];
 			decl.Members.CopyTo (members, 0);
@@ -31,6 +31,7 @@ namespace Xamarin.Android.Tasks
 			map = resourceMap ?? new Dictionary<string, string> ();
 			resources = CreateResourceClass ();
 			animation = CreateClass ("Animation");
+			arrays = CreateClass ("Array");
 			attrib = CreateClass ("Attribute");
 			boolean = CreateClass ("Boolean");
 			layout = CreateClass ("Layout");
@@ -60,6 +61,7 @@ namespace Xamarin.Android.Tasks
 			SortMembers (animation);
 			SortMembers (ids);
 			SortMembers (attrib);
+			SortMembers (arrays);
 			SortMembers (boolean);
 			SortMembers (colors);
 			SortMembers (dimension);
@@ -74,6 +76,8 @@ namespace Xamarin.Android.Tasks
 
 			if (animation.Members.Count > 1)
 				resources.Members.Add (animation);
+			if (arrays.Members.Count > 1)
+				resources.Members.Add (arrays);
 			if (attrib.Members.Count > 1)
 				resources.Members.Add (attrib);
 			if (boolean.Members.Count > 1)
@@ -112,14 +116,14 @@ namespace Xamarin.Android.Tasks
 			var path = Directory.GetParent (file).Name;
 			var ext = Path.GetExtension (file);
 			switch (ext) {
-				case ".xml":
-				case ".axml":
-					if (string.Compare (path, "raw", StringComparison.OrdinalIgnoreCase) == 0)
-						goto default;
-					ProcessXmlFile (file);
-					break;
-				default:
-					break;
+			case ".xml":
+			case ".axml":
+				if (string.Compare (path, "raw", StringComparison.OrdinalIgnoreCase) == 0)
+					goto default;
+				ProcessXmlFile (file);
+				break;
+			default:
+				break;
 			}
 			CreateResourceField (path, fileName);
 		}
@@ -143,7 +147,7 @@ namespace Xamarin.Android.Tasks
 
 		CodeTypeDeclaration CreateClass (string type)
 		{
-			var t = new CodeTypeDeclaration (JavaResourceParser.GetNestedTypeName (type)) {
+			var t = new CodeTypeDeclaration (ResourceParser.GetNestedTypeName (type)) {
 				IsPartial = true,
 				TypeAttributes = TypeAttributes.Public,
 			};
@@ -172,8 +176,8 @@ namespace Xamarin.Android.Tasks
 				Attributes = MemberAttributes.Static | MemberAttributes.Public,
 				InitExpression = new CodePrimitiveExpression (0),
 				Comments = {
-					new CodeCommentStatement ("aapt resource value: 0"),
-				},
+						new CodeCommentStatement ("aapt resource value: 0"),
+					},
 			};
 			parentType.Members.Add (f);
 		}
@@ -183,7 +187,7 @@ namespace Xamarin.Android.Tasks
 			string mappedName = GetResourceName (parentType.Name, name, map);
 			if (parentType.Members.OfType<CodeTypeMember> ().Any (x => string.Compare (x.Name, mappedName, StringComparison.OrdinalIgnoreCase) == 0))
 				return;
-			var f = new CodeMemberField (typeof (int[]), name) {
+			var f = new CodeMemberField (typeof (int []), name) {
 				// pity I can't make the member readonly...
 				Attributes = MemberAttributes.Public | MemberAttributes.Static,
 			};
@@ -191,20 +195,20 @@ namespace Xamarin.Android.Tasks
 			if (c == null) {
 				f.InitExpression = c = new CodeArrayCreateExpression (typeof (int []));
 			}
-			for (int i = 0; i < count;i++)
+			for (int i = 0; i < count; i++)
 				c.Initializers.Add (new CodePrimitiveExpression (0));
-			
+
 			parentType.Members.Add (f);
 		}
 
 		HashSet<string> resourceNamesToUseDirectly = new HashSet<string> () {
-			"integer-array",
-			"string-array",
-			"declare-styleable",
-			"add-resource",
-		};
+				"integer-array",
+				"string-array",
+				"declare-styleable",
+				"add-resource",
+			};
 
-		void CreateResourceField (string root, string fieldName, XElement element = null)
+		void CreateResourceField (string root, string fieldName, XmlReader element = null)
 		{
 			var i = root.IndexOf ('-');
 			var item = i < 0 ? root : root.Substring (0, i);
@@ -243,65 +247,98 @@ namespace Xamarin.Android.Tasks
 				break;
 			case "enum":
 			case "flag":
+			case "id":
 				CreateIntField (ids, fieldName);
 				break;
-			case "configVarying":
 			case "integer-array":
 			case "string-array":
+				CreateIntField (arrays, fieldName);
+				break;
+			case "configVarying":
 			case "add-resource":
 			case "declare-styleable":
 				ProcessStyleable (element);
 				break;
 			case "style":
-				// special case Style 
-				//ProcessStyle (element);
 				CreateIntField (style, fieldName.Replace (".", "_"));
 				break;
 			default:
-				//Log.LogDebugMessage ($"default {root} => {fieldName}");
 				break;
 			}
 		}
 
-		void ProcessStyleable (XElement element)
+		void ProcessStyleable (XmlReader reader)
 		{
-			var topName = element.Attribute ("name").Value;
-			var items = element.Descendants ().Where (x => x.Name.LocalName == "attr");
-			CreateIntArrayField (styleable, topName, items.Count ());
-			foreach (var item in items) {
-				if (item.Name.LocalName == "attr") {
-					CreateIntField (styleable, $"{topName}_{item.Attribute ("name").Value.Replace (":", "_")}");
+			string topName = null;
+			int fieldCount = 0;
+			while (reader.Read ()) {
+				if (reader.NodeType == XmlNodeType.Whitespace || reader.NodeType == XmlNodeType.Comment)
+					continue;
+				string name = null;
+				if (string.IsNullOrEmpty (topName)) {
+					if (reader.HasAttributes) {
+						while (reader.MoveToNextAttribute ()) {
+							if (reader.Name.Replace ("android:", "") == "name")
+								topName = reader.Value;
+						}
+					}
+				}
+				if (!reader.IsStartElement () || reader.LocalName == "declare-styleable")
+					continue;
+				if (reader.HasAttributes) {
+					while (reader.MoveToNextAttribute ()) {
+						if (reader.Name.Replace ("android:", "") == "name")
+							name = reader.Value;
+					}
+				}
+				reader.MoveToElement ();
+				if (reader.LocalName == "attr") {
+					CreateIntField (styleable, $"{topName}_{name.Replace (":", "_")}");
+					if (!name.StartsWith ("android:", StringComparison.OrdinalIgnoreCase))
+						CreateIntField (attrib, name);
+					fieldCount++;
+				} else {
+					if (name != null)
+						CreateIntField (ids, $"{name.Replace (":", "_")}");
 				}
 			}
+			CreateIntArrayField (styleable, topName, fieldCount);
 		}
 
-		void ProcessXmlFile (string file) {
-			var doc = XDocument.Load (file);
-			var ns = XNamespace.Get ("http://schemas.android.com/apk/res/android");
-			var nameAttributes = doc.Descendants ().Attributes (ns + "name")
-					.Concat (doc.Descendants ().Attributes ("name"));
-			foreach (var attr in nameAttributes) {
-				// skip android: prefixed items
-				if (attr.Value.Contains ("android:"))
-					continue;
-				if (attr.Parent.Name.LocalName == "item") {
-					if (attr.Parent.Attribute ("type") != null)
-						CreateResourceField (attr.Parent.Attribute ("type").Value, attr.Name.LocalName, attr.Parent);
-					else {
-						var f = attr.Parent.Parent.Name;
-						Log.LogDebugMessage ($"Item {attr.Name} {attr.Value} {attr.Parent.Attribute ("type")?.Value ?? "noval"} {f}");
+		void ProcessXmlFile (string file)
+		{
+			using (var reader = XmlReader.Create (file)) {
+				while (reader.Read ()) {
+					if (reader.NodeType == XmlNodeType.Whitespace || reader.NodeType == XmlNodeType.Comment)
+						continue;
+					if (reader.IsStartElement ()) {
+						var elementName = reader.Name;
+						if (reader.HasAttributes) {
+							string name = null;
+							string type = null;
+							string id = null;
+							while (reader.MoveToNextAttribute ()) {
+								if (reader.LocalName == "name")
+									name = reader.Value;
+								if (reader.LocalName == "type")
+									type = reader.Value;
+								if (reader.LocalName == "id")
+									id = reader.Value.Replace ("@+id/", "").Replace ("@id/", ""); ;
+							}
+							if (name?.Contains ("android:") ?? false)
+								continue;
+							if (id?.Contains ("android:") ?? false)
+								continue;
+							// Move the reader back to the element node.
+							reader.MoveToElement ();
+							if (!string.IsNullOrEmpty (name))
+								CreateResourceField (type ?? elementName, name, reader.ReadSubtree ());
+							if (!string.IsNullOrEmpty (id)) {
+								CreateIntField (ids, id);
+							}
+						}
 					}
-				} else
-					CreateResourceField (attr.Parent.Name.LocalName, attr.Value, attr.Parent);
-			}
-			var attrs = doc.Descendants ().Attributes (ns + "id")
-					.Concat (doc.Descendants ().Attributes ("id"));
-			foreach (var attr in attrs) {
-				var name = attr.Value.Replace ("@+id/", "").Replace ("@id/", "");
-				// skip android prefixed items
-				if (attr.Value.Contains ("android:"))
-					continue;
-				CreateIntField (ids, name);
+				}
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -1,0 +1,308 @@
+﻿using System;
+using System.CodeDom;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+
+namespace Xamarin.Android.Tasks
+{
+	class ManagedResourceParser : ResourceParser
+	{
+		CodeTypeDeclaration resources;
+		CodeTypeDeclaration layout, ids, drawable, strings, colors, dimension, raw, animation, attrib, boolean, ints, styleable, style;
+		Dictionary<string, string> map;
+
+		void SortMembers(CodeTypeDeclaration decl)
+		{
+			CodeTypeMember [] members = new CodeTypeMember [decl.Members.Count];
+			decl.Members.CopyTo (members, 0);
+			decl.Members.Clear ();
+			Array.Sort (members, (x, y) => string.Compare (x.Name, y.Name, StringComparison.OrdinalIgnoreCase));
+			decl.Members.AddRange (members);
+		}
+
+		public CodeTypeDeclaration Parse (string resourceDirectory, IEnumerable<string> additionalResourceDirectories, bool isApp, Dictionary<string, string> resourceMap)
+		{
+			if (!Directory.Exists (resourceDirectory))
+				throw new ArgumentException ("Specified resource directory was not found: " + resourceDirectory);
+
+			map = resourceMap ?? new Dictionary<string, string> ();
+			resources = CreateResourceClass ();
+			animation = CreateClass ("Animation");
+			attrib = CreateClass ("Attribute");
+			boolean = CreateClass ("Boolean");
+			layout = CreateClass ("Layout");
+			ids = CreateClass ("Id");
+			ints = CreateClass ("Integer");
+			drawable = CreateClass ("Drawable");
+			strings = CreateClass ("String");
+			colors = CreateClass ("Color");
+			dimension = CreateClass ("Dimension");
+			raw = CreateClass ("Raw");
+			styleable = CreateClass ("Styleable");
+			style = CreateClass ("Style");
+
+			foreach (var dir in Directory.GetDirectories (resourceDirectory, "*", SearchOption.TopDirectoryOnly)) {
+				foreach (var file in Directory.GetFiles (dir, "*.*", SearchOption.AllDirectories)) {
+					ProcessResourceFile (file);
+				}
+			}
+			if (additionalResourceDirectories != null) {
+				foreach (var dir in additionalResourceDirectories) {
+					foreach (var file in Directory.GetFiles (dir, "*.*", SearchOption.AllDirectories)) {
+						ProcessResourceFile (file);
+					}
+				}
+			}
+
+			SortMembers (animation);
+			SortMembers (ids);
+			SortMembers (attrib);
+			SortMembers (boolean);
+			SortMembers (colors);
+			SortMembers (dimension);
+			SortMembers (drawable);
+			SortMembers (ints);
+			SortMembers (layout);
+			SortMembers (raw);
+			SortMembers (strings);
+			SortMembers (style);
+			SortMembers (styleable);
+
+
+			if (animation.Members.Count > 1)
+				resources.Members.Add (animation);
+			if (attrib.Members.Count > 1)
+				resources.Members.Add (attrib);
+			if (boolean.Members.Count > 1)
+				resources.Members.Add (boolean);
+			if (colors.Members.Count > 1)
+				resources.Members.Add (colors);
+			if (dimension.Members.Count > 1)
+				resources.Members.Add (dimension);
+			if (drawable.Members.Count > 1)
+				resources.Members.Add (drawable);
+			if (ids.Members.Count > 1)
+				resources.Members.Add (ids);
+			if (ints.Members.Count > 1)
+				resources.Members.Add (ints);
+			if (layout.Members.Count > 1)
+				resources.Members.Add (layout);
+			if (raw.Members.Count > 1)
+				resources.Members.Add (raw);
+			if (strings.Members.Count > 1)
+				resources.Members.Add (strings);
+			if (style.Members.Count > 1)
+				resources.Members.Add (style);
+			if (styleable.Members.Count > 1)
+				resources.Members.Add (styleable);
+
+			return resources;
+		}
+
+		void ProcessResourceFile (string file)
+		{
+			var fileName = Path.GetFileNameWithoutExtension (file);
+			if (string.IsNullOrEmpty (fileName))
+				return;
+			if (fileName.EndsWith (".9", StringComparison.OrdinalIgnoreCase))
+				fileName = Path.GetFileNameWithoutExtension (fileName);
+			var path = Directory.GetParent (file).Name;
+			var ext = Path.GetExtension (file);
+			switch (ext) {
+				case ".xml":
+				case ".axml":
+					if (string.Compare (path, "raw", StringComparison.OrdinalIgnoreCase) == 0)
+						goto default;
+					ProcessXmlFile (file);
+					break;
+				default:
+					break;
+			}
+			CreateResourceField (path, fileName);
+		}
+
+		CodeTypeDeclaration CreateResourceClass ()
+		{
+			var decl = new CodeTypeDeclaration ("Resource") {
+				IsPartial = true,
+			};
+			var asm = Assembly.GetExecutingAssembly ().GetName ();
+			var codeAttrDecl =
+				new CodeAttributeDeclaration ("System.CodeDom.Compiler.GeneratedCodeAttribute",
+					new CodeAttributeArgument (
+						new CodePrimitiveExpression (asm.Name)),
+					new CodeAttributeArgument (
+						new CodePrimitiveExpression (asm.Version.ToString ()))
+				);
+			decl.CustomAttributes.Add (codeAttrDecl);
+			return decl;
+		}
+
+		CodeTypeDeclaration CreateClass (string type)
+		{
+			var t = new CodeTypeDeclaration (JavaResourceParser.GetNestedTypeName (type)) {
+				IsPartial = true,
+				TypeAttributes = TypeAttributes.Public,
+			};
+			t.Members.Add (new CodeConstructor () {
+				Attributes = MemberAttributes.Private,
+			});
+			return t;
+		}
+
+		void CreateField (CodeTypeDeclaration parentType, string name, Type type)
+		{
+			var f = new CodeMemberField (type, name) {
+				// pity I can't make the member readonly...
+				Attributes = MemberAttributes.Public | MemberAttributes.Static,
+			};
+			parentType.Members.Add (f);
+		}
+
+		void CreateIntField (CodeTypeDeclaration parentType, string name)
+		{
+			string mappedName = GetResourceName (parentType.Name, name, map);
+			if (parentType.Members.OfType<CodeTypeMember> ().Any (x => string.Compare (x.Name, mappedName, StringComparison.OrdinalIgnoreCase) == 0))
+				return;
+			var f = new CodeMemberField (typeof (int), mappedName) {
+				// pity I can't make the member readonly...
+				Attributes = MemberAttributes.Static | MemberAttributes.Public,
+				InitExpression = new CodePrimitiveExpression (0),
+				Comments = {
+					new CodeCommentStatement ("aapt resource value: 0"),
+				},
+			};
+			parentType.Members.Add (f);
+		}
+
+		void CreateIntArrayField (CodeTypeDeclaration parentType, string name, int count)
+		{
+			string mappedName = GetResourceName (parentType.Name, name, map);
+			if (parentType.Members.OfType<CodeTypeMember> ().Any (x => string.Compare (x.Name, mappedName, StringComparison.OrdinalIgnoreCase) == 0))
+				return;
+			var f = new CodeMemberField (typeof (int[]), name) {
+				// pity I can't make the member readonly...
+				Attributes = MemberAttributes.Public | MemberAttributes.Static,
+			};
+			CodeArrayCreateExpression c = (CodeArrayCreateExpression)f.InitExpression;
+			if (c == null) {
+				f.InitExpression = c = new CodeArrayCreateExpression (typeof (int []));
+			}
+			for (int i = 0; i < count;i++)
+				c.Initializers.Add (new CodePrimitiveExpression (0));
+			
+			parentType.Members.Add (f);
+		}
+
+		HashSet<string> itemSubTypes = new HashSet<string> () {
+			"integer-array",
+			"string-array",
+			"declare-styleable",
+			"add-resource",
+		};
+
+		void CreateResourceField (string root, string fieldName, XElement element = null)
+		{
+			var i = root.IndexOf ('-');
+			var item = i < 0 ? root : root.Substring (0, i);
+			item = itemSubTypes.Contains (root) ? root : item;
+			switch (item.ToLower ()) {
+			case "bool":
+				CreateIntField (boolean, fieldName);
+				break;
+			case "color":
+				CreateIntField (colors, fieldName);
+				break;
+			case "drawable":
+				CreateIntField (drawable, fieldName);
+				break;
+			case "dimen":
+			case "fraction":
+				CreateIntField (dimension, fieldName);
+				break;
+			case "integer":
+				CreateIntField (ints, fieldName);
+				break;
+			case "anim":
+				CreateIntField (animation, fieldName);
+				break;
+			case "attr":
+				CreateIntField (attrib, fieldName);
+				break;
+			case "layout":
+				CreateIntField (layout, fieldName);
+				break;
+			case "raw":
+				CreateIntField (raw, fieldName);
+				break;
+			case "string":
+				CreateIntField (strings, fieldName);
+				break;
+			case "enum":
+			case "flag":
+				CreateIntField (ids, fieldName);
+				break;
+			case "configVarying":
+			case "integer-array":
+			case "string-array":
+			case "add-resource":
+			case "declare-styleable":
+				ProcessStyleable (element);
+				break;
+			case "style":
+				// special case Style 
+				//ProcessStyle (element);
+				CreateIntField (style, fieldName.Replace (".", "_"));
+				break;
+			default:
+				//Log.LogDebugMessage ($"default {root} => {fieldName}");
+				break;
+			}
+		}
+
+		void ProcessStyleable (XElement element)
+		{
+			var topName = element.Attribute ("name").Value;
+			var items = element.Descendants ().Where (x => x.Name.LocalName == "attr");
+			CreateIntArrayField (styleable, topName, items.Count ());
+			foreach (var item in items) {
+				if (item.Name.LocalName == "attr") {
+					CreateIntField (styleable, $"{topName}_{item.Attribute ("name").Value.Replace (":", "_")}");
+				}
+			}
+		}
+
+		void ProcessXmlFile (string file) {
+			var doc = XDocument.Load (file);
+			var ns = XNamespace.Get ("http://schemas.android.com/apk/res/android");
+			var nameAttributes = doc.Descendants ().Attributes (ns + "name")
+					.Concat (doc.Descendants ().Attributes ("name"));
+			foreach (var attr in nameAttributes) {
+				// skip android: prefixed items
+				if (attr.Value.Contains ("android:"))
+					continue;
+				if (attr.Parent.Name.LocalName == "item") {
+					if (attr.Parent.Attribute ("type") != null)
+						CreateResourceField (attr.Parent.Attribute ("type").Value, attr.Name.LocalName, attr.Parent);
+					else {
+						var f = attr.Parent.Parent.Name;
+						Log.LogDebugMessage ($"Item {attr.Name} {attr.Value} {attr.Parent.Attribute ("type")?.Value ?? "noval"} {f}");
+					}
+				} else
+					CreateResourceField (attr.Parent.Name.LocalName, attr.Value, attr.Parent);
+			}
+			var attrs = doc.Descendants ().Attributes (ns + "id")
+					.Concat (doc.Descendants ().Attributes ("id"));
+			foreach (var attr in attrs) {
+				var name = attr.Value.Replace ("@+id/", "").Replace ("@id/", "");
+				// skip android prefixed items
+				if (attr.Value.Contains ("android:"))
+					continue;
+				CreateIntField (ids, name);
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -197,7 +197,7 @@ namespace Xamarin.Android.Tasks
 			parentType.Members.Add (f);
 		}
 
-		HashSet<string> itemSubTypes = new HashSet<string> () {
+		HashSet<string> resourceNamesToUseDirectly = new HashSet<string> () {
 			"integer-array",
 			"string-array",
 			"declare-styleable",
@@ -208,7 +208,7 @@ namespace Xamarin.Android.Tasks
 		{
 			var i = root.IndexOf ('-');
 			var item = i < 0 ? root : root.Substring (0, i);
-			item = itemSubTypes.Contains (root) ? root : item;
+			item = resourceNamesToUseDirectly.Contains (root) ? root : item;
 			switch (item.ToLower ()) {
 			case "bool":
 				CreateIntField (boolean, fieldName);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ResourceParser.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.CodeDom;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Tasks
+{
+	class ResourceParser
+	{
+		public TaskLoggingHelper Log { get; set; }
+
+		internal int ToInt32 (string value, int @base)
+		{
+			try {
+				return Convert.ToInt32 (value, @base);
+			} catch (Exception e) {
+				throw new NotSupportedException (
+						string.Format ("Could not convert value '{0}' (base '{1}') into an Int32.",
+							value, @base),
+						e);
+			}
+		}
+
+		internal static string GetNestedTypeName (string name)
+		{
+			switch (name) {
+				case "anim": return "Animation";
+				case "attr": return "Attribute";
+				case "bool": return "Boolean";
+				case "dimen": return "Dimension";
+				default: return char.ToUpperInvariant (name[0]) + name.Substring (1);
+			}
+		}
+
+		internal string GetResourceName (string type, string name, Dictionary<string, string> map)
+		{
+			string mappedValue;
+			string key = string.Format ("{0}{1}{2}", type, Path.DirectorySeparatorChar, name).ToLowerInvariant ();
+
+			if (map.TryGetValue (key, out mappedValue)) {
+				Log.LogDebugMessage ("  - Remapping resource: {0}.{1} -> {2}", type, name, mappedValue);
+				return mappedValue.Substring (mappedValue.LastIndexOf (Path.DirectorySeparatorChar) + 1);
+			}
+
+			Log.LogDebugMessage ("  - Not remapping resource: {0}.{1}", type, name);
+
+			return name;
+		}
+
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -102,6 +102,8 @@
     <Compile Include="Mono.Android\GrantUriPermissionAttribute.Partial.cs" />
     <Compile Include="Utilities\InvalidActivityNameException.cs" />
     <Compile Include="Utilities\JavaResourceParser.cs" />
+    <Compile Include="Utilities\ResourceParser.cs" />
+    <Compile Include="Utilities\ManagedResourceParser.cs" />
     <Compile Include="Utilities\ManifestDocumentElement.cs" />
     <Compile Include="Utilities\ManifestDocument.cs" />
     <Compile Include="Mono.Android\MetaDataAttribute.Partial.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -993,6 +993,9 @@ because xbuild doesn't support framework reference assemblies.
 	<_AndroidResourceDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' != 'True' ">$(AndroidResgenFile)</_AndroidResourceDesignerFile>
 	<_AndroidStaticResourcesFlag>$(IntermediateOutputPath)static.flag</_AndroidStaticResourcesFlag>
 	<_AndroidResourcesCacheFile>$(IntermediateOutputPath)mergeresources.cache</_AndroidResourcesCacheFile>
+	<_AndroidUseManagedDesignTimeResourceGenerator Condition=" '$(_AndroidUseManagedDesignTimeResourceGenerator)' == '' " >True</_AndroidUseManagedDesignTimeResourceGenerator>
+	<_AndroidDesignTimeResDirIntermediate>$(IntermediateOutputPath)designtime\</_AndroidDesignTimeResDirIntermediate>
+	<_AndroidManagedResourceDesignerFile>$(_AndroidDesignTimeResDirIntermediate)$(_AndroidResourceDesigner)</_AndroidManagedResourceDesignerFile>
 </PropertyGroup>
 
 <ItemGroup>
@@ -1036,11 +1039,60 @@ because xbuild doesn't support framework reference assemblies.
 		Overwrite="true"/>
 </Target>
 
+<Choose>
+	<When Condition=" $(_AndroidUseManagedDesignTimeResourceGenerator) == 'True' And '$(DesignTimeBuild)' == 'True' And '$(BuildingInsideVisualStudio)' == 'True' ">
+		<PropertyGroup>
+			<ManagedDesignTimeBuild>True</ManagedDesignTimeBuild>
+		</PropertyGroup>
+	</When>
+	<Otherwise>
+		<PropertyGroup>
+			<ManagedDesignTimeBuild>False</ManagedDesignTimeBuild>
+		</PropertyGroup>
+	</Otherwise>
+</Choose>
+
+<!-- Managed DesignTime Resource Generation -->
+<Target Name="_ManagedUpdateAndroidResgen" Condition=" '$(ManagedDesignTimeBuild)' == 'True' "
+		Inputs="@(AndroidResource);@(ReferencePath)"
+		Outputs="$(_AndroidManagedResourceDesignerFile)"
+		DependsOnTargets="_ExtractLibraryProjectImports">
+	<MakeDir Directories="$(_AndroidDesignTimeResDirIntermediate)" />
+	<!-- Parse primary R.java and create Resources.Designer.cs -->
+	<GenerateResourceDesigner
+		ContinueOnError="$(DesignTimeBuild)"
+		NetResgenOutputFile="$(_AndroidManagedResourceDesignerFile)"
+		JavaResgenInputFile="$(_GeneratedPrimaryJavaResgenFile)"
+		Namespace="$(AndroidResgenNamespace)"
+		ProjectDir="$(ProjectDir)"
+		Resources="@(AndroidResource)"
+		ResourceDirectory="$(MonoAndroidResourcePrefix)"
+		AdditionalResourceDirectories="@(LibraryResourceDirectories)"
+		IsApplication="$(AndroidApplication)"
+		References="@(ReferencePath)"
+		UseManagedResourceGenerator="True"
+	/>
+	<ItemGroup>
+		<CorrectCasedItem Include="%(Compile.Identity)" Condition="'%(Compile.Identity)' == '$(AndroidResgenFile)'"/>
+		<CorrectCasedItem Include="%(Compile.Identity)" Condition="'%(Compile.Identity)' == 'Resources\Resource.designer.cs'"/>
+		<Compile Remove="@(CorrectCasedItem)" Condition=" '$(ManagedDesignTimeBuild)' == 'True' And '%(CorrectCasedItem.Identity)' != '' "/>
+		<Compile Include="$(_AndroidManagedResourceDesignerFile)" Condition=" '$(ManagedDesignTimeBuild)' == 'True' And Exists ('$(_AndroidManagedResourceDesignerFile)')" />
+	</ItemGroup>
+	<WriteLinesToFile
+		Condition="Exists ('$(_AndroidManagedResourceDesignerFile)')"
+		File="$(IntermediateOutputPath)$(CleanFile)"
+		Lines="$(_AndroidManagedResourceDesignerFile)"
+		Overwrite="false" />
+</Target>
+	
 <!-- Resource Build -->
 
-<Target Name="UpdateAndroidResources"
-	DependsOnTargets="$(CoreResolveReferencesDependsOn);_CreatePropertiesCache;_CheckForDeletedResourceFile;_ComputeAndroidResourcePaths;_UpdateAndroidResgen;_AddLibraryProjectsEmbeddedResourceToProject;_GenerateJavaDesignerForComponent" />
+<Target Name="_UpdateAndroidResources" Condition=" '$(ManagedDesignTimeBuild)' == 'False' "
+	DependsOnTargets="$(CoreResolveReferencesDependsOn);_CreatePropertiesCache;_CheckForDeletedResourceFile;_ComputeAndroidResourcePaths;_UpdateAndroidResgen;_AddLibraryProjectsEmbeddedResourceToProject;_GenerateJavaDesignerForComponent"> 
+</Target>
 
+<Target Name="UpdateAndroidResources" DependsOnTargets="_ManagedUpdateAndroidResgen;_UpdateAndroidResources" />
+		
 <!-- Handle a case where the designer file has been deleted, but the flag file still exists -->
 <Target Name="_CheckForDeletedResourceFile">
 	<Delete Files="$(_AndroidResgenFlagFile)"
@@ -1348,6 +1400,7 @@ because xbuild doesn't support framework reference assemblies.
 		AdditionalResourceDirectories="@(LibraryResourceDirectories)"
 		IsApplication="$(AndroidApplication)"
 		References="@(ReferencePath)"
+		UseManagedResourceGenerator="False"
 	/>
 
 	<!-- Only copy if the file contents changed, so users only get Reload? dialog for real changes -->
@@ -2473,6 +2526,7 @@ because xbuild doesn't support framework reference assemblies.
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)proguard" Condition="Exists ('$(MonoAndroidIntermediate)proguard')" />
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediateResourceCache)" Condition="Exists ('$(MonoAndroidIntermediateResourceCache)')" />
 	<RemoveDirFixed Directories="$(_AndroidAotBinDirectory)" Condition="Exists ('$(_AndroidAotBinDirectory)')" />
+	<RemoveDirFixed Directories="$(_AndroidDesignTimeResDirIntermediate)" Condition="Exists ('$(_AndroidDesignTimeResDirIntermediate)')" />
 	<Delete Files="$(IntermediateOutputPath)_dex_stamp" />
  	<Delete Files="$(MonoAndroidIntermediate)R.cs.flag" />
 	<Delete Files="$(MonoAndroidIntermediate)acw-map.txt" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -993,7 +993,7 @@ because xbuild doesn't support framework reference assemblies.
 	<_AndroidResourceDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' != 'True' ">$(AndroidResgenFile)</_AndroidResourceDesignerFile>
 	<_AndroidStaticResourcesFlag>$(IntermediateOutputPath)static.flag</_AndroidStaticResourcesFlag>
 	<_AndroidResourcesCacheFile>$(IntermediateOutputPath)mergeresources.cache</_AndroidResourcesCacheFile>
-	<_AndroidUseManagedDesignTimeResourceGenerator Condition=" '$(_AndroidUseManagedDesignTimeResourceGenerator)' == '' " >True</_AndroidUseManagedDesignTimeResourceGenerator>
+	<AndroidUseManagedDesignTimeResourceGenerator Condition=" '$(AndroidUseManagedDesignTimeResourceGenerator)' == '' " >True</AndroidUseManagedDesignTimeResourceGenerator>
 	<_AndroidDesignTimeResDirIntermediate>$(IntermediateOutputPath)designtime\</_AndroidDesignTimeResDirIntermediate>
 	<_AndroidManagedResourceDesignerFile>$(_AndroidDesignTimeResDirIntermediate)$(_AndroidResourceDesigner)</_AndroidManagedResourceDesignerFile>
 </PropertyGroup>
@@ -1040,7 +1040,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Choose>
-	<When Condition=" $(_AndroidUseManagedDesignTimeResourceGenerator) == 'True' And '$(DesignTimeBuild)' == 'True' And '$(BuildingInsideVisualStudio)' == 'True' ">
+	<When Condition=" $(AndroidUseManagedDesignTimeResourceGenerator) == 'True' And '$(DesignTimeBuild)' == 'True' And '$(BuildingInsideVisualStudio)' == 'True' ">
 		<PropertyGroup>
 			<ManagedDesignTimeBuild>True</ManagedDesignTimeBuild>
 		</PropertyGroup>


### PR DESCRIPTION
One of our (many) problems in the DesignTime build is the amount of
time we need to spend in `aapt`. Our current Resource Designer
generator process is as follows.

1) Copy all the resources into one folder.
2) Correct the Casing on those resources so they are lowercase
   while maintaining a map of the changes we made.
3) Call `aapt` to generate a `R.java` file which contains all the
   Id's for the required resources.
4) Parse the `R.java` file and create a C# Code Dom to represent
   the Resource.Designer.cs. Note we also need to convert the lowercased
   resource back into the case from the app so the C# code will match
   what the user typed in.
5) Finally write out the `Resource.Designer.cs`

So we do a TON of stuff there.

For a design time build we don't really need to do all of that stuff.
Firstly because its a design time build (not a real one) we don't
care about what the values of the ids are. We just need to have a
good `Resource.Designer.cs` class. We also don't need to convert the
casing back and forth. We can just use the casing the user defines
because that is what we normally end up with anyway.
We don't need to generate a `R.java` as we can operate on the
projects `Resources` folder directly.