### PR TITLE
[Xamarin.Android.Build.Tasks] libpng warnings are errors? (#900)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -365,6 +365,10 @@ namespace Xamarin.Android.Tasks
 				if (!string.IsNullOrEmpty (match.Groups["line"]?.Value))
 					line = int.Parse (match.Groups["line"].Value) + 1;
 				var error = match.Groups["message"].Value;
+				if (error.Contains ("warning")) {
+					LogWarning (singleLine);
+					return;
+				}
 
 				// Try to map back to the original resource file, so when the user
 				// double clicks the error, it won't take them to the obj/Debug copy


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=59764

Our regex to pick up error messages from the android tooling is
picking up *warnings*:

	obj/Debug/res/drawable-nodpi/background_started.png: libpng warning: iCCP: Not recognizing known sRGB profile that has been edited

This is because the format matches our error regex.

So we need to ignore things that have "warning" in them and log
those as actual warnings, instead of percolating them as errors.