### PR TITLE
[tests] Add Configuration info to test names

### DIFF
--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -3,6 +3,7 @@
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.Adb" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.CheckAdbTarget" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.CreateAndroidEmulator" />
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.RenameTestCases" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.RunInstrumentationTests" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.RunUITests" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.StartAndroidEmulator" />
@@ -182,5 +183,43 @@
         DefinitionsFilename="%(TestApk.TimingDefinitionsFilename)"
         AddResults="true"
         Activity="%(TestApk.Activity)" />
+  </Target>
+  <Target Name="RenameTestCases">
+    <Error
+        Condition=" '$(RenameTestCasesGlob)' == '' "
+        Text="Please set `%24(RenameTestCasesGlob)`."
+    />
+    <Error
+        Condition=" '$(Configuration)' == '' "
+        Text="Please set `%24(Configuration)`."
+    />
+    <PropertyGroup>
+      <_DeleteSource Condition=" '$(DeleteTestCaseSourceFiles)' != '' ">$(DeleteTestCaseSourceFiles)</_DeleteSource>
+      <_DeleteSource Condition=" '$(_DeleteSource)' == '' ">True</_DeleteSource>
+    </PropertyGroup>
+    <ItemGroup>
+      <_RenameSource1 Include="$(RenameTestCasesGlob)" />
+    </ItemGroup>
+    <ItemGroup>
+      <_RenameSource  Include="%(_RenameSource1.Identity)">
+        <DestinationFolder>@(_RenameSource1->'%(RootDir)%(Directory)')</DestinationFolder>
+      </_RenameSource>
+    </ItemGroup>
+    <RenameTestCases
+        Configuration="$(Configuration)"
+        DeleteSourceFiles="$(_DeleteSource)"
+        SourceFile="%(_RenameSource.Identity)"
+        DestinationFolder="%(_RenameSource.DestinationFolder)"
+    />
+  </Target>
+  <Target Name="RenameApkTestCases"
+      Condition=" '@(TestApk)' != '' ">
+    <RenameTestCases
+        Condition=" '%(TestApk.ResultsPath)' != '' "
+        Configuration="$(Configuration)$(_AotName)"
+        DeleteSourceFiles="True"
+        DestinationFolder="$(MSBuildThisFileDirectory)..\.."
+        SourceFile="%(TestApk.ResultsPath)"
+    />
   </Target>
 </Project>

--- a/src/Mono.Android/Test/Mono.Android-Tests.projitems
+++ b/src/Mono.Android/Test/Mono.Android-Tests.projitems
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.ProcessPlotInput" />
   <PropertyGroup>
-    <_MonoAndroidTestResultsPath>$(MSBuildThisFileDirectory)..\..\..\TestResult-Mono.Android_Tests.xml</_MonoAndroidTestResultsPath>
+    <_MonoAndroidTestResultsPath>$(OutputPath)TestResult-Mono.Android_Tests.xml</_MonoAndroidTestResultsPath>
     <_MonoAndroidTestPackage>Mono.Android_Tests</_MonoAndroidTestPackage>
     <_MonoAndroidTestApkFile>$(OutputPath)Mono.Android_Tests-Signed.apk</_MonoAndroidTestApkFile>
     <_MonoAndroidTestApkSizesInput>apk-sizes-$(_MonoAndroidTestPackage)-$(Configuration)$(_AotName).txt</_MonoAndroidTestApkSizesInput>
@@ -16,10 +16,21 @@
     </TestApk>
   </ItemGroup>
   <Target Name="_RecordApkSizes" AfterTargets="DeployTestApks">
