### PR TITLE
[timing] CSV results in separate file per test app

### DIFF
--- a/build-tools/scripts/Packaging.mk
+++ b/build-tools/scripts/Packaging.mk
@@ -66,7 +66,7 @@ package-deb: $(ZIP_OUTPUT)
 _TEST_ERRORS_BASENAME   = xa-test-errors-v$(PRODUCT_VERSION).$(-num-commits-since-version-change)_$(OS_NAME)-$(OS_ARCH)_$(GIT_BRANCH)_$(GIT_COMMIT)
 
 "$(_TEST_ERRORS_BASENAME).zip" package-test-errors:
-	build-tools/scripts/ln-to.sh -r . -o "$(_TEST_ERRORS_BASENAME)" bin/Test*/temp TestResult-*.xml bin/Test*/TestOutput-*.txt
+	build-tools/scripts/ln-to.sh -r . -o "$(_TEST_ERRORS_BASENAME)" bin/Test*/temp TestResult-*.xml bin/Test*/TestOutput-*.txt bin/Test*/Timing_* *.csv
 	zip -r "$(_TEST_ERRORS_BASENAME).zip" "$(_TEST_ERRORS_BASENAME)"
 
 _BUILD_STATUS_BUNDLE_INCLUDE = \

--- a/build-tools/timing/timing.targets
+++ b/build-tools/timing/timing.targets
@@ -32,12 +32,9 @@
     </_MSBuildTimingDependsOn>
   </PropertyGroup>
   <Target Name="MSBuildTiming" DependsOnTargets="$(_MSBuildTimingDependsOn)">
-    <ItemGroup>
-      <_TimingResults Include="$(_OutputDir)Timing_*.xml" />
-    </ItemGroup>
     <ProcessMSBuildTiming
         InputFiles="@(_TimingResults)"
-        ResultsFilename="$(_TopDir)TestResult-MSBuild-times.csv"
+        ResultsFilename="$(_TopDir)TestResult-Timing-%(ProjectName).csv"
         LabelSuffix="-$(Configuration)"
         AddResults="True"
     />
@@ -58,10 +55,11 @@
   <Target Name="FreshBuild"
       Outputs="$(_TopDir)bin\Test$(Configuration)\Timing_FreshBuild_$(Configuration)_%(XACaptureBuildTimingProject.Name).xml">
     <PropertyGroup>
+      <_ProjectName>@(XACaptureBuildTimingProject->'%(Name)')</_ProjectName>
       <_ID>@(XACaptureBuildTimingProject->'%(ShortName)')-FreshBuild</_ID>
-      <_Description>A fresh build after a clean checkout for @(XACaptureBuildTimingProject->'%(Name)')</_Description>
+      <_Description>A fresh build after a clean checkout for $(_ProjectName)</_Description>
       <_Target>SignAndroidPackage</_Target>
-      <_OutputFile>$(_OutputDir)Timing_$(_ID)_$(Configuration)_@(XACaptureBuildTimingProject->'%(Name)')</_OutputFile>
+      <_OutputFile>$(_OutputDir)Timing_$(_ID)_$(Configuration)_$(_ProjectName)</_OutputFile>
     </PropertyGroup>
     <!--Simulate a clean checkout with git commands-->
     <Git
@@ -95,77 +93,124 @@
         Command="$(_TopDir).nuget\NuGet.exe restore &quot;%(XACaptureBuildTimingProject.Restore)&quot;"
     />
     <Exec Command="$(_XABuild) /fl /flp:LogFile=$(_OutputFile).log &quot;/logger:$(_TimingLogger);ID=$(_ID);Description=$(_Description);Commit=$(XAVersionHash);OutputPath=$(_OutputFile).xml&quot; /p:Configuration=$(Configuration) /p:AndroidSupportedAbis=x86 %(XACaptureBuildTimingProject.Identity) /t:$(_Target)" />
+    <ItemGroup>
+      <_TimingResults Include="$(_OutputFile).xml">
+        <ProjectName>$(_ProjectName)</ProjectName>
+      </_TimingResults>
+    </ItemGroup>
   </Target>
   <Target Name="FreshInstall"
       Outputs="$(_TopDir)bin\Test$(Configuration)\Timing_FreshInstall_$(Configuration)_%(XACaptureBuildTimingProject.Name).xml">
     <PropertyGroup>
