### PR TITLE
[tests] fix emulator launch when ANDROID_HOME is set

### DIFF
--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
@@ -62,7 +62,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				return;
 
 			var port = string.IsNullOrEmpty (Port) ? "" : $" -port {Port}";
-			var arguments = $"-avd {ImageName}{port}";
+			var arguments = $"-verbose -avd {ImageName}{port}";
 			Log.LogMessage (MessageImportance.Low, $"Tool {emulator} execution started with arguments: {arguments}");
 			var psi = new ProcessStartInfo () {
 				FileName                = emulator,
@@ -78,6 +78,10 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			var p = new Process () {
 				StartInfo = psi,
 			};
+			if (!string.IsNullOrEmpty (AndroidSdkHome)) {
+				psi.EnvironmentVariables ["ANDROID_HOME"] = AndroidSdkHome;
+				Log.LogMessage (MessageImportance.Low, $"\tANDROID_HOME=\"{AndroidSdkHome}\"");
+			}
 
 			var sawError        = new AutoResetEvent (false);
 


### PR DESCRIPTION
It appears the installation of Android Studio has exported `ANDROID_HOME`
on my system. This is problematic for our build, since it installs a
specific version of the Android SDK into ~/android-toolchain/sdk.

The fix is to set `ANDROID_HOME` for the `emulator` command using the
existing value for `AndroidSdkHome` from our build. This allows the emulator
to locate the proper system image in ~/android-toolchain/sdk/system-images.
I suspect a similar problem is happening on VSTS, in our monodroid build.

I also added the `-verbose` flag to the `emulator` command so we will have
more information if the emulator fails to launch during a build.