### PR TITLE
[Xamarin.Android.Build.Tasks] PackageReference and AndroidUseLatestPlatformSdk do not work together

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -141,6 +141,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 -->
 
 <PropertyGroup>
+	<ResolveNuGetPackageAssetsDependsOn>
+		_SetLatestTargetFrameworkVersion;
+		$(ResolveNuGetPackageAssetsDependsOn)
+	</ResolveNuGetPackageAssetsDependsOn>
 	<GetReferenceAssemblyPathsDependsOn>
 		_SetLatestTargetFrameworkVersion;
 		$(GetReferenceAssemblyPathsDependsOn)
@@ -171,6 +175,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<_XASupportsFastDev Condition=" Exists ('$(MSBuildThisFileDirectory)Xamarin.Android.Common.Debugging.targets') ">True</_XASupportsFastDev>
 	<_XASupportsFastDev Condition=" '$(_XASupportsFastDev)' == '' ">False</_XASupportsFastDev>
 	<AndroidApplication Condition="'$(AndroidApplication)' == ''">false</AndroidApplication>
+	<AndroidUseSharedRuntime Condition=" '$(AndroidUseSharedRuntime)' == '' Or '$(_XASupportsFastDev)' == 'False' ">False</AndroidUseSharedRuntime>
 	<AndroidNeedsInternetPermission Condition="'$(AndroidNeedsInternetPermission)' == '' And '$(AndroidEmbedProfilers)' == ''">False</AndroidNeedsInternetPermission>
 	<AndroidNeedsInternetPermission Condition="'$(AndroidNeedsInternetPermission)' == '' And '$(AndroidEmbedProfilers)' != ''">True</AndroidNeedsInternetPermission>
 	<AndroidUseLatestPlatformSdk Condition="'$(AndroidUseLatestPlatformSdk)' == ''">False</AndroidUseLatestPlatformSdk>
@@ -190,7 +195,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidAotMode Condition=" '$(AndroidAotMode)' == '' And '$(AotAssemblies)' == 'True' ">Normal</AndroidAotMode>
 	<AotAssemblies Condition=" '$(AndroidAotMode)' != '' ">True</AotAssemblies>
 	<AotAssemblies Condition=" '$(AotAssemblies)' == '' ">False</AotAssemblies>
-	<AndroidUseSharedRuntime Condition=" '$(AndroidUseSharedRuntime)' == '' Or '$(_XASupportsFastDev)' == 'False' ">False</AndroidUseSharedRuntime>
 
 	<AndroidExplicitCrunch Condition=" '$(AndroidExplicitCrunch)' == '' ">False</AndroidExplicitCrunch>
 	<AndroidUseDebugRuntime
@@ -604,6 +608,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	</GetReferenceAssemblyPaths>
 </Target>
 
+<Target Name="_SetLatestTargetFrameworkVersionForPackageReference" BeforeTargets="_GetRestoreTargetFrameworksOutput" DependsOnTargets="_SetLatestTargetFrameworkVersion">
+</Target>
+
 <Target Name="_SetLatestTargetFrameworkVersion" DependsOnTargets="_GetReferenceAssemblyPaths">
 	<ResolveSdks
 			AndroidApiLevel="$(AndroidApiLevel)"
@@ -644,9 +651,15 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		<Output TaskParameter="Value" PropertyName="TargetFrameworkMoniker"
 				Condition="'$(TargetFrameworkProfile)' != ''"
 		/>
+		<Output TaskParameter="Value" PropertyName="NuGetTargetMoniker"
+				Condition="'$(TargetFrameworkProfile)' != ''"
+		/>
 	</CreateProperty>
 	<CreateProperty Value="$(TargetFrameworkIdentifier),Version=$(_TargetFrameworkVersion)">
 		<Output TaskParameter="Value" PropertyName="TargetFrameworkMoniker"
+				Condition="'$(TargetFrameworkProfile)' == ''"
+		/>
+		<Output TaskParameter="Value" PropertyName="NuGetTargetMoniker"
 				Condition="'$(TargetFrameworkProfile)' == ''"
 		/>
 	</CreateProperty>


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=59534

When using `PackageReference` with our system it run before
`_SetLatestTargetFrameworkVersion`. As a result it always
uses a `$(TargetFrameworkVersion)` of v2.3 or what ever the
user defined in the project manually.

So we need to make sure that `_SetLatestTargetFrameworkVersion`
runs as part of the `PackageReference` target chain. Fortunately
that chain is run as part of `ResolveNuGetPackageAssetsDependsOn`.
As well as `_GetRestoreTargetFrameworksOutput`.
So we just need to make sure that our target in run as part of
that target chain in order to fix this issue.

We also need to update a few NuGet specific properties to ensure
that it uses the correct `TargetPlatformMoniker`. This is done 
via the `NuGetTargetMoniker`.