### PR TITLE
fix bug #51664 - change GlobalAction to Action where appropriate.

### DIFF
--- a/build-tools/enumification-helpers/methodmap.ext.csv
+++ b/build-tools/enumification-helpers/methodmap.ext.csv
@@ -744,9 +744,9 @@
 16, android.view.accessibility, AccessibilityNodeInfo, focusSearch, direction, Android.Views.FocusSearchDirection
 16, android.view.accessibility, AccessibilityNodeInfo, getMovementGranularities, return, Android.Views.Accessibility.MovementGranularity
 16, android.view.accessibility, AccessibilityNodeInfo, setMovementGranularities, granularities, Android.Views.Accessibility.MovementGranularity
-16, android.view.accessibility, AccessibilityNodeProvider, performAction, action, Android.AccessibilityServices.GlobalAction
-16, android.view, View, performAccessibilityAction, action, Android.AccessibilityServices.GlobalAction
-16, android.view, View.AccessibilityDelegate, performAccessibilityAction, action, Android.AccessibilityServices.GlobalAction
+16, android.view.accessibility, AccessibilityNodeProvider, performAction, action, Android.Views.Accessibility.Action
+16, android.view, View, performAccessibilityAction, action, Android.Views.Accessibility.Action
+16, android.view, View.AccessibilityDelegate, performAccessibilityAction, action, Android.Views.Accessibility.Action
 16, android.view, View, getImportantForAccessibility, return, Android.Views.ImportantForAccessibility
 16, android.view, View, setImportantForAccessibility, mode, Android.Views.ImportantForAccessibility
 16, android.view, View, getWindowSystemUiVisibility, return, Android.Views.SystemUiFlags

