### PR TITLE
[Xamarin.Android.Build.Tasks] Better support for netstandard libraries.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks.tpnitems
+++ b/src/Xamarin.Android.Build.Tasks.tpnitems
@@ -78,5 +78,47 @@
       </LicenseText>
       <SourceUrl>https://github.com/IronyProject/Irony</SourceUrl>
     </ThirdPartyNotice>
+    <ThirdPartyNotice Include="JamesNK/Newtonsoft.Json">
+      <LicenseText>
+      The MIT License (MIT)
+
+      Copyright (c) 2007 James Newton-King
+
+      Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+      associated documentation files (the "Software"), to deal in the Software without restriction, including
+      without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+      copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+      following conditions:
+
+      The above copyright notice and this permission notice shall be included in all copies or substantial
+      portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+      LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+      WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+      </LicenseText>
+      <SourceUrl>https://github.com/JamesNK/Newtonsoft.Json</SourceUrl>
+    </ThirdPartyNotice>
+    <ThirdPartyNotice Include="NuGet/NuGet.Client">
+      <LicenseText>
+      Copyright (c) .NET Foundation and Contributors.
+
+      All rights reserved.
+
+      Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+      these files except in compliance with the License. You may obtain a copy of the
+      License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software distributed
+      under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+      CONDITIONS OF ANY KIND, either express or implied. See the License for the
+      specific language governing permissions and limitations under the License.
+      </LicenseText>
+      <SourceUrl>https://github.com/NuGet/NuGet.Client</SourceUrl>
+    </ThirdPartyNotice>
   </ItemGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -79,7 +79,7 @@ namespace Xamarin.Android.Tasks
 
 			LockFile lockFile = null;
 			if (!string.IsNullOrEmpty (ProjectAssetFile) && File.Exists (ProjectAssetFile)) {
-				lockFile = LockFileUtilities.GetLockFile (ProjectAssetFile, NullLogger.Instance);
+				lockFile = LockFileUtilities.GetLockFile (ProjectAssetFile, new NuGetLogger(Log));
 			}
 
 			try {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -280,9 +280,14 @@ namespace XamFormsSample
 
         public App()
         {
-            JsonConvert.DeserializeObject<string>(""test"");
-            package = Package.Open ("""");
+            try {
+                JsonConvert.DeserializeObject<string>(""test"");
+                package = Package.Open ("""");
+            } catch {
+            }
             InitializeComponent();
+
+            MainPage = new ContentPage ();
         }
 
         protected override void OnStart()
@@ -320,6 +325,7 @@ namespace XamFormsSample
 				IsRelease = true,
 				UseLatestPlatformSdk = true,
 				References = {
+					new BuildItem.Reference ("Java.Interop.Export"),
 					new BuildItem.Reference ("Mono.Android.Export"),
 					new BuildItem.ProjectReference ($"..\\{netStandardProject.ProjectName}\\{netStandardProject.ProjectName}.csproj",
 						netStandardProject.ProjectName, netStandardProject.ProjectGuid),
@@ -337,6 +343,29 @@ namespace XamFormsSample
 					KnownPackages.XamarinForms_2_3_4_231,
 				}
 			};
