### PR TITLE
[Xamarin.Android.Build.Tasks] Fix usage of wrong method to log warning.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -93,7 +93,7 @@ namespace Xamarin.Android.Tasks
 							Log.FixupResourceFilenameAndLogCodedError ("XA1002", message, file, resdir, resource_name_case_map);
 							break;
 						case TraceLevel.Warning:
-							Log.FixupResourceFilenameAndLogCodedError ("XA1001", message, file, resdir, resource_name_case_map);
+							Log.FixupResourceFilenameAndLogCodedWarning ("XA1001", message, file, resdir, resource_name_case_map);
 							break;
 						default:
 							Log.LogDebugMessage (message);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyAndConvertResources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyAndConvertResources.cs
@@ -107,7 +107,7 @@ namespace Xamarin.Android.Tasks
 						Log.FixupResourceFilenameAndLogCodedError ("XA1002", message, filename, resdir.ItemSpec, resource_name_case_map);
 						break;
 					case TraceLevel.Warning:
-						Log.FixupResourceFilenameAndLogCodedError ("XA1001", message, filename, resdir.ItemSpec, resource_name_case_map);
+						Log.FixupResourceFilenameAndLogCodedWarning ("XA1001", message, filename, resdir.ItemSpec, resource_name_case_map);
 						break;
 					default:
 						Log.LogDebugMessage (message);


### PR DESCRIPTION
Commit 1886e6f1 added new methods to log warnings and errors for
resource files. However the warning changes were calling the
`FixupResourceFilenameAndLogCodedError` method.

Lets call `FixupResourceFilenameAndLogCodedWarning` where it should
be called instead.