### PR TITLE
[Xamarin.Android.Build.Tasks] CopyIfChanged sets LastWriteTimeUtc (#2…

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -117,10 +117,7 @@ namespace Xamarin.Android.Tasks
 					// we strip those here and point the designer to use resources from obj/
 					MonoAndroidHelper.CleanBOM (tmpdest);
 
-					if (MonoAndroidHelper.CopyIfChanged (tmpdest, file)) {
-						MonoAndroidHelper.SetWriteable (file);
-						MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (file, srcmodifiedDate, Log);
-					}
+					MonoAndroidHelper.CopyIfChanged (tmpdest, file);
 				} finally {
 					File.Delete (tmpdest);
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyAndConvertResources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyAndConvertResources.cs
@@ -58,8 +58,6 @@ namespace Xamarin.Android.Tasks
 						continue;
 					}
 					if (dstmodifiedDate < srcmodifiedDate && MonoAndroidHelper.CopyIfChanged (filename, destfilename)) {
-						MonoAndroidHelper.SetWriteable (destfilename);
-
 						// If the resource is not part of a raw-folder we strip away an eventual UTF-8 BOM
 						// This is a requirement for the Android designer because the desktop Java renderer
 						// doesn't support those type of BOM (it really wants the document to start
@@ -68,7 +66,6 @@ namespace Xamarin.Android.Tasks
 						if (isXml && !MonoAndroidHelper.IsRawResourcePath (filename))
 							MonoAndroidHelper.CleanBOM (destfilename);
 
-						MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (destfilename, srcmodifiedDate, Log);
 						modifiedFiles.Add (new TaskItem (destfilename));
 					}
 				} else
@@ -93,8 +90,6 @@ namespace Xamarin.Android.Tasks
 				try {
 					AndroidResource.UpdateXmlResource (res, tmpdest, acw_map);
 					if (MonoAndroidHelper.CopyIfChanged (tmpdest, destfilename)) {
-						MonoAndroidHelper.SetWriteable (destfilename);
-						MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (destfilename, srcmodifiedDate, Log);
 						if (!modifiedFiles.Any (i => i.ItemSpec == destfilename))
 							modifiedFiles.Add (new TaskItem (destfilename));
 					}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyConfigFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyConfigFiles.cs
@@ -26,8 +26,6 @@ namespace Xamarin.Android.Tasks
 				var date = DateTime.Now;
 				if (File.Exists (src)) {
 					MonoAndroidHelper.CopyIfChanged (src, dst);
-					MonoAndroidHelper.SetWriteable (dst);
-					MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (dst, date, Log);
 				}
 			}
 			return true;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyGeneratedJavaResourceClasses.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyGeneratedJavaResourceClasses.cs
@@ -38,10 +38,7 @@ namespace Xamarin.Android.Tasks
 					continue;
 
 				var date = File.GetLastWriteTimeUtc (src);
-				if (MonoAndroidHelper.CopyIfChanged (src, dst)) {
-					MonoAndroidHelper.SetWriteable (dst);
-					MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (dst, date, Log);
-				}
+				MonoAndroidHelper.CopyIfChanged (src, dst);
 				list.Add (dst);
 			}
 			// so far we only need the package's R.java for GenerateResourceDesigner input.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyIfChanged.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyIfChanged.cs
@@ -22,8 +22,6 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public ITaskItem[] DestinationFiles { get; set; }
 
-		public bool KeepDestinationDates { get; set; }
-
 		[Output]
 		public ITaskItem[] ModifiedFiles { get; set; }
 
@@ -54,12 +52,7 @@ namespace Xamarin.Android.Tasks
 					MonoAndroidHelper.SetWriteable (dest);
 					continue;
 				}
-				MonoAndroidHelper.SetWriteable (dest);
 				modifiedFiles.Add (new TaskItem (dest));
-				if (KeepDestinationDates)
-					MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (dest, dstmodifiedDate, Log);
-				else
-					MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (dest, DateTime.UtcNow, Log);
 			}
 
 			ModifiedFiles = modifiedFiles.ToArray ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyMdbFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyMdbFiles.cs
@@ -31,8 +31,6 @@ namespace Xamarin.Android.Tasks {
 					var date = DateTime.Now;
 					if (MonoAndroidHelper.CopyIfChanged (src, dst)) {
 						copiedFiles.Add (DestinationFiles [i]);
-						MonoAndroidHelper.SetWriteable (dst);
-						MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (dst, date, Log);
 					}
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateAdditionalLibraryResourceCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateAdditionalLibraryResourceCache.cs
@@ -42,8 +42,6 @@ namespace Xamarin.Android.Tasks
 					var destPath = newPath.Replace (src, dest);
 					var cachedDate = File.GetLastWriteTimeUtc (src);
 					MonoAndroidHelper.CopyIfChanged (newPath, destPath);
-					MonoAndroidHelper.SetWriteable (destPath);
-					MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (destPath, cachedDate, Log);
 					copiedResources.Add (new TaskItem (destPath));
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
@@ -43,7 +43,6 @@ namespace Xamarin.Android.Tasks
 					var dest = Path.GetFullPath (item.ItemSpec).Replace (imageGroup.Key, tempDirectory);
 					Directory.CreateDirectory (Path.GetDirectoryName (dest));
 					MonoAndroidHelper.CopyIfChanged (item.ItemSpec, dest);
-					MonoAndroidHelper.SetWriteable (dest);
 				}
 
 				// crunch them
