### PR TITLE
[Xamarin.Android.Build.Tasks] Try to speed up ConvertResourcesCases

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -18,11 +18,14 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string AcwMapFile { get; set; }
 
+		public string AndroidResgenFlagFile { get; set; }
+
 		public override bool Execute ()
 		{
 			Log.LogDebugMessage ("ConvertResourcesCases Task");
 			Log.LogDebugMessage ("  ResourceDirectories: {0}", ResourceDirectories);
 			Log.LogDebugMessage ("  AcwMapFile: {0}", AcwMapFile);
+			Log.LogDebugMessage ("  AndroidResgenFlagFile: {0}", AndroidResgenFlagFile);
 
 			var acw_map = MonoAndroidHelper.LoadAcwMapFile (AcwMapFile);
 
@@ -50,10 +53,19 @@ namespace Xamarin.Android.Tasks
 				.SelectMany (dir => Directory.EnumerateFiles (dir, "*.xml")
 					.Concat (Directory.EnumerateFiles (dir, "*.axml")));
 
+			var lastUpdate = DateTime.MinValue;
+			if (!string.IsNullOrEmpty (AndroidResgenFlagFile) && File.Exists (AndroidResgenFlagFile)) {
+				lastUpdate = File.GetLastWriteTimeUtc (AndroidResgenFlagFile);
+			}
+			Log.LogDebugMessage ("  AndroidResgenFlagFile modified: {0}", lastUpdate);
 			// Fix up each file
 			foreach (string file in xmls) {
-				Log.LogDebugMessage ("  Processing: {0}", file);
 				var srcmodifiedDate = File.GetLastWriteTimeUtc (file);
+				if (srcmodifiedDate <= lastUpdate) {
+					Log.LogDebugMessage ("  Skipping: {0}  {1} <= {2}", file, srcmodifiedDate, lastUpdate);
+					continue;
+				}
+				Log.LogDebugMessage ("  Processing: {0}   {1} > {2}", file, srcmodifiedDate, lastUpdate);
 				var tmpdest = Path.GetTempFileName ();
 				MonoAndroidHelper.CopyIfChanged (file, tmpdest);
 				MonoAndroidHelper.SetWriteable (tmpdest);
@@ -70,7 +82,7 @@ namespace Xamarin.Android.Tasks
 
 					if (MonoAndroidHelper.CopyIfChanged (tmpdest, file)) {
 						MonoAndroidHelper.SetWriteable (file);
-						MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (file, srcmodifiedDate, Log);
+						//MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (file, srcmodifiedDate, Log);
 					}
 				} finally {
 					File.Delete (tmpdest);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -18,14 +18,14 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string AcwMapFile { get; set; }
 
-		public string AndroidResgenFlagFile { get; set; }
+		public string AndroidConversionFlagFile { get; set; }
 
 		public override bool Execute ()
 		{
 			Log.LogDebugMessage ("ConvertResourcesCases Task");
 			Log.LogDebugMessage ("  ResourceDirectories: {0}", ResourceDirectories);
 			Log.LogDebugMessage ("  AcwMapFile: {0}", AcwMapFile);
-			Log.LogDebugMessage ("  AndroidResgenFlagFile: {0}", AndroidResgenFlagFile);
+			Log.LogDebugMessage ("  AndroidConversionFlagFile: {0}", AndroidConversionFlagFile);
 
 			var acw_map = MonoAndroidHelper.LoadAcwMapFile (AcwMapFile);
 
@@ -54,8 +54,8 @@ namespace Xamarin.Android.Tasks
 					.Concat (Directory.EnumerateFiles (dir, "*.axml")));
 
 			var lastUpdate = DateTime.MinValue;
-			if (!string.IsNullOrEmpty (AndroidResgenFlagFile) && File.Exists (AndroidResgenFlagFile)) {
-				lastUpdate = File.GetLastWriteTimeUtc (AndroidResgenFlagFile);
+			if (!string.IsNullOrEmpty (AndroidConversionFlagFile) && File.Exists (AndroidConversionFlagFile)) {
+				lastUpdate = File.GetLastWriteTimeUtc (AndroidConversionFlagFile);
 			}
 			Log.LogDebugMessage ("  AndroidResgenFlagFile modified: {0}", lastUpdate);
 			// Fix up each file

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -82,7 +82,6 @@ namespace Xamarin.Android.Tasks
 
 					if (MonoAndroidHelper.CopyIfChanged (tmpdest, file)) {
 						MonoAndroidHelper.SetWriteable (file);
-						//MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (file, srcmodifiedDate, Log);
 					}
 				} finally {
 					File.Delete (tmpdest);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1436,7 +1436,7 @@ because xbuild doesn't support framework reference assemblies.
 	<ConvertResourcesCases
 		ResourceDirectories="$(MonoAndroidResDirIntermediate);@(LibraryResourceDirectories)"
 		AcwMapFile="$(_AcwMapFile)"
-		AndroidResgenFlagFile="$(_AndroidResgenFlagFile)"
+		AndroidConversionFlagFile="$(_AndroidResgenFlagFile)"
 	/>
 
 	<GetExtraPackages
@@ -1951,7 +1951,7 @@ because xbuild doesn't support framework reference assemblies.
   </GenerateJavaStubs>
   <ConvertResourcesCases 
 	ResourceDirectories="$(MonoAndroidResDirIntermediate)"
-	AndroidResgenFlagFile="$(_AndroidResgenFlagFile)"
+	AndroidConversionFlagFile="$(_AcwMapFile)"
 	AcwMapFile="$(_AcwMapFile)" />
 </Target>
 
@@ -2010,11 +2010,12 @@ because xbuild doesn't support framework reference assemblies.
   </CreateTemporaryDirectory>
 
 	<!-- Change cases so we support mixed case resource names -->
+		<!--
 	<ConvertResourcesCases
 		ResourceDirectories="$(MonoAndroidResDirIntermediate);@(LibraryResourceDirectories)"
-		AndroidResgenFlagFile="$(_AndroidResgenFlagFile)"
+		AndroidConversionFlagFile="$(_AndroidResgenFlagFile)"
 		AcwMapFile="$(_AcwMapFile)" />
-
+		-->
   <GetExtraPackages
   	IntermediateOutputPath="$(IntermediateOutputPath)"
   	LibraryProjectImportsDirectoryName="$(_LibraryProjectImportsDirectoryName)">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1951,7 +1951,6 @@ because xbuild doesn't support framework reference assemblies.
   </GenerateJavaStubs>
   <ConvertResourcesCases 
 	ResourceDirectories="$(MonoAndroidResDirIntermediate)"
-	AndroidConversionFlagFile="$(_AcwMapFile)"
 	AcwMapFile="$(_AcwMapFile)" />
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2008,13 +2008,6 @@ because xbuild doesn't support framework reference assemblies.
     <Output TaskParameter="TemporaryDirectory" PropertyName="AaptTemporaryDirectory" />
   </CreateTemporaryDirectory>
 
-	<!-- Change cases so we support mixed case resource names -->
-		<!--
-	<ConvertResourcesCases
-		ResourceDirectories="$(MonoAndroidResDirIntermediate);@(LibraryResourceDirectories)"
-		AndroidConversionFlagFile="$(_AndroidResgenFlagFile)"
-		AcwMapFile="$(_AcwMapFile)" />
-		-->
   <GetExtraPackages
   	IntermediateOutputPath="$(IntermediateOutputPath)"
   	LibraryProjectImportsDirectoryName="$(_LibraryProjectImportsDirectoryName)">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1436,6 +1436,7 @@ because xbuild doesn't support framework reference assemblies.
 	<ConvertResourcesCases
 		ResourceDirectories="$(MonoAndroidResDirIntermediate);@(LibraryResourceDirectories)"
 		AcwMapFile="$(_AcwMapFile)"
+		AndroidResgenFlagFile="$(_AndroidResgenFlagFile)"
 	/>
 
 	<GetExtraPackages
@@ -1950,6 +1951,7 @@ because xbuild doesn't support framework reference assemblies.
   </GenerateJavaStubs>
   <ConvertResourcesCases 
 	ResourceDirectories="$(MonoAndroidResDirIntermediate)"
+	AndroidResgenFlagFile="$(_AndroidResgenFlagFile)"
 	AcwMapFile="$(_AcwMapFile)" />
 </Target>
 
@@ -2010,6 +2012,7 @@ because xbuild doesn't support framework reference assemblies.
 	<!-- Change cases so we support mixed case resource names -->
 	<ConvertResourcesCases
 		ResourceDirectories="$(MonoAndroidResDirIntermediate);@(LibraryResourceDirectories)"
+		AndroidResgenFlagFile="$(_AndroidResgenFlagFile)"
 		AcwMapFile="$(_AcwMapFile)" />
 
   <GetExtraPackages


### PR DESCRIPTION
We currently call `ConvertResourcesCases` in three different places. [1], [2], [3]. For the most part they process the same files , over and over and over again. On a large project this is totally a waste of time. If the file has been processed once and not updated then we should not need to process it again.

So the only exception here is `GenerateJavaStubs`. The case here is this needs to be done AFTER we have compiled the app.. but we need to replace any instances of `Foo.MyClass` with `<md5hash>.MyClass` which is generated in the java code. So we do still need to process the resource files for the app after the main assembly has been built. 

That said if we know `UpdateAndroidResgen` has run, then we DONT need to run this again in `_CreateBaseApk`.

So this is an attempt to see if we can only process the files which have changed between each of those calls. Alternatively rework the targets so that we only have one call at the right place in the build system (probably as part of the `UpdateAndroidResources`)

If this does not work then the next task will be to rework the `AndroidResource.UpdateXmlResources` to NOT use `XDocument` but try to use `XPathDocument` or `XmlReader/Writer` instead since it is a streaming version and should be allot quicker. 

[1] https://github.com/xamarin/xamarin-android/blob/5d64fb4bbad606eb4a3478085db0ca98616f9966/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets#L1951
[2] https://github.com/xamarin/xamarin-android/blob/5d64fb4bbad606eb4a3478085db0ca98616f9966/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets#L1436
[3] https://github.com/xamarin/xamarin-android/blob/5d64fb4bbad606eb4a3478085db0ca98616f9966/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets#L2011