### PR TITLE
[WIP] idea to speed up Xamarin.Android.Build.Tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -165,9 +165,10 @@ using System.Runtime.CompilerServices;
 				var oldpath = image.Include ().Replace ('\\', Path.DirectorySeparatorChar);
 				image.Include = () => "Resources/drawable/NewImage.png";
 				image.Timestamp = DateTimeOffset.UtcNow.AddMinutes (1);
+				b.AssertTargetIsBuilt ("_Sign");
 				Assert.IsTrue (b.Build (proj), "Second build should have succeeded.");
+				AssertBuild (b);
 				Assert.IsFalse (File.Exists (Path.Combine (b.ProjectDirectory, oldpath)), "XamarinProject.UpdateProjectFiles() failed to delete file");
-				Assert.IsFalse (b.Output.IsTargetSkipped ("_Sign"), "incorrectly skipped some build");
 			}
 		}
 
@@ -178,8 +179,9 @@ using System.Runtime.CompilerServices;
 			proj.LayoutMain = @"<root/>\n" + proj.LayoutMain;
 			using (var b = CreateApkBuilder ("temp/ErroneousResource")) {
 				b.ThrowOnBuildFailure = false;
+				b.Assertions.Add (new Assertion (o => o.Contains (string.Format ("Resources{0}layout{0}Main.axml", Path.DirectorySeparatorChar)) && o.Contains (": error "), "error with expected file name is not found"));
 				Assert.IsFalse (b.Build (proj), "Build should have failed.");
-				Assert.IsTrue (b.LastBuildOutput.Split ('\n').Any (s => s.Contains (string.Format ("Resources{0}layout{0}Main.axml", Path.DirectorySeparatorChar)) && s.Contains (": error ")), "error with expected file name is not found");
+				AssertBuild (b);
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -204,27 +204,18 @@ using System.Runtime.CompilerServices;
 				b.ThrowOnBuildFailure = false;
 				Assert.IsTrue (b.Build (proj), "First build was supposed to build without errors");
 				var firstBuildTime = b.LastBuildTime;
+				b.AssertTargetSkipped ("_GenerateAndroidResourceDir");
+				b.AssertTargetSkipped ("_CompileJava");
 				Assert.IsTrue (b.Build (proj), "Second build was supposed to build without errors");
+				AssertBuild (b);
 				Assert.IsTrue (firstBuildTime > b.LastBuildTime, "Second build was supposed to be quicker than the first");
-				Assert.IsTrue (
-					b.Output.IsTargetSkipped ("_GenerateAndroidResourceDir"),
-					"The Target _GenerateAndroidResourceDir should have been skipped");
-				Assert.IsTrue (
-					b.Output.IsTargetSkipped ("_CompileJava"),
-					"The Target _CompileJava should have been skipped");
 				image1.Timestamp = DateTime.UtcNow;
 				var layout = proj.AndroidResources.First (x => x.Include() == "Resources\\layout\\Main.axml");
 				layout.Timestamp = DateTime.UtcNow;
+				b.AssertTargetIsBuilt ("_GenerateAndroidResourceDir");
+				b.AssertTargetSkipped ("_CompileJava");
+				b.AssertTargetIsBuilt ("_CreateBaseApk");
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate:true, saveProject: false), "Third build was supposed to build without errors");
-				Assert.IsFalse (
-					b.Output.IsTargetSkipped ("_GenerateAndroidResourceDir"),
-					"The Target _GenerateAndroidResourceDir should not have been skipped");
-				Assert.IsTrue (
-					b.Output.IsTargetSkipped ("_CompileJava"),
-					"The Target _CompileJava (2) should have been skipped");
-				Assert.IsFalse (
-					b.Output.IsTargetSkipped ("_CreateBaseApk"),
-					"The Target _CreateBaseApk should not have been skipped");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -500,21 +500,21 @@ namespace UnnamedProject
 			proj.SetProperty ("TargetFrameworkVersion", "v5.0");
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				b.Verbosity = LoggerVerbosity.Diagnostic;
+				b.AssertTargetIsBuilt ("_GenerateJavaDesignerForComponent");
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				StringAssert.DoesNotContain ("Skipping target \"_GenerateJavaDesignerForComponent\" because",
-					b.LastBuildOutput, "Target _GenerateJavaDesignerForComponent should not have been skipped");
+				AssertBuild (b);
+				b.AssertAllTargetsSkipped ("_GenerateJavaDesignerForComponent");
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				StringAssert.Contains ("Skipping target \"_GenerateJavaDesignerForComponent\" because",
-					b.LastBuildOutput, "Target _GenerateJavaDesignerForComponent should have been skipped");
+				AssertBuild (b);
 				var files = Directory.EnumerateFiles (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "resourcecache")
 					, "abc_fade_in.xml", SearchOption.AllDirectories);
 				Assert.AreEqual (1, files.Count (), "There should only be one abc_fade_in.xml in the resourcecache");
 				var resFile = files.First ();
 				Assert.IsTrue (File.Exists (resFile), "{0} should exist", resFile);
 				File.SetLastWriteTime (resFile, DateTime.UtcNow);
