### PR TITLE
[Xamarin.Android.Build.Tasks] The "ConvertResourcesCases" task failed unexpectedly.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -58,7 +58,7 @@ namespace Xamarin.Android.Tasks
 				MonoAndroidHelper.CopyIfChanged (file, tmpdest);
 				MonoAndroidHelper.SetWriteable (tmpdest);
 				try {
-					AndroidResource.UpdateXmlResource (tmpdest, acwMap,
+					AndroidResource.UpdateXmlResource (resdir, tmpdest, acwMap,
 						ResourceDirectories.Where (s => s != item).Select(s => s.ItemSpec));
 
 					// We strip away an eventual UTF-8 BOM from the XML file.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Android.Tasks
 			foreach (string file in xmls) {
 				Log.LogDebugMessage ("  Processing: {0}", file);
 				var srcmodifiedDate = File.GetLastWriteTimeUtc (file);
-				var tmpdest = file + "_" + Path.GetFileName (Path.GetTempFileName ());
+				var tmpdest = Path.GetTempFileName ();
 				MonoAndroidHelper.CopyIfChanged (file, tmpdest);
 				MonoAndroidHelper.SetWriteable (tmpdest);
 				try {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Android.Tasks
 			foreach (string file in xmls) {
 				Log.LogDebugMessage ("  Processing: {0}", file);
 				var srcmodifiedDate = File.GetLastWriteTimeUtc (file);
-				var tmpdest = file + ".tmp";
+				var tmpdest = file + "_" + Path.GetFileName (Path.GetTempFileName ());
 				MonoAndroidHelper.CopyIfChanged (file, tmpdest);
 				MonoAndroidHelper.SetWriteable (tmpdest);
 				try {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyAndConvertResources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyAndConvertResources.cs
@@ -86,7 +86,7 @@ namespace Xamarin.Android.Tasks
 				var destfilename = p.Value;
 				var srcmodifiedDate = File.GetLastWriteTimeUtc (filename);
 				var dstmodifiedDate = File.Exists (destfilename) ? File.GetLastAccessTimeUtc (destfilename) : DateTime.MinValue;
-				var tmpdest = p.Value + ".tmp";
+				var tmpdest = Path.GetTempFileName ();
 				MonoAndroidHelper.CopyIfChanged (filename, tmpdest);
 				MonoAndroidHelper.SetWriteable (tmpdest);
 				try {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyAndConvertResources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyAndConvertResources.cs
@@ -87,10 +87,11 @@ namespace Xamarin.Android.Tasks
 				var srcmodifiedDate = File.GetLastWriteTimeUtc (filename);
 				var dstmodifiedDate = File.Exists (destfilename) ? File.GetLastAccessTimeUtc (destfilename) : DateTime.MinValue;
 				var tmpdest = Path.GetTempFileName ();
+				var res = Path.Combine (Path.GetDirectoryName (filename), "..");
 				MonoAndroidHelper.CopyIfChanged (filename, tmpdest);
 				MonoAndroidHelper.SetWriteable (tmpdest);
 				try {
-					AndroidResource.UpdateXmlResource (tmpdest, acw_map);
+					AndroidResource.UpdateXmlResource (res, tmpdest, acw_map);
 					if (MonoAndroidHelper.CopyIfChanged (tmpdest, destfilename)) {
 						MonoAndroidHelper.SetWriteable (destfilename);
 						MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (destfilename, srcmodifiedDate, Log);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
@@ -9,17 +9,14 @@ using System.Xml.XPath;
 namespace Monodroid {
 	static class AndroidResource {
 		
-		public static void UpdateXmlResource (string filename, Dictionary<string, string> acwMap, IEnumerable<string> additionalDirectories = null)
+		public static void UpdateXmlResource (string res, string filename, Dictionary<string, string> acwMap, IEnumerable<string> additionalDirectories = null)
 		{
 			// use a temporary file so we only update the real file if things actually changed
 			string tmpfile = filename + ".bk";
 			try {
 				XDocument doc = XDocument.Load (filename, LoadOptions.SetLineInfo);
 
-				// The assumption here is that the file we're fixing up is in a directory below the
-				// obj/${Configuration}/res/ directory and so appending ../gives us the actual path to
-				// 'res/'
-				UpdateXmlResource (Path.Combine (Path.GetDirectoryName (filename), ".."), doc.Root, acwMap, additionalDirectories);
+				UpdateXmlResource (res, doc.Root, acwMap, additionalDirectories);
 				using (var stream = File.OpenWrite (tmpfile))
 					using (var xw = new LinePreservedXmlWriter (new StreamWriter (stream)))
 						xw.WriteNode (doc.CreateNavigator (), false);


### PR DESCRIPTION
DevDiv Issue 571365

We have a report that `ConvertResourcesCases` is failing with the follow
error.

	error MSB4018: The "ConvertResourcesCases" task failed unexpectedly.
	Android/Xamarin.Android.Common.targets(1334,2): error MSB4018: System.IO.FileNotFoundException: <some path>/design_layout_snackbar.xml.tmp does not exist

This is completely weird, especially as the Task is not called in
parallel. What I susepct is happening is VSForMac is running is
UpdateResources task at the same time the user is doing a build.

Because the name of the temp files we are just `foo.xml.tmp` it
is highly possible that one instance of the task is deleting the
file while the other instance is still running. This is difficult
to replicate.

This change uses

	System.IO.Path.GetTempFileName ();

to generate a random temp file name for the temp file. This should
stop filename collisions since the file will end up in the `/tmp` directory.