### PR TITLE
[jdk] Don't require `javac`/`jar` in $PATH

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -9,7 +9,7 @@
   />
   <Import
       Project="$(MSBuildThisFileDirectory)Configuration.OperatingSystem.props"
-      Condition=" '$(DoNotLoadOSProperties)' != 'True' "
+      Condition=" Exists('$(MSBuildThisFileDirectory)Configuration.OperatingSystem.props') And '$(DoNotLoadOSProperties)' != 'True' "
   />
   <PropertyGroup>
     <ProductVersion>8.0.99</ProductVersion>
@@ -48,6 +48,7 @@
     <AndroidSdkDirectory>$(AndroidToolchainDirectory)\sdk</AndroidSdkDirectory>
     <AndroidNdkDirectory>$(AndroidToolchainDirectory)\ndk</AndroidNdkDirectory>
     <AntDirectory>$(AndroidToolchainDirectory)\ant</AntDirectory>
+    <AntToolPath>$(AntDirectory)\bin</AntToolPath>
     <AndroidSupportedHostJitAbis Condition=" '$(AndroidSupportedHostJitAbis)' == '' ">$(HostOS)</AndroidSupportedHostJitAbis>
     <AndroidSupportedTargetJitAbis Condition=" '$(AndroidSupportedTargetJitAbis)' == '' ">armeabi-v7a:x86</AndroidSupportedTargetJitAbis>
     <JavaInteropSourceDirectory Condition=" '$(JavaInteropSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\Java.Interop</JavaInteropSourceDirectory>

--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -128,7 +128,7 @@
     <_AndroidMxeOutput Include="@(_AndroidMxeToolchain->'$(AndroidMxeFullPath)\%(Identity)\lib\libz.a')" />
   </ItemGroup>
   <Target Name="_AcceptAndroidSdkLicenses">
-	<AcceptAndroidSdkLicenses AndroidSdkDirectory="$(AndroidSdkDirectory)" />
+    <AcceptAndroidSdkLicenses AndroidSdkDirectory="$(AndroidSdkDirectory)" JavaSdkDirectory="$(JavaSdkDirectory)" />
   </Target>
   <Target Name="_CreateMxeToolchains"
       DependsOnTargets="_SetMxeToolchainMakefileTimeToLastCommitTimestamp"

--- a/build-tools/dependencies/dependencies.projitems
+++ b/build-tools/dependencies/dependencies.projitems
@@ -34,10 +34,10 @@
     <RequiredProgram Include="intltoolize"          Condition=" '$(NeedMxe)' == 'true' And $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <Homebrew>intltool</Homebrew>
     </RequiredProgram>
-    <RequiredProgram Include="javac">
+    <RequiredProgram Include="$(JavaCPath)">
       <MinimumVersion>1.8</MinimumVersion>
       <CurrentVersionCommand                        Condition=" '$(HostOS)' != 'Windows' ">$(MSBuildThisFileDirectory)..\scripts\javac-version</CurrentVersionCommand>
-      <CurrentVersionCommand                        Condition=" '$(HostOS)' == 'Windows' ">javac -version 2&gt;&amp;1</CurrentVersionCommand>
+      <CurrentVersionCommand                        Condition=" '$(HostOS)' == 'Windows' ">&quot;$(JavaCPath)&quot; -version 2&gt;&amp;1</CurrentVersionCommand>
       <UbuntuInstall>$(_AptGetInstall) openjdk-8-jdk</UbuntuInstall>
     </RequiredProgram>
     <RequiredProgram Include="make"                 Condition=" '$(HostOS)' != 'Windows' " />

--- a/build-tools/scripts/JavaCallableWrappers.targets
+++ b/build-tools/scripts/JavaCallableWrappers.targets
@@ -30,15 +30,15 @@
       <_MonoAndroidJar>$(OutputPath)mono.android.jar</_MonoAndroidJar>
     </PropertyGroup>
     <Exec
