### PR TITLE
[Xamarin.Android.Build.Tasks] Fix `UpdateGeneratedFiles` to depend on `ResolveAssemblyReferences`.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -604,7 +604,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </Target>
 
 <Target Name="UpdateGeneratedFiles"
-		DependsOnTargets="_RemoveLegacyDesigner;UpdateAndroidResources"
+		DependsOnTargets="ResolveAssemblyReferences;_RemoveLegacyDesigner;UpdateAndroidResources"
 	>
 </Target>
 


### PR DESCRIPTION
After a ton of debugging under VS2017 I finally nailed down
one of the problems which cause

	error APT0000: No resource found that matches the given name (at 'resource_name' with value '@string/foo').

When a user modifies a layout file we now call `UpdatedGeneratedFiles`
automatically to regenerate the designer files. The problem is that
sometimes both `@(ReferencePath)` and `@(ReferenceDependencyPaths)`
are completely empty. But not all the time. It seems that `msbuild`
provides those items *most* of the time.. but not ALL of the time.
As a result what happens is we end up with a `libraryprojectimports.cache`
file which contains ONLY `.jar` files references. It has no values
for `ResolvedResourceDirectories`, `ResolvedAssetDirectories` or
`ResolvedResourceDirectoryStamps`. The result is `aapt` cannot find
any of the support library resources.

I could not repo this issue from the command line, so I suspect its
something to do with the IDE build system.

So the fix is to make `UpdatedGeneratedFiles` depend on
`ResolveAssemblyReferences`. This way we can make sure those
item groups are populated with the required values before we
try to refresh the library cache.