### PR TITLE
[Xamarin.Android.Build.Tasks] ILRepack the NuGet.* Tasks Dependencies.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/ILRepack.targets
+++ b/src/Xamarin.Android.Build.Tasks/ILRepack.targets
@@ -17,6 +17,7 @@
 		<ILRepack Parallel="true"
 			Internalize="true"
 			Verbose="true"
+			DebugInfo="true"
 			InternalizeExclude="@(DoNotInternalizeAssemblies)"
 			InputAssemblies="$(OutputPath)\$(AssemblyName).dll;@(InputAssemblies)"
 			LibraryPath="$(OutputPath)"

--- a/src/Xamarin.Android.Build.Tasks/ILRepack.targets
+++ b/src/Xamarin.Android.Build.Tasks/ILRepack.targets
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Target Name="ILRepacker" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
+
+    <ItemGroup>
+		<InputAssemblies Include="$(OutputPath)\$(AssemblyName).dll" />
+        <InputAssemblies Include="$(OutputPath)\NuGet.ProjectModel.dll" />
+        <InputAssemblies Include="$(OutputPath)\Newtonsoft.Json.dll" />
+        <InputAssemblies Include="$(OutputPath)\NuGet.Common.dll" />
+        <InputAssemblies Include="$(OutputPath)\NuGet.Common.dll" />
+        <InputAssemblies Include="$(OutputPath)\NuGet.Frameworks.dll" />
+        <InputAssemblies Include="$(OutputPath)\NuGet.LibraryModel.dll" />
+        <InputAssemblies Include="$(OutputPath)\NuGet.Versioning.dll" />
+		<InputAssemblies Include="$(OutputPath)\NuGet.Packaging.dll" />
+		<InputAssemblies Include="$(OutputPath)\NuGet.Packaging.Core.dll" />
+		<InputAssemblies Include="$(OutputPath)\NuGet.DependencyResolver.Core.dll" />
+		<InputAssemblies Include="$(OutputPath)\NuGet.Configuration.dll" />
+    </ItemGroup>
+
+    <ILRepack
+        Parallel="true"
+        Internalize="true"
+		Verbose="true"
+        InternalizeExclude="@(DoNotInternalizeAssemblies)"
+        InputAssemblies="@(InputAssemblies)"
+        TargetKind="Dll"
+        OutputFile="$(OutputPath)\$(AssemblyName).dll"
+    />
+
+    </Target>
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/ILRepack.targets
+++ b/src/Xamarin.Android.Build.Tasks/ILRepack.targets
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<Target Name="ILRepacker" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
+	<Target Name="ILRepacker" AfterTargets="Build">
 		<ItemGroup>
-			<InputAssemblies Include="$(OutputPath)\$(AssemblyName).dll" />
 			<InputAssemblies Include="$(OutputPath)\NuGet.ProjectModel.dll" />
 			<InputAssemblies Include="$(OutputPath)\Newtonsoft.Json.dll" />
 			<InputAssemblies Include="$(OutputPath)\NuGet.Common.dll" />
@@ -19,10 +18,11 @@
 			Internalize="true"
 			Verbose="true"
 			InternalizeExclude="@(DoNotInternalizeAssemblies)"
-			InputAssemblies="@(InputAssemblies)"
+			InputAssemblies="$(OutputPath)\$(AssemblyName).dll;@(InputAssemblies)"
 			LibraryPath="$(OutputPath)"
 			TargetKind="Dll"
 			OutputFile="$(OutputPath)\$(AssemblyName).dll"
 		/>
+		<Delete Files="@(InputAssemblies)" />
 	</Target>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/ILRepack.targets