-    <Delete Files="$(MSBuildThisFileDirectory)..\..\..\TestResult-Mono.Android_Tests-values.csv;$(MSBuildThisFileDirectory)..\..\..\TestResult-Mono.Android_Tests-times.csv" Condition=" '$(Configuration)' == 'Debug' " />
-    <Exec Condition=" '$(HostOS)' == 'Darwin' " Command="stat -f &quot;stat: %z %N&quot; &quot;$(_MonoAndroidTestApkFile)&quot; > $(_MonoAndroidTestApkSizesInput)" />
-    <Exec Condition=" '$(HostOS)' == 'Linux' " Command="stat -c &quot;stat: %s %N&quot; &quot;$(_MonoAndroidTestApkFile)&quot; > $(_MonoAndroidTestApkSizesInput)" />
-    <Exec Command="unzip -l &quot;$(_MonoAndroidTestApkFile)&quot; >> $(_MonoAndroidTestApkSizesInput)" />
-    <ProcessPlotInput InputFilename="$(_MonoAndroidTestApkSizesInput)" ApplicationPackageName="$(_MonoAndroidTestPackage)" ResultsFilename="$(MSBuildThisFileDirectory)..\..\..\TestResult-Mono.Android_Tests.xml" DefinitionsFilename="$(MSBuildThisFileDirectory)apk-sizes-definitions-$(Configuration)$(_AotName).txt" AddResults="true" />
+    <Exec
+        Condition=" '$(HostOS)' == 'Darwin' "
+        Command="stat -f &quot;stat: %z %N&quot; &quot;$(_MonoAndroidTestApkFile)&quot; > &quot;$(OutputPath)$(_MonoAndroidTestApkSizesInput)&quot;"
+    />
+    <Exec
+        Condition=" '$(HostOS)' == 'Linux' "
+        Command="stat -c &quot;stat: %s %N&quot; &quot;$(_MonoAndroidTestApkFile)&quot; > &quot;$(OutputPath)$(_MonoAndroidTestApkSizesInput)&quot;"
+    />
+    <Exec Command="unzip -l &quot;$(_MonoAndroidTestApkFile)&quot; >> &quot;$(OutputPath)$(_MonoAndroidTestApkSizesInput)&quot;" />
+    <ProcessPlotInput
+        InputFilename="$(OutputPath)$(_MonoAndroidTestApkSizesInput)"
+        ApplicationPackageName="$(_MonoAndroidTestPackage)"
+        ResultsFilename="$(_MonoAndroidTestResultsPath)"
+        DefinitionsFilename="$(MSBuildThisFileDirectory)apk-sizes-definitions-$(Configuration)$(_AotName).txt"
+        AddResults="True"
+    />
   </Target>
 </Project>

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -35,6 +35,7 @@
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -47,6 +48,7 @@
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GenerateMonoDroidIncludes.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GenerateProfile.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GetNugetPackageBasePath.cs" />
+    <Compile Include="Xamarin.Android.Tools.BootstrapTasks\RenameTestCases.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\StartAndroidEmulator.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\UnzipDirectoryChildren.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Zip.cs" />

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	public class RenameTestCases : Task
+	{
+		public                  bool                DeleteSourceFiles           { get; set; }
+		public                  string              Configuration               { get; set; }
+		[Required]
+		public                  string              SourceFile                  { get; set; }
+		[Required]
+		public                  string              DestinationFolder           { get; set; }
+
+		[Output]
+		public                  ITaskItem[]         CreatedFiles                { get; set; }
+
+		public override bool Execute ()
+		{
+			Log.LogMessage (MessageImportance.Low, $"Task {nameof (RenameTestCases)}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (Configuration)}: {Configuration}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (DeleteSourceFiles)}: {DeleteSourceFiles}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (DestinationFolder)}: {DestinationFolder}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (SourceFile)}: {SourceFile}");
+
+			var createdFiles    = new List<ITaskItem> ();
+			var testNameSuffix  = string.IsNullOrWhiteSpace (Configuration)
+				? ""
+				: $" / {Configuration}";
+			try {
+				var dest    = FixupTestResultFile (SourceFile, testNameSuffix);
+				var item    = new TaskItem (dest);
+				item.SetMetadata ("SourceFile", SourceFile);
+				createdFiles.Add (item);
+			}
+			catch (Exception e) {
+				Log.LogErrorFromException (e);
+			}
+
+			CreatedFiles    = createdFiles.ToArray ();
+
+			Log.LogMessage (MessageImportance.Low, $"  [Output] {nameof (CreatedFiles)}:");
+			foreach (var f in CreatedFiles) {
+				Log.LogMessage (MessageImportance.Low, $"    [Output] {f}:");
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+
+		string FixupTestResultFile (string source, string testNameSuffix)
+		{
+			var doc = XDocument.Load (source);
+			switch (doc.Root.Name.LocalName) {
+			case "test-results":
+				FixupNUnit2Results (doc, testNameSuffix);
+				break;
+			}
+			var destFilename = Path.GetFileNameWithoutExtension (source) +
+				(string.IsNullOrWhiteSpace (Configuration) ? "" : "-" + Configuration) +
+				Path.GetExtension (source);
+			var dest = Path.Combine (DestinationFolder, destFilename);
+
+			doc.Save (dest);
+			if (DeleteSourceFiles && Path.GetFullPath (source) != Path.GetFullPath (dest)) {
+				File.Delete (source);
+			}
+			return dest;
+		}
+
+		void FixupNUnit2Results (XDocument doc, string testNameSuffix)
+		{
+			foreach (var e in doc.Descendants ("test-case")) {
+				var name = (string) e.Attribute ("name");
+				if (name.EndsWith (testNameSuffix, StringComparison.OrdinalIgnoreCase))
+					continue;
+				name += testNameSuffix;
+				e.SetAttributeValue ("name", name);
+			}
+		}
+	}
+}

--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.projitems
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.projitems
@@ -4,7 +4,7 @@
     <TestApk Include="$(OutputPath)Xamarin.Android.JcwGen_Tests-Signed.apk">
       <Package>Xamarin.Android.JcwGen_Tests</Package>
       <InstrumentationType>xamarin.android.jcwgentests.TestInstrumentation</InstrumentationType>
-      <ResultsPath>$(MSBuildThisFileDirectory)..\..\..\TestResult-Xamarin.Android.JcwGen_Tests.xml</ResultsPath>
+      <ResultsPath>$(OutputPath)TestResult-Xamarin.Android.JcwGen_Tests.xml</ResultsPath>
       <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)..\..\..\build-tools\scripts\TimingDefinitions.txt</TimingDefinitionsFilename>
     </TestApk>
   </ItemGroup>

