### PR TITLE
[msbuild] fix wrong enum-to-string mapping in ActivityAttribute.Confi…

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
@@ -218,7 +218,7 @@ namespace Xamarin.Android.Manifest {
 				values.Add ("navigation");
 			if ((value & ConfigChanges.Orientation) == ConfigChanges.Orientation)
 				values.Add ("orientation");
-			if ((value & ConfigChanges.SmallestScreenSize) == ConfigChanges.ScreenSize)
+			if ((value & ConfigChanges.SmallestScreenSize) == ConfigChanges.SmallestScreenSize)
 				values.Add ("smallestScreenSize");
 			if ((value & ConfigChanges.ScreenLayout) == ConfigChanges.ScreenLayout)
 				values.Add ("screenLayout");


### PR DESCRIPTION
…gChanges.

This should fix https://github.com/xamarin/xamarin-android/issues/1234

Turned out it was from monodroid/b774219, long-standing issue.