### PR TITLE
[mono] Use sdks/ to build target runtimes

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.mdproj
+++ b/build-tools/android-toolchain/android-toolchain.mdproj
@@ -20,7 +20,6 @@
       _CopyBootstrapTasksAssembly;
       _DownloadItems;
       _UnzipFiles;
-      _CreateNdkToolchains;
       _CreateMxeToolchains;
       _AcceptAndroidSdkLicenses;
     </BuildDependsOn>

--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -132,24 +132,6 @@
     </AndroidSdkItem>
   </ItemGroup>
   <ItemGroup>
-    <_NdkToolchain Include="arm-linux-androideabi-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':armeabi:')) Or $(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':armeabi-v7a:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-armeabi:'))">
-      <Platform>9</Platform>
-      <Arch>arm</Arch>
-    </_NdkToolchain>
-    <_NdkToolchain Include="aarch64-linux-android-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':arm64-v8a:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-arm64:'))">
-      <Platform>21</Platform>
-      <Arch>arm64</Arch>
-    </_NdkToolchain>
-    <_NdkToolchain Include="x86-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':x86:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-x86:'))">
-      <Platform>9</Platform>
-      <Arch>x86</Arch>
-    </_NdkToolchain>
-    <_NdkToolchain Include="x86_64-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':x86_64:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-x86_64:'))">
-      <Platform>21</Platform>
-      <Arch>x86_64</Arch>
-    </_NdkToolchain>
-  </ItemGroup>
-  <ItemGroup>
     <AntItem Include="apache-ant-1.9.9-bin.zip">
       <HostOS></HostOS>
     </AntItem>

--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -91,20 +91,6 @@
         AlwaysCreate="True"
     />
   </Target>
-  <Target Name="_CreateNdkToolchains"
-      Condition=" '$(OS)' == 'Unix' "
-      Inputs="$(AndroidToolchainDirectory)\ndk\.stamp-ndk"
-      Outputs="@(_NdkToolchain->'$(AndroidToolchainDirectory)\toolchains\%(Identity)\AndroidVersion.txt')">
-    <PropertyGroup>
-      <_Script>$(AndroidToolchainDirectory)\ndk\build\tools\make_standalone_toolchain.py</_Script>
-    </PropertyGroup>
-    <RemoveDir Directories="@(_NdkToolchain->'$(AndroidToolchainDirectory)\toolchains\%(Identity)')" />
-    <Exec Command="python &quot;$(_Script)&quot; -v --api %(_NdkToolchain.Platform) --install-dir &quot;$(AndroidToolchainDirectory)\toolchains\%(_NdkToolchain.Identity)&quot; --arch %(_NdkToolchain.Arch)" />
-    <Touch
-        Files="@(_NdkToolchain->'$(AndroidToolchainDirectory)\toolchains\%(Identity)\AndroidVersion.txt')"
-        AlwaysCreate="False"
-    />
-  </Target>
   <Target Name="_SetMxeToolchainMakefileTimeToLastCommitTimestamp"
       Condition=" '$(NeedMxe)' == 'true' And ($(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:')))">
     <GitCommitTime

--- a/build-tools/mono-runtimes/ProfileAssemblies.projitems
+++ b/build-tools/mono-runtimes/ProfileAssemblies.projitems
@@ -252,8 +252,6 @@
     <MonoTestAssembly Include="monodroid_System.Xml.Linq_test.dll">
       <SourcePath>System.Xml.Linq</SourcePath>
     </MonoTestAssembly>
-    <MonoTestAssembly Include="nunitlite.dll">
-      <SourcePath>lib/monodroid</SourcePath>
-    </MonoTestAssembly>
+    <MonoTestRunner Include="nunitlite.dll" />
   </ItemGroup>
 </Project>

