### PR TITLE
[Xamarin.Android.Build.Tasks] Generate error when JDK 9 is used

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -395,7 +395,7 @@ namespace Xamarin.Android.Tasks
 					Log.LogError ($"Java SDK {requiredJavaForBuildTools} or above is required when using build-tools {buildToolsVersion}.");
 				}
 				if (versionNumber > Version.Parse (LatestSupportedJavaVersion)) {
-					Log.LogWarning ($"JDK Version `{versionNumber}` is later than latest suppored JDK version `{LatestSupportedJavaVersion}`.");
+					Log.LogCodedError ("XA0030", $"Building with JDK Version `{versionNumber}` is not supported. Please install JDK version `{LatestSupportedJavaVersion}`. See https://aka.ms/xamarin/jdk9-errors");
 				}
 			} else
 				Log.LogWarning ($"Failed to get the Java SDK version as it does not appear to contain a valid version number. `javac -version` returned: ```{versionInfo}```");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2163,8 +2163,8 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 					$"LatestSupportedJavaVersion={latestSupportedJavaVersion}",
 				}), string.Format ("Build should have {0}", expectedResult ? "succeeded" : "failed"));
 			}
-			//Directory.Delete (javaPath, recursive: true);
-			//Directory.Delete (AndroidSdkDirectory, recursive: true);
+			Directory.Delete (javaPath, recursive: true);
+			Directory.Delete (AndroidSdkDirectory, recursive: true);
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2054,76 +2054,94 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				/*targetFrameworkVersion*/ "v7.1",
 				/*buildToolsVersion*/ "24.0.1",
 				/*JavaVersion*/ "1.8.0_101",
+				/*latestSupportedJavaVersion*/ "1.8.0",
 				/*expectedResult*/ true,
 			},
 			new object [] {
 				/*targetFrameworkVersion*/ "v7.1",
 				/*buildToolsVersion*/ "24.0.1",
 				/*JavaVersion*/ "1.7.0_101",
+				/*latestSupportedJavaVersion*/ "1.8.0",
 				/*expectedResult*/ false,
 			},
 			new object [] {
 				/*targetFrameworkVersion*/ "v7.1",
 				/*buildToolsVersion*/ "24.0.1",
 				/*JavaVersion*/ "1.6.0_101",
+				/*latestSupportedJavaVersion*/ "1.8.0",
 				/*expectedResult*/ false,
 			},
 			new object [] {
 				/*targetFrameworkVersion*/ "v6.0",
 				/*buildToolsVersion*/ "24.0.1",
 				/*JavaVersion*/ "1.8.0_101",
+				/*latestSupportedJavaVersion*/ "1.8.0",
 				/*expectedResult*/ true,
 			},
 			new object [] {
 				/*targetFrameworkVersion*/ "v6.0",
 				/*buildToolsVersion*/ "24.0.0",
 				/*JavaVersion*/ "1.7.0_101",
+				/*latestSupportedJavaVersion*/ "1.8.0",
 				/*expectedResult*/ true,
 			},
 			new object [] {
 				/*targetFrameworkVersion*/ "v6.0",
 				/*buildToolsVersion*/ "24.0.0",
 				/*JavaVersion*/ "1.6.0_101",
+				/*latestSupportedJavaVersion*/ "1.8.0",
 				/*expectedResult*/ false,
 			},
 			new object [] {
 				/*targetFrameworkVersion*/ "v5.0",
 				/*buildToolsVersion*/ "24.0.1",
 				/*JavaVersion*/ "1.8.0_101",
+				/*latestSupportedJavaVersion*/ "1.8.0",
 				/*expectedResult*/ true,
 			},
 			new object [] {
 				/*targetFrameworkVersion*/ "v5.0",
 				/*buildToolsVersion*/ "24.0.0",
 				/*JavaVersion*/ "1.7.0_101",
+				/*latestSupportedJavaVersion*/ "1.8.0",
 				/*expectedResult*/ true,
 			},
 			new object [] {
 				/*targetFrameworkVersion*/ "v5.0",
 				/*buildToolsVersion*/ "24.0.0",
 				/*JavaVersion*/ "1.6.0_101",
+				/*latestSupportedJavaVersion*/ "1.8.0",
 				/*expectedResult*/ true,
 			},
 			new object [] {
 				/*targetFrameworkVersion*/ "v5.0",
 				/*buildToolsVersion*/ "24.0.1",
 				/*JavaVersion*/ "1.6.0_101",
+				/*latestSupportedJavaVersion*/ "1.8.0",
 				/*expectedResult*/ false,
 			},
 			new object [] {
 				/*targetFrameworkVersion*/ "v7.1",
 				/*buildToolsVersion*/ "24.0.1",
 				/*JavaVersion*/ "1.6.x_101",
+				/*latestSupportedJavaVersion*/ "1.8.0",
 				/*expectedResult*/ true,
+			},
+			new object [] {
+				/*targetFrameworkVersion*/ "v8.1",
+				/*buildToolsVersion*/ "24.0.1",
+				/*JavaVersion*/ "9.0.4",
+				/*latestSupportedJavaVersion*/ "1.8.0",
+				/*expectedResult*/ false,
 			},
 		};
 #pragma warning restore 414
 
 		[Test]
 		[TestCaseSource ("validateJavaVersionTestCases")]
