### PR TITLE
[mono-runtime] Remap Mono.Cecil for utilities

### DIFF
--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -656,6 +656,15 @@
         SourceFiles="@(_MonoUtilitySource)"
         DestinationFiles="@(_MonoUtilityDest)"
     />
+    <ItemGroup>
+      <_MonoUtilityExe Include="@(_MonoUtility)">
+        <Source>$(_MonoOutputDir)\%(Identity)</Source>
+        <Dest>$(_MSBuildDir)\%(Identity)</Dest>
+      </_MonoUtilityExe>
+    </ItemGroup>
+    <Exec
+        Command="$(RemapAssemblyRefTool) &quot;%(_MonoUtilityExe.Source)&quot; &quot;%(_MonoUtilityExe.Dest)&quot; Mono.Cecil &quot;..\..\bin\Build$(Configuration)\Xamarin.Android.Cecil.dll&quot;"
+    />
   </Target>
   <Target Name="_InstallBcl"
       Inputs="@(_BclProfileItems)"


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/1652

Xamarin.Android doesn't ship `Mono.Cecil.dll`, as it is not fully
API-stable, and there have been historical problems when multiple
different versions of `Mono.Cecil.dll` were being used within the same
process at the same time.

Our solution to this was to "vendorize" `Mono.Cecil` into
`Xamarin.Android.Cecil.dll`, and update any utilities which reference
`Mono.Cecil.dll` to instead reference `Xamarin.Android.Cecil.dll` by
using `remap-assembly-ref.exe`; see also e814528c.

Unfortunately we overlooked some utilities.

Update `mono-runtimes.targets` so that `illinkanalyzer.exe`,
`mono-symbolicate.exe`, and `mkbundle.exe` have any assembly
references to `Mono.Cecil` remap'd to target `Xamarin.Android.Cecil`.