### PR TITLE
[Xamarin.Android.Build.Tasks] Only update the CustomView if the document changed.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Android.Tasks {
 							continue;
 						if (!File.Exists (file))
 							continue;
-						var document = XDocument.Load (file);
+						var document = XDocument.Load (file, options : LoadOptions.SetLineInfo);
 						var e = document.Root;
 						bool update = false;
 						foreach (var elem in AndroidResource.GetElements (e).Prepend (e)) {
@@ -65,7 +65,11 @@ namespace Xamarin.Android.Tasks {
 							update |= TryFixFragment (a, acw_map);
 						}
 						if (update) {
-							document.Save (file);
+							var lastModified = File.GetLastWriteTimeUtc (file);
+							if (document.SaveIfChanged (file)) {
+								Log.LogDebugMessage ($"Fixed up Custom Views in {file}");
+								MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (file, lastModified, Log);
+							}
 						}
 						processed.Add (file);
 					}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ConvertResourcesCasesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ConvertResourcesCasesTests.cs
@@ -57,6 +57,9 @@ namespace Xamarin.Android.Build.Tests {
 			StringAssert.Contains ("md5d6f7135293df7527c983d45d07471c5e.CustomTextView", output, "md5d6f7135293df7527c983d45d07471c5e.CustomTextView should exist in the main.xml");
 			StringAssert.DoesNotContain ("ClassLibrary1.CustomView", output, "ClassLibrary1.CustomView should have been replaced.");
 			StringAssert.DoesNotContain ("classlibrary1.CustomView", output, "classlibrary1.CustomView should have been replaced.");
+			Assert.IsTrue (custom.Execute (), "Task should have executed successfully");
+			var secondOutput = File.ReadAllText (Path.Combine(resPath, "layout", "main.xml"));
+			StringAssert.AreEqualIgnoringCase (output, secondOutput, "Files should not have changed.");
 			Directory.Delete (path, recursive: true);
 		}
 
@@ -107,6 +110,9 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.AreEqual ("XA1002", errors [0].Code, "XA1002 should have been raised.");
 			var expected = Path.Combine ("Resources", "layout", "main.xml");
 			Assert.AreEqual (expected, errors [0].File, $"Error should have the \"{expected}\" path. But contained \"{errors [0].File}\"");
+			Assert.IsFalse (custom.Execute (), "Task should have executed successfully");
+			var secondOutput = File.ReadAllText (Path.Combine (resPath, "layout", "main.xml"));
+			StringAssert.AreEqualIgnoringCase (output, secondOutput, "Files should not have changed.");
 			Directory.Delete (path, recursive: true);
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/XDocumentExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/XDocumentExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Xml.XPath;
 using System.Xml.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -29,12 +30,14 @@ namespace Xamarin.Android.Tasks
 			return element.ToString (SaveOptions.DisableFormatting);
 		}
 
-		public static void SaveIfChanged (this XDocument document, string fileName)
+		public static bool SaveIfChanged (this XDocument document, string fileName)
 		{
 			var tempFile = System.IO.Path.GetTempFileName ();
 			try {
-				document.Save (tempFile);
-				MonoAndroidHelper.CopyIfChanged (tempFile, fileName);
+				using (var stream = File.OpenWrite (tempFile))
+				using (var xw = new Monodroid.LinePreservedXmlWriter (new StreamWriter (stream)))
+					xw.WriteNode (document.CreateNavigator (), false);
+				return MonoAndroidHelper.CopyIfChanged (tempFile, fileName);
 			} finally {
 				File.Delete (tempFile);
 			}


### PR DESCRIPTION
While investigating a Designer Build breakage in monodroid we
hit an issue where the `ConvertCustomView` task was updating
a file even if nothing had changed in it.

As a result this causes a problem because we end up in a loop
where `_GenerateJavaStubs` and `_UpdateAndroidResgen` and the
designer target all update the same files over and over.

So lets try to avoid that by only updating the custom view
if the file actaually changes. However lets also keep the
modified date for the file which was written by
`_UpdateAndroidResgen`. This will ensure we dont keep running
the same targets over and over.