### PR TITLE
[build] Update our copy of Java.Runtime.Environment.dll.config

### DIFF
--- a/build-tools/scripts/java-interop.dllmap
+++ b/build-tools/scripts/java-interop.dllmap
@@ -1,0 +1,4 @@
+  <dllmap dll="java-interop" os="osx" target="lib/host-Darwin/libmono-android.debug.dylib" />
+  <dllmap dll="java-interop" os="linux" target="lib/host-Linux/libmono-android.debug.so" />
+  <dllmap dll="java-interop" os="windows" wordsize="64" target="lib/host-mxe-Win64/libmono-android.debug.dll" />
+  <dllmap dll="java-interop" os="windows" wordsize="32" target="lib/host-mxe-Win32/libmono-android.debug.dll" />

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -20,6 +20,10 @@
         SourceFiles="@(Assembly)"
         DestinationFolder="$(OutputPath)\..\v1.0"
     />
+    <Exec
+        Condition="Exists ('$(OutputPath)\..\v1.0\Java.Runtime.Environment.dll.config') And !Exists ('$(OutputPath)\..\v1.0\Java.Runtime.Environment.dll.config.in.bak')"
+        Command="sed -i .in.bak -e '/&lt;configuration&gt;/r $(MSBuildThisFileDirectory)\..\..\build-tools\scripts\java-interop.dllmap' $(OutputPath)\..\v1.0\Java.Runtime.Environment.dll.config"
+    />
   </Target>
   <Target Name="_BuildAssemblyInfo_cs"
       DependsOnTargets="GetXAVersionInfo"

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -146,14 +146,15 @@
   <Target Name="_CreateJavaInteropDllConfig"
       Inputs="$(XAInstallPrefix)xbuild\Xamarin\Android\Java.Interop.dll"
       Outputs="$(XAInstallPrefix)xbuild\Xamarin\Android\Java.Interop.dll.config">
+    <ReadLinesFromFile
+        File="../../build-tools/scripts/java-interop.dllmap">
+        <Output
+            TaskParameter="Lines"
+            ItemName="_JavaInteropDllMapContent" />
+    </ReadLinesFromFile>
     <WriteLinesToFile
         File="$(XAInstallPrefix)xbuild\Xamarin\Android\Java.Interop.dll.config"
-        Lines="&lt;configuration&gt;
-  &lt;dllmap dll=&quot;java-interop&quot; os=&quot;osx&quot; target=&quot;lib/host-Darwin/libmono-android.debug.dylib&quot; /&gt;
-  &lt;dllmap dll=&quot;java-interop&quot; os=&quot;linux&quot; target=&quot;lib/host-Linux/libmono-android.debug.so&quot; /&gt;
-  &lt;dllmap dll=&quot;java-interop&quot; os=&quot;windows&quot; wordsize=&quot;64&quot; target=&quot;lib/host-mxe-Win64/libmono-android.debug.dll&quot; /&gt;
-  &lt;dllmap dll=&quot;java-interop&quot; os=&quot;windows&quot; wordsize=&quot;32&quot; target=&quot;lib/host-mxe-Win32/libmono-android.debug.dll&quot; /&gt;
-&lt;/configuration&gt;"
+        Lines="&lt;configuration&gt;;@(_JavaInteropDllMapContent);&lt;/configuration&gt;"
         Overwrite="True"
 	/>
     </Target>


### PR DESCRIPTION
Add dll maps to map `libmono-android` as `java-interop` shared library
for `Java.Runtime.Environment.dll`. Similar way as we do for
`Java.Interop.dll` in `monodroid.targets`