### PR TITLE
[enumification] filter final ints without explicit constant value.

### DIFF
--- a/build-tools/enumification-helpers/generate-const-list-2.cs
+++ b/build-tools/enumification-helpers/generate-const-list-2.cs
@@ -60,7 +60,7 @@ public class Driver
 			}
 		}
 		
-		consts = consts.Where (f => f.IsFinal).ToArray ();
+		consts = consts.Where (f => f.IsFinal && !string.IsNullOrEmpty (f.Value)).ToArray ();
 
 		var fields = new List<string> ();
 		string package = null, type = null;


### PR DESCRIPTION
There were final fields that actually didn't give value in the API XML.