### PR TITLE
Bump Mono to fix builds on the Linux PR builders

### DIFF
--- a/build-tools/scripts/dependencies/debian-common.sh
+++ b/build-tools/scripts/dependencies/debian-common.sh
@@ -1,7 +1,6 @@
 DEBIAN_COMMON_DEPS="autoconf
 	autotools-dev
 	automake
-	clang
 	curl
 	g++-mingw-w64
 	gcc-mingw-w64


### PR DESCRIPTION
Linux PR builders run on Debian instead of Ubuntu and because of an omission in
the Mono SDKs makefiles the bots tried to use MXE instead of the mingw
environment provided by the distribution. The Mono bump includes a fix for this.