### PR TITLE
[Xamarin.Android.Build.Tasks] clean intermediates if NuGets change

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2067,6 +2067,9 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 					b.RequiresMSBuild = true;
 					b.Target = "Restore,Build";
 				}
+				//[TearDown] will still delete if test outcome successful, I need logs if assertions fail but build passes
+				b.CleanupAfterSuccessfulBuild =
+					b.CleanupOnDispose = false;
 				var projectDir = Path.Combine (Root, b.ProjectDirectory);
 				if (Directory.Exists (projectDir))
 					Directory.Delete (projectDir, true);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -49,6 +49,15 @@ namespace Xamarin.ProjectTools
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v4.25.4.0.1\\lib\\MonoAndroid70\\Xamarin.Android.Support.v4.dll" }
 			}
 		};
+		public static Package AndroidSupportV4_27_0_2_1 = new Package () {
+			Id = "Xamarin.Android.Support.v4",
+			Version = "27.0.2.1",
+			TargetFramework = "MonoAndroid81",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.v4") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v4.27.0.2.1\\lib\\MonoAndroid70\\Xamarin.Android.Support.v4.dll" }
+			}
+		};
 		public static Package AndroidSupportV4Beta = new Package () {
 			Id = "Xamarin.Android.Support.v4",
 			Version = "21.0.0.0-beta1",
@@ -103,6 +112,16 @@ namespace Xamarin.ProjectTools
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v7.RecyclerView.21.0.0.0-beta1\\lib\\MonoAndroid\\Xamarin.Android.Support.v7.RecyclerView.dll" }
 				}
 		};
+		public static Package SupportV7RecyclerView_27_0_2_1 = new Package {
+			Id = "Xamarin.Android.Support.v7.RecyclerView",
+			Version = "27.0.2.1",
+			TargetFramework = "MonoAndroid81",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.V7.RecyclerView") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v7.RecyclerView.27.0.2.1\\lib\\MonoAndroid81\\Xamarin.Android.Support.v7.RecyclerView.dll"
+				}
+			}
+		};
 		public static Package SupportV7CardView = new Package {
 			Id = "Xamarin.Android.Support.v7.Cardview",
 			Version = "21.0.3.0",
@@ -128,6 +147,15 @@ namespace Xamarin.ProjectTools
 			References = {
 				new BuildItem.Reference ("Xamarin.Android.Support.v7.CardView") {
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v7.CardView.25.4.0.1\\lib\\MonoAndroid70\\Xamarin.Android.Support.v7.CardView.dll" }
+			}
+		};
+		public static Package SupportV7CardView_27_0_2_1 = new Package {
+			Id = "Xamarin.Android.Support.v7.Cardview",
+			Version = "27.0.2.1",
+			TargetFramework = "MonoAndroid81",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.v7.CardView") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v7.CardView.27.0.2.1\\lib\\MonoAndroid81\\Xamarin.Android.Support.v7.CardView.dll" }
 			}
 		};
 		public static Package SupportV7AppCompat_21_0_3_0 = new Package {
@@ -211,6 +239,60 @@ namespace Xamarin.ProjectTools
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.Media.Compat.25.4.0.1\\lib\\MonoAndroid70\\Xamarin.Android.Support.Media.Compat.dll" }
 			}
 		};
