### PR TITLE
Make Android emulator creation task slightly less racy

### DIFF
--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -118,7 +118,7 @@
     />
     <Exec
         Condition=" '$(HostOS)' != 'Windows' And '$(_EmuTarget)' != '' "
-        ContinueOnError="ErrorAndContinue"
+        ContinueOnError="WarnAndContinue"
         Command="kill -HUP $(_EmuPid)"
     />
     <Sleep
@@ -127,7 +127,7 @@
     />
     <Exec
         Condition=" '$(HostOS)' != 'Windows' And '$(_EmuTarget)' != '' "
-        ContinueOnError="ErrorAndContinue"
+        ContinueOnError="WarnAndContinue"
         Command="kill -KILL $(_EmuPid)"
     />
   </Target>
@@ -174,7 +174,7 @@
       Condition=" '@(TestApk)' != '' ">
     <Xamarin.Android.Tools.BootstrapTasks.Adb
         Condition=" '@(TestApkPermission)' != '' "
-        ContinueOnError="ErrorAndContinue"
+        IgnoreExitCode="True"
         Arguments="$(_AdbTarget) $(AdbOptions) shell pm grant %(TestApkPermission.Package) android.permission.%(TestApkPermission.Identity)"
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)"


### PR DESCRIPTION
The `CreateAndroidEmulator` task calls the Android SDK utility
`avdmanager` (which replaced the former `android` tool in creation of AVDs) in
order to create an instance of AVD used by our APK tests. The tool has the habit
of asking a question whether or not the user wants to create a custom hardware
profile for the emulator and it cannot be persuaded to not ask that question.
So, in order to be polite and answer it, we loop after the process has started
and keep sending it newline characters which, at some point, answer the question
and everybody is happy.

The process works most of the time but, unfortunately, it requires us to rely on
`System.Diagnostics.Process.HasExited` property which is *not* a reliable way to
test whether the process went away, *especially* right after it quit. And so
sometimes we attempt to write the standard input of the process when the process
is already gone which results in an exception similar to the one below:

```
 The "CreateAndroidEmulator" task failed unexpectedly.
 System.IO.IOException: Write fault on path /Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/tests/[Unknown]
   at System.IO.FileStream.WriteInternal (System.Byte[] src, System.Int32 offset, System.Int32 count) [0x000be] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-04/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.IO/FileStream.cs:658
   at System.IO.FileStream.Write (System.Byte[] array, System.Int32 offset, System.Int32 count) [0x00090] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-04/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.IO/FileStream.cs:614
   at System.IO.StreamWriter.Flush (System.Boolean flushStream, System.Boolean flushEncoder) [0x0007e] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-04/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/io/streamwriter.cs:318
   at System.IO.StreamWriter.Write (System.Char[] buffer) [0x00079] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-04/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/io/streamwriter.cs:392
   at System.IO.TextWriter.WriteLine () [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-04/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/io/textwriter.cs:372
   at Xamarin.Android.Tools.BootstrapTasks.CreateAndroidEmulator.Exec (System.String android, System.String arguments, System.Diagnostics.DataReceivedEventHandler stderr) [0x00161] in /Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateAndroidEmulator.cs:136
   at Xamarin.Android.Tools.BootstrapTasks.CreateAndroidEmulator.Run (System.String android) [0x0002d] in /Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateAndroidEmulator.cs:74
   at Xamarin.Android.Tools.BootstrapTasks.CreateAndroidEmulator.Execute () [0x001a0] in /Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateAndroidEmulator.cs:46
   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute () [0x00023] in /_/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs:631
   at Microsoft.Build.BackEnd.TaskBuilder+<ExecuteInstantiatedTask>d__26.MoveNext () [0x001f6] in /_/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs:787
```

To make the race window smaller, this commit changes the way we wait for the
process to quit as well as it corrects some issues with the way we capture
stderr from the process. In addition, it catches and reports on the above
IOException without breaking the build, should the race happen anyway.