### PR TITLE
Unwrap JavaProxyThrowable in unhandled exception handler

### DIFF
--- a/src/Mono.Android/Android.Runtime/UncaughtExceptionHandler.cs
+++ b/src/Mono.Android/Android.Runtime/UncaughtExceptionHandler.cs
@@ -43,7 +43,9 @@ namespace Android.Runtime {
 			mono_unhandled_exception (ex);
 			if (AppDomain_DoUnhandledException != null) {
 				try {
-					var args  = new UnhandledExceptionEventArgs (ex, isTerminating: true);
+					var jltp = ex as JavaProxyThrowable;
+					Exception innerException = jltp?.InnerException;
+					var args  = new UnhandledExceptionEventArgs (innerException ?? ex, isTerminating: true);
 					AppDomain_DoUnhandledException (AppDomain.CurrentDomain, args);
 				}
 				catch (Exception e) {


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/1144

User code cannot easily unwrap the inner exception itself unless
it uses reflection to read the `JavaProxyThrowable.InnerException`
property which is unacceptable.

Add code to unwrap the exception before calling the AppDomain
unhandled exception handler.