### PR TITLE
[tests] JarContentBuilder should locate java

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1484,8 +1484,6 @@ public class Test
 			proj.Jars.Add (new AndroidItem.EmbeddedJar (Path.Combine ("java", "test.jar")) {
 				BinaryContent = new JarContentBuilder () {
 					BaseDirectory = Path.Combine (path, "java"),
-					JavacFullPath = "javac",
-					JarFullPath = "jar",
 					JarFileName = "test.jar",
 					JavaSourceFileName = Path.Combine ("com", "xamarin", "testing", "Test.java"),
 					JavaSourceText = java
@@ -1548,8 +1546,6 @@ public class Test
 			proj.Jars.Add (new AndroidItem.EmbeddedJar (Path.Combine ("java", "test.jar")) {
 				BinaryContent = new JarContentBuilder () {
 					BaseDirectory = Path.Combine (path, "java"),
-					JavacFullPath = "javac",
-					JarFullPath = "jar",
 					JarFileName = "test.jar",
 					JavaSourceFileName = Path.Combine ("com", "xamarin", "testing", "Test.java"),
 					JavaSourceText = java

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/JarContentBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/JarContentBuilder.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using Xamarin.Android.Tools;
 
 namespace Xamarin.ProjectTools
 {
@@ -15,6 +15,23 @@ namespace Xamarin.ProjectTools
 		// It can support more than one file but we don't need compllicated one yet.
 		public string JavaSourceFileName { get; set; }
 		public string JavaSourceText { get; set; }
+
+		public JarContentBuilder ()
+		{
+			Action<TraceLevel, string> logger = (level, value) => {
+				switch (level) {
+					case TraceLevel.Error:
+						throw new Exception ($"AndroidSdkInfo {level}: {value}");
+					default:
+						Console.WriteLine ($"AndroidSdkInfo {level}: {value}");
+						break;
+				}
+			};
+
+			var androidSdk = new AndroidSdkInfo (logger);
+			JavacFullPath = Path.Combine (androidSdk.JavaSdkPath, "bin", "javac");
+			JarFullPath = Path.Combine (androidSdk.JavaSdkPath, "bin", "jar");
+		}
 
 		public override byte [] Build ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -167,6 +167,10 @@
       <Name>libzip-windows</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\..\external\xamarin-android-tools\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj">
+      <Project>{E34BCFA0-CAA4-412C-AA1C-75DB8D67D157}</Project>
+      <Name>Xamarin.Android.Tools.AndroidSdk</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
- `JavacFullPath` was  hardcoded to `javac`
- `JarFullPath` was hardcoded to `jar`
- Now uses `AndroidSdkInfo` to locate java
- Tests using this should now pass on Windows