### PR TITLE
[Xamarin.Android.Build.Tasks] Force xbuild to behave like msbuild.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.CSharp.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.CSharp.targets
@@ -35,6 +35,11 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
         <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
         <_AndroidResourceDesigner>Resource.Designer.cs</_AndroidResourceDesigner>
     </PropertyGroup>
+    <!-- Force Xbuild to behave like msbuild -->
+    <PropertyGroup>
+        <DebugSymbols Condition=" '$(DebugType)' == 'None' ">true</DebugSymbols>
+        <DebugType Condition=" '$(DebugType)' == 'None' Or '$(DebugType)' == '' ">portable</DebugType>
+    </PropertyGroup>
     <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
     <Import Project="Xamarin.Android.Common.targets" />
     <!--

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -277,12 +277,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 </PropertyGroup>
 
-<!-- Force Xbuild to behave like msbuild -->
-<PropertyGroup>
-	<DebugSymbols Condition=" '$(DebugType)' == 'None' ">false</DebugSymbols>
-	<DebugType Condition=" '$(DebugType)' == 'None' ">portable</DebugType>
-</PropertyGroup>
-
 <Choose>
 	<When Condition=" '$(DebugSymbols)' == 'True' And '$(DebugType)' != '' And ('$(EmbedAssembliesIntoApk)' == 'False' Or '$(Optimize)' != 'True') ">
 		<PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
@@ -33,7 +33,11 @@ Copyright (C) 2012 Xamarin. All rights reserved.
         <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
         <_AndroidResourceDesigner>Resource.Designer.fs</_AndroidResourceDesigner>
     </PropertyGroup>
-
+    <!-- Force Xbuild to behave like msbuild -->
+    <PropertyGroup>
+        <DebugSymbols Condition=" '$(DebugType)' == 'None' ">true</DebugSymbols>
+        <DebugType Condition=" '$(DebugType)' == 'None' Or '$(DebugType)' == '' ">portable</DebugType>
+    </PropertyGroup>
     <!-- xbuild searches multiple MSBuildExtensionsPath32, but only in the Import element, so we can't determine this with a variable -->
     <Import
       Condition="'$(Language)' != 'F#' And Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')"


### PR DESCRIPTION
Commit 8643ded9 tried to make sure xbuild worked like msbuild
when it came to `'$(DebugType)' == 'None'`. The "fix" however
was not correct.

When DebugType is None under msbuild, it changes to `portable`
and DebugSymbols get set to 'true'. Also when DebugType is empty
it gets set to `portable` but the DebugSymbols is left alone.

So we need to get xbuild to do the same. Otherwise we get the
wrong runtimes. But by the time we get the the .Common.targets
it is too late to change the `DebugSymbols` value. xbuild does
not take the change. So we need to do this before xbuild gets
a chance to set the value of `DebugSymbols`.

The trick is to alter the properties in the CSharp and Fsharp
targets BEFORE we import the Microsoft targets.