### PR TITLE
[setup-windows] links for Xamarin.Android.Sdk.props/targets

### DIFF
--- a/Documentation/UsingJenkinsBuildArtifacts.md
+++ b/Documentation/UsingJenkinsBuildArtifacts.md
@@ -114,6 +114,8 @@ Within the elevated command prompt, execute the `setup-windows.exe` program:
 	Executing: MKLINK /D "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid" "C:\xa-sdk\oss-xamarin.android_v7.4.99.57_Darwin-x86_64_master_97f08f7\bin\Debug\lib\xamarin.android\xbuild-frameworks\MonoAndroid"
 	Executing: MKLINK /D "C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\MonoAndroid" "C:\xa-sdk\oss-xamarin.android_v7.4.99.57_Darwin-x86_64_master_97f08f7\bin\Debug\lib\xamarin.android\xbuild-frameworks\MonoAndroid"
 	Executing: MKLINK /D "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\Xamarin\Android" "C:\xa-sdk\oss-xamarin.android_v7.4.99.57_Darwin-x86_64_master_97f08f7\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android"
+	Executing: MKLINK "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\Xamarin\Xamarin.Android.Sdk.props" "C:\xa-sdk\oss-xamarin.android_v7.4.99.57_Darwin-x86_64_master_97f08f7\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Xamarin.Android.Sdk.props"
+	Executing: MKLINK "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\Xamarin\Xamarin.Android.Sdk.targets" "C:\xa-sdk\oss-xamarin.android_v7.4.99.57_Darwin-x86_64_master_97f08f7\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Xamarin.Android.Sdk.targets"
 	Success!
 
 To uninstall, run `setup-windows.exe /uninstall`:

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -40,6 +40,12 @@
     </None>
     <None
         Condition=" '$(OS)' == 'Windows_NT' "
+        Include="MSBuild\Xamarin\Xamarin.Android.Sdk.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>..\Xamarin.Android.Sdk.targets</Link>
+    </None>
+    <None
+        Condition=" '$(OS)' == 'Windows_NT' "
         Include="MSBuild\Xamarin\Android\Xamarin.Android.Bindings.Before.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Xamarin.Android.Bindings.Before.targets</Link>


### PR DESCRIPTION
We need to create symbolic links for Xamarin.Android.Sdk.props and
Xamarin.Android.Sdk.targets so you can test changes to these files on
Windows.

Changes:
- Xamarin.Android.Sdk.targets needs to be copied to build output on
Windows
- setup-windows refactored to support both files & directories
- setup-windows now links the additional files
- Updated example output in documentation