### PR TITLE
[tests] kill adb when Xamarin.Android.Build.Tests complete

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -1,30 +1,59 @@
-﻿using System;
-using System.IO;
+﻿using NUnit.Framework;
+using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Security.Cryptography;
-using Xamarin.ProjectTools;
-using NUnit.Framework;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
-using System.Threading;
+using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
+using Xamarin.ProjectTools;
 
 namespace Xamarin.Android.Build.Tests
 {
 	public class BaseTest
 	{
-		static BaseTest ()
+		[SetUpFixture]
+		public class SetUp
 		{
-			try {
-				var adbTarget = Environment.GetEnvironmentVariable ("ADB_TARGET");
-				int sdkVersion = -1;
-				HasDevices = int.TryParse (RunAdbCommand ($"{adbTarget} shell getprop ro.build.version.sdk").Trim(), out sdkVersion) && sdkVersion != -1;
-			} catch (Exception ex) {
-				Console.Error.WriteLine ("Failed to determine whether there is Android target emulator or not" + ex);
+			public static bool HasDevices {
+				get;
+				private set;
+			}
+
+			[OneTimeSetUp]
+			public void BeforeAllTests ()
+			{
+				try {
+					var adbTarget = Environment.GetEnvironmentVariable ("ADB_TARGET");
+					int sdkVersion = -1;
+					HasDevices = int.TryParse (RunAdbCommand ($"{adbTarget} shell getprop ro.build.version.sdk").Trim (), out sdkVersion) && sdkVersion != -1;
+				} catch (Exception ex) {
+					Console.Error.WriteLine ("Failed to determine whether there is Android target emulator or not: " + ex);
+				}
+			}
+
+			[OneTimeTearDown]
+			public void AfterAllTests ()
+			{
+				//NOTE: adb.exe can cause a couple issues on Windows
+				//	1) it holds a lock on ~/android-toolchain, so a future build that needs to delete/recreate would fail
+				//	2) the MSBuild <Exec /> task *can* hang until adb.exe exits
+
+				try {
+					RunAdbCommand ("kill-server", true);
+				} catch (Exception ex) {
+					Console.Error.WriteLine ("Failed to run adb kill-server: " + ex);
+				}
+
+				//NOTE: in case `adb kill-server` fails, kill the process as a last resort
+				foreach (var p in Process.GetProcessesByName ("adb.exe"))
+					p.Kill ();
 			}
 		}
 
-		public static readonly bool HasDevices;
+		protected bool HasDevices => SetUp.HasDevices;
 
 		protected bool IsWindows {
 			get { return Environment.OSVersion.Platform == PlatformID.Win32NT; }


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build?buildId=1768391
Context: https://devdiv.visualstudio.com/DevDiv/_build?buildId=1778620

There are a couple issues happening on VSTS:
1. If the build needs to delete/recreate `~\android-toolchain\sdk`,
   sometimes `adb.exe` is running and so the directory cannot be
   deleted.
2. Sometimes the `<Exec />` MSBuild task will hang indefinitely, even
   though the NUnit tests have completed.

Our test run `adb.exe` here, to determine if a device/emulator is
connected:

https://github.com/xamarin/xamarin-android/blob/master/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs#L19-L21

It turns out the two issues are directly related. If you launch
`adb.exe`, and it is the first instance of `adb`, it will continue to
run as a daemon-like process. The `<Exec />` task will block until all
child processes of `nunit3-console.exe` exit, and so we get a hang
running our tests...

To fix this, I setup a `[SetUpFixture]`, which is a feature of NUnit
that lets you run code before and after all the tests complete. I
moved the `static ctor` of `BaseTest` into a `[OneTimeSetUp]` method,
and then created a `[OneTimeTearDown]` method to kill `adb`.

Other changes:
- I let VS sort the using statements, since they were oddly ordered.