-		public void ValidateJavaVersion (string targetFrameworkVersion, string buildToolsVersion, string javaVersion, bool expectedResult) 
+		public void ValidateJavaVersion (string targetFrameworkVersion, string buildToolsVersion, string javaVersion, string latestSupportedJavaVersion, bool expectedResult) 
 		{
-			var path = Path.Combine ("temp", $"ValidateJavaVersion_{targetFrameworkVersion}_{buildToolsVersion}_{javaVersion}");
+			var path = Path.Combine ("temp", $"ValidateJavaVersion_{targetFrameworkVersion}_{buildToolsVersion}_{latestSupportedJavaVersion}_{javaVersion}");
 			string javaExe = "java";
 			var javaPath = CreateFauxJavaSdkDirectory (Path.Combine (path, "JavaSDK"), javaVersion, out javaExe);
 			var AndroidSdkDirectory = CreateFauxAndroidSdkDirectory (Path.Combine (path, "android-sdk"), buildToolsVersion);
@@ -2142,10 +2160,11 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 					$"JavaToolExe={javaExe}",
 					$"AndroidSdkBuildToolsVersion={buildToolsVersion}",
 					$"AndroidSdkDirectory={AndroidSdkDirectory}",
+					$"LatestSupportedJavaVersion={latestSupportedJavaVersion}",
 				}), string.Format ("Build should have {0}", expectedResult ? "succeeded" : "failed"));
 			}
-			Directory.Delete (javaPath, recursive: true);
-			Directory.Delete (AndroidSdkDirectory, recursive: true);
+			//Directory.Delete (javaPath, recursive: true);
+			//Directory.Delete (AndroidSdkDirectory, recursive: true);
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -5,8 +5,8 @@
 		<DependsOnSystemRuntime Condition=" '$(DependsOnSystemRuntime)' == '' ">true</DependsOnSystemRuntime>
 		<CopyNuGetImplementations Condition=" '$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
 		<YieldDuringToolExecution Condition="'$(YieldDuringToolExecution)' == ''">true</YieldDuringToolExecution>
-		<LatestSupportedJavaVersion>1.8.0</LatestSupportedJavaVersion>
-		<MinimumSupportedJavaVersion>1.6.0</MinimumSupportedJavaVersion>
+		<LatestSupportedJavaVersion Condition="'$(LatestSupportedJavaVersion)' == ''">1.8.0</LatestSupportedJavaVersion>
+		<MinimumSupportedJavaVersion Condition="'$(MinimumSupportedJavaVersion)' == ''">1.6.0</MinimumSupportedJavaVersion>
 		<AndroidVersionCodePattern Condition=" '$(AndroidUseLegacyVersionCode)' != 'True' And '$(AndroidVersionCodePattern)' == '' ">{abi}{versionCode:D5}</AndroidVersionCodePattern>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes #1248

JDK 9 doesn't currently provide a robust and reliable user
experience. Until we can provide a reliable experience, we
should "fail early".

We already have a property for `$(LatestSupportedJavaVersion)`
which currently cannot be overridden. We also currently emit
a warning when the java version is greater than this property.
However with JDK 9 it seems a warning is not enough. So we
should change the warning to an error. We also need to make
`$(LatestSupportedJavaVersion)` writable so that it can be
overridden from the command line via.

	msbuild /p:LatestSupportedJavaVersion=9.0.0 /t:SignAndroidPackage TheApp.csproj