### PR TITLE
Ignore <merge> when generating code-behind source

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
@@ -251,6 +251,12 @@ namespace Xamarin.Android.Tasks
 					continue;
 
 				XPathNavigator current = nodes.Current;
+
+				// <merge> anywhere is ignored - Android always returns 'null' if you try to find such
+				// an element. Prevents https://github.com/xamarin/xamarin-android/issues/1929
+				if (String.Compare ("merge", current.LocalName, StringComparison.Ordinal) == 0)
+					continue;
+
 				bool isInclude = String.Compare ("include", current.LocalName, StringComparison.Ordinal) == 0;
 
 				if (!GetAndParseId (current, filePath, androidNS, isInclude, out id, out parsedId, out name)  && !isInclude) {

--- a/tests/CodeBehind/BuildTests/CodeBehindBuildTests.csproj
+++ b/tests/CodeBehind/BuildTests/CodeBehindBuildTests.csproj
@@ -48,6 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />
+    <Compile Include="MainMergeActivity.cs" />
     <Compile Include="MainActivityNotPartial.cs" />
     <Compile Include="AnotherMainActivity.cs" />
     <Compile Include="OnboardingActivity.cs" />
@@ -63,6 +64,7 @@
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\layout\Main.axml" />
+    <AndroidResource Include="Resources\layout\MainMerge.axml" />
     <AndroidResource Include="Resources\layout-land\Main.axml" />
     <AndroidResource Include="Resources\layout\settings.xml" />
     <AndroidResource Include="Resources\layout\loading.xml" />

--- a/tests/CodeBehind/BuildTests/MainMergeActivity.cs
+++ b/tests/CodeBehind/BuildTests/MainMergeActivity.cs
@@ -1,0 +1,52 @@
+﻿using Android.App;
+using Android.Widget;
+using Android.OS;
+
+namespace Xamarin.Android.Tests.CodeBehindBuildTests
+{
+	[Activity (Label = "MainMergeActivity")]
+	public partial class MainMergeActivity : Activity
+	{
+		int count = 1;
+		bool onSetContentViewCalled_01 = false;
+		bool onSetContentViewCalled_02 = false;
+		bool onSetContentViewCalled_03 = false;
+
+		protected override void OnCreate (Bundle savedInstanceState)
+		{
+			base.OnCreate (savedInstanceState);
+
+			// Set our view from the "main" layout resource
+			SetContentView (Resource.Layout.MainMerge);
+
+			// Compile time: check by assignment if correct types were generated
+			CommonSampleLibrary.LogFragment log = log_fragment;
+
+#if NOT_CONFLICTING_FRAGMENT
+			CommonSampleLibrary.LogFragment log2 = secondary_log_fragment;
+#else
+			global::Android.App.Fragment log2 = secondary_log_fragment;
+#endif
+			TextView t = Text1;
+
+			Button button = myButton;
+			button.Click += delegate { button.Text = $"{count++} clicks!"; };
+		}
+
+		partial void OnSetContentView (global::Android.Views.View view, ref bool callBaseAfterReturn)
+		{
+			onSetContentViewCalled_01 = true;
+		}
+
+                partial void OnSetContentView (global::Android.Views.View view, global::Android.Views.ViewGroup.LayoutParams @params, ref bool callBaseAfterReturn)
+		{
+			onSetContentViewCalled_02 = true;
+		}
+
+                partial void OnSetContentView (int layoutResID, ref bool callBaseAfterReturn)
+		{
+			onSetContentViewCalled_03 = true;
+		}
+	}
+}
+

--- a/tests/CodeBehind/BuildTests/Resources/layout/MainMerge.axml
+++ b/tests/CodeBehind/BuildTests/Resources/layout/MainMerge.axml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This comment is here to test that the generator
+     properly skips non-element nodes preceding the
+     first element node in the layout file -->
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:xamarin="http://schemas.xamarin.com/android/xamarin/tools"
+       xamarin:classes="Xamarin.Android.Tests.CodeBehindBuildTests.MainMergeActivity">
+<LinearLayout
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    >
+<Button  
+    android:id="@+id/myButton"
+    android:layout_width="match_parent" 
+    android:layout_height="wrap_content" 
+    android:text="@string/hello"
+    />
+<fragment
+    xamarin:managedType="CommonSampleLibrary.LogFragment"
+    android:name="commonsamplelibrary.LogFragment"
+    android:id="@+id/log_fragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />
+<fragment
+    android:name="CommonSampleLibrary.LogFragment"
+    android:id="@+id/secondary_log_fragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />
+<TextView
+    android:id="@android:id/text1" />
+</LinearLayout>
+</merge>

--- a/tests/CodeBehind/UnitTests/BuildTests.cs
+++ b/tests/CodeBehind/UnitTests/BuildTests.cs
@@ -134,6 +134,11 @@ namespace CodeBehindUnitTests
 					{"public", "global::Android.App.Fragment", "secondary_log_fragment"},
 					{"public", "CommonSampleLibrary.LogFragment", "tertiary_log_fragment"},
 				},
