### PR TITLE
Update LayoutCodeBehind.md

### DIFF
--- a/Documentation/guides/LayoutCodeBehind.md
+++ b/Documentation/guides/LayoutCodeBehind.md
@@ -48,6 +48,9 @@ constants from the `Resource` type and the `FindViewById<T>()` method:
 
 ```csharp
 class MainActivity : Activity {
+
+  // Code omitted for brevity
+
   protected override void OnCreate (Bundle savedInstanceState)
   {
     base.OnCreate (savedInstanceState);
@@ -120,6 +123,9 @@ for strongly-typed access to IDs within the layout file:
 ```csharp
 // User-written code
 class MainActivity : Activity {
+
+  // Code omitted for brevity
+
   protected override void OnCreate (Bundle savedInstanceState)
   {
     base.OnCreate (savedInstanceState);
@@ -141,6 +147,9 @@ Alternatively, instead of using `SetContentView(int)`, which may result in a
 ```csharp
 // User-written code
 class MainActivity : Activity {
+
+  // Code omitted for brevity
+
   protected override void OnCreate (Bundle savedInstanceState)
   {
     base.OnCreate (savedInstanceState);

--- a/Documentation/guides/LayoutCodeBehind.md
+++ b/Documentation/guides/LayoutCodeBehind.md
@@ -47,7 +47,7 @@ partial class Resource {
 constants from the `Resource` type and the `FindViewById<T>()` method:
 
 ```csharp
-partial class MainActivity : Activity {
+class MainActivity : Activity {
   protected override void OnCreate (Bundle savedInstanceState)
   {
     base.OnCreate (savedInstanceState);
@@ -119,7 +119,7 @@ for strongly-typed access to IDs within the layout file:
 
 ```csharp
 // User-written code
-partial class MainActivity : Activity {
+class MainActivity : Activity {
   protected override void OnCreate (Bundle savedInstanceState)
   {
     base.OnCreate (savedInstanceState);
@@ -140,7 +140,7 @@ Alternatively, instead of using `SetContentView(int)`, which may result in a
 
 ```csharp
 // User-written code
-partial class MainActivity : Activity {
+class MainActivity : Activity {
   protected override void OnCreate (Bundle savedInstanceState)
   {
     base.OnCreate (savedInstanceState);
@@ -221,7 +221,7 @@ strongly typed properties for all of the *ids* within the layout file.
 Code-Behind builds atop the Binding mechanism, while requiring that layout
 files "opt-in" to Code-Behind generation by using the new
 [`xamarin:classes`](#xamarin:classes) XML attribute, which is a `;`-separated
-list of full class names to generated.
+list of full class names to be generated.
 
 Given the Android Layout file `Resources\layout\Main.axml`:
 


### PR DESCRIPTION
* Drop the `partial` modifier in the *Binding* examples. Our templates don't generate partial classes and it may create the impression that `partial` must be added, which it is not. 
* Fix a typo