### PR TITLE
Fix AOT build

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/Adb.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/Adb.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -12,56 +13,267 @@ using Xamarin.Android.BuildTools.PrepTasks;
 
 namespace Xamarin.Android.Tools.BootstrapTasks
 {
-	public class Adb : PathToolTask
+	public class Adb : Task
 	{
-		public                  string          Arguments                   { get; set; }
+		protected class CommandInfo
+		{
+			public string       ArgumentsString      { get; set; }
+			public Func<string> ArgumentsGenerator   { get; set; }
+			public bool         MergeStdoutAndStderr { get; set; } = true;
+			public bool         IgnoreExitCode       { get; set; }
+			public string       StdoutFilePath       { get; set; }
+			public bool         StdoutAppend         { get; set; }
+			public string       StderrFilePath       { get; set; }
+			public bool         StderrAppend         { get; set; }
+			public StreamWriter StdoutWriter         { get; set; }
+			public StreamWriter StderrWriter         { get; set; }
+			public Func<bool>   ShouldRun            { get; set; } = () => true;
+			public bool         SuppressMSbuildLog   { get; set; }
+
+			public string       Arguments            => ArgumentsGenerator != null ? ArgumentsGenerator () : ArgumentsString;
+		}
+
+		List<string>            lines = new List <string> ();
+		object                  linesLock = new object ();
+
+		public                  string          AdbTarget             { get; set; }
+		public                  string          AdbOptions            { get; set; }
+		public                  string          Arguments             { get; set; }
+		public                  string          WorkingDirectory      { get; set; }
+		public                  bool            IgnoreExitCode        { get; set; }
+		public                  int             Timeout               { get; set; } = -1;
+		public                  string[]        EnvironmentVariables  { get; set; }
+
+		[Required]
+		public                  string          ToolPath              { get; set; }
+
+		[Required]
+		public                  string          ToolExe               { get; set; }
 
 		[Output]
-		public                  string[]        Output                      { get; set; }
+		public                  string[]        Output                { get; set; }
 
-		protected   virtual     bool            LogTaskMessages {
-			get { return true; }
-		}
-
-		protected   override    string          ToolBaseName {
-			get { return "adb"; }
-		}
-
-		List<string> lines;
-		List<string> Lines {
-			get { return lines ?? (lines = new List<string> ()); }
-		}
+		protected   virtual     int             OutputTimeout         => 30; // seconds
 
 		public override bool Execute ()
 		{
-			if (LogTaskMessages) {
-				Log.LogMessage (MessageImportance.Low, $"Task {nameof (Adb)}");
-				Log.LogMessage (MessageImportance.Low, $"  {nameof (Arguments)}: {Arguments}");
-			}
+			List <CommandInfo> commandArguments = GenerateCommandArguments ();
+			if (commandArguments == null || commandArguments.Count == 0)
+				return !Log.HasLoggedErrors;
 
-			base.Execute ();
+			string adbPath = Path.Combine (ToolPath, ToolExe);
+			for (int i = 0; i < commandArguments.Count; i++) {
+				CommandInfo info = commandArguments [i];
+				if (info.ShouldRun != null && !info.ShouldRun ())
+					continue;
+
+				info.StdoutWriter = OpenOutputFile (info.StdoutFilePath, info.StdoutAppend);
+				if (!info.MergeStdoutAndStderr)
+					info.StderrWriter = OpenOutputFile (info.StderrFilePath, info.StderrAppend);
+				BeforeCommand (i, info);
+				try {
+					Log.LogMessage (MessageImportance.Normal, $"Executing: {adbPath} {info.Arguments}");
+					if (info.StdoutWriter != null)
+						LogFileWrite ("stdout", info.StdoutFilePath, info.StdoutAppend);
+					if (info.StderrWriter != null)
+						LogFileWrite ("stderr", info.StderrFilePath, info.StderrAppend);
+					int exitCode = RunCommand (adbPath, info);
+					if (exitCode == 0)
+						continue;
+
+					bool ignoreExit = IgnoreExitCode | info.IgnoreExitCode;
+					string message = $"  Command {adbPath} {info.Arguments} failed with exit code {exitCode}";
+					if (!ignoreExit) {
+						Log.LogError (message);
+						break;
+					}
+					Log.LogWarning (message);
+				} catch {
+					throw;
+				} finally {
+					AfterCommand (i, info);
+					info.StdoutWriter?.Dispose ();
+					info.StdoutWriter = null;
+					info.StderrWriter?.Dispose ();
+					info.StderrWriter = null;
+				}
+			}
 
 			Output  = lines?.ToArray ();
-
-			if (LogTaskMessages) {
-				Log.LogMessage (MessageImportance.Low, $"  [Output] {nameof (Output)}:");
-				foreach (var line in (Output ?? new string [0]))
-					Log.LogMessage (MessageImportance.Low, $"    {line}");
-			}
 
 			return !Log.HasLoggedErrors;
 		}
 
-		protected override string GenerateCommandLineCommands ()
+		void LogFileWrite (string streamName, string outputFileName, bool appends)
 		{
-			return Arguments;
+			string op = appends ? "appending" : "writing";
+			Log.LogMessage (MessageImportance.Normal, $"  {op} {streamName} to file: {outputFileName}");
 		}
 
-		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
+		StreamWriter OpenOutputFile (string path, bool appendIfExists)
 		{
-			Log.LogMessage (MessageImportance.Low, singleLine);
-			Lines.Add (singleLine);
+			if (String.IsNullOrEmpty (path))
+				return null;
+
+			return new StreamWriter (appendIfExists ? File.Open (path, FileMode.Append) : File.Create (path));
 		}
+
+		protected virtual List <CommandInfo> GenerateCommandArguments ()
+		{
+			return new List <CommandInfo> {
+				new CommandInfo {
+					ArgumentsString = Arguments
+				}
+			};
+		}
+
+		protected virtual void BeforeCommand (int commandIndex, CommandInfo info)
+		{}
+
+		protected virtual void AfterCommand (int commandIndex, CommandInfo info)
+		{}
+
+		protected virtual void CustomizeProcessStartInfo (ProcessStartInfo psi)
+		{}
+
+		protected virtual void ProcessStdout (string line)
+		{}
+
+		protected virtual void ProcessStderr (string line)
+		{}
+
+		void OnOutput (string line, bool isStdout, CommandInfo info)
+		{
+			lock (linesLock) lines.Add (line);
+
+			if (!info.SuppressMSbuildLog) {
+				if (isStdout)
+					Log.LogMessage (MessageImportance.Low, line);
+				else
+					Log.LogWarning (line);
+			}
+
+			if (isStdout || info.MergeStdoutAndStderr) {
+				info.StdoutWriter?.WriteLine (line);
+				ProcessStdout (line);
+			} else {
+				info.StderrWriter?.WriteLine (line);
+				ProcessStderr (line);
+			}
+		}
+
+		int RunCommand (string commandPath, CommandInfo info)
+		{
+			var si = new ProcessStartInfo (commandPath) {
+				UseShellExecute = false,
+				CreateNoWindow = true,
+			};
+
+			if (!String.IsNullOrEmpty (WorkingDirectory))
+				si.WorkingDirectory = WorkingDirectory;
+
+			si.RedirectStandardOutput = true;
+			si.RedirectStandardError = true;
+			si.StandardOutputEncoding = Encoding.Default;
+			si.StandardErrorEncoding = Encoding.Default;
+			si.Arguments = info.Arguments;
+
+			if (EnvironmentVariables != null && EnvironmentVariables.Length > 0) {
+				foreach (string ev in EnvironmentVariables) {
+					string name;
+					string value;
+
+					int idx = ev.IndexOf ('=');
+					if (idx < 0) {
+						name = ev.Trim ();
+						value = String.Empty;
+					} else {
+						name = ev.Substring (0, idx).Trim ();
+						value = ev.Substring (idx + 1).Trim ();
+					}
+
+					if (String.IsNullOrEmpty (name)) {
+						Log.LogWarning ($"  Invalid environment variable definition: '{ev}'");
+						continue;
+					}
+
+					if (String.IsNullOrEmpty (value))
+						value = "1";
+
+					Log.LogMessage (MessageImportance.Low, $"  Defining environment variable: {name} = {value}");
+					si.EnvironmentVariables.Add (name, value);
+				}
+			}
+
+			CustomizeProcessStartInfo (si);
+
+			ManualResetEvent stdout_completed = null;
+			if (!si.RedirectStandardError)
+				si.StandardErrorEncoding = null;
+			else
+				stdout_completed = new ManualResetEvent (false);
+
+			ManualResetEvent stderr_completed = null;
+			if (!si.RedirectStandardOutput)
+				si.StandardOutputEncoding = null;
+			else
+				stderr_completed = new ManualResetEvent (false);
+
+			var p = new Process {
+				StartInfo = si
+			};
+			p.Start ();
+
+			var outputLock = new Object ();
+
+			if (si.RedirectStandardOutput) {
+				p.OutputDataReceived += (sender, e) => {
+					if (e.Data != null)
+						OnOutput (e.Data, true, info);
+					else
+						stdout_completed.Set ();
+				};
+				p.BeginOutputReadLine ();
+			}
+
+			if (si.RedirectStandardError) {
+				p.ErrorDataReceived += (sender, e) => {
+					if (e.Data != null)
+						OnOutput (e.Data, false, info);
+					else
+						stderr_completed.Set ();
+				};
+				p.BeginErrorReadLine ();
+			}
+
+			bool needToWait = true;
+			bool exited = true;
+			if (Timeout > 0) {
+				exited = p.WaitForExit (Timeout);
+				if (!exited) {
+					Log.LogWarning ($"  Process '{commandPath} {si.Arguments}' failed to exit within the timeout of {Timeout}ms, killing the process");
+					p.Kill ();
+				}
+
+				// We need to call the parameter-less WaitForExit only if any of the standard output
+				// streams have been redirected (see
+				// https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit?view=netframework-4.7.2#System_Diagnostics_Process_WaitForExit)
+				//
+				if (!si.RedirectStandardOutput && !si.RedirectStandardError)
+					needToWait = false;
+			}
+
+			if (needToWait)
+				p.WaitForExit ();
+
+			if (si.RedirectStandardError && stderr_completed != null)
+				stderr_completed.WaitOne (TimeSpan.FromSeconds (OutputTimeout));
+			if (si.RedirectStandardOutput && stdout_completed != null)
+				stdout_completed.WaitOne (TimeSpan.FromSeconds (OutputTimeout));
+
+			return exited? p.ExitCode : -1;
+		}
+
 	}
 }
 

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
@@ -11,8 +11,11 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 {
 	public class RunInstrumentationTests : Adb
 	{
-		public                  string              AdbTarget                   { get; set; }
-		public                  string              AdbOptions                  { get; set; }
+		const                   string              TestResultsPathResult       = "INSTRUMENTATION_RESULT: nunit2-results-path=";
+		const                   int                 StateRunInstrumentation     = 0;
+		const                   int                 StateGetLogcat              = 1;
+		const                   int                 StatePullFiles              = 2;
+		const                   int                 MaxState                    = StatePullFiles;
 
 		public                  string              TestFixture                 { get; set; }
 
@@ -26,22 +29,15 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		[Required]
 		public                  string              LogcatFilename              { get; set; }
 
+		[Required]
+		public                  string              PackageName                 { get; set; }
+
 		[Output]
 		public                  string              FailedToRun                 { get; set; }
 
 		public                  string              LogLevel                    { get; set; }
 
-		protected   override    bool                LogTaskMessages {
-			get { return false; }
-		}
-
-		enum ExecuteState {
-			RunInstrumentation,
-			PullFiles,
-			GetLogcat,
-		}
-
-		ExecuteState            executionState;
+		int                     currentState = -1;
 		string                  targetTestResultsPath;
 		TextWriter              logcatWriter;
 
@@ -57,88 +53,80 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				NUnit2TestResultsFile   = n.ToString ();
 			}
 
-			Log.LogMessage (MessageImportance.Low, $"Task {nameof (RunInstrumentationTests)}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (AdbTarget)}: {AdbTarget}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (AdbOptions)}: {AdbOptions}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (Component)}: {Component}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (InstrumentationArguments)}:");
-			foreach (var a in InstrumentationArguments) {
-				Log.LogMessage (MessageImportance.Low, $"    {a}:");
-			}
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (NUnit2TestResultsFile)}: {NUnit2TestResultsFile}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (LogcatFilename)}: {LogcatFilename}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (TestFixture)}: {TestFixture}");
-
-			executionState  = ExecuteState.RunInstrumentation;
 			base.Execute ();
 
