### PR TITLE
[Xamarin.Android.Build.Tasks] ApkSigner Failed if minsdk > maxSdk

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
@@ -56,6 +56,7 @@ namespace Xamarin.Android.Tasks
 			if (manifest.TargetSdkVersion.HasValue)
 				maxSdk = manifest.TargetSdkVersion.Value;
 
+			minSdk = Math.Min (minSdk, maxSdk);
 			cmd.AppendSwitch ("sign");
 			cmd.AppendSwitchIfNotNull ("--ks ", KeyStore);
 			cmd.AppendSwitchIfNotNull ("--ks-pass pass:", StorePass);


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=60444

We should NOT ever pass a minSdk value that is greater than
the maxSdk. It results in the following error

	Min API Level (10) > max API Level (8)

So we should check the values and use the minimum value
for the minSdk.