### PR TITLE
[xabuild.exe] fixes for paths/settings on macOS

### DIFF
--- a/tools/xabuild/XABuildPaths.cs
+++ b/tools/xabuild/XABuildPaths.cs
@@ -143,18 +143,19 @@ namespace Xamarin.Android.Build
 				MSBuildPath              = Path.Combine (mono, "msbuild");
 				MSBuildBin               = Path.Combine (MSBuildPath, vsVersion, "bin");
 				MSBuildConfig            = Path.Combine (MSBuildBin, "MSBuild.dll.config");
-				DotNetSdkPath            =
-					MSBuildSdksPath      = FindLatestDotNetSdk ("/usr/local/share/dotnet/sdk");
+				DotNetSdkPath            = FindLatestDotNetSdk ("/usr/local/share/dotnet/sdk");
+				MSBuildSdksPath          = DotNetSdkPath ?? Path.Combine (MSBuildBin, "Sdks");
 				ProjectImportSearchPaths = new [] { MSBuildPath, Path.Combine (mono, "xbuild"), Path.Combine (monoExternal, "xbuild") };
 				SystemProfiles           = Path.Combine (mono, "xbuild-frameworks");
 				SearchPathsOS            = IsMacOS ? "osx" : "unix";
 
-				string nuget = Path.Combine(mono, "xbuild", "Microsoft", "NuGet");
-				if (Directory.Exists(nuget)) {
+				string nuget = Path.Combine (mono, "xbuild", "Microsoft", "NuGet");
+				if (Directory.Exists (nuget)) {
 					NuGetTargets = Path.Combine (nuget, "Microsoft.NuGet.targets");
 					NuGetProps   = Path.Combine (nuget, "Microsoft.NuGet.props");
 				}
-				if (!string.IsNullOrEmpty (DotNetSdkPath)) {
+				NuGetRestoreTargets = Path.Combine (MSBuildBin, "NuGet.targets");
+				if (!File.Exists (NuGetRestoreTargets) && !string.IsNullOrEmpty (DotNetSdkPath)) {
 					NuGetRestoreTargets  = Path.Combine (DotNetSdkPath, "..", "NuGet.targets");
 				}
 			}


### PR DESCRIPTION
When looking at my Mono 5.12 installation, I noticed a few files we
should be using with `xabuild.exe`:
- `/Library/Frameworks/Mono.framework/Versions/5.12.0/lib/mono/msbuild/15.0/bin/NuGet.targets`
- `/Library/Frameworks/Mono.framework/Versions/5.12.0/lib/mono/msbuild/15.0/bin/Sdks` directory

`NuGet.targets` is needed for `XABuildPaths.NuGetRestoreTargets`, and
the `Sdks` directory can be used for `MSBuildSdksPath`.

Both of these values can still fall back to .NET Core, if they are not
found.

After these changes, it more closely matches the Windows code. We
should be able to build a wider range of .NET standard projects with
`xabuild.exe` now on macOS.