### PR TITLE
[libzip-windows] Fix building with `msbuild`

### DIFF
--- a/build-tools/api-xml-adjuster/api-xml-adjuster.targets
+++ b/build-tools/api-xml-adjuster/api-xml-adjuster.targets
@@ -12,13 +12,18 @@
         AdditionalMetadata="ParameterDescription=$(_TopDir)\src\Mono.Android\Profiles\api-%(AndroidApiInfo.Level).params.txt;ClassParseXml=$(_OutputPath)api\api-%(AndroidApiInfo.Level).xml.class-parse;ApiAdjustedXml=$(_OutputPath)api\api-%(AndroidApiInfo.Level).xml.in">
       <Output TaskParameter="Include" ItemName="ApiFileDefinition"/>
     </CreateItem>
+    <ItemGroup>
+      <_ApiParameterDescription Include="%(ApiFileDefinition.ParameterDescription)" />
+      <_ApiClassParseXml        Include="%(ApiFileDefinition.ClassParseXml)" />
+      <_ApiAdjustedXml          Include="%(ApiFileDefinition.ApiAdjustedXml)" />
+    </ItemGroup>
   </Target>
 
   <Target Name="_ClassParse"
       BeforeTargets="_AdjustApiXml"
       DependsOnTargets="_DefineApiFiles"
-      Inputs="%(ApiFileDefinition.ParameterDescription)"
-      Outputs="%(ApiFileDefinition.ClassParseXml)">
+      Inputs="@(_ApiParameterDescription)"
+      Outputs="@(_ApiClassParseXml)">
     <PropertyGroup>
       <ClassParse>$(_TopDir)\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\class-parse.exe</ClassParse>
     </PropertyGroup>
@@ -31,8 +36,8 @@
   <Target Name="_AdjustApiXml"
       AfterTargets="Build"
       DependsOnTargets="_DefineApiFiles"
-      Inputs="%(ApiFileDefinition.ClassParseXml)"
-      Outputs="%(ApiFileDefinition.ApiAdjustedXml)">
+      Inputs="@(_ApiClassParseXml)"
+      Outputs="@(_ApiAdjustedXml)">
     <PropertyGroup>
       <ApiXmlAdjuster>$(_TopDir)\bin\Build$(Configuration)\api-xml-adjuster.exe</ApiXmlAdjuster>
     </PropertyGroup>

--- a/src/libzip/libzip.targets
+++ b/src/libzip/libzip.targets
@@ -37,9 +37,12 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <_LibZipTargetMakefile Include="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)\Makefile" />
+  </ItemGroup>
   <Target Name="_Make"
       Condition=" '@(_LibZipTarget)' != '' "
-      Inputs="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)\Makefile"
+      Inputs="@(_LibZipTargetMakefile)"
       Outputs="@(Content)">
     <Exec
         Command="make"

--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -786,14 +786,19 @@
     />
   </Target>
 
+  <ItemGroup>
+    <_MonoCrossRuntimeStamp               Include="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)\.stamp" />
+    <_MonoCrossRuntimeIntermediateOutput  Include="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)\mono\mini\mono-sgen%(_MonoCrossRuntime.ExeSuffix)" />
+    <_MonoCrossRuntimeOutput              Include="$(_MSBuildDir)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)" />
+  </ItemGroup>
 
   <!-- The condition below is to work around a bug in xbuild which attempts to batch
        even if there are no _MonoCrossRuntime items and the Copy task fails
   -->
   <Target Name="_BuildCrossRuntimes"
       DependsOnTargets="_GenerateCrossOffsetHeaderFiles"
-      Inputs="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)\.stamp"
-      Outputs="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)\mono\mini\mono-sgen%(_MonoCrossRuntime.ExeSuffix)"
+      Inputs="@(_MonoCrossRuntimeStamp)"
+      Outputs="@(_MonoCrossRuntimeIntermediateOutput)"
       Condition=" '@(_MonoCrossRuntime)' != '' ">
     <Message Text="Building %(_MonoCrossRuntime.Identity) in $(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)"/>
     <Exec
