### PR TITLE
[Xamarin.Android.Build.Tasks] Default to XA_TLS_PROVIDER=btls

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -365,7 +365,7 @@ namespace Xamarin.Android.Tasks
 			const string defaultLogLevel = "MONO_LOG_LEVEL=info";
 			const string defaultMonoDebug = "MONO_DEBUG=gen-compact-seq-points";
 			const string defaultHttpMessageHandler = "XA_HTTP_CLIENT_HANDLER_TYPE=System.Net.Http.HttpClientHandler, System.Net.Http";
-			const string defaultTlsProvider = "XA_TLS_PROVIDER=default";
+			const string defaultTlsProvider = "XA_TLS_PROVIDER=btls";
 			string xamarinBuildId = string.Format ("XAMARIN_BUILD_ID={0}", buildId);
 
 			bool haveLogLevel = false;
@@ -484,7 +484,8 @@ namespace Xamarin.Android.Tasks
 
 		void AddBtlsLibs (ZipArchiveEx apk, string abi)
 		{
-			if (string.Compare ("btls", TlsProvider, StringComparison.OrdinalIgnoreCase) == 0) {
+			if (string.IsNullOrEmpty (TlsProvider) ||
+					string.Compare ("btls", TlsProvider, StringComparison.OrdinalIgnoreCase) == 0) {
 				AddNativeLibrary (apk, abi, "libmono-btls-shared.so");
 			}
 			// These are the other supported values

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1852,7 +1852,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		static object [] TlsProviderTestCases =
 		{
 			// androidTlsProvider, isRelease, extpected
-			new object[] { "", true, false, },
+			new object[] { "", true, true, },
 			new object[] { "default", true, false, },
 			new object[] { "legacy", true, false, },
 			new object[] { "btls", true, true, }


### PR DESCRIPTION
What do we want? TLS 1.2+ support by default!

The question has been, how "best" to do that? See also: 908f56d6.

If you need TLS 1.2 support via `System.Net.Http.HttpClient`, *and* you
don't need TLS 1.2 support via `System.Net.WebClient`, *and* you
*only* run on Android 5.0 or later (API-21+), you can use
`Xamarin.Android.Net.AndroidClientHandler`.

That is, admittedly, a lot of "and"s. Pre-Android 4.4 devices make up
approximately 17% of devices [accessing the Google Play Store][0]
(as of 2018-Feb-28). `AndroidClientHandler` will *work* on those
devices, but it uses the underlying Android APIs to provide TLS
access, and Android itself didn't support TLS 1.2 until 5.0.

`AndroidClientHandler` can be enabled by building with
`$(AndroidHttpClientHandlerType)` set to
`Xamarin.Android.Net.AndroidClientHandler`.

The alternative to all of the above limitations -- support for *all*
Android versions, support for `WebClient` -- has been "btls", which
provides TLS 1.2 support via the `libmono-btls-shared.so` native
library.

BTLS can be enabled by setting `$(AndroidTlsProvider)` to `btls`.

The problem with using btls is that `libmono-btls-shared.so` is *big*,
between 3.3MB for x86 to 3.8MB for x86_64. Compressed into a `.apk`,
it contributes *at least* 1MB *per supported ABI*.

However, "missing" TLS 1.2 support in default projects is becoming
untenable. We need to pick *something* to improve our default project
experience.

Update the `<BuildApk/>` task so that if `$(AndroidTlsProvider)` is
not otherwise set, we default to using `btls`.

Developers may "undo" this change to default build behavior by setting
`$(AndroidTlsProvider)` to either `default` or `legacy`.

[0]: https://developer.android.com/about/dashboards/index.html