### PR TITLE
[Xamarin.Android.Build.Tasks] Add Default Metadata for `@(AndroidResource)` Items.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -10,4 +10,10 @@
 		<AndroidVersionCodePattern Condition=" '$(AndroidUseLegacyVersionCode)' != 'True' And '$(AndroidVersionCodePattern)' == '' ">{abi}{versionCode:D5}</AndroidVersionCodePattern>
 		<AndroidResourceGeneratorTargetName>UpdateGeneratedFiles</AndroidResourceGeneratorTargetName>
 	</PropertyGroup>
+	<ItemDefinitionGroup>
+		<AndroidResource>
+			<SubType>Designer</SubType>
+			<Generator>MSBuild:UpdateGeneratedFiles</Generator>
+		</AndroidResource>
+	</ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
Fixes #1287

One of the problems we have encountered is that the logic behind
how and when the design time build (DTB) is run is unclear. Specifically
what events/changes trigger a DTB. After lenghty conversations with
the Visual Studio team it seems that their prefered solution is to
use the `Generator` metadata.

The idea behind this is that an Item can include

	<Generator>MSBuild:Target</Generator>

metadata which specify the MSBuild `Target` to run if that file
is modified. If these data is present Visual Studio will run the
target, which then modifies the required files which then triggers
an DTB update. Other ideas included adding a FileSystemWatcher to
the Visual Studio Addin to detect these changes and run targets.
That said the Generator metadata is built in and should work for
this purpose.

So now the problem. Normally you define this metadata on the Item
in the csproj. We have 1000's of developers with existing projects
which DO NOT include this data. So how do we fix up existing projects
without a) requiring manual changes or b) having to write a tool to
upgrade the projects.

This is where `<ItemDefinitionGroup/>` [1] comes in :). It allows
us to define the `default` metadata we want to include on Items.
So if we define

	<ItemDefinitionGroup>
		<Foo>
           		<A>bar</A>
        	</Foo>
	</ItemDefinitionGroup>

	<Foo Include="1">
		<A>some</A>
	</Foo>
	<Foo Include="2" />

When will happen is `<A>bar</A>` will be automatically added to
the `<Foo Include="2" />`. It will be skipped on the other one
because it already has a `<A/>` element defined. This is a really
nice feature since it allows us to add the required metadata in
the background without having to get users to upgrade projects.
Also because these are default values the csproj files will NOT
be changed when a user alters the project for some other reason.
i.e they WONT end up will ALL the `<AndroidResource />` items
having this new data on them.

The other thing to note is that these changes will only apply to
the DTB. The target we are calling in this case is `UpdateGeneratedFiles`.
This target is not part of the `Build` chain. As a result
`_SetupDesingTimeBuildForCompile` will be called. This sets `$(DesignTimeBuild)`
to true. So calling this target will ONLY update the DTB related files.

[1] https://docs.microsoft.com/en-us/visualstudio/msbuild/itemdefinitiongroup-element-msbuild