### PR TITLE
[build] fix `Exists` check for `ndk-build` on Windows

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -97,6 +97,8 @@
     <AndroidToolExe Condition=" '$(AndroidToolExe)' == '' ">android</AndroidToolExe>
     <EmulatorToolPath Condition=" '$(EmulatorToolPath)' == '' ">$(AndroidSdkFullPath)\tools</EmulatorToolPath>
     <EmulatorToolExe Condition=" '$(EmulatorToolExe)' == '' ">emulator</EmulatorToolExe>
+    <NdkBuildPath Condition=" '$(NdkBuildPath)' == '' And '$(HostOS)' != 'Windows' ">$(AndroidNdkDirectory)\ndk-build</NdkBuildPath>
+    <NdkBuildPath Condition=" '$(NdkBuildPath)' == '' And '$(HostOS)' == 'Windows' ">$(AndroidNdkDirectory)\ndk-build.cmd</NdkBuildPath>
   </PropertyGroup>
   <!--
     "Fixup" $(AndroidSupportedHostJitAbis) so that Condition attributes elsewhere

--- a/src/Mono.Android/Test/Mono.Android-Tests.targets
+++ b/src/Mono.Android/Test/Mono.Android-Tests.targets
@@ -14,7 +14,7 @@
       DependsOnTargets="AndroidPrepareForBuild"
       Inputs="jni\reuse-threads.c;jni\Android.mk"
       Outputs="@(AndroidNativeLibrary)">
-    <Error Text="Could not locate Android NDK." Condition="!Exists ('$(AndroidNdkDirectory)\ndk-build')" />
-    <Exec Command="&quot;$(AndroidNdkDirectory)\ndk-build&quot;" />
+    <Error Text="Could not locate Android NDK." Condition="!Exists ('$(NdkBuildPath)')" />
+    <Exec Command="&quot;$(NdkBuildPath)&quot;" />
   </Target>
 </Project>

--- a/src/sqlite-xamarin/sqlite-xamarin.targets
+++ b/src/sqlite-xamarin/sqlite-xamarin.targets
@@ -24,7 +24,7 @@
   <Target Name="_NdkBuild"
       Inputs="src\stamp"
       Outputs="@(_LibSqliteXamarin)">
-    <Exec Command="$(AndroidNdkDirectory)\ndk-build SQLITE_SOURCE_DIR=&quot;$(SqliteSourceFullPath)&quot; APP_ABI=&quot;$(_AppAbi)&quot;"
+    <Exec Command="&quot;$(NdkBuildPath)&quot; SQLITE_SOURCE_DIR=&quot;$(SqliteSourceFullPath)&quot; APP_ABI=&quot;$(_AppAbi)&quot;"
         WorkingDirectory="src\main\jni" />
   </Target>
   <Target Name="_CleanLibraries"

--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.targets
@@ -7,10 +7,10 @@
       Inputs="jni\Android.mk;jni\timing.c"
       Outputs="@(AndroidNativeLibrary)">
     <Error
-        Condition="!Exists ('$(AndroidNdkDirectory)\ndk-build')"
+        Condition="!Exists ('$(NdkBuildPath)')"
         Text="Could not locate Android NDK."
     />
-    <Exec Command="&quot;$(AndroidNdkDirectory)\ndk-build&quot;" />
+    <Exec Command="&quot;$(NdkBuildPath)&quot;" />
   </Target>
   <Target Name="RunTests"
       DependsOnTargets="AndroidPrepareForBuild">

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
@@ -5,10 +5,10 @@
       Inputs="jni\simple-lib.c;jni\Android.mk"
       Outputs="@(AndroidNativeLibrary);$(OutputPath)\native-lib-1\NativeLib.zip">
     <Error
-        Condition="!Exists ('$(AndroidNdkDirectory)\ndk-build')"
+        Condition="!Exists ('$(NdkBuildPath)')"
         Text="Could not locate Android NDK."
     />
-    <Exec Command="&quot;$(AndroidNdkDirectory)\ndk-build&quot;" />
+    <Exec Command="&quot;$(NdkBuildPath)&quot;" />
     <MakeDir Directories="$(OutputPath)\native-lib-1" />
     <Exec
         Command="zip -r ../$(OutputPath)/native-lib-1/NativeLib.zip arm64-v8a armeabi armeabi-v7a x86 x86_64"
@@ -20,11 +20,11 @@
       Inputs="simple2\jni\simple2-lib.c;simple2\jni\Android.mk"
       Outputs="@(AndroidNativeLibrary);$(OutputPath)\native-lib-2\NativeLib2.zip">
     <Error
-        Condition="!Exists ('$(AndroidNdkDirectory)\ndk-build')"
+        Condition="!Exists ('$(NdkBuildPath)')"
         Text="Could not locate Android NDK."
     />
     <Exec
-        Command="&quot;$(AndroidNdkDirectory)\ndk-build&quot;"
+        Command="&quot;$(NdkBuildPath)&quot;"
         WorkingDirectory="simple2"
     />
     <MakeDir Directories="$(OutputPath)\native-lib-2" />

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib2/Xamarin.Android.BindingResolveImportLib2.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib2/Xamarin.Android.BindingResolveImportLib2.csproj
@@ -85,8 +85,8 @@
     <Delete Files="Jars/lib2.jar;Jars/com/xamarin/android/test/binding/resolveimport/Lib2.class" />
   </Target>
   <Target Name="BuildNativeLibs" DependsOnTargets="AndroidPrepareForBuild" Inputs="jni\timing.c;jni\Android.mk" Outputs="@(EmbeddedNativeLibrary)">
-    <Error Text="Could not locate Android NDK." Condition="!Exists ('$(AndroidNdkDirectory)\ndk-build')" />
-    <Exec Command="&quot;$(AndroidNdkDirectory)\ndk-build&quot;" />
+    <Error Text="Could not locate Android NDK." Condition="!Exists ('$(NdkBuildPath)')" />
+    <Exec Command="&quot;$(NdkBuildPath)&quot;" />
   </Target>
   <Target Name="CleanNativeLibs">
     <RemoveDir Directories="obj\local;libs" />

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib4/Xamarin.Android.BindingResolveImportLib4.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib4/Xamarin.Android.BindingResolveImportLib4.csproj
@@ -83,8 +83,8 @@
     <Delete Files="Jars/lib4.jar;Jars/com/xamarin/android/test/binding/resolveimport/Lib4.class" />
   </Target>
   <Target Name="BuildNativeLibs" DependsOnTargets="AndroidPrepareForBuild" Inputs="jni\timing.c;jni\Android.mk" Outputs="@(EmbeddedNativeLibrary)">
-    <Error Text="Could not locate Android NDK." Condition="!Exists ('$(AndroidNdkDirectory)\ndk-build')" />
-    <Exec Command="&quot;$(AndroidNdkDirectory)\ndk-build&quot;" />
+    <Error Text="Could not locate Android NDK." Condition="!Exists ('$(NdkBuildPath)')" />
+    <Exec Command="&quot;$(NdkBuildPath)&quot;" />
   </Target>
   <Target Name="CleanNativeLibs">
     <RemoveDir Directories="obj\local;libs" />


### PR DESCRIPTION
Checks for `Exists ('$(AndroidNdkDirectory)\ndk-build')` will not work
on Windows, since the file is named `ndk-build.cmd`.

To fix this, I created a new `NdkBuildPath` property to be used
throughout the build, which will have the correct value on Windows.