### PR TITLE
[Xamarin.Android.Build.Tasks] Add ExtraArgs support to `CreateMultiDexMainDexClassList`.

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -689,6 +689,26 @@ when packaing Release applications.
     **Experimental**. Added in Xamarin.Android 8.4.  
     The default value is False.
 
+- **AndroidMultiDexClassListExtraArgs** &ndash; A string property
+    which allows developers to pass additional arguments to the 
+    `com.android.multidex.MainDexListBuilder` when generating the 
+    `multidex.keep` file. 
+
+    One specific case is if you are getting the following error
+    during the `dx` compilation.
+
+        com.android.dex.DexException: Too many classes in --main-dex-list, main dex capacity exceeded
+
+    If you are getting this error you can add the following to the
+    .csproj.
+
+        <DxExtraArguments>--force-jumbo </DxExtraArguments>
+        <AndroidMultiDexClassListExtraArgs>--disable-annotation-resolution-workaround</AndroidMultiDexClassListExtraArgs>
+
+    this should allow the `dx` step to succeed.
+
+    Added in Xamarin.Android 8.3.
+
 ### Binding Project Build Properties
 
 The following MSBuild properties are used with

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
@@ -29,6 +29,7 @@ namespace Xamarin.Android.Tasks
 		public string MultiDexMainDexListFile { get; set; }
 		public ITaskItem[] CustomMainDexListFiles { get; set; }
 		public string ProguardInputJarFilter { get; set; }
+		public string ExtraArgs { get; set; }
 
 		Action<CommandLineBuilder> commandlineAction;
 		string tempJar;
@@ -96,6 +97,8 @@ namespace Xamarin.Android.Tasks
 			var jars = JavaLibraries.Select (i => i.ItemSpec).Concat (new string [] { Path.Combine (ClassesOutputDirectory, "..", "classes.zip") });
 			cmd.AppendSwitchIfNotNull ("-Djava.ext.dirs=", Path.Combine (AndroidSdkBuildToolsPath, "lib"));
 			cmd.AppendSwitch ("com.android.multidex.MainDexListBuilder");
+			if (!string.IsNullOrWhiteSpace (ExtraArgs))
+				cmd.AppendSwitch (ExtraArgs);
 			cmd.AppendSwitch ($"{enclosingDoubleQuote}{tempJar}{enclosingDoubleQuote}");
 			cmd.AppendSwitchUnquotedIfNotNull ("", $"{enclosingDoubleQuote}{enclosingQuote}" +
 				string.Join ($"{enclosingQuote}{Path.PathSeparator}{enclosingQuote}", jars) + 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2531,6 +2531,7 @@ because xbuild doesn't support framework reference assemblies.
     MultiDexMainDexListFile="$(_AndroidMainDexListFile)"
     CustomMainDexListFiles="@(MultiDexMainDexList)"
     ProguardInputJarFilter="$(_AndroidProguardInputJarFilter)"
+    ExtraArgs="$(AndroidMultiDexClassListExtraArgs)"
     >
   </CreateMultiDexMainDexClassList>
 


### PR DESCRIPTION
Context #1888

The component team need the ability to pass additional arguments
to the `com.android.multidex.MainDexListBuilder`. Specifically
they need to pass `--disable-annotation-resolution-workaround`.

Since we don't want to do that on all apps, we should add the ability
for them to provide those values in the `csproj` of the binding.

This commit adds `$(AndroidMultiDexClassListExtraArgs)` which will be
appended to the `CreateMultiDexMainDexClassList` command line.
This will allow the team to pass any additional arguments they need.