### PR TITLE
[bcl-tests] fixes for compilation on Windows

### DIFF
--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/SystemUnzip.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/SystemUnzip.cs
@@ -108,7 +108,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks {
 				p.WaitForExit ();
 			}
 
-			var entries = GetExtractedSourceEntries (nestedTemp);
+			var entries = GetExtractedSourceDirectories (nestedTemp);
 
 			var seenDestFiles   = new HashSet<string> ();
 
@@ -164,12 +164,12 @@ namespace Xamarin.Android.BuildTools.PrepTasks {
 			}
 		}
 
-		IEnumerable<string> GetExtractedSourceEntries (string root)
+		IEnumerable<string> GetExtractedSourceDirectories (string root)
 		{
-			var entries = Directory.EnumerateFileSystemEntries (root, SourceEntryGlobParts [0], SearchOption.TopDirectoryOnly);
+			var entries = Directory.EnumerateDirectories (root, SourceEntryGlobParts [0], SearchOption.TopDirectoryOnly);
 			for (int i = 1; i < SourceEntryGlobParts.Length; ++i) {
 				entries = entries
-					.SelectMany (e => Directory.EnumerateFileSystemEntries (e, SourceEntryGlobParts [i], SearchOption.TopDirectoryOnly));
+					.SelectMany (e => Directory.EnumerateDirectories (e, SourceEntryGlobParts [i], SearchOption.TopDirectoryOnly));
 			}
 			return entries;
 		}

--- a/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj
+++ b/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj
@@ -62,7 +62,7 @@
     <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="System.Net\NetworkChangeTest.cs" />
     <Compile Include="System.Net.Http\HttpClientTest.cs" />
-    <Compile Include="$(IntermediateOutputPath)\App.cs" Condition=" Exists('$(IntermediateOutputPath)\App.cs') "/>
+    <Compile Include="$(IntermediateOutputPath)\App.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />

--- a/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets
+++ b/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets
@@ -67,9 +67,6 @@
       Inputs="@(MonoTestAssembly->'..\..\bin\$(Configuration)\bcl-tests\%(Identity)')"
       Outputs="$(IntermediateOutputPath)\App.cs">
     <MakeDir Directories="$(IntermediateOutputPath)" />
-    <ItemGroup>
-      <Compile Include="$(IntermediateOutputPath)\App.cs" />
-    </ItemGroup>
     <PropertyGroup>
       <_Assemblies>@(MonoTestAssembly->'"%(Identity)"', ',  ')</_Assemblies>
     </PropertyGroup>


### PR DESCRIPTION
Context:
https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=1047263

There are a couple fixes to get the BCL tests (and
Xamarin.Android-Tests.sln) compiling on Windows.

The `SystemUnzip` task is passing some file paths to
`Directory.EnumerateFiles`. Since it does not appear that this would
work; in general, it seems that `GetExtractedSourceEntries` should only
return directories as a simple fix to this problem.

Next, MSBuild is getting a duplicate `<Compile />` entry passed to `Csc`
for `obj/Debug/App.cs`. There was a conditional `<Compile />` entry as
well as one added during the `_GenerateApp_cs` task. It seems simpler to
just remove the condition and the duplicate `<Compile />` entry, since
`<BuildDependsOn />` causes the `_GenerateApp_cs` task to run first.