### PR TITLE
[Xamarin.Android.Build.Tasks] Always create the debug.keystore

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -55,6 +55,22 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void CheckKeystoreIsCreated ()
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+			};
+			using (var b = CreateApkBuilder ("temp/CheckKeystoreIsCreated", false, false)) {
+				var file = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "debug.keystore");
+				var p = new string [] {
+					$"_ApkDebugKeyStore={file}",
+				};
+				Assert.IsTrue (b.Build (proj, parameters: p), "Build should have succeeded.");
+				FileAssert.Exists (file, $"{file} should have been created.");
+			}
+		}
+
+		[Test]
 		public void FSharpAppHasAndroidDefine ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2494,13 +2494,13 @@ because xbuild doesn't support framework reference assemblies.
 	<CreateProperty Value="$(_ApkDebugKeyStore)" Condition="'$(AndroidKeyStore)'!='True'">
 		<Output TaskParameter="Value" PropertyName="_ApkKeyStore"/>
 	</CreateProperty>
-	<CreateProperty Value="android" Condition="'$(AndroidKeyStore)'!='True'">
+	<CreateProperty Value="$(_ApkDebugKeyPassword)" Condition="'$(AndroidKeyStore)'!='True'">
 		<Output TaskParameter="Value" PropertyName="_ApkStorePass"/>
 	</CreateProperty>
-	<CreateProperty Value="androiddebugkey" Condition="'$(AndroidKeyStore)'!='True'">
+	<CreateProperty Value="$(_ApkDebugKeyAlias)" Condition="'$(AndroidKeyStore)'!='True'">
 		<Output TaskParameter="Value" PropertyName="_ApkKeyAlias"/>
 	</CreateProperty>
-	<CreateProperty Value="android" Condition="'$(AndroidKeyStore)'!='True'">
+	<CreateProperty Value="$(_ApkDebugKeyStorePassword)" Condition="'$(AndroidKeyStore)'!='True'">
 		<Output TaskParameter="Value" PropertyName="_ApkKeyPass"/>
 	</CreateProperty>
 	

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -730,6 +730,24 @@ because xbuild doesn't support framework reference assemblies.
 		<Output TaskParameter="Value" PropertyName="_ApkDebugKeyStore"/>
 	</CreateProperty>
 
+	<CreateProperty Value="android">
+		<Output TaskParameter="Value" PropertyName="_ApkDebugKeyStorePassword"
+			Condition="'$(_ApkDebugKeyStorePassword)' == ''"
+		/>
+	</CreateProperty>
+
+	<CreateProperty Value="android">
+		<Output TaskParameter="Value" PropertyName="_ApkDebugKeyPassword"
+			Condition="'$(_ApkDebugKeyPassword)' == ''"
+		/>
+	</CreateProperty>
+
+	<CreateProperty Value="androiddebugkey">
+		<Output TaskParameter="Value" PropertyName="_ApkDebugKeyAlias"
+			Condition="'$(_ApkDebugKeyAlias)' == ''"
+		/>
+	</CreateProperty>
+
 	<CreateProperty Value="$(MonoAndroidToolsDirectory)">
 		<Output TaskParameter="Value" PropertyName="_MonoAndroidToolsDirectory"/>
 	</CreateProperty>
@@ -2455,9 +2473,23 @@ because xbuild doesn't support framework reference assemblies.
 
   <Delete Files="$(_UploadFlagFile)" Condition="Exists ('$(_UploadFlagFile)')" />
 </Target>
-  
 
