### PR TITLE
[Xamarin.Android.Build.Tasks] Add new Disabled Issue for MissingSuperCall

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
@@ -168,6 +168,10 @@ namespace Xamarin.Android.Tasks
 			// for the MonoPackageManager.java since we have to use a static to keep track of the
 			// application instance.
 			{ "StaticFieldLeak", new Version(26, 0, 2) },
+			// We need to hard code this test as disabled because Lint will issue a error
+			// for our generated code not calling super.OnCreate. This however is by design
+			// so we need to ignore this error.
+			{ "MissingSuperCall", new Version (26, 1, 1) },
 		};
 
 		static readonly Regex lintVersionRegex = new Regex (@"version[\t\s]+(?<version>[\d\.]+)");


### PR DESCRIPTION
lint 26.1.1 added a new MissingSuperCall check to lint. This
errors out if a class does NOT call `super.OnCreate`. Because
our generated code doesn't need to call `supoer.OnCreate`.