### PR TITLE
[Xamarin.Android.Build.Tasks] DesignTimeBuild Improvements 

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
@@ -459,13 +459,7 @@ namespace Xamarin.Android.Tasks {
 					new XElement ("AdditionalNativeLibraryReferences", 
 							AdditionalNativeLibraryReferences.Select(e => new XElement ("AdditionalNativeLibraryReference", e)))
 					));
-			var tempFile = System.IO.Path.GetTempFileName ();
-			try {
-				document.Save (tempFile);
-				MonoAndroidHelper.CopyIfChanged (tempFile, CacheFile);
-			} finally {
-				File.Delete (tempFile);
-			}
+			document.SaveIfChanged (CacheFile);
 
 			LogDebugTaskItems ("  AdditionalAndroidResourcePaths: ", AdditionalAndroidResourcePaths);
 			LogDebugTaskItems ("  AdditionalJavaLibraryReferences: ", AdditionalJavaLibraryReferences);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
@@ -459,7 +459,13 @@ namespace Xamarin.Android.Tasks {
 					new XElement ("AdditionalNativeLibraryReferences", 
 							AdditionalNativeLibraryReferences.Select(e => new XElement ("AdditionalNativeLibraryReference", e)))
 					));
-			document.Save (CacheFile);
+			var tempFile = System.IO.Path.GetTempFileName ();
+			try {
+				document.Save (tempFile);
+				MonoAndroidHelper.CopyIfChanged (tempFile, CacheFile);
+			} finally {
+				File.Delete (tempFile);
+			}
 
 			LogDebugTaskItems ("  AdditionalAndroidResourcePaths: ", AdditionalAndroidResourcePaths);
 			LogDebugTaskItems ("  AdditionalJavaLibraryReferences: ", AdditionalJavaLibraryReferences);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
@@ -54,13 +54,7 @@ namespace Xamarin.Android.Tasks
 									new XElement ("NativeLibraries", NativeLibraries.Select(e => new XElement ("NativeLibrary", e.ItemSpec))),
 									new XElement ("Jars", Jars.Select(e => new XElement ("Jar", e.ItemSpec)))
 						));
-				var tempFile = System.IO.Path.GetTempFileName ();
-				try {
-					document.Save (tempFile);
-					MonoAndroidHelper.CopyIfChanged (tempFile, CacheFile);
-				} finally {
-					File.Delete (tempFile);
-				}
+				document.SaveIfChanged (CacheFile);
 			}
 
 			return true;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
@@ -54,7 +54,13 @@ namespace Xamarin.Android.Tasks
 									new XElement ("NativeLibraries", NativeLibraries.Select(e => new XElement ("NativeLibrary", e.ItemSpec))),
 									new XElement ("Jars", Jars.Select(e => new XElement ("Jar", e.ItemSpec)))
 						));
-				document.Save (CacheFile);
+				var tempFile = System.IO.Path.GetTempFileName ();
+				try {
+					document.Save (tempFile);
+					MonoAndroidHelper.CopyIfChanged (tempFile, CacheFile);
+				} finally {
+					File.Delete (tempFile);
+				}
 			}
 
 			return true;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -122,13 +122,7 @@ namespace Xamarin.Android.Tasks
 						new XElement ("ResolvedResourceDirectoryStamps",
 							ResolvedResourceDirectoryStamps.Select(e => new XElement ("ResolvedResourceDirectoryStamp", e)))
 					));
-				var tempFile = System.IO.Path.GetTempFileName ();
-				try {
-					document.Save (tempFile);
-					MonoAndroidHelper.CopyIfChanged (tempFile, CacheFile);
-				} finally {
-					File.Delete (tempFile);
-				}
+				document.SaveIfChanged (CacheFile);
 			}
 
 			assemblyMap.Save (AssemblyIdentityMapFile);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -122,7 +122,13 @@ namespace Xamarin.Android.Tasks
 						new XElement ("ResolvedResourceDirectoryStamps",
 							ResolvedResourceDirectoryStamps.Select(e => new XElement ("ResolvedResourceDirectoryStamp", e)))
 					));
