### PR TITLE
[Xamarin.Android.Build.Tasks] Invalidate Build if $(AdbTarget) changes.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1084,6 +1084,8 @@ because xbuild doesn't support framework reference assemblies.
 	<_PropertyCacheItems Include="OS=$(OS)" />
 	<_PropertyCacheItems Include="DesignTimeBuild=$(DesignTimeBuild)" />
 	<_PropertyCacheItems Include="AndroidIncludeDebugSymbols=$(AndroidIncludeDebugSymbols)" />
+	<_PropertyCacheItems Include="AdbTarget=$(AdbTarget)" />
+	<_PropertyCacheItems Include="AdbOptions=$(AdbOptions)" />
 </ItemGroup>
 
 <Target Name="_ReadPropertiesCache">


### PR DESCRIPTION
If the `$(AdbTarget)` changes we currently do not invlaidate
the build. This can cause problems since we taylor the build
for the specific device which it attached. This happens for
FastDev builds.