### PR TITLE
[tests] Xamarin.Android-Tests.sln builds on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.userprefs
+*.user
 bin
 Configuration.Override.props
 Configuration.OperatingSystem.props
@@ -11,6 +12,7 @@ TestResult.xml
 TestResult-*.xml
 TestResult-*.csv
 .vs/
+.gradle/
 Resource.designer.cs
 logcat-*.txt
 apk-sizes-*.txt

--- a/Configuration.props
+++ b/Configuration.props
@@ -68,6 +68,7 @@
     <AllSupportedTargetAndroidAbis>$(AllSupported32BitTargetAndroidAbis);$(AllSupported64BitTargetAndroidAbis)</AllSupportedTargetAndroidAbis>
     <XABuildToolsVersion>26.0.1</XABuildToolsVersion>
     <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">26.0.1</XABuildToolsFolder>
+    <XAIntegratedTests Condition="'$(XAIntegratedTests)' == ''">True</XAIntegratedTests>
     <PathSeparator>$([System.IO.Path]::PathSeparator)</PathSeparator>
   </PropertyGroup>
   <PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ and `$(TargetFrameworkVersion)`s. If you want a complete environment --
 
     make jenkins
 
-Unit tests are build in a separate target:
+Unit tests are built in a separate target:
 
     make all-tests
 
@@ -251,7 +251,11 @@ To build Xamarin.Android, ensure you are using MSBuild version 15+ and run:
 
 These are roughly the same as how `make prepare` and `make` are used on other platforms.
 
-_NOTE: there is not currently an equivalent of `make jenkins` or `make all-tests` on Windows._
+Unit tests are built on Windows via:
+
+    msbuild Xamarin.Android-Tests.sln /p:XAIntegratedTests=False 
+
+_NOTE: there is not currently an equivalent of `make jenkins` on Windows._
 
 _Troubleshooting: Ensure you check your MSBuild version(`msbuild -version`) and path for the proper version of MSBuild._
 

--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -28,6 +28,7 @@
         Replacements="@JAVA_HOME@=$(_JavaSdkDirectory)"
     />
     <Exec Command="$(_NuGet) restore Xamarin.Android.sln" WorkingDirectory="$(_TopDir)" />
+    <Exec Command="$(_NuGet) restore Xamarin.Android-Tests.sln" WorkingDirectory="$(_TopDir)" />
     <Exec Command="$(_NuGet) restore external\Java.Interop\Java.Interop.sln" WorkingDirectory="$(_TopDir)" />
     <Exec Command="$(_NuGet) restore external\LibZipSharp\libZipSharp.sln" WorkingDirectory="$(_TopDir)" />
     <Exec Command="$(_NuGet) restore external\xamarin-android-tools\Xamarin.Android.Tools.sln" WorkingDirectory="$(_TopDir)" />

--- a/src/Mono.Android/Test/Mono.Android-Tests.csproj
+++ b/src/Mono.Android/Test/Mono.Android-Tests.csproj
@@ -108,13 +108,13 @@
       <Private>False</Private>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\..\Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj">
+    <ProjectReference Include="..\..\Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj" Condition=" '$(XAIntegratedTests)' == 'True' ">
       <Name>Xamarin.Android.Build.Tasks</Name>
       <Project>{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}</Project>
       <Private>False</Private>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\..\Xamarin.Android.NUnitLite\Xamarin.Android.NUnitLite.csproj">
+    <ProjectReference Include="..\..\Xamarin.Android.NUnitLite\Xamarin.Android.NUnitLite.csproj" Condition=" '$(XAIntegratedTests)' == 'True' ">
       <Name>Xamarin.Android.NUnitLite</Name>
       <Project>{4D603AA3-3BFD-43C8-8050-0CD6C2601126}</Project>
       <Private>False</Private>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -119,7 +119,7 @@
     />
   </Target>
   <Target Name="_GenerateXACommonProps"
-      DependsOnTargets="GetXAVersionInfo"
+      DependsOnTargets="ResolveReferences;GetXAVersionInfo"
       BeforeTargets="DeployOutputFiles"
       Inputs="Xamarin.Android.Common.props.in"
       Outputs="Xamarin.Android.Common.props">

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
@@ -11,7 +11,7 @@
     <Exec Command="&quot;$(NdkBuildPath)&quot;" />
     <MakeDir Directories="$(OutputPath)\native-lib-1" />
     <Exec
-        Command="zip -r ../$(OutputPath)/native-lib-1/NativeLib.zip arm64-v8a armeabi armeabi-v7a x86 x86_64"
+        Command="&quot;$(JarPath)&quot; cf ../$(OutputPath)/native-lib-1/NativeLib.zip arm64-v8a armeabi armeabi-v7a x86 x86_64"
         WorkingDirectory="libs"
     />
   </Target>
@@ -30,11 +30,11 @@
     <MakeDir Directories="$(OutputPath)\native-lib-2" />
     <MakeDir Directories="$(OutputPath)\native-lib-2\aar-test" />
     <Exec
-        Command="zip -r ../../$(OutputPath)/native-lib-2/aar-test/EmbeddedNativeLib.zip arm64-v8a armeabi armeabi-v7a x86 x86_64"
+        Command="&quot;$(JarPath)&quot; cf ../../$(OutputPath)/native-lib-2/aar-test/EmbeddedNativeLib.zip arm64-v8a armeabi armeabi-v7a x86 x86_64"
         WorkingDirectory="simple2/libs"
     />
     <Exec
