### PR TITLE
[create-vsix] Properly install $(AndroidFirstFrameworkVersion)

### DIFF
--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -88,7 +88,7 @@
       <ReferenceAssemblies
           Condition=" Exists ('$(LibDir)xbuild-frameworks\MonoAndroid\$(AndroidFirstFrameworkVersion)\%(_FirstFrameworkFile.Identity)') "
           Include="$(LibDir)xbuild-frameworks\MonoAndroid\$(AndroidFirstFrameworkVersion)\%(_FirstFrameworkFile.Identity)">
-        <VSIXSubPath>Microsoft/Framework/$(AndroidFirstFrameworkVersion)/</VSIXSubPath>
+        <VSIXSubPath>Microsoft/Framework/MonoAndroid/$(AndroidFirstFrameworkVersion)/</VSIXSubPath>
       </ReferenceAssemblies>
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/1454

Commit cdaa52b3 had a thinko: it updated `@(ReferenceAssemblies)` so
that e.g. `Mono.Android.Export.dll` and `OpenTK-1.0.dll` would only be
installed *once*, into `$(AndroidFirstFrameworkVersion)` -- instead of
having a copy in *each* framework version -- but
`%(ReferenceAssemblies.VSIXSubPath)` had the wrong value.

Consequently, the files were being installed into the wrong directory.

Fix `%(ReferenceAssemblies.VSIXSubPath)` so that instead of the
incorrect `Microsoft/Framework/$(AndroidFirstFrameworkVersion)/` it's
`Microsoft/Framework/MonoAndroid/$(AndroidFirstFrameworkVersion)/`.