### PR TITLE
[Xamarin.Android.Build.Tasks] update <Proguard /> task for latest acw-map.txt file

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
@@ -130,9 +130,10 @@ namespace Xamarin.Android.Tasks
 			var classesZip = Path.Combine (ClassesOutputDirectory, "..", "classes.zip");
 			var acwLines = File.ReadAllLines (AcwMapFile);
 			using (var appcfg = File.CreateText (ProguardGeneratedApplicationConfiguration))
-				for (int i = 0; i + 3 < acwLines.Length; i += 4)
+				for (int i = 0; i + 2 < acwLines.Length; i += 3)
 					try {
-						var java = acwLines [i + 3].Substring (acwLines [i + 3].IndexOf (';') + 1);
+						var line = acwLines [i + 2];
+						var java = line.Substring (line.IndexOf (';') + 1);
 						appcfg.WriteLine ("-keep class " + java + " { *; }");
 					} catch {
 						// skip invalid lines

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -450,6 +450,12 @@ namespace Xamarin.Android.Tests
 			var proj = new XamarinAndroidApplicationProject () { IsRelease = isRelease, EnableProguard = enableProguard, UseLatestPlatformSdk = useLatestSdk, TargetFrameworkVersion = useLatestSdk ? "v7.1" : "v5.0" };
 			using (var b = CreateApkBuilder (Path.Combine ("temp", $"BuildProguard Enabled Project(1){isRelease}{enableProguard}{useLatestSdk}"))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+
+				if (isRelease && enableProguard) {
+					var proguardProjectPrimary = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "proguard", "proguard_project_primary.cfg");
+					FileAssert.Exists (proguardProjectPrimary);
+					StringAssertEx.ContainsText (File.ReadAllLines (proguardProjectPrimary), "-keep class md52d9cf6333b8e95e8683a477bc589eda5.MainActivity");
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes #1373

Since #1131, the contents of the `acw-map.txt` file have changed. We
have removed the fully qualified type names from the file, and there is
some code in the `<Proguard />` task that relies on a specific number of
lines per C# type.

We need to update the for-loop to skip every third line instead of every
fourth line.

I also updated the loop to only index against the `acwLines` array once
per loop interation, as a small performance improvement. The code is also
a little more readable from this change.

Lastly, I added some code to the proguard test so that it validates the
proguard configuration file contains the appropriate contents. Prior to
this, the test was only making sure the build succeeded.