### PR TITLE
[Xamarin.Android.Build.Tasks] Handle lint.bat not returning version info.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
@@ -326,11 +326,11 @@ namespace Xamarin.Android.Tasks
 					sb.AppendLine (e.Data);
 			}
 			);
-			if (result != 0) {
+			var versionInfo = sb.ToString ();
+			if (result != 0 || versionInfo.Contains ("unknown")) {
 				Log.LogWarning ($"Could not get version from '{tool}'");
 				return new Version ();
 			}
-			var versionInfo = sb.ToString ();
 			// lint: version 26.0.2
 			var versionNumberMatch = lintVersionRegex.Match (versionInfo);
 			Version versionNumber;


### PR DESCRIPTION
Turns out lint.bat does not always return a version number. It
returns stuff like

	lint: version unknown
	lint: unknown version

not very helpful. So we need to handle that case and return a
empty verison.