+		public static Package SupportV7AppCompat_27_0_2_1 = new Package {
+			Id = "Xamarin.Android.Support.v7.AppCompat",
+			Version = "27.0.2.1",
+			TargetFramework = "MonoAndroid81",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.v7.AppCompat") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v7.AppCompat.27.0.2.1\\lib\\MonoAndroid81\\Xamarin.Android.Support.v7.AppCompat.dll" }
+			}
+		};
+		public static Package SupportCompat_27_0_2_1 = new Package {
+			Id = "Xamarin.Android.Support.Compat",
+			Version = "27.0.2.1",
+			TargetFramework = "MonoAndroid81",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.Compat") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.Compat.27.0.2.1\\lib\\MonoAndroid81\\Xamarin.Android.Support.Compat.dll" }
+			}
+		};
+		public static Package SupportCoreUI_27_0_2_1 = new Package {
+			Id = "Xamarin.Android.Support.Core.UI",
+			Version = "27.0.2.1",
+			TargetFramework = "MonoAndroid81",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.Core.UI") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.Core.UI.27.0.2.1\\lib\\MonoAndroid81\\Xamarin.Android.Support.Core.UI.dll" }
+			}
+		};
+		public static Package SupportCoreUtils_27_0_2_1 = new Package {
+			Id = "Xamarin.Android.Support.Core.Utils",
+			Version = "27.0.2.1",
+			TargetFramework = "MonoAndroid81",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.Core.Utils") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.Core.Utils.27.0.2.1\\lib\\MonoAndroid81\\Xamarin.Android.Support.Core.Utils.dll" }
+			}
+		};
+		public static Package SupportFragment_27_0_2_1 = new Package {
+			Id = "Xamarin.Android.Support.Fragment",
+			Version = "27.0.2.1",
+			TargetFramework = "MonoAndroid81",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.Fragment") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.Fragment.27.0.2.1\\lib\\MonoAndroid81\\Xamarin.Android.Support.Fragment.dll" }
+			}
+		};
+		public static Package SupportMediaCompat_27_0_2_1 = new Package {
+			Id = "Xamarin.Android.Support.Media.Compat",
+			Version = "27.0.2.1",
+			TargetFramework = "MonoAndroid81",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.Media.Compat") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.Media.Compat.27.0.2.1\\lib\\MonoAndroid81\\Xamarin.Android.Support.Media.Compat.dll" }
+			}
+		};
 		public static Package SupportV7MediaRouter_21_0_3_0 = new Package {
 			Id = "Xamarin.Android.Support.v7.MediaRouter",
 			Version = "21.0.3.0",
@@ -218,6 +300,24 @@ namespace Xamarin.ProjectTools
 			References = {
 				new BuildItem.Reference ("Xamarin.Android.Support.v7.MediaRouter") {
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v7.MediaRouter.21.0.3.0\\lib\\MonoAndroid403\\Xamarin.Android.Support.v7.MediaRouter.dll" }
+			}
+		};
+		public static Package SupportV7MediaRouter_25_4_0_1 = new Package {
+			Id = "Xamarin.Android.Support.v7.MediaRouter",
+			Version = "25.4.0.1",
+			TargetFramework = "MonoAndroid70",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.v7.MediaRouter") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v7.MediaRouter.25.4.0.1\\lib\\MonoAndroid70\\Xamarin.Android.Support.v7.MediaRouter.dll" }
+			}
+		};
+		public static Package SupportV7MediaRouter_27_0_2_1 = new Package {
+			Id = "Xamarin.Android.Support.v7.MediaRouter",
+			Version = "27.0.2.1",
+			TargetFramework = "MonoAndroid81",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.v7.MediaRouter") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v7.MediaRouter.27.0.2.1\\lib\\MonoAndroid81\\Xamarin.Android.Support.v7.MediaRouter.dll" }
 			}
 		};
 		public static Package SupportV7Palette_22_1_1_1 = new Package {
@@ -236,6 +336,15 @@ namespace Xamarin.ProjectTools
 			References = {
 				new BuildItem.Reference ("Xamarin.Android.Support.Design") {
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.Design.25.4.0.1\\lib\\MonoAndroid70\\Xamarin.Android.Support.Design.dll" }
+				}
+		};
+		public static Package SupportDesign_27_0_2_1 = new Package {
+			Id = "Xamarin.Android.Support.Design",
+			Version = "27.0.2.1",
+			TargetFramework = "MonoAndroid81",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.Design") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.Design.27.0.2.1\\lib\\MonoAndroid81\\Xamarin.Android.Support.Design.dll" }
 				}
 		};
 		public static Package GooglePlayServices_22_0_0_2 = new Package {
@@ -315,6 +424,28 @@ namespace Xamarin.ProjectTools
 				},
 				new BuildItem.Reference ("Xamarin.Forms.Platform") {
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.2.3.4.231\\lib\\MonoAndroid10\\Xamarin.Forms.Platform.dll"
+				},
+			}
+		};
+		public static Package XamarinForms_3_0_0_561731 = new Package {
+			Id = "Xamarin.Forms",
+			Version = "3.0.0.561731",
+			TargetFramework = "MonoAndroid10",
+			References =  {
+				new BuildItem.Reference ("Xamarin.Forms.Platform.Android") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.0.0.561731\\lib\\MonoAndroid10\\Xamarin.Forms.Platform.Android.dll"
+				},
+				new BuildItem.Reference ("FormsViewGroup") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.0.0.561731\\lib\\MonoAndroid10\\FormsViewGroup.dll"
+				},
+				new BuildItem.Reference ("Xamarin.Forms.Core") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.0.0.561731\\lib\\MonoAndroid10\\Xamarin.Forms.Core.dll"
+				},
+				new BuildItem.Reference ("Xamarin.Forms.Xaml") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.0.0.561731\\lib\\MonoAndroid10\\Xamarin.Forms.Xaml.dll"
+				},
+				new BuildItem.Reference ("Xamarin.Forms.Platform") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.0.0.561731\\lib\\MonoAndroid10\\Xamarin.Forms.Platform.dll"
 				},
 			}
 		};
