### PR TITLE
[Xamarin.Android.Build.Tasks] Fix an issue where the 'ref' nuget is not found on windows.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1608,7 +1608,6 @@ because xbuild doesn't support framework reference assemblies.
 		I18nAssemblies="$(MandroidI18n)"
 		LinkMode="$(AndroidLinkMode)"
 		ProjectAssetFile="$(ProjectLockFile)"
-		NuGetPackageRoot="$(NuGetPackageRoot)"
 		TargetMoniker="$(NuGetTargetMoniker)"
 		ReferenceAssembliesDirectory="$(TargetFrameworkDirectory)">
       <Output TaskParameter="ResolvedAssemblies" ItemName="ResolvedAssemblies" />


### PR DESCRIPTION
The previous commit 029a8b49 fixed up some issues with resolving
the correct nuget. However on windows we get some weird pathing
issues because the project.assets.json file is using `/` as
path seperators. This is probably to be platform independent.

So in the project.assets.json we have a PackageName of

`System.IO.Packaging/4.4.0`

note the use of the `/`.

But our string comparision was using what ever path we had, on
windows that was `\`. 

`c:\pathtonuget\system.io.packaging\4.4.0\ref\netstandard1.3\System.IO.Packaging.dll`

So we never found the Library were we
looking for because `system.io.packaging/4.4.0` != `system.io.packaging\4.4.0`.
We just got lucky that it worked on Mac because the path separator is `/`.

We also need to normalize the resulting full path
to match the system path separator, otherwise we end up looking for files like

`c:\pathtonuget\system.io.packaging/4.4.0\lib\netstandard1.3/System.IO.Packaging.dll`

which do not work.