### PR TITLE
[tests] RunningMSBuild likely should be set on Windows

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -53,9 +53,9 @@ namespace Xamarin.ProjectTools
 
 		public string XABuildExe {
 			get {
+				RunningMSBuild = true;
 				string xabuild;
 				if (IsUnix) {
-					RunningMSBuild = true;
 					var useMSBuild = Environment.GetEnvironmentVariable ("USE_MSBUILD");
 					if (!string.IsNullOrEmpty (useMSBuild) && useMSBuild == "0" && !RequiresMSBuild) {
 						RunningMSBuild = false;


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/Default/_build/index?buildId=1180513

The Xamarin.Android.Build.Tests aren't creating binary logs on Windows
at the moment, due to `RunningMSBuild` not being set. This flag is
probably supposed to be set on Windows, it may fix some tests as well as
enable binary logs.