### PR TITLE
[Mono.Android] Fix the build

### DIFF
--- a/src/Mono.Android/Android.Views/View.AccessibilityDelegate.cs
+++ b/src/Mono.Android/Android.Views/View.AccessibilityDelegate.cs
@@ -14,8 +14,8 @@ namespace Android.Views
 			{
 				return PerformAccessibilityAction (host, (Android.Views.Accessibility.Action) (int) action, args);
 			}
-		}
 #endif
+		}
 	}
 }
 


### PR DESCRIPTION
Commit 47f370f6 broken the build on monodroid. The #endif was
in the incorrect place which resulted in a compile error.