### PR TITLE
[build] Fix the MSBuild build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ linux-prepare::
 GetPath   = $(shell $(MSBUILD) $(MSBUILD_FLAGS) /p:DoNotLoadOSProperties=True /nologo /v:minimal /t:Get$(1)FullPath build-tools/scripts/Paths.targets | tr -d '[[:space:]]' )
 
 MSBUILD_PREPARE_PROJS = \
+	build-tools/mono-runtimes/mono-runtimes.mdproj \
 	src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
 
 prepare-external:


### PR DESCRIPTION
The [`msbuild`-based Jenkins job][jenkins-msbuild] job has been
failing a lot recently:

[jenkins-msbuild]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-msbuild/

	error MSB3644: The reference assemblies for framework "MonoAndroid,Version=v1.0" were not found.

The cause of the error is that *when there is no prebuilt mono runtime
to download*, this file does not exist:

	bin/Debug/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v1.0/RedistList/FrameworkList.xml

The above file is created by the
`build-tools/scripts/mono-runtimes.mdproj` build, and
`mono-runtimes.mdproj` *is not being built*. Without a mono build,
there is no `MonoAndroid/v1.0` framework, and everything fails.

I don't know when this actually broke, or what change is responsible.
(It works with `xbuild`!)

Attempt to improve reliability by adding `mono-runtimes.mdproj` to
`$(MSBUILD_PREPARE_PROJS)`. This will cause the `msbuild`-based build
to explicitly build `mono-runtimes.mdproj` *before* attempting to
build `Xamarin.Android.Build.Tasks.csproj` or `Xamarin.Android.sln`.