### PR TITLE
[performance measurements] Fix result files location

### DIFF
--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -179,9 +179,10 @@
         Condition=" '%(TestApk.TimingDefinitionsFilename)' != '' "
         InputFilename="$(_LogcatFilename)"
         ApplicationPackageName="%(TestApk.Package)"
-        ResultsFilename="%(TestApk.ResultsPath)"
+        ResultsFilename="%(TestApk.TimingResultsFilename)"
         DefinitionsFilename="%(TestApk.TimingDefinitionsFilename)"
         AddResults="true"
+        LabelSuffix="-$(Configuration)$(_AotName)"
         Activity="%(TestApk.Activity)" />
   </Target>
   <Target Name="RenameTestCases">

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ProcessLogcatTiming.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ProcessLogcatTiming.cs
@@ -64,7 +64,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 					Log.LogMessage (MessageImportance.Normal, " -- Performance summary --");
 					Log.LogMessage (MessageImportance.Normal, $"Last timing message: {(last - start).TotalMilliseconds}ms");
 
-					WriteResults ("times");
+					WriteResults ();
 				} else
 					Log.LogWarning ("Wasn't able to collect the performance data");
 

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ProcessPlotInput.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ProcessPlotInput.cs
@@ -23,6 +23,8 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 
 		public bool AddResults { get; set; }
 
+		public string LabelSuffix { get; set; }
+
 		protected Dictionary<string, Regex> definedRegexs = new Dictionary<string, Regex> ();
 		protected Dictionary<string, string> results = new Dictionary<string, string> ();
 
@@ -77,7 +79,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 					}
 				}
 
-				WriteResults ("values");
+				WriteResults ();
 
 				reader.Close ();
 			}
@@ -85,30 +87,29 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 			return true;
 		}
 
-		protected void WriteResults (string filenameEnd)
+		protected void WriteResults ()
 		{
 			if (ResultsFilename != null) {
-				string filename = Path.Combine (Path.GetDirectoryName (ResultsFilename), $"{Path.GetFileNameWithoutExtension (ResultsFilename)}-{filenameEnd}.csv");
 				string line1 = null, line2 = null;
-				if (AddResults && File.Exists (filename))
-					using (var reader = new StreamReader (filename)) {
+				if (AddResults && File.Exists (ResultsFilename))
+					using (var reader = new StreamReader (ResultsFilename)) {
 						try {
 							line1 = reader.ReadLine ();
 							line2 = reader.ReadLine ();
 						} catch (Exception e) {
-							Log.LogWarning ($"unable to read previous results from {filename}\n{e}");
+							Log.LogWarning ($"unable to read previous results from {ResultsFilename}\n{e}");
 							line1 = line2 = null;
 						}
 					}
-				using (var resultsFile = new StreamWriter (filename)) {
-					WriteValues (resultsFile, results.Keys, line1);
+				using (var resultsFile = new StreamWriter (ResultsFilename)) {
+					WriteValues (resultsFile, results.Keys, line1, LabelSuffix);
 					WriteValues (resultsFile, results.Values, line2);
 					resultsFile.Close ();
 				}
 			}
 		}
 
-		void WriteValues (StreamWriter writer, ICollection<string> values, string line)
+		void WriteValues (StreamWriter writer, ICollection<string> values, string line, string suffix = null)
 		{
 			bool first;
 			if (string.IsNullOrEmpty (line))
@@ -121,6 +122,8 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 				if (!first)
 					writer.Write (',');
 				writer.Write (key);
+				if (!string.IsNullOrEmpty (suffix))
+					writer.Write (suffix);
 				first = false;
 			}
 			writer.WriteLine ();

--- a/src/Mono.Android/Test/Mono.Android-Tests.projitems
+++ b/src/Mono.Android/Test/Mono.Android-Tests.projitems
@@ -6,13 +6,15 @@
     <_MonoAndroidTestPackage>Mono.Android_Tests</_MonoAndroidTestPackage>
     <_MonoAndroidTestApkFile>$(OutputPath)Mono.Android_Tests-Signed.apk</_MonoAndroidTestApkFile>
     <_MonoAndroidTestApkSizesInput>apk-sizes-$(_MonoAndroidTestPackage)-$(Configuration)$(_AotName).txt</_MonoAndroidTestApkSizesInput>
+    <_MonoAndroidApkSizesResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-Mono.Android_Tests-values.csv</_MonoAndroidApkSizesResultsFilename>
   </PropertyGroup>
   <ItemGroup>
     <TestApk Include="$(_MonoAndroidTestApkFile)">
       <Package>$(_MonoAndroidTestPackage)</Package>
       <InstrumentationType>xamarin.android.runtimetests.TestInstrumentation</InstrumentationType>
       <ResultsPath>$(_MonoAndroidTestResultsPath)</ResultsPath>
-      <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)timing-definitions-$(Configuration)$(_AotName).txt</TimingDefinitionsFilename>
+      <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)..\..\..\build-tools\scripts\TimingDefinitions.txt</TimingDefinitionsFilename>
+      <TimingResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-Mono.Android_Tests-times.csv</TimingResultsFilename>
     </TestApk>
   </ItemGroup>
   <Target Name="_RecordApkSizes" AfterTargets="DeployTestApks">