-			using (logcatWriter = File.Exists (LogcatFilename) ? File.AppendText (LogcatFilename) : File.CreateText (LogcatFilename)) {
-				executionState = ExecuteState.GetLogcat;
-				base.Execute ();
-			}
-
-			if (string.IsNullOrEmpty (targetTestResultsPath)) {
+			if (String.IsNullOrEmpty (targetTestResultsPath)) {
 				FailedToRun = Component;
 				Log.LogError (
 						"Could not find NUnit2 results file after running component `{0}`: " +
 						"no `nunit2-results-path` bundle value found in command output!",
 						Component);
-				// Can return false once we use MSBuild and not xbuild
-				// return false;
-				return true;
+				return false;
 			}
-
-			executionState  = ExecuteState.PullFiles;
-			base.Execute ();
 
 			return !Log.HasLoggedErrors;
 		}
 
-		protected override string GenerateCommandLineCommands ()
+		protected override List <CommandInfo> GenerateCommandArguments ()
 		{
-			switch (executionState) {
-			case ExecuteState.RunInstrumentation:
-				var args = new StringBuilder ();
-				foreach (var a in InstrumentationArguments) {
-					var kvp = a.Split (new [] { '=' }, 2);
-					args.Append (" -e \"").Append (kvp [0]).Append ("\" \"");
-					args.Append (kvp.Length > 1 ? kvp [1] : "");
-					args.Append ("\"");
-				}
+			return new List <CommandInfo> {
+				new CommandInfo {
+					ArgumentsString = $"{AdbTarget} {AdbOptions} shell am instrument {GetRunInstrumentationArguments ()} -w \"{Component}\"",
+				},
 
-				if (!String.IsNullOrEmpty (LogLevel)) {
-					args.Append ($" -e \"loglevel {LogLevel}\"");
-				}
+				new CommandInfo {
+					ArgumentsString = $"{AdbTarget} {AdbOptions} logcat -v threadtime -d",
+				},
 
-				if (!string.IsNullOrWhiteSpace (TestFixture)) {
-					args.Append (" -e suite \"").Append (TestFixture).Append ("\"");
-				}
-				return $"{AdbTarget} {AdbOptions} shell am instrument {args.ToString ()} -w \"{Component}\"";
-			case ExecuteState.PullFiles:
-				return $"{AdbTarget} {AdbOptions} pull \"{targetTestResultsPath}\" \"{NUnit2TestResultsFile}\"";
-			case ExecuteState.GetLogcat:
-				return $"{AdbTarget} {AdbOptions} logcat -v threadtime -d";
-			}
-			throw new InvalidOperationException ($"Invalid state `{executionState}`!");
+				new CommandInfo {
+					ArgumentsGenerator = () => $"{AdbTarget} {AdbOptions} shell run-as {PackageName} cat \"{targetTestResultsPath}\"",
+					MergeStdoutAndStderr = false,
+					StdoutFilePath = NUnit2TestResultsFile,
+					SuppressMSbuildLog = true,
+					ShouldRun = () => !String.IsNullOrEmpty (targetTestResultsPath)
+				},
+			};
 		}
 
