### PR TITLE
[api-compatibility] Only check stable API levels

### DIFF
--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -23,13 +23,13 @@ ZIP_OUTPUT            = $(ZIP_OUTPUT_BASENAME).$(ZIP_EXTENSION)
 ## The following values *must* use SPACE, **not** TAB, to separate values.
 
 # $(ALL_API_LEVELS) and $(ALL_FRAMEWORKS) must be kept in sync w/ each other
-ALL_API_LEVELS    = 1 2 3 4 5 6 7 8 9 10    11  12  13  14  15      16    17    18    19    20        21    22    23    24    25    26  27  28
+ALL_API_LEVELS    = 1 2 3 4 5 6 7 8 9 10    11  12  13  14  15      16    17    18    19    20        21    22    23    24    25    26    27    28
 # this was different from ALL_API_LEVELS when API Level 26 was "O". Same could happen in the future.
-ALL_PLATFORM_IDS  = 1 2 3 4 5 6 7 8 9 10    11  12  13  14  15      16    17    18    19    20        21    22    23    24    25    26  27  P
+ALL_PLATFORM_IDS  = 1 2 3 4 5 6 7 8 9 10    11  12  13  14  15      16    17    18    19    20        21    22    23    24    25    26    27    P
 # supported api levels
 ALL_FRAMEWORKS    = _ _ _ _ _ _ _ _ _ v2.3  _   _   _   _   v4.0.3  v4.1  v4.2  v4.3  v4.4  v4.4.87   v5.0  v5.1  v6.0  v7.0  v7.1  v8.0  v8.1  v8.1.99
-API_LEVELS        =                   10                    15      16    17    18    19    20        21    22    23    24    25    26  27  28
-STABLE_API_LEVELS =                   10                    15      16    17    18    19    20        21    22    23    24    25    26
+API_LEVELS        =                   10                    15      16    17    18    19    20        21    22    23    24    25    26    27    28
+STABLE_API_LEVELS =                   10                    15      16    17    18    19    20        21    22    23    24    25    26    27
 
 ## The preceding values *must* use SPACE, **not** TAB, to separate values.
 

--- a/tests/api-compatibility/api-compatibility.mk
+++ b/tests/api-compatibility/api-compatibility.mk
@@ -15,6 +15,7 @@ FRAMEWORK_DIR     = bin/$(CONFIGURATION)/lib/xamarin.android/xbuild-frameworks/M
 run-api-compatibility-tests: $(MONO_API_HTML) $(MONO_API_INFO)
 	mkdir -p bin/Build$(CONFIGURATION)/compatibility
 	make -C external/xamarin-android-api-compatibility check \
+		STABLE_FRAMEWORKS="$(STABLE_FRAMEWORKS)" \
 		MONO_API_HTML="$(RUNTIME) $(abspath $(MONO_API_HTML))" \
 		MONO_API_INFO="$(RUNTIME) $(abspath $(MONO_API_INFO))" \
 		HTML_OUTPUT_DIR="$(abspath bin/Build$(CONFIGURATION)/compatibility)" \


### PR DESCRIPTION
[xamarin-android build #915][0] reports various api-compatibility
failures, such as:

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/915/consoleText

	<h1>### API BREAK BETWEEN v8.1 and v8.1.99</h1>
	<!-- start namespace Android.Telephony --> <div>
	<h2>Namespace Android.Telephony</h2>
	<!-- start type CellIdentityCdma --> <div>
	<h3>Type Changed: Android.Telephony.CellIdentityCdma</h3>
	Modified base type: <span class='removed removed-inline removed-breaking-inline'>Java.Lang.Object</span> <span class='added '>Android.Telephony.CellIdentity</span>

We want to ignore these for now, as these changes are against an
*unstable* API level, and we don't want to have to ensure
intra-API-stability for unstable API levels. (In part becuase we
haven't enumified unstable API levels, because they're in flux.)

Update `$(STABLE_API_LEVELS)` so that it includes API-27 -- which
should have been done in f41afb61 -- and update
`make run-api-compatibility-tests` so that it only checks
`$(STABLE_FRAMEWORKS)`, not *all* frameworks.