### PR TITLE
[Mono.Android] API-27/v8.1 is stable

### DIFF
--- a/src/Mono.Android/Mono.Android.projitems
+++ b/src/Mono.Android/Mono.Android.projitems
@@ -137,7 +137,7 @@
       <Name>Oreo</Name>
       <Level>27</Level>
       <Id>27</Id>
-      <Stable>False</Stable>
+      <Stable>True</Stable>
     </AndroidApiInfo>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The API-27 binding has been considered stable (-ish) since commit
914f95fc, give or take a few problems (c2811327, 9cc80d7a, etc.).

Ensure that the generated `AndroidApiInfo.xml` files (8942eca0)
state that API-27 is stable.