### PR TITLE
[Xamarin.Android.Build.Tasks] Backport XA0115 error but make it a warning.

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -40,6 +40,8 @@
 + [XA0112](xa0112.md): `aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.
 + [XA0113](xa0113.md): Google Play requires that new applications must use a `$(TargetFrameworkVersion)` of v8.0 (API level 26) or above.
 + [XA0114](xa0114.md): Google Play requires that application updates must use a `$(TargetFrameworkVersion)` of v8.0 (API level 26) or above.
++ [XA0115](xa0115.md): This ABI ('armeabi') is deprecated and will be removed in the next release. Please update your project properties.
++ [XA0116](xa0116.md): The TargetFrameworkVersion {TargetFrameworkVersion} is deprecated. Please update it to be v4.4 or higher.
 
 ### XA1xxx Project Related
 

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -41,7 +41,7 @@
 + [XA0113](xa0113.md): Google Play requires that new applications must use a `$(TargetFrameworkVersion)` of v8.0 (API level 26) or above.
 + [XA0114](xa0114.md): Google Play requires that application updates must use a `$(TargetFrameworkVersion)` of v8.0 (API level 26) or above.
 + [XA0115](xa0115.md): This ABI ('armeabi') is deprecated and will be removed in the next release. Please update your project properties.
-+ [XA0116](xa0116.md): The TargetFrameworkVersion {TargetFrameworkVersion} is deprecated. Please update it to be v4.4 or higher.
++ [XA0117](xa0117.md): The TargetFrameworkVersion {TargetFrameworkVersion} is deprecated. Please update it to be v4.4 or higher.
 
 ### XA1xxx Project Related
 

--- a/Documentation/guides/messages/xa0115.md
+++ b/Documentation/guides/messages/xa0115.md
@@ -1,0 +1,15 @@
+# Compiler Warning XA0115
+
+Due to the [removal of armeabi support in Android NDK r17][ndk-guide],
+Xamarin.Android 9.1 is the last version that supports the armeabi architecture.
+Projects that have this old ABI selected in the `$(AndroidSupportedAbis)`
+property will need to be updated to remove it before they will build
+successfully with newer versions of Xamarin.Android.  The newer armeabi-v7a ABI
+should now be used instead.  The `$(AndroidSupportedAbis)` setting can be found
+in the **Advanced** section of the **Android Options** project properties in
+Visual Studio and **Android Build** project properties in Visual Studio for Mac.
+
+Example message:
+- `Invalid value 'armeabi' in $(AndroidSupportedAbis). This ABI is no longer supported. Please update your project properties.`
+
+[ndk-guide]: https://developer.android.com/ndk/guides/abis

--- a/Documentation/guides/messages/xa0116.md
+++ b/Documentation/guides/messages/xa0116.md
@@ -1,0 +1,17 @@
+# Compiler Warning XA0115
+
+As the Android platform evolves certain apiLevels will be deprecated and
+removed. Google publishes information about the market share of each
+Android version [here](https://developer.android.com/about/dashboards/).
+
+If you are seeing this warning it is because your `$(TargetFrameworkVersion)`
+is set to a value which is likely to be deprecated in the near future.
+To remove this warning update your `$(TargetFrameworkVersion)` to use
+the latest stable platform. 
+
+Your `android:minSdk` value can still use older versions of the android platform.
+
+[Distribution dashboard](https://developer.android.com/about/dashboards/)
+[Google Play's target API level requirement](https://developer.android.com/distribute/best-practices/develop/target-sdk)
+
+

--- a/Documentation/guides/messages/xa0117.md
+++ b/Documentation/guides/messages/xa0117.md
@@ -1,4 +1,4 @@
-# Compiler Warning XA0115
+# Compiler Warning XA0117
 
 As the Android platform evolves certain apiLevels will be deprecated and
 removed. Google publishes information about the market share of each

--- a/Documentation/guides/messages/xa0117.md
+++ b/Documentation/guides/messages/xa0117.md
@@ -1,8 +1,12 @@
 # Compiler Warning XA0117
 
-As the Android platform evolves certain apiLevels will be deprecated and
-removed. Google publishes information about the market share of each
-Android version [here](https://developer.android.com/about/dashboards/).
+As the Android platform evolves certain versions will be deprecated and
+removed. How we decide if a platform is deprecated largely depends on if
+the [ndk](https://developer.android.com/ndk/downloads/revision_history) is able to support the platform in question.
+It also depends on if the Android Support Libraries support that platform.
+
+If both of the above have removed support for a particular `apiLevel` is it
+highly likely that it will be deprecated and removed from Xamarin.Android.
 
 If you are seeing this warning it is because your `$(TargetFrameworkVersion)`
 is set to a value which is likely to be deprecated in the near future.
@@ -12,6 +16,7 @@ the latest stable platform.
 Your `android:minSdk` value can still use older versions of the android platform.
 
 [Distribution dashboard](https://developer.android.com/about/dashboards/)
+[ndk](https://developer.android.com/ndk/downloads/revision_history) 
 [Google Play's target API level requirement](https://developer.android.com/distribute/best-practices/develop/target-sdk)
 
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
@@ -192,6 +192,8 @@ namespace Xamarin.Android.Tasks
 					Log.LogCodedWarning ("XA0113", $"Google Play requires that new applications must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {TargetFrameworkVersion} (API level {AndroidApiLevel}).");
 				if (apiLevel < 26)
 					Log.LogCodedWarning ("XA0114", $"Google Play requires that application updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {TargetFrameworkVersion} (API level {AndroidApiLevel}).");
+				if (apiLevel < 19)
+					Log.LogCodedWarning ("XA0116", $"The TargetFrameworkVersion {TargetFrameworkVersion} is deprecated. Please update it to be v4.4 or higher.");
 			}
 
 			SequencePointsMode mode;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
@@ -193,7 +193,7 @@ namespace Xamarin.Android.Tasks
 				if (apiLevel < 26)
 					Log.LogCodedWarning ("XA0114", $"Google Play requires that application updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {TargetFrameworkVersion} (API level {AndroidApiLevel}).");
 				if (apiLevel < 19)
-					Log.LogCodedWarning ("XA0116", $"The TargetFrameworkVersion {TargetFrameworkVersion} is deprecated. Please update it to be v4.4 or higher.");
+					Log.LogCodedWarning ("XA0117", $"The TargetFrameworkVersion {TargetFrameworkVersion} is deprecated. Please update it to be v4.4 or higher.");
 			}
 
 			SequencePointsMode mode;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -494,6 +494,16 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		TargetFrameworkVersion="$(TargetFrameworkVersion)" />
 </Target>
 
+<Target Name="_CheckSupportedAbis">
+	<PropertyGroup>
+		<_RequestedAbis>;$(AndroidSupportedAbis);</_RequestedAbis>
+	</PropertyGroup>
+	<Warning Code="XA0115"
+			Condition="$(_RequestedAbis.Contains(';armeabi;'))"
+			Text="This ABI ('armeabi') is deprecated and will be removed in the next release. Please update your project properties."
+	/>
+</Target>
+
 <Target Name="_StripEmbeddedLibraries"
   Inputs="@(ResolvedAssemblies)" 
   Outputs="$(_AndroidStripFlag)"
@@ -528,6 +538,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     _CheckProjectItems;
     _CheckForContent;
     _CheckTargetFramework;
+	_CheckSupportedAbis;
     _RemoveLegacyDesigner;
     _ValidateAndroidPackageProperties;
     $(BuildDependsOn);


### PR DESCRIPTION
Commit b1d81460 introduced a new error XA0115. This error is raised
if the user has `armeabi` in their `$(AndroidSupportedAbis)`.

We need to do a similar thing in the d15-9 release. However it should
not be an error but a warning. It will turn into an error for the next
release.

This commit also introduces a warning if the user is using a
`$(TargetFrameworkVersion)` less than 19. These platforms have
a very low market share and will be slowly removed from our
build system going forward. This warning is to make sure that users
get a heads up before their application starts failing to build.