### PR TITLE
Fix MonoAndroid path resolution on Linux

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Xamarin.Android.Sdk.props
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Xamarin.Android.Sdk.props
@@ -19,7 +19,7 @@ Copyright (C) 2011-2016 Xamarin. All rights reserved.
 		<VsInstallationID>$(DevEnvIni.Substring($(InstallationIDEqualsIndex), 8))</VsInstallationID>
 	</PropertyGroup>
 
-	<PropertyGroup>
+	<PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
 		<!-- Until VS2017+ includes its own ReferenceAssemblies outside of C:\Program Files (x86)\Reference Assemblies and into 
 			 the VsInstallRoot, we must override this ourselves for our SDKs -->
 		<TargetFrameworkRootPath Condition="'$(VsInstallRoot)' != '' And '$(TargetFrameworkRootPath)' == ''">$(VsInstallRoot)\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\</TargetFrameworkRootPath>
@@ -27,6 +27,11 @@ Copyright (C) 2011-2016 Xamarin. All rights reserved.
 
 		<!-- We should always override the framework path so that XA resolves to its own mscorlib.dll -->
 		<FrameworkPathOverride>$(TargetFrameworkRootPath)MonoAndroid\v1.0</FrameworkPathOverride>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(OS)' == 'Unix'">
+		<FrameworkPathOverride>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries($(TargetFrameworkIdentifier), $(TargetFrameworkVersion), $(TargetFrameworkProfile), $(PlatformTarget), $(TargetFrameworkRootPath)))</FrameworkPathOverride>
+		<TargetFrameworkRootPath Condition="Exists('$(FrameworkPathOverride)')">$(FrameworkPathOverride)\..\..\</TargetFrameworkRootPath>
 	</PropertyGroup>
 
 	<Target Name="RedirectMonoAndroidSdkPaths" Condition="'$(VsInstallRoot)' != ''">


### PR DESCRIPTION
Currently, we indiscriminately set TargetFrameworkRootPath in a way that breaks on Linux, so make that setting Windows-specific and add a more generic one for Linux. As for OSX, it's not clear to me why OSX was never affected by the issue.