### PR TITLE
[Xamarin.Android.Build.Tasks] better ResolveAssemblies errors

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -220,20 +220,20 @@ namespace Xamarin.Android.Tasks
 					reference_assembly = resolver.Resolve (reference);
 				} catch (FileNotFoundException ex) {
 					var references = new StringBuilder ();
-					for (int i = resolutionPath.Count - 1; i >= 0; i--) {
+					for (int i = 0; i < resolutionPath.Count; i++) {
+						if (i != 0)
+							references.Append (" > ");
 						references.Append ('`');
 						references.Append (resolutionPath [i]);
 						references.Append ('`');
-						if (i != 0)
-							references.Append (" > ");
 					}
 
 					string missingAssembly = Path.GetFileNameWithoutExtension (ex.FileName);
-					string message = $"Could not find assembly `{missingAssembly}`, referenced by {references}.";
+					string message = $"Can not resolve reference: `{missingAssembly}`, referenced by {references}.";
 					if (MonoAndroidHelper.IsFrameworkAssembly (ex.FileName)) {
-						LogError ("XA9999", $"{message} Perhaps it doesn't exist in the Mono for Android profile?");
+						LogError ("XA2002", $"{message} Perhaps it doesn't exist in the Mono for Android profile?");
 					} else {
-						LogError ("XA9999", $"{message} Please add a NuGet package or assembly reference for `{missingAssembly}`, or remove the reference to `{resolutionPath [0]}`.");
+						LogError ("XA2002", $"{message} Please add a NuGet package or assembly reference for `{missingAssembly}`, or remove the reference to `{resolutionPath [0]}`.");
 					}
 					return;
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BuildHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BuildHelper.cs
@@ -49,7 +49,7 @@ namespace Xamarin.Android.Build.Tests
 					return;
 				}
 			}
-			Assert.Fail (message);
+			Assert.Fail (message ?? $"String did not contain '{text}'!");
 		}
 
 		public static bool ContainsText (this IEnumerable<string> collection, string expected) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -385,6 +385,16 @@ namespace Xamarin.ProjectTools
 				}
 			}
 		};
+		public static Package Microsoft_Azure_EventHubs = new Package {
+			Id = "Microsoft.Azure.EventHubs",
+			Version = "2.0.0",
+			TargetFramework = "netstandard2.0",
+			References = {
+				new BuildItem.Reference("Microsoft.Azure.EventHubs") {
+					MetadataValues = "HintPath=..\\packages\\Microsoft.Azure.EventHubs.2.0.0\\lib\\netstandard2.0\\Microsoft.Azure.EventHubs.dll"
+				}
+			}
+		};
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
@@ -135,7 +135,10 @@ namespace Xamarin.ProjectTools
 				var referenceGroup = p.Elements ().FirstOrDefault (x => x.Name.LocalName == "ItemGroup" &&  x.HasElements && x.Elements ().Any (e => e.Name.LocalName == "Reference"));
 				if (referenceGroup != null) {
 					foreach (var pr in PackageReferences) {
+						//NOTE: without the namespace it puts xmlns=""
+						XNamespace ns = "http://schemas.microsoft.com/developer/msbuild/2003";
 						var e = XElement.Parse ($"<PackageReference Include=\"{pr.Id}\" Version=\"{pr.Version}\"/>");
+						e.Name = ns + e.Name.LocalName;
 						referenceGroup.Add (e);
 					}
 					sw = new StringWriter ();

--- a/tools/xabuild/XABuildPaths.cs
+++ b/tools/xabuild/XABuildPaths.cs
@@ -148,6 +148,12 @@ namespace Xamarin.Android.Build
 				ProjectImportSearchPaths = new [] { MSBuildPath, Path.Combine (mono, "xbuild"), Path.Combine (monoExternal, "xbuild") };
 				SystemProfiles           = Path.Combine (mono, "xbuild-frameworks");
 				SearchPathsOS            = IsMacOS ? "osx" : "unix";
+
+				string nuget = Path.Combine(mono, "xbuild", "Microsoft", "NuGet");
+				if (Directory.Exists(nuget)) {
+					NuGetTargets = Path.Combine (nuget, "Microsoft.NuGet.targets");
+					NuGetProps   = Path.Combine (nuget, "Microsoft.NuGet.props");
+				}
 				if (!string.IsNullOrEmpty (DotNetSdkPath)) {
 					NuGetRestoreTargets  = Path.Combine (DotNetSdkPath, "..", "NuGet.targets");
 				}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/1532

In discussion around this issue, we realized the error message given by
the `<ResolveAssemblies />` MSBuild task is confusing for developers.

Currently users are getting:

    Could not load assembly A. Perhaps it doesn't exist in the Mono for Android profile?

This message makes sense for `System.*` or framework assemblies.

We were thinking in some cases we could give an error such as:

    Could not find assembly A, referenced by B. Please add a NuGet package or assembly reference for A, or remove the reference to B.

Additionally we should list an assembly "resolution path", so we can
easily figure out where the missing assembly came from.

In order to make this work:
- Keep a `List<string>` to store the name of each assembly
- Catch `FileNotFoundException` specifically
- Check `MonoAndroidHelper.IsFrameworkAssembly` to decide if we show the
old message, or the new/improved message
- We have to track the `resolutionPath` variable as we go, passing it
through recursively as well as removing items as we "un-indent"

The full error message wil now read:
```
error XA9999: Could not find assembly
`Microsoft.Azure.Services.AppAuthentication`, referenced by
`Microsoft.Azure.EventHubs`. Please add a NuGet package or assembly
reference for `Microsoft.Azure.Services.AppAuthentication`, or remove
the reference to `Microsoft.Azure.EventHubs`.
```

If there are multiple assemblies involved you should see something like:
```
error XA999: Could not find assembly `C`, referenced by `B` > `A`.
Please add a NuGet package or assembly reference for `C`, or remove the
reference to `A`.
```

Other changes:
- Added a unit test specifically for the NuGet used in #1532. Tested the
scenario where a library project references the broken NuGet, add the
`<ProjectReference />` to the app, then get a different error message.
- `StringAssertEx` should give some reasonable default assertion message
if `message` is not supplied
- `<PackageReference />` elements had this odd `xmlns=""` attribute, so
I included the msbuild XML namespace to fix this
- Found an issue in `xabuild.exe` where the NuGet targets were not setup.
Most cases of `/t:Restore;Build` seems like they would fail on macOS.