### PR TITLE
[Xamarin.Android.Build.Tasks] Fix Warning in Design Time Build.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1124,6 +1124,7 @@ because xbuild doesn't support framework reference assemblies.
 		References="@(ReferencePath)"
 		UseManagedResourceGenerator="True"
 		DesignTimeBuild="$(DesignTimeBuild)"
+		Condition="Exists ('$(MonoAndroidResourcePrefix)')"
 	/>
 	<ItemGroup>
 		<CorrectCasedItem Include="%(Compile.Identity)" Condition="'%(Compile.Identity)' == '$(AndroidResgenFile)'"/>


### PR DESCRIPTION
When building a MultiTarget netstandard project which includes
`monoandroidX.X` we get the following warning

	System.ArgumentException: Specified resource directory was not found:

This is raised by the `ManagedResourceParser` because the
`$(MonoAndroidResourcePrefix)` does not exist. Its a netstandard
project so it won't have any (maybe).
This commit makes sure we only run the `GenerateResourceDesigner`
if that directory exists. This will stop the warning showing and
give us a clean Design Time build.