### PR TITLE
Use httpbin.org for AndroidClientHandler tests

### DIFF
--- a/src/Mono.Android/Test/Xamarin.Android.Net/AndroidClientHandlerTests.cs
+++ b/src/Mono.Android/Test/Xamarin.Android.Net/AndroidClientHandlerTests.cs
@@ -142,7 +142,7 @@ namespace Xamarin.Android.NetTests {
   [TestFixture]
   public class AndroidClientHandlerTests : HttpClientHandlerTestBase
   {
-    const string Tls_1_2_Url = "https://tlstest.xamdev.com/";
+    const string Tls_1_2_Url = "https://httpbin.org";
 
     protected override HttpClientHandler CreateHandler ()
     {
@@ -259,8 +259,8 @@ namespace Xamarin.Android.NetTests {
 	  [Test]
 	  public void Redirect_Without_Protocol_Works()
 	  {
-		  var requestURI = new Uri ("http://tlstest.xamdev.com/redirect.php");
-		  var redirectedURI = new Uri ("http://tlstest.xamdev.com/redirect-301.html");
+		  var requestURI = new Uri ("https://httpbin.org/redirect-to?url=https://httpbin.org/user-agent");
+		  var redirectedURI = new Uri ("https://httpbin.org/user-agent");
 		  using (var c = new HttpClient (CreateHandler ())) {
 			  var tr = c.GetAsync (requestURI);
 			  tr.Wait ();


### PR DESCRIPTION
This is a temporary step before we get our own server set up.