### PR TITLE
[Xamarin.Android.Build.Tasks] Fix issues with `ExtraArgs` for Aapt2.

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -817,6 +817,13 @@ resources.
 
     Added in Xamarin.Android 8.3.
 
+-   **AndroidAapt2CompileExtraArgs** &ndash; Specifies additional
+    command-line options to pass to the **aapt2 compile** command when
+    processing Android assets and resources.
+
+-   **AndroidAapt2LinkExtraArgs** &ndash; Specifies additional
+    command-line options to pass to the **aapt2 link** command when
+    processing Android assets and resources.
 <a name="Signing_Properties" />
 
 ### Signing Properties

--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -821,9 +821,14 @@ resources.
     command-line options to pass to the **aapt2 compile** command when
     processing Android assets and resources.
 
+    Added in Xamarin.Android 9.1.
+
 -   **AndroidAapt2LinkExtraArgs** &ndash; Specifies additional
     command-line options to pass to the **aapt2 link** command when
     processing Android assets and resources.
+
+    Added in Xamarin.Android 9.1.
+
 <a name="Signing_Properties" />
 
 ### Signing Properties

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -13,6 +13,7 @@
 ### aptxxxx Aapt Tooling
 
 + [apt0000](apt0000.md): Generic `aapt` Error/Warning.
++ [apt0001](apt0001.md): unknown option -- `{option}` . This is the result of using `aapt` command line arguments with `aapt2`. The arguments are not compatible.
 
 ### XA0xxx Environment/Missing Tooling
 

--- a/Documentation/guides/messages/apt0001.md
+++ b/Documentation/guides/messages/apt0001.md
@@ -1,0 +1,14 @@
+# Compiler Error APT0001
+
+The new Android `aapt2` resource tool has different commandline arguments to the 
+older `aapt` tool. These are generally incompatible with each other. If you are 
+receiving this error, check that the values provided in
+
+    <AndroidAapt2LinkExtraArgs/>
+    <AndroidAapt2CompileExtraArgs>
+
+are valid for `aapt2`. You can use `aapt2 compile` and `aapt2 link` to view
+the list of valid arguments.
+
+- error APT0001: unknown option -- --no-crunch . This is the result of using `aapt` command line arguments with `aapt2`. The arguments are not compatible.
+

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -106,7 +106,7 @@ namespace Xamarin.Android.Tasks {
 					line = int.Parse (match.Groups ["line"].Value) + 1;
 				var level = match.Groups ["level"].Value.ToLowerInvariant ();
 				var message = match.Groups ["message"].Value;
-				
+
 				// Handle the following which is NOT an error :(
 				// W/ResourceType(23681): For resource 0x0101053d, entry index(1341) is beyond type entryCount(733)
 				if (file.StartsWith ("W/")) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -92,10 +92,10 @@ namespace Xamarin.Android.Tasks {
 			}
 		}
 
-		protected void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance, bool apptResult)
+		protected bool LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance, bool apptResult)
 		{
 			if (string.IsNullOrEmpty (singleLine))
-				return;
+				return true;
 
 			var match = AndroidToolTask.AndroidErrorRegex.Match (singleLine.Trim ());
 
@@ -106,32 +106,37 @@ namespace Xamarin.Android.Tasks {
 					line = int.Parse (match.Groups ["line"].Value) + 1;
 				var level = match.Groups ["level"].Value.ToLowerInvariant ();
 				var message = match.Groups ["message"].Value;
-
+				
 				// Handle the following which is NOT an error :(
 				// W/ResourceType(23681): For resource 0x0101053d, entry index(1341) is beyond type entryCount(733)
 				if (file.StartsWith ("W/")) {
 					LogCodedWarning ("APT0000", singleLine);
-					return;
+					return true;
+				}
+				if (message.StartsWith ("unknown option")) {
+					// we need to filter out the remailing help lines somehow. 
+					LogCodedError ("APT0001", $"{message}. This is the result of using `aapt` command line arguments with `aapt2`. The arguments are not compatible.");
+					return false;
 				}
 				if (message.Contains ("fakeLogOpen")) {
 					LogMessage (singleLine, messageImportance);
-					return;
+					return true;
 				}
 				if (message.Contains ("note:")) {
 					LogMessage (singleLine, messageImportance);
-					return;
+					return true;
 				}
 				if (message.Contains ("warn:")) {
 					LogCodedWarning ("APT0000", singleLine);
-					return;
+					return true;
 				}
 				if (level.Contains ("note")) {
 					LogMessage (message, messageImportance);
-					return;
+					return true;
 				}
 				if (level.Contains ("warning")) {
 					LogCodedWarning ("APT0000", singleLine);
-					return;
+					return true;
 				}
 
 				// Try to map back to the original resource file, so when the user
@@ -155,7 +160,7 @@ namespace Xamarin.Android.Tasks {
 
 				if (level.Contains ("error") || (line != 0 && !string.IsNullOrEmpty (file))) {
 					LogCodedError ("APT0000", message, file, line);
-					return;
+					return true;
 				}
 			}
 
@@ -164,6 +169,7 @@ namespace Xamarin.Android.Tasks {
 			} else {
 				LogCodedWarning ("APT0000", singleLine);
 			}
+			return true;
 		}
 
 		protected void LoadResourceCaseMap ()

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -92,7 +92,7 @@ namespace Xamarin.Android.Tasks {
 			}
 		}
 
