### PR TITLE
[monodroid] recreate shared runtime symlink if it points to an invalid location

### DIFF
--- a/src/monodroid/jni/monodroid-glue.c
+++ b/src/monodroid/jni/monodroid-glue.c
@@ -662,8 +662,16 @@ get_libmonosgen_path ()
 			create_public_directory (links_dir);
 		}
 		free (links_dir);
-		if (!file_exists (link))
-			symlink (libmonoso, link);
+		if (!file_exists (link)) {
+			int result = symlink (libmonoso, link);
+			if (result != 0 && errno == EEXIST) {
+				log_warn (LOG_DEFAULT, "symlink exists, recreating: %s -> %s", link, libmonoso);
+				unlink (link);
+				result = symlink (libmonoso, link);
+			}
+			if (result != 0)
+				log_warn (LOG_DEFAULT, "symlink failed with errno=%i %s", errno, strerror (errno));
+		}
 		free (libmonoso);
 		libmonoso = link;
 	}


### PR DESCRIPTION
The following scenario using `Fast Deployment` causes an issue:
- Build and run a `Debug` mode Xamarin.Android app
- Update Xamarin.Android
- Build and run again

On the second deployment, a *new* shared Mono runtime will be
installed on the device.

And so, the symlink pointing to the shared Mono runtime was pointing
to a location that does not exist:

    $ run-as com.xamarin.myapp ls -la /data/user/0/com.xamarin.myapp/files/.__override__/links
    lrwxrwxrwx 1 u0_a132 u0_a132   93 2018-07-19 16:57 libmonosgen-2.0.so -> /data/app/Mono.Android.DebugRuntime-Y2eHYda6s0hMKJmiCfcYlA==/lib/x86/libmonosgen-32bit-2.0.so

    $ ls /data/app/Mono.Android.DebugRuntime-Y2eHYda6s0hMKJmiCfcYlA==/lib/x86/
    ls: /data/app/Mono.Android.DebugRuntime-Y2eHYda6s0hMKJmiCfcYlA==/lib/x86/: No such file or directory

This caused the app to crash on startup:

    [monodroid] Creating public update directory: `/data/user/0/com.xamarin.myapp/files/.__override__`
    [monodroid] Using override path: /data/user/0/com.xamarin.myapp/files/.__override__
    [monodroid] Trying to load sgen from: /data/user/0/com.xamarin.myapp/files/.__override__/libmonosgen-2.0.so
    [monodroid] Trying to load sgen from: /storage/emulated/0/Android/data/com.xamarin.myapp/files/.__override__/libmonosgen-2.0.so
    [monodroid] Trying to load sgen from: /storage/emulated/0/../legacy/Android/data/com.xamarin.myapp/files/.__override__/libmonosgen-2.0.so
    [monodroid] Trying to load sgen from: /data/app/com.xamarin.myapp-5PqDQ9Z3Et8G7_1D2EtGIg==/lib/x86/libmonosgen-2.0.so
    [monodroid] Trying to load sgen from: /data/user/0/com.xamarin.myapp/files/.__override__/links/libmonosgen-2.0.so
    [monodroid] Trying to load sgen from: /system/lib/libmonosgen-2.0.so
    [monodroid] cannot find libmonosgen-2.0.so in override_dir: /data/user/0/com.xamarin.myapp/files/.__override__, app_libdir: /data/app/com.xamarin.myapp-5PqDQ9Z3Et8G7_1D2EtGIg==/lib/x86 nor in previously printed locations.
    [monodroid] Do you have a shared runtime build of your app with AndroidManifest.xml android:minSdkVersion < 10 while running on a 64-bit Android 5.0 target? This combination is not supported.
    [monodroid] Please either set android:minSdkVersion >= 10 or use a build without the shared runtime (like default Release configuration).

After looking into it further, it appears you can just uninstall the
shared runtime to cause the issue. It appears that the path to
`/data/app/Mono.Android.DebugRuntime-Y2eHYda6s0hMKJmiCfcYlA==/`
changes each time the Mono Shared Runtime is installed.

Here is an example test that can reproduce the issue:

    [Test]
    public void ReinstallSharedRuntime ()
    {
        if (!HasDevices) {
            Assert.Ignore ("Test Skipped no devices or emulators found.");
        }

        const string noSuchFile = "No such file or directory";
        const string libmonosgen = "libmonosgen-2.0.so";
        const string monoRuntime = "Mono.Android.DebugRuntime";

        var proj = new XamarinAndroidApplicationProject ();
        proj.SetProperty (proj.DebugProperties, "AndroidUseSharedRuntime", true);
        proj.SetProperty (proj.DebugProperties, "EmbedAssembliesIntoApk", false);

        using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
            //Make sure we are at a clean state
            RunAdbCommand ($"shell pm uninstall {proj.PackageName}");
            RunAdbCommand ($"shell pm uninstall {monoRuntime}");

            b.Target = "Install,_Run";
            Assert.IsTrue (b.Build (proj), "first `Install` and `_Run` should have succeeded.");
            Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "Installing shared runtime"), "Shared runtime should have been installed!");

            var link = $"/data/user/0/{proj.PackageName}/files/.__override__/links/{libmonosgen}";
            var listing = RunAdbCommand ($"shell run-as {proj.PackageName} ls -la {link}");
            Assert.IsFalse (listing.Contains (noSuchFile), $"{link} should exist!");
            var symlink = listing.Split (' ').Last ().Trim ();
            Assert.IsFalse (string.IsNullOrEmpty (symlink), $"Should find {libmonosgen} from listing: {listing}");
            listing = RunAdbCommand ($"shell run-as {proj.PackageName} ls {symlink}");
            Assert.IsFalse (listing.Contains (noSuchFile), $"{symlink} should exist after the first run");

            var result = RunAdbCommand ($"shell pm uninstall {monoRuntime}").Trim ();
            Assert.AreEqual ("Success", result, "Uninstalling the shared runtime should succeed.");

            //HACK: this is temporary, but is currently required
            var upload_flag = b.Output.GetIntermediaryPath ("upload.flag");
            File.Delete (upload_flag);

            Assert.IsTrue (b.Build (proj), "second `Install` and `_Run` should have succeeded.");
            Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "Installing shared runtime"), "Shared runtime should have been installed!");
            listing = RunAdbCommand ($"shell run-as {proj.PackageName} ls -la {link}");
            Assert.IsFalse (listing.Contains (noSuchFile), $"{link} should exist!");
            symlink = listing.Split (' ').Last ().Trim ();
            Assert.IsFalse (string.IsNullOrEmpty (symlink), $"Should find {libmonosgen} from listing: {listing}");
            listing = RunAdbCommand ($"shell run-as {proj.PackageName} ls {symlink}");
            Assert.IsFalse (listing.Contains (noSuchFile), $"{symlink} should exist after the second run");
        }
    }

So (I think) the fix here is:
- Check the result of `symlink`
- If it failed with `EEXIST`, delete the file and try again
- Add additional logging so we can see if `symlink` fails

After this fixed is merged, I think we should also add the above test
to the proprietary `monodroid` repo. (Assuming it isn't too fragile,
of course)