### PR TITLE
[Xamarin.Android.Build.Tasks] Desugar now works without Proguard/MultiDex

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Desugar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Desugar.cs
@@ -39,12 +39,7 @@ namespace Xamarin.Android.Tasks
 			if (!Directory.Exists (OutputDirectory))
 				Directory.CreateDirectory (OutputDirectory);
 
-			base.Execute ();
-
-			Log.LogDebugMessage ($"{nameof (Desugar)} Outputs:");
-			Log.LogDebugTaskItems ($"  {nameof (OutputJars)}:", OutputJars);
-
-			return !Log.HasLoggedErrors;
+			return base.Execute ();
 		}
 
 		protected override string GenerateCommandLineCommands ()

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Desugar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Desugar.cs
@@ -8,7 +8,6 @@ using Microsoft.Build.Utilities;
 using System.Text;
 using System.Collections.Generic;
 using Xamarin.Android.Tools;
-using Xamarin.Android.Tools.Aidl;
 
 namespace Xamarin.Android.Tasks
 {
@@ -29,7 +28,6 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string OutputDirectory { get; set; }
 
-		public string InputClassesDirectory { get; set; }
 
 		public string [] InputJars { get; set; }
 
@@ -38,19 +36,15 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("Desugar Task");
-			Log.LogDebugMessage ("  JavaPlatformJarPath: ", JavaPlatformJarPath);
-			Log.LogDebugMessage ("  DesugarJarPath: ", DesugarJarPath);
-			Log.LogDebugMessage ("  DesugarExtraArguments: ", DesugarExtraArguments);
-			Log.LogDebugMessage ("  ManifestFile: ", ManifestFile);
-			Log.LogDebugMessage ("  OutputDirectory: ", OutputDirectory);
-			Log.LogDebugMessage ("  InputClassesDirectory: ", InputClassesDirectory);
-			Log.LogDebugTaskItems ("  InputJars: ", InputJars);
-
 			if (!Directory.Exists (OutputDirectory))
 				Directory.CreateDirectory (OutputDirectory);
 
-			return base.Execute ();
+			base.Execute ();
+
+			Log.LogDebugMessage ($"{nameof (Desugar)} Outputs:");
+			Log.LogDebugTaskItems ($"  {nameof (OutputJars)}:", OutputJars);
+
+			return !Log.HasLoggedErrors;
 		}
 
 		protected override string GenerateCommandLineCommands ()
@@ -91,13 +85,6 @@ namespace Xamarin.Android.Tasks
 			if (!string.IsNullOrEmpty (DesugarExtraArguments))
 				cmd.AppendSwitch (DesugarExtraArguments); // it should contain "--dex".
 
-			if (!string.IsNullOrEmpty (InputClassesDirectory)) {
-				cmd.AppendSwitch ("--input ");
-				cmd.AppendFileNameIfNotNull (InputClassesDirectory);
-				cmd.AppendSwitch ("--output ");
-				cmd.AppendFileNameIfNotNull (Path.Combine (OutputDirectory, "__app_classes__.jar"));
-			}
-
 			var outputs = new List<string> ();
 			var md5 = System.Security.Cryptography.MD5.Create ();
 			foreach (var jar in InputJars) {
@@ -110,7 +97,6 @@ namespace Xamarin.Android.Tasks
 			}
 
 			OutputJars = outputs.ToArray ();
-			Log.LogDebugTaskItems ("  OutputJars: ", OutputJars);
 
 			return cmd.ToString ();
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2809,9 +2809,15 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 0QMAAAwAAAAAAAAAAAAAAAAAwwAAAExhbWJkYS5jbGFzc1BLBQYAAAAAAwADALcAAAD7AgAAAAA=
 				") });
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
-				builder.ThrowOnBuildFailure = false;
+				builder.ThrowOnBuildFailure = enableDesugar;
 				Assert.AreEqual (enableDesugar, builder.Build (proj), "Unexpected build result");
 				Assert.IsFalse (builder.LastBuildOutput.ContainsText ("Duplicate zip entry"), "Should not get warning about [META-INF/MANIFEST.MF]");
