### PR TITLE
[Xamarin.Android.Build.Tasks] ManagedResourceParser should not throw

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -42,6 +42,8 @@
 
 ### XA1xxx Project Related
 
++ [XA1000](xa1000.md): There was an problem parsing {file}. This is likely due to incomplete or invalid xml.
+
 ### XA2xxx Linker
 
 ### XA3xxx AOT

--- a/Documentation/guides/messages/xa1000.md
+++ b/Documentation/guides/messages/xa1000.md
@@ -1,0 +1,8 @@
+# Compiler Warning XA1000
+
+This warning means there was an problem parsing a layout xml file
+by the `ManagedResourceParser`. This is usually due to invalid or
+incomplete xml. 
+
+If the xml is invalid your project will probably fail to build. 
+You should investigate any formatting issues with the specified xml file.

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1336,5 +1336,22 @@ namespace UnnamedProject
 				FileAssert.Exists (Path.Combine (Root, path, proj.IntermediateOutputPath, "generated", "Binding.Main.g.cs"));
 			}
 		}
+
+		[Test]
+		public void CheckInvalidXmlInManagedResourceParser ()
+		{
+			var path = Path.Combine ("temp", TestName);
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				LayoutMain = @""
+			};
+			proj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", "True");
+			using (var builder = CreateApkBuilder (path)) {
+				builder.ThrowOnBuildFailure = false;
+				builder.Target = "Compile";
+				Assert.IsFalse (builder.Build (proj), "Build should have failed.");
+				StringAssertEx.Contains ("warning XA1000", builder.LastBuildOutput, "Build output should contain a XA1000 warning.");
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1342,8 +1342,8 @@ namespace UnnamedProject
 		{
 			var path = Path.Combine ("temp", TestName);
 			var proj = new XamarinAndroidApplicationProject () {
-				IsRelease = true,
-				LayoutMain = @""
+				IsRelease       = true,
+				LayoutMain      = @"",
 			};
 			proj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", "True");
 			using (var builder = CreateApkBuilder (path)) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -246,7 +246,11 @@ namespace Xamarin.Android.Tasks
 			case ".axml":
 				if (string.Compare (path, "raw", StringComparison.OrdinalIgnoreCase) == 0)
 					goto default;
-				ProcessXmlFile (file);
+				try {
+					ProcessXmlFile (file);
+				} catch (XmlException ex) {
+					Log.LogCodedWarning ("XA1000", $"There was an problem parsing {file}. This is likely due to incomplete or invalid xml. Exception: {ex}");
+				}
 				break;
 			default:
 				break;


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/Xamarin%20Project%20Mgrs/_workitems/edit/639674

If a user generates an invalid or incomplete xml file the
`ManagedResourceParser` should not crash with an exception.


> The "GenerateResourceDesigner" task failed unexpectedly.System.Xml.XmlException: Root element is missing.   at System.Xml.XmlTextReaderImpl.Throw(Exception e)   at System.Xml.XmlTextReaderImpl.ParseDocumentContent()   at System.Xml.XmlTextReaderImpl.Read()   at Xamarin.Android.Tasks.ManagedResourceParser.ProcessXmlFile(String file)   at Xamarin.Android.Tasks.ManagedResourceParser.ProcessResourceFile(String file)   at Xamarin.Android.Tasks.ManagedResourceParser.Parse(String resourceDirectory, IEnumerable`1 additionalResourceDirectories, Boolean isApp, Dictionary`2 resourceMap)   at Xamarin.Android.Tasks.GenerateResourceDesigner.Execute()   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()   at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext()

It should issue a warning and let the build fail at a point
where `aapt` can issue a decent error.

If we leave the error reporting to `aapt` users should know how
to fix the issue, and get a decent error message.