### PR TITLE
[Mono.Android] Fix ViewStructure enumification (take 2!) (#901)

### DIFF
--- a/build-tools/enumification-helpers/methodmap.ext.csv
+++ b/build-tools/enumification-helpers/methodmap.ext.csv
@@ -1607,7 +1607,7 @@
 26, android.bluetooth, BluetoothGattServer, setPreferredPhy, rxPhy, Android.Bluetooth.BluetoothPhy
 26, android.bluetooth, BluetoothGattServer, setPreferredPhy, phyOptions, Android.Bluetooth.BluetoothPhyOption
 
-26, android.view, ViewStructure, setAutofillType, p0, Android.Views.AutofillType
+26, android.view, ViewStructure, setAutofillType, type, Android.Views.AutofillType
 26, android.view, Window, getColorMode, return, Android.Content.PM.ActivityColorMode
 26, android.view, Window, setColorMode, colorMode, Android.Content.PM.ActivityColorMode
 26, android.view, WindowManager.LayoutParams, getColorMode, return, Android.Content.PM.ActivityColorMode

--- a/src/Mono.Android/methodmap.csv
+++ b/src/Mono.Android/methodmap.csv
@@ -2203,7 +2203,7 @@
 26, android.bluetooth, BluetoothGattServer, setPreferredPhy, rxPhy, Android.Bluetooth.BluetoothPhy
 26, android.bluetooth, BluetoothGattServer, setPreferredPhy, phyOptions, Android.Bluetooth.BluetoothPhyOption
 
-26, android.view, ViewStructure, setAutofillType, p0, Android.Views.AutofillType
+26, android.view, ViewStructure, setAutofillType, type, Android.Views.AutofillType
 26, android.view, Window, getColorMode, return, Android.Content.PM.ActivityColorMode
 26, android.view, Window, setColorMode, colorMode, Android.Content.PM.ActivityColorMode
 26, android.view, WindowManager.LayoutParams, getColorMode, return, Android.Content.PM.ActivityColorMode


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=59655

Bumps to xamarin-android-api-compatibility/d15-4/f25a3d55.

Commit f6f521e6 inadvertently reverted commit 3fc03b33.

Doh!

Re-fix Bug #59655 and enumify `ViewStructure.SetAutofillType()`.