### PR TITLE
[Xamarin.Android.Build.Tasks] `fakeLogOpen` is ignorable

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -411,7 +411,11 @@ namespace Xamarin.Android.Tasks
 					line = int.Parse (match.Groups["line"].Value) + 1;
 				var level = match.Groups["level"].Value.ToLowerInvariant ();
 				var message = match.Groups ["message"].Value;
-				if (message.Contains ("fakeLogOpen") || level.Contains ("warning")) {
+				if (message.Contains ("fakeLogOpen")) {
+					LogMessage (singleLine, MessageImportance.Normal);
+					return;
+				}
+				if (level.Contains ("warning")) {
 					LogWarning (singleLine);
 					return;
 				}


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/585941

Commit 42a4b9be special-cased the `fakeLogOpen` messages to produce
warnings, instead of their earlier behavior of producing *errors*.

This was an improvement, in that builds were now able to finish, but
now developers are being "spammed" with lots of warnings about
`fakeLogOpen`, which cannot be easily ignored.

Further special-case the `fakeLogOpen` messages so that instead of
producing warnings, we instead produce "normal" messages.