### PR TITLE
[tests] migrate test targets to MSBuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ TestResult-*.csv
 Resource.designer.cs
 logcat-*.txt
 apk-sizes-*.txt
+*.rawproto
+src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props

--- a/Before.Xamarin.Android.sln.targets
+++ b/Before.Xamarin.Android.sln.targets
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)build-tools\scripts\PrepareWindows.targets" Condition=" '$(OS)' == 'Windows_NT' " />
+  <Import Project="$(MSBuildThisFileDirectory)build-tools\scripts\RunTests.targets" />
 </Project>

--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -15,7 +15,7 @@
         AndroidSdkPath="$(AndroidSdkDirectory)"
         AndroidNdkPath="$(AndroidNdkDirectory)"
         JavaSdkPath="$(JavaSdkDirectory)"
-        Output="$(_TopDir)\external\Java.Interop\bin\BuildDebug\JdkInfo.props">
+        Output="$(_TopDir)\external\Java.Interop\bin\Build$(Configuration)\JdkInfo.props">
       <Output TaskParameter="JavaSdkDirectory" PropertyName="_JavaSdkDirectory" />
     </JdkInfo>
     <Copy

--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="RunAllTests" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <_TopDir>$(MSBuildThisFileDirectory)..\..</_TopDir>
+  </PropertyGroup>
+  <Import Project="$(_TopDir)\Configuration.props" />
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.SetEnvironmentVariable" />
+  <PropertyGroup>
+    <XAIntegratedTests Condition=" '$(HostOS)' == 'Windows' ">False</XAIntegratedTests>
+    <_Runtime Condition=" '$(HostOS)' != 'Windows' ">$(ManagedRuntime)</_Runtime>
+    <_NUnit>$(_Runtime) packages\NUnit.ConsoleRunner.3.7.0\tools\nunit3-console.exe</_NUnit>
+    <_Test Condition=" '$(TEST)' != '' ">--test=&quot;$(TEST)&quot;</_Test>
+    <_XABuild>$(_TopDir)\bin\$(Configuration)\bin\xabuild</_XABuild>
+    <_XABuildProperties>/p:Configuration=$(Configuration) /p:XAIntegratedTests=$(XAIntegratedTests)</_XABuildProperties>
+  </PropertyGroup>
+  <ItemGroup>
+    <_TestAssembly Include="$(_TopDir)\bin\Test$(Configuration)\Xamarin.Android.Build.Tests.dll" />
+    <_JavaInteropTestResults Include="$(JavaInteropSourceDirectory)\TestResult-*.xml" />
+    <_ApkTestProject Include="$(_TopDir)\src\Mono.Android\Test\Mono.Android-Tests.csproj" />
+    <_ApkTestProject Include="$(_TopDir)\tests\CodeGen-Binding\Xamarin.Android.JcwGen-Tests\Xamarin.Android.JcwGen-Tests.csproj" />
+    <_ApkTestProject Include="$(_TopDir)\tests\locales\Xamarin.Android.Locale-Tests\Xamarin.Android.Locale-Tests.csproj" />
+    <_ApkTestProject Include="$(_TopDir)\tests\Xamarin.Android.Bcl-Tests\Xamarin.Android.Bcl-Tests.csproj" />
+    <_ApkTestProject Include="$(_TopDir)\tests\Xamarin.Forms-Performance-Integration\Droid\Xamarin.Forms.Performance.Integration.Droid.csproj" />
+    <_ApkTestProjectAot Include="$(_TopDir)\src\Mono.Android\Test\Mono.Android-Tests.csproj" />
+  </ItemGroup>
+  <Target Name="RunNUnitTests">
+    <SetEnvironmentVariable Name="USE_MSBUILD" Value="0" Condition=" '$(USE_MSBUILD)' == '' " />
+    <Exec
+        Command="$(_NUnit) $(NUNIT_EXTRA) %(_TestAssembly.Identity) $(_Test) --result=&quot;TestResult-%(Filename).xml;format=nunit2&quot; --output=&quot;bin\Test$(Configuration)\TestOutput-%(Filename).txt&quot;"
+        WorkingDirectory="$(_TopDir)"
+        ContinueOnError="True"
+    />
+    <ItemGroup>
+      <_RenameTestCasesGlob Include="$(_TopDir)\TestResult-*Tests.xml" />
+    </ItemGroup>
+    <PropertyGroup>
+      <_RenamedTestCases>@(_RenameTestCasesGlob)</_RenamedTestCases>
+    </PropertyGroup>
+    <MSBuild
+        Projects="$(MSBuildThisFileDirectory)TestApks.targets"
+        Targets="RenameTestCases"
+        Properties="Configuration=$(Configuration);RenameTestCasesGlob=$(_RenamedTestCases)"
+    />
+  </Target>
+  <Target Name="RunJavaInteropTests">
+    <MSBuild Projects="$(JavaInteropSourceDirectory)\Java.Interop.sln" Condition=" '$(HostOS)' == 'Windows' " />
+    <Exec
+        Command ="make -C &quot;$(JavaInteropSourceDirectory)&quot; CONFIGURATION=$(Configuration) all"
+        Condition=" '$(HostOS)' != 'Windows' "
+    />
+    <SetEnvironmentVariable Name="ANDROID_SDK_PATH" Value="$(AndroidSdkFullPath)" />
+    <MSBuild Projects="$(JavaInteropSourceDirectory)\build-tools\scripts\RunNUnitTests.targets" />
+    <ItemGroup>
+      <_RenameTestCasesGlob Include="$(JavaInteropSourceDirectory)\TestResult-*Tests.xml" />
+    </ItemGroup>
+    <PropertyGroup>
+      <_RenamedTestCases>@(_RenameTestCasesGlob)</_RenamedTestCases>
+    </PropertyGroup>
+    <MSBuild
+        Projects="$(MSBuildThisFileDirectory)TestApks.targets"
+        Targets="RenameTestCases"
+        Properties="Configuration=$(Configuration);RenameTestCasesGlob=$(_RenamedTestCases)"
+    />
+    <Copy SourceFiles="@(_JavaInteropTestResults)" DestinationFolder="$(_TopDir)" />
+  </Target>
+  <Target Name="RunApkTests">
+    <Exec Command="$(_XABuild) %(_ApkTestProject.Identity) /t:SignAndroidPackage $(_XABuildProperties)" />
+    <MSBuild Projects="$(_TopDir)\tests\RunApkTests.targets" />
+    <Exec 
+        Command="$(_XABuild) %(_ApkTestProjectAot.Identity) /t:SignAndroidPackage $(_XABuildProperties) /p:AotAssemblies=True"
+        Condition=" '$(Configuration)' == 'Release' "
+    />
+    <MSBuild 
+        Projects="$(_TopDir)\tests\RunApkTests.targets"
+        Condition=" '$(Configuration)' == 'Release' "
+    />
+  </Target>
+  <Target Name="RunAllTests" DependsOnTargets="RunNUnitTests;RunJavaInteropTests;RunApkTests" />
+</Project>

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -195,6 +195,7 @@
         Text="Please set `%24(Configuration)`."
     />
     <PropertyGroup>
