### PR TITLE
[Mono.Android] Do not try to use new jni marshal methods yet

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -250,9 +250,6 @@ namespace Android.Runtime {
 
 		public override void RegisterNativeMembers (JniType jniType, Type type, string methods)
 		{
-			if (base.TryRegisterNativeMembers (jniType, type, methods))
-				return;
-
 			if (methods == null)
 				return;
 


### PR DESCRIPTION
The jnimarshalmethod-gen build infrastructure is not ready yet, so
for now we don't need to look for the registration methods.

The `TryRegisterNativeMembers` is quite slow and needs an update. See
https://github.com/xamarin/xamarin-android/issues/1898.