### PR TITLE
[build] Cursory JDK 9 support

### DIFF
--- a/build-tools/scripts/Jar.targets
+++ b/build-tools/scripts/Jar.targets
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="_GetJavacVersions"
+      DependsOnTargets="AndroidPrepareForBuild">
+    <PropertyGroup>
+      <_JavacSourceVersion Condition="$(_JdkVersion.StartsWith ('9'))">1.8</_JavacSourceVersion>
+      <_JavacSourceVersion Condition=" '$(_JavacSourceVersion)' == '' ">1.5</_JavacSourceVersion>
+      <_JavacTargetVersion Condition="$(_JdkVersion.StartsWith ('9'))">1.8</_JavacTargetVersion>
+      <_JavacTargetVersion Condition=" '$(_JavacTargetVersion)' == '' ">1.6</_JavacTargetVersion>
+    </PropertyGroup>
+  </Target>
+  <Target Name="BuildTestJarFile"
+      DependsOnTargets="_GetJavacVersions"
+      Inputs="@(TestJarEntry)"
+      Outputs="%(TestJarEntry.OutputFile)">
+    <ItemGroup>
+      <_JavacSource
+          Include="@(TestJarEntry)"
+      />
+    </ItemGroup>
+    <PropertyGroup>
+      <_Javac>"$(JavaCPath)"</_Javac>
+      <_Jar>"$(JarPath)"</_Jar>
+      <_Targets>-source $(_JavacSourceVersion) -target $(_JavacTargetVersion)</_Targets>
+      <_DestDir>$(IntermediateOutputPath)__CreateTestJarFile-bin</_DestDir>
+      <_AndroidJar>-cp "$(AndroidSdkDirectory)\platforms\android-$(_AndroidApiLevelName)\android.jar"</_AndroidJar>
+    </PropertyGroup>
+    <MakeDir Directories="$(_DestDir)" />
+    <Exec Command="$(_Javac) $(_Targets) -d &quot;$(_DestDir)&quot; $(_AndroidJar) @(_JavacSource->'&quot;%(Identity)&quot;', ' ')" />
+    <Exec
+        Command="$(_Jar) cf &quot;classes.jar&quot; ."
+        WorkingDirectory="$(_DestDir)"
+    />
+    <Copy
+        SourceFiles="$(_DestDir)\classes.jar"
+        DestinationFiles="%(TestJarEntry.OutputFile)"
+    />
+    <RemoveDir Directories="$(_DestDir)" />
+  </Target>
+  <Target Name="CleanTestJarFile">
+    <Delete Files="%(TestJarEntry.OutputFile)" />
+  </Target>
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -116,6 +116,12 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public bool AndroidUseApkSigner { get; set; }
 
+		[Output]
+		public string JdkVersion { get; set; }
+
+		[Output]
+		public string MinimumRequiredJdkVersion { get; set; }
+
 		static bool             IsWindows = Path.DirectorySeparatorChar == '\\';
 		static readonly string  ZipAlign  = IsWindows ? "zipalign.exe" : "zipalign";
 		static readonly string  Aapt      = IsWindows ? "aapt.exe" : "aapt";
@@ -140,6 +146,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  AndroidSdkBuildToolsVersion: {0}", AndroidSdkBuildToolsVersion);
 			Log.LogDebugMessage ($"  {nameof (AndroidSdkPath)}: {AndroidSdkPath}");
 			Log.LogDebugMessage ($"  {nameof (AndroidNdkPath)}: {AndroidNdkPath}");
+			Log.LogDebugMessage ($"  {nameof (JavaSdkPath)}: {JavaSdkPath}");
 			Log.LogDebugTaskItems ("  ReferenceAssemblyPaths: ", ReferenceAssemblyPaths);
 			Log.LogDebugMessage ("  TargetFrameworkVersion: {0}", TargetFrameworkVersion);
 			Log.LogDebugMessage ("  UseLatestAndroidPlatformSdk: {0}", UseLatestAndroidPlatformSdk);
@@ -280,6 +287,8 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  AndroidSdkBuildToolsBinPath: {0}", AndroidSdkBuildToolsBinPath);
 			Log.LogDebugMessage ("  AndroidSdkPath: {0}", AndroidSdkPath);
 			Log.LogDebugMessage ("  JavaSdkPath: {0}", JavaSdkPath);
+			Log.LogDebugMessage ("  JdkVersion: {0}", JdkVersion);
+			Log.LogDebugMessage ("  MinimumRequiredJdkVersion: {0}", MinimumRequiredJdkVersion);
 			Log.LogDebugMessage ("  MonoAndroidBinPath: {0}", MonoAndroidBinPath);
 			Log.LogDebugMessage ("  MonoAndroidToolsPath: {0}", MonoAndroidToolsPath);
 			Log.LogDebugMessage ("  TargetFrameworkVersion: {0}", TargetFrameworkVersion);
@@ -320,7 +329,10 @@ namespace Xamarin.Android.Tasks
 			return !Log.HasLoggedErrors;
 		}
 
