### PR TITLE
[Xamarin.Android.Build.Tasks] leave classes.zip uncompressed

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System.Text;
 using System.Collections.Generic;
+using Xamarin.Tools.Zip;
 
 namespace Xamarin.Android.Tasks
 {
@@ -36,7 +37,7 @@ namespace Xamarin.Android.Tasks
 				return result;
 			// compress all the class files
 			using (var zip = new ZipArchiveEx (Path.Combine (ClassesOutputDirectory, "..", "classes.zip"), FileMode.OpenOrCreate))
-				zip.AddDirectory (ClassesOutputDirectory, "");
+				zip.AddDirectory (ClassesOutputDirectory, "", CompressionMethod.Store);
 			return result;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
@@ -52,7 +52,7 @@ namespace Xamarin.Android.Tasks
 			return pathName.Replace ("\\", "/");
 		}
 
-		void AddFiles (string folder, string folderInArchive)
+		void AddFiles (string folder, string folderInArchive, CompressionMethod method)
 		{
 			int count = 0;
 			foreach (string fileName in Directory.GetFiles (folder, "*.*", SearchOption.TopDirectoryOnly)) {
@@ -64,9 +64,9 @@ namespace Xamarin.Android.Tasks
 				if (zip.ContainsEntry (archiveFileName, out index)) {
 					var e = zip.First (x => x.FullName == archiveFileName);
 					if (e.ModificationTime < fi.LastWriteTimeUtc)
-						zip.AddFile (fileName, archiveFileName);
+						zip.AddFile (fileName, archiveFileName, compressionMethod: method);
 				} else {
-					zip.AddFile (fileName, archiveFileName);
+					zip.AddFile (fileName, archiveFileName, compressionMethod: method);
 				}
 				count++;
 				if (count == ZipArchiveEx.ZipFlushLimit) {
@@ -84,7 +84,7 @@ namespace Xamarin.Android.Tasks
 				zip.DeleteEntry ((ulong)index);
 		}
 
-		public void AddDirectory (string folder, string folderInArchive)
+		public void AddDirectory (string folder, string folderInArchive, CompressionMethod method = CompressionMethod.Default)
 		{
 			if (!string.IsNullOrEmpty (folder)) {
 				folder = folder.Replace ('/', Path.DirectorySeparatorChar).Replace ('\\', Path.DirectorySeparatorChar);
@@ -94,7 +94,7 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
-			AddFiles (folder, folderInArchive);
+			AddFiles (folder, folderInArchive, method);
 			foreach (string dir in Directory.GetDirectories (folder, "*", SearchOption.AllDirectories)) {
 				var di = new DirectoryInfo (dir);
 				if ((di.Attributes & FileAttributes.Hidden) != 0)
@@ -106,7 +106,7 @@ namespace Xamarin.Android.Tasks
 				} catch (ZipException) {
 					
 				}
-				AddFiles (dir, fullDirPath);
+				AddFiles (dir, fullDirPath, method);
 			}
 		}
 


### PR DESCRIPTION
I was thinking about a couple of the slower MSBuild tasks:
- `Javac`
- `CompileToDalvik`

One thing I noticed here was that `Javac` outputs a `classes.zip`
file, and `CompileToDalvik` consumes it. It also looked like we are
using `CompressionMethod.Default` as you would expect.

So why should we compress this file at all? It seemed that was work we
could just skip and things would work fine? Presumably `dx.jar` can
work with an uncompressed `classes.zip` file faster than a compressed
one?

So I made the following changes:
- Added an option to pass in the `CompressionMethod` in `ZipArchiveEx`
- Used `CompressionMethod.Store` for creating `classes.zip`

The results on a File | New Xamarin.Forms app looked great!

Before:

     3443 ms  Javac                                      1 calls
    11545 ms  CompileToDalvik                            1 calls

After:

     3338 ms  Javac                                      1 calls
    10535 ms  CompileToDalvik                            1 calls

I did a `Clean` before running the `SignAndroidPackage` target on
these builds.

These savings seem pretty good! The only drawback being we use more
disk space in `$(IntermediateOutputPath)`.