### PR TITLE
[Xamarin.Android.Build.Tasks] fix for proguard enclosing char on windows

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
@@ -75,31 +75,28 @@ namespace Xamarin.Android.Tasks
 
 		void GenerateProguardCommands (CommandLineBuilder cmd)
 		{
-			var enclosingChar = OS.IsWindows ? "\"" : string.Empty;
+			var enclosingChar = OS.IsWindows ? "\"" : "'";
 			var jars = JavaLibraries.Select (i => i.ItemSpec).Concat (new string [] { Path.Combine (ClassesOutputDirectory, "classes.zip") });
 			cmd.AppendSwitchIfNotNull ("-jar ", ProguardJarPath);
-			cmd.AppendSwitchUnquotedIfNotNull ("-injars ", $"{enclosingChar}'" + string.Join ($"{ProguardInputJarFilter}'{Path.PathSeparator}'", jars) + $"{ProguardInputJarFilter}'{enclosingChar}");
+			cmd.AppendSwitchUnquotedIfNotNull ("-injars ", $"{enclosingChar}" + string.Join ($"{ProguardInputJarFilter}{enclosingChar}{Path.PathSeparator}{enclosingChar}", jars) + $"{ProguardInputJarFilter}{enclosingChar}");
 			cmd.AppendSwitch ("-dontwarn");
 			cmd.AppendSwitch ("-forceprocessing");
 			cmd.AppendSwitchIfNotNull ("-outjars ", tempJar);
-			cmd.AppendSwitchIfNotNull ("-libraryjars ", $"'{Path.Combine (AndroidSdkBuildToolsPath, "lib", "shrinkedAndroid.jar")}'");
+			cmd.AppendSwitchIfNotNull ("-libraryjars ", $"{enclosingChar}{Path.Combine (AndroidSdkBuildToolsPath, "lib", "shrinkedAndroid.jar")}{enclosingChar}");
 			cmd.AppendSwitch ("-dontoptimize");
 			cmd.AppendSwitch ("-dontobfuscate");
 			cmd.AppendSwitch ("-dontpreverify");
-			cmd.AppendSwitchUnquotedIfNotNull ("-include ", $"{enclosingChar}'{Path.Combine (AndroidSdkBuildToolsPath, "mainDexClasses.rules")}'{enclosingChar}");
+			cmd.AppendSwitchUnquotedIfNotNull ("-include ", $"{enclosingChar}{Path.Combine (AndroidSdkBuildToolsPath, "mainDexClasses.rules")}{enclosingChar}");
 		}
 
 		void GenerateMainDexListBuilderCommands(CommandLineBuilder cmd)
 		{
-			var enclosingDoubleQuote = OS.IsWindows ? "\"" : string.Empty;
-			var enclosingQuote = OS.IsWindows ? string.Empty : "'";
+			var enclosingChar = OS.IsWindows ? "\"" : "'";
 			var jars = JavaLibraries.Select (i => i.ItemSpec).Concat (new string [] { Path.Combine (ClassesOutputDirectory, "classes.zip") });
 			cmd.AppendSwitchIfNotNull ("-Djava.ext.dirs=", Path.Combine (AndroidSdkBuildToolsPath, "lib"));
 			cmd.AppendSwitch ("com.android.multidex.MainDexListBuilder");
-			cmd.AppendSwitch ($"{enclosingDoubleQuote}{tempJar}{enclosingDoubleQuote}");
-			cmd.AppendSwitchUnquotedIfNotNull ("", $"{enclosingDoubleQuote}{enclosingQuote}" +
-				string.Join ($"{enclosingQuote}{Path.PathSeparator}{enclosingQuote}", jars) + 
-				$"{enclosingQuote}{enclosingDoubleQuote}");
+			cmd.AppendSwitchUnquotedIfNotNull ("", $"{enclosingChar}{tempJar}{enclosingChar}");
+			cmd.AppendSwitchUnquotedIfNotNull ("", enclosingChar + string.Join ($"{enclosingChar}{Path.PathSeparator}{enclosingChar}", jars) + enclosingChar);
 			writeOutputToKeepFile = true;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
@@ -140,10 +140,10 @@ namespace Xamarin.Android.Tasks
 
 			var injars = new List<string> ();
 			var libjars = new List<string> ();
-			injars.Add (classesZip);
+			injars.Add (classesZip + ProguardInputJarFilter);
 			if (JavaLibrariesToEmbed != null)
 				foreach (var jarfile in JavaLibrariesToEmbed)
-					injars.Add (jarfile.ItemSpec);
+					injars.Add (jarfile.ItemSpec + ProguardInputJarFilter);
 
 			using (var xamcfg = File.Create (ProguardCommonXamarinConfiguration))
 				GetType ().Assembly.GetManifestResourceStream ("proguard_xamarin.cfg").CopyTo (xamcfg);
@@ -158,11 +158,11 @@ namespace Xamarin.Android.Tasks
 				.Select (s => s.Trim ())
 				.Where (s => !string.IsNullOrWhiteSpace (s));
 
-			var enclosingChar = OS.IsWindows ? "\"" : string.Empty;
+			var enclosingChar = OS.IsWindows ? "\"" : "'";
 
 			foreach (var file in configs) {
 				if (File.Exists (file))
-					cmd.AppendSwitchUnquotedIfNotNull ("-include ", $"{enclosingChar}'{file}'{enclosingChar}");
+					cmd.AppendSwitchUnquotedIfNotNull ("-include ", $"{enclosingChar}{file}{enclosingChar}");
 				else
 					Log.LogWarning ("Proguard configuration file '{0}' was not found.", file);
 			}
@@ -172,10 +172,9 @@ namespace Xamarin.Android.Tasks
 				foreach (var jarfile in ExternalJavaLibraries.Select (p => p.ItemSpec))
 					libjars.Add (jarfile);
 
-			cmd.AppendSwitchUnquotedIfNotNull ("-injars ", $"{enclosingChar}'" + string.Join ($"{ProguardInputJarFilter}'{Path.PathSeparator}'", injars.Distinct ()) + $"{ProguardInputJarFilter}'{enclosingChar}");
-
-			cmd.AppendSwitchUnquotedIfNotNull ("-libraryjars ", $"{enclosingChar}'" + string.Join ($"'{Path.PathSeparator}'", libjars.Distinct ()) + $"'{enclosingChar}");
-			
+			string delimiter = $"{enclosingChar}{Path.PathSeparator}{enclosingChar}";
+			cmd.AppendSwitchUnquotedIfNotNull ("-injars ", enclosingChar + string.Join (delimiter, injars.Distinct ()) + enclosingChar);
+			cmd.AppendSwitchUnquotedIfNotNull ("-libraryjars ", enclosingChar + string.Join (delimiter, libjars.Distinct ()) + enclosingChar);
 			cmd.AppendSwitchIfNotNull ("-outjars ", ProguardJarOutput);
 
 			if (EnableLogging) {


### PR DESCRIPTION
I noticed on Windows, the `Desugar(True, True, True)` test was failing
with:

```
java.io.IOException: Can't read
[E:\A\_work\1\s\bin\TestDebug\temp\Desugar(True,True,True)\obj\Release\android\bin\classes\classes.zip(!META-INF\MANIFEST.MF)]
(No such file or directory)
```

However, running locally proved the file does exist.

Somehow #1049 introduced a case where proguard is failing due to the
combination the new `(!META-INF/MANIFEST.MF)` filter and the parameters
passed to proguard in this test.

Looking into it, we had an odd form of how the paths were being passed
on Windows using a combination of single and double-quotes:

```
-injars "'path1(!META-INF/MANIFEST.MF)';'path2(!META-INF/MANIFEST.MF)'"
```
The way these paths were passed was not working on Windows after adding
this new filter--but only for this `Desugar` test... Most cases were
working, such as our tests around multi-dex and proguard.

It worked correctly on Windows when specified as:
```
-injars "path1(!META-INF/MANIFEST.MF)";"path2(!META-INF/MANIFEST.MF)"
```

So keep things consistent, I refactored the code to use " on Windows and
' on other platforms. This also resolved the issues in the `Desugar` test on
Windows, for which I also added an additional assertion.