### PR TITLE
[Xamarin.Android.Build.Tasks] Rework AsyncTask to use ConfigureAwait

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -216,7 +216,12 @@ namespace Xamarin.Android.Tasks
 
 			assemblyMap.Load (AssemblyIdentityMapFile);
 
-			ThreadingTasks.Parallel.ForEach (ManifestFiles, () => 0, DoExecute, (obj) => { Complete (); });
+			ThreadingTasks.ParallelOptions options = new ThreadingTasks.ParallelOptions {
+				CancellationToken = Token,
+				TaskScheduler = ThreadingTasks.TaskScheduler.Current,
+			};
+
+			ThreadingTasks.Parallel.ForEach (ManifestFiles, options, () => 0, DoExecute, (obj) => { Complete (); });
 
 			base.Execute ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -239,11 +239,11 @@ namespace Xamarin.Android.Tasks
 
 			var task = ThreadingTasks.Task.Run ( () => {
 				return RunParallelAotCompiler (nativeLibs);
-			});
+			}, Token);
 
 			task.ContinueWith ( (t) => {
 				Complete ();
-			});
+			}).ConfigureAwait (false);
 
 			base.Execute ();
 
@@ -267,6 +267,7 @@ namespace Xamarin.Android.Tasks
 
 				ThreadingTasks.ParallelOptions options = new ThreadingTasks.ParallelOptions {
 					CancellationToken = cts.Token,
+					TaskScheduler = ThreadingTasks.TaskScheduler.Current,
 				};
 
 				ThreadingTasks.Parallel.ForEach (GetAotConfigs (), options,

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
@@ -80,9 +80,14 @@ namespace Xamarin.Android.Tasks
 			if (!imageFiles.Any ())
 				return true;
 
+			ThreadingTasks.ParallelOptions options = new ThreadingTasks.ParallelOptions {
+				CancellationToken = Token,
+				TaskScheduler = ThreadingTasks.TaskScheduler.Current,
+			};
+
 			var imageGroups = imageFiles.GroupBy (x => Path.GetDirectoryName (Path.GetFullPath (x.ItemSpec)));
 
-			ThreadingTasks.Parallel.ForEach (imageGroups, () => 0, DoExecute, (obj) => { Complete (); });
+			ThreadingTasks.Parallel.ForEach (imageGroups, options, () => 0, DoExecute, (obj) => { Complete (); });
 
 			return !Log.HasLoggedErrors;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
@@ -427,11 +427,13 @@ namespace Xamarin.Android.Tasks {
 						}
 					}
 				}
-			}).ContinueWith ((t) => {
-				if (t.Exception != null)
-					Log.LogErrorFromException (t.Exception.GetBaseException ());
+			}, Token).ContinueWith ((t) => {
+				if (t.Exception != null) {
+					var ex = t.Exception.GetBaseException ();
+					LogError (ex.Message + Environment.NewLine + ex.StackTrace);
+				}
 				Complete ();
-			});
+			}).ConfigureAwait (false);
 
 			var result = base.Execute ();
 


### PR DESCRIPTION
We should be using `ConfigureAwait(false)` for our `Task.Run`
calls to ensure that the Continuations do NOT run on the
main thread. This is probably the reason why VS locks up
when we call these methods. The Continuation which calls
`Complete` is trying to run on the UI thread, which will
be locked waiting for the Task to complete.

We should also provide the Cancelation Token and the
TaskScheduler for the `Parallel.ForEach` calls.
