### PR TITLE
Bump to xamarin/xamarin-android-tools:master@917d3b3c

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -229,10 +229,15 @@ namespace Xamarin.Android.Build.Tests
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
 				Assert.IsTrue (b.Build (proj), "build failed");
-				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, " 0 Warning(s)"));
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, " 0 Warning(s)"),
+						"First build should not contain warnings!  Contains\n" +
+						string.Join ("\n", b.LastBuildOutput.Where (line => line.Contains ("warning"))));
 				proj.AndroidResources.First ().Timestamp = null;
 				Assert.IsTrue (b.Build (proj), "Second build failed");
-				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, " 0 Warning(s)"));
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, " 0 Warning(s)"), "Second build should not contain warnings!");
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, " 0 Warning(s)"),
+						"Second build should not contain warnings!  Contains\n" +
+						string.Join ("\n", b.LastBuildOutput.Where (line => line.Contains ("warning"))));
 			}
 		}
 


### PR DESCRIPTION
Context: https://paper.dropbox.com/doc/OpenJDK-and-You--AH1yWKdVXgno~uXYfmcUAZTwAg-NoECAe2XkBQeoxFfGL6ea
Context: https://github.com/xamarin/xamarin-android-tools/pull/29#issuecomment-400048306
Context: https://github.com/xamarin/xamarin-android/pull/2004#issuecomment-409924069
Context: https://github.com/xamarin/xamarin-android-tools/blob/917d3b3ce455eed6a4a0e4271d34661bdf0b261d/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs#L256

Fixes: http://work.devdiv.io/646086
Fixes: http://work.devdiv.io/652760
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/597752
Fixes: https://github.com/xamarin/xamarin-android-tools/issues/26
Fixes: https://github.com/xamarin/xamarin-android-tools/issues/39

Update & export `%JAVA_HOME%`, `%PATH%` on Windows.

We are [observing some unit test failures in this bump][0], which
[appear to be machine-specific][1].  We still don't understand the
cause of the unit test failures, so to assist in the eventual tracking
of this issue there is some additional, conditional, debug spew.

[0]: https://github.com/xamarin/xamarin-android/pull/2004#issuecomment-409924069
[1]: https://github.com/xamarin/xamarin-android/pull/2004#issuecomment-410069608