### PR TITLE
[Tests] Make the HttpClientTest.TestEscapedURI test ignore timeout

### DIFF
--- a/tests/BCL-Tests/LocalTests.NUnit/System.Net.Http/HttpClientTest.cs
+++ b/tests/BCL-Tests/LocalTests.NUnit/System.Net.Http/HttpClientTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 using NUnit.Framework;
 
@@ -19,11 +20,14 @@ namespace BclTests {
                 var t = client.GetStringAsync("http://naver.com/t[e]st.txt");
                 t.Wait(1000);
                 Assert.IsNotNull(t.Result);
-            }
-            catch (AggregateException e)
-            {
+            } catch (TaskCanceledException) {
+                Assert.Ignore ("Connection timed out");
+            } catch (AggregateException e) {
                 Assert.AreEqual (1, e.InnerExceptions.Count);
-                Assert.AreEqual (typeof(HttpRequestException), e.InnerExceptions[0].GetType ());
+                if (e.InnerExceptions[0].GetType () == typeof (TaskCanceledException))
+                    Assert.Ignore ("Connection timed out");
+                else
+                    Assert.AreEqual (typeof(HttpRequestException), e.InnerExceptions[0].GetType ());
             }
         }
     }


### PR DESCRIPTION
The server used in the test sometimes cannot be reached, there's no need to
treat it as a failure. Ignore the timeout with Assert.Ignore instead.