### PR TITLE
[Xamarin.Android.Build.Tasks] fix classes-zip inception

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileToDalvik.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileToDalvik.cs
@@ -119,7 +119,7 @@ namespace Xamarin.Android.Tasks
 				cmd.AppendFileNamesIfNotNull (AlternativeJarFiles, " ");
 			} else {
 				Log.LogDebugMessage ("  processing ClassesOutputDirectory...");
-				var zip = Path.GetFullPath (Path.Combine (ClassesOutputDirectory, "classes.zip"));
+				var zip = Path.GetFullPath (Path.Combine (ClassesOutputDirectory, "..", "classes.zip"));
 				if (!File.Exists (zip)) {
 					throw new FileNotFoundException ($"'{zip}' does not exist. Please rebuild the project.");
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
@@ -76,7 +76,7 @@ namespace Xamarin.Android.Tasks
 		void GenerateProguardCommands (CommandLineBuilder cmd)
 		{
 			var enclosingChar = OS.IsWindows ? "\"" : string.Empty;
-			var jars = JavaLibraries.Select (i => i.ItemSpec).Concat (new string [] { Path.Combine (ClassesOutputDirectory, "classes.zip") });
+			var jars = JavaLibraries.Select (i => i.ItemSpec).Concat (new string [] { Path.Combine (ClassesOutputDirectory, "..", "classes.zip") });
 			cmd.AppendSwitchIfNotNull ("-jar ", ProguardJarPath);
 			cmd.AppendSwitchUnquotedIfNotNull ("-injars ", "\"'" + string.Join ($"'{ProguardInputJarFilter}{Path.PathSeparator}'", jars) + $"'{ProguardInputJarFilter}\"");
 			cmd.AppendSwitch ("-dontwarn");
@@ -93,7 +93,7 @@ namespace Xamarin.Android.Tasks
 		{
 			var enclosingDoubleQuote = OS.IsWindows ? "\"" : string.Empty;
 			var enclosingQuote = OS.IsWindows ? string.Empty : "'";
-			var jars = JavaLibraries.Select (i => i.ItemSpec).Concat (new string [] { Path.Combine (ClassesOutputDirectory, "classes.zip") });
+			var jars = JavaLibraries.Select (i => i.ItemSpec).Concat (new string [] { Path.Combine (ClassesOutputDirectory, "..", "classes.zip") });
 			cmd.AppendSwitchIfNotNull ("-Djava.ext.dirs=", Path.Combine (AndroidSdkBuildToolsPath, "lib"));
 			cmd.AppendSwitch ("com.android.multidex.MainDexListBuilder");
 			cmd.AppendSwitch ($"{enclosingDoubleQuote}{tempJar}{enclosingDoubleQuote}");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
@@ -35,7 +35,7 @@ namespace Xamarin.Android.Tasks
 			if (!result)
 				return result;
 			// compress all the class files
-			using (var zip = new ZipArchiveEx (Path.Combine (ClassesOutputDirectory, "classes.zip"), FileMode.OpenOrCreate))
+			using (var zip = new ZipArchiveEx (Path.Combine (ClassesOutputDirectory, "..", "classes.zip"), FileMode.OpenOrCreate))
 				zip.AddDirectory (ClassesOutputDirectory, "");
 			return result;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
@@ -127,7 +127,7 @@ namespace Xamarin.Android.Tasks
 			if (!ClassesOutputDirectory.EndsWith (Path.DirectorySeparatorChar.ToString (), StringComparison.OrdinalIgnoreCase))
 				ClassesOutputDirectory += Path.DirectorySeparatorChar;
 
-			var classesZip = Path.Combine (ClassesOutputDirectory, "classes.zip");
+			var classesZip = Path.Combine (ClassesOutputDirectory, "..", "classes.zip");
 			var acwLines = File.ReadAllLines (AcwMapFile);
 			using (var appcfg = File.CreateText (ProguardGeneratedApplicationConfiguration))
 				for (int i = 0; i + 3 < acwLines.Length; i += 4)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -203,6 +203,54 @@ namespace Xamarin.Android.Tests
 		}
 
 		[Test]
+		public void BuildIncrementingClassName ()
+		{
+			int count = 0;
+			var source = new BuildItem ("Compile", "World.cs") {
+				TextContent = () => {
+					int current = ++count;
+					return $"namespace Hello{current} {{ public class World{current} : Java.Lang.Object {{ }} }}";
+				}
+			};
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.Sources.Add (source);
+
+			using (var b = CreateApkBuilder ("temp/BuildIncrementingClassName")) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+
+				var classesZipPath = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "bin", "classes.zip");
+				FileAssert.Exists (classesZipPath);
+				var expectedBuilder = new StringBuilder ();
+				using (var zip = ZipHelper.OpenZip (classesZipPath)) {
+					foreach (var file in zip) {
+						expectedBuilder.AppendLine (file.FullName);
+					}
+				}
+				var expectedZip = expectedBuilder.ToString ();
+
+				source.Timestamp = null; //Force the file to re-save w/ new Timestamp
+				Assert.IsTrue (b.Build (proj), "Second build should have succeeded.");
+
+				var actualBuilder = new StringBuilder ();
+				using (var zip = ZipHelper.OpenZip (classesZipPath)) {
+					foreach (var file in zip) {
+						actualBuilder.AppendLine (file.FullName);
+					}
+				}
+				var actualZip = actualBuilder.ToString ();
+				Assert.AreNotEqual (expectedZip, actualZip);
+
+				//Build with no changes
+				Assert.IsTrue (b.Build (proj), "Third build should have succeeded.");
+				FileAssert.Exists (classesZipPath);
+
+				//Clean
+				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
+				FileAssert.DoesNotExist (classesZipPath);
+			}
+		}
+
+		[Test]
 		public void BuildMkBundleApplicationRelease ()
 		{
 			var proj = new XamarinAndroidApplicationProject () { IsRelease = true, BundleAssemblies = true };


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=61073
Context: a296784

When we added the new `classes.zip` functionality, there was one oddity
present. On the first build, everything appears to be normal. On the
second build, `classes.zip` appeared to contain itself inside itself???

To make things even stranger, I wrote a unit test that contains a
`Java.Lang.Object` subclass in which its type and namespace names change
on each write. This worked fine on macOS, even with the oddity of
`classes.zip` continually zipping itself inside itself... The new java
sources would appear at the bottom of the list within the zip file.

Everything broke down when I tried my unit test on Windows, the case of
`classes.zip` trying to compress itself inside itself was silently
failing. It was not processing any further files after the failing zip
entry, and so *in theory* this situation would cause many Java stubs to
be missing from the zip.

Solution? Let's just put `classes.zip` up one directory.

So instead of:
```
obj/Debug/android/bin/classes/classes.zip
```
Move it to:
```
obj/Debug/android/bin/classes.zip
```

This prevents the `classes` directory from containing `classes.zip`, and
our strange case of `classes.zip` inception.

Merry Christmas! I'm going to go play Skylanders now.