### PR TITLE
[build] Build Xamarin.Android.NUnitLite.dll for API-10

### DIFF
--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -114,8 +114,8 @@ framework-assemblies:
 		rm -f bin/$(conf)/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v1.0/Xamarin.Android.NUnitLite.dll; \
 		$(call MSBUILD_BINLOG,NUnitLite,$(_SLN_BUILD),$(conf)) $(MSBUILD_FLAGS) src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj \
 			/p:Configuration=$(conf) $(_MSBUILD_ARGS) \
-			/p:AndroidApiLevel=$(lastword $(API_LEVELS)) /p:AndroidPlatformId=$(word $(lastword $(API_LEVELS)), $(ALL_PLATFORM_IDS)) \
-			/p:AndroidFrameworkVersion=$(lastword $(FRAMEWORKS)) || exit 1; )
+			/p:AndroidApiLevel=$(firstword $(API_LEVELS)) /p:AndroidPlatformId=$(word $(firstword $(API_LEVELS)), $(ALL_PLATFORM_IDS)) \
+			/p:AndroidFrameworkVersion=$(firstword $(FRAMEWORKS)) || exit 1; )
 	_latest_stable_framework=$$($(MSBUILD) /p:DoNotLoadOSProperties=True /nologo /v:minimal /t:GetAndroidLatestStableFrameworkVersion build-tools/scripts/Info.targets | tr -d '[[:space:]]') ; \
 	$(foreach conf, $(CONFIGURATIONS), \
 		rm -f "bin/$(conf)/lib/xamarin.android/xbuild-frameworks/MonoAndroid/$$_latest_stable_framework"/Mono.Android.Export.* ; \

--- a/src/Xamarin.Android.NUnitLite/Gui/Instrumentations/TestSuiteInstrumentation.cs
+++ b/src/Xamarin.Android.NUnitLite/Gui/Instrumentations/TestSuiteInstrumentation.cs
@@ -103,11 +103,7 @@ namespace Xamarin.Android.NUnitLite {
 
 		string GetResultsPath ()
 		{
-			Java.IO.File resultsPathFile = null;
-#if __ANDROID_19__
-			if (((int)Build.VERSION.SdkInt) >= 19)
-				resultsPathFile = Context.GetExternalFilesDir (global::Android.OS.Environment.DirectoryDocuments);
-#endif
+			Java.IO.File resultsPathFile = GetExternalFilesDir ();
 			var usePathFile = resultsPathFile != null && resultsPathFile.Exists ();
 			var resultsPath = usePathFile
 				? resultsPathFile.AbsolutePath
@@ -115,6 +111,19 @@ namespace Xamarin.Android.NUnitLite {
 			if (!usePathFile && !Directory.Exists (resultsPath))
 				Directory.CreateDirectory (resultsPath);
 			return Path.Combine (resultsPath, "TestResults.xml");
+		}
+
+		Java.IO.File GetExternalFilesDir ()
+		{
+			if (((int)Build.VERSION.SdkInt) < 19)
+				return null;
+			string type = null;
+#if __ANDROID_19__
+			type = global::Android.OS.Environment.DirectoryDocuments;
+#else   // !__ANDROID_19__
+			type = global::Android.OS.Environment.DirectoryDownloads;
+#endif  // !__ANDROID_19__
+			return Context.GetExternalFilesDir (type);
 		}
 
 		// On some Android targets, the external storage directory is "emulated",


### PR DESCRIPTION
Context: 24158d08be1db5a45dfd2ebfe8c05a85bfa8af00
Fixes: https://github.com/xamarin/xamarin-android/issues/2189

What do we want?  A reliable way to get `TestResults.xml` files off of
the Android target device, so that we can get unit test results.
A reliable way that works on a variety of Android API levels and their
corresponding emulators.

(What do we want?  ***GREEN BUILDS***.)

The problem with 24158d08 is twofold:

 1. When building an app with a `$(TargetFrameworkVersion)` less than
    `v9.0` (`$(lastword $(API_LEVELS))`), there is a build warning:

        warning XA0105: The $(TargetFrameworkVersion) for 'Foo' (v9.0) is greater than the $(TargetFrameworkVersion) for your project (v5.0). You need to increase the $(TargetFrameworkVersion) for your project.

 2. When *running*/using `Xamarin.Android.NUnitLite.dll` on an API-10
    device/pre-API-21 device, there is a *runtime* error.

(1) is ignorable, -ish.

(2) is not:

	FATAL EXCEPTION: main
	Process: Xamarin.Android.Locale_Tests, PID: 12615
	android.runtime.JavaProxyThrowable: System.TypeLoadException: Could not resolve type with token 010000d4 from typeref (expected class 'Android.OS.BaseBundle' in assembly 'Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065')
	  at Xamarin.Android.NUnitLite.AndroidRunner.GetSetupTestTarget (Android.Content.Intent intent) [0x00000] in /Users/builder/data/lanes/6102/d2851781/source/monodroid/external/xamarin-android/src/Xamarin.Android.NUnitLite/Gui/AndroidRunner.cs:345
	  at Xamarin.Android.NUnitLite.TestSuiteActivity.SetupTestTarget () [0x00008] in /Users/builder/data/lanes/6102/d2851781/source/monodroid/external/xamarin-android/src/Xamarin.Android.NUnitLite/Gui/Activities/TestSuiteActivity.cs:246
	  at Xamarin.Android.NUnitLite.TestSuiteActivity.UpdateData (Android.Runtime.JavaList`1[T] data, Android.Widget.ListView lv) [0x00006] in /Users/builder/data/lanes/6102/d2851781/source/monodroid/external/xamarin-android/src/Xamarin.Android.NUnitLite/Gui/Activities/TestSuiteActivity.cs:137
	  at Xamarin.Android.NUnitLite.TestSuiteActivity.OnCreate (Android.OS.Bundle bundle) [0x0003b] in /Users/builder/data/lanes/6102/d2851781/source/monodroid/external/xamarin-android/src/Xamarin.Android.NUnitLite/Gui/Activities/TestSuiteActivity.cs:49
	  at Xamarin.Android.LocaleTests.MainActivity.OnCreate (Android.OS.Bundle bundle) [0x0000d] in C:\Users\peter\source\monodroid\external\xamarin-android\tests\locales\Xamarin.Android.Locale-Tests\MainActivity.cs:19

Consequently, while 24158d08 gave *us* a green Jenkins job, the
resulting assembly is not usable when run on Android devices < API-21.

The fix?  Partially revert 24158d08 so that
`Xamarin.Android.NUnitLite.dll` is once again built against
`$(firstword $(API_LEVELS))`, i.e. API-10, and instead update
`Xamarin.Android.NUnitLite.dll` so that instead of using
`Environment.DirectoryDocuments` -- which only exists in API-19+ -- we
use `Environment.DirectoryDownloads` on pre-API-19 devices.

Let's see if this works!