-        Command="javac $(_Target) $(_D) -bootclasspath $(_AndroidJar)$(PathSeparator)&quot;$(_MonoAndroidJar)&quot; @$(IntermediateOutputPath)jcw\classes.txt"
+        Command="&quot;$(JavaCPath)&quot; $(_Target) $(_D) -bootclasspath $(_AndroidJar)$(PathSeparator)&quot;$(_MonoAndroidJar)&quot; @$(IntermediateOutputPath)jcw\classes.txt"
     />
     <Exec
         Condition="Exists('$(_MonoAndroidJar)')"
-        Command="jar uf &quot;$(_MonoAndroidJar)&quot; -C &quot;$(IntermediateOutputPath)jcw\bin&quot; ."
+        Command="&quot;$(JarPath)&quot; uf &quot;$(_MonoAndroidJar)&quot; -C &quot;$(IntermediateOutputPath)jcw\bin&quot; ."
     />
     <Exec
         Condition="!Exists('$(_MonoAndroidJar)')"
-        Command="jar cf &quot;$(_MonoAndroidJar)&quot; -C &quot;$(IntermediateOutputPath)jcw\bin&quot; ."
+        Command="&quot;$(JarPath)&quot; cf &quot;$(_MonoAndroidJar)&quot; -C &quot;$(IntermediateOutputPath)jcw\bin&quot; ."
     />
   </Target>
   <Target Name="_GenerateMonoAndroidDex16"

--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -5,28 +5,27 @@
     <_TopDir>$(MSBuildThisFileDirectory)..\..</_TopDir>
     <_NuGet>.nuget\NuGet.exe</_NuGet>
   </PropertyGroup>
-  <ItemGroup>
-    <_ConfigurationFile Include="Windows-Configuration.OperatingSystem.props">
-      <Destination>$(_TopDir)\Configuration.OperatingSystem.props</Destination>
-    </_ConfigurationFile>
-    <_ConfigurationFile Include="Configuration.Java.Interop.Override.props">
-      <Destination>$(_TopDir)\external\Java.Interop\Configuration.Override.props</Destination>
-    </_ConfigurationFile>
-  </ItemGroup>
   <UsingTask AssemblyFile="$(_TopDir)\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.JdkInfo" />
+  <UsingTask AssemblyFile="$(_TopDir)\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
   <Target Name="Prepare">
     <Exec Command="git submodule update --init --recursive" WorkingDirectory="$(_TopDir)" />
-    <Copy
-        SourceFiles="@(_ConfigurationFile)"
-        DestinationFiles="@(_ConfigurationFile->'%(Destination)')"
-        SkipUnchangedFiles="True"
-    />
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\xa-prep-tasks\xa-prep-tasks.csproj" />
     <JdkInfo
         AndroidSdkPath="$(AndroidSdkPath)"
         AndroidNdkPath="$(AndroidNdkPath)"
         JavaSdkPath="$(JavaSdkDirectory)"
-        Output="$(_TopDir)\external\Java.Interop\bin\BuildDebug\JdkInfo.props"
+        Output="$(_TopDir)\external\Java.Interop\bin\BuildDebug\JdkInfo.props">
+      <Output TaskParameter="JavaSdkDirectory" PropertyName="_JavaSdkDirectory" />
+    </JdkInfo>
+    <Copy
+        SourceFiles="Configuration.Java.Interop.Override.props"
+        DestinationFiles="$(_TopDir)\external\Java.Interop\Configuration.Override.props"
+        SkipUnchangedFiles="True"
+    />
+    <ReplaceFileContents
+        SourceFile="Windows-Configuration.OperatingSystem.props.in"
+        DestinationFile="$(_TopDir)\Configuration.OperatingSystem.props"
+        Replacements="@JAVA_HOME@=$(_JavaSdkDirectory)"
     />
     <Exec Command="$(_NuGet) restore Xamarin.Android.sln" WorkingDirectory="$(_TopDir)" />
     <Exec Command="$(_NuGet) restore external\Java.Interop\Java.Interop.sln" WorkingDirectory="$(_TopDir)" />

