### PR TITLE
[Xamarin.Android.Build.Tasks] Add support for Generated Resources via VSForMac (#643)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -8,5 +8,6 @@
 		<LatestSupportedJavaVersion Condition="'$(LatestSupportedJavaVersion)' == ''">1.8.0</LatestSupportedJavaVersion>
 		<MinimumSupportedJavaVersion Condition="'$(MinimumSupportedJavaVersion)' == ''">1.6.0</MinimumSupportedJavaVersion>
 		<AndroidVersionCodePattern Condition=" '$(AndroidUseLegacyVersionCode)' != 'True' And '$(AndroidVersionCodePattern)' == '' ">{abi}{versionCode:D5}</AndroidVersionCodePattern>
+		<AndroidResourceGeneratorTargetName>UpdateGeneratedFiles</AndroidResourceGeneratorTargetName>
 	</PropertyGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -533,6 +533,22 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
    </CompileDependsOn>
  </PropertyGroup>
 
+<PropertyGroup >
+  <CoreCompileDependsOn>UpdateGeneratedFiles;$(CoreCompileDependsOn)</CoreCompileDependsOn>
+</PropertyGroup>
+
+<PropertyGroup >
+  <CoreCompileDependsOn>UpdateGeneratedFiles;$(CoreCompileDependsOn)</CoreCompileDependsOn>
+</PropertyGroup>
+
+<PropertyGroup >
+  <CoreCompileDependsOn>UpdateGeneratedFiles;$(CoreCompileDependsOn)</CoreCompileDependsOn>
+</PropertyGroup>
+
+<PropertyGroup >
+  <CoreCompileDependsOn>UpdateGeneratedFiles;$(CoreCompileDependsOn)</CoreCompileDependsOn>
+</PropertyGroup>
+
 <PropertyGroup>
     <!-- no need to add those wear resources into C#, hence this order... -->
 	<CoreResolveReferencesDependsOn>
@@ -574,12 +590,18 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	</CreateProperty>
 </Target>
 
+<Target Name="UpdateGeneratedFiles"
+		DependsOnTargets="_RemoveLegacyDesigner;UpdateAndroidResources"
+	>
+</Target>
+
 <Target Name="_RemoveLegacyDesigner" Condition="'$(AndroidUseIntermediateDesignerFile)' == 'True'">
 	<ItemGroup>
 		<CorrectCasedItem Include="%(Compile.Identity)" Condition="'%(Compile.Identity)' == '$(AndroidResgenFile)'"/>
 		<Compile Remove="@(CorrectCasedItem)" Condition=" '$(AndroidResgenFile)' != '' "/>
 		<Compile Include="$(_AndroidResourceDesignerFile)" />
 	</ItemGroup>
+	<Message Importance="High" Text="$(AndroidResgenFile) is no longer required and can be safely removed." Condition=" '$(AndroidResgenFile)' != '' And Exists('$(AndroidResgenFile)') " />
 </Target>
 
 <Target Name="_ValidateAndroidPackageProperties">


### PR DESCRIPTION
Context https://bugzilla.xamarin.com/show_bug.cgi?id=5870

One of the issues with the current resource designer implementation
is that it is not in the intermediate directory. As a result it is
always causing problems for Source control systems.

Additionally normal .net apps create generated files in the
intermediate directory and make use of the a target and make use
of "build time code generation" [1] by making use if the Generator
metadata in MSBuild. Visual studio already has support for this
however VisualStudioForMac did not.

The issue with VisualStudioForMac is now being solved. With this commit
we will introduce a new target UpdateGeneratedFiles which can be
used by both VS and XS to generate the Resource.Designer.xx file
in the intermediate directory.

All of this is current protected by the AndroidUseIntermediateDesignerFile
property which defaults to false.

[1] https://mhut.ch/journal/2015/06/30/build_time_code_generation_msbuild