### PR TITLE
Fix build with msbuild on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export OS            := $(shell uname)
+export OS_NAME       := $(shell uname)
 export OS_ARCH       := $(shell uname -m)
 export NO_SUDO ?= false
 V             ?= 0
@@ -53,11 +53,11 @@ uninstall::
 	rm "$(prefix)/lib/mono/xbuild/Xamarin/Android"
 	rm "$(prefix)/lib/mono/xbuild-frameworks/MonoAndroid"
 
-ifeq ($(OS),Linux)
+ifeq ($(OS_NAME),Linux)
 export LINUX_DISTRO         := $(shell lsb_release -i -s || true)
 export LINUX_DISTRO_RELEASE := $(shell lsb_release -r -s || true)
 prepare:: linux-prepare
-endif # $(OS)=Linux
+endif # $(OS_NAME)=Linux
 
 prepare:: prepare-msbuild
 

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -10,13 +10,13 @@ GIT_COMMIT        = $(shell LANG=C git log --no-color --first-parent -n1 --prett
 # "0" when commit hash is invalid (e.g. 00000000)
 -num-commits-since-version-change = $(shell LANG=C git log $(-commit-of-last-version-change)..HEAD --oneline 2>/dev/null | wc -l | sed 's/ //g')
 
-ifeq ($(OS),Linux)
+ifeq ($(OS_NAME),Linux)
 ZIP_EXTENSION         = tar.bz2
 else
 ZIP_EXTENSION         = zip
 endif
 
-ZIP_OUTPUT_BASENAME   = xamarin.android-oss_v$(PRODUCT_VERSION).$(-num-commits-since-version-change)_$(OS)-$(OS_ARCH)_$(GIT_BRANCH)_$(GIT_COMMIT)
+ZIP_OUTPUT_BASENAME   = xamarin.android-oss_v$(PRODUCT_VERSION).$(-num-commits-since-version-change)_$(OS_NAME)-$(OS_ARCH)_$(GIT_BRANCH)_$(GIT_COMMIT)
 ZIP_OUTPUT            = $(ZIP_OUTPUT_BASENAME).$(ZIP_EXTENSION)
 
 
@@ -54,7 +54,7 @@ ALL_AOT_ABIS = \
 	x86 \
 	x86_64 \
 
-ifneq ($(OS),Linux)
+ifneq ($(OS_NAME),Linux)
 ALL_HOST_ABIS += \
 	mxe-Win32 \
 	mxe-Win64
@@ -67,7 +67,7 @@ ALL_AOT_ABIS += \
 	win-x86_64
 endif
 
-ifneq ($(OS),Linux)
+ifneq ($(OS_NAME),Linux)
 MONO_OPTIONS += --arch=64
 endif
 

--- a/build-tools/scripts/msbuild.mk
+++ b/build-tools/scripts/msbuild.mk
@@ -14,7 +14,7 @@
 #   $(CONFIGURATION): Build configuration name, e.g. Debug or Release
 #   $(MSBUILD): The MSBuild program to use.
 #   $(MSBUILD_ARGS): Extra arguments to pass to $(MSBUILD); embedded into $(MSBUILD_FLAGS)
-#   $(OS): Operating system; used to determine `pkg-config` location
+#   $(OS_NAME): Operating system; used to determine `pkg-config` location
 #   $(V): Build verbosity
 #
 # Outputs:
@@ -25,11 +25,11 @@
 MSBUILD       = xbuild
 MSBUILD_FLAGS = /p:Configuration=$(CONFIGURATION) $(MSBUILD_ARGS)
 
-ifeq ($(OS),Darwin)
+ifeq ($(OS_NAME),Darwin)
 _PKG_CONFIG   = /Library/Frameworks/Mono.framework/Commands/pkg-config
-else    # $(OS) != Darwin
+else    # $(OS_NAME) != Darwin
 _PKG_CONFIG   = pkg-config
-endif   # $(OS) == Darwin
+endif   # $(OS_NAME) == Darwin
 
 ifneq ($(V),0)
 MSBUILD_FLAGS += /v:diag

--- a/build-tools/scripts/runtime-helpers.mk
+++ b/build-tools/scripts/runtime-helpers.mk
@@ -48,15 +48,15 @@ rebuild-bcl-assembly:
 	$(MSBUILD) /t:_InstallBcl $(MONO_RUNTIMES_PROJECT)
 
 rebuild-all-bcl:
-	@if [ ! -d $(MONO_RUNTIMES_BUILD_DIR)/host-$(OS) ]; then \
-		echo Host Mono runtime for $(OS) has not been built ; \
+	@if [ ! -d $(MONO_RUNTIMES_BUILD_DIR)/host-$(OS_NAME) ]; then \
+		echo Host Mono runtime for $(OS_NAME) has not been built ; \
 		echo or cached Mono runtime was installed ; \
-		echo In order to build host Mono for $(OS) please enable it in Configuration.Override.props file and ; \
+		echo In order to build host Mono for $(OS_NAME) please enable it in Configuration.Override.props file and ; \
 		echo Run the following command: make rebuild-mono ; \
 		echo Unable to rebuild all BCL assemblies ; \
 		exit 1 ; \
 	fi
-	make -C $(MONO_RUNTIMES_BUILD_DIR)/host-$(OS)
+	make -C $(MONO_RUNTIMES_BUILD_DIR)/host-$(OS_NAME)
 
 .PHONY: rebuild-bcl-assembly rebuild-all-bcl
 


### PR DESCRIPTION
XA's Makefile exports the OS environment variable set to output of the `uname -s` 
command which returns the operating system's name. On macOS it will return
`Darwin`, on Linux `Linux` etc. MSBuild (the build system, not the command)
defines a standard property `$(OS)` which names the operating system kind -
`Windows_NT` on Windows and `Unix` on *nix systems.

Our project and target files (also a large set of them from e.g. Mono) use the
property to check whether they are running on Unix or Windows and they rely on
the property's value to be set correctly to make the right decisions.
MSBuild (the system) supports setting of properties from the command line but it
also takes their values from the process environment. However, it appears
there's a major difference between Mono's xbuild (which is used by default by
XA) and msbuild in that xbuild "protects" the `OS` property by NOT using the
OS environment property to set its value, while msbuild sets the property from
the environment variable. This results in the property to have the value of
`Darwin` on macOS and `Linux` on Linux and it happens to work (more or less)
correctly on macOS because we do check for `'$(OS)' == 'Darwin' or '$(OS)' == 'Unix')` 
in a few places while we do NOT check for `'$(OS)' == 'Linux')`
anywhere. All this together breaks XA build on Linux in a few places.

This patch makes the msbuild build (`make MSBUILD=msbuild`) to work on Linux by
renaming the Make `$(OS)` variable to `$(CURRENT_OS)` and thus "protecting" the
standard value of the `$(OS)` property during the build.