### PR TITLE
[tests] fix CheckTargetFrameworkVersion tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1722,14 +1722,15 @@ namespace App1
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
 			};
+			proj.SetProperty ("AndroidUseLatestPlatformSdk", "False");
 			proj.SetProperty ("TargetFrameworkVersion", "v2.3");
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				if (!Directory.Exists (Path.Combine (builder.FrameworkLibDirectory, "xbuild-frameworks", "MonoAndroid", "v2.3")))
 					Assert.Ignore ("This is a Pull Request Build. Ignoring test.");
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
-				StringAssertEx.Contains ($"Output Property: TargetFrameworkVersion=v2.3", builder.LastBuildOutput, "TargetFrameworkVerson should be v2.3");
+				Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, $"Output Property: TargetFrameworkVersion=v2.3"), "TargetFrameworkVerson should be v2.3");
 				Assert.IsTrue (builder.Build (proj, parameters: new [] { "TargetFrameworkVersion=v4.4" }), "Build should have succeeded.");
-				StringAssertEx.Contains ($"Output Property: TargetFrameworkVersion=v4.4", builder.LastBuildOutput, "TargetFrameworkVerson should be v4.4");
+				Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, $"Output Property: TargetFrameworkVersion=v4.4"), "TargetFrameworkVerson should be v4.4");
 
 			}
 		}
@@ -2161,14 +2162,15 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 			};
+			proj.SetProperty ("AndroidUseLatestPlatformSdk", "False");
 			proj.SetProperty ("TargetFrameworkVersion", "v2.3");
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				if (!Directory.Exists (Path.Combine (builder.FrameworkLibDirectory, "xbuild-frameworks", "MonoAndroid", "v2.3")))
 					Assert.Ignore ("This is a Pull Request Build. Ignoring test.");
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
-				StringAssertEx.Contains ($"Output Property: TargetFrameworkVersion=v2.3", builder.LastBuildOutput, "TargetFrameworkVerson should be v2.3");
+				Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, $"Output Property: TargetFrameworkVersion=v2.3"), "TargetFrameworkVerson should be v2.3");
 				Assert.IsTrue (builder.Build (proj, parameters: new [] { "TargetFrameworkVersion=v4.4" }), "Build should have succeeded.");
-				StringAssertEx.Contains ($"Output Property: TargetFrameworkVersion=v4.4", builder.LastBuildOutput, "TargetFrameworkVerson should be v4.4");
+				Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, $"Output Property: TargetFrameworkVersion=v4.4"), "TargetFrameworkVerson should be v4.4");
 			}
 		}
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/1916

These tests were never quite right, since they were just looking for
instances of `TargetFrameworkVersion` in the build log. This would
match for inputs and outputs, and wasn't actually testing anything
because it appeared to always pass.

In #1916 I improved them by looking for
`Output Property: TargetFrameworkVersion=v2.3`, but they were
not passing.

Two issues to fix:
- These tests should set `AndroidUseLatestPlatformSdk=False`
- These tests shouldn't use `StringAssertEx.Contains` because it calls
  `Assert.Pass`, skipping any future assertions...

When testing on Windows, these tests get skipped, so I had to fix
things on Mac. The PR builder also skips them, so we did not see the
issue until it was merged into master.