### PR TITLE
[Xamarin.Android.Build.Tasks] _CopyIntermediateAssemblies uses CopyIfChanged

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1943,20 +1943,15 @@ because xbuild doesn't support framework reference assemblies.
 	Outputs="@(ResolvedUserAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
 	DependsOnTargets="_ResolveAssemblies;_ResolveSatellitePaths;_CreatePackageWorkspace;_CreateIntermediateAssembliesDir;_CopyConfigFiles">
 	<!-- Make a copy of every assembly we need in assemblies -->
-	<Copy
+	<CopyIfChanged
 		SourceFiles="@(ResolvedAssemblies)"
 		DestinationFiles="@(ResolvedAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
-		SkipUnchangedFiles="true" />
-	<Copy
+	/>
+	<CopyIfChanged
 		SourceFiles="@(_AndroidResolvedSatellitePaths)"
 		DestinationFiles="@(_AndroidResolvedSatellitePaths->'$(MonoAndroidLinkerInputDir)%(DestinationSubDirectory)%(Filename)%(Extension)')"
-		SkipUnchangedFiles="true"
 	/>
 	<Delete Files="@(ResolvedAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension).mdb')" />
-	<ItemGroup>
-		<_IntermediateAssemblyFiles Include="$(MonoAndroidLinkerInputDir)*" />
-	</ItemGroup>
-	<Touch Files="@(_IntermediateAssemblyFiles)" />
 </Target>
 
 <Target Name="_CollectConfigFiles"


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/2088

970da9ef was a good step towards "correctness" in building
incrementally in the following scenario:
- File | New Xamarin.Forms project | NetStandard library
- Build
- Change XAML
- Build

In this scenario, there is now a new target rising to the surface we
can improve:

    276 ms  _CopyIntermediateAssemblies                1 calls

Looking at the target, it seems we could use the `CopyIfChanged` task
here more effectively. This task will automaticaly set the timestamps
of files that have been copied, and so we don't need any subsequent
`<ItemGroup />` or `<Touch />` elements. It was also touching *all*
files instead of just the ones that were changed.

After this change:

    33 ms  _CopyIntermediateAssemblies                1 calls

The overall build went from 7.058s to 6.652s, so there must be some
other targets that benefit from the timestamps not changing on *all*
of these files.