### PR TITLE
[Xamarin.Android.Build.Tasks] Always emit targetSdkVersion in the manifest

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1039,7 +1039,7 @@ namespace App1
 			var proj = new XamarinAndroidApplicationProject ();
 			proj.UseLatestPlatformSdk = true;
 			proj.SetProperty ("AndroidLintEnabled", true.ToString ());
-			proj.SetProperty ("AndroidLintDisabledIssues", "StaticFieldLeak,ObsoleteSdkInt");
+			proj.SetProperty ("AndroidLintDisabledIssues", "StaticFieldLeak,ObsoleteSdkInt,AllowBackup");
 			proj.SetProperty ("AndroidLintEnabledIssues", "");
 			proj.SetProperty ("AndroidLintCheckIssues", "");
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("public class MainActivity : Activity", @"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -13,6 +13,13 @@ namespace Xamarin.Android.Build.Tests
 	[Parallelizable (ParallelScope.Children)]
 	public partial class ManifestTest : BaseTest
 	{
+		readonly string MinAndTargetSdkManifest = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" android:versionCode=""1"" android:versionName=""1.0"" package=""foo.foo"">
+	<uses-sdk android:minSdkVersion=""{0}"" android:targetSdkVersion=""{1}""/>
+	<application android:label=""foo"">
+	</application>
+</manifest>";
+		
 		readonly string TargetSdkManifest = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <manifest xmlns:android=""http://schemas.android.com/apk/res/android"" android:versionCode=""1"" android:versionName=""1.0"" package=""Bug12935.Bug12935"">
 	<uses-sdk android:targetSdkVersion=""{0}""/>
@@ -127,9 +134,9 @@ namespace Bug12935
 				IsRelease = true,
 			};
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				var manifestFile = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "AndroidManifest.xml");
 				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
 				Assert.IsTrue (b.Build (proj), "build failed");
-				var manifestFile = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "AndroidManifest.xml");
 				XDocument doc = XDocument.Load (manifestFile);
 				var ns = doc.Root.GetNamespaceOfPrefix ("android");
 				var targetSdkXName = XName.Get ("targetSdkVersion", ns.NamespaceName);
@@ -139,6 +146,15 @@ namespace Bug12935
 				var version = b.LatestTargetFrameworkVersion ();
 				var level = b.GetAndroidApiLevelForFramework (version);
 				Assert.AreEqual (level, targetSdk?.Value, $"targetSdkVersion should have been {level}");
+				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
+				proj.AndroidManifest = string.Format (MinAndTargetSdkManifest, 11, 25);
+				Assert.IsTrue (b.Build (proj), "build failed");
+				doc = XDocument.Load (manifestFile);
+				usesSdk = doc.XPathSelectElement ("/manifest/uses-sdk");
+				Assert.IsNotNull (usesSdk, "Failed to read the uses-sdk element");
+				targetSdk = usesSdk.Attribute (targetSdkXName);
+				Assert.AreEqual ("25", targetSdk?.Value, $"targetSdkVersion should have been 25");
+
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Xml.Linq;
 
 namespace Xamarin.ProjectTools
 {
@@ -193,6 +194,17 @@ namespace Xamarin.ProjectTools
 					latest = version;
 			}
 			return "v" + latest.ToString (2);
+		}
+
+		public string GetAndroidApiLevelForFramework (string frameworkVersion)
+		{
+			var outdir = FrameworkLibDirectory;
+			var path = Path.Combine (outdir, "xbuild-frameworks", "MonoAndroid", frameworkVersion, "AndroidApiInfo.xml");
+			if (!File.Exists (path)) {
+				return "0";
+			}
+			var doc = XDocument.Load (path);
+			return doc.Element ("AndroidApiInfo")?.Element ("Level")?.Value ?? "0";
 		}
 
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -263,6 +263,7 @@ namespace Xamarin.Android.Tasks {
 				targetSdkVersion = tsv.Value;
 			else {
 				targetSdkVersion = SdkVersionName;
+				uses.Add (new XAttribute (androidNs + "targetSdkVersion", SdkVersionName));
 				uses.AddBeforeSelf (new XComment ("suppress UsesMinSdkAttributes"));
 			}
 


### PR DESCRIPTION
Context #1163

We currently do not always emit `targetSdkVersion` in the
AndroidManifest.xml. If the user has `AndroidUseLatestPlatformSdk`
set (which is the default) then it definately doesn't get
written.

This can cause problems when a developer is trying to use
modern features. Because of the `targetSdkVersion` is not
specified it defaults to the `minSdkVersion` value.

So lets add a check to make sure we always emit this value.
We already have code which makes sure we do not overwrite
it if the user has specificed it. So all we need to do is
handle the case where they haven't added it.