### PR TITLE
[Xamarin.Android.Build.Tasks] fix for parallel builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -74,10 +74,10 @@ namespace Xamarin.Android.Tasks
 				}
 				Log.LogDebugMessage ("  Processing: {0}   {1} > {2}", file, srcmodifiedDate, lastUpdate);
 				var tmpdest = Path.GetTempFileName ();
-				MonoAndroidHelper.CopyIfChanged (file, tmpdest);
+				File.Copy (file, tmpdest, overwrite: true);
 				MonoAndroidHelper.SetWriteable (tmpdest);
 				try {
-					AndroidResource.UpdateXmlResource (resdir, tmpdest, acwMap,
+					bool success = AndroidResource.UpdateXmlResource (resdir, tmpdest, acwMap,
 						ResourceDirectories.Where (s => s != item).Select(s => s.ItemSpec), (t, m) => {
 							string targetfile = file;
 							if (targetfile.StartsWith (resdir, StringComparison.InvariantCultureIgnoreCase)) {
@@ -98,6 +98,10 @@ namespace Xamarin.Android.Tasks
 									break;
 							}
 						});
+					if (!success) {
+						//If we failed to write the file, a warning is logged, we should skip to the next file
+						continue;
+					}
 
 					// We strip away an eventual UTF-8 BOM from the XML file.
 					// This is a requirement for the Android designer because the desktop Java renderer

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
@@ -11,7 +11,7 @@ using System.Xml.XPath;
 namespace Monodroid {
 	static class AndroidResource {
 		
-		public static void UpdateXmlResource (string res, string filename, Dictionary<string, string> acwMap, IEnumerable<string> additionalDirectories = null, Action<TraceLevel, string> logMessage = null)
+		public static bool UpdateXmlResource (string res, string filename, Dictionary<string, string> acwMap, IEnumerable<string> additionalDirectories = null, Action<TraceLevel, string> logMessage = null)
 		{
 			// use a temporary file so we only update the real file if things actually changed
 			string tmpfile = filename + ".bk";
@@ -24,14 +24,13 @@ namespace Monodroid {
 						xw.WriteNode (doc.CreateNavigator (), false);
 				Xamarin.Android.Tasks.MonoAndroidHelper.CopyIfChanged (tmpfile, filename);
 				File.Delete (tmpfile);
-			}
-			catch (Exception e) {
+				return true;
+			} catch (Exception e) {
 				if (File.Exists (tmpfile)) {
 					File.Delete (tmpfile);
 				}
-				if (logMessage != null)
-					logMessage (TraceLevel.Warning, $"AndroidResgen: Warning while updating Resource XML '{filename}': {e.Message}");
-				return;
+				logMessage?.Invoke (TraceLevel.Warning, $"AndroidResgen: Warning while updating Resource XML '{filename}': {e.Message}");
+				return false;
 			}
 		}
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/2043

When parallel builds occur, we can get `obj/Debug/lp` into a broken
state:

    Resources/layout/abc_action_menu_layout.xml warning XA1001:
        AndroidResgen: Warning while updating Resource XML '/var/folders/nx/rzr6lcqj6j3_vp7vtp28v2cw0000gn/T/tmp6bafd8e4.tmp': Root element is missing.

Then later, `<Aapt />` fails on the empty file:

    obj/Debug/lp/11/jl/res/layout/abc_action_menu_layout.xml(2,0): error APT0000: Error parsing XML: no element found

It appears that `ConvertResourcesCases` still copies the file, even if
`AndroidResource.UpdateXmlResource` fails. Subsequent builds will
continue to fail, because an empty file has been copied with a newer
timestamp. Once in this state, developers would have to `Rebuild` the
project or delete `obj`.

The fix here is to:
- Return a `bool` indicating if `AndroidResource.UpdateXmlResource`
  succeeds
- Don't write the final file if `AndroidResource.UpdateXmlResource`
  failed

This change doesn't fully fix #2043, as I think VS for Mac should
prevent builds from happening in parallel. I tried the change in the
IDE once, and it worked. However, I feel like if I repeated the steps
10 times in a row, something would eventually go wrong.

This change *does*, however, fix the issue for the user so a `Rebuild`
is not required.

Other changes:
- The original temp file can use `File.Copy` since it is empty
- We can  use the `?` operator for invoking `logMessage`