### PR TITLE
[timing] use Release build of xabuild/xamarin-android if possible

### DIFF
--- a/build-tools/timing/timing.targets
+++ b/build-tools/timing/timing.targets
@@ -45,7 +45,9 @@
   <Target Name="MSBuildPrep" DependsOnTargets="GetXAVersionInfo;AcquireAndroidTarget">
     <PropertyGroup>
       <_OutputDir>$(_TopDir)bin\Test$(Configuration)\</_OutputDir>
-      <_XABuild>$(_TopDir)bin\$(Configuration)\bin\xabuild</_XABuild>
+      <!--NOTE: prefer a Release build of xamarin-android if it exists-->
+      <_XABuild Condition="Exists('$(_TopDir)bin\Release\bin\xabuild')">$(_TopDir)bin\Release\bin\xabuild</_XABuild>
+      <_XABuild Condition=" '$(_XABuild)' == '' ">$(_TopDir)bin\$(Configuration)\bin\xabuild</_XABuild>
       <_TimingLogger>Xamarin.Android.Tools.BootstrapTasks.TimingLogger,$(_TopDir)bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll</_TimingLogger>
     </PropertyGroup>
     <ItemGroup>


### PR DESCRIPTION
When timing builds, and plotting them on Jenkins, we should prefer to
use the `Release` build output of `xamarin-android` if it exists.

This also will fix a problem downstream in `monodroid`, where I'm not
able to profile `Debug` builds because `bin\Debug` *might* not exist.
`monodroid` seems to mostly use `Release` builds of `xamarin-android`.
We really need to profile `Debug` Xamarin.Android application builds
so that we can see how `Fast Deployment` is performing.