### PR TITLE
[tests] changes to build test APKs with system Xamarin.Android

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -70,7 +70,7 @@
     <AllSupportedTargetAndroidAbis>$(AllSupported32BitTargetAndroidAbis);$(AllSupported64BitTargetAndroidAbis)</AllSupportedTargetAndroidAbis>
     <XABuildToolsVersion>26.0.1</XABuildToolsVersion>
     <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">26.0.1</XABuildToolsFolder>
-    <XAIntegratedTests Condition="'$(XAIntegratedTests)' == ''">True</XAIntegratedTests>
+    <XAIntegratedTests Condition="'$(XAIntegratedTests)' == ''">False</XAIntegratedTests>
     <PathSeparator>$([System.IO.Path]::PathSeparator)</PathSeparator>
   </PropertyGroup>
   <PropertyGroup>

--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -7,7 +7,6 @@
   <Import Project="$(_TopDir)\Configuration.props" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.SetEnvironmentVariable" />
   <PropertyGroup>
-    <XAIntegratedTests Condition=" '$(HostOS)' == 'Windows' ">False</XAIntegratedTests>
     <_Runtime Condition=" '$(HostOS)' != 'Windows' ">$(ManagedRuntime)</_Runtime>
     <_NUnit>$(_Runtime) packages\NUnit.ConsoleRunner.3.7.0\tools\nunit3-console.exe</_NUnit>
     <_Test Condition=" '$(TEST)' != '' ">--test=&quot;$(TEST)&quot;</_Test>

--- a/src/Mono.Android/Test/Mono.Android-Tests.csproj
+++ b/src/Mono.Android/Test/Mono.Android-Tests.csproj
@@ -99,7 +99,7 @@
     <AndroidResource Include="Resources\drawable\android_button.xml" />
     <AndroidResource Include="Resources\xml\XmlReaderResourceParser.xml" />
   </ItemGroup>
-  <Import Project="..\..\..\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Import Project="Mono.Android-Tests.targets" />
   <ItemGroup>
     <ProjectReference Include="..\..\Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj" Condition=" '$(XAIntegratedTests)' == 'True' ">


### PR DESCRIPTION
`Mono.Android-Tests.csproj` needed to use `$(MSBuildExtensionsPath)` as
part of locating `Xamarin.Android.CSharp.targets`. The other test APK
projects were already doing this.

The other change here is to set `XAIntegratedTests` to False by default,
so that it is not required to be set when building the test APKs with
your system Xamarin.Android installation.