### PR TITLE
Revert "[mono-sdks] Pass the Host{Cc,Cxx}{32,64} parameters"

### DIFF
--- a/src/mono-runtimes/mono-runtimes.projitems
+++ b/src/mono-runtimes/mono-runtimes.projitems
@@ -171,8 +171,6 @@
   <ItemGroup>
     <!-- LLVM -->
     <_LlvmRuntime Include="llvm32" Condition=" ($(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':armeabi:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':x86:'))) ">
-      <Cc>$(HostCc32)</Cc>
-      <Cxx>$(HostCxx32)</Cxx>
       <ExeSuffix></ExeSuffix>
       <InstallBinaries>true</InstallBinaries>
       <InstallPath Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">Darwin/</InstallPath>
@@ -180,8 +178,6 @@
     </_LlvmRuntime>
 
     <_LlvmRuntime Include="llvm64" Condition=" ($(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':arm64:')) Or $(AndroidSupportedTargetAotAbisForConditionalChecks.Contains (':x86_64:'))) And '$(_LlvmCanBuild64)' == 'yes' ">
-      <Cc>$(HostCc64)</Cc>
-      <Cxx>$(HostCxx64)</Cxx>
       <ExeSuffix></ExeSuffix>
       <InstallBinaries>true</InstallBinaries>
       <InstallPath Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">Darwin/</InstallPath>

--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -166,7 +166,7 @@
           Outputs="@(_LlvmSourceBinary)"
           Condition=" '@(_LlvmRuntime)' != '' ">
     <Exec
-        Command="make $(MakeConcurrency) package-llvm-%(_LlvmRuntime.Identity) $(_MonoSdksParameters) CC=&quot;%(_LlvmRuntime.Cc)&quot; CXX=&quot;%(_LlvmRuntime.Cxx)&quot;"
+        Command="make $(MakeConcurrency) package-llvm-%(_LlvmRuntime.Identity) $(_MonoSdksParameters)"
         IgnoreStandardErrorWarningFormat="True"
         WorkingDirectory="$(MonoSourceFullPath)\sdks\builds"
     />
@@ -839,7 +839,6 @@
         WorkingDirectory="$(MonoSourceFullPath)\sdks\builds"
     />
     <Exec
-        Condition=" '@(_LlvmRuntime)' != '' "
         Command="make $(MakeConcurrency) clean-llvm-%(_LlvmRuntime.Identity) $(_MonoSdksParameters)"
         IgnoreStandardErrorWarningFormat="True"
         WorkingDirectory="$(MonoSourceFullPath)\sdks\builds"


### PR DESCRIPTION
Commit 9a985136 [broke the macOS build][0]: 

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/961/

	make -j4 package-llvm-llvmwin32 CONFIGURATION=debug IGNORE_PROVISION_MXE=true IGNORE_PROVISION_ANDROID=true IGNORE_PACKAGE_LLVM=true ANDROID_TOOLCHAIN_DIR="/Users/builder/android-toolchain" ANDROID_TOOLCHAIN_CACHE_DIR="/Users/builder/android-archives" ANDROID_TOOLCHAIN_PREFIX="/Users/builder/android-toolchain/toolchains" ANDROID_BUILD_TOOLS_VERSION="28-rc1" ANDROID_BUILD_TOOLS_DIR="28.0.0-rc1" LLVM_SRC="…/xamarin-android/src/mono-runtimes/../../external/llvm" MXE_PREFIX_DIR="/Users/builder/android-toolchain" MXE_SRC="…/xamarin-android/src/mono-runtimes/../../external/mxe" CC="" CXX=""
	...
	mkdir: /Users/builder/jenkins/workspace/xamarin-android/xamarin-android/external/mono/sdks/builds/llvm-llvmwin32/BuildTools/lib/Support/Release: File exists
	...
	/bin/sh: -I/Users/builder/jenkins/workspace/xamarin-android/xamarin-android/external/llvm/include: No such file or directory
	...
	rm: /Users/builder/jenkins/workspace/xamarin-android/xamarin-android/external/mono/sdks/builds/llvm-llvmwin32/BuildTools/lib/Support/Release/APInt.d.tmp: No such file or directory
	make[5]: *** [/Users/builder/jenkins/workspace/xamarin-android/xamarin-android/external/mono/sdks/builds/llvm-llvmwin32/BuildTools/lib/Support/Release/APSInt.o] Error 1
	...
	error MSB3073: The command "make -j4 …" exited with code 2. […/xamarin-android/src/mono-runtimes/mono-runtimes.csproj]

Revert commit 9a985136 so we can fix it at our liesure.