### PR TITLE
[build] Set `$(JI_MAX_JDK)` for Java.Interop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,8 @@ prepare-external:
 	nuget restore Xamarin.Android-Tests.sln
 	$(foreach conf, $(CONFIGURATIONS), \
 		(cd external/xamarin-android-tools && make prepare CONFIGURATION=$(conf)) && \
-		(cd $(call GetPath,JavaInterop) && make prepare CONFIGURATION=$(conf)) && \
-		(cd $(call GetPath,JavaInterop) && make bin/Build$(conf)/JdkInfo.props CONFIGURATION=$(conf)) && ) \
+		(cd $(call GetPath,JavaInterop) && make prepare CONFIGURATION=$(conf) JI_MAX_JDK=8) && \
+		(cd $(call GetPath,JavaInterop) && make bin/Build$(conf)/JdkInfo.props CONFIGURATION=$(conf) JI_MAX_JDK=8) && ) \
 	true
 
 prepare-deps: prepare-external


### PR DESCRIPTION
Update the `make prepare` step so that we pass `JI_MAX_JDK=8` to
Java.Interop's `make prepare` step. This prevents us from using JDK 9
if it is installed on the machine.

Internal VSTS builds are failing *seemingly* because JDK 9 is
installed and used by default on the build machine, with `gradelw`
bailing out with:

	Caused by: java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlSchema

This previously worked with JDK 8, so we're hoping that the use of
JDK 9 is the cause, and by *excluding* JDK 9 from being used we'll be
able to build on VSTS again.