### PR TITLE
[Xamarin.Android.Build.Tasks] Disable per-TFN IntermediateOutputPath

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.DefaultOutputPaths.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.DefaultOutputPaths.targets
@@ -10,7 +10,8 @@
 		<IntermediateOutputPath Condition=" '$(PlatformName)' != 'AnyCPU' ">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(AndroidUseLatestPlatformSdk)' != 'true'">
-		<AppendTargetFrameworkToIntermediateOutputPath Condition="'$(AppendTargetFrameworkToIntermediateOutputPath)' == ''">true</AppendTargetFrameworkToIntermediateOutputPath>
+		<!-- We don't change the IntermediateOutputPath by default to avoid backward compatibility issues -->
+		<AppendTargetFrameworkToIntermediateOutputPath Condition="'$(AppendTargetFrameworkToIntermediateOutputPath)' == ''">False</AppendTargetFrameworkToIntermediateOutputPath>
 		<!-- We don't change the OutputPath by default to avoid backward compatibility issues -->
 		<AppendTargetFrameworkToOutputPath Condition="'$(AppendTargetFrameworkToOutputPath)' == ''">false</AppendTargetFrameworkToOutputPath>
 		<TargetFrameworkToOutputPath>$(TargetFrameworkIdentifier)$(TargetFrameworkVersion.TrimStart('v').Replace('.', ''))</TargetFrameworkToOutputPath>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -532,6 +532,7 @@ namespace Xamarin.Android.Tests
 			var proj = CreateMultiDexRequiredApplication ();
 			proj.UseLatestPlatformSdk = false;
 			proj.SetProperty ("AndroidEnableMultiDex", "True");
+			proj.SetProperty ("AppendTargetFrameworkToIntermediateOutputPath", "True");
 
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName), false, false)) {
 				proj.TargetFrameworkVersion = b.LatestTargetFrameworkVersion ();


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/620311

Defaulting `$(AppendTargetFrameworkToIntermediateOutputPath)` to True
is breaking QA unit tests, and we still have no good idea how much
havoc this will wreak upon our customers.

Default `$(AppendTargetFrameworkToIntermediateOutputPath)` to False so
that the new `$(IntermediateOutputPath)` mechanism it implies
(13d216fd) can be opted-in to instead of out of.