@@ -58,7 +57,6 @@ namespace Xamarin.Android.Tasks
 					if (!File.Exists (dest))
 						continue;
 					MonoAndroidHelper.CopyIfChanged (dest, item.ItemSpec);
-					MonoAndroidHelper.SetWriteable (dest);
 					// reset the Dates so MSBuild/xbuild doesn't think they changed.
 					MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (item.ItemSpec, srcmodifiedDate, Log);
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -306,9 +306,7 @@ namespace Xamarin.Android.Tasks
 			var np  = path + ".new";
 			using (var o = File.OpenWrite (np))
 				generator (o);
-			if (MonoAndroidHelper.CopyIfChanged (np, path)) {
-				MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (path, DateTime.UtcNow, Log);
-			}
+			MonoAndroidHelper.CopyIfChanged (np, path);
 			File.Delete (np);
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
@@ -171,22 +171,16 @@ namespace Xamarin.Android.Tasks
 					else if (!MonoAndroidHelper.IsForceRetainedAssembly (filename))
 						continue;
 
-					if (MonoAndroidHelper.CopyIfChanged (copysrc, assemblyDestination)) {
-						MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (assemblyDestination, DateTime.UtcNow, Log);
-					}
+					MonoAndroidHelper.CopyIfChanged (copysrc, assemblyDestination);
 					try {
 						var mdbDestination = assemblyDestination + ".mdb";
-						if (MonoAndroidHelper.CopyIfChanged (assembly.ItemSpec + ".mdb", mdbDestination)) {
-							MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (mdbDestination, DateTime.UtcNow, Log);
-						}
+						MonoAndroidHelper.CopyIfChanged (assembly.ItemSpec + ".mdb", mdbDestination);
 					} catch (Exception) { // skip it, mdb sometimes fails to read and it's optional
 					}
 					var pdb = Path.ChangeExtension (copysrc, "pdb");
 					if (File.Exists (pdb) && Files.IsPortablePdb (pdb)) {
 						var pdbDestination = Path.ChangeExtension (Path.Combine (copydst, filename), "pdb");
-						if (MonoAndroidHelper.CopyIfChanged (pdb, pdbDestination)) {
-							MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (pdbDestination, DateTime.UtcNow, Log);
-						}
+						MonoAndroidHelper.CopyIfChanged (pdb, pdbDestination);
 					}
 				}
 			} catch (ResolutionException ex) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -61,6 +61,9 @@ namespace Xamarin.Android.Tools {
 
 				if (!Directory.Exists (source)) {
 					File.Copy (source, destination, true);
+					MonoAndroidHelper.SetWriteable (destination);
+					File.SetLastWriteTimeUtc (destination, DateTime.UtcNow);
+					File.SetLastAccessTimeUtc (destination, DateTime.UtcNow);
 					return true;
 				}
 			}/* else
@@ -78,6 +81,8 @@ namespace Xamarin.Android.Tools {
 				using (var f = File.Create (destination)) {
 					source.CopyTo (f);
 				}
+				File.SetLastWriteTimeUtc (destination, DateTime.UtcNow);
+				File.SetLastAccessTimeUtc (destination, DateTime.UtcNow);
 #if TESTCACHE
 				if (hash != null)
 					File.WriteAllText (destination + ".hash", hash);
@@ -96,6 +101,8 @@ namespace Xamarin.Android.Tools {
 				Directory.CreateDirectory (Path.GetDirectoryName (destination));
 
 				File.Copy (source, destination, true);
+				File.SetLastWriteTimeUtc (destination, DateTime.UtcNow);
+				File.SetLastAccessTimeUtc (destination, DateTime.UtcNow);
 #if TESTCACHE
 				if (hash != null)
 					File.WriteAllText (destination + ".hash", hash);


### PR DESCRIPTION
…038)

`MonoAndroidHelper.CopyIfChanged()` has a boolean return value,
returning true if the destination file was updated, otherwise false.

Question: What should be done with this return value?

This is, surprisingly, a difficult question to answer: sometimes the
return value is checked, more often it isn't.  When it is checked,
it's to determine whether or not
`MonoAndroidHelper.SetLastAccessAndWriteTimeUtc()` should be called;
see e.g. commit d7e3a232.

So should `SetLastAccessAndWriteTimeUtc()` *always* be invoked?
Sometimes?  Never?  Is there a guideline *at all*?

Turns out...there wasn't a guideline that we could infer.
Additionally, the *lack* of `SetLastAccessAndWriteTimeUtc()` was a
*source* of bugs, as `File.Copy()` would *preserve* the timestamp
of the *source* file, while many targets want "updated" timestamps
to prevent the target from re-running again; again, d7e3a232.

This entire scenario is confusing.  Confusion is *not* good.

To try to clear up this confusion, a question:  Is there any scenario
for which `MonoAndroidHelper.CopyIfChanged()` *shouldn't* call
`MonoAndroidHelper.SetLastAccessAndWriteTimeUtc()` when the source
file needs to be copied to the target file?

We cannot currently imagine such a scenario.

Alter the semantics of `MonoAndroidHelper.CopyIfChanged()` so that
the timestamp of the target file is updated to "now" when the target
file is updated (i.e. the source file differs).

This *removes* many of our "update the write time if
`CopyIfChanged()` returned true" codepaths, and makes it considerably
easier to reason about what *exactly* should be done with the return
value of `MonoAndroidHelper.CopyIfChanged()`: it is now usually safe
to ignore, but if e.g. two files are "linked" in some way, it can
continue to be used.