### PR TITLE
[Xamarin.Android.Build.Tasks] Ignore AndroidAsset items which are folders.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidUpdateResDir.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidUpdateResDir.cs
@@ -49,6 +49,9 @@ namespace Xamarin.Android.Tasks
 		
 		[Output]
 		public ITaskItem[] IntermediateFiles { get; set; }
+
+		[Output]
+		public ITaskItem [] ResolvedResourceFiles { get; set; }
 		
 		[Output]
 		public string ResourceNameCaseMap { get; set; }
@@ -61,7 +64,8 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  LowercaseFilenames: {0}", LowercaseFilenames);
 			Log.LogDebugTaskItems ("  ResourceFiles:", ResourceFiles);
 
-			IntermediateFiles = new ITaskItem[ResourceFiles.Length];
+			var intermediateFiles = new List<ITaskItem> ();
+			var resolvedFiles = new List<ITaskItem> ();
 			
 			string[] prefixes = Prefixes != null ? Prefixes.Split (';') : null;
 			if (prefixes != null) {
@@ -77,7 +81,9 @@ namespace Xamarin.Android.Tasks
 
 			for (int i = 0; i < ResourceFiles.Length; i++) {
 				var item = ResourceFiles [i];
-				
+
+				if (Directory.Exists (item.ItemSpec))
+					continue;
 				//compute the target path
 				string rel;
 				var logicalName = item.GetMetadata ("LogicalName").Replace ('\\', Path.DirectorySeparatorChar);
@@ -114,11 +120,15 @@ namespace Xamarin.Android.Tasks
 				var newItem = new TaskItem (dest);
 				newItem.SetMetadata ("LogicalName", rel);
 				item.CopyMetadataTo (newItem);
-				IntermediateFiles [i] = newItem;
+				intermediateFiles.Add (newItem);
+				resolvedFiles.Add (item);
 			}
 
+			IntermediateFiles = intermediateFiles.ToArray ();
+			ResolvedResourceFiles = resolvedFiles.ToArray ();
 			ResourceNameCaseMap = nameCaseMap.ToString ().Replace (nameCaseMap.NewLine, ";");
 			Log.LogDebugTaskItems ("  IntermediateFiles:", IntermediateFiles);
+			Log.LogDebugTaskItems ("  ResolvedResourceFiles:", ResolvedResourceFiles);
 			Log.LogDebugTaskItems ("  ResourceNameCaseMap:", ResourceNameCaseMap);
 			return true;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildAssetsTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildAssetsTest.cs
@@ -69,6 +69,9 @@ namespace Xamarin.Android.Build.Tests
 						TextContent = () => "Asset1",
 						Encoding = Encoding.ASCII,
 					},
