### PR TITLE
[Linux] Pass distro version to the prepare script and add libtool-bin…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,9 @@ linux-prepare::
 		cat Documentation/binfmt_misc-warning-Linux.txt ; \
 	fi; \
 	if [ -f build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO)-$(LINUX_DISTRO_RELEASE).sh ]; then \
-		sh build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO)-$(LINUX_DISTRO_RELEASE).sh; \
+		sh build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO)-$(LINUX_DISTRO_RELEASE).sh $(LINUX_DISTRO_RELEASE); \
 	elif [ -f build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO).sh ]; then \
-		sh build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO).sh; \
+		sh build-tools/scripts/dependencies/linux-prepare-$(LINUX_DISTRO).sh $(LINUX_DISTRO_RELEASE); \
 	fi
 
 # $(call GetPath,path)

--- a/build-tools/scripts/dependencies/linux-prepare-Ubuntu.sh
+++ b/build-tools/scripts/dependencies/linux-prepare-Ubuntu.sh
@@ -10,4 +10,11 @@ DISTRO_DEPS="$DISTRO_DEPS
 	"
 fi
 
+MAJOR=$(echo $1 | cut -d '.' -f 1)
+MINOR=$(echo $1 | cut -d '.' -f 2)
+
+if [ $MAJOR -eq 17 -a $MINOR -eq 10 ] || [ $MAJOR -ge 18 ]; then
+	DISTRO_DEPS="$DISTRO_DEPS libtool-bin"
+fi
+
 debian_install


### PR DESCRIPTION
… for Ubuntu

This is useful when a package is available from some version of the distro
onwards - it wouldn't make sense to create a separate script for each new
distro. Instead, we can quickly check whether the current distro has the package
within the same script.