### PR TITLE
[Xamarin.Android.Bcl-Tests] Allow Xamarin.Android.NUnitLite.dll path to be overridden

### DIFF
--- a/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets
+++ b/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets
@@ -20,10 +20,11 @@
     <ItemGroup>
       <_Source  Include="@(MonoTestAssembly->'..\..\bin\$(Configuration)\bcl-tests\%(Identity)')" />
     </ItemGroup>
-    <PropertyGroup>
-      <_XAFrameworksDir Condition=" '$(_XAFrameworksDir)' == '' ">$(XAInstallPrefix)xbuild-frameworks</_XAFrameworksDir>
-      <_NUnit>$(_XAFrameworksDir)\MonoAndroid\v1.0\Xamarin.Android.NUnitLite.dll</_NUnit>
-    </PropertyGroup>
+    <ResolveAssemblyReference
+        Assemblies="Xamarin.Android.NUnitLite"
+        SearchPaths="$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0;$(FrameworkPathOverride)">
+      <Output TaskParameter="ResolvedFiles"   PropertyName="_Nunit" />
+    </ResolveAssemblyReference>
     <Exec
         Command="$(RemapAssemblyRefTool) &quot;%(_Source.Identity)&quot; &quot;$(IntermediateOutputPath)%(_Source.Filename)%(_Source.Extension)&quot; nunitlite &quot;$(_NUnit)&quot;"
     />

--- a/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets
+++ b/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets
@@ -23,7 +23,7 @@
     <ResolveAssemblyReference
         Assemblies="Xamarin.Android.NUnitLite"
         SearchPaths="$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0;$(FrameworkPathOverride)">
-      <Output TaskParameter="ResolvedFiles"   PropertyName="_Nunit" />
+      <Output TaskParameter="ResolvedFiles"   PropertyName="_NUnit" />
     </ResolveAssemblyReference>
     <Exec
         Command="$(RemapAssemblyRefTool) &quot;%(_Source.Identity)&quot; &quot;$(IntermediateOutputPath)%(_Source.Filename)%(_Source.Extension)&quot; nunitlite &quot;$(_NUnit)&quot;"

--- a/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets
+++ b/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets
@@ -21,7 +21,8 @@
       <_Source  Include="@(MonoTestAssembly->'..\..\bin\$(Configuration)\bcl-tests\%(Identity)')" />
     </ItemGroup>
     <PropertyGroup>
-      <_NUnit>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\Xamarin.Android.NUnitLite.dll</_NUnit>
+      <_XAFrameworksDir Condition=" '$(_XAFrameworksDir)' == '' ">$(XAInstallPrefix)xbuild-frameworks</_XAFrameworksDir>
+      <_NUnit>$(_XAFrameworksDir)\MonoAndroid\v1.0\Xamarin.Android.NUnitLite.dll</_NUnit>
     </PropertyGroup>
     <Exec
         Command="$(RemapAssemblyRefTool) &quot;%(_Source.Identity)&quot; &quot;$(IntermediateOutputPath)%(_Source.Filename)%(_Source.Extension)&quot; nunitlite &quot;$(_NUnit)&quot;"


### PR DESCRIPTION
This is required for "system" execution on Windows, as there is no 'xbuild-frameworks' folder installed by the XA .vsix. An example framework installation location in VS2017 is shown below:
'C:\Program Files (x86)\Microsoft Visual Studio\Preview\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0'.