### PR TITLE
[Xamarin.Android.Build.Tasks] Per-TFV IOP on Windows

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.DefaultOutputPaths.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.DefaultOutputPaths.targets
@@ -10,7 +10,9 @@
 		<IntermediateOutputPath Condition=" '$(PlatformName)' != 'AnyCPU' ">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(AndroidUseLatestPlatformSdk)' != 'true'">
-		<!-- We don't change the IntermediateOutputPath by default to avoid backward compatibility issues -->
+		<!-- Only change IntermediateOutputPath on Windows by default to avoid backward compatibility issues -->
+		<AppendTargetFrameworkToIntermediateOutputPath Condition=" '$(AppendTargetFrameworkToIntermediateOutputPath)' == '' And '$(OS)' == 'Windows_NT' ">True</AppendTargetFrameworkToIntermediateOutputPath>
+		<AppendTargetFrameworkToIntermediateOutputPath Condition=" '$(AppendTargetFrameworkToIntermediateOutputPath)' == '' And '$(OS)' != 'Windows_NT' ">False</AppendTargetFrameworkToIntermediateOutputPath>
 		<AppendTargetFrameworkToIntermediateOutputPath Condition="'$(AppendTargetFrameworkToIntermediateOutputPath)' == ''">False</AppendTargetFrameworkToIntermediateOutputPath>
 		<!-- We don't change the OutputPath by default to avoid backward compatibility issues -->
 		<AppendTargetFrameworkToOutputPath Condition="'$(AppendTargetFrameworkToOutputPath)' == ''">false</AppendTargetFrameworkToOutputPath>


### PR DESCRIPTION
Context: 13d216fd86b4419eee8029abecf2ef24115edf26
Context: 96b735273bb70b5ef40698d9ed4c287108792b9d

After internal deliberation, we have decided that it is sufficiently
"safe enough" to set
`$(AppendTargetFrameworkToIntermediateOutputPath)`=True on Windows,
so that `$(IntermediateOutputPath)` contains
`$(TargetFrameworkVersion)`.