### PR TITLE
[tests] update NUnit to 3.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SOLUTION      = Xamarin.Android.sln
 NUNIT_TESTS = \
 	bin/Test$(CONFIGURATION)/Xamarin.Android.Build.Tests.dll
 
-NUNIT_CONSOLE = packages/NUnit.ConsoleRunner.3.2.1/tools/nunit3-console.exe
+NUNIT_CONSOLE = packages/NUnit.ConsoleRunner.3.6.0/tools/nunit3-console.exe
 
 ifneq ($(V),0)
 MONO_OPTIONS += --debug

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -36,7 +36,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="nunit.framework">
-      <HintPath>..\..\..\..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
+      <HintPath>..\..\..\..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/packages.config
@@ -1,8 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.2.1" targetFramework="net45" />
+  <package id="NUnit" version="3.6.0" targetFramework="net451" />
+  <package id="NUnit.Console" version="3.6.0" targetFramework="net451" />
+  <package id="NUnit.ConsoleRunner" version="3.6.0" targetFramework="net451" />
+  <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net451" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.6.0" targetFramework="net451" />
+  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net451" />
+  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net451" />
+  <package id="NUnit.Extension.VSProjectLoader" version="3.6.0" targetFramework="net451" />
   <package id="Unofficial.Ionic.Zip" version="1.9.1.8" targetFramework="net45" />
-  <package id="NUnit.Console" version="3.2.1" />
-  <package id="NUnit.ConsoleRunner" version="3.2.1" />
-  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.2.1" />
 </packages>


### PR DESCRIPTION
Context:
https://jenkins.mono-project.com/job/xamarin-android-pr-builder/1659/testReport/

I’ve been noticing the Xamarin.Android.Build.Tests are occasionally
failing and reporting zero test results (no failures, no success). This
situation doesn’t break PR builds, and effectively skips
Xamarin.Android.Build.Tests.

Updating NUnit.ConsoleRunner may be the fix as mentioned on this issue:
https://github.com/nunit/nunit/issues/1509

Unfortunately NUnit has some more dependencies now, so there are a few
more packages. I chose version 3.6.0, as I could get a parallel version
number across all NUnit packages.