### PR TITLE
Revert "Bump to lipzip/rel-1-3-0/51ff59da"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,7 +20,7 @@
 [submodule "external/libzip"]
 	path = external/libzip
 	url = https://github.com/nih-at/libzip.git
-	branch = rel-1-3-0
+	branch = master
 [submodule "external/LibZipSharp"]
 	path = external/LibZipSharp
 	url = https://github.com/grendello/LibZipSharp.git

--- a/build-tools/libzip/libzip.projitems
+++ b/build-tools/libzip/libzip.projitems
@@ -3,13 +3,13 @@
   <ItemGroup>
     <_LibZipTarget Include="host-Darwin" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">
       <CMake>cmake</CMake>
-      <CMakeFlags>-DCMAKE_OSX_ARCHITECTURES=&quot;i386;x86_64&quot; -DBUILD_SHARED_LIBS=ON</CMakeFlags>
+      <CMakeFlags>-DCMAKE_OSX_ARCHITECTURES=&quot;i386;x86_64&quot;</CMakeFlags>
       <OutputLibrary>libzip.3.0.dylib</OutputLibrary>
       <OutputLibraryPath>lib/libzip.3.0.dylib</OutputLibraryPath>
     </_LibZipTarget>
     <_LibZipTarget Include="host-Linux" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:')) AND '$(_LinuxBuildLibZip)' == 'true' ">
       <CMake>cmake</CMake>
-      <CMakeFlags>-DBUILD_SHARED_LIBS=ON</CMakeFlags>
+      <CMakeFlags></CMakeFlags>
       <OutputLibrary>libzip.so</OutputLibrary>
       <OutputLibraryPath>lib/libzip.so</OutputLibraryPath>
     </_LibZipTarget>


### PR DESCRIPTION
Commit fa9f62a1 [broke the master build][b630]:

[b630]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/630/

	Linking C executable hole.exe
	CMakeFiles/hole.dir/objects.a(hole.c.obj):hole.c:(.text+0x77): undefined reference to `__imp_zip_error_init'
	...

Revert commit fa9f62a1 until we figure out how to properly fix it.