### PR TITLE
Lazy magic marshaling types map initialization

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -291,14 +291,12 @@ namespace Android.Runtime {
 
 			static MagicRegistrationMap ()
 			{
-				typesMap = new Dictionary<string, int> ();
-
 				Prefill ();
 			}
 
 			static public bool Filled {
 				get {
-					return typesMap.Count > 0;
+					return typesMap != null && typesMap.Count > 0;
 				}
 			}
 


### PR DESCRIPTION
Initialize the types map in `Prefill` method, updated by the
linker. Also pass the types count to the dictionary constructor to
improve performance and optimize memory allocation.

An example of `MagicRegistrationMap::Prefill` method, updated by the
linker, with the new code:

    using System.Collections.Generic;

    private static void Prefill ()
    {
    	MagicRegistrationMap.typesMap = new Dictionary<string, int> (5);
    	MagicRegistrationMap.typesMap ["xatemplateaot.MainActivity"] = 0;
    	MagicRegistrationMap.typesMap ["Android.Runtime.UncaughtExceptionHandler"] = 1;
    	MagicRegistrationMap.typesMap ["Android.Views.View+IOnClickListenerImplementor"] = 2;
    	MagicRegistrationMap.typesMap ["Java.Lang.Thread+RunnableImplementor"] = 3;
    	MagicRegistrationMap.typesMap ["Java.Interop.TypeManager+JavaTypeManager"] = 4;
    }