### PR TITLE
[setup-windows] fix for VS 2017 and MSBuild 15+

### DIFF
--- a/Documentation/UsingJenkinsBuildArtifacts.md
+++ b/Documentation/UsingJenkinsBuildArtifacts.md
@@ -111,6 +111,7 @@ Administrator-elevated **Developer Command Prompt for VS 2017** window:
 Within the elevated command prompt, execute the `setup-windows.exe` program:
 
 	> C:\xa-sdk\oss-xamarin.android_v7.4.99.60_Darwin-x86_64_master_4f3d604\bin\Debug\bin\setup-windows.exe
+	Executing: MKLINK /D "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid" "C:\xa-sdk\oss-xamarin.android_v7.4.99.57_Darwin-x86_64_master_97f08f7\bin\Debug\lib\xamarin.android\xbuild-frameworks\MonoAndroid"
 	Executing: MKLINK /D "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\MonoAndroid" "C:\xa-sdk\oss-xamarin.android_v7.4.99.57_Darwin-x86_64_master_97f08f7\bin\Debug\lib\xamarin.android\xbuild-frameworks\MonoAndroid"
 	Executing: MKLINK /D "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\Xamarin\Android" "C:\xa-sdk\oss-xamarin.android_v7.4.99.57_Darwin-x86_64_master_97f08f7\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android"
 	Success!


### PR DESCRIPTION
When building `HelloWorld.csproj`, my machine is loading reference
assemblies from:

```
ReferenceAssemblyPaths: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\
```

This is different from what `setup-windows.exe` is making a link for. So
if I attempt to build `HelloWorld.csproj` for API 26 /
TargetFrameworkVersion 8.0, it fails because the framework does not
exist on my system. It turns out this is happening because I am using
MSBuild 15.0 from my VS install, instead of the .NET framework version
of MSBuild.

The fix here is to create an additional file link for VS 2017. I also
streamlined the `Uninstall` method so it takes in an array of
directories.