### PR TITLE
[Mono.Android] build and reference non-PCL Java.Interop

### DIFF
--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -8,13 +8,23 @@
   </ItemGroup>
   <Target Name="_BuildJavaInterop"
       BeforeTargets="BeforeResolveReferences"
-      Inputs="$(JavaInteropFullPath)\src\Java.Interop\Java.Interop.csproj"
+      Inputs="$(MSBuildThisFile);$(JavaInteropFullPath)\src\Java.Interop\Java.Interop.csproj"
       Outputs="$(OutputPath)\..\v1.0\Java.Interop.dll">
+    <PropertyGroup>
+      <_GlobalProperties>
+        JavaInteropProfile=Net45;
+        XAInstallPrefix=$(XAInstallPrefix);
+        TargetFrameworkIdentifier=MonoAndroid;
+        TargetFrameworkVersion=v1.0;
+        TargetFrameworkRootPath=$(XAInstallPrefix)xbuild-frameworks;
+      </_GlobalProperties>
+    </PropertyGroup>
     <MSBuild
         Projects="$(JavaInteropFullPath)\src\Java.Interop\Java.Interop.csproj"
+        Properties="$(_GlobalProperties)"
     />
     <ItemGroup>
-      <Assembly Include="$(JavaInteropFullPath)\bin\$(Configuration)\*.dll*" />
+      <Assembly Include="$(JavaInteropFullPath)\bin\$(Configuration)Net45\*.dll*" />
     </ItemGroup>
     <Copy
         SourceFiles="@(Assembly)"


### PR DESCRIPTION
Fixes: http://work.devdiv.io/667174
Context: https://github.com/xamarin/java.interop/pull/360

Building `Java.Interop` in a similar fashion as `Mono.Android.dll`:

    <PropertyGroup>
        <NoStdLib>true</NoStdLib>
        <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
        <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
        <TargetFrameworkRootPath>$(XAInstallPrefix)xbuild-framework</TargetFrameworkRootPath>
    </PropertyGroup>
    <ItemGroup>
        <Reference Include="mscorlib">
            <HintPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\mscorlib.dll</HintPath>
            <Private>False</Private>
        </Reference>
        <Reference Include="System">
            <HintPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\System.dll</HintPath>
            <Private>False</Private>
        </Reference>
        <Reference Include="System.Core">
            <HintPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\System.Core.dll</HintPath>
            <Private>False</Private>
        </Reference>
    </ItemGroup>

Decreases the assemblies referenced in a "Hello World" Xamarin.Android
project dramatically:

    Adding assembly reference for Java.Interop, Version=0.1.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065, recursively...
        Adding assembly reference for System.Runtime, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.ComponentModel.Composition, Version=2.0.5.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, recursively...
        Adding assembly reference for System.Diagnostics.Debug, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Threading, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Collections, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Collections.Concurrent, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Reflection, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Linq.Expressions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Reflection.Primitives, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Dynamic.Runtime, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.ObjectModel, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Linq, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Runtime.InteropServices, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Runtime.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Reflection.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
    Adding assembly reference for Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065, recursively...

Becomes:

    Adding assembly reference for Java.Interop, Version=0.1.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065, recursively...
    Adding assembly reference for Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065, recursively...

And the savings in build times for "Hello World", this is the
`Rebuild` target:
- `Debug` + PCL - 8.424s
- `Release` + PCL - 13.651s
- `Debug` + *not* PCL - 4.258s
- `Release` + *not* PCL - 9.487s

*NOTE: this was a master/Debug build of Xamarin.Android*

The `Java.Interop.dll` in
`lib\xamarin.android\xbuild\Xamarin\Android\` remains unchanged, as
referenced by `Xamarin.Android.Build.Tasks`.

The modified `Java.Interop.dll` in
`lib\xamarin.android\xbuild-frameworks\MonoAndroid\v1.0\` will look
something like:

```csharp
// bin\Debug\lib\xamarin.android\xbuild-frameworks\MonoAndroid\v1.0\Java.Interop.dll
// Java.Interop, Version=0.1.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065

[assembly: TargetFramework("MonoAndroid,Version=v1.0")]
```

Changes:
- `$(MSBuildThisFile)` should be an input of `_BuildJavaInterop`
- Set `$(JavaInteropProfile)` and various other properties so a
  non-PCL version of `Java.Interop.dll` is built
- Make sure to copy `Java.Interop.dll` from the `DebugNet45` directory
- Bump to java.interop/master/659711c

https://github.com/xamarin/java.interop/compare/893562c...659711c