### PR TITLE
[tests] set ToolPath and ToolExe for RunUITests

### DIFF
--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -151,7 +151,9 @@
         Condition=" '%(TestApk.Activity)' != '' "
         AdbTarget="$(_AdbTarget)"
         AdbOptions="$(AdbOptions)"
-        Activity="%(TestApk.Activity)">
+        Activity="%(TestApk.Activity)"
+        ToolExe="$(AdbToolExe)"
+        ToolPath="$(AdbToolPath)">
     </RunUITests>
     <PropertyGroup>
       <_LogcatFilename>logcat-$(Configuration)$(_AotName).txt</_LogcatFilename>


### PR DESCRIPTION
The RunUITests task call didn't have the tool path and exe set. So it
worked OK locally, where I have the adb tool in PATH and didn't work
on Jenkins. With this fix it should work on Jenkins and other setups.