### PR TITLE
[Xamarin.Android.Tools.BootstrapTasks] Remove adb errors

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CheckAdbTarget.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CheckAdbTarget.cs
@@ -36,10 +36,6 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 		public override bool Execute ()
 		{
-			Log.LogMessage (MessageImportance.Low, $"Task {nameof (CheckAdbTarget)}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (AdbTarget)}: {AdbTarget}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (SdkVersion)}: {SdkVersion}");
-
 			state = CommandState.CheckSdk;
 			base.Execute ();
 
@@ -47,9 +43,6 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				state = CommandState.CheckPM;
 				base.Execute ();
 			}
-
-			Log.LogMessage (MessageImportance.Low, $"  [Output] {nameof (AdbTarget)}: {AdbTarget}");
-			Log.LogMessage (MessageImportance.Low, $"  [Output] {nameof (IsValidTarget)}: {IsValidTarget}");
 
 			return true;
 		}
@@ -73,7 +66,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
 		{
-			base.LogEventsFromTextOutput (singleLine, messageImportance);
+			Log.LogMessage (MessageImportance.Low, singleLine);
 			if (string.IsNullOrEmpty (singleLine))
 				return;
 


### PR DESCRIPTION
Many of our PR builds recently have been failing, e.g. [3697][3697]:

	CHECKADBTARGET : error : no devices/emulators found [/Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/build-tools/timing/timing.csproj]

What's "funny" about this error message is that the
`<CheckAdbTarget/>` task *shouldn't ever fail*: the `Execute()` always
returns `true` (no error), and *itself* never calls `LogError()`.

However, it *did* call `ToolTask.LogEventsFromTextOutput()`, which
*can* call `LogError()` if it runs across an error in a "canonical"
format, complete with uppercasing the task name when it does so.

Remove the `base.LogEventsFromTextOutput()` invocation so that we
don't inadvertently log an error message.  With luck, this will remove
`<CheckAdbTarget/>` as a possible source of errors, and increase
reliability of our unit tests.

[3697]: https://jenkins.mono-project.com/job/xamarin-android-pr-builder/3697/