### PR TITLE
[tests] fixed FrameworkLibDirectory on Windows

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -262,7 +262,8 @@ namespace Xamarin.Android.Tests
 				Assert.AreEqual (expectedResult, b.Build (proj), "Build should have {0}.", expectedResult ? "succeeded" : "failed");
 				if (!expectedResult)
 					return;
-				if (checkMinLlvmPath) {
+				//NOTE: Windows has shortened paths such as: C:\Users\myuser\ANDROI~3\ndk\PLATFO~1\AN3971~1\arch-x86\usr\lib\libc.so
+				if (checkMinLlvmPath && !IsWindows) {
 					// LLVM passes a direct path to libc.so, and we need to use the libc.so
 					// which corresponds to the *minimum* SDK version specified in AndroidManifest.xml
 					// Since we overrode minSdkVersion=10, that means we should use libc.so from android-9.

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -122,7 +122,10 @@ namespace Xamarin.ProjectTools
 		{
 			var runtimeInfo = new List<RuntimeInfo> ();
 			var outdir = FrameworkLibDirectory;
-			var path = Path.Combine (outdir, IsUnix ? Path.Combine ("xbuild", "Xamarin", "Android", "lib") : "");
+			var path = Path.Combine (outdir, "xbuild", "Xamarin", "Android", "lib");
+			if (!Directory.Exists (path)) {
+				path = outdir;
+			}
 			foreach (var file in Directory.EnumerateFiles (path, "libmono-android.*.so", SearchOption.AllDirectories)) {
 				string fullFilePath = Path.GetFullPath (file);
 				DirectoryInfo parentDir = Directory.GetParent (fullFilePath);


### PR DESCRIPTION
When I originally setup `FrameworkLibDirectory` on Windows,
`setup-windows.exe` was the method for running these tests. Now that
`xabuild.exe` is used instead, we need this directory to also possibly
be used from within the build tree as when `IsUnix` is true.

Changes:
- `FrameworkLibDirectory` will return locations within the build tree on
windows
- A few places that used to have an `IsUnix` check such as
`AndroidMSBuildDirectory`, it made more sense to do a `Directory.Exists`,
and then fallback to using `FrameworkLibDirectory`
- Fixed the `CrossCompilerAvailable` method on Windows
- The `BuildAotApplication` test has a `Regex` that won't work on
Windows due to shortened paths. It looked best to skip this assertion.

This short fix a variety of tests on Windows, and hopefully un-ignore
many tests as well.