### PR TITLE
[xabuild] support <PackageReference />

### DIFF
--- a/tools/xabuild/XABuild.cs
+++ b/tools/xabuild/XABuild.cs
@@ -64,6 +64,8 @@ namespace Xamarin.Android.Build
 			SetProperty (toolsets, "MSBuildExtensionsPath", paths.MSBuildExtensionsPath);
 			SetProperty (toolsets, "MSBuildExtensionsPath32", paths.MSBuildExtensionsPath);
 			SetProperty (toolsets, "RoslynTargetsPath", Path.Combine (paths.MSBuildBin, "Roslyn"));
+			SetProperty (toolsets, "NuGetProps", paths.NuGetProps);
+			SetProperty (toolsets, "NuGetTargets", paths.NuGetTargets);
 			SetProperty (toolsets, "NuGetRestoreTargets", paths.NuGetRestoreTargets);
 			SetProperty (toolsets, "MonoAndroidToolsDirectory", paths.MonoAndroidToolsDirectory);
 			SetProperty (toolsets, "TargetFrameworkRootPath", paths.FrameworksDirectory + Path.DirectorySeparatorChar); //NOTE: Must include trailing \

--- a/tools/xabuild/XABuildPaths.cs
+++ b/tools/xabuild/XABuildPaths.cs
@@ -96,6 +96,10 @@ namespace Xamarin.Android.Build
 
 		public string DotNetSdkPath { get; private set; }
 
+		public string NuGetTargets { get; private set; }
+
+		public string NuGetProps { get; private set; }
+
 		public string NuGetRestoreTargets { get; private set; }
 
 		public XABuildPaths ()
@@ -106,6 +110,7 @@ namespace Xamarin.Android.Build
 			XABuildDirectory          = Path.GetDirectoryName (GetType ().Assembly.Location);
 			XamarinAndroidBuildOutput = Path.GetFullPath (Path.Combine (XABuildDirectory, ".."));
 
+			const string vsVersion    = "15.0";
 			string programFiles       = Environment.GetFolderPath (Environment.SpecialFolder.ProgramFilesX86);
 			string prefix             = Path.Combine (XamarinAndroidBuildOutput, "lib", "xamarin.android");
 
@@ -121,19 +126,22 @@ namespace Xamarin.Android.Build
 					VsInstallRoot = programFiles;
 
 				MSBuildPath              = Path.Combine (VsInstallRoot, "MSBuild");
-				MSBuildBin               = Path.Combine (MSBuildPath, "15.0", "Bin");
+				MSBuildBin               = Path.Combine (MSBuildPath, vsVersion, "Bin");
 				MSBuildConfig            = Path.Combine (MSBuildBin, "MSBuild.exe.config");
 				DotNetSdkPath            = FindLatestDotNetSdk (Path.Combine (Environment.GetEnvironmentVariable ("ProgramW6432"), "dotnet", "sdk"));
 				MSBuildSdksPath          = DotNetSdkPath ?? Path.Combine (MSBuildPath, "Sdks");
 				ProjectImportSearchPaths = new [] { MSBuildPath, "$(MSBuildProgramFiles32)\\MSBuild" };
 				SystemProfiles           = Path.Combine (programFiles, "Reference Assemblies", "Microsoft", "Framework");
 				SearchPathsOS            = "windows";
+				string nuget             = Path.Combine (MSBuildPath, "Microsoft", "NuGet", vsVersion);
+				NuGetProps               = Path.Combine (nuget, "Microsoft.NuGet.props");
+				NuGetTargets             = Path.Combine (nuget, "Microsoft.NuGet.targets");
 				NuGetRestoreTargets      = Path.Combine (VsInstallRoot, "Common7", "IDE", "CommonExtensions", "Microsoft", "NuGet", "NuGet.targets");
 			} else {
 				string mono              = IsMacOS ? "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono" : "/usr/lib/mono";
 				string monoExternal      = IsMacOS ? "/Library/Frameworks/Mono.framework/External/" : "/usr/lib/mono";
 				MSBuildPath              = Path.Combine (mono, "msbuild");
-				MSBuildBin               = Path.Combine (MSBuildPath, "15.0", "bin");
+				MSBuildBin               = Path.Combine (MSBuildPath, vsVersion, "bin");
 				MSBuildConfig            = Path.Combine (MSBuildBin, "MSBuild.dll.config");
 				DotNetSdkPath            =
 					MSBuildSdksPath      = FindLatestDotNetSdk ("/usr/local/share/dotnet/sdk");


### PR DESCRIPTION
The `NetStandardReferenceTest` has been failing on Windows due to its
use of `<PackageReference />`.

Windows appears to need to import two files:
- C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\Microsoft\NuGet\15.0\Microsoft.NuGet.props
- C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\Microsoft\NuGet\15.0\Microsoft.NuGet.targets

Luckily we can set two properties to specify these paths:
`$(NuGetProps)` and `$(NuGetTargets)`. I think this is only a problem on
Windows, as these files aren't present on macOS.