### PR TITLE
[Xamarin.Android.Tools.BootstrapTasks] Check Package Manager

### DIFF
--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -101,6 +101,20 @@
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)"
     />
+    <Exec
+        Condition=" '$(HostOS)' != 'Windows' And '$(_EmuTarget)' != '' "
+        ContinueOnError="True"
+        Command="kill -HUP $(_EmuPid)"
+    />
+    <Sleep
+        Condition=" '$(HostOS)' != 'Windows' And '$(_EmuTarget)' != '' "
+        Milliseconds="5000"
+    />
+    <Exec
+        Condition=" '$(HostOS)' != 'Windows' And '$(_EmuTarget)' != '' "
+        ContinueOnError="True"
+        Command="kill -KILL $(_EmuPid)"
+    />
     <Error
         Condition="'@(_FailedComponent)' != ''"
         Text="Execution of the following components did not complete successfully: @(_FailedComponent->'%(Identity)', ', ')"


### PR DESCRIPTION
Emulator-related failures (3294a50e, db668ba0, c0892674, bc6440bc,
3fa9e9e9, b54f8cd2, 3b893cd4, 7450efcc, and 6358a643) are
unfortunately *still* a fact of life (argh!).

The current set of issues:

  * [A never-seen-before failure in `adb uninstall`][xa662]:

        Tool …/adb execution started with arguments: -s emulator-5570  uninstall "Mono.Android_Tests"
        Failure [DELETE_FAILED_INTERNAL_ERROR]

  * [A continuing problem connecting to the Package Manager][xa664]:

        Tool …/adb execution started with arguments:   uninstall "Mono.Android_Tests"
        Error: Could not access the Package Manager.  Is the system running?

[xa662]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/662/
[xa664]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/664/

Both of these problems appear related to the emulator being in some
"invalid" state, and poses the question: can we determine that the
emulator is FUBAR *earlier*, so that we can create a new (saner?)
emulator instance?

Take a stab in the dark, and hope that *any* `adb shell pm`-related
command will trigger the same set of errors, and update the
`<CheckAdbTarget/>` task to issue the following command if the
emulator appears to be valid:

	adb shell pm path com.android.shell

If the above `pm path` command fails -- ideally with one of the above
messages -- then flag the target as invalid. This will cause the
`AcquireAndroidTarget` target to use the `<CreateAndroidEmulator/>`
and `<StartAndroidEmulator/>` tasks to create a new emulator.

The one downside is that we presumably have these invalid emulators
running around in the first place because the `ReleaseAndroidTarget`
target isn't reliably exiting the emulator instance (b54f8cd2).

Attempt to improve this by non-discriminately killing *all*
`emulator` processes within `ReleaseAndroidTarget` on non-Windows
platforms. (Stabs in the dark are fun!)