### PR TITLE
[build] fix for *new* TargetFrameworkVersion during nuget restore

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -16,6 +16,7 @@
     <!-- Used by the `build-tools/create-vsix` build so that `Mono.Android.Export.dll`/etc. are only included *once* -->
     <!-- Should correspond to the first value from `$(API_LEVELS)` in `build-tools/scripts/BuildEverything.mk` -->
     <AndroidFirstFrameworkVersion Condition="'$(AndroidFirstFrameworkVersion)' == ''">v2.3</AndroidFirstFrameworkVersion>
+    <_IsRunningNuGetRestore Condition="$(RestoreTaskAssemblyFile.EndsWith('NuGet.exe', StringComparison.InvariantCultureIgnoreCase))">True</_IsRunningNuGetRestore>
     <!-- *Latest* *stable* API level binding that we support; used when building src/Xamarin.Android.Build.Tasks -->
     <AndroidLatestStableApiLevel Condition="'$(AndroidLatestStableApiLevel)' == ''">28</AndroidLatestStableApiLevel>
     <AndroidLatestStablePlatformId Condition="'$(AndroidLatestStablePlatformId)' == ''">$(AndroidLatestStableApiLevel)</AndroidLatestStablePlatformId>
@@ -27,7 +28,8 @@
     <!-- The API level and TargetFrameworkVersion for the default Mono.Android.dll build -->
     <AndroidApiLevel Condition=" '$(AndroidApiLevel)' == '' ">$(AndroidLatestStableApiLevel)</AndroidApiLevel>
     <AndroidPlatformId Condition=" '$(AndroidPlatformId)' == '' ">$(AndroidLatestStablePlatformId)</AndroidPlatformId>
-    <AndroidFrameworkVersion Condition=" '$(AndroidFrameworkVersion)' == '' ">$(AndroidLatestStableFrameworkVersion)</AndroidFrameworkVersion>
+    <AndroidFrameworkVersion Condition=" '$(AndroidFrameworkVersion)' == '' And '$(_IsRunningNuGetRestore)' != 'True' ">$(AndroidLatestStableFrameworkVersion)</AndroidFrameworkVersion>
+    <AndroidUseLatestPlatformSdk Condition=" '$(AndroidFrameworkVersion)' == '' And '$(_IsRunningNuGetRestore)' == 'True' ">True</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
   <PropertyGroup>
     <AutoProvision Condition=" '$(AutoProvision)' == '' ">False</AutoProvision>


### PR DESCRIPTION
Context: http://build.devdiv.io/1820059

Since f9a7cfc, NuGet restore has been failing for `Xamarin.Android-Tests.sln`:

    Error XA0000: Could not determine API level for $(TargetFrameworkVersion) of 'v9.0'. [E:\A\_work\2\s\src\Mono.Android\Test\Mono.Android-Tests.csproj]

When running:

    .nuget\NuGet.exe restore Xamarin.Android-Tests.sln -Verbosity Detailed

There is a little more insight into how NuGet works:

    C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\bin\msbuild.exe
        "C:\Users\myuser\AppData\Local\Temp\NuGetScratch\rh0oot0c.d22.nugetinputs.targets"
        /t:GenerateRestoreGraphFile /nologo /nr:false /v:q
        /p:NuGetRestoreTargets="C:\Users\myuser\AppData\Local\Temp\NuGetScratch\zzcd4yd1.a0q.nugetrestore.targets"
        /p:RestoreUseCustomAfterTargets="True"
        /p:RestoreTaskAssemblyFile="C:\Users\myuser\Desktop\Git\xamarin-android\.nuget\NuGet.exe"
        /p:RestoreSolutionDirectory="C:\Users\myuser\Desktop\Git\xamarin-android"
        /p:SolutionDir="C:\Users\myuser\Desktop\Git\xamarin-android"
        /p:RestoreBuildInParallel="False" /p:RestoreUseSkipNonexistentTargets="False"

Apparently this targets file:

https://github.com/NuGet/NuGet.Client/blob/5244dc7596f0cc0ed65984dc8c040d23b0e9c09b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets

Is extracted and invoked through MSBuild.

Then `<ResolveSdks />` from the system install fails, because it does
not know what `TargetFrameworkVersion=v9.0` is yet!

So a "hacky" solution is:
- Don't set `TargetFrameworkVersion` if NuGet is running
- Set `AndroidUseLatestPlatformSdk=True` instead

We can detect if NuGet is running by using a property from the above
command:

    <_IsRunningNuGetRestore Condition="$(RestoreTaskAssemblyFile.EndsWith('NuGet.exe', StringComparison.InvariantCultureIgnoreCase))">True</_IsRunningNuGetRestore>

By leaving `AndroidFrameworkVersion` blank in `Configuration.props`,
it fixes `TargetFrameworkVersion` in our projects, because they do
this:

    <Import Project="..\..\..\Configuration.props" />
    <PropertyGroup>
      <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
    </PropertyGroup>