### PR TITLE
[Xamarin.Android.Build.Tasks] Updates for xabuild.exe

### DIFF
--- a/tools/xabuild/XABuildPaths.cs
+++ b/tools/xabuild/XABuildPaths.cs
@@ -114,10 +114,11 @@ namespace Xamarin.Android.Build
 				SearchPathsOS            = "windows";
 			} else {
 				string mono              = IsMacOS ? "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono" : "/usr/lib/mono";
+				string monoExternal      = IsMacOS ? "/Library/Frameworks/Mono.framework/External/" : "/usr/lib/mono";
 				MSBuildPath              = Path.Combine (mono, "msbuild");
 				MSBuildBin               = Path.Combine (MSBuildPath, "15.0", "bin");
 				MSBuildConfig            = Path.Combine (MSBuildBin, "MSBuild.dll.config");
-				ProjectImportSearchPaths = new [] { MSBuildPath, Path.Combine (mono, "xbuild") };
+				ProjectImportSearchPaths = new [] { MSBuildPath, Path.Combine (mono, "xbuild"), Path.Combine (monoExternal, "xbuild") };
 				SystemProfiles           = Path.Combine (mono, "xbuild-frameworks");
 				XABuildConfig            = Path.Combine (XABuildDirectory, "MSBuild.dll.config");
 				SearchPathsOS            = IsMacOS ? "osx" : "unix";


### PR DESCRIPTION
This commit fixes a couple of issues which appeared when
using xabuild.exe on macos. Firstly if the symlink exists
already the SymbolicLink code will error out and fail the
build completely. This happens because if you run two or
more xabuild.exe instances at the same time they trip over
each other trying to create the symlink.

So rather than erroring completely we should only error if
the link does NOT exist. If it does exist after an attempted
creation we should ignore the exception.

The other is about where we look for extensions. Xamarin.Android
is installed on mac into

	/Library/Frameworks/Mono.framework/External/xbuild

this was not included in the search path for MSbuild, so it never
manages to find the required .targets.