### PR TITLE
[tests] merge runtime test timing measurements into one plot

### DIFF
--- a/build-tools/scripts/UnitTestApks.targets
+++ b/build-tools/scripts/UnitTestApks.targets
@@ -146,11 +146,14 @@
       <Output TaskParameter="FailedToRun" ItemName="_FailedComponent"/>
     </RunInstrumentationTests>
     <PropertyGroup>
-      <_DefinitionsFilename Condition=" '%(UnitTestApk.TimingDefinitionsFilename)' == '' ">$(MSBuildThisFileDirectory)/TimingDefinitions.txt</_DefinitionsFilename>
-      <_DefinitionsFilename Condition=" '%(UnitTestApk.TimingDefinitionsFilename)' != '' ">%(UnitTestApk.TimingDefinitionsFilename)</_DefinitionsFilename>
-      <_LogcatFilenameEnd>-logcat-$(Configuration)$(_AotName).txt</_LogcatFilenameEnd>
+      <_LogcatFilename>logcat-$(Configuration)$(_AotName).txt</_LogcatFilename>
     </PropertyGroup>
-    <Exec Command="&quot;$(AdbToolPath)\$(AdbToolExe)&quot; $(_AdbTarget) $(AdbOptions) logcat -v threadtime -d > %(UnitTestApk.Package)$(_LogcatFilenameEnd)" />
-    <ProcessLogcatTiming InputFilename="%(UnitTestApk.Package)$(_LogcatFilenameEnd)" ApplicationPackageName="%(UnitTestApk.Package)" ResultsFilename="%(UnitTestApk.ResultsPath)" DefinitionsFilename="$(_DefinitionsFilename)" />
+    <Exec Command="&quot;$(AdbToolPath)\$(AdbToolExe)&quot; $(_AdbTarget) $(AdbOptions) logcat -v threadtime -d > $(_LogcatFilename)" />
+    <ProcessLogcatTiming
+        InputFilename="$(_LogcatFilename)"
+        ApplicationPackageName="%(UnitTestApk.Package)"
+        ResultsFilename="%(UnitTestApk.ResultsPath)"
+        DefinitionsFilename="%(UnitTestApk.TimingDefinitionsFilename)"
+        AddResults="true" />
   </Target>
 </Project>

--- a/src/Mono.Android/Test/Mono.Android-Tests.projitems
+++ b/src/Mono.Android/Test/Mono.Android-Tests.projitems
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.ProcessPlotInput" />
   <PropertyGroup>
-    <_MonoAndroidTestResultsPath>$(MSBuildThisFileDirectory)..\..\..\TestResult-Mono.Android_Tests-$(Configuration)$(_AotName).xml</_MonoAndroidTestResultsPath>
+    <_MonoAndroidTestResultsPath>$(MSBuildThisFileDirectory)..\..\..\TestResult-Mono.Android_Tests.xml</_MonoAndroidTestResultsPath>
     <_MonoAndroidTestPackage>Mono.Android_Tests</_MonoAndroidTestPackage>
     <_MonoAndroidTestApkFile>$(OutputPath)Mono.Android_Tests-Signed.apk</_MonoAndroidTestApkFile>
     <_MonoAndroidTestApkSizesInput>apk-sizes-$(_MonoAndroidTestPackage)-$(Configuration)$(_AotName).txt</_MonoAndroidTestApkSizesInput>
@@ -12,10 +12,11 @@
       <Package>$(_MonoAndroidTestPackage)</Package>
       <InstrumentationType>xamarin.android.runtimetests.TestInstrumentation</InstrumentationType>
       <ResultsPath>$(_MonoAndroidTestResultsPath)</ResultsPath>
+      <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)timing-definitions-$(Configuration)$(_AotName).txt</TimingDefinitionsFilename>
     </UnitTestApk>
   </ItemGroup>
   <Target Name="_RecordApkSizes" AfterTargets="DeployUnitTestApks">
