### PR TITLE
[Xamarin.Android.Build.Tasks] Cache if we are using Release or Debug

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1056,6 +1056,7 @@ because xbuild doesn't support framework reference assemblies.
 	<_PropertyCacheItems Include="AndroidCreatePackagePerAbi=$(AndroidCreatePackagePerAbi)" />
 	<_PropertyCacheItems Include="OS=$(OS)" />
 	<_PropertyCacheItems Include="DesignTimeBuild=$(DesignTimeBuild)" />
+	<_PropertyCacheItems Include="AndroidIncludeDebugSymbols=$(AndroidIncludeDebugSymbols)" />
 </ItemGroup>
 
 <Target Name="_ReadPropertiesCache">


### PR DESCRIPTION
The VS team have asked if there is a way to know which runtime
is being used by a particular build configuration.

Since we calculate the `AndroidIncludeDebugSymbols` when the project
is loaded is makes sense to store that in the `build.props` file.
It should not change very often unless the user constantly
updated the project. This way the VS team can read the `build.props`
file and look for the value.

We could have added a new target, but at the point this is needed
VS can not call MSBuild targets or read properties.