### PR TITLE
[Xamarin.Android.Build.Tasks] Fix CheckTargetFrameworks to use LogCodedWarning

### DIFF
--- a/Documentation/guides/messages/xa0105.md
+++ b/Documentation/guides/messages/xa0105.md
@@ -1,10 +1,10 @@
 # Compiler Warning XA0105
 
 The Xamarin.Android build will emit a `XA0105` warning if it detects that one
-of the referenced libraries or projects is using a `TargetFrameworkVersion` higher 
-than the project being built. Using libraries which are targeting a higher
-`TargetFrameworkVersion` can cause unexpected results at runtime. Especially
-when running on older devices. 
+of the referenced libraries or projects is using a `$(TargetFrameworkVersion)`
+higher than the project being built. Using libraries which are targeting a
+higher `$(TargetFrameworkVersion)` can cause unexpected results at runtime.
+Especially when running on older devices.
 
 The fix is to increase the `$(TargetFrameworkVersion)` for your project to 
 be equal to or higher than the referenced library projects. 

--- a/Documentation/guides/messages/xa0105.md
+++ b/Documentation/guides/messages/xa0105.md
@@ -1,0 +1,10 @@
+# Compiler Warning XA0105
+
+The Xamarin.Android build will emit a `XA0105` warning if it detects that one
+of the referenced libraries or projects is using a `TargetFrameworkVersion` higher 
+than the project being built. Using libraries which are targeting a higher
+`TargetFrameworkVersion` can cause unexpected results at runtime. Especially
+when running on older devices. 
+
+The fix is to increase the `$(TargetFrameworkVersion)` for your project to 
+be equal to or higher than the referenced library projects. 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckTargetFrameworks.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckTargetFrameworks.cs
@@ -64,7 +64,7 @@ namespace Xamarin.Android.Tasks
 			var mainapiLevel = MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (TargetFrameworkVersion);
 			foreach (var item in apiLevels.Where (x => mainapiLevel < x.Value)) {
 				var itemOSVersion = MonoAndroidHelper.SupportedVersions.GetFrameworkVersionFromApiLevel (item.Value);
-				Log.LogWarning (null, "XA0105", null, ProjectFile, 0, 0, 0, 0,
+				Log.LogCodedWarning ("XA0105", ProjectFile, 0,
 					"The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for your project ({2}). " +
 					"You need to increase the $(TargetFrameworkVersion) for your project.", Path.GetFileName (item.Key.ItemSpec), itemOSVersion, TargetFrameworkVersion);
 			}


### PR DESCRIPTION
As part of our Error/Warning clean up we are changing
`CheckTargetFrameworks` to use LogCodedWarning and adding
docs for `XA0105`.