### PR TITLE
[libzip, mono-runtimes, monodroid] Build with msbuild

### DIFF
--- a/src/libzip/libzip.targets
+++ b/src/libzip/libzip.targets
@@ -38,7 +38,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <_LibZipTargetMakefile Include="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)\Makefile" />
+    <_LibZipTargetMakefile Include="@(_LibZipTarget->'$(IntermediateOutputPath)\%(Identity)\Makefile')" />
   </ItemGroup>
   <Target Name="_Make"
       Condition=" '@(_LibZipTarget)' != '' "

--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -796,9 +796,9 @@
   </Target>
 
   <ItemGroup>
-    <_MonoCrossRuntimeStamp               Include="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)\.stamp" />
-    <_MonoCrossRuntimeIntermediateOutput  Include="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)\mono\mini\mono-sgen%(_MonoCrossRuntime.ExeSuffix)" />
-    <_MonoCrossRuntimeOutput              Include="$(_MSBuildDir)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)" />
+    <_MonoCrossRuntimeStamp               Include="@(_MonoCrossRuntime->'$(IntermediateOutputPath)\%(Identity)\.stamp')" />
+    <_MonoCrossRuntimeIntermediateOutput  Include="@(_MonoCrossRuntime->'$(IntermediateOutputPath)\%(Identity)\mono\mini\mono-sgen%(ExeSuffix)')" />
+    <_MonoCrossRuntimeOutput              Include="@(_MonoCrossRuntime->'$(_MSBuildDir)\%(InstallPath)%(CrossMonoName)%(ExeSuffix)')" />
   </ItemGroup>
 
   <!-- The condition below is to work around a bug in xbuild which attempts to batch

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -105,10 +105,10 @@
   </Target>
   <Target Name="_GetBuildHostRuntimes">
     <ItemGroup>
-      <_OutputDebugPath         Include="$(OutputPath)%(_HostRuntime.OutputDirectory)\%(_HostRuntime.OutputBasename).debug.d.%(_HostRuntime.NativeLibraryExtension)" />
-      <_OutputDebugStripPath    Include="$(OutputPath)%(_HostRuntime.OutputDirectory)\%(_HostRuntime.OutputBasename).debug.%(_HostRuntime.NativeLibraryExtension)" />
-      <_OutputReleasePath       Include="$(OutputPath)%(_HostRuntime.OutputDirectory)\%(_HostRuntime.OutputBasename).release.d.%(_HostRuntime.NativeLibraryExtension)" />
-      <_OutputReleaseStripPath  Include="$(OutputPath)%(_HostRuntime.OutputDirectory)\%(_HostRuntime.OutputBasename).release.%(_HostRuntime.NativeLibraryExtension)" />
+      <_OutputDebugPath         Include="$(OutputPath)%(_HostRuntime.OutputDirectory)\libmono-android.debug.d.%(_HostRuntime.NativeLibraryExtension)" />
+      <_OutputDebugStripPath    Include="$(OutputPath)%(_HostRuntime.OutputDirectory)\libmono-android.debug.%(_HostRuntime.NativeLibraryExtension)" />
+      <_OutputReleasePath       Include="$(OutputPath)%(_HostRuntime.OutputDirectory)\libmono-android.release.d.%(_HostRuntime.NativeLibraryExtension)" />
+      <_OutputReleaseStripPath  Include="$(OutputPath)%(_HostRuntime.OutputDirectory)\libmono-android.release.%(_HostRuntime.NativeLibraryExtension)" />
     </ItemGroup>
   </Target>
   <Target Name="_BuildHostRuntimes"


### PR DESCRIPTION
Like e3abe4b8, but different: we had another `xbuild`-ism that
`msbuild` doesn't like: the "intermixing" of "strings" and item
metdata within *top-level* item groups.

For example:

	<_MonoCrossRuntimeIntermediateOutput Include="$(IntermediateOutputPath)\%(_MonoCrossRuntime.Identity)\mono\mini\mono-sgen%(_MonoCrossRuntime.ExeSuffix)" />

The above uses item metadata, e.g. `%(_MonoCrossRuntime.Identity)`,
*outside* of a `@(_MonoCrossRuntime->'...')` context, at top-level
scope. The result is a [build break][0]

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-msbuild/857/

	src/mono-runtimes/mono-runtimes.targets(818,5): error MSB3375:
	The file "obj/Debug//%(_MonoCrossRuntime.Identity)/mono/mini/mono-sgen%(_MonoCrossRuntime.ExeSuffix)" does not exist.

Note that the item metadata wasn't actually replaced, and instead was
used literally.

The fix is to replace the above "intermixing" with `@(Foo->...)`:

	<_MonoCrossRuntimeIntermediateOutput  Include="@(_MonoCrossRuntime->'$(IntermediateOutputPath)\%(Identity)\mono\mini\mono-sgen%(ExeSuffix)')" />

This appeases MSBuild, allowing things to build.

Review matches for:

	$ git grep '<.*Include="\$.*%'

and fix any top-level `<ItemGroup/>` matches.