### PR TITLE
[Xamarin.Android.Build.Tasks] ReOrder when Assets are Processed.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -536,7 +536,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	</CoreResolveReferencesDependsOn>
 	<ResolveReferencesDependsOn>
 		$(CoreResolveReferencesDependsOn);
-		UpdateAndroidAssets;
 		UpdateAndroidInterfaceProxies;
 		UpdateAndroidResources;
 		$(ApplicationResolveReferencesDependsOn);
@@ -1907,6 +1906,7 @@ because xbuild doesn't support framework reference assemblies.
 		_CheckDuplicateJavaLibraries;
 		_GetAdditionalResourcesFromAssemblies;
 		_CreateAdditionalResourceCache;
+		UpdateAndroidAssets;
 		$(_AfterCreateBaseApkDependsOnTargets);
 	</_CreateBaseApkDependsOnTargets>
 	<_CreateBaseApkInputs>


### PR DESCRIPTION
Context #1150

The way the current system works is that the `UpdateAndroidAssets`
target is called as part of the `ResolveReferencesDependsOn`. This
makes it impossible to do any kind of processing of assets after
the project has already built. It also menas that a straight up
call to `Build` will result in all the assets being copied into
the intermediate directory. If your project has a large number
of assets that is going to take time. Note this might also be
called as part of a designtime build at the moment... not good.

So is there a reason why we call `UpdateAndroidAssets` before
`Compile`? We don't generate any entries in the Designer.cs files
for them.. We don't clean them up.. we dont appear to do anything
except package them! So the anser looks to be a resounding NO!

So we shall move the `UpdateAndroidAssets` to be part of the
`_CreateBaseApkDependsOnTargets`. This means they will be
processed just before we create the base apk. This will
occur after compilation has completed. So we have a win win..

This commit also includes a unit test which does some post processing
after the `Compile` target to update an asset, it makes sure that
post processing does work.