### PR TITLE
[tests] `gradlew` needs JAVA_HOME set on Windows

### DIFF
--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
@@ -43,7 +43,7 @@
       Inputs="java\JavaLib\project.properties"
       Outputs="$(OutputPath)JavaLib.zip">
     <Exec
-        EnvironmentVariables="ANDROID_HOME=$(AndroidSdkDirectory)"
+        EnvironmentVariables="ANDROID_HOME=$(AndroidSdkDirectory);JAVA_HOME=$(JavaSdkDirectory)"
         Command=".\gradlew assembleDebug --stacktrace"
         WorkingDirectory="$(MSBuildThisFileDirectory)java\JavaLib"
     />


### PR DESCRIPTION
Context in #800

Failing build at:
https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=999607