### PR TITLE
[tests] Run tests in parallel on non-Windows

### DIFF
--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -138,18 +138,51 @@
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\timing\timing.csproj" Targets="MSBuildTiming" />
   </Target>
   <ItemGroup>
-    <_RunTestTarget Include="RunNUnitTests" />
-    <_RunTestTarget Include="RunJavaInteropTests" />
-    <_RunTestTarget Include="RunApkTests" />
+    <_RunParallelTestTarget Include="RunNUnitTests" />
+    <_RunParallelTestTarget Include="RunJavaInteropTests" />
+    <_RunParallelTestTarget Include="RunApkTests" />
+  </ItemGroup>
+  <ItemGroup>
     <_RunTestTarget Include="RunPerformanceTests" />
   </ItemGroup>
   <Target Name="RunAllTests">
     <MSBuild
+        Condition=" '$(HostOS)' == 'Windows' "
         ContinueOnError="ErrorAndContinue"
         Projects="$(MSBuildThisFileDirectory)RunTests.targets"
         RunEachTargetSeparately="True"
-        Targets="@(_RunTestTarget)"
+        Targets="@(_RunParallelTestTarget)"
     />
-  </Target>
+    <ItemGroup Condition=" '$(USE_MSBUILD)' == '1' ">
+      <_RunParallelTestTarget>
+        <_BinLog>$(_XABinLogPrefix)-$([System.DateTime]::Now.ToString ("yyyyMMddTHHmmss"))-Target-%(Identity).binlog"</_BinLog>
+      </_RunParallelTestTarget>
+    </ItemGroup>
+    <ItemGroup>
+      <_Commands Include="@(_RunParallelTestTarget->'echo Executing in background: msbuild $(MSBuildThisFileDirectory)RunTests.targets %(_BinLog) /t:%(Identity)')" />
+      <_Commands Include="@(_RunParallelTestTarget->'msbuild $(MSBuildThisFileDirectory)RunTests.targets %(_BinLog) /t:%(Identity) &amp;')" />
+      <_Commands Include="wait" />
+      <_Commands Include="exit 0" />
+    </ItemGroup>
+    <PropertyGroup>
+      <_ParallelTargets>$(MSBuildThisFileDirectory)..\..\bin\Test$(Configuration)\parallel-targets.sh</_ParallelTargets>
+    </PropertyGroup>
+    <WriteLinesToFile
+        File="$(_ParallelTargets)"
+        Lines="@(_Commands)"
+        Overwrite="True"
+    />
+    <Exec
+        Condition=" '$(HostOS)' != 'Windows' "
+        ContinueOnError="ErrorAndContinue"
+        WorkingDirectory="$(_TopDir)"
+        Command="bash &quot;$(_ParallelTargets)&quot;"
+    />
+    <MSBuild
+         ContinueOnError="ErrorAndContinue"
+         Projects="$(MSBuildThisFileDirectory)RunTests.targets"
+         RunEachTargetSeparately="True"
+         Targets="@(_RunTestTarget)"
+     />
+   </Target>
 </Project>
-


### PR DESCRIPTION
What do we want?  Faster unit test execution!

How do we do that?  By running things in parallel!

Some of our existing tests are already run in parallel, such as the
`src/Xamarin.Android.Build.Tasks/Tests` tests which use NUnit's
`[Parallelizable (ParallelScope.Children)]`, but there is currently no
way to run the `Xamarin.Android.Build.Tasks` NUnit tests
*concurrently* with the on-device `.apk` tests concurrently with the
Java.Interop unit tests concurrently with...

We *think* there might be a "win" here, as the
`Xamarin.Android.Build.Tasks` unit tests are heavily I/O bound, while
the `.apk` BCL tests are -- presumably -- CPU bound, so executing
these at the same time might net some nice time savings.

Spike the idea by updating the `RunAllTests` target to *generate a
shell script* which executes `msbuild` to run the appropriate test
target, in the background, then waiting for all jobs to finish.

The generated `bin/Test$(Configuration)/parallel-targets.sh` file
resembles:

	echo Executing in background: msbuild …/build-tools/scripts/RunTests.targets /v:normal /binaryLogger:"…/msbuild-20181012T083249-Target-RunNUnitTests.binlog" /t:RunNUnitTests
	msbuild …/build-tools/scripts/RunTests.targets /v:normal /binaryLogger:"…/msbuild-20181012T083249-Target-RunNUnitTests.binlog" /t:RunNUnitTests &
	wait
	exit 0
