### PR TITLE
[tests] Don't use obsolete NDK API levels

### DIFF
--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Properties/AndroidManifest.xml
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Xamarin.Android.JcwGen_Tests">
-	<uses-sdk android:minSdkVersion="4" />
+	<uses-sdk android:minSdkVersion="9" />
 	<application android:label="Xamarin.Android.JcwGen-Tests">
 	</application>
 </manifest>

--- a/tests/locales/Xamarin.Android.Locale-Tests/Properties/AndroidManifest.xml
+++ b/tests/locales/Xamarin.Android.Locale-Tests/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Xamarin.Android.Locale_Tests">
-	<uses-sdk android:minSdkVersion="4" />
+	<uses-sdk android:minSdkVersion="9" />
 	<application android:label="Xamarin.Android.Locale-Tests">
 	</application>
 </manifest>


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=60185

Newer versions of NDK don't include API 4 anymore but two of our tests specified
that they required that particular version to build. This caused the tests to
fail because the android-4 platform path was nowhere to be found.

Bump the minimum SDK version to 9 (which is the lowest platform included in the NDK
as of now)