### PR TITLE
[Xamarin.Android.Build.Tasks] restore behavior for custom $(AndroidSdkDirectory)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
@@ -16,9 +16,6 @@ namespace Xamarin.Android.Tasks
 		private XNamespace androidNs = "http://schemas.android.com/apk/res/android";
 
 		[Required]
-		public string AndroidSdkDirectory { get; set; }
-
-		[Required]
 		public string AndroidSdkPlatform { get; set; }
 
 		public string AndroidManifest { get; set; }
@@ -31,11 +28,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("GetJavaPlatformJar Task");
-			Log.LogDebugMessage ("  AndroidSdkDirectory: {0}", AndroidSdkDirectory);
-			Log.LogDebugMessage ("  AndroidSdkPlatform: {0}", AndroidSdkPlatform);
-			Log.LogDebugMessage ("  AndroidManifest: {0}", AndroidManifest);
-			
 			var platform = AndroidSdkPlatform;
 
 			XAttribute target_sdk = null;
@@ -74,9 +66,6 @@ namespace Xamarin.Android.Tasks
 				return !Log.HasLoggedErrors;
 
 			TargetSdkVersion = MonoAndroidHelper.SupportedVersions.GetApiLevelFromId (platform).ToString ();
-
-			Log.LogDebugMessage ("  [Output] JavaPlatformJarPath: {0}", JavaPlatformJarPath);
-			Log.LogDebugMessage ("  [Output] TargetSdkVersion: {0}", TargetSdkVersion);
 
 			return !Log.HasLoggedErrors;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
