### PR TITLE
Fix issue #1588

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -302,7 +302,9 @@ namespace Xamarin.Android.Net
 		{
 			return Task.Run (() => {
 				try {
-					using (ct.Register (() => httpConnection?.Disconnect ()))
+					using (ct.Register(() => DisconnectAsync(httpConnection).ContinueWith(t => {
+							if (t.Exception != null) Logger.Log(LogLevel.Info, LOG_APP, $"Disconnection exception: {t.Exception}");
+						}, TaskScheduler.Default)))
 						httpConnection?.Connect ();
 				} catch {
 					ct.ThrowIfCancellationRequested ();


### PR DESCRIPTION
On AndroidClientHandler, the ConnectAsync method creates a temporary cancellation token callback to disconnect the connection, but it was not making sure the httpConnection.Disconnect() do not happen on the main thread - it can cause Android to throw an exception. For more information read https://github.com/xamarin/xamarin-android/issues/1588 

To fix it we changed the ct.Register callback in ConnectAsync to be just like the one in DoProcessRequest