### PR TITLE
[linker] Added PreserveJniMarshalMethods option

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -678,7 +678,8 @@ when packaing Release applications.
 
         /p:AndroidGenerateJniMarshalMethods=True
 
-    **Experimental**. Added in Xamarin.Android 8.3.
+    **Experimental**. Added in Xamarin.Android 8.4.  
+    The default value is False.
 
 ### Binding Project Build Properties
 

--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -663,6 +663,23 @@ when packaing Release applications.
     See [Lint Help](http://www.androiddocs.com/tools/help/lint.html) for more details on
     the android `lint` tooling.
 
+-  **AndroidGenerateJniMarshalMethods** &ndash; A bool property which
+   enables generating of JNI marshal methods as part of the build
+   process. This greatly reduces the System.Reflection usage in the
+   binding helper code.
+
+   By default this will be set to False. If the developers wish to use
+   the new JNI marshal methods feature, they can set
+
+        <AndroidGenerateJniMarshalMethods>True</AndroidGenerateJniMarshalMethods>
+
+    in their csproj. Alternatively provide the property on the command
+    line via
+
+        /p:AndroidGenerateJniMarshalMethods=True
+
+    **Experimental**. Added in Xamarin.Android 8.3.
+
 ### Binding Project Build Properties
 
 The following MSBuild properties are used with
@@ -761,7 +778,7 @@ resources.
 -  **AndroidUseAapt2** &ndash; A bool property which allows the developer to
     control the use of the `aapt2` tool for packaging.
     By default this will be set to false and we will use `aapt`.
-    If the developer wishes too use the new `aapt2` functionality
+    If the developer wishes to use the new `aapt2` functionality
     they can set
         
         <AndroidUseAapt2>True</AndroidUseAapt2>

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AndroidLinkContext.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/AndroidLinkContext.cs
@@ -1,0 +1,16 @@
+﻿using Mono.Linker;
+using Mono.Cecil;
+
+namespace MonoDroid.Tuner
+{
+	public class AndroidLinkContext : LinkContext
+	{
+		public AndroidLinkContext (Pipeline pipeline, AssemblyResolver resolver)
+			: base (pipeline, resolver) {}
+
+		public AndroidLinkContext (Pipeline pipeline, AssemblyResolver resolver, ReaderParameters readerParameters, UnintializedContextFactory factory)
+			: base (pipeline, resolver, readerParameters, factory) {}
+
+		public bool PreserveJniMarshalMethods { get; set; }
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
@@ -37,7 +37,7 @@ namespace MonoDroid.Tuner
 
 		static LinkContext CreateLinkContext (LinkerOptions options, Pipeline pipeline, ILogger logger)
 		{
-			var context = new LinkContext (pipeline, options.Resolver);
+			var context = new AndroidLinkContext (pipeline, options.Resolver);
 			if (options.DumpDependencies) {
 				var prepareDependenciesDump = context.Annotations.GetType ().GetMethod ("PrepareDependenciesDump", new Type[] {});
 				if (prepareDependenciesDump != null)
@@ -51,6 +51,7 @@ namespace MonoDroid.Tuner
 			context.SymbolReaderProvider = new DefaultSymbolReaderProvider (true);
 			context.SymbolWriterProvider = new DefaultSymbolWriterProvider ();
 			context.OutputDirectory = options.OutputDirectory;
+			context.PreserveJniMarshalMethods = options.PreserveJniMarshalMethods;
 			return context;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/LinkerOptions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/LinkerOptions.cs
@@ -22,5 +22,6 @@ namespace MonoDroid.Tuner
 		public bool DumpDependencies { get; set; }
 		public string HttpClientHandlerType { get; set; }
 		public string TlsProvider { get; set; }
+		public bool PreserveJniMarshalMethods { get; set; }
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MonoDroidMarkStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MonoDroidMarkStep.cs
@@ -22,7 +22,7 @@ namespace MonoDroid.Tuner
 			marshalTypes.Clear ();
 			base.Process (context);
 
-			if (UpdateMarshalTypes ())
+			if (PreserveJniMarshalMethods () && UpdateMarshalTypes ())
 				base.Process (context);
 		}
 
@@ -196,6 +196,14 @@ namespace MonoDroid.Tuner
 			return true;
 		}
 
+		bool PreserveJniMarshalMethods ()
+		{
+			if (_context is AndroidLinkContext ac)
+				return ac.PreserveJniMarshalMethods;
+
+			return false;
+		}
+
 		// If this is one of our infrastructure methods that has [Register], like:
 		// [Register ("hasWindowFocus", "()Z", "GetHasWindowFocusHandler")],
 		// we need to preserve the "GetHasWindowFocusHandler" method as well.
@@ -207,7 +215,7 @@ namespace MonoDroid.Tuner
 				return;
 
 			MethodDefinition marshalMethod;
-			if (method.TryGetMarshalMethod (nativeMethod, signature, out marshalMethod)) {
+			if (PreserveJniMarshalMethods () && method.TryGetMarshalMethod (nativeMethod, signature, out marshalMethod)) {
 				MarkMethod (marshalMethod);
 				marshalTypes.Add (marshalMethod.DeclaringType);
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
@@ -51,6 +51,8 @@ namespace Xamarin.Android.Tasks
 
 		public string TlsProvider { get; set; }
 
+		public bool PreserveJniMarshalMethods { get; set; }
+
 		IEnumerable<AssemblyDefinition> GetRetainAssemblies (DirectoryAssemblyResolver res)
 		{
 			List<AssemblyDefinition> retainList = null;
@@ -83,6 +85,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  LinkOnlyNewerThan: {0}", LinkOnlyNewerThan);
 			Log.LogDebugMessage ("  HttpClientHandlerType: {0}", HttpClientHandlerType);
 			Log.LogDebugMessage ("  TlsProvider: {0}", TlsProvider);
+			Log.LogDebugMessage ("  PreserveJniMarshalMethods: {0}", PreserveJniMarshalMethods);
 
 			var rp = new ReaderParameters {
 				InMemory    = true,
@@ -115,6 +118,7 @@ namespace Xamarin.Android.Tasks
 			options.DumpDependencies = DumpDependencies;
 			options.HttpClientHandlerType = HttpClientHandlerType;
 			options.TlsProvider = TlsProvider;
+			options.PreserveJniMarshalMethods = PreserveJniMarshalMethods;
 			
 			var skiplist = new List<string> ();
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -575,6 +575,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <Compile Include="Tasks\JavaDoc.cs" />
+    <Compile Include="Linker\MonoDroid.Tuner\AndroidLinkContext.cs" />
   </ItemGroup>
   <ItemGroup>
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.LaunchMode.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -303,6 +303,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<_InstantRunEnabled Condition=" '$(_InstantRunEnabled)' == '' ">False</_InstantRunEnabled>
 	<_AndroidBuildPropertiesCache>$(IntermediateOutputPath)build.props</_AndroidBuildPropertiesCache>
 
+	<AndroidGenerateJniMarshalMethods Condition=" '$(AndroidGenerateJniMarshalMethods)' == '' ">False</AndroidGenerateJniMarshalMethods>
+
 </PropertyGroup>
 
 <Choose>
@@ -2057,6 +2059,7 @@ because xbuild doesn't support framework reference assemblies.
       LinkSkip="$(AndroidLinkSkip)"
       LinkDescriptions="@(LinkDescription)"
       ProguardConfiguration="$(_ProguardProjectConfiguration)"
+      PreserveJniMarshalMethods="$(AndroidGenerateJniMarshalMethods)"
       EnableProguard="$(AndroidEnableProguard)"
       DumpDependencies="$(LinkerDumpDependencies)"
       ResolvedAssemblies="@(ResolvedAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"


### PR DESCRIPTION
This option makes preserving new marshal methods, generated by
`jnimarshalmethod-gen.exe`, optional in the linker.

It also introduces new `JniMarshalMethods` property to toggle building
with generated marshal methods and will be used by following
patches too. It defaults to *False*.