### PR TITLE
[create-vsix] Create a separate package for unstable frameworks

### DIFF
--- a/build-tools/create-vsix/AndroidSdkPackage.cs
+++ b/build-tools/create-vsix/AndroidSdkPackage.cs
@@ -3,7 +3,11 @@ using Microsoft.VisualStudio.Shell;
 
 namespace Xamarin.Android.Sdk
 {
+#if UNSTABLE_FRAMEWORKS
+    [Guid("0ce7b215-7684-4884-9f5b-1cdd800a5253")]
+#else   // UNSTABLE_FRAMEWORKS
     [Guid("d0e8d881-b09d-40bf-923b-b3efddc53c16")]
+#endif  // !UNSTABLE_FRAMEWORKS
     public class AndroidSdkPackage : Package
     {
     }

--- a/build-tools/create-vsix/VSPackage-UnstableFrameworks.resx
+++ b/build-tools/create-vsix/VSPackage-UnstableFrameworks.resx
@@ -1,0 +1,140 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+    VS SDK Notes: This resx file contains the resources that will be consumed from your package by Visual Studio.
+    For example, Visual Studio will attempt to load resource '400' from this resource stream when it needs to
+    load your package's icon. Because Visual Studio will always look in the VSPackage.resources stream first for
+    resources it needs, you should put additional resources that Visual Studio will load directly into this resx
+    file.
+
+    Resources that you would like to access directly from your package in a strong-typed fashion should be stored
+    in Resources.resx or another resx file.
+-->
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="110" xml:space="preserve">
+    <value>Xamarin.Android SDK for Unstable Frameworks</value>
+  </data>
+  <data name="112" xml:space="preserve">
+    <value>Xamarin.Android Reference Assemblies for Unstable Frameworks.</value>
+  </data>
+  <data name="400" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources/AndroidSdkPackage.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+</root>

--- a/build-tools/create-vsix/Xamarin.Android.Sdk-UnstableFrameworks.pkgdef.in
+++ b/build-tools/create-vsix/Xamarin.Android.Sdk-UnstableFrameworks.pkgdef.in
@@ -1,0 +1,11 @@
+[$RootKey$\InstalledProducts\AndroidSdkPackage]
+@="#110"
+"Package"="{0ce7b215-7684-4884-9f5b-1cdd800a5253}"
+"PID"="@PACKAGE_VERSION@.@PACKAGE_VERSION_BUILD@ (@PACKAGE_HEAD_BRANCH@/@PACKAGE_HEAD_REV@)"
+"ProductDetails"="#112"
+"LogoID"="#400"
+[$RootKey$\Packages\{0ce7b215-7684-4884-9f5b-1cdd800a5253}]
+@="AndroidSdkPackage"
+"InprocServer32"="$WinDir$\SYSTEM32\MSCOREE.DLL"
+"Class"="Xamarin.Android.Sdk.AndroidSdkPackage"
+"CodeBase"="$PackageFolder$\Xamarin.Android.Sdk.dll"

--- a/build-tools/create-vsix/create-vsix.csproj
+++ b/build-tools/create-vsix/create-vsix.csproj
@@ -21,7 +21,11 @@
     <IsProductComponent Condition=" '$(IsProductComponent)' == '' ">True</IsProductComponent>
     <_BuildVsix Condition=" '$(CreateVsixContainer)' == 'True' And Exists ('$(VsSDKInstall)') ">True</_BuildVsix>
     <_BuildVsix Condition=" '$(_BuildVsix)' == '' ">False</_BuildVsix>
-    <ExtensionInstallationFolder>Xamarin\Xamarin.Android.Sdk</ExtensionInstallationFolder>
+    <UnstableFrameworks Condition=" '$(UnstableFrameworks)' == '' ">False</UnstableFrameworks>
+    <_PackageDefinitionTemplate Condition=" '$(UnstableFrameworks)' == 'True' ">Xamarin.Android.Sdk-UnstableFrameworks.pkgdef.in</_PackageDefinitionTemplate>
+    <_PackageDefinitionTemplate Condition=" '$(_PackageDefinitionFile)' == '' ">Xamarin.Android.Sdk.pkgdef.in</_PackageDefinitionTemplate>
+    <ExtensionInstallationFolder Condition=" '$(UnstableFrameworks)' == 'True' ">Xamarin\Xamarin.Android.Sdk-UnstableFrameworks</ExtensionInstallationFolder>
+    <ExtensionInstallationFolder Condition=" '$(ExtensionInstallationFolder)' == '' ">Xamarin\Xamarin.Android.Sdk</ExtensionInstallationFolder>
     <OutputPath>bin\$(Configuration)</OutputPath>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
@@ -37,7 +41,11 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="VSPackage.resx">
+    <EmbeddedResource Condition=" '$(UnstableFrameworks)' == 'False' " Include="VSPackage.resx">
+      <MergeWithCTO>True</MergeWithCTO>
+      <ManifestResourceName>VSPackage</ManifestResourceName>
+    </EmbeddedResource>
+    <EmbeddedResource Condition=" '$(UnstableFrameworks)' == 'True' " Include="VSPackage-UnstableFrameworks.resx">
       <MergeWithCTO>True</MergeWithCTO>
       <ManifestResourceName>VSPackage</ManifestResourceName>
     </EmbeddedResource>
@@ -103,6 +111,9 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VsSDKInstall)\Microsoft.VsSDK.targets" Condition=" '$(_BuildVsix)' == 'True' " />
+  <PropertyGroup Condition=" '$(UnstableFrameworks)' == 'True' ">
+    <DefineConstants>$(DefineConstants);UNSTABLE_FRAMEWORKS</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(_BuildVsix)' == 'True' ">
     <BuildDependsOn>
       _CreateDependencies;

