### PR TITLE
Add sqlite3 package to Debian/Ubuntu dependencies

### DIFF
--- a/build-tools/scripts/dependencies/debian-common.sh
+++ b/build-tools/scripts/dependencies/debian-common.sh
@@ -14,6 +14,7 @@ DEBIAN_COMMON_DEPS="autoconf
 	openjdk-8-jdk
 	unzip
 	vim-common
+	sqlite3
 	"
 
 if [ "$OS_ARCH" = "x86_64" ]; then


### PR DESCRIPTION
The `sqlite3` command is used by build-tools/mono-runtimes/mono-runtimes.targets
during the build and is thus a hard dependency.