### PR TITLE
[Xamarin.Android.Build.Tasks] Add XA0117 TargetFrameworkVersion is deprecated.

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -41,6 +41,8 @@
 + [XA0113](xa0113.md): Google Play requires that new applications must use a `$(TargetFrameworkVersion)` of v8.0 (API level 26) or above.
 + [XA0114](xa0114.md): Google Play requires that application updates must use a `$(TargetFrameworkVersion)` of v8.0 (API level 26) or above.
 + [XA0115](xa0115.md): Invalid value 'armeabi' in $(AndroidSupportedAbis). This ABI is no longer supported. Please update your project properties.
++ [XA0116](xa0116.md): Unable to find `EmbeddedResource` of name `{ResourceName}`.
++ [XA0117](xa0117.md): The TargetFrameworkVersion {TargetFrameworkVersion} is deprecated. Please update it to be v4.4 or higher.
 
 ### XA1xxx Project Related
 

--- a/Documentation/guides/messages/xa0117.md
+++ b/Documentation/guides/messages/xa0117.md
@@ -1,22 +1,25 @@
 # Compiler Warning XA0117
 
 As the Android platform evolves certain versions will be deprecated and
-removed. How we decide if a platform is deprecated largely depends on if
-the [ndk](https://developer.android.com/ndk/downloads/revision_history) is able to support the platform in question.
-It also depends on if the Android Support Libraries support that platform.
+removed. How we decide if a platform is deprecated largely depends on whether
+the [Android NDK][ndk] continues to support the platform in question.
+It also depends on whether the
+[Android Support Libraries support that platform][support].
 
-If both of the above have removed support for a particular `apiLevel` is it
-highly likely that it will be deprecated and removed from Xamarin.Android.
+If both the Android NDK and the Android Support Libraries have removed support
+for a particular `apiLevel`, then it is highly likely that support for the
+API level will be deprecated and removed from Xamarin.Android.
 
 If you are seeing this warning it is because your `$(TargetFrameworkVersion)`
 is set to a value which is likely to be deprecated in the near future.
 To remove this warning update your `$(TargetFrameworkVersion)` to use
 the latest stable platform. 
 
-Your `android:minSdk` value can still use older versions of the android platform.
+Your `android:minSdk` value within `AndroidManifest.xml` can still mention
+older versions of the android platform.
 
-[Distribution dashboard](https://developer.android.com/about/dashboards/)
-[ndk](https://developer.android.com/ndk/downloads/revision_history) 
-[Google Play's target API level requirement](https://developer.android.com/distribute/best-practices/develop/target-sdk)
+
+[ndk]: https://developer.android.com/ndk/downloads/revision_history
+[support]: https://developer.android.com/distribute/best-practices/develop/target-sdk
 
 

--- a/Documentation/guides/messages/xa0117.md
+++ b/Documentation/guides/messages/xa0117.md
@@ -1,0 +1,17 @@
+# Compiler Warning XA0115
+
+As the Android platform evolves certain apiLevels will be deprecated and
+removed. Google publishes information about the market share of each
+Android version [here](https://developer.android.com/about/dashboards/).
+
+If you are seeing this warning it is because your `$(TargetFrameworkVersion)`
+is set to a value which is likely to be deprecated in the near future.
+To remove this warning update your `$(TargetFrameworkVersion)` to use
+the latest stable platform. 
+
+Your `android:minSdk` value can still use older versions of the android platform.
+
+[Distribution dashboard](https://developer.android.com/about/dashboards/)
+[Google Play's target API level requirement](https://developer.android.com/distribute/best-practices/develop/target-sdk)
+
+

--- a/Documentation/guides/messages/xa0117.md
+++ b/Documentation/guides/messages/xa0117.md
@@ -1,8 +1,12 @@
-# Compiler Warning XA0115
+# Compiler Warning XA0117
 
-As the Android platform evolves certain apiLevels will be deprecated and
-removed. Google publishes information about the market share of each
-Android version [here](https://developer.android.com/about/dashboards/).
+As the Android platform evolves certain versions will be deprecated and
+removed. How we decide if a platform is deprecated largely depends on if
+the [ndk](https://developer.android.com/ndk/downloads/revision_history) is able to support the platform in question.
+It also depends on if the Android Support Libraries support that platform.
+
+If both of the above have removed support for a particular `apiLevel` is it
+highly likely that it will be deprecated and removed from Xamarin.Android.
 
 If you are seeing this warning it is because your `$(TargetFrameworkVersion)`
 is set to a value which is likely to be deprecated in the near future.
@@ -12,6 +16,7 @@ the latest stable platform.
 Your `android:minSdk` value can still use older versions of the android platform.
 
 [Distribution dashboard](https://developer.android.com/about/dashboards/)
+[ndk](https://developer.android.com/ndk/downloads/revision_history) 
 [Google Play's target API level requirement](https://developer.android.com/distribute/best-practices/develop/target-sdk)
 
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
@@ -190,6 +190,8 @@ namespace Xamarin.Android.Tasks
 					Log.LogCodedWarning ("XA0113", $"Google Play requires that new applications must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {TargetFrameworkVersion} (API level {AndroidApiLevel}).");
 				if (apiLevel < 26)
 					Log.LogCodedWarning ("XA0114", $"Google Play requires that application updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {TargetFrameworkVersion} (API level {AndroidApiLevel}).");
+				if (apiLevel < 19)
+					Log.LogCodedWarning ("XA0117", $"The TargetFrameworkVersion {TargetFrameworkVersion} is deprecated. Please update it to be v4.4 or higher.");
 			}
 
 			SequencePointsMode mode;


### PR DESCRIPTION
Add a new Warning XA0117 which will inform users if they are
using a `$(TargetFrameworkVersion)` which is going to be
deprecated in the future.

In d16 out minimum supported version will be v4.4 (19).
v2.3 (10) will be removed.