### PR TITLE
[tests] option to include/exclude categories from Test APKs

### DIFF
--- a/Documentation/DevelopmentTips.md
+++ b/Documentation/DevelopmentTips.md
@@ -178,6 +178,20 @@ For example:
 	$ tools/scripts/xabuild /t:DeployTestApks tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj
 	$ tools/scripts/xabuild /t:RunTestApks    tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj
 
+## Running `.apk` Projects with Include/Exclude
+
+For example, to exclude tests that use the internet (`InetAccess` category):
+
+	$ make run-apk-tests EXCLUDECATEGORIES=InetAccess
+
+On Windows:
+
+	$ msbuild Xamarin.Android.sln /t:RunApkTests /p:ExcludeCategories=InetAccess
+
+`INCLUDECATEGORIES` and `IncludeCategories` function in the same fashion.
+
+To specify multiple categories, delimit each category with a `:` character. The `:` delimiter works well with both `MSBuild` properties and `make` variables.
+
 ### Running A Single Test Fixture
 
 A single NUnit *Test Fixture* -- a class with the `[TestFixture]`

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -152,12 +152,17 @@
 
   <Target Name="RunTestApks"
       Condition=" '@(TestApk)' != '' ">
+    <PropertyGroup>
+      <_IncludeCategories Condition=" '$(IncludeCategories)' != '' ">include=$(IncludeCategories)</_IncludeCategories>
+      <_ExcludeCategories Condition=" '$(ExcludeCategories)' != '' ">exclude=$(ExcludeCategories)</_ExcludeCategories>
+    </PropertyGroup>
     <RunInstrumentationTests
         Condition=" '%(TestApk.InstrumentationType)' != ''"
         AdbTarget="$(_AdbTarget)"
         AdbOptions="$(AdbOptions)"
         Component="%(TestApk.Package)/%(TestApk.InstrumentationType)"
         NUnit2TestResultsFile="%(TestApk.ResultsPath)"
+        InstrumentationArguments="$(_IncludeCategories);$(_ExcludeCategories)"
         TestFixture="$(TestFixture)"
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)">

