### PR TITLE
[Xamarin.Android.Build.Tasks] Handle special characters like @ in path

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertDebuggingFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertDebuggingFiles.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Android.Tasks
 
 			var convertedFiles = new List<ITaskItem> ();
 			foreach (var file in Files) {
-				var pdb = file.ToString ();
+				var pdb = file.ItemSpec;
 
 				if (!File.Exists (pdb))
 					continue;


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=38285

We were using `TaskItem.ToString ()` to get the path of
the Task item. Turns out on windows this escapes special
characters that msbuild uses. So `@` -> `%40`.

As a result the file no longer loads when we try to convert the
debugging file. So the solution is to use `TaskItem.ItemSpec`
instead.