### PR TITLE
[XABuild] Work around the XABuild Config issue by creating it before the tests run.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -182,11 +182,14 @@ namespace Xamarin.Android.Build.Tests
 		public void FixtureSetup ()
 		{
 			var builder = new Builder ();
+			var configPath = Path.Combine (Path.GetDirectoryName (builder.XABuildExe), IsWindows ? "xabuild.exe.config" : "MSBuild.dll.config");
 			// Hack around the Config issue.
-			if (builder.RunningMSBuild) {
-				var psi = new ProcessStartInfo (builder.XABuildExe);
-				psi.UseShellExecute = false;
-				psi.CreateNoWindow = true;
+			if (!File.Exists (configPath) && builder.RunningMSBuild) {
+				var psi = new ProcessStartInfo (builder.XABuildExe) {
+					Arguments = "/version",
+					UseShellExecute = false,
+					CreateNoWindow = true,
+				};
 				psi.EnvironmentVariables ["MSBUILD"] = "msbuild";
 				var p = Process.Start (psi);
 				p.WaitForExit ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using System.Linq;
 using System.Threading;
 using System.Text;
+using System.Diagnostics;
 
 namespace Xamarin.Android.Build.Tests
 {
@@ -180,6 +181,16 @@ namespace Xamarin.Android.Build.Tests
 		[OneTimeSetUp]
 		public void FixtureSetup ()
 		{
+			var builder = new Builder ();
+			// Hack around the Config issue.
+			if (builder.RunningMSBuild) {
+				var psi = new ProcessStartInfo (builder.XABuildExe);
+				psi.UseShellExecute = false;
+				psi.CreateNoWindow = true;
+				psi.EnvironmentVariables ["MSBUILD"] = "msbuild";
+				var p = Process.Start (psi);
+				p.WaitForExit ();
+			}
 			// Clean the Resource Cache.
 			if (string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("BUILD_HOST")))
 				return;

--- a/tools/xabuild/XABuild.cs
+++ b/tools/xabuild/XABuild.cs
@@ -32,6 +32,8 @@ namespace Xamarin.Android.Build
 
 		static void CreateConfig (XABuildPaths paths)
 		{
+			if (File.Exists (paths.XABuildConfig))
+				return;
 			var xml = new XmlDocument ();
 			xml.Load (paths.MSBuildConfig);
 

--- a/tools/xabuild/XABuild.cs
+++ b/tools/xabuild/XABuild.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Android.Build
 
 		static void CreateConfig (XABuildPaths paths)
 		{
-			if (File.Exists (paths.XABuildConfig))
+			if (!paths.IsWindows && File.Exists (paths.XABuildConfig))
 				return;
 			var xml = new XmlDocument ();
 			xml.Load (paths.MSBuildConfig);


### PR DESCRIPTION
We have a problem with multiple instances of xabuild trying to
create/overrite a config file on each run. This causes all sorts
or failures.

So let just force a call to xabuild before the tests run. We can
then skip the creation of the file as it already exists. The
environment wont change between tests so there is no need to
keep creating this file over and over again.