### PR TITLE
[Xamarin.Android.Build.Tasks] Emit an Error if a custom view cannot be fixed up.

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -44,6 +44,8 @@
 ### XA1xxx Project Related
 
 + [XA1000](xa1000.md): There was an problem parsing {file}. This is likely due to incomplete or invalid xml.
++ [XA1001](xa1001.md): AndroidResgen: Warning while updating Resource XML '{filename}': {Message}
++ [XA1002](xa1002.md): We found a matching key '{Key}' for '{Item}'. But the casing was incorrect. Please correct the casing
 
 ### XA2xxx Linker
 

--- a/Documentation/guides/messages/xa1001.md
+++ b/Documentation/guides/messages/xa1001.md
@@ -1,0 +1,7 @@
+# Compiler Warning XA1001
+
+AndroidResgen: Warning while updating Resource XML '{filename}': {Message}
+
+This warning is raised if we encounter an unknown issue when processing
+the layout and resources. It is a generic warning that does not describe 
+any specific problem. The details will be in the `{Message}`.

--- a/Documentation/guides/messages/xa1002.md
+++ b/Documentation/guides/messages/xa1002.md
@@ -1,0 +1,13 @@
+# Compiler Error XA1000
+
+This error will be emitted when we are unable to find a matching custom new in the 
+ResourceCaseMap string. 
+
+As part of the build process `Namespace.CustomViewFoo` items in layout files are
+replaced with `{MD5Hash}.CustomViewFoo`. We attempt to replace a couple of variants
+of the `Namespace.CustomViewFoo`. One is the original casing found in the C# source
+files. The other is all lowercase. If we cannot find a match we will do a case 
+insensitive lookup to see if there are items which do match. If we find one this 
+error will be raised.
+
+We found a matching key 'Namespace.CustomViewFoo' for 'NameSpace.CustomViewFoo'. But the casing was incorrect. Please correct the casing

--- a/Documentation/guides/messages/xa1002.md
+++ b/Documentation/guides/messages/xa1002.md
@@ -1,4 +1,4 @@
-# Compiler Error XA1000
+# Compiler Error XA1002
 
 This error will be emitted when we are unable to find a matching custom new in the 
 ResourceCaseMap string. 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -92,7 +92,7 @@ namespace Xamarin.Android.Tasks
 
 		public string ResourceSymbolsTextFileDirectory { get; set; }
 
-		Dictionary<string,string> resource_name_case_map = new Dictionary<string,string> ();
+		Dictionary<string,string> resource_name_case_map;
 		AssemblyIdentityMap assemblyMap = new AssemblyIdentityMap ();
 		string resourceDirectory;
 
