### PR TITLE
[tests] nuget output and test names go to output file

### DIFF
--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -26,7 +26,7 @@
   <Target Name="RunNUnitTests">
     <SetEnvironmentVariable Name="USE_MSBUILD" Value="0" Condition=" '$(USE_MSBUILD)' == '' " />
     <Exec
-        Command="$(_NUnit) $(NUNIT_EXTRA) %(_TestAssembly.Identity) $(_Test) --result=&quot;TestResult-%(Filename).xml;format=nunit2&quot; --output=&quot;bin\Test$(Configuration)\TestOutput-%(Filename).txt&quot;"
+        Command="$(_NUnit) $(NUNIT_EXTRA) %(_TestAssembly.Identity) $(_Test) --labels=All --result=&quot;TestResult-%(Filename).xml;format=nunit2&quot; --output=&quot;bin\Test$(Configuration)\TestOutput-%(Filename).txt&quot;"
         WorkingDirectory="$(_TopDir)"
         ContinueOnError="ErrorAndContinue"
     />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -286,10 +286,21 @@ namespace Xamarin.ProjectTools
 			var psi = new ProcessStartInfo (isWindows ? nuget : "mono") {
 				Arguments = $"{(isWindows ? "" : "\"" + nuget + "\"")} restore -PackagesDirectory \"{Path.Combine (Root, directory, "..", "packages")}\" \"{Path.Combine (Root, directory, "packages.config")}\"",
 				CreateNoWindow = true,
+				UseShellExecute = false,
 				WindowStyle = ProcessWindowStyle.Hidden,
+				RedirectStandardError = true,
+				RedirectStandardOutput = true,
 			};
-			var process = Process.Start (psi);
-			process.WaitForExit ();
+			using (var process = new Process {
+				StartInfo = psi,
+			}) {
+				process.OutputDataReceived += (sender, e) => Console.WriteLine (e.Data);
+				process.ErrorDataReceived += (sender, e) => Console.Error.WriteLine (e.Data);
+				process.Start ();
+				process.BeginOutputReadLine ();
+				process.BeginErrorReadLine ();
+				process.WaitForExit ();
+			}
 		}
 
 		public string ProcessSourceTemplate (string source)


### PR DESCRIPTION
Previously if you ran the NUnit tests you would get nuget output such as:
```
Restoring NuGet package Xamarin.Android.Support.v7.Cardview.24.2.1.
Adding package 'Xamarin.Android.Support.v7.Cardview.24.2.1' to folder 'C:\Users\myuser\Desktop\Git\xamarin-android\bin\TestDebug\temp\packages'
Added package 'Xamarin.Android.Support.v7.Cardview.24.2.1' to folder 'C:\Users\myuser\Desktop\Git\xamarin-android\bin\TestDebug\temp\packages'

NuGet Config files used:
    C:\Users\myuser\AppData\Roaming\NuGet\NuGet.Config
    C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config
    C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.Fallback.config

Feeds used:
    C:\Users\myuser\.nuget\packages\
    https://api.nuget.org/v3/index.json
    C:\Users\myuser\Desktop\NuGet
    https://www.myget.org/F/xamarin-essentials/api/v3/index.json
    C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\

Installed:
    1 package(s) to packages.config projects
```

`Xamarin.ProjectTools` was not redirecting the output of nuget, and so
we were getting the odd behavior of seeing all nuget output at the
console. By redirecting the output to `System.Console`, the output now
correctly goes to `TestOutput-Xamarin.Android.Build.Tests.txt`.

I also added the `--labels=All` switch to the `nunit-console` command,
which will log each test completion such as:

    => Xamarin.Android.Build.Tests.BuildTest.BuildAfterAddingNuget