+++ b/src/Xamarin.Android.Build.Tasks/ILRepack.targets
@@ -1,31 +1,28 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Target Name="ILRepacker" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
-
-    <ItemGroup>
-		<InputAssemblies Include="$(OutputPath)\$(AssemblyName).dll" />
-        <InputAssemblies Include="$(OutputPath)\NuGet.ProjectModel.dll" />
-        <InputAssemblies Include="$(OutputPath)\Newtonsoft.Json.dll" />
-        <InputAssemblies Include="$(OutputPath)\NuGet.Common.dll" />
-        <InputAssemblies Include="$(OutputPath)\NuGet.Common.dll" />
-        <InputAssemblies Include="$(OutputPath)\NuGet.Frameworks.dll" />
-        <InputAssemblies Include="$(OutputPath)\NuGet.LibraryModel.dll" />
-        <InputAssemblies Include="$(OutputPath)\NuGet.Versioning.dll" />
-		<InputAssemblies Include="$(OutputPath)\NuGet.Packaging.dll" />
-		<InputAssemblies Include="$(OutputPath)\NuGet.Packaging.Core.dll" />
-		<InputAssemblies Include="$(OutputPath)\NuGet.DependencyResolver.Core.dll" />
-		<InputAssemblies Include="$(OutputPath)\NuGet.Configuration.dll" />
-    </ItemGroup>
-
-    <ILRepack
-        Parallel="true"
-        Internalize="true"
-		Verbose="true"
-        InternalizeExclude="@(DoNotInternalizeAssemblies)"
-        InputAssemblies="@(InputAssemblies)"
-        TargetKind="Dll"
-        OutputFile="$(OutputPath)\$(AssemblyName).dll"
-    />
-
-    </Target>
+	<Target Name="ILRepacker" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
+		<ItemGroup>
+			<InputAssemblies Include="$(OutputPath)\$(AssemblyName).dll" />
+			<InputAssemblies Include="$(OutputPath)\NuGet.ProjectModel.dll" />
+			<InputAssemblies Include="$(OutputPath)\Newtonsoft.Json.dll" />
+			<InputAssemblies Include="$(OutputPath)\NuGet.Common.dll" />
+			<InputAssemblies Include="$(OutputPath)\NuGet.Common.dll" />
+			<InputAssemblies Include="$(OutputPath)\NuGet.Frameworks.dll" />
+			<InputAssemblies Include="$(OutputPath)\NuGet.LibraryModel.dll" />
+			<InputAssemblies Include="$(OutputPath)\NuGet.Versioning.dll" />
+			<InputAssemblies Include="$(OutputPath)\NuGet.Packaging.dll" />
+			<InputAssemblies Include="$(OutputPath)\NuGet.Packaging.Core.dll" />
+			<InputAssemblies Include="$(OutputPath)\NuGet.DependencyResolver.Core.dll" />
+			<InputAssemblies Include="$(OutputPath)\NuGet.Configuration.dll" />
+		</ItemGroup>
+		<ILRepack Parallel="true"
+			Internalize="true"
+			Verbose="true"
+			InternalizeExclude="@(DoNotInternalizeAssemblies)"
+			InputAssemblies="@(InputAssemblies)"
+			LibraryPath="$(OutputPath)"
+			TargetKind="Dll"
+			OutputFile="$(OutputPath)\$(AssemblyName).dll"
+		/>
+	</Target>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -734,4 +734,5 @@
     <Folder Include="Linker\Linker\" />
     <Folder Include="utils\" />
   </ItemGroup>
+  <Import Project="..\..\packages\ILRepack.Lib.MSBuild.Task.2.0.15.4\build\ILRepack.Lib.MSBuild.Task.targets" Condition="Exists('..\..\packages\ILRepack.Lib.MSBuild.Task.2.0.15.4\build\ILRepack.Lib.MSBuild.Task.targets')" />
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -585,6 +585,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Xamarin.Android.Build.Tasks.targets" />
+    <None Include="ILRepack.targets" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/packages.config
@@ -16,4 +16,5 @@
   <package id="NuGet.Versioning" version="4.6.0" targetFramework="net462" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net462" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net462" />
+  <package id="ILRepack.Lib.MSBuild.Task" version="2.0.15.4" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
`ResolveAssemblies` is throwing the following error on
a newer mono (2018-04).

	error : Could not load file or assembly 'NuGet.ProjectModel, Version=4.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' or one of its dependencies.

This is because we took a dependency on NuGet.ProjectModel 4.6 and
the newer mono has 4.7. This results in the error above.

Now we cannot always be sure which version of the NuGet assemblies
will be installed since users are able to upgrade mono independently.
So this PR will use the `ILRepack` NuGet to package up the dependencies
we need so that `Xamarin.Android.Build.Tasks` contains all the
correct assemblies it needs.