-		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
+		string GetRunInstrumentationArguments ()
 		{
-			if (executionState == ExecuteState.GetLogcat) {
-				logcatWriter.WriteLine (singleLine);
-				return;
+			var args = new StringBuilder ();
+			foreach (string a in InstrumentationArguments) {
+				string[] kvp = a.Split (new [] { '=' }, 2);
+				args.Append (" -e \"").Append (kvp [0]).Append ("\" \"");
+				args.Append (kvp.Length > 1 ? kvp [1] : "");
+				args.Append ("\"");
 			}
 
-			const string TestResultsPathResult  = "INSTRUMENTATION_RESULT: nunit2-results-path=";
+			if (!String.IsNullOrEmpty (LogLevel)) {
+				args.Append ($" -e \"loglevel {LogLevel}\"");
+			}
 
-			base.LogEventsFromTextOutput (singleLine, messageImportance);
+			if (!String.IsNullOrWhiteSpace (TestFixture)) {
+				args.Append (" -e suite \"").Append (TestFixture).Append ("\"");
+			}
 
-			if (string.IsNullOrEmpty (singleLine))
+			return args.ToString ();
+		}
+
+		protected override void BeforeCommand (int commandIndex, CommandInfo info)
+		{
+			if (commandIndex < 0 || commandIndex > MaxState)
+				throw new ArgumentOutOfRangeException (nameof (commandIndex));
+
+			currentState = commandIndex;
+		}
+
+		protected override void ProcessStdout (string line)
+		{
+			if (currentState != StateRunInstrumentation || String.IsNullOrEmpty (line))
 				return;
-			if (!singleLine.Contains (TestResultsPathResult))
+
+			int i = line.IndexOf (TestResultsPathResult, StringComparison.OrdinalIgnoreCase);
+			if (i < 0)
 				return;
-			var i = singleLine.IndexOf (TestResultsPathResult);
-			targetTestResultsPath   = singleLine.Substring (i + TestResultsPathResult.Length).Trim ();
+
+			targetTestResultsPath = line.Substring (i + TestResultsPathResult.Length).Trim ();
 		}
 	}
 }

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunUITests.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunUITests.cs
@@ -1,12 +1,13 @@
 ﻿using Microsoft.Build.Framework;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Xamarin.Android.Tools.BootstrapTasks
 {
 	public class RunUITests : Adb
 	{
-		public                  string              AdbTarget                   { get; set; }
-		public                  string              AdbOptions                  { get; set; }
+		const                   int                 StateRunTests               = 0;
+		const                   int                 StateGetLogcat              = 1;
 
 		[Required]
 		public                  string              Activity                    { get; set; }
@@ -14,48 +15,29 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		[Required]
 		public                  string              LogcatFilename              { get; set; }
 
-		protected   override    bool                LogTaskMessages {
-			get { return false; }
-		}
-
-		bool getLogcat;
-		TextWriter logcatWriter;
-
-
-		public override bool Execute ()
+		protected virtual void AfterCommand (int commandIndex, CommandInfo info)
 		{
-			Log.LogMessage (MessageImportance.Low, $"Task {nameof (RunUITests)}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (AdbTarget)}: {AdbTarget}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (AdbOptions)}: {AdbOptions}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (Activity)}: {Activity}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (LogcatFilename)}: {LogcatFilename}");
-
-			base.Execute ();
-
-			Log.LogMessage(MessageImportance.Low, $"  going to wait for 15 seconds");
-			System.Threading.Thread.Sleep (15000);
-
-			using (logcatWriter = File.Exists (LogcatFilename) ? File.AppendText (LogcatFilename) : File.CreateText (LogcatFilename)) {
-				getLogcat = true;
-				base.Execute ();
-			}
-
-			return !Log.HasLoggedErrors;
-		}
-
-		protected override string GenerateCommandLineCommands ()
-		{
-			return getLogcat ? $"{AdbTarget} {AdbOptions} logcat -v threadtime -d" : $"{AdbTarget} {AdbOptions} shell am start -n \"{Activity}\"";
-		}
-
-		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
-		{
-			if (getLogcat) {
-				logcatWriter.WriteLine (singleLine);
+			if (commandIndex != StateRunTests)
 				return;
-			}
 
-			base.LogEventsFromTextOutput (singleLine, messageImportance);
+			Log.LogMessage (MessageImportance.Low, $"  going to wait for 15 seconds");
+			System.Threading.Thread.Sleep (15000);
+		}
+
+		protected override List <CommandInfo> GenerateCommandArguments ()
+		{
+			return new List <CommandInfo> {
+				new CommandInfo {
+					ArgumentsString = $"{AdbTarget} {AdbOptions} shell am start -n \"{Activity}\"",
+				},
+
+				new CommandInfo {
+					ArgumentsString = $"{AdbTarget} {AdbOptions} logcat -v threadtime -d",
+					MergeStdoutAndStderr = false,
+					StdoutFilePath = LogcatFilename,
+					StdoutAppend = File.Exists (LogcatFilename)
+				},
+			};
 		}
 	}
 }

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -48,6 +48,7 @@ ALL_HOST_ABIS = \
 	$(shell uname)
 
 ALL_AOT_ABIS = \
