### PR TITLE
xabuild: exit if TARGETS_DIR can't be found

### DIFF
--- a/tools/scripts/xabuild
+++ b/tools/scripts/xabuild
@@ -97,6 +97,7 @@ done
 
 if [ ! -d "$TARGETS_DIR" ]; then
 	(>&2 echo "$name: Could not determine Xamarin.Android targets path.")
+	exit 1
 fi
 export TARGETS_DIR
 export MONO_ANDROID_PATH="$prefix"


### PR DESCRIPTION
Otherwise we'd continue in the script and all sorts of weirdness would occur since TARGETS_DIR is empty.