### PR TITLE
[build] `make dist`-compatible log packages

### DIFF
--- a/build-tools/scripts/Packaging.mk
+++ b/build-tools/scripts/Packaging.mk
@@ -63,9 +63,12 @@ package-deb: $(ZIP_OUTPUT)
 	cd $(ZIP_OUTPUT_BASENAME) && DEBEMAIL="Xamarin Public Jenkins (auto-signing) <releng@xamarin.com>" dch --create -v $(PRODUCT_VERSION).$(-num-commits-since-version-change) --package xamarin.android-oss --force-distribution --distribution alpha "New release - please see git log for $(GIT_COMMIT)"
 	cd $(ZIP_OUTPUT_BASENAME) && dpkg-buildpackage -us -uc -rfakeroot
 
-package-test-errors:
+_TEST_ERRORS_BASENAME   = xa-test-errors-v$(PRODUCT_VERSION).$(-num-commits-since-version-change)_$(OS_NAME)-$(OS_ARCH)_$(GIT_BRANCH)_$(GIT_COMMIT)
+
+"$(_TEST_ERRORS_BASENAME).zip" package-test-errors:
 ifneq ($(wildcard bin/Test*/temp),)
-	zip -r test-errors.zip bin/Test*/temp
+	build-tools/scripts/ln-to.sh -r . -o "$(_TEST_ERRORS_BASENAME)" bin/Test*/temp
+	zip -r "$(_TEST_ERRORS_BASENAME).zip" "$(_TEST_ERRORS_BASENAME)"
 endif # We have test error output
 
 _BUILD_STATUS_BUNDLE_INCLUDE = \
@@ -79,16 +82,18 @@ _BUILD_STATUS_BUNDLE_INCLUDE = \
 	$(shell find . -name '.ninja_log') \
 	$(shell find . -name 'android-*.config.cache')
 
-_BUILD_STATUS_ZIP_OUTPUT = build-status-$(GIT_COMMIT).$(ZIP_EXTENSION)
+_BUILD_STATUS_BASENAME   = xa-build-status-v$(PRODUCT_VERSION).$(-num-commits-since-version-change)_$(OS_NAME)-$(OS_ARCH)_$(GIT_BRANCH)_$(GIT_COMMIT)
+_BUILD_STATUS_ZIP_OUTPUT = $(_BUILD_STATUS_BASENAME).$(ZIP_EXTENSION)
 
 ifneq ($(wildcard Configuration.Override.props),)
 _BUILD_STATUS_BUNDLE_INCLUDE += \
 	Configuration.Override.props
 endif
 
-package-build-status:
+"$(_BUILD_STATUS_ZIP_OUTPUT)" package-build-status:
+	build-tools/scripts/ln-to.sh -r . -o "$(_BUILD_STATUS_BASENAME)" $(_BUILD_STATUS_BUNDLE_INCLUDE)
 ifeq ($(ZIP_EXTENSION),zip)
-	zip -r "$(_BUILD_STATUS_ZIP_OUTPUT)" $(_BUILD_STATUS_BUNDLE_INCLUDE)
+	zip -r "$(_BUILD_STATUS_ZIP_OUTPUT)" "$(_BUILD_STATUS_BASENAME)"
 else ifeq ($(ZIP_EXTENSION),tar.bz2)
-	tar -cjhvf "$(_BUILD_STATUS_ZIP_OUTPUT)" $(_BUILD_STATUS_BUNDLE_INCLUDE)
+	tar -cjhvf "$(_BUILD_STATUS_ZIP_OUTPUT)" "$(_BUILD_STATUS_BASENAME)"
 endif

