### PR TITLE
[Xamarin.Android.Build.Tasks] GetAndroidDependencies should call _SetLatestTargetFrameworkVersion

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2770,7 +2770,7 @@ because xbuild doesn't support framework reference assemblies.
 
 
 <!-- SDK Management Targets -->
-<Target Name="GetAndroidDependencies" DependsOnTargets="$(GetAndroidDependenciesDependsOn)" Returns="@(AndroidDependency)">
+<Target Name="GetAndroidDependencies" DependsOnTargets="_SetLatestTargetFrameworkVersion;$(GetAndroidDependenciesDependsOn)" Returns="@(AndroidDependency)">
   <PropertyGroup>
     <_ProjectAndroidManifest>$(ProjectDir)$(AndroidManifest)</_ProjectAndroidManifest>
     <_NdkRequired Condition="'$(BundleAssemblies)' == 'True' Or '$(AotAssemblies)' == 'True'">true</_NdkRequired>


### PR DESCRIPTION
This is a bug in the `<GetAndroidDependencies/>` target. It does
not call `MonoAndroidHelper.RefreshSupportedVersions`. As a result
if called directly it will generate a Null Reference exception because
`MonoAndroidHelper.SupportedVersions` will be null.

So we should be dependent on `<_SetLatestTargetFrameworkVersion/>`.
This will initialize the `MonoAndroidHelper.SupportedVersions`. But
it will also resolve the correct `TargetFrameworkVersion` if the
user is using `AndroidUseLatestPlatformSdk`.