### PR TITLE
[Xamarin.Android.Build.Tasks] refactor/split up ResolveSdks

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
@@ -1,0 +1,382 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Linq;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Globalization;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// ResolveAndroidTooling does lot of the grunt work ResolveSdks used to do:
+	/// - Modify TargetFrameworkVersion
+	/// - Calculate ApiLevel and ApiLevelName
+	/// - Find the paths of various Android tooling that other tasks need to call
+	/// </summary>
+	public class ResolveAndroidTooling : Task
+	{
+		public string AndroidNdkPath { get; set; }
+
+		public string AndroidSdkPath { get; set; }
+
+		public string AndroidSdkBuildToolsVersion { get; set; }
+
+		public string ProjectFilePath { get; set; }
+
+		public string SequencePointsMode { get; set; }
+
+		public bool UseLatestAndroidPlatformSdk { get; set; }
+
+		public bool AotAssemblies { get; set; }
+
+		[Output]
+		public string TargetFrameworkVersion { get; set; }
+
+		[Output]
+		public string AndroidApiLevel { get; set; }
+
+		[Output]
+		public string AndroidApiLevelName { get; set; }
+
+		[Output]
+		public string SupportedApiLevel { get; set; }
+
+		[Output]
+		public string AndroidSdkBuildToolsPath { get; set; }
+
+		[Output]
+		public string AndroidSdkBuildToolsBinPath { get; set; }
+
+		[Output]
+		public string ZipAlignPath { get; set; }
+
+		[Output]
+		public string AndroidSequencePointsMode { get; set; }
+
+		[Output]
+		public string LintToolPath { get; set; }
+
+		[Output]
+		public string ApkSignerJar { get; set; }
+
+		[Output]
+		public bool AndroidUseApkSigner { get; set; }
+
+		[Output]
+		public bool AndroidUseAapt2 { get; set; }
+
+		[Output]
+		public string Aapt2Version { get; set; }
+
+		static readonly bool IsWindows = Path.DirectorySeparatorChar == '\\';
+		static readonly string ZipAlign = IsWindows ? "zipalign.exe" : "zipalign";
+		static readonly string Aapt = IsWindows ? "aapt.exe" : "aapt";
+		static readonly string Aapt2 = IsWindows ? "aapt2.exe" : "aapt2";
+		static readonly string Android = IsWindows ? "android.bat" : "android";
+		static readonly string Lint = IsWindows ? "lint.bat" : "lint";
+		static readonly string ApkSigner = "apksigner.jar";
+
+		public override bool Execute ()
+		{
+			string toolsZipAlignPath = Path.Combine (AndroidSdkPath, "tools", ZipAlign);
+			bool findZipAlign = (string.IsNullOrEmpty (ZipAlignPath) || !Directory.Exists (ZipAlignPath)) && !File.Exists (toolsZipAlignPath);
+
+			var lintPaths = new string [] {
+				LintToolPath ?? string.Empty,
+				Path.Combine (AndroidSdkPath, "tools"),
+				Path.Combine (AndroidSdkPath, "tools", "bin"),
+			};
+
+			LintToolPath = null;
+			foreach (var path in lintPaths) {
+				if (File.Exists (Path.Combine (path, Lint))) {
+					LintToolPath = path;
+					break;
+				}
+			}
+
+			foreach (var dir in MonoAndroidHelper.AndroidSdk.GetBuildToolsPaths (AndroidSdkBuildToolsVersion)) {
+				Log.LogDebugMessage ("Trying build-tools path: {0}", dir);
+				if (dir == null || !Directory.Exists (dir))
+					continue;
+
+				var toolsPaths = new string [] {
+					Path.Combine (dir),
+					Path.Combine (dir, "bin"),
+				};
+
+				string aapt = toolsPaths.FirstOrDefault (x => File.Exists (Path.Combine (x, Aapt)));
+				if (string.IsNullOrEmpty (aapt)) {
+					Log.LogDebugMessage ("Could not find `{0}`; tried: {1}", Aapt,
+						string.Join (Path.PathSeparator.ToString (), toolsPaths.Select (x => Path.Combine (x, Aapt))));
+					continue;
+				}
+				AndroidSdkBuildToolsPath = Path.GetFullPath (dir);
+				AndroidSdkBuildToolsBinPath = Path.GetFullPath (aapt);
+
+				string zipalign = toolsPaths.FirstOrDefault (x => File.Exists (Path.Combine (x, ZipAlign)));
+				if (findZipAlign && string.IsNullOrEmpty (zipalign)) {
+					Log.LogDebugMessage ("Could not find `{0}`; tried: {1}", ZipAlign,
+						string.Join (Path.PathSeparator.ToString (), toolsPaths.Select (x => Path.Combine (x, ZipAlign))));
+					continue;
+				} else
+					break;
+			}
+
+			if (string.IsNullOrEmpty (AndroidSdkBuildToolsPath)) {
+				Log.LogCodedError ("XA5205",
+						string.Format (
+							"Cannot find `{0}`. Please install the Android SDK Build-tools package with the `{1}{2}tools{2}{3}` program.",
+							Aapt, AndroidSdkPath, Path.DirectorySeparatorChar, Android));
+				return false;
+			}
+
+			ApkSignerJar = Path.Combine (AndroidSdkBuildToolsBinPath, "lib", ApkSigner);
+			AndroidUseApkSigner = File.Exists (ApkSignerJar);
+
+			bool aapt2Installed = File.Exists (Path.Combine (AndroidSdkBuildToolsBinPath, Aapt2));
+			if (aapt2Installed && AndroidUseAapt2) {
+				if (!GetAapt2Version ()) {
+					AndroidUseAapt2 = false;
+					aapt2Installed = false;
+					Log.LogCodedWarning ("XA0111", "Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.");
+				}
+			}
+			if (AndroidUseAapt2) {
+				if (!aapt2Installed) {
+					AndroidUseAapt2 = false;
+					Log.LogCodedWarning ("XA0112", "`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.");
+				}
+			}
+
+			if (string.IsNullOrEmpty (ZipAlignPath) || !Directory.Exists (ZipAlignPath)) {
+				ZipAlignPath = new [] {
+						Path.Combine (AndroidSdkBuildToolsPath),
+						Path.Combine (AndroidSdkBuildToolsBinPath),
+						Path.Combine (AndroidSdkPath, "tools"),
+					}
+					.Where (p => File.Exists (Path.Combine (p, ZipAlign)))
+					.FirstOrDefault ();
+			}
+			if (string.IsNullOrEmpty (ZipAlignPath)) {
+				Log.LogCodedError ("XA5205",
+						string.Format (
+							"Cannot find `{0}`. Please install the Android SDK Build-tools package with the `{1}{2}tools{2}{3}` program.",
+							ZipAlign, AndroidSdkPath, Path.DirectorySeparatorChar, Android));
+				return false;
+			}
+
+			if (!ValidateApiLevels ())
+				return false;
+
+			if (!MonoAndroidHelper.SupportedVersions.FrameworkDirectories.Any (p => Directory.Exists (Path.Combine (p, TargetFrameworkVersion)))) {
+				Log.LogError (
+					subcategory: string.Empty,
+					errorCode: "XA0001",
+					helpKeyword: string.Empty,
+					file: ProjectFilePath,
+					lineNumber: 0,
+					columnNumber: 0,
+					endLineNumber: 0,
+					endColumnNumber: 0,
+					message: "Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.",
+					messageArgs: new []{
+						TargetFrameworkVersion,
+					}
+				);
+				return false;
+			}
+
+			int apiLevel;
+			if (int.TryParse (AndroidApiLevel, out apiLevel)) {
+				if (apiLevel < 26)
+					Log.LogCodedWarning ("XA0113", $"Google Play requires that new applications must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {TargetFrameworkVersion} (API level {AndroidApiLevel}).");
+				if (apiLevel < 26)
+					Log.LogCodedWarning ("XA0114", $"Google Play requires that application updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {TargetFrameworkVersion} (API level {AndroidApiLevel}).");
+			}
+
+			SequencePointsMode mode;
+			if (!Aot.TryGetSequencePointsMode (SequencePointsMode ?? "None", out mode))
+				Log.LogCodedError ("XA0104", "Invalid Sequence Point mode: {0}", SequencePointsMode);
+			AndroidSequencePointsMode = mode.ToString ();
+
+			AndroidApiLevelName = MonoAndroidHelper.SupportedVersions.GetIdFromApiLevel (AndroidApiLevel);
+
+			Log.LogDebugMessage ($"{nameof (ResolveAndroidTooling)} Outputs:");
+			Log.LogDebugMessage ($"  {nameof (TargetFrameworkVersion)}: {TargetFrameworkVersion}");
+			Log.LogDebugMessage ($"  {nameof (AndroidApiLevel)}: {AndroidApiLevel}");
+			Log.LogDebugMessage ($"  {nameof (AndroidApiLevelName)}: {AndroidApiLevelName}");
+			Log.LogDebugMessage ($"  {nameof (SupportedApiLevel)}: {SupportedApiLevel}");
+			Log.LogDebugMessage ($"  {nameof (AndroidSdkBuildToolsPath)}: {AndroidSdkBuildToolsPath}");
+			Log.LogDebugMessage ($"  {nameof (AndroidSdkBuildToolsBinPath)}: {AndroidSdkBuildToolsBinPath}");
+			Log.LogDebugMessage ($"  {nameof (ZipAlignPath)}: {ZipAlignPath}");
+			Log.LogDebugMessage ($"  {nameof (AndroidSequencePointsMode)}: {AndroidSequencePointsMode}");
+			Log.LogDebugMessage ($"  {nameof (LintToolPath)}: {LintToolPath}");
+			Log.LogDebugMessage ($"  {nameof (ApkSignerJar)}: {ApkSignerJar}");
+			Log.LogDebugMessage ($"  {nameof (AndroidUseApkSigner)}: {AndroidUseApkSigner}");
+			Log.LogDebugMessage ($"  {nameof (AndroidUseAapt2)}: {AndroidUseAapt2}");
+			Log.LogDebugMessage ($"  {nameof (Aapt2Version)}: {Aapt2Version}");
+
+			return !Log.HasLoggedErrors;
+		}
+
+		//  Android Asset Packaging Tool (aapt) 2:19
+		static readonly Regex Aapt2VersionRegex = new Regex (@"(?<version>[\d\:]+)(\d+)?");
+
+		bool GetAapt2Version ()
+		{
+			var sb = new StringBuilder ();
+			var aapt2Tool = Path.Combine (AndroidSdkBuildToolsBinPath, Aapt2);
+			try {
+				MonoAndroidHelper.RunProcess (aapt2Tool, "version", (s, e) => {
+					if (!string.IsNullOrEmpty (e.Data))
+						sb.AppendLine (e.Data);
+				}, (s, e) => {
+					if (!string.IsNullOrEmpty (e.Data))
+						sb.AppendLine (e.Data);
+				}
+				);
+			} catch (Exception ex) {
+				Log.LogWarningFromException (ex);
+				return false;
+			}
+			var versionInfo = sb.ToString ();
+			var versionNumberMatch = Aapt2VersionRegex.Match (versionInfo);
+			Log.LogDebugMessage ($"`{aapt2Tool} version` returned: ```{versionInfo}```");
+			if (versionNumberMatch.Success && Version.TryParse (versionNumberMatch.Groups ["version"]?.Value.Replace (":", "."), out Version versionNumber)) {
+				Aapt2Version = versionNumber.ToString ();
+				return true;
+			}
+			return false;
+		}
+
+		bool ValidateApiLevels ()
+		{
+			// Priority:
+			//    $(UseLatestAndroidPlatformSdk) > $(AndroidApiLevel) > $(TargetFrameworkVersion)
+			//
+			// If $(TargetFrameworkVersion) isn't set, and $(AndroidApiLevel) isn't
+			// set, act as if $(UseLatestAndroidPlatformSdk) is True
+			//
+			// If $(UseLatestAndroidPlatformSdk) is true, we do as it says: use the
+			// latest installed version.
+			//
+			// Otherwise, if $(AndroidApiLevel) is set, use it and set $(TargetFrameworkVersion).
+			//    Rationale: monodroid/samples/xbuild.make uses $(AndroidApiLevel)
+			//    to build for a specific API level.
+			// Otherwise, if $(TargetFrameworkVersion) is set, use it and set $(AndroidApiLevel).
+
+			UseLatestAndroidPlatformSdk = UseLatestAndroidPlatformSdk ||
+				(string.IsNullOrWhiteSpace (AndroidApiLevel) && string.IsNullOrWhiteSpace (TargetFrameworkVersion));
+
+			if (UseLatestAndroidPlatformSdk) {
+				AndroidApiLevel = GetMaxInstalledApiLevel ().ToString ();
+				SupportedApiLevel = GetMaxStableApiLevel ().ToString ();
+				int maxInstalled, maxSupported = 0;
+				if (int.TryParse (AndroidApiLevel, out maxInstalled) && int.TryParse (SupportedApiLevel, out maxSupported) && maxInstalled > maxSupported) {
+					Log.LogDebugMessage ($"API Level {AndroidApiLevel} is greater than the maximum supported API level of {SupportedApiLevel}. " +
+						"Support for this API will be added in a future release.");
+					AndroidApiLevel = SupportedApiLevel;
+				}
+				if (!string.IsNullOrWhiteSpace (TargetFrameworkVersion)) {
+					var userSelected = MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (TargetFrameworkVersion);
+					// overwrite using user version only if it is 
+					// above the maxStableApi and a valid apiLevel.
+					if (userSelected != null && userSelected > maxSupported && userSelected <= maxInstalled) {
+						AndroidApiLevel = userSelected.ToString ();
+						SupportedApiLevel = userSelected.ToString ();
+					}
+				}
+				TargetFrameworkVersion = GetTargetFrameworkVersionFromApiLevel ();
+				return TargetFrameworkVersion != null;
+			}
+
+			if (!string.IsNullOrWhiteSpace (TargetFrameworkVersion)) {
+				TargetFrameworkVersion = TargetFrameworkVersion.Trim ();
+				string id = MonoAndroidHelper.SupportedVersions.GetIdFromFrameworkVersion (TargetFrameworkVersion);
+				if (id == null) {
+					Log.LogCodedError ("XA0000",
+							"Could not determine API level for $(TargetFrameworkVersion) of '{0}'.",
+							TargetFrameworkVersion);
+					return false;
+				}
+				AndroidApiLevel = MonoAndroidHelper.SupportedVersions.GetApiLevelFromId (id).ToString ();
+				SupportedApiLevel = AndroidApiLevel;
+				return true;
+			}
+
+			if (!string.IsNullOrWhiteSpace (AndroidApiLevel)) {
+				AndroidApiLevel = AndroidApiLevel.Trim ();
+				SupportedApiLevel = GetMaxSupportedApiLevel (AndroidApiLevel);
+				TargetFrameworkVersion = GetTargetFrameworkVersionFromApiLevel ();
+				return TargetFrameworkVersion != null;
+			}
+
+			Log.LogCodedError ("XA0000", "Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); SHOULD NOT BE REACHED.");
+			return false;
+		}
+
+		int GetMaxInstalledApiLevel ()
+		{
+			string platformsDir = Path.Combine (AndroidSdkPath, "platforms");
+			var apiIds = Directory.EnumerateDirectories (platformsDir)
+				.Select (platformDir => Path.GetFileName (platformDir))
+				.Where (dir => dir.StartsWith ("android-", StringComparison.OrdinalIgnoreCase))
+				.Select (dir => dir.Substring ("android-".Length))
+				.Select (apiName => MonoAndroidHelper.SupportedVersions.GetIdFromApiLevel (apiName));
+			int maxApiLevel = int.MinValue;
+			foreach (var id in apiIds) {
+				int? v = MonoAndroidHelper.SupportedVersions.GetApiLevelFromId (id);
+				if (!v.HasValue)
+					continue;
+				maxApiLevel = Math.Max (maxApiLevel, v.Value);
+			}
+			if (maxApiLevel < 0)
+				Log.LogCodedError ("XA5300",
+						"No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.",
+						platformsDir, Path.DirectorySeparatorChar, Android);
+			return maxApiLevel;
+		}
+
+		int GetMaxStableApiLevel ()
+		{
+			return MonoAndroidHelper.SupportedVersions.MaxStableVersion.ApiLevel;
+		}
+
+		string GetMaxSupportedApiLevel (string apiLevel)
+		{
+			int level = 0;
+			if (!int.TryParse (apiLevel, NumberStyles.Integer, CultureInfo.InvariantCulture, out level))
+				return apiLevel;
+			var referenceAssemblyPaths = MonoAndroidHelper.TargetFrameworkDirectories;
+			if (referenceAssemblyPaths == null)
+				return apiLevel;
+			foreach (string versionedDir in referenceAssemblyPaths) {
+				string parent = Path.GetDirectoryName (versionedDir.TrimEnd (Path.DirectorySeparatorChar));
+				for (int l = level; l > 0; l--) {
+					string tfv = MonoAndroidHelper.SupportedVersions.GetFrameworkVersionFromApiLevel (l);
+					if (tfv == null)
+						continue;
+					string dir = Path.Combine (parent, tfv);
+					if (Directory.Exists (dir))
+						return l.ToString ();
+				}
+			}
+			return apiLevel;
+		}
+
+		string GetTargetFrameworkVersionFromApiLevel ()
+		{
+			string targetFramework = MonoAndroidHelper.SupportedVersions.GetFrameworkVersionFromId (SupportedApiLevel) ??
+				MonoAndroidHelper.SupportedVersions.GetFrameworkVersionFromId (AndroidApiLevel);
+			if (targetFramework != null)
+				return targetFramework;
+			Log.LogCodedError ("XA0000",
+					"Could not determine $(TargetFrameworkVersion) for API level '{0}.'",
+					AndroidApiLevel);
+			return null;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -26,66 +26,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Text;
-using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
-using Xamarin.Android.Tools;
-using System.Xml.Linq;
-using Xamarin.Android.Tools;
-using System.Text.RegularExpressions;
+using Microsoft.Build.Utilities;
+using System;
+using System.IO;
 
 namespace Xamarin.Android.Tasks
 {
+	/// <summary>
+	/// ResolveSdks' job is to call RefreshAndroidSdk and setup static members of MonoAndroidHelper
+	/// </summary>
 	public class ResolveSdks : Task
 	{
-		[Output]
-		public string AndroidApiLevel { get; set; }
-
-		[Output]
-		public string AndroidApiLevelName { get; set; }
-
-		[Output]
-		public string SupportedApiLevel { get; set; }
-
-		public string AndroidSdkBuildToolsVersion { get; set; }
-
-		public string BuildingInsideVisualStudio { get; set; }
-
-		public string ProjectFilePath             { get; set; }
-		public bool   UseLatestAndroidPlatformSdk { get; set; }
-		public bool   AotAssemblies               { get; set; }
-
-		public string JavaToolExe { get; set; }
-		public string JavacToolExe { get; set; }
-
-		public string LatestSupportedJavaVersion { get; set; }
-
-		public string MinimumSupportedJavaVersion { get; set; }
-
-		[Output]
 		public string[] ReferenceAssemblyPaths { get; set; }
-
-		public string CacheFile { get; set;}
-
-		public string SequencePointsMode { get; set;}
-
-		[Output]
-		public string TargetFrameworkVersion { get; set; }
-
-		[Output]
-		public string MonoAndroidToolsPath { get; set; }
-
-		[Output]
-		public string MonoAndroidBinPath { get; set; }
-
-		[Output]
-		public string MonoAndroidIncludePath { get; set; }
 
 		[Output]
 		public string AndroidNdkPath { get; set; }
@@ -97,70 +50,13 @@ namespace Xamarin.Android.Tasks
 		public string JavaSdkPath { get; set; }
 
 		[Output]
-		public string AndroidSdkBuildToolsPath { get; set; }
+		public string MonoAndroidToolsPath { get; set; }
 
 		[Output]
-		public string AndroidSdkBuildToolsBinPath { get; set; }
-
-		[Output]
-		public string ZipAlignPath { get; set; }
-
-		[Output]
-		public string AndroidSequencePointsMode { get; set; }
-
-		[Output]
-		public string LintToolPath { get; set; }
-
-		[Output]
-		public string ApkSignerJar { get; set; }
-
-		[Output]
-		public bool AndroidUseApkSigner { get; set; }
-
-		[Output]
-		public bool AndroidUseAapt2 { get; set; }
-
-		[Output]
-		public string Aapt2Version { get; set; }
-
-		[Output]
-		public string JdkVersion { get; set; }
-
-		[Output]
-		public string MinimumRequiredJdkVersion { get; set; }
-
-		static bool             IsWindows = Path.DirectorySeparatorChar == '\\';
-		static readonly string  ZipAlign  = IsWindows ? "zipalign.exe" : "zipalign";
-		static readonly string  Aapt      = IsWindows ? "aapt.exe" : "aapt";
-		static readonly string  Aapt2      = IsWindows ? "aapt2.exe" : "aapt2";
-		static readonly string  Android   = IsWindows ? "android.bat" : "android";
-		static readonly string  Lint      = IsWindows ? "lint.bat" : "lint";
-		static readonly string  ApkSigner = "apksigner.jar";
-
+		public string MonoAndroidBinPath { get; set; }
 
 		public override bool Execute ()
 		{
-			try {
-				return RunTask();
-			}
-			finally {
-			}
-		}
-
-		public bool RunTask ()
-		{
-			Log.LogDebugMessage ("ResolveSdksTask:");
-			Log.LogDebugMessage ("  AndroidApiLevel: {0}", AndroidApiLevel);
-			Log.LogDebugMessage ("  AndroidSdkBuildToolsVersion: {0}", AndroidSdkBuildToolsVersion);
-			Log.LogDebugMessage ($"  {nameof (AndroidSdkPath)}: {AndroidSdkPath}");
-			Log.LogDebugMessage ($"  {nameof (AndroidNdkPath)}: {AndroidNdkPath}");
-			Log.LogDebugMessage ($"  {nameof (JavaSdkPath)}: {JavaSdkPath}");
-			Log.LogDebugTaskItems ("  ReferenceAssemblyPaths: ", ReferenceAssemblyPaths);
-			Log.LogDebugMessage ("  TargetFrameworkVersion: {0}", TargetFrameworkVersion);
-			Log.LogDebugMessage ("  UseLatestAndroidPlatformSdk: {0}", UseLatestAndroidPlatformSdk);
-			Log.LogDebugMessage ("  SequencePointsMode: {0}", SequencePointsMode);
-			Log.LogDebugMessage ("  LintToolPath: {0}", LintToolPath);
-
 			// OS X:    $prefix/lib/xamarin.android/xbuild/Xamarin/Android
 			// Windows: %ProgramFiles(x86)%\MSBuild\Xamarin\Android
 			if (string.IsNullOrEmpty (MonoAndroidToolsPath)) {
@@ -183,9 +79,9 @@ namespace Xamarin.Android.Tasks
 				return false;
 			}
 
-			this.AndroidNdkPath = MonoAndroidHelper.AndroidSdk.AndroidNdkPath;
-			this.AndroidSdkPath = MonoAndroidHelper.AndroidSdk.AndroidSdkPath;
-			this.JavaSdkPath    = MonoAndroidHelper.AndroidSdk.JavaSdkPath;
+			AndroidNdkPath = MonoAndroidHelper.AndroidSdk.AndroidNdkPath;
+			AndroidSdkPath = MonoAndroidHelper.AndroidSdk.AndroidSdkPath;
+			JavaSdkPath    = MonoAndroidHelper.AndroidSdk.JavaSdkPath;
 
 			if (string.IsNullOrEmpty (AndroidSdkPath)) {
 				Log.LogCodedError ("XA5300", "The Android SDK Directory could not be found. Please set via /p:AndroidSdkDirectory.");
@@ -196,430 +92,17 @@ namespace Xamarin.Android.Tasks
 				return false;
 			}
 
-			if (!ValidateJavaVersion (TargetFrameworkVersion, AndroidSdkBuildToolsVersion))
-				return false;
-
-			string toolsZipAlignPath = Path.Combine (AndroidSdkPath, "tools", ZipAlign);
-			bool findZipAlign = (string.IsNullOrEmpty (ZipAlignPath) || !Directory.Exists (ZipAlignPath)) && !File.Exists (toolsZipAlignPath);
-
-			var lintPaths = new string [] {
-				LintToolPath ?? string.Empty,
-				Path.Combine (AndroidSdkPath, "tools"),
-				Path.Combine (AndroidSdkPath, "tools", "bin"),
-			};
-
-			LintToolPath = null;
-			foreach ( var path in lintPaths) {
-				if (File.Exists (Path.Combine (path, Lint))) {
-					LintToolPath = path;
-					break;
-				}
-			}
-
-			foreach (var dir in MonoAndroidHelper.AndroidSdk.GetBuildToolsPaths (AndroidSdkBuildToolsVersion)) {
-				Log.LogDebugMessage ("Trying build-tools path: {0}", dir);
-				if (dir == null || !Directory.Exists (dir))
-					continue;
-
-				var toolsPaths = new string[] {
-					Path.Combine (dir),
-					Path.Combine (dir, "bin"), 
-				};
-					
-				string aapt = toolsPaths.FirstOrDefault (x => File.Exists (Path.Combine (x, Aapt)));
-				if (string.IsNullOrEmpty (aapt)) {
-					Log.LogDebugMessage ("Could not find `{0}`; tried: {1}", Aapt,
-						string.Join (";", toolsPaths.Select (x => Path.Combine (x, Aapt))));
-					continue;
-				}
-				AndroidSdkBuildToolsPath = Path.GetFullPath (dir);
-				AndroidSdkBuildToolsBinPath = Path.GetFullPath (aapt);
-
-				string zipalign = toolsPaths.FirstOrDefault (x => File.Exists (Path.Combine (x, ZipAlign)));
-				if (findZipAlign && string.IsNullOrEmpty (zipalign)) {
-					Log.LogDebugMessage ("Could not find `{0}`; tried: {1}", ZipAlign,
-						string.Join (";", toolsPaths.Select (x => Path.Combine (x, ZipAlign))));
-					continue;
-				}
-				else
-					break;
-			}
-
-			if (string.IsNullOrEmpty (AndroidSdkBuildToolsPath)) {
-				Log.LogCodedError ("XA5205",
-						string.Format (
-							"Cannot find `{0}`. Please install the Android SDK Build-tools package with the `{1}{2}tools{2}{3}` program.",
-							Aapt, AndroidSdkPath, Path.DirectorySeparatorChar, Android));
-				return false;
-			}
-
-			ApkSignerJar = Path.Combine (AndroidSdkBuildToolsBinPath, "lib", ApkSigner);
-			AndroidUseApkSigner = File.Exists (ApkSignerJar);
-
-			bool aapt2Installed = File.Exists (Path.Combine (AndroidSdkBuildToolsBinPath, Aapt2));
-			if (aapt2Installed && AndroidUseAapt2) {
-				if (!GetAapt2Version ()) {
-					AndroidUseAapt2 = false;
-					aapt2Installed = false;
-					Log.LogCodedWarning ("XA0111", "Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.");
-				}
-			}
-			if (AndroidUseAapt2) {
-				if (!aapt2Installed) {
-					AndroidUseAapt2 = false;
-					Log.LogCodedWarning ("XA0112", "`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.");
-				}
-			}
-
-			if (string.IsNullOrEmpty (ZipAlignPath) || !Directory.Exists (ZipAlignPath)) {
-				ZipAlignPath = new[]{
-					Path.Combine (AndroidSdkBuildToolsPath),
-					Path.Combine (AndroidSdkBuildToolsBinPath),
-					Path.Combine (AndroidSdkPath, "tools"),
-				}
-					.Where (p => File.Exists (Path.Combine (p, ZipAlign)))
-					.FirstOrDefault ();
-			}
-			if (string.IsNullOrEmpty (ZipAlignPath)) {
-				Log.LogCodedError ("XA5205",
-						string.Format (
-							"Cannot find `{0}`. Please install the Android SDK Build-tools package with the `{1}{2}tools{2}{3}` program.",
-							ZipAlign, AndroidSdkPath, Path.DirectorySeparatorChar, Android));
-				return false;
-			}
-
-			if (!ValidateApiLevels ())
-				return false;
-
-			if (!MonoAndroidHelper.SupportedVersions.FrameworkDirectories.Any (p => Directory.Exists (Path.Combine (p, TargetFrameworkVersion)))) {
-				Log.LogError (
-					subcategory:      string.Empty,
-					errorCode:        "XA0001",
-					helpKeyword:      string.Empty,
-					file:             ProjectFilePath,
-					lineNumber:       0,
-					columnNumber:     0,
-					endLineNumber:    0,
-					endColumnNumber:  0,
-					message:          "Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.",
-					messageArgs:      new[]{
-						TargetFrameworkVersion,
-					}
-				);
-				return false;
-			}
-
-			int apiLevel;
-			if (int.TryParse (AndroidApiLevel, out apiLevel)) {
-				if (apiLevel < 26)
-					Log.LogCodedWarning ("XA0113", $"Google Play requires that new applications must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {TargetFrameworkVersion} (API level {AndroidApiLevel}).");
-				if (apiLevel < 26)
-					Log.LogCodedWarning ("XA0114", $"Google Play requires that application updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {TargetFrameworkVersion} (API level {AndroidApiLevel}).");
-			}
-
-			SequencePointsMode mode;
-			if (!Aot.TryGetSequencePointsMode (SequencePointsMode ?? "None", out mode))
-				Log.LogCodedError ("XA0104", "Invalid Sequence Point mode: {0}", SequencePointsMode);
-			AndroidSequencePointsMode = mode.ToString ();
-
 			MonoAndroidHelper.TargetFrameworkDirectories = ReferenceAssemblyPaths;
 
-			AndroidApiLevelName = MonoAndroidHelper.SupportedVersions.GetIdFromApiLevel (AndroidApiLevel);
-
-			Log.LogDebugMessage ("ResolveSdksTask Outputs:");
-			Log.LogDebugMessage ("  AndroidApiLevel: {0}", AndroidApiLevel);
-			Log.LogDebugMessage ("  AndroidApiLevelName: {0}", AndroidApiLevelName);
-			Log.LogDebugMessage ("  AndroidNdkPath: {0}", AndroidNdkPath);
-			Log.LogDebugMessage ("  AndroidSdkBuildToolsPath: {0}", AndroidSdkBuildToolsPath);
-			Log.LogDebugMessage ("  AndroidSdkBuildToolsBinPath: {0}", AndroidSdkBuildToolsBinPath);
-			Log.LogDebugMessage ("  AndroidSdkPath: {0}", AndroidSdkPath);
-			Log.LogDebugMessage ("  JavaSdkPath: {0}", JavaSdkPath);
-			Log.LogDebugMessage ("  JdkVersion: {0}", JdkVersion);
-			Log.LogDebugMessage ("  MinimumRequiredJdkVersion: {0}", MinimumRequiredJdkVersion);
-			Log.LogDebugMessage ("  MonoAndroidBinPath: {0}", MonoAndroidBinPath);
-			Log.LogDebugMessage ("  MonoAndroidToolsPath: {0}", MonoAndroidToolsPath);
-			Log.LogDebugMessage ("  TargetFrameworkVersion: {0}", TargetFrameworkVersion);
-			Log.LogDebugMessage ("  ZipAlignPath: {0}", ZipAlignPath);
-			Log.LogDebugMessage ("  SupportedApiLevel: {0}", SupportedApiLevel);
-			Log.LogDebugMessage ("  AndroidSequencePointMode: {0}", AndroidSequencePointsMode);
-			Log.LogDebugMessage ("  LintToolPath: {0}", LintToolPath);
-			Log.LogDebugMessage ("  AndroidUseApkSigner: {0}", AndroidUseApkSigner);
-			Log.LogDebugMessage ("  AndroidUseAapt2: {0}", AndroidUseAapt2);
-			Log.LogDebugMessage ("  Aapt2Version: {0}", Aapt2Version);
-
-			if (!string.IsNullOrEmpty (CacheFile)) {
-				Directory.CreateDirectory (Path.GetDirectoryName (CacheFile));
-
-				var document = new XDocument (
-					new XDeclaration ("1.0", "UTF-8", null),
-					new XElement ("Sdk",
-						new XElement ("AndroidApiLevel", AndroidApiLevel),
-						new XElement ("AndroidApiLevelName", AndroidApiLevelName),
-						new XElement ("AndroidNdkPath", AndroidNdkPath),
-						new XElement ("AndroidSdkBuildToolsPath", AndroidSdkBuildToolsPath),
-						new XElement ("AndroidSdkBuildToolsBinPath", AndroidSdkBuildToolsBinPath),
-						new XElement ("AndroidSdkPath", AndroidSdkPath),
-						new XElement ("JavaSdkPath", JavaSdkPath),
-						new XElement ("MonoAndroidBinPath", MonoAndroidBinPath),
-						new XElement ("MonoAndroidToolsPath", MonoAndroidToolsPath),
-						new XElement ("ReferenceAssemblyPaths",
-								(ReferenceAssemblyPaths ?? new string [0])
-								.Select(e => new XElement ("ReferenceAssemblyPath", e))),
-						new XElement ("TargetFrameworkVersion", TargetFrameworkVersion),
-						new XElement ("ZipAlignPath", ZipAlignPath),
-						new XElement ("MonoAndroidIncludePath", MonoAndroidIncludePath),
-						new XElement ("SupportedApiLevel", SupportedApiLevel),
-						new XElement ("AndroidSequencePointsMode", AndroidSequencePointsMode.ToString ()),
-						new XElement ("LintToolPath", LintToolPath)
-					));
-				document.Save (CacheFile);
-			}
+			Log.LogDebugMessage ($"{nameof (ResolveSdks)} Outputs:");
+			Log.LogDebugMessage ($"  {nameof (AndroidSdkPath)}: {AndroidSdkPath}");
+			Log.LogDebugMessage ($"  {nameof (AndroidNdkPath)}: {AndroidNdkPath}");
+			Log.LogDebugMessage ($"  {nameof (JavaSdkPath)}: {JavaSdkPath}");
+			Log.LogDebugMessage ($"  {nameof (MonoAndroidBinPath)}: {MonoAndroidBinPath}");
+			Log.LogDebugMessage ($"  {nameof (MonoAndroidToolsPath)}: {MonoAndroidToolsPath}");
 
 			//note: this task does not error out if it doesn't find all things. that's the job of the targets
 			return !Log.HasLoggedErrors;
-		}
-
-		// `java -version` will produce values such as:
-		//  java version "9.0.4"
-		//  java version "1.8.0_77"
-		static  readonly  Regex JavaVersionRegex  = new Regex (@"version ""(?<version>[\d\.]+)(_d+)?[^""]*""");
-
-		// `javac -version` will produce values such as:
-		//  javac 9.0.4
-		//  javac 1.8.0_77
-		static  readonly  Regex JavacVersionRegex = new Regex (@"(?<version>[\d\.]+)(_d+)?");
-
-		//  Android Asset Packaging Tool (aapt) 2:19
-		static readonly Regex Aapt2VersionRegex = new Regex (@"(?<version>[\d\:]+)(\d+)?");
-
-		Version GetJavaVersionForFramework (string targetFrameworkVersion)
-		{
-			var apiLevel = MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (targetFrameworkVersion);
-			if (apiLevel >= 24)
-				return new Version (1, 8);
-			else if (apiLevel == 23)
-				return new Version (1, 7);
-			else
-				return new Version (1, 6);
-		}
-
-		Version GetJavaVersionForBuildTools (string buildToolsVersion)
-		{
-			Version buildTools;
-			if (!Version.TryParse (buildToolsVersion, out buildTools)) {
-				return Version.Parse (LatestSupportedJavaVersion);
-			}
-			if (buildTools >= new Version (24, 0, 1))
-				return new Version (1, 8);
-			return Version.Parse (MinimumSupportedJavaVersion);
-		}
-
-		bool ValidateJavaVersion (string targetFrameworkVersion, string buildToolsVersion)
-		{
-			var java  = JavaToolExe   ?? (OS.IsWindows ? "java.exe" : "java");
-			var javac = JavacToolExe  ?? (OS.IsWindows ? "javac.exe" : "javac");
-
-			return ValidateJavaVersion (java, JavaVersionRegex, targetFrameworkVersion, buildToolsVersion) &&
-				ValidateJavaVersion (javac, JavacVersionRegex, targetFrameworkVersion, buildToolsVersion);
-		}
-
-		bool ValidateJavaVersion (string javaExe, Regex versionRegex, string targetFrameworkVersion, string buildToolsVersion)
-		{
-			Version requiredJavaForFrameworkVersion = GetJavaVersionForFramework (targetFrameworkVersion);
-			Version requiredJavaForBuildTools = GetJavaVersionForBuildTools (buildToolsVersion);
-
-			Version required = requiredJavaForFrameworkVersion > requiredJavaForBuildTools ? requiredJavaForFrameworkVersion : requiredJavaForBuildTools;
-
-			MinimumRequiredJdkVersion = required.ToString ();
-			
-			var sb = new StringBuilder ();
-			
-			var javaTool = Path.Combine (JavaSdkPath, "bin", javaExe);
-			try {
-				MonoAndroidHelper.RunProcess (javaTool, "-version", (s, e) => {
-						if (!string.IsNullOrEmpty (e.Data))
-							sb.AppendLine (e.Data);
-					}, (s, e) => {
-						if (!string.IsNullOrEmpty (e.Data))
-							sb.AppendLine (e.Data);
-					}
-				);
-			} catch (Exception ex) {
-				Log.LogWarningFromException (ex);
-				Log.LogCodedWarning ("XA0034", $"Failed to get the Java SDK version. Please ensure you have Java {required} or above installed.");
-				return false;
-			}
-			var versionInfo = sb.ToString ();
-			var versionNumberMatch = versionRegex.Match (versionInfo);
-			Version versionNumber;
-			if (versionNumberMatch.Success && Version.TryParse (versionNumberMatch.Groups ["version"]?.Value, out versionNumber)) {
-				JdkVersion  = versionNumberMatch.Groups ["version"].Value;
-				Log.LogMessage (MessageImportance.Normal, $"Found Java SDK version {versionNumber}.");
-				if (versionNumber < requiredJavaForFrameworkVersion) {
-					Log.LogCodedError ("XA0031", $"Java SDK {requiredJavaForFrameworkVersion} or above is required when targeting FrameworkVersion {targetFrameworkVersion}.");
-				}
-				if (versionNumber < requiredJavaForBuildTools) {
-					Log.LogCodedError ("XA0032", $"Java SDK {requiredJavaForBuildTools} or above is required when using build-tools {buildToolsVersion}.");
-				}
-				if (versionNumber > Version.Parse (LatestSupportedJavaVersion)) {
-					Log.LogCodedError ("XA0030", $"Building with JDK Version `{versionNumber}` is not supported. Please install JDK version `{LatestSupportedJavaVersion}`. See https://aka.ms/xamarin/jdk9-errors");
-				}
-			} else
-				Log.LogCodedWarning ("XA0033", $"Failed to get the Java SDK version as it does not appear to contain a valid version number. `{javaExe} -version` returned: ```{versionInfo}```");
-			return !Log.HasLoggedErrors;
-		}
-
-		bool GetAapt2Version ()
-		{
-			var sb = new StringBuilder ();
-			var aapt2Tool = Path.Combine (AndroidSdkBuildToolsBinPath, Aapt2);
-			try {
-				MonoAndroidHelper.RunProcess (aapt2Tool, "version",  (s, e) => {
-						if (!string.IsNullOrEmpty (e.Data))
-							sb.AppendLine (e.Data);
-					}, (s, e) => {
-						if (!string.IsNullOrEmpty (e.Data))
-							sb.AppendLine (e.Data);
-					}
-				);
-			} catch (Exception ex) {
-				Log.LogWarningFromException (ex);
-				return false;
-			}
-			var versionInfo = sb.ToString ();
-			var versionNumberMatch = Aapt2VersionRegex.Match (versionInfo);
-			Log.LogDebugMessage ($"`{aapt2Tool} version` returned: ```{versionInfo}```");
-			if (versionNumberMatch.Success && Version.TryParse (versionNumberMatch.Groups ["version"]?.Value.Replace (":", "."), out Version versionNumber)) {
-				Aapt2Version = versionNumber.ToString ();
-				return true;
-			}
-			return false;
-		}
-
-		bool ValidateApiLevels ()
-		{
-			// Priority:
-			//    $(UseLatestAndroidPlatformSdk) > $(AndroidApiLevel) > $(TargetFrameworkVersion)
-			//
-			// If $(TargetFrameworkVersion) isn't set, and $(AndroidApiLevel) isn't
-			// set, act as if $(UseLatestAndroidPlatformSdk) is True
-			//
-			// If $(UseLatestAndroidPlatformSdk) is true, we do as it says: use the
-			// latest installed version.
-			//
-			// Otherwise, if $(AndroidApiLevel) is set, use it and set $(TargetFrameworkVersion).
-			//    Rationale: monodroid/samples/xbuild.make uses $(AndroidApiLevel)
-			//    to build for a specific API level.
-			// Otherwise, if $(TargetFrameworkVersion) is set, use it and set $(AndroidApiLevel).
-
-			UseLatestAndroidPlatformSdk = UseLatestAndroidPlatformSdk ||
-				(string.IsNullOrWhiteSpace (AndroidApiLevel) && string.IsNullOrWhiteSpace (TargetFrameworkVersion));
-
-			if (UseLatestAndroidPlatformSdk) {
-				AndroidApiLevel         = GetMaxInstalledApiLevel ().ToString ();
-				SupportedApiLevel       = GetMaxStableApiLevel ().ToString ();
-				int maxInstalled, maxSupported = 0;
-				if (int.TryParse (AndroidApiLevel, out maxInstalled) && int.TryParse (SupportedApiLevel, out maxSupported) && maxInstalled > maxSupported) {
-					Log.LogDebugMessage ($"API Level {AndroidApiLevel} is greater than the maximum supported API level of {SupportedApiLevel}. " +
-						"Support for this API will be added in a future release.");
-					AndroidApiLevel = SupportedApiLevel;
-				}
-				if (!string.IsNullOrWhiteSpace (TargetFrameworkVersion)) {
-					var userSelected = MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (TargetFrameworkVersion);
-					// overwrite using user version only if it is 
-					// above the maxStableApi and a valid apiLevel.
-					if (userSelected != null && userSelected > maxSupported && userSelected <= maxInstalled) {
-						AndroidApiLevel   = userSelected.ToString ();
-						SupportedApiLevel = userSelected.ToString ();
-					}
-				}
-				TargetFrameworkVersion  = GetTargetFrameworkVersionFromApiLevel ();
-				return TargetFrameworkVersion != null;
-			}
-
-			if (!string.IsNullOrWhiteSpace (TargetFrameworkVersion)) {
-				TargetFrameworkVersion  = TargetFrameworkVersion.Trim ();
-				string id   = MonoAndroidHelper.SupportedVersions.GetIdFromFrameworkVersion (TargetFrameworkVersion);
-				if (id == null) {
-					Log.LogCodedError ("XA0000",
-							"Could not determine API level for $(TargetFrameworkVersion) of '{0}'.",
-							TargetFrameworkVersion);
-					return false;
-				}
-				AndroidApiLevel     = MonoAndroidHelper.SupportedVersions.GetApiLevelFromId (id).ToString ();
-				SupportedApiLevel   = AndroidApiLevel;
-				return true;
-			}
-
-			if (!string.IsNullOrWhiteSpace (AndroidApiLevel)) {
-				AndroidApiLevel         = AndroidApiLevel.Trim ();
-				SupportedApiLevel       = GetMaxSupportedApiLevel (AndroidApiLevel);
-				TargetFrameworkVersion  = GetTargetFrameworkVersionFromApiLevel ();
-				return TargetFrameworkVersion != null;
-			}
-
-			Log.LogCodedError ("XA0000", "Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); SHOULD NOT BE REACHED.");
-			return false;
-		}
-
-		int GetMaxInstalledApiLevel ()
-		{
-			string platformsDir = Path.Combine (AndroidSdkPath, "platforms");
-			var apiIds = Directory.EnumerateDirectories (platformsDir)
-				.Select (platformDir => Path.GetFileName (platformDir))
-				.Where (dir => dir.StartsWith ("android-", StringComparison.OrdinalIgnoreCase))
-				.Select (dir => dir.Substring ("android-".Length))
-				.Select (apiName => MonoAndroidHelper.SupportedVersions.GetIdFromApiLevel (apiName));
-			int maxApiLevel = int.MinValue;
-			foreach (var id in apiIds) {
-				int? v = MonoAndroidHelper.SupportedVersions.GetApiLevelFromId (id);
-				if (!v.HasValue)
-					continue;
-				maxApiLevel = Math.Max (maxApiLevel, v.Value);
-			}
-			if (maxApiLevel < 0)
-				Log.LogCodedError ("XA5300",
-						"No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.",
-						platformsDir, Path.DirectorySeparatorChar, Android);
-			return maxApiLevel;
-		}
-
-		int GetMaxStableApiLevel ()
-		{
-			return MonoAndroidHelper.SupportedVersions.MaxStableVersion.ApiLevel;
-		}
-
-		string GetMaxSupportedApiLevel (string apiLevel)
-		{
-			int level = 0;
-			if (!int.TryParse (apiLevel, NumberStyles.Integer, CultureInfo.InvariantCulture, out level))
-				return apiLevel;
-			if (ReferenceAssemblyPaths == null)
-				return apiLevel;
-			foreach (string versionedDir in ReferenceAssemblyPaths) {
-				string parent   = Path.GetDirectoryName (versionedDir.TrimEnd (Path.DirectorySeparatorChar));
-				for ( int l = level ; l > 0; l--) {
-					string tfv = MonoAndroidHelper.SupportedVersions.GetFrameworkVersionFromApiLevel (l);
-					if (tfv == null)
-						continue;
-					string dir = Path.Combine (parent, tfv);
-					if (Directory.Exists (dir))
-						return l.ToString ();
-				}
-			}
-			return apiLevel;
-		}
-
-		string GetTargetFrameworkVersionFromApiLevel ()
-		{
-			string targetFramework = MonoAndroidHelper.SupportedVersions.GetFrameworkVersionFromId (SupportedApiLevel) ??
-				MonoAndroidHelper.SupportedVersions.GetFrameworkVersionFromId (AndroidApiLevel);
-			if (targetFramework != null)
-				return targetFramework;
-			Log.LogCodedError ("XA0000",
-					"Could not determine $(TargetFrameworkVersion) for API level '{0}.'",
-					AndroidApiLevel);
-			return null;
 		}
 
 		void ErrorHandler (string task, string message)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ValidateJavaVersion.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ValidateJavaVersion.cs
@@ -1,0 +1,134 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// ValidateJavaVersion's job is to shell out to java and javac to detect their version
+	/// </summary>
+	public class ValidateJavaVersion : Task
+	{
+		public string TargetFrameworkVersion { get; set; }
+
+		public string AndroidSdkBuildToolsVersion { get; set; }
+
+		public string JavaSdkPath { get; set; }
+
+		public string JavaToolExe { get; set; }
+
+		public string JavacToolExe { get; set; }
+
+		public string LatestSupportedJavaVersion { get; set; }
+
+		public string MinimumSupportedJavaVersion { get; set; }
+
+		[Output]
+		public string MinimumRequiredJdkVersion { get; set; }
+
+		[Output]
+		public string JdkVersion { get; set; }
+
+		public override bool Execute ()
+		{
+			if (!ValidateJava (TargetFrameworkVersion, AndroidSdkBuildToolsVersion))
+				return false;
+
+			Log.LogDebugMessage ($"{nameof (ValidateJavaVersion)} Outputs:");
+			Log.LogDebugMessage ($"  {nameof (JdkVersion)}: {JdkVersion}");
+			Log.LogDebugMessage ($"  {nameof (MinimumRequiredJdkVersion)}: {MinimumRequiredJdkVersion}");
+
+			return !Log.HasLoggedErrors;
+		}
+
+		// `java -version` will produce values such as:
+		//  java version "9.0.4"
+		//  java version "1.8.0_77"
+		static readonly Regex JavaVersionRegex = new Regex (@"version ""(?<version>[\d\.]+)(_d+)?[^""]*""");
+
+		// `javac -version` will produce values such as:
+		//  javac 9.0.4
+		//  javac 1.8.0_77
+		static readonly Regex JavacVersionRegex = new Regex (@"(?<version>[\d\.]+)(_d+)?");
+
+		bool ValidateJava (string targetFrameworkVersion, string buildToolsVersion)
+		{
+			var java = JavaToolExe ?? (OS.IsWindows ? "java.exe" : "java");
+			var javac = JavacToolExe ?? (OS.IsWindows ? "javac.exe" : "javac");
+
+			return ValidateJava (java, JavaVersionRegex, targetFrameworkVersion, buildToolsVersion) &&
+				ValidateJava (javac, JavacVersionRegex, targetFrameworkVersion, buildToolsVersion);
+		}
+
+		bool ValidateJava (string javaExe, Regex versionRegex, string targetFrameworkVersion, string buildToolsVersion)
+		{
+			Version requiredJavaForFrameworkVersion = GetJavaVersionForFramework (targetFrameworkVersion);
+			Version requiredJavaForBuildTools = GetJavaVersionForBuildTools (buildToolsVersion);
+
+			Version required = requiredJavaForFrameworkVersion > requiredJavaForBuildTools ? requiredJavaForFrameworkVersion : requiredJavaForBuildTools;
+
+			MinimumRequiredJdkVersion = required.ToString ();
+
+			var sb = new StringBuilder ();
+
+			var javaTool = Path.Combine (JavaSdkPath, "bin", javaExe);
+			try {
+				MonoAndroidHelper.RunProcess (javaTool, "-version", (s, e) => {
+					if (!string.IsNullOrEmpty (e.Data))
+						sb.AppendLine (e.Data);
+				}, (s, e) => {
+					if (!string.IsNullOrEmpty (e.Data))
+						sb.AppendLine (e.Data);
+				});
+			} catch (Exception ex) {
+				Log.LogWarningFromException (ex);
+				Log.LogCodedWarning ("XA0034", $"Failed to get the Java SDK version. Please ensure you have Java {required} or above installed.");
+				return false;
+			}
+			var versionInfo = sb.ToString ();
+			var versionNumberMatch = versionRegex.Match (versionInfo);
+			Version versionNumber;
+			if (versionNumberMatch.Success && Version.TryParse (versionNumberMatch.Groups ["version"]?.Value, out versionNumber)) {
+				JdkVersion = versionNumberMatch.Groups ["version"].Value;
+				Log.LogMessage (MessageImportance.Normal, $"Found Java SDK version {versionNumber}.");
+				if (versionNumber < requiredJavaForFrameworkVersion) {
+					Log.LogCodedError ("XA0031", $"Java SDK {requiredJavaForFrameworkVersion} or above is required when targeting FrameworkVersion {targetFrameworkVersion}.");
+				}
+				if (versionNumber < requiredJavaForBuildTools) {
+					Log.LogCodedError ("XA0032", $"Java SDK {requiredJavaForBuildTools} or above is required when using build-tools {buildToolsVersion}.");
+				}
+				if (versionNumber > Version.Parse (LatestSupportedJavaVersion)) {
+					Log.LogCodedError ("XA0030", $"Building with JDK Version `{versionNumber}` is not supported. Please install JDK version `{LatestSupportedJavaVersion}`. See https://aka.ms/xamarin/jdk9-errors");
+				}
+			} else
+				Log.LogCodedWarning ("XA0033", $"Failed to get the Java SDK version as it does not appear to contain a valid version number. `{javaExe} -version` returned: ```{versionInfo}```");
+			return !Log.HasLoggedErrors;
+		}
+
+		Version GetJavaVersionForFramework (string targetFrameworkVersion)
+		{
+			var apiLevel = MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (targetFrameworkVersion);
+			if (apiLevel >= 24)
+				return new Version (1, 8);
+			else if (apiLevel == 23)
+				return new Version (1, 7);
+			else
+				return new Version (1, 6);
+		}
+
+		Version GetJavaVersionForBuildTools (string buildToolsVersion)
+		{
+			Version buildTools;
+			if (!Version.TryParse (buildToolsVersion, out buildTools)) {
+				return Version.Parse (LatestSupportedJavaVersion);
+			}
+			if (buildTools >= new Version (24, 0, 1))
+				return new Version (1, 8);
+			return Version.Parse (MinimumSupportedJavaVersion);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1699,10 +1699,12 @@ namespace App1
 			};
 			proj.SetProperty ("TargetFrameworkVersion", "v2.3");
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
+				if (!Directory.Exists (Path.Combine (builder.FrameworkLibDirectory, "xbuild-frameworks", "MonoAndroid", "v2.3")))
+					Assert.Ignore ("This is a Pull Request Build. Ignoring test.");
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
-				StringAssertEx.Contains ($"TargetFrameworkVersion: v2.3", builder.LastBuildOutput, "TargetFrameworkVerson should be v2.3");
+				StringAssertEx.Contains ($"Output Property: TargetFrameworkVersion=v2.3", builder.LastBuildOutput, "TargetFrameworkVerson should be v2.3");
 				Assert.IsTrue (builder.Build (proj, parameters: new [] { "TargetFrameworkVersion=v4.4" }), "Build should have succeeded.");
-				StringAssertEx.Contains ($"TargetFrameworkVersion: v4.4", builder.LastBuildOutput, "TargetFrameworkVerson should be v4.4");
+				StringAssertEx.Contains ($"Output Property: TargetFrameworkVersion=v4.4", builder.LastBuildOutput, "TargetFrameworkVerson should be v4.4");
 
 			}
 		}
@@ -2136,10 +2138,12 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 			};
 			proj.SetProperty ("TargetFrameworkVersion", "v2.3");
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
+				if (!Directory.Exists (Path.Combine (builder.FrameworkLibDirectory, "xbuild-frameworks", "MonoAndroid", "v2.3")))
+					Assert.Ignore ("This is a Pull Request Build. Ignoring test.");
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
-				StringAssertEx.Contains ($"TargetFrameworkVersion: v2.3", builder.LastBuildOutput, "TargetFrameworkVerson should be v2.3");
+				StringAssertEx.Contains ($"Output Property: TargetFrameworkVersion=v2.3", builder.LastBuildOutput, "TargetFrameworkVerson should be v2.3");
 				Assert.IsTrue (builder.Build (proj, parameters: new [] { "TargetFrameworkVersion=v4.4" }), "Build should have succeeded.");
-				StringAssertEx.Contains ($"TargetFrameworkVersion: v4.4", builder.LastBuildOutput, "TargetFrameworkVerson should be v4.4");
+				StringAssertEx.Contains ($"Output Property: TargetFrameworkVersion=v4.4", builder.LastBuildOutput, "TargetFrameworkVerson should be v4.4");
 			}
 		}
 
