### PR TITLE
[Xamarin.Android.Build.Tasks] Add `AndroidAarLibrary` Build Action

### DIFF
--- a/Documentation/build_process.md
+++ b/Documentation/build_process.md
@@ -897,6 +897,20 @@ Item Attribute Name
           </AndroidNativeLibrary>
         </ItemGroup>
 
+<a name="AndroidAarLibrary" class="injected"></a>
+
+## AndroidAarLibrary
+
+The Build action of `AndroidAarLibrary` should be used to directly
+reference .aar files. This build action will be most commonly used
+by Xamarin Components. Namely to include references to .aar files 
+which are required to get Google Play and other services working.
+
+Files with this Build action will be treated in a similar fashion too
+the embedded resources found in Library projects. The .aar will be 
+extracted into the intermediate directory. Then any assets, resource
+and .jar files will be included in the appropriate item groups.  
+
 ## Content
 
 The normal `Content` Build action is not supported (as we

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidBuildActions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidBuildActions.cs
@@ -11,6 +11,7 @@ namespace Xamarin.ProjectTools
 	{
 		public const string AndroidResource = "AndroidResource";
 		public const string AndroidAsset = "AndroidAsset";
+		public const string AndroidAarLibrary = "AndroidAarLibrary";
 		public const string AndroidEnvironment = "AndroidEnvironment";
 		public const string AndroidInterfaceDescription = "AndroidInterfaceDescription";
 		public const string AndroidJavaSource = "AndroidJavaSource";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidItem.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidItem.cs
@@ -144,5 +144,15 @@ namespace Xamarin.ProjectTools
 			{
 			}
 		}
+		public class AndroidAarLibrary : BuildItem {
+			public AndroidAarLibrary (string include)
+				: this (() => include)
+			{
+			}
+			public AndroidAarLibrary (Func<string> include)
+				: base (AndroidBuildActions.AndroidAarLibrary, include)
+			{
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -250,6 +250,13 @@ namespace Xamarin.Android.Tools {
 			return updated;
 		}
 
+		public static string HashString (string s)
+		{
+			using (HashAlgorithm hashAlg = new SHA1Managed ()) {
+				return HashFile (s, hashAlg);
+			}
+		}
+
 		public static string HashFile (string filename)
 		{
 			using (HashAlgorithm hashAlg = new SHA1Managed ()) {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -311,6 +311,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 		CacheFile="$(_AndroidLibraryProjectImportsCache)"
 		DesignTimeBuild="$(DesignTimeBuild)"
 		Assemblies="@(ReferencePath);@(ReferenceDependencyPaths)"
+		AarLibraries="@(AndroidAarLibrary)"
 		ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
 		UseShortFileNames="$(UseShortFileNames)"
 		OutputDirectory="$(IntermediateOutputPath)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1177,6 +1177,7 @@ because xbuild doesn't support framework reference assemblies.
 		CacheFile="$(_AndroidLibraryProjectImportsCache)"
 		DesignTimeBuild="$(DesignTimeBuild)"
 		Assemblies="@(ReferencePath);@(ReferenceDependencyPaths)"
+		AarLibraries="@(AndroidAarLibrary)"
 		ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
 		UseShortFileNames="$(UseShortFileNames)"
 		OutputDirectory="$(IntermediateOutputPath)"


### PR DESCRIPTION
Our components team currently have to go through a ton
of hoops to include .aar files in the build system.
Because we are not allowed to ship some of the google .aar
files with the Nuget packasges they need to be downloaded
on demand. To work within the current build system these
.aar files then need to be unpacked, restructured,
compressed and included in the Nuget assembly as an
EmbeddedResource. This requires updating the assembly
after it has been downloaded from nuget.

With the introduction of the `AndroidAarLibrary` build
action we can remove the rebuilding of the Nuget assembly
completely. The new system will still download the required
.aar files on demand. But instead of repacking them into
the .dll, the Nuget .targets file will simply add these
.aar files to the `AndroidAarLibrary` ItemGroup. These
Items will then be picked up by the `ResolveLibraryProjectImports`
task. They will then be extracted into the `$(IntermediateOutputDir)`.
From there the resources, assets and .jar files in the .aar will
then be included in the build system of the application.