### PR TITLE
Make it easier to build for an API platform other than default

### DIFF
--- a/Documentation/DevelopmentTips.md
+++ b/Documentation/DevelopmentTips.md
@@ -2,6 +2,30 @@
 
 Tips and tricks while developing Xamarin.Android.
 
+# How do I build Xamarin.Android for a given API?
+
+There are a few ways to do it:
+
+* Use [Configuration.Override.props][override-props]
+* Build all the platforms with
+  
+      make framework-assemblies
+  
+* Build several platforms other than the default
+  
+      make framework-assemblies API_LEVELS="LEVEL1 LEVEL2"
+  
+  where *LEVEL1* and *LEVEL2* are [API levels from the API_LEVELS variable][api-levels]
+  
+* Build just the platform you want, other than the default one with
+  
+      make API_LEVEL=LEVEL
+  
+  where *LEVEL* is one of the [API levels from the API_LEVELS variable][api-levels]
+
+[override-props]: ../README.md#build-configuration
+[api-levels]: ../build-tools/scripts/BuildEverything.mk#L31]
+
 # How do I rebuild the Mono Runtime and Native Binaries?
 
 ## The short way

--- a/Documentation/DevelopmentTips.md
+++ b/Documentation/DevelopmentTips.md
@@ -2,26 +2,34 @@
 
 Tips and tricks while developing Xamarin.Android.
 
-# How do I build Xamarin.Android for a given API?
+# How do I build `Mono.Android.dll` for a given API Level?
 
 There are a few ways to do it:
 
-* Use [Configuration.Override.props][override-props]
-* Build all the platforms with
+  * Use [`Configuration.Override.props`][override-props], and override 
+    `$(AndroidApiLevel)` and `$(AndroidFrameworkVersion)`.
+
+  * Build all the platforms with:
   
-      make framework-assemblies
+        make framework-assemblies
   
-* Build several platforms other than the default
+    Note that `make framework-assemblies` builds `Mono.Android.dll`
+    for *both* Debug and Release configurations. To build only a
+    single configuration, set the `$(CONFIGURATIONS)` make variable:
+
+        make framework-assemblies CONFIGURATIONS=Debug
+
+  * Build several platforms other than the default
   
-      make framework-assemblies API_LEVELS="LEVEL1 LEVEL2"
+        make framework-assemblies API_LEVELS="LEVEL1 LEVEL2"
   
-  where *LEVEL1* and *LEVEL2* are [API levels from the API_LEVELS variable][api-levels]
+    where *LEVEL1* and *LEVEL2* are [API levels from the `$(API_LEVELS)` variable][api-levels].
   
-* Build just the platform you want, other than the default one with
+  * Build just the platform you want, other than the default one with
   
-      make API_LEVEL=LEVEL
+        make API_LEVEL=LEVEL
   
-  where *LEVEL* is one of the [API levels from the API_LEVELS variable][api-levels]
+    where *LEVEL* is one of the [API levels from the `$(API_LEVELS)` variable][api-levels].
 
 [override-props]: ../README.md#build-configuration
 [api-levels]: ../build-tools/scripts/BuildEverything.mk#L31]

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ CONFIGURATION = Debug
 RUNTIME       := $(shell if [ -f "`which mono64`" ] ; then echo mono64 ; else echo mono; fi) --debug=casts
 SOLUTION      = Xamarin.Android.sln
 TEST_TARGETS  = build-tools/scripts/RunTests.targets
+API_LEVEL     ?=
 
 ifneq ($(V),0)
 MONO_OPTIONS += --debug
@@ -23,6 +24,10 @@ _SLN_BUILD  = $(MSBUILD)
 else    # $(MSBUILD) != 1
 _SLN_BUILD  = MSBUILD="$(MSBUILD)" tools/scripts/xabuild
 endif   # $(USE_MSBUILD) == 1
+
+ifneq ($(API_LEVEL),)
+MSBUILD_FLAGS += /p:AndroidApiLevel=$(API_LEVEL) /p:AndroidFrameworkVersion=$(word $(API_LEVEL), $(ALL_FRAMEWORKS))
+endif
 
 all::
 	$(_SLN_BUILD) $(MSBUILD_FLAGS) $(SOLUTION)


### PR DESCRIPTION
This commits adds the `ANDROID_API` makefile variable which, when set, will
build XA for the specified platform. It takes advantage of the variables found
in BuildEverything.mk by indexing the ALL_FRAMEWORKS variable with the API level
number and setting the msbuild properties accordingly.