### PR TITLE
[Xamarin.Android.Build.Tasks] ignore aapt/AndroidManifest.xml

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -566,6 +566,26 @@ namespace Xamarin.ProjectTools
 				}
 			}
 		};
+		public static Package Xamarin_Android_Crashlytics_2_9_4 = new Package {
+			Id = "Xamarin.Android.Crashlytics",
+			Version = "2.9.4",
+			TargetFramework = "MonoAndroid60",
+			References = {
+				new BuildItem.Reference("Xamarin.Android.Crashlytics") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Crashlytics.2.9.4\\lib\\MonoAndroid60\\Xamarin.Android.Crashlytics.dll"
+				}
+			}
+		};
+		public static Package Xamarin_Android_Fabric_1_4_3 = new Package {
+			Id = "Xamarin.Android.Fabric",
+			Version = "1.4.3",
+			TargetFramework = "MonoAndroid60",
+			References = {
+				new BuildItem.Reference("Xamarin.Android.Fabric") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Fabric.1.4.3\\lib\\MonoAndroid60\\Xamarin.Android.Fabric.dll"
+				}
+			}
+		};
 	}
 }
 


### PR DESCRIPTION
Context: https://stackoverflow.com/questions/41592744/function-of-aapt-androidmanifest-xml-in-aar
Fixes: https://github.com/xamarin/xamarin-android/issues/2141

Apparently Android Studio is now shipping a duplicate, pre-formatted
`AndroidManifest.xml` file, inside of AAR files. Its purpose is to be
used with `aapt` invocations, since errors may be thrown related to
`{` or `}` characters.

Since this file may exist in AAR files used by Xamarin.Android, we
should ignore `aapt/AndroidManifest.xml` files the same way we ignore
them inside `manifest` or `bin` directories.

Changes:
- Added a `IgnoredManifestDirectories` list, since we are getting to a
  point where `!= && != && !=` would be a lot of noise.
- Switched the LINQ expression to simple `foreach` loop, which should
  also give a slight performance benefit.