### PR TITLE
[android-toolchain] update emulator to 26.1.4.0

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -23,7 +23,7 @@
       <HostOS>Linux</HostOS>
       <DestDir>tools</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="emulator-linux-3965150.zip">
+    <AndroidSdkItem Include="emulator-linux-4266726.zip">
       <HostOS>Linux</HostOS>
       <DestDir>emulator</DestDir>
     </AndroidSdkItem>
@@ -42,7 +42,7 @@
       <HostOS>Darwin</HostOS>
       <DestDir>tools</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="emulator-darwin-3965150.zip">
+    <AndroidSdkItem Include="emulator-darwin-4266726.zip">
       <HostOS>Darwin</HostOS>
       <DestDir>emulator</DestDir>
     </AndroidSdkItem>
@@ -61,7 +61,7 @@
       <HostOS>Windows</HostOS>
       <DestDir>tools</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="emulator-windows-3965150.zip">
+    <AndroidSdkItem Include="emulator-windows-4266726.zip">
       <HostOS>Windows</HostOS>
       <DestDir>emulator</DestDir>
     </AndroidSdkItem>


### PR DESCRIPTION
Context:
https://developer.android.com/studio/releases/emulator.html#26-1-3

Google has added support for `hypervisor.framework` on Mac instead of
using HAXM. It appears all we need to do to enable this is use a newer
version of the emulator. Thanks to @JonDouglas for the info about this.

To check that `hypervisor.framework` is enabled, run `make
run-apk-tests V=1`, and you should see the following output when the emulator starts:

`emulator: CPU Acceleration status: Hypervisor.Framework OS X Version 10.12`

On my machine, I also had to uninstall HAXM, which you can either do by
running the silent uninstaller or the following command:

`sudo kextunload -b com.intel.kext.intelhaxm`