### PR TITLE
[Mono.Android-Tests] Use new internalx TLS test servers

### DIFF
--- a/src/Mono.Android/Test/System.Net/SslTest.cs
+++ b/src/Mono.Android/Test/System.Net/SslTest.cs
@@ -27,7 +27,7 @@ namespace System.NetTests {
 			Exception  exception  = null;
 
 			var thread = new Thread (() => {
-				string url = "https://tlstest-1.xamdev.com/";
+				string url = "https://tls-test-1.internalx.com";
 
 				var downloadTask = new WebClient ().DownloadDataTaskAsync (url);
 				var completeTask = downloadTask.ContinueWith (t => {

--- a/src/Mono.Android/Test/Xamarin.Android.Net/AndroidClientHandlerTests.cs
+++ b/src/Mono.Android/Test/Xamarin.Android.Net/AndroidClientHandlerTests.cs
@@ -142,7 +142,7 @@ namespace Xamarin.Android.NetTests {
   [TestFixture]
   public class AndroidClientHandlerTests : HttpClientHandlerTestBase
   {
-    const string Tls_1_2_Url = "https://tlstest.xamdev.com/";
+    const string Tls_1_2_Url = "https://tls-test.internalx.com";
 
     protected override HttpClientHandler CreateHandler ()
     {
@@ -259,8 +259,8 @@ namespace Xamarin.Android.NetTests {
 	  [Test]
 	  public void Redirect_Without_Protocol_Works()
 	  {
-		  var requestURI = new Uri ("http://tlstest.xamdev.com/redirect.php");
-		  var redirectedURI = new Uri ("http://tlstest.xamdev.com/redirect-301.html");
+		  var requestURI = new Uri ("http://tls-test.internalx.com/redirect.php");
+		  var redirectedURI = new Uri ("http://tls-test.internalx.com/redirect-301.html");
 		  using (var c = new HttpClient (CreateHandler ())) {
 			  var tr = c.GetAsync (requestURI);
 			  tr.Wait ();


### PR DESCRIPTION
A recent certificate expiration on the old 'xamdev' test servers caused a number of failures in existing tests. We have since stood up new test servers which can be used instead.

This is a version of #1476 for d15-7.