### PR TITLE
[Mono.Android] Fix AssistStructure.ViewNode enumification

### DIFF
--- a/src/Mono.Android/methodmap.csv
+++ b/src/Mono.Android/methodmap.csv
@@ -2284,8 +2284,8 @@
 26, android.app.admin, DevicePolicyManager, bindDeviceAdminServiceAsUser, flags, Android.Content.Bind
 26, android.app.admin, DevicePolicyManager, resetPasswordWithToken, flags, Android.App.Admin.ResetPasswordFlags
 26, android.app.admin, DevicePolicyManager, lockNow, flags, Android.App.Admin.DevicePolicyManagerFlags
-26, android.app.assist, AssistStructure.ViewNode, getAutofillType, return, Android.Text.InputTypes
-26, android.app.assist, AssistStructure.ViewNode, getInputType, return, Android.Views.AutofillType
+26, android.app.assist, AssistStructure.ViewNode, getAutofillType, return, Android.Views.AutofillType
+26, android.app.assist, AssistStructure.ViewNode, getInputType, return, Android.Text.InputTypes
 26, android.app.job, JobInfo.Builder, setClipData, grantFlags, Android.Content.ActivityFlags
 26, android.app.job, JobInfo, getClipGrandFlags, grantFlags, Android.Content.ActivityFlags
 26, android.app.job, JobParameters, getClipGrandFlags, grantFlags, Android.Content.ActivityFlags


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=59625
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=59532

Bumps to xamarin-android-api-compatibility/master/19a5fbce.

The `Android.App.Assist.AssistStructure.ViewNode.AutofillType` and
`Android.App.Assist.AssistStructure.ViewNode.InputType` properties
had their types swapped.

Update `methodmap.csv` so that the appropriate types are used.