### PR TITLE
[Xamarin.Android.Build.Tests] Fix the unit tests for DesignTimeBuilds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -221,6 +221,8 @@ printf ""%d"" x
 </manifest>";
 			}
 			using (var b = CreateApkBuilder (path)) {
+				if (!b.CrossCompilerAvailable (supportedAbis))
+					Assert.Ignore ("Cross compiler was not available");
 				b.ThrowOnBuildFailure = false;
 				b.Verbosity = LoggerVerbosity.Diagnostic;
 				Assert.AreEqual (expectedResult, b.Build (proj), "Build should have {0}.", expectedResult ? "succeeded" : "failed");
@@ -277,6 +279,8 @@ printf ""%d"" x
 			proj.SetProperty (KnownProperties.AndroidSupportedAbis, supportedAbis);
 			proj.SetProperty ("EnableLLVM", enableLLVM.ToString ());
 			using (var b = CreateApkBuilder (path)) {
+				if (!b.CrossCompilerAvailable (supportedAbis))
+					Assert.Ignore ("Cross compiler was not available");
 				b.ThrowOnBuildFailure = false;
 				Assert.AreEqual (expectedResult, b.Build (proj), "Build should have {0}.", expectedResult ? "succeeded" : "failed");
 				if (!expectedResult)
@@ -1074,6 +1078,8 @@ namespace App1
 			proj.SetProperty (proj.ActiveConfigurationProperties, "DebugSymbols", debugSymbols);
 			proj.SetProperty (proj.ActiveConfigurationProperties, "DebugType", debugType);
 			using (var b = CreateApkBuilder ("temp/SequencePointChecks", false, false)) {
+				if (aotAssemblies && !b.CrossCompilerAvailable (string.Join (";", abis)))
+					Assert.Ignore ("Cross compiler was not available");
 				b.Verbosity = LoggerVerbosity.Diagnostic;
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				var apk = Path.Combine (Root, b.ProjectDirectory,
@@ -1755,12 +1761,12 @@ public class Test
 		}
 
 		[Test]
-		public void BuildInDesignTimeMode ()
+		public void BuildInDesignTimeMode ([Values(false, true)] bool useManagedParser)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 			};
-			proj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", "False");
+			proj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", useManagedParser.ToString ());
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name), false ,false)) {
 				builder.Verbosity = LoggerVerbosity.Diagnostic;
 				builder.Target = "UpdateAndroidResources";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -72,7 +72,7 @@ namespace Xamarin.ProjectTools
 				{ "armeabi", "cross-arm" },
 				{ "x86", "cross-x86" },
 				{ "x86_64", "cross-x86_64" },
-				{ "arm64", "cross-arm64" },
+				{ "arm64-v8a", "cross-arm64" },
 			};
 			bool result = true;
 			foreach (var abi in supportedAbis.Split (';')) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -65,6 +65,28 @@ namespace Xamarin.ProjectTools
 			}
 		}
 
+		public bool CrossCompilerAvailable (string supportedAbis)
+		{
+			var crossCompilerLookup = new Dictionary<string, string> {
+				{ "armeabi-v7a", "cross-arm" },
+				{ "armeabi", "cross-arm" },
+				{ "x86", "cross-x86" },
+				{ "x86_64", "cross-x86_64" },
+				{ "arm64", "cross-arm64" },
+			};
+			bool result = true;
+			foreach (var abi in supportedAbis.Split (';')) {
+				var fileName = crossCompilerLookup [abi];
+				if (IsUnix) {
+					result &= (File.Exists (Path.Combine (FrameworkLibDirectory, "xbuild", "Xamarin", "Android", "Darwin", fileName)) ||
+						File.Exists (Path.Combine (FrameworkLibDirectory, "xbuild", "Xamarin", "Android", "Linux", fileName)));
+				} else {
+					result &= File.Exists (Path.Combine (FrameworkLibDirectory, ".exe"));
+				}
+			}
+			return result;
+		}
+
 		public string LatestTargetFrameworkVersion () {
 			Version latest = new Version (1, 0);
 			var outdir = FrameworkLibDirectory;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1056,7 +1056,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_ManagedUpdateAndroidResgen" Condition=" '$(ManagedDesignTimeBuild)' == 'True' "
 		Inputs="@(AndroidResource);@(ReferencePath)"
 		Outputs="$(_AndroidManagedResourceDesignerFile)"
-		DependsOnTargets="_ExtractLibraryProjectImports">
+		DependsOnTargets="_CreatePropertiesCache;_ExtractLibraryProjectImports">
 	<MakeDir Directories="$(_AndroidDesignTimeResDirIntermediate)" />
 	<!-- Parse primary R.java and create Resources.Designer.cs -->
 	<GenerateResourceDesigner


### PR DESCRIPTION
Commit 10d1213b added the new Managed Design Time builds.
However some of the tests were not complete. This commit
fixes those tests.

It also adds a new method to check if the cross compilers
are available. If they are not those tests will be Ignored.