### PR TITLE
[linker] Improve logging

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
@@ -142,8 +142,7 @@ namespace MonoDroid.Tuner
 				var iface    = ifaceInfo.InterfaceType;
 				var ifaceDef = iface.Resolve ();
 				if (ifaceDef == null) {
-					if (Context.LogInternalExceptions)
-						Console.WriteLine ("Unable to unresolve interface: {0}", iface.FullName);
+					Context.LogMessage ("Unable to unresolve interface: {0}", iface.FullName);
 					continue;
 				}
 				if (ifaceDef.HasGenericParameters)
@@ -191,8 +190,7 @@ namespace MonoDroid.Tuner
 
 			type.Methods.Add (newMethod);
 
-			if (Context.LogInternalExceptions)
-				Console.WriteLine ("Added method: {0} to type: {1} scope: {2}", method, type.FullName, type.Scope);
+			Context.LogMessage ("Added method: {0} to type: {1} scope: {2}", method, type.FullName, type.Scope);
 		}
 
 		MethodReference abstractMethodErrorConstructor;

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
@@ -15,7 +15,7 @@ namespace MonoDroid.Tuner
 {
 	class Linker
 	{
-		public static void Process (LinkerOptions options, out LinkContext context)
+		public static void Process (LinkerOptions options, ILogger logger, out LinkContext context)
 		{
 			var pipeline = CreatePipeline (options);
 
@@ -24,7 +24,7 @@ namespace MonoDroid.Tuner
 				foreach (var assembly in options.RetainAssemblies)
 					pipeline.PrependStep (new ResolveFromAssemblyStep (assembly));
 
-			context = CreateLinkContext (options, pipeline);
+			context = CreateLinkContext (options, pipeline, logger);
 			context.Resolver.AddSearchDirectory (options.OutputDirectory);
 
 			Run (pipeline, context);
@@ -35,7 +35,7 @@ namespace MonoDroid.Tuner
 			pipeline.Process (context);
 		}
 
-		static LinkContext CreateLinkContext (LinkerOptions options, Pipeline pipeline)
+		static LinkContext CreateLinkContext (LinkerOptions options, Pipeline pipeline, ILogger logger)
 		{
 			var context = new LinkContext (pipeline, options.Resolver);
 			if (options.DumpDependencies) {
@@ -43,7 +43,8 @@ namespace MonoDroid.Tuner
 				if (prepareDependenciesDump != null)
 					prepareDependenciesDump.Invoke (context.Annotations, null);
 			}
-			context.LogInternalExceptions = Xamarin.Android.Tasks.MonoAndroidHelper.LogInternalExceptions;
+			context.LogInternalExceptions = true;
+			context.Logger = logger;
 			context.CoreAction = AssemblyAction.Link;
 			context.LinkSymbols = true;
 			context.SymbolReaderProvider = new DefaultSymbolReaderProvider (true);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -357,6 +357,12 @@
     <Compile Include="$(LinkerSourceFullPath)\linker\Mono.Linker\MarkException.cs">
       <Link>Linker\Mono.Linker\MarkException.cs</Link>
     </Compile>
+    <Compile Include="$(LinkerSourceFullPath)\linker\Mono.Linker\ConsoleLogger.cs">
+      <Link>Linker\Mono.Linker\ConsoleLogger.cs</Link>
+    </Compile>
+    <Compile Include="$(LinkerSourceFullPath)\linker\Mono.Linker\ILogger.cs">
+      <Link>Linker\Mono.Linker\ILogger.cs</Link>
+    </Compile>
     <Compile Include="Tasks\MergeResources.cs" />
     <Compile Include="Tasks\GetConvertedJavaLibraries.cs" />
     <Compile Include="Tasks\JavaCompileToolTask.cs" />


### PR DESCRIPTION
Implement linker's new ILogger interface to log linker messages in the
LinkAssemblies task. This way we can see the linker messages in the
diagnostic build output, without the need to set the __XA_LOG_ERRORS__
environment variable.

This way we can see for example messages from the
FixAbstractMethodsStep, so we know whether any assemblies were
modified when the linker mode was set to None. (like we do in default
Debug configuration) That is handy when we are trying to decide
whether a bug is related to or caused by the linker.