### PR TITLE
[build] include Windows targets on all platforms

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -33,43 +33,36 @@
       <Link>..\..\Novell\MonoDroid.FSharp.targets</Link>
     </None>
     <None
-        Condition=" '$(OS)' == 'Windows_NT' "
         Include="MSBuild\Xamarin\Xamarin.Android.Sdk.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>..\Xamarin.Android.Sdk.props</Link>
     </None>
     <None
-        Condition=" '$(OS)' == 'Windows_NT' "
         Include="MSBuild\Xamarin\Xamarin.Android.Sdk.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>..\Xamarin.Android.Sdk.targets</Link>
     </None>
     <None
-        Condition=" '$(OS)' == 'Windows_NT' "
         Include="MSBuild\Xamarin\Android\Xamarin.Android.Bindings.Before.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Xamarin.Android.Bindings.Before.targets</Link>
     </None>
     <None
-        Condition=" '$(OS)' == 'Windows_NT' "
         Include="MSBuild\Xamarin\Android\Xamarin.Android.Common\ImportAfter\Microsoft.Cpp.Android.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Xamarin.Android.Common\ImportAfter\Microsoft.Cpp.Android.targets</Link>
     </None>
     <None
-        Condition=" '$(OS)' == 'Windows_NT' "
         Include="MSBuild\Xamarin\Android\Xamarin.Android.Common\ImportAfter\Xamarin.Android.Windows.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>\Xamarin.Android.Common\ImportAfter\Xamarin.Android.Windows.targets</Link>
     </None>
     <None
-        Condition=" '$(OS)' == 'Windows_NT' "
         Include="MSBuild\Xamarin\Android\Xamarin.Android.Common.After.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Xamarin.Android.Common.After.targets</Link>
     </None>
     <None
-        Condition=" '$(OS)' == 'Windows_NT' "
         Include="MSBuild\Xamarin\Android\Xamarin.Android.Common.Before.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Xamarin.Android.Common.Before.targets</Link>


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/xabuild

In creating a prototype `xabuild.exe` that is cross-platform, I’ve
discovered these `*.targets` files are needed on macOS as well as
Windows. Without them, PCL projects (such as a Xamarin.Forms app) do
not build properly when using `xabuild.exe`.