--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\scripts\XAVersionInfo.targets" />
+  <Import Project="..\..\src\Mono.Android\Mono.Android.projitems" />
   <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"   TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
   <PropertyGroup>
     <!-- Don't ever deploy, since that won't work on Mac -->
@@ -43,7 +44,7 @@
       <_FirstFrameworkFile  Include="OpenTK.pdb" />
       <_FirstFrameworkFile  Include="OpenTK.xml" />
     </ItemGroup>
-    <ItemGroup>
+    <ItemGroup Condition=" '$(UnstableFrameworks)' == 'False' ">
       <MSBuild Include="$(LibDir)xbuild\Novell\**\*.*" />
       <MSBuild>
         <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Novell/%(RecursiveDir)</VSIXSubPath>
@@ -82,13 +83,24 @@
       />
       <ReferenceAssemblies Remove="$(LibDir)xbuild-frameworks\**\*.dylib" />
       <ReferenceAssemblies Remove="$(LibDir)xbuild-frameworks\**\libZipSharp*.*" />
+      <ReferenceAssemblies
+          Condition=" '%(AndroidApiInfo.Stable)' == 'False' "
+          Remove="$(LibDir)xbuild-frameworks\MonoAndroid\%(AndroidApiInfo.Identity)\**\*.*"
+      />
     </ItemGroup>
-    <ItemGroup Condition="Exists('$(LibDir)xbuild-frameworks\MonoAndroid\$(AndroidFirstFrameworkVersion)')">
+    <ItemGroup Condition=" '$(UnstableFrameworks)' == 'False' And Exists('$(LibDir)xbuild-frameworks\MonoAndroid\$(AndroidFirstFrameworkVersion)')">
       <ReferenceAssemblies Remove="$(LibDir)xbuild-frameworks\**\%(_FirstFrameworkFile.Identity)" />
       <ReferenceAssemblies
           Condition=" Exists ('$(LibDir)xbuild-frameworks\MonoAndroid\$(AndroidFirstFrameworkVersion)\%(_FirstFrameworkFile.Identity)') "
           Include="$(LibDir)xbuild-frameworks\MonoAndroid\$(AndroidFirstFrameworkVersion)\%(_FirstFrameworkFile.Identity)">
         <VSIXSubPath>Microsoft/Framework/$(AndroidFirstFrameworkVersion)/</VSIXSubPath>
