### PR TITLE
[Xamarin.Android.Build.Tasks] Android Defines are not available in DesignTime Builds.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -77,6 +77,32 @@ printf ""%d"" x
 		}
 
 		[Test]
+		public void DesignTimeBuildHasAndrodDefine ()
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+
+			};
+			proj.Sources.Add (new BuildItem ("Compile", "IsAndroidDefined.cs") {
+				TextContent = () => @"
+namespace Xamarin.Android.Tests
+{
+	public class Foo {
+		public void FooMethod () {
+#if !__ANDROID__ || !__MOBILE__
+			Compile Error please :)
+#endif
+		}
+	}
+}
+",
+			});
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName ))) {
+				b.Target = "Compile";
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
+		[Test]
 		public void BuildApplicationAndClean ([Values (false, true)] bool isRelease)
 		{
 			var proj = new XamarinAndroidApplicationProject () {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -522,6 +522,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
  <PropertyGroup>
    <CompileDependsOn>
      _SetupDesignTimeBuildForCompile;
+     _AddAndroidDefines;
      $(CompileDependsOn);
    </CompileDependsOn>
  </PropertyGroup>


### PR DESCRIPTION
The DesignTime build does not include the required Android
Defines. As a result we can get into a situation where shared
code is not compiled correctly. The Intellisense will therefore
be inaccurate or worse the design time build fails and we get
no intellisense at all.