### PR TITLE
[tests] fix Windows test failures

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -206,7 +206,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void CheckSignApk ([Values(true, false)] bool useApkSigner, [Values(true, false)] bool perAbiApk)
 		{
-			string ext = Environment.OSVersion.Platform != PlatformID.Unix ? ".exe" : "";
+			string ext = Environment.OSVersion.Platform != PlatformID.Unix ? ".bat" : "";
 			var foundApkSigner = Directory.EnumerateDirectories (Path.Combine (AndroidSdkPath, "build-tools")).Any (dir => Directory.EnumerateFiles (dir, "apksigner"+ ext).Any ());
 			if (useApkSigner && !foundApkSigner) {
 				Assert.Ignore ("Skipping test. Required build-tools verison which contains apksigner is not installed.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -68,7 +68,7 @@ namespace Xamarin.Android.Build.Tests
 
 		public static string AndroidSdkPath {
 			get {
-				var home = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
+				var home = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
 				var sdkPath = Environment.GetEnvironmentVariable ("ANDROID_SDK_PATH");
 				if (string.IsNullOrEmpty (sdkPath))
 					sdkPath = Path.Combine (home, "android-toolchain", "sdk");


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=1605061&tab=ms.vss-test-web.test-result-details&_a=summary

Noticed these are probably failing since 41bc8ff, but the build was
not working overall on Windows at the time--so we didn't catch it.

The `CheckSignApk` test had a couple issues:
- `C:\Users\myuser\Documents\android-toolchain\sdk` was being used as
the location of the Android SDK on Windows. `BaseTest` needed to use
`Environment.SpecialFolder.UserProfile` instead of `Personal`.
- `apksigner` is `apksigner.bat` instead of `apksigner.exe` on Windows