### PR TITLE
[Xamarin.Android.Build.Tasks] Ignore Assemblies which use `@(AndroidAarLibrary)`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -410,21 +410,28 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<MakeDir Directories="$(_AndroidDesignTimeResDirIntermediate)" Condition=" '$(DesignTimeBuild)' == 'true' " />
 </Target>
 
+<Target Name="_CollectLibraryProjects">
+	<ItemGroup>
+		<_LibraryProject Include="@(ReferencePath);@(ReferenceDependencyPaths)" />
+	</ItemGroup>
+</Target>
+
 <PropertyGroup>
 	<_BeforeBuildAdditionalResourcesCache>
 		_CreatePropertiesCache;
+		_CollectLibraryProjects;
 	</_BeforeBuildAdditionalResourcesCache>
 </PropertyGroup>
 
 <Target Name="_BuildAdditionalResourcesCache"
-	Inputs="@(ReferencePath);@(ReferenceDependencyPaths);$(MSBuildProjectFullPath);$(NugetPackagesConfig);$(_AndroidBuildPropertiesCache)"
+	Inputs="@(_LibraryProject);$(MSBuildProjectFullPath);$(NugetPackagesConfig);$(_AndroidBuildPropertiesCache)"
 	Outputs="$(_AndroidResourcePathsCache)"
 	DependsOnTargets="$(_BeforeBuildAdditionalResourcesCache)"
 	>
  <GetAdditionalResourcesFromAssemblies
    AndroidSdkDirectory="$(_AndroidSdkDirectory)"
    AndroidNdkDirectory="$(_AndroidNdkDirectory)"
-   Assemblies="@(ReferencePath);@(ReferenceDependencyPaths)"
+   Assemblies="@(_LibraryProject)"
    CacheFile="$(_AndroidResourcePathsCache)"
    YieldDuringToolExecution="$(YieldDuringToolExecution)"
    DesignTimeBuild="$(DesignTimeBuild)"
@@ -1185,13 +1192,14 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_ResolveLibraryProjectImports"
-		Inputs="$(MSBuildProjectFullPath);@(ReferencePath);@(ReferenceDependencyPaths);$(_AndroidBuildPropertiesCache)"
+		DependsOnTargets="_CollectLibraryProjects"
+		Inputs="$(MSBuildProjectFullPath);@(_LibraryProject);@(AndroidAarLibrary);$(_AndroidBuildPropertiesCache)"
 		Outputs="$(_AndroidLibraryProjectImportsCache)">
 	<ResolveLibraryProjectImports
 		ContinueOnError="$(DesignTimeBuild)"
 		CacheFile="$(_AndroidLibraryProjectImportsCache)"
 		DesignTimeBuild="$(DesignTimeBuild)"
-		Assemblies="@(ReferencePath);@(ReferenceDependencyPaths)"
+		Assemblies="@(_LibraryProject)"
 		AarLibraries="@(AndroidAarLibrary)"
 		ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
 		UseShortFileNames="$(UseShortFileNames)"


### PR DESCRIPTION
This is a slight modification to our Aar support. We have a
situation where some versions of the components use the
new `@(AndroidAarLibrary)` ItemGroup to extract resources.
BUT (and its a big one).. It also cotnains the old style
embedded resource archive!

So what ends up happening is we extract the resources TWICE!
So what the component team need is a way to tell our build
system to ignore certain assemblies since they have Aar files.
Rather than trying to do some weird path matching logic which
will no doubt fail we introduce a new Item Group `@(_LibraryProjects)`.

This new item group is populated in  the new `_CollectLibraryProjects`
target from the existing `@(ReferencePath);@(ReferenceDependencyPaths)`.
The component team can then run a target after the `_CollectLibraryProjects`
target to remove the problem assemblies from the resource
extraction process.

	<Target Name="_Foo" AfterTargets="_CollectLibraryProjects">
		<ItemGroup>
			<_LibraryProject Remove="%(_LibraryProject.Identity)" Condition=" '%(_LibraryProject.Filename)' == 'foo.dll'" />
		</ItemGroup>
	</Target>

This new item group will only be used in `_ResolveLibraryProjectImports`
and `_BuildAdditionalResourceCache`. So removing the assembly will
have no effect on the building or deplopyment of the application.