### PR TITLE
[Xamarin.Android.Build.Tasks] Rework Parallel.ForEach

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -257,7 +257,7 @@ namespace Xamarin.Android.Tasks
 
 			ThreadingTasks.ParallelOptions options = new ThreadingTasks.ParallelOptions {
 				CancellationToken = Token,
-				TaskScheduler = ThreadingTasks.TaskScheduler.Current,
+				TaskScheduler = ThreadingTasks.TaskScheduler.Default,
 			};
 
 			ThreadingTasks.Parallel.ForEach (ManifestFiles, options, ProcessManifest);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -267,7 +267,7 @@ namespace Xamarin.Android.Tasks
 
 				ThreadingTasks.ParallelOptions options = new ThreadingTasks.ParallelOptions {
 					CancellationToken = cts.Token,
-					TaskScheduler = ThreadingTasks.TaskScheduler.Current,
+					TaskScheduler = ThreadingTasks.TaskScheduler.Default,
 				};
 
 				ThreadingTasks.Parallel.ForEach (GetAotConfigs (), options,

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
@@ -70,7 +70,7 @@ namespace Xamarin.Android.Tasks
 			return;
 		}
 
-		public override bool Execute () 
+		public override bool Execute ()
 		{
 			var task = ThreadingTasks.Task.Run ( () => {
 				return DoExecute ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
@@ -95,7 +95,7 @@ namespace Xamarin.Android.Tasks
 
 			ThreadingTasks.ParallelOptions options = new ThreadingTasks.ParallelOptions {
 				CancellationToken = Token,
-				TaskScheduler = ThreadingTasks.TaskScheduler.Current,
+				TaskScheduler = ThreadingTasks.TaskScheduler.Default,
 			};
 
 			var imageGroups = imageFiles.GroupBy (x => Path.GetDirectoryName (Path.GetFullPath (x.ItemSpec)));


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/578528

We are getting allot of reports of hangs in the aapt
task. While this might be down tot he aapt verson
itself, it did highlight a possible problem with our
implementation.

Firstly `Parallel.ForEach` is a BLOCKING call. So our
implementation in `Aapt.cs` and `Crunch.cs` was not
taking that into account. Also `Parellel.ForEach` will
use the current thread to run tasks. So if we run it
from the main MSBuild `Execute` method it will run
at least on of the items on that thread. Given one of
our goals was to not block the UI thread in VS this
might well cause a problem. Also the Local final action
in `Parallel.ForEach` is run for every task, not when all
have completed. As a result the `Complete` method was
being called many times. Luckily this did not cause a
problem because `Parallel.ForEach` was blocking and
`base.Execute` (which does the waiting in `AsyncTask`)
was not running.

So taking notes from the `Aot.cs` task, we should kick
of the processing in a thread of its own. This will ensure
that we a) don't block the UI thread and b) make sure tasks
are run off the UI Thread and c) makes sure `Complete` is called
appropriately.

Based on information at [1] we should also be using `TaskScheduler.Default`
not `TaskScheduler.Current`.

[1] https://github.com/Microsoft/vs-threading/blob/master/doc/threading_rules.md