### PR TITLE
[Xamarin.Android.Build.Tasks] Fix issue with pathing to resource.cache (#1533)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
@@ -385,6 +385,7 @@ namespace Xamarin.Android.Tasks {
 			LogDebugMessage ("GetAdditionalResourcesFromAssemblies Task");
 			LogDebugMessage ("  AndroidSdkDirectory: {0}", AndroidSdkDirectory);
 			LogDebugMessage ("  AndroidNdkDirectory: {0}", AndroidNdkDirectory);
+			LogDebugMessage ("  CacheFile: {0}", CacheFile);
 			LogDebugTaskItems ("  Assemblies: ", Assemblies);
 
 			if (Environment.GetEnvironmentVariable ("XA_DL_IGNORE_CERT_ERRROS") == "yesyesyes") {
@@ -398,6 +399,10 @@ namespace Xamarin.Android.Tasks {
 
 			if (Assemblies == null)
 				return;
+
+			var cacheFileFullPath = CacheFile;
+			if (!Path.IsPathRooted (cacheFileFullPath))
+				cacheFileFullPath = Path.Combine (WorkingDirectory, cacheFileFullPath);
 
 			System.Threading.Tasks.Task.Run (() => {
 				// The cache location can be overriden by the (to be documented) XAMARIN_CACHEPATH
@@ -444,8 +449,8 @@ namespace Xamarin.Android.Tasks {
 			var result = base.Execute ();
 
 			if (!result || Log.HasLoggedErrors) {
-				if (File.Exists (CacheFile))
-					File.Delete (CacheFile);
+				if (File.Exists (cacheFileFullPath))
+					File.Delete (cacheFileFullPath);
 				return;
 			}
 
@@ -465,7 +470,7 @@ namespace Xamarin.Android.Tasks {
 					new XElement ("AdditionalNativeLibraryReferences", 
 							AdditionalNativeLibraryReferences.Select(e => new XElement ("AdditionalNativeLibraryReference", e)))
 					));
-			document.Save (CacheFile);
+			document.Save (cacheFileFullPath);
 
 			LogDebugTaskItems ("  AdditionalAndroidResourcePaths: ", AdditionalAndroidResourcePaths);
 			LogDebugTaskItems ("  AdditionalJavaLibraryReferences: ", AdditionalJavaLibraryReferences);


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/597577

Commit aee709d made some changes which effect the working directory
if a task. Now it seems we now need to provide a full path for
the resource.cache file when we try to save it similar to what
we did for [1].

[1] https://github.com/xamarin/xamarin-android/commit/aee709d2ec98ddeb9a0cec9604e4fefa7321196e#diff-97e1ab3c8027acfecf85b8bb5a88dd9aR269