### PR TITLE
[android-toolchain] Provide path to `autopoint`

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -146,14 +146,18 @@
         Condition=" !$(AndroidMxeFullPath.EndsWith ($(_MxeHash))) "
         Text="%24(AndroidMxeFullPath) value of `$(AndroidMxeFullPath)` MUST end with `$(_MxeHash)`!"
     />
+    <PropertyGroup>
+      <_AutopointPath Condition=" '$(HostOS)' == 'Darwin' ">:%24(dirname %24(brew list gettext | grep autopoint%24))</_AutopointPath>
+      <_Path>$PATH$(_AutopointPath)</_Path>
+    </PropertyGroup>
     <Exec
         Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:'))"
-        Command="make MXE_TARGETS=&quot;$(MingwCommandPrefix32)&quot; gcc cmake zlib pthreads dlfcn-win32 mman-win32 PREFIX=&quot;$(AndroidMxeFullPath)&quot; OS_SHORT_NAME=&quot;disable-native-plugins&quot;"
+        Command="PATH=$(_Path) make MXE_TARGETS=&quot;$(MingwCommandPrefix32)&quot; gcc cmake zlib pthreads dlfcn-win32 mman-win32 PREFIX=&quot;$(AndroidMxeFullPath)&quot; OS_SHORT_NAME=&quot;disable-native-plugins&quot;"
         WorkingDirectory="..\..\external\mxe"
     />
     <Exec
         Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))"
-        Command="make MXE_TARGETS=&quot;$(MingwCommandPrefix64)&quot; gcc cmake zlib pthreads dlfcn-win32 mman-win32 PREFIX=&quot;$(AndroidMxeFullPath)&quot; OS_SHORT_NAME=&quot;disable-native-plugins&quot;"
+        Command="PATH=$(_Path) make MXE_TARGETS=&quot;$(MingwCommandPrefix64)&quot; gcc cmake zlib pthreads dlfcn-win32 mman-win32 PREFIX=&quot;$(AndroidMxeFullPath)&quot; OS_SHORT_NAME=&quot;disable-native-plugins&quot;"
         WorkingDirectory="..\..\external\mxe"
     />
     <Touch Files="@(_AndroidMxeOutput)" />


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/Default/_build/index?buildId=1138882&_a=summary
Context: https://github.com/xamarin/xamarin-android/pull/606#issuecomment-304171702

We [discovered 6 months ago][0] that a mono bump was failing to build
because:

[0]: https://jenkins.mono-project.com/job/xamarin-android-pr-builder/966

 1. The Jenkins machine building the PR has Homebrew 1.2.1 installed.

 2. The Jenkins machine attempting to build the PR has never built
    MXE before, as MXE is only required for *full* builds in which the
    mono runtime has changed.

 3. The MXE build failed, because `autopoint` wasn't in `$PATH`:

        Executing: make MXE_TARGETS="i686-w64-mingw32.static" gcc cmake zlib pthreads dlfcn-win32 mman-win32 PREFIX="/Users/builder/android-toolchain /mxe"
        Missing requirement: autopoint

The result is a very sad panda.

This *could* be fixed by force-linking the `gettext` package:

	$ brew link --force gettext

However, this is considered to be overkill, as there may be multiple
other `autopoint`s in `$PATH`. (Presumably there's *some* reason why
Brew 1.2 doesn't install `autopoint` into `$PATH`...)

This same issue also reappeared while attempting to build
xamarin-android within VSTS, as the VSTS bots similarly haven't run
`brew link --force gettext` either.

Fix this issue by overriding `$PATH` when building MXE so that it
contains the path to `autopoint`, as returned by:

	dirname $(brew list gettext | grep autopoint$)