### PR TITLE
[tests] fix for launching emulator on Windows

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/StartAndroidEmulator.cs
@@ -62,7 +62,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				return;
 
 			var port = string.IsNullOrEmpty (Port) ? "" : $" -port {Port}";
-			var arguments = $"-verbose -avd {ImageName}{port}";
+			var arguments = $"-verbose -avd {ImageName}{port} -cache-size 512";
 			Log.LogMessage (MessageImportance.Low, $"Tool {emulator} execution started with arguments: {arguments}");
 			var psi = new ProcessStartInfo () {
 				FileName                = emulator,


### PR DESCRIPTION
Context: https://developer.android.com/studio/run/emulator-commandline

When attempting to use the emulator created from our build, on Windows
I commonly get an error such as:

    adb : error : failed to copy 'bin\TestDebug\Mono.Android_Tests-Signed.apk' to '/data/local/tmp/Mono.Android_Tests-Signed.apk': remote No space left on device [tests\RunApkTests.targets]

The issue seems to be there is not enough disk space allocated to
`/data/local/tmp/`.

When I look at the build log, where we start the emulator:

    [emulator stdout]   disk.cachePartition.size = 66m

It appears that only 66MB is allocated by default. I'm not sure how we
aren't hitting the same problem on other platforms.

If I add the flag `-cache-size 512`, I now see:

    [emulator stdout]   disk.cachePartition.size = 512m

And now I can properly install all of our test APKs.

_NOTE: I also had to delete my emulator when testing this change. It
appears the new setting does not help unless you create a fresh
emulator?_