### PR TITLE
[tests] StartAndroidEmulator should check stdout for "ERROR:"

### DIFF
--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
@@ -95,6 +95,10 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 					Log.LogError ("Emulator failed to start: ram_size is 0MB! Please re-install HAXM.");
 					sawError.Set ();
 				}
+				if (e.Data.IndexOf ("ERROR:", StringComparison.Ordinal) >= 0) {
+					Log.LogError ($"Emulator failed to start: {e.Data}");
+					sawError.Set ();
+				}
 			};
 			DataReceivedEventHandler error = null;
 			error = (o, e) => {


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/index?definitionId=8113

In cases where HAXM is installed/not working, an `ERROR:` message can be
displayed via stdout. We should check both stdout and stderr for
`ERROR:` messages.

This caused builds to hang on VSTS, since the VMs on VSTS do not
currently support HAXM.