### PR TITLE
[api-xml-adjuster] Don't needlessly rebuild XML

### DIFF
--- a/build-tools/api-xml-adjuster/api-xml-adjuster.targets
+++ b/build-tools/api-xml-adjuster/api-xml-adjuster.targets
@@ -8,22 +8,23 @@
   </PropertyGroup>
 
   <Target Name="_DefineApiFiles">
-    <CreateItem Include="@(AndroidApiInfo)"
-        AdditionalMetadata="ParameterDescription=$(_TopDir)\src\Mono.Android\Profiles\api-%(AndroidApiInfo.Level).params.txt;ClassParseXml=$(_OutputPath)api\api-%(AndroidApiInfo.Level).xml.class-parse;ApiAdjustedXml=$(_OutputPath)api\api-%(AndroidApiInfo.Level).xml.in">
+    <ItemGroup>
+      <_Api
+          Condition=" Exists('$(_TopDir)\src\Mono.Android\Profiles\api-%(AndroidApiInfo.Level).params.txt') "
+          Include="@(AndroidApiInfo)">
+      </_Api>
+    </ItemGroup>
+    <CreateItem Include="@(_Api)"
+        AdditionalMetadata="ParameterDescription=$(_TopDir)\src\Mono.Android\Profiles\api-%(_Api.Level).params.txt;ClassParseXml=$(_OutputPath)api\api-%(_Api.Level).xml.class-parse;ApiAdjustedXml=$(_OutputPath)api\api-%(_Api.Level).xml.in">
       <Output TaskParameter="Include" ItemName="ApiFileDefinition"/>
     </CreateItem>
-    <ItemGroup>
-      <_ApiParameterDescription Include="%(ApiFileDefinition.ParameterDescription)" />
-      <_ApiClassParseXml        Include="%(ApiFileDefinition.ClassParseXml)" />
-      <_ApiAdjustedXml          Include="%(ApiFileDefinition.ApiAdjustedXml)" />
-    </ItemGroup>
   </Target>
 
   <Target Name="_ClassParse"
       BeforeTargets="_AdjustApiXml"
       DependsOnTargets="_DefineApiFiles"
-      Inputs="@(_ApiParameterDescription)"
-      Outputs="@(_ApiClassParseXml)">
+      Inputs="%(ApiFileDefinition.ParameterDescription)"
+      Outputs="%(ApiFileDefinition.ApiAdjustedXml)">
     <PropertyGroup>
       <ClassParse>$(_TopDir)\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\class-parse.exe</ClassParse>
     </PropertyGroup>
@@ -36,8 +37,8 @@
   <Target Name="_AdjustApiXml"
       AfterTargets="Build"
       DependsOnTargets="_DefineApiFiles"
-      Inputs="@(_ApiClassParseXml)"
-      Outputs="@(_ApiAdjustedXml)">
+      Inputs="%(ApiFileDefinition.ClassParseXml)"
+      Outputs="%(ApiFileDefinition.ApiAdjustedXml)">
     <PropertyGroup>
       <ApiXmlAdjuster>$(_TopDir)\bin\Build$(Configuration)\api-xml-adjuster.exe</ApiXmlAdjuster>
     </PropertyGroup>


### PR DESCRIPTION
Commit e3abe4b8 broke caching of the
`bin/Build$(Configuration)/api/api-*.xml.*` files, reintroducing the
scenario that commit 5c46ee39 fixed. The result is that *minutes* may
be spent needlessly re-generating API XML.

The cause of the breakage is that `@(_ApiParameterDescription)`
(introduced in e3abe4b8) will contain entries that we don't care
about, e.g. API-4, for which no longer generate bindings. As such, the
`_ClassParse` target Inputs were looking for files which will never
exist, thus causing the `_ClassParse` target to always execute.

This *could* be fixed by making `@(_ApiParameterDescription)`/etc.
entries conditional on on the file
`%(_ApiParameterDescription.ParameterDescription)` refers to actually
existing, a'la:

	<ItemGroup>
	  <_ApiParameterDescription
	      Condition="Exists('%(ApiFileDefinition.ParameterDescription)')"
	      Include="%(ApiFileDefinition.ParameterDescription)"
	  />
	</ItemGroup>

However, this is suboptimal, as it means everything must still be
rebuilt if only one file changes:

	$ touch src/Mono.Android/Profiles/api-27.params.txt
	$ (cd build-tools/api-xml-adjuster ; time msbuild )
	real    2m20.205s
	# eep!

What we really want is [MSBuild Target Batching][0], but our use of
item groups *without* item metadata prevents target batching!

[0]: https://msdn.microsoft.com/en-us/library/ms171473.aspx

Which leads to a realization: the rationalization for commit e3abe4b8
was incomplete: The problem wasn't using metadata within Target Inputs
and Outputs; the problem was intermixing strings with metadata.

Meaning the pre-e3abe4b8 `api-xml-adjuster.targets` was *correct*
(except for the bit about it mentioning files which didn't exist,
causing needless rebuilds):

	<!-- Good! Permits Target Batching -->
	<Target Name="_ClassParse"
	    Inputs="%(ApiFileDefinition.ParameterDescription)"
	    Outputs="%(ApiFileDefinition.ApiAdjustedXml)"
	  ...

vs. what e3abe4b8 was attempting to fix:

	<!-- BAD! Intermixes metadata with strings -->
	<Target Name="_Make"
	    Inputs="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)\Makefile"
	  ...

Reviewing e3abe4b8, `api-xml-adjuster.targets` is the only file that
was *already* properly using item medata within Target Inputs & Outputs.

Fix `class-parse.exe` and `api-xml-adjuster.exe` rebuilds by properly
using MSBuild Target Batching, *and* by *filtering*
`@(ApiFileDefinition)` so that it only contains values for which we
have a `src/Mono.Android/Profiles/api-*.params.txt` file.

With these changes in place, single-file rebuilds are much faster:

	$ touch src/Mono.Android/Profiles/api-27.params.txt
	$ (cd build-tools/api-xml-adjuster ; time msbuild )
	real    0m26.662s
