### PR TITLE
[Xamarin.Android.Build.Tasks] Add `FrameworkDirectories` to `GenerateJavaStubs`.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -33,6 +33,9 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string AcwMapFile { get; set; }
 
+		[Required]
+		public ITaskItem [] FrameworkDirectories { get; set; }
+
 		public string ManifestTemplate { get; set; }
 		public string[] MergedManifestDocuments { get; set; }
 
@@ -78,6 +81,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  UseSharedRuntime: {0}", UseSharedRuntime);
 			Log.LogDebugTaskItems ("  ResolvedAssemblies:", ResolvedAssemblies);
 			Log.LogDebugTaskItems ("  ResolvedUserAssemblies:", ResolvedUserAssemblies);
+			Log.LogDebugTaskItems ("  FrameworkDirectories: ", FrameworkDirectories);
 			Log.LogDebugMessage ("  BundledWearApplicationName: {0}", BundledWearApplicationName);
 			Log.LogDebugTaskItems ("  MergedManifestDocuments:", MergedManifestDocuments);
 			Log.LogDebugMessage ("  PackageNamingPolicy: {0}", PackageNamingPolicy);
@@ -115,6 +119,11 @@ namespace Xamarin.Android.Tasks
 			JavaNativeTypeManager.PackageNamingPolicy = Enum.TryParse (PackageNamingPolicy, out pnp) ? pnp : PackageNamingPolicyEnum.LowercaseHash;
 			var temp = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
 			Directory.CreateDirectory (temp);
+
+			foreach (var dir in FrameworkDirectories) {
+				if (Directory.Exists (dir.ItemSpec))
+					res.SearchDirectories.Add (dir.ItemSpec);
+			}
 
 			var selectedWhitelistAssemblies = new List<string> ();
 			

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2170,6 +2170,7 @@ because xbuild doesn't support framework reference assemblies.
 	BundledWearApplicationName="$(BundledWearApplicationPackageName)"
 	PackageNamingPolicy="$(AndroidPackageNamingPolicy)"
 	ApplicationJavaClass="$(AndroidApplicationJavaClass)"
+	FrameworkDirectories="$(_XATargetFrameworkDirectories);$(_XATargetFrameworkDirectories)Facades"
 	AcwMapFile="$(_AcwMapFile)">
   </GenerateJavaStubs>
   <ConvertResourcesCases 


### PR DESCRIPTION
Context https://devdiv.visualstudio.com/DevDiv/_workitems/edit/631540

The Cecil `DirectoryAssemblyResolver` is failing to resolve
`System.Runtime.dll` when loading assebmlies from the Intermediate
directory.

	MSB4018: System.IO.FileNotFoundException: Could not load assembly 'System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. Perhaps it doesn't exist in the Mono for Android profile?

This seems to be becaue we have netstandard2.0 references in the
list of assemblies which reference `System.Runtime.dll`. However
in `GenerateJavaStubs` we are not including the `v1.0` or the
`Facades` directory in the search path. As a result the dependency
cannot be loaded. By default `DirectoryAssemblyResolver` only
uses the directories from the assemblies being loaded to search
for dependencies. Because `System.Runtime.dll` is a `Framework`
assembly, it will NEVER be copied into the intermediate directory.

So lets tell `DirectoryAssemblyResolver` about where the other
directories are.