### PR TITLE
[Xamarin.Android.Buiild.Tasks] Allow uncompressed native libraries in apk

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Collections.Generic;
 using System.Xml.Linq;
+using Xamarin.Tools.Zip;
 
 namespace Xamarin.Android.Build.Tests
 {
@@ -168,24 +169,28 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void CheckIncludedNativeLibraries ()
+		public void CheckIncludedNativeLibraries ([Values (true, false)] bool compressNativeLibraries)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 			};
 			proj.Packages.Add(KnownPackages.SQLitePCLRaw_Core);
 			proj.SetProperty(proj.ReleaseProperties, KnownProperties.AndroidSupportedAbis, "x86");
+			proj.SetProperty (proj.ReleaseProperties, "AndroidStoreUncompressedFileExtensions", compressNativeLibraries ? "" : ".so");
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
 				b.ThrowOnBuildFailure = false;
 				Assert.IsTrue (b.Build (proj), "build failed");
 				var apk = Path.Combine (Root, b.ProjectDirectory,
 						proj.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
+				CompressionMethod method = compressNativeLibraries ? CompressionMethod.Deflate : CompressionMethod.Store;
 				using (var zip = ZipHelper.OpenZip (apk)) {
 					var libFiles = zip.Where (x => x.FullName.StartsWith("lib/") && !x.FullName.Equals("lib/", StringComparison.InvariantCultureIgnoreCase));
 					var abiPaths = new string[] { "lib/x86/" };
-					foreach (var file in libFiles)
-						Assert.IsTrue(abiPaths.Any (x => file.FullName.Contains (x)), $"Apk contains an unnesscary lib file: {file.FullName}");
+					foreach (var file in libFiles) {
+						Assert.IsTrue (abiPaths.Any (x => file.FullName.Contains (x)), $"Apk contains an unnesscary lib file: {file.FullName}");
+						Assert.IsTrue (file.CompressionMethod == method, $"{file.FullName} should have been CompressionMethod.{method} in the apk, but was CompressionMethod.{file.CompressionMethod}");
+					}
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2705,6 +2705,7 @@ because xbuild doesn't support framework reference assemblies.
     AndroidEmbedProfilers="$(AndroidEmbedProfilers)"
     HttpClientHandlerType="$(AndroidHttpClientHandlerType)"
     TlsProvider="$(AndroidTlsProvider)"
+    UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)"
     EnableSGenConcurrent="$(AndroidEnableSGenConcurrent)">
     <Output TaskParameter="BuildId" PropertyName="_XamarinBuildId" />
     <Output TaskParameter="OutputFiles" ItemName="ApkFiles" />


### PR DESCRIPTION
Fixes #1822

Currently we only apply the `$(AndroidStoreUncompressedFileExtensions)` to
the resources added to the apk via `aapt2`. All the other resources added
by `BuildApk` are added as `Deflate`. As a result this means an  
Xamarin.Android apk cannot run on `Android.Things` since it requires the 
native libraries to be uncompressed.

We should we using the `$(AndroidStoreUncompressedFileExtensions)` property
as part of the `BuildApk` process to ensure that files which need to 
be left uncompressed are. 