### PR TITLE
[tests] Enable diagnostic logging for `make V=1`

### DIFF
--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -11,7 +11,8 @@
     <_NUnit>$(_Runtime) packages\NUnit.ConsoleRunner.3.7.0\tools\nunit3-console.exe</_NUnit>
     <_Test Condition=" '$(TEST)' != '' ">--test=&quot;$(TEST)&quot;</_Test>
     <_XABuild>$(_TopDir)\bin\$(Configuration)\bin\xabuild</_XABuild>
-    <_XABuildProperties>/p:Configuration=$(Configuration) /p:XAIntegratedTests=$(XAIntegratedTests)</_XABuildProperties>
+    <_XABuildDiag Condition=" '$(V)' != '' ">/v:diag </_XABuildDiag>
+    <_XABuildProperties>$(_XABuildDiag)/p:Configuration=$(Configuration) /p:XAIntegratedTests=$(XAIntegratedTests)</_XABuildProperties>
   </PropertyGroup>
   <ItemGroup>
     <_TestAssembly Include="$(_TopDir)\bin\Test$(Configuration)\Xamarin.Android.Build.Tests.dll" />


### PR DESCRIPTION
The [xamarin-android Jenkins job][0] isn't green, but it's not because
of any failing unit tests; 81ef825a fixed the last known unit test
failure.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/

This leaves us wondering: what's broken *now*?

Fortunately we have logs, e.g. [build #987][1]:

[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/987/

	Resources/drawable/android_button.xml(4): error APT0000: No resource found that matches the given name (at 'drawable' with value '@drawable/AndroidPressed'). […/xamarin-android/src/Mono.Android/Test/Mono.Android-Tests.csproj]
	Resources/drawable/android_button.xml(4): error APT0000: No resource found that matches the given name (at 'drawable' with value '@drawable/AndroidPressed'). […/xamarin-android/src/Mono.Android/Test/Mono.Android-Tests.csproj]
	…/xamarin-android/build-tools/scripts/RunTests.targets(87,5): error MSB3073: The command "…/xamarin-android/build-tools/scripts/../../bin/Release/bin/xabuild …/xamarin-android/build-tools/scripts/../../src/Mono.Android/Test/Mono.Android-Tests.csproj /t:SignAndroidPackage /p:Configuration=Release /p:XAIntegratedTests=False /p:AotAssemblies=True" exited with code 1.

Now we know why it's failing, we review the log file, and...

There's no diagnostic output for that failing build.

(Insert screaming & crying here.)

Fortunately we've been able to since repro the issue (fix pending),
but that's not quite the point/problem.

The problem is that figuring out what went wrong with the above
command would have been *much* easier if we had diagnostic output.

Update the e.g. `RunApkTests` MSBuild target so that if the `$V`
environment variable is not an empty string, we add `/v:diag` to
`xabuild` invocations. This permits straightforward `make` use:

	$ make run-all-tests CONFIGURATION=Release V=1
	# Unit test builds *also* produce diagnostic build output!