### PR TITLE
[Xamarin.Android.Build.Tasks] Improve `javac -version` parsing

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -332,7 +332,7 @@ namespace Xamarin.Android.Tasks
 		// `java -version` will produce values such as:
 		//  java version "9.0.4"
 		//  java version "1.8.0_77"
-		static readonly Regex javaVersionRegex = new Regex (@"version ""(?<version>[\d\.]+)(_\d+)?""");
+		static readonly Regex javaVersionRegex = new Regex (@"version ""(?<version>[\d\.]+)(_d+)?[^""]*""");
 
 		Version GetJavaVersionForFramework (string targetFrameworkVersion)
 		{


### PR DESCRIPTION
The [Ubuntu build][0] is [failing][1]:

	warning : Failed to get the Java SDK version as it does not appear to contain a valid version number.
	`javac -version` returned:
	```openjdk version "1.8.0_03-Ubuntu"
	OpenJDK Runtime Environment (build 1.8.0_03-Ubuntu-8u77-b03-3ubuntu3-b03)
	OpenJDK 64-Bit Server VM (build 25.03-b03, mixed mode)
	```
	...
	Task "AdjustJavacVersionArguments"
	  …/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/Xamarin.Android.Common.targets:
	  error : Error executing task AdjustJavacVersionArguments: Required property 'JdkVersion' not set.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-linux/779/
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-linux/779/consoleText

This was introduced/broken by commit 0e1d1c8a, which turned
`AdjustJavacVersionArguments.JdkVersion` into a `[Required]`
parameter. The value for `AdjustJavacVersionArguments.JdkVersion`
comes from the `<ResolveSdks/>` task `JdkVersion` output parameter,
which itself comes from parsing `javac -version` output.

The problem is that the regex we used to parse the output of
`javac -version` wasn't properly parsing the output on Ubuntu:

	openjdk version "1.8.0_03-Ubuntu"

Specifically, the `-Ubuntu` text was causing the regex to not match.

Update the regex to be a bit more lenient, enabling it to work with
the Ubuntu `javac -version` output, which *should* allow the build to
progress further.