### PR TITLE
[tests] BuildAMassiveApp needs JavaMaximumHeapSize

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2062,7 +2062,8 @@ public class Test
 				},
 			};
 			//NOTE: BuildingInsideVisualStudio prevents the projects from being built as dependencies
-			app1.SetProperty("BuildingInsideVisualStudio", "False");
+			app1.SetProperty ("BuildingInsideVisualStudio", "False");
+			app1.SetProperty ("JavaMaximumHeapSize", "1G");
 			app1.Imports.Add (new Import ("foo.targets") {
 				TextContent = () => @"<?xml version=""1.0"" encoding=""utf-16""?>
 <Project ToolsVersion=""4.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=1223975

A recent Windows test run failed with:
```
E:\A\_work\1\s\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Common.targets(2191,3):
error XA5213:
	java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize).
		Java ran out of memory while executing 'java.exe -jar
		C:\Users\dlab\android-toolchain\sdk\build-tools\26.0.1\\lib\dx.jar
		--dex --no-strict --output obj\Release\android\bin
		E:\A\_work\1\s\bin\TestDebug\temp\BuildAMassiveApp\App1\obj\Release\android\bin\classes\classes.zip
		E:\A\_work\1\s\bin\Debug\lib\xamarin.android\xbuild-frameworks\MonoAndroid\v8.1\mono.android.jar
		C:\Users\dlab\AppData\Local\Xamarin\GooglePlayServicesLib\22.0.0\embedded\classes.jar
		C:\Users\dlab\AppData\Local\Xamarin\Xamarin.Android.Support.v4\21.0.3\embedded\classes.jar
		C:\Users\dlab\AppData\Local\Xamarin\Xamarin.Android.Support.v4\21.0.3\embedded\libs\internal_impl-21.0.3.jar'
		[E:\A\_work\1\s\bin\TestDebug\temp\BuildAMassiveApp\App1\App1.csproj]
```

Since this is quite a large app, I believe we need to set
`$(JavaMaximumHeapSize)` to `1G` for this test. I am not sure why it is
working for me locally, however.