### PR TITLE
[Xamarin.Android.Build.Tasks] Fix message for missing Platform error XA5207

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2085,6 +2085,32 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		}
 
 		[Test]
+		public void IfAndroidJarDoesNotExistThrowXA5207 ()
+		{
+			var path = Path.Combine ("temp", TestName);
+			var AndroidSdkDirectory = CreateFauxAndroidSdkDirectory (Path.Combine (path, "android-sdk"), "24.0.1", minApiLevel: 10, maxApiLevel: 26);
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				TargetFrameworkVersion = "v8.1",
+				UseLatestPlatformSdk = false,
+			};
+			using (var builder = CreateApkBuilder (Path.Combine (path, proj.ProjectName), false, false)) {
+				if (!Directory.Exists (Path.Combine (builder.FrameworkLibDirectory, "xbuild-frameworks", "MonoAndroid", "v8.1")))
+					Assert.Ignore ("This is a Pull Request Build. Ignoring test.");
+				builder.ThrowOnBuildFailure = false;
+				builder.Target = "AndroidPrepareForBuild";
+				Assert.IsFalse (builder.Build (proj, parameters: new string [] {
+					$"AndroidSdkBuildToolsVersion=24.0.1",
+					$"AndroidSdkDirectory={AndroidSdkDirectory}",
+					$"_AndroidApiLevel=27",
+				}), "Build should have failed");
+				Assert.IsTrue (builder.LastBuildOutput.ContainsText ("error : XA5207"), "XA5207 should have been raised.");
+				Assert.IsTrue (builder.LastBuildOutput.ContainsText ("Could not find android.jar for API Level 27"), "XA5207 should have had a good error message.");
+			}
+			Directory.Delete (AndroidSdkDirectory, recursive: true);
+		}
+
+		[Test]
 		[NonParallelizable]
 		public void BuildAMassiveApp()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2098,13 +2098,14 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				if (!Directory.Exists (Path.Combine (builder.FrameworkLibDirectory, "xbuild-frameworks", "MonoAndroid", "v8.1")))
 					Assert.Ignore ("This is a Pull Request Build. Ignoring test.");
 				builder.ThrowOnBuildFailure = false;
+				builder.Verbosity = LoggerVerbosity.Diagnostic;
 				builder.Target = "AndroidPrepareForBuild";
 				Assert.IsFalse (builder.Build (proj, parameters: new string [] {
 					$"AndroidSdkBuildToolsVersion=24.0.1",
 					$"AndroidSdkDirectory={AndroidSdkDirectory}",
 					$"_AndroidApiLevel=27",
 				}), "Build should have failed");
-				Assert.IsTrue (builder.LastBuildOutput.ContainsText ("error : XA5207"), "XA5207 should have been raised.");
+				Assert.IsTrue (builder.LastBuildOutput.ContainsText ("error XA5207:"), "XA5207 should have been raised.");
 				Assert.IsTrue (builder.LastBuildOutput.ContainsText ("Could not find android.jar for API Level 27"), "XA5207 should have had a good error message.");
 			}
 			Directory.Delete (AndroidSdkDirectory, recursive: true);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -543,7 +543,7 @@ namespace Xamarin.Android.Tasks
 			var platformPath = MonoAndroidHelper.AndroidSdk.TryGetPlatformDirectoryFromApiLevel (platform, MonoAndroidHelper.SupportedVersions);
 			if (platformPath == null) {
 				var expectedPath = MonoAndroidHelper.AndroidSdk.GetPlatformDirectoryFromId (platform);
-				log.LogError ("XA5207", "Could not find android.jar for API Level {0}. " +
+				log.LogError (null, "XA5207", null, null, 0, 0, 0, 0, "Could not find android.jar for API Level {0}. " +
 						"This means the Android SDK platform for API Level {0} is not installed. " +
 						"Either install it in the Android SDK Manager (Tools > Open Android SDK Manager...), " +
 						"or change your Xamarin.Android project to target an API version that is installed. " +

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -543,7 +543,7 @@ namespace Xamarin.Android.Tasks
 			var platformPath = MonoAndroidHelper.AndroidSdk.TryGetPlatformDirectoryFromApiLevel (platform, MonoAndroidHelper.SupportedVersions);
 			if (platformPath == null) {
 				var expectedPath = MonoAndroidHelper.AndroidSdk.GetPlatformDirectoryFromId (platform);
-				log.LogError (null, "XA5207", null, null, 0, 0, 0, 0, "Could not find android.jar for API Level {0}. " +
+				log.LogCodedError ("XA5207", "Could not find android.jar for API Level {0}. " +
 						"This means the Android SDK platform for API Level {0} is not installed. " +
 						"Either install it in the Android SDK Manager (Tools > Open Android SDK Manager...), " +
 						"or change your Xamarin.Android project to target an API version that is installed. " +


### PR DESCRIPTION
Fixes #1136

Commit 7f45a6d reworked the GetJavaPlatformJar Task (and others)
to handle a NRE exception. However the error logging code in
MonoAndroidHelper.cs was not formatted correctly. As a result
the XA5207 error would be logged without any message.

This commit fixes up the LogError call to make sure the error
has a decent message. It also adds a unit test so that we can
catch this issue if it regresses in the future.