### PR TITLE
[OpenTK-1.0] Disable per-TFN IntermediateOutputPath

### DIFF
--- a/src/OpenTK-1.0/OpenTK.csproj
+++ b/src/OpenTK-1.0/OpenTK.csproj
@@ -21,6 +21,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AndroidApplication>false</AndroidApplication>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
+    <AppendTargetFrameworkToIntermediateOutputPath>False</AppendTargetFrameworkToIntermediateOutputPath>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <Import Project="..\..\build-tools\scripts\MonoAndroidFramework.props" />


### PR DESCRIPTION
Commit 13d216fd [broke the build][0], within the `make opentk-jcw`
build target:

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/1003/

	$ msbuild /p:Configuration=Debug /p:AndroidApiLevel=15 /p:AndroidPlatformId=15 /p:AndroidFrameworkVersion=v4.0.3 /t:GenerateJavaCallableWrappers /v:diag src/OpenTK-1.0/OpenTK.csproj
	...
	Target "GenerateJavaCallableWrappers: (TargetId:2)" in file "…/xamarin-android/build-tools/scripts/JavaCallableWrappers.targets" from project "…/xamarin-android/src/OpenTK-1.0/OpenTK.csproj" (entry point):
	Building target "GenerateJavaCallableWrappers" completely.
	Input file "…/xamarin-android/src/OpenTK-1.0/obj/Debug/MonoAndroid403/OpenTK-1.0.dll" does not exist.
	...
	mono --debug=casts "…/xamarin-android/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/jcw-gen.exe" -v10 -o "…/xamarin-android/src/OpenTK-1.0/obj/Debug/MonoAndroid403/jcw/src" -L "…/xamarin-android/bin/Debug/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v4.0.3/" -L "…/xamarin-android/bin/Debug/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v4.0.3/../v1.0" -L "…/xamarin-android/bin/Debug/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v4.0.3/../v1.0/Facades" "…/xamarin-android/src/OpenTK-1.0/obj/Debug/MonoAndroid403/OpenTK-1.0.dll" (TaskId:3)
	jcw-gen: System.IO.FileNotFoundException: Could not load assembly 'OpenTK-1.0, Version=0.0.0.0, Culture=neutral, PublicKeyToken='. Perhaps it doesn't exist in the Mono for Android profile? (TaskId:3)
	File name: 'OpenTK-1.0.dll' (TaskId:3)
	  at Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.Resolve (Mono.Cecil.AssemblyNameReference reference, Mono.Cecil.ReaderParameters parameters) [0x000c3] in …/xamarin-android/external/Java.Interop/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs:241  (TaskId:3)
	  at Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.Resolve (Mono.Cecil.AssemblyNameReference reference) [0x00001] in …/xamarin-android/external/Java.Interop/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs:191  (TaskId:3)
	  at Java.Interop.Tools.Cecil.AssemblyResolverCoda.GetAssembly (Mono.Cecil.IAssemblyResolver resolver, System.String fileName) [0x00001] in …/xamarin-android/external/Java.Interop/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs:48  (TaskId:3)
	  at Java.Interop.Tools.JavaCallableWrappers.JavaTypeScanner.GetJavaTypes (System.Collections.Generic.IEnumerable`1[T] assemblies, Mono.Cecil.IAssemblyResolver resolver) [0x0001c] in …/xamarin-android/external/Java.Interop/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaTypeScanner.cs:31  (TaskId:3)
	  at Java.Interop.Tools.App.Main (System.String[] args) [0x001f2] in …/xamarin-android/external/Java.Interop/tools/jcw-gen/App.cs:66  (TaskId:3)
	...
	make: *** [opentk-jcw] Error 1

The reason for the failure is because of an interaction between commit
46de66f and 13d216fd: starting with 46de66f,
`make framework-assemblies` only builds *one* version of
`OpenTK-1.0.dll`, the version for the first `$(API_LEVELS)` value.
Once that single `OpenTK-1.0.dll` is built -- with an intermediate
"copy" in `src/OpenTK-1.0/obj/Debug/OpenTK-1.0.dll` -- the same
intermediate assembly is reused by `make opentk-jcw` to generate the
Java Callable Wrappers for `OpenTK-1.0.dll` and inserted into
`mono.android.jar.`

Commit 46de66f screws up this process, because it creates an
environment in which there are *many* intermediate `OpenTK-1.0.dll`
assemblies -- one per `$(TargetFrameworkVersion)` value -- e.g.
`src/OpenTK-1.0/obj/Debug/MonoAndroid23/OpenTK-1.0.dll`.
Unfortunately, the `GenerateJavaCallableWrappers` target doesn't
rebuild `OpenTK-1.0.dll` -- intentionally! for consistency! -- which
is why we get the `Input file "...OpenTK-1.0.dll" does not exist`
message within the output.

The fix? Selectively "revert" 46de66f by having `OpenTK.csproj` set
`$(AppendTargetFrameworkToIntermediateOutputPath)`=False.  This
returns the `OpenTK.csproj` build to the previous state of affairs of
having a single intermediate `OpenTK-1.0.dll` assembly, allowing the
`make opentk-jcw` target to execute without error.