### PR TITLE
Revert "[tests] Report errors last in `RunApkTests`"

### DIFF
--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -37,25 +37,19 @@
       <_RenamedTestCases>@(_RenameNUnitTestCasesGlob)</_RenamedTestCases>
     </PropertyGroup>
     <MSBuild
-        ContinueOnError="ErrorAndContinue"
         Projects="$(MSBuildThisFileDirectory)TestApks.targets"
         Targets="RenameTestCases"
         Properties="Configuration=$(Configuration);RenameTestCasesGlob=$(_RenamedTestCases)"
     />
   </Target>
   <Target Name="RunJavaInteropTests">
-    <MSBuild
-        Condition=" '$(HostOS)' == 'Windows' "
-        ContinueOnError="ErrorAndContinue"
-        Projects="$(JavaInteropSourceDirectory)\Java.Interop.sln"
-    />
+    <MSBuild Projects="$(JavaInteropSourceDirectory)\Java.Interop.sln" Condition=" '$(HostOS)' == 'Windows' " />
     <Exec
         Command ="make -C &quot;$(JavaInteropSourceDirectory)&quot; CONFIGURATION=$(Configuration) all"
         Condition=" '$(HostOS)' != 'Windows' "
     />
     <SetEnvironmentVariable Name="ANDROID_SDK_PATH" Value="$(AndroidSdkFullPath)" />
     <MSBuild 
-        ContinueOnError="ErrorAndContinue"
         Projects="$(JavaInteropSourceDirectory)\build-tools\scripts\RunNUnitTests.targets"
         Properties="AndroidSdkDirectory=$(AndroidSdkDirectory)"
     />
@@ -66,7 +60,6 @@
       <_RenamedTestCases>@(_RenameJITestCasesGlob)</_RenamedTestCases>
     </PropertyGroup>
     <MSBuild
-        ContinueOnError="ErrorAndContinue"
         Projects="$(MSBuildThisFileDirectory)TestApks.targets"
         Targets="RenameTestCases"
         Properties="Configuration=$(Configuration);RenameTestCasesGlob=$(_RenamedTestCases)"
@@ -79,16 +72,12 @@
   </Target>
   <Target Name="RunApkTests">
     <Exec Command="$(_XABuild) %(_ApkTestProject.Identity) /t:SignAndroidPackage $(_XABuildProperties)" />
-    <MSBuild
-        ContinueOnError="ErrorAndContinue"
-        Projects="$(_TopDir)\tests\RunApkTests.targets"
-    />
+    <MSBuild Projects="$(_TopDir)\tests\RunApkTests.targets" />
     <Exec 
         Command="$(_XABuild) %(_ApkTestProjectAot.Identity) /t:SignAndroidPackage $(_XABuildProperties) /p:AotAssemblies=True"
         Condition=" '$(Configuration)' == 'Release' "
     />
     <MSBuild 
-        ContinueOnError="ErrorAndContinue"
         Projects="$(_TopDir)\tests\RunApkTests.targets"
         Condition=" '$(Configuration)' == 'Release' "
         Properties="AotAssemblies=True"

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -117,8 +117,6 @@
         ContinueOnError="True"
         Command="kill -KILL $(_EmuPid)"
     />
-  </Target>
-  <Target Name="ReportComponentFailures">
     <Error
         Condition="'@(_FailedComponent)' != ''"
         Text="Execution of the following components did not complete successfully: @(_FailedComponent->'%(Identity)', ', ')"

--- a/tests/RunApkTests.targets
+++ b/tests/RunApkTests.targets
@@ -30,7 +30,6 @@
       RunTestApks;
       ReleaseAndroidTarget;
       RenameApkTestCases;
-      ReportComponentFailures;
     </RunApkTestsDependsOn>
   </PropertyGroup>
   <Target Name="RunApkTests"


### PR DESCRIPTION
Reverts commit 4a85391f80154c7181b1eb4aeccbbb6e00296084

Commit 4a85391f [broke the build][0]:

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/967/

	xamarin-android/build-tools/scripts/TestApks.targets(223,5): error : Root element is missing
	...
	ERROR: Step ‘Publish xUnit test result report’ aborted due to exception: 
	org.xml.sax.SAXParseException; lineNumber: 1; columnNumber: 1; Premature end of file.
	        at com.sun.org.apache.xerces.internal.parsers.DOMParser.parse(DOMParser.java:257)
	        at com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderImpl.parse(DocumentBuilderImpl.java:339)
	        at org.jenkinsci.lib.dtkit.util.converter.ConversionService.convert(ConversionService.java:316)
	Caused: org.jenkinsci.lib.dtkit.util.converter.ConversionException: Error to convert - A file not found
	        at org.jenkinsci.lib.dtkit.util.converter.ConversionService.convert(ConversionService.java:358)
	...
	Finished: FAILURE

Revert until we can better test things.