### PR TITLE
Minimal changes to fix libmonodroid build for Windows with DEBUG

### DIFF
--- a/src/mono-runtimes/mono-runtimes.projitems
+++ b/src/mono-runtimes/mono-runtimes.projitems
@@ -216,7 +216,7 @@
       <Strip>strip</Strip>
       <StripFlags>-S</StripFlags>
       <TargetAbi>armv5-none-linux-androideabi</TargetAbi>
-      <ConfigureFlags>--target=armv5-linux-androideabi --cache-file=$(_CrossConfigureCachePrefix)arm.config.cache --with-cross-offsets=armv5-none-linux-androideabi.h $(_CrossConfigureFlags32) --with-llvm=$(_LlvmPrefix32)</ConfigureFlags>
+      <ConfigureFlags>--target=armv5-linux-androideabi --with-cross-offsets=armv5-none-linux-androideabi.h $(_CrossConfigureFlags32) --with-llvm=$(_LlvmPrefix32)</ConfigureFlags>
       <ExeSuffix></ExeSuffix>
       <BuildEnvironment></BuildEnvironment>
       <ConfigureEnvironment></ConfigureEnvironment>
@@ -240,7 +240,7 @@
       <Strip>strip</Strip>
       <StripFlags>-S</StripFlags>
       <TargetAbi>aarch64-v8a-linux-android</TargetAbi>
-      <ConfigureFlags>--target=aarch64-v8a-linux-android --cache-file=$(_CrossConfigureCachePrefix)arm64.config.cache --with-cross-offsets=aarch64-v8a-linux-android.h $(_CrossConfigureFlags) --with-llvm=$(_CrossDefaultLlvmPrefix)</ConfigureFlags>
+      <ConfigureFlags>--target=aarch64-v8a-linux-android --with-cross-offsets=aarch64-v8a-linux-android.h $(_CrossConfigureFlags) --with-llvm=$(_CrossDefaultLlvmPrefix)</ConfigureFlags>
       <ExeSuffix></ExeSuffix>
       <BuildEnvironment></BuildEnvironment>
       <ConfigureEnvironment></ConfigureEnvironment>
@@ -264,7 +264,7 @@
       <Strip>strip</Strip>
       <StripFlags>-S</StripFlags>
       <TargetAbi>i686-none-linux-android</TargetAbi>
-      <ConfigureFlags>--target=i686-linux-android --cache-file=$(_CrossConfigureCachePrefix)x86.config.cache --with-cross-offsets=i686-none-linux-android.h $(_CrossConfigureFlags32)  --with-llvm=$(_LlvmPrefix32)</ConfigureFlags>
+      <ConfigureFlags>--target=i686-linux-android --with-cross-offsets=i686-none-linux-android.h $(_CrossConfigureFlags32)  --with-llvm=$(_LlvmPrefix32)</ConfigureFlags>
       <ExeSuffix></ExeSuffix>
       <BuildEnvironment></BuildEnvironment>
       <ConfigureEnvironment></ConfigureEnvironment>
@@ -288,7 +288,7 @@
       <Strip>strip</Strip>
       <StripFlags>-S</StripFlags>
       <TargetAbi>x86_64-none-linux-android</TargetAbi>
-      <ConfigureFlags>--target=x86_64-linux-android --cache-file=$(_CrossConfigureCachePrefix)x86_64.config.cache --with-cross-offsets=x86_64-none-linux-android.h $(_CrossConfigureFlags)  --with-llvm=$(_CrossDefaultLlvmPrefix)</ConfigureFlags>
+      <ConfigureFlags>--target=x86_64-linux-android --with-cross-offsets=x86_64-none-linux-android.h $(_CrossConfigureFlags)  --with-llvm=$(_CrossDefaultLlvmPrefix)</ConfigureFlags>
       <ExeSuffix></ExeSuffix>
       <BuildEnvironment></BuildEnvironment>
       <ConfigureEnvironment></ConfigureEnvironment>
@@ -312,7 +312,7 @@
       <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-strip</Strip>
       <StripFlags>-S</StripFlags>
       <TargetAbi>armv5-none-linux-androideabi</TargetAbi>
-      <ConfigureFlags>--target=armv5-linux-androideabi --host="$(_CrossConfigureBuildHostWin32)" --cache-file=$(_CrossConfigureCachePrefix)arm-win.config.cache --with-cross-offsets=armv5-none-linux-androideabi.h $(_CrossConfigureFlags32) --with-llvm=$(_LlvmPrefixWin32)</ConfigureFlags>
+      <ConfigureFlags>--target=armv5-linux-androideabi --host="$(_CrossConfigureBuildHostWin32)" --with-cross-offsets=armv5-none-linux-androideabi.h $(_CrossConfigureFlags32) --with-llvm=$(_LlvmPrefixWin32)</ConfigureFlags>
       <ExeSuffix>.exe</ExeSuffix>
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ConfigureEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</ConfigureEnvironment>
@@ -335,7 +335,7 @@
       <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-strip</Strip>
       <StripFlags>-S</StripFlags>
       <TargetAbi>aarch64-v8a-linux-android</TargetAbi>
