### PR TITLE
[msbuild][Mono.Android] add a bunch of "missing" manifest attributes.

### DIFF
--- a/src/Mono.Android/Android.App/UsesConfigurationAttribute.cs
+++ b/src/Mono.Android/Android.App/UsesConfigurationAttribute.cs
@@ -1,0 +1,25 @@
+using System;
+
+using Android.Content.PM;
+using Android.Views;
+
+namespace Android.App {
+
+	[Serializable]
+	[AttributeUsage (AttributeTargets.Assembly, 
+			AllowMultiple=true, 
+			Inherited=false)]
+	public sealed partial class UsesConfigurationAttribute : Attribute {
+
+		public UsesConfigurationAttribute ()
+		{
+		}
+
+		public bool ReqFiveWayNav { get; set; }
+		public bool ReqHardKeyboard { get; set; }
+		public string ReqKeyboardType { get; set; }
+		public string ReqNavigation { get; set; }
+		public string ReqTouchScreen { get; set; }
+	}
+}
+

--- a/src/Mono.Android/Android.App/UsesFeatureAttribute.cs
+++ b/src/Mono.Android/Android.App/UsesFeatureAttribute.cs
@@ -22,6 +22,9 @@ namespace Android.App
 		public bool                   Required                {get; set;}
 #endif
 		public int                    GLESVersion             {get; set;}
