### PR TITLE
[tests] fix failing MultiDex test on Windows

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -535,11 +535,13 @@ namespace Xamarin.Android.Tests
 			string intermediateDir = proj.IntermediateOutputPath;
 			if (IsWindows) {
 				proj.SetProperty ("AppendTargetFrameworkToIntermediateOutputPath", "True");
-				intermediateDir = Path.Combine (proj.IntermediateOutputPath, proj.TargetFrameworkMoniker);
 			}
 
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName), false, false)) {
 				proj.TargetFrameworkVersion = b.LatestTargetFrameworkVersion ();
+				if (IsWindows) {
+					intermediateDir = Path.Combine (intermediateDir, proj.TargetFrameworkMoniker);
+				}
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				Assert.IsTrue (File.Exists (Path.Combine (Root, b.ProjectDirectory, intermediateDir,  "android/bin/classes.dex")),
 					"multidex-ed classes.zip exists");


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build?buildId=1793969

Our VSTS builds on Windows have had one failing unit test for a while
(but the build was otherwise broken in general).

    Xamarin.Android.Build.Tests.BuildTest.BuildMultiDexApplication(False,"v7.1")
        multidex-ed classes.zip exists
        Expected: True
        But was: False
    at Xamarin.Android.Build.Tests.BuildTest.BuildMultiDexApplication(Boolean useJackAndJill, String fxVersion)
        in E:\A\_work\2\s\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.Android.Build.Tests\BuildTest.cs:line 544

1589dff3 was a good attempt at handling our new
`AppendTargetFrameworkToIntermediateOutputPath` logic in this test.

However, it was using `TargetFrameworkMoniker` *before* this line:

    proj.TargetFrameworkVersion = b.LatestTargetFrameworkVersion ();

And so, it was using an incorrect `TargetFrameworkMoniker` for
assertions later in the test.

Moving the usage of `TargetFrameworkMoniker` *after*
`TargetFrameworkVersion` is set should fix this test and get the
Windows build green again.