### PR TITLE
[Xamarin.Android.Build.Tasks] Add GetAndroidDependencies Target

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
@@ -48,13 +48,13 @@ namespace Xamarin.Android.Tasks
 				var manifest = AndroidAppManifest.Load (ManifestFile.ItemSpec, MonoAndroidHelper.SupportedVersions);
 				manifestApiLevel = manifest.TargetSdkVersion ?? manifest.MinSdkVersion ?? DefaultMinSDKVersion;
 			}
-			dependencies.Add (CreateAndroidDependency ("platform", $"{Math.Max (targetApiLevel.Value, manifestApiLevel)}"));
-			dependencies.Add (CreateAndroidDependency ("build-tool", BuildToolsVersion));
+			dependencies.Add (CreateAndroidDependency ("platform", $"android-{Math.Max (targetApiLevel.Value, manifestApiLevel)}"));
+			dependencies.Add (CreateAndroidDependency ("build-tools", BuildToolsVersion));
 			if (!string.IsNullOrEmpty (PlatformToolsVersion)) {
-				dependencies.Add (CreateAndroidDependency ("platform-tool", PlatformToolsVersion));
+				dependencies.Add (CreateAndroidDependency ("platform-tools", PlatformToolsVersion));
 			}
 			if (!string.IsNullOrEmpty (ToolsVersion)) {
-				dependencies.Add (CreateAndroidDependency ("tool", ToolsVersion));
+				dependencies.Add (CreateAndroidDependency ("tools", ToolsVersion));
 			}
 			if (!string.IsNullOrEmpty (NdkVersion)) {
 				dependencies.Add (CreateAndroidDependency ("ndk-bundle", NdkVersion));

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Android.Tasks
 				var manifest = AndroidAppManifest.Load (ManifestFile.ItemSpec, MonoAndroidHelper.SupportedVersions);
 				manifestApiLevel = manifest.TargetSdkVersion ?? manifest.MinSdkVersion ?? DefaultMinSDKVersion;
 			}
-			dependencies.Add (CreateAndroidDependency ("platform", $"android-{Math.Max (targetApiLevel.Value, manifestApiLevel)}"));
+			dependencies.Add (CreateAndroidDependency ("platforms", $"android-{Math.Max (targetApiLevel.Value, manifestApiLevel)}"));
 			dependencies.Add (CreateAndroidDependency ("build-tools", BuildToolsVersion));
 			if (!string.IsNullOrEmpty (PlatformToolsVersion)) {
 				dependencies.Add (CreateAndroidDependency ("platform-tools", PlatformToolsVersion));

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Collections.Generic;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -41,11 +42,11 @@ namespace Xamarin.Android.Tasks
 		public override bool Execute ()
 		{
 			var dependencies = new List<ITaskItem> ();
-			var targetApiLevel = MonoAndroidHelper.SupportedVersions.g (TargetFrameworkVersion);
+			var targetApiLevel = MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (TargetFrameworkVersion);
 			var manifestApiLevel = DefaultMinSDKVersion;
 			if (File.Exists (ManifestFile.ItemSpec)) {
 				var manifest = AndroidAppManifest.Load (ManifestFile.ItemSpec, MonoAndroidHelper.SupportedVersions);
-				var manifestApiLevel = manifest.TargetSdkVersion ?? manifest.MinSdkVersion ?? DefaultMinSDKVersion;
+				manifestApiLevel = manifest.TargetSdkVersion ?? manifest.MinSdkVersion ?? DefaultMinSDKVersion;
 			}
 			dependencies.Add (CreateAndroidDependency ("platform", $"{Math.Max (targetApiLevel.Value, manifestApiLevel)}"));
 			dependencies.Add (CreateAndroidDependency ("build-tool", BuildToolsVersion));

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
@@ -23,6 +23,8 @@ namespace Xamarin.Android.Tasks
 
 		public string ToolsVersion { get; set; }
 
+		public string NdkVersion { get; set; }
+
 		[Output]
 		public ITaskItem [] Dependencies { get; set; }
 
@@ -49,6 +51,9 @@ namespace Xamarin.Android.Tasks
 			}
 			if (!string.IsNullOrEmpty (ToolsVersion)) {
 				dependencies.Add (CreateAndroidDependency ("tool", ToolsVersion));
+			}
+			if (!string.IsNullOrEmpty (NdkVersion)) {
+				dependencies.Add (CreateAndroidDependency ("ndk-bundle", NdkVersion));
 			}
 			Dependencies = dependencies.ToArray ();
 			return !Log.HasLoggedErrors;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
@@ -48,8 +48,9 @@ namespace Xamarin.Android.Tasks
 				var manifest = AndroidAppManifest.Load (ManifestFile.ItemSpec, MonoAndroidHelper.SupportedVersions);
 				manifestApiLevel = manifest.TargetSdkVersion ?? manifest.MinSdkVersion ?? DefaultMinSDKVersion;
 			}
