### PR TITLE
[Xamarin.Android.Build.Tasks] Aapt MSBuild Task treats no default translation warnings as MSBuild errors

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -365,7 +365,7 @@ namespace Xamarin.Android.Tasks
 				if (!string.IsNullOrEmpty (match.Groups["line"]?.Value))
 					line = int.Parse (match.Groups["line"].Value) + 1;
 				var error = match.Groups["message"].Value;
-				if (error.Contains ("warning")) {
+				if (error.Contains ("warning") || singleLine.Contains ("warning")) {
 					LogWarning (singleLine);
 					return;
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -360,12 +360,6 @@ namespace Xamarin.Android.Tasks
 			var match = AndroidToolTask.AndroidErrorRegex.Match (singleLine.Trim ());
 
 			if (match.Success) {
-				Console.WriteLine ($"\t   path: '{match.Groups ["path"].Value}'");
-				Console.WriteLine ($"\t   file: '{match.Groups ["file"].Value}'");
-				Console.WriteLine ($"\t   line: '{match.Groups ["line"].Value}'");
-				Console.WriteLine ($"\t  level: '{match.Groups ["level"].Value}'");
-				Console.WriteLine ($"\tmessage: '{match.Groups ["message"].Value}'");
-
 				var file = match.Groups["file"].Value;
 				int line = 0;
 				if (!string.IsNullOrEmpty (match.Groups["line"]?.Value))

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -360,12 +360,19 @@ namespace Xamarin.Android.Tasks
 			var match = AndroidToolTask.AndroidErrorRegex.Match (singleLine.Trim ());
 
 			if (match.Success) {
+				Console.WriteLine ($"\t   path: '{match.Groups ["path"].Value}'");
+				Console.WriteLine ($"\t   file: '{match.Groups ["file"].Value}'");
+				Console.WriteLine ($"\t   line: '{match.Groups ["line"].Value}'");
+				Console.WriteLine ($"\t  level: '{match.Groups ["level"].Value}'");
+				Console.WriteLine ($"\tmessage: '{match.Groups ["message"].Value}'");
+
 				var file = match.Groups["file"].Value;
 				int line = 0;
 				if (!string.IsNullOrEmpty (match.Groups["line"]?.Value))
 					line = int.Parse (match.Groups["line"].Value) + 1;
-				var error = match.Groups["message"].Value;
-				if (error.Contains ("warning") || singleLine.Contains ("warning")) {
+				var level = match.Groups["level"].Value;
+				var message = match.Groups ["message"].Value;
+				if (level.Contains ("warning")) {
 					LogWarning (singleLine);
 					return;
 				}
@@ -379,10 +386,10 @@ namespace Xamarin.Android.Tasks
 				}
 
 				// Strip any "Error:" text from aapt's output
-				if (error.StartsWith ("error: ", StringComparison.InvariantCultureIgnoreCase))
-					error = error.Substring ("error: ".Length);
+				if (message.StartsWith ("error: ", StringComparison.InvariantCultureIgnoreCase))
+					message = message.Substring ("error: ".Length);
 
-				LogError ("APT0000", error, file, line);
+				LogError ("APT0000", message, file, line);
 				return;
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidToolTask.cs
@@ -83,7 +83,29 @@ namespace Xamarin.Android.Tasks
 		internal static Regex AndroidErrorRegex {
 			get {
 				if (androidErrorRegex == null)
-					androidErrorRegex = new Regex (@"^(?<file>.+?)([:(](?<line>\d+)[:)])?:+\s*((error)\s*(?<level>\w*(?=:)):?)?(?<message>.*)", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+					androidErrorRegex = new Regex (@"
+^
+( # start optional path followed by `:`
+ (?<path>
+  (?<file>.+[\\/][^:\(]+)
+  (
+   ([:](?<line>\d+))
+   |
+   (\((?<line>\d+)\))
+  )?
+ )
+ \s*
+ :
+)?
+( # optional warning|error:
+ \s*
+ (?<level>(warning|error)[^:]*)\s*
+ :
+)?
+\s*
+(?<message>.*)
+$
+", RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.IgnorePatternWhitespace);
 				return androidErrorRegex;
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidToolTask.cs
@@ -80,7 +80,7 @@ namespace Xamarin.Android.Tasks
 		//   res/drawable/foo-bar.jpg: Invalid file name: must contain only [a-z0-9_.]
 		// Look for them and convert them to MSBuild compatible errors.
 		static Regex androidErrorRegex;
-		internal static Regex AndroidErrorRegex {
+		public static Regex AndroidErrorRegex {
 			get {
 				if (androidErrorRegex == null)
 					androidErrorRegex = new Regex (@"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidRegExTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidRegExTests.cs
@@ -1,10 +1,78 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+
 namespace Xamarin.Android.Build.Tests
 {
 	public class AndroidRegExTests
 	{
-		public AndroidRegExTests ()
+
+
+		/*
+"Resources/values/theme.xml(2): error APT0000: Error retrieving parent for item: No resource found that matches the given name '@android:style/Theme.AppCompat'." \
+  "Resources/values/theme.xml:2: error APT0000: Error retrieving parent for item: No resource found that matches the given name '@android:style/Theme.AppCompat'." \
+  "res/drawable/foo-bar.jpg: Invalid file name: must contain only [a-z0-9_.]"
+
+		*/
+		class AndroidRegExTestsCases : IEnumerable {
+			public IEnumerator GetEnumerator ()
+			{
+				yield return new object [] {
+					/*message*/		"warning: string 'app_name1' has no default translation.",
+					/*expectedToMatch*/	true,
+					/*expectedFile*/	"",
+					/*expectedLine*/	"",
+					/*expectedLevel*/	"warning",
+					/*expectedMessage*/	"string 'app_name1' has no default translation."
+				};
+				yield return new object [] {
+					/*message*/		"res\\layout\\main.axml: error: No resource identifier found for attribute \"id2\" in package \"android\" (TaskId:22)",
+					/*expectedToMatch*/	true,
+					/*expectedFile*/	"res\\layout\\main.axml",
+					/*expectedLine*/	"",
+					/*expectedLevel*/	"error",
+					/*expectedMessage*/	"No resource identifier found for attribute \"id2\" in package \"android\" (TaskId:22)"
+				};
+				yield return new object [] {
+					/*message*/		"Resources/values/theme.xml(2): error APT0000: Error retrieving parent for item: No resource found that matches the given name '@android:style/Theme.AppCompat'.",
+					/*expectedToMatch*/	true,
+					/*expectedFile*/	"Resources/values/theme.xml",
+					/*expectedLine*/	"2",
+					/*expectedLevel*/	"error APT0000",
+					/*expectedMessage*/	"Error retrieving parent for item: No resource found that matches the given name '@android:style/Theme.AppCompat'."
+				};
+				yield return new object [] {
+					/*message*/		"Resources/values/theme.xml:2: error APT0000: Error retrieving parent for item: No resource found that matches the given name '@android:style/Theme.AppCompat'.",
+					/*expectedToMatch*/	true,
+					/*expectedFile*/	"Resources/values/theme.xml",
+					/*expectedLine*/	"2",
+					/*expectedLevel*/	"error APT0000",
+					/*expectedMessage*/	"Error retrieving parent for item: No resource found that matches the given name '@android:style/Theme.AppCompat'."
+				};
+				yield return new object [] {
+					/*message*/		"res/drawable/foo-bar.jpg: Invalid file name: must contain only [a-z0-9_.]",
+					/*expectedToMatch*/	true,
+					/*expectedFile*/	"res/drawable/foo-bar.jpg",
+					/*expectedLine*/	"",
+					/*expectedLevel*/	"",
+					/*expectedMessage*/	"Invalid file name: must contain only [a-z0-9_.]"
+				};
+
+			}
+		}
+
+		[Test]
+		[TestCaseSource(typeof (AndroidRegExTestsCases))]
+		public void RegExTests(string message, bool expectedToMatch, string expectedFile, string expectedLine, string expectedLevel, string expextedMessage)
 		{
+			var regex = Xamarin.Android.Tasks.AndroidToolTask.AndroidErrorRegex;
+			var result = regex.Match (message);
+			Assert.AreEqual (expectedToMatch,result.Success);
+			Assert.AreEqual (expectedFile, result.Groups["file"].Value);
+			Assert.AreEqual (expectedLine.ToString (), result.Groups ["line"].Value);
+			Assert.AreEqual (expectedLevel, result.Groups ["level"].Value);
+			Assert.AreEqual (expextedMessage, result.Groups ["message"].Value);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidRegExTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidRegExTests.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace Xamarin.Android.Build.Tests
+{
+	public class AndroidRegExTests
+	{
+		public AndroidRegExTests ()
+		{
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1083,5 +1083,22 @@ namespace Lib1 {
 				}
 			}
 		}
+
+		[Test]
+		public void CheckDefaultTranslationWarnings ()
+		{
+			var path = Path.Combine ("temp", TestName);
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				OtherBuildItems = {
+					new BuildItem.Folder ("Resources\\values-fr\\") {
+					},
+				},
+			};
+			using (var builder = CreateApkBuilder (path, false, false)) {
+				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
+				StringAssert.Contains ("has no default translation", builder.LastBuildOutput, "Build output should contain a warning about 'no default translation'");
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1095,6 +1095,13 @@ namespace Lib1 {
 					},
 				},
 			};
+
+			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values-fr\\Strings.xml") {
+				TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
+<resources>
+  <string name=""test"" >Test</string>
+</resources>",
+			});
 			using (var builder = CreateApkBuilder (path, false, false)) {
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
 				StringAssert.Contains ("has no default translation", builder.LastBuildOutput, "Build output should contain a warning about 'no default translation'");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -38,6 +38,12 @@
     <Reference Include="nunit.framework">
       <HintPath>..\..\..\..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="Xamarin.Android.Build.Tasks">
+      <HintPath>$(OutputPath)..\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Build.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Build.Engine" />
+    <Reference Include="Microsoft.Build.Tasks.v4.0" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -49,10 +55,6 @@
       <Project>{E248B2CA-303B-4645-ADDC-9D4459D550FD}</Project>
       <Name>libZipSharp</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\Xamarin.Android.Build.Tasks.csproj">
-      <Project>{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}</Project>
-      <Name>Xamarin.Android.Build.Tasks</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -63,5 +65,6 @@
   <ItemGroup>
     <Compile Include="BuildTest.OSS.cs" />
     <Compile Include="ManifestTest.OSS.cs" />
+    <Compile Include="AndroidRegExTests.cs" />
   </ItemGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -49,6 +49,10 @@
       <Project>{E248B2CA-303B-4645-ADDC-9D4459D550FD}</Project>
       <Name>libZipSharp</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\Xamarin.Android.Build.Tasks.csproj">
+      <Project>{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}</Project>
+      <Name>Xamarin.Android.Build.Tasks</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -38,9 +38,11 @@
     <Reference Include="nunit.framework">
       <HintPath>..\..\..\..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.Android.Build.Tasks">
+    <!-- Because Xamarin.Android.Build.Tasks.csproj doesn't build in VsForMac :(
+    <Reference Include="Xamarin.Android.Build.Tasks" Condition="Exists('$(OutputPath)..\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Build.Tasks.dll')">
       <HintPath>$(OutputPath)..\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Build.Tasks.dll</HintPath>
     </Reference>
+    -->
     <Reference Include="Microsoft.Build.Engine" />
     <Reference Include="Microsoft.Build.Tasks.v4.0" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
@@ -54,6 +56,10 @@
     <ProjectReference Include="..\..\..\..\external\LibZipSharp\libZipSharp.csproj">
       <Project>{E248B2CA-303B-4645-ADDC-9D4459D550FD}</Project>
       <Name>libZipSharp</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Xamarin.Android.Build.Tasks.csproj">
+      <Project>{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}</Project>
+      <Name>Xamarin.Android.Build.Tasks</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildActions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildActions.cs
@@ -15,5 +15,6 @@ namespace Xamarin.ProjectTools
 		public const string Compile = "Compile";
 		public const string EmbeddedResource = "EmbeddedResource";
 		public const string Content = "Content";
+		public const string Folder = "Folder";
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildItem.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildItem.cs
@@ -34,6 +34,18 @@ namespace Xamarin.ProjectTools
 			}
 		}
 
+		public class Folder : BuildItem
+		{
+			public Folder (string include)
+				: this (() => include)
+			{
+			}
+			public Folder (Func<string> include)
+				: base (BuildActions.Folder, include)
+			{
+			}
+		}
+
 		public class Content : BuildItem
 		{
 			public Content (string include)


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=60445

The regex is picking up the warning in

	warning: string 'app_name1' has no default translation.

but the "warning" part is being picked up by the very first
capture group so the current code does not detect its a warning.
So in addition to checking the capture group, we should look at
the entire line and check for "warning"