### PR TITLE
[Xamarin.ProjectTools] fix for VSTS and BUILD_SOURCEVERSIONMESSAGE

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -298,8 +298,14 @@ namespace Xamarin.ProjectTools
 					psi.EnvironmentVariables [kvp.Key] = kvp.Value;
 				}
 			}
-			//NOTE: fix for Jenkins, see https://github.com/xamarin/xamarin-android/pull/1049#issuecomment-347625456
-			psi.EnvironmentVariables ["ghprbPullLongDescription"] = "";
+
+			//NOTE: commit messages can "accidentally" cause test failures
+			// Consider if you added an error message in a commit message, then wrote a test asserting the error no longer occurs.
+			// Both Jenkins and VSTS have an environment variable containing the full commit message, which will inexplicably cause your test to fail...
+			// For a Jenkins case, see https://github.com/xamarin/xamarin-android/pull/1049#issuecomment-347625456
+			// For a VSTS case, see http://build.devdiv.io/1806783
+			psi.EnvironmentVariables ["ghprbPullLongDescription"] =
+				psi.EnvironmentVariables ["BUILD_SOURCEVERSIONMESSAGE"] = "";
 
 			psi.Arguments = args.ToString ();
 			


### PR DESCRIPTION
Context: http://build.devdiv.io/1806783

Commit messages can "accidentally" cause test failures on VSTS.

Consider if you added an error message in a commit message, then wrote
a test asserting the error no longer occurs.

Both Jenkins and VSTS have an environment variable containing the full
commit message, which will inexplicably cause your test to fail...

- Jenkins sets `ghprbPullLongDescription`
- VSTS sets `BUILD_SOURCEVERSIONMESSAGE`

In this case my build log had:
```
BUILD_SOURCEVERSIONAUTHOR = Jonathan Peppers
BUILD_SOURCEVERSIONMESSAGE = [Xamarin.Android.Build.Tasks] clean intermediates if NuGets change (#1878)
~~commit message text~~
        Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.animated.vector.drawable\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Animated.Vector.Drawable.dll: extracted files are up to date
        Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.annotations\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Annotations.dll: extracted files are up to date
        Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.compat\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Compat.dll: extracted files are up to date
        Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.core.ui\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Core.UI.dll: extracted files are up to date
        Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.core.utils\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Core.Utils.dll: extracted files are up to date
        Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.design\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Design.dll: extracted files are up to date
        Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.fragment\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Fragment.dll: extracted files are up to date
        Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.media.compat\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Media.Compat.dll: extracted files are up to date
        Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.transition\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Transition.dll: extracted files are up to date
        Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.v4\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.v4.dll: extracted files are up to date
        Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.v7.appcompat\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.v7.AppCompat.dll: extracted files are up to date
        Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.v7.cardview\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.v7.CardView.dll: extracted files are up to date
        Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.v7.mediarouter\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.v7.MediaRouter.dll: extracted files are up to date
        Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.v7.palette\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.v7.Palette.dll: extracted files are up to date
        Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.v7.recyclerview\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.v7.RecyclerView.dll: extracted files are up to date
        Skipped resource lookup for C:\Users\myuser\.nuget\packages\xamarin.android.support.vector.drawable\27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Vector.Drawable.dll: extracted files are up to date
~~commit message text~~
BUILD_STAGINGDIRECTORY = E:\A\_work\2\a
```

The test was asserting that `Xamarin.Android.Support.v4.dll: extracted files are up to date` was not found...

We can clear these values on the `ProcessStartInfo` object when
running MSBuild in Xamarin.ProjectTools.