### PR TITLE
[build] Generate XABuildPaths.cs for all $(CONFIGURATIONS)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,16 +66,6 @@ endif # $(OS_NAME)=Linux
 
 prepare:: prepare-paths prepare-msbuild
 
-XA_BUILD_PATHS_OUT = bin/Test$(CONFIGURATION)/XABuildPaths.cs
-
-prepare-paths: $(XA_BUILD_PATHS_OUT)
-
-$(XA_BUILD_PATHS_OUT): build-tools/scripts/XABuildPaths.cs.in
-	mkdir -p $(shell dirname $@)
-	sed -e 's;@CONFIGURATION@;$(CONFIGURATION);g' \
-	    -e 's;@TOP_DIRECTORY@;$(shell pwd);g' < $< > $@
-	cat $@
-
 linux-prepare::
 	BINFMT_MISC_TROUBLE="cli win" \
 	BINFMT_WARN=no ; \
@@ -137,6 +127,18 @@ include build-tools/scripts/Packaging.mk
 include tests/api-compatibility/api-compatibility.mk
 
 topdir  := $(shell pwd)
+
+
+XA_BUILD_PATHS_OUT = $(CONFIGURATIONS:%=bin/Test%/XABuildPaths.cs)
+
+prepare-paths: $(XA_BUILD_PATHS_OUT)
+
+$(XA_BUILD_PATHS_OUT): bin/Test%/XABuildPaths.cs: build-tools/scripts/XABuildPaths.cs.in
+	mkdir -p $(shell dirname $@)
+	sed -e 's;@CONFIGURATION@;$*;g' \
+	    -e 's;@TOP_DIRECTORY@;$(topdir);g' < $< > $@
+	cat $@
+
 
 # Usage: $(call CALL_CREATE_THIRD_PARTY_NOTICES,configuration,path,licenseType,includeExternalDeps,includeBuildDeps)
 define CREATE_THIRD_PARTY_NOTICES


### PR DESCRIPTION
Commit e937f9b4 broke `make prepare` for the Release configuration.
Jenkins assumes that `make prepare` is a single invocation for *both*
Debug & Release builds; see e.g. `make prepare-external`:

	$(foreach conf, $(CONFIGURATIONS), ...)

Commit e937f9b4 didn't abide by this requirement, and thus only
generated `XABuildPaths.cs` for the Debug configuration. As such, when
attempting to build in the Release configuration, [things broke][0]:

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/958/

	CSC: error CS2001: Source file '…/xamarin-android/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/../../../../bin/TestRelease/XABuildPaths.cs' could not be found.

The fix is to update `make prepare-paths` so that it generates
`bin/Test$(Configuration)/XABuildPaths.cs` for *all*
`$(CONFIGURATIONS)` values.