### PR TITLE
[src/Mono.Android] regenerated api-26.xml.in and fixed build on metadata.

### DIFF
--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1378,4 +1378,7 @@
   <remove-node path="/api/package/interface/implements[@name='java.lang.AutoCloseable']" />
 
 
+  <attr path="/api/package[@name='android.media']/interface[@name='MediaCas.EventListener']" name="argsType">MediaCasEventArgs</attr>
+  <attr path="/api/package[@name='android.media']/interface[@name='MediaCas.EventListener']/method[@name='onEvent']/parameter[@name='MediaCas']" name="managedName">mediaCas</attr>
+
 </metadata>


### PR DESCRIPTION
Somehow the latest class-parse gives more parameter names on api-26
(we have no idea what caused that). That somehow resulted in some
event generation related breakage, which is also fixed in this change.