### PR TITLE
[Mono.Android] Do not fallback in GetJavaToManagedType

### DIFF
--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -206,25 +206,10 @@ namespace Java.Interop {
 		internal static Type GetJavaToManagedType (string class_name)
 		{
 			var t = monodroid_typemap_java_to_managed (class_name);
-			if (t != IntPtr.Zero)
-				return Type.GetType (Marshal.PtrToStringAnsi (t));
+			if (t == IntPtr.Zero)
+				return null;
 
-			var type    = (Type) null;
-			int ls      = class_name.LastIndexOf ('/');
-			var package = ls >= 0 ? class_name.Substring (0, ls) : "";
-			List<Converter<string, Type>> mappers;
-			if (packageLookup.TryGetValue (package, out mappers)) {
-				foreach (Converter<string, Type> c in mappers) {
-					type = c (class_name);
-					if (type == null)
-						continue;
-					return type;
-				}
-			}
-			if ((type = Type.GetType (JavaNativeTypeManager.ToCliType (class_name))) != null) {
-				return type;
-			}
-			return null;
+			return Type.GetType (Marshal.PtrToStringAnsi (t));
 		}
 
 		internal static IJavaObject CreateInstance (IntPtr handle, JniHandleOwnership transfer)


### PR DESCRIPTION
In https://github.com/xamarin/xamarin-android/issues/1830 we saw that
there are cases when `monodroid_typemap_java_to_managed` fails to get
us managed type name. These are internal and nested private
classes. We don't need to fallback in these cases.

So the fallback didn't get us anything as we don't have managed
bindings for these.

Avoiding the fallback saves us aprox. 9ms in
`TypeManager::GetJavaToManagedType ()`, which is about 90%
improvement. 10ms to 1ms. (measured on x86_64 emulator, XamlSamples
app)

Also the JIT *Compiled methods* number goes down from 5133 to 5107.