--- a/build-tools/mono-runtimes/mono-runtimes.projitems
+++ b/build-tools/mono-runtimes/mono-runtimes.projitems
@@ -15,20 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <_MonoRuntime Include="armeabi" Condition=" '$(_ArmeabiRuntimeConfigure)' == 'true' ">
-      <Ar>$(_ArmAr)</Ar>
-      <As>$(_ArmAs)</As>
-      <Cc>$(_ArmCc)</Cc>
-      <Cpp>$(_ArmCpp) $(_ArmCppFlags)</Cpp>
-      <CFlags>$(_ArmCFlags) -march=armv5te $(_TargetCFlags)</CFlags>
-      <Cxx>$(_ArmCxx)</Cxx>
-      <CxxFlags>$(_ArmCxxFlags) -march=armv5te $(_TargetCxxFlags)</CxxFlags>
-      <CxxCpp>$(_ArmCxxCpp) $(_ArmCppFlags)</CxxCpp>
-      <Ld>$(_ArmLd)</Ld>
-      <LdFlags>$(_ArmLdFlags)</LdFlags>
-      <Objdump>$(_ArmObjdump)</Objdump>
-      <RanLib>$(_ArmRanLib)</RanLib>
-      <Strip>$(_ArmStrip)</Strip>
-      <ConfigureFlags>--host=armv5-linux-androideabi $(_TargetConfigureFlags)</ConfigureFlags>
+      <MonoSdks>true</MonoSdks>
       <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
       <NativeLibraryExtension>so</NativeLibraryExtension>
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
@@ -41,20 +28,7 @@
   <!-- Cross compiler doesn't need this one, it uses the 'armeabi' build above. Thus no PropertyGroup here. -->
   <ItemGroup>
     <_MonoRuntime Include="armeabi-v7a" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':armeabi-v7a:'))">
-      <Ar>$(_ArmAr)</Ar>
-      <As>$(_ArmAs)</As>
-      <Cc>$(_ArmCc)</Cc>
-      <Cpp>$(_ArmCpp) $(_ArmCppFlags)</Cpp>
-      <CFlags>$(_ArmCFlags) -mtune=cortex-a8 -march=armv7-a -mfpu=vfp -mfloat-abi=softfp $(_TargetCFlags)</CFlags>
-      <Cxx>$(_ArmCxx)</Cxx>
-      <CxxFlags>$(_ArmCxxFlags) -mtune=cortex-a8 -march=armv7-a -mfpu=vfp -mfloat-abi=softfp $(_TargetCxxFlags) </CxxFlags>
-      <CxxCpp>$(_ArmCxxCpp) $(_ArmCppFlags)</CxxCpp>
-      <Ld>$(_ArmLd)</Ld>
-      <LdFlags>$(_ArmLdFlags)</LdFlags>
-      <Objdump>$(_ArmObjdump)</Objdump>
-      <RanLib>$(_ArmRanLib)</RanLib>
-      <Strip>$(_ArmStrip)</Strip>
-      <ConfigureFlags>--host=armv5-linux-androideabi $(_TargetConfigureFlags)</ConfigureFlags>
+      <MonoSdks>true</MonoSdks>
       <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
       <NativeLibraryExtension>so</NativeLibraryExtension>
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
@@ -70,20 +44,7 @@
   </PropertyGroup>
   <ItemGroup>
     <_MonoRuntime Include="arm64-v8a" Condition=" '$(_Arm64RuntimeConfigure)' == 'true' ">
-      <Ar>$(_Arm64Ar)</Ar>
-      <As>$(_Arm64As)</As>
-      <Cc>$(_Arm64Cc)</Cc>
-      <Cpp>$(_Arm64Cpp) $(_Arm64CppFlags)</Cpp>
-      <CFlags>$(_Arm64CFlags) $(_TargetCFlags)</CFlags>
-      <Cxx>$(_Arm64Cxx)</Cxx>
-      <CxxFlags>$(_Arm64CxxFlags) $(_TargetCxxFlags) </CxxFlags>
-      <CxxCpp>$(_Arm64CxxCpp) $(_Arm64CppFlags)</CxxCpp>
-      <Ld>$(_Arm64Ld)</Ld>
-      <LdFlags>$(_Arm64LdFlags)</LdFlags>
-      <Objdump>$(_Arm64Objdump)</Objdump>
-      <RanLib>$(_Arm64RanLib)</RanLib>
-      <Strip>$(_Arm64Strip)</Strip>
-      <ConfigureFlags>--host=aarch64-linux-android $(_TargetConfigureFlags)</ConfigureFlags>
+      <MonoSdks>true</MonoSdks>
       <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
       <NativeLibraryExtension>so</NativeLibraryExtension>
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>
@@ -99,20 +60,7 @@
   </PropertyGroup>
   <ItemGroup>
     <_MonoRuntime Include="x86" Condition=" '$(_X86RuntimeConfigure)' == 'true' ">
