### PR TITLE
[build] Use `msbuild` by default to build xamarin-android

### DIFF
--- a/Documentation/building/unix-instructions.md
+++ b/Documentation/building/unix-instructions.md
@@ -1,8 +1,8 @@
 # Building Xamarin.Android on Linux and macOS
 
 Building Xamarin.Android on Linux and macOS relies on GNU make and
-MSBuild via the `xbuild` command (within Mono). MSBuild via `msbuild`
-can also be used by setting the `$(MSBUILD)` make variable to `msbuild`.
+MSBuild via the `msbuild` command (within Mono). MSBuild via `xbuild`
+can also be used by setting the `$(MSBUILD)` make variable to `xbuild`.
 
 # Building Xamarin.Android
 
@@ -240,7 +240,7 @@ history.
 The various Mono runtimes -- over *20* of them (!) -- all store object code
 within `src/mono-runtimes/obj/$(Configuration)/TARGET`.
 
-If you change sources within `external/mono`, a top-level `make`/`xbuild`
+If you change sources within `external/mono`, a top-level `make`/`msbuild`
 invocation may not rebuild those mono native binaries. To explicitly rebuild
 *all* Mono runtimes, you must do two things:
 
@@ -256,7 +256,7 @@ an "intermediate" commit in order to trigger a rebuild.)
 The `ForceBuild` target can be executed as:
 
 	# Build and install all runtimes
-	$ xbuild /t:ForceBuild src/mono-runtimes/mono-runtimes.csproj
+	$ msbuild /t:ForceBuild src/mono-runtimes/mono-runtimes.csproj
 
 The `ForceBuild` target will build mono for *all* configured architectures,
 then invoke the `_InstallRuntimes` target when all the mono's have finished
@@ -279,7 +279,7 @@ For example, to rebuild Mono for armeabi-v7a:
 	$ make -C src/mono-runtimes/obj/Debug/armeabi-v7a
 	
 	# This updates bin/$(Configuration)/lib/xamarin.android/xbuild/Xamarin/Android/lib/armeabi-v7a/libmonosgen-2.0.so
-	$ xbuild /t:_InstallRuntimes src/mono-runtimes/mono-runtimes.csproj
+	$ msbuild /t:_InstallRuntimes src/mono-runtimes/mono-runtimes.csproj
 
 
 # How do I rebuild BCL assemblies?
@@ -300,5 +300,5 @@ Once the assemblies have been rebuilt, they can be copied into the appropriate
 Xamarin.Android SDK directory by using the `_InstallBcl` target:
 
 	# This updates bin/$(Configuration)/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v1.0/ASSEMBLY.dll
-	$ xbuild src/mono-runtimes/mono-runtimes.csproj /t:_InstallBcl
+	$ msbuild src/mono-runtimes/mono-runtimes.csproj /t:_InstallBcl
 

--- a/build-tools/api-xml-adjuster/Makefile
+++ b/build-tools/api-xml-adjuster/Makefile
@@ -29,7 +29,7 @@ ANDROID_JAR = $(ANDROID_SDK_PATH)/platforms/android-$(LEVEL)/android.jar
 
 DOCS_DIR_CUR_LEVEL = $(DOCS_DIR)/docs-api-$(LEVEL)
 
-XBUILD = JAVA_INTEROP_PATH=$(JAVA_INTEROP_PATH) xbuild
+XBUILD = JAVA_INTEROP_PATH=$(JAVA_INTEROP_PATH) msbuild
 
 all:
 	for level in $(API_LEVELS) ; do \

--- a/build-tools/debian-metadata/control
+++ b/build-tools/debian-metadata/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/xamarin/xamarin-android
 
 Package: xamarin.android-oss
 Architecture: amd64
-Depends: mono-xbuild (>= 5.2), java8-sdk, ${misc:Depends}, ${shlibs:Depends}
+Depends: msbuild, java8-sdk, ${misc:Depends}, ${shlibs:Depends}
 Description: Xamarin.Android libraries and runtime (host component)
  The best way to build native Android apps.
  .

--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -31,10 +31,10 @@
         ContinueOnError="ErrorAndContinue"
     />
     <ItemGroup>
-      <_RenameTestCasesGlob Include="$(_TopDir)\TestResult-*Tests.xml" />
+      <_RenameNUnitTestCasesGlob Include="$(_TopDir)\TestResult-*Tests.xml" />
     </ItemGroup>
     <PropertyGroup>
-      <_RenamedTestCases>@(_RenameTestCasesGlob)</_RenamedTestCases>
+      <_RenamedTestCases>@(_RenameNUnitTestCasesGlob)</_RenamedTestCases>
     </PropertyGroup>
     <MSBuild
         Projects="$(MSBuildThisFileDirectory)TestApks.targets"
