### PR TITLE
[Xamarin.Android.Build.Tasks] Fix test broken by new Binding system

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutBindings.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutBindings.cs
@@ -280,6 +280,8 @@ namespace Xamarin.Android.Tasks
 
 		bool GenerateSource (BindingGenerator generator, string outputFilePath, ICollection <LayoutWidget> widgets, string classNamespace, string className, List<PartialClass> partialClasses)
 		{
+			bool result = false;
+			var tempFile = Path.GetTempFileName ();
 			try {
 				if (partialClasses != null && partialClasses.Count > 0) {
 					foreach (var pc in partialClasses) {
@@ -291,12 +293,16 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 
-				using (var fs = File.Open (outputFilePath, FileMode.Create)) {
+				using (var fs = File.Open (tempFile, FileMode.Create)) {
 					using (var sw = new StreamWriter (fs, Encoding.UTF8)) {
-						return GenerateSource (sw, generator, widgets, classNamespace, className, partialClasses);
+						result = GenerateSource (sw, generator, widgets, classNamespace, className, partialClasses);
 					}
 				}
+				if (result)
+					MonoAndroidHelper.CopyIfChanged (tempFile, outputFilePath);
 			} finally {
+				if (File.Exists (tempFile))
+					File.Delete (tempFile);
 				if (partialClasses != null && partialClasses.Count > 0) {
 					foreach (var pc in partialClasses) {
 						if (pc == null)
@@ -315,6 +321,7 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 			}
+			return result;
 		}
 
 		bool GenerateSource (StreamWriter writer, BindingGenerator generator, ICollection <LayoutWidget> widgets, string classNamespace, string className, List<PartialClass> partialClasses)


### PR DESCRIPTION
Commit ab3773cf added support for a new Binding system. It
broke on of our updated unit tests though. If a resource is
updated but not changed the resulting binding generator should
NOT produce an updated binding cs file. If it does the result
is the `CoreCompile` target ends up running and a whole host
of other targets then run as a result including `_LinkAssembliesNoShrink`.

What we should be doing is generating to a temp file and then
only update the binding if there has been a change.