### PR TITLE
[Xamarin.Android.Build.Tasks] Fix IncrementalClean on msbuild. (#1063)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Common/ImportAfter/Xamarin.Android.Windows.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Common/ImportAfter/Xamarin.Android.Windows.targets
@@ -14,7 +14,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	</PropertyGroup>
 
 	<Target Name="_RegisterMdbFilesWithFileWrites" BeforeTargets="IncrementalClean">  
-		<CreateItem Include="$(OutDir)*.dll.mdb;$(MonoAndroidIntermediateAssemblyDir)*.dll.mdb">  
+		<CreateItem Include="$(OutDir)*.dll.mdb;$(MonoAndroidIntermediateAssemblyDir)*.dll.mdb;$(_AndroidManagedResourceDesignerFile)">
 			<Output TaskParameter="Include" ItemName="_FilesToRegister" />  
 		</CreateItem>  
 		<CreateItem Include="$([System.IO.Path]::GetFullPath('%(_FilesToRegister.Identity)'))"


### PR DESCRIPTION
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=60880

Commit 552ad5d7 added code to make sure the `designtime` build
files are NOT deleted by the `IncrementalClean` target.
While it fixed the issue for `xbuild` it did NOT fix it for
`msbuild`. As a result the file was still deleted.

So we need to add the file to the target in the
Xamarin.Android.Windows.targets to ensure that it is NOT
removed (just like the mdb files).