### PR TITLE
Revert "[Xamarin.Android.Build.Tasks] more fixes for parallel builds (#2063)"

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -243,16 +243,10 @@ namespace Xamarin.Android.Tools {
 				files.Add (outfile);
 				var dt = File.Exists (outfile) ? File.GetLastWriteTimeUtc (outfile) : DateTime.MinValue;
 				if (forceUpdate || entry.ModificationTime > dt) {
-					var temp = Path.GetTempFileName ();
 					try {
-						using (var stream = File.Create (temp)) {
-							entry.Extract (stream);
-						}
-						MonoAndroidHelper.CopyIfChanged (temp, outfile);
+						entry.Extract (destination, fullName, FileMode.Create);
 					} catch (PathTooLongException) {
 						throw new PathTooLongException ($"Could not extract \"{fullName}\" to \"{outfile}\". Path is too long.");
-					} finally {
-						File.Delete (temp);
 					}
 					updated = true;
 				}


### PR DESCRIPTION
This *partially* reverts commit 73f7f47e15495755bfd1da1448cd7d6e305fd71f.

We want the change to the test, because it was failing on MacOS.

However, I noticed a performance regression in
`ResolveLibraryProjectImports`. It went from ~1 sec to ~3 sec for me.

Since we shouldn't make our build times *worse*, let's revert this
change for now. It only *helped* parallel builds on Mac, but did not
fully fix them.