### PR TITLE
Fix build on Debian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,11 @@ linux-prepare::
 	if [ "x$$BINFMT_WARN" = "xyes" ]; then \
 		cat Documentation/binfmt_misc-warning-Linux.txt ; \
 	fi; \
-	if [ -f build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO).sh ]; then \
-		sh build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO).sh; \
-	elif [ -f build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO)-$(LINUX_DISTRO_RELEASE).sh ]; then \
+	if [ -f build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO)-$(LINUX_DISTRO_RELEASE).sh ]; then \
 		sh build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO)-$(LINUX_DISTRO_RELEASE).sh; \
-	fi; \
+	elif [ -f build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO).sh ]; then \
+		sh build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO).sh; \
+	fi
 
 # $(call GetPath,path)
 GetPath   = $(shell $(MSBUILD) $(MSBUILD_FLAGS) /p:DoNotLoadOSProperties=True /nologo /v:minimal /t:Get$(1)FullPath build-tools/scripts/Paths.targets | tr -d '[[:space:]]' )

--- a/build-tools/libzip/libzip.props
+++ b/build-tools/libzip/libzip.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-      <_LinuxBuildLibZip Condition=" '$(_LinuxBuildLibZip)' == '' AND '$(HostOS)' == 'Linux' AND '$(HostOsName)' != 'Ubuntu' ">true</_LinuxBuildLibZip>
+      <_LinuxBuildLibZip Condition=" '$(_LinuxBuildLibZip)' == '' AND '$(HostOS)' == 'Linux' AND '$(HostOsFlavor)' != 'Debian' ">true</_LinuxBuildLibZip>
   </PropertyGroup>
 </Project>

--- a/build-tools/scripts/dependencies/debian-common.sh
+++ b/build-tools/scripts/dependencies/debian-common.sh
@@ -1,0 +1,47 @@
+DEBIAN_COMMON_DEPS="autoconf
+	autotools-dev
+	automake
+	clang
+	curl
+	g++-mingw-w64
+	gcc-mingw-w64
+	git
+	libtool
+	libz-mingw-w64-dev
+	libzip4
+	linux-libc-dev
+	make
+	openjdk-8-jdk
+	unzip
+	vim-common
+	"
+
+if [ "$OS_ARCH" = "x86_64" ]; then
+UBUNTU_DEPS="$UBUNTU_DEPS
+	lib32stdc++6
+	lib32z1
+	gcc-multilib
+	g++-multilib
+	"
+fi
+
+debian_install()
+{
+	if [ "$NO_SUDO" = "true" ]; then
+		for p in $DISTRO_DEPS; do
+			if dpkg -l $p > /dev/null 2>&1 ; then
+				echo "[INSTALLED] $p"
+			else
+				echo "[ MISSING ] $p"
+				PACKAGES_MISSING=yes
+			fi
+		done
+		if [ "x$PACKAGES_MISSING" = "xyes" ]; then
+			echo Some packages are missing, cannot continue
+			echo
+			exit 1
+		fi
+	else
+		sudo apt-get -f -u install $DISTRO_DEPS
+	fi
+}

--- a/build-tools/scripts/dependencies/linux-prepare-Debian.sh
+++ b/build-tools/scripts/dependencies/linux-prepare-Debian.sh
@@ -1,0 +1,7 @@
+. "`dirname $0`"/debian-common.sh
+
+DISTRO_DEPS="$DEBIAN_COMMON_DEPS \
+    zlib1g-dev
+"
+
+debian_install

--- a/build-tools/scripts/dependencies/linux-prepare-Ubuntu.sh
+++ b/build-tools/scripts/dependencies/linux-prepare-Ubuntu.sh
@@ -1,46 +1,13 @@
-UBUNTU_DEPS="autoconf 
-	autotools-dev 
-	automake 
-	clang 
-	curl 
-	g++-mingw-w64 
-	gcc-mingw-w64 
-	git 
-	libtool 
-	libz-mingw-w64-dev 
-	libzip4 
-	linux-libc-dev 
-	make 
-	openjdk-8-jdk 
-	unzip 
-	vim-common
-	"
+. "`dirname $0`"/debian-common.sh
+
+DISTRO_DEPS="$DEBIAN_COMMON_DEPS"
 
 if [ "$OS_ARCH" = "x86_64" ]; then
