### PR TITLE
[msbuild] Fix TargetFrameworkRootPath for non-Windows environment.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Xamarin.Android.Sdk.props
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Xamarin.Android.Sdk.props
@@ -22,8 +22,9 @@ Copyright (C) 2011-2016 Xamarin. All rights reserved.
 	<PropertyGroup>
 		<!-- Until VS2017+ includes its own ReferenceAssemblies outside of C:\Program Files (x86)\Reference Assemblies and into 
 			 the VsInstallRoot, we must override this ourselves for our SDKs -->
-		<TargetFrameworkRootPath Condition="'$(VsInstallRoot)' != '' And '$(TargetFrameworkRootPath)' == ''">$(VsInstallRoot)\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\</TargetFrameworkRootPath>
-		<TargetFrameworkRootPath Condition="'$(VsInstallRoot)' == '' And '$(TargetFrameworkRootPath)' == ''">$(ProgramFiles)\Reference Assemblies\Microsoft\Framework\</TargetFrameworkRootPath>
+		<TargetFrameworkRootPath Condition="'$(OS)' == 'Windows_NT' And '$(VsInstallRoot)' != '' And '$(TargetFrameworkRootPath)' == ''">$(VsInstallRoot)\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\</TargetFrameworkRootPath>
+		<TargetFrameworkRootPath Condition="'$(OS)' == 'Windows_NT' And '$(VsInstallRoot)' == '' And '$(TargetFrameworkRootPath)' == ''">$(ProgramFiles)\Reference Assemblies\Microsoft\Framework\</TargetFrameworkRootPath>
+		<TargetFrameworkRootPath Condition="'$(OS)' != 'Windows_NT' And '$(TargetFrameworkRootPath)' == ''">$(MSBuildThisFileDirectory)..\..\xbuild-frameworks\</TargetFrameworkRootPath>
 
 		<!-- We should always override the framework path so that XA resolves to its own mscorlib.dll -->
 		<FrameworkPathOverride>$(TargetFrameworkRootPath)MonoAndroid\v1.0</FrameworkPathOverride>


### PR DESCRIPTION
With this fix, `msbuild` will just work if xamarin-android is installed
to the same installation prefix directory as mono and msbuild, to the
right target framework path.

The fix is to NOT alter the TargetFrameworkRootPath location for
Windows-specific path.