### PR TITLE
Bump to xamarin-android-api-compatibility/d15-7/10df9b67

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -36,7 +36,7 @@
 [submodule "external/xamarin-android-api-compatibility"]
 	path = external/xamarin-android-api-compatibility
 	url = https://github.com/xamarin/xamarin-android-api-compatibility.git
-	branch = d15-6
+	branch = d15-7
 [submodule "external/xamarin-android-tools"]
 	path = external/xamarin-android-tools
 	url = https://github.com/xamarin/xamarin-android-tools


### PR DESCRIPTION
Context: 34f437d97d6d5f56d684af99449de49b870b32cc
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/873/

The bump to mono/2017-12 in commit 34f437d9 included ABI "breakage" in
`System.Data.dll` which wasn't *actual* breakage.

Update xamarin-android-api-compatibility to so that we don't report
warnings for this "breakage."