### PR TITLE
[Xamarin.Android.Build.Tasks] Dont clean the designtime folder

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1862,8 +1862,10 @@ public class Test
 				Assert.IsFalse (builder.Output.IsTargetSkipped ("_CreatePropertiesCache"), "target \"_CreatePropertiesCache\" should have been run.");
 				Assert.IsTrue (builder.Output.IsTargetSkipped ("_ResolveLibraryProjectImports"), "target \"_ResolveLibraryProjectImports\' should have been skipped.");
 				Assert.IsTrue (builder.Clean (proj), "Clean Should have succeeded");
+				builder.Target = "_CleanDesignTimeIntermediateDir";
+				Assert.IsTrue (builder.Build (proj), "_CleanDesignTimeIntermediateDir should have succeeded");
 				librarycache = Path.Combine (Root, path, proj.IntermediateOutputPath, "designtime", "libraryprojectimports.cache");
-				Assert.IsFalse (File.Exists (librarycache), $"'{librarycache}' should exist.");
+				Assert.IsFalse (File.Exists (librarycache), $"'{librarycache}' should not exist.");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2611,6 +2611,10 @@ because xbuild doesn't support framework reference assemblies.
 	<RemoveDirFixed Directories="$(OutDir)$(_AndroidPackage).apk.mSYM" Condition=" '$(_AndroidPackage)' != '' And Exists ('$(OutDir)$(_AndroidPackage).apk.mSYM')" />
 </Target>
 
+<Target Name="_CleanDesignTimeIntermediateDir">
+	<RemoveDirFixed Directories="$(_AndroidDesignTimeResDirIntermediate)" Condition="Exists ('$(_AndroidDesignTimeResDirIntermediate)')" />
+</Target>
+
 <Target Name="_CleanGeneratedDeploymentFiles">
 	<CreateItem Include="$(IntermediateOutputPath)*.deployment">
 		<Output TaskParameter="Include" ItemName="_OutputDeploymentFiles" />
@@ -2636,7 +2640,6 @@ because xbuild doesn't support framework reference assemblies.
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)proguard" Condition="Exists ('$(MonoAndroidIntermediate)proguard')" />
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediateResourceCache)" Condition="Exists ('$(MonoAndroidIntermediateResourceCache)')" />
 	<RemoveDirFixed Directories="$(_AndroidAotBinDirectory)" Condition="Exists ('$(_AndroidAotBinDirectory)')" />
-	<RemoveDirFixed Directories="$(_AndroidDesignTimeResDirIntermediate)" Condition="Exists ('$(_AndroidDesignTimeResDirIntermediate)')" />
 	<Delete Files="$(IntermediateOutputPath)_dex_stamp" />
  	<Delete Files="$(MonoAndroidIntermediate)R.cs.flag" />
 	<Delete Files="$(MonoAndroidIntermediate)acw-map.txt" />


### PR DESCRIPTION
Context https://bugzilla.xamarin.com/show_bug.cgi?id=60880

Turns out the design time build in Visual Studio does not
clean up after itself.. ever. So we really should not be
deleting the directory on a `Clean`.

This commit move that code into is own internal target
and updates the tests to reflect the changes.