### PR TITLE
[Xamarin.Android.Build.Tasks] [Aapt2] Allow dashes in Resource file names

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
@@ -17,13 +17,22 @@ namespace Xamarin.Android.Tasks {
 		public ITaskItem[] Resources { get; set; }
 
 		Regex fileNameCheck = new Regex ("[^a-zA-Z0-9_.]+", RegexOptions.Compiled);
+		Regex fileNameWithHyphenCheck = new Regex ("[^a-zA-Z0-9_.-]+", RegexOptions.Compiled);
 
 		public override bool Execute ()
 		{
 			foreach (var resource in Resources) {
-				var match = fileNameCheck.Match (Path.GetFileName (resource.ItemSpec));
-				if (match.Success) {
-					Log.LogCodedError ("APT0000", resource.ItemSpec, 0, "Invalid file name: It must contain only [a-zA-Z0-9_.].");
+				var fileName = Path.GetFileName (resource.ItemSpec);
+				if (string.Compare (Directory.GetParent (resource.ItemSpec).Name, "values", StringComparison.OrdinalIgnoreCase) == 0) {
+					var match = fileNameWithHyphenCheck.Match (fileName);
+					if (match.Success) {
+						Log.LogCodedError ("APT0000", resource.ItemSpec, 0, "Invalid file name: It must contain only [a-zA-Z0-9_.-].");
+					}
+				} else {
+					var match = fileNameCheck.Match (fileName);
+					if (match.Success) {
+						Log.LogCodedError ("APT0000", resource.ItemSpec, 0, "Invalid file name: It must contain only [a-zA-Z0-9_.].");
+					}
 				}
 			}
 			return !Log.HasLoggedErrors;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
@@ -23,15 +23,16 @@ namespace Xamarin.Android.Tasks {
 		{
 			foreach (var resource in Resources) {
 				var fileName = Path.GetFileName (resource.ItemSpec);
-				if (string.Compare (Directory.GetParent (resource.ItemSpec).Name, "values", StringComparison.OrdinalIgnoreCase) == 0) {
+				var directory = Path.GetFileName (Path.GetDirectoryName (resource.ItemSpec));
+				if (directory.StartsWith ("values", StringComparison.OrdinalIgnoreCase)) {
 					var match = fileNameWithHyphenCheck.Match (fileName);
 					if (match.Success) {
-						Log.LogCodedError ("APT0000", resource.ItemSpec, 0, "Invalid file name: It must contain only [a-zA-Z0-9_.-].");
+						Log.LogCodedError ("APT0000", resource.ItemSpec, 0, $"Invalid file name: It must contain only {fileNameWithHyphenCheck}.");
 					}
 				} else {
 					var match = fileNameCheck.Match (fileName);
 					if (match.Success) {
-						Log.LogCodedError ("APT0000", resource.ItemSpec, 0, "Invalid file name: It must contain only [a-zA-Z0-9_.].");
+						Log.LogCodedError ("APT0000", resource.ItemSpec, 0, $"Invalid file name: It must contain only {fileNameCheck}.");
 					}
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -696,6 +696,12 @@ namespace UnnamedProject
 			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\drawable\\icon-2.png") {
 				BinaryContent = () => XamarinAndroidCommonProject.icon_binary_hdpi,
 			});
+			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values\\strings-2.xml") {
+				TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
+<resources>
+	<string name=""hello"">Hello World, Click Me!</string>
+</resources>",
+			});
 			var projectPath = string.Format ($"temp/{TestName}");
 			using (var b = CreateApkBuilder (Path.Combine (projectPath, "UnamedApp"), false, false)) {
 				b.Verbosity = LoggerVerbosity.Diagnostic;


### PR DESCRIPTION
Fixes #1780
    
We forgot to include `-` as a valid character for the Resource
filenames when implementing the `CheckForInvalidResourceFileNames`
Task. As a result many working samples, when using `aapt2`, failed
with.
    
     APT0000: Invalid file name: It must contain only [a-zA-Z0-9_.].
    
The fix is to allow `-` as a filename character.
This is only done for `values` filenames, since they
are the only ones which support `-`. For all other resource types `-` is invalid.