### PR TITLE
[Xamarin.Android.Build.Tasks] _CleanIntermediateIfNuGetsChange deletes build.props

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2030,6 +2030,8 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 			};
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				Assert.IsTrue (b.Build (proj), "first build should have succeeded.");
+				string build_props = b.Output.GetIntermediaryPath ("build.props");
+				FileAssert.Exists (build_props, "build.props should exist after first build.");
 				proj.Packages.Add (KnownPackages.SupportV7CardView_24_2_1);
 				foreach (var reference in KnownPackages.SupportV7CardView_24_2_1.References) {
 					reference.Timestamp = DateTimeOffset.Now;
@@ -2039,11 +2041,13 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				Assert.IsTrue (b.Build (proj), "second build should have succeeded.");
 				var doc = File.ReadAllText (Path.Combine (b.Root, b.ProjectDirectory, proj.IntermediateOutputPath, "resourcepaths.cache"));
 				Assert.IsTrue (doc.Contains (Path.Combine ("Xamarin.Android.Support.v7.CardView", "24.2.1")), "CardView should be resolved as a reference.");
+				FileAssert.Exists (build_props, "build.props should exist after second build.");
 
 				proj.MainActivity = proj.DefaultMainActivity.Replace ("clicks", "CLICKS");
 				proj.Touch ("MainActivity.cs");
 				Assert.IsTrue (b.Build (proj), "third build should have succeeded.");
 				Assert.IsTrue (b.Output.IsTargetSkipped ("_CleanIntermediateIfNuGetsChange"), "A build with no changes to NuGets should *not* trigger `_CleanIntermediateIfNuGetsChange`!");
+				FileAssert.Exists (build_props, "build.props should exist after third build.");
 			}
 		}
 
@@ -2083,6 +2087,8 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 
 				var nugetStamp = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, proj.ProjectName + ".nuget.stamp");
 				FileAssert.Exists (nugetStamp, "`_CleanIntermediateIfNuGetsChange` did not create stamp file!");
+				string build_props = b.Output.GetIntermediaryPath ("build.props");
+				FileAssert.Exists (build_props, "build.props should exist after first build.");
 
 				if (!usePackageReference) {
 					foreach (var p in proj.Packages) {
@@ -2112,11 +2118,13 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				Assert.IsFalse (b.Output.IsTargetSkipped ("_CleanIntermediateIfNuGetsChange"), "`_CleanIntermediateIfNuGetsChange` should have run!");
 				FileAssert.Exists (nugetStamp, "`_CleanIntermediateIfNuGetsChange` did not create stamp file!");
 				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "Xamarin.Android.Support.v4.dll: extracted files are up to date"), "`ResolveLibraryProjectImports` should not skip `Xamarin.Android.Support.v4.dll`!");
+				FileAssert.Exists (build_props, "build.props should exist after second build.");
 
 				proj.MainActivity = proj.MainActivity.Replace ("clicks", "CLICKS");
 				proj.Touch ("MainActivity.cs");
 				Assert.IsTrue (b.Build (proj), "third build should have succeeded.");
 				Assert.IsTrue (b.Output.IsTargetSkipped ("_CleanIntermediateIfNuGetsChange"), "A build with no changes to NuGets should *not* trigger `_CleanIntermediateIfNuGetsChange`!");
+				FileAssert.Exists (build_props, "build.props should exist after third build.");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -519,13 +519,13 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <BuildDependsOn>
     _ValidateLinkMode;
     _SetupDesignTimeBuildForBuild;
+    _CleanIntermediateIfNuGetsChange;
     _CreatePropertiesCache;
     _CheckProjectItems;
     _CheckForContent;
     _CheckTargetFramework;
     _RemoveLegacyDesigner;
     _ValidateAndroidPackageProperties;
-    _CleanIntermediateIfNuGetsChange;
     $(BuildDependsOn);
     _CompileDex;
     $(_PostBuildTargets)
@@ -536,6 +536,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <BuildDependsOn>
     _ValidateLinkMode;
      _SetupDesignTimeBuildForBuild;
+    _CleanIntermediateIfNuGetsChange;
      _CreatePropertiesCache;
     _AddAndroidDefines;
     _AddNativeLibraryArchiveToCompile;
@@ -544,7 +545,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     _CheckTargetFramework;
     _RemoveLegacyDesigner;
     _ValidateAndroidPackageProperties;
-    _CleanIntermediateIfNuGetsChange;
     $(BuildDependsOn);
   </BuildDependsOn>
 </PropertyGroup>
@@ -657,6 +657,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     Inputs="$(_NuGetAssetsFile)"
     Outputs="$(_AndroidNuGetStampFile)">
   <CallTarget Targets="_CleanMonoAndroidIntermediateDir" />
+  <MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" />
   <Touch Files="$(_AndroidNuGetStampFile)" AlwaysCreate="true" />
   <ItemGroup>
     <FileWrites Include="$(_AndroidNuGetStampFile)" />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/1878

The initial `_CleanIntermediateIfNuGetsChange` target had a terrible
bug.

If you were building a project for the first time, due to the ordering
of targets:

    <BuildDependsOn>
        _ValidateLinkMode;
        _SetupDesignTimeBuildForBuild;
        _CreatePropertiesCache;
        _AddAndroidDefines;
        _AddNativeLibraryArchiveToCompile;
        _CheckTargetFramework;
        _RemoveLegacyDesigner;
        _ValidateAndroidPackageProperties;
        _CleanIntermediateIfNuGetsChange;
        $(BuildDependsOn);
    </BuildDependsOn>

`_CreatePropertiesCache` creates `build.props`, but then on a first
build `_CleanIntermediateIfNuGetsChange` runs and deletes it!

The fix here is to move `_CleanIntermediateIfNuGetsChange` ahead of
`_CreatePropertiesCache`--it does not appear that any other
intermediate files are created before this target.

I also updated the tests that validate
`_CleanIntermediateIfNuGetsChange` to make sure that `build.props`
exist.