+#if ANDROID_24
+		public int                    Version { get; private set; }
+#endif
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/ActivityAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/ActivityAttribute.Partial.cs
@@ -17,12 +17,15 @@ namespace Android.App {
 	partial class ActivityAttribute {
 
 		bool _AllowEmbedded;
+		string _ColorMode;
 		bool _HardwareAccelerated;
+		float _MaxAspectRatio;
 		string _ParentActivity;
 		LayoutDirection _LayoutDirection;
 		UiOptions _UiOptions;
 		bool _Immersive;
 		bool _ResizeableActivity;
+		bool _ShowForAllUsers;
 		bool _SupportsPictureInPicture;
 		string _RoundIcon;
 
@@ -47,6 +50,11 @@ namespace Android.App {
 			  "clearTaskOnLaunch",
 			  self          => self.ClearTaskOnLaunch,
 			  (self, value) => self.ClearTaskOnLaunch = (bool) value
+			}, {
+			  "ColorMode",
+			  "colorMode",
+			  self          => self._ColorMode,
+			  (self, value) => self._ColorMode = (string) value
 			}, {
 			  "ConfigurationChanges",
 			  "configChanges",
@@ -113,6 +121,11 @@ namespace Android.App {
 			  null,
 			  (self, value) => self.MainLauncher  = (bool) value
 			}, {
+			  "MaxAspectRatio",
+			  "maxAspectRatio",
+			  self          => self._MaxAspectRatio,
+			  (self, value) => self._MaxAspectRatio = (float) value
+			}, {
 			  "MultiProcess",
 			  "multiprocess",
 			  self          => self.MultiProcess,
@@ -163,6 +176,11 @@ namespace Android.App {
 			  "screenOrientation",
 			  self          => self.ScreenOrientation,
 			  (self, value) => self.ScreenOrientation = (ScreenOrientation) value
+			}, {
+			  "ShowForAllUsers",
+			  "showForAllUsers",
+			  self          => self._ShowForAllUsers,
+			  (self, value) => self._ShowForAllUsers = (bool) value
 			}, {
 			  "StateNotNeeded",
 			  "stateNotNeeded",

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/ApplicationAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/ApplicationAttribute.Partial.cs
@@ -19,9 +19,12 @@ namespace Android.App {
 	partial class ApplicationAttribute {
 
 		string _BackupAgent;
+		bool _BackupInForeground;
 		string _Banner;
+		bool _FullBackupOnly;
 		string _Logo;
 		string _ManageSpaceActivity;
+		string _NetworkSecurityConfig;
 		string _RequiredAccountType;
 		string _RestrictedAccountType;
 		bool _HardwareAccelerated;
@@ -30,6 +33,7 @@ namespace Android.App {
 		bool _LargeHeap;
 		UiOptions _UiOptions;
 		bool _SupportsRtl;
+		bool _UsesCleartextTraffic;
 		bool _VMSafeMode;
 		bool _ResizeableActivity;
 		ICustomAttributeProvider provider;
@@ -66,6 +70,11 @@ namespace Android.App {
 					return ManifestDocumentElement.ToString (typeDef);
 			  }
 			}, {
+			  "BackupInForeground",
+			  "backupInForeground",
+			  self          => self._BackupInForeground,
+			  (self, value) => self._BackupInForeground = (bool) value
+			}, {
 			  "Banner",
 			  "banner",
 			  self          => self._Banner,
@@ -100,6 +109,11 @@ namespace Android.App {
 			  "fullBackupContent",
 			  self          => self._FullBackupContent,
 			  (self, value) => self._FullBackupContent  = (bool) value
+			}, {
+			  "FullBackupOnly",
+			  "fullBackupOnly",
+			  self          => self._FullBackupOnly,
+			  (self, value) => self._FullBackupOnly = (bool) value
 			}, {
 			  "HardwareAccelerated",
 			  "hardwareAccelerated",
@@ -146,6 +160,12 @@ namespace Android.App {
 			  "name",
 			  (self, value) => self.Name  = (string) value,
 			  ToNameAttribute
+			}, {
+			  "NetworkSecurityConfig",
+			  "networkSecurityConfig",
+			  self          => self._NetworkSecurityConfig,
+			  (self, value) => self._NetworkSecurityConfig = (string) value,
+			  typeof (Type)
 			}, {
 			  "Permission",
 			  "permission",
@@ -206,6 +226,11 @@ namespace Android.App {
 			  "uiOptions",
 			  self          => self._UiOptions,
 			  (self, value) => self._UiOptions  = (UiOptions) value
+			}, {
+			  "UsesCleartextTraffic",
+			  "usesCleartextTraffic",
+			  self          => self._UsesCleartextTraffic,
+			  (self, value) => self._UsesCleartextTraffic = (bool) value
 			}, {
 			  "VMSafeMode",
 			  "vmSafeMode",

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/InstrumentationAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/InstrumentationAttribute.Partial.cs
@@ -13,6 +13,7 @@ namespace Android.App {
 	partial class InstrumentationAttribute {
 		
 		string _RoundIcon;
+		string _TargetProcesses;
 
 		static ManifestDocumentElement<InstrumentationAttribute> mapping = new ManifestDocumentElement<InstrumentationAttribute> ("instrumentation") {
 			{
@@ -50,6 +51,11 @@ namespace Android.App {
 			  "targetPackage",
 			  self          => self.TargetPackage,
 			  (self, value) => self.TargetPackage = (string) value
+			}, {
+			  "TargetProcesses",
+			  "targetProcesses",
+			  self          => self._TargetProcesses,
+			  (self, value) => self._TargetProcesses = (string) value
 			},
 		};
 

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/UsesConfigurationAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/UsesConfigurationAttribute.Partial.cs
@@ -1,0 +1,66 @@
+using System;
+
+using System.Collections.Generic;
+using Xamarin.Android.Manifest;
+using System.Xml.Linq;
+using Mono.Cecil;
+
+using Java.Interop.Tools.Cecil;
+
+namespace Android.App {
+
+	partial class UsesConfigurationAttribute	{
+
+		bool _Required;
+
+		static ManifestDocumentElement<UsesConfigurationAttribute> mapping = new ManifestDocumentElement<UsesConfigurationAttribute> ("uses-configuration") {
+			{
+			  "ReqFiveWayNav",
+			  "reqFiveWayNav",
+			  self          => self.ReqFiveWayNav,
+			  (self, value) => self.ReqFiveWayNav  = (bool) value
+			}, {
+			  "ReqHardKeyboard",
+			  "reqHardKeyboard",
+			  self          => self.ReqHardKeyboard,
+			  (self, value) => self.ReqHardKeyboard  = (bool) value
+			}, {
+			  "ReqKeyboardType",
+			  "reqKeyboardType",
+			  self          => self.ReqKeyboardType,
+			  (self, value) => self.ReqKeyboardType = (string) value
+			}, {
+			  "ReqNavigation",
+			  "reqNavigation",
+			  self          => self.ReqNavigation,
+			  (self, value) => self.ReqNavigation = (string) value
+			}, {
+			  "ReqTouchScreen",
+			  "reqTouchScreen",
+			  self          => self.ReqTouchScreen,
+			  (self, value) => self.ReqTouchScreen = (string) value
+			}
+		};
+
+		internal XElement ToElement (string packageName)
+		{
+			return mapping.ToElement (this, specified, packageName);
+		}
+
+		ICollection<string> specified;
+
+		public static IEnumerable<UsesConfigurationAttribute> FromCustomAttributeProvider (ICustomAttributeProvider provider)
+		{
+			var attrs = provider.GetCustomAttributes ("Android.App.UsesConfigurationAttribute");
+			foreach (var attr in attrs) {
+
+				UsesConfigurationAttribute self = new UsesConfigurationAttribute ();
+
+				self.specified = mapping.Load (self, attr);
+
+				yield return self;
+			}
+		}
+	}
+}
+

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/UsesFeatureAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/UsesFeatureAttribute.Partial.cs
@@ -12,6 +12,7 @@ namespace Android.App {
 	partial class UsesFeatureAttribute	{
 
 		bool _Required;
+		int _Version;
 
 		static ManifestDocumentElement<UsesFeatureAttribute> mapping = new ManifestDocumentElement<UsesFeatureAttribute> ("uses-feature") {
 			{
@@ -29,6 +30,11 @@ namespace Android.App {
 			  "glEsVersion",
 			  self          => self.GLESVesionAsString(),
 			  (self, value) => self.GLESVersion  = (int) value
+			}, {
+			  "Version",
+			  "version",
+			  self          => self._Version,
+			  (self, value) => self._Version = (int) value
 			}
 		};
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -154,6 +154,7 @@
     <Compile Include="Mono.Android\PermissionAttribute.Partial.cs" />
     <Compile Include="Mono.Android\PermissionGroupAttribute.Partial.cs" />
     <Compile Include="Mono.Android\PermissionTreeAttribute.Partial.cs" />
+    <Compile Include="Mono.Android\UsesConfigurationAttribute.Partial.cs" />
     <Compile Include="Mono.Android\UsesFeatureAttribute.Partial.cs" />
     <Compile Include="Mono.Android\SupportsGLTextureAttribute.Partial.cs" />
     <Compile Include="Tasks\CreateNativeLibraryArchive.cs" />
@@ -471,6 +472,9 @@
     </Compile>
     <Compile Include="..\Mono.Android\\Android.App\PermissionTreeAttribute.cs">
       <Link>Mono.Android\PermissionTreeAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\Mono.Android\\Android.App\UsesConfigurationAttribute.cs">
+      <Link>Mono.Android\UsesConfigurationAttribute.cs</Link>
     </Compile>
     <Compile Include="..\Mono.Android\\Android.App\UsesFeatureAttribute.cs">
       <Link>Mono.Android\UsesFeatureAttribute.cs</Link>

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
@@ -24,6 +24,9 @@ namespace Android.App
 		public bool                   AllowTaskReparenting    {get; set;}
 		public bool                   AlwaysRetainTaskState   {get; set;}
 		public bool                   ClearTaskOnLaunch       {get; set;}
+#if ANDROID_26
+		public string                 ColorMode               {get; set;}
+#endif
 		public ConfigChanges          ConfigurationChanges    {get; set;}
 #if ANDROID_24
 		public bool                   DirectBootAware         {get; set;}
@@ -44,6 +47,9 @@ namespace Android.App
 		public LayoutDirection        LayoutDirection         {get; set;}
 #endif
 		public bool                   MainLauncher            {get; set;}
+#if ANDROID_26
+		public float                  MaxAspectRatio          {get; set;}
+#endif
 		public bool                   MultiProcess            {get; set;}
 		public bool                   NoHistory               {get; set;}
 #if ANDROID_16
@@ -56,6 +62,9 @@ namespace Android.App
 #endif
 #if ANDROID_25
 		public string                 RoundIcon               {get; set;}
+#endif
+#if ANDROID_23
+                public bool                   ShowForAllUsers         {get; set;}
 #endif
 #if ANDROID_24
 		public bool                   SupportsPictureInPicture {get;set;}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
@@ -64,7 +64,7 @@ namespace Android.App
 		public string                 RoundIcon               {get; set;}
 #endif
 #if ANDROID_23
-                public bool                   ShowForAllUsers         {get; set;}
+		public bool                   ShowForAllUsers         {get; set;}
 #endif
 #if ANDROID_24
 		public bool                   SupportsPictureInPicture {get;set;}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ApplicationAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ApplicationAttribute.cs
@@ -23,6 +23,9 @@ namespace Android.App {
 #if ANDROID_8
 		public Type                   BackupAgent             {get; set;}
 #endif
+#if ANDROID_24
+		public bool                   BackupInForeground      {get; set;}
+#endif
 #if ANDROID_21
 		public string                 Banner                  {get; set;}
 #endif
@@ -35,6 +38,9 @@ namespace Android.App {
 #if ANDROID_23
 		public bool                   ExtractNativeLibs       {get; set;}
 		public bool                   FullBackupContent       {get; set;}
+#endif
+#if ANDROID_21
+		public bool                   FullBackupOnly          {get; set;}
 #endif
 #if ANDROID_11
 		public bool                   HardwareAccelerated     {get; set;}
@@ -50,6 +56,9 @@ namespace Android.App {
 		public string                 Logo                    {get; set;}
 #endif
 		public Type                   ManageSpaceActivity     {get; set;}
+#if ANDROID_26
+		public string                 NetworkSecurityConfig   {get; set;}
+#endif 
 		public string                 Permission              {get; set;}
 		public bool                   Persistent              {get; set;}
 		public string                 Process                 {get; set;}
@@ -70,6 +79,9 @@ namespace Android.App {
 		public string                 Theme                   {get; set;}
 #if ANDROID_14
 		public UiOptions              UiOptions               {get; set;}
+#endif
+#if ANDROID_23
+		public bool                   UsesCleartextTraffic    {get; set;}
 #endif
 #if ANDROID_10
 		public bool                   VMSafeMode              {get; set;}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/InstrumentationAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/InstrumentationAttribute.cs
@@ -21,6 +21,9 @@ namespace Android.App {
 		public string                 RoundIcon               {get; set;}
 #endif
 		public string                 TargetPackage   {get; set;}
+#if ANDROID_26
+		public string                 TargetProcesses {get; set;}
+#endif
 	}
 }
 


### PR DESCRIPTION
This should fix https://github.com/xamarin/xamarin-android/issues/1224.

Those attributes were based on build-tools/manifest-attribute-codegen.exe
(which is not really codegen yet, but lists up all the manifest attributes
that are found from Android SDK resources).

However not all the attributes were documented. For those undocumented
attributes, the issue https://github.com/xamarin/xamarin-android/issues/1336
was created to track.