### PR TITLE
[build] set VSIX compression level to Normal

### DIFF
--- a/build-tools/create-vsix/create-vsix.csproj
+++ b/build-tools/create-vsix/create-vsix.csproj
@@ -19,6 +19,7 @@
     <IncludeDebugSymbolsInVSIXContainer>False</IncludeDebugSymbolsInVSIXContainer>
     <IsExperimental Condition=" '$(IsExperimental)' == '' ">true</IsExperimental>
     <IsProductComponent Condition=" '$(IsProductComponent)' == '' ">True</IsProductComponent>
+    <ZipPackageCompressionLevel Condition=" '$(ZipPackageCompressionLevel)' == '' ">Normal</ZipPackageCompressionLevel>
     <_BuildVsix Condition=" '$(CreateVsixContainer)' == 'True' And Exists ('$(VsSDKInstall)') ">True</_BuildVsix>
     <_BuildVsix Condition=" '$(_BuildVsix)' == '' ">False</_BuildVsix>
     <ExtensionInstallationFolder>Xamarin\Xamarin.Android.Sdk</ExtensionInstallationFolder>


### PR DESCRIPTION
While generating a VSIX, I noticed this in the build log:

    CreateVsixContainer:
      Creating VSIX Container...
      Creating the package with the following compression level. "NotCompressed".

Changing the `ZipPackageCompressionLevel` property to `Normal`, seems
to change the VSIX so it is properly compressed.

The file size goes from 584991368 bytes to 172998318 bytes.

It's worth doing this, just to make the download smaller in the OSS
repo. I need to do some further research and make sure the VSIX we are
shipping commercially is compressed.