### PR TITLE
Netstandard Support

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -408,6 +408,10 @@ namespace XamFormsSample
 				"System.Dynamic.Runtime.dll",
 				"System.Text.RegularExpressions.dll",
 				"System.Diagnostics.Tools.dll",
+				"Newtonsoft.Json.dll",
+				"Microsoft.CSharp.dll",
+				"System.Numerics.dll",
+				"System.Xml.Linq.dll",
 			};
 			var path = Path.Combine ("temp", TestContext.CurrentContext.Test.Name);
 			using (var builder = CreateDllBuilder (Path.Combine (path, netStandardProject.ProjectName), cleanupOnDispose: false)) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -223,5 +223,228 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (b.Build (proj), "build failed");
 			}
 		}
+
+		[Test]
+		public void NetStandardReferenceTest ()
+		{
+			var netStandardProject = new DotNetStandard () {
+				Language = XamarinAndroidProjectLanguage.CSharp,
+				ProjectName = "XamFormsSample",
+				ProjectGuid = Guid.NewGuid ().ToString (),
+				Sdk = "Microsoft.NET.Sdk",
+				TargetFramework = "netstandard1.4",
+				IsRelease = true,
+				PackageTargetFallback = "portable-net45+win8+wpa81+wp8",
+				PackageReferences = {
+					KnownPackages.XamarinFormsPCL_2_3_4_231,
+					new Package () {
+						Id = "System.IO.Packaging",
+						Version = "4.4.0",
+					},
+// Uncomment when https://bugzilla.xamarin.com/show_bug.cgi?id=59313 gets fixed
+//					new Package () {
+//						Id = "Newtonsoft.Json",
+//						Version = "10.0.3"
+//					},
+				},
+				OtherBuildItems = {
+					new BuildItem ("None") {
+						Remove = () => "**\\*.xaml",
+					},
+					new BuildItem ("Compile") {
+						Update = () => "**\\*.xaml.cs",
+						DependentUpon = () => "%(Filename)"
+					},
+					new BuildItem ("EmbeddedResource") {
+						Include = () => "**\\*.xaml",
+						SubType = () => "Designer",
+						Generator = () => "MSBuild:UpdateDesignTimeXaml",
+					},
+				},
+				Sources = {
+					new BuildItem.Source ("App.xaml.cs") {
+						TextContent = () => @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+//using Newtonsoft.Json;
+
+using Xamarin.Forms;
+
+namespace XamFormsSample
+{
+    public partial class App : Application
+    {
+        public App()
+        {
+// Uncomment when https://bugzilla.xamarin.com/show_bug.cgi?id=59313 gets fixed
+//            JsonConvert.DeserializeObject<string>(""test"");
+            InitializeComponent();
+        }
+
+        protected override void OnStart()
+        {
+            // Handle when your app starts
+        }
+
+        protected override void OnSleep()
+        {
+            // Handle when your app sleeps
+        }
+
+        protected override void OnResume()
+        {
+            // Handle when your app resumes
+        }
+    }
+}",
+					},
+					new BuildItem.Source ("App.xaml") {
+						TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<Application xmlns=""http://xamarin.com/schemas/2014/forms""
+             xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+             x:Class=""XamFormsSample.App"">
+  <Application.Resources>
+    <!-- Application resource dictionary -->
+  </Application.Resources>
+</Application>",
+					},
+				},
+			};
+
+			var app = new XamarinAndroidApplicationProject () {
+				ProjectName = "App1",
+				IsRelease = true,
+				UseLatestPlatformSdk = true,
+				References = {
+					new BuildItem.Reference ("Mono.Android.Export"),
+					new BuildItem.ProjectReference ($"..\\{netStandardProject.ProjectName}\\{netStandardProject.ProjectName}.csproj",
+						netStandardProject.ProjectName, netStandardProject.ProjectGuid),
+				},
+				PackageReferences = {
+					KnownPackages.SupportDesign_25_4_0_1,
+					KnownPackages.SupportV7CardView_24_2_1,
+					KnownPackages.AndroidSupportV4_25_4_0_1,
+					KnownPackages.SupportCoreUtils_25_4_0_1,
+					KnownPackages.SupportMediaCompat_25_4_0_1,
+					KnownPackages.SupportFragment_25_4_0_1,
+					KnownPackages.SupportCoreUI_25_4_0_1,
+					KnownPackages.SupportCompat_25_4_0_1,
+					KnownPackages.SupportV7AppCompat_25_4_0_1,
+					KnownPackages.XamarinForms_2_3_4_231,
+				}
+			};
+			app.SetProperty (KnownProperties.AndroidSupportedAbis, "x86;armeabi-v7a");
+			var expectedFiles = new string [] {
+				"Java.Interop.dll",
+				"Mono.Android.dll",
+				"mscorlib.dll",
+				"mscorlib.dll.mdb",
+				"System.Collections.Concurrent.dll",
+				"System.Collections.dll",
+				"System.Core.dll",
+				"System.Diagnostics.Debug.dll",
+				"System.dll",
+				"System.Linq.dll",
+				"System.Reflection.dll",
+				"System.Reflection.Extensions.dll",
+				"System.Runtime.dll",
+				"System.Runtime.Extensions.dll",
+				"System.Runtime.InteropServices.dll",
+				"System.Runtime.Serialization.dll",
+				"System.Threading.dll",
+				"System.IO.Packaging.dll",
+				"System.IO.Compression.dll",
+				"System.IO.Compression.pdb",
+				"Mono.Android.Export.dll",
+				"Mono.Android.Export.pdb",
+				"App1.dll",
+				"App1.pdb",
+				"FormsViewGroup.dll",
+				"FormsViewGroup.dll.mdb",
+				"Xamarin.Android.Support.Compat.dll",
+				"Xamarin.Android.Support.Core.UI.dll",
+				"Xamarin.Android.Support.Core.Utils.dll",
+				"Xamarin.Android.Support.Design.dll",
+				"Xamarin.Android.Support.Fragment.dll",
+				"Xamarin.Android.Support.Media.Compat.dll",
+				"Xamarin.Android.Support.v4.dll",
+				"Xamarin.Android.Support.v7.AppCompat.dll",
+				"Xamarin.Android.Support.Animated.Vector.Drawable.dll",
+				"Xamarin.Android.Support.Vector.Drawable.dll",
+				"Xamarin.Android.Support.Transition.dll",
+				"Xamarin.Android.Support.v7.MediaRouter.dll",
+				"Xamarin.Android.Support.v7.RecyclerView.dll",
+				"Xamarin.Android.Support.Annotations.dll",
+				"Xamarin.Android.Support.v7.CardView.dll",
+				"Xamarin.Forms.Core.dll",
+				"Xamarin.Forms.Core.dll.mdb",
+				"Xamarin.Forms.Platform.Android.dll",
+				"Xamarin.Forms.Platform.Android.dll.mdb",
+				"Xamarin.Forms.Platform.dll",
+				"Xamarin.Forms.Xaml.dll",
+				"Xamarin.Forms.Xaml.dll.mdb",
+				"XamFormsSample.dll",
+				"XamFormsSample.pdb",
+				"Mono.Android.pdb",
+				"System.Core.pdb",
+				"System.pdb",
+				"Mono.Security.dll",
+				"Mono.Security.pdb",
+				"System.Xml.dll",
+				"System.Xml.pdb",
+				"System.ComponentModel.Composition.dll",
+				"System.ComponentModel.Composition.pdb",
+				"System.Net.Http.dll",
+				"System.Net.Http.pdb",
+				"System.Runtime.Serialization.pdb",
+				"System.ServiceModel.Internals.dll",
+				"System.ServiceModel.Internals.pdb",
+				"System.Threading.Tasks.dll",
+				"System.ObjectModel.dll",
+				"System.Globalization.dll",
+				"System.ComponentModel.dll",
+				"System.Xml.ReaderWriter.dll",
+				"System.Linq.Expressions.dll",
+				"System.IO.dll",
+				"System.Dynamic.Runtime.dll",
+				"System.Text.RegularExpressions.dll",
+				"System.Diagnostics.Tools.dll",
+			};
+			var path = Path.Combine ("temp", TestContext.CurrentContext.Test.Name);
+			using (var builder = CreateDllBuilder (Path.Combine (path, netStandardProject.ProjectName), cleanupOnDispose: false)) {
+				if (!Directory.Exists (builder.MicrosoftNetSdkDirectory))
+					Assert.Ignore ("Microsoft.NET.Sdk not found.");
+				builder.RequiresMSBuild = true;
+				builder.Target = "Restore";
+				Assert.IsTrue (builder.Build (netStandardProject), "XamFormsSample Nuget packages should have been restored.");
+				builder.Target = "Build";
+				Assert.IsTrue (builder.Build (netStandardProject), "XamFormsSample should have built.");
+				using (var ab = CreateApkBuilder (Path.Combine (path, app.ProjectName), cleanupOnDispose: false)) {
+					ab.RequiresMSBuild = true;
+					ab.Target = "Restore";
+					Assert.IsTrue (ab.Build (app), "App should have built.");
+					ab.Target = "SignAndroidPackage";
+					Assert.IsTrue (ab.Build (app), "App should have built.");
+					var apk = Path.Combine (Root, ab.ProjectDirectory,
+						app.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
+					using (var zip = ZipHelper.OpenZip (apk)) {
+						var existingFiles = zip.Where (a => a.FullName.StartsWith ("assemblies/", StringComparison.InvariantCultureIgnoreCase));
+						var missingFiles = expectedFiles.Where (x => !zip.ContainsEntry ("assmelbies/" + Path.GetFileName (x)));
+						Assert.IsTrue (missingFiles.Any (),
+						string.Format ("The following Expected files are missing. {0}",
+							string.Join (Environment.NewLine, missingFiles)));
+						var additionalFiles = existingFiles.Where (x => !expectedFiles.Contains (Path.GetFileName (x.FullName)));
+						Assert.IsTrue (!additionalFiles.Any (),
+							string.Format ("Unexpected Files found! {0}",
+							string.Join (Environment.NewLine, additionalFiles.Select (x => x.FullName))));
+					}
+					if (!HasDevices)
+						Assert.Ignore ("Skipping Installation. No devices available.");
+					ab.Target = "Install";
+					Assert.IsTrue (ab.Build (app), "App should have installed.");
+				}
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -241,11 +241,10 @@ namespace Xamarin.Android.Build.Tests
 						Id = "System.IO.Packaging",
 						Version = "4.4.0",
 					},
-// Uncomment when https://bugzilla.xamarin.com/show_bug.cgi?id=59313 gets fixed
-//					new Package () {
-//						Id = "Newtonsoft.Json",
-//						Version = "10.0.3"
-//					},
+					new Package () {
+						Id = "Newtonsoft.Json",
+						Version = "10.0.3"
+					},
 				},
 				OtherBuildItems = {
 					new BuildItem ("None") {
@@ -267,7 +266,7 @@ namespace Xamarin.Android.Build.Tests
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-//using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 using Xamarin.Forms;
 
@@ -277,8 +276,7 @@ namespace XamFormsSample
     {
         public App()
         {
-// Uncomment when https://bugzilla.xamarin.com/show_bug.cgi?id=59313 gets fixed
-//            JsonConvert.DeserializeObject<string>(""test"");
+            JsonConvert.DeserializeObject<string>(""test"");
             InitializeComponent();
         }
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -66,7 +66,7 @@ namespace Xamarin.ProjectTools
 				new BuildItem.Reference ("Xamarin.Android.Support.v13") {
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v13.20.0.0.4\\lib\\MonoAndroid32\\Xamarin.Android.Support.v13.dll" }
 				}
-			};
+		};
 		public static Package AndroidSupportV13Beta = new Package () {
 			Id = "Xamarin.Android.Support.v13",
 			Version = "21.0.0.0-beta1",
@@ -93,20 +93,20 @@ namespace Xamarin.ProjectTools
 				new BuildItem.Reference ("Xamarin.Android.Wearable") {
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Wear.1.0.0-preview7\\lib\\MonoAndroid10\\Xamarin.Android.Wearable.dll" }
 				}
-			};
+		};
 		public static Package SupportV7RecyclerView = new Package {
 			Id = "Xamarin.Android.Support.v7.RecyclerView",
-			Version="21.0.0.0-beta1",
-			TargetFramework="MonoAndroid523",
+			Version = "21.0.0.0-beta1",
+			TargetFramework = "MonoAndroid523",
 			References = {
 				new BuildItem.Reference ("Xamarin.Android.Support.V7.RecyclerView") {
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v7.RecyclerView.21.0.0.0-beta1\\lib\\MonoAndroid\\Xamarin.Android.Support.v7.RecyclerView.dll" }
 				}
-			};
+		};
 		public static Package SupportV7CardView = new Package {
 			Id = "Xamarin.Android.Support.v7.Cardview",
-			Version="21.0.3.0",
-			TargetFramework="MonoAndroid523",
+			Version = "21.0.3.0",
+			TargetFramework = "MonoAndroid523",
 			References = {
 				new BuildItem.Reference ("Xamarin.Android.Support.v7.CardView") {
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v7.CardView.21.0.3.0\\lib\\MonoAndroid403\\Xamarin.Android.Support.v7.CardView.dll" }
@@ -119,6 +119,15 @@ namespace Xamarin.ProjectTools
 			References = {
 				new BuildItem.Reference ("Xamarin.Android.Support.v7.CardView") {
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v7.CardView.24.2.1\\lib\\MonoAndroid70\\Xamarin.Android.Support.v7.CardView.dll" }
+			}
+		};
+		public static Package SupportV7CardView_25_4_0_1 = new Package {
+			Id = "Xamarin.Android.Support.v7.Cardview",
+			Version = "25.4.0.1",
+			TargetFramework = "MonoAndroid70",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.v7.CardView") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v7.CardView.25.4.0.1\\lib\\MonoAndroid70\\Xamarin.Android.Support.v7.CardView.dll" }
 			}
 		};
 		public static Package SupportV7AppCompat_21_0_3_0 = new Package {
@@ -220,6 +229,15 @@ namespace Xamarin.ProjectTools
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v7.Palette.22.1.1.1\\lib\\MonoAndroid403\\Xamarin.Android.Support.v7.Palette.dll" }
 			}
 		};
+		public static Package SupportDesign_25_4_0_1 = new Package {
+			Id = "Xamarin.Android.Support.Design",
+			Version = "25.4.0.1",
+			TargetFramework = "MonoAndroid70",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.Design") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.Design.25.4.0.1\\lib\\MonoAndroid70\\Xamarin.Android.Support.Design.dll" }
+				}
+		};
 		public static Package GooglePlayServices_22_0_0_2 = new Package {
 			Id = "Xamarin.GooglePlayServices",
 			Version = "22.0.0.2",
@@ -262,6 +280,41 @@ namespace Xamarin.ProjectTools
 				},
 				new BuildItem.Reference ("Xamarin.Forms.Platform") {
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.1.4.2.6359\\lib\\MonoAndroid10\\Xamarin.Forms.Platform.dll"
+				},
+			}
+		};
+		public static Package XamarinFormsPCL_2_3_4_231 = new Package {
+			Id = "Xamarin.Forms",
+			Version = "2.3.4.231",
+			TargetFramework = "portable-net45+win+wp80+MonoAndroid10+xamarinios10+MonoTouch10",
+			References = {
+				new BuildItem.Reference ("Xamarin.Forms.Core") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.2.3.4.231\\lib\\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\\Xamarin.Forms.Core.dll"
+				},
+				new BuildItem.Reference ("Xamarin.Forms.Xaml") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.2.3.4.231\\lib\\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\\Xamarin.Forms.Xaml.dll"
+				},
+			}
+		};
+		public static Package XamarinForms_2_3_4_231 = new Package {
+			Id = "Xamarin.Forms",
+			Version = "2.3.4.231",
+			TargetFramework = "MonoAndroid44",
+			References =  {
+				new BuildItem.Reference ("Xamarin.Forms.Platform.Android") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.2.3.4.231\\lib\\MonoAndroid10\\Xamarin.Forms.Platform.Android.dll"
+				},
+				new BuildItem.Reference ("FormsViewGroup") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.2.3.4.231\\lib\\MonoAndroid10\\FormsViewGroup.dll"
+				},
+				new BuildItem.Reference ("Xamarin.Forms.Core") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.2.3.4.231\\lib\\MonoAndroid10\\Xamarin.Forms.Core.dll"
+				},
+				new BuildItem.Reference ("Xamarin.Forms.Xaml") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.2.3.4.231\\lib\\MonoAndroid10\\Xamarin.Forms.Xaml.dll"
+				},
+				new BuildItem.Reference ("Xamarin.Forms.Platform") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.2.3.4.231\\lib\\MonoAndroid10\\Xamarin.Forms.Platform.dll"
 				},
 			}
 		};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
