### PR TITLE
[Xamarin.Andriod.Build.Tasks] Pulling in native libraries from incorrect supported architectures

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -534,7 +534,7 @@ namespace Xamarin.Android.Tasks
 						var data = ressozip.GetResourceData ();
 						using (var ms = new MemoryStream (data)) {
 							using (var zip = ZipArchive.Open (ms)) {
-								foreach (var e in zip.Where (x => abis.Any (a => x.FullName.Contains (a)))) {
+								foreach (var e in zip.Where (x => abis.Any (a => x.FullName.Contains ($"/{a}/")))) {
 									if (e.IsDirectory)
 										continue;
 									var key = e.FullName.Replace ("native_library_imports", "lib");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -158,5 +158,28 @@ namespace Xamarin.Android.Build.Tests
 				}
 			}
 		}
+
+		[Test]
+		public void CheckIncludedNativeLibraries ()
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+			};
+            proj.Packages.Add(KnownPackages.SQLitePCLRaw_Core);
+            proj.SetProperty(proj.ReleaseProperties, KnownProperties.AndroidSupportedAbis, "armeabi;x86");
+            using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
+                b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
+				b.ThrowOnBuildFailure = false;
+				Assert.IsTrue (b.Build (proj), "build failed");
+				var apk = Path.Combine (Root, b.ProjectDirectory,
+						proj.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
+				using (var zip = ZipHelper.OpenZip (apk)) {
+                    var libFiles = zip.Where (x => x.FullName.StartsWith("lib"));
+                    var abiPaths = new string[] { "lib/armeabi/", "lib/x86/" };
+                    foreach (var file in libFiles)
+                        Assert.IsTrue(abiPaths.Any (x => file.FullName.Contains (x)), $"Apk contains an unnesscary lib file: {file.FullName}");
+				}
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -166,7 +166,7 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = true,
 			};
             proj.Packages.Add(KnownPackages.SQLitePCLRaw_Core);
-            proj.SetProperty(proj.ReleaseProperties, KnownProperties.AndroidSupportedAbis, "armeabi;x86");
+            proj.SetProperty(proj.ReleaseProperties, KnownProperties.AndroidSupportedAbis, "x86");
             using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
                 b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
 				b.ThrowOnBuildFailure = false;
@@ -174,8 +174,8 @@ namespace Xamarin.Android.Build.Tests
 				var apk = Path.Combine (Root, b.ProjectDirectory,
 						proj.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
 				using (var zip = ZipHelper.OpenZip (apk)) {
-                    var libFiles = zip.Where (x => x.FullName.StartsWith("lib"));
-                    var abiPaths = new string[] { "lib/armeabi/", "lib/x86/" };
+                    var libFiles = zip.Where (x => x.FullName.StartsWith("lib/") && !x.FullName.Equals("lib/", StringComparison.InvariantCultureIgnoreCase));
+                    var abiPaths = new string[] { "lib/x86/" };
                     foreach (var file in libFiles)
                         Assert.IsTrue(abiPaths.Any (x => file.FullName.Contains (x)), $"Apk contains an unnesscary lib file: {file.FullName}");
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -322,6 +322,16 @@ namespace Xamarin.ProjectTools
 				},
 			}
 		};
+        public static Package SQLitePCLRaw_Core = new Package {
+            Id = "SQLitePCLRaw.core",
+            Version = "1.1.8",
+            TargetFramework = "monoandroid71",
+            References = {
+                new BuildItem.Reference("SQLitePCL") {
+                    MetadataValues = "HintPath=..\\packages\\SQLitePCLRaw.core.1.1.8\\lib\\MonoAndroid\\SQLitePCLRaw.core.dll"
+                }
+            }
+        };
 	}
 }
 


### PR DESCRIPTION
If building only for x86 or armeabi, x86_64 and armeabi-v7a native libaries are still pulled in when building the APK because the names are being checked using 'contains'.  This causes issues when deploying to x86_64 device, but only building for x86 because android will start the VM for x86_64 and get a runtime error because it will be missing the libmonodroid.so.

See bug https://bugzilla.xamarin.com/show_bug.cgi?id=47607
Test project: https://github.com/nwestfall/XamarinMultidexTest