### PR TITLE
Use `cp -n` during ThirdPartyNotices.txt copying.

### DIFF
--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -167,7 +167,7 @@ package-oss $(ZIP_OUTPUT):
 	if [ -d bin/Release/bin ] ; then cp tools/scripts/xabuild bin/Release/bin ; fi
 	if [ ! -d $(ZIP_OUTPUT_BASENAME) ] ; then mkdir $(ZIP_OUTPUT_BASENAME) ; fi
 	if [ ! -L $(ZIP_OUTPUT_BASENAME)/bin ] ; then ln -s ../bin $(ZIP_OUTPUT_BASENAME) ; fi
-	if [ ! -f $(ZIP_OUTPUT_BASENAME)/ThirdPartyNotices.txt ] ; then cp -f bin/*/lib/xamarin.android/ThirdPartyNotices.txt $(ZIP_OUTPUT_BASENAME) ; fi
+	if [ ! -f $(ZIP_OUTPUT_BASENAME)/ThirdPartyNotices.txt ] ; then cp -n bin/*/lib/xamarin.android/ThirdPartyNotices.txt $(ZIP_OUTPUT_BASENAME) ; fi
 	_exclude_list=".__exclude_list.txt"; \
 	ls -1d $(_BUNDLE_ZIPS_EXCLUDE) > "$$_exclude_list" 2>/dev/null ; \
 	for c in $(CONFIGURATIONS) ; do \

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -38,12 +38,6 @@ FRAMEWORKS        = $(foreach a, $(API_LEVELS), $(word $(a),$(ALL_FRAMEWORKS)))
 STABLE_FRAMEWORKS = $(foreach a, $(STABLE_API_LEVELS), $(word $(a),$(ALL_FRAMEWORKS)))
 PLATFORM_IDS      = $(foreach a, $(API_LEVELS), $(word $(a),$(ALL_PLATFORM_IDS)))
 
-ifeq ($(OS_NAME),Linux)
-CP_F              = cp -af
-else
-CP_F              = cp -f
-endif
-
 ALL_JIT_ABIS  = \
 	armeabi \
 	armeabi-v7a \
@@ -173,7 +167,7 @@ package-oss $(ZIP_OUTPUT):
 	if [ -d bin/Release/bin ] ; then cp tools/scripts/xabuild bin/Release/bin ; fi
 	if [ ! -d $(ZIP_OUTPUT_BASENAME) ] ; then mkdir $(ZIP_OUTPUT_BASENAME) ; fi
 	if [ ! -L $(ZIP_OUTPUT_BASENAME)/bin ] ; then ln -s ../bin $(ZIP_OUTPUT_BASENAME) ; fi
-	if [ ! -f $(ZIP_OUTPUT_BASENAME)/ThirdPartyNotices.txt ] ; then $(CP_F) bin/*/lib/xamarin.android/ThirdPartyNotices.txt $(ZIP_OUTPUT_BASENAME) ; fi
+	if [ ! -f $(ZIP_OUTPUT_BASENAME)/ThirdPartyNotices.txt ] ; then cp -f bin/*/lib/xamarin.android/ThirdPartyNotices.txt $(ZIP_OUTPUT_BASENAME) ; fi
 	_exclude_list=".__exclude_list.txt"; \
 	ls -1d $(_BUNDLE_ZIPS_EXCLUDE) > "$$_exclude_list" 2>/dev/null ; \
 	for c in $(CONFIGURATIONS) ; do \


### PR DESCRIPTION
`cp -f` (or `-af`) doesn't help on Linux when copying multiple files with
the same name to one target directory (as is the case here when building
both Debug and Release configurations). Using `cp -n` means the overwrite
is skipped, rather than fatal. macOS does not care about the overwrite
either way - passing `-n` to BSD `cp` is non-fatal, and fixes the build
failures on Linux.

```
directhex@flame:/tmp/dirtests$ mkdir a1
directhex@flame:/tmp/dirtests$ mkdir a2
directhex@flame:/tmp/dirtests$ touch a1/foo.txt a2/foo.txt
directhex@flame:/tmp/dirtests$ mkdir out
directhex@flame:/tmp/dirtests$ cp -af a*/*.txt out/
cp: will not overwrite just-created 'out/foo.txt' with 'a2/foo.txt'
directhex@flame:/tmp/dirtests$ cp -n a*/*.txt out/
directhex@flame:/tmp/dirtests$ 
```