### PR TITLE
[Xamarin.Android.Build.Tasks] 3 tales of #deletebinobj

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2413,6 +2413,10 @@ because xbuild doesn't support framework reference assemblies.
   Inputs="$(MSBuildAllProjects);$(MonoPlatformJarPath);@(_JavaStubFiles);@(AndroidJavaSource);@(AddOnPlatformLibraries)"
   Outputs="$(IntermediateOutputPath)_javac.stamp">
 
+  <!-- remove existing <Javac /> outputs, since *.class files and classes.zip could contain old files -->
+  <RemoveDir Directories="$(IntermediateOutputPath)android\bin\classes" />
+  <Delete Files="$(IntermediateOutputPath)android\bin\classes.zip" />
+
   <!-- Compile java code -->
   <Javac
     JavaPlatformJarPath="$(JavaPlatformJarPath)"
@@ -2566,7 +2570,10 @@ because xbuild doesn't support framework reference assemblies.
   </CreateMultiDexMainDexClassList>
 
   <!-- remove existing dex files that may be previous multidex outputs. -->
-  <Delete Files="$(IntermediateOutputPath)android\bin\classes\*.dex" />
+  <ItemGroup>
+    <_DexesToDelete Include="$(IntermediateOutputPath)android\bin\*.dex" />
+  </ItemGroup>
+  <Delete Files="@(_DexesToDelete)" />
 
   <!-- Compile java code to dalvik -->
   <CompileToDalvik 


### PR DESCRIPTION
I got report from a customer (over email) of an error such as:

    Java.Lang.ClassNotFoundException: Didn't find class "com.google.android.gms.R$string" on path: DexPathList

The build log showed the app was using a combination of Firebase with
MultiDex enabled, so I tried the Firebase sample from the docs team:

https://github.com/xamarin/monodroid-samples/tree/master/Firebase/FCMNotifications

Things appeared to work fine, but something seemed strange: my "spider
sense" was going off.

My initial thought was that the customer recently enabled MultiDex,
and toggling MultiDex on/off was breaking the build.

Oh, it was much worse than that.

I wrote a simple test with the following scenario:
- Build an app that *requires* MultiDex, w/ many methods
- Check we have `classes.dex`, `classes2.dex`, `classes3.dex`
- Remove the Java code with all the methods, so MultiDex is no longer required
- Build again
- We should *only* have `classes.dex`

Here I found problem No. 1:

    <Delete Files="$(IntermediateOutputPath)android\bin\classes\*.dex" />

Not only is this the *wrong* directory which should be
`$(IntermediateOutputPath)android\bin\*.dex`, but this is also
incorrect use of the `<Delete />` task! Using wildcards like this
requires use of an `<ItemGroup />` to "gather" the paths.

I added an `<ItemGroup />` and moved on:

    <ItemGroup>
        <_DexesToDelete Include="$(IntermediateOutputPath)android\bin\*.dex" />
    </ItemGroup>
    <Delete Files="@(_DexesToDelete)" />

And then I found problem No. 2...

After it was now properly deleting the dexes, `classes2.dex` and
`classes3.dex` were still recreated!

Looking into `obj\Debug\android\bin\classes`, I saw
`ManyMethods.class` and `ManyMethods2.class`, which should *not*
exist!

Nothing deletes old `*.classes` files! I guess they are just left
around? `javac` happily overwrites existing `*.class` files as needed?

So I added a call to remove the `classes` directory before `<Javac />`:

    <RemoveDir Directories="$(IntermediateOutputPath)android\bin\classes" />

And then I found problem No. 3...

When inspecting `obj`, I noticed `obj\Debug\android\bin\classes.zip`
still contained `ManyMethods.class` and `ManyMethods2.class`. Even
though they were deleted...

It looked like the `<Javac />` task was *appending* to the zip file!

So I added a final `<Delete />` to remove `classes.zip`:

    <Delete Files="$(IntermediateOutputPath)android\bin\classes.zip" />

And my test now passes...

How did this ever work???