### PR TITLE
Provide warnings around compileSdkVersion(TargetFrameworkVersion), targetSdkVersion, and minSdkVersion

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -784,7 +784,7 @@ when packaing Release applications.
     developers who are not targeting the Google Play Store and do
     not wish to run those checks.
 
-    Added in Xamarin.Android 9.2.
+    Added in Xamarin.Android 9.4.
 
 ### Binding Project Build Properties
 

--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -778,6 +778,14 @@ when packaing Release applications.
 
     Added in Xamarin.Android 9.2.
 
+- **AndroidEnableGooglePlayStoreChecks** &ndash; A bool property
+    which allows developers to disable the following Google Play
+    Store checks, XA1004, XA1005 and XA1006. This is useful for 
+    developers who are not targeting the Google Play Store and do
+    not wish to run those checks.
+
+    Added in Xamarin.Android 9.2.
+
 ### Binding Project Build Properties
 
 The following MSBuild properties are used with

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -53,6 +53,9 @@
 + [XA1003](xa1003.md): '{zip}' does not exist. Please rebuild the project.
 + [XA1004](xa1004.md): There was an error opening {filename}. The file is probably corrupt. Try deleting it and building again.
 + [XA1005](xa1005.md): Attempting naive type name fixup for element with ID '{id}' and type '{managedType}'
++ [XA1006](xa1006.md): Your application is running on a version of Android ({compileSdk}) that is more recent than your targetSdkVersion specifies ({targetSdk}). Set your targetSdkVersion to the highest version of Android available to match your TargetFrameworkVersion ({compileSdk}).
++ [XA1007](xa1007.md): The minSdkVersion ({minSdk}) is greater than targetSdkVersion. Please change the value such that minSdkVersion is less than or equal to targetSdkVersion ({targetSdk}).
++ [XA1008](xa1008.md): The TargetFrameworkVersion ({compileSdk}) should not be lower than targetSdkVersion ({targetSdk})
 
 ### XA2xxx Linker
 

--- a/Documentation/guides/messages/xa1006.md
+++ b/Documentation/guides/messages/xa1006.md
@@ -1,0 +1,7 @@
+# Compiler Warning XA1006
+
+ You are building against a version of Android (compileSdk) that
+ is more recent than your targetSdkVersion specifies (targetSdk).
+
+ Set your targetSdkVersion to the highest version of Android available
+ to match your TargetFrameworkVersion (compileSdk).

--- a/Documentation/guides/messages/xa1007.md
+++ b/Documentation/guides/messages/xa1007.md
@@ -1,0 +1,6 @@
+# Compiler Warning XA1007
+
+The minSdkVersion (minSdk) is greater than targetSdkVersion.
+
+Please change the value such that minSdkVersion is less than
+or equal to targetSdkVersion (targetSdk).

--- a/Documentation/guides/messages/xa1008.md
+++ b/Documentation/guides/messages/xa1008.md
@@ -1,0 +1,8 @@
+# Compiler Warning XA1008
+
+The TargetFrameworkVersion (compileSdk) must not be lower
+than targetSdkVersion (targetSdk).
+
+You should either, increase the `$(TargetFrameworkVersion)` 
+of your project. Or decrease the `android:targetSdkVersion`
+in your `AndroidManifest.xml` to correct this issue.

--- a/Novell/MonoDroid.FSharp.targets
+++ b/Novell/MonoDroid.FSharp.targets
@@ -1,0 +1,4 @@
+<Project>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.FSharp.targets" />
+</Project>
+

--- a/Novell/Novell.MonoDroid.CSharp.targets
+++ b/Novell/Novell.MonoDroid.CSharp.targets
@@ -1,0 +1,3 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+</Project>

