### PR TITLE
[Xamarin.Android.Build.Tasks] Add Installer target Import.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2731,6 +2731,8 @@ because xbuild doesn't support framework reference assemblies.
 
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.PCLSupport.targets" />
 
+<Import Project="$(MSBuildThisFileDirectory)Xamarin.Installer.Common.targets"
+        Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Installer.Common.targets')"/>
 <!--
 *******************************************
   Extensibility hook that allows VS to


### PR DESCRIPTION
We need to add an additional conditional Import for the
Installer target. This will allow commercial users to use
the following targets.

	`GetAndroidDependencies`
	`InstallAndroidDependencies`