### PR TITLE
[Tasks] Add aot to the list of valid profilers

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -437,6 +437,7 @@ namespace Xamarin.Android.Tasks
 		};
 
 		public static readonly string[] ValidProfilers = new[]{
+			"aot",
 			"log",
 		};
 


### PR DESCRIPTION
With this change it is possible to build an apk containing `aot`
profiler module (libmono-profiler-aot.so shared library) and profile
the app with it. It can enabled by setting `mono.debug.profile`
property to `aot` on the device or emulator.

Note that the `aot` profiler saves the data during the mono
runtime shutdown. So one way (only way?) to get the data is to call
`System.Environment.Exit` to end the XA app. Currently  there is
an issue with Java.Interop, where during the shutdown we get
an unhandled exception and thus the shutdown process doesn't
finish, which means the profile output is not written to the file.
Hopefully I can fix that soon.