### PR TITLE
[tests] set $(AndroidSdkDirectory) for JI tests

### DIFF
--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -48,7 +48,10 @@
         Condition=" '$(HostOS)' != 'Windows' "
     />
     <SetEnvironmentVariable Name="ANDROID_SDK_PATH" Value="$(AndroidSdkFullPath)" />
-    <MSBuild Projects="$(JavaInteropSourceDirectory)\build-tools\scripts\RunNUnitTests.targets" />
+    <MSBuild 
+        Projects="$(JavaInteropSourceDirectory)\build-tools\scripts\RunNUnitTests.targets"
+        Properties="AndroidSdkDirectory=$(AndroidSdkDirectory)"
+    />
     <ItemGroup>
       <_RenameTestCasesGlob Include="$(JavaInteropSourceDirectory)\TestResult-*Tests.xml" />
     </ItemGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/pull/211

For Windows to set `ANDROID_SDK_PATH` for the Java.Interop unit tests,
we need to pass `$(AndroidSdkDirectory)` through.

Otherwise a few tests get skipped in
Xamarin.Android.Tools.Bytecode-Tests.dll.