-			dependencies.Add (CreateAndroidDependency ("platforms", $"android-{Math.Max (targetApiLevel.Value, manifestApiLevel)}"));
-			dependencies.Add (CreateAndroidDependency ("build-tools", BuildToolsVersion));
+			var sdkVersion = Math.Max (targetApiLevel.Value, manifestApiLevel);
+			dependencies.Add (CreateAndroidDependency ($"platforms;android-{sdkVersion}", $"android-{sdkVersion}"));
+			dependencies.Add (CreateAndroidDependency ($"build-tools;{BuildToolsVersion}", BuildToolsVersion));
 			if (!string.IsNullOrEmpty (PlatformToolsVersion)) {
 				dependencies.Add (CreateAndroidDependency ("platform-tools", PlatformToolsVersion));
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
@@ -49,7 +49,7 @@ namespace Xamarin.Android.Tasks
 				manifestApiLevel = manifest.TargetSdkVersion ?? manifest.MinSdkVersion ?? DefaultMinSDKVersion;
 			}
 			var sdkVersion = Math.Max (targetApiLevel.Value, manifestApiLevel);
-			dependencies.Add (CreateAndroidDependency ($"platforms;android-{sdkVersion}", $"android-{sdkVersion}"));
+			dependencies.Add (CreateAndroidDependency ($"platforms;android-{sdkVersion}", $""));
 			dependencies.Add (CreateAndroidDependency ($"build-tools;{BuildToolsVersion}", BuildToolsVersion));
 			if (!string.IsNullOrEmpty (PlatformToolsVersion)) {
 				dependencies.Add (CreateAndroidDependency ("platform-tools", PlatformToolsVersion));

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks
+{
+	public class CalculateProjectDependencies : Task
+	{
+		const int DefaultMinSDKVersion = 11;
+
+		[Required]
+		public string TargetFrameworkVersion { get; set; }
+
+		[Required]
+		public ITaskItem ManifestFile { get; set; }
+
+		[Required]
+		public string BuildToolsVersion { get; set; }
+
+		public string PlatformToolsVersion { get; set; }
+
+		public string ToolsVersion { get; set; }
+
+		[Output]
+		public ITaskItem [] Dependencies { get; set; }
+
+		ITaskItem CreateAndroidDependency (string include, string version)
+		{
+			if (string.IsNullOrEmpty (version))
+				return new TaskItem (include);
+
+			return new TaskItem (include, new Dictionary<string, string> {
+				{ "Version", version }
+			});
+		}
+
+		public override bool Execute ()
+		{
+			var dependencies = new List<ITaskItem> ();
+			var targetApiLevel = MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (TargetFrameworkVersion);
+			var manifest = AndroidAppManifest.Load (ManifestFile.ItemSpec, MonoAndroidHelper.SupportedVersions);
+			var manifestApiLevel = manifest.TargetSdkVersion ?? manifest.MinSdkVersion ?? DefaultMinSDKVersion;
+			dependencies.Add (CreateAndroidDependency ("platform", $"{Math.Max (targetApiLevel.Value, manifestApiLevel)}"));
+			dependencies.Add (CreateAndroidDependency ("build-tool", BuildToolsVersion));
+			if (!string.IsNullOrEmpty (PlatformToolsVersion)) {
+				dependencies.Add (CreateAndroidDependency ("platform-tool", PlatformToolsVersion));
+			}
+			if (!string.IsNullOrEmpty (ToolsVersion)) {
+				dependencies.Add (CreateAndroidDependency ("tool", ToolsVersion));
+			}
+			Dependencies = dependencies.ToArray ();
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
@@ -41,9 +41,12 @@ namespace Xamarin.Android.Tasks
 		public override bool Execute ()
 		{
 			var dependencies = new List<ITaskItem> ();
-			var targetApiLevel = MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (TargetFrameworkVersion);
-			var manifest = AndroidAppManifest.Load (ManifestFile.ItemSpec, MonoAndroidHelper.SupportedVersions);
-			var manifestApiLevel = manifest.TargetSdkVersion ?? manifest.MinSdkVersion ?? DefaultMinSDKVersion;
+			var targetApiLevel = MonoAndroidHelper.SupportedVersions.g (TargetFrameworkVersion);
+			var manifestApiLevel = DefaultMinSDKVersion;
+			if (File.Exists (ManifestFile.ItemSpec)) {
+				var manifest = AndroidAppManifest.Load (ManifestFile.ItemSpec, MonoAndroidHelper.SupportedVersions);
+				var manifestApiLevel = manifest.TargetSdkVersion ?? manifest.MinSdkVersion ?? DefaultMinSDKVersion;
+			}
 			dependencies.Add (CreateAndroidDependency ("platform", $"{Math.Max (targetApiLevel.Value, manifestApiLevel)}"));
 			dependencies.Add (CreateAndroidDependency ("build-tool", BuildToolsVersion));
 			if (!string.IsNullOrEmpty (PlatformToolsVersion)) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
@@ -38,8 +38,14 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.AreEqual (5, task.Dependencies.Length);
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tools" && x.GetMetadata ("Version") == "26.0.1"),
 				"Dependencies should contains a build-tools version 26.0.1");
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "tools" && x.GetMetadata ("Version") == "26.0.1"),
+				"Dependencies should contains a tools version 26.0.1");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform" && x.GetMetadata ("Version") == "android-26"),
 				"Dependencies should contains a platform version android-26");
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform-tools" && x.GetMetadata ("Version") == "26.0.3"),
+				"Dependencies should contains a platform-tools version 26.0.3");
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "ndk-bundle" && x.GetMetadata ("Version") == "r12d"),
+				"Dependencies should contains a ndk-bundle version r12d");
 		}
 
 		[Test]
