### PR TITLE
[api-xml-adjuster] Fix rebuilds

### DIFF
--- a/build-tools/api-xml-adjuster/api-xml-adjuster.targets
+++ b/build-tools/api-xml-adjuster/api-xml-adjuster.targets
@@ -17,8 +17,8 @@
   <Target Name="_ClassParse"
       BeforeTargets="_AdjustApiXml"
       DependsOnTargets="_DefineApiFiles"
-      Inputs="@(ApiFileDefinition -&gt; %(ApiFileDefinition.ParameterDescription))"
-      Outputs="@(ApiFileDefinition -&gt; %(ApiFileDefinition.ClassParseXml))">
+      Inputs="%(ApiFileDefinition.ParameterDescription)"
+      Outputs="%(ApiFileDefinition.ClassParseXml)">
     <PropertyGroup>
       <ClassParse>$(_TopDir)\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\class-parse.exe</ClassParse>
     </PropertyGroup>
@@ -31,8 +31,8 @@
   <Target Name="_AdjustApiXml"
       AfterTargets="Build"
       DependsOnTargets="_DefineApiFiles"
-      Inputs="@(ApiFileDefinition -&gt; %(ApiFileDefinition.ClassParseXml))"
-      Outputs="@(ApiFileDefinition -&gt; %(ApiFileDefinition.ApiAdjustedXml)">
+      Inputs="%(ApiFileDefinition.ClassParseXml)"
+      Outputs="%(ApiFileDefinition.ApiAdjustedXml)">
     <PropertyGroup>
       <ApiXmlAdjuster>$(_TopDir)\bin\Build$(Configuration)\api-xml-adjuster.exe</ApiXmlAdjuster>
     </PropertyGroup>


### PR DESCRIPTION
Ideally, project rebuilds when nothing has changed should be *fast*.

`api-xml-adjuster` isn't:

	$ time (cd build-tools/api-xml-adjuster ; xbuild)
	real	2m1.084s
	user	1m55.916s
	sys	0m8.853s

	# and the rebuild!
	$ time (cd build-tools/api-xml-adjuster ; xbuild)
	real	2m0.824s
	user	1m56.140s
	sys	0m8.600s

A *minimum* two minute+ rebuild -- when *nothing* has changed -- is a
surefire way to get really annoyed.

With diagnostic logging, we start to see the culprit:

	Target _ClassParse needs to be built as input file '@(ApiFileDefinition -> /Volumes/Seagate4TB/work/xamarin-android/build-tools/api-xml-adjuster/../../src/Mono.Android/Profiles/api-27.params.txt)' does not exist.

This in turn causes `class-parse.exe` and `api-xml-adjuster.exe` to be
*re-executed* on *every* `android.jar` on *every* build.

Fix this by correcting the `//Target/@Inputs` and `//Target/@Outputs`
for the `_ClassParse` and `_AdjustApiXml` tasks. After which,
no-change rebuilds are *significantly* faster:

	$ time (cd build-tools/api-xml-adjuster ; xbuild)
	real	0m5.308s
	user	0m6.042s
	sys	0m1.237s