### PR TITLE
[Xamarin.Android.Build.Tasks] Don't get resources in DTB

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -300,6 +300,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
       CacheFile="$(IntermediateOutputPath)resourcepaths.cache"
       YieldDuringToolExecution="$(YieldDuringToolExecution)"
       DesignTimeBuild="$(DesignTimeBuild)"
+      Condition=" '$(DesignTimeBuild)' == 'false' Or '$(DesignTimeBuild)' == '' "
     />
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -400,6 +400,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
    CacheFile="$(_AndroidResourcePathsCache)"
    YieldDuringToolExecution="$(YieldDuringToolExecution)"
    DesignTimeBuild="$(DesignTimeBuild)"
+   Condition=" '$(DesignTimeBuild)' == 'false' Or '$(DesignTimeBuild)' == '' "
   />
 </Target>
 


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=60080
Context: 1cd582ec

It appears that the `<GetAdditionalResourcesFromAssemblies/>` task is
causing Visual Studio 2015 to hang when loading projects.

In the interests of expediency, "revert" to d15-3 behavior and make
the `<GetAdditionalResourcesFromAssemblies/>` task invocation
conditional on `$(DesignTimeBuild)` being False, i.e. only execute
`<GetAdditionalResourcesFromAssemblies/>` when performing *normal*
builds, *not* Design-Time builds.