### PR TITLE
Made _ResolveLibraryProjectImports not work on design time

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1149,7 +1149,7 @@ because xbuild doesn't support framework reference assemblies.
 	/>
 </Target>
 
-<Target Name="_ResolveLibraryProjectImports"
+<Target Name="_ResolveLibraryProjectImports" Condition="'$(DesignTimeBuild)' != 'true'"
 		Inputs="$(MSBuildProjectFullPath);@(ReferencePath);@(ReferenceDependencyPaths);$(_AndroidBuildPropertiesCache)"
 		Outputs="$(_AndroidLibraryProjectImportsCache)">
 	<ResolveLibraryProjectImports


### PR DESCRIPTION
Having _ResolveLibraryProjectImports work on design time results in a
cache file that doesn't include nuget packages (when using
PackageReferences). Design time is most of the times too early (it
happens first immediately after unfold). Without this fix, the first
build fails on the APT task because resources are not found. They are
not found because a cache already exists, so library imports are not
processed again. And that cache is missing anything coming from nuget.
An alternative option is to remove that file on nuget restore. If that's
better please close this non-merged and go for that :)