-		protected bool LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance, bool apptResult)
+		protected bool LogAapt2EventsFromOutput (string singleLine, MessageImportance messageImportance, bool apptResult)
 		{
 			if (string.IsNullOrEmpty (singleLine))
 				return true;
@@ -113,7 +113,7 @@ namespace Xamarin.Android.Tasks {
 					LogCodedWarning ("APT0000", singleLine);
 					return true;
 				}
-				if (message.StartsWith ("unknown option")) {
+				if (message.StartsWith ("unknown option", StringComparison.OrdinalIgnoreCase)) {
 					// we need to filter out the remailing help lines somehow. 
 					LogCodedError ("APT0001", $"{message}. This is the result of using `aapt` command line arguments with `aapt2`. The arguments are not compatible.");
 					return false;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
@@ -75,7 +75,7 @@ namespace Xamarin.Android.Tasks {
 			}
 			foreach (var line in output) {
 				if (line.StdError) {
-					if (!LogEventsFromTextOutput (line.Line, MessageImportance.Normal, success))
+					if (!LogAapt2EventsFromOutput (line.Line, MessageImportance.Normal, success))
 						break;
 				} else {
 					LogMessage (line.Line, MessageImportance.Normal);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
@@ -22,6 +22,8 @@ namespace Xamarin.Android.Tasks {
 
 		public bool ExplicitCrunch { get; set; }
 
+		public string ExtraArgs { get; set; }
+
 		[Output]
 		public ITaskItem [] CompiledResourceFlatArchives => archives.ToArray ();
 
@@ -73,7 +75,8 @@ namespace Xamarin.Android.Tasks {
 			}
 			foreach (var line in output) {
 				if (line.StdError) {
-					LogEventsFromTextOutput (line.Line, MessageImportance.Normal, success);
+					if (!LogEventsFromTextOutput (line.Line, MessageImportance.Normal, success))
+						break;
 				} else {
 					LogMessage (line.Line, MessageImportance.Normal);
 				}
@@ -90,6 +93,8 @@ namespace Xamarin.Android.Tasks {
 			cmd.AppendSwitchIfNotNull ("--dir ", ResourceDirectoryFullPath (dir.ItemSpec));
 			if (ExplicitCrunch)
 				cmd.AppendSwitch ("--no-crunch");
+			if (!string.IsNullOrEmpty (ExtraArgs))
+				cmd.AppendSwitch (ExtraArgs);
 			if (MonoAndroidHelper.LogInternalExceptions)
 				cmd.AppendSwitch ("-v");
 			return cmd.ToString ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -242,7 +242,7 @@ namespace Xamarin.Android.Tasks {
 				: ret;
 			foreach (var line in output) {
 				if (line.StdError) {
-					if (!LogEventsFromTextOutput (line.Line, MessageImportance.Normal, success))
+					if (!LogAapt2EventsFromOutput (line.Line, MessageImportance.Normal, success))
 						break;
 				} else {
 					LogMessage (line.Line, MessageImportance.Normal);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -242,7 +242,8 @@ namespace Xamarin.Android.Tasks {
 				: ret;
 			foreach (var line in output) {
 				if (line.StdError) {
-					LogEventsFromTextOutput (line.Line, MessageImportance.Normal, success);
+					if (!LogEventsFromTextOutput (line.Line, MessageImportance.Normal, success))
+						break;
 				} else {
 					LogMessage (line.Line, MessageImportance.Normal);
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Aapt2Tests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Aapt2Tests.cs
@@ -192,6 +192,7 @@ namespace Xamarin.Android.Build.Tests {
 				ExtraArgs = "--no-crunch "
 			};
 			Assert.False (task.Execute (), "task should have failed.");
+			Assert.AreEqual (1, errors.Count, "One error should have been raised.");
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1349,6 +1349,7 @@ because xbuild doesn't support framework reference assemblies.
 		ContinueOnError="$(DesignTimeBuild)"
 		ResourceDirectories="@(_LibraryResourceDirectories)"
 		ExplicitCrunch="$(AndroidExplicitCrunch)"
+		ExtraArgs="$(AndroidAapt2CompileExtraArgs)"
 		ToolPath="$(Aapt2ToolPath)"
 		ToolExe="$(Aapt2ToolExe)"
 	/>
@@ -1383,6 +1384,7 @@ because xbuild doesn't support framework reference assemblies.
 		ResourceDirectories="$(MonoAndroidResDirIntermediate)"
 		ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
 		ExplicitCrunch="$(AndroidExplicitCrunch)"
+		ExtraArgs="$(AndroidAapt2CompileExtraArgs)"
 		ToolPath="$(Aapt2ToolPath)"
 		ToolExe="$(Aapt2ToolExe)"
 	/>
@@ -1555,6 +1557,7 @@ because xbuild doesn't support framework reference assemblies.
    AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
    ManifestFiles="@(_AdditonalAndroidResourceCachePaths->'%(Identity)\AndroidManifest.xml');@(LibraryResourceDirectories->'%(Identity)\..\AndroidManifest.xml')"
    YieldDuringToolExecution="$(YieldDuringToolExecution)"
+   ExtraArgs="$(AndroidAapt2LinkExtraArgs)"
    ToolPath="$(Aapt2ToolPath)"
    ToolExe="$(Aapt2ToolExe)"
  />
@@ -1723,7 +1726,7 @@ because xbuild doesn't support framework reference assemblies.
 		YieldDuringToolExecution="$(YieldDuringToolExecution)"
 		ResourceSymbolsTextFile="$(IntermediateOutputPath)R.txt"
 		ResourceDirectories="$(MonoAndroidResDirIntermediate)"
-		ExtraArgs="$(AndroidResgenExtraArgs)"
+		ExtraArgs="$(AndroidAapt2LinkExtraArgs)"
 		ToolPath="$(Aapt2ToolPath)"
 		ToolExe="$(Aapt2ToolExe)"
 	/>
@@ -2340,6 +2343,7 @@ because xbuild doesn't support framework reference assemblies.
     AndroidSdkPlatform="$(_AndroidApiLevel)"
     JavaDesignerOutputDirectory="$(AaptTemporaryDirectory)"
     ManifestFiles="$(IntermediateOutputPath)android\AndroidManifest.xml"
+    ExtraArgs="$(AndroidAapt2LinkExtraArgs)"
     ToolPath="$(Aapt2ToolPath)"
     ToolExe="$(Aapt2ToolExe)"
   />


### PR DESCRIPTION
Fixes #1985

We currently use the same `AndroidResgenExtraArgs` property for
both `aapt` and `aapt2`. As a result when passing `--no-crunch`
to the `aapt2 link` command the following error is raised.

	error APT0000: unknown option '--no-crunch'. "unknown option '--no-crunch'.".

Even worse.. you get 70 errors as `aapt2` dumps the contents of
the help output to stdout. This is not idea and does not allow
the user to act on the error.

So this commit does a couple of things

1) Add two new properties for passing arguments for `aapt2`

```
<AndroidAapt2LinkExtraArgs/>
<AndroidAapt2CompileExtraArgs/>
```

   These will be used for `aapt2` instead of `AndroidResgenExtraArgs`.

2) Update the `Aapt2` to handle the unknown option error by emiting
   and more descriptive error message. Also make sure we ignore the
   rest of the `help` messages so that the user gets only one error
   and not 70.


- [x] Add Docs for new Properties