### PR TITLE
[tests] Check for " failed " emulator message

### DIFF
--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
@@ -115,7 +115,8 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 					Log.LogError ($"Emulator failed to start: `{e.Data}`. Please try again?");
 					sawError.Set ();
 				}
-				if (e.Data.IndexOf ("ERROR:", StringComparison.Ordinal) >= 0) {
+				if (e.Data.IndexOf ("ERROR:", StringComparison.Ordinal) >= 0 ||
+						e.Data.IndexOf (" failed ", StringComparison.Ordinal) >= 0) {
 					Log.LogError ($"Emulator failed to start: {e.Data}");
 					sawError.Set ();
 				}


### PR DESCRIPTION
The Jenkins emulator-based tests are [hanging][0] -- again (see also
3294a50e) -- this time with new messages to `stderr`:

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/903/console

	_RegisterApplication(), FAILED TO establish the default connection to the WindowServer, _CGSDefaultConnection() is NULL.
	_RegisterApplication(), FAILED TO establish the default connection to the WindowServer, _CGSDefaultConnection() is NULL.
	2018-03-08 11:26:32.097 qemu-system-i386[74190:5500464] CFPasteboardRef CFPasteboardCreate(CFAllocatorRef, CFStringRef) : failed to create global data
	PasteBoard: Error creating pasteboard: com.apple.pasteboard.clipboard [-4960]
	2018-03-08 11:26:32.097 qemu-system-i386[74190:5500464] CFPasteboardRef CFPasteboardCreate(CFAllocatorRef, CFStringRef) : failed to create global data
	PasteBoard: Error creating pasteboard: com.apple.pasteboard.find [-4960]
	2018-03-08 11:26:32.100 qemu-system-i386[74190:5500464] CFPasteboardRef CFPasteboardCreate(CFAllocatorRef, CFStringRef) : failed to create global data
	2018-03-08 11:26:32.101 qemu-system-i386[74190:5500464] CFPasteboardRef CFPasteboardCreate(CFAllocatorRef, CFStringRef) : failed to create global data
	2018-03-08 11:26:32.101 qemu-system-i386[74190:5500464] CFPasteboardRef CFPasteboardCreate(CFAllocatorRef, CFStringRef) : failed to create global data
	2018-03-08 11:26:32.102 qemu-system-i386[74190:5500464] CFPasteboardRef CFPasteboardCreate(CFAllocatorRef, CFStringRef) : failed to create global data

*Something* is horrifically wrong -- not sure what, currently -- which
is causing the emulator launch to fail. However, we're not detecting
it, so we later wait around ~forever until the build times out.

Check for the string ` failed ` from `stderr`, and if we see it, flag
an error on emulator launch.