### PR TITLE
[xabuild] better NetStandard support

### DIFF
--- a/tools/xabuild/XABuild.cs
+++ b/tools/xabuild/XABuild.cs
@@ -64,6 +64,7 @@ namespace Xamarin.Android.Build
 			SetProperty (toolsets, "MSBuildExtensionsPath", paths.MSBuildExtensionsPath);
 			SetProperty (toolsets, "MSBuildExtensionsPath32", paths.MSBuildExtensionsPath);
 			SetProperty (toolsets, "RoslynTargetsPath", Path.Combine (paths.MSBuildBin, "Roslyn"));
+			SetProperty (toolsets, "NuGetRestoreTargets", paths.NuGetRestoreTargets);
 			SetProperty (toolsets, "MonoAndroidToolsDirectory", paths.MonoAndroidToolsDirectory);
 			SetProperty (toolsets, "TargetFrameworkRootPath", paths.FrameworksDirectory + Path.DirectorySeparatorChar); //NOTE: Must include trailing \
 			if (!string.IsNullOrEmpty (paths.AndroidSdkDirectory))


### PR DESCRIPTION
This solves two problems with `xabuild.exe`:
- `xabuild.exe /t:Restore` did not work on Windows
- `xabuild.exe` only supported .NET Core 2.0.0

To fix these issues:
- Set `NuGetRestoreTargets` property, this allows Windows to properly
import `NuGet.targets`, which fixes the `Restore` target
- I found this property in
`%VsInstallDir%\MSBuild\15.0\Microsoft.Common.targets\ImportAfter\Microsoft.NuGet.ImportAfter.targets`
- Note that on Windows I had to use the `ProgramW6432` environment
variable, so that a 32-bit process on a 64-bit machine could find the
path to `C:\Program Files\`
- Added logic to locate the newest version of .NET Core within the
`dotnet/sdk` directory. This allows `xabuild.exe` to function on
machines that have .NET Core 2.0.3, 1.0.0, etc.