### PR TITLE
[tests] fix the Windows build for DSO tests

### DIFF
--- a/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/Config.cs.in
+++ b/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/Config.cs.in
@@ -5,6 +5,6 @@ namespace EmbeddedDSOUnitTests
 {
 	public static class Config
 	{
-		public static readonly string ZipAlignPath = Path.Combine ("@ANDROID_SDK_DIRECTORY@", "build-tools", "@BUILD_TOOLS_FOLDER@", "zipalign@EXECUTABLE_EXTENSION@");
+		public static readonly string ZipAlignPath = Path.Combine (@"@ANDROID_SDK_DIRECTORY@", "build-tools", "@BUILD_TOOLS_FOLDER@", "zipalign@EXECUTABLE_EXTENSION@");
 	}
 }

--- a/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/EmbeddedDSO-UnitTests.csproj
+++ b/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/EmbeddedDSO-UnitTests.csproj
@@ -59,14 +59,16 @@
   </ItemGroup>
 
   <Target Name="Prepare"
-	  BeforeTargets="CoreCompile">
+      BeforeTargets="CoreCompile"
+      Inputs="$(MSBuildThisFileDirectory)Config.cs.in"
+      Outputs="$(IntermediateOutputPath)Config.cs">
     <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
       <ExecutableExtension>.exe</ExecutableExtension>
     </PropertyGroup>
 
     <ReplaceFileContents
         SourceFile="$(MSBuildThisFileDirectory)Config.cs.in"
-        DestinationFile="$(IntermediateOutputPath)\Config.cs"
+        DestinationFile="$(IntermediateOutputPath)Config.cs"
         Replacements="@ANDROID_SDK_DIRECTORY@=$(AndroidSdkDirectory);@BUILD_TOOLS_FOLDER@=$(XABuildToolsFolder);@EXECUTABLE_EXTENSION@=$(ExecutableExtension)"
     />
   </Target>


### PR DESCRIPTION
Getting a compiler error on Windows for `obj\Debug\Config.cs`, the
generated code is:

    public static readonly string ZipAlignPath = Path.Combine ("C:\Users\myuser\android-toolchain\sdk", "build-tools", "28.0.0", "zipalign.exe");

Fixes include:
- Use the `@` symbol before the base path in `Config.cs.in`
- Use `Inputs` and `Outputs` on the `Prepare` target so it doesn't run
  all the time
- Fix the double slash, since `$(IntermediateOutputPath)` always has a
  trailing slash after the core MSBuild targets are imported
- Fixed a tab character