### PR TITLE
[Xamarin.Android.Build.Tasks] added filter to proguard commands

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
@@ -28,6 +28,7 @@ namespace Xamarin.Android.Tasks
 		
 		public string MultiDexMainDexListFile { get; set; }
 		public ITaskItem[] CustomMainDexListFiles { get; set; }
+		public string ProguardInputJarFilter { get; set; }
 
 		Action<CommandLineBuilder> commandlineAction;
 		string tempJar;
@@ -43,6 +44,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  ToolExe: {0}", ToolExe);
 			Log.LogDebugMessage ("  ToolPath: {0}", ToolPath);
 			Log.LogDebugMessage ("  ProguardJarPath: {0}", ProguardJarPath);
+			Log.LogDebugMessage ("  ProguardInputJarFilter: {0}", ProguardInputJarFilter);
 
 			if (CustomMainDexListFiles != null && CustomMainDexListFiles.Any ()) {
 				var content = string.Concat (CustomMainDexListFiles.Select (i => File.ReadAllText (i.ItemSpec)));
@@ -76,7 +78,7 @@ namespace Xamarin.Android.Tasks
 			var enclosingChar = OS.IsWindows ? "\"" : string.Empty;
 			var jars = JavaLibraries.Select (i => i.ItemSpec).Concat (new string [] { Path.Combine (ClassesOutputDirectory, "classes.zip") });
 			cmd.AppendSwitchIfNotNull ("-jar ", ProguardJarPath);
-			cmd.AppendSwitchUnquotedIfNotNull ("-injars ", $"{enclosingChar}'" + string.Join ($"'{Path.PathSeparator}'", jars) + $"'{enclosingChar}");
+			cmd.AppendSwitchUnquotedIfNotNull ("-injars ", $"{enclosingChar}'" + string.Join ($"{ProguardInputJarFilter}'{Path.PathSeparator}'", jars) + $"{ProguardInputJarFilter}'{enclosingChar}");
 			cmd.AppendSwitch ("-dontwarn");
 			cmd.AppendSwitch ("-forceprocessing");
 			cmd.AppendSwitchIfNotNull ("-outjars ", tempJar);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
@@ -69,6 +69,7 @@ namespace Xamarin.Android.Tasks
 		public string PrintSeedsOutput { get; set; }
 		public string PrintUsageOutput { get; set; }
 		public string PrintMappingOutput { get; set; }
+		public string ProguardInputJarFilter { get; set; }
 
 		protected override string ToolName {
 			get {
@@ -98,6 +99,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  DumpOutput: {0}", DumpOutput);
 			Log.LogDebugMessage ("  PrintSeedsOutput: {0}", PrintSeedsOutput);
 			Log.LogDebugMessage ("  PrintMappingOutput: {0}", PrintMappingOutput);
+			Log.LogDebugMessage ("  ProguardInputJarFilter: {0}", ProguardInputJarFilter);
 
 			EnvironmentVariables = MonoAndroidHelper.GetProguardEnvironmentVaribles (ProguardHome);
 
@@ -170,7 +172,7 @@ namespace Xamarin.Android.Tasks
 				foreach (var jarfile in ExternalJavaLibraries.Select (p => p.ItemSpec))
 					libjars.Add (jarfile);
 
-			cmd.AppendSwitchUnquotedIfNotNull ("-injars ", $"{enclosingChar}'" + string.Join ($"'{Path.PathSeparator}'", injars.Distinct ()) + $"'{enclosingChar}");
+			cmd.AppendSwitchUnquotedIfNotNull ("-injars ", $"{enclosingChar}'" + string.Join ($"{ProguardInputJarFilter}'{Path.PathSeparator}'", injars.Distinct ()) + $"{ProguardInputJarFilter}'{enclosingChar}");
 
 			cmd.AppendSwitchUnquotedIfNotNull ("-libraryjars ", $"{enclosingChar}'" + string.Join ($"'{Path.PathSeparator}'", libjars.Distinct ()) + $"'{enclosingChar}");
 			

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -391,6 +391,7 @@ printf ""%d"" x
 				Assert.IsTrue (File.Exists (multidexKeepPath), "multidex.keep exists");
 				Assert.IsTrue (File.ReadAllLines (multidexKeepPath).Length > 1, "multidex.keep must contain more than one line.");
 				Assert.IsTrue (b.LastBuildOutput.ContainsText (Path.Combine (proj.TargetFrameworkVersion, "mono.android.jar")), proj.TargetFrameworkVersion + "/mono.android.jar should be used.");
+				Assert.IsFalse (b.LastBuildOutput.ContainsText ("Duplicate zip entry"), "Should not get warning about [META-INF/MANIFEST.MF]");
 			}
 		}
 
@@ -437,6 +438,7 @@ namespace UnnamedProject {
 }" });
 			using (var b = CreateApkBuilder ("temp/CustomApplicationClassAndMultiDex")) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsFalse (b.LastBuildOutput.ContainsText ("Duplicate zip entry"), "Should not get warning about [META-INF/MANIFEST.MF]");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -252,6 +252,9 @@ namespace Xamarin.ProjectTools
 					psi.EnvironmentVariables [kvp.Key] = kvp.Value;
 				}
 			}
