### PR TITLE
[Xamarin.Android.Build.Tasks] Fix typo in MonkeyPatcher.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Resources/MonkeyPatcher.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/MonkeyPatcher.java
@@ -322,7 +322,7 @@ public class MonkeyPatcher {
                 references = map.values ();
             }
             for (WeakReference<Resources> wr : references) {
-                Resources resources = wr.ge ();
+                Resources resources = wr.get ();
                 if (resources != null) {
                     // Set the AssetManager of the Resources instance to our brand new one
                     try {


### PR DESCRIPTION
Commit 3f360c09 introduced the `MonkeyPatcher` but it seems
there was a typo in it. This commit fixes that issue.