### PR TITLE
Add Linux Mint to the fold

### DIFF
--- a/build-tools/scripts/dependencies/debian-common.sh
+++ b/build-tools/scripts/dependencies/debian-common.sh
@@ -18,7 +18,7 @@ DEBIAN_COMMON_DEPS="autoconf
 	"
 
 if [ "$OS_ARCH" = "x86_64" ]; then
-UBUNTU_DEPS="$UBUNTU_DEPS
+DEBIAN_COMMON_DEPS="$DEBIAN_COMMON_DEPS
 	lib32stdc++6
 	lib32z1
 	gcc-multilib
@@ -43,6 +43,6 @@ debian_install()
 			exit 1
 		fi
 	else
-		sudo apt-get -f -u install $DISTRO_DEPS
+		sudo apt-get -f -u -y install $DISTRO_DEPS
 	fi
 }

--- a/build-tools/scripts/dependencies/linux-prepare-LinuxMint.sh
+++ b/build-tools/scripts/dependencies/linux-prepare-LinuxMint.sh
@@ -5,7 +5,7 @@ DISTRO_DEPS="$DEBIAN_COMMON_DEPS"
 MAJOR=$(echo $1 | cut -d '.' -f 1)
 MINOR=$(echo $1 | cut -d '.' -f 2)
 
-if [ $MAJOR -eq 17 -a $MINOR -eq 10 ] || [ $MAJOR -ge 18 ]; then
+if [ $MAJOR -ge 19 ]; then
     NEED_LIBTOOL=yes
 else
     NEED_LIBTOOL=no

--- a/build-tools/scripts/dependencies/ubuntu-common.sh
+++ b/build-tools/scripts/dependencies/ubuntu-common.sh
@@ -1,0 +1,11 @@
+if [ "$OS_ARCH" = "x86_64" ]; then
+    DISTRO_DEPS="$DISTRO_DEPS
+	libx32tinfo-dev
+	linux-libc-dev:i386
+	zlib1g-dev:i386
+	"
+fi
+
+if [ "$NEED_LIBTOOL" = "yes" ]; then
+    DISTRO_DEPS="$DISTRO_DEPS libtool-bin"
+fi

--- a/build-tools/scripts/generate-os-info
+++ b/build-tools/scripts/generate-os-info
@@ -79,8 +79,8 @@ function getInfo_Linux()
     fi
 
     case "$OS_NAME" in
-      Ubuntu|Debian) HOST_OS_FLAVOR=Debian ;;
-      *) OS_FLAVOR=Generic ;;
+      Ubuntu|Debian|LinuxMint) HOST_OS_FLAVOR=Debian ;;
+      *) HOST_OS_FLAVOR=Generic ;;
     esac
 
     HOST_CPUS="`nproc`"


### PR DESCRIPTION
Add detection and preparation script for the Linux Mint distribution. Since Mint
is based on Ubuntu, this patch reorganizes things a little bit to reuse as much
of Ubuntu specific code as possible.