### PR TITLE
[tests] Add link description xml file for Bcl_tests

### DIFF
--- a/tests/Xamarin.Android.Bcl-Tests/Resources/LinkerDescription.xml
+++ b/tests/Xamarin.Android.Bcl-Tests/Resources/LinkerDescription.xml
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<linker>
+  <assembly fullname="mscorlib">
+    <type fullname="System.Security.Permissions.UIPermission">
+      <method name="System.Security.Permissions.IBuiltInPermission.GetTokenIndex"/>
+    </type>
+    <type fullname="System.Reflection.AssemblyProductAttribute">
+      <method name=".ctor"/>
+    </type>
+    <type fullname="System.Reflection.AssemblyCopyrightAttribute">
+      <method name=".ctor"/>
+    </type>
+    <type fullname="System.Reflection.AssemblyTrademarkAttribute">
+      <method name=".ctor"/>
+    </type>
+    <type fullname="System.Reflection.AssemblyVersionAttribute">
+      <method name=".ctor"/>
+    </type>
+    <type fullname="System.Reflection.AssemblyFileVersionAttribute">
+      <method name=".ctor"/>
+    </type>
+    <type fullname="System.Reflection.AssemblyInformationalVersionAttribute">
+      <method name=".ctor"/>
+    </type>
+    <type fullname="System.Reflection.AssemblyCultureAttribute">
+      <method name=".ctor"/>
+    </type>
+    <type fullname="System.Reflection.AssemblyAlgorithmIdAttribute">
+      <method name=".ctor"/>
+    </type>
+    <type fullname="System.Reflection.AssemblyFlagsAttribute">
+      <method name=".ctor"/>
+    </type>
+    <type fullname="System.Reflection.AssemblyDelaySignAttribute">
+      <method name=".ctor"/>
+    </type>
+    <type fullname="System.Reflection.AssemblyKeyNameAttribute">
+      <method name=".ctor"/>
+    </type>
+    <type fullname="System.Runtime.CompilerServices.MethodImplAttribute">
+      <method name=".ctor"/>
+    </type>
+    <type fullname="System.Runtime.InteropServices.DllImportAttribute">
+      <method name=".ctor"/>
+    </type>
+    <type fullname="System.ConsoleKey"/>
+    <type fullname="System.ConsoleKeyInfo"/>
+  </assembly>
+</linker>

--- a/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj
+++ b/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj
@@ -89,6 +89,9 @@
     <AndroidResource Include="Resources\mipmap-xxhdpi\Icon.png" />
     <AndroidResource Include="Resources\mipmap-xxxhdpi\Icon.png" />
   </ItemGroup>
+  <ItemGroup>
+    <LinkDescription Include="Resources\LinkerDescription.xml" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Import Project="Xamarin.Android.Bcl-Tests.targets" />
   <PropertyGroup>


### PR DESCRIPTION
Some of the tests use reflection to access BCL API. Parts of the
needed API is linked away by the linker. The link description file
makes sure the needed parts stay in the mscorlib and thus the tests
don't fail.

This fixes remaining issues in the Bcl_tests in Release configuration
and the test should run without failures when linked (LinkSdkOnly).