### PR TITLE
[Xamarin.Android.Build.Tests] Fix detection of Emulators.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -16,8 +16,8 @@ namespace Xamarin.Android.Build.Tests
 		{
 			try {
 				var adbTarget = Environment.GetEnvironmentVariable ("ADB_TARGET");
-				HasDevices = string.Compare (RunAdbCommand ($"{adbTarget} shell getprop ro.build.version.sdk"),
-						"error: no devices/emulators found" , StringComparison.InvariantCultureIgnoreCase) != 0;
+				int sdkVersion = -1;
+				HasDevices = int.TryParse (RunAdbCommand ($"{adbTarget} shell getprop ro.build.version.sdk").Trim(), out sdkVersion) && sdkVersion != -1;
 			} catch (Exception ex) {
 				Console.Error.WriteLine ("Failed to determine whether there is Android target emulator or not" + ex);
 			}


### PR DESCRIPTION
If the `adb` command times out it will probably return
an empty string. In that case we should NOT run the
tests which need devices.

So instead of checking for an error, lets try to parse
the output to an int. We should be getting a valid
integer value back for the sdk version. If we do not then
we should not run those tests.