### PR TITLE
[xabuild] Only create the xabuild.exe.config if it does not exist.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -7,6 +7,8 @@ using System.Xml.Linq;
 using Microsoft.Build.Framework;
 using NUnit.Framework;
 using Xamarin.ProjectTools;
+using System.Threading.Tasks;
+using System.Diagnostics;
 
 namespace Xamarin.Android.Build.Tests
 {
@@ -2077,6 +2079,23 @@ namespace UnnamedProject {
 				Assert.IsTrue (builder.Build (proj, parameters: new [] { "AndroidErrorOnCustomJavaObject=False" }), "Build should have succeeded.");
 				StringAssert.Contains ($"warning XA4", builder.LastBuildOutput, "warning XA4212");
 			}
+		}
+
+		[Test]
+		public void RunXABuildInParallel ()
+		{
+			var xabuild = new ProjectBuilder ("temp/RunXABuildInParallel").XABuildExe;
+
+			Parallel.For (0, 10, i => {
+				using (var p = Process.Start (new ProcessStartInfo (xabuild, "/version") {
+					CreateNoWindow = true,
+					WindowStyle = ProcessWindowStyle.Hidden,
+					UseShellExecute = false,
+				})) {
+					p.WaitForExit ();
+					Assert.AreEqual (0, p.ExitCode);
+				}
+			});
 		}
 	}
 }

