### PR TITLE
[tests] fix Java.Interop test results copying

### DIFF
--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -15,7 +15,6 @@
   </PropertyGroup>
   <ItemGroup>
     <_TestAssembly Include="$(_TopDir)\bin\Test$(Configuration)\Xamarin.Android.Build.Tests.dll" />
-    <_JavaInteropTestResults Include="$(JavaInteropSourceDirectory)\TestResult-*.xml" />
     <_ApkTestProject Include="$(_TopDir)\src\Mono.Android\Test\Mono.Android-Tests.csproj" />
     <_ApkTestProject Include="$(_TopDir)\tests\CodeGen-Binding\Xamarin.Android.JcwGen-Tests\Xamarin.Android.JcwGen-Tests.csproj" />
     <_ApkTestProject Include="$(_TopDir)\tests\locales\Xamarin.Android.Locale-Tests\Xamarin.Android.Locale-Tests.csproj" />
@@ -61,7 +60,11 @@
         Targets="RenameTestCases"
         Properties="Configuration=$(Configuration);RenameTestCasesGlob=$(_RenamedTestCases)"
     />
+    <ItemGroup>
+      <_JavaInteropTestResults Include="$(JavaInteropSourceDirectory)\TestResult-*.xml" />
+    </ItemGroup>
     <Copy SourceFiles="@(_JavaInteropTestResults)" DestinationFolder="$(_TopDir)" />
+    <Delete Files="@(_JavaInteropTestResults)" />
   </Target>
   <Target Name="RunApkTests">
     <Exec Command="$(_XABuild) %(_ApkTestProject.Identity) /t:SignAndroidPackage $(_XABuildProperties)" />


### PR DESCRIPTION
On Windows, under MSBuild, I noticed a clean build was not copying the
test results from `external/Java.Interop` to the root directory. Two
things were causing this to be overlooked: the `<Copy />` task left the
original files from past test runs, and the `@(_JavaInteropTestResults)`
`ItemGroup` was calculated at the top of the file. I *think* this is
somehow working on xbuild.

To fix this, I moved the location of the `@(_JavaInteropTestResults)`
`ItemGroup` to happen during the target, instead of at the top of the
file. I also added a `<Delete />` task after the `<Copy />` to keep a clean
`external/Java.Interop` directory. It doesn't look like xbuild supports
`<Move />`.