### PR TITLE
Fixed the issue #1931

### DIFF
--- a/src/Mono.Android/Test/Xamarin.Android.Net/HttpClientIntegrationTests.cs
+++ b/src/Mono.Android/Test/Xamarin.Android.Net/HttpClientIntegrationTests.cs
@@ -570,7 +570,7 @@ namespace Xamarin.Android.NetTests {
 			}
 		}
 #endif  // TODO
-        [Test]
+		[Test]
 		public void Send_Transfer_Encoding_Custom ()
 		{
 			bool? failed = null;

--- a/src/Mono.Android/Test/Xamarin.Android.Net/HttpClientIntegrationTests.cs
+++ b/src/Mono.Android/Test/Xamarin.Android.Net/HttpClientIntegrationTests.cs
@@ -468,7 +468,7 @@ namespace Xamarin.Android.NetTests {
 					var request = l.Request;
 
 					try {
-						Assert.AreEqual ("MLK,Android,Phone,1.1.9", request.UserAgent, "#1");
+						Assert.AreEqual ("MLK Android Phone 1.1.9", request.UserAgent, "#1");
 						failed = false;
 					} catch (Exception ex) {
 						failed = true;
@@ -570,7 +570,7 @@ namespace Xamarin.Android.NetTests {
 			}
 		}
 #endif  // TODO
-		[Test]
+        [Test]
 		public void Send_Transfer_Encoding_Custom ()
 		{
 			bool? failed = null;

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -71,6 +71,12 @@ namespace Xamarin.Android.Net
 		const string DEFLATE_ENCODING = "deflate";
 		const string IDENTITY_ENCODING = "identity";
 
+		static readonly IDictionary<string, string> headerSeparators = new Dictionary<string, string>
+		{
+			["Server"] = " ",
+			["User-Agent"] = " "
+		};
+
 		static readonly HashSet <string> known_content_headers = new HashSet <string> (StringComparer.OrdinalIgnoreCase) {
 			"Allow",
 			"Content-Disposition",
@@ -868,13 +874,15 @@ namespace Xamarin.Android.Net
 			httpConnection.SetRequestProperty (data.UseProxyAuthentication ? "Proxy-Authorization" : "Authorization", authorization.Message);
 		}
 
+		static string GetHeaderSeparator(string name) => headerSeparators.TryGetValue(name, out var value) ? value : ",";
+
 		void AddHeaders (HttpURLConnection conn, HttpHeaders headers)
 		{
 			if (headers == null)
 				return;
 
 			foreach (KeyValuePair<string, IEnumerable<string>> header in headers) {
-				conn.SetRequestProperty (header.Key, header.Value != null ? String.Join (",", header.Value) : String.Empty);
+				conn.SetRequestProperty (header.Key, header.Value != null ? String.Join (GetHeaderSeparator(header.Key), header.Value) : String.Empty);
 			}
 		}
 		

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -71,9 +71,8 @@ namespace Xamarin.Android.Net
 		const string DEFLATE_ENCODING = "deflate";
 		const string IDENTITY_ENCODING = "identity";
 
-		static readonly IDictionary<string, string> headerSeparators = new Dictionary<string, string>
-		{
-			["User-Agent"] = " "
+		static readonly IDictionary<string, string> headerSeparators = new Dictionary<string, string> {
+			["User-Agent"] = " ",
 		};
 
 		static readonly HashSet <string> known_content_headers = new HashSet <string> (StringComparer.OrdinalIgnoreCase) {
@@ -873,7 +872,7 @@ namespace Xamarin.Android.Net
 			httpConnection.SetRequestProperty (data.UseProxyAuthentication ? "Proxy-Authorization" : "Authorization", authorization.Message);
 		}
 
-		static string GetHeaderSeparator(string name) => headerSeparators.TryGetValue(name, out var value) ? value : ",";
+		static string GetHeaderSeparator (string name) => headerSeparators.TryGetValue (name, out var value) ? value : ",";
 
 		void AddHeaders (HttpURLConnection conn, HttpHeaders headers)
 		{
@@ -881,7 +880,7 @@ namespace Xamarin.Android.Net
 				return;
 
 			foreach (KeyValuePair<string, IEnumerable<string>> header in headers) {
-				conn.SetRequestProperty (header.Key, header.Value != null ? String.Join (GetHeaderSeparator(header.Key), header.Value) : String.Empty);
+				conn.SetRequestProperty (header.Key, header.Value != null ? String.Join (GetHeaderSeparator (header.Key), header.Value) : String.Empty);
 			}
 		}
 		

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -73,7 +73,6 @@ namespace Xamarin.Android.Net
 
 		static readonly IDictionary<string, string> headerSeparators = new Dictionary<string, string>
 		{
-			["Server"] = " ",
 			["User-Agent"] = " "
 		};
 


### PR DESCRIPTION
HTTP headers `Server` and `User-Agent` must use space symbol as a separator instead of comma as defined in [RFC 7231](https://tools.ietf.org/html/rfc7231). Implemented this requirement similar to what have been done for NSUrlSessionHandler.cs in Xamarin.iOS.

See the issue #1931
