### PR TITLE
[Xamarin.Android.Build.Tasks] Fix a bug when extracting resources.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -226,7 +226,7 @@ namespace Xamarin.Android.Tools {
 				var dt = File.Exists (outfile) ? File.GetLastWriteTimeUtc (outfile) : DateTime.MinValue;
 				if (forceUpdate || entry.ModificationTime > dt) {
 					try {
-						entry.Extract (destination, fullName, FileMode.OpenOrCreate);
+						entry.Extract (destination, fullName, FileMode.Create);
 					} catch (PathTooLongException) {
 						throw new PathTooLongException ($"Could not extract \"{fullName}\" to \"{outfile}\". Path is too long.");
 					}


### PR DESCRIPTION
There is a small bug in the zip extraction. We were using
`FileMode.OpenOrCreate` to write the files. The problem is
`OpenOrCreate` does not truncate the file if it exists. So
if we have a resource which is smaller than the file on disk
we end up with additonal stuff at the end of it..

So lets use `Create` instead which will truncate the file
if it exists aleady.