### PR TITLE
[Mono.Android] Use the faster java type name mapping

### DIFF
--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -309,7 +309,7 @@ namespace Java.Interop {
 
 		public static void RegisterType (string java_class, Type t)
 		{
-			string jniFromType = JavaNativeTypeManager.ToJniName (t);
+			string jniFromType = JNIEnv.GetJniName (t);
 			lock (jniToManaged) {
 				Type lookup;
 				if (!jniToManaged.TryGetValue (java_class, out lookup)) {


### PR DESCRIPTION
This fixes https://github.com/xamarin/xamarin-android/issues/1831

Make sure we use the code path, which uses the `typename.*` maps. It
is much faster than `JavaNativeTypeManager.ToJniName`.

Tested with x86 emulator again. It saves 17ms (from 18ms to 1ms) in XA
template and 26ms (from 28ms to 2ms) in XamlSamples app. So it scales
well.

It also decreases JIT usage. XA template: *Compiled methods* 1954 to
1880.