--- a/build-tools/scripts/ln-to.sh
+++ b/build-tools/scripts/ln-to.sh
@@ -1,0 +1,81 @@
+#!/bin/bash -e
+
+function Help()
+{
+	echo "$0: usage: $0 -r ROOT_DIR -o OUT_DIR [FILE]+"
+	exit 1
+}
+
+function FullPath()
+{
+	local p="$1"
+	if [ -d "$p" ]; then
+		echo "$(cd "$p" && pwd)"
+	else
+		d="`dirname "$p"`"
+		echo "$(cd "$d" && pwd)/$(basename "$p")"
+	fi
+}
+
+function SubdirPath()
+{
+	local root path subdir
+	root="$1"
+	path="$2"
+
+	if [ -d "$path" ]; then
+		path="$(cd "$path" && pwd)"
+		subdir="${path#$root}"
+		echo "${subdir:-.}"
+	else
+		local b d
+		d="$(dirname "$path")"
+		b="$(basename "$path")"
+		path="$(cd $d && pwd)"
+		subdir="${path#$root}"
+		echo "${subdir:-.}/$b"
+	fi
+}
+
+while getopts "o:r:" option ; do
+	case "$option" in
+		o)
+			TARGET_DIR="$OPTARG"
+			;;
+		r)
+			ROOT_DIR="$OPTARG"
+			;;
+	esac
+done
+
+shift $(($OPTIND-1))
+
+if [ -z "$TARGET_DIR" -o -z "$ROOT_DIR" ]; then
+	echo "$0: missing required argument -o or -r" >&2
+	Help
+fi
+
+if [ ! -d "$ROOT_DIR" ]; then
+	echo "$0: \"-r '$ROOT_DIR'\" must refer to a valid directory" 2>&2
+	Help
+fi
+
+mkdir -p "$TARGET_DIR"
+TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
+ROOT_DIR="$(cd "$ROOT_DIR" && pwd)"
+
+for p in "$@" ; do
+	if [ ! -e "$p" ]; then
+		echo "$0: Skipping non-existent file '$p'" >&2
+		continue
+	fi
+	full_path="$(FullPath "$p")"
+	sub_path="$(SubdirPath "$ROOT_DIR" "$full_path")"
+	target_sub="$TARGET_DIR/$(dirname "$sub_path")"
+	target_path="$target_sub/$(basename "$p")"
+	mkdir -p "$target_sub"
+	if [ -f "$target_path" ]; then
+		rm "$target_path"
+	fi
+	ln -s "$full_path" "$target_path"
+done


### PR DESCRIPTION
The "log pakages" produced by `make package-build-status` (a2a970f5)
and `make package-test-errors` (0435a91f) have one usability problem:
they aren't compatible with [`make dist`][make-dist].

Specifically, `make dist`-style packages are packages which have a
root directory that is the same as the basename of the package name.
For example, if a package is named `foo.zip`, then the contents of
`foo.zip` would all be within a `foo` directory.

Addiotionally, `make dist`-style files usually have a "version number"
of some form encoded in the filename, with `foo-1.zip` having all
files within it nested under the `foo-1` directory.

This has two wonderful benefits:

 1. When downloading such files, they won't "collide" with each other,
    because they have unique values within the filename.

 2. When extracting such files, the extracted contents won't collide
    with each other, as they're extracted into unique "toplevel" dirs.

Compare to e.g. `make package-build-status`, which creates a
`build-status-$(GIT_COMMIT).zip` file (thus fulfilling benefit (1)),
but when you *extract* `build-status-$(GIT_COMMIT).zip`, it extracts
"on top of" a previous extraction:

	$ unzip build-status-0636fcc.zip
	Archive:  build-status-0636fcc.zip
	  inflating: Configuration.OperatingSystem.props
	  inflating: bin/BuildDebug/msbuild-20180716T144550-prepare-deps.binlog
	...

	$ unzip build-status-0d81a6b7.zip
	Archive:  build-status-0d81a6b7.zip
	replace Configuration.OperatingSystem.props? [y]es, [n]o, [A]ll, [N]one, [r]ename:
	# ARGH!

This Is Madness™!

Update the `make package-build-status` and `make package-test-errors`
targets so that the files they produce are consistent with
`make dist` convention, e.g. `make package-build-status` will create a
file named `xa-build-status-vVERSION_OS-OS_ARCH_BRANCH_HASH.zip` --
which is consistent with the `make package-oss` filename -- and the
*contents* of `xa-build-status-vVERSION_OS-OS_ARCH_BRANCH_HASH.zip`
are within a `xa-build-status-vVERSION_OS-OS_ARCH_BRANCH_HASH` path.
This allows these files to be extracted without overwriting previous
extractions.

Similarly, `make package-test-errors` will now create a file named
`xa-test-errors-vVERSION_OS-OS_ARCH_BRANCH_HASH.zip`.

[make-dist]: https://www.gnu.org/prep/standards/html_node/Standard-Targets.html