### PR TITLE
[tests] fixes for emulator creation on Windows

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -125,7 +125,7 @@
       <HostOS></HostOS>
       <DestDir>extras\android\m2repository</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="x86-21_r04.zip">
+    <AndroidSdkItem Include="x86-21_r05.zip">
       <HostOS></HostOS>
       <RelUrl>sys-img/android/</RelUrl>
       <DestDir>system-images\android-21\default\x86</DestDir>

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -28,6 +28,7 @@
         Condition=" '$(_ValidAdbTarget)' != 'True' "
         AndroidAbi="x86"
         AndroidSdkHome="$(AndroidSdkDirectory)"
+        JavaSdkHome="$(JavaSdkDirectory)"
         SdkVersion="21"
         ImageName="$(_TestImageName)"
         ToolExe="$(AvdManagerToolExe)"

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateAndroidEmulator.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateAndroidEmulator.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		public                  string          SdkVersion      {get; set;}
 		public                  string          AndroidAbi      {get; set;}
 		public                  string          AndroidSdkHome  {get; set;}
+		public                  string          JavaSdkHome     {get; set;}
 
 		public                  string          ToolPath        {get; set;}
 		public                  string          ToolExe         {get; set;}
@@ -31,6 +32,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			Log.LogMessage (MessageImportance.Low, $"Task {nameof (CreateAndroidEmulator)}");
 			Log.LogMessage (MessageImportance.Low, $"  {nameof (AndroidAbi)}: {AndroidAbi}");
 			Log.LogMessage (MessageImportance.Low, $"  {nameof (AndroidSdkHome)}: {AndroidSdkHome}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (JavaSdkHome)}: {JavaSdkHome}");
 			Log.LogMessage (MessageImportance.Low, $"  {nameof (ImageName)}: {ImageName}");
 			Log.LogMessage (MessageImportance.Low, $"  {nameof (SdkVersion)}: {SdkVersion}");
 			Log.LogMessage (MessageImportance.Low, $"  {nameof (TargetId)}: {TargetId}");
@@ -87,6 +89,10 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			if (!string.IsNullOrEmpty (AndroidSdkHome)) {
 				psi.EnvironmentVariables ["ANDROID_SDK_HOME"] = AndroidSdkHome;
 				Log.LogMessage (MessageImportance.Low, $"\tANDROID_SDK_HOME=\"{AndroidSdkHome}\"");
+			}
+			if (!string.IsNullOrEmpty (JavaSdkHome)) {
+				psi.EnvironmentVariables ["JAVA_HOME"] = JavaSdkHome;
+				Log.LogMessage (MessageImportance.Low, $"\tJAVA_HOME=\"{JavaSdkHome}\"");
 			}
 			var p = new Process () {
 				StartInfo   = psi,


### PR DESCRIPTION
- `JAVA_HOME` needs to be set for `avdmanager.bat`
- Installing apks on the emulator was failing with
`INSTALL_FAILED_INSUFFICIENT_STORAGE` on Windows
- A newer revision of the emulator fixes this, now using
`x86-21_r05.zip`