### PR TITLE
[Xamarin.ProjectTools] Fix an IO error when reading process.log

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -349,7 +349,8 @@ namespace Xamarin.ProjectTools
 
 				if (nativeCrashDetected) {
 					Console.WriteLine ($"Native crash detected! Running the build for {projectOrSolution} again.");
-					File.Move(processLog, processLog + ".bak");
+					if (attempt == 0)
+						File.Move (processLog, processLog + ".bak");
 					continue;
 				} else {
 					break;


### PR DESCRIPTION
If we hit a native crash in both of the attempts to run an
msbuild test we get an IO exception when trying to append the
'process.log' to the build output.

`System.IO.FileNotFoundException: Could not find file process.log`

This is because `process.log` was moved to `process.log.bak` when
we get a nartive crash.

What we want is to ignore any native crashes on the first run of
the test. If we still get a native crash on the next run we should
log it.

So on the first crash we Move the file over to the `process.log.bak`.
But we only do this on the first crash (attempt == 0). Otherwise we
end up moving the file again and we hit an error when trying to
append the process.log to the build output.