### PR TITLE
[Xamarin.Android.Build.Tasks] Only report `ndk-bundle` if required.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
@@ -26,6 +26,8 @@ namespace Xamarin.Android.Tasks
 
 		public string NdkVersion { get; set; }
 
+		public bool NdkRequired { get; set; }
+
 		[Output]
 		public ITaskItem [] Dependencies { get; set; }
 
@@ -57,7 +59,7 @@ namespace Xamarin.Android.Tasks
 			if (!string.IsNullOrEmpty (ToolsVersion)) {
 				dependencies.Add (CreateAndroidDependency ("tools", ToolsVersion));
 			}
-			if (!string.IsNullOrEmpty (NdkVersion)) {
+			if (!string.IsNullOrEmpty (NdkVersion) && NdkRequired) {
 				dependencies.Add (CreateAndroidDependency ("ndk-bundle", NdkVersion));
 			}
 			Dependencies = dependencies.ToArray ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Android.Build.Tests {
 			task.ManifestFile = new TaskItem (Path.Combine (path, "AndroidManifest.xml"));
 			Assert.IsTrue (task.Execute ());
 			Assert.IsNotNull (task.Dependencies);
-			Assert.AreEqual (5, task.Dependencies.Length);
+			Assert.AreEqual (ndkRequred ? 5 : 4, task.Dependencies.Length);
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tools;26.0.1" && x.GetMetadata ("Version") == "26.0.1"),
 				"Dependencies should contains a build-tools version 26.0.1");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "tools" && x.GetMetadata ("Version") == "26.0.1"),

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
@@ -13,6 +13,46 @@ namespace Xamarin.Android.Build.Tests {
 	[TestFixture]
 	[Parallelizable (ParallelScope.Children)]
 	public class GetDependenciesTest : BaseTest {
+
+		[Test]
+		public void CheckNdkBundle ([Values(true, false)] bool ndkRequred)
+		{
+			var path = Path.Combine ("temp", TestName);
+			var referencePath = CreateFauxReferencesDirectory (Path.Combine (path, "references"), new ApiInfo [] {
+				new ApiInfo () { Id = 26, Level = 26, Name = "Oreo", FrameworkVersion = "v8.0", Stable = true },
+			});
+			MonoAndroidHelper.RefreshSupportedVersions (new string [] { referencePath });
+			IBuildEngine engine = new MockBuildEngine (TestContext.Out);
+			var task = new CalculateProjectDependencies {
+				BuildEngine = engine
+			};
+
+			task.PlatformToolsVersion = "26.0.3";
+			task.ToolsVersion = "26.0.1";
+			task.NdkVersion = "12.1";
+			task.NdkRequired = ndkRequred;
+			task.BuildToolsVersion = "26.0.1";
+			task.TargetFrameworkVersion = "v8.0";
+			task.ManifestFile = new TaskItem (Path.Combine (path, "AndroidManifest.xml"));
+			Assert.IsTrue (task.Execute ());
+			Assert.IsNotNull (task.Dependencies);
+			Assert.AreEqual (5, task.Dependencies.Length);
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tools;26.0.1" && x.GetMetadata ("Version") == "26.0.1"),
+				"Dependencies should contains a build-tools version 26.0.1");
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "tools" && x.GetMetadata ("Version") == "26.0.1"),
+				"Dependencies should contains a tools version 26.0.1");
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platforms;android-26" && x.GetMetadata ("Version") == ""),
+				"Dependencies should contains a platform version android-26");
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform-tools" && x.GetMetadata ("Version") == "26.0.3"),
+				"Dependencies should contains a platform-tools version 26.0.3");
+			if (ndkRequred) {
+				Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "ndk-bundle" && x.GetMetadata ("Version") == "12.1"),
+					"Dependencies should contain a ndk-bundle version 12.1");
+			} else {
+				Assert.IsNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "ndk-bundle"),
+					"Dependencies should not contain a ndk-bundle item");
+			}
+		}
 		
 		[Test]
 		public void ManifestFileDoesNotExist ()
@@ -30,6 +70,7 @@ namespace Xamarin.Android.Build.Tests {
 			task.PlatformToolsVersion = "26.0.3";
 			task.ToolsVersion = "26.0.1";
 			task.NdkVersion = "12.1";
+			task.NdkRequired = true;
 			task.BuildToolsVersion = "26.0.1";
 			task.TargetFrameworkVersion = "v8.0";
 			task.ManifestFile = new TaskItem (Path.Combine (path, "AndroidManifest.xml"));
@@ -72,6 +113,7 @@ namespace Xamarin.Android.Build.Tests {
 			task.PlatformToolsVersion = "26.0.3";
 			task.ToolsVersion = "26.0.1";
 			task.NdkVersion = "12.1";
+			task.NdkRequired = true;
 			task.BuildToolsVersion = "26.0.1";
 			task.TargetFrameworkVersion = "v8.0";
 			task.ManifestFile = new TaskItem (manifestFile);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2773,6 +2773,8 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="GetAndroidDependencies" DependsOnTargets="$(GetAndroidDependenciesDependsOn)" Returns="@(AndroidDependency)">
   <PropertyGroup>
     <_ProjectAndroidManifest>$(ProjectDir)$(AndroidManifest)</_ProjectAndroidManifest>
+    <_NdkRequired Condition="'$(BundleAssemblies)' == 'True' Or '$(AotAssemblies)' == 'True'">true</_NdkRequired>
+    <_NdkRequired Condition="'$(_NdkRequired)' == ''">false</_NdkRequired>
   </PropertyGroup>
   <Error Text="AndroidManifest file does not exist" Condition="'$(_ProjectAndroidManifest)'!='' And !Exists ('$(_ProjectAndroidManifest)')"/>
   <CalculateProjectDependencies
@@ -2782,6 +2784,7 @@ because xbuild doesn't support framework reference assemblies.
     PlatformToolsVersion="$(AndroidSdkPlatformToolsVersion)"
     ToolsVersion="$(AndroidSdkToolsVersion)"
     NdkVersion="$(AndroidNdkVersion)"
+    NdkRequired="$(_NdkRequired)"
   >
     <Output TaskParameter="Dependencies" ItemName="AndroidDependency" />
   </CalculateProjectDependencies>


### PR DESCRIPTION
We should only list `ndk-bundle` in the AndroidDependencies if
the user is using Aot or MkBundle. Otherwise we will end up
downloading a ton of stuff we don't need.

This commit fixes the `CalculateProjectDependencies` to report
`ndk-bundle` if needed. It also adds a unit test to make sure
it is not included when it shouldn't be.