### PR TITLE
Reduce Android.* dependency from Java.Interop repo.

### DIFF
--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
@@ -10,7 +10,7 @@ namespace Android.App
 	[AttributeUsage (AttributeTargets.Class, 
 			AllowMultiple=false, 
 			Inherited=false)]
-	public sealed partial class ActivityAttribute : Attribute {
+	public sealed partial class ActivityAttribute : Attribute, Java.Interop.IJniNameProviderAttribute {
 
 		public ActivityAttribute ()
 		{

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ApplicationAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ApplicationAttribute.cs
@@ -9,7 +9,7 @@ namespace Android.App {
 	[AttributeUsage (AttributeTargets.Assembly | AttributeTargets.Class, 
 			AllowMultiple=false, 
 			Inherited=false)]
-	public sealed partial class ApplicationAttribute : Attribute {
+	public sealed partial class ApplicationAttribute : Attribute, Java.Interop.IJniNameProviderAttribute {
 
 		public ApplicationAttribute ()
 		{

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/InstrumentationAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/InstrumentationAttribute.cs
@@ -6,7 +6,7 @@ namespace Android.App {
 	[AttributeUsage (AttributeTargets.Assembly | AttributeTargets.Class, 
 			AllowMultiple=true, 
 			Inherited=false)]
-	public sealed partial class InstrumentationAttribute : Attribute {
+	public sealed partial class InstrumentationAttribute : Attribute, Java.Interop.IJniNameProviderAttribute {
 
 		public InstrumentationAttribute ()
 		{

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ServiceAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ServiceAttribute.cs
@@ -9,7 +9,7 @@ namespace Android.App {
 	[AttributeUsage (AttributeTargets.Class, 
 			AllowMultiple=false, 
 			Inherited=false)]
-	public sealed partial class ServiceAttribute : Attribute {
+	public sealed partial class ServiceAttribute : Attribute, Java.Interop.IJniNameProviderAttribute {
 
 		public ServiceAttribute ()
 		{

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.Content/BroadcastReceiverAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.Content/BroadcastReceiverAttribute.cs
@@ -6,7 +6,7 @@ namespace Android.Content {
 	[AttributeUsage (AttributeTargets.Class, 
 			AllowMultiple=false, 
 			Inherited=false)]
-	public partial class BroadcastReceiverAttribute : Attribute {
+	public partial class BroadcastReceiverAttribute : Attribute, Java.Interop.IJniNameProviderAttribute {
 
 		public BroadcastReceiverAttribute ()
 		{

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.Content/ContentProviderAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.Content/ContentProviderAttribute.cs
@@ -6,7 +6,7 @@ namespace Android.Content {
 	[AttributeUsage (AttributeTargets.Class, 
 			AllowMultiple=false, 
 			Inherited=false)]
-	public partial class ContentProviderAttribute : Attribute {
+	public partial class ContentProviderAttribute : Attribute, Java.Interop.IJniNameProviderAttribute {
 
 		public ContentProviderAttribute (string[] authorities)
 		{

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.Runtime/RegisterAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.Runtime/RegisterAttribute.cs
@@ -6,7 +6,7 @@ namespace Android.Runtime {
 #if !JCW_ONLY_TYPE_NAMES
 	public
 #endif  // !JCW_ONLY_TYPE_NAMES
-	sealed class RegisterAttribute : Attribute {
+	sealed class RegisterAttribute : Attribute, Java.Interop.IJniNameProviderAttribute {
 
 		string connector;
 		string name;

--- a/src/Xamarin.Android.NamingCustomAttributes/Java.Interop/IJniNameProviderAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Java.Interop/IJniNameProviderAttribute.cs
@@ -1,0 +1,8 @@
+﻿using System;
+namespace Java.Interop
+{
+	public interface IJniNameProviderAttribute
+	{
+		string Name { get; }
+	}
+}

--- a/src/Xamarin.Android.NamingCustomAttributes/Xamarin.Android.NamingCustomAttributes.projitems
+++ b/src/Xamarin.Android.NamingCustomAttributes/Xamarin.Android.NamingCustomAttributes.projitems
@@ -21,5 +21,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Android.App\ServiceAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Android.App\InstrumentationAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Android.App\LayoutAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop\IJniNameProviderAttribute.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Those Attributes are specific to Android, but they have been part of
Java.Interop codebase because things were not that well separate.

Add a simple interface to avoid concrete dependencies to Android.*
attributes and make things simpler.