### PR TITLE
[Xamarin.Android.Build.Tasks] Fix Intellisense errors for switch statements

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
@@ -27,8 +27,8 @@ namespace Foo.Foo
 		public partial class Animator
 		{
 			
-			// aapt resource value: 0
-			public const int slide_in_bottom = 0;
+			// aapt resource value: 0x7F030002
+			public const int slide_in_bottom = 2130903042;
 			
 			static Animator()
 			{
@@ -43,8 +43,8 @@ namespace Foo.Foo
 		public partial class Drawable
 		{
 			
-			// aapt resource value: 0
-			public const int ic_menu_preferences = 0;
+			// aapt resource value: 0x7F040002
+			public const int ic_menu_preferences = 2130968578;
 			
 			static Drawable()
 			{
@@ -59,8 +59,8 @@ namespace Foo.Foo
 		public partial class Font
 		{
 			
-			// aapt resource value: 0
-			public const int arial = 0;
+			// aapt resource value: 0x7F050002
+			public const int arial = 2131034114;
 			
 			static Font()
 			{
@@ -75,8 +75,8 @@ namespace Foo.Foo
 		public partial class Id
 		{
 			
-			// aapt resource value: 0
-			public const int menu_settings = 0;
+			// aapt resource value: 0x7F060002
+			public const int menu_settings = 2131099650;
 			
 			static Id()
 			{
@@ -91,8 +91,8 @@ namespace Foo.Foo
 		public partial class Menu
 		{
 			
-			// aapt resource value: 0
-			public const int Options = 0;
+			// aapt resource value: 0x7F070002
+			public const int Options = 2131165186;
 			
 			static Menu()
 			{
@@ -107,8 +107,8 @@ namespace Foo.Foo
 		public partial class Mipmap
 		{
 			
-			// aapt resource value: 0
-			public const int icon = 0;
+			// aapt resource value: 0x7F080002
+			public const int icon = 2131230722;
 			
 			static Mipmap()
 			{
@@ -123,8 +123,8 @@ namespace Foo.Foo
 		public partial class Plurals
 		{
 			
-			// aapt resource value: 0
-			public const int num_locations_reported = 0;
+			// aapt resource value: 0x7F020002
+			public const int num_locations_reported = 2130837506;
 			
 			static Plurals()
 			{
@@ -139,17 +139,17 @@ namespace Foo.Foo
 		public partial class String
 		{
 			
-			// aapt resource value: 0
-			public const int app_name = 0;
+			// aapt resource value: 0x7F010003
+			public const int app_name = 2130771971;
 			
-			// aapt resource value: 0
-			public const int foo = 0;
+			// aapt resource value: 0x7F010005
+			public const int foo = 2130771973;
 			
-			// aapt resource value: 0
-			public const int hello = 0;
+			// aapt resource value: 0x7F010002
+			public const int hello = 2130771970;
 			
-			// aapt resource value: 0
-			public const int menu_settings = 0;
+			// aapt resource value: 0x7F010004
+			public const int menu_settings = 2130771972;
 			
 			static String()
 			{

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -14,6 +14,8 @@ namespace Xamarin.Android.Tasks
 		CodeTypeDeclaration layout, ids, drawable, strings, colors, dimension, raw, animator, animation, attrib, boolean, font, ints, interpolators, menu, mipmaps, plurals, styleable, style, arrays;
 		Dictionary<string, string> map;
 		bool app;
+		List<CodeTypeDeclaration> declarationIds = new List<CodeTypeDeclaration> ();
+		const string itemPackageId = "0x7f";
 
 		void SortMembers (CodeTypeDeclaration decl)
 		{
@@ -281,17 +283,30 @@ namespace Xamarin.Android.Tasks
 			parentType.Members.Add (f);
 		}
 
+		int CreateResourceId (CodeTypeDeclaration parentType)
+		{
+			
+			int typeid = declarationIds.IndexOf (parentType) + 1;
+			if (typeid == 0) {
+				declarationIds.Add (parentType);
+				typeid = declarationIds.Count;
+			}
+			int itemid = parentType.Members.Count + 1;
+			return Convert.ToInt32(itemPackageId + typeid.ToString ().PadLeft (2, '0') + itemid.ToString ().PadLeft (4, '0'), 16); 
+		}
+
 		void CreateIntField (CodeTypeDeclaration parentType, string name, int value = 0)
 		{
 			string mappedName = GetResourceName (parentType.Name, name, map);
 			if (parentType.Members.OfType<CodeTypeMember> ().Any (x => string.Compare (x.Name, mappedName, StringComparison.OrdinalIgnoreCase) == 0))
 				return;
+			int id = value == 0 ? CreateResourceId (parentType): value;
 			var f = new CodeMemberField (typeof (int), mappedName) {
 				// pity I can't make the member readonly...
 				Attributes = app ? MemberAttributes.Const | MemberAttributes.Public : MemberAttributes.Static | MemberAttributes.Public,
-				InitExpression = new CodePrimitiveExpression (value),
+				InitExpression = new CodePrimitiveExpression (id),
 				Comments = {
-						new CodeCommentStatement ($"aapt resource value: {value}"),
+						new CodeCommentStatement ($"aapt resource value: {id}"),
 					},
 			};
 			parentType.Members.Add (f);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -306,7 +306,7 @@ namespace Xamarin.Android.Tasks
 				Attributes = app ? MemberAttributes.Const | MemberAttributes.Public : MemberAttributes.Static | MemberAttributes.Public,
 				InitExpression = new CodePrimitiveExpression (id),
 				Comments = {
-						new CodeCommentStatement ($"aapt resource value: {id}"),
+						new CodeCommentStatement ($"aapt resource value: 0x{id.ToString("X")}"),
 					},
 			};
 			parentType.Members.Add (f);


### PR DESCRIPTION
We got a report on slack that intellisense is showing errors on switch
statements for android resources. This might be because ALL of
the resource ids are 0 when using the managed parser.

This commit mimics the algorithm used by aapt as decribed at [1].
As a result most of the ids will be unique, which should fix
the intellisense errors.

[1] https://stackoverflow.com/questions/6517151/how-does-the-mapping-between-android-resources-and-resources-id-work