### PR TITLE
[Tests] Measure test sizes in Release/Aot configuration again

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -72,6 +72,7 @@
     <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">26.0.1</XABuildToolsFolder>
     <XAIntegratedTests Condition="'$(XAIntegratedTests)' == ''">False</XAIntegratedTests>
     <PathSeparator>$([System.IO.Path]::PathSeparator)</PathSeparator>
+    <TestsAotName Condition=" '$(AotAssemblies)' == 'true' ">-Aot</TestsAotName>
   </PropertyGroup>
   <PropertyGroup>
     <_MingwPrefixTail Condition=" '$(HostOS)' == 'Darwin' ">.static</_MingwPrefixTail>

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -10,6 +10,7 @@
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.KillProcess" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.Sleep" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.ProcessLogcatTiming" />
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.ProcessPlotInput" />
 
   <PropertyGroup>
     <_TestImageName>XamarinAndroidTestRunner</_TestImageName>
@@ -177,7 +178,7 @@
         ToolPath="$(AdbToolPath)">
     </RunUITests>
     <PropertyGroup>
-      <_LogcatFilename>logcat-$(Configuration)$(_AotName).txt</_LogcatFilename>
+      <_LogcatFilename>logcat-$(Configuration)$(TestsAotName).txt</_LogcatFilename>
     </PropertyGroup>
     <Exec Command="&quot;$(AdbToolPath)\$(AdbToolExe)&quot; $(_AdbTarget) $(AdbOptions) logcat -v threadtime -d > $(_LogcatFilename)" />
     <ProcessLogcatTiming
@@ -187,7 +188,7 @@
         ResultsFilename="%(TestApk.TimingResultsFilename)"
         DefinitionsFilename="%(TestApk.TimingDefinitionsFilename)"
         AddResults="true"
-        LabelSuffix="-$(Configuration)$(_AotName)"
+        LabelSuffix="-$(Configuration)$(TestsAotName)"
         Activity="%(TestApk.Activity)" />
   </Target>
   <Target Name="RenameTestCases">
@@ -223,10 +224,33 @@
       Condition=" '@(TestApk)' != '' ">
     <RenameTestCases
         Condition=" '%(TestApk.ResultsPath)' != '' "
-        Configuration="$(Configuration)$(_AotName)"
+        Configuration="$(Configuration)$(TestsAotName)"
         DeleteSourceFiles="True"
         DestinationFolder="$(MSBuildThisFileDirectory)..\.."
         SourceFile="%(TestApk.ResultsPath)"
+    />
+  </Target>
+  <Target Name="RecordApkSizes"
+      Condition=" '$(HostOS)' != 'Windows' ">
+    <Exec
+        Condition=" '$(HostOS)' == 'Darwin' And '%(TestApk.ApkSizesDefinitionFilename)' != '' "
+        Command="stat -f &quot;stat: %z %N&quot; &quot;%(TestApk.Identity)&quot; > &quot;$(OutputPath)%(TestApk.ApkSizesInputFilename)&quot;"
+    />
+    <Exec
+        Condition=" '$(HostOS)' == 'Linux'  And '%(TestApk.ApkSizesDefinitionFilename)' != '' "
+        Command="stat -c &quot;stat: %s %N&quot; &quot;%(TestApk.Identity)&quot; > &quot;$(OutputPath)%(TestApk.ApkSizesInputFilename)&quot;"
+    />
+    <Exec
+        Condition=" '%(TestApk.ApkSizesDefinitionFilename)' != '' "
+        Command="unzip -l &quot;%(TestApk.Identity)&quot; >> &quot;$(OutputPath)%(TestApk.ApkSizesInputFilename)&quot;" />
+    <ProcessPlotInput
+        Condition=" '%(TestApk.ApkSizesDefinitionFilename)' != '' "
+        InputFilename="$(OutputPath)%(TestApk.ApkSizesInputFilename)"
+        ApplicationPackageName="%(TestApk.Package)"
+        ResultsFilename="%(TestApk.ApkSizesResultsFilename)"
+        DefinitionsFilename="%(TestApk.ApkSizesDefinitionFilename)"
+        AddResults="True"
+        LabelSuffix="-$(Configuration)$(TestsAotName)"
     />
   </Target>
 </Project>

--- a/src/Mono.Android/Test/Mono.Android-Tests.projitems
+++ b/src/Mono.Android/Test/Mono.Android-Tests.projitems
@@ -1,41 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.ProcessPlotInput" />
-  <PropertyGroup>
-    <_MonoAndroidTestResultsPath>$(OutputPath)TestResult-Mono.Android_Tests.xml</_MonoAndroidTestResultsPath>
-    <_MonoAndroidTestPackage>Mono.Android_Tests</_MonoAndroidTestPackage>
-    <_MonoAndroidTestApkFile>$(OutputPath)Mono.Android_Tests-Signed.apk</_MonoAndroidTestApkFile>
-    <_MonoAndroidTestApkSizesInput>apk-sizes-$(_MonoAndroidTestPackage)-$(Configuration)$(_AotName).txt</_MonoAndroidTestApkSizesInput>
-    <_MonoAndroidApkSizesResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-Mono.Android_Tests-values.csv</_MonoAndroidApkSizesResultsFilename>
-  </PropertyGroup>
   <ItemGroup>
