### PR TITLE
[libzip] Remove building of i386 on MacOS.

### DIFF
--- a/src/libzip/libzip.projitems
+++ b/src/libzip/libzip.projitems
@@ -3,7 +3,7 @@
   <ItemGroup>
     <_LibZipTarget Include="host-Darwin" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">
       <CMake>cmake</CMake>
-      <CMakeFlags>-C$(MSBuildThisFileDirectory)/CMakeCacheInitialOSX.txt -DCMAKE_OSX_ARCHITECTURES=&quot;i386;x86_64&quot; -DBUILD_SHARED_LIBS=ON</CMakeFlags>
+      <CMakeFlags>-C$(MSBuildThisFileDirectory)/CMakeCacheInitialOSX.txt -DCMAKE_OSX_ARCHITECTURES=&quotx86_64&quot; -DBUILD_SHARED_LIBS=ON</CMakeFlags>
       <OutputLibrary>libzip.5.0.dylib</OutputLibrary>
       <OutputLibraryPath>lib/libzip.5.0.dylib</OutputLibraryPath>
     </_LibZipTarget>

--- a/src/libzip/libzip.projitems
+++ b/src/libzip/libzip.projitems
@@ -3,7 +3,7 @@
   <ItemGroup>
     <_LibZipTarget Include="host-Darwin" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">
       <CMake>cmake</CMake>
-      <CMakeFlags>-C$(MSBuildThisFileDirectory)/CMakeCacheInitialOSX.txt -DCMAKE_OSX_ARCHITECTURES=&quotx86_64&quot; -DBUILD_SHARED_LIBS=ON</CMakeFlags>
+      <CMakeFlags>-C$(MSBuildThisFileDirectory)/CMakeCacheInitialOSX.txt -DCMAKE_OSX_ARCHITECTURES=&quot;x86_64&quot; -DBUILD_SHARED_LIBS=ON</CMakeFlags>
       <OutputLibrary>libzip.5.0.dylib</OutputLibrary>
       <OutputLibraryPath>lib/libzip.5.0.dylib</OutputLibraryPath>
     </_LibZipTarget>


### PR DESCRIPTION
Xcode 10.0 deprecates compiling of 32bit applications.

	The macOS 10.14 SDK no longer contains support for compiling
	32-bit applications. If developers need to compile for i386, Xcode
	9.4 or earlier is required. (39858111)

So just build 64bit everywhere.