### PR TITLE
[Makefile] Add support for a Max Mono Version.

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -55,6 +55,8 @@
     <LlvmSourceDirectory Condition=" '$(LlvmSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\llvm</LlvmSourceDirectory>
     <MonoSourceDirectory>$(MSBuildThisFileDirectory)external\mono</MonoSourceDirectory>
     <MonoRequiredMinimumVersion Condition=" '$(MonoRequiredMinimumVersion)' == '' ">5.4.0</MonoRequiredMinimumVersion>
+    <MonoRequiredMaximumVersion Condition=" '$(MonoRequiredMaximumVersion)' == '' ">5.6.0</MonoRequiredMaximumVersion>
+    <IgnoreMaxMonoVersion Condition=" '$(IgnoreMaxMonoVersion)' == '' ">True</IgnoreMaxMonoVersion>
     <MonoRequiredDarwinMinimumVersion>$(MonoRequiredMinimumVersion).147</MonoRequiredDarwinMinimumVersion>
     <LinkerSourceDirectory>$(MSBuildThisFileDirectory)external\linker</LinkerSourceDirectory>
     <OpenTKSourceDirectory>$(MSBuildThisFileDirectory)external\opentk</OpenTKSourceDirectory>

--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ Overridable MSBuild properties include:
     `$(HOME)\android-toolchain`.
 * `$(HostCc)`, `$(HostCxx)`: The C and C++ compilers to use to generate
     host-native binaries.
+* `$(IgnoreMaxMonoVersion)`: Skip the enforcement of the `$(MonoRequiredMaximumVersion)`
+    property. This is so that developers can run against the latest
+    and greatest. But the build system can enforce the min and max 
+    versions. The default is `true` however on jenkins we pass 
+         /p:IgnoreMaxMonoVersion=False
+    by default.
 * `$(JavaInteropSourceDirectory)`: The Java.Interop source directory to
     build and reference projects from. By default, this is
     `external/Java.Interop` directory, maintained by `git submodule update`.
@@ -205,7 +211,10 @@ Overridable MSBuild properties include:
     system mono which corresponds vaguely to the [`external/mono`](external)
     version. This is not strictly required; older mono versions *may* work, they
     just are not tested, and thus not guaranteed or supported.  
-    By default this is `4.9.3`.
+    By default this is `5.4.0`.
+* `$(MonoRequiredMaximumVersion)`: The max *system* mono version that is
+    required. This is so that we can ensure a stable build environment by
+    making sure we dont install unstable versions.
 * `$(MonoSgenBridgeVersion)`: The Mono SGEN Bridge version to support.
     Valid values include:
 

--- a/build-tools/dependencies/dependencies.projitems
+++ b/build-tools/dependencies/dependencies.projitems
@@ -56,6 +56,7 @@
     </RequiredProgram>
     <RequiredProgram Include="$(ManagedRuntime)"    Condition=" '$(ManagedRuntime)' != '' ">
       <MinimumVersion>$(MonoRequiredMinimumVersion)</MinimumVersion>
+      <MaximumVersion Condition=" '$(IgnoreMaxMonoVersion)' == '' Or '$(IgnoreMaxMonoVersion)' == 'False' " >$(MonoRequiredMaximumVersion)</MaximumVersion>
       <DarwinMinimumVersion>$(MonoRequiredDarwinMinimumVersion)</DarwinMinimumVersion>
       <CurrentVersionCommand>$(MSBuildThisFileDirectory)..\scripts\mono-version</CurrentVersionCommand>
       <DarwinMinimumUrl>https://bosstoragemirror.blob.core.windows.net/wrench/mono-2017-06/28/28a417c2c0d1a2d1231d8b0a5beea3201208b57d/$(_DarwinMonoFramework)</DarwinMinimumUrl>


### PR DESCRIPTION
There are circumstances when we don't want to use the latest
and greatest version of mono. On the CI servers we will want
to keep to certain versions so that we have a stable build.
But on developer machines we will want to allow the developer
to ignore such checks.

This commit adds support for a Max mono version. By default
this proeprty is ignored. But on build systems we should pass

	/p:IgnoreMaxMonoVersion=False

to ensure that the max version is applied and we run against
a stable version of mono.