### PR TITLE
[Xamarin.Android.Build.Tasks] missing EmbeddedResource.LogicalName for __AndroidLibraryProjects__

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -958,7 +958,7 @@ namespace Lib1 {
 					Assert.IsFalse (appBuilder.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "_UpdateAndroidResgen target not should be skipped.");
 					foo.Timestamp = DateTime.UtcNow;
 					Assert.IsTrue (libBuilder.Build (libProj, doNotCleanupOnUpdate: true, saveProject: false), "Library project should have built");
-					Assert.IsTrue (libBuilder.Output.IsTargetSkipped ("_AddLibraryProjectsEmbeddedResourceToProject"), "_AddLibraryProjectsEmbeddedResourceToProject should be skipped.");
+					Assert.IsTrue (libBuilder.Output.IsTargetSkipped ("_CreateManagedLibraryResourceArchive"), "_CreateManagedLibraryResourceArchive should be skipped.");
 					Assert.IsTrue (appBuilder.Build (appProj, doNotCleanupOnUpdate: true, saveProject: false), "Application Build should have succeeded.");
 					Assert.IsTrue (appBuilder.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "_UpdateAndroidResgen target should be skipped.");
 					theme.TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -968,7 +968,7 @@ namespace Lib1 {
 </resources>";
 					theme.Timestamp = DateTime.UtcNow;
 					Assert.IsTrue (libBuilder.Build (libProj, doNotCleanupOnUpdate: true, saveProject: false), "Library project should have built");
-					Assert.IsFalse (libBuilder.Output.IsTargetSkipped ("_AddLibraryProjectsEmbeddedResourceToProject"), "_AddLibraryProjectsEmbeddedResourceToProject should not be skipped.");
+					Assert.IsFalse (libBuilder.Output.IsTargetSkipped ("_CreateManagedLibraryResourceArchive"), "_CreateManagedLibraryResourceArchive should not be skipped.");
 					Assert.IsTrue (appBuilder.Build (appProj, doNotCleanupOnUpdate: true, saveProject: false), "Application Build should have succeeded.");
 					string text = File.ReadAllText (Path.Combine (Root, path, appProj.ProjectName, "Resources", "Resource.designer.cs"));
 					Assert.IsTrue (text.Contains ("theme_devicedefault_background2"), "Resource.designer.cs was not updated.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -39,11 +39,13 @@ namespace Lib
 			};
 			using (var b = CreateDllBuilder (Path.Combine (testPath, "Lib"))) {
 				Assert.IsTrue (b.Build (lib), "Build should have succeeded.");
-				Assert.IsTrue (b.LastBuildOutput.ContainsText ("LogicalName=__AndroidLibraryProjects__.zip"),
+				Assert.IsTrue (b.LastBuildOutput.ContainsText ("LogicalName=__AndroidLibraryProjects__.zip") ||
+						b.LastBuildOutput.ContainsText ("Lib.obj.Debug.__AndroidLibraryProjects__.zip,__AndroidLibraryProjects__.zip"),
 						"The LogicalName for __AndroidLibraryProjects__.zip should be set.");
-				class1Source.Timestamp = null;
+				class1Source.Timestamp = DateTime.UtcNow.Add (TimeSpan.FromMinutes (1));
 				Assert.IsTrue (b.Build (lib), "Build should have succeeded.");
-				Assert.IsTrue (b.LastBuildOutput.ContainsText ("LogicalName=__AndroidLibraryProjects__.zip"),
+				Assert.IsTrue (b.LastBuildOutput.ContainsText ("LogicalName=__AndroidLibraryProjects__.zip") ||
+						b.LastBuildOutput.ContainsText ("Lib.obj.Debug.__AndroidLibraryProjects__.zip,__AndroidLibraryProjects__.zip"),
 						"The LogicalName for __AndroidLibraryProjects__.zip should be set.");
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -12,6 +12,42 @@ namespace Xamarin.Android.Build.Tests
 	[Parallelizable (ParallelScope.Children)]
 	public class IncrementalBuildTest : BaseTest
 	{
+
+		[Test]
+		public void LibraryIncrementalBuild () {
+
+			var testPath = Path.Combine ("temp", TestName);
+			var class1Source = new BuildItem.Source ("Class1.cs") {
+				TextContent = () => @"
+using System;
+namespace Lib
+{
+	public class Class1
+	{
+		public Class1 ()
+		{
+		}
+	}
+}"
+			};
+			var lib = new XamarinAndroidLibraryProject () {
+				ProjectName = "Lib",
+				ProjectGuid = Guid.NewGuid ().ToString (),
+				Sources = {
+					class1Source,
+				},
+			};
+			using (var b = CreateDllBuilder (Path.Combine (testPath, "Lib"))) {
+				Assert.IsTrue (b.Build (lib), "Build should have succeeded.");
+				Assert.IsTrue (b.LastBuildOutput.ContainsText ("LogicalName=__AndroidLibraryProjects__.zip"),
+						"The LogicalName for __AndroidLibraryProjects__.zip should be set.");
+				class1Source.Timestamp = null;
+				Assert.IsTrue (b.Build (lib), "Build should have succeeded.");
+				Assert.IsTrue (b.LastBuildOutput.ContainsText ("LogicalName=__AndroidLibraryProjects__.zip"),
+						"The LogicalName for __AndroidLibraryProjects__.zip should be set.");
+			}
+		}
+
 		[Test]
 		public void AllProjectsHaveSameOutputDirectory()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1462,12 +1462,11 @@ because xbuild doesn't support framework reference assemblies.
 		AndroidResgenFlagFile="$(_AndroidResgenFlagFile)" />
 </Target>
 
-<Target Name="_AddLibraryProjectsEmbeddedResourceToProject"
+<Target Name="_CreateManagedLibraryResourceArchive"
 		Inputs="@(_AndroidResourceDest);@(AndroidAsset);@(AndroidJavaLibrary);@(AndroidJavaSource);@(_AndroidResourceDestRemovedFiles)"
 		Outputs="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip"
 		Condition=" '$(AndroidApplication)' != 'True' "
 	>
-
 	<!-- embed managed resources into dll as a zip archive, like AndroidLibraryProjectZip -->
 	<CreateManagedLibraryResourceArchive
 		OutputDirectory="$(IntermediateOutputPath)$(_LibraryProjectImportsDirectoryName)"
@@ -1480,6 +1479,12 @@ because xbuild doesn't support framework reference assemblies.
 		AndroidResourcesInThisExactProject="@(_AndroidResourceDest)"
 		RemovedAndroidResourceFiles="@(_AndroidResourceDestRemovedFiles)"
 	/>
+</Target>
+
+<Target Name="_AddLibraryProjectsEmbeddedResourceToProject"
+		DependsOnTargets="_CreateManagedLibraryResourceArchive"
+		Condition=" '$(AndroidApplication)' != 'True' "
+	>
 	<CreateItem
 		Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip"
         Condition="Exists ('$(IntermediateOutputPath)__AndroidLibraryProjects__.zip')"


### PR DESCRIPTION
Fixes #1235

There seems to be a bug in msbuild [1] where if you create
an item inside a task and the task is skipped, the metadata
is not created for the item.

So we get into a situation where our `__AndroidLibraryProjects__.zip`
does not contain the correct LogicalName. As a result our
extraction process cannot find the resource, and builds fail.

This commit spits out the code that created the zip file into
its own target `_CreateManagedLibraryResourceArchive`. This means
we can skip this new target it needed. However the target
which creates the item `_AddLibraryProjectsEmbeddedResourceToProject`
can now run for every build. This will ensure that the metadata is
always created.

Also added a unit test.

[1] https://social.msdn.microsoft.com/Forums/netframework/en-US/259271d8-a3fc-4a9b-9e3a-fecad8f6f63f/potential-bug-with-createitem-task-and-additionalmetadata?forum=msbuild