### PR TITLE
[Xamarin.Android.Build.Tasks] Fix Aapt2 warnings showing as errors

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -414,7 +414,7 @@ namespace Xamarin.Android.Tasks
 				var file = match.Groups["file"].Value;
 				int line = 0;
 				if (!string.IsNullOrEmpty (match.Groups["line"]?.Value))
-					line = int.Parse (match.Groups["line"].Value) + 1;
+					line = int.Parse (match.Groups["line"].Value.Trim ()) + 1;
 				var level = match.Groups["level"].Value.ToLowerInvariant ();
 				var message = match.Groups ["message"].Value;
 				if (message.Contains ("fakeLogOpen")) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -103,13 +103,14 @@ namespace Xamarin.Android.Tasks {
 				var file = match.Groups ["file"].Value;
 				int line = 0;
 				if (!string.IsNullOrEmpty (match.Groups ["line"]?.Value))
-					line = int.Parse (match.Groups ["line"].Value) + 1;
+					line = int.Parse (match.Groups ["line"].Value.Trim ()) + 1;
 				var level = match.Groups ["level"].Value.ToLowerInvariant ();
 				var message = match.Groups ["message"].Value;
 
 				// Handle the following which is NOT an error :(
 				// W/ResourceType(23681): For resource 0x0101053d, entry index(1341) is beyond type entryCount(733)
-				if (file.StartsWith ("W/")) {
+				// W/ResourceType( 3681): For resource 0x0101053d, entry index(1341) is beyond type entryCount(733)
+				if (file.StartsWith ("W/", StringComparison.OrdinalIgnoreCase)) {
 					LogCodedWarning ("APT0000", singleLine);
 					return;
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidToolTask.cs
@@ -91,9 +91,9 @@ namespace Xamarin.Android.Tasks
  (?<path>
   (?<file>.+[\\/][^:\(]+)
   (
-   ([:](?<line>\d+))
+   ([:](?<line>[\d ]+))
    |
-   (\((?<line>\d+)\))
+   (\((?<line>[\d ]+)\))
   )?
  )
  \s*

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidRegExTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidRegExTests.cs
@@ -130,6 +130,22 @@ namespace Xamarin.Android.Build.Tests
 					/*expectedLevel*/	"",
 					/*expectedMessage*/	"invalid resource directory name: bar-55"
 				};
+				yield return new object [] {
+					/*message*/		"W/ResourceType(23681): For resource 0x0101053d, entry index(1341) is beyond type entryCount(733)",
+					/*expectedToMatch*/	true,
+					/*expectedFile*/	"W/ResourceType",
+					/*expectedLine*/	"23681",
+					/*expectedLevel*/	"",
+					/*expectedMessage*/	"For resource 0x0101053d, entry index(1341) is beyond type entryCount(733)"
+				};
+				yield return new object [] {
+					/*message*/		"W/ResourceType( 5536): For resource 0x0101053d, entry index(1341) is beyond type entryCount(1155)",
+					/*expectedToMatch*/	true,
+					/*expectedFile*/	"W/ResourceType",
+					/*expectedLine*/	" 5536",
+					/*expectedLevel*/	"",
+					/*expectedMessage*/	"For resource 0x0101053d, entry index(1341) is beyond type entryCount(1155)"
+				};
 			}
 		}
 


### PR DESCRIPTION
Fixes (again) #1770

On windows we are hitting the same issue where the warnings
`aapt2` is producing are being logged as errors.

The weird part is that the "file" group was not being populated
with the right informaton.. This turns out to be down to how
`aapt2` is reporting the warnings..

	W/ResourceType(23681): For resource 0x0101053d, entry index(1341) is beyond type entryCount(733)
	W/ResourceType( 5536): For resource 0x0101053d, entry index(1341) is beyond type entryCount(1155)
		       ^
		    Hmmmmm.

This space throws off our regex and results in the entire line
ending up in the `message` property.
So the fix is to update the regex to allow spaces for the `line`
capture group. We then also need to Trim that value before passing
it into `int.Parse` to ensure we don't get an error.