### PR TITLE
[Xamarin.Android.Build.Tests] Fix up an Error in the Designer Tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -436,7 +436,7 @@ namespace UnnamedProject
 					File.Delete (Path.Combine (Root, b.ProjectDirectory, designer));
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				var fi = new FileInfo (Path.Combine (Root, b.ProjectDirectory, designer));
-				Assert.IsFalse (fi.Length > 3,
+				Assert.IsFalse (fi.Length > new [] { 0xef, 0xbb, 0xbf, 0x0d, 0x0a }.Length,
 					"{0} should not contain anything.", designer);
 				var outputFile = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,
 					"Resource.Designer"  + proj.Language.DefaultDesignerExtension);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -435,9 +435,9 @@ namespace UnnamedProject
 				if (File.Exists (designer))
 					File.Delete (Path.Combine (Root, b.ProjectDirectory, designer));
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				Assert.IsFalse (File.Exists (Path.Combine (b.ProjectDirectory, "Resources",
-					"Resource.designer"  + proj.Language.DefaultDesignerExtension)),
-					"{0} should not exists", designer);
+				var fi = new FileInfo (Path.Combine (Root, b.ProjectDirectory, designer));
+				Assert.IsFalse (fi.Length > 3,
+					"{0} should not contain anything.", designer);
 				var outputFile = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,
 					"Resource.Designer"  + proj.Language.DefaultDesignerExtension);
 				Assert.IsTrue (File.Exists (outputFile), "Resource.Designer{1} should have been created in {0}",
@@ -467,7 +467,7 @@ namespace UnnamedProject
 				Assert.IsNotNull (designer, $"Failed to retrieve the Resource.designer.{proj.Language.DefaultDesignerExtension}");
 				designer.Deleted = true;
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				Assert.IsFalse (File.Exists (Path.Combine (b.ProjectDirectory, "Resources",
+				Assert.IsFalse (File.Exists (Path.Combine (Root, b.ProjectDirectory, "Resources",
 					"Resource.designer"  + proj.Language.DefaultDesignerExtension)),
 					"{0} should not exists", designer.Include ());
 				var outputFile = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -43,8 +43,8 @@ namespace Xamarin.ProjectTools
 			SetProperty ("AndroidManifest", "Properties\\AndroidManifest.xml");
 			SetProperty (DebugProperties, "AndroidLinkMode", "None");
 			SetProperty (ReleaseProperties, "AndroidLinkMode", "SdkOnly");
-			SetProperty (DebugProperties, "EmbedAssembliesIntoApk", "False");
-			SetProperty (ReleaseProperties, "EmbedAssembliesIntoApk", "True");
+			SetProperty (DebugProperties, "EmbedAssembliesIntoApk", "False", "'$(EmbedAssembliesIntoApk)' == ''");
+			SetProperty (ReleaseProperties, "EmbedAssembliesIntoApk", "True", "'$(EmbedAssembliesIntoApk)' == ''");
 
 			AndroidManifest = default_android_manifest;
 			LayoutMain = default_layout_main;


### PR DESCRIPTION
We made an assumption when the test was written that the
old Resource.designer.cs was going to be deleted in
projects when using `$(AndroidUseIntermediateDesignerFile)`.
The decision was changed so it would jsut be ignored.
So the existing check that is should not exist was wrong.

That said it did not fail because we did not include the `Root`
proeprty in the path so it always passed because that file
did not exist in the location we were checking.

The change to nunit3 changed that as because of the way the
working directory is set that check now failed. Because
the old incorrect path was not correct.. doh.

So a better check is to make sure that the old file is
just emtpy. We almost empty since the the project tools
write the file we end up with a Unicode marker.

We also update the XamarinAndroidApplicationProject so that
we can override the `$(EmbedAssembliesIntoApk)`. This is
required for various unit tests. The way it currently worked
was that no matter what you set.. you always got the default.
This worked for the OSS repo as we don't use the shared-runtime.
But for the monodroid stuff, we need to be able to change that
value. This was stopping the test projects doing that.