### PR TITLE
[enumification] fix RemoteConference.ConnectionProperties (issue #1087)

### DIFF
--- a/build-tools/enumification-helpers/enum-conversion-mappings.xml
+++ b/build-tools/enumification-helpers/enum-conversion-mappings.xml
@@ -1056,7 +1056,9 @@
   <map package='java.util' class='Spliterator' fields='*' prefix='' enum-name="SpliteratorCharacteristics" api-level="24" />
 
   <map package='android.content.pm' class='LauncherApps.ShortcutQuery' prefix='FLAG_' enum-name="LauncherAppsShortcutQueryFlags" extra-default="None" api-level="25" />
-  <map package='android.telecom' class='Connection' prefix='PROPERTY_' enum-name="ConnectionProperties" extra-default="None" api-level="25" />
+  <!-- This API Level specification is FAKE. It started since API Level 25, but the method that uses this value existed since API Level 24.
+  Therefore it comes with `force-api-level` attribute to indicate that it should generate overriden value. -->
+  <map package='android.telecom' class='Connection' prefix='PROPERTY_' enum-name="ConnectionProperties" extra-default="None" api-level="25" force-api-level="24" />
   <map package='android.view.inputmethod' class='InputConnection' prefix='INPUT_CONTENT_' enum-name="InputContentFlags" extra-default="None" api-level="25" />
   <map package='android.view.inputmethod' class='VoicemailContract.Status' prefix='CONFIGURATION_STATE_' enum-name="VoicemailContractConfigurationState" api-level="25" />
 

--- a/build-tools/enumification-helpers/generate-const-mapping.cs
+++ b/build-tools/enumification-helpers/generate-const-mapping.cs
@@ -88,6 +88,7 @@ namespace MonoDroid.Tools
 				var enn = map.GetAttribute ("enum-name");
 				var extdef = map.GetAttribute ("extra-default");
 				var overrides = new Dictionary<string,string> ();
+				var forceApiLevel = map.GetAttribute ("force-api-level");
 				foreach (XmlElement field in map.SelectNodes ("field"))
 					overrides.Add (field.GetAttribute ("java"), field.GetAttribute ("managed"));
 				try {
@@ -117,7 +118,7 @@ namespace MonoDroid.Tools
 						fieldName != extdef && fld.IsInterface ? "I:" : "",
 						fieldName == extdef ? "" : pkg.Replace ('.', '/') + '/' + type + '.' + fld.Constant,
 						val,
-						api);
+						string.IsNullOrEmpty (forceApiLevel) ? api : forceApiLevel);
 				}
 				} catch (Exception ex) {
 					Console.Error.WriteLine ("Error in {0} / {1} / {2}", pkg, type, enn);

--- a/build-tools/enumification-helpers/methodmap.ext.csv
+++ b/build-tools/enumification-helpers/methodmap.ext.csv
@@ -1501,7 +1501,6 @@
 24, android.service.quicksettings, Tile, getState, return, Android.Service.QuickSettings.TileState
 24, android.service.quicksettings, Tile, setState, state, Android.Service.QuickSettings.TileState
 24, android.speech.tts, UtteranceProgressListener, onBeginSynthesis, audioFormat, Android.Media.Encoding
-24, android.telecom, RemoteConference, getConnectionProperties, return, Android.Telecom.CallProperty
 24, android.telephony, TelephonyManager, getIccAuthentication, appType, Android.Telephony.UiccApplicationType
 24, android.telephony, TelephonyManager, getIccAuthentication, authType, Android.Telephony.AutheenticationType
 24, android.telephony, TelephonyManager, getDataNetworkType, return, Android.Telephony.NetworkType
@@ -1545,7 +1544,8 @@
 25, android.telecom, Connection, setConnectionProperties, connectionProperties, Android.Telecom.ConnectionProperties
 25, android.telecom, Conference, getConnectionProperties, return, Android.Telecom.ConnectionProperties
 25, android.telecom, Conference, setConnectionProperties, connectionProperties, Android.Telecom.ConnectionProperties
-25, android.telecom, RemoteConnection, getConnectionProperties, return, Android.Telecom.ConnectionProperties
+// Use of this enum involves some FAKE. The corresponding constants doesn't exist in API Level 24.
+24, android.telecom, RemoteConnection, getConnectionProperties, return, Android.Telecom.ConnectionProperties
 25, android.telecom, RemoteConnection.Callback, onConnectionPropertiesChanged, connectionProperties, Android.Telecom.ConnectionProperties
 25, android.telecom, RemoteConference, getConnectionProperties, return, Android.Telecom.ConnectionProperties
 25, android.telecom, RemoteConference.Callback, onConnectionPropertiesChanged, connectionProperties, Android.Telecom.ConnectionProperties
@@ -1777,4 +1777,4 @@
 // 27, android.os, SharedMemory, map, prot, ... is part of OsConstants.
 27, android.view.accessibility, AccessibilityRequestPreparer, ctor, requestTypes, Android.Views.Accessibility.AccessibilityRequestTypes
 // android.view.ViewStructure.setInputType never appeared before - it seems Google keeps breaking API on the docs, which is rather likely they are filling doc bits by fixing their tools.
-27, android.webkit.WebViewClient, onSafeBrowsingHit, threatType, Android.Webkit.SafeBrowsingThreat
+27, android.webkit, WebViewClient, onSafeBrowsingHit, threatType, Android.Webkit.SafeBrowsingThreat

--- a/src/Mono.Android/map.csv
+++ b/src/Mono.Android/map.csv
@@ -5611,9 +5611,9 @@
 25,Android.Content.PM.LauncherAppsShortcutQueryFlags,MatchDynamic,android/content/pm/LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC,1
 25,Android.Content.PM.LauncherAppsShortcutQueryFlags,MatchManifest,android/content/pm/LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST,8
 25,Android.Content.PM.LauncherAppsShortcutQueryFlags,MatchPinned,android/content/pm/LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED,2
-0,Android.Telecom.ConnectionProperties,None,,0
-25,Android.Telecom.ConnectionProperties,HasCdmaVoicePrivacy,android/telecom/Connection.PROPERTY_HAS_CDMA_VOICE_PRIVACY,32
-25,Android.Telecom.ConnectionProperties,IsExternalCall,android/telecom/Connection.PROPERTY_IS_EXTERNAL_CALL,16
-26,Android.Telecom.ConnectionProperties,SelfManaged,android/telecom/Connection.PROPERTY_SELF_MANAGED,128
+24,Android.Telecom.ConnectionProperties,None,,0
+24,Android.Telecom.ConnectionProperties,HasCdmaVoicePrivacy,android/telecom/Connection.PROPERTY_HAS_CDMA_VOICE_PRIVACY,32
+24,Android.Telecom.ConnectionProperties,IsExternalCall,android/telecom/Connection.PROPERTY_IS_EXTERNAL_CALL,16
+24,Android.Telecom.ConnectionProperties,SelfManaged,android/telecom/Connection.PROPERTY_SELF_MANAGED,128
 0,Android.Views.InputMethods.InputContentFlags,None,,0
 25,Android.Views.InputMethods.InputContentFlags,GrantReadUriPermission,I:android/view/inputmethod/InputConnection.INPUT_CONTENT_GRANT_READ_URI_PERMISSION,1

--- a/src/Mono.Android/methodmap.csv
+++ b/src/Mono.Android/methodmap.csv
@@ -597,6 +597,9 @@
 // I'm making these changes so far only in this extra mappings.
 // Things will change significantly so it had better be done all at once...
 
+// I'm making these changes so far only in this extra mappings.
+// Things will change significantly so it had better be done all at once...
+
 0, android.app, Activity, onKeyShortcut, keyCode, Android.Views.Keycode
 0, android.app, Activity, getRequestedOrientation, return, Android.Content.PM.ScreenOrientation
 0, android.app, Activity, setRequestedOrientation, requestedOrientation, Android.Content.PM.ScreenOrientation
@@ -2097,7 +2100,6 @@
 24, android.service.quicksettings, Tile, getState, return, Android.Service.QuickSettings.TileState
 24, android.service.quicksettings, Tile, setState, state, Android.Service.QuickSettings.TileState
 24, android.speech.tts, UtteranceProgressListener, onBeginSynthesis, audioFormat, Android.Media.Encoding
-24, android.telecom, RemoteConference, getConnectionProperties, return, Android.Telecom.CallProperty
 24, android.telephony, TelephonyManager, getIccAuthentication, appType, Android.Telephony.UiccApplicationType
 24, android.telephony, TelephonyManager, getIccAuthentication, authType, Android.Telephony.AutheenticationType
 24, android.telephony, TelephonyManager, getDataNetworkType, return, Android.Telephony.NetworkType
@@ -2141,7 +2143,8 @@
 25, android.telecom, Connection, setConnectionProperties, connectionProperties, Android.Telecom.ConnectionProperties
 25, android.telecom, Conference, getConnectionProperties, return, Android.Telecom.ConnectionProperties
 25, android.telecom, Conference, setConnectionProperties, connectionProperties, Android.Telecom.ConnectionProperties
-25, android.telecom, RemoteConnection, getConnectionProperties, return, Android.Telecom.ConnectionProperties
+// Use of this enum involves some FAKE. The corresponding constants doesn't exist in API Level 24.
+24, android.telecom, RemoteConnection, getConnectionProperties, return, Android.Telecom.ConnectionProperties
 25, android.telecom, RemoteConnection.Callback, onConnectionPropertiesChanged, connectionProperties, Android.Telecom.ConnectionProperties
 25, android.telecom, RemoteConference, getConnectionProperties, return, Android.Telecom.ConnectionProperties
 25, android.telecom, RemoteConference.Callback, onConnectionPropertiesChanged, connectionProperties, Android.Telecom.ConnectionProperties


### PR DESCRIPTION
See the github comments on the issue details.

To solve the issue, we introduce a "fake" mapping fixup in enumification-helpers.

Use "force-api-level" mapping information to override the correct API Level
information to generate modified map(.ext).csv.

methodmap.csv is also fixed to (1) remove old mapping for 24 and (2) change
the mapping for 25 down to 24 too.