### PR TITLE
[Xamarin.Android.Build.Tasks] Android design-time intellisense doesn't process global cache AARs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -87,7 +87,7 @@ using System.Runtime.CompilerServices;
 					b.Target = "Compile";
 					Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, parameters: new string [] { "DesignTimeBuild=true" }, environmentVariables: envVar),
 						"first build failed");
-					Assert.AreEqual (!useManagedParser, b.LastBuildOutput.ContainsText ("Skipping GetAdditionalResourcesFromAssemblies"),
+					Assert.IsTrue(b.LastBuildOutput.ContainsText ("Skipping GetAdditionalResourcesFromAssemblies"),
 						"failed to skip the downloading of files.");
 					var items = new List<string> ();
 					string first = null;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1079,7 +1079,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_ManagedUpdateAndroidResgen" Condition=" '$(ManagedDesignTimeBuild)' == 'True' "
 		Inputs="@(AndroidResource);@(ReferencePath)"
 		Outputs="$(_AndroidManagedResourceDesignerFile)"
-		DependsOnTargets="_CreatePropertiesCache;_ExtractLibraryProjectImports">
+		DependsOnTargets="_CreatePropertiesCache;_ExtractLibraryProjectImports;_CreateAdditionalResourceCache">
 	<MakeDir Directories="$(_AndroidDesignTimeResDirIntermediate)" />
 	<!-- Parse primary R.java and create Resources.Designer.cs -->
 	<GenerateResourceDesigner
@@ -1090,7 +1090,7 @@ because xbuild doesn't support framework reference assemblies.
 		ProjectDir="$(ProjectDir)"
 		Resources="@(AndroidResource)"
 		ResourceDirectory="$(MonoAndroidResourcePrefix)"
-		AdditionalResourceDirectories="@(LibraryResourceDirectories)"
+		AdditionalResourceDirectories="@(LibraryResourceDirectories);@(_AdditionalAndroidResourcePaths->'%(Identity)\res')"
 		IsApplication="$(AndroidApplication)"
 		References="@(ReferencePath)"
 		UseManagedResourceGenerator="True"


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=60878

The Managed Resource Parsing system was not including items downloaded
into the global resource cache. As a result intellisense for those
items did not work.

This commit fixes that by adding `_CreateAdditionalResourceCache` to the
`_ManagedUpdateAndroidResgen` target. This will ensure that those
items are included. Note that we still DO NOT download files during
the designtime build. So if the required items have not been downloaded
the intellisense will still not show those items. The user will
need to do a full build to ensure those items are in place.