### PR TITLE
[Mono.Android] Support building with API-10

### DIFF
--- a/src/Mono.Android/Android.App/Activity.cs
+++ b/src/Mono.Android/Android.App/Activity.cs
@@ -46,8 +46,10 @@ namespace Android.App {
 		public virtual void OnLayoutViewNotFound <T> (int resourceId, ref T view) where T: View
 		{}
 
+#if ANDROID_11
 		public virtual void OnLayoutFragmentNotFound <T> (int resourceId, ref T fragment) where T: Fragment
 		{}
+#endif  // ANDROID_11
 	}
 }
 

--- a/src/Mono.Android/Android.Views/View.cs
+++ b/src/Mono.Android/Android.Views/View.cs
@@ -84,10 +84,12 @@ namespace Android.Views {
 			activity?.OnLayoutViewNotFound <T> (resourceId, ref view);
 		}
 
+#if ANDROID_11
 		public virtual void OnLayoutFragmentNotFound <T> (int resourceId, ref T fragment) where T: global::Android.App.Fragment
 		{
 			var activity = Context as global::Android.App.Activity;
 			activity?.OnLayoutFragmentNotFound <T> (resourceId, ref fragment);
 		}
+#endif  // ANDROID_11
 	}
 }

--- a/src/Mono.Android/Xamarin.Android.Design/ILayoutBindingClient.cs
+++ b/src/Mono.Android/Xamarin.Android.Design/ILayoutBindingClient.cs
@@ -12,6 +12,8 @@ namespace Xamarin.Android.Design
 
 		T FindViewById<T> (int value) where T : View;
 		void OnLayoutViewNotFound <T> (int resourceId, ref T view) where T: View;
+#if ANDROID_14
 		void OnLayoutFragmentNotFound <T> (int resourceId, ref T fragment) where T: Fragment;
+#endif  // ANDROID_14
 	}
 }

--- a/src/Mono.Android/Xamarin.Android.Design/LayoutBinding.cs
+++ b/src/Mono.Android/Xamarin.Android.Design/LayoutBinding.cs
@@ -32,6 +32,7 @@ namespace Xamarin.Android.Design
 			return ret;
 		}
 
+#if ANDROID_11
 		protected T FindFragment <T> (int resourceId, ref T cachedField) where T: Fragment
 		{
 			if (cachedField != null)
@@ -51,5 +52,6 @@ namespace Xamarin.Android.Design
 			cachedField = ret;
 			return ret;
 		}
+#endif  // ANDROID_11
 	}
 }


### PR DESCRIPTION
Commit ab3773cf [broke the build][0]:

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/972/

	Xamarin.Android.Design/ILayoutBindingClient.cs(15,79): error CS0246: The type or namespace name 'Fragment' could not be found (are you missing a using directive or an assembly reference?)
	Xamarin.Android.Design/LayoutBinding.cs(35,77): error CS0246: The type or namespace name 'Fragment' could not be found (are you missing a using directive or an assembly reference?)
	Android.App/Activity.cs(49,94): error CS0246: The type or namespace name 'Fragment' could not be found (are you missing a using directive or an assembly reference?)
	Android.Views/View.cs(87,114): error CS0234: The type or namespace name 'Fragment' does not exist in the namespace 'Android.App' (are you missing an assembly reference?)
	Android.Views/View.cs(87,23): error CS0425: The constraints for type parameter 'T' of method 'View.OnLayoutFragmentNotFound<T>(int, ref T)' must match the constraints for type parameter 'T' of interface method 'ILayoutBindingClient.OnLayoutFragmentNotFound<T>(int, ref T)'. Consider using an explicit interface implementation instead.

The above C# compiler errors result when attempting to build
`src/Mono.Android` for API-10:

	$ make API_LEVEL=10
	# -or-
	$ (cd src/Mono.Android; msbuild /p:AndroidFrameworkVersion=v2.3 /p:AndroidApiLevel=10)

The problem is that API-10 doesn't contain the `Android.App.Fragment`
type, which is used in ab3773cf.

Fix things by making references to `Android.App.Fragment` conditional
on API-11+.