### PR TITLE
[Xamarin.Android.Common.targets] Allow AdbTarget to be used for deployment

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -3051,7 +3051,7 @@ because xbuild doesn't support framework reference assemblies.
 </PropertyGroup>
 
 <Target Name="_Deploy">
-  <Exec Command="&quot;$(AdbToolPath)\adb&quot; install -r &quot;$(ApkFileSigned)&quot;" />
+  <Exec Command="&quot;$(AdbToolPath)\adb&quot; $(AdbTarget) install -r &quot;$(ApkFileSigned)&quot;" />
 </Target>
 
 <Target Name="Install"


### PR DESCRIPTION
The current Install (_Deploy) target will fail with 'error : more than one device/emulator' if multiple devices or emulators are attached. This change allows us to pass the -s argument to adb (e.g. '/p:AdbTarget=-s foo'), which allows us to specify an individual target if multiple are present.

Failure example:

```
"Tests.csproj" (Install target) (1) ->
(_Deploy target) -> 
  EXEC : error : more than one device/emulator [/foo/bar/Tests.csproj]
  EXEC : error : more than one device/emulator [/foo/bar/Tests.csproj]
  adb : error : failed to get feature set: more than one device/emulator [/foo/bar/Tests.csproj]
  /foo/bar/xamarin.android-oss_v8.4.99.3_Darwin-x86_64_HEAD_7ba040a/bin/Release/lib/xamarin.android/xbuild/Xamarin/Android/Xamarin.Android.Common.targets(3054,3): error MSB3073: The command ""/foo/bar/android-sdk-macosx/platform-tools/adb" install -r "bin/Release/Tests.Tests-Signed.apk"" exited with code 255. [/foo/bar/Tests.csproj]

    2 Warning(s)
    4 Error(s)
```