### PR TITLE
Bump Android Emulator to version 27.1.12

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -23,7 +23,7 @@
       <HostOS>Linux</HostOS>
       <DestDir>tools</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="emulator-linux-4266726">
+    <AndroidSdkItem Include="emulator-linux-4623001">
       <HostOS>Linux</HostOS>
       <DestDir>emulator</DestDir>
     </AndroidSdkItem>
@@ -42,7 +42,7 @@
       <HostOS>Darwin</HostOS>
       <DestDir>tools</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="emulator-darwin-4266726">
+    <AndroidSdkItem Include="emulator-darwin-4623001">
       <HostOS>Darwin</HostOS>
       <DestDir>emulator</DestDir>
     </AndroidSdkItem>
@@ -61,7 +61,7 @@
       <HostOS>Windows</HostOS>
       <DestDir>tools</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="emulator-windows-4266726">
+    <AndroidSdkItem Include="emulator-windows-4623001">
       <HostOS>Windows</HostOS>
       <DestDir>emulator</DestDir>
     </AndroidSdkItem>

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -31,7 +31,7 @@
         AndroidAbi="x86"
         AndroidSdkHome="$(AndroidSdkDirectory)"
         JavaSdkHome="$(JavaSdkDirectory)"
-        SdkVersion="21"
+        SdkVersion="23"
         ImageName="$(_TestImageName)"
         ToolExe="$(AvdManagerToolExe)"
         ToolPath="$(AndroidToolsBinPath)"


### PR DESCRIPTION
This is the latest emulator from Google. Faster and more reliable.
Unfortunately, on Ubuntu it is necessary to remove the bundled copy
of the libstd++ library since it conflicts with the system-installed
version and prevents the emulator from starting.

The removal is limited to Ubuntu because that's the only distribution
we tested it on. Technically it is needed only on Ubuntu 17.10 and
newer since the emulator works fine on the current LTS 16.04, but since
removing it on 16.04 doesn't hurt it in any way we can skip checking the
exact version of the OS and make the condition simpler.