### PR TITLE
Fix release build when no cross runtimes are present

### DIFF
--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -411,7 +411,7 @@
         DestinationFiles="@(_InstallUnstrippedCrossRuntimeBinaryOutput)"
     />
     <Exec
-        Condition=" '$(Configuration)' != 'Debug' Or '%(_MonoCrossRuntime.ExeSuffix)' == '.exe' "
+        Condition=" '@(_CrossRuntimeBinarySource)' != '' And ('$(Configuration)' != 'Debug' Or '%(_MonoCrossRuntime.ExeSuffix)' == '.exe') "
         Command="&quot;%(_MonoCrossRuntime.Strip)&quot; %(_MonoCrossRuntime.StripFlags) &quot;$(_MSBuildDir)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)&quot;"
     />
     <Touch Files="@(_InstallCrossRuntimeBinaryOutput);@(_InstallCrossRuntimeBinaryOutput)" />


### PR DESCRIPTION
If one tries to build a release version of XA (`make CONFIGURATION=Release`) but
the tree is not configured to build any of the cross compilers, the build will
fail when trying to strip the non-existing runtime with an error similar to:

   Copying file from ".../external/mono/sdks/out/android-host-Linux-release/bin/mono" to ".../bin/Release/lib/xamarin.android/xbuild/Xamarin/Android/Linux/mono".
   Touching ".../bin/Release/lib/xamarin.android/xbuild/Xamarin/Android/Linux/mono".
   ""  ".../bin/Release/lib/xamarin.android/xbuild/Xamarin/Android/"
   /bin/sh: 2: /tmp/tmp755872b2be394779865a2aa8606e7deb.exec.cmd: : Permission denied

This is because the condition on the `Exec` task doesn't take into account the
possibility that there are no cross runtimes built.