### PR TITLE
[Xamarin.Android.Build.Tasks] Add Logging if the task fails.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -240,13 +240,7 @@ namespace Xamarin.Android.Tasks
 				DoExecute ();
 			}, Token);
 
-			task.ContinueWith ( (t) => {
-				if (t.Exception != null) {
-					var ex = t.Exception.GetBaseException ();
-					LogError (ex.Message + Environment.NewLine + ex.StackTrace);
-				}
-				Complete ();
-			});
+			task.ContinueWith (Complete);
 
 			base.Execute ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -241,6 +241,10 @@ namespace Xamarin.Android.Tasks
 			}, Token);
 
 			task.ContinueWith ( (t) => {
+				if (t.Exception != null) {
+					var ex = t.Exception.GetBaseException ();
+					LogError (ex.Message + Environment.NewLine + ex.StackTrace);
+				}
 				Complete ();
 			});
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -242,6 +242,10 @@ namespace Xamarin.Android.Tasks
 			}, Token);
 
 			task.ContinueWith ( (t) => {
+				if (t.Exception != null) {
+					var ex = t.Exception.GetBaseException ();
+					LogError (ex.Message + Environment.NewLine + ex.StackTrace);
+				}
 				Complete ();
 			});
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -241,13 +241,7 @@ namespace Xamarin.Android.Tasks
 				return RunParallelAotCompiler (nativeLibs);
 			}, Token);
 
-			task.ContinueWith ( (t) => {
-				if (t.Exception != null) {
-					var ex = t.Exception.GetBaseException ();
-					LogError (ex.Message + Environment.NewLine + ex.StackTrace);
-				}
-				Complete ();
-			});
+			task.ContinueWith (Complete);
 
 			base.Execute ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AsyncTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AsyncTask.cs
@@ -54,6 +54,15 @@ namespace Xamarin.Android.Tasks
 			taskCancelled.Set ();
 		}
 
+		public void Complete (System.Threading.Tasks.Task task)
+		{
+			if (task.Exception != null) {
+				var ex = task.Exception.GetBaseException ();
+				LogError (ex.Message + Environment.NewLine + ex.StackTrace);
+			}
+			Complete ();
+		}
+
 		public void Complete()
 		{
 			completed.Set ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AsyncTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AsyncTask.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Android.Tasks
 			taskCancelled.Set ();
 		}
 
-		public void Complete (System.Threading.Tasks.Task task)
+		protected void Complete (System.Threading.Tasks.Task task)
 		{
 			if (task.Exception != null) {
 				var ex = task.Exception.GetBaseException ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
@@ -76,13 +76,7 @@ namespace Xamarin.Android.Tasks
 				return DoExecute ();
 			}, Token);
 
-			task.ContinueWith ( (t) => {
-				if (t.Exception != null) {
-					var ex = t.Exception.GetBaseException ();
-					LogError (ex.Message + Environment.NewLine + ex.StackTrace);
-				}
-				Complete ();
-			});
+			task.ContinueWith (Complete);
 
 			return !Log.HasLoggedErrors;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
@@ -77,6 +77,10 @@ namespace Xamarin.Android.Tasks
 			}, Token);
 
 			task.ContinueWith ( (t) => {
+				if (t.Exception != null) {
+					var ex = t.Exception.GetBaseException ();
+					LogError (ex.Message + Environment.NewLine + ex.StackTrace);
+				}
 				Complete ();
 			});
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
@@ -427,13 +427,7 @@ namespace Xamarin.Android.Tasks {
 						}
 					}
 				}
-			}, Token).ContinueWith ((t) => {
-				if (t.Exception != null) {
-					var ex = t.Exception.GetBaseException ();
-					LogError (ex.Message + Environment.NewLine + ex.StackTrace);
-				}
-				Complete ();
-			});
+			}, Token).ContinueWith (Complete);
 
 			var result = base.Execute ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -56,13 +56,7 @@ namespace Xamarin.Android.Tasks
 				using (var resolver = new DirectoryAssemblyResolver (this.CreateTaskLogger (), loadDebugSymbols: false)) {
 					return Execute (resolver);
 				}
-			}, Token).ContinueWith ((t) => {
-				if (t.Exception != null) {
-					var ex = t.Exception.GetBaseException ();
-					LogError (ex.Message + Environment.NewLine + ex.StackTrace);
-				}
-				Complete ();
-			});
+			}, Token).ContinueWith (Complete);
 			return base.Execute ();
 		}
 


### PR DESCRIPTION
Some of our task continuations were not logging any
exceptions if they failed. This commit adds code to
ensure that if the task fails we get the log information
and stacktrace.