### PR TITLE
[Xamarin.Android.Build.Tasks] _LinkAssembliesNoShrink timestamps

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
@@ -160,10 +160,8 @@ namespace Xamarin.Android.Tasks
 							// We cannot just copy the linker output from *current* run output, because
 							// it always renew the assemblies, in *different* binary values, whereas
 							// the dll in the OptionalDestinationDirectory must retain old and unchanged.
-							if (File.Exists (assemblyDestination)) {
-								MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (assemblyDestination, DateTime.UtcNow, Log);
+							if (File.Exists (assemblyDestination))
 								continue;
-							}
 						} else {
 							// Prefer fixup assemblies if exists, otherwise just copy the original.
 							copysrc = Path.Combine (OutputDirectory, filename);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -205,11 +205,13 @@ namespace Xamarin.Android.Tests
 		}
 
 		[Test]
-		public void CheckTimestamps ()
+		public void CheckTimestamps ([Values (true, false)] bool isRelease)
 		{
 			var start = DateTime.UtcNow.AddSeconds (-1);
-			var proj = new XamarinAndroidApplicationProject ();
-			using (var b = CreateApkBuilder ("temp/CheckTimestamps")) {
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = isRelease,
+			};
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				//To be sure we are at a clean state, delete bin/obj
 				var intermediate = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath);
 				if (Directory.Exists (intermediate))
@@ -240,7 +242,8 @@ namespace Xamarin.Android.Tests
 
 				//One last build with no changes
 				Assert.IsTrue (b.Build (proj), "third build should have succeeded.");
-				Assert.IsTrue (b.Output.IsTargetSkipped ("_LinkAssembliesNoShrink"), "`_LinkAssembliesNoShrink` should be skipped!");
+				string targetName = isRelease ? "_LinkAssembliesShrink" : "_LinkAssembliesNoShrink";
+				Assert.IsTrue (b.Output.IsTargetSkipped (targetName), $"`{targetName}` should be skipped!");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2078,7 +2078,13 @@ because xbuild doesn't support framework reference assemblies.
       LinkOnlyNewerThan="$(_AndroidLinkFlag)"
       ResolvedAssemblies="@(ResolvedAssemblies)" />
 
-	<!-- We don't have to depend on flag file for NoShrink, but it is used to check timestamp -->
+    <!--NOTE: the linker's use of File.Copy requires us to update the timestamps of output files -->
+    <ItemGroup>
+      <_FilesToTouch Include="$(MonoAndroidIntermediateAssemblyTempDir)*" />
+    </ItemGroup>
+    <Touch Files="@(_FilesToTouch)" />
+
+    <!-- We don't have to depend on flag file for NoShrink, but it is used to check timestamp -->
     <Touch Files="$(_AndroidLinkFlag)" AlwaysCreate="true" />
 </Target>
 	


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/3d999d32c3dcd78f687f0976f0b5a6a985736a75#diff-42a9402e6466c65d49d0ee7caf21f327R164

Since 3d999d32, a test is failing downstream in monodroid that is
testing the following scenario:
- With `Fast Deployment` enabled, run `/t:Install`
- Make a small code change
- Run `/t:Install` again
- Assemblies are getting uploaded to the device that should already be
  up to date!

3d999d32 was addressing a symptom of the problem, but not the root
cause. The `OutputStep` of the linker has various uses of `File.Copy`,
which *preserves* the timestamp of the source file.

https://github.com/mono/linker/blob/615f62c32705322aeb0f3f15212a3dbb94b7f0aa/linker/Linker.Steps/OutputStep.cs#L187

The solution, then, is to run the `<Touch />` MSBuild task on the
linker's output. This will keep the proper timestamps, and a portion
of the changes in 3d999d32 are no longer needed.

I updated the `CheckTimestamps` test to validate `Debug` and `Release`
configurations, so `_LinkAssembliesShrink` is also tested in this
manner. It turns out `_LinkAssembliesShrink` is currently working
fine, since it uses `$(_AndroidLinkFlag)` as its `Outputs`.