### PR TITLE
[tests] Add category support to the new NUnit runner, and a category to the DotNetInterfacesShouldEqualJavaInterfaces test

### DIFF
--- a/src/Mono.Android/Test/System.Net/NetworkInterfaces.cs
+++ b/src/Mono.Android/Test/System.Net/NetworkInterfaces.cs
@@ -100,7 +100,7 @@ namespace System.NetTests
 			}
 		}
 
-		[Test]
+		[Test, Ignore("See https://github.com/xamarin/xamarin-android/issues/1534")]
 		public void DotNetInterfacesShouldEqualJavaInterfaces ()
 		{
 			List <InterfaceInfo> dotnetInterfaces = GetInfos (MNetworkInterface.GetAllNetworkInterfaces ());

--- a/src/Mono.Android/Test/System.Net/NetworkInterfaces.cs
+++ b/src/Mono.Android/Test/System.Net/NetworkInterfaces.cs
@@ -100,7 +100,7 @@ namespace System.NetTests
 			}
 		}
 
-		[Test, Ignore("See https://github.com/xamarin/xamarin-android/issues/1534")]
+		[Test, Category("NetworkInterfaces")]
 		public void DotNetInterfacesShouldEqualJavaInterfaces ()
 		{
 			List <InterfaceInfo> dotnetInterfaces = GetInfos (MNetworkInterface.GetAllNetworkInterfaces ());

--- a/tests/TestRunner.Core/TestInstrumentation.cs
+++ b/tests/TestRunner.Core/TestInstrumentation.cs
@@ -315,6 +315,17 @@ namespace Xamarin.Android.UnitTests
 			return Assembly.LoadFrom (filePath);
 		}
 
+		protected Dictionary<string, string> GetStringExtrasFromBundle()
+		{
+			var filtersFromBundle = new Dictionary<string, string>();
+			foreach (var key in arguments.KeySet()) {
+				string value = arguments.GetString(key);
+				if (!string.IsNullOrEmpty(value))
+					filtersFromBundle.Add(key, value);
+			}
+			return filtersFromBundle;
+		}
+
 		protected virtual void ConfigureFilters (TRunner runner)
 		{}
 

--- a/tests/TestRunner.Core/TestInstrumentation.cs
+++ b/tests/TestRunner.Core/TestInstrumentation.cs
@@ -315,13 +315,13 @@ namespace Xamarin.Android.UnitTests
 			return Assembly.LoadFrom (filePath);
 		}
 
-		protected Dictionary<string, string> GetStringExtrasFromBundle()
+		protected Dictionary<string, string> GetStringExtrasFromBundle ()
 		{
-			var filtersFromBundle = new Dictionary<string, string>();
-			foreach (var key in arguments.KeySet()) {
-				string value = arguments.GetString(key);
-				if (!string.IsNullOrEmpty(value))
-					filtersFromBundle.Add(key, value);
+			var filtersFromBundle = new Dictionary<string, string> ();
+			foreach (var key in arguments.KeySet ()) {
+				string value = arguments.GetString (key);
+				if (!string.IsNullOrEmpty (value))
+					filtersFromBundle.Add (key, value);
 			}
 			return filtersFromBundle;
 		}

--- a/tests/TestRunner.NUnit/NUnitTestInstrumentation.cs
+++ b/tests/TestRunner.NUnit/NUnitTestInstrumentation.cs
@@ -42,13 +42,13 @@ namespace Xamarin.Android.UnitTests.NUnit
 			};
 		}
 
-		IEnumerable<string> GetFilterValuesFromExtras(string key)
+		IEnumerable<string> GetFilterValuesFromExtras (string key)
 		{
-			Dictionary<string, string> extras = GetStringExtrasFromBundle();
-			if (extras.ContainsKey(key)) {
-				string filterValue = extras[key];
-				if (!string.IsNullOrEmpty(filterValue))
-					return filterValue.Split(':');
+			Dictionary<string, string> extras = GetStringExtrasFromBundle ();
+			if (extras.ContainsKey (key)) {
+				string filterValue = extras [key];
+				if (!string.IsNullOrEmpty (filterValue))
+					return filterValue.Split (':');
 			}
 			return null;
 		}

--- a/tests/TestRunner.NUnit/NUnitTestInstrumentation.cs
+++ b/tests/TestRunner.NUnit/NUnitTestInstrumentation.cs
@@ -36,10 +36,35 @@ namespace Xamarin.Android.UnitTests.NUnit
 
 		protected override NUnitTestRunner CreateRunner (LogWriter logger, Bundle bundle)
 		{
+			SetIncludedAndExcludedCategoriesFromBundle(bundle);
+
 			return new NUnitTestRunner (Context, logger, bundle) {
 				GCAfterEachFixture = true,
 				TestsRootDirectory = TestsDirectory
 			};
+		}
+
+		void SetIncludedAndExcludedCategoriesFromBundle(Bundle bundle)
+		{
+			string include = bundle?.GetString("include");
+			if (!string.IsNullOrEmpty(include)) {
+				var tempList = new List<string>(include.Split(':'));
+
+				if (IncludedCategories != null)
+					tempList.AddRange(IncludedCategories);
+
+				IncludedCategories = tempList;
+			}
+
+			string exclude = bundle?.GetString("exclude");
+			if (!string.IsNullOrEmpty(exclude)) {
+				var tempList = new List<string>(exclude.Split(':'));
+
+				if (ExcludedCategories != null)
+					tempList.AddRange(ExcludedCategories);
+
+				ExcludedCategories = tempList;
+			}
 		}
 
 		protected override void ConfigureFilters (NUnitTestRunner runner)


### PR DESCRIPTION
This test is failing rather consistently on many physical devices. See https://github.com/xamarin/xamarin-android/issues/1534 for more info.

I'd like to add a way to ignore this test conditionally, and we can do so with categories. However, the new NUnit test runner currently only allows included or excluded categories to be set in code when inheriting from `Xamarin.Android.UnitTests.NUnit.NUnitTestInstrumentation`. To address this, `NUnitTestInstrumentation` will now attempt to process certain instrumentation extras provided from the command line.

Usage:

`adb shell am instrument -e include InetAccess:NetworkInterfaces -w (PackageName)/(InstrumentationName)`

or

`adb shell am instrument -e exclude NetworkInterfaces -w (PackageName)/(InstrumentationName)`
