### PR TITLE
[Xamarin.Android.Build.Tasks] Generate an R.txt for DesignTime Builds.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -90,7 +90,7 @@ namespace Xamarin.Android.Tasks
 
 		public string AndroidSdkPlatform { get; set; }
 
-		public string ResourceSymbolsTextFile { get; set; }
+		public string ResourceSymbolsTextFileDirectory { get; set; }
 
 		Dictionary<string,string> resource_name_case_map = new Dictionary<string,string> ();
 		AssemblyIdentityMap assemblyMap = new AssemblyIdentityMap ();
@@ -323,8 +323,8 @@ namespace Xamarin.Android.Tasks
 
 			cmd.AppendSwitch ("--auto-add-overlay");
 
-			if (!string.IsNullOrEmpty (ResourceSymbolsTextFile))
-				cmd.AppendSwitchIfNotNull ("--output-text-symbols ", ResourceSymbolsTextFile);
+			if (!string.IsNullOrEmpty (ResourceSymbolsTextFileDirectory))
+				cmd.AppendSwitchIfNotNull ("--output-text-symbols ", ResourceSymbolsTextFileDirectory);
 
 			var extraArgsExpanded = ExpandString (ExtraArgs);
 			if (extraArgsExpanded != ExtraArgs)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -90,6 +90,8 @@ namespace Xamarin.Android.Tasks
 
 		public string AndroidSdkPlatform { get; set; }
 
+		public string ResourceSymbolsTextFile { get; set; }
+
 		Dictionary<string,string> resource_name_case_map = new Dictionary<string,string> ();
 		AssemblyIdentityMap assemblyMap = new AssemblyIdentityMap ();
 
@@ -320,6 +322,9 @@ namespace Xamarin.Android.Tasks
 				cmd.AppendSwitch ("--no-crunch");
 
 			cmd.AppendSwitch ("--auto-add-overlay");
+
+			if (!string.IsNullOrEmpty (ResourceSymbolsTextFile))
+				cmd.AppendSwitchIfNotNull ("--output-text-symbols ", ResourceSymbolsTextFile);
 
 			var extraArgsExpanded = ExpandString (ExtraArgs);
 			if (extraArgsExpanded != ExtraArgs)

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1398,6 +1398,7 @@ because xbuild doesn't support framework reference assemblies.
 		YieldDuringToolExecution="$(YieldDuringToolExecution)"
 		ExplicitCrunch="$(AndroidExplicitCrunch)"
 		SupportedAbis="$(_BuildTargetAbis)"
+		ResourceSymbolsTextFile="$(IntermediateOutputPath)R.txt"
 		ContinueOnError="$(DesignTimeBuild)"
 	/>
 	

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2664,6 +2664,7 @@ because xbuild doesn't support framework reference assemblies.
 	<Delete Files="$(_AndroidStaticResourcesFlag)" />
 	<Delete Files="$(_AndroidLibraryProjectImportsCache)" />
 	<Delete Files="$(_AndroidLibrayProjectAssemblyMapFile)" />
+	<Delete Files="$(IntermediateOutputPath)R.txt" />
 </Target>
 
 <Target Name="_CollectMonoAndroidOutputs" DependsOnTargets="_ValidateAndroidPackageProperties">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1398,7 +1398,7 @@ because xbuild doesn't support framework reference assemblies.
 		YieldDuringToolExecution="$(YieldDuringToolExecution)"
 		ExplicitCrunch="$(AndroidExplicitCrunch)"
 		SupportedAbis="$(_BuildTargetAbis)"
-		ResourceSymbolsTextFile="$(IntermediateOutputPath)"
+		ResourceSymbolsTextFileDirectory="$(IntermediateOutputPath)"
 		ContinueOnError="$(DesignTimeBuild)"
 	/>
 	

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2681,6 +2681,9 @@ because xbuild doesn't support framework reference assemblies.
 	<CreateItem Include="$(_AndroidResgenFlagFile)">
 		<Output TaskParameter="Include" ItemName="FileWrites"/>
 	</CreateItem>
+	<CreateItem Include="$(IntermediateOutputPath)R.txt">
+		<Output TaskParameter="Include" ItemName="FileWrites"/>
+	</CreateItem>
 	<CreateItem Include="$(ApkFileSigned)">
 		<Output TaskParameter="Include" ItemName="FileWrites"/>
 	</CreateItem>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1398,7 +1398,7 @@ because xbuild doesn't support framework reference assemblies.
 		YieldDuringToolExecution="$(YieldDuringToolExecution)"
 		ExplicitCrunch="$(AndroidExplicitCrunch)"
 		SupportedAbis="$(_BuildTargetAbis)"
-		ResourceSymbolsTextFile="$(IntermediateOutputPath)R.txt"
+		ResourceSymbolsTextFile="$(IntermediateOutputPath)"
 		ContinueOnError="$(DesignTimeBuild)"
 	/>
 	


### PR DESCRIPTION
Commit fd969980 added support for reading and parsing R.txt
files. This commit adds support for generating the file as
part of the `_UpdateAndroidResgen` target.

The idea is that if the R.txt file is present we should use
that for our design time build Resource.Designer.cs.