### PR TITLE
Bump $(ProductVersion) to 8.0.0

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -12,7 +12,7 @@
       Condition=" '$(DoNotLoadOSProperties)' != 'True' "
   />
   <PropertyGroup>
-    <ProductVersion>7.4.99</ProductVersion>
+    <ProductVersion>8.0.0</ProductVersion>
     <!-- *Latest* API level binding that we support; used when building src/Xamarin.Android.Build.Tasks -->
     <AndroidLatestApiLevel Condition="'$(AndroidLatestApiLevel)' == ''">25</AndroidLatestApiLevel>
     <AndroidLatestFrameworkVersion Condition="'$(AndroidLatestFrameworkVersion)' == ''">v7.1</AndroidLatestFrameworkVersion>


### PR DESCRIPTION
We (try to) base Xamarin.Android product versions on the latest
Android versions. Android 8.0 Oreo™ [has been announced][0], and since
the xamarin-android/d15-4 branch includes an API-26/v8.0 binding, the
overall product version for d15-4 should *also* be bumped to v8.0.

[0]: https://www.android.com/versions/oreo-8-0/