### PR TITLE
Bump to LibZipSharp/master/b7aab1e26

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
@@ -34,8 +34,6 @@ namespace Xamarin.Android.Tasks
 				zip.Dispose ();
 				zip = null;
 			}
-			// Requied to ensure that all the FileStream handles are disposed of. 
-			GC.Collect ();
 			zip = ZipArchive.Open (archive, FileMode.Open);
 		}
 


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/Release%20Dashboard/_workitems?id=534477&_a=edit

On Xamarin.Android 8.1 on Windows, we are experiencing problems with
file sharing causing build errors:

	error while writing anim: obj\Debug\android\bin\classes\android\support\design\R$anim.class (The process cannot access the file because it is being used by another process)

Bump to LibZipSharp/b7aab1e2 so that we don't need to rely on the GC
finalizing object instances to close `FileStream` instances.

This deterministic closing of files in turn means that
`ZipArchiveEx.Flush()` no longer needs to call `GC.Collect()`, which
wasn't a reliable fix anyway...