### PR TITLE
[Mono.Android] Bind Build.getVersion() as Build.GetVersion()

### DIFF
--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1381,4 +1381,14 @@
   <attr path="/api/package[@name='android.media']/interface[@name='MediaCas.EventListener']" name="argsType">MediaCasEventArgs</attr>
   <attr path="/api/package[@name='android.media']/interface[@name='MediaCas.EventListener']/method[@name='onEvent']/parameter[@name='MediaCas']" name="managedName">mediaCas</attr>
 
+  <!-- detected field-property conflicts (e.g. see bug #60069)
+
+  Some people think it's easy to implement "check and skip property generation" without trying to do,
+  but in reality it is not easy. That will change order of processing and
+  results in changes in generated code,
+  resulting in further unexpected breakages. That is not acceptable.
+  Fixing conflicts in metadata without changing the order of processing
+  is the only way to go. For further changes we should completely rewrite everything.
+   -->
+  <attr path="/api/package[@name='android.os']/class[@name='Build']/method[@name='getSerial']" name="propertyName"></attr>
 </metadata>


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=60069
Context: https://bugzilla.xamarin.com/attachment.cgi?id=25276

API-26 added an [`android.os.Build.getSerial()`][0] method. Under
normal "name mangling" conventions, `generator` binds this as an
`Android.OS.Build.Serial` property.

[0]: https://developer.android.com/reference/android/os/Build.html#getSerial()

There's just one "minor" problem with this: there is *also* an
[`android.os.Build.SERIAL`][1] field, since API-9, which `generator`
*also* binds as an `Android.OS.Build.Serial` property.

[1]: https://developer.android.com/reference/android/os/Build.html#SERIAL

Thus, a question: given the Java code:

```java
public class Build {
	public static String SERIAL = "UNKNOWN";
	public static String getSerial() {/* ... */ }
}
```

What will `generator` do?

Answer: the wrong thing: the field is *ignored*, and the
`Build.getSerial()` method is used for the `Build.Serial` property.

This is problematic. *The managed API has not changed* -- pre-API-26
and post-API-26 both have a string `Build.Serial` property --
but the *behavior* of the method has changed from reading the value of
a static field, to invoking a static method.

A static method that only exists on devices running API-26 and later.

Meaning:

 1. Create a new Xamarin.Android app.
 2. Set `$(TargetFrameworkVersion)` to v8.0, and
    `//uses-sdk/@android:minSdkVersion` to 11 within
		`AndroidManifest.xml`.
 3. Within e.g. `MainActivity.OnCreate()`, reference the
    `Android.OS.Build.Serial` property.
 4. Build the app, and run on e.g. an Android 7.1 device.

Expected result: it works!

Actual result: not so much:

	Java.Lang.NoSuchMethodError: no static method "Landroid/os/Build;.getSerial()Ljava/lang/String;"

@atsushieno has determined that this is the only such behavioral
breakage introduced by API-26. His
[referenced metadata fixup changes][2] patch lists all the fields
which are currently being ignored by the `Mono.Android` build process.

[2]: https://bugzilla.xamarin.com/attachment.cgi?id=25276

In the interest of expediency (and getting this merged into d15-4),
include *only* the metadata changes that impact `Build.getSerial()`,
and force it to be bound as a `Build.GetSerial()` method. This
"un-hides" the `Build.Serial` binding of the `Build.SERIAL` field,
restoring semantic compatibility.

The remaining of the metadata fixup changes should be merged
separately.