+			//NOTE: fix for Jenkins, see https://github.com/xamarin/xamarin-android/pull/1049#issuecomment-347625456
+			psi.EnvironmentVariables ["ghprbPullLongDescription"] = "";
+
 			psi.Arguments = args.ToString ();
 			
 			psi.CreateNoWindow = true;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -248,6 +248,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<_AndroidLibrayProjectIntermediatePath Condition=" '$(_AndroidLibrayProjectIntermediatePath)' == '' And '$(UseShortFileNames)' == 'True' ">$(IntermediateOutputPath)lp\</_AndroidLibrayProjectIntermediatePath>
 	<_AndroidLibrayProjectIntermediatePath Condition=" '$(_AndroidLibrayProjectIntermediatePath)' == '' ">$(IntermediateOutputPath)__library_projects__\</_AndroidLibrayProjectIntermediatePath>
 	<_AndroidLibrayProjectAssemblyMapFile>$(_AndroidLibrayProjectIntermediatePath)map.cache</_AndroidLibrayProjectAssemblyMapFile>
+	<_AndroidProguardInputJarFilter>(!META-INF/MANIFEST.MF)</_AndroidProguardInputJarFilter>
 		
 	<!-- $(EnableProguard) is an obsolete property that should be removed at some stage. -->
 	<AndroidEnableProguard Condition="'$(AndroidEnableProguard)'==''">$(EnableProguard)</AndroidEnableProguard>
@@ -2153,6 +2154,7 @@ because xbuild doesn't support framework reference assemblies.
     PrintSeedsOutput="$(IntermediateOutputPath)proguard\seeds.txt"
     PrintUsageOutput="$(IntermediateOutputPath)proguard\usage.txt"
     PrintMappingOutput="$(IntermediateOutputPath)proguard\mapping.txt"
+    ProguardInputJarFilter="$(_AndroidProguardInputJarFilter)"
      />
 
   <CreateItem 
@@ -2176,6 +2178,7 @@ because xbuild doesn't support framework reference assemblies.
     JavaLibraries="@(_JarsToProguard)"
     MultiDexMainDexListFile="$(_AndroidMainDexListFile)"
     CustomMainDexListFiles="@(MultiDexMainDexList)"
+    ProguardInputJarFilter="$(_AndroidProguardInputJarFilter)"
     >
   </CreateMultiDexMainDexClassList>
 


### PR DESCRIPTION
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=56834

A default multi-dex application will print a warning to the console
such as:
```
Warning: can't write resource [META-INF/MANIFEST.MF] (Duplicate zip entry [android-support-multidex.jar:META-INF/MANIFEST.MF])
```

This is due to most jar files containing a `META-INF/MANIFEST.MF`,
which really just needs to be excluded from the proguard command.
We can do this by adding a filter to the end of each jar file passed
via the `-injars` command line option.

Changes:
- Added a `$(_AndroidProguardInputJarFilter)` internal property, which
defaults to `(!META-INF/MANIFEST.MF)` so we ignore the most common warning
by default
- Added a `ProguardInputJarFilter` property to the `<Proguard />` and
`<CreateMultiDexMainDexClassList />` tasks
- Added assertions to multi-dex unit tests making sure we aren't getting
the warning anymore
- Minor fix to clear the `ghprbPullLongDescription` environment variable during
tests, otherwise my PR/commit message causes my new test assertions to fail