### PR TITLE
[Xamarin.Android.Build.Tasks] AndroidCreatePackagePerAbi APKs should be signed

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -227,17 +227,31 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidCreatePackagePerAbi, perAbiApk);
 			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidSupportedAbis, "armeabi-v7a;x86");
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
-				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
-				Assert.IsTrue (b.Build (proj), "build failed");
+				var bin = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath);
+				Assert.IsTrue (b.Build (proj), "First build failed");
 				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, " 0 Warning(s)"),
 						"First build should not contain warnings!  Contains\n" +
 						string.Join ("\n", b.LastBuildOutput.Where (line => line.Contains ("warning"))));
+
+				//Make sure the APKs are signed
+				foreach (var apk in Directory.GetFiles (bin, "*-Signed.apk")) {
+					using (var zip = ZipHelper.OpenZip (apk)) {
+						Assert.IsTrue (zip.Any (e => e.FullName == "META-INF/MANIFEST.MF"), $"APK file `{apk}` is not signed! It is missing `META-INF/MANIFEST.MF`.");
+					}
+				}
+
 				proj.AndroidResources.First ().Timestamp = null;
 				Assert.IsTrue (b.Build (proj), "Second build failed");
-				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, " 0 Warning(s)"), "Second build should not contain warnings!");
 				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, " 0 Warning(s)"),
 						"Second build should not contain warnings!  Contains\n" +
 						string.Join ("\n", b.LastBuildOutput.Where (line => line.Contains ("warning"))));
+
+				//Make sure the APKs are signed
+				foreach (var apk in Directory.GetFiles (bin, "*-Signed.apk")) {
+					using (var zip = ZipHelper.OpenZip (apk)) {
+						Assert.IsTrue (zip.Any (e => e.FullName == "META-INF/MANIFEST.MF"), $"APK file `{apk}` is not signed! It is missing `META-INF/MANIFEST.MF`.");
+					}
+				}
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2936,9 +2936,13 @@ because xbuild doesn't support framework reference assemblies.
 		ToolPath="$(ZipAlignToolPath)"
 		ToolExe="$(ZipalignToolExe)"
 	/>
+	<ItemGroup>
+		<ApkAbiFilesSigned Include="$(ApkFileSigned)" Condition="'$(AndroidUseApkSigner)' == 'true'" />
+		<ApkAbiFilesSigned Condition="'$(AndroidCreatePackagePerAbi)' == 'true' And '$(AndroidUseApkSigner)' == 'true' " Include="$(OutDir)$(_AndroidPackage)*-Signed.apk" />
+	</ItemGroup>
 	<AndroidApkSigner Condition=" '$(AndroidUseApkSigner)' == 'true' "
 		ApkSignerJar="$(ApkSignerJar)"
-		ApkToSign="$(ApkFileSigned)"
+		ApkToSign="%(ApkAbiFilesSigned.FullPath)"
 		KeyStore="$(_ApkKeyStore)"
 		KeyAlias="$(_ApkKeyAlias)"
 		KeyPass="$(_ApkKeyPass)"
@@ -2948,7 +2952,7 @@ because xbuild doesn't support framework reference assemblies.
 		ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
 		AdditionalArguments="$(AndroidApkSignerAdditionalArguments)"
 	/>
-	<Message Text="Signed android package '$(ApkFileSigned)'" />
+	<Message Text="Signed android package '%(ApkAbiFilesSigned.Identity)'" />
 	<ItemGroup>
 		<ApkAbiFilesSigned Include="$(ApkFileSigned)" Condition="'$(AndroidUseApkSigner)' != 'true'" />
 		<ApkAbiFilesSigned Condition="'$(AndroidCreatePackagePerAbi)' == 'true' And '$(AndroidUseApkSigner)' != 'true'" Include="$(OutDir)$(_AndroidPackage)*-Signed.apk" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2937,12 +2937,12 @@ because xbuild doesn't support framework reference assemblies.
 		ToolExe="$(ZipalignToolExe)"
 	/>
 	<ItemGroup>
-		<ApkAbiFilesSigned Include="$(ApkFileSigned)" Condition="'$(AndroidUseApkSigner)' == 'true'" />
-		<ApkAbiFilesSigned Condition="'$(AndroidCreatePackagePerAbi)' == 'true' And '$(AndroidUseApkSigner)' == 'true' " Include="$(OutDir)$(_AndroidPackage)*-Signed.apk" />
+		<ApkAbiFilesAligned Include="$(ApkFileSigned)" Condition="'$(AndroidUseApkSigner)' == 'true'" />
+		<ApkAbiFilesAligned Condition="'$(AndroidCreatePackagePerAbi)' == 'true' And '$(AndroidUseApkSigner)' == 'true' " Include="$(OutDir)$(_AndroidPackage)*-Signed.apk" />
 	</ItemGroup>
 	<AndroidApkSigner Condition=" '$(AndroidUseApkSigner)' == 'true' "
 		ApkSignerJar="$(ApkSignerJar)"
-		ApkToSign="%(ApkAbiFilesSigned.FullPath)"
+		ApkToSign="%(ApkAbiFilesAligned.FullPath)"
 		KeyStore="$(_ApkKeyStore)"
 		KeyAlias="$(_ApkKeyAlias)"
 		KeyPass="$(_ApkKeyPass)"
@@ -2952,7 +2952,7 @@ because xbuild doesn't support framework reference assemblies.
 		ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
 		AdditionalArguments="$(AndroidApkSignerAdditionalArguments)"
 	/>
-	<Message Text="Signed android package '%(ApkAbiFilesSigned.Identity)'" />
+	<Message Text="Signed android package '%(ApkAbiFilesAligned.Identity)'" />
 	<ItemGroup>
 		<ApkAbiFilesSigned Include="$(ApkFileSigned)" Condition="'$(AndroidUseApkSigner)' != 'true'" />
 		<ApkAbiFilesSigned Condition="'$(AndroidCreatePackagePerAbi)' == 'true' And '$(AndroidUseApkSigner)' != 'true'" Include="$(OutDir)$(_AndroidPackage)*-Signed.apk" />


### PR DESCRIPTION
Fixes: http://work.devdiv.io/663415
Fixes: https://github.com/xamarin/xamarin-android/issues/2060
Context: https://github.com/xamarin/xamarin-android/pull/2064
Context: https://github.com/xamarin/xamarin-android/commit/41bc8ffa0b8f21c4b41cc33fb629b433cfc5b3fd

Since 41bc8ff, I believe we have had the following problem:
- `$(AndroidUseApkSigner)` is `True`, this is the default now
- `$(AndroidCreatePackagePerAbi)` is `True`
- The per-abi APKs are not signed!

I think this bug surfaced in the 15.7 timeframe.

Looking at the existing code, an `ApkAbiFilesSigned` item group is
computed at a time at which the files may not exist yet: making the
`ApkAbiFilesSigned` item group empty on a first build. We used this
item group to delete existing APK files if they exist, but we also
need it sign them!

We also need to call `<AndroidApkSigner />` against *all* APKs instead
of just the single `$(ApkFileSigned)`.

Building upon @benventive's initial PR, I added a couple changes so we
can merge this:
- Added checks in an existing test to make sure `META-INF/MANIFEST.MF`
  exists in the APK. This was an easy way to determine if the APKs are
  signed.
- A new `ApkAbiFilesSigned` item group was added after deleting the
  existing files. I think it makes a little more sense (reads better)
  to name them `ApkAbiFilesAligned`.