### PR TITLE
Appending target framework to the OutputPath/IntermediateOutputPath

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.DefaultOutputPaths.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.DefaultOutputPaths.targets
@@ -1,0 +1,26 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup Condition="'$(BaseIntermediateOutputPath)' == ''">
+		<BaseIntermediateOutputPath>obj</BaseIntermediateOutputPath>
+	</PropertyGroup>
+	<PropertyGroup>
+		<BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>
+	</PropertyGroup>	
+	<PropertyGroup Condition=" $(IntermediateOutputPath) == '' ">
+		<IntermediateOutputPath Condition=" '$(PlatformName)' == 'AnyCPU' ">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
+		<IntermediateOutputPath Condition=" '$(PlatformName)' != 'AnyCPU' ">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(AndroidUseLatestPlatformSdk)' != 'true'">
+		<AppendTargetFrameworkToIntermediateOutputPath Condition="'$(AppendTargetFrameworkToIntermediateOutputPath)' == ''">true</AppendTargetFrameworkToIntermediateOutputPath>
+		<!-- We don't change the OutputPath by default to avoid backward compatibility issues -->
+		<AppendTargetFrameworkToOutputPath Condition="'$(AppendTargetFrameworkToOutputPath)' == ''">false</AppendTargetFrameworkToOutputPath>
+		<TargetFrameworkToOutputPath>$(TargetFrameworkIdentifier)$(TargetFrameworkVersion.TrimStart('v').Replace('.', ''))</TargetFrameworkToOutputPath>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(AppendTargetFrameworkToIntermediateOutputPath)' == 'true'">
+		<IntermediateOutputPath Condition="'$(IntermediateOutputPath)' != '' and !HasTrailingSlash('$(IntermediateOutputPath)')">$(IntermediateOutputPath)\</IntermediateOutputPath>
+		<IntermediateOutputPath>$(IntermediateOutputPath)$(TargetFrameworkToOutputPath)</IntermediateOutputPath>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(AppendTargetFrameworkToOutputPath)' == 'true'">
+		<OutputPath Condition="'$(OutputPath)' != '' and !HasTrailingSlash('$(OutputPath)')">$(OutputPath)\</OutputPath>
+		<OutputPath>$(OutputPath)$(TargetFrameworkToOutputPath)</OutputPath>
+	</PropertyGroup>
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -508,12 +508,12 @@ namespace Xamarin.Android.Tests
 			proj.UseLatestPlatformSdk = false;
 			proj.SetProperty ("AndroidEnableMultiDex", "True");
 
-			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName), false, false)) {
 				proj.TargetFrameworkVersion = b.LatestTargetFrameworkVersion ();
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				Assert.IsTrue (File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android/bin/classes.dex")),
+				Assert.IsTrue (File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, proj.TargetFrameworkMoniker,  "android/bin/classes.dex")),
 					"multidex-ed classes.zip exists");
-				var multidexKeepPath  = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "multidex.keep");
+				var multidexKeepPath  = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, proj.TargetFrameworkMoniker, "multidex.keep");
 				Assert.IsTrue (File.Exists (multidexKeepPath), "multidex.keep exists");
 				Assert.IsTrue (File.ReadAllLines (multidexKeepPath).Length > 1, "multidex.keep must contain more than one line.");
 				Assert.IsTrue (b.LastBuildOutput.ContainsText (Path.Combine (proj.TargetFrameworkVersion, "mono.android.jar")), proj.TargetFrameworkVersion + "/mono.android.jar should be used.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
@@ -39,5 +39,7 @@ namespace Xamarin.ProjectTools
 		public bool UseLatestPlatformSdk { get; set; }
 
 		public string TargetFrameworkVersion { get; set; }
+
+		public string TargetFrameworkMoniker { get { return "MonoAndroid" + TargetFrameworkVersion.TrimStart ('v').Replace (".", ""); } }
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -67,6 +67,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Xamarin.Android.Common.Before.targets</Link>
     </None>
+    <None
+        Include="MSBuild\Xamarin\Android\Xamarin.Android.DefaultOutputPaths.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Xamarin.Android.DefaultOutputPaths.targets</Link>
+    </None>
     <None Include="Xamarin.Android.Analysis.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.CSharp.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.CSharp.targets
@@ -40,6 +40,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
         <DebugSymbols Condition=" '$(DebugType)' == 'None' ">true</DebugSymbols>
         <DebugType Condition=" '$(DebugType)' == 'None' Or '$(DebugType)' == '' ">portable</DebugType>
     </PropertyGroup>
+    <Import Project="Xamarin.Android.DefaultOutputPaths.targets" />
     <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
     <Import Project="Xamarin.Android.Common.targets" />
     <!--


### PR DESCRIPTION
We only can do this when AndroidUseLatestPlatformSdk is false due to the
need of evaluating the MsBuild properties before calculating the latest SDK
using the _SetLatestTargetFrameworkVersion target (Xamarin.Android.Common.targets)

XA heavily leverages generated files in the intermediate output directory to achieve incremental build,
which is key since a lot of the Android/Java SDK tools are slow.

In XA, targeting different API levels is done by changing the TargetFramework property in the project.
This effectively invalidates all previous intermediate artifacts. Since this is not an uncommon
action (i.e. user is trying out various target API levels to see which one works best for their needs),
we'd like to preserve whatever artifacts were generated in a previous run for a given framework.

So rather than invalidating all incremental files when that property is changed (i.e. doing a full
clean+build on the next run), a better approach is to append the target framework to the intermediate output path,
following in the footsteps from .NETCore/.NETStandard (which always append the target framework too).