### PR TITLE
Generate source file with XA build paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,17 @@ export LINUX_DISTRO_RELEASE := $(shell lsb_release -r -s || true)
 prepare:: linux-prepare
 endif # $(OS_NAME)=Linux
 
-prepare:: prepare-msbuild
+prepare:: prepare-paths prepare-msbuild
+
+XA_BUILD_PATHS_OUT = bin/Test$(CONFIGURATION)/XABuildPaths.cs
+
+prepare-paths: $(XA_BUILD_PATHS_OUT)
+
+$(XA_BUILD_PATHS_OUT): build-tools/scripts/XABuildPaths.cs.in
+	mkdir -p $(shell dirname $@)
+	sed -e 's;@CONFIGURATION@;$(CONFIGURATION);g' \
+	    -e 's;@TOP_DIRECTORY@;$(shell pwd);g' < $< > $@
+	cat $@
 
 linux-prepare::
 	BINFMT_MISC_TROUBLE="cli win" \

--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -34,6 +34,12 @@
         DestinationFile="$(_TopDir)\Configuration.OperatingSystem.props"
         Replacements="@JAVA_HOME@=$(_JavaSdkDirectory)"
     />
+    <MakeDir Directories="$(_TopDir)\bin\Test$(Configuration)" />
+    <ReplaceFileContents
+        SourceFile="$(MSBuildThisFileDirectory)XABuildPaths.cs.in"
+        DestinationFile="$(_TopDir)\bin\Test$(Configuration)\XABuildPaths.cs"
+        Replacements="@TOP_DIRECTORY@=$(_TopDir);@CONFIGURATION@=$(Configuration)"
+    />
     <MSBuild 
         Projects="$(_TopDir)\build-tools\ThirdPartyNotices\ThirdPartyNotices.csproj"
         Properties="ThirdPartyNoticeFile=$(_TopDir)\ThirdPartyNotices.txt;ThirdPartyNoticeLicenseType=foundation"

--- a/build-tools/scripts/XABuildPaths.cs.in
+++ b/build-tools/scripts/XABuildPaths.cs.in
@@ -1,0 +1,17 @@
+using System;
+using System.IO;
+
+namespace Xamarin.Android.Build
+{
+	public static class Paths
+	{
+		public const string Configuration = "@CONFIGURATION@";
+		public const string TopDirectory = @"@TOP_DIRECTORY@";
+
+		public static readonly string PrefixDirectory = Path.Combine (TopDirectory, "bin", Configuration);
+		public static readonly string BinDirectory = Path.Combine (PrefixDirectory, "bin");
+		public static readonly string XABuildScript = Path.Combine (BinDirectory, "xabuild");
+		public static readonly string XABuildExe = Path.Combine (BinDirectory, "xabuild.exe");
+		public static readonly string TestOutputDirectory = Path.Combine (TopDirectory, "bin", "Test@CONFIGURATION@");
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Diagnostics;
 using Microsoft.Build.Framework;
 
+using XABuildPaths = Xamarin.Android.Build.Paths;
+
 namespace Xamarin.ProjectTools
 {
 	public class ProjectBuilder : Builder
@@ -60,7 +62,7 @@ namespace Xamarin.ProjectTools
 
 			Output = project.CreateBuildOutput (this);
 
-			project.NuGetRestore (Path.Combine (Root, ProjectDirectory), PackagesDirectory);
+			project.NuGetRestore (Path.Combine (XABuildPaths.TestOutputDirectory, ProjectDirectory), PackagesDirectory);
 
 			bool result = BuildInternal (Path.Combine (ProjectDirectory, project.ProjectFilePath), Target, parameters, environmentVariables);
 			built_before = true;
@@ -103,7 +105,7 @@ namespace Xamarin.ProjectTools
 				return;
 			built_before = false;
 
-			var projectDirectory = Path.Combine (Root, ProjectDirectory);
+			var projectDirectory = Path.Combine (XABuildPaths.TestOutputDirectory, ProjectDirectory);
 			if (Directory.Exists (projectDirectory)) {
 				FileSystemUtils.SetDirectoryWriteable (projectDirectory);
 				Directory.Delete (projectDirectory, true);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -7,6 +7,8 @@ using Microsoft.Build.Construction;
 using System.Diagnostics;
 using System.Text;
 
+using XABuildPaths = Xamarin.Android.Build.Paths;
+
 namespace Xamarin.ProjectTools
 {
 	public abstract class XamarinProject 
@@ -190,7 +192,7 @@ namespace Xamarin.ProjectTools
 
 		public string Root {
 			get {
-				return Path.GetDirectoryName (new Uri (typeof (XamarinProject).Assembly.CodeBase).LocalPath);
+				return XABuildPaths.TestOutputDirectory;
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -80,6 +80,9 @@
     <Compile Include="Common\ContentBuilder.cs" />
     <Compile Include="Common\DotNetStandard.cs" />
     <Compile Include="Common\DotNetXamarinProject.cs" />
+    <Compile Include="..\..\..\..\bin\Test$(CONFIGURATION)\XABuildPaths.cs">
+       <Link>XABuildPaths.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Common\" />


### PR DESCRIPTION
The generated file contains paths to the top source directory, `xabuild`,
`xabuild.exe`, current `bin` directory, current test output directory and a
constant with the current configuration name. The paths can be useful in test
projects to find various bits and pieces which are currently referred to using
paths relative to a specific location and thus not really "portable" between
various test projects.