-      <Ar>$(_X86Ar)</Ar>
-      <As>$(_X86As)</As>
-      <Cc>$(_X86Cc)</Cc>
-      <Cpp>$(_X86Cpp) $(_X86CppFlags)</Cpp>
-      <CFlags>$(_X86CFlags) $(_TargetCFlags)</CFlags>
-      <Cxx>$(_X86Cxx)</Cxx>
-      <CxxFlags>$(_X86CxxFlags) $(_TargetCxxFlags) </CxxFlags>
-      <CxxCpp>$(_X86CxxCpp) $(_X86CppFlags)</CxxCpp>
-      <Ld>$(_X86Ld)</Ld>
-      <LdFlags>$(_X86LdFlags)</LdFlags>
-      <Objdump>$(_X86Objdump)</Objdump>
-      <RanLib>$(_X86RanLib)</RanLib>
-      <Strip>$(_X86Strip)</Strip>
-      <ConfigureFlags>--host=i686-linux-android $(_TargetConfigureFlags)</ConfigureFlags>
+      <MonoSdks>true</MonoSdks>
       <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
       <NativeLibraryExtension>so</NativeLibraryExtension>
       <OutputMonoBtlsFilename>libmono-btls-shared</OutputMonoBtlsFilename>
@@ -128,20 +76,7 @@
   </PropertyGroup>
   <ItemGroup>
     <_MonoRuntime Include="x86_64" Condition=" '$(_X8664RuntimeConfigure)' == 'true' ">
-      <Ar>$(_X86_64Ar)</Ar>
-      <As>$(_X86_64As)</As>
-      <Cc>$(_X86_64Cc)</Cc>
-      <Cpp>$(_X86_64Cpp) $(_X86_64CppFlags)</Cpp>
-      <CFlags>$(_X86_64CFlags) $(_TargetCFlags)</CFlags>
-      <Cxx>$(_X86_64Cxx)</Cxx>
-      <CxxFlags>$(_X86_64CxxFlags) $(_TargetCxxFlags) </CxxFlags>
-      <CxxCpp>$(_X86_64CxxCpp) $(_X86_64CppFlags)</CxxCpp>
-      <Ld>$(_X86_64Ld)</Ld>
-      <LdFlags>$(_X86_64LdFlags)</LdFlags>
-      <RanLib>$(_X86_64RanLib)</RanLib>
-      <Objdump>$(_X86_64Objdump)</Objdump>
-      <Strip>$(_X86_64Strip)</Strip>
-      <ConfigureFlags>--host=x86_64-linux-android $(_TargetConfigureFlags)</ConfigureFlags>
+      <MonoSdks>true</MonoSdks>
       <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
       <NativeLibraryExtension>so</NativeLibraryExtension>
       <OutputProfilerFilename>libmono-profiler-log</OutputProfilerFilename>

--- a/build-tools/mono-runtimes/mono-runtimes.props
+++ b/build-tools/mono-runtimes/mono-runtimes.props
@@ -5,13 +5,6 @@
     <_CommonCFlags Condition=" '$(Configuration)' == 'Release' ">-g -O2</_CommonCFlags>
     <_HostWinCFlags Condition=" '$(Configuration)' == 'Debug' ">-ggdb3 -O0 -DXAMARIN_PRODUCT_VERSION=0</_HostWinCFlags>
     <_HostWinCFlags Condition=" '$(Configuration)' == 'Release' ">-g -O2 -DXAMARIN_PRODUCT_VERSION=0</_HostWinCFlags>
