### PR TITLE
[build-tools] Improve logcat timing processing

### DIFF
--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ProcessLogcatTiming.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ProcessLogcatTiming.cs
@@ -22,6 +22,8 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 				var procIdentification = string.IsNullOrEmpty (Activity) ? $"added application {ApplicationPackageName}" : $"activity {Activity}";
 				var startIdentification = PID > 0 ? $".*: pid={PID}" : $@"{procIdentification}: pid=(?<pid>\d+)";
 				var procStartRegex = new Regex ($@"^(?<timestamp>\d+-\d+\s+[\d:\.]+)\s+.*ActivityManager: Start proc.*for {startIdentification}");
+				var startIdentification2 = PID > 0 ? $"{PID}:" : $@"(?<pid>\d+):.*{procIdentification}";
+				var procStartRegex2 = new Regex ($@"^(?<timestamp>\d+-\d+\s+[\d:\.]+)\s+.*ActivityManager: Start proc {startIdentification2}");
 				Regex timingRegex = null;
 				DateTime start = DateTime.Now;
 				DateTime last = start;
@@ -30,6 +32,8 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 				while ((line = reader.ReadLine ()) != null) {
 					if (!started) {
 						var match = procStartRegex.Match (line);
+						if (!match.Success)
+							match = procStartRegex2.Match (line);
 						if (!match.Success)
 							continue;
 


### PR DESCRIPTION
Add another regexp match for timing log start. So far I have been
using the logcat timing with logcat output from the emulator with API
version 21. Looks like the logcat format changed in newer Android
versions.

Here is an example of the relevant part of the logcat output on Pixel
2 device (API 27):

```
03-08 15:11:48.140  1128  4745 I ActivityManager: Start proc 18503:com.xamarin.xatemplateaot/u0a241 for activity com.xamarin.xatemplateaot/md58018c7d08c228c8e2a3e03723c59ca27.MainActivity
```
While on the emulator with API 21 we see:
```
03-07 20:53:48.816  1527  1869 I ActivityManager: Start proc com.xamarin.xatemplateaot for activity com.xamarin.xatemplateaot/md58018c7d08c228c8e2a3e03723c59ca27.MainActivity: pid=3080 uid=10057 gids={50057, 9997, 3003} abi=x86
```
The main difference here for us is the location of the PID number.