### PR TITLE
[Mono.Android] Avoid using Guid.NewGuid () for dynamic constructor names

### DIFF
--- a/src/Mono.Android/Android.Runtime/ConstructorBuilder.cs
+++ b/src/Mono.Android/Android.Runtime/ConstructorBuilder.cs
@@ -3,16 +3,16 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace Android.Runtime {
 	internal class ConstructorBuilder {
-		static AssemblyBuilder builder = AppDomain.CurrentDomain.DefineDynamicAssembly (new AssemblyName {Name = "MonoDroidConstructors"}, AssemblyBuilderAccess.Run, null, null, null,  null, null, true);
-		static ModuleBuilder module = builder.DefineDynamicModule ("Implementations", false);
-
 		static MethodInfo newobject = typeof (System.Runtime.Serialization.FormatterServices).GetMethod ("GetUninitializedObject", BindingFlags.Public | BindingFlags.Static);
 		static MethodInfo gettype = typeof (System.Type).GetMethod ("GetTypeFromHandle", BindingFlags.Public | BindingFlags.Static);
 		static FieldInfo handlefld = typeof (Java.Lang.Object).GetField ("handle", BindingFlags.NonPublic | BindingFlags.Instance);
 		static FieldInfo Throwable_handle = typeof (Java.Lang.Throwable).GetField ("handle", BindingFlags.NonPublic | BindingFlags.Instance);
+
+		static int dynamicMethodNameCounter;
 
 		internal static Action <IntPtr, object []> CreateDelegate (Type type, ConstructorInfo cinfo, Type [] parameter_types) {
 			var handle = handlefld;
@@ -20,7 +20,7 @@ namespace Android.Runtime {
 				handle = Throwable_handle;
 			}
 
-			DynamicMethod method = new DynamicMethod (Guid.NewGuid ().ToString (), typeof (void), new Type [] {typeof (IntPtr), typeof (object []) }, module, true);
+			DynamicMethod method = new DynamicMethod ($"{Interlocked.Increment (ref dynamicMethodNameCounter)}c", typeof (void), new Type [] {typeof (IntPtr), typeof (object []) }, typeof (object), true);
 			ILGenerator il = method.GetILGenerator ();
 
 			il.DeclareLocal (typeof (object));


### PR DESCRIPTION
Reduce usage of slow `Guid.NewGuid ()` calls. All we need is method
unique name here and unique integer number should be all we need.

When looking further into
https://github.com/xamarin/xamarin-android/issues/1832 I noticed that
`ConstructorBuilder` uses `Guid.NewGuid ()` as well.

It also creates new assembly builder which is slow too and involves
call to `System.Guid:FastNewGuidArray ()` thrue
`System.Reflection.Emit.ModuleBuilder:.cctor ()`. I think we can avoid
creating new module as we already "pollute" `System.Object` in
`JNINativeWrapper` and thus we can put the constructors there as well.

After that change, together with
https://github.com/xamarin/xamarin-android/pull/1868, our
Xamarin.Android template app doesn't call the `Guid.NewGuid ()` during
the startup anymore.

In case of 'xamarin-forms-test/XamlSample', the first time the
`Guid.NewGuid ()` is called, is from XForms
https://github.com/xamarin/Xamarin.Forms/blob/14af670f5a200d164284fa4f0b3e4f7ce03b53df/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs#L152

The impact of these 2 relatively small changes is quite nice (from both PRs #1868  and #1872). For the template XA application (Debug configuration with profiling enabled on x86 emulator) it saves:

saved | location | description
------:|---------|-------------
5ms | `Android.Runtime.JNIEnv:Initialize` | the removal of the `NewGuid ()` calls
3ms | `Android.Runtime.AndroidTypeManager:RegisterNativeMembers` | the removal of the `NewGuid ()` calls
11ms | `ConstructorBuilder:.cctor ()` | the removal of the builders

Where the whole `Android.Runtime.JNIEnv:Initialize` took 298ms previously. It also means less code to JIT

Original

	Compiled methods: 2063
	Generated code size: 589860

New

	Compiled methods: 1954
	Generated code size: 562413
