### PR TITLE
[Xamarin.ProjectTools] Handle xbuilds negative index error.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -13,6 +13,7 @@ namespace Xamarin.ProjectTools
 	public class Builder : IDisposable
 	{
 		const string SigSegvError = "Got a SIGSEGV while executing native code";
+		const string ConsoleLoggerError = "[ERROR] FATAL UNHANDLED EXCEPTION: System.ArgumentException: is negative";
 		string buildLogFullPath;
 		public bool IsUnix { get; set; }
 		public bool RunningMSBuild { get; set; }
@@ -316,6 +317,9 @@ namespace Xamarin.ProjectTools
 							if (e.Data.StartsWith (SigSegvError, StringComparison.OrdinalIgnoreCase)) {
 								nativeCrashDetected = true;
 							}
+							if (e.Data.StartsWith (ConsoleLoggerError, StringComparison.OrdinalIgnoreCase)) {
+								nativeCrashDetected = true;
+							}
 						}
 						if (e.Data == null)
 							err.Set ();
@@ -324,6 +328,9 @@ namespace Xamarin.ProjectTools
 						if (e.Data != null && !string.IsNullOrEmpty (processLog)) {
 							File.AppendAllText (processLog, e.Data + Environment.NewLine);
 							if (e.Data.StartsWith (SigSegvError, StringComparison.OrdinalIgnoreCase)) {
+								nativeCrashDetected = true;
+							}
+							if (e.Data.StartsWith (ConsoleLoggerError, StringComparison.OrdinalIgnoreCase)) {
 								nativeCrashDetected = true;
 							}
 						}


### PR DESCRIPTION
We have an occasional issue with xbuild throwing an error.

	Unhandled Exception:
	System.ArgumentException: is negative
	Parameter name: count
	  at (wrapper managed-to-native) System.Buffer.InternalBlockCopy(System.Array,int,System.Array,int,int)
	  at System.IO.StreamWriter.Write (System.Char[] buffer, System.Int32 index, System.Int32 count) [0x00094] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/io/streamwriter.cs:415
	  at System.IO.TextWriter.WriteLine (System.String value) [0x00070] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/io/textwriter.cs:490
	  at Microsoft.Build.BuildEngine.ConsoleLogger+BuildRecord.WriteLine (System.String message) [0x00051] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/ConsoleLogger.cs:856
	  at Microsoft.Build.BuildEngine.ConsoleLogger+BuildRecord.DumpPerformanceSummary () [0x0000c] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/ConsoleLogger.cs:903
	  at Microsoft.Build.BuildEngine.ConsoleLogger+BuildRecord.BuildFinishedHandlerActual (Microsoft.Build.Framework.BuildFinishedEventArgs args) [0x0003e] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/ConsoleLogger.cs:572
	  at Microsoft.Build.BuildEngine.ConsoleLogger+BuildRecord.BuildFinishedHandler (Microsoft.Build.Framework.BuildFinishedEventArgs args) [0x00000] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/ConsoleLogger.cs:558
	  at Microsoft.Build.BuildEngine.ConsoleLogger.BuildFinishedHandler (System.Object sender, Microsoft.Build.Framework.BuildFinishedEventArgs e) [0x00000] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/ConsoleLogger.cs:306
	  at (wrapper delegate-invoke) <Module>.invoke_void_object_BuildFinishedEventArgs(object,Microsoft.Build.Framework.BuildFinishedEventArgs)
	  at Microsoft.Build.BuildEngine.EventSource.FireBuildFinished (System.Object sender, Microsoft.Build.Framework.BuildFinishedEventArgs bfea) [0x00008] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/EventSource.cs:103
	  at Microsoft.Build.BuildEngine.Engine.LogBuildFinished (System.Boolean succeeded) [0x0000d] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/Engine.cs:485
	  at Microsoft.Build.BuildEngine.Engine.UnregisterAllLoggers () [0x00008] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/Engine.cs:391
	  at Mono.XBuild.CommandLine.MainClass.Execute () [0x00390] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/tools/xbuild/Main.cs:170
	  at Mono.XBuild.CommandLine.MainClass.Main (System.String[] args) [0x0000c] in /Users/builder/data/lanes/5533/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/tools/xbuild/Main.cs:62
	[ERROR] FATAL UNHANDLED EXCEPTION: System.ArgumentException: is negative

So we should handle this like we do the native crash. If we
detect it we should re-run the build. Hopefully that will
make our tests a bit more stable.