### PR TITLE
Make sure to remove previous Xamarin.Android.Sdk.(props|targets)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ install::
 	-mkdir -p "$(prefix)/lib/mono/xbuild/Xamarin/"
 	cp -a "bin/$(CONFIGURATION)/lib/xamarin.android/." "$(prefix)/lib/xamarin.android/"
 	-rm -rf "$(prefix)/lib/mono/xbuild/Novell"
+	-rm -rf "$(prefix)/lib/mono/xbuild/Xamarin/Xamarin.Android.Sdk.props"
+	-rm -rf "$(prefix)/lib/mono/xbuild/Xamarin/Xamarin.Android.Sdk.targets"
 	-rm -rf "$(prefix)/lib/mono/xbuild/Xamarin/Android"
 	-rm -rf "$(prefix)/lib/mono/xbuild-frameworks/MonoAndroid"
 	ln -s "$(prefix)/lib/xamarin.android/xbuild/Xamarin/Android/" "$(prefix)/lib/mono/xbuild/Xamarin/Android"


### PR DESCRIPTION
They have been kept old in their directory, and updates have been prevented.
That resulted in incorrect TargetFrameworkRootPath setting in the previous
bogus property definition. Removing this file fixes it.