### PR TITLE
[Xamarin.Android.Build.Tasks] Move DesignTime Cache files to designtime folder.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1790,19 +1790,27 @@ public class Test
 		[Test]
 		public void BuildInDesignTimeMode ([Values(false, true)] bool useManagedParser)
 		{
+			var path = Path.Combine ("temp", TestContext.CurrentContext.Test.Name);
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 			};
 			proj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", useManagedParser.ToString ());
-			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name), false ,false)) {
+			using (var builder = CreateApkBuilder (path, false ,false)) {
 				builder.Verbosity = LoggerVerbosity.Diagnostic;
 				builder.Target = "UpdateAndroidResources";
 				builder.Build (proj, parameters: new string[] { "DesignTimeBuild=true" });
 				Assert.IsFalse (builder.Output.IsTargetSkipped ("_CreatePropertiesCache"), "target \"_CreatePropertiesCache\" should have been run.");
 				Assert.IsFalse (builder.Output.IsTargetSkipped ("_ResolveLibraryProjectImports"), "target \"_ResolveLibraryProjectImports\' should have been run.");
+				var librarycache = Path.Combine (Root, path, proj.IntermediateOutputPath, "designtime", "libraryprojectimports.cache");
+				Assert.IsTrue (File.Exists (librarycache), $"'{librarycache}' should exist.");
+				librarycache = Path.Combine (Root, path, proj.IntermediateOutputPath, "libraryprojectimports.cache");
+				Assert.IsFalse (File.Exists (librarycache), $"'{librarycache}' should not exist.");
 				builder.Build (proj, parameters: new string[] { "DesignTimeBuild=true" });
 				Assert.IsFalse (builder.Output.IsTargetSkipped ("_CreatePropertiesCache"), "target \"_CreatePropertiesCache\" should have been run.");
 				Assert.IsTrue (builder.Output.IsTargetSkipped ("_ResolveLibraryProjectImports"), "target \"_ResolveLibraryProjectImports\' should have been skipped.");
+				Assert.IsTrue (builder.Clean (proj), "Clean Should have succeeded");
+				librarycache = Path.Combine (Root, path, proj.IntermediateOutputPath, "designtime", "libraryprojectimports.cache");
+				Assert.IsFalse (File.Exists (librarycache), $"'{librarycache}' should exist.");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -396,7 +396,11 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		<DesignTimeBuild Condition=" '$(DesignTimeBuild)' == '' ">true</DesignTimeBuild>
 		<ManagedDesignTimeBuild Condition=" '$(AndroidUseManagedDesignTimeResourceGenerator)' == 'True' And '$(DesignTimeBuild)' == 'True' And '$(BuildingInsideVisualStudio)' == 'True' ">True</ManagedDesignTimeBuild>
 		<ManagedDesignTimeBuild Condition=" '$(ManagedDesignTimeBuild)' == '' ">False</ManagedDesignTimeBuild>
+		<_AndroidResourcePathsCache Condition=" '$(DesignTimeBuild)' == 'true' ">$(_AndroidDesignTimeResDirIntermediate)resourcepaths.cache</_AndroidResourcePathsCache>
+		<_AndroidLibraryImportsCache Condition=" '$(DesignTimeBuild)' == 'true' ">$(_AndroidDesignTimeResDirIntermediate)libraryimports.cache</_AndroidLibraryImportsCache>
+		<_AndroidLibraryProjectImportsCache Condition=" '$(DesignTimeBuild)' == 'true' ">$(_AndroidDesignTimeResDirIntermediate)libraryprojectimports.cache</_AndroidLibraryProjectImportsCache>
 	</PropertyGroup>
+	<MakeDir Directories="$(_AndroidDesignTimeResDirIntermediate)" Condition=" '$(DesignTimeBuild)' == 'true' " />
 </Target>
 
 <PropertyGroup>


### PR DESCRIPTION
The DesignTime build is generally run before any nuget packages
have been restore. As a result we end up with empty cache files.
Because those files exist and are considered uptodate, when the
main build finally happens they are not re-generated.
This causes errors like

	error: Error: No resource found that matches the given name: attr 'colorAccent'.

on a new default template.

So the DesignTime build should have its own set of cache files which
do not conflict with the main build. This way when the main build
runs the cache files will not be in place.