### PR TITLE
[Xamarin.Android.Build.Tests] Ignore AOT tests if compiler is not available.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.OSS.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.OSS.cs
@@ -14,6 +14,16 @@ namespace Xamarin.Android.Build.Tests
 #pragma warning disable 414
 		static object [] AotChecks = new object [] {
 			new object[] {
+				/* supportedAbis */   "armeabi",
+				/* enableLLVM */      false,
+				/* expectedResult */  true,
+			},
+			new object[] {
+				/* supportedAbis */   "armeabi",
+				/* enableLLVM */      true,
+				/* expectedResult */  true,
+			},
+			new object[] {
 				/* supportedAbis */   "armeabi-v7a",
 				/* enableLLVM */      false,
 				/* expectedResult */  true,
@@ -24,12 +34,32 @@ namespace Xamarin.Android.Build.Tests
 				/* expectedResult */  true,
 			},
 			new object[] {
+				/* supportedAbis */   "arm64-v8a",
+				/* enableLLVM */      false,
+				/* expectedResult */  true,
+			},
+			new object[] {
+				/* supportedAbis */   "arm64-v8a",
+				/* enableLLVM */      true,
+				/* expectedResult */  true,
+			},
+			new object[] {
 				/* supportedAbis */   "x86",
 				/* enableLLVM */      false,
 				/* expectedResult */  true,
 			},
 			new object[] {
 				/* supportedAbis */   "x86",
+				/* enableLLVM */      true,
+				/* expectedResult */  true,
+			},
+			new object[] {
+				/* supportedAbis */   "x86_64",
+				/* enableLLVM */      false,
+				/* expectedResult */  true,
+			},
+			new object[] {
+				/* supportedAbis */   "x86_64",
 				/* enableLLVM */      true,
 				/* expectedResult */  true,
 			},

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -222,7 +222,9 @@ printf ""%d"" x
 			}
 			using (var b = CreateApkBuilder (path)) {
 				if (!b.CrossCompilerAvailable (supportedAbis))
-					Assert.Ignore ("Cross compiler was not available");
+					Assert.Ignore ($"Cross compiler for {supportedAbis} was not available");
+				if (!b.GetSupportedRuntimes ().Any (x => supportedAbis == x.Abi))
+					Assert.Ignore ($"Runtime for {supportedAbis} was not available.");
 				b.ThrowOnBuildFailure = false;
 				b.Verbosity = LoggerVerbosity.Diagnostic;
 				Assert.AreEqual (expectedResult, b.Build (proj), "Build should have {0}.", expectedResult ? "succeeded" : "failed");
@@ -281,6 +283,8 @@ printf ""%d"" x
 			using (var b = CreateApkBuilder (path)) {
 				if (!b.CrossCompilerAvailable (supportedAbis))
 					Assert.Ignore ("Cross compiler was not available");
+				if (!b.GetSupportedRuntimes ().Any (x => supportedAbis == x.Abi))
+					Assert.Ignore ($"Runtime for {supportedAbis} was not available.");
 				b.ThrowOnBuildFailure = false;
 				Assert.AreEqual (expectedResult, b.Build (proj), "Build should have {0}.", expectedResult ? "succeeded" : "failed");
 				if (!expectedResult)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.OSS.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.OSS.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+using Xamarin.ProjectTools;
+using System.IO;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using Xamarin.Tools.Zip;
+
+namespace Xamarin.Android.Build.Tests
+{
+	public partial class ManifestTest : BaseTest
+	{
+		static object [] DebuggerAttributeCases = new object [] {
+			// DebugType, isRelease, extpected
+			new object[] { "", true, false, },
+			new object[] { "", false, true, },
+			new object[] { "None", true, false, },
+			new object[] { "None", false, false, },
+			new object[] { "PdbOnly", true, false, },
+			new object[] { "PdbOnly", false, true, },
+			new object[] { "Full", true, false, },
+			new object[] { "Full", false, true, },
+			new object[] { "Portable", true, false, },
+			new object[] { "Portable", false, true, },
+		};
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -10,7 +10,7 @@ using Xamarin.Tools.Zip;
 
 namespace Xamarin.Android.Build.Tests
 {
-	public class ManifestTest : BaseTest
+	public partial class ManifestTest : BaseTest
 	{
 		readonly string TargetSdkManifest = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <manifest xmlns:android=""http://schemas.android.com/apk/res/android"" android:versionCode=""1"" android:versionName=""1.0"" package=""Bug12935.Bug12935"">
@@ -435,20 +435,6 @@ namespace Bug12935
 				Assert.IsTrue (manifest.Contains ("AAAAAAAA"), "#1");
 			}
 		}
-
-		static object[] DebuggerAttributeCases = new object[] {
-			// DebugType, isRelease, extpected
-			new object[] { "", true, false, },
-			new object[] { "", false, true, },
-			new object[] { "None", true, false, },
-			new object[] { "None", false, false, },
-			new object[] { "PdbOnly", true, false, },
-			new object[] { "PdbOnly", false, true, },
-			new object[] { "Full", true, false, },
-			new object[] { "Full", false, true, },
-			new object[] { "Portable", true, false, },
-			new object[] { "Portable", false, true, },
-		};
 
 		[Test]
 		[TestCaseSource ("DebuggerAttributeCases")]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -58,5 +58,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BuildTest.OSS.cs" />
+    <Compile Include="ManifestTest.OSS.cs" />
   </ItemGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -121,7 +121,7 @@ namespace Xamarin.ProjectTools
 			var runtimeInfo = new List<RuntimeInfo> ();
 			var outdir = FrameworkLibDirectory;
 			var path = Path.Combine (outdir, IsUnix ? Path.Combine ("xbuild", "Xamarin", "Android", "lib") : "");
-			foreach (var file in Directory.EnumerateFiles (path, "libmono-android.*.*.so", SearchOption.AllDirectories)) {
+			foreach (var file in Directory.EnumerateFiles (path, "libmono-android.*.so", SearchOption.AllDirectories)) {
 				string fullFilePath = Path.GetFullPath (file);
 				DirectoryInfo parentDir = Directory.GetParent (fullFilePath);
 				if (parentDir == null)

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -177,7 +177,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">MonoAndroid</TargetFrameworkIdentifier>
 	<MonoAndroidVersion>v$(_XAMajorVersionNumber).0</MonoAndroidVersion>
 	<AndroidUpdateResourceReferences Condition="'$(AndroidUpdateResourceReferences)' == ''">True</AndroidUpdateResourceReferences>
-	<EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' Or '$(_XASupportsFastDev)' == 'False' ">True</EmbedAssembliesIntoApk>
+	<EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' And '$(Optimize)' != 'True' And '$(_XASupportsFastDev)' == 'True' ">False</EmbedAssembliesIntoApk>
+	<EmbedAssembliesIntoApk Condition=" '$(_XASupportsFastDev)' == 'False' ">True</EmbedAssembliesIntoApk>
 	<AndroidPreferNativeLibrariesWithDebugSymbols Condition=" '$(AndroidPreferNativeLibrariesWithDebugSymbols)' == '' ">False</AndroidPreferNativeLibrariesWithDebugSymbols>
 	<AndroidSkipJavacVersionCheck Condition="'$(AndroidSkipJavacVersionCheck)' == ''">False</AndroidSkipJavacVersionCheck>
 	<AndroidBuildApplicationPackage Condition=" '$(AndroidBuildApplicationPackage)' == ''">False</AndroidBuildApplicationPackage>


### PR DESCRIPTION
This commit makes a number of changes to the unit tests to allow us
to handle different behaviour between x-a and monodroid.
Firstly we can now ignore AOT based tests if the compilers or
runtime is not available. This means we can share the test inputs
between repos.
We also split out the Debugger Attribute test inputs into a ManifestTest.OSS.cs
file to we can provide different inputs in monodroid. This is because
there is a difference in behaviour between the two systems. In certain
cases in monodroid we DO want a debug runtime/attribute where in x-a
we never do. For exmaple in x-a having DebugSymbols = 'None', EmbedAssemblies=False
and Optimize = False will result in the DebugAttribute not being
added. This is correct behaviour for x-a because we ALWAYS embed
assemblies regardless of the user setting.

In monodroid hower that is incorrect. So we need seperate test cases.

This commit also moves some of the logic to do with EmbedAssemblies into
the Xamarin.Android.Common.targets. This is protected bu the `$(_XASupportsFastDev)`
property. Again it means the logic is all in one place rather than
being split up across .targets. This should make it easier to maintain.