### PR TITLE
[Xamarin.Android.Build.Tasks] Add support for `apksigner`

### DIFF
--- a/Documentation/build_process.md
+++ b/Documentation/build_process.md
@@ -613,6 +613,16 @@ when packaing Release applications.
 
     Added in Xamarin.Android 8.1.
 
+-  **AndroidUseApkSigner** &ndash; A bool property which allows the developer to
+    use the to the `apksigner` tool rather than the `jarsigner`.
+
+    Added in Xamarin.Android 8.2.
+
+-  **AndroidApkSignerAdditionalArguments** &ndash; A string property which allows
+    the developer to provide additional arguments to the `apksigner` tool.
+
+    Added in Xamarin.Android 8.2.
+
 ## Binding Project Build Properties
 
 The following MSBuild properties are used with

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks
+{
+	public class AndroidApkSigner : AndroidToolTask
+	{
+		[Required]
+		public string ApkToSign { get; set; }
+
+		[Required]
+		public ITaskItem ManifestFile { get; set; }
+
+		[Required]
+		public string KeyStore { get; set; }
+
+		[Required]
+		public string KeyAlias { get; set; }
+
+		[Required]
+		public string KeyPass { get; set; }
+
+		[Required]
+		public string StorePass { get; set; }
+
+		public string AdditionalArguments { get; set; }
+
+		protected override string GenerateCommandLineCommands ()
+		{
+			var cmd = new CommandLineBuilder ();
+
+			var manifest = AndroidAppManifest.Load (ManifestFile.ItemSpec, MonoAndroidHelper.SupportedVersions);
+			int minSdk = MonoAndroidHelper.SupportedVersions.MaxStableVersion.ApiLevel;
+			int maxSdk = MonoAndroidHelper.SupportedVersions.MaxStableVersion.ApiLevel;
+			if (manifest.MinSdkVersion.HasValue)
+				minSdk = manifest.MinSdkVersion.Value;
+
+			if (manifest.TargetSdkVersion.HasValue)
+				maxSdk = manifest.TargetSdkVersion.Value;
+
+			cmd.AppendSwitch ("sign");
+			cmd.AppendSwitchIfNotNull ("--ks ", KeyStore);
+			cmd.AppendSwitchIfNotNull ("--ks-pass pass:", StorePass);
+			cmd.AppendSwitchIfNotNull ("--ks-key-alias ", KeyAlias);
+			cmd.AppendSwitchIfNotNull ("--key-pass pass:", KeyPass);
+			cmd.AppendSwitchIfNotNull ("--min-sdk-version ", minSdk.ToString ());
+			cmd.AppendSwitchIfNotNull ("--max-sdk-version ", maxSdk.ToString ());
+			cmd.AppendSwitchIfNotNull ("--in ", ApkToSign);
+		
+			if (!string.IsNullOrEmpty (AdditionalArguments))
+				cmd.AppendSwitch (AdditionalArguments);
+
+			return cmd.ToString ();
+		}
+
+		protected override string GenerateFullPathToTool ()
+		{
+			return Path.Combine (ToolPath, ToolExe);
+		}
+
+		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance importance)
+		{
+			singleLine = singleLine.Trim ();
+			if (singleLine.Length == 0)
+				return;
+
+			if (singleLine.StartsWith ("Warning:")) {
+				Log.LogWarning (singleLine);
+				return;
+			}
+
+			Log.LogMessage (singleLine, importance);
+		}
+
+		protected override string ToolName {
+			get {
+				return IsWindows ? "apksigner.ext" : "apksigner";
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Android.Tasks
 			var cmd = new CommandLineBuilder ();
 
 			var manifest = AndroidAppManifest.Load (ManifestFile.ItemSpec, MonoAndroidHelper.SupportedVersions);
-			int minSdk = MonoAndroidHelper.SupportedVersions.MaxStableVersion.ApiLevel;
+			int minSdk = MonoAndroidHelper.SupportedVersions.MinStableVersion.ApiLevel;
 			int maxSdk = MonoAndroidHelper.SupportedVersions.MaxStableVersion.ApiLevel;
 			if (manifest.MinSdkVersion.HasValue)
 				minSdk = manifest.MinSdkVersion.Value;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
@@ -28,6 +28,21 @@ namespace Xamarin.Android.Tasks
 
 		public string AdditionalArguments { get; set; }
 
+		public override bool Execute ()
+		{
+			Log.LogDebugMessage ("AndroidApkSigner:");
+			Log.LogDebugMessage ("  ApkToSign: {0}", ApkToSign);
+			Log.LogDebugMessage ("  ManifestFile: {0}", ManifestFile);
+			Log.LogDebugMessage ("  AdditionalArguments: {0}", AdditionalArguments);
+
+			if (!File.Exists (GenerateFullPathToTool ())) {
+				Log.LogError ($"'{GenerateFullPathToTool ()}' does not exist. You need to install android-sdk build-tools 26.0.1 or above.");
+				return false;
+			}
+
+			return base.Execute ();
+		}
+
 		protected override string GenerateCommandLineCommands ()
 		{
 			var cmd = new CommandLineBuilder ();
@@ -67,7 +82,7 @@ namespace Xamarin.Android.Tasks
 			if (singleLine.Length == 0)
 				return;
 
-			if (singleLine.StartsWith ("Warning:")) {
+			if (singleLine.StartsWith ("Warning:", StringComparison.OrdinalIgnoreCase)) {
 				Log.LogWarning (singleLine);
 				return;
 			}
@@ -77,7 +92,7 @@ namespace Xamarin.Android.Tasks
 
 		protected override string ToolName {
 			get {
-				return IsWindows ? "apksigner.ext" : "apksigner";
+				return ToolExe;
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -110,11 +110,18 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public string LintToolPath { get; set; }
 
+		[Output]
+		public string ApkSignerToolExe { get; set; }
+
+		[Output]
+		public bool AndroidUseApkSigner { get; set; }
+
 		static bool             IsWindows = Path.DirectorySeparatorChar == '\\';
 		static readonly string  ZipAlign  = IsWindows ? "zipalign.exe" : "zipalign";
 		static readonly string  Aapt      = IsWindows ? "aapt.exe" : "aapt";
 		static readonly string  Android   = IsWindows ? "android.bat" : "android";
 		static readonly string  Lint      = IsWindows ? "lint.bat" : "lint";
+		static readonly string  ApkSigner = "apksigner";
 
 
 		public override bool Execute ()
@@ -214,6 +221,9 @@ namespace Xamarin.Android.Tasks
 							Aapt, AndroidSdkPath, Path.DirectorySeparatorChar, Android));
 				return false;
 			}
+
+			ApkSignerToolExe = MonoAndroidHelper.GetExecutablePath (AndroidSdkBuildToolsBinPath, ApkSigner);
+			AndroidUseApkSigner = File.Exists (Path.Combine (AndroidSdkBuildToolsBinPath, ApkSignerToolExe));
 
 			if (string.IsNullOrEmpty (ZipAlignPath) || !Directory.Exists (ZipAlignPath)) {
 				ZipAlignPath = new[]{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -201,5 +201,27 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (text.Contains ("package unnamedproject;"), "expected package not found in the source.");
 			}
 		}
+
+		[Test]
+		public void CheckSignApk ([Values(true, false)] bool useApkSigner)
+		{
+			string ext = Environment.OSVersion.Platform != PlatformID.Unix ? ".exe" : "";
+			if (useApkSigner && !File.Exists (Path.Combine (AndroidSdkPath, "build-tools", "26.0.1", "apksigner"+ ext))) {
+				Assert.Ignore ("Skipping test. Required build-tools verison 26.0.1 is not installed.");
+			}
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+			};
+			if (useApkSigner) {
+				proj.SetProperty ("AndroidUseApkSigner", "true");
+				proj.SetProperty ("AndroidBuildToolsVersion", "26.0.1");
+			} else {
+				proj.RemoveProperty ("AndroidUseApkSigner");
+			}
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
+				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
+				Assert.IsTrue (b.Build (proj), "build failed");
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -65,6 +65,16 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
+		public static string AndroidSdkPath {
+			get {
+				var home = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
+				var sdkPath = Environment.GetEnvironmentVariable ("ANDROID_SDK_PATH");
+				if (string.IsNullOrEmpty (sdkPath))
+					sdkPath = Path.Combine (home, "android-toolchain", "sdk");
+				return sdkPath;
+			}
+		}
+
 		protected void WaitFor(int milliseconds)
 		{
 			var pause = new ManualResetEvent(false);
@@ -74,11 +84,7 @@ namespace Xamarin.Android.Build.Tests
 		protected static string RunAdbCommand (string command, bool ignoreErrors = true)
 		{
 			string ext = Environment.OSVersion.Platform != PlatformID.Unix ? ".exe" : "";
-			var home = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
-			var sdkPath = Environment.GetEnvironmentVariable ("ANDROID_SDK_PATH");
-			if (string.IsNullOrEmpty (sdkPath))
-				sdkPath = Path.Combine (home, "android-toolchain", "sdk");
-			string adb = Path.Combine (sdkPath, "platform-tools", "adb" + ext);
+			string adb = Path.Combine (AndroidSdkPath, "platform-tools", "adb" + ext);
 			var proc = System.Diagnostics.Process.Start (new System.Diagnostics.ProcessStartInfo (adb, command) { RedirectStandardOutput = true, RedirectStandardError = true, UseShellExecute = false });
 			proc.WaitForExit ();
 			var result = proc.StandardOutput.ReadToEnd ().Trim () + proc.StandardError.ReadToEnd ().Trim ();

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -99,12 +99,13 @@ namespace Xamarin.Android.Tasks {
 			}
 		}
 		public string GetMinimumSdk () {
+			int defaultMinSdkVersion = MonoAndroidHelper.SupportedVersions.MinStableVersion.ApiLevel;
 			var minAttr = doc.Root.Element ("uses-sdk")?.Attribute (androidNs + "minSdkVersion");
 			if (minAttr == null) {
 				int minSdkVersion;
 				if (!int.TryParse (SdkVersionName, out minSdkVersion))
-					minSdkVersion = 11;
-				return Math.Min (minSdkVersion, 11).ToString ();
+					minSdkVersion = defaultMinSdkVersion;
+				return Math.Min (minSdkVersion, defaultMinSdkVersion).ToString ();
 			}
 			return minAttr.Value;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -507,5 +507,28 @@ namespace Xamarin.Android.Tasks
 				// On the other hand, xbuild has a bug and fails to parse '=' in the value, so we skip JAVA_TOOL_OPTIONS on Mono runtime.
 				new string [] { proguardHomeVariable, "JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8" };
 		}
+
+		public static string GetExecutablePath (string dir, string exe)
+		{
+			if (string.IsNullOrEmpty (dir))
+				return exe;
+			foreach (var e in Executables (exe))
+				if (File.Exists (Path.Combine (dir, e)))
+					return e;
+			return exe;
+		}
+
+		public static IEnumerable<string> Executables (string executable)
+		{
+			yield return executable;
+			var pathExt = Environment.GetEnvironmentVariable ("PATHEXT");
+			var pathExts = pathExt?.Split (new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+
+			if (pathExts == null)
+				yield break;
+
+			foreach (var ext in pathExts)
+				yield return Path.ChangeExtension (executable, ext);
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -490,6 +490,7 @@
     <Compile Include="Utilities\AssemblyIdentityMap.cs" />
     <Compile Include="Utilities\GdbPaths.cs" />
     <Compile Include="Utilities\SatelliteAssembly.cs" />
+    <Compile Include="Tasks\AndroidApkSigner.cs" />
   </ItemGroup>
   <ItemGroup>
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.LaunchMode.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2444,6 +2444,7 @@ because xbuild doesn't support framework reference assemblies.
 		TimestampAuthorityCertificateAlias="$(JarsignerTimestampAuthorityCertificateAlias)"
 		SigningAlgorithm="$(AndroidApkSigningAlgorithm)"
 	/>
+	<Delete Files="%(ApkAbiFilesSigned.FullPath)" Condition=" '$(AndroidUseApkSigner)' == 'true' "/>
 	<AndroidZipAlign Condition=" '$(AndroidUseApkSigner)' == 'true' "
 		Source="%(ApkAbiFilesIntermediate.FullPath)"
 		DestinationDirectory="$(OutDir)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -22,6 +22,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.AndroidSignPackage" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.AndroidCreateDebugKey" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.AndroidZipAlign" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.AndroidApkSigner" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GetAndroidPackageName" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ResolveSdks" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ReadResolvedSdksCache" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -2428,7 +2429,7 @@ because xbuild doesn't support framework reference assemblies.
 		ToolExe="$(KeytoolToolExe)"
 		Command="-list"
 		Condition="'$(AndroidKeyStore)'==''" />
-	<AndroidSignPackage
+	<AndroidSignPackage Condition=" '$(AndroidUseApkSigner)' != 'true' "
 		UnsignedApk="%(ApkAbiFilesIntermediate.FullPath)"
 		SignedApkDirectory="$(OutDir)"
 		KeyStore="$(_ApkKeyStore)"
@@ -2441,24 +2442,41 @@ because xbuild doesn't support framework reference assemblies.
 		TimestampAuthorityCertificateAlias="$(JarsignerTimestampAuthorityCertificateAlias)"
 		SigningAlgorithm="$(AndroidApkSigningAlgorithm)"
 	/>
+	<AndroidZipAlign Condition=" '$(AndroidUseApkSigner)' == 'true' "
+		Source="%(ApkAbiFilesIntermediate.FullPath)"
+		DestinationDirectory="$(OutDir)"
+		ToolPath="$(ZipAlignToolPath)"
+		ToolExe="$(ZipalignToolExe)"
+	/>
+	<AndroidApkSigner Condition=" '$(AndroidUseApkSigner)' == 'true' "
+		ApkToSign="$(ApkFileSigned)"
+		KeyStore="$(_ApkKeyStore)"
+		KeyAlias="$(_ApkKeyAlias)"
+		KeyPass="$(_ApkKeyPass)"
+		StorePass="$(_ApkStorePass)"
+		ToolPath="$(AndroidSdkBuildToolsBinPath)"
+		ToolExe="$(ApkSignerToolExe)"
+		ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
+		AdditionalArguments="$(AndroidApkSignerAdditionalArguments)"
+	/>
 	<Message Text="Signed android package '$(ApkFileSigned)'" />
 	<ItemGroup>
 		<ApkAbiFilesSigned Include="$(ApkFileSigned)" />
 		<ApkAbiFilesSigned Condition="'$(AndroidCreatePackagePerAbi)' == 'true'" Include="$(OutDir)$(_AndroidPackage)*-Signed.apk" />
 	</ItemGroup>
-	<Delete Files="%(ApkAbiFilesSigned.FullPath)" />
+	<Delete Files="%(ApkAbiFilesSigned.FullPath)" Condition=" '$(AndroidUseApkSigner)' != 'true' "/>
 	<ItemGroup>
 		<ApkAbiFilesUnaligned Include="$(OutDir)$(_AndroidPackage)-Signed-Unaligned.apk" />
 		<ApkAbiFilesUnaligned Condition="'$(AndroidCreatePackagePerAbi)' == 'true'" Include="$(OutDir)$(_AndroidPackage)*-Signed-Unaligned.apk" />
 	</ItemGroup>
-	<Message Text="Unaligned android package '%(ApkAbiFilesUnaligned.FullPath)'" />
-	<AndroidZipAlign
+	<Message Text="Unaligned android package '%(ApkAbiFilesUnaligned.FullPath)'"  Condition=" '$(AndroidUseApkSigner)' != 'true' "/>
+	<AndroidZipAlign Condition=" '$(AndroidUseApkSigner)' != 'true' "
 		Source="%(ApkAbiFilesUnaligned.FullPath)"
 		DestinationDirectory="$(OutDir)"
 		ToolPath="$(ZipAlignToolPath)"
 		ToolExe="$(ZipalignToolExe)"
 	/>
-	<Delete Files="%(ApkAbiFilesUnaligned.FullPath)" />
+	<Delete Files="%(ApkAbiFilesUnaligned.FullPath)"/>
 </Target>
 
 <Target Name="SignAndroidPackage" DependsOnTargets="Build;Package;_Sign">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2478,7 +2478,7 @@ because xbuild doesn't support framework reference assemblies.
 		ToolPath="$(ZipAlignToolPath)"
 		ToolExe="$(ZipalignToolExe)"
 	/>
-	<Delete Files="%(ApkAbiFilesUnaligned.FullPath)"/>
+	<Delete Files="%(ApkAbiFilesUnaligned.FullPath)" />
 </Target>
 
 <Target Name="SignAndroidPackage" DependsOnTargets="Build;Package;_Sign">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -650,6 +650,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		<Output TaskParameter="AndroidSdkBuildToolsBinPath" PropertyName="AndroidSdkBuildToolsBinPath" Condition="'$(AndroidSdkBuildToolsBinPath)' == ''" />
 		<Output TaskParameter="AndroidSequencePointsMode"   PropertyName="_SequencePointsMode"         Condition="'$(_SequencePointsMode)' == ''" />
 		<Output TaskParameter="LintToolPath"              PropertyName="LintToolPath"               Condition="'$(LintToolPath)' == ''" />
+		<Output TaskParameter="ApkSignerToolExe"          PropertyName="ApkSignerToolExe"           Condition="'$(ApkSignerToolExe)' == ''" />
+		<Output TaskParameter="AndroidUseApkSigner"       PropertyName="AndroidUseApkSigner"        Condition="'$(AndroidUseApkSigner)' == ''" />
 	</ResolveSdks>
 	<CreateProperty Value="$(TargetFrameworkIdentifier),Version=$(_TargetFrameworkVersion),Profile=$(TargetFrameworkProfile)">
 		<Output TaskParameter="Value" PropertyName="TargetFrameworkMoniker"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2444,7 +2444,7 @@ because xbuild doesn't support framework reference assemblies.
 		TimestampAuthorityCertificateAlias="$(JarsignerTimestampAuthorityCertificateAlias)"
 		SigningAlgorithm="$(AndroidApkSigningAlgorithm)"
 	/>
-	<Delete Files="%(ApkAbiFilesSigned.FullPath)" Condition=" '$(AndroidUseApkSigner)' == 'true' "/>
+	<Delete Files="$(ApkFileSigned)" Condition=" '$(AndroidUseApkSigner)' == 'true' "/>
 	<AndroidZipAlign Condition=" '$(AndroidUseApkSigner)' == 'true' "
 		Source="%(ApkAbiFilesIntermediate.FullPath)"
 		DestinationDirectory="$(OutDir)"


### PR DESCRIPTION
Context https://bugzilla.xamarin.com/show_bug.cgi?id=57914

This commit adds support for the `apksigner` tool which
ships with android. It is enabled by a new property

	$(AndroidUseApkSigner)

When set to true the old `jarsigner` code will be bypassed.
The new system examines the manifest file to figure out the
min and max supported versions of android. This is then passed
to the `apksigner` along with the other information (like keys etc)
and allows `apksigner` to figure out what signing algorithm to use.

Additional parameters can be passed to the tool by the developer
via the `AndroidApkSignerAdditionalArguments` property.