### PR TITLE
[tests] fix BuildAMassiveApp under MSBuild

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2059,6 +2059,8 @@ public class Test
 					KnownPackages.GooglePlayServices_22_0_0_2,
 				},
 			};
+			//NOTE: BuildingInsideVisualStudio prevents the projects from being built as dependencies
+			app1.SetProperty("BuildingInsideVisualStudio", "False");
 			app1.Imports.Add (new Import ("foo.targets") {
 				TextContent = () => @"<?xml version=""1.0"" encoding=""utf-16""?>
 <Project ToolsVersion=""4.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/Default/_build/index?buildId=1206705&tab=ms.vss-test-web.test-result-details

`BuildAMassiveApp` has been failing under MSBuild with:
```
E:\A\_work\1\s\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Common.targets(1167,2):
error MSB4018: The "ResolveLibraryProjectImports" task failed unexpectedly.
System.IO.FileNotFoundException: Could not load assembly 'Lib0,
Version=0.0.0.0, Culture=neutral, PublicKeyToken='. Perhaps it doesn't exist in the Mono for Android profile?
File name: 'Lib0.dll'
```
It turns out that setting `BuildingInsideVisualStudio` signals MSBuild
that it doesn't need to figure out project dependencies. So
`Lib0.csproj` isn't built at the time `ResolveLibraryProjectImports`
runs.

For now, it seems simpler to turn off `BuildingInsideVisualStudio` in
this test under MSBuild, since it was not the goal of the test to verify
how things would work inside Visual Studio.