### PR TITLE
[Xamarin.Android.Tools.BootstrapTasks] Emit proper error XML

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
@@ -78,22 +78,25 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 					new XAttribute ("ignored", "0"),
 					new XAttribute ("inconclusive", "0"),
 					new XAttribute ("invalid", "0"),
-					new XAttribute ("name", SourceFile),
+					new XAttribute ("name", dest),
 					new XAttribute ("not-run", "0"),
 					new XAttribute ("skipped", "0"),
 					new XAttribute ("time", DateTime.Now.ToString ("HH:mm:ss")),
 					new XAttribute ("total", "1"),
 					new XElement ("test-suite",
-						new XAttribute ("type", "Assembly"),
-						new XAttribute ("name", SourceFile),
+						new XAttribute ("type", "APK-File"),
+						new XAttribute ("name", dest),
 						new XAttribute ("executed", "True"),
 						new XAttribute ("result", "Failure"),
 						new XAttribute ("success", "False"),
 						new XAttribute ("time", "0"),
 						new XAttribute ("asserts", "0"),
-						new XElement ("failure",
-							new XElement ("message", $"Error processing `{SourceFile}`.  Check the build log for execution errors."),
-							new XElement ("stack-trace", e.ToString ())))));
+						new XElement ("results",
+							new XElement ("test-case",
+								new XAttribute ("name", Path.GetFileName (dest)),
+								new XElement ("failure",
+									new XElement ("message", $"Error processing `{SourceFile}`.  Check the build log for execution errors."),
+									new XElement ("stack-trace", e.ToString ())))))));
 			doc.Save (dest);
 		}
 


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/1193/

The hope (dream?) behind 0ec00e12 was that if (when) a `.apk` test had
some unspeakable error occur -- one in which the `TestResults*.xml`
file wasn't generated -- then `<RenameTestCases/>` would generate a
"stub" error XML file so that we'd see an *actual* error in the
Jenkins job status page.

How'd we do?

Not good: [Job #1193][0] had a failure when running
`Xamarin.Android.Locale_Tests-Signed.apk` (currently unexplored),
which caused our "stub error XML file" to be generated.  The result is
that Jenkins *did not report any errors*.

Doh!

Why?  Cast our memory back to 23b2642e, and we can see why:

	$ xsltproc nunit-1.0-to-junit-2.xsl TestResult-Xamarin.Android.Locale_Tests-Debug.xml
	<?xml version="1.0"?>
	<testsuites/>

(The perils of not having a good way to test things...)

The `nunit-1.0-to-junit-2.xsl` transform requires that there be a
`/test-results/test-suite/results/test-case` element in order to
generate *something meaningful*, and `<RenameTestCases/>` wasn't
creating such an element, just `/test-results/test-suite/failure`.

Update `<RenameTestCases/>` so that it now emits a
`/test-results/test-suite/results/test-case/failure` element, which
appeases `nunit-1.0-to-junit-2.xsl`:

	$ xsltproc nunit-1.0-to-junit-2.xsl Updated.xml
	<testsuites>
	  <testsuite ...>
	    <testcase ...>
	      <failure>
	        ...

Additionally, update the file so that instead of using the *source*
XML file -- e.g.
`xamarin-android/tests/../bin/TestDebug/TestResult-Xamarin.Android.Locale_Tests.xml`
-- we instead use the *destination* file, which is a bit more
meaningful.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/1193