@@ -54,10 +54,10 @@
         Properties="AndroidSdkDirectory=$(AndroidSdkDirectory)"
     />
     <ItemGroup>
-      <_RenameTestCasesGlob Include="$(JavaInteropSourceDirectory)\TestResult-*Tests.xml" />
+      <_RenameJITestCasesGlob Include="$(JavaInteropSourceDirectory)\TestResult-*Tests.xml" />
     </ItemGroup>
     <PropertyGroup>
-      <_RenamedTestCases>@(_RenameTestCasesGlob)</_RenamedTestCases>
+      <_RenamedTestCases>@(_RenameJITestCasesGlob)</_RenamedTestCases>
     </PropertyGroup>
     <MSBuild
         Projects="$(MSBuildThisFileDirectory)TestApks.targets"

--- a/build-tools/scripts/msbuild.mk
+++ b/build-tools/scripts/msbuild.mk
@@ -22,7 +22,7 @@
 #   $(MSBUILD): The MSBuild program to use. Defaults to `xbuild` unless overridden.
 #   $(MSBUILD_FLAGS): Additional MSBuild flags; contains $(CONFIGURATION), $(V), $(MSBUILD_ARGS).
 
-MSBUILD       = xbuild
+MSBUILD       = msbuild
 MSBUILD_FLAGS = /p:Configuration=$(CONFIGURATION) $(MSBUILD_ARGS)
 
 ifeq ($(OS_NAME),Darwin)
@@ -36,7 +36,7 @@ MSBUILD_FLAGS += /v:diag
 endif   # $(V) != 0
 
 ifeq ($(MSBUILD),msbuild)
-USE_MSBUILD   = 1
+export USE_MSBUILD  = 1
 endif   # $(MSBUILD) == msbuild
 
 ifeq ($(USE_MSBUILD),1)

--- a/tools/scripts/xabuild
+++ b/tools/scripts/xabuild
@@ -39,7 +39,7 @@ truepath=$(readlink "$0" || echo "$0")
 prefix="$(cd `dirname "${truepath}"` && pwd)"
 
 if [ -z "$MSBUILD" ] ; then
-	MSBUILD=xbuild
+	MSBUILD=msbuild
 fi
 
 if [ -z "$CONFIGURATION" ]; then


### PR DESCRIPTION
`xbuild` is "wonky" in all manner of ways -- for better or worse
(648aff99, e3abe4b8, 069c65ae).

