### PR TITLE
[Xamarin.Android.Build.Tasks] minSdkVersion checks on 32-bit

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -210,7 +210,8 @@ printf ""%d"" x
 			proj.SetProperty (KnownProperties.TargetFrameworkVersion, "v5.1");
 			proj.SetProperty (KnownProperties.AndroidSupportedAbis, supportedAbis);
 			proj.SetProperty ("EnableLLVM", enableLLVM.ToString ());
-			if (enableLLVM) {
+			bool checkMinLlvmPath = enableLLVM && (supportedAbis == "armeabi-v7a" || supportedAbis == "x86");
+			if (checkMinLlvmPath) {
 				// Set //uses-sdk/@android:minSdkVersion so that LLVM uses the right libc.so
 				proj.AndroidManifest = $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <manifest xmlns:android=""http://schemas.android.com/apk/res/android"" android:versionCode=""1"" android:versionName=""1.0"" package=""{proj.PackageName}"">
@@ -225,7 +226,7 @@ printf ""%d"" x
 				Assert.AreEqual (expectedResult, b.Build (proj), "Build should have {0}.", expectedResult ? "succeeded" : "failed");
 				if (!expectedResult)
 					return;
-				if (enableLLVM) {
+				if (checkMinLlvmPath) {
 					// LLVM passes a direct path to libc.so, and we need to use the libc.so
 					// which corresponds to the *minimum* SDK version specified in AndroidManifest.xml
 					// Since we overrode minSdkVersion=10, that means we should use libc.so from android-9.


### PR DESCRIPTION
The `BuildAotApplication()` test additions from commit a953d3f1 don't
work when `supportedAbis` is a 64-bit platform such as `x86_64` or
`arm64-v8a`, because the test checks for `android-9`, which is only
going to be valid for 32-bit architectures. (64-bit architecture
support requires API-21, iirc.)

Update the minSdkVersion path check to only execute when dealing with
32-bit architectures.