### PR TITLE
[Xamarin.Android.Build.Tasks] Add 'transition' and 'array' support

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
@@ -27,8 +27,8 @@ namespace Foo.Foo
 		public partial class Animator
 		{
 			
-			// aapt resource value: 0x7F030002
-			public const int slide_in_bottom = 2130903042;
+			// aapt resource value: 0x7F040002
+			public const int slide_in_bottom = 2130968578;
 			
 			static Animator()
 			{
@@ -40,11 +40,27 @@ namespace Foo.Foo
 			}
 		}
 		
+		public partial class Array
+		{
+			
+			// aapt resource value: 0x7F110002
+			public const int widths_array = 2131820546;
+			
+			static Array()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Array()
+			{
+			}
+		}
+		
 		public partial class Dimension
 		{
 			
-			// aapt resource value: 0x7F090002
-			public const int main_text_item_size = 2131296258;
+			// aapt resource value: 0x7F100002
+			public const int main_text_item_size = 2131755010;
 			
 			static Dimension()
 			{
@@ -59,8 +75,8 @@ namespace Foo.Foo
 		public partial class Drawable
 		{
 			
-			// aapt resource value: 0x7F040002
-			public const int ic_menu_preferences = 2130968578;
+			// aapt resource value: 0x7F050002
+			public const int ic_menu_preferences = 2131034114;
 			
 			static Drawable()
 			{
@@ -75,8 +91,8 @@ namespace Foo.Foo
 		public partial class Font
 		{
 			
-			// aapt resource value: 0x7F050002
-			public const int arial = 2131034114;
+			// aapt resource value: 0x7F060002
+			public const int arial = 2131099650;
 			
 			static Font()
 			{
@@ -91,8 +107,8 @@ namespace Foo.Foo
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7F060002
-			public const int menu_settings = 2131099650;
+			// aapt resource value: 0x7F070002
+			public const int menu_settings = 2131165186;
 			
 			static Id()
 			{
@@ -107,8 +123,8 @@ namespace Foo.Foo
 		public partial class Menu
 		{
 			
-			// aapt resource value: 0x7F070002
-			public const int Options = 2131165186;
+			// aapt resource value: 0x7F080002
+			public const int Options = 2131230722;
 			
 			static Menu()
 			{
@@ -123,8 +139,8 @@ namespace Foo.Foo
 		public partial class Mipmap
 		{
 			
-			// aapt resource value: 0x7F080002
-			public const int icon = 2131230722;
+			// aapt resource value: 0x7F090002
+			public const int icon = 2131296258;
 			
 			static Mipmap()
 			{
@@ -139,8 +155,8 @@ namespace Foo.Foo
 		public partial class Plurals
 		{
 			
-			// aapt resource value: 0x7F020002
-			public const int num_locations_reported = 2130837506;
+			// aapt resource value: 0x7F030002
+			public const int num_locations_reported = 2130903042;
 			
 			static Plurals()
 			{
@@ -155,17 +171,17 @@ namespace Foo.Foo
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7F010003
-			public const int app_name = 2130771971;
+			// aapt resource value: 0x7F020003
+			public const int app_name = 2130837507;
 			
-			// aapt resource value: 0x7F010005
-			public const int foo = 2130771973;
+			// aapt resource value: 0x7F020005
+			public const int foo = 2130837509;
 			
-			// aapt resource value: 0x7F010002
-			public const int hello = 2130771970;
+			// aapt resource value: 0x7F020002
+			public const int hello = 2130837506;
 			
-			// aapt resource value: 0x7F010004
-			public const int menu_settings = 2130771972;
+			// aapt resource value: 0x7F020004
+			public const int menu_settings = 2130837508;
 			
 			static String()
 			{
@@ -173,6 +189,22 @@ namespace Foo.Foo
 			}
 			
 			private String()
+			{
+			}
+		}
+		
+		public partial class Transition
+		{
+			
+			// aapt resource value: 0x7F010002
+			public const int transition = 2130771970;
+			
+			static Transition()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Transition()
 			{
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManagedResourceParserTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManagedResourceParserTests.cs
@@ -31,6 +31,13 @@ namespace Xamarin.Android.Build.Tests {
 		const string StringsXml2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <resources>
   <string name = ""foo"" > Hello World, Click Me!</string>
+  <string-array name=""widths_array"">
+    <item>Thin</item>
+    <item>Thinish</item>
+    <item>Medium</item>
+    <item>Thickish</item>
+    <item>Thick</item>
+  </string-array>
 </resources>
 ";
 		const string Menu = @"<menu xmlns:android=""http://schemas.android.com/apk/res/android"">
@@ -54,13 +61,22 @@ namespace Xamarin.Android.Build.Tests {
 	<dimen name=""main_text_item_size"">17dp</dimen>
 </resources>";
 
+		const string Transition = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<changeBounds
+  xmlns:android=""http://schemas.android.com/apk/res/android""
+  android:duration=""5000""
+  android:interpolator=""@android:anim/overshoot_interpolator"" />
+";
+
 		[Test]
 		public void GenerateDesignerFile ()
 		{
 			var path = Path.Combine ("temp", TestName);
 			Directory.CreateDirectory (Path.Combine (Root, path, "res", "values"));
+			Directory.CreateDirectory (Path.Combine (Root, path, "res", "transition"));
 
 			File.WriteAllText (Path.Combine (Root, path, "res", "values", "strings.xml"), StringsXml);
+			File.WriteAllText (Path.Combine (Root, path, "res", "transition", "transition.xml"), Transition);
 
 			Directory.CreateDirectory (Path.Combine (Root, path, "lp", "res", "animator"));
 			Directory.CreateDirectory (Path.Combine (Root, path, "lp", "res", "font"));

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Android.Tasks
 	class ManagedResourceParser : ResourceParser
 	{
 		CodeTypeDeclaration resources;
-		CodeTypeDeclaration layout, ids, drawable, strings, colors, dimension, raw, animator, animation, attrib, boolean, font, ints, interpolators, menu, mipmaps, plurals, styleable, style, arrays, xml;
+		CodeTypeDeclaration layout, ids, drawable, strings, colors, dimension, raw, animator, animation, attrib, boolean, font, ints, interpolators, menu, mipmaps, plurals, styleable, style, arrays, xml, transition;
 		Dictionary<string, string> map;
 		bool app;
 		List<CodeTypeDeclaration> declarationIds = new List<CodeTypeDeclaration> ();
@@ -56,6 +56,7 @@ namespace Xamarin.Android.Tasks
 			plurals = CreateClass ("Plurals");
 			styleable = CreateClass ("Styleable");
 			style = CreateClass ("Style");
+			transition = CreateClass ("Transition");
 			xml = CreateClass ("Xml");
 
 			// This top most R.txt will contain EVERYTHING we need. including library resources since it represents
@@ -103,6 +104,7 @@ namespace Xamarin.Android.Tasks
 			SortMembers (strings);
 			SortMembers (style);
 			SortMembers (styleable);
+			SortMembers (transition);
 			SortMembers (xml);
 
 
@@ -146,6 +148,8 @@ namespace Xamarin.Android.Tasks
 				resources.Members.Add (style);
 			if (styleable.Members.Count > 1)
 				resources.Members.Add (styleable);
+			if (transition.Members.Count > 1)
+				resources.Members.Add (transition);
 			if (xml.Members.Count > 1)
 				resources.Members.Add (xml);
 
@@ -224,6 +228,9 @@ namespace Xamarin.Android.Tasks
 							arrayValues.Select (x => string.IsNullOrEmpty (x) ? 0 : Convert.ToInt32 (x, 16)).ToArray ());
 						break;
 					}
+					break;
+				case "transition":
+					CreateIntField (transition, itemName, value);
 					break;
 				case "xml":
 					CreateIntField (xml, itemName, value);
@@ -428,6 +435,9 @@ namespace Xamarin.Android.Tasks
 				break;
 			case "style":
 				CreateIntField (style, fieldName.Replace (".", "_"));
+				break;
+			case "transition":
+				CreateIntField (transition, fieldName);
 				break;
 			case "xml":
 				CreateIntField (xml, fieldName);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -173,6 +173,9 @@ namespace Xamarin.Android.Tasks
 				case "attr":
 					CreateIntField (attrib, itemName, value);
 					break;
+				case "array":
+					CreateIntField (arrays, itemName, value);
+					break;
 				case "bool":
 					CreateIntField (boolean, itemName, value);
 					break;


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/1983
The ManagedResourceParser did not support `transition`
resource types. This commit adds support for that missing
type.

It was also missing 'array' support when parsing the `R.txt` file.
This has also been added.