### PR TITLE
[Mono.Android-Tests] Fix #1191, add new instrumentation class for new NUnit runner

### DIFF
--- a/src/Mono.Android/Test/Android.App/ApplicationTest.cs
+++ b/src/Mono.Android/Test/Android.App/ApplicationTest.cs
@@ -55,7 +55,7 @@ namespace Android.AppTests
 			using (var n = new ComponentName (context, klass)) {
 				var activityInfo  = context.PackageManager.GetActivityInfo (n, 0);
 				var configChanges = activityInfo.ConfigChanges;
-				Assert.AreEqual (ConfigChanges.KeyboardHidden, configChanges);
+				Assert.AreEqual (ConfigChanges.KeyboardHidden, configChanges & ConfigChanges.KeyboardHidden);
 			}
 		}
 	}

--- a/src/Mono.Android/Test/Mono.Android-Tests.csproj
+++ b/src/Mono.Android/Test/Mono.Android-Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -83,6 +83,7 @@
     <Compile Include="Xamarin.Android.RuntimeTests\MainActivity.cs" />
     <Compile Include="Xamarin.Android.RuntimeTests\MyIntent.cs" />
     <Compile Include="Xamarin.Android.RuntimeTests\NonJavaObject.cs" />
+    <Compile Include="Xamarin.Android.RuntimeTests\NUnitInstrumentation.cs" />
     <Compile Include="Xamarin.Android.RuntimeTests\TestInstrumentation.cs" />
     <Compile Include="Android.OS\BundleTest.cs" />
   </ItemGroup>
@@ -104,6 +105,14 @@
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Import Project="Mono.Android-Tests.targets" />
   <ItemGroup>
+    <ProjectReference Include="..\..\..\tests\TestRunner.Core\TestRunner.Core.csproj">
+      <Project>{3cc4e384-4985-4d93-a34c-73f69a379fa7}</Project>
+      <Name>TestRunner.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\tests\TestRunner.NUnit\TestRunner.NUnit.csproj">
+      <Project>{CB2335CB-0050-4020-8A05-E9614EDAA05E}</Project>
+      <Name>TestRunner.NUnit</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj" Condition=" '$(XAIntegratedTests)' == 'True' ">
       <Name>Xamarin.Android.Build.Tasks</Name>
       <Project>{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}</Project>

--- a/src/Mono.Android/Test/Xamarin.Android.RuntimeTests/NUnitInstrumentation.cs
+++ b/src/Mono.Android/Test/Xamarin.Android.RuntimeTests/NUnitInstrumentation.cs
@@ -1,0 +1,40 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Android.App;
+using Android.Runtime;
+using Xamarin.Android.UnitTests;
+using Xamarin.Android.UnitTests.NUnit;
+
+namespace Xamarin.Android.RuntimeTests
+{
+    [Instrumentation(Name = "xamarin.android.runtimetests.NUnitInstrumentation")]
+    public class NUnitInstrumentation : NUnitTestInstrumentation
+    {
+        const string DefaultLogTag = "NUnit";
+
+        string logTag = DefaultLogTag;
+
+        protected override string LogTag
+        {
+            get { return logTag; }
+            set { logTag = value ?? DefaultLogTag; }
+        }
+
+        protected NUnitInstrumentation(IntPtr handle, JniHandleOwnership transfer)
+            : base(handle, transfer)
+        {
+        }
+
+        protected override IList<TestAssemblyInfo> GetTestAssemblies()
+        {
+            Assembly asm = Assembly.GetExecutingAssembly();
+
+            return new List<TestAssemblyInfo>()
+            {
+                new TestAssemblyInfo(asm, asm.Location ?? String.Empty)
+            };
+        }
+    }
+}

--- a/src/Mono.Android/Test/Xamarin.Android.RuntimeTests/TestInstrumentation.cs
+++ b/src/Mono.Android/Test/Xamarin.Android.RuntimeTests/TestInstrumentation.cs
@@ -9,6 +9,7 @@ using Xamarin.Android.NUnitLite;
 
 namespace Xamarin.Android.RuntimeTests {
 
+    [Obsolete("Please use Xamarin.Android.RuntimeTests.NUnitTestInstrumentation")]
 	[Instrumentation (Name="xamarin.android.runtimetests.TestInstrumentation")]
 	public class TestInstrumentation : TestSuiteInstrumentation {
 

--- a/src/Mono.Android/Test/Xamarin.Android.RuntimeTests/TestInstrumentation.cs
+++ b/src/Mono.Android/Test/Xamarin.Android.RuntimeTests/TestInstrumentation.cs
@@ -9,7 +9,7 @@ using Xamarin.Android.NUnitLite;
 
 namespace Xamarin.Android.RuntimeTests {
 
-    [Obsolete("Please use Xamarin.Android.RuntimeTests.NUnitTestInstrumentation")]
+	[Obsolete("Please use Xamarin.Android.RuntimeTests.NUnitTestInstrumentation")]
 	[Instrumentation (Name="xamarin.android.runtimetests.TestInstrumentation")]
 	public class TestInstrumentation : TestSuiteInstrumentation {
 

--- a/tests/TestRunner.NUnit/NUnitTestRunner.cs
+++ b/tests/TestRunner.NUnit/NUnitTestRunner.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Android.UnitTests.NUnit
 		Dictionary<string, object> builderSettings;
 		TestSuiteResult results;
 
-		public ITestFilter Filter { get; set; }
+		public ITestFilter Filter { get; set; } = TestFilter.Empty;
 		public bool GCAfterEachFixture { get; set; }
 
 		protected override string ResultsFileName { get; set; } = "TestResults.NUnit.xml";


### PR DESCRIPTION
* Fixes #1191. The `Mcc` and `Mnc` values are now always present in ActivityInfo.ConfigChanges in Android 8.0+. The proposed fix is to ensure that `ConfigChanges` contains the `KeyboardHidden` flag , rather than requiring an exact match.
* Adds new instrumentation for new NUnit runner.
* Fixes possible NRE in new NUnit instrumentation/runner if test inclusion/exclusion data isn't provided.

Using the new NUnit runner is desirable as it is reliably producing test result xml files on device which can be pulled and published with ease. The previous runner had issues with certain devices when it came to providing the correct "on device" path to the test result xml. I've only marked the old instrumentation as obsolete (rather than deleting it) as I am not entirely familiar with how it is used in jenkins/wrench, and figured it could be cleaned up at a later date if those tools also want to migrate to use the new instrumentation/runner.