### PR TITLE
[timing] more configuration options for MSBuild timing

### DIFF
--- a/build-tools/timing/timing.projitems
+++ b/build-tools/timing/timing.projitems
@@ -7,14 +7,14 @@
     <XACaptureBuildTimingProject Include="$(_TopDir)samples\HelloWorld\HelloWorld.csproj">
       <Name>HelloWorld</Name>
       <ShortName>HelloWorld</ShortName>
-      <DirectoryToClean>$([System.IO.Path]::GetFullPath('$(_TopDir)samples\HelloWorld'))</DirectoryToClean>
+      <DirectoryFullPath>$([System.IO.Path]::GetFullPath('$(_TopDir)samples\HelloWorld'))</DirectoryFullPath>
       <CSharpFile>$(_TopDir)samples\HelloWorld\MainActivity.cs</CSharpFile>
       <AndroidResourceFile>$(_TopDir)samples\HelloWorld\Resources\values\Strings.xml</AndroidResourceFile>
     </XACaptureBuildTimingProject>
     <XACaptureBuildTimingProject Include="$(_TopDir)tests\Xamarin.Forms-Performance-Integration\Droid\Xamarin.Forms.Performance.Integration.Droid.csproj">
       <Name>Xamarin.Forms-Integration</Name>
       <ShortName>XF</ShortName>
-      <DirectoryToClean>$([System.IO.Path]::GetFullPath('$(_TopDir)tests\Xamarin.Forms-Performance-Integration'))</DirectoryToClean>
+      <DirectoryFullPath>$([System.IO.Path]::GetFullPath('$(_TopDir)tests\Xamarin.Forms-Performance-Integration'))</DirectoryFullPath>
       <CSharpFile>$(_TopDir)tests\Xamarin.Forms-Performance-Integration\Droid\MainActivity.cs</CSharpFile>
       <AndroidResourceFile>$(_TopDir)tests\Xamarin.Forms-Performance-Integration\Droid\Resources\values\styles.xml</AndroidResourceFile>
     </XACaptureBuildTimingProject>

--- a/build-tools/timing/timing.targets
+++ b/build-tools/timing/timing.targets
@@ -45,7 +45,7 @@
   <Target Name="MSBuildPrep" DependsOnTargets="GetXAVersionInfo;AcquireAndroidTarget">
     <PropertyGroup>
       <_OutputDir>$(_TopDir)bin\Test$(Configuration)\</_OutputDir>
-      <_XABuild>$(_TopDir)bin\Debug\bin\xabuild</_XABuild>
+      <_XABuild>$(_TopDir)bin\$(Configuration)\bin\xabuild</_XABuild>
       <_TimingLogger>Xamarin.Android.Tools.BootstrapTasks.TimingLogger,$(_TopDir)bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll</_TimingLogger>
     </PropertyGroup>
     <ItemGroup>
@@ -63,15 +63,35 @@
     </PropertyGroup>
     <!--Simulate a clean checkout with git commands-->
     <Git
-        Arguments="rm -r --cached %(XACaptureBuildTimingProject.DirectoryToClean)"
+        Condition=" '%(XACaptureBuildTimingProject.Repo)' == '' "
+        Arguments="clean -dxf &quot;%(XACaptureBuildTimingProject.DirectoryFullPath)&quot;"
         WorkingDirectory="$(_TopDir)"
         ToolPath="$(GitToolPath)"
-        ToolExe="$(GitToolExe)" />
+        ToolExe="$(GitToolExe)"
+    />
+    <!--If the XACaptureBuildTimingProject defines Repo, we need to clone it-->
+    <RemoveDir
+        Condition=" '%(XACaptureBuildTimingProject.Repo)' != '' And Exists('%(XACaptureBuildTimingProject.DirectoryFullPath)')"
+        Directories="%(XACaptureBuildTimingProject.DirectoryFullPath)"
+    />
     <Git