@@ -63,6 +69,9 @@ namespace Xamarin.Android.Build.Tests {
 	<uses-sdk android:minSdkVersion='10' />
 </manifest>");
 
+			task.PlatformToolsVersion = "26.0.3";
+			task.ToolsVersion = "26.0.1";
+			task.NdkVersion = "r12d";
 			task.BuildToolsVersion = "26.0.1";
 			task.TargetFrameworkVersion = "v8.0";
 			task.ManifestFile = new TaskItem (manifestFile);
@@ -70,11 +79,15 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.IsNotNull (task.Dependencies);
 			Assert.AreEqual (5, task.Dependencies.Length);
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tools" && x.GetMetadata ("Version") == "26.0.1"),
-				"Dependencies should contain a build-tools version 26.0.1");
+				"Dependencies should contains a build-tools version 26.0.1");
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "tools" && x.GetMetadata ("Version") == "26.0.1"),
+				"Dependencies should contains a tools version 26.0.1");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform" && x.GetMetadata ("Version") == "android-26"),
-				"Dependencies should contain a platform version android-26");
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform" && x.GetMetadata ("Version") == "android-10"),
-				"Dependencies should contain a platform version android-10");
+				"Dependencies should contains a platform version android-26");
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform-tools" && x.GetMetadata ("Version") == "26.0.3"),
+				"Dependencies should contains a platform-tools version 26.0.3");
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "ndk-bundle" && x.GetMetadata ("Version") == "r12d"),
+				"Dependencies should contains a ndk-bundle version r12d");
 
 			Directory.Delete (path, recursive: true);
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
@@ -27,16 +27,19 @@ namespace Xamarin.Android.Build.Tests {
 				BuildEngine = engine
 			};
 
+			task.PlatformToolsVersion = "26.0.3";
+			task.ToolsVersion = "26.0.1";
+			task.NdkVersion = "r12d";
 			task.BuildToolsVersion = "26.0.1";
 			task.TargetFrameworkVersion = "v8.0";
 			task.ManifestFile = new TaskItem (Path.Combine (path, "AndroidManifest.xml"));
 			Assert.IsTrue (task.Execute ());
 			Assert.IsNotNull (task.Dependencies);
-			Assert.AreEqual (4, task.Dependencies.Length);
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tool" && x.GetMetadata ("Version") == "26.0.1"),
-				"Dependencies should contains a build-tool version 26.0.1");
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform" && x.GetMetadata ("Version") == "26"),
-				"Dependencies should contains a platform version 26");
+			Assert.AreEqual (5, task.Dependencies.Length);
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tools" && x.GetMetadata ("Version") == "26.0.1"),
+				"Dependencies should contains a build-tools version 26.0.1");
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform" && x.GetMetadata ("Version") == "android-26"),
+				"Dependencies should contains a platform version android-26");
 		}
 
 		[Test]
