### PR TITLE
[Aapt] fix original file name in error message

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -439,7 +439,7 @@ namespace Xamarin.Android.Tasks
 				// Try to map back to the original resource file, so when the user
 				// double clicks the error, it won't take them to the obj/Debug copy
 				if (file.StartsWith (resourceDirectory, StringComparison.InvariantCultureIgnoreCase)) {
-					file = file.Substring (resourceDirectory.Length);
+					file = file.Substring (resourceDirectory.Length).TrimStart (Path.DirectorySeparatorChar);
 					file = resource_name_case_map.ContainsKey (file) ? resource_name_case_map [file] : file;
 					file = Path.Combine ("Resources", file);
 				}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/1490

Since aee709d, the `ReportAaptErrorsInOriginalFileName` test has been
failing on Windows.

Looking into it, there really was a problem. The error message was
reporting the path as `\layout\main.xml`, which will not map back to
file within the user's project in an IDE.

It appears the change of the use of a `WorkingDirectory` caused the
following:
- `file` starts out as a full path such as
`C:\Users\myuser\Desktop\Git\xamarin-android\bin\TestDebug\temp\ErroneousResource\obj\Debug\res\layout\main.xml`
- `resourceDirectory` is a full path such as
`C:\Users\myuser\Desktop\Git\xamarin-android\bin\TestDebug\temp\ErroneousResource\obj\Debug\res`
- After the `Substring` the result is `\layout\main.xml`, so we need to
trim the leading `\` in order to locate the original file name from
`resource_name_case_map`

I am not sure how this test would pass on other platforms, but this
was definitely failing on Windows.