### PR TITLE
[Xamarin.Android.Build.Tasks] fix for UseLatest when API level not installed

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -624,7 +624,7 @@ when packaing Release applications.
     allows the developer to define custom items to use with the
     `AndroidVersionCodePattern`. They are in the form of a `key=value`
     pair. All items in the `value` should be integer values. For
-    example: `screen=23;target=$(_SupportedApiLevel)`. As you can see
+    example: `screen=23;target=$(_AndroidApiLevel)`. As you can see
     you can make use of existing or custom MSBuild properties in the
     string.
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
@@ -358,13 +358,14 @@ namespace Xamarin.Android.Build.Tests {
 		[TestCaseSource (nameof (TargetFrameworkPairingParameters))]
 		public void TargetFrameworkPairing (string description, ApiInfo[] androidSdk, ApiInfo[] targetFrameworks, string userSelected, string androidApiLevel, string androidApiLevelName, string targetFrameworkVersion)
 		{
-			var path = Path.Combine ("temp", $"{nameof (TargetFrameworkPairing)}_{description}");
+			var path = Path.Combine ("temp", $"{nameof (TargetFrameworkPairing)}_{description.Replace (' ', '_')}");
 			var androidSdkPath = CreateFauxAndroidSdkDirectory (Path.Combine (path, "android-sdk"), "26.0.3", androidSdk);
 			string javaExe = string.Empty;
 			string javacExe;
 			var javaPath = CreateFauxJavaSdkDirectory (Path.Combine (path, "jdk"), "1.8.0", out javaExe, out javacExe);
 			var referencePath = CreateFauxReferencesDirectory (Path.Combine (path, "references"), targetFrameworks);
-			IBuildEngine engine = new MockBuildEngine (TestContext.Out);
+			var log = new StringBuilder ();
+			IBuildEngine engine = new MockBuildEngine (new StringWriter (log));
 			var resolveSdks = new ResolveSdks {
 				BuildEngine = engine,
 				AndroidSdkPath = androidSdkPath,
@@ -380,7 +381,7 @@ namespace Xamarin.Android.Build.Tests {
 				LatestSupportedJavaVersion = "1.8.0",
 				MinimumSupportedJavaVersion = "1.7.0",
 			};
-			Assert.IsTrue (resolveSdks.Execute (), "ResolveSdks should succeed!");
+			Assert.IsTrue (resolveSdks.Execute (), $"ResolveSdks should succeed! Failed with: {log}");
 			Assert.AreEqual (androidApiLevel, resolveSdks.AndroidApiLevel, $"AndroidApiLevel should be {androidApiLevel}");
 			Assert.AreEqual (androidApiLevelName, resolveSdks.AndroidApiLevelName, $"AndroidApiLevelName should be {androidApiLevelName}");
 			Assert.AreEqual (targetFrameworkVersion, resolveSdks.TargetFrameworkVersion, $"TargetFrameworkVersion should be {targetFrameworkVersion}");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
@@ -181,7 +181,7 @@ namespace Xamarin.Android.Build.Tests {
 			task.JavaToolExe = javaExe;
 			task.JavacToolExe = javacExe;
 			Assert.AreEqual (expectedTaskResult, task.Execute (), $"Task should have {(expectedTaskResult ? "succeeded" : "failed" )}.");
-			Assert.AreEqual (expectedTargetFramework, task.TargetFrameworkVersion, $"TargetFrameworkVersion should be {expectedTargetFramework} but was {targetFrameworkVersion}");
+			Assert.AreEqual (expectedTargetFramework, task.TargetFrameworkVersion, $"TargetFrameworkVersion should be {expectedTargetFramework} but was {task.TargetFrameworkVersion}");
 			if (!string.IsNullOrWhiteSpace (expectedError)) {
 				Assert.AreEqual (1, errors.Count (), "An error should have been raised.");
 				Assert.AreEqual (expectedError, errors [0].Code, $"Expected error code {expectedError} but found {errors [0].Code}");
@@ -230,7 +230,6 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.AreEqual (task.AndroidApiLevel, "26", "AndroidApiLevel should be 26");
 			Assert.AreEqual (task.TargetFrameworkVersion, "v8.0", "TargetFrameworkVersion should be v8.0");
 			Assert.AreEqual (task.AndroidApiLevelName, "26", "AndroidApiLevelName should be 26");
-			Assert.AreEqual (task.SupportedApiLevel, "26", "SupportedApiLevel should be 26");
 			Assert.NotNull (task.ReferenceAssemblyPaths, "ReferenceAssemblyPaths should not be null.");
 			Assert.AreEqual (task.ReferenceAssemblyPaths.Length, 1, "ReferenceAssemblyPaths should have 1 entry.");
 			Assert.AreEqual (task.ReferenceAssemblyPaths[0], Path.Combine (referencePath, "MonoAndroid"), $"ReferenceAssemblyPaths should be {Path.Combine (referencePath, "MonoAndroid")}.");
@@ -257,6 +256,134 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.AreEqual (task.AndroidUseApkSigner, false, "AndroidUseApkSigner should be false");
 			Assert.AreEqual (task.JdkVersion, "1.8.0", "JdkVersion should be 1.8.0");
 			Assert.AreEqual (task.MinimumRequiredJdkVersion, "1.8", "MinimumRequiredJdkVersion should be 1.8");
+			Directory.Delete (Path.Combine (Root, path), recursive: true);
+		}
+
+		static object [] TargetFrameworkPairingParameters = new [] {
+			//We support 28, but only 27 is installed
+			new object [] {
+				"Older API Installed", //description
+				// androidSdks
+				new [] {
+					new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
+				},
+				// targetFrameworks
+				new ApiInfo [] {
+					new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
+					new ApiInfo () { Id = "28", Level = 28, Name = "P",    FrameworkVersion = "v9.0", Stable = true },
+				},
+				null,   //userSelected
+				"27",   //androidApiLevel
+				"27",   //androidApiLevelName
+				"v8.1", //targetFrameworkVersion
+			},
+			//28 is installed but we only support 27
+			new object [] {
+				"Newer API Installed", //description
+				// androidSdks
+				new [] {
+					new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
+					new ApiInfo () { Id = "28", Level = 28, Name = "P",    FrameworkVersion = "v9.0", Stable = true },
+				},
+				// targetFrameworks
+				new ApiInfo [] {
+					new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
+				},
+				null,   //userSelected
+				"27",   //androidApiLevel
+				"27",   //androidApiLevelName
+				"v8.1", //targetFrameworkVersion
+			},
+			//A paired downgrade to API 26
+			new object [] {
+				"Paired Downgrade", //description
+				// androidSdks
+				new [] {
+					new ApiInfo () { Id = "26", Level = 26, Name = "Oreo", FrameworkVersion = "v8.0", Stable = true },
+					new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
+				},
+				// targetFrameworks
+				new ApiInfo [] {
+					new ApiInfo () { Id = "26", Level = 26, Name = "Oreo", FrameworkVersion = "v8.0", Stable = true },
+					new ApiInfo () { Id = "28", Level = 28, Name = "P",    FrameworkVersion = "v9.0", Stable = true },
+				},
+				null,   //userSelected
+				"26",   //androidApiLevel
+				"26",   //androidApiLevelName
+				"v8.0", //targetFrameworkVersion
+			},
+			//A new API level 28 is not stable yet
+			new object [] {
+				"New Unstable API", //description
+				// androidSdks
+				new [] {
+					new ApiInfo () { Id = "26", Level = 26, Name = "Oreo", FrameworkVersion = "v8.0", Stable = true },
+					new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
+					new ApiInfo () { Id = "28", Level = 28, Name = "P",    FrameworkVersion = "v9.0", Stable = false },
+				},
+				// targetFrameworks
+				new ApiInfo [] {
+					new ApiInfo () { Id = "26", Level = 26, Name = "Oreo", FrameworkVersion = "v8.0", Stable = true },
+					new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
+					new ApiInfo () { Id = "28", Level = 28, Name = "P",    FrameworkVersion = "v9.0", Stable = false },
+				},
+				null,   //userSelected
+				"27",   //androidApiLevel
+				"27",   //androidApiLevelName
+				"v8.1", //targetFrameworkVersion
+			},
+			//User selected a new API level 28 is not stable yet
+			new object [] {
+				"User Selected Unstable API", //description
+				// androidSdks
+				new [] {
+					new ApiInfo () { Id = "26", Level = 26, Name = "Oreo", FrameworkVersion = "v8.0", Stable = true },
+					new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
+					new ApiInfo () { Id = "28", Level = 28, Name = "P",    FrameworkVersion = "v9.0", Stable = false },
+				},
+				// targetFrameworks
+				new ApiInfo [] {
+					new ApiInfo () { Id = "26", Level = 26, Name = "Oreo", FrameworkVersion = "v8.0", Stable = true },
+					new ApiInfo () { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1", Stable = true },
+					new ApiInfo () { Id = "28", Level = 28, Name = "P",    FrameworkVersion = "v9.0", Stable = false },
+				},
+				"v9.0", //userSelected
+				"28",   //androidApiLevel
+				"28",   //androidApiLevelName
+				"v9.0", //targetFrameworkVersion
+			},
+		};
+
+		[Test]
+		[TestCaseSource (nameof (TargetFrameworkPairingParameters))]
+		public void TargetFrameworkPairing (string description, ApiInfo[] androidSdk, ApiInfo[] targetFrameworks, string userSelected, string androidApiLevel, string androidApiLevelName, string targetFrameworkVersion)
+		{
+			var path = Path.Combine ("temp", $"{nameof (TargetFrameworkPairing)}_{description}");
+			var androidSdkPath = CreateFauxAndroidSdkDirectory (Path.Combine (path, "android-sdk"), "26.0.3", androidSdk);
+			string javaExe = string.Empty;
+			string javacExe;
+			var javaPath = CreateFauxJavaSdkDirectory (Path.Combine (path, "jdk"), "1.8.0", out javaExe, out javacExe);
+			var referencePath = CreateFauxReferencesDirectory (Path.Combine (path, "references"), targetFrameworks);
+			IBuildEngine engine = new MockBuildEngine (TestContext.Out);
+			var resolveSdks = new ResolveSdks {
+				BuildEngine = engine,
+				AndroidSdkPath = androidSdkPath,
+				AndroidNdkPath = androidSdkPath,
+				JavaSdkPath = javaPath,
+				JavaToolExe = javaExe,
+				JavacToolExe = javacExe,
+				ReferenceAssemblyPaths = new [] {
+					Path.Combine (referencePath, "MonoAndroid"),
+				},
+				UseLatestAndroidPlatformSdk = true,
+				TargetFrameworkVersion = userSelected,
+				LatestSupportedJavaVersion = "1.8.0",
+				MinimumSupportedJavaVersion = "1.7.0",
+			};
+			Assert.IsTrue (resolveSdks.Execute (), "ResolveSdks should succeed!");
+			Assert.AreEqual (androidApiLevel, resolveSdks.AndroidApiLevel, $"AndroidApiLevel should be {androidApiLevel}");
+			Assert.AreEqual (androidApiLevelName, resolveSdks.AndroidApiLevelName, $"AndroidApiLevelName should be {androidApiLevelName}");
+			Assert.AreEqual (targetFrameworkVersion, resolveSdks.TargetFrameworkVersion, $"TargetFrameworkVersion should be {targetFrameworkVersion}");
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -684,7 +684,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 			ZipAlignPath="$(ZipAlignToolPath)">
 		<Output TaskParameter="AndroidApiLevel"           PropertyName="_AndroidApiLevel"           Condition="'$(_AndroidApiLevel)' == ''" />
 		<Output TaskParameter="AndroidApiLevelName"       PropertyName="_AndroidApiLevelName" />
-		<Output TaskParameter="SupportedApiLevel"         PropertyName="_SupportedApiLevel"	/>
 		<Output TaskParameter="TargetFrameworkVersion"    PropertyName="_TargetFrameworkVersion" />
 		<Output TaskParameter="ReferenceAssemblyPaths"    PropertyName="_XATargetFrameworkDirectories" />
 		<Output TaskParameter="TargetFrameworkVersion"    PropertyName="TargetFrameworkVersion" />
@@ -965,7 +964,7 @@ because xbuild doesn't support framework reference assemblies.
 	</CreateProperty>
 
 	<!-- Get the defined constants for this API Level -->
-	<GetAndroidDefineConstants AndroidApiLevel="$(_SupportedApiLevel)" ProductVersion="$(MonoAndroidVersion)">
+	<GetAndroidDefineConstants AndroidApiLevel="$(_AndroidApiLevel)" ProductVersion="$(MonoAndroidVersion)">
 		<Output TaskParameter="AndroidDefineConstants" ItemName="AndroidDefineConstants" />
 	</GetAndroidDefineConstants>
 


### PR DESCRIPTION
Cherry-pick from (#2018)

Fixes: https://github.com/xamarin/xamarin-android/issues/2007

Apparently there is a situation we aren't doing the right thing for:

  - `$(TargetFrameworkVersion)`=v9.0
  - `$(AndroidUseLatestPlatformSdk)`=True
  - API 28 is not installed

In this case, we *should* be downgrading `$(TargetFrameworkVersion)`
to `v8.1`.  Instead we get:

	ResolveSdksTask Outputs:
	    AndroidApiLevel: 27
	    AndroidApiLevelName: 27
	    TargetFrameworkVersion: v9.0

This puts us in a weird state, since we would use `.jar` files for
different API levels:

  - `platforms/android-27/android.jar`
  - `xbuild-frameworks/MonoAndroid/v9.0/mono.android.jar`

This in turn causes `proguard` (and likely other things) to fail:

	PROGUARD : warning : there were 38 unresolved references to classes or interfaces.
	    You may need to add missing library jars or update their versions.
	    If your code works fine without the missing classes, you can suppress
	    the warnings with '-dontwarn' options.
	    (http://proguard.sourceforge.net/manual/troubleshooting.html#unresolvedclass)

The fix here is somewhat complicated:

 1. Starting at `maxSupported` API level, check to see if:
 2. An Android API directory corresponding to `maxSupported` exists,
    e.g. `platforms/android-28`, and
 3. A `$(TargetFrameworkVersion)` directory corresponding to (2)
    exists such as `MonoAndroid/v9.0`.
 4. Decrement `maxSupported` until a value which satisfies *both*
    (2) and (3) is found.

Add a parameterized test cases verifying that the right thing is
happening when `$(AndroidUseLatestPlatformSdk)`=True and different
API levels are actually installed.

Other changes:

  - Refactored a bit to not call `int.TryParse()` when not needed. We
    could just use the `int` value and call `ToString()` in a better
    order.
  - One existing test case had an incorrect failure message; fixed.

Finally, remove `$(_SupportedApiLevel)`.  This MSBuild property
appears to be vestigial, and was causing confusion but had no real
benefit, i.e. as `$(_SupportedApiLevel)` is used to generate the
`ANDROID_X` values in `<GetAndroidDefineConstants/>`, what possible
value is there in allowing it to be *higher* than
`$(TargetFrameworkVersion)`, which controls which `Mono.Android.dll`
the source code is compiled against?

It appears that we can just remove `$(_SupportedApiLevel)`, and use
`$(_AndroidApiLevel)` in its place.  I also checked private repos,
and could find nothing that is using this property.