### PR TITLE
[Mono.Android] Avoid using Guid.NewGuid () for dynamic method names

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.cs
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Threading;
 
 namespace Android.Runtime {
 	public static class JNINativeWrapper {
@@ -9,6 +10,8 @@ namespace Android.Runtime {
 		static MethodInfo mono_unhandled_exception_method;
 		static MethodInfo exception_handler_method;
 		static MethodInfo wait_for_bridge_processing_method;
+
+		static int dynamicMethodNameCounter;
 
 		static void get_runtime_types ()
 		{
@@ -48,7 +51,7 @@ namespace Android.Runtime {
 				param_types [i] = parameters [i].ParameterType;
 			}
 
-			var dynamic = new DynamicMethod (Guid.NewGuid ().ToString (), ret_type, param_types, typeof (object), true);
+			var dynamic = new DynamicMethod (Interlocked.Increment (ref dynamicMethodNameCounter).ToString (), ret_type, param_types, typeof (object), true);
 			var ig = dynamic.GetILGenerator ();
 
 			LocalBuilder retval = null;


### PR DESCRIPTION
Reduce usage of slow `Guid.NewGuid ()` calls. All we need is method
unique name here and unique integer number should be all we need.

https://github.com/xamarin/xamarin-android/issues/1832

FYI, during the startup of `xamarin-forms-samples/XamlSamples` app,
the counter is incremented 54 times.