### PR TITLE
[Xamarin.Android.Build.Tasks] <GenerateJavaStubs /> generates a shorter acw-map.txt

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -880,7 +880,7 @@ namespace Android.Runtime {
 		{
 			if (type == null)
 				throw new ArgumentNullException ("type");
-			var java  = monodroid_typemap_managed_to_java (type.AssemblyQualifiedName);
+			var java  = monodroid_typemap_managed_to_java (type.FullName + ", " + type.Assembly.GetName ().Name);
 			return java == IntPtr.Zero
 				? JavaNativeTypeManager.ToJniName (type)
 				: Marshal.PtrToStringAnsi (java);

--- a/src/Mono.Android/Test/Java.Interop/JnienvTest.cs
+++ b/src/Mono.Android/Test/Java.Interop/JnienvTest.cs
@@ -388,13 +388,18 @@ namespace Java.InteropTests
 		[DllImport ("__Internal")]
 		static extern IntPtr monodroid_typemap_managed_to_java (string java);
 
+		string GetTypeName (Type type)
+		{
+			return type.FullName + ", " + type.Assembly.GetName ().Name;
+		}
+
 		[Test]
 		public void ManagedToJavaTypeMapping ()
 		{
-			var m = monodroid_typemap_managed_to_java (typeof (Activity).AssemblyQualifiedName);
-			Assert.AreNotEqual (IntPtr.Zero, m);
-			m = monodroid_typemap_managed_to_java (typeof (JnienvTest).AssemblyQualifiedName);
-			Assert.AreEqual (IntPtr.Zero, m);
+			var m = monodroid_typemap_managed_to_java (GetTypeName (typeof (Activity)));
+			Assert.AreNotEqual (IntPtr.Zero, m, "`Activity` subclasses Java.Lang.Object, it should be in the typemap!");
+			m = monodroid_typemap_managed_to_java (GetTypeName (typeof (JnienvTest)));
+			Assert.AreEqual (IntPtr.Zero, m, "`JnienvTest` does *not* subclass Java.Lang.Object, it should *not* be in the typemap!");
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -163,7 +163,6 @@ namespace Xamarin.Android.Tasks
 				string javaKey    = JavaNativeTypeManager.ToJniName (type).Replace ('/', '.');
 
 				acw_map.WriteLine ("{0};{1}", type.GetPartialAssemblyQualifiedName (), javaKey);
-				acw_map.WriteLine ("{0};{1}", type.GetAssemblyQualifiedName (), javaKey);
 
 				TypeDefinition conflict;
 				if (managed.TryGetValue (managedKey, out conflict)) {


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=61073
Context: xamarin/java.interop#227

The Java-to-Managed typemaps list types such as:
```
android/app/Activity
Android.App.Activity, Mono.Android, Version=0.0.0.0, Culture=neutral,
PublicKeyToken=84e04ff9cfb79065
```
This is found in the intermediate dir after a  build in `acw-map.txt`,
or `$(_AcwMapFile)`.

Let’s assume you have an Android project with the following
assembly-level attribute:
```
[assembly:AssemblyVersion("1.0.0.*")]
```

Then on *every* build, the typemap is invalidated because your version
number has been incremented.

Changes:
- Bumped Java.Interop to master/429dc2a
- `JNIEnv` needs to use the shorter type name when calling
`monodroid_typemap_managed_to_java`
- `GenerateJavaStubs` should not be writing lines for
`type.GetAssemblyQualifiedName` into `acw-map.txt`
- `JnienvTest` needed some updates to use the new type name format
- Wrote a test using `[assembly:AssemblyVersion("1.0.0.*")]` that
checks `acw-map.txt` contents