### PR TITLE
[Xamarin.Android.Build.Tasks] Null Reference Exceoption when getting android.jar

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
@@ -69,7 +69,8 @@ namespace Xamarin.Android.Tasks
 			}
 
 			platform            = GetTargetSdkVersion (platform, target_sdk);
-			JavaPlatformJarPath = Path.Combine (MonoAndroidHelper.AndroidSdk.TryGetPlatformDirectoryFromApiLevel (platform, MonoAndroidHelper.SupportedVersions), "android.jar");
+			var platformPath = MonoAndroidHelper.AndroidSdk.TryGetPlatformDirectoryFromApiLevel (platform, MonoAndroidHelper.SupportedVersions);
+			JavaPlatformJarPath = Path.Combine (platformPath ?? MonoAndroidHelper.AndroidSdk.GetPlatformDirectoryFromId (platform), "android.jar");
 
 			if (!File.Exists (JavaPlatformJarPath)) {
 				Log.LogError ("Could not find android.jar for API Level {0}. " +

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
@@ -69,25 +69,16 @@ namespace Xamarin.Android.Tasks
 			}
 
 			platform            = GetTargetSdkVersion (platform, target_sdk);
-			var platformPath = MonoAndroidHelper.AndroidSdk.TryGetPlatformDirectoryFromApiLevel (platform, MonoAndroidHelper.SupportedVersions);
-			JavaPlatformJarPath = Path.Combine (platformPath ?? MonoAndroidHelper.AndroidSdk.GetPlatformDirectoryFromId (platform), "android.jar");
-
-			if (!File.Exists (JavaPlatformJarPath)) {
-				Log.LogError ("Could not find android.jar for API Level {0}. " +
-						"This means the Android SDK platform for API Level {0} is not installed. " +
-						"Either install it in the Android SDK Manager (Tools > Open Android SDK Manager...), " +
-						"or change your Xamarin.Android project to target an API version that is installed. " +
-						"({1} missing.)",
-						platform, JavaPlatformJarPath);
-				return false;
-			}
+			JavaPlatformJarPath =  MonoAndroidHelper.TryGetAndroidJarPath (Log, platform);
+			if (JavaPlatformJarPath == null)
+				return !Log.HasLoggedErrors;
 
 			TargetSdkVersion = platform;
 
 			Log.LogDebugMessage ("  [Output] JavaPlatformJarPath: {0}", JavaPlatformJarPath);
 			Log.LogDebugMessage ("  [Output] TargetSdkVersion: {0}", TargetSdkVersion);
 
-			return true;
+			return !Log.HasLoggedErrors;
 		}
 
 		string GetTargetSdkVersion (string target, XAttribute target_sdk)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JarToXml.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JarToXml.cs
@@ -68,13 +68,9 @@ namespace Xamarin.Android.Tasks
 			}
 
 			// Ensure that the user has the platform they are targeting installed
-			var platformPath = MonoAndroidHelper.AndroidSdk.TryGetPlatformDirectoryFromApiLevel (AndroidApiLevel, MonoAndroidHelper.SupportedVersions);
-			var jarpath = Path.Combine (platformPath ?? MonoAndroidHelper.AndroidSdk.GetPlatformDirectoryFromId (AndroidApiLevel), "android.jar");
-
-			if (!File.Exists (jarpath)) {
-				Log.LogError ("Could not find android.jar for API Level {0}.  This means the Android SDK platform for API Level {0} is not installed.  Either install it in the Android SDK Manager, or change your Android Bindings project to target an API version that is installed. ({1} missing.)", AndroidApiLevel, jarpath);
-				return false;
-			}
+			var jarpath = MonoAndroidHelper.TryGetAndroidJarPath (Log, AndroidApiLevel);
+			if (jarpath == null)
+				return !Log.HasLoggedErrors;
 
 			// Ensure that all requested jars exist
 			foreach (var jar in SourceJars)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JarToXml.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JarToXml.cs
@@ -68,7 +68,8 @@ namespace Xamarin.Android.Tasks
 			}
 
 			// Ensure that the user has the platform they are targeting installed
-			var jarpath = Path.Combine (MonoAndroidHelper.AndroidSdk.TryGetPlatformDirectoryFromApiLevel (AndroidApiLevel, MonoAndroidHelper.SupportedVersions), "android.jar");
+			var platformPath = MonoAndroidHelper.AndroidSdk.TryGetPlatformDirectoryFromApiLevel (AndroidApiLevel, MonoAndroidHelper.SupportedVersions);
+			var jarpath = Path.Combine (platformPath ?? MonoAndroidHelper.AndroidSdk.GetPlatformDirectoryFromId (AndroidApiLevel), "android.jar");
 
 			if (!File.Exists (jarpath)) {
 				Log.LogError ("Could not find android.jar for API Level {0}.  This means the Android SDK platform for API Level {0} is not installed.  Either install it in the Android SDK Manager, or change your Android Bindings project to target an API version that is installed. ({1} missing.)", AndroidApiLevel, jarpath);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -536,7 +536,7 @@ namespace Xamarin.Android.Tasks
 			var platformPath = MonoAndroidHelper.AndroidSdk.TryGetPlatformDirectoryFromApiLevel (platform, MonoAndroidHelper.SupportedVersions);
 			if (platformPath == null) {
 				var expectedPath = MonoAndroidHelper.AndroidSdk.GetPlatformDirectoryFromId (platform);
-				log.LogError ("XA1234", "Could not find android.jar for API Level {0}. " +
+				log.LogError ("XA5207", "Could not find android.jar for API Level {0}. " +
 						"This means the Android SDK platform for API Level {0} is not installed. " +
 						"Either install it in the Android SDK Manager (Tools > Open Android SDK Manager...), " +
 						"or change your Xamarin.Android project to target an API version that is installed. " +

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -530,5 +530,21 @@ namespace Xamarin.Android.Tasks
 			foreach (var ext in pathExts)
 				yield return Path.ChangeExtension (executable, ext);
 		}
+
+		public static string TryGetAndroidJarPath (TaskLoggingHelper log, string platform)
+		{
+			var platformPath = MonoAndroidHelper.AndroidSdk.TryGetPlatformDirectoryFromApiLevel (platform, MonoAndroidHelper.SupportedVersions);
+			if (platformPath == null) {
+				var expectedPath = MonoAndroidHelper.AndroidSdk.GetPlatformDirectoryFromId (platform);
+				log.LogError ("XA1234", "Could not find android.jar for API Level {0}. " +
+						"This means the Android SDK platform for API Level {0} is not installed. " +
+						"Either install it in the Android SDK Manager (Tools > Open Android SDK Manager...), " +
+						"or change your Xamarin.Android project to target an API version that is installed. " +
+						"({1} missing.)",
+						platform, Path.Combine (expectedPath, "android.jar"));
+				return null;
+			}
+			return Path.Combine (platformPath, "android.jar");
+		}
 	}
 }


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=60324

If a android.jar file does NOT exist for a target platform we should
raise a normal error. But we currently throw a null reference
exception.

`TryGetPlatformDirectoryFromApiLevel` can return null, this is by
design. So we need to handle that in the places where its used.
And return a reasonable error message if we do get a null back.