### PR TITLE
[Xamarin.Android.Build.Tests] Reworks tests to use msbuild.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Common/ImportAfter/Xamarin.Android.Windows.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Common/ImportAfter/Xamarin.Android.Windows.targets
@@ -14,7 +14,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	</PropertyGroup>
 
 	<Target Name="_RegisterMdbFilesWithFileWrites" BeforeTargets="IncrementalClean">  
-		<CreateItem Include="$(OutDir)*.dll.mdb;$(MonoAndroidIntermediateAssemblyDir)*.dll.mdb">  
+		<CreateItem Include="$(OutDir)*.dll.mdb;$(MonoAndroidIntermediateAssemblyDir)*.dll.mdb;$(MonoAndroidLinkerInputDir)*.dll.mdb">  
 			<Output TaskParameter="Include" ItemName="_FilesToRegister" />  
 		</CreateItem>  
 		<CreateItem Include="$([System.IO.Path]::GetFullPath('%(_FilesToRegister.Identity)'))"

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
@@ -41,6 +41,9 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public bool UseManagedResourceGenerator { get; set; }
 
+		[Required]
+		public bool DesignTimeBuild { get; set; }
+
 		private Dictionary<string, string> resource_fixup = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase);
 
 		public override bool Execute ()
@@ -121,7 +124,13 @@ namespace Xamarin.Android.Tasks
 						var suffix = assemblyName.ItemSpec.EndsWith (".dll") ? String.Empty : ".dll";
 						string hintPath = assemblyName.GetMetadata ("HintPath").Replace (Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
 						string fileName = assemblyName.ItemSpec + suffix;
-						resolver.Load (Path.GetFullPath (assemblyName.ItemSpec));
+						string fullPath = Path.GetFullPath (assemblyName.ItemSpec);
+						// Skip non existing files in DesignTimeBuild
+						if (!File.Exists (fullPath) && DesignTimeBuild) {
+							Log.LogDebugMessage ("Skipping non existant dependancy '{0}' due to design time build.", fullPath);
+							continue;
+						}
+						resolver.Load (fullPath);
 						if (!String.IsNullOrEmpty (hintPath) && !File.Exists (hintPath)) // ignore invalid HintPath
 							hintPath = null;
 						string assemblyPath = String.IsNullOrEmpty (hintPath) ? fileName : hintPath;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
@@ -397,10 +397,17 @@ namespace Xamarin.Android.Tasks {
 				using (var resolver = new DirectoryAssemblyResolver (this.CreateTaskLogger (), loadDebugSymbols: false)) {
 					foreach (var assemblyItem in Assemblies) {
 						string fullPath = Path.GetFullPath (assemblyItem.ItemSpec);
+						if (DesignTimeBuild && !File.Exists (fullPath)) {
+							LogWarning ("Failed to load '{0}'. Check the file exists or the project has been built.", fullPath);
+							continue;
+						}
 						if (assemblies.Contains (fullPath)) {
 							LogDebugMessage ("  Skip assembly: {0}, it was already processed", fullPath);
 							continue;
 						}
+						// don't try to even load mscorlib it will fail.
+						if (string.Compare (Path.GetFileNameWithoutExtension (fullPath), "mscorlib", StringComparison.OrdinalIgnoreCase) == 0)
+							continue;
 						assemblies.Add (fullPath);
 						resolver.Load (fullPath);
 						// Append source file name (without the Xamarin. prefix or extension) to the base folder

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -37,7 +37,10 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string AssemblyIdentityMapFile { get; set; }
 
-		public string CacheFile { get; set;} 
+		public string CacheFile { get; set; }
+
+		[Required]
+		public bool DesignTimeBuild { get; set; }
 
 		[Output]
 		public string [] Jars { get; set; }
@@ -204,6 +207,11 @@ namespace Xamarin.Android.Tasks
 					foreach (var env in Directory.EnumerateFiles (outDirForDll, "__AndroidEnvironment__*", SearchOption.TopDirectoryOnly)) {
 						resolvedEnvironments.Add (env);
 					}
+					continue;
+				}
+
+				if (!File.Exists (assemblyPath) && DesignTimeBuild) {
+					Log.LogDebugMessage ("Skipping non existant dependancy '{0}' due to design time build.", assemblyPath);
 					continue;
 				}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.OSS.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.OSS.cs
@@ -133,7 +133,7 @@ namespace Xamarin.Android.Build.Tests
 				/* debugType */        "",
 				/* optimize */         true ,
 				/* embedassebmlies */  true ,
-				/* expectedResult */   "debug",
+				/* expectedResult */   "release",
 			},
 			new object[] {
 				/* supportedAbi */     new string[] { "armeabi-v7a"},
@@ -141,7 +141,7 @@ namespace Xamarin.Android.Build.Tests
 				/* debugType */        "",
 				/* optimize */         true ,
 				/* embedassebmlies */  false ,
-				/* expectedResult */   "debug",
+				/* expectedResult */   "release",
 			},
 			new object[] {
 				/* supportedAbi */     new string[] { "armeabi-v7a"},

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -59,20 +59,20 @@ public class TestMe {
 			using (var b = CreateApkBuilder (Path.Combine ("temp", "JavacTaskDoesNotRunOnSecondBuild"), false, false)) {
 				Assert.IsTrue (b.Build (app), "First build should have succeeded");
 				Assert.IsFalse (
-					b.LastBuildOutput.Contains ("Skipping target \"_CompileJava\" because"),
+					b.Output.IsTargetSkipped ("_CompileJava"),
 					"the _CompileJava target should not be skipped");
 				Assert.IsFalse (
-					b.LastBuildOutput.Contains ("Skipping target \"_BuildApkEmbed\" because"),
+					b.Output.IsTargetSkipped ("_BuildApkEmbed"),
 					"the _BuildApkEmbed target should not be skipped");
 				var expectedOutput = Path.Combine (Root, b.ProjectDirectory, app.IntermediateOutputPath, "android", "bin", "classes", 
 					"com", "android", "test", "TestMe.class");
 				Assert.IsTrue (File.Exists (expectedOutput), string.Format ("{0} should exist.", expectedOutput));
 				Assert.IsTrue (b.Build (app), "Second build should have succeeded");
 				Assert.IsTrue (
-					b.LastBuildOutput.Contains ("Skipping target \"_CompileJava\" because"),
+					b.Output.IsTargetSkipped ("_CompileJava"),
 					"the _CompileJava target should be skipped");
 				Assert.IsTrue (
-					b.LastBuildOutput.Contains ("Skipping target \"_BuildApkEmbed\" because"),
+					b.Output.IsTargetSkipped ("_BuildApkEmbed"),
 					"the _BuildApkEmbed target should be skipped");
 				Assert.IsTrue (File.Exists (expectedOutput), string.Format ("{0} should exist.", expectedOutput));
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.OSS.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.OSS.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Android.Build.Tests
 			new object[] { "", true, false, },
 			new object[] { "", false, true, },
 			new object[] { "None", true, false, },
-			new object[] { "None", false, false, },
+			new object[] { "None", false, true, },
 			new object[] { "PdbOnly", true, false, },
 			new object[] { "PdbOnly", false, true, },
 			new object[] { "Full", true, false, },

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -480,6 +480,8 @@ namespace Bug12935
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", $"DebuggerAttribute_{debugType}_{isRelease}_{expected}"), false, false)) {
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
 				var manifest = builder.Output.GetIntermediaryAsText (Root, Path.Combine ("android", "AndroidManifest.xml"));
+				if (!isRelease && debugType == "None" && !builder.RunningMSBuild)
+					expected = false;
 				Assert.AreEqual (expected, manifest.Contains ("android:debuggable=\"true\""), $"Manifest  {(expected ? "should" : "should not")} contain the andorid:debuggable attribute");
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -222,7 +222,13 @@ namespace Xamarin.Android.Build.Tests
 					TestContext.Out.WriteLine ("*************************************************************************");
 					TestContext.Out.WriteLine (file);
 					TestContext.Out.WriteLine ();
-					TestContext.Out.WriteLine (File.ReadAllText (file));
+					using (StreamReader reader = new StreamReader (file)) {
+						string line;
+						while ((line = reader.ReadLine ()) != null) {
+							TestContext.Out.WriteLine (line);
+							TestContext.Out.Flush ();
+						}
+					}
 					TestContext.Out.WriteLine ("*************************************************************************");
 					TestContext.Out.Flush ();
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
@@ -49,8 +49,11 @@ namespace Xamarin.ProjectTools
 			if (!Builder.LastBuildOutput.Contains (target))
 				throw new ArgumentException (string.Format ("Target '{0}' is not even in the build output.", target));
 			return Builder.LastBuildOutput.Contains (string.Format ("Target {0} skipped due to ", target))
-				      || Builder.LastBuildOutput.Contains (string.Format ("Skipping target \"{0}\" because its outputs are up-to-date", target))
-				      || Builder.LastBuildOutput.Contains ($"Skipping target \"{target}\" because all output files are up-to-date");
+					|| Builder.LastBuildOutput.Contains (string.Format ("Skipping target \"{0}\" because it has no outputs.", target))
+					|| Builder.LastBuildOutput.Contains (string.Format ("Target \"{0}\" skipped, due to", target))
+					|| Builder.LastBuildOutput.Contains (string.Format ("Skipping target \"{0}\" because its outputs are up-to-date", target))
+					|| Builder.LastBuildOutput.Contains (string.Format ("target {0}, skipping", target))
+					|| Builder.LastBuildOutput.Contains ($"Skipping target \"{target}\" because all output files are up-to-date");
 		}
 
 		public bool IsApkInstalled {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -40,8 +40,10 @@ namespace Xamarin.ProjectTools
 		public string XABuildExe {
 			get {
 				if (IsUnix) {
-					if (!string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("USE_MSBUILD"))) {
-						RunningMSBuild = true;
+					RunningMSBuild = true;
+					var useMSBuild = Environment.GetEnvironmentVariable ("USE_MSBUILD");
+					if (string.IsNullOrEmpty (useMSBuild) || useMSBuild == "0") {
+						RunningMSBuild = false;
 					}
 					return Path.GetFullPath (Path.Combine (Root, "..", "..", "tools", "scripts", "xabuild"));
 				}
@@ -167,9 +169,12 @@ namespace Xamarin.ProjectTools
 			var start = DateTime.UtcNow;
 			var args  = new StringBuilder ();
 			var psi   = new ProcessStartInfo (XABuildExe);
-			args.AppendFormat ("{0} /t:{1} {2} /p:UseHostCompilerIfAvailable=false /p:BuildingInsideVisualStudio=true",
+			args.AppendFormat ("{0} /t:{1} {2}",
 				QuoteFileName(Path.Combine (Root, projectOrSolution)), target, logger);
-
+			if (RunningMSBuild)
+				args.Append (" /p:BuildingOutOfProcess=true");
+			else
+				args.Append (" /p:UseHostCompilerIfAvailable=false /p:BuildingInsideVisualStudio=true");
 			if (parameters != null) {
 				foreach (var param in parameters) {
 					args.AppendFormat (" /p:{0}", param);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/SolutionBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/SolutionBuilder.cs
@@ -24,31 +24,43 @@ namespace Xamarin.ProjectTools
 			foreach (var p in Projects) {
 				using (var pb = new ProjectBuilder (Path.Combine (SolutionPath, p.ProjectName))) {
 					pb.Save (p);
+					p.NuGetRestore (Path.Combine (SolutionPath, p.ProjectName), Path.Combine (SolutionPath, "packages"));
 				}
 			}
 			// write a sln.
 			var sb = new StringBuilder ();
-			sb.AppendFormat ("Microsoft Visual Studio Solution File, Format Version {0}\n", "12.00");
-			sb.AppendFormat ("# Visual Studio {0}\n", "2012");
+			sb.AppendFormat ("Microsoft Visual Studio Solution File, Format Version {0}\r\n", "12.00");
+			sb.AppendFormat ("# Visual Studio {0}\r\n", "2012");
 			foreach (var p in Projects) {
-				sb.AppendFormat ("Project(\"{{{0}}}\") = \"{1}\", \"{2}\", \"{{{3}}}\"\n", p.ProjectTypeGuid, p.ProjectName, 
+				sb.AppendFormat ("Project(\"{{{0}}}\") = \"{1}\", \"{2}\", \"{{{3}}}\"\r\n", p.ProjectTypeGuid, p.ProjectName, 
 					Path.Combine(p.ProjectName,p.ProjectFilePath), p.ProjectGuid);
-				sb.Append ("EndProject\n");
+				sb.Append ("EndProject\r\n");
 			}
-			sb.Append ("Global\n");
-			sb.Append ("\tGlobalSection(SolutionConfigurationPlatforms) = preSolution\n");
-			sb.Append ("\t\tDebug|AnyCPU = Debug|AnyCPU\n");
-			sb.Append ("\t\tRelease|AnyCPU = Release|AnyCPU\n");
-			sb.Append ("\tEndGlobalSection\n");
-			sb.Append ("\tGlobalSection(ProjectConfigurationPlatforms) = postSolution\n");
+			sb.Append ("Global\r\n");
+			sb.Append ("\tGlobalSection(SolutionConfigurationPlatforms) = preSolution\r\n");
+			sb.Append ("\t\tDebug|AnyCPU = Debug|AnyCPU\r\n");
+			sb.Append ("\t\tRelease|AnyCPU = Release|AnyCPU\r\n");
+			sb.Append ("\tEndGlobalSection\r\n");
+			sb.Append ("\tGlobalSection(ProjectConfigurationPlatforms) = postSolution\r\n");
 			foreach (var p in Projects) {
-				sb.AppendFormat ("{{{0}}}.Debug|AnyCPU.ActiveCfg = Debug|AnyCPU\n", p.ProjectGuid);
-				sb.AppendFormat ("{{{0}}}.Debug|AnyCPU.Build.0 = Debug|AnyCPU\n", p.ProjectGuid);
-				sb.AppendFormat ("{{{0}}}.Release|AnyCPU.ActiveCfg = Release|AnyCPU\n", p.ProjectGuid);
-				sb.AppendFormat ("{{{0}}}.Release|AnyCPU.Build.0 = Release|AnyCPU\n", p.ProjectGuid);
+				sb.AppendFormat ("\t\t{{{0}}}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU\r\n", p.ProjectGuid);
+				sb.AppendFormat ("\t\t{{{0}}}.Debug|AnyCPU.Build.0 = Debug|Any CPU\r\n", p.ProjectGuid);
+				if (p is XamarinAndroidApplicationProject)
+					sb.AppendFormat ("\t\t{{{0}}}.Debug|AnyCPU.Deploy.0 = Debug|Any CPU\r\n", p.ProjectGuid);
+				sb.AppendFormat ("\t\t{{{0}}}.Release|AnyCPU.ActiveCfg = Release|Any CPU\r\n", p.ProjectGuid);
+				sb.AppendFormat ("\t\t{{{0}}}.Release|AnyCPU.Build.0 = Release|Any CPU\r\n", p.ProjectGuid);
+				if (p is XamarinAndroidApplicationProject)
+					sb.AppendFormat ("\t\t{{{0}}}.Release|AnyCPU.Deploy.0 = Release|Any CPU\r\n", p.ProjectGuid);
+
 			}
-			sb.Append ("\tEndGlobalSection\n");
-			sb.Append ("EndGlobal\n");
+			sb.Append ("\tEndGlobalSection\r\n");
+			sb.Append ("\tGlobalSection (SolutionProperties) = preSolution\r\n");
+			sb.Append ("\t\tHideSolutionNode = FALSE\r\n");
+			sb.Append ("\tEndGlobalSection\r\n");
+			sb.Append ("\tGlobalSection (ExtensibilityGlobals) = postSolution\r\n");
+			sb.Append ("\t\tSolutionGuid = { BA9651E4 - A332 - 4729 - 9FB4 - 24520221DC3C}\r\n");
+			sb.Append ("\tEndGlobalSection\r\n");
+			sb.Append ("EndGlobal\r\n");
 			File.WriteAllText (Path.Combine (SolutionPath, SolutionName), sb.ToString ());
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -61,7 +61,6 @@ namespace Xamarin.ProjectTools
 			SetProperty ("ConsolePause", "false");
 			SetProperty ("RootNamespace", () => RootNamespace ?? ProjectName);
 			SetProperty ("AssemblyName", () => AssemblyName ?? ProjectName);
-			SetProperty ("BuildingInsideVisualStudio", "True");
 			SetProperty ("BaseIntermediateOutputPath", "obj\\", " '$(BaseIntermediateOutputPath)' == '' ");
 
 			SetProperty (DebugProperties, "DebugSymbols", "true");
@@ -257,7 +256,7 @@ namespace Xamarin.ProjectTools
 					Timestamp = ItemGroupList.SelectMany (ig => ig).Where (i => i.Timestamp != null).Select (i => (DateTimeOffset)i.Timestamp).Max (),
 					Path = ProjectFilePath,
 					Content = SaveProject (),
-					Encoding = System.Text.Encoding.Unicode
+					Encoding = System.Text.Encoding.UTF8,
 				});
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -297,6 +297,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 	<ResolveLibraryProjectImports
 		ContinueOnError="$(DesignTimeBuild)"
 		CacheFile="$(_AndroidLibraryProjectImportsCache)"
+		DesignTimeBuild="$(DesignTimeBuild)"
 		Assemblies="@(ReferencePath);@(ReferenceDependencyPaths)"
 		ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
 		UseShortFileNames="$(UseShortFileNames)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -277,6 +277,12 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 </PropertyGroup>
 
+<!-- Force Xbuild to behave like msbuild -->
+<PropertyGroup>
+	<DebugSymbols Condition=" '$(DebugType)' == 'None' ">false</DebugSymbols>
+	<DebugType Condition=" '$(DebugType)' == 'None' ">portable</DebugType>
+</PropertyGroup>
+
 <Choose>
 	<When Condition=" '$(DebugSymbols)' == 'True' And '$(DebugType)' != '' And ('$(EmbedAssembliesIntoApk)' == 'False' Or '$(Optimize)' != 'True') ">
 		<PropertyGroup>
@@ -456,7 +462,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <Target Name="_StripEmbeddedLibraries"
   Inputs="@(ResolvedAssemblies)" 
   Outputs="$(_AndroidStripFlag)"
-  DependsOnTargets="_CopyIntermediateAssemblies;_CopyMdbFiles">
+  DependsOnTargets="_CopyIntermediateAssemblies;_CopyPdbFiles;_CopyMdbFiles">
     <StripEmbeddedLibraries
       Condition="'$(AndroidLinkMode)' != 'None' AND '$(AndroidUseSharedRuntime)' != 'true'"
       Assemblies="@(ResolvedAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')" />
@@ -1079,6 +1085,7 @@ because xbuild doesn't support framework reference assemblies.
 		IsApplication="$(AndroidApplication)"
 		References="@(ReferencePath)"
 		UseManagedResourceGenerator="True"
+		DesignTimeBuild="$(DesignTimeBuild)"
 	/>
 	<ItemGroup>
 		<CorrectCasedItem Include="%(Compile.Identity)" Condition="'%(Compile.Identity)' == '$(AndroidResgenFile)'"/>
@@ -1148,6 +1155,7 @@ because xbuild doesn't support framework reference assemblies.
 	<ResolveLibraryProjectImports
 		ContinueOnError="$(DesignTimeBuild)"
 		CacheFile="$(_AndroidLibraryProjectImportsCache)"
+		DesignTimeBuild="$(DesignTimeBuild)"
 		Assemblies="@(ReferencePath);@(ReferenceDependencyPaths)"
 		ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
 		UseShortFileNames="$(UseShortFileNames)"
@@ -1411,6 +1419,7 @@ because xbuild doesn't support framework reference assemblies.
 		IsApplication="$(AndroidApplication)"
 		References="@(ReferencePath)"
 		UseManagedResourceGenerator="False"
+		DesignTimeBuild="$(DesignTimeBuild)"
 	/>
 
 	<!-- Only copy if the file contents changed, so users only get Reload? dialog for real changes -->
@@ -1644,25 +1653,49 @@ because xbuild doesn't support framework reference assemblies.
 		Overwrite="false" />
 </Target>
 
-<Target Name="_CopyMdbFiles"
-		Inputs="@(_ResolvedMdbFiles);@(_ResolvedPortablePdbFiles)"
-		Outputs="@(_ResolvedMdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)');@(_ResolvedPortablePdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
-		DependsOnTargets="_ConvertPdbFiles;_CollectMdbFiles" >
+<Target Name="_CopyPdbFiles"
+		Inputs="@(_ResolvedPortablePdbFiles)"
+		Outputs="@(_ResolvedPortablePdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
+		DependsOnTargets="_ConvertPdbFiles">
 	<CopyMdbFiles
-			SourceFiles="@(_ResolvedMdbFiles);@(_ResolvedPortablePdbFiles)"
-			DestinationFiles="@(_ResolvedMdbFiles->'$(OutputPath)%(Filename)%(Extension)');@(_ResolvedPortablePdbFiles->'$(OutputPath)%(Filename)%(Extension)')">
-		<Output TaskParameter="CopiedFiles" ItemName="_MdbFilesCopied" />
+			SourceFiles="@(_ResolvedPortablePdbFiles)"
+			DestinationFiles="@(_ResolvedPortablePdbFiles->'$(OutputPath)%(Filename)%(Extension)')">
+		<Output TaskParameter="CopiedFiles" ItemName="_PdbFilesCopied" />
+		<Output TaskParameter="CopiedFiles" ItemName="FileWrites" />
 	</CopyMdbFiles>
 	<Copy
-			SourceFiles="@(_ResolvedMdbFiles->'$(OutputPath)%(Filename)%(Extension)');@(_ResolvedPortablePdbFiles->'$(OutputPath)%(Filename)%(Extension)')"
-			DestinationFiles="@(_ResolvedMdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)');@(_ResolvedPortablePdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
+			SourceFiles="@(_ResolvedPortablePdbFiles->'$(OutputPath)%(Filename)%(Extension)')"
+			DestinationFiles="@(_ResolvedPortablePdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
 			SkipUnchangedFiles="true">
-		<Output TaskParameter="CopiedFiles" ItemName="_DebugFilesCopiedToLinkerSrc" />
+		<Output TaskParameter="CopiedFiles" ItemName="_PdbDebugFilesCopiedToLinkerSrc" />
+		<Output TaskParameter="CopiedFiles" ItemName="FileWrites" />
 	</Copy>
 	<Touch Files="@(_DebugFilesCopiedToLinkerSrc)" />
 	<WriteLinesToFile
 		File="$(IntermediateOutputPath)$(CleanFile)"
-		Lines="@(_MdbFilesCopied);@(_DebugFilesCopiedToLinkerSrc)"
+		Lines="@(_PdbFilesCopied->'%(FullPath)');@(_PdbDebugFilesCopiedToLinkerSrc->'%(FullPath)')"
+		Overwrite="false" />
+</Target>
+
+<Target Name="_CopyMdbFiles"
+		Inputs="@(_ResolvedMdbFiles)"
+		Outputs="@(_ResolvedMdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
+		DependsOnTargets="_CollectMdbFiles" >
+	<CopyMdbFiles
+			SourceFiles="@(_ResolvedMdbFiles)"
+			DestinationFiles="@(_ResolvedMdbFiles->'$(OutputPath)%(Filename)%(Extension)')">
+		<Output TaskParameter="CopiedFiles" ItemName="_MdbFilesCopied" />
+	</CopyMdbFiles>
+	<Copy
+			SourceFiles="@(_ResolvedMdbFiles->'$(OutputPath)%(Filename)%(Extension)')"
+			DestinationFiles="@(_ResolvedMdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
+			SkipUnchangedFiles="true">
+		<Output TaskParameter="CopiedFiles" ItemName="_MdbDebugFilesCopiedToLinkerSrc" />
+	</Copy>
+	<Touch Files="@(_DebugFilesCopiedToLinkerSrc)" />
+	<WriteLinesToFile
+		File="$(IntermediateOutputPath)$(CleanFile)"
+		Lines="@(_MdbFilesCopied->'%(FullPath)');@(_MdbDebugFilesCopiedToLinkerSrc->'%(FullPath)')"
 		Overwrite="false" />
 </Target>
 	

--- a/tools/scripts/xabuild
+++ b/tools/scripts/xabuild
@@ -83,7 +83,7 @@ else
 fi
 
 if [[ "$MSBUILD" == "msbuild" ]] ; then
-	exec mono "$prefix/bin/xabuild.exe" "$@"
+	exec mono "$prefix/bin/xabuild.exe" "$@" "/p:MonoDroidInstallDirectory=$prefix"
 	exit $?
 fi
 
@@ -129,7 +129,7 @@ export MSBuildExtensionsPath="$TARGETS_DIR"
 
 case "$MSBUILD" in
 	*msbuild*)
-		XABUILD_FLAGS+=(/p:TargetFrameworkRootPath="$TARGETS_DIR-frameworks")
+		XABUILD_FLAGS+=(/p:TargetFrameworkRootPath="$TARGETS_DIR-frameworks/")
 		;;
 	*xbuild*)
 		export XBUILD_FRAMEWORK_FOLDERS_PATH="$TARGETS_DIR-frameworks"


### PR DESCRIPTION
This commit reworks the tests to work on msbuild by default.
xbuild is deprecated, so we should ensure that our system works
100% on msbuild.

So allot of changes in the system here. The hightlights are

We have to NOT use `BuildingInsideVisualStudio` when building
under `msbuild`. Setting this property to `true` has a side effect
of telling `msbuild` .. "Dont bother to build ProjectReferences".
This is because under VS that is something the IDE takes care of.
It turns out that the bug we had to do with `__NonExistantFile__`
causing the `csc` task to run ALL the time was fixed.

All of the `IsTargetSkipped` checks have been unified to call
`IsTargetSkipped` method out BuildOutput. It has also been updated
to include more target "skipped" formats which xbuild and msbuild
supports.

There is also a difference in behaviour between xbuild and msbuild.
You may well have noticed that ALL the tests that have had the

	"debug" -> "release"

changes (including the debugger attribute one) are around

	$(DebugType) == "None"

Under xbuild when $(DebugType) == "None" and $(DebugSymbols) == "True"
we end up with $(DebugType) == "None" and $(DebugSymbols) == "True".
Which results in a debug runtime and apk.

However.... under msbuild when $(DebugType) == "None"
and $(DebugSymbols) == "True" we end up with $(DebugType) == "portable"
and $(DebugSymbols) == "False".. so we get a release runtime and apk.

This is because None is NOT a valid value for $(DebugType) in msbuild,
so it resets BOTH $(DebugType) and $(DebugSymbols). So we have a
difference of behaviour between the two systems.

So in this commit we check for $(DebugType) == "None" and change it
and $(DebugSymbols) to match the msbuild behaviour. This will probably
break some QA tests.. but this is expected and the tests should be
updated to reflect this.