### PR TITLE
[Xamarin.Android.Build.Tasks] plumbing for coded warnings

### DIFF
--- a/Documentation/guides/messages/apt0000.md
+++ b/Documentation/guides/messages/apt0000.md
@@ -1,0 +1,12 @@
+# Compiler Error/Warning APT0000
+
+This message indicates that `aapt` (Android Asset Packaging Tool) reported an error or warning. `aapt` is part of the Android SDK and is used internally by Xamarin.Android to process and compile resources into binary assets. Learn more about `aapt` and Android resources from the [Android documentation](https://developer.android.com/guide/topics/resources/accessing-resources.html).
+
+Errors reported by `aapt` are very much outside of Xamarin.Android's control, so a general error code of `APT0000` is used reporting the exact message coming from `aapt`.
+
+A few common messages include:
+- `error APT0000: res\drawable\image (1).png: Invalid file name: must contain only [a-z0-9_.]`
+- `error APT0000: Resource entry resource_name is already defined.`
+- `error APT0000: No resource found that matches the given name (at 'resource_name' with value '@string/foo').`
+- `error APT0000: invalid resource directory name: obj\Debug\dir with spaces "dir with spaces".`
+- `warning APT0000: warning: string 'resource_name' has no default translation.`

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -433,7 +433,7 @@ namespace Xamarin.Android.Tasks
 					return;
 				}
 				if (level.Contains ("warning")) {
-					LogWarning (singleLine);
+					LogCodedWarning ("APT0000", singleLine);
 					return;
 				}
 
