### PR TITLE
[Xamarin.Android.Build.Tasks] Fix a Hang in Visual Studio DesignTime Build.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -87,7 +87,7 @@ using System.Runtime.CompilerServices;
 					b.Target = "Compile";
 					Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, parameters: new string [] { "DesignTimeBuild=true" }, environmentVariables: envVar),
 						"first build failed");
-					Assert.AreEqual (!useManagedParser, b.LastBuildOutput.Contains ("Skipping download of "),
+					Assert.AreEqual (!useManagedParser, b.LastBuildOutput.Contains ("Skipping GetAdditionalResourcesFromAssemblies"),
 						"failed to skip the downloading of files.");
 					var items = new List<string> ();
 					string first = null;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -278,7 +278,9 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
       CacheFile="$(IntermediateOutputPath)resourcepaths.cache"
       YieldDuringToolExecution="$(YieldDuringToolExecution)"
       DesignTimeBuild="$(DesignTimeBuild)"
+      Condition=" '$(DesignTimeBuild)' == '' Or '$(DesignTimeBuild)' == 'false' "
     />
+  <Message Text="Skipping GetAdditionalResourcesFromAssemblies in DesignTime build" Condition=" '$(DesignTimeBuild)' == 'true' " />
   </Target>
 
   <Target Name="_GetAdditionalResourcesFromAssemblies" DependsOnTargets="_BuildAdditionalResourcesCache">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -418,7 +418,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
    YieldDuringToolExecution="$(YieldDuringToolExecution)"
    DesignTimeBuild="$(DesignTimeBuild)"
    ContinueOnError="$(DesignTimeBuild)"
+   Condition=" '$(DesignTimeBuild)' == '' Or '$(DesignTimeBuild)' == 'false' "
   />
+  <Message Text="Skipping GetAdditionalResourcesFromAssemblies in DesignTime build" Condition=" '$(DesignTimeBuild)' == 'true' " />
 </Target>
 
 <Target Name="_ValidateResourceCache">


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=60080

In a previus attempt to fix an intellisense build (1cd582ec) we
caused this issue. The DesignTime build does NOT like our AsyncTask
as it locks the IDE.

This commit puts the old code back in place which skips the task
if we are in DesignTime mode. But so we can easily test it, we
emit an message that our test can pick up to ensure we are doing
the correct thing. Without the message we have no way of knowing
if the task is skipped.