### PR TITLE
[Xamarin.ProjectTools] Reset the native crash flag.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -351,6 +351,7 @@ namespace Xamarin.ProjectTools
 					Console.WriteLine ($"Native crash detected! Running the build for {projectOrSolution} again.");
 					if (attempt == 0)
 						File.Move (processLog, processLog + ".bak");
+					nativeCrashDetected = false;
 					continue;
 				} else {
 					break;


### PR DESCRIPTION
If we detected a native crash on the first run of the
test we did NOT reset it.. We really should otherwise we
get incorrect log messasges on the next build.