### PR TITLE
[linux] Add a libzip4 package dependency to .deb

### DIFF
--- a/build-tools/debian-metadata/control
+++ b/build-tools/debian-metadata/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/xamarin/xamarin-android
 
 Package: xamarin.android-oss
 Architecture: amd64
-Depends: msbuild, java8-sdk, ${misc:Depends}, ${shlibs:Depends}
+Depends: msbuild, java8-sdk, libzip4, ${misc:Depends}, ${shlibs:Depends}
 Description: Xamarin.Android libraries and runtime (host component)
  The best way to build native Android apps.
  .


### PR DESCRIPTION
Building an apk breaks without libzip.so.4 present