### PR TITLE
[Xamarin.Android.Build.Tasks] Set the timestamps on the `resources.cache` files.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
@@ -470,7 +470,7 @@ namespace Xamarin.Android.Tasks {
 					new XElement ("AdditionalNativeLibraryReferences", 
 							AdditionalNativeLibraryReferences.Select(e => new XElement ("AdditionalNativeLibraryReference", e)))
 					));
-			document.SaveIfChanged (cacheFileFullPath);
+			document.SaveIfChanged (cacheFileFullPath, Log);
 
 			LogDebugTaskItems ("  AdditionalAndroidResourcePaths: ", AdditionalAndroidResourcePaths);
 			LogDebugTaskItems ("  AdditionalJavaLibraryReferences: ", AdditionalJavaLibraryReferences);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
@@ -60,7 +60,7 @@ namespace Xamarin.Android.Tasks
 									new XElement ("NativeLibraries", NativeLibraries.Select(e => new XElement ("NativeLibrary", e.ItemSpec))),
 									new XElement ("Jars", Jars.Select(e => new XElement ("Jar", e.ItemSpec)))
 						));
-				document.SaveIfChanged (CacheFile);
+				document.SaveIfChanged (CacheFile, Log);
 			}
 
 			return true;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -122,7 +122,7 @@ namespace Xamarin.Android.Tasks
 						new XElement ("ResolvedResourceDirectoryStamps",
 							ResolvedResourceDirectoryStamps.Select(e => new XElement ("ResolvedResourceDirectoryStamp", e)))
 					));
-				document.SaveIfChanged (CacheFile);
+				document.SaveIfChanged (CacheFile, Log);
 			}
 
 			assemblyMap.Save (AssemblyIdentityMapFile);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/XDocumentExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/XDocumentExtensions.cs
@@ -29,12 +29,13 @@ namespace Xamarin.Android.Tasks
 			return element.ToString (SaveOptions.DisableFormatting);
 		}
 
-		public static void SaveIfChanged (this XDocument document, string fileName)
+		public static void SaveIfChanged (this XDocument document, string fileName, TaskLoggingHelper log)
 		{
 			var tempFile = System.IO.Path.GetTempFileName ();
 			try {
 				document.Save (tempFile);
-				MonoAndroidHelper.CopyIfChanged (tempFile, fileName);
+				if (MonoAndroidHelper.CopyIfChanged (tempFile, fileName))
+					MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (fileName, DateTime.UtcNow, log);
 			} finally {
 				File.Delete (tempFile);
 			}


### PR DESCRIPTION
We currently do not force the setting of the write and access
timestamps when saving the resource.caches files. We have
recently (90e31550) been reviewing and adding this in other
parts of the build system. This is to ensure that when we do
modify a file it has the latest timestamp.

This commit adds support for calling

	MonoAndroidHelper.SetLastAccessAndWriteTimeUtc ()

when we save the XDocument cache files.