+			app.MainActivity = @"using System;
+using Android.App;
+using Android.Content;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+using Android.OS;
+using XamFormsSample;
+
+namespace App1
+{
+	[Activity (Label = ""App1"", MainLauncher = true, Icon = ""@drawable/icon"")]
+	public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity {
+			protected override void OnCreate (Bundle bundle)
+			{
+				base.OnCreate (bundle);
+
+				global::Xamarin.Forms.Forms.Init (this, bundle);
+
+				LoadApplication (new App ());
+			}
+		}
+	}";
 			app.SetProperty (KnownProperties.AndroidSupportedAbis, "x86;armeabi-v7a");
 			var expectedFiles = new string [] {
 				"Java.Interop.dll",
@@ -346,6 +375,7 @@ namespace XamFormsSample
 				"System.dll",
 				"System.Runtime.Serialization.dll",
 				"System.IO.Packaging.dll",
+				"System.IO.Compression.dll",
 				"Mono.Android.Export.dll",
 				"App1.dll",
 				"FormsViewGroup.dll",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -325,7 +325,6 @@ namespace XamFormsSample
 				IsRelease = true,
 				UseLatestPlatformSdk = true,
 				References = {
-					new BuildItem.Reference ("Java.Interop.Export"),
 					new BuildItem.Reference ("Mono.Android.Export"),
 					new BuildItem.ProjectReference ($"..\\{netStandardProject.ProjectName}\\{netStandardProject.ProjectName}.csproj",
 						netStandardProject.ProjectName, netStandardProject.ProjectGuid),

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Android.Build.Tests</RootNamespace>
     <AssemblyName>Xamarin.Android.Build.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="Xamarin.Android.Build.Tests.Shared.projitems" Label="Shared" Condition="Exists('Xamarin.Android.Build.Tests.Shared.projitems')" />
   <Import Project="..\..\..\..\Configuration.props" />

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NuGetLogger.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NuGetLogger.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using NuGet.Common;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Tasks {
+
+	class NuGetLogger : ILogger {
+		TaskLoggingHelper log;
+
+		public NuGetLogger (TaskLoggingHelper log)
+		{
+			this.log = log;
+		}
+
+		public void Log (LogLevel level, string data)
+		{
+			log.LogMessage (data);
+		}
+
+		public void Log (ILogMessage message)
+		{
+			log.LogMessage (message.Message);
+		}
+
+		public System.Threading.Tasks.Task LogAsync (LogLevel level, string data)
+		{
+			return System.Threading.Tasks.Task.Run (() => Log (level, data));
+		}
+
+		public System.Threading.Tasks.Task LogAsync (ILogMessage message)
+		{
+			return System.Threading.Tasks.Task.Run (() => Log (message));
+		}
+
+		public void LogDebug (string data)
+		{
+			Log (LogLevel.Debug, data);
+		}
+
+		public void LogError (string data)
+		{
+			Log (LogLevel.Debug, data);
+		}
+
+		public void LogInformation (string data)
+		{
+			Log (LogLevel.Debug, data);
+		}
+
+		public void LogInformationSummary (string data)
+		{
+			Log (LogLevel.Debug, data);
+		}
+
+		public void LogMinimal (string data)
+		{
+			Log (LogLevel.Debug, data);
+		}
+
+		public void LogVerbose (string data)
+		{
+			Log (LogLevel.Debug, data);
+		}
+
+		public void LogWarning (string data)
+		{
+			Log (LogLevel.Debug, data);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NuGetLogger.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NuGetLogger.cs
@@ -6,28 +6,28 @@ using TPL = System.Threading.Tasks;
 namespace Xamarin.Android.Tasks {
 
 	class NuGetLogger : LoggerBase {
-		TaskLoggingHelper log;
+		Action<string> log;
 
-		public NuGetLogger (TaskLoggingHelper log)
+		public NuGetLogger (Action<string> log)
 		{
 			this.log = log;
 		}
 
-		public override void Log(ILogMessage message) {
-			log.LogDebugMessage ("{0}", message.Message);
+		public override void Log (ILogMessage message) {
+			log (message.Message);
 		}
 
-		public override void Log(LogLevel level, string data) {
-			log.LogDebugMessage ("{0}", data);
+		public override void Log (LogLevel level, string data) {
+			log (data);
 		}
 
-		public override TPL.Task LogAsync(ILogMessage message) {
-			Log(message);
+		public override TPL.Task LogAsync (ILogMessage message) {
+			Log (message);
 			return TPL.Task.FromResult(0);
 		}
 
-		public override TPL.Task LogAsync(LogLevel level, string data) {
-			Log(level, data);
+		public override TPL.Task LogAsync (LogLevel level, string data) {
+			Log (level, data);
 			return TPL.Task.FromResult(0);
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NuGetLogger.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NuGetLogger.cs
@@ -14,12 +14,12 @@ namespace Xamarin.Android.Tasks {
 
 		public void Log (LogLevel level, string data)
 		{
-			log.LogMessage (data);
+			log.LogDebugMessage (data);
 		}
 
 		public void Log (ILogMessage message)
 		{
-			log.LogMessage (message.Message);
+			log.LogDebugMessage (message.Message);
 		}
 
 		public System.Threading.Tasks.Task LogAsync (LogLevel level, string data)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NuGetLogger.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NuGetLogger.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using NuGet.Common;
 using Microsoft.Build.Utilities;
+using TPL = System.Threading.Tasks;
 
 namespace Xamarin.Android.Tasks {
 
-	class NuGetLogger : ILogger {
+	class NuGetLogger : LoggerBase {
 		TaskLoggingHelper log;
 
 		public NuGetLogger (TaskLoggingHelper log)
@@ -12,59 +13,22 @@ namespace Xamarin.Android.Tasks {
 			this.log = log;
 		}
 
-		public void Log (LogLevel level, string data)
-		{
-			log.LogDebugMessage (data);
+		public override void Log(ILogMessage message) {
+			log.LogDebugMessage ("{0}", message.Message);
 		}
 
-		public void Log (ILogMessage message)
-		{
-			log.LogDebugMessage (message.Message);
+		public override void Log(LogLevel level, string data) {
+			log.LogDebugMessage ("{0}", data);
 		}
 
-		public System.Threading.Tasks.Task LogAsync (LogLevel level, string data)
-		{
-			return System.Threading.Tasks.Task.Run (() => Log (level, data));
+		public override TPL.Task LogAsync(ILogMessage message) {
+			Log(message);
+			return TPL.Task.FromResult(0);
 		}
 
-		public System.Threading.Tasks.Task LogAsync (ILogMessage message)
-		{
-			return System.Threading.Tasks.Task.Run (() => Log (message));
-		}
-
-		public void LogDebug (string data)
-		{
-			Log (LogLevel.Debug, data);
-		}
-
-		public void LogError (string data)
-		{
-			Log (LogLevel.Debug, data);
-		}
-
-		public void LogInformation (string data)
-		{
-			Log (LogLevel.Debug, data);
-		}
-
-		public void LogInformationSummary (string data)
-		{
-			Log (LogLevel.Debug, data);
-		}
-
-		public void LogMinimal (string data)
-		{
-			Log (LogLevel.Debug, data);
-		}
-
-		public void LogVerbose (string data)
-		{
-			Log (LogLevel.Debug, data);
-		}
-
-		public void LogWarning (string data)
-		{
-			Log (LogLevel.Debug, data);
+		public override TPL.Task LogAsync(LogLevel level, string data) {
+			Log(level, data);
+			return TPL.Task.FromResult(0);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>Xamarin.Android.Tasks</RootNamespace>
     <AssemblyName>Xamarin.Android.Build.Tasks</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
@@ -50,6 +50,52 @@
     </Reference>
     <Reference Include="FSharp.Core">
       <HintPath>..\..\packages\FSharp.Core.3.1.2.5\lib\net40\FSharp.Core.dll</HintPath>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Frameworks">
+      <HintPath>..\..\packages\NuGet.Frameworks.4.6.0\lib\net46\NuGet.Frameworks.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Common">
+      <HintPath>..\..\packages\NuGet.Common.4.6.0\lib\net46\NuGet.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="NuGet.Configuration">
+      <HintPath>..\..\packages\NuGet.Configuration.4.6.0\lib\net46\NuGet.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security" />
+    <Reference Include="NuGet.Versioning">
+      <HintPath>..\..\packages\NuGet.Versioning.4.6.0\lib\net46\NuGet.Versioning.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.LibraryModel">
+      <HintPath>..\..\packages\NuGet.LibraryModel.4.6.0\lib\net46\NuGet.LibraryModel.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Packaging.Core">
+      <HintPath>..\..\packages\NuGet.Packaging.Core.4.6.0\lib\net46\NuGet.Packaging.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Packaging">
+      <HintPath>..\..\packages\NuGet.Packaging.4.6.0\lib\net46\NuGet.Packaging.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Runtime.InteropServices">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.4.3.0\lib\net462\System.Runtime.InteropServices.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Protocol">
+      <HintPath>..\..\packages\NuGet.Protocol.4.6.0\lib\net46\NuGet.Protocol.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IdentityModel" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="NuGet.DependencyResolver.Core">
+      <HintPath>..\..\packages\NuGet.DependencyResolver.Core.4.6.0\lib\net46\NuGet.DependencyResolver.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.ProjectModel">
+      <HintPath>..\..\packages\NuGet.ProjectModel.4.6.0\lib\net46\NuGet.ProjectModel.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -553,6 +553,7 @@
     <Compile Include="Utilities\SatelliteAssembly.cs" />
     <Compile Include="Tasks\AndroidApkSigner.cs" />
     <Compile Include="Tasks\Desugar.cs" />
+    <Compile Include="Utilities\NuGetLogger.cs" />
     <None Include="Resources\desugar_deploy.jar">
       <Link>desugar_deploy.jar</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -50,6 +50,7 @@
     </Reference>
     <Reference Include="FSharp.Core">
       <HintPath>..\..\packages\FSharp.Core.3.1.2.5\lib\net40\FSharp.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1591,6 +1591,9 @@ because xbuild doesn't support framework reference assemblies.
 		Assemblies="@(FilteredAssemblies)"
 		I18nAssemblies="$(MandroidI18n)"
 		LinkMode="$(AndroidLinkMode)"
+		ProjectAssetFile="$(ProjectLockFile)"
+		NuGetPackageRoot="$(NuGetPackageRoot)"
+		TargetMoniker="$(NuGetTargetMoniker)"
 		ReferenceAssembliesDirectory="$(TargetFrameworkDirectory)">
       <Output TaskParameter="ResolvedAssemblies" ItemName="ResolvedAssemblies" />
       <Output TaskParameter="ResolvedUserAssemblies" ItemName="ResolvedUserAssemblies" />

--- a/src/Xamarin.Android.Build.Tasks/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/packages.config
@@ -3,4 +3,17 @@
   <package id="FSharp.Compiler.CodeDom" version="1.0.0.1" targetFramework="net45" />
   <package id="FSharp.Core" version="3.1.2.5" targetFramework="net451" />
   <package id="Irony" version="0.9.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net451" />
+  <package id="NuGet.Common" version="4.6.0" targetFramework="net462" />
+  <package id="NuGet.Configuration" version="4.6.0" targetFramework="net462" />
+  <package id="NuGet.DependencyResolver.Core" version="4.6.0" targetFramework="net462" />
+  <package id="NuGet.Frameworks" version="4.6.0" targetFramework="net462" />
+  <package id="NuGet.LibraryModel" version="4.6.0" targetFramework="net462" />
+  <package id="NuGet.Packaging" version="4.6.0" targetFramework="net462" />
+  <package id="NuGet.Packaging.Core" version="4.6.0" targetFramework="net462" />
+  <package id="NuGet.ProjectModel" version="4.6.0" targetFramework="net462" />
+  <package id="NuGet.Protocol" version="4.6.0" targetFramework="net462" />
+  <package id="NuGet.Versioning" version="4.6.0" targetFramework="net462" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
Fixes #1154, #1162

Netstandard packages sometimes ship with both reference and
implementation assemblies. The Nuget build task `ResolveNuGetPackageAssets`
only resolves the `ref` version of the assemblies. There does
not seem to be away way to FORCE Nuget to resolve the lib one.
How .net Core manages to do this is still a mistery. That said
the Nuget `ResolveNuGetPackageAssets` does give us a hint as to
how to use the `project.assets.json` file to figure out what
`lib` version of the package we should be including.

This commit reworks `ResolveAssemblies` to attempt to map the
`ref` to a `lib` if we find a Referenece Assembly. Historically
we just issue a warning (which will probably be ignored), but
now we will use the `project.assets.json` file to find the
implementation version of the `ref` assembly.

We need to be using `Nuget.ProjectModel` since it an API for 
querying the `project.assets.json`. We make use of the Nuget build properties
`$(ProjectLockFile)` for the location of the `project.assets.json`
, `$(NuGetPackageRoot)` for the root folder of the Nuget packages
and `$(NuGetTargetMoniker)` for resolving which `TargetFrameworks` 
we are looking for. All of these properties should be set by Nuget.
If they are not we should fallback to the default behaviour and just issue the warning.

	{
  		"version": 3,
  		"targets": {
    			"MonoAndroid,Version=v8.1": {
				"System.IO.Packaging/4.4.0": {
					"type": "package",
					"compile": {
						"ref/netstandard1.3/System.IO.Packaging.dll": {}
					},
					"runtime": {
						"lib/netstandard1.3/System.IO.Packaging.dll": {}
					}
				},
			}
		}
	}

The code above is a cut down sample of the `project.assets.json`. So our
code will first resolve the `targets`. We use `$(NuGetTargetMoniker)` to
do this. For an android project this should have a value of
`MonoAndroid,Version=v8.1`. Note we do NOT need to worry about the version
here. When Nuget restores the packages it creates the file so it will
use the correct version.
Next we try to find the `System.IO.Packaging`. We need to look at the
`lockFile.Libraries` to get information about the install path in the 
Nuget folder, and then `target.Libraries` to pick out the  `runtime`
item.
Once we have resolved the path we need to then combine that with the 
`$(NuGetPackageRoot)` to get the full path to the new library. If at any 
point during all of this code we don't get what we expect (i.e a null) we 
should abort and just issue the warning.

The only real concern with this is if the format of the `project.assets.json`
file changes. It is not ment to be edited by a human so there is the
possibiltity that the Nuget team will decide to either change the schema or
even migrate to a new file format. Hopefully we can just update the `Nuget`
nuggets if that happens.