### PR TITLE
[build] Fix Linux `make package-oss`

### DIFF
--- a/build-tools/scripts/Packaging.mk
+++ b/build-tools/scripts/Packaging.mk
@@ -29,7 +29,16 @@ package-oss $(ZIP_OUTPUT):
 	if [ ! -d $(ZIP_OUTPUT_BASENAME) ] ; then mkdir $(ZIP_OUTPUT_BASENAME) ; fi
 	if [ ! -L $(ZIP_OUTPUT_BASENAME)/bin ] ; then ln -s ../bin $(ZIP_OUTPUT_BASENAME) ; fi
 	if [ ! -f $(ZIP_OUTPUT_BASENAME)/ThirdPartyNotices.txt ] ; then \
-		cp -n $(firstword $(wildcard bin/*/lib/xamarin.android/ThirdPartyNotices.txt)) $(ZIP_OUTPUT_BASENAME) ; \
+		TPN="$(firstword $(wildcard bin/*/lib/xamarin.android/ThirdPartyNotices.txt))"; \
+		if [ -f "$$TPN" ]; then \
+			cp -n "$$TPN" $(ZIP_OUTPUT_BASENAME) ; \
+		else \
+			echo "warning: ThirdPartyNotices.txt file '$$TPN' does not exist." ; \
+			echo "warning: pwd=`pwd`"; \
+			echo "warning: files?" $(ls bin/*/lib/xamarin.android/ThirdPartyNotices.txt); \
+			echo "warning: trying hard-coded path"; \
+			cp bin/Debug/lib/xamarin.android/ThirdPartyNotices.txt $(ZIP_OUTPUT_BASENAME) || true ; \
+		fi; \
 	fi
 	_exclude_list=".__exclude_list.txt"; \
 	ls -1d $(_BUNDLE_ZIPS_EXCLUDE) > "$$_exclude_list" 2>/dev/null ; \
@@ -40,6 +49,8 @@ package-oss $(ZIP_OUTPUT):
 			echo "$(ZIP_OUTPUT_BASENAME)/bin/$$c/lib/xamarin.android/xbuild/$$f" >> "$$_exclude_list"; \
 		done; \
 	done
+	echo "Exclude List:"
+	cat ".__exclude_list.txt"
 ifeq ($(ZIP_EXTENSION),zip)
 	zip -r "$(ZIP_OUTPUT)" \
 		`ls -1d $(_BUNDLE_ZIPS_INCLUDE) 2>/dev/null` \


### PR DESCRIPTION
The [xamarin-android-linux][0] job has long been broken, and I had
hoped that commit 3b904c20 would allow it to build once more.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-linux/

Commit 3b904c20 *does* appear to have improved matters; build times
went from ~1h to ~4h, so it was certainly building more. :-)

Unfortunately, the build [fails within `make package-oss`][1]:

[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-linux/956/

	if [ ! -f xamarin.android-oss_v8.3.99.151_Linux-x86_64_HEAD_3b904c2/ThirdPartyNotices.txt ] ; then \
		cp -n  xamarin.android-oss_v8.3.99.151_Linux-x86_64_HEAD_3b904c2 ; \
	fi
	cp: missing destination file operand after 'xamarin.android-oss_v8.3.99.151_Linux-x86_64_HEAD_3b904c2'
	Try 'cp --help' for more information.
	build-tools/scripts/Packaging.mk:27: recipe for target 'xamarin.android-oss_v8.3.99.151_Linux-x86_64_HEAD_3b904c2.tar.bz2' failed
	make: *** [xamarin.android-oss_v8.3.99.151_Linux-x86_64_HEAD_3b904c2.tar.bz2] Error 1

This error doesn't make sense to me; the `cp -n` is in `Packaging.mk`:

	cp -n $(firstword $(wildcard bin/*/lib/xamarin.android/ThirdPartyNotices.txt)) $(ZIP_OUTPUT_BASENAME)

Apparently the `$(firstword $(wildcard ...))` construct is returning
the empty string, which (again) makes no sense to me because
`bin/Debug/xamarin.android/ThirdPartyNotices.txt` *is* created, as per
investigation of the Jenkins Workspace while a build is in-progress.

Also note that this is only happening on Linux; macOS executes this
Just Fine™.

In the absense of actually understanding what's wrong and fixing the
real problem, instead print out some debug spew if the `cp` operation
*would* fail -- because `$(firstword $(wildcard ...))` returns "" --
and fallback to an attempted "hardcoded" `cp` operation.

Hopefully this will allow `make package-oss` to finish on Linux,
allowing for a long-missing-and-desired "non-red build".