--- a/tests/RunApkTests.targets
+++ b/tests/RunApkTests.targets
@@ -19,9 +19,9 @@
     `$(TEST_APK_PROJECTS_RELEASE)` within the toplevel `Makefile`.
     -->
   <Import Project="..\src\Mono.Android\Test\Mono.Android-Tests.projitems" />
-  <Import Project="..\tests\Xamarin.Android.Bcl-Tests\Xamarin.Android.Bcl-Tests.projitems" Condition=" '$(Configuration)' == 'Debug' " />
-  <Import Project="..\tests\CodeGen-Binding\Xamarin.Android.JcwGen-Tests\Xamarin.Android.JcwGen-Tests.projitems" Condition=" '$(Configuration)' == 'Debug' " />
-  <Import Project="..\tests\locales\Xamarin.Android.Locale-Tests\Xamarin.Android.Locale-Tests.projitems"  Condition=" '$(Configuration)' == 'Debug' " />
+  <Import Project="..\tests\Xamarin.Android.Bcl-Tests\Xamarin.Android.Bcl-Tests.projitems" Condition=" '$(AotAssemblies)' != 'True' " />
+  <Import Project="..\tests\CodeGen-Binding\Xamarin.Android.JcwGen-Tests\Xamarin.Android.JcwGen-Tests.projitems" Condition=" '$(AotAssemblies)' != 'True' " />
+  <Import Project="..\tests\locales\Xamarin.Android.Locale-Tests\Xamarin.Android.Locale-Tests.projitems"  Condition=" '$(AotAssemblies)' != 'True' " />
   <Import Project="..\tests\Xamarin.Forms-Performance-Integration\Droid\Xamarin.Forms.Performance.Integration.Droid.projitems"  Condition=" '$(Configuration)' == 'Release' And '$(AotAssemblies)' != 'true' " />
   <Import Project="..\build-tools\scripts\TestApks.targets" />
   <PropertyGroup>
