### PR TITLE
[Xamarin.Android.Build.Tasks] Remove Unsupported Lint Checks

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
@@ -207,27 +207,27 @@ namespace Xamarin.Android.Tasks
 
 			foreach (var issue in DisabledIssuesByVersion) {
 				if (lintToolVersion < issue.Value) {
-					Regex issueReplaceRegex = new Regex ($"{issue.Key}(,)?");
-					if (!string.IsNullOrEmpty (DisabledIssues) && DisabledIssues.Contains (issue.Key)) {
-						var match = issueReplaceRegex.Match (DisabledIssues);
-						if (match.Success) {
-							DisabledIssues = DisabledIssues.Replace (match.Value, string.Empty);
-							Log.LogWarning ($"Removing {issue.Key} from DisabledIssues. Lint {lintToolVersion} does not support this check.");
-						}
-					}
-					if (!string.IsNullOrEmpty (EnabledIssues) && EnabledIssues.Contains (issue.Key)) {
-						var match = issueReplaceRegex.Match (EnabledIssues);
-						if (match.Success) {
-							EnabledIssues = EnabledIssues.Replace (match.Value, string.Empty);
-							Log.LogWarning ($"Removing {issue.Key} from EnabledIssues. Lint {lintToolVersion} does not support this check.");
-						}
-					}
+					DisabledIssues = CleanIssues (issue.Key, lintToolVersion, DisabledIssues, nameof (DisabledIssues));
+					EnabledIssues = CleanIssues (issue.Key, lintToolVersion, EnabledIssues, nameof (EnabledIssues) );
 				}
 			}
 
 			base.Execute ();
 
 			return !Log.HasLoggedErrors;
+		}
+
+		string CleanIssues (string issueToRemove, Version lintToolVersion, string issues, string issuePropertyName)
+		{
+			Regex issueReplaceRegex = new Regex ($"\b{issueToRemove}\b(,)?");
+			if (!string.IsNullOrEmpty (issues) && issues.Contains (issueToRemove)) {
+				var match = issueReplaceRegex.Match (DisabledIssues);
+				if (match.Success) {
+					issues = issues.Replace (match.Value, string.Empty);
+					Log.LogWarning ($"Removing {issueToRemove} from {issuePropertyName}. Lint {lintToolVersion} does not support this check.");
+				}
+			}
+			return issues;
 		}
 
 		protected override string GenerateCommandLineCommands ()

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
@@ -174,7 +174,7 @@ namespace Xamarin.Android.Tasks
 			{ "MissingSuperCall", new Version (26, 1, 1) },
 		};
 
-		static readonly Regex lintVersionRegex = new Regex (@"version[\t\s]+(?<version>[\d\.]+)");
+		static readonly Regex lintVersionRegex = new Regex (@"version[\t\s]+(?<version>[\d\.]+)", RegexOptions.Compiled);
 
 		public override bool Execute ()
 		{
@@ -204,6 +204,26 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugTaskItems ("  ClassDirectories:", ClassDirectories);
 			Log.LogDebugTaskItems ("  LibraryDirectories:", LibraryDirectories);
 			Log.LogDebugTaskItems ("  LibraryJars:", LibraryJars);
+
+			foreach (var issue in DisabledIssuesByVersion) {
+				if (lintToolVersion < issue.Value) {
+					Regex issueReplaceRegex = new Regex ($"{issue.Key}(,)?");
+					if (!string.IsNullOrEmpty (DisabledIssues) && DisabledIssues.Contains (issue.Key)) {
+						var match = issueReplaceRegex.Match (DisabledIssues);
+						if (match.Success) {
+							DisabledIssues = DisabledIssues.Replace (match.Value, string.Empty);
+							Log.LogWarning ($"Removing {issue.Key} from DisabledIssues. Lint {lintToolVersion} does not support this check.");
+						}
+					}
+					if (!string.IsNullOrEmpty (EnabledIssues) && EnabledIssues.Contains (issue.Key)) {
+						var match = issueReplaceRegex.Match (EnabledIssues);
+						if (match.Success) {
+							EnabledIssues = EnabledIssues.Replace (match.Value, string.Empty);
+							Log.LogWarning ($"Removing {issue.Key} from EnabledIssues. Lint {lintToolVersion} does not support this check.");
+						}
+					}
+				}
+			}
 
 			base.Execute ();
 


### PR DESCRIPTION
If a user provides lint checks which are not supported by
the current lint version it will error.

	Invalid id or ategory "StatckFieldLeak"

This is normally ok. But in our build system we sometimes end up
on a bot which has an older version of lint. And in this case
the test fails, which in reality it should ignore the id we
are trying to use.

So this commit addds some validation to the Disabled and Enabled
checks. If its not supported we will remove the check and issue
a warning.