### PR TITLE
[tests] fix for ResolveSdksTaskTests on Windows

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -91,7 +91,7 @@ namespace Xamarin.Android.Build.Tests
 
 		public string Root {
 			get {
-				return XABuildPaths.TestOutputDirectory;
+				return Path.GetFullPath (XABuildPaths.TestOutputDirectory);
 			}
 		}
 


### PR DESCRIPTION
Context: http://build.devdiv.io/1901382

Since 8b244a1, the use of relative paths in the `BaseTest.Root` is
causing a test failure such as:

    Xamarin.Android.Build.Tests.ResolveSdksTaskTests.ResolveSdkTiming

    MonoAndroidToolsPath should be E:\A\_work\13\s\build-tools\scripts\..\..\bin\TestDebug
    Expected string length 29 but was 55. Strings differ at index 17.
    Expected: "E:\\A\\_work\\13\\s\\bin\\TestDebug"
    But was: "E:\\A\\_work\\13\\s\\build-tools\\scripts\\..\\..\\bin\\TestDebug"
    ---------------------------------^

To restore the old behavior of the path returned, using
`Path.GetFullPath` in the `Root` property seems to fix the failures.

The old code was returning the full path, so this puts things back the
way it was:

    public string Root {
        get {
            return Path.GetDirectoryName (new Uri (typeof (XamarinProject).Assembly.CodeBase).LocalPath);
        }
    }