### PR TITLE
[tests] update NUnit to 3.7.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,6 @@ NUNIT_TESTS = \
 
 NUNIT_CONSOLE = packages/NUnit.ConsoleRunner.3.7.0/tools/nunit3-console.exe
 
-NUNIT_WORKERS ?= --workers=1
-
 ifneq ($(V),0)
 MONO_OPTIONS += --debug
 endif
@@ -140,7 +138,7 @@ define RUN_NUNIT_TEST
 	MONO_TRACE_LISTENER=Console.Out \
 	USE_MSBUILD=$(if $(USE_MSBUILD),$(USE_MSBUILD),0) \
 	$(RUNTIME) --runtime=v4.0.0 \
-		$(NUNIT_CONSOLE) $(NUNIT_EXTRA) $(NUNIT_WORKERS) $(1) \
+		$(NUNIT_CONSOLE) $(NUNIT_EXTRA) $(1) \
 		$(if $(TEST),--test=$(TEST)) \
 		--result="TestResult-$(basename $(notdir $(1))).xml;format=nunit2" \
 		-output=bin/Test$(CONFIGURATION)/TestOutput-$(basename $(notdir $(1))).txt \

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -36,7 +36,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="nunit.framework">
-      <HintPath>..\..\..\..\packages\NUnit.3.7.0\lib\net45\nunit.framework.dll</HintPath>
+      <HintPath>..\..\..\..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.7.0" targetFramework="net451" />
+  <package id="NUnit" version="3.7.1" targetFramework="net451" />
   <package id="NUnit.Console" version="3.7.0" targetFramework="net451" />
   <package id="NUnit.ConsoleRunner" version="3.7.0" targetFramework="net451" />
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net451" />


### PR DESCRIPTION
Context: https://github.com/nunit/nunit/releases/tag/3.7.1

The release notes for NUnit 3.7.1 mention a hang with parallelized
tests, so it is worth a try to see if updating fixes it.

Reverting 6687dac as well to see if we get a green build.