### PR TITLE
[Xamarin.Android.Build.Tasks] Failed to load ILRepack.Lib.MSBuild.Task.dll

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/ILRepack.targets
+++ b/src/Xamarin.Android.Build.Tasks/ILRepack.targets
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\packages\ILRepack.Lib.MSBuild.Task.2.0.15.4\build\ILRepack.Lib.MSBuild.Task.dll" TaskName="ILRepack" />
 	<Target Name="ILRepacker" AfterTargets="Build">
 		<ItemGroup>
 			<InputAssemblies Include="$(OutputPath)\NuGet.ProjectModel.dll" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -734,5 +734,5 @@
     <Folder Include="Linker\Linker\" />
     <Folder Include="utils\" />
   </ItemGroup>
-  <Import Project="..\..\packages\ILRepack.Lib.MSBuild.Task.2.0.15.4\build\ILRepack.Lib.MSBuild.Task.targets" Condition="Exists('..\..\packages\ILRepack.Lib.MSBuild.Task.2.0.15.4\build\ILRepack.Lib.MSBuild.Task.targets')" />
+  <Import Project="ILRepack.targets" Condition="Exists('ILRepack.targets')" />
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -734,5 +734,5 @@
     <Folder Include="Linker\Linker\" />
     <Folder Include="utils\" />
   </ItemGroup>
-  <Import Project="ILRepack.targets" Condition="Exists('ILRepack.targets')" />
+  <Import Project="ILRepack.targets" />
 </Project>


### PR DESCRIPTION
When building via monodroid we get a build error

	Error initializing task ILRepack: System.IO.FileNotFoundException:
	File name: '[path]/monodroid/external/xamarin-android/src/Xamarin.Android.Build.Tasks/ILRepack.Lib.MSBuild.Task.dll'

which it really really weird because the .targets in the NuGet is using

	$(MSBuildThisFileDirectory)ILRepack.Lib.MSBuild.Task.dll

and that is somehow resolving to a path outside of the the `packages`
folder....

So lets load the assembly in the `ILRepack.targets` manually
from the location we know it will be.