### PR TITLE
[Xamarin.Android.Build.Tasks] Rework Parellel.ForEach

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -216,7 +216,12 @@ namespace Xamarin.Android.Tasks
 
 			assemblyMap.Load (AssemblyIdentityMapFile);
 
-			ThreadingTasks.Parallel.ForEach (ManifestFiles, () => 0, DoExecute, (obj) => { Complete (); });
+			ThreadingTasks.ParallelOptions options = new ThreadingTasks.ParallelOptions {
+				CancellationToken = Token,
+				TaskScheduler = ThreadingTasks.TaskScheduler.Current,
+			};
+
+			ThreadingTasks.Parallel.ForEach (ManifestFiles, options, () => 0, DoExecute, (obj) => { Complete (); });
 
 			base.Execute ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -239,7 +239,7 @@ namespace Xamarin.Android.Tasks
 
 			var task = ThreadingTasks.Task.Run ( () => {
 				return RunParallelAotCompiler (nativeLibs);
-			});
+			}, Token);
 
 			task.ContinueWith ( (t) => {
 				Complete ();
@@ -267,6 +267,7 @@ namespace Xamarin.Android.Tasks
 
 				ThreadingTasks.ParallelOptions options = new ThreadingTasks.ParallelOptions {
 					CancellationToken = cts.Token,
+					TaskScheduler = ThreadingTasks.TaskScheduler.Current,
 				};
 
 				ThreadingTasks.Parallel.ForEach (GetAotConfigs (), options,

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
@@ -80,9 +80,14 @@ namespace Xamarin.Android.Tasks
 			if (!imageFiles.Any ())
 				return true;
 
+			ThreadingTasks.ParallelOptions options = new ThreadingTasks.ParallelOptions {
+				CancellationToken = Token,
+				TaskScheduler = ThreadingTasks.TaskScheduler.Current,
+			};
+
 			var imageGroups = imageFiles.GroupBy (x => Path.GetDirectoryName (Path.GetFullPath (x.ItemSpec)));
 
-			ThreadingTasks.Parallel.ForEach (imageGroups, () => 0, DoExecute, (obj) => { Complete (); });
+			ThreadingTasks.Parallel.ForEach (imageGroups, options, () => 0, DoExecute, (obj) => { Complete (); });
 
 			return !Log.HasLoggedErrors;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
@@ -427,9 +427,11 @@ namespace Xamarin.Android.Tasks {
 						}
 					}
 				}
-			}).ContinueWith ((t) => {
-				if (t.Exception != null)
-					Log.LogErrorFromException (t.Exception.GetBaseException ());
+			}, Token).ContinueWith ((t) => {
+				if (t.Exception != null) {
+					var ex = t.Exception.GetBaseException ();
+					LogError (ex.Message + Environment.NewLine + ex.StackTrace);
+				}
 				Complete ();
 			});
 


### PR DESCRIPTION
We should also provide the Cancelation Token and the
TaskScheduler for the `Parallel.ForEach` calls.

Removed a call to Log.LogErrorFromException as the continuation does/will NOT run on the UI thread.