### PR TITLE
[build] cmake fixes for Windows

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -32,7 +32,7 @@
   <PropertyGroup>
     <AutoProvision Condition=" '$(AutoProvision)' == '' ">False</AutoProvision>
     <AutoProvisionUsesSudo Condition=" '$(AutoProvisionUsesSudo)' == '' ">False</AutoProvisionUsesSudo>
-    <XAInstallPrefix Condition=" '$(XAInstallPrefix)' == '' ">$(MSBuildThisFileDirectory)\bin\$(Configuration)\lib\xamarin.android\</XAInstallPrefix>
+    <XAInstallPrefix Condition=" '$(XAInstallPrefix)' == '' ">$(MSBuildThisFileDirectory)bin\$(Configuration)\lib\xamarin.android\</XAInstallPrefix>
     <LinuxMingwDependenciesRootDirectory Condition=" '$(LinuxMingwDependenciesRootDirectory)' == '' ">$(MSBuildThisFileDirectory)\bin\Build$(Configuration)\linux-mingw-deps</LinuxMingwDependenciesRootDirectory>
     <HostOS Condition=" '$(HostOS)' == '' And '$(OS)' == 'Windows_NT' ">Windows</HostOS>
     <HostCc Condition=" '$(HostCc)' == '' ">$(HostCc64)</HostCc>

--- a/build-tools/android-toolchain/android-toolchain-windows.targets
+++ b/build-tools/android-toolchain/android-toolchain-windows.targets
@@ -79,16 +79,19 @@
 
     <UnzipDirectoryChildren
         HostOS="$(HostOS)"
+        NoSubdirectory="%(_PlatformAndroidSdkItem.NoSubdirectory)"
         SourceFiles="@(_PlatformAndroidSdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity).zip')"
         DestinationFolder="$(AndroidToolchainDirectory)\sdk"
     />
     <UnzipDirectoryChildren
         HostOS="$(HostOS)"
+        NoSubdirectory="%(_PlatformAndroidSdkItem.NoSubdirectory)"
         SourceFiles="@(_PlatformAndroidNdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity).zip')"
         DestinationFolder="$(AndroidToolchainDirectory)\ndk"
     />
     <UnzipDirectoryChildren
         HostOS="$(HostOS)"
+        NoSubdirectory="%(_PlatformAndroidSdkItem.NoSubdirectory)"
         SourceFiles="@(_PlatformAntItem->'$(AndroidToolchainCacheDirectory)\%(Identity).zip')"
         DestinationFolder="$(AntDirectory)"
     />

--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -70,10 +70,11 @@
       <DestDir>platforms\android-10</DestDir>
     </AndroidSdkItem>
 
-    <!-- Note: if the version is changed here (which forces the change of path), make sure to update Configure.props! -->
-    <AndroidSdkItem Include="cmake-3.6.4111459-windows-x86_64.zip">
+    <!-- Note: if the version is changed here (which forces the change of path), make sure to update Configuration.props! -->
+    <AndroidSdkItem Include="cmake-3.6.4111459-windows-x86_64">
       <HostOS>Windows</HostOS>
       <DestDir>cmake\3.6.4111459</DestDir>
+      <NoSubdirectory>True</NoSubdirectory>
     </AndroidSdkItem>
 
     <AndroidSdkItem Include="android-15_r03">

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -12,7 +12,7 @@ include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 
 set(JAVA_INTEROP_SRC_PATH "../../external/Java.Interop/src/java-interop")
-set(TOP_DIR ${CMAKE_SOURCE_DIR})
+string(REPLACE "\\" "/" TOP_DIR ${CMAKE_SOURCE_DIR})
 
 if(NOT DEFINED SGEN_BRIDGE_VERSION)
   message(FATAL_ERROR "Please set the SGEN_BRIDGE_VERSION variable on command line (-DSGEN_BRIDGE_VERSION=VERSION)")
@@ -20,6 +20,8 @@ endif()
 
 if(NOT DEFINED MONO_PATH)
   message(FATAL_ERROR "Please set the MONO_PATH variable on command line (-DMONO_PATH=PATH)")
+else()
+  string(REPLACE "\\" "/" MONO_PATH ${MONO_PATH})
 endif()
 
 if(NOT ANDROID)

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -47,13 +47,13 @@
       Outputs="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\CMakeCache.txt');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\CMakeCache.txt')">
     <MakeDir Directories="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Debug" />
     <Exec
-        Command="$(CmakePath) $(_CmakeAndroidFlags) -DCONFIGURATION=Release -DCMAKE_BUILD_TYPE=Debug -DANDROID_ABI=%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(OutputPath)/%(AndroidSupportedTargetJitAbi.Identity) $(MSBuildThisFileDirectory)"
+        Command="$(CmakePath) $(_CmakeAndroidFlags) -DCONFIGURATION=Release -DCMAKE_BUILD_TYPE=Debug -DANDROID_ABI=%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(OutputPath)%(AndroidSupportedTargetJitAbi.Identity) $(MSBuildThisFileDirectory)"
         WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Debug"
     />
 
     <MakeDir Directories="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Release" />
     <Exec
-        Command="$(CmakePath) $(_CmakeAndroidFlags) -DSTRIP_DEBUG=ON -DCONFIGURATION=Debug -DCMAKE_BUILD_TYPE=Release -DANDROID_ABI=%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(OutputPath)/%(AndroidSupportedTargetJitAbi.Identity) $(MSBuildThisFileDirectory)"
+        Command="$(CmakePath) $(_CmakeAndroidFlags) -DSTRIP_DEBUG=ON -DCONFIGURATION=Debug -DCMAKE_BUILD_TYPE=Release -DANDROID_ABI=%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(OutputPath)%(AndroidSupportedTargetJitAbi.Identity) $(MSBuildThisFileDirectory)"
         WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Release"
     />
   </Target>


### PR DESCRIPTION
Fixes for unzipping the cmake download:
- `android-toolchain.projitems` doesn't need to specify `.zip`, as the
  targets append this extension automatically
- It appears that the zip of cmake doesn't have a subdirectory
  - Added a `NoSubdirectory` item metadata
  - Set `<UnzipDirectoryChildren NoSubdirectory="True" />` so that
    cmake is extracted correctly

Issues with paths:
- cmake does not appear to like odd combinations of paths, such as
  `\/` or `\\`. These are likely mistakes that *happen to work*, so we
  should clean them up.
- `Configuration.props` had a double path separator in
  `$(XAInstallPrefix)`, since `$(MSBuildThisFileDirectory)` contains a
  trailing slash
- `monodroid.targets` had a path with `\/` on Windows, since
  `$(OutputPath)` has a trailing slash
- `CMakeLists.txt` had two places I needed to replace Windows-style
  paths `\` -> `/`, since these were generating paths that had a
  combination of `\` and `/`