### PR TITLE
[Xamarin.ProjectTools] Only add the process.log if it exists.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -360,7 +360,8 @@ namespace Xamarin.ProjectTools
 
 			if (buildLogFullPath != null && processLog != null) {
 				Directory.CreateDirectory (Path.GetDirectoryName (buildLogFullPath));
-				File.AppendAllText (buildLogFullPath, File.ReadAllText (processLog));
+				if (File.Exists (processLog))
+					File.AppendAllText (buildLogFullPath, File.ReadAllText (processLog));
 			}
 			if (!result && ThrowOnBuildFailure) {
 				string message = "Build failure: " + Path.GetFileName (projectOrSolution) + (BuildLogFile != null && File.Exists (buildLogFullPath) ? "Build log recorded at " + buildLogFullPath : null);


### PR DESCRIPTION
This commit adds an additional check to only process the
process.log if the file exists. We might be in a situation
where nothing is written to StdOut or StdErr as a result we
might not get a log file. So lets not crash the test if it
does not exist.