### PR TITLE
[Xamarin.Android.Build.Tasks] Aapt2 & AndroidResgenExtraArgs compatibility

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -772,6 +772,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	/>
 	<PropertyGroup>
 		<AndroidExplicitCrunch Condition=" '$(_AndroidUseAapt2)' == 'True' ">false</AndroidExplicitCrunch>
+		<AndroidAap2LinkExtraArgs Condition=" '$(_AndroidUseAapt2)' == 'True' And $(AndroidResgenExtraArgs.Contains('--no-version-vectors')) And !($(AndroidAap2LinkExtraArgs.Contains('--no-version-vectors'))) ">--no-version-vectors $(AndroidAap2LinkExtraArgs) </AndroidAap2LinkExtraArgs>
 	</PropertyGroup>
 </Target>
 


### PR DESCRIPTION
Fixes #2029

The Xamarin.Android.Support.Vector.Drawable [1] NuGet package
overrides `$(AndroidResgenExtraArgs)` with `--no-version-vectors`.
Since 77d603a2 `aapt2` now has its own properties for `link` and
`compile`. As a result people using `aapt2` are likely to encounter
issues when using the above Nuget Package.

To help our users we can auto detect if the `--no-version-vectors`
is set in the `$(AndroidResgenExtraArgs)` property and auto
include that into the new `$(AndroidAap2LinkExtraArgs)` property
(if it does not contain it already). This will hopefully provide
a smooth transiton for users using `aapt2`.

Note `$(AndroidAap2CompileExtraArgs)` does NOT need the same argument
since is it not a valid argument for the `compile` task.

[1] https://www.nuget.org/packages/Xamarin.Android.Support.Vector.Drawable/27.0.2.1