### PR TITLE
[xabuild] reference missing assembly on newer Mono versions

### DIFF
--- a/tools/xabuild/xabuild.csproj
+++ b/tools/xabuild/xabuild.csproj
@@ -38,6 +38,9 @@
     <Reference Include="MSBuild">
       <HintPath>$(MSBuildReferencePath)\MSBuild.$(_MSBuildExtension)</HintPath>
     </Reference>
+    <Reference Include="System.Reflection.Metadata" Condition=" '$(OS)' != 'Windows_NT' ">
+      <HintPath>$(MSBuildReferencePath)\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/1975

In newer versions of Mono, `xabuild` is failing with:

    /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin/Microsoft.Common.CurrentVersion.targets(2126,5): error MSB3248:
        Parameter "AssemblyFiles" has invalid value "xamarin-android/bin/Debug/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v1.0/mscorlib.dll".
        Could not load file or assembly 'System.Reflection.Metadata, Version=1.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies.

Or another example:

    Mono: The following assembly referenced from monodroid/external/xamarin-android/bin/Debug/bin/Microsoft.Build.Tasks.Core.dll could not be loaded:
        Assembly:   System.Reflection.Metadata    (assemblyref_index=7)
        Version:    1.3.0.0
        Public Key: b03f5f7f11d50a3a

Looking at copies of `System.Reflection.Metadata` in my Mono
installation:

    $ find /Library/Frameworks/Mono.framework/ | grep System.Reflection.Metadata.dll$
    /Library/Frameworks/Mono.framework//Versions/5.12.0/lib/mono/msbuild/15.0/bin/System.Reflection.Metadata.dll
    /Library/Frameworks/Mono.framework//Versions/5.12.0/lib/mono/msbuild/15.0/bin/Roslyn/System.Reflection.Metadata.dll
    /Library/Frameworks/Mono.framework//Versions/5.12.0/lib/mono/fsharp/System.Reflection.Metadata.dll
    /Library/Frameworks/Mono.framework//Versions/5.12.0/lib/mono/4.5/System.Reflection.Metadata.dll
    /Library/Frameworks/Mono.framework//Versions/5.12.0/lib/mono/4.5/dim/System.Reflection.Metadata.dll

It appears that the Mono version of MSBuild has its own copy of
`System.Reflection.Metadata.dll`. Referencing this MSBuild-specific
assembly from `xabuild.csproj` on non-Windows platforms appears to
solve the problem.