### PR TITLE
[Xamarin.Android.Build.Tasks] Add CancelableTask.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AsyncTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AsyncTask.cs
@@ -7,9 +7,8 @@ using System.Collections;
 
 namespace Xamarin.Android.Tasks
 {
-	public class AsyncTask : Task, ICancelableTask {
+	public class AsyncTask : CancelableTask {
 
-		CancellationTokenSource tcs = new CancellationTokenSource ();
 		Queue logMessageQueue =new Queue ();
 		Queue warningMessageQueue = new Queue ();
 		Queue errorMessageQueue = new Queue ();
@@ -45,8 +44,6 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		public CancellationToken Token { get { return tcs.Token; } }
-
 		public bool YieldDuringToolExecution { get; set; }
 
 		protected string WorkingDirectory { get; private set; } 
@@ -64,7 +61,7 @@ namespace Xamarin.Android.Tasks
 			WorkingDirectory = Directory.GetCurrentDirectory ();
 		}
 
-		public void Cancel ()
+		public override void Cancel ()
 		{
 			taskCancelled.Set ();
 		}
@@ -354,7 +351,7 @@ namespace Xamarin.Android.Tasks
 						}, customDataAvailable);
 						break;
 					case WaitHandleIndex.TaskCancelled:
-						tcs.Cancel ();
+						base.Cancel ();
 						isRunning = false;
 						break;
 					case WaitHandleIndex.Completed:

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CancelableTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CancelableTask.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using Microsoft.Build.Utilities;
+using Microsoft.Build.Framework;
+using System.Threading;
+using System.Collections;
+
+namespace Xamarin.Android.Tasks
+{
+	public class CancelableTask : Task, ICancelableTask {
+		CancellationTokenSource tcs = new CancellationTokenSource ();
+
+		public CancellationToken Token { get { return tcs.Token; } }
+
+		public virtual void Cancel ()
+		{
+			tcs.Cancel ();
+		}
+
+		public override bool Execute ()
+		{
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -574,6 +574,7 @@
     <Compile Include="Tasks\LayoutLocationInfo.cs" />
     <Compile Include="Tasks\LayoutTypeFixup.cs" />
     <Compile Include="Tasks\LayoutWidget.cs" />
+    <Compile Include="Tasks\CancelableTask.cs" />
     <None Include="Resources\desugar_deploy.jar">
       <Link>desugar_deploy.jar</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
The `ICancelableTask` is implemented by the AsyncTask
so that long background processes can respond to a `Cancel`
requrest from MSBuild.

The problem here is that many of our tasks which we might
want to cancel, do not derive from `AsyncTask`. Given that
allot of the time a task wont be using the features of
`AsyncTask`, it makes sense to introduce a new bass class.

This new class implements `ICancelableTask` and will allow
normal `Tasks` to use those features. This can be done by
overriding the `Cancel` method. Or alternatively using the
`CancellationToken` property `Token` to `Register` callbacks
or simply check `Token.IsCancellationRequested`.

`AsyncTask` has been updated to use the new base class.