### PR TITLE
[Xamarin.Android.Build.Tasks] Stop designtime designer being deleted.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Common/ImportAfter/Xamarin.Android.Windows.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Common/ImportAfter/Xamarin.Android.Windows.targets
@@ -15,7 +15,7 @@ Copyright (C) 2014 Xamarin. All rights reserved.
 	</PropertyGroup>
 
 	<Target Name="_RegisterAndroidFilesWithFileWrites" BeforeTargets="IncrementalClean" Condition=" '$(_IsRunningXBuild)' != 'true' ">  
-		<CreateItem Include="$(OutDir)*.pdb;$(OutDir)*.dll;$(OutDir)*.dll.mdb;$(MonoAndroidIntermediateAssemblyDir)*.dll.mdb;$(MonoAndroidIntermediateAssemblyDir)*.pdb;$(MonoAndroidLinkerInputDir)*.dll.mdb;$(MonoAndroidLinkerInputDir)*.pdb;$(_AndroidManagedResourceDesignerFile)">  
+		<CreateItem Include="$(OutDir)*.pdb;$(OutDir)*.dll;$(OutDir)*.dll.mdb;$(MonoAndroidIntermediateAssemblyDir)*.dll.mdb;$(MonoAndroidIntermediateAssemblyDir)*.pdb;$(MonoAndroidLinkerInputDir)*.dll.mdb;$(MonoAndroidLinkerInputDir)*.pdb">  
 			<Output TaskParameter="Include" ItemName="_FilesToRegister" />
 		</CreateItem>
 		<CreateItem Include="$([System.IO.Path]::GetFullPath('%(_FilesToRegister.Identity)'))"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1016,7 +1016,7 @@ namespace Lib1 {
 					"Target '_ManagedUpdateAndroidResgen' should not have run.");
 
 				Assert.IsTrue (appBuilder.Clean (appProj), "Clean should have succeeded");
-				Assert.IsFalse (File.Exists (designerFile), $"'{designerFile}' should have been cleaned.");
+				Assert.IsTrue (File.Exists (designerFile), $"'{designerFile}' should not have been cleaned.");
 
 			}
 		}
@@ -1112,10 +1112,10 @@ namespace Lib1 {
 
 
 					Assert.IsTrue (appBuilder.Clean (appProj), "Clean should have succeeded");
-					Assert.IsFalse (File.Exists (designerFile), $"'{designerFile}' should have been cleaned.");
+					Assert.IsTrue (File.Exists (designerFile), $"'{designerFile}' should not have been cleaned.");
 					designerFile = Path.Combine (Root, path, libProj.ProjectName, libProj.IntermediateOutputPath, "designtime", "Resource.Designer.cs");
 					Assert.IsTrue (libBuilder.Clean (libProj), "Clean should have succeeded");
-					Assert.IsFalse (File.Exists (designerFile), $"'{designerFile}' should have been cleaned.");
+					Assert.IsTrue (File.Exists (designerFile), $"'{designerFile}' should not have been cleaned.");
 
 
 				}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1116,11 +1116,6 @@ because xbuild doesn't support framework reference assemblies.
 		<Compile Remove="@(CorrectCasedItem)" Condition=" '$(ManagedDesignTimeBuild)' == 'True' And '%(CorrectCasedItem.Identity)' != '' "/>
 		<Compile Include="$(_AndroidManagedResourceDesignerFile)" Condition=" '$(ManagedDesignTimeBuild)' == 'True' And Exists ('$(_AndroidManagedResourceDesignerFile)')" />
 	</ItemGroup>
-	<WriteLinesToFile
-		Condition="Exists ('$(_AndroidManagedResourceDesignerFile)')"
-		File="$(IntermediateOutputPath)$(CleanFile)"
-		Lines="$([System.IO.Path]::GetFullPath('$(_AndroidManagedResourceDesignerFile)'))"
-		Overwrite="false" />
 </Target>
 	
 <!-- Resource Build -->


### PR DESCRIPTION
Fixes #1286

We have a number of problems with our DesignTime build system. The
main one which this PR addresses is the designer file is deleted
by `IncrementalClean` AND `CoreClean`. This them completely messes
up the DesignTime system since it can no longer find the file.

So what we should be doing is making sure we don't tell the build
system about the designer file ;). We do this by not writing the
path to the `$(CleanFile)`.