### PR TITLE
[CodeBehind] Make sure the generated binding is not linked out

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutBindings.CSharpBindingGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutBindings.CSharpBindingGenerator.cs
@@ -177,6 +177,7 @@ namespace Xamarin.Android.Tasks
 
 			protected override void WriteBindingConstructor (State state, string className)
 			{
+				WriteLineIndent (state, $"[global::Android.Runtime.PreserveAttribute (Conditional=true)]");
 				WriteLineIndent (state, $"public {className} (global::{BindingClientInterfaceFull} client) : base (client)");
 				WriteLineIndent (state, "{}");
 				state.WriteLine ();


### PR DESCRIPTION
When the application with generated code-behind bindings is built in the Release
configuration with binding enabled (the default), the binding classes might be
linked out as they are instantiated using `Activator.CreateInstance` and not
directly. Prevent this from happening by decorating the binding constructor with
the `[Preserve]` custom attribute which tells the linker to keep the method in
the application.