### PR TITLE
[xabuild] interprocess locking via FileStream

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1,8 +1,10 @@
 ﻿﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Build.Framework;
 using NUnit.Framework;
@@ -2077,6 +2079,25 @@ namespace UnnamedProject {
 				Assert.IsTrue (builder.Build (proj, parameters: new [] { "AndroidErrorOnCustomJavaObject=False" }), "Build should have succeeded.");
 				StringAssert.Contains ($"warning XA4", builder.LastBuildOutput, "warning XA4212");
 			}
+		}
+
+		[Test]
+		public void RunXABuildInParallel ()
+		{
+			var xabuild = new ProjectBuilder ("temp/RunXABuildInParallel").XABuildExe;
+
+			Parallel.For (0, 10, i => {
+				using (var p = Process.Start(new ProcessStartInfo (xabuild, "/version") {
+					CreateNoWindow         = true,
+					RedirectStandardOutput = true,
+					RedirectStandardError  = true,
+					WindowStyle            = ProcessWindowStyle.Hidden,
+					UseShellExecute        = false,
+				})) {
+					p.WaitForExit ();
+					Assert.AreEqual (0, p.ExitCode);
+				}
+			});
 		}
 	}
 }


### PR DESCRIPTION
Context in #954
Context: http://aakinshin.net/blog/post/namedmutex-on-mono/

The Xamarin.Android.Build.Tests run xabuild.exe in parallel, which
brings up some interesting issues. xabuild.exe needs to overwrite a
config file that is used by the `MSBuildApp` class. We cannot do a
`File.Exists` check, because A) the file exists on Windows due to some
assembly binding redirects, and B) we still need an interprocess lock.

So my solution after some trial and error:
- Open a `FileStream` on the config file, retrying on `IOException`
- Force `MSBuildApp`’s static constructor to run deterministically,
while the `FileStream` is still open

Hopefully this hack isn’t _too_ terrible.