### PR TITLE
[tests] Fix issue in ProjectBuilder.Cleanup

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -102,9 +102,11 @@ namespace Xamarin.ProjectTools
 			if (!last_build_result)
 				return;
 			built_before = false;
-			if (Directory.Exists (ProjectDirectory)) {
-				FileSystemUtils.SetDirectoryWriteable (ProjectDirectory);
-				Directory.Delete (ProjectDirectory, true);
+
+			var projectDirectory = Path.Combine (Root, ProjectDirectory);
+			if (Directory.Exists (projectDirectory)) {
+				FileSystemUtils.SetDirectoryWriteable (projectDirectory);
+				Directory.Delete (projectDirectory, true);
 			}
 		}
 


### PR DESCRIPTION
This method was not using the full path to the project directory, and so
it wasn't actually deleting anything. This caused test failures on
Windows in tests such as `ManifestTest.Bug12935`. This particular test
was modifying the contents of `AndroidManifest.xml`, and checking the
results of the build afterward. Since the project files were not
deleted, changes to the `AndroidManifest.xml` were not getting written
to disk during the test.