### PR TITLE
[performance measurements] Added AOT'ed assemblies sizes again

### DIFF
--- a/src/Mono.Android/Test/apk-sizes-definitions.txt
+++ b/src/Mono.Android/Test/apk-sizes-definitions.txt
@@ -1,4 +1,6 @@
 apk=^stat: (?<value>\d+)\s+(?<message>.*)$
 Mono.Android.dll=^\s*(?<value>\d+)\s+.*(?<message>Mono.Android.dll)$
+Mono.Android.dll.so=^\s*(?<value>\d+)\s+.*(?<message>Mono.Android.dll.so)$
 mscorlib.dll=^\s*(?<value>\d+)\s+.*(?<message>mscorlib.dll)$
+mscorlib.dll.so=^\s*(?<value>\d+)\s+.*(?<message>mscorlib.dll.so)$
 monosgen-armeabi-v7a=^\s*(?<value>\d+)\s+.*(?<message>armeabi-v7a/libmonosgen-2.0.so)$


### PR DESCRIPTION
The https://github.com/xamarin/xamarin-android/commit/2dc5689a5d823fc91b04791d5354254e5ed2d31d fixed the files location, but new size measurements definition
didn't include the AOT'ed assemblies sizes.