### PR TITLE
[tests] update NUnit.ConsoleRunner

### DIFF
--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -8,7 +8,7 @@
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.SetEnvironmentVariable" />
   <PropertyGroup>
     <_Runtime Condition=" '$(HostOS)' != 'Windows' ">$(ManagedRuntime)</_Runtime>
-    <_NUnit>$(_Runtime) packages\NUnit.ConsoleRunner.3.7.0\tools\nunit3-console.exe</_NUnit>
+    <_NUnit>$(_Runtime) packages\NUnit.ConsoleRunner.3.8.0\tools\nunit3-console.exe</_NUnit>
     <_Test Condition=" '$(TEST)' != '' ">--test=&quot;$(TEST)&quot;</_Test>
     <_XABuild>$(_TopDir)\bin\$(Configuration)\bin\xabuild</_XABuild>
     <_XABuildDiag Condition=" '$(V)' != '' ">/v:diag </_XABuildDiag>

--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -28,7 +28,7 @@
   <Target Name="RunNUnitTests">
     <SetEnvironmentVariable Name="USE_MSBUILD" Value="0" Condition=" '$(USE_MSBUILD)' == '' " />
     <Exec
-        Command="$(_NUnit) $(NUNIT_EXTRA) %(_TestAssembly.Identity) $(_Test) --labels=All --result=&quot;TestResult-%(Filename).xml;format=nunit2&quot; --output=&quot;bin\Test$(Configuration)\TestOutput-%(Filename).txt&quot;"
+        Command="$(_NUnit) $(NUNIT_EXTRA) %(_TestAssembly.Identity) $(_Test) --trace=Verbose --labels=All --result=&quot;TestResult-%(Filename).xml;format=nunit2&quot; --output=&quot;bin\Test$(Configuration)\TestOutput-%(Filename).txt&quot;"
         WorkingDirectory="$(_TopDir)"
         ContinueOnError="ErrorAndContinue"
     />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -39,7 +39,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="nunit.framework">
-      <HintPath>..\..\..\..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
+      <HintPath>..\..\..\..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <!-- Because Xamarin.Android.Build.Tasks.csproj doesn't build in VsForMac :(
     <Reference Include="Xamarin.Android.Build.Tasks" Condition="Exists('$(OutputPath)..\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Build.Tasks.dll')">

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="3.7.1" targetFramework="net451" />
-  <package id="NUnit.Console" version="3.7.0" targetFramework="net451" />
-  <package id="NUnit.ConsoleRunner" version="3.7.0" targetFramework="net451" />
+  <package id="NUnit.Console" version="3.8.0" targetFramework="net462" />
+  <package id="NUnit.ConsoleRunner" version="3.8.0" targetFramework="net462" />
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net451" />
   <package id="NUnit.Extension.NUnitV2Driver" version="3.7.0" targetFramework="net451" />
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net451" />
-  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net451" />
-  <package id="NUnit.Extension.VSProjectLoader" version="3.6.0" targetFramework="net451" />
+  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.3" targetFramework="net462" />
+  <package id="NUnit.Extension.VSProjectLoader" version="3.7.0" targetFramework="net462" />
   <package id="Unofficial.Ionic.Zip" version="1.9.1.8" targetFramework="net45" />
 </packages>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.7.1" targetFramework="net451" />
+  <package id="NUnit" version="3.8.1" targetFramework="net462" />
   <package id="NUnit.Console" version="3.8.0" targetFramework="net462" />
   <package id="NUnit.ConsoleRunner" version="3.8.0" targetFramework="net462" />
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net451" />

--- a/tests/CodeBehind/UnitTests/run.sh
+++ b/tests/CodeBehind/UnitTests/run.sh
@@ -4,4 +4,4 @@ export USE_MSBUILD=1
 export MSBUILD=msbuild
 msbuild CodeBehindUnitTests.csproj
 cd ../../../
-exec mono --debug packages/NUnit.ConsoleRunner.3.7.0/tools/nunit3-console.exe bin/TestDebug/CodeBehind/CodeBehindUnitTests.dll
+exec mono --debug packages/NUnit.ConsoleRunner.3.8.0/tools/nunit3-console.exe bin/TestDebug/CodeBehind/CodeBehindUnitTests.dll


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=1685026

On master, Windows builds have been frequently timing out on the
completion of the Xamarin.Android.Build.Tests NUnit tests:

    2018-05-14T16:11:30.6755378Z   Test Run Summary
    2018-05-14T16:11:30.6755639Z     Overall result: Warning
    2018-05-14T16:11:30.6755977Z     Test Count: 314, Passed: 275, Failed: 0, Warnings: 0, Inconclusive: 0, Skipped: 39
    2018-05-14T16:11:30.6756344Z       Skipped Tests - Ignored: 39, Explicit: 0, Other: 0
    2018-05-14T16:11:30.6758931Z     Start time: 2018-05-14 15:48:47Z
    2018-05-14T16:11:30.6772121Z       End time: 2018-05-14 16:11:30Z
    2018-05-14T16:11:30.6772666Z       Duration: 1362.691 seconds
    2018-05-14T16:11:30.6772900Z
    2018-05-14T16:11:30.6989428Z   Results (nunit2) saved as TestResult-Xamarin.Android.Build.Tests.xml
    2018-05-14T19:34:35.2647344Z Attempting to cancel the build...
    2018-05-14T19:34:40.2864864Z ##[warning]build-tools\scripts\RunTests.targets(30,5): Warning MSB4220: Waiting for the currently executing task "Exec" to cancel.

VSTS is hitting the 4 hour build timeout we have configured, and so
VSTS is cancelling the running `<Exec />` MSBuild task. It is very
strange, because it seems to be timing out *after* it starts writing
the test results file...

Updating NUnit.ConsoleRunner to see if this helps any:

NUnit.ConsoleRunner 3.7.0 -> 3.8.0