### PR TITLE
[codebehind] fix for FindLayoutsToBind on Windows

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/FindLayoutsToBind.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/FindLayoutsToBind.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Android.Tasks
 {
 	public class FindLayoutsToBind : Task
 	{
-		static readonly char DirSeparator = Path.DirectorySeparatorChar == '\\' ? '\\' : '/';
+		static readonly string DirSeparator = Path.DirectorySeparatorChar == '\\' ? @"\\" : "/";
 		static readonly Regex layoutPathRegex = new Regex ($".*{DirSeparator}+layout(-?\\w+)*{DirSeparator}+.*\\.a?xml$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
 		public bool GenerateLayoutBindings { get; set; }


### PR DESCRIPTION
Since ab3773cf, `Xamarin.Android-Tests.sln` hasn't been building on
Windows, with the following errors:

    "Mono.Android-Tests.csproj" (default target) (2) ->
        Xamarin.Android.RuntimeTests\MainActivity.cs(19,4): error CS0103: The name 'first_text_view' does not exist in the current context
        Xamarin.Android.RuntimeTests\MainActivity.cs(23,4): error CS0103: The name 'second_text_view' does not exist in the current context
        Xamarin.Android.RuntimeTests\MainActivity.cs(27,4): error CS0103: The name 'my_scroll_view' does not exist in the current context
        Xamarin.Android.RuntimeTests\MainActivity.cs(29,4): error CS0103: The name 'first_text_view' does not exist in the current context
        Xamarin.Android.RuntimeTests\MainActivity.cs(33,4): error CS0103: The name 'second_text_view' does not exist in the current context
        Xamarin.Android.RuntimeTests\MainActivity.cs(37,4): error CS0103: The name 'csharp_simple_fragment' does not exist in the current context
        Xamarin.Android.RuntimeTests\MainActivity.cs(38,4): error CS0103: The name 'csharp_partial_assembly' does not exist in the current context
        Xamarin.Android.RuntimeTests\MainActivity.cs(39,4): error CS0103: The name 'csharp_full_assembly' does not exist in the current context

Changing the build action of `Main.axml` to `AndroidBoundLayout` got
`Mono.Android-Tests.csproj` building again. We shouldn't have to do this
unless `$(AndroidGenerateLayoutBindings)` is set to `False`.

Looking into it, the `Regex` did not appear to be matching files correctly on Windows:

    static readonly char DirSeparator = Path.DirectorySeparatorChar == '\\' ? '\\' : '/';
    static readonly Regex layoutPathRegex = new Regex ($".*{DirSeparator}+layout(-?\\w+)*{DirSeparator}+.*\\.a?xml$", RegexOptions.Compiled | RegexOptions.IgnoreCase);

The `Regex` needs to escape the `\\`, in order to match paths on Windows.