### PR TITLE
[mono-runtimes] Provide `configure --build` value for Linux

### DIFF
--- a/build-tools/mono-runtimes/mono-runtimes.props
+++ b/build-tools/mono-runtimes/mono-runtimes.props
@@ -92,6 +92,8 @@
 
   <!-- LLVM+cross Linux -->
   <PropertyGroup Condition=" '$(HostOS)' == 'Linux' ">
+    <_CrossConfigureBuildHost32>$(HostTriplet32)</_CrossConfigureBuildHost32>
+    <_CrossConfigureBuildHost64>$(HostTriplet64)</_CrossConfigureBuildHost64>
     <_CrossConfigureBuildHost>$(HostTriplet)</_CrossConfigureBuildHost>
     <_CrossConfigureBuildHostWin32>$(_MingwTriplet32)</_CrossConfigureBuildHostWin32>
     <_CrossConfigureBuildHostWin64>$(_MingwTriplet64)</_CrossConfigureBuildHostWin64>


### PR DESCRIPTION
Fixes: https://github.com/mono/mono/issues/6989

The AOT cross-compilers were being mis-`configure`d on Linux, as the
`configure --build` option wasn't actually specified, unlike macOS.

The result is executing the cross-compilers may result in an assert
failing:

	[AOT] MONO_PATH="/mnt/jenkins/workspace/xamarin-android-linux/xamarin-android/bin/TestDebug/temp/CheckSequencePointGenerationTrueTrueTrueTruePdbOnlyFalserelease/obj/Release/android/assets" MONO_ENV_OPTIONS="" /mnt/jenkins/workspace/xamarin-android-linux/xamarin-android/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/Linux/cross-arm --aot=msym-dir=/mnt/jenkins/workspace/xamarin-android-linux/xamarin-android/bin/TestDebug/temp/CheckSequencePointGenerationTrueTrueTrueTruePdbOnlyFalserelease/obj/Release/aot/armeabi-v7a,outfile=/mnt/jenkins/workspace/xamarin-android-linux/xamarin-android/bin/TestDebug/temp/CheckSequencePointGenerationTrueTrueTrueTruePdbOnlyFalserelease/obj/Release/aot/armeabi-v7a/libaot-UnnamedProject.dll.so,asmwriter,mtriple=armv7-linux-gnueabi,tool-prefix=/home/builder/android-toolchain/ndk/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin/arm-linux-androideabi-,ld-flags=,llvm-path=/mnt/jenkins/workspace/xamarin-android-linux/xamarin-android/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/Linux,temp-path=/mnt/jenkins/workspace/xamarin-android-linux/xamarin-android/bin/TestDebug/temp/CheckSequencePointGenerationTrueTrueTrueTruePdbOnlyFalserelease/obj/Release/aot/armeabi-v7a/UnnamedProject.dll /mnt/jenkins/workspace/xamarin-android-linux/xamarin-android/bin/TestDebug/temp/CheckSequencePointGenerationTrueTrueTrueTruePdbOnlyFalserelease/obj/Release/android/assets/UnnamedProject.dll
	[aot-compiler stdout] Mono Ahead of Time compiler - compiling assembly /mnt/jenkins/workspace/xamarin-android-linux/xamarin-android/bin/TestDebug/temp/CheckSequencePointGenerationTrueTrueTrueTruePdbOnlyFalserelease/obj/Release/android/assets/shrunk/System.dll
	[aot-compiler stdout] AOTID 1C512E38-4EF8-E26C-2771-39AE345EA87F
	[aot-compiler stdout] unknown opcode storei8_membase_reg in mono_arch_output_basic_block()
	[aot-compiler stdout]
	[aot-compiler stdout] * Assertion: should not be reached at /mnt/jenkins/workspace/xamarin-android-linux/xamarin-android/external/mono/mono/mini/mini-arm.c:5924

Specify the `$(_CrossConfigureBuildHost32)` and
`$(_CrossConfigureBuildHost64)` MSBuild properties for Linux so that
`configure --build` gets correct values on Linux.