@@ -30,7 +30,8 @@
       UndeployTestApks;
       DeployTestApks;
       RunTestApks;
-      ReleaseAndroidTarget
+      ReleaseAndroidTarget;
+      RenameApkTestCases;
     </RunApkTestsDependsOn>
   </PropertyGroup>
   <Target Name="RunApkTests"

--- a/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj
+++ b/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>pdbonly</DebugType>
+    <DebugType>Full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\TestRelease</OutputPath>
     <ErrorReport>prompt</ErrorReport>

--- a/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.projitems
+++ b/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.projitems
@@ -4,7 +4,7 @@
     <TestApk Include="$(OutputPath)Xamarin.Android.Bcl_Tests-Signed.apk">
       <Package>Xamarin.Android.Bcl_Tests</Package>
       <InstrumentationType>xamarin.android.bcltests.TestInstrumentation</InstrumentationType>
-      <ResultsPath>$(MSBuildThisFileDirectory)..\..\TestResult-Xamarin.Android.Bcl_Tests.xml</ResultsPath>
+      <ResultsPath>$(OutputPath)TestResult-Xamarin.Android.Bcl_Tests.xml</ResultsPath>
       <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)..\..\build-tools\scripts\TimingDefinitions.txt</TimingDefinitionsFilename>
     </TestApk>
   </ItemGroup>

--- a/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets
+++ b/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets
@@ -62,6 +62,7 @@
         HostOS="$(HostOS)"
         DestinationFolder="..\..\bin\$(Configuration)\bcl-tests"
     />
+    <Touch Files="@(_TestResource)" />
   </Target>
   <Target Name="_GenerateApp_cs"
       Inputs="@(MonoTestAssembly->'..\..\bin\$(Configuration)\bcl-tests\%(Identity)')"

--- a/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.projitems
+++ b/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.projitems
@@ -4,7 +4,7 @@
     <TestApk Include="$(OutputPath)Xamarin.Forms_Performance_Integration-Signed.apk">
       <Package>Xamarin.Forms_Performance_Integration</Package>
       <Activity>Xamarin.Forms_Performance_Integration/md52b709e14dec302485bbcaeac0bd817ce.MainActivity</Activity>
-      <ResultsPath>$(MSBuildThisFileDirectory)..\..\..\TestResult-Xamarin.Forms_Test.xml</ResultsPath>
+      <ResultsPath></ResultsPath>
       <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)timing-definitions.txt</TimingDefinitionsFilename>
     </TestApk>
   </ItemGroup>

--- a/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.projitems
+++ b/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.projitems
@@ -4,7 +4,7 @@
     <TestApk Include="$(OutputPath)Xamarin.Android.Locale_Tests-Signed.apk">
       <Package>Xamarin.Android.Locale_Tests</Package>
       <InstrumentationType>xamarin.android.localetests.TestInstrumentation</InstrumentationType>
-      <ResultsPath>$(MSBuildThisFileDirectory)..\..\..\TestResult-Xamarin.Android.Locale_Tests.xml</ResultsPath>
+      <ResultsPath>$(OutputPath)TestResult-Xamarin.Android.Locale_Tests.xml</ResultsPath>
       <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)..\..\..\build-tools\scripts\TimingDefinitions.txt</TimingDefinitionsFilename>
     </TestApk>
   </ItemGroup>


### PR DESCRIPTION
Context: 0077d151
Context: d1d9820a

A "funny" thing happened when commit e9daf5ea didn't build on Jenkins:
I realized that not all tests were run in all configurations. From
commit d1d9820a:

> Why are some tests Debug-only and some aren't?

The answer: time, primarily. Why run tests multiple times, when they
can be potentially time-consuming?

While tests can be slow, they're not always *that* slow -- except for
`Xamarin.Android.Build.Tests` and the BCL tests -- and even there,
program behavior can alter between Debug and Release configurations.
See in particular commit 0077d151, in which the BCL tests are run only
in the Debug configuration because tests *failed* when run in the
Release configuration.

