### PR TITLE
[Xamarin.Android.Build.Tasks] Add more warning codes

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -43,6 +43,7 @@
 + [XA0115](xa0115.md): Invalid value 'armeabi' in $(AndroidSupportedAbis). This ABI is no longer supported. Please update your project properties.
 + [XA0116](xa0116.md): Unable to find `EmbeddedResource` of name `{ResourceName}`.
 + [XA0117](xa0117.md): The TargetFrameworkVersion {TargetFrameworkVersion} is deprecated. Please update it to be v4.4 or higher.
++ [XA0118](xa0118.md): Could not parse '{TargetMoniker}'
 
 ### XA1xxx Project Related
 
@@ -50,6 +51,7 @@
 + [XA1001](xa1001.md): AndroidResgen: Warning while updating Resource XML '{filename}': {Message}
 + [XA1002](xa1002.md): We found a matching key '{Key}' for '{Item}'. But the casing was incorrect. Please correct the casing
 + [XA1003](xa1003.md): '{zip}' does not exist. Please rebuild the project.
++ [XA1005](xa1005.md): Attempting naive type name fixup for element with ID '{id}' and type '{managedType}'
 
 ### XA2xxx Linker
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
@@ -317,8 +317,8 @@ namespace Xamarin.Android.Tasks
 					managedType = managedType.Substring (0, idx).Trim ();
 
 				if (mayNeedTypeFixup && (idx = managedType.LastIndexOf ('.')) >= 0) {
-					LogWarning ($"Attempting naive type name fixup for element with ID '{id}' and type '{managedType}'");
-					LogMessage ("If the above fixup fails, please add `tools:managedType` attribute to the element with fully qualified managed type name of the element");
+					LogCodedWarning ("XA1005", $"Attempting naive type name fixup for element with ID '{id}' and type '{managedType}'");
+					LogCodedWarning ("XA1005", "If the above fixup fails, please add `xamarin:managedType` attribute to the element with fully qualified managed type name of the element");
 
 					oldType = managedType;
 					string ns = managedType.Substring (0, idx);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
@@ -267,7 +267,7 @@ namespace Xamarin.Android.Tasks
 					var ext = Path.GetExtension (android);
 					var dir = Path.GetDirectoryName (user);
 
-					Log.LogWarning ("Resource target names differ; got '{0}', expected '{1}'.",
+					Log.LogDebugMessage ("Resource target names differ; got '{0}', expected '{1}'.",
 						Path.Combine (dir, Path.GetFileName (to) + ext),
 						Path.Combine (dir, Path.GetFileName (curTo) + ext));
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
@@ -108,14 +108,14 @@ namespace Xamarin.Android.Tasks {
 			bool isDirectory, string fullPath)
 		{
 			if (!attr.HasConstructorArguments || attr.ConstructorArguments.Count != 1) {
-				LogWarning ("Attribute {0} doesn't have expected one constructor agrument", attr.AttributeType.FullName);
+				LogCodedWarning (errorCode, "Attribute {0} doesn't have expected one constructor agrument", attr.AttributeType.FullName);
 				return;
 			}
 
 			CustomAttributeArgument arg = attr.ConstructorArguments.First ();
 			string path = arg.Value as string;
 			if (string.IsNullOrEmpty (path)) {
-				LogWarning ("Attribute {0} contructor argument is empty or not set to string", attr.AttributeType.FullName);
+				LogCodedWarning (errorCode, "Attribute {0} contructor argument is empty or not set to string", attr.AttributeType.FullName);
 				return;
 			}
 			path = SubstituteEnvVariables (path).TrimEnd (Path.DirectorySeparatorChar);
@@ -298,7 +298,7 @@ namespace Xamarin.Android.Tasks {
 			string file = Path.Combine (zipDir, !uri.IsFile ? hash + ".zip" : Path.GetFileName (uri.AbsolutePath));
 			if (string.IsNullOrEmpty (extraPath) && (!File.Exists (file) || !IsValidDownload (file, sha1) || !MonoAndroidHelper.IsValidZip (file))) {
 				if (DesignTimeBuild) {
-					LogWarning ($"DesignTimeBuild={DesignTimeBuild}. Skipping download of {url}");
+					LogDebugMessage ($"DesignTimeBuild={DesignTimeBuild}. Skipping download of {url}");
 					return null;
 				}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadAdditionalResourcesFromAssemblyCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadAdditionalResourcesFromAssemblyCache.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("Task ReadAdditionalResourcesFromAssemblyCache");
 			Log.LogDebugMessage ("  CacheFile: {0}", CacheFile);
 			if (!File.Exists (CacheFile)) {
-				Log.LogWarning ("{0} does not exist. No Additional Resources found", CacheFile);
+				Log.LogDebugMessage ("{0} does not exist. No Additional Resources found", CacheFile);
 				return !Log.HasLoggedErrors;
 			}
 			var doc = XDocument.Load (CacheFile);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadImportedLibrariesCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadImportedLibrariesCache.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("Task ReadImportedLibrariesCache");
 			Log.LogDebugMessage ("  CacheFile: {0}", CacheFile);
 			if (!File.Exists (CacheFile)) {
-				Log.LogWarning ("{0} does not exist. No Imported Libraries found", CacheFile);
+				Log.LogDebugMessage ("{0} does not exist. No Imported Libraries found", CacheFile);
 				return !Log.HasLoggedErrors;
 			}
 			var doc = XDocument.Load (CacheFile);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadLibraryProjectImportsCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadLibraryProjectImportsCache.cs
@@ -57,7 +57,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("Task ReadLibraryProjectImportsCache");
 			Log.LogDebugMessage ("  CacheFile: {0}", CacheFile);
 			if (!File.Exists (CacheFile)) {
-				Log.LogWarning ("{0} does not exist. No Project Library Imports found", CacheFile);
+				Log.LogDebugMessage ("{0} does not exist. No Project Library Imports found", CacheFile);
 				return !Log.HasLoggedErrors;
 			}
 			var doc = XDocument.Load (CacheFile);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -173,12 +173,12 @@ namespace Xamarin.Android.Tasks
 
 			var framework = NuGetFramework.Parse (TargetMoniker);
 			if (framework == null) {
-				LogWarning ($"Could not parse '{TargetMoniker}'");
+				LogCodedWarning ("XA0118", $"Could not parse '{TargetMoniker}'");
 				return null;
 			}
 			var target = lockFile.GetTarget (framework, string.Empty);
 			if (target == null) {
-				LogWarning ($"Could not resolve target for '{TargetMoniker}'");
+				LogCodedWarning ("XA0118", $"Could not resolve target for '{TargetMoniker}'");
 				return null;
 			}
 			foreach (var folder in lockFile.PackageFolders) {


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/1560

* I investigated the code paths that led into the `LogWarning()` in
  `GenerateResourceDesigner.AddRename()`.  I could not find any way to
  hit that message with the current code.  Moreover, the only reports of
  the message I could find on the web were from capitalization
  mismatches, and those are now explicitly ignored by the use of the
  `StringComparison.OrdinalIgnoreCase` argument in the call to
  `string.Compare()`.  Since this message does not currently indicate an
  actionable problem, I changed it from a warning to a debug message.

* Neither of the warnings in
  `GetAdditionalResourcesFromAssemblies.AddAttributeValue()` is
  actionable for Xamarin.Android app developers.  The first warning can
  only arise if a new attribute name has been added to the `switch`
  statement in `DoExecute()`.  The second warning can only occur in a
  library that uses one of those attributes.  Since the attributes are
  not formally documented, they are currently only intended for use by
  the Xamarin team.  Since these warnings aren't aimed at end-users,
  they don't need to have their own codes.  So for now, I just updated
  the warnings to reuse the `errorCode`.

* The first warning in
  `GetAdditionalResourcesFromAssemblies.MakeSureLibraryIsInPlace()` is
  just an informational message.  The download step is *expected* to be
  skipped during design-time builds.  I changed the warning to a debug
  message accordingly.

* I changed the warning in `ReadAdditionalResourcesFromAssemblyCache` to
  a debug message because it is just informational.  For example, in the
  normal process of building application projects, the
  Xamarin.Android.Common.targets checks if `CacheFile` exists before it
  invokes the task, so an absent `CacheFile` is often normal.  In cases
  where the warning could be actionable for an end-user, the warning
  would indicate that something went wrong earlier when creating the
  `CacheFile` in `GetAdditionalResourcesFromAssemblies`, so even in that
  case this warning would not be needed because more actionable messages
  should come from the earlier task.  On top of that, this whole old
  mechanism of downloading external files is rarely used now that the
  large majority of the NuGet packages from the Xamarin team have been
  updated to use the newer Xamarin.Build.Download mechanism.

* I also changed the warnings in `ReadImportedLibrariesCache` and
 `ReadLibraryProjectImportsCache` to debug messages for similar reasons.
 A missing cache file in one of these tasks indicates that something
 went wrong during the corresponding earlier `GetImportedLibraries` or
 `ResolveLibraryProjectImports` task, so any actionable messages would
 need to get logged in the earlier task instead.

* The warnings in
  `ResolveAssemblies.ResolveRuntimeAssemblyForReferenceAssembly()`
  should not occur during normal use.  They both depend on *generated*
  content related to the NuGet target framework moniker.  Based on these
  considerations, I assigned just one shared warning code to both
  warnings for now.