### PR TITLE
Bump to xamarin-android-api-compatibility/master/2c689ef2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -36,7 +36,7 @@
 [submodule "external/xamarin-android-api-compatibility"]
 	path = external/xamarin-android-api-compatibility
 	url = https://github.com/xamarin/xamarin-android-api-compatibility.git
-	branch = d15-7
+	branch = master
 [submodule "external/xamarin-android-tools"]
 	path = external/xamarin-android-tools
 	url = https://github.com/xamarin/xamarin-android-tools

--- a/tests/api-compatibility/api-compatibility.mk
+++ b/tests/api-compatibility/api-compatibility.mk
@@ -13,9 +13,11 @@ FRAMEWORK_DIR     = bin/$(CONFIGURATION)/lib/xamarin.android/xbuild-frameworks/M
 
 
 run-api-compatibility-tests: $(MONO_API_HTML) $(MONO_API_INFO)
+	mkdir -p bin/Build$(CONFIGURATION)/compatibility
 	make -C external/xamarin-android-api-compatibility check \
 		MONO_API_HTML="$(RUNTIME) $(abspath $(MONO_API_HTML))" \
 		MONO_API_INFO="$(RUNTIME) $(abspath $(MONO_API_INFO))" \
+		HTML_OUTPUT_DIR="$(abspath bin/Build$(CONFIGURATION)/compatibility)" \
 		XA_FRAMEWORK_DIR="$(abspath $(FRAMEWORK_DIR))"
 
 $(MONO_API_HTML): $(wildcard $(MONO_API_HTML_DIR)/*.cs) $(MONO_OPTIONS_SRC)


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/1089

We found that xamarin-android-api-compatibility wasn't *actually*
performing the inter-API-level checks, meaning an important API
compatibility check wasn't being performed.

Bump to xamarin-android-api-compatibility/2c689ef2 so that
inter-API-level checks are properly performed.

Additionally, set `$(HTML_OUTPUT_DIR)` so that `mono-api-html` output
files are written into `bin/Build$(CONFIGURATION)/compatibility`.
This will (hopefully) allow us to use the Jenkins
**Publish HTML reports** Post-build Action to nicely display API
compatibility breakage, without requiring that we read the actual
build log output.