### PR TITLE
[windows] fixes NuGet restore on Windows

### DIFF
--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -30,5 +30,6 @@
     <Exec Command="$(_NuGet) restore Xamarin.Android.sln" WorkingDirectory="$(_TopDir)" />
     <Exec Command="$(_NuGet) restore external\Java.Interop\Java.Interop.sln" WorkingDirectory="$(_TopDir)" />
     <Exec Command="$(_NuGet) restore external\LibZipSharp\libZipSharp.sln" WorkingDirectory="$(_TopDir)" />
+    <Exec Command="$(_NuGet) restore external\xamarin-android-tools\Xamarin.Android.Tools.sln" WorkingDirectory="$(_TopDir)" />
   </Target>
 </Project>


### PR DESCRIPTION
There are some additinonal NuGet packages needed in Xamarin.Android.sln
we can install by restoring Xamarin.Android.Tools.sln

Fixes Windows build on master: https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=988121