### PR TITLE
Added AppDomainSetup.set_ShadowCopyDirectories to preserves list

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/PreserveLists/mscorlib.xml
+++ b/src/Xamarin.Android.Build.Tasks/Linker/PreserveLists/mscorlib.xml
@@ -16,6 +16,7 @@
 
 		<type fullname="System.AppDomainSetup" preserve="fields">
 			<method name="set_ShadowCopyFiles" />
+			<method name="set_ShadowCopyDirectories" />
 		</type>
 		<type fullname="System.AppDomainUnloadedException" />
 		<type fullname="System.ApplicationException" />


### PR DESCRIPTION
Needed to fix https://bugzilla.xamarin.com/show_bug.cgi?id=59115
since monodroid_create_appdomain sets this property, expecting
it to always be there