### PR TITLE
Enabled TLS 1.1 and 1.2 support on platforms >= 16 and <= 20

### DIFF
--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -335,6 +335,7 @@
     <Compile Include="Xamarin.Android.Net\AuthModuleBasic.cs" />
     <Compile Include="Xamarin.Android.Net\AuthModuleDigest.cs" />
     <Compile Include="Xamarin.Android.Net\IAndroidAuthenticationModule.cs" />
+    <Compile Include="Xamarin.Android.Net\OldAndroidSSLSocketFactory.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\build-tools\api-xml-adjuster\api-xml-adjuster.csproj">

--- a/src/Mono.Android/Test/Xamarin.Android.Net/AndroidClientHandlerTests.cs
+++ b/src/Mono.Android/Test/Xamarin.Android.Net/AndroidClientHandlerTests.cs
@@ -153,7 +153,7 @@ namespace Xamarin.Android.NetTests {
 		[Test]
 		public void Tls_1_2_Url_Works ()
 		{
-			if (((int) Build.VERSION.SdkInt) < 21) {
+			if (((int) Build.VERSION.SdkInt) < 16) {
 				Assert.Ignore ("Host platform doesn't support TLS 1.2.");
 				return;
 			}

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Android.OS;
 using Android.Runtime;
 using Java.IO;
 using Java.Net;
@@ -804,6 +805,13 @@ namespace Xamarin.Android.Net
 			SSLSocketFactory socketFactory = ConfigureCustomSSLSocketFactory (httpsConnection);
 			if (socketFactory != null) {
 				httpsConnection.SSLSocketFactory = socketFactory;
+				return;
+			}
+
+			// Context: https://github.com/xamarin/xamarin-android/issues/1615
+			int apiLevel = (int)Build.VERSION.SdkInt;
+			if (apiLevel >= 16 && apiLevel <= 20) {
+				httpsConnection.SSLSocketFactory = new OldAndroidSSLSocketFactory ();
 				return;
 			}
 

--- a/src/Mono.Android/Xamarin.Android.Net/OldAndroidSSLSocketFactory.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/OldAndroidSSLSocketFactory.cs
@@ -1,0 +1,61 @@
+using Java.Net;
+using Javax.Net.Ssl;
+
+namespace Xamarin.Android.Net
+{
+	// Context: https://github.com/xamarin/xamarin-android/issues/1615
+	//
+	// Code based on the code provided in the issue above
+	//
+	class OldAndroidSSLSocketFactory : SSLSocketFactory
+	{
+		readonly SSLSocketFactory factory = (SSLSocketFactory)Default;
+
+		public override string[] GetDefaultCipherSuites ()
+		{
+			return factory.GetDefaultCipherSuites ();
+		}
+
+		public override string[] GetSupportedCipherSuites ()
+		{
+			return factory.GetSupportedCipherSuites ();
+		}
+		public override Socket CreateSocket (InetAddress address, int port, InetAddress localAddress, int localPort)
+		{
+			return EnableTlsOnSocket (factory.CreateSocket (address, port, localAddress, localPort));
+		}
+
+		public override Socket CreateSocket (InetAddress host, int port)
+		{
+			return EnableTlsOnSocket (factory.CreateSocket (host, port));
+		}
+
+		public override Socket CreateSocket (string host, int port, InetAddress localHost, int localPort)
+		{
+			return EnableTlsOnSocket (factory.CreateSocket (host, port, localHost, localPort));
+		}
+
+		public override Socket CreateSocket (string host, int port)
+		{
+			return EnableTlsOnSocket (factory.CreateSocket (host, port));
+		}
+
+		public override Socket CreateSocket (Socket s, string host, int port, bool autoClose)
+		{
+			return EnableTlsOnSocket (factory.CreateSocket (s, host, port, autoClose));
+		}
+
+		public override Socket CreateSocket ()
+		{
+			return EnableTlsOnSocket (factory.CreateSocket ());
+		}
+
+		private Socket EnableTlsOnSocket (Socket socket)
+		{
+			if (socket is SSLSocket sslSocket) {
+				sslSocket.SetEnabledProtocols (sslSocket.GetSupportedProtocols ());
+			}
+			return socket;
+		}
+	}
+}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/1615

It turns out that the older platforms do support TLS 1.1 and 1.2 protocols but
that they don't enable it by default. Thanks to code provided by
https://github.com/gameleon-dev in the issue linked to above we now support it
too.

Updated the TLS 1.2 tests to enable them on platforms >= 16