### PR TITLE
[tests] Measure end time of NUnit tests

### DIFF
--- a/build-tools/scripts/TimingDefinitions.txt
+++ b/build-tools/scripts/TimingDefinitions.txt
@@ -4,3 +4,4 @@ last=monodroid-timing:\s+(?<message>.*)$
 # measure time of runtime and JNIEnv initialization end
 init=monodroid-timing:\s+(?<message>Runtime\.init: end native-to-managed.*)$
 JNI.init=monodroid-timing:\s+(?<message>JNIEnv\.Initialize end:.*)$
+NUnit.results=NUnitLite: Passed:


### PR DESCRIPTION
Added NUnit.results label to the default time performance definition
file. It matches NUnit line with results, which is printed out at the
end of the NUnit driven test.