### PR TITLE
[build] Fix the list of ILRepack assemblies.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/ILRepack.targets
+++ b/src/Xamarin.Android.Build.Tasks/ILRepack.targets
@@ -6,7 +6,7 @@
 			<InputAssemblies Include="$(OutputPath)\NuGet.ProjectModel.dll" />
 			<InputAssemblies Include="$(OutputPath)\Newtonsoft.Json.dll" />
 			<InputAssemblies Include="$(OutputPath)\NuGet.Common.dll" />
-			<InputAssemblies Include="$(OutputPath)\NuGet.Common.dll" />
+			<InputAssemblies Include="$(OutputPath)\NuGet.Protocol.dll" />
 			<InputAssemblies Include="$(OutputPath)\NuGet.Frameworks.dll" />
 			<InputAssemblies Include="$(OutputPath)\NuGet.LibraryModel.dll" />
 			<InputAssemblies Include="$(OutputPath)\NuGet.Versioning.dll" />


### PR DESCRIPTION
We had a duplicate Nuget.Common when we need a
Nuget.Protocol.