### PR TITLE
[build] fix for monodroid.targets on Windows

### DIFF
--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -160,6 +160,7 @@
       <_DllMaps>@(_JavaInteropDllMapContent->'%(Identity)', '%0a  ')</_DllMaps>
     </PropertyGroup>
     <ReplaceFileContents
+        Condition="Exists('$(JavaInteropSourceDirectory)\src\Java.Runtime.Environment\Java.Runtime.Environment.dll.config')"
         SourceFile="$(JavaInteropSourceDirectory)\src\Java.Runtime.Environment\Java.Runtime.Environment.dll.config"
         DestinationFile="$(XAInstallPrefix)xbuild\Xamarin\Android\Java.Runtime.Environment.dll.config"
         Replacements="&lt;configuration&gt;=&lt;configuration&gt;%0a  $(_DllMaps)"


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build?buildId=1778402

Since d18c45a, the build has been failing on Windows with:

    src\monodroid\monodroid.targets (162, 5)
    src\monodroid\monodroid.targets(162,5): Error MSB4018: The "ReplaceFileContents" task failed unexpectedly.
    System.IO.FileNotFoundException: Could not find file 'E:\A\_work\2\s\external\Java.Interop\src\Java.Runtime.Environment\Java.Runtime.Environment.dll.config'.
    File name: 'E:\A\_work\2\s\external\Java.Interop\src\Java.Runtime.Environment\Java.Runtime.Environment.dll.config'
    at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
    at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
    at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
    at System.IO.StreamReader..ctor(String path, Encoding encoding, Boolean detectEncodingFromByteOrderMarks, Int32 bufferSize, Boolean checkHost)
    at System.IO.StreamReader..ctor(String path)
    at System.IO.File.OpenText(String path)
    at Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents.Execute() in E:\A\_work\2\s\build-tools\xa-prep-tasks\Xamarin.Android.BuildTools.PrepTasks\ReplaceFileContents.cs:line 35
    at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
    at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext()

Currently nothing on Windows creates this file, since it is generated
by a Makefile:

https://github.com/xamarin/java.interop/blob/5efe5c29a0f0e1b7e80bc0b51d847c339d438f9a/Makefile#L89

For now, we can just skip the `ReplaceFileContents` task if the file
doesn't exist.