### PR TITLE
[Xamarin.Android.Build.Tests] Fix BaseTest to use the same Root path.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -9,6 +9,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using Xamarin.ProjectTools;
+using XABuildPaths = Xamarin.Android.Build.Paths;
 
 namespace Xamarin.Android.Build.Tests
 {
@@ -90,7 +91,7 @@ namespace Xamarin.Android.Build.Tests
 
 		public string Root {
 			get {
-				return Path.GetDirectoryName (new Uri (typeof (XamarinProject).Assembly.CodeBase).LocalPath);
+				return XABuildPaths.TestOutputDirectory;
 			}
 		}
 


### PR DESCRIPTION
Our tests were not all using the same root path. While this
does not cause a problem in this repo. It does cause a
problem in monodroid. This is because the Root for the
base test is looking in the wrong directory. The result
is file checks fail.