The desire, then, is to run *all* tests in both Debug and Release
configurations. Yes, it'll take longer! So what! (Within reason:
`Xamarin.Android.Build.Tests` should only be run once!)

However, this raises two problems:

 1. Filename collisions
 2. Jenkins unit test display

Until now, all tests wrote files into a filename that didn't include
the Configuration, e.g. `TestResult-Mono.Android_Tests.xml`. If we did
run these tests twice, the second test invocation would overwrite the
first test invocation. This isn't desirable.

Then there's the display on Jenkins: if we did have e.g.
`TestResult-Mono.Android_Tests-Debug.xml`       and
`TestResult-Mono.Android_Tests-Release.xml`, how will Jenkins display
that information? I haven't tested, but I would assume that one of two
things will occur, assuming reasonable Jenkins behavior:

 1. Each test will be listed twice, e.g.

        ApplicationContextIsApp
        ApplicationContextIsApp

 2. They'll be "merged" into a single entry.

Neither of these behaviors is desirable: if Debug passes but Release
fails, we need to be able to differentiate between them. Neither of
these possible renderings allows us to tell which configuration fails.

Solve both of these problems by introducing a new `<RenameTestCases/>`
task. This task takes three values of importance:

```xml
<RenameTestCases
    Configuration="CONFIGURATION"
    SourceFile="SOURCE"
    DestinationFolder="DESTINATION"
/>
```

The `<RenameTestCases/>` task will read in `SOURCE`, and if `SOURCE`
is an XML file which we determine is NUnit2-formatted XML (root
element of `<test-case/>`), we will update every `//test-case/@name`
value so that it ends with ` / CONFIGURATION`. The updated XML is
then written to the `DESTINATION` directory, with a filename that
contains `CONFIGURATION`, and `SOURCE` is deleted.

Thus, if we have a Debug-configuration
`TestResult-Mono.Android_Tests.xml` file with XML fragment:

```xml
<test-case
    name="Mono.Android_Tests, Android.AppTests.ApplicationTest.ApplicationContextIsApp"
    ...
/>
```

then `<RenameTestCases/>` will create the file
`TestResult-Mono.Android_Tests-Debug.xml` file with XML fragment:

```xml
<test-case
    name="Mono.Android_Tests, Android.AppTests.ApplicationTest.ApplicationContextIsApp / Debug"
    ...
/>
```

This allows us to run tests in both Debug and Release configurations
while not inadvertently overwriting the `TestResults*.xml` files that
Jenkins reads, and ensuring that the Jenkins test result output is
rendered in a meaningfully useful fashion.

Aside: when updating `//test-case/@name`, the resulting value *cannot*
end in `)`. If it does, then the `(root)` package name issue fixed in
commit 23b2642e reappears for the `generator` unit tests.

**Completely random aside about the state of `xbuild`**:
A development version of `<RenameTestCases/>` was "saner", using
`ITaskItem[]` and not string:

```csharp
partial class RenameTestCases {
    public      ITaskItem[]   SourceFiles {get; set;}
    // vs.
    //  public  string        SourceFile  {get; set;}
}
```

The problem is that the above, while entirely reasonable, did not work
at all correctly with `xbuild`:

```xml
<RenameTestCases SourceFiles="%(TestApk.ResultsPath)" />
```

Under `xbuild`, MSBuild properties would not be expanded, e.g.
`RenameTestCases.SourceFiles` would get a "bizarro" value of e.g.
`$(OutputPath)Mono.Android_Tests-Signed.apk`, which is *useless* and
would result in `FileNotFoundException`s.

MSBuild proper, of course, worked as desired.

TODO: Once this is merged, update the Jenkins Configuration page so
that instead of:

        make run-all-tests V=1 || exit 1

it instead runs both Debug and Release configuration tests:

        make run-all-tests SKIP_NUNIT_TESTS=1    V=1 || exit 1
        make run-all-tests CONFIGURATION=Release V=1 || exit 1

Note that `$(SKIP_NUNIT_TESTS)` is specified so that we only run the
lengthy (1+hr!) `Xamarin.Android.Build.Tests` tests in the Release
configuration, not the Debug + Release configurations.