### PR TITLE
Remove top version range from prerequisites

### DIFF
--- a/build-tools/create-vsix/source.extension.vsixmanifest
+++ b/build-tools/create-vsix/source.extension.vsixmanifest
@@ -7,10 +7,10 @@
     <Icon>Resources\AndroidSdkPackage.ico</Icon>
   </Metadata>
   <Installation AllUsers="true" Experimental="|create-vsix;GetIsExperimental|">
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,16.0)"  />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,)"  />
   </Installation>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="Xamarin.Android.Sdk.pkgdef" />


### PR DESCRIPTION
The valid ranges will be controlled by Willow, rather than the VSIXes themselves.