### PR TITLE
[build] Add `make package-test-errors` target

### DIFF
--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -200,3 +200,8 @@ package-deb: $(ZIP_OUTPUT)
 	ln -sf $(ZIP_OUTPUT) xamarin.android-oss_$(PRODUCT_VERSION).$(-num-commits-since-version-change).orig.tar.bz2
 	cd $(ZIP_OUTPUT_BASENAME) && DEBEMAIL="Xamarin Public Jenkins (auto-signing) <releng@xamarin.com>" dch --create -v $(PRODUCT_VERSION).$(-num-commits-since-version-change) --package xamarin.android-oss --force-distribution --distribution alpha "New release - please see git log for $(GIT_COMMIT)"
 	cd $(ZIP_OUTPUT_BASENAME) && dpkg-buildpackage -us -uc -rfakeroot
+
+package-test-errors:
+ifneq ($(wildcard bin/Test*/temp),)
+	zip -r test-errors.zip bin/Test*/temp
+endif # We have test error output


### PR DESCRIPTION
Sometimes a PR build will [fail][0]. That's to be expected! ;-)

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-pr-builder/2600/

However, sometimes the error message is [largely useless][1]:

[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-pr-builder/2600/testReport/junit/Xamarin.Android.Build.Tests.BuildTest/BuildAotApplicationAndBundle/Xamarin_Android_Build_Tests_BuildTest_BuildAotApplicationAndBundle__armeabi_v7a__False_True____Debug/

	MESSAGE:
	  Build should have succeeded.
	Expected: True
	But was:  False

	STACK TRACE:
	  at Xamarin.Android.Build.Tests.BuildTest.BuildAotApplicationAndBundle (System.String supportedAbis, System.Boolean enableLLVM, System.Boolean expectedResult)

That's not helpful at all.

In such circumstanes, the usual "fallback" path is to check the
Jenkins [**Workspace**][2], then pray that the mentioned failing
projects *still exist*. The problem here is that the Workspace is
cleared on *every* Jenkins build (for a specific job), so if another
PR build has started, the Workspace for the previous build is no
longer accessible.

[2]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-pr-builder/ws/

Add a new `make package-test-errors` target. When called, *if* there
are any error projects within `bin/Test*/temp`, they will be packaged
up into `test-errors.zip`. We can then upload `test-errors.zip` to
Azure -- along with the other PR build outputs -- allowing for saner
determination of What Went Wrong™, allowing the PR to be fixed.