### PR TITLE
[Xamarin.Android.Build.Tasks] Rework AndroidApkSigner to use .jar directly.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
@@ -6,8 +6,11 @@ using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
-	public class AndroidApkSigner : AndroidToolTask
+	public class AndroidApkSigner : JavaToolTask
 	{
+		[Required]
+		public string ApkSignerJar { get; set; }
+
 		[Required]
 		public string ApkToSign { get; set; }
 
@@ -31,6 +34,7 @@ namespace Xamarin.Android.Tasks
 		public override bool Execute ()
 		{
 			Log.LogDebugMessage ("AndroidApkSigner:");
+			Log.LogDebugMessage ("  ApkSignerJar: {0}", ApkSignerJar);
 			Log.LogDebugMessage ("  ApkToSign: {0}", ApkToSign);
 			Log.LogDebugMessage ("  ManifestFile: {0}", ManifestFile);
 			Log.LogDebugMessage ("  AdditionalArguments: {0}", AdditionalArguments);
@@ -57,6 +61,8 @@ namespace Xamarin.Android.Tasks
 				maxSdk = manifest.TargetSdkVersion.Value;
 
 			minSdk = Math.Min (minSdk, maxSdk);
+
+			cmd.AppendSwitchIfNotNull ("-jar ", ApkSignerJar);
 			cmd.AppendSwitch ("sign");
 			cmd.AppendSwitchIfNotNull ("--ks ", KeyStore);
 			cmd.AppendSwitchIfNotNull ("--ks-pass pass:", StorePass);
@@ -68,14 +74,9 @@ namespace Xamarin.Android.Tasks
 			if (!string.IsNullOrEmpty (AdditionalArguments))
 				cmd.AppendSwitch (AdditionalArguments);
 
-			cmd.AppendSwitchIfNotNull (" ", ApkToSign);
+			cmd.AppendSwitchIfNotNull (" ", Path.GetFullPath (ApkToSign));
 
 			return cmd.ToString ();
-		}
-
-		protected override string GenerateFullPathToTool ()
-		{
-			return Path.Combine (ToolPath, ToolExe);
 		}
 
 		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance importance)
@@ -93,9 +94,7 @@ namespace Xamarin.Android.Tasks
 		}
 
 		protected override string ToolName {
-			get {
-				return ToolExe;
-			}
+			get { return OS.IsWindows ? "java.exe" : "java"; }
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -111,7 +111,7 @@ namespace Xamarin.Android.Tasks
 		public string LintToolPath { get; set; }
 
 		[Output]
-		public string ApkSignerToolExe { get; set; }
+		public string ApkSignerJar { get; set; }
 
 		[Output]
 		public bool AndroidUseApkSigner { get; set; }
@@ -121,7 +121,7 @@ namespace Xamarin.Android.Tasks
 		static readonly string  Aapt      = IsWindows ? "aapt.exe" : "aapt";
 		static readonly string  Android   = IsWindows ? "android.bat" : "android";
 		static readonly string  Lint      = IsWindows ? "lint.bat" : "lint";
-		static readonly string  ApkSigner = "apksigner";
+		static readonly string  ApkSigner = "apksigner.jar";
 
 
 		public override bool Execute ()
@@ -222,8 +222,8 @@ namespace Xamarin.Android.Tasks
 				return false;
 			}
 
-			ApkSignerToolExe = MonoAndroidHelper.GetExecutablePath (AndroidSdkBuildToolsBinPath, ApkSigner);
-			AndroidUseApkSigner = File.Exists (Path.Combine (AndroidSdkBuildToolsBinPath, ApkSignerToolExe));
+			ApkSignerJar = Path.Combine (AndroidSdkBuildToolsBinPath, "lib", ApkSigner);
+			AndroidUseApkSigner = File.Exists (ApkSignerJar);
 
 			if (string.IsNullOrEmpty (ZipAlignPath) || !Directory.Exists (ZipAlignPath)) {
 				ZipAlignPath = new[]{

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -662,7 +662,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		<Output TaskParameter="AndroidSdkBuildToolsBinPath" PropertyName="AndroidSdkBuildToolsBinPath" Condition="'$(AndroidSdkBuildToolsBinPath)' == ''" />
 		<Output TaskParameter="AndroidSequencePointsMode"   PropertyName="_SequencePointsMode"         Condition="'$(_SequencePointsMode)' == ''" />
 		<Output TaskParameter="LintToolPath"              PropertyName="LintToolPath"               Condition="'$(LintToolPath)' == ''" />
-		<Output TaskParameter="ApkSignerToolExe"          PropertyName="ApkSignerToolExe"           Condition="'$(ApkSignerToolExe)' == ''" />
+		<Output TaskParameter="ApkSignerJar"              PropertyName="ApkSignerJar"               Condition="'$(ApkSignerJar)' == ''" />
 		<Output TaskParameter="AndroidUseApkSigner"       PropertyName="AndroidUseApkSigner"        Condition="'$(AndroidUseApkSigner)' == ''" />
 	</ResolveSdks>
 	<CreateProperty Value="$(TargetFrameworkIdentifier),Version=$(_TargetFrameworkVersion),Profile=$(TargetFrameworkProfile)">
@@ -2549,13 +2549,14 @@ because xbuild doesn't support framework reference assemblies.
 		ToolExe="$(ZipalignToolExe)"
 	/>
 	<AndroidApkSigner Condition=" '$(AndroidUseApkSigner)' == 'true' "
+		ApkSignerJar="$(ApkSignerJar)"
 		ApkToSign="$(ApkFileSigned)"
 		KeyStore="$(_ApkKeyStore)"
 		KeyAlias="$(_ApkKeyAlias)"
 		KeyPass="$(_ApkKeyPass)"
 		StorePass="$(_ApkStorePass)"
-		ToolPath="$(AndroidSdkBuildToolsBinPath)"
-		ToolExe="$(ApkSignerToolExe)"
+		ToolPath="$(JavacToolPath)"
+		ToolExe="$(JavacToolExe)"
 		ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
 		AdditionalArguments="$(AndroidApkSignerAdditionalArguments)"
 	/>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2555,8 +2555,8 @@ because xbuild doesn't support framework reference assemblies.
 		KeyAlias="$(_ApkKeyAlias)"
 		KeyPass="$(_ApkKeyPass)"
 		StorePass="$(_ApkStorePass)"
-		ToolPath="$(JavacToolPath)"
-		ToolExe="$(JavacToolExe)"
+		ToolPath="$(JavaToolPath)"
+		ToolExe="$(JavaToolExe)"
 		ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
 		AdditionalArguments="$(AndroidApkSignerAdditionalArguments)"
 	/>


### PR DESCRIPTION
Once again we hit an issue where the `apksigner.bat` file provided
with android build-tools was not functioning correctly. So like
we did with `dx.bat` and other tooling we should switch to using
the `apksigner.jar` file directly.

Additionally JDK 9 has removed support for the `java.ext.dirs`, which
all versions of the `apksigner.bat` use. As a result this tool will
not work with JDK 9. So its best to remove it now.

We have existing unit tests which check that the Apk is being
signed correctly. So not additional tests are required.