### PR TITLE
[Xamarin.Android.Build.Tasks] Add @(AndroidAarLibrary)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -158,20 +158,21 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 <!-- Get our Build Action to show up in VS -->
 <ItemGroup>
-	<AvailableItemName Include="AndroidAsset" />  
-	<AvailableItemName Include="AndroidEnvironment" />  
-	<AvailableItemName Include="AndroidInterfaceDescription" />  
-	<AvailableItemName Include="AndroidJavaSource" />
-	<AvailableItemName Include="AndroidJavaLibrary" />
-	<AvailableItemName Include="AndroidExternalJavaLibrary" />
-	<AvailableItemName Include="AndroidNativeLibrary" />
-    <AvailableItemName Include="EmbeddedNativeLibrary" />
-	<AvailableItemName Include="AndroidResource" />  
-	<AvailableItemName Include="LinkDescription" />  
-	<AvailableItemName Include="ProguardConfiguration" />
-	<AvailableItemName Include="ProjectReference" />
-	<AvailableItemName Include="AndroidLintConfig" />
-	<AvailableItemName Include="MultiDexMainDexList" />
+  <AvailableItemName Include="AndroidAarLibrary" />
+  <AvailableItemName Include="AndroidAsset" />
+  <AvailableItemName Include="AndroidEnvironment" />
+  <AvailableItemName Include="AndroidExternalJavaLibrary" />
+  <AvailableItemName Include="AndroidInterfaceDescription" />
+  <AvailableItemName Include="AndroidJavaLibrary" />
+  <AvailableItemName Include="AndroidJavaSource" />
+  <AvailableItemName Include="AndroidLintConfig" />
+  <AvailableItemName Include="AndroidNativeLibrary" />
+  <AvailableItemName Include="AndroidResource" />
+  <AvailableItemName Include="EmbeddedNativeLibrary" />
+  <AvailableItemName Include="LinkDescription" />
+  <AvailableItemName Include="MultiDexMainDexList" />
+  <AvailableItemName Include="ProguardConfiguration" />
+  <AvailableItemName Include="ProjectReference" />
 </ItemGroup>
 
 <!-- Version/fx properties -->


### PR DESCRIPTION
Adding `@(AndroidAarLibrary)` to `@(AvailableItemName)` *should* have
been done as part of commit 6a8ea2bb, but was overlooked.

We want `@(AvailableItemName)` to be up-to-date so that you can have
conditional MSBuild behavior based on whether a particular item is
supported.

In particular, @Redth wants to ensure that the `@(AndroidAarLibrary)`
build action is available as part of his Components work, and ensuring
that `@(AvailableItemName)` contains `@(AndroidAarLibrary)` is the
most straightforward way to do so.

Additionally, sort and re-indent the `@(AvailableItemName)` entries.