### PR TITLE
[android-toolchain] support Windows again

### DIFF
--- a/build-tools/android-toolchain/android-toolchain-windows.targets
+++ b/build-tools/android-toolchain/android-toolchain-windows.targets
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.AcceptAndroidSdkLicenses" />
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.GitCommitHash" />
+  <Target Name="_CopyBootstrapTasksAssembly"
+      Outputs="$(OutputPath)\Xamarin.Android.Tools.BootstrapTasks.dll">
+    <MSBuild
+        Projects="..\Xamarin.Android.Tools.BootstrapTasks\Xamarin.Android.Tools.BootstrapTasks.csproj"
+        Properties="OutputPath=$(AndroidToolchainDirectory)\"
+    />
+  </Target>
+  <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.UnzipDirectoryChildren" />
+  <PropertyGroup>
+    <BuildDependsOn>
+      ResolveReferences;
+      _CopyBootstrapTasksAssembly;
+      _DownloadItems;
+      _UnzipFiles;
+      _AcceptAndroidSdkLicenses;
+    </BuildDependsOn>
+  </PropertyGroup>
+  <Target Name="_DetermineItems">
+    <CreateItem
+        Include="@(AndroidSdkItem)"
+        Condition=" '%(HostOS)' == '$(HostOS)' Or '%(HostOS)' == '' ">
+      <Output TaskParameter="Include" ItemName="_PlatformAndroidSdkItem"/>
+    </CreateItem>
+    <CreateItem
+        Include="@(AndroidNdkItem)"
+        Condition=" '%(HostOS)' == '$(HostOS)' Or '%(HostOS)' == '' ">
+      <Output TaskParameter="Include" ItemName="_PlatformAndroidNdkItem"/>
+    </CreateItem>
+    <CreateItem
+        Include="@(AntItem)"
+        Condition=" '%(HostOS)' == '$(HostOS)' Or '%(HostOS)' == '' ">
+      <Output TaskParameter="Include" ItemName="_PlatformAntItem"/>
+    </CreateItem>
+    <ItemGroup>
+        <_SdkStampFiles Include="@(_PlatformAndroidSdkItem->'$(AndroidToolchainDirectory)\sdk\.stamp-%(Identity)')" />
+    </ItemGroup>
+    <ItemGroup>
+      <_SdkStampFiles Include="@(_PlatformAntItem->'$(AntDirectory)\.stamp-%(Identity)')" />
+    </ItemGroup>
+    <ItemGroup>
+      <_DownloadedItem Include="@(_PlatformAndroidSdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity).zip')" />
+      <_DownloadedItem Include="@(_PlatformAndroidNdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity).zip')" />
+      <_DownloadedItem Include="@(_PlatformAntItem->'$(AndroidToolchainCacheDirectory)\%(Identity).zip')" />
+    </ItemGroup>
+  </Target>
+  <Target Name="_DownloadItems"
+      DependsOnTargets="_DetermineItems"
+      Outputs="@(_DownloadedItem)">
+    <MakeDir Directories="$(AndroidToolchainCacheDirectory)" />
+    <DownloadUri
+        SourceUris="@(_PlatformAndroidSdkItem->'$(AndroidUri)/%(RelUrl)%(Identity).zip');@(_PlatformAndroidNdkItem->'$(AndroidUri)/%(RelUrl)%(Identity).zip')"
+        DestinationFiles="@(_PlatformAndroidSdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity).zip');@(_PlatformAndroidNdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity).zip')"
+    />
+    <DownloadUri
+        SourceUris="@(_PlatformAntItem->'$(AntUri)/%(RelUrl)%(Identity).zip')"
+        DestinationFiles="@(_PlatformAntItem->'$(AndroidToolchainCacheDirectory)\%(Identity).zip')"
+    />
+  </Target>
+  <Target Name="_UnzipFiles"
+      DependsOnTargets="_DetermineItems"
+      Inputs="@(_DownloadedItem)"
+      Outputs="@(_SdkStampFiles);$(AndroidToolchainDirectory)\ndk\.stamp-ndk">
+    <CreateItem
+        Include="@(_PlatformAndroidSdkItem->'$(AndroidToolchainCacheDirectory)\%(_PlatformAndroidSdkItem.Identity).zip'">
+      <Output TaskParameter="Include" ItemName="_AndroidSdkItems"/>
+    </CreateItem>
+    <CreateItem
+        Include="@(_PlatformAndroidNdkItem->'$(AndroidToolchainCacheDirectory)\%(_PlatformAndroidNdkItem.Identity).zip'"
+        Condition=" '%(HostOS)' == '$(HostOS)' Or '%(HostOS)' == '' ">
+      <Output TaskParameter="Include" ItemName="_AndroidNdkItems"/>
+    </CreateItem>
+
+    <RemoveDir Directories="$(AndroidSdkDirectory);$(AndroidNdkDirectory);$(AntDirectory)" />
+    <MakeDir Directories="$(AndroidSdkDirectory);$(AndroidNdkDirectory);$(AntDirectory)" />
+
+    <UnzipDirectoryChildren
+        HostOS="$(HostOS)"
+        SourceFiles="@(_PlatformAndroidSdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity).zip')"
+        DestinationFolder="$(AndroidToolchainDirectory)\sdk"
+    />
+    <UnzipDirectoryChildren
+        HostOS="$(HostOS)"
+        SourceFiles="@(_PlatformAndroidNdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity).zip')"
+        DestinationFolder="$(AndroidToolchainDirectory)\ndk"
+    />
+    <UnzipDirectoryChildren
+        HostOS="$(HostOS)"
+        SourceFiles="@(_PlatformAntItem->'$(AndroidToolchainCacheDirectory)\%(Identity).zip')"
+        DestinationFolder="$(AntDirectory)"
+    />
+    <Touch
+        Files="@(_SdkStampFiles);$(AndroidToolchainDirectory)\ndk\.stamp-ndk"
+        AlwaysCreate="True"
+    />
+  </Target>
+  <Target Name="_AcceptAndroidSdkLicenses">
+    <AcceptAndroidSdkLicenses AndroidSdkDirectory="$(AndroidSdkDirectory)" JavaSdkDirectory="$(JavaSdkDirectory)" />
+  </Target>
+</Project>

