### PR TITLE
[Xamarin.Android.Build.Tasks] Fix inconsistent library cache files.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
@@ -37,7 +37,11 @@ namespace Xamarin.Android.Tasks
 				return true;
 			}
 			// there could be ./AndroidManifest.xml and bin/AndroidManifest.xml, which will be the same. So, ignore "bin" ones.
-			ManifestDocuments = Directory.GetFiles (TargetDirectory, "AndroidManifest.xml", SearchOption.AllDirectories).Where (f => !Path.GetDirectoryName (f).EndsWith ("bin") && !Path.GetDirectoryName (f).EndsWith ("manifest")).Select (p => new TaskItem (p)).ToArray ();
+			ManifestDocuments = Directory.GetFiles (TargetDirectory, "AndroidManifest.xml", SearchOption.AllDirectories)
+				.Where (f => {
+					var directory = Path.GetFileName (Path.GetDirectoryName (f));
+					return directory != "bin" && directory != "manifest";
+				}).Select (p => new TaskItem (p)).ToArray ();
 			NativeLibraries = Directory.GetFiles (TargetDirectory, "*.so", SearchOption.AllDirectories)
 				.Where (p => MonoAndroidHelper.GetNativeLibraryAbi (p) != null)
 				.Select (p => new TaskItem (p)).ToArray ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
@@ -41,7 +41,9 @@ namespace Xamarin.Android.Tasks
 				.Where (f => {
 					var directory = Path.GetFileName (Path.GetDirectoryName (f));
 					return directory != "bin" && directory != "manifest";
-				}).Select (p => new TaskItem (p)).ToArray ();
+				})
+				.Select (p => new TaskItem (p))
+				.ToArray ();
 			NativeLibraries = Directory.GetFiles (TargetDirectory, "*.so", SearchOption.AllDirectories)
 				.Where (p => MonoAndroidHelper.GetNativeLibraryAbi (p) != null)
 				.Select (p => new TaskItem (p)).ToArray ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Android.Tasks
 				return true;
 			}
 			// there could be ./AndroidManifest.xml and bin/AndroidManifest.xml, which will be the same. So, ignore "bin" ones.
-			ManifestDocuments = Directory.GetFiles (TargetDirectory, "AndroidManifest.xml", SearchOption.AllDirectories).Where (f => !Path.GetDirectoryName (f).EndsWith ("bin")).Select (p => new TaskItem (p)).ToArray ();
+			ManifestDocuments = Directory.GetFiles (TargetDirectory, "AndroidManifest.xml", SearchOption.AllDirectories).Where (f => !Path.GetDirectoryName (f).EndsWith ("bin") && !Path.GetDirectoryName (f).EndsWith ("manifest")).Select (p => new TaskItem (p)).ToArray ();
 			NativeLibraries = Directory.GetFiles (TargetDirectory, "*.so", SearchOption.AllDirectories)
 				.Where (p => MonoAndroidHelper.GetNativeLibraryAbi (p) != null)
 				.Select (p => new TaskItem (p)).ToArray ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -258,7 +258,6 @@ namespace Xamarin.Android.Tasks
 								outfs.Write (data, 0, data.Length);
 							updated = true;
 						}
-						jars.Add (outjarFile);
 					}
 
 					// embedded AndroidResourceLibrary archive


### PR DESCRIPTION
Fixes #1814

Both `GetImportedLibraries` and `ResolveLibraryProjectImports` have
a problem where the cache files they genereate are not always
consistent between builds.

In some cases additional entries are added/removed. As a result
targets like `_UpdateAndroidResgen` will run when they really
do not need to. Here are some examples of the changes

	diff -u old.cache Bug15162/obj/Debug/libraryprojectimports.cache
	--- old.cache	2018-06-14 11:12:10.000000000 +0100
	+++ Bug15162/obj/Debug/libraryprojectimports.cache	2018-06-14 11:12:28.000000000 +0100
	@@ -1,8 +1,6 @@
	 ﻿<?xml version="1.0" encoding="utf-8"?>
	 <Paths>
	   <Jars>
	-    <Jar>obj/Debug/lp/0/jl/formsviewgroup.jar</Jar>
	-    <Jar>obj/Debug/lp/7/jl/support-annotations.jar</Jar>
	     <Jar>/Users/dean/Downloads/Bug15162-1/Bug15162/obj/Debug/lp/0/jl/formsviewgroup.jar</Jar>
	     <Jar>/Users/dean/Downloads/Bug15162-1/Bug15162/obj/Debug/lp/10/jl/bin/classes.jar</Jar>
	     <Jar>/Users/dean/Downloads/Bug15162-1/Bug15162/obj/Debug/lp/11/jl/bin/classes.jar</Jar>

and

	diff -u old.cache Bug15162/obj/Debug/libraryimports.cache
	--- old.cache	2018-06-14 11:29:41.000000000 +0100
	+++ Bug15162/obj/Debug/libraryimports.cache	2018-06-14 11:30:42.000000000 +0100
	@@ -3,27 +3,40 @@
	   <ManifestDocuments>
	     <ManifestDocument>obj/Debug/lp/10/jl/AndroidManifest.xml</ManifestDocument>
	     <ManifestDocument>obj/Debug/lp/11/jl/AndroidManifest.xml</ManifestDocument>
	+    <ManifestDocument>obj/Debug/lp/11/jl/manifest/AndroidManifest.xml</ManifestDocument>
	     <ManifestDocument>obj/Debug/lp/12/jl/AndroidManifest.xml</ManifestDocument>

In both cases additional files are picked up or added. In the case of `ResolveLibraryProjectImports`
the extra `jars.Add` was not need because at the end of the task we add ALL the jar files
we find in the output directory. The additional `jars.Add` was responsible for adding
the non-fullpath variants of the files.

The `GetImportedLibraries` was adding the files from a `manifest` subdirectory in the `lp`
intermediate directories.