-        Command="zip -r NativeLib2.zip aar-test"
+        Command="&quot;$(JarPath)&quot; cf NativeLib2.zip aar-test"
         WorkingDirectory="$(OutputPath)\native-lib-2"
     />
   </Target>

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib1/Xamarin.Android.BindingResolveImportLib1.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib1/Xamarin.Android.BindingResolveImportLib1.csproj
@@ -60,10 +60,10 @@
   </PropertyGroup>
   <Target Name="BuildJar" Inputs="Jars/com/xamarin/android/test/binding/resolveimport/Lib1.java" Outputs="Jars/lib1.zip">
     <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d Jars -sourcepath Jars Jars/com/xamarin/android/test/binding/resolveimport/Lib1.java" />
-    <Exec WorkingDirectory="Jars" Command="zip -r lib1.jar com" />
+    <Exec WorkingDirectory="Jars" Command="&quot;$(JarPath)&quot; cf lib1.jar com" />
     <MakeDir Directories="Jars/zipped;Jars/zipped/bin" />
     <Copy SourceFiles="Jars/lib1.jar;Properties/AndroidManifest.xml" DestinationFiles="Jars/zipped/bin/lib1.jar;Jars/zipped/bin/AndroidManifest.xml" />
-    <Exec WorkingDirectory="Jars/zipped" Command="zip -r lib1.zip bin" />
+    <Exec WorkingDirectory="Jars/zipped" Command="&quot;$(JarPath)&quot; cf lib1.zip bin" />
     <Copy SourceFiles="Jars/zipped/lib1.zip" DestinationFiles="Jars/lib1.zip" />
   </Target>
   <Target Name="CleanJar">

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib2/Xamarin.Android.BindingResolveImportLib2.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib2/Xamarin.Android.BindingResolveImportLib2.csproj
@@ -78,7 +78,7 @@
   </PropertyGroup>
   <Target Name="BuildJar" Inputs="Jars/com/xamarin/android/test/binding/resolveimport/Lib2.java" Outputs="Jars/lib2.jar">
     <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d Jars -sourcepath Jars Jars/com/xamarin/android/test/binding/resolveimport/Lib2.java" />
-    <Exec WorkingDirectory="Jars" Command="zip -r lib2.jar com" />
+    <Exec WorkingDirectory="Jars" Command="&quot;$(JarPath)&quot; cf lib2.jar com" />
   </Target>
   <Target Name="CleanJar">
     <RemoveDir Directories="Jars/bin" />

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib3/Xamarin.Android.BindingResolveImportLib3.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib3/Xamarin.Android.BindingResolveImportLib3.csproj
@@ -78,10 +78,10 @@
   </PropertyGroup>
   <Target Name="BuildJar" Inputs="Jars/com/xamarin/android/test/binding/resolveimport/Lib3.java" Outputs="Jars/lib3.zip">
     <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d Jars -sourcepath Jars Jars/com/xamarin/android/test/binding/resolveimport/Lib3.java" />
-    <Exec WorkingDirectory="Jars" Command="zip -r lib3.jar com" />
+    <Exec WorkingDirectory="Jars" Command="&quot;$(JarPath)&quot; cf lib3.jar com" />
     <MakeDir Directories="Jars/zipped;Jars/zipped/bin" />
     <Copy SourceFiles="Jars/lib3.jar;Properties/AndroidManifest.xml" DestinationFiles="Jars/zipped/bin/lib3.jar;Jars/zipped/bin/AndroidManifest.xml" />
-    <Exec WorkingDirectory="Jars/zipped" Command="zip -r lib3.zip bin" />
+    <Exec WorkingDirectory="Jars/zipped" Command="&quot;$(JarPath)&quot; cf lib3.zip bin" />
     <Copy SourceFiles="Jars/zipped/lib3.zip" DestinationFiles="Jars/lib3.zip" />
   </Target>
   <Target Name="CleanJar">

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib4/Xamarin.Android.BindingResolveImportLib4.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib4/Xamarin.Android.BindingResolveImportLib4.csproj
@@ -76,7 +76,7 @@
   </PropertyGroup>
   <Target Name="BuildJar" Inputs="Jars/com/xamarin/android/test/binding/resolveimport/Lib4.java" Outputs="Jars/lib4.jar">
     <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d Jars -sourcepath Jars Jars/com/xamarin/android/test/binding/resolveimport/Lib4.java" />
-    <Exec WorkingDirectory="Jars" Command="zip -r lib4.jar com" />
+    <Exec WorkingDirectory="Jars" Command="&quot;$(JarPath)&quot; cf lib4.jar com" />
   </Target>
   <Target Name="CleanJar">
     <RemoveDir Directories="Jars/bin" />


### PR DESCRIPTION
- Needed to NuGet restore Xamarin.Android-Tests.sln
- Added `XAIntegratedTests` property which defaults to true. Windows
will need to set this property in order to build
Xamarin.Android-Tests.sln
- Some project references in Mono.Android-Tests.csproj should be
conditional against `XAIntegratedTests`
- Usage of `zip -r` is replaced with `jar cf` using `$(JarPath)`
- Xamarin.Android.Build.Tasks.csproj had a file-locking issue similar to
create-vsix.csproj: the `_GenerateXACommonProps` target needs to depend
on `ResolveReferences`

Other changes:
- Updated README
- Updated .gitignore for `.gradle/` and `*.user` files