### PR TITLE
[xabuild] MSBuild assemblies should not "Copy Local"

### DIFF
--- a/tools/xabuild/xabuild.csproj
+++ b/tools/xabuild/xabuild.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="..\..\build-tools\scripts\MSBuildReferences.projitems" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -35,9 +34,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MSBuild">
-      <HintPath>$(MSBuildReferencePath)\MSBuild.$(_MSBuildExtension)</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
@@ -60,7 +56,4 @@
     </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="AfterBuild">
-    <Delete Files="$(OutputPath)MSBuild.$(_MSBuildExtension).config" />
-  </Target>
 </Project>


### PR DESCRIPTION
Mono 2018-04 (or 5.14.x) has some changes to MSBuild assemblies that
cause the following failure when using `xabuild.exe`:

    Mono: The following assembly referenced from monodroid/external/xamarin-android/bin/Debug/bin/Microsoft.Build.Tasks.Core.dll could not be loaded:
        Assembly:   System.Reflection.Metadata    (assemblyref_index=7)
        Version:    1.3.0.0
        Public Key: b03f5f7f11d50a3a

Currently `xabuild.exe` is referencing various MSBuild assemblies that
get copied into `bin/$(Configuration)/bin` and shipped in the OSS zip.

This isn't exactly desirable, since we don't really want to ship these
assemblies... These assemblies are OS-specific (as far as I can tell),
I noticed that these assemblies coming from a zip built on macOS do
not work on Windows.

`xabuild.exe` does not need to reference any MSBuild assemblies, and
we can use reflection + custom assembly loading to load MSBuild. This
keeps `bin/Debug/bin` free of additional assemblies, and now only
contains a few files:
- xabuild
- xabuild.exe
- xabuild.exe.config
- xabuild.pdb

By using the `AppDomain.AssemblyResolve` event, we can add some code
to probe the MSBuild bin directory for assemblies. If not found, we
can return `null` and let the runtime do its default behavior.