--- a/src/Mono.Android/Test/System.Net/ProxyTest.cs
+++ b/src/Mono.Android/Test/System.Net/ProxyTest.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 
 namespace System.NetTests {
 
-	[TestFixture]
+	[TestFixture, Category ("InetAccess")]
 	public class ProxyTest {
 
 		// https://bugzilla.xamarin.com/show_bug.cgi?id=14968

--- a/src/Mono.Android/Test/System.Net/SslTest.cs
+++ b/src/Mono.Android/Test/System.Net/SslTest.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 
 namespace System.NetTests {
 
-	[TestFixture]
+	[TestFixture, Category ("InetAccess")]
 	public class SslTest {
 
 		// https://xamarin.desk.com/agent/case/35534

--- a/src/Mono.Android/Test/Xamarin.Android.Net/AndroidClientHandlerTests.cs
+++ b/src/Mono.Android/Test/Xamarin.Android.Net/AndroidClientHandlerTests.cs
@@ -39,10 +39,10 @@ using NUnit.Framework;
 using Android.OS;
 
 namespace Xamarin.Android.NetTests {
-
+	[Category("InetAccess")]
 	public abstract class HttpClientHandlerTestBase
 	{
-    protected abstract HttpClientHandler CreateHandler ();
+		protected abstract HttpClientHandler CreateHandler ();
 
 		class Proxy : IWebProxy
 		{

--- a/src/Mono.Android/Test/Xamarin.Android.Net/HttpClientIntegrationTests.cs
+++ b/src/Mono.Android/Test/Xamarin.Android.Net/HttpClientIntegrationTests.cs
@@ -38,7 +38,7 @@ using System.Linq;
 using System.IO;
 
 namespace Xamarin.Android.NetTests {
-
+	[Category ("InetAccess")]
 	public abstract class HttpClientIntegrationTestBase
 	{
     protected abstract HttpClientHandler CreateHandler ();

--- a/src/Xamarin.Android.NUnitLite/Gui/Activities/TestSuiteActivity.cs
+++ b/src/Xamarin.Android.NUnitLite/Gui/Activities/TestSuiteActivity.cs
@@ -103,12 +103,12 @@ namespace Xamarin.Android.NUnitLite
 
 		protected virtual IEnumerable <string> GetIncludedCategories ()
 		{
-			return null;
+			yield break;
 		}
 
 		protected virtual IEnumerable <string> GetExcludedCategories ()
 		{
-			return null;
+			yield break;
 		}
 
 		// Subclasses can override this method to update the test filtering that the runner will use.

--- a/src/Xamarin.Android.NUnitLite/Gui/AndroidRunner.cs
+++ b/src/Xamarin.Android.NUnitLite/Gui/AndroidRunner.cs
@@ -389,7 +389,8 @@ namespace Xamarin.Android.NUnitLite
 					gotCategories = true;
 				}
 
-				chain = new AndFilter (chain, negate ? (TestFilter)new NotFilter (filter) : (TestFilter)filter);
+				if (gotCategories)
+					chain = new AndFilter (chain, negate ? (TestFilter)new NotFilter (filter) : (TestFilter)filter);
 			}
 
 			if (!gotCategories)

--- a/src/Xamarin.Android.NUnitLite/Gui/Instrumentations/TestSuiteInstrumentation.cs
+++ b/src/Xamarin.Android.NUnitLite/Gui/Instrumentations/TestSuiteInstrumentation.cs
@@ -146,12 +146,22 @@ namespace Xamarin.Android.NUnitLite {
 
 		protected virtual IEnumerable <string> GetIncludedCategories ()
 		{
-			return null;
+			string include = arguments?.GetString ("include");
+			if (!string.IsNullOrEmpty (include)) {
+				foreach (var category in include.Split (':')) {
+					yield return category;
+				}
+			}
 		}
 
 		protected virtual IEnumerable <string> GetExcludedCategories ()
 		{
-			return null;
+			string exclude = arguments?.GetString ("exclude");
+			if (!string.IsNullOrEmpty (exclude)) {
+				foreach (var category in exclude.Split (':')) {
+					yield return category;
+				}
+			}
 		}
 
 		protected virtual void UpdateFilter ()

--- a/tests/Xamarin.Android.Bcl-Tests/TestInstrumentation.cs
+++ b/tests/Xamarin.Android.Bcl-Tests/TestInstrumentation.cs
@@ -29,7 +29,12 @@ namespace Xamarin.Android.BclTests {
 
 		protected override IEnumerable<string> GetExcludedCategories ()
 		{
-			return App.GetExcludedCategories ();
+			foreach (var category in base.GetExcludedCategories ()) {
+				yield return category;
+			}
+			foreach (var category in App.GetExcludedCategories ()) {
+				yield return category;
+			}
 		}
 
 		protected override void UpdateFilter ()


### PR DESCRIPTION
In some QA needs to run tests on devices without a network connection,
so an option to disable tests that rely on the network in Mono.Android-Tests
is needed.

NUnit has the option to include or exclude tests based on the
`CategoryAttribute`. Various tests were decorated with
`[Category("InetAccess")]` that appeared to use the internet. To verify
this works, I ran the tests with my internet disabled. The test run for
Mono.Android-Tests went down from 106 to 84 tests, with no failures.

To exclude a category, on Windows:
```
    msbuild Xamarin.Android.sln /t:RunApkTests /p:ExcludeCategories=InetAccess
```
On MacOS/Linux:
```
    make run-apk-tests EXCLUDECATEGORIES=InetAccess
```
If you want to specify multiple categories, use `:` (colon) to delimit
each category. This delimiter is used for various values throughout
Xamarin.Android's build because it works well from the command line for both
MSBuild and make.

I also added the option specify `Include` as well, but it isn't particularly
useful for this case.