### PR TITLE
[Xamarin.Android.Build.Tasks] _UpdateAndroidResgen always runs.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -82,6 +82,7 @@ namespace Xamarin.Android.Tasks
 
 					if (MonoAndroidHelper.CopyIfChanged (tmpdest, file)) {
 						MonoAndroidHelper.SetWriteable (file);
+						File.SetLastWriteTimeUtc (srcmodifiedDate);
 					}
 				} finally {
 					File.Delete (tmpdest);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -82,7 +82,7 @@ namespace Xamarin.Android.Tasks
 
 					if (MonoAndroidHelper.CopyIfChanged (tmpdest, file)) {
 						MonoAndroidHelper.SetWriteable (file);
-						File.SetLastWriteTimeUtc (srcmodifiedDate);
+						MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (file, srcmodifiedDate, Log);
 					}
 				} finally {
 					File.Delete (tmpdest);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -111,6 +111,7 @@ using System.Runtime.CompilerServices;
 					Assert.IsTrue (b.LastBuildOutput.ContainsText ($"Downloading {url}") || b.LastBuildOutput.ContainsText ($"reusing existing archive: {zipPath}"), $"{url} should have been downloaded.");
 					FileAssert.Exists (Path.Combine (extractedDir, "1", "content", "android-N", "aapt"), $"Files should have been extracted to {extractedDir}");
 					FileAssert.Exists (Path.Combine (intermediateOutputPath, "R.txt"), "R.txt should exist after IncrementalClean!");
+					FileAssert.Exists (Path.Combine (intermediateOutputPath, "res.flag"), "res.flag should exist after IncrementalClean!");
 					if (useManagedParser) {
 						FileAssert.Exists (designTimeDesigner, $"{designTimeDesigner} should not have been deleted.");
 					}
@@ -222,9 +223,6 @@ using System.Runtime.CompilerServices;
 				var firstBuildTime = b.LastBuildTime;
 				Assert.IsTrue (b.Build (proj), "Second build was supposed to build without errors");
 				Assert.IsTrue (firstBuildTime > b.LastBuildTime, "Second build was supposed to be quicker than the first");
-				Assert.IsTrue (
-					b.Output.IsTargetSkipped ("_UpdateAndroidResgen"),
-					"The Target _UpdateAndroidResgen should have been skipped");
 				Assert.IsTrue (
 					b.Output.IsTargetSkipped ("_UpdateAndroidResgen"),
 					"The Target _UpdateAndroidResgen should have been skipped");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -223,6 +223,12 @@ using System.Runtime.CompilerServices;
 				Assert.IsTrue (b.Build (proj), "Second build was supposed to build without errors");
 				Assert.IsTrue (firstBuildTime > b.LastBuildTime, "Second build was supposed to be quicker than the first");
 				Assert.IsTrue (
+					b.Output.IsTargetSkipped ("_UpdateAndroidResgen"),
+					"The Target _UpdateAndroidResgen should have been skipped");
+				Assert.IsTrue (
+					b.Output.IsTargetSkipped ("_UpdateAndroidResgen"),
+					"The Target _UpdateAndroidResgen should have been skipped");
+				Assert.IsTrue (
 					b.Output.IsTargetSkipped ("_GenerateAndroidResourceDir"),
 					"The Target _GenerateAndroidResourceDir should have been skipped");
 				Assert.IsTrue (
@@ -232,6 +238,9 @@ using System.Runtime.CompilerServices;
 				var layout = proj.AndroidResources.First (x => x.Include() == "Resources\\layout\\Main.axml");
 				layout.Timestamp = DateTime.UtcNow;
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate:true, saveProject: false), "Third build was supposed to build without errors");
+				Assert.IsFalse (
+					b.Output.IsTargetSkipped ("_UpdateAndroidResgen"),
+					"The Target _UpdateAndroidResgen should not have been skipped");
 				Assert.IsFalse (
 					b.Output.IsTargetSkipped ("_GenerateAndroidResourceDir"),
 					"The Target _GenerateAndroidResourceDir should not have been skipped");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/GetDependenciesTests.cs
@@ -52,6 +52,7 @@ namespace Xamarin.Android.Build.Tests {
 				Assert.IsNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "ndk-bundle"),
 					"Dependencies should not contain a ndk-bundle item");
 			}
+			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
 		
 		[Test]
@@ -87,6 +88,7 @@ namespace Xamarin.Android.Build.Tests {
 				"Dependencies should contains a platform-tools version 26.0.3");
 			Assert.IsNotNull (task.Dependencies.FirstOrDefault (x => x.ItemSpec == "ndk-bundle" && x.GetMetadata ("Version") == "12.1"),
 				"Dependencies should contains a ndk-bundle version 12.1");
