### PR TITLE
[build] fix Windows build on a fresh machine

### DIFF
--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -11,6 +11,12 @@
   <Target Name="Prepare">
     <Exec Command="git submodule update --init --recursive" WorkingDirectory="$(_TopDir)" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\xa-prep-tasks\xa-prep-tasks.csproj" />
+    <Exec Command="$(_NuGet) restore Xamarin.Android.sln" WorkingDirectory="$(_TopDir)" />
+    <Exec Command="$(_NuGet) restore Xamarin.Android-Tests.sln" WorkingDirectory="$(_TopDir)" />
+    <Exec Command="$(_NuGet) restore external\Java.Interop\Java.Interop.sln" WorkingDirectory="$(_TopDir)" />
+    <Exec Command="$(_NuGet) restore external\LibZipSharp\libZipSharp.sln" WorkingDirectory="$(_TopDir)" />
+    <Exec Command="$(_NuGet) restore external\xamarin-android-tools\Xamarin.Android.Tools.sln" WorkingDirectory="$(_TopDir)" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)..\android-toolchain\android-toolchain.mdproj" />
     <JdkInfo
         AndroidSdkPath="$(AndroidSdkDirectory)"
         AndroidNdkPath="$(AndroidNdkDirectory)"
@@ -28,10 +34,5 @@
         DestinationFile="$(_TopDir)\Configuration.OperatingSystem.props"
         Replacements="@JAVA_HOME@=$(_JavaSdkDirectory)"
     />
-    <Exec Command="$(_NuGet) restore Xamarin.Android.sln" WorkingDirectory="$(_TopDir)" />
-    <Exec Command="$(_NuGet) restore Xamarin.Android-Tests.sln" WorkingDirectory="$(_TopDir)" />
-    <Exec Command="$(_NuGet) restore external\Java.Interop\Java.Interop.sln" WorkingDirectory="$(_TopDir)" />
-    <Exec Command="$(_NuGet) restore external\LibZipSharp\libZipSharp.sln" WorkingDirectory="$(_TopDir)" />
-    <Exec Command="$(_NuGet) restore external\xamarin-android-tools\Xamarin.Android.Tools.sln" WorkingDirectory="$(_TopDir)" />
   </Target>
 </Project>


### PR DESCRIPTION
We discovered the build fails on Windows if you:
- wipe out `~\android-toolchain`
- `git clean -dxf`
- `msbuild Xamarin.Android.sln /t:Prepare`
- Or just have a fresh machine

We need to reorder the steps of what happens in `PrepareWindows.targets`:
1. `git submodule update`
2. build `xa-prep-tasks`, which gets `.nuget\NuGet.exe`
2. `nuget restore`
3. build `android-toolchain` , which is the missing step that installs the Android SDK
4. proceed with everything else

Without step no. 3, the missing Android SDK that gets installed to
`~\android-toolchain` causes the `<JdkInfo />` task to fail.