-    <Delete Files="$(MSBuildThisFileDirectory)..\..\..\TestResult-Mono.Android_Tests-values.csv" Condition=" '$(Configuration)' == 'Debug' " />
+    <Delete Files="$(MSBuildThisFileDirectory)..\..\..\TestResult-Mono.Android_Tests-values.csv;$(MSBuildThisFileDirectory)..\..\..\TestResult-Mono.Android_Tests-times.csv" Condition=" '$(Configuration)' == 'Debug' " />
     <Exec Condition=" '$(HostOS)' == 'Darwin' " Command="stat -f &quot;stat: %z %N&quot; &quot;$(_MonoAndroidTestApkFile)&quot; > $(_MonoAndroidTestApkSizesInput)" />
     <Exec Condition=" '$(HostOS)' == 'Linux' " Command="stat -c &quot;stat: %s %N&quot; &quot;$(_MonoAndroidTestApkFile)&quot; > $(_MonoAndroidTestApkSizesInput)" />
     <Exec Command="unzip -l &quot;$(_MonoAndroidTestApkFile)&quot; >> $(_MonoAndroidTestApkSizesInput)" />

--- a/src/Mono.Android/Test/timing-definitions-Debug.txt
+++ b/src/Mono.Android/Test/timing-definitions-Debug.txt
@@ -1,0 +1,6 @@
+# measure time of last monodroid-timing message appearance
+last-Debug=monodroid-timing:\s+(?<message>.*)$
+
+# measure time of runtime and JNIEnv initialization end
+init-Debug=monodroid-timing:\s+(?<message>Runtime\.init: end native-to-managed.*)$
+JNI.init-Debug=monodroid-timing:\s+(?<message>JNIEnv\.Initialize end:.*)$

--- a/src/Mono.Android/Test/timing-definitions-Release-Aot.txt
+++ b/src/Mono.Android/Test/timing-definitions-Release-Aot.txt
@@ -1,0 +1,6 @@
+# measure time of last monodroid-timing message appearance
+last-Release-Aot=monodroid-timing:\s+(?<message>.*)$
+
+# measure time of runtime and JNIEnv initialization end
+init-Release-Aot=monodroid-timing:\s+(?<message>Runtime\.init: end native-to-managed.*)$
+JNI.init-Release-Aot=monodroid-timing:\s+(?<message>JNIEnv\.Initialize end:.*)$

--- a/src/Mono.Android/Test/timing-definitions-Release.txt
+++ b/src/Mono.Android/Test/timing-definitions-Release.txt
@@ -1,0 +1,6 @@
+# measure time of last monodroid-timing message appearance
+last-Release=monodroid-timing:\s+(?<message>.*)$
+
+# measure time of runtime and JNIEnv initialization end
+init-Release=monodroid-timing:\s+(?<message>Runtime\.init: end native-to-managed.*)$
+JNI.init-Release=monodroid-timing:\s+(?<message>JNIEnv\.Initialize end:.*)$

--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.projitems
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.projitems
@@ -5,6 +5,7 @@
       <Package>Xamarin.Android.JcwGen_Tests</Package>
       <InstrumentationType>xamarin.android.jcwgentests.TestInstrumentation</InstrumentationType>
       <ResultsPath>$(MSBuildThisFileDirectory)..\..\..\TestResult-Xamarin.Android.JcwGen_Tests.xml</ResultsPath>
+      <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)..\..\..\build-tools\scripts\TimingDefinitions.txt</TimingDefinitionsFilename>
     </UnitTestApk>
   </ItemGroup>
 </Project>

--- a/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.projitems
+++ b/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.projitems
@@ -5,6 +5,7 @@
       <Package>Xamarin.Android.Locale_Tests</Package>
       <InstrumentationType>xamarin.android.localetests.TestInstrumentation</InstrumentationType>
       <ResultsPath>$(MSBuildThisFileDirectory)..\..\..\TestResult-Xamarin.Android.Locale_Tests.xml</ResultsPath>
+      <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)..\..\..\build-tools\scripts\TimingDefinitions.txt</TimingDefinitionsFilename>
     </UnitTestApk>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
 - also dump logcat only once per target run, we don't need to
   differentiate it for various tests, as they are batched over one
   emulator instance