### PR TITLE
Remove armeabi from build.

### DIFF
--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -39,7 +39,6 @@ STABLE_FRAMEWORKS = $(foreach a, $(STABLE_API_LEVELS), $(word $(a),$(ALL_FRAMEWO
 PLATFORM_IDS      = $(foreach a, $(API_LEVELS), $(word $(a),$(ALL_PLATFORM_IDS)))
 
 ALL_JIT_ABIS  = \
-	armeabi \
 	armeabi-v7a \
 	arm64-v8a \
 	x86 \

--- a/src/Mono.Android/Test/Mono.Android-Tests.targets
+++ b/src/Mono.Android/Test/Mono.Android-Tests.targets
@@ -2,7 +2,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <AndroidNativeLibrary Include="libs\arm64-v8a\libreuse-threads.so" />
-    <AndroidNativeLibrary Include="libs\armeabi\libreuse-threads.so" />
     <AndroidNativeLibrary Include="libs\armeabi-v7a\libreuse-threads.so" />
     <AndroidNativeLibrary Include="libs\x86\libreuse-threads.so" />
     <AndroidNativeLibrary Include="libs\x86_64\libreuse-threads.so" />

--- a/src/Mono.Android/Test/jni/Application.mk
+++ b/src/Mono.Android/Test/jni/Application.mk
@@ -1,2 +1,2 @@
 # Build both ARMv5TE and ARMv7-A machine code.
-APP_ABI := arm64-v8a armeabi armeabi-v7a x86 x86_64
+APP_ABI := arm64-v8a armeabi-v7a x86 x86_64

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -298,7 +298,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		
 	<_PackagedResources>$(IntermediateOutputPath)android\bin\packaged_resources</_PackagedResources>
 
-	<_Android32bitArchitectures>armeabi-v7a;armeabi;x86;mips</_Android32bitArchitectures>
+	<_Android32bitArchitectures>armeabi-v7a;x86;mips</_Android32bitArchitectures>
 	<_Android64bitArchitectures>arm64-v8a;x86_64;mips64</_Android64bitArchitectures>
 
 	<_AndroidSequencePointsMode Condition=" '$(MonoSymbolArchive)' == 'True' And '$(AndroidUseDebugRuntime)' == 'False' And '$(AotAssemblies)' == 'True' And '$(DebugSymbols)' == 'True' And ('$(DebugType)' == 'PdbOnly' Or '$(DebugType)' == 'Portable')">Offline</_AndroidSequencePointsMode>

--- a/src/sqlite-xamarin/src/main/jni/Application.mk
+++ b/src/sqlite-xamarin/src/main/jni/Application.mk
@@ -1,1 +1,1 @@
-APP_ABI := armeabi armeabi-v7a arm64-v8a x86 x86_64
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64

--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.csproj
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.csproj
@@ -82,7 +82,6 @@
   </PropertyGroup>
   <ItemGroup>
     <AndroidNativeLibrary Include="libs\arm64-v8a\libtiming.so" />
-    <AndroidNativeLibrary Include="libs\armeabi\libtiming.so" />
     <AndroidNativeLibrary Include="libs\armeabi-v7a\libtiming.so" />
     <AndroidNativeLibrary Include="libs\x86\libtiming.so" />
     <AndroidNativeLibrary Include="libs\x86_64\libtiming.so" />

--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/jni/Application.mk
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/jni/Application.mk
@@ -1,2 +1,2 @@
 # Build both ARMv5TE and ARMv7-A machine code.
-APP_ABI := arm64-v8a armeabi armeabi-v7a x86 x86_64
+APP_ABI := arm64-v8a armeabi-v7a x86 x86_64

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Properties/AssemblyInfo.cs
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Properties/AssemblyInfo.cs
@@ -29,8 +29,6 @@ using Android.App;
 // native library path should contain abi
 [assembly: Android.NativeLibraryReference ("arm64-v8a/libsimple.so",
 	SourceUrl="file:///NativeLib.zip", Version="native-lib-1")]
-[assembly: Android.NativeLibraryReference ("armeabi/libsimple.so",
-	SourceUrl="file:///NativeLib.zip", Version="native-lib-1")]
 [assembly: Android.NativeLibraryReference ("armeabi-v7a/libsimple.so",
 	SourceUrl="file:///NativeLib.zip", Version="native-lib-1")]
 [assembly: Android.NativeLibraryReference ("x86/libsimple.so",
@@ -40,9 +38,6 @@ using Android.App;
 
 // native library path should contain abi
 [assembly: Android.NativeLibraryReference ("arm64-v8a/libsimple2.so",
-	EmbeddedArchive="aar-test/EmbeddedNativeLib.zip",
-	SourceUrl="file:///NativeLib2.zip", Version="native-lib-2")]
-[assembly: Android.NativeLibraryReference ("armeabi/libsimple2.so",
 	EmbeddedArchive="aar-test/EmbeddedNativeLib.zip",
 	SourceUrl="file:///NativeLib2.zip", Version="native-lib-2")]
 [assembly: Android.NativeLibraryReference ("armeabi-v7a/libsimple2.so",

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.csproj
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.csproj
@@ -72,7 +72,6 @@
   </PropertyGroup>
   <ItemGroup>
     <AndroidNativeLibrary Include="libs\arm64-v8a\libsimple.so" />
-    <AndroidNativeLibrary Include="libs\armeabi\libsimple.so" />
     <AndroidNativeLibrary Include="libs\armeabi-v7a\libsimple.so" />
     <AndroidNativeLibrary Include="libs\x86\libsimple.so" />
     <AndroidNativeLibrary Include="libs\x86_64\libsimple.so" />

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
@@ -11,7 +11,7 @@
     <Exec Command="&quot;$(NdkBuildPath)&quot;" />
     <MakeDir Directories="$(OutputPath)\native-lib-1" />
     <Exec
-        Command="&quot;$(JarPath)&quot; cf ../$(OutputPath)/native-lib-1/NativeLib.zip arm64-v8a armeabi armeabi-v7a x86 x86_64"
+        Command="&quot;$(JarPath)&quot; cf ../$(OutputPath)/native-lib-1/NativeLib.zip arm64-v8a armeabi-v7a x86 x86_64"
         WorkingDirectory="libs"
     />
   </Target>
@@ -30,7 +30,7 @@
     <MakeDir Directories="$(OutputPath)\native-lib-2" />
     <MakeDir Directories="$(OutputPath)\native-lib-2\aar-test" />
     <Exec
-        Command="&quot;$(JarPath)&quot; cf ../../$(OutputPath)/native-lib-2/aar-test/EmbeddedNativeLib.zip arm64-v8a armeabi armeabi-v7a x86 x86_64"
+        Command="&quot;$(JarPath)&quot; cf ../../$(OutputPath)/native-lib-2/aar-test/EmbeddedNativeLib.zip arm64-v8a armeabi-v7a x86 x86_64"
         WorkingDirectory="simple2/libs"
     />
     <Exec

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/jni/Application.mk
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/jni/Application.mk
@@ -1,2 +1,2 @@
 # Build both ARMv5TE and ARMv7-A machine code.
-APP_ABI := arm64-v8a armeabi armeabi-v7a x86 x86_64
+APP_ABI := arm64-v8a armeabi-v7a x86 x86_64

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/simple2/jni/Application.mk
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/simple2/jni/Application.mk
@@ -1,2 +1,2 @@
 # Build both ARMv5TE and ARMv7-A machine code.
-APP_ABI := arm64-v8a armeabi armeabi-v7a x86 x86_64
+APP_ABI := arm64-v8a armeabi-v7a x86 x86_64

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-Tests/Xamarin.Android.MakeBundle-Tests.csproj
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-Tests/Xamarin.Android.MakeBundle-Tests.csproj
@@ -74,7 +74,6 @@
   <ItemGroup>
     <AndroidNativeLibrary Include="libs\x86\libsanangeles.so" />
     <Compile Include="MainActivity.cs" />
-    <AndroidNativeLibrary Include="libs\armeabi\libsanangeles.so" />
     <AndroidNativeLibrary Include="libs\armeabi-v7a\libsanangeles.so" />
   </ItemGroup>
 </Project>

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib2/Xamarin.Android.BindingResolveImportLib2.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib2/Xamarin.Android.BindingResolveImportLib2.csproj
@@ -80,7 +80,6 @@
     </CleanDependsOn>
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedNativeLibrary Include="libs\armeabi\libtiming2.so" />
     <EmbeddedNativeLibrary Include="libs\armeabi-v7a\libtiming2.so" />
     <EmbeddedNativeLibrary Include="libs\x86\libtiming2.so" />
   </ItemGroup>

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib2/jni/Application.mk
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib2/jni/Application.mk
@@ -1,2 +1,2 @@
 # Build both ARMv5TE and ARMv7-A machine code.
-APP_ABI := arm64-v8a armeabi armeabi-v7a x86 x86_64
+APP_ABI := arm64-v8a armeabi-v7a x86 x86_64

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib4/Xamarin.Android.BindingResolveImportLib4.csproj
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib4/Xamarin.Android.BindingResolveImportLib4.csproj
@@ -78,7 +78,6 @@
     </CleanDependsOn>
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedNativeLibrary Include="libs\armeabi\libtiming4.so" />
     <EmbeddedNativeLibrary Include="libs\armeabi-v7a\libtiming4.so" />
     <EmbeddedNativeLibrary Include="libs\x86\libtiming4.so" />
   </ItemGroup>

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib4/jni/Application.mk
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib4/jni/Application.mk
@@ -1,2 +1,2 @@
 # Build both ARMv5TE and ARMv7-A machine code.
-APP_ABI := arm64-v8a armeabi armeabi-v7a x86 x86_64
+APP_ABI := arm64-v8a armeabi-v7a x86 x86_64


### PR DESCRIPTION
Starting with Android NDK r17, armeabi is *removed*, meaning that we
cannot build anything with armeabi anymore.

seealso: https://github.com/xamarin/java.interop/pull/346