### PR TITLE
[Xamarin.Android.Build.Tasks] Fragments & CodeBehind

### DIFF
--- a/src/Mono.Android/Test/Mono.Android-Tests.csproj
+++ b/src/Mono.Android/Test/Mono.Android-Tests.csproj
@@ -97,6 +97,8 @@
     <AndroidResource Include="Resources\drawable\android_focused.png" />
     <AndroidResource Include="Resources\drawable\android_normal.png" />
     <AndroidResource Include="Resources\drawable\android_button.xml" />
+    <AndroidResource Include="Resources\layout\FragmentFixup.axml" />
+    <AndroidResource Include="Resources\layout\Main.axml" />
     <AndroidResource Include="Resources\xml\XmlReaderResourceParser.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/src/Mono.Android/Test/Resources/layout/FragmentFixup.axml
+++ b/src/Mono.Android/Test/Resources/layout/FragmentFixup.axml
@@ -3,21 +3,7 @@
     android:orientation="vertical"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    xmlns:tools="http://schemas.xamarin.com/android/tools"
-    tools:class="Xamarin.Android.RuntimeTests.MainActivity"
     >
-  <TextView
-    android:id="@+id/first_text_view"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:editable="false"
-  />
-  <TextView
-    android:id="@+id/second_text_view"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:editable="false"
-  />
   <fragment
       android:name="Xamarin.Android.RuntimeTests.MyFragment"
       android:id="@+id/csharp_simple_fragment"
@@ -25,13 +11,19 @@
       android:layout_height="wrap_content"
   />
   <fragment
-      android:name="Xamarin.Android.RuntimeTests.MyFragment, Hello"
+      android:name="xamarin.android.runtimetests.MyFragment"
+      android:id="@+id/csharp_legacy_fragment"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+  />
+  <fragment
+      android:name="Xamarin.Android.RuntimeTests.MyFragment, Mono.Android-Tests"
       android:id="@+id/csharp_partial_assembly"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
   />
   <fragment
-      android:name="Xamarin.Android.RuntimeTests.MyFragment, Hello, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
+      android:name="Xamarin.Android.RuntimeTests.MyFragment, Mono.Android-Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
       android:id="@+id/csharp_full_assembly"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"

--- a/src/Mono.Android/Test/Xamarin.Android.RuntimeTests/MainActivity.cs
+++ b/src/Mono.Android/Test/Xamarin.Android.RuntimeTests/MainActivity.cs
@@ -1,16 +1,26 @@
 using System.Reflection;
 using Android.App;
 using Android.OS;
+using Android.Views;
+using Android.Widget;
 using Xamarin.Android.NUnitLite;
 
 namespace Xamarin.Android.RuntimeTests
 {
 	[Activity (Label = "runtime", MainLauncher = true,
 			Name="xamarin.android.runtimetests.MainActivity")]
-	public class MainActivity : TestSuiteActivity
+	public partial class MainActivity : TestSuiteActivity
 	{
 		protected override void OnCreate (Bundle bundle)
 		{
+			// Note; for testing <fragment/> fixup only.
+			// The actual view is set/replaced in `TestSuiteActivity.OnCreate()`
+			SetContentView (Resource.Layout.FragmentFixup);
+
+			first_text_view.Click += delegate {
+				// ignore
+			};
+
 			// tests can be inside the main assembly
 			AddTest (Assembly.GetExecutingAssembly ());
 			// or in any reference assemblies
@@ -20,5 +30,17 @@ namespace Xamarin.Android.RuntimeTests
 			base.OnCreate (bundle);
 		}
 	}
+
+#if __ANDROID_11__
+	public class MyFragment : Fragment {
+
+		public override View OnCreateView (LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+		{
+			return new TextView (Activity) {
+				Text = "via fragment!",
+			};
+		}
+	}
+#endif  // ANDROID_15
 }
 


### PR DESCRIPTION
While trying to repro Issue #1296, I had a brilliant idea: let's use
the new CodeBehind support from 7c31899b!

Everything then fell apart.

For starters, Issue #1296 deals with Fragments, and 7c31899b didn't
support the presence of `<fragment/>` within Layout files.

Plumb support for that, by adding:

	partial class MainActivity {
	  partial void OnLayoutFragmentNotFound<T> (int resourceId, ref T type)
	    where T : global::Android.App.Fragment;
	}

Another issue was noticed as well: all the line numbers in the `#line`
pragmas were always `1`. This was narrowed down to a bug in
`GetLineInfo()`.

Then there's an issue with where I was using the CodeBehind file:
within the `src/Mono.Android/Test` project, which is in the
`Xamarin.Android.RuntimeTests` namespace. This prompted all manner of
namespace resolution failures:

	error CS0234: The type or namespace name 'App' does not exist in the namespace 'Xamarin.Android' (are you missing an assembly reference?)
	...

Fix this by using `CodeTypeReferenceOptions.GlobalReference` as much
as is practical (which isn't enough), and by "kludging" up the
`CodeNamespaceImport` construction so that we instead emit:

	using global::System;

Finally, the generated codebehind had some weird nesting going on:

	partial class MainActivity {
	  public __first_text_view_Views first_text_view {get;}
	  public sealed partial class __first_text_view_Views {
	    public __second_text_view_Views second_text_view {get;}
	    public sealed partial class __second_text_view_Views {
	      public sealed partial class __csharp_simple_fragment_Views {
	        public sealed partial class __csharp_partial_assembly_Views {
	        }
	      }
	    }
	  }
	}

It was bizarre *and* unusable: the `second_text_view` property --
corresponding to `<TextView android:id="@+id/second_text_view" />` --
was *nested within* a generated `MainActivity.__first_text_view_Views`
type, and I'm not sure why that existed. Furthermore, it *can't* work,
as the generated
`MainActivity.__first_text_view_Views.__CreateClass___second_text_view_Views()`
method depends on a constructor which doesn't exist:

	private @__second_text_view_Views @__CreateClass___second_text_view_Views() {
	  // There *is* a __second_text_view_Views(Activity) constructor,
	  // but not __second_text_view_Views(__first_text_view_Views).
	  return new @__second_text_view_Views(this);
	}

I "solved" (?) this by updating `LoadWidgets()` so that it always used
`widgetRoot` for all recursive calls to `LoadWidgets()`, so that there
is only ever one root. This removed all the nested types.