### PR TITLE
[Xamarin.Android.Build.Tasks] Preserve set_ShadowCopyDirectories (#803)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/PreserveLists/mscorlib.xml
+++ b/src/Xamarin.Android.Build.Tasks/Linker/PreserveLists/mscorlib.xml
@@ -16,6 +16,7 @@
 
 		<type fullname="System.AppDomainSetup" preserve="fields">
 			<method name="set_ShadowCopyFiles" />
+			<method name="set_ShadowCopyDirectories" />
 		</type>
 		<type fullname="System.AppDomainUnloadedException" />
 		<type fullname="System.ApplicationException" />


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=59115

`monodroid_create_appdomain()` requires that the
`AppDomainSetup.set_ShadowCopyDirectories` property exist, so that
it can be called.

Unfortunately, the linker may remove this property, which results in
a SIGSEGV if it's been removed:

	C  [libmonosgen-2.0.dylib+0x20bc9c]  mono_property_set_value+0xc
	C  [libmono-android.debug.dylib+0x154fe]  monodroid_property_set+0xbe
	C  [libmono-android.debug.dylib+0x15268]  monodroid_create_appdomain+0x248
	C  [libmono-android.debug.dylib+0xf159]  create_domain+0x149
	C  [libmono-android.debug.dylib+0xe439]  create_and_initialize_domain+0x69
	C  [libmono-android.debug.dylib+0xe89d]  Java_mono_android_Runtime_createNewContext+0x7d

Add `AppDomainSetup.set_ShadowCopyDirectories` to the linker's
preserve list, so that the Android Designer can work as intended.