### PR TITLE
[Xamarin.Android.Build.Tasks] ProGuard/MultiDex fix parentheses in path

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
@@ -75,28 +75,31 @@ namespace Xamarin.Android.Tasks
 
 		void GenerateProguardCommands (CommandLineBuilder cmd)
 		{
-			var enclosingChar = OS.IsWindows ? "\"" : "'";
+			var enclosingChar = OS.IsWindows ? "\"" : string.Empty;
 			var jars = JavaLibraries.Select (i => i.ItemSpec).Concat (new string [] { Path.Combine (ClassesOutputDirectory, "classes.zip") });
 			cmd.AppendSwitchIfNotNull ("-jar ", ProguardJarPath);
-			cmd.AppendSwitchUnquotedIfNotNull ("-injars ", $"{enclosingChar}" + string.Join ($"{ProguardInputJarFilter}{enclosingChar}{Path.PathSeparator}{enclosingChar}", jars) + $"{ProguardInputJarFilter}{enclosingChar}");
+			cmd.AppendSwitchUnquotedIfNotNull ("-injars ", "\"'" + string.Join ($"'{ProguardInputJarFilter}{Path.PathSeparator}'", jars) + $"'{ProguardInputJarFilter}\"");
 			cmd.AppendSwitch ("-dontwarn");
 			cmd.AppendSwitch ("-forceprocessing");
 			cmd.AppendSwitchIfNotNull ("-outjars ", tempJar);
-			cmd.AppendSwitchIfNotNull ("-libraryjars ", $"{enclosingChar}{Path.Combine (AndroidSdkBuildToolsPath, "lib", "shrinkedAndroid.jar")}{enclosingChar}");
+			cmd.AppendSwitchIfNotNull ("-libraryjars ", $"'{Path.Combine (AndroidSdkBuildToolsPath, "lib", "shrinkedAndroid.jar")}'");
 			cmd.AppendSwitch ("-dontoptimize");
 			cmd.AppendSwitch ("-dontobfuscate");
 			cmd.AppendSwitch ("-dontpreverify");
-			cmd.AppendSwitchUnquotedIfNotNull ("-include ", $"{enclosingChar}{Path.Combine (AndroidSdkBuildToolsPath, "mainDexClasses.rules")}{enclosingChar}");
+			cmd.AppendSwitchUnquotedIfNotNull ("-include ", $"{enclosingChar}'{Path.Combine (AndroidSdkBuildToolsPath, "mainDexClasses.rules")}'{enclosingChar}");
 		}
 
 		void GenerateMainDexListBuilderCommands(CommandLineBuilder cmd)
 		{
-			var enclosingChar = OS.IsWindows ? "\"" : "'";
+			var enclosingDoubleQuote = OS.IsWindows ? "\"" : string.Empty;
+			var enclosingQuote = OS.IsWindows ? string.Empty : "'";
 			var jars = JavaLibraries.Select (i => i.ItemSpec).Concat (new string [] { Path.Combine (ClassesOutputDirectory, "classes.zip") });
 			cmd.AppendSwitchIfNotNull ("-Djava.ext.dirs=", Path.Combine (AndroidSdkBuildToolsPath, "lib"));
 			cmd.AppendSwitch ("com.android.multidex.MainDexListBuilder");
-			cmd.AppendSwitchUnquotedIfNotNull ("", $"{enclosingChar}{tempJar}{enclosingChar}");
-			cmd.AppendSwitchUnquotedIfNotNull ("", enclosingChar + string.Join ($"{enclosingChar}{Path.PathSeparator}{enclosingChar}", jars) + enclosingChar);
+			cmd.AppendSwitch ($"{enclosingDoubleQuote}{tempJar}{enclosingDoubleQuote}");
+			cmd.AppendSwitchUnquotedIfNotNull ("", $"{enclosingDoubleQuote}{enclosingQuote}" +
+				string.Join ($"{enclosingQuote}{Path.PathSeparator}{enclosingQuote}", jars) + 
+				$"{enclosingQuote}{enclosingDoubleQuote}");
 			writeOutputToKeepFile = true;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
@@ -140,10 +140,10 @@ namespace Xamarin.Android.Tasks
 
 			var injars = new List<string> ();
 			var libjars = new List<string> ();
-			injars.Add (classesZip + ProguardInputJarFilter);
+			injars.Add (classesZip);
 			if (JavaLibrariesToEmbed != null)
 				foreach (var jarfile in JavaLibrariesToEmbed)
-					injars.Add (jarfile.ItemSpec + ProguardInputJarFilter);
+					injars.Add (jarfile.ItemSpec);
 
 			using (var xamcfg = File.Create (ProguardCommonXamarinConfiguration))
 				GetType ().Assembly.GetManifestResourceStream ("proguard_xamarin.cfg").CopyTo (xamcfg);
@@ -158,11 +158,11 @@ namespace Xamarin.Android.Tasks
 				.Select (s => s.Trim ())
 				.Where (s => !string.IsNullOrWhiteSpace (s));
 
-			var enclosingChar = OS.IsWindows ? "\"" : "'";
+			var enclosingChar = OS.IsWindows ? "\"" : string.Empty;
 
 			foreach (var file in configs) {
 				if (File.Exists (file))
-					cmd.AppendSwitchUnquotedIfNotNull ("-include ", $"{enclosingChar}{file}{enclosingChar}");
+					cmd.AppendSwitchUnquotedIfNotNull ("-include ", $"{enclosingChar}'{file}'{enclosingChar}");
 				else
 					Log.LogWarning ("Proguard configuration file '{0}' was not found.", file);
 			}
@@ -172,9 +172,8 @@ namespace Xamarin.Android.Tasks
 				foreach (var jarfile in ExternalJavaLibraries.Select (p => p.ItemSpec))
 					libjars.Add (jarfile);
 
-			string delimiter = $"{enclosingChar}{Path.PathSeparator}{enclosingChar}";
-			cmd.AppendSwitchUnquotedIfNotNull ("-injars ", enclosingChar + string.Join (delimiter, injars.Distinct ()) + enclosingChar);
-			cmd.AppendSwitchUnquotedIfNotNull ("-libraryjars ", enclosingChar + string.Join (delimiter, libjars.Distinct ()) + enclosingChar);
+			cmd.AppendSwitchUnquotedIfNotNull ("-injars ", "\"'" + string.Join ($"'{ProguardInputJarFilter}{Path.PathSeparator}'", injars.Distinct ()) + $"'{ProguardInputJarFilter}\"");
+			cmd.AppendSwitchUnquotedIfNotNull ("-libraryjars ", $"{enclosingChar}'" + string.Join ($"'{Path.PathSeparator}'", libjars.Distinct ()) + $"'{enclosingChar}");
 			cmd.AppendSwitchIfNotNull ("-outjars ", ProguardJarOutput);
 
 			if (EnableLogging) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1671,6 +1671,19 @@ public class Test
 				AotAssemblies = isRelease,
 				EnableProguard = enableProguard,
 			};
