### PR TITLE
[Xamarin.Android.Build.Tasks] Check `javac -version`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2277,7 +2277,8 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		{
 			var path = Path.Combine ("temp", $"ValidateJavaVersion_{targetFrameworkVersion}_{buildToolsVersion}_{latestSupportedJavaVersion}_{javaVersion}");
 			string javaExe = "java";
-			var javaPath = CreateFauxJavaSdkDirectory (Path.Combine (path, "JavaSDK"), javaVersion, out javaExe);
+			string javacExe;
+			var javaPath = CreateFauxJavaSdkDirectory (Path.Combine (path, "JavaSDK"), javaVersion, out javaExe, out javacExe);
 			var AndroidSdkDirectory = CreateFauxAndroidSdkDirectory (Path.Combine (path, "android-sdk"), buildToolsVersion);
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
@@ -2292,6 +2293,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				Assert.AreEqual (expectedResult, builder.Build (proj, parameters: new string[] {
 					$"JavaSdkDirectory={javaPath}",
 					$"JavaToolExe={javaExe}",
+					$"JavacToolExe={javacExe}",
 					$"AndroidSdkBuildToolsVersion={buildToolsVersion}",
 					$"AndroidSdkDirectory={AndroidSdkDirectory}",
 					$"LatestSupportedJavaVersion={latestSupportedJavaVersion}",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
@@ -155,7 +155,8 @@ namespace Xamarin.Android.Build.Tests {
 			var path = Path.Combine ("temp", "UseLatestAndroidSdk_" + Guid.NewGuid ());
 			var androidSdkPath = CreateFauxAndroidSdkDirectory (Path.Combine (path, "android-sdk"), buildtools, apis);
 			string javaExe = string.Empty;
-			var javaPath = CreateFauxJavaSdkDirectory (Path.Combine (path, "jdk"), jdk, out javaExe);
+			string javacExe;
+			var javaPath = CreateFauxJavaSdkDirectory (Path.Combine (path, "jdk"), jdk, out javaExe, out javacExe);
 			var referencePath = CreateFauxReferencesDirectory (Path.Combine (path, "references"), apis);
 			var errors = new List<BuildErrorEventArgs> ();
 			IBuildEngine engine = new MockBuildEngine (TestContext.Out, errors);
@@ -178,6 +179,7 @@ namespace Xamarin.Android.Build.Tests {
 			task.CacheFile = Path.Combine (Root, path, "sdk.xml");
 			task.SequencePointsMode = "None";
 			task.JavaToolExe = javaExe;
+			task.JavacToolExe = javacExe;
 			Assert.AreEqual (expectedTaskResult, task.Execute (), $"Task should have {(expectedTaskResult ? "succeeded" : "failed" )}.");
 			Assert.AreEqual (expectedTargetFramework, task.TargetFrameworkVersion, $"TargetFrameworkVersion should be {expectedTargetFramework} but was {targetFrameworkVersion}");
 			if (!string.IsNullOrWhiteSpace (expectedError)) {
@@ -194,7 +196,8 @@ namespace Xamarin.Android.Build.Tests {
 			var path = Path.Combine ("temp", TestName);
 			var androidSdkPath = CreateFauxAndroidSdkDirectory (Path.Combine (path, "android-sdk"), "26.0.3");
 			string javaExe = string.Empty;
-			var javaPath = CreateFauxJavaSdkDirectory (Path.Combine (path, "jdk"), "1.8.0", out javaExe);
+			string javacExe;
+			var javaPath = CreateFauxJavaSdkDirectory (Path.Combine (path, "jdk"), "1.8.0", out javaExe, out javacExe);
 			var referencePath = CreateFauxReferencesDirectory (Path.Combine (path, "references"), new ApiInfo [] {
 				new ApiInfo () { Id = "26", Level = 26, Name = "Oreo", FrameworkVersion = "v8.0", Stable = true },
 				new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
@@ -219,6 +222,7 @@ namespace Xamarin.Android.Build.Tests {
 			task.CacheFile = Path.Combine (Root, path, "sdk.xml");
 			task.SequencePointsMode = "None";
 			task.JavaToolExe = javaExe;
+			task.JavacToolExe = javacExe;
 			var start = DateTime.UtcNow;
 			Assert.IsTrue (task.Execute ());
 			var executionTime = DateTime.UtcNow - start;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -667,6 +667,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 			TargetFrameworkVersion="$(TargetFrameworkVersion)"
 			UseLatestAndroidPlatformSdk="$(AndroidUseLatestPlatformSdk)"
 			JavaToolExe="$(JavaToolExe)"
+			JavacToolExe="$(JavacToolExe)"
 			LatestSupportedJavaVersion="$(LatestSupportedJavaVersion)"
 			MinimumSupportedJavaVersion="$(MinimumSupportedJavaVersion)"
 			LintToolPath="$(LintToolPath)"


### PR DESCRIPTION
@directhex notes:

> Jdk and jre aren't the same thing.
> If jre (java) is 8 but Jdk (javac) is 9, javac throws exit 2
> Yes I know it's an edge case
> But we should check both java and javac version for XA0030

Update `<ResolveSdks/>` to validate versions from *both*
`java -version` *and* `javac -version`, to ensure that we don't
inadvertently use JDK 9 tooling (see also 9c9e5e53).