### PR TITLE
[build] Generate separate .binlog files for tests.

### DIFF
--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -11,7 +11,8 @@
     <_NUnit>$(_Runtime) packages\NUnit.ConsoleRunner.3.7.0\tools\nunit3-console.exe</_NUnit>
     <_Test Condition=" '$(TEST)' != '' ">--test=&quot;$(TEST)&quot;</_Test>
     <_XABuild>$(_TopDir)\bin\$(Configuration)\bin\xabuild</_XABuild>
-    <_XABuildDiag Condition=" '$(V)' != '' ">/v:diag </_XABuildDiag>
+    <_XABinLogPrefix>/v:normal /binaryLogger:"$(MSBuildThisFileDirectory)\..\..\bin\Build$(Configuration)\msbuild</_XABinLogPrefix>
+    <_XABuildDiag Condition=" '$(USE_MSBUILD)' == '0' And '$(V)' != '' ">/v:diag </_XABuildDiag>
     <_XABuildProperties>$(_XABuildDiag)/p:Configuration=$(Configuration) /p:XAIntegratedTests=$(XAIntegratedTests)</_XABuildProperties>
   </PropertyGroup>
   <ItemGroup>
@@ -88,13 +89,23 @@
     <Delete Files="@(_JavaInteropTestResults)" />
   </Target>
   <Target Name="RunApkTests">
-    <Exec Command="$(_XABuild) %(_ApkTestProject.Identity) /t:SignAndroidPackage $(_XABuildProperties)" />
+    <ItemGroup Condition=" '$(USE_MSBUILD)' == '1' ">
+      <_ApkTestProject>
+        <_BinLog>$(_XABinLogPrefix)-$([System.DateTime]::Now.ToString ("yyyyMMddTHHmmss"))-%(Filename).binlog"</_BinLog>
+      </_ApkTestProject>
+    </ItemGroup>
+    <Exec Command="$(_XABuild) %(_ApkTestProject.Identity) %(_ApkTestProject._BinLog) /t:SignAndroidPackage $(_XABuildProperties)" />
     <MSBuild
         ContinueOnError="ErrorAndContinue"
         Projects="$(_TopDir)\tests\RunApkTests.targets"
     />
+    <ItemGroup Condition=" '$(USE_MSBUILD)' == '1' ">
+      <_ApkTestProjectAot>
+        <_BinLog>$(_XABinLogPrefix)-$([System.DateTime]::Now.ToString ("yyyyMMddTHHmmss"))-%(Filename)-AOT.binlog"</_BinLog>
+      </_ApkTestProjectAot>
+    </ItemGroup>
     <Exec 
-        Command="$(_XABuild) %(_ApkTestProjectAot.Identity) /t:SignAndroidPackage $(_XABuildProperties) /p:AotAssemblies=True"
+        Command="$(_XABuild) %(_ApkTestProjectAot.Identity) %(_ApkTestProjectAot._BinLog) /t:SignAndroidPackage $(_XABuildProperties) /p:AotAssemblies=True"
         Condition=" '$(Configuration)' == 'Release' "
     />
     <MSBuild 
@@ -103,8 +114,13 @@
         Condition=" '$(Configuration)' == 'Release' "
         Properties="AotAssemblies=True"
     />
+    <ItemGroup Condition=" '$(USE_MSBUILD)' == '1' ">
+      <_ApkTestProjectBundle>
+        <_BinLog>$(_XABinLogPrefix)-$([System.DateTime]::Now.ToString ("yyyyMMddTHHmmss"))-%(Filename)-Bundle.binlog"</_BinLog>
+      </_ApkTestProjectBundle>
+    </ItemGroup>
     <Exec
-        Command="$(_XABuild) %(_ApkTestProjectBundle.Identity) /t:SignAndroidPackage $(_XABuildProperties) /p:BundleAssemblies=True /p:EmbedAssembliesIntoApk=True"
+        Command="$(_XABuild) %(_ApkTestProjectBundle.Identity) %(_ApkTestProjectBundle._BinLog) /t:SignAndroidPackage $(_XABuildProperties) /p:BundleAssemblies=True /p:EmbedAssembliesIntoApk=True"
         Condition=" '$(Configuration)' == 'Release' "
     />
     <MSBuild

--- a/build-tools/scripts/msbuild.mk
+++ b/build-tools/scripts/msbuild.mk
@@ -31,10 +31,6 @@ else    # $(OS_NAME) != Darwin
 _PKG_CONFIG   = pkg-config
 endif   # $(OS_NAME) == Darwin
 
-ifneq ($(V),0)
-MSBUILD_FLAGS += /v:diag
-endif   # $(V) != 0
-
 ifeq ($(MSBUILD),msbuild)
 export USE_MSBUILD  = 1
 endif   # $(MSBUILD) == msbuild
@@ -54,6 +50,10 @@ MSBUILD_FLAGS += /p:_DebugFileExt=.pdb
 else    # $(_CSC_EMITS_PDB) == ''
 MSBUILD_FLAGS += /p:_DebugFileExt=.mdb
 endif   # $(_CSC_EMITS_PDB) == Pdb
+
+ifneq ($(V),0)
+MSBUILD_FLAGS += /v:diag
+endif   # $(V) != 0
 
 # $(call MSBUILD_BINLOG,name,msbuild=$(MSBUILD),conf=$(CONFIGURATION))
 define MSBUILD_BINLOG


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/1792
Context: 987a05fa890b8a24513820942f2c134099273950

Commit 987a05fa updated the "normal" build log process, as used by
Jenkins/etc., so that Console output received "normal" build verbosity
messages, while MSBuild `.binlog` files would be generated so that
"diagnostic" build logs could be produced "later," as necessary.

Unfortunately, commit 987a05fa didn't update unit test builds.
Consequently, `make run-apk-tests`/etc. would emit *diagnostic* build
logs to the Console, meaning instead of the previous ~1GB log file, we
instead had a "mere" ~400MB instead.

Update test execution so that they follow the spirit of 987a05fa:
`.binlog` files for diagnostic output, with "normal" output printed to
the console, resulting in smaller Jenkins log files.