### PR TITLE
[Xamarin.Android.Build.Utilities] Wrong error code for obsolete framework

### DIFF
--- a/src/Xamarin.Android.Build.Utilities/AndroidVersion.cs
+++ b/src/Xamarin.Android.Build.Utilities/AndroidVersion.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Android.Build.Utilities
 			this.OSVersion = osVersion;
 			this.CodeName = codeName;
 			this.Version = version;
-			this.FrameworkVersion = frameworkVersion;
+			this.FrameworkVersion = frameworkVersion ?? "v" + osVersion;
 			this.Stable = stable;
 		}
 


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=59867

There is a bug in AndroidVersion. If the frameworkVersion is not
provided it is left as `null`. But we need to have a valid entry.
In xamarin-android-tools we use

	"v"+osVersion;

to calculate the frameworkVersion.