-    <_BtlsConfigureFlags>--enable-dynamic-btls --with-btls-android-ndk=$(AndroidToolchainDirectory)\ndk</_BtlsConfigureFlags>
-    <_CommonConfigureFlags>--without-ikvm-native --enable-maintainer-mode --with-profile4_x=no --with-monodroid --enable-nls=no --with-sigaltstack=yes --with-tls=pthread mono_cv_uscore=yes</_CommonConfigureFlags>
-    <_TargetConfigureFlags>$(_CommonConfigureFlags) --enable-minimal=ssa,interpreter,portability,attach,verifier,full_messages,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,security,shared_handles --disable-mcs-build --disable-executables --disable-iconv --disable-boehm $(_BtlsConfigureFlags)</_TargetConfigureFlags>
-    <_SecurityCFlags>-fstack-protector</_SecurityCFlags>
-    <_TargetCFlags>$(_SecurityCFlags) -DMONODROID=1</_TargetCFlags>
-    <_TargetCxxFlags>$(_SecurityCFlags) -DMONODROID=1</_TargetCxxFlags>
-    <_TargetLdFlags>-z now -z relro -z noexecstack -ldl -lm -llog -lc -lgcc</_TargetLdFlags>
   </PropertyGroup>
 
   <!-- LLVM+cross common -->
@@ -112,74 +105,6 @@
   </PropertyGroup>
 
   <!-- Mono runtimes settings -->
