### PR TITLE
Add MSBuild notes for Windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Unit tests are build in a separate target:
 
 ## Windows
 
-To build Xamarin.Android, run:
+To build Xamarin.Android, ensure you are using MSBuild version 15+ and run:
 
     msbuild build-tools\scripts\PrepareWindows.targets
     msbuild Xamarin.Android.sln
@@ -243,6 +243,8 @@ To build Xamarin.Android, run:
 These are roughly the same as how `make prepare` and `make` are used on other platforms.
 
 _NOTE: there is not currently an equivalent of `make jenkins` or `make all-tests` on Windows._
+
+_Troubleshooting: Ensure you check your MSBuild version(`msbuild -version`) and path for the proper verson of MSBuild._
 
 ## Linux build notes
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ These are roughly the same as how `make prepare` and `make` are used on other pl
 
 _NOTE: there is not currently an equivalent of `make jenkins` or `make all-tests` on Windows._
 
-_Troubleshooting: Ensure you check your MSBuild version(`msbuild -version`) and path for the proper verson of MSBuild._
+_Troubleshooting: Ensure you check your MSBuild version(`msbuild -version`) and path for the proper version of MSBuild._
 
 ## Linux build notes
 


### PR DESCRIPTION
This PR is inspired by the known issue of finding a compatible MSBuild given that VS 2017 has SxS support and additionally installs various versions of MSBuild (such as MSBuild 15 and MSBuild 4 depending on payloads installed). People may try to build using an incompatible MSBuild version that lacks proper C# feature support.

https://twitter.com/KirillOsenkov/status/901128280069230592