### PR TITLE
Update SQLite to version 3.52.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -41,6 +41,7 @@
 [submodule "external/sqlite"]
     path = external/sqlite
     url = https://github.com/xamarin/sqlite.git
+    branch = 3.25.2
 [submodule "external/xamarin-android-api-compatibility"]
     path = external/xamarin-android-api-compatibility
     url = https://github.com/xamarin/xamarin-android-api-compatibility.git

--- a/Configuration.props
+++ b/Configuration.props
@@ -31,7 +31,7 @@
     <AndroidFrameworkVersion Condition=" '$(AndroidFrameworkVersion)' == '' And '$(_IsRunningNuGetRestore)' != 'True' ">$(AndroidLatestStableFrameworkVersion)</AndroidFrameworkVersion>
     <AndroidUseLatestPlatformSdk Condition=" '$(AndroidFrameworkVersion)' == '' And '$(_IsRunningNuGetRestore)' == 'True' ">True</AndroidUseLatestPlatformSdk>
     <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
-    <AndroidNdkApiLevel Condition=" '$(AndroidNdkApiLevel)' == '' ">9</AndroidNdkApiLevel>
+    <AndroidNdkApiLevel Condition=" '$(AndroidNdkApiLevel)' == '' ">14</AndroidNdkApiLevel>
   </PropertyGroup>
   <PropertyGroup>
     <AutoProvision Condition=" '$(AutoProvision)' == '' ">False</AutoProvision>

--- a/build-tools/scripts/cmake-common.props
+++ b/build-tools/scripts/cmake-common.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <_CmakeCommonFlags>-GNinja -DCMAKE_MAKE_PROGRAM=$(NinjaPath)</_CmakeCommonFlags>
-    <_CmakeAndroidFlags>$(_CmakeCommonFlags) -DANDROID_TOOLCHAIN=clang -DANDROID_NATIVE_API_LEVEL=$(AndroidNdkApiLevel) -DCMAKE_TOOLCHAIN_FILE=$(AndroidNdkDirectory)\build\cmake\android.toolchain.cmake -DANDROID_NDK=$(AndroidNdkDirectory)</_CmakeAndroidFlags>
+    <_CmakeAndroidFlags>$(_CmakeCommonFlags) -DANDROID_TOOLCHAIN=clang -DANDROID_NATIVE_API_LEVEL=$(AndroidNdkApiLevel) -DANDROID_PLATFORM=android-$(AndroidNdkApiLevel) -DCMAKE_TOOLCHAIN_FILE=$(AndroidNdkDirectory)\build\cmake\android.toolchain.cmake -DANDROID_NDK=$(AndroidNdkDirectory)</_CmakeAndroidFlags>
   </PropertyGroup>
 </Project>

--- a/src/sqlite-xamarin/CMakeLists.txt
+++ b/src/sqlite-xamarin/CMakeLists.txt
@@ -22,7 +22,6 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${SQLITE_OUTPUT_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${SQLITE_OUTPUT_DIR})
 
 add_definitions("-DNO_ANDROID_FUNCS=1")
-add_definitions("-DHAVE_POSIX_FALLOCATE=0")
 add_definitions("-DNDEBUG=1")
 add_definitions("-DHAVE_USLEEP=1")
 add_definitions("-DSQLITE_HAVE_ISNAN")
@@ -40,12 +39,30 @@ add_definitions("-DSQLITE_OMIT_BUILTIN_TEST")
 add_definitions("-DSQLITE_OMIT_COMPILEOPTION_DIAGS")
 add_definitions("-DSQLITE_OMIT_LOAD_EXTENSION")
 add_definitions("-DSQLITE_DEFAULT_FILE_PERMISSIONS=0600")
+add_definitions("-DSQLITE_SECURE_DELETE")
+add_definitions("-DSQLITE_ENABLE_BATCH_ATOMIC_WRITE")
+add_definitions("-DBIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD")
 add_definitions("-DHAVE_MALLOC_H=1")
+
+if (ANDROID_NATIVE_API_LEVEL GREATER 16)
+  add_definitions("-DHAVE_MALLOC_USABLE_SIZE")
+endif()
+
+# Disabled until we switch to building with API >= 12
+if (ANDROID_NATIVE_API_LEVEL GREATER 11)
+  add_definitions("-DUSE_PREAD64")
+endif()
+
+add_definitions("-Dfdatasync=fdatasync")
+
+if (NOT ANDROID_NDK_MAJOR OR ANDROID_NDK_MAJOR LESS 17)
+  add_definitions("-D__ANDROID_API_Q__=29")
+endif()
 
 macro(c_compiler_has_flag _flag)
   check_c_compiler_flag(-${_flag} HAS_${_flag}_C)
   if (HAS_${_flag}_C)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -${_flag}")
+    set(LOCAL_CMAKE_C_FLAGS "${LOCAL_CMAKE_C_FLAGS} -${_flag}")
   endif()
 endmacro(c_compiler_has_flag)
 
@@ -68,16 +85,17 @@ set(TEST_COMPILER_ARGS
   Wformat
   Werror=format-security
   Wall
+  Wno-unused-parameter
   mindirect-branch=thunk-inline
   mfunction-return=thunk-inline
   )
 
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
   set(TEST_COMPILER_ARGS ${TEST_COMPILER_ARGS} ggdb3 fno-omit-frame-pointer)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0")
+  set(LOCAL_CMAKE_C_FLAGS "${LOCAL_CMAKE_C_FLAGS} -O0")
 else()
   set(TEST_COMPILER_ARGS ${TEST_COMPILER_ARGS} g fomit-frame-pointer O2)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2")
+  set(LOCAL_CMAKE_C_FLAGS "${LOCAL_CMAKE_C_FLAGS} -O2")
 endif()
 
 foreach(arg ${TEST_COMPILER_ARGS})
@@ -107,6 +125,8 @@ foreach(arg ${TEST_LINKER_ARGS})
   linker_has_flag(${arg})
 endforeach(arg)
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${LOCAL_C_FLAGS}")
+
 set(SQLITE_XAMARIN_SOURCES
   ${SQLITE_SOURCE_DIR}/dist/sqlite3.c
   )
@@ -125,12 +145,6 @@ file(APPEND ${SOURCES_FRAGMENT_FILE} "  </ItemGroup>\n\
 
 add_library(${SQLITE_LIBRARY_NAME} SHARED ${SQLITE_XAMARIN_SOURCES})
 
-set(LINK_LIBS "-ldl")
-
-if(ENABLE_NDK)
-  set(LINK_LIBS "${LINK_LIBS} -llog")
-elseif(NOT ANDROID)
-  set(LINK_LIBS "-pthread ${LINK_LIBS}")
-endif()
+set(LINK_LIBS "-ldl -llog")
 
 target_link_libraries(${SQLITE_LIBRARY_NAME} ${LINK_LIBS})


### PR DESCRIPTION
The full list of changes since our previous release 3.9.2 can be found here:

  https://sqlite.org/changes.html

Additionally, bump the base NDK API platform we use to build native code to 14.
This is in line with the API level Mono runtime is built with as well as with
the minimum supported API in newer NDKs. Making the change part of this commit
because it also affects the way SQLite is built.