@@ -251,9 +251,7 @@ namespace Xamarin.Android.Tasks
 
 		void DoExecute ()
 		{
-			if (ResourceNameCaseMap != null)
-				foreach (var arr in ResourceNameCaseMap.Split (';').Select (l => l.Split ('|')).Where (a => a.Length == 2))
-					resource_name_case_map [arr [1]] = arr [0]; // lowercase -> original
+			resource_name_case_map = MonoAndroidHelper.LoadResourceCaseMap (ResourceNameCaseMap);
 
 			assemblyMap.Load (Path.Combine (WorkingDirectory, AssemblyIdentityMapFile));
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Android.Tasks {
 	
 	public class Aapt2 : AsyncTask {
 
-		protected Dictionary<string, string> resource_name_case_map = new Dictionary<string, string> ();
+		protected Dictionary<string, string> resource_name_case_map;
 
 		public ITaskItem [] ResourceDirectories { get; set; }
 
@@ -174,9 +174,7 @@ namespace Xamarin.Android.Tasks {
 
 		protected void LoadResourceCaseMap ()
 		{
-			if (ResourceNameCaseMap != null)
-				foreach (var arr in ResourceNameCaseMap.Split (';').Select (l => l.Split ('|')).Where (a => a.Length == 2))
-					resource_name_case_map [arr [1]] = arr [0]; // lowercase -> original
+			resource_name_case_map = MonoAndroidHelper.LoadResourceCaseMap (ResourceNameCaseMap);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ConvertResourcesCasesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ConvertResourcesCasesTests.cs
@@ -80,7 +80,7 @@ namespace Xamarin.Android.Build.Tests {
 			StringAssert.DoesNotContain ("ClassLibrary1.CustomView", output, "ClassLibrary1.CustomView should have been replaced.");
 			StringAssert.Contains ("classLibrary1.CustomView", output, "classLibrary1.CustomView should have been replaced.");
 			Assert.AreEqual (1, errors.Count, "One Error should have been raised.");
-			Assert.AreEqual ("XA1000", errors [0].Code, "XA1000 should have been raised.");
+			Assert.AreEqual ("XA1002", errors [0].Code, "XA1002 should have been raised.");
 			Directory.Delete (path, recursive: true);
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ConvertResourcesCasesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ConvertResourcesCasesTests.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.ProjectTools;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using System.Text;
+using Xamarin.Android.Tasks;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Build.Tests {
+
+	[TestFixture]
+	[Parallelizable (ParallelScope.Self)]
+	public class ConvertResourcesCasesTests  : BaseTest {
+		[Test]
+		public void CheckClassIsReplacedWithMd5 ()
+		{
+			var path = Path.Combine (Root, "temp", "CheckClassIsReplacedWithMd5");
+			Directory.CreateDirectory (path);
+			var resPath = Path.Combine (path, "res");
+			Directory.CreateDirectory (Path.Combine (resPath, "layout"));
+			File.WriteAllText (Path.Combine (resPath, "layout", "main.xml"), @"<?xml version='1.0' ?>
+<LinearLayout xmlns:android='http://schemas.android.com/apk/res/android'>
+<ClassLibrary1.CustomView xmlns:android='http://schemas.android.com/apk/res/android' />
+<classlibrary1.CustomView xmlns:android='http://schemas.android.com/apk/res/android' />
+</LinearLayout>
+");
+			var errors = new List<BuildErrorEventArgs> ();
+			IBuildEngine engine = new MockBuildEngine (TestContext.Out, errors);
+			var task = new ConvertResourcesCases {
+				BuildEngine = engine
+			};
+			task.ResourceDirectories = new ITaskItem [] {
+				new TaskItem (resPath),
+			};
+			task.AcwMapFile = Path.Combine (path, "acwmap.txt");
+			File.WriteAllLines (task.AcwMapFile, new string [] {
+				"ClassLibrary1.CustomView;md5d6f7135293df7527c983d45d07471c5e.CustomTextView",
+				"classlibrary1.CustomView;md5d6f7135293df7527c983d45d07471c5e.CustomTextView",
+			});
+			Assert.IsTrue (task.Execute (), "Task should have executed successfully");
+			var output = File.ReadAllText (Path.Combine (resPath, "layout", "main.xml"));
+			StringAssert.Contains ("md5d6f7135293df7527c983d45d07471c5e.CustomTextView", output, "md5d6f7135293df7527c983d45d07471c5e.CustomTextView should exist in the main.xml");
+			StringAssert.DoesNotContain ("ClassLibrary1.CustomView", output, "ClassLibrary1.CustomView should have been replaced.");
+			StringAssert.DoesNotContain ("classlibrary1.CustomView", output, "classlibrary1.CustomView should have been replaced.");
+			Directory.Delete (path, recursive: true);
+		}
+
+		[Test]
+		public void CheckClassIsNotReplacedWithMd5 ()
+		{
+			var path = Path.Combine (Root, "temp", "CheckClassIsNotReplacedWithMd5");
+			Directory.CreateDirectory (path);
+			var resPath = Path.Combine (path, "res");
+			Directory.CreateDirectory (Path.Combine (resPath, "layout"));
+			File.WriteAllText (Path.Combine (resPath, "layout", "main.xml"), @"<?xml version='1.0' ?>
+<LinearLayout xmlns:android='http://schemas.android.com/apk/res/android'>
+<ClassLibrary1.CustomView xmlns:android='http://schemas.android.com/apk/res/android' />
+<classLibrary1.CustomView xmlns:android='http://schemas.android.com/apk/res/android' />
+</LinearLayout>
+");
+			var errors = new List<BuildErrorEventArgs> ();
+			IBuildEngine engine = new MockBuildEngine (TestContext.Out, errors);
+			var task = new ConvertResourcesCases {
+				BuildEngine = engine
+			};
+			task.ResourceDirectories = new ITaskItem [] {
+				new TaskItem (resPath),
+			};
+			task.AcwMapFile = Path.Combine (path, "acwmap.txt");
+			File.WriteAllLines (task.AcwMapFile, new string [] {
+				"ClassLibrary1.CustomView;md5d6f7135293df7527c983d45d07471c5e.CustomTextView",
+				"classlibrary1.CustomView;md5d6f7135293df7527c983d45d07471c5e.CustomTextView",
+			});
+			Assert.IsTrue (task.Execute (), "Task should have executed successfully");
+			var output = File.ReadAllText (Path.Combine (resPath, "layout", "main.xml"));
+			StringAssert.Contains ("md5d6f7135293df7527c983d45d07471c5e.CustomTextView", output, "md5d6f7135293df7527c983d45d07471c5e.CustomTextView should exist in the main.xml");
+			StringAssert.DoesNotContain ("ClassLibrary1.CustomView", output, "ClassLibrary1.CustomView should have been replaced.");
+			StringAssert.Contains ("classLibrary1.CustomView", output, "classLibrary1.CustomView should have been replaced.");
+			Assert.AreEqual (1, errors.Count, "One Error should have been raised.");
+			Assert.AreEqual ("XA1000", errors [0].Code, "XA1000 should have been raised.");
+			Directory.Delete (path, recursive: true);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Aapt2Tests.cs" />
     <Compile Include="Tasks\ValidateJavaVersionTests.cs" />
     <Compile Include="ZipArchiveExTests.cs" />
+    <Compile Include="ConvertResourcesCasesTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Expected\GenerateDesignerFileExpected.cs">

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -553,5 +553,15 @@ namespace Xamarin.Android.Tasks
 			}
 			return Path.Combine (platformPath, "android.jar");
 		}
+
+		public static Dictionary<string, string> LoadResourceCaseMap (string resourceCaseMap)
+		{
+			var result = new Dictionary<string, string> ();
+			if (resourceCaseMap != null) {
+				foreach (var arr in resourceCaseMap.Split (';').Select (l => l.Split ('|')).Where (a => a.Length == 2))
+					result [arr [1]] = arr [0]; // lowercase -> original
+			}
+			return result;
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2219,6 +2219,7 @@ because xbuild doesn't support framework reference assemblies.
   </GenerateJavaStubs>
   <ConvertResourcesCases 
 	ResourceDirectories="$(MonoAndroidResDirIntermediate);@(LibraryResourceDirectories)"
+	ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
 	AcwMapFile="$(_AcwMapFile)" />
 </Target>
 


### PR DESCRIPTION
Context https://github.com/xamarin/xamarin-android/issues/1711

When using a custom view within a layout file we replace the
`namespace.classname` with an `md5hash.classname`. We do this
by using the `acwmap.txt` file to make known types onto the
`md5` hashed ones. We do this in a case sensitive manner. We
also only support Camel case and lower case type names.

	ClassLibrary1.CustomView=md5d6f7135293df7527c983d45d07471c5e.CustomTextView
	classlibrary1.CustomView=md5d6f7135293df7527c983d45d07471c5e.CustomTextView

Given that a user is able to type these manually it is highly
probable that typo's will occur. If for example a user types

	Classlibrary1.CustomView

(Note the lower case `L`) this will NOT be fixed up. Instead the user will recieve the
following error at runtime.

	FATAL UNHANDLED EXCEPTION: Android.Views.InflateException: Binary XML file line #1: Binary XML file line #1: Error inflating class Classlibrary1.CustomTextView ---> Android.Views.InflateException: Binary XML file line #1: Error inflating class Classlibrary1.CustomTextView ---> Java.Lang.ClassNotFoundException: Didn't find class "Classlibrary1.CustomTextView"

if you are using the control in a number of places this runtime error
does nothing to help track down the problem.

Instead what we should be doing is detecting these issues and emitting
a build error. This will provide the user not only the problem but
also a link to the file causing the probem.

TODO
----

- [x] Fix up the name so it points to the file in `Resources` not `res`
- [x] Add a Unit test.
- [x] Add Error code and document.