### PR TITLE
[linker] improve method detection in FixAbstractMethodsStep

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
@@ -95,8 +95,23 @@ namespace MonoDroid.Tuner
 			return true;
 		}
 
+		bool IsInOverrides (MethodDefinition iMethod, MethodDefinition tMethod)
+		{
+			if (!tMethod.HasOverrides)
+				return false;
+
+			foreach (var o in tMethod.Overrides)
+				if (o != null && iMethod == o.Resolve ())
+					return true;
+
+			return false;
+		}
+
 		bool HaveSameSignature (TypeReference iface, MethodDefinition iMethod, MethodDefinition tMethod)
 		{
+			if (IsInOverrides (iMethod, tMethod))
+				return true;
+
 			if (iMethod.Name != tMethod.Name && (iMethod.DeclaringType == null || (iMethod.DeclaringType.DeclaringType == null ? (string.Format ("{0}.{1}", iface.FullName, iMethod.Name) != tMethod.Name) : (string.Format ("{0}.{1}.{2}", iMethod.DeclaringType.DeclaringType, iface.Name, iMethod.Name) != tMethod.Name))))
 				return false;
 

--- a/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding/java/test/bindings/Cursor.java
+++ b/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding/java/test/bindings/Cursor.java
@@ -3,6 +3,7 @@ package test.bindings;
 public interface Cursor {
     void method();
     int methodWithRT ();
+    int methodWithCursor (Cursor cursor);
     int methodWithParams (int number, String text);
     int methodWithParams (int number, String text, float real);
 }

--- a/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding/java/test/bindings/Cursor.java
+++ b/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding/java/test/bindings/Cursor.java
@@ -5,6 +5,7 @@ public interface Cursor {
     void newMethod();
     int methodWithRT ();
     int newMethodWithRT ();
+    int methodWithCursor (Cursor cursor);
     int methodWithParams (int number, String text);
     int newMethodWithParams (int number, String text);
     int methodWithParams (int number, String text, float real);

--- a/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-Library/MyClrCursor.cs
+++ b/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-Library/MyClrCursor.cs
@@ -3,7 +3,7 @@ using Test.Bindings;
 
 namespace Library
 {
-	public class MyClrCursor : Java.Lang.Object, ICursor
+	public class MyClrCursor : Java.Lang.Object, global::Test.Bindings.ICursor
 	{
 		public void Method ()
 		{
@@ -22,6 +22,13 @@ namespace Library
 		public int MethodWithRT ()
 		{
 			return 3;
+		}
+
+		int global::Test.Bindings.ICursor.MethodWithCursor (global::Test.Bindings.ICursor cursor)
+		{
+			var a = 2;
+			var b = 2;
+			return a + b;
 		}
 	}
 }

--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/BindingTests.cs
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/BindingTests.cs
@@ -179,6 +179,11 @@ namespace Xamarin.Android.JcwGenTests {
 				if (e.GetType ().ToString () != "Java.Lang.AbstractMethodError")
 					throw e;
 			}
+
+			var mi = ic.GetType ().GetMethod ("MethodWithCursor");
+
+			if (mi != null && mi.GetMethodBody ().LocalVariables.Count == 0)
+				throw new Exception ("FixAbstractMethodStep broken, MethodWithRT added, while it should not be");
 		}
 
 		// Context https://bugzilla.xamarin.com/show_bug.cgi?id=36036


### PR DESCRIPTION
The forms team run into an issue with debugger in VS [1]. During
investigation it turned out that our FixAbstractMethodsStep injects 2
methods, which were not needed, as the methods were already
implemented. The bug itself looks like an issue, where original mdb
file was used in the apk, instead of the one written by our linker.

This change improves the method detection, where method name starts
with `global::`. In this particular case it were these methods:

    global::Android.Views.View.IOnTouchListener.OnTouch
    global::Android.Views.View.IOnClickListener.OnClick

[1] https://bugzilla.xamarin.com/show_bug.cgi?id=59293