@@ -402,6 +533,36 @@ namespace Xamarin.ProjectTools
 			References = {
 				new BuildItem.Reference("PCLCrypto") {
 					MetadataValues = "HintPath=..\\packages\\PCLCrypto.2.1.17-alpha-g5b1e8dff8c\\lib\\monoandroid23\\PCLCrypto.dll"
+				}
+			}
+		};
+		public static Package Android_Arch_Core_Common_26_1_0 = new Package {
+			Id = "Xamarin.Android.Arch.Core.Common",
+			Version = "26.1.0",
+			TargetFramework = "MonoAndroid80",
+			References = {
+				new BuildItem.Reference("Xamarin.Android.Arch.Core.Common") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Arch.Core.Common.26.1.0\\lib\\MonoAndroid80\\Xamarin.Android.Arch.Core.Common.dll"
+				}
+			}
+		};
+		public static Package Android_Arch_Lifecycle_Common_26_1_0 = new Package {
+			Id = "Xamarin.Android.Arch.Lifecycle.Common",
+			Version = "26.1.0",
+			TargetFramework = "MonoAndroid80",
+			References = {
+				new BuildItem.Reference("Xamarin.Android.Arch.Lifecycle.Common") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Arch.Lifecycle.Common.26.1.0\\lib\\MonoAndroid80\\Xamarin.Android.Arch.Lifecycle.Common.dll"
+				}
+			}
+		};
+		public static Package Android_Arch_Lifecycle_Runtime_26_1_0 = new Package {
+			Id = "Xamarin.Android.Arch.Lifecycle.Runtime",
+			Version = "26.1.0",
+			TargetFramework = "MonoAndroid80",
+			References = {
+				new BuildItem.Reference("Xamarin.Android.Arch.Lifecycle.Runtime") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Arch.Lifecycle.Runtime.26.1.0\\lib\\MonoAndroid80\\Xamarin.Android.Arch.Lifecycle.Runtime.dll"
 				}
 			}
 		};

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -271,6 +271,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<_AndroidLibrayProjectAssemblyMapFile>$(_AndroidLibrayProjectIntermediatePath)map.cache</_AndroidLibrayProjectAssemblyMapFile>
 	<_AndroidProguardInputJarFilter>(!META-INF/MANIFEST.MF)</_AndroidProguardInputJarFilter>
 	<_AndroidAapt2VersionFile>$(IntermediateOutputPath)aapt2.version</_AndroidAapt2VersionFile>
+	<_AndroidNuGetStampFile>$(IntermediateOutputPath)$(MSBuildProjectName).nuget.stamp</_AndroidNuGetStampFile>
 
 	<!-- $(EnableProguard) is an obsolete property that should be removed at some stage. -->
 	<AndroidEnableProguard Condition="'$(AndroidEnableProguard)'==''">$(EnableProguard)</AndroidEnableProguard>
