### PR TITLE
[Xamarin.Android.Build.Tasks] Use `adb install -r`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2696,7 +2696,7 @@ because xbuild doesn't support framework reference assemblies.
 </PropertyGroup>
 
 <Target Name="_Deploy">
-  <Exec Command="&quot;$(AdbToolPath)\adb&quot; install &quot;$(ApkFileSigned)&quot;" />
+  <Exec Command="&quot;$(AdbToolPath)\adb&quot; install -r &quot;$(ApkFileSigned)&quot;" />
 </Target>
 
 <Target Name="Install"


### PR DESCRIPTION
Commit 70d9e2ff added a "rudimentary `Install` target". This worked in
that it would install a package, but was less than ideal because it
would *fail* on multiple installs:

	$ msbuild /t:Install App.csproj
	# works
	$ msbuild /t:Install App.csproj
	Failed to install App-Signed.apk: Failure [INSTALL_FAILED_ALREADY_EXISTS: Attempt to re-install App without first uninstalling.]

Use `adb install -r` instead of `adb install` so that we *replace*
existing packages, should there be an existing package.

This should remove a potential headache from using the OSS bits with
Visual Studio for Mac/etc.