### PR TITLE
[Xamarin.Android.Build.Tests] Use `MSBUILD` environment variable rather than `USE_MSBUILD`.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -168,12 +168,8 @@ namespace Xamarin.Android.Tasks
 			if (!outdir.Exists)
 				outdir.Create ();
 
-			foreach (var assembly in Assemblies) {
-				Log.LogDebugMessage ($"Loading {assembly.ItemSpec}");
-				var asm = res.Load (assembly.ItemSpec);
-				if (asm == null)
-					Log.LogDebugMessage ($"Failed to Load {assembly.ItemSpec}");
-			}
+			foreach (var assembly in Assemblies)
+				res.Load (assembly.ItemSpec);
 
 			bool updated = false;
 			// FIXME: reorder references by import priority (not sure how to do that yet)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -168,8 +168,12 @@ namespace Xamarin.Android.Tasks
 			if (!outdir.Exists)
 				outdir.Create ();
 
-			foreach (var assembly in Assemblies)
-				res.Load (assembly.ItemSpec);
+			foreach (var assembly in Assemblies) {
+				Log.LogDebugMessage ($"Loading {assembly.ItemSpec}");
+				var asm = res.Load (assembly.ItemSpec);
+				if (asm == null)
+					Log.LogDebugMessage ($"Failed to Load {assembly.ItemSpec}");
+			}
 
 			bool updated = false;
 			// FIXME: reorder references by import priority (not sure how to do that yet)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -61,8 +61,8 @@ namespace Xamarin.ProjectTools
 				RunningMSBuild = true;
 				string xabuild;
 				if (IsUnix) {
-					var useMSBuild = Environment.GetEnvironmentVariable ("MSBUILD");
-					if (!string.IsNullOrEmpty (useMSBuild) && useMSBuild == "xbuild" && !RequiresMSBuild) {
+					var msBuild = Environment.GetEnvironmentVariable ("MSBUILD");
+					if (!string.IsNullOrEmpty (msBuild) && msBuild == "xbuild" && !RequiresMSBuild) {
 						RunningMSBuild = false;
 					}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -61,8 +61,8 @@ namespace Xamarin.ProjectTools
 				RunningMSBuild = true;
 				string xabuild;
 				if (IsUnix) {
-					var useMSBuild = Environment.GetEnvironmentVariable ("USE_MSBUILD");
-					if (!string.IsNullOrEmpty (useMSBuild) && useMSBuild == "0" && !RequiresMSBuild) {
+					var useMSBuild = Environment.GetEnvironmentVariable ("MSBUILD");
+					if (!string.IsNullOrEmpty (useMSBuild) && useMSBuild == "xbuild" && !RequiresMSBuild) {
 						RunningMSBuild = false;
 					}
 


### PR DESCRIPTION
In our old unit test system we called into msbuild/xbuild
directly. With our new system we make use of `xabuild`. This
is a wrapper around msbuild/xbuild which sets up the
xamarin-android environment.

For the old tests we passed `USE_MSBUILD` to control if we neeed
to use msbuild or xbuild. However with `xabuild` we pass the
`MSBUILD` environment varioable. This can be `msbuild` or `xbuild`
rather than a `1` or `0`.

The problem is the old variable was still being used so there
was a mismatch between what the tests were expecting and what
was being used. So take

	MSBUILD=msbuild
	USE_MSBUILD=0

The tests would expect to be using xbuild and will therefore check
for xbuild type messages and behaviour. But xabuild would be using
msbuild. This results in weird errors.

So lets get rid of the `USE_MSBUILD` usage and just use the `MSBUILD`
envionment variable to decide which system we are using.