-  <PropertyGroup>
-    <_ArmNdkPlatformPath>$(AndroidToolchainDirectory)\ndk\platforms\android-9</_ArmNdkPlatformPath>
-    <_ArmAr>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-ar</_ArmAr>
-    <_ArmAs>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-as</_ArmAs>
-    <_ArmCc>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-clang</_ArmCc>
-    <_ArmCFlags>$(_CommonCFlags) -D__POSIX_VISIBLE=201002 -DSK_RELEASE -DNDEBUG -UDEBUG -fpic</_ArmCFlags>
-    <_ArmCpp>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-cpp</_ArmCpp>
-    <_ArmCppFlags>-I$(_ArmNdkPlatformPath)\arch-arm\usr\include\</_ArmCppFlags>
-    <_ArmCxx>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-clang++</_ArmCxx>
-    <_ArmCxxFlags>$(_ArmCFlags)</_ArmCxxFlags>
-    <_ArmCxxCpp>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-cpp</_ArmCxxCpp>
-    <_ArmLd>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-ld</_ArmLd>
-    <_ArmLdFlags>$(_TargetLdFlags) -Wl,--fix-cortex-a8 -Wl,-rpath-link=$(_ArmNdkPlatformPath)\arch-arm\usr\lib,-dynamic-linker=/system/bin/linker -L$(_ArmNdkPlatformPath)\arch-arm\usr\lib</_ArmLdFlags>
-    <_ArmObjdump>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-objdump</_ArmObjdump>
-    <_ArmRanLib>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-ranlib</_ArmRanLib>
-    <_ArmStrip>$(AndroidToolchainDirectory)\toolchains\arm-linux-androideabi-clang\bin\arm-linux-androideabi-strip</_ArmStrip>
-  </PropertyGroup>
-  <PropertyGroup>
-    <_Arm64NdkPlatformPath>$(AndroidToolchainDirectory)\ndk\platforms\android-21</_Arm64NdkPlatformPath>
-    <_Arm64Ar>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-ar</_Arm64Ar>
-    <_Arm64As>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-as</_Arm64As>
-    <_Arm64Cc>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-clang</_Arm64Cc>
-    <_Arm64CFlags>$(_CommonCFlags) -D__POSIX_VISIBLE=201002 -DSK_RELEASE -DNDEBUG -UDEBUG -fpic -DL_cuserid=9 -DANDROID64</_Arm64CFlags>
-    <_Arm64Cpp>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-cpp</_Arm64Cpp>
-    <_Arm64CppFlags>-I$(_Arm64NdkPlatformPath)\arch-arm64\usr\include</_Arm64CppFlags>
-    <_Arm64Cxx>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-clang++</_Arm64Cxx>
-    <_Arm64CxxFlags>$(_Arm64CFlags)</_Arm64CxxFlags>
-    <_Arm64CxxCpp>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-cpp</_Arm64CxxCpp>
-    <_Arm64Ld>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-ld</_Arm64Ld>
-    <_Arm64LdFlags>$(_TargetLdFlags) -Wl,-rpath-link=$(_Arm64NdkPlatformPath)\arch-arm64\usr\lib,-dynamic-linker=/system/bin/linker -L$(_Arm64NdkPlatformPath)\arch-arm64\usr\lib</_Arm64LdFlags>
-    <_Arm64Objdump>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-objdump</_Arm64Objdump>
-    <_Arm64RanLib>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-ranlib</_Arm64RanLib>
-    <_Arm64Strip>$(AndroidToolchainDirectory)\toolchains\aarch64-linux-android-clang\bin\aarch64-linux-android-strip</_Arm64Strip>
-  </PropertyGroup>
-  <PropertyGroup>
-    <_X86NdkPlatformPath>$(AndroidToolchainDirectory)\ndk\platforms\android-9</_X86NdkPlatformPath>
-    <_X86Ar>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-ar</_X86Ar>
-    <_X86As>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-as</_X86As>
-    <_X86Cc>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-clang</_X86Cc>
-    <_X86CFlags>$(_CommonCFlags)</_X86CFlags>
-    <_X86Cpp>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-cpp</_X86Cpp>
-    <_X86CppFlags>-I$(_X86NdkPlatformPath)\arch-x86\usr\include</_X86CppFlags>
-    <_X86Cxx>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-clang++</_X86Cxx>
-    <_X86CxxFlags>$(_X86CFlags)</_X86CxxFlags>
-    <_X86CxxCpp>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-cpp</_X86CxxCpp>
-    <_X86Ld>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-ld</_X86Ld>
-    <_X86LdFlags>$(_TargetLdFlags) -Wl,-rpath-link=$(_X86NdkPlatformPath)\arch-x86\usr\lib,-dynamic-linker=/system/bin/linker -L$(_X86NdkPlatformPath)\arch-x86\usr\lib</_X86LdFlags>
-    <_X86Objdump>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-objdump</_X86Objdump>
-    <_X86RanLib>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-ranlib</_X86RanLib>
-    <_X86Strip>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-strip</_X86Strip>
-  </PropertyGroup>
-  <PropertyGroup>
-    <_X86_64NdkPlatformPath>$(AndroidToolchainDirectory)\ndk\platforms\android-21</_X86_64NdkPlatformPath>
-    <_X86_64Ar>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-ar</_X86_64Ar>
-    <_X86_64As>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-as</_X86_64As>
-    <_X86_64Cc>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-clang</_X86_64Cc>
-    <_X86_64CFlags>$(_CommonCFlags) -DL_cuserid=9</_X86_64CFlags>
-    <_X86_64Cpp>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-cpp</_X86_64Cpp>
-    <_X86_64CppFlags>-I$(_X86_64NdkPlatformPath)\arch-x86\usr\include</_X86_64CppFlags>
-    <_X86_64Cxx>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-clang++</_X86_64Cxx>
-    <_X86_64CxxFlags>$(_X86_64CFlags)</_X86_64CxxFlags>
-    <_X86_64CxxCpp>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-cpp</_X86_64CxxCpp>
-    <_X86_64Ld>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-ld</_X86_64Ld>
-    <_X86_64LdFlags>$(_TargetLdFlags) -Wl,-rpath-link=$(_X86_64NdkPlatformPath)\arch-x86_64\usr\lib,-dynamic-linker=/system/bin/linker -L$(_X86_64NdkPlatformPath)\arch-x86_64\usr\lib</_X86_64LdFlags>
-    <_X86_64Objdump>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-objdump</_X86_64Objdump>
-    <_X86_64RanLib>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-ranlib</_X86_64RanLib>
-    <_X86_64Strip>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-strip</_X86_64Strip>
-  </PropertyGroup>
   <PropertyGroup>
     <_HostWin64CFlags>$(_HostWinCFlags)</_HostWin64CFlags>
   </PropertyGroup>

--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -57,10 +57,14 @@
     <_BclAssembly Include="@(MonoProfileAssembly)" />
     <_BclExcludeDebugSymbols  Include="System.Windows.dll" />
     <_BclExcludeDebugSymbols  Include="System.Xml.Serialization.dll" />
