### PR TITLE
[Xamarin.Android.Build.Tests] Fix the processing of the build.log files.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -235,6 +235,7 @@ namespace Xamarin.ProjectTools
 								if (match.Success) {
 									LastBuildTime = TimeSpan.Parse (match.Groups ["TimeSpan"].Value);
 									Console.WriteLine ($"Found Time Elapsed {LastBuildTime}");
+								}
 							}
 						}
 					}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -220,18 +220,30 @@ namespace Xamarin.ProjectTools
 
 			LastBuildTime = DateTime.UtcNow - start;
 
-			LastBuildOutput = psi.FileName + " " + args.ToString () + Environment.NewLine;
+			var sb = new StringBuilder ();
+			sb.AppendLine ( psi.FileName + " " + args.ToString () + Environment.NewLine);
 			if (!ranToCompletion)
-				LastBuildOutput += "Build Timed Out!";
-			if (buildLogFullPath != null && File.Exists (buildLogFullPath))
-				LastBuildOutput += File.ReadAllText (buildLogFullPath);
-			LastBuildOutput += string.Format ("\n#stdout begin\n{0}\n#stdout end\n", p.StandardOutput.ReadToEnd ());
-			LastBuildOutput += string.Format ("\n#stderr begin\n{0}\n#stderr end\n", p.StandardError.ReadToEnd ());
-
-			var match = timeElapsedRegEx.Match (LastBuildOutput);
-			if (match.Success) {
-				LastBuildTime = TimeSpan.Parse (match.Groups ["TimeSpan"].Value);
+				sb.AppendLine ("Build Timed Out!");
+			if (buildLogFullPath != null && File.Exists (buildLogFullPath)) {
+				using (var fs = File.OpenRead (buildLogFullPath)) {
+					using (var sr = new StreamReader (fs, Encoding.UTF8, true, 65536)) {
+						string line;
+						while ((line = sr.ReadLine ()) != null) {
+							sb.AppendLine (line);
+							if (line.StartsWith ("Time Elapsed", StringComparison.OrdinalIgnoreCase)) {
+								var match = timeElapsedRegEx.Match (line);
+								if (match.Success) {
+									LastBuildTime = TimeSpan.Parse (match.Groups ["TimeSpan"].Value);
+									Console.WriteLine ($"Found Time Elapsed {LastBuildTime}");
+							}
+						}
+					}
+				}
 			}
+			sb.AppendFormat ("\n#stdout begin\n{0}\n#stdout end\n", p.StandardOutput.ReadToEnd ());
+			sb.AppendFormat ("\n#stderr begin\n{0}\n#stderr end\n", p.StandardError.ReadToEnd ());
+
+			LastBuildOutput = sb.ToString ();
 
 			if (buildLogFullPath != null) {
 				Directory.CreateDirectory (Path.GetDirectoryName (buildLogFullPath));


### PR DESCRIPTION
Commit 029c86fb kinda caused a perforanace problem because it
was regex'ing the entire build log. Some of those logs can
grow to 300+ meg in size.

This commit reworks the build log processing to
1) Use a StringBuilder rather than concat strings.
2) Search for the build time from the end of the file first.

Hopefully this will improve things.