--- a/Novell/Novell.MonoDroid.Common.targets
+++ b/Novell/Novell.MonoDroid.Common.targets
@@ -1,0 +1,4 @@
+<Project>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Common.targets" />
+</Project>
+

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckGoogleSdkRequirements.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckGoogleSdkRequirements.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Build.Utilities;
+using Microsoft.Build.Framework;
+using System.IO;
+using System.Linq;
+
+using Java.Interop.Tools.Cecil;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks
+{
+	public class CheckGoogleSdkRequirements : Task 
+	{
+		[Required]
+		public string TargetFrameworkVersion { get; set; }
+
+		[Required]
+		public string ManifestFile { get; set; }
+
+		public override bool Execute ()
+		{
+			ManifestDocument manifest = new ManifestDocument (ManifestFile, this.Log);
+
+			var compileSdk = MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (TargetFrameworkVersion);
+
+			if (!int.TryParse (manifest.GetMinimumSdk (), out int minSdk)) {
+				minSdk = 1;
+			}
+			if (!int.TryParse (manifest.GetTargetSdk (), out int targetSdk)) {
+				targetSdk = compileSdk.Value;
+			}
+
+			//We should throw a warning if the targetSdkVersion is lower than compileSdkVersion(TargetFrameworkVersion).
+			if (targetSdk < compileSdk) {
+				Log.LogCodedWarning ("XA1006",
+					$"You are building against version of Android ({compileSdk}) that is more recent than your targetSdkVersion specifies ({targetSdk}). Set your targetSdkVersion to the highest version of Android available to match your TargetFrameworkVersion ({compileSdk}).");
+			}
+			//We should throw an warning if the compileSdkVersion(TargetFrameworkVersion) is lower than targetSdkVersion.
+			if (compileSdk < targetSdk) {
+				Log.LogCodedWarning ("XA1008",
+					$"The TargetFrameworkVersion ({compileSdk}) must not be lower than targetSdkVersion ({targetSdk}). You should either, increase the `$(TargetFrameworkVersion)` of your project. Or decrease the `android:targetSdkVersion` in your `AndroidManifest.xml` to correct this issue.");
+			}
+			//We should throw an warning if the minSdkVersion is greater than targetSdkVers1ion.
+			if (minSdk > targetSdk) {
+				Log.LogCodedWarning ("XA1007",
+					$"The minSdkVersion ({minSdk}) is greater than targetSdkVersion. Please change the value such that minSdkVersion is less than or equal to targetSdkVersion ({targetSdk}).");
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CheckGoogleSdkRequirementsTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CheckGoogleSdkRequirementsTests.cs
@@ -1,0 +1,99 @@
+﻿using Microsoft.Build.Framework;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xamarin.Android.Tasks;
+using Xamarin.Android.Tools;
+using Xamarin.ProjectTools;
+
+namespace Xamarin.Android.Build.Tests {
+	[TestFixture]
+	public class CheckGoogleSdkRequirementsTests : BaseTest {
+		List<BuildErrorEventArgs> errors;
+		List<BuildWarningEventArgs> warnings;
+		MockBuildEngine engine;
+
+		[SetUp]
+		public void Setup ()
+		{
+			var path = Path.Combine ("temp", TestName);
+			engine = new MockBuildEngine (TestContext.Out, errors = new List<BuildErrorEventArgs> (), warnings = new List<BuildWarningEventArgs> ());
+			var referencePath = CreateFauxReferencesDirectory (Path.Combine (path, "references"), new [] {
+				new ApiInfo { Id = "27", Level = 27, Name = "Oreo", FrameworkVersion = "v8.1",  Stable = true },
+				new ApiInfo { Id = "28", Level = 28, Name = "Pie", FrameworkVersion = "v9.0",  Stable = true },
+			});
+			MonoAndroidHelper.RefreshSupportedVersions (new [] {
+				Path.Combine (referencePath, "MonoAndroid"),
+			});
+		}
+
+		[TearDown]
+		public void TearDown ()
+		{
+			var path = Path.Combine ("temp", TestName);
+			Directory.Delete (Path.Combine (Root, path), recursive: true);
+		}
+
+		string CreateManiestFile (int minSDk, int targetSdk) {
+			var manifest = Path.Combine (Root, "temp", TestName, "AndroidManifest.xml");
+			File.WriteAllText (manifest, string.Format (@"<manifest xmlns:android='http://schemas.android.com/apk/res/android' android:versionCode='1' android:versionName='1.0' package='Foo.Foo'>
+	<uses-sdk android:minSdkVersion = '{0}' android:targetSdkVersion = '{1}' />
+</manifest>
+", minSDk, targetSdk));
+			return manifest;
+		}
+
+		[Test]
+		public void CheckManifestIsOK ()
+		{
+			var task = new CheckGoogleSdkRequirements () {
+				BuildEngine = engine,
+				TargetFrameworkVersion = "v9.0",
+				ManifestFile = CreateManiestFile (10, 28),
+			};
+			Assert.True (task.Execute (), "Task should have succeeded.");
+			Assert.AreEqual (0, errors.Count, "There should be 0 errors reported.");
+			Assert.AreEqual (0, warnings.Count, "There should be 0 warnings reported.");
+		}
+
+		[Test]
+		public void CheckManifestTargetSdkLowerThanCompileSdk ()
+		{
+			var task = new CheckGoogleSdkRequirements () {
+				BuildEngine = engine,
+				TargetFrameworkVersion = "v9.0",
+				ManifestFile = CreateManiestFile (10, 27),
+			};
+			Assert.True (task.Execute (), "Task should have succeeded.");
+			Assert.AreEqual (0, errors.Count, "There should be 0 errors reported.");
+			Assert.AreEqual (1, warnings.Count, "There should be 1 warning reported.");
+		}
+
+		[Test]
+		public void CheckManifestCompileSdkLowerThanTargetSdk ()
+		{
+			var task = new CheckGoogleSdkRequirements () {
+				BuildEngine = engine,
+				TargetFrameworkVersion = "v8.1",
+				ManifestFile = CreateManiestFile (10, 28),
+			};
+			Assert.True (task.Execute (), "Task should have succeeded.");
+			Assert.AreEqual (0, errors.Count, "There should be 1 error reported.");
+			Assert.AreEqual (1, warnings.Count, "There should be 0 warnings reported.");
+		}
+
+		[Test]
+		public void CheckManifestMinSdkLowerThanTargetSdk ()
+		{
+			var task = new CheckGoogleSdkRequirements () {
+				BuildEngine = engine,
+				TargetFrameworkVersion = "v8.1",
+				ManifestFile = CreateManiestFile (28, 27),
+			};
+			Assert.True (task.Execute (), "Task should have succeeded.");
+			Assert.AreEqual (0, errors.Count, "There should be 0 error reported.");
+			Assert.AreEqual (1, warnings.Count, "There should be 1 warnings reported.");
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="ZipArchiveExTests.cs" />
     <Compile Include="ConvertResourcesCasesTests.cs" />
     <Compile Include="Tasks\NdkUtilTests.cs" />
+    <Compile Include="Tasks\CheckGoogleSdkRequirementsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Expected\GenerateDesignerFileExpected.cs">

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -113,7 +113,8 @@ namespace Xamarin.Android.Tasks {
 			return minAttr.Value;
 		}
 
-		public string GetTargetSdk () {
+		public string GetTargetSdk ()
+		{
 			var targetAttr = doc.Root.Element ("uses-sdk")?.Attribute (androidNs + "targetSdkVersion");
 			if (targetAttr == null) {
 				return SdkVersionName;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -113,6 +113,14 @@ namespace Xamarin.Android.Tasks {
 			return minAttr.Value;
 		}
 
+		public string GetTargetSdk () {
+			var targetAttr = doc.Root.Element ("uses-sdk")?.Attribute (androidNs + "targetSdkVersion");
+			if (targetAttr == null) {
+				return SdkVersionName;
+			}
+			return targetAttr.Value;
+		}
+
 		TaskLoggingHelper log;
 
 		public ManifestDocument (string templateFilename, TaskLoggingHelper log) : base ()

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -588,6 +588,7 @@
     <Compile Include="Tasks\LayoutWidget.cs" />
     <Compile Include="Tasks\CancelableTask.cs" />
     <Compile Include="..\..\bin\Build$(Configuration)\XABuildConfig.cs" />
+    <Compile Include="Tasks\CheckGoogleSdkRequirements.cs" />
     <None Include="Resources\desugar_deploy.jar">
       <Link>desugar_deploy.jar</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -37,6 +37,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.CalculateAdditionalResourceCacheDirectories" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CalculateLayoutCodeBehind" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CalculateProjectDependencies" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.CheckGoogleSdkRequirements" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CheckForRemovedItems" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CheckForInvalidResourceFileNames" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CompileToDalvik" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -241,6 +242,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidLintEnabled Condition=" '$(AndroidLintEnabled)' == ''">False</AndroidLintEnabled>
 	<AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">False</AndroidUseIntermediateDesignerFile>
 
+	<!-- Google Play Store Checks -->
+	<AndroidEnableGooglePlayStoreChecks Condition=" '$(AndroidEnableGooglePlayStoreChecks)' == '' ">true</AndroidEnableGooglePlayStoreChecks>
+		
 	<!-- Prevent warnings about assembly version conflicts -->
 	<AutoUnifyAssemblyReferences Condition="'$(AutoUnifyAssemblyReferences)' == ''">True</AutoUnifyAssemblyReferences>
 	<AutoGenerateBindingRedirects Condition="'$(AutoGenerateBindingRedirects)' == ''">False</AutoGenerateBindingRedirects>
@@ -521,6 +525,12 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
  </CreateItem>
 </Target>
 
+<Target Name="_CheckGoogleSdkRequirements" Condition="Exists('$(IntermediateOutputPath)android\AndroidManifest.xml') And '$(AndroidEnableGooglePlayStoreChecks)' == 'true' ">
+	<CheckGoogleSdkRequirements
+		TargetFrameworkVersion="$(TargetFrameworkVersion)"
+		ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
+	/>
+</Target>
 
 <!--
 *******************************************
@@ -2885,6 +2895,7 @@ because xbuild doesn't support framework reference assemblies.
 		_CheckApkPerAbiFlag
 		;_LintChecks
 		;_IncludeNativeSystemLibraries
+		;_CheckGoogleSdkRequirements
 	</_PrepareBuildApkDependsOnTargets>
 </PropertyGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -525,11 +525,12 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
  </CreateItem>
 </Target>
 
-<Target Name="_CheckGoogleSdkRequirements" Condition="Exists('$(IntermediateOutputPath)android\AndroidManifest.xml') And '$(AndroidEnableGooglePlayStoreChecks)' == 'true' ">
-	<CheckGoogleSdkRequirements
-		TargetFrameworkVersion="$(TargetFrameworkVersion)"
-		ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
-	/>
+<Target Name="_CheckGoogleSdkRequirements"
+    Condition="Exists('$(IntermediateOutputPath)android\AndroidManifest.xml') And '$(AndroidEnableGooglePlayStoreChecks)' == 'true' ">
+  <CheckGoogleSdkRequirements
+      TargetFrameworkVersion="$(TargetFrameworkVersion)"
+      ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
+  />
 </Target>
 
 <!--


### PR DESCRIPTION
Context https://github.com/xamarin/xamarin-android/issues/1768

Google has the following guidance for these three values:

> minSdkVersion (lowest possible) <= targetSdkVersion == compileSdkVersion (latest SDK)

This commit adds a new Task `CheckGoogleSdkRequirements` which is responsible for checking
these values. It will be enabled by default but the task can be disabled via the
`AndroidEnableGooglePlayStoreChecks` property. 