-    <_BclTestAssemblySource       Include="@(MonoTestAssembly->'$(MonoSourceFullPath)\mcs\class\%(SourcePath)\%(Identity)')" />
-    <_BclTestAssemblySource       Include="@(MonoTestAssembly->'$(MonoSourceFullPath)\mcs\class\%(SourcePath)\%(Filename).pdb')" />
+    <_BclTestAssemblySource       Include="@(MonoTestAssembly->'$(MonoSourceFullPath)\mcs\class\lib\monodroid\tests\%(Identity)')" />
+    <_BclTestAssemblySource       Include="@(MonoTestAssembly->'$(MonoSourceFullPath)\mcs\class\lib\monodroid\tests\%(Filename).pdb')" />
+    <_BclTestAssemblySource       Include="@(MonoTestRunner->'$(MonoSourceFullPath)\mcs\class\lib\monodroid\%(Identity)')" />
+    <_BclTestAssemblySource       Include="@(MonoTestRunner->'$(MonoSourceFullPath)\mcs\class\lib\monodroid\%(Filename).pdb')" />
     <_BclTestAssemblyDestination  Include="@(MonoTestAssembly->'$(XAInstallPrefix)\..\..\bcl-tests\%(Identity)')" />
     <_BclTestAssemblyDestination  Include="@(MonoTestAssembly->'$(XAInstallPrefix)\..\..\bcl-tests\%(Filename).pdb')" />
+    <_BclTestAssemblyDestination  Include="@(MonoTestRunner->'$(XAInstallPrefix)\..\..\bcl-tests\%(Identity)')" />
+    <_BclTestAssemblyDestination  Include="@(MonoTestRunner->'$(XAInstallPrefix)\..\..\bcl-tests\%(Filename).pdb')" />
   </ItemGroup>
   <ItemGroup>
     <_BclTestOutput Include="@(_BclTestAssemblyDestination)" />
@@ -211,13 +215,24 @@
       DependsOnTargets="_BuildLlvm;_Autogen"
       Inputs="$(MonoSourceFullPath)\configure"
       Outputs="$(IntermediateOutputPath)\%(_MonoRuntime.Identity)\Makefile">
-    <MakeDir Directories="$(IntermediateOutputPath)\%(_MonoRuntime.Identity)" />
     <Exec
+        Condition=" '%(_MonoRuntime.MonoSdks)' == 'True' "
+        Command="make $(MakeConcurrency) -C sdks\builds configure-android-%(_MonoRuntime.Identity)"
+        IgnoreStandardErrorWarningFormat="True"
+        WorkingDirectory="$(MonoSourceFullPath)"
+    />
+    <MakeDir
+        Condition=" '%(_MonoRuntime.MonoSdks)' != 'True' "
+        Directories="$(IntermediateOutputPath)\%(_MonoRuntime.Identity)"
+    />
+    <Exec
+        Condition=" '%(_MonoRuntime.MonoSdks)' != 'True' "
         Command="$(MonoSourceFullPath)\configure LDFLAGS=&quot;%(_MonoRuntime.LdFlags)&quot; CFLAGS=&quot;%(_MonoRuntime.CFlags)&quot; CXXFLAGS=&quot;%(_MonoRuntime.CxxFlags)&quot; CC=&quot;%(_MonoRuntime.Cc)&quot; CXX=&quot;%(_MonoRuntime.Cxx)&quot; CPP=&quot;%(_MonoRuntime.Cpp)&quot; CXXCPP=&quot;%(_MonoRuntime.CxxCpp)&quot; LD=&quot;%(_MonoRuntime.Ld)&quot; AR=&quot;%(_MonoRuntime.Ar)&quot; AS=&quot;%(_MonoRuntime.As)&quot; RANLIB=&quot;%(_MonoRuntime.RanLib)&quot; STRIP=&quot;%(_MonoRuntime.Strip)&quot; DLLTOOL=&quot;%(_MonoRuntime.DllTool)&quot; OBJDUMP=&quot;%(_MonoRuntime.Objdump)&quot; --cache-file=..\%(_MonoRuntime.Identity).config.cache %(_MonoRuntime.ConfigureFlags)"
         IgnoreStandardErrorWarningFormat="True"
         WorkingDirectory="$(IntermediateOutputPath)\%(_MonoRuntime.Identity)"
     />
     <Touch
