### PR TITLE
[tests] fix failures related to AndroidSdkDirectory property

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -185,6 +185,19 @@ namespace Xamarin.ProjectTools
 					buildLogFullPath, Verbosity.ToString ().ToLower ());
 
 			var start = DateTime.UtcNow;
+			var homeDirectory = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
+ 			var androidSdkToolPath = Path.Combine (homeDirectory, "android-toolchain");
+ 			var sdkPath = Environment.GetEnvironmentVariable ("ANDROID_SDK_PATH");
+ 			if (String.IsNullOrEmpty (sdkPath))
+ 				sdkPath = GetPathFromRegistry ("AndroidSdkDirectory");
+ 			if (String.IsNullOrEmpty (sdkPath))
+ 				sdkPath = Path.GetFullPath (Path.Combine (androidSdkToolPath, "sdk"));
+ 			var ndkPath = Environment.GetEnvironmentVariable ("ANDROID_NDK_PATH");
+ 			if (String.IsNullOrEmpty (ndkPath))
+ 				ndkPath = GetPathFromRegistry ("AndroidNdkDirectory");
+ 			if (String.IsNullOrEmpty (ndkPath))
+ 				ndkPath = Path.GetFullPath (Path.Combine (androidSdkToolPath, "ndk"));
+
 			var args  = new StringBuilder ();
 			var psi   = new ProcessStartInfo (XABuildExe);
 			args.AppendFormat ("{0} /t:{1} {2}",
@@ -193,6 +206,12 @@ namespace Xamarin.ProjectTools
 				args.Append (" /p:BuildingOutOfProcess=true");
 			else
 				args.Append (" /p:UseHostCompilerIfAvailable=false /p:BuildingInsideVisualStudio=true");
+			if (Directory.Exists (sdkPath)) {
+				args.AppendFormat (" /p:AndroidSdkDirectory=\"{0}\" ", sdkPath);
+			}
+			if (Directory.Exists (ndkPath)) {
+				args.AppendFormat (" /p:AndroidNdkDirectory=\"{0}\" ", ndkPath);
+			}
 			if (parameters != null) {
 				foreach (var param in parameters) {
 					args.AppendFormat (" /p:{0}", param);

--- a/tools/xabuild/XABuild.cs
+++ b/tools/xabuild/XABuild.cs
@@ -64,8 +64,6 @@ namespace Xamarin.Android.Build
 			SetProperty (toolsets, "MSBuildExtensionsPath", paths.MSBuildExtensionsPath);
 			SetProperty (toolsets, "MSBuildExtensionsPath32", paths.MSBuildExtensionsPath);
 			SetProperty (toolsets, "RoslynTargetsPath", Path.Combine (paths.MSBuildBin, "Roslyn"));
-			SetProperty (toolsets, "AndroidSdkDirectory", paths.AndroidSdkDirectory);
-			SetProperty (toolsets, "AndroidNdkDirectory", paths.AndroidNdkDirectory);
 			SetProperty (toolsets, "MonoAndroidToolsDirectory", paths.MonoAndroidToolsDirectory);
 			SetProperty (toolsets, "TargetFrameworkRootPath", paths.FrameworksDirectory + Path.DirectorySeparatorChar); //NOTE: Must include trailing \
 

--- a/tools/xabuild/XABuildPaths.cs
+++ b/tools/xabuild/XABuildPaths.cs
@@ -83,10 +83,6 @@ namespace Xamarin.Android.Build
 
 		public string MonoAndroidToolsDirectory { get; private set; }
 
-		public string AndroidSdkDirectory { get; private set; }
-
-		public string AndroidNdkDirectory { get; private set; }
-
 		public XABuildPaths ()
 		{
 			IsWindows                 = Environment.OSVersion.Platform == PlatformID.Win32NT;
@@ -96,7 +92,6 @@ namespace Xamarin.Android.Build
 			XamarinAndroidBuildOutput = Path.GetFullPath (Path.Combine (XABuildDirectory, ".."));
 
 			string programFiles       = Environment.GetFolderPath (Environment.SpecialFolder.ProgramFilesX86);
-			string userProfile        = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
 			string prefix             = Path.Combine (XamarinAndroidBuildOutput, "lib", "xamarin.android");
 
 			if (IsWindows) {
@@ -130,8 +125,6 @@ namespace Xamarin.Android.Build
 			FrameworksDirectory       = Path.Combine (prefix, "xbuild-frameworks");
 			MSBuildExtensionsPath     = Path.Combine (prefix, "xbuild");
 			MonoAndroidToolsDirectory = Path.Combine (prefix, "xbuild", "Xamarin", "Android");
-			AndroidSdkDirectory       = Path.Combine (userProfile, "android-toolchain", "sdk");
-			AndroidNdkDirectory       = Path.Combine (userProfile, "android-toolchain", "ndk");
 			MSBuildExeTempPath        = Path.GetTempFileName ();
 			XABuildConfig             = MSBuildExeTempPath + ".config";
 		}


### PR DESCRIPTION
Context in #910

When switching to `xabuild.exe`, two mistakes were made:
- `xabuild.exe` shouldn’t set `AndroidSdkDirectory` or
`AndroidNdkDirectory`
- Xamarin.Android.Build.Tests should pass these values to xabuild

This restores some of the code in `Builder.cs` removed in f9d15dd