### PR TITLE
[msbuild] fix Aapt2 property reference.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -665,7 +665,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 			AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
 			AndroidSdkPath="$(AndroidSdkDirectory)"
 			AndroidNdkPath="$(AndroidNdkDirectory)"
-			AndroidUseAapt2="$(Aapt2Version)"
+			AndroidUseAapt2="$(AndroidUseAapt2)"
 			AotAssemblies="$(AotAssemblies)"
 			SequencePointsMode="$(_AndroidSequencePointsMode)"
 			BuildingInsideVisualStudio="$(BuildingInsideVisualStudio)"


### PR DESCRIPTION
`AndroidUseAapt2="$(Aapt2Version)"` is wrong.

The commit message from 3395dbc says:

        <AndroidUseAapt2>True</AndroidUseAapt2>

so use it. To make sure, specifying Aapt2Version didn't affect anything.