### PR TITLE
[tests] process the logcat only when definitions are set

### DIFF
--- a/build-tools/scripts/UnitTestApks.targets
+++ b/build-tools/scripts/UnitTestApks.targets
@@ -150,6 +150,7 @@
     </PropertyGroup>
     <Exec Command="&quot;$(AdbToolPath)\$(AdbToolExe)&quot; $(_AdbTarget) $(AdbOptions) logcat -v threadtime -d > $(_LogcatFilename)" />
     <ProcessLogcatTiming
+        Condition=" '%(UnitTestApk.TimingDefinitionsFilename)' != '' "
         InputFilename="$(_LogcatFilename)"
         ApplicationPackageName="%(UnitTestApk.Package)"
         ResultsFilename="%(UnitTestApk.ResultsPath)"


### PR DESCRIPTION
 - this makes the timing processing optional and also makes it easier
   to use the XA's tests infrastructure outside of XA