### PR TITLE
[docs] added ADB0000 error code

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -1,4 +1,8 @@
 
+### adbxxxx Adb Tooling
+
++ [adb0000](adb0000.md): Generic `adb` Error/Warning.
+
 ### andXXxxxx Generic Android Tooling
 
 + [andas0000](andas0000.md): Generic `apksigner` Error/Warning.

--- a/Documentation/guides/messages/adb0000.md
+++ b/Documentation/guides/messages/adb0000.md
@@ -1,0 +1,19 @@
+# Compiler Error/Warning ADB0000
+
+This message indicates that `adb` (Android Debug Bridge) reported an
+error or warning. `adb` is part of the Android SDK and is used
+internally by Xamarin.Android to communicate with Android emulators
+and devices. Learn more about `adb` from the [Android
+documentation](https://developer.android.com/studio/command-line/adb).
+
+Note that nothing in the open source `xamarin-android` repository
+emits `ADB0000`, as features such as debugging and "fast deployment"
+are implemented in the proprietary Xamarin.Android bits.
+
+Errors reported by `adb` are very much outside of Xamarin.Android's
+control, so a general error code of `ADB0000` is used reporting the
+exact message coming from `adb`.
+
+A few common messages include:
+- `error ADB0000: error: no devices/emulators found`
+- `error ADB0000: Failure [INSTALL_FAILED_NO_MATCHING_ABIS]: Failed to extract native libraries`


### PR DESCRIPTION
Context: https://github.com/xamarin/monodroid/pull/780
Context: https://github.com/xamarin/xamarin-android/issues/1560
Closes: https://github.com/xamarin/xamarin-android/issues/1727

I implemented `ADB0000` in the proprietary part of Xamarin.Android,
but need to document the error code in the open source
`xamarin-android` repository.

Looking at how the `Install` target is setup in `xamarin-android`, it
did not appear there was a good way to emit this error code for the
following target:

    <Target Name="_Deploy">
      <Exec Command="&quot;$(AdbToolPath)\adb&quot; install -r &quot;$(ApkFileSigned)&quot;" />
    </Target>

Since proprietary Xamarin.Android overrides this target, it is
probably not worth the work to write a custom MSBuild task to add the
`ADB0000` error code for open source `xamarin-android`.