### PR TITLE
[xabuild.exe] another fix for multi-process file access

### DIFF
--- a/tools/xabuild/SymbolicLink.cs
+++ b/tools/xabuild/SymbolicLink.cs
@@ -11,15 +11,7 @@ namespace Xamarin.Android.Build
 		{
 			if (!Directory.Exists (source)) {
 				if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
-					//NOTE: attempt with and without the AllowUnprivilegedCreate flag, seems to fix Windows Server 2016
-					if (!CreateSymbolicLink (source, target, SymbolLinkFlag.Directory | SymbolLinkFlag.AllowUnprivilegedCreate) &&
-						!CreateSymbolicLink (source, target, SymbolLinkFlag.Directory)) {
-						var error = new Win32Exception ().Message;
-						var result = Directory.Exists (source);
-						if (!result)
-							Console.Error.WriteLine ($"Unable to create symbolic link from `{source}` to `{target}`: {error}");
-						return result;
-					}
+					return CreateWindowsSymLink (source, target);
 				} else {
 					return CreateUnixSymLink (source, target);
 				}
@@ -28,10 +20,24 @@ namespace Xamarin.Android.Build
 			return true;
 		}
 
+		static bool CreateWindowsSymLink (string source, string target)
+		{
+			//NOTE: attempt with and without the AllowUnprivilegedCreate flag, seems to fix Windows Server 2016
+			if (!CreateSymbolicLink (source, target, SymbolLinkFlag.Directory | SymbolLinkFlag.AllowUnprivilegedCreate) &&
+				!CreateSymbolicLink (source, target, SymbolLinkFlag.Directory)) {
+				if (!Directory.Exists (source)) {
+					var error = new Win32Exception ().Message;
+					Console.Error.WriteLine ($"Unable to create symbolic link from `{source}` to `{target}`: {error}");
+					return false;
+				}
+			}
+			return true;
+		}
+
 		static bool CreateUnixSymLink (string source, string target)
 		{
 			int r = symlink (Path.GetFullPath (target), source);
-			if (r != 0) {
+			if (r != 0 && !Directory.Exists (source)) {
 				perror ($"`ln -s '{source}' '{target}'` failed");
 				return false;
 			}

--- a/tools/xabuild/SymbolicLink.cs
+++ b/tools/xabuild/SymbolicLink.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Android.Build
 		{
 			//NOTE: attempt with and without the AllowUnprivilegedCreate flag, seems to fix Windows Server 2016
 			if (!CreateSymbolicLink (source, target, SymbolLinkFlag.Directory | SymbolLinkFlag.AllowUnprivilegedCreate) &&
-				!CreateSymbolicLink (source, target, SymbolLinkFlag.Directory)) {
+					!CreateSymbolicLink (source, target, SymbolLinkFlag.Directory)) {
 				if (!Directory.Exists (source)) {
 					var error = new Win32Exception ().Message;
 					Console.Error.WriteLine ($"Unable to create symbolic link from `{source}` to `{target}`: {error}");


### PR DESCRIPTION
Context: d82c97c
Context: https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=1550431

For a while, my previous changes to `xabuild.exe` seemed to be working.

It still failed sometimes after reviewing past builds on VSTS:
- `RunXABuildInParallel` test failed randomly with non-zero exit code
when running `xabuild /version`
- Any test in `Xamarin.Android.Build.Tests`

The exception is something like:

    Unhandled Exception: System.IO.IOException: The process cannot access the file 'bin\Debug\lib\xamarin.android\xbuild-frameworks\.__sys_links.txt' because it is being used by another process.

I think one more change might finally fix this. Before this change,
`xabuild.exe` was opening the `.__sys_links.txt` every time. It should
first check and see if the symbolic links already exist before opening
the file.

I also added a `Console.WriteLine` to list every file link, and I soon
saw something odd from the logs on VSTS:
```
[xabuild] creating symbolic link 'E:\A\_work\2\s\bin\Debug\lib\xamarin.android\xbuild-frameworks\MonoAndroid'
    -> 'C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\MonoAndroid'
```

I remoted into the machine, and there was a symbolic link leftover from
`setup-windows.exe` (I believe) that was pointing from
`C:\Program Files (x86)\Reference Assemblies` to `xamarin-android` build
output somewhere!

Changes (summary):
- Check if any symbolic links are needed before opening
`.__sys_links.txt`
- Added a special case for a `MonoAndroid` directory on a VSTS build
agent (I will login and remove this directory on the agent later)
- Added a `Console.WriteLine` for when file links are created.
- Additionally, we should be using `File.AppendText` instead of
`File.CreateText` as we don't want to *ever* completely overwrite
`.__sys_links.txt`
- Refactored `SymbolicLink` so it more clearly calls `Directory.Exists`
one last time before deciding the symbolic link creation was a failure.
Also moved the Windows-specific code to its own method.