### PR TITLE
[Xamarin.Android.Build.Tasks] we should set TargetFrameworkMonikerAssemblyAttributesPath

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -146,6 +146,28 @@ namespace Xamarin.Android.Tests
 		}
 
 		[Test]
+		public void TargetFrameworkMonikerAssemblyAttributesPath ()
+		{
+			const string filePattern = "MonoAndroid,Version=v*.AssemblyAttributes.cs";
+			var proj = new XamarinAndroidApplicationProject {
+				TargetFrameworkVersion = "v6.0",
+			};
+			proj.SetProperty ("AndroidUseLatestPlatformSdk", "True");
+
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "build should have succeeded.");
+
+				var intermediate = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath);
+				var old_assemblyattributespath = Path.Combine (intermediate, $"MonoAndroid,Version={proj.TargetFrameworkVersion}.AssemblyAttributes.cs");
+				FileAssert.DoesNotExist (old_assemblyattributespath, "TargetFrameworkMonikerAssemblyAttributesPath should have the newer TargetFrameworkVersion.");
+
+				var new_assemblyattributespath = Directory.EnumerateFiles (intermediate, filePattern).SingleOrDefault ();
+				Assert.IsNotNull (new_assemblyattributespath, $"A *single* file of pattern {filePattern} should exist in `$(IntermediateOutputPath)`.");
+				StringAssert.DoesNotContain (proj.TargetFrameworkVersion, File.ReadAllText (new_assemblyattributespath), $"`{new_assemblyattributespath}` should not contain `{proj.TargetFrameworkVersion}`!");
+			}
+		}
+
+		[Test]
 		public void CheckTimestamps ()
 		{
 			var start = DateTime.UtcNow.AddSeconds (-1);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -750,6 +750,16 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 				Condition="'$(TargetFrameworkProfile)' == ''"
 		/>
 	</CreateProperty>
+	<CreateProperty Value="$(IntermediateOutputPath)$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)">
+		<Output TaskParameter="Value" PropertyName="TargetFrameworkMonikerAssemblyAttributesPath"
+				Condition="'$(TargetFrameworkMoniker)' != ''"
+		/>
+	</CreateProperty>
+	<CreateItem Include="$(TargetFrameworkMonikerAssemblyAttributesPath)">
+		<Output TaskParameter="Include" ItemName="FileWrites"
+				Condition="'$(TargetFrameworkMonikerAssemblyAttributesPath)' != ''"
+		/>
+	</CreateItem>
 	<CreateItem Include="$(_JavaInteropReferences)">
 		<Output TaskParameter="Include" ItemName="Reference" />
 	</CreateItem>


### PR DESCRIPTION
Context: https://github.com/Microsoft/msbuild/blob/b3f9eeab651c92bade6e4f64d11b59aa39e149cb/src/Tasks/Microsoft.Common.CurrentVersion.targets#L3305
Fixes: https://github.com/xamarin/xamarin-android/issues/1960

While reviewing build logs, I have noticed something very odd if you
are building for `TargetFrameworkVersion=v6.0` and it gets switched to
a different one such as `TargetFrameworkVersion=v9.0`.

Here is the `GenerateTargetFrameworkMonikerAttribute` target from
`Microsoft.Common.CurrentVersion.targets`:

    WriteLinesToFile
        Parameters
            File = C:\Users\myuser\AppData\Local\Temp\MonoAndroid,Version=v6.0.AssemblyAttributes.cs
            Lines
                // <autogenerated />
                using System;
                using System.Reflection;
                [assembly: global::System.Runtime.Versioning.TargetFrameworkAttribute("MonoAndroid,Version=v9.0", FrameworkDisplayName = "Xamarin.Android v9.0 Support")]
            Overwrite = True

This was *very* odd, since it was writing a file named
`MonoAndroid,Version=v6.0.AssemblyAttributes.cs` but then writing
`[assembly: TargetFrameworkAttribute("MonoAndroid,Version=v9.0"]` into
it!

It appears we are seeing MSBuild's implementation of how
`[assembly: TargetFrameworkAttribute]` is added to a compiled assembly.
It writes to a temp file using the value from
`$(TargetFrameworkMonikerAssemblyAttributesPath)`. We are not setting
this property in `Xamarin.Android.Common.targets` after modifying the
value of `$(TargetFrameworkVersion)`.

## What could this break?

Consider building multiple Xamarin.Android projects at the same time
with different `TargetFrameworkVersion` settings. The builds could
"step on each other" and write an inappropriate value into the temp
file!

In fact, this did actually occur in March, see an example from kzu
here: https://xamarinhq.slack.com/archives/C03CEGRUW/p1521475676000161

    kzu: how is this even possible?

            <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
            <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>

    kzu: run `Rebuild` from IDE. get warning

            warning XA0105: The $(TargetFrameworkVersion) for App1.Android.dll (v8.1) is greater than the $(TargetFrameworkVersion) for your project (v8.0). You need to increase the $(TargetFrameworkVersion) for your project.

It looks like the contents of
`MonoAndroid,Version=v8.0.AssemblyAttributes.cs` likely contained
`v8.1`, causing an unexplicable warning. The file was also not getting
updated, even on a `Rebuild`!

I added some additional code in `Xamarin.Android.Common.targets` to
set the `$(TargetFrameworkMonikerAssemblyAttributesPath)`
appropriately, and added a test to check for the problem.

I used the exact code from MSBuild, but changed the file to live in
`$(IntermediateOutputPath)`, as to avoid read/write race conditions if
multiple Xamarin.Android projects were being built on the same
machine.

MSBuild core targets handle creating this file, cleaning it, etc.

https://github.com/Microsoft/msbuild/blob/b3f9eeab651c92bade6e4f64d11b59aa39e149cb/src/Tasks/Microsoft.Common.CurrentVersion.targets#L3302-L3337

We also need to add `$(TargetFrameworkMonikerAssemblyAttributesPath)`
to the `FileWrites` item group so `IncrementalClean` and `Clean` work
appropriately.