### PR TITLE
[tests] Add Xamarin.Forms.Performance.Integration.Droid.csproj

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,7 @@ run-ji-tests:
 TEST_APK_PROJECTS = \
 	src/Mono.Android/Test/Mono.Android-Tests.csproj \
 	tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.csproj \
+	tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj \
 	tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj
 
 TEST_APK_PROJECTS_RELEASE = \


### PR DESCRIPTION
[Jenkins build 601][j601] is unstable:

[j601]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/601/

	xamarin-android/build-tools/scripts/TestApks.targets: error : Tool exited with code: 255.
	Output: adb: error: cannot stat '…/xamarin-android/tests/../bin/TestRelease/Xamarin.Forms_Performance_Integration-Signed.apk':
	No such file or directory

`Xamarin.Forms_Performance_Integration-Signed.apk` doesn't exist
because it's not built, and it's not built because commit
09ba1ee4 forgot to add the project to `$(TEST_APK_PROJECTS)` within
`Makefile`. (Oops.)

Update `$(TEST_APK_PROJECTS)` so that
`Xamarin.Forms.Performance.Integration.Droid.csproj` is built.