### PR TITLE
[build] Add error for spaces in Android NDK path

### DIFF
--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -9,6 +9,10 @@
   <UsingTask AssemblyFile="$(_TopDir)\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.JdkInfo" />
   <UsingTask AssemblyFile="$(_TopDir)\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
   <Target Name="Prepare">
+    <Error
+        Text="The specified `%24(AndroidToolchainDirectory)` '$(AndroidToolchainDirectory)' contains a space. Android NDK commands do not support this. Please create a Configuration.Override.props file that sets the AndroidToolchainDirectory property to a different path."
+        Condition="$(AndroidToolchainDirectory.Contains (' '))"
+    />
     <Exec Command="git submodule update --init --recursive" WorkingDirectory="$(_TopDir)" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\xa-prep-tasks\xa-prep-tasks.csproj" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\download-bundle\download-bundle.csproj" />


### PR DESCRIPTION
Add an error early in the preparation targets to let contributors know that having spaces in the Android NDK path will cause an error later in the build.  For example, before this change, a build run under a user named "Windows User" would hit the following error:

    'C:\Users\Windows' is not recognized as an internal or external
    command, operable program or batch file.

    C:\source\xamarin-android\src\sqlite-xamarin\sqlite-xamarin.targets
    (27,5): error MSB3073: The command "
        "C:\Users\Windows User\android-toolchain\ndk\ndk-build.cmd"

        SQLITE_SOURCE_DIR="C:\source\xamarin-android\external\sqlite"

        APP_ABI="armeabi-v7a x86""
    exited with code 1.

As a follow-up to the related conversation in https://github.com/xamarin/xamarin-android/pull/2075, I tried a few steps to resolve this issue.  Unfortunately, it turns out that the limitation goes beyond the `ndk-build.cmd` batch files.  Even if the build skipped those .cmd files and called `make.exe` directly, it would still fail because android-toolchain\ndk\build\core\build-local.mk and the other related `make` include files *also* assume the NDK path contains no spaces:

    C:\Users\Windows User\android-toolchain\ndk\build\\..\build\core\
    build-local.mk:48: User/android-toolchain/ndk/build//../build/core/
    init.mk: No such file or directory

    C:\Users\Windows User\android-toolchain\ndk\build\\..\build\core\
    build-local.mk:199: /add-application.mk: No such file or directory

    C:\Users\Windows User\android-toolchain\ndk\build\\..\build\core\
    build-local.mk:213: /setup-imports.mk: No such file or directory

    C:\Users\Windows User\android-toolchain\ndk\build\\..\build\core\
    build-local.mk:213: /setup-imports.mk: No such file or directory

    make: *** No rule to make target `/build-all.mk'.  Stop.

In fact, if you try to work around this issue with the .mk files by setting the working directory for `make.exe` to the NDK directory and using a relative rather than absolute path for build-local.mk, then the NDK outputs its own error explaining that spaces in the NDK path are not allowed:

    Android NDK: Your Android application project path contains spaces:
    'C:/Users User/android-toolchain'

    build\core\build-local.mk:158: *** Android NDK: Aborting.    .  Stop.

    Android NDK: The Android NDK build cannot work here. Please move
    your project to a different location.