### PR TITLE
[tests] Fix apk sizes input filename

### DIFF
--- a/src/Mono.Android/Test/Mono.Android-Tests.projitems
+++ b/src/Mono.Android/Test/Mono.Android-Tests.projitems
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_MonoAndroidTestPackage>Mono.Android_Tests</_MonoAndroidTestPackage>
+  </PropertyGroup>
   <ItemGroup>
     <TestApk Include="$(OutputPath)Mono.Android_Tests-Signed.apk">
-      <Package>Mono.Android_Tests</Package>
+      <Package>$(_MonoAndroidTestPackage)</Package>
       <InstrumentationType>xamarin.android.runtimetests.TestInstrumentation</InstrumentationType>
       <ResultsPath>$(OutputPath)TestResult-Mono.Android_Tests.xml</ResultsPath>
       <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)..\..\..\build-tools\scripts\TimingDefinitions.txt</TimingDefinitionsFilename>
       <TimingResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-Mono.Android_Tests-times.csv</TimingResultsFilename>
-      <ApkSizesInputFilename>apk-sizes-$(Package)-$(Configuration)$(TestsAotName).txt</ApkSizesInputFilename>
+      <ApkSizesInputFilename>apk-sizes-$(_MonoAndroidTestPackage)-$(Configuration)$(TestsAotName).txt</ApkSizesInputFilename>
       <ApkSizesDefinitionFilename>$(MSBuildThisFileDirectory)..\..\..\build-tools\scripts\ApkSizesDefinitions.txt</ApkSizesDefinitionFilename>
       <ApkSizesResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-Mono.Android_Tests-values.csv</ApkSizesResultsFilename>
     </TestApk>

--- a/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.projitems
+++ b/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.projitems
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_XamarinFormsIntergationPackage>Xamarin.Forms_Performance_Integration</_XamarinFormsIntergationPackage>
+  </PropertyGroup>
   <ItemGroup>
     <TestApk Include="$(OutputPath)Xamarin.Forms_Performance_Integration-Signed.apk">
-      <Package>Xamarin.Forms_Performance_Integration</Package>
+      <Package>$(_XamarinFormsIntergationPackage)</Package>
       <Activity>Xamarin.Forms_Performance_Integration/md52b709e14dec302485bbcaeac0bd817ce.MainActivity</Activity>
       <ResultsPath></ResultsPath>
       <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)timing-definitions.txt</TimingDefinitionsFilename>
       <TimingResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-Xamarin.Forms_Test-times.csv</TimingResultsFilename>
-      <ApkSizesInputFilename>apk-sizes-$(Package)-$(Configuration)$(TestsAotName).txt</ApkSizesInputFilename>
+      <ApkSizesInputFilename>apk-sizes-$(_XamarinFormsIntergationPackage)-$(Configuration)$(TestsAotName).txt</ApkSizesInputFilename>
       <ApkSizesDefinitionFilename>$(MSBuildThisFileDirectory)..\..\..\build-tools\scripts\ApkSizesDefinitions.txt</ApkSizesDefinitionFilename>
       <ApkSizesResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-Xamarin.Forms_Tests-values.csv</ApkSizesResultsFilename>
     </TestApk>


### PR DESCRIPTION
Previous commit
https://github.com/xamarin/xamarin-android/commit/dd42c9a41fac43a96b001e374c7a691aff3284c8
tried to fix apk sizes input filename, as it was broken for some
time. I overlooked that `Package` is part of the item group though and
not a property group as I thought. Thus we got all measurement mixed,
so last one won and thus we have wrong numbers for Mono.Android
test. This patch fixes that.