### PR TITLE
[Xamarin.Android.Build.Tasks] fix for readonly files on MacOS

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2574,6 +2574,31 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		}
 
 		[Test]
+		public void ResolveLibraryImportsWithReadonlyFiles ()
+		{
+			//NOTE: doesn't need to be a full Android Wear app
+			var proj = new XamarinAndroidApplicationProject {
+				Packages = {
+					KnownPackages.AndroidWear_2_2_0,
+					KnownPackages.Android_Arch_Core_Common_26_1_0,
+					KnownPackages.Android_Arch_Lifecycle_Common_26_1_0,
+					KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0,
+					KnownPackages.SupportCompat_27_0_2_1,
+					KnownPackages.SupportCoreUI_27_0_2_1,
+					KnownPackages.SupportPercent_27_0_2_1,
+					KnownPackages.SupportV7RecyclerView_27_0_2_1,
+				},
+			};
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				b.RequiresMSBuild = true;
+				b.Target = "Restore";
+				Assert.IsTrue (b.Build (proj), "Restore should have succeeded.");
+				b.Target = "Build";
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
+		[Test]
 		public void AndroidLibraryProjectsZipWithOddPaths ()
 		{
 			var proj = new XamarinAndroidLibraryProject ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -103,6 +103,15 @@ namespace Xamarin.ProjectTools
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Wear.1.0.0-preview7\\lib\\MonoAndroid10\\Xamarin.Android.Wearable.dll" }
 				}
 		};
+		public static Package AndroidWear_2_2_0 = new Package () {
+			Id = "Xamarin.Android.Wear",
+			Version = "2.2.0",
+			TargetFramework = "MonoAndroid80",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Wearable") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Wear.2.2.0\\lib\\MonoAndroid80\\Xamarin.Android.Wear.dll" }
+				}
+		};
 		public static Package SupportV7RecyclerView = new Package {
 			Id = "Xamarin.Android.Support.v7.RecyclerView",
 			Version = "21.0.0.0-beta1",
@@ -291,6 +300,15 @@ namespace Xamarin.ProjectTools
 			References = {
 				new BuildItem.Reference ("Xamarin.Android.Support.Media.Compat") {
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.Media.Compat.27.0.2.1\\lib\\MonoAndroid81\\Xamarin.Android.Support.Media.Compat.dll" }
+			}
+		};
+		public static Package SupportPercent_27_0_2_1 = new Package {
+			Id = "Xamarin.Android.Support.Percent",
+			Version = "27.0.2.1",
+			TargetFramework = "MonoAndroid81",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.Percent") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.Percent.27.0.2.1\\lib\\MonoAndroid81\\Xamarin.Android.Support.Percent.dll" }
 			}
 		};
 		public static Package SupportV7MediaRouter_21_0_3_0 = new Package {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -245,6 +245,7 @@ namespace Xamarin.Android.Tools {
 				if (forceUpdate || entry.ModificationTime > dt) {
 					try {
 						entry.Extract (destination, fullName, FileMode.Create);
+						MonoAndroidHelper.SetWriteable (outfile);
 						var utcNow = DateTime.UtcNow;
 						File.SetLastWriteTimeUtc (outfile, utcNow);
 						File.SetLastAccessTimeUtc (outfile, utcNow);


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2198

In 970da9efb, I fixed various issues with incremental builds.

But one scenario has a regression on MacOS:
- Add the `Xamarin.Android.Wear` NuGet to a new project
- Build

Encounter an error such as:

    error MSB4018: The "ResolveLibraryProjectImports" task failed unexpectedly.
    error MSB4018: System.UnauthorizedAccessException: Access to the path "/Users/peter/Projects/TestWearab/TestWearab/obj/Debug/lp/15/jl/proguard.txt" is denied.
    error MSB4018:   at System.IO.File.SetLastWriteTime (System.String path, System.DateTime lastWriteTime) [0x0002b] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-06/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.IO/File.cs:488
    error MSB4018:   at System.IO.File.SetLastWriteTimeUtc (System.String path, System.DateTime lastWriteTimeUtc) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-06/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.IO/File.cs:493
    error MSB4018:   at Xamarin.Android.Tools.Files.ExtractAll (Xamarin.Tools.Zip.ZipArchive zip, System.String destination, System.Action`2[T1,T2] progressCallback, System.Func`2[T,TResult] modifyCallback, System.Func`2[T,TResult] deleteCallback, System.Boolean forceUpdate) [0x00152] in <97b2eb9ff07947edbf0f4e47cfa2efbf>:0
    error MSB4018:   at Xamarin.Android.Tasks.ResolveLibraryProjectImports.Extract (Java.Interop.Tools.Cecil.DirectoryAssemblyResolver res, System.Collections.Generic.ICollection`1[T] jars, System.Collections.Generic.ICollection`1[T] resolvedResourceDirectories, System.Collections.Generic.ICollection`1[T] resolvedAssetDirectories, System.Collections.Generic.ICollection`1[T] resolvedEnvironments) [0x00528] in <97b2eb9ff07947edbf0f4e47cfa2efbf>:0
    error MSB4018:   at Xamarin.Android.Tasks.ResolveLibraryProjectImports.Execute () [0x000fc] in <97b2eb9ff07947edbf0f4e47cfa2efbf>:0

I could resolve the issue with at the cmd line such as:

    chmod 770 obj/Debug/lp/15/jl/proguard.txt

What is likely happening is that files in
`__AndroidLibraryProjects__.zip` are marked readonly, and so they are
getting extracted that way.

Then this code is failing on MacOS with readonly files:

    var utcNow = DateTime.UtcNow;
    File.SetLastWriteTimeUtc (outfile, utcNow);
    File.SetLastAccessTimeUtc (outfile, utcNow);

Adding a call to make the file writeable solves the issue:

    MonoAndroidHelper.SetWriteable (outfile);