### PR TITLE
[msbuild] Now JavaDoc task takes reference jars, and relevant tasks d…

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaDoc.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaDoc.cs
@@ -17,6 +17,12 @@ namespace Xamarin.Android.Tasks
 
 		public string [] DestinationDirectories { get; set; }
 
+		public string [] ReferenceJars { get; set; }
+
+		public string JavaPlatformJar { get; set; }
+
+		public string [] ExtraArgs { get; set; }
+
 		protected override string ToolName {
 			get { return OS.IsWindows ? "javadoc.exe" : "javadoc"; }
 		}
@@ -26,18 +32,21 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("JavaDoc Task");
 			Log.LogDebugTaskItems ("  SourceDirectories: ", SourceDirectories);
 			Log.LogDebugTaskItems ("  DestinationDirectories: ", DestinationDirectories);
+			Log.LogDebugMessage ("  JavaPlatformJar: {0}", JavaPlatformJar);
+			Log.LogDebugTaskItems ("  ReferenceJars: ", ReferenceJars);
+			Log.LogDebugTaskItems ("  ExtraArgs: ", ExtraArgs);
 
 			foreach (var dir in DestinationDirectories)
 				if (!Directory.Exists (dir))
 					Directory.CreateDirectory (dir);
 
-			bool retval = true;
+			// Basically, javadoc will return non-zero return code with those expected errors. We have to ignore them.
 			foreach (var pair in SourceDirectories.Zip (DestinationDirectories, (src, dst) => new { Source = src, Destination = dst })) {
 				context_src = pair.Source;
 				context_dst = pair.Destination;
-				retval &= base.Execute ();
+				base.Execute ();
 			}
-			return retval;
+			return true;
 		}
 
 		string context_src;
@@ -53,8 +62,26 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendFileNameIfNotNull (context_src);
 			cmd.AppendSwitch ("-subpackages");
 			cmd.AppendSwitch (".");
+			var cps = ReferenceJars?.ToList () ?? new List<string> ();
+			if (JavaPlatformJar != null)
+				cps.Add (JavaPlatformJar);
+			if (cps.Any ()) {
+				if (OS.IsWindows)
+					cmd.AppendSwitch ("-cp " + string.Join (";", cps.Select (cp => '"' + cp + '"')));
+				else 
+					cmd.AppendSwitch ("-cp " + '"' + string.Join (":", cps) + '"');
+			}
+			if (ExtraArgs != null)
+				foreach (var extraArg in ExtraArgs)
+					cmd.AppendSwitch (extraArg);
 
 			return cmd.ToString ();
+		}
+
+		// log them as is, regardless of message importance. Javadoc compilation errors should never be reported as errors.
+		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
+		{
+			Log.LogDebugMessage (singleLine);
 		}
 	}
 	

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -334,6 +334,10 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 			CacheFile="$(_AndroidLibraryImportsCache)">
 		<Output TaskParameter="Jars" ItemName="ExtractedJarImports" />
 	</GetImportedLibraries>
+
+    <CreateItem Include="@(ZippedLibraryProjectJars);@(ExtractedJarImports)">
+      <Output TaskParameter="Include" ItemName="ReferenceJar" />
+    </CreateItem>
 </Target>
 
 <Target Name="_GetLibraryImports" DependsOnTargets="_BuildLibraryImportsCache">
@@ -376,9 +380,12 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <Unzip Sources="@(JavaSourceJar)" DestinationDirectories="@(JavaSourceJar->'$(IntermediateOutputPath)javasources\%(FileName)')" />
 	
     <JavaDoc
+        ContinueOnError="true"
         ToolPath="$(JavaToolPath)"
         SourceDirectories="@(JavaSourceJar->'$(IntermediateOutputPath)javasources\%(FileName)')"
         DestinationDirectories="@(JavaSourceJar->'$(IntermediateOutputPath)javadocs\%(FileName)')"
+        ReferenceJars="@(EmbeddedReferenceJar);@(ReferenceJar);@(_AdditionalJavaLibraryReferences)"
+        JavaPlatformJar="$(AndroidSdkDirectory)\platforms\android-$(_AndroidApiLevel)\android.jar"
         />
 	
     <Touch Files="@(JavaSourceJar->'$(IntermediateOutputPath)javasources\%(FileName).stamp')" AlwaysCreate="True" />
@@ -393,10 +400,6 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
           DependsOnTargets="$(ExportJarToXmlDependsOnTargets)"
           Inputs="@(EmbeddedJar);@(EmbeddedReferenceJar);@(InputJar);@(ReferenceJar);$(MSBuildAllProjects);@(_AdditionalJavaLibraryReferences)"
           Outputs="$(ApiOutputFile)">
-
-    <CreateItem Include="@(ZippedLibraryProjectJars);@(ExtractedJarImports)">
-      <Output TaskParameter="Include" ItemName="ReferenceJar" />
-    </CreateItem>
 
     <ItemGroup>
       <_AndroidDocumentationPath Include="@(JavaDocIndex->'%(RootDir)\%(Directory)')" />
@@ -540,6 +543,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 		ToolExe="$(MDocToolExe)"
     	 />
     <ImportJavaDoc
+    	ContinueOnError="true"
     	JavaDocs="@(JavaDocIndex)"
     	References="@(ReferencePath);@(ReferenceDependencyPaths)"
     	Transforms="@(TransformFile)"


### PR DESCRIPTION
…on't break.

Those changes were required to make it pass for building new androidx
libraries (but not limited to them).
Without references as in `javadoc -cp` they fail to resolve references.

It's okay, but JavaToolTask picks up all those messages as errors, and
the error code is respected and thus the entire binding library build fails.

That's not what we want. We should skip those failures and go on.

The subsequent crash at javadoc-to-mdoc failure needs investigation, but
it shouldn't block binding builds either.