+				
+				if (enableDesugar) {
+					var className = "Lmono/MonoRuntimeProvider;";
+					var dexFile = builder.Output.GetIntermediaryPath (Path.Combine ("android", "bin", "classes.dex"));
+					Assert.IsTrue (DexUtils.ContainsClass (className, dexFile, builder.AndroidSdkDirectory), $"`{dexFile}` should include `{className}`!");
+				}
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/DexUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Utilities/DexUtils.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.ProjectTools
+{
+	public static class DexUtils
+	{
+		/// <summary>
+		/// Runs the dexdump command to see if a class exists in a dex file
+		///     dexdump returns data of the form:
+		///     Class descriptor  : 'Landroid/app/ActivityTracker;'
+		/// </summary>
+		/// <param name="className">A Java class name of the form 'Landroid/app/ActivityTracker;'</param>
+		public static bool ContainsClass (string className, string dexFile, string androidSdkDirectory)
+		{
+			bool containsClass = false;
+			DataReceivedEventHandler handler = (s, e) => {
+				if (e.Data != null && e.Data.Contains ("Class descriptor") && e.Data.Contains (className))
+					containsClass = true;
+			};
+
+			var androidSdk = new AndroidSdkInfo ((l, m) => {
+					Console.WriteLine ($"{l}: {m}");
+					if (l == TraceLevel.Error) {
+						throw new Exception (m);
+					}
+				}, androidSdkDirectory);
+			var buildToolsPath = androidSdk.GetBuildToolsPaths ().FirstOrDefault ();
+			if (string.IsNullOrEmpty (buildToolsPath)) {
+				throw new Exception ($"Unable to find build-tools in `{androidSdkDirectory}`!");
+			}
+
+			var psi = new ProcessStartInfo {
+				FileName = Path.Combine (buildToolsPath, "dexdump"),
+				Arguments = $"\"{dexFile}\"",
+				CreateNoWindow = true,
+				WindowStyle = ProcessWindowStyle.Hidden,
+				UseShellExecute = false,
+				RedirectStandardError = true,
+				RedirectStandardOutput = true,
+			};
+			var builder = new StringBuilder ();
+			using (var p = new Process { StartInfo = psi }) {
+				p.ErrorDataReceived += handler;
+				p.OutputDataReceived += handler;
+
+				p.Start ();
+				p.BeginErrorReadLine ();
+				p.BeginOutputReadLine ();
+				p.WaitForExit ();
+			}
+
+			return containsClass;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Android\KnownProperties.cs" />
     <Compile Include="Android\AndroidLinkMode.cs" />
     <Compile Include="Common\FailedBuildException.cs" />
+    <Compile Include="Utilities\DexUtils.cs" />
     <Compile Include="Utilities\PNGChecker.cs" />
     <Compile Include="Utilities\ZipHelper.cs" />
     <Compile Include="Common\XamarinPCLProject.cs" />
@@ -79,16 +80,8 @@
     <Compile Include="Common\DotNetStandard.cs" />
     <Compile Include="Common\DotNetXamarinProject.cs" />
     <Compile Include="..\..\..\..\bin\Test$(CONFIGURATION)\XABuildPaths.cs">
-       <Link>XABuildPaths.cs</Link>
+      <Link>XABuildPaths.cs</Link>
     </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Common\" />
-    <Folder Include="Android\" />
-    <Folder Include="Resources\" />
-    <Folder Include="Resources\Wear\" />
-    <Folder Include="Resources\Base\" />
-    <Folder Include="Utilities\" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\Wear\LayoutMain.axml">
@@ -139,8 +132,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <Content
-        Include="..\..\..\..\.nuget\NuGet.exe">
+    <Content Include="..\..\..\..\.nuget\NuGet.exe">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2473,7 +2473,6 @@ because xbuild doesn't support framework reference assemblies.
     ToolPath="$(JavaToolPath)"
     JavaMaximumHeapSize="$(JavaMaximumHeapSize)"
     JavaOptions="$(JavaOptions)"
-    InputClassesDirectory="$(IntermediateOutputPath)android\bin\classes"
     InputJars="@(_JavaLibrariesToCompileForAppDx)"
     ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
     OutputDirectory="$(IntermediateOutputPath)android\bin\desugared">
@@ -2524,7 +2523,7 @@ because xbuild doesn't support framework reference assemblies.
     <Output TaskParameter="Include" ItemName="_AlternativeJarForAppDx" />
   </CreateItem>
   <CreateItem
-    Include="@(_DesugaredJars)"
+    Include="$(IntermediateOutputPath)android\bin\classes.zip;@(_DesugaredJars)"
     Condition="('$(AndroidEnableProguard)' != 'True' or '$(_ProguardProjectConfiguration)' == '') and '$(AndroidEnableDesugar)' == 'True'">
     <Output TaskParameter="Include" ItemName="_AlternativeJarForAppDx" />
   </CreateItem>


### PR DESCRIPTION
Looking into a customer's binding project, usage of
`$(AndroidEnableDesugar)` was causing a crash at runtime where
`mono.MonoRuntimeProvider` was completely missing from the APK.
Looking into it further, it seemed that our desugar support only
worked when used in combination with Proguard or MultiDex.

What was happening:
- The `<Desugar />` MSBuild task "desugars" the Xamarin.Android app
  code into a `__app_classes__.jar` file
- However `__app_classes__.jar` was not added to the `OutputJars`
  output property
- In `Xamarin.Android.Common.targets` a `@(_AlternativeJarForAppDx)`
  item group is used for the input to `javac`, which does not contain
  any of the Xamarin.Android app's Java code!

In fact, a workaround for the customer's project, was to add the
following to their Xamarin.Android app project file:

    <ItemGroup>
      <_AlternativeJarForAppDx Include="$(IntermediateOutputPath)android\bin\desugared\__app_classes__.jar" />
    </ItemGroup>

-- which was less than ideal.

So before I fixed the issue, I improved our tests:
- Added a `DexUtils` class that invokes the `dexdump` command, so we
  can assert that a dex file contains a specific Java class
- Added `AndroidSdkDirectory` and `AndroidNdkDirectory` properties to
  `Xamarin.ProjectTools`, since I needed the Android SDK path to use
  `dexdump`
- Fixed a bug where we need to use
  `Environment.SpecialFolder.UserProfile`, or the
  `android-toolchain\sdk` directory is not found on Windows
- Added an assertion to the desugar tests, checking that
  `Lmono/MonoRuntimeProvider;` exists in the dex file
- The desugar tests should also `ThrowOnBuildFailure` if desugar is
  enabled

Next, the fixes for desugar support:
- We no longer need `InputClassesDirectory`, and do not need to
  generate `__app_classes__.jar`, since it was not being used at all
  anyway.
- In `Xamarin.Android.Common.targets` we should include `classes.zip`
  in the `@(_AlternativeJarForAppDx)` item group.
- I updated the `<Desugar />` task to our new pattern of only logging
  the `[Output]` properties

The new tests are now green!

Note:
- I tried *including* `__app_classes__.jar` at first, but proguard
  commands were failing. When the app code was "desugared", required
  attributes were removed such as `@Keep`. Since D8/R8 is the way
  forward in the future, I thought it simpler to just omit the
  creation of `__app_classes__.jar`.