### PR TITLE
[xabuild] use a temp file for xabuild's config

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1,8 +1,10 @@
 ﻿﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Build.Framework;
 using NUnit.Framework;
@@ -2077,6 +2079,26 @@ namespace UnnamedProject {
 				Assert.IsTrue (builder.Build (proj, parameters: new [] { "AndroidErrorOnCustomJavaObject=False" }), "Build should have succeeded.");
 				StringAssert.Contains ($"warning XA4", builder.LastBuildOutput, "warning XA4212");
 			}
+		}
+
+		[Test]
+		public void RunXABuildInParallel ()
+		{
+			var xabuild = new ProjectBuilder ("temp/RunXABuildInParallel").XABuildExe;
+			var psi     = new ProcessStartInfo (xabuild, "/version") {
+				CreateNoWindow         = true,
+				RedirectStandardOutput = true,
+				RedirectStandardError  = true,
+				WindowStyle            = ProcessWindowStyle.Hidden,
+				UseShellExecute        = false,
+			};
+
+			Parallel.For (0, 10, i => {
+				using (var p = Process.Start (psi)) {
+					p.WaitForExit ();
+					Assert.AreEqual (0, p.ExitCode);
+				}
+			});
 		}
 	}
 }

--- a/tools/xabuild/XABuildPaths.cs
+++ b/tools/xabuild/XABuildPaths.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Android.Build
 		public string XABuildDirectory { get; private set; }
 
 		/// <summary>
-		/// Path to xabuild.exe.config, on Unix it seems to use MSBuild.dll.config instead
+		/// Path to xabuild.exe's config file, this is now a temporary file based on MSBuildExeTempPath
 		/// </summary>
 		public string XABuildConfig { get; private set; }
 
@@ -44,6 +44,11 @@ namespace Xamarin.Android.Build
 		/// Path to directory of MSBuild.exe
 		/// </summary>
 		public string MSBuildBin { get; private set; }
+
+		/// <summary>
+		/// Temporary file used for MSBUILD_EXE_PATH
+		/// </summary>
+		public string MSBuildExeTempPath { get; private set; }
 
 		/// <summary>
 		/// Path to MSBuild's App.config file
@@ -110,7 +115,6 @@ namespace Xamarin.Android.Build
 				MSBuildConfig            = Path.Combine (MSBuildBin, "MSBuild.exe.config");
 				ProjectImportSearchPaths = new [] { MSBuildPath, "$(MSBuildProgramFiles32)\\MSBuild" };
 				SystemProfiles           = Path.Combine (programFiles, "Reference Assemblies", "Microsoft", "Framework");
-				XABuildConfig            = Path.Combine (XABuildDirectory, "xabuild.exe.config");
 				SearchPathsOS            = "windows";
 			} else {
 				string mono              = IsMacOS ? "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono" : "/usr/lib/mono";
@@ -120,7 +124,6 @@ namespace Xamarin.Android.Build
 				MSBuildConfig            = Path.Combine (MSBuildBin, "MSBuild.dll.config");
 				ProjectImportSearchPaths = new [] { MSBuildPath, Path.Combine (mono, "xbuild"), Path.Combine (monoExternal, "xbuild") };
 				SystemProfiles           = Path.Combine (mono, "xbuild-frameworks");
-				XABuildConfig            = Path.Combine (XABuildDirectory, "MSBuild.dll.config");
 				SearchPathsOS            = IsMacOS ? "osx" : "unix";
 			}
 
@@ -129,6 +132,8 @@ namespace Xamarin.Android.Build
 			MonoAndroidToolsDirectory = Path.Combine (prefix, "xbuild", "Xamarin", "Android");
 			AndroidSdkDirectory       = Path.Combine (userProfile, "android-toolchain", "sdk");
 			AndroidNdkDirectory       = Path.Combine (userProfile, "android-toolchain", "ndk");
+			MSBuildExeTempPath        = Path.GetTempFileName ();
+			XABuildConfig             = MSBuildExeTempPath + ".config";
 		}
 
 		[DllImport ("libc")]


### PR DESCRIPTION
Context in #954 #964 #967

The Xamarin.Android.Build.Tests run xabuild.exe in parallel, which
brings up some interesting issues. xabuild.exe needs to overwrite a
config file that is used by the `MSBuildApp` class. Several PRs
were made to try to address this issue.

This solution uses the `MSBUILD_EXE_PATH` environment variable, that
gets MSBuild to load a temporary file for the config file. This allows
multiple xabuild.exe's to run in parallel without issue.

Past attempts:
- In #954, `EventWaitHandle` was used, which does not work when running
under Mono.
- In #964, `FileStream` was used as an interprocess lock and `MSBuildApp`'s
static ctor was forced to run during the lock. It wasn't ideal.
- In #967, the config file was created before the tests run, and uses a
`File.Exists` check. This approach would not work on Windows.