### PR TITLE
[Xamarin.Android.Build.Tasks] Deploying to Android fails with zipalign error

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -216,7 +216,6 @@ namespace Xamarin.Android.Build.Tests
 			};
 			if (useApkSigner) {
 				proj.SetProperty ("AndroidUseApkSigner", "true");
-	//			proj.SetProperty ("AndroidSdkBuildToolsVersion", "26.0.1");
 			} else {
 				proj.RemoveProperty ("AndroidUseApkSigner");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2612,7 +2612,11 @@ because xbuild doesn't support framework reference assemblies.
 		TimestampAuthorityCertificateAlias="$(JarsignerTimestampAuthorityCertificateAlias)"
 		SigningAlgorithm="$(AndroidApkSigningAlgorithm)"
 	/>
-	<Delete Files="$(ApkFileSigned)" Condition=" '$(AndroidUseApkSigner)' == 'true' "/>
+	<ItemGroup>
+		<ApkAbiFilesSigned Include="$(ApkFileSigned)" Condition="'$(AndroidUseApkSigner)' == 'true'" />
+		<ApkAbiFilesSigned Condition="'$(AndroidCreatePackagePerAbi)' == 'true' And '$(AndroidUseApkSigner)' == 'true' " Include="$(OutDir)$(_AndroidPackage)*-Signed.apk" />
+	</ItemGroup>
+	<Delete Files="%(ApkAbiFilesSigned.FullPath)" Condition=" '$(AndroidUseApkSigner)' == 'true' "/>
 	<AndroidZipAlign Condition=" '$(AndroidUseApkSigner)' == 'true' "
 		Source="%(ApkAbiFilesIntermediate.FullPath)"
 		DestinationDirectory="$(OutDir)"
@@ -2633,8 +2637,8 @@ because xbuild doesn't support framework reference assemblies.
 	/>
 	<Message Text="Signed android package '$(ApkFileSigned)'" />
 	<ItemGroup>
-		<ApkAbiFilesSigned Include="$(ApkFileSigned)" />
-		<ApkAbiFilesSigned Condition="'$(AndroidCreatePackagePerAbi)' == 'true'" Include="$(OutDir)$(_AndroidPackage)*-Signed.apk" />
+		<ApkAbiFilesSigned Include="$(ApkFileSigned)" Condition="'$(AndroidUseApkSigner)' != 'true'" />
+		<ApkAbiFilesSigned Condition="'$(AndroidCreatePackagePerAbi)' == 'true' And '$(AndroidUseApkSigner)' != 'true'" Include="$(OutDir)$(_AndroidPackage)*-Signed.apk" />
 	</ItemGroup>
 	<Delete Files="%(ApkAbiFilesSigned.FullPath)" Condition=" '$(AndroidUseApkSigner)' != 'true' "/>
 	<ItemGroup>


### PR DESCRIPTION
Fixes #1519

The change to introduce `apksigner` had a slight flaw in its
signing logic. It only ever deleted `$(ApkFileSigned)` when
rebuilding the apk. So in the case where we are splitting the
apk by abi.. we didn't delete the other abi specific apks..

This commit fixes up the targets so that we correctly remove
the abi specific apks if they are being used when `$(AndroidUseApkSigner)`
is `true`.