### PR TITLE
[Xamarin.Android.Project.Tools] Fix the Xamarin.ProjectTools so it compiles in VSForMac

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.Darwin.projitems
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.Darwin.projitems
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Content Include="$(XAInstallPrefix)xbuild\Xamarin\Android\libzip.3.0.dylib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\build-tools\libzip\libzip.mdproj">
+      <Project>{900A0F71-BAAD-417A-8D1A-8D330297CDD0}</Project>
+      <Name>libzip</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.Linux.projitems
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.Linux.projitems
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Content Include="$(XAInstallPrefix)xbuild\Xamarin\Android\libzip.so">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.Windows.projitems
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.Windows.projitems
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\build-tools\libzip-windows\libzip-windows.mdproj">
+      <Project>{0DE278D6-000F-4001-BB98-187C0AF58A61}</Project>
+      <Name>libzip-windows</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -136,16 +136,6 @@
   <ItemGroup>
     <None Include="packages.config" />
     <Content
-        Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))"
-        Include="$(XAInstallPrefix)xbuild\Xamarin\Android\libzip.3.0.dylib">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content
-        Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:')) And '$(_LinuxBuildLibZip)' == 'True' "
-        Include="$(XAInstallPrefix)xbuild\Xamarin\Android\libzip.so">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content
         Include="..\..\..\..\.nuget\NuGet.exe">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -155,22 +145,13 @@
       <Project>{E248B2CA-303B-4645-ADDC-9D4459D550FD}</Project>
       <Name>libZipSharp</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\..\build-tools\libzip\libzip.mdproj"
-        Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">
-      <Project>{900A0F71-BAAD-417A-8D1A-8D330297CDD0}</Project>
-      <Name>libzip</Name>
-      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\..\build-tools\libzip-windows\libzip-windows.mdproj"
-        Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
-      <Project>{0DE278D6-000F-4001-BB98-187C0AF58A61}</Project>
-      <Name>libzip-windows</Name>
-      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-    </ProjectReference>
     <ProjectReference Include="..\..\..\..\external\xamarin-android-tools\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj">
       <Project>{E34BCFA0-CAA4-412C-AA1C-75DB8D67D157}</Project>
       <Name>Xamarin.Android.Tools.AndroidSdk</Name>
     </ProjectReference>
   </ItemGroup>
+  <Import Project="$(MSBuildThisFileDirectory)\Xamarin.ProjectTools.Darwin.projitems" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))" />
+  <Import Project="$(MSBuildThisFileDirectory)\Xamarin.ProjectTools.Linux.projitems" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:')) And '$(_LinuxBuildLibZip)' == 'True' " />
+  <Import Project="$(MSBuildThisFileDirectory)\Xamarin.ProjectTools.Windows.projitems" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Context https://bugzilla.xamarin.com/show_bug.cgi?id=58994

There is a bug in VSForMac which does not like Conditionals on things
like `Content` or `ProjectReference`. This commit moves those itms
into `projitems` files which then allows us to use the `Import`
with the required Conditional. This works around the issue.