### PR TITLE
[build] Prepare Java.Runtime.Environment.Override.dllmap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ prepare-props: prepare-deps
 	cp "$(call GetPath,JavaInterop)/product.snk" "$(call GetPath,MonoSource)"
 	cp build-tools/scripts/Configuration.Java.Interop.Override.props external/Java.Interop/Configuration.Override.props
 	cp $(call GetPath,MonoSource)/mcs/class/msfinal.pub .
+	cp build-tools/scripts/java-interop.dllmap external/Java.Interop/Java.Runtime.Environment.Override.dllmap
 
 prepare-msbuild: prepare-props
 ifeq ($(USE_MSBUILD),1)

--- a/build-tools/scripts/java-interop.dllmap
+++ b/build-tools/scripts/java-interop.dllmap
@@ -1,0 +1,4 @@
+  <dllmap dll="java-interop" os="osx" target="lib/host-Darwin/libmono-android.debug.dylib" />
+  <dllmap dll="java-interop" os="linux" target="lib/host-Linux/libmono-android.debug.so" />
+  <dllmap dll="java-interop" os="windows" wordsize="64" target="lib/host-mxe-Win64/libmono-android.debug.dll" />
+  <dllmap dll="java-interop" os="windows" wordsize="32" target="lib/host-mxe-Win32/libmono-android.debug.dll" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1102,6 +1102,7 @@ because xbuild doesn't support framework reference assemblies.
 	<_AndroidComponentResgenFlagFile>$(IntermediateOutputPath)Component.R.cs.flag</_AndroidComponentResgenFlagFile>
 	<_AndroidStripFlag>$(IntermediateOutputPath)strip.flag</_AndroidStripFlag>
 	<_AndroidLinkFlag>$(IntermediateOutputPath)link.flag</_AndroidLinkFlag>
+	<_AndroidJniMarshalMethodsFlag>$(IntermediateOutputPath)jnimarshalmethods.flag</_AndroidJniMarshalMethodsFlag>
 	<_AndroidApkPerAbiFlagFile>$(IntermediateOutputPath)android\bin\apk_per_abi.flag</_AndroidApkPerAbiFlagFile>
 	<_AndroidDebugKeyStoreFlag>$(IntermediateOutputPath)android_debug_keystore.flag</_AndroidDebugKeyStoreFlag>
 	<_RemoveRegisterFlag>$(MonoAndroidIntermediateAssetsDir)shrunk\shrunk.flag</_RemoveRegisterFlag>
@@ -2012,7 +2013,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 	
 <Target Name="_LinkAssemblies"
-  DependsOnTargets="_ResolveAssemblies;_CreatePackageWorkspace;_LinkAssembliesNoShrink;_LinkAssembliesShrink" />
+  DependsOnTargets="_ResolveAssemblies;_CreatePackageWorkspace;_GenerateJniMarshalMethods;_LinkAssembliesNoShrink;_LinkAssembliesShrink" />
 
 <Target Name="_LinkAssembliesNoShrink"
   Condition="'$(AndroidLinkMode)' == 'None'"
@@ -2035,6 +2036,19 @@ because xbuild doesn't support framework reference assemblies.
     <Touch Files="$(_AndroidLinkFlag)" AlwaysCreate="true" />
 </Target>
 	
+<Target Name="_GenerateJniMarshalMethods"
+  Condition="'$(JniMarshalMethods)' == 'True' And '$(Configuration)' == 'Release' And '$(AndroidLinkMode)' != 'None'"
+  DependsOnTargets="_GetReferenceAssemblyPaths"
+  Inputs="@(ResolvedUserAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
+  Outputs="$(_AndroidJniMarshalMethodsFlag)">
+
+    <Exec
+       Command="MONO_PATH=$(_XATargetFrameworkDirectories) $(MonoAndroidBinDirectory)\mono $(MonoAndroidBinDirectory)\..\jnimarshalmethod-gen.exe @(ResolvedUserAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
+    />
+    <Touch Files="$(_AndroidJniMarshalMethodsFlag)" AlwaysCreate="True" />
+
+</Target>
+
 <Target Name="_LinkAssembliesShrink"
   Condition="'$(AndroidLinkMode)' != 'None'"
   Inputs="@(ResolvedUserAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)');$(_AndroidBuildPropertiesCache)"

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -146,14 +146,15 @@
   <Target Name="_CreateJavaInteropDllConfig"
       Inputs="$(XAInstallPrefix)xbuild\Xamarin\Android\Java.Interop.dll"
       Outputs="$(XAInstallPrefix)xbuild\Xamarin\Android\Java.Interop.dll.config">
+    <ReadLinesFromFile
+	File="../../build-tools/scripts/java-interop.dllmap">
+	<Output
+	    TaskParameter="Lines"
+	    ItemName="_JavaInteropDllMapContent" />
+    </ReadLinesFromFile>
     <WriteLinesToFile
         File="$(XAInstallPrefix)xbuild\Xamarin\Android\Java.Interop.dll.config"
-        Lines="&lt;configuration&gt;
-  &lt;dllmap dll=&quot;java-interop&quot; os=&quot;osx&quot; target=&quot;lib/host-Darwin/libmono-android.debug.dylib&quot; /&gt;
-  &lt;dllmap dll=&quot;java-interop&quot; os=&quot;linux&quot; target=&quot;lib/host-Linux/libmono-android.debug.so&quot; /&gt;
-  &lt;dllmap dll=&quot;java-interop&quot; os=&quot;windows&quot; wordsize=&quot;64&quot; target=&quot;lib/host-mxe-Win64/libmono-android.debug.dll&quot; /&gt;
-  &lt;dllmap dll=&quot;java-interop&quot; os=&quot;windows&quot; wordsize=&quot;32&quot; target=&quot;lib/host-mxe-Win32/libmono-android.debug.dll&quot; /&gt;
-&lt;/configuration&gt;"
+        Lines="&lt;configuration&gt;;@(_JavaInteropDllMapContent);&lt;/configuration&gt;"
         Overwrite="True"
 	/>
     </Target>


### PR DESCRIPTION
Prepare dllmap override in Java.Interop repo to have
`Java.Runtime.Environment.dll` working with our libmono-android shared
library.

Introduced `build-tools/scripts/java-interop.dllmap` to share that
information between `Java.Interop.dll.config` and
`Java.Runtime.Environment.dll.config`.