### PR TITLE
[Xamarin.Android.Build.Tasks] use designtime/build.props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ Resource.designer.cs
 logcat-*.txt
 apk-sizes-*.txt
 *.rawproto
+*.binlog
 src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -121,6 +121,43 @@ namespace Xamarin.Android.Tests
 		}
 
 		[Test]
+		public void SwitchBetweenDesignTimeBuild ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "first *regular* build should have succeeded.");
+				var build_props = b.Output.GetIntermediaryPath ("build.props");
+				var designtime_build_props = b.Output.GetIntermediaryPath (Path.Combine ("designtime", "build.props"));
+				FileAssert.Exists (build_props, "build.props should exist after a first `Build`.");
+				FileAssert.DoesNotExist (designtime_build_props, "designtime/build.props should *not* exist after a first `Build`.");
+
+				b.Target = "Compile";
+				Assert.IsTrue (b.Build (proj, parameters: new [] { "DesignTimeBuild=True" }), "first design-time build should have succeeded.");
+				FileAssert.Exists (build_props, "build.props should exist after a design-time build.");
+				FileAssert.Exists (designtime_build_props, "designtime/build.props should exist after a design-time build.");
+
+				b.Target = "Build";
+				Assert.IsTrue (b.Build (proj), "second *regular* build should have succeeded.");
+				FileAssert.Exists (build_props, "build.props should exist after the second `Build`.");
+				FileAssert.Exists (designtime_build_props, "designtime/build.props should exist after the second `Build`.");
+
+				//NOTE: none of these targets should run, since we have not actually changed anything!
+				Assert.IsTrue (b.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "`_UpdateAndroidResgen` should be skipped!");
+				//TODO: We would like for this assertion to work, but the <Compile /> item group changes between DTB and regular builds
+				//      $(IntermediateOutputPath)designtime\Resource.designer.cs -> Resources\Resource.designer.cs
+				//      And so the built assembly changes between DTB and regular build, triggering `_LinkAssembliesNoShrink`
+				//Assert.IsTrue (b.Output.IsTargetSkipped ("_LinkAssembliesNoShrink"), "`_LinkAssembliesNoShrink` should be skipped!");
+
+				b.Target = "Clean";
+				Assert.IsTrue (b.Build (proj), "clean should have succeeded.");
+
+				FileAssert.DoesNotExist (build_props, "build.props should *not* exist after `Clean`.");
+				FileAssert.Exists (designtime_build_props, "designtime/build.props should exist after `Clean`.");
+			}
+		}
+
+		[Test]
 		public void BuildPropsBreaksConvertResourcesCases ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -274,6 +274,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<_AndroidProguardInputJarFilter>(!META-INF/MANIFEST.MF)</_AndroidProguardInputJarFilter>
 	<_AndroidAapt2VersionFile>$(IntermediateOutputPath)aapt2.version</_AndroidAapt2VersionFile>
 	<_AndroidNuGetStampFile>$(IntermediateOutputPath)$(MSBuildProjectName).nuget.stamp</_AndroidNuGetStampFile>
+	<_AndroidIntermediateDesignTimeBuildDirectory>$(IntermediateOutputPath)designtime\</_AndroidIntermediateDesignTimeBuildDirectory>
 
 	<!-- $(EnableProguard) is an obsolete property that should be removed at some stage. -->
 	<AndroidEnableProguard Condition="'$(AndroidEnableProguard)'==''">$(EnableProguard)</AndroidEnableProguard>
@@ -305,6 +306,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<_AndroidSequencePointsMode Condition=" '$(_AndroidSequencePointsMode)' == ''">None</_AndroidSequencePointsMode>
 	<_InstantRunEnabled Condition=" '$(_InstantRunEnabled)' == '' ">False</_InstantRunEnabled>
 	<_AndroidBuildPropertiesCache>$(IntermediateOutputPath)build.props</_AndroidBuildPropertiesCache>
+	<_AndroidDesignTimeBuildPropertiesCache>$(_AndroidIntermediateDesignTimeBuildDirectory)build.props</_AndroidDesignTimeBuildPropertiesCache>
 
 	<AndroidGenerateJniMarshalMethods Condition=" '$(AndroidGenerateJniMarshalMethods)' == '' ">False</AndroidGenerateJniMarshalMethods>
 
@@ -426,8 +428,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		<_AndroidResourcePathsCache Condition=" '$(DesignTimeBuild)' == 'true' And !Exists ('$(_AndroidResourcePathsCache)') ">$(_AndroidResourcePathsDesignTimeCache)</_AndroidResourcePathsCache>
 		<_AndroidLibraryImportsCache Condition=" '$(DesignTimeBuild)' == 'true' And !Exists ('$(_AndroidLibraryImportsCache)') ">$(_AndroidLibraryImportsDesignTimeCache)</_AndroidLibraryImportsCache>
 		<_AndroidLibraryProjectImportsCache Condition=" '$(DesignTimeBuild)' == 'true' And !Exists ('$(_AndroidLibraryProjectImportsCache)') ">$(_AndroidLibraryProjectImportsDesignTimeCache)</_AndroidLibraryProjectImportsCache>
+		<_AndroidBuildPropertiesCache Condition=" '$(DesignTimeBuild)' == 'true' ">$(_AndroidDesignTimeBuildPropertiesCache)</_AndroidBuildPropertiesCache>
 	</PropertyGroup>
