### PR TITLE
Revert "[create-vsix, build] Don't package API-10 assemblies"

### DIFF
--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -52,7 +52,6 @@
       <MSBuild Remove="$(LibDir)xbuild\**\*.d.dll" />
       <MSBuild Remove="$(LibDir)xbuild\**\*.d.exe" />
       <ReferenceAssemblies Include="$(LibDir)xbuild-frameworks\**\*.*" />
-      <ReferenceAssemblies Remove="$(LibDir)xbuild-frameworks\MonoAndroid\v2.3\**\*.*" />
       <ReferenceAssemblies Remove="**\*.dylib" />
       <ReferenceAssemblies Remove="**\libZipSharp*.*" />
       <ReferenceAssemblies>

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -30,7 +30,6 @@ ALL_PLATFORM_IDS  = 1 2 3 4 5 6 7 8 9 10    11  12  13  14  15      16    17    
 ALL_FRAMEWORKS    = _ _ _ _ _ _ _ _ _ v2.3  _   _   _   _   v4.0.3  v4.1  v4.2  v4.3  v4.4  v4.4.87   v5.0  v5.1  v6.0  v7.0  v7.1  v8.0  v8.1
 API_LEVELS        =                   10                    15      16    17    18    19    20        21    22    23    24    25    26  27
 STABLE_API_LEVELS =                   10                    15      16    17    18    19    20        21    22    23    24    25    26
-PKG_API_LEVELS    =                                         15      16    17    18    19    20        21    22    23    24    25    26  27
 
 ## The preceding values *must* use SPACE, **not** TAB, to separate values.
 
@@ -100,7 +99,7 @@ leeroy-all:
 
 framework-assemblies:
 	PREV_VERSION="v1.0"; \
-	$(foreach a, $(PKG_API_LEVELS), \
+	$(foreach a, $(API_LEVELS), \
 		CUR_VERSION=`echo "$(ALL_FRAMEWORKS)"|tr -s " "|cut -d " " -s -f $(a)`; \
 		$(foreach conf, $(CONFIGURATIONS), \
 			REDIST_FILE=bin/$(conf)/lib/xamarin.android/xbuild-frameworks/MonoAndroid/$${CUR_VERSION}/RedistList/FrameworkList.xml; \
@@ -115,19 +114,19 @@ framework-assemblies:
 	$(foreach conf, $(CONFIGURATIONS), \
 		rm -f bin/$(conf)/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v1.0/Xamarin.Android.NUnitLite.dll; \
 		$(_SLN_BUILD) $(MSBUILD_FLAGS) src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj /p:Configuration=$(conf) $(_MSBUILD_ARGS) \
-			/p:AndroidApiLevel=$(firstword $(PKG_API_LEVELS)) /p:AndroidPlatformId=$(word $(firstword $(PKG_API_LEVELS)), $(ALL_PLATFORM_IDS)) /p:AndroidFrameworkVersion=$(word $(firstword $(PKG_API_LEVELS)), $(ALL_FRAMEWORKS)) ; )
+			/p:AndroidApiLevel=$(firstword $(API_LEVELS)) /p:AndroidPlatformId=$(word $(firstword $(API_LEVELS)), $(ALL_PLATFORM_IDS)) /p:AndroidFrameworkVersion=$(firstword $(FRAMEWORKS)); )
 	_latest_framework=$$($(MSBUILD) /p:DoNotLoadOSProperties=True /nologo /v:minimal /t:GetAndroidLatestFrameworkVersion build-tools/scripts/Info.targets | tr -d '[[:space:]]') ; \
 	$(foreach conf, $(CONFIGURATIONS), \
 		rm -f "bin/$(conf)/lib/xamarin.android/xbuild-frameworks/MonoAndroid/$$_latest_framework"/Mono.Android.Export.* ; \
 		$(_SLN_BUILD) $(MSBUILD_FLAGS) src/Mono.Android.Export/Mono.Android.Export.csproj /p:Configuration=$(conf) $(_MSBUILD_ARGS) \
-			/p:AndroidApiLevel=$(firstword $(PKG_API_LEVELS)) /p:AndroidPlatformId=$(word $(firstword $(PKG_API_LEVELS)), $(ALL_PLATFORM_IDS)) /p:AndroidFrameworkVersion=$(word $(firstword $(PKG_API_LEVELS)), $(ALL_FRAMEWORKS)) ; ) \
+			/p:AndroidApiLevel=$(firstword $(API_LEVELS)) /p:AndroidPlatformId=$(word $(firstword $(API_LEVELS)), $(ALL_PLATFORM_IDS)) /p:AndroidFrameworkVersion=$(firstword $(FRAMEWORKS)); ) \
 	$(foreach conf, $(CONFIGURATIONS), \
 		rm -f "bin/$(conf)/lib/xamarin.android/xbuild-frameworks/MonoAndroid/$$_latest_framework"/OpenTK-1.0.* ; \
 		$(_SLN_BUILD) $(MSBUILD_FLAGS) src/OpenTK-1.0/OpenTK.csproj /p:Configuration=$(conf) $(_MSBUILD_ARGS) \
-			/p:AndroidApiLevel=$(firstword $(PKG_API_LEVELS)) /p:AndroidPlatformId=$(word $(firstword $(PKG_API_LEVELS)), $(ALL_PLATFORM_IDS)) /p:AndroidFrameworkVersion=$(word $(firstword $(PKG_API_LEVELS)), $(ALL_FRAMEWORKS)) ; )
+			/p:AndroidApiLevel=$(firstword $(API_LEVELS)) /p:AndroidPlatformId=$(word $(firstword $(API_LEVELS)), $(ALL_PLATFORM_IDS)) /p:AndroidFrameworkVersion=$(firstword $(FRAMEWORKS)); )
 
 opentk-jcw:
-	$(foreach a, $(PKG_API_LEVELS), \
+	$(foreach a, $(API_LEVELS), \
 		$(foreach conf, $(CONFIGURATIONS), \
 			touch bin/$(conf)/lib/xamarin.android/xbuild-frameworks/MonoAndroid/*/OpenTK-1.0.dll; \
 			$(_SLN_BUILD) $(MSBUILD_FLAGS) src/OpenTK-1.0/OpenTK.csproj /t:GenerateJavaCallableWrappers /p:Configuration=$(conf) $(_MSBUILD_ARGS) \


### PR DESCRIPTION
Reverts commit 6671f059.

Removing the build and install of API-10 broke the monodroid build;
this will need to be fixed later.

Additionally, commit 6671f059 was *incomplete*: it stopped building
and installing the `v2.3` framework, but e.g.
`Xamarin.Android.CSharp.targets` still used `v2.3` as the default.