-UBUNTU_DEPS="$UBUNTU_DEPS 
-	lib32stdc++6 
-	lib32z1 
-	gcc-multilib 
-	g++-multilib 
-	libx32tinfo-dev 
-	linux-libc-dev:i386 
+DISTRO_DEPS="$DISTRO_DEPS
+	libx32tinfo-dev
+	linux-libc-dev:i386
 	zlib1g-dev:i386
 	"
-fi 
-if [ "$NO_SUDO" = "true" ]; then
-	for p in $UBUNTU_DEPS; do 
-		if dpkg -l $p > /dev/null 2>&1 ; then 
-			echo "[INSTALLED] $p" 
-		else 
-			echo "[ MISSING ] $p" 
-			PACKAGES_MISSING=yes 
-		fi 
-	done 
-	if [ "x$PACKAGES_MISSING" = "xyes" ]; then 
-		echo Some packages are missing, cannot continue 
-		echo 
-		exit 1
-	fi
-else
-	sudo apt-get -f -u install $UBUNTU_DEPS
 fi
+
+debian_install

--- a/build-tools/scripts/generate-os-info
+++ b/build-tools/scripts/generate-os-info
@@ -37,6 +37,11 @@ function getInfo_Linux()
       OS_RELEASE="`lsb_release -rs`"
     fi
 
+    case "$OS_NAME" in
+      Ubuntu|Debian) HOST_OS_FLAVOR=Debian ;;
+      *) OS_FLAVOR=Generic ;;
+    esac
+
     HOST_CPUS="`nproc`"
 
     if echo $compiler_version | grep -i "Free Software Foundation" > /dev/null 2>&1; then
@@ -89,6 +94,7 @@ function getInfo_Darwin()
     HOST_CXX32="clang++ -m32"
     HOST_CC64=clang
     HOST_CXX64=clang++
+    HOST_OS_FLAVOR=macOS
 }
 
 if [ -z "$1" ]; then
@@ -108,6 +114,7 @@ cat <<EOF > "$1"
     <PropertyGroup>
         <HostOS Condition=" '\$(HostOS)' == '' ">$OS_TYPE</HostOS>
         <HostOsName Condition=" '\$(HostOsName)' == '' ">$OS_NAME</HostOsName>
+        <HostOsFlavor Condition=" '\$(HostOsFlavor)' == '' ">$HOST_OS_FLAVOR</HostOsFlavor>
         <HostOsRelease Condition=" '\$(HostOsRelease)' == '' ">$OS_RELEASE</HostOsRelease>
         <HostTriplet Condition=" '\$(HostTriplet)' == '' ">$HOST_TRIPLET</HostTriplet>
         <HostTriplet32 Condition=" '\$(HostTriplet32)' == '' ">$HOST_TRIPLET32</HostTriplet32>


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=60901

The root cause of the bug is the condition in build-tools/libzip/libzip.props
which checks whether to build libzip or not and, currently, does NOT build the
library only on Ubuntu machines. The reason for this was that, so far, none of
us tested the build on Debian and it wasn't certain what, if any, changes would
be required (despite Ubuntu being based on Debian) in order for the build to
work on Debian proper and, possibly, other related distros.

This commit introduces a new msbuild property, `$(HostOsFlavor)` which can be
used to cluster related distros/operating systems into groups with the purpose
of sharing certain behaviors or operations - like building, or not, of libzip.

This commit also introduces a `make prepare` script to install dependencies on
Debian (tested on Debian 9.1.2 64-bit) as well as rearranges the order in which
we check for distro-specific prepration script. We now first seek for script
specific to the current distro version/release and only then for the "generic"
script for this distribution.

With the changes in place `make prepare && make` work start-to-finish on Debian.