### PR TITLE
[Xamarin.Android.Build.Tasks] Add Warnings for minimum Google Play requirements.

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -37,8 +37,8 @@
 + [XA0110](xa0110.md): Disabling $(AndroidExplicitCrunch) as it is not supported by `aapt2`. If you wish to use $(AndroidExplicitCrunch) please set $(AndroidUseAapt2) to false.
 + [XA0111](xa0111.md): Could not get the `aapt2` version. Please check it is installed correctly.
 + [XA0112](xa0112.md): `aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.
-+ [XA0113](xa0113.md): Google Play requires that new applications must use a TargetFrameworkVersion of v8.0 (API level 26) or above.
-+ [XA0114](xa0114.md): Google Play requires that application updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above.
++ [XA0113](xa0113.md): Google Play requires that new applications must use a `$(TargetFrameworkVersion)` of v8.0 (API level 26) or above.
++ [XA0114](xa0114.md): Google Play requires that application updates must use a `$(TargetFrameworkVersion)` of v8.0 (API level 26) or above.
 
 ### XA1xxx Project Related
 

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -37,6 +37,8 @@
 + [XA0110](xa0110.md): Disabling $(AndroidExplicitCrunch) as it is not supported by `aapt2`. If you wish to use $(AndroidExplicitCrunch) please set $(AndroidUseAapt2) to false.
 + [XA0111](xa0111.md): Could not get the `aapt2` version. Please check it is installed correctly.
 + [XA0112](xa0112.md): `aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.
++ [XA0113](xa0113.md): Google Play requires that new applications must use a TargetFrameworkVersion of v8.0 (API level 26) or above.
++ [XA0114](xa0114.md): Google Play requires that application updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above.
 
 ### XA1xxx Project Related
 

--- a/Documentation/guides/messages/xa0113.md
+++ b/Documentation/guides/messages/xa0113.md
@@ -2,7 +2,15 @@
 
 As of August 1st 2018 any new application uploaded to the google play
 store needs to target v8.0 (API 26) or above. If you are seeing this
-warning, you should update the `TargetFramrworkVersion` of your projects
+warning, you should update the `TargetFrameworkVersion` of your projects
 to be v8.0 or above.
