### PR TITLE
[Xamarin.Forms Integration] only set `$(AndroidUseAapt2)` on non-Windows platforms

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -393,7 +393,15 @@ namespace Xamarin.ProjectTools
 			}
 			if (!result && ThrowOnBuildFailure) {
 				string message = "Build failure: " + Path.GetFileName (projectOrSolution) + (BuildLogFile != null && File.Exists (buildLogFullPath) ? "Build log recorded at " + buildLogFullPath : null);
-				throw new FailedBuildException (message, null, File.ReadAllText (buildLogFullPath));
+				if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
+					//NOTE: on Windows I've had various issues when the full build log is in the error:
+					// - VS IDE hangs for a very long time in the test results window
+					// - Builds on VSTS hang when writing NUnit results to disk
+					//We have build artifacts of these logs on VSTS anyway
+					throw new FailedBuildException (message, null);
+				} else {
+					throw new FailedBuildException (message, null, File.ReadAllText (buildLogFullPath));
+				}
 			}
 
 			return result;

--- a/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
+++ b/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
@@ -15,11 +15,11 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
-    <AndroidUseAapt2>True</AndroidUseAapt2>
   </PropertyGroup>
   <Import Project="..\..\..\Configuration.props" />
   <PropertyGroup>
     <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
+    <AndroidUseAapt2 Condition=" '$(HostOS)' != 'Windows' ">True</AndroidUseAapt2>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/1771

The `Xamarin.Forms-Performance-Integration` project is currently
setting `$(AndroidUseAapt2)` as a way to test its performance
improvements.

Since setting `$(AndroidUseAapt2)` would cause `aapt.exe` to operate
across different drives on VSTS (`C:\` and `E:\`), this is breaking
the build.

For now, let's not set `$(AndroidUseAapt2)` on Windows. We also have
to move the property *after* `Configuration.props` is imported, so
`$(HostOS)` is set.