### PR TITLE
[Xamarin.Android.Build.Tasks] only update typemap timestamps if changes occur

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -306,8 +306,9 @@ namespace Xamarin.Android.Tasks
 			var np  = path + ".new";
 			using (var o = File.OpenWrite (np))
 				generator (o);
-			MonoAndroidHelper.CopyIfChanged (np, path);
-			MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (path, DateTime.UtcNow, Log);
+			if (MonoAndroidHelper.CopyIfChanged (np, path)) {
+				MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (path, DateTime.UtcNow, Log);
+			}
 			File.Delete (np);
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -227,8 +227,8 @@ namespace Xamarin.Android.Tests
 					Assert.IsTrue (info.LastWriteTimeUtc > start, $"`{file}` is older than `{start}`, with a timestamp of `{info.LastWriteTimeUtc}`!");
 				}
 
-				//Build again after a code change, checking a few files
-				proj.MainActivity = proj.DefaultMainActivity.Replace ("clicks", "CLICKS");
+				//Build again after a code change (renamed Java.Lang.Object subclass), checking a few files
+				proj.MainActivity = proj.DefaultMainActivity.Replace ("MainActivity", "MainActivity2");
 				proj.Touch ("MainActivity.cs");
 				start = DateTime.UtcNow;
 				Assert.IsTrue (b.Build (proj), "second build should have succeeded.");


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/1930

Since 3d999d3, `Fast Deployment` has been rebuilding the APK when it
shouldn't. Apparently the `typemap.mj` and `typemap.jm` files'
timestamps are used when deciding to repack/deploy the APK or not.

After looking at my `CheckTimestamps` test, I don't think it was quite
right. It should modify `MainActivity`'s type name so that these files
will be updated. Just modifying code won't invalidate these files.
Then the `GenerateJavaStubs` task should only update the timestamps if
the file was actually changed, which should fix `Fast Deployment`.