### PR TITLE
[monodroid] Add libjava-interop sources to runtime sources

### DIFF
--- a/src/monodroid/jni/dylib-mono.c
+++ b/src/monodroid/jni/dylib-mono.c
@@ -136,6 +136,7 @@ int monodroid_dylib_mono_init (struct DylibMono *mono_imports, const char *libmo
 	LOAD_SYMBOL(mono_string_new)
 	LOAD_SYMBOL(mono_thread_attach)
 	LOAD_SYMBOL(mono_thread_create)
+	LOAD_SYMBOL(mono_thread_current)
 	LOAD_SYMBOL(mono_use_llvm)
 
 

--- a/src/monodroid/jni/dylib-mono.h
+++ b/src/monodroid/jni/dylib-mono.h
@@ -60,6 +60,7 @@ typedef void MonoObject;
 typedef void MonoProfiler;
 typedef void MonoProperty;
 typedef void MonoString;
+typedef void MonoThread;
 typedef void MonoType;
 typedef void (*MonoDomainFunc) (MonoDomain *domain, void* user_data);
 
@@ -190,12 +191,12 @@ typedef void*           (*monodroid_mono_assembly_name_new_fptr) (const char *na
 typedef void            (*monodroid_mono_assembly_name_free_fptr) (MonoAssemblyName *aname);
 typedef void*           (*monodroid_mono_assembly_open_full_fptr) (const char *filename, MonoImageOpenStatus *status, mono_bool refonly);
 typedef char*           (*monodroid_mono_check_corlib_version_fptr) ();
-typedef void*           (*monodroid_mono_class_from_mono_type_fptr) (void *arg0);
+typedef MonoClass*      (*monodroid_mono_class_from_mono_type_fptr) (MonoType *arg0);
 typedef void*           (*monodroid_mono_class_from_name_fptr) (MonoImage *image, const char *name_space, const char *name);
 typedef char*           (*monodroid_mono_class_get_name_fptr) (MonoClass *arg0);
 typedef char*           (*monodroid_mono_class_get_namespace_fptr) (MonoClass *arg0);
 typedef mono_bool       (*monodroid_mono_class_is_subclass_of_fptr) (MonoClass *klass, MonoClass *klassc, mono_bool use_interfaces);
-typedef void*           (*monodroid_mono_class_get_field_from_name_fptr) (MonoClass *arg0, char *arg1);
+typedef void*           (*monodroid_mono_class_get_field_from_name_fptr) (MonoClass *arg0, const char *arg1);
 typedef MonoClassField* (*monodroid_mono_class_get_fields_fptr) (MonoClass *arg0, void **arg1);
 typedef void*           (*monodroid_mono_class_get_method_from_name_fptr) (MonoClass *arg0, char *arg1, int arg2);
 typedef MonoProperty*   (*monodroid_mono_class_get_property_from_name_fptr) (MonoClass *klass, const char *name);
@@ -249,6 +250,7 @@ typedef void            (*monodroid_mono_set_signal_chaining_fptr)(mono_bool cha
 typedef MonoString*     (*monodroid_mono_string_new_fptr)(MonoDomain *domain, const char *text);
 typedef void*           (*monodroid_mono_thread_attach_fptr) (MonoDomain *domain);
 typedef void            (*monodroid_mono_thread_create_fptr) (MonoDomain *domain, void* func, void* arg);
+typedef MonoThread*     (*monodroid_mono_thread_current_fptr) (void);
 typedef void            (*monodroid_mono_gc_disable_fptr) (void);
 typedef void*           (*monodroid_mono_install_assembly_refonly_preload_hook_fptr) (MonoAssemblyPreLoadFunc func, void *user_data);
 typedef int             (*monodroid_mono_runtime_set_main_args_fptr) (int argc, char* argv[]);
@@ -339,6 +341,7 @@ struct DylibMono {
 	monodroid_mono_property_set_value_fptr                  mono_property_set_value;
 	monodroid_mono_class_get_property_from_name_fptr        mono_class_get_property_from_name;
 	monodroid_mono_domain_from_appdomain_fptr               mono_domain_from_appdomain;
+	monodroid_mono_thread_current_fptr                      mono_thread_current;
 };
 
 MONO_API  struct  DylibMono*  monodroid_dylib_mono_new (const char *libmono_path);

--- a/src/monodroid/monodroid.props
+++ b/src/monodroid/monodroid.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <_DebugCFlags>-ggdb3 -O0 -fno-omit-frame-pointer</_DebugCFlags>
     <_ReleaseCFlags>-g -O2</_ReleaseCFlags>
-    <_CommonCFlags>-Ijni -Ijni/zip "-I$(MonoSourceFullPath)\mono\eglib" -std=c99 -DSGEN_BRIDGE_VERSION=$(MonoSgenBridgeVersion) -D_REENTRANT -DHAVE_CONFIG_H -DMONO_DLL_EXPORT -DJI_DLL_EXPORT -fno-strict-aliasing -ffunction-sections -fvisibility=hidden -Wformat -Werror=format-security</_CommonCFlags>
+    <_CommonCFlags>-Ijni -Ijni/zip "-I$(MonoSourceFullPath)\mono\eglib" -std=c99 -DSGEN_BRIDGE_VERSION=$(MonoSgenBridgeVersion) -D_REENTRANT -DHAVE_CONFIG_H -DMONO_DLL_EXPORT -DJI_DLL_EXPORT -DDYLIB_MONO -fno-strict-aliasing -ffunction-sections -fvisibility=hidden -Wformat -Werror=format-security</_CommonCFlags>
     <_HostUnixCFlags>$(_CommonCFlags) -Wa,--noexecstack</_HostUnixCFlags>
     <_HostUnixLdFlags>-Wall -lstdc++ -lz -shared -fpic</_HostUnixLdFlags>
     <_HostCommonWinCFlags>$(_CommonCFlags) -DWINDOWS -DNTDDI_VERSION=NTDDI_VISTA -D_WIN32_WINNT=_WIN32_WINNT_VISTA -fomit-frame-pointer</_HostCommonWinCFlags>

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -20,6 +20,9 @@
     <_CFile Include="jni\util.c" />
     <_CFile Include="jni\zip\ioapi.c" />
     <_CFile Include="jni\zip\unzip.c" />
+    <_CFile Include="$(JavaInteropSourceDirectory)\src\java-interop\java-interop.c" />
+    <_CFile Include="$(JavaInteropSourceDirectory)\src\java-interop\java-interop-mono.c" />
+    <_CFile Include="$(JavaInteropSourceDirectory)\src\java-interop\java-interop-gc-bridge-mono.c" />
   </ItemGroup>
   <!-- These are referenced in %(_HostRuntime.ExtraSource) -->
   <ItemGroup>


### PR DESCRIPTION
Also add `MonoThread` and `mono_thread_current` to *dylib*.

Fixed `monodroid_mono_class_get_field_from_name_fptr` signature, where
we were missing *const* for 2nd argument.
    
Used relevant types in the `monodroid_mono_class_from_mono_type_fptr`
signature.