### PR TITLE
[tests] fix Aapt2Tests on Windows

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Aapt2Tests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Aapt2Tests.cs
@@ -135,18 +135,21 @@ namespace Xamarin.Android.Build.Tests {
 			IBuildEngine engine = new MockBuildEngine (TestContext.Out, errors);
 			var directorySeperator = Path.DirectorySeparatorChar;
 			var current = Directory.GetCurrentDirectory ();
-			Directory.SetCurrentDirectory (path);
-			var task = new Aapt2Compile {
-				BuildEngine = engine,
-				ToolPath = GetPathToAapt2 (),
-				ResourceDirectories = new ITaskItem [] { new TaskItem (resPath) },
-				ResourceNameCaseMap = $"Layout{directorySeperator}Main.xml|layout{directorySeperator}main.axml;Values{directorySeperator}Strings.xml|values{directorySeperator}strings.xml",
-			};
-			Assert.False (task.Execute (), "task should not have succeeded.");
+			try {
+				Directory.SetCurrentDirectory (path);
+				var task = new Aapt2Compile {
+					BuildEngine = engine,
+					ToolPath = GetPathToAapt2 (),
+					ResourceDirectories = new ITaskItem [] { new TaskItem (resPath) },
+					ResourceNameCaseMap = $"Layout{directorySeperator}Main.xml|layout{directorySeperator}main.axml;Values{directorySeperator}Strings.xml|values{directorySeperator}strings.xml",
+				};
+				Assert.False (task.Execute (), "task should not have succeeded.");
+			} finally {
+				Directory.SetCurrentDirectory (current);
+			}
 			Assert.AreEqual (1, errors.Count, "One Error should have been raised.");
 			Assert.AreEqual ($"Resources{directorySeperator}Values{directorySeperator}Strings.xml", errors[0].File, $"`values{directorySeperator}strings.xml` should have been replaced with `Resources{directorySeperator}Values{directorySeperator}Strings.xml`");
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
-			Directory.SetCurrentDirectory (current);
 		}
 	}
 }


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build?buildId=1722717&tab=ms.vss-test-web.test-result-details

I noticed one of the new aapt2 tests is failing on Windows with:

    System.IO.IOException :
        The process cannot access the file 'E:\A\_work\1\s\bin\TestDebug\temp\Aapt2CompileFixesUpErrors' because it is being used by another process.

I also noticed usage of `Directory.SetCurrentDirectory` within the
test, that should be within a `try-finally` block.

The following fixes the test:
- Reset `$CWD` right after we run `Aapt2Compile.Execute`, as we should
  no longer need it modified at that point
- Use a `try-finally` block, in case something `throws`