@@ -7,7 +7,7 @@ using Microsoft.Build.Construction;
 
 namespace Xamarin.ProjectTools
 {
-	public abstract class XamarinAndroidProject : XamarinProject
+	public abstract class XamarinAndroidProject : DotNetXamarinProject
 	{
 		protected XamarinAndroidProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
 			: base (debugConfigurationName, releaseConfigurationName)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildActions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildActions.cs
@@ -11,6 +11,7 @@ namespace Xamarin.ProjectTools
 	{
 		public const string None = "None";
 		public const string ProjectReference = "ProjectReference";
+		public const string PackageReference = "PackageReference";
 		public const string Reference = "Reference";
 		public const string Compile = "Compile";
 		public const string EmbeddedResource = "EmbeddedResource";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildItem.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildItem.cs
@@ -90,7 +90,7 @@ namespace Xamarin.ProjectTools
 		{
 		}
 
-		public BuildItem (string buildAction, Func<string> include)
+		public BuildItem (string buildAction, Func<string> include = null)
 		{
 			BuildAction = buildAction;
 			Include = include;
@@ -98,11 +98,23 @@ namespace Xamarin.ProjectTools
 			Timestamp = DateTimeOffset.UtcNow;
 			Encoding = Encoding.UTF8;
 			Attributes = FileAttributes.Normal;
+			Generator = null;
+			Remove = null;
+			SubType = null;
+			Update = null;
+			DependentUpon = null;
+			Version = null;
 		}
 
 		public DateTimeOffset? Timestamp { get; set; }
 		public string BuildAction { get; set; }
 		public Func<string> Include { get; set; }
+		public Func<string> Remove { get; set; }
+		public Func<string> Update { get; set; }
+		public Func<string> SubType { get; set; }
+		public Func<string> Generator { get; set; }
+		public Func<string> DependentUpon { get; set; }
+		public Func<string> Version { get; set; }
 		public IDictionary<string,string> Metadata { get; private set; }
 		public Func<string> TextContent { get; set; }
 		public Func<byte[]> BinaryContent { get; set; }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -341,6 +341,8 @@ namespace Xamarin.ProjectTools
 
 				if (nativeCrashDetected) {
 					Console.WriteLine ($"Native crash detected! Running the build for {projectOrSolution} again.");
+					File.Move(processLog, processLog + ".bak");
+					File.Delete(processLog);
 					continue;
 				} else {
 					break;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -342,7 +342,6 @@ namespace Xamarin.ProjectTools
 				if (nativeCrashDetected) {
 					Console.WriteLine ($"Native crash detected! Running the build for {projectOrSolution} again.");
 					File.Move(processLog, processLog + ".bak");
-					File.Delete(processLog);
 					continue;
 				} else {
 					break;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -29,6 +29,7 @@ namespace Xamarin.ProjectTools
 		public TimeSpan LastBuildTime { get; protected set; }
 		public string BuildLogFile { get; set; }
 		public bool ThrowOnBuildFailure { get; set; }
+		public bool RequiresMSBuild { get; set; }
 
 		string GetVisualStudio2017Directory ()
 		{
@@ -55,7 +56,7 @@ namespace Xamarin.ProjectTools
 				if (IsUnix) {
 					RunningMSBuild = true;
 					var useMSBuild = Environment.GetEnvironmentVariable ("USE_MSBUILD");
-					if (!string.IsNullOrEmpty (useMSBuild) && useMSBuild == "0") {
+					if (!string.IsNullOrEmpty (useMSBuild) && useMSBuild == "0" && !RequiresMSBuild) {
 						RunningMSBuild = false;
 					}
 					#if DEBUG
@@ -118,6 +119,29 @@ namespace Xamarin.ProjectTools
 					var x86 = Environment.GetFolderPath (Environment.SpecialFolder.ProgramFilesX86);
 					return Path.Combine (x86, "MSBuild", "Xamarin", "Android");
 				}
+			}
+		}
+
+		public string MicrosoftNetSdkDirectory {
+			get {
+				string path;
+				if (IsUnix) {
+					path = Path.Combine ("/usr", "local", "share", "dotnet", "sdk", "2.0.0", "Sdks", "Microsoft.NET.Sdk");
+					if (File.Exists (Path.Combine (path, "Sdk", "Sdk.props")))
+						return path;
+					return string.Empty;
+				}
+				var visualStudioDirectory = GetVisualStudio2017Directory ();
+				if (!string.IsNullOrEmpty (visualStudioDirectory)) {
+					path = Path.Combine (visualStudioDirectory, "MSBuild", "Sdks", "Microsoft.NET.Sdk");
+					if (File.Exists (Path.Combine (path, "Sdk", "Sdk.props")))
+						return path;
+				}
+				var x86 = Environment.GetFolderPath (Environment.SpecialFolder.ProgramFilesX86);
+				path = Path.Combine (x86, "MSBuild", "Sdks", "Microsoft.NET.Sdk");
+				if (File.Exists (Path.Combine (path, "Sdk", "Sdk.props")))
+					return path;
+				return string.Empty;
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetStandard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetStandard.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Xamarin.ProjectTools
+{
+	public class DotNetStandard : XamarinProject
+	{
+
+		public override string ProjectTypeGuid {
+			get {
+				return string.Empty;
+			}
+		}
+
+		public DotNetStandard ()
+		{
+			Sources = new List<BuildItem> ();
+			OtherBuildItems = new List<BuildItem> ();
+			SetProperty (CommonProperties, "DebugType", "full");
+			ItemGroupList.Add (Sources);
+		}
+		public string PackageTargetFallback {
+			get { return GetProperty ("PackageTargetFallback"); }
+			set { SetProperty ("PackageTargetFallback", value); }
+		}
+		public string TargetFramework {
+			get { return GetProperty ("TargetFramework"); }
+			set { SetProperty ("TargetFramework", value); }
+		}
+		public string Sdk { get; set; }
+
+		public IList<BuildItem> OtherBuildItems { get; private set; }
+		public IList<BuildItem> Sources { get; private set; }
+
+		public override string SaveProject ()
+		{
+			var sb = new StringBuilder ();
+			sb.AppendLine ("\t<PropertyGroup>");
+			foreach (var pg in PropertyGroups) {
+				if (!pg.Properties.Any ())
+					continue;
+				foreach (var p in pg.Properties) {
+					var conditon = string.IsNullOrEmpty (p.Condition) ? "" : $" Conditon=\"{p.Condition}\"";
+					sb.AppendLine ($"\t\t<{p.Name}{conditon}>{p.Value ()}</{p.Name}>");
+				}
+			}
+			sb.AppendLine ("\t</PropertyGroup>");
+			sb.AppendLine ("\t<ItemGroup>");
+			foreach (var pr in PackageReferences) {
+				sb.AppendLine ($"\t\t<PackageReference Include=\"{pr.Id}\" Version=\"{pr.Version}\"/>");
+			}
+			sb.AppendLine ("\t</ItemGroup>");
+			sb.AppendLine ("\t<ItemGroup>");
+			foreach (var bi in OtherBuildItems) {
+				sb.Append ($"\t\t<{bi.BuildAction} ");
+				if (bi.Include != null) sb.Append ($"Include=\"{bi.Include ()}\" ");
+				if (bi.Update != null) sb.Append ($"Update=\"{bi.Update ()}\" ");
+				if (bi.Remove != null) sb.Append ($"Remove=\"{bi.Remove ()}\" ");
+				if (bi.Generator != null) sb.Append ($"Generator=\"{bi.Generator ()}\" ");
+				if (bi.DependentUpon != null) sb.Append ($"DependentUpon=\"{bi.DependentUpon ()}\" ");
+				if (bi.Version != null) sb.Append ($"Version=\"{bi.Version ()}\" ");
+				if (bi.SubType != null) sb.Append ($"SubType=\"{bi.SubType ()}\" ");
+				if (bi.Metadata.Any ()) {
+					sb.AppendLine ($"\t\t/>");
+				} else {
+					sb.AppendLine ($">");
+					foreach (var kvp in bi.Metadata) {
+						sb.AppendLine ($"\t\t\t<{kvp.Key}>{kvp.Value}</{kvp.Key}>");
+					}
+					sb.AppendLine ($"\t\t</{bi.BuildAction}>");
+				}
+			}
+			sb.AppendLine ("\t</ItemGroup>");
+			return $"<Project Sdk=\"{Sdk}\">\r\n{sb.ToString ()}\r\n</Project>";
+		}
+
+		public override void NuGetRestore (string directory, string packagesDirectory = null)
+		{
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.Build.Construction;
+
+namespace Xamarin.ProjectTools
+{
+	public abstract class DotNetXamarinProject : XamarinProject
+	{
+		protected DotNetXamarinProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
+			: base (debugConfigurationName, releaseConfigurationName)
+		{
+			ProjectName = "UnnamedProject";
+
+			Sources = new List<BuildItem> ();
+			OtherBuildItems = new List<BuildItem> ();
+
+			ItemGroupList.Add (References);
+			ItemGroupList.Add (OtherBuildItems);
+			ItemGroupList.Add (Sources);
+
+			AddReferences ("System"); // default
+
+			SetProperty (KnownProperties.Configuration, debugConfigurationName, "'$(Configuration)' == ''");
+			SetProperty ("Platform", "AnyCPU", "'$(Platform)' == ''");
+			SetProperty ("ErrorReport", "prompt");
+			SetProperty ("WarningLevel", "4");
+			SetProperty ("ConsolePause", "false");
+			SetProperty ("RootNamespace", () => RootNamespace ?? ProjectName);
+			SetProperty ("AssemblyName", () => AssemblyName ?? ProjectName);
+			SetProperty ("BuildingInsideVisualStudio", "True");
+			SetProperty ("BaseIntermediateOutputPath", "obj\\", " '$(BaseIntermediateOutputPath)' == '' ");
+
+			SetProperty (DebugProperties, "DebugSymbols", "true");
+			SetProperty (DebugProperties, "DebugType", "full");
+			SetProperty (DebugProperties, "Optimize", "false");
+			SetProperty (DebugProperties, KnownProperties.OutputPath, Path.Combine ("bin", debugConfigurationName));
+			SetProperty (DebugProperties, "DefineConstants", "DEBUG;");
+			SetProperty (DebugProperties, KnownProperties.IntermediateOutputPath, Path.Combine ("obj", debugConfigurationName));
+
+			SetProperty (ReleaseProperties, "Optimize", "true");
+			SetProperty (ReleaseProperties, "ErrorReport", "prompt");
+			SetProperty (ReleaseProperties, "WarningLevel", "4");
+			SetProperty (ReleaseProperties, "ConsolePause", "false");
+			SetProperty (ReleaseProperties, KnownProperties.OutputPath, Path.Combine ("bin", releaseConfigurationName));
+			SetProperty (ReleaseProperties, KnownProperties.IntermediateOutputPath, Path.Combine ("obj", releaseConfigurationName));
+
+			Sources.Add (new BuildItem.Source (() => "Properties\\AssemblyInfo" + Language.DefaultExtension) { TextContent = () => ProcessSourceTemplate (AssemblyInfo ?? Language.DefaultAssemblyInfo) });
+		}
+
+		void AddProperties (IList<Property> list, string condition, KeyValuePair<string, string> [] props)
+		{
+			foreach (var p in props)
+				list.Add (new Property (condition, p.Key, p.Value));
+		}
+
+		public IList<BuildItem> OtherBuildItems { get; private set; }
+		public IList<BuildItem> Sources { get; private set; }
+
+		public IList<Property> ActiveConfigurationProperties {
+			get { return IsRelease ? ReleaseProperties : DebugProperties; }
+		}
+
+		public string OutputPath {
+			get { return GetProperty (ActiveConfigurationProperties, KnownProperties.OutputPath); }
+			set { SetProperty (ActiveConfigurationProperties, KnownProperties.OutputPath, value); }
+		}
+
+		public string IntermediateOutputPath {
+			get { return GetProperty (ActiveConfigurationProperties, KnownProperties.IntermediateOutputPath); }
+			set { SetProperty (ActiveConfigurationProperties, KnownProperties.IntermediateOutputPath, value); }
+		}
+
+		public BuildItem GetItem (string include)
+		{
+			return ItemGroupList.SelectMany (g => g).First (i => i.Include ().Equals (include, StringComparison.OrdinalIgnoreCase));
+		}
+
+		public void AddReferences (params string [] references)
+		{
+			foreach (var s in references)
+				References.Add (new BuildItem.Reference (s));
+		}
+
+		public void AddSources (params string [] sources)
+		{
+			foreach (var s in sources)
+				Sources.Add (new BuildItem.Source (s));
+		}
+
+		public void Touch (params string [] itemPaths)
+		{
+			foreach (var item in itemPaths)
+				GetItem (item).Timestamp = DateTimeOffset.Now;
+		}
+
+		public virtual ProjectRootElement Construct ()
+		{
+			var root = ProjectRootElement.Create ();
+			if (Packages.Any ())
+				root.AddItemGroup ().AddItem (BuildActions.None, "packages.config");
+			foreach (var pkg in Packages.Where (p => p.AutoAddReferences))
+				foreach (var reference in pkg.References)
+					if (!References.Any (r => r.Include == reference.Include))
+						References.Add (reference);
+			
+			foreach (var pg in PropertyGroups)
+				pg.AddElement (root);
+
+			foreach (var ig in ItemGroupList) {
+				var ige = root.AddItemGroup ();
+				foreach (var i in ig) {
+					if (i.Deleted)
+						continue;
+					ige.AddItem (i.BuildAction, i.Include (), i.Metadata);
+				}
+			}
+
+			root.FullPath = ProjectName + Language.DefaultProjectExtension;
+
+			return root;
+		}
+
+		public override string SaveProject ()
+		{
+			var root = Construct ();
+			var sw = new StringWriter ();
+			root.Save (sw);
+			var document = XDocument.Parse (sw.ToString ());
+			var pn = XName.Get ("Project", "http://schemas.microsoft.com/developer/msbuild/2003");
+			var p = document.Element (pn);
+			if (p != null) {
+				var referenceGroup = p.Elements ().FirstOrDefault (x => x.Name.LocalName == "ItemGroup" &&  x.HasElements && x.Elements ().Any (e => e.Name.LocalName == "Reference"));
+				if (referenceGroup != null) {
+					foreach (var pr in PackageReferences) {
+						var e = XElement.Parse ($"<PackageReference Include=\"{pr.Id}\" Version=\"{pr.Version}\"/>");
+						referenceGroup.Add (e);
+					}
+					sw = new StringWriter ();
+					document.Save (sw);
+				}
+			}
+			return sw.ToString ();
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -60,7 +60,7 @@ namespace Xamarin.ProjectTools
 
 			Output = project.CreateBuildOutput (this);
 
-			project.NuGetRestore (ProjectDirectory, PackagesDirectory);
+			project.NuGetRestore (Path.Combine (Root, ProjectDirectory), PackagesDirectory);
 
 			bool result = BuildInternal (Path.Combine (ProjectDirectory, project.ProjectFilePath), Target, parameters, environmentVariables);
 			built_before = true;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinPCLProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinPCLProject.cs
@@ -2,7 +2,7 @@
 
 namespace Xamarin.ProjectTools
 {
-	public class XamarinPCLProject : XamarinProject
+	public class XamarinPCLProject : DotNetXamarinProject
 	{
 		public XamarinPCLProject ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -31,6 +31,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.Build.Engine" />
@@ -77,6 +78,8 @@
     <Compile Include="Utilities\FileSystemUtils.cs" />
     <Compile Include="Android\JarContentBuilder.cs" />
     <Compile Include="Common\ContentBuilder.cs" />
+    <Compile Include="Common\DotNetStandard.cs" />
+    <Compile Include="Common\DotNetXamarinProject.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Common\" />


### PR DESCRIPTION
This adds Netstandard support to our msbuild unit test system. You can now create a new `DotNetStandard` project and add that as a reference. The builder also has a new property `RequiresMSBuild` which is used to force the system to use `msbuild` for its build process. 