### PR TITLE
[Xamarin.Android.Build.Tasks] fix timestamps in various intermediate folders

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
@@ -167,14 +167,24 @@ namespace Xamarin.Android.Tasks
 					else if (!MonoAndroidHelper.IsForceRetainedAssembly (filename))
 						continue;
 
-					MonoAndroidHelper.CopyIfChanged (copysrc, Path.Combine (copydst, filename));
+					var assemblyDestination = Path.Combine (copydst, filename);
+					if (MonoAndroidHelper.CopyIfChanged (copysrc, assemblyDestination)) {
+						MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (assemblyDestination, DateTime.UtcNow, Log);
+					}
 					try {
-						MonoAndroidHelper.CopyIfChanged (assembly.ItemSpec + ".mdb", Path.Combine (copydst, filename + ".mdb"));
+						var mdbDestination = assemblyDestination + ".mdb";
+						if (MonoAndroidHelper.CopyIfChanged (assembly.ItemSpec + ".mdb", mdbDestination)) {
+							MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (mdbDestination, DateTime.UtcNow, Log);
+						}
 					} catch (Exception) { // skip it, mdb sometimes fails to read and it's optional
 					}
 					var pdb = Path.ChangeExtension (copysrc, "pdb");
-					if (File.Exists (pdb) && Files.IsPortablePdb (pdb))
-						MonoAndroidHelper.CopyIfChanged (pdb, Path.ChangeExtension (Path.Combine (copydst, filename), "pdb"));
+					if (File.Exists (pdb) && Files.IsPortablePdb (pdb)) {
+						var pdbDestination = Path.ChangeExtension (Path.Combine (copydst, filename), "pdb");
+						if (MonoAndroidHelper.CopyIfChanged (pdb, pdbDestination)) {
+							MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (pdbDestination, DateTime.UtcNow, Log);
+						}
+					}
 				}
 			} catch (ResolutionException ex) {
 				Diagnostic.Error (2006, ex, "Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.", ex.Member, ex.Member.Module.Assembly, ex.Scope);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
@@ -190,7 +190,7 @@ namespace Xamarin.Android.Build.Tests {
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
 
-		[Test]
+		[Test, NonParallelizable]
 		public void ResolveSdkTiming ()
 		{
 			var path = Path.Combine ("temp", TestName);
@@ -226,7 +226,7 @@ namespace Xamarin.Android.Build.Tests {
 			var start = DateTime.UtcNow;
 			Assert.IsTrue (task.Execute ());
 			var executionTime = DateTime.UtcNow - start;
-			Assert.LessOrEqual (executionTime, TimeSpan.FromSeconds(1), "Task should not take more than 1 second to run.");
+			Assert.LessOrEqual (executionTime, TimeSpan.FromSeconds(2), "Task should not take more than 2 seconds to run.");
 			Assert.AreEqual (task.AndroidApiLevel, "26", "AndroidApiLevel should be 26");
 			Assert.AreEqual (task.TargetFrameworkVersion, "v8.0", "TargetFrameworkVersion should be v8.0");
 			Assert.AreEqual (task.AndroidApiLevelName, "26", "AndroidApiLevelName should be 26");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1704,6 +1704,7 @@ because xbuild doesn't support framework reference assemblies.
     SourceFiles="$(MonoPlatformJarPath)"
     DestinationFiles="$(IntermediateOutputPath)android\bin\mono.android.jar"
     SkipUnchangedFiles="true" />
+  <Touch Files="$(IntermediateOutputPath)android\bin\mono.android.jar" />
   
   <Touch Files="$(_AndroidStaticResourcesFlag)" AlwaysCreate="true" />
 </Target>
@@ -1730,7 +1731,7 @@ because xbuild doesn't support framework reference assemblies.
 		DestinationFiles="@(_AndroidResolvedSatellitePaths->'$(MonoAndroidLinkerInputDir)%(DestinationSubDirectory)%(Filename)%(Extension)')"
 		SkipUnchangedFiles="true"
 	/>
-	<Touch Files="@(ResolvedUserAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')" />
+	<Touch Files="@(ResolvedAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')" />
 	<Touch Files="@(_AndroidResolvedSatellitePaths->'$(MonoAndroidLinkerInputDir)%(DestinationSubDirectory)%(Filename)%(Extension)')" />
 	<Delete Files="@(ResolvedAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension).mdb')" />
 </Target>


### PR DESCRIPTION
When taking an audit of our build times, I was testing the following
scenario:
- `msbuild Droid.csproj /t:Install /bl:first.binlog`
- `msbuild Droid.csproj /t:Install /bl:second.binlog`

In theory, the "second" build should be very fast and basically not do
anything. Unfortunately that was not the case.

In my example, I saw build logs such as:

    Target _LinkAssembliesNoShrink
        Building target "_LinkAssembliesNoShrink" partially, because some output files are out of date with respect to their input files.
        [ResolvedUserAssemblies: Input=C:\Users\myuser\.nuget\packages\xamarin.forms\3.0.0.482510\lib\MonoAndroid10\FormsViewGroup.dll, Output=obj\Debug\android\assets\FormsViewGroup.dll] Input file is newer than output file.
        [ResolvedUserAssemblies: Input=C:\Users\myuser\.nuget\packages\xamarin.forms\3.0.0.482510\lib\MonoAndroid10\Xamarin.Forms.Core.dll, Output=obj\Debug\android\assets\Xamarin.Forms.Core.dll] Input file is newer than output file.
        [ResolvedUserAssemblies: Input=C:\Users\myuser\.nuget\packages\xamarin.forms\3.0.0.482510\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll, Output=obj\Debug\android\assets\Xamarin.Forms.Platform.Android.dll] Input file is newer than output file.
        [ResolvedUserAssemblies: Input=C:\Users\myuser\.nuget\packages\xamarin.forms\3.0.0.482510\lib\MonoAndroid10\Xamarin.Forms.Platform.dll, Output=obj\Debug\android\assets\Xamarin.Forms.Platform.dll] Input file is newer than output file.
        [ResolvedUserAssemblies: Input=C:\Users\myuser\.nuget\packages\xamarin.forms\3.0.0.482510\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll, Output=obj\Debug\android\assets\Xamarin.Forms.Xaml.dll] Input file is newer than output file.
        LinkAssemblies

Looking at the `LinkAssemblies` MSBuild task, I didn't see anything
that would be setting the timestamps on copied files.

For timestamps to be correct, we should either:
- Use `MonoAndroidHelper.SetLastAccessAndWriteTimeUtc` in C#
- Use the `<Touch />` MSBuild task after using the `<Copy />` MSBuild
  task

This lead me to write a `CheckTimestamps` unit test that does the
following:
- Store `DateTime.UtcNow` in a variable
- Build an app
- Make sure nothing in `bin` or `obj` are older than the start time

This uncovered even more out of date files such as:
- `mono.android.jar`
- Assemblies in `obj/Debug/linksrc` or `$(MonoAndroidLinkerInputDir)`

Fixes made in various places:
- `<LinkAssemblies />` task needed to use
  `MonoAndroidHelper.SetLastAccessAndWriteTimeUtc` everywhere
  `MonoAndroidHelper.CopyIfChanged` is used
- The `_CopyIntermediateAssemblies` target appeared to have a typo. It
  was running a `<Touch />` on `ResolvedUserAssemblies` where it
  looked like it should be `ResolvedAssemblies` from the above
  `<Copy />`
- The `_AddStaticResources` target needed a `<Touch />` for
  `mono.android.jar`

This fix should improve our incremental build times dramatically, as
these timestamps caused other targets to run that slow things down.