+	armeabi-v7a \
 	arm64 \
 	x86 \
 	x86_64 \

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -24,7 +24,7 @@
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)"
         Timeout="60000">
-      <Output TaskParameter="AdbTarget"     PropertyName="_AdbTarget" />
+      <Output TaskParameter="DetectedAdbTarget"     PropertyName="_AdbTarget" />
       <Output TaskParameter="IsValidTarget" PropertyName="_ValidAdbTarget"  />
     </Xamarin.Android.Tools.BootstrapTasks.CheckAdbTarget>
     <CreateAndroidEmulator
@@ -162,6 +162,7 @@
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)"
         Timeout="120000"
+	IgnoreExitCode="true"
     />
   </Target>
 
@@ -184,6 +185,7 @@
         AdbTarget="$(_AdbTarget)"
         AdbOptions="$(AdbOptions)"
         LogLevel="Verbose"
+	PackageName="%(TestApkInstrumentation.Package)"
         Component="%(TestApkInstrumentation.Package)/%(TestApkInstrumentation.Identity)"
         NUnit2TestResultsFile="%(TestApkInstrumentation.ResultsPath)"
         LogcatFilename="$(_LogcatFilenameBase)-%(TestApkInstrumentation.Package).txt"

--- a/src/Mono.Android/Test/Mono.Android-Tests.csproj
+++ b/src/Mono.Android/Test/Mono.Android-Tests.csproj
@@ -18,12 +18,10 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
+    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
   <Import Project="..\..\..\Configuration.props" />
