### PR TITLE
Fix bundling of assemblies in NDK with unified headers

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -137,7 +137,7 @@
   </ItemGroup>
   <ItemGroup>
     <_NdkToolchain Include="arm-linux-androideabi-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':armeabi:')) Or $(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':armeabi-v7a:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-armeabi:'))">
-      <Platform>9</Platform>
+      <Platform>14</Platform>
       <Arch>arm</Arch>
     </_NdkToolchain>
     <_NdkToolchain Include="aarch64-linux-android-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':arm64-v8a:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-arm64:'))">
@@ -145,7 +145,7 @@
       <Arch>arm64</Arch>
     </_NdkToolchain>
     <_NdkToolchain Include="x86-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':x86:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-x86:'))">
-      <Platform>9</Platform>
+      <Platform>14</Platform>
       <Arch>x86</Arch>
     </_NdkToolchain>
     <_NdkToolchain Include="x86_64-clang" Condition="$(AndroidSupportedTargetJitAbisForConditionalChecks.Contains(':x86_64:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':win-x86_64:'))">

--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -17,6 +17,7 @@
     <_TestAssembly Include="$(_TopDir)\bin\Test$(Configuration)\Xamarin.Android.Build.Tests.dll" />
     <_ApkTestProject Include="$(_TopDir)\src\Mono.Android\Test\Mono.Android-Tests.csproj" />
     <_ApkTestProject Include="$(_TopDir)\tests\CodeGen-Binding\Xamarin.Android.JcwGen-Tests\Xamarin.Android.JcwGen-Tests.csproj" />
+    <_ApkTestProject Include="$(_TopDir)\tests\CodeGen-MkBundle\Xamarin.Android.MakeBundle-Tests\Xamarin.Android.MakeBundle-Tests.csproj" />
     <_ApkTestProject Include="$(_TopDir)\tests\locales\Xamarin.Android.Locale-Tests\Xamarin.Android.Locale-Tests.csproj" />
     <_ApkTestProject Include="$(_TopDir)\tests\Xamarin.Android.Bcl-Tests\Xamarin.Android.Bcl-Tests.csproj" />
     <_ApkTestProject Include="$(_TopDir)\tests\Xamarin.Forms-Performance-Integration\Droid\Xamarin.Forms.Performance.Integration.Droid.csproj" />

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
@@ -169,12 +169,24 @@ namespace Xamarin.Android.Tasks
 
 				clb = new CommandLineBuilder ();
 				clb.AppendSwitch ("-c");
+
+				// This is necessary only when unified headers are in use but it won't hurt to have it
+				// defined even if we don't use them
+				clb.AppendSwitch ($"-D__ANDROID_API__={level}");
+
 				clb.AppendSwitch ("-o");
 				clb.AppendFileNameIfNotNull (Path.Combine (outpath, "temp.o"));
 				if (!string.IsNullOrWhiteSpace (IncludePath)) {
 					clb.AppendSwitch ("-I");
 					clb.AppendFileNameIfNotNull (IncludePath);
 				}
+
+				string asmIncludePath = NdkUtil.GetNdkAsmIncludePath (AndroidNdkDirectory, arch, level);
+				if (!String.IsNullOrEmpty (asmIncludePath)) {
+					clb.AppendSwitch ("-I");
+					clb.AppendFileNameIfNotNull (asmIncludePath);
+				}
+
 				clb.AppendSwitch ("-I");
 				clb.AppendFileNameIfNotNull (NdkUtil.GetNdkPlatformIncludePath (AndroidNdkDirectory, arch, level));
 				clb.AppendFileNameIfNotNull (Path.Combine (outpath, "temp.c"));


### PR DESCRIPTION
Context: https://developercommunity.visualstudio.com/content/problem/166029/building-xamarinandroid-application-with-bundleass.html

NDK 14r introduced experimental support for so-called "unified headers" which
replace the per-platform C header files, NDK 15 deprecated the old headers and
NDK 16 removed them completely. Xamarin.Android has been building itself with
NDK configured to use unified headers for a while now, but we missed one piece
of code which is affected by the change - mkbundle.

This commit adds code to MakeBundleNativeCodeExternal task to make it possible
to build code generated by mkbundle on systems with NDK that lacks the
per-platform header files. This is done in a backward-compatible way but if your
NDK has both the old and the new headers, the latter will be used.

Additionally, minimum API versions to 14 for 32-bit targets (forward
compatibility with NDK r16)