### PR TITLE
[enumification][Mono.Android] fix ChoiceMode enum generation.

### DIFF
--- a/build-tools/enumification-helpers/enum-conversion-mappings.xml
+++ b/build-tools/enumification-helpers/enum-conversion-mappings.xml
@@ -842,7 +842,8 @@
   <map package='android.webkit' class='WebView.HitTestResult' fields='*' enum-name='HitTestResult' is-transient='false' />
   <map package='android.webkit' class='WebViewClient' prefix='ERROR_' enum-name='ClientError' is-transient='false' />
   <map package='android.webkit' class='WebViewClient' prefix='SAFE_BROWSING_THREAT_' enum-name='SafeBrowsingThreat' is-transient='false' />
-  <map package='android.widget' class='AbsListView' prefix='CHOICE_MODE_' enum-name='ChoiceMode' is-transient='false' />
+  <map package='android.widget' class='ListView' prefix='CHOICE_MODE_' enum-name='ChoiceMode' is-transient='true' />
+  <map package='android.widget' class='AbsListView' prefix='CHOICE_MODE_' fields='CHOICE_MODE_MULTIPLE_MODAL' enum-name='ChoiceMode' is-transient='true' />
   <map package='android.widget' class='AbsListView' prefix='TRANSCRIPT_MODE_' enum-name='TranscriptMode' is-transient='false' />
   <map package='android.widget' class='AdapterView' prefix='ITEM_VIEW_TYPE_' enum-name='ItemViewType' is-transient='false' />
   <map package='android.widget' class='CursorAdapter' prefix='FLAG_' enum-name='CursorAdapterFlags' extra-default='None' is-transient='false' />

--- a/src/Mono.Android/map.csv
+++ b/src/Mono.Android/map.csv
@@ -2967,10 +2967,6 @@
 27,Android.Webkit.SafeBrowsingThreat,Phishing,android/webkit/WebViewClient.SAFE_BROWSING_THREAT_PHISHING,2
 27,Android.Webkit.SafeBrowsingThreat,Unknown,android/webkit/WebViewClient.SAFE_BROWSING_THREAT_UNKNOWN,0
 27,Android.Webkit.SafeBrowsingThreat,UnwantedSoftware,android/webkit/WebViewClient.SAFE_BROWSING_THREAT_UNWANTED_SOFTWARE,3
-15,Android.Widget.ChoiceMode,Multiple,android/widget/AbsListView.CHOICE_MODE_MULTIPLE,2
-15,Android.Widget.ChoiceMode,MultipleModal,android/widget/AbsListView.CHOICE_MODE_MULTIPLE_MODAL,3
-15,Android.Widget.ChoiceMode,None,android/widget/AbsListView.CHOICE_MODE_NONE,0
-15,Android.Widget.ChoiceMode,Single,android/widget/AbsListView.CHOICE_MODE_SINGLE,1
 10,Android.Widget.TranscriptMode,AlwaysScroll,android/widget/AbsListView.TRANSCRIPT_MODE_ALWAYS_SCROLL,2
 10,Android.Widget.TranscriptMode,Disabled,android/widget/AbsListView.TRANSCRIPT_MODE_DISABLED,0
 10,Android.Widget.TranscriptMode,Normal,android/widget/AbsListView.TRANSCRIPT_MODE_NORMAL,1
@@ -5095,6 +5091,10 @@
 27,Android.Views.FeedbackConstants,VirtualKeyRelease,android/view/HapticFeedbackConstants.VIRTUAL_KEY_RELEASE,8
 10,Android.Views.FeedbackFlags,IgnoreGlobalSetting,android/view/HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING,2
 10,Android.Views.FeedbackFlags,IgnoreViewSetting,android/view/HapticFeedbackConstants.FLAG_IGNORE_VIEW_SETTING,1
+10,Android.Widget.ChoiceMode,Multiple,android/widget/ListView.CHOICE_MODE_MULTIPLE,2
+10,Android.Widget.ChoiceMode,None,android/widget/ListView.CHOICE_MODE_NONE,0
+10,Android.Widget.ChoiceMode,Single,android/widget/ListView.CHOICE_MODE_SINGLE,1
+15,Android.Widget.ChoiceMode,MultipleModal,android/widget/AbsListView.CHOICE_MODE_MULTIPLE_MODAL,3
 24,Android.AccessibilityServices.AccessibilityServiceShowMode,Auto,android/accessibilityservice/AccessibilityService.SHOW_MODE_AUTO,0
 24,Android.AccessibilityServices.AccessibilityServiceShowMode,Hidden,android/accessibilityservice/AccessibilityService.SHOW_MODE_HIDDEN,1
 24,Android.App.Admin.BugReportFailureReason,FailedCompleting,android/app/admin/DeviceAdminReceiver.BUGREPORT_FAILURE_FAILED_COMPLETING,0


### PR DESCRIPTION
After the last API XML generation sanitization, ChoiceMode was removed
because they were generated from AbsListView fields which DOES NOT EXIST
in API Level 10.

And getChoiceMode() and setChoiceMode are removed because they expect
that nonexistent enum.

Fortunately they are in ListView in API Level 10, so they can be generated
from there.