### PR TITLE
[Linux] Fix a few problems with host build of libmonodroid

### DIFF
--- a/src/monodroid/jni/monodroid-glue.c
+++ b/src/monodroid/jni/monodroid-glue.c
@@ -27,6 +27,10 @@
 
 #include "mono_android_Runtime.h"
 
+#if defined (LINUX)
+#include <sys/syscall.h>
+#endif
+
 #if defined (DEBUG)
 #include <fcntl.h>
 #include <arpa/inet.h>
@@ -1121,18 +1125,20 @@ monodroid_disable_gc_hooks ()
 	gc_disabled = 1;
 }
 
-#ifndef LINUX
+#ifndef ANDROID
 static pid_t gettid ()
 {
 #ifdef WINDOWS
 	return GetCurrentThreadId ();
-#else
+#elif defined (LINUX) // WINDOWS
+	return syscall (SYS_gettid);
+#else // LINUX
 	uint64_t tid;
 	pthread_threadid_np (NULL, &tid);
 	return (pid_t)tid;
 #endif
 }
-#endif
+#endif // ANDROID
 
 typedef mono_bool (*MonodroidGCTakeRefFunc) (JNIEnv *env, MonoObject *obj);
 

--- a/src/monodroid/jni/xamarin_getifaddrs.c
+++ b/src/monodroid/jni/xamarin_getifaddrs.c
@@ -994,8 +994,10 @@ get_link_info (const struct nlmsghdr *message)
 				break;
 
 			default:
+#if DEBUG
 				log_debug (LOG_NETLINK, "     rta_type: ");
 				print_ifla_name (attribute->rta_type);
+#endif // DEBUG
 				break;
 		}
 

--- a/src/monodroid/monodroid.projitems
+++ b/src/monodroid/monodroid.projitems
@@ -13,7 +13,7 @@
     </_HostRuntime>
     <_HostRuntime Include="host-Linux" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:'))">
       <Cc>$(HostCc)</Cc>
-      <CFlags>@(JdkIncludePath->'-I%(Identity)', ' ') $(_HostUnixCFlags) $(_HostLinuxCFlags) -D_GNU_SOURCE</CFlags>
+      <CFlags>@(JdkIncludePath->'-I%(Identity)', ' ') $(_HostUnixCFlags) $(_HostLinuxCFlags) -D_GNU_SOURCE -DLINUX -Dlinux -D__linux__</CFlags>
       <LdFlags>$(_HostUnixLdFlags)</LdFlags>
       <ExtraSource>$(_UnixAdditionalSourceFiles)</ExtraSource>
       <NativeLibraryExtension>so</NativeLibraryExtension>


### PR DESCRIPTION
We've been building libmonodroid for Linux host incorrectly. While the shared
library built, it would never load properly, failing to resolve the
`pthread_threadid_np` and `print_ifla_name` functions.

The former is due the fact that we attempted to implement the `gettid`
function (returns current thread ID) which does not exist in glibc on Linux and
our implementation called `pthread_threadid_np` which caused a compiler warning
about missing declaration of the function - an error which would show up only at
runtime (but we practically don't use the Linux host libmonodroid currently and
so nobody noticed the issue). This commit fixes the implementation by calling
the `SYS_gettid` system call directly on Linux (but not on Android which has its
own implementation of the call in bionic)

The latter was due to missing `#ifdef DEBUG` around the call to the function
which is present only if `DEBUG` is defined.