-	<MakeDir Directories="$(_AndroidDesignTimeResDirIntermediate)" Condition=" '$(DesignTimeBuild)' == 'true' " />
+	<MakeDir Directories="$(_AndroidIntermediateDesignTimeBuildDirectory)" Condition=" '$(DesignTimeBuild)' == 'true' " />
 </Target>
 
 <PropertyGroup>
@@ -1147,11 +1150,10 @@ because xbuild doesn't support framework reference assemblies.
 	<_AndroidStaticResourcesFlag>$(IntermediateOutputPath)static.flag</_AndroidStaticResourcesFlag>
 	<_AndroidResourcesCacheFile>$(IntermediateOutputPath)mergeresources.cache</_AndroidResourcesCacheFile>
 	<AndroidUseManagedDesignTimeResourceGenerator Condition=" '$(AndroidUseManagedDesignTimeResourceGenerator)' == '' " >True</AndroidUseManagedDesignTimeResourceGenerator>
-	<_AndroidDesignTimeResDirIntermediate>$(IntermediateOutputPath)designtime\</_AndroidDesignTimeResDirIntermediate>
-	<_AndroidResourcePathsDesignTimeCache>$(_AndroidDesignTimeResDirIntermediate)resourcepaths.cache</_AndroidResourcePathsDesignTimeCache>
-	<_AndroidLibraryImportsDesignTimeCache>$(_AndroidDesignTimeResDirIntermediate)libraryimports.cache</_AndroidLibraryImportsDesignTimeCache>
-	<_AndroidLibraryProjectImportsDesignTimeCache>$(_AndroidDesignTimeResDirIntermediate)libraryprojectimports.cache</_AndroidLibraryProjectImportsDesignTimeCache>
-	<_AndroidManagedResourceDesignerFile>$(_AndroidDesignTimeResDirIntermediate)$(_AndroidResourceDesigner)</_AndroidManagedResourceDesignerFile>
+	<_AndroidResourcePathsDesignTimeCache>$(_AndroidIntermediateDesignTimeBuildDirectory)resourcepaths.cache</_AndroidResourcePathsDesignTimeCache>
+	<_AndroidLibraryImportsDesignTimeCache>$(_AndroidIntermediateDesignTimeBuildDirectory)libraryimports.cache</_AndroidLibraryImportsDesignTimeCache>
+	<_AndroidLibraryProjectImportsDesignTimeCache>$(_AndroidIntermediateDesignTimeBuildDirectory)libraryprojectimports.cache</_AndroidLibraryProjectImportsDesignTimeCache>
+	<_AndroidManagedResourceDesignerFile>$(_AndroidIntermediateDesignTimeBuildDirectory)$(_AndroidResourceDesigner)</_AndroidManagedResourceDesignerFile>
 </PropertyGroup>
 
 <ItemGroup>
@@ -1216,7 +1218,7 @@ because xbuild doesn't support framework reference assemblies.
 		Inputs="$(_ManagedUpdateAndroidResgenInputs);$(_AndroidResourcePathsCache);$(_AndroidLibraryProjectImportsCache);$(_AndroidLibraryImportsCache);"
 		Outputs="$(_AndroidManagedResourceDesignerFile)"
 		DependsOnTargets="_CreatePropertiesCache;_ExtractLibraryProjectImports;_CreateAdditionalResourceCache">
-	<MakeDir Directories="$(_AndroidDesignTimeResDirIntermediate)" />
+	<MakeDir Directories="$(_AndroidIntermediateDesignTimeBuildDirectory)" />
 	<!-- Parse primary R.java and create Resources.Designer.cs -->
 	<GenerateResourceDesigner
 		ContinueOnError="$(DesignTimeBuild)"
@@ -2985,7 +2987,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_CleanDesignTimeIntermediateDir">
-	<RemoveDirFixed Directories="$(_AndroidDesignTimeResDirIntermediate)" Condition="Exists ('$(_AndroidDesignTimeResDirIntermediate)')" />
+	<RemoveDirFixed Directories="$(_AndroidIntermediateDesignTimeBuildDirectory)" Condition="Exists ('$(_AndroidIntermediateDesignTimeBuildDirectory)')" />
 </Target>
 
 <Target Name="_CleanGeneratedDeploymentFiles">


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/1958
Context: https://github.com/xamarin/xamarin-android/issues/1933
Context: https://github.com/xamarin/xamarin-android/pull/1943

One of the issues I noticed while debugging the issue with #1933 is
that `$(IntermediateOutputPath)build.props` gets invalidated if
`$(DesignTimeBuild)` changes. `build.props` triggers alot of targets
to build completely again, so this is pretty bad for our build times
in an IDE...

Design-Time Builds can run quite frequently in VS Windows, and we
don't want to rebuild a bunch of things unnecessarily when the user
switches back to a regular build.

So a solution, is to use a `obj/Debug/designtime/build.props` that
works independantly of `build.props`. This prevents some slower
targets from running when they shouldn't, such as
`_UpdateAndroidResgen`.

I added a test to validate these changes, which also verify that
`IncrementalClean` isn't deleting these files.

It also is important to point out that any files in the `designtime`
directory are not deleted during a `Clean`. Context on this here:
https://github.com/xamarin/xamarin-android/commit/34a377456872b957b3e3a573075f88b7d4a7e1b8

Other changes:
- Updated `.gitignore` for `*.binlog`
- Renamed `_AndroidDesignTimeResDirIntermediate` to
  `_AndroidIntermediateDesignTimeBuildDirectory` and declared it
  earlier in `Xamarin.Android.Common.targets`