### PR TITLE
Bump to xamarin/Java.Interop:master@32f0c9cf

### DIFF
--- a/build-tools/scripts/Configuration.Java.Interop.Override.props
+++ b/build-tools/scripts/Configuration.Java.Interop.Override.props
@@ -3,5 +3,6 @@
   <PropertyGroup>
     <CecilSourceDirectory>$(MSBuildThisFileDirectory)..\..\external\mono\external\cecil</CecilSourceDirectory>
     <UtilityOutputFullPath>$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\</UtilityOutputFullPath>
+    <XamarinAndroidToolsDirectory>$(MSBuildThisFileDirectory)..\..\external\xamarin-android-tools</XamarinAndroidToolsDirectory>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Adds xamarin/xamarin-android-tools to xamarin/Java.Interop.

Override `$(XamarinAndroidToolsDirectory)` so that the Java.Interop
build will use xamarin-android's `external/xamarin-android-tools` in
precedence/priority over the commit that Java.Interop uses, in a
similar fashion as 9bc51aed and Cecil.