### PR TITLE
[build] fix for JdkInfo task in PrepareWindows.targets

### DIFF
--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -5,14 +5,15 @@
     <_TopDir>$(MSBuildThisFileDirectory)..\..</_TopDir>
     <_NuGet>.nuget\NuGet.exe</_NuGet>
   </PropertyGroup>
+  <Import Project="$(_TopDir)\Configuration.props" />
   <UsingTask AssemblyFile="$(_TopDir)\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.JdkInfo" />
   <UsingTask AssemblyFile="$(_TopDir)\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
   <Target Name="Prepare">
     <Exec Command="git submodule update --init --recursive" WorkingDirectory="$(_TopDir)" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\xa-prep-tasks\xa-prep-tasks.csproj" />
     <JdkInfo
-        AndroidSdkPath="$(AndroidSdkPath)"
-        AndroidNdkPath="$(AndroidNdkPath)"
+        AndroidSdkPath="$(AndroidSdkDirectory)"
+        AndroidNdkPath="$(AndroidNdkDirectory)"
         JavaSdkPath="$(JavaSdkDirectory)"
         Output="$(_TopDir)\external\Java.Interop\bin\BuildDebug\JdkInfo.props">
       <Output TaskParameter="JavaSdkDirectory" PropertyName="_JavaSdkDirectory" />


### PR DESCRIPTION
On Windows after formatting my machine (don't ask), `PrepareWindows.targets` was failing with:

System.InvalidOperationException: Could not determine Android SDK location.

Looking into it, there appear to be two things wrong:
- `PrepareWindows.targets` should import `Configuration.props`
- The incoming variables are `AndroidSdkDirectory` and `AndroidNdkDirectory` not `AndroidSdkPath` and `AndroidNdkPath`

I'm not quite sure how this _ever_ worked, unless `AndroidSdkInfo` was able to find _some_ Android SDK on your machine.