### PR TITLE
[build] Fix `make prepare` ordering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,11 +88,7 @@ GetPath   = $(shell $(MSBUILD) $(MSBUILD_FLAGS) /p:DoNotLoadOSProperties=True /n
 MSBUILD_PREPARE_PROJS = \
 	src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
 
-prepare-deps:
-	./build-tools/scripts/generate-os-info Configuration.OperatingSystem.props
-	$(MSBUILD) $(MSBUILD_FLAGS) build-tools/dependencies/dependencies.mdproj
-
-prepare-external: prepare-deps
+prepare-external:
 	git submodule update --init --recursive
 	nuget restore $(SOLUTION)
 	nuget restore Xamarin.Android-Tests.sln
@@ -102,7 +98,11 @@ prepare-external: prepare-deps
 		(cd $(call GetPath,JavaInterop) && make bin/Build$(conf)/JdkInfo.props CONFIGURATION=$(conf)) && ) \
 	true
 
-prepare-props: prepare-external
+prepare-deps: prepare-external
+	./build-tools/scripts/generate-os-info Configuration.OperatingSystem.props
+	$(MSBUILD) $(MSBUILD_FLAGS) build-tools/dependencies/dependencies.mdproj
+
+prepare-props: prepare-deps
 	cp build-tools/scripts/Configuration.Java.Interop.Override.props external/Java.Interop/Configuration.Override.props
 	cp $(call GetPath,MonoSource)/mcs/class/msfinal.pub .
 


### PR DESCRIPTION
@clancey was trying to build xamarin-android, which failed:

	$ make prepare
	./build-tools/scripts/generate-os-info Configuration.OperatingSystem.props
	xbuild /p:Configuration=Debug  /p:_DebugFileExt=.pdb build-tools/dependencies/dependencies.mdproj
	...
	warning : Referenced Project ../../external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj not found, ignoring.
	...
	Xamarin.Android.BuildTools.PrepTasks/JdkInfo.cs(9,23): error CS0234: The type or namespace name 'Tools' does not exist in the namespace 'Xamarin.Android' (are you missing an assembly reference?)

The problem is that `make prepare-deps`, which builds
`build-tools/dependencies/dependencies.mdproj`, implicitly builds
`build-tools/xa-prep-tasks/xa-prep-tasks.csproj`, which in turn
depends on
`external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj`,
which is only reliably created by `make prepare-external`s
`git submodule update --init --recursive`.

Unfortunately, `make prepare-external` wasn't invoked until *after*
`make prepare-deps`, meaning there is no way for `make prepare` to
actually work on a clean install!

(This works on Jenkins because Jenkins automatically checks out all
submodules, so it never encounters this "clean checkout" scenario.)

Reorder the targets that `make prepare` executes so that
`make prepare-external` is run *before* `make prepare-deps`, ensuring
that git submodules exist before we attempt to use them.