### PR TITLE
[build] fix Java.Interop's Mono.Cecil usage on Windows

### DIFF
--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -34,6 +34,19 @@
         DestinationFile="$(_TopDir)\Configuration.OperatingSystem.props"
         Replacements="@JAVA_HOME@=$(_JavaSdkDirectory)"
     />
+    <ItemGroup>
+      <_CecilFiles Include="$(_TopDir)\external\Java.Interop\external\Mono.Cecil*" />
+    </ItemGroup>
+    <Copy
+        SourceFiles="@(_CecilFiles)"
+        DestinationFolder="$(_TopDir)\external\mono\external"
+        SkipUnchangedFiles="True"
+    />
+    <Copy
+        SourceFiles="$(_TopDir)\external\Java.Interop\product.snk"
+        DestinationFolder="$(_TopDir)\external\mono"
+        SkipUnchangedFiles="True"
+    />
     <MakeDir Directories="$(_TopDir)\bin\Test$(Configuration)" />
     <ReplaceFileContents
         SourceFile="$(MSBuildThisFileDirectory)XABuildPaths.cs.in"


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/9bc51aed62d6e00035496dc3c6a76fb303a5fa90#diff-b67911656ef5d18c4ae36cb6741b7965R114

Java.Interop was recently configured to use Mono's copy of
`Mono.Cecil`. This change was setup in the `Makefile`:

    prepare-props: prepare-deps
        cp $(call GetPath,JavaInterop)/external/Mono.Cecil* "$(call GetPath,MonoSource)/external"
        cp "$(call GetPath,JavaInterop)/product.snk" "$(call GetPath,MonoSource)"

We have to run the equivalent of these `cp` commands in
`PrepareWindows.targets`.