-  <PropertyGroup>
-    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <Optimize>false</Optimize>

--- a/src/Mono.Android/Test/Mono.Android-Tests.projitems
+++ b/src/Mono.Android/Test/Mono.Android-Tests.projitems
@@ -22,5 +22,13 @@
       <Package>Mono.Android_Tests</Package>
       <ResultsPath>$(OutputPath)TestResult-Mono.Android_Tests.xml</ResultsPath>
     </TestApkInstrumentation>
+
+    <TestApkPermission Include="READ_EXTERNAL_STORAGE">
+      <Package>Mono.Android_Tests</Package>
+    </TestApkPermission>
+
+    <TestApkPermission Include="WRITE_EXTERNAL_STORAGE">
+      <Package>Mono.Android_Tests</Package>
+    </TestApkPermission>
   </ItemGroup>
 </Project>

--- a/src/Mono.Android/Test/Properties/AndroidManifest.xml
+++ b/src/Mono.Android/Test/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Mono.Android_Tests">
-	<uses-sdk android:minSdkVersion="14" />
+	<uses-sdk android:minSdkVersion="14" android:targetSdkVersion="22" />
 	<application android:label="Xamarin.Android.RuntimeTests" android:name="android.apptests.App">
 		<activity
 				android:name="android.apptests.RenamedActivity"
