### PR TITLE
Make sure merged api description has the latest platform level

### DIFF
--- a/build-tools/api-merge/ApiDescription.cs
+++ b/build-tools/api-merge/ApiDescription.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Android.ApiMerge {
 		public static bool HackGenericTypeParameterNames = true;
 
 		XDocument Contents;
+		XAttribute contentsPlatform;
 		Dictionary<string, XElement> Types = new Dictionary<string, XElement>();
 
 		public ApiDescription (string source)
@@ -26,6 +27,8 @@ namespace Xamarin.Android.ApiMerge {
 			foreach (var package in api.Elements ("package")) {
 				AddPackage (package, platform);
 			}
+
+			contentsPlatform = api.Attributes ("platform").LastOrDefault ();
 		}
 
 		XElement GetRoot (XDocument doc, string sourcePath, out string platform)
@@ -52,6 +55,12 @@ namespace Xamarin.Android.ApiMerge {
 			var n = XDocument.Load (apiLocation);
 			string platform = null;
 			XElement api = GetRoot (n, apiLocation, out platform);
+			if (!String.IsNullOrEmpty (platform) && contentsPlatform != null) {
+				// Update the api platform to the current document's value. Documents are
+				// sorted in ascending order, so we'll end up with the latest platform in
+				// the merged document, as it should be.
+				contentsPlatform.SetValue (platform);
+			}
 
 			foreach (var npackage in api.Elements ("package")) {
 				var spackage = GetPackage ((string) npackage.Attribute ("name"));


### PR DESCRIPTION
When merging we process several API description files, each for a separate
platform. The resulting file currently carries the *first* platform level in its
`<api platform="">` root element attribute. This is a subtle issue that may
cause problems when applying fixups from metadata (for instance) as the
`api-since` and `api-until` attributes in fixups may apply to incorrect sets of
API members.

Fix the issue by putting the latest API description platform level as obtained
from the files provided to api-merge (the files are sorted in platform level
ascending order)