### PR TITLE
[timing] fix for Debug/Release to get combined into CSV

### DIFF
--- a/build-tools/timing/timing.targets
+++ b/build-tools/timing/timing.targets
@@ -39,6 +39,7 @@
         InputFiles="@(_TimingResults)"
         ResultsFilename="$(_TopDir)TestResult-MSBuild-times.csv"
         LabelSuffix="-$(Configuration)"
+        AddResults="True"
     />
   </Target>
   <Target Name="MSBuildPrep" DependsOnTargets="GetXAVersionInfo;AcquireAndroidTarget">


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/plot/Build%20times/

The plots on Jenkins are only displaying times for the `Release`
configuration. Looking into it, the `<ProcessMSBuildTiming />` task
was not using the `AddResults` option, so it was replacing the
contents of the CSV file. MSBuild is invoked twice for `Debug` and
`Release`.

Setting `AddResults` will now append additional columns to the
`TestResult-MSBuild-times.csv` file so we get results for both `Debug`
and `Release` configurations.