### PR TITLE
[build] Avoid using `$(wildcard) on generated files

### DIFF
--- a/build-tools/scripts/Packaging.mk
+++ b/build-tools/scripts/Packaging.mk
@@ -29,16 +29,9 @@ package-oss $(ZIP_OUTPUT):
 	if [ ! -d $(ZIP_OUTPUT_BASENAME) ] ; then mkdir $(ZIP_OUTPUT_BASENAME) ; fi
 	if [ ! -L $(ZIP_OUTPUT_BASENAME)/bin ] ; then ln -s ../bin $(ZIP_OUTPUT_BASENAME) ; fi
 	if [ ! -f $(ZIP_OUTPUT_BASENAME)/ThirdPartyNotices.txt ] ; then \
-		TPN="$(firstword $(wildcard bin/*/lib/xamarin.android/ThirdPartyNotices.txt))"; \
-		if [ -f "$$TPN" ]; then \
-			cp -n "$$TPN" $(ZIP_OUTPUT_BASENAME) ; \
-		else \
-			echo "warning: ThirdPartyNotices.txt file '$$TPN' does not exist." ; \
-			echo "warning: pwd=`pwd`"; \
-			echo "warning: files?" $(ls bin/*/lib/xamarin.android/ThirdPartyNotices.txt); \
-			echo "warning: trying hard-coded path"; \
-			cp bin/Debug/lib/xamarin.android/ThirdPartyNotices.txt $(ZIP_OUTPUT_BASENAME) || true ; \
-		fi; \
+		for f in bin/*/lib/xamarin.android/ThirdPartyNotices.txt ; do \
+			cp -n "$$f" $(ZIP_OUTPUT_BASENAME) || true; \
+		done; \
 	fi
 	_exclude_list=".__exclude_list.txt"; \
 	ls -1d $(_BUNDLE_ZIPS_EXCLUDE) > "$$_exclude_list" 2>/dev/null ; \


### PR DESCRIPTION
Commit 7f56c949 attempted to fix `make package-oss` on Linux, noting:

> In the absense of actually understanding what's wrong and fixing the
> real problem, instead print out some debug spew if the `cp` operation
> *would* fail -- because `$(firstword $(wildcard ...))` returns "" --
> and fallback to an attempted "hardcoded" `cp` operation.

We now have a plausible explanation which matches the facts on hand:
[`$(wildcard)` should be used with care][wildcard], because it's
behavior is dependant upon filesystem caching done by **make**.

[wildcard]: https://www.cmcrossroads.com/article/trouble-wildcard

> The unexpected, and apparently inconsistent, results above are
> because GNU Make contains its own cache of directory entries.
> `$(wildcard)` reads from that cache (and not directly from disk like
> `ls`) to get its results. When that cache is filled is vital to
> understanding the results the `$(wildcard)` will return.

In short, `$(wildcard)` should *not* be used with files that are
potentially generated during the "current" `make` invocation.
Use with "static" file lists, or files generated by *unrelated* `make`
invocations should be fine, but not within the *same*.

Review `$(wildcard)` use and use alternate mechanisms when we want to
use files which were potentially built within the same `make` process.