### PR TITLE
Make sure app bundle has soname set

### DIFF
--- a/Xamarin.Android-Tests.sln
+++ b/Xamarin.Android-Tests.sln
@@ -36,6 +36,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CodeGen-MkBundle", "CodeGen
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Android.MakeBundle-Tests", "tests\CodeGen-MkBundle\Xamarin.Android.MakeBundle-Tests\Xamarin.Android.MakeBundle-Tests.csproj", "{A0B2692E-9FBE-4157-9526-7145F07F2C5A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Android.MakeBundle-UnitTests", "tests\CodeGen-MkBundle\Xamarin.Android.MakeBundle-UnitTests\Xamarin.Android.MakeBundle-UnitTests.csproj", "{FA8EEC88-CA3C-4D69-B206-54B392570DC6}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ResolveImports", "ResolveImports", "{E49089E4-4CE0-475E-BE9C-0AB4E4D56EE9}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Android.BindingResolveImportLib1", "tests\ResolveImports\Xamarin.Android.BindingResolveImportLib1\Xamarin.Android.BindingResolveImportLib1.csproj", "{2A0519DF-0DDA-45F7-AC3C-E2992748D364}"
@@ -206,6 +208,10 @@ Global
 		{B160F0E7-799A-4EB9-92B8-D71623C7674A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B160F0E7-799A-4EB9-92B8-D71623C7674A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B160F0E7-799A-4EB9-92B8-D71623C7674A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FA8EEC88-CA3C-4D69-B206-54B392570DC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FA8EEC88-CA3C-4D69-B206-54B392570DC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FA8EEC88-CA3C-4D69-B206-54B392570DC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FA8EEC88-CA3C-4D69-B206-54B392570DC6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -18,6 +18,7 @@
     <_TestAssembly Include="$(_TopDir)\bin\Test$(Configuration)\Xamarin.Android.Build.Tests.dll" />
     <_TestAssembly Include="$(_TopDir)\bin\Test$(Configuration)\CodeBehind\CodeBehindUnitTests.dll" />
     <_TestAssembly Include="$(_TopDir)\bin\Test$(Configuration)\EmbeddedDSO\EmbeddedDSOUnitTests.dll" />
+    <_TestAssembly Include="$(_TopDir)\bin\Test$(Configuration)\Xamarin.Android.MakeBundle-UnitTests\Xamarin.Android.MakeBundle-UnitTests.dll" />
     <_ApkTestProject Include="$(_TopDir)\src\Mono.Android\Test\Mono.Android-Tests.csproj" />
     <_ApkTestProject Include="$(_TopDir)\tests\CodeGen-Binding\Xamarin.Android.JcwGen-Tests\Xamarin.Android.JcwGen-Tests.csproj" />
     <_ApkTestProject Include="$(_TopDir)\tests\CodeGen-MkBundle\Xamarin.Android.MakeBundle-Tests\Xamarin.Android.MakeBundle-Tests.csproj" />

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
@@ -18,6 +18,8 @@ namespace Xamarin.Android.Tasks
 	// can't be a single ToolTask, because it has to run mkbundle many times for each arch.
 	public class MakeBundleNativeCodeExternal : Task
 	{
+		const string BundleSharedLibraryName = "libmonodroid_bundle_app.so";
+
 		[Required]
 		public string AndroidNdkDirectory { get; set; }
 
@@ -202,8 +204,12 @@ namespace Xamarin.Android.Tasks
 				clb.AppendSwitch ("--shared");
 				clb.AppendFileNameIfNotNull (Path.Combine (outpath, "temp.o"));
 				clb.AppendFileNameIfNotNull (Path.Combine (outpath, "assemblies.o"));
+
+				// API23+ requires that the shared library has its soname set or it won't load
+				clb.AppendSwitch ("-soname");
+				clb.AppendSwitch (BundleSharedLibraryName);
 				clb.AppendSwitch ("-o");
-				clb.AppendFileNameIfNotNull (Path.Combine (outpath, "libmonodroid_bundle_app.so"));
+				clb.AppendFileNameIfNotNull (Path.Combine (outpath, BundleSharedLibraryName));
 				clb.AppendSwitch ("-L");
 				clb.AppendFileNameIfNotNull (NdkUtil.GetNdkPlatformLibPath (AndroidNdkDirectory, arch, level));
 				clb.AppendSwitch ("-lc");

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-Tests/Xamarin.Android.MakeBundle-Tests.csproj
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-Tests/Xamarin.Android.MakeBundle-Tests.csproj
@@ -19,7 +19,16 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
   </PropertyGroup>
-  <Import Project="..\..\..\Configuration.props" />
+
+  <PropertyGroup Condition=" '$(UnitTestsMode)' == 'true' ">
+    <RelativeRootPath>..\..\..\..\..\..</RelativeRootPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(UnitTestsMode)' != 'true' ">
+    <RelativeRootPath>..\..\..</RelativeRootPath>
+  </PropertyGroup>
+
+  <Import Project="$(RelativeRootPath)\Configuration.props" />
   <PropertyGroup>
     <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
   </PropertyGroup>
@@ -27,16 +36,20 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\bin\TestDebug</OutputPath>
+    <OutputPath Condition=" '$(UnitTestsMode)' != 'true' ">$(RelativeRootPath)\bin\TestDebug</OutputPath>
+    <OutputPath Condition=" '$(UnitTestsMode)' == 'true' ">bin\Debug</OutputPath>
     <DefineConstants>DEBUG;__MOBILE__;__ANDROID__;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
     <ConsolePause>false</ConsolePause>
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+    <BundleAssemblies>true</BundleAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
-    <OutputPath>..\..\..\bin\TestRelease</OutputPath>
+    <OutputPath Condition=" '$(UnitTestsMode)' != 'true' ">$(RelativeRootPath)\bin\TestRelease</OutputPath>
+    <OutputPath Condition=" '$(UnitTestsMode)' == 'true' ">bin\Release</OutputPath>
     <DefineConstants>__MOBILE__;__ANDROID__;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/BuildTests.cs
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/BuildTests.cs
@@ -1,0 +1,303 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Xml;
+using System.Xml.XPath;
+
+using Microsoft.Build.Framework;
+using NUnit.Framework;
+using Xamarin.ProjectTools;
+using Xamarin.Tools.Zip;
+
+using XABuildPaths = global::Xamarin.Android.Build.Paths;
+
+namespace Xamarin.Android.MakeBundle.UnitTests
+{
+	sealed class LocalBuilder : Builder
+	{
+		public bool Build (string projectOrSolution, string target, string[] parameters = null, Dictionary<string, string> environmentVariables = null)
+		{
+			return BuildInternal (projectOrSolution, target, parameters, environmentVariables);
+		}
+	}
+
+	[Parallelizable (ParallelScope.Children)]
+	public class BuildTests_EmbeddedDSOBuildTests
+	{
+		const string ProjectName = "Xamarin.Android.MakeBundle-Tests";
+		const string ProjectAssemblyName = "Xamarin.Android.MakeBundle-Tests";
+		const string ProjectPackageName = "Xamarin.Android.MakeBundle_Tests";
+
+		static readonly char[] ElfDynamicFieldSep = new [] { ' ', '\t' };
+		static readonly string TestProjectRootDirectory;
+		static readonly string TestOutputDir;
+
+		static readonly List <string> produced_binaries = new List <string> {
+			$"{ProjectAssemblyName}.dll",
+			$"{ProjectPackageName}-Signed.apk",
+			$"{ProjectPackageName}.apk",
+		};
+
+		static readonly List <string> log_files = new List <string> {
+			"process.log",
+			"msbuild.binlog",
+		};
+
+		static readonly string[] bundles = new [] {
+			"lib/x86/libmonodroid_bundle_app.so",
+			"lib/armeabi-v7a/libmonodroid_bundle_app.so",
+		};
+
+		string elfReaderPath;
+		bool elfReaderLlvm;
+		string testProjectPath;
+		string apk;
+
+		static BuildTests_EmbeddedDSOBuildTests ()
+		{
+			TestProjectRootDirectory = Path.GetFullPath (Path.Combine (XABuildPaths.TopDirectory, "tests", "CodeGen-MkBundle", "Xamarin.Android.MakeBundle-Tests"));
+			TestOutputDir = Path.Combine (XABuildPaths.TestOutputDirectory, "CodeGen-MkBundle");
+		}
+
+		[TestFixtureSetUp]
+		public void BuildProject ()
+		{
+			if (File.Exists (Config.LlvmReadobj)) {
+				elfReaderPath = Config.LlvmReadobj;
+				elfReaderLlvm = true;
+			} else if (File.Exists (Config.GccReadelf)) {
+				elfReaderPath = Config.GccReadelf;
+				elfReaderLlvm = false;
+			} else
+				Assert.Fail ($"No ELF reader found. Tried '{Config.LlvmReadobj}' and '{Config.GccReadelf}'");
+
+			Console.WriteLine ($"Will use the following ELF reader: {elfReaderPath}");
+
+			testProjectPath = PrepareProject (ProjectName);
+			apk = Path.Combine (testProjectPath, "bin", XABuildPaths.Configuration, $"{ProjectPackageName}-Signed.apk");
+			string projectPath = Path.Combine (testProjectPath, $"{ProjectName}.csproj");
+			LocalBuilder builder = GetBuilder ("Xamarin.Android.MakeBundle-Tests");
+			bool success = builder.Build (projectPath, "SignAndroidPackage", new [] { "UnitTestsMode=true" });
+
+			Assert.That (success, Is.True, "Should have been built");
+		}
+
+		[Test]
+		public void BinariesExist ()
+		{
+			foreach (string binary in produced_binaries) {
+				string fp = Path.Combine (testProjectPath, "bin", XABuildPaths.Configuration, binary);
+
+				Assert.That (new FileInfo (fp), Does.Exist, $"File {fp} should exist");
+			}
+		}
+
+		[Test]
+		public void PackageIsBundled ()
+		{
+			Assert.That (new FileInfo (apk), Does.Exist, $"File {apk} should exist");
+
+			using (ZipArchive zip = ZipArchive.Open (apk, FileMode.Open)) {
+				Assert.That (zip, Is.Not.Null, $"{apk} couldn't be opened as a zip archive");
+
+				foreach (string bundle in bundles) {
+					Assert.That (zip.ContainsEntry (bundle), Is.True, $"`{bundle}` file not found in {apk}");
+				}
+			}
+		}
+
+		[Test]
+		public void BundleHasSoname ()
+		{
+			Assert.That (new FileInfo (apk), Does.Exist, $"File {apk} should exist");
+
+			using (ZipArchive zip = ZipArchive.Open (apk, FileMode.Open)) {
+				Assert.That (zip, Is.Not.Null, $"{apk} couldn't be opened as a zip archive");
+
+				foreach (string bundle in bundles) {
+					Assert.That (zip.ContainsEntry (bundle), Is.True, $"`{bundle}` file not found in {apk}");
+					CheckBundleForSoname (zip, bundle);
+				}
+			}
+		}
+
+		void CheckBundleForSoname (ZipArchive zip, string bundlePath)
+		{
+			string tempFile = Path.GetTempFileName ();
+			using (Stream fs = File.Open (tempFile, FileMode.Create)) {
+				ZipEntry entry = zip.FirstOrDefault (e => String.Compare (e.FullName, bundlePath, StringComparison.Ordinal) == 0);
+				Assert.That (entry, Is.Not.Null, $"Unable to open the `{bundlePath}` entry in {apk}");
+
+				entry.Extract (fs);
+			}
+
+			var stdout = new List<string> ();
+			string arguments;
+			string sonameField;
+
+			if (elfReaderLlvm) {
+				arguments = "-dynamic-table";
+				sonameField = "SONAME";
+			} else {
+				arguments = "-d";
+				sonameField = "(SONAME)";
+			}
+			bool success;
+
+			try {
+				Console.WriteLine ($"Checking bundle {bundlePath} in {tempFile}");
+				success = RunCommand (elfReaderPath, $"{arguments} \"{tempFile}\"", stdout);
+			} finally {
+				File.Delete (tempFile);
+			}
+
+			Assert.That (success, Is.True, $"Command {elfReaderPath} failed");
+
+			string soname = null;
+			foreach (string l in stdout) {
+				string line = l?.Trim ();
+				if (String.IsNullOrEmpty (line))
+					continue;
+
+				string[] parts = line.Split (ElfDynamicFieldSep, StringSplitOptions.RemoveEmptyEntries);
+				if (parts.Length < 3)
+					continue;
+
+				if (String.Compare (sonameField, parts [1], StringComparison.Ordinal) != 0)
+					continue;
+
+				if (parts.Length > 3)
+					soname = String.Join (" ", parts, 3, parts.Length - 3);
+				else
+					soname = String.Empty;
+				break;
+			}
+
+			const string expectedSoname = "libmonodroid_bundle_app.so";
+			Assert.That (soname, Is.Not.Null, $"Bundle {bundlePath} doesn't have DT_SONAME in ELF header");
+			Assert.That (soname.Length, Is.GreaterThanOrEqualTo (0), $"Unknown DT_SONAME field format in {bundlePath}");
+			Assert.That (soname.IndexOf (expectedSoname, StringComparison.Ordinal), Is.GreaterThanOrEqualTo (0), $"Unexpected bundle {bundlePath} SONAME (expected {expectedSoname}");
+		}
+
+		bool RunCommand (string command, string arguments, List<string> stdout)
+		{
+			var psi = new ProcessStartInfo () {
+				FileName		= command,
+				Arguments		= arguments,
+				UseShellExecute		= false,
+				RedirectStandardInput	= false,
+				RedirectStandardOutput	= true,
+				RedirectStandardError	= true,
+				CreateNoWindow		= true,
+				WindowStyle		= ProcessWindowStyle.Hidden,
+			};
+
+			var stderr_completed = new ManualResetEvent (false);
+			var stdout_completed = new ManualResetEvent (false);
+
+			var p = new Process () {
+				StartInfo   = psi,
+			};
+
+			p.ErrorDataReceived += (sender, e) => {
+				if (e.Data == null)
+					stderr_completed.Set ();
+				else
+					Console.WriteLine ($"stderr: {e.Data}");
+			};
+
+			p.OutputDataReceived += (sender, e) => {
+				if (e.Data == null)
+					stdout_completed.Set ();
+				else {
+					stdout.Add (e.Data);
+					Console.WriteLine ($"stdout: {e.Data}");
+				}
+			};
+
+			using (p) {
+				p.StartInfo = psi;
+				p.Start ();
+				p.BeginOutputReadLine ();
+				p.BeginErrorReadLine ();
+
+				bool success = p.WaitForExit (60000);
+
+				// We need to call the parameter-less WaitForExit only if any of the standard
+				// streams have been redirected (see
+				// https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit?view=netframework-4.7.2#System_Diagnostics_Process_WaitForExit)
+				//
+				p.WaitForExit ();
+				stderr_completed.WaitOne (TimeSpan.FromSeconds (60));
+				stdout_completed.WaitOne (TimeSpan.FromSeconds (60));
+
+				if (!success || p.ExitCode != 0) {
+					Console.Error.WriteLine ($"Process `{command} {arguments}` exited with value {p.ExitCode}.");
+					return false;
+				}
+
+				return true;
+			}
+		}
+
+		string PrepareProject (string testName)
+		{
+			string tempRoot = Path.Combine (TestOutputDir, $"{testName}.build", XABuildPaths.Configuration);
+			string temporaryProjectPath = Path.Combine (tempRoot, "project");
+
+			var ignore = new HashSet <string> {
+				Path.Combine (TestProjectRootDirectory, "bin"),
+				Path.Combine (TestProjectRootDirectory, "obj"),
+			};
+
+			CopyRecursively (TestProjectRootDirectory, temporaryProjectPath, ignore);
+			return temporaryProjectPath;
+		}
+
+		void CopyRecursively (string fromDir, string toDir, HashSet <string> ignoreDirs)
+		{
+			if (String.IsNullOrEmpty (fromDir))
+				throw new ArgumentException ($"{nameof (fromDir)} is must have a non-empty value");
+			if (String.IsNullOrEmpty (toDir))
+				throw new ArgumentException ($"{nameof (toDir)} is must have a non-empty value");
+
+			if (ignoreDirs.Contains (fromDir))
+				return;
+
+			var fdi = new DirectoryInfo (fromDir);
+			if (!fdi.Exists)
+				throw new InvalidOperationException ($"Source directory '{fromDir}' does not exist");
+
+			if (Directory.Exists (toDir))
+				Directory.Delete (toDir, true);
+
+			foreach (FileSystemInfo fsi in fdi.EnumerateFileSystemInfos ("*", SearchOption.TopDirectoryOnly)) {
+				if (fsi is FileInfo finfo)
+					CopyFile (fsi.FullName, Path.Combine (toDir, finfo.Name));
+				else
+					CopyRecursively (fsi.FullName, Path.Combine (toDir, fsi.Name), ignoreDirs);
+			}
+		}
+
+		void CopyFile (string from, string to)
+		{
+			string dir = Path.GetDirectoryName (to);
+			if (!Directory.Exists (dir))
+				Directory.CreateDirectory (dir);
+			File.Copy (from, to, true);
+		}
+
+		LocalBuilder GetBuilder (string baseLogFileName)
+		{
+			return new LocalBuilder {
+				Verbosity = LoggerVerbosity.Diagnostic,
+				BuildLogFile = $"{baseLogFileName}.log"
+			};
+		}
+	}
+}

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Config.cs.in
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Config.cs.in
@@ -1,0 +1,11 @@
+using System;
+using System.IO;
+
+namespace Xamarin.Android.MakeBundle.UnitTests
+{
+	public static class Config
+	{
+		public static readonly string LlvmReadobj = Path.Combine (@"@ANDROID_NDK_DIRECTORY@", "toolchains", "llvm", "prebuilt", "@HOST_ARCH@", "bin", "llvm-readobj@EXECUTABLE_EXTENSION@");
+		public static readonly string GccReadelf = Path.Combine (@"@ANDROID_NDK_DIRECTORY@", "toolchains", "@OLD_TOOLCHAIN@", "prebuilt", "@HOST_ARCH@", "bin", "x86_64-linux-android-readelf@EXECUTABLE_EXTENSION@");
+	}
+}

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Properties/AssemblyInfo.cs
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,26 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle ("Xmarin.Android.MakeBundle-UnitTests")]
+[assembly: AssemblyDescription ("")]
+[assembly: AssemblyConfiguration ("")]
+[assembly: AssemblyCompany ("")]
+[assembly: AssemblyProduct ("")]
+[assembly: AssemblyCopyright ("Microsoft")]
+[assembly: AssemblyTrademark ("")]
+[assembly: AssemblyCulture ("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion ("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Xamarin.Android.MakeBundle-UnitTests.csproj
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Xamarin.Android.MakeBundle-UnitTests.csproj
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FA8EEC88-CA3C-4D69-B206-54B392570DC6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Xamarin.Android.MakeBundle.UnitTests</RootNamespace>
+    <AssemblyName>Xamarin.Android.MakeBundle-UnitTests</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\..\bin\TestDebug\Xamarin.Android.MakeBundle-UnitTests</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\..\bin\TestRelease\Xamarin.Android.MakeBundle-UnitTests</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\Configuration.props" />
+  <Import Project="..\..\..\build-tools\scripts\MSBuildReferences.projitems" />
+  <UsingTask AssemblyFile="..\..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
+
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="nunit.framework">
+      <HintPath>..\..\..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="BuildTests.cs" />
+    <Compile Include="$(IntermediateOutputPath)Config.cs" />
+    <Compile Include="..\..\..\bin\Test$(CONFIGURATION)/XABuildPaths.cs">
+       <Link>XABuildPaths.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Xamarin.ProjectTools.csproj">
+      <Project>{2DD1EE75-6D8D-4653-A800-0A24367F7F38}</Project>
+      <Name>Xamarin.ProjectTools</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\external\LibZipSharp\libZipSharp.csproj">
+      <Project>{E248B2CA-303B-4645-ADDC-9D4459D550FD}</Project>
+      <Name>libZipSharp</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="Xamarin.Android.MakeBundle-UnitTests.targets" />
+</Project>

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Xamarin.Android.MakeBundle-UnitTests.targets
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Xamarin.Android.MakeBundle-UnitTests.targets
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="Prepare"
+      BeforeTargets="CoreCompile"
+      Inputs="$(MSBuildThisFileDirectory)Config.cs.in"
+      Outputs="$(IntermediateOutputPath)Config.cs">
+    <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+      <ExecutableExtension>.exe</ExecutableExtension>
+      <HostArch>windows-x86_64</HostArch>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <HostArch Condition=" '$(HostOS)' == 'Linux' ">linux-x86_64</HostArch>
+      <HostArch Condition=" '$(HostOS)' == 'Darwin' ">darwin-x86_64</HostArch>
+    </PropertyGroup>
+
+    <ReplaceFileContents
+        SourceFile="$(MSBuildThisFileDirectory)Config.cs.in"
+        DestinationFile="$(IntermediateOutputPath)\Config.cs"
+        Replacements="@ANDROID_NDK_DIRECTORY@=$(AndroidNdkDirectory);@OLD_TOOLCHAIN@=x86_64-4.9;@EXECUTABLE_EXTENSION@=$(ExecutableExtension);@HOST_ARCH@=$(HostArch)"
+    />
+  </Target>
+</Project>

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/packages.config
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.7.1" targetFramework="net451" />
+</packages>


### PR DESCRIPTION
Android API23 and newer requires that any shared library used by an application
which targets API23 or newer has its soname set in the ELF header or otherwise
the OS will refuse to load it:

   09-18 08:07:27.687 10698 10698 W linker  : Warning: "/data/app/Mono.Android_Tests-O9bT_-xHyd26brpmOI9RNg==/lib/x86/libmonodroid_bundle_app.so" has no DT_SONAME (will use libmonodroid_bundle_app.so instead) and will not work when the app moves to API level 23 or later (https://android.googlesource.
com/platform/bionic/+/master/missing-soname-enforced-for-api-level-23) (allowing for now because this app's target API level is still 22) (TaskId:201)

This commit fixes the problem by passing `-soname libmonodroid_bundle_app.so` to
the linker when building the bundle.