### PR TITLE
[build] Use `cp -f` in `make package-oss`

### DIFF
--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -166,7 +166,7 @@ package-oss $(ZIP_OUTPUT):
 	if [ -d bin/Release/bin ] ; then cp tools/scripts/xabuild bin/Release/bin ; fi
 	if [ ! -d $(ZIP_OUTPUT_BASENAME) ] ; then mkdir $(ZIP_OUTPUT_BASENAME) ; fi
 	if [ ! -L $(ZIP_OUTPUT_BASENAME)/bin ] ; then ln -s ../bin $(ZIP_OUTPUT_BASENAME) ; fi
-	if [ ! -f $(ZIP_OUTPUT_BASENAME)/ThirdPartyNotices.txt ] ; then cp bin/*/lib/xamarin.android/ThirdPartyNotices.txt $(ZIP_OUTPUT_BASENAME) ; fi
+	if [ ! -f $(ZIP_OUTPUT_BASENAME)/ThirdPartyNotices.txt ] ; then cp -f bin/*/lib/xamarin.android/ThirdPartyNotices.txt $(ZIP_OUTPUT_BASENAME) ; fi
 	_exclude_list=".__exclude_list.txt"; \
 	ls -1d $(_BUNDLE_ZIPS_EXCLUDE) > "$$_exclude_list" 2>/dev/null ; \
 	for c in $(CONFIGURATIONS) ; do \


### PR DESCRIPTION
Commit 2bd13c4a [broke the Linux build][0]:

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-linux/817/

	cp: will not overwrite just-created 'xamarin.android-oss_v8.3.99.20_Linux-x86_64_HEAD_2bd13c4/ThirdPartyNotices.txt' with 'bin/Release/lib/xamarin.android/ThirdPartyNotices.txt'
	build-tools/scripts/BuildEverything.mk:165: recipe for target 'xamarin.android-oss_v8.3.99.20_Linux-x86_64_HEAD_2bd13c4.tar.bz2' failed

I don't care if the Debug or Release file is used; they should be
identical.

Replace `cp` with `cp -f` so that `make package-oss` doesn't fail.