### PR TITLE
[libzip-windows] use libzip.dll and zlib.dll from NuGet

### DIFF
--- a/build-tools/libzip-windows/libzip-windows.mdproj
+++ b/build-tools/libzip-windows/libzip-windows.mdproj
@@ -15,23 +15,7 @@
     <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets" />
-  <PropertyGroup>
-    <BuildDependsOnLocal Condition=" '$(HostOS)' == 'Darwin' ">
-      ResolveReferences;
-      _BuildUnlessCached
-    </BuildDependsOnLocal>
-  </PropertyGroup>
   <Import Project="libzip-windows.props" />
   <Import Project="libzip-windows.projitems" />
   <Import Project="libzip-windows.targets" />
-  <Import Project="..\libzip\libzip.targets" />
-  <ItemGroup>
-    <ProjectReference Include="..\android-toolchain\android-toolchain.mdproj" Condition=" '$(HostOS)' != 'Windows' ">
-      <Project>{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA}</Project>
-      <Name>android-toolchain</Name>
-      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-    </ProjectReference>
-  </ItemGroup>
-  <Target Name="Build" DependsOnTargets="$(BuildDependsOnLocal)" Condition=" '$(HostOS)' != 'Windows' " />
-  <Target Name="Clean" />
 </Project>

--- a/build-tools/libzip-windows/libzip-windows.projitems
+++ b/build-tools/libzip-windows/libzip-windows.projitems
@@ -1,28 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <_LibZipTarget Include="host-mxe-Win64" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
-      <CMake>$(AndroidMxeFullPath)\bin\x86_64-w64-mingw32.static-cmake</CMake>
-      <CMakeFlags></CMakeFlags>
-      <OutputLibrary>x64/libzip.dll</OutputLibrary>
-      <OutputLibraryPath>lib/libzip.dll</OutputLibraryPath>
-    </_LibZipTarget>
-    <_LibZipTarget Include="host-mxe-Win32" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:'))">
-      <CMake>$(AndroidMxeFullPath)\bin\i686-w64-mingw32.static-cmake</CMake>
-      <CMakeFlags></CMakeFlags>
-      <OutputLibrary>libzip.dll</OutputLibrary>
-      <OutputLibraryPath>lib/libzip.dll</OutputLibraryPath>
-    </_LibZipTarget>
-    <_NuGetBinary Include="..\..\external\LibZipSharp\bin\$(OS)\$(Configuration)\libzip.dll">
+    <None Include="packages.config" />
+    <_NuGetBinary Include="..\..\packages\libzip.redist.1.1.2.7\build\native\bin\Win32\v140\Release\zip.dll">
       <Destination>libzip.dll</Destination>
     </_NuGetBinary>
-    <_NuGetBinary Include="..\..\external\LibZipSharp\bin\$(OS)\$(Configuration)\zlib.dll">
+    <_NuGetBinary Include="..\..\packages\grpc.dependencies.zlib.redist.1.2.8.10\build\native\bin\v140\Win32\Release\dynamic\cdecl\zlib.dll">
       <Destination>zlib.dll</Destination>
     </_NuGetBinary>
-    <_NuGetBinary Include="..\..\external\LibZipSharp\bin\$(OS)\$(Configuration)\x64\libzip.dll">
+    <_NuGetBinary Include="..\..\packages\libzip.redist.1.1.2.7\build\native\bin\x64\v140\Release\zip.dll">
       <Destination>x64\libzip.dll</Destination>
     </_NuGetBinary>
-    <_NuGetBinary Include="..\..\external\LibZipSharp\bin\$(OS)\$(Configuration)\x64\zlib.dll">
+    <_NuGetBinary Include="..\..\packages\grpc.dependencies.zlib.redist.1.2.8.10\build\native\bin\v140\x64\Release\dynamic\cdecl\zlib.dll">
       <Destination>x64\zlib.dll</Destination>
     </_NuGetBinary>
   </ItemGroup>

--- a/build-tools/libzip-windows/libzip-windows.targets
+++ b/build-tools/libzip-windows/libzip-windows.targets
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="Build"
-      Condition=" '$(HostOS)' == 'Windows' "
       Inputs="@(_NuGetBinary)"
       Outputs="@(_NuGetBinary->'$(OutputPath)%(Destination)')">
     <Copy 

--- a/build-tools/libzip-windows/packages.config
+++ b/build-tools/libzip-windows/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="libzip.redist" version="1.1.2.7" />
+  <package id="grpc.dependencies.zlib.redist" version="1.2.8.10" />
+</packages>


### PR DESCRIPTION
When bumping libzip in #874 or #863 libzip is no longer building under
mxe. We can switch to using the NuGet packages instead.