### PR TITLE
[Xamarin.Android.Build.Tasks] Speed up ResolveLibraryProjectImports

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -310,7 +310,7 @@ namespace Xamarin.Android.Tasks
 						stamp.Create ().Close ();
 				}
 			}
-			foreach (var f in outdir.GetFiles ("*.jar", SearchOption.AllDirectories)
+			foreach (var f in outdir.EnumerateFiles ("*.jar", SearchOption.AllDirectories)
 					.Select (fi => fi.FullName)) {
 				if (jars.Contains (f))
 					continue;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -362,11 +362,13 @@ namespace Xamarin.Android.Tasks
 				return;
 
 			var dirInfo = new DirectoryInfo (directory);
-			dirInfo.Attributes &= ~FileAttributes.ReadOnly;
+			if ((dirInfo.Attributes | FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+				dirInfo.Attributes &= ~FileAttributes.ReadOnly;
 
 			foreach (var dir in Directory.EnumerateDirectories (directory, "*", SearchOption.AllDirectories)) {
 				dirInfo = new DirectoryInfo (dir);
-				dirInfo.Attributes &= ~FileAttributes.ReadOnly;
+				if ((dirInfo.Attributes | FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+					dirInfo.Attributes &= ~FileAttributes.ReadOnly;
 			}
 
 			foreach (var file in Directory.EnumerateFiles (directory, "*", SearchOption.AllDirectories)) {


### PR DESCRIPTION
Rather than trying to ALWAYS unset the ReadOnly flag, lets only
do it if the directory is read only. Also use EnumerateFiles
rather than GetFiles to get the .jar files. EnumerateFiles is
more efficient.