### PR TITLE
[Xamarin.Android.Build.Tasks] Ignore Aapt2 Warnings from StdErr

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -107,6 +107,8 @@ namespace Xamarin.Android.Tasks {
 				var level = match.Groups ["level"].Value.ToLowerInvariant ();
 				var message = match.Groups ["message"].Value;
 
+				// Handle the following which is NOT an error :(
+				// W/ResourceType(23681): For resource 0x0101053d, entry index(1341) is beyond type entryCount(733)
 				if (file.StartsWith ("W/")) {
 					LogCodedWarning ("APT0000", singleLine);
 					return;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -106,6 +106,11 @@ namespace Xamarin.Android.Tasks {
 					line = int.Parse (match.Groups ["line"].Value) + 1;
 				var level = match.Groups ["level"].Value.ToLowerInvariant ();
 				var message = match.Groups ["message"].Value;
+
+				if (file.StartsWith ("W/")) {
+					LogCodedWarning ("APT0000", singleLine);
+					return;
+				}
 				if (message.Contains ("fakeLogOpen")) {
 					LogMessage (singleLine, messageImportance);
 					return;


### PR DESCRIPTION
Fixes #1770

Turns out that `aapt2` does write warnings to `stderr` after
all. One example is [1]. This uses the `ALOGW` macro to write
a warning to `stderr`. These warnings are prefixed by a
`W/<type>`. So we can ue that to detect the warning in our
output logging code.

[1] https://github.com/aosp-mirror/platform_frameworks_base/blob/07735797a235ed98d182d0a40c8bdce4d92f9f0a/libs/androidfw/ResourceTypes.cpp#L6127