### PR TITLE
[runtime] Use a set of properties to pass common configure flags

### DIFF
--- a/build-tools/mono-runtimes/mono-runtimes.projitems
+++ b/build-tools/mono-runtimes/mono-runtimes.projitems
@@ -167,7 +167,7 @@
       <Objdump>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-objdump</Objdump>
       <RanLib>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-ranlib</RanLib>
       <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-strip</Strip>
-      <ConfigureFlags>PATH="$PATH:$(AndroidMxeFullPath)\bin" --host=$(MingwCommandPrefix64) --target=$(MingwCommandPrefix64) --disable-boehm --enable-mcs-build=no --enable-nls=no --enable-maintainer-mode --with-monodroid --disable-llvm ac_cv_header_zlib_h=no ac_cv_search_dlopen=no</ConfigureFlags>
+      <ConfigureFlags>PATH="$PATH:$(AndroidMxeFullPath)\bin" --host=$(MingwCommandPrefix64) --target=$(MingwCommandPrefix64) $(_CommonHostConfigureFlags) --disable-dynamic-btls --disable-mcs-build --disable-llvm ac_cv_header_zlib_h=no ac_cv_search_dlopen=no</ConfigureFlags>
       <NativeLibraryExtension>dll</NativeLibraryExtension>
       <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
       <OutputProfilerFilename></OutputProfilerFilename>
@@ -190,7 +190,7 @@
       <Objdump>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-objdump</Objdump>
       <RanLib>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-ranlib</RanLib>
       <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-strip</Strip>
-      <ConfigureFlags>PATH="$PATH:$(AndroidMxeFullPath)\bin" --host=$(MingwCommandPrefix32) --target=$(MingwCommandPrefix32) --disable-boehm --enable-mcs-build=no --enable-nls=no --enable-maintainer-mode --with-monodroid --disable-llvm ac_cv_header_zlib_h=no ac_cv_search_dlopen=no</ConfigureFlags>
+      <ConfigureFlags>PATH="$PATH:$(AndroidMxeFullPath)\bin" --host=$(MingwCommandPrefix32) --target=$(MingwCommandPrefix32) $(_CommonHostConfigureFlags) --disable-dynamic-btls --disable-mcs-build --disable-llvm ac_cv_header_zlib_h=no ac_cv_search_dlopen=no</ConfigureFlags>
       <NativeLibraryExtension>dll</NativeLibraryExtension>
       <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
       <OutputProfilerFilename></OutputProfilerFilename>
@@ -211,7 +211,7 @@
       <RanLib>ranlib</RanLib>
       <Strip>strip</Strip>
       <StripFlags>-S</StripFlags>
-      <ConfigureFlags>--enable-dynamic-btls --enable-maintainer-mode --without-ikvm-native --with-monodroid --with-mcs-docs=no --disable-mono-debugger --with-profile4_x=no --disable-boehm --enable-nls=no --disable-iconv</ConfigureFlags>
+      <ConfigureFlags>$(_CommonHostConfigureFlags)</ConfigureFlags>
       <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
       <NativeLibraryExtension>dylib</NativeLibraryExtension>
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
@@ -232,7 +232,7 @@
       <RanLib>ranlib</RanLib>
       <Strip>strip</Strip>
       <StripFlags>-S</StripFlags>
-      <ConfigureFlags>--enable-dynamic-btls --enable-maintainer-mode --without-ikvm-native --with-monodroid --with-mcs-docs=no --disable-mono-debugger --with-profile4_x=no --disable-boehm --enable-nls=no --disable-iconv</ConfigureFlags>
+      <ConfigureFlags>$(_CommonHostConfigureFlags)</ConfigureFlags>
       <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
       <NativeLibraryExtension>so</NativeLibraryExtension>
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>

--- a/build-tools/mono-runtimes/mono-runtimes.props
+++ b/build-tools/mono-runtimes/mono-runtimes.props
@@ -5,9 +5,11 @@
     <_CommonCFlags Condition=" '$(Configuration)' == 'Release' ">-g -O2</_CommonCFlags>
     <_HostWinCFlags Condition=" '$(Configuration)' == 'Debug' ">-ggdb3 -O0 -DXAMARIN_PRODUCT_VERSION=0</_HostWinCFlags>
     <_HostWinCFlags Condition=" '$(Configuration)' == 'Release' ">-g -O2 -DXAMARIN_PRODUCT_VERSION=0</_HostWinCFlags>
-    <_BtlsConfigureFlags>--enable-dynamic-btls --with-btls-android-ndk=$(AndroidToolchainDirectory)\ndk</_BtlsConfigureFlags>
-    <_CommonConfigureFlags>--without-ikvm-native --enable-maintainer-mode --with-profile4_x=no --with-monodroid --enable-nls=no --with-sigaltstack=yes --with-tls=pthread mono_cv_uscore=yes</_CommonConfigureFlags>
-    <_TargetConfigureFlags>$(_CommonConfigureFlags) --enable-minimal=ssa,interpreter,portability,attach,verifier,full_messages,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,security,shared_handles --disable-mcs-build --disable-executables --disable-iconv --disable-boehm $(_BtlsConfigureFlags)</_TargetConfigureFlags>
+    <_BtlsConfigureFlags>--with-btls-android-ndk=$(AndroidToolchainDirectory)\ndk</_BtlsConfigureFlags>
+    <_CommonConfigureFlags>--without-ikvm-native --enable-maintainer-mode --with-profile2=no --with-profile4=no --with-monodroid --enable-nls=no </_CommonConfigureFlags>
+    <_CommonHostConfigureFlags>$(_CommonConfigureFlags) --with-mcs-docs=no --disable-mono-debugger --disable-iconv --disable-boehm</_CommonHostConfigureFlags>
+    <_CommonTargetConfigureFlags>$(_CommonConfigureFlags) --with-profile4_x=no --with-sigaltstack=yes --with-tls=pthread mono_cv_uscore=yes</_CommonTargetConfigureFlags>
+    <_TargetConfigureFlags>$(_CommonTargetConfigureFlags) --enable-minimal=ssa,portability,attach,verifier,full_messages,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,security,shared_handles --disable-mcs-build --disable-executables --disable-iconv --disable-boehm $(_BtlsConfigureFlags)</_TargetConfigureFlags>
     <_SecurityCFlags>-fstack-protector</_SecurityCFlags>
     <_TargetCFlags>$(_SecurityCFlags) -DMONODROID=1</_TargetCFlags>
     <_TargetCxxFlags>$(_SecurityCFlags) -DMONODROID=1</_TargetCxxFlags>


### PR DESCRIPTION
DRY - do not repeat configure args across various runtimes.