### PR TITLE
[Xamarin.Android.Build.Tasks] Android design-time intellisense gets deleted by IncrementalClean

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -99,12 +99,19 @@ using System.Runtime.CompilerServices;
 						first = items.First ();
 						Assert.IsTrue (items.All (x => x == first), "All Items should have matching values");
 					}
+					var designTimeDesigner = Path.Combine (path, proj.ProjectName, proj.IntermediateOutputPath, "designtime", "Resource.designer.cs");
+					if (useManagedParser) {
+						Assert.IsTrue (File.Exists (designTimeDesigner), $"{designTimeDesigner} should have been created.");
+					}
 					WaitFor (1000);
 					b.Target = "Build";
 					Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, parameters: new string [] { "DesignTimeBuild=false" }, environmentVariables: envVar), "second build failed");
 					Assert.IsFalse(b.Output.IsTargetSkipped ("_BuildAdditionalResourcesCache"), "_BuildAdditionalResourcesCache should have run.");
 					Assert.IsTrue (b.LastBuildOutput.ContainsText ($"Downloading {url}") || b.LastBuildOutput.ContainsText ($"reusing existing archive: {zipPath}"), $"{url} should have been downloaded.");
 					Assert.IsTrue (File.Exists (Path.Combine (extractedDir, "1", "content", "android-N", "aapt")), $"Files should have been extracted to {extractedDir}");
+					if (useManagedParser) {
+						Assert.IsTrue (File.Exists (designTimeDesigner), $"{designTimeDesigner} should not have been deleted.");
+					}
 					items.Clear ();
 					if (!useManagedParser) {
 						foreach (var file in Directory.EnumerateFiles (Path.Combine (path, proj.ProjectName, proj.IntermediateOutputPath, "android"), "R.java", SearchOption.AllDirectories)) {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1106,7 +1106,7 @@ because xbuild doesn't support framework reference assemblies.
 	<WriteLinesToFile
 		Condition="Exists ('$(_AndroidManagedResourceDesignerFile)')"
 		File="$(IntermediateOutputPath)$(CleanFile)"
-		Lines="$(_AndroidManagedResourceDesignerFile)"
+		Lines="$([System.IO.Path]::GetFullPath('$(_AndroidManagedResourceDesignerFile)'))"
 		Overwrite="false" />
 </Target>
 	


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=60880

For some weird reason, writing the designer.cs location to the
FileWrites file was not working. It was getting deleted still.

So lets add it to the Xamarin.Android.Windows.targets. This is what
we use to make sure files are NOT deleted by the IncrementalClean.
Again no idea why writing the data to the FileWrites file as NOT
working.

A unit test has also been updated to make sure the designtime
file is NOT removed on the next full build after the designtime
one.