### PR TITLE
[build] Fix GenerateJavaCallableWrappers dependencies

### DIFF
--- a/build-tools/scripts/JavaCallableWrappers.targets
+++ b/build-tools/scripts/JavaCallableWrappers.targets
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="GenerateJavaCallableWrappers"
       AfterTargets="$(JavaCallableWrapperAfterTargets)"
-      Inputs="$(JavaCallableWrapperAbsAssembly)"
+      Inputs="$(JavaCallableWrapperAbsAssembly);@(JavaCallableWrapperSource)"
       Outputs="$(OutputPath)mono.android.jar">
     <MakeDir Directories="$(IntermediateOutputPath)jcw;$(IntermediateOutputPath)jcw\bin" />
     <PropertyGroup>
@@ -20,7 +20,7 @@
     </ItemGroup>
     <WriteLinesToFile
         File="$(IntermediateOutputPath)jcw\classes.txt"
-        Lines="@(_CommonJavaSources);@(_JavaSources)"
+        Lines="@(JavaCallableWrapperSource);@(_JavaSources)"
         Overwrite="True"
     />
     <PropertyGroup>

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -104,7 +104,7 @@
     <JavacSourceVersion Condition=" '$(JavacSourceVersion)' == '' ">1.6</JavacSourceVersion>
   </PropertyGroup>
   <ItemGroup>
-    <_CommonJavaSources Include="java\**\*.java" />
+    <JavaCallableWrapperSource Include="java\**\*.java" />
   </ItemGroup>
   <Target Name="_GenerateFrameworkList"
       BeforeTargets="GetTargetFrameworkProperties;GetReferenceAssemblyPaths;ResolveReferences"


### PR DESCRIPTION
Commit ff28d572 updated some of the Java source code that is included
into `mono.android.jar`, which needs to be kept synchronized with the
`libmono-android*` ("libmonodroid")` native libraries.

Unfortunately, the build system didn't know about this dependency; the
`GenerateJavaCallableWrappers` target only executes when
`Mono.Android.dll` is updated, but commit ff28d572 didn't have
anything which would cause `Mono.Android.dll` to be updated.

As a result, *pre-existing build trees* that had `Mono.Android.dll`
and `mono.android.jar` files from *before* commit ff28d572, when
updated to be at ff28d572 or later, would rebuild
`src/Xamarin.Android.Build.Tasks` -- which contains
`MonoPackageManager.java` -- but would *not* rebuild
`mono.android.jar`. This would result in build-time failures when
building the unit tests:

	obj/Release/android/src/mono/MonoPackageManager.java(59,7): error :  error: incompatible types: String[] cannot be converted to String

Update the `GenerateJavaCallableWrappers` target to include
`@(JavaCallableWrapperSource)` as an input dependency, and update
`Mono.Android.targets` to include `src/Mono.Android/java/**` into
`@(JavaCallableWrapperSource)`. This will ensure that the next time
the Mono.Android-related Java sources are updated, we properly rebuild
`mono.android.jar`.