--- a/build-tools/scripts/Windows-Configuration.OperatingSystem.props.in
+++ b/build-tools/scripts/Windows-Configuration.OperatingSystem.props.in
@@ -9,5 +9,8 @@
     <HostTriplet64 Condition=" '$(HostTriplet64)' == '' ">x86_64-win32</HostTriplet64>
     <HostCpuCount Condition=" '$(HostCpuCount)' == '' ">$([System.Environment]::ProcessorCount)</HostCpuCount>
     <HostBits Condition=" '$(HostBits)' == '' ">64</HostBits>
+    <JavaSdkDirectory>@JAVA_HOME@</JavaSdkDirectory>
+    <JavaCPath>$(JavaSdkDirectory)\bin\javac.exe</JavaCPath>
+    <JarPath>$(JavaSdkDirectory)\bin\jar.exe</JarPath>
   </PropertyGroup>
 </Project>

--- a/build-tools/scripts/generate-os-info
+++ b/build-tools/scripts/generate-os-info
@@ -120,6 +120,8 @@ cat <<EOF > "$1"
         <HostCc64 Condition=" '\$(HostCc64)' == '' ">$HOST_CC64</HostCc64>
         <HostCxx32 Condition=" '\$(HostCxx32)' == '' ">$HOST_CXX32</HostCxx32>
         <HostCxx64 Condition=" '\$(HostCxx64)' == '' ">$HOST_CXX64</HostCxx64>
+        <JavaCPath Condition=" '\$(JavaCPath)' == '' ">javac</JavaCPath>
+        <JarPath Condition=" '\$(JarPath)' == '' ">jar</JarPath>
     </PropertyGroup>
 </Project>
 EOF

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/AcceptAndroidSdkLicenses.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/AcceptAndroidSdkLicenses.cs
@@ -11,10 +11,20 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 		[Required]
 		public string AndroidSdkDirectory { get; set; }
 
+		public string JavaSdkDirectory { get; set; }
+
 		public override bool Execute ()
 		{
+			Log.LogMessage (MessageImportance.Low, $"Task {nameof (AcceptAndroidSdkLicenses)}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (AndroidSdkDirectory)}: {AndroidSdkDirectory}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (JavaSdkDirectory)}: {JavaSdkDirectory}");
+
 			var licdir = Path.Combine (Path.Combine (AndroidSdkDirectory, "licenses"));
 			Directory.CreateDirectory (licdir);
+
+			if (!string.IsNullOrEmpty (JavaSdkDirectory)) {
+				Environment.SetEnvironmentVariable ("JAVA_HOME", JavaSdkDirectory);
+			}
 
 			string _;
 			var path = Which.GetProgramLocation ("sdkmanager", out _, new [] { Path.Combine (AndroidSdkDirectory, "tools", "bin") });

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/JdkInfo.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/JdkInfo.cs
@@ -18,6 +18,9 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 
 		public string JavaSdkPath { get; set; }
 
+		[Output]
+		public string JavaSdkDirectory { get; set; }
+
 		public override bool Execute ()
 		{
 			Log.LogMessage (MessageImportance.Low, $"Task {nameof (JdkInfo)}");
@@ -67,7 +70,14 @@ namespace Xamarin.Android.BuildTools.PrepTasks
       </ItemGroup>
     </When>
   </Choose>
+  <PropertyGroup>
+    <JavaCPath Condition="" '$(JavaCPath)' == '' "">{Path.Combine (javaSdkPath, "bin", "javac.exe")}</JavaCPath>
+    <JarPath Condition="" '$(JarPath)' == '' "">{Path.Combine (javaSdkPath, "bin", "jar.exe")}</JarPath>
+  </PropertyGroup>
 </Project>");
+
+				JavaSdkDirectory = javaSdkPath;
+				Log.LogMessage (MessageImportance.Low, $"  [Output] {nameof (JavaSdkDirectory)}: {JavaSdkDirectory}");
 
 				return !Log.HasLoggedErrors;
 			}

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/Which.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/Which.cs
@@ -31,10 +31,10 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 			var pathExt     = Environment.GetEnvironmentVariable ("PATHEXT");
 			var pathExts    = pathExt?.Split (new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
 			FileExtensions  = new string [(pathExts?.Length ?? 0) + 1];
-			FileExtensions [0] = null;
 			if (pathExts != null) {
-				Array.Copy (pathExts, 0, FileExtensions, 1, pathExts.Length);
+				Array.Copy (pathExts, 0, FileExtensions, 0, pathExts.Length);
 			}
+			FileExtensions [FileExtensions.Length - 1] = null;
 		}
 
 		public static string GetProgramLocation (string programBasename, out string filename, string[] directories = null)

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -40,6 +40,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Adb.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Android.cs" />
+    <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Ant.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\CheckAdbTarget.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\CreateAndroidEmulator.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Emulator.cs" />

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/Ant.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/Ant.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Build.Framework;
+using System;
+using Xamarin.Android.BuildTools.PrepTasks;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	public class Ant : PathToolTask
+	{
+		public string Arguments { get; set; }
+
+		public string JavaSdkDirectory { get; set; }
+
+		public string WorkingDirectory { get; set; }
+
+		protected override string ToolBaseName {
+			get { return "ant"; }
+		}
+
+		public override bool Execute ()
+		{
+			Log.LogMessage (MessageImportance.Low, $"Task {nameof (Ant)}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (Arguments)}: {Arguments}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (JavaSdkDirectory)}: {JavaSdkDirectory}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (WorkingDirectory)}: {WorkingDirectory}");
+
+			if (!string.IsNullOrEmpty (JavaSdkDirectory))
+				Environment.SetEnvironmentVariable ("JAVA_HOME", JavaSdkDirectory);
+
+			base.Execute ();
+
+			return !Log.HasLoggedErrors;
+		}
+
+		protected override string GenerateCommandLineCommands ()
+		{
+			return Arguments;
+		}
+
+		protected override string GetWorkingDirectory ()
+		{
+			return WorkingDirectory;
+		}
+	}
+}

