### PR TITLE
[DO NOT MERGE] Better mkbundle interop

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
@@ -39,6 +39,9 @@ namespace Xamarin.Android.Tasks
 		public bool EmbedDebugSymbols { get; set; }
 		public bool KeepTemp { get; set; }
 
+		[Required]
+		public string BundleApiPath { get; set; }
+
 		[Output]
 		public ITaskItem [] OutputNativeLibraries { get; set; }
 
@@ -113,6 +116,8 @@ namespace Xamarin.Android.Tasks
 				clb.AppendSwitch ("--nomain");
 				clb.AppendSwitch ("--i18n none");
 				clb.AppendSwitch ("--bundled-header");
+				clb.AppendSwitch ("--mono-api-struct-path");
+				clb.AppendFileNameIfNotNull (BundleApiPath);
 				clb.AppendSwitch ("--style");
 				clb.AppendSwitch ("linux");
 				clb.AppendSwitch ("-c");
@@ -157,22 +162,6 @@ namespace Xamarin.Android.Tasks
 					return false;
 				}
 
-				Log.LogDebugMessage ("[mkbundle] modifying mono_mkbundle_init");
-				// make some changes in the mkbundle output so that it does not require libmonodroid.so
-				var mkbundleOutput = new StringBuilder (File.ReadAllText (Path.Combine (outpath, "temp.c")));
-
-				mkbundleOutput.Replace ("mono_jit_set_aot_mode", "mono_jit_set_aot_mode_ptr")
-					.Replace ("void mono_mkbundle_init ()", "void mono_mkbundle_init (void (register_bundled_assemblies_func)(const MonoBundledAssembly **), void (register_config_for_assembly_func)(const char *, const char *), void (mono_jit_set_aot_mode_func) (int mode))")
-					.Replace ("mono_register_config_for_assembly (\"", "register_config_for_assembly_func (\"")
-					.Replace ("install_dll_config_files (void)", "install_dll_config_files (void (register_config_for_assembly_func)(const char *, const char *))")
-					.Replace ("install_dll_config_files ()", "install_dll_config_files (register_config_for_assembly_func)")
-					.Replace ("mono_register_bundled_assemblies(", "register_bundled_assemblies_func(")
-					.Replace ("int nbundles;", "int nbundles;\n\n\tmono_jit_set_aot_mode_ptr = mono_jit_set_aot_mode_func;");
-
-				mkbundleOutput.Insert (0, "void (*mono_jit_set_aot_mode_ptr) (int mode);\n");
-
-				File.WriteAllText (Path.Combine (outpath, "temp.c"), mkbundleOutput.ToString ());
-
 				// then compile temp.c into temp.o and ...
 
 				clb = new CommandLineBuilder ();
@@ -181,6 +170,10 @@ namespace Xamarin.Android.Tasks
 				// This is necessary only when unified headers are in use but it won't hurt to have it
 				// defined even if we don't use them
 				clb.AppendSwitch ($"-D__ANDROID_API__={level}");
+
+				// This is necessary because of the injected code, which is reused between libmonodroid
+				// and the bundle
+				clb.AppendSwitch ("-DANDROID");
 
 				clb.AppendSwitch ("-o");
 				clb.AppendFileNameIfNotNull (Path.Combine (outpath, "temp.o"));

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -574,6 +574,10 @@
       <Link>LayoutBinding.cs</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="..\monodroid\jni\mkbundle-api.h">
+      <Link>mkbundle-api.h</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <Compile Include="Tasks\JavaDoc.cs" />
     <Compile Include="Linker\MonoDroid.Tuner\AndroidLinkContext.cs" />
   </ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -303,9 +303,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<_AndroidSequencePointsMode Condition=" '$(_AndroidSequencePointsMode)' == ''">None</_AndroidSequencePointsMode>
 	<_InstantRunEnabled Condition=" '$(_InstantRunEnabled)' == '' ">False</_InstantRunEnabled>
 	<_AndroidBuildPropertiesCache>$(IntermediateOutputPath)build.props</_AndroidBuildPropertiesCache>
-
 	<AndroidGenerateJniMarshalMethods Condition=" '$(AndroidGenerateJniMarshalMethods)' == '' ">False</AndroidGenerateJniMarshalMethods>
-
+	<MakeBundleKeepTemporaryFiles Condition=" '$(MakeBundleKeepTemporaryFiles)' == '' ">False</MakeBundleKeepTemporaryFiles>
 </PropertyGroup>
 
 <Choose>
@@ -2688,12 +2687,14 @@ because xbuild doesn't support framework reference assemblies.
   <!-- Bundle the assemblies into native libraries in the apk -->
   <MakeBundleNativeCodeExternal
 		Condition="'$(BundleAssemblies)' == 'True'"
+		KeepTemp="$(MakeBundleKeepTemporaryFiles)"
 		AndroidNdkDirectory="$(_AndroidNdkDirectory)"
 		Assemblies="@(_ResolvedUserAssemblies);@(_AndroidResolvedSatellitePaths);@(_ShrunkFrameworkAssemblies)"
 		IncludePath="$(MonoAndroidIncludeDirectory)"
 		SupportedAbis="$(_BuildTargetAbis)"
 		TempOutputPath="$(IntermediateOutputPath)"
-		ToolPath="$(_MonoAndroidToolsDirectory)">
+		ToolPath="$(_MonoAndroidToolsDirectory)"
+		BundleApiPath="$(MSBuildThisFileDirectory)\mkbundle-api.h">
  	<Output TaskParameter="OutputNativeLibraries" PropertyName="_BundleResultNativeLibraries" />
   </MakeBundleNativeCodeExternal>
   <!-- Put the assemblies and native libraries in the apk -->