@@ -17,8 +17,6 @@ namespace Xamarin.Android.Tasks
 	/// </summary>
 	public class ResolveAndroidTooling : Task
 	{
-		public string AndroidNdkPath { get; set; }
-
 		public string AndroidSdkPath { get; set; }
 
 		public string AndroidSdkBuildToolsVersion { get; set; }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
@@ -182,7 +182,6 @@ namespace Xamarin.Android.Build.Tests {
 			var androidTooling = new ResolveAndroidTooling {
 				BuildEngine = engine,
 				AndroidSdkPath = androidSdkPath,
-				AndroidNdkPath = androidSdkPath,
 				TargetFrameworkVersion = targetFrameworkVersion,
 				AndroidSdkBuildToolsVersion = buildtools,
 				UseLatestAndroidPlatformSdk = useLatestAndroidSdk,
@@ -234,7 +233,6 @@ namespace Xamarin.Android.Build.Tests {
 			var androidTooling = new ResolveAndroidTooling {
 				BuildEngine = engine,
 				AndroidSdkPath = androidSdkPath,
-				AndroidNdkPath = androidSdkPath,
 				TargetFrameworkVersion = "v8.0",
 				AndroidSdkBuildToolsVersion = "26.0.3",
 				UseLatestAndroidPlatformSdk = false,
@@ -396,7 +394,6 @@ namespace Xamarin.Android.Build.Tests {
 			var androidTooling = new ResolveAndroidTooling {
 				BuildEngine = engine,
 				AndroidSdkPath = androidSdkPath,
-				AndroidNdkPath = androidSdkPath,
 				UseLatestAndroidPlatformSdk = true,
 				TargetFrameworkVersion = userSelected,
 			};

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -173,16 +173,16 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
         AndroidNdkPath="$(AndroidNdkDirectory)"
         JavaSdkPath="$(JavaSdkDirectory)"
         ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)">
-      <Output TaskParameter="AndroidNdkPath"            PropertyName="AndroidNdkDirectory"        Condition="'$(AndroidNdkDirectory)' == ''" />
-      <Output TaskParameter="AndroidSdkPath"            PropertyName="AndroidSdkDirectory"        Condition="'$(AndroidSdkDirectory)' == ''" />
-      <Output TaskParameter="JavaSdkPath"               PropertyName="JavaSdkDirectory"           Condition="'$(JavaSdkDirectory)' == ''" />
+      <Output TaskParameter="AndroidNdkPath"            PropertyName="_AndroidNdkDirectory" />
+      <Output TaskParameter="AndroidSdkPath"            PropertyName="_AndroidSdkDirectory" />
+      <Output TaskParameter="JavaSdkPath"               PropertyName="_JavaSdkDirectory" />
       <Output TaskParameter="MonoAndroidToolsPath"      PropertyName="MonoAndroidToolsDirectory" />
       <Output TaskParameter="MonoAndroidBinPath"        PropertyName="MonoAndroidBinDirectory" />
     </ResolveSdks>
     <ValidateJavaVersion
         TargetFrameworkVersion="$(TargetFrameworkVersion)"
         AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
-        JavaSdkPath="$(JavaSdkDirectory)"
+        JavaSdkPath="$(_JavaSdkDirectory)"
         JavaToolExe="$(JavaToolExe)"
         JavacToolExe="$(JavacToolExe)"
         LatestSupportedJavaVersion="$(LatestSupportedJavaVersion)"
@@ -193,8 +193,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <ResolveAndroidTooling
         TargetFrameworkVersion="$(TargetFrameworkVersion)"
         AndroidApiLevel="$(AndroidApiLevel)"
-        AndroidSdkPath="$(AndroidSdkDirectory)"
-        AndroidNdkPath="$(AndroidNdkDirectory)"
+        AndroidSdkPath="$(_AndroidSdkDirectory)"
         AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
         UseLatestAndroidPlatformSdk="$(AndroidUseLatestPlatformSdk)"
         SequencePointsMode="$(AndroidSequencePointsMode)"
@@ -223,34 +222,25 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
   <!-- Find all the needed SDKs -->
   <Target Name="_ResolveMonoAndroidSdks" DependsOnTargets="_ResolveMonoAndroidFramework">
 
-    <Error Text="Could not locate Android SDK." Condition="'$(AndroidSdkDirectory)'==''" />
-    <Error Text="Could not locate Java 6 or 7 SDK.  (Download from http://www.oracle.com/technetwork/java/javase/downloads.)" Condition="'$(JavaSdkDirectory)'==''" />
+    <Error Text="Could not locate Android SDK." Condition="'$(_AndroidSdkDirectory)'==''" />
+    <Error Text="Could not locate Java 6 or 7 SDK.  (Download from http://www.oracle.com/technetwork/java/javase/downloads.)" Condition="'$(_JavaSdkDirectory)'==''" />
 
-    <CreateProperty Value="$(AndroidNdkDirectory)">
-      <Output TaskParameter="Value" PropertyName="_AndroidNdkDirectory"/>
-    </CreateProperty>
     <CreateProperty Value="$(_AndroidNdkDirectory)\">
       <Output TaskParameter="Value" PropertyName="_AndroidNdkDirectory"
         Condition="!HasTrailingSlash('$(_AndroidNdkDirectory)')" />
     </CreateProperty>
 
-    <CreateProperty Value="$(AndroidSdkDirectory)">
-      <Output TaskParameter="Value" PropertyName="_AndroidSdkDirectory"/>
-    </CreateProperty>
     <CreateProperty Value="$(_AndroidSdkDirectory)\">
       <Output TaskParameter="Value" PropertyName="_AndroidSdkDirectory"
         Condition="!HasTrailingSlash('$(_AndroidSdkDirectory)')" />
     </CreateProperty>
 
-    <CreateProperty Value="$(JavaSdkDirectory)">
-      <Output TaskParameter="Value" PropertyName="_JavaSdkDirectory"/>
-    </CreateProperty>
     <CreateProperty Value="$(_JavaSdkDirectory)\">
       <Output TaskParameter="Value" PropertyName="_JavaSdkDirectory"
         Condition="!HasTrailingSlash('$(_JavaSdkDirectory)')" />
     </CreateProperty>
 
-	<CreateProperty Value="$(_JavaSdkDirectory)\bin">
+	<CreateProperty Value="$(_JavaSdkDirectory)bin">
 		<Output TaskParameter="Value" PropertyName="JavaToolPath"
 				Condition="'$(JavaToolPath)' == ''"
 		/>
@@ -396,7 +386,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
         SourceDirectories="@(JavaSourceJar->'$(IntermediateOutputPath)javasources\%(FileName)')"
         DestinationDirectories="@(JavaSourceJar->'$(IntermediateOutputPath)javadocs\%(FileName)')"
         ReferenceJars="@(EmbeddedReferenceJar);@(ReferenceJar);@(_AdditionalJavaLibraryReferences)"
-        JavaPlatformJar="$(AndroidSdkDirectory)\platforms\android-$(_AndroidApiLevel)\android.jar"
+        JavaPlatformJar="$(_AndroidSdkDirectory)\platforms\android-$(_AndroidApiLevel)\android.jar"
         />
 	
     <Touch Files="@(JavaSourceJar->'$(IntermediateOutputPath)javasources\%(FileName).stamp')" AlwaysCreate="True" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1176,10 +1176,11 @@ because xbuild doesn't support framework reference assemblies.
 	</ItemGroup>
 	<MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" />
 	<WriteLinesToFile
-		File="$(_AndroidBuildPropertiesCache)"
-		Lines="@(_PropertyCacheItems)"
-		Overwrite="true"
-		WriteOnlyWhenDifferent="true" />
+			File="$(_AndroidBuildPropertiesCache)"
+			Lines="@(_PropertyCacheItems)"
+			Overwrite="true"
+			WriteOnlyWhenDifferent="true"
+	/>
 </Target>
 
 <PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -613,7 +613,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<Error Text="Could not determine package name." Condition="'$(_AndroidPackage)' == ''" />
 
 	<GetJavaPlatformJar
-		AndroidSdkDirectory="$(AndroidSdkDirectory)"
 		AndroidSdkPlatform="$(_AndroidApiLevel)"
 		AndroidManifest="$(_AndroidManifestAbs)">
 			<Output TaskParameter="JavaPlatformJarPath" PropertyName="JavaPlatformJarPath" />
@@ -673,16 +672,16 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 			AndroidNdkPath="$(AndroidNdkDirectory)"
 			JavaSdkPath="$(JavaSdkDirectory)"
 			ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)">
-		<Output TaskParameter="AndroidNdkPath"            PropertyName="AndroidNdkDirectory"        Condition="'$(AndroidNdkDirectory)' == ''" />
-		<Output TaskParameter="AndroidSdkPath"            PropertyName="AndroidSdkDirectory"        Condition="'$(AndroidSdkDirectory)' == ''" />
-		<Output TaskParameter="JavaSdkPath"               PropertyName="JavaSdkDirectory"           Condition="'$(JavaSdkDirectory)' == ''" />
+		<Output TaskParameter="AndroidNdkPath"            PropertyName="_AndroidNdkDirectory" />
+		<Output TaskParameter="AndroidSdkPath"            PropertyName="_AndroidSdkDirectory" />
+		<Output TaskParameter="JavaSdkPath"               PropertyName="_JavaSdkDirectory" />
 		<Output TaskParameter="MonoAndroidToolsPath"      PropertyName="MonoAndroidToolsDirectory" />
 		<Output TaskParameter="MonoAndroidBinPath"        PropertyName="MonoAndroidBinDirectory" />
 	</ResolveSdks>
 	<ValidateJavaVersion
 			TargetFrameworkVersion="$(TargetFrameworkVersion)"
 			AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
-			JavaSdkPath="$(JavaSdkDirectory)"
+			JavaSdkPath="$(_JavaSdkDirectory)"
 			JavaToolExe="$(JavaToolExe)"
 			JavacToolExe="$(JavacToolExe)"
 			LatestSupportedJavaVersion="$(LatestSupportedJavaVersion)"
@@ -693,8 +692,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<ResolveAndroidTooling
 			TargetFrameworkVersion="$(TargetFrameworkVersion)"
 			AndroidApiLevel="$(AndroidApiLevel)"
-			AndroidSdkPath="$(AndroidSdkDirectory)"
-			AndroidNdkPath="$(AndroidNdkDirectory)"
+			AndroidSdkPath="$(_AndroidSdkDirectory)"
 			AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
 			UseLatestAndroidPlatformSdk="$(AndroidUseLatestPlatformSdk)"
 			AndroidUseAapt2="$(AndroidUseAapt2)"
@@ -807,8 +805,8 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_ResolveMonoAndroidSdks" DependsOnTargets="_ResolveMonoAndroidFramework">
 
 	<Error Text="Could not locate MonoAndroid SDK." Condition="'$(MonoAndroidToolsDirectory)'==''" />
-	<Error Text="Could not locate Android SDK. Please set via /p:AndroidSdkDirectory." Condition="'$(AndroidSdkDirectory)'==''" />
-	<Error Text="Could not locate Java 6 or 7 SDK.  (Download from http://www.oracle.com/technetwork/java/javase/downloads.)" Condition="'$(JavaSdkDirectory)'==''" />
+	<Error Text="Could not locate Android SDK. Please set via /p:AndroidSdkDirectory." Condition="'$(_AndroidSdkDirectory)'==''" />
+	<Error Text="Could not locate Java 6 or 7 SDK.  (Download from http://www.oracle.com/technetwork/java/javase/downloads.)" Condition="'$(_JavaSdkDirectory)'==''" />
 
 	<!-- AppData for Mono for Android-->
 	<GetAppSettingsDirectory>
@@ -837,18 +835,12 @@ because xbuild doesn't support framework reference assemblies.
 		<Output TaskParameter="Value" PropertyName="_MonoAndroidToolsDirectory"
 			Condition="!HasTrailingSlash('$(_MonoAndroidToolsDirectory)')" />
 	</CreateProperty>
-	
-	<CreateProperty Value="$(AndroidNdkDirectory)">
-		<Output TaskParameter="Value" PropertyName="_AndroidNdkDirectory"/>
-	</CreateProperty>
+
 	<CreateProperty Value="$(_AndroidNdkDirectory)\">
 		<Output TaskParameter="Value" PropertyName="_AndroidNdkDirectory"
 			Condition="!HasTrailingSlash('$(_AndroidNdkDirectory)')" />
 	</CreateProperty>
-	
-	<CreateProperty Value="$(AndroidSdkDirectory)">
-		<Output TaskParameter="Value" PropertyName="_AndroidSdkDirectory"/>
-	</CreateProperty>
+
 	<CreateProperty Value="$(_AndroidSdkDirectory)\">
 		<Output TaskParameter="Value" PropertyName="_AndroidSdkDirectory"
 			Condition="!HasTrailingSlash('$(_AndroidSdkDirectory)')" />
@@ -865,10 +857,7 @@ because xbuild doesn't support framework reference assemblies.
 				Condition="!HasTrailingSlash('$(AndroidSdkBuildToolsBinPath)')"
 		/>
 	</CreateProperty>
-	
-	<CreateProperty Value="$(JavaSdkDirectory)">
-		<Output TaskParameter="Value" PropertyName="_JavaSdkDirectory"/>
-	</CreateProperty>
+
 	<CreateProperty Value="$(_JavaSdkDirectory)\">
 		<Output TaskParameter="Value" PropertyName="_JavaSdkDirectory"
 			Condition="!HasTrailingSlash('$(_JavaSdkDirectory)')" />
@@ -957,25 +946,25 @@ because xbuild doesn't support framework reference assemblies.
 		/>
 	</CreateProperty>
 
-	<CreateProperty Value="$(_JavaSdkDirectory)\bin">
+	<CreateProperty Value="$(_JavaSdkDirectory)bin">
 		<Output TaskParameter="Value" PropertyName="JarsignerToolPath"
 				Condition="'$(JarsignerToolPath)' == ''"
 		/>
 	</CreateProperty>
 
-	<CreateProperty Value="$(_JavaSdkDirectory)\bin">
+	<CreateProperty Value="$(_JavaSdkDirectory)bin">
 		<Output TaskParameter="Value" PropertyName="JavaToolPath"
 				Condition="'$(JavaToolPath)' == ''"
 		/>
 	</CreateProperty>
 
-	<CreateProperty Value="$(_JavaSdkDirectory)\bin">
+	<CreateProperty Value="$(_JavaSdkDirectory)bin">
 		<Output TaskParameter="Value" PropertyName="JavacToolPath"
 				Condition="'$(JavacToolPath)' == ''"
 		/>
 	</CreateProperty>
 
-	<CreateProperty Value="$(_JavaSdkDirectory)\bin">
+	<CreateProperty Value="$(_JavaSdkDirectory)bin">
 		<Output TaskParameter="Value" PropertyName="KeytoolToolPath"
 				Condition="'$(KeytoolToolPath)' == ''"
 		/>
@@ -1058,7 +1047,7 @@ because xbuild doesn't support framework reference assemblies.
 		IntermediateOutputPath="$(IntermediateOutputPath)"
 		ToolPath="$(LintToolPath)"
 		ToolExe="$(LintToolExe)"
-		JavaSdkPath="$(JavaSdkDirectory)"
+		JavaSdkPath="$(_JavaSdkDirectory)"
 	/>
 </Target>
 
@@ -1157,48 +1146,40 @@ because xbuild doesn't support framework reference assemblies.
 	<_AndroidManagedResourceDesignerFile>$(_AndroidIntermediateDesignTimeBuildDirectory)$(_AndroidResourceDesigner)</_AndroidManagedResourceDesignerFile>
 </PropertyGroup>
 
-<ItemGroup>
-	<!--- List of items we want to trigger a build if changed -->
-	<_PropertyCacheItems Include="BundleAssemblies=$(BundleAssemblies)" />
-	<_PropertyCacheItems Include="AotAssemblies=$(AotAssemblies)" />
-	<_PropertyCacheItems Include="AndroidAotMode=$(AndroidAotMode)" />
-	<_PropertyCacheItems Include="ExplicitCrunch=$(AndroidExplicitCrunch)" />
-	<_PropertyCacheItems Include="EnableProguard=$(AndroidEnableProguard)" />
-	<_PropertyCacheItems Include="UseSharedRuntime=$(AndroidUseSharedRuntime)" />
-	<_PropertyCacheItems Include="EmbedAssembliesIntoApk=$(EmbedAssembliesIntoApk)" />
-	<_PropertyCacheItems Include="AndroidLinkMode=$(AndroidLinkMode)" />
-	<_PropertyCacheItems Include="AndroidLinkSkip=$(AndroidLinkSkip)" />
-	<_PropertyCacheItems Include="AndroidSdkBuildToolsVersion=$(AndroidSdkBuildToolsVersion)" />
-	<_PropertyCacheItems Include="AndroidSdkPath=$(AndroidSdkDirectory)" />
-	<_PropertyCacheItems Include="AndroidNdkPath=$(AndroidNdkDirectory)" />
-	<_PropertyCacheItems Include="JavaSdkPath=$(JavaSdkDirectory)" />
-	<_PropertyCacheItems Include="AndroidSequencePointsMode=$(_AndroidSequencePointsMode)" />
-	<_PropertyCacheItems Include="XamarinAndroidVersion=$(XamarinAndroidVersion)" />
-	<_PropertyCacheItems Include="MonoSymbolArchive=$(MonoSymbolArchive)" />
-	<_PropertyCacheItems Include="AndroidUseLatestPlatformSdk=$(AndroidUseLatestPlatformSdk)" />
-	<_PropertyCacheItems Include="TargetFrameworkVersion=$(TargetFrameworkVersion)" />
-	<_PropertyCacheItems Include="AndroidCreatePackagePerAbi=$(AndroidCreatePackagePerAbi)" />
-	<_PropertyCacheItems Include="OS=$(OS)" />
-	<_PropertyCacheItems Include="DesignTimeBuild=$(DesignTimeBuild)" />
-	<_PropertyCacheItems Include="AndroidIncludeDebugSymbols=$(AndroidIncludeDebugSymbols)" />
-	<_PropertyCacheItems Include="AdbTarget=$(AdbTarget)" />
-	<_PropertyCacheItems Include="AdbOptions=$(AdbOptions)" />
-</ItemGroup>
-
-<Target Name="_ReadPropertiesCache">
-	<ReadLinesFromFile File="$(_AndroidBuildPropertiesCache)"
-			Condition="Exists('$(_AndroidBuildPropertiesCache)')">
-		<Output TaskParameter="Lines" ItemName="_PropertiesCache"/>
-	</ReadLinesFromFile>
-</Target>
-
-<Target Name="_CreatePropertiesCache" DependsOnTargets="_SetupDesignTimeBuildForBuild;_ReadPropertiesCache">
+<Target Name="_CreatePropertiesCache" DependsOnTargets="_SetupDesignTimeBuildForBuild;_SetLatestTargetFrameworkVersion">
+	<ItemGroup>
+		<!--- List of items we want to trigger a build if changed -->
+		<_PropertyCacheItems Include="BundleAssemblies=$(BundleAssemblies)" />
+		<_PropertyCacheItems Include="AotAssemblies=$(AotAssemblies)" />
+		<_PropertyCacheItems Include="AndroidAotMode=$(AndroidAotMode)" />
+		<_PropertyCacheItems Include="ExplicitCrunch=$(AndroidExplicitCrunch)" />
+		<_PropertyCacheItems Include="EnableProguard=$(AndroidEnableProguard)" />
+		<_PropertyCacheItems Include="UseSharedRuntime=$(AndroidUseSharedRuntime)" />
+		<_PropertyCacheItems Include="EmbedAssembliesIntoApk=$(EmbedAssembliesIntoApk)" />
+		<_PropertyCacheItems Include="AndroidLinkMode=$(AndroidLinkMode)" />
+		<_PropertyCacheItems Include="AndroidLinkSkip=$(AndroidLinkSkip)" />
+		<_PropertyCacheItems Include="AndroidSdkBuildToolsVersion=$(AndroidSdkBuildToolsVersion)" />
+		<_PropertyCacheItems Include="AndroidSdkPath=$(_AndroidSdkDirectory)" />
+		<_PropertyCacheItems Include="AndroidNdkPath=$(_AndroidNdkDirectory)" />
+		<_PropertyCacheItems Include="JavaSdkPath=$(_JavaSdkDirectory)" />
+		<_PropertyCacheItems Include="AndroidSequencePointsMode=$(_AndroidSequencePointsMode)" />
+		<_PropertyCacheItems Include="XamarinAndroidVersion=$(XamarinAndroidVersion)" />
+		<_PropertyCacheItems Include="MonoSymbolArchive=$(MonoSymbolArchive)" />
+		<_PropertyCacheItems Include="AndroidUseLatestPlatformSdk=$(AndroidUseLatestPlatformSdk)" />
+		<_PropertyCacheItems Include="TargetFrameworkVersion=$(TargetFrameworkVersion)" />
+		<_PropertyCacheItems Include="AndroidCreatePackagePerAbi=$(AndroidCreatePackagePerAbi)" />
+		<_PropertyCacheItems Include="OS=$(OS)" />
+		<_PropertyCacheItems Include="DesignTimeBuild=$(DesignTimeBuild)" />
+		<_PropertyCacheItems Include="AndroidIncludeDebugSymbols=$(AndroidIncludeDebugSymbols)" />
+		<_PropertyCacheItems Include="AdbTarget=$(AdbTarget)" />
+		<_PropertyCacheItems Include="AdbOptions=$(AdbOptions)" />
+	</ItemGroup>
 	<MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" />
 	<WriteLinesToFile
-		Condition="'@(_PropertiesCache)' != '@(_PropertyCacheItems)'" 
 		File="$(_AndroidBuildPropertiesCache)"
 		Lines="@(_PropertyCacheItems)"
-		Overwrite="true"/>
+		Overwrite="true"
+		WriteOnlyWhenDifferent="true" />
 </Target>
 
 <PropertyGroup>
@@ -1425,7 +1406,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_AddMultiDexDependencyJars">
-	<CreateItem Include="$(AndroidSdkDirectory)\$(AndroidMultiDexSupportJar)"
+	<CreateItem Include="$(_AndroidSdkDirectory)\$(AndroidMultiDexSupportJar)"
 		Condition="'$(AndroidEnableMultiDex)' == 'True' AND '$(AndroidMultiDexSupportJar)' != ''">
       <Output TaskParameter="Include" ItemName="AndroidJavaLibrary" />
 	</CreateItem>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2200

In 93ddf96f, I split up the `ResolveSdks` MSBuild task.

In doing that I broke a situation:
- `msbuild /p:AndroidUseLatestPlatformSdk=true /p:AndroidSdkDirectory="C:\DoesNotExist" MyApp.csproj`
- This works in 15.8 stable, but not 15.9 or master where 93ddf96f is
  applied

The error message is also rather unpleasant, due to an unhandled
exception:

    (_SetLatestTargetFrameworkVersion target) ->
        error MSB4018: The "ResolveAndroidTooling" task failed unexpectedly.
        error MSB4018: System.IO.DirectoryNotFoundException: Could not find a part of the path 'C:\DoesNotExist\platforms'.

The cause, is how `$(AndroidSdkDirectory)` is handled as an output:

    <Output TaskParameter="AndroidSdkPath" PropertyName="AndroidSdkDirectory" Condition="'$(AndroidSdkDirectory)' == ''" />

We don't modify `$(AndroidSdkDirectory)` if it was supplied somehow to
the build.

Then we use `$(AndroidSdkDirectory)` directly here:

    <ResolveAndroidTooling
        ...
        AndroidSdkPath="$(AndroidSdkDirectory)"
        ...
    />

So the fix here is a bit of refactoring:
- Let's use `$(_AndroidSdkDirectory)`, `$(_AndroidNdkDirectory)`, and
  `$(_JavaSdkDirectory)` throughout our targets, and leave the
  original values unchanged. We should remove the non-underscored
  values everywhere else.
- We can remove places we call `<CreateProperty />` to create
  `$(_AndroidSdkDirectory)`, since it is set earlier now.
- I saw several places we are using `<CreateProperty
  Value="$(_JavaSdkDirectory)\bin">`, which uses a double slash. We
  can omit a `\` here.
- We can refactor `GetJavaPlatformJar` in general, it doesn't use this
  property so we can remove it. We can also remove extra log messages.

Then there was one place that introduced a dilemma:

    <_PropertyCacheItems Include="AndroidSdkPath=$(AndroidSdkDirectory)" />
    <_PropertyCacheItems Include="AndroidNdkPath=$(AndroidNdkDirectory)" />
    <_PropertyCacheItems Include="JavaSdkPath=$(JavaSdkDirectory)" />

This happens at project evaluation time, so it's not actually using
the proper value for these properties!

So I reworked the targets using this:
- `_CreatePropertiesCache` now depends on
  `_SetLatestTargetFrameworkVersion`
- `_CreatePropertiesCache` now uses `$(_AndroidSdkDirectory)` and
  friends
- We now take advantage of `<WriteLinesToFile
  WriteOnlyWhenDifferent="True" />`
- We can completely remove the `_ReadPropertiesCache` target

Overall this moves `_SetLatestTargetFrameworkVersion` to happen
earlier, but I believe our build is *more correct* as a result.

Downstream in `monodroid`, we will need to update two targets:
- `ResolveXamarinAndroidTools`
- `InstallPackageAssemblies`

I will investigate if this can be done separately to bumping
`xamarin-android`.