### PR TITLE
[xabuild] Remove Mono.Posix use

### DIFF
--- a/tools/xabuild/packages.config
+++ b/tools/xabuild/packages.config
@@ -1,4 +1,3 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Mono.Posix" version="4.0.0.0" targetFramework="net46" />
 </packages>

--- a/tools/xabuild/xabuild.csproj
+++ b/tools/xabuild/xabuild.csproj
@@ -36,9 +36,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Mono.Posix, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Mono.Posix.4.0.0.0\lib\net40\Mono.Posix.dll</HintPath>
-    </Reference>
     <Reference Include="MSBuild">
       <HintPath>$(_MSBuildToolsPath)\MSBuild.$(_MSBuildExtension)</HintPath>
     </Reference>


### PR DESCRIPTION
We would like to migrate to using `msbuild` to build everything on
Jenkins, instead of `xbuild`.

Before doing so, we updated the [xamarin-android-msbuild][0] job so
that it mirrored the [xamarin-android][1] job, updating it to build
and run unit tests. (Unit tests were previously skipped on the
`xamarin-android-msbuild` job because unit test execution takes
awhile, and behavior under MSBuild *should* be identical to that under
`xbuild`, so there wasn't a perceived need to spend time on them.)

It is at that point that [everything stopped working][2]:

	/Users/builder/jenkins/workspace/xamarin-android-msbuild/tools/scripts/../../bin/Debug/bin/xabuild.exe.dll /p:Configuration=Debug /p:MonoDroidInstallDirectory=/Users/builder/jenkins/workspace/xamarin-android-msbuild/tools/scripts/../../bin/Debug /v:diag Xamarin.Android-Tests.sln
	...
	Stacktrace:

	  at <unknown> <0xffffffff>
	  at (wrapper managed-to-native) object.__icall_wrapper_mono_gc_alloc_vector (intptr,intptr,intptr)
	  at (wrapper alloc) object.AllocVector (intptr,intptr)
	  at System.Collections.Hashtable.rehash (int,bool)
	  at System.Collections.Hashtable.expand ()
	  at System.Collections.Hashtable.Insert (object,object,bool)
	  at System.Collections.Hashtable.set_Item (object,object)
	  at System.Environment.GetEnvironmentVariables ()
	  at Microsoft.Build.Internal.CommunicationsUtilities.GetEnvironmentVariables ()
	  at Microsoft.Build.Execution.BuildParameters.Initialize (Microsoft.Build.Collections.PropertyDictionary`1<Microsoft.Build.Execution.ProjectPropertyInstance>,Microsoft.Build.Evaluation.ProjectRootElementCache,Microsoft.Build.Evaluation.ToolsetProvider)
	  at Microsoft.Build.Execution.BuildParameters..ctor (Microsoft.Build.Evaluation.ProjectCollection)
	  at Microsoft.Build.Execution.ProjectInstance..ctor (Microsoft.Build.Construction.ProjectRootElement,System.Collections.Generic.IDictionary`2<string, string>,string,int,Microsoft.Build.Evaluation.ProjectCollection,Microsoft.Build.BackEnd.SdkResolution.ISdkResolverService,int)
	  at Microsoft.Build.Construction.SolutionProjectGenerator.CreateTraversalInstance (string,bool,System.Collections.Generic.List`1<Microsoft.Build.Construction.ProjectInSolution>)
	  at Microsoft.Build.Construction.SolutionProjectGenerator.CreateSolutionProject (string,bool)
	  at Microsoft.Build.Construction.SolutionProjectGenerator.Generate ()
	  at Microsoft.Build.Construction.SolutionProjectGenerator.Generate (Microsoft.Build.Construction.SolutionFile,System.Collections.Generic.IDictionary`2<string, string>,string,Microsoft.Build.Framework.BuildEventContext,Microsoft.Build.BackEnd.Logging.ILoggingService,System.Collections.Generic.IReadOnlyCollection`1<string>,Microsoft.Build.BackEnd.SdkResolution.ISdkResolverService,int)
	  at Microsoft.Build.Execution.ProjectInstance.GenerateSolutionWrapper (string,System.Collections.Generic.IDictionary`2<string, string>,string,Microsoft.Build.BackEnd.Logging.ILoggingService,Microsoft.Build.Framework.BuildEventContext,System.Collections.Generic.IReadOnlyCollection`1<string>,Microsoft.Build.BackEnd.SdkResolution.ISdkResolverService,int)
	  at Microsoft.Build.Execution.ProjectInstance.LoadSolutionForBuild (string,Microsoft.Build.Collections.PropertyDictionary`1<Microsoft.Build.Execution.ProjectPropertyInstance>,string,Microsoft.Build.Execution.BuildParameters,Microsoft.Build.BackEnd.Logging.ILoggingService,Microsoft.Build.Framework.BuildEventContext,bool,System.Collections.Generic.IReadOnlyCollection`1<string>,Microsoft.Build.BackEnd.SdkResolution.ISdkResolverService,int)
	  at Microsoft.Build.Execution.BuildManager.LoadSolutionIntoConfiguration (Microsoft.Build.BackEnd.BuildRequestConfiguration,Microsoft.Build.BackEnd.BuildRequest)
	  at Microsoft.Build.Execution.BuildManager.HandleNewRequest (int,Microsoft.Build.BackEnd.BuildRequestBlocker)
	  at Microsoft.Build.Execution.BuildManager.IssueRequestToScheduler (Microsoft.Build.Execution.BuildSubmission,bool,Microsoft.Build.BackEnd.BuildRequestBlocker)
	  at Microsoft.Build.Execution.BuildManager/<>c__DisplayClass63_1.<ExecuteSubmission>b__0 ()
	  at Microsoft.Build.Execution.BuildManager.ProcessWorkQueue (System.Action)
	  at Microsoft.Build.Execution.BuildManager.<BeginBuild>b__50_0 (System.Action)
	  at System.Threading.Tasks.Dataflow.ActionBlock`1<TInput_REF>.ProcessMessage (System.Action`1<TInput_REF>,System.Collections.Generic.KeyValuePair`2<TInput_REF, long>)
	  at System.Threading.Tasks.Dataflow.ActionBlock`1/<>c__DisplayClass5<TInput_REF>.<.ctor>b__0 (System.Collections.Generic.KeyValuePair`2<TInput_REF, long>)
	  at System.Threading.Tasks.Dataflow.Internal.TargetCore`1<TInput_REF>.ProcessMessagesLoopCore ()
	  at System.Threading.Tasks.Dataflow.Internal.TargetCore`1<TInput_REF>.<ProcessAsyncIfNecessary_Slow>b__3 (object)
	  at System.Threading.Tasks.Task.InnerInvoke ()
	  at System.Threading.Tasks.Task.Execute ()
	  at System.Threading.Tasks.Task.ExecutionContextCallback (object)
	  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext,System.Threading.ContextCallback,object,bool)
	  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext,System.Threading.ContextCallback,object,bool)
	  at System.Threading.Tasks.Task.ExecuteWithThreadLocal (System.Threading.Tasks.Task&)
	  at System.Threading.Tasks.Task.ExecuteEntry (bool)
	  at System.Threading.Tasks.Task.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem ()
	  at System.Threading.ThreadPoolWorkQueue.Dispatch ()
	  at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback ()
	  at (wrapper runtime-invoke) <Module>.runtime_invoke_bool (object,intptr,intptr,intptr)

	Native stacktrace:

		0   mono                                0x000000010b3c1251 mono_handle_native_crash + 257
		1   mono                                0x000000010b45d9f6 altstack_handle_and_restore + 70
		2   mono                                0x000000010b593fd4 sgen_client_par_object_get_size + 4
		3   mono                                0x000000010b594e6b pin_objects_in_nursery + 667
		4   mono                                0x000000010b5942a0 collect_nursery + 512
		5   mono                                0x000000010b590dea sgen_perform_collection + 442
		6   mono                                0x000000010b58662b sgen_alloc_obj_nolock + 763
		7   mono                                0x000000010b583997 mono_gc_alloc_vector + 119
		8   ???                                 0x000000010bac87f5 0x0 + 4490823669
		9   mscorlib.dll.dylib                  0x000000010d79596f System_Collections_Hashtable_rehash_int_bool + 95
		10  ???                                 0x000000010f213323 0x0 + 4548801315
		11  ???                                 0x000000010f29e123 0x0 + 4549370147
		12  ???                                 0x000000010f29ce73 0x0 + 4549365363
		13  ???                                 0x000000010f29cb1b 0x0 + 4549364507
		14  ???                                 0x000000010f23aa2b 0x0 + 4548962859
		15  ???                                 0x000000010f238fc3 0x0 + 4548956099
		16  ???                                 0x000000010f2384d3 0x0 + 4548953299
		17  ???                                 0x000000010f237fbb 0x0 + 4548951995
		18  ???                                 0x000000010f237853 0x0 + 4548950099
		19  ???                                 0x000000010f237463 0x0 + 4548949091
		20  ???                                 0x000000010f237262 0x0 + 4548948578
		21  ???                                 0x000000010f23710b 0x0 + 4548948235
		22  ???                                 0x000000010f236eab 0x0 + 4548947627
		23  ???                                 0x000000010f235f6b 0x0 + 4548943723
		24  mscorlib.dll.dylib                  0x000000010d6679b6 System_Threading_Tasks_Task_ExecutionContextCallback_object + 70
		25  mscorlib.dll.dylib                  0x000000010d63d651 System_Threading_ExecutionContext_Run_System_Threading_ExecutionContext_System_Threading_ContextCallback_object_bool + 33
		26  mscorlib.dll.dylib                  0x000000010d667767 System_Threading_Tasks_Task_ExecuteEntry_bool + 231
		27  mscorlib.dll.dylib                  0x000000010d644ab9 System_Threading__ThreadPoolWaitCallback_PerformWaitCallback + 9
		28  mono                                0x000000010b3163d7 mono_jit_runtime_invoke + 1383
		29  mono                                0x000000010b50e1f4 do_runtime_invoke + 84
		30  mono                                0x000000010b532ac6 worker_callback + 966
		31  mono                                0x000000010b53519c worker_thread + 348
		32  mono                                0x000000010b530080 start_wrapper + 704
		33  libsystem_pthread.dylib             0x00007fff8ff5199d _pthread_body + 131
		34  libsystem_pthread.dylib             0x00007fff8ff5191a _pthread_body + 0
		35  libsystem_pthread.dylib             0x00007fff8ff4f351 thread_start + 13