+
+If you are not targeting the Google Play store and wish to hide these
+warnings you can make use of the `/nowarn:XA0113` command line switch. 
+Alternatively add
+
+    <NoWarn>XA0113</NoWarn>
+
+to your .csproj.
 
 [Google Play's target API level requirement](https://developer.android.com/distribute/best-practices/develop/target-sdk)

--- a/Documentation/guides/messages/xa0113.md
+++ b/Documentation/guides/messages/xa0113.md
@@ -1,0 +1,8 @@
+﻿# Compiler Warning XA0113
+
+As of August 1st 2018 any new application uploaded to the google play
+store needs to target v8.0 (API 26) or above. If you are seeing this
+warning, you should update the `TargetFramrworkVersion` of your projects
+to be v8.0 or above.
+
+[Google Play's target API level requirement](https://developer.android.com/distribute/best-practices/develop/target-sdk)

--- a/Documentation/guides/messages/xa0113.md
+++ b/Documentation/guides/messages/xa0113.md
@@ -2,7 +2,7 @@
 
 As of August 1st 2018 any new application uploaded to the google play
 store needs to target v8.0 (API 26) or above. If you are seeing this
-warning, you should update the `TargetFrameworkVersion` of your projects
+warning, you should update the `$(TargetFrameworkVersion)` of your projects
 to be v8.0 or above.
 
 If you are not targeting the Google Play store and wish to hide these

--- a/Documentation/guides/messages/xa0114.md
+++ b/Documentation/guides/messages/xa0114.md
@@ -2,7 +2,15 @@
 
 As of November 1st 2018 any application update uploaded to the google play
 store needs to target v8.0 (API 26) or above. If you are seeing this
-warning, you should update the `TargetFramrworkVersion` of your projects
+warning, you should update the `TargetFrameworkVersion` of your projects
 to be v8.0 or above.
+
+If you are not targeting the Google Play store and wish to hide these
+warnings you can make use of the `/nowarn:XA0114` command line switch. 
+Alternatively add
+
+    <NoWarn>XA0114</NoWarn>
+
+to your .csproj.
 
 [Google Play's target API level requirement](https://developer.android.com/distribute/best-practices/develop/target-sdk)

--- a/Documentation/guides/messages/xa0114.md
+++ b/Documentation/guides/messages/xa0114.md
@@ -1,0 +1,8 @@
+﻿# Compiler Warning XA0114
+
+As of November 1st 2018 any application update uploaded to the google play
+store needs to target v8.0 (API 26) or above. If you are seeing this
+warning, you should update the `TargetFramrworkVersion` of your projects
+to be v8.0 or above.
+
+[Google Play's target API level requirement](https://developer.android.com/distribute/best-practices/develop/target-sdk)

--- a/Documentation/guides/messages/xa0114.md
+++ b/Documentation/guides/messages/xa0114.md
@@ -2,7 +2,7 @@
 
 As of November 1st 2018 any application update uploaded to the google play
 store needs to target v8.0 (API 26) or above. If you are seeing this
-warning, you should update the `TargetFrameworkVersion` of your projects
+warning, you should update the `$(TargetFrameworkVersion)` of your projects
 to be v8.0 or above.
 
 If you are not targeting the Google Play store and wish to hide these

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -309,6 +309,16 @@ namespace Xamarin.Android.Tasks
 				return false;
 			}
 
+			int apiLevel;
+			var augustDeadline = new DateTime (2018, 8, 1);
+			var novemberDeadline = new DateTime (2018, 11, 1);
+			if (int.TryParse (AndroidApiLevel, out apiLevel)) {
+				if (apiLevel < 26 && DateTime.Now >= augustDeadline)
+					Log.LogCodedWarning ("XA0113", $"Google Play requires that new applications must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {TargetFrameworkVersion} (API level {AndroidApiLevel}).");
+				if (apiLevel < 26 && DateTime.Now >= novemberDeadline)
+					Log.LogCodedWarning ("XA0114", $"Google Play requires that application updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {TargetFrameworkVersion} (API level {AndroidApiLevel}).");
+			}
+
 			SequencePointsMode mode;
 			if (!Aot.TryGetSequencePointsMode (SequencePointsMode ?? "None", out mode))
 				Log.LogCodedError ("XA0104", "Invalid Sequence Point mode: {0}", SequencePointsMode);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -310,12 +310,10 @@ namespace Xamarin.Android.Tasks
 			}
 
 			int apiLevel;
-			var augustDeadline = new DateTime (2018, 8, 1);
-			var novemberDeadline = new DateTime (2018, 11, 1);
 			if (int.TryParse (AndroidApiLevel, out apiLevel)) {
-				if (apiLevel < 26 && DateTime.Now >= augustDeadline)
+				if (apiLevel < 26)
 					Log.LogCodedWarning ("XA0113", $"Google Play requires that new applications must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {TargetFrameworkVersion} (API level {AndroidApiLevel}).");
-				if (apiLevel < 26 && DateTime.Now >= novemberDeadline)
+				if (apiLevel < 26)
 					Log.LogCodedWarning ("XA0114", $"Google Play requires that application updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {TargetFrameworkVersion} (API level {AndroidApiLevel}).");
 			}
 


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/635168
Fixes https://github.com/xamarin/xamarin-android/issues/1766

Google as of August and November 2018 will required a minimum
of TargetFrameworkVersion v8.0 to publish/update apps.

This commit adds a new check to `ResolveSdksTask` which will
emit warnings when we hit those dates. This will only happen
if the `TargetFrameworkVersion` < `v8.0`

If you are not targeting the Google Play store and wish to hide these
warnings you can make use of the `/nowarn:XA0114,XA0113` command line switch. 
Alternatively add

    <NoWarn>XA0114;XA0113</NoWarn>

to your .csproj.

[1] [Google Play's target API level requirement](https://developer.android.com/distribute/best-practices/develop/target-sdk)