### PR TITLE
[Xamarin.Android.Build.Tasks] Disable layout bindings

### DIFF
--- a/src/Mono.Android/Test/Mono.Android-Tests.csproj
+++ b/src/Mono.Android/Test/Mono.Android-Tests.csproj
@@ -101,7 +101,7 @@
     <AndroidResource Include="Resources\drawable\android_button.xml" />
     <AndroidResource Include="Resources\xml\XmlReaderResourceParser.xml" />
     <AndroidResource Include="Resources\layout\FragmentFixup.axml" />
-    <AndroidResource Include="Resources\layout\Main.axml" />
+    <AndroidBoundLayout Include="Resources\layout\Main.axml" />
     <AndroidResource Include="..\..\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Resources\Base\Image.9.png">
       <Link>Resources\Drawable\Image.9.png</Link>
     </AndroidResource>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1249,6 +1249,7 @@ namespace UnnamedProject
 	}
 ",
 			};
+			proj.SetProperty ("AndroidGenerateLayoutBindings", "True");
 			using (var builder = CreateApkBuilder (path)) {
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
 				FileAssert.Exists (Path.Combine (Root, path, proj.IntermediateOutputPath, "generated", "Binding.Main.g.cs"));

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -195,7 +195,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidPreferNativeLibrariesWithDebugSymbols Condition=" '$(AndroidPreferNativeLibrariesWithDebugSymbols)' == '' ">False</AndroidPreferNativeLibrariesWithDebugSymbols>
 	<AndroidSkipJavacVersionCheck Condition="'$(AndroidSkipJavacVersionCheck)' == ''">False</AndroidSkipJavacVersionCheck>
 	<AndroidBuildApplicationPackage Condition=" '$(AndroidBuildApplicationPackage)' == ''">False</AndroidBuildApplicationPackage>
-	<AndroidGenerateLayoutBindings Condition=" '$(AndroidGenerateLayoutBindings)' == '' ">True</AndroidGenerateLayoutBindings>
+	<AndroidGenerateLayoutBindings Condition=" '$(AndroidGenerateLayoutBindings)' == '' ">False</AndroidGenerateLayoutBindings>
 
 	<!-- Currently only C# is supported -->
 	<AndroidGenerateLayoutBindings Condition=" '$(Language)' != 'C#' ">False</AndroidGenerateLayoutBindings>

--- a/tests/CodeBehind/BuildTests/CodeBehindBuildTests.csproj
+++ b/tests/CodeBehind/BuildTests/CodeBehindBuildTests.csproj
@@ -16,6 +16,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
+    <AndroidGenerateLayoutBindings>True</AndroidGenerateLayoutBindings>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/1669

The layout bindings and associated Code-Behind (ab3773cf)
infrastructure is breaking existing projects, e.g. the
[Cheesesquare sample][0] [fails to build][1] with:

[0]: http://github.com/xamarin/monodroid-samples/tree/master/android5.0/Cheesesquare
[1]: https://github.com/xamarin/xamarin-android/issues/1669#issuecomment-388163599

	error CS0234: The type or namespace name 'Android' does not exist in the namespace 'Cheesesquare'

This is apparently happening because the wrong namespace is used for
the generated `Resource` type, with generated code containing:

	public TextView Text1 => FindView (global::Cheesesquare.Android.Resource.Id.Text1, ref __Text1);

There is no `Cheesesquare.Android.Resource` type; the generated
`Resource.designer.cs` file contains `Cheesesquare.Resource`.

Disable layout binds for now, until it can become more stable.