### PR TITLE
[Xamarin.Android.Build.Tasks] Install FSharp.Core 4.3.1

### DIFF
--- a/src/Xamarin.Android.Build.Tasks.tpnitems
+++ b/src/Xamarin.Android.Build.Tasks.tpnitems
@@ -24,6 +24,10 @@
 
   <!-- External dependencies from `Xamarin.Android.Build.Tasks/packages.config` -->
   <ItemGroup Condition=" '$(TpnIncludeExternalDependencies)' == 'True' ">
+    <ThirdPartyNotice Include="fsharp/fsharp">
+      <LicenseFile>$(MSBuildThisFileDirectory)\..\build-tools\license-data\Apache-2.0.txt</LicenseFile>
+      <SourceUrl>https://github.com/fsharp/fsharp/</SourceUrl>
+    </ThirdPartyNotice>
     <ThirdPartyNotice Include="fsprojects/FSharp.Compiler.CodeDom">
       <LicenseText>
         This is free and unencumbered software released into the public domain.

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -48,6 +48,9 @@
     <Reference Include="FSharp.Compiler.CodeDom">
       <HintPath>..\..\packages\FSharp.Compiler.CodeDom.1.0.0.1\lib\net40\FSharp.Compiler.CodeDom.dll</HintPath>
     </Reference>
+    <Reference Include="FSharp.Core">
+      <HintPath>..\..\packages\FSharp.Core.3.1.2.5\lib\net40\FSharp.Core.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(IntermediateOutputPath)Profile.g.cs" />

--- a/src/Xamarin.Android.Build.Tasks/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FSharp.Compiler.CodeDom" version="1.0.0.1" targetFramework="net45" />
+  <package id="FSharp.Core" version="3.1.2.5" targetFramework="net451" />
   <package id="Irony" version="0.9.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Fixes: https://github.com/mono/mono/issues/7511
Fixes: https://github.com/xamarin/xamarin-android/issues/1438

Context: https://github.com/xamarin/xamarin-android/pull/1289

PR #1289 bumps xamarin-android to use the mono/2018-02 branch, and is
encountering an error when executing the
`Xamarin.Android.Build.Tests.AndroidUpdateResourcesTest.CheckResourceDesignerIsCreated()`
test, with the following error:

	/Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/Xamarin.Android.Common.targets: error : Error executing task GenerateResourceDesigner: Could not load file or assembly 'FSharp.Core, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies.
	Error executing task GenerateResourceDesigner: System.IO.FileNotFoundException: Could not load file or assembly 'FSharp.Core, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies.
	File name: 'FSharp.Core, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
	  at System.CodeDom.Compiler.CodeDomProvider.CreateGenerator (System.IO.TextWriter output) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-02/external/bockbuild/builds/mono-x64/external/corefx/src/System.CodeDom/src/System/CodeDom/Compiler/CodeDomProvider.cs:123
	  at Xamarin.Android.Tasks.GenerateResourceDesigner.WriteFile (System.String file, System.CodeDom.CodeTypeDeclaration resources, System.String language, System.Boolean isFSharp, System.Boolean isCSharp) [0x0012a] in /Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs:217
	  at Xamarin.Android.Tasks.GenerateResourceDesigner.Execute () [0x0065b] in /Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs:155
	  at Microsoft.Build.BuildEngine.TaskEngine.Execute () [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-02/external/bockbuild/builds/mono-x64/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/TaskEngine.cs:134
	  at Microsoft.Build.BuildEngine.BuildTask.Execute () [0x0008d] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-02/external/bockbuild/builds/mono-x64/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/BuildTask.cs:101

The mono/2018-02 branch bumps the `FSharp.Core.dll` assembly that is
distributed with mono to have an assembly version of 4.4.1.

The `FSharp.Compiler.CodeDom` NuGet package that
`Xamarin.Android.Build.Tasks.dll` references requires FSharp.Core
4.3.1, hence the `FileNotFoundException`.

The (hopeful) fix? Install the required `FSharp.Core.dll` version, so
that `FSharp.Compiler.CodeDom` can work as desired.