### PR TITLE
[api-xml-adjuster] add default paths to topdir and Java.Interop in Makefile

### DIFF
--- a/build-tools/api-xml-adjuster/Makefile
+++ b/build-tools/api-xml-adjuster/Makefile
@@ -2,6 +2,9 @@ CONFIGURATION=Debug
 
 SHELL = /bin/bash
 
+TOP=../../
+JAVA_INTEROP_PATH=../../external/Java.Interop
+
 ANDROID_SDK_PATH=$(shell find ~/ -maxdepth 1 -name android-sdk-*)
 
 DOCS_DIR=~/android-toolchain/docs


### PR DESCRIPTION
... so that we can avoid unnecessary build failures by default.