--- a/src/Mono.Android/Android.Views.Accessibility/AccessibilityEvent.cs
+++ b/src/Mono.Android/Android.Views.Accessibility/AccessibilityEvent.cs
@@ -1,6 +1,17 @@
+using System;
+using Android.AccessibilityServices;
+
 namespace Android.Views.Accessibility {
 
 	partial class AccessibilityEvent {
+
+#if ANDROID_16
+		[Obsolete ("This maps to incorrect type. Use GetAction() and SetAction() until we fix the API")]
+		public GlobalAction Action {
+			get { return (GlobalAction) GetAction (); }
+			set { SetAction ((GlobalAction) value); }
+		}
+#endif // ANDROID_16
 
 #if ANDROID_14
 		public new string BeforeText {

--- a/src/Mono.Android/Android.Views.Accessibility/AccessibilityNodeProvider.cs
+++ b/src/Mono.Android/Android.Views.Accessibility/AccessibilityNodeProvider.cs
@@ -1,0 +1,17 @@
+using System;
+using Android.AccessibilityServices;
+using Android.OS;
+
+namespace Android.Views.Accessibility
+{
+	public partial class AccessibilityNodeProvider
+	{
+#if ANDROID_16
+		public bool PerformAction (int virtualViewId, GlobalAction action, Bundle arguments)
+		{
+			return PerformAction (virtualViewId, (Action) action, arguments);
+		}
+#endif
+	}
+}
+

--- a/src/Mono.Android/Android.Views/View.AccessibilityDelegate.cs
+++ b/src/Mono.Android/Android.Views/View.AccessibilityDelegate.cs
@@ -1,0 +1,21 @@
+using System;
+using Android.AccessibilityServices;
+using Android.OS;
+
+namespace Android.Views
+{
+	public partial class View
+	{
+		public partial class AccessibilityDelegate
+		{
+#if ANDROID_16
+			[Obsolete ("This method takes incorrect enum type. Please use PerformAccessibilityAction() overload with Action instead.")]
+			public bool PerformAccessibilityAction (View host, GlobalAction action, Bundle args)
+			{
+				return PerformAccessibilityAction (host, (Android.Views.Accessibility.Action) (int) action, args);
+			}
+		}
+#endif
+	}
+}
+

--- a/src/Mono.Android/Android.Views/View.cs
+++ b/src/Mono.Android/Android.Views/View.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using Android.AccessibilityServices;
+using Android.OS;
 using Android.Runtime;
 
 namespace Android.Views {
@@ -10,6 +12,14 @@ namespace Android.Views {
 #endif
 
 	public partial class View {
+
+#if ANDROID_16
+		[Obsolete ("This method uses wrong enum type. Please use PerformAccessibilityAction(Action) instead.")]
+		public bool PerformAccessibilityAction (GlobalAction action, Bundle arguments)
+		{
+			return PerformAccessibilityAction ((Android.Views.Accessibility.Action) (int) action, arguments);
+		}
+#endif
 
 		public T FindViewById<T> (int id)
 			where T : Android.Views.View

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -230,6 +230,7 @@
     <Compile Include="Android.Util\Base64OutputStream.cs" />
     <Compile Include="Android.Util\Log.cs" />
     <Compile Include="Android.Util\SparseArray.cs" />
+    <Compile Include="Android.Views\View.AccessibilityDelegate.cs" />
     <Compile Include="Android.Views\InputDevice.cs" />
     <Compile Include="Android.Views\KeyCharacterMap.cs" />
     <Compile Include="Android.Views\KeyEvent.cs" />
@@ -240,6 +241,7 @@
     <Compile Include="Android.Views\Window.cs" />
     <Compile Include="Android.Views.Accessibility\AccessibilityEvent.cs" />
     <Compile Include="Android.Views.Accessibility\AccessibilityManager.cs" />
+    <Compile Include="Android.Views.Accessibility\AccessibilityNodeProvider.cs" />
     <Compile Include="Android.Views.InputMethods\InputMethodManager.cs" />
     <Compile Include="Android.Widget\AbsListView.cs" />
     <Compile Include="Android.Widget\AdapterView.cs" />

--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -3,6 +3,14 @@
        regarded as obfuscated, so avoid that by explicitly marking not. -->
   <attr path="/api/package[@name='android']/class[@name='Manifest.permission']" name="obfuscated">false</attr>
 
+  <!-- FIXME: we should remove this fixup in the future release. It was
+  introduced due to mismatching enum use, and we already marked the API as
+  [Obsolete] -->
+  <attr path="/api/package[@name='android.view.accessibility']/class[@name='AccessibilityEvent']/method[@name='getAction']" name="propertyName"></attr>
+  <attr path="/api/package[@name='android.view.accessibility']/class[@name='AccessibilityEvent']/method[@name='setAction']" name="propertyName"></attr>
+  <attr path="/api/package[@name='android.view']/class[@name='View']/method[@name='getAccessibilityAction']" name="propertyName"></attr>
+  <attr path="/api/package[@name='android.view']/class[@name='View']/method[@name='setAccessibilityAction']" name="propertyName"></attr>
+
   <!-- FIXME: hack to workaround api-merge bug that brings two identical methods (it doesn't care generic type params) -->
   <remove-node path="/api/package[@name='android.animation']/interface[@name='TypeEvaluator']/method[@name='evaluate' and @merge.SourceFile]" />
 

--- a/src/Mono.Android/methodmap.csv
+++ b/src/Mono.Android/methodmap.csv
@@ -1340,9 +1340,9 @@
 16, android.view.accessibility, AccessibilityNodeInfo, focusSearch, direction, Android.Views.FocusSearchDirection
 16, android.view.accessibility, AccessibilityNodeInfo, getMovementGranularities, return, Android.Views.Accessibility.MovementGranularity
 16, android.view.accessibility, AccessibilityNodeInfo, setMovementGranularities, granularities, Android.Views.Accessibility.MovementGranularity
-16, android.view.accessibility, AccessibilityNodeProvider, performAction, action, Android.AccessibilityServices.GlobalAction
-16, android.view, View, performAccessibilityAction, action, Android.AccessibilityServices.GlobalAction
-16, android.view, View.AccessibilityDelegate, performAccessibilityAction, action, Android.AccessibilityServices.GlobalAction
+16, android.view.accessibility, AccessibilityNodeProvider, performAction, action, Android.Views.Accessibility.Action
+16, android.view, View, performAccessibilityAction, action, Android.Views.Accessibility.Action
+16, android.view, View.AccessibilityDelegate, performAccessibilityAction, action, Android.Views.Accessibility.Action
 16, android.view, View, getImportantForAccessibility, return, Android.Views.ImportantForAccessibility
 16, android.view, View, setImportantForAccessibility, mode, Android.Views.ImportantForAccessibility
 16, android.view, View, getWindowSystemUiVisibility, return, Android.Views.SystemUiFlags


### PR DESCRIPTION
The fixes are twofolds:

- add GetAction/SetAction to alter Action property and add [Obsolete] on
  Action property.
- Add PerformAccessibilityAction() / PerformAction() overloads that use
  Action instead.

In the future we remove [Obsolete]d members so that we can bring back
sanitized API.