### PR TITLE
[msbuild] fix for JavaSourceJar and test

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -441,8 +441,8 @@ AAAA==";
 				binding.OtherBuildItems.Add (new BuildItem ("JavaSourceJar", "javasourcejartest-sources.jar") {
 					BinaryContent = () => Convert.FromBase64String (sourcesJarBase64)
 				});
-				bindingBuilder.Build (binding);
-				string xml = Path.Combine (bindingBuilder.Output.GetIntermediaryAsText ("docs/Com.Xamarin.Android.Test.Msbuildtest/JavaSourceJarTest.xml"));
+				Assert.IsTrue (bindingBuilder.Build (binding), "binding build should have succeeded");
+				string xml = bindingBuilder.Output.GetIntermediaryAsText ("docs/Com.Xamarin.Android.Test.Msbuildtest/JavaSourceJarTest.xml");
 				Assert.IsTrue (xml.Contains ("<param name=\"name\"> - name to display.</param>"), "missing doc");
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -530,7 +530,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
   </Target>
 
   <Target Name="BuildDocumentation"
-	  	Inputs="@(JavaDocIndex)"
+	  	Inputs="@(JavaDocIndex);@(IntermediateAssembly->'$(IntermediateOutputPath)%(filename).xml')"
 	  	Outputs="@(IntermediateAssembly->'$(OutputPath)%(filename).xml')"
 	  	Condition="'@(JavaDocIndex)' != ''">
     <MDoc


### PR DESCRIPTION
Context #1091

The test `BindingBuildTest.JavaSourceJar` appears to pass under xbuild,
but fail under msbuild. This seems be true for macOS or Windows.

Under further inspection, I noticed the `BuildDocumentation` target was
never running under msbuild. It was being skipped due to the outputs
being up-to-date in comparison to the inputs. To fix the skipped target,
I was able to add an additional input in
`Xamarin.Android.Bindings.targets`.

The line:
```
    <Copy
      SourceFiles="@(IntermediateAssembly->'$(IntermediateOutputPath)%(filename).xml')"
      DestinationFiles="@(IntermediateAssembly->'$(OutputPath)%(filename).xml')"
      SkipUnchangedFiles="true" />
```

Implies that `@(IntermediateAssembly->'$(IntermediateOutputPath)%(filename).xml')`
also should be an input.

Additionally, there was some stuff in the test that seemed incorrect:
- The return value of `bindingBuilder.Build` should have an assertion
that it is true
- For some reason the text from `GetIntermediaryAsText` was being passed
to `Path.Combine`. I think this was a typo that wasn't intentional.