### PR TITLE
[Xamarin.Android.Build.Tasks] missing error code in ResolveSdks

### DIFF
--- a/Documentation/guides/messages/xa5300.md
+++ b/Documentation/guides/messages/xa5300.md
@@ -1,4 +1,4 @@
-# Error XA5300
+# Compiler Error/Warning XA5300
 
 The XA5300 error is generated when the required Android SDK or Java SDK cannot
 be located during the build.
@@ -8,4 +8,8 @@ This can be fixed on the command-line by overriding either the
 
 This can also be fixed [within Visual Studio options][vs-sdk].
 
+Consider submitting a [bug][bug] if you are getting this failure under
+normal circumstances.
+
 [vs-sdk]: https://docs.microsoft.com/en-us/xamarin/android/troubleshooting/questions/android-sdk-location?tabs=vswin
+[bug]: https://github.com/xamarin/xamarin-android/wiki/Submitting-Bugs,-Feature-Requests,-and-Pull-Requests

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -104,26 +104,6 @@ namespace Xamarin.Android.Tasks
 			//note: this task does not error out if it doesn't find all things. that's the job of the targets
 			return !Log.HasLoggedErrors;
 		}
-
-		void ErrorHandler (string task, string message)
-		{
-			Log.LogError ($"{task} {message}");
-		}
-
-		void WarningHandler (string task, string message)
-		{
-			Log.LogWarning ($"{task} {message}");
-		}
-
-		void DebugHandler (string task, string message)
-		{
-			Log.LogDebugMessage ($"DEBUG {task} {message}");
-		}
-
-		void InfoHandler (string task, string message)
-		{
-			Log.LogMessage ($"{task} {message}");
-		}
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -97,13 +97,13 @@ namespace Xamarin.Android.Tasks
 					if (log == null)
 						Console.Error.Write (value);
 					else
-						log.LogError ("{0}", value);
+						log.LogCodedError ("XA5300", "{0}", value);
 					break;
 				case TraceLevel.Warning:
 					if (log == null)
 						Console.WriteLine (value);
 					else
-						log.LogWarning ("{0}", value);
+						log.LogCodedWarning ("XA5300", "{0}", value);
 					break;
 				default:
 					if (log == null)


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/1560

In a0d4317b4 we added the `XA5300` error code, but there were a few
loose ends:
- The `*Handler` methods in `ResolveSdks` are completely unused. We
  should remove them.
- `MonoAndroidHelper.RefreshAndroidSdk` should use the `XA5300` error
  code.

I also expanded upon the `xa5300.md` documentation a bit.