### PR TITLE
[Xamarin.Android.Build.Tasks] Intelligently update the `$(Intermediate)res` directory.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (b.Build (proj), "first build failed");
 				Assert.IsTrue (b.Build (proj), "second build failed");
 				Assert.IsTrue (b.Output.IsTargetSkipped ("_Sign"), "failed to skip some build");
-				proj.AndroidResources.First ().Timestamp = null; // means "always build"
+				proj.AndroidResources.Last ().Timestamp = null; // means "always build"
 				Assert.IsTrue (b.Build (proj), "third build failed");
 				Assert.IsFalse (b.Output.IsTargetSkipped ("_Sign"), "incorrectly skipped some build");
 			}
@@ -468,8 +468,21 @@ namespace UnnamedProject
 				File.SetAttributes (designerPath, FileAttributes.ReadOnly);
 				Assert.IsTrue ((File.GetAttributes (designerPath) & FileAttributes.ReadOnly) == FileAttributes.ReadOnly,
 					"{0} should be read only", designerPath);
-				var mainAxml = Path.Combine (Root, b.ProjectDirectory, "Resources", "layout", "Main.axml");
-				File.SetLastWriteTimeUtc (mainAxml, DateTime.UtcNow);
+				var main = proj.AndroidResources.First (x => x.Include () == "Resources\\layout\\Main.axml");
+				main.Timestamp = DateTime.UtcNow;
+				main.TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
+<LinearLayout xmlns:android=""http://schemas.android.com/apk/res/android""
+	android:orientation=""vertical""
+	android:layout_width=""fill_parent""
+	android:layout_height=""fill_parent""
+	>
+<Button  
+	android:id=""@+id/myButton""
+	android:layout_width=""fill_parent"" 
+	android:layout_height=""wrap_content"" 
+	android:text=""Hello""
+	/>
+</LinearLayout>";
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				Assert.IsTrue ((File.GetAttributes (designerPath) & FileAttributes.ReadOnly) != FileAttributes.ReadOnly,
 					"{0} should be writable", designerPath);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -588,7 +588,7 @@ namespace UnnamedProject {
 				Assert.IsTrue (
 					b.Output.IsTargetSkipped ("_StripEmbeddedLibraries"),
 					"the _StripEmbeddedLibraries target should not run");
-				proj.AndroidResources.First ().Timestamp = null;
+				proj.AndroidResources.Last ().Timestamp = null;
 				Assert.IsTrue (b.Build (proj), "third build failed");
 				Assert.IsFalse (
 					b.Output.IsTargetSkipped ("_Sign"),

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -13,6 +13,23 @@ namespace Xamarin.Android.Build.Tests
 	public class IncrementalBuildTest : BaseTest
 	{
 		[Test]
+		public void CheckResourceDirectoryDoesNotGetHosed ()
+		{
+			// do a release build
+			// change one of the properties (say AotAssemblies) 
+			// do another build. it should NOT hose the resource directory.
+			var path = Path.Combine ("temp", TestName);
+			var proj = new XamarinAndroidApplicationProject () {
+				ProjectName = "App1",
+				IsRelease = true,
+			};
+			using (var b = CreateApkBuilder (path, false, false)) {
+				Assert.IsTrue(b.Build (proj), "First should have succeeded");
+				Assert.IsTrue(b.Build (proj,  parameters: new [] { "AotAssemblies=True" }), "Second should have succeeded");
+			}
+		}
+
+		[Test]
 		public void IncrementalCleanDuringClean ()
 		{
 			var path = Path.Combine ("temp", TestName);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1193,20 +1193,21 @@ because xbuild doesn't support framework reference assemblies.
 			DestinationFiles="@(_AndroidResourceDest)"
 			AcwMapFile="$(_AcwMapFile)"
 			CacheFile="$(_AndroidResourcesCacheFile)"
-			Condition=" '$(AndroidExplicitCrunch)' == 'True' And '$(AndroidApplication)' != '' And $(AndroidApplication)">
+			Condition="  '$(AndroidExplicitCrunch)' == 'True' And '$(AndroidApplication)' != '' And $(AndroidApplication)">
 		<Output ItemName="_ModifiedResources" TaskParameter="ModifiedFiles"/>
 	</CopyAndConvertResources>
 	<Crunch SourceFiles="@(_ModifiedResources)" ToolPath="$(AaptToolPath)" ToolExe="$(AaptToolExe)"
 			Condition=" '$(AndroidExplicitCrunch)' == 'True' And '$(AndroidApplication)' != '' And $(AndroidApplication)" />
-	<Copy SourceFiles="@(_AndroidResolvedResources)"
+	<CopyIfChanged SourceFiles="@(_AndroidResolvedResources)"
 		DestinationFiles="@(_AndroidResourceDest)"
-		SkipUnchangedFiles="true"
 		Condition=" '$(AndroidExplicitCrunch)' != 'True' Or '$(AndroidApplication)' == '' Or !($(AndroidApplication))"
-	/>
+	>
+		<Output ItemName="_ModifiedResources" TaskParameter="ModifiedFiles"/>
+	</CopyIfChanged>
 	<RemoveUnknownFiles Files="@(_AndroidResourceDest)" Directory="$(MonoAndroidResDirIntermediate)" RemoveDirectories="true">
 		<Output ItemName="_AndroidResourceDestRemovedFiles" TaskParameter="RemovedFiles" />
 	</RemoveUnknownFiles>
-	<Touch Files="$(_AndroidResFlagFile)" AlwaysCreate="True" />
+	<Touch Files="$(_AndroidResFlagFile)" AlwaysCreate="True" Condition=" !Exists ('$(_AndroidResFlagFile)') Or  '@(_ModifiedResources)' != '' Or '@(_AndroidResourceDestRemovedFiles)' != '' " />
 	<ItemGroup>
 		<FileWrites Include="$(_AndroidResFlagFile)" />
 	</ItemGroup>


### PR DESCRIPTION
For a long time it seems we have not been correctly updating the
`$(Intermediate)res` in the `_GenerateAndroidResourcesDir` target.
This has recently come to light with our switch over to msbuild
as our main way to compile (rather than xbuild).

For Target `Inputs` and `Outputs` msbuild only checks the timestamps
of files to decide if they have changed. However the Copy task checks
both the timestamps AND the contents. It seems to do this even if
the timestamps are the same or the destination file is newer. 
If the contents change the file is copied.

This causes us a problem, since we fixup the destination files
by changing the cases of Resources. Also we replace references to
managed class names with the md5 hashes Java class. As a result if
we run the `_GenerateAndroidResourcesDir` for what ever reason,
almost ALL the items will get updated. This will then cascade and
result in a new APK being built.

This might explain some of the odd behaviour we get reported by
our uses regarding resources not being found, or long deployments.

So lets use our `CopyIfChanged` task rather than `Copy`. This task only
tries to copy the file IF the source file is newer. After that if
the file did not change it will be skipped. But if it did change
it will be copied. We also update the `Touch` call to make sure
we only touch the resource flag file IF and ONLY IF

1. The file does not exist
2. One of the files has been modified.

Some of the tests which wanted to force a resource build had to be
updated since they were just modifying the timestamp of the first
resource item in the project. This generally is a drawable and never
changes so we never hit the problem where the source and destination
files are different. As a result the expected targets did not run
because the system correctly detected no changes.