### PR TITLE
[Xamarin.Android.Build.Tasks] proguard warning code

### DIFF
--- a/Documentation/guides/messages/xa4304.md
+++ b/Documentation/guides/messages/xa4304.md
@@ -1,0 +1,23 @@
+# Compiler Error XA4304
+
+The `Proguard` MSBuild task encountered a proguard configuration file
+that was not found on disk. These files are generally declared in your
+Xamarin.Android project with a build action of
+`ProguardConfiguration`. However, Xamarin.Android also generates
+proguard configuration files internally during the build process.
+
+To learn more about `Proguard` and how it relates to Android
+development, see the [Android documentation][android] or the [Proguard
+website][proguard].
+
+## Resolution
+
+Verify you are not declaring a `ProguardConfiguration` build item that
+does not exist.
+
+Consider submitting a [bug][bug] if you are getting this warning under
+normal circumstances.
+
+[android]: https://developer.android.com/studio/build/shrink-code
+[proguard]: https://www.guardsquare.com/en/products/proguard/manual
+[bug]: https://github.com/xamarin/xamarin-android/wiki/Submitting-Bugs,-Feature-Requests,-and-Pull-Requests

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
@@ -81,26 +81,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("Proguard");
-			Log.LogDebugMessage ("  AndroidSdkDirectory: {0}", AndroidSdkDirectory);
-			Log.LogDebugMessage ("  JavaPlatformJarPath: {0}", JavaPlatformJarPath);
-			Log.LogDebugMessage ("  ClassesOutputDirectory: {0}", ClassesOutputDirectory);
-			Log.LogDebugMessage ("  AcwMapFile: {0}", AcwMapFile);
-			Log.LogDebugMessage ("  ProguardGeneratedApplicationConfiguration: {0}", ProguardGeneratedApplicationConfiguration);
-			Log.LogDebugMessage ("  ProguardJarOutput: {0}", ProguardJarOutput);
-			Log.LogDebugTaskItems ("  ProguardGeneratedReferenceConfiguration:", ProguardGeneratedReferenceConfiguration);
-			Log.LogDebugTaskItems ("  ProguardGeneratedApplicationConfiguration:", ProguardGeneratedApplicationConfiguration);
-			Log.LogDebugTaskItems ("  ProguardCommonXamarinConfiguration:", ProguardCommonXamarinConfiguration);
-			Log.LogDebugTaskItems ("  ProguardConfigurationFiles:", ProguardConfigurationFiles);
-			Log.LogDebugTaskItems ("  ExternalJavaLibraries:", ExternalJavaLibraries);
-			Log.LogDebugTaskItems ("  DoNotPackageJavaLibraries:", DoNotPackageJavaLibraries);
-			Log.LogDebugMessage ("  UseProguard: {0}", UseProguard);
-			Log.LogDebugMessage ("  EnableLogging: {0}", EnableLogging);
-			Log.LogDebugMessage ("  DumpOutput: {0}", DumpOutput);
-			Log.LogDebugMessage ("  PrintSeedsOutput: {0}", PrintSeedsOutput);
-			Log.LogDebugMessage ("  PrintMappingOutput: {0}", PrintMappingOutput);
-			Log.LogDebugMessage ("  ProguardInputJarFilter: {0}", ProguardInputJarFilter);
-
 			EnvironmentVariables = MonoAndroidHelper.GetProguardEnvironmentVaribles (ProguardHome);
 
 			return base.Execute ();
@@ -165,7 +145,7 @@ namespace Xamarin.Android.Tasks
 				if (File.Exists (file))
 					cmd.AppendSwitchUnquotedIfNotNull ("-include ", $"{enclosingChar}'{file}'{enclosingChar}");
 				else
-					Log.LogWarning ("Proguard configuration file '{0}' was not found.", file);
+					Log.LogCodedWarning ("XA4304", file, 0, "Proguard configuration file '{0}' was not found.", file);
 			}
 
 			libjars.Add (JavaPlatformJarPath);


### PR DESCRIPTION
Added a warning code for the `Proguard` MSBuild task along with
documentation. There was only one warning to fix here.

Additionally, I removed the extraneous log messages from the
`Proguard` task, since diagnostic MSBuild output will include all the
information we need.