### PR TITLE
Ensure directory removal with rm `-rf`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ install::
 
 uninstall::
 	rm -rf "$(prefix)/lib/xamarin.android/" "$(prefix)/bin/xabuild"
-	rm "$(prefix)/lib/mono/xbuild/Xamarin/Android"
-	rm "$(prefix)/lib/mono/xbuild-frameworks/MonoAndroid"
+	rm -rf "$(prefix)/lib/mono/xbuild/Xamarin/Android"
+	rm -rf "$(prefix)/lib/mono/xbuild-frameworks/MonoAndroid"
 
 ifeq ($(OS_NAME),Linux)
 export LINUX_DISTRO         := $(shell lsb_release -i -s || true)

--- a/tools/scripts/xabuild
+++ b/tools/scripts/xabuild
@@ -173,7 +173,7 @@ function ConfigureLocalXbuild()
 	for e in "$xbuild_dir"/* ; do
 		local b=`basename "$e"`
 		if [ -e "$TARGETS_DIR/$b" -o -f "$TARGETS_DIR/$b" -o -L "$TARGETS_DIR/$b" ]; then
-			rm "$TARGETS_DIR/$b"
+			rm -rf "$TARGETS_DIR/$b"
 		fi
 		ln -s "$e" "$TARGETS_DIR"
 		if [ -d "$e" ]; then


### PR DESCRIPTION
This is the common build failure, what we see after `make prepare` and `make`:

	rm: cannot remove '/sources/monodroid/monodroid/external/xamarin-android/tools/scripts/../../bin/Debug/lib/xamarin.android/xbuild/Xamarin': Is a directory

This does not show up once you run `make` again, so it's a cosmetic problem.
But this should not happen. First-time contributors would get stuck at it
and may leave after seeing this. This should be fixed.