### PR TITLE
[Xamarin.Android.Build.Tasks] Use XNavigation for AndroidResource

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/IntentFilterAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/IntentFilterAttribute.Partial.cs
@@ -90,8 +90,8 @@ namespace Android.App {
 					Actions.Select (a => new XElement ("action", new XAttribute (android + "name", ReplacePackage (a, packageName)))),
 					(Categories ?? new string[0]).Select (c => new XElement ("category", new XAttribute (android + "name", ReplacePackage (c, packageName)))),
 					GetData (packageName));
-			AndroidResource.UpdateXmlResource (r);
-			return r;
+			r.SetAttributeValue (XNamespace.Xmlns + "android", android.NamespaceName);
+			return AndroidResource.UpdateXmlResource (r);
 		}
 
 		static readonly XNamespace android = "http://schemas.android.com/apk/res/android";

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AsyncTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AsyncTask.cs
@@ -4,6 +4,7 @@ using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
 using System.Threading;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace Xamarin.Android.Tasks
 {
@@ -266,6 +267,18 @@ namespace Xamarin.Android.Tasks
 				#pragma warning restore 618
 			}
 			EnqueueMessage (customMessageQueue, e, customDataAvailable);
+		}
+
+		public void FixupResourceFilenameAndLogCodedError (string code, string message, string file, string resourceDir, Dictionary<string, string> resourceNameCaseMap)
+		{
+			var targetfile = MSBuildExtensions.FixupResourceFilename (file, resourceDir, resourceNameCaseMap);
+			LogCodedError (code, file: targetfile, lineNumber: 0, message: message);
+		}
+
+		public void FixupResourceFilenameAndLogCodedWarning (string code, string message, string file, string resourceDir, Dictionary<string, string> resourceNameCaseMap)
+		{
+			var targetfile = MSBuildExtensions.FixupResourceFilename (file, resourceDir, resourceNameCaseMap);
+			LogCodedWarning (code, file: targetfile, lineNumber: 0, message: message);
 		}
 
 		public override bool Execute ()

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyAndConvertResources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyAndConvertResources.cs
@@ -5,6 +5,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Monodroid;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.IO;
 using Xamarin.Android.Tools;
 
@@ -35,7 +36,7 @@ namespace Xamarin.Android.Tasks
 		public ITaskItem[] ModifiedFiles { get; set; }
 
 		private List<ITaskItem> modifiedFiles = new List<ITaskItem>();
-		Dictionary<string, HashSet<string>> customViewMap;
+		ConcurrentDictionary<string, HashSet<string>> customViewMap;
 
 		public override bool Execute ()
 		{
@@ -118,8 +119,8 @@ namespace Xamarin.Android.Tasks
 						return;
 					HashSet<string> set;
 					if (!customViewMap.TryGetValue (e, out set))
-						customViewMap.Add (e, set = new HashSet<string> ());
-					set.Add (file);
+						customViewMap.TryAdd (e, set = new HashSet<string> ());
+					set.Add (filename);
 
 				});
 				if (updated) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidResourceTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidResourceTests.cs
@@ -8,11 +8,56 @@ using Microsoft.Build.Framework;
 using System.Text;
 using Xamarin.Android.Tasks;
 using Microsoft.Build.Utilities;
