### PR TITLE
[tests] Windows fixes for Xamarin.Android.Build.Tests

### DIFF
--- a/build-tools/libzip-windows/libzip-windows.mdproj
+++ b/build-tools/libzip-windows/libzip-windows.mdproj
@@ -32,6 +32,6 @@
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
-  <Target Name="Build" DependsOnTargets="$(BuildDependsOnLocal)" Condition=" '$(HostOS)' != 'Windows' " />
+  <Target Name="Build" DependsOnTargets="$(BuildDependsOnLocal)" />
   <Target Name="Clean" />
 </Project>

--- a/build-tools/libzip-windows/libzip-windows.targets
+++ b/build-tools/libzip-windows/libzip-windows.targets
@@ -1,13 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="Build"
-      Condition=" '$(HostOS)' == 'Windows' "
-      Inputs="@(_NuGetBinary)"
-      Outputs="@(_NuGetBinary->'$(OutputPath)%(Destination)')">
-    <Copy 
-        SourceFiles="@(_NuGetBinary)"
-        DestinationFiles="@(_NuGetBinary->'$(OutputPath)%(Destination)')"
-        SkipUnchangedFiles="True"
-    />
-  </Target>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -228,11 +228,10 @@ namespace Com.Ipaulpro.Afilechooser {
 				IsRelease = true,
 			};
 			binding.AndroidClassParser = "class-parse";
-			var multidexJar = Environment.OSVersion.Platform == PlatformID.Win32NT
-				? Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.ProgramFilesX86), "MSBuild", "Xamarin", "Android", "android-support-multidex.jar") 
-				: Path.Combine ("$(MonoDroidInstallDirectory)", "lib", "xamarin.android", "xbuild", "Xamarin", "Android", "android-support-multidex.jar");
-			binding.Jars.Add (new AndroidItem.EmbeddedJar (() => multidexJar));
+
 			using (var bindingBuilder = CreateDllBuilder ("temp/BindingCustomJavaApplicationClass/MultiDexBinding")) {
+				string multidexJar = Path.Combine (bindingBuilder.FrameworkLibDirectory, "android-support-multidex.jar");
+				binding.Jars.Add (new AndroidItem.EmbeddedJar (() => multidexJar));
 				bindingBuilder.Build (binding);
 				var proj = new XamarinAndroidApplicationProject ();
 				proj.OtherBuildItems.Add (new BuildItem ("ProjectReference", "..\\MultiDexBinding\\UnnamedProject.csproj"));

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Android.Build.Tests
 			var home = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
 			var sdkPath = Environment.GetEnvironmentVariable ("ANDROID_SDK_PATH");
 			if (string.IsNullOrEmpty (sdkPath))
-				sdkPath = $"{home}/android-toolchain/sdk";
+				sdkPath = Path.Combine (home, "android-toolchain", "sdk");
 			string adb = Path.Combine (sdkPath, "platform-tools", "adb" + ext);
 			var proc = System.Diagnostics.Process.Start (new System.Diagnostics.ProcessStartInfo (adb, command) { RedirectStandardOutput = true, RedirectStandardError = true, UseShellExecute = false });
 			proc.WaitForExit ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -388,8 +388,11 @@ namespace Xamarin.ProjectTools
 				return;
 
 			var isWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
-			var psi = new ProcessStartInfo (isWindows ? "NuGet.exe" : "mono") {
-				Arguments = $"{(isWindows ? "" : "\"" + Path.Combine (Root,"NuGet.exe") + "\"")} restore -PackagesDirectory \"{Path.Combine (Root, directory, "..", "packages")}\" \"{Path.Combine (Root, directory, "packages.config")}\"",
+			var nuget = Path.Combine (Root, "NuGet.exe");
+			var psi = new ProcessStartInfo (isWindows ? nuget : "mono") {
+				Arguments = $"{(isWindows ? "" : "\"" + nuget + "\"")} restore -PackagesDirectory \"{Path.Combine (Root, directory, "..", "packages")}\" \"{Path.Combine (Root, directory, "packages.config")}\"",
+				CreateNoWindow = true,
+				WindowStyle = ProcessWindowStyle.Hidden,
 			};
 			var process = Process.Start (psi);
 			process.WaitForExit ();

--- a/src/Xamarin.Android.Build.Tasks/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FSharp.Compiler.CodeDom" version="0.9.4" targetFramework="net45" />
   <package id="FSharp.Compiler.CodeDom" version="1.0.0.1" targetFramework="net45" />
   <package id="Irony" version="0.9.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This resolves several issues:
- `XamarinProject` was not finding NuGet.exe on Windows and the process
is visible
- On Windows, the tests need `libzip.dll` and `zlib.dll` in their output
- `BindingBuildTest` was not using `android-support-multidex.jar` from
VS 2017 installation
- `RunAdbCommand` was using unix-style paths

Changes:
- Run `.nuget/NuGet.exe` on Windows and make it hidden
- Bump LibZipSharp, which better supports `<ProjectReference />`,
`libzip-windows.mdproj` no longer needs to do anything on Windows
- `BindingBuildTest` can use the `FrameworkLibDirectory` property
- `RunAdbCommand` should use `Path.Combine`
- Removed duplicate `FSharp.Compiler.CodeDom` in `packages.config`
(test runner warning)