+			proj.OtherBuildItems.Add (new BuildItem ("AndroidJavaLibrary", "Hello (World).jar") { BinaryContent = () => Convert.FromBase64String (@"
+UEsDBBQACAgIAMl8lUsAAAAAAAAAAAAAAAAJAAQATUVUQS1JTkYv/soAAAMAUEsHCAAAAAACAAAAA
+AAAAFBLAwQUAAgICADJfJVLAAAAAAAAAAAAAAAAFAAAAE1FVEEtSU5GL01BTklGRVNULk1G803My0
+xLLS7RDUstKs7Mz7NSMNQz4OVyLkpNLElN0XWqBAlY6BnEG5oaKWj4FyUm56QqOOcXFeQXJZYA1Wv
+ycvFyAQBQSwcIbrokAkQAAABFAAAAUEsDBBQACAgIAIJ8lUsAAAAAAAAAAAAAAAASAAAAc2FtcGxl
+L0hlbGxvLmNsYXNzO/Vv1z4GBgYTBkEuBhYGXg4GPnYGfnYGAUYGNpvMvMwSO0YGZg3NMEYGFuf8l
+FRGBn6fzLxUv9LcpNSikMSkHKAIa3l+UU4KI4OIhqZPVmJZon5OYl66fnBJUWZeujUjA1dwfmlRcq
+pbJkgtl0dqTk6+HkgZDwMrAxvQFrCIIiMDT3FibkFOqj6Yz8gggDDKPykrNbmEQZGBGehCEGBiYAR
+pBpLsQJ4skGYE0qxa2xkYNwIZjAwcQJINIggkORm4oEqloUqZhZg2oClkB5LcYLN5AFBLBwjQMrpO
+0wAAABMBAABQSwECFAAUAAgICADJfJVLAAAAAAIAAAAAAAAACQAEAAAAAAAAAAAAAAAAAAAATUVUQ
+S1JTkYv/soAAFBLAQIUABQACAgIAMl8lUtuuiQCRAAAAEUAAAAUAAAAAAAAAAAAAAAAAD0AAABNRV
+RBLUlORi9NQU5JRkVTVC5NRlBLAQIUABQACAgIAIJ8lUvQMrpO0wAAABMBAAASAAAAAAAAAAAAAAA
+AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 			if (enableMultiDex)
 				proj.SetProperty ("AndroidEnableMultiDex", "True");
 
@@ -1690,6 +1703,7 @@ public class Test
 			}
 			using (var b = CreateApkBuilder (Path.Combine ("temp", $"BuildReleaseAppWithA InIt({isRelease}{enableProguard}{enableMultiDex})"))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsFalse (b.LastBuildOutput.ContainsText ("Duplicate zip entry"), "Should not get warning about [META-INF/MANIFEST.MF]");
 			}
 		}
 


### PR DESCRIPTION
Fixes: #1135
Context: #1068

When making changes in #1068, I added a unit test that builds an
application with both spaces and parentheses in its path. However, this
was not enough to test everything; the test also needed an
`AndroidJavaLibrary` build item with spaces and parentheses in its name!

Changes:
- Made a `Hello (World).jar` file, that has a single class in it
- Added the jar file as a `AndroidJavaLibrary`, in
the `BuildApplicationWithSpacesInPath` test
- Reverted `Proguard.cs` and `CreateMultiDexMainDexClassList.cs` from
what I did in #1068 -- Dean tried to warn me
- Move the `(!META-INF/MANIFEST.MF)` filter expression outside the
single quotes
- For the `-injars` expression to work on *both* macOS and Windows,
I had to enclose the entire expression in double-quotes

PR #1068 was a good attempt at trying to cleanup the code, but I could
not get the manifest filter to work along with a path including a
parentheses.