### PR TITLE
[Xamarin.Android.Build.Tests] Lets retry a build if we get a native crash

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -269,7 +269,7 @@ namespace Xamarin.ProjectTools
 										Console.WriteLine ($"Found Time Elapsed {LastBuildTime}");
 									}
 								}
-								if (line.StartsWith ("at (wrapper managed-to-native", StringComparison.OrdinalIgnoreCase)) {
+								if (line.StartsWith ("Got a SIGSEGV while executing native code", StringComparison.OrdinalIgnoreCase)) {
 									nativeCrashDetected = true;
 									break;
 								}


### PR DESCRIPTION
We get a few probems when building with mono/xbuild. We get
the occasional crash :(

	at <unknown> <0xffffffff>
	at (wrapper managed-to-native) object.__icall_wrapper_mono_gc_alloc_obj (intptr,intptr) [0x00000] in <4fdc5ed61a074cafb49fa42deb20d521>:0
	at (wrapper alloc) object.AllocSmall (intptr,intptr) <0x000fa>

So what we might want to do is to retry the build if we get this.
It usually doesn't happen twice in a row.