### PR TITLE
Don't ignore IntentFilter attribute on content provider classes

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -695,12 +695,15 @@ namespace Xamarin.Android.Tasks {
 
 			IEnumerable<MetaDataAttribute> metadata = MetaDataAttribute.FromCustomAttributeProvider (type);
 			IEnumerable<GrantUriPermissionAttribute> grants = GrantUriPermissionAttribute.FromTypeDefinition (type);
+			IEnumerable<IntentFilterAttribute> intents = IntentFilterAttribute.FromTypeDefinition (type);
 
 			XElement element = attr.ToElement (PackageName);
 			if (element.Attribute (attName) == null)
 				element.Add (new XAttribute (attName, name));
 			element.Add (metadata.Select (md => md.ToElement (PackageName)));
 			element.Add (grants.Select (intent => intent.ToElement (PackageName)));
+			element.Add (intents.Select (intent => intent.ToElement (PackageName)));
+
 			return element;
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2202
Context: https://forums.xamarin.com/discussion/96028/android-documentsprovider-intent-filter

When generating `AndroidManifest.xml` we currently fail to take into account any
instances of the `IntentFilterAttribute` custom attribute decorating all the
content provider classes (that is ones with another custom attribute -
`ContentProviderAttribute`). This forces the developer to manually edit the
manifest to add appropriate entry for the provider and its intent filters.

This commit removes the limitation by making sure our manifest generator looks
for and processes the `IntentFilter` custom attribute.