### PR TITLE
Sanitize (eliminate) proguard build log outputs.

### DIFF
--- a/src/proguard/proguard.targets
+++ b/src/proguard/proguard.targets
@@ -2,7 +2,7 @@
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll"  TaskName="Xamarin.Android.Tools.BootstrapTasks.Ant" />
   <Target Name="_BuildProGuard">
     <Ant
-        Arguments="-verbose -f buildscripts\build.xml proguard"
+        Arguments="$(AntProguardBuildAdditionalArguments) -f buildscripts\build.xml proguard"
         ToolPath="$(AntToolPath)"
         JavaSdkDirectory="$(JavaSdkDirectory)"
         WorkingDirectory="$(ProGuardSourceFullPath)"


### PR DESCRIPTION
You are generating such extraneous build log lines:

				proguard:
				    [javac] proguard/ProGuard.java omitted as /sources/xamarin-android/external/proguard/classes/proguard/ProGuard.class is up to date.
				     [copy] No sources found.
				     [copy] No sources found.
				      [jar] proguard/ArgumentWordReader.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/ArgumentWordReader.class is up to date.
				      [jar] proguard/AssumeNoSideEffectsChecker.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/AssumeNoSideEffectsChecker.class is up to date.
				      [jar] proguard/ClassMemberChecker.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/ClassMemberChecker.class is up to date.
				      [jar] proguard/ClassPath.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/ClassPath.class is up to date.
				      [jar] proguard/ClassPathEntry.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/ClassPathEntry.class is up to date.
				      [jar] proguard/ClassSpecification.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/ClassSpecification.class is up to date.
				      [jar] proguard/ClassSpecificationVisitorFactory.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/ClassSpecificationVisitorFactory.class is up to date.
				      [jar] proguard/Configuration.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/Configuration.class is up to date.
				      [jar] proguard/ConfigurationChecker.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/ConfigurationChecker.class is up to date.
				      [jar] proguard/ConfigurationConstants.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/ConfigurationConstants.class is up to date.
				      [jar] proguard/ConfigurationParser.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/ConfigurationParser.class is up to date.
				      [jar] proguard/ConfigurationWriter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/ConfigurationWriter.class is up to date.
				      [jar] proguard/DataEntryReaderFactory.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/DataEntryReaderFactory.class is up to date.
				      [jar] proguard/DataEntryWriterFactory.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/DataEntryWriterFactory.class is up to date.
				      [jar] proguard/DescriptorKeepChecker.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/DescriptorKeepChecker.class is up to date.
				      [jar] proguard/DuplicateClassPrinter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/DuplicateClassPrinter.class is up to date.
				      [jar] proguard/FileWordReader.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/FileWordReader.class is up to date.
				      [jar] proguard/FullyQualifiedClassNameChecker.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/FullyQualifiedClassNameChecker.class is up to date.
				      [jar] proguard/GPL.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/GPL.class is up to date.
				      [jar] proguard/GetAnnotationChecker.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/GetAnnotationChecker.class is up to date.
				      [jar] proguard/GetEnclosingClassChecker.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/GetEnclosingClassChecker.class is up to date.
				      [jar] proguard/GetEnclosingMethodChecker.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/GetEnclosingMethodChecker.class is up to date.
				      [jar] proguard/GetSignatureChecker.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/GetSignatureChecker.class is up to date.
				      [jar] proguard/Initializer.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/Initializer.class is up to date.
				      [jar] proguard/InputReader.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/InputReader.class is up to date.
				      [jar] proguard/KeepClassMemberChecker.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/KeepClassMemberChecker.class is up to date.
				      [jar] proguard/KeepClassSpecification.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/KeepClassSpecification.class is up to date.
				      [jar] proguard/LibraryKeepChecker.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/LibraryKeepChecker.class is up to date.
				      [jar] proguard/LineWordReader.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/LineWordReader.class is up to date.
				      [jar] proguard/MemberSpecification.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/MemberSpecification.class is up to date.
				      [jar] proguard/OutputWriter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/OutputWriter.class is up to date.
				      [jar] proguard/ParseException.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/ParseException.class is up to date.
				      [jar] proguard/ProGuard.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/ProGuard.class is up to date.
				      [jar] proguard/SeedPrinter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/SeedPrinter.class is up to date.
				      [jar] proguard/Targeter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/Targeter.class is up to date.
				      [jar] proguard/UpToDateChecker$1.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/UpToDateChecker$1.class is up to date.
				      [jar] proguard/UpToDateChecker$ModificationTimeChecker.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/UpToDateChecker$ModificationTimeChecker.class is up to date.
				      [jar] proguard/UpToDateChecker.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/UpToDateChecker.class is up to date.
				      [jar] proguard/WordReader.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/WordReader.class is up to date.
				      [jar] proguard/classfile/ClassConstants.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/ClassConstants.class is up to date.
				      [jar] proguard/classfile/ClassPool.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/ClassPool.class is up to date.
				      [jar] proguard/classfile/Clazz.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/Clazz.class is up to date.
				      [jar] proguard/classfile/Field.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/Field.class is up to date.
				      [jar] proguard/classfile/JavaConstants.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/JavaConstants.class is up to date.
				      [jar] proguard/classfile/LibraryClass.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/LibraryClass.class is up to date.
				      [jar] proguard/classfile/LibraryField.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/LibraryField.class is up to date.
				      [jar] proguard/classfile/LibraryMember.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/LibraryMember.class is up to date.
				      [jar] proguard/classfile/LibraryMethod.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/LibraryMethod.class is up to date.
				      [jar] proguard/classfile/Member.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/Member.class is up to date.
				      [jar] proguard/classfile/Method.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/Method.class is up to date.
				      [jar] proguard/classfile/ProgramClass.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/ProgramClass.class is up to date.
				      [jar] proguard/classfile/ProgramField.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/ProgramField.class is up to date.
				      [jar] proguard/classfile/ProgramMember.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/ProgramMember.class is up to date.
				      [jar] proguard/classfile/ProgramMethod.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/ProgramMethod.class is up to date.
				      [jar] proguard/classfile/VisitorAccepter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/VisitorAccepter.class is up to date.
				      [jar] proguard/classfile/attribute/Attribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/Attribute.class is up to date.
				      [jar] proguard/classfile/attribute/BootstrapMethodInfo.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/BootstrapMethodInfo.class is up to date.
				      [jar] proguard/classfile/attribute/BootstrapMethodsAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/BootstrapMethodsAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/CodeAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/CodeAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/ConstantValueAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/ConstantValueAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/DeprecatedAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/DeprecatedAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/EnclosingMethodAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/EnclosingMethodAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/ExceptionInfo.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/ExceptionInfo.class is up to date.
				      [jar] proguard/classfile/attribute/ExceptionsAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/ExceptionsAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/ExtendedLineNumberInfo.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/ExtendedLineNumberInfo.class is up to date.
				      [jar] proguard/classfile/attribute/InnerClassesAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/InnerClassesAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/InnerClassesInfo.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/InnerClassesInfo.class is up to date.
				      [jar] proguard/classfile/attribute/LineNumberInfo.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/LineNumberInfo.class is up to date.
				      [jar] proguard/classfile/attribute/LineNumberTableAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/LineNumberTableAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/LocalVariableInfo.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/LocalVariableInfo.class is up to date.
				      [jar] proguard/classfile/attribute/LocalVariableTableAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/LocalVariableTableAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/LocalVariableTypeInfo.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/LocalVariableTypeInfo.class is up to date.
				      [jar] proguard/classfile/attribute/LocalVariableTypeTableAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/LocalVariableTypeTableAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/MethodParametersAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/MethodParametersAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/ParameterInfo.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/ParameterInfo.class is up to date.
				      [jar] proguard/classfile/attribute/SignatureAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/SignatureAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/SourceDirAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/SourceDirAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/SourceFileAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/SourceFileAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/SyntheticAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/SyntheticAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/UnknownAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/UnknownAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/Annotation.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/Annotation.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/AnnotationDefaultAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/AnnotationDefaultAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/AnnotationElementValue.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/AnnotationElementValue.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/AnnotationsAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/AnnotationsAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/ArrayElementValue.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/ArrayElementValue.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/ClassElementValue.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/ClassElementValue.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/ConstantElementValue.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/ConstantElementValue.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/ElementValue.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/ElementValue.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/EnumConstantElementValue.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/EnumConstantElementValue.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/ParameterAnnotationsAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/ParameterAnnotationsAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/RuntimeInvisibleAnnotationsAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/RuntimeInvisibleAnnotationsAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/RuntimeInvisibleParameterAnnotationsAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/RuntimeInvisibleParameterAnnotationsAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/RuntimeInvisibleTypeAnnotationsAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/RuntimeInvisibleTypeAnnotationsAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/RuntimeVisibleAnnotationsAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/RuntimeVisibleAnnotationsAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/RuntimeVisibleParameterAnnotationsAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/RuntimeVisibleParameterAnnotationsAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/RuntimeVisibleTypeAnnotationsAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/RuntimeVisibleTypeAnnotationsAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/TypeAnnotation.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/TypeAnnotation.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/TypeAnnotationsAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/TypeAnnotationsAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/TypePathInfo.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/TypePathInfo.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/target/CatchTargetInfo.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/target/CatchTargetInfo.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/target/EmptyTargetInfo.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/target/EmptyTargetInfo.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/target/FormalParameterTargetInfo.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/target/FormalParameterTargetInfo.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/target/LocalVariableTargetElement.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/target/LocalVariableTargetElement.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/target/LocalVariableTargetInfo.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/target/LocalVariableTargetInfo.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/target/OffsetTargetInfo.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/target/OffsetTargetInfo.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/target/SuperTypeTargetInfo.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/target/SuperTypeTargetInfo.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/target/TargetInfo.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/target/TargetInfo.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/target/ThrowsTargetInfo.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/target/ThrowsTargetInfo.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/target/TypeArgumentTargetInfo.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/target/TypeArgumentTargetInfo.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/target/TypeParameterBoundTargetInfo.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/target/TypeParameterBoundTargetInfo.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/target/TypeParameterTargetInfo.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/target/TypeParameterTargetInfo.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/target/visitor/LocalVariableTargetElementVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/target/visitor/LocalVariableTargetElementVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/target/visitor/TargetInfoVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/target/visitor/TargetInfoVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/visitor/AllAnnotationVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/visitor/AllAnnotationVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/visitor/AllElementValueVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/visitor/AllElementValueVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/visitor/AnnotatedClassVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/visitor/AnnotatedClassVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/visitor/AnnotationToMemberVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/visitor/AnnotationToMemberVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/visitor/AnnotationTypeFilter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/visitor/AnnotationTypeFilter.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/visitor/AnnotationVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/visitor/AnnotationVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/visitor/ElementValueVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/visitor/ElementValueVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/visitor/TypeAnnotationVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/visitor/TypeAnnotationVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/annotation/visitor/TypePathInfoVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/annotation/visitor/TypePathInfoVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/DoubleType.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/DoubleType.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/FloatType.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/FloatType.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/FullFrame.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/FullFrame.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/IntegerType.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/IntegerType.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/LessZeroFrame.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/LessZeroFrame.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/LongType.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/LongType.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/MoreZeroFrame.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/MoreZeroFrame.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/NullType.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/NullType.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/ObjectType.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/ObjectType.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/SameOneFrame.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/SameOneFrame.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/SameZeroFrame.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/SameZeroFrame.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/StackMapAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/StackMapAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/StackMapFrame.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/StackMapFrame.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/StackMapTableAttribute.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/StackMapTableAttribute.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/TopType.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/TopType.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/UninitializedThisType.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/UninitializedThisType.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/UninitializedType.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/UninitializedType.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/VerificationType.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/VerificationType.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/VerificationTypeFactory.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/VerificationTypeFactory.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/visitor/StackMapFrameVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/visitor/StackMapFrameVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/preverification/visitor/VerificationTypeVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/preverification/visitor/VerificationTypeVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/visitor/AllAttributeVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/visitor/AllAttributeVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/visitor/AllBootstrapMethodInfoVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/visitor/AllBootstrapMethodInfoVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/visitor/AllExceptionInfoVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/visitor/AllExceptionInfoVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/visitor/AllInnerClassesInfoVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/visitor/AllInnerClassesInfoVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/visitor/AllLineNumberInfoVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/visitor/AllLineNumberInfoVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/visitor/AttributeNameFilter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/visitor/AttributeNameFilter.class is up to date.
				      [jar] proguard/classfile/attribute/visitor/AttributeVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/visitor/AttributeVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/visitor/BootstrapMethodInfoVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/visitor/BootstrapMethodInfoVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/visitor/ExceptionInfoVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/visitor/ExceptionInfoVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/visitor/InnerClassesInfoVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/visitor/InnerClassesInfoVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/visitor/LineNumberInfoVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/visitor/LineNumberInfoVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/visitor/LineNumberRangeFinder.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/visitor/LineNumberRangeFinder.class is up to date.
				      [jar] proguard/classfile/attribute/visitor/LocalVariableInfoVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/visitor/LocalVariableInfoVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/visitor/LocalVariableTypeInfoVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/visitor/LocalVariableTypeInfoVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/visitor/MultiAttributeVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/visitor/MultiAttributeVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/visitor/NonEmptyAttributeFilter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/visitor/NonEmptyAttributeFilter.class is up to date.
				      [jar] proguard/classfile/attribute/visitor/ParameterInfoVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/visitor/ParameterInfoVisitor.class is up to date.
				      [jar] proguard/classfile/attribute/visitor/RequiredAttributeFilter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/visitor/RequiredAttributeFilter.class is up to date.
				      [jar] proguard/classfile/attribute/visitor/StackSizeComputer.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/attribute/visitor/StackSizeComputer.class is up to date.
				      [jar] proguard/classfile/constant/ClassConstant.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/ClassConstant.class is up to date.
				      [jar] proguard/classfile/constant/Constant.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/Constant.class is up to date.
				      [jar] proguard/classfile/constant/DoubleConstant.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/DoubleConstant.class is up to date.
				      [jar] proguard/classfile/constant/FieldrefConstant.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/FieldrefConstant.class is up to date.
				      [jar] proguard/classfile/constant/FloatConstant.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/FloatConstant.class is up to date.
				      [jar] proguard/classfile/constant/IntegerConstant.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/IntegerConstant.class is up to date.
				      [jar] proguard/classfile/constant/InterfaceMethodrefConstant.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/InterfaceMethodrefConstant.class is up to date.
				      [jar] proguard/classfile/constant/InvokeDynamicConstant.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/InvokeDynamicConstant.class is up to date.
				      [jar] proguard/classfile/constant/LongConstant.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/LongConstant.class is up to date.
				      [jar] proguard/classfile/constant/MethodHandleConstant.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/MethodHandleConstant.class is up to date.
				      [jar] proguard/classfile/constant/MethodTypeConstant.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/MethodTypeConstant.class is up to date.
				      [jar] proguard/classfile/constant/MethodrefConstant.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/MethodrefConstant.class is up to date.
				      [jar] proguard/classfile/constant/NameAndTypeConstant.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/NameAndTypeConstant.class is up to date.
				      [jar] proguard/classfile/constant/RefConstant.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/RefConstant.class is up to date.
				      [jar] proguard/classfile/constant/StringConstant.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/StringConstant.class is up to date.
				      [jar] proguard/classfile/constant/Utf8Constant.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/Utf8Constant.class is up to date.
				      [jar] proguard/classfile/constant/visitor/AllConstantVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/visitor/AllConstantVisitor.class is up to date.
				      [jar] proguard/classfile/constant/visitor/BootstrapMethodArgumentVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/visitor/BootstrapMethodArgumentVisitor.class is up to date.
				      [jar] proguard/classfile/constant/visitor/BootstrapMethodHandleTraveler.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/visitor/BootstrapMethodHandleTraveler.class is up to date.
				      [jar] proguard/classfile/constant/visitor/ConstantTagFilter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/visitor/ConstantTagFilter.class is up to date.
				      [jar] proguard/classfile/constant/visitor/ConstantVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/visitor/ConstantVisitor.class is up to date.
				      [jar] proguard/classfile/constant/visitor/ExceptClassConstantFilter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/visitor/ExceptClassConstantFilter.class is up to date.
				      [jar] proguard/classfile/constant/visitor/MethodrefTraveler.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/constant/visitor/MethodrefTraveler.class is up to date.
				      [jar] proguard/classfile/editor/AccessFixer$1.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/AccessFixer$1.class is up to date.
				      [jar] proguard/classfile/editor/AccessFixer$MyAccessFixer.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/AccessFixer$MyAccessFixer.class is up to date.
				      [jar] proguard/classfile/editor/AccessFixer$MyReferencedClassStorer.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/AccessFixer$MyReferencedClassStorer.class is up to date.
				      [jar] proguard/classfile/editor/AccessFixer.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/AccessFixer.class is up to date.
				      [jar] proguard/classfile/editor/AnnotationAdder.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/AnnotationAdder.class is up to date.
				      [jar] proguard/classfile/editor/AnnotationsAttributeEditor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/AnnotationsAttributeEditor.class is up to date.
				      [jar] proguard/classfile/editor/AttributeAdder.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/AttributeAdder.class is up to date.
				      [jar] proguard/classfile/editor/AttributeSorter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/AttributeSorter.class is up to date.
				      [jar] proguard/classfile/editor/AttributesEditor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/AttributesEditor.class is up to date.
				      [jar] proguard/classfile/editor/BootstrapMethodInfoAdder.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/BootstrapMethodInfoAdder.class is up to date.
				      [jar] proguard/classfile/editor/BootstrapMethodRemapper.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/BootstrapMethodRemapper.class is up to date.
				      [jar] proguard/classfile/editor/BootstrapMethodsAttributeAdder.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/BootstrapMethodsAttributeAdder.class is up to date.
				      [jar] proguard/classfile/editor/BootstrapMethodsAttributeEditor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/BootstrapMethodsAttributeEditor.class is up to date.
				      [jar] proguard/classfile/editor/BridgeMethodFixer.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/BridgeMethodFixer.class is up to date.
				      [jar] proguard/classfile/editor/ClassEditor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/ClassEditor.class is up to date.
				      [jar] proguard/classfile/editor/ClassElementSorter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/ClassElementSorter.class is up to date.
				      [jar] proguard/classfile/editor/ClassReferenceFixer.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/ClassReferenceFixer.class is up to date.
				      [jar] proguard/classfile/editor/CodeAttributeComposer.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/CodeAttributeComposer.class is up to date.
				      [jar] proguard/classfile/editor/CodeAttributeEditor$1.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/CodeAttributeEditor$1.class is up to date.
				      [jar] proguard/classfile/editor/CodeAttributeEditor$CompositeInstruction.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/CodeAttributeEditor$CompositeInstruction.class is up to date.
				      [jar] proguard/classfile/editor/CodeAttributeEditor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/CodeAttributeEditor.class is up to date.
				      [jar] proguard/classfile/editor/ComparableConstant.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/ComparableConstant.class is up to date.
				      [jar] proguard/classfile/editor/ConstantAdder.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/ConstantAdder.class is up to date.
				      [jar] proguard/classfile/editor/ConstantPoolEditor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/ConstantPoolEditor.class is up to date.
				      [jar] proguard/classfile/editor/ConstantPoolRemapper.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/ConstantPoolRemapper.class is up to date.
				      [jar] proguard/classfile/editor/ConstantPoolShrinker.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/ConstantPoolShrinker.class is up to date.
				      [jar] proguard/classfile/editor/ConstantPoolSorter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/ConstantPoolSorter.class is up to date.
				      [jar] proguard/classfile/editor/ElementValueAdder.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/ElementValueAdder.class is up to date.
				      [jar] proguard/classfile/editor/ElementValuesEditor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/ElementValuesEditor.class is up to date.
				      [jar] proguard/classfile/editor/ExceptionAdder.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/ExceptionAdder.class is up to date.
				      [jar] proguard/classfile/editor/ExceptionInfoAdder.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/ExceptionInfoAdder.class is up to date.
				      [jar] proguard/classfile/editor/ExceptionsAttributeEditor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/ExceptionsAttributeEditor.class is up to date.
				      [jar] proguard/classfile/editor/InnerClassesAccessFixer.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/InnerClassesAccessFixer.class is up to date.
				      [jar] proguard/classfile/editor/InstructionAdder.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/InstructionAdder.class is up to date.
				      [jar] proguard/classfile/editor/InstructionWriter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/InstructionWriter.class is up to date.
				      [jar] proguard/classfile/editor/InterfaceAdder.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/InterfaceAdder.class is up to date.
				      [jar] proguard/classfile/editor/InterfaceDeleter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/InterfaceDeleter.class is up to date.
				      [jar] proguard/classfile/editor/InterfaceSorter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/InterfaceSorter.class is up to date.
				      [jar] proguard/classfile/editor/InterfacesEditor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/InterfacesEditor.class is up to date.
				      [jar] proguard/classfile/editor/LineNumberInfoAdder.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/LineNumberInfoAdder.class is up to date.
				      [jar] proguard/classfile/editor/LineNumberTableAttributeEditor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/LineNumberTableAttributeEditor.class is up to date.
				      [jar] proguard/classfile/editor/LineNumberTableAttributeTrimmer.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/LineNumberTableAttributeTrimmer.class is up to date.
				      [jar] proguard/classfile/editor/LocalVariableInfoAdder.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/LocalVariableInfoAdder.class is up to date.
				      [jar] proguard/classfile/editor/LocalVariableTableAttributeEditor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/LocalVariableTableAttributeEditor.class is up to date.
				      [jar] proguard/classfile/editor/LocalVariableTypeInfoAdder.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/LocalVariableTypeInfoAdder.class is up to date.
				      [jar] proguard/classfile/editor/LocalVariableTypeTableAttributeEditor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/LocalVariableTypeTableAttributeEditor.class is up to date.
				      [jar] proguard/classfile/editor/MemberAdder.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/MemberAdder.class is up to date.
				      [jar] proguard/classfile/editor/MemberReferenceFixer.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/MemberReferenceFixer.class is up to date.
				      [jar] proguard/classfile/editor/MethodInvocationFixer.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/MethodInvocationFixer.class is up to date.
				      [jar] proguard/classfile/editor/NamedAttributeDeleter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/NamedAttributeDeleter.class is up to date.
				      [jar] proguard/classfile/editor/ParameterAnnotationsAttributeEditor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/ParameterAnnotationsAttributeEditor.class is up to date.
				      [jar] proguard/classfile/editor/ParameterInfoAdder.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/ParameterInfoAdder.class is up to date.
				      [jar] proguard/classfile/editor/StackSizeUpdater.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/StackSizeUpdater.class is up to date.
				      [jar] proguard/classfile/editor/SubclassAdder.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/SubclassAdder.class is up to date.
				      [jar] proguard/classfile/editor/VariableCleaner.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/VariableCleaner.class is up to date.
				      [jar] proguard/classfile/editor/VariableEditor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/VariableEditor.class is up to date.
				      [jar] proguard/classfile/editor/VariableRemapper.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/VariableRemapper.class is up to date.
				      [jar] proguard/classfile/editor/VariableSizeUpdater.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/editor/VariableSizeUpdater.class is up to date.
				      [jar] proguard/classfile/instruction/BranchInstruction.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/instruction/BranchInstruction.class is up to date.
				      [jar] proguard/classfile/instruction/ConstantInstruction.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/instruction/ConstantInstruction.class is up to date.
				      [jar] proguard/classfile/instruction/Instruction.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/instruction/Instruction.class is up to date.
				      [jar] proguard/classfile/instruction/InstructionConstants.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/instruction/InstructionConstants.class is up to date.
				      [jar] proguard/classfile/instruction/InstructionFactory.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/instruction/InstructionFactory.class is up to date.
				      [jar] proguard/classfile/instruction/InstructionUtil.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/instruction/InstructionUtil.class is up to date.
				      [jar] proguard/classfile/instruction/LookUpSwitchInstruction.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/instruction/LookUpSwitchInstruction.class is up to date.
				      [jar] proguard/classfile/instruction/SimpleInstruction.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/instruction/SimpleInstruction.class is up to date.
				      [jar] proguard/classfile/instruction/SwitchInstruction.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/instruction/SwitchInstruction.class is up to date.
				      [jar] proguard/classfile/instruction/TableSwitchInstruction.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/instruction/TableSwitchInstruction.class is up to date.
				      [jar] proguard/classfile/instruction/VariableInstruction.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/instruction/VariableInstruction.class is up to date.
				      [jar] proguard/classfile/instruction/visitor/AllInstructionVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/instruction/visitor/AllInstructionVisitor.class is up to date.
				      [jar] proguard/classfile/instruction/visitor/InstructionCounter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/instruction/visitor/InstructionCounter.class is up to date.
				      [jar] proguard/classfile/instruction/visitor/InstructionVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/instruction/visitor/InstructionVisitor.class is up to date.
				      [jar] proguard/classfile/instruction/visitor/MultiInstructionVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/instruction/visitor/MultiInstructionVisitor.class is up to date.
				      [jar] proguard/classfile/io/LibraryClassReader.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/io/LibraryClassReader.class is up to date.
				      [jar] proguard/classfile/io/ProgramClassReader.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/io/ProgramClassReader.class is up to date.
				      [jar] proguard/classfile/io/ProgramClassWriter$1.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/io/ProgramClassWriter$1.class is up to date.
				      [jar] proguard/classfile/io/ProgramClassWriter$AttributeBodyWriter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/io/ProgramClassWriter$AttributeBodyWriter.class is up to date.
				      [jar] proguard/classfile/io/ProgramClassWriter$ConstantBodyWriter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/io/ProgramClassWriter$ConstantBodyWriter.class is up to date.
				      [jar] proguard/classfile/io/ProgramClassWriter$ElementValueBodyWriter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/io/ProgramClassWriter$ElementValueBodyWriter.class is up to date.
				      [jar] proguard/classfile/io/ProgramClassWriter$StackMapFrameBodyWriter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/io/ProgramClassWriter$StackMapFrameBodyWriter.class is up to date.
				      [jar] proguard/classfile/io/ProgramClassWriter$VerificationTypeBodyWriter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/io/ProgramClassWriter$VerificationTypeBodyWriter.class is up to date.
				      [jar] proguard/classfile/io/ProgramClassWriter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/io/ProgramClassWriter.class is up to date.
				      [jar] proguard/classfile/io/RuntimeDataInput.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/io/RuntimeDataInput.class is up to date.
				      [jar] proguard/classfile/io/RuntimeDataOutput.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/io/RuntimeDataOutput.class is up to date.
				      [jar] proguard/classfile/util/AccessUtil.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/AccessUtil.class is up to date.
				      [jar] proguard/classfile/util/AllParameterVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/AllParameterVisitor.class is up to date.
				      [jar] proguard/classfile/util/ClassReferenceInitializer.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/ClassReferenceInitializer.class is up to date.
				      [jar] proguard/classfile/util/ClassSubHierarchyInitializer.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/ClassSubHierarchyInitializer.class is up to date.
				      [jar] proguard/classfile/util/ClassSuperHierarchyInitializer.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/ClassSuperHierarchyInitializer.class is up to date.
				      [jar] proguard/classfile/util/ClassUtil.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/ClassUtil.class is up to date.
				      [jar] proguard/classfile/util/DescriptorClassEnumeration.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/DescriptorClassEnumeration.class is up to date.
				      [jar] proguard/classfile/util/DynamicClassReferenceInitializer.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/DynamicClassReferenceInitializer.class is up to date.
				      [jar] proguard/classfile/util/DynamicMemberReferenceInitializer.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/DynamicMemberReferenceInitializer.class is up to date.
				      [jar] proguard/classfile/util/EnumFieldReferenceInitializer.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/EnumFieldReferenceInitializer.class is up to date.
				      [jar] proguard/classfile/util/ExternalTypeEnumeration.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/ExternalTypeEnumeration.class is up to date.
				      [jar] proguard/classfile/util/InstructionSequenceMatcher.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/InstructionSequenceMatcher.class is up to date.
				      [jar] proguard/classfile/util/InternalTypeEnumeration.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/InternalTypeEnumeration.class is up to date.
				      [jar] proguard/classfile/util/MemberFinder$1.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/MemberFinder$1.class is up to date.
				      [jar] proguard/classfile/util/MemberFinder$MemberFoundException.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/MemberFinder$MemberFoundException.class is up to date.
				      [jar] proguard/classfile/util/MemberFinder.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/MemberFinder.class is up to date.
				      [jar] proguard/classfile/util/MethodLinker.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/MethodLinker.class is up to date.
				      [jar] proguard/classfile/util/SimplifiedVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/SimplifiedVisitor.class is up to date.
				      [jar] proguard/classfile/util/StringReferenceInitializer.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/StringReferenceInitializer.class is up to date.
				      [jar] proguard/classfile/util/StringSharer.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/StringSharer.class is up to date.
				      [jar] proguard/classfile/util/WarningPrinter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/util/WarningPrinter.class is up to date.
				      [jar] proguard/classfile/visitor/AllClassVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/visitor/AllClassVisitor.class is up to date.
				      [jar] proguard/classfile/visitor/AllFieldVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/visitor/AllFieldVisitor.class is up to date.
				      [jar] proguard/classfile/visitor/AllMemberVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/visitor/AllMemberVisitor.class is up to date.
				      [jar] proguard/classfile/visitor/AllMethodVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/visitor/AllMethodVisitor.class is up to date.
				      [jar] proguard/classfile/visitor/BottomClassFilter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/visitor/BottomClassFilter.class is up to date.
				      [jar] proguard/classfile/visitor/ClassAccessFilter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/visitor/ClassAccessFilter.class is up to date.
				      [jar] proguard/classfile/visitor/ClassCleaner.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/visitor/ClassCleaner.class is up to date.
				      [jar] proguard/classfile/visitor/ClassCollector.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/visitor/ClassCollector.class is up to date.
				      [jar] proguard/classfile/visitor/ClassCounter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/visitor/ClassCounter.class is up to date.
				      [jar] proguard/classfile/visitor/ClassHierarchyTraveler.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/visitor/ClassHierarchyTraveler.class is up to date.
				      [jar] proguard/classfile/visitor/ClassNameFilter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/visitor/ClassNameFilter.class is up to date.
				      [jar] proguard/classfile/visitor/ClassPoolFiller.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/visitor/ClassPoolFiller.class is up to date.
				      [jar] proguard/classfile/visitor/ClassPoolVisitor.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/visitor/ClassPoolVisitor.class is up to date.
				      [jar] proguard/classfile/visitor/ClassPresenceFilter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/visitor/ClassPresenceFilter.class is up to date.
				      [jar] proguard/classfile/visitor/ClassPrinter.class omitted as /sources/xamarin-android/external/proguard/lib/proguard.jar:proguard/classfile/visitor/ClassPrinter.class is up to date.
<snip>

They are 99.99% extraneous and should be eliminated from usual build outputs.
    
If you EVER had problem building proguard and having problem DUE TO lack
of such verbose build outputs, then you can create your own branch,
enable logging, and then create a PR on github. It will give you detailed
build outputs. If you need it do it only within your build.