+      <_ProjectName>@(XACaptureBuildTimingProject->'%(Name)')</_ProjectName>
       <_ID>@(XACaptureBuildTimingProject->'%(ShortName)')-FreshInstall</_ID>
-      <_Description>An install after a fresh build for @(XACaptureBuildTimingProject->'%(Name)')</_Description>
+      <_Description>An install after a fresh build for $(_ProjectName)</_Description>
       <_Target>Install</_Target>
-      <_OutputFile>$(_OutputDir)Timing_$(_ID)_$(Configuration)_@(XACaptureBuildTimingProject->'%(Name)')</_OutputFile>
+      <_OutputFile>$(_OutputDir)Timing_$(_ID)_$(Configuration)_$(_ProjectName)</_OutputFile>
     </PropertyGroup>
     <Exec Command="$(_XABuild) /fl /flp:LogFile=$(_OutputFile).log &quot;/logger:$(_TimingLogger);ID=$(_ID);Description=$(_Description);Commit=$(XAVersionHash);OutputPath=$(_OutputFile).xml&quot; /p:Configuration=$(Configuration) /p:AndroidSupportedAbis=x86 %(XACaptureBuildTimingProject.Identity) /t:$(_Target)" />
+    <ItemGroup>
+      <_TimingResults Include="$(_OutputFile).xml">
+        <ProjectName>$(_ProjectName)</ProjectName>
+      </_TimingResults>
+    </ItemGroup>
   </Target>
   <Target Name="SecondBuild"
       Outputs="$(_TopDir)bin\Test$(Configuration)\Timing_SecondBuild_$(Configuration)_%(XACaptureBuildTimingProject.Name).xml">
     <PropertyGroup>
+      <_ProjectName>@(XACaptureBuildTimingProject->'%(Name)')</_ProjectName>
       <_ID>@(XACaptureBuildTimingProject->'%(ShortName)')-SecondBuild</_ID>
-      <_Description>A second build after a fresh build for @(XACaptureBuildTimingProject->'%(Name)')</_Description>
+      <_Description>A second build after a fresh build for $(_ProjectName)</_Description>
       <_Target>SignAndroidPackage</_Target>
-      <_OutputFile>$(_OutputDir)Timing_$(_ID)_$(Configuration)_@(XACaptureBuildTimingProject->'%(Name)')</_OutputFile>
+      <_OutputFile>$(_OutputDir)Timing_$(_ID)_$(Configuration)_$(_ProjectName)</_OutputFile>
     </PropertyGroup>
     <Exec Command="$(_XABuild) /fl /flp:LogFile=$(_OutputFile).log &quot;/logger:$(_TimingLogger);ID=$(_ID);Description=$(_Description);Commit=$(XAVersionHash);OutputPath=$(_OutputFile).xml&quot; /p:Configuration=$(Configuration) /p:AndroidSupportedAbis=x86 %(XACaptureBuildTimingProject.Identity) /t:$(_Target)" />
+    <ItemGroup>
+      <_TimingResults Include="$(_OutputFile).xml">
+        <ProjectName>$(_ProjectName)</ProjectName>
+      </_TimingResults>
+    </ItemGroup>
   </Target>
   <Target Name="SecondInstall"
       Outputs="$(_TopDir)bin\Test$(Configuration)\Timing_SecondInstall_$(Configuration)_%(XACaptureBuildTimingProject.Name).xml">
     <PropertyGroup>
+      <_ProjectName>@(XACaptureBuildTimingProject->'%(Name)')</_ProjectName>
       <_ID>@(XACaptureBuildTimingProject->'%(ShortName)')-SecondInstall</_ID>
-      <_Description>An install after a second build for @(XACaptureBuildTimingProject->'%(Name)')</_Description>
+      <_Description>An install after a second build for $(_ProjectName)</_Description>
       <_Target>Install</_Target>
-      <_OutputFile>$(_OutputDir)Timing_$(_ID)_$(Configuration)_@(XACaptureBuildTimingProject->'%(Name)')</_OutputFile>
+      <_OutputFile>$(_OutputDir)Timing_$(_ID)_$(Configuration)_$(_ProjectName)</_OutputFile>
     </PropertyGroup>
     <Exec Command="$(_XABuild) /fl /flp:LogFile=$(_OutputFile).log &quot;/logger:$(_TimingLogger);ID=$(_ID);Description=$(_Description);Commit=$(XAVersionHash);OutputPath=$(_OutputFile).xml&quot; /p:Configuration=$(Configuration) /p:AndroidSupportedAbis=x86 %(XACaptureBuildTimingProject.Identity) /t:$(_Target)" />
