### PR TITLE
Fix package creation on oss

### DIFF
--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -38,6 +38,12 @@ FRAMEWORKS        = $(foreach a, $(API_LEVELS), $(word $(a),$(ALL_FRAMEWORKS)))
 STABLE_FRAMEWORKS = $(foreach a, $(STABLE_API_LEVELS), $(word $(a),$(ALL_FRAMEWORKS)))
 PLATFORM_IDS      = $(foreach a, $(API_LEVELS), $(word $(a),$(ALL_PLATFORM_IDS)))
 
+ifeq ($(OS_NAME),Linux)
+CP_F              = cp -af
+else
+CP_F              = cp -f
+endif
+
 ALL_JIT_ABIS  = \
 	armeabi \
 	armeabi-v7a \
@@ -166,7 +172,7 @@ package-oss $(ZIP_OUTPUT):
 	if [ -d bin/Release/bin ] ; then cp tools/scripts/xabuild bin/Release/bin ; fi
 	if [ ! -d $(ZIP_OUTPUT_BASENAME) ] ; then mkdir $(ZIP_OUTPUT_BASENAME) ; fi
 	if [ ! -L $(ZIP_OUTPUT_BASENAME)/bin ] ; then ln -s ../bin $(ZIP_OUTPUT_BASENAME) ; fi
-	if [ ! -f $(ZIP_OUTPUT_BASENAME)/ThirdPartyNotices.txt ] ; then cp -f bin/*/lib/xamarin.android/ThirdPartyNotices.txt $(ZIP_OUTPUT_BASENAME) ; fi
+	if [ ! -f $(ZIP_OUTPUT_BASENAME)/ThirdPartyNotices.txt ] ; then $(CP_F) bin/*/lib/xamarin.android/ThirdPartyNotices.txt $(ZIP_OUTPUT_BASENAME) ; fi
 	_exclude_list=".__exclude_list.txt"; \
 	ls -1d $(_BUNDLE_ZIPS_EXCLUDE) > "$$_exclude_list" 2>/dev/null ; \
 	for c in $(CONFIGURATIONS) ; do \


### PR DESCRIPTION
`make package-oss` fails on Linux with the following error:

    if [ ! -f xamarin.android-oss_v8.3.99.23_Linux-x86_64_master_3f587f51/ThirdPartyNotices.txt ] ; then cp -f bin/*/lib/xamarin.android/ThirdPartyNotices.txt xamarin.android-oss_v8.3.99.23_Linux-x86_64_master_3f587f51 ; fi
    cp: will not overwrite just-created 'xamarin.android-oss_v8.3.99.23_Linux-x86_64_master_3f587f51/ThirdPartyNotices.txt' with 'bin/Release/lib/xamarin.android/ThirdPartyNotices.txt'

which is due to some weird decisions GNU cp makes when copying files with the
same names from different source directories to the same destination. The fix is
to use `-a` (archive), however, it's not portable as macOS (BSD) version of cp
doesn't support it. Thus, this patch