### PR TITLE
[linux] Accurate dependency tracking for package

### DIFF
--- a/build-tools/debian-metadata/control
+++ b/build-tools/debian-metadata/control
@@ -2,7 +2,7 @@ Source: xamarin.android-oss
 Section: unknown
 Priority: optional
 Maintainer: Xamarin <hello@xamarin.com>
-Build-Depends: debhelper (>=9)
+Build-Depends: debhelper (>=9), cli-common-dev (>= 0.9~), libzip-dev
 Standards-Version: 3.9.6
 Homepage: https://www.xamarin.com/platform
 Vcs-Git: https://github.com/xamarin/xamarin-android.git
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/xamarin/xamarin-android
 
 Package: xamarin.android-oss
 Architecture: amd64
-Depends: msbuild, java8-sdk, libzip4, ${misc:Depends}, ${shlibs:Depends}
+Depends: msbuild, java8-sdk, ${cli:Depends}, ${misc:Depends}, ${shlibs:Depends}
 Description: Xamarin.Android libraries and runtime (host component)
  The best way to build native Android apps.
  .

--- a/build-tools/debian-metadata/rules
+++ b/build-tools/debian-metadata/rules
@@ -8,8 +8,27 @@ override_dh_auto_configure:
 override_dh_auto_build:
 override_dh_auto_test:
 override_dh_strip_nondeterminism:
-override_dh_shlibdeps:
+override_dh_makeclilibs:
 	echo "noop"
 
+override_dh_shlibdeps:
+	dh_shlibdeps -X/usr/lib/xamarin.android/xbuild-frameworks/ -X/usr/lib/xamarin.android/xbuild/Xamarin/Android/lib/
+
+override_dh_clideps:
+	dh_clideps -X/usr/lib/xamarin.android/xbuild-frameworks/ \
+		--exclude-moduleref=clr.dll \
+		--exclude-moduleref=crypt32.dll \
+		--exclude-moduleref=dbghelp.dll \
+		--exclude-moduleref=fusion \
+		--exclude-moduleref=fusion.dll \
+		--exclude-moduleref=lzo.dll \
+		--exclude-moduleref=mscoree.dll \
+		--exclude-moduleref=mscorwks.dll \
+		--exclude-moduleref=msvcrt \
+		--exclude-moduleref=NTDLL.DLL \
+		--exclude-moduleref=ole32.dll \
+		--exclude-moduleref=sfc.dll \
+		--exclude-moduleref=wintrust.dll
+
 %:
-	dh $@ 
+	dh $@ --with cli


### PR DESCRIPTION
Instead of needing to guess dependencies and hand-encode them, this uses the automatic dependency generator (with a big pile of excludes)