+			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1800,7 +1800,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_LinkAssembliesNoShrink"
   Condition="'$(AndroidLinkMode)' == 'None'"
   Inputs="@(ResolvedUserAssemblies)"
-  Outputs="@(ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')">
+  Outputs="@(ResolvedUserAssemblies->'$(MonoAndroidIntermediateDir)%(Filename)%(Extension)')">
 
     <LinkAssemblies
       UseSharedRuntime="$(AndroidUseSharedRuntime)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1043,6 +1043,7 @@ because xbuild doesn't support framework reference assemblies.
 	<MonoAndroidIntermediateResourceCache>$(IntermediateOutputPath)resourcecache</MonoAndroidIntermediateResourceCache>
 	<_AndroidAotBinDirectory>$(IntermediateOutputPath)aot</_AndroidAotBinDirectory>
 	<_AndroidResgenFlagFile>$(IntermediateOutputPath)R.cs.flag</_AndroidResgenFlagFile>
+	<_AndroidResFlagFile>$(IntermediateOutputPath)res.flag</_AndroidResFlagFile>
 	<_AndroidComponentResgenFlagFile>$(IntermediateOutputPath)Component.R.cs.flag</_AndroidComponentResgenFlagFile>
 	<_AndroidStripFlag>$(IntermediateOutputPath)strip.flag</_AndroidStripFlag>
 	<_AndroidLinkFlag>$(IntermediateOutputPath)link.flag</_AndroidLinkFlag>
@@ -1178,7 +1179,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_GenerateAndroidResourceDir"
 	Inputs="$(MSBuildProjectFullPath);$(MSBuildAllProjects);@(_AndroidResolvedResources);$(_AndroidBuildPropertiesCache)"
-	Outputs="@(_AndroidResourceDest)"
+	Outputs="$(_AndroidResFlagFile)"
 	DependsOnTargets="$(_OnResolveMonoAndroidSdks)">
 	<CopyAndConvertResources SourceFiles="@(_AndroidResolvedResources)"
 			DestinationFiles="@(_AndroidResourceDest)"
@@ -1197,6 +1198,10 @@ because xbuild doesn't support framework reference assemblies.
 	<RemoveUnknownFiles Files="@(_AndroidResourceDest)" Directory="$(MonoAndroidResDirIntermediate)" RemoveDirectories="true">
 		<Output ItemName="_AndroidResourceDestRemovedFiles" TaskParameter="RemovedFiles" />
 	</RemoveUnknownFiles>
+	<Touch Files="$(_AndroidResFlagFile)" AlwaysCreate="True" />
+	<ItemGroup>
+		<FileWrites Include="$(_AndroidResFlagFile)" />
+	</ItemGroup>
 </Target>
 
 <Target Name="_ResolveLibraryProjectImports"
@@ -1948,7 +1953,6 @@ because xbuild doesn't support framework reference assemblies.
   </GenerateJavaStubs>
   <ConvertResourcesCases 
 	ResourceDirectories="$(MonoAndroidResDirIntermediate)"
-	AndroidConversionFlagFile="$(_AcwMapFile)"
 	AcwMapFile="$(_AcwMapFile)" />
 </Target>
 
@@ -2729,6 +2733,7 @@ because xbuild doesn't support framework reference assemblies.
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediateResourceCache)" Condition="Exists ('$(MonoAndroidIntermediateResourceCache)')" />
 	<RemoveDirFixed Directories="$(_AndroidAotBinDirectory)" Condition="Exists ('$(_AndroidAotBinDirectory)')" />
 	<Delete Files="$(IntermediateOutputPath)_dex_stamp" />
+	<Delete Files="$(_AndroidResFlagFile)" />
  	<Delete Files="$(MonoAndroidIntermediate)R.cs.flag" />
 	<Delete Files="$(MonoAndroidIntermediate)acw-map.txt" />
 	<Delete Files="$(MonoAndroidIntermediate)mergeresources.cache" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1800,7 +1800,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_LinkAssembliesNoShrink"
   Condition="'$(AndroidLinkMode)' == 'None'"
   Inputs="@(ResolvedUserAssemblies)"
-  Outputs="@(ResolvedUserAssemblies->'$(MonoAndroidIntermediateDir)%(Filename)%(Extension)')">
+  Outputs="@(ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')">
 
     <LinkAssemblies
       UseSharedRuntime="$(AndroidUseSharedRuntime)"
