### PR TITLE
[tests] changes to get test projects building again on Windows/monodroid

### DIFF
--- a/src/Mono.Android/Test/Mono.Android-Tests.csproj
+++ b/src/Mono.Android/Test/Mono.Android-Tests.csproj
@@ -101,7 +101,7 @@
     <AndroidResource Include="Resources\drawable\android_button.xml" />
     <AndroidResource Include="Resources\xml\XmlReaderResourceParser.xml" />
     <AndroidResource Include="Resources\layout\FragmentFixup.axml" />
-    <AndroidResource Include="Resources\layout\Main.axml" />
+    <AndroidBoundLayout Include="Resources\layout\Main.axml" />
     <AndroidResource Include="..\..\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Resources\Base\Image.9.png">
       <Link>Resources\Drawable\Image.9.png</Link>
     </AndroidResource>

--- a/tests/CodeBehind/BuildTests/CodeBehindBuildTests.csproj
+++ b/tests/CodeBehind/BuildTests/CodeBehindBuildTests.csproj
@@ -61,14 +61,14 @@
     <None Include="Assets\AboutAssets.txt" />
   </ItemGroup>
   <ItemGroup>
-    <AndroidResource Include="Resources\layout\Main.axml" />
-    <AndroidResource Include="Resources\layout-land\Main.axml" />
-    <AndroidResource Include="Resources\layout\settings.xml" />
-    <AndroidResource Include="Resources\layout\loading.xml" />
-    <AndroidResource Include="Resources\layout\item_separator.xml" />
-    <AndroidResource Include="Resources\layout\onboarding_intro.xml" />
-    <AndroidResource Include="Resources\layout\onboarding_info.xml" />
-    <AndroidResource Include="Resources\layout-land\onboarding_intro.xml" />
+    <AndroidBoundLayout Include="Resources\layout\Main.axml" />
+    <AndroidBoundLayout Include="Resources\layout-land\Main.axml" />
+    <AndroidBoundLayout Include="Resources\layout\settings.xml" />
+    <AndroidBoundLayout Include="Resources\layout\loading.xml" />
+    <AndroidBoundLayout Include="Resources\layout\item_separator.xml" />
+    <AndroidBoundLayout Include="Resources\layout\onboarding_intro.xml" />
+    <AndroidBoundLayout Include="Resources\layout\onboarding_info.xml" />
+    <AndroidBoundLayout Include="Resources\layout-land\onboarding_intro.xml" />
     <AndroidResource Include="Resources\values\Strings.xml" />
     <AndroidResource Include="Resources\mipmap-hdpi\Icon.png" />
     <AndroidResource Include="Resources\mipmap-mdpi\Icon.png" />

--- a/tests/CodeBehind/BuildTests/MainActivity.cs
+++ b/tests/CodeBehind/BuildTests/MainActivity.cs
@@ -38,12 +38,12 @@ namespace Xamarin.Android.Tests.CodeBehindBuildTests
 			onSetContentViewCalled_01 = true;
 		}
 
-                partial void OnSetContentView (global::Android.Views.View view, global::Android.Views.ViewGroup.LayoutParams @params, ref bool callBaseAfterReturn)
+		partial void OnSetContentView (global::Android.Views.View view, global::Android.Views.ViewGroup.LayoutParams @params, ref bool callBaseAfterReturn)
 		{
 			onSetContentViewCalled_02 = true;
 		}
 
-                partial void OnSetContentView (int layoutResID, ref bool callBaseAfterReturn)
+		partial void OnSetContentView (int layoutResID, ref bool callBaseAfterReturn)
 		{
 			onSetContentViewCalled_03 = true;
 		}

--- a/tests/CodeBehind/BuildTests/OnboardingActivityPartial.cs
+++ b/tests/CodeBehind/BuildTests/OnboardingActivityPartial.cs
@@ -59,12 +59,12 @@ namespace Xamarin.Android.Tests.CodeBehindBuildTests
 			onSetContentViewCalled_01 = true;
 		}
 