--- a/tools/xabuild/XABuild.cs
+++ b/tools/xabuild/XABuild.cs
@@ -35,11 +35,11 @@ namespace Xamarin.Android.Build
 
 		static void CreateConfig (XABuildPaths paths)
 		{
-			if (File.Exists (paths.XABuildConfig))
-				return;
-			
 			waitHandle.WaitOne ();
 			try {
+				if (File.Exists (paths.XABuildConfig))
+					return;
+
 				var xml = new XmlDocument ();
 				xml.Load (paths.MSBuildConfig);
 

--- a/tools/xabuild/XABuild.cs
+++ b/tools/xabuild/XABuild.cs
@@ -32,6 +32,8 @@ namespace Xamarin.Android.Build
 
 		static void CreateConfig (XABuildPaths paths)
 		{
+			if (File.Exists (paths.XABuildConfig))
+				return;
 			var xml = new XmlDocument ();
 			xml.Load (paths.MSBuildConfig);
 

--- a/tools/xabuild/XABuild.cs
+++ b/tools/xabuild/XABuild.cs
@@ -2,6 +2,7 @@
 using System;
 using System.IO;
 using System.Xml;
+using System.Threading;
 
 namespace Xamarin.Android.Build
 {
@@ -30,57 +31,65 @@ namespace Xamarin.Android.Build
 			return MSBuildApp.Main ();
 		}
 
+		static EventWaitHandle waitHandle = new EventWaitHandle (true, EventResetMode.AutoReset, "XABUILD_SHARED_BY_ALL_PROCESSES");
+
 		static void CreateConfig (XABuildPaths paths)
 		{
 			if (File.Exists (paths.XABuildConfig))
 				return;
-			var xml = new XmlDocument ();
-			xml.Load (paths.MSBuildConfig);
+			
+			waitHandle.WaitOne ();
+			try {
+				var xml = new XmlDocument ();
+				xml.Load (paths.MSBuildConfig);
 
-			var toolsets = xml.SelectSingleNode ("configuration/msbuildToolsets/toolset");
-			SetProperty (toolsets, "VsInstallRoot", paths.VsInstallRoot);
-			SetProperty (toolsets, "MSBuildToolsPath", paths.MSBuildBin);
-			SetProperty (toolsets, "MSBuildToolsPath32", paths.MSBuildBin);
-			SetProperty (toolsets, "MSBuildToolsPath64", paths.MSBuildBin);
-			SetProperty (toolsets, "MSBuildExtensionsPath", paths.MSBuildExtensionsPath);
-			SetProperty (toolsets, "MSBuildExtensionsPath32", paths.MSBuildExtensionsPath);
-			SetProperty (toolsets, "RoslynTargetsPath", Path.Combine (paths.MSBuildBin, "Roslyn"));
-			SetProperty (toolsets, "AndroidSdkDirectory", paths.AndroidSdkDirectory);
-			SetProperty (toolsets, "AndroidNdkDirectory", paths.AndroidNdkDirectory);
-			SetProperty (toolsets, "MonoAndroidToolsDirectory", paths.MonoAndroidToolsDirectory);
-			SetProperty (toolsets, "TargetFrameworkRootPath", paths.FrameworksDirectory + Path.DirectorySeparatorChar); //NOTE: Must include trailing \
+				var toolsets = xml.SelectSingleNode ("configuration/msbuildToolsets/toolset");
+				SetProperty (toolsets, "VsInstallRoot", paths.VsInstallRoot);
+				SetProperty (toolsets, "MSBuildToolsPath", paths.MSBuildBin);
+				SetProperty (toolsets, "MSBuildToolsPath32", paths.MSBuildBin);
+				SetProperty (toolsets, "MSBuildToolsPath64", paths.MSBuildBin);
+				SetProperty (toolsets, "MSBuildExtensionsPath", paths.MSBuildExtensionsPath);
+				SetProperty (toolsets, "MSBuildExtensionsPath32", paths.MSBuildExtensionsPath);
+				SetProperty (toolsets, "RoslynTargetsPath", Path.Combine (paths.MSBuildBin, "Roslyn"));
+				SetProperty (toolsets, "AndroidSdkDirectory", paths.AndroidSdkDirectory);
+				SetProperty (toolsets, "AndroidNdkDirectory", paths.AndroidNdkDirectory);
+				SetProperty (toolsets, "MonoAndroidToolsDirectory", paths.MonoAndroidToolsDirectory);
+				SetProperty (toolsets, "TargetFrameworkRootPath", paths.FrameworksDirectory + Path.DirectorySeparatorChar); //NOTE: Must include trailing \
 
-			var projectImportSearchPaths = toolsets.SelectSingleNode ("projectImportSearchPaths");
-			var searchPaths = projectImportSearchPaths.SelectSingleNode ($"searchPaths[@os='{paths.SearchPathsOS}']") as XmlElement;
+				var projectImportSearchPaths = toolsets.SelectSingleNode ("projectImportSearchPaths");
+				var searchPaths = projectImportSearchPaths.SelectSingleNode ($"searchPaths[@os='{paths.SearchPathsOS}']") as XmlElement;
 
-			//NOTE: on Linux, the searchPaths XML element does not exist, so we have to create it
-			if (searchPaths == null) {
-				searchPaths = xml.CreateElement ("searchPaths");
-				searchPaths.SetAttribute ("os", paths.SearchPathsOS);
+				//NOTE: on Linux, the searchPaths XML element does not exist, so we have to create it
+				if (searchPaths == null) {
+					searchPaths = xml.CreateElement ("searchPaths");
+					searchPaths.SetAttribute ("os", paths.SearchPathsOS);
 
-				var property = xml.CreateElement ("property");
-				property.SetAttribute ("name", "MSBuildExtensionsPath");
-				property.SetAttribute ("value", "");
-				searchPaths.AppendChild (property);
+					var property = xml.CreateElement ("property");
+					property.SetAttribute ("name", "MSBuildExtensionsPath");
+					property.SetAttribute ("value", "");
+					searchPaths.AppendChild (property);
 
-				property = xml.CreateElement ("property");
-				property.SetAttribute ("name", "MSBuildExtensionsPath32");
-				property.SetAttribute ("value", "");
-				searchPaths.AppendChild (property);
+					property = xml.CreateElement ("property");
+					property.SetAttribute ("name", "MSBuildExtensionsPath32");
+					property.SetAttribute ("value", "");
+					searchPaths.AppendChild (property);
 
-				property = xml.CreateElement ("property");
-				property.SetAttribute ("name", "MSBuildExtensionsPath64");
-				property.SetAttribute ("value", "");
-				searchPaths.AppendChild (property);
+					property = xml.CreateElement ("property");
+					property.SetAttribute ("name", "MSBuildExtensionsPath64");
+					property.SetAttribute ("value", "");
+					searchPaths.AppendChild (property);
 
-				projectImportSearchPaths.AppendChild (searchPaths);
+					projectImportSearchPaths.AppendChild (searchPaths);
+				}
+
+				foreach (XmlNode property in searchPaths.SelectNodes ("property[starts-with(@name, 'MSBuildExtensionsPath')]/@value")) {
+					property.Value = string.Join (";", paths.ProjectImportSearchPaths);
+				}
+
+				xml.Save (paths.XABuildConfig);
+			} finally {
+				waitHandle.Set ();
 			}
-
-			foreach (XmlNode property in searchPaths.SelectNodes ("property[starts-with(@name, 'MSBuildExtensionsPath')]/@value")) {
-				property.Value = string.Join (";", paths.ProjectImportSearchPaths);
-			}
-
-			xml.Save (paths.XABuildConfig);
 		}
 
 		/// <summary>


### PR DESCRIPTION
When running the tests in parallel we end up trying to create the
config file all the time. This sometimes causes failures becuase
the file is removed or incomplete when a test runs.

So we should only write the config file once.