### PR TITLE
[VSfM] Fix "Invalid configuration mapping" error

### DIFF
--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -354,10 +354,10 @@ Global
 		{B501D075-6183-4E1D-92C9-F7B5002475B1}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{B501D075-6183-4E1D-92C9-F7B5002475B1}.Release|AnyCPU.ActiveCfg = Release|Any CPU
 		{B501D075-6183-4E1D-92C9-F7B5002475B1}.Release|AnyCPU.Build.0 = Release|Any CPU
-		{1DA0CB12-5508-4E83-A242-0C8D6D99A49B}.Debug|AnyCPU.ActiveCfg = Debug|AnyCPU
-		{1DA0CB12-5508-4E83-A242-0C8D6D99A49B}.Debug|AnyCPU.Build.0 = Debug|AnyCPU
-		{1DA0CB12-5508-4E83-A242-0C8D6D99A49B}.Release|AnyCPU.ActiveCfg = Release|AnyCPU
-		{1DA0CB12-5508-4E83-A242-0C8D6D99A49B}.Release|AnyCPU.Build.0 = Release|AnyCPU
+		{1DA0CB12-5508-4E83-A242-0C8D6D99A49B}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{1DA0CB12-5508-4E83-A242-0C8D6D99A49B}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{1DA0CB12-5508-4E83-A242-0C8D6D99A49B}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{1DA0CB12-5508-4E83-A242-0C8D6D99A49B}.Release|AnyCPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The `build-tools/download-bundle` project was flagged with an
"Invalid configuration mapping" error when `Xamarin.Android.sln` was
loaded into Visual Studio for Mac.