@@ -66,12 +69,12 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.IsTrue(task.Execute ());
 			Assert.IsNotNull (task.Dependencies);
 			Assert.AreEqual (5, task.Dependencies.Length);
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tool" && x.GetMetadata ("Version") == "26.0.1"),
-				"Dependencies should contain a build-tool version 26.0.1");
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform" && x.GetMetadata ("Version") == "26"),
-				"Dependencies should contain a platform version 26");
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform" && x.GetMetadata ("Version") == "10"),
-				"Dependencies should contain a platform version 10");
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tools" && x.GetMetadata ("Version") == "26.0.1"),
+				"Dependencies should contain a build-tools version 26.0.1");
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform" && x.GetMetadata ("Version") == "android-26"),
+				"Dependencies should contain a platform version android-26");
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform" && x.GetMetadata ("Version") == "android-10"),
+				"Dependencies should contain a platform version android-10");
 
 			Directory.Delete (path, recursive: true);
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
@@ -36,11 +36,11 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.IsTrue (task.Execute ());
 			Assert.IsNotNull (task.Dependencies);
 			Assert.AreEqual (5, task.Dependencies.Length);
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tools" && x.GetMetadata ("Version") == "26.0.1"),
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tools;26.0.1" && x.GetMetadata ("Version") == "26.0.1"),
 				"Dependencies should contains a build-tools version 26.0.1");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "tools" && x.GetMetadata ("Version") == "26.0.1"),
 				"Dependencies should contains a tools version 26.0.1");
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platforms" && x.GetMetadata ("Version") == "android-26"),
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platforms;android-26" && x.GetMetadata ("Version") == "android-26"),
 				"Dependencies should contains a platform version android-26");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform-tools" && x.GetMetadata ("Version") == "26.0.3"),
 				"Dependencies should contains a platform-tools version 26.0.3");
@@ -78,11 +78,11 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.IsTrue(task.Execute ());
 			Assert.IsNotNull (task.Dependencies);
 			Assert.AreEqual (5, task.Dependencies.Length);
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tools" && x.GetMetadata ("Version") == "26.0.1"),
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tools;26.0.1" && x.GetMetadata ("Version") == "26.0.1"),
 				"Dependencies should contains a build-tools version 26.0.1");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "tools" && x.GetMetadata ("Version") == "26.0.1"),
 				"Dependencies should contains a tools version 26.0.1");
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platforms" && x.GetMetadata ("Version") == "android-26"),
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platforms;android-26" && x.GetMetadata ("Version") == "android-26"),
 				"Dependencies should contains a platform version android-26");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform-tools" && x.GetMetadata ("Version") == "26.0.3"),
 				"Dependencies should contains a platform-tools version 26.0.3");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
@@ -40,7 +40,7 @@ namespace Xamarin.Android.Build.Tests {
 				"Dependencies should contains a build-tools version 26.0.1");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "tools" && x.GetMetadata ("Version") == "26.0.1"),
 				"Dependencies should contains a tools version 26.0.1");
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform" && x.GetMetadata ("Version") == "android-26"),
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platforms" && x.GetMetadata ("Version") == "android-26"),
 				"Dependencies should contains a platform version android-26");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform-tools" && x.GetMetadata ("Version") == "26.0.3"),
 				"Dependencies should contains a platform-tools version 26.0.3");
@@ -82,7 +82,7 @@ namespace Xamarin.Android.Build.Tests {
 				"Dependencies should contains a build-tools version 26.0.1");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "tools" && x.GetMetadata ("Version") == "26.0.1"),
 				"Dependencies should contains a tools version 26.0.1");
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform" && x.GetMetadata ("Version") == "android-26"),
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platforms" && x.GetMetadata ("Version") == "android-26"),
 				"Dependencies should contains a platform version android-26");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform-tools" && x.GetMetadata ("Version") == "26.0.3"),
 				"Dependencies should contains a platform-tools version 26.0.3");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using NUnit.Framework;
