### PR TITLE
[Xamarin.Android.Build.Tasks] Create classes.zip for dx.jar. [WIP]

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
@@ -74,7 +74,7 @@ namespace Xamarin.Android.Tasks
 		void GenerateProguardCommands (CommandLineBuilder cmd)
 		{
 			var enclosingChar = OS.IsWindows ? "\"" : string.Empty;
-			var jars = JavaLibraries.Select (i => i.ItemSpec).Concat (new string [] { ClassesOutputDirectory });
+			var jars = JavaLibraries.Select (i => i.ItemSpec).Concat (new string [] { Path.Combine (ClassesOutputDirectory, "classes.zip") });
 			cmd.AppendSwitchIfNotNull ("-jar ", ProguardJarPath);
 			cmd.AppendSwitchUnquotedIfNotNull ("-injars ", $"{enclosingChar}'" + string.Join ($"'{Path.PathSeparator}'", jars) + $"'{enclosingChar}");
 			cmd.AppendSwitch ("-dontwarn");
@@ -91,7 +91,7 @@ namespace Xamarin.Android.Tasks
 		{
 			var enclosingDoubleQuote = OS.IsWindows ? "\"" : string.Empty;
 			var enclosingQuote = OS.IsWindows ? string.Empty : "'";
-			var jars = JavaLibraries.Select (i => i.ItemSpec).Concat (new string [] { ClassesOutputDirectory });
+			var jars = JavaLibraries.Select (i => i.ItemSpec).Concat (new string [] { Path.Combine (ClassesOutputDirectory, "classes.zip") });
 			cmd.AppendSwitchIfNotNull ("-Djava.ext.dirs=", Path.Combine (AndroidSdkBuildToolsPath, "lib"));
 			cmd.AppendSwitch ("com.android.multidex.MainDexListBuilder");
 			cmd.AppendSwitch ($"{enclosingDoubleQuote}{tempJar}{enclosingDoubleQuote}");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
@@ -31,7 +31,13 @@ namespace Xamarin.Android.Tasks
 		{
 			if (!Directory.Exists (ClassesOutputDirectory))
 				Directory.CreateDirectory (ClassesOutputDirectory);
-			return base.Execute ();
+			var result = base.Execute ();
+			if (!result)
+				return result;
+			// compress all the class files
+			using (var zip = new ZipArchiveEx (Path.Combine (ClassesOutputDirectory, "classes.zip"), FileMode.OpenOrCreate))
+				zip.AddDirectory (ClassesOutputDirectory, "");
+			return result;
 		}
 
 		protected override string GenerateCommandLineCommands ()

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
@@ -39,9 +39,6 @@ namespace Xamarin.Android.Tasks
 		public string AcwMapFile { get; set; }
 
 		[Required]
-		public string ProguardJarInput { get; set; }
-
-		[Required]
 		public string ProguardJarOutput { get; set; }
 
 		[Required]
@@ -89,7 +86,6 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  ClassesOutputDirectory: {0}", ClassesOutputDirectory);
 			Log.LogDebugMessage ("  AcwMapFile: {0}", AcwMapFile);
 			Log.LogDebugMessage ("  ProguardGeneratedApplicationConfiguration: {0}", ProguardGeneratedApplicationConfiguration);
-			Log.LogDebugMessage ("  ProguardJarInput: {0}", ProguardJarInput);
 			Log.LogDebugMessage ("  ProguardJarOutput: {0}", ProguardJarOutput);
 			Log.LogDebugTaskItems ("  ProguardGeneratedReferenceConfiguration:", ProguardGeneratedReferenceConfiguration);
 			Log.LogDebugTaskItems ("  ProguardGeneratedApplicationConfiguration:", ProguardGeneratedApplicationConfiguration);
@@ -126,17 +122,10 @@ namespace Xamarin.Android.Tasks
 				cmd.AppendSwitchIfNotNull ("-jar ", Path.Combine (ProguardJarPath));
 			}
 
-			if (!ClassesOutputDirectory.EndsWith (Path.DirectorySeparatorChar.ToString ()))
+			if (!ClassesOutputDirectory.EndsWith (Path.DirectorySeparatorChar.ToString (), StringComparison.OrdinalIgnoreCase))
 				ClassesOutputDirectory += Path.DirectorySeparatorChar;
-			var classesFullPath = Path.GetFullPath (ClassesOutputDirectory);
 
-			if (File.Exists (ProguardJarInput))
-				File.Delete (ProguardJarInput);
-			using (var zip = ZipArchive.Open (ProguardJarInput, FileMode.Create)) {
-				foreach (var file in Directory.GetFiles (classesFullPath, "*", SearchOption.AllDirectories))
-					zip.AddFile (file, Path.Combine (Path.GetDirectoryName (file.Substring (classesFullPath.Length)), Path.GetFileName (file)));
-			}
-
+			var classesZip = Path.Combine (ClassesOutputDirectory, "classes.zip");
 			var acwLines = File.ReadAllLines (AcwMapFile);
 			using (var appcfg = File.CreateText (ProguardGeneratedApplicationConfiguration))
 				for (int i = 0; i + 3 < acwLines.Length; i += 4)
@@ -149,7 +138,7 @@ namespace Xamarin.Android.Tasks
 
 			var injars = new List<string> ();
 			var libjars = new List<string> ();
-			injars.Add (ProguardJarInput);
+			injars.Add (classesZip);
 			if (JavaLibrariesToEmbed != null)
 				foreach (var jarfile in JavaLibrariesToEmbed)
 					injars.Add (jarfile.ItemSpec);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1997,7 +1997,7 @@ because xbuild doesn't support framework reference assemblies.
     Jars="@(_JavaLibrariesToCompile);@(_InstantRunJavaReference);@(_ReferenceJavaLibs)"
     JavacTargetVersion="$(JavacTargetVersion)"
     JavacSourceVersion="$(JavacSourceVersion)"
-       />
+  />
 
   <Touch Files="$(IntermediateOutputPath)_javac.stamp" AlwaysCreate="true" />
 </Target>
@@ -2075,7 +2075,6 @@ because xbuild doesn't support framework reference assemblies.
     JavaLibrariesToEmbed="@(_JavaLibrariesToCompile);@(_InstantRunJavaReference)"
     ExternalJavaLibraries="@(AndroidExternalJavaLibrary)"
     DoNotPackageJavaLibraries="@(_ResolvedDoNotPackageAttributes)"
-    ProguardJarInput="$(IntermediateOutputPath)proguard\__proguard_input__.jar"
     ProguardJarOutput="$(IntermediateOutputPath)proguard\__proguard_output__.jar"
     EnableLogging="$(ProguardEnableLogging)"
     DumpOutput="$(IntermediateOutputPath)proguard\dump.txt"


### PR DESCRIPTION
Commit 2d23a275 reverted a change which is required for j8.jar.
But the change resulted in a command line which would exceed
the max command line limits on windows.

It turns out that both dx.jar and j8.jar allow for a `zip` file
to be used to pass in the `.class` files. So lets create a zip
and refresh/update it on each build. Then use that rather than
the class directory in `CompileToDalvik`.

This also fixes the JarContentBuilder to pick up the android
sdk and ndk directories from the environment variables which
the build system pass in.