### PR TITLE
Refactor dynamic method names creation

### DIFF
--- a/src/Mono.Android/Android.Runtime/ConstructorBuilder.cs
+++ b/src/Mono.Android/Android.Runtime/ConstructorBuilder.cs
@@ -12,7 +12,6 @@ namespace Android.Runtime {
 		static FieldInfo handlefld = typeof (Java.Lang.Object).GetField ("handle", BindingFlags.NonPublic | BindingFlags.Instance);
 		static FieldInfo Throwable_handle = typeof (Java.Lang.Throwable).GetField ("handle", BindingFlags.NonPublic | BindingFlags.Instance);
 
-		static int dynamicMethodNameCounter;
 
 		internal static Action <IntPtr, object []> CreateDelegate (Type type, ConstructorInfo cinfo, Type [] parameter_types) {
 			var handle = handlefld;
@@ -20,7 +19,7 @@ namespace Android.Runtime {
 				handle = Throwable_handle;
 			}
 
-			DynamicMethod method = new DynamicMethod ($"{Interlocked.Increment (ref dynamicMethodNameCounter)}c", typeof (void), new Type [] {typeof (IntPtr), typeof (object []) }, typeof (object), true);
+			DynamicMethod method = new DynamicMethod (DynamicMethodNameCounter.GetUniqueName (), typeof (void), new Type [] {typeof (IntPtr), typeof (object []) }, typeof (DynamicMethodNameCounter), true);
 			ILGenerator il = method.GetILGenerator ();
 
 			il.DeclareLocal (typeof (object));

--- a/src/Mono.Android/Android.Runtime/DynamicMethodNameCounter.cs
+++ b/src/Mono.Android/Android.Runtime/DynamicMethodNameCounter.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Threading;
+
+namespace Android.Runtime {
+	internal class DynamicMethodNameCounter {
+		static long dynamicMethodNameCounter;
+
+		internal static string GetUniqueName ()
+		{
+			return Interlocked.Increment (ref dynamicMethodNameCounter).ToString (System.Globalization.CultureInfo.InvariantCulture);
+		}
+	}
+}

--- a/src/Mono.Android/Android.Runtime/JNINativeWrapper.cs
+++ b/src/Mono.Android/Android.Runtime/JNINativeWrapper.cs
@@ -11,8 +11,6 @@ namespace Android.Runtime {
 		static MethodInfo exception_handler_method;
 		static MethodInfo wait_for_bridge_processing_method;
 
-		static int dynamicMethodNameCounter;
-
 		static void get_runtime_types ()
 		{
 			if (mono_unhandled_exception_method != null)
@@ -51,7 +49,7 @@ namespace Android.Runtime {
 				param_types [i] = parameters [i].ParameterType;
 			}
 
-			var dynamic = new DynamicMethod (Interlocked.Increment (ref dynamicMethodNameCounter).ToString (), ret_type, param_types, typeof (object), true);
+			var dynamic = new DynamicMethod (DynamicMethodNameCounter.GetUniqueName (), ret_type, param_types, typeof (DynamicMethodNameCounter), true);
 			var ig = dynamic.GetILGenerator ();
 
 			LocalBuilder retval = null;

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -84,6 +84,7 @@
     <Compile Include="..\..\external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings\JavaNativeTypeManager.cs">
       <Link>JavaNativeTypeManager.cs</Link>
     </Compile>
+    <Compile Include="Android.Runtime\DynamicMethodNameCounter.cs" />
   </ItemGroup>
   <Import Project="..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems')" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Put the dynamic method name logic in one place. It also removes the
formatted string use and uses `InvariantCulture`.

It hopefully improves the performance (simpler string operations,
`InvariantCulture`). The change in performance is so small though, that
I wasn't able to measure it.

We use `long` counter, because `ConstructorBuilder` can, in some
cases, create a new constructor per java object instance. This should
be addressed in the future. After that we can probably get back to
`int` counter.

Also associate the created dynamic methods with
`DynamicMethodNameCounter` class instead of `System.Object`