### PR TITLE
[build] `make package-build-status` captures binlog files

### DIFF
--- a/build-tools/scripts/Packaging.mk
+++ b/build-tools/scripts/Packaging.mk
@@ -70,6 +70,7 @@ endif # We have test error output
 
 _BUILD_STATUS_BUNDLE_INCLUDE = \
 	Configuration.OperatingSystem.props \
+	$(wildcard bin/Build*/msbuild*.binlog) \
 	$(shell find . -name 'config.log') \
 	$(shell find . -name 'config.status') \
 	$(shell find . -name 'config.h') \

--- a/build-tools/scripts/msbuild.mk
+++ b/build-tools/scripts/msbuild.mk
@@ -44,7 +44,7 @@ ifeq ($(USE_MSBUILD),1)
 # $(call MSBUILD_BINLOG,name,msbuild=$(MSBUILD),conf=$(CONFIGURATION))
 define MSBUILD_BINLOG
 	$(if $(2),$(2),$(MSBUILD)) $(MSBUILD_FLAGS) /v:normal \
-		/binaryLogger:"$(dir $(realpath $(firstword $(MAKEFILE_LIST))))/bin/Build$(if $(3),$(3),$(CONFIGURATION))/msbuild-`date +%s`-$(1).binlog"
+		/binaryLogger:"$(dir $(realpath $(firstword $(MAKEFILE_LIST))))/bin/Build$(if $(3),$(3),$(CONFIGURATION))/msbuild-`date +%Y%m%dT%H%M%S`-$(1).binlog"
 endef
 
 else    # $(MSBUILD) != 1


### PR DESCRIPTION
Commit 987a05fa updated the build system to create MSBuild `binlog`
files, so that the "normal" build logs could be smaller.

There's just one problem with this arrangement: when something goes
wrong, we need the `*.binlog` files to determine what went wrong, but
*nothing was preserving the `.binlog` files*!

Oops.

Update the `make package-build-status` target so that it stores
generated `*.binlog` files into the `build-status-*` file.

Additionally, alter the `.binlog` filename format so that instead of
containing the Unix time_t/epoch value, it instead uses ISO 8601
notation of `<year><month><date>T<hour><minute><second>`.  This
results in more human readable values, and will allow for saner
integration in the future for when we migrate unit test execution over
to also produce `.binlog` files, as producing ISO-8601 format is
straightforward from .NET `System.DateTime`; time_t isn't as easy.