### PR TITLE
[Xamarin.Android.Build.Tasks] Fix Removal of Non Duplicate elements

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -401,11 +401,18 @@ namespace Xamarin.Android.Tasks {
 			}
 		}
 
+		public IEnumerable<XElement> ResolveDuplicates (IEnumerable<XElement> elements)
+		{
+			foreach (var e in elements)
+				foreach (var d in ResolveDuplicates (e.Elements ()))
+					yield return d;
+			foreach (var d in elements.GroupBy (x => x.ToFullString ()).SelectMany (x => x.Skip (1)))
+				yield return d;
+		}
+
 		void RemoveDuplicateElements ()
 		{
-			var duplicates = doc.Descendants ()
-			                    .GroupBy (x => x.ToFullString ())
-					    .SelectMany (x => x.Skip (1));
+			var duplicates = ResolveDuplicates (doc.Elements ());
 			foreach (var duplicate in duplicates)
 				duplicate.Remove ();
 			


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=59473

Commit d079a42e went a bit too far when removing duplicates.
It removed *any* duplicate entry that appeared anywhere in the
document. What we really wanted to remove full duplicates that
exist at the same level as the current element in the document.
For example:

```xml
	<foo>
		<bar name="bar1">
		  <bar2 />
		</bar>
                <bar name="bar2">
                  <bar2 />
                </bar>
		<dupe/>
		<dupe/>
	</foo>
```

`<bar2/>` should *not* be removed but one of the `<dupe/>` values
should. This commit reworks `RemoveDuplicates()` code to handle the
correct logic. It also adds a unit test for this exact senario.