### PR TITLE
[Xamarin.Android.Build.Tasks] fix for UseLatest when API level not installed

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -624,7 +624,7 @@ when packaing Release applications.
     allows the developer to define custom items to use with the
     `AndroidVersionCodePattern`. They are in the form of a `key=value`
     pair. All items in the `value` should be integer values. For
-    example: `screen=23;target=$(_SupportedApiLevel)`. As you can see
+    example: `screen=23;target=$(_AndroidApiLevel)`. As you can see
     you can make use of existing or custom MSBuild properties in the
     string.
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
@@ -294,10 +294,10 @@ namespace Xamarin.Android.Tasks
 
 				for (int apiLevel = maxSupported; apiLevel >= MonoAndroidHelper.SupportedVersions.MinStableVersion.ApiLevel; apiLevel--) {
 					var id = MonoAndroidHelper.SupportedVersions.GetIdFromApiLevel (apiLevel);
-					var apiPlatformDir = Path.Combine (AndroidSdkPath, "platforms", "android-" + id);
-					if (Directory.Exists (apiPlatformDir)) {
+					var apiPlatformDir = MonoAndroidHelper.AndroidSdk.TryGetPlatformDirectoryFromApiLevel (id, MonoAndroidHelper.SupportedVersions);
+					if (apiPlatformDir != null && Directory.Exists (apiPlatformDir)) {
 						var targetFramework = MonoAndroidHelper.SupportedVersions.GetFrameworkVersionFromId (id);
-						if (targetFramework != null && MonoAndroidHelper.SupportedVersions.FrameworkDirectories.Any (p => Directory.Exists (Path.Combine (p, targetFramework)))) {
+						if (targetFramework != null && MonoAndroidHelper.SupportedVersions.InstalledBindingVersions.Any (b => b.FrameworkVersion == targetFramework)) {
 							AndroidApiLevel = apiLevel.ToString ();
 							TargetFrameworkVersion = targetFramework;
 							break;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
@@ -41,9 +41,6 @@ namespace Xamarin.Android.Tasks
 		public string AndroidApiLevelName { get; set; }
 
 		[Output]
-		public string SupportedApiLevel { get; set; }
-
-		[Output]
 		public string AndroidSdkBuildToolsPath { get; set; }
 
 		[Output]
@@ -208,7 +205,6 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ($"  {nameof (TargetFrameworkVersion)}: {TargetFrameworkVersion}");
 			Log.LogDebugMessage ($"  {nameof (AndroidApiLevel)}: {AndroidApiLevel}");
 			Log.LogDebugMessage ($"  {nameof (AndroidApiLevelName)}: {AndroidApiLevelName}");
-			Log.LogDebugMessage ($"  {nameof (SupportedApiLevel)}: {SupportedApiLevel}");
 			Log.LogDebugMessage ($"  {nameof (AndroidSdkBuildToolsPath)}: {AndroidSdkBuildToolsPath}");
 			Log.LogDebugMessage ($"  {nameof (AndroidSdkBuildToolsBinPath)}: {AndroidSdkBuildToolsBinPath}");
 			Log.LogDebugMessage ($"  {nameof (ZipAlignPath)}: {ZipAlignPath}");
@@ -275,9 +271,8 @@ namespace Xamarin.Android.Tasks
 				int maxInstalled = GetMaxInstalledApiLevel ();
 				int maxSupported = GetMaxStableApiLevel ();
 				AndroidApiLevel = maxInstalled.ToString ();
-				SupportedApiLevel = maxSupported.ToString ();
 				if (maxInstalled > maxSupported) {
-					Log.LogDebugMessage ($"API Level {AndroidApiLevel} is greater than the maximum supported API level of {SupportedApiLevel}. " +
+					Log.LogDebugMessage ($"API Level {maxInstalled} is greater than the maximum supported API level of {maxSupported}. " +
 						"Support for this API will be added in a future release.");
 				}
 				if (!string.IsNullOrWhiteSpace (TargetFrameworkVersion)) {
@@ -287,8 +282,7 @@ namespace Xamarin.Android.Tasks
 					if (userSelected != null && userSelected > maxSupported && userSelected <= maxInstalled) {
 						maxInstalled =
 							maxSupported = userSelected.Value;
-						AndroidApiLevel =
-							SupportedApiLevel = userSelected.ToString ();
+						AndroidApiLevel = userSelected.ToString ();
 					}
 				}
 
@@ -317,13 +311,11 @@ namespace Xamarin.Android.Tasks
 					return false;
 				}
 				AndroidApiLevel = MonoAndroidHelper.SupportedVersions.GetApiLevelFromId (id).ToString ();
-				SupportedApiLevel = AndroidApiLevel;
 				return true;
 			}
 
 			if (!string.IsNullOrWhiteSpace (AndroidApiLevel)) {
 				AndroidApiLevel = AndroidApiLevel.Trim ();
-				SupportedApiLevel = GetMaxSupportedApiLevel (AndroidApiLevel);
 				TargetFrameworkVersion = GetTargetFrameworkVersionFromApiLevel ();
 				return TargetFrameworkVersion != null;
 			}
@@ -383,8 +375,7 @@ namespace Xamarin.Android.Tasks
 
 		string GetTargetFrameworkVersionFromApiLevel ()
 		{
-			string targetFramework = MonoAndroidHelper.SupportedVersions.GetFrameworkVersionFromId (SupportedApiLevel) ??
-				MonoAndroidHelper.SupportedVersions.GetFrameworkVersionFromId (AndroidApiLevel);
+			string targetFramework = MonoAndroidHelper.SupportedVersions.GetFrameworkVersionFromId (AndroidApiLevel);
 			if (targetFramework != null)
 				return targetFramework;
 			Log.LogCodedError ("XA0000",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
@@ -190,7 +190,7 @@ namespace Xamarin.Android.Build.Tests {
 				SequencePointsMode = "None",
 			};
 			Assert.AreEqual (expectedTaskResult, resolveSdks.Execute () && validateJavaVersion.Execute () && androidTooling.Execute (), $"Tasks should have {(expectedTaskResult ? "succeeded" : "failed" )}.");
-			Assert.AreEqual (expectedTargetFramework, androidTooling.TargetFrameworkVersion, $"TargetFrameworkVersion should be {expectedTargetFramework} but was {targetFrameworkVersion}");
+			Assert.AreEqual (expectedTargetFramework, androidTooling.TargetFrameworkVersion, $"TargetFrameworkVersion should be {expectedTargetFramework} but was {androidTooling.TargetFrameworkVersion}");
 			if (!string.IsNullOrWhiteSpace (expectedError)) {
 				Assert.AreEqual (1, errors.Count (), "An error should have been raised.");
 				Assert.AreEqual (expectedError, errors [0].Code, $"Expected error code {expectedError} but found {errors [0].Code}");
@@ -240,7 +240,7 @@ namespace Xamarin.Android.Build.Tests {
 				UseLatestAndroidPlatformSdk = false,
 				AotAssemblies = false,
 				SequencePointsMode = "None",
-			};;
+			};
 			var start = DateTime.UtcNow;
 			Assert.IsTrue (resolveSdks.Execute (), "ResolveSdks should succeed!");
 			Assert.IsTrue (validateJavaVersion.Execute (), "ValidateJavaVersion should succeed!");
@@ -276,6 +276,142 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.AreEqual (androidTooling.AndroidUseApkSigner, false, "AndroidUseApkSigner should be false");
 			Assert.AreEqual (validateJavaVersion.JdkVersion, "1.8.0", "JdkVersion should be 1.8.0");
 			Assert.AreEqual (validateJavaVersion.MinimumRequiredJdkVersion, "1.8", "MinimumRequiredJdkVersion should be 1.8");
+			Directory.Delete (Path.Combine (Root, path), recursive: true);
+		}
+
+		static object [] TargetFrameworkPairingParameters = new [] {
+			//We support 28, but only 27 is installed
+			new object [] {
+				"Older API Installed", //description
+				// androidSdks
+				new [] {
+					new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
+				},
+				// targetFrameworks
+				new ApiInfo [] {
+					new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
+					new ApiInfo () { Id = "28", Level = 28, Name = "P",    FrameworkVersion = "v9.0", Stable = true },
+				},
+				null,   //userSelected
+				"27",   //androidApiLevel
+				"27",   //androidApiLevelName
+				"v8.1", //targetFrameworkVersion
+				"28",   //supportedApiLevel
+			},
+			//28 is installed but we only support 27
+			new object [] {
+				"Newer API Installed", //description
+				// androidSdks
+				new [] {
+					new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
+					new ApiInfo () { Id = "28", Level = 28, Name = "P",    FrameworkVersion = "v9.0", Stable = true },
+				},
+				// targetFrameworks
+				new ApiInfo [] {
+					new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
+				},
+				null,   //userSelected
+				"27",   //androidApiLevel
+				"27",   //androidApiLevelName
+				"v8.1", //targetFrameworkVersion
+				"27",   //supportedApiLevel
+			},
+			//A paired downgrade to API 26
+			new object [] {
+				"Paired Downgrade", //description
+				// androidSdks
+				new [] {
+					new ApiInfo () { Id = "26", Level = 26, Name = "Oreo", FrameworkVersion = "v8.0", Stable = true },
+					new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
+				},
+				// targetFrameworks
+				new ApiInfo [] {
+					new ApiInfo () { Id = "26", Level = 26, Name = "Oreo", FrameworkVersion = "v8.0", Stable = true },
+					new ApiInfo () { Id = "28", Level = 28, Name = "P",    FrameworkVersion = "v9.0", Stable = true },
+				},
+				null,   //userSelected
+				"26",   //androidApiLevel
+				"26",   //androidApiLevelName
+				"v8.0", //targetFrameworkVersion
+				"28",   //supportedApiLevel
+			},
+			//A new API level 28 is not stable yet
+			new object [] {
+				"New Unstable API", //description
+				// androidSdks
+				new [] {
+					new ApiInfo () { Id = "26", Level = 26, Name = "Oreo", FrameworkVersion = "v8.0", Stable = true },
+					new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
+					new ApiInfo () { Id = "28", Level = 28, Name = "P",    FrameworkVersion = "v9.0", Stable = false },
+				},
+				// targetFrameworks
+				new ApiInfo [] {
+					new ApiInfo () { Id = "26", Level = 26, Name = "Oreo", FrameworkVersion = "v8.0", Stable = true },
+					new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
+					new ApiInfo () { Id = "28", Level = 28, Name = "P",    FrameworkVersion = "v9.0", Stable = false },
+				},
+				null,   //userSelected
+				"27",   //androidApiLevel
+				"27",   //androidApiLevelName
+				"v8.1", //targetFrameworkVersion
+				"27",   //supportedApiLevel
+			},
+			//User selected a new API level 28 is not stable yet
+			new object [] {
+				"User Selected Unstable API", //description
+				// androidSdks
+				new [] {
+					new ApiInfo () { Id = "26", Level = 26, Name = "Oreo", FrameworkVersion = "v8.0", Stable = true },
+					new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
+					new ApiInfo () { Id = "28", Level = 28, Name = "P",    FrameworkVersion = "v9.0", Stable = false },
+				},
+				// targetFrameworks
+				new ApiInfo [] {
+					new ApiInfo () { Id = "26", Level = 26, Name = "Oreo", FrameworkVersion = "v8.0", Stable = true },
+					new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
+					new ApiInfo () { Id = "28", Level = 28, Name = "P",    FrameworkVersion = "v9.0", Stable = false },
+				},
+				"v9.0", //userSelected
+				"28",   //androidApiLevel
+				"28",   //androidApiLevelName
+				"v9.0", //targetFrameworkVersion
+				"28",   //supportedApiLevel
+			},
+		};
+
+		[Test]
+		[TestCaseSource (nameof (TargetFrameworkPairingParameters))]
+		public void TargetFrameworkPairing (string description, ApiInfo[] androidSdk, ApiInfo[] targetFrameworks, string userSelected, string androidApiLevel, string androidApiLevelName, string targetFrameworkVersion, string supportedApiLevel)
+		{
+			var path = Path.Combine ("temp", $"{nameof (TargetFrameworkPairing)}_{description}");
+			var androidSdkPath = CreateFauxAndroidSdkDirectory (Path.Combine (path, "android-sdk"), "26.0.3", androidSdk);
+			string javaExe = string.Empty;
+			string javacExe;
+			var javaPath = CreateFauxJavaSdkDirectory (Path.Combine (path, "jdk"), "1.8.0", out javaExe, out javacExe);
+			var referencePath = CreateFauxReferencesDirectory (Path.Combine (path, "references"), targetFrameworks);
+			IBuildEngine engine = new MockBuildEngine (TestContext.Out);
+			var resolveSdks = new ResolveSdks {
+				BuildEngine = engine,
+				AndroidSdkPath = androidSdkPath,
+				AndroidNdkPath = androidSdkPath,
+				JavaSdkPath = javaPath,
+				ReferenceAssemblyPaths = new [] {
+					Path.Combine (referencePath, "MonoAndroid"),
+				},
+			};
+			var androidTooling = new ResolveAndroidTooling {
+				BuildEngine = engine,
+				AndroidSdkPath = androidSdkPath,
+				AndroidNdkPath = androidSdkPath,
+				UseLatestAndroidPlatformSdk = true,
+				TargetFrameworkVersion = userSelected,
+			};
+			Assert.IsTrue (resolveSdks.Execute (), "ResolveSdks should succeed!");
+			Assert.IsTrue (androidTooling.Execute (), "ResolveAndroidTooling should succeed!");
+			Assert.AreEqual (androidApiLevel, androidTooling.AndroidApiLevel, $"AndroidApiLevel should be {androidApiLevel}");
+			Assert.AreEqual (androidApiLevelName, androidTooling.AndroidApiLevelName, $"AndroidApiLevelName should be {androidApiLevelName}");
+			Assert.AreEqual (targetFrameworkVersion, androidTooling.TargetFrameworkVersion, $"TargetFrameworkVersion should be {targetFrameworkVersion}");
+			Assert.AreEqual (supportedApiLevel, androidTooling.SupportedApiLevel, $"SupportedApiLevel should be {supportedApiLevel}");
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
@@ -250,7 +250,6 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.AreEqual (androidTooling.AndroidApiLevel, "26", "AndroidApiLevel should be 26");
 			Assert.AreEqual (androidTooling.TargetFrameworkVersion, "v8.0", "TargetFrameworkVersion should be v8.0");
 			Assert.AreEqual (androidTooling.AndroidApiLevelName, "26", "AndroidApiLevelName should be 26");
-			Assert.AreEqual (androidTooling.SupportedApiLevel, "26", "SupportedApiLevel should be 26");
 			Assert.NotNull (resolveSdks.ReferenceAssemblyPaths, "ReferenceAssemblyPaths should not be null.");
 			Assert.AreEqual (resolveSdks.ReferenceAssemblyPaths.Length, 1, "ReferenceAssemblyPaths should have 1 entry.");
 			Assert.AreEqual (resolveSdks.ReferenceAssemblyPaths[0], Path.Combine (referencePath, "MonoAndroid"), $"ReferenceAssemblyPaths should be {Path.Combine (referencePath, "MonoAndroid")}.");
@@ -296,7 +295,6 @@ namespace Xamarin.Android.Build.Tests {
 				"27",   //androidApiLevel
 				"27",   //androidApiLevelName
 				"v8.1", //targetFrameworkVersion
-				"28",   //supportedApiLevel
 			},
 			//28 is installed but we only support 27
 			new object [] {
@@ -314,7 +312,6 @@ namespace Xamarin.Android.Build.Tests {
 				"27",   //androidApiLevel
 				"27",   //androidApiLevelName
 				"v8.1", //targetFrameworkVersion
-				"27",   //supportedApiLevel
 			},
 			//A paired downgrade to API 26
 			new object [] {
@@ -333,7 +330,6 @@ namespace Xamarin.Android.Build.Tests {
 				"26",   //androidApiLevel
 				"26",   //androidApiLevelName
 				"v8.0", //targetFrameworkVersion
-				"28",   //supportedApiLevel
 			},
 			//A new API level 28 is not stable yet
 			new object [] {
@@ -354,7 +350,6 @@ namespace Xamarin.Android.Build.Tests {
 				"27",   //androidApiLevel
 				"27",   //androidApiLevelName
 				"v8.1", //targetFrameworkVersion
-				"27",   //supportedApiLevel
 			},
 			//User selected a new API level 28 is not stable yet
 			new object [] {
@@ -375,13 +370,12 @@ namespace Xamarin.Android.Build.Tests {
 				"28",   //androidApiLevel
 				"28",   //androidApiLevelName
 				"v9.0", //targetFrameworkVersion
-				"28",   //supportedApiLevel
 			},
 		};
 
 		[Test]
 		[TestCaseSource (nameof (TargetFrameworkPairingParameters))]
-		public void TargetFrameworkPairing (string description, ApiInfo[] androidSdk, ApiInfo[] targetFrameworks, string userSelected, string androidApiLevel, string androidApiLevelName, string targetFrameworkVersion, string supportedApiLevel)
+		public void TargetFrameworkPairing (string description, ApiInfo[] androidSdk, ApiInfo[] targetFrameworks, string userSelected, string androidApiLevel, string androidApiLevelName, string targetFrameworkVersion)
 		{
 			var path = Path.Combine ("temp", $"{nameof (TargetFrameworkPairing)}_{description}");
 			var androidSdkPath = CreateFauxAndroidSdkDirectory (Path.Combine (path, "android-sdk"), "26.0.3", androidSdk);
@@ -411,7 +405,6 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.AreEqual (androidApiLevel, androidTooling.AndroidApiLevel, $"AndroidApiLevel should be {androidApiLevel}");
 			Assert.AreEqual (androidApiLevelName, androidTooling.AndroidApiLevelName, $"AndroidApiLevelName should be {androidApiLevelName}");
 			Assert.AreEqual (targetFrameworkVersion, androidTooling.TargetFrameworkVersion, $"TargetFrameworkVersion should be {targetFrameworkVersion}");
-			Assert.AreEqual (supportedApiLevel, androidTooling.SupportedApiLevel, $"SupportedApiLevel should be {supportedApiLevel}");
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -726,7 +726,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		<Output TaskParameter="TargetFrameworkVersion"      PropertyName="TargetFrameworkVersion" />
 		<Output TaskParameter="AndroidApiLevel"             PropertyName="_AndroidApiLevel"            Condition="'$(_AndroidApiLevel)' == ''" />
 		<Output TaskParameter="AndroidApiLevelName"         PropertyName="_AndroidApiLevelName" />
-		<Output TaskParameter="SupportedApiLevel"           PropertyName="_SupportedApiLevel" />
 		<Output TaskParameter="AndroidSdkBuildToolsPath"    PropertyName="AndroidSdkBuildToolsPath"    Condition="'$(AndroidSdkBuildToolsPath)' == ''" />
 		<Output TaskParameter="AndroidSdkBuildToolsBinPath" PropertyName="AndroidSdkBuildToolsBinPath" Condition="'$(AndroidSdkBuildToolsBinPath)' == ''" />
 		<Output TaskParameter="ZipAlignPath"                PropertyName="ZipAlignToolPath"            Condition="'$(ZipAlignToolPath)' == ''" />
@@ -1007,7 +1006,7 @@ because xbuild doesn't support framework reference assemblies.
 	</CreateProperty>
 
 	<!-- Get the defined constants for this API Level -->
-	<GetAndroidDefineConstants AndroidApiLevel="$(_SupportedApiLevel)" ProductVersion="$(MonoAndroidVersion)">
+	<GetAndroidDefineConstants AndroidApiLevel="$(_AndroidApiLevel)" ProductVersion="$(MonoAndroidVersion)">
 		<Output TaskParameter="AndroidDefineConstants" ItemName="AndroidDefineConstants" />
 	</GetAndroidDefineConstants>
 


### PR DESCRIPTION
Fixes #2007

Apparently there is a situation we aren't doing the right thing for:
- `TargetFrameworkVersion` is set to `v9.0`
- `AndroidUseLatestPlatformSdk`=`True`
- API 28 is not installed

In this case, we *should* be downgrading `TargetFrameworkVersion` to `v8.1`. Instead we get:

    ResolveSdksTask Outputs:
        AndroidApiLevel: 27
        AndroidApiLevelName: 27
        TargetFrameworkVersion: v9.0

This puts us in a weird state, since we would use JAR files for
different API levels:
- `platforms/android-27/android.jar`
- `xbuild-frameworks/MonoAndroid/v9.0/mono.android.jar`

This causes `proguard` (and likely other things) to fail:

    PROGUARD : warning : there were 38 unresolved references to classes or interfaces.
        You may need to add missing library jars or update their versions.
        If your code works fine without the missing classes, you can suppress
        the warnings with '-dontwarn' options.
        (http://proguard.sourceforge.net/manual/troubleshooting.html#unresolvedclass)

The fix here is somewhat complicated:
- Start at `maxSupported` API level and decrement until...
- An Android API level directory exists
- A `TargetFrameworkVersion` directory exists such as `MonoAndroid/v9.0`
- Use a properly paired API level + `TargetFrameworkVersion` combination

I also added parameterized test cases verifying the right thing is
happening when `AndroidUseLatestPlatformSdk` is enabled and different
API levels are actually installed.

Other changes:
- Refactored a bit to not call `int.TryParse` when not needed. We
could just use the `int` value and call `ToString ()` in a better
order.
- One existing test case had an incorrect failure message, I fixed.
- Removed `$(_SupportedApiLevel)` in favor of `$(_AndroidApiLevel)`,
since it appeared to be vestigial/not used