### PR TITLE
[create-vsix] fix build ordering for xa-prep-tasks on Windows

### DIFF
--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -99,7 +99,7 @@
       Returns="$(IsExperimental)">
   </Target>
   <Target Name="_CreateDependencies"
-      DependsOnTargets="GetXAVersionInfo"
+      DependsOnTargets="ResolveReferences;GetXAVersionInfo"
       BeforeTargets="Build"
       Inputs="Xamarin.Android.Sdk.pkgdef.in"
       Outputs="Xamarin.Android.Sdk.pkgdef">


### PR DESCRIPTION
Context:
https://devdiv.visualstudio.com/DevDiv/Default/_build/index?buildId=978440&_a=summary

On Windows the following scenario is happening:
- `_CreateDependencies` (and `GetXAVersionInfo`) load xa-prep-tasks.dll
- This locks the assembly (on Windows only)
- the `<ProjectReference>` causes xa-prep-tasks to build, but the output
assembly is locked
- There is also an issue here if xa-prep-tasks is not built yet, as
MSBuild tasks are used from it.

The fix is to add a `DependsOnTargets` for `ResolveAssemblies`, this
builds xa-prep-tasks before using it.