### PR TITLE
[Xamarin.Android.Build.Tasks] fixes for invalid __AndroidLibraryProjects__.zip

### DIFF
--- a/Documentation/guides/messages/xa4303.md
+++ b/Documentation/guides/messages/xa4303.md
@@ -4,13 +4,14 @@ The `ResolveLibraryProjectImports` task encountered a failure
 extracting `__AndroidLibraryProjects__.zip` from a referenced
 assembly. This zip file contains any Android-related files embedded in
 the assembly during the Xamarin.Android build process. This includes
-`AndroidAsset`, `AndroidResource`, etc.
+`@(AndroidAsset)`, `@(AndroidResource)`, etc.
 
 `XA4303` could be caused by any of the following:
-- A `PathTooLongException` occurred while extracting the zip file.
-  Learn more about `MAX_PATH` on Windows [here][max_path].
-- An invalid path was encountered inside the zip file, such as `:` on
-  Windows.
+
+  - A `PathTooLongException` occurred while extracting the zip file.
+    Learn more about `MAX_PATH` on Windows [here][max_path].
+  - An invalid path was encountered inside the zip file, such as `:` on
+    Windows.
 
 Consider submitting a [bug][bug] if you are getting this warning under
 normal circumstances.

--- a/Documentation/guides/messages/xa4303.md
+++ b/Documentation/guides/messages/xa4303.md
@@ -1,0 +1,19 @@
+# Compiler Error XA4303
+
+The `ResolveLibraryProjectImports` task encountered a failure
+extracting `__AndroidLibraryProjects__.zip` from a referenced
+assembly. This zip file contains any Android-related files embedded in
+the assembly during the Xamarin.Android build process. This includes
+`AndroidAsset`, `AndroidResource`, etc.
+
+`XA4303` could be caused by any of the following:
+- A `PathTooLongException` occurred while extracting the zip file.
+  Learn more about `MAX_PATH` on Windows [here][max_path].
+- An invalid path was encountered inside the zip file, such as `:` on
+  Windows.
+
+Consider submitting a [bug][bug] if you are getting this warning under
+normal circumstances.
+
+[max_path]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx#maxpath
+[bug]: https://github.com/xamarin/xamarin-android/wiki/Submitting-Bugs,-Feature-Requests,-and-Pull-Requests

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateManagedLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateManagedLibraryResourceArchive.cs
@@ -120,14 +120,14 @@ namespace Xamarin.Android.Tasks
 				Log.LogMessage ("writing __res_name_case_map.txt...");
 				foreach (var res in AndroidResourcesInThisExactProject)
 					nameCaseMap.WriteLine ("{0};{1}", res.GetMetadata ("LogicalName").Replace ('\\', '/'), Path.Combine (Path.GetFileName (Path.GetDirectoryName (res.ItemSpec)), Path.GetFileName (res.ItemSpec)).Replace ('\\', '/'));
-				File.WriteAllText (Path.Combine (OutputDirectory, "__res_name_case_map.txt"), nameCaseMap.ToString ());
+				File.WriteAllText (Path.Combine (outDirInfo.FullName, "__res_name_case_map.txt"), nameCaseMap.ToString ());
 			}
 
 			var outpath = Path.Combine (outDirInfo.Parent.FullName, "__AndroidLibraryProjects__.zip");
 			var fileMode = File.Exists (outpath) ? FileMode.Open : FileMode.CreateNew;
 			if (Files.ArchiveZipUpdate (outpath, f => {
 				using (var zip = new ZipArchiveEx (f, fileMode)) {
-					zip.AddDirectory (OutputDirectory, "library_project_imports");
+					zip.AddDirectory (outDirInfo.FullName, "library_project_imports");
 					if (RemovedAndroidResourceFiles != null) {
 						foreach (var r in RemovedAndroidResourceFiles) {
 							Log.LogDebugMessage ($"Removed {r.ItemSpec} from {outpath}");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -283,7 +283,11 @@ namespace Xamarin.Android.Tasks
 									return !jars.Contains (fileToDelete);
 								}, forceUpdate: false);
 							} catch (PathTooLongException ex) {
-								Log.LogErrorFromException (new PathTooLongException ($"Error extracting resources from \"{assemblyPath}\"", ex));
+								Log.LogCodedError ("XA4303", $"Error extracting resources from \"{assemblyPath}\": {ex}");
+								return;
+							} catch (NotSupportedException ex) {
+								Log.LogCodedError ("XA4303", $"Error extracting resources from \"{assemblyPath}\": {ex}");
+								return;
 							}
 						}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2213,6 +2213,56 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 			}
 		}
 
