### PR TITLE
[Mono.Android-Tests] Improve AggregateException logging

### DIFF
--- a/src/Mono.Android/Test/Xamarin.Android.Net/AndroidClientHandlerTests.cs
+++ b/src/Mono.Android/Test/Xamarin.Android.Net/AndroidClientHandlerTests.cs
@@ -193,7 +193,7 @@ namespace Xamarin.Android.NetTests {
 				}
 				catch (AggregateException e) {
 					if (supportTls1_2) {
-						Assert.Fail ("SHOULD NOT BE REACHED: BTLS is present, TLS 1.2 should work.");
+						Assert.Fail ("SHOULD NOT BE REACHED: BTLS is present, TLS 1.2 should work. Network error? {0}", e.ToString ());
 					}
 					if (!supportTls1_2) {
 						Assert.IsTrue (IsSecureChannelFailure (e),
@@ -216,7 +216,7 @@ namespace Xamarin.Android.NetTests {
 					Assert.Fail ("SHOULD NOT HAPPEN: Request is expected to cancel");
 				}
 				catch (AggregateException ex) {
-					Assert.IsTrue (ex.InnerExceptions.Any (ie => ie is System.OperationCanceledException), "Request did not throw cancellation exception");
+					Assert.IsTrue (ex.InnerExceptions.Any (ie => ie is System.OperationCanceledException), "Request did not throw cancellation exception; threw: {0}", ex);
 					Assert.IsTrue (cts.IsCancellationRequested, "The request was canceled before cancellation was requested");
 				}
 			}
@@ -233,7 +233,7 @@ namespace Xamarin.Android.NetTests {
 					Assert.Fail ("SHOULD NOT HAPPEN: Request is expected to cancel");
 				}
 				catch (AggregateException ex) {
-					Assert.IsTrue (ex.InnerExceptions.Any(ie => ie is System.OperationCanceledException), "Request did not throw cancellation exception");
+					Assert.IsTrue (ex.InnerExceptions.Any(ie => ie is System.OperationCanceledException), "Request did not throw cancellation exception; threw: {0}", ex);
 					Assert.IsTrue (cts.IsCancellationRequested, "The request was canceled before cancellation was requested");
 				}
 			}
@@ -252,7 +252,7 @@ namespace Xamarin.Android.NetTests {
 				}
 				catch (AggregateException ex)
 				{
-					Assert.IsTrue (ex.InnerExceptions.Any (ie => ie is System.OperationCanceledException), "Request did not throw cancellation exception");
+					Assert.IsTrue (ex.InnerExceptions.Any (ie => ie is System.OperationCanceledException), "Request did not throw cancellation exception; threw: {0}", ex);
 				}
 			}
 		}

--- a/src/Mono.Android/Test/Xamarin.Android.Net/HttpClientIntegrationTests.cs
+++ b/src/Mono.Android/Test/Xamarin.Android.Net/HttpClientIntegrationTests.cs
@@ -164,7 +164,7 @@ namespace Xamarin.Android.NetTests {
 					Assert.Fail ("#1");
 				} catch (AggregateException e) {
 					Console.WriteLine ("CancelRequestViaProxy exception: {0}", e);
-					Assert.IsTrue (e.InnerException is TaskCanceledException, "#2");
+					Assert.IsTrue (e.InnerException is TaskCanceledException, "#2; threw: {0}", e);
 				}
 			}
 		}
@@ -590,7 +590,7 @@ namespace Xamarin.Android.NetTests {
 						client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead).Wait ();
 						Assert.Fail ("#1");
 					} catch (AggregateException e) {
-						Assert.AreEqual (typeof (InvalidOperationException), e.InnerException.GetType (), "#2");
+						Assert.AreEqual (typeof (InvalidOperationException), e.InnerException.GetType (), "#2; threw: {0}", e);
 					}
 					Assert.IsNull (failed, "#102");
 				} finally {
@@ -707,7 +707,7 @@ namespace Xamarin.Android.NetTests {
 							client.SendAsync (request, HttpCompletionOption.ResponseContentRead).Wait (WaitTimeout);
 							Assert.Fail ("#2");
 						} catch (AggregateException e) {
-							Assert.IsTrue (e.InnerException is HttpRequestException, "#3");
+							Assert.IsTrue (e.InnerException is HttpRequestException, "#3; threw: {0}", e);
 						}
 					}
 				} finally {
@@ -944,7 +944,7 @@ namespace Xamarin.Android.NetTests {
 					} catch (AggregateException e) {
 						Console.WriteLine ("# jonp: GetByteArray_ServerError");
 						Console.WriteLine (e);
-						Assert.IsTrue (e.InnerException is HttpRequestException, "#2");
+						Assert.IsTrue (e.InnerException is HttpRequestException, "#2; threw: {0}", e);
 					}
 				} finally {
 					listener.Close ();


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/1180/testReport/junit/(root)/AndroidClientHandlerTests/Mono_Android_Tests__Xamarin_Android_NetTests_AndroidClientHandlerTests_Sanity_Tls_1_2_Url_WithMonoClientHandlerFails___Release/

`AggregateException`, like `Exception`, can be ~anything, and
represent an *actual failure* that needs to be fixed...or a
(hopefully) transient network failure that will disappear the next
time the test is run.

Which brings us to
`AndroidClientHandlerTests.Sanity_Tls_1_2_Url_WithMonoClientHandlerFails()`:
this test has been failing more often of late, but *we don't know
why*.  Our *guess* is that it's a transient network failure, as
*sometimes* the test works, but even if we assume that's the case,
we're still getting these "failures".

How do we fix the failures?  By detecting a transient network issue,
and ignoring the test.

How do we detect a transient network issue?

¯\_(ツ)_/¯

Which is the problem: *presumably* there is an exception somewhere
within the `AggregateException` which we could use to differentiate
between an *actual* failure and a transient network failure, but
*currently* we don't log exception thrown.  Meaning we have nothing to
ponder about or check.

Update `AggregateException` use so that if we `Assert.Fail()`, we also
log the exception as part of the failure message.