-<Target Name="_ResolveAndroidSigningKey" DependsOnTargets="$(_OnResolveMonoAndroidSdks)">
+<Target Name="_CreateAndroidDebugSigningKey"
+		Condition="!Exists ('$(_ApkDebugKeyStore)')"
+		DependsOnTargets="$(_OnResolveMonoAndroidSdks)"
+	>
+	<AndroidCreateDebugKey
+		KeyStore="$(_ApkDebugKeyStore)"
+		KeyAlias="$(_ApkDebugKeyAlias)"
+		KeyPass="$(_ApkDebugKeyPassword)"
+		StorePass="$(_ApkDebugKeyStorePassword)"
+		ToolPath="$(KeytoolToolPath)"
+		ToolExe="$(KeytoolToolExe)"
+		Command="-genkeypair"
+	 />
+</Target>
+
+<Target Name="_ResolveAndroidSigningKey" DependsOnTargets="$(_OnResolveMonoAndroidSdks);_CreateAndroidDebugSigningKey">
 	<!-- would use a PropertyGroup here but xbuild doesn't support it -->
 	<CreateProperty Value="$(_ApkDebugKeyStore)" Condition="'$(AndroidKeyStore)'!='True'">
 		<Output TaskParameter="Value" PropertyName="_ApkKeyStore"/>
@@ -2484,16 +2516,6 @@ because xbuild doesn't support framework reference assemblies.
 	<CreateProperty Value="$(AndroidSigningKeyPass)" Condition="'$(AndroidKeyStore)'=='True'">
 		<Output TaskParameter="Value" PropertyName="_ApkKeyPass"/>
 	</CreateProperty>
-	
-	<AndroidCreateDebugKey
-		KeyStore="$(_ApkKeyStore)"
-		KeyAlias="$(_ApkKeyAlias)"
-		KeyPass="$(_ApkKeyPass)"
-		StorePass="$(_ApkStorePass)"
-		ToolPath="$(KeytoolToolPath)"
-		ToolExe="$(KeytoolToolExe)"
-		Command="-genkeypair"
-		Condition="'$(AndroidKeyStore)'=='' and !Exists ('$(_ApkKeyStore)')" />
 
 	<Delete Files="$(_AndroidDebugKeyStoreFlag)" Condition="'$(AndroidKeyStore)'=='True'" />
 	<Touch Files="$(_AndroidDebugKeyStoreFlag)" AlwaysCreate="True" Condition="'$(AndroidKeyStore)'!='True'" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2494,13 +2494,13 @@ because xbuild doesn't support framework reference assemblies.
 	<CreateProperty Value="$(_ApkDebugKeyStore)" Condition="'$(AndroidKeyStore)'!='True'">
 		<Output TaskParameter="Value" PropertyName="_ApkKeyStore"/>
 	</CreateProperty>
-	<CreateProperty Value="$(_ApkDebugKeyPassword)" Condition="'$(AndroidKeyStore)'!='True'">
+	<CreateProperty Value="$(_ApkDebugKeyStorePassword)" Condition="'$(AndroidKeyStore)'!='True'">
 		<Output TaskParameter="Value" PropertyName="_ApkStorePass"/>
 	</CreateProperty>
 	<CreateProperty Value="$(_ApkDebugKeyAlias)" Condition="'$(AndroidKeyStore)'!='True'">
 		<Output TaskParameter="Value" PropertyName="_ApkKeyAlias"/>
 	</CreateProperty>
-	<CreateProperty Value="$(_ApkDebugKeyStorePassword)" Condition="'$(AndroidKeyStore)'!='True'">
+	<CreateProperty Value="$(_ApkDebugKeyPassword)" Condition="'$(AndroidKeyStore)'!='True'">
 		<Output TaskParameter="Value" PropertyName="_ApkKeyPass"/>
 	</CreateProperty>
 	

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -732,24 +732,6 @@ because xbuild doesn't support framework reference assemblies.
 		/>
 	</CreateProperty>
 
