### PR TITLE
[Xamarin.Android.Build.Tests] Add Build Log to the Exception data.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/FailedBuildException.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/FailedBuildException.cs
@@ -30,6 +30,12 @@ namespace Xamarin.ProjectTools
 		{
 			return string.Format ("[FailedBuildException: BuildLog={0}]", BuildLog);
 		}
+
+		public override string StackTrace {
+			get {
+				return $"{base.StackTrace}\nBuildLog: {BuildLog}";
+			}
+		}
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/FailedBuildException.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/FailedBuildException.cs
@@ -26,11 +26,6 @@ namespace Xamarin.ProjectTools
 
 		public string BuildLog { get; set; }
 
-		public override string ToString ()
-		{
-			return string.Format ("[FailedBuildException: BuildLog={0}]", BuildLog);
-		}
-
 		public override string StackTrace {
 			get {
 				return $"{base.StackTrace}\nBuildLog: {BuildLog}";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/FailedBuildException.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/FailedBuildException.cs
@@ -25,6 +25,11 @@ namespace Xamarin.ProjectTools
 		}
 
 		public string BuildLog { get; set; }
+
+		public override string ToString ()
+		{
+			return string.Format ("[FailedBuildException: BuildLog={0}]", BuildLog);
+		}
 	}
 }
 


### PR DESCRIPTION
If the build fails we get a generic message to look at the build.log.
This is a pain because the build log is HUGE! and takes ages to find the
problem.

It seems NUnit does not include the BuildLog property from the
`FailedBuildException`. So lets override the ToString method to
include the data.