+        Condition=" '%(_MonoRuntime.MonoSdks)' != 'True' "
         Files="$(IntermediateOutputPath)\%(_MonoRuntime.Identity)\.stamp"
         AlwaysCreate="True"
     />
@@ -225,7 +240,11 @@
   <Target Name="_GetRuntimesOutputItems">
     <ItemGroup>
       <_RuntimeSource
-          Condition=" '%(_MonoRuntime.DoBuild)' == 'True' "
+          Condition=" '%(_MonoRuntime.MonoSdks)' == 'True' And '%(_MonoRuntime.DoBuild)' == 'True' "
+          Include="@(_MonoRuntime->'$(MonoSourceFullPath)\sdks\builds\android-%(Identity)-release\mono\mini\.libs\%(OutputRuntimeFilename).%(NativeLibraryExtension)')"
+      />
+      <_RuntimeSource
+          Condition=" '%(_MonoRuntime.MonoSdks)' != 'True' And '%(_MonoRuntime.DoBuild)' == 'True' "
           Include="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\mono\mini\.libs\%(OutputRuntimeFilename).%(NativeLibraryExtension)')"
       />
       <_InstallRuntimeOutput
@@ -237,7 +256,11 @@
           Include="@(_MonoRuntime->'$(_MSBuildDir)\lib\%(Identity)\%(OutputRuntimeFilename).d.%(NativeLibraryExtension)')"
       />
       <_ProfilerSource
-          Condition=" '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputProfilerFilename)' != '' "
+          Condition=" '%(_MonoRuntime.MonoSdks)' == 'True' And '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputProfilerFilename)' != '' "
+          Include="@(_MonoRuntime->'$(MonoSourceFullPath)\sdks\builds\android-%(Identity)-release\mono\profiler\.libs\%(OutputProfilerFilename).%(NativeLibraryExtension)')"
+      />
+      <_ProfilerSource
+          Condition=" '%(_MonoRuntime.MonoSdks)' != 'True' And '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputProfilerFilename)' != '' "
           Include="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\mono\profiler\.libs\%(OutputProfilerFilename).%(NativeLibraryExtension)')"
       />
       <_InstallProfilerOutput
@@ -249,7 +272,11 @@
           Include="@(_MonoRuntime->'$(_MSBuildDir)\lib\%(Identity)\%(OutputProfilerFilename).d.%(NativeLibraryExtension)')"
       />
       <_MonoBtlsSource
-          Condition=" '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputMonoBtlsFilename)' != '' "
+          Condition=" '%(_MonoRuntime.MonoSdks)' == 'True' And '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputMonoBtlsFilename)' != '' "
+          Include="@(_MonoRuntime->'$(MonoSourceFullPath)\sdks\builds\android-%(Identity)-release\mono\btls\build-shared\%(OutputMonoBtlsFilename).%(NativeLibraryExtension)')"
+      />
+      <_MonoBtlsSource
+          Condition=" '%(_MonoRuntime.MonoSdks)' != 'True' And '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputMonoBtlsFilename)' != '' "
           Include="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\mono\btls\build-shared\%(OutputMonoBtlsFilename).%(NativeLibraryExtension)')"
       />
       <_InstallMonoBtlsOutput
@@ -261,7 +288,11 @@
           Include="@(_MonoRuntime->'$(_MSBuildDir)\lib\%(Identity)\%(OutputMonoBtlsFilename).d.%(NativeLibraryExtension)')"
       />
       <_MonoPosixHelperSource
-          Condition=" '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputMonoPosixHelperFilename)' != '' "
+          Condition=" '%(_MonoRuntime.MonoSdks)' == 'True' And '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputMonoPosixHelperFilename)' != '' "
+          Include="@(_MonoRuntime->'$(MonoSourceFullPath)\sdks\builds\android-%(Identity)-release\support\.libs\%(OutputMonoPosixHelperFilename).%(NativeLibraryExtension)')"
+      />
+      <_MonoPosixHelperSource
+          Condition=" '%(_MonoRuntime.MonoSdks)' != 'True' And '%(_MonoRuntime.DoBuild)' == 'True' And '%(_MonoRuntime.OutputMonoPosixHelperFilename)' != '' "
           Include="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\support\.libs\%(OutputMonoPosixHelperFilename).%(NativeLibraryExtension)')"
       />
       <_InstallMonoPosixHelperOutput