@@ -28,9 +30,10 @@
     <ProcessPlotInput
         InputFilename="$(OutputPath)$(_MonoAndroidTestApkSizesInput)"
         ApplicationPackageName="$(_MonoAndroidTestPackage)"
-        ResultsFilename="$(_MonoAndroidTestResultsPath)"
-        DefinitionsFilename="$(MSBuildThisFileDirectory)apk-sizes-definitions-$(Configuration)$(_AotName).txt"
+        ResultsFilename="$(_MonoAndroidApkSizesResultsFilename)"
+        DefinitionsFilename="$(MSBuildThisFileDirectory)apk-sizes-definitions.txt"
         AddResults="True"
+	LabelSuffix="-$(Configuration)$(_AotName)"
     />
   </Target>
 </Project>

--- a/src/Mono.Android/Test/apk-sizes-definitions-Debug.txt
+++ b/src/Mono.Android/Test/apk-sizes-definitions-Debug.txt
@@ -1,4 +1,0 @@
-apk-Debug=^stat: (?<value>\d+)\s+(?<message>.*)$
-Mono.Android.dll-Debug=^\s*(?<value>\d+)\s+.*(?<message>Mono.Android.dll)$
-mscorlib.dll-Debug=^\s*(?<value>\d+)\s+.*(?<message>mscorlib.dll)$
-monosgen-armeabi-v7a-Debug=^\s*(?<value>\d+)\s+.*(?<message>armeabi-v7a/libmonosgen-2.0.so)$

--- a/src/Mono.Android/Test/apk-sizes-definitions-Release-Aot.txt
+++ b/src/Mono.Android/Test/apk-sizes-definitions-Release-Aot.txt
@@ -1,6 +1,0 @@
-apk-Release-Aot=^stat: (?<value>\d+)\s+(?<message>.*)$
-Mono.Android.dll-Release-Aot=^\s*(?<value>\d+)\s+.*(?<message>Mono.Android.dll)$
-Mono.Android.dll.so-Release-Aot=^\s*(?<value>\d+)\s+.*(?<message>Mono.Android.dll.so)$
-mscorlib.dll-Release-Aot=^\s*(?<value>\d+)\s+.*(?<message>mscorlib.dll)$
-mscorlib.dll.so-Release-Aot=^\s*(?<value>\d+)\s+.*(?<message>mscorlib.dll.so)$
-monosgen-armeabi-v7a-Release-Aot=^\s*(?<value>\d+)\s+.*(?<message>armeabi-v7a/libmonosgen-2.0.so)$

--- a/src/Mono.Android/Test/apk-sizes-definitions-Release.txt
+++ b/src/Mono.Android/Test/apk-sizes-definitions-Release.txt
@@ -1,4 +1,0 @@
-apk-Release=^stat: (?<value>\d+)\s+(?<message>.*)$
-Mono.Android.dll-Release=^\s*(?<value>\d+)\s+.*(?<message>Mono.Android.dll)$
-mscorlib.dll-Release=^\s*(?<value>\d+)\s+.*(?<message>mscorlib.dll)$
-monosgen-armeabi-v7a-Release=^\s*(?<value>\d+)\s+.*(?<message>armeabi-v7a/libmonosgen-2.0.so)$

--- a/src/Mono.Android/Test/apk-sizes-definitions.txt
+++ b/src/Mono.Android/Test/apk-sizes-definitions.txt
@@ -1,0 +1,4 @@
+apk=^stat: (?<value>\d+)\s+(?<message>.*)$
+Mono.Android.dll=^\s*(?<value>\d+)\s+.*(?<message>Mono.Android.dll)$
+mscorlib.dll=^\s*(?<value>\d+)\s+.*(?<message>mscorlib.dll)$
+monosgen-armeabi-v7a=^\s*(?<value>\d+)\s+.*(?<message>armeabi-v7a/libmonosgen-2.0.so)$

