### PR TITLE
Bump to mono/2017-10/63e8dc6e

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
@@ -46,6 +46,7 @@ namespace MonoDroid.Tuner
 			context.LogInternalExceptions = true;
 			context.Logger = logger;
 			context.CoreAction = AssemblyAction.Link;
+			context.UserAction = AssemblyAction.Link;
 			context.LinkSymbols = true;
 			context.SymbolReaderProvider = new DefaultSymbolReaderProvider (true);
 			context.SymbolWriterProvider = new DefaultSymbolWriterProvider ();


### PR DESCRIPTION
Bumps to cecil/mono-2017-10/76ffcdab.
This is consistent with cba77e9d, which *hopefully* means we won't get
the unit test failures seen in PR #1101.