### PR TITLE
[tests] fix for first launch of adb

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -28,7 +28,15 @@ namespace Xamarin.Android.Build.Tests
 				try {
 					var adbTarget = Environment.GetEnvironmentVariable ("ADB_TARGET");
 					int sdkVersion = -1;
-					HasDevices = int.TryParse (RunAdbCommand ($"{adbTarget} shell getprop ro.build.version.sdk").Trim (), out sdkVersion) && sdkVersion != -1;
+					var result = RunAdbCommand ($"{adbTarget} shell getprop ro.build.version.sdk");
+					if (result.Contains ("*")) {
+						//NOTE: We may get a result of:
+						//
+						//27* daemon not running; starting now at tcp:5037
+						//* daemon started successfully
+						result = result.Split ('*').First ().Trim ();
+					}
+					HasDevices = int.TryParse (result, out sdkVersion) && sdkVersion != -1;
 				} catch (Exception ex) {
 					Console.Error.WriteLine ("Failed to determine whether there is Android target emulator or not: " + ex);
 				}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/77cf939df5e6d3bf657cb191db819abc99b6957b

Since 77cf939, we have been killing adb after tests complete.

This causes an issue if you are running a test in an IDE that uses
`BaseTest.HasDevices`. The first run will likely work, but the second
one fails saying `Test Skipped no devices or emulators found.`.

If you run a test, and adb is not already running, consider the
following code:

    var result = RunAdbCommand ($"{adbTarget} shell getprop ro.build.version.sdk");

It will return with:

    27* daemon not running; starting now at tcp:5037
    * daemon started successfully

Since we pass the result to `int.TryParse`, we are treating the
command as if it had failed, meaning no devices were attached.

To make this more robust, we can split on the `*` character and take
the first item. This allows this command to work even if adb is being
launched for the first time.

Other changes:
- We also do not need to call `Trim ()` from the result of
  `RunAdbCommand` since it already calls `Trim ()`.