### PR TITLE
[monodroid] Include enable_soft_breakpoints conditionally

### DIFF
--- a/src/monodroid/jni/monodroid-glue.c
+++ b/src/monodroid/jni/monodroid-glue.c
@@ -2490,7 +2490,7 @@ copy_file_to_internal_location(char *to, char *from, char* file)
 	free (from_file);
 	free (to_file);
 }
-#else
+#else  /* !defined (ANDROID) */
 #ifdef DEBUG
 static int
 enable_soft_breakpoints (void)
@@ -2503,7 +2503,7 @@ void
 set_world_accessable (const char *path)
 {
 }
-#endif
+#endif /* !defined (ANDROID) */
 
 static void
 mono_runtime_init (char *runtime_args)

--- a/src/monodroid/jni/monodroid-glue.c
+++ b/src/monodroid/jni/monodroid-glue.c
@@ -2405,6 +2405,7 @@ static const char *soft_breakpoint_kernel_list[] = {
 	"2.6.32.21-g1e30168", NULL
 };
 
+#ifdef DEBUG
 static int
 enable_soft_breakpoints (void)
 {
@@ -2438,6 +2439,7 @@ enable_soft_breakpoints (void)
 	log_info (LOG_DEBUGGER, "soft breakpoints enabled (%s property set to %s)", DEBUG_MONO_SOFT_BREAKPOINTS, value);
 	return 1;
 }
+#endif /* DEBUG */
 
 void
 set_world_accessable (const char *path)
@@ -2489,11 +2491,13 @@ copy_file_to_internal_location(char *to, char *from, char* file)
 	free (to_file);
 }
 #else
+#ifdef DEBUG
 static int
 enable_soft_breakpoints (void)
 {
 	return 0;
 }
+#endif /* DEBUG */
 
 void
 set_world_accessable (const char *path)


### PR DESCRIPTION
Noticed the following warning in the build
log. `enable_soft_breakpoints` function is called only when `DEBUG` is
defined. So make sure we don't compile it when `DEBUG` is not defined.

```
jni/monodroid-glue.c(2493,1): warning GF055929C: unused function 'enable_soft_breakpoints' [-Wunused-function] [/Users/rodo/git/xa2/src/monodroid/monodroid.csproj]
```