### PR TITLE
[xabuild] Copy `xabuild` to the output directory.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -43,6 +43,13 @@ namespace Xamarin.ProjectTools
 					if (!string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("USE_MSBUILD"))) {
 						RunningMSBuild = true;
 					}
+					#if DEBUG
+					var xabuild = Path.GetFullPath (Path.Combine (Root, "..", "Debug", "bin", "xabuild"));
+					#else
+					var xabuild = Path.GetFullPath (Path.Combine (Root, "..", "Release", "bin", "xabuild"));
+					#endif
+					if (File.Exists (xabuild))
+						return xabuild;
 					return Path.GetFullPath (Path.Combine (Root, "..", "..", "tools", "scripts", "xabuild"));
 				}
 

--- a/tools/xabuild/xabuild.csproj
+++ b/tools/xabuild/xabuild.csproj
@@ -63,6 +63,12 @@
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\scripts\xabuild">
+      <Link>xabuild</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
     <Delete Files="$(OutputPath)MSBuild.$(_MSBuildExtension).config" />


### PR DESCRIPTION
In order to get the tests running using xabuild on monodroid
we kinda need it in the output directory. This commit adds
it as Content to the xabuild.csproj. It also updaes the Builder
to look for `xabuild` in the output directory first and then
fallback to `tools\scripts`.