+      </ReferenceAssemblies>
+    </ItemGroup>
+    <ItemGroup Condition=" '$(UnstableFrameworks)' == 'True' ">
+      <ReferenceAssemblies
+          Condition=" '%(AndroidApiInfo.Stable)' == 'False' "
+          Include="$(LibDir)xbuild-frameworks\MonoAndroid\%(AndroidApiInfo.Identity)\**\*.*">
+        <VSIXSubPath>Microsoft/Framework/%(AndroidApiInfo.Identity)/%(RecursiveDir)</VSIXSubPath>
       </ReferenceAssemblies>
     </ItemGroup>
     <ItemGroup>
@@ -129,6 +141,27 @@
       <VsixVersion>$(ProductVersion).$(XAVersionCommitCount)</VsixVersion>
     </PropertyGroup>
   </Target>
+  <Target Name="GetVsixId"
+      Returns="$(VsixId)">
+    <PropertyGroup>
+      <VsixId Condition=" '$(UnstableFrameworks)' == 'True' ">Xamarin.Android.Sdk-UnstableFrameworks</VsixId>
+      <VsixId Condition=" '$(VsixId)' == '' ">Xamarin.Android.Sdk</VsixId>
+    </PropertyGroup>
+  </Target>
+  <Target Name="GetVsixDescription"
+      Returns="$(VsixDescription)">
+    <PropertyGroup>
+      <VsixDescription Condition=" '$(UnstableFrameworks)' == 'True' ">Xamarin.Android.Sdk-UnstableFrameworks</VsixDescription>
+      <VsixDescription Condition=" '$(VsixDescription)' == '' ">Xamarin.Android.Sdk</VsixDescription>
+    </PropertyGroup>
+  </Target>
+  <Target Name="GetVsixDisplayName"
+      Returns="$(VsixDisplayName)">
+    <PropertyGroup>
+      <VsixDisplayName Condition=" '$(UnstableFrameworks)' == 'True' ">Xamarin.Android SDK Unstable Frameworks</VsixDisplayName>
+      <VsixDisplayName Condition=" '$(VsixDisplayName)' == '' ">Xamarin.Android SDK</VsixDisplayName>
+    </PropertyGroup>
+  </Target>
   <Target Name="FixupTargetVsixContainer"
       BeforeTargets="VSIXContainerProjectOutputGroup;CreateVsixContainer"
       DependsOnTargets="_GetVsixPath">
@@ -142,11 +175,9 @@
   </Target>
   <Target Name="_CreateDependencies"
       DependsOnTargets="ResolveReferences;GetXAVersionInfo"
-      BeforeTargets="Build"
-      Inputs="Xamarin.Android.Sdk.pkgdef.in"
-      Outputs="Xamarin.Android.Sdk.pkgdef">
+      BeforeTargets="Build">
     <ReplaceFileContents
-        SourceFile="Xamarin.Android.Sdk.pkgdef.in"
+        SourceFile="$(_PackageDefinitionTemplate)"
         DestinationFile="Xamarin.Android.Sdk.pkgdef"
         Replacements="@PACKAGE_VERSION@=$(ProductVersion);@PACKAGE_VERSION_BUILD@=$(XAVersionCommitCount);@PACKAGE_HEAD_REV@=$(XAVersionHash);@PACKAGE_HEAD_BRANCH@=$(XAVersionBranch)">
     </ReplaceFileContents>
