### PR TITLE
[xabuild.exe] handle AndroidSdkDirectory like the script

### DIFF
--- a/tools/xabuild/XABuild.cs
+++ b/tools/xabuild/XABuild.cs
@@ -66,6 +66,10 @@ namespace Xamarin.Android.Build
 			SetProperty (toolsets, "RoslynTargetsPath", Path.Combine (paths.MSBuildBin, "Roslyn"));
 			SetProperty (toolsets, "MonoAndroidToolsDirectory", paths.MonoAndroidToolsDirectory);
 			SetProperty (toolsets, "TargetFrameworkRootPath", paths.FrameworksDirectory + Path.DirectorySeparatorChar); //NOTE: Must include trailing \
+			if (!string.IsNullOrEmpty (paths.AndroidSdkDirectory))
+				SetProperty (toolsets, "AndroidSdkDirectory", paths.AndroidSdkDirectory);
+			if (!string.IsNullOrEmpty (paths.AndroidNdkDirectory))
+				SetProperty (toolsets, "AndroidNdkDirectory", paths.AndroidNdkDirectory);
 
 			var projectImportSearchPaths = toolsets.SelectSingleNode ("projectImportSearchPaths");
 			var searchPaths = projectImportSearchPaths.SelectSingleNode ($"searchPaths[@os='{paths.SearchPathsOS}']") as XmlElement;


### PR DESCRIPTION
Context:
https://github.com/xamarin/xamarin-android/blob/master/tools/scripts/xabuild#L105

`xabuild`, the shell script, has some logic to set MSBuild properties
for `AndroidSdkDirectory` and `AndroidNdkDirectory`. The issue here is
on Windows, `xabuild.exe` is not invoked from this shell script. So we
need to replicate the logic in C# in `xabuild.exe`, but not break what
was fixed in #977.

Changes:
- check for `ANDROID_SDK_PATH` or `ANDROID_NDK_PATH` environment
variables
- Run `Paths.targets` via a new MSBuild process, the same way as
`xabuild`, the script
- Set the `AndroidSdkDirectory` and `AndroidNdkDirectory` values in the
config file if they are not blank
- `AndroidSdkDirectory` and `AndroidNdkDirectory` can still be
overridden by a user, because incoming values supersede what is found
in the config file