### PR TITLE
[Xamarin.Android.Build.Tests] Don't clean up the test while debugging.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -182,7 +182,7 @@ namespace Xamarin.Android.Build.Tests
 		[TearDown]
 		protected virtual void CleanupTest ()
 		{
-			if (TestContext.CurrentContext.Test.Properties ["Output"] == null)
+			if (System.Diagnostics.Debugger.IsAttached || TestContext.CurrentContext.Test.Properties ["Output"] == null)
 					return;
 			// find the "root" directory just below "temp" and clean from there because
 			// some tests create multiple subdirectories


### PR DESCRIPTION
One annoying thing when developing tests is if you have a failing
test you have to modify the source code to stop it being cleaned up.
This commit checks to see if the Debugger is attached before cleaning
up. If it is attached the source code for the test will not be removed.
This will allow the developer to examine the results.