### PR TITLE
[monodroid] Convert path to utf8 on windows.

### DIFF
--- a/src/monodroid/jni/monodroid-glue.c
+++ b/src/monodroid/jni/monodroid-glue.c
@@ -659,14 +659,14 @@ copy_native_libraries_to_internal_location (void)
 			log_warn (LOG_DEFAULT, "checking file: `%s`", e->d_name);
 			if (monodroid_dirent_hasextension (e, ".so")) {
 #if WINDOWS
-				char *file_name = utils.utf16_to_utf8 (e->d_name);
-#else
+				char *file_name = utf16_to_utf8 (e->d_name);
+#else   /* ndef WINDOWS */
 				char *file_name = e->d_name;
-#endif
+#endif  /* ndef WINDOWS */
 				copy_file_to_internal_location (primary_override_dir, dir_path, file_name);
 #if WINDOWS
 				free (file_name);
-#endif
+#endif  /* def WINDOWS */
 			}
 		}
 		monodroid_closedir (dir);

--- a/src/monodroid/jni/monodroid-glue.c
+++ b/src/monodroid/jni/monodroid-glue.c
@@ -658,7 +658,15 @@ copy_native_libraries_to_internal_location (void)
 		while (readdir_r (dir, &b, &e) == 0 && e) {
 			log_warn (LOG_DEFAULT, "checking file: `%s`", e->d_name);
 			if (monodroid_dirent_hasextension (e, ".so")) {
-				copy_file_to_internal_location (primary_override_dir, dir_path, e->d_name);
+#if WINDOWS
+				char *file_name = utils.utf16_to_utf8 (e->d_name);
+#else
+				char *file_name = e->d_name;
+#endif
+				copy_file_to_internal_location (primary_override_dir, dir_path, file_name);
+#if WINDOWS
+				free (file_name);
+#endif
 			}
 		}
 		monodroid_closedir (dir);


### PR DESCRIPTION
The `d_name` property on the directory structture is not
a `char*` on windows but a `wchar_t`. As a result it might
not behave as expected when running on the desktop.

we should use `utils.utf16_to_utf8` to convert the values
over to a format which `copy_file_to_internal_location` can
take.