### PR TITLE
Bump to lipzip/rel-1-3-0/51ff59da (#863)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,7 +20,7 @@
 [submodule "external/libzip"]
 	path = external/libzip
 	url = https://github.com/nih-at/libzip.git
-	branch = master
+	branch = rel-1-3-0
 [submodule "external/LibZipSharp"]
 	path = external/LibZipSharp
 	url = https://github.com/grendello/LibZipSharp.git

--- a/build-tools/libzip-windows/libzip-windows.projitems
+++ b/build-tools/libzip-windows/libzip-windows.projitems
@@ -3,13 +3,13 @@
   <ItemGroup>
     <_LibZipTarget Include="host-mxe-Win64" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
       <CMake>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-cmake</CMake>
-      <CMakeFlags></CMakeFlags>
+      <CMakeFlags>-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE -DBUILD_SHARED_LIBS=TRUE</CMakeFlags>
       <OutputLibrary>x64/libzip.dll</OutputLibrary>
       <OutputLibraryPath>lib/libzip.dll</OutputLibraryPath>
     </_LibZipTarget>
     <_LibZipTarget Include="host-mxe-Win32" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:'))">
       <CMake>$(AndroidMxeFullPath)\bin\i686-w64-mingw32.static-cmake</CMake>
-      <CMakeFlags></CMakeFlags>
+      <CMakeFlags>-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE -DBUILD_SHARED_LIBS=TRUE</CMakeFlags>
       <OutputLibrary>libzip.dll</OutputLibrary>
       <OutputLibraryPath>lib/libzip.dll</OutputLibraryPath>
     </_LibZipTarget>

--- a/build-tools/libzip/libzip.projitems
+++ b/build-tools/libzip/libzip.projitems
@@ -3,13 +3,13 @@
   <ItemGroup>
     <_LibZipTarget Include="host-Darwin" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">
       <CMake>cmake</CMake>
-      <CMakeFlags>-DCMAKE_OSX_ARCHITECTURES=&quot;i386;x86_64&quot;</CMakeFlags>
+      <CMakeFlags>-DCMAKE_OSX_ARCHITECTURES=&quot;i386;x86_64&quot; -DBUILD_SHARED_LIBS=ON</CMakeFlags>
       <OutputLibrary>libzip.3.0.dylib</OutputLibrary>
       <OutputLibraryPath>lib/libzip.3.0.dylib</OutputLibraryPath>
     </_LibZipTarget>
     <_LibZipTarget Include="host-Linux" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:')) AND '$(_LinuxBuildLibZip)' == 'true' ">
       <CMake>cmake</CMake>
-      <CMakeFlags></CMakeFlags>
+      <CMakeFlags>-DBUILD_SHARED_LIBS=ON</CMakeFlags>
       <OutputLibrary>libzip.so</OutputLibrary>
       <OutputLibraryPath>lib/libzip.so</OutputLibraryPath>
     </_LibZipTarget>


### PR DESCRIPTION
The new version fixes CVE-2017-12858 and CVE-2017-14107.

**PR notes**
The original PR failed to build on Windows, its follow up failed as well - despite passing the correct (or so it seemed) `CMake` flags, static library was still being built. This, hopefully, fixes the issue.