### PR TITLE
[monodroid] Add Java.Interop.dll.config for host JI assembly

### DIFF
--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -112,7 +112,7 @@
     </ItemGroup>
   </Target>
   <Target Name="_BuildHostRuntimes"
-      DependsOnTargets="_GetBuildHostRuntimes"
+      DependsOnTargets="_GetBuildHostRuntimes;_CreateJavaInteropDllConfig"
       Inputs="@(_CFile);@(_UnixCFile)"
       Outputs="@(_HostRuntime->'$(OutputPath)%(OutputDirectory)\libmono-android.debug.%(NativeLibraryExtension)')">
     <Message Text="Building host runtime %(_HostRuntime.Identity) in $(OutputPath)%(_HostRuntime.OutputDirectory)"/>
@@ -139,6 +139,20 @@
         Command="%(_HostRuntime.Strip) %(_HostRuntime.StripFlags) &quot;$(OutputPath)%(_HostRuntime.OutputDirectory)\libmono-android.release.%(_HostRuntime.NativeLibraryExtension)&quot;"
     />
   </Target>
+  <Target Name="_CreateJavaInteropDllConfig"
+      Inputs="$(XAInstallPrefix)xbuild\Xamarin\Android\Java.Interop.dll"
+      Outputs="$(XAInstallPrefix)xbuild\Xamarin\Android\Java.Interop.dll.config">
+    <WriteLinesToFile
+        File="$(XAInstallPrefix)xbuild\Xamarin\Android\Java.Interop.dll.config"
+        Lines="&lt;configuration&gt;
+  &lt;dllmap dll=&quot;java-interop&quot; os=&quot;osx&quot; target=&quot;lib/host-Darwin/libmono-android.debug.dylib&quot; /&gt;
+  &lt;dllmap dll=&quot;java-interop&quot; os=&quot;linux&quot; target=&quot;lib/host-Linux/libmono-android.debug.so&quot; /&gt;
+  &lt;dllmap dll=&quot;java-interop&quot; os=&quot;windows&quot; wordsize=&quot;64&quot; target=&quot;lib/host-mxe-Win64/libmono-android.debug.dll&quot; /&gt;
+  &lt;dllmap dll=&quot;java-interop&quot; os=&quot;windows&quot; wordsize=&quot;32&quot; target=&quot;lib/host-mxe-Win32/libmono-android.debug.dll&quot; /&gt;
+&lt;/configuration&gt;"
+        Overwrite="True"
+	/>
+    </Target>
   <Target Name="CoreCompile"
       DependsOnTargets="Build">
   </Target>


### PR DESCRIPTION
Make sure the `Java.Interop.dll` has `java_interop_jnienv_get_java_vm`
function available, through the *DllMap* in the config file. The function is called from [JniEnvironment.cs](https://github.com/xamarin/java.interop/blob/master/src/Java.Interop/Java.Interop/JniEnvironment.cs#L168).

This code path is reached during `jnimarshalmethod-gen.exe` run.