### PR TITLE
Ensure a GREF is used to cache a Java class reference

### DIFF
--- a/src/monodroid/jni/monodroid-networkinfo.c
+++ b/src/monodroid/jni/monodroid-networkinfo.c
@@ -46,6 +46,7 @@ java_classes_init (void)
 {
 	JNIEnv *env = get_jnienv ();
 	NetworkInterface_class = (*env)->FindClass (env, "java/net/NetworkInterface");
+	NetworkInterface_class = (*env)->NewGlobalRef (env, NetworkInterface_class);
 	NetworkInterface_getByName = (*env)->GetStaticMethodID (env, NetworkInterface_class, "getByName", "(Ljava/lang/String;)Ljava/net/NetworkInterface;");
 	NetworkInterface_isUp = (*env)->GetMethodID (env, NetworkInterface_class, "isUp", "()Z");
 	NetworkInterface_supportsMulticast = (*env)->GetMethodID (env, NetworkInterface_class, "supportsMulticast", "()Z");


### PR DESCRIPTION
 Ensure a GREF is used to cache a Java class reference

When caching a reference to a Java class one must ensure that the
reference is a global one or it will be invalidated on transition
to the Java runtime. JNI/FindClass returns a local one, so we need
to explicitly call NewGlobalRef in order to prevent invalidation.

Fix reading messages from netlink socket on some emulators. Previously, the
buffer we used was sometimes too small and messages were truncated and
interpreted incorrectly. Buffer now is dynamically allocated and its size equals
the host CPU's page size. This is enough to read the messages we care about.

Fix faulty test which didn't take into account link scope for IPv6 addresses.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=59045