--- a/src/proguard/proguard.targets
+++ b/src/proguard/proguard.targets
@@ -1,7 +1,10 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll"  TaskName="Xamarin.Android.Tools.BootstrapTasks.Ant" />
   <Target Name="_BuildProGuard">
-    <Exec
-        Command="$(AntDirectory)\bin\ant -verbose -f buildscripts\build.xml proguard"
+    <Ant
+        Arguments="-verbose -f buildscripts\build.xml proguard"
+        ToolPath="$(AntToolPath)"
+        JavaSdkDirectory="$(JavaSdkDirectory)"
         WorkingDirectory="$(ProGuardSourceFullPath)"
     />
     <MakeDir Directories="$(OutputPath)" />
@@ -28,8 +31,10 @@
     <Delete Files="$(OutputPath)\lib\proguard.jar" />
     <Delete Files="$(OutputPath)\bin\proguard.sh" />
     <Delete Files="$(OutputPath)\bin\proguard.bat" />
-    <Exec
-        Command="$(AntDirectory)\bin\ant -f buildscripts\build.xml clean"
+    <Ant
+        Arguments="-f buildscripts\build.xml clean"
+        ToolPath="$(AntToolPath)"
+        JavaSdkDirectory="$(JavaSdkDirectory)"
         WorkingDirectory="$(ProGuardSourceFullPath)"
     />
   </Target>

--- a/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding.targets
@@ -5,8 +5,8 @@
       Inputs="@(InputJarSource)"
       Outputs="@(InputJar)">
     <MakeDir Directories="Jars\classes" />
-    <Exec Command="&quot;$(JavaSdkDirectory)\bin\javac&quot; -source 1.5 -target 1.6 -d &quot;Jars\classes&quot; @(InputJarSource -&gt; '%(Identity)', ' ')" />
-    <Exec Command="&quot;$(JavaSdkDirectory)\bin\jar&quot; cf &quot;@(InputJar)&quot; -C &quot;Jars\classes&quot; ." />
+    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d &quot;Jars\classes&quot; @(InputJarSource -&gt; '%(Identity)', ' ')" />
+    <Exec Command="&quot;$(JarPath)&quot; cf &quot;@(InputJar)&quot; -C &quot;Jars\classes&quot; ." />
   </Target>
   <Target Name="CleanLocal">
     <RemoveDir Directories="bin;obj;Jars\classes;@(InputJar)"/>

