### PR TITLE
[create-vsix] Remove unnecessary cruft

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -13,11 +13,14 @@
   />
   <PropertyGroup>
     <ProductVersion>8.3.99</ProductVersion>
+    <!-- Used by the `build-tools/create-vsix` build so that `Mono.Android.Export.dll`/etc. are only included *once* -->
+    <!-- Should correspond to the first value from `$(API_LEVELS)` in `build-tools/scripts/BuildEverything.mk` -->
+    <AndroidFirstFrameworkVersion Condition="'$(AndroidFirstFrameworkVersion)' == ''">v2.3</AndroidFirstFrameworkVersion>
     <!-- *Latest* *stable* API level binding that we support; used when building src/Xamarin.Android.Build.Tasks -->
     <AndroidLatestStableApiLevel Condition="'$(AndroidLatestStableApiLevel)' == ''">27</AndroidLatestStableApiLevel>
     <AndroidLatestStablePlatformId Condition="'$(AndroidLatestStablePlatformId)' == ''">$(AndroidLatestStableApiLevel)</AndroidLatestStablePlatformId>
     <AndroidLatestStableFrameworkVersion Condition="'$(AndroidLatestStableFrameworkVersion)'==''">v8.1</AndroidLatestStableFrameworkVersion>
-    <!-- *Latest* (possibly unstable) API level binding that we support; used when building src/Xamarin.Android.Build.Tasks -->
+    <!-- *Latest* (possibly unstable) API level binding that we support; for informational purposes -->
     <AndroidLatestApiLevel Condition="'$(AndroidLatestApiLevel)' == ''">28</AndroidLatestApiLevel>
     <AndroidLatestPlatformId Condition=" '$(AndroidLatestPlatformId)' == '' ">P</AndroidLatestPlatformId>
     <AndroidLatestFrameworkVersion Condition="'$(AndroidLatestFrameworkVersion)' == ''">v8.1.99</AndroidLatestFrameworkVersion>

--- a/Documentation/building/configuration.md
+++ b/Documentation/building/configuration.md
@@ -27,6 +27,11 @@ Overridable MSBuild properties include:
     This is an integer value, e.g. `15` for
     [API-15 (Android 4.0.3)](http://developer.android.com/about/versions/android-4.0.3.html).
 
+  * `$(AndroidFirstFrameworkVersion)`: The first `$(TargetFrameworkVersion)`
+    which will be built by `make jenkins` and included in the installer.
+    Currently `v2.3`, but will be changed when we drop support for API-10.
+    This controls what is included in `build-tools/create-vsix` packages.
+
   * `$(AndroidFrameworkVersion)`: The Xamarin.Android `$(TargetFrameworkVersion)`
     version which corresponds to `$(AndroidApiLevel)`. This is *usually* the
     Android version number with a leading `v`, e.g. `v4.0.3` for API-15.

--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -34,6 +34,16 @@
       <Output TaskParameter="Lines" ItemName="_SymLinks"/>
     </ReadLinesFromFile>
     <ItemGroup>
+      <_FirstFrameworkFile  Include="Mono.Android.Export.dll" />
+      <_FirstFrameworkFile  Include="Mono.Android.Export.pdb" />
+      <_FirstFrameworkFile  Include="OpenTK-1.0.dll" />
+      <_FirstFrameworkFile  Include="OpenTK-1.0.pdb" />
+      <_FirstFrameworkFile  Include="OpenTK-1.0.xml" />
+      <_FirstFrameworkFile  Include="OpenTK.dll" />
+      <_FirstFrameworkFile  Include="OpenTK.pdb" />
+      <_FirstFrameworkFile  Include="OpenTK.xml" />
+    </ItemGroup>
+    <ItemGroup>
       <MSBuild Include="$(LibDir)xbuild\Novell\**\*.*" />
       <MSBuild>
         <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Novell/%(RecursiveDir)</VSIXSubPath>
@@ -47,6 +57,11 @@
       <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\Darwin\**\*.*" />
       <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\Linux\**\*.*" />
       <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\**\*.dylib" />
+      <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\**\*.pdb" />
+      <MSBuild
+          Condition=" '$(Configuration)' != 'Debug' "
+          Remove="$(LibDir)xbuild\Xamarin\Android\**\*.d.so"
+      />
       <MSBuild Include="..\..\src\Xamarin.Android.Build.Tasks\MSBuild\Xamarin\**\*.*" />
       <MSBuild>
         <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Xamarin/%(RecursiveDir)</VSIXSubPath>
@@ -65,8 +80,18 @@
           Condition=" '@(_SymLinks)' != '' "
           Remove="$(LibDir)xbuild-frameworks\%(_SymLinks.Identity)\**\*.*"
       />
-      <ReferenceAssemblies Remove="**\*.dylib" />
-      <ReferenceAssemblies Remove="**\libZipSharp*.*" />
+      <ReferenceAssemblies Remove="$(LibDir)xbuild-frameworks\**\*.dylib" />
+      <ReferenceAssemblies Remove="$(LibDir)xbuild-frameworks\**\libZipSharp*.*" />
+    </ItemGroup>
+    <ItemGroup Condition="Exists('$(LibDir)xbuild-frameworks\MonoAndroid\$(AndroidFirstFrameworkVersion)')">
+      <ReferenceAssemblies Remove="$(LibDir)xbuild-frameworks\**\%(_FirstFrameworkFile.Identity)" />
+      <ReferenceAssemblies
+          Condition=" Exists ('$(LibDir)xbuild-frameworks\MonoAndroid\$(AndroidFirstFrameworkVersion)\%(_FirstFrameworkFile.Identity)') "
+          Include="$(LibDir)xbuild-frameworks\MonoAndroid\$(AndroidFirstFrameworkVersion)\%(_FirstFrameworkFile.Identity)">
+        <VSIXSubPath>Microsoft/Framework/$(AndroidFirstFrameworkVersion)/</VSIXSubPath>
+      </ReferenceAssemblies>
+    </ItemGroup>
+    <ItemGroup>
       <ReferenceAssemblies>
         <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Microsoft/Framework/%(RecursiveDir)</VSIXSubPath>
       </ReferenceAssemblies>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/1267

The commercial Windows `Xamarin.Android.Sdk.*.vsix` file contains lots
of files that the macOS `xamarin.android*.pkg` file does not.

Update `build-tools/create-vsix` to remove some of the additional
files which are not necessary, including:

  * `*.dylib`: macOS native libraries, not needed on Windows.
  * `$MSBuild/Xamarin/Android/**/*.pdb`: Debug symbols.
  * `$MSBuild/Xamarin/Android/lib/**/*.d.so`: Native libraries which
    have not been `strip`d.
  * `$ReferenceAssemblies/Microsoft/Framework/MonoAndroid/**/libZipSharp.*
    `libZipSharp*` is only needed in `$MSBuild`.
  * Distribute `Mono.Android.Export.*`, `OpenTK.*`, and `OpenTK-1.0.*`
    for only *one* API level, not *every* API level.
    `RedistList/FrameworkList.xml` ensures that previous framework
    versions will be included in assembly resolution via
    `/FileList/@IncludeFramework`, so there is no need to ship 10+
    identical copies of these assemblies.

A remaining (significant!) contribution to the size difference between
Windows and macOS is *documentation*: `Mono.Android.xml` is included
for each `$(TargetFrameworkVersion)`, and is ~57MB *per copy*.
This will *not* be addressed in xamarin-android, as documentation is
handled elsewhere (and I'm not entirely sure how to handle it).