### PR TITLE
Added --classpath_entry for Desugar

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Desugar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Desugar.cs
@@ -75,7 +75,7 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitch ("--min_sdk_version ");
 			cmd.AppendSwitch (minApiVersion.ToString ());
 			
-			if(minApiVersion < 24) {
+			if (minApiVersion < 24) {
 				cmd.AppendSwitch("--desugar_try_with_resources_omit_runtime_classes ");
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Desugar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Desugar.cs
@@ -74,6 +74,10 @@ namespace Xamarin.Android.Tasks
 
 			cmd.AppendSwitch ("--min_sdk_version ");
 			cmd.AppendSwitch (minApiVersion.ToString ());
+			
+			if(minApiVersion < 24) {
+				commandLineBuilder.AppendSwitch("--desugar_try_with_resources_omit_runtime_classes ");
+			}
 
 			//cmd.AppendSwitchIfNotNull ("-J-Dfile.encoding=", "UTF8");
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Desugar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Desugar.cs
@@ -85,6 +85,8 @@ namespace Xamarin.Android.Tasks
 			foreach (var jar in InputJars) {
 				var output = Path.Combine (OutputDirectory, BitConverter.ToString (md5.ComputeHash (Encoding.UTF8.GetBytes (jar))) + Path.GetFileName (jar));
 				outputs.Add (output);
+				cmd.AppendSwitch ("--classpath_entry ");
+				cmd.AppendFileNameIfNotNull (jar);
 				cmd.AppendSwitch ("--input ");
 				cmd.AppendFileNameIfNotNull (jar);
 				cmd.AppendSwitch ("--output ");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Desugar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Desugar.cs
@@ -76,7 +76,7 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitch (minApiVersion.ToString ());
 			
 			if(minApiVersion < 24) {
-				commandLineBuilder.AppendSwitch("--desugar_try_with_resources_omit_runtime_classes ");
+				cmd.AppendSwitch("--desugar_try_with_resources_omit_runtime_classes ");
 			}
 
 			//cmd.AppendSwitchIfNotNull ("-J-Dfile.encoding=", "UTF8");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2973,6 +2973,42 @@ namespace UnnamedProject {
 				EnableDesugar = enableDesugar,
 				EnableProguard = enableProguard,
 			};
+			proj.AndroidManifest = proj.AndroidManifest.Replace ("<uses-sdk />", "<uses-sdk android:minSdkVersion=\"24\" />");
+			//Okhttp and Okio
+			//https://github.com/square/okhttp
+			//https://github.com/square/okio
+			if (enableProguard) {
+				//NOTE: these are just enough rules to get it to build, not optimal
+				var rules = new [] {
+					"-dontwarn javax.annotation.**",
+					"-dontwarn org.codehaus.mojo.animal_sniffer.*",
+				};
+				//FIXME: We aren't de-BOM'ing proguard files?
+				var encoding = new UTF8Encoding (encoderShouldEmitUTF8Identifier: false);
+				var bytes = encoding.GetBytes (string.Join (Environment.NewLine, rules));
+				proj.OtherBuildItems.Add (new BuildItem ("ProguardConfiguration", "okhttp3.pro") {
+					BinaryContent = () => bytes,
+				});
+			}
+			proj.OtherBuildItems.Add (new BuildItem ("AndroidJavaLibrary", "okio-1.13.0.jar") {
+				WebContent = "http://central.maven.org/maven2/com/squareup/okio/okio/1.13.0/okio-1.13.0.jar"
+			});
+			proj.OtherBuildItems.Add (new BuildItem ("AndroidJavaLibrary", "okhttp-3.8.0.jar") {
+				WebContent = "http://central.maven.org/maven2/com/squareup/okhttp3/okhttp/3.8.0/okhttp-3.8.0.jar"
+			});
+			proj.OtherBuildItems.Add (new BuildItem ("AndroidJavaLibrary", "retrofit-2.3.0.jar") {
+				WebContent = "http://central.maven.org/maven2/com/squareup/retrofit2/retrofit/2.3.0/retrofit-2.3.0.jar"
+			});
+			proj.OtherBuildItems.Add (new BuildItem ("AndroidJavaLibrary", "converter-gson-2.3.0.jar") {
+				WebContent = "http://central.maven.org/maven2/com/squareup/retrofit2/converter-gson/2.3.0/converter-gson-2.3.0.jar"
+			});
+			proj.OtherBuildItems.Add (new BuildItem ("AndroidJavaLibrary", "gson-2.7.jar") {
+				WebContent = "http://central.maven.org/maven2/com/google/code/gson/gson/2.7/gson-2.7.jar"
+			});
+			//Twitter SDK https://mvnrepository.com/artifact/com.twitter.sdk.android/twitter-core/3.3.0
+			proj.OtherBuildItems.Add (new BuildItem ("AndroidAarLibrary", "twitter-core-3.3.0.aar") {
+				WebContent = "http://repo.spring.io/libs-release/com/twitter/sdk/android/twitter-core/3.3.0/twitter-core-3.3.0.aar",
+			});
 			/* The source is simple:
 			 * 
 				public class Lambda

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2979,6 +2979,7 @@ namespace UnnamedProject {
 			if (enableProguard) {
 				//NOTE: these are just enough rules to get it to build, not optimal
 				var rules = new [] {
+					"-dontwarn com.google.devtools.build.android.desugar.**",
 					"-dontwarn javax.annotation.**",
 					"-dontwarn org.codehaus.mojo.animal_sniffer.*",
 				};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2973,7 +2973,6 @@ namespace UnnamedProject {
 				EnableDesugar = enableDesugar,
 				EnableProguard = enableProguard,
 			};
-			proj.AndroidManifest = proj.AndroidManifest.Replace ("<uses-sdk />", "<uses-sdk android:minSdkVersion=\"24\" />");
 			//Okhttp and Okio
 			//https://github.com/square/okhttp
 			//https://github.com/square/okio


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2143
Context: https://github.com/xamarin/xamarin-android/issues/1639

Xamarin.Android's current implementation of desugar runs a command
such as:

    java -jar desugar_deploy.jar 
        --bootclasspath_entry ~\android-toolchain\sdk\platforms\android-28\android.jar 
        --min_sdk_version 11 
        --classpath_entry xamarin-android\bin\Debug\lib\xamarin.android\xbuild-frameworks\MonoAndroid\v9.0\mono.android.jar 
        --input Lambda.jar 
        --output obj\Debug\android\bin\desugared\14-57-25-90-94-EE-16-09-B8-68-88-BC-9D-FC-6C-89Lambda.jar

However, certain jars are failing with messages such as:

    Exception in thread "main" java.lang.TypeNotPresentException: Type okhttp3.Interceptor not present

Or another example:

    Error: java.lang.TypeNotPresentException : Type io.reactivex.functions.Action not present

The first fix here is to add the `--classpath_entry` flag for every
`--input`, for some reason `Desugar` is not treating `--input` jars as
classpath entries?

Next, we expanded on the `BuildTest.Desugar` test using a complicated
set of Java libraries from Maven central:

    proj.OtherBuildItems.Add (new BuildItem ("AndroidJavaLibrary", "okio-1.13.0.jar") {
        WebContent = "http://central.maven.org/maven2/com/squareup/okio/okio/1.13.0/okio-1.13.0.jar"
    });
    proj.OtherBuildItems.Add (new BuildItem ("AndroidJavaLibrary", "okhttp-3.8.0.jar") {
        WebContent = "http://central.maven.org/maven2/com/squareup/okhttp3/okhttp/3.8.0/okhttp-3.8.0.jar"
    });
    proj.OtherBuildItems.Add (new BuildItem ("AndroidJavaLibrary", "retrofit-2.3.0.jar") {
        WebContent = "http://central.maven.org/maven2/com/squareup/retrofit2/retrofit/2.3.0/retrofit-2.3.0.jar"
    });
    proj.OtherBuildItems.Add (new BuildItem ("AndroidJavaLibrary", "converter-gson-2.3.0.jar") {
        WebContent = "http://central.maven.org/maven2/com/squareup/retrofit2/converter-gson/2.3.0/converter-gson-2.3.0.jar"
    });
    proj.OtherBuildItems.Add (new BuildItem ("AndroidJavaLibrary", "gson-2.7.jar") {
        WebContent = "http://central.maven.org/maven2/com/google/code/gson/gson/2.7/gson-2.7.jar"
    });
    proj.OtherBuildItems.Add (new BuildItem ("AndroidAarLibrary", "twitter-core-3.3.0.aar") {
        WebContent = "http://repo.spring.io/libs-release/com/twitter/sdk/android/twitter-core/3.3.0/twitter-core-3.3.0.aar",
    });

This was working, as long as you had `android:minSdkVersion="24"` in
your `AndroidManifest.xml`. This wasn't ideal if you wanted to run
your app on older API levels...

Luckily, another command line switched solved this problem:

    //Added to the Desugar MSBuild task
    if (minApiVersion < 24) {
        cmd.AppendSwitch("--desugar_try_with_resources_omit_runtime_classes ");
    }

What a crazy name for a flag! Documented by `desugar` as:

    --[no]desugar_try_with_resources_omit_runtime_classes (a boolean; default: "false")
        Omits the runtime classes necessary to support try-with-resources from the
        output. This property has effect only if --
        desugar_try_with_resources_if_needed is used.
    --min_sdk_version (an integer; default: "1")
        Minimum targeted sdk version.  If >= 24, enables default methods in
        interfaces.

This makes sense that something would happen at API level 24...

Once doing this, the `Desugar` test passes without modifying
`minSdkVersion`.

The expanded `Desugar` test will also greatly help with our D8/R8
implementation
(https://github.com/xamarin/xamarin-android/issues/2040).

This complex set of Java dependencies from Maven will be useful.