### PR TITLE
Fixed build on VS when using NetStandard libraries

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -88,6 +88,9 @@
     <None Include="Xamarin.Android.FSharp.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Xamarin.Android.PCLSupport.props">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Xamarin.Android.PCLSupport.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.PCLSupport.props
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.PCLSupport.props
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<UsingTask
+		TaskName="GetDependsOnNETStandard"
+		Condition="'$(_IsXBuild)' != 'true' And Exists ('$(MSBuildExtensionsPath)\Microsoft\Microsoft.NET.Build.Extensions\tools\net46\Microsoft.NET.Build.Extensions.Tasks.dll')"
+		AssemblyFile="$(MSBuildExtensionsPath)\Microsoft\Microsoft.NET.Build.Extensions\tools\net46\Microsoft.NET.Build.Extensions.Tasks.dll" />
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.PCLSupport.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.PCLSupport.targets
@@ -16,10 +16,8 @@
 		</ImplicitlyExpandDesignTimeFacadesDependsOn>
 	</PropertyGroup>
 
-	<UsingTask
-		TaskName="GetDependsOnNETStandard"
-		Condition="'$(_IsXBuild)' != 'true' And Exists ('$(MSBuildExtensionsPath)\Microsoft\Microsoft.NET.Build.Extensions\tools\net46\Microsoft.NET.Build.Extensions.Tasks.dll')"
-		AssemblyFile="$(MSBuildExtensionsPath)\Microsoft\Microsoft.NET.Build.Extensions\tools\net46\Microsoft.NET.Build.Extensions.Tasks.dll" />
+	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).props" 
+		Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).props') And ('$(_IsXBuild)' != 'true' And Exists ('$(MSBuildExtensionsPath)\Microsoft\Microsoft.NET.Build.Extensions\tools\net46\Microsoft.NET.Build.Extensions.Tasks.dll'))" />
 	
 	<Target Name="ImplicitlyExpandDesignTimeFacades" Condition="'$(ImplicitlyExpandDesignTimeFacades)' == 'true'" DependsOnTargets="$(ImplicitlyExpandDesignTimeFacadesDependsOn)">
 


### PR DESCRIPTION
On a VS project which has an Android App referencing a NetStandard
library, making changes on the NetStandad library will not force a build
of either project. This change moves the redefinition of the task to
where it will not be hit when it shouldn't be. This can be easily tried
with https://github.com/Microsoft/SmartHotel360-mobile-desktop-apps.
Open the Android Solution and run, then change the Login.xaml and try
running again. Without this change, the deployed app will not be
affected. It works correctly with this change.