+    <ItemGroup>
+      <_TimingResults Include="$(_OutputFile).xml">
+        <ProjectName>$(_ProjectName)</ProjectName>
+      </_TimingResults>
+    </ItemGroup>
   </Target>
   <Target Name="TouchCSharpBuild"
       Outputs="$(_TopDir)bin\Test$(Configuration)\Timing_TouchCSharpBuild_$(Configuration)_%(XACaptureBuildTimingProject.Name).xml">
     <PropertyGroup>
+      <_ProjectName>@(XACaptureBuildTimingProject->'%(Name)')</_ProjectName>
       <_ID>@(XACaptureBuildTimingProject->'%(ShortName)')-TouchCSharpBuild</_ID>
-      <_Description>A build after a fresh build that touches a C# file for @(XACaptureBuildTimingProject->'%(Name)')</_Description>
+      <_Description>A build after a fresh build that touches a C# file for $(_ProjectName)</_Description>
       <_Target>SignAndroidPackage</_Target>
-      <_OutputFile>$(_OutputDir)Timing_$(_ID)_$(Configuration)_@(XACaptureBuildTimingProject->'%(Name)')</_OutputFile>
+      <_OutputFile>$(_OutputDir)Timing_$(_ID)_$(Configuration)_$(_ProjectName)</_OutputFile>
     </PropertyGroup>
     <Touch Files="%(XACaptureBuildTimingProject.CSharpFile)" />
     <Exec Command="$(_XABuild) /fl /flp:LogFile=$(_OutputFile).log &quot;/logger:$(_TimingLogger);ID=$(_ID);Description=$(_Description);Commit=$(XAVersionHash);OutputPath=$(_OutputFile).xml&quot; /p:Configuration=$(Configuration) /p:AndroidSupportedAbis=x86 %(XACaptureBuildTimingProject.Identity) /t:$(_Target)" />
+    <ItemGroup>
+      <_TimingResults Include="$(_OutputFile).xml">
+        <ProjectName>$(_ProjectName)</ProjectName>
+      </_TimingResults>
+    </ItemGroup>
   </Target>
   <Target Name="TouchCSharpInstall"
       Outputs="$(_TopDir)bin\Test$(Configuration)\Timing_TouchCSharpInstall_$(Configuration)_%(XACaptureBuildTimingProject.Name).xml">
     <PropertyGroup>
+      <_ProjectName>@(XACaptureBuildTimingProject->'%(Name)')</_ProjectName>
       <_ID>@(XACaptureBuildTimingProject->'%(ShortName)')-TouchCSharpInstall</_ID>
-      <_Description>An install after touching a C# file for @(XACaptureBuildTimingProject->'%(Name)')</_Description>
+      <_Description>An install after touching a C# file for $(_ProjectName)</_Description>
       <_Target>Install</_Target>
-      <_OutputFile>$(_OutputDir)Timing_$(_ID)_$(Configuration)_@(XACaptureBuildTimingProject->'%(Name)')</_OutputFile>
+      <_OutputFile>$(_OutputDir)Timing_$(_ID)_$(Configuration)_$(_ProjectName)</_OutputFile>
     </PropertyGroup>
     <Exec Command="$(_XABuild) /fl /flp:LogFile=$(_OutputFile).log &quot;/logger:$(_TimingLogger);ID=$(_ID);Description=$(_Description);Commit=$(XAVersionHash);OutputPath=$(_OutputFile).xml&quot; /p:Configuration=$(Configuration) /p:AndroidSupportedAbis=x86 %(XACaptureBuildTimingProject.Identity) /t:$(_Target)" />
+    <ItemGroup>
+      <_TimingResults Include="$(_OutputFile).xml">
+        <ProjectName>$(_ProjectName)</ProjectName>
+      </_TimingResults>
+    </ItemGroup>
   </Target>
   <Target Name="TouchAndroidResourceBuild"
       Outputs="$(_TopDir)bin\Test$(Configuration)\Timing_TouchAndroidResourceBuild_$(Configuration)_%(XACaptureBuildTimingProject.Name).xml">
     <PropertyGroup>
