### PR TITLE
[linker] Use mono's linker submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,10 +29,6 @@
 	path = external/llvm
 	url = https://github.com/mono/llvm.git
 	branch = master
-[submodule "external/linker"]
-	path = external/linker
-	url = https://github.com/mono/linker.git
-	branch = master
 [submodule "external/proguard"]
 	path = external/proguard
 	url = https://github.com/xamarin/proguard.git

--- a/Configuration.props
+++ b/Configuration.props
@@ -58,7 +58,7 @@
     <MonoRequiredMaximumVersion Condition=" '$(MonoRequiredMaximumVersion)' == '' ">5.9.0</MonoRequiredMaximumVersion>
     <IgnoreMaxMonoVersion Condition=" '$(IgnoreMaxMonoVersion)' == '' ">True</IgnoreMaxMonoVersion>
     <MonoRequiredDarwinMinimumVersion>$(MonoRequiredMinimumVersion).22</MonoRequiredDarwinMinimumVersion>
-    <LinkerSourceDirectory>$(MSBuildThisFileDirectory)external\linker</LinkerSourceDirectory>
+    <LinkerSourceDirectory>$(MSBuildThisFileDirectory)external\mono\external\linker</LinkerSourceDirectory>
     <OpenTKSourceDirectory>$(MSBuildThisFileDirectory)external\opentk</OpenTKSourceDirectory>
     <LibZipSourceDirectory Condition=" '$(LibZipSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\libzip</LibZipSourceDirectory>
     <LibZipSharpSourceDirectory Condition=" '$(LibZipSharpSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\LibZipSharp</LibZipSharpSourceDirectory>


### PR DESCRIPTION
Instead of having own submodule. This way we unify with xamarin-macios
as it also uses mono's linker submodule.