### PR TITLE
[Xamarin.Android.Build.Tasks] shorten $(IntermediateOutputPath) for MAX_PATH

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.DefaultOutputPaths.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.DefaultOutputPaths.targets
@@ -6,8 +6,7 @@
 		<BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>
 	</PropertyGroup>	
 	<PropertyGroup Condition=" $(IntermediateOutputPath) == '' ">
-		<IntermediateOutputPath Condition=" '$(PlatformName)' == 'AnyCPU' ">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
-		<IntermediateOutputPath Condition=" '$(PlatformName)' != 'AnyCPU' ">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
+		<IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(AndroidUseLatestPlatformSdk)' != 'true'">
 		<!-- Only change IntermediateOutputPath on Windows by default to avoid backward compatibility issues -->
@@ -16,7 +15,7 @@
 		<AppendTargetFrameworkToIntermediateOutputPath Condition="'$(AppendTargetFrameworkToIntermediateOutputPath)' == ''">False</AppendTargetFrameworkToIntermediateOutputPath>
 		<!-- We don't change the OutputPath by default to avoid backward compatibility issues -->
 		<AppendTargetFrameworkToOutputPath Condition="'$(AppendTargetFrameworkToOutputPath)' == ''">false</AppendTargetFrameworkToOutputPath>
-		<TargetFrameworkToOutputPath>$(TargetFrameworkIdentifier)$(TargetFrameworkVersion.TrimStart('v').Replace('.', ''))</TargetFrameworkToOutputPath>
+		<TargetFrameworkToOutputPath>$(TargetFrameworkVersion.TrimStart('v').Replace('.', ''))</TargetFrameworkToOutputPath>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(AppendTargetFrameworkToIntermediateOutputPath)' == 'true'">
 		<IntermediateOutputPath Condition="'$(IntermediateOutputPath)' != '' and !HasTrailingSlash('$(IntermediateOutputPath)')">$(IntermediateOutputPath)\</IntermediateOutputPath>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -691,7 +691,7 @@ namespace Xamarin.Android.Tests
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName), false, false)) {
 				proj.TargetFrameworkVersion = b.LatestTargetFrameworkVersion ();
 				if (IsWindows) {
-					intermediateDir = Path.Combine (intermediateDir, proj.TargetFrameworkMoniker);
+					intermediateDir = Path.Combine (intermediateDir, proj.TargetFrameworkAbbreviated);
 				}
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				Assert.IsTrue (File.Exists (Path.Combine (Root, b.ProjectDirectory, intermediateDir,  "android/bin/classes.dex")),

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
@@ -40,6 +40,14 @@ namespace Xamarin.ProjectTools
 
 		public string TargetFrameworkVersion { get; set; }
 
-		public string TargetFrameworkMoniker { get { return "MonoAndroid" + TargetFrameworkVersion.TrimStart ('v').Replace (".", ""); } }
+		/// <summary>
+		/// TargetFrameworkVersion=v8.1 -> 81
+		/// </summary>
+		public string TargetFrameworkAbbreviated => TargetFrameworkVersion?.TrimStart ('v').Replace (".", "");
+
+		/// <summary>
+		/// TargetFrameworkVersion=v8.1 -> MonoAndroid81
+		/// </summary>
+		public string TargetFrameworkMoniker => "MonoAndroid" + TargetFrameworkAbbreviated;
 	}
 }


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/1628
Fixes: http://work.devdiv.io/667203

Customers are reporting MAX_PATH (or PathTooLongException) related
failures when upgrading Visual Studio from 15.7 to 15.8. This appears
to be due to the change of moving `$(IntermediateOutputPath)` from
`obj\Debug\` to `obj\\Debug\MonoAndroid81`.

Note we have two things we can do here to improve this:
- Rename `MonoAndroid81` to just `81`
- Fix the double slash `\\`

There was also the comment of using `$(AndroidApiLevel)`, but it feels
a bit safer to use what we have currently and shorten it. In the long
run, we should revisit the current approach entirely.

It appears during MSBuild evaluation, the `$(PlatformName)` is empty
(and not equal to `AnyCPU`). So we should just drop this extra
directory entirely, since it is causing a double-slash `\\`.

The original goals of PR #1628 were to fix this scenario:
- Build with `MonoAndroid81`
- Build with `MonoAndroid90` or *something else*, something in `obj`
  is completely broken and requires #deletebinobj

We should fix the above scenario properly down the road, and we won't
need an extra `81` folder at all.