### PR TITLE
Skip using InstallationID if it is not available

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Xamarin.Android.Sdk.props
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Xamarin.Android.Sdk.props
@@ -11,7 +11,7 @@ Copyright (C) 2011-2016 Xamarin. All rights reserved.
 -->
 <Project InitialTargets="RedirectMonoAndroidSdkPaths;RemoveSdksCache" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-	<PropertyGroup Condition="'$(VsInstallRoot)' != ''">
+	<PropertyGroup Condition="'$(VsInstallRoot)' != '' And Exists('$(VsInstallRoot)\Common7\IDE\devenv.isolation.ini')">
 		<!-- Grab InstallationID from devenv.ini.isolation's InstallationID=[ID] -->
 		<DevEnvIni>$([System.IO.File]::ReadAllText('$(VsInstallRoot)\Common7\IDE\devenv.isolation.ini'))</DevEnvIni>
 		<InstallationIDEqualsIndex>$(DevEnvIni.IndexOf('InstallationID='))</InstallationIDEqualsIndex>
@@ -35,7 +35,7 @@ Copyright (C) 2011-2016 Xamarin. All rights reserved.
 			<MonoAndroidBinDirectory Condition=" '$(MonoAndroidBinDirectory)' == '' ">$(VsInstallRoot)\MSBuild\Xamarin\Android</MonoAndroidBinDirectory>
 		</PropertyGroup>
 
-		<SetVsMonoAndroidRegistryKey InstallationID="$(VsInstallationID)" VisualStudioVersion="$(VisualStudioVersion)" />
+		<SetVsMonoAndroidRegistryKey Condition="'$(VsInstallationID)' != ''" InstallationID="$(VsInstallationID)" VisualStudioVersion="$(VisualStudioVersion)" />
 	</Target>
 
 	<Target Name="RemoveSdksCache" Condition="Exists('$(IntermediateOutputPath)sdks.cache')">


### PR DESCRIPTION
This is required to support the new "Visual Studio Build Tools" SKU (installs only build tools) where `devenv.isolation.ini` is not available (already confirmed this is intentional with the VS Setup team) and thus our build breaks. We are using InstallationID to support SxS at design-time so this isn't really needed in this case, it's safe to skip it.