### PR TITLE
[Xamarin.Android.Build.Tasks] Add Debug info for Lint Task

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
@@ -186,6 +186,7 @@ namespace Xamarin.Android.Tasks
 			}
 
 			Version lintToolVersion = GetLintVersion (GenerateFullPathToTool ());
+			Log.LogDebugMessage ("  LintVersion: {0}", lintToolVersion);
 			foreach (var issue in DisabledIssuesByVersion) {
 				if (lintToolVersion >= issue.Value) {
 					if (string.IsNullOrEmpty (DisabledIssues) || !DisabledIssues.Contains (issue.Key))


### PR DESCRIPTION
We need to output the Lint tool Path we use and the Lint Tool
version for diagnostic purposes. So if it does fail we have
the information we need to correct the issue.