### PR TITLE
[Mono.Android] ResourceIdManager.UpdateIdValues called N times

### DIFF
--- a/src/Mono.Android/Android.Runtime/ResourceIdManager.cs
+++ b/src/Mono.Android/Android.Runtime/ResourceIdManager.cs
@@ -10,6 +10,7 @@ namespace Android.Runtime
 		{
 			if (id_initialized)
 				return;
+			id_initialized = true;
 			var executingAssembly = Assembly.GetExecutingAssembly ();
 			var type = executingAssembly != null ? GetResourceTypeFromAssembly (executingAssembly) : null;
 			if (type == null) {
@@ -27,7 +28,6 @@ namespace Android.Runtime
 					action ();
 				}
 			}
-			id_initialized = true;
 		}
 
 		static Type GetResourceTypeFromAssembly (Assembly assembly)


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/1544

I was able to verify that my app's `Resource.UpdateIdValues` was
getting invoked multiple times with VS 15.7.4:
- Create a new Xamarin.Android app
- Create a new Xamarin.Android library, and reference it from the app
- (Optional) call `Android.Runtime.ResourceIdManager.UpdateIdValues`
  directly

By placing a breakpoint, and/or `Log.Debug` messages, I can verify
that my app's `Resource.UpdateIdValues` was being called 5 times!

The issue lies in this code:

    if (id_initialized)
        return;
    //System.Reflection code to call Resource.UpdateIdValues() in the app
    id_initialized = true;

While `Resource.UpdateIdValues` is being invoked,
`ResourceIdManager.UpdateIdValues ()` is called recursively.
`id_initialized` will not be set until after the reflection code has
finished.

The fix is to immediately set the flag:

    if (id_initialized)
        return;
    id_initialized = true;
    //System.Reflection code to call Resource.UpdateIdValues() in the app

I was able to verify the fix in my app:
- Build the app with `xabuild`
- Re-add the `Log.Debug` message in my app's `Resource.UpdateIdValues`
- Deploy the app with `xabuild`
- Upon launch, I *now* only see 1 log message with `adb logcat`

The performance impact is likely:
- The reflection code would be slow in
  `Android.Runtime.ResourceIdManager.UpdateIdValues`
- In the app's `Resource.UpdateIdValues`, mostly fields are being read
  and set. It *helps* to skip this, but it shouldn't be as slow as the
  reflection code.

We should consider this for 15.8 if there is still time.