### PR TITLE
[bcl-tests] fix NUnit test result files for Jenkins

### DIFF
--- a/src/Xamarin.Android.NUnitLite/NUnitLite/Runner/OutputWriters/NUnit2XmlOutputWriter.cs
+++ b/src/Xamarin.Android.NUnitLite/NUnitLite/Runner/OutputWriters/NUnit2XmlOutputWriter.cs
@@ -249,6 +249,9 @@ namespace NUnitLite.Runner
 
             if (properties.ContainsKey(PropertyNames.Category))
             {
+                if (properties[PropertyNames.Category].Count == 0)
+                    return;
+
                 xmlWriter.WriteStartElement("categories");
 
                 foreach (string category in properties[PropertyNames.Category])

--- a/tests/TestRunner.xUnit/NUnitXml.xslt
+++ b/tests/TestRunner.xUnit/NUnitXml.xslt
@@ -128,6 +128,7 @@
           <xsl:value-of select="@time"/>
         </xsl:attribute>
       </xsl:if>
+      <xsl:apply-templates select="traits"/>
       <xsl:if test="reason">
         <reason>
           <message>
@@ -135,7 +136,6 @@
           </message>
         </reason>
       </xsl:if>
-      <xsl:apply-templates select="traits"/>
       <xsl:apply-templates select="failure"/>
     </test-case>
   </xsl:template>


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/job/xamarin-android-pr-builder/3806
Context: https://github.com/mono/NUnitLite/pull/12

Our on-device tests don't appear to be reporting properly in Jenkins:

    INFO: Starting to record.
    INFO: Processing NUnit-2.x (default)
    INFO: [NUnit-2.x (default)] - 16 test report file(s) were found with the pattern 'xamarin-android/TestResult-*.xml' relative to '/Users/builder/jenkins/workspace/xamarin-android-pr-builder' for the testing framework 'NUnit-2.x (default)'.
    WARNING: The file '/Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/TestResult-Xamarin.Android.Bcl_Tests.nunit-Debug.xml' is an invalid file.
    WARNING: At line 7 of file:/Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/TestResult-Xamarin.Android.Bcl_Tests.nunit-Debug.xml:cvc-complex-type.2.4.b: The content of element 'categories' is not complete. One of '{category}' is expected.

Followed by thousands of similar warnings...

Apparently the latest Jenkins plugin for NUnit tests is more strict
about the test result format. We can add the patch from @akoeplinger
to prevent these empty `<categories />` from being omitted.

So then we have a similar problem in our XUnit tests...

Context: https://jenkins.mono-project.com/job/xamarin-android-pr-builder/3806
Context: xunit/xunit#1797

Our on-device XUnit tests don't appear to be reporting properly in
Jenkins:

    WARNING: The result file '/Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/TestResult-Xamarin.Android.Bcl_Tests.nunit-Debug.xml' for the metric 'NUnit' is not valid. The result file has been skipped.
    WARNING: The file '/Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/TestResult-Xamarin.Android.Bcl_Tests.xunit-Debug.xml' is an invalid file.
    WARNING: At line 36993 of file:/Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/TestResult-Xamarin.Android.Bcl_Tests.xunit-Debug.xml:cvc-complex-type.2.4.d: Invalid content was found starting with element 'properties'. No child element is expected at this point.
    WARNING: At line 37006 of file:/Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/TestResult-Xamarin.Android.Bcl_Tests.xunit-Debug.xml:cvc-complex-type.2.4.d: Invalid content was found starting with element 'properties'. No child element is expected at this point.

@akoeplinger also has a patch for the XLST transforms in XUnit.

Hopefully this fixes it!