### PR TITLE
[build] move bundle zip to `$(AndroidToolchainCacheDirectory)`

### DIFF
--- a/build-tools/xa-prep-tasks/xa-prep-tasks.targets
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.targets
@@ -62,7 +62,7 @@
   <Target Name="_GetBundleOutputPath"
       DependsOnTargets="GetBundleFileName">
     <PropertyGroup>
-      <_BundlePath>$(OutputPath)$(XABundleFileName)</_BundlePath>
+      <_BundlePath>$(AndroidToolchainCacheDirectory)\$(XABundleFileName)</_BundlePath>
     </PropertyGroup>
   </Target>
   <Target Name="_DownloadBundle"


### PR DESCRIPTION
Previously the bundle was being downloaded to `bin/BuildDebug`, which
would be commonly cleaned for each build on CI systems. We can speed up
our builds by downloading the file to `~/android-archives`, which is
already used for various other downloads. This will persist the file
between builds on the same build agent.