### PR TITLE
[bcl tests] fix remaining issue for Release configuration

### DIFF
--- a/tests/Xamarin.Android.Bcl-Tests/Resources/LinkerDescription.xml
+++ b/tests/Xamarin.Android.Bcl-Tests/Resources/LinkerDescription.xml
@@ -43,6 +43,9 @@
     <type fullname="System.Runtime.InteropServices.DllImportAttribute">
       <method name=".ctor"/>
     </type>
+    <type fullname="System.Runtime.Remoting.Activation.ActivationServices">
+      <method name="CreateProxyForType"/>
+    </type>
     <type fullname="System.ConsoleKey"/>
     <type fullname="System.ConsoleKeyInfo"/>
   </assembly>


### PR DESCRIPTION
The results reporting acted weird and hid 2 failures, which were not
reported in the instrumentation result lines

         INSTRUMENTATION_RESULT: failed=0
         INSTRUMENTATION_RESULT: inconclusive=0
         INSTRUMENTATION_RESULT: passed=20134
         INSTRUMENTATION_RESULT: run=20466
         INSTRUMENTATION_RESULT: nunit2-results-path=/data/data/Xamarin.Android.Bcl_Tests/files/.__override__/TestResults.xml
         INSTRUMENTATION_RESULT: skipped=322
         INSTRUMENTATION_CODE: -1

and were only reported in the
`TestResult-Xamarin.Android.Bcl_Tests-Release.xml` file.

From logcat output we can see the crash (same for both failures)

    --------- beginning of crash
    E/AndroidRuntime( 3826): FATAL EXCEPTION: main
    E/AndroidRuntime( 3826): Process: Xamarin.Android.Bcl_Tests, PID: 3826
    E/AndroidRuntime( 3826): android.runtime.JavaProxyThrowable: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.NotSupportedException: Linked away.
    E/AndroidRuntime( 3826):   at (wrapper managed-to-native) System.Object:__icall_wrapper_ves_icall_object_new_specific (intptr)
    E/AndroidRuntime( 3826):   at MonoTests.System.Runtime.Remoting.ContextTest..ctor () [0x00000] in <0484cb939a1a4a72be4938b3c08edcaa>:0
    E/AndroidRuntime( 3826):   at (wrapper managed-to-native) System.Reflection.MonoCMethod:InternalInvoke (System.Reflection.MonoCMethod,object,object[],System.Exception&)
    E/AndroidRuntime( 3826):   at System.Reflection.MonoCMethod.InternalInvoke (System.Object obj, System.Object[] parameters) [0x00002] in <0e1d684ae38a4822aaf6364f06390ad6>:0
    E/AndroidRuntime( 3826):    --- End of inner exception stack trace ---

That lead us to the `mono/mono/metadata/object.c` source, where
`mono_error_set_not_supported (error, "Linked away.");` is used 6
times.

One of the cases was related to `im = mono_class_get_method_from_name
(klass, "CreateProxyForType", 1);`. That led us to the linked away
System.Runtime.Remoting.Activation.ActivationServices.CreateProxyForType
method.