--- a/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding.targets
@@ -5,8 +5,8 @@
       Inputs="@(InputJarSource)"
       Outputs="@(InputJar)">
     <MakeDir Directories="Jars\classes" />
-    <Exec Command="&quot;$(JavaSdkDirectory)\bin\javac&quot; -source 1.5 -target 1.6 -d &quot;Jars\classes&quot; @(InputJarSource -&gt; '%(Identity)', ' ')" />
-    <Exec Command="&quot;$(JavaSdkDirectory)\bin\jar&quot; cf &quot;@(InputJar)&quot; -C &quot;Jars\classes&quot; ." />
+    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d &quot;Jars\classes&quot; @(InputJarSource -&gt; '%(Identity)', ' ')" />
+    <Exec Command="&quot;$(JarPath)&quot; cf &quot;@(InputJar)&quot; -C &quot;Jars\classes&quot; ." />
   </Target>
   <Target Name="CleanLocal">
     <RemoveDir Directories="bin;obj;Jars\classes;@(InputJar)"/>

--- a/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/Xamarin.Android.McwGen-Tests.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/Xamarin.Android.McwGen-Tests.targets
@@ -5,11 +5,11 @@
       Inputs="@(XamarinTestJar);%(IgnoreJar.Source)"
       Outputs="@(EmbeddedJar);@(IgnoreJar)">
     <MakeDir Directories="$(OutputPath)xt-classes" />
-    <Exec Command="&quot;$(JavaSdkDirectory)\bin\javac&quot; -source 1.5 -target 1.6 -d &quot;$(OutputPath)xt-classes&quot; -cp &quot;$(AndroidSdkDirectory)\platforms\android-$(_AndroidApiLevelName)\android.jar&quot; @(XamarinTestJar -&gt; '%(Identity)', ' ')" />
-    <Exec Command="&quot;$(JavaSdkDirectory)\bin\jar&quot; cf &quot;$(OutputPath)xamarin-test.jar&quot; -C &quot;$(OutputPath)xt-classes&quot; ." />
+    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d &quot;$(OutputPath)xt-classes&quot; -cp &quot;$(AndroidSdkDirectory)\platforms\android-$(_AndroidApiLevelName)\android.jar&quot; @(XamarinTestJar -&gt; '%(Identity)', ' ')" />
+    <Exec Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)xamarin-test.jar&quot; -C &quot;$(OutputPath)xt-classes&quot; ." />
     <MakeDir Directories="@(IgnoreJar-&gt;'$(OutputPath)%(JarBaseName)')" />
-    <Exec Command="&quot;$(JavaSdkDirectory)\bin\javac&quot; -source 1.5 -target 1.6 -d @(IgnoreJar-&gt;'$(OutputPath)%(JarBaseName)') %(IgnoreJar.Source)" />
-    <Exec Command="&quot;$(JavaSdkDirectory)\bin\jar&quot; cf @(IgnoreJar-&gt;'$(OutputPath)%(JarBaseName).jar') -C @(IgnoreJar-&gt;'$(OutputPath)%(JarBaseName)') ." />
+    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d @(IgnoreJar-&gt;'$(OutputPath)%(JarBaseName)') %(IgnoreJar.Source)" />
+    <Exec Command="&quot;$(JarPath)&quot; cf @(IgnoreJar-&gt;'$(OutputPath)%(JarBaseName).jar') -C @(IgnoreJar-&gt;'$(OutputPath)%(JarBaseName)') ." />
   </Target>
   <Target Name="CleanLocal">
     <RemoveDir Directories="bin;obj;libs"/>

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib1/Xamarin.Android.BindingResolveImportLib1.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib1/Xamarin.Android.BindingResolveImportLib1.csproj
@@ -59,7 +59,7 @@
     </CleanDependsOn>
   </PropertyGroup>
   <Target Name="BuildJar" Inputs="Jars/com/xamarin/android/test/binding/resolveimport/Lib1.java" Outputs="Jars/lib1.zip">
