### PR TITLE
[Xamarin.Android.Build.Tasks] Fix PCL _DesignTimeFacadeAssemblies Detetion.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -98,6 +98,13 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
+				Packages = {
+					new Package () {
+						Id = "System.Runtime.InteropServices.WindowsRuntime",
+						Version = "4.0.1",
+						TargetFramework = "monoandroid71",
+					},
+				},
 			};
 			proj.References.Add (new BuildItem.Reference ("Mono.Data.Sqlite.dll"));
 			var expectedFiles = new string [] {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.PCLSupport.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.PCLSupport.targets
@@ -24,8 +24,22 @@
 
 		<ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true'">
 			<_DesignTimeFacadeAssemblies Include="%(DesignTimeFacadeDirectories.Identity)*.dll"/>
-			<ReferencePath Remove="@(_DesignTimeFacadeAssemblies)"/>
-			<ReferencePath Include="%(_DesignTimeFacadeAssemblies.Identity)">
+		</ItemGroup>
+
+		<CreateItem Include="%(_DesignTimeFacadeAssemblies.FileName)"
+				AdditionalMetadata="OriginalIdentity=%(_DesignTimeFacadeAssemblies.Identity)">
+			<Output TaskParameter="Include" ItemName="_DesignTimeFacadeAssemblies_Names" />
+		</CreateItem>
+
+		<CreateItem Include="%(ReferencePath.FileName)"
+				AdditionalMetadata="OriginalIdentity=%(ReferencePath.Identity)">
+			<Output TaskParameter="Include" ItemName="_ReferencePath_Names" />
+		</CreateItem>
+
+		<ItemGroup>
+			<_DesignTimeFacadeAssemblies_Names Remove="@(_ReferencePath_Names)"/>
+
+			<ReferencePath Include="@(_DesignTimeFacadeAssemblies_Names->'%(OriginalIdentity)')">
 				<WinMDFile>false</WinMDFile>
 				<CopyLocal>false</CopyLocal>
 				<ResolvedFrom>ImplicitlyExpandDesignTimeFacades</ResolvedFrom>


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=57849

We are sometimes getting duplicate assembly references in the `@(ReferencePath)`
ItemGroup. This is comming from the DesignTime Facade assembly detection.

Looking at the msbuild targets [1], they do duplicate detection by checking the
`%(Filename)` does not exist in the assembly list already. So we should
do the same in our Xamarin.Android.PCLSupport.targets.

[1] https://github.com/mono/msbuild/blob/xplat-master/src/Tasks/Microsoft.NETFramework.CurrentVersion.targets#L103