### PR TITLE
Don't optimize URL encoding

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -207,9 +207,6 @@ namespace Xamarin.Android.Net
 			if (url == null)
 				return String.Empty;
 
-			if (String.IsNullOrEmpty (url.Query))
-				return Uri.EscapeUriString (url.ToString ());
-
 			// UriBuilder takes care of encoding everything properly
 			var bldr = new UriBuilder (url);
 			if (url.IsDefaultPort)


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=60473

In the case when the URL doesn't contain any query elements we
optimized for speed and memory by not using UrlBuilder to do the
encoding work on the URL. However, it causes problems with URLs
that are sent pre-encoded.

Remove the optimization and rely on UrlBuilder in all cases.