### PR TITLE
[aapt2] _CreateAapt2VersionCache target should not run when aapt2 is disabled

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Aapt2Tests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Aapt2Tests.cs
@@ -148,5 +148,17 @@ namespace Xamarin.Android.Build.Tests {
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 			Directory.SetCurrentDirectory (current);
 		}
+
+		[Test]
+		public void Aapt2Disabled ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty ("AndroidUseAapt2", "False");
+			using (var b = CreateApkBuilder ("temp/Aapt2Disabled")) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "Task \"Aapt2Link\" skipped"), "Aapt2Link task should be skipped!");
+				Assert.IsTrue (b.Output.IsTargetSkipped ("_CreateAapt2VersionCache"), "_CreateAapt2VersionCache target should be skipped!");
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -741,6 +741,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <Target Name="_CreateAapt2VersionCache"
 		DependsOnTargets="_ReadAapt2VersionCache"
 		AfterTargets="_SetLatestTargetFrameworkVersion"
+		Condition="'$(_AndroidUseAapt2)' == 'True'"
 	>
 	<MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" />
 	<WriteLinesToFile


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/1748

I was testing build times on master with a project in the
Xamarin.Forms repo.

I discovered the following scenario:
1. Build [Xamarin.Forms.ControlGallery.Android.csproj](https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj)
2. Build it again, with no changes

The `_CreateAapt2VersionCache` target was always running, and it seems
to be a bit of a performance regression.

For example, in the log from building this project I saw the following
times from `_CreateAapt2VersionCache` in this project and other referenced
projects:
- 144ms
- 51ms
- 92ms
- 127ms
- 102ms

Total of 516ms added to a build with no changes.

To fix this I:
- Added a test with `$(AndroidUseAapt2)` set to `False`, verifying
  `Aapt2Link` and `_CreateAapt2VersionCache` are skipped.
- Added a `Condition` so that `_CreateAapt2VersionCache` doesn't run
  if aapt2 is disabled