### PR TITLE
[Xamarin.Android.Build.Tasks] Enable the new VersionCode system by default.

### DIFF
--- a/Documentation/build_process.md
+++ b/Documentation/build_process.md
@@ -572,6 +572,10 @@ when packaing Release applications.
     You can define custom items using the [AndroidVersionCodeProperties](#AndroidVersionCodeProperties) 
     property.
 
+    By default the value will be set to `{abi}{versionCode:D6}`. If a developer
+    wants to keep the old behaviour you can override the default by setting
+    the [AndroidUseLegacyVersionCode](#AndroidUseLegacyVersionCode) property to `true`
+
     Added in Xamarin.Android 7.2.
 
     <a name="AndroidVersionCodeProperties" class="injected"></a>
@@ -586,6 +590,15 @@ when packaing Release applications.
     in the string. 
 
     Added in Xamarin.Android 7.2.
+
+    <a name="AndroidUseLegacyVersionCode" class="injected"></a>
+-   **AndroidUseLegacyVersionCode** &ndash; A boolean property will allows
+    the developer to revert the versionCode calculation back to its old pre 
+    Xamarin.Android 8.2 behaviour. This should ONLY be used for developers 
+    with existing applications in the Google Play Store. It is highly recommended
+    that the new [AndroidVersionCodePattern](#AndroidVersionCodePattern) property is used.
+
+    Added in Xamarin.Android 8.2.
 
 -  **AndroidUseManagedDesignTimeResourceGenerator** &ndash; A boolean property which
     will switch over the design time builds to use the managed resource parser rather

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -270,6 +270,7 @@ namespace Bug12935
 				/* seperateApk */ false,
 				/* abis */ "armeabi-v7a",
 				/* versionCode */ "123",
+				/* useLagacy */ true,
 				/* pattern */ null,
 				/* props */ null,
 				/* shouldBuild */ true,
@@ -279,6 +280,17 @@ namespace Bug12935
 				/* seperateApk */ false,
 				/* abis */ "armeabi-v7a",
 				/* versionCode */ "123",
+				/* useLagacy */ false,
+				/* pattern */ null,
+				/* props */ null,
+				/* shouldBuild */ true,
+				/* expected */ "123",
+			},
+			new object[] {
+				/* seperateApk */ false,
+				/* abis */ "armeabi-v7a",
+				/* versionCode */ "123",
+				/* useLagacy */ false,
 				/* pattern */ "{abi}{versionCode}",
 				/* props */ null,
 				/* shouldBuild */ true,
@@ -288,6 +300,7 @@ namespace Bug12935
 				/* seperateApk */ false,
 				/* abis */ "armeabi-v7a",
 				/* versionCode */ "1",
+				/* useLagacy */ false,
 				/* pattern */ "{abi}{versionCode}",
 				/* props */ "versionCode=123",
 				/* shouldBuild */ true,
@@ -297,6 +310,7 @@ namespace Bug12935
 				/* seperateApk */ false,
 				/* abis */ "armeabi-v7a;x86",
 				/* versionCode */ "123",
+				/* useLagacy */ false,
 				/* pattern */ "{abi}{versionCode}",
 				/* props */ null,
 				/* shouldBuild */ true,
@@ -306,6 +320,7 @@ namespace Bug12935
 				/* seperateApk */ true,
 				/* abis */ "armeabi-v7a;x86",
 				/* versionCode */ "123",
+				/* useLagacy */ true,
 				/* pattern */ null,
 				/* props */ null,
 				/* shouldBuild */ true,
@@ -315,6 +330,17 @@ namespace Bug12935
 				/* seperateApk */ true,
 				/* abis */ "armeabi-v7a;x86",
 				/* versionCode */ "123",
+				/* useLagacy */ false,
+				/* pattern */ null,
+				/* props */ null,
+				/* shouldBuild */ true,
+				/* expected */ "200123;300123",
+			},
+			new object[] {
+				/* seperateApk */ true,
+				/* abis */ "armeabi-v7a;x86",
+				/* versionCode */ "123",
+				/* useLagacy */ false,
 				/* pattern */ "{abi}{versionCode}",
 				/* props */ null,
 				/* shouldBuild */ true,
@@ -324,6 +350,7 @@ namespace Bug12935
 				/* seperateApk */ true,
 				/* abis */ "armeabi-v7a;x86",
 				/* versionCode */ "12",
+				/* useLagacy */ false,
 				/* pattern */ "{abi}{minSDK:00}{versionCode:000}",
 				/* props */ null,
 				/* shouldBuild */ true,
@@ -333,6 +360,7 @@ namespace Bug12935
 				/* seperateApk */ true,
 				/* abis */ "armeabi-v7a;x86",
 				/* versionCode */ "12",
+				/* useLagacy */ false,
 				/* pattern */ "{abi}{minSDK:00}{screen}{versionCode:000}",
 				/* props */ "screen=24",
 				/* shouldBuild */ true,
@@ -342,6 +370,7 @@ namespace Bug12935
 				/* seperateApk */ true,
 				/* abis */ "armeabi-v7a;x86",
 				/* versionCode */ "12",
+				/* useLagacy */ false,
 				/* pattern */ "{abi}{minSDK:00}{screen}{foo:0}{versionCode:000}",
 				/* props */ "screen=24;foo=$(Foo)",
 				/* shouldBuild */ true,
@@ -351,6 +380,7 @@ namespace Bug12935
 				/* seperateApk */ true,
 				/* abis */ "armeabi-v7a;x86",
 				/* versionCode */ "12",
+				/* useLagacy */ false,
 				/* pattern */ "{abi}{minSDK:00}{screen}{foo:00}{versionCode:000}",
 				/* props */ "screen=24;foo=$(Foo)",
 				/* shouldBuild */ false,
@@ -360,7 +390,7 @@ namespace Bug12935
 
 		[Test]
 		[TestCaseSource("VersionCodeTestSource")]
-		public void VersionCodeTests (bool seperateApk, string abis, string versionCode, string versionCodePattern, string versionCodeProperties, bool shouldBuild, string expectedVersionCode)
+		public void VersionCodeTests (bool seperateApk, string abis, string versionCode, bool useLegacy, string versionCodePattern, string versionCodeProperties, bool shouldBuild, string expectedVersionCode)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
@@ -377,6 +407,8 @@ namespace Bug12935
 				proj.SetProperty (proj.ReleaseProperties, "AndroidVersionCodeProperties", versionCodeProperties);
 			else
 				proj.RemoveProperty (proj.ReleaseProperties, "AndroidVersionCodeProperties");
+			if (useLegacy)
+				proj.SetProperty (proj.ReleaseProperties, "AndroidUseLegacyVersionCode", true);
 			proj.AndroidManifest = proj.AndroidManifest.Replace ("android:versionCode=\"1\"", $"android:versionCode=\"{versionCode}\"");
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", "VersionCodeTests"), false, false)) {
 				builder.ThrowOnBuildFailure = false;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -943,7 +943,7 @@ namespace Xamarin.Android.Tasks {
 				throw new ArgumentOutOfRangeException ("VersionCode", $"VersionCode {versionCode} is invalid. It must be an integer value.");
 			if (code > maxVersionCode || code < 0)
 				throw new ArgumentOutOfRangeException ("VersionCode", $"VersionCode {code} is outside 0, {maxVersionCode} interval");
-			VersionCode = versionCode;
+			VersionCode = versionCode.TrimStart ('0');
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -7,5 +7,6 @@
 		<YieldDuringToolExecution Condition="'$(YieldDuringToolExecution)' == ''">true</YieldDuringToolExecution>
 		<LatestSupportedJavaVersion>1.8.0</LatestSupportedJavaVersion>
 		<MinimumSupportedJavaVersion>1.6.0</MinimumSupportedJavaVersion>
+		<AndroidVersionCodePattern Condition=" '$(AndroidUseLegacyVersionCode)' != 'True' And '$(AndroidVersionCodePattern)' == '' ">{abi}{versionCode:D5}</AndroidVersionCodePattern>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
The new versionCode system introduced in commit 0a2f008c is now on by default.
The default code is

	`{abi}{versionCode:D6}`

For a versionCode of `123` the default will produce a code of `123`
for a full .apk and `200123`, `300123`, etc for split abi .apks.

Developers can revert to the existing behaviour by setting

	`<AndroidUseLegacyVersionCode>true</AndroidUseLegacyVersionCode>`

in their .csproj. This will revert to the existng behaviour by NOT
setting the default value for `AndroidVersionCodePattern`.