### PR TITLE
[Xamarin.Android.Build.Tests] Dont kill adb when debugging.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -45,6 +45,9 @@ namespace Xamarin.Android.Build.Tests
 			[OneTimeTearDown]
 			public void AfterAllTests ()
 			{
+				if (System.Diagnostics.Debugger.IsAttached)
+					return;
+
 				//NOTE: adb.exe can cause a couple issues on Windows
 				//	1) it holds a lock on ~/android-toolchain, so a future build that needs to delete/recreate would fail
 				//	2) the MSBuild <Exec /> task *can* hang until adb.exe exits


### PR DESCRIPTION
When we are debugging tests we don't want to kill `adb` after
the tests. This is so we can re-run tests without having to
run

	adb start-server

every time.