### PR TITLE
Fix loading of Xamarin.Android.sln for omnisharp-roslyn

### DIFF
--- a/build-tools/libzip/libzip.targets
+++ b/build-tools/libzip/libzip.targets
@@ -79,4 +79,7 @@
     <RemoveDir Directories="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)" />
     <Delete Files="@(_LibZipTarget->'$(_LibZipOutputPath)%(OutputLibrary)')" />
   </Target>
+  <Target Name="CoreCompile"
+      DependsOnTargets="_BuildUnlessCached">
+  </Target>
 </Project>

--- a/build-tools/mono-runtimes/mono-runtimes.targets
+++ b/build-tools/mono-runtimes/mono-runtimes.targets
@@ -708,4 +708,7 @@
     <RemoveDir Directories="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity)');@(_MonoCrossRuntime->'$(IntermediateOutputPath)\%(Identity)');$(_LlvmBuildDir32);$(_LlvmBuildDir64);$(_LlvmBuildDirWin32);$(_LlvmBuildDirWin64)" />
     <Delete Files="@(_MonoRuntime->'$(IntermediateOutputPath)\%(Identity).config.cache');$(_CrossOutputPrefix)*.config.cache;$(_CrossOutputDirTop)\llvm*.config.cache" />
   </Target>
+  <Target Name="CoreCompile"
+      DependsOnTargets="_BuildRuntimes">
+  </Target>
 </Project>

--- a/build-tools/unix-distribution-setup/unix-distribution-setup.csproj
+++ b/build-tools/unix-distribution-setup/unix-distribution-setup.csproj
@@ -5,6 +5,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{2CF172E5-BDAE-4ABA-8BC8-08040ED3E77A}</ProjectGuid>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkMoniker>.NETFramework,Version=v4.5.1</TargetFrameworkMoniker>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/build-tools/unix-distribution-setup/unix-distribution-setup.targets
+++ b/build-tools/unix-distribution-setup/unix-distribution-setup.targets
@@ -23,5 +23,13 @@
 
   <Target Name="Clean">
   </Target>
+
+  <Target Name="CoreCompile"
+      DependsOnTargets="Build">
+  </Target>
+
+  <Target Name="Compile"
+      DependsOnTargets="CoreCompile">
+  </Target>
 </Project>
 

--- a/src/System.Drawing.Primitives/System.Drawing.Primitives.targets
+++ b/src/System.Drawing.Primitives/System.Drawing.Primitives.targets
@@ -18,5 +18,8 @@
     <Delete Files="$(OutputPath)\System.Drawing.Primitives.dll" />
     <Exec Command="make -C $(MonoSourceFullPath)\mcs\class\Facades\System.Drawing.Primitives PROFILE=monodroid clean" />
   </Target>
+  <Target Name="CoreCompile"
+      DependsOnTargets="_BuildSystemDrawingPrimitivesFacade">
+  </Target>
 </Project>
 

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -139,4 +139,7 @@
         Command="%(_HostRuntime.Strip) %(_HostRuntime.StripFlags) &quot;$(OutputPath)%(_HostRuntime.OutputDirectory)\libmono-android.release.%(_HostRuntime.NativeLibraryExtension)&quot;"
     />
   </Target>
+  <Target Name="CoreCompile"
+      DependsOnTargets="Build">
+  </Target>
 </Project>

--- a/src/netstandard/netstandard.targets
+++ b/src/netstandard/netstandard.targets
@@ -18,5 +18,8 @@
     <Delete Files="$(OutputPath)\netstandard.dll" />
     <Exec Command="make -C $(MonoSourceFullPath)\mcs\class\Facades\netstandard PROFILE=monodroid clean" />
   </Target>
+  <Target Name="CoreCompile"
+      DependsOnTargets="_BuildNetstandardFacade">
+  </Target>
 </Project>
 

--- a/src/proguard/proguard.targets
+++ b/src/proguard/proguard.targets
@@ -38,5 +38,8 @@
         WorkingDirectory="$(ProGuardSourceFullPath)"
     />
   </Target>
+  <Target Name="CoreCompile"
+      DependsOnTargets="_BuildProGuard">
+  </Target>
 </Project>
 

--- a/src/sqlite-xamarin/sqlite-xamarin.targets
+++ b/src/sqlite-xamarin/sqlite-xamarin.targets
@@ -31,4 +31,8 @@
       AfterTargets="Clean">
     <RemoveDir Directories="src/main/libs;src/main/obj" />
   </Target>
+
+  <Target Name="CoreCompile"
+      DependsOnTargets="_NdkBuild">
+  </Target>
 </Project>


### PR DESCRIPTION
[Omnisharp-Roslyn](https://github.com/OmniSharp/omnisharp-roslyn/) uses an internal MSBuild loader which has a number of
demands/assumptions on the contents of .csproj+.targets files.
It assumes the following targets are present:

 * Compile
 * CoreCompile

It also assumes that the `TargetFrameworkMoniker` property is set.

This commit makes a number of changes to our non-managed projects to make sure
the above expectations are met. With those changes in place one can load
Xamarin.Android.sln into an editor that uses OmniSharp for .NET code completion
etc.