### PR TITLE
Always version the output vsix file

### DIFF
--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -87,6 +87,12 @@
       <VsixVersion>$(ProductVersion).$(XAVersionCommitCount)</VsixVersion>
     </PropertyGroup>
   </Target>
+  <Target Name="FixupTargetVsixContainer" BeforeTargets="VSIXContainerProjectOutputGroup;CreateVsixContainer" DependsOnTargets="_GetVsixPath">
+    <PropertyGroup>
+      <TargetVsixContainerName>$([System.IO.Path]::GetFileName('$(VsixPath)'))</TargetVsixContainerName>
+      <TargetVsixContainer>$(OutDir)$(TargetVsixContainerName)</TargetVsixContainer>
+    </PropertyGroup>
+  </Target>  
   <Target Name="GetIsExperimental"
       Returns="$(IsExperimental)">
   </Target>
@@ -114,11 +120,11 @@
   </Target>
   <Target Name="_CopyToBuildConfiguration"
       DependsOnTargets="_GetVsixPath"
-      Inputs="$(OutputPath)$(AssemblyName).vsix"
+      Inputs="$(TargetVsixContainer)"
       Outputs="$(VsixPath)">
     <Copy
-        SourceFiles="$(OutputPath)$(AssemblyName).vsix"
-        DestinationFiles="$(VsixPath)"
+        SourceFiles="$(TargetVsixContainer)"
+        DestinationFolder="$(_VsixDir)"
     />
     <Copy
         SourceFiles="$(OutputPath)Xamarin.Android.Sdk.json"


### PR DESCRIPTION
When the VSSDK builds the VSIX container, it generates a manifest (catalog.json) placed inside it that has the resulting
filename in it. This manifest is used in alpha pack generation (by XVS) to determine the payloads to include. This is done
by invoking the VSMAN tool (manifest generation thing) uses the contents of the catalog. If the filename inside the
catalog doesn't match the actual filename included in the alpha pack manifest, installation fails, so we need to ensure 
the filename is changed early enough in the process so that it's consistent in the embedded manifest.
