### PR TITLE
[Xamarin.Android.Build.Tasks] AndroidSdk GetPlatformDirectoryFromApiLevel returns null

### DIFF
--- a/src/Xamarin.Android.Build.Utilities/AndroidSdk.cs
+++ b/src/Xamarin.Android.Build.Utilities/AndroidSdk.cs
@@ -100,7 +100,7 @@ namespace Xamarin.Android.Build.Utilities
 				return dir;
 
 			var level = versions.GetApiLevelFromId (id);
-			return level.HasValue ? GetPlatformDirectory (level.Value) : null;
+			return level.HasValue ? GetPlatformDirectory (level.Value) : dir;
 		}
 
 		public static bool IsPlatformInstalled (int apiLevel)

--- a/src/Xamarin.Android.Build.Utilities/AndroidSdk.cs
+++ b/src/Xamarin.Android.Build.Utilities/AndroidSdk.cs
@@ -100,11 +100,7 @@ namespace Xamarin.Android.Build.Utilities
 				return dir;
 
 			var level = versions.GetApiLevelFromId (id);
-			dir       = level.HasValue ? GetPlatformDirectory (level.Value) : null;
-			if (dir != null && Directory.Exists (dir))
-				return dir;
-
-			return null;
+			return level.HasValue ? GetPlatformDirectory (level.Value) : null;
 		}
 
 		public static bool IsPlatformInstalled (int apiLevel)


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=59962

`GetPlatformDirectoryFromApiLevel` is returning null. All of
the places we are expecting this to return just the path even
if it does not exist. So rather than checking if it exists in
this method we will just return the information we get.