### PR TITLE
[tests] change to re-save project file if properties change

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2056,8 +2056,6 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 					Assert.IsTrue (Directory.Exists (Path.Combine (Root, path, proj.ProjectName, proj.IntermediateOutputPath, "__library_projects__")),
 						"The __library_projects__ directory should exist.");
 					proj.RemoveProperty ("_AndroidLibrayProjectIntermediatePath");
-					//HACK: forces project to re-save, is there a *better* way?
-					proj.Sources.First ().Timestamp = DateTimeOffset.UtcNow;
 					Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
 					if (useShortFileNames) {
 						Assert.IsFalse (Directory.Exists (Path.Combine (Root, path, proj.ProjectName, proj.IntermediateOutputPath, "__library_projects__")),

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -137,14 +137,19 @@ namespace Xamarin.ProjectTools
 			return new BuildOutput (this) { Builder = builder };
 		}
 
+		string project_file_contents;
+
 		public virtual List<ProjectResource> Save (bool saveProject = true)
 		{
 			var list = new List<ProjectResource> ();
 			if (saveProject) {
+				var contents = SaveProject ();
+				var timestamp = contents != project_file_contents ? default (DateTimeOffset?) : 
+					ItemGroupList.SelectMany (ig => ig).Where (i => i.Timestamp != null).Select (i => (DateTimeOffset)i.Timestamp).Max ();
 				list.Add (new ProjectResource () {
-					Timestamp = ItemGroupList.SelectMany (ig => ig).Where (i => i.Timestamp != null).Select (i => (DateTimeOffset)i.Timestamp).Max (),
+					Timestamp = timestamp,
 					Path = ProjectFilePath,
-					Content = SaveProject (),
+					Content = project_file_contents = contents,
 					Encoding = System.Text.Encoding.UTF8,
 				});
 			}


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=1480184&tab=ms.vss-test-web.test-result-details&_a=summary

In the case of `Xamarin.Android.Build.Tests.BuildTest.ValidateUseLatestAndroid`,
there are points at which `UseLatestPlatformSdk` and `TargetFrameworkVersion`
are changed, but the `csproj` file is not re-saved on Windows.

So how does the test pass on macOS?

They pass on macOS due to `FileInfo.LastWriteTimeUtc` not containing
the millisecond information, which means files are likely to re-save
on macOS when not needed.

A simple fix for Windows, is to keep a reference to the last `csproj`
file contents. If the contents change, make the `Timestamp` of the
`csproj` null so it will always re-save.

After making this change, I was able to remove the following code from
another unit test:

    proj.Sources.First ().Timestamp = DateTimeOffset.UtcNow;