### PR TITLE
[Xamarin.Android.Build.Tests] Fix the BindingCustomJavaApplicationClass Test

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -230,7 +230,7 @@ namespace Com.Ipaulpro.Afilechooser {
 			binding.AndroidClassParser = "class-parse";
 
 			using (var bindingBuilder = CreateDllBuilder ("temp/BindingCustomJavaApplicationClass/MultiDexBinding")) {
-				string multidexJar = Path.Combine (bindingBuilder.FrameworkLibDirectory, "android-support-multidex.jar");
+				string multidexJar = Path.Combine (bindingBuilder.AndroidMSBuildDirectory, "android-support-multidex.jar");
 				binding.Jars.Add (new AndroidItem.EmbeddedJar (() => multidexJar));
 				bindingBuilder.Build (binding);
 				var proj = new XamarinAndroidApplicationProject ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -89,6 +89,12 @@ namespace Xamarin.ProjectTools
 			}
 		}
 
+		public string AndroidMSBuildDirectory {
+			get {
+				return IsUnix ? Path.Combine (FrameworkLibDirectory, "xbuild", "Xamarin", "Android") : FrameworkLibDirectory;
+			}
+		}
+
 		public string FrameworkLibDirectory {
 			get {
 				if (IsUnix) {


### PR DESCRIPTION
Fix up the builder to return a new property `AndroidMSBuildDirectory`
which returns the correct directory to look for msbuild related files.

a subdirectory of `lib/xamarin.android` on windows they are in
a completely different location.