### PR TITLE
[tests] change NUnit result format on Windows

### DIFF
--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -9,6 +9,8 @@
   <PropertyGroup>
     <_Runtime Condition=" '$(HostOS)' != 'Windows' ">$(ManagedRuntime)</_Runtime>
     <_NUnit>$(_Runtime) packages\NUnit.ConsoleRunner.3.7.0\tools\nunit3-console.exe</_NUnit>
+    <_NUnitFormat Condition=" '$(HostOS)' != 'Windows' ">nunit2</_NUnitFormat>
+    <_NUnitFormat Condition=" '$(HostOS)' == 'Windows' ">nunit3</_NUnitFormat>
     <_Test Condition=" '$(TEST)' != '' ">--test=&quot;$(TEST)&quot;</_Test>
     <_XABuild>$(_TopDir)\bin\$(Configuration)\bin\xabuild</_XABuild>
     <_XABuildDiag Condition=" '$(V)' != '' ">/v:diag </_XABuildDiag>
@@ -28,7 +30,7 @@
   <Target Name="RunNUnitTests">
     <SetEnvironmentVariable Name="USE_MSBUILD" Value="0" Condition=" '$(USE_MSBUILD)' == '' " />
     <Exec
-        Command="$(_NUnit) $(NUNIT_EXTRA) %(_TestAssembly.Identity) $(_Test) --labels=All --result=&quot;TestResult-%(Filename).xml;format=nunit2&quot; --output=&quot;bin\Test$(Configuration)\TestOutput-%(Filename).txt&quot;"
+        Command="$(_NUnit) $(NUNIT_EXTRA) %(_TestAssembly.Identity) $(_Test) --labels=All --result=&quot;TestResult-%(Filename).xml;format=$(_NUnitFormat)&quot; --output=&quot;bin\Test$(Configuration)\TestOutput-%(Filename).txt&quot;"
         WorkingDirectory="$(_TopDir)"
         ContinueOnError="ErrorAndContinue"
     />


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=1685026

On master, Windows builds have been frequently timing out on the
completion of the Xamarin.Android.Build.Tests NUnit tests:

    2018-05-14T16:11:30.6755378Z   Test Run Summary
    2018-05-14T16:11:30.6755639Z     Overall result: Warning
    2018-05-14T16:11:30.6755977Z     Test Count: 314, Passed: 275, Failed: 0, Warnings: 0, Inconclusive: 0, Skipped: 39
    2018-05-14T16:11:30.6756344Z       Skipped Tests - Ignored: 39, Explicit: 0, Other: 0
    2018-05-14T16:11:30.6758931Z     Start time: 2018-05-14 15:48:47Z
    2018-05-14T16:11:30.6772121Z       End time: 2018-05-14 16:11:30Z
    2018-05-14T16:11:30.6772666Z       Duration: 1362.691 seconds
    2018-05-14T16:11:30.6772900Z
    2018-05-14T16:11:30.6989428Z   Results (nunit2) saved as TestResult-Xamarin.Android.Build.Tests.xml
    2018-05-14T19:34:35.2647344Z Attempting to cancel the build...
    2018-05-14T19:34:40.2864864Z ##[warning]build-tools\scripts\RunTests.targets(30,5): Warning MSB4220: Waiting for the currently executing task "Exec" to cancel.

VSTS is hitting the 4 hour build timeout we have configured, and so
VSTS is cancelling the running `<Exec />` MSBuild task. It is very
strange, because it seems to be timing out *after* it starts writing
the test results file...

Since the tests appear to be completed, seeing if using the default
`nunit3` result format on Windows will solve the problem.