### PR TITLE
 [build-tools] Allow various bundle download and unzip properties to be overridden

### DIFF
--- a/build-tools/bundle/bundle-path.targets
+++ b/build-tools/bundle/bundle-path.targets
@@ -36,8 +36,8 @@
       DependsOnTargets="_GetHashes">
     <PropertyGroup>
       <XABundleVersion>v21</XABundleVersion>
-      <XABundleFileName Condition=" '$(HostOS)' != 'Windows' ">bundle-$(XABundleVersion)-h$(_VersionHash)-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
-      <XABundleFileName Condition=" '$(HostOS)' == 'Windows' ">bundle-$(XABundleVersion)-h$(_VersionHash)-$(Configuration)-Darwin-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
+      <XABundleFileName Condition=" '$(HostOS)' != 'Windows' AND '$(XABundleFileName)' == '' ">bundle-$(XABundleVersion)-h$(_VersionHash)-$(Configuration)-$(HostOS)-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
+      <XABundleFileName Condition=" '$(HostOS)' == 'Windows' AND '$(XABundleFileName)' == '' ">bundle-$(XABundleVersion)-h$(_VersionHash)-$(Configuration)-Darwin-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
     </PropertyGroup>
   </Target>
 </Project>

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/SystemUnzip.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/SystemUnzip.cs
@@ -26,6 +26,8 @@ namespace Xamarin.Android.BuildTools.PrepTasks {
 
 		public  string          HostOS              { get; set; }
 
+		public  string          TempUnzipDir        { get; set; }
+
 		[Required]
 		public  ITaskItem       DestinationFolder   { get; set; }
 
@@ -58,7 +60,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks {
 
 			Directory.CreateDirectory (DestinationFolder.ItemSpec);
 
-			var tempDir = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
+			var tempDir = TempUnzipDir ?? Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
 			Directory.CreateDirectory (tempDir);
 			Log.LogMessage (MessageImportance.Low, $"  Extracting into temporary directory: {tempDir}");
 

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.targets
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.targets
@@ -69,9 +69,12 @@
       DependsOnTargets="_GetBundleOutputPath"
       Inputs=""
       Outputs="$(_BundlePath)">
+    <PropertyGroup>
+      <XABundleDownloadPrefix Condition=" '$(XABundleDownloadPrefix)' == '' ">$(_AzureBaseUri)$(Configuration)</XABundleDownloadPrefix>
+    </PropertyGroup>
     <DownloadUri
         ContinueOnError="True"
-        SourceUris="$(_AzureBaseUri)$(Configuration)/$(XABundleFileName)"
+        SourceUris="$(XABundleDownloadPrefix)/$(XABundleFileName)"
         DestinationFiles="$(_BundlePath)"
     />
     <Error

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.targets
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.targets
@@ -98,12 +98,12 @@
       Inputs="$(_BundlePath)"
       Outputs="$(OutputPath).extracted-$(XABundleFileName)">
     <PropertyGroup>
-      <_BundleUnzipPath Condition=" '$(_BundleUnzipPath)' == '' "></_BundleUnzipPath>
+      <XABundleUnzipPath Condition=" '$(XABundleUnzipPath)' == '' "></XABundleUnzipPath>
     </PropertyGroup>
     <SystemUnzip
         SourceFiles="$(_BundlePath)"
         HostOS="$(HostOS)"
-        TempUnzipDir="$(_BundleUnzipPath)"
+        TempUnzipDir="$(XABundleUnzipPath)"
         DestinationFolder="..\..\bin\$(Configuration)"
     />
     <WriteLinesToFile

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.targets
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.targets
@@ -97,9 +97,13 @@
       Condition=" Exists('$(_BundlePath)') "
       Inputs="$(_BundlePath)"
       Outputs="$(OutputPath).extracted-$(XABundleFileName)">
+    <PropertyGroup>
+      <_BundleUnzipPath Condition=" '$(_BundleUnzipPath)' == '' "></_BundleUnzipPath>
+    </PropertyGroup>
     <SystemUnzip
         SourceFiles="$(_BundlePath)"
         HostOS="$(HostOS)"
+        TempUnzipDir="$(_BundleUnzipPath)"
         DestinationFolder="..\..\bin\$(Configuration)"
     />
     <WriteLinesToFile


### PR DESCRIPTION
The intent here is to make it easier to fetch bcl-test artifacts for PR builds. QA's current bcl-test harness relies on the `_DownloadAndExtractBundle` target to download and extract the bcl-test
assemblies to the correct location. However, this falls apart when attempting to test a PR build as the mono bundle is not uploaded. One solution to this problem is to allow us to override the file "bundle" that is downloaded, as PR builds do upload a zipped up build output which contains the relevant test assemblies.

Now that the bundle download URI properties can be overridden, we quickly run in to max path length limitations when attempting to `SystemUnzip` the entirety of the XA build on Windows. A new property for a temporary bundle extraction location has been added to address this.

Example property values:
```
/p:XABundleDownloadPrefix="https://xamjenkinsartifact.blob.core.windows.net/xamarin-android/2889/xamarin-android"
/p:XABundleFileName="xamarin.android-oss_v8.3.99.161_Darwin-x86_64_HEAD_b88ba02.zip"
/p:XABundleUnzipPath="C:\x"
```
