### PR TITLE
[Xamarin.Android.Build.Tasks] remove try/catch, unused temp file

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -86,44 +86,38 @@ namespace Xamarin.Android.Tasks
 				}
 				Log.LogDebugMessage ("  Processing: {0}   {1} > {2}", file, srcmodifiedDate, lastUpdate);
 				MonoAndroidHelper.SetWriteable (file);
-				try {
-					bool success = AndroidResource.UpdateXmlResource (resdir, file, acwMap,
-						resourcedirectories, (level, message) => {
-							switch (level) {
-							case TraceLevel.Error:
-								Log.FixupResourceFilenameAndLogCodedError ("XA1002", message, file, resdir, resource_name_case_map);
-								break;
-							case TraceLevel.Warning:
-								Log.FixupResourceFilenameAndLogCodedError ("XA1001", message, file, resdir, resource_name_case_map);
-								break;
-							default:
-								Log.LogDebugMessage (message);
-								break;
-							}
-						}, registerCustomView : (e, filename) => {
-						if (customViewMap == null)
-							return;
-						HashSet<string> set;
-						if (!customViewMap.TryGetValue (e, out set))
-							customViewMap.Add (e, set = new HashSet<string> ());
-						set.Add (filename);
-					});
-					if (!success) {
-						//If we failed to write the file, a warning is logged, we should skip to the next file
-						continue;
-					}
-
-					// We strip away an eventual UTF-8 BOM from the XML file.
-					// This is a requirement for the Android designer because the desktop Java renderer
-					// doesn't support those type of BOM (it really wants the document to start
-					// with "<?"). Since there is no way to plug into the file saving mechanism in X.S
-					// we strip those here and point the designer to use resources from obj/
-					MonoAndroidHelper.CleanBOM (file);
-
-
-				} finally {
-
+				bool success = AndroidResource.UpdateXmlResource (resdir, file, acwMap,
+					resourcedirectories, (level, message) => {
+						switch (level) {
+						case TraceLevel.Error:
+							Log.FixupResourceFilenameAndLogCodedError ("XA1002", message, file, resdir, resource_name_case_map);
+							break;
+						case TraceLevel.Warning:
+							Log.FixupResourceFilenameAndLogCodedError ("XA1001", message, file, resdir, resource_name_case_map);
+							break;
+						default:
+							Log.LogDebugMessage (message);
+							break;
+						}
+					}, registerCustomView : (e, filename) => {
+					if (customViewMap == null)
+						return;
+					HashSet<string> set;
+					if (!customViewMap.TryGetValue (e, out set))
+						customViewMap.Add (e, set = new HashSet<string> ());
+					set.Add (filename);
+				});
+				if (!success) {
+					//If we failed to write the file, a warning is logged, we should skip to the next file
+					continue;
 				}
+
+				// We strip away an eventual UTF-8 BOM from the XML file.
+				// This is a requirement for the Android designer because the desktop Java renderer
+				// doesn't support those type of BOM (it really wants the document to start
+				// with "<?"). Since there is no way to plug into the file saving mechanism in X.S
+				// we strip those here and point the designer to use resources from obj/
+				MonoAndroidHelper.CleanBOM (file);
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyAndConvertResources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyAndConvertResources.cs
@@ -96,39 +96,35 @@ namespace Xamarin.Android.Tasks
 				var destfilename = p.Value;
 				var srcmodifiedDate = File.GetLastWriteTimeUtc (filename);
 				var dstmodifiedDate = File.Exists (destfilename) ? File.GetLastWriteTimeUtc (destfilename) : DateTime.MinValue;
-				var tmpdest = Path.GetTempFileName ();
+
 				var res = Path.Combine (Path.GetDirectoryName (filename), "..");
 				MonoAndroidHelper.CopyIfChanged (filename, destfilename);
 				MonoAndroidHelper.SetWriteable (destfilename);
-				try {
-					var updated = AndroidResource.UpdateXmlResource (res, destfilename, acw_map, logMessage: (level, message) => {
-						ITaskItem resdir = ResourceDirectories?.FirstOrDefault (x => filename.StartsWith (x.ItemSpec)) ?? null;
-						switch (level) {
-						case TraceLevel.Error:
-							Log.FixupResourceFilenameAndLogCodedError ("XA1002", message, filename, resdir.ItemSpec, resource_name_case_map);
-							break;
-						case TraceLevel.Warning:
-							Log.FixupResourceFilenameAndLogCodedError ("XA1001", message, filename, resdir.ItemSpec, resource_name_case_map);
-							break;
-						default:
-							Log.LogDebugMessage (message);
-							break;
-						}
-					}, registerCustomView: (e, file) => {
-						if (customViewMap == null)
-							return;
-						HashSet<string> set;
-						if (!customViewMap.TryGetValue (e, out set))
-							customViewMap.Add (e, set = new HashSet<string> ());
-						set.Add (file);
-
-					});
-					if (updated) {
-						if (!modifiedFiles.Any (i => i.ItemSpec == destfilename))
-							modifiedFiles.Add (new TaskItem (destfilename));
+				var updated = AndroidResource.UpdateXmlResource (res, destfilename, acw_map, logMessage: (level, message) => {
+					ITaskItem resdir = ResourceDirectories?.FirstOrDefault (x => filename.StartsWith (x.ItemSpec)) ?? null;
+					switch (level) {
+					case TraceLevel.Error:
+						Log.FixupResourceFilenameAndLogCodedError ("XA1002", message, filename, resdir.ItemSpec, resource_name_case_map);
+						break;
+					case TraceLevel.Warning:
+						Log.FixupResourceFilenameAndLogCodedError ("XA1001", message, filename, resdir.ItemSpec, resource_name_case_map);
+						break;
+					default:
+						Log.LogDebugMessage (message);
+						break;
 					}
-				} finally {
-					File.Delete (tmpdest);
+				}, registerCustomView: (e, file) => {
+					if (customViewMap == null)
+						return;
+					HashSet<string> set;
+					if (!customViewMap.TryGetValue (e, out set))
+						customViewMap.Add (e, set = new HashSet<string> ());
+					set.Add (file);
+
+				});
+				if (updated) {
+					if (!modifiedFiles.Any (i => i.ItemSpec == destfilename))
+						modifiedFiles.Add (new TaskItem (destfilename));
 				}
 			}
 			merger.Save ();


### PR DESCRIPTION
- remove the try clause around `UpdateXmlResource`, it's a duplicate
- remove unused `tempfile` variable