### PR TITLE
[Xamarin.Android.Build.Tasks] Ignore the StaticFieldLeak Lint warning

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
@@ -166,6 +166,12 @@ namespace Xamarin.Android.Tasks
 			// that means for EVERYTHING! Which will be a HUGE amount of warnings for a large project
 			if (string.IsNullOrEmpty (DisabledIssues) || !DisabledIssues.Contains ("UnusedResources"))
 				DisabledIssues = "UnusedResources" + (!string.IsNullOrEmpty(DisabledIssues) ? ","+DisabledIssues : "");
+
+			// We need to hard code this test as disabled in because Lint will issue a warning
+			// for the MonoPackageManager.java since we have to use a static to keep track of the
+			// application instance.
+			if (string.IsNullOrEmpty (DisabledIssues) || !DisabledIssues.Contains ("StaticFieldLeak"))
+				DisabledIssues = "StaticFieldLeak" + (!string.IsNullOrEmpty (DisabledIssues) ? "," + DisabledIssues : "");
 			
 			Log.LogDebugMessage ("Lint Task");
 			Log.LogDebugMessage ("  TargetDirectory: {0}", TargetDirectory);


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=58340

Lint added a new warning which checks for static fields on
Java classes. Unfortunately we need to use a static in our
MonoPackageManager.java classes because we need to keep track
of the Application instance. So we should ignre this particlar
warning.