### PR TITLE
[Xamarin.Android.Build.Tasks] Update `CalculateProjectDependencies` to match new spec.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
@@ -51,8 +51,8 @@ namespace Xamarin.Android.Tasks
 				manifestApiLevel = manifest.TargetSdkVersion ?? manifest.MinSdkVersion ?? DefaultMinSDKVersion;
 			}
 			var sdkVersion = Math.Max (targetApiLevel.Value, manifestApiLevel);
-			dependencies.Add (CreateAndroidDependency ($"platforms;android-{sdkVersion}", $""));
-			dependencies.Add (CreateAndroidDependency ($"build-tools;{BuildToolsVersion}", BuildToolsVersion));
+			dependencies.Add (CreateAndroidDependency ($"platforms/android-{sdkVersion}", $""));
+			dependencies.Add (CreateAndroidDependency ($"build-tools/{BuildToolsVersion}", BuildToolsVersion));
 			if (!string.IsNullOrEmpty (PlatformToolsVersion)) {
 				dependencies.Add (CreateAndroidDependency ("platform-tools", PlatformToolsVersion));
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
@@ -37,11 +37,11 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.IsTrue (task.Execute ());
 			Assert.IsNotNull (task.Dependencies);
 			Assert.AreEqual (ndkRequred ? 5 : 4, task.Dependencies.Length);
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tools;26.0.1" && x.GetMetadata ("Version") == "26.0.1"),
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tools/26.0.1" && x.GetMetadata ("Version") == "26.0.1"),
 				"Dependencies should contains a build-tools version 26.0.1");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "tools" && x.GetMetadata ("Version") == "26.0.1"),
 				"Dependencies should contains a tools version 26.0.1");
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platforms;android-26" && x.GetMetadata ("Version") == ""),
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platforms/android-26" && x.GetMetadata ("Version") == ""),
 				"Dependencies should contains a platform version android-26");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform-tools" && x.GetMetadata ("Version") == "26.0.3"),
 				"Dependencies should contains a platform-tools version 26.0.3");
@@ -77,11 +77,11 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.IsTrue (task.Execute ());
 			Assert.IsNotNull (task.Dependencies);
 			Assert.AreEqual (5, task.Dependencies.Length);
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tools;26.0.1" && x.GetMetadata ("Version") == "26.0.1"),
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tools/26.0.1" && x.GetMetadata ("Version") == "26.0.1"),
 				"Dependencies should contains a build-tools version 26.0.1");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "tools" && x.GetMetadata ("Version") == "26.0.1"),
 				"Dependencies should contains a tools version 26.0.1");
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platforms;android-26" && x.GetMetadata ("Version") == ""),
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platforms/android-26" && x.GetMetadata ("Version") == ""),
 				"Dependencies should contains a platform version android-26");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform-tools" && x.GetMetadata ("Version") == "26.0.3"),
 				"Dependencies should contains a platform-tools version 26.0.3");
@@ -120,11 +120,11 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.IsTrue(task.Execute ());
 			Assert.IsNotNull (task.Dependencies);
 			Assert.AreEqual (5, task.Dependencies.Length);
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tools;26.0.1" && x.GetMetadata ("Version") == "26.0.1"),
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "build-tools/26.0.1" && x.GetMetadata ("Version") == "26.0.1"),
 				"Dependencies should contains a build-tools version 26.0.1");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "tools" && x.GetMetadata ("Version") == "26.0.1"),
 				"Dependencies should contains a tools version 26.0.1");
-			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platforms;android-26" && x.GetMetadata ("Version") == ""),
+			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platforms/android-26" && x.GetMetadata ("Version") == ""),
 				"Dependencies should contains a platform version android-26");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "platform-tools" && x.GetMetadata ("Version") == "26.0.3"),
 				"Dependencies should contains a platform-tools version 26.0.3");


### PR DESCRIPTION
The path separator for the android manifest change from
a `;` to a '/'. This commit updates the `CalculateProjectDependencies`
task to use the new format. It also updates the tests.

The current manifest [1] has been updated to [2]. It seems the general reasoning was to make the way the components are queried via the Sdk Manager and the MsBuild tasks consistent. It also makes the output of the `CalculateProjectDependencies` more `msbuild` friendly. 

The new manifest [2] now has a `filesystem-path` in addition to the `path`

`path="build-tools;27.0.3" filesystem-path="build-tools/27.0.3"`

Note that the `filesystem-path` includes `/` rather than `;`. Prior to this change the `InstallAndroidDependencies` needed to fix up the output of `CalculateProjectDependencies` to correctly query the SDK Manager for installed components. With this change both the `InstallAndroidDependencies` Task and the Command line tool can consume the output of `CalculateProjectDependencies` without any changes. The AndroidDependency will now have items
such as

`platforms/android-21`
`build-tools/27.0.3`
`ndk-bundle`

Version numbers are still provided as metadata as per the spec [3].

[1] https://xamarin.azureedge.net/Installer/xamarin-android-sdk.xml
[2] [xamarin-android-sdk.xml](https://gist.github.com/dellis1972/08ba76cc19cdce3dec89c68684664299)
[3] [Spec](https://microsoft-my.sharepoint.com/:w:/r/personal/mhutch_microsoft_com/_layouts/15/WopiFrame.aspx?sourcedoc=%7B0436dd38-c9ff-4cf2-b33c-ee4515b68546%7D&action=edit&wdPid=64869a58)