### PR TITLE
[Xamarin.Android.Build.Tests] Give every test its own fixture.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SOLUTION      = Xamarin.Android.sln
 NUNIT_TESTS = \
 	bin/Test$(CONFIGURATION)/Xamarin.Android.Build.Tests.dll
 
-NUNIT_CONSOLE = packages/NUnit.ConsoleRunner.3.6.0/tools/nunit3-console.exe
+NUNIT_CONSOLE = packages/NUnit.ConsoleRunner.3.7.0/tools/nunit3-console.exe
 
 ifneq ($(V),0)
 MONO_OPTIONS += --debug
@@ -133,7 +133,7 @@ define RUN_NUNIT_TEST
 	MONO_TRACE_LISTENER=Console.Out \
 	$(RUNTIME) --runtime=v4.0.0 \
 		$(NUNIT_CONSOLE) $(NUNIT_EXTRA) $(1) \
-		$(if $(RUN),-run:$(RUN)) \
+		$(if $(TEST),--test=$(TEST)) \
 		--result="TestResult-$(basename $(notdir $(1))).xml;format=nunit2" \
 		-output=bin/Test$(CONFIGURATION)/TestOutput-$(basename $(notdir $(1))).txt \
 	|| true ; \

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Android.Build.Tests
 {
 	[TestFixture]
 	[Parallelizable (ParallelScope.Fixtures)]
-	public class AndroidUpdateResourcesTest : BaseTest
+	public class RepetitiveBuildTestFixture : BaseTest
 	{
 		[Test]
 		public void RepetitiveBuild ()
@@ -34,7 +34,11 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsFalse (b.LastBuildOutput.Contains ("Skipping target \"_Sign\" because"), "incorrectly skipped some build");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class DesignTimeBuildTestFixture : BaseTest
+	{
 		[Test]
 		public void DesignTimeBuild ([Values(false, true)] bool isRelease, [Values (false, true)] bool useManagedParser)
 		{
@@ -114,7 +118,11 @@ using System.Runtime.CompilerServices;
 				}
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class CheckEmbeddedSupportLibraryResourcesTestFixture : BaseTest
+	{
 		[Test]
 		public void CheckEmbeddedSupportLibraryResources ()
 		{
@@ -137,7 +145,11 @@ using System.Runtime.CompilerServices;
 				Assert.IsTrue (File.Exists (Rdrawable), $"{Rdrawable} should exist");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class MoveResourceTestFixture : BaseTest
+	{
 		[Test]
 		public void MoveResource ()
 		{
@@ -159,7 +171,11 @@ using System.Runtime.CompilerServices;
 				Assert.IsFalse (b.LastBuildOutput.Contains ("Skipping target \"_Sign\" because"), "incorrectly skipped some build");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class ReportAaptErrorsInOrigionalFileNameTestFixture : BaseTest
+	{
 		[Test]
 		public void ReportAaptErrorsInOriginalFileName ()
 		{
@@ -172,7 +188,11 @@ using System.Runtime.CompilerServices;
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class RepetiviteBuildUpdateSingleResourceTestFixture : BaseTest
+	{
 		[Test]
 		public void RepetiviteBuildUpdateSingleResource ()
 		{
@@ -216,7 +236,11 @@ using System.Runtime.CompilerServices;
 					"The Target _CreateBaseApk should not have been skipped");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class Check9PatchFilesAreProcessedTestFixture : BaseTest
+	{
 		[Test]
 		public void Check9PatchFilesAreProcessed ([Values(false, true)] bool explicitCrunch)
 		{
@@ -269,7 +293,11 @@ using System.Runtime.CompilerServices;
 				}
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class CheckXmlResourcesFilesAreProcessedTestFixture : BaseTest
+	{
 		[Test]
 		/// <summary>
 		/// Based on https://bugzilla.xamarin.com/show_bug.cgi?id=29263
@@ -372,7 +400,11 @@ namespace UnnamedProject
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class CheckResourceDesignerIsCreatedTestFixture : BaseTest
+	{
 		static object[] ReleaseLanguage = new object[] {
 			new object[] { false, XamarinAndroidProjectLanguage.CSharp },
 			new object[] { true, XamarinAndroidProjectLanguage.CSharp },
@@ -400,9 +432,13 @@ namespace UnnamedProject
 					proj.IntermediateOutputPath, proj.Language.DefaultExtension);
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class CheckResourceDesignerIsUpdatedWhenReadOnlyTestFixture : BaseTest
+	{
 		[Test]
-		[TestCaseSource("ReleaseLanguage")]
+		[TestCaseSource(typeof(CheckResourceDesignerIsCreatedTestFixture), "ReleaseLanguage")]
 		public void CheckResourceDesignerIsUpdatedWhenReadOnly (bool isRelease, ProjectLanguage language)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
@@ -423,9 +459,13 @@ namespace UnnamedProject
 					"{0} should be writable", designerPath);
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class CheckOldResourceDesignerIsNotUsedTestFixture : BaseTest
+	{
 		[Test]
-		[TestCaseSource("ReleaseLanguage")]
+		[TestCaseSource(typeof (CheckResourceDesignerIsCreatedTestFixture), "ReleaseLanguage")]
 		public void CheckOldResourceDesignerIsNotUsed (bool isRelease, ProjectLanguage language)
 		{
 			if (language == XamarinAndroidProjectLanguage.FSharp)
@@ -453,10 +493,14 @@ namespace UnnamedProject
 					proj.IntermediateOutputPath, proj.Language.DefaultDesignerExtension);
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class CheckOldResourceDesignerWithWrongCasingIsRemovedTestFixture : BaseTest
+	{
 		// ref https://bugzilla.xamarin.com/show_bug.cgi?id=30089
 		[Test]
-		[TestCaseSource("ReleaseLanguage")]
+		[TestCaseSource(typeof (CheckResourceDesignerIsCreatedTestFixture), "ReleaseLanguage")]
 		public void CheckOldResourceDesignerWithWrongCasingIsRemoved (bool isRelease, ProjectLanguage language)
 		{
 			if (language == XamarinAndroidProjectLanguage.FSharp)
@@ -485,7 +529,11 @@ namespace UnnamedProject
 					proj.IntermediateOutputPath, proj.Language.DefaultDesignerExtension);
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class TargetGenerateJavaDesignerForComponentIsSkippedTestFixture : BaseTest
+	{
 		[Test]
 		public void TargetGenerateJavaDesignerForComponentIsSkipped ([Values(false, true)] bool isRelease)
 		{ 
@@ -515,7 +563,11 @@ namespace UnnamedProject
 					b.LastBuildOutput, "Target _GenerateJavaDesignerForComponent should not have been skipped");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class CheckAaptErrorRaisedForMissingResourceTestFixture : BaseTest
+	{
 		[Test]
 		public void CheckAaptErrorRaisedForMissingResource ()
 		{
@@ -543,7 +595,11 @@ namespace UnnamedProject
 				StringAssert.Contains ("2 Error(s)", b.LastBuildOutput);
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class CheckAaptErrorRaisedForInvalidDirectoryNameTestFixture : BaseTest
+	{
 		[Test]
 		public void CheckAaptErrorRaisedForInvalidDirectoryName ()
 		{
@@ -562,7 +618,11 @@ namespace UnnamedProject
 				StringAssert.Contains ("1 Error(s)", b.LastBuildOutput);
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class CheckAaptErrorRaisedForInvalidFileNameTestFixture : BaseTest
+	{
 		[Test]
 		public void CheckAaptErrorRaisedForInvalidFileName ()
 		{
@@ -579,7 +639,11 @@ namespace UnnamedProject
 				StringAssert.Contains ("1 Error(s)", b.LastBuildOutput);
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class CheckAaptErrorRaisedForDuplicateResourceinAppTestFixture : BaseTest
+	{
 		[Test]
 		public void CheckAaptErrorRaisedForDuplicateResourceinApp ()
 		{
@@ -601,7 +665,11 @@ namespace UnnamedProject
 				StringAssert.Contains ("2 Error(s)", b.LastBuildOutput);
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class CheckWarningsRaisedForDuplicateResourcesAcrossEntireProjectTestFixture : BaseTest
+	{
 		[Test]
 		[Ignore ("Ignore until our own MergeResources is implemented")]
 		public void CheckWarningsRaisedForDuplicateResourcesAcrossEntireProject () 
@@ -670,7 +738,11 @@ namespace UnnamedProject
 				}
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class InternationalResourceTestTestFixture : BaseTest
+	{
 		[Test]
 		[Ignore ("Enable once Merge Resources is finished")]
 		public void InternationalResourceTest ([Values (false, true)] bool explicitCrunch)
@@ -749,7 +821,11 @@ namespace UnnamedProject
 				}
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class MergeResourcesTestFixture : BaseTest
+	{
 		[Test]
 		[Ignore ("Enable once Merge Resources is finished")]
 		public void MergeResources ([Values(false, true)] bool explicitCrunch)
@@ -836,7 +912,11 @@ namespace UnnamedProject
 				}
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class CheckFilesAreRemovedTestFixture : BaseTest
+	{
 		[Test]
 		public void CheckFilesAreRemoved () {
 
@@ -872,7 +952,11 @@ namespace UnnamedProject
 					"Theme.xml was NOT removed from the intermediate directory");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class CheckDontUpdateResourceIfNotNeededTestFixture : BaseTest
+	{
 		[Test]
 		public void CheckDontUpdateResourceIfNotNeeded ()
 		{
@@ -944,7 +1028,11 @@ namespace Lib1 {
 				}
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class BuildAppWithManagedResourceParserTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildAppWithManagedResourceParser()
 		{
@@ -981,7 +1069,11 @@ namespace Lib1 {
 
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public class BuildAppWithManagedResourceParserAndLibrariesTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildAppWithManagedResourceParserAndLibraries ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 
 namespace Xamarin.Android.Build.Tests
 {
-	[Parallelizable (ParallelScope.Fixtures)]
+	[Parallelizable (ParallelScope.Fixtures | ParallelScope.Children)]
 	public class BindingBuildTest : BaseTest
 	{
 #pragma warning disable 414
@@ -18,7 +18,7 @@ namespace Xamarin.Android.Build.Tests
 		};
 
 		[Test]
-		[TestCaseSource ("ClassParseOptions")]
+		[TestCaseSource (typeof(BindingBuildTest), "ClassParseOptions")]
 		public void BuildBasicBindingLibrary (string classParser)
 		{
 			var proj = new XamarinAndroidBindingProject () {
@@ -34,7 +34,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[TestCaseSource ("ClassParseOptions")]
+		[TestCaseSource (typeof (BindingBuildTest), "ClassParseOptions")]
 		public void CleanBasicBindingLibrary (string classParser)
 		{
 			var proj = new XamarinAndroidBindingProject () {
@@ -57,7 +57,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[TestCaseSource ("ClassParseOptions")]
+		[TestCaseSource (typeof (BindingBuildTest), "ClassParseOptions")]
 		public void BuildAarBindigLibraryStandalone (string classParser)
 		{
 			var proj = new XamarinAndroidBindingProject () {
@@ -75,7 +75,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[TestCaseSource ("ClassParseOptions")]
+		[TestCaseSource (typeof (BindingBuildTest), "ClassParseOptions")]
 		public void BuildAarBindigLibraryWithNuGetPackageOfJar (string classParser)
 		{
 			var proj = new XamarinAndroidBindingProject () {
@@ -100,7 +100,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[TestCaseSource ("ClassParseOptions")]
+		[TestCaseSource (typeof (BindingBuildTest), "ClassParseOptions")]
 		public void BuildLibraryZipBindigLibraryWithAarOfJar (string classParser)
 		{
 			var proj = new XamarinAndroidBindingProject () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildAssetsTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildAssetsTest.cs
@@ -9,6 +9,7 @@ using System.Xml.Linq;
 
 namespace Xamarin.Android.Build.Tests
 {
+	[Parallelizable (ParallelScope.Fixtures | ParallelScope.Children)]
 	public class BuildAssetsTest : BaseTest
 	{
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -11,7 +11,7 @@ using Xamarin.ProjectTools;
 namespace Xamarin.Android.Build.Tests
 {
 	[Parallelizable (ParallelScope.Fixtures)]
-	public partial class BuildTest : BaseTest
+	public partial class BuildBasicApplicationTextFixture : BaseTest
 	{
 		[Test]
 		public void BuildBasicApplication ()
@@ -21,7 +21,11 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildBasicApplicationReleaseTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildBasicApplicationRelease ()
 		{
@@ -30,7 +34,11 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildBasicApplicationFSharpTestFixture : BaseTest
+	{
 		[Test]
 		[Category ("Minor")]
 		public void BuildBasicApplicationFSharp ()
@@ -40,7 +48,11 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildBasicApplicationReleaseFSharpTestFixture : BaseTest
+	{
 		[Test]
 		[Category ("Minor")]
 		public void BuildBasicApplicationReleaseFSharp ()
@@ -50,7 +62,11 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class FSharpAppHasAndroidDefineTestFixture : BaseTest
+	{
 		[Test]
 		public void FSharpAppHasAndroidDefine ()
 		{
@@ -73,7 +89,11 @@ printf ""%d"" x
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildApplicationAndCleanTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildApplicationAndClean ([Values (false, true)] bool isRelease)
 		{
@@ -91,7 +111,11 @@ printf ""%d"" x
 				Assert.AreEqual (0, files.Count (), "{0} should be Empty. Found {1}", proj.OutputPath, string.Join (Environment.NewLine, files));
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildApplicationWithLibraryAndCleanTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildApplicationWithLibraryAndClean ([Values (false, true)] bool isRelease)
 		{
@@ -141,7 +165,11 @@ printf ""%d"" x
 				}
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildMkBundleApplicationReleaseTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildMkBundleApplicationRelease ()
 		{
@@ -166,7 +194,11 @@ printf ""%d"" x
 				}
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildMkBundleApplicationReleaseAllAbiTestFixture : BaseTest
+	{
 		[Test]
 		[Category ("Minor")]
 		public void BuildMkBundleApplicationReleaseAllAbi ()
@@ -195,9 +227,13 @@ printf ""%d"" x
 				}
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildAotApplicationTestFixture : BaseTest
+	{
 		[Test]
-		[TestCaseSource ("AotChecks")]
+		[TestCaseSource (typeof(BuildTest), "AotChecks")]
 		[Category ("Minor")]
 		public void BuildAotApplication (string supportedAbis, bool enableLLVM, bool expectedResult)
 		{
@@ -265,9 +301,13 @@ printf ""%d"" x
 					"the _BuildApkEmbed target should be skipped");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildAotApplicationAndBundleTestFixture : BaseTest
+	{
 		[Test]
-		[TestCaseSource ("AotChecks")]
+		[TestCaseSource (typeof (BuildTest), "AotChecks")]
 		[Category ("Minor")]
 		public void BuildAotApplicationAndBundle (string supportedAbis, bool enableLLVM, bool expectedResult)
 		{
@@ -316,9 +356,13 @@ printf ""%d"" x
 					"the _BuildApkEmbed target should be skipped");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildProguardEnabledProjectTestFixture : BaseTest
+	{
 		[Test]
-		[TestCaseSource ("ProguardChecks")]
+		[TestCaseSource (typeof (BuildTest), "ProguardChecks")]
 		public void BuildProguardEnabledProject (bool isRelease, bool enableProguard, bool useLatestSdk)
 		{
 			var proj = new XamarinAndroidApplicationProject () { IsRelease = isRelease, EnableProguard = enableProguard, UseLatestPlatformSdk = useLatestSdk, TargetFrameworkVersion = useLatestSdk ? "v7.1" : "v5.0" };
@@ -326,25 +370,11 @@ printf ""%d"" x
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}
 		}
+	}
 
-		XamarinAndroidApplicationProject CreateMultiDexRequiredApplication (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
-		{
-			var proj = new XamarinAndroidApplicationProject (debugConfigurationName, releaseConfigurationName);
-			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods.java") {
-				TextContent = () => "public class ManyMethods { \n"
-					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
-					+ "}",
-				Encoding = Encoding.ASCII
-			});
-			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods2.java") {
-				TextContent = () => "public class ManyMethods2 { \n"
-					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
-					+ "}",
-				Encoding = Encoding.ASCII
-			});
-			return proj;
-		}
-
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildApplicationOver65536MethodsTestFixture : BaseTest
+	{
 		[Test]
 		[Category ("Minor")]
 		public void BuildApplicationOver65536Methods ()
@@ -356,7 +386,11 @@ printf ""%d"" x
 				b.Clean (proj);
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class CreateMultiDexWithSpacesInConfigTestFixture : BaseTest
+	{
 		[Test]
 		public void CreateMultiDexWithSpacesInConfig ()
 		{
@@ -367,9 +401,13 @@ printf ""%d"" x
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildMultiDexApplicationTestFixture : BaseTest
+	{
 		[Test]
-		[TestCaseSource ("JackFlagAndFxVersion")]
+		[TestCaseSource (typeof (BuildTest), "JackFlagAndFxVersion")]
 		public void BuildMultiDexApplication (bool useJackAndJill, string fxVersion)
 		{
 			var proj = CreateMultiDexRequiredApplication ();
@@ -387,7 +425,11 @@ printf ""%d"" x
 				Assert.IsTrue (b.LastBuildOutput.Contains (Path.Combine (proj.TargetFrameworkVersion, "mono.android.jar")), proj.TargetFrameworkVersion + "/mono.android.jar should be used.");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class MultiDexCustomMainDexFileListTestFixture : BaseTest
+	{
 		[Test]
 		public void MultiDexCustomMainDexFileList ()
 		{
@@ -402,7 +444,11 @@ printf ""%d"" x
 			b.Clean (proj);
 			b.Dispose ();
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class CustomApplicationClassAndMultiDexTestFixture : BaseTest
+	{
 		[Test]
 		public void CustomApplicationClassAndMultiDex ()
 		{
@@ -433,7 +479,11 @@ namespace UnnamedProject {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BasicApplicationRepetitiveBuildTestFixture : BaseTest
+	{
 		[Test]
 		public void BasicApplicationRepetitiveBuild ()
 		{
@@ -461,7 +511,11 @@ namespace UnnamedProject {
 					"the _Sign target should run");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BasicApplicationRepetitiveReleaseBuildTestFixture : BaseTest
+	{
 		[Test]
 		public void BasicApplicationRepetitiveReleaseBuild ()
 		{
@@ -503,7 +557,11 @@ namespace UnnamedProject {
 					"the _Sign target should run");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildBasicApplicationCheckMdbTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildBasicApplicationCheckMdb ()
 		{
@@ -516,7 +574,11 @@ namespace UnnamedProject {
 					"UnnamedProject.dll.mdb must be copied to the Intermediate directory");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildBasicApplicationCheckMdbRepeatBuildTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildBasicApplicationCheckMdbRepeatBuild ()
 		{
@@ -538,7 +600,11 @@ namespace UnnamedProject {
 					"UnnamedProject.dll.mdb must be copied to the Intermediate directory");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildAppCheckDebugSymbolsTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildAppCheckDebugSymbols ()
 		{
@@ -602,7 +668,11 @@ namespace App1
 				}
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildBasicApplicationCheckMdbAndPortablePdbTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildBasicApplicationCheckMdbAndPortablePdb ()
 		{
@@ -661,7 +731,11 @@ namespace App1
 					"{0} should have been updated", pdbToMdbPath);
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildBasicApplicationCheckConfigFilesTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildBasicApplicationCheckConfigFiles ()
 		{
@@ -687,7 +761,12 @@ namespace App1
 					"the _CopyConfigFiles target should be skipped");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildApplicationCheckItEmitsAWarningWithContentItemsTestFixture : BaseTest
+	{
+		[Test]
 		public void BuildApplicationCheckItEmitsAWarningWithContentItems ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -708,7 +787,11 @@ namespace App1
 					"Build Output did not contain the correct error message");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildApplicationCheckThatAddStaticResourcesTargetDoesNotRerunTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildApplicationCheckThatAddStaticResourcesTargetDoesNotRerun ()
 		{
@@ -727,7 +810,11 @@ namespace App1
 					"The _AddStaticResources should NOT have been run");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class AaptErrorWhenDuplicateStringEntryTestFixture : BaseTest
+	{
 		[Test]
 		[Ignore ("Re enable when MergeResources work is complete")]
 		public void AaptErrorWhenDuplicateStringEntry ()
@@ -746,7 +833,11 @@ namespace App1
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class CheckJavaErrorTestFixture : BaseTest
+	{
 		[Test]
 		public void CheckJavaError ()
 		{
@@ -775,7 +866,11 @@ namespace App1
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class XA5213IsRaisedWhenOutOfMemoryErrorIsThrownTestFixture : BaseTest
+	{
 		[Test]
 		/// <summary>
 		/// Based on issue raised in
@@ -835,7 +930,11 @@ namespace App1
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class DuplicateValuesInResourceCaseMapTestFixture : BaseTest
+	{
 		[Test]
 		/// <summary>
 		/// Based on issue raised in
@@ -862,7 +961,11 @@ namespace App1
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class CheckLintErrorsAndWarningsTestFixture : BaseTest
+	{
 		[Test]
 		public void CheckLintErrorsAndWarnings ()
 		{
@@ -886,7 +989,11 @@ namespace App1
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class CheckLintConfigMergingTestFixture : BaseTest
+	{
 		[Test]
 		public void CheckLintConfigMerging ()
 		{
@@ -921,7 +1028,11 @@ namespace App1
 				Assert.IsFalse (File.Exists (lintFile), "{0} should have been deleted on clean.", lintFile);
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildLibraryWhichUsesResourcesTestFixture : BaseTest
+	{
 		[Test]
 		/// <summary>
 		/// Reference https://bugzilla.xamarin.com/show_bug.cgi?id=29568
@@ -944,7 +1055,11 @@ namespace App1
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class TestAndroidStoreKeyTestFixture : BaseTest
+	{
 #pragma warning disable 414
 		static object [] AndroidStoreKeyTests = new object [] {
 						// isRelease, AndroidKeyStore, ExpectedResult
@@ -984,7 +1099,11 @@ namespace App1
 					"The Wrong keystore was used to sign the apk");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildApplicationWithJavaSourceTestFixture : BaseTest
+	{
 #pragma warning disable 414
 		static object [] BuildApplicationWithJavaSourceChecks = new object [] {
 			new object[] {
@@ -1028,9 +1147,13 @@ namespace App1
 			} finally {
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class CheckWhichRuntimeIsIncludedTestFixture : BaseTest
+	{
 		[Test]
-		[TestCaseSource ("RuntimeChecks")]
+		[TestCaseSource (typeof (BuildTest), "RuntimeChecks")]
 		public void CheckWhichRuntimeIsIncluded (string[] supportedAbi, bool debugSymbols, string debugType, bool? optimize, bool? embedassebmlies, string expectedRuntime) {
 			var proj = new XamarinAndroidApplicationProject ();
 			proj.SetProperty (proj.ActiveConfigurationProperties, "DebugSymbols", debugSymbols);
@@ -1066,9 +1189,13 @@ namespace App1
 				}
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class CheckSequencePointGenerationTestFixture : BaseTest
+	{
 		[Test]
-		[TestCaseSource ("SequencePointChecks")]
+		[TestCaseSource (typeof (BuildTest), "SequencePointChecks")]
 		public void CheckSequencePointGeneration (bool isRelease, bool monoSymbolArchive, bool aotAssemblies,
 			bool debugSymbols, string debugType, bool embedMdb, string expectedRuntime)
 		{
@@ -1132,7 +1259,11 @@ namespace App1
 				Assert.IsTrue (!Directory.Exists (msymarchive), "{0} should have been deleted on Clean", msymarchive);
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildApplicationWithMonoEnvironmentTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildApplicationWithMonoEnvironment ([Values ("", "Normal", "Offline")] string sequencePointsMode)
 		{
@@ -1162,7 +1293,11 @@ namespace App1
 				}
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class CheckMonoDebugIsAddedToEnvironmentTestFixture : BaseTest
+	{
 		[Test]
 		public void CheckMonoDebugIsAddedToEnvironment ([Values ("", "Normal", "Offline")] string sequencePointsMode)
 		{
@@ -1190,7 +1325,11 @@ namespace App1
 				}
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildWithNativeLibrariesTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildWithNativeLibraries ([Values (true, false)] bool isRelease)
 		{
@@ -1269,7 +1408,11 @@ namespace App1
 			}
 			Directory.Delete (path, recursive: true);
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildWithExternalJavaLibraryTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildWithExternalJavaLibrary ()
 		{
@@ -1293,7 +1436,11 @@ namespace App1
 				}
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class CheckItemMetadataTestFixture : BaseTest
+	{
 		[Test]
 		public void CheckItemMetadata ([Values (true, false)] bool isRelease)
 		{
@@ -1330,7 +1477,11 @@ namespace App1
 				StringAssert.Contains ("ResourceMetaDataOK", builder.LastBuildOutput, "Metadata was not copied for AndroidResource");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class CheckLogicalNamePathSeperatorsTestFixture : BaseTest
+	{
 		// Context https://bugzilla.xamarin.com/show_bug.cgi?id=29706
 		[Test]
 		public void CheckLogicalNamePathSeperators ([Values (false, true)] bool isRelease)
@@ -1370,7 +1521,11 @@ namespace App1
 				}
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class ApplicationJavaClassPropertiesTestFixture : BaseTest
+	{
 		[Test]
 		public void ApplicationJavaClassProperties ()
 		{
@@ -1382,7 +1537,11 @@ namespace App1
 			Assert.IsTrue (appsrc.Contains ("android.test.mock.MockApplication"), "app class");
 			builder.Dispose ();
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class ApplicationIdPlaceholderTestFixture : BaseTest
+	{
 		[Test]
 		public void ApplicationIdPlaceholder ()
 		{
@@ -1394,7 +1553,11 @@ namespace App1
 			Assert.IsTrue (appsrc.Contains ("<provider android:name=\"UnnamedProject.UnnamedProject\""), "placeholder not replaced");
 			builder.Dispose ();
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class ResourceExtractionTestFixture : BaseTest
+	{
 		[Test]
 		public void ResourceExtraction ()
 		{
@@ -1419,7 +1582,11 @@ namespace App1
 				Assert.IsTrue (builder.Build (proj), "Second Build should have succeeded");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class CheckTargetFrameworkVersionTestFixture : BaseTest
+	{
 		[Test]
 		public void CheckTargetFrameworkVersion ([Values (true, false)] bool isRelease)
 		{
@@ -1435,7 +1602,11 @@ namespace App1
 
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class GeneratorValidateEventNameTestFixture : BaseTest
+	{
 #pragma warning disable 414
 		public static object [] GeneratorValidateEventNameArgs = new object [] {
 			new object [] { false, true, string.Empty, string.Empty },
@@ -1503,7 +1674,11 @@ public class Test
 				Assert.AreEqual (failureExpected, !result, "Should build fail?");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class GeneratorValidateMultiMethodEventNameTestFixture : BaseTest
+	{
 #pragma warning disable 414
 		public static object [] GeneratorValidateMultiMethodEventNameArgs = new object [] {
 			new object [] { false, "BG8505", string.Empty, string.Empty },
@@ -1570,7 +1745,11 @@ public class Test
 				}
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildReleaseApplicationTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildReleaseApplication ()
 		{
@@ -1581,7 +1760,11 @@ public class Test
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildReleaseApplicationWithSpacesInPathTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildReleaseApplicationWithSpacesInPath ()
 		{
@@ -1605,7 +1788,11 @@ public class Test
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildReleaseApplicationWithNugetPackagesTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildReleaseApplicationWithNugetPackages ()
 		{
@@ -1621,7 +1808,11 @@ public class Test
 										"Nuget Package Xamarin.Android.Support.v4.21.0.3.0 should have been restored.");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildWithTlsProviderTestFixture : BaseTest
+	{
 		static object [] TlsProviderTestCases =
 		{
 			// androidTlsProvider, isRelease, extpected
@@ -1658,7 +1849,11 @@ public class Test
 				}
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildAfterAddingNugetTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildAfterAddingNuget ()
 		{
@@ -1675,9 +1870,13 @@ public class Test
 				Assert.IsTrue (doc.Contains ("Xamarin.Android.Support.v7.CardView/24.2.1"), "CardView should be resolved as a reference.");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class CheckTargetFrameworkVersion2TestFixture : BaseTest
+	{
 		[Test]
-		public void CheckTargetFrameworkVersion ()
+		public void CheckTargetFrameworkVersion2 ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
@@ -1690,7 +1889,11 @@ public class Test
 				StringAssert.Contains ($"TargetFrameworkVersion: v4.4", builder.LastBuildOutput, "TargetFrameworkVerson should be v4.4");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildBasicApplicationCheckPdbTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildBasicApplicationCheckPdb ()
 		{
@@ -1763,7 +1966,11 @@ public class Test
 					"{0} should have been updated", pdbToMdbPath);
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildInDesignTimeModeTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildInDesignTimeMode ([Values(false, true)] bool useManagedParser)
 		{
@@ -1782,7 +1989,11 @@ public class Test
 				Assert.IsTrue (builder.Output.IsTargetSkipped ("_ResolveLibraryProjectImports"), "target \"_ResolveLibraryProjectImports\' should have been skipped.");
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class CheckLibraryImportsUpgradeTestFixture : BaseTest
+	{
 		[Test]
 		public void CheckLibraryImportsUpgrade ([Values(false, true)] bool useShortFileNames)
 		{
@@ -1830,7 +2041,11 @@ public class Test
 				}
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class ValidateJavaVersionTestFixture : BaseTest
+	{
 #pragma warning disable 414
 		static object [] validateJavaVersionTestCases = new object [] {
 			new object [] {
@@ -1928,7 +2143,11 @@ public class Test
 				}), string.Format ("Build should have {0}", expectedResult ? "succeeded" : "failed"));
 			}
 		}
+	}
 
+	[Parallelizable (ParallelScope.Fixtures)]
+	public partial class BuildAMassiveAppTestFixture : BaseTest
+	{
 		[Test]
 		public void BuildAMassiveApp()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -677,7 +677,7 @@ namespace App1
 		public void BuildBasicApplicationCheckMdbAndPortablePdb ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
-			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationCheckPdb")) {
+			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationCheckMdbAndPortablePdb")) {
 				b.Verbosity = LoggerVerbosity.Diagnostic;
 				var reference = new BuildItem.Reference ("PdbTestLibrary.dll") {
 					WebContent = "https://www.dropbox.com/s/s4br29kvuy8ygz1/PdbTestLibrary.dll?dl=1"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -10,7 +10,7 @@ using System.Xml.Linq;
 namespace Xamarin.Android.Build.Tests
 {
 	[TestFixture]
-	[Parallelizable (ParallelScope.Fixtures)]
+	[Parallelizable (ParallelScope.Fixtures | ParallelScope.Children)]
 	public class IncrementalBuildTest : BaseTest
 	{
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -10,6 +10,7 @@ using Xamarin.Tools.Zip;
 
 namespace Xamarin.Android.Build.Tests
 {
+	[Parallelizable (ParallelScope.Fixtures | ParallelScope.Children)]
 	public partial class ManifestTest : BaseTest
 	{
 		readonly string TargetSdkManifest = @"<?xml version=""1.0"" encoding=""utf-8""?>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -9,7 +9,7 @@ using System.Xml.Linq;
 
 namespace Xamarin.Android.Build.Tests
 {
-	[Parallelizable (ParallelScope.Fixtures)]
+	[Parallelizable (ParallelScope.Fixtures | ParallelScope.Children)]
 	public class PackagingTest : BaseTest
 	{
 #pragma warning disable 414

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -159,6 +159,24 @@ namespace Xamarin.Android.Build.Tests
 			return BuildHelper.CreateDllBuilder (directory, cleanupAfterSuccessfulBuild, cleanupOnDispose);
 		}
 
+		protected XamarinAndroidApplicationProject CreateMultiDexRequiredApplication (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
+		{
+			var proj = new XamarinAndroidApplicationProject (debugConfigurationName, releaseConfigurationName);
+			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods.java") {
+				TextContent = () => "public class ManyMethods { \n"
+					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
+					+ "}",
+				Encoding = Encoding.ASCII
+			});
+			proj.OtherBuildItems.Add (new BuildItem (AndroidBuildActions.AndroidJavaSource, "ManyMethods2.java") {
+				TextContent = () => "public class ManyMethods2 { \n"
+					+ string.Join (Environment.NewLine, Enumerable.Range (0, 32768).Select (i => "public void method" + i + "() {}"))
+					+ "}",
+				Encoding = Encoding.ASCII
+			});
+			return proj;
+		}
+
 		[OneTimeSetUp]
 		public void FixtureSetup ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -36,7 +36,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="nunit.framework">
-      <HintPath>..\..\..\..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
+      <HintPath>..\..\..\..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.6.0" targetFramework="net451" />
-  <package id="NUnit.Console" version="3.6.0" targetFramework="net451" />
-  <package id="NUnit.ConsoleRunner" version="3.6.0" targetFramework="net451" />
+  <package id="NUnit" version="3.8.1" targetFramework="net451" />
+  <package id="NUnit.Console" version="3.7.0" targetFramework="net451" />
+  <package id="NUnit.ConsoleRunner" version="3.7.0" targetFramework="net451" />
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net451" />
-  <package id="NUnit.Extension.NUnitV2Driver" version="3.6.0" targetFramework="net451" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.7.0" targetFramework="net451" />
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net451" />
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net451" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.6.0" targetFramework="net451" />


### PR DESCRIPTION
In an effort to speed up the tests by allows more
parallelization we are giving each test its own fixture.
This should allow more tests to run at once.