### PR TITLE
[Mono.Android] Fix ViewStructure enumification

### DIFF
--- a/build-tools/enumification-helpers/methodmap.ext.csv
+++ b/build-tools/enumification-helpers/methodmap.ext.csv
@@ -1607,6 +1607,7 @@
 26, android.bluetooth, BluetoothGattServer, setPreferredPhy, rxPhy, Android.Bluetooth.BluetoothPhy
 26, android.bluetooth, BluetoothGattServer, setPreferredPhy, phyOptions, Android.Bluetooth.BluetoothPhyOption
 
+26, android.view, ViewStructure, setAutofillType, p0, Android.Views.AutofillType
 26, android.view, Window, getColorMode, return, Android.Content.PM.ActivityColorMode
 26, android.view, Window, setColorMode, colorMode, Android.Content.PM.ActivityColorMode
 26, android.view, WindowManager.LayoutParams, getColorMode, return, Android.Content.PM.ActivityColorMode
@@ -1688,8 +1689,8 @@
 26, android.app.admin, DevicePolicyManager, bindDeviceAdminServiceAsUser, flags, Android.Content.Bind
 26, android.app.admin, DevicePolicyManager, resetPasswordWithToken, flags, Android.App.Admin.ResetPasswordFlags
 26, android.app.admin, DevicePolicyManager, lockNow, flags, Android.App.Admin.DevicePolicyManagerFlags
-26, android.app.assist, AssistStructure.ViewNode, getAutofillType, return, Android.Text.InputTypes
-26, android.app.assist, AssistStructure.ViewNode, getInputType, return, Android.Views.AutofillType
+26, android.app.assist, AssistStructure.ViewNode, getAutofillType, return, Android.Views.AutofillType
+26, android.app.assist, AssistStructure.ViewNode, getInputType, return, Android.Text.InputTypes
 26, android.app.job, JobInfo.Builder, setClipData, grantFlags, Android.Content.ActivityFlags
 26, android.app.job, JobInfo, getClipGrandFlags, grantFlags, Android.Content.ActivityFlags
 26, android.app.job, JobParameters, getClipGrandFlags, grantFlags, Android.Content.ActivityFlags

--- a/src/Mono.Android/methodmap.csv
+++ b/src/Mono.Android/methodmap.csv
@@ -2203,6 +2203,7 @@
 26, android.bluetooth, BluetoothGattServer, setPreferredPhy, rxPhy, Android.Bluetooth.BluetoothPhy
 26, android.bluetooth, BluetoothGattServer, setPreferredPhy, phyOptions, Android.Bluetooth.BluetoothPhyOption
 
+26, android.view, ViewStructure, setAutofillType, p0, Android.Views.AutofillType
 26, android.view, Window, getColorMode, return, Android.Content.PM.ActivityColorMode
 26, android.view, Window, setColorMode, colorMode, Android.Content.PM.ActivityColorMode
 26, android.view, WindowManager.LayoutParams, getColorMode, return, Android.Content.PM.ActivityColorMode


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=59655

Bumps to xamarin-android-api-compatibility/master/7fce46a4.

Enumify `Android.Views.ViewStructure.SetAutofillType()`.