### PR TITLE
[tests] make adb logcat appear in the build output

### DIFF
--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -156,7 +156,7 @@
     <PropertyGroup>
       <_LogcatFilename>logcat-$(Configuration)$(_AotName).txt</_LogcatFilename>
     </PropertyGroup>
-    <Exec Command="&quot;$(AdbToolPath)\$(AdbToolExe)&quot; $(_AdbTarget) $(AdbOptions) logcat -v threadtime -d > $(_LogcatFilename)" />
+    <Exec Command="&quot;$(AdbToolPath)\$(AdbToolExe)&quot; $(_AdbTarget) $(AdbOptions) logcat -v threadtime -d | tee $(_LogcatFilename)" />
     <ProcessLogcatTiming
         Condition=" '%(TestApk.TimingDefinitionsFilename)' != '' "
         InputFilename="$(_LogcatFilename)"


### PR DESCRIPTION
It is useful to have the logcat output in the Jenkins CI console logs,
as the Workspace is only available until a next build starts and so
logcat-*.txt dumps, we create after running tests, are available only
for short time.