### PR TITLE
[tests] fix for FSharp targets on Windows

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
@@ -43,6 +43,12 @@ Copyright (C) 2012 Xamarin. All rights reserved.
       Condition="'$(Language)' != 'F#' And Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')"
       Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets" />
     <Import
+      Condition="'$(Language)' != 'F#' And Exists('$(FSharpInstallDir)Microsoft.FSharp.Targets')"
+      Project="$(FSharpInstallDir)Microsoft.FSharp.Targets" />
+    <Import
+      Condition="'$(Language)' != 'F#' And Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.1\Framework\v4.0\Microsoft.FSharp.Targets')"
+      Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.1\Framework\v4.0\Microsoft.FSharp.Targets" />
+    <Import
       Condition="'$(Language)' != 'F#' And Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets')"
       Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets" />
     <Import


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/Default/_build/index?buildId=1188880&_a=summary&tab=ms.vss-test-web.test-result-details

Our FSharp tests are failing on Windows due to the way we are having to
import `Microsoft.FSharp.targets`:

```
<Import
    Condition="'$(Language)' != 'F#' And Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')"
    Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets"
/>
```

Since `xabuild.exe` is modifying `$(MSBuildExtensionsPath)` to a path in
XA's build tree, the `Condition` always evaluates to `False`--even though
the search path fallbacks would have located it. Since we are having to
use `Condition` and check for multiple paths for F#, MSBuild's search path
fallback logic will not be able to work in this file.

Two changes to improve this, which should fix the tests on Windows:
- Added F# 4.1 directory searching, as this was missing
- Added a lookup of the `FSHARPINSTALLDIR` environment variable. This
was installed system-wide on my machine from Visual Studio 2017 15.4. It
is also already set on our VSTS build agents.