+				b.AssertTargetIsBuilt ("_GenerateJavaDesignerForComponent");
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				StringAssert.DoesNotContain ("Skipping target \"_GenerateJavaDesignerForComponent\" because",
-					b.LastBuildOutput, "Target _GenerateJavaDesignerForComponent should not have been skipped");
+				AssertBuild (b);
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -177,6 +177,15 @@ namespace Xamarin.Android.Build.Tests
 			return BuildHelper.CreateDllBuilder (directory, cleanupAfterSuccessfulBuild, cleanupOnDispose);
 		}
 
+		protected void AssertBuild(ProjectBuilder builder)
+		{
+			foreach (var assertion in builder.Assertions) {
+				if (!assertion.Passed) {
+					Assert.Fail (assertion.ToString ());
+				}
+			}
+		}
+
 		[OneTimeSetUp]
 		public void FixtureSetup ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -184,6 +184,7 @@ namespace Xamarin.Android.Build.Tests
 					Assert.Fail (assertion.ToString ());
 				}
 			}
+			builder.Assertions.Clear ();
 		}
 
 		protected void AssertBuildDidNotPass (ProjectBuilder builder)
@@ -193,6 +194,7 @@ namespace Xamarin.Android.Build.Tests
 					Assert.Fail (assertion.ToString ());
 				}
 			}
+			builder.Assertions.Clear ();
 		}
 
 		[OneTimeSetUp]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -186,6 +186,15 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
