### PR TITLE
Fix builds when there Android toolchain directory doesn't exist yet

### DIFF
--- a/build-tools/api-xml-adjuster/api-xml-adjuster.csproj
+++ b/build-tools/api-xml-adjuster/api-xml-adjuster.csproj
@@ -47,6 +47,13 @@
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\android-toolchain\android-toolchain.csproj">
+      <Project>{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA}</Project>
+      <Name>android-toolchain</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="api-xml-adjuster.targets" />
 </Project>


### PR DESCRIPTION
Part of the XA build process is download and installation of Android SDK, NDK as
well as creation of native compilation toolchains. However, it appears that at
some point we regressed and stopped performing those tasks and, thus, the builds
fail when adjusting API description files with api-xml-adjuster since at this
point no SDK, NDK or toolchains are found. The download and installation of
those components is handled by the android-toolchain project which is dependent
upon by several other projects in XA that require the SDK and the NDK to be
present. android-xml-adjuster needs them as well but it hasn't dependent on
android-toolchain until this commit which adds a reference to the toolchain
project and fixes the build.