-        Arguments="checkout HEAD %(XACaptureBuildTimingProject.DirectoryToClean)"
+        Condition=" '%(XACaptureBuildTimingProject.Repo)' != '' "
+        Arguments="clone &quot;%(XACaptureBuildTimingProject.Repo)&quot; --depth=1 &quot;%(XACaptureBuildTimingProject.DirectoryFullPath)&quot;"
         WorkingDirectory="$(_TopDir)"
         ToolPath="$(GitToolPath)"
-        ToolExe="$(GitToolExe)" />
+        ToolExe="$(GitToolExe)"
+    />
+    <Git
+        Condition=" '%(XACaptureBuildTimingProject.Repo)' != '' And '%(XACaptureBuildTimingProject.Commit)' != '' "
+        Arguments="checkout &quot;%(XACaptureBuildTimingProject.Commit)&quot;"
+        WorkingDirectory="%(XACaptureBuildTimingProject.DirectoryFullPath)"
+        ToolPath="$(GitToolPath)"
+        ToolExe="$(GitToolExe)"
+    />
+    <Exec 
+        Condition=" '%(XACaptureBuildTimingProject.Restore)' != '' "
+        Command="$(_TopDir).nuget\NuGet.exe restore &quot;%(XACaptureBuildTimingProject.Restore)&quot;"
+    />
     <Exec Command="$(_XABuild) /fl /flp:LogFile=$(_OutputFile).log &quot;/logger:$(_TimingLogger);ID=$(_ID);Description=$(_Description);Commit=$(XAVersionHash);OutputPath=$(_OutputFile).xml&quot; /p:Configuration=$(Configuration) /p:AndroidSupportedAbis=x86 %(XACaptureBuildTimingProject.Identity) /t:$(_Target)" />
   </Target>
   <Target Name="FreshInstall"


### PR DESCRIPTION
In our private `monodroid` repo, a few features are needed in order to
setup timing:
- `xabuild` needs to be supported for `Release` configuration
- Need to be able to clone a project not in our repo
- Need to be able to run NuGet restore

Changes:
- Use `bin\$(Configuration)\bin\xabuild`
- Added `Restore` metadata to `XACaptureBuildTimingProject`, which
  defaults to empty. If specified, `.nuget\NuGet.exe restore` will be
  called on the value, which should generally be a path to a `*.sln`
  file.
- Added `Repo` metadata to `XACaptureBuildTimingProject`, which
  defaults to empty. If enabled, this script will use git commands to
  clone the repo (with a depth of 1) and move to a specified commit
- Added `Commit` metadata to `XACaptureBuildTimingProject`, which
  defaults to empty. If enabled, a `git checkout` command will run.
- Renamed `DirectoryToClean` to just `DirectoryFullPath` as it did not
  quite make sense for external projects
- Also changed the behavior we had before to be less destructive, it
  now just runs `git clean -dxf` on the folder instead of resetting
  changes in the working copy.

What will need to happen in `monodroid`:
- Run `timing.csproj` with `/p:Configuration=Release`
- Add the following `<ItemGroup />`

```xml
<XACaptureBuildTimingProject Include="$(_SmartHotelProjectDir)SmartHotel.Clients.Android.csproj">
  <Name>SmartHotel</Name>
  <ShortName>SmartHotel</ShortName>
  <DirectoryFullPath>$([System.IO.Path]::GetFullPath('$(_SmartHotelExternalDir)')</DirectoryFullPath>
  <CSharpFile>$(_SmartHotelProjectDir)MainActivity.cs</CSharpFile>
  <AndroidResourceFile>$(_SmartHotelProjectDir)Resources\values\styles.xml</AndroidResourceFile>
  <Repo>https://github.com/Microsoft/SmartHotel360-mobile-desktop-apps.git</Repo>
  <Commit>4540a879fb9c6e6813751b849bf34871ace064de</Commit>
  <Restore>$(_SmartHotelExternalDir)src\SmartHotel.Clients.Android.sln</Restore>
</XACaptureBuildTimingProject>
```

With defined properties:

    <_SmartHotelExternalDir>$(_TopDir)external\SmartHotel\</_SmartHotelExternalDir>
    <_SmartHotelProjectDir>$(_SmartHotelExternalDir)src\SmartHotel.Clients\SmartHotel.Clients.Android\</_SmartHotelProjectDir>