### PR TITLE
[Xamarin.Android.Build.Tasks] Fix an issue with `actionLayout`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Properties/AssemblyInfo.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/AssemblyInfo.cs
@@ -36,3 +36,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion ("1.0.0.0")]
 
 [assembly: InternalsVisibleTo ("AndroidMSBuildTests")]
+[assembly: InternalsVisibleTo ("Xamarin.Android.Build.Tests")]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidResourceTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidResourceTests.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.ProjectTools;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using System.Text;
+using Xamarin.Android.Tasks;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Build.Tests {
+	[TestFixture]
+	[Parallelizable (ParallelScope.Self)]
+	public class AndroidResourceTests : BaseTest {
+		[Test]
+		public void MenuActionLayout ()
+		{
+			var path = Path.Combine (Root, "temp", "MenuActionLayout");
+			Directory.CreateDirectory (path);
+			var layoutDir = Path.Combine (path, "res", "layout");
+			var menuDir = Path.Combine (path, "res", "menu");
+			Directory.CreateDirectory (layoutDir);
+			Directory.CreateDirectory (menuDir);
+			File.WriteAllText (Path.Combine (layoutDir, "servinglayout.xml"), @"<?xml version=""1.0"" encoding=""utf-8""?>
+<LinearLayout xmlns:android=""http://schemas.android.com/apk/res/android""
+	android:orientation = ""horizontal""
+	android:layout_width = ""match_parent""
+	android:layout_height = ""match_parent"" >");
+			
+			var actions = Path.Combine (menuDir, "actions.xml");
+			File.WriteAllText (actions, @"<?xml version=""1.0"" encoding=""utf-8""?>
+<menu
+	xmlns:android = ""http://schemas.android.com/apk/res/android""
+	xmlns:app = ""http://schemas.android.com/apk/res-auto"">
+	<item
+		android:id = ""@+id/addToFavorites""
+		android:title = ""Add to Favorites""
+		app:showAsAction = ""always""
+	/>
+	<item
+		android:title = ""Servings""
+		android:icon = ""@drawable/ic_people_white_24dp""
+		app:showAsAction = ""always"">
+		<menu>
+			<group android:checkableBehavior = ""single"">
+
+			<item
+				android:id = ""@+id/oneServing""
+				android:title = ""1 serving""
+				android:checked= ""true""
+				app:actionLayout = ""@layout/ServingLayout""
+			/>
+			<item
+				android:id = ""@+id/twoServings""
+				android:title = ""2 servings"" />
+			<item
+				android:id = ""@+id/fourServings""
+				android:title = ""4 servings"" />
+			</group>
+		</menu>
+	</item>
+	<item
+		android:id = ""@+id/about""
+		android:title = ""About""
+		app:showAsAction = ""never"" />
+
+</menu>");
+			Monodroid.AndroidResource.UpdateXmlResource (actions, new Dictionary<string, string> (), null);
+			var actionsText = File.ReadAllText (actions);
+			Assert.True (actionsText.Contains ("@layout/servinglayout"), "'@layout/ServingLayout' was not converted to '@layout/servinglayout'");
+			Directory.Delete (path, recursive: true);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -74,5 +74,6 @@
     <Compile Include="AndroidRegExTests.cs" />
     <Compile Include="GetDependenciesTests.cs" />
     <Compile Include="ResolveSdksTaskTests.cs" />
+    <Compile Include="AndroidResourceTests.cs" />
   </ItemGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
@@ -213,6 +213,7 @@ namespace Monodroid {
 			switch (attr.Name.LocalName) {
 			case "rectLayout":
 			case "roundLayout":
+			case "actionLayout":
 				attr.Value = attr.Value.ToLowerInvariant ();
 				return true;
 			}


### PR DESCRIPTION
Our Resource Case converter `AndroidResource` did not handle
the `actionLayout` attribute for the `http://schemas.android.com/apk/res-auto`
namespace in menu xml files.

As a result the value for the `actionLayout` would not be
lowercased. This results in the following error

	No resource found that matches the given name (at ‘actionLayout’ with value ‘@layout/ServingLayout’).

The fix is to add support for `actionLayout` to `AndroidResource`.
We also have added a unit test for this particular case and allowed
the `Xamarin.Android.Build.Tests` access to the internals of the
`Xamarin.Android.Build.Tasks` so it can unit test more of the
internal classes it has.