### PR TITLE
[Mono.Android] build and reference non-PCL Java.Interop

### DIFF
--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -8,13 +8,23 @@
   </ItemGroup>
   <Target Name="_BuildJavaInterop"
       BeforeTargets="BeforeResolveReferences"
-      Inputs="$(JavaInteropFullPath)\src\Java.Interop\Java.Interop.csproj"
+      Inputs="$(MSBuildThisFile);$(JavaInteropFullPath)\src\Java.Interop\Java.Interop.csproj"
       Outputs="$(OutputPath)\..\v1.0\Java.Interop.dll">
+    <PropertyGroup>
+      <_GlobalProperties>
+        JavaInteropProfile=Net45;
+        XAInstallPrefix=$(XAInstallPrefix);
+        TargetFrameworkIdentifier=MonoAndroid;
+        TargetFrameworkVersion=v1.0;
+        TargetFrameworkRootPath=$(XAInstallPrefix)xbuild-frameworks;
+      </_GlobalProperties>
+    </PropertyGroup>
     <MSBuild
         Projects="$(JavaInteropFullPath)\src\Java.Interop\Java.Interop.csproj"
+        Properties="$(_GlobalProperties)"
     />
     <ItemGroup>
-      <Assembly Include="$(JavaInteropFullPath)\bin\$(Configuration)\*.dll*" />
+      <Assembly Include="$(JavaInteropFullPath)\bin\$(Configuration)Net45\*.dll*" />
     </ItemGroup>
     <Copy
         SourceFiles="@(Assembly)"


### PR DESCRIPTION
Fixes: http://work.devdiv.io/667174

Context: https://github.com/xamarin/java.interop/commit/893562cb6b02031c5991ec94769db5fd1a88b53e
Context: https://github.com/xamarin/java.interop/commit/659711c77407c95a27b58ff6f2c84c9fe6db0691
Context: https://github.com/xamarin/java.interop/compare/b873e81...a09932d

Bumped to java.interop/d15-9/a09932d

Build `lib\xamarin.android\xbuild-frameworks\MonoAndroid\v1.0\Java.Interop.dll`
as a `MonoAndroid`-profile assembly instead of as a PCL assembly.
This decreases the assemblies referenced in a "Hello World"
Xamarin.Android project dramatically; this:

	Adding assembly reference for Java.Interop, Version=0.1.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065, recursively...
	    Adding assembly reference for System.Runtime, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
	    Adding assembly reference for System.ComponentModel.Composition, Version=2.0.5.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, recursively...
	    Adding assembly reference for System.Diagnostics.Debug, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
	    Adding assembly reference for System.Threading, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
	    Adding assembly reference for System.Collections, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
	    Adding assembly reference for System.Collections.Concurrent, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
	    Adding assembly reference for System.Reflection, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
	    Adding assembly reference for System.Linq.Expressions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
	    Adding assembly reference for System.Reflection.Primitives, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
	    Adding assembly reference for System.Dynamic.Runtime, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
	    Adding assembly reference for System.ObjectModel, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
	    Adding assembly reference for System.Linq, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
	    Adding assembly reference for System.Runtime.InteropServices, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
	    Adding assembly reference for System.Runtime.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
	    Adding assembly reference for System.Reflection.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
	Adding assembly reference for Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065, recursively...

now becomes:

	Adding assembly reference for Java.Interop, Version=0.1.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065, recursively...
	Adding assembly reference for Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065, recursively...

Because fewer assemblies need to be resolved, the `Rebuild` target
times improve by 30%-50% for the "Hello World" app:

  - `Debug` + PCL:            8.424s
  - `Debug` + *not* PCL:      4.258s (~50% faster!)
  - `Release` + PCL:         13.651s
  - `Release` + *not* PCL:    9.487s (~30% faster!)

The `lib\xamarin.android\xbuild\Xamarin\Android\Java.Interop.dll`
copy used by `Xamarin.Android.Build.Tasks.dll` remains unchanged, as
it is referenced by `Xamarin.Android.Build.Tasks.csproj`.