@@ -2733,7 +2733,7 @@ because xbuild doesn't support framework reference assemblies.
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediateResourceCache)" Condition="Exists ('$(MonoAndroidIntermediateResourceCache)')" />
 	<RemoveDirFixed Directories="$(_AndroidAotBinDirectory)" Condition="Exists ('$(_AndroidAotBinDirectory)')" />
 	<Delete Files="$(IntermediateOutputPath)_dex_stamp" />
-	<Delete Files="$(_AndroidResFlagFile)" />
+	<Delete Files="$(MonoAndroidIntermediate)R.cs.flag" />
  	<Delete Files="$(MonoAndroidIntermediate)R.cs.flag" />
 	<Delete Files="$(MonoAndroidIntermediate)acw-map.txt" />
 	<Delete Files="$(MonoAndroidIntermediate)mergeresources.cache" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2733,7 +2733,6 @@ because xbuild doesn't support framework reference assemblies.
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediateResourceCache)" Condition="Exists ('$(MonoAndroidIntermediateResourceCache)')" />
 	<RemoveDirFixed Directories="$(_AndroidAotBinDirectory)" Condition="Exists ('$(_AndroidAotBinDirectory)')" />
 	<Delete Files="$(IntermediateOutputPath)_dex_stamp" />
-	<Delete Files="$(MonoAndroidIntermediate)R.cs.flag" />
  	<Delete Files="$(MonoAndroidIntermediate)R.cs.flag" />
 	<Delete Files="$(MonoAndroidIntermediate)acw-map.txt" />
 	<Delete Files="$(MonoAndroidIntermediate)mergeresources.cache" />
@@ -2743,6 +2742,7 @@ because xbuild doesn't support framework reference assemblies.
 	<Delete Files="$(MonoAndroidIntermediate)__AndroidNativeLibraries__.zip" />
 	<Delete Files="$(MonoAndroidIntermediate)stub_application_data.txt" />
 	<Delete Files="$(IntermediateOutputPath)_javac.stamp" />
+	<Delete Files="$(_AndroidResFlagFile)" />
 	<Delete Files="$(_AndroidStripFlag)" />
 	<Delete Files="$(_AndroidLinkFlag)" />
 	<Delete Files="$(_AndroidComponentResgenFlagFile)" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1197,9 +1197,6 @@ because xbuild doesn't support framework reference assemblies.
 	<RemoveUnknownFiles Files="@(_AndroidResourceDest)" Directory="$(MonoAndroidResDirIntermediate)" RemoveDirectories="true">
 		<Output ItemName="_AndroidResourceDestRemovedFiles" TaskParameter="RemovedFiles" />
 	</RemoveUnknownFiles>
-	<Touch Files="@(_AndroidResourceDest)"
-		Condition=" '$(AndroidExplicitCrunch)' != 'True' Or '$(AndroidApplication)' == '' Or !($(AndroidApplication))"
-	/>
 </Target>
 
 <Target Name="_ResolveLibraryProjectImports"
@@ -1925,7 +1922,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_GenerateJavaStubs"
   DependsOnTargets="_SetLatestTargetFrameworkVersion;_PrepareAssemblies;$(_AfterPrepareAssemblies)"
-  Inputs="$(MSBuildAllProjects);@(_ResolvedAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache)"
+  Inputs="$(MSBuildAllProjects);@(_ResolvedAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(_AndroidResourceDest)"
   Outputs="$(IntermediateOutputPath)android\AndroidManifest.xml;$(_AcwMapFile);$(_AndroidTypeMappingJavaToManaged);$(_AndroidTypeMappingManagedToJava)">
   <GenerateJavaStubs
     ResolvedAssemblies="@(_ResolvedAssemblies)"
@@ -1951,6 +1948,7 @@ because xbuild doesn't support framework reference assemblies.
   </GenerateJavaStubs>
   <ConvertResourcesCases 
 	ResourceDirectories="$(MonoAndroidResDirIntermediate)"
+	AndroidConversionFlagFile="$(_AcwMapFile)"
 	AcwMapFile="$(_AcwMapFile)" />
 </Target>
 


### PR DESCRIPTION
Commit a50e00bb broke the build in such that `_UpdateAndroidResgen`
always runs. This is because the resource file last modified date
was always newer than the `R.cs.flag`.

As a result of reading the fix to set the last write, this then broke `_GenerateAndroidResourceDir`. 
This is because the `build.props` ended up being newer than the resource files in `@(_AndroidResourceDest)` causing the target to run when it shouldn't. So we also introduce an `_AndroidResFlagFile` to control when we need to generate the resource directory in the `$(IntermediateOutputPath)`.

Unit tests have been updated to make sure these target do not run when they are no supposed to.