@@ -802,7 +807,7 @@
         WorkingDirectory="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)"
     />
     <Touch
-        Files="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)\mono\mini\mono-sgen%(_MonoCrossRuntime.ExeSuffix)"
+        Files="@(_MonoCrossRuntimeIntermediateOutput)"
     />
   </Target>
 
@@ -810,8 +815,8 @@
        even if there are no _MonoCrossRuntime items and the Copy task fails
   -->
   <Target Name="_InstallCrossRuntimes"
-      Inputs="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)\mono\mini\mono-sgen%(_MonoCrossRuntime.ExeSuffix)"
-      Outputs="$(_MSBuildDir)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
+      Inputs="@(_MonoCrossRuntimeIntermediateOutput)"
+      Outputs="@(_MonoCrossRuntimeOutput)"
       Condition=" '@(_MonoCrossRuntime)' != '' ">
     <Copy
         SourceFiles="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)\mono\mini\mono-sgen%(_MonoCrossRuntime.ExeSuffix)"
@@ -826,7 +831,7 @@
         Command="&quot;%(_MonoCrossRuntime.Strip)&quot; %(_MonoCrossRuntime.StripFlags) &quot;$(_MSBuildDir)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)&quot;"
     />
     <Touch
-        Files="$(_MSBuildDir)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)"
+        Files="@(_MonoCrossRuntimeOutput)"
     />
   </Target>
   <Target Name="GetMonoBundleItems"


### PR DESCRIPTION
Whenever `external/mono` is bumped, the
[`xamarin-android-msbuild` job breaks][0]:

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-msbuild/838/

	Building target "_Make" completely.
	...
	Task "Touch" (TaskId:1642)
	  Task Parameter:
	    Files=
	      …/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/x64/libzip.dll
	        CMake=/Users/builder/android-toolchain/mxe-b9cbb53/bin/x86_64-w64-mingw32.static-cmake
	        CMakeFlags=
	        CopyToOutputDirectory=Always
	        OutputLibrary=x64/libzip.dll
	        OutputLibraryPath=lib/libzip.dll
	      …/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/libzip.dll
	        CMake=/Users/builder/android-toolchain/mxe-b9cbb53/bin/i686-w64-mingw32.static-cmake
	        CMakeFlags=
	        CopyToOutputDirectory=Always
	        OutputLibrary=libzip.dll
	        OutputLibraryPath=lib/libzip.dll (TaskId:1642)
	  Touching "…/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/x64/libzip.dll". (TaskId:1642)
	…/build-tools/libzip/libzip.targets(52,5): error MSB3375: The file "…/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/libzip.dll" does not exist. […/build-tools/libzip-windows/libzip-windows.csproj]
	Done executing task "Touch" -- FAILED. (TaskId:1642)

This is due to an "`xbuild`-ism" we were inadvertently using which
`msbuild` doesn't like: when item metadata is used in
`//Target/@Inputs`, [MSBuild Target Batching][1] is *not* used.

[1]: https://msdn.microsoft.com/en-us/library/ms171473.aspx

Case in point, the `_Make` target:

	<!-- BAD! -->
	<Target Name="_Make"
	    Condition=" '@(_LibZipTarget)' != '' "
	    Inputs="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)\Makefile"
	    Outputs="@(Content)">

Because this used "inline" item metadata, the target wasn't being
batched as intended (and as `xbuild` does). Consequently,
`@(_LibZipTarget)` was only being built for mxe-Win64, *not*
mxe-Win32, which is why the `<Touch/>` use within the `_Make` target
failed.

The fix? Don't Do That™. Instead, use a new `@(_LibZipTargetMakefile)`
item group for the `//Target/@Inputs`, which allows `msbuild` to
properly batch the `_Make` target contents:

	<ItemGroup>
	  <_LibZipTargetMakefile Include="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)\Makefile" />
	</ItemGroup>
	<Target Name="_Make"
	    Condition=" '@(_LibZipTarget)' != '' "
	    Inputs="@(_LibZipTargetMakefile)"
	    Outputs="@(Content)">

Review other files matching `git grep 'Inputs=.*%'` and fix them too.