### PR TITLE
[msbuild] Prepare for d8 (new dex compiler)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileToDalvik.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileToDalvik.cs
@@ -20,6 +20,8 @@ namespace Xamarin.Android.Tasks
 
 		public string DxJarPath { get; set; }
 
+		public string DxExtraArguments { get; set; }
+
 		public string JavaToolPath { get; set; }
 
 		[Required]
@@ -59,6 +61,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  ToolExe: {0}",  ToolExe);
 			Log.LogDebugMessage ("  ToolPath: {0}", ToolPath);
 			Log.LogDebugMessage ("  UseDx: {0}", UseDx);
+			Log.LogDebugMessage ("  DxExtraArguments: {0}", DxExtraArguments);
 			Log.LogDebugMessage ("  MultiDexEnabled: {0}", MultiDexEnabled);
 			Log.LogDebugMessage ("  MultiDexMainDexListFile: {0}", MultiDexMainDexListFile);
 			Log.LogDebugTaskItems ("  JavaLibrariesToCompile:", JavaLibrariesToCompile);
@@ -97,23 +100,23 @@ namespace Xamarin.Android.Tasks
 				cmd.AppendSwitchIfNotNull("-Xmx", JavaMaximumHeapSize);
 
 				cmd.AppendSwitchIfNotNull ("-jar ", Path.Combine (DxJarPath));
-				cmd.AppendSwitch ("--no-strict");
 			}
 
-			cmd.AppendSwitch ("--dex");
+			cmd.AppendSwitch (DxExtraArguments);
 
 			if (MultiDexEnabled) {
 				cmd.AppendSwitch ("--multi-dex");
 				cmd.AppendSwitchIfNotNull ("--main-dex-list=", MultiDexMainDexListFile);
 			}
-			cmd.AppendSwitchIfNotNull ("--output=", Path.GetDirectoryName (ClassesOutputDirectory));
+			cmd.AppendSwitchIfNotNull ("--output ", Path.GetDirectoryName (ClassesOutputDirectory));
 
 
 			// .jar files
 			if (File.Exists (OptionalObfuscatedJarFile))
 				cmd.AppendFileNameIfNotNull (OptionalObfuscatedJarFile);
 			else {
-				cmd.AppendFileNameIfNotNull (ClassesOutputDirectory);
+				foreach (var cls in Directory.GetFiles (ClassesOutputDirectory, "*.class", SearchOption.AllDirectories))
+					cmd.AppendFileNameIfNotNull (cls);
 				foreach (var jar in JavaLibrariesToCompile)
 					cmd.AppendFileNameIfNotNull (jar.ItemSpec);
 			}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -789,6 +789,13 @@ because xbuild doesn't support framework reference assemblies.
 				Condition="'$(DxJarPath)' == ''"
 		/>
 	</CreateProperty>
+
+	<CreateProperty Value="--dex --no-strict">
+		<Output TaskParameter="Value" PropertyName="DxExtraArguments"
+			Condition="'$(DxExtraArguments)' == ''"
+		/>
+	</CreateProperty>
+
 	<CreateProperty Value="$(AndroidSdkBuildToolsPath)\">
 		<Output TaskParameter="Value" PropertyName="DxToolPath"
 				Condition="'$(UseDx)' == 'True' And '$(DxToolPath)' == ''"
@@ -2029,6 +2036,7 @@ because xbuild doesn't support framework reference assemblies.
   <!-- Compile java code to dalvik -->
   <CompileToDalvik 
     DxJarPath="$(DxJarPath)"
+    DxExtraArguments="$(DxExtraArguments)"
     JavaToolPath="$(JavaToolPath)"
     JavaMaximumHeapSize="$(JavaMaximumHeapSize)"
     JavaOptions="$(JavaOptions)"


### PR DESCRIPTION
You can get d8 compiler sources from https://r8.googlesource.com/

d8 expects slightly different set of command line arguments. There is no
--no-strict nor --dex arguments, and --output= is not accepted.
Classes must be explicitly specified (no assumption on "directory == classes").

With all these changes, I could build apk with this command line:

    DxJarPath=/path/to/d8.jar DxExtraArguments="--debug" msbuild MyProject.csproj /t:SignAndroidPackage

With this change, anyone can offer custom NuGet package for d8 compiler
with its own custom MSBuild targets that specifies DxJarPath and
DxExtraArguments (just like what we could do for facebook proguard).