### PR TITLE
 [build] Windows support for ThirdPartyNotices

### DIFF
--- a/build-tools/ThirdPartyNotices/ThirdPartyNotices.csproj
+++ b/build-tools/ThirdPartyNotices/ThirdPartyNotices.csproj
@@ -22,7 +22,7 @@
     </BuildDependsOn>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\xa-prep-tasks\xa-prep-tasks.csproj">
+    <ProjectReference Include="..\xa-prep-tasks\xa-prep-tasks.csproj" Condition=" '$(HostOS)' != 'Windows' ">
       <Project>{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}</Project>
       <Name>xa-prep-tasks</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>

--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -34,5 +34,13 @@
         DestinationFile="$(_TopDir)\Configuration.OperatingSystem.props"
         Replacements="@JAVA_HOME@=$(_JavaSdkDirectory)"
     />
+    <MSBuild 
+        Projects="$(_TopDir)\build-tools\ThirdPartyNotices\ThirdPartyNotices.csproj"
+        Properties="ThirdPartyNoticeFile=$(_TopDir)\ThirdPartyNotices.txt;ThirdPartyNoticeLicenseType=foundation"
+    />
+    <MSBuild 
+        Projects="$(_TopDir)\build-tools\ThirdPartyNotices\ThirdPartyNotices.csproj"
+        Properties="ThirdPartyNoticeFile=$(_TopDir)\bin\$(Configuration)\lib\xamarin.android\ThirdPartyNotices.txt;ThirdPartyNoticeLicenseType=microsoft-oss;TpnIncludeExternalDependencies=True"
+    />
   </Target>
 </Project>


### PR DESCRIPTION
Context: #464

Since the `ThirdPartyNotices.txt` functionality was implemented in
`Makefile`, this file was not getting generated on Windows. This commit
adds the same functionality to `PrepareWindows.targets`, which basically
just builds `ThirdPartyNotices.csproj` twice with different parameters.

The only workaround I had to add for Windows was to make the
`<ProjectReference />` for `xa-prep-tasks.csproj` condition on Windows.
Otherwise, I was getting into a file-locking issue where the nested
`<MSBuild />` task was trying to copy `xa-prep-tasks.dll` to the output
directory while it was in use.