-		static readonly Regex javaVersionRegex = new Regex (@"""(?<version>[\d\.]+)_\d+""");
+		// `java -version` will produce values such as:
+		//  java version "9.0.4"
+		//  java version "1.8.0_77"
+		static readonly Regex javaVersionRegex = new Regex (@"version ""(?<version>[\d\.]+)(_\d+)?""");
 
 		Version GetJavaVersionForFramework (string targetFrameworkVersion)
 		{
@@ -350,6 +362,8 @@ namespace Xamarin.Android.Tasks
 			Version requiredJavaForBuildTools = GetJavaVersionForBuildTools (buildToolsVersion);
 
 			Version required = requiredJavaForFrameworkVersion > requiredJavaForBuildTools ? requiredJavaForFrameworkVersion : requiredJavaForBuildTools;
+
+			MinimumRequiredJdkVersion = required.ToString ();
 			
 			var sb = new StringBuilder ();
 			
@@ -372,6 +386,7 @@ namespace Xamarin.Android.Tasks
 			var versionNumberMatch = javaVersionRegex.Match (versionInfo);
 			Version versionNumber;
 			if (versionNumberMatch.Success && Version.TryParse (versionNumberMatch.Groups ["version"]?.Value, out versionNumber)) {
+				JdkVersion  = versionNumberMatch.Groups ["version"].Value;
 				Log.LogMessage (MessageImportance.Normal, $"Found Java SDK version {versionNumber}.");
 				if (versionNumber < requiredJavaForFrameworkVersion) {
 					Log.LogError ($"Java SDK {requiredJavaForFrameworkVersion} or above is required when targeting FrameworkVerison {targetFrameworkVersion}.");
@@ -379,8 +394,11 @@ namespace Xamarin.Android.Tasks
 				if (versionNumber < requiredJavaForBuildTools) {
 					Log.LogError ($"Java SDK {requiredJavaForBuildTools} or above is required when using build-tools {buildToolsVersion}.");
 				}
+				if (versionNumber > Version.Parse (LatestSupportedJavaVersion)) {
+					Log.LogWarning ($"JDK Version `{versionNumber}` is later than latest suppored JDK version `{LatestSupportedJavaVersion}`.");
+				}
 			} else
-				Log.LogWarning ($"Failed to get the Java SDK version. Found {versionInfo} but this does not seem to contain a valid version number.");
+				Log.LogWarning ($"Failed to get the Java SDK version as it does not appear to contain a valid version number. `javac -version` returned: ```{versionInfo}```");
 			return !Log.HasLoggedErrors;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -190,6 +190,8 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 		<Output TaskParameter="JavaSdkPath"               PropertyName="JavaSdkDirectory"           Condition="'$(JavaSdkDirectory)' == ''" />
 		<Output TaskParameter="MonoAndroidToolsPath"      PropertyName="MonoAndroidToolsDirectory" />
 		<Output TaskParameter="AndroidSdkBuildToolsBinPath" PropertyName="AndroidSdkBuildToolsBinPath" Condition="'$(AndroidSdkBuildToolsBinPath)' == ''" />
+		<Output TaskParameter="JdkVersion"                PropertyName="_JdkVersion" />
+		<Output TaskParameter="MinimumRequiredJdkVersion" PropertyName="_DefaultJdkVersion" />
 	</ResolveSdks>
     <CreateProperty Value="$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion),Profile=$(TargetFrameworkProfile)">
       <Output TaskParameter="Value" PropertyName="TargetFrameworkMoniker"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -664,6 +664,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		<Output TaskParameter="LintToolPath"              PropertyName="LintToolPath"               Condition="'$(LintToolPath)' == ''" />
 		<Output TaskParameter="ApkSignerToolExe"          PropertyName="ApkSignerToolExe"           Condition="'$(ApkSignerToolExe)' == ''" />
 		<Output TaskParameter="AndroidUseApkSigner"       PropertyName="AndroidUseApkSigner"        Condition="'$(AndroidUseApkSigner)' == ''" />
+		<Output TaskParameter="JdkVersion"                PropertyName="_JdkVersion" />
+		<Output TaskParameter="MinimumRequiredJdkVersion" PropertyName="_DefaultJdkVersion" />
 	</ResolveSdks>
 	<CreateProperty Value="$(TargetFrameworkIdentifier),Version=$(_TargetFrameworkVersion),Profile=$(TargetFrameworkProfile)">
 		<Output TaskParameter="Value" PropertyName="TargetFrameworkMoniker"
@@ -2007,12 +2009,12 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_AdjustJavacVersionArguments">
 
 	<AdjustJavacVersionArguments
-		Condition="'$(JavacTargetVersion)'=='' or '$(JavacSourceVersion)' == ''"
-		ToolPath="$(JavacToolPath)"
-	    ToolExe="$(JavacToolExe)"
-	    SkipJavacVersionCheck="$(AndroidSkipJavacVersionCheck)"
-	    EnableProguard="$(AndroidEnableProguard)"
-	    EnableMultiDex="$(AndroidEnableMultiDex)">
+			Condition=" '$(JavacTargetVersion)' == '' or '$(JavacSourceVersion)' == '' "
+			JdkVersion="$(_JdkVersion)"
+			DefaultJdkVersion="$(_DefaultJdkVersion)"
+			SkipJavacVersionCheck="$(AndroidSkipJavacVersionCheck)"
+			EnableProguard="$(AndroidEnableProguard)"
+			EnableMultiDex="$(AndroidEnableMultiDex)">
 	    <Output TaskParameter="TargetVersion" PropertyName="JavacTargetVersion" />
 	    <Output TaskParameter="SourceVersion" PropertyName="JavacSourceVersion" />
 	</AdjustJavacVersionArguments>

--- a/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding.csproj
+++ b/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding.csproj
@@ -61,18 +61,22 @@
     <InputJar Include="Jars\Cursor.jar" />
   </ItemGroup>
   <ItemGroup>
-    <InputJarSource Include="java\test\bindings\Cursor.java" />
+    <TestJarEntry Include="java\test\bindings\Cursor.java">
+      <OutputFile>Jars/Cursor.jar</OutputFile>
+    </TestJarEntry>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
+  <Import Project="..\..\..\build-tools\scripts\Jar.targets" />
   <Import Project="Xamarin.Android.FixJavaAbstractMethod-APIv1Binding.targets" />
   <PropertyGroup>
     <BuildDependsOn>
-      BuildJars;
+      BuildTestJarFile;
       $(BuildDependsOn)
     </BuildDependsOn>
   </PropertyGroup>
   <PropertyGroup>
     <CleanDependsOn>
+      CleanTestJarFile;
       $(CleanDependsOn);
       CleanLocal;
     </CleanDependsOn>

--- a/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding.targets
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="BuildJars"
-      DependsOnTargets="AndroidPrepareForBuild"
-      Inputs="@(InputJarSource)"
-      Outputs="@(InputJar)">
-    <MakeDir Directories="Jars\classes" />
-    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d &quot;Jars\classes&quot; @(InputJarSource -&gt; '%(Identity)', ' ')" />
-    <Exec Command="&quot;$(JarPath)&quot; cf &quot;@(InputJar)&quot; -C &quot;Jars\classes&quot; ." />
-  </Target>
   <Target Name="CleanLocal">
-    <RemoveDir Directories="bin;obj;Jars\classes;@(InputJar)"/>
+    <RemoveDir Directories="bin;obj;"/>
   </Target>
 </Project>

--- a/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding.csproj
+++ b/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding.csproj
@@ -61,18 +61,22 @@
     <InputJar Include="Jars\Cursor.jar" />
   </ItemGroup>
   <ItemGroup>
-    <InputJarSource Include="java\test\bindings\Cursor.java" />
+    <TestJarEntry Include="java\test\bindings\Cursor.java">
+      <OutputFile>Jars/Cursor.jar</OutputFile>
+    </TestJarEntry>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
+  <Import Project="..\..\..\build-tools\scripts\Jar.targets" />
   <Import Project="Xamarin.Android.FixJavaAbstractMethod-APIv2Binding.targets" />
   <PropertyGroup>
     <BuildDependsOn>
-      BuildJars;
+      BuildTestJarFile;
       $(BuildDependsOn)
     </BuildDependsOn>
   </PropertyGroup>
   <PropertyGroup>
     <CleanDependsOn>
+      CleanTestJarFile;
       $(CleanDependsOn);
       CleanLocal;
     </CleanDependsOn>

--- a/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding.targets
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="BuildJars"
-      DependsOnTargets="AndroidPrepareForBuild"
-      Inputs="@(InputJarSource)"
-      Outputs="@(InputJar)">
-    <MakeDir Directories="Jars\classes" />
-    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d &quot;Jars\classes&quot; @(InputJarSource -&gt; '%(Identity)', ' ')" />
-    <Exec Command="&quot;$(JarPath)&quot; cf &quot;@(InputJar)&quot; -C &quot;Jars\classes&quot; ." />
-  </Target>
   <Target Name="CleanLocal">
-    <RemoveDir Directories="bin;obj;Jars\classes;@(InputJar)"/>
+    <RemoveDir Directories="bin;obj"/>
   </Target>
 </Project>

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
@@ -42,9 +42,12 @@
       DependsOnTargets="AndroidPrepareForBuild"
       Inputs="java\JavaLib\project.properties"
       Outputs="$(OutputPath)JavaLib.zip">
+    <PropertyGroup>
+      <_Jdk9Modules Condition="$(_JdkVersion.StartsWith ('9'))">JAVA_OPTS="--add-modules java.xml.bind"</_Jdk9Modules>
+    </PropertyGroup>
     <Exec
         EnvironmentVariables="ANDROID_HOME=$(AndroidSdkDirectory);JAVA_HOME=$(JavaSdkDirectory)"
-        Command=".\gradlew assembleDebug --stacktrace"
+        Command="$(_Jdk9Modules) .\gradlew assembleDebug --stacktrace --no-daemon"
         WorkingDirectory="$(MSBuildThisFileDirectory)java\JavaLib"
     />
     <MakeDir Directories="$(OutputPath)" />

--- a/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/Xamarin.Android.McwGen-Tests.csproj
+++ b/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/Xamarin.Android.McwGen-Tests.csproj
@@ -62,44 +62,73 @@
     <EmbeddedJar Include="$(OutputPath)xamarin-test.jar" />
   </ItemGroup>
   <ItemGroup>
-    <IgnoreJar Include="$(OutputPath)empty-1.jar">
-      <JarBaseName>empty-1</JarBaseName>
-      <Source>java\com\xamarin\android\Empty1.java</Source>
-    </IgnoreJar>
-    <IgnoreJar Include="$(OutputPath)empty-2.jar">
-      <JarBaseName>empty-2</JarBaseName>
-      <Source>java\com\xamarin\android\Empty2.java</Source>
-    </IgnoreJar>
+    <TestJarEntry Include="java\com\xamarin\android\Empty1.java">
+      <OutputFile>Jars/empty-1.jar</OutputFile>
+    </TestJarEntry>
+    <TestJarEntry Include="java\com\xamarin\android\Empty2.java">
+      <OutputFile>Jars/empty-2.jar</OutputFile>
+    </TestJarEntry>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedReferenceJar Include="@(IgnoreJar)" />
   </ItemGroup>
   <ItemGroup>
-    <XamarinTestJar Include="java\com\xamarin\android\Bxc4288.java" />
-    <XamarinTestJar Include="java\com\xamarin\android\Bxc58383.java" />
-    <XamarinTestJar Include="java\com\xamarin\android\CallMethodFromCtor.java" />
-    <XamarinTestJar Include="java\com\xamarin\android\CallNonvirtualBase.java" />
-    <XamarinTestJar Include="java\com\xamarin\android\CallNonvirtualDerived.java" />
-    <XamarinTestJar Include="java\com\xamarin\android\DataHandler.java" />
-    <XamarinTestJar Include="java\com\xamarin\android\DataListener.java" />
-    <XamarinTestJar Include="java\com\xamarin\android\Logger.java" />
-    <XamarinTestJar Include="java\com\xamarin\android\MarkerIgnoringBase.java" />
-    <XamarinTestJar Include="java\com\xamarin\android\MyCanvas.java" />
-    <XamarinTestJar Include="java\com\xamarin\android\Timing.java" />
-    <XamarinTestJar Include="java\com\xamarin\android\Bxc9446.java" />
-    <XamarinTestJar Include="java\com\xamarin\android\Bxc7634.java" />
-    <XamarinTestJar Include="java\com\xamarin\android\Bxc37706Throwable.java" />
+    <TestJarEntry Include="java\com\xamarin\android\Bxc4288.java">
+      <OutputFile>Jars/xamarin-test.jar</OutputFile>
+    </TestJarEntry>
+    <TestJarEntry Include="java\com\xamarin\android\Bxc58383.java">
+      <OutputFile>Jars/xamarin-test.jar</OutputFile>
+    </TestJarEntry>
+    <TestJarEntry Include="java\com\xamarin\android\CallMethodFromCtor.java">
+      <OutputFile>Jars/xamarin-test.jar</OutputFile>
+    </TestJarEntry>
+    <TestJarEntry Include="java\com\xamarin\android\CallNonvirtualBase.java">
+      <OutputFile>Jars/xamarin-test.jar</OutputFile>
+    </TestJarEntry>
+    <TestJarEntry Include="java\com\xamarin\android\CallNonvirtualDerived.java">
+      <OutputFile>Jars/xamarin-test.jar</OutputFile>
+    </TestJarEntry>
+    <TestJarEntry Include="java\com\xamarin\android\DataHandler.java">
+      <OutputFile>Jars/xamarin-test.jar</OutputFile>
+    </TestJarEntry>
+    <TestJarEntry Include="java\com\xamarin\android\DataListener.java">
+      <OutputFile>Jars/xamarin-test.jar</OutputFile>
+    </TestJarEntry>
+    <TestJarEntry Include="java\com\xamarin\android\Logger.java">
+      <OutputFile>Jars/xamarin-test.jar</OutputFile>
+    </TestJarEntry>
+    <TestJarEntry Include="java\com\xamarin\android\MarkerIgnoringBase.java">
+      <OutputFile>Jars/xamarin-test.jar</OutputFile>
+    </TestJarEntry>
+    <TestJarEntry Include="java\com\xamarin\android\MyCanvas.java">
+      <OutputFile>Jars/xamarin-test.jar</OutputFile>
+    </TestJarEntry>
+    <TestJarEntry Include="java\com\xamarin\android\Timing.java">
+      <OutputFile>Jars/xamarin-test.jar</OutputFile>
+    </TestJarEntry>
+    <TestJarEntry Include="java\com\xamarin\android\Bxc9446.java">
+      <OutputFile>Jars/xamarin-test.jar</OutputFile>
+    </TestJarEntry>
+    <TestJarEntry Include="java\com\xamarin\android\Bxc7634.java">
+      <OutputFile>Jars/xamarin-test.jar</OutputFile>
+    </TestJarEntry>
+    <TestJarEntry Include="java\com\xamarin\android\Bxc37706Throwable.java">
+      <OutputFile>Jars/xamarin-test.jar</OutputFile>
+    </TestJarEntry>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
+  <Import Project="..\..\..\build-tools\scripts\Jar.targets" />
   <Import Project="Xamarin.Android.McwGen-Tests.targets" />
   <PropertyGroup>
     <BuildDependsOn>
-      BuildJars;
+      BuildTestJarFile;
+      _CopyTestJarFiles;
       $(BuildDependsOn)
     </BuildDependsOn>
   </PropertyGroup>
   <PropertyGroup>
     <CleanDependsOn>
+      CleanTestJarFile;
       $(CleanDependsOn);
       CleanLocal;
     </CleanDependsOn>

--- a/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/Xamarin.Android.McwGen-Tests.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/Xamarin.Android.McwGen-Tests.targets
@@ -1,15 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="BuildJars"
-      DependsOnTargets="AndroidPrepareForBuild"
-      Inputs="@(XamarinTestJar);%(IgnoreJar.Source)"
-      Outputs="@(EmbeddedJar);@(IgnoreJar)">
-    <MakeDir Directories="$(OutputPath)xt-classes" />
-    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d &quot;$(OutputPath)xt-classes&quot; -cp &quot;$(AndroidSdkDirectory)\platforms\android-$(_AndroidApiLevelName)\android.jar&quot; @(XamarinTestJar -&gt; '%(Identity)', ' ')" />
-    <Exec Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)xamarin-test.jar&quot; -C &quot;$(OutputPath)xt-classes&quot; ." />
-    <MakeDir Directories="@(IgnoreJar-&gt;'$(OutputPath)%(JarBaseName)')" />
-    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d @(IgnoreJar-&gt;'$(OutputPath)%(JarBaseName)') %(IgnoreJar.Source)" />
-    <Exec Command="&quot;$(JarPath)&quot; cf @(IgnoreJar-&gt;'$(OutputPath)%(JarBaseName).jar') -C @(IgnoreJar-&gt;'$(OutputPath)%(JarBaseName)') ." />
+  <Target Name="_CopyTestJarFiles">
+    <Copy
+        SourceFiles="%(TestJarEntry.OutputFile)"
+        DestinationFolder="$(OutputPath)"
+    />
   </Target>
   <Target Name="CleanLocal">
     <RemoveDir Directories="bin;obj;libs"/>

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib1/Xamarin.Android.BindingResolveImportLib1.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib1/Xamarin.Android.BindingResolveImportLib1.csproj
@@ -43,33 +43,26 @@
     <None Include="Properties\AndroidManifest.xml" />
     <None Include="Additions\AboutAdditions.txt" />
     <None Include="Jars\AboutJars.txt" />
-    <None Include="Jars\com\xamarin\android\test\binding\resolveimport\Lib1.java">
+    <TestJarEntry Include="Jars\com\xamarin\android\test\binding\resolveimport\Lib1.java">
       <Link>Jars\com\xamarin\android\test\binding\resolveimport\Lib1.java</Link>
-    </None>
+      <OutputFile>Jars/lib1.jar</OutputFile>
+    </TestJarEntry>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
+  <Import Project="..\..\..\build-tools\scripts\Jar.targets" />
+  <Import Project="Xamarin.Android.BindingResolveImportLib1.targets" />
   <PropertyGroup>
     <BuildDependsOn>
-      BuildJar;
+      BuildTestJarFile;
+      _BuildLibraryProjectZips;
       $(BuildDependsOn)
     </BuildDependsOn>
     <CleanDependsOn>
-      CleanJar;
+      CleanTestJarFile;
+      _CleanLibraryProjectZips;
       $(CleanDependsOn)
     </CleanDependsOn>
   </PropertyGroup>
-  <Target Name="BuildJar" Inputs="Jars/com/xamarin/android/test/binding/resolveimport/Lib1.java" Outputs="Jars/lib1.zip">
-    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d Jars -sourcepath Jars Jars/com/xamarin/android/test/binding/resolveimport/Lib1.java" />
-    <Exec WorkingDirectory="Jars" Command="&quot;$(JarPath)&quot; cf lib1.jar com" />
-    <MakeDir Directories="Jars/zipped;Jars/zipped/bin" />
-    <Copy SourceFiles="Jars/lib1.jar;Properties/AndroidManifest.xml" DestinationFiles="Jars/zipped/bin/lib1.jar;Jars/zipped/bin/AndroidManifest.xml" />
-    <Exec WorkingDirectory="Jars/zipped" Command="&quot;$(JarPath)&quot; cf lib1.zip bin" />
-    <Copy SourceFiles="Jars/zipped/lib1.zip" DestinationFiles="Jars/lib1.zip" />
-  </Target>
-  <Target Name="CleanJar">
-    <RemoveDir Directories="Jars/bin;Jars/zipped" />
-    <Delete Files="Jars/lib1.jar;Jars/lib1.zip;Jars/com/xamarin/android/test/binding/resolveimport/Lib1.class" />
-  </Target>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
@@ -86,8 +79,5 @@
   </ItemGroup>
   <ItemGroup>
     <LibraryProjectZip Include="Jars\zipped\lib1.zip" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Jars\com\" />
   </ItemGroup>
 </Project>

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib1/Xamarin.Android.BindingResolveImportLib1.targets
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib1/Xamarin.Android.BindingResolveImportLib1.targets
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="_BuildLibraryProjectZips"
+      Inputs="Jars\lib1.jar"
+      Outputs="Jars\zipped\lib1.zip">
+    <MakeDir Directories="Jars\zipped;Jars\zipped\bin" />
+    <Copy
+        SourceFiles="Jars\lib1.jar;Properties\AndroidManifest.xml"
+        DestinationFiles="Jars\zipped\bin\lib1.jar;Jars\zipped\bin\AndroidManifest.xml"
+    />
+    <Exec
+        Command="&quot;$(JarPath)&quot; cf lib1.zip bin"
+        WorkingDirectory="Jars\zipped"
+    />
+    <Copy
+        SourceFiles="Jars\zipped\lib1.zip"
+        DestinationFiles="Jars\lib1.zip"
+    />
+  </Target>
+  <Target Name="_CleanLibraryProjectZips">
+    <Delete Files="Jars\zipped\lib1.zip" />
+  </Target>
+</Project>

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib2/Xamarin.Android.BindingResolveImportLib2.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib2/Xamarin.Android.BindingResolveImportLib2.csproj
@@ -51,9 +51,10 @@
   <ItemGroup>
     <None Include="Additions\AboutAdditions.txt" />
     <None Include="Jars\AboutJars.txt" />
-    <None Include="Jars\com\xamarin\android\test\binding\resolveimport\Lib2.java">
+    <TestJarEntry Include="Jars\com\xamarin\android\test\binding\resolveimport\Lib2.java">
       <Link>Jars\com\xamarin\android\test\binding\resolveimport\Lib2.java</Link>
-    </None>
+      <OutputFile>Jars/lib2.jar</OutputFile>
+    </TestJarEntry>
   </ItemGroup>
   <ItemGroup>
     <TransformFile Include="Transforms\EnumFields.xml" />
@@ -61,39 +62,23 @@
     <TransformFile Include="Transforms\Metadata.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
+  <Import Project="..\..\..\build-tools\scripts\Jar.targets" />
+  <Import Project="Xamarin.Android.BindingResolveImportLib2.targets" />
   <ItemGroup>
     <EmbeddedJar Include="Jars\lib2.jar" />
   </ItemGroup>
   <PropertyGroup>
     <BuildDependsOn>
-      BuildJar;
+      BuildTestJarFile;
       BuildNativeLibs;
       $(BuildDependsOn)
     </BuildDependsOn>
     <CleanDependsOn>
-      CleanJar;
+      CleanTestJarFile;
       CleanNativeLibs;
       $(CleanDependsOn)
     </CleanDependsOn>
   </PropertyGroup>
-  <Target Name="BuildJar" Inputs="Jars/com/xamarin/android/test/binding/resolveimport/Lib2.java" Outputs="Jars/lib2.jar">
-    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d Jars -sourcepath Jars Jars/com/xamarin/android/test/binding/resolveimport/Lib2.java" />
-    <Exec WorkingDirectory="Jars" Command="&quot;$(JarPath)&quot; cf lib2.jar com" />
-  </Target>
-  <Target Name="CleanJar">
-    <RemoveDir Directories="Jars/bin" />
-    <Delete Files="Jars/lib2.jar;Jars/com/xamarin/android/test/binding/resolveimport/Lib2.class" />
-  </Target>
-  <Target Name="BuildNativeLibs" DependsOnTargets="AndroidPrepareForBuild" Inputs="jni\timing.c;jni\Android.mk" Outputs="@(EmbeddedNativeLibrary)">
-    <Error Text="Could not locate Android NDK." Condition="!Exists ('$(NdkBuildPath)')" />
-    <Exec Command="&quot;$(NdkBuildPath)&quot;" />
-  </Target>
-  <Target Name="CleanNativeLibs">
-    <RemoveDir Directories="obj\local;libs" />
-  </Target>
-  <ItemGroup>
-    <Folder Include="Jars\com\" />
-  </ItemGroup>
   <ItemGroup>
     <EmbeddedNativeLibrary Include="libs\armeabi\libtiming2.so" />
     <EmbeddedNativeLibrary Include="libs\armeabi-v7a\libtiming2.so" />

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib2/Xamarin.Android.BindingResolveImportLib2.targets
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib2/Xamarin.Android.BindingResolveImportLib2.targets
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="BuildNativeLibs"
+      DependsOnTargets="AndroidPrepareForBuild"
+      Inputs="jni\timing.c;jni\Android.mk"
+      Outputs="@(EmbeddedNativeLibrary)">
+    <Error
+        Condition="!Exists ('$(NdkBuildPath)')"
+        Text="Could not locate Android NDK."
+    />
+    <Exec Command="&quot;$(NdkBuildPath)&quot;" />
+  </Target>
+  <Target Name="CleanNativeLibs">
+    <RemoveDir Directories="obj\local;libs" />
+  </Target>
+</Project>

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib3/Xamarin.Android.BindingResolveImportLib3.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib3/Xamarin.Android.BindingResolveImportLib3.csproj
@@ -52,9 +52,10 @@
   <ItemGroup>
     <None Include="Additions\AboutAdditions.txt" />
     <None Include="Jars\AboutJars.txt" />
-    <None Include="Jars\com\xamarin\android\test\binding\resolveimport\Lib3.java">
+    <TestJarEntry Include="Jars\com\xamarin\android\test\binding\resolveimport\Lib3.java">
       <Link>Jars\com\xamarin\android\test\binding\resolveimport\Lib3.java</Link>
-    </None>
+      <OutputFile>Jars/lib3.jar</OutputFile>
+    </TestJarEntry>
     <None Include="Properties\AndroidManifest.xml" />
   </ItemGroup>
   <ItemGroup>
@@ -63,32 +64,21 @@
     <TransformFile Include="Transforms\Metadata.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
+  <Import Project="..\..\..\build-tools\scripts\Jar.targets" />
+  <Import Project="Xamarin.Android.BindingResolveImportLib3.targets" />
   <ItemGroup>
     <LibraryProjectZip Include="Jars\zipped\lib3.zip" />
   </ItemGroup>
   <PropertyGroup>
     <BuildDependsOn>
-      BuildJar;
+      BuildTestJarFile;
+      _BuildLibraryProjectZips;
       $(BuildDependsOn)
     </BuildDependsOn>
     <CleanDependsOn>
-      CleanJar;
+      CleanTestJarFile;
+      _CleanLibraryProjectZips;
       $(CleanDependsOn)
     </CleanDependsOn>
   </PropertyGroup>
-  <Target Name="BuildJar" Inputs="Jars/com/xamarin/android/test/binding/resolveimport/Lib3.java" Outputs="Jars/lib3.zip">
-    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d Jars -sourcepath Jars Jars/com/xamarin/android/test/binding/resolveimport/Lib3.java" />
-    <Exec WorkingDirectory="Jars" Command="&quot;$(JarPath)&quot; cf lib3.jar com" />
-    <MakeDir Directories="Jars/zipped;Jars/zipped/bin" />
-    <Copy SourceFiles="Jars/lib3.jar;Properties/AndroidManifest.xml" DestinationFiles="Jars/zipped/bin/lib3.jar;Jars/zipped/bin/AndroidManifest.xml" />
-    <Exec WorkingDirectory="Jars/zipped" Command="&quot;$(JarPath)&quot; cf lib3.zip bin" />
-    <Copy SourceFiles="Jars/zipped/lib3.zip" DestinationFiles="Jars/lib3.zip" />
-  </Target>
-  <Target Name="CleanJar">
-    <RemoveDir Directories="Jars/bin;Jars/zipped" />
-    <Delete Files="Jars/lib3.zip;Jars/zipped/lib3.zip;Jars/lib3.jar;Jars/com/xamarin/android/test/binding/resolveimport/Lib3.class" />
-  </Target>
-  <ItemGroup>
-    <Folder Include="Jars\com\" />
-  </ItemGroup>
 </Project>

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib3/Xamarin.Android.BindingResolveImportLib3.targets
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib3/Xamarin.Android.BindingResolveImportLib3.targets
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="_BuildLibraryProjectZips"
+      Inputs="Jars\lib3.jar"
+      Outputs="Jars\zipped\lib3.zip">
+    <MakeDir Directories="Jars\zipped;Jars\zipped\bin" />
+    <Copy
+        SourceFiles="Jars\lib3.jar;Properties\AndroidManifest.xml"
+        DestinationFiles="Jars\zipped\bin\lib3.jar;Jars\zipped\bin\AndroidManifest.xml"
+    />
+    <Exec
+        Command="&quot;$(JarPath)&quot; cf lib3.zip bin"
+        WorkingDirectory="Jars\zipped"
+    />
+    <Copy
+        SourceFiles="Jars\zipped\lib3.zip"
+        DestinationFiles="Jars\lib3.zip"
+    />
+  </Target>
+  <Target Name="_CleanLibraryProjectZips">
+    <Delete Files="Jars\zipped\lib3.zip" />
+  </Target>
+</Project>

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib4/Xamarin.Android.BindingResolveImportLib4.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib4/Xamarin.Android.BindingResolveImportLib4.csproj
@@ -49,9 +49,10 @@
   <ItemGroup>
     <None Include="Additions\AboutAdditions.txt" />
     <None Include="Jars\AboutJars.txt" />
-    <None Include="Jars\com\xamarin\android\test\binding\resolveimport\Lib4.java">
+    <TestJarEntry Include="Jars\com\xamarin\android\test\binding\resolveimport\Lib4.java">
       <Link>Jars\com\xamarin\android\test\binding\resolveimport\Lib4.java</Link>
-    </None>
+      <OutputFile>Jars/lib4.jar</OutputFile>
+    </TestJarEntry>
   </ItemGroup>
   <ItemGroup>
     <TransformFile Include="Transforms\EnumFields.xml" />
@@ -59,39 +60,23 @@
     <TransformFile Include="Transforms\Metadata.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
+  <Import Project="..\..\..\build-tools\scripts\Jar.targets" />
+  <Import Project="Xamarin.Android.BindingResolveImportLib4.targets" />
   <ItemGroup>
     <EmbeddedJar Include="Jars\lib4.jar" />
   </ItemGroup>
   <PropertyGroup>
     <BuildDependsOn>
-      BuildJar;
+      BuildTestJarFile;
       BuildNativeLibs;
       $(BuildDependsOn)
     </BuildDependsOn>
     <CleanDependsOn>
-      CleanJar;
+      CleanTestJarFile;
       CleanNativeLibs;
       $(CleanDependsOn)
     </CleanDependsOn>
   </PropertyGroup>
-  <Target Name="BuildJar" Inputs="Jars/com/xamarin/android/test/binding/resolveimport/Lib4.java" Outputs="Jars/lib4.jar">
-    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d Jars -sourcepath Jars Jars/com/xamarin/android/test/binding/resolveimport/Lib4.java" />
-    <Exec WorkingDirectory="Jars" Command="&quot;$(JarPath)&quot; cf lib4.jar com" />
-  </Target>
-  <Target Name="CleanJar">
-    <RemoveDir Directories="Jars/bin" />
-    <Delete Files="Jars/lib4.jar;Jars/com/xamarin/android/test/binding/resolveimport/Lib4.class" />
-  </Target>
-  <Target Name="BuildNativeLibs" DependsOnTargets="AndroidPrepareForBuild" Inputs="jni\timing.c;jni\Android.mk" Outputs="@(EmbeddedNativeLibrary)">
-    <Error Text="Could not locate Android NDK." Condition="!Exists ('$(NdkBuildPath)')" />
-    <Exec Command="&quot;$(NdkBuildPath)&quot;" />
-  </Target>
-  <Target Name="CleanNativeLibs">
-    <RemoveDir Directories="obj\local;libs" />
-  </Target>
-  <ItemGroup>
-    <Folder Include="Jars\com\" />
-  </ItemGroup>
   <ItemGroup>
     <EmbeddedNativeLibrary Include="libs\armeabi\libtiming4.so" />
     <EmbeddedNativeLibrary Include="libs\armeabi-v7a\libtiming4.so" />

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib4/Xamarin.Android.BindingResolveImportLib4.targets
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib4/Xamarin.Android.BindingResolveImportLib4.targets
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="BuildNativeLibs"
+      DependsOnTargets="AndroidPrepareForBuild"
+      Inputs="jni\timing.c;jni\Android.mk"
+      Outputs="@(EmbeddedNativeLibrary)">
+    <Error
+        Condition="!Exists ('$(NdkBuildPath)')"
+        Text="Could not locate Android NDK."
+    />
+    <Exec Command="&quot;$(NdkBuildPath)&quot;" />
+  </Target>
+  <Target Name="CleanNativeLibs">
+    <RemoveDir Directories="obj\local;libs" />
+  </Target>
+</Project>


### PR DESCRIPTION
We have a VSTS+macOS build machine which has JDK 9 as the default JDK,
thus causing *all* xamarin-android builds to fail, as `gradlew` and
JDK 9 don't *directly* mix:

	Executing: ./gradlew assembleDebug --stacktrace
	...
	org.gradle.api.ProjectConfigurationException: A problem occurred configuring project ':library'.
	  ...
	Caused by: org.gradle.internal.event.ListenerNotificationException:
	Failed to notify project evaluation listener.
	  ...
	Caused by: java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlSchema
	  ...
	Caused by: java.lang.ClassNotFoundException: javax.xml.bind.annotation.XmlSchema

When using JDK 9, `gradlew` fails because *something* within it
attempts to use the deprecated type
`javax.xml.bind.annotation.XmlSchema`, and JDK 9 doesn't provide
deprecated modules in the default `$CLASSPATH`.

Knowing that the VSTS machine *also* has JDK 8 installed, we've tried
to "filter out" JDK 9 so that it wouldn't be used; see e.g. a3c43584.
Unfortunately that doesn't work, because on macOS the default JDK used
is [always the JDK with the highest version number][macOS-jdk], and
this can't be easily changed system-wide because changing this
behavior requires "removing" a `Info.plist` file to prevent the JDK
from being "seen" by `/usr/bin/java`:

[macOS-jdk]: https://stackoverflow.com/a/44169445

	# Don't use JDK 9 by default on macOS:
	$ cd /Library/Java/JavaVirtualMachines/jdk-9.0.4.jdk/Contents
	$ mv Info.plist Info.plist.disabled

(Renaming `Info.plist.disabled` to `Info.plist` will restore JDK 9 as
the default JDK on the machine.)

A "proper" fix would presumably involve using and exporting
`$JAVA_HOME` *everywhere*, which isn't currently the case.
[This is something that *should* be explored.][xa-1213]

[xa-1213]: https://github.com/xamarin/xamarin-android/issues/1213

In the meantime, a question: *Can* we build with JDK 9?
*Is it even possible in the first place*?

Turns out, *yes*, it *is* possible. The above `gradlew` error can be
fixed by providing the (new-in-JDK9) `--add-modules` option, so that
the `java.xml.bind` module is accessible:

	$ ANDROID_HOME=... JAVA_OPTS="--add-modules java.xml.bind" ./gradlew assembleDebug --stacktrace --no-daemon
	# ...works!

Unfortunately, *other* parts xamarin-android get in the way, e.g. the
`<ResolveSdks/>` task doesn't correctly parse the version number out
of `java -version`, and JDK 9 `javac` requires `-source` and `-target`
when `-bootclasspath` is used.

Update the build system and tests so that things *can* be built under
JDK 9.

**Note**: This does ***NOT*** mean that building and/or using JDK 9
will be commercially supported in *any* way. (It might not even work!)