### PR TITLE
[proguard] Preserve ManagedPeer class

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Resources/proguard_xamarin.cfg
+++ b/src/Xamarin.Android.Build.Tasks/Resources/proguard_xamarin.cfg
@@ -12,6 +12,7 @@
 -keep class opentk.GameViewBase { *; <init>(...); }
 -keep class opentk_1_0.platform.android.AndroidGameView { *; <init>(...); }
 -keep class opentk_1_0.GameViewBase { *; <init>(...); }
+-keep class com.xamarin.java_interop.ManagedPeer { *; <init>(...); }
 
 -keep class android.runtime.** { <init>(***); }
 -keep class assembly_mono_android.android.runtime.** { <init>(***); }


### PR DESCRIPTION
After XA stopped using Java.Interop built in XAIntegration
configuration, we need com.xamarin.java_interop.ManagedPeer to be
present in the mono.android.jar file, as managed ManagedPeer type
requires it.

Thus we need to preserve that class when using proguard.

Fixes https://github.com/xamarin/xamarin-android/issues/1331