@@ -273,7 +304,11 @@
           Include="@(_MonoRuntime->'$(_MSBuildDir)\lib\%(Identity)\%(OutputMonoPosixHelperFilename).d.%(NativeLibraryExtension)')"
       />
       <_RuntimeEglibHeaderSource
-          Condition=" '%(_MonoRuntime.DoBuild)' == 'True' "
+          Condition=" '%(_MonoRuntime.MonoSdks)' == 'True' And '%(_MonoRuntime.DoBuild)' == 'True' "
+          Include="@(_MonoRuntime->'$(MonoSourceFullPath)\sdks\builds\android-%(Identity)-release\mono\eglib\eglib-config.h')"
+      />
+      <_RuntimeEglibHeaderSource
+          Condition=" '%(_MonoRuntime.MonoSdks)' != 'True' And '%(_MonoRuntime.DoBuild)' == 'True' "
           Include="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)\mono\eglib\eglib-config.h')"
       />
       <_RuntimeEglibHeaderOutput
@@ -296,7 +331,13 @@
       Inputs="@(_RuntimeBuildStamp)"
       Outputs="@(_RuntimeSource);@(_ProfilerSource);@(_MonoPosixHelperSource);@(_BclProfileItems);@(_MonoBtlsSource);@(_BclTestOutput)">
     <Exec
-        Condition=" '%(_MonoRuntime.DoBuild)' == 'true' "
+        Condition=" '%(_MonoRuntime.MonoSdks)' == 'True' And '%(_MonoRuntime.DoBuild)' == 'true' "
+        Command="make $(MakeConcurrency) -C sdks\builds build-android-%(_MonoRuntime.Identity)"
+        IgnoreStandardErrorWarningFormat="True"
+        WorkingDirectory="$(MonoSourceFullPath)"
+    />
+    <Exec
+        Condition=" '%(_MonoRuntime.MonoSdks)' != 'True' And '%(_MonoRuntime.DoBuild)' == 'true' "
         Command="make $(MakeConcurrency) # %(_MonoRuntime.Identity)"
         IgnoreStandardErrorWarningFormat="True"
         WorkingDirectory="$(IntermediateOutputPath)\%(_MonoRuntime.Identity)"
@@ -305,6 +346,13 @@
         Files="@(_RuntimeSource);@(_ProfilerSource);@(_MonoPosixHelperSource);@(_BclProfileItems);@(_MonoBtlsSource)"
     />
     <Exec
+        Condition=" '%(_MonoRuntime.MonoSdks)' == 'True' "
+        Command="make $(MakeConcurrency) -C sdks\builds\android-%(_MonoRuntime.Identity)-release\runtime test"
+        IgnoreStandardErrorWarningFormat="True"
+        WorkingDirectory="$(MonoSourceFullPath)"
+    />
+    <Exec
+        Condition=" '%(_MonoRuntime.MonoSdks)' != 'True' "
         Command="make $(MakeConcurrency) test # %(_MonoRuntime.Identity)"
         IgnoreStandardErrorWarningFormat="True"
         WorkingDirectory="$(IntermediateOutputPath)\%(_MonoRuntime.Identity)\runtime"


### PR DESCRIPTION
This is to use the newly created sdks/ folder in mono which builds mono for android, iOS and wasm. We use the build of android to share more of the build logic. This will in the long term improve the development experience of Mono on Android, as it will be easier to test it on device or emulator, without Xamarin.Android. This will also improve integration as we will be able to more easily test Mono on Android as port of Mono's CI.

This PR is not to be merged, it is mostly to get some Xamarin.Android's CI testing. We will be able to merge whenever Xamarin.Android bump to `mono:2017-12+`

TODO:

- [ ] targets:
  - [ ] llvm32
  - [ ] llvm64
  - [ ] cross-arm
  - [ ] cross-arm64
  - [ ] cross-x86
  - [ ] cross-x86_64
- [ ] tooling
  - [ ] use make-standalone-toolchain.py
  - [ ] use 