### PR TITLE
[Xamarin.Android.Build.Tasks] Fix up library project java classes

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1994,7 +1994,7 @@ because xbuild doesn't support framework reference assemblies.
 	AcwMapFile="$(_AcwMapFile)">
   </GenerateJavaStubs>
   <ConvertResourcesCases 
-	ResourceDirectories="$(MonoAndroidResDirIntermediate)"
+	ResourceDirectories="$(MonoAndroidResDirIntermediate);@(LibraryResourceDirectories)"
 	AcwMapFile="$(_AcwMapFile)" />
 </Target>
 


### PR DESCRIPTION
Commit a50e00bb removed one of the calls to `ConvertResourcesCases`.
This was responsible for the library project layouts not being
updated with the md5 generated java class names.

However rather than adding the call back in we can expand the
call in `_GenerateJavaStubs` to include the library prjects.
This makes more sense because that is the target in which we
generate the stubs in the first place.