-                partial void OnSetContentView (global::Android.Views.View view, global::Android.Views.ViewGroup.LayoutParams @params, ref bool callBaseAfterReturn)
+		partial void OnSetContentView (global::Android.Views.View view, global::Android.Views.ViewGroup.LayoutParams @params, ref bool callBaseAfterReturn)
 		{
 			onSetContentViewCalled_02 = true;
 		}
 
-                partial void OnSetContentView (int layoutResID, ref bool callBaseAfterReturn)
+		partial void OnSetContentView (int layoutResID, ref bool callBaseAfterReturn)
 		{
 			onSetContentViewCalled_03 = true;
 		}

--- a/tests/CodeBehind/BuildTests/Resources/layout-land/Main.axml
+++ b/tests/CodeBehind/BuildTests/Resources/layout-land/Main.axml
@@ -21,6 +21,7 @@
 
 <!-- This should cause the property type to decay to Fragment -->
 <fragment
+    xamarin:managedType="CommonSampleLibrary.LogFragment"
     android:name="commonsamplelibrary.LogFragment"
     android:id="@+id/secondary_log_fragment"
     android:layout_width="match_parent"
@@ -28,7 +29,8 @@
 
 <!-- This tests naive fixup of type names - capitalization of the namespaces -->
 <fragment
-    android:name="commonSampleLibrary.LogFragment"
+    xamarin:managedType="CommonSampleLibrary.LogFragment"
+    android:name="commonsamplelibrary.LogFragment"
     android:id="@+id/tertiary_log_fragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent" />

--- a/tests/CodeBehind/BuildTests/Resources/layout-land/onboarding_intro.xml
+++ b/tests/CodeBehind/BuildTests/Resources/layout-land/onboarding_intro.xml
@@ -3,16 +3,16 @@
 	      android:id="@+id/onboarding_intro">
     <TextView android:id="@+id/welcome" />
     <RelativeLayout>
-	<RelativeLayout android:id="@+id/onboarding_info">
+	<LinearLayout android:id="@+id/onboarding_info">
 	    <TextView android:id="@+id/intro_highlighted_text"/>
 	    <TextView android:id="@+id/intro_primary_text" />
 	    <TextView android:id="@+id/intro_secondary_text" />
-	</RelativeLayout>
+	</LinearLayout>
 	<RelativeLayout android:id="@+id/more_info">
 	    <TextView android:id="@+id/more_highlighted_text" />
 	    <TextView android:id="@+id/more_intro_primary_text" />
 	    <TextView android:id="@+id/more_intro_secondary_text" />
 	</RelativeLayout>
     </RelativeLayout>
-    <Button android:id="@+id/different_view_types" />
+    <TextView android:id="@+id/different_view_types" />
 </LinearLayout>

--- a/tests/CodeBehind/BuildTests/Resources/layout-land/onboarding_intro_many2.xml
+++ b/tests/CodeBehind/BuildTests/Resources/layout-land/onboarding_intro_many2.xml
@@ -3,11 +3,11 @@
 	      android:id="@+id/onboarding_intro">
     <TextView android:id="@+id/welcome" />
     <RelativeLayout>
-	<RelativeLayout android:id="@+id/onboarding_info">
+	<LinearLayout android:id="@+id/onboarding_info">
 	    <TextView android:id="@+id/intro_highlighted_text"/>
 	    <TextView android:id="@+id/intro_primary_text" />
 	    <TextView android:id="@+id/intro_secondary_text" />
-	</RelativeLayout>
+	</LinearLayout>
 	<RelativeLayout android:id="@+id/more_info">
 	    <TextView android:id="@+id/more_highlighted_text" />
 	    <TextView android:id="@+id/more_intro_primary_text" />

--- a/tests/CodeBehind/BuildTests/Resources/layout/Main.axml
+++ b/tests/CodeBehind/BuildTests/Resources/layout/Main.axml
@@ -19,7 +19,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent" />
 <fragment
-    android:name="CommonSampleLibrary.LogFragment"
+    xamarin:managedType="CommonSampleLibrary.LogFragment"
+    android:name="commonsamplelibrary.LogFragment"
     android:id="@+id/secondary_log_fragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent" />

