### PR TITLE
bump Android platform-tools to fix adb server version mismatch with P.

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -15,7 +15,7 @@
       <HostOS>Linux</HostOS>
       <DestDir>build-tools\$(XABuildToolsFolder)</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="platform-tools_r27.0.1-linux">
+    <AndroidSdkItem Include="platform-tools_r28.0.0-linux">
       <HostOS>Linux</HostOS>
       <DestDir>platform-tools</DestDir>
     </AndroidSdkItem>
@@ -34,7 +34,7 @@
       <HostOS>Darwin</HostOS>
       <DestDir>build-tools\$(XABuildToolsFolder)</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="platform-tools_r27.0.1-darwin">
+    <AndroidSdkItem Include="platform-tools_r28.0.0-darwin">
       <HostOS>Darwin</HostOS>
       <DestDir>platform-tools</DestDir>
     </AndroidSdkItem>
@@ -53,7 +53,7 @@
       <HostOS>Windows</HostOS>
       <DestDir>build-tools\$(XABuildToolsFolder)</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="platform-tools_r27.0.1-windows">
+    <AndroidSdkItem Include="platform-tools_r28.0.0-windows">
       <HostOS>Windows</HostOS>
       <DestDir>platform-tools</DestDir>
     </AndroidSdkItem>


### PR DESCRIPTION
If you are running Android O or above as the Android target to test
`run-apk-tests`, it will fail because of adb server version mismatch
(39 vs. 40). It is a typical adb issue e.g.:

https://sqa.stackexchange.com/questions/20524/how-to-resolve-adb-server-version-32-doesnt-match-this-client-36-killin

We need newer adb to fix this issue.