### PR TITLE
[Xamarin.Android.Build.Tests] Clean up DebugType = "None" test changes.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1073,8 +1073,6 @@ namespace App1
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				var apkPath = Path.Combine (Root, b.ProjectDirectory,
 					proj.IntermediateOutputPath,"android", "bin", "UnnamedProject.UnnamedProject.apk");
-				if (debugSymbols && optimize.HasValue && optimize.Value && debugType == "" && !b.RunningMSBuild)
-					expectedRuntime = "debug";
 				using (var apk = ZipHelper.OpenZip (apkPath)) {
 					foreach (var abi in supportedAbi) {
 						var runtime = runtimeInfo.FirstOrDefault (x => x.Abi == abi && x.Runtime == expectedRuntime);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -480,8 +480,6 @@ namespace Bug12935
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", $"DebuggerAttribute_{debugType}_{isRelease}_{expected}"), false, false)) {
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
 				var manifest = builder.Output.GetIntermediaryAsText (Root, Path.Combine ("android", "AndroidManifest.xml"));
-				if (!isRelease && debugType == "None" && !builder.RunningMSBuild)
-					expected = false;
 				Assert.AreEqual (expected, manifest.Contains ("android:debuggable=\"true\""), $"Manifest  {(expected ? "should" : "should not")} contain the andorid:debuggable attribute");
 			}
 		}


### PR DESCRIPTION
Commit 8643ded9 added support for running the tests in msbuild.
Part of that change was altering the behaviour of `xbuild to
match that of msbuild. This was regarding the way they hande
the `$(DebugType) == "None"`.

The commit altered the .targets file to reset `$(DebugType)` to
`portable` if `None` is detected. It also resets `$(DebugSymbols)`
to `false` in the same senario.

As a result the the in these two tests which do the same thing
should not longer be required.