### PR TITLE
Update emulator to the latest version, switch to API 28

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -116,7 +116,7 @@
     <AndroidToolPath Condition=" '$(AndroidToolPath)' == '' ">$(AndroidSdkFullPath)\tools</AndroidToolPath>
     <AndroidToolsBinPath Condition=" '$(AndroidToolsBinPath)' == '' ">$(AndroidToolPath)\bin</AndroidToolsBinPath>
     <AndroidToolExe Condition=" '$(AndroidToolExe)' == '' ">android</AndroidToolExe>
-    <EmulatorToolPath Condition=" '$(EmulatorToolPath)' == '' ">$(AndroidSdkFullPath)\tools</EmulatorToolPath>
+    <EmulatorToolPath Condition=" '$(EmulatorToolPath)' == '' ">$(AndroidSdkFullPath)\emulator</EmulatorToolPath>
     <EmulatorToolExe Condition=" '$(EmulatorToolExe)' == '' ">emulator</EmulatorToolExe>
     <NdkBuildPath Condition=" '$(NdkBuildPath)' == '' And '$(HostOS)' != 'Windows' ">$(AndroidNdkDirectory)\ndk-build</NdkBuildPath>
     <NdkBuildPath Condition=" '$(NdkBuildPath)' == '' And '$(HostOS)' == 'Windows' ">$(AndroidNdkDirectory)\ndk-build.cmd</NdkBuildPath>

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/Adb.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/Adb.cs
@@ -59,7 +59,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
 		{
-			base.LogEventsFromTextOutput (singleLine, messageImportance);
+			Log.LogMessage (MessageImportance.Low, singleLine);
 			Lines.Add (singleLine);
 		}
 	}

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateAndroidEmulator.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateAndroidEmulator.cs
@@ -23,8 +23,9 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		public                  string          TargetId        {get; set;}
 
 		public                  string          ImageName           {get; set;} = "XamarinAndroidTestRunner";
+
+		public                  string          DataPartitionSizeMB {get; set;} = "2048";
 		public                  string          RamSizeMB           {get; set;} = "2048";
-		public                  string          DataPartitionSizeMB { get; set;} = "2048";
 
 
 		public override bool Execute ()

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateAndroidEmulator.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateAndroidEmulator.cs
@@ -22,7 +22,10 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 		public                  string          TargetId        {get; set;}
 
-		public                  string          ImageName       {get; set;} = "XamarinAndroidTestRunner";
+		public                  string          ImageName           {get; set;} = "XamarinAndroidTestRunner";
+		public                  string          RamSizeMB           {get; set;} = "2048";
+		public                  string          DataPartitionSizeMB { get; set;} = "2048";
+
 
 		public override bool Execute ()
 		{
@@ -68,6 +71,29 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 			var arguments   = $"create avd --abi {AndroidAbi} -f -n {ImageName} --package \"{TargetId}\"";
 			Exec (android, arguments);
+
+			string configPath = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), ".android", "avd", $"{ImageName}.avd", "config.ini");
+			if (!File.Exists (configPath)) {
+				Log.LogWarning ($"Config file for AVD '{ImageName}' not found at {configPath}");
+				Log.LogWarning ($"AVD '{ImageName}' will use default emulator settings (memory and data partition size)");
+				return;
+			}
+
+			ulong diskSize;
+			if (!UInt64.TryParse (DataPartitionSizeMB, out diskSize))
+				Log.LogError ($"Invalid data partition size '{DataPartitionSizeMB}' - must be a positive integer value expressing size in megabytes");
+
+			ulong ramSize;
+			if (!UInt64.TryParse (RamSizeMB, out ramSize))
+				Log.LogError ($"Invalid RAM size '{RamSizeMB}' - must be a positive integer value expressing size in megabytes");
+
+			if (Log.HasLoggedErrors)
+				return;
+
+			File.AppendAllLines (configPath, new string[] {
+				$"disk.dataPartition.size={diskSize}M",
+				$"hw.ramSize={ramSize}"
+			});
 		}
 
 		StreamWriter stdin;

--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -23,7 +23,7 @@
       <HostOS>Linux</HostOS>
       <DestDir>tools</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="emulator-linux-4266726">
+    <AndroidSdkItem Include="emulator-linux-4969155">
       <HostOS>Linux</HostOS>
       <DestDir>emulator</DestDir>
     </AndroidSdkItem>
@@ -42,7 +42,7 @@
       <HostOS>Darwin</HostOS>
       <DestDir>tools</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="emulator-darwin-4266726">
+    <AndroidSdkItem Include="emulator-darwin-4969155">
       <HostOS>Darwin</HostOS>
       <DestDir>emulator</DestDir>
     </AndroidSdkItem>
@@ -61,7 +61,7 @@
       <HostOS>Windows</HostOS>
       <DestDir>tools</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="emulator-windows-4266726">
+    <AndroidSdkItem Include="emulator-windows-4969155">
       <HostOS>Windows</HostOS>
       <DestDir>emulator</DestDir>
     </AndroidSdkItem>
@@ -151,10 +151,10 @@
       <HostOS></HostOS>
       <DestDir>extras\android\m2repository</DestDir>
     </AndroidSdkItem>
-    <AndroidSdkItem Include="x86-21_r05">
+    <AndroidSdkItem Include="x86-28_r04">
       <HostOS></HostOS>
       <RelUrl>sys-img/android/</RelUrl>
-      <DestDir>system-images\android-21\default\x86</DestDir>
+      <DestDir>system-images\android-28\default\x86</DestDir>
     </AndroidSdkItem>
   </ItemGroup>
   <ItemGroup>

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -32,10 +32,12 @@
         AndroidAbi="x86"
         AndroidSdkHome="$(AndroidSdkDirectory)"
         JavaSdkHome="$(JavaSdkDirectory)"
-        SdkVersion="21"
+        SdkVersion="28"
         ImageName="$(_TestImageName)"
         ToolExe="$(AvdManagerToolExe)"
         ToolPath="$(AndroidToolsBinPath)"
+        RamSizeMB="2048"
+        DataPartitionSizeMB="2048"
     />
     <StartAndroidEmulator
         Condition=" '$(_ValidAdbTarget)' != 'True' "


### PR DESCRIPTION
This commit updates the Android emulator to the latest version
available (`4969155` a.k.a. v27.3.10), switches its system image to API 28,
makes sure that the emulator is started from the `emulator` subdir of the
Android SDK root (the binary in `tools` won't work anymore) and makes sure we
don't error out when we attempt to uninstall packages that don't exist in the
AVD.