### PR TITLE
[tests] Ignore XUnit `nonuapaottests` category

### DIFF
--- a/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/XUnitInstrumentation.cs
+++ b/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/XUnitInstrumentation.cs
@@ -65,7 +65,10 @@ namespace xUnitTestRunner
 				// From some failing corefx tests
 				new XUnitFilter ("category", "nonlinuxtests", true),
 				new XUnitFilter ("category", "nonmonotests", true),
-				new XUnitFilter ("category", "nonnetfxtests", true)
+				new XUnitFilter ("category", "nonnetfxtests", true),
+#if !DEBUG  // aka "Release"
+				new XUnitFilter ("category", "nonuapaottests", true),
+#endif  // !DEBUG
 			};
 
 			if (excludedTestNames != null && excludedTestNames.Count > 0) {


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/1400

Related: https://github.com/xamarin/xamarin-android/pull/1421

The mono/corefx xUnit test
[`TaskSchedulerTests.GetTaskSchedulersForDebugger_ReturnsDefaultScheduler()`][0]
[fails when built in Release mode][1]:

[0]: https://github.com/dotnet/corefx/blob/893708a4c46047af6fb14bc0f2c33b3ca6adc527/src/System.Threading.Tasks/tests/TaskScheduler/TaskSchedulerTests.cs#L293-L301
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/980/testReport/junit/Test%20collection%20for%20System.Threading.Tasks.Tests/TaskSchedulerTests/System_Threading_Tasks_Tests_TaskSchedulerTests_GetTaskSchedulersForDebugger_ReturnsDefaultScheduler___Release/

	System.NullReferenceException : Object reference not set to an instance of an object
	+++++++++++++++++++
	STACK TRACE:
	  at System.Threading.Tasks.Tests.TaskSchedulerTests.GetTaskSchedulersForDebugger_ReturnsDefaultScheduler ()

The cause is that the test grabs the `MethodInfo` for the
`TaskScheduler.GetTaskSchedulersForDebugger()` method, which the
linker removes -- correctly! as there are no references to it -- and
the test then attempts to *invoke* the `MethodInfo`, but the
`MethodInfo` is `null` (linked away!), resulting in the
`NullReferenceException`.

The test should be fixed, but in the meantime we can instead ignore
the xUnit *category* of this test when building for Release.