--- a/src/monodroid/jni/dylib-mono.c
+++ b/src/monodroid/jni/dylib-mono.c
@@ -139,7 +139,7 @@ int monodroid_dylib_mono_init (struct DylibMono *mono_imports, const char *libmo
 	LOAD_SYMBOL(mono_thread_create)
 	LOAD_SYMBOL(mono_thread_current)
 	LOAD_SYMBOL(mono_use_llvm)
-
+	LOAD_SYMBOL(mono_aot_register_module)
 
 	if (symbols_missing) {
 		log_fatal (LOG_DEFAULT, "Failed to load some Mono symbols, aborting...");

--- a/src/monodroid/jni/dylib-mono.h
+++ b/src/monodroid/jni/dylib-mono.h
@@ -254,6 +254,7 @@ typedef MonoThread*     (*monodroid_mono_thread_current_fptr) (void);
 typedef void            (*monodroid_mono_gc_disable_fptr) (void);
 typedef void*           (*monodroid_mono_install_assembly_refonly_preload_hook_fptr) (MonoAssemblyPreLoadFunc func, void *user_data);
 typedef int             (*monodroid_mono_runtime_set_main_args_fptr) (int argc, char* argv[]);
+typedef void            (*mono_aot_register_module_fptr) (void* aot_info);
 
 /* NOTE: structure members MUST NOT CHANGE ORDER. */
 struct DylibMono {
@@ -342,6 +343,7 @@ struct DylibMono {
 	monodroid_mono_class_get_property_from_name_fptr        mono_class_get_property_from_name;
 	monodroid_mono_domain_from_appdomain_fptr               mono_domain_from_appdomain;
 	monodroid_mono_thread_current_fptr                      mono_thread_current;
+	mono_aot_register_module_fptr                           mono_aot_register_module;
 };
 
 MONO_API  struct  DylibMono*  monodroid_dylib_mono_new (const char *libmono_path);

--- a/src/monodroid/jni/mkbundle-api.h
+++ b/src/monodroid/jni/mkbundle-api.h
@@ -1,0 +1,27 @@
+#ifndef __MKBUNDLE_API_H
+#define __MKBUNDLE_API_H
+typedef struct BundleMonoAPI
+{
+	void (*mono_register_bundled_assemblies) (const MonoBundledAssembly **assemblies);
+	void (*mono_register_config_for_assembly) (const char* assembly_name, const char* config_xml);
+	void (*mono_jit_set_aot_mode) (int mode);
+	void (*mono_aot_register_module) (void* aot_info);
+	void (*mono_config_parse_memory) (const char *buffer);
+	void (*mono_register_machine_config) (const char *config_xml);
+} BundleMonoAPI;
+
+#if ANDROID
+#include <stdarg.h>
+#include <android/log.h>
+
+static void
+mkbundle_log_error (const char *format, ...)
+{
+	va_list ap;
+
+	va_start (ap, format);
+	__android_log_vprint (ANDROID_LOG_ERROR, "mkbundle", format, ap);
+	va_end (ap);
+}
+#endif // ANDROID
+#endif // __MKBUNDLE_API_H


### PR DESCRIPTION
**NOTE: this PR can be merged *ONLY* after Xamarin.Android can update its Mono
to a version which [includes this commit](https://github.com/mono/mono/commit/170e9442c976ed6cd4a499093e11a9e12e7368bb) (the [commit is now in the](https://github.com/mono/mono/commit/170e9442c976ed6cd4a499093e11a9e12e7368bb) `mono/2018-06` branch).
It would be best that Mono bump to pull the commit would be added to this PR, so that the tests succeed and we have no broken
builds.**

Xamarin.Android side of the Mono's mkbundle update which makes it easier (and
safer) to introduce changes in the template generated by mkbundle when creating
the application bundle.

Code generated by mkbundle calls into the Mono runtime and in order for this to
work on Xamarin.Android, libmonodroid needs to properly initialize the bundle or
the application won't work (`dlsym` won't be able to find the Mono runtime
symbols). This has been done by patching the generated code using plain
search-and-replace which is very fragile even to the slightest changes and it
doesn't guarantee that any new additions won't break the Xamarin.Android
bundle (see https://github.com/xamarin/xamarin-android/issues/1651)

Mono's mkbundle has been updated (see https://github.com/mono/mono/commit/170e9442c976ed6cd4a499093e11a9e12e7368bb)
to support third parties, like Xamarin.Android, which need to use special
methods to initialize the bundle. The third party provides a small bit of source
code with a dispatch structure (mkbundle has its own default version of the
structure) which contains pointers to all the Mono runtime methods required by
the initialization code. The provided code is inserted by mkbundle in place of
its default version. If there are any incompatibilities between the two
structures (such as missing pointers, invalid signature, additional pointers
etc) then the bundle will not build, thus allowing the third party to notice the
problem early and update its version of the structure. Likewise, if the build
succeeds but the pointers aren't correctly initialized (i.e. they are `null`), a
runtime check will discover the fact and fail the application gracefully.

The bit of inserted code also contains platform-specific logging function in
place of the calls to `fprintf` used by mkbundle previously. For Xamarin.Android
it means that all the error messages will end up in logcat.

Xamarin.Android's version of the structure and the error logging function are
found in the `mkbundle-api.h` C header which is used *both* when building
libmonodroid (to ensure that when initializing the generated bundle libmonodroid
is ABI-compatible with it) and is copied to the framework directory to be used
when generating the application bundle.

Sample of XA-generated bundle code:
https://gist.github.com/grendello/465ecec96b3bee801e6bbc5a28019833