### PR TITLE
[plots] Get logcat output for timing in the tasks

### DIFF
--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -162,6 +162,7 @@
     <PropertyGroup>
       <_IncludeCategories Condition=" '$(IncludeCategories)' != '' ">include=$(IncludeCategories)</_IncludeCategories>
       <_ExcludeCategories Condition=" '$(ExcludeCategories)' != '' ">exclude=$(ExcludeCategories)</_ExcludeCategories>
+      <_LogcatFilenameBase>logcat-$(Configuration)$(TestsAotName)</_LogcatFilenameBase>
     </PropertyGroup>
     <RunInstrumentationTests
         Condition=" '%(TestApkInstrumentation.Identity)' != ''"
@@ -169,6 +170,7 @@
         AdbOptions="$(AdbOptions)"
         Component="%(TestApkInstrumentation.Package)/%(TestApkInstrumentation.Identity)"
         NUnit2TestResultsFile="%(TestApkInstrumentation.ResultsPath)"
+        LogcatFilename="$(_LogcatFilenameBase)-%(TestApkInstrumentation.Package).txt"
         InstrumentationArguments="$(_IncludeCategories);$(_ExcludeCategories)"
         TestFixture="$(TestFixture)"
         ToolExe="$(AdbToolExe)"
@@ -180,16 +182,13 @@
         AdbTarget="$(_AdbTarget)"
         AdbOptions="$(AdbOptions)"
         Activity="%(TestApk.Activity)"
+        LogcatFilename="$(_LogcatFilenameBase)-%(TestApk.Package).txt"
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)">
     </RunUITests>
-    <PropertyGroup>
-      <_LogcatFilename>logcat-$(Configuration)$(TestsAotName).txt</_LogcatFilename>
-    </PropertyGroup>
-    <Exec Command="&quot;$(AdbToolPath)\$(AdbToolExe)&quot; $(_AdbTarget) $(AdbOptions) logcat -v threadtime -d > $(_LogcatFilename)" />
     <ProcessLogcatTiming
-        Condition=" '%(TestApk.TimingDefinitionsFilename)' != '' "
-        InputFilename="$(_LogcatFilename)"
+        Condition=" '%(TestApk.TimingDefinitionsFilename)' != '' And Exists ('$(_LogcatFilenameBase)-%(TestApk.Package).txt')"
+        InputFilename="$(_LogcatFilenameBase)-%(TestApk.Package).txt"
         ApplicationPackageName="%(TestApk.Package)"
         ResultsFilename="%(TestApk.TimingResultsFilename)"
         DefinitionsFilename="%(TestApk.TimingDefinitionsFilename)"

--- a/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunUITests.cs
+++ b/src/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunUITests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Build.Framework;
+using System.IO;
 
 namespace Xamarin.Android.Tools.BootstrapTasks
 {
@@ -10,9 +11,16 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		[Required]
 		public                  string              Activity                    { get; set; }
 
+		[Required]
+		public                  string              LogcatFilename              { get; set; }
+
 		protected   override    bool                LogTaskMessages {
 			get { return false; }
 		}
+
+		bool getLogcat;
+		TextWriter logcatWriter;
+
 
 		public override bool Execute ()
 		{
@@ -20,18 +28,34 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			Log.LogMessage (MessageImportance.Low, $"  {nameof (AdbTarget)}: {AdbTarget}");
 			Log.LogMessage (MessageImportance.Low, $"  {nameof (AdbOptions)}: {AdbOptions}");
 			Log.LogMessage (MessageImportance.Low, $"  {nameof (Activity)}: {Activity}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (LogcatFilename)}: {LogcatFilename}");
 
 			base.Execute ();
 
 			Log.LogMessage(MessageImportance.Low, $"  going to wait for 15 seconds");
 			System.Threading.Thread.Sleep (15000);
 
+			using (logcatWriter = File.Exists (LogcatFilename) ? File.AppendText (LogcatFilename) : File.CreateText (LogcatFilename)) {
+				getLogcat = true;
+				base.Execute ();
+			}
+
 			return !Log.HasLoggedErrors;
 		}
 
 		protected override string GenerateCommandLineCommands ()
 		{
-			return $"{AdbTarget} {AdbOptions} shell am start -n \"{Activity}\"";
+			return getLogcat ? $"{AdbTarget} {AdbOptions} logcat -v threadtime -d" : $"{AdbTarget} {AdbOptions} shell am start -n \"{Activity}\"";
+		}
+
+		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
+		{
+			if (getLogcat) {
+				logcatWriter.WriteLine (singleLine);
+				return;
+			}
+
+			base.LogEventsFromTextOutput (singleLine, messageImportance);
 		}
 	}
 }


### PR DESCRIPTION
Lately the BCL tests started to produce a lot of logcat output, way
over the 4M limit of the buffer.

Thus we need to get the logcat output after every apk test run.

I have considered to batch the `RunTestApks` target. That would not
work very well though, as we are already batching the tasks in this
target with two related different item groups. So I moved the
collection of the logcat output to the `RunInstrumentationTests` and
`RunUITests` tasks.