### PR TITLE
[Xamarin.Android.Build.Tasks] Xamarin Android Lint checks fail on Windows

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
@@ -323,12 +323,12 @@ namespace Xamarin.Android.Tasks
 				if (!string.IsNullOrEmpty (file))
 					Log.LogWarning ("", "XA0102", "", file, line, column, 0, 0, text.Replace ("Warning:", ""));
 				else 
-					Log.LogWarning (text.Replace ("Warning:", ""));
+					Log.LogCodedWarning ("XA0102", text.Replace ("Warning:", ""));
 			} else {
 				if (!string.IsNullOrEmpty (file))
 					Log.LogError ("", "XA0103", "", file, line, column, 0, 0, text.Replace ("Error:", ""));
 				else
-					Log.LogError (text.Replace ("Error:", ""));
+					Log.LogCodedError ("XA0103", text.Replace ("Error:", ""));
 			}
 		}
 
@@ -360,8 +360,23 @@ namespace Xamarin.Android.Tasks
 			});
 			var versionInfo = sb.ToString ();
 			if (result != 0 || versionInfo.Contains ("unknown")) {
-				Log.LogWarning ($"Could not get version from '{tool}'");
-				return new Version ();
+				// lets try to parse the lint-xx-x-x-dev.jar filename to get the version
+				var libPath = Path.Combine (Path.GetDirectoryName (tool), "..", "lib");
+				if (Directory.Exists (libPath)) {
+					Version v;
+					foreach (var file in Directory.EnumerateFiles (libPath, "lint-??.?.?-dev.jar")) {
+						var split = Path.GetFileName (file).Split ('-');
+						if (split.Length != 3)
+							continue;
+						if (!string.IsNullOrEmpty (split [1])) {
+							if (Version.TryParse (split [1], out v)) {
+								return v;
+							}
+						}
+					}
+				}
+				Log.LogCodedWarning ("XA0000", $"Could not get version from '{tool}'. Defaulting to 1.0");
+				return new Version (1, 0);
 			}
 			// lint: version 26.0.2
 			var versionNumberMatch = lintVersionRegex.Match (versionInfo);
@@ -369,7 +384,7 @@ namespace Xamarin.Android.Tasks
 			if (versionNumberMatch.Success && Version.TryParse (versionNumberMatch.Groups ["version"]?.Value, out versionNumber)) {
 				return versionNumber;
 			}
-			return new Version ();
+			return new Version (1, 0);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #1374

Turns out `lint.bat --version` on windows returns `unknown version`.
As a result none of the tests we want to be disabled are disabled.
So we can work around this by extracting the version number from
the filename of the .jar file that is being used.

	lint-26.0.0-dev.jar

So if we find `unknown` we will try to figure out the version
from the filename of the .jar. Failing that lets default to
at least 1.0 so that our base checks are disabled correctly.