### PR TITLE
Clean improvements for BinObj issues

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -3077,6 +3077,41 @@ because xbuild doesn't support framework reference assemblies.
   </CalculateProjectDependencies>
 </Target>
 
+<PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'">
+  <EnableCleanAllFiles Condition="'$(EnableCleanAllFiles)' == ''">true</EnableCleanAllFiles>
+  <EnableCleanOnNuGetPackagesChange Condition="'$(EnableCleanOnNuGetPackagesChange)' == ''">true</EnableCleanOnNuGetPackagesChange>
+  <CoreCleanDependsOn Condition="'$(EnableCleanAllFiles)' == 'true'">
+     _CleanAllFiles;
+    $(CoreCleanDependsOn)
+  </CoreCleanDependsOn>
+  <BuildDependsOn Condition="'$(EnableCleanOnNuGetPackagesChange)' == 'true'">
+    _CleanOnNuGetPackagesChange;
+    $(BuildDependsOn)
+  </BuildDependsOn>
+</PropertyGroup>
+
+<Target Name="_CleanAllFiles">
+  <ItemGroup>
+    <Clean Include="$(OutputPath)**\*.*" />
+    <Clean Include="$(IntermediateOutputPath)**\*.*" Exclude="$(_AndroidDesignTimeResDirIntermediate)\**\*.*" />
+  </ItemGroup>
+</Target>
+
+<Target Name="_BeforeCleanOnNuGetPackagesChange">
+  <PropertyGroup>
+    <_NuGetAssetsFile Condition="Exists('$(ProjectLockFile)')">$(ProjectLockFile)</_NuGetAssetsFile>
+    <_NuGetAssetsFile Condition="'$(_NuGetAssetsFile)' == '' and Exists('packages.config')">packages.config</_NuGetAssetsFile>
+  </PropertyGroup>
+</Target>
+
+<Target Name="_CleanOnNuGetPackagesChange" DependsOnTargets="_BeforeCleanOnNuGetPackagesChange"
+        Inputs="$(_NuGetAssetsFile)"
+        Outputs="$(ProjectLockFile).stamp">
+  <CallTarget Targets="Clean" />
+  <Touch Files="$(ProjectLockFile).stamp" AlwaysCreate="true" />
+</Target>
+
+
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Common.Debugging.targets"
         Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Android.Common.Debugging.targets')"/>
 


### PR DESCRIPTION
1. Clean outputs on nuget install/restore

When building an Android project inside VS and the corresponding NuGet assets file
(packages.config or obj\project.assets.json) is updated, the Clean target is also
executed to make sure that remaining artifacts provided by previously installed packages
are removed.

2. Ensure all files are included when the Clean target is executed

For now, we're only scheduling the targets when they are executed inside the VS
in order to avoid CI issues and because the reports we have so far are for dev
environments only.