### PR TITLE
build fix: do not generate API XML definitions every time.

### DIFF
--- a/build-tools/api-xml-adjuster/api-xml-adjuster.targets
+++ b/build-tools/api-xml-adjuster/api-xml-adjuster.targets
@@ -1,4 +1,5 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask TaskName="Xamarin.Android.BuildTools.PrepTasks.GetMappedFilesThatExist"  AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" />
 
   <Import Project="..\..\src\Mono.Android\Mono.Android.projitems" />
 
@@ -9,14 +10,25 @@
 
   <Target Name="_DefineApiFiles">
     <CreateItem Include="@(AndroidApiInfo)"
+		Condition="Exists('$(_TopDir)\src\Mono.Android\Profiles\api-%(AndroidApiInfo.Level).params.txt')"
         AdditionalMetadata="ParameterDescription=$(_TopDir)\src\Mono.Android\Profiles\api-%(AndroidApiInfo.Level).params.txt;ClassParseXml=$(_OutputPath)api\api-%(AndroidApiInfo.Level).xml.class-parse;ApiAdjustedXml=$(_OutputPath)api\api-%(AndroidApiInfo.Level).xml.in">
       <Output TaskParameter="Include" ItemName="ApiFileDefinition"/>
     </CreateItem>
-    <ItemGroup>
-      <_ApiParameterDescription Include="%(ApiFileDefinition.ParameterDescription)" />
-      <_ApiClassParseXml        Include="%(ApiFileDefinition.ClassParseXml)" />
-      <_ApiAdjustedXml          Include="%(ApiFileDefinition.ApiAdjustedXml)" />
-    </ItemGroup>
+    <GetMappedFilesThatExist 
+		ResultingFiles="%(ApiFileDefinition.ParameterDescription)"
+		CheckedFiles="%(ApiFileDefinition.ParameterDescription)">
+      <Output TaskParameter="FilesThatExist" ItemName="_ApiParameterDescription" />
+    </GetMappedFilesThatExist>
+    <GetMappedFilesThatExist 
+		ResultingFiles="%(ApiFileDefinition.ClassParseXml)"
+		CheckedFiles="%(ApiFileDefinition.ParameterDescription)">
+      <Output TaskParameter="FilesThatExist" ItemName="_ApiClassParseXml" />
+    </GetMappedFilesThatExist>
+    <GetMappedFilesThatExist 
+		ResultingFiles="%(ApiFileDefinition.ApiAdjustedXml)"
+		CheckedFiles="%(ApiFileDefinition.ParameterDescription)">
+      <Output TaskParameter="FilesThatExist" ItemName="_ApiAdjustedXml" />
+    </GetMappedFilesThatExist>
   </Target>
 
   <Target Name="_ClassParse"
@@ -24,6 +36,7 @@
       DependsOnTargets="_DefineApiFiles"
       Inputs="@(_ApiParameterDescription)"
       Outputs="@(_ApiClassParseXml)">
+    
     <PropertyGroup>
       <ClassParse>$(_TopDir)\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\class-parse.exe</ClassParse>
     </PropertyGroup>

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GetMappedFilesThatExist.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GetMappedFilesThatExist.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (C) 2011 Xamarin, Inc. All rights reserved.
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.BuildTools.PrepTasks {
+	// We have a list of files, we want to get the
+	// ones that actually exist on disk.
+	public class GetMappedFilesThatExist : Task
+	{
+		[Required]
+		public string[] CheckedFiles { get; set; }
+
+		[Required]
+		public string[] ResultingFiles { get; set; }
+
+		[Output]
+		public string[] FilesThatExist { get; set; }
+
+		public override bool Execute ()
+		{
+			if (CheckedFiles.Length != ResultingFiles.Length)
+				throw new ArgumentException ("CheckedFiles and ResultingFiles must be arrays of the same length.");
+
+			FilesThatExist = CheckedFiles.Zip (ResultingFiles, (c, r) => new {Checked = c, Result = r})
+			                             .Where (p => File.Exists (p.Checked))
+			                             .Select (p => p.Result)
+			                             .ToArray ();
+			
+			return true;
+		}
+	}
+}

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\Sleep.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\ProcessPlotInput.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\ProcessLogcatTiming.cs" />
+    <Compile Include="Xamarin.Android.BuildTools.PrepTasks\GetMappedFilesThatExist.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\external\xamarin-android-tools\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj">


### PR DESCRIPTION
https://github.com/xamarin/xamarin-android/pull/1491 broke build caching.
Now api-\*.xml.in is generated EVERY TIME, which adds tremendous amount of
build time. And this build happens every time anything that depends on
api-\*.xml.in and all its subsequent dependencies.
For example, Xamarin.Android.Build.Tasks build is suffered from it.

The cause of the problem is this:

	Inputs="@(_ApiParameterDescription)"

which is expanded as follows:

	/sources/xamarin-android/build-tools/api-xml-adjuster/../../src/Mono.Android/Profiles/api-4.params.txt;/sources/xamarin-android/build-tools/api-xml-adjuster/../../src/Mono.Android/Profiles/api-5.params.txt; ...

Note that many of those (e.g. API Level 4-9) do not exist.
For non-existent inputs, MSBuild targets always execute.

To fix the issue, add another build task that returns only existent files
and use it to determine the actual targets.

This is sadly a compromised solution that updates on ANY API level will
trigger generation of ALL API levels (but must be applied IMMEDIATELY
without excuse for "better solution". It's a BLOCKER for development.
No one can work on MSBuild tasks if this bug remains).