-    <Exec Command="javac -source 1.5 -target 1.6 -d Jars -sourcepath Jars Jars/com/xamarin/android/test/binding/resolveimport/Lib1.java" />
+    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d Jars -sourcepath Jars Jars/com/xamarin/android/test/binding/resolveimport/Lib1.java" />
     <Exec WorkingDirectory="Jars" Command="zip -r lib1.jar com" />
     <MakeDir Directories="Jars/zipped;Jars/zipped/bin" />
     <Copy SourceFiles="Jars/lib1.jar;Properties/AndroidManifest.xml" DestinationFiles="Jars/zipped/bin/lib1.jar;Jars/zipped/bin/AndroidManifest.xml" />

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib2/Xamarin.Android.BindingResolveImportLib2.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib2/Xamarin.Android.BindingResolveImportLib2.csproj
@@ -77,7 +77,7 @@
     </CleanDependsOn>
   </PropertyGroup>
   <Target Name="BuildJar" Inputs="Jars/com/xamarin/android/test/binding/resolveimport/Lib2.java" Outputs="Jars/lib2.jar">
-    <Exec Command="javac -source 1.5 -target 1.6 -d Jars -sourcepath Jars Jars/com/xamarin/android/test/binding/resolveimport/Lib2.java" />
+    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d Jars -sourcepath Jars Jars/com/xamarin/android/test/binding/resolveimport/Lib2.java" />
     <Exec WorkingDirectory="Jars" Command="zip -r lib2.jar com" />
   </Target>
   <Target Name="CleanJar">

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib3/Xamarin.Android.BindingResolveImportLib3.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib3/Xamarin.Android.BindingResolveImportLib3.csproj
@@ -77,7 +77,7 @@
     </CleanDependsOn>
   </PropertyGroup>
   <Target Name="BuildJar" Inputs="Jars/com/xamarin/android/test/binding/resolveimport/Lib3.java" Outputs="Jars/lib3.zip">
-    <Exec Command="javac -source 1.5 -target 1.6 -d Jars -sourcepath Jars Jars/com/xamarin/android/test/binding/resolveimport/Lib3.java" />
+    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d Jars -sourcepath Jars Jars/com/xamarin/android/test/binding/resolveimport/Lib3.java" />
     <Exec WorkingDirectory="Jars" Command="zip -r lib3.jar com" />
     <MakeDir Directories="Jars/zipped;Jars/zipped/bin" />
     <Copy SourceFiles="Jars/lib3.jar;Properties/AndroidManifest.xml" DestinationFiles="Jars/zipped/bin/lib3.jar;Jars/zipped/bin/AndroidManifest.xml" />

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib4/Xamarin.Android.BindingResolveImportLib4.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib4/Xamarin.Android.BindingResolveImportLib4.csproj
@@ -75,7 +75,7 @@
     </CleanDependsOn>
   </PropertyGroup>
   <Target Name="BuildJar" Inputs="Jars/com/xamarin/android/test/binding/resolveimport/Lib4.java" Outputs="Jars/lib4.jar">
-    <Exec Command="javac -source 1.5 -target 1.6 -d Jars -sourcepath Jars Jars/com/xamarin/android/test/binding/resolveimport/Lib4.java" />
+    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d Jars -sourcepath Jars Jars/com/xamarin/android/test/binding/resolveimport/Lib4.java" />
     <Exec WorkingDirectory="Jars" Command="zip -r lib4.jar com" />
   </Target>
   <Target Name="CleanJar">


### PR DESCRIPTION
Windows machines do not include Java in their path by default, so it is
a better experience to not require it for the build.

Changes to make this happen:
- `JavaCPath` and `JarPath` are configured in
`Configuration.OperatingSystem.props`
- Usage of `javac` and `jar` across the repo use appropriate variables
now
- `generate-os-info` needs to set `JavaCPath` and `JarPath`
- Created a new `<Ant>` MSBuild task
- A couple places, Windows needs `JAVA_HOME` to be set, so we are doing
this via `Environment.SetEnvironmentVariable` in a couple MSBuild tasks
- `Configuration.OperatingSystem.props` is conditional, so it is
possible to build xa-prep-tasks without it
- `Which` needs to accept files without extensions last for Windows, `PATHEXT` should be empty on Unix