@@ -2529,31 +2533,42 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				builder.Target = "_SetLatestTargetFrameworkVersion";
 				Assert.True (builder.Build (proj, parameters: parameters, environmentVariables: envVar),
 					string.Format ("First Build should have succeeded"));
-				Assert.IsTrue (builder.LastBuildOutput.ContainsOccurances ("TargetFrameworkVersion: v8.0", 2), "TargetFrameworkVersion should be v8.0");
+
+				//NOTE: these are generally of this form, from diagnostic log output:
+				//    Task Parameter:TargetFrameworkVersion=v8.0
+				//    ...
+				//    Output Property: TargetFrameworkVersion=v8.0
+				// ValidateJavaVersion and ResolveAndroidTooling take input, ResolveAndroidTooling has final output
+
+				Assert.IsTrue (builder.LastBuildOutput.ContainsOccurances ("Task Parameter:TargetFrameworkVersion=v8.0", 2), "TargetFrameworkVersion should initially be v8.0");
+				Assert.IsTrue (builder.LastBuildOutput.ContainsOccurances ("Output Property: TargetFrameworkVersion=v8.0", 1), "TargetFrameworkVersion should be v8.0");
 
 				proj.TargetFrameworkVersion = "v8.0";
 				Assert.True (builder.Build (proj, parameters: parameters, environmentVariables: envVar),
 					string.Format ("Second Build should have succeeded"));
