### PR TITLE
[Xamarin.Android.Build.Tasks] Add Locking for processing aapt output.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -126,17 +126,19 @@ namespace Xamarin.Android.Tasks
 				CreateNoWindow = true,
 				WindowStyle = ProcessWindowStyle.Hidden,
 			};
-
+			object lockObject = new object ();
 			using (var proc = new Process ()) {
 				proc.OutputDataReceived += (sender, e) => {
 					if (e.Data != null)
-						output.Add (new OutputLine (e.Data, stdError: false));
+						lock (lockObject)
+							output.Add (new OutputLine (e.Data, stdError: false));
 					else
 						stdout_completed.Set ();
 				};
 				proc.ErrorDataReceived += (sender, e) => {
 					if (e.Data != null)
-						output.Add (new OutputLine (e.Data, stdError: true));
+						lock (lockObject)
+							output.Add (new OutputLine (e.Data, stdError: true));
 					else
 						stderr_completed.Set ();
 				};


### PR DESCRIPTION
We got a bug report where Aapt crashes with the following

	Unhandled Exception: System.ArgumentOutOfRangeException: capacity was less than the current size.
	Parameter name: value
	   at System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument argument, ExceptionResource resource)
	   at System.Collections.Generic.List`1.set_Capacity(Int32 value)
	   at System.Collections.Generic.List`1.EnsureCapacity(Int32 min)
	   at System.Collections.Generic.List`1.Add(T item)
	   at Xamarin.Android.Tasks.Aapt.<>c__DisplayClass134_0.<RunAapt>b__0(Object sender, DataReceivedEventArgs e)

This looks like a problem were the StdOut and StdError message handlers
are being called a the same time. As a result they try to add and
item at the same time causing this problem when the collection tries
to grow.

So lets put in some locks to ensure that only one message handler
can add an item at a time.
