### PR TITLE
[Xamarin.Android.Build.Tasks] precompile SetVsMonoAndroidRegistryKey

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Xamarin.Android.Sdk.props
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Xamarin.Android.Sdk.props
@@ -43,18 +43,7 @@ Copyright (C) 2011-2016 Xamarin. All rights reserved.
 		<Delete Files="$(IntermediateOutputPath)sdks.cache" />
 	</Target>
 
-	<UsingTask Condition="'$(VsInstallRoot)' != ''" TaskName="SetVsMonoAndroidRegistryKey" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
-		<ParameterGroup>
-			<InstallationID Required="true" />
-			<VisualStudioVersion Required="true" />
-		</ParameterGroup>
-		<Task>
-			<Code Type="Fragment" Language="cs">
-				Environment.SetEnvironmentVariable("XAMARIN_ANDROID_REGKEY", string.Format(@"SOFTWARE\Xamarin\VisualStudio\{0}_{1}\Android", VisualStudioVersion, InstallationID), EnvironmentVariableTarget.Process);
-				Log.LogMessage(Environment.GetEnvironmentVariable("XAMARIN_ANDROID_REGKEY"));
-			</Code>
-		</Task>
-	</UsingTask>
+	<UsingTask TaskName="Xamarin.Android.Tasks.SetVsMonoAndroidRegistryKey" AssemblyFile="Android\Xamarin.Android.Build.Tasks.dll" />
 
 	<PropertyGroup>
 		<XamarinAndroidSdkPropsImported>true</XamarinAndroidSdkPropsImported>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/SetVsMonoAndroidRegistryKey.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/SetVsMonoAndroidRegistryKey.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+
+namespace Xamarin.Android.Tasks
+{
+	public class SetVsMonoAndroidRegistryKey : Task
+	{
+		[Required]
+		public string InstallationID { get; set; }
+
+		[Required]
+		public string VisualStudioVersion { get; set; }
+
+		const string EnvironmentVariable = "XAMARIN_ANDROID_REGKEY";
+
+		public override bool Execute ()
+		{
+			string value = $@"SOFTWARE\Xamarin\VisualStudio\{VisualStudioVersion}_{InstallationID}\Android";
+			Log.LogDebugMessage ($"Setting %{EnvironmentVariable}%=\"{value}\"");
+			Environment.SetEnvironmentVariable (EnvironmentVariable, value, EnvironmentVariableTarget.Process);
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Mono.Android\ActivityAttribute.Partial.cs" />
     <Compile Include="Mono.Android\ContentProviderAttribute.Partial.cs" />
     <Compile Include="Mono.Android\LayoutAttribute.Partial.cs" />
+    <Compile Include="Tasks\SetVsMonoAndroidRegistryKey.cs" />
     <Compile Include="Tasks\ValidateJavaVersion.cs" />
     <Compile Include="Utilities\AndroidAddOnManifest.cs" />
     <Compile Include="Mono.Android\IntentFilterAttribute.Partial.cs" />


### PR DESCRIPTION
In `Xamarin.Android.Sdk.props` we have some inline C# code for a
MSBuild task named `SetVsMonoAndroidRegistryKey`. Which is
understandable, since the code needed is so simple. But thinking about
it, MSBuild has to *compile* this code to run it. Which seems
inherently slower than if we compiled the code during our build.

Currently its entire parent target, `RedirectMonoAndroidSdkPaths`,
takes:

    157 ms  RedirectMonoAndroidSdkPaths                1 calls

I moved this task inside `Xamarin.Android.Build.Tasks.dll`, and we
appear to get some improvements "for free":

    76 ms  RedirectMonoAndroidSdkPaths                1 calls

I looked at some past logs, and there are some times where the
`RedirectMonoAndroidSdkPaths` target was taking over 200ms. I suspect
MSBuild might also have some caching functionality for inlined C#
code. There might be a cached assembly somewhere? Not sure.

What makes this a better fix is that this target runs for all
builds--even builds with no changes.

General changes:
- The `<UsingTask />` doesn't need a condition, since it will be
  lazily evaluated anyways.
- Used string interpolation where it looked nicer.
- Used `LogDebugMessage` and improved the log message.