### PR TITLE
[Xamarin.Android.Build.Tasks] Add Coded Error for TargetFramework v4.5

### DIFF
--- a/Documentation/guides/messages/xa0109.md
+++ b/Documentation/guides/messages/xa0109.md
@@ -1,0 +1,7 @@
+# Compiler Warning XA0109
+
+This warning is raised because android version v4.5 no longer exists. As a result it
+is not supported by Xamarin.Android. 
+
+If you see this warning you should change your `$(TargetFrameworkVersion)` to be one of the 
+supported [versions](https://docs.microsoft.com/en-us/xamarin/android/app-fundamentals/android-api-levels?tabs=vswin#android-versions). 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -944,7 +944,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_CheckTargetFramework">
-	<Warning Text="Unsupported or invalid %24(TargetFrameworkVersion) value of 'v4.5'. Please update your Project Options." Condition=" '$(TargetFrameworkVersion)' == 'v4.5' "/> 
+	<Warning Code="XA0109" Text="Unsupported or invalid %24(TargetFrameworkVersion) value of 'v4.5'. Please update your Project Options." Condition=" '$(TargetFrameworkVersion)' == 'v4.5' "/> 
 </Target>
 
 <Target Name="_CheckForContent">


### PR DESCRIPTION
The `<Warning/>` which was being raised if the user used a
`$(TargetFrameworkVersion)` of `v4.5` did not have a code.

This adds a code and a document for it.