### PR TITLE
[Xamarin.ProjectTools] Fix path to xabuild for monodroid.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -52,6 +52,9 @@ namespace Xamarin.ProjectTools
 					#endif
 					if (File.Exists (xabuild))
 						return xabuild;
+					xabuild = Path.GetFullPath (Path.Combine (Root, "..", "..", "..", "..", "..", "..", "..", "out", "bin", "xabuild"));
+					if (File.Exists (xabuild))
+						return xabuild;
 					return Path.GetFullPath (Path.Combine (Root, "..", "..", "tools", "scripts", "xabuild"));
 				}
 


### PR DESCRIPTION
The Builder was not checking for the xabuild script in the
`out` directory for the monodroid tree.