### PR TITLE
[xabuild.exe] fix for .NET standard projects

### DIFF
--- a/tools/xabuild/XABuild.cs
+++ b/tools/xabuild/XABuild.cs
@@ -103,6 +103,7 @@ namespace Xamarin.Android.Build
 
 			xml.Save (paths.XABuildConfig);
 
+			Environment.SetEnvironmentVariable ("MSBuildSDKsPath", paths.MSBuildSdksPath, EnvironmentVariableTarget.Process);
 			Environment.SetEnvironmentVariable ("MSBUILD_EXE_PATH", paths.MSBuildExeTempPath, EnvironmentVariableTarget.Process);
 			return xml;
 		}

--- a/tools/xabuild/XABuildPaths.cs
+++ b/tools/xabuild/XABuildPaths.cs
@@ -67,6 +67,11 @@ namespace Xamarin.Android.Build
 		public string MSBuildExtensionsPath { get; private set; }
 
 		/// <summary>
+		/// Used as the MSBuildSDKsPath environment variable, required for .NET standard projects to build
+		/// </summary>
+		public string MSBuildSdksPath { get; private set; }
+
+		/// <summary>
 		/// Array of search paths for MSBuildExtensionsPath
 		/// </summary>
 		public string [] ProjectImportSearchPaths { get; private set; }
@@ -113,6 +118,7 @@ namespace Xamarin.Android.Build
 				MSBuildPath              = Path.Combine (VsInstallRoot, "MSBuild");
 				MSBuildBin               = Path.Combine (MSBuildPath, "15.0", "Bin");
 				MSBuildConfig            = Path.Combine (MSBuildBin, "MSBuild.exe.config");
+				MSBuildSdksPath          = Path.Combine (MSBuildPath, "Sdks");
 				ProjectImportSearchPaths = new [] { MSBuildPath, "$(MSBuildProgramFiles32)\\MSBuild" };
 				SystemProfiles           = Path.Combine (programFiles, "Reference Assemblies", "Microsoft", "Framework");
 				SearchPathsOS            = "windows";
@@ -122,6 +128,7 @@ namespace Xamarin.Android.Build
 				MSBuildPath              = Path.Combine (mono, "msbuild");
 				MSBuildBin               = Path.Combine (MSBuildPath, "15.0", "bin");
 				MSBuildConfig            = Path.Combine (MSBuildBin, "MSBuild.dll.config");
+				MSBuildSdksPath          = "/usr/local/share/dotnet/sdk/2.0.0/Sdks";
 				ProjectImportSearchPaths = new [] { MSBuildPath, Path.Combine (mono, "xbuild"), Path.Combine (monoExternal, "xbuild") };
 				SystemProfiles           = Path.Combine (mono, "xbuild-frameworks");
 				SearchPathsOS            = IsMacOS ? "osx" : "unix";


### PR DESCRIPTION
Context: https://github.com/Microsoft/msbuild/blob/master/src/Shared/BuildEnvironmentHelper.cs#L511

`xabuild.exe` did not support building .NET standard projects. It turns
out a `MSBuildSDKPaths` environment variable needed to be set for locating
the `Sdks` directory. On Windows, this path is relative to Visual Studio /
MSBuild, but on Mac I had to hardcode the path to .NET Core. It seems to
use the same path on Linux as well.