### PR TITLE
[Xamarin.Android.Build.Tasks] Run `ResolveNativeLibrariesInManagedReferences` Test in Release

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -187,6 +187,7 @@ public class TestMe {
 		{
 			var lib = new XamarinAndroidLibraryProject () {
 				ProjectName = "Lib",
+				IsRelease = true,
 				ProjectGuid = Guid.NewGuid ().ToString (),
 				OtherBuildItems = {
 					new BuildItem (AndroidBuildActions.EmbeddedNativeLibrary, "libs/armeabi-v7a/libfoo.so") {
@@ -217,6 +218,7 @@ namespace Lib
 			var lib2 = new XamarinAndroidLibraryProject () {
 				ProjectName = "Lib2",
 				ProjectGuid = Guid.NewGuid ().ToString (),
+				IsRelease = true,
 				OtherBuildItems = {
 					new BuildItem (AndroidBuildActions.EmbeddedNativeLibrary, "libs/armeabi-v7a/libfoo2.so") {
 						TextContent = () => string.Empty,
@@ -254,6 +256,7 @@ namespace Lib2
 					Assert.IsTrue (libbuilder2.Build (lib2), "lib 1st. build failed");
 
 					var app = new XamarinAndroidApplicationProject () { ProjectName = "App",
+						IsRelease = true,
 						OtherBuildItems = {
 							new BuildItem.ProjectReference (@"..\Lib2\Lib2.csproj", "Lib2", lib2.ProjectGuid),
 						}


### PR DESCRIPTION
The `ResolveNativeLibrariesInManagedReferences` test fails when run
in Debug mode when we are using the `_BuildApkForFastDev`. This is
because the updated `libfoo.so` is not being updated in the apk.

Now this is probably a bug in the system. This is because the native
libraries are embedded into the apk even in fast dev. However to we
do not update the apk in fast dev mode if an assembly changes. This
is because we don't want to rebuild the apk every time a bit of
code is changed.

So this behaviour needs to be redone. This is will be handled
in the new instant run support in PR #609. This new system will
fast deploy native libraries to the device.

So for now so we can get a xamarin-adroid bump in monodroid we
should restrict this test to Release only.