### PR TITLE
[Xamarin.Android.Build.Tests] Fix BuildHelper Root

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BuildHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BuildHelper.cs
@@ -23,7 +23,8 @@ namespace Xamarin.Android.Build.Tests
 			return new ProjectBuilder (directory) {
 				CleanupAfterSuccessfulBuild = cleanupAfterSuccessfulBuild,
 				CleanupOnDispose = cleanupOnDispose,
-				Verbosity = LoggerVerbosity.Diagnostic
+				Verbosity = LoggerVerbosity.Diagnostic,
+				Root = Xamarin.Android.Build.Paths.TestOutputDirectory,
 			};
 		}
 	}


### PR DESCRIPTION
Some of the tests in monodroid are failing because
it was assumed that the test `Root` folder would be
in the project output directory.

However with the new `XAConfig` file changes in XA that
is no longer the case. As a result some of the unit tests
fail because it is looking for files in the wrong place.

This commit changes the `Root` property of the `ProjectBuilder`
to use the one from `XAConfig`.