### PR TITLE
[windows] fail the build if bundle download fails

### DIFF
--- a/build-tools/xa-prep-tasks/xa-prep-tasks.targets
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.targets
@@ -74,6 +74,10 @@
         SourceUris="$(_AzureBaseUri)$(Configuration)/$(XABundleFileName)"
         DestinationFiles="$(_BundlePath)"
     />
+    <Error
+        Text="The Windows build depends on a cached mono bundle, that may not be available yet. Try going back a few commits (with git reset) to download a different bundle."
+        Condition=" '$(HostOS)' == 'Windows' And '$(MSBuildLastTaskResult)' == 'False' "
+    />
   </Target>
   <Target Name="_DownloadNuGet"
 	Inputs=""


### PR DESCRIPTION
One of my biggest nightmares when developing for `xamarin-android` on
Windows, is noticing when I inadventently modified the hash for the
downloaded bundle, or check out a newer commit where the bundle is not
available yet. In cases where the bundle gets a 404, this is merely a
warning and the build continues on. This is a problem on Windows, since
it completely depends on the bundle download.

Depending on the state of your build tree, one of the following could
happen on Windows due to a failed bundle download:
- an `<Exec />` task fails, due to it trying to run `make`
- thousands of build errors on `Mono.Android.csproj` complaining about
missing `mscorlib` types

Explicitly failing the build on Windows, makes it a lot more clear what
is wrong. It also fails the build faster, freeing up development/build
agent time.

I used the `$(MSBuildLastTaskResult)` built-in property to check if the
`<DownloadUri />` task failed, even though it has
`ContinueOnError=True`. This is nice, because you get the 404 error
message as well as the newly added message.