### PR TITLE
[xa-prep-tasks] `DownloadUri` needs to create directory

### DIFF
--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/DownloadUri.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/DownloadUri.cs
@@ -58,9 +58,10 @@ namespace Xamarin.Android.BuildTools.PrepTasks {
 				Log.LogMessage (MessageImportance.Normal, $"Skipping uri '{uri}' as destination file already exists '{destinationFile}'.");
 				return;
 			}
-			var dp  = Path.GetDirectoryName (destinationFile);
-			var dn  = Path.GetFileName (destinationFile);
-			var tempPath    = Path.Combine (dp, "." + dn + ".download");
+			var dp       = Path.GetDirectoryName (destinationFile);
+			var dn       = Path.GetFileName (destinationFile);
+			var tempPath = Path.Combine (dp, "." + dn + ".download");
+			Directory.CreateDirectory(dp);
 
 			Log.LogMessage (MessageImportance.Normal, $"Downloading `{uri}` to `{tempPath}`.");
 			try {


### PR DESCRIPTION
Context in #880

Since we are now downloading the bundle to `~/android-archives`, it is
possible that the directory will not exist on a clean machine. We should
be calling `Directory.CreateDirectory` in the `DownloadUri` task anyway,
as this could easily happen on any destination file.

A case this occured  on VSTS:
https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=1006149