### PR TITLE
[Xamarin.Android.Build.Test] Rework CreateFauxAndroidSdkDirectory to take ApiInfo[].

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2284,7 +2284,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		public void IfAndroidJarDoesNotExistThrowXA5207 ()
 		{
 			var path = Path.Combine ("temp", TestName);
-			var AndroidSdkDirectory = CreateFauxAndroidSdkDirectory (Path.Combine (path, "android-sdk"), "24.0.1", minApiLevel: 10, maxApiLevel: 26);
+			var AndroidSdkDirectory = CreateFauxAndroidSdkDirectory (Path.Combine (path, "android-sdk"), "24.0.1");
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 				TargetFrameworkVersion = "v8.1",
@@ -2310,15 +2310,16 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		[Test]
 		public void ValidateUseLatestAndroid ()
 		{
-			var path = Path.Combine ("temp", TestName);
-			var androidSdkPath = CreateFauxAndroidSdkDirectory (Path.Combine (path, "android-sdk"),
-				"23.0.6", minApiLevel: 10, maxApiLevel: 28, alphaApiLevel: "P");
-			var referencesPath = CreateFauxReferencesDirectory (Path.Combine (path, "xbuild-frameworks"), new ApiInfo [] {
+			var apis = new ApiInfo [] {
 				new ApiInfo () { Id = "23", Level = 23, Name = "Marshmallow", FrameworkVersion = "v6.0", Stable = true },
 				new ApiInfo () { Id = "26", Level = 26, Name = "Oreo", FrameworkVersion = "v8.0", Stable = true },
 				new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
 				new ApiInfo () { Id = "P", Level = 28, Name = "P", FrameworkVersion="v8.99", Stable = false },
-			});
+			};
+			var path = Path.Combine ("temp", TestName);
+			var androidSdkPath = CreateFauxAndroidSdkDirectory (Path.Combine (path, "android-sdk"),
+					"23.0.6", apis);
+			var referencesPath = CreateFauxReferencesDirectory (Path.Combine (path, "xbuild-frameworks"), apis);
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 				TargetFrameworkVersion = "v8.0",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
@@ -17,9 +17,11 @@ namespace Xamarin.Android.Build.Tests {
 #pragma warning disable 414
 
 		static ApiInfo [] apiInfoSelection = new ApiInfo [] {
+			new ApiInfo () { Id = "25", Level = 25, Name = "Nougat", FrameworkVersion = "v7.1",  Stable = true },
 			new ApiInfo () { Id = "26", Level = 26, Name = "Oreo", FrameworkVersion = "v8.0",  Stable = true  },
 			new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1",  Stable = true  },
 			new ApiInfo () { Id = "P",  Level = 28, Name = "P",    FrameworkVersion = "v8.99", Stable = false },
+			new ApiInfo () { Id = "Z",  Level = 127, Name = "Z",    FrameworkVersion = "v108.1.99", Stable = false },
 		};
 
 		static object [] UseLatestAndroidSdkTestCases = new object [] {
@@ -73,6 +75,17 @@ namespace Xamarin.Android.Build.Tests {
 				/* apis*/ apiInfoSelection,
 				/* useLatestAndroidSdk */ true,
 				/* targetFrameworkVersion */ null,
+				/* expectedTaskResult */ true,
+				/* expectedTargetFramework */ "v8.1",
+				/* expectedError */ "",
+				/* expectedErrorMessage */ "",
+			},
+			new object[] {
+				/* buildtools */   "26.0.3",
+				/* jdk */ "1.8.0",
+				/* apis*/ apiInfoSelection,
+				/* useLatestAndroidSdk */ true,
+				/* targetFrameworkVersion */ "v7.1",
 				/* expectedTaskResult */ true,
 				/* expectedTargetFramework */ "v8.1",
 				/* expectedError */ "",
@@ -140,7 +153,7 @@ namespace Xamarin.Android.Build.Tests {
 		public void UseLatestAndroidSdk (string buildtools, string jdk, ApiInfo[] apis, bool useLatestAndroidSdk, string targetFrameworkVersion, bool expectedTaskResult, string expectedTargetFramework, string expectedError = "", string expectedErrorMessage = "")
 		{
 			var path = Path.Combine ("temp", "UseLatestAndroidSdk_" + Guid.NewGuid ());
-			var androidSdkPath = CreateFauxAndroidSdkDirectory (Path.Combine (path, "android-sdk"), buildtools, minApiLevel: 26, maxApiLevel: 27, alphaApiLevel: "P");
+			var androidSdkPath = CreateFauxAndroidSdkDirectory (Path.Combine (path, "android-sdk"), buildtools, apis);
 			string javaExe = string.Empty;
 			var javaPath = CreateFauxJavaSdkDirectory (Path.Combine (path, "jdk"), jdk, out javaExe);
 			var referencePath = CreateFauxReferencesDirectory (Path.Combine (path, "references"), apis);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -132,7 +132,7 @@ namespace Xamarin.Android.Build.Tests
 				});
 			}
 			foreach (var level in apiLevels ?? defaults.ToArray ()) {
-				var dir = Path.Combine (androidSdkPlatformsPath, $"android-{level}");
+				var dir = Path.Combine (androidSdkPlatformsPath, $"android-{level.Id}");
 				Directory.CreateDirectory(dir);
 				File.WriteAllText (Path.Combine (dir, "android.jar"), "");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -105,7 +105,7 @@ namespace Xamarin.Android.Build.Tests
 			return result;
 		}
 
-		protected string CreateFauxAndroidSdkDirectory (string path, string buildToolsVersion, int minApiLevel = 10, int maxApiLevel = 26, string alphaApiLevel = "")
+		protected string CreateFauxAndroidSdkDirectory (string path, string buildToolsVersion, ApiInfo [] apiLevels = null)
 		{
 			var androidSdkDirectory = Path.Combine (Root, path);
 			var androidSdkToolsPath = Path.Combine (androidSdkDirectory, "tools");
@@ -125,14 +125,15 @@ namespace Xamarin.Android.Build.Tests
 			File.WriteAllText (Path.Combine (androidSdkBuildToolsPath, IsWindows ? "aapt.exe" : "aapt"), "");
 			File.WriteAllText (Path.Combine (androidSdkToolsPath, IsWindows ? "lint.bat" : "lint"), "");
 
-			for (int i=minApiLevel; i < maxApiLevel; i++) {
-				var dir = Path.Combine (androidSdkPlatformsPath, $"android-{i}");
-				Directory.CreateDirectory(dir);
-				File.WriteAllText (Path.Combine (dir, "android.jar"), "");
+			List<ApiInfo> defaults = new List<ApiInfo> ();
+			for (int i = 10; i < 26; i++) {
+				defaults.Add (new ApiInfo () {
+					Id = i.ToString (),
+				});
 			}
-			if (!string.IsNullOrEmpty (alphaApiLevel)) {
-				var dir = Path.Combine (androidSdkPlatformsPath, $"android-{alphaApiLevel}");
-				Directory.CreateDirectory (dir);
+			foreach (var level in apiLevels ?? defaults.ToArray ()) {
+				var dir = Path.Combine (androidSdkPlatformsPath, $"android-{level}");
+				Directory.CreateDirectory(dir);
 				File.WriteAllText (Path.Combine (dir, "android.jar"), "");
 			}
 			return androidSdkDirectory;


### PR DESCRIPTION
Context #1511

For most tests we already define an ApiInfo[] to contain
apis we want to test against. This commit cleans up the helper
methods to make use of the same ApiInfo[] arrays to create
the `android-{Id}` directories.

It also adds unit tests to conver the fix made for #1511.