-				Assert.IsTrue (builder.LastBuildOutput.ContainsOccurances ("TargetFrameworkVersion: v8.0", 2), "TargetFrameworkVersion should be v8.0");
+				Assert.IsTrue (builder.LastBuildOutput.ContainsOccurances ("Task Parameter:TargetFrameworkVersion=v8.0", 2), "TargetFrameworkVersion should initially be v8.0");
+				Assert.IsTrue (builder.LastBuildOutput.ContainsOccurances ("Output Property: TargetFrameworkVersion=v8.0", 1), "TargetFrameworkVersion should be v8.0");
 
 				proj.UseLatestPlatformSdk = true;
 				proj.TargetFrameworkVersion = "v8.1";
 				Assert.True (builder.Build (proj, parameters: parameters, environmentVariables: envVar),
 					string.Format ("Third Build should have succeeded"));
-				Assert.IsTrue (builder.LastBuildOutput.ContainsOccurances ("TargetFrameworkVersion: v8.1", 2), "TargetFrameworkVersion should be v8.1");
+				Assert.IsTrue (builder.LastBuildOutput.ContainsOccurances ("Task Parameter:TargetFrameworkVersion=v8.1", 2), "TargetFrameworkVersion should initially be v8.1");
+				Assert.IsTrue (builder.LastBuildOutput.ContainsOccurances ("Output Property: TargetFrameworkVersion=v8.1", 1), "TargetFrameworkVersion should be v8.1");
 
 				proj.UseLatestPlatformSdk = true;
 				proj.TargetFrameworkVersion = "v8.99";
 				Assert.True (builder.Build (proj, parameters: parameters, environmentVariables: envVar),
 					string.Format ("Third Build should have succeeded"));
