### PR TITLE
add BroadcastReceiverAttribute.Description property. (fix bug #60940)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/BroadcastReceiverAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/BroadcastReceiverAttribute.Partial.cs
@@ -16,6 +16,11 @@ namespace Android.Content {
 
 		static ManifestDocumentElement<BroadcastReceiverAttribute> mapping = new ManifestDocumentElement<BroadcastReceiverAttribute> ("receiver") {
 			{
+			  "Description",
+			  "description",
+			  self          => self.Description,
+			  (self, value) => self.Description = (string) value
+			}, {
 			  "DirectBootAware",
 			  "directBootAware",
 			  self          => self.DirectBootAware,

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.Content/BroadcastReceiverAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.Content/BroadcastReceiverAttribute.cs
@@ -15,6 +15,7 @@ namespace Android.Content {
 		public bool                   DirectBootAware         {get; set;}
 		public bool                   Enabled                 {get; set;}
 		public bool                   Exported                {get; set;}
+		public string                 Description             {get; set;}
 		public string                 Icon                    {get; set;}
 		public string                 Label                   {get; set;}
 		public string                 Name                    {get; set;}


### PR DESCRIPTION
There is some grand idea to generate all those attributes code, but it's
going to take long time and this bug shouldn't need to wait for that.
This bug can be fixed with just a few lines of changes.