### PR TITLE
[build] Bump mxe and add commit sha to AndroidMxeInstallPrefix

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -43,7 +43,7 @@
     <AndroidPreviousFrameworkVersion Condition=" '$(AndroidPreviousFrameworkVersion)' == '' ">v1.0</AndroidPreviousFrameworkVersion>
     <AndroidToolchainCacheDirectory Condition=" '$(AndroidToolchainCacheDirectory)' == '' ">$(HOME)\android-archives</AndroidToolchainCacheDirectory>
     <AndroidToolchainDirectory Condition=" '$(AndroidToolchainDirectory)' == '' ">$(HOME)\android-toolchain</AndroidToolchainDirectory>
-    <AndroidMxeInstallPrefix Condition=" '$(AndroidMxeInstallPrefix)' == '' And '$(NeedMxe)' == 'true' ">$(AndroidToolchainDirectory)\mxe</AndroidMxeInstallPrefix>
+    <AndroidMxeInstallPrefix Condition=" '$(AndroidMxeInstallPrefix)' == '' And '$(NeedMxe)' == 'true' ">$(AndroidToolchainDirectory)\mxe-a926b16</AndroidMxeInstallPrefix>
     <AndroidMxeInstallPrefix Condition=" '$(HostOS)' == 'Linux' ">\usr</AndroidMxeInstallPrefix>
     <AndroidSdkDirectory>$(AndroidToolchainDirectory)\sdk</AndroidSdkDirectory>
     <AndroidNdkDirectory>$(AndroidToolchainDirectory)\ndk</AndroidNdkDirectory>

--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -4,6 +4,7 @@
   <Import Project="android-toolchain.projitems" />
   <Import Project="..\scripts\RequiredPrograms.targets" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.AcceptAndroidSdkLicenses" />
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.GitCommitHash" />
   <Target Name="_CopyBootstrapTasksAssembly"
       Outputs="$(OutputPath)\Xamarin.Android.Tools.BootstrapTasks.dll">
     <MSBuild
@@ -135,14 +136,24 @@
       Condition=" '$(NeedMxe)' == 'true' And ($(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:')))"
       Inputs="..\..\external\mxe\Makefile"
       Outputs="@(_AndroidMxeOutput)">
+    <GitCommitHash
+        WorkingDirectory="..\..\external\mxe"
+        ToolPath="$(GitToolPath)"
+        ToolExe="$(GitToolExe)">
+      <Output TaskParameter="AbbreviatedCommitHash" PropertyName="_MxeHash" />
+    </GitCommitHash>
+    <Error
+        Condition=" !$(AndroidMxeFullPath.EndsWith ($(_MxeHash))) "
+        Text="%24(AndroidMxeFullPath) value of `$(AndroidMxeFullPath)` MUST end with `$(_MxeHash)`!"
+    />
     <Exec
         Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:'))"
-        Command="make MXE_TARGETS=&quot;$(MingwCommandPrefix32)&quot; gcc cmake zlib pthreads dlfcn-win32 mman-win32 PREFIX=&quot;$(AndroidMxeFullPath)&quot;"
+        Command="make MXE_TARGETS=&quot;$(MingwCommandPrefix32)&quot; gcc cmake zlib pthreads dlfcn-win32 mman-win32 PREFIX=&quot;$(AndroidMxeFullPath)&quot; OS_SHORT_NAME=&quot;disable-native-plugins&quot;"
         WorkingDirectory="..\..\external\mxe"
     />
     <Exec
         Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))"
-        Command="make MXE_TARGETS=&quot;$(MingwCommandPrefix64)&quot; gcc cmake zlib pthreads dlfcn-win32 mman-win32 PREFIX=&quot;$(AndroidMxeFullPath)&quot;"
+        Command="make MXE_TARGETS=&quot;$(MingwCommandPrefix64)&quot; gcc cmake zlib pthreads dlfcn-win32 mman-win32 PREFIX=&quot;$(AndroidMxeFullPath)&quot; OS_SHORT_NAME=&quot;disable-native-plugins&quot;"
         WorkingDirectory="..\..\external\mxe"
     />
     <Touch Files="@(_AndroidMxeOutput)" />

--- a/src/monodroid/monodroid.props
+++ b/src/monodroid/monodroid.props
@@ -7,7 +7,7 @@
     <_HostUnixCFlags>$(_CommonCFlags) -Wa,--noexecstack</_HostUnixCFlags>
     <_HostUnixLdFlags>-Wall -lstdc++ -lz -shared -fpic</_HostUnixLdFlags>
     <_HostCommonWinCFlags>$(_CommonCFlags) -DWINDOWS -DNTDDI_VERSION=NTDDI_VISTA -D_WIN32_WINNT=_WIN32_WINNT_VISTA -fomit-frame-pointer</_HostCommonWinCFlags>
-    <_HostCommonWinLdFlags>-Wall -lstdc++ -lz -shared -fpic -ldl -lmman -pthread -lwsock32 -lole32 -luuid -lshlwapi</_HostCommonWinLdFlags>
+    <_HostCommonWinLdFlags>-Wall -lstdc++ -lz -shared -fpic -ldl -lmman -pthread -lwsock32 -lole32 -luuid -lshlwapi -lpsapi</_HostCommonWinLdFlags>
     <_UnixAdditionalSourceFiles>$(MonoSourceFullPath)\support\nl.c jni\debug.c jni\monodroid-networkinfo.c jni\xamarin_getifaddrs.c</_UnixAdditionalSourceFiles>
     <_LinuxFlatPakBuild Condition="Exists('/.flatpak-info')" >-DLINUX_FLATPAK</_LinuxFlatPakBuild>
   </PropertyGroup>


### PR DESCRIPTION
This ensures that we can revert mxe to an earlier version.

Background:

The current "do we need to rebuild <dependency>" is mostly "forward-only". It works properly if you bump forward in time, but if you go _backwards_, it won't rebuild because it's timestamp based.

For example: if we bump MXE, it'll rebuild the (cached!) MXE on the build server but if we find that MXE is broken and we need to revert... we can't because what we're reverting to is older than the bump!