### PR TITLE
[tests] Export `$USE_MSBUILD=$(USE_MSBUILD)`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ distclean:
 # $(call RUN_NUNIT_TEST,filename,log-lref?)
 define RUN_NUNIT_TEST
 	MONO_TRACE_LISTENER=Console.Out \
+	USE_MSBUILD=$(if $(USE_MSBUILD),$(USE_MSBUILD),0) \
 	$(RUNTIME) --runtime=v4.0.0 \
 		$(NUNIT_CONSOLE) $(NUNIT_EXTRA) $(1) \
 		$(if $(TEST),--test=$(TEST)) \


### PR DESCRIPTION
Context: 286b9c28
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/700/testReport/

`Xamarin.ProjectTools` was updated in commit 286b9c28 to use `msbuild`
(via `xabuild`) when `$USE_MSBUILD` is *not* `0`, and to continue
using `xbuild` (the historical default!) when `$USE_MSBUILD` is `0`.

Unfortunately, *nothing exports `$USE_MSBUILD`*. Consequently, we
*always* use `msbuild`/`xabuild`, unless the calling environment
explicitly exports it (which isn't the case on Jenkins).

Update the `RUN_NUNIT_TEST` make `define` so that the `$USE_MSBUILD`
environment variable is exported to the *value of* the
`$(USE_MSBUILD)` make variable, IFF it's not the empty string.
If `$(USE_MSBUILD)` *is* the empty string, export `USE_MSBUILD=0`,
which will cause `xbuild` to be used.

With luck, this will allow the current `Xamarin.Android.Build.Tests`
failures -- all 20 of them -- to be "fixed" until such time as all
`Xamarin.Android.Build.Tests` tests *actually* pass w/ MSBuild.