### PR TITLE
[Xamarin.Android.Build.Tests] Fix CheckMaxResWarningIsEmittedAsAWarning test.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1144,7 +1144,8 @@ namespace Lib1 {
 					Assert.Ignore ($"Skipping Test. TargetFrameworkVersion {proj.TargetFrameworkVersion} was not available.");
 				}
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
-				StringAssertEx.Contains ("warning APT0000: warning : max res 26, skipping values-v27", builder.LastBuildOutput, "Build output should contain an APT0000 warning about 'max res 26, skipping values-v27'");
+				var expected = builder.RunningMSBuild ? "warning APT0000: max res 26, skipping values-v27" : "warning APT0000: warning : max res 26, skipping values-v27";
+				StringAssertEx.Contains (expected, builder.LastBuildOutput, "Build output should contain an APT0000 warning about 'max res 26, skipping values-v27'");
 			}
 		}
 


### PR DESCRIPTION
Turns out MSbuild was producing a slightly different warning message
to xbuild for `CheckMaxResWarningIsEmittedAsAWarning`.

We expected

	warning APT0000: warning : max res 26, skipping values-v27

but got

	warning APT0000: max res 26, skipping values-v27

so the test failed.