### PR TITLE
[build] Explicitly create `bin/Build$(Configuration)`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,8 @@ prepare-external:
 
 prepare-deps: prepare-external
 	./build-tools/scripts/generate-os-info Configuration.OperatingSystem.props
+	$(foreach conf, $(CONFIGURATIONS), \
+		mkdir -p bin/Build$(conf) ; )
 	$(call MSBUILD_BINLOG,prepare-deps) build-tools/dependencies/dependencies.csproj
 	$(call MSBUILD_BINLOG,prepare-bundle) build-tools/download-bundle/download-bundle.csproj
 


### PR DESCRIPTION
[The build][0] is [broken][1]!

	msbuild /p:Configuration=Debug /p:AutoProvision=True /p:AutoProvisionUsesSudo=True /p:IgnoreMaxMonoVersion=False /v:diag /v:normal /binaryLogger:"…/xamarin-android//bin/BuildDebug/msbuild-`date +%Y%m%dT%H%M%S`-prepare-deps.binlog" build-tools/dependencies/dependencies.csproj
	Microsoft (R) Build Engine version 15.3.0.0 (d15.3/e5db6a9 Wed May 10 05:29:34 EDT 2017)
	Copyright (C) Microsoft Corporation. All rights reserved.

	/Library/Frameworks/Mono.framework/Versions/5.2.0/lib/mono/msbuild/15.0/bin/MSBuild.dll /binaryLogger:…/xamarin-android/bin/BuildDebug/msbuild-20180824T102507-prepare-deps.binlog /p:Configuration=Debug /p:AutoProvision=True /p:AutoProvisionUsesSudo=True /p:IgnoreMaxMonoVersion=False /v:diag /v:normal build-tools/dependencies/dependencies.csproj
	MSBUILD : Logger error MSB4104: Failed to write to log file "…/xamarin-android/bin/BuildDebug/msbuild-20180824T102507-prepare-deps.binlog". Could not find a part of the path "…/xamarin-android/bin/BuildDebug/msbuild-20180824T102507-prepare-deps.binlog".
	System.IO.DirectoryNotFoundException: Could not find a part of the path "…/xamarin-android/bin/BuildDebug/msbuild-20180824T102507-prepare-deps.binlog".
	...

What's curious is that the commit which "broke" the
xamarin-android:master build -- commit d373e31 -- has *nothing* which
could possibly impact this part of the build, so we've been
scratching our heads over this for days...

Comparing the [failing build][1] against the [last good build][2]
does bring up some "interesting" differences, in particular the
mono and msbuild versions used.

The good build is using Mono 5.14 and MSBuild 15.8:

	Microsoft (R) Build Engine version 15.8.68.658 (xplat-master/9202c914 Fri Jun 22 12:15:07 EDT 2018) for Mono
	...
	Search paths being used for $(MSBuildExtensionsPath) are /Library/Frameworks/Mono.framework/Versions/5.14.0/lib/mono/xbuild;/Library/Frameworks/Mono.framework/External/xbuild/

The bad build is using Mono 5.2 (?!) and MSBuild 15.3:

	Microsoft (R) Build Engine version 15.3.0.0 (d15.3/e5db6a9 Wed May 10 05:29:34 EDT 2017)
	...
	Search paths being used for $(MSBuildExtensionsPath) are /Library/Frameworks/Mono.framework/Versions/5.2.0/lib/mono/xbuild:/Library/Frameworks/Mono.framework/External/xbuild/

Why does this matter?  Newer `msbuild` versions will create non-
existent directories used in the `/binaryLogger` argument, e.g. this
command always works, when `new-path` does not already exist:

	rmdir new-path
	msbuild /binaryLogger:new-path/output.binlog Project.csproj

Apparently this is *not* the case with Mono 5.2/MSBuild d15.3.

Update the `make prepare-deps` target so that the
`bin/Build$(Configuration)` directories are *always* created before
`$(call MSBUILD_BINLOG)` is executed, ensuring that the
`/binaryLogger` output directory already exists, thus appeasing
mono 5.2/msbuild 15.3.

(*How* that build machine got Mono 5.2 installed and used in the
*first* place is currently unknown.)

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/1139/
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/1139/console
[2]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/1138/