@@ -9,4 +9,6 @@
 	</application>
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.SET_TIME_ZONE" />
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Properties/AndroidManifest.xml
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Properties/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Xamarin.Android.JcwGen_Tests">
-	<uses-sdk android:minSdkVersion="14" />
+	<uses-sdk android:minSdkVersion="14" android:targetSdkVersion="22" />
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<application android:label="Xamarin.Android.JcwGen-Tests">
 	</application>
 </manifest>

--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.csproj
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.csproj
@@ -17,11 +17,11 @@
     <AssemblyName>Xamarin.Android.JcwGen-Tests</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
+    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
   <Import Project="..\..\..\Configuration.props" />
-  <PropertyGroup>
-    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.projitems
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.projitems
@@ -17,5 +17,13 @@
       <Package>Xamarin.Android.JcwGen_Tests</Package>
       <ResultsPath>$(OutputPath)TestResult-Xamarin.Android.JcwGen_Tests.xml</ResultsPath>
     </TestApkInstrumentation>
+
+    <TestApkPermission Include="READ_EXTERNAL_STORAGE">
+      <Package>Xamarin.Android.JcwGen_Tests</Package>
+    </TestApkPermission>
+
+    <TestApkPermission Include="WRITE_EXTERNAL_STORAGE">
+      <Package>Xamarin.Android.JcwGen_Tests</Package>
+    </TestApkPermission>
   </ItemGroup>
 </Project>

