### PR TITLE
Normalize paths passed to api-merge

### DIFF
--- a/build-tools/api-merge/api-merge.cs
+++ b/build-tools/api-merge/api-merge.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Android.ApiMerge {
 				  v => glob = v },
 				{ "last-description=",
 				  "Last {DESCRIPTION} to process. Any later descriptions are ignored.",
-				  v => lastDescription = v },
+				  v => lastDescription = NormalizePath (v) },
 				{ "version",
 				  "Output version information and exit.",
 				  v => show_version = v != null },
@@ -69,12 +69,20 @@ namespace Xamarin.Android.ApiMerge {
 			SortSources (sources, glob);
 			ApiDescription context = new ApiDescription (sources [0]);
 			for (int i = 1; i < sources.Count; i++) {
-				if (sources [i-1] == lastDescription)
+				if (NormalizePath (sources [i-1]) == lastDescription)
 					break;
 				context.Merge (sources [i]);
 			}
 			context.Save (dest);
 			return 0;
+		}
+
+		static string NormalizePath (string path)
+		{
+			if (String.IsNullOrEmpty (path))
+				return path;
+
+			return Path.GetFullPath (path);
 		}
 
 		static void SortSources (List<string> sources, string globPattern)


### PR DESCRIPTION
Depending on whether api-merge is invoked by xbuild or msbuild, the paths passed
to the app can be relative, full or mixed. However, the code assumes that
they're all equal and compares them to know when to stop processing the passed
sources.

Since the assumption is wrong and it breaks our builds, this patch makes sure
that all paths are normalized before they are compared.