### PR TITLE
[Xamarin.Android.Build.Tasks] Add ConvertCustomView Task

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
@@ -83,8 +83,8 @@ namespace Xamarin.Android.Tasks {
 			/* Some attributes reference a Java class name.
 			 * try to convert those like for TryFixCustomView
 			 */
-			if (attr.Name != (res_auto + "layout_behavior")                              // For custom CoordinatorLayout behavior
-			    && (attr.Parent.Name != "transition" || attr.Name.LocalName != "class")) // For custom transitions
+			if (attr.Name != (res_auto + "layout_behavior") &&                            // For custom CoordinatorLayout behavior
+			    		(attr.Parent.Name != "transition" || attr.Name.LocalName != "class")) // For custom transitions
 				return false;
 
 			if (!acwMap.TryGetValue (attr.Value, out string mappedValue))

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
@@ -1,0 +1,152 @@
+// Copyright (C) 2018 Microsoft, Inc. All rights reserved.
+
+using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Monodroid;
+
+namespace Xamarin.Android.Tasks {
+	public class ConvertCustomView : Task {
+
+		[Required]
+		public string CustomViewMapFile { get; set; }
+
+		[Required]
+		public string AcwMapFile { get; set; }
+
+		public string ResourceNameCaseMap { get; set; }
+
+		public ITaskItem [] ResourceDirectories { get; set; }
+
+		public override bool Execute ()
+		{
+			var resource_name_case_map = MonoAndroidHelper.LoadResourceCaseMap (ResourceNameCaseMap);
+			var acw_map = MonoAndroidHelper.LoadAcwMapFile (AcwMapFile);
+			var customViewMap = MonoAndroidHelper.LoadCustomViewMapFile (BuildEngine4, CustomViewMapFile);
+			var processed = new HashSet<string> ();
+
+			foreach (var kvp in acw_map) {
+				var key = kvp.Key;
+				var value = kvp.Value;
+				if (key == value)
+					continue;
+				if (customViewMap.TryGetValue (key, out HashSet<string> resourceFiles)) {
+					foreach (var file in resourceFiles) {
+						if (processed.Contains (file))
+							continue;
+						if (!File.Exists (file))
+							continue;
+						var document = XDocument.Load (file);
+						var e = document.Root;
+						bool update = false;
+						foreach (var elem in AndroidResource.GetElements (e).Prepend (e)) {
+							update |= TryFixCustomView (elem, acw_map, (t, m) => {
+								string targetfile = file;
+								ITaskItem resdir = ResourceDirectories?.FirstOrDefault (x => file.StartsWith (x.ItemSpec)) ?? null;
+								if (resdir != null && targetfile.StartsWith (resdir.ItemSpec, StringComparison.InvariantCultureIgnoreCase)) {
+									targetfile = file.Substring (resdir.ItemSpec.Length).TrimStart (Path.DirectorySeparatorChar);
+									if (resource_name_case_map.TryGetValue (targetfile, out string temp))
+										targetfile = temp;
+									targetfile = Path.Combine ("Resources", targetfile);
+								}
+								switch (t) {
+								case TraceLevel.Error:
+									Log.LogCodedError ("XA1002", file: targetfile, lineNumber: 0, message: m);
+									break;
+								case TraceLevel.Warning:
+									Log.LogCodedWarning ("XA1001", file: targetfile, lineNumber: 0, message: m);
+									break;
+								default:
+									Log.LogDebugMessage (m);
+									break;
+								}
+							});
+						}
+						foreach (XAttribute a in AndroidResource.GetAttributes (e)) {
+							update |= TryFixCustomClassAttribute (a, acw_map);
+							update |= TryFixFragment (a, acw_map);
+						}
+						if (update) {
+							document.Save (file);
+						}
+						processed.Add (file);
+					}
+				}
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+
+		static readonly XNamespace res_auto = "http://schemas.android.com/apk/res-auto";
+		static readonly XNamespace android = "http://schemas.android.com/apk/res/android";
+
+		bool TryFixCustomClassAttribute (XAttribute attr, Dictionary<string, string> acwMap)
+		{
+			/* Some attributes reference a Java class name.
+			 * try to convert those like for TryFixCustomView
+			 */
+			if (attr.Name != (res_auto + "layout_behavior")                              // For custom CoordinatorLayout behavior
+			    && (attr.Parent.Name != "transition" || attr.Name.LocalName != "class")) // For custom transitions
+				return false;
+
+			if (!acwMap.TryGetValue (attr.Value, out string mappedValue))
+				return false;
+
+			attr.Value = mappedValue;
+			return true;
+		}
+
+		bool TryFixFragment (XAttribute attr, Dictionary<string, string> acwMap)
+		{
+			// Looks for any: 
+			//   <fragment class="My.DotNet.Class" 
+			//   <fragment android:name="My.DotNet.Class" ...
+			// and tries to change it to the ACW name
+			if (attr.Parent.Name != "fragment")
+				return false;
+
+			if (attr.Name == "class" || attr.Name == android + "name") {
+				if (acwMap.TryGetValue (attr.Value, out string mappedValue)) {
+					attr.Value = mappedValue;
+
+					return true;
+				} else if (attr.Value?.Contains (',') ?? false) {
+					// attr.Value could be an assembly-qualified name that isn't in acw-map.txt;
+					// see e5b1c92c, https://github.com/xamarin/xamarin-android/issues/1296#issuecomment-365091948
+					var n = attr.Value.Substring (0, attr.Value.IndexOf (','));
+					if (acwMap.TryGetValue (n, out mappedValue)) {
+						attr.Value = mappedValue;
+						return true;
+					}
+				}
+			}
+
+			return false;
+		}
+
+		bool TryFixCustomView (XElement elem, Dictionary<string, string> acwMap, Action<TraceLevel, string> logMessage = null)
+		{
+			// Looks for any <My.DotNet.Class ...
+			// and tries to change it to the ACW name
+			string name = elem.Name.ToString ();
+			if (acwMap.TryGetValue (name, out string mappedValue)) {
+				elem.Name = mappedValue;
+				return true;
+			}
+			if (logMessage == null)
+				return false;
+			var matchingKey = acwMap.FirstOrDefault (x => String.Equals (x.Key, name, StringComparison.OrdinalIgnoreCase));
+			if (matchingKey.Key != null) {
+				// we have elements with slightly different casing.
+				// lets issue a error.
+				logMessage (TraceLevel.Error, $"We found a matching key '{matchingKey.Key}' for '{name}'. But the casing was incorrect. Please correct the casing");
+			}
+			return false;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
@@ -45,24 +45,17 @@ namespace Xamarin.Android.Tasks {
 						var e = document.Root;
 						bool update = false;
 						foreach (var elem in AndroidResource.GetElements (e).Prepend (e)) {
-							update |= TryFixCustomView (elem, acw_map, (t, m) => {
-								string targetfile = file;
+							update |= TryFixCustomView (elem, acw_map, (level, message) => {
 								ITaskItem resdir = ResourceDirectories?.FirstOrDefault (x => file.StartsWith (x.ItemSpec)) ?? null;
-								if (resdir != null && targetfile.StartsWith (resdir.ItemSpec, StringComparison.InvariantCultureIgnoreCase)) {
-									targetfile = file.Substring (resdir.ItemSpec.Length).TrimStart (Path.DirectorySeparatorChar);
-									if (resource_name_case_map.TryGetValue (targetfile, out string temp))
-										targetfile = temp;
-									targetfile = Path.Combine ("Resources", targetfile);
-								}
-								switch (t) {
+								switch (level) {
 								case TraceLevel.Error:
-									Log.LogCodedError ("XA1002", file: targetfile, lineNumber: 0, message: m);
+									Log.FixupResourceFilenameAndLogCodedError ("XA1002", message, file, resdir.ItemSpec, resource_name_case_map);
 									break;
 								case TraceLevel.Warning:
-									Log.LogCodedWarning ("XA1001", file: targetfile, lineNumber: 0, message: m);
+									Log.FixupResourceFilenameAndLogCodedError ("XA1001", message, file, resdir.ItemSpec, resource_name_case_map);
 									break;
 								default:
-									Log.LogDebugMessage (m);
+									Log.LogDebugMessage (message);
 									break;
 								}
 							});

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -88,26 +88,19 @@ namespace Xamarin.Android.Tasks
 				MonoAndroidHelper.SetWriteable (file);
 				try {
 					bool success = AndroidResource.UpdateXmlResource (resdir, file, acwMap,
-						resourcedirectories, (t, m) => {
-							string targetfile = file;
-							if (targetfile.StartsWith (resdir, StringComparison.InvariantCultureIgnoreCase)) {
-								targetfile = file.Substring (resdir.Length).TrimStart (Path.DirectorySeparatorChar);
-								if (resource_name_case_map.TryGetValue (targetfile, out string temp))
-									targetfile = temp;
-								targetfile = Path.Combine ("Resources", targetfile);
+						resourcedirectories, (level, message) => {
+							switch (level) {
+							case TraceLevel.Error:
+								Log.FixupResourceFilenameAndLogCodedError ("XA1002", message, file, resdir, resource_name_case_map);
+								break;
+							case TraceLevel.Warning:
+								Log.FixupResourceFilenameAndLogCodedError ("XA1001", message, file, resdir, resource_name_case_map);
+								break;
+							default:
+								Log.LogDebugMessage (message);
+								break;
 							}
-							switch (t) {
-								case TraceLevel.Error:
-									Log.LogCodedError ("XA1002", file: targetfile, lineNumber: 0, message: m);
-									break;
-								case TraceLevel.Warning:
-									Log.LogCodedWarning ("XA1001", file: targetfile, lineNumber: 0, message: m);
-									break;
-								default:
-									Log.LogDebugMessage (m);
-									break;
-							}
-					}, registerCustomView : (e, filename) => {
+						}, registerCustomView : (e, filename) => {
 						if (customViewMap == null)
 							return;
 						HashSet<string> set;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -19,25 +19,30 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string AcwMapFile { get; set; }
 
+		[Required]
+		public string CustomViewMapFile { get; set; }
+
 		public string AndroidConversionFlagFile { get; set; }
 
 		public string ResourceNameCaseMap { get; set; }
 
 		Dictionary<string,string> resource_name_case_map;
+		Dictionary<string, HashSet<string>> customViewMap;
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("ConvertResourcesCases Task");
-			Log.LogDebugMessage ("  ResourceDirectories: {0}", ResourceDirectories);
-			Log.LogDebugMessage ("  AcwMapFile: {0}", AcwMapFile);
-			Log.LogDebugMessage ("  AndroidConversionFlagFile: {0}", AndroidConversionFlagFile);
-			Log.LogDebugMessage ("  ResourceNameCaseMap: {0}", ResourceNameCaseMap);
-
 			resource_name_case_map = MonoAndroidHelper.LoadResourceCaseMap (ResourceNameCaseMap);
 			var acw_map = MonoAndroidHelper.LoadAcwMapFile (AcwMapFile);
 
+
+			if (CustomViewMapFile != null)
+				customViewMap = Xamarin.Android.Tasks.MonoAndroidHelper.LoadCustomViewMapFile (BuildEngine4, CustomViewMapFile);
+
 			// Look in the resource xml's for capitalized stuff and fix them
 			FixupResources (acw_map);
+
+			if (customViewMap != null)
+				Xamarin.Android.Tasks.MonoAndroidHelper.SaveCustomViewMapFile (BuildEngine4, CustomViewMapFile, customViewMap);
 
 			return true;
 		}
@@ -80,11 +85,9 @@ namespace Xamarin.Android.Tasks
 					continue;
 				}
 				Log.LogDebugMessage ("  Processing: {0}   {1} > {2}", file, srcmodifiedDate, lastUpdate);
-				var tmpdest = Path.GetTempFileName ();
-				File.Copy (file, tmpdest, overwrite: true);
-				MonoAndroidHelper.SetWriteable (tmpdest);
+				MonoAndroidHelper.SetWriteable (file);
 				try {
-					bool success = AndroidResource.UpdateXmlResource (resdir, tmpdest, acwMap,
+					bool success = AndroidResource.UpdateXmlResource (resdir, file, acwMap,
 						resourcedirectories, (t, m) => {
 							string targetfile = file;
 							if (targetfile.StartsWith (resdir, StringComparison.InvariantCultureIgnoreCase)) {
@@ -104,7 +107,14 @@ namespace Xamarin.Android.Tasks
 									Log.LogDebugMessage (m);
 									break;
 							}
-						});
+					}, registerCustomView : (e, filename) => {
+						if (customViewMap == null)
+							return;
+						HashSet<string> set;
+						if (!customViewMap.TryGetValue (e, out set))
+							customViewMap.Add (e, set = new HashSet<string> ());
+						set.Add (filename);
+					});
 					if (!success) {
 						//If we failed to write the file, a warning is logged, we should skip to the next file
 						continue;
@@ -115,11 +125,11 @@ namespace Xamarin.Android.Tasks
 					// doesn't support those type of BOM (it really wants the document to start
 					// with "<?"). Since there is no way to plug into the file saving mechanism in X.S
 					// we strip those here and point the designer to use resources from obj/
-					MonoAndroidHelper.CleanBOM (tmpdest);
+					MonoAndroidHelper.CleanBOM (file);
 
-					MonoAndroidHelper.CopyIfChanged (tmpdest, file);
+
 				} finally {
-					File.Delete (tmpdest);
+
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyAndConvertResources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyAndConvertResources.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -23,10 +24,18 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string CacheFile { get; set; }
 
+		[Required]
+		public string CustomViewMapFile { get; set; }
+
+		public ITaskItem [] ResourceDirectories { get; set; }
+
+		public string ResourceNameCaseMap { get; set; }
+
 		[Output]
 		public ITaskItem[] ModifiedFiles { get; set; }
 
 		private List<ITaskItem> modifiedFiles = new List<ITaskItem>();
+		Dictionary<string, HashSet<string>> customViewMap;
 
 		public override bool Execute ()
 		{
@@ -39,6 +48,10 @@ namespace Xamarin.Android.Tasks
 				throw new ArgumentException ("source and destination count mismatch");
 
 			var acw_map = MonoAndroidHelper.LoadAcwMapFile (AcwMapFile);
+			var resource_name_case_map = MonoAndroidHelper.LoadResourceCaseMap (ResourceNameCaseMap);
+
+			if (CustomViewMapFile != null)
+				customViewMap = Xamarin.Android.Tasks.MonoAndroidHelper.LoadCustomViewMapFile (BuildEngine4, CustomViewMapFile);
 
 			var xmlFilesToUpdate = new Dictionary<string,string> ();
 			for (int i = 0; i < SourceFiles.Length; i++) {
@@ -85,11 +98,32 @@ namespace Xamarin.Android.Tasks
 				var dstmodifiedDate = File.Exists (destfilename) ? File.GetLastWriteTimeUtc (destfilename) : DateTime.MinValue;
 				var tmpdest = Path.GetTempFileName ();
 				var res = Path.Combine (Path.GetDirectoryName (filename), "..");
-				MonoAndroidHelper.CopyIfChanged (filename, tmpdest);
-				MonoAndroidHelper.SetWriteable (tmpdest);
+				MonoAndroidHelper.CopyIfChanged (filename, destfilename);
+				MonoAndroidHelper.SetWriteable (destfilename);
 				try {
-					AndroidResource.UpdateXmlResource (res, tmpdest, acw_map);
-					if (MonoAndroidHelper.CopyIfChanged (tmpdest, destfilename)) {
+					var updated = AndroidResource.UpdateXmlResource (res, destfilename, acw_map, logMessage: (level, message) => {
+						ITaskItem resdir = ResourceDirectories?.FirstOrDefault (x => filename.StartsWith (x.ItemSpec)) ?? null;
+						switch (level) {
+						case TraceLevel.Error:
+							Log.FixupResourceFilenameAndLogCodedError ("XA1002", message, filename, resdir.ItemSpec, resource_name_case_map);
+							break;
+						case TraceLevel.Warning:
+							Log.FixupResourceFilenameAndLogCodedError ("XA1001", message, filename, resdir.ItemSpec, resource_name_case_map);
+							break;
+						default:
+							Log.LogDebugMessage (message);
+							break;
+						}
+					}, registerCustomView: (e, file) => {
+						if (customViewMap == null)
+							return;
+						HashSet<string> set;
+						if (!customViewMap.TryGetValue (e, out set))
+							customViewMap.Add (e, set = new HashSet<string> ());
+						set.Add (file);
+
+					});
+					if (updated) {
 						if (!modifiedFiles.Any (i => i.ItemSpec == destfilename))
 							modifiedFiles.Add (new TaskItem (destfilename));
 					}
@@ -101,6 +135,9 @@ namespace Xamarin.Android.Tasks
 			ModifiedFiles = modifiedFiles.ToArray ();
 
 			Log.LogDebugTaskItems (" ModifiedFiles:", ModifiedFiles);
+
+			if (customViewMap != null)
+				Xamarin.Android.Tasks.MonoAndroidHelper.SaveCustomViewMapFile (BuildEngine4, CustomViewMapFile, customViewMap);
 
 			return true;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ConvertResourcesCasesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ConvertResourcesCasesTests.cs
@@ -25,6 +25,8 @@ namespace Xamarin.Android.Build.Tests {
 <LinearLayout xmlns:android='http://schemas.android.com/apk/res/android'>
 <ClassLibrary1.CustomView xmlns:android='http://schemas.android.com/apk/res/android' />
 <classlibrary1.CustomView xmlns:android='http://schemas.android.com/apk/res/android' />
+<fragment android:name='classlibrary1.CustomView' />
+<fragment class='ClassLibrary1.CustomView' />
 </LinearLayout>
 ");
 			var errors = new List<BuildErrorEventArgs> ();
@@ -36,11 +38,21 @@ namespace Xamarin.Android.Build.Tests {
 				new TaskItem (resPath),
 			};
 			task.AcwMapFile = Path.Combine (path, "acwmap.txt");
+			task.CustomViewMapFile = Path.Combine (path, "classmap.txt");
 			File.WriteAllLines (task.AcwMapFile, new string [] {
 				"ClassLibrary1.CustomView;md5d6f7135293df7527c983d45d07471c5e.CustomTextView",
 				"classlibrary1.CustomView;md5d6f7135293df7527c983d45d07471c5e.CustomTextView",
 			});
 			Assert.IsTrue (task.Execute (), "Task should have executed successfully");
+			var custom = new ConvertCustomView () {
+				BuildEngine = engine,
+				CustomViewMapFile = task.CustomViewMapFile,
+				AcwMapFile = task.AcwMapFile,
+				ResourceDirectories = new ITaskItem [] {
+					new TaskItem (resPath),
+				},
+			};
+			Assert.IsTrue (custom.Execute (), "Task should have executed successfully");
 			var output = File.ReadAllText (Path.Combine (resPath, "layout", "main.xml"));
 			StringAssert.Contains ("md5d6f7135293df7527c983d45d07471c5e.CustomTextView", output, "md5d6f7135293df7527c983d45d07471c5e.CustomTextView should exist in the main.xml");
 			StringAssert.DoesNotContain ("ClassLibrary1.CustomView", output, "ClassLibrary1.CustomView should have been replaced.");
@@ -59,6 +71,8 @@ namespace Xamarin.Android.Build.Tests {
 <LinearLayout xmlns:android='http://schemas.android.com/apk/res/android'>
 <ClassLibrary1.CustomView xmlns:android='http://schemas.android.com/apk/res/android' />
 <classLibrary1.CustomView xmlns:android='http://schemas.android.com/apk/res/android' />
+<fragment android:name='classLibrary1.CustomView' />
+<fragment class='ClassLibrary1.CustomView' />
 </LinearLayout>
 ");
 			var errors = new List<BuildErrorEventArgs> ();
@@ -70,17 +84,29 @@ namespace Xamarin.Android.Build.Tests {
 				new TaskItem (resPath),
 			};
 			task.AcwMapFile = Path.Combine (path, "acwmap.txt");
+			task.CustomViewMapFile = Path.Combine (path, "classmap.txt");
 			File.WriteAllLines (task.AcwMapFile, new string [] {
 				"ClassLibrary1.CustomView;md5d6f7135293df7527c983d45d07471c5e.CustomTextView",
 				"classlibrary1.CustomView;md5d6f7135293df7527c983d45d07471c5e.CustomTextView",
 			});
 			Assert.IsTrue (task.Execute (), "Task should have executed successfully");
+			var custom = new ConvertCustomView () {
+				BuildEngine = engine,
+				CustomViewMapFile = task.CustomViewMapFile,
+				AcwMapFile = task.AcwMapFile,
+				ResourceDirectories = new ITaskItem [] {
+					new TaskItem (resPath),
+				},
+			};
+			Assert.IsFalse (custom.Execute (), "Task should have executed successfully");
 			var output = File.ReadAllText (Path.Combine (resPath, "layout", "main.xml"));
 			StringAssert.Contains ("md5d6f7135293df7527c983d45d07471c5e.CustomTextView", output, "md5d6f7135293df7527c983d45d07471c5e.CustomTextView should exist in the main.xml");
 			StringAssert.DoesNotContain ("ClassLibrary1.CustomView", output, "ClassLibrary1.CustomView should have been replaced.");
 			StringAssert.Contains ("classLibrary1.CustomView", output, "classLibrary1.CustomView should have been replaced.");
 			Assert.AreEqual (1, errors.Count, "One Error should have been raised.");
 			Assert.AreEqual ("XA1002", errors [0].Code, "XA1002 should have been raised.");
+			var expected = Path.Combine ("Resources", "layout", "main.xml");
+			Assert.AreEqual (expected, errors [0].File, $"Error should have the \"{expected}\" path. But contained \"{errors [0].File}\"");
 			Directory.Delete (path, recursive: true);
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
@@ -11,26 +11,27 @@ using System.Xml.XPath;
 namespace Monodroid {
 	static class AndroidResource {
 		
-		public static bool UpdateXmlResource (string res, string filename, Dictionary<string, string> acwMap, IEnumerable<string> additionalDirectories = null, Action<TraceLevel, string> logMessage = null)
+		public static bool UpdateXmlResource (string res, string filename, Dictionary<string, string> acwMap, IEnumerable<string> additionalDirectories = null, Action<TraceLevel, string> logMessage = null, Action<string, string> registerCustomView = null)
 		{
 			// use a temporary file so we only update the real file if things actually changed
 			string tmpfile = filename + ".bk";
 			try {
 				XDocument doc = XDocument.Load (filename, LoadOptions.SetLineInfo);
-
-				UpdateXmlResource (res, doc.Root, acwMap, additionalDirectories, logMessage);
+				UpdateXmlResource (res, doc.Root, acwMap, additionalDirectories, logMessage, (e) => {
+					registerCustomView?.Invoke (e, filename);
+				});
 				using (var stream = File.OpenWrite (tmpfile))
 					using (var xw = new LinePreservedXmlWriter (new StreamWriter (stream)))
 						xw.WriteNode (doc.CreateNavigator (), false);
-				Xamarin.Android.Tasks.MonoAndroidHelper.CopyIfChanged (tmpfile, filename);
-				File.Delete (tmpfile);
-				return true;
+
+				return Xamarin.Android.Tasks.MonoAndroidHelper.CopyIfChanged (tmpfile, filename);
 			} catch (Exception e) {
+				logMessage?.Invoke (TraceLevel.Warning, $"AndroidResgen: Warning while updating Resource XML '{filename}': {e.Message}");
+				return false;
+			} finally {
 				if (File.Exists (tmpfile)) {
 					File.Delete (tmpfile);
 				}
-				logMessage?.Invoke (TraceLevel.Warning, $"AndroidResgen: Warning while updating Resource XML '{filename}': {e.Message}");
-				return false;
 			}
 		}
 
@@ -54,17 +55,17 @@ namespace Monodroid {
 			UpdateXmlResource (null, e, acwMap);
 		}
 
-		static IEnumerable<T> Prepend<T> (this IEnumerable<T> l, T another) where T : XNode
+		internal static IEnumerable<T> Prepend<T> (this IEnumerable<T> l, T another) where T : XNode
 		{
 			yield return another;
 			foreach (var e in l)
 				yield return e;
 		}
 		
-		static void UpdateXmlResource (string resourcesBasePath, XElement e, Dictionary<string, string> acwMap, IEnumerable<string> additionalDirectories = null, Action<TraceLevel, string> logMessage = null)
+		static void UpdateXmlResource (string resourcesBasePath, XElement e, Dictionary<string, string> acwMap, IEnumerable<string> additionalDirectories = null, Action<TraceLevel, string> logMessage = null, Action<string> registerCustomView = null)
 		{
 			foreach (var elem in GetElements (e).Prepend (e)) {
-				TryFixCustomView (elem, acwMap, logMessage);
+				registerCustomView?.Invoke (elem.Name.ToString ());
 			}
 
 			foreach (var path in fixResourcesAliasPaths) {
@@ -77,14 +78,12 @@ namespace Monodroid {
 				if (a.IsNamespaceDeclaration)
 					continue;
 
-				if (TryFixFragment (a, acwMap))
-					continue;
+				TryFixFragment (a, acwMap, registerCustomView);
 				
 				if (TryFixResAuto (a, acwMap))
 					continue;
 
-				if (TryFixCustomClassAttribute (a, acwMap))
-					continue;
+				TryFixCustomClassAttribute (a, acwMap, registerCustomView);
 
 				if (a.Name.Namespace != android &&
 						!(a.Name.LocalName == "layout" && a.Name.Namespace == XNamespace.None &&
@@ -142,7 +141,7 @@ namespace Monodroid {
 			return false;
 		}
 		
-		static IEnumerable<XAttribute> GetAttributes (XElement e)
+		internal static IEnumerable<XAttribute> GetAttributes (XElement e)
 		{
 			foreach (XAttribute a in e.Attributes ())
 				yield return a;
@@ -151,7 +150,7 @@ namespace Monodroid {
 					yield return a;
 		}
 
-		static IEnumerable<XElement> GetElements (XElement e)
+		internal static IEnumerable<XElement> GetElements (XElement e)
 		{
 			foreach (var a in e.Elements ()) {
 				yield return a;
@@ -176,33 +175,26 @@ namespace Monodroid {
 			}
 		}
 
-		private static bool TryFixFragment (XAttribute attr, Dictionary<string, string> acwMap)
+		private static void TryFixFragment (XAttribute attr, Dictionary<string, string> acwMap, Action<string> registerCustomView = null)
 		{
 			// Looks for any: 
 			//   <fragment class="My.DotNet.Class" 
 			//   <fragment android:name="My.DotNet.Class" ...
 			// and tries to change it to the ACW name
 			if (attr.Parent.Name != "fragment")
-				return false;
+				return;
 
 			if (attr.Name == "class" || attr.Name == android + "name") {
-				if (acwMap.TryGetValue (attr.Value, out string mappedValue)) {
-					attr.Value = mappedValue;
-
-					return true;
-				}
-				else if (attr.Value?.Contains (',') ?? false) {
+				var n = attr.Value;
+				if (n == null)
+					return;
+				if (n.Contains (',')) {
 					// attr.Value could be an assembly-qualified name that isn't in acw-map.txt;
 					// see e5b1c92c, https://github.com/xamarin/xamarin-android/issues/1296#issuecomment-365091948
-					var n = attr.Value.Substring (0, attr.Value.IndexOf (','));
-					if (acwMap.TryGetValue (n, out mappedValue)) {
-						attr.Value = mappedValue;
-						return true;
-					}
+					n = attr.Value.Substring (0, attr.Value.IndexOf (','));
 				}
+				registerCustomView?.Invoke (n);
 			}
-
-			return false;
 		}
 
 		private static bool TryFixResAuto (XAttribute attr, Dictionary<string, string> acwMap)
@@ -219,40 +211,16 @@ namespace Monodroid {
 			return false;
 		}
 
-		private static bool TryFixCustomView (XElement elem, Dictionary<string, string> acwMap, Action<TraceLevel, string> logMessage = null)
-		{
-			// Looks for any <My.DotNet.Class ...
-			// and tries to change it to the ACW name
-			string name = elem.Name.ToString ();
-			if (acwMap.TryGetValue (name, out string mappedValue)) {
-				elem.Name = mappedValue;
-				return true;
-			}
-			if (logMessage == null)
-				return false;
-			var matchingKey = acwMap.FirstOrDefault(x => String.Equals(x.Key, name, StringComparison.OrdinalIgnoreCase));
-			if (matchingKey.Key != null) {
-				// we have elements with slightly different casing.
-				// lets issue a error.
-				logMessage (TraceLevel.Error, $"We found a matching key '{matchingKey.Key}' for '{name}'. But the casing was incorrect. Please correct the casing");
-			}
-			return false;
-		}
-
-		private static bool TryFixCustomClassAttribute (XAttribute attr, Dictionary<string, string> acwMap)
+		private static void TryFixCustomClassAttribute (XAttribute attr, Dictionary<string, string> acwMap, Action<string> registerCustomView = null)
 		{
 			/* Some attributes reference a Java class name.
 			 * try to convert those like for TryFixCustomView
 			 */
 			if (attr.Name != (res_auto + "layout_behavior")                              // For custom CoordinatorLayout behavior
 			    && (attr.Parent.Name != "transition" || attr.Name.LocalName != "class")) // For custom transitions
-				return false;
+				return;
 
-			if (!acwMap.TryGetValue (attr.Value, out string mappedValue))
-				return false;
-
-			attr.Value = mappedValue;
-			return true;
+			registerCustomView?.Invoke (attr.Value);
 		}
 
 		private static string TryLowercaseValue (string value, string resourceBasePath, IEnumerable<string> additionalDirectories)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MSBuildExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MSBuildExtensions.cs
@@ -188,5 +188,29 @@ namespace Xamarin.Android.Tasks
 					yield return t;
 			}
 		}
+
+		public static string FixupResourceFilename (string file, string resourceDir, Dictionary<string, string> resourceNameCaseMap)
+		{
+			var targetfile = file;
+			if (resourceDir != null && targetfile.StartsWith (resourceDir, StringComparison.InvariantCultureIgnoreCase)) {
+				targetfile = file.Substring (resourceDir.Length).TrimStart (Path.DirectorySeparatorChar);
+				if (resourceNameCaseMap.TryGetValue (targetfile, out string temp))
+					targetfile = temp;
+				targetfile = Path.Combine ("Resources", targetfile);
+			}
+			return targetfile;
+		}
+
+		public static void FixupResourceFilenameAndLogCodedError (this TaskLoggingHelper log, string code, string message, string file,  string resourceDir, Dictionary<string, string> resourceNameCaseMap)
+		{
+			var targetfile = FixupResourceFilename (file, resourceDir, resourceNameCaseMap);
+			log.LogCodedError (code, file: targetfile, lineNumber: 0, message: message);
+		}
+
+		public static void FixupResourceFilenameAndLogCodedWarning (this TaskLoggingHelper log, string code, string message, string file, string resourceDir, Dictionary<string, string> resourceNameCaseMap)
+		{
+			var targetfile = FixupResourceFilename (file, resourceDir, resourceNameCaseMap);
+			log.LogCodedWarning (code, file: targetfile, lineNumber: 0, message: message);
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -249,6 +249,7 @@
     <Compile Include="Tasks\CalculateLayoutCodeBehind.cs" />
     <Compile Include="Tasks\FindLayoutsToBind.cs" />
     <Compile Include="Tasks\CalculateProjectDependencies.cs" />
+    <Compile Include="Tasks\ConvertCustomView.cs" />
     <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\BitAccess.cs">
       <Link>pdb2mdb\BitAccess.cs</Link>
     </Compile>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -44,6 +44,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.CollectNonEmptyDirectories" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ConvertDebuggingFiles" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ConvertResourcesCases" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.ConvertCustomView" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CopyIfChanged" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CopyResource" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CopyAndConvertResources" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -1150,6 +1151,7 @@ because xbuild doesn't support framework reference assemblies.
 	<_AndroidDebugKeyStoreFlag>$(IntermediateOutputPath)android_debug_keystore.flag</_AndroidDebugKeyStoreFlag>
 	<_RemoveRegisterFlag>$(MonoAndroidIntermediateAssetsDir)shrunk\shrunk.flag</_RemoveRegisterFlag>
 	<_AcwMapFile>$(IntermediateOutputPath)acw-map.txt</_AcwMapFile>
+	<_CustomViewMapFile>$(IntermediateOutputPath)customview-map.txt</_CustomViewMapFile>
 	<_AndroidTypeMappingJavaToManaged>$(IntermediateOutputPath)android\typemap.jm</_AndroidTypeMappingJavaToManaged>
 	<_AndroidTypeMappingManagedToJava>$(IntermediateOutputPath)android\typemap.mj</_AndroidTypeMappingManagedToJava>
 	<AndroidResgenNamespace Condition="'$(AndroidResgenNamespace)'==''" >$(RootNamespace)</AndroidResgenNamespace>
@@ -1341,6 +1343,7 @@ because xbuild doesn't support framework reference assemblies.
 		ContinueOnError="$(DesignTimeBuild)"
 		ResourceDirectories="@(_LibraryResourceDirectories)"
 		AcwMapFile="$(_AcwMapFile)"
+		CustomViewMapFile="$(_CustomViewMapFile)"
 		AndroidConversionFlagFile="%(_LibraryResourceDirectories.Identity)\..\compiled.flata"
 	/>
 	<Aapt2Compile
@@ -1376,6 +1379,7 @@ because xbuild doesn't support framework reference assemblies.
 		ContinueOnError="$(DesignTimeBuild)"
 		ResourceDirectories="$(MonoAndroidResDirIntermediate)"
 		AcwMapFile="$(_AcwMapFile)"
+		CustomViewMapFile="$(_CustomViewMapFile)"
 		AndroidConversionFlagFile="$(IntermediateOutputPath)\compiled.flata"
 	/>
 	<Aapt2Compile
@@ -1666,6 +1670,7 @@ because xbuild doesn't support framework reference assemblies.
 		Condition="'$(_AndroidUseAapt2)' != 'True'"
 		ResourceDirectories="$(MonoAndroidResDirIntermediate);@(LibraryResourceDirectories)"
 		AcwMapFile="$(_AcwMapFile)"
+		CustomViewMapFile="$(_CustomViewMapFile)"
 		AndroidConversionFlagFile="$(_AndroidResgenFlagFile)"
 	/>
 
@@ -2225,11 +2230,12 @@ because xbuild doesn't support framework reference assemblies.
 	FrameworkDirectories="$(_XATargetFrameworkDirectories);$(_XATargetFrameworkDirectories)Facades"
 	AcwMapFile="$(_AcwMapFile)">
   </GenerateJavaStubs>
-  <ConvertResourcesCases 
+  <ConvertCustomView
+	Condition="Exists('$(_CustomViewMapFile)')"
+	CustomViewMapFile="$(_CustomViewMapFile)"
+	AcwMapFile="$(_AcwMapFile)"
 	ResourceDirectories="$(MonoAndroidResDirIntermediate);@(LibraryResourceDirectories)"
 	ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
-	AcwMapFile="$(_AcwMapFile)"
-	AndroidConversionFlagFile="$(IntermediateOutputPath)_javastubs.stamp"
   />
   <Touch Files="$(IntermediateOutputPath)_javastubs.stamp;$(_AndroidResgenFlagFile)" AlwaysCreate="True" />
   <ItemGroup>
@@ -3052,6 +3058,7 @@ because xbuild doesn't support framework reference assemblies.
 	<Delete Files="$(IntermediateOutputPath)_dex_stamp" />
  	<Delete Files="$(MonoAndroidIntermediate)R.cs.flag" />
 	<Delete Files="$(MonoAndroidIntermediate)acw-map.txt" />
+	<Delete Files="$(MonoAndroidIntermediate)customview-map.txt" />
 	<Delete Files="$(MonoAndroidIntermediate)mergeresources.cache" />
 	<Delete Files="$(MonoAndroidIntermediate)jarlist.cache" />
 	<Delete Files="$(MonoAndroidIntermediate)resolved_assemblies.txt" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1290,6 +1290,9 @@ because xbuild doesn't support framework reference assemblies.
 			DestinationFiles="@(_AndroidResourceDest)"
 			AcwMapFile="$(_AcwMapFile)"
 			CacheFile="$(_AndroidResourcesCacheFile)"
+			CustomViewMapFile="$(_CustomViewMapFile)"
+			ResourceDirectories="$(MonoAndroidResDirIntermediate);@(LibraryResourceDirectories)"
+			ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
 			Condition="  '$(AndroidExplicitCrunch)' == 'True' And '$(AndroidApplication)' != '' And $(AndroidApplication)">
 		<Output ItemName="_ModifiedResources" TaskParameter="ModifiedFiles"/>
 	</CopyAndConvertResources>
@@ -1342,6 +1345,7 @@ because xbuild doesn't support framework reference assemblies.
 		Condition=" '@(_LibraryResourceDirectories)' != '' "
 		ContinueOnError="$(DesignTimeBuild)"
 		ResourceDirectories="@(_LibraryResourceDirectories)"
+		ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
 		AcwMapFile="$(_AcwMapFile)"
 		CustomViewMapFile="$(_CustomViewMapFile)"
 		AndroidConversionFlagFile="%(_LibraryResourceDirectories.Identity)\..\compiled.flata"
@@ -1378,6 +1382,7 @@ because xbuild doesn't support framework reference assemblies.
 	<ConvertResourcesCases
 		ContinueOnError="$(DesignTimeBuild)"
 		ResourceDirectories="$(MonoAndroidResDirIntermediate)"
+		ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
 		AcwMapFile="$(_AcwMapFile)"
 		CustomViewMapFile="$(_CustomViewMapFile)"
 		AndroidConversionFlagFile="$(IntermediateOutputPath)\compiled.flata"
@@ -1669,6 +1674,7 @@ because xbuild doesn't support framework reference assemblies.
 	<ConvertResourcesCases
 		Condition="'$(_AndroidUseAapt2)' != 'True'"
 		ResourceDirectories="$(MonoAndroidResDirIntermediate);@(LibraryResourceDirectories)"
+		ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
 		AcwMapFile="$(_AcwMapFile)"
 		CustomViewMapFile="$(_CustomViewMapFile)"
 		AndroidConversionFlagFile="$(_AndroidResgenFlagFile)"


### PR DESCRIPTION
Fixed #2100

Currently `ConvertResourcesCases` is called twice on ALL
resources referenced by the project. This is terribly inefficient.
However it is required. The first pass is done before a `Compile`,
this fixes up the casing for things like drawables etc ready to
be processed by aapt. The second is done after `GenerateJavaStubs`
which happens AFTER the `Compile` step. This is to replace any
custom view references with the correct `{md5}.View` style references.
This is because we replace the normal readable namespace with an md5 hash.

The problem was that `ConvertResourcesCases` is doing a TON of
work it doesn't really need to do the second time around. For example
checking if it needs to lower case names of items. The second pass
really only needs to worry about custom views. In addition to that
it was also re-scanning ALL the files again.

This commit introduces a new Task `ConvertCustomView`. The sole
purpose of this task is to fix up the layout files which contain
custom views. It does nothing else. To make this even quicker we
modify `ConvertResourcesCases` to emit a mapping file (class-map.txt). This file
contains items like

	MonoDroid.Example.MyLayout;/fullpath/to/file.xml
	android.support.v7.widget.ActionBarOverlayLayout;/fullpath/to/some/other/file.xml

This allows us to know were the files are which contain ANY layout.

With this information in conjuction with the `acw_map.txt` file will
allow us to do a targeted update. So we go through the `acw_map.txt`
values and fix up those files where we have entires in the `class-map.txt`.

This reduces the amount of time spent processing files quite a bit.
For a Blank Xamarin Forms app from a clean build.

	2639 ms  ConvertResourcesCases                      1 calls
	   3 ms  ConvertCustomView                          1 calls

Normally the `ConvertResourcesCases` would be called twice and would
take a total of 5-6 seconds.

- [x] Fix up Paths in Error Message
- [X] Write a decent Commit Message
- [x] General Clean up.