+using Xamarin.ProjectTools;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using System.Text;
+using Xamarin.Android.Tasks;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Build.Tests {
+
+	[TestFixture]
+	[Parallelizable (ParallelScope.Children)]
+	public class GetDependenciesTest : BaseTest {
+		
+		[Test]
+		public void ManifestFileDoesNotExist ()
+		{
+			IBuildEngine engine = new MockBuildEngine (TestContext.Out);
+			var task = new CalculateProjectDependencies {
+				BuildEngine = engine
+			};
+
+			task.BuildToolsVersion = "26.0.1";
+			task.TargetFrameworkVersion = "v8.0";
+			task.ManifestFile = new TaskItem ("AndroidManifest.xml");
+			task.Execute ();
+			Assert.IsNotNull (task.Dependencies);
+			Assert.AreEqual (4, task.Dependencies.Length);
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tool" && x.GetMetadata ("Version") == "26.0.1"),
+				"Dependencies should contains a build-tool version 26.0.1");
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform" && x.GetMetadata ("Version") == "26"),
+				"Dependencies should contains a platform version 26");
+		}
+
+		[Test]
+		public void ManifestFileExists ()
+		{
+			IBuildEngine engine = new MockBuildEngine (TestContext.Out);
+			var task = new CalculateProjectDependencies {
+				BuildEngine = engine
+			};
+
+			var path = Path.Combine (Root, "temp", TestName);
+			Directory.CreateDirectory (path);
+			var manifestFile = Path.Combine (path, "AndroidManifest.xml");
+			File.WriteAllText (manifestFile, @"<?xml version='1.0' ?>
+<manifest xmlns:android='http://schemas.android.com/apk/res/android' android:versionCode='1' android:versionName='1.0' package='Mono.Android_Tests'>
+	<uses-sdk android:minSdkVersion='10' />
+</manifest>");
+
+			task.BuildToolsVersion = "26.0.1";
+			task.TargetFrameworkVersion = "v8.0";
+			task.ManifestFile = new TaskItem (manifestFile);
+			Assert.IsTrue(task.Execute ());
+			Assert.IsNotNull (task.Dependencies);
+			Assert.AreEqual (5, task.Dependencies.Length);
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tool" && x.GetMetadata ("Version") == "26.0.1"),
+				"Dependencies should contain a build-tool version 26.0.1");
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform" && x.GetMetadata ("Version") == "26"),
+				"Dependencies should contain a platform version 26");
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform" && x.GetMetadata ("Version") == "10"),
+				"Dependencies should contain a platform version 10");
+
+			Directory.Delete (path, recursive: true);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
@@ -17,6 +17,11 @@ namespace Xamarin.Android.Build.Tests {
 		[Test]
 		public void ManifestFileDoesNotExist ()
 		{
+			var path = Path.Combine ("temp", TestName);
+			var referencePath = CreateFauxReferencesDirectory (Path.Combine (path, "references"), new ApiInfo[] {
+				new ApiInfo () { Id = 26, Level = 26, Name = "Oreo", FrameworkVersion = "v8.0", Stable = true },
+			} );
+			MonoAndroidHelper.RefreshSupportedVersions (new string [] { referencePath });
 			IBuildEngine engine = new MockBuildEngine (TestContext.Out);
 			var task = new CalculateProjectDependencies {
 				BuildEngine = engine
@@ -24,8 +29,8 @@ namespace Xamarin.Android.Build.Tests {
 
 			task.BuildToolsVersion = "26.0.1";
 			task.TargetFrameworkVersion = "v8.0";
-			task.ManifestFile = new TaskItem ("AndroidManifest.xml");
-			task.Execute ();
+			task.ManifestFile = new TaskItem (Path.Combine (path, "AndroidManifest.xml"));
+			Assert.IsTrue (task.Execute ());
 			Assert.IsNotNull (task.Dependencies);
 			Assert.AreEqual (4, task.Dependencies.Length);
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tool" && x.GetMetadata ("Version") == "26.0.1"),
@@ -37,12 +42,17 @@ namespace Xamarin.Android.Build.Tests {
 		[Test]
 		public void ManifestFileExists ()
 		{
+			var path = Path.Combine (Root, "temp", TestName);
+			var referencePath = CreateFauxReferencesDirectory (Path.Combine (path, "references"), new ApiInfo[] {
+				new ApiInfo () { Id = 26, Level = 26, Name = "Oreo", FrameworkVersion = "v8.0", Stable = true },
+			} );
+			MonoAndroidHelper.RefreshSupportedVersions (new string [] { referencePath });
 			IBuildEngine engine = new MockBuildEngine (TestContext.Out);
 			var task = new CalculateProjectDependencies {
 				BuildEngine = engine
 			};
 
-			var path = Path.Combine (Root, "temp", TestName);
+
 			Directory.CreateDirectory (path);
 			var manifestFile = Path.Combine (path, "AndroidManifest.xml");
 			File.WriteAllText (manifestFile, @"<?xml version='1.0' ?>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
@@ -40,7 +40,7 @@ namespace Xamarin.Android.Build.Tests {
 				"Dependencies should contains a build-tools version 26.0.1");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "tools" && x.GetMetadata ("Version") == "26.0.1"),
 				"Dependencies should contains a tools version 26.0.1");
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platforms;android-26" && x.GetMetadata ("Version") == "android-26"),
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platforms;android-26" && x.GetMetadata ("Version") == ""),
 				"Dependencies should contains a platform version android-26");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform-tools" && x.GetMetadata ("Version") == "26.0.3"),
 				"Dependencies should contains a platform-tools version 26.0.3");
@@ -82,7 +82,7 @@ namespace Xamarin.Android.Build.Tests {
 				"Dependencies should contains a build-tools version 26.0.1");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "tools" && x.GetMetadata ("Version") == "26.0.1"),
 				"Dependencies should contains a tools version 26.0.1");
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platforms;android-26" && x.GetMetadata ("Version") == "android-26"),
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platforms;android-26" && x.GetMetadata ("Version") == ""),
 				"Dependencies should contains a platform version android-26");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform-tools" && x.GetMetadata ("Version") == "26.0.3"),
 				"Dependencies should contains a platform-tools version 26.0.3");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Android.Build.Tests {
 
 			task.PlatformToolsVersion = "26.0.3";
 			task.ToolsVersion = "26.0.1";
-			task.NdkVersion = "r12d";
+			task.NdkVersion = "12.1";
 			task.BuildToolsVersion = "26.0.1";
 			task.TargetFrameworkVersion = "v8.0";
 			task.ManifestFile = new TaskItem (Path.Combine (path, "AndroidManifest.xml"));
@@ -44,8 +44,8 @@ namespace Xamarin.Android.Build.Tests {
 				"Dependencies should contains a platform version android-26");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform-tools" && x.GetMetadata ("Version") == "26.0.3"),
 				"Dependencies should contains a platform-tools version 26.0.3");
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "ndk-bundle" && x.GetMetadata ("Version") == "r12d"),
-				"Dependencies should contains a ndk-bundle version r12d");
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "ndk-bundle" && x.GetMetadata ("Version") == "12.1"),
+				"Dependencies should contains a ndk-bundle version 12.1");
 		}
 
 		[Test]