The #mono team investigated, and determined that the crash was due to
memory corruption caused by `Mono.Unix.Native.Syscall.stat()`.

Specifically, the [`Mono.Posix.dll` package][3] which `xabuild.exe`
was using is *ancient* (5+ years old), and -- more importantly --
comes from a time *before* the `Mono.Unix.Native.Stat.st_atime_nsec`
and related fields existed. Consequently, the `Stat` size within
`Mono.Posix.dll` differed -- 24 bytes smaller! -- than what
`libMonoPosixHelper.dylib` expected, wherein `libMonoPosixHelper.dylib`
is coming from the `build-tools/mono-runtimes` build (significantly
newer than `Mono.Posix.dll`).

The `Mono.Posix` nuget package is thus incompatible with our current
use case.

Alternatively, we could update the mono bundle to include the built
`build/net45/mac/Mono.Posix.dll` file, but I have "bootstrap"
concerns, and am not convinced that I want to wait until after
`build-tools/mono-runtimes` has finished building in order to use
`xabuild.exe` in all scenarios.

Thus, to fix the above memory corruption, *remove* use of
`Mono.Posix.dll` from `xabuild.exe`, and instead directly P/Invoke the
needed POSIX functions, specifically **symlink**(2) and **perror**(3).

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-msbuild/
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/
[2]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-msbuild/761/
[3]: https://www.nuget.org/packages/Mono.Posix/4.0.0