### PR TITLE
[Xamarin.Android.ProjectTools] Fix logic error in native crash detection.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -281,7 +281,7 @@ namespace Xamarin.ProjectTools
 				sb.AppendFormat ("\n#stderr begin\n{0}\n#stderr end\n", p.StandardError.ReadToEnd ());
 
 				LastBuildOutput = sb.ToString ();
-				if (!nativeCrashDetected) {
+				if (nativeCrashDetected) {
 					Console.WriteLine ($"Native crash detected! Running the build for {projectOrSolution} again.");
 					continue;
 				}


### PR DESCRIPTION
Commit 855ad009 added logic to detect if a test had a native crash and to
retry the test. There was a flaw in the logic such that it would
run every test twice...

This fixes that.