### PR TITLE
Preparation for the new test runner

### DIFF
--- a/build-tools/mono-runtimes/ProfileAssemblies.projitems
+++ b/build-tools/mono-runtimes/ProfileAssemblies.projitems
@@ -192,6 +192,10 @@
     <MonoTestAssembly Include="monodroid_corlib_test.dll">
       <SourcePath>corlib</SourcePath>
     </MonoTestAssembly>
+    <MonoTestAssembly Include="monodroid_corlib_xunit-test.dll">
+      <SourcePath>corlib</SourcePath>
+      <TestType>xunit</TestType>
+    </MonoTestAssembly>
     <MonoTestAssembly Include="monodroid_I18N.CJK_test.dll">
       <SourcePath>I18N/CJK</SourcePath>
     </MonoTestAssembly>
@@ -236,6 +240,10 @@
     </MonoTestAssembly>
     <MonoTestAssembly Include="monodroid_System.Numerics_test.dll">
       <SourcePath>System.Numerics</SourcePath>
+    </MonoTestAssembly>
+    <MonoTestAssembly Include="monodroid_System.Numerics_xunit-test.dll">
+      <SourcePath>System.Numerics</SourcePath>
+      <TestType>xunit</TestType>
     </MonoTestAssembly>
     <MonoTestAssembly Include="monodroid_System.Runtime.Serialization_test.dll">
       <SourcePath>System.Runtime.Serialization</SourcePath>

--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -310,6 +310,11 @@
         IgnoreStandardErrorWarningFormat="True"
         WorkingDirectory="$(IntermediateOutputPath)\%(_MonoRuntime.Identity)\runtime"
     />
+    <Exec
+        Condition=" '%(MonoTestAssembly.TestType)' == 'xunit' "
+        Command="make -C $(MonoSourceFullPath)\mcs\class\%(MonoTestAssembly.SourcePath) xunit-test-local"
+        WorkingDirectory="$(MonoSourceFullPath)"
+    />
     <Copy
         SourceFiles="@(_BclTestAssemblySource)"
         DestinationFiles="@(_BclTestAssemblyDestination)"

--- a/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets
+++ b/tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets
@@ -5,20 +5,29 @@
   <Import Project="Xamarin.Android.Bcl-Tests.projitems" />
   <Import Project="..\..\build-tools\scripts\TestApks.targets" />
   <Import Project="..\..\build-tools\mono-runtimes\ProfileAssemblies.projitems" />
+  <Target Name="_GetNUnitAssemblies">
+    <ItemGroup>
+      <_NUnitAssembly
+          Condition=" '%(MonoTestAssembly.TestType)' != 'xunit' "
+          Include="@(MonoTestAssembly)"
+      />
+    </ItemGroup>
+  </Target>
   <Target Name="_AddTestAssemblies"
       DependsOnTargets="_RemapAssemblies"
       BeforeTargets="ResolveAssemblyReferences">
     <ItemGroup>
-      <Reference Include="@(MonoTestAssembly->'$(IntermediateOutputPath)%(Identity)')" />
+      <Reference Include="@(_NUnitAssembly->'$(IntermediateOutputPath)%(Identity)')" />
       <Reference Remove="$(IntermediateOutputPath)nunitlite.dll" />
     </ItemGroup>
   </Target>
   <Target Name="_RemapAssemblies"
-      Inputs="@(MonoTestAssembly->'..\..\bin\$(Configuration)\bcl-tests\%(Identity)')"
-      Outputs="@(MonoTestAssembly->'$(IntermediateOutputPath)%(Identity)')">
+      DependsOnTargets="_GetNUnitAssemblies"
+      Inputs="@(_NUnitAssembly->'..\..\bin\$(Configuration)\bcl-tests\%(Identity)')"
+      Outputs="@(_NUnitAssembly->'$(IntermediateOutputPath)%(Identity)')">
     <MakeDir Directories="$(IntermediateOutputPath)" />
     <ItemGroup>
-      <_Source  Include="@(MonoTestAssembly->'..\..\bin\$(Configuration)\bcl-tests\%(Identity)')" />
+      <_Source  Include="@(_NUnitAssembly->'..\..\bin\$(Configuration)\bcl-tests\%(Identity)')" />
     </ItemGroup>
     <ResolveAssemblyReference
         Assemblies="Xamarin.Android.NUnitLite"
@@ -67,11 +76,12 @@
     <Touch Files="@(_TestResource)" />
   </Target>
   <Target Name="_GenerateApp_cs"
-      Inputs="@(MonoTestAssembly->'..\..\bin\$(Configuration)\bcl-tests\%(Identity)')"
+      DependsOnTargets="_GetNUnitAssemblies"
+      Inputs="@(_NUnitAssembly->'..\..\bin\$(Configuration)\bcl-tests\%(Identity)')"
       Outputs="$(IntermediateOutputPath)\App.cs">
     <MakeDir Directories="$(IntermediateOutputPath)" />
     <PropertyGroup>
-      <_Assemblies>@(MonoTestAssembly->'"%(Identity)"', ',  ')</_Assemblies>
+      <_Assemblies>@(_NUnitAssembly->'"%(Identity)"', ',  ')</_Assemblies>
     </PropertyGroup>
     <ReplaceFileContents
         SourceFile="App.cs.in"


### PR DESCRIPTION
PR https://github.com/xamarin/xamarin-android/pull/1075 keeps rebuilding all the
Mono runtimes because the two files in this commit are part of the logic to
determine whether to use cached Mono or not. The result isn't cached, because
it's a PR builder, and so we keep waiting for 7h+ each time a smallest change is
made. This commit will cause Mono to be rebuilt and cached and, in turn, speed
up round-trip time for PR 1075