### PR TITLE
[tests] support for running tests on VSTS

### DIFF
--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -28,7 +28,7 @@
     <Exec
         Command="$(_NUnit) $(NUNIT_EXTRA) %(_TestAssembly.Identity) $(_Test) --result=&quot;TestResult-%(Filename).xml;format=nunit2&quot; --output=&quot;bin\Test$(Configuration)\TestOutput-%(Filename).txt&quot;"
         WorkingDirectory="$(_TopDir)"
-        ContinueOnError="True"
+        ContinueOnError="ErrorAndContinue"
     />
     <ItemGroup>
       <_RenameTestCasesGlob Include="$(_TopDir)\TestResult-*Tests.xml" />


### PR DESCRIPTION
To get our desired behavior on VSTS, we have to:
- Make sure our call to NUnit returns a failing exit code
- Set the "Continue on Error" option in VSTS
- Add a step at the end of our build definition in VSTS to fail the
build if any issues ocurred

To make this work, we have to change our `<Exec />` task usage to
`ContinueOnError="ErrorAndContinue"`.

Example builds with a failing test can be found here:
- https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=1502302&tab=ms.vss-test-web.test-result-details
- https://jenkins.mono-project.com/job/xamarin-android-pr-builder/2739/