### PR TITLE
[Xamarin.ProjectTools] only save packages.config if it changes

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2039,6 +2039,11 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				Assert.IsTrue (b.Build (proj), "second build should have succeeded.");
 				var doc = File.ReadAllText (Path.Combine (b.Root, b.ProjectDirectory, proj.IntermediateOutputPath, "resourcepaths.cache"));
 				Assert.IsTrue (doc.Contains (Path.Combine ("Xamarin.Android.Support.v7.CardView", "24.2.1")), "CardView should be resolved as a reference.");
+
+				proj.MainActivity = proj.DefaultMainActivity.Replace ("clicks", "CLICKS");
+				proj.Touch ("MainActivity.cs");
+				Assert.IsTrue (b.Build (proj), "third build should have succeeded.");
+				Assert.IsTrue (b.Output.IsTargetSkipped ("_CleanIntermediateIfNuGetsChange"), "A build with no changes to NuGets should *not* trigger `_CleanIntermediateIfNuGetsChange`!");
 			}
 		}
 
@@ -2107,6 +2112,11 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				Assert.IsFalse (b.Output.IsTargetSkipped ("_CleanIntermediateIfNuGetsChange"), "`_CleanIntermediateIfNuGetsChange` should have run!");
 				FileAssert.Exists (nugetStamp, "`_CleanIntermediateIfNuGetsChange` did not create stamp file!");
 				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "Xamarin.Android.Support.v4.dll: extracted files are up to date"), "`ResolveLibraryProjectImports` should not skip `Xamarin.Android.Support.v4.dll`!");
+
+				proj.MainActivity = proj.MainActivity.Replace ("clicks", "CLICKS");
+				proj.Touch ("MainActivity.cs");
+				Assert.IsTrue (b.Build (proj), "third build should have succeeded.");
+				Assert.IsTrue (b.Output.IsTargetSkipped ("_CleanIntermediateIfNuGetsChange"), "A build with no changes to NuGets should *not* trigger `_CleanIntermediateIfNuGetsChange`!");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -140,6 +140,7 @@ namespace Xamarin.ProjectTools
 		}
 
 		string project_file_contents;
+		string packages_config_contents;
 
 		public virtual List<ProjectResource> Save (bool saveProject = true)
 		{
@@ -157,11 +158,16 @@ namespace Xamarin.ProjectTools
 			}
 
 			if (Packages.Any ()) {
+				var contents = "<packages>\n" + string.Concat (Packages.Select (p => string.Format ("  <package id='{0}' version='{1}' targetFramework='{2}' />\n",
+					p.Id, p.Version, p.TargetFramework))) + "</packages>";
+				var timestamp = contents != packages_config_contents ? default (DateTimeOffset?) : DateTimeOffset.MinValue;
 				list.Add (new ProjectResource () {
+					Timestamp = timestamp,
 					Path = "packages.config",
-					Content = "<packages>\n" + string.Concat (Packages.Select (p => string.Format ("  <package id='{0}' version='{1}' targetFramework='{2}' />\n",
-						p.Id, p.Version, p.TargetFramework))) + "</packages>"
+					Content = packages_config_contents = contents,
 				});
+			} else {
+				packages_config_contents = null;
 			}
 
 			foreach (var ig in ItemGroupList)


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/1878

The way `Xamarin.ProjectTools` saves `packages.config`, it would
accidentally trigger `_CleanIntermediateIfNuGetsChange`. It saves the
file *every* time, regardless if the contents changed or not. This
would play havoc with `_CleanIntermediateIfNuGetsChange` and cause it
to run when it shouldn't.

So I modeled what we are currently doing for conditionally saving the
project file. I keep the last `packages.config` contents around, and
make sure it only saves to disk if it changes. Using
`DateTimeOffSet.MinValue` as a `Timestamp` will prevent the file from
being written to disk.

I updated two tests to validate this change, which also adds some
additional validation to the `_CleanIntermediateIfNuGetsChange`
target.