### PR TITLE
[Xamarin.Android.Build.Tasks] Correctly set build tools version in CheckSignApk test

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -214,7 +214,7 @@ namespace Xamarin.Android.Build.Tests
 			};
 			if (useApkSigner) {
 				proj.SetProperty ("AndroidUseApkSigner", "true");
-				proj.SetProperty ("AndroidBuildToolsVersion", "26.0.1");
+				proj.SetProperty ("AndroidSdkBuildToolsVersion", "26.0.1");
 			} else {
 				proj.RemoveProperty ("AndroidUseApkSigner");
 			}


### PR DESCRIPTION
The test failed locally for me with:

```
/Users/alexander/dev/xamarin-android/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/Xamarin.Android.Common.targets: 
error : '/Users/alexander/Library/Developer/Xamarin/android-sdk-macosx/build-tools/23.0.0/apksigner' does not exist.
You need to install android-sdk build-tools 26.0.1 or above.
```

which is weird since it's looking into the 23.0.0 build tools which doesn't have apksigner even though the test specifies build tools 26.0.1.

Turns out the test had a typo, it used AndroidBuildToolsVersion instead of AndroidSdkBuildToolsVersion so it fell back to 23.0.0 :)