### PR TITLE
[tests] Use explicit Activity name in XF test

### DIFF
--- a/tests/Xamarin.Forms-Performance-Integration/Droid/MainActivity.cs
+++ b/tests/Xamarin.Forms-Performance-Integration/Droid/MainActivity.cs
@@ -10,7 +10,7 @@ using Android.OS;
 
 namespace Xamarin.Forms.Performance.Integration.Droid
 {
-	[Activity (Icon = "@drawable/icon", Theme = "@style/MyTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
+	[Activity (Icon = "@drawable/icon", Theme = "@style/MyTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation, Name = "xamarin.forms.performance.integration.MainActivity")]
 	public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
 	{
 		bool firstOnCreate = true;

--- a/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.projitems
+++ b/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.projitems
@@ -6,7 +6,7 @@
   <ItemGroup>
     <TestApk Include="$(OutputPath)Xamarin.Forms_Performance_Integration-Signed.apk">
       <Package>$(_XamarinFormsIntergationPackage)</Package>
-      <Activity>Xamarin.Forms_Performance_Integration/md52b709e14dec302485bbcaeac0bd817ce.MainActivity</Activity>
+      <Activity>Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity</Activity>
       <ResultsPath></ResultsPath>
       <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)timing-definitions.txt</TimingDefinitionsFilename>
       <TimingResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-Xamarin.Forms_Test-times.csv</TimingResultsFilename>


### PR DESCRIPTION
Looks like the hash in the `MainActivity` activity name is changing, so
give the activity an explicit name.

This fixes the performance measurements for XF test.