### PR TITLE
[build] update SDK tools URLs

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -19,7 +19,7 @@
       <HostOS>Linux</HostOS>
       <DestDir>platform-tools</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="sdk-tools-linux-3952940.zip">
+    <AndroidSdkItem Include="tools_r25.2.5-linux.zip">
       <HostOS>Linux</HostOS>
       <DestDir>tools</DestDir>
     </AndroidSdkItem>
@@ -38,7 +38,7 @@
       <HostOS>Darwin</HostOS>
       <DestDir>platform-tools</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="sdk-tools-darwin-3952940.zip">
+    <AndroidSdkItem Include="tools_r25.2.5-macosx.zip">
       <HostOS>Darwin</HostOS>
       <DestDir>tools</DestDir>
     </AndroidSdkItem>
@@ -57,7 +57,7 @@
       <HostOS>Windows</HostOS>
       <DestDir>platform-tools</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="sdk-tools-windows-3952940.zip">
+    <AndroidSdkItem Include="tools_r25.2.5-windows.zip">
       <HostOS>Windows</HostOS>
       <DestDir>tools</DestDir>
     </AndroidSdkItem>

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/AcceptAndroidSdkLicenses.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/AcceptAndroidSdkLicenses.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 
 			string _;
 			var path = Which.GetProgramLocation ("sdkmanager", out _, new [] { Path.Combine (AndroidSdkDirectory, "tools", "bin") });
-			var psi = new ProcessStartInfo (path, "--licenses") { UseShellExecute = false, RedirectStandardInput = true };
+			var psi = new ProcessStartInfo (path, "--update") { UseShellExecute = false, RedirectStandardInput = true };
 			var proc = Process.Start (psi);
 			for (int i = 0; i < 10; i++)
 				proc.StandardInput.WriteLine ('y');


### PR DESCRIPTION
On Windows, the `lint` tool installed by the build was broken.
This causes several tests to fail on Windows verifying features
around `lint` After looking into it, it appears the URLs used to
download the SDK tools were not found in:

https://dl.google.com/android/repository/repository-12.xml

The correct URLs appear to be of the form `tools_rx.x.x-platform.zip`.
Note Google uses `macosx` in this file name instead of `darwin`.
Not sure what version of the SDK tools were being used previously,
they must be a prerelease or nightly release.

Other changes:
- The command `sdkmanager --license` is now `sdkmanager --update`