### PR TITLE
[Xamarin.Android.Build.Tasks] Intellisense can't recongize 'Resource Dimension' definition

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1121,6 +1121,12 @@ namespace Lib1 {
 	<color name=""SomeColor"">#ffffffff</color>
 </resources>",
 			};
+			var dimen = new AndroidItem.AndroidResource ("Resources\\valuea\\dimen.xml") {
+				TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
+<resources>
+	<dimen name=""main_text_item_size"">17dp</dimen>
+</resources>",
+			};
 			var libProj = new XamarinAndroidLibraryProject () {
 				IsRelease = true,
 				ProjectName = "Lib1",
@@ -1172,6 +1178,7 @@ namespace Lib1 {
 					StringAssert.Contains ("Icon", designerContents, $"{designerFile} should contain Resources.Drawable.Icon");
 					StringAssert.Contains ("Main", designerContents, $"{designerFile} should contain Resources.Layout.Main");
 					StringAssert.Contains ("material_grey_50", designerContents, $"{designerFile} should contain Resources.Color.material_grey_50");
+					StringAssert.Contains ("main_text_item_size", designerContents, $"{designerFile} should contain Resources.Dimension.main_text_item_size");
 					StringAssert.DoesNotContain ("theme_devicedefault_background", designerContents, $"{designerFile} should not contain Resources.Color.theme_devicedefault_background");
 					libBuilder.Target = "Build";
 					Assert.IsTrue (libBuilder.Build (libProj), "Library project should have built");
@@ -1191,6 +1198,7 @@ namespace Lib1 {
 					StringAssert.Contains ("Icon", designerContents, $"{designerFile} should contain Resources.Drawable.Icon");
 					StringAssert.Contains ("Main", designerContents, $"{designerFile} should contain Resources.Layout.Main");
 					StringAssert.Contains ("material_grey_50", designerContents, $"{designerFile} should contain Resources.Color.material_grey_50");
+					StringAssert.Contains ("main_text_item_size", designerContents, $"{designerFile} should contain Resources.Dimension.main_text_item_size");
 					StringAssert.Contains ("theme_devicedefault_background", designerContents, $"{designerFile} should contain Resources.Color.theme_devicedefault_background");
 					StringAssert.Contains ("SomeColor", designerContents, $"{designerFile} should contain Resources.Color.SomeColor");
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1121,7 +1121,7 @@ namespace Lib1 {
 	<color name=""SomeColor"">#ffffffff</color>
 </resources>",
 			};
-			var dimen = new AndroidItem.AndroidResource ("Resources\\valuea\\dimen.xml") {
+			var dimen = new AndroidItem.AndroidResource ("Resources\\values\\dimen.xml") {
 				TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
 <resources>
 	<dimen name=""main_text_item_size"">17dp</dimen>
@@ -1132,6 +1132,7 @@ namespace Lib1 {
 				ProjectName = "Lib1",
 				AndroidResources = {
 					theme,
+					dimen,
 				},
 			};
 			libProj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", "True");
@@ -1178,7 +1179,7 @@ namespace Lib1 {
 					StringAssert.Contains ("Icon", designerContents, $"{designerFile} should contain Resources.Drawable.Icon");
 					StringAssert.Contains ("Main", designerContents, $"{designerFile} should contain Resources.Layout.Main");
 					StringAssert.Contains ("material_grey_50", designerContents, $"{designerFile} should contain Resources.Color.material_grey_50");
-					StringAssert.Contains ("main_text_item_size", designerContents, $"{designerFile} should contain Resources.Dimension.main_text_item_size");
+					StringAssert.DoesNotContain ("main_text_item_size", designerContents, $"{designerFile} should not contain Resources.Dimension.main_text_item_size");
 					StringAssert.DoesNotContain ("theme_devicedefault_background", designerContents, $"{designerFile} should not contain Resources.Color.theme_devicedefault_background");
 					libBuilder.Target = "Build";
 					Assert.IsTrue (libBuilder.Build (libProj), "Library project should have built");
@@ -1200,6 +1201,7 @@ namespace Lib1 {
 					StringAssert.Contains ("material_grey_50", designerContents, $"{designerFile} should contain Resources.Color.material_grey_50");
 					StringAssert.Contains ("main_text_item_size", designerContents, $"{designerFile} should contain Resources.Dimension.main_text_item_size");
 					StringAssert.Contains ("theme_devicedefault_background", designerContents, $"{designerFile} should contain Resources.Color.theme_devicedefault_background");
+					StringAssert.Contains ("main_text_item_size", designerContents, $"{designerFile} should contain Resources.Dimension.main_text_item_size");
 					StringAssert.Contains ("SomeColor", designerContents, $"{designerFile} should contain Resources.Color.SomeColor");
 
 					appBuilder.Target = "SignAndroidPackage";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
@@ -40,6 +40,22 @@ namespace Foo.Foo
 			}
 		}
 		
+		public partial class Dimension
+		{
+			
+			// aapt resource value: 0x7F090002
+			public const int main_text_item_size = 2131296258;
+			
+			static Dimension()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Dimension()
+			{
+			}
+		}
+		
 		public partial class Drawable
 		{
 			

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManagedResourceParserTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManagedResourceParserTests.cs
@@ -71,7 +71,7 @@ namespace Xamarin.Android.Build.Tests {
 			File.WriteAllText (Path.Combine (Root, path, "lp", "res", "animator", "slide_in_bottom.xml"), Animator);
 			File.WriteAllText (Path.Combine (Root, path, "lp", "res", "font", "arial.ttf"), "");
 			File.WriteAllText (Path.Combine (Root, path, "lp", "res", "values", "strings.xml"), StringsXml2);
-			File.WriteAllText (Path.Combine (Root, path, "lp", "res", "values", "dimen.xml"), DesignTimeBuild);
+			File.WriteAllText (Path.Combine (Root, path, "lp", "res", "values", "dimen.xml"), Dimen);
 			using (var stream = typeof (XamarinAndroidCommonProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Base.Icon.png")) {
 				var icon_binary_mdpi = new byte [stream.Length];
 				stream.Read (icon_binary_mdpi, 0, (int)stream.Length);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManagedResourceParserTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManagedResourceParserTests.cs
@@ -49,6 +49,11 @@ namespace Xamarin.Android.Build.Tests {
     android:valueTo=""0""
     android:valueType=""floatType"" />";
 
+		const string Dimen = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<resources>
+	<dimen name=""main_text_item_size"">17dp</dimen>
+</resources>";
+
 		[Test]
 		public void GenerateDesignerFile ()
 		{
@@ -66,6 +71,7 @@ namespace Xamarin.Android.Build.Tests {
 			File.WriteAllText (Path.Combine (Root, path, "lp", "res", "animator", "slide_in_bottom.xml"), Animator);
 			File.WriteAllText (Path.Combine (Root, path, "lp", "res", "font", "arial.ttf"), "");
 			File.WriteAllText (Path.Combine (Root, path, "lp", "res", "values", "strings.xml"), StringsXml2);
+			File.WriteAllText (Path.Combine (Root, path, "lp", "res", "values", "dimen.xml"), DesignTimeBuild);
 			using (var stream = typeof (XamarinAndroidCommonProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Base.Icon.png")) {
 				var icon_binary_mdpi = new byte [stream.Length];
 				stream.Read (icon_binary_mdpi, 0, (int)stream.Length);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -370,6 +370,8 @@ namespace Xamarin.Android.Tasks
 				CreateIntField (drawable, fieldName);
 				break;
 			case "dimen":
+				CreateIntField (dimension, fieldName);
+				break;
 			case "font":
 				CreateIntField (font, fieldName);
 				break;


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/628467
Fixes #1784

We were not correctly processing `dimen` resource items when parsing
the actual resources. We did however do it correctly when processing
the `R.txt` file.