### PR TITLE
[xabuild] we don't need config file in stdout

### DIFF
--- a/tools/xabuild/XABuild.cs
+++ b/tools/xabuild/XABuild.cs
@@ -45,19 +45,7 @@ namespace Xamarin.Android.Build
 					}
 				}
 
-				int exitCode = MSBuildApp.Main ();
-				if (exitCode != 0) {
-					Console.WriteLine ($"MSBuildApp.Main exited with {exitCode}, xabuild configuration is:");
-
-					var settings = new XmlWriterSettings {
-						Indent = true,
-						NewLineOnAttributes = true,
-					};
-					using (var writer = XmlTextWriter.Create (Console.Out, settings)) {
-						xml.WriteTo (writer);
-					}
-				}
-				return exitCode;
+				return MSBuildApp.Main ();
 			} finally {
 				//NOTE: these are temporary files
 				foreach (var file in new [] { paths.MSBuildExeTempPath, paths.XABuildConfig }) {


### PR DESCRIPTION
When we first implemented `xabuild.exe`, we though it was helpful to
see the configuration file that was used if the build failed.

However, it mostly seems unnecessary now, since:
- All variables used are printed in diagnostic or binary log files.
  They show up as properties at the beginning of the build.
- We are all much more accustomed to looking through binary log files
  now anyway. Our build even saves them!

I very much dislike having to scroll *way* up my console window when a
build fails!

Here is an example of what the output *used* to look like:

    > .\bin\Debug\bin\xabuild /asdfsadfsdadf
    Microsoft (R) Build Engine version 15.8.168+ga8fba1ebd7 for .NET Framework
    Copyright (C) Microsoft Corporation. All rights reserved.

    MSBUILD : error MSB1001: Unknown switch.
    Switch: /asdfsadfsdadf

    For switch syntax, type "MSBuild /help"
    MSBuildApp.Main exited with 1, xabuild configuration is:
    <?xml version="1.0" encoding="utf-8"?>
    <configuration>
      <configSections>
        <section
          name="msbuildToolsets"
          type="Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
      </configSections>
      <startup
        useLegacyV2RuntimeActivationPolicy="true">
        <supportedRuntime
          version="v4.0"
          sku=".NETFramework,Version=v4.6" />
      </startup>
      <runtime>
        <AppContextSwitchOverrides
          value="Switch.System.IO.UseLegacyPathHandling=false" />
        <DisableFXClosureWalk
          enabled="true" />
        <generatePublisherEvidence
          enabled="false" />
        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
          <dependentAssembly>
            <assemblyIdentity
              name="Microsoft.Build.Framework"
              culture="neutral"
              publicKeyToken="b03f5f7f11d50a3a" />
            <bindingRedirect
              oldVersion="0.0.0.0-99.9.9.9"
              newVersion="15.1.0.0" />
          </dependentAssembly>
          <dependentAssembly>
            <assemblyIdentity
              name="Microsoft.Build"
              culture="neutral"
              publicKeyToken="b03f5f7f11d50a3a" />
            <bindingRedirect
              oldVersion="0.0.0.0-99.9.9.9"
              newVersion="15.1.0.0" />
          </dependentAssembly>
          <dependentAssembly>
            <assemblyIdentity
              name="Microsoft.Build.Conversion.Core"
              culture="neutral"
              publicKeyToken="b03f5f7f11d50a3a" />
            <bindingRedirect
              oldVersion="0.0.0.0-99.9.9.9"
              newVersion="15.1.0.0" />
          </dependentAssembly>
          <dependentAssembly>
            <assemblyIdentity
              name="Microsoft.Build.Tasks.Core"
              culture="neutral"
              publicKeyToken="b03f5f7f11d50a3a" />
            <bindingRedirect
              oldVersion="0.0.0.0-99.9.9.9"
              newVersion="15.1.0.0" />
          </dependentAssembly>
          <dependentAssembly>
            <assemblyIdentity
              name="Microsoft.Build.Utilities.Core"
              culture="neutral"
              publicKeyToken="b03f5f7f11d50a3a" />
            <bindingRedirect
              oldVersion="0.0.0.0-99.9.9.9"
              newVersion="15.1.0.0" />
          </dependentAssembly>
          <dependentAssembly>
            <assemblyIdentity
              name="Microsoft.Build.Engine"
              culture="neutral"
              publicKeyToken="b03f5f7f11d50a3a" />
            <bindingRedirect
              oldVersion="0.0.0.0-99.9.9.9"
              newVersion="15.1.0.0" />
          </dependentAssembly>
          <dependentAssembly>
            <assemblyIdentity
              name="Microsoft.Build.Conversion.Core"
              culture="neutral"
              publicKeyToken="b03f5f7f11d50a3a" />
            <bindingRedirect
              oldVersion="0.0.0.0-99.9.9.9"
              newVersion="15.1.0.0" />
          </dependentAssembly>
          <!-- Redirects for facade assemblies -->
          <dependentAssembly>
            <assemblyIdentity
              name="System.IO.Compression"
              culture="neutral"
              publicKeyToken="b77a5c561934e089" />
            <bindingRedirect
              oldVersion="0.0.0.0-4.1.2.0"
              newVersion="4.1.2.0" />
          </dependentAssembly>
          <dependentAssembly>
            <assemblyIdentity
              name="System.Runtime.InteropServices.RuntimeInformation"
              publicKeyToken="b03f5f7f11d50a3a"
              culture="neutral" />
            <bindingRedirect
              oldVersion="0.0.0.0-4.0.1.0"
              newVersion="4.0.1.0" />
          </dependentAssembly>
          <!-- Redirects for components dropped by Visual Studio -->
          <dependentAssembly>
            <assemblyIdentity
              name="Microsoft.Activities.Build"
              culture="neutral"
              publicKeyToken="31bf3856ad364e35" />
            <bindingRedirect
              oldVersion="4.0.0.0"
              newVersion="15.0.0.0" />
            <codeBase
              version="15.0.0.0"
              href=".\amd64\Microsoft.Activities.Build.dll" />
          </dependentAssembly>
          <dependentAssembly>
            <assemblyIdentity
              name="XamlBuildTask"
              culture="neutral"
              publicKeyToken="31bf3856ad364e35" />
            <bindingRedirect
              oldVersion="4.0.0.0"
              newVersion="15.0.0.0" />
            <codeBase
              version="15.0.0.0"
              href=".\amd64\XamlBuildTask.dll" />
          </dependentAssembly>
          <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->
          <dependentAssembly>
            <assemblyIdentity
              name="FxCopTask"
              culture="neutral"
              publicKeyToken="b03f5f7f11d50a3a" />
            <codeBase
              version="15.0.0.0"
              href="..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\FxCopTask.dll" />
          </dependentAssembly>
          <dependentAssembly>
            <assemblyIdentity
              name="Microsoft.VisualStudio.CodeAnalysis"
              culture="neutral"
              publicKeyToken="b03f5f7f11d50a3a" />
            <codeBase
              version="15.0.0.0"
              href="..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.dll" />
          </dependentAssembly>
          <dependentAssembly>
            <assemblyIdentity
              name="Microsoft.VisualStudio.CodeAnalysis.Sdk"
              culture="neutral"
              publicKeyToken="b03f5f7f11d50a3a" />
            <codeBase
              version="15.0.0.0"
              href="..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
          </dependentAssembly>
        </assemblyBinding>
      </runtime>
      <!-- To define one or more new toolsets, add an 'msbuildToolsets' element in this file. -->
      <msbuildToolsets
        default="15.0">
        <toolset
          toolsVersion="15.0">
          <property
            name="AndroidNdkDirectory"
            value="C:\Users\myuser\android-toolchain\ndk" />
          <property
            name="AndroidSdkDirectory"
            value="C:\Users\myuser\android-toolchain\sdk" />
          <property
            name="TargetFrameworkRootPath"
            value="C:\Users\myuser\Desktop\Git\xamarin-android\bin\Debug\lib\xamarin.android\xbuild-frameworks\" />
          <property
            name="MonoAndroidToolsDirectory"
            value="C:\Users\myuser\Desktop\Git\xamarin-android\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android" />
          <property
            name="NuGetRestoreTargets"
            value="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.targets" />
          <property
            name="NuGetTargets"
            value="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\Microsoft\NuGet\15.0\Microsoft.NuGet.targets" />
          <property
            name="NuGetProps"
            value="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\Microsoft\NuGet\15.0\Microsoft.NuGet.props" />
          <property
            name="MSBuildToolsPath"
            value="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin" />
          <property
            name="MSBuildToolsPath32"
            value="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin" />
          <property
            name="MSBuildToolsPath64"
            value="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin" />
          <property
            name="MSBuildSDKsPath"
            value="$([MSBuild]::GetMSBuildSDKsPath())" />
          <property
            name="FrameworkSDKRoot"
            value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.6.1@InstallationFolder)" />
          <property
            name="MSBuildRuntimeVersion"
            value="4.0.30319" />
          <property
            name="MSBuildFrameworkToolsPath"
            value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
          <property
            name="MSBuildFrameworkToolsPath32"
            value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
          <property
            name="MSBuildFrameworkToolsPath64"
            value="$(SystemRoot)\Microsoft.NET\Framework64\v$(MSBuildRuntimeVersion)\" />
          <property
            name="MSBuildFrameworkToolsRoot"
            value="$(SystemRoot)\Microsoft.NET\Framework\" />
          <property
            name="SDK35ToolsPath"
            value="$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.0A\WinSDK-NetFx35Tools-x86', 'InstallationFolder', null, RegistryView.Registry32))" />
          <property
            name="SDK40ToolsPath"
            value="$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.6.1\WinSDK-NetFx40Tools-x86', 'InstallationFolder', null, RegistryView.Registry32))" />
          <property
            name="WindowsSDK80Path"
            value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.1@InstallationFolder)" />
          <property
            name="VsInstallRoot"
            value="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise" />
          <property
            name="MSBuildToolsRoot"
            value="$(VsInstallRoot)\MSBuild" />
          <property
            name="MSBuildExtensionsPath"
            value="C:\Users\myuser\Desktop\Git\xamarin-android\bin\Debug\lib\xamarin.android\xbuild" />
          <property
            name="MSBuildExtensionsPath32"
            value="C:\Users\myuser\Desktop\Git\xamarin-android\bin\Debug\lib\xamarin.android\xbuild" />
          <property
            name="RoslynTargetsPath"
            value="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\Roslyn" />
          <!-- VC Specific Paths -->
          <property
            name="VCTargetsPath"
            value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath)','$(VsInstallRoot)\Common7\IDE\VC\VCTargets\'))" />
          <property
            name="VCTargetsPath14"
            value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath14)','$([MSBuild]::GetProgramFiles32())\MSBuild\Microsoft.Cpp\v4.0\V140\'))" />
          <property
            name="VCTargetsPath12"
            value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath12)','$([MSBuild]::GetProgramFiles32())\MSBuild\Microsoft.Cpp\v4.0\V120\'))" />
          <property
            name="VCTargetsPath11"
            value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath11)','$([MSBuild]::GetProgramFiles32())\MSBuild\Microsoft.Cpp\v4.0\V110\'))" />
          <property
            name="VCTargetsPath10"
            value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath10)','$([MSBuild]::GetProgramFiles32())\MSBuild\Microsoft.Cpp\v4.0\'))" />
          <property
            name="AndroidTargetsPath"
            value="$(MSBuildExtensionsPath32)\Microsoft\MDD\Android\V150\" />
          <property
            name="iOSTargetsPath"
            value="$(MSBuildExtensionsPath32)\Microsoft\MDD\iOS\V150\" />
          <projectImportSearchPaths>
            <searchPaths
              os="windows">
              <property
                name="MSBuildExtensionsPath"
                value="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild;$(MSBuildProgramFiles32)\MSBuild" />
              <property
                name="MSBuildExtensionsPath32"
                value="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild;$(MSBuildProgramFiles32)\MSBuild" />
              <property
                name="MSBuildExtensionsPath64"
                value="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild;$(MSBuildProgramFiles32)\MSBuild" />
              <property
                name="VSToolsPath"
                value="$(MSBuildProgramFiles32)\MSBuild\Microsoft\VisualStudio\v$(VisualStudioVersion)" />
            </searchPaths>
          </projectImportSearchPaths>
        </toolset>
      </msbuildToolsets>
    </configuration>

Now it's much more pleasant:

    > .\bin\Debug\bin\xabuild /asdfsadfsdadf
    Microsoft (R) Build Engine version 15.8.168+ga8fba1ebd7 for .NET Framework
    Copyright (C) Microsoft Corporation. All rights reserved.

    MSBUILD : error MSB1001: Unknown switch.
    Switch: /asdfsadfsdadf

    For switch syntax, type "MSBuild /help"

And we can review build logs if we need more detail.