### PR TITLE
[Xamarin.Android.Build.Tasks] skip _CleanIntermediateIfNuGetsChange on first build

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -653,7 +653,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <Target Name="_CleanIntermediateIfNuGetsChange" DependsOnTargets="_BeforeCleanIntermediateIfNuGetsChange"
     Inputs="$(_NuGetAssetsFile)"
     Outputs="$(_AndroidNuGetStampFile)">
-  <CallTarget Targets="_CleanMonoAndroidIntermediateDir" />
+  <CallTarget Targets="_CleanMonoAndroidIntermediateDir" Condition="Exists('$(_AndroidNuGetStampFile)')" />
   <MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" />
   <Touch Files="$(_AndroidNuGetStampFile)" AlwaysCreate="true" />
   <ItemGroup>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2183
Context: https://github.com/xamarin/xamarin-android/issues/2177
Context: https://github.com/xamarin/xamarin-android/pull/1878
Context: http://work.devdiv.io/661455

We are seeing reports of issues related to VS for Mac displaying
`Updating Android Resources...` in the title bar, and a build running
at the same time.

This is effectively running two commands at the same time:

    msbuild YourAndroid.csproj /t:UpdateAndroidResources
    msbuild YourAndroid.csproj /t:Build

In the case such as #2183, we get the failure:

    Task "RemoveDirFixed"
        Xamarin.Android.Common.targets(3042,2): error : Directory /Users/builder/agent/_work/r1/a/XQA.VSMac/XQA.VisualStudioMac/TestResults/26ff4d25/TestAndroidEnableAOTEnterprise/Temp/DroidApp/DroidApp/obj/Release/lp/ is not empty

In this case, the error is coming from
`_CleanIntermediateIfNuGetsChange`, which has an issue we can improve.
The target is *meant* to only run when NuGets change, but is currently
running on a first build.

If we skip the call to `_CleanMonoAndroidIntermediateDir` if
`$(_AndroidNuGetStampFile)` does not exist, then our
`_CleanIntermediateIfNuGetsChange` target will only clean files in
later builds when NuGets change.

I've not found anything we can do for the root cause of the VS for Mac
issue, but this will at least help matters on the initial build.