### PR TITLE
Follow JniType split and name changes in Java.Interop module.

### DIFF
--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -3,10 +3,9 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Java.Interop.Tools.TypeNameMappings;
 
 using Android.Runtime;
-
-using JniTypeMapping    = Java.Interop.Tools.TypeNameMappings.JniType;
 
 namespace Java.Interop {
 
@@ -222,7 +221,7 @@ namespace Java.Interop {
 					return type;
 				}
 			}
-			if ((type = Type.GetType (JniTypeMapping.ToCliType (class_name))) != null) {
+			if ((type = Type.GetType (JavaNativeTypeManager.ToCliType (class_name))) != null) {
 				return type;
 			}
 			return null;
@@ -310,7 +309,7 @@ namespace Java.Interop {
 
 		public static void RegisterType (string java_class, Type t)
 		{
-			string jniFromType = JniTypeMapping.ToJniName (t);
+			string jniFromType = JavaNativeTypeManager.ToJniName (t);
 			lock (jniToManaged) {
 				Type lookup;
 				if (!jniToManaged.TryGetValue (java_class, out lookup)) {

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/ApplicationAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/ApplicationAttribute.Partial.cs
@@ -241,7 +241,7 @@ namespace Android.App {
 		{
 			var type = self.provider as TypeDefinition;
 			if (string.IsNullOrEmpty (self.Name) && type != null)
-				return JniType.ToJniName (type).Replace ('/', '.');
+				return JavaNativeTypeManager.ToJniName (type).Replace ('/', '.');
 
 			return self.Name;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -112,7 +112,7 @@ namespace Xamarin.Android.Tasks
 		void Run (DirectoryAssemblyResolver res)
 		{
 			PackageNamingPolicy pnp;
-			JniType.PackageNamingPolicy = Enum.TryParse (PackageNamingPolicy, out pnp) ? pnp : PackageNamingPolicyEnum.LowercaseHash;
+			JavaNativeTypeManager.PackageNamingPolicy = Enum.TryParse (PackageNamingPolicy, out pnp) ? pnp : PackageNamingPolicyEnum.LowercaseHash;
 			var temp = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
 			Directory.CreateDirectory (temp);
 
@@ -160,7 +160,7 @@ namespace Xamarin.Android.Tasks
 
 			foreach (var type in java_types) {
 				string managedKey = type.FullName.Replace ('/', '.');
-				string javaKey    = JniType.ToJniName (type).Replace ('/', '.');
+				string javaKey    = JavaNativeTypeManager.ToJniName (type).Replace ('/', '.');
 
 				acw_map.WriteLine ("{0};{1}", type.GetPartialAssemblyQualifiedName (), javaKey);
 				acw_map.WriteLine ("{0};{1}", type.GetAssemblyQualifiedName (), javaKey);
@@ -189,7 +189,7 @@ namespace Xamarin.Android.Tasks
 				managed.Add (managedKey, type);
 				java.Add (javaKey, type);
 				acw_map.WriteLine ("{0};{1}", managedKey, javaKey);
-				acw_map.WriteLine ("{0};{1}", JniType.ToCompatJniName (type).Replace ('/', '.'), javaKey);
+				acw_map.WriteLine ("{0};{1}", JavaNativeTypeManager.ToCompatJniName (type).Replace ('/', '.'), javaKey);
 			}
 
 			acw_map.Close ();
@@ -262,8 +262,8 @@ namespace Xamarin.Android.Tasks
 			StringWriter regCallsWriter = new StringWriter ();
 			regCallsWriter.WriteLine ("\t\t// Application and Instrumentation ACWs must be registered first.");
 			foreach (var type in java_types) {
-				if (JniType.IsApplication (type) || JniType.IsInstrumentation (type)) {
-					string javaKey = JniType.ToJniName (type).Replace ('/', '.');				
+				if (JavaNativeTypeManager.IsApplication (type) || JavaNativeTypeManager.IsInstrumentation (type)) {
+					string javaKey = JavaNativeTypeManager.ToJniName (type).Replace ('/', '.');				
 					regCallsWriter.WriteLine ("\t\tmono.android.Runtime.register (\"{0}\", {1}.class, {1}.__md_methods);",
 						type.GetAssemblyQualifiedName (), javaKey);
 				}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -277,8 +277,8 @@ namespace Xamarin.Android.Tasks {
 				if (PackageName == null)
 					PackageName = t.Namespace;
 
-				var name        = JniType.ToJniName (t).Replace ('/', '.');
-				var compatName  = JniType.ToCompatJniName (t).Replace ('/', '.');
+				var name        = JavaNativeTypeManager.ToJniName (t).Replace ('/', '.');
+				var compatName  = JavaNativeTypeManager.ToCompatJniName (t).Replace ('/', '.');
 				if (((string) app.Attribute (attName)) == compatName) {
 					app.SetAttributeValue (attName, name);
 				}
@@ -835,7 +835,7 @@ namespace Xamarin.Android.Tasks {
 			
 			foreach (var type in subclasses)
 				if (type.IsSubclassOf ("Android.App.Instrumentation")) {
-					var xe = InstrumentationFromTypeDefinition (type, JniType.ToJniName (type).Replace ('/', '.'), targetSdkVersion);
+					var xe = InstrumentationFromTypeDefinition (type, JavaNativeTypeManager.ToJniName (type).Replace ('/', '.'), targetSdkVersion);
 					if (xe != null)
 						manifest.Add (xe);
 				}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Android.Manifest {
 
 		public static string ToString (TypeDefinition typeDef)
 		{
-			return JniType.ToJniName (typeDef).Replace ('/', '.');
+			return JavaNativeTypeManager.ToJniName (typeDef).Replace ('/', '.');
 		}
 
 		public static TypeDefinition ResolveType (string type, ICustomAttributeProvider provider, IAssemblyResolver resolver)

--- a/src/Xamarin.Android.Tools.JavadocImporter/javadoc-to-mdoc.cs
+++ b/src/Xamarin.Android.Tools.JavadocImporter/javadoc-to-mdoc.cs
@@ -465,7 +465,7 @@ namespace Xamarin.Android.Tools.JavaDocToMdoc
 				.Append (name)
 				.Append ("(");
 			bool first = true;
-			foreach (JniType t in JniType.FromSignature (mregister.Signature)) {
+			foreach (JniTypeName t in JavaNativeTypeManager.FromSignature (mregister.Signature)) {
 				if (!first)
 					anchor.Append (", ");
 				first = false;


### PR DESCRIPTION
JniType -> JniTypeName (instance) and JavaNativeTypeManager (static).

There is no ambiguity between two JniType in mobile profile anymore.

(There are still two JniTypeNameManagers, which should be resolved in
the next refactoring phases.)