### PR TITLE
[lint] JAVA_HOME must be set on Windows

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
@@ -51,6 +51,9 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string IntermediateOutputPath { get; set; }
 
+		[Required]
+		public string JavaSdkPath { get; set; }
+
 		/// <summary>
 		/// Location of an xml config files used to 
 		/// determine whether issues are enabled or disabled 
@@ -195,6 +198,7 @@ namespace Xamarin.Android.Tasks
 			}
 
 			Log.LogDebugMessage ("  TargetDirectory: {0}", TargetDirectory);
+			Log.LogDebugMessage ("  JavaSdkPath: {0}", JavaSdkPath);
 			Log.LogDebugMessage ("  EnabledChecks: {0}", EnabledIssues);
 			Log.LogDebugMessage ("  DisabledChecks: {0}", DisabledIssues);
 			Log.LogDebugMessage ("  CheckIssues: {0}", CheckIssues);
@@ -211,6 +215,8 @@ namespace Xamarin.Android.Tasks
 					EnabledIssues = CleanIssues (issue.Key, lintToolVersion, EnabledIssues, nameof (EnabledIssues) );
 				}
 			}
+
+			EnvironmentVariables = new [] { "JAVA_HOME=" + JavaSdkPath };
 
 			base.Execute ();
 
@@ -344,8 +350,10 @@ namespace Xamarin.Android.Tasks
 			}, (s, e) => {
 				if (!string.IsNullOrEmpty (e.Data))
 					sb.AppendLine (e.Data);
-			}
-			);
+			},
+			new Dictionary<string, string> {
+				{ "JAVA_HOME", JavaSdkPath }
+			});
 			var versionInfo = sb.ToString ();
 			if (result != 0 || versionInfo.Contains ("unknown")) {
 				Log.LogWarning ($"Could not get version from '{tool}'");

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Android.Tasks
 
 		readonly static byte[] Utf8Preamble = System.Text.Encoding.UTF8.GetPreamble ();
 
-		public static int RunProcess (string name, string args, DataReceivedEventHandler onOutput, DataReceivedEventHandler onError)
+		public static int RunProcess (string name, string args, DataReceivedEventHandler onOutput, DataReceivedEventHandler onError, Dictionary<string, string> environmentVariables = null)
 		{
 			var psi = new ProcessStartInfo (name, args) {
 				UseShellExecute = false,
@@ -40,6 +40,11 @@ namespace Xamarin.Android.Tasks
 				CreateNoWindow = true,
 				WindowStyle = ProcessWindowStyle.Hidden,
 			};
+			if (environmentVariables != null) {
+				foreach (var pair in environmentVariables) {
+					psi.EnvironmentVariables [pair.Key] = pair.Value;
+				}
+			}
 			Process p = new Process ();
 			p.StartInfo = psi;
 			

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -942,6 +942,7 @@ because xbuild doesn't support framework reference assemblies.
 		IntermediateOutputPath="$(IntermediateOutputPath)"
 		ToolPath="$(LintToolPath)"
 		ToolExe="$(LintToolExe)"
+		JavaSdkPath="$(JavaSdkDirectory)"
 	/>
 </Target>
 


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/Default/_build/index?buildId=1196396&_a=summary&tab=ms.vss-test-web.test-result-details

I am not sure how I missed this, but the `<Lint />` task was always
failing on Windows unless `JAVA_HOME` is set.

The error is:
```
LINT JAVA_HOME is not set and no 'java' command could be found in your PATH.
```

To fix this:
- Pass `$(JavaSdkDirectory)` to the `<Lint />` task
- Set `JAVA_HOME` for `ToolTask`'s `EnvironmentVariables` property
- Set `JAVA_HOME` when running `lint.bat --version`, I had to add an
optional parameter for environment variables to
`MonoAndroidHelper.RunProcess`