### PR TITLE
[Tests] Run runtime test in Release/Aot configuration again

### DIFF
--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -76,6 +76,7 @@
     <MSBuild 
         Projects="$(_TopDir)\tests\RunApkTests.targets"
         Condition=" '$(Configuration)' == 'Release' "
+        Properties="AotAssemblies=True"
     />
   </Target>
   <Target Name="RunAllTests" DependsOnTargets="RunNUnitTests;RunJavaInteropTests;RunApkTests" />


### PR DESCRIPTION
Recently the migration of running the apk tests to msbuild
(https://github.com/xamarin/xamarin-android/commit/cdf3bcc11aaf036b68daaec504f6ffa4dbbc120a)
stopped running runtime test with Aot and thus we are missing
performance measurements for Release/Aot.

The reason of it is that `_AotName` property is not set, when calling
MSBuild task to run the apk tests. This patch sets the `AotAssemblies`
property when calling `RunApkTests.targets`