-      <ConfigureFlags>--target=aarch64-v8a-linux-android --host="$(_CrossConfigureBuildHostWin64)" --cache-file=$(_CrossConfigureCachePrefix)arm64-win.config.cache --with-cross-offsets=aarch64-v8a-linux-android.h $(_CrossConfigureFlags) --with-llvm=$(_LlvmPrefixWin64)</ConfigureFlags>
+      <ConfigureFlags>--target=aarch64-v8a-linux-android --host="$(_CrossConfigureBuildHostWin64)" --with-cross-offsets=aarch64-v8a-linux-android.h $(_CrossConfigureFlags) --with-llvm=$(_LlvmPrefixWin64)</ConfigureFlags>
       <ExeSuffix>.exe</ExeSuffix>
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ConfigureEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</ConfigureEnvironment>
@@ -358,7 +358,7 @@
       <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix32)-strip</Strip>
       <StripFlags>-S</StripFlags>
       <TargetAbi>i686-none-linux-android</TargetAbi>
-      <ConfigureFlags>--target=i686-linux-android --host="$(_CrossConfigureBuildHostWin32)" --cache-file=$(_CrossConfigureCachePrefix)x86-win.config.cache --with-cross-offsets=i686-none-linux-android.h $(_CrossConfigureFlags32) --with-llvm=$(_LlvmPrefixWin32)</ConfigureFlags>
+      <ConfigureFlags>--target=i686-linux-android --host="$(_CrossConfigureBuildHostWin32)" --with-cross-offsets=i686-none-linux-android.h $(_CrossConfigureFlags32) --with-llvm=$(_LlvmPrefixWin32)</ConfigureFlags>
       <ExeSuffix>.exe</ExeSuffix>
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ConfigureEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</ConfigureEnvironment>
@@ -381,7 +381,7 @@
       <Strip>$(AndroidMxeFullPath)\bin\$(MingwCommandPrefix64)-strip</Strip>
       <StripFlags>-S</StripFlags>
       <TargetAbi>x86_64-none-linux-android</TargetAbi>
-      <ConfigureFlags>--target=x86_64-linux-android --host="$(_CrossConfigureBuildHostWin64)" --cache-file=$(_CrossConfigureCachePrefix)x86_64-win.config.cache --with-cross-offsets=x86_64-none-linux-android.h $(_CrossConfigureFlags) --with-llvm=$(_LlvmPrefixWin64)</ConfigureFlags>
+      <ConfigureFlags>--target=x86_64-linux-android --host="$(_CrossConfigureBuildHostWin64)" --with-cross-offsets=x86_64-none-linux-android.h $(_CrossConfigureFlags) --with-llvm=$(_LlvmPrefixWin64)</ConfigureFlags>
       <ExeSuffix>.exe</ExeSuffix>
       <BuildEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</BuildEnvironment>
       <ConfigureEnvironment>PATH="$(AndroidMxeFullPath)\bin:$(PATH)"</ConfigureEnvironment>

--- a/src/monodroid/jni/monodroid-glue.c
+++ b/src/monodroid/jni/monodroid-glue.c
@@ -31,7 +31,7 @@
 #include <sys/syscall.h>
 #endif
 
-#if defined (DEBUG)
+#if defined (DEBUG) && !defined (WINDOWS)
 #include <fcntl.h>
 #include <arpa/inet.h>
 #include <sys/types.h>
@@ -83,7 +83,7 @@ static int sdb_fd;
 static int profiler_configured;
 static int profiler_fd;
 static char *profiler_description;
-#ifdef DEBUG
+#if DEBUG
 static int config_timedout;
 static struct timeval wait_tv;
 static struct timespec wait_ts;
@@ -2061,7 +2061,7 @@ gather_bundled_assemblies (JNIEnv *env, jobjectArray runtimeApks, mono_bool regi
 	}
 }
 
-#if DEBUG
+#if defined (DEBUG) && !defined (WINDOWS)
 int monodroid_debug_connect (int sock, struct sockaddr_in addr) {
 	long flags = 0;
 	int res = 0;
@@ -2519,7 +2519,7 @@ mono_runtime_init (char *runtime_args)
 #endif
 	char *prop_val;
 
-#if DEBUG
+#if defined (DEBUG) && !defined (WINDOWS)
 	memset(&options, 0, sizeof (options));
 
 	cur_time = time (NULL);
@@ -3824,7 +3824,7 @@ Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobject
 
 	monodroid_get_namespaced_system_property (DEBUG_MONO_CONNECT_PROPERTY, &connect_args);
 
-#ifdef DEBUG
+#if defined (DEBUG) && !defined (WINDOWS)
 	if (connect_args) {
 		int res = start_connection (connect_args);
 		if (res != 2) {


### PR DESCRIPTION
When the `DEBUG` macro is defined it causes the build to include code that's
specific to Unix systems and will not build when targetting Windows (mostly
related to sockets). This commit modifies the minimal set of lines (on purpose,
to reduce the noise) to make the Windows cross-builds work.

Additionally, the `--cache-file` configure parameter is removed from
`mono-runtimes.projitems` as it is a duplicate and incorrect, with the correct
one found in `mono-runtimes.targets` file, in the `_ConfigureCrossRuntimes`
target.