+using System.Xml;
+using System.Xml.Linq;
 
 namespace Xamarin.Android.Build.Tests {
 	[TestFixture]
 	[Parallelizable (ParallelScope.Self)]
 	public class AndroidResourceTests : BaseTest {
+		[Test]
+		public void CheckNamespaceMangle ()
+		{
+			var manifest = new XElement (XName.Get ("manifest"));
+			manifest.SetAttributeValue (XNamespace.Xmlns + "android", "http://schemas.android.com/apk/res/android");
+			var app = new XElement ("application");
+			manifest.Add (app);
+			var m = new global::Android.App.IntentFilterAttribute (new string [] { "foo" }) {
+				DataSchemes = new string[] { "http", "https" },
+			};
+			var result = m.ToElement ("UnnamedProject.UnnamedProject");
+			app.Add (result);
+			var xml = manifest.ToFullString ();
+		}
+
+		[Test]
+		public void LowercaseResources ()
+		{
+			var path = Path.Combine (Root, "temp", "LowercaseResources");
+			Directory.CreateDirectory (path);
+			var layoutDir = Path.Combine (path, "res", "layout");
+			var drawableDir = Path.Combine (path, "res", "drawable");
+			Directory.CreateDirectory (layoutDir);
+			Directory.CreateDirectory (drawableDir);
+			File.WriteAllText (Path.Combine (drawableDir, "button.png"), string.Empty);
+			var main = Path.Combine (layoutDir, "main.xml");
+			File.WriteAllText (main, @"<?xml version=""1.0"" encoding=""utf-8""?>
+<LinearLayout xmlns:android=""http://schemas.android.com/apk/res/android""
+	android:orientation=""horizontal""
+	android:layout_width=""match_parent""
+	android:layout_height=""match_parent"">
+	<classlibrary1.CustomView xmlns:android=""http://schemas.android.com/apk/res/android""/>
+	<ImageView xmlns:android=""http://schemas.android.com/apk/res/android"" android:src=""@drawable/Button"" />
+</LinearLayout>");
+			var acwMap = new Dictionary<string, string> () {
+				{ "classlibrary1.CustomView", "md5d6f7135293df7527c983d45d07471c5e.CustomTextView" },
+			};
+			Monodroid.AndroidResource.UpdateXmlResource (Path.Combine (path, "res"), main, acwMap, null);
+			var mainText = File.ReadAllText (main);
+			Assert.True (mainText.Contains ("@drawable/button"), "'@drawable/Button' was not converted to '@drawable/button'");
+			Directory.Delete (path, recursive: true);
+		}
+
 		[Test]
 		public void MenuActionLayout ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (b.Build (proj), "first build failed");
 				Assert.IsTrue (b.Build (proj), "second build failed");
 				Assert.IsTrue (b.Output.IsTargetSkipped ("_Sign"), "failed to skip some build");
-				proj.AndroidResources.Last ().Timestamp = null; // means "always build"
+				proj.AndroidResources.Last ().Timestamp = DateTime.UtcNow; // means "always build"
 				Assert.IsTrue (b.Build (proj), "third build failed");
 				Assert.IsFalse (b.Output.IsTargetSkipped ("_Sign"), "incorrectly skipped some build");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -855,6 +855,9 @@ namespace UnnamedProject {
 				Assert.IsTrue (
 					b.Output.IsTargetSkipped ("_Sign"),
 					"the _Sign target should not run");
+				Assert.IsTrue (
+					b.Output.IsTargetSkipped ("_StripEmbeddedLibraries"),
+					"the _StripEmbeddedLibraries target should not run");
 				proj.AndroidResources.Last ().Timestamp = null;
 				Assert.IsTrue (b.Build (proj), "third build failed");
 				Assert.IsFalse (

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
@@ -504,12 +505,12 @@ namespace Xamarin.Android.Tasks
 			return acw_map;
 		}
 
-		public static Dictionary<string, HashSet<string>> LoadCustomViewMapFile (IBuildEngine4 engine, string mapFile)
+		public static ConcurrentDictionary<string, HashSet<string>> LoadCustomViewMapFile (IBuildEngine4 engine, string mapFile)
 		{
-			var cachedMap = (Dictionary<string, HashSet<string>>)engine?.GetRegisteredTaskObject (mapFile, RegisteredTaskObjectLifetime.Build);
+			var cachedMap = (ConcurrentDictionary<string, HashSet<string>>)engine?.GetRegisteredTaskObject (mapFile, RegisteredTaskObjectLifetime.Build);
 			if (cachedMap != null)
 				return cachedMap;
-			var map = new Dictionary<string, HashSet<string>> ();
+			var map = new ConcurrentDictionary<string, HashSet<string>> ();
 			if (!File.Exists (mapFile))
 				return map;
 			foreach (var s in File.ReadLines (mapFile)) {
@@ -518,13 +519,13 @@ namespace Xamarin.Android.Tasks
 				var value = items [1];
 				HashSet<string> set;
 				if (!map.TryGetValue (key, out set))
-					map.Add (key, set = new HashSet<string> ());
+					map.TryAdd (key, set = new HashSet<string> ());
 				set.Add (value);
 			}
 			return map;
 		}
 
-		public static void SaveCustomViewMapFile (IBuildEngine4 engine, string mapFile, Dictionary<string, HashSet<string>> map)
+		public static void SaveCustomViewMapFile (IBuildEngine4 engine, string mapFile, ConcurrentDictionary<string, HashSet<string>> map)
 		{
 			engine?.RegisterTaskObject (mapFile, map, RegisteredTaskObjectLifetime.Build, allowEarlyCollection: false);
 			var temp = Path.GetTempFileName ();


### PR DESCRIPTION
AndroidResource is slooow. Mainly because it is written to
repeatedly loop through the elements in the document.
We should use streaming to process these documents since it
will be faster.

Current Master Xamarin Forms Test App Time Elapsed 



| Master | PR | Diff |
| -------- | ---- | ---- |
| 00:00:23.39 |  00:00:21.52 | -00:00:01.87
- [ ]  Tests, tests and more tests
- [x]  Switch to `AsyncTask`