+      <_DeleteSource Condition=" '$(KEEP_TEST_SOURCES)' != '' ">False</_DeleteSource>
       <_DeleteSource Condition=" '$(DeleteTestCaseSourceFiles)' != '' ">$(DeleteTestCaseSourceFiles)</_DeleteSource>
       <_DeleteSource Condition=" '$(_DeleteSource)' == '' ">True</_DeleteSource>
     </PropertyGroup>

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/SetEnvironmentVariable.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/SetEnvironmentVariable.cs
@@ -1,0 +1,27 @@
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using System;
+
+namespace Xamarin.Android.BuildTools.PrepTasks
+{
+	public class SetEnvironmentVariable : Task
+	{
+		[Required]
+		public string Name { get; set; }
+
+		[Required]
+		public string Value { get; set; }
+
+		public override bool Execute ()
+		{
+			Log.LogMessage (MessageImportance.Low, $"Task {nameof (SetEnvironmentVariable)}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (Name)}: {Name}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (Value)}: {Value}");
+
+			Environment.SetEnvironmentVariable(Name, Value);
+
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
@@ -45,6 +45,7 @@
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\HashFileContents.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\JdkInfo.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\PathToolTask.cs" />
+    <Compile Include="Xamarin.Android.BuildTools.PrepTasks\SetEnvironmentVariable.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\SystemUnzip.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\Which.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\GitBlame.cs" />

--- a/src/Mono.Android/Test/Mono.Android-Tests.csproj
+++ b/src/Mono.Android/Test/Mono.Android-Tests.csproj
@@ -102,12 +102,6 @@
   <Import Project="..\..\..\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Import Project="Mono.Android-Tests.targets" />
   <ItemGroup>
-    <ProjectReference Include="..\..\..\build-tools\android-toolchain\android-toolchain.mdproj">
-      <Name>android-toolchain</Name>
-      <Project>{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA}</Project>
-      <Private>False</Private>
-      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-    </ProjectReference>
     <ProjectReference Include="..\..\Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj" Condition=" '$(XAIntegratedTests)' == 'True' ">
       <Name>Xamarin.Android.Build.Tasks</Name>
       <Project>{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}</Project>


### PR DESCRIPTION
The end goal here is to enable Windows users to easily run the various
types of tests. Commands have been migrated to MSBuild, keeping `make`
commands the same for macOS and linux.

## Usage

Windows:
```
msbuild Xamarin.Android.sln /t:RunAllTests
msbuild Xamarin.Android.sln /t:RunNUnitTests
msbuild Xamarin.Android.sln /t:RunJavaInteropTests
msbuild Xamarin.Android.sln /t:RunApkTests
```

macOS/linux should remain unchanged:
```
make run-all-tests
make run-nunit-tests
make run-ji-tests
make run-apk-tests
```

## Changes

- Added a new build-tools/scripts/RunTests.targets
- Before.Xamarin.Android.sln.targets includes these test targets
- A new `SetEnvironmentVariable` task is needed, added to xa-prep-tasks
- Mono.Android-Tests.csproj needs to remove the `<ProjectReference />` android-toolchain
  - Otherwise xa-prep-tasks.dll can become locked on Windows
  - A nested xabuild.exe call will attempt to ovewrite it
- Update .gitignore for *.rawproto and the generated Xamarin.Android.Common.props

## NOTE

Don't merge quite yet, still working on this (hope the build passes). It might be possible to cleanup further with another PR to Java.Interop.