### PR TITLE
[Xamarin.Android.Build.Tests] Fix BuildAppCheckDebugSymbols for monodroid

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -609,6 +609,8 @@ namespace App1
 					var outputPath = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath);
 					using (var apk = ZipHelper.OpenZip (Path.Combine (outputPath, proj.PackageName + ".apk"))) {
 						var data = ZipHelper.ReadFileFromZip (apk, "assemblies/Library1.pdb");
+						if (data == null)
+							data = File.ReadAllBytes (assetsPdb);
 						var filedata = File.ReadAllBytes (linkSrc);
 						Assert.AreEqual (filedata.Length, data.Length, "Library1.pdb in the apk should match {0}", linkSrc);
 					}


### PR DESCRIPTION
The BuildAppCheckDebugSymbols test does not take into account
that when building in debug mode on monodroid the assemblies
are not embedded in the apk. As a result when trying to get
`Library1.pdb` from the apk we get a null back. This causes
a Null Ref exception when we try to get a length.

The fix is to look in the `assets` directory if we can't get
the file from the zip. This will allow the test to work in
both xamarin-android and monodroid.