### PR TITLE
[xa-prep-tasks] Support single-digit versions

### DIFF
--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/Which.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/Which.cs
@@ -138,7 +138,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 			return curVersion > maxVersion;
 		}
 
-		static  readonly    Regex           VersionMatch    = new Regex (@"(?<version>\d+\.\d+(\.\d+(\.\d+)?)?)");
+		static  readonly    Regex           VersionMatch    = new Regex (@"(?<version>\d+(\.\d+(\.\d+(\.\d+)?)?)?)");
 
 		Version GetCurrentVersion ()
 		{
@@ -167,6 +167,9 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 					if (!m.Success)
 						return;
 					curVersion = m.Groups ["version"].Value;
+                                        if (!curVersion.Contains (".")) {
+                                                curVersion      += ".0";
+                                        }
 				};
 				p.Start ();
 				p.BeginOutputReadLine ();


### PR DESCRIPTION
JDK 9 reports a single-digit version value:

	$ javac -version
	javac 9

Unfortunately, this means that the `<Which/>` task won't properly
recognize JDK 9's `javac` as passing the
`%(RequiredProgram.MinimumVersion)` value of 1.8, because `<Which/>`
requires *at least* two digits, not one. (Because `System.Version`
required at least two digits; one would throw `ArgumentException`.)

Update the `<Which/>` task so that it supports single-digit version
values, treating them as if they had a "minor" value of `0`.