### PR TITLE
[Xamarin.Android.Build.Tests] Fix Framework Path Detection.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -77,13 +77,17 @@ namespace Xamarin.ProjectTools
 			get {
 				if (IsUnix) {
 					var outdir = Environment.GetEnvironmentVariable ("XA_BUILD_OUTPUT_PATH");
+					var configuraton = Environment.GetEnvironmentVariable ("CONFIGURATION") ?? "Debug";
+					var libmonodroidPath = Path.Combine ("lib", "xamarin.android", "xbuild", "Xamarin", "Android", "lib", "armeabi-v7a", "libmono-android.release.so");
 					if (String.IsNullOrEmpty(outdir))
 						outdir = Path.GetFullPath (Path.Combine (Root, "..", "..", "..", "..", "..", "..", "..", "out"));
-					if (!Directory.Exists (Path.Combine (outdir, "lib")))
+					if (!Directory.Exists (Path.Combine (outdir, "lib")) || !File.Exists (Path.Combine (outdir, libmonodroidPath)))
+						outdir = Path.GetFullPath (Path.Combine (Root, "..", "..", "bin", configuraton));
+					if (!Directory.Exists (Path.Combine (outdir, "lib")) || !File.Exists (Path.Combine (outdir, libmonodroidPath)))
 						outdir = Path.GetFullPath (Path.Combine (Root, "..", "..", "bin", "Debug"));
-					if (!Directory.Exists (Path.Combine (outdir, "lib")))
+					if (!Directory.Exists (Path.Combine (outdir, "lib")) || !File.Exists (Path.Combine (outdir, libmonodroidPath)))
 						outdir = Path.GetFullPath (Path.Combine (Root, "..", "..", "bin", "Release"));
-					if (!Directory.Exists (outdir))
+					if (!Directory.Exists (Path.Combine (outdir, "lib")) || !File.Exists (Path.Combine (outdir, libmonodroidPath)))
 						outdir = "/Library/Frameworks/Xamarin.Android.framework/Versions/Current";
 					return Path.Combine (outdir, "lib", "xamarin.android");
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -77,7 +77,11 @@ namespace Xamarin.ProjectTools
 			get {
 				if (IsUnix) {
 					var outdir = Environment.GetEnvironmentVariable ("XA_BUILD_OUTPUT_PATH");
+					#if DEBUG
 					var configuraton = Environment.GetEnvironmentVariable ("CONFIGURATION") ?? "Debug";
+					#else
+					var configuraton = Environment.GetEnvironmentVariable ("CONFIGURATION") ?? "Release";
+					#endif
 					var libmonodroidPath = Path.Combine ("lib", "xamarin.android", "xbuild", "Xamarin", "Android", "lib", "armeabi-v7a", "libmono-android.release.so");
 					if (String.IsNullOrEmpty(outdir))
 						outdir = Path.GetFullPath (Path.Combine (Root, "..", "..", "..", "..", "..", "..", "..", "out"));


### PR DESCRIPTION
On jenkins is appears we are getting a situation where we
are picking up an empty directory for the FrameworkPath.
As a result we always get 0 when trying to pick up the
runtime that are available. So tests which check the runtimes
fail.

This commit adds a check for a 'libmono-android.release.so' file
so can ensure the required files exist in the folder. Also added
code to pick up the `CONFIGURATION` environment variable from
the Makefile.