--- a/build-tools/android-toolchain/android-toolchain.csproj
+++ b/build-tools/android-toolchain/android-toolchain.csproj
@@ -6,7 +6,7 @@
     <ProjectGuid>{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA}</ProjectGuid>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
-  <Import Project="android-toolchain.targets" />
+  <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>$(AndroidToolchainDirectory)</OutputPath>
   </PropertyGroup>
@@ -14,15 +14,10 @@
     <OutputPath>$(AndroidToolchainDirectory)</OutputPath>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <BuildDependsOn>
-      ResolveReferences;
-      _CopyBootstrapTasksAssembly;
-      _CreateAndroidToolchains;
-      _CreateMxeToolchains;
-      _AcceptAndroidSdkLicenses;
-    </BuildDependsOn>
-  </PropertyGroup>
+  <Import Project="android-toolchain.projitems" />
+  <Import Project="..\scripts\RequiredPrograms.targets" />
+  <Import Project="android-toolchain.targets" Condition=" '$(HostOS)' != 'Windows' " />
+  <Import Project="android-toolchain-windows.targets" Condition=" '$(HostOS)' == 'Windows' " />
   <ItemGroup>
     <ProjectReference Include="..\xa-prep-tasks\xa-prep-tasks.csproj">
       <Project>{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}</Project>

--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\Configuration.props" />
-  <Import Project="android-toolchain.projitems" />
-  <Import Project="..\scripts\RequiredPrograms.targets" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.AcceptAndroidSdkLicenses" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.GitCommitHash" />
+  <PropertyGroup>
+    <BuildDependsOn>
+      ResolveReferences;
+      _CopyBootstrapTasksAssembly;
+      _CreateAndroidToolchains;
+      _CreateMxeToolchains;
+      _AcceptAndroidSdkLicenses;
+    </BuildDependsOn>
+  </PropertyGroup>
   <Target Name="_CopyBootstrapTasksAssembly"
       Outputs="$(OutputPath)\Xamarin.Android.Tools.BootstrapTasks.dll">
     <MSBuild


### PR DESCRIPTION
Context fef4541

Since the `mono-sdks` took over the installation of `android-toolchain`,
these dependencies are now installed by `make` scripts. This
unfortunately, will not work on Windows since we allow builds with
a vanilla install of Visual Studio 2017 and a simple:
`msbuild Xamarin.Android.sln /t:Prepare` then `/t:Build`.

To fix this, I brought back the old MSBuild code in a
`android-toolchain-windows.targets` file to be used only on Windows. I
had to rearrange how things are imported a bit to get this to work
properly.

This should give us what we want:
- The `mono-sdks` install the Android toolchain on macOS/linux
- Windows still functions as it did before