### PR TITLE
[xabuild] check if MSBuildSDKsPath exists

### DIFF
--- a/tools/xabuild/XABuild.cs
+++ b/tools/xabuild/XABuild.cs
@@ -103,7 +103,9 @@ namespace Xamarin.Android.Build
 
 			xml.Save (paths.XABuildConfig);
 
-			Environment.SetEnvironmentVariable ("MSBuildSDKsPath", paths.MSBuildSdksPath, EnvironmentVariableTarget.Process);
+			if (Directory.Exists (paths.MSBuildSdksPath)) {
+				Environment.SetEnvironmentVariable ("MSBuildSDKsPath", paths.MSBuildSdksPath, EnvironmentVariableTarget.Process);
+			}
 			Environment.SetEnvironmentVariable ("MSBUILD_EXE_PATH", paths.MSBuildExeTempPath, EnvironmentVariableTarget.Process);
 			return xml;
 		}


### PR DESCRIPTION
This is a minor fix, but it is possible the system running `xabuild.exe`
will not have .NET Core installed. So we shouldn't set this environment
variable if the directory does not exist.