+					new AndroidItem.AndroidAsset ("Assets\\subfolder\\") {
+
+					},
 					new AndroidItem.AndroidAsset ("Assets\\subfolder\\asset2.txt") {
 						TextContent = () => "Asset2",
 						Encoding = Encoding.ASCII,
@@ -82,6 +85,9 @@ namespace Xamarin.Android.Build.Tests
 					new AndroidItem.AndroidAsset ("Assets\\asset3.txt") {
 						TextContent = () => "Asset3",
 						Encoding = Encoding.ASCII,
+					},
+					new AndroidItem.AndroidAsset ("Assets\\subfolder\\") {
+						
 					},
 					new AndroidItem.AndroidAsset ("Assets\\subfolder\\asset4.txt") {
 						TextContent = () => "Asset4",
@@ -97,12 +103,16 @@ namespace Xamarin.Android.Build.Tests
 					using (var apk = ZipHelper.OpenZip (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "bin", "packaged_resources"))) {
 						foreach (var a in libproj.OtherBuildItems.Where (x => x is AndroidItem.AndroidAsset)) {
 							var item = a.Include ().ToLower ().Replace ("\\", "/");
+							if (item.EndsWith ("/"))
+								continue;
 							var data = ZipHelper.ReadFileFromZip (apk, item);
 							Assert.IsNotNull (data, "{0} should be in the apk.", item);
 							Assert.AreEqual (a.TextContent (), Encoding.ASCII.GetString (data), "The Contents of {0} should be \"{1}\"", item, a.TextContent ());
 						}
 						foreach (var a in proj.OtherBuildItems.Where (x => x is AndroidItem.AndroidAsset)) {
 							var item = a.Include ().ToLower ().Replace ("\\", "/");
+							if (item.EndsWith ("/"))
+								continue;
 							var data = ZipHelper.ReadFileFromZip (apk, item);
 							Assert.IsNotNull (data, "{0} should be in the apk.", item);
 							Assert.AreEqual (a.TextContent (), Encoding.ASCII.GetString (data), "The Contents of {0} should be \"{1}\"", item, a.TextContent ());

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -59,8 +59,10 @@ namespace Xamarin.Android.Tools {
 				if (!string.IsNullOrEmpty (directory))
 					Directory.CreateDirectory (directory);
 
-				File.Copy (source, destination, true);
-				return true;
+				if (!Directory.Exists (source)) {
+					File.Copy (source, destination, true);
+					return true;
+				}
 			}/* else
 				Console.WriteLine ("Skipping copying {0}, unchanged", Path.GetFileName (destination));*/
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -993,14 +993,15 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_ComputeAndroidAssetsPaths">
 	<AndroidComputeResPaths ResourceFiles="@(AndroidAsset)" IntermediateDir="$(MonoAndroidAssetsDirIntermediate)" Prefixes="$(MonoAndroidAssetsPrefix)" ProjectDir="$(ProjectDir)">
 		<Output ItemName="_AndroidAssetsDest" TaskParameter="IntermediateFiles" />
+		<Output ItemName="_AndroidResolvedAssets" TaskParameter="ResolvedResourceFiles" />
 	</AndroidComputeResPaths>
 </Target>
 
 <Target Name="_GenerateAndroidAssetsDir"
-	Inputs="$(MSBuildAllProjects);@(AndroidAsset)"
+	Inputs="$(MSBuildAllProjects);@(_AndroidResolvedAssets)"
 	Outputs="@(_AndroidAssetsDest)">
 	<MakeDir Directories="$(MonoAndroidAssetsDirIntermediate)" />
-	<Copy SourceFiles="@(AndroidAsset)" DestinationFiles="@(_AndroidAssetsDest)" SkipUnchangedFiles="true" />
+	<Copy SourceFiles="@(_AndroidResolvedAssets)" DestinationFiles="@(_AndroidAssetsDest)" SkipUnchangedFiles="true" />
 	<RemoveUnknownFiles Files="@(_AndroidAssetsDest)" Directory="$(MonoAndroidAssetsDirIntermediate)" RemoveDirectories="true" />
 	<Touch Files="@(_AndroidAssetsDest)" />
 </Target>
@@ -1131,16 +1132,17 @@ because xbuild doesn't support framework reference assemblies.
 	<AndroidComputeResPaths ResourceFiles="@(AndroidResource)" IntermediateDir="$(MonoAndroidResDirIntermediate)" Prefixes="$(MonoAndroidResourcePrefix)" LowercaseFilenames="True" ProjectDir="$(ProjectDir)">
 		<Output ItemName="_AndroidResourceDest" TaskParameter="IntermediateFiles" />
 		<Output PropertyName="_AndroidResourceNameCaseMap" TaskParameter="ResourceNameCaseMap" />
+		<Output ItemName="_AndroidResolvedResources" TaskParameter="ResolvedResourceFiles" />
 	</AndroidComputeResPaths>
   
 	<MakeDir Directories="$(MonoAndroidResDirIntermediate)" />
 </Target>
 
 <Target Name="_GenerateAndroidResourceDir"
-	Inputs="$(MSBuildProjectFullPath);$(MSBuildAllProjects);@(AndroidResource);$(_AndroidBuildPropertiesCache)"
+	Inputs="$(MSBuildProjectFullPath);$(MSBuildAllProjects);@(_AndroidResolvedResources);$(_AndroidBuildPropertiesCache)"
 	Outputs="@(_AndroidResourceDest)"
 	DependsOnTargets="$(_OnResolveMonoAndroidSdks)">
-	<CopyAndConvertResources SourceFiles="@(AndroidResource)"
+	<CopyAndConvertResources SourceFiles="@(_AndroidResolvedResources)"
 			DestinationFiles="@(_AndroidResourceDest)"
 			AcwMapFile="$(_AcwMapFile)"
 			CacheFile="$(_AndroidResourcesCacheFile)"
@@ -1149,7 +1151,7 @@ because xbuild doesn't support framework reference assemblies.
 	</CopyAndConvertResources>
 	<Crunch SourceFiles="@(_ModifiedResources)" ToolPath="$(AaptToolPath)" ToolExe="$(AaptToolExe)"
 			Condition=" '$(AndroidExplicitCrunch)' == 'True' And '$(AndroidApplication)' != '' And $(AndroidApplication)" />
-	<Copy SourceFiles="@(AndroidResource)"
+	<Copy SourceFiles="@(_AndroidResolvedResources)"
 		DestinationFiles="@(_AndroidResourceDest)"
 		SkipUnchangedFiles="true"
 		Condition=" '$(AndroidExplicitCrunch)' != 'True' Or '$(AndroidApplication)' == '' Or !($(AndroidApplication))"

--- a/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj
+++ b/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj
@@ -18,7 +18,7 @@
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
-    <AndroidSupportedAbis>armeabi-v7a;armeabi;x86;arm64-v8a;x86_64</AndroidSupportedAbis>
+    <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
   </PropertyGroup>
   <Import Project="..\..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj
+++ b/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj
@@ -31,7 +31,7 @@
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
-    <AndroidSupportedAbis>armeabi-v7a;x86;arm64-v8a</AndroidSupportedAbis>
+    <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
     <MandroidI18n>cjk;mideast;other;rare;west</MandroidI18n>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">


### PR DESCRIPTION
When adding a new subfolder in the IDE (VSForMac) we end up
with a folder which has a build action of AndroidAsset.
This causes the copy task to fail with

	Cannot copy <folder> to <destfolder>, as the source file doesn't exist",

This is because we assume that all items in AndroidAsset (and
AndroidResource) and files. It looks like this is not the case.
While a work around is easy .. simply remove the item. It does
require that the user manually update the csproj.

So this commit uses `Directory.Exists` to check to see if the
item is a directory or not. If it is we skip over it. Otherwise
its a file so we should copy.

We do this in `Files.cs` but also in `AndroidUpdateResDir.cs`.
The latter has been changed to output a list of the "Resolved"
files which will not include any folders.