### PR TITLE
[linker] Preserve System.dll parts conditionaly

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/PreserveLists/System.xml
+++ b/src/Xamarin.Android.Build.Tasks/Linker/PreserveLists/System.xml
@@ -3,9 +3,7 @@
 	<assembly fullname="System">
 		<type fullname="System.Configuration.DefaultConfig" />
 		<type fullname="System.Diagnostics.DefaultTraceListener" />
-		<type fullname="System.Diagnostics.FileVersionInfo" />
 		<type fullname="System.Diagnostics.Process" />
-		<type fullname="System.Diagnostics.ProcessModule" />
 		<type fullname="System.IO.FAMWatcher" />
 		<type fullname="System.IO.FileSystemWatcher" />
 		<type fullname="System.IO.InotifyWatcher" />
@@ -19,11 +17,6 @@
 		<type fullname="System.Net.HttpRequestCreator">
 			<method signature="System.Void .ctor()" />
 		</type>
-		<type fullname="System.Net.SocketAddress" />
-		<type fullname="System.Net.Sockets.LingerOption" />
-		<type fullname="System.Net.Sockets.Socket" />
-		<type fullname="System.Net.Sockets.MulticastOption" preserve="fields" />
-		<type fullname="System.Net.Sockets.Socket/SocketAsyncResult" preserve="fields" />
 		<type fullname="System.Net.Sockets.SocketException" />
 	</assembly>
 </linker>


### PR DESCRIPTION
Do not always preserve System.dll parts. The ProcessSystem method was
ported from Xamarin.MaciOS.

I run across this when testing linker-analyzer tool. The
`System.Net.Sockets.Socket` looked like a good candidate to check as
it was big and had only few dependencies. It turned out we preserve
the whole type unconditionaly.

```
Distance | TypeDef:System.Net.Sockets.Socket [total deps: 4][size: 16927 total size: 16927]
------------------------------------------------------------------------
       1 | Other:ResolveFromXmlStep: descriptor System.xml from Xamarin.Android.Build.Tasks, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
       1 | Assembly:System, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
       2 | Other:MonoDroid.Tuner.MonoDroidMarkStep
```

I have also found out that Xamarin.MaciOS has already better solution
for it, so I have ported the relevant parts.

After this we have

```
Distance | TypeDef:System.Net.Sockets.Socket [total deps: 21][size: 5320 total size: 5320]
------------------------------------------------------------------------
       1 | Method:System.Boolean System.Net.Sockets.Socket::get_SupportsIPv6()
       2 | Method:System.Net.IPHostEntry System.Net.Dns::hostent_to_IPHostEntry(System.String,System.String,System.String[],System.String[])
       3 | Assembly:System, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
       4 | Other:MonoDroid.Tuner.MonoDroidMarkStep
       3 | Method:System.Net.IPHostEntry System.Net.Dns::GetHostByAddressFromString(System.String,System.Boolean)
       4 | Method:System.Net.IPHostEntry System.Net.Dns::GetHostByAddress(System.Net.IPAddress)
       4 | Method:System.Net.IPHostEntry System.Net.Dns::GetHostByAddress(System.String)
       5 | Method:System.Net.IPHostEntry System.Net.Dns::Resolve(System.String)
       6 | Method:System.IAsyncResult System.Net.Dns::BeginResolve(System.String,System.AsyncCallback,System.Object)
       4 | Method:System.Net.IPHostEntry System.Net.Dns::GetHostEntry(System.Net.IPAddress)
       5 | Method:System.IAsyncResult System.Net.Dns::BeginGetHostEntry(System.Net.IPAddress,System.AsyncCallback,System.Object)
       6 | Method:System.Threading.Tasks.Task`1<System.Net.IPHostEntry> System.Net.Dns::GetHostEntryAsync(System.Net.IPAddress)
       5 | Method:System.Net.IPHostEntry System.Net.Dns::GetHostEntry(System.String)
       6 | Method:System.IAsyncResult System.Net.Dns::BeginGetHostEntry(System.String,System.AsyncCallback,System.Object)
       7 | Method:System.Threading.Tasks.Task`1<System.Net.IPHostEntry> System.Net.Dns::GetHostEntryAsync(System.String)
       6 | Method:System.Net.IPAddress[] System.Net.Dns::GetHostAddresses(System.String)
       7 | Method:System.IAsyncResult System.Net.Dns::BeginGetHostAddresses(System.String,System.AsyncCallback,System.Object)
       8 | Method:System.Threading.Tasks.Task`1<System.Net.IPAddress[]> System.Net.Dns::GetHostAddressesAsync(System.String)
       3 | Method:System.Net.IPHostEntry System.Net.Dns::GetHostByName(System.String)
       4 | Method:System.IAsyncResult System.Net.Dns::BeginGetHostByName(System.String,System.AsyncCallback,System.Object)
```

With template XA app we save 1% of apk size. Let see if it will also
show in the sizes measurement plot. Note that linker-analyzer sizes
now represent only method body sizes.