### PR TITLE
Add Missing Activity Attributes #1891

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/ActivityAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/ActivityAttribute.Partial.cs
@@ -46,6 +46,16 @@ namespace Android.App {
 			  self          => self.AlwaysRetainTaskState,
 			  (self, value) => self.AlwaysRetainTaskState = (bool) value
 			}, {
+              "AutoRemoveFromRecents",
+              "autoRemoveFromRecents",
+              self          => self.AutoRemoveFromRecents,
+              (self, value) => self.AutoRemoveFromRecents = (bool) value
+            }, {
+              "Banner",
+              "banner",
+              self          => self.Banner,
+              (self, value) => self.Banner = (string) value
+            }, {
 			  "ClearTaskOnLaunch",
 			  "clearTaskOnLaunch",
 			  self          => self.ClearTaskOnLaunch,
@@ -66,11 +76,21 @@ namespace Android.App {
 			  self          => self.DirectBootAware,
 			  (self, value) => self.DirectBootAware = (bool) value
 			}, {
-			  "Enabled",
+              "DocumentLaunchMode",
+              "documentLaunchMode",
+              self          => self.DocumentLaunchMode,
+              (self, value) => self.DocumentLaunchMode = (DocumentLaunchMode) value
+            }, {
+              "Enabled",
 			  "enabled",
 			  self          => self.Enabled,
 			  (self, value) => self.Enabled = (bool) value
 			}, {
+              "EnableVrMode",
+              "enableVrMode",
+              self          => self.EnableVrMode,
+              (self, value) => self.EnableVrMode = (string) value
+            }, {
 			  "ExcludeFromRecents",
 			  "excludeFromRecents",
 			  self          => self.ExcludeFromRecents,
@@ -126,6 +146,11 @@ namespace Android.App {
 			  self          => self._MaxAspectRatio,
 			  (self, value) => self._MaxAspectRatio = (float) value
 			}, {
+              "MaxRecents",
+              "maxRecents",
+              self          => self.MaxRecents,
+              (self, value) => self.MaxRecents = (int) value
+            }, {
 			  "MultiProcess",
 			  "multiprocess",
 			  self          => self.MultiProcess,
@@ -147,7 +172,12 @@ namespace Android.App {
 			  (self, value) => self._ParentActivity = (string) value,
 			  typeof (Type)
 			}, {
-			  "Permission",
+              "PersistableMode",
+              "persistableMode",
+              self          => self.PersistableMode,
+              (self, value) => self.PersistableMode  = (ActivityPersistableMode) value
+            }, {
+              "Permission",
 			  "permission",
 			  self          => self.Permission,
 			  (self, value) => self.Permission  = (string) value
@@ -157,6 +187,11 @@ namespace Android.App {
 			  self          => self.Process,
 			  (self, value) => self.Process = (string) value
 			}, {
+              "RelinquishTaskIdentity",
+              "relinquishTaskIdentity",
+              self          => self.RelinquishTaskIdentity,
+              (self, value) => self.RelinquishTaskIdentity = (bool) value
+            }, {
 			  "ResizeableActivity",
 			  "resizeableActivity",
 			  self          => self._ResizeableActivity,
@@ -177,6 +212,11 @@ namespace Android.App {
 			  self          => self.ScreenOrientation,
 			  (self, value) => self.ScreenOrientation = (ScreenOrientation) value
 			}, {
+              "SingleUser",
+              "singleUser",
+              self          => self.SingleUser,
+              (self, value) => self.SingleUser = (bool) value
+            }, {
 			  "ShowForAllUsers",
 			  "showForAllUsers",
 			  self          => self._ShowForAllUsers,

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/ActivityAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/ActivityAttribute.Partial.cs
@@ -72,21 +72,10 @@ namespace Android.App {
 			  self          => self.ConfigurationChanges,
 			  (self, value) => self.ConfigurationChanges  = (ConfigChanges) value
 			}, {
-			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
-			  "Description",
-			  "description",
-			  self          => self.Description,
-			  (self, value) => self.Description = (string) value
-			}, {
 			  "DirectBootAware",
 			  "directBootAware",
 			  self          => self.DirectBootAware,
 			  (self, value) => self.DirectBootAware = (bool) value
-			}, {
-			  "DocumentLaunchMode",
-			  "documentLaunchMode",
-			  self          => self.DocumentLaunchMode,
-			  (self, value) => self.DocumentLaunchMode = (DocumentLaunchMode) value
 			}, {
 			  "Enabled",
 			  "enabled",
@@ -108,12 +97,6 @@ namespace Android.App {
 			  "exported",
 			  self          => self.Exported,
 			  (self, value) => self.Exported  = (bool) value
-			}, {
-			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
-			  "FinishOnCloseSystemDialogs",
-			  "finishOnCloseSystemDialogs",
-			  self          => self.FinishOnCloseSystemDialogs,
-			  (self, value) => self.FinishOnCloseSystemDialogs  = (bool) value
 			}, {
 			  "FinishOnTaskLaunch",
 			  "finishOnTaskLaunch",
@@ -144,17 +127,6 @@ namespace Android.App {
 			  "launchMode",
 			  self          => self.LaunchMode,
 			  (self, value) => self.LaunchMode  = (LaunchMode) value
-			}, {
-			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
-			  "LockTaskMode",
-			  "lockTaskMode",
-			  self          => self.LockTaskMode,
-			  (self, value) => self.LockTaskMode = (LockTaskMode) value
-			}, {
-			  "Logo",
-			  "logo",
-			  self          => self.Logo,
-			  (self, value) => self.Logo = (string) value
 			}, {
 			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
 			  "LayoutDirection",
@@ -213,12 +185,6 @@ namespace Android.App {
 			  self          => self.Process,
 			  (self, value) => self.Process = (string) value
 			}, {
-			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
-			  "RecreateOnConfigChanges",
-			  "recreateOnConfigChanges",
-			  self          => self.RecreateOnConfigChanges,
-			  (self, value) => self.RecreateOnConfigChanges = (bool) value
-			}, {
 			  "RelinquishTaskIdentity",
 			  "relinquishTaskIdentity",
 			  self          => self.RelinquishTaskIdentity,
@@ -228,17 +194,6 @@ namespace Android.App {
 			  "resizeableActivity",
 			  self          => self._ResizeableActivity,
 			  (self, value) => self._ResizeableActivity = (bool) value
-			}, {
-			  "ResumeWhilePausing",
-			  "resumeWhilePausing",
-			  self          => self.ResumeWhilePausing,
-			  (self, value) => self.ResumeWhilePausing = (bool) value
-			}, {
-			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
-			  "RotationAnimation",
-			  "rotationAnimation",
-			  self          => self.RotationAnimation,
-			  (self, value) => self.RotationAnimation = (string) value
 			}, {
 			  "RoundIcon",
 			  "roundIcon",
@@ -255,21 +210,10 @@ namespace Android.App {
 			  self          => self.ScreenOrientation,
 			  (self, value) => self.ScreenOrientation = (ScreenOrientation) value
 			}, {
-			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
-			  "SingleUser",
-			  "singleUser",
-			  self          => self.SingleUser,
-			  (self, value) => self.SingleUser = (bool) value
-			}, {
 			  "ShowForAllUsers",
 			  "showForAllUsers",
 			  self          => self._ShowForAllUsers,
 			  (self, value) => self._ShowForAllUsers = (bool) value
-			}, {
-			  "ShowOnLockScreen",
-			  "showOnLockScreen",
-			  self          => self.ShowOnLockScreen,
-			  (self, value) => self.ShowOnLockScreen = (bool) value
 			}, {
 			  "StateNotNeeded",
 			  "stateNotNeeded",
@@ -290,12 +234,6 @@ namespace Android.App {
 			  "uiOptions",
 			  self          => self._UiOptions,
 			  (self, value) => self._UiOptions = (UiOptions) value
-			}, {
-			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
-			  "VisibleToInstantApps",
-			  "visibleToInstantApps",
-			  self          => self.VisibleToInstantApps,
-			  (self, value) => self.VisibleToInstantApps = (bool) value
 			}, {
 			  "WindowSoftInputMode",
 			  "windowSoftInputMode",

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/ActivityAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/ActivityAttribute.Partial.cs
@@ -47,16 +47,16 @@ namespace Android.App {
 			  self          => self.AlwaysRetainTaskState,
 			  (self, value) => self.AlwaysRetainTaskState = (bool) value
 			}, {
-              "AutoRemoveFromRecents",
-              "autoRemoveFromRecents",
-              self          => self.AutoRemoveFromRecents,
-              (self, value) => self.AutoRemoveFromRecents = (bool) value
-            }, {
-              "Banner",
-              "banner",
-              self          => self.Banner,
-              (self, value) => self.Banner = (string) value
-            }, {
+			  "AutoRemoveFromRecents",
+			  "autoRemoveFromRecents",
+			  self          => self.AutoRemoveFromRecents,
+			  (self, value) => self.AutoRemoveFromRecents = (bool) value
+			}, {
+			  "Banner",
+			  "banner",
+			  self          => self.Banner,
+			  (self, value) => self.Banner = (string) value
+			}, {
 			  "ClearTaskOnLaunch",
 			  "clearTaskOnLaunch",
 			  self          => self.ClearTaskOnLaunch,
@@ -72,31 +72,33 @@ namespace Android.App {
 			  self          => self.ConfigurationChanges,
 			  (self, value) => self.ConfigurationChanges  = (ConfigChanges) value
 			}, {
-              "Description",
-              "description",
-              self          => self.Description,
-              (self, value) => self.Description = (string) value
-            }, {
-              "DirectBootAware",
+			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
+			  "Description",
+			  "description",
+			  self          => self.Description,
+			  (self, value) => self.Description = (string) value
+			}, {
+			  "DirectBootAware",
 			  "directBootAware",
 			  self          => self.DirectBootAware,
 			  (self, value) => self.DirectBootAware = (bool) value
 			}, {
-              "DocumentLaunchMode",
-              "documentLaunchMode",
-              self          => self.DocumentLaunchMode,
-              (self, value) => self.DocumentLaunchMode = (DocumentLaunchMode) value
-            }, {
-              "Enabled",
+			  "DocumentLaunchMode",
+			  "documentLaunchMode",
+			  self          => self.DocumentLaunchMode,
+			  (self, value) => self.DocumentLaunchMode = (DocumentLaunchMode) value
+			}, {
+			  "Enabled",
 			  "enabled",
 			  self          => self.Enabled,
 			  (self, value) => self.Enabled = (bool) value
 			}, {
-              "EnableVrMode",
-              "enableVrMode",
-              self          => self.EnableVrMode,
-              (self, value) => self.EnableVrMode = (string) value
-            }, {
+			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
+			  "EnableVrMode",
+			  "enableVrMode",
+			  self          => self.EnableVrMode,
+			  (self, value) => self.EnableVrMode = (string) value
+			}, {
 			  "ExcludeFromRecents",
 			  "excludeFromRecents",
 			  self          => self.ExcludeFromRecents,
@@ -107,12 +109,13 @@ namespace Android.App {
 			  self          => self.Exported,
 			  (self, value) => self.Exported  = (bool) value
 			}, {
-              "FinishOnCloseSystemDialogs",
-              "finishOnCloseSystemDialogs",
-              self          => self.FinishOnCloseSystemDialogs,
-              (self, value) => self.FinishOnCloseSystemDialogs  = (bool) value
-            }, {
-              "FinishOnTaskLaunch",
+			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
+			  "FinishOnCloseSystemDialogs",
+			  "finishOnCloseSystemDialogs",
+			  self          => self.FinishOnCloseSystemDialogs,
+			  (self, value) => self.FinishOnCloseSystemDialogs  = (bool) value
+			}, {
+			  "FinishOnTaskLaunch",
 			  "finishOnTaskLaunch",
 			  self          => self.FinishOnTaskLaunch,
 			  (self, value) => self.FinishOnTaskLaunch  = (bool) value
@@ -142,17 +145,19 @@ namespace Android.App {
 			  self          => self.LaunchMode,
 			  (self, value) => self.LaunchMode  = (LaunchMode) value
 			}, {
-              "LockTaskMode",
-              "lockTaskMode",
-              self          => self.LockTaskMode,
-              (self, value) => self.LockTaskMode = (LockTaskMode) value
-            }, {
-              "Logo",
-              "logo",
-              self          => self.Logo,
-              (self, value) => self.Logo = (string) value
-            }, {
-              "LayoutDirection",
+			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
+			  "LockTaskMode",
+			  "lockTaskMode",
+			  self          => self.LockTaskMode,
+			  (self, value) => self.LockTaskMode = (LockTaskMode) value
+			}, {
+			  "Logo",
+			  "logo",
+			  self          => self.Logo,
+			  (self, value) => self.Logo = (string) value
+			}, {
+			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
+			  "LayoutDirection",
 			  "layoutDirection",
 			  self          => self._LayoutDirection,
 			  (self, value) => self._LayoutDirection  = (LayoutDirection) value
@@ -167,11 +172,11 @@ namespace Android.App {
 			  self          => self._MaxAspectRatio,
 			  (self, value) => self._MaxAspectRatio = (float) value
 			}, {
-              "MaxRecents",
-              "maxRecents",
-              self          => self.MaxRecents,
-              (self, value) => self.MaxRecents = (int) value
-            }, {
+			  "MaxRecents",
+			  "maxRecents",
+			  self          => self.MaxRecents,
+			  (self, value) => self.MaxRecents = (int) value
+			}, {
 			  "MultiProcess",
 			  "multiprocess",
 			  self          => self.MultiProcess,
@@ -193,12 +198,12 @@ namespace Android.App {
 			  (self, value) => self._ParentActivity = (string) value,
 			  typeof (Type)
 			}, {
-              "PersistableMode",
-              "persistableMode",
-              self          => self.PersistableMode,
-              (self, value) => self.PersistableMode  = (ActivityPersistableMode) value
-            }, {
-              "Permission",
+			  "PersistableMode",
+			  "persistableMode",
+			  self          => self.PersistableMode,
+			  (self, value) => self.PersistableMode  = (ActivityPersistableMode) value
+			}, {
+			  "Permission",
 			  "permission",
 			  self          => self.Permission,
 			  (self, value) => self.Permission  = (string) value
@@ -208,32 +213,34 @@ namespace Android.App {
 			  self          => self.Process,
 			  (self, value) => self.Process = (string) value
 			}, {
-              "RecreateOnConfigChanges",
-              "recreateOnConfigChanges",
-              self          => self.RecreateOnConfigChanges,
-              (self, value) => self.RecreateOnConfigChanges = (bool) value
-            }, {
-              "RelinquishTaskIdentity",
-              "relinquishTaskIdentity",
-              self          => self.RelinquishTaskIdentity,
-              (self, value) => self.RelinquishTaskIdentity = (bool) value
-            }, {
+			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
+			  "RecreateOnConfigChanges",
+			  "recreateOnConfigChanges",
+			  self          => self.RecreateOnConfigChanges,
+			  (self, value) => self.RecreateOnConfigChanges = (bool) value
+			}, {
+			  "RelinquishTaskIdentity",
+			  "relinquishTaskIdentity",
+			  self          => self.RelinquishTaskIdentity,
+			  (self, value) => self.RelinquishTaskIdentity = (bool) value
+			}, {
 			  "ResizeableActivity",
 			  "resizeableActivity",
 			  self          => self._ResizeableActivity,
 			  (self, value) => self._ResizeableActivity = (bool) value
 			}, {
-              "ResumeWhilePausing",
-              "resumeWhilePausing",
-              self          => self.ResumeWhilePausing,
-              (self, value) => self.ResumeWhilePausing = (bool) value
-            }, {
-              "RotationAnimation",
-              "rotationAnimation",
-              self          => self.RotationAnimation,
-              (self, value) => self.RotationAnimation = (string) value
-            }, {
-              "RoundIcon",
+			  "ResumeWhilePausing",
+			  "resumeWhilePausing",
+			  self          => self.ResumeWhilePausing,
+			  (self, value) => self.ResumeWhilePausing = (bool) value
+			}, {
+			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
+			  "RotationAnimation",
+			  "rotationAnimation",
+			  self          => self.RotationAnimation,
+			  (self, value) => self.RotationAnimation = (string) value
+			}, {
+			  "RoundIcon",
 			  "roundIcon",
 			  self          => self._RoundIcon,
 			  (self, value) => self._RoundIcon  = (string) value
@@ -248,22 +255,23 @@ namespace Android.App {
 			  self          => self.ScreenOrientation,
 			  (self, value) => self.ScreenOrientation = (ScreenOrientation) value
 			}, {
-              "SingleUser",
-              "singleUser",
-              self          => self.SingleUser,
-              (self, value) => self.SingleUser = (bool) value
-            }, {
+			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
+			  "SingleUser",
+			  "singleUser",
+			  self          => self.SingleUser,
+			  (self, value) => self.SingleUser = (bool) value
+			}, {
 			  "ShowForAllUsers",
 			  "showForAllUsers",
 			  self          => self._ShowForAllUsers,
 			  (self, value) => self._ShowForAllUsers = (bool) value
 			}, {
-              "ShowOnLockScreen",
-              "showOnLockScreen",
-              self          => self.ShowOnLockScreen,
-              (self, value) => self.ShowOnLockScreen = (bool) value
-            }, {
-              "StateNotNeeded",
+			  "ShowOnLockScreen",
+			  "showOnLockScreen",
+			  self          => self.ShowOnLockScreen,
+			  (self, value) => self.ShowOnLockScreen = (bool) value
+			}, {
+			  "StateNotNeeded",
 			  "stateNotNeeded",
 			  self          => self.StateNotNeeded,
 			  (self, value) => self.StateNotNeeded  = (bool) value
@@ -283,12 +291,13 @@ namespace Android.App {
 			  self          => self._UiOptions,
 			  (self, value) => self._UiOptions = (UiOptions) value
 			}, {
-              "VisibleToInstantApps",
-              "visibleToInstantApps",
-              self          => self.VisibleToInstantApps,
-              (self, value) => self.VisibleToInstantApps = (bool) value
-            }, {
-              "WindowSoftInputMode",
+			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
+			  "VisibleToInstantApps",
+			  "visibleToInstantApps",
+			  self          => self.VisibleToInstantApps,
+			  (self, value) => self.VisibleToInstantApps = (bool) value
+			}, {
+			  "WindowSoftInputMode",
 			  "windowSoftInputMode",
 			  self          => self.WindowSoftInputMode,
 			  (self, value) => self.WindowSoftInputMode = (SoftInput) value

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/ActivityAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/ActivityAttribute.Partial.cs
@@ -9,6 +9,7 @@ using Java.Interop.Tools.Cecil;
 
 using Xamarin.Android.Manifest;
 
+using Android.App;
 using Android.Content.PM;
 using Android.Views;
 
@@ -71,7 +72,12 @@ namespace Android.App {
 			  self          => self.ConfigurationChanges,
 			  (self, value) => self.ConfigurationChanges  = (ConfigChanges) value
 			}, {
-			  "DirectBootAware",
+              "Description",
+              "description",
+              self          => self.Description,
+              (self, value) => self.Description = (string) value
+            }, {
+              "DirectBootAware",
 			  "directBootAware",
 			  self          => self.DirectBootAware,
 			  (self, value) => self.DirectBootAware = (bool) value
@@ -101,7 +107,12 @@ namespace Android.App {
 			  self          => self.Exported,
 			  (self, value) => self.Exported  = (bool) value
 			}, {
-			  "FinishOnTaskLaunch",
+              "FinishOnCloseSystemDialogs",
+              "finishOnCloseSystemDialogs",
+              self          => self.FinishOnCloseSystemDialogs,
+              (self, value) => self.FinishOnCloseSystemDialogs  = (bool) value
+            }, {
+              "FinishOnTaskLaunch",
 			  "finishOnTaskLaunch",
 			  self          => self.FinishOnTaskLaunch,
 			  (self, value) => self.FinishOnTaskLaunch  = (bool) value
@@ -131,7 +142,17 @@ namespace Android.App {
 			  self          => self.LaunchMode,
 			  (self, value) => self.LaunchMode  = (LaunchMode) value
 			}, {
-			  "LayoutDirection",
+              "LockTaskMode",
+              "lockTaskMode",
+              self          => self.LockTaskMode,
+              (self, value) => self.LockTaskMode = (LockTaskMode) value
+            }, {
+              "Logo",
+              "logo",
+              self          => self.Logo,
+              (self, value) => self.Logo = (string) value
+            }, {
+              "LayoutDirection",
 			  "layoutDirection",
 			  self          => self._LayoutDirection,
 			  (self, value) => self._LayoutDirection  = (LayoutDirection) value
@@ -187,6 +208,11 @@ namespace Android.App {
 			  self          => self.Process,
 			  (self, value) => self.Process = (string) value
 			}, {
+              "RecreateOnConfigChanges",
+              "recreateOnConfigChanges",
+              self          => self.RecreateOnConfigChanges,
+              (self, value) => self.RecreateOnConfigChanges = (bool) value
+            }, {
               "RelinquishTaskIdentity",
               "relinquishTaskIdentity",
               self          => self.RelinquishTaskIdentity,
@@ -197,7 +223,17 @@ namespace Android.App {
 			  self          => self._ResizeableActivity,
 			  (self, value) => self._ResizeableActivity = (bool) value
 			}, {
-			  "RoundIcon",
+              "ResumeWhilePausing",
+              "resumeWhilePausing",
+              self          => self.ResumeWhilePausing,
+              (self, value) => self.ResumeWhilePausing = (bool) value
+            }, {
+              "RotationAnimation",
+              "rotationAnimation",
+              self          => self.RotationAnimation,
+              (self, value) => self.RotationAnimation = (string) value
+            }, {
+              "RoundIcon",
 			  "roundIcon",
 			  self          => self._RoundIcon,
 			  (self, value) => self._RoundIcon  = (string) value
@@ -222,7 +258,12 @@ namespace Android.App {
 			  self          => self._ShowForAllUsers,
 			  (self, value) => self._ShowForAllUsers = (bool) value
 			}, {
-			  "StateNotNeeded",
+              "ShowOnLockScreen",
+              "showOnLockScreen",
+              self          => self.ShowOnLockScreen,
+              (self, value) => self.ShowOnLockScreen = (bool) value
+            }, {
+              "StateNotNeeded",
 			  "stateNotNeeded",
 			  self          => self.StateNotNeeded,
 			  (self, value) => self.StateNotNeeded  = (bool) value
@@ -242,7 +283,12 @@ namespace Android.App {
 			  self          => self._UiOptions,
 			  (self, value) => self._UiOptions = (UiOptions) value
 			}, {
-			  "WindowSoftInputMode",
+              "VisibleToInstantApps",
+              "visibleToInstantApps",
+              self          => self.VisibleToInstantApps,
+              (self, value) => self.VisibleToInstantApps = (bool) value
+            }, {
+              "WindowSoftInputMode",
 			  "windowSoftInputMode",
 			  self          => self.WindowSoftInputMode,
 			  (self, value) => self.WindowSoftInputMode = (SoftInput) value

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/ActivityAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/ActivityAttribute.Partial.cs
@@ -72,10 +72,21 @@ namespace Android.App {
 			  self          => self.ConfigurationChanges,
 			  (self, value) => self.ConfigurationChanges  = (ConfigChanges) value
 			}, {
+			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
+			  "Description",
+			  "description",
+			  self          => self.Description,
+			  (self, value) => self.Description = (string) value
+			}, {
 			  "DirectBootAware",
 			  "directBootAware",
 			  self          => self.DirectBootAware,
 			  (self, value) => self.DirectBootAware = (bool) value
+			}, {
+			  "DocumentLaunchMode",
+			  "documentLaunchMode",
+			  self          => self.DocumentLaunchMode,
+			  (self, value) => self.DocumentLaunchMode = (DocumentLaunchMode) value
 			}, {
 			  "Enabled",
 			  "enabled",
@@ -97,6 +108,12 @@ namespace Android.App {
 			  "exported",
 			  self          => self.Exported,
 			  (self, value) => self.Exported  = (bool) value
+			}, {
+			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
+			  "FinishOnCloseSystemDialogs",
+			  "finishOnCloseSystemDialogs",
+			  self          => self.FinishOnCloseSystemDialogs,
+			  (self, value) => self.FinishOnCloseSystemDialogs  = (bool) value
 			}, {
 			  "FinishOnTaskLaunch",
 			  "finishOnTaskLaunch",
@@ -127,6 +144,17 @@ namespace Android.App {
 			  "launchMode",
 			  self          => self.LaunchMode,
 			  (self, value) => self.LaunchMode  = (LaunchMode) value
+			}, {
+			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
+			  "LockTaskMode",
+			  "lockTaskMode",
+			  self          => self.LockTaskMode,
+			  (self, value) => self.LockTaskMode = (LockTaskMode) value
+			}, {
+			  "Logo",
+			  "logo",
+			  self          => self.Logo,
+			  (self, value) => self.Logo = (string) value
 			}, {
 			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
 			  "LayoutDirection",
@@ -185,6 +213,12 @@ namespace Android.App {
 			  self          => self.Process,
 			  (self, value) => self.Process = (string) value
 			}, {
+			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
+			  "RecreateOnConfigChanges",
+			  "recreateOnConfigChanges",
+			  self          => self.RecreateOnConfigChanges,
+			  (self, value) => self.RecreateOnConfigChanges = (bool) value
+			}, {
 			  "RelinquishTaskIdentity",
 			  "relinquishTaskIdentity",
 			  self          => self.RelinquishTaskIdentity,
@@ -194,6 +228,17 @@ namespace Android.App {
 			  "resizeableActivity",
 			  self          => self._ResizeableActivity,
 			  (self, value) => self._ResizeableActivity = (bool) value
+			}, {
+			  "ResumeWhilePausing",
+			  "resumeWhilePausing",
+			  self          => self.ResumeWhilePausing,
+			  (self, value) => self.ResumeWhilePausing = (bool) value
+			}, {
+			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
+			  "RotationAnimation",
+			  "rotationAnimation",
+			  self          => self.RotationAnimation,
+			  (self, value) => self.RotationAnimation = (string) value
 			}, {
 			  "RoundIcon",
 			  "roundIcon",
@@ -210,10 +255,21 @@ namespace Android.App {
 			  self          => self.ScreenOrientation,
 			  (self, value) => self.ScreenOrientation = (ScreenOrientation) value
 			}, {
+			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
+			  "SingleUser",
+			  "singleUser",
+			  self          => self.SingleUser,
+			  (self, value) => self.SingleUser = (bool) value
+			}, {
 			  "ShowForAllUsers",
 			  "showForAllUsers",
 			  self          => self._ShowForAllUsers,
 			  (self, value) => self._ShowForAllUsers = (bool) value
+			}, {
+			  "ShowOnLockScreen",
+			  "showOnLockScreen",
+			  self          => self.ShowOnLockScreen,
+			  (self, value) => self.ShowOnLockScreen = (bool) value
 			}, {
 			  "StateNotNeeded",
 			  "stateNotNeeded",
@@ -234,6 +290,12 @@ namespace Android.App {
 			  "uiOptions",
 			  self          => self._UiOptions,
 			  (self, value) => self._UiOptions = (UiOptions) value
+			}, {
+			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
+			  "VisibleToInstantApps",
+			  "visibleToInstantApps",
+			  self          => self.VisibleToInstantApps,
+			  (self, value) => self.VisibleToInstantApps = (bool) value
 			}, {
 			  "WindowSoftInputMode",
 			  "windowSoftInputMode",

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/ActivityAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/ActivityAttribute.Partial.cs
@@ -9,7 +9,6 @@ using Java.Interop.Tools.Cecil;
 
 using Xamarin.Android.Manifest;
 
-using Android.App;
 using Android.Content.PM;
 using Android.Views;
 
@@ -18,17 +17,33 @@ namespace Android.App {
 	partial class ActivityAttribute {
 
 		bool _AllowEmbedded;
+		bool _AutoRemoveFromRecents;
+		string _Banner;
 		string _ColorMode;
+		DocumentLaunchMode _DocumentLaunchMode;
 		bool _HardwareAccelerated;
-		float _MaxAspectRatio;
-		string _ParentActivity;
-		LayoutDirection _LayoutDirection;
-		UiOptions _UiOptions;
 		bool _Immersive;
+		LayoutDirection _LayoutDirection;
+		string _LockTaskMode;
+		string _Logo;
+		float _MaxAspectRatio;
+		int _MaxRecents;
+		string _ParentActivity;
+		ActivityPersistableMode _PersistableMode;
+		ConfigChanges _RecreateOnConfigChanges;
+		bool _RelinquishTaskIdentity;
 		bool _ResizeableActivity;
-		bool _ShowForAllUsers;
-		bool _SupportsPictureInPicture;
+		bool _ResumeWhilePausing;
+		WindowRotationAnimation _RotationAnimation;
 		string _RoundIcon;
+		bool _ShowForAllUsers;
+		bool _ShowOnLockScreen;
+		bool _ShowWhenLocked;
+		bool _SingleUser;
+		bool _SupportsPictureInPicture;
+		bool _TurnScreenOn;
+		UiOptions _UiOptions;
+		bool _VisibleToInstantApps;
 
 		static ManifestDocumentElement<ActivityAttribute> mapping = new ManifestDocumentElement<ActivityAttribute> ("activity") {
 			{
@@ -49,13 +64,13 @@ namespace Android.App {
 			}, {
 			  "AutoRemoveFromRecents",
 			  "autoRemoveFromRecents",
-			  self          => self.AutoRemoveFromRecents,
-			  (self, value) => self.AutoRemoveFromRecents = (bool) value
+			  self          => self._AutoRemoveFromRecents,
+			  (self, value) => self._AutoRemoveFromRecents = (bool) value
 			}, {
 			  "Banner",
 			  "banner",
-			  self          => self.Banner,
-			  (self, value) => self.Banner = (string) value
+			  self          => self._Banner,
+			  (self, value) => self._Banner = (string) value
 			}, {
 			  "ClearTaskOnLaunch",
 			  "clearTaskOnLaunch",
@@ -85,8 +100,8 @@ namespace Android.App {
 			}, {
 			  "DocumentLaunchMode",
 			  "documentLaunchMode",
-			  self          => self.DocumentLaunchMode,
-			  (self, value) => self.DocumentLaunchMode = (DocumentLaunchMode) value
+			  self          => self._DocumentLaunchMode,
+			  (self, value) => self._DocumentLaunchMode = (DocumentLaunchMode) value
 			}, {
 			  "Enabled",
 			  "enabled",
@@ -146,21 +161,21 @@ namespace Android.App {
 			  (self, value) => self.LaunchMode  = (LaunchMode) value
 			}, {
 			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
-			  "LockTaskMode",
-			  "lockTaskMode",
-			  self          => self.LockTaskMode,
-			  (self, value) => self.LockTaskMode = (LockTaskMode) value
-			}, {
-			  "Logo",
-			  "logo",
-			  self          => self.Logo,
-			  (self, value) => self.Logo = (string) value
-			}, {
-			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
 			  "LayoutDirection",
 			  "layoutDirection",
 			  self          => self._LayoutDirection,
 			  (self, value) => self._LayoutDirection  = (LayoutDirection) value
+			}, {
+			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
+			  "LockTaskMode",
+			  "lockTaskMode",
+			  self          => self._LockTaskMode,
+			  (self, value) => self._LockTaskMode = (string) value
+			}, {
+			  "Logo",
+			  "logo",
+			  self          => self._Logo,
+			  (self, value) => self._Logo = (string) value
 			}, {
 			  "MainLauncher",
 			  null,
@@ -174,8 +189,8 @@ namespace Android.App {
 			}, {
 			  "MaxRecents",
 			  "maxRecents",
-			  self          => self.MaxRecents,
-			  (self, value) => self.MaxRecents = (int) value
+			  self          => self._MaxRecents,
+			  (self, value) => self._MaxRecents = (int) value
 			}, {
 			  "MultiProcess",
 			  "multiprocess",
@@ -198,15 +213,15 @@ namespace Android.App {
 			  (self, value) => self._ParentActivity = (string) value,
 			  typeof (Type)
 			}, {
-			  "PersistableMode",
-			  "persistableMode",
-			  self          => self.PersistableMode,
-			  (self, value) => self.PersistableMode  = (ActivityPersistableMode) value
-			}, {
 			  "Permission",
 			  "permission",
 			  self          => self.Permission,
 			  (self, value) => self.Permission  = (string) value
+			}, {
+			  "PersistableMode",
+			  "persistableMode",
+			  self          => self._PersistableMode,
+			  (self, value) => self._PersistableMode  = (ActivityPersistableMode) value
 			}, {
 			  "Process",
 			  "process",
@@ -216,13 +231,13 @@ namespace Android.App {
 			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
 			  "RecreateOnConfigChanges",
 			  "recreateOnConfigChanges",
-			  self          => self.RecreateOnConfigChanges,
-			  (self, value) => self.RecreateOnConfigChanges = (bool) value
+			  self          => self._RecreateOnConfigChanges,
+			  (self, value) => self._RecreateOnConfigChanges = (ConfigChanges) value
 			}, {
 			  "RelinquishTaskIdentity",
 			  "relinquishTaskIdentity",
-			  self          => self.RelinquishTaskIdentity,
-			  (self, value) => self.RelinquishTaskIdentity = (bool) value
+			  self          => self._RelinquishTaskIdentity,
+			  (self, value) => self._RelinquishTaskIdentity = (bool) value
 			}, {
 			  "ResizeableActivity",
 			  "resizeableActivity",
@@ -231,35 +246,24 @@ namespace Android.App {
 			}, {
 			  "ResumeWhilePausing",
 			  "resumeWhilePausing",
-			  self          => self.ResumeWhilePausing,
-			  (self, value) => self.ResumeWhilePausing = (bool) value
+			  self          => self._ResumeWhilePausing,
+			  (self, value) => self._ResumeWhilePausing = (bool) value
 			}, {
 			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
 			  "RotationAnimation",
 			  "rotationAnimation",
-			  self          => self.RotationAnimation,
-			  (self, value) => self.RotationAnimation = (string) value
+			  self          => self._RotationAnimation,
+			  (self, value) => self._RotationAnimation = (WindowRotationAnimation) value
 			}, {
 			  "RoundIcon",
 			  "roundIcon",
 			  self          => self._RoundIcon,
 			  (self, value) => self._RoundIcon  = (string) value
 			}, {
-			  "SupportsPictureInPicture",
-			  "supportsPictureInPicture",
-			  self          => self._SupportsPictureInPicture,
-			  (self, value) => self._SupportsPictureInPicture = (bool) value
-			}, {
 			  "ScreenOrientation",
 			  "screenOrientation",
 			  self          => self.ScreenOrientation,
 			  (self, value) => self.ScreenOrientation = (ScreenOrientation) value
-			}, {
-			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
-			  "SingleUser",
-			  "singleUser",
-			  self          => self.SingleUser,
-			  (self, value) => self.SingleUser = (bool) value
 			}, {
 			  "ShowForAllUsers",
 			  "showForAllUsers",
@@ -268,13 +272,30 @@ namespace Android.App {
 			}, {
 			  "ShowOnLockScreen",
 			  "showOnLockScreen",
-			  self          => self.ShowOnLockScreen,
-			  (self, value) => self.ShowOnLockScreen = (bool) value
+			  self          => self._ShowOnLockScreen,
+			  (self, value) => self._ShowOnLockScreen = (bool) value
+			}, {
+			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
+			  "ShowWhenLocked",
+			  "showWhenLocked",
+			  self          => self._ShowWhenLocked,
+			  (self, value) => self._ShowWhenLocked = (bool) value
+			}, {
+			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
+			  "SingleUser",
+			  "singleUser",
+			  self          => self._SingleUser,
+			  (self, value) => self._SingleUser = (bool) value
 			}, {
 			  "StateNotNeeded",
 			  "stateNotNeeded",
 			  self          => self.StateNotNeeded,
 			  (self, value) => self.StateNotNeeded  = (bool) value
+			}, {
+			  "SupportsPictureInPicture",
+			  "supportsPictureInPicture",
+			  self          => self._SupportsPictureInPicture,
+			  (self, value) => self._SupportsPictureInPicture = (bool) value
 			}, {
 			  "TaskAffinity",
 			  "taskAffinity",
@@ -286,6 +307,12 @@ namespace Android.App {
 			  self          => self.Theme,
 			  (self, value) => self.Theme = (string) value
 			}, {
+			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
+			  "TurnScreenOn",
+			  "turnScreenOn",
+			  self          => self._TurnScreenOn,
+			  (self, value) => self._TurnScreenOn = (bool) value
+			}, {
 			  "UiOptions",
 			  "uiOptions",
 			  self          => self._UiOptions,
@@ -294,8 +321,8 @@ namespace Android.App {
 			  // TODO: Not currently documented at: https://developer.android.com/guide/topics/manifest/activity-element
 			  "VisibleToInstantApps",
 			  "visibleToInstantApps",
-			  self          => self.VisibleToInstantApps,
-			  (self, value) => self.VisibleToInstantApps = (bool) value
+			  self          => self._VisibleToInstantApps,
+			  (self, value) => self._VisibleToInstantApps = (bool) value
 			}, {
 			  "WindowSoftInputMode",
 			  "windowSoftInputMode",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -682,7 +682,7 @@ class TestActivity : Activity { }"
 			using (ProjectBuilder builder = CreateDllBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
 
-				string manifest = builder.Output.GetIntermediaryAsText ("android\\AndroidManifest.xml");
+				string manifest = builder.Output.GetIntermediaryAsText (Path.Combine ("android", "AndroidManifest.xml"));
 				var doc = XDocument.Parse (manifest);
 				var ns = XNamespace.Get ("http://schemas.android.com/apk/res/android");
 				IEnumerable<XElement> activities = doc.Element ("manifest")?.Element ("application")?.Elements ("activity");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -7,6 +7,7 @@ using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using Xamarin.Tools.Zip;
+using System.Collections.Generic;
 
 namespace Xamarin.Android.Build.Tests
 {
@@ -608,6 +609,86 @@ public class TestActivity2 : FragmentActivity {
 					Assert.IsNotNull (e.Element ("intent-filter"), "TestActivity2 should have an intent-filter");
 					Assert.IsNotNull (e.Element ("intent-filter").Element ("action"), "TestActivity2 should have an intent-filter/action");
 				}
+			}
+		}
+
+		[Test]
+		public void AllActivityAttributeProperties ()
+		{
+			const string expectedOutput = "android:allowEmbedded=\"true\" android:allowTaskReparenting=\"true\" android:alwaysRetainTaskState=\"true\" android:autoRemoveFromRecents=\"true\" android:banner=\"@drawable/icon\" android:clearTaskOnLaunch=\"true\" android:colorMode=\"hdr\" android:configChanges=\"mcc\" android:description=\"@string/app_name\" android:directBootAware=\"true\" android:documentLaunchMode=\"never\" android:enabled=\"true\" android:enableVrMode=\"foo\" android:excludeFromRecents=\"true\" android:exported=\"true\" android:finishOnCloseSystemDialogs=\"true\" android:finishOnTaskLaunch=\"true\" android:hardwareAccelerated=\"true\" android:icon=\"@drawable/icon\" android:immersive=\"true\" android:label=\"TestActivity\" android:launchMode=\"singleTop\" android:lockTaskMode=\"normal\" android:logo=\"@drawable/icon\" android:maxAspectRatio=\"1.2\" android:maxRecents=\"1\" android:multiprocess=\"true\" android:name=\"com.contoso.TestActivity\" android:noHistory=\"true\" android:parentActivityName=\"md52d9cf6333b8e95e8683a477bc589eda5.MainActivity\" android:permission=\"com.contoso.permission.TEST_ACTIVITY\" android:persistableMode=\"persistNever\" android:process=\"com.contoso.process.testactivity_process\" android:recreateOnConfigChanges=\"mcc\" android:relinquishTaskIdentity=\"true\" android:resizeableActivity=\"true\" android:resumeWhilePausing=\"true\" android:rotationAnimation=\"crossfade\" android:roundIcon=\"@drawable/icon\" android:screenOrientation=\"portrait\" android:showForAllUsers=\"true\" android:showOnLockScreen=\"true\" android:showWhenLocked=\"true\" android:singleUser=\"true\" android:stateNotNeeded=\"true\" android:supportsPictureInPicture=\"true\" android:taskAffinity=\"com.contoso\" android:theme=\"@android:style/Theme.Light\" android:turnScreenOn=\"true\" android:uiOptions=\"splitActionBarWhenNarrow\" android:visibleToInstantApps=\"true\" android:windowSoftInputMode=\"stateUnchanged|adjustUnspecified\"";
+
+			var proj = new XamarinAndroidApplicationProject ();
+
+			proj.Sources.Add (new BuildItem.Source ("TestActivity.cs") {
+				TextContent = () => @"using Android.App;
+using Android.Content.PM;
+using Android.Views;
+[Activity (
+	AllowEmbedded              = true,
+	AllowTaskReparenting       = true,
+	AlwaysRetainTaskState      = true,
+	AutoRemoveFromRecents      = true,
+	Banner                     = ""@drawable/icon"",
+	ClearTaskOnLaunch          = true,
+	ColorMode                  = ""hdr"",
+	ConfigurationChanges       = ConfigChanges.Mcc,
+	Description                = ""@string/app_name"",
+	DirectBootAware            = true,
+	DocumentLaunchMode         = DocumentLaunchMode.Never,
+	Enabled                    = true,
+	EnableVrMode               = ""foo"",
+	ExcludeFromRecents         = true,
+	Exported                   = true,
+	FinishOnCloseSystemDialogs = true,
+	FinishOnTaskLaunch         = true,
+	HardwareAccelerated        = true,
+	Icon                       = ""@drawable/icon"",
+	Immersive                  = true,
+	Label                      = ""TestActivity"",
+	LaunchMode                 = LaunchMode.SingleTop,
+	LockTaskMode               = ""normal"",
+	Logo                       = ""@drawable/icon"",
+	MaxAspectRatio             = 1.2F,
+	MaxRecents                 = 1,
+	MultiProcess               = true,
+	Name                       = ""com.contoso.TestActivity"",
+	NoHistory                  = true,
+	ParentActivity             = typeof (UnnamedProject.MainActivity),
+	Permission                 = ""com.contoso.permission.TEST_ACTIVITY"",
+	PersistableMode            = ActivityPersistableMode.Never,
+	Process                    = ""com.contoso.process.testactivity_process"",
+	RecreateOnConfigChanges    = ConfigChanges.Mcc,
+	RelinquishTaskIdentity     = true,
+	ResizeableActivity         = true,
+	ResumeWhilePausing         = true,
+	RotationAnimation          = WindowRotationAnimation.Crossfade,
+	RoundIcon                  = ""@drawable/icon"",
+	ScreenOrientation          = ScreenOrientation.Portrait,
+	ShowForAllUsers            = true,
+	ShowOnLockScreen           = true,
+	ShowWhenLocked             = true,
+	SingleUser                 = true,
+	StateNotNeeded             = true,
+	SupportsPictureInPicture   = true,
+	TaskAffinity               = ""com.contoso"",
+	Theme                      = ""@android:style/Theme.Light"",
+	TurnScreenOn               = true,
+	UiOptions                  = UiOptions.SplitActionBarWhenNarrow,
+	VisibleToInstantApps       = true,
+	WindowSoftInputMode        = Android.Views.SoftInput.StateUnchanged)]
+class TestActivity : Activity { }"
+			});
+
+			using (ProjectBuilder builder = CreateDllBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
+
+				string manifest = builder.Output.GetIntermediaryAsText ("android\\AndroidManifest.xml");
+				var doc = XDocument.Parse (manifest);
+				var ns = XNamespace.Get ("http://schemas.android.com/apk/res/android");
+				IEnumerable<XElement> activities = doc.Element ("manifest")?.Element ("application")?.Elements ("activity");
+				XElement e = activities.FirstOrDefault (x => x.Attribute (ns.GetName ("label"))?.Value == "TestActivity");
+				Assert.IsNotNull (e, "Manifest should contain an activity labeled TestActivity");
+				Assert.AreEqual (expectedOutput, string.Join (" ", e.Attributes ()));
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
@@ -254,7 +254,7 @@ namespace Xamarin.Android.Manifest {
 				case DocumentLaunchMode.Never:           return "never";
 				case DocumentLaunchMode.None:            return "none";
 				default:
-					throw new ArgumentException("Unsupported DocumentLaunchMode value '" + value + "'.", "DocumentLaunchMode");
+					throw new ArgumentException ($"Unsupported DocumentLaunchMode value '{value}'.", "DocumentLaunchMode");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
@@ -185,6 +185,7 @@ namespace Xamarin.Android.Manifest {
 			{ typeof (ConfigChanges),           (value, p, r, v) => ToString ((ConfigChanges) value) },
             { typeof (DocumentLaunchMode),      (value, p, r, v) => ToString ((DocumentLaunchMode) value) },
 			{ typeof (LaunchMode),              (value, p, r, v) => ToString ((LaunchMode) value) },
+            { typeof (LockTaskMode),            (value, p, r, v) => ToString ((LockTaskMode) value) },
 			{ typeof (Protection),              (value, p, r, v) => ToString ((Protection) value) },
 			{ typeof (ScreenOrientation),       (value, p, r, v) => ToString ((ScreenOrientation) value, v) },
 			{ typeof (SoftInput),               (value, p, r, v) => ToString ((SoftInput) value) },
@@ -270,7 +271,19 @@ namespace Xamarin.Android.Manifest {
 			}
 		}
 
-		static string ToString (Protection value)
+        static string ToString (LockTaskMode value)
+        {
+            switch (value)
+            {
+                case LockTaskMode.Locked: return "locked";
+                case LockTaskMode.None: return "none";
+                case LockTaskMode.Pinned: return "pinned";
+                default:
+                    throw new ArgumentException("Unsupported LockTaskMode value '" + value + "'.", "LockTaskMode");
+            }
+        }
+
+        static string ToString (Protection value)
 		{
 			value = value & Protection.MaskBase;
 			switch (value) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
@@ -178,7 +178,7 @@ namespace Xamarin.Android.Manifest {
 		}
 
 		static readonly Dictionary<Type, Func<object, ICustomAttributeProvider, IAssemblyResolver, int, string>> ValueConverters = new Dictionary<Type, Func<object, ICustomAttributeProvider, IAssemblyResolver, int, string>> () {
-			{ typeof (bool),                (value, p, r, v) => ToString ((bool) value) }
+			{ typeof (bool),                (value, p, r, v) => ToString ((bool) value) },
 			{ typeof (int),                 (value, p, r, v) => value.ToString () },
 			{ typeof (string),              (value, p, r, v) => value.ToString () },
 			{ typeof (ActivityPersistableMode),     (value, p, r, v) => ToString ((ActivityPersistableMode) value) },

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
@@ -183,9 +183,7 @@ namespace Xamarin.Android.Manifest {
 			{ typeof (string),              (value, p, r, v) => value.ToString () },
 			{ typeof (ActivityPersistableMode),     (value, p, r, v) => ToString ((ActivityPersistableMode) value) },
 			{ typeof (ConfigChanges),       (value, p, r, v) => ToString ((ConfigChanges) value) },
-			{ typeof (DocumentLaunchMode),  (value, p, r, v) => ToString ((DocumentLaunchMode) value) },
 			{ typeof (LaunchMode),          (value, p, r, v) => ToString ((LaunchMode) value) },
-			{ typeof (LockTaskMode),        (value, p, r, v) => ToString ((LockTaskMode) value) },
 			{ typeof (Protection),          (value, p, r, v) => ToString ((Protection) value) },
 			{ typeof (ScreenOrientation),   (value, p, r, v) => ToString ((ScreenOrientation) value, v) },
 			{ typeof (SoftInput),           (value, p, r, v) => ToString ((SoftInput) value) },
@@ -246,18 +244,6 @@ namespace Xamarin.Android.Manifest {
 			return string.Join ("|", values.ToArray ());
 		}
 
-		static string ToString (DocumentLaunchMode value)
-		{
-			switch (value) {
-				case DocumentLaunchMode.Always:          return "always";
-				case DocumentLaunchMode.IntoExisting:    return "intoExisting";
-				case DocumentLaunchMode.Never:           return "never";
-				case DocumentLaunchMode.None:            return "none";
-				default:
-					throw new ArgumentException ($"Unsupported DocumentLaunchMode value '{value}'.", "DocumentLaunchMode");
-			}
-		}
-
 		static string ToString (LaunchMode value)
 		{
 			switch (value) {
@@ -267,17 +253,6 @@ namespace Xamarin.Android.Manifest {
 				case LaunchMode.SingleTop:        return "singleTop";
 				default:
 					throw new ArgumentException ("Unsupported LaunchMode value '" + value + "'.", "LaunchMode");
-			}
-		}
-
-		static string ToString (LockTaskMode value)
-		{
-			switch (value) {
-				case LockTaskMode.Locked: return "locked";
-				case LockTaskMode.None: return "none";
-				case LockTaskMode.Pinned: return "pinned";
-				default:
-					throw new ArgumentException ($"Unsupported LockTaskMode value '{value}'.", "LockTaskMode");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
@@ -178,22 +178,35 @@ namespace Xamarin.Android.Manifest {
 		}
 
 		static readonly Dictionary<Type, Func<object, ICustomAttributeProvider, IAssemblyResolver, int, string>> ValueConverters = new Dictionary<Type, Func<object, ICustomAttributeProvider, IAssemblyResolver, int, string>> () {
-			{ typeof (bool),                (value, p, r, v) => ToString ((bool) value) },
-			{ typeof (int),                 (value, p, r, v) => value.ToString () },
-			{ typeof (string),              (value, p, r, v) => value.ToString () },
-			{ typeof (ConfigChanges),       (value, p, r, v) => ToString ((ConfigChanges) value) },
-			{ typeof (LaunchMode),          (value, p, r, v) => ToString ((LaunchMode) value) },
-			{ typeof (Protection),          (value, p, r, v) => ToString ((Protection) value) },
-			{ typeof (ScreenOrientation),   (value, p, r, v) => ToString ((ScreenOrientation) value, v) },
-			{ typeof (SoftInput),           (value, p, r, v) => ToString ((SoftInput) value) },
-			{ typeof (UiOptions),           (value, p, r, v) => ToString ((UiOptions) value) },
-			{ typeof (Type),                (value, p, r, v) => ToString (value.ToString (), p, r) },
+			{ typeof (bool),                    (value, p, r, v) => ToString ((bool) value) },
+			{ typeof (int),                     (value, p, r, v) => value.ToString () },
+			{ typeof (string),                  (value, p, r, v) => value.ToString () },
+            { typeof (ActivityPersistableMode), (value, p, r, v) => ToString ((ActivityPersistableMode) value) },
+			{ typeof (ConfigChanges),           (value, p, r, v) => ToString ((ConfigChanges) value) },
+            { typeof (DocumentLaunchMode),      (value, p, r, v) => ToString ((DocumentLaunchMode) value) },
+			{ typeof (LaunchMode),              (value, p, r, v) => ToString ((LaunchMode) value) },
+			{ typeof (Protection),              (value, p, r, v) => ToString ((Protection) value) },
+			{ typeof (ScreenOrientation),       (value, p, r, v) => ToString ((ScreenOrientation) value, v) },
+			{ typeof (SoftInput),               (value, p, r, v) => ToString ((SoftInput) value) },
+			{ typeof (UiOptions),               (value, p, r, v) => ToString ((UiOptions) value) },
+			{ typeof (Type),                    (value, p, r, v) => ToString (value.ToString (), p, r) },
 		};
 
 		static string ToString (bool value)
 		{
 			return value ? "true" : "false";
 		}
+
+        static string ToString (ActivityPersistableMode value)
+        {
+            switch (value) {
+                case ActivityPersistableMode.AcrossReboots:   return "persistAcrossReboots";
+                case ActivityPersistableMode.Never:           return "persistNever";
+                case ActivityPersistableMode.RootOnly:        return "persistRootOnly";
+                default:
+                    throw new ArgumentException("Unsupported ActivityPersistableMode value '" + value + "'.", "ActivityPersistableMode");
+            }
+        }
 
 		static string ToString (ConfigChanges value)
 		{
@@ -232,7 +245,20 @@ namespace Xamarin.Android.Manifest {
 			return string.Join ("|", values.ToArray ());
 		}
 
-		static string ToString (LaunchMode value)
+        static string ToString(DocumentLaunchMode value)
+        {
+            switch (value)
+            {
+                case DocumentLaunchMode.Always:          return "always";
+                case DocumentLaunchMode.IntoExisting:    return "intoExisting";
+                case DocumentLaunchMode.Never:           return "never";
+                case DocumentLaunchMode.None:            return "none";
+                default:
+                    throw new ArgumentException("Unsupported DocumentLaunchMode value '" + value + "'.", "DocumentLaunchMode");
+            }
+        }
+
+        static string ToString (LaunchMode value)
 		{
 			switch (value) {
 				case LaunchMode.Multiple:         return "standard";

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
@@ -178,19 +178,19 @@ namespace Xamarin.Android.Manifest {
 		}
 
 		static readonly Dictionary<Type, Func<object, ICustomAttributeProvider, IAssemblyResolver, int, string>> ValueConverters = new Dictionary<Type, Func<object, ICustomAttributeProvider, IAssemblyResolver, int, string>> () {
-			{ typeof (bool),                    (value, p, r, v) => ToString ((bool) value) },
-			{ typeof (int),                     (value, p, r, v) => value.ToString () },
-			{ typeof (string),                  (value, p, r, v) => value.ToString () },
-            { typeof (ActivityPersistableMode), (value, p, r, v) => ToString ((ActivityPersistableMode) value) },
-			{ typeof (ConfigChanges),           (value, p, r, v) => ToString ((ConfigChanges) value) },
-            { typeof (DocumentLaunchMode),      (value, p, r, v) => ToString ((DocumentLaunchMode) value) },
-			{ typeof (LaunchMode),              (value, p, r, v) => ToString ((LaunchMode) value) },
-            { typeof (LockTaskMode),            (value, p, r, v) => ToString ((LockTaskMode) value) },
-			{ typeof (Protection),              (value, p, r, v) => ToString ((Protection) value) },
-			{ typeof (ScreenOrientation),       (value, p, r, v) => ToString ((ScreenOrientation) value, v) },
-			{ typeof (SoftInput),               (value, p, r, v) => ToString ((SoftInput) value) },
-			{ typeof (UiOptions),               (value, p, r, v) => ToString ((UiOptions) value) },
-			{ typeof (Type),                    (value, p, r, v) => ToString (value.ToString (), p, r) },
+			{ typeof (bool),                (value, p, r, v) => ToString ((bool) value) }
+			{ typeof (int),                 (value, p, r, v) => value.ToString () },
+			{ typeof (string),              (value, p, r, v) => value.ToString () },
+			{ typeof (ActivityPersistableMode),     (value, p, r, v) => ToString ((ActivityPersistableMode) value) },
+			{ typeof (ConfigChanges),       (value, p, r, v) => ToString ((ConfigChanges) value) },
+			{ typeof (DocumentLaunchMode),  (value, p, r, v) => ToString ((DocumentLaunchMode) value) },
+			{ typeof (LaunchMode),          (value, p, r, v) => ToString ((LaunchMode) value) },
+			{ typeof (LockTaskMode),        (value, p, r, v) => ToString ((LockTaskMode) value) },
+			{ typeof (Protection),          (value, p, r, v) => ToString ((Protection) value) },
+			{ typeof (ScreenOrientation),   (value, p, r, v) => ToString ((ScreenOrientation) value, v) },
+			{ typeof (SoftInput),           (value, p, r, v) => ToString ((SoftInput) value) },
+			{ typeof (UiOptions),           (value, p, r, v) => ToString ((UiOptions) value) },
+			{ typeof (Type),                (value, p, r, v) => ToString (value.ToString (), p, r) },
 		};
 
 		static string ToString (bool value)
@@ -198,16 +198,16 @@ namespace Xamarin.Android.Manifest {
 			return value ? "true" : "false";
 		}
 
-        static string ToString (ActivityPersistableMode value)
-        {
-            switch (value) {
-                case ActivityPersistableMode.AcrossReboots:   return "persistAcrossReboots";
-                case ActivityPersistableMode.Never:           return "persistNever";
-                case ActivityPersistableMode.RootOnly:        return "persistRootOnly";
-                default:
-                    throw new ArgumentException("Unsupported ActivityPersistableMode value '" + value + "'.", "ActivityPersistableMode");
-            }
-        }
+		static string ToString (ActivityPersistableMode value)
+		{
+			switch (value) {
+				case ActivityPersistableMode.AcrossReboots:   return "persistAcrossReboots";
+				case ActivityPersistableMode.Never:           return "persistNever";
+				case ActivityPersistableMode.RootOnly:        return "persistRootOnly";
+				default:
+					throw new ArgumentException ($"Unsupported ActivityPersistableMode value '{value}'.", "ActivityPersistableMode");
+			}
+		}
 
 		static string ToString (ConfigChanges value)
 		{
@@ -246,20 +246,19 @@ namespace Xamarin.Android.Manifest {
 			return string.Join ("|", values.ToArray ());
 		}
 
-        static string ToString(DocumentLaunchMode value)
-        {
-            switch (value)
-            {
-                case DocumentLaunchMode.Always:          return "always";
-                case DocumentLaunchMode.IntoExisting:    return "intoExisting";
-                case DocumentLaunchMode.Never:           return "never";
-                case DocumentLaunchMode.None:            return "none";
-                default:
-                    throw new ArgumentException("Unsupported DocumentLaunchMode value '" + value + "'.", "DocumentLaunchMode");
-            }
-        }
+		static string ToString (DocumentLaunchMode value)
+		{
+			switch (value) {
+				case DocumentLaunchMode.Always:          return "always";
+				case DocumentLaunchMode.IntoExisting:    return "intoExisting";
+				case DocumentLaunchMode.Never:           return "never";
+				case DocumentLaunchMode.None:            return "none";
+				default:
+					throw new ArgumentException("Unsupported DocumentLaunchMode value '" + value + "'.", "DocumentLaunchMode");
+			}
+		}
 
-        static string ToString (LaunchMode value)
+		static string ToString (LaunchMode value)
 		{
 			switch (value) {
 				case LaunchMode.Multiple:         return "standard";
@@ -271,19 +270,18 @@ namespace Xamarin.Android.Manifest {
 			}
 		}
 
-        static string ToString (LockTaskMode value)
-        {
-            switch (value)
-            {
-                case LockTaskMode.Locked: return "locked";
-                case LockTaskMode.None: return "none";
-                case LockTaskMode.Pinned: return "pinned";
-                default:
-                    throw new ArgumentException("Unsupported LockTaskMode value '" + value + "'.", "LockTaskMode");
-            }
-        }
+		static string ToString (LockTaskMode value)
+		{
+			switch (value) {
+				case LockTaskMode.Locked: return "locked";
+				case LockTaskMode.None: return "none";
+				case LockTaskMode.Pinned: return "pinned";
+				default:
+					throw new ArgumentException ($"Unsupported LockTaskMode value '{value}'.", "LockTaskMode");
+			}
+		}
 
-        static string ToString (Protection value)
+		static string ToString (Protection value)
 		{
 			value = value & Protection.MaskBase;
 			switch (value) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
@@ -183,7 +183,9 @@ namespace Xamarin.Android.Manifest {
 			{ typeof (string),              (value, p, r, v) => value.ToString () },
 			{ typeof (ActivityPersistableMode),     (value, p, r, v) => ToString ((ActivityPersistableMode) value) },
 			{ typeof (ConfigChanges),       (value, p, r, v) => ToString ((ConfigChanges) value) },
+			{ typeof (DocumentLaunchMode),  (value, p, r, v) => ToString ((DocumentLaunchMode) value) },
 			{ typeof (LaunchMode),          (value, p, r, v) => ToString ((LaunchMode) value) },
+			{ typeof (LockTaskMode),        (value, p, r, v) => ToString ((LockTaskMode) value) },
 			{ typeof (Protection),          (value, p, r, v) => ToString ((Protection) value) },
 			{ typeof (ScreenOrientation),   (value, p, r, v) => ToString ((ScreenOrientation) value, v) },
 			{ typeof (SoftInput),           (value, p, r, v) => ToString ((SoftInput) value) },
@@ -244,6 +246,18 @@ namespace Xamarin.Android.Manifest {
 			return string.Join ("|", values.ToArray ());
 		}
 
+		static string ToString (DocumentLaunchMode value)
+		{
+			switch (value) {
+				case DocumentLaunchMode.Always:          return "always";
+				case DocumentLaunchMode.IntoExisting:    return "intoExisting";
+				case DocumentLaunchMode.Never:           return "never";
+				case DocumentLaunchMode.None:            return "none";
+				default:
+					throw new ArgumentException ($"Unsupported DocumentLaunchMode value '{value}'.", "DocumentLaunchMode");
+			}
+		}
+
 		static string ToString (LaunchMode value)
 		{
 			switch (value) {
@@ -253,6 +267,17 @@ namespace Xamarin.Android.Manifest {
 				case LaunchMode.SingleTop:        return "singleTop";
 				default:
 					throw new ArgumentException ("Unsupported LaunchMode value '" + value + "'.", "LaunchMode");
+			}
+		}
+
+		static string ToString (LockTaskMode value)
+		{
+			switch (value) {
+				case LockTaskMode.Locked: return "locked";
+				case LockTaskMode.None: return "none";
+				case LockTaskMode.Pinned: return "pinned";
+				default:
+					throw new ArgumentException ($"Unsupported LockTaskMode value '{value}'.", "LockTaskMode");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
@@ -180,17 +180,18 @@ namespace Xamarin.Android.Manifest {
 		static readonly Dictionary<Type, Func<object, ICustomAttributeProvider, IAssemblyResolver, int, string>> ValueConverters = new Dictionary<Type, Func<object, ICustomAttributeProvider, IAssemblyResolver, int, string>> () {
 			{ typeof (bool),                (value, p, r, v) => ToString ((bool) value) },
 			{ typeof (int),                 (value, p, r, v) => value.ToString () },
+			{ typeof (float),               (value, p, r, v) => value.ToString () },
 			{ typeof (string),              (value, p, r, v) => value.ToString () },
 			{ typeof (ActivityPersistableMode),     (value, p, r, v) => ToString ((ActivityPersistableMode) value) },
 			{ typeof (ConfigChanges),       (value, p, r, v) => ToString ((ConfigChanges) value) },
 			{ typeof (DocumentLaunchMode),  (value, p, r, v) => ToString ((DocumentLaunchMode) value) },
 			{ typeof (LaunchMode),          (value, p, r, v) => ToString ((LaunchMode) value) },
-			{ typeof (LockTaskMode),        (value, p, r, v) => ToString ((LockTaskMode) value) },
 			{ typeof (Protection),          (value, p, r, v) => ToString ((Protection) value) },
 			{ typeof (ScreenOrientation),   (value, p, r, v) => ToString ((ScreenOrientation) value, v) },
 			{ typeof (SoftInput),           (value, p, r, v) => ToString ((SoftInput) value) },
 			{ typeof (UiOptions),           (value, p, r, v) => ToString ((UiOptions) value) },
 			{ typeof (Type),                (value, p, r, v) => ToString (value.ToString (), p, r) },
+			{ typeof (WindowRotationAnimation),     (value, p, r, v) => ToString ((WindowRotationAnimation) value) },
 		};
 
 		static string ToString (bool value)
@@ -270,17 +271,6 @@ namespace Xamarin.Android.Manifest {
 			}
 		}
 
-		static string ToString (LockTaskMode value)
-		{
-			switch (value) {
-				case LockTaskMode.Locked: return "locked";
-				case LockTaskMode.None: return "none";
-				case LockTaskMode.Pinned: return "pinned";
-				default:
-					throw new ArgumentException ($"Unsupported LockTaskMode value '{value}'.", "LockTaskMode");
-			}
-		}
-
 		static string ToString (Protection value)
 		{
 			value = value & Protection.MaskBase;
@@ -354,6 +344,18 @@ namespace Xamarin.Android.Manifest {
 				case UiOptions.SplitActionBarWhenNarrow:  return "splitActionBarWhenNarrow";
 				default:
 					throw new ArgumentException ("Unsupported UiOptions value '" + value + "'.", "LaunchMode");
+			}
+		}
+
+		static string ToString (WindowRotationAnimation value)
+		{
+			switch (value) {
+				case WindowRotationAnimation.Crossfade: return "crossfade";
+				case WindowRotationAnimation.Jumpcut:   return "jumpcut";
+				case WindowRotationAnimation.Rotate:    return "rotate";
+				case WindowRotationAnimation.Seamless:  return "seamless";
+				default:
+					throw new ArgumentException ($"Unsupported WindowRotationAnimation value '{value}'", "WindowRotationAnimation");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -600,6 +600,7 @@
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Views.LayoutDirection.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.ActivityPersistableMode.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.DocumentLaunchMode.cs" />
+    <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.App.LockTaskMode.cs" />
     <Compile Include="@(_MonoAndroidEnum)">
       <Link>Mono.Android\%(Filename)%(Extension)</Link>
     </Compile>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -598,6 +598,8 @@
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Views.SoftInput.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.Protection.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Views.LayoutDirection.cs" />
+    <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.ActivityPersistableMode.cs" />
+    <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.DocumentLaunchMode.cs" />
     <Compile Include="@(_MonoAndroidEnum)">
       <Link>Mono.Android\%(Filename)%(Extension)</Link>
     </Compile>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -599,8 +599,6 @@
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.Protection.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Views.LayoutDirection.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.ActivityPersistableMode.cs" />
-    <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.DocumentLaunchMode.cs" />
-    <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.App.LockTaskMode.cs" />
     <Compile Include="@(_MonoAndroidEnum)">
       <Link>Mono.Android\%(Filename)%(Extension)</Link>
     </Compile>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -599,6 +599,8 @@
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.Protection.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Views.LayoutDirection.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.ActivityPersistableMode.cs" />
+    <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.DocumentLaunchMode.cs" />
+    <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.App.LockTaskMode.cs" />
     <Compile Include="@(_MonoAndroidEnum)">
       <Link>Mono.Android\%(Filename)%(Extension)</Link>
     </Compile>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -600,7 +600,7 @@
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Views.LayoutDirection.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.ActivityPersistableMode.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.DocumentLaunchMode.cs" />
-    <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.App.LockTaskMode.cs" />
+    <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Views.WindowRotationAnimation.cs" />
     <Compile Include="@(_MonoAndroidEnum)">
       <Link>Mono.Android\%(Filename)%(Extension)</Link>
     </Compile>

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
@@ -7,12 +7,13 @@ namespace Android.App
 {
 
 	[Serializable]
-	[AttributeUsage (AttributeTargets.Class, 
-			AllowMultiple=false, 
-			Inherited=false)]
-	public sealed partial class ActivityAttribute : Attribute, Java.Interop.IJniNameProviderAttribute {
+	[AttributeUsage(AttributeTargets.Class,
+			AllowMultiple = false,
+			Inherited = false)]
+	public sealed partial class ActivityAttribute : Attribute, Java.Interop.IJniNameProviderAttribute
+	{
 
-		public ActivityAttribute ()
+		public ActivityAttribute()
 		{
 		}
 
@@ -23,8 +24,12 @@ namespace Android.App
 #endif
 		public bool                   AllowTaskReparenting    {get; set;}
 		public bool                   AlwaysRetainTaskState   {get; set;}
+#if ANDROID_21
 		public bool                   AutoRemoveFromRecents   {get; set;}
+#endif
+#if ANDROID_20
 		public string                 Banner                  {get; set;}
+#endif
 		public bool                   ClearTaskOnLaunch       {get; set;}
 #if ANDROID_26
 		public string                 ColorMode               {get; set;}
@@ -53,16 +58,22 @@ namespace Android.App
 #if ANDROID_26
 		public float                  MaxAspectRatio          {get; set;}
 #endif
+#if ANDROID_21
 		public int                    MaxRecents              {get; set;}
+#endif
 		public bool                   MultiProcess            {get; set;}
 		public bool                   NoHistory               {get; set;}
 #if ANDROID_16
 		public Type                   ParentActivity          {get; set;}
 #endif
+#if ANDROID_21
 		public ActivityPersistableMode      PersistableMode   {get; set;}
+#endif
 		public string                 Permission              {get; set;}
 		public string                 Process                 {get; set;}
+#if ANDROID_21
 		public bool                   RelinquishTaskIdentity  {get; set;}
+#endif
 #if ANDROID_24
 		public bool                   ResizeableActivity      {get;set;}
 #endif

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
@@ -16,69 +16,77 @@ namespace Android.App
 		{
 		}
 
-		public string                 Name                    {get; set;}
+		public string                    Name                    {get; set;}
 
 #if ANDROID_20
-		public bool                   AllowEmbedded           {get; set;}
+		public bool                      AllowEmbedded           {get; set;}
 #endif
-		public bool                   AllowTaskReparenting    {get; set;}
-		public bool                   AlwaysRetainTaskState   {get; set;}
-		public bool                   ClearTaskOnLaunch       {get; set;}
+		public bool                      AllowTaskReparenting    {get; set;}
+		public bool                      AlwaysRetainTaskState   {get; set;}
+        public bool                      AutoRemoveFromRecents   {get; set;}
+        public string                    Banner                  {get; set;}
+		public bool                      ClearTaskOnLaunch       {get; set;}
 #if ANDROID_26
-		public string                 ColorMode               {get; set;}
+		public string                    ColorMode               {get; set;}
 #endif
-		public ConfigChanges          ConfigurationChanges    {get; set;}
+		public ConfigChanges             ConfigurationChanges    {get; set;}
 #if ANDROID_24
-		public bool                   DirectBootAware         {get; set;}
+		public bool                      DirectBootAware         {get; set;}
 #endif
-		public bool                   Enabled                 {get; set;}
-		public bool                   ExcludeFromRecents      {get; set;}
-		public bool                   Exported                {get; set;}
-		public bool                   FinishOnTaskLaunch      {get; set;}
+		public DocumentLaunchMode        DocumentLaunchMode      {get; set;}
+        public string                    EnableVrMode            {get; set;}
+		public bool                      Enabled                 {get; set;}
+		public bool                      ExcludeFromRecents      {get; set;}
+		public bool                      Exported                {get; set;}
+		public bool                      FinishOnTaskLaunch      {get; set;}
 #if ANDROID_11
-		public bool                   HardwareAccelerated     {get; set;}
+		public bool                      HardwareAccelerated     {get; set;}
 #endif
-		public string                 Icon                    {get; set;}
-		public string                 Label                   {get; set;}
-		public LaunchMode             LaunchMode              {get; set;}
+		public string                    Icon                    {get; set;}
+		public string                    Label                   {get; set;}
+		public LaunchMode                LaunchMode              {get; set;}
 #if ANDROID_17
 		[Obsolete ("There is no //activity/@android:layoutDirection attribute. This was a mistake. " +
 				"Perhaps you wanted ConfigurationChanges=ConfigChanges.LayoutDirection?")]
-		public LayoutDirection        LayoutDirection         {get; set;}
+		public LayoutDirection           LayoutDirection         {get; set;}
 #endif
-		public bool                   MainLauncher            {get; set;}
+		public bool                      MainLauncher            {get; set;}
 #if ANDROID_26
-		public float                  MaxAspectRatio          {get; set;}
+		public float                     MaxAspectRatio          {get; set;}
 #endif
-		public bool                   MultiProcess            {get; set;}
-		public bool                   NoHistory               {get; set;}
+		public int                       MaxRecents              {get; set;}
+		public bool                      MultiProcess            {get; set;}
+		public bool                      NoHistory               {get; set;}
 #if ANDROID_16
-		public Type                   ParentActivity          {get; set;}
+		public Type                      ParentActivity          {get; set;}
 #endif
-		public string                 Permission              {get; set;}
-		public string                 Process                 {get; set;}
+		public ActivityPersistableMode   PersistableMode         {get; set;}
+		public string                    Permission              {get; set;}
+		public string                    Process                 {get; set;}
+		public bool                      RelinquishTaskIdentity  {get; set;}
 #if ANDROID_24
-		public bool                   ResizeableActivity      {get;set;}
+		public bool                      ResizeableActivity      {get;set;}
 #endif
 #if ANDROID_25
-		public string                 RoundIcon               {get; set;}
+		public string                    RoundIcon               {get; set;}
 #endif
 #if ANDROID_23
-		public bool                   ShowForAllUsers         {get; set;}
+		public bool                      ShowForAllUsers         {get; set;}
 #endif
 #if ANDROID_24
-		public bool                   SupportsPictureInPicture {get;set;}
+		public bool                      SupportsPictureInPicture {get;set;}
 #endif
-		public ScreenOrientation      ScreenOrientation       {get; set;}
-		public bool                   StateNotNeeded          {get; set;}
-		public string                 TaskAffinity            {get; set;}
-		public string                 Theme                   {get; set;}
+		public ScreenOrientation         ScreenOrientation       {get; set;}
+		public bool                      SingleUser              {get; set;}
+		public bool                      StateNotNeeded          {get; set;}
+		public string                    TaskAffinity            {get; set;}
+		public string                    Theme                   {get; set;}
 #if ANDROID_14
-		public UiOptions              UiOptions               {get; set;}
+		public UiOptions                 UiOptions               {get; set;}
 #endif
-		public SoftInput              WindowSoftInputMode     {get; set;}
+		public SoftInput                 WindowSoftInputMode     {get; set;}
 #if ANDROID_15 // this is not documented on http://developer.android.com/guide/topics/manifest/activity-element.html but on https://developers.google.com/glass/develop/gdk/immersions
-		public bool                   Immersive               {get; set;}
-#endif
+		public bool                      Immersive               {get; set;}
+#endif      
 	}
 }

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
@@ -30,16 +30,13 @@ namespace Android.App
 		public string                 ColorMode               {get; set;}
 #endif
 		public ConfigChanges          ConfigurationChanges    {get; set;}
-		public string                 Description             {get; set;}
 #if ANDROID_24
 		public bool                   DirectBootAware         {get; set;}
 #endif
-		public DocumentLaunchMode     DocumentLaunchMode      {get; set;}
 		public string                 EnableVrMode            {get; set;}
 		public bool                   Enabled                 {get; set;}
 		public bool                   ExcludeFromRecents      {get; set;}
 		public bool                   Exported                {get; set;}
-		public bool                   FinishOnCloseSystemDialogs    {get; set;}
 		public bool                   FinishOnTaskLaunch      {get; set;}
 #if ANDROID_11
 		public bool                   HardwareAccelerated     {get; set;}
@@ -47,8 +44,6 @@ namespace Android.App
 		public string                 Icon                    {get; set;}
 		public string                 Label                   {get; set;}
 		public LaunchMode             LaunchMode              {get; set;}
-		public LockTaskMode           LockTaskMode            {get; set;}
-		public string                 Logo                    {get; set;}
 #if ANDROID_17
 		[Obsolete ("There is no //activity/@android:layoutDirection attribute. This was a mistake. " +
 				"Perhaps you wanted ConfigurationChanges=ConfigChanges.LayoutDirection?")]
@@ -67,32 +62,26 @@ namespace Android.App
 		public ActivityPersistableMode      PersistableMode   {get; set;}
 		public string                 Permission              {get; set;}
 		public string                 Process                 {get; set;}
-		public bool                   RecreateOnConfigChanges {get; set;} 
 		public bool                   RelinquishTaskIdentity  {get; set;}
 #if ANDROID_24
 		public bool                   ResizeableActivity      {get;set;}
 #endif
-		public bool                   ResumeWhilePausing      {get; set;}
-		public string                 RotationAnimation       {get; set;}
 #if ANDROID_25
 		public string                 RoundIcon               {get; set;}
 #endif
 #if ANDROID_23
 		public bool                   ShowForAllUsers         {get; set;}
 #endif
-		public bool                   ShowOnLockScreen        {get; set;}
 #if ANDROID_24
 		public bool                   SupportsPictureInPicture {get;set;}
 #endif
 		public ScreenOrientation      ScreenOrientation       {get; set;}
-		public bool                   SingleUser              {get; set;}
 		public bool                   StateNotNeeded          {get; set;}
 		public string                 TaskAffinity            {get; set;}
 		public string                 Theme                   {get; set;}
 #if ANDROID_14
 		public UiOptions              UiOptions               {get; set;}
 #endif
-		public bool                   VisibleToInstantApps    {get; set;}
 		public SoftInput              WindowSoftInputMode     {get; set;}
 #if ANDROID_15 // this is not documented on http://developer.android.com/guide/topics/manifest/activity-element.html but on https://developers.google.com/glass/develop/gdk/immersions
 		public bool                   Immersive               {get; set;}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
@@ -32,8 +32,8 @@ namespace Android.App
 		public ConfigChanges          ConfigurationChanges    {get; set;}
 #if ANDROID_24
 		public bool                   DirectBootAware         {get; set;}
-#endif
 		public string                 EnableVrMode            {get; set;}
+#endif
 		public bool                   Enabled                 {get; set;}
 		public bool                   ExcludeFromRecents      {get; set;}
 		public bool                   Exported                {get; set;}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
@@ -70,7 +70,7 @@ namespace Android.App
 		public bool                   RecreateOnConfigChanges {get; set;} 
 		public bool                   RelinquishTaskIdentity  {get; set;}
 #if ANDROID_24
-		public bool                   ResizeableActivity      {get; set;}
+		public bool                   ResizeableActivity      {get;set;}
 #endif
 		public bool                   ResumeWhilePausing      {get; set;}
 		public string                 RotationAnimation       {get; set;}
@@ -82,7 +82,7 @@ namespace Android.App
 #endif
 		public bool                   ShowOnLockScreen        {get; set;}
 #if ANDROID_24
-		public bool                   SupportsPictureInPicture  {get;set;}
+		public bool                   SupportsPictureInPicture {get;set;}
 #endif
 		public ScreenOrientation      ScreenOrientation       {get; set;}
 		public bool                   SingleUser              {get; set;}
@@ -96,6 +96,6 @@ namespace Android.App
 		public SoftInput              WindowSoftInputMode     {get; set;}
 #if ANDROID_15 // this is not documented on http://developer.android.com/guide/topics/manifest/activity-element.html but on https://developers.google.com/glass/develop/gdk/immersions
 		public bool                   Immersive               {get; set;}
-#endif      
+#endif
 	}
 }

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
@@ -16,86 +16,86 @@ namespace Android.App
 		{
 		}
 
-		public string                    Name                        {get; set;}
+		public string                 Name                    {get; set;}
 
 #if ANDROID_20
-		public bool                      AllowEmbedded               {get; set;}
+		public bool                   AllowEmbedded           {get; set;}
 #endif
-		public bool                      AllowTaskReparenting        {get; set;}
-		public bool                      AlwaysRetainTaskState       {get; set;}
-        public bool                      AutoRemoveFromRecents       {get; set;}
-        public string                    Banner                      {get; set;}
-		public bool                      ClearTaskOnLaunch           {get; set;}
+		public bool                   AllowTaskReparenting    {get; set;}
+		public bool                   AlwaysRetainTaskState   {get; set;}
+		public bool                   AutoRemoveFromRecents   {get; set;}
+		public string                 Banner                  {get; set;}
+		public bool                   ClearTaskOnLaunch       {get; set;}
 #if ANDROID_26
-		public string                    ColorMode                   {get; set;}
+		public string                 ColorMode               {get; set;}
 #endif
-		public ConfigChanges             ConfigurationChanges        {get; set;}
-        public string                    Description                 {get; set;}
+		public ConfigChanges          ConfigurationChanges    {get; set;}
+		public string                 Description             {get; set;}
 #if ANDROID_24
-		public bool                      DirectBootAware             {get; set;}
+		public bool                   DirectBootAware         {get; set;}
 #endif
-		public DocumentLaunchMode        DocumentLaunchMode          {get; set;}
-        public string                    EnableVrMode                {get; set;}
-		public bool                      Enabled                     {get; set;}
-		public bool                      ExcludeFromRecents          {get; set;}
-		public bool                      Exported                    {get; set;}
-        public bool                      FinishOnCloseSystemDialogs  {get; set;}
-		public bool                      FinishOnTaskLaunch          {get; set;}
+		public DocumentLaunchMode     DocumentLaunchMode      {get; set;}
+		public string                 EnableVrMode            {get; set;}
+		public bool                   Enabled                 {get; set;}
+		public bool                   ExcludeFromRecents      {get; set;}
+		public bool                   Exported                {get; set;}
+		public bool                   FinishOnCloseSystemDialogs    {get; set;}
+		public bool                   FinishOnTaskLaunch      {get; set;}
 #if ANDROID_11
-		public bool                      HardwareAccelerated         {get; set;}
+		public bool                   HardwareAccelerated     {get; set;}
 #endif
-		public string                    Icon                        {get; set;}
-		public string                    Label                       {get; set;}
-		public LaunchMode                LaunchMode                  {get; set;}
-        public LockTaskMode              LockTaskMode                {get; set;}
-        public string                    Logo                        {get; set;}
+		public string                 Icon                    {get; set;}
+		public string                 Label                   {get; set;}
+		public LaunchMode             LaunchMode              {get; set;}
+		public LockTaskMode           LockTaskMode            {get; set;}
+		public string                 Logo                    {get; set;}
 #if ANDROID_17
 		[Obsolete ("There is no //activity/@android:layoutDirection attribute. This was a mistake. " +
 				"Perhaps you wanted ConfigurationChanges=ConfigChanges.LayoutDirection?")]
-		public LayoutDirection           LayoutDirection             {get; set;}
+		public LayoutDirection        LayoutDirection         {get; set;}
 #endif
-		public bool                      MainLauncher                {get; set;}
+		public bool                   MainLauncher            {get; set;}
 #if ANDROID_26
-		public float                     MaxAspectRatio              {get; set;}
+		public float                  MaxAspectRatio          {get; set;}
 #endif
-		public int                       MaxRecents                  {get; set;}
-		public bool                      MultiProcess                {get; set;}
-		public bool                      NoHistory                   {get; set;}
+		public int                    MaxRecents              {get; set;}
+		public bool                   MultiProcess            {get; set;}
+		public bool                   NoHistory               {get; set;}
 #if ANDROID_16
-		public Type                      ParentActivity              {get; set;}
+		public Type                   ParentActivity          {get; set;}
 #endif
-		public ActivityPersistableMode   PersistableMode             {get; set;}
-		public string                    Permission                  {get; set;}
-		public string                    Process                     {get; set;}
-        public bool                      RecreateOnConfigChanges     {get; set;} 
-		public bool                      RelinquishTaskIdentity      {get; set;}
+		public ActivityPersistableMode      PersistableMode   {get; set;}
+		public string                 Permission              {get; set;}
+		public string                 Process                 {get; set;}
+		public bool                   RecreateOnConfigChanges {get; set;} 
+		public bool                   RelinquishTaskIdentity  {get; set;}
 #if ANDROID_24
-		public bool                      ResizeableActivity          {get; set;}
+		public bool                   ResizeableActivity      {get; set;}
 #endif
-        public bool                      ResumeWhilePausing          {get; set;}
-        public string                    RotationAnimation           {get; set;}
+		public bool                   ResumeWhilePausing      {get; set;}
+		public string                 RotationAnimation       {get; set;}
 #if ANDROID_25
-		public string                    RoundIcon                   {get; set;}
+		public string                 RoundIcon               {get; set;}
 #endif
 #if ANDROID_23
-		public bool                      ShowForAllUsers             {get; set;}
+		public bool                   ShowForAllUsers         {get; set;}
 #endif
-        public bool                      ShowOnLockScreen            {get; set;}
+		public bool                   ShowOnLockScreen        {get; set;}
 #if ANDROID_24
-        public bool                      SupportsPictureInPicture    {get; set;}
+		public bool                   SupportsPictureInPicture  {get;set;}
 #endif
-		public ScreenOrientation         ScreenOrientation           {get; set;}
-		public bool                      SingleUser                  {get; set;}
-		public bool                      StateNotNeeded              {get; set;}
-		public string                    TaskAffinity                {get; set;}
-		public string                    Theme                       {get; set;}
+		public ScreenOrientation      ScreenOrientation       {get; set;}
+		public bool                   SingleUser              {get; set;}
+		public bool                   StateNotNeeded          {get; set;}
+		public string                 TaskAffinity            {get; set;}
+		public string                 Theme                   {get; set;}
 #if ANDROID_14
-		public UiOptions                 UiOptions                   {get; set;}
+		public UiOptions              UiOptions               {get; set;}
 #endif
-        public bool                      VisibleToInstantApps        {get; set;}
-		public SoftInput                 WindowSoftInputMode         {get; set;}
+		public bool                   VisibleToInstantApps    {get; set;}
+		public SoftInput              WindowSoftInputMode     {get; set;}
 #if ANDROID_15 // this is not documented on http://developer.android.com/guide/topics/manifest/activity-element.html but on https://developers.google.com/glass/develop/gdk/immersions
-		public bool                      Immersive                   {get; set;}
+		public bool                   Immersive               {get; set;}
 #endif      
 	}
 }

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
@@ -16,77 +16,86 @@ namespace Android.App
 		{
 		}
 
-		public string                    Name                    {get; set;}
+		public string                    Name                        {get; set;}
 
 #if ANDROID_20
-		public bool                      AllowEmbedded           {get; set;}
+		public bool                      AllowEmbedded               {get; set;}
 #endif
-		public bool                      AllowTaskReparenting    {get; set;}
-		public bool                      AlwaysRetainTaskState   {get; set;}
-        public bool                      AutoRemoveFromRecents   {get; set;}
-        public string                    Banner                  {get; set;}
-		public bool                      ClearTaskOnLaunch       {get; set;}
+		public bool                      AllowTaskReparenting        {get; set;}
+		public bool                      AlwaysRetainTaskState       {get; set;}
+        public bool                      AutoRemoveFromRecents       {get; set;}
+        public string                    Banner                      {get; set;}
+		public bool                      ClearTaskOnLaunch           {get; set;}
 #if ANDROID_26
-		public string                    ColorMode               {get; set;}
+		public string                    ColorMode                   {get; set;}
 #endif
-		public ConfigChanges             ConfigurationChanges    {get; set;}
+		public ConfigChanges             ConfigurationChanges        {get; set;}
+        public string                    Description                 {get; set;}
 #if ANDROID_24
-		public bool                      DirectBootAware         {get; set;}
+		public bool                      DirectBootAware             {get; set;}
 #endif
-		public DocumentLaunchMode        DocumentLaunchMode      {get; set;}
-        public string                    EnableVrMode            {get; set;}
-		public bool                      Enabled                 {get; set;}
-		public bool                      ExcludeFromRecents      {get; set;}
-		public bool                      Exported                {get; set;}
-		public bool                      FinishOnTaskLaunch      {get; set;}
+		public DocumentLaunchMode        DocumentLaunchMode          {get; set;}
+        public string                    EnableVrMode                {get; set;}
+		public bool                      Enabled                     {get; set;}
+		public bool                      ExcludeFromRecents          {get; set;}
+		public bool                      Exported                    {get; set;}
+        public bool                      FinishOnCloseSystemDialogs  {get; set;}
+		public bool                      FinishOnTaskLaunch          {get; set;}
 #if ANDROID_11
-		public bool                      HardwareAccelerated     {get; set;}
+		public bool                      HardwareAccelerated         {get; set;}
 #endif
-		public string                    Icon                    {get; set;}
-		public string                    Label                   {get; set;}
-		public LaunchMode                LaunchMode              {get; set;}
+		public string                    Icon                        {get; set;}
+		public string                    Label                       {get; set;}
+		public LaunchMode                LaunchMode                  {get; set;}
+        public LockTaskMode              LockTaskMode                {get; set;}
+        public string                    Logo                        {get; set;}
 #if ANDROID_17
 		[Obsolete ("There is no //activity/@android:layoutDirection attribute. This was a mistake. " +
 				"Perhaps you wanted ConfigurationChanges=ConfigChanges.LayoutDirection?")]
-		public LayoutDirection           LayoutDirection         {get; set;}
+		public LayoutDirection           LayoutDirection             {get; set;}
 #endif
-		public bool                      MainLauncher            {get; set;}
+		public bool                      MainLauncher                {get; set;}
 #if ANDROID_26
-		public float                     MaxAspectRatio          {get; set;}
+		public float                     MaxAspectRatio              {get; set;}
 #endif
-		public int                       MaxRecents              {get; set;}
-		public bool                      MultiProcess            {get; set;}
-		public bool                      NoHistory               {get; set;}
+		public int                       MaxRecents                  {get; set;}
+		public bool                      MultiProcess                {get; set;}
+		public bool                      NoHistory                   {get; set;}
 #if ANDROID_16
-		public Type                      ParentActivity          {get; set;}
+		public Type                      ParentActivity              {get; set;}
 #endif
-		public ActivityPersistableMode   PersistableMode         {get; set;}
-		public string                    Permission              {get; set;}
-		public string                    Process                 {get; set;}
-		public bool                      RelinquishTaskIdentity  {get; set;}
+		public ActivityPersistableMode   PersistableMode             {get; set;}
+		public string                    Permission                  {get; set;}
+		public string                    Process                     {get; set;}
+        public bool                      RecreateOnConfigChanges     {get; set;} 
+		public bool                      RelinquishTaskIdentity      {get; set;}
 #if ANDROID_24
-		public bool                      ResizeableActivity      {get;set;}
+		public bool                      ResizeableActivity          {get; set;}
 #endif
+        public bool                      ResumeWhilePausing          {get; set;}
+        public string                    RotationAnimation           {get; set;}
 #if ANDROID_25
-		public string                    RoundIcon               {get; set;}
+		public string                    RoundIcon                   {get; set;}
 #endif
 #if ANDROID_23
-		public bool                      ShowForAllUsers         {get; set;}
+		public bool                      ShowForAllUsers             {get; set;}
 #endif
+        public bool                      ShowOnLockScreen            {get; set;}
 #if ANDROID_24
-		public bool                      SupportsPictureInPicture {get;set;}
+        public bool                      SupportsPictureInPicture    {get; set;}
 #endif
-		public ScreenOrientation         ScreenOrientation       {get; set;}
-		public bool                      SingleUser              {get; set;}
-		public bool                      StateNotNeeded          {get; set;}
-		public string                    TaskAffinity            {get; set;}
-		public string                    Theme                   {get; set;}
+		public ScreenOrientation         ScreenOrientation           {get; set;}
+		public bool                      SingleUser                  {get; set;}
+		public bool                      StateNotNeeded              {get; set;}
+		public string                    TaskAffinity                {get; set;}
+		public string                    Theme                       {get; set;}
 #if ANDROID_14
-		public UiOptions                 UiOptions               {get; set;}
+		public UiOptions                 UiOptions                   {get; set;}
 #endif
-		public SoftInput                 WindowSoftInputMode     {get; set;}
+        public bool                      VisibleToInstantApps        {get; set;}
+		public SoftInput                 WindowSoftInputMode         {get; set;}
 #if ANDROID_15 // this is not documented on http://developer.android.com/guide/topics/manifest/activity-element.html but on https://developers.google.com/glass/develop/gdk/immersions
-		public bool                      Immersive               {get; set;}
+		public bool                      Immersive                   {get; set;}
 #endif      
 	}
 }

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
@@ -7,13 +7,12 @@ namespace Android.App
 {
 
 	[Serializable]
-	[AttributeUsage(AttributeTargets.Class,
-			AllowMultiple = false,
-			Inherited = false)]
-	public sealed partial class ActivityAttribute : Attribute, Java.Interop.IJniNameProviderAttribute
-	{
+	[AttributeUsage (AttributeTargets.Class, 
+			AllowMultiple=false, 
+			Inherited=false)]
+	public sealed partial class ActivityAttribute : Attribute, Java.Interop.IJniNameProviderAttribute {
 
-		public ActivityAttribute()
+		public ActivityAttribute ()
 		{
 		}
 
@@ -39,7 +38,10 @@ namespace Android.App
 #if ANDROID_24
 		public bool                   DirectBootAware         {get; set;}
 #endif
+#if ANDROID_21
 		public DocumentLaunchMode     DocumentLaunchMode      {get; set;}
+#endif
+#if ANDROID_24
 		public string                 EnableVrMode            {get; set;}
 #endif
 		public bool                   Enabled                 {get; set;}
@@ -53,8 +55,12 @@ namespace Android.App
 		public string                 Icon                    {get; set;}
 		public string                 Label                   {get; set;}
 		public LaunchMode             LaunchMode              {get; set;}
-		public LockTaskMode           LockTaskMode            {get; set;}
+#if ANDROID_23
+		public string                 LockTaskMode            {get; set;}
+#endif
+#if ANDROID_11
 		public string                 Logo                    {get; set;}
+#endif
 #if ANDROID_17
 		[Obsolete ("There is no //activity/@android:layoutDirection attribute. This was a mistake. " +
 				"Perhaps you wanted ConfigurationChanges=ConfigChanges.LayoutDirection?")]
@@ -72,41 +78,60 @@ namespace Android.App
 #if ANDROID_16
 		public Type                   ParentActivity          {get; set;}
 #endif
+		public string                 Permission              {get; set;}
 #if ANDROID_21
 		public ActivityPersistableMode      PersistableMode   {get; set;}
 #endif
-		public string                 Permission              {get; set;}
 		public string                 Process                 {get; set;}
-		public bool                   RecreateOnConfigChanges {get; set;} 
+#if ANDROID_26
+		public ConfigChanges          RecreateOnConfigChanges    {get; set;}
+#endif
 #if ANDROID_21
 		public bool                   RelinquishTaskIdentity  {get; set;}
 #endif
 #if ANDROID_24
 		public bool                   ResizeableActivity      {get;set;}
 #endif
+#if ANDROID_21
 		public bool                   ResumeWhilePausing      {get; set;}
-		public string                 RotationAnimation       {get; set;}
+#endif
+#if ANDROID_26
+		public WindowRotationAnimation      RotationAnimation    {get; set;}
+#endif
 #if ANDROID_25
 		public string                 RoundIcon               {get; set;}
 #endif
 #if ANDROID_23
 		public bool                   ShowForAllUsers         {get; set;}
 #endif
+#if ANDROID_17
+		[Obsolete ("Please use ShowForAllUsers instead.")]
 		public bool                   ShowOnLockScreen        {get; set;}
+#endif
 #if ANDROID_24
 		public bool                   SupportsPictureInPicture {get;set;}
 #endif
 		public ScreenOrientation      ScreenOrientation       {get; set;}
+#if ANDROID_27
+		public bool                   ShowWhenLocked          {get; set;}
+#endif
+#if ANDROID_17
 		public bool                   SingleUser              {get; set;}
+#endif
 		public bool                   StateNotNeeded          {get; set;}
 		public string                 TaskAffinity            {get; set;}
 		public string                 Theme                   {get; set;}
+#if ANDROID_27
+		public bool                   TurnScreenOn            {get; set;}
+#endif
 #if ANDROID_14
 		public UiOptions              UiOptions               {get; set;}
 #endif
+#if ANDROID_26
 		public bool                   VisibleToInstantApps    {get; set;}
+#endif
 		public SoftInput              WindowSoftInputMode     {get; set;}
-#if ANDROID_15 // this is not documented on http://developer.android.com/guide/topics/manifest/activity-element.html but on https://developers.google.com/glass/develop/gdk/immersions
+#if ANDROID_11 // this is not documented on http://developer.android.com/guide/topics/manifest/activity-element.html but on https://developers.google.com/glass/develop/gdk/immersions
 		public bool                   Immersive               {get; set;}
 #endif
 	}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
@@ -35,13 +35,17 @@ namespace Android.App
 		public string                 ColorMode               {get; set;}
 #endif
 		public ConfigChanges          ConfigurationChanges    {get; set;}
+		public string                 Description             {get; set;}
 #if ANDROID_24
 		public bool                   DirectBootAware         {get; set;}
+#endif
+		public DocumentLaunchMode     DocumentLaunchMode      {get; set;}
 		public string                 EnableVrMode            {get; set;}
 #endif
 		public bool                   Enabled                 {get; set;}
 		public bool                   ExcludeFromRecents      {get; set;}
 		public bool                   Exported                {get; set;}
+		public bool                   FinishOnCloseSystemDialogs    {get; set;}
 		public bool                   FinishOnTaskLaunch      {get; set;}
 #if ANDROID_11
 		public bool                   HardwareAccelerated     {get; set;}
@@ -49,6 +53,8 @@ namespace Android.App
 		public string                 Icon                    {get; set;}
 		public string                 Label                   {get; set;}
 		public LaunchMode             LaunchMode              {get; set;}
+		public LockTaskMode           LockTaskMode            {get; set;}
+		public string                 Logo                    {get; set;}
 #if ANDROID_17
 		[Obsolete ("There is no //activity/@android:layoutDirection attribute. This was a mistake. " +
 				"Perhaps you wanted ConfigurationChanges=ConfigChanges.LayoutDirection?")]
@@ -71,28 +77,34 @@ namespace Android.App
 #endif
 		public string                 Permission              {get; set;}
 		public string                 Process                 {get; set;}
+		public bool                   RecreateOnConfigChanges {get; set;} 
 #if ANDROID_21
 		public bool                   RelinquishTaskIdentity  {get; set;}
 #endif
 #if ANDROID_24
 		public bool                   ResizeableActivity      {get;set;}
 #endif
+		public bool                   ResumeWhilePausing      {get; set;}
+		public string                 RotationAnimation       {get; set;}
 #if ANDROID_25
 		public string                 RoundIcon               {get; set;}
 #endif
 #if ANDROID_23
 		public bool                   ShowForAllUsers         {get; set;}
 #endif
+		public bool                   ShowOnLockScreen        {get; set;}
 #if ANDROID_24
 		public bool                   SupportsPictureInPicture {get;set;}
 #endif
 		public ScreenOrientation      ScreenOrientation       {get; set;}
+		public bool                   SingleUser              {get; set;}
 		public bool                   StateNotNeeded          {get; set;}
 		public string                 TaskAffinity            {get; set;}
 		public string                 Theme                   {get; set;}
 #if ANDROID_14
 		public UiOptions              UiOptions               {get; set;}
 #endif
+		public bool                   VisibleToInstantApps    {get; set;}
 		public SoftInput              WindowSoftInputMode     {get; set;}
 #if ANDROID_15 // this is not documented on http://developer.android.com/guide/topics/manifest/activity-element.html but on https://developers.google.com/glass/develop/gdk/immersions
 		public bool                   Immersive               {get; set;}


### PR DESCRIPTION
Adds a number of attributes for an Activity that are supported in android

autoRemoveFromRecents
banner
colorMode
description(NOT FOUND IN DOCS, ONLY SOURCE)
enableVrMode
finishOnCloseSystemDiaglogs(NOT FOUND IN DOCS, ONLY SOURCE)
lockTaskMode(NOT FOUND IN DOCS, ONLY SOURCE)
logo(NOT FOUND IN DOCS, ONLY SOURCE)
maxAspectRatio
maxRecents
persistableMode
recreateOnConfigChanges(NOT FOUND IN DOCS, ONLY SOURCE)
relinquishTaskIdentity
resumeWhilePausing(NOT FOUND IN DOCS, ONLY SOURCE)
rotationAnimation(NOT FOUND IN DOCS, ONLY SOURCE)
showForAllUsers
showOnLockScreen(NOT FOUND IN DOCS, ONLY SOURCE)
singleUser
splitName
visibleToInstantApps(NOT FOUND IN DOCS, ONLY SOURCE)

see #1891 