### PR TITLE
[create-vsix] Don't package xabuild.exe symlinks

### DIFF
--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -30,6 +30,9 @@
   </ItemDefinitionGroup>
   <Target Name="AddContent"
       Returns="@(MSBuild);@(ReferenceAssemblies)">
+    <ReadLinesFromFile File="$(LibDir)\xbuild-frameworks\.__sys_links.txt">
+      <Output TaskParameter="Lines" ItemName="_SymLinks"/>
+    </ReadLinesFromFile>
     <ItemGroup>
       <MSBuild Include="$(LibDir)xbuild\Novell\**\*.*" />
       <MSBuild>
@@ -57,6 +60,8 @@
       <MSBuild Remove="$(LibDir)xbuild\**\*.d.dll" />
       <MSBuild Remove="$(LibDir)xbuild\**\*.d.exe" />
       <ReferenceAssemblies Include="$(LibDir)xbuild-frameworks\**\*.*" />
+      <ReferenceAssemblies Remove="$(LibDir)xbuild-frameworks\.__sys_links.txt" />
+      <ReferenceAssemblies Remove="$(LibDir)xbuild-frameworks\%(_SymLinks.Identity)\**\*.*" />
       <ReferenceAssemblies Remove="**\*.dylib" />
       <ReferenceAssemblies Remove="**\libZipSharp*.*" />
       <ReferenceAssemblies>

--- a/tools/xabuild/XABuild.cs
+++ b/tools/xabuild/XABuild.cs
@@ -26,6 +26,7 @@ namespace Xamarin.Android.Build
 					if (!SymbolicLink.Create (Path.Combine (paths.FrameworksDirectory, name), dir)) {
 						return 1;
 					}
+					File.AppendAllText (Path.Combine (paths.FrameworksDirectory, ".__sys_links.txt"), name + "\n");
 				}
 
 				int exitCode = MSBuildApp.Main ();


### PR DESCRIPTION
`xabuild.exe` execution involves the creation of symbolic links within
`bin/$(Configuration)/lib/xamarin.android/xbuild-frameworks`, pointing
into the `.NETFramework` and `.NETPortable` directories.

`build-tools/create-vsix` doesn't know anything about these symbolic
links, and *follows* them.

The result is that *if* you build with `xabuild.exe` then create a
`.vsix`, the resulting file will contain lots of "garbage":

	$ make prepare all all-tests MSBUILD=msbuild
	# `make all-tests` executes `xabuild.exe`
	$ make create-vsix CONFIGURATIONS=Debug
	$ unzip -l Xamarin.Android.Sdk-OSS*.vsix
	...
	      135  03-08-2018 21:40   $ReferenceAssemblies/Microsoft/Framework/.NETFramework/v2.0/RedistList/FrameworkList.xml
	...
	    22640  03-08-2018 21:40   $ReferenceAssemblies/Microsoft/Framework/.NETPortable/v4.0/Microsoft.CSharp.dll
	...

All told, an extra *1041* files are included in the `.vsix` because of
the `.NETFramework` and `.NETPortable` symbolic links.

Fix this by introducing "communication" between `xabuild.exe` and
`create-vsix.targets`:

 1. When `xabuild.exe` creates a symbolic link, add the name of the
    symbolic link into
    `bin/$(Configuration)/lib/xamarin.android/xbuild-frameworks/.__sys_links.txt`.

 2. Update the `AddContent` target within `create-vsix.targets` to
    read the contents of `.__sys_links.txt`, and exclude each
    directory found within it.

This prevents the `.NETFramework` and `.NETPortable` symlinks from
being followed by the `.vsix` creator, allowing the `.vsix` contents
to be at least marginally saner.