### PR TITLE
[tests] set ToolPath and ToolExe for RunUITests

### DIFF
--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -151,7 +151,9 @@
         Condition=" '%(TestApk.Activity)' != '' "
         AdbTarget="$(_AdbTarget)"
         AdbOptions="$(AdbOptions)"
-        Activity="%(TestApk.Activity)">
+        Activity="%(TestApk.Activity)"
+        ToolExe="$(AdbToolExe)"
+        ToolPath="$(AdbToolPath)">
     </RunUITests>
     <PropertyGroup>
       <_LogcatFilename>logcat-$(Configuration)$(_AotName).txt</_LogcatFilename>


### PR DESCRIPTION
Please do not merge yet. I want to try it on PR builder, so Debug configuration is still enabled for Forms test. Once it works, I will disable the Debug in another PR, which will contain this fix as well.

The RunUITests task call didn't have the tool path and exe set. So it worked locally where I have adb in PATH and didn't work on Jenkins.