### PR TITLE
[Xamarin.Android.Build.Tasks] Stop IncrementalClean removing assemblies.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Common/ImportAfter/Xamarin.Android.Windows.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Common/ImportAfter/Xamarin.Android.Windows.targets
@@ -11,16 +11,16 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 
 	<PropertyGroup>
 		<Debugger Condition="'$(Debugger)'==''">Xamarin</Debugger>
+		<_IsRunningXBuild Condition=" '$(MSBuildRuntimeVersion)' == '' ">true</_IsRunningXBuild>
 	</PropertyGroup>
 
-	<Target Name="_RegisterMdbFilesWithFileWrites" BeforeTargets="IncrementalClean">  
-		<CreateItem Include="$(OutDir)*.dll.mdb;$(MonoAndroidIntermediateAssemblyDir)*.dll.mdb;$(MonoAndroidIntermediateAssemblyDir)*.pdb;$(MonoAndroidLinkerInputDir)*.dll.mdb;$(MonoAndroidLinkerInputDir)*.pdb;$(_AndroidManagedResourceDesignerFile)">  
-			<Output TaskParameter="Include" ItemName="_FilesToRegister" />  
-		</CreateItem>  
+	<Target Name="_RegisterAndroidFilesWithFileWrites" BeforeTargets="IncrementalClean" Condition=" '$(_IsRunningXBuild)' == 'false' ">  
+		<CreateItem Include="$(OutDir)*.pdb;$(OutDir)*.dll;$(OutDir)*.dll.mdb;$(MonoAndroidIntermediateAssemblyDir)*.dll.mdb;$(MonoAndroidIntermediateAssemblyDir)*.pdb;$(MonoAndroidLinkerInputDir)*.dll.mdb;$(MonoAndroidLinkerInputDir)*.pdb;$(_AndroidManagedResourceDesignerFile)">  
+			<Output TaskParameter="Include" ItemName="_FilesToRegister" />
+		</CreateItem>
 		<CreateItem Include="$([System.IO.Path]::GetFullPath('%(_FilesToRegister.Identity)'))"
 				Condition="Exists('%(_FilesToRegister.Identity)')">  
 			<Output TaskParameter="Include" ItemName="_CleanCurrentFileWrites" />  
 		</CreateItem>
 	</Target>
-	
 </Project>


### PR DESCRIPTION
Fixes #1164
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=61108

The IncrementalClean target basically deletes a ton of stuff
if its not in the FileWrites group. Under certain conditons
this include assemblies in the `$(OutDir)`.
It mainly effects projects which use a shared `$(OutDir)`.
So it a third level dependency is copied to the `$(OutDir)`
but is not referenced by the main app project we end up with
IncrementalClean deleting the file. This then breaks packaging
since we expect the file to exist.
This causes problems with TFS because it seems to ALWAYS use
a shared `$(OutDir)`.
To work around this problem we just need to tell IncrementalClean
to ignore any dll in the `$(OutDir)`. Since we already have a
target in place to handle this we can just expand the list of
files it should be ignoring.