### PR TITLE
Fix a subtle logic bug with null conditional operator

### DIFF
--- a/tests/Xamarin.Android.Bcl-Tests/App.cs
+++ b/tests/Xamarin.Android.Bcl-Tests/App.cs
@@ -66,7 +66,7 @@ namespace Xamarin.Android.BclTests
 
 		internal static ITestFilter UpdateFilter (ITestFilter filter)
 		{
-			if (ExcludeTestNames?.Length == 0)
+			if (ExcludeTestNames == null || ExcludeTestNames.Length == 0)
 				return filter;
 			var excludeTestNamesFilter  = new SimpleNameFilter (ExcludeTestNames);
 			return new AndFilter (filter, new NotFilter (excludeTestNamesFilter));


### PR DESCRIPTION
This commit fixes one of the subtle pitfalls of the null conditional
operator (and the biggest issue with it, IMO, as it introduces subtle
*runtime* bugs which may be hard to find, depending on where and how
the code is used)

It is tempting to use the null conditional operator as follows:

    string[] arr = null;
    if (arr?.Length == 0)
       Console.WriteLine ("Array has no elements or is null");
    Console.WriteLine ($"Array contains {arr.Length} elements");

However, the above code will throw a NullReferenceException in the last
line. The reason is that the conditional expression preceeding it will
yield `false` because the ?. operator returns a nullable type which, in
this case, will have a value of `null` - and that value is not equal to
`0` obviously. Yet since the conditional expression type is `int?` and
an implicit conversion to `int` exists, the compiler will NOT issue an
error (if you replace `0` with, say, `true` there will be a compilation
error) and happily generate code which will yield a false positive thus
leading to the runtime exception.

While it would be possible to modify the existing condition to the
following form:

    if (!(arr?.Length >= 0))

it looks cumbersome and unnecessarily complicates reading the code. Thus,
in instances when the null conditional operator applies to nullable types
instead of reference ones, it is safer to just use the good old long equivalent
to the comfortable ?. shortcut.

Arguably, in this case the NREX won't happen since our array is not `null`,
but I'm a big proponent of correct code, so... :)