### PR TITLE
[tests] fix failing NetStandardReferenceTest on Windows

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -374,7 +374,6 @@ namespace App1
 				"System.dll",
 				"System.Runtime.Serialization.dll",
 				"System.IO.Packaging.dll",
-				"System.IO.Compression.dll",
 				"Mono.Android.Export.dll",
 				"App1.dll",
 				"FormsViewGroup.dll",


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=1515010&tab=ms.vss-test-web.test-result-details

Since f7c942d, the NUnit tests have been failing on Windows. The
`NetStandardReferenceTest` is looking for `System.IO.Compression.dll`
inside the APK, but it is not there.

Looking into it, I don't see anything that explicitly needs
`System.IO.Compression.dll`, so perhaps we really don't need to assert
that this file exists.