### PR TITLE
[Xamarin.Android.Build.Tasks] New APT0000 msbuild errors are being reported from aapt output parsing

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -394,7 +394,7 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
-			LogError("APT0000", string.Format("{0} \"{1}\".", singleLine.Trim(), singleLine.Substring(singleLine.LastIndexOfAny(new char[] { '\\', '/' }) + 1)), ToolName);
+			LogError ("APT0000", string.Format("{0} \"{1}\".", singleLine.Trim(), singleLine.Substring(singleLine.LastIndexOfAny(new char[] { '\\', '/' }) + 1)), ToolName);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -369,7 +369,7 @@ namespace Xamarin.Android.Tasks
 				int line = 0;
 				if (!string.IsNullOrEmpty (match.Groups["line"]?.Value))
 					line = int.Parse (match.Groups["line"].Value) + 1;
-				var level = match.Groups["level"].Value.ToLower ();
+				var level = match.Groups["level"].Value.ToLowerInvariant ();
 				var message = match.Groups ["message"].Value;
 				if (message.Contains ("fakeLogOpen") || level.Contains ("warning")) {
 					LogWarning (singleLine);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -117,7 +117,7 @@ namespace Xamarin.Android.Tasks
 			using (var proc = new Process ()) {
 				proc.OutputDataReceived += (sender, e) => {
 					if (e.Data != null)
-						LogEventsFromTextOutput (e.Data, MessageImportance.Normal);
+						LogMessage (e.Data, MessageImportance.Normal);
 					else
 						stdout_completed.Set ();
 				};
@@ -394,22 +394,7 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
-			// Handle additional errors that doesn't match the regex
-			foreach (var knownInvalidError in KnownInvalidErrorMessages) {
-				if (singleLine.Trim ().StartsWith (knownInvalidError, StringComparison.OrdinalIgnoreCase)) {
-					LogError ("APT0000", string.Format ("{0} \"{1}\".", knownInvalidError, singleLine.Substring (singleLine.LastIndexOfAny (new char [] { '\\', '/' }) + 1)), ToolName);
-					return;
-				}
-			}
-
-			LogMessage (singleLine, messageImportance);
+			LogError("APT0000", string.Format("{0} \"{1}\".", singleLine.Trim(), singleLine.Substring(singleLine.LastIndexOfAny(new char[] { '\\', '/' }) + 1)), ToolName);
 		}
-
-		static readonly string [] KnownInvalidErrorMessages = {
-			"invalid resource directory name:",
-			"invalid file name:",
-			"package name is required with",
-			"No <manifest> tag.",
-		};
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidToolTask.cs
@@ -105,7 +105,7 @@ namespace Xamarin.Android.Tasks
 \s*
 (?<message>.*)
 $
-", RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.IgnorePatternWhitespace, RegexOptions.IgnoreCase);
+", RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.IgnorePatternWhitespace | RegexOptions.IgnoreCase);
 				return androidErrorRegex;
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidToolTask.cs
@@ -99,7 +99,7 @@ namespace Xamarin.Android.Tasks
 )?
 ( # optional warning|error:
  \s*
- (?<level>(warning|error)[^:]*)\s*
+ (?<level>(warning|error|Error|ERROR)[^:]*)\s*
  :
 )?
 \s*

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidToolTask.cs
@@ -99,13 +99,13 @@ namespace Xamarin.Android.Tasks
 )?
 ( # optional warning|error:
  \s*
- (?<level>(warning|error|Error|ERROR)[^:]*)\s*
+ (?<level>(warning|error)[^:]*)\s*
  :
 )?
 \s*
 (?<message>.*)
 $
-", RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.IgnorePatternWhitespace);
+", RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.IgnorePatternWhitespace, RegexOptions.IgnoreCase);
 				return androidErrorRegex;
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidRegExTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidRegExTests.cs
@@ -58,7 +58,70 @@ namespace Xamarin.Android.Build.Tests
 					/*expectedLevel*/	"",
 					/*expectedMessage*/	"Invalid file name: must contain only [a-z0-9_.]"
 				};
-
+				yield return new object [] {
+					/*message*/		"max res 10, skipping values-sw600dp",
+					/*expectedToMatch*/	true,
+					/*expectedFile*/	"",
+					/*expectedLine*/	"",
+					/*expectedLevel*/	"",
+					/*expectedMessage*/	"max res 10, skipping values-sw600dp"
+				};
+				yield return new object [] {
+					/*message*/		"max res 10, skipping values-sw600dp-land",
+					/*expectedToMatch*/	true,
+					/*expectedFile*/	"",
+					/*expectedLine*/	"",
+					/*expectedLevel*/	"",
+					/*expectedMessage*/	"max res 10, skipping values-sw600dp-land"
+				};
+				yield return new object [] {
+					/*message*/		"Error: unable to generate entry for resource data",
+					/*expectedToMatch*/	true,
+					/*expectedFile*/	"",
+					/*expectedLine*/	"",
+					/*expectedLevel*/	"Error",
+					/*expectedMessage*/	"unable to generate entry for resource data"
+				};
+				yield return new object [] {
+					/*message*/		"Error: malformed resource filename",
+					/*expectedToMatch*/	true,
+					/*expectedFile*/	"",
+					/*expectedLine*/	"",
+					/*expectedLevel*/	"Error",
+					/*expectedMessage*/	"malformed resource filename"
+				};
+				yield return new object [] {
+					/*message*/		"warning: Multiple AndroidManifest.xml files found, using foo\\AndroidManifest.xml",
+					/*expectedToMatch*/	true,
+					/*expectedFile*/	"",
+					/*expectedLine*/	"",
+					/*expectedLevel*/	"warning",
+					/*expectedMessage*/	"Multiple AndroidManifest.xml files found, using foo\\AndroidManifest.xml"
+				};
+				yield return new object [] {
+					/*message*/		"Resources/values/theme.xml:55: No start tag found",
+					/*expectedToMatch*/	true,
+					/*expectedFile*/	"Resources/values/theme.xml",
+					/*expectedLine*/	"55",
+					/*expectedLevel*/	"",
+					/*expectedMessage*/	"No start tag found"
+				};
+				yield return new object [] {
+					/*message*/		"package name is required with --rename-manifest-package.",
+					/*expectedToMatch*/	true,
+					/*expectedFile*/	"",
+					/*expectedLine*/	"",
+					/*expectedLevel*/	"",
+					/*expectedMessage*/	"package name is required with --rename-manifest-package."
+				};
+				yield return new object [] {
+					/*message*/		"invalid resource directory name: bar-55",
+					/*expectedToMatch*/	true,
+					/*expectedFile*/	"",
+					/*expectedLine*/	"",
+					/*expectedLevel*/	"",
+					/*expectedMessage*/	"invalid resource directory name: bar-55"
+				};
 			}
 		}
 


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=528572

The current RegEx was capturing output which was not and error
or warning. It turns out that aapt is not very consistent with
its error messaging. Sometimes they use `error`, sometimes then
use `Error` or `ERROR`. Or in the worse case, they don't flag it
as anything.

This commit adds a few more tests to AndroidRegExTests as well
as alters the logic in `Aapt` a bit as well. This logic will
only log as an error if we have an error `level` or we have
a `file` and `line`. This seems to be fairly consistent when
looking at the `aapt` source code.

We also added a few extra `Known` errors which the regex might not
pick. This is because they do not contain a `level` or a `file`
and `line` number.