### PR TITLE
[Xamarin.Android.Build.Tasks] Fix Conditon on _RegisterAndroidFilesWithFileWrites

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Common/ImportAfter/Xamarin.Android.Windows.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Common/ImportAfter/Xamarin.Android.Windows.targets
@@ -14,7 +14,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 		<_IsRunningXBuild Condition=" '$(MSBuildRuntimeVersion)' == '' ">true</_IsRunningXBuild>
 	</PropertyGroup>
 
-	<Target Name="_RegisterAndroidFilesWithFileWrites" BeforeTargets="IncrementalClean" Condition=" '$(_IsRunningXBuild)' == 'false' ">  
+	<Target Name="_RegisterAndroidFilesWithFileWrites" BeforeTargets="IncrementalClean" Condition=" '$(_IsRunningXBuild)' != 'true' ">  
 		<CreateItem Include="$(OutDir)*.pdb;$(OutDir)*.dll;$(OutDir)*.dll.mdb;$(MonoAndroidIntermediateAssemblyDir)*.dll.mdb;$(MonoAndroidIntermediateAssemblyDir)*.pdb;$(MonoAndroidLinkerInputDir)*.dll.mdb;$(MonoAndroidLinkerInputDir)*.pdb;$(_AndroidManagedResourceDesignerFile)">  
 			<Output TaskParameter="Include" ItemName="_FilesToRegister" />
 		</CreateItem>


### PR DESCRIPTION
Commit 20123b5 broke the build system on windows. The
condition on `_RegisterAndroidFilesWithFileWrites` was
incorrect. `_IsRunningXBuild` can be empty when running
under MSbuild. As a result the condition will always
result in the target being skipped.

This commit fixes the condition to that it will run
correctly under msbuild and is skipped on xbuild.