### PR TITLE
Better NetStandard Support

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -268,6 +268,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
+using System.IO.Packaging;
 
 using Xamarin.Forms;
 
@@ -275,9 +276,12 @@ namespace XamFormsSample
 {
     public partial class App : Application
     {
+        Package package;
+
         public App()
         {
             JsonConvert.DeserializeObject<string>(""test"");
+            var package = Package.Open ("""");
             InitializeComponent();
         }
 
@@ -338,29 +342,13 @@ namespace XamFormsSample
 				"Java.Interop.dll",
 				"Mono.Android.dll",
 				"mscorlib.dll",
-				"mscorlib.dll.mdb",
-				"System.Collections.Concurrent.dll",
-				"System.Collections.dll",
 				"System.Core.dll",
-				"System.Diagnostics.Debug.dll",
 				"System.dll",
-				"System.Linq.dll",
-				"System.Reflection.dll",
-				"System.Reflection.Extensions.dll",
-				"System.Runtime.dll",
-				"System.Runtime.Extensions.dll",
-				"System.Runtime.InteropServices.dll",
 				"System.Runtime.Serialization.dll",
-				"System.Threading.dll",
 				"System.IO.Packaging.dll",
-				"System.IO.Compression.dll",
-				"System.IO.Compression.pdb",
 				"Mono.Android.Export.dll",
-				"Mono.Android.Export.pdb",
 				"App1.dll",
-				"App1.pdb",
 				"FormsViewGroup.dll",
-				"FormsViewGroup.dll.mdb",
 				"Xamarin.Android.Support.Compat.dll",
 				"Xamarin.Android.Support.Core.UI.dll",
 				"Xamarin.Android.Support.Core.Utils.dll",
@@ -377,38 +365,14 @@ namespace XamFormsSample
 				"Xamarin.Android.Support.Annotations.dll",
 				"Xamarin.Android.Support.v7.CardView.dll",
 				"Xamarin.Forms.Core.dll",
-				"Xamarin.Forms.Core.dll.mdb",
 				"Xamarin.Forms.Platform.Android.dll",
-				"Xamarin.Forms.Platform.Android.dll.mdb",
 				"Xamarin.Forms.Platform.dll",
 				"Xamarin.Forms.Xaml.dll",
-				"Xamarin.Forms.Xaml.dll.mdb",
 				"XamFormsSample.dll",
-				"XamFormsSample.pdb",
-				"Mono.Android.pdb",
-				"System.Core.pdb",
-				"System.pdb",
 				"Mono.Security.dll",
-				"Mono.Security.pdb",
 				"System.Xml.dll",
-				"System.Xml.pdb",
-				"System.ComponentModel.Composition.dll",
-				"System.ComponentModel.Composition.pdb",
 				"System.Net.Http.dll",
-				"System.Net.Http.pdb",
-				"System.Runtime.Serialization.pdb",
 				"System.ServiceModel.Internals.dll",
-				"System.ServiceModel.Internals.pdb",
-				"System.Threading.Tasks.dll",
-				"System.ObjectModel.dll",
-				"System.Globalization.dll",
-				"System.ComponentModel.dll",
-				"System.Xml.ReaderWriter.dll",
-				"System.Linq.Expressions.dll",
-				"System.IO.dll",
-				"System.Dynamic.Runtime.dll",
-				"System.Text.RegularExpressions.dll",
-				"System.Diagnostics.Tools.dll",
 				"Newtonsoft.Json.dll",
 				"Microsoft.CSharp.dll",
 				"System.Numerics.dll",
@@ -418,12 +382,12 @@ namespace XamFormsSample
 			using (var builder = CreateDllBuilder (Path.Combine (path, netStandardProject.ProjectName), cleanupOnDispose: false)) {
 				if (!Directory.Exists (builder.MicrosoftNetSdkDirectory))
 					Assert.Ignore ("Microsoft.NET.Sdk not found.");
-				builder.RequiresMSBuild = true;
-				builder.Target = "Restore";
-				Assert.IsTrue (builder.Build (netStandardProject), "XamFormsSample Nuget packages should have been restored.");
-				builder.Target = "Build";
-				Assert.IsTrue (builder.Build (netStandardProject), "XamFormsSample should have built.");
 				using (var ab = CreateApkBuilder (Path.Combine (path, app.ProjectName), cleanupOnDispose: false)) {
+					builder.RequiresMSBuild = true;
+					builder.Target = "Restore";
+					Assert.IsTrue (builder.Build (netStandardProject), "XamFormsSample Nuget packages should have been restored.");
+					builder.Target = "Build";
+					Assert.IsTrue (builder.Build (netStandardProject), "XamFormsSample should have built.");
 					ab.RequiresMSBuild = true;
 					ab.Target = "Restore";
 					Assert.IsTrue (ab.Build (app), "App should have built.");
@@ -433,8 +397,8 @@ namespace XamFormsSample
 						app.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
 					using (var zip = ZipHelper.OpenZip (apk)) {
 						var existingFiles = zip.Where (a => a.FullName.StartsWith ("assemblies/", StringComparison.InvariantCultureIgnoreCase));
-						var missingFiles = expectedFiles.Where (x => !zip.ContainsEntry ("assmelbies/" + Path.GetFileName (x)));
-						Assert.IsTrue (missingFiles.Any (),
+						var missingFiles = expectedFiles.Where (x => !zip.ContainsEntry ("assemblies/" + Path.GetFileName (x)));
+						Assert.IsFalse (missingFiles.Any (),
 						string.Format ("The following Expected files are missing. {0}",
 							string.Join (Environment.NewLine, missingFiles)));
 						var additionalFiles = existingFiles.Where (x => !expectedFiles.Contains (Path.GetFileName (x.FullName)));

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -281,7 +281,7 @@ namespace XamFormsSample
         public App()
         {
             JsonConvert.DeserializeObject<string>(""test"");
-            var package = Package.Open ("""");
+            package = Package.Open ("""");
             InitializeComponent();
         }
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -3,6 +3,7 @@
 		<XamarinAndroidVersion>@PACKAGE_VERSION@-@PACKAGE_VERSION_BUILD@</XamarinAndroidVersion>
 		<_JavaInteropReferences>Java.Interop;System.Runtime</_JavaInteropReferences>
 		<DependsOnSystemRuntime Condition=" '$(DependsOnSystemRuntime)' == '' ">true</DependsOnSystemRuntime>
+		<ImplicitlyExpandNETStandardFacades>false</ImplicitlyExpandNETStandardFacades>
 		<CopyNuGetImplementations Condition=" '$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
 		<YieldDuringToolExecution Condition="'$(YieldDuringToolExecution)' == ''">true</YieldDuringToolExecution>
 		<LatestSupportedJavaVersion Condition="'$(LatestSupportedJavaVersion)' == ''">1.8.0</LatestSupportedJavaVersion>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1567,6 +1567,10 @@ because xbuild doesn't support framework reference assemblies.
 	DependsOnTargets="SetWearAppTargetToPackageForAndroid;Build;_CopyPackage" />
 	
 <Target Name="_ResolveAssemblies">
+	<Message Text="------------ ReferenceCopyLocalPaths ---------------" />
+	<Message Text="%(ReferenceCopyLocalPaths.Identity) = %(ReferenceCopyLocalPaths.ResolvedFrom)" />
+	<Message Text="------------ ReferencePath ---------------" />
+	<Message Text="%(ReferencePath.Identity) = %(ReferencePath.ResolvedFrom)" />
 	<!--- Remove the ImplicitlyExpandDesignTimeFacades assemblies. We have already build the app there are not required for packaging  -->
 	<ItemGroup>
 		<FilteredAssemblies Include="$(OutDir)$(TargetFileName)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1567,10 +1567,6 @@ because xbuild doesn't support framework reference assemblies.
 	DependsOnTargets="SetWearAppTargetToPackageForAndroid;Build;_CopyPackage" />
 	
 <Target Name="_ResolveAssemblies">
-	<Message Text="------------ ReferenceCopyLocalPaths ---------------" />
-	<Message Text="%(ReferenceCopyLocalPaths.Identity) = %(ReferenceCopyLocalPaths.ResolvedFrom)" />
-	<Message Text="------------ ReferencePath ---------------" />
-	<Message Text="%(ReferencePath.Identity) = %(ReferencePath.ResolvedFrom)" />
 	<!--- Remove the ImplicitlyExpandDesignTimeFacades assemblies. We have already build the app there are not required for packaging  -->
 	<ItemGroup>
 		<FilteredAssemblies Include="$(OutDir)$(TargetFileName)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.PCLSupport.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.PCLSupport.targets
@@ -47,6 +47,11 @@
 			<Output TaskParameter="DependsOnNETStandard" PropertyName="_XADependsOnNETStandard" />
 		</GetDependsOnNETStandard>
 
+		<Message Text="------------ DesignTimeFacadeDirectories ---------------" />
+		<Message Text="%(DesignTimeFacadeDirectories.Identity)" />
+		<Message Text="------------ _DesignTimeFacadeAssemblies ---------------" />
+		<Message Text="%(_DesignTimeFacadeAssemblies.Identity)" />
+
 		<ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true' or ('$(_XANETStandardInbox)' == 'true' and '$(_XADependsOnNETStandard)' == 'true')">
 			<_DesignTimeFacadeAssemblies Include="%(DesignTimeFacadeDirectories.Identity)*.dll"/>
 			<ReferencePath Remove="@(_DesignTimeFacadeAssemblies)"/>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.PCLSupport.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.PCLSupport.targets
@@ -47,11 +47,6 @@
 			<Output TaskParameter="DependsOnNETStandard" PropertyName="_XADependsOnNETStandard" />
 		</GetDependsOnNETStandard>
 
-		<Message Text="------------ DesignTimeFacadeDirectories ---------------" />
-		<Message Text="%(DesignTimeFacadeDirectories.Identity)" />
-		<Message Text="------------ _DesignTimeFacadeAssemblies ---------------" />
-		<Message Text="%(_DesignTimeFacadeAssemblies.Identity)" />
-
 		<ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true' or ('$(_XANETStandardInbox)' == 'true' and '$(_XADependsOnNETStandard)' == 'true')">
 			<_DesignTimeFacadeAssemblies Include="%(DesignTimeFacadeDirectories.Identity)*.dll"/>
 			<ReferencePath Remove="@(_DesignTimeFacadeAssemblies)"/>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.PCLSupport.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.PCLSupport.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<!-- PCL Support -->
 	<PropertyGroup>
-		<IsXBuild Condition="'$(MSBuildRuntimeVersion)' == ''">true</IsXBuild>
+		<_IsXBuild Condition="'$(MSBuildRuntimeVersion)' == ''">true</_IsXBuild>
 		<CheckForSystemRuntimeDependency>true</CheckForSystemRuntimeDependency>
 		<ImplicitlyExpandDesignTimeFacades>true</ImplicitlyExpandDesignTimeFacades>
 		<ResolveReferencesDependsOn>
@@ -18,7 +18,7 @@
 
 	<UsingTask
 		TaskName="GetDependsOnNETStandard"
-		Condition="'$(IsXBuild)' != 'true'"
+		Condition="'$(_IsXBuild)' != 'true' And Exists ('$(MSBuildExtensionsPath)\Microsoft\Microsoft.NET.Build.Extensions\tools\net46\Microsoft.NET.Build.Extensions.Tasks.dll')"
 		AssemblyFile="$(MSBuildExtensionsPath)\Microsoft\Microsoft.NET.Build.Extensions\tools\net46\Microsoft.NET.Build.Extensions.Tasks.dll" />
 	
 	<Target Name="ImplicitlyExpandDesignTimeFacades" Condition="'$(ImplicitlyExpandDesignTimeFacades)' == 'true'" DependsOnTargets="$(ImplicitlyExpandDesignTimeFacadesDependsOn)">
@@ -42,7 +42,7 @@
 			If $(_HasReferenceToSystemRuntime) is true, then the facades are going to be expanded anyway, so don't run this.
 		-->
 		<GetDependsOnNETStandard
-				Condition="'$(_HasReferenceToSystemRuntime)' != 'true' and '$(IsXBuild)' != 'true' and '$(DependsOnNETStandard)' == '' and '@(_XACandidateNETStandardReferences)' != ''"
+				Condition="'$(_HasReferenceToSystemRuntime)' != 'true' and '$(_IsXBuild)' != 'true' and '$(DependsOnNETStandard)' == '' and '@(_XACandidateNETStandardReferences)' != ''"
 				References="@(_XACandidateNETStandardReferences)">
 			<Output TaskParameter="DependsOnNETStandard" PropertyName="_XADependsOnNETStandard" />
 		</GetDependsOnNETStandard>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.PCLSupport.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.PCLSupport.targets
@@ -2,6 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<!-- PCL Support -->
 	<PropertyGroup>
+		<IsXBuild Condition="'$(MSBuildRuntimeVersion)' == ''">true</IsXBuild>
 		<CheckForSystemRuntimeDependency>true</CheckForSystemRuntimeDependency>
 		<ImplicitlyExpandDesignTimeFacades>true</ImplicitlyExpandDesignTimeFacades>
 		<ResolveReferencesDependsOn>
@@ -14,32 +15,42 @@
 			GetReferenceAssemblyPaths
 		</ImplicitlyExpandDesignTimeFacadesDependsOn>
 	</PropertyGroup>
+
+	<UsingTask
+		TaskName="GetDependsOnNETStandard"
+		Condition="'$(IsXBuild)' != 'true'"
+		AssemblyFile="$(MSBuildExtensionsPath)\Microsoft\Microsoft.NET.Build.Extensions\tools\net46\Microsoft.NET.Build.Extensions.Tasks.dll" />
 	
 	<Target Name="ImplicitlyExpandDesignTimeFacades" Condition="'$(ImplicitlyExpandDesignTimeFacades)' == 'true'" DependsOnTargets="$(ImplicitlyExpandDesignTimeFacadesDependsOn)">
-	
+
+		<ItemGroup>
+			<_XACandidateNETStandardReferences Include="@(Reference);@(_ResolvedProjectReferencePaths)" />
+			<_XAInboxNETStandardFolders Include="$(TargetFrameworkDirectory)" />
+		</ItemGroup>
+		
 		<PropertyGroup>
 			<_HasReferenceToSystemRuntime Condition="'$(DependsOnSystemRuntime)' == 'true' or '%(_ResolvedProjectReferencePaths.TargetPlatformIdentifier)' == 'Portable' 
 								or '%(ReferenceDependencyPaths.Filename)' == 'System.Runtime'">true</_HasReferenceToSystemRuntime>
+			<_XANETStandardInbox Condition="'$(XI_NETStandardInbox)' == '' and Exists('%(XI_InboxNETStandardFolders.Identity)\netstandard.dll')">true</_XANETStandardInbox>
 		</PropertyGroup>
 
-		<ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true'">
+		<!--
+			Facades are expanded if we have a reference that depends on System.Runtime .
+			XI projects have `$(TargetFrameworkIdentifier) != .NETFramework`, so Microsoft.NET.Build.Extensions (which provides support for ns 2.0 projects) doesn't get
+			imported. And netstandard.dll reference, even if required, doesn't get added.
+			So, we need to check if any references depend on `netstandard`. And if so, expand the facades, which include netstandard.dll .
+			If $(_HasReferenceToSystemRuntime) is true, then the facades are going to be expanded anyway, so don't run this.
+		-->
+		<GetDependsOnNETStandard
+				Condition="'$(_HasReferenceToSystemRuntime)' != 'true' and '$(IsXBuild)' != 'true' and '$(DependsOnNETStandard)' == '' and '@(_XACandidateNETStandardReferences)' != ''"
+				References="@(_XACandidateNETStandardReferences)">
+			<Output TaskParameter="DependsOnNETStandard" PropertyName="_XADependsOnNETStandard" />
+		</GetDependsOnNETStandard>
+
+		<ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true' or ('$(_XANETStandardInbox)' == 'true' and '$(_XADependsOnNETStandard)' == 'true')">
 			<_DesignTimeFacadeAssemblies Include="%(DesignTimeFacadeDirectories.Identity)*.dll"/>
-		</ItemGroup>
-
-		<CreateItem Include="%(_DesignTimeFacadeAssemblies.FileName)"
-				AdditionalMetadata="OriginalIdentity=%(_DesignTimeFacadeAssemblies.Identity)">
-			<Output TaskParameter="Include" ItemName="_DesignTimeFacadeAssemblies_Names" />
-		</CreateItem>
-
-		<CreateItem Include="%(ReferencePath.FileName)"
-				AdditionalMetadata="OriginalIdentity=%(ReferencePath.Identity)">
-			<Output TaskParameter="Include" ItemName="_ReferencePath_Names" />
-		</CreateItem>
-
-		<ItemGroup>
-			<_DesignTimeFacadeAssemblies_Names Remove="@(_ReferencePath_Names)"/>
-
-			<ReferencePath Include="@(_DesignTimeFacadeAssemblies_Names->'%(OriginalIdentity)')">
+			<ReferencePath Remove="@(_DesignTimeFacadeAssemblies)"/>
+			<ReferencePath Include="%(_DesignTimeFacadeAssemblies.Identity)">
 				<WinMDFile>false</WinMDFile>
 				<CopyLocal>false</CopyLocal>
 				<ResolvedFrom>ImplicitlyExpandDesignTimeFacades</ResolvedFrom>


### PR DESCRIPTION
Context #1154 

This PR brings in changes from xamarin/xamarin-macios#2643 and xamarin/xamarin-macios#2731 to improve our net standard support. While it does not fix the packaging problem in #1154 it will give us parity with the iOS code base. 