### PR TITLE
[Java.Interop] Add JavaTypeManager class based on JavaObject

### DIFF
--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -358,5 +358,20 @@ namespace Java.Interop {
 				}
 			}
 		}
+
+		[Register ("mono/android/TypeManager", DoNotGenerateAcw = true)]
+		internal class JavaTypeManager : Java.Lang.Object
+		{
+			[Register ("activate", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;[Ljava/lang/Object;)V", "")]
+			static void n_Activate (IntPtr jnienv, IntPtr jclass, IntPtr typename_ptr, IntPtr signature_ptr, IntPtr jobject, IntPtr parameters_ptr)
+			{
+				TypeManager.n_Activate (jnienv, jclass, typename_ptr, signature_ptr, jobject, parameters_ptr);
+			}
+
+			internal static Delegate GetActivateHandler ()
+			{
+				return TypeManager.GetActivateHandler ();
+			}
+		}
 	}
 }

--- a/src/Mono.Android/java/mono/android/TypeManager.java
+++ b/src/Mono.Android/java/mono/android/TypeManager.java
@@ -13,6 +13,6 @@ public class TypeManager {
 		String methods = 
 			"n_activate:(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;[Ljava/lang/Object;)V:GetActivateHandler\n" +
 			"";
-		mono.android.Runtime.register ("Java.Interop.TypeManager, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", TypeManager.class, methods);
+		mono.android.Runtime.register ("Java.Interop.TypeManager+JavaTypeManager, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", TypeManager.class, methods);
 	}
 }


### PR DESCRIPTION
And use it from Java side in place of the old
`Java.Interop.TypeManager` and its `Activate` method. As it is based
on `JavaObject`, it will work nicely with the *jnimarshalmethod-gen*.