### PR TITLE
[Xamarin.Android.Build.Tasks] Ignore the ObsoleteSdkInt Lint Check

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
@@ -175,6 +175,10 @@ namespace Xamarin.Android.Tasks
 			// for our generated code not calling super.OnCreate. This however is by design
 			// so we need to ignore this error.
 			{ "MissingSuperCall", new Version (26, 1, 1) },
+			// We need to disble this test since the code in
+			// MonoPackageManager.java causes this warning to be emitted.
+			// This is by design so we can safely ignore this.
+			{ "ObsoleteSdkInt", new Version (1, 0) },
 		};
 
 		static readonly Regex lintVersionRegex = new Regex (@"version[\t\s]+(?<version>[\d\.]+)", RegexOptions.Compiled);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
@@ -178,7 +178,7 @@ namespace Xamarin.Android.Tasks
 			// We need to disble this test since the code in
 			// MonoPackageManager.java causes this warning to be emitted.
 			// This is by design so we can safely ignore this.
-			{ "ObsoleteSdkInt", new Version (1, 0) },
+			{ "ObsoleteSdkInt", new Version (26, 1, 1) },
 		};
 
 		static readonly Regex lintVersionRegex = new Regex (@"version[\t\s]+(?<version>[\d\.]+)", RegexOptions.Compiled);


### PR DESCRIPTION
Context #1171

There is a new test [ObsoleteSdkInt] which produces a warning
such as

	obj/Debug/android/src/mono/MonoPackageManager.java(85,6): warning XA0102:  Unnecessary; SDK_INT is always >= 10 [ObsoleteSdkInt]

So our MonoPackageManager.java file is the cause of this
particular warning [1]. I am not sure we can remove that
line of code yet, since our apps can run on older devices.
That said once the % share of devices for API's < 8 is 0,
we can probably remove that line of code completely and
re-enable this check.

[1] https://github.com/xamarin/xamarin-android/blob/master/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.java#L85