--- a/src/Mono.Android/Test/timing-definitions-Debug.txt
+++ b/src/Mono.Android/Test/timing-definitions-Debug.txt
@@ -1,6 +1,0 @@
-# measure time of last monodroid-timing message appearance
-last-Debug=monodroid-timing:\s+(?<message>.*)$
-
-# measure time of runtime and JNIEnv initialization end
-init-Debug=monodroid-timing:\s+(?<message>Runtime\.init: end native-to-managed.*)$
-JNI.init-Debug=monodroid-timing:\s+(?<message>JNIEnv\.Initialize end:.*)$

--- a/src/Mono.Android/Test/timing-definitions-Release-Aot.txt
+++ b/src/Mono.Android/Test/timing-definitions-Release-Aot.txt
@@ -1,6 +1,0 @@
-# measure time of last monodroid-timing message appearance
-last-Release-Aot=monodroid-timing:\s+(?<message>.*)$
-
-# measure time of runtime and JNIEnv initialization end
-init-Release-Aot=monodroid-timing:\s+(?<message>Runtime\.init: end native-to-managed.*)$
-JNI.init-Release-Aot=monodroid-timing:\s+(?<message>JNIEnv\.Initialize end:.*)$

--- a/src/Mono.Android/Test/timing-definitions-Release.txt
+++ b/src/Mono.Android/Test/timing-definitions-Release.txt
@@ -1,6 +1,0 @@
-# measure time of last monodroid-timing message appearance
-last-Release=monodroid-timing:\s+(?<message>.*)$
-
-# measure time of runtime and JNIEnv initialization end
-init-Release=monodroid-timing:\s+(?<message>Runtime\.init: end native-to-managed.*)$
-JNI.init-Release=monodroid-timing:\s+(?<message>JNIEnv\.Initialize end:.*)$

--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.projitems
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.projitems
@@ -6,6 +6,7 @@
       <InstrumentationType>xamarin.android.jcwgentests.TestInstrumentation</InstrumentationType>
       <ResultsPath>$(OutputPath)TestResult-Xamarin.Android.JcwGen_Tests.xml</ResultsPath>
       <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)..\..\..\build-tools\scripts\TimingDefinitions.txt</TimingDefinitionsFilename>
+      <TimingResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-Xamarin.Android.JcwGen_Tests-times.csv</TimingResultsFilename>
     </TestApk>
   </ItemGroup>
 </Project>

--- a/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.projitems
+++ b/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.projitems
@@ -6,6 +6,7 @@
       <InstrumentationType>xamarin.android.bcltests.TestInstrumentation</InstrumentationType>
       <ResultsPath>$(OutputPath)TestResult-Xamarin.Android.Bcl_Tests.xml</ResultsPath>
       <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)..\..\build-tools\scripts\TimingDefinitions.txt</TimingDefinitionsFilename>
+      <TimingResultsFilename>$(MSBuildThisFileDirectory)..\..\TestResult-Xamarin.Android.Bcl_Tests-times.csv</TimingResultsFilename>
     </TestApk>
   </ItemGroup>
 </Project>

--- a/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.projitems
+++ b/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.projitems
@@ -6,6 +6,7 @@
       <Activity>Xamarin.Forms_Performance_Integration/md52b709e14dec302485bbcaeac0bd817ce.MainActivity</Activity>
       <ResultsPath></ResultsPath>
       <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)timing-definitions.txt</TimingDefinitionsFilename>
+      <TimingResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-Xamarin.Forms_Test-times.csv</TimingResultsFilename>
     </TestApk>
   </ItemGroup>
 </Project>

--- a/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.projitems
+++ b/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.projitems
@@ -6,6 +6,7 @@
       <InstrumentationType>xamarin.android.localetests.TestInstrumentation</InstrumentationType>
       <ResultsPath>$(OutputPath)TestResult-Xamarin.Android.Locale_Tests.xml</ResultsPath>
       <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)..\..\..\build-tools\scripts\TimingDefinitions.txt</TimingDefinitionsFilename>
+      <TimingResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-Xamarin.Android.Locale_Tests-times.csv</TimingResultsFilename>
     </TestApk>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Do not use `TestApk.ResultsPath` as base for performance measurements
anymore - it has changed recently by https://github.com/xamarin/xamarin-android/commit/385699a58635d87a1cc65b60995d3420995f21d7. Instead
pass own results filename to the ProcessLogcatTiming and
ProcessPlotInput tasks.

Also added LabelSuffix parameter to the task, so that it is easier to
create merged measurements. It comes handy as more tests are run in
multiple configurations now. It also simplifies the use of definitions
files as we don't need one per configuration anymore.