### PR TITLE
[Xamarin.Android.Build.Tasks] _UpdateAndroidResgen is throwing new AP…

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -264,7 +264,9 @@ namespace Xamarin.Android.Tasks
 						//    __library_projects__/[dllname]/[library_project_imports | jlibs]/bin
 						using (var zip = MonoAndroidHelper.ReadZipFile (finfo.FullName)) {
 							updated |= Files.ExtractAll (zip, importsDir, modifyCallback: (entryFullName) => {
-								return entryFullName.Replace ("library_project_imports/", "");
+								return entryFullName
+									.Replace ("library_project_imports\\","")
+									.Replace ("library_project_imports/", "");
 							}, deleteCallback: (fileToDelete) => {
 								return !jars.Contains (fileToDelete);
 							}, forceUpdate: false);


### PR DESCRIPTION
…T0000 errors in d15-4 (#769)

Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=58889
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=58890

Commit 0667a2b6 and ea6b9b45 added support for short path names.
However during the rework we added code to replace

	library_project_imports/

with an empty string. Some of the Nuget Support packages seem
to include a `__AndroidLibraryProjects__.zip` which uses
windows path sepatators rather than unix ones. So the code
to strip off the `library_project_imports/` does not work.
We end up with a directory structure like

	__library_projects__/[dllname]/library_project_imports/library_project_imports

which a) does not get picked up by our tasks and b) takes up
a bunch of additional characters in our already long path..

The result is the two errors above... one to do with missing resources
the other a PathToLong error.

Because the nuget packages have already shipped and will be in use,
we need to handle BOTH cases.