-	<CreateProperty Value="android">
-		<Output TaskParameter="Value" PropertyName="_ApkDebugKeyStorePassword"
-			Condition="'$(_ApkDebugKeyStorePassword)' == ''"
-		/>
-	</CreateProperty>
-
-	<CreateProperty Value="android">
-		<Output TaskParameter="Value" PropertyName="_ApkDebugKeyPassword"
-			Condition="'$(_ApkDebugKeyPassword)' == ''"
-		/>
-	</CreateProperty>
-
-	<CreateProperty Value="androiddebugkey">
-		<Output TaskParameter="Value" PropertyName="_ApkDebugKeyAlias"
-			Condition="'$(_ApkDebugKeyAlias)' == ''"
-		/>
-	</CreateProperty>
-
 	<CreateProperty Value="$(MonoAndroidToolsDirectory)">
 		<Output TaskParameter="Value" PropertyName="_MonoAndroidToolsDirectory"/>
 	</CreateProperty>
@@ -2482,9 +2464,9 @@ because xbuild doesn't support framework reference assemblies.
 	>
 	<AndroidCreateDebugKey
 		KeyStore="$(_ApkDebugKeyStore)"
-		KeyAlias="$(_ApkDebugKeyAlias)"
-		KeyPass="$(_ApkDebugKeyPassword)"
-		StorePass="$(_ApkDebugKeyStorePassword)"
+		KeyAlias="androiddebugkey"
+		KeyPass="android"
+		StorePass="android"
 		ToolPath="$(KeytoolToolPath)"
 		ToolExe="$(KeytoolToolExe)"
 		Command="-genkeypair"
@@ -2496,13 +2478,13 @@ because xbuild doesn't support framework reference assemblies.
 	<CreateProperty Value="$(_ApkDebugKeyStore)" Condition="'$(AndroidKeyStore)'!='True'">
 		<Output TaskParameter="Value" PropertyName="_ApkKeyStore"/>
 	</CreateProperty>
-	<CreateProperty Value="$(_ApkDebugKeyStorePassword)" Condition="'$(AndroidKeyStore)'!='True'">
+	<CreateProperty Value="android" Condition="'$(AndroidKeyStore)'!='True'">
 		<Output TaskParameter="Value" PropertyName="_ApkStorePass"/>
 	</CreateProperty>
-	<CreateProperty Value="$(_ApkDebugKeyAlias)" Condition="'$(AndroidKeyStore)'!='True'">
+	<CreateProperty Value="androiddebugkey" Condition="'$(AndroidKeyStore)'!='True'">
 		<Output TaskParameter="Value" PropertyName="_ApkKeyAlias"/>
 	</CreateProperty>
-	<CreateProperty Value="$(_ApkDebugKeyPassword)" Condition="'$(AndroidKeyStore)'!='True'">
+	<CreateProperty Value="android" Condition="'$(AndroidKeyStore)'!='True'">
 		<Output TaskParameter="Value" PropertyName="_ApkKeyPass"/>
 	</CreateProperty>
 	

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -727,7 +727,9 @@ because xbuild doesn't support framework reference assemblies.
 	</CreateProperty>
 
 	<CreateProperty Value="$(_AppSettingsDirectory)debug.keystore">
-		<Output TaskParameter="Value" PropertyName="_ApkDebugKeyStore"/>
+		<Output TaskParameter="Value" PropertyName="_ApkDebugKeyStore"
+			Condition="'$(_ApkDebugKeyStore)' == ''"
+		/>
 	</CreateProperty>
 
 	<CreateProperty Value="android">


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=61065

If a user sets the `$(AndroidKeyStore)` to `True` for a
debug configuration they will get the following error.

	[MESSAGE] jarsigner error: java.lang.RuntimeException: keystore load: /Users/$(user)/.local/share/Xamarin/Mono for Android/debug.keystore (No such file or directory)

Note this will only happen if they have NEVER build with
`$(AndroidKeyStore)` set to `False`. This is because we
don't always generate the `debug.keystore`.

So rather than hitting this issue we should always generate the
`debug.keystore` regardless of what the setting for `$(AndroidKeyStore)`
is. This commit splits out the keystore generation into its own
target. This target will check the existance of the file and
generate it if required. We also move all the debug key property
values into Properties so that they can be updated in one place.