-				Assert.IsTrue (builder.LastBuildOutput.ContainsOccurances ("TargetFrameworkVersion: v8.99", 2), "TargetFrameworkVersion should be v8.99");
+				Assert.IsTrue (builder.LastBuildOutput.ContainsOccurances ("Task Parameter:TargetFrameworkVersion=v8.99", 2), "TargetFrameworkVersion should initially be v8.99");
+				Assert.IsTrue (builder.LastBuildOutput.ContainsOccurances ("Output Property: TargetFrameworkVersion=v8.99", 1), "TargetFrameworkVersion should be v8.99");
 
 				proj.UseLatestPlatformSdk = true;
 				proj.TargetFrameworkVersion = "v6.0";
 				Assert.True (builder.Build (proj, parameters: parameters, environmentVariables: envVar),
 					string.Format ("Forth Build should have succeeded"));
-				Assert.IsTrue (builder.LastBuildOutput.ContainsOccurances ("TargetFrameworkVersion: v6.0", 1), "TargetFrameworkVersion should initially be v6.0");
-				Assert.IsTrue (builder.LastBuildOutput.ContainsOccurances ("TargetFrameworkVersion: v8.1", 1), "TargetFrameworkVersion should be v8.1");
+				Assert.IsTrue (builder.LastBuildOutput.ContainsOccurances ("Task Parameter:TargetFrameworkVersion=v6.0", 2), "TargetFrameworkVersion should initially be v6.0");
+				Assert.IsTrue (builder.LastBuildOutput.ContainsOccurances ("Output Property: TargetFrameworkVersion=v8.1", 1), "TargetFrameworkVersion should be v8.1");
 			}
 			Directory.Delete (referencesPath, recursive: true);
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
@@ -160,28 +160,37 @@ namespace Xamarin.Android.Build.Tests {
 			var referencePath = CreateFauxReferencesDirectory (Path.Combine (path, "references"), apis);
 			var errors = new List<BuildErrorEventArgs> ();
 			IBuildEngine engine = new MockBuildEngine (TestContext.Out, errors);
-			var task = new ResolveSdks {
-				BuildEngine = engine
+			var resolveSdks = new ResolveSdks {
+				BuildEngine = engine,
+				AndroidSdkPath = androidSdkPath,
+				AndroidNdkPath = androidSdkPath,
+				JavaSdkPath = javaPath,
+				ReferenceAssemblyPaths = new [] {
+					Path.Combine (referencePath, "MonoAndroid"),
+				},
 			};
-			task.AndroidSdkPath = androidSdkPath;
-			task.AndroidNdkPath = androidSdkPath;
-			task.JavaSdkPath = javaPath;
-			task.TargetFrameworkVersion = targetFrameworkVersion;
-			task.AndroidSdkBuildToolsVersion = buildtools;
-			task.BuildingInsideVisualStudio = "true";
-			task.UseLatestAndroidPlatformSdk = useLatestAndroidSdk;
-			task.AotAssemblies = false;
-			task.LatestSupportedJavaVersion = "1.8.0";
-			task.MinimumSupportedJavaVersion = "1.7.0";
-			task.ReferenceAssemblyPaths = new string [] {
-				Path.Combine (referencePath, "MonoAndroid"),
+			var validateJavaVersion = new ValidateJavaVersion {
+				BuildEngine = engine,
+				TargetFrameworkVersion = targetFrameworkVersion,
+				AndroidSdkBuildToolsVersion = buildtools,
+				JavaSdkPath = javaPath,
+				JavaToolExe = javaExe,
+				JavacToolExe = javacExe,
+				LatestSupportedJavaVersion = "1.8.0",
+				MinimumSupportedJavaVersion = "1.7.0",
 			};
-			task.CacheFile = Path.Combine (Root, path, "sdk.xml");
-			task.SequencePointsMode = "None";
-			task.JavaToolExe = javaExe;
-			task.JavacToolExe = javacExe;
-			Assert.AreEqual (expectedTaskResult, task.Execute (), $"Task should have {(expectedTaskResult ? "succeeded" : "failed" )}.");
-			Assert.AreEqual (expectedTargetFramework, task.TargetFrameworkVersion, $"TargetFrameworkVersion should be {expectedTargetFramework} but was {targetFrameworkVersion}");
+			var androidTooling = new ResolveAndroidTooling {
+				BuildEngine = engine,
+				AndroidSdkPath = androidSdkPath,
+				AndroidNdkPath = androidSdkPath,
+				TargetFrameworkVersion = targetFrameworkVersion,
+				AndroidSdkBuildToolsVersion = buildtools,
+				UseLatestAndroidPlatformSdk = useLatestAndroidSdk,
+				AotAssemblies = false,
+				SequencePointsMode = "None",
+			};
+			Assert.AreEqual (expectedTaskResult, resolveSdks.Execute () && validateJavaVersion.Execute () && androidTooling.Execute (), $"Tasks should have {(expectedTaskResult ? "succeeded" : "failed" )}.");
+			Assert.AreEqual (expectedTargetFramework, androidTooling.TargetFrameworkVersion, $"TargetFrameworkVersion should be {expectedTargetFramework} but was {targetFrameworkVersion}");
 			if (!string.IsNullOrWhiteSpace (expectedError)) {
 				Assert.AreEqual (1, errors.Count (), "An error should have been raised.");
 				Assert.AreEqual (expectedError, errors [0].Code, $"Expected error code {expectedError} but found {errors [0].Code}");
@@ -203,60 +212,70 @@ namespace Xamarin.Android.Build.Tests {
 				new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
 			});
 			IBuildEngine engine = new MockBuildEngine (TestContext.Out);
-			var task = new ResolveSdks {
-				BuildEngine = engine
+			var resolveSdks = new ResolveSdks {
+				BuildEngine = engine,
+				AndroidSdkPath = androidSdkPath,
+				AndroidNdkPath = androidSdkPath,
+				JavaSdkPath = javaPath,
+				ReferenceAssemblyPaths = new [] {
+					Path.Combine (referencePath, "MonoAndroid"),
+				},
 			};
-			task.AndroidSdkPath = androidSdkPath;
-			task.AndroidNdkPath = androidSdkPath;
-			task.JavaSdkPath = javaPath;
-			task.TargetFrameworkVersion = "v8.0";
-			task.AndroidSdkBuildToolsVersion = "26.0.3";
-			task.BuildingInsideVisualStudio = "true";
-			task.UseLatestAndroidPlatformSdk = false;
-			task.AotAssemblies = false;
-			task.LatestSupportedJavaVersion = "1.8.0";
-			task.MinimumSupportedJavaVersion = "1.7.0";
-			task.ReferenceAssemblyPaths = new string [] {
-				Path.Combine (referencePath, "MonoAndroid"),
+			var validateJavaVersion = new ValidateJavaVersion {
+				BuildEngine = engine,
+				TargetFrameworkVersion = "v8.0",
+				AndroidSdkBuildToolsVersion = "26.0.3",
+				JavaSdkPath = javaPath,
+				JavaToolExe = javaExe,
+				JavacToolExe = javacExe,
+				LatestSupportedJavaVersion = "1.8.0",
+				MinimumSupportedJavaVersion = "1.7.0",
 			};
-			task.CacheFile = Path.Combine (Root, path, "sdk.xml");
-			task.SequencePointsMode = "None";
-			task.JavaToolExe = javaExe;
-			task.JavacToolExe = javacExe;
+			var androidTooling = new ResolveAndroidTooling {
+				BuildEngine = engine,
+				AndroidSdkPath = androidSdkPath,
+				AndroidNdkPath = androidSdkPath,
+				TargetFrameworkVersion = "v8.0",
+				AndroidSdkBuildToolsVersion = "26.0.3",
+				UseLatestAndroidPlatformSdk = false,
+				AotAssemblies = false,
+				SequencePointsMode = "None",
+			};;
 			var start = DateTime.UtcNow;
-			Assert.IsTrue (task.Execute ());
+			Assert.IsTrue (resolveSdks.Execute (), "ResolveSdks should succeed!");
+			Assert.IsTrue (validateJavaVersion.Execute (), "ValidateJavaVersion should succeed!");
+			Assert.IsTrue (androidTooling.Execute (), "ResolveAndroidTooling should succeed!");
 			var executionTime = DateTime.UtcNow - start;
 			Assert.LessOrEqual (executionTime, TimeSpan.FromSeconds(2), "Task should not take more than 2 seconds to run.");
-			Assert.AreEqual (task.AndroidApiLevel, "26", "AndroidApiLevel should be 26");
-			Assert.AreEqual (task.TargetFrameworkVersion, "v8.0", "TargetFrameworkVersion should be v8.0");
-			Assert.AreEqual (task.AndroidApiLevelName, "26", "AndroidApiLevelName should be 26");
-			Assert.AreEqual (task.SupportedApiLevel, "26", "SupportedApiLevel should be 26");
-			Assert.NotNull (task.ReferenceAssemblyPaths, "ReferenceAssemblyPaths should not be null.");
-			Assert.AreEqual (task.ReferenceAssemblyPaths.Length, 1, "ReferenceAssemblyPaths should have 1 entry.");
-			Assert.AreEqual (task.ReferenceAssemblyPaths[0], Path.Combine (referencePath, "MonoAndroid"), $"ReferenceAssemblyPaths should be {Path.Combine (referencePath, "MonoAndroid")}.");
+			Assert.AreEqual (androidTooling.AndroidApiLevel, "26", "AndroidApiLevel should be 26");
+			Assert.AreEqual (androidTooling.TargetFrameworkVersion, "v8.0", "TargetFrameworkVersion should be v8.0");
+			Assert.AreEqual (androidTooling.AndroidApiLevelName, "26", "AndroidApiLevelName should be 26");
+			Assert.AreEqual (androidTooling.SupportedApiLevel, "26", "SupportedApiLevel should be 26");
+			Assert.NotNull (resolveSdks.ReferenceAssemblyPaths, "ReferenceAssemblyPaths should not be null.");
+			Assert.AreEqual (resolveSdks.ReferenceAssemblyPaths.Length, 1, "ReferenceAssemblyPaths should have 1 entry.");
+			Assert.AreEqual (resolveSdks.ReferenceAssemblyPaths[0], Path.Combine (referencePath, "MonoAndroid"), $"ReferenceAssemblyPaths should be {Path.Combine (referencePath, "MonoAndroid")}.");
 			var expected = Path.Combine (Root);
-			Assert.AreEqual (task.MonoAndroidToolsPath, expected, $"MonoAndroidToolsPath should be {expected}");
+			Assert.AreEqual (resolveSdks.MonoAndroidToolsPath, expected, $"MonoAndroidToolsPath should be {expected}");
 			expected += Path.DirectorySeparatorChar;
-			if (task.MonoAndroidBinPath != expected) {
+			if (resolveSdks.MonoAndroidBinPath != expected) {
 				//For non-Windows platforms, remove a directory such as "Darwin", MonoAndroidBinPath also has a trailing /
-				var binPath = Path.GetDirectoryName (Path.GetDirectoryName (task.MonoAndroidBinPath)) + Path.DirectorySeparatorChar;
+				var binPath = Path.GetDirectoryName (Path.GetDirectoryName (resolveSdks.MonoAndroidBinPath)) + Path.DirectorySeparatorChar;
 				Assert.AreEqual (binPath, expected, $"MonoAndroidBinPath should be {expected}");
 			}
-			Assert.AreEqual (task.MonoAndroidIncludePath, null, "MonoAndroidIncludePath should be null");
-			Assert.AreEqual (task.AndroidSdkPath, androidSdkPath, $"AndroidSdkPath should be {androidSdkPath}");
-			Assert.AreEqual (task.JavaSdkPath, javaPath, $"JavaSdkPath should be {javaPath}");
+			Assert.AreEqual (resolveSdks.AndroidSdkPath, androidSdkPath, $"AndroidSdkPath should be {androidSdkPath}");
+			Assert.AreEqual (resolveSdks.JavaSdkPath, javaPath, $"JavaSdkPath should be {javaPath}");
 			expected = Path.Combine (androidSdkPath, "build-tools", "26.0.3");
-			Assert.AreEqual (task.AndroidSdkBuildToolsPath, expected, $"AndroidSdkBuildToolsPath should be {expected}");
-			Assert.AreEqual (task.AndroidSdkBuildToolsBinPath, expected, "AndroidSdkBuildToolsBinPath should be {expected}");
-			Assert.AreEqual (task.ZipAlignPath, expected, "ZipAlignPath should be {expected}");
-			Assert.AreEqual (task.AndroidSequencePointsMode, "None", "AndroidSequencePointsMode should be None");
+			Assert.AreEqual (androidTooling.AndroidSdkBuildToolsPath, expected, $"AndroidSdkBuildToolsPath should be {expected}");
+			Assert.AreEqual (androidTooling.AndroidSdkBuildToolsBinPath, expected, "AndroidSdkBuildToolsBinPath should be {expected}");
+			Assert.AreEqual (androidTooling.ZipAlignPath, expected, "ZipAlignPath should be {expected}");
+			Assert.AreEqual (androidTooling.AndroidSequencePointsMode, "None", "AndroidSequencePointsMode should be None");
 			expected = Path.Combine (androidSdkPath, "tools");
-			Assert.AreEqual (task.LintToolPath, expected, $"LintToolPath should be {expected}");
+			Assert.AreEqual (androidTooling.LintToolPath, expected, $"LintToolPath should be {expected}");
 			expected = Path.Combine (androidSdkPath, "build-tools", "26.0.3", "lib", "apksigner.jar");
-			Assert.AreEqual (task.ApkSignerJar, expected, $"ApkSignerJar should be {expected}");
-			Assert.AreEqual (task.AndroidUseApkSigner, false, "AndroidUseApkSigner should be false");
-			Assert.AreEqual (task.JdkVersion, "1.8.0", "JdkVersion should be 1.8.0");
-			Assert.AreEqual (task.MinimumRequiredJdkVersion, "1.8", "MinimumRequiredJdkVersion should be 1.8");
+			Assert.AreEqual (androidTooling.ApkSignerJar, expected, $"ApkSignerJar should be {expected}");
+			Assert.AreEqual (androidTooling.AndroidUseApkSigner, false, "AndroidUseApkSigner should be false");
+			Assert.AreEqual (validateJavaVersion.JdkVersion, "1.8.0", "JdkVersion should be 1.8.0");
+			Assert.AreEqual (validateJavaVersion.MinimumRequiredJdkVersion, "1.8", "MinimumRequiredJdkVersion should be 1.8");
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -30,6 +30,8 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
   <UsingTask TaskName="Xamarin.Android.Tasks.ResolveAssemblies" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.ResolveLibraryProjectImports" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.ResolveSdks" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.ValidateJavaVersion" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <UsingTask TaskName="Xamarin.Android.Tasks.ResolveAndroidTooling" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.ReadLibraryProjectImportsCache" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.ReadImportedLibrariesCache" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
   <UsingTask TaskName="Xamarin.Android.Tasks.CreateNativeLibraryArchive" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -165,36 +167,44 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 	</GetReferenceAssemblyPaths>
 </Target>
 
-<Target Name="_SetLatestTargetFrameworkVersion" DependsOnTargets="_GetReferenceAssemblyPaths">
-	<ResolveSdks
-			AndroidApiLevel="$(AndroidApiLevel)"
-			AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
-			AndroidSdkPath="$(AndroidSdkDirectory)"
-			AndroidNdkPath="$(AndroidNdkDirectory)"
-			BuildingInsideVisualStudio="$(BuildingInsideVisualStudio)"
-			JavaSdkPath="$(JavaSdkDirectory)"
-			ProjectFilePath="$(MSBuildProjectFullPath)"
-			ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)"
-			TargetFrameworkVersion="$(TargetFrameworkVersion)"
-			SequencePointsMode="$(AndroidSequencePointsMode)"
-			UseLatestAndroidPlatformSdk="$(AndroidUseLatestPlatformSdk)"
-			JavaToolExe="$(JavaToolExe)"
-			LatestSupportedJavaVersion="$(LatestSupportedJavaVersion)"
-			MinimumSupportedJavaVersion="$(MinimumSupportedJavaVersion)"
-	>
-		<Output TaskParameter="AndroidApiLevel"           PropertyName="_AndroidApiLevel"           Condition="'$(_AndroidApiLevel)' == ''" />
-		<Output TaskParameter="AndroidApiLevelName"       PropertyName="_AndroidApiLevelName" />
-		<Output TaskParameter="TargetFrameworkVersion"    PropertyName="_TargetFrameworkVersion" />
-		<Output TaskParameter="TargetFrameworkVersion"    PropertyName="TargetFrameworkVersion" />
-		<Output TaskParameter="AndroidNdkPath"            PropertyName="AndroidNdkDirectory"        Condition="'$(AndroidNdkDirectory)' == ''" />
-		<Output TaskParameter="AndroidSdkPath"            PropertyName="AndroidSdkDirectory"        Condition="'$(AndroidSdkDirectory)' == ''" />
-		<Output TaskParameter="AndroidSdkBuildToolsPath"  PropertyName="AndroidSdkBuildToolsPath"   Condition="'$(AndroidSdkBuildToolsPath)' == ''" />
-		<Output TaskParameter="JavaSdkPath"               PropertyName="JavaSdkDirectory"           Condition="'$(JavaSdkDirectory)' == ''" />
-		<Output TaskParameter="MonoAndroidToolsPath"      PropertyName="MonoAndroidToolsDirectory" />
-		<Output TaskParameter="AndroidSdkBuildToolsBinPath" PropertyName="AndroidSdkBuildToolsBinPath" Condition="'$(AndroidSdkBuildToolsBinPath)' == ''" />
-		<Output TaskParameter="JdkVersion"                PropertyName="_JdkVersion" />
-		<Output TaskParameter="MinimumRequiredJdkVersion" PropertyName="_DefaultJdkVersion" />
-	</ResolveSdks>
+  <Target Name="_SetLatestTargetFrameworkVersion" DependsOnTargets="_GetReferenceAssemblyPaths">
+    <ResolveSdks
+        AndroidSdkPath="$(AndroidSdkDirectory)"
+        AndroidNdkPath="$(AndroidNdkDirectory)"
+        JavaSdkPath="$(JavaSdkDirectory)"
+        ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)">
+      <Output TaskParameter="AndroidNdkPath"            PropertyName="AndroidNdkDirectory"        Condition="'$(AndroidNdkDirectory)' == ''" />
+      <Output TaskParameter="AndroidSdkPath"            PropertyName="AndroidSdkDirectory"        Condition="'$(AndroidSdkDirectory)' == ''" />
+      <Output TaskParameter="JavaSdkPath"               PropertyName="JavaSdkDirectory"           Condition="'$(JavaSdkDirectory)' == ''" />
+      <Output TaskParameter="MonoAndroidToolsPath"      PropertyName="MonoAndroidToolsDirectory" />
+      <Output TaskParameter="MonoAndroidBinPath"        PropertyName="MonoAndroidBinDirectory" />
+    </ResolveSdks>
+    <ValidateJavaVersion
+        TargetFrameworkVersion="$(TargetFrameworkVersion)"
+        AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
+        JavaSdkPath="$(JavaSdkDirectory)"
+        JavaToolExe="$(JavaToolExe)"
+        JavacToolExe="$(JavacToolExe)"
+        LatestSupportedJavaVersion="$(LatestSupportedJavaVersion)"
+        MinimumSupportedJavaVersion="$(MinimumSupportedJavaVersion)">
+      <Output TaskParameter="JdkVersion"                PropertyName="_JdkVersion" />
+      <Output TaskParameter="MinimumRequiredJdkVersion" PropertyName="_DefaultJdkVersion" />
+    </ValidateJavaVersion>
+    <ResolveAndroidTooling
+        TargetFrameworkVersion="$(TargetFrameworkVersion)"
+        AndroidApiLevel="$(AndroidApiLevel)"
+        AndroidSdkPath="$(AndroidSdkDirectory)"
+        AndroidNdkPath="$(AndroidNdkDirectory)"
+        AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
+        UseLatestAndroidPlatformSdk="$(AndroidUseLatestPlatformSdk)"
+        SequencePointsMode="$(AndroidSequencePointsMode)"
+        ProjectFilePath="$(MSBuildProjectFullPath)">
+      <Output TaskParameter="TargetFrameworkVersion"      PropertyName="TargetFrameworkVersion" />
+      <Output TaskParameter="AndroidApiLevel"             PropertyName="_AndroidApiLevel"            Condition="'$(_AndroidApiLevel)' == ''" />
+      <Output TaskParameter="AndroidApiLevelName"         PropertyName="_AndroidApiLevelName" />
+      <Output TaskParameter="AndroidSdkBuildToolsPath"    PropertyName="AndroidSdkBuildToolsPath"    Condition="'$(AndroidSdkBuildToolsPath)' == ''" />
+      <Output TaskParameter="AndroidSdkBuildToolsBinPath" PropertyName="AndroidSdkBuildToolsBinPath" Condition="'$(AndroidSdkBuildToolsBinPath)' == ''" />
+    </ResolveAndroidTooling>
     <CreateProperty Value="$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion),Profile=$(TargetFrameworkProfile)">
       <Output TaskParameter="Value" PropertyName="TargetFrameworkMoniker"
           Condition="'$(TargetFrameworkProfile)' != ''"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -130,6 +130,7 @@
     <Compile Include="Tasks\Javac.cs" />
     <Compile Include="Tasks\LinkAssemblies.cs" />
     <Compile Include="Tasks\CopyResource.cs" />
+    <Compile Include="Tasks\ResolveAndroidTooling.cs" />
     <Compile Include="Tasks\ResolveAssemblies.cs" />
     <Compile Include="Tasks\GetAppSettingsDirectory.cs" />
     <Compile Include="Tasks\CopyIfChanged.cs" />
@@ -150,6 +151,7 @@
     <Compile Include="Mono.Android\ActivityAttribute.Partial.cs" />
     <Compile Include="Mono.Android\ContentProviderAttribute.Partial.cs" />
     <Compile Include="Mono.Android\LayoutAttribute.Partial.cs" />
+    <Compile Include="Tasks\ValidateJavaVersion.cs" />
     <Compile Include="Utilities\AndroidAddOnManifest.cs" />
     <Compile Include="Mono.Android\IntentFilterAttribute.Partial.cs" />
     <Compile Include="Mono.Android\GrantUriPermissionAttribute.Partial.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -25,6 +25,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.AndroidApkSigner" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GetAndroidPackageName" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ResolveSdks" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.ValidateJavaVersion" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.ResolveAndroidTooling" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.Aapt" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.Aapt2Compile" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.Aapt2Link" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -684,49 +686,55 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 <Target Name="_SetLatestTargetFrameworkVersion" DependsOnTargets="_GetReferenceAssemblyPaths">
 	<ResolveSdks
-			AndroidApiLevel="$(AndroidApiLevel)"
-			AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
 			AndroidSdkPath="$(AndroidSdkDirectory)"
 			AndroidNdkPath="$(AndroidNdkDirectory)"
-			AndroidUseAapt2="$(AndroidUseAapt2)"
-			AotAssemblies="$(AotAssemblies)"
-			SequencePointsMode="$(_AndroidSequencePointsMode)"
-			BuildingInsideVisualStudio="$(BuildingInsideVisualStudio)"
 			JavaSdkPath="$(JavaSdkDirectory)"
-			ProjectFilePath="$(MSBuildProjectFullPath)"
-			ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)"
-			TargetFrameworkVersion="$(TargetFrameworkVersion)"
-			UseLatestAndroidPlatformSdk="$(AndroidUseLatestPlatformSdk)"
-			JavaToolExe="$(JavaToolExe)"
-			JavacToolExe="$(JavacToolExe)"
-			LatestSupportedJavaVersion="$(LatestSupportedJavaVersion)"
-			MinimumSupportedJavaVersion="$(MinimumSupportedJavaVersion)"
-			LintToolPath="$(LintToolPath)"
-			ZipAlignPath="$(ZipAlignToolPath)">
-		<Output TaskParameter="AndroidApiLevel"           PropertyName="_AndroidApiLevel"           Condition="'$(_AndroidApiLevel)' == ''" />
-		<Output TaskParameter="AndroidApiLevelName"       PropertyName="_AndroidApiLevelName" />
-		<Output TaskParameter="SupportedApiLevel"         PropertyName="_SupportedApiLevel"	/>
-		<Output TaskParameter="TargetFrameworkVersion"    PropertyName="_TargetFrameworkVersion" />
-		<Output TaskParameter="ReferenceAssemblyPaths"    PropertyName="_XATargetFrameworkDirectories" />
-		<Output TaskParameter="TargetFrameworkVersion"    PropertyName="TargetFrameworkVersion" />
+			ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)">
 		<Output TaskParameter="AndroidNdkPath"            PropertyName="AndroidNdkDirectory"        Condition="'$(AndroidNdkDirectory)' == ''" />
 		<Output TaskParameter="AndroidSdkPath"            PropertyName="AndroidSdkDirectory"        Condition="'$(AndroidSdkDirectory)' == ''" />
-		<Output TaskParameter="AndroidSdkBuildToolsPath"  PropertyName="AndroidSdkBuildToolsPath"   Condition="'$(AndroidSdkBuildToolsPath)' == ''" />
 		<Output TaskParameter="JavaSdkPath"               PropertyName="JavaSdkDirectory"           Condition="'$(JavaSdkDirectory)' == ''" />
 		<Output TaskParameter="MonoAndroidToolsPath"      PropertyName="MonoAndroidToolsDirectory" />
 		<Output TaskParameter="MonoAndroidBinPath"        PropertyName="MonoAndroidBinDirectory" />
-		<Output TaskParameter="ZipAlignPath"              PropertyName="ZipAlignToolPath"           Condition="'$(ZipAlignToolPath)' == ''" />
-		<Output TaskParameter="AndroidSdkBuildToolsBinPath" PropertyName="AndroidSdkBuildToolsBinPath" Condition="'$(AndroidSdkBuildToolsBinPath)' == ''" />
-		<Output TaskParameter="AndroidSequencePointsMode"   PropertyName="_SequencePointsMode"         Condition="'$(_SequencePointsMode)' == ''" />
-		<Output TaskParameter="LintToolPath"              PropertyName="LintToolPath"               Condition="'$(LintToolPath)' == ''" />
-		<Output TaskParameter="ApkSignerJar"              PropertyName="ApkSignerJar"               Condition="'$(ApkSignerJar)' == ''" />
-		<Output TaskParameter="AndroidUseApkSigner"       PropertyName="AndroidUseApkSigner"        Condition="'$(AndroidUseApkSigner)' == ''" />
-		<Output TaskParameter="AndroidUseAapt2"           PropertyName="_AndroidUseAapt2" />
-		<Output TaskParameter="Aapt2Version"              PropertyName="_Aapt2Version" />
+	</ResolveSdks>
+	<ValidateJavaVersion
+			TargetFrameworkVersion="$(TargetFrameworkVersion)"
+			AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
+			JavaSdkPath="$(JavaSdkDirectory)"
+			JavaToolExe="$(JavaToolExe)"
+			JavacToolExe="$(JavacToolExe)"
+			LatestSupportedJavaVersion="$(LatestSupportedJavaVersion)"
+			MinimumSupportedJavaVersion="$(MinimumSupportedJavaVersion)">
 		<Output TaskParameter="JdkVersion"                PropertyName="_JdkVersion" />
 		<Output TaskParameter="MinimumRequiredJdkVersion" PropertyName="_DefaultJdkVersion" />
-	</ResolveSdks>
-	<CreateProperty Value="$(TargetFrameworkIdentifier),Version=$(_TargetFrameworkVersion),Profile=$(TargetFrameworkProfile)">
+	</ValidateJavaVersion>
+	<ResolveAndroidTooling
+			TargetFrameworkVersion="$(TargetFrameworkVersion)"
+			AndroidApiLevel="$(AndroidApiLevel)"
+			AndroidSdkPath="$(AndroidSdkDirectory)"
+			AndroidNdkPath="$(AndroidNdkDirectory)"
+			AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
+			UseLatestAndroidPlatformSdk="$(AndroidUseLatestPlatformSdk)"
+			AndroidUseAapt2="$(AndroidUseAapt2)"
+			AotAssemblies="$(AotAssemblies)"
+			SequencePointsMode="$(_AndroidSequencePointsMode)"
+			ProjectFilePath="$(MSBuildProjectFullPath)"			
+			LintToolPath="$(LintToolPath)"
+			ZipAlignPath="$(ZipAlignToolPath)">
+		<Output TaskParameter="TargetFrameworkVersion"      PropertyName="TargetFrameworkVersion" />
+		<Output TaskParameter="AndroidApiLevel"             PropertyName="_AndroidApiLevel"            Condition="'$(_AndroidApiLevel)' == ''" />
+		<Output TaskParameter="AndroidApiLevelName"         PropertyName="_AndroidApiLevelName" />
+		<Output TaskParameter="SupportedApiLevel"           PropertyName="_SupportedApiLevel" />
+		<Output TaskParameter="AndroidSdkBuildToolsPath"    PropertyName="AndroidSdkBuildToolsPath"    Condition="'$(AndroidSdkBuildToolsPath)' == ''" />
+		<Output TaskParameter="AndroidSdkBuildToolsBinPath" PropertyName="AndroidSdkBuildToolsBinPath" Condition="'$(AndroidSdkBuildToolsBinPath)' == ''" />
+		<Output TaskParameter="ZipAlignPath"                PropertyName="ZipAlignToolPath"            Condition="'$(ZipAlignToolPath)' == ''" />
+		<Output TaskParameter="AndroidSequencePointsMode"   PropertyName="_SequencePointsMode"         Condition="'$(_SequencePointsMode)' == ''" />
+		<Output TaskParameter="LintToolPath"                PropertyName="LintToolPath"                Condition="'$(LintToolPath)' == ''" />
+		<Output TaskParameter="ApkSignerJar"                PropertyName="ApkSignerJar"                Condition="'$(ApkSignerJar)' == ''" />
+		<Output TaskParameter="AndroidUseApkSigner"         PropertyName="AndroidUseApkSigner"         Condition="'$(AndroidUseApkSigner)' == ''" />
+		<Output TaskParameter="AndroidUseAapt2"             PropertyName="_AndroidUseAapt2" />
+		<Output TaskParameter="Aapt2Version"                PropertyName="_Aapt2Version" />
+	</ResolveAndroidTooling>
+	<CreateProperty Value="$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion),Profile=$(TargetFrameworkProfile)">
 		<Output TaskParameter="Value" PropertyName="TargetFrameworkMoniker"
 				Condition="'$(TargetFrameworkProfile)' != ''"
 		/>
@@ -734,7 +742,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 				Condition="'$(TargetFrameworkProfile)' != ''"
 		/>
 	</CreateProperty>
-	<CreateProperty Value="$(TargetFrameworkIdentifier),Version=$(_TargetFrameworkVersion)">
+	<CreateProperty Value="$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion)">
 		<Output TaskParameter="Value" PropertyName="TargetFrameworkMoniker"
 				Condition="'$(TargetFrameworkProfile)' == ''"
 		/>
@@ -874,7 +882,7 @@ because xbuild doesn't support framework reference assemblies.
 	
 	<Message Text="MonoAndroid Tools: $(_MonoAndroidToolsDirectory)"/>
 	<Message Text="Android Platform API level: $(_AndroidApiLevel)"/>
-	<Message Text="TargetFrameworkVersion: $(_TargetFrameworkVersion)"/>
+	<Message Text="TargetFrameworkVersion: $(TargetFrameworkVersion)"/>
 	<Message Text="Android NDK: $(_AndroidNdkDirectory)"/>
 	<Message Text="Android SDK: $(_AndroidSdkDirectory)"/>
 	<Message Text="Android SDK Build Tools: $(AndroidSdkBuildToolsPath)"/>
@@ -2219,7 +2227,7 @@ because xbuild doesn't support framework reference assemblies.
     MainAssembly="$(MonoAndroidLinkerInputDir)$(TargetFileName)"
     OutputDirectory="$(IntermediateOutputPath)android\src\mono" 
     UseSharedRuntime="$(AndroidUseSharedRuntime)"
-    TargetFrameworkVersion="$(_TargetFrameworkVersion)" 
+    TargetFrameworkVersion="$(TargetFrameworkVersion)" 
     Manifest="$(IntermediateOutputPath)android\AndroidManifest.xml" />
 </Target>
 


### PR DESCRIPTION
Context: http://work.devdiv.io/639234

The `ResolveSdks` MSBuild task was quite large, and had lots of inputs
and outputs. Because of this, it is difficult to tell which parts of
it are slow.

As a first stab at refactoring, I split it into three tasks that are
more focused in their concerns:
- `ResolveSdks` - now focuses on resolving `AndroidSdkPath`,
  `AndroidNdkPath` and `JavaSdkPath`. It also sets up any static
  members of `MonoAndroidHelper`.
- `ValidateJavaVersion` - shells out to `java` and `javac`, sets
  `MinimumRequiredJdkVersion` and `JdkVersion`.
- `ResolveAndroidTooling` - does all the other work: calculates
  `TargetFrameworkVersion` and finds the paths of various Android
  command line tooling

The goal here is to clean things up without really changing how
anything works. And in `ResolveSdksTaskTests`, I kept the tests
exactly the same but changed it to call all three tasks.

After the refactoring, we have a much better picture of what we need
to improve performance for. Here is the result of running the simplest
test, `BuildBasicApplication`:

    ResolveSdks 21ms
    ValidateJavaVersion 298ms
    ResolveAndroidTooling 15ms

So `ValidateJavaVersion` is where we should focus on performance
improvements (caching).

## Improvements to logging

In general we have been logging like this for every MSBuild task:

    public override bool Execute ()
    {
        Log.LogDebugMessage ($"{nameof (MyMSBuildTask)}");
        Log.LogDebugMessage ($"  {nameof (InputValue1)}: {InputValue1}");

        //Do stuff

        Log.LogDebugMessage ($"{nameof (MyMSBuildTask)} Outputs:");
        Log.LogDebugMessage ($"  {nameof (OutputValue1)}: {OutputValue1}");

        return !Log.HasLoggedErrors;
    }

The diagnostic log output would look something like:

    Task "MyMSBuildTask" (TaskId:8)
      Task Parameter:InputValue1=1234 (TaskId:8)
      MyMSBuildTask: (TaskId:8)
        InputValue1: 1234 (TaskId:8)
      MyMSBuildTask Outputs: (TaskId:8)
        OutputValue1: abcd (TaskId:8)
      Output Property: OutputValue1=abcd (TaskId:8)
    Done executing task "MyMSBuildTask". (TaskId:8)

The log messages are mostly duplicate, and seem unneeded. However, the
`Output Property` log only prints from MSBuild if this is specified in
the target:

    <Output TaskParameter="OutputValue1" PropertyName="OutputValue1" />

Since you *could* omit this, or rename the property, we should
continue logging all `[Output]` properties. However, I have removed
input ones in the changed tasks since they seem completely duplicate.

Other changes:
- Removed `$(_TargetFrameworkVersion)` property from
  `Xamarin.Android.Common.targets` in favor of just using
  `$(TargetFrameworkVersion)`. This seemed to be leftover from the
  past and not used.
- General refactoring/ordering of properties on MSBuild tasks
- General refactoring/ordering of properties in
  `Xamarin.Android.Common.targets` / `Xamarin.Android.Bindings.targets`
- Use `nameof` where appropriate in log messages
- `ResolveAndroidTooling` should use `Path.PathSeparator`
- Updated `ValidateUseLatestAndroid` and `CheckTargetFrameworkVersion`
tests