### PR TITLE
[Xamarin.Android.Build.Tasks] Emit @(XamarinProjectAnalysisResult)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Analysis.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Analysis.targets
@@ -50,7 +50,7 @@ Copyright (C) 2015 Xamarin. All rights reserved.
 		<Output TaskParameter="Result" ItemName="_MinSdkValue" />
 	</XmlPeek>
 	<ItemGroup>
-		<XamarinPackageAnalysisTargets Include="XAA0001" 
+		<XamarinProjectAnalysisResult Include="XAA0001"
 				Condition="($(AndroidSupportedAbis.Contains('arm64-v8a')) Or $(AndroidSupportedAbis.Contains('x86_64'))) And '@(_MinSdkValue)' &lt; '10'" >
 			<Category>Android</Category>
 			<Problem>
@@ -59,7 +59,7 @@ Copyright (C) 2015 Xamarin. All rights reserved.
 			<Fix>
 				Update the minSdkVersion in your app
 			</Fix>
-		</XamarinPackageAnalysisTargets>
+		</XamarinProjectAnalysisResult>
 	</ItemGroup>
 </Target>
 


### PR DESCRIPTION
Visual Studio allows "project analysis rules" to be run against a
project, so that problems which shouldn't be build errors or warnigns
can still be reported to the developer.

In Visual Studio for Mac, the analysis rules can be executed via the
**Project** > **Run Code Analysis On *Project Name*** menu item.

However, when I do this in a project which should elicit an analysis
error, *nothing* is reported. :-/

The `xamarin-analysis` documentation states that the analysis rules
should emit errors into the `@(XamarinProjectAnalysisResult)`
item group.

We were inadvertently placing these into
`@(XamarinPackageAnalysisTargets)`, which is actually used to
determine which targets should be executed. As such, no errors are
actually displayed to the developer within the IDE.