### PR TITLE
[Xamarin.Android.Build.Tests] Bump mimimum Timing for Managed Resource Build.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -985,7 +985,7 @@ namespace Lib1 {
 		[Test]
 		public void BuildAppWithManagedResourceParserAndLibraries ()
 		{
-			int maxBuildTimeMs = 5000;
+			int maxBuildTimeMs = 8000;
 			var path = Path.Combine ("temp", "BuildAppWithManagedResourceParserAndLibraries");
 			var theme = new AndroidItem.AndroidResource ("Resources\\values\\Theme.xml") {
 				TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>


### PR DESCRIPTION
Our unit tests reliably take over 5 seconds to do a design time
build :(. But that does not happen locally, so we are bumping the
time limit up to 8 seconds.