### PR TITLE
Fix bundled app crash on startup

### DIFF
--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -24,6 +24,7 @@
     <_ApkTestProject Include="$(_TopDir)\tests\BCL-Tests\Xamarin.Android.Bcl-Tests\Xamarin.Android.Bcl-Tests.csproj" />
     <_ApkTestProject Include="$(_TopDir)\tests\Xamarin.Forms-Performance-Integration\Droid\Xamarin.Forms.Performance.Integration.Droid.csproj" />
     <_ApkTestProjectAot Include="$(_TopDir)\src\Mono.Android\Test\Mono.Android-Tests.csproj" />
+    <_ApkTestProjectBundle Include="$(_TopDir)\src\Mono.Android\Test\Mono.Android-Tests.csproj" />
   </ItemGroup>
   <Target Name="RunNUnitTests">
     <SetEnvironmentVariable Name="USE_MSBUILD" Value="0" Condition=" '$(USE_MSBUILD)' == '' " />
@@ -94,6 +95,16 @@
         Projects="$(_TopDir)\tests\RunApkTests.targets"
         Condition=" '$(Configuration)' == 'Release' "
         Properties="AotAssemblies=True"
+    />
+    <Exec
+        Command="$(_XABuild) %(_ApkTestProjectBundle.Identity) /t:SignAndroidPackage $(_XABuildProperties) /p:BundleAssemblies=True /p:EmbedAssembliesIntoApk=True"
+        Condition=" '$(Configuration)' == 'Release' "
+    />
+    <MSBuild
+        ContinueOnError="ErrorAndContinue"
+        Projects="$(_TopDir)\tests\RunApkTests.targets"
+        Condition=" '$(Configuration)' == 'Release' "
+        Properties="BundleAssemblies=True"
     />
   </Target>
   <Target Name="RunPerformanceTests">

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -156,14 +157,21 @@ namespace Xamarin.Android.Tasks
 					return false;
 				}
 
+				Log.LogDebugMessage ("[mkbundle] modifying mono_mkbundle_init");
 				// make some changes in the mkbundle output so that it does not require libmonodroid.so
-				var mkbundleOutput = File.ReadAllText (Path.Combine (outpath, "temp.c"));
-				mkbundleOutput = mkbundleOutput.Replace ("void mono_mkbundle_init ()", "void mono_mkbundle_init (void (register_bundled_assemblies_func)(const MonoBundledAssembly **), void (register_config_for_assembly_func)(const char *, const char *))")
+				var mkbundleOutput = new StringBuilder (File.ReadAllText (Path.Combine (outpath, "temp.c")));
+
+				mkbundleOutput.Replace ("mono_jit_set_aot_mode", "mono_jit_set_aot_mode_ptr")
+					.Replace ("void mono_mkbundle_init ()", "void mono_mkbundle_init (void (register_bundled_assemblies_func)(const MonoBundledAssembly **), void (register_config_for_assembly_func)(const char *, const char *), void (mono_jit_set_aot_mode_func) (int mode))")
 					.Replace ("mono_register_config_for_assembly (\"", "register_config_for_assembly_func (\"")
 					.Replace ("install_dll_config_files (void)", "install_dll_config_files (void (register_config_for_assembly_func)(const char *, const char *))")
 					.Replace ("install_dll_config_files ()", "install_dll_config_files (register_config_for_assembly_func)")
-					.Replace ("mono_register_bundled_assemblies(", "register_bundled_assemblies_func(");
-				File.WriteAllText (Path.Combine (outpath, "temp.c"), mkbundleOutput);
+					.Replace ("mono_register_bundled_assemblies(", "register_bundled_assemblies_func(")
+					.Replace ("int nbundles;", "int nbundles;\n\n\tmono_jit_set_aot_mode_ptr = mono_jit_set_aot_mode_func;");
+
+				mkbundleOutput.Insert (0, "void (*mono_jit_set_aot_mode_ptr) (int mode);\n");
+
+				File.WriteAllText (Path.Combine (outpath, "temp.c"), mkbundleOutput.ToString ());
 
 				// then compile temp.c into temp.o and ...
 

--- a/src/monodroid/jni/monodroid-glue.c
+++ b/src/monodroid/jni/monodroid-glue.c
@@ -682,7 +682,7 @@ get_libmonosgen_path ()
 	return libmonoso;
 }
 
-typedef void* (*mono_mkbundle_init_ptr) (void (*)(const MonoBundledAssembly **), void (*)(const char* assembly_name, const char* config_xml));
+typedef void* (*mono_mkbundle_init_ptr) (void (*)(const MonoBundledAssembly **), void (*)(const char* assembly_name, const char* config_xml),void (*) (int mode));
 mono_mkbundle_init_ptr mono_mkbundle_init;
 
 static void
@@ -2633,7 +2633,7 @@ mono_runtime_init (char *runtime_args)
 	register_gc_hooks ();
 
 	if (mono_mkbundle_init)
-		mono_mkbundle_init (mono.mono_register_bundled_assemblies, mono.mono_register_config_for_assembly);
+		mono_mkbundle_init (mono.mono_register_bundled_assemblies, mono.mono_register_config_for_assembly, mono.mono_jit_set_aot_mode);
 
 	/*
 	 * Assembly preload hooks are invoked in _reverse_ registration order.


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/1651

Recent update to mono brought in changes in the code generated by `mkbundle`
when dealing with AOT. Unfortunately, the changes require the bundle to be able
to find the `mono_jit_set_aot_mode` runtime function which isn't exported in the
Xamarin.Android up and thus the loading of the bundle crashes on startup with
the following message:

    dlopen failed: cannot locate symbol "mono_jit_set_aot_mode" referenced by libmonodroid_bundle_app.so

To fix this we need to augment the bundle's `mono_mkbundle_init` function in
generated code to take a third parameter - pointer to the abovementioned
function. With the current code this requires a set of rather ugly changes, as
seen in this commit, but it makes the application not crash on start and is the
fastest way to fix the issue right now.

This is a short-term fix, a long-term one will be presented at a later time.