### PR TITLE
[Xamarin.Android.Build.Tasks] fix for android:name="$" in manifest

### DIFF
--- a/Documentation/guides/messages/xa4302.md
+++ b/Documentation/guides/messages/xa4302.md
@@ -1,0 +1,10 @@
+# Compiler Warning XA4302
+
+The `GenerateJavaStubs` task encountered an unhandled exception
+merging the final `AndroidManifest.xml` file. This could be caused by
+malformed XML in your application project or a referenced assembly.
+
+Consider submitting a [bug][bug] if you are getting this warning under
+normal circumstances.
+
+[bug]: https://github.com/xamarin/xamarin-android/wiki/Submitting-Bugs,-Feature-Requests,-and-Pull-Requests

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -500,7 +500,7 @@ namespace Bug12935
 					zip.AddEntry ("AndroidManifest.xml", @"<?xml version='1.0'?>
 <manifest xmlns:android='http://schemas.android.com/apk/res/android' package='com.xamarin.test'>
     <uses-sdk android:minSdkVersion='14'/>
-
+    <permission android:name='${applicationId}.permission.C2D_MESSAGE' android:protectionLevel='signature' />
     <application>
         <activity android:name='.signin.internal.SignInHubActivity' />
         <provider
@@ -588,6 +588,8 @@ public class TestActivity2 : FragmentActivity {
 				using (var builder = CreateApkBuilder (Path.Combine (path, "App1"))) {
 					Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
 					var manifest = builder.Output.GetIntermediaryAsText (Root, "android/AndroidManifest.xml");
+					Assert.IsTrue (manifest.Contains ("com.xamarin.manifest.permission.C2D_MESSAGE"),
+						"${applicationId}.permission.C2D_MESSAGE was not replaced with com.xamarin.manifest.permission.C2D_MESSAGE");
 					Assert.IsTrue (manifest.Contains ("com.xamarin.test.signin.internal.SignInHubActivity"),
 						".signin.internal.SignInHubActivity was not replaced with com.xamarin.test.signin.internal.SignInHubActivity");
 					Assert.IsTrue (manifest.Contains ("com.xamarin.manifest.FacebookInitProvider"),

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -400,7 +400,7 @@ namespace Xamarin.Android.Tasks {
 					try {
 						MergeLibraryManifest (mergedManifest);
 					} catch (Exception ex) {
-						log.LogWarningFromException (ex);
+						log.LogCodedWarning ("XA4302", "Unhandled exception merging `AndroidManifest.xml`: {0}", ex);
 					}
 				}
 			}
@@ -441,7 +441,7 @@ namespace Xamarin.Android.Tasks {
 			foreach (var top in xdoc.XPathSelectElements ("/manifest/*")) {
 				var name = top.Attribute (AndroidXmlNamespace.GetName ("name"));
 				var existing = (name != null) ?
-					doc.XPathSelectElement (string.Format ("/manifest/{0}[@android:name='{1}']", top.Name.LocalName, XmlConvert.VerifyNCName (name.Value)), nsResolver) :
+					doc.XPathSelectElement (string.Format ("/manifest/{0}[@android:name='{1}']", top.Name.LocalName, name.Value), nsResolver) :
 					doc.XPathSelectElement (string.Format ("/manifest/{0}", top.Name.LocalName));
 				if (existing != null)
 					// if there is existing node with the same android:name, then append contents to existing node.


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/1698

In the project reproducing this issue, the Xamarin.Firebase.lid NuGet
produces an `AndroidManifest.xml` with the following line:

    <permission android:name="${applicationId}.permission.C2D_MESSAGE" android:protectionLevel="signature" />

Unfortunately our manifest merging code is throwing an exception and
producing a warning such as:

    Xamarin.Android.Common.targets(1910,3): warning : Name cannot begin with the '$' character, hexadecimal value 0x24.

We also aren't getting the contents of this `AndroidManifest.xml`
merged, so this is definitely an issue!

The exception is coming from the following code:

    var existing = (name != null) ?
        doc.XPathSelectElement (string.Format ("/manifest/{0}[@android:name='{1}']", top.Name.LocalName, XmlConvert.VerifyNCName (name.Value)), nsResolver) :
        doc.XPathSelectElement (string.Format ("/manifest/{0}", top.Name.LocalName));

Apparently `XmlConvert.VerifyNCName` throws an exception if the input
value contains a `$`.

It appears it has been this way for quite some time, prior to becoming
open source:

https://github.com/xamarin/xamarin-android/blame/bb8183c8c16667b18ba9197e78294b17a0af532c/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs#L444

I suspect the original goal was to validate the XPath expression
wouldn't throw an exception, but it seems to work fine to use the
value as-is. Let's just not call `XmlConvert.VerifyNCName` at all.

After the fix, I get additional lines in my
`obj/Debug/android/AndroidManifest.xml`:

    <permission android:name="com.companyname.DollarSignProb.permission.C2D_MESSAGE" android:protectionLevel="signature" />
    <uses-permission android:name="com.companyname.DollarSignProb.permission.C2D_MESSAGE" />

So it is now properly merging the `AndroidManifest.xml`.

Other changes:
- Updated `ManifestTest.MergeLibraryManifest` test so it also verifies
  this fix
- Added `XA4302` as part of the effort towards:
  https://github.com/xamarin/xamarin-android/issues/1560