### PR TITLE
[build] setup a Prepare target for Xamarin.Android.sln

### DIFF
--- a/Before.Xamarin.Android.sln.targets
+++ b/Before.Xamarin.Android.sln.targets
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)build-tools\scripts\PrepareWindows.targets" Condition=" '$(OS)' == 'Windows_NT' " />
+</Project>

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Building Xamarin.Android requires:
 * [Autotools (`autoconf`, `automake`, etc.)](#autotools)
 * [The Android SDK and NDK](#ndk)
 
-The `make prepare` build step (or `PrepareWindows.targets` on Windows) will
+The `make prepare` build step (or `/t:Prepare` on Windows) will
 check that all required dependencies are present.
 If you would like `make prepare` to automatically install
 required dependencies, set the `$(AutoProvision)` MSBuild property to True
@@ -246,7 +246,7 @@ Unit tests are built in a separate target:
 
 To build Xamarin.Android, ensure you are using MSBuild version 15+ and run:
 
-    msbuild build-tools\scripts\PrepareWindows.targets
+    msbuild Xamarin.Android.sln /t:Prepare
     msbuild Xamarin.Android.sln
 
 These are roughly the same as how `make prepare` and `make` are used on other platforms.

--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -18,12 +18,12 @@
       <Output TaskParameter="JavaSdkDirectory" PropertyName="_JavaSdkDirectory" />
     </JdkInfo>
     <Copy
-        SourceFiles="Configuration.Java.Interop.Override.props"
+        SourceFiles="$(MSBuildThisFileDirectory)Configuration.Java.Interop.Override.props"
         DestinationFiles="$(_TopDir)\external\Java.Interop\Configuration.Override.props"
         SkipUnchangedFiles="True"
     />
     <ReplaceFileContents
-        SourceFile="Windows-Configuration.OperatingSystem.props.in"
+        SourceFile="$(MSBuildThisFileDirectory)Windows-Configuration.OperatingSystem.props.in"
         DestinationFile="$(_TopDir)\Configuration.OperatingSystem.props"
         Replacements="@JAVA_HOME@=$(_JavaSdkDirectory)"
     />


### PR DESCRIPTION
Context:
https://stackoverflow.com/questions/17709873/how-can-i-invoke-my-msbuild-target-when-msbuild-exe-starts-and-when-it-ends

There is a convention where an MSBuild file named
`Before.<SolutionName>.sln.targets` will get imported prior to a SLN
file getting built. This enables us to import `PrepareWindows.targets`
and enable `msbuild Xamarin.Android.sln /t:Prepare` to work
appropriately.

macOS/linux have remained unchanged, since `PrepareWindows.targets`
currently only works for Windows. `make prepare` could be ported to
MSBuild in the future.

## Question

Do we need to look into `make prepare` for the other platforms yet?

If `make prepare` was fully ported to MSBuild, you could run the same
command to build on any platform:
```
msbuild Xamarin.Android.sln /t:Prepare /t:Build
```
I tested, and `xbuild` looks like it supports the `Before.<SolutionName>.sln.targets`
convention.