### PR TITLE
[Xamarin.Android.Build.Tasks] Aapt task needs to ignore fakeLogOpen

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -371,7 +371,7 @@ namespace Xamarin.Android.Tasks
 					line = int.Parse (match.Groups["line"].Value) + 1;
 				var level = match.Groups["level"].Value;
 				var message = match.Groups ["message"].Value;
-				if (level.Contains ("warning")) {
+				if (message.Contains ("fakeLogOpen") || level.Contains ("warning")) {
 					LogWarning (singleLine);
 					return;
 				}


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=1137183
(search for APT0000 in Xamarin.Android-Tests.sln output)

Our Windows builds on VSTS are randomly failing with:
```
2017-11-14T00:49:35.1654201Z   Executing package -f -m -M
E:\A\_work\_temp\lrwwmk1i.il2\manifest\AndroidManifest.xml -J
E:\A\_work\_temp\lrwwmk1i.il2 --custom-package mono.android_tests -F
E:\A\_work\_temp\lrwwmk1i.il2\resources.apk.bk -S obj\Debug\res -S
E:\A\_work\2\s\src\Mono.Android\Test\obj\Debug\lp\1\jl\res -I
C:\Users\dlab\android-toolchain\sdk\platforms\android-26\android.jar
--auto-add-overlay --max-res-version 26 (TaskId:87)
2017-11-14T00:49:35.2324246Z
E:\A\_work\2\s\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Common.targets(1373,2):
error APT0000: fakeLogOpen(/dev/log_crash, O_WRONLY) failed
[E:\A\_work\2\s\src\Mono.Android\Test\Mono.Android-Tests.csproj]
2017-11-14T00:49:35.2324246Z
E:\A\_work\2\s\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Common.targets(1373,2):
error APT0000: fakeLogOpen(/dev/log_security, O_WRONLY) failed
[E:\A\_work\2\s\src\Mono.Android\Test\Mono.Android-Tests.csproj]
2017-11-14T00:49:35.2324246Z
E:\A\_work\2\s\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Common.targets(1373,2):
error APT0000: fakeLogOpen(/dev/log_security, O_WRONLY) failed
[E:\A\_work\2\s\src\Mono.Android\Test\Mono.Android-Tests.csproj]
2017-11-14T00:49:35.2324246Z
E:\A\_work\2\s\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Common.targets(1373,2):
error APT0000: fakeLogOpen(/dev/log_security, O_WRONLY) failed
[E:\A\_work\2\s\src\Mono.Android\Test\Mono.Android-Tests.csproj]
2017-11-14T00:49:35.2333825Z Done executing task "Aapt" -- FAILED.
(TaskId:87)
```

I was able to repro this locally with the following PowerShell script:
```
$successful='0'
while ($successful -eq '0')
{
    & git clean -dxf .\src\ .\bin\TestDebug\
    & .\bin\Debug\bin\xabuild.exe .\src\Mono.Android\Test\Mono.Android-Tests.csproj /t:SignAndroidPackage /bl /noconsolelogger
    $successful = $lastExitCode
}
```

Merely cleaning stuff and rebuilding over and over would cause the issue
to crop up.

What is also odd about the failure:
- Running the `aapt.exe` command manually after the failure works
- The exit code is 0
- If I change the Aapt task to ignore errors, the APK seems to be valid.
Mono.Android-Tests still pass when I deploy and run them.

So what I *think* should be done here is to just check for `fakeLogOpen`
in the output, and treat this as a warning. This allows the build to go
on, which seems to produce a valid APK. We may not know this is resolved
until merged into master and we see a few builds succeed on VSTS.