### PR TITLE
[Xamarin.Android.Build.Tasks] Rework Aapt log processing.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidRegExTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidRegExTests.cs
@@ -75,6 +75,14 @@ namespace Xamarin.Android.Build.Tests
 					/*expectedMessage*/	"max res 10, skipping values-sw600dp-land"
 				};
 				yield return new object [] {
+ 					/*message*/		"max res 10, skipping values-sw720dp-land-v13",
+ 					/*expectedToMatch*/	true,
+ 					/*expectedFile*/	"",
+ 					/*expectedLine*/	"",
+ 					/*expectedLevel*/	"",
+ 					/*expectedMessage*/	"max res 10, skipping values-sw720dp-land-v13"
+				};
+				yield return new object [] {
 					/*message*/		"Error: unable to generate entry for resource data",
 					/*expectedToMatch*/	true,
 					/*expectedFile*/	"",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -186,6 +186,23 @@ using System.Runtime.CompilerServices;
 		}
 
 		[Test]
+		public void ReportAaptWarningsForBlankLevel ()
+		{
+			//This test should get the warning `Invalid file name: must contain only [a-z0-9_.]`
+			//    However, <Aapt /> still fails due to aapt failing, Resource.designer.cs is not generated
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\drawable\\Image (1).png") {
+				BinaryContent = () => XamarinAndroidCommonProject.icon_binary_mdpi
+			});
+			using (var b = CreateApkBuilder ("temp/ReportAaptWarningsForBlankLevel")) {
+				b.ThrowOnBuildFailure = false;
+				Assert.IsFalse (b.Build (proj), "Build should have failed.");
+				StringAssertEx.Contains ("APT0000", b.LastBuildOutput, "An error message with a blank \"level\", should be reported as an error!");
+				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
+			}
+		}
+
+		[Test]
 		public void RepetiviteBuildUpdateSingleResource ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();


### PR DESCRIPTION
Context #1134 

Aapt is pretty inconsistent with how it reports errors and
warnings. Warnings are written to stderr..

So we are reworking the output processing for aapt to hopefully
handle errors are warnings in a more consistent way. Rather than
process the output in realtime we will buffer it and process the
output once aapt has completed. This will allow us to check to
see if the required output file (R.java) was created. If it
wasn't then we can assume that the process failed.

We can then process the output knowing that we are expecting
and error. In the case where R.java does exist, we can assume
if we do find anything which looks like an error it is more
than likely a warning.