+				new SourceFile (Path.Combine (generatedSourcesDir, "Binding.MainMerge.g.cs")) {
+					{"public", "Button", "myButton"},
+					{"public", "CommonSampleLibrary.LogFragment", "log_fragment"},
+					{"public", "CommonSampleLibrary.LogFragment", "secondary_log_fragment"},
+				},
 				new SourceFile (Path.Combine (generatedSourcesDir, "Binding.onboarding_info.g.cs")) {
 					{"public", "LinearLayout", "onboarding_stations_info_inner"},
 					{"public", "ImageView", "icon_view"},
@@ -185,6 +190,20 @@ namespace CodeBehindUnitTests
 					{"public", "CommonSampleLibrary.LogFragment", "log_fragment"},
 					{"public", "global::Android.App.Fragment", "secondary_log_fragment"},
 					{"public", "CommonSampleLibrary.LogFragment", "tertiary_log_fragment"},
+
+					// Methods
+					{"public override", "void", "SetContentView", "global::Android.Views.View view"},
+					{"public override", "void", "SetContentView", "global::Android.Views.View view, global::Android.Views.ViewGroup.LayoutParams @params"},
+					{"public override", "void", "SetContentView", "int layoutResID"},
+					{"partial", "void", "OnSetContentView", "global::Android.Views.View view, ref bool callBaseAfterReturn"},
+					{"partial", "void", "OnSetContentView", "global::Android.Views.View view, global::Android.Views.ViewGroup.LayoutParams @params, ref bool callBaseAfterReturn"},
+					{"partial", "void", "OnSetContentView", "int layoutResID, ref bool callBaseAfterReturn"},
+				},
+				new SourceFile (Path.Combine (generatedSourcesDir, "Xamarin.Android.Tests.CodeBehindBuildTests.MainMergeActivity.MainMerge.g.cs")) {
+					// Properties
+					{"public", "Button", "myButton"},
+					{"public", "CommonSampleLibrary.LogFragment", "log_fragment"},
+					{"public", "CommonSampleLibrary.LogFragment", "secondary_log_fragment"},
 
 					// Methods
 					{"public override", "void", "SetContentView", "global::Android.Views.View view"},


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/1929

`<merge>` is an element used by Android to avoid stacking too many view groups
when one layout is included into another. In such cases `<merge>` can be used as
a place-holder which is replaced by the enclosing view group of the layout that
includes another layout with `<merge>` as the root element. However, as much as
you can call `FindViewById` to find an instance of `<merge>` which was given the
`android:id` attribute, Android will always return `null` in such case, as the
element has no type counterpart in the `Android.Views` collection of views.
Therefore, we must ignore the element whenever we process a layout that contains
it decorated with `android:id` in order to avoid confusion in generated
code (i.e. the property generated for the element would be of type `merge` which
does not exist). We could instead generate a property of type
`Android.Views.View` and always return `null` from it, but that unnecessarily
increases code size - we'd be adding effectively dead code.