### PR TITLE
[Xamarin.Android.Build.Tests] Flush our test output.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -303,12 +303,14 @@ namespace Xamarin.Android.Build.Tests
 		public void TestSetup ()
 		{
 			TestContext.Out.WriteLine ($"[TESTLOG] Test {TestName} Starting");
+			TestContext.Out.Flush ();
 		}
 
 		[TearDown]
 		protected virtual void CleanupTest ()
 		{
 			TestContext.Out.WriteLine ($"[TESTLOG] Test {TestName} Complete");
+			TestContext.Out.Flush ();
 			if (System.Diagnostics.Debugger.IsAttached || TestContext.CurrentContext.Test.Properties ["Output"] == null)
 					return;
 			// find the "root" directory just below "temp" and clean from there because


### PR DESCRIPTION
Our wrench build if timing out because its not getting
any console output from Nunit. This is because Nunit
is buffering the output.

So lets Flush the Output so we get decent progress messages.