### PR TITLE
[java.interop] improve JavaCast() for interfaces

### DIFF
--- a/src/Mono.Android/Java.Interop/JavaObjectExtensions.cs
+++ b/src/Mono.Android/Java.Interop/JavaObjectExtensions.cs
@@ -63,11 +63,7 @@ namespace Java.Interop {
 				return (TResult) CastClass (instance, resultType);
 			}
 			else if (resultType.IsInterface) {
-				Type invokerType = GetHelperType (resultType, "Invoker");
-				if (invokerType == null)
-					throw new ArgumentException ("Unable to get Invoker for interface '" + resultType.FullName + "'.", "TResult");
-				Func<IntPtr, JniHandleOwnership, TResult> getObject = (Func<IntPtr, JniHandleOwnership, TResult>) Delegate.CreateDelegate (typeof (Func<IntPtr, JniHandleOwnership, TResult>), invokerType, "GetObject");
-				return getObject (instance.Handle, JniHandleOwnership.DoNotTransfer);
+				return (TResult) Java.Lang.Object.GetObject (instance.Handle, JniHandleOwnership.DoNotTransfer, resultType);
 			}
 			else
 				throw new NotSupportedException (string.Format ("Unable to convert type '{0}' to '{1}'.",
@@ -113,11 +109,7 @@ namespace Java.Interop {
 				return CastClass (instance, resultType);
 			}
 			else if (resultType.IsInterface) {
-				Type invokerType = GetHelperType (resultType, "Invoker");
-				if (invokerType == null)
-					throw new ArgumentException ("Unable to get Invoker for interface '" + resultType.FullName + "'.", "resultType");
-				var getObject = invokerType.GetMethod ("GetObject", new[]{typeof (IntPtr), typeof (JniHandleOwnership)});
-				return (IJavaObject) getObject.Invoke (null, new object[]{instance.Handle, JniHandleOwnership.DoNotTransfer});
+				return Java.Lang.Object.GetObject (instance.Handle, JniHandleOwnership.DoNotTransfer, resultType);
 			}
 			else
 				throw new NotSupportedException (string.Format ("Unable to convert type '{0}' to '{1}'.",

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Extensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Extensions.cs
@@ -98,5 +98,60 @@ namespace MonoDroid.Tuner {
 			}
 			return false;
 		}
+
+		const string RegisterAttribute = "Android.Runtime.RegisterAttribute";
+
+		private static bool IsRegisterAttribute (CustomAttribute attribute)
+		{
+			var constructor = attribute.Constructor;
+
+			if (constructor.DeclaringType.FullName != RegisterAttribute)
+				return false;
+
+			if (!constructor.HasParameters)
+				return false;
+
+			if (constructor.Parameters.Count != 3)
+				return false;
+
+			return true;
+		}
+
+		public static bool TryGetRegisterAttribute (this MethodDefinition method, out CustomAttribute register)
+		{
+			register = null;
+
+			if (!method.HasCustomAttributes)
+				return false;
+
+			foreach (CustomAttribute attribute in method.CustomAttributes) {
+				if (!IsRegisterAttribute (attribute))
+					continue;
+
+				register = attribute;
+				return true;
+			}
+
+			return false;
+		}
+
+		public static bool TryGetRegisterMember (this MethodDefinition md, out string method)
+		{
+			CustomAttribute register;
+			method = null;
+
+			if (!md.TryGetRegisterAttribute (out register))
+				return false;
+
+			if (register.ConstructorArguments.Count != 3)
+				return false;
+
+			method = (string)register.ConstructorArguments [2].Value;
+
+			if (string.IsNullOrEmpty (method))
+				return false;
+
+			return true;
+		}
 	}
 }


### PR DESCRIPTION
Currently, interfaces generate `Invoker` classes such as:
```
// src/Mono.Android/obj/Debug/android-26/mcw/Java.Lang.IAppendable.cs
partial class IAppendableInvoker {
        public static IAppendable GetObject (IntPtr handle, JniHandleOwnership transfer)
        {
            return global::Java.Lang.Object.GetObject<IAppendable>(handle, transfer);
        }
}
```

`JavaCast` was previously looking up these `Invoker` types and calling
the `GetObject` method via reflection. We can simplify this by just calling
`Java.Lang.Object.GetObject()` directly—bypassing all the reflection.

One day we might be able to drop the generated `Invoker` method from
generator, but compiled bindings would break on older versions of
Xamarin.Android. It might be *instead* worthwhile look into allowing
the linker to strip the `*Invoker.GetObject()` methods that are now
not used anymore.