### PR TITLE
[tests] fix for Adb task on Windows

### DIFF
--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/PathToolTask.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/PathToolTask.cs
@@ -9,6 +9,11 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 	{
 		protected   abstract    string          ToolBaseName { get; }
 
+		public      override    string          ToolExe {
+			get { return base.ToolExe; }
+			set { if (value != ToolBaseName) base.ToolExe = value; }
+		}
+
 		protected   override    string          ToolName {
 			get {
 				var dirs = string.IsNullOrEmpty (ToolPath)


### PR DESCRIPTION
Context: The `Adb` task inherits `PathToolTask`, which inherits
`ToolTask`.

The `Adb` task's `ToolExe` is commonly set to `$(AdbToolExe)`. The
problem with this is that `Microsoft.Build.Utilities.ToolTask` has its
own validation that checks if the file exists. On Windows, a file named
`adb` does not exist, because it is named `adb.exe`.

The solution here is to not set `base.ToolExe` if the incoming value
already matches `ToolBaseName`. This prevents the validation, and
`PathToolTask` can continue to use `Which` appropriately to either find
`adb` or `adb.exe` depending on the platform. This also allows
`$(AdbToolExe)` to be overidden if needed.