### PR TITLE
Make {x,n}unit runner logging level configurable from command line

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
@@ -29,6 +29,8 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		[Output]
 		public                  string              FailedToRun                 { get; set; }
 
+		public                  string              LogLevel                    { get; set; }
+
 		protected   override    bool                LogTaskMessages {
 			get { return false; }
 		}
@@ -70,6 +72,11 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			executionState  = ExecuteState.RunInstrumentation;
 			base.Execute ();
 
+			using (logcatWriter = File.Exists (LogcatFilename) ? File.AppendText (LogcatFilename) : File.CreateText (LogcatFilename)) {
+				executionState = ExecuteState.GetLogcat;
+				base.Execute ();
+			}
+
 			if (string.IsNullOrEmpty (targetTestResultsPath)) {
 				FailedToRun = Component;
 				Log.LogError (
@@ -83,11 +90,6 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 			executionState  = ExecuteState.PullFiles;
 			base.Execute ();
-
-			using (logcatWriter = File.Exists (LogcatFilename) ? File.AppendText (LogcatFilename) : File.CreateText (LogcatFilename)) {
-				executionState = ExecuteState.GetLogcat;
-				base.Execute ();
-			}
 
 			return !Log.HasLoggedErrors;
 		}
@@ -103,6 +105,11 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 					args.Append (kvp.Length > 1 ? kvp [1] : "");
 					args.Append ("\"");
 				}
+
+				if (!String.IsNullOrEmpty (LogLevel)) {
+					args.Append ($" -e \"loglevel {LogLevel}\"");
+				}
+
 				if (!string.IsNullOrWhiteSpace (TestFixture)) {
 					args.Append (" -e suite \"").Append (TestFixture).Append ("\"");
 				}

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -181,6 +181,7 @@
         Condition=" '%(TestApkInstrumentation.Identity)' != ''"
         AdbTarget="$(_AdbTarget)"
         AdbOptions="$(AdbOptions)"
+        LogLevel="Verbose"
         Component="%(TestApkInstrumentation.Package)/%(TestApkInstrumentation.Identity)"
         NUnit2TestResultsFile="%(TestApkInstrumentation.ResultsPath)"
         LogcatFilename="$(_LogcatFilenameBase)-%(TestApkInstrumentation.Package).txt"

--- a/tests/TestRunner.Core/LogWriter.cs
+++ b/tests/TestRunner.Core/LogWriter.cs
@@ -6,6 +6,8 @@ namespace Xamarin.Android.UnitTests
 {
 	public class LogWriter
 	{
+		const string Tag = "LogWriter";
+
 		public MinimumLogLevel MinimumLogLevel { get; set; } = MinimumLogLevel.Info;
 
 		public void OnError (string tag, string message)
@@ -41,6 +43,22 @@ namespace Xamarin.Android.UnitTests
 			if (MinimumLogLevel < MinimumLogLevel.Info)
 				return;
 			Log.Info (tag, message);
+		}
+
+		public void SetMinimuLogLevelFromString (string minimumLevel)
+		{
+			// Be forgiving... :P
+			if (String.IsNullOrEmpty (minimumLevel))
+				return;
+
+			MinimumLogLevel level;
+			if (!Enum.TryParse (minimumLevel, true, out level)) {
+				Log.Warn (Tag, $"Unknown log level name: {minimumLevel}");
+				return;
+			}
+
+			Log.Info (Tag, $"Setting log level to {level}");
+			MinimumLogLevel = level;
 		}
 	}
 }

--- a/tests/TestRunner.Core/TestInstrumentation.cs
+++ b/tests/TestRunner.Core/TestInstrumentation.cs
@@ -13,6 +13,11 @@ namespace Xamarin.Android.UnitTests
 {
 	public abstract class TestInstrumentation <TRunner> : Instrumentation where TRunner: TestRunner
 	{
+		protected sealed class KnownArguments
+		{
+			public const string LogLevel = "loglevel";
+		}
+
 		const string ResultExecutedTests = "run";
 		const string ResultPassedTests = "passed";
 		const string ResultSkippedTests = "skipped";
@@ -70,8 +75,23 @@ namespace Xamarin.Android.UnitTests
 		public override void OnCreate (Bundle arguments)
 		{
 			base.OnCreate (arguments);
+			ProcessArguments (arguments);
 			this.arguments = arguments;
 			Start ();
+		}
+
+		protected virtual void ProcessArguments (Bundle arguments)
+		{
+			// Because of the way GetStringExtrasFromBundle below is implemented, we need to remove from the
+			// bundle the arguments we know. GetStringExtrasFromBundle treats all entries as category
+			// filters.
+			if (arguments == null)
+				return;
+
+			if (arguments.ContainsKey (KnownArguments.LogLevel)) {
+				Logger.SetMinimuLogLevelFromString (arguments.GetString (KnownArguments.LogLevel)?.Trim ());
+				arguments.Remove (KnownArguments.LogLevel);
+			}
 		}
 
 		public override void OnStart ()


### PR DESCRIPTION
The LogWriter class used by both xUnit and NUnit test runners has configurable
minimum logging level which defaults to `Info`. It is not possible to configure
the level from command line, e.g. when starting the instrumentation. This commit
fixes the problem by introducing the `loglevel` parameter which can be sent to
the instrumentation using this syntax:

     -e "loglevel info"

The acceptable log level values are (the strings are case-insensitive):

   * Wtf
   * Error
   * Warning
   * Info
   * Debug
   * Verbose

The default in the logger class is reasonable `Info`, however this commit
changes the value used by the `RunTestApks` target to `Verbose` in order to try
to figure out why the tests are failing on us when run on PR builders.