### PR TITLE
[Xamarin.Android.Build.Tasks] Designer items should be const for apps.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
@@ -28,7 +28,7 @@ namespace Foo.Foo
 		{
 			
 			// aapt resource value: 0
-			public static int slide_in_bottom = 0;
+			public const int slide_in_bottom = 0;
 			
 			static Animator()
 			{
@@ -44,7 +44,7 @@ namespace Foo.Foo
 		{
 			
 			// aapt resource value: 0
-			public static int ic_menu_preferences = 0;
+			public const int ic_menu_preferences = 0;
 			
 			static Drawable()
 			{
@@ -60,7 +60,7 @@ namespace Foo.Foo
 		{
 			
 			// aapt resource value: 0
-			public static int arial = 0;
+			public const int arial = 0;
 			
 			static Font()
 			{
@@ -76,7 +76,7 @@ namespace Foo.Foo
 		{
 			
 			// aapt resource value: 0
-			public static int menu_settings = 0;
+			public const int menu_settings = 0;
 			
 			static Id()
 			{
@@ -92,7 +92,7 @@ namespace Foo.Foo
 		{
 			
 			// aapt resource value: 0
-			public static int Options = 0;
+			public const int Options = 0;
 			
 			static Menu()
 			{
@@ -108,7 +108,7 @@ namespace Foo.Foo
 		{
 			
 			// aapt resource value: 0
-			public static int icon = 0;
+			public const int icon = 0;
 			
 			static Mipmap()
 			{
@@ -124,7 +124,7 @@ namespace Foo.Foo
 		{
 			
 			// aapt resource value: 0
-			public static int num_locations_reported = 0;
+			public const int num_locations_reported = 0;
 			
 			static Plurals()
 			{
@@ -140,16 +140,16 @@ namespace Foo.Foo
 		{
 			
 			// aapt resource value: 0
-			public static int app_name = 0;
+			public const int app_name = 0;
 			
 			// aapt resource value: 0
-			public static int foo = 0;
+			public const int foo = 0;
 			
 			// aapt resource value: 0
-			public static int hello = 0;
+			public const int hello = 0;
 			
 			// aapt resource value: 0
-			public static int menu_settings = 0;
+			public const int menu_settings = 0;
 			
 			static String()
 			{

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -304,7 +304,7 @@ namespace Xamarin.Android.Tasks
 				return;
 			var f = new CodeMemberField (typeof (int []), name) {
 				// pity I can't make the member readonly...
-				Attributes = app ? MemberAttributes.Const | MemberAttributes.Public : MemberAttributes.Static | MemberAttributes.Public,
+				Attributes = MemberAttributes.Static | MemberAttributes.Public,
 			};
 			CodeArrayCreateExpression c = (CodeArrayCreateExpression)f.InitExpression;
 			if (c == null) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -13,6 +13,7 @@ namespace Xamarin.Android.Tasks
 		CodeTypeDeclaration resources;
 		CodeTypeDeclaration layout, ids, drawable, strings, colors, dimension, raw, animator, animation, attrib, boolean, font, ints, interpolators, menu, mipmaps, plurals, styleable, style, arrays;
 		Dictionary<string, string> map;
+		bool app;
 
 		void SortMembers (CodeTypeDeclaration decl)
 		{
@@ -28,6 +29,7 @@ namespace Xamarin.Android.Tasks
 			if (!Directory.Exists (resourceDirectory))
 				throw new ArgumentException ("Specified resource directory was not found: " + resourceDirectory);
 
+			app = isApp;
 			map = resourceMap ?? new Dictionary<string, string> ();
 			resources = CreateResourceClass ();
 			animation = CreateClass ("Animation");
@@ -274,7 +276,7 @@ namespace Xamarin.Android.Tasks
 		{
 			var f = new CodeMemberField (type, name) {
 				// pity I can't make the member readonly...
-				Attributes = MemberAttributes.Public | MemberAttributes.Static,
+				Attributes = app ? MemberAttributes.Const | MemberAttributes.Public : MemberAttributes.Static | MemberAttributes.Public,
 			};
 			parentType.Members.Add (f);
 		}
@@ -286,7 +288,7 @@ namespace Xamarin.Android.Tasks
 				return;
 			var f = new CodeMemberField (typeof (int), mappedName) {
 				// pity I can't make the member readonly...
-				Attributes = MemberAttributes.Static | MemberAttributes.Public,
+				Attributes = app ? MemberAttributes.Const | MemberAttributes.Public : MemberAttributes.Static | MemberAttributes.Public,
 				InitExpression = new CodePrimitiveExpression (value),
 				Comments = {
 						new CodeCommentStatement ($"aapt resource value: {value}"),
@@ -302,7 +304,7 @@ namespace Xamarin.Android.Tasks
 				return;
 			var f = new CodeMemberField (typeof (int []), name) {
 				// pity I can't make the member readonly...
-				Attributes = MemberAttributes.Public | MemberAttributes.Static,
+				Attributes = app ? MemberAttributes.Const | MemberAttributes.Public : MemberAttributes.Static | MemberAttributes.Public,
 			};
 			CodeArrayCreateExpression c = (CodeArrayCreateExpression)f.InitExpression;
 			if (c == null) {


### PR DESCRIPTION
The `ManagedResourceParser` was not taking into account the fact
that the app should be using `const` not `static` for the
resource fields.