@@ -524,6 +525,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     _CheckTargetFramework;
     _RemoveLegacyDesigner;
     _ValidateAndroidPackageProperties;
+    _CleanIntermediateIfNuGetsChange;
     $(BuildDependsOn);
     _CompileDex;
     $(_PostBuildTargets)
@@ -542,6 +544,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     _CheckTargetFramework;
     _RemoveLegacyDesigner;
     _ValidateAndroidPackageProperties;
+    _CleanIntermediateIfNuGetsChange;
     $(BuildDependsOn);
   </BuildDependsOn>
 </PropertyGroup>
@@ -641,6 +644,23 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<CreateProperty Value="$(OutDir)$(_AndroidPackage)-Signed.apk">
 		<Output TaskParameter="Value" PropertyName="ApkFileSigned"/>
 	</CreateProperty>
+</Target>
+
+<Target Name="_BeforeCleanIntermediateIfNuGetsChange">
+  <PropertyGroup>
+    <_NuGetAssetsFile Condition="Exists('$(ProjectLockFile)')">$(ProjectLockFile)</_NuGetAssetsFile>
+    <_NuGetAssetsFile Condition="'$(_NuGetAssetsFile)' == '' and Exists('packages.config')">packages.config</_NuGetAssetsFile>
+  </PropertyGroup>
+</Target>
+
+<Target Name="_CleanIntermediateIfNuGetsChange" DependsOnTargets="_BeforeCleanIntermediateIfNuGetsChange"
+    Inputs="$(_NuGetAssetsFile)"
+    Outputs="$(_AndroidNuGetStampFile)">
+  <CallTarget Targets="_CleanMonoAndroidIntermediateDir" />
+  <Touch Files="$(_AndroidNuGetStampFile)" AlwaysCreate="true" />
+  <ItemGroup>
+    <FileWrites Include="$(_AndroidNuGetStampFile)" />
+  </ItemGroup>
 </Target>
 
 <Target Name="_ResolveMonoAndroidFramework" DependsOnTargets="GetReferenceAssemblyPaths" >


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/1741
Fixes: https://github.com/xamarin/xamarin-android/issues/1828

PR #1741 is a good attempt at fixing this, but...
- It is a little heavy handed and basically "nukes the world".
- It does not reproduce an issue in a test and "fix it", it fixes an
  "unknown" #deletebinobj problem.

I also have a few nitpicks about PR #1741:
- It only comes into effect if `BuildingInsideVisualStudio` is `True`.
  We should also fix command-line builds.
- The `$(ProjectLockFile).stamp` file isn't added to `FileWrites`.

So let's improve on #1741! As it had some good ideas, we just need to
narrow its focus.

First, I reproduced a real issue in a test with the following
scenario:
- Create a Xamarin.Forms 2.3.4 app that uses the 25.4.x support
  libraries
- Build it
- Update the NuGets to Xamarin.Forms 3.0.x and the 27.x support
  libraries
- Build again
- Stuff breaks... namely the following message:

