### PR TITLE
[msbuild] default value for JavaMaximumHeapSize

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -456,11 +456,13 @@ when packaing Release applications.
 -   **JavaMaximumHeapSize** &ndash; Specifies the value of the **java**
     `-Xmx` parameter value to use when building the `.dex` file as part
     of the packaging process. If not specified, then the `-Xmx` option
-    is not provided to **java**.
+    supplies **java** with a value of `1G`. This was found to be commonly
+    required on Windows in comparison to other platforms.
 
-    Specifying this property is necessary if the
+    Without this value an error could be thrown such as:
     [`_CompileDex` target throws a `java.lang.OutOfMemoryError`](https://bugzilla.xamarin.com/show_bug.cgi?id=18327).
 
+    Customize the value by changing:
     ```xml
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
     ```

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -271,8 +271,6 @@ using System.Runtime.CompilerServices;
 				proj.Packages.Add (KnownPackages.GooglePlayServices_22_0_0_2);
 				proj.AndroidExplicitCrunch = explicitCrunch;
 				proj.SetProperty ("TargetFrameworkVersion", "v5.0");
-				proj.SetProperty (proj.DebugProperties, "JavaMaximumHeapSize", "1G");
-				proj.SetProperty (proj.ReleaseProperties, "JavaMaximumHeapSize", "1G");
 				using (var b = CreateApkBuilder (Path.Combine (projectPath, "Application1"), false, false)) {
 					b.Verbosity = LoggerVerbosity.Diagnostic;
 					Assert.IsTrue (b.Build (proj), "Build should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2311,7 +2311,6 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 			};
 			//NOTE: BuildingInsideVisualStudio prevents the projects from being built as dependencies
 			app1.SetProperty ("BuildingInsideVisualStudio", "False");
-			app1.SetProperty ("JavaMaximumHeapSize", "1G");
 			app1.Imports.Add (new Import ("foo.targets") {
 				TextContent = () => @"<?xml version=""1.0"" encoding=""utf-16""?>
 <Project ToolsVersion=""4.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -265,6 +265,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidEnableMultiDex Condition="'$(AndroidEnableMultiDex)'==''">False</AndroidEnableMultiDex>
 	<AndroidEnableDesugar Condition="'$(AndroidEnableDesugar)'==''">False</AndroidEnableDesugar>
 
+	<!-- Default Java heap size to 1GB (-Xmx1G) if not specified-->
+	<JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
+
 	<ProguardConfigFiles Condition="'$(ProguardConfigFiles)' == ''">
 		{sdk.dir}tools\proguard\proguard-android.txt;
 		{intermediate.common.xamarin};


### PR DESCRIPTION
Fixes #1415

Commonly Xamarin.Android apps on Windows require the `JavaMaximumHeapSize`
property to be set, in order to make it past the `CompileToDalvik`
MSBuild task that invokes `dx.jar`. Passing `java.exe` a value of
`-Xmx1G` mitigates the `java.lang.OutOfMemoryError`.

We have been getting reports of this happening for File->New Project
templates, so it seems to be time to default the value to `1G` if it
is not set.

Changes:
- Set `JavaMaximumHeapSize` in `Xamarin.Android.Common.targets` if unset
- Removed places `JavaMaximumHeapSize` was required to be set for
some unit tests to pass on Windows
- Update documentation

Concerns:

At one time, a default value for `JavaMaximumHeapSize` was attempted,
only to get reports of an error such as:

    While trying to start a Java application with a maximum heap size of
    1GB, you receive the following error:
    "JVMJ9VM015W Initialization error for library j9gc24(2): Failed to
    instantiate heap; 1G requested
    Could not create the Java virtual machine.

Hopefully, this was something that was happening for older JDK versions in
the past on Windows.