### PR TITLE
[build] SKIP_NUNIT_TESTS check is reversed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ define RUN_NUNIT_TEST
 endef
 
 run-nunit-tests: $(NUNIT_TESTS)
-ifneq ($(SKIP_NUNIT_TESTS),)
+ifeq ($(SKIP_NUNIT_TESTS),)
 	$(foreach t,$(NUNIT_TESTS), $(call RUN_NUNIT_TEST,$(t),1))
 endif # $(SKIP_NUNIT_TESTS) == ''
 


### PR DESCRIPTION
When working with the `Makefile` I noticed this command doesn’t run the
tests:
```
$ make run-nunit-tests
make: Nothing to be done for `run-nunit-tests’.
```
And this command runs the tests:
```
$ make run-nunit-tests SKIP_NUNIT_TESTS=1
```

I suspect the intention is that `ifneq` needs to be `ifeq`.

I believe this was introduced in https://github.com/xamarin/xamarin-android/commit/385699a58635d87a1cc65b60995d3420995f21d7.