### PR TITLE
Bump to Java.Interop/master/bed29582

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,8 @@ prepare-deps: prepare-external
 	$(MSBUILD) $(MSBUILD_FLAGS) build-tools/dependencies/dependencies.csproj
 
 prepare-props: prepare-deps
+	cp $(call GetPath,JavaInterop)/external/Mono.Cecil* "$(call GetPath,MonoSource)/external"
+	cp "$(call GetPath,JavaInterop)/product.snk" "$(call GetPath,MonoSource)"
 	cp build-tools/scripts/Configuration.Java.Interop.Override.props external/Java.Interop/Configuration.Override.props
 	cp $(call GetPath,MonoSource)/mcs/class/msfinal.pub .
 

--- a/build-tools/scripts/Configuration.Java.Interop.Override.props
+++ b/build-tools/scripts/Configuration.Java.Interop.Override.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <CecilSourceDirectory>$(MSBuildThisFileDirectory)..\..\external\mono\external\cecil</CecilSourceDirectory>
     <UtilityOutputFullPath>$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\</UtilityOutputFullPath>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/1493

Allows injection of `<dllmap/>` entries into
`Java.Runtime.Environment.dll.config`.

Use `<fileapi.h>`, not `<FileAPI.h>`, as Linux wants the former.

Add `$(CecilSourceDirectory)` support.