@@ -450,15 +450,15 @@ namespace Xamarin.Android.Tasks
 					message = message.Substring ("error: ".Length);
 
 				if (level.Contains ("error") || (line != 0 && !string.IsNullOrEmpty (file))) {
-					LogError ("APT0000", message, file, line);
+					LogCodedError ("APT0000", message, file, line);
 					return;
 				}
 			}
 
 			if (!apptResult) {
-				LogError ("APT0000", string.Format ("{0} \"{1}\".", singleLine.Trim (), singleLine.Substring (singleLine.LastIndexOfAny (new char [] { '\\', '/' }) + 1)), ToolName);
+				LogCodedError ("APT0000", string.Format ("{0} \"{1}\".", singleLine.Trim (), singleLine.Substring (singleLine.LastIndexOfAny (new char [] { '\\', '/' }) + 1)), ToolName);
 			} else {
-				LogWarning (singleLine);
+				LogCodedWarning ("APT0000", singleLine);
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AsyncTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AsyncTask.cs
@@ -134,25 +134,25 @@ namespace Xamarin.Android.Tasks
 
 		public void LogError (string message)
 		{
-			LogError (code: null, message: message, file: null, lineNumber: 0);
+			LogCodedError (code: null, message: message, file: null, lineNumber: 0);
 		}
 
-		public void LogError (string message, params object[] messageArgs)
+		public void LogError (string message, params object [] messageArgs)
 		{
-			LogError (code: null, message: string.Format (message, messageArgs));
+			LogCodedError (code: null, message: string.Format (message, messageArgs));
 		}
 
 		public void LogCodedError (string code, string message)
 		{
-			LogError (code: code, message: message, file: null, lineNumber: 0);
+			LogCodedError (code: code, message: message, file: null, lineNumber: 0);
 		}
 
-		public void LogCodedError (string code, string message, params object[] messageArgs)
+		public void LogCodedError (string code, string message, params object [] messageArgs)
 		{
-			LogError (code: code, message: string.Format (message, messageArgs), file: null, lineNumber: 0);
+			LogCodedError (code: code, message: string.Format (message, messageArgs), file: null, lineNumber: 0);
 		}
 
-		public void LogError (string code, string message, string file = null, int lineNumber = 0)
+		public void LogCodedError (string code, string message, string file, int lineNumber)
 		{
 			if (UIThreadId == Thread.CurrentThread.ManagedThreadId) {
 				#pragma warning disable 618
@@ -186,24 +186,49 @@ namespace Xamarin.Android.Tasks
 			EnqueueMessage (errorMessageQueue, data, errorDataAvailable);
 		}
 
-		public void LogWarning (string message, params object[] messageArgs)
+		public void LogWarning (string message)
 		{
-			LogWarning (string.Format (message, messageArgs));
+			LogCodedWarning (code: null, message: message, file: null, lineNumber: 0);
 		}
 
-		public void LogWarning (string message)
+		public void LogWarning (string message, params object[] messageArgs)
+		{
+			LogCodedWarning (code: null, message: string.Format (message, messageArgs));
+		}
+
+		public void LogCodedWarning (string code, string message)
+		{
+			LogCodedWarning (code: code, message: message, file: null, lineNumber: 0);
+		}
+
+		public void LogCodedWarning (string code, string message, params object [] messageArgs)
+		{
+			LogCodedWarning (code: code, message: string.Format (message, messageArgs), file: null, lineNumber: 0);
+		}
+
+		public void LogCodedWarning (string code, string message, string file, int lineNumber)
 		{
 			if (UIThreadId == Thread.CurrentThread.ManagedThreadId) {
 				#pragma warning disable 618
-				Log.LogWarning (message);
+				Log.LogWarning (
+					subcategory: null,
+					warningCode: code,
+					helpKeyword: null,
+					file: file,
+					lineNumber: lineNumber,
+					columnNumber: 0,
+					endLineNumber: 0,
+					endColumnNumber: 0,
+					message: message
+				);
 				return;
 				#pragma warning restore 618
 			}
 			var data = new BuildWarningEventArgs (
 					subcategory: null,
-					code: null,
-					file: null,
-					lineNumber: 0,
+					code: code,
+					file: file,
+					lineNumber: lineNumber,
 					columnNumber: 0,
 					endLineNumber: 0,
 					endColumnNumber: 0,
@@ -298,7 +323,7 @@ namespace Xamarin.Android.Tasks
 					case WaitHandleIndex.WarningDataAvailable:
 						LogInternal<BuildWarningEventArgs> (warningMessageQueue, (e) => {
 							#pragma warning disable 618
-							Log.LogWarning (e.Message);
+							Log.LogCodedWarning (e.Code, file: e.File, lineNumber: e.LineNumber, message: e.Message);
 							#pragma warning restore 618
 						}, warningDataAvailable);
 						break;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -231,9 +231,9 @@ namespace Xamarin.Android.Tasks
 					string missingAssembly = Path.GetFileNameWithoutExtension (ex.FileName);
 					string message = $"Can not resolve reference: `{missingAssembly}`, referenced by {references}.";
 					if (MonoAndroidHelper.IsFrameworkAssembly (ex.FileName)) {
-						LogError ("XA2002", $"{message} Perhaps it doesn't exist in the Mono for Android profile?");
+						LogCodedError ("XA2002", $"{message} Perhaps it doesn't exist in the Mono for Android profile?");
 					} else {
-						LogError ("XA2002", $"{message} Please add a NuGet package or assembly reference for `{missingAssembly}`, or remove the reference to `{resolutionPath [0]}`.");
+						LogCodedError ("XA2002", $"{message} Please add a NuGet package or assembly reference for `{missingAssembly}`, or remove the reference to `{resolutionPath [0]}`.");
 					}
 					return;
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1144,7 +1144,7 @@ namespace Lib1 {
 					Assert.Ignore ($"Skipping Test. TargetFrameworkVersion {proj.TargetFrameworkVersion} was not available.");
 				}
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
-				StringAssertEx.Contains ("warning : max res 26, skipping values-v27", builder.LastBuildOutput, "Build output should contain a warning about 'max res 26, skipping values-v27'");
+				StringAssertEx.Contains ("warning APT0000: warning : max res 26, skipping values-v27", builder.LastBuildOutput, "Build output should contain an APT0000 warning about 'max res 26, skipping values-v27'");
 			}
 		}
 
@@ -1160,15 +1160,16 @@ namespace Lib1 {
 				},
 			};
 
+			string name = "test";
 			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values-fr\\Strings.xml") {
-				TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
+				TextContent = () => $@"<?xml version=""1.0"" encoding=""utf-8""?>
 <resources>
-  <string name=""test"" >Test</string>
+  <string name=""{name}"" >Test</string>
 </resources>",
 			});
 			using (var builder = CreateApkBuilder (path, false, false)) {
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
-				StringAssertEx.Contains ("has no default translation", builder.LastBuildOutput, "Build output should contain a warning about 'no default translation'");
+				StringAssertEx.Contains ($"warning APT0000: warning: string '{name}' has no default translation.", builder.LastBuildOutput, "Build output should contain an APT0000 warning about 'no default translation'");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MSBuildExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MSBuildExtensions.cs
@@ -118,17 +118,12 @@ namespace Xamarin.Android.Tasks
 
 		public static void LogCodedWarning (this TaskLoggingHelper log, string code, string message, params object [] messageArgs)
 		{
-			log.LogWarning (
-					subcategory:        string.Empty,
-					warningCode:        code,
-					helpKeyword:        string.Empty,
-					file:               string.Empty,
-					lineNumber:         0,
-					columnNumber:       0,
-					endLineNumber:      0,
-					endColumnNumber:    0,
-					message:            message,
-					messageArgs:        messageArgs);
+			log.LogWarning (string.Empty, code, string.Empty, string.Empty, 0, 0, 0, 0, message, messageArgs);
+		}
+
+		public static void LogCodedWarning (this TaskLoggingHelper log, string code, string file, int lineNumber, string message, params object [] messageArgs)
+		{
+			log.LogWarning (string.Empty, code, string.Empty, file, lineNumber, 0, 0, 0, message, messageArgs);
 		}
 
 		public static Action<TraceLevel, string> CreateTaskLogger (this Task task)


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/1560

To get started in fixing #1560, some of our helper methods need updating
in order to completely support coded warnings in MSBuild tasks.

- `AsyncTask` needs "background-thread-safe" versions of `LogWarning`
that allow us to specify error codes. The `WaitForCompletion` method
also needed to call `LogCodedWarning` internally.
- Overloads of `LogError` and `LogWarning` that specify an error code
are renamed to `LogCodedError` and `LogCodedWarning`. This will help us
identify log messages that need error codes by searching for `LogError`
- `MSBuildExtensions` need proper method overloads for
`LogCodedWarning`, I copied what we have for `LogCodedError` so
`LogCodedWarning` will match it exactly

Changes to `<Aapt />`, as a guinea pig:
- All warnings will report APT0000
- Updated tests where appropriate, note that MSBuild appends
`warning APT0000:` and `aapt` prints its own `warning :` afterward
- It doesn't look like we can make an error coming from `aapt` any more
specific than `APT0000`, but open to suggestions
- Added documentation for `APT0000`, which is about as helpful as it can
be. It at least explains what `aapt` is and links to the Android
documentation, listing a few messages returned by `aapt` as examples.

Other fixes:
- Since the overload for an error code with `AsyncTask.LogError` was
removed, these needed to change to `LogCodedError` in
`<ResolveAssemblies />`