### PR TITLE
[create-vsix] Don't exclude @(_Symlinks) when empty

### DIFF
--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -61,7 +61,10 @@
       <MSBuild Remove="$(LibDir)xbuild\**\*.d.exe" />
       <ReferenceAssemblies Include="$(LibDir)xbuild-frameworks\**\*.*" />
       <ReferenceAssemblies Remove="$(LibDir)xbuild-frameworks\.__sys_links.txt" />
-      <ReferenceAssemblies Remove="$(LibDir)xbuild-frameworks\%(_SymLinks.Identity)\**\*.*" />
+      <ReferenceAssemblies
+          Condition=" '@(_SymLinks)' != '' "
+          Remove="$(LibDir)xbuild-frameworks\%(_SymLinks.Identity)\**\*.*"
+      />
       <ReferenceAssemblies Remove="**\*.dylib" />
       <ReferenceAssemblies Remove="**\libZipSharp*.*" />
       <ReferenceAssemblies>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/1401

Commit 328286b7 had an unanticipated side-effect: the resulting
`.vsix` contained *no* `$ReferenceAssemblies` entries when running
`make create-vsix` with an xbuild-based build tree:

	$ make prepare all # MSBUILD=msbuild NOT PROVIDED
	$ make create-vsix CONFIGURATIONS=Debug
	$ unzip -l bin/BuildDebug/Xamarin.Android.Sdk-OSS*.vsix
	# no $ReferenceAssemblies files!

This is because when building only with `xbuild`,
`bin/$(Configuration)/lib/xamarin.android/xbuild-frameworks/.__sys_links.txt`
doesn't exist, and thus `@(_SymLinks)` is *empty*.

Consequently, the interpolation of
`$(LibDir)xbuild-frameworks\%(_SymLinks.Identity)\**\*.*` is
`$(LibDir)xbuild-frameworks\**\*.*`, which causes *all*
`@(ReferenceAssemblies)` entries to be removed.

Doh!

Fix this by making the `%(_Symlinks.Identity)` removal conditional on
`@(_Symlinks)` actually containing values.