### PR TITLE
[Xamarin.Android.Build.Tasks] `_CreateAapt2VersionCache` slow due to wildcard usage

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -793,10 +793,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 			Lines="$(_Aapt2Version)"
 			Overwrite="true"
 	/>
-	<ItemGroup>
-		<_CompiledFlataArchive Include="$(_AndroidLibrayProjectIntermediatePath)**\*.flata" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'" />
-		<_CompiledFlataArchive Include="$(IntermediateOutputPath)\*.flata" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'" />
-		<_CompiledFlataStamp Include="$(_AndroidLibrayProjectIntermediatePath)**\compiled.stamp" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'" />
+	<ItemGroup Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'">
+		<_CompiledFlataArchive Include="$(_AndroidLibrayProjectIntermediatePath)**\*.flata" />
+		<_CompiledFlataArchive Include="$(IntermediateOutputPath)\*.flata" />
+		<_CompiledFlataStamp Include="$(_AndroidLibrayProjectIntermediatePath)**\compiled.stamp" />
 	</ItemGroup>
 	<Delete Files="@(_CompiledFlataArchive);@(_CompiledFlataStamp)" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'" />
 </Target>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -794,9 +794,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 			Overwrite="true"
 	/>
 	<ItemGroup>
-		<_CompiledFlataArchive Include="$(IntermediateOutputPath)\lp\**\*.flata" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'" />
+		<_CompiledFlataArchive Include="$(_AndroidLibrayProjectIntermediatePath)**\*.flata" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'" />
 		<_CompiledFlataArchive Include="$(IntermediateOutputPath)\*.flata" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'" />
-		<_CompiledFlataStamp Include="$(IntermediateOutputPath)\lp\**\compiled.stamp" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'" />
+		<_CompiledFlataStamp Include="$(_AndroidLibrayProjectIntermediatePath)**\compiled.stamp" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'" />
 	</ItemGroup>
 	<Delete Files="@(_CompiledFlataArchive);@(_CompiledFlataStamp)" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'" />
 </Target>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -788,15 +788,15 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	>
 	<MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" />
 	<WriteLinesToFile
-			Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'"
+			Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'" 
 			File="$(_AndroidAapt2VersionFile)"
 			Lines="$(_Aapt2Version)"
 			Overwrite="true"
 	/>
 	<ItemGroup>
-		<_CompiledFlataArchive Include="$(IntermediateOutputPath)\lp\**\*.flata" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'"/>
-		<_CompiledFlataArchive Include="$(IntermediateOutputPath)\*.flata" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'"/>
-		<_CompiledFlataStamp Include="$(IntermediateOutputPath)\lp\**\compiled.stamp" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'"/>
+		<_CompiledFlataArchive Include="$(IntermediateOutputPath)\lp\**\*.flata" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'" />
+		<_CompiledFlataArchive Include="$(IntermediateOutputPath)\*.flata" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'" />
+		<_CompiledFlataStamp Include="$(IntermediateOutputPath)\lp\**\compiled.stamp" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'" />
 	</ItemGroup>
 	<Delete Files="@(_CompiledFlataArchive);@(_CompiledFlataStamp)" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'" />
 </Target>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -784,18 +784,19 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <Target Name="_CreateAapt2VersionCache"
 		DependsOnTargets="_ReadAapt2VersionCache"
 		AfterTargets="_SetLatestTargetFrameworkVersion"
-		Condition="'$(_AndroidUseAapt2)' == 'True'"
+		Condition="'$(_AndroidUseAapt2)' == 'True' And '$(_Aapt2Version)' != '@(_Aapt2VersionCache)'"
 	>
 	<MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" />
 	<WriteLinesToFile
-			Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'" 
+			Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'"
 			File="$(_AndroidAapt2VersionFile)"
 			Lines="$(_Aapt2Version)"
 			Overwrite="true"
 	/>
 	<ItemGroup>
-		<_CompiledFlataArchive Include="$(IntermediateOutputPath)\**\*.flata"/>
-		<_CompiledFlataStamp Include="$(IntermediateOutputPath)\**\compiled.stamp"/>
+		<_CompiledFlataArchive Include="$(IntermediateOutputPath)\lp\**\*.flata" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'"/>
+		<_CompiledFlataArchive Include="$(IntermediateOutputPath)\*.flata" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'"/>
+		<_CompiledFlataStamp Include="$(IntermediateOutputPath)\lp\**\compiled.stamp" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'"/>
 	</ItemGroup>
 	<Delete Files="@(_CompiledFlataArchive);@(_CompiledFlataStamp)" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'" />
 </Target>


### PR DESCRIPTION
Fixes #2121

There were a number of performace issues with `_CreateAapt2VersionCache`.
First the wildcards were processing the ENTIRE `$(IntermediateOutputPath)`!
What they should have been doing was targeting specific
directories. I.e the root of `$(IntermediateOutputPath)` and
the directories under `$(IntermediateOutputPath)\lp`.

Second the target did not have a Condition to stop it running if
the versions matched, so that has been added.

However, even if a target is NOT run. MSbuild will still evaluate
the `PropertyGroups` and `ItemGroups` within the targets. So we
need to add `Conditon` on the `_CompiledFlataArchive` and
`_CompiledFlataStamp` items as well.

With these in place the time when this target is skipped is down
to 1ms.