### PR TITLE
[tests] Use `internalx.com`, not `xamdev.com`

### DIFF
--- a/src/Mono.Android/Test/System.Net/SslTest.cs
+++ b/src/Mono.Android/Test/System.Net/SslTest.cs
@@ -27,7 +27,7 @@ namespace System.NetTests {
 			Exception  exception  = null;
 
 			var thread = new Thread (() => {
-				string url = "https://tlstest-1.xamdev.com/";
+				string url = "https://tlstest-1.internalx.com/";
 
 				var downloadTask = new WebClient ().DownloadDataTaskAsync (url);
 				var completeTask = downloadTask.ContinueWith (t => {

--- a/src/Mono.Android/Test/Xamarin.Android.Net/AndroidClientHandlerTests.cs
+++ b/src/Mono.Android/Test/Xamarin.Android.Net/AndroidClientHandlerTests.cs
@@ -142,7 +142,7 @@ namespace Xamarin.Android.NetTests {
   [TestFixture]
   public class AndroidClientHandlerTests : HttpClientHandlerTestBase
   {
-    const string Tls_1_2_Url = "https://tlstest.xamdev.com/";
+    const string Tls_1_2_Url = "https://tlstest.internalx.com/";
 
     protected override HttpClientHandler CreateHandler ()
     {
@@ -259,8 +259,8 @@ namespace Xamarin.Android.NetTests {
 	  [Test]
 	  public void Redirect_Without_Protocol_Works()
 	  {
-		  var requestURI = new Uri ("http://tlstest.xamdev.com/redirect.php");
-		  var redirectedURI = new Uri ("http://tlstest.xamdev.com/redirect-301.html");
+		  var requestURI = new Uri ("http://tlstest.internalx.com/redirect.php");
+		  var redirectedURI = new Uri ("http://tlstest.internalx.com/redirect-301.html");
 		  using (var c = new HttpClient (CreateHandler ())) {
 			  var tr = c.GetAsync (requestURI);
 			  tr.Wait ();


### PR DESCRIPTION
The SSL certificates for `xamdev.com` have expired and won't be
renewed. We need to migrate to using `internalx.com` in order to fix
our SSL-based unit tests.