### PR TITLE
[Mono.Android] Use package fallback in GetJavaToManagedType on desktop

### DIFF
--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -206,10 +206,29 @@ namespace Java.Interop {
 		internal static Type GetJavaToManagedType (string class_name)
 		{
 			var t = monodroid_typemap_java_to_managed (class_name);
-			if (t == IntPtr.Zero)
-				return null;
+			if (t != IntPtr.Zero)
+				return Type.GetType (Marshal.PtrToStringAnsi (t));
 
-			return Type.GetType (Marshal.PtrToStringAnsi (t));
+			if (!JNIEnv.IsRunningOnDesktop) {
+				return null;
+			}
+
+			var type    = (Type) null;
+			int ls      = class_name.LastIndexOf ('/');
+			var package = ls >= 0 ? class_name.Substring (0, ls) : "";
+			List<Converter<string, Type>> mappers;
+			if (packageLookup.TryGetValue (package, out mappers)) {
+				foreach (Converter<string, Type> c in mappers) {
+					type = c (class_name);
+					if (type == null)
+						continue;
+					return type;
+				}
+			}
+			if ((type = Type.GetType (JavaNativeTypeManager.ToCliType (class_name))) != null) {
+				return type;
+			}
+			return null;
 		}
 
 		internal static IJavaObject CreateInstance (IntPtr handle, JniHandleOwnership transfer)


### PR DESCRIPTION
This partially reverts commit 6418edce

Context: http://work.devdiv.io/675738

Commit 6418edce breaks the Android Designer, because the
Android Designer doesn't generate `typemap.jm` and `typemap.mj` files,
which `monodroid_typemap_java_to_managed()` uses in order to perform
the Java->managed type mapping.  Without an appropriate `typemap.jm`
file, and with the removal of the Reflection (-ish)-based fallback
code in commit 6418edce, there is no way within the Android Designer
to associate a Java type with a corresponding C# type, for e.g. custom
("new") `View` subclasses written in C# or outside of `android.jar`.

The d15-9 branch hit the same problem, and likewise reverted this
change in commit 91a3fe52.

Instead of *fully* reverting 6418edce, "revert" it *on Desktop*.
When running on an Android Device, the fallback codepath won't be
used, allowing for faster runtime execution (less work is done), while
within the Android Designer (Desktop execution), the fallback code
path will once again be available.