### PR TITLE
[Xamarin.Android.Build.Tasks] Fix XA5300 error reporting

### DIFF
--- a/Documentation/guides/messages/xa5300.md
+++ b/Documentation/guides/messages/xa5300.md
@@ -1,0 +1,11 @@
+# Error XA5300
+
+The XA5300 error is generated when the required Android SDK or Java SDK cannot
+be located during the build.
+
+This can be fixed on the command-line by overriding either the
+`$(AndroidSdkDirectory)` or `$(JavaSdkDirectory)` MSBuild properties:
+
+This can also be fixed [within Visual Studio options][vs-sdk].
+
+[vs-sdk]: https://docs.microsoft.com/en-us/xamarin/android/troubleshooting/questions/android-sdk-location?tabs=vswin

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -88,10 +88,10 @@ namespace Xamarin.Android.Tasks
 #if MSBUILD
 		static TaskLoggingHelper androidSdkLogger;
 
-		public static void RefreshAndroidSdk (string sdkPath, string ndkPath, string javaPath)
+		public static void RefreshAndroidSdk (string sdkPath, string ndkPath, string javaPath, TaskLoggingHelper logHelper = null)
 		{
 			Action<TraceLevel, string> logger = (level, value) => {
-				var log = androidSdkLogger;
+				var log = logHelper ?? androidSdkLogger;
 				switch (level) {
 				case TraceLevel.Error:
 					if (log == null)


### PR DESCRIPTION
When the Android SDK cannot be found, an XA5205 error *should* have
been reported.

Unfortunately for @directhex on Linux, that wasn't the case:

	$ msbuild Project.csproj
	...
	error MSB4018: The "ResolveSdks" task failed unexpectedly.
	error MSB4018: System.InvalidOperationException: Could not determine Android SDK location. Please provide `androidSdkPath`.
	error MSB4018:   at Xamarin.Android.Tools.AndroidSdkInfo..ctor (System.Action`2[T1,T2] logger, System.String androidSdkPath, System.String androidNdkPath, System.String javaSdkPath)
	error MSB4018:   at Xamarin.Android.Tasks.MonoAndroidHelper.RefreshAndroidSdk (System.String sdkPath, System.String ndkPath, System.String javaPath)
	error MSB4018:   at Xamarin.Android.Tasks.ResolveSdks.RunTask ()
	error MSB4018:   at Xamarin.Android.Tasks.ResolveSdks.Execute ()
	error MSB4018:   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute ()
	error MSB4018:   at Microsoft.Build.BackEnd.TaskBuilder+<ExecuteInstantiatedTask>d__26.MoveNext ()

The problem is due to commit b16ee559, which integrated
xamarin-android-tools and introduced use of `AndroidSdkInfo`.

`AndroidSdkInfo` *requires* that it be provided or that it be able to
*find* an Android SDK or Java JDK. If neither can be found, then the
`AndroidSdkInfo` constructor will throw an
`InvalidOperationException`, precisely as seen above.

This semantic change was overlooked, and generally wouldn't be
observed unless building on a "clean machine" that didn't have a
previous Xamarin.Android installation.

Update `MonoAndroidHelper.RefreshAndroidSdk()` so that the
`InvalidOperationException` is appropriately converted to an MSBuild
error, improving the user experience.

Additionally, change the error code from XA5205 (originally
"missing `aapt`") to XA5300 ("Android SDK not found") and add
documentation for the error message.