### PR TITLE
[Xamarin.Android.Build.Tasks] Allow Debugging.Tasks to access GetPaths

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/GdbPaths.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/GdbPaths.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Xamarin.Android.Tools
 {
-	enum AndroidDebugServer
+	public enum AndroidDebugServer
 	{
 		/// GNU's GDB debug server (provided by Android NDK)
 		Gdb,
@@ -13,7 +13,7 @@ namespace Xamarin.Android.Tools
 		Llgs
 	}
 		
-	class GdbPaths
+	public class GdbPaths
 	{
 		public static AndroidDebugServer? GetAndroidDebugServer (string name)
 		{


### PR DESCRIPTION
Commit b16ee559 made GdbPaths private. But it is needed/used by
the monodroid repo. This commit makes it `public` and allows
the `Xamarin.Android.Build.Debugging.Tasks` access it.