--- a/tests/locales/Xamarin.Android.Locale-Tests/Properties/AndroidManifest.xml
+++ b/tests/locales/Xamarin.Android.Locale-Tests/Properties/AndroidManifest.xml
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Xamarin.Android.Locale_Tests">
-	<uses-sdk android:minSdkVersion="14" />
+	<uses-sdk android:minSdkVersion="14" android:targetSdkVersion="22" />
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<application android:label="Xamarin.Android.Locale-Tests">
 	</application>
 </manifest>

--- a/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj
+++ b/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj
@@ -18,12 +18,10 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
+    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
   <Import Project="..\..\..\Configuration.props" />
-  <PropertyGroup>
-    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.projitems
+++ b/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.projitems
@@ -10,5 +10,13 @@
       <Package>Xamarin.Android.Locale_Tests</Package>
       <ResultsPath>$(OutputPath)TestResult-Xamarin.Android.Locale_Tests.xml</ResultsPath>
     </TestApkInstrumentation>
+
+    <TestApkPermission Include="READ_EXTERNAL_STORAGE">
+      <Package>Xamarin.Android.Locale_Tests</Package>
+    </TestApkPermission>
+
+    <TestApkPermission Include="WRITE_EXTERNAL_STORAGE">
+      <Package>Xamarin.Android.Locale_Tests</Package>
+    </TestApkPermission>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The `leeroy` make target failed with a "file not found" exception while
attempting to invoke the `cross-arm` crosscompiler and the reason for this was
that `cross-arm` was never built because of the `armeabi-v7a` target missing in
the `ALL_AOT_ABIS` make variable in the `build-tools/scripts/BuildEverything.mk`
file.

This commit adds the missing target architecture and fixes the build.