### PR TITLE
[Xamarin.Android.Build.Tasks] Stop `_LinkAssembliesNoShrink` running all the time.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -228,6 +228,9 @@ using System.Runtime.CompilerServices;
 				Assert.IsTrue (
 					b.Output.IsTargetSkipped ("_CompileJava"),
 					"The Target _CompileJava should have been skipped");
+				Assert.IsTrue (
+					b.Output.IsTargetSkipped ("_LinkAssembliesNoShrink"),
+					"The Target _LinkAssembliesNoShrink should have been skipped");
 				image1.Timestamp = DateTime.UtcNow;
 				var layout = proj.AndroidResources.First (x => x.Include() == "Resources\\layout\\Main.axml");
 				layout.Timestamp = DateTime.UtcNow;
@@ -238,6 +241,9 @@ using System.Runtime.CompilerServices;
 				Assert.IsTrue (
 					b.Output.IsTargetSkipped ("_CompileJava"),
 					"The Target _CompileJava (2) should have been skipped");
+				Assert.IsTrue (
+					b.Output.IsTargetSkipped ("_LinkAssembliesNoShrink"),
+					"The Target _LinkAssembliesNoShrink should have been skipped");
 				Assert.IsFalse (
 					b.Output.IsTargetSkipped ("_CreateBaseApk"),
 					"The Target _CreateBaseApk should not have been skipped");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1798,7 +1798,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_LinkAssembliesNoShrink"
   Condition="'$(AndroidLinkMode)' == 'None'"
   Inputs="@(ResolvedUserAssemblies)"
-  Outputs="@(ResolvedUserAssemblies->'$(MonoAndroidIntermediateDir)%(Filename)%(Extension)')">
+  Outputs="@(ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')">
 
     <LinkAssemblies
       UseSharedRuntime="$(AndroidUseSharedRuntime)"


### PR DESCRIPTION
This has been a long standing issue that we never caught...
The `Output` on the `_LinkAssembliesNoShrink` target was
incorrect. It was using `$(MonoAndroidIntermediateDir)`
rather than `$(MonoAndroidIntermediateAssemblyDir)`.

As a result it was always looking for the output files in the
project root directory.. They never existed so the target
ALWAYS ran!.