--- a/tests/CodeBehind/BuildTests/Resources/layout/onboarding_intro.xml
+++ b/tests/CodeBehind/BuildTests/Resources/layout/onboarding_intro.xml
@@ -5,9 +5,9 @@
 	      xamarin:classes="Xamarin.Android.Tests.CodeBehindBuildTests.OnboardingActivityPartial">
     <TextView android:id="@+id/title" />
     <TextView android:id="@+id/welcome" />
-    <RelativeLayout>
+    <LinearLayout>
         <include android:id="@+id/onboarding_info" layout="@layout/onboarding_info" />
-    </RelativeLayout>
+    </LinearLayout>
 
     <TextView android:id="@+id/different_view_types" />
 </LinearLayout>


### PR DESCRIPTION
Since ab3773cf, `Xamarin.Android-Tests.sln` hasn't been building on
Windows, with the following errors:

    "Mono.Android-Tests.csproj" (default target) (2) ->
        Xamarin.Android.RuntimeTests\MainActivity.cs(19,4): error CS0103: The name 'first_text_view' does not exist in the current context
        Xamarin.Android.RuntimeTests\MainActivity.cs(23,4): error CS0103: The name 'second_text_view' does not exist in the current context
        Xamarin.Android.RuntimeTests\MainActivity.cs(27,4): error CS0103: The name 'my_scroll_view' does not exist in the current context
        Xamarin.Android.RuntimeTests\MainActivity.cs(29,4): error CS0103: The name 'first_text_view' does not exist in the current context
        Xamarin.Android.RuntimeTests\MainActivity.cs(33,4): error CS0103: The name 'second_text_view' does not exist in the current context
        Xamarin.Android.RuntimeTests\MainActivity.cs(37,4): error CS0103: The name 'csharp_simple_fragment' does not exist in the current context
        Xamarin.Android.RuntimeTests\MainActivity.cs(38,4): error CS0103: The name 'csharp_partial_assembly' does not exist in the current context
        Xamarin.Android.RuntimeTests\MainActivity.cs(39,4): error CS0103: The name 'csharp_full_assembly' does not exist in the current context

Looking into it, there were several layout files that were not
specifying `AndroidBoundLayout` as the build action. Changing the build
action of `Main.axml` got `Mono.Android-Tests.csproj` building again.

Unfortunately, as I looked into `CodeBehindBuildTests.csproj`, many of
the situations where @grendello had setup conflicting types did not
compile. _For now_, it seems our best option is to resolve the conflicts
to get things to compile again. Cases where one layout had `<Button />`
and another had `<TextView />`, I just changed the layouts to use the
same type. When @grendello gets back, he can investigate and get these
tests back to what they were trying to accomplish for testing.

I am uncertain on how these projects were building on other platforms,
but similar build errors have cropped up upstream in `monodroid`:

    /Users/builder/jenkins/workspace/monodroid-pr/monodroid/external/xamarin-android/src/Mono.Android/Test/Xamarin.Android.RuntimeTests/MainActivity.cs
        MainActivity.cs(17,36): error CS0117: 'Resource.Layout' does not contain a definition for 'Main'
        MainActivity.cs(19,4): error CS0103: The name 'first_text_view' does not exist in the current context
        MainActivity.cs(23,4): error CS0103: The name 'second_text_view' does not exist in the current context
        MainActivity.cs(27,4): error CS0103: The name 'my_scroll_view' does not exist in the current context
        MainActivity.cs(29,4): error CS0103: The name 'first_text_view' does not exist in the current context
        MainActivity.cs(33,4): error CS0103: The name 'second_text_view' does not exist in the current context
        MainActivity.cs(37,4): error CS0103: The name 'csharp_simple_fragment' does not exist in the current context
        MainActivity.cs(38,4): error CS0103: The name 'csharp_partial_assembly' does not exist in the current context
        MainActivity.cs(39,4): error CS0103: The name 'csharp_full_assembly' does not exist in the current context

I'm hoping this PR will fix Windows builds and builds upstream in
`monodroid`.