### PR TITLE
[build] fix Novell/*.MonoDroid.*.targets copy during build

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -60,6 +60,7 @@
     <ProjectReference Include="..\..\Xamarin.Android.Build.Tasks.csproj">
       <Project>{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}</Project>
       <Name>Xamarin.Android.Build.Tasks</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
For a little while, our build has been copying three files to the root
of our build tree:
- Novell/MonoDroid.FSharp.targets
- Novell/Novell.MonoDroid.Common.targets
- Novell/Novell.MonoDroid.CSharp.targets

These files are copied to build output in the
Xamarin.Android.Build.Tasks project, but they should go in
`bin/$(Configuration)` not the root of the build tree.

While looking at binary log output, I noticed the
Xamarin.Android.Build.Tests project was doing the copy due to having a
`<ProjectReference />` to Xamarin.Android.Build.Tasks.

Adding `<Private>False</Private>` to the `<ProjectReference />` fixes
these files from being copied, and doesn't appear to have any other ill
effects.