### PR TITLE
Remove extra "v" from $(TargetFrameworkVersion) XA0105 warning

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckTargetFrameworks.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckTargetFrameworks.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Android.Tasks
 			foreach (var item in apiLevels.Where (x => mainapiLevel < x.Value)) {
 				var itemOSVersion = MonoAndroidHelper.SupportedVersions.GetFrameworkVersionFromApiLevel (item.Value);
 				Log.LogWarning (null, "XA0105", null, ProjectFile, 0, 0, 0, 0,
-					"The $(TargetFrameworkVersion) for {0} (v{1}) is greater than the $(TargetFrameworkVersion) for your project ({2}). " +
+					"The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for your project ({2}). " +
 					"You need to increase the $(TargetFrameworkVersion) for your project.", Path.GetFileName (item.Key.ItemSpec), itemOSVersion, TargetFrameworkVersion);
 			}
 


### PR DESCRIPTION
Removes an additional "v" that was being included in a warning message when the `$(TargetFrameworkVersion)` is lower than what other assemblies expect in a `XA0105` warning.

Example Warnings on 15.6:

```
2>C:\Users\dougl\source\repos\App75\App75\App75.Android\App75.Android.csproj : warning XA0105: The $(TargetFrameworkVersion) for FormsViewGroup.dll (vv8.0) is greater than the $(TargetFrameworkVersion) for your project (v7.1). You need to increase the $(TargetFrameworkVersion) for your project.

2>C:\Users\dougl\source\repos\App75\App75\App75.Android\App75.Android.csproj : warning XA0105: The $(TargetFrameworkVersion) for Xamarin.Forms.Platform.Android.dll (vv8.0) is greater than the $(TargetFrameworkVersion) for your project (v7.1). You need to increase the $(TargetFrameworkVersion) for your project.

2>C:\Users\dougl\source\repos\App75\App75\App75.Android\App75.Android.csproj : warning XA0105: The $(TargetFrameworkVersion) for Xamarin.Forms.Platform.dll (vv8.0) is greater than the $(TargetFrameworkVersion) for your project (v7.1). You need to increase the $(TargetFrameworkVersion) for your project.
```