### PR TITLE
[Xamarin.Android.Build.Tools] Add $(AndroidSdkPlatformToolsVersion)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -233,6 +233,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
 
 	<AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">23.0.0</AndroidSdkBuildToolsVersion>
+	<AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">25.0.5</AndroidSdkPlatformToolsVersion>
+	<AndroidSdkToolsVersion Condition="'$(AndroidSdkToolsVersion)' == ''">25.2.5</AndroidSdkToolsVersion>
+	<AndroidNdkVersion Condition="'$(AndroidNdkVersion)' == ''">r14b</AndroidNdkVersion>
 
 	<!-- Obsolete -->
 	<AndroidGdbDebugServer>None</AndroidGdbDebugServer>


### PR DESCRIPTION
Fixes #1165

We need to provide default values for `platform-tools` and
`tools` so that our SDK Manager can correctly download
the required versions.