### PR TITLE
[windows] changes for System.EnterpriseServices to load in VS

### DIFF
--- a/src/System.EnterpriseServices/System.EnterpriseServices.csproj
+++ b/src/System.EnterpriseServices/System.EnterpriseServices.csproj
@@ -3,13 +3,16 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{2868FC32-A4E7-4008-87C8-2C7879CACB58}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>System.EnterpriseServices</RootNamespace>
     <AssemblyName>System.EnterpriseServices</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
+    <NoStdLib>true</NoStdLib>
+    <AndroidApplication>false</AndroidApplication>
+    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <Import Project="..\..\build-tools\scripts\MonoAndroidFramework.props" />
@@ -41,7 +44,7 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(OutputPath)\..\..\..\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <ItemGroup>
     <ProjectReference Include="..\Mono.Android\Mono.Android.csproj">
       <Project>{66CF299A-CE95-4131-BCD8-DB66E30C4BF7}</Project>


### PR DESCRIPTION
When opening Xamarin.Android.sln in Visual Studio 2017, you are
presented with a dialog box saying `.NETFramework,v8.0` is not
installed.

The fix is to setup the System.EnterpriseServices project like OpenTK's
csproj: make it an Android Library project with the appropriate `ProjectTypeGuids`
and import `Xamarin.Android.CSharp.targets`. These changes allow VS to load
the project.