-				document.Save (CacheFile);
+				var tempFile = System.IO.Path.GetTempFileName ();
+				try {
+					document.Save (tempFile);
+					MonoAndroidHelper.CopyIfChanged (tempFile, CacheFile);
+				} finally {
+					File.Delete (tempFile);
+				}
 			}
 
 			assemblyMap.Save (AssemblyIdentityMapFile);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -958,7 +958,7 @@ namespace Lib1 {
 					Assert.IsTrue (libBuilder.Build (libProj, doNotCleanupOnUpdate: true, saveProject: false), "Library project should have built");
 					Assert.IsTrue (libBuilder.Output.IsTargetSkipped ("_CreateManagedLibraryResourceArchive"), "_CreateManagedLibraryResourceArchive should be skipped.");
 					Assert.IsTrue (appBuilder.Build (appProj, doNotCleanupOnUpdate: true, saveProject: false), "Application Build should have succeeded.");
-					Assert.IsFalse (appBuilder.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "_UpdateAndroidResgen target NOT should be skipped since Lib1 was updated.");
+					Assert.IsTrue (appBuilder.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "_UpdateAndroidResgen target should be skipped");
 					theme.TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
 <resources>
 	<color name=""theme_devicedefault_background"">#00000000</color>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -958,7 +958,7 @@ namespace Lib1 {
 					Assert.IsTrue (libBuilder.Build (libProj, doNotCleanupOnUpdate: true, saveProject: false), "Library project should have built");
 					Assert.IsTrue (libBuilder.Output.IsTargetSkipped ("_CreateManagedLibraryResourceArchive"), "_CreateManagedLibraryResourceArchive should be skipped.");
 					Assert.IsTrue (appBuilder.Build (appProj, doNotCleanupOnUpdate: true, saveProject: false), "Application Build should have succeeded.");
-					Assert.IsTrue (appBuilder.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "_UpdateAndroidResgen target should be skipped.");
+					Assert.IsFalse (appBuilder.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "_UpdateAndroidResgen target NOT should be skipped since Lib1 was updated.");
 					theme.TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
 <resources>
 	<color name=""theme_devicedefault_background"">#00000000</color>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -958,7 +958,7 @@ namespace Lib1 {
 					Assert.IsTrue (libBuilder.Build (libProj, doNotCleanupOnUpdate: true, saveProject: false), "Library project should have built");
 					Assert.IsTrue (libBuilder.Output.IsTargetSkipped ("_CreateManagedLibraryResourceArchive"), "_CreateManagedLibraryResourceArchive should be skipped.");
 					Assert.IsTrue (appBuilder.Build (appProj, doNotCleanupOnUpdate: true, saveProject: false), "Application Build should have succeeded.");
-					Assert.IsTrue (appBuilder.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "_UpdateAndroidResgen target should be skipped");
+					Assert.IsTrue (appBuilder.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "_UpdateAndroidResgen target should be skipped.");
 					theme.TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
 <resources>
 	<color name=""theme_devicedefault_background"">#00000000</color>

--- a/src/Xamarin.Android.Build.Tasks/Utilities/XDocumentExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/XDocumentExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 using Microsoft.Build.Framework;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/XDocumentExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/XDocumentExtensions.cs
@@ -27,6 +27,17 @@ namespace Xamarin.Android.Tasks
 		{
 			return element.ToString (SaveOptions.DisableFormatting);
 		}
+
+		public static void SaveIfChanged (this XDocument document, string fileName)
+		{
+			var tempFile = System.IO.Path.GetTempFileName ();
+			try {
+				document.Save (tempFile);
+				MonoAndroidHelper.CopyIfChanged (tempFile, fileName);
+			} finally {
+				File.Delete (tempFile);
+			}
+		}
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1107,9 +1107,21 @@ because xbuild doesn't support framework reference assemblies.
 		Overwrite="true"/>
 </Target>
 
+<PropertyGroup>
+	<_ManagedUpdateAndroidResgenInputs>
+		$(MSBuildAllProjects);
+		@(AndroidResource);
+		@(ReferencePath);
+		@(_LibraryResourceDirectoryStamps);
+		@(_AdditonalAndroidResourceCachePaths->'%(Identity)\cache.stamp');
+		$(_AndroidBuildPropertiesCache);
+		$(ProjectAssetsFile);
+	</_ManagedUpdateAndroidResgenInputs>
+</PropertyGroup>
+
 <!-- Managed DesignTime Resource Generation -->
 <Target Name="_ManagedUpdateAndroidResgen" Condition=" '$(ManagedDesignTimeBuild)' == 'True' "
-		Inputs="@(AndroidResource);@(ReferencePath)"
+		Inputs="$(_ManagedUpdateAndroidResgenInputs);$(_AndroidResourcePathsCache);$(_AndroidLibraryProjectImportsCache);$(_AndroidLibraryImportsCache);"
 		Outputs="$(_AndroidManagedResourceDesignerFile)"
 		DependsOnTargets="_CreatePropertiesCache;_ExtractLibraryProjectImports;_CreateAdditionalResourceCache">
 	<MakeDir Directories="$(_AndroidDesignTimeResDirIntermediate)" />
@@ -1188,7 +1200,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_ResolveLibraryProjectImports"
-		Inputs="$(MSBuildProjectFullPath);@(ReferencePath);@(ReferenceDependencyPaths);$(_AndroidBuildPropertiesCache)"
+		Inputs="$(ProjectAssetsFile);$(MSBuildProjectFullPath);@(ReferencePath);@(ReferenceDependencyPaths);$(_AndroidBuildPropertiesCache)"
 		Outputs="$(_AndroidLibraryProjectImportsCache)">
 	<ResolveLibraryProjectImports
 		ContinueOnError="$(DesignTimeBuild)"
@@ -1393,7 +1405,11 @@ because xbuild doesn't support framework reference assemblies.
 		@(_AndroidResourceDest);
 		@(_LibraryResourceDirectoryStamps);
 		@(_AdditonalAndroidResourceCachePaths->'%(Identity)\cache.stamp');
-		$(_AndroidBuildPropertiesCache)
+		$(_AndroidBuildPropertiesCache);
+		$(ProjectAssetsFile);
+		$(_AndroidResourcePathsCache);
+		$(_AndroidLibraryProjectImportsCache);
+		$(_AndroidLibraryImportsCache);
 	</_UpdateAndroidResgenInputs>
 </PropertyGroup>
 


### PR DESCRIPTION
We had a report from @garuma that the `Resource.designer.cs` was not being updated correctly if the Nuget packages were not restored when opening the project. This is a user preference option apparently. This is due to when the Design Time Build (DTB) is run. The main DTB is run on project load. The `ManagedResourceParser` would then run on the available resources, which would NOT include those from the Nuget packages as they were not restored.

When the Nuget packages are finally restored the designer is not updated because none of the inputs changes. On a restore Nuget does not modify the csproj, or change any of the project build properties. As a result some of our targets a skipped. 

This commit adds the various .cache files we use to the inputs of `_UpdateAndroidResgen` and other targets to ensure that they get updated when these files change. It also adds the Nuget `$(ProjectAssetsFile)` to the list of inputs so that if that changes we rebuild the designer on the next DTB. 

This work uncovered a problem with the way we store the .cache files `$(_AndroidResourcePathsCache)`, `$(_AndroidLibraryProjectImportsCache)` and `$(_AndroidLibraryImportsCache)`. It turns out that they were being saved every time the task ran. Even if the contents of the files did not change. This then caused `_UpdateAndroidResgen` to run even if it did not need to. So an extension method was added to `XDocument` called `SaveIfChanged` which uses the same temp file trick we use in other places to ensure we only update the file if it changes.