### PR TITLE
Update xUnit packages to the latest versions

### DIFF
--- a/tests/TestRunner.xUnit/TestRunner.xUnit.csproj
+++ b/tests/TestRunner.xUnit/TestRunner.xUnit.csproj
@@ -44,10 +44,10 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
     <Reference Include="xunit.abstractions">
-      <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\netstandard1.0\xunit.abstractions.dll</HintPath>
+      <HintPath>..\..\packages\xunit.abstractions.2.0.2\lib\netstandard2.0\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.runner.utility.netstandard15">
-      <HintPath>..\..\packages\xunit.runner.utility.2.3.1\lib\netstandard1.5\xunit.runner.utility.netstandard15.dll</HintPath>
+    <Reference Include="xunit.runner.utility.netstandard20">
+      <HintPath>..\..\packages\xunit.runner.utility.2.4.0\lib\netstandard2.0\xunit.runner.utility.netstandard20.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -76,5 +76,5 @@
     <EmbeddedResource Include="NUnitXml.xslt" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-  <Import Project="..\..\packages\NETStandard.Library.2.0.1\build\netstandard2.0\NETStandard.Library.targets" Condition="Exists('..\..\packages\NETStandard.Library.2.0.1\build\netstandard2.0\NETStandard.Library.targets')" />
+  <Import Project="..\..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets" Condition="Exists('..\..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets')" />
 </Project>

--- a/tests/TestRunner.xUnit/packages.config
+++ b/tests/TestRunner.xUnit/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.NETCore.Platforms" version="2.0.1" targetFramework="monoandroid81" />
+  <package id="Microsoft.NETCore.Platforms" version="2.1.0" targetFramework="monoandroid81" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="monoandroid80" />
-  <package id="NETStandard.Library" version="2.0.1" targetFramework="monoandroid80" />
+  <package id="NETStandard.Library" version="2.0.3" targetFramework="monoandroid81" />
   <package id="System.AppContext" version="4.3.0" targetFramework="monoandroid80" />
   <package id="System.Collections" version="4.3.0" targetFramework="monoandroid80" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="monoandroid80" />
-  <package id="System.Console" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Console" version="4.3.1" targetFramework="monoandroid81" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="monoandroid80" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="monoandroid80" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="monoandroid80" />
@@ -26,7 +26,7 @@
   <package id="System.Reflection" version="4.3.0" targetFramework="monoandroid80" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="monoandroid80" />
   <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="monoandroid80" />
-  <package id="System.Reflection.TypeExtensions" version="4.4.0" targetFramework="monoandroid80" />
+  <package id="System.Reflection.TypeExtensions" version="4.5.0" targetFramework="monoandroid81" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="monoandroid80" />
   <package id="System.Runtime" version="4.3.0" targetFramework="monoandroid80" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="monoandroid80" />
@@ -44,8 +44,8 @@
   <package id="System.Threading" version="4.3.0" targetFramework="monoandroid80" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="monoandroid80" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="monoandroid80" />
-  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="monoandroid80" />
+  <package id="System.Xml.ReaderWriter" version="4.3.1" targetFramework="monoandroid81" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="monoandroid80" />
-  <package id="xunit.abstractions" version="2.0.1" targetFramework="monoandroid80" />
-  <package id="xunit.runner.utility" version="2.3.1" targetFramework="monoandroid80" />
+  <package id="xunit.abstractions" version="2.0.2" targetFramework="monoandroid81" />
+  <package id="xunit.runner.utility" version="2.4.0" targetFramework="monoandroid81" />
 </packages>


### PR DESCRIPTION
Update the xUnit (upstream) runner. The tests completed properly, hopefully it means it now handles all the unhandled exceptions properly (or we were lucky this time not to hit the network issue which caused the unhandled exception previously).