### PR TITLE
[Xamarin.Android.Build.Tasks] AOT+LLVM needs minSdkVersion

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2159,6 +2159,7 @@ because xbuild doesn't support framework reference assemblies.
 	AndroidAotMode="$(AndroidAotMode)"
 	AndroidNdkDirectory="$(_AndroidNdkDirectory)"
 	AndroidApiLevel="$(_AndroidApiLevel)"
+	ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
 	SupportedAbis="$(_BuildTargetAbis)"
 	AndroidSequencePointsMode="$(_SequencePointsMode)"
 	AotAdditionalArguments="$(AndroidAotAdditionalArguments)"


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=58029

Scenario: Build a project with:

  * `$(Configuration)`=Release
  * `$(AotAssemblies)`=True
  * `$(EnableLLVM)`=True
  * `$(TargetFrameworkVersion)`=v7.1 (API-25)
  * `//uses-sdk/@android:minSdkVersion`=22 (in `AndroidManifest.xml`)
  * with Android NDK r12b or later

Actual results: the app runs, but the AOT'd images aren't used:

	AOT: image 'Xamarin.Android.Support.v7.AppCompat.dll.so' not found: dlopen failed: cannot locate symbol "__aeabi_memset" referenced by "/data/app/com.companyname.App1-1/lib/arm/libaot-Xamarin.Android.Support.v7.AppCompat.dll.so"...

The `__aeabi_memset` symbol can't be found, preventing e.g.
`Xamarin.Android.Support.v7.AppCompat.dll.so` from being used. Meaning
the app pays the build overhead and size penalty of AOT+LLVM, but
doesn't get anything out of it; only the JIT is used.

The [cause of the missing `__aeabi_memset` symbol][0] is that we're
using the NDK paths which corresponds with `$(TargetFrameworkVersion)`,
*not* the NDK paths which correspond with
`//uses-sdk/@android:minSdkVersion`. Because of this, if you use the
`.apk` on a platform which is >= `minSdkVersion` but less than
`$(TargetFrameworkVersion)`, the AOT images won't be used.

[0]: https://github.com/android-ndk/ndk/issues/126

Fix this by updating the `<Aot/>` task to instead use the
`//uses-sdk/@android:minSdkVersion` value, as determined by the
`<GenerateJavaStubs/>` task. This ensures that we use NDK paths which
correspond to the app's minimum supported API level, which should
allow the AOT images to be loaded on downlevel devices.