### PR TITLE
[tests] Check for "ERROR:" emulator message

### DIFF
--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
@@ -107,6 +107,10 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 					Log.LogError ($"Emulator failed to start: `{e.Data}`. Please try again?");
 					sawError.Set ();
 				}
+				if (e.Data.IndexOf ("ERROR:", StringComparison.Ordinal) >= 0) {
+					Log.LogError ($"Emulator failed to start: {e.Data}");
+					sawError.Set ();
+				}
 			};
 
 			p.OutputDataReceived  += output;


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=1145123&tab=details&_a=summary

We want to check for `emulator` errors early, so that we don't have a
"hung build" that sticks around until we hit a timeout; see db668ba0.

A new error condition arose while attempting to run the
`emulator`-based tests on VSTS:

	[emulator stdout] emulator: ERROR: This AVD's configuration is missing a kernel file! Please ensure the file "kernel-ranchu" is in the same location as your system image.
	[emulator stdout] emulator: ERROR: ANDROID_SDK_ROOT is undefined

These weren't otherwise handled, and thus the error wasn't treated as
an actual error. The result is that *nothing happened*, and the
subsequent `adb wait-for-device` hung until the build timed out.

Check for a message containing `ERROR:` written to stderr, and if such
a message is seen, flag it as an error.