### PR TITLE
[Xamarin.Android.Build.Tasks] Insert newlines between types

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
@@ -107,7 +107,7 @@ namespace Xamarin.Android.Tasks
 			var exceptionMatch = ExceptionRegEx.Match (singleLine);
 
 			if (writeOutputToKeepFile && !match.Success && !exceptionMatch.Success)
-				File.AppendAllText (MultiDexMainDexListFile, singleLine);
+				File.AppendAllText (MultiDexMainDexListFile, singleLine + "\n");
 			base.LogEventsFromTextOutput (singleLine, messageImportance);
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -354,6 +354,9 @@ printf ""%d"" x
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				Assert.IsTrue (File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android/bin/classes.dex")),
 					"multidex-ed classes.zip exists");
+				var multidexKeepPath  = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "multidex.keep");
+				Assert.IsTrue (File.Exists (multidexKeepPath), "multidex.keep exists");
+				Assert.IsTrue (File.ReadAllLines (multidexKeepPath).Length > 1, "multidex.keep must contain more than one line.");
 				Assert.IsTrue (b.LastBuildOutput.Contains (Path.Combine (proj.TargetFrameworkVersion, "mono.android.jar")), proj.TargetFrameworkVersion + "/mono.android.jar should be used.");
 			}
 		}


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=59036

When building a project with `$(AndroidEnableMultiDex)`=True, an
`obj/$(Configuration)/multidex.keep` file is generated, which is a
list of Java classes, one per line, which should be placed into the
"main" `.dex` file for the application.

Unfortunately, commit 6829b7d1 results in a `multidex.keep` file which
places all types onto a single line, instead of one class per line.
This results in *breaking* multidex, as when this happens, nothing
ensures that the required types are in the main `.dex` file, which
could prevent the app from launching on the target device.

Fix the `<CreateMultiDexMainDexClassList/>` task by always appending a
newline after every type which should be preserved.