@@ -158,21 +189,28 @@
       <_Branch>$(_Branch.Replace ('\', '-'))</_Branch>
     </PropertyGroup>
     <PropertyGroup>
+      <VsixPath Condition=" '$(UnstableFrameworks)' == 'True' And '$(UnstableVsixPath)' != '' ">$(UnstableVsixPath)</VsixPath>
+      <VsixPath Condition=" '$(UnstableFrameworks)' == 'True' And '$(UnstableVsixPath)' == '' ">..\..\bin\Build$(Configuration)\$(AssemblyName)-OSS-$(ProductVersion).$(XAVersionCommitCount)_$(_Branch)_$(XAVersionHash)-UnstableFrameworks.vsix</VsixPath>
       <VsixPath Condition=" '$(VsixPath)' == '' ">..\..\bin\Build$(Configuration)\$(AssemblyName)-OSS-$(ProductVersion).$(XAVersionCommitCount)_$(_Branch)_$(XAVersionHash).vsix</VsixPath>
       <_VsixDir>$([System.IO.Path]::GetDirectoryName ($(VsixPath)))</_VsixDir>
     </PropertyGroup>
   </Target>
   <Target Name="_CopyToBuildConfiguration"
-      DependsOnTargets="_GetVsixPath"
+      DependsOnTargets="_GetVsixPath;GetVsixId"
       Inputs="$(TargetVsixContainer)"
       Outputs="$(VsixPath)">
     <Copy
         SourceFiles="$(TargetVsixContainer)"
         DestinationFolder="$(_VsixDir)"
     />
+    <PropertyGroup>
+      <_VsixFile>$([System.IO.Path]::GetFileName ($(VsixPath)))</_VsixFile>
+      <_JsonDestFile>$([System.IO.Path]::ChangeExtension ($(_VsixFile), '.json'))</_JsonDestFile>
+      <_JsonSourceFile>$(VsixId).json</_JsonSourceFile>
+    </PropertyGroup>
     <Copy
-        SourceFiles="$(OutputPath)Xamarin.Android.Sdk.json"
-        DestinationFolder="$(_VsixDir)"
+        SourceFiles="$(OutputPath)$(_JsonSourceFile)"
+        DestinationFiles="$(_VsixDir)\$(_JsonDestFile)"
     />
   </Target>
   <!--

--- a/build-tools/create-vsix/source.extension.vsixmanifest
+++ b/build-tools/create-vsix/source.extension.vsixmanifest
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="Xamarin.Android.Sdk" Version="|create-vsix;GetVsixVersion|" Language="en-US" Publisher="Xamarin" />
-    <DisplayName>Xamarin.Android SDK</DisplayName>
-    <Description xml:space="preserve">Xamarin.Android SDK</Description>
+    <Identity Id="|create-vsix;GetVsixId|" Version="|create-vsix;GetVsixVersion|" Language="en-US" Publisher="Xamarin" />
+    <DisplayName>|create-vsix;GetVsixDisplayName|</DisplayName>
+    <Description xml:space="preserve">|create-vsix;GetVsixDescription|</Description>
     <Icon>Resources\AndroidSdkPackage.ico</Icon>
   </Metadata>
   <Installation AllUsers="true" Experimental="|create-vsix;GetIsExperimental|">

--- a/build-tools/scripts/Info.targets
+++ b/build-tools/scripts/Info.targets
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\Configuration.props" />
+  <Import Project="..\..\src\Mono.Android\Mono.Android.projitems" />
   <Target Name="GetProductVersion">
     <Message
         Text="$(ProductVersion)"
@@ -10,6 +11,28 @@
   <Target Name="GetAndroidLatestStableFrameworkVersion">
     <Message
         Text="$(AndroidLatestStableFrameworkVersion)"
+        Importance="High"
+    />
+  </Target>
+  <Target Name="GetAndroidLatestStableFrameworkVersion">
+    <Message
+        Text="$(AndroidLatestStableFrameworkVersion)"
+        Importance="High"
+    />
+  </Target>
+  <Target Name="HaveUnstableFrameworks">
+    <ItemGroup>
+      <_UnstableInstalled
+          Condition=" '%(Stable)' == 'False' And Exists ('$(XAInstallPrefix)\xbuild-frameworks\MonoAndroid\%(Identity)') "
+          Include="@(AndroidApiInfo)"
+      />
+    </ItemGroup>
+    <PropertyGroup>
+      <_HaveUnstable Condition=" '@(_UnstableInstalled)' != '' ">True</_HaveUnstable>
+      <_HaveUnstable Condition=" '$(_HaveUnstable)' == '' ">False</_HaveUnstable>
+    </PropertyGroup>
+    <Message
+        Text="$(_HaveUnstable)"
         Importance="High"
     />
   </Target>


### PR DESCRIPTION
**Background**

It's Android preview time!

Even better, we have support for building API-P bindings within around
a week of the Google announcement, via 8ce25376.

This raises a question: How does this binding get *used*?

Historically, we haven't been very good at this: various bits of code
needed to know *all* of the API levels (to associate with
`$(TargetFrameworkVersion)` values and Ids and names and...), which
meant that the only way the preview binding could be used was to have
a preview release of the *entire development stack*: Xamarin.Android,
IDE, build-tools, the works.

Invariably we didn't have a "preview" release of the new binding until
after it was API-stable (or close to it), and the IDEs have been
updated, all of which would be *months* after the announcement.

Commit 8942eca0 envisioned a New World Order™ in which the mapping
between API level and `$(TargetFrameworkVersion)`/etc. could be more
*dynamic*, based on `AndroidApiInfo.xml` files probed at process and
IDE startup, to *simplify* what it takes to use binding assemblies.

This support, mutated in various forms, is already in the IDEs (though
a preview IDE may be needed).

With foundational support, we can now try the next bit: update
`create-vsix.csproj` so that it can generate one of two packages:

 1. A `Xamarin.Android.Sdk-OSS-*.vsix` file which contains *only* the
    stable API level bindings.

 2. An optional `Xamarin.Android.Sdk-OSS-*-UnstableFrameworks.vsix`
    file which contains *only* the ***unstable*** API bindings.

The idea is that the first package can be the "normal" release
package, while the second package can be installed "side-by-side" with
the first pacakge.

Furthermore, the *intent* is that the `-UnstableFrameworks` package
could be installed side-by-side with *any* Xamarin.Android.Sdk
package. Ideally, this means that it could be installed alongside the
current *stable* Xamarin.Android SDK package, with no ill effects.

The target workflow is thus:

 1. Developer has Xamarin.Android SDK installed on their machine.

 2. Developer downloads and installs the `-UnstableFrameworks`
    package from:

        https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/lastSuccessfulBuild/Azure/

 3. Developer restarts their IDE.

 4. Developer edits the `.csproj` of their project, and sets the
    `$(TargetFrameworkVersion)` value to the value of the unstable API
    binding, e.g. `v8.1.99`.

    *Note*: It may instead be possible to change things from within
    the IDE. Some specifics are not yet sorted out.

 5. The next build of the project uses the preview/unstable API level.

With luck, this should allow us to provide "usable" (if broken!
they're not API stable!) for testing on an improved timeframe.

**Implementation**

Hack up `create-vsix.csproj` and company to support a new MSBuild
property: `$(UnstableFrameworks)` (default False). When True, the
output package name is changed to have a `-UnstableFrameworks` suffix,
the package ID is changed, the installation directory is changed...
*Lots* of things are changed, including the package contents.

The "normal" package is altered so that it *only* contains Stable
framework bindings. (This is a change from before, in which *all*
framework bindings were included.)

The "unstable" package contains only non-Stable framework bindings.

The `make create-vsix` Makefile target and `HaveUnstableFrameworks`
target within `build-tools/scripts/Info.targets` work together to only
build the `-UnstableFrameworks.vsix` package if there *are* unstable
frameworks to package. If there are no unstable packages, no
`-UnstableFrameworks` package is created.