+		protected void AssertBuildDidNotPass (ProjectBuilder builder)
+		{
+			foreach (var assertion in builder.Assertions) {
+				if (assertion.Passed) {
+					Assert.Fail (assertion.ToString ());
+				}
+			}
+		}
+
 		[OneTimeSetUp]
 		public void FixtureSetup ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -224,8 +224,17 @@ namespace Xamarin.Android.Build.Tests
 				return;
 			if (TestContext.CurrentContext.Result.Outcome.Status == NUnit.Framework.Interfaces.TestStatus.Passed || 
 			    TestContext.CurrentContext.Result.Outcome.Status == NUnit.Framework.Interfaces.TestStatus.Skipped) {
-				FileSystemUtils.SetDirectoryWriteable (output);
-				Directory.Delete (output, recursive: true);
+
+				do {
+					try {
+						FileSystemUtils.SetDirectoryWriteable (output);
+						Directory.Delete (output, recursive: true);
+						break;
+					} catch (IOException) {
+						//NOTE: seems to happen quite a bit on Windows
+						Thread.Sleep (25);
+					}
+				} while (true);
 			} else {
 				foreach (var file in Directory.GetFiles (Path.Combine (output), "build.log", SearchOption.AllDirectories)) {
 					TestContext.Out.WriteLine ("*************************************************************************");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Assertion.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Assertion.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Linq.Expressions;
+
+namespace Xamarin.ProjectTools
+{
+	public class Assertion
+	{
+		readonly Expression<Func<string, bool>> expression;
+		Func<string, bool> func;
+
+		public bool Passed { get; private set; }
+
+		public Assertion (Expression<Func<string, bool>> expression)
+		{
+			this.expression = expression;
+		}
+
+		public void Assert(string line)
+		{
+			if (!Passed) {
+				if (func == null)
+					func = expression.Compile ();
+				Passed = func (line);
+			}
+		}
+
+		public override string ToString ()
+		{
+			return expression.Body.ToString ();
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Assertion.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Assertion.cs
@@ -3,6 +3,9 @@ using System.Linq.Expressions;
 
 namespace Xamarin.ProjectTools
 {
+	/// <summary>
+	/// Represents an "assertion" that a condition is true as the build output streams through a callback
+	/// </summary>
 	public class Assertion
 	{
 		readonly Expression<Func<string, bool>> expression;
@@ -10,9 +13,12 @@ namespace Xamarin.ProjectTools
 
 		public bool Passed { get; private set; }
 
-		public Assertion (Expression<Func<string, bool>> expression)
+		public string Message { get; private set; }
+
+		public Assertion (Expression<Func<string, bool>> expression, string message = null)
 		{
 			this.expression = expression;
+			Message = message;
 		}
 
 		public void Assert(string line)
@@ -26,7 +32,10 @@ namespace Xamarin.ProjectTools
 
 		public override string ToString ()
 		{
-			return expression.Body.ToString ();
+			if (!string.IsNullOrEmpty (Message))
+				return Message;
+
+			return $"Expression was false: {expression.Body}";
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
@@ -44,30 +44,10 @@ namespace Xamarin.ProjectTools
 			return File.ReadAllText (GetIntermediaryPath (file));
 		}
 
-		public bool IsTargetSkipped (string target)
+		//TODO: remove
+		public bool IsTargetSkipped (string a)
 		{
-			if (!Builder.LastBuildOutput.Contains (target))
-				throw new ArgumentException (string.Format ("Target '{0}' is not even in the build output.", target));
-			return Builder.LastBuildOutput.Contains (string.Format ("Target {0} skipped due to ", target))
-					|| Builder.LastBuildOutput.Contains (string.Format ("Skipping target \"{0}\" because it has no outputs.", target))
-					|| Builder.LastBuildOutput.Contains (string.Format ("Target \"{0}\" skipped, due to", target))
-					|| Builder.LastBuildOutput.Contains (string.Format ("Skipping target \"{0}\" because its outputs are up-to-date", target))
-					|| Builder.LastBuildOutput.Contains (string.Format ("target {0}, skipping", target))
-					|| Builder.LastBuildOutput.Contains ($"Skipping target \"{target}\" because all output files are up-to-date");
-		}
-
-		public bool IsApkInstalled {
-			get { return Builder.LastBuildOutput.Contains (" pm install "); }
-		}
-
-		public bool AreTargetsAllSkipped (params string [] targets)
-		{
-			return targets.All (t => IsTargetSkipped (t));
-		}
-
-		public bool AreTargetsAllBuilt (params string [] targets)
-		{
-			return targets.All (t => !IsTargetSkipped (t));
+			throw new NotImplementedException ();
 		}
 	}
 	

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -40,6 +40,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Common\Assertion.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Common\BuildActions.cs" />
     <Compile Include="Common\BuildItem.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -40,8 +40,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Common\Assertion.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Common\Assertion.cs" />
     <Compile Include="Common\BuildActions.cs" />
     <Compile Include="Common\BuildItem.cs" />
     <Compile Include="Common\Package.cs" />


### PR DESCRIPTION
I wanted to send this in to discuss next week.

### The current situation
Currently the Xamarin.Android.Build.Tests are doing the [following](https://github.com/xamarin/xamarin-android/blob/master/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs#L184):
- Running msbuild w/ verbose logging to file and `/noconsolelogger`
- Combining stdout and stderror into a large string named `LastBuildOutput`
- Many tests are asserting against the text in `LastBuildOutput`
- There is also some code that opens the log file on disk to find the MSBuild build duration

So a couple issues from this:
- We use a lot of memory here, with potentially enormous strings, some of it is duplicated strings
- Asserting against `LastBuildOutput` is doing a `string.Contains` on potentially massive strings
- The test `BuildAMassiveApp` always fails on Windows with `OutOfMemoryException`
- On Windows, our `Process.Start/WaitForExit` implementation can hang. If the stdout or stderror buffer gets full, when `WaitForExit` hangs with the 10 minute timeout. I see this happening mostly if a test fails (because the output is bigger). Link about this [here](https://stackoverflow.com/questions/139593/processstartinfo-hanging-on-waitforexit-why).

I'm sure this code evolved over time--it probably wasn't planned to be implemented this way.

### An idea
The "idea" is we could instead:
- Run msbuild with verbose logging to the console (not to file at all)
- Use the `OutputDataReceived` and `ErrorDataReceived` events to assert against MSBuild output as it streams through
- Append this output to a file for failures later if needed

The problem with doing this, is you would have to setup assertions before running the build. Then checking if they all passed after the build. This is a bit confusing, and a juxtaposition of the Arrange, Act, Assert pattern people think about when writing tests.

### The initial results

I did a quick implementation of this idea, and compared the results of the following test class with 44 tests (on Mac):
```
make run-nunit-tests TEST=Xamarin.Android.Build.Tests.AndroidUpdateResourcesTest
```

The results on master:
```
Test Run Summary
  Overall result: Warning
  Test Count: 44, Passed: 35, Failed: 0, Warnings: 0, Inconclusive: 0, Skipped: 9
    Skipped Tests - Ignored: 9, Explicit: 0, Other: 0
  Start time: 2017-11-03 16:46:54Z
    End time: 2017-11-03 16:54:49Z
    Duration: 474.909 seconds
```

The results with this PR:
```
Test Run Summary
  Overall result: Failed
  Test Count: 44, Passed: 30, Failed: 5, Warnings: 0, Inconclusive: 0, Skipped: 9
    Failed Tests - Failures: 5, Errors: 0, Invalid: 0
    Skipped Tests - Ignored: 9, Explicit: 0, Other: 0
  Start time: 2017-11-03 20:04:41Z
    End time: 2017-11-03 20:11:00Z
    Duration: 379.545 seconds
```
There are still some failures I'll look into fixing here. These failures seemed to be running the full test (they aren't failing and taking less than <10ms that would influence the shorter time).

This boils down to maybe a 20% speed increase of these tests. These tests are currently taking about 1 hour on Jenkins PRs.

### Drawbacks

This seems like a decent amount of work--and the not very fun kind. It also seems scary that we could mistakenly change a test to make it always pass.

Investing in this, while it would improve quality & build times, doesn't bring new features to Xamarin.Android.