### PR TITLE
Fix MXE build of libzip

### DIFF
--- a/build-tools/libzip-windows/libzip-windows.projitems
+++ b/build-tools/libzip-windows/libzip-windows.projitems
@@ -3,13 +3,13 @@
   <ItemGroup>
     <_LibZipTarget Include="host-mxe-Win64" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <CMake>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-cmake</CMake>
-      <CMakeFlags></CMakeFlags>
+      <CMakeFlags>-DBUILD_SHARED_LIBS=ON</CMakeFlags>
       <OutputLibrary>x64/libzip.dll</OutputLibrary>
       <OutputLibraryPath>lib/libzip.dll</OutputLibraryPath>
     </_LibZipTarget>
     <_LibZipTarget Include="host-mxe-Win32" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:'))">
       <CMake>$(AndroidMxeFullPath)\bin\i686-w64-mingw32.static-cmake</CMake>
-      <CMakeFlags></CMakeFlags>
+      <CMakeFlags>-DBUILD_SHARED_LIBS=ON</CMakeFlags>
       <OutputLibrary>libzip.dll</OutputLibrary>
       <OutputLibraryPath>lib/libzip.dll</OutputLibraryPath>
     </_LibZipTarget>


### PR DESCRIPTION
Commit https://github.com/xamarin/xamarin-android/commit/fa9f62a113bf9fba42e39c4556b130988137b967 failed to update the MXE build of the library
and so it was still being built as a static archive (which is the
new libzip default) and caused build failures when building
libzip executables.

This commit makes MXE build a shared version of the library and,
hopefully, fixes the issue.