### PR TITLE
[Xamarin.Android.Build.Tasks] GenerateJavaStubs Rebuilds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -97,6 +97,15 @@ namespace Xamarin.Android.Tasks
 					Log.LogMessage (e.ToString ());
 			}
 
+			if (Log.HasLoggedErrors) {
+				// Ensure that on a rebuild, we don't *skip* the `_GenerateJavaStubs` target,
+				// by ensuring that the target outputs have been deleted.
+				Files.DeleteFile (MergedAndroidManifestOutput, Log);
+				Files.DeleteFile (AcwMapFile, Log);
+				Files.DeleteFile (Path.Combine (OutputDirectory, "typemap.jm"), Log);
+				Files.DeleteFile (Path.Combine (OutputDirectory, "typemap.mj"), Log);
+			}
+
 			return !Log.HasLoggedErrors;
 		}
 


### PR DESCRIPTION
Commit 9d131af4 introduced a [unit test failure][m573] on
xamarin-android/master:

[m573]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/573/

	Xamarin.Android.Build.Tests.BuildTest.XA4212
	Expected: String containing "warning XA4"
	 But was: <log file contents...>

Aside: The XA4212 test creates a project with a bad `IJavaObject`
type, builds the project -- which triggers an XA4212 error, which *is*
observed in the unit test -- then *rebuilds* the project, but this
time with `$(AndroidErrorOnCustomJavaObject)`=False.

The intention is that the second build should instead elicit an XA4212
*warning*, but otherwise continue just fine.

What's interesting about the log file contents is that it shows that
the `<GenerateJavaStubs/>` task isn't executed *at all*, but it's the
`<GenerateJavaStubs/>` task which is supposed to emit the warning!

	Skipping target "_GenerateJavaStubs" because its outputs are up-to-date.

Update the `<GenerateJavaStubs/>` task so that if it errors out, it
*removes* any `<GenerateJavaStubs/>` output files. This will ensure
that on subsequent builds, the `_GenerateJavaStubs` target won't be
inadvertently skipped.

(This issue *should* have been caught during the
[**macOS+xbuild PR builder** build for PR #797][pr1491]. It *wasn't*,
because the `Xamarin.Android.Build.Tests` tests weren't reported. For
example, PR #1491 ran 869 tests, while PR #1492 ran 1085! I'm not sure
what can be done to better detect and prevent this in the future.)

[pr1491]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-pr-builder/1491/