### PR TITLE
[Xamarin.Android.Build.Tasks] Crash when using NetStandard and Xamarin.Forms

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -76,6 +76,10 @@ namespace Xamarin.Android.Tasks
 					var assemblyDef = resolver.Load (assembly.ItemSpec);
 					if (assemblyDef == null)
 						throw new InvalidOperationException ("Failed to load assembly " + assembly.ItemSpec);
+					if (MonoAndroidHelper.IsReferenceAssembly (assemblyDef)) {
+						Log.LogWarning ($"Ignoring {assembly_path} as it is a Reference Assembly");
+						continue;
+					}
 					topAssemblyReferences.Add (assemblyDef);
 					assemblies.Add (Path.GetFullPath (assemblyDef.MainModule.FullyQualifiedName));
 				}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -303,10 +303,15 @@ namespace Xamarin.Android.Tasks
 
 		public static bool IsReferenceAssembly (string assembly)
 		{
-			var a = AssemblyDefinition.ReadAssembly (assembly, new ReaderParameters() { InMemory = true, ReadSymbols = false, });
-			if (!a.HasCustomAttributes)
+			var a = AssemblyDefinition.ReadAssembly (assembly, new ReaderParameters () { InMemory = true, ReadSymbols = false, });
+			return IsReferenceAssembly (a);
+		}
+
+		public static bool IsReferenceAssembly (AssemblyDefinition assembly)
+		{
+			if (!assembly.HasCustomAttributes)
 				return false;
-			return a.CustomAttributes.Any (t => t.AttributeType.FullName == "System.Runtime.CompilerServices.ReferenceAssemblyAttribute");
+			return assembly.CustomAttributes.Any (t => t.AttributeType.FullName == "System.Runtime.CompilerServices.ReferenceAssemblyAttribute");
 		}
 
 		public static bool ExistsInFrameworkPath (string assembly)

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1493,10 +1493,9 @@ because xbuild doesn't support framework reference assemblies.
 		<FilteredAssemblies Include="$(OutDir)$(TargetFileName)"
 				Condition="Exists ('$(OutDir)$(TargetFileName)')" />
 		<FilteredAssemblies Include="%(ReferenceCopyLocalPaths.Identity)"
-				Condition="'%(ReferenceCopyLocalPaths.ResolvedFrom)' != 'ImplicitlyExpandDesignTimeFacades' And '%(ReferenceCopyLocalPaths.Extension)' == '.dll' And '%(ReferenceCopyLocalPaths.DestinationSubDirectory)' == '' "/>
-		<!-- Fallback to @(ReferencePath) if @(ReferenceCopyLocalPaths) is empty. This is for xbuild support -->
+				Condition="'%(ReferenceCopyLocalPaths.ResolvedFrom)' != 'ImplicitlyExpandDesignTimeFacades' And '%(ReferenceCopyLocalPaths.Extension)' == '.dll' And '%(ReferenceCopyLocalPaths.RelativeDir)' == '' "/>
 		<FilteredAssemblies Include="%(ReferencePath.Identity)"
-				Condition="'%(ReferencePath.ResolvedFrom)' != 'ImplicitlyExpandDesignTimeFacades' And '@(ReferenceCopyLocalPaths)' == '' "/>
+				Condition="'%(ReferencePath.ResolvedFrom)' != 'ImplicitlyExpandDesignTimeFacades' "/>
 	</ItemGroup>
 	<!-- Find all the assemblies this app requires -->
 	<ResolveAssemblies


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=57342

Commit 8f2ae248 attempted to fix this issue. However it made the
assumption that `@(ReferenceCopyLocalPaths)` contained the same
items as `@(ReferencePath)`. However it did not. So we should use
a combination of the two to figure out what assmeblies are needed.
We need to disgard reference assemblies though, we do this by
checking for the appropriate attributes before we add the assembly
to the list of items we want to package.