### PR TITLE
[Xamarin.Android.Build.Tasks] Apksigner invocation fails on build-tools 25 and lower

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
@@ -64,10 +64,11 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitchIfNotNull ("--key-pass pass:", KeyPass);
 			cmd.AppendSwitchIfNotNull ("--min-sdk-version ", minSdk.ToString ());
 			cmd.AppendSwitchIfNotNull ("--max-sdk-version ", maxSdk.ToString ());
-			cmd.AppendSwitchIfNotNull ("--in ", ApkToSign);
 		
 			if (!string.IsNullOrEmpty (AdditionalArguments))
 				cmd.AppendSwitch (AdditionalArguments);
+
+			cmd.AppendSwitchIfNotNull (" ", ApkToSign);
 
 			return cmd.ToString ();
 		}


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=525752

Older `apksigner` versions did not have an `--in` parameter. Instead
they expected the last item to be passed to be the .apk to sign.

So to make this work on older `apksigner` versions we should rework
the Task to pass the apk last.