### PR TITLE
Generator support for api.xml style java docs for parameter names

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ClassParse.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ClassParse.cs
@@ -31,12 +31,14 @@ namespace Xamarin.Android.Tasks
 
 		public ITaskItem [] DroidDoc2Paths { get; set; }
 
+		public ITaskItem [] ApiXmlDocPaths { get; set; }
+
 		public ITaskItem [] JavaDocs { get; set; }
 
 		public IEnumerable<ITaskItem> DocsPaths {
 			get {
 				Func<ITaskItem[],IEnumerable<ITaskItem>> f = l => l ?? Enumerable.Empty<ITaskItem> ();
-				return f (JavaDocPaths).Concat (f (Java7DocPaths)).Concat (f (Java8DocPaths)).Concat (f (DroidDocPaths)).Concat (f (DroidDoc2Paths)).Concat (f (JavaDocs));
+				return f (JavaDocPaths).Concat (f (Java7DocPaths)).Concat (f (Java8DocPaths)).Concat (f (DroidDocPaths)).Concat (f (DroidDoc2Paths)).Concat (f (ApiXmlDocPaths)).Concat (f (JavaDocs));
 			}
 		}
 
@@ -50,6 +52,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogTaskItems ("  Java8DocPaths: ", Java8DocPaths);
 			Log.LogTaskItems ("  DroidDocPaths: ", DroidDocPaths);
 			Log.LogTaskItems ("  DroidDoc2Paths: ", DroidDoc2Paths);
+			Log.LogTaskItems ("  ApiXmlDocPaths: ", ApiXmlDocPaths);
 			Log.LogTaskItems ("  JavaDocs: ", JavaDocs);
 
 			using (var output = new StreamWriter (OutputFile, append: false, 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -372,6 +372,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
       Java7DocPaths="$(Java7DocPaths)"
       Java8DocPaths="$(Java8DocPaths)"
       DroidDocPaths="$(DroidDocPaths)"
+      ApiXmlDocPaths="$(ApiXmlDocPaths)"
       JavaDocs="@(JavaDocJar->'$(IntermediateOutputPath)javadocs\%(FileName)')"
     />
 


### PR DESCRIPTION
Adds support to binding projects to make use of `ApiXmlDocPaths` as a project property for including `api.xml` style java docs to be used by `ClassParse` for resolving parameter names.

This format is used by Android Support libraries (and eventually Google Play Services / Firebase). 

This requires https://github.com/xamarin/java.interop/commit/4d6c5a9486827432492b129702fad98df26d5835 
