### PR TITLE
[Xamarin.Android.Build.Tasks] dx.jar command line too long.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileToDalvik.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileToDalvik.cs
@@ -115,8 +115,7 @@ namespace Xamarin.Android.Tasks
 			if (File.Exists (OptionalObfuscatedJarFile))
 				cmd.AppendFileNameIfNotNull (OptionalObfuscatedJarFile);
 			else {
-				foreach (var cls in Directory.GetFiles (ClassesOutputDirectory, "*.class", SearchOption.AllDirectories))
-					cmd.AppendFileNameIfNotNull (cls);
+				cmd.AppendFileNameIfNotNull (ClassesOutputDirectory);
 				foreach (var jar in JavaLibrariesToCompile)
 					cmd.AppendFileNameIfNotNull (jar.ItemSpec);
 			}


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=59651

We were passing ALL the .class files in as parameters to the
dx.jar invocation. Turns out we can just pass the top level
directory. In this case `$(IntermediateOutputPath)android\bin\classes`
will do fine. Because its a directory dx will pick up any
.class file it finds in any subdirectory.

I did try this with the .jar files as well, but because allot
of the libraries have a `lib` folder which contain a internal .jar
file it causes problems. This is because it produces dupicate types.
So rather than specificly ignore the lib folder (which migth change)
we will just stick to the current system.