```
    bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Common.targets(2153,3): error MSB4018: The "GenerateJavaStubs" task failed unexpectedly.
        System.IO.FileNotFoundException: Could not load assembly 'System.IO, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. Perhaps it doesn't exist in the Mono for Android profile?
        File name: 'System.IO.dll'
        at Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.Resolve(AssemblyNameReference reference, ReaderParameters parameters) in external\Java.Interop\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil\DirectoryAssemblyResolver.cs:line 241
        at Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.Resolve(AssemblyNameReference reference) in external\Java.Interop\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil\DirectoryAssemblyResolver.cs:line 191
        at Mono.Cecil.MetadataResolver.Resolve(TypeReference type) in external\mono\external\cecil\Mono.Cecil\MetadataResolver.cs:line 101
        at Mono.Cecil.ModuleDefinition.Resolve(TypeReference type) in external\mono\external\cecil\Mono.Cecil\ModuleDefinition.cs:line 774
        at Mono.Cecil.TypeReference.Resolve() in external\mono\external\cecil\Mono.Cecil\TypeReference.cs:line 280
        at Java.Interop.Tools.Cecil.TypeDefinitionRocks.GetBaseType(TypeDefinition type) in external\Java.Interop\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil\TypeDefinitionRocks.cs:line 14
        at Java.Interop.Tools.Cecil.TypeDefinitionRocks.<GetTypeAndBaseTypes>d__1.MoveNext() in external\Java.Interop\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil\TypeDefinitionRocks.cs:line 21
        at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
        at Java.Interop.Tools.Cecil.TypeDefinitionRocks.IsSubclassOf(TypeDefinition type, String typeName) in external\Java.Interop\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil\TypeDefinitionRocks.cs:line 55
        at Java.Interop.Tools.JavaCallableWrappers.JavaTypeScanner.AddJavaTypes(List`1 javaTypes, TypeDefinition type) in external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\JavaTypeScanner.cs:line 46
        at Java.Interop.Tools.JavaCallableWrappers.JavaTypeScanner.GetJavaTypes(IEnumerable`1 assemblies, IAssemblyResolver resolver) in external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\JavaTypeScanner.cs:line 36
        at Xamarin.Android.Tasks.GenerateJavaStubs.Run(DirectoryAssemblyResolver res) in src\Xamarin.Android.Build.Tasks\Tasks\GenerateJavaStubs.cs:line 138
        at Xamarin.Android.Tasks.GenerateJavaStubs.Execute() in src\Xamarin.Android.Build.Tasks\Tasks\GenerateJavaStubs.cs:line 91
        at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
        at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext() [bin\TestDebug\temp\BuildAfterUpgradingNuget\UnnamedProject.csproj]
```

The real problem here though is that many of the intermediate files in
`obj\Debug\lp` (among others) are out of sync. Namely we can see
messages like this from the `ResolveLibraryProjectImports` MSBuild
task in the build log:

    Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.animated.vector.drawable\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Animated.Vector.Drawable.dll: extracted files are up to date
    Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.annotations\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Annotations.dll: extracted files are up to date
    Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.compat\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Compat.dll: extracted files are up to date
    Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.core.ui\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Core.UI.dll: extracted files are up to date
    Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.core.utils\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Core.Utils.dll: extracted files are up to date
    Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.design\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Design.dll: extracted files are up to date
    Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.fragment\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Fragment.dll: extracted files are up to date
    Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.media.compat\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Media.Compat.dll: extracted files are up to date
    Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.transition\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Transition.dll: extracted files are up to date
    Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.v4\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.v4.dll: extracted files are up to date
    Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.v7.appcompat\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.v7.AppCompat.dll: extracted files are up to date
    Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.v7.cardview\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.v7.CardView.dll: extracted files are up to date
    Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.v7.mediarouter\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.v7.MediaRouter.dll: extracted files are up to date
    Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.v7.palette\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.v7.Palette.dll: extracted files are up to date
    Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.v7.recyclerview\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.v7.RecyclerView.dll: extracted files are up to date
    Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.vector.drawable\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Vector.Drawable.dll: extracted files are up to date

These are *bad*, since the extracted files were from the 25.4.x
support libraries! It is happening because the timestamps of these
system-wide `%UserProfile%\.nuget` NuGet packages are quite old.

So a solution for now, based on #1741:
- When NuGet packages change
- Clean some subset of files/directories -- not a full `Clean`

I borrowed the logic for calculating `$(_NuGetAssetsFile)` from #1741,
since it was working pretty well. I added a
`_CleanIntermediateIfNuGetsChange` MSBuild target that runs the
`_CleanMonoAndroidIntermediateDir` target as this was the smallest
deletion I could figure out that fixes the problem. At first I tried
deleting other subsets of files/directories, but couldn't find a
combination that worked.

This change does have some impact on build times, when
`_CleanIntermediateIfNuGetsChange` runs and deletes files, it takes
1-2 seconds on my machine for the test case. There will also be
further build time taken from other targets that run because files
were deleted. However, we would likely prefer a slightly slower,
correct build, than a faster incorrect one... It is certaining going
to be faster than the `Build`, error message, `Rebuild` cycle -- or
nuking `bin` and `obj`.

Down the road, we could consider some other change to refactor how
`obj\Debug\lp` is generated and make it resilient to NuGet changes.