Worse, our unit tests has a tendency to throw
`ArgumentOutOfRangeException` when running under `xbuild`, e.g. this
recent [`BuildAotApplicationAndBundle("armeabi",True,True)` error][0]
which produces a (temporary, Workspace-local) [log file][1] with:

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/955/testReport/Xamarin.Android.Build.Tests/BuildTest/BuildAotApplicationAndBundle__armeabi__True_True_/
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/ws/xamarin-android/bin/TestRelease/temp/BuildAotApplicationAndBundle_armeabi_True_True/build.log

        …/xamarin-android/bin/Release/lib/xamarin.android/xbuild/Xamarin/Android/Xamarin.Android.Common.targets: error : Error executing task BuildApk: Non-negative number required.
        Parameter name: srcOffset
        Error executing task BuildApk: System.ArgumentOutOfRangeException: Non-negative number required.
        Parameter name: srcOffset
          at System.Buffer.BlockCopy (System.Array src, System.Int32 srcOffset, System.Array dst, System.Int32 dstOffset, System.Int32 count) [0x0009d] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/corlib/ReferenceSources/Buffer.cs:65
          at System.IO.FileStream.WriteSegment (System.Byte[] src, System.Int32 src_offset, System.Int32 count) [0x00023] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.IO/FileStream.cs:995
          at System.IO.FileStream.WriteInternal (System.Byte[] src, System.Int32 offset, System.Int32 count) [0x00099] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.IO/FileStream.cs:647
          at System.IO.FileStream.Write (System.Byte[] array, System.Int32 offset, System.Int32 count) [0x00090] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.IO/FileStream.cs:614
          at System.IO.StreamWriter.Flush (System.Boolean flushStream, System.Boolean flushEncoder) [0x0007e] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/io/streamwriter.cs:318
          at System.IO.StreamWriter.Write (System.Char[] buffer, System.Int32 index, System.Int32 count) [0x00078] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/io/streamwriter.cs:411
          at System.IO.TextWriter.WriteLine (System.String value) [0x00070] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/io/textwriter.cs:490
          at Microsoft.Build.BuildEngine.ConsoleLogger+BuildRecord.WriteLine (System.String message) [0x00051] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/ConsoleLogger.cs:856
          at Microsoft.Build.BuildEngine.ConsoleLogger+BuildRecord.MessageHandler (Microsoft.Build.Framework.BuildMessageEventArgs args) [0x0001c] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/ConsoleLogger.cs:708
          at Microsoft.Build.BuildEngine.ConsoleLogger.MessageHandler (System.Object sender, Microsoft.Build.Framework.BuildMessageEventArgs e) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/ConsoleLogger.cs:344
          at Microsoft.Build.BuildEngine.EventSource.FireMessageRaised (System.Object sender, Microsoft.Build.Framework.BuildMessageEventArgs bmea) [0x00008] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/EventSource.cs:69
          at Microsoft.Build.BuildEngine.BuildEngine.LogMessageEvent (Microsoft.Build.Framework.BuildMessageEventArgs e) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/BuildEngine.cs:130
          at Microsoft.Build.Utilities.TaskLoggingHelper.LogMessageFromText (System.String lineOfText, Microsoft.Build.Framework.MessageImportance messageImportance) [0x00031] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/TaskLoggingHelper.cs:314
          at Microsoft.Build.Utilities.TaskLoggingHelper.LogMessage (Microsoft.Build.Framework.MessageImportance importance, System.String message, System.Object[] messageArgs) [0x0000e] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/TaskLoggingHelper.cs:248
          at (wrapper remoting-invoke-with-check) Microsoft.Build.Utilities.TaskLoggingHelper.LogMessage(Microsoft.Build.Framework.MessageImportance,string,object[])
          at Xamarin.Android.Tasks.MSBuildExtensions.LogDebugTaskItems (Microsoft.Build.Utilities.TaskLoggingHelper log, System.String message, Microsoft.Build.Framework.ITaskItem[] items) [0x00030] in <d1b2bbe8a91444ef81018dda8acfe92a>:0
          at Xamarin.Android.Tasks.BuildApk.Execute () [0x001da] in <d1b2bbe8a91444ef81018dda8acfe92a>:0
          at Microsoft.Build.BuildEngine.TaskEngine.Execute () [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/TaskEngine.cs:134
          at Microsoft.Build.BuildEngine.BuildTask.Execute () [0x0008d] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/Microsoft.Build.Engine/Microsoft.Build.BuildEngine/BuildTask.cs:101

It's hard to have a "green" build when the build system randomly
fails. Furthermore, `xbuild` is no longer maintained, so whatever
bug we're triggering in `xbuild` *will not be fixed*, `xbuild` itself
is ***deprecated***, and the #mono team wants us to use `msbuild`.

Update the build system so that we use `msbuild` by default instead.

Additionally, repair remaining `xbuild`-isms, in particular:

In `msbuild`, item groups are "cumulative". For example, because both
the `RunNUnitTests` and `RunJavaInteropTests` targets updated the
`@(_RenameTestCasesGlob)` item group, when `RunJavaInteropTests` was
executed it contained items from the `RunNUnitTests` execution, which
was unexpected and resulted in a test execution failure:

        …/build-tools/scripts/TestApks.targets(221,5): error : Could not find file "/Users/builder/jenkins/workspace/xamarin-android-msbuild-pr-builder/TestResult-Xamarin.Android.Build.Tests.xml"

`TestResult-Xamarin.Android.Build.Tests.xml` didn't exist during the
execution of the `RunJavaInteropTests` because it was deleted/renamed
as part of the `RunNUnitTests` target.

There is also an unintended `make`-ism: `$(USE_MSBUILD)` is used by
various parts of the build system *and unit tests* to determine
whether or not `msbuild` or `xbuild` is being used, and change
behavior accordingly. Unfortunately, `$(USE_MSBUILD)` wasn't being
[`export`ed][2], and thus wasn't visible to child processes.
Consequently, even though `msbuild` was being used for the build
and unit test execution, the unit tests thought that `xbuild`-based
outputs should be used for checks. This resulted in at least three
`Xamarin.Android.Build.Tests` failures:

[2]: https://www.gnu.org/software/make/manual/html_node/Variables_002fRecursion.html#Variables_002fRecursion

  * `Xamarin.Android.Build.Tests.AndroidUpdateResourcesTest.BuildAppWithManagedResourceParserAndLibraries / Debug`
  * `Xamarin.Android.Build.Tests.BuildTest.CheckJavaError / Debug`
  * `Xamarin.Android.Build.Tests.BuildTest.BuildAMassiveApp / Debug`

If necessary, `xbuild` can continue to be used to build things:

        make all MSBUILD=xbuild

However, we make no guarantees for how long `xbuild` will continue to
work going forward.