### PR TITLE
[Xamarin.ProjectTools] Allow msbuild tests to run against system x-a.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -40,6 +40,7 @@ namespace Xamarin.ProjectTools
 
 		public string XABuildExe {
 			get {
+				string xabuild;
 				if (IsUnix) {
 					RunningMSBuild = true;
 					var useMSBuild = Environment.GetEnvironmentVariable ("USE_MSBUILD");
@@ -47,23 +48,26 @@ namespace Xamarin.ProjectTools
 						RunningMSBuild = false;
 					}
 					#if DEBUG
-					var xabuild = Path.GetFullPath (Path.Combine (Root, "..", "Debug", "bin", "xabuild"));
+					xabuild = Path.GetFullPath (Path.Combine (Root, "..", "Debug", "bin", "xabuild"));
 					#else
-					var xabuild = Path.GetFullPath (Path.Combine (Root, "..", "Release", "bin", "xabuild"));
+					xabuild = Path.GetFullPath (Path.Combine (Root, "..", "Release", "bin", "xabuild"));
 					#endif
 					if (File.Exists (xabuild))
 						return xabuild;
 					xabuild = Path.GetFullPath (Path.Combine (Root, "..", "..", "..", "..", "..", "..", "..", "out", "bin", "xabuild"));
 					if (File.Exists (xabuild))
 						return xabuild;
-					return Path.GetFullPath (Path.Combine (Root, "..", "..", "tools", "scripts", "xabuild"));
+					return RunningMSBuild ? "msbuild" : "xbuild";
 				}
 
 				#if DEBUG
-				return Path.GetFullPath (Path.Combine (Root, "..", "..", "bin", "Debug", "bin", "xabuild.exe"));
+				xabuild = Path.GetFullPath (Path.Combine (Root, "..", "..", "bin", "Debug", "bin", "xabuild.exe"));
 				#else
-				return Path.GetFullPath (Path.Combine (Root, "..", "..", "bin", "Release", "bin", "xabuild.exe"));
+				xabuild =  Path.GetFullPath (Path.Combine (Root, "..", "..", "bin", "Release", "bin", "xabuild.exe"));
 				#endif
+				if (File.Exists (xabuild))
+					return xabuild;
+				return "msbuild";
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -61,9 +61,9 @@ namespace Xamarin.ProjectTools
 				}
 
 				#if DEBUG
-				xabuild = Path.GetFullPath (Path.Combine (Root, "..", "..", "bin", "Debug", "bin", "xabuild.exe"));
+				xabuild = Path.GetFullPath (Path.Combine (Root, "..", "Debug", "bin", "xabuild.exe"));
 				#else
-				xabuild =  Path.GetFullPath (Path.Combine (Root, "..", "..", "bin", "Release", "bin", "xabuild.exe"));
+				xabuild =  Path.GetFullPath (Path.Combine (Root, "..", "Release", "bin", "xabuild.exe"));
 				#endif
 				if (File.Exists (xabuild))
 					return xabuild;


### PR DESCRIPTION
We want to be able to run the msbuild tests against a system
installed xamarin-android. So we need to fallback to using
`msbuild` or `xbuild` if the required `xabuild` is NOT in place.

So if we do a full build `xabuild` will be in `bin\$(Configuration)\bin`
and the tests will run under the local environment. But if we just build
the tests `xabuild` will not exist since its copied as part of the
XABuild project build process.