### PR TITLE
[build] fix various incorrect paths used by <ProjectReference />

### DIFF
--- a/build-tools/bundle/bundle.csproj
+++ b/build-tools/bundle/bundle.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -32,18 +32,18 @@
       <Name>android-toolchain</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\mono-runtimes\mono-runtimes.csproj">
+    <ProjectReference Include="..\..\src\mono-runtimes\mono-runtimes.csproj">
       <Project>{C03E6CF1-7460-4CDC-A4AB-292BBC0F61F2}</Project>
       <Name>mono-runtimes</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\libzip\libzip.csproj" Condition=" '$(HostOS)' != 'Windows' ">
+    <ProjectReference Include="..\..\src\libzip\libzip.csproj" Condition=" '$(HostOS)' != 'Windows' ">
       <Project>{900A0F71-BAAD-417A-8D1A-8D330297CDD0}</Project>
       <Name>libzip</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </ProjectReference>
-    <ProjectReference Include="..\libzip-windows\libzip-windows.csproj">
+    <ProjectReference Include="..\..\src\libzip-windows\libzip-windows.csproj">
       <Project>{0DE278D6-000F-4001-BB98-187C0AF58A61}</Project>
       <Name>libzip-windows</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>

--- a/src/libzip-windows/libzip-windows.csproj
+++ b/src/libzip-windows/libzip-windows.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -26,7 +26,7 @@
   <Import Project="libzip-windows.targets" />
   <Import Project="..\libzip\libzip.targets" />
   <ItemGroup>
-    <ProjectReference Include="..\android-toolchain\android-toolchain.csproj" Condition=" '$(HostOS)' != 'Windows' ">
+    <ProjectReference Include="..\..\build-tools\android-toolchain\android-toolchain.csproj" Condition=" '$(HostOS)' != 'Windows' ">
       <Project>{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA}</Project>
       <Name>android-toolchain</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>

--- a/src/libzip/libzip.csproj
+++ b/src/libzip/libzip.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -25,7 +25,7 @@
   <Import Project="libzip.projitems" />
   <Import Project="libzip.targets" />
   <ItemGroup>
-    <ProjectReference Include="..\xa-prep-tasks\xa-prep-tasks.csproj">
+    <ProjectReference Include="..\..\build-tools\xa-prep-tasks\xa-prep-tasks.csproj">
       <Project>{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}</Project>
       <Name>xa-prep-tasks</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>

--- a/src/mono-runtimes/mono-runtimes.csproj
+++ b/src/mono-runtimes/mono-runtimes.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -22,17 +22,17 @@
   </PropertyGroup>
   <Import Project="mono-runtimes.targets" />
   <ItemGroup>
-    <ProjectReference Include="..\xa-prep-tasks\xa-prep-tasks.csproj">
+    <ProjectReference Include="..\..\build-tools\xa-prep-tasks\xa-prep-tasks.csproj">
       <Project>{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}</Project>
       <Name>xa-prep-tasks</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\android-toolchain\android-toolchain.csproj">
+    <ProjectReference Include="..\..\build-tools\android-toolchain\android-toolchain.csproj">
       <Project>{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA}</Project>
       <Name>android-toolchain</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\remap-assembly-ref\remap-assembly-ref.csproj">
+    <ProjectReference Include="..\..\build-tools\remap-assembly-ref\remap-assembly-ref.csproj">
       <Project>{C876DA71-8573-4CEF-9149-716D72455ED4}</Project>
       <Name>remap-assembly-ref</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>


### PR DESCRIPTION
Opening the Xamarin.Android.sln in curent stable VS 2017, results in the
IDE going through a lengthy process where it "fixes" mismatched
`<ProjectReference />` paths.

Looking into it, these paths were indeed wrong. I was seeing warnings
during the build for these `<ProjectReference />` items, and these were
just going unnoticed. These projects must have gotten moved around at
some point, and the failing references only caused warnings.

Hopefully these fixes do not cause future file-locking issues when
building `Xamarin.Android.sln` on Windows. I will have to wait until
this is merged to test, since these changes will trigger a new bundle to
be created.