### PR TITLE
[build] ThirdPartyNotices.txt and $(CONFIGURATIONS)

### DIFF
--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -101,7 +101,8 @@ leeroy: leeroy-all framework-assemblies opentk-jcw
 
 leeroy-all:
 	$(foreach conf, $(CONFIGURATIONS), \
-		$(_SLN_BUILD) $(MSBUILD_FLAGS) $(SOLUTION) /p:Configuration=$(conf) $(_MSBUILD_ARGS) && ) \
+		$(_SLN_BUILD) $(MSBUILD_FLAGS) $(SOLUTION) /p:Configuration=$(conf) $(_MSBUILD_ARGS) && \
+		$(call CREATE_THIRD_PARTY_NOTICES,$(conf),bin/$(conf)/lib/xamarin.android/ThirdPartyNotices.txt,$(THIRD_PARTY_NOTICE_LICENSE_TYPE),True,False) && ) \
 	true
 
 framework-assemblies:


### PR DESCRIPTION
An unanticipated side-effect of commit 2bd13c4a was that
`make prepare` was downloading `bundle-v*.zip` for *both*
[Debug and Release][0] configurations, even on the PR builder (which
only builds Debug by default):

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-pr-builder/2610/console

	Downloading `https://xamjenkinsartifact.azureedge.net/xamarin-android/xamarin-android/bin/Debug/bundle-v21-h86de098f-Debug-Darwin-libzip=1d8b1ac,llvm=bdb3a11,mono=607cbde.zip` to `/Users/builder/android-archives/.bundle-v21-h86de098f-Debug-Darwin-libzip=1d8b1ac,llvm=bdb3a11,mono=607cbde.zip.download`
	...
	Downloading `https://xamjenkinsartifact.azureedge.net/xamarin-android/xamarin-android/bin/Release/bundle-v21-h86de098f-Release-Darwin-libzip=1d8b1ac,llvm=bdb3a11,mono=607cbde.zip` to `/Users/builder/android-archives/.bundle-v21-h86de098f-Release-Darwin-libzip=1d8b1ac,llvm=bdb3a11,mono=607cbde.zip.download`.

This is unneccessary, but was a result of:

	$(foreach c, $(CONFIGURATIONS), \
	  $(eval $(call CREATE_THIRD_PARTY_NOTICES ...)))

Since `ThirdPartyNotices.csproj` has a `@(ProjectReference)` to
`xa-prep-tasks.csproj`, the build of which attempts to download the
bundle, simply executing `ThirdPartyNotices.csproj` was triggering a
bundle download, which is not desired.

Rework the dependencies so that by default we only create
`bin/$(CONFIGURATION)/lib/xamarin.android/ThirdPartyNotices.txt`, not
one for all `$(CONFIGURATIONS)`, and move the `$(CONFIGURATIONS)`
logic into `make leeroy-all`.