### PR TITLE
Bump to mono/2017-10/56195c0c and remove linker exclusions in corlib tests

### DIFF
--- a/tests/Xamarin.Android.Bcl-Tests/Resources/LinkerDescription.xml
+++ b/tests/Xamarin.Android.Bcl-Tests/Resources/LinkerDescription.xml
@@ -4,59 +4,6 @@
     <type fullname="System.Security.Permissions.UIPermission">
       <method name="System.Security.Permissions.IBuiltInPermission.GetTokenIndex"/>
     </type>
-    <type fullname="System.Reflection.AssemblyProductAttribute">
-      <method name=".ctor"/>
-    </type>
-    <type fullname="System.Reflection.AssemblyCopyrightAttribute">
-      <method name=".ctor"/>
-    </type>
-    <type fullname="System.Reflection.AssemblyTrademarkAttribute">
-      <method name=".ctor"/>
-    </type>
-    <type fullname="System.Reflection.AssemblyVersionAttribute">
-      <method name=".ctor"/>
-    </type>
-    <type fullname="System.Reflection.AssemblyFileVersionAttribute">
-      <method name=".ctor"/>
-    </type>
-    <type fullname="System.Reflection.AssemblyInformationalVersionAttribute">
-      <method name=".ctor"/>
-    </type>
-    <type fullname="System.Reflection.AssemblyCultureAttribute">
-      <method name=".ctor"/>
-    </type>
-    <type fullname="System.Reflection.AssemblyAlgorithmIdAttribute">
-      <method name=".ctor"/>
-    </type>
-    <type fullname="System.Reflection.AssemblyFlagsAttribute">
-      <method name=".ctor"/>
-    </type>
-    <type fullname="System.Reflection.AssemblyDelaySignAttribute">
-      <method name=".ctor"/>
-    </type>
-    <type fullname="System.Reflection.AssemblyKeyNameAttribute">
-      <method name=".ctor"/>
-    </type>
-    <type fullname="System.Reflection.AssemblyKeyFileAttribute">
-      <method name=".ctor"/>
-    </type>
-    <type fullname="System.AttributeUsageAttribute">
-      <method name=".ctor"/>
-      <method name="get_AllowMultiple"/>
-      <method name="set_AllowMultiple"/>
-    </type>
-    <type fullname="System.Runtime.InteropServices.MarshalAsAttribute">
-      <method name=".ctor"/>
-      <field signature="System.Int32 SizeConst"/>
-      <field signature="System.Type MarshalTypeRef"/>
-      <field signature="System.String MarshalCookie"/>
-    </type>
-    <type fullname="System.Runtime.CompilerServices.MethodImplAttribute">
-      <method name=".ctor"/>
-    </type>
-    <type fullname="System.Runtime.InteropServices.DllImportAttribute">
-      <method name=".ctor"/>
-    </type>
     <type fullname="System.Runtime.Remoting.Activation.ActivationServices">
       <method name="CreateProxyForType"/>
     </type>


### PR DESCRIPTION
I added tests for the *Attributes which were linked away in https://github.com/mono/mono/commit/5a5ab38c9e39c64b23b2071c195400b743a38455 so we should be able to remove the linker exclusions now.