+		[Test]
+		public void ResolveLibraryImportsWithInvalidZip ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				PackageReferences = {
+					KnownPackages.PCLCrypto_Alpha,
+				},
+			};
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
+				b.RequiresMSBuild = true;
+				b.Target = "Restore";
+				Assert.IsTrue (b.Build (proj), "Restore should have succeeded.");
+				b.Target = "Build";
+				b.ThrowOnBuildFailure = false;
+				if (b.Build (proj)) {
+					//NOTE: `:` in a file path should fail on Windows, but passes on macOS
+					if (IsWindows)
+						Assert.Fail ("Build should have failed.");
+				} else {
+					Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "error XA4303: Error extracting resources from"), "Should receive XA4303 error.");
+				}
+			}
+		}
+
+		[Test]
+		public void AndroidLibraryProjectsZipWithOddPaths ()
+		{
+			var proj = new XamarinAndroidLibraryProject ();
+			proj.Imports.Add (new Import ("foo.props") {
+				TextContent = () => $@"
+					<Project>
+					  <PropertyGroup>
+						<IntermediateOutputPath>$(MSBuildThisFileDirectory)../{TestContext.CurrentContext.Test.Name}/obj/$(Configuration)/foo/</IntermediateOutputPath>
+					  </PropertyGroup>
+					</Project>"
+			});
+			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values\\foo.xml") {
+				TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?><resources><string name=""foo"">bar</string></resources>",
+			});
+			using (var b = CreateDllBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+
+				var zipFile = Path.Combine (Root, b.ProjectDirectory, b.Output.IntermediateOutputPath, "foo", "__AndroidLibraryProjects__.zip");
+				FileAssert.Exists (zipFile);
+				using (var zip = ZipHelper.OpenZip (zipFile)) {
+					Assert.IsTrue (zip.ContainsEntry ("library_project_imports/res/values/foo.xml"), $"{zipFile} should contain a library_project_imports/res/values/foo.xml entry");
+				}
+			}
+		}
+
 #pragma warning disable 414
 		static object [] validateJavaVersionTestCases = new object [] {
 			new object [] {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -82,6 +82,7 @@
     <Compile Include="ManagedResourceParserTests.cs" />
     <Compile Include="Tasks\KeyToolTests.cs" />
     <Compile Include="Aapt2Tests.cs" />
+    <Compile Include="ZipArchiveExTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Expected\GenerateDesignerFileExpected.cs">

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ZipArchiveExTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ZipArchiveExTests.cs
@@ -1,0 +1,106 @@
+﻿using NUnit.Framework;
+using System.IO;
+using System.Text;
+using Xamarin.Android.Tasks;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	public class ZipArchiveExTests
+	{
+		string temp;
+		string zip;
+
+		[SetUp]
+		public void SetUp ()
+		{
+			string root = Path.GetDirectoryName (GetType ().Assembly.Location);
+			temp = Path.Combine (root, "temp", TestContext.CurrentContext.Test.Name);
+			Directory.CreateDirectory (temp);
+			zip = Path.Combine (root, "test.zip");
+		}
+
+		[TearDown]
+		public void TearDown ()
+		{
+			Directory.Delete (temp, true);
+			File.Delete (zip);
+		}
+
+		void CreateDirectories (params string [] paths)
+		{
+			foreach (var path in paths) {
+				var dest = Path.Combine (temp, path);
+				Directory.CreateDirectory (Path.GetDirectoryName (dest));
+				//Just put the path in the test file, for testing purposes
+				File.WriteAllText (dest, path);
+			}
+		}
+
+		void AssertZip (string expected)
+		{
+			FileAssert.Exists (zip, "Zip file should exist!");
+
+			var builder = new StringBuilder ();
+			using (var archive = new ZipArchiveEx (zip, FileMode.Open)) {
+				foreach (var entry in archive.Archive) {
+					builder.AppendLine (entry.FullName);
+				}
+			}
+
+			Assert.AreEqual (expected.Trim (), builder.ToString ().Trim ());
+		}
+
+		[Test]
+		public void AddDirectory ()
+		{
+			CreateDirectories ("A.txt", Path.Combine ("B", "B.txt"));
+
+			using (var archive = new ZipArchiveEx (zip, FileMode.Create)) {
+				archive.AddDirectory (temp, "temp");
+			}
+
+			AssertZip (
+@"temp/A.txt
+temp/B/
+temp/B/B.txt");
+		}
+
+		[Test]
+		public void AddDirectoryOddPaths ()
+		{
+			CreateDirectories ("A.txt", Path.Combine ("B", "B.txt"));
+
+			using (var archive = new ZipArchiveEx (zip, FileMode.Create)) {
+				archive.AddDirectory (temp + $@"\../{nameof (AddDirectoryOddPaths)}/", "temp");
+			}
+
+			AssertZip (
+@"temp/A.txt
+temp/B/
+temp/B/B.txt");
+		}
+
+		[Test]
+		public void AddDirectoryCurrentDirectory ()
+		{
+			CreateDirectories ("A.txt", Path.Combine ("B", "B.txt"));
+
+			string cwd = Directory.GetCurrentDirectory ();
+			try {
+				Directory.SetCurrentDirectory (temp);
+
+				using (var archive = new ZipArchiveEx (zip, FileMode.Create)) {
+					archive.AddDirectory (".", "temp");
+				}
+
+				AssertZip (
+@"temp/A.txt
+temp/B/
+temp/B/B.txt");
+			} finally {
+				Directory.SetCurrentDirectory (cwd);
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -395,6 +395,16 @@ namespace Xamarin.ProjectTools
 				}
 			}
 		};
+		public static Package PCLCrypto_Alpha = new Package {
+			Id = "PCLCrypto",
+			Version = "2.1.17-alpha-g5b1e8dff8c",
+			TargetFramework = "monoandroid23",
+			References = {
+				new BuildItem.Reference("PCLCrypto") {
+					MetadataValues = "HintPath=..\\packages\\PCLCrypto.2.1.17-alpha-g5b1e8dff8c\\lib\\monoandroid23\\PCLCrypto.dll"
+				}
+			}
+		};
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
@@ -86,12 +86,20 @@ namespace Xamarin.Android.Tasks
 
 		public void AddDirectory (string folder, string folderInArchive)
 		{
+			if (!string.IsNullOrEmpty (folder)) {
+				folder = folder.Replace ('/', Path.DirectorySeparatorChar).Replace ('\\', Path.DirectorySeparatorChar);
+				folder = Path.GetFullPath (folder);
+				if (folder [folder.Length - 1] == Path.DirectorySeparatorChar) {
+					folder = folder.Substring (0, folder.Length - 1);
+				}
+			}
+
 			AddFiles (folder, folderInArchive);
 			foreach (string dir in Directory.GetDirectories (folder, "*", SearchOption.AllDirectories)) {
 				var di = new DirectoryInfo (dir);
 				if ((di.Attributes & FileAttributes.Hidden) != 0)
 					continue;
-				var internalDir = dir.Replace ("./", string.Empty).Replace (folder, string.Empty);
+				var internalDir = dir.Replace (folder, string.Empty);
 				string fullDirPath = folderInArchive + internalDir;
 				try {
 					zip.CreateDirectory (fullDirPath);


### PR DESCRIPTION
Context: https://developercommunity.visualstudio.com/content/problem/218603/msbuild-failure-in-resolvelibraryprojectimports-ta.html
Context: https://github.com/AArnott/PCLCrypto/issues/138
Fixes: http://work.devdiv.io/631267

Developers were reporting an error when consuming the PCLCrypto
`2.1.17-alpha-g5b1e8dff8c` NuGet package:

    error MSB4018: The "ResolveLibraryProjectImports" task failed unexpectedly.
    error MSB4018: System.NotSupportedException: The given path's format is not supported.
    error MSB4018: at System.Security.Permissions.FileIOPermission.EmulateFileIOPermissionChecks(String fullPath)
    error MSB4018: at System.IO.Directory.InternalCreateDirectoryHelper(String path, Boolean checkHost)
    error MSB4018: at System.IO.Directory.CreateDirectory(String path)
    error MSB4018: at Xamarin.Android.Tools.Files.ExtractAll(ZipArchive zip, String destination, Action`2 progressCallback, Func`2 modifyCallback, Func`2 deleteCallback, Boolean forceUpdate)
    error MSB4018: at Xamarin.Android.Tasks.ResolveLibraryProjectImports.Extract(DirectoryAssemblyResolver res, ICollection`1 jars, ICollection`1 resolvedResourceDirectories, ICollection`1 resolvedAssetDirectories, ICollection`1 resolvedEnvironments)
    error MSB4018: at Xamarin.Android.Tasks.ResolveLibraryProjectImports.Execute()
    error MSB4018: at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()

Upon trying this myself, I extracted the contents of
`__AndroidLibraryProjects__.zip` and encountered some *very* odd files
paths inside the zip:

    Archive:  __AndroidLibraryProjects__.zip
    Zip file size: 1939 bytes, number of entries: 7
    defN 18-Mar-10 10:12 library_project_imports/__res_name_case_map.txt
    stor 18-Mar-10 10:12 library_project_importsC:/projects/pclcrypto/src/.obj/pclcrypto/Release/monoandroid23/jl/assets/
    stor 18-Mar-10 10:12 library_project_importsC:/projects/pclcrypto/src/.obj/pclcrypto/Release/monoandroid23/jl/bin/
    stor 18-Mar-10 10:12 library_project_importsC:/projects/pclcrypto/src/.obj/pclcrypto/Release/monoandroid23/jl/java/
    stor 18-Mar-10 10:12 library_project_importsC:/projects/pclcrypto/src/.obj/pclcrypto/Release/monoandroid23/jl/res/
    stor 18-Mar-10 10:12 library_project_importsC:/projects/pclcrypto/src/.obj/pclcrypto/Release/monoandroid23/jl/res/values/
    defN 18-Mar-10 10:12 library_project_importsC:/projects/pclcrypto/src/.obj/pclcrypto/Release/monoandroid23/jl/res/values/strings.xml
    7 files, 167 bytes uncompressed, 117 bytes compressed:  29.9%

Since these file paths contain a `:`, we are getting
`System.NotSupportedException` when calling
`Directory.CreateDirectory`. They are also completely incorrect paths!

Next, I looked at PCLCrypto's project on Github and was able to
publicly find the binary MSBuild log from this release:
https://ci.appveyor.com/project/AArnott/pclcrypto/build/2.1.17-alpha

    CreateManagedLibraryResourceArchive Task
      OutputDirectory: C:\projects\pclcrypto\src\../obj/pclcrypto/Release\monoandroid23\jl
      ResourceDirectory: C:\projects\pclcrypto\src\../obj/pclcrypto/Release\monoandroid23\res\
      AndroidAssets:
      AndroidJavaSources:
      AndroidJavaLibraries:
      AndroidResourcesInThisExactProject:
        C:\projects\pclcrypto\obj\pclcrypto\Release\monoandroid23\res\values\strings.xml
      RemovedAndroidResourceFiles:
    writing __res_name_case_map.txt...
    Saving contents to C:\projects\pclcrypto\obj\pclcrypto\Release\monoandroid23\__AndroidLibraryProjects__.zip

Somehow passing in these odd paths to the
`CreateManagedLibraryResourceArchive` MSBuild task is creating a
malformed `__AndroidLibraryProjects__.zip`!

So I cloned the source, and I could reproduce the behavior with VS
2017 15.7.3. Looking at the project's `csproj` and other MSBuild
files, I found that `BaseIntermediateOutputPath` was declared in an
odd way:

    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)../obj/$(MSBuildProjectName)/</BaseIntermediateOutputPath>

So this explains how we are getting
`C:\projects\pclcrypto\src\../obj/pclcrypto/Release\monoandroid23\jl`
as input during the build. I submitted a PR to PCLCrypto with a
workaround: use Windows path separators.

As for the fix in Xamarin.Android, we really have two issues to fix:
- Paths such as
  `C:\projects\pclcrypto\src\../obj/pclcrypto/Release\monoandroid23\jl`
  should not produce an invalid `__AndroidLibraryProjects__.zip`
- We provide a better error message if an invalid zip is encountered
  during `ResolveLibraryProjectImports`

### CreateManagedLibraryResourceArchive

The first fix was simple: there were a few places where
`OutputDirectory` was used as-is, but most of this task is using a
`DirectoryInfo.FullName` value. We can switch to using `FullName`,
since it is the full path and will have its path separators
normalized.

I added the `AndroidLibraryProjectsZipWithOddPaths` test to validate
this fix.

### ZipArchiveEx

In addition to the fixes in the `CreateManagedLibraryResourceArchive`
MSBuild task, it appears that `ZipArchiveEx` has some weird logic
working with paths:

    var internalDir = dir.Replace ("./", string.Empty).Replace (folder, string.Empty);
    string fullDirPath = folderInArchive + internalDir;

Not only is `./` likely ignoring Windows directory separators, but
there is some weird behavior caused by a test case.

If I pass in `folder` as:

    "C:\Users\myuser\Desktop\Git\xamarin-android\bin\TestDebug\temp\../temp/"

Then `internalDir` evaluates to:

    "C:\Users\myuser\Desktop\Git\xamarin-android\bin\TestDebug\temp\.temp/B"

Then `fullDirPath` is:

    "tempC:\Users\myuser\Desktop\Git\xamarin-android\bin\TestDebug\temp\.temp/B"

So the paths here aren't right at all!

I added a new set of `ZipArchiveExTests` to reproduce the issue.

Next, I added some logic to normalize directory separators and call
`Path.GetFullPath` on the incoming folder.

I also added a check to see if the path ends with
`Path.DirectorySeparatorChar`, as that would break this line, which
assumes `internalDir` is prefixed with the directory separator:

    string fullDirPath = folderInArchive + internalDir;

### ResolveLibraryProjectImports

As for `ResolveLibraryProjectImports`, it was calling into
`Files.ExtractAll` where `Directory.CreateDirectory` calls could
possibly encounter invalid paths that would throw
`System.NotSupportedException`. We can handle this exception and make
sure the zip entry is reported in the exception. All we can do is
`throw`, but at least including the errant zip entry text is an
improvement.

Since `ResolveLibraryProjectImports` was already handling
`PathTooLongException`, I changed it to also handle
`NotSupportedException` in the same way. I created a new `XA4303`
error code along with documentation, to properly report the failure
extracting `__AndroidLibraryProjects__.zip`.

I added the `ResolveLibraryProjectImportsWithInvalidZip` test to
validate these changes.

Other changes:
- In `Files.ExtractAll`, it looked like `progressCallback` wasn't
  being invoked at the right time. I moved it at the top of the
  `foreach` loop, so callers will get progress updates for files that
  are skipped.