@@ -71,7 +71,7 @@ namespace Xamarin.Android.Build.Tests {
 
 			task.PlatformToolsVersion = "26.0.3";
 			task.ToolsVersion = "26.0.1";
-			task.NdkVersion = "r12d";
+			task.NdkVersion = "12.1";
 			task.BuildToolsVersion = "26.0.1";
 			task.TargetFrameworkVersion = "v8.0";
 			task.ManifestFile = new TaskItem (manifestFile);
@@ -86,8 +86,8 @@ namespace Xamarin.Android.Build.Tests {
 				"Dependencies should contains a platform version android-26");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform-tools" && x.GetMetadata ("Version") == "26.0.3"),
 				"Dependencies should contains a platform-tools version 26.0.3");
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "ndk-bundle" && x.GetMetadata ("Version") == "r12d"),
-				"Dependencies should contains a ndk-bundle version r12d");
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "ndk-bundle" && x.GetMetadata ("Version") == "12.1"),
+				"Dependencies should contains a ndk-bundle version 12.1");
 
 			Directory.Delete (path, recursive: true);
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -131,14 +131,29 @@ namespace Xamarin.Android.Build.Tests
 			return androidSdkDirectory;
 		}
 
-		protected string CreateFauxReferencesDirectory (string path, string[] versions)
+		public struct ApiInfo {
+			public int Id;
+			public int Level;
+			public string Name;
+			public string FrameworkVersion;
+			public bool Stable;
+		}
+
+		protected string CreateFauxReferencesDirectory (string path, ApiInfo [] versions)
 		{
+
 			string referencesDirectory = Path.Combine (Root, path);
 			Directory.CreateDirectory (referencesDirectory);
-			Directory.CreateDirectory (Path.Combine (referencesDirectory, "v1.0"));
-			File.WriteAllText (Path.Combine (referencesDirectory, "v1.0", "mscorlib.dll"), "");
-			foreach (var v in versions){
-				Directory.CreateDirectory (Path.Combine (referencesDirectory, v));
+			Directory.CreateDirectory (Path.Combine (referencesDirectory, "MonoAndroid", "v1.0"));
+			File.WriteAllText (Path.Combine (referencesDirectory, "MonoAndroid", "v1.0", "mscorlib.dll"), "");
+			foreach (var v in versions) {
+				Directory.CreateDirectory (Path.Combine (referencesDirectory, "MonoAndroid", v.FrameworkVersion));
+				Directory.CreateDirectory (Path.Combine (referencesDirectory, "MonoAndroid", v.FrameworkVersion, "RedistList"));
+				File.WriteAllText (Path.Combine (referencesDirectory, "MonoAndroid", v.FrameworkVersion, "MonoAndroid.dll"), "");
+				File.WriteAllText (Path.Combine (referencesDirectory, "MonoAndroid", v.FrameworkVersion, "AndroidApiInfo.xml"),
+					$"<AndroidApiInfo>\n<Id>{v.Id}</Id>\n<Level>{v.Level}</Level>\n<Name>{v.Name}</Name>\n<Version>{v.FrameworkVersion}</Version>\n<Stable>{v.Stable}</Stable>\n</AndroidApiInfo>");
+				File.WriteAllText (Path.Combine (referencesDirectory, "MonoAndroid", v.FrameworkVersion, "RedistList", "FrameworkList.xml"),
+					$"<FileList Redist=\"MonoAndroid\" Name=\"Xamarin.Android {v.FrameworkVersion} Support\" IncludeFramework=\"v1.0\"></FileList>");
 			}
 			return referencesDirectory;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/MockBuildEngine.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/MockBuildEngine.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+
+namespace Xamarin.Android.Build.Tests {
+	public class MockBuildEngine : IBuildEngine, IBuildEngine2, IBuildEngine3, IBuildEngine4 {
+		public MockBuildEngine (TextWriter output)
+		{
+			this.Output = output;
+		}
+
+		private TextWriter Output { get; }
+
+		int IBuildEngine.ColumnNumberOfTaskNode => -1;
+
+		bool IBuildEngine.ContinueOnError => false;
+
+		int IBuildEngine.LineNumberOfTaskNode => -1;
+
+		string IBuildEngine.ProjectFileOfTaskNode => "this.xml";
+
+		bool IBuildEngine2.IsRunningMultipleNodes => false;
+
+		bool IBuildEngine.BuildProjectFile (string projectFileName, string [] targetNames, IDictionary globalProperties, IDictionary targetOutputs) => true;
+
+		void IBuildEngine.LogCustomEvent (CustomBuildEventArgs e)
+		{
+			this.Output.WriteLine ($"Custom: {e.Message}");
+		}
+
+		void IBuildEngine.LogErrorEvent (BuildErrorEventArgs e)
+		{
+			this.Output.WriteLine ($"Error: {e.Message}");
+		}
+
+		void IBuildEngine.LogMessageEvent (BuildMessageEventArgs e)
+		{
+			this.Output.WriteLine ($"Message: {e.Message}");
+		}
+
+		void IBuildEngine.LogWarningEvent (BuildWarningEventArgs e)
+		{
+			this.Output.WriteLine ($"Warning: {e.Message}");
+		}
+
+		private Dictionary<object, object> Tasks = new Dictionary<object, object> ();
+
+		void IBuildEngine4.RegisterTaskObject (object key, object obj, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection)
+		{
+			Tasks.Add (key, obj);
+		}
+
+		object IBuildEngine4.GetRegisteredTaskObject (object key, RegisteredTaskObjectLifetime lifetime)
+		{
+			return null;
+		}
+
+		object IBuildEngine4.UnregisterTaskObject (object key, RegisteredTaskObjectLifetime lifetime)
+		{
+			var obj = Tasks [key];
+			Tasks.Remove (key);
+			return obj;
+		}
+
+		BuildEngineResult IBuildEngine3.BuildProjectFilesInParallel (string [] projectFileNames, string [] targetNames, IDictionary [] globalProperties, IList<string> [] removeGlobalProperties, string [] toolsVersion, bool returnTargetOutputs)
+		{
+			throw new NotImplementedException ();
+		}
+
+		void IBuildEngine3.Yield () { }
+
+		void IBuildEngine3.Reacquire () { }
+
+		bool IBuildEngine2.BuildProjectFile (string projectFileName, string [] targetNames, IDictionary globalProperties, IDictionary targetOutputs, string toolsVersion) => true;
+
+		bool IBuildEngine2.BuildProjectFilesInParallel (string [] projectFileNames, string [] targetNames, IDictionary [] globalProperties, IDictionary [] targetOutputsPerProject, string [] toolsVersion, bool useResultsCache, bool unloadProjectsOnCompletion) => true;
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
@@ -19,6 +19,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)PackagingTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\BaseTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\BuildHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\MockBuildEngine.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)Utilities\" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -72,5 +72,6 @@
     <Compile Include="BuildTest.OSS.cs" />
     <Compile Include="ManifestTest.OSS.cs" />
     <Compile Include="AndroidRegExTests.cs" />
+    <Compile Include="GetDependenciesTests.cs" />
   </ItemGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -187,6 +187,7 @@
     <Compile Include="Tasks\JavaToolTask.cs" />
     <Compile Include="Tasks\GenerateLayoutCodeBehind.cs" />
     <Compile Include="Tasks\CalculateLayoutCodeBehind.cs" />
+    <Compile Include="Tasks\CalculateProjectDependencies.cs" />
     <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\BitAccess.cs">
       <Link>pdb2mdb\BitAccess.cs</Link>
     </Compile>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2781,6 +2781,7 @@ because xbuild doesn't support framework reference assemblies.
     BuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
     PlatformToolsVersion="$(AndroidSdkPlatformToolsVersion)"
     ToolsVersion="$(AndroidSdkToolsVersion)"
+    NdkVersion="$(AndroidNdkVersion)"
   >
     <Output TaskParameter="Dependencies" ItemName="AndroidDependency" />
   </CalculateProjectDependencies>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -238,7 +238,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">27.0.3</AndroidSdkBuildToolsVersion>
 	<AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">27.0.1</AndroidSdkPlatformToolsVersion>
 	<AndroidSdkToolsVersion Condition="'$(AndroidSdkToolsVersion)' == ''">26.1.1</AndroidSdkToolsVersion>
-	<AndroidNdkVersion Condition="'$(AndroidNdkVersion)' == ''">r14b</AndroidNdkVersion>
+	<AndroidNdkVersion Condition="'$(AndroidNdkVersion)' == ''">16.1</AndroidNdkVersion>
 
 	<!-- Obsolete -->
 	<AndroidGdbDebugServer>None</AndroidGdbDebugServer>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -32,6 +32,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.BuildApk" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CalculateAdditionalResourceCacheDirectories" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CalculateLayoutCodeBehind" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.CalculateProjectDependencies" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CheckForRemovedItems" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CheckTargetFrameworks" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CompileToDalvik" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -2765,6 +2766,24 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="Install"
     Condition="'$(AndroidApplication)'!='' And $(AndroidApplication)"
     DependsOnTargets="$(InstallDependsOnTargets)">
+</Target>
+
+
+<!-- SDK Management Targets -->
+<Target Name="GetAndroidDependencies" DependsOnTargets="$(GetAndroidDependenciesDependsOn)" Returns="@(AndroidDependency)">
+  <PropertyGroup>
+    <_ProjectAndroidManifest>$(ProjectDir)$(AndroidManifest)</_ProjectAndroidManifest>
+  </PropertyGroup>
+  <Error Text="AndroidManifest file does not exist" Condition="'$(_ProjectAndroidManifest)'!='' And !Exists ('$(_ProjectAndroidManifest)')"/>
+  <CalculateProjectDependencies
+    TargetFrameworkVersion="$(TargetFrameworkVersion)"
+    ManifestFile="$(_ProjectAndroidManifest)"
+    BuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
+    PlatformToolsVersion="$(AndroidSdkPlatformToolsVersion)"
+    ToolsVersion="$(AndroidSdkToolsVersion)"
+  >
+    <Output TaskParameter="Dependencies" ItemName="AndroidDependency" />
+  </CalculateProjectDependencies>
 </Target>
 
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Common.Debugging.targets"


### PR DESCRIPTION
Fixes #1269

This commit adds the `GetAndroidDependencies` target to the
`Xamarin.Android.Common.targets`. Its purpose is to examine
the various settings in the project and report which android
sdk build-tools, platform-tools etc are required.

`GetAndroidDependencies` will output an @(AndroidDependency)
with Version metadata Valid component names are platform,
build-tool, platform-tool and tool.