-    <TestApk Include="$(_MonoAndroidTestApkFile)">
-      <Package>$(_MonoAndroidTestPackage)</Package>
+    <TestApk Include="$(OutputPath)Mono.Android_Tests-Signed.apk">
+      <Package>Mono.Android_Tests</Package>
       <InstrumentationType>xamarin.android.runtimetests.TestInstrumentation</InstrumentationType>
-      <ResultsPath>$(_MonoAndroidTestResultsPath)</ResultsPath>
+      <ResultsPath>$(OutputPath)TestResult-Mono.Android_Tests.xml</ResultsPath>
       <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)..\..\..\build-tools\scripts\TimingDefinitions.txt</TimingDefinitionsFilename>
       <TimingResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-Mono.Android_Tests-times.csv</TimingResultsFilename>
+      <ApkSizesInputFilename>apk-sizes-$(_MonoAndroidTestPackage)-$(Configuration)$(TestsAotName).txt</ApkSizesInputFilename>
+      <ApkSizesDefinitionFilename>$(MSBuildThisFileDirectory)apk-sizes-definitions.txt</ApkSizesDefinitionFilename>
+      <ApkSizesResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-Mono.Android_Tests-values.csv</ApkSizesResultsFilename>
     </TestApk>
   </ItemGroup>
-  <Target Name="_RecordApkSizes"
-      AfterTargets="DeployTestApks"
-      Condition=" '$(HostOS)' != 'Windows' ">
-    <Exec
-        Condition=" '$(HostOS)' == 'Darwin' "
-        Command="stat -f &quot;stat: %z %N&quot; &quot;$(_MonoAndroidTestApkFile)&quot; > &quot;$(OutputPath)$(_MonoAndroidTestApkSizesInput)&quot;"
-    />
-    <Exec
-        Condition=" '$(HostOS)' == 'Linux' "
-        Command="stat -c &quot;stat: %s %N&quot; &quot;$(_MonoAndroidTestApkFile)&quot; > &quot;$(OutputPath)$(_MonoAndroidTestApkSizesInput)&quot;"
-    />
-    <Exec Command="unzip -l &quot;$(_MonoAndroidTestApkFile)&quot; >> &quot;$(OutputPath)$(_MonoAndroidTestApkSizesInput)&quot;" />
-    <ProcessPlotInput
-        InputFilename="$(OutputPath)$(_MonoAndroidTestApkSizesInput)"
-        ApplicationPackageName="$(_MonoAndroidTestPackage)"
-        ResultsFilename="$(_MonoAndroidApkSizesResultsFilename)"
-        DefinitionsFilename="$(MSBuildThisFileDirectory)apk-sizes-definitions.txt"
-        AddResults="True"
-        LabelSuffix="-$(Configuration)$(_AotName)"
-    />
-  </Target>
 </Project>

--- a/tests/RunApkTests.targets
+++ b/tests/RunApkTests.targets
@@ -5,9 +5,6 @@
     <OutputPath>$(MSBuildThisFileDirectory)..\bin\Test$(Configuration)\</OutputPath>
   </PropertyGroup>
   <Import Project="..\Configuration.props" />
-  <PropertyGroup>
-    <_AotName Condition=" '$(AotAssemblies)' == 'true' ">-Aot</_AotName>
-  </PropertyGroup>
   <!--
     Note that the `.csproj` for each `@(TestApk)` entry *must* be added to
     `$(TEST_APK_PROJECTS)` and/or `$(TEST_APK_PROJECTS_RELEASE)`
@@ -29,6 +26,7 @@
       AcquireAndroidTarget;
       UndeployTestApks;
       DeployTestApks;
+      RecordApkSizes;
       RunTestApks;
       ReleaseAndroidTarget;
       RenameApkTestCases;


### PR DESCRIPTION
One more fix after the migration of running the apk tests to msbuild
(https://github.com/xamarin/xamarin-android/commit/cdf3bcc11aaf036b68daaec504f6ffa4dbbc120a).

The reason of it is that `_AotName` property is not set, when building
the test. This patch moves the property to `Configuration.props` and
renames it to `TestsAotName`, so that it is set in the test project.

I also have to move _RecordApkSizes target to `TestApks.targets` as I
was experiencing troubles with `AfterTargets` dependency. It looks
like `xbuild` didn't run it the second time, even when the target was
called from project called by MSBuild task.

So to overcome this dependency issue, I moved the target to avoid
using `AfterTargets`. This also means that we can now easily measure
the sizes of the other tests as well (on demand).
