### PR TITLE
[Xamarin.Android.Build.Tasks] Add coded error for armeabi

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -40,6 +40,7 @@
 + [XA0112](xa0112.md): `aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.
 + [XA0113](xa0113.md): Google Play requires that new applications must use a `$(TargetFrameworkVersion)` of v8.0 (API level 26) or above.
 + [XA0114](xa0114.md): Google Play requires that application updates must use a `$(TargetFrameworkVersion)` of v8.0 (API level 26) or above.
++ [XA0115](xa0115.md): Invalid value 'armeabi' in $(AndroidSupportedAbis). This ABI is no longer supported. Please update your project properties.
 
 ### XA1xxx Project Related
 

--- a/Documentation/guides/messages/xa0115.md
+++ b/Documentation/guides/messages/xa0115.md
@@ -1,0 +1,15 @@
+# Compiler Error XA0115
+
+Due to the [removal of armeabi support in Android NDK r17][ndk-guide],
+Xamarin.Android 9.1 is the last version that supports the armeabi architecture.
+Projects that have this old ABI selected in the `$(AndroidSupportedAbis)`
+property will need to be updated to remove it before they will build
+successfully with newer versions of Xamarin.Android.  The newer armeabi-v7a ABI
+should now be used instead.  The `$(AndroidSupportedAbis)` setting can be found
+in the **Advanced** section of the **Android Options** project properties in
+Visual Studio and **Android Build** project properties in Visual Studio for Mac.
+
+Example message:
+- `Invalid value 'armeabi' in $(AndroidSupportedAbis). This ABI is no longer supported. Please update your project properties.`
+
+[ndk-guide]: https://developer.android.com/ndk/guides/abis

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3021,6 +3021,20 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 				}
 			}
 		}
+
+		[Test]
+		public void XA0115 ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty (KnownProperties.AndroidSupportedAbis, "armeabi;armeabi-v7a");
+			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
+				builder.ThrowOnBuildFailure = false;
+				Assert.IsFalse (builder.Build (proj), "Build should have failed with XA0115.");
+				StringAssertEx.Contains ($"error XA0115", builder.LastBuildOutput, "Error should be XA0115");
+				Assert.IsTrue (builder.Clean (proj), "Clean should have succeeded.");
+			}
+		}
+
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1047,8 +1047,9 @@ because xbuild doesn't support framework reference assemblies.
 		<_RequestedAbis>;$(AndroidSupportedAbis);</_RequestedAbis>
 	</PropertyGroup>
 	<Error Code="XA0115"
-		Text="Invalid value 'armeabi' in %24(AndroidSupportedAbis). This ABI is no longer supported. Please update your project properties."
-		Condition="$(_RequestedAbis.Contains(';armeabi;'))" />
+			Condition="$(_RequestedAbis.Contains(';armeabi;'))"
+			Text="Invalid value 'armeabi' in %24(AndroidSupportedAbis). This ABI is no longer supported. Please update your project properties."
+	/>
 </Target>
 
 <Target Name="_CheckForContent">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -529,6 +529,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     _CheckProjectItems;
     _CheckForContent;
     _CheckTargetFramework;
+    _CheckSupportedAbis;
     _RemoveLegacyDesigner;
     _ValidateAndroidPackageProperties;
     $(BuildDependsOn);
@@ -1039,6 +1040,15 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_CheckTargetFramework">
 	<Warning Code="XA0109" Text="Unsupported or invalid %24(TargetFrameworkVersion) value of 'v4.5'. Please update your Project Options." Condition=" '$(TargetFrameworkVersion)' == 'v4.5' "/> 
+</Target>
+
+<Target Name="_CheckSupportedAbis">
+	<PropertyGroup>
+		<_RequestedAbis>;$(AndroidSupportedAbis);</_RequestedAbis>
+	</PropertyGroup>
+	<Error Code="XA0115"
+		Text="Invalid value 'armeabi' in %24(AndroidSupportedAbis). This ABI is no longer supported. Please update your project properties."
+		Condition="$(_RequestedAbis.Contains(';armeabi;'))" />
 </Target>
 
 <Target Name="_CheckForContent">


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/2173
Context: https://github.com/xamarin/xamarin-android/pull/2106

This commit checks for the presence of the now unsupported armeabi architecture in the `$(AndroidSupportedAbis)` property by using a conditional error in a new target.  Another option could be to to change the error to a warning and *ignore* the ";armeabi;" substring in the
property.  But that seems a little risky for cases where users might not notice the warning.  They would probably be surprised later when they discovered that their APKs did not contain armeabi support.

I also debated on whether it would be better to move this check into the `BuildApk` task.  I decided that since it is just a small test to look for a substring in an MSBuild property, using a conditional `Error` task in a small new target seems fine.

I verified that this new error appears in the build output as desired if the `$(AndroidSupportedAbis)` property includes "armeabi" either by itself or at the beginning, middle, or end of a list.  I also verified that the error does *not* appear and that the `SignAndroidPackage` target completes successfully when the property is set to "armeabi-v7a;x86".