### PR TITLE
[CodeBehind] Fix code generation for layouts with non-element root

### DIFF
--- a/Documentation/guides/LayoutCodeBehind.md
+++ b/Documentation/guides/LayoutCodeBehind.md
@@ -465,6 +465,7 @@ a number of very simple adjustments to try to match the code, such as:
 
       * `android.view` -> `Android.Views`
       * `android.support.wearable.view` -> `Android.Support.Wearable.Views`
+	  * `android.support.constraint` -> `Android.Support.Constraints`
       * `com.actionbarsherlock` -> `ABSherlock`
       * `com.actionbarsherlock.widget` -> `ABSherlock.Widget`
       * `com.actionbarsherlock.view` -> `ABSherlock.View`

--- a/Documentation/guides/LayoutCodeBehind.md
+++ b/Documentation/guides/LayoutCodeBehind.md
@@ -465,7 +465,7 @@ a number of very simple adjustments to try to match the code, such as:
 
       * `android.view` -> `Android.Views`
       * `android.support.wearable.view` -> `Android.Support.Wearable.Views`
-	  * `android.support.constraint` -> `Android.Support.Constraints`
+      * `android.support.constraint` -> `Android.Support.Constraints`
       * `com.actionbarsherlock` -> `ABSherlock`
       * `com.actionbarsherlock.widget` -> `ABSherlock.Widget`
       * `com.actionbarsherlock.view` -> `ABSherlock.View`

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
@@ -74,6 +74,7 @@ namespace Xamarin.Android.Tasks
 		readonly Dictionary <string, string> knownNamespaceFixups = new Dictionary <string, string> (StringComparer.OrdinalIgnoreCase) {
 			{"android.view", "Android.Views"},
 			{"android.support.wearable.view", "Android.Support.Wearable.Views"},
+			{"android.support.constraint", "Android.Support.Constraints"},
 			{"com.actionbarsherlock", "ABSherlock"},
 			{"com.actionbarsherlock.widget", "ABSherlock.Widget"},
 			{"com.actionbarsherlock.view", "ABSherlock.View"},
@@ -220,6 +221,13 @@ namespace Xamarin.Android.Tasks
 			bool skipFirst = false;
 
 			nav.MoveToFirstChild ();
+
+			// This is needed in case the first element after XML declaration is not an actual element but a
+			// comment, for instance
+			while (nav.NodeType != XPathNodeType.Element) {
+				nav.MoveToNext ();
+			}
+
 			string xamarinClasses = nav.GetAttribute (XamarinClassesAttribute, xamarinNS)?.Trim ();
 
 			if (!String.IsNullOrWhiteSpace (rootWidgetIdOverride)) {

--- a/tests/CodeBehind/BuildTests/Resources/layout/Main.axml
+++ b/tests/CodeBehind/BuildTests/Resources/layout/Main.axml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- This comment is here to test that the generator
+     properly skips non-element nodes preceding the
+     first element node in the layout file -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="match_parent"


### PR DESCRIPTION
If the Android layout file being processed has an XML node other than an
element (e.g. a comment) directly following the XML declaration node, the
generator fails to properly locate the root element and will miss any namespace
declarations on it, as well as the `xamarin:classes` attribute.

This results in failure to generate partial class code and will also cause an
error to parse any elements with the `xamarin:managedType` attribute further
down in the layout file.

The fix is to skip over non-element nodes until we find the first element one
and then attempt to read namespaces and other attributes.