### PR TITLE
[download-bundle] Update mono bundle download URL

### DIFF
--- a/build-tools/download-bundle/download-bundle.targets
+++ b/build-tools/download-bundle/download-bundle.targets
@@ -4,7 +4,7 @@
   <UsingTask AssemblyFile="$(OutputPath)xa-prep-tasks.dll"   TaskName="Xamarin.Android.BuildTools.PrepTasks.SystemUnzip" />
   <Import Project="..\create-bundle\bundle-path.targets" />
   <PropertyGroup>
-    <_AzureBaseUri>https://xamjenkinsartifact.azureedge.net/xamarin-android/xamarin-android/bin/</_AzureBaseUri>
+    <_AzureBaseUri>https://xamjenkinsartifact.azureedge.net/mono-jenkins/xamarin-android/bin/</_AzureBaseUri>
     <_NuGetUri>https://dist.nuget.org/win-x86-commandline/latest/nuget.exe</_NuGetUri>
     <_NuGetPath>$(MSBuildThisFileDirectory)\..\..\.nuget</_NuGetPath>
   </PropertyGroup>


### PR DESCRIPTION
Around 2018-Aug-15, the Jenkins config for xamarin-android was changed
in a way which [altered the URL for where files are uploaded][0] so
that it contained `${BUILD_NUMBER}`, which is a value which increments
on every build.  A consequence of this change is that the bundle could
no longer used, as it could no longer be *found*, as there is no way
of knowing what `${BUILD_NUMBER}` could possibly be, which in turn
caused increased build times for PRs and master builds, as mono would
now always need to be rebuilt.

On 2018-Sep-7, the [Jenkins config was updated][1] to remove
`${BUILD_NUMBER}` from the URL, allowing for "static" URLs which works
with our bundle mechansism.

With the removal of `${BUILD_NUMBER}`, we're good, right?  The bundle
should now be used?

Not so much.  One other part needs updating: the *rest* of the URL
*also* changed as part of the 2018-Aug-15 change!
`download-bundle.targets` was attempting to download e.g.:

	https://xamjenkinsartifact.azureedge.net/xamarin-android/xamarin-android/bin/Debug/bundle-v21-h7419ab9f-Debug-Darwin-libzip=b95cf3f,llvm=bdb3a11,mono=cca6805.zip

However, the *correct* URL we now need to download is e.g.:

	https://xamjenkinsartifact.blob.core.windows.net/mono-jenkins/xamarin-android/bin/Debug/bundle-v21-h7419ab9f-Debug-Darwin-libzip=b95cf3f,llvm=bdb3a11,mono=cca6805.zip

Update `$(_AzureBaseUri)` so that we now download from the correct
base URL, so that the mono bundle can actually be downloaded.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/jobConfigHistory/showDiffFiles?timestamp1=2018-07-23_19-09-25&timestamp2=2018-08-15_22-31-28
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/jobConfigHistory/showDiffFiles?timestamp1=2018-08-31_14-49-55&timestamp2=2018-09-07_18-49-53