+      <_ProjectName>@(XACaptureBuildTimingProject->'%(Name)')</_ProjectName>
       <_ID>@(XACaptureBuildTimingProject->'%(ShortName)')-TouchAndroidResourceBuild</_ID>
-      <_Description>A build after a fresh build that touches an Android resource XML file for @(XACaptureBuildTimingProject->'%(Name)')</_Description>
+      <_Description>A build after a fresh build that touches an Android resource XML file for $(_ProjectName)</_Description>
       <_Target>SignAndroidPackage</_Target>
-      <_OutputFile>$(_OutputDir)Timing_$(_ID)_$(Configuration)_@(XACaptureBuildTimingProject->'%(Name)')</_OutputFile>
+      <_OutputFile>$(_OutputDir)Timing_$(_ID)_$(Configuration)_$(_ProjectName)</_OutputFile>
     </PropertyGroup>
     <Touch Files="%(XACaptureBuildTimingProject.AndroidResourceFile)" />
     <Exec Command="$(_XABuild) /fl /flp:LogFile=$(_OutputFile).log &quot;/logger:$(_TimingLogger);ID=$(_ID);Description=$(_Description);Commit=$(XAVersionHash);OutputPath=$(_OutputFile).xml&quot; /p:Configuration=$(Configuration) /p:AndroidSupportedAbis=x86 %(XACaptureBuildTimingProject.Identity) /t:$(_Target)" />
+    <ItemGroup>
+      <_TimingResults Include="$(_OutputFile).xml">
+        <ProjectName>$(_ProjectName)</ProjectName>
+      </_TimingResults>
+    </ItemGroup>
   </Target>
   <Target Name="TouchAndroidResourceInstall"
       Outputs="$(_TopDir)bin\Test$(Configuration)\Timing_TouchAndroidResourceInstall_$(Configuration)_%(XACaptureBuildTimingProject.Name).xml">
     <PropertyGroup>
+      <_ProjectName>@(XACaptureBuildTimingProject->'%(Name)')</_ProjectName>
       <_ID>@(XACaptureBuildTimingProject->'%(ShortName)')-TouchAndroidResourceInstall</_ID>
-      <_Description>An install after touching an Android resource XML file for @(XACaptureBuildTimingProject->'%(Name)')</_Description>
+      <_Description>An install after touching an Android resource XML file for $(_ProjectName)</_Description>
       <_Target>Install</_Target>
-      <_OutputFile>$(_OutputDir)Timing_$(_ID)_$(Configuration)_@(XACaptureBuildTimingProject->'%(Name)')</_OutputFile>
+      <_OutputFile>$(_OutputDir)Timing_$(_ID)_$(Configuration)_$(_ProjectName)</_OutputFile>
     </PropertyGroup>
     <Exec Command="$(_XABuild) /fl /flp:LogFile=$(_OutputFile).log &quot;/logger:$(_TimingLogger);ID=$(_ID);Description=$(_Description);Commit=$(XAVersionHash);OutputPath=$(_OutputFile).xml&quot; /p:Configuration=$(Configuration) /p:AndroidSupportedAbis=x86 %(XACaptureBuildTimingProject.Identity) /t:$(_Target)" />
+    <ItemGroup>
+      <_TimingResults Include="$(_OutputFile).xml">
+        <ProjectName>$(_ProjectName)</ProjectName>
+      </_TimingResults>
+    </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/plot/Build%20times/

Our existing graph plotting build times on Jenkins is a bit
unreadable: there are too many columns!

In fact, the graph crashes completely when a third app is added
downstream in `monodroid`.

So after this change, we produce:
- `TestResult-Timing-HelloWorld.csv`
- `TestResult-Timing-Xamarin.Forms-Integration.csv`

We can ingest these as two separate graphs on Jenkins.

After this is merged, I will need to add some further configuration on
Jenkins:
- Rename the existing graph to `(History)` to keep the old data
- Add two new graphs for `Hello World` and `Xamarin.Forms`

Other changes:
- Include `bin\Test*\Timing_*` output files in `test-errors.zip`
- This includes both `*.log` files of the build output, and `*.xml`
  files of timing of each MSBuild target individually.
- Include `*.csv` files in `test-errors.zip`

If we ever need this data down the road, we will have it stored on
Azure.