### PR TITLE
[Xamarin.Android.Build.Tasks] Fix Aapt task to emit warnings

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -164,7 +164,9 @@ namespace Xamarin.Android.Tasks
 		{
 			var output = new List<OutputLine> ();
 			var ret = RunAapt (cmd, output);
-			var success = File.Exists (Path.Combine (JavaDesignerOutputDirectory, "R.java"));
+			var success = !string.IsNullOrEmpty (currentResourceOutputFile)
+				? File.Exists (Path.Combine (currentResourceOutputFile + ".bk"))
+				: ret;
 			foreach (var line in output) {
 				if (line.StdError) {
 					LogEventsFromTextOutput (line.Line, MessageImportance.Normal, success);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1123,6 +1123,34 @@ namespace Lib1 {
 		}
 
 		[Test]
+		public void CheckMaxResWarningIsEmittedAsAWarning()
+		{
+			var path = Path.Combine ("temp", TestName);
+			var proj = new XamarinAndroidApplicationProject () {
+				TargetFrameworkVersion = "v8.0",
+				UseLatestPlatformSdk = false,
+				IsRelease = true,
+				OtherBuildItems = {
+					new BuildItem.Folder ("Resources\\values-v27\\") {
+					},
+				},
+			};
+			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values-v27\\Strings.xml") {
+				TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
+<resources>
+  <string name=""test"" >Test</string>
+</resources>",
+			});
+			using (var builder = CreateApkBuilder (path)) {
+				if (!builder.TargetFrameworkExists (proj.TargetFrameworkVersion)) {
+					Assert.Ignore ($"Skipping Test. TargetFrameworkVersion {proj.TargetFrameworkVersion} was not available.");
+				}
+				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
+				StringAssertEx.Contains ("warning : max res 26, skipping values-v27", builder.LastBuildOutput, "Build output should contain a warning about 'max res 26, skipping values-v27'");
+			}
+		}
+
+		[Test]
 		public void CheckDefaultTranslationWarnings ()
 		{
 			var path = Path.Combine ("temp", TestName);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -195,6 +195,15 @@ namespace Xamarin.ProjectTools
 			return "v" + latest.ToString (2);
 		}
 
+		public bool TargetFrameworkExists (string targetFramework)
+		{
+			var path = Path.Combine (FrameworkLibDirectory, "xbuild-frameworks", "MonoAndroid", targetFramework);
+			if (!Directory.Exists (path)) {
+				return false;
+			}
+			return true;
+		}
+
 
 		public string Root {
 			get {


### PR DESCRIPTION
Context #1134

Commit 23c5801 reworked Aapt to emit warnings if the required
output file did exist. If it didn't we should emit errors.
There was one slight problem with this, we were checking the
wrong file. We should have been checking for the temp
packaged_resources file rather than the R.txt (which will
always exist after an initial build).

This commit fixes that amd adds a unit test. Note the in order
to create the senario we need to have a `$(TargetFrameworkVersion)`
which is `v8.0`. We currently only build `v1.0` and `v8.1` for
PR builds. So the test checks to see if that target framework is
available. If not the test will be ignored.