### PR TITLE
[Xamarin.Android.Build.Tasks] AOT+LLVM needs minSdkVersion (#795)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -45,6 +45,9 @@ namespace Xamarin.Android.Tasks
 		public string SdkBinDirectory { get; set; }
 
 		[Required]
+		public ITaskItem ManifestFile { get; set; }
+
+		[Required]
 		public ITaskItem[] ResolvedAssemblies { get; set; }
 
 		// Which ABIs to include native libs for
@@ -168,9 +171,22 @@ namespace Xamarin.Android.Tasks
 			return true;
 		}
 
-		static int GetNdkApiLevel(string androidNdkPath, string androidApiLevel, AndroidTargetArch arch)
+		int GetNdkApiLevel(string androidNdkPath, string androidApiLevel, AndroidTargetArch arch)
 		{
-			int level = int.Parse(androidApiLevel);
+			var manifest    = AndroidAppManifest.Load (ManifestFile.ItemSpec);
+
+			int level;
+			if (manifest.MinSdkVersion.HasValue) {
+				level       = manifest.MinSdkVersion.Value;
+			}
+			else if (int.TryParse (androidApiLevel, out level)) {
+				// level already set
+			}
+			else {
+				// Probably not ideal!
+				level       = AndroidVersion.MaxApiLevel;
+			}
+
 			// Some Android API levels do not exist on the NDK level. Workaround this my mapping them to the
 			// most appropriate API level that does exist.
 			if (level == 6 || level == 7) level = 5;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2145,6 +2145,7 @@ because xbuild doesn't support framework reference assemblies.
 	AndroidNdkDirectory="$(_AndroidNdkDirectory)"
 	AndroidApiLevel="$(_AndroidApiLevel)"
 	SdkBinDirectory="$(MonoAndroidBinDirectory)"
+	ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
 	SupportedAbis="$(_BuildTargetAbis)"
 	AndroidSequencePointsMode="$(_SequencePointsMode)"
 	AotAdditionalArguments="$(AndroidAotAdditionalArguments)"


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=58029

Scenario: Build a project with:

  * `$(Configuration)`=Release
  * `$(AotAssemblies)`=True
  * `$(EnableLLVM)`=True
  * `$(TargetFrameworkVersion)`=v7.1 (API-25)
  * `//uses-sdk/@android:minSdkVersion`=10 (in `AndroidManifest.xml`)
  * with Android NDK r12b or later
  * on particular hardware devices, e.g. a Nexus 5.

Actual results: the app runs, but the AOT'd images aren't used:

	AOT: image 'Xamarin.Android.Support.v7.AppCompat.dll.so' not found: dlopen failed: cannot locate symbol "__aeabi_memset" referenced by "/data/app/com.companyname.App1-1/lib/arm/libaot-Xamarin.Android.Support.v7.AppCompat.dll.so"...

The `__aeabi_memset` symbol can't be found, preventing e.g.
`Xamarin.Android.Support.v7.AppCompat.dll.so` from being used. Meaning
the app pays the build overhead and size penalty of AOT+LLVM, but
doesn't get anything out of it; only the JIT is used.

The [cause of the missing `__aeabi_memset` symbol][0] is that we're
using the NDK paths which corresponds with `$(TargetFrameworkVersion)`,
*not* the NDK paths which correspond with
`//uses-sdk/@android:minSdkVersion`. Because of this, if you use the
`.apk` on a platform which is >= `minSdkVersion` but less than
`$(TargetFrameworkVersion)`, the AOT images won't be used.

[0]: https://github.com/android-ndk/ndk/issues/126

Fix this by updating the `<Aot/>` task to instead use the
`//uses-sdk/@android:minSdkVersion` value. This ensures that we use
NDK paths which correspond to the app's minimum supported API level,
which should allow the AOT images to be loaded on downlevel devices.