### PR TITLE
Generator support for api.xml style java docs for parameter names

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ClassParse.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ClassParse.cs
@@ -21,46 +21,21 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public ITaskItem[] SourceJars { get; set; }
 
-		public ITaskItem[] JavaDocPaths { get; set; }
-
-		public ITaskItem[] Java7DocPaths { get; set; }
-
-		public ITaskItem[] Java8DocPaths { get; set; }
-
-		public ITaskItem[] DroidDocPaths { get; set; }
-
-		public ITaskItem [] DroidDoc2Paths { get; set; }
-
-		public ITaskItem [] ApiXmlDocPaths { get; set; }
-
-		public ITaskItem [] JavaDocs { get; set; }
-
-		public IEnumerable<ITaskItem> DocsPaths {
-			get {
-				Func<ITaskItem[],IEnumerable<ITaskItem>> f = l => l ?? Enumerable.Empty<ITaskItem> ();
-				return f (JavaDocPaths).Concat (f (Java7DocPaths)).Concat (f (Java8DocPaths)).Concat (f (DroidDocPaths)).Concat (f (DroidDoc2Paths)).Concat (f (ApiXmlDocPaths)).Concat (f (JavaDocs));
-			}
-		}
+		public ITaskItem [] DocumentationPaths { get; set; }
 
 		public override bool Execute ()
 		{
 			Log.LogDebugMessage ("ClassParse Task");
 			Log.LogDebugMessage ("  OutputFile: {0}", OutputFile);
 			Log.LogTaskItems ("  SourceJars: ", SourceJars);
-			Log.LogTaskItems ("  JavaDocPaths: ", JavaDocPaths);
-			Log.LogTaskItems ("  Java7DocPaths: ", Java7DocPaths);
-			Log.LogTaskItems ("  Java8DocPaths: ", Java8DocPaths);
-			Log.LogTaskItems ("  DroidDocPaths: ", DroidDocPaths);
-			Log.LogTaskItems ("  DroidDoc2Paths: ", DroidDoc2Paths);
-			Log.LogTaskItems ("  ApiXmlDocPaths: ", ApiXmlDocPaths);
-			Log.LogTaskItems ("  JavaDocs: ", JavaDocs);
+			Log.LogTaskItems ("  DocumentationPaths: ", DocumentationPaths);
 
 			using (var output = new StreamWriter (OutputFile, append: false, 
 						encoding: new UTF8Encoding (encoderShouldEmitUTF8Identifier: false))) {
 				Bytecode.Log.OnLog = LogEventHandler;
 				var classPath = new Bytecode.ClassPath () {
 					ApiSource = "class-parse",
-					DocumentationPaths = (DocsPaths ?? Enumerable.Empty<ITaskItem> ()).Select(x => x.ItemSpec)
+					DocumentationPaths = (DocumentationPaths ?? Enumerable.Empty<ITaskItem> ()).Select(x => x.ItemSpec)
 				};
 				foreach (var jar in SourceJars) {
 					if (Bytecode.ClassPath.IsJarFile (jar.ItemSpec)) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ClassParse.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ClassParse.cs
@@ -31,12 +31,14 @@ namespace Xamarin.Android.Tasks
 
 		public ITaskItem [] DroidDoc2Paths { get; set; }
 
+		public ITaskItem [] ApiXmlDocPaths { get; set; }
+
 		public ITaskItem [] JavaDocs { get; set; }
 
 		public IEnumerable<ITaskItem> DocsPaths {
 			get {
 				Func<ITaskItem[],IEnumerable<ITaskItem>> f = l => l ?? Enumerable.Empty<ITaskItem> ();
-				return f (JavaDocPaths).Concat (f (Java7DocPaths)).Concat (f (Java8DocPaths)).Concat (f (DroidDocPaths)).Concat (f (DroidDoc2Paths)).Concat (f (JavaDocs));
+				return f (JavaDocPaths).Concat (f (Java7DocPaths)).Concat (f (Java8DocPaths)).Concat (f (DroidDocPaths)).Concat (f (DroidDoc2Paths)).Concat (f (ApiXmlDocPaths)).Concat (f (JavaDocs));
 			}
 		}
 
@@ -50,6 +52,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogTaskItems ("  Java8DocPaths: ", Java8DocPaths);
 			Log.LogTaskItems ("  DroidDocPaths: ", DroidDocPaths);
 			Log.LogTaskItems ("  DroidDoc2Paths: ", DroidDoc2Paths);
+			Log.LogTaskItems ("  ApiXmlDocPaths: ", ApiXmlDocPaths);
 			Log.LogTaskItems ("  JavaDocs: ", JavaDocs);
 
 			using (var output = new StreamWriter (OutputFile, append: false, 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -366,17 +366,20 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
       <Output TaskParameter="Include" ItemName="ReferenceJar" />
     </CreateItem>
 
+    <ItemGroup>
+      <_AndroidDocumentationPath Include="$(AndroidDocumentationPath)" />
+      <_AndroidDocumentationPath Include="$(JavaDocPaths)" />
+      <_AndroidDocumentationPath Include="$(Java7DocPaths)" />
+      <_AndroidDocumentationPath Include="$(Java8DocPaths)" />
+      <_AndroidDocumentationPath Include="$(DroidDocPaths)" />
+      <_AndroidDocumentationPath Include="@(JavaDocJar->'$(IntermediateOutputPath)javadocs\%(FileName)')" />
+    </ItemGroup>
+    
     <!-- Extract the API from the .jar file and store as .xml, using either class-parse or jar2xml -->
-	
     <ClassParse Condition="'$(AndroidClassParser)' == 'class-parse'"
       OutputFile="$(ApiOutputFile).class-parse"
       SourceJars="@(EmbeddedJar);@(InputJar)"
-      JavaDocPaths="$(JavaDocPaths)"
-      Java7DocPaths="$(Java7DocPaths)"
-      Java8DocPaths="$(Java8DocPaths)"
-      DroidDocPaths="$(DroidDocPaths)"
-      ApiXmlDocPaths="$(ApiXmlDocPaths)"
-      JavaDocs="@(JavaDocJar->'$(IntermediateOutputPath)javadocs\%(FileName)')"
+      DocumentationPaths="@(_AndroidDocumentationPath)"
     />
 
     <BindingsGenerator Condition="'$(AndroidClassParser)' == 'class-parse'"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -68,6 +68,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
   
   <!-- Get our Build Actions to show up in VS -->
   <ItemGroup>
+    <AvailableItemName Include="AndroidDocumentationPath" />
     <AvailableItemName Include="EmbeddedJar" />
     <AvailableItemName Include="EmbeddedNativeLibrary" />
     <AvailableItemName Include="EmbeddedReferenceJar" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -68,7 +68,6 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
   
   <!-- Get our Build Actions to show up in VS -->
   <ItemGroup>
-    <AvailableItemName Include="AndroidDocumentationPath" />
     <AvailableItemName Include="EmbeddedJar" />
     <AvailableItemName Include="EmbeddedNativeLibrary" />
     <AvailableItemName Include="EmbeddedReferenceJar" />
@@ -368,7 +367,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     </CreateItem>
 
     <ItemGroup>
-      <_AndroidDocumentationPath Include="@(AndroidDocumentationPath)" />
+      <_AndroidDocumentationPath Include="@(JavaDocIndex)" />
       <_AndroidDocumentationPath Include="$(JavaDocPaths)" />
       <_AndroidDocumentationPath Include="$(Java7DocPaths)" />
       <_AndroidDocumentationPath Include="$(Java8DocPaths)" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -368,7 +368,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     </CreateItem>
 
     <ItemGroup>
-      <_AndroidDocumentationPath Include="$(AndroidDocumentationPath)" />
+      <_AndroidDocumentationPath Include="@(AndroidDocumentationPath)" />
       <_AndroidDocumentationPath Include="$(JavaDocPaths)" />
       <_AndroidDocumentationPath Include="$(Java7DocPaths)" />
       <_AndroidDocumentationPath Include="$(Java8DocPaths)" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -375,6 +375,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
       Java7DocPaths="$(Java7DocPaths)"
       Java8DocPaths="$(Java8DocPaths)"
       DroidDocPaths="$(DroidDocPaths)"
+      ApiXmlDocPaths="$(ApiXmlDocPaths)"
       JavaDocs="@(JavaDocJar->'$(IntermediateOutputPath)javadocs\%(FileName)')"
     />
 


### PR DESCRIPTION
Adds support to binding projects to make use of ApiXmlDocPaths as a project property for including api.xml style java docs to be used by ClassParse for resolving parameter names.

This format is used by Android Support libraries (and eventually Google Play Services / Firebase).

This requires xamarin/java.interop@61c70ece24e5e59118fe4b093c60ef2898eb2748

This PR supercedes and closes #916.
