### PR TITLE
[Xamarin.Android.Build.Tasks] Use `InMemory` for `GenerateResourceDesigner`.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
@@ -10,6 +10,7 @@ using Microsoft.Build.Utilities;
 using Monodroid;
 
 using Java.Interop.Tools.Cecil;
+using Mono.Cecil;
 
 namespace Xamarin.Android.Tasks
 {
@@ -119,7 +120,7 @@ namespace Xamarin.Android.Tasks
 			var assemblyNames = new List<string> ();
 			if (IsApplication && References != null && References.Any ()) {
 				// FIXME: should this be unified to some better code with ResolveLibraryProjectImports?
-				using (var resolver = new DirectoryAssemblyResolver (this.CreateTaskLogger (), loadDebugSymbols: false)) {
+				using (var resolver = new DirectoryAssemblyResolver (this.CreateTaskLogger (), loadDebugSymbols: false, loadReaderParameters: MonoAndroidHelper.DefaultInMemoryNoSymbolsReader)) {
 					foreach (var assemblyName in References) {
 						var suffix = assemblyName.ItemSpec.EndsWith (".dll") ? String.Empty : ".dll";
 						string hintPath = assemblyName.GetMetadata ("HintPath").Replace (Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -31,6 +31,11 @@ namespace Xamarin.Android.Tasks
 
 		readonly static byte[] Utf8Preamble = System.Text.Encoding.UTF8.GetPreamble ();
 
+		internal static ReaderParameters DefaultInMemoryNoSymbolsReader = new ReaderParameters () {
+			InMemory = true,
+			ReadSymbols = false,
+		};
+
 		public static int RunProcess (string name, string args, DataReceivedEventHandler onOutput, DataReceivedEventHandler onError, Dictionary<string, string> environmentVariables = null)
 		{
 			var psi = new ProcessStartInfo (name, args) {
@@ -308,7 +313,7 @@ namespace Xamarin.Android.Tasks
 
 		public static bool IsReferenceAssembly (string assembly)
 		{
-			var a = AssemblyDefinition.ReadAssembly (assembly, new ReaderParameters () { InMemory = true, ReadSymbols = false, });
+			var a = AssemblyDefinition.ReadAssembly (assembly, DefaultInMemoryNoSymbolsReader);
 			return IsReferenceAssembly (a);
 		}
 


### PR DESCRIPTION
Context https://devdiv.visualstudio.com/DevDiv/_workitems/edit/616623

We seem to be getting a lock in VS when restoring Nuget Packages.
The call stack seems to indicate that we are hanging in
`GenerateResourceDesigner`. Specifically in the `ReadByes` call that
Cecil finally ends up in.

```
[Managed to Native Transition]  
>    mscorlib.dll!System.IO.BinaryReader.ReadBytes(int count)    Unknown
    Xamarin.Android.Cecil.dll!Mono.Cecil.PE.ImageReader.ReadHeapData(uint offset, uint size)    Unknown
    Xamarin.Android.Cecil.dll!Mono.Cecil.PE.ImageReader.ReadMetadataStream(Mono.Cecil.PE.Section section)   Unknown
    Xamarin.Android.Cecil.dll!Mono.Cecil.PE.ImageReader.ReadMetadata()  Unknown
    Xamarin.Android.Cecil.dll!Mono.Cecil.PE.ImageReader.ReadImage() Unknown
    Xamarin.Android.Cecil.dll!Mono.Cecil.PE.ImageReader.ReadImage(Mono.Disposable<System.IO.Stream> stream, string file_name) Unknown
    Xamarin.Android.Cecil.dll!Mono.Cecil.ModuleDefinition.ReadModule(string fileName, Mono.Cecil.ReaderParameters parameters)   Unknown
    Java.Interop.Tools.Cecil.dll!Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.ReadAssembly(string file)   Unknown
    Java.Interop.Tools.Cecil.dll!Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.Load(string fileName, bool forceLoad)   Unknown
    Xamarin.Android.Build.Tasks.dll!Xamarin.Android.Tasks.GenerateResourceDesigner.Execute()    Unknown
```

One theory is we are locking the file.. somehow. So just to be sure
we should make sure Cecil is using `InMemory` for the designer.