### PR TITLE
[monodroid] Add java-interop-jvm.c to desktop libmonodroid

### DIFF
--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -36,6 +36,7 @@ if(NOT ANDROID)
   set(MONODROID_SOURCES
     ${MONODROID_SOURCES}
     ${JAVA_INTEROP_SRC_PATH}/java-interop-gc-bridge-mono.c
+    ${JAVA_INTEROP_SRC_PATH}/java-interop-jvm.c
     )
 endif()
 


### PR DESCRIPTION
So that `jnimarshalmethod-gen.exe` (and possible future desktop
utilities, which would use JVM) work.