### PR TITLE
[Xamarin.Android.Build.Tasks] Merge local and dependencies Resources conflicting

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
@@ -24,6 +24,8 @@ namespace Xamarin.Android.Tasks {
 
 		public string ExtraArgs { get; set; }
 
+		public string FlatArchivesDirectory { get; set; }
+
 		[Output]
 		public ITaskItem [] CompiledResourceFlatArchives => archives.ToArray ();
 
@@ -68,7 +70,9 @@ namespace Xamarin.Android.Tasks {
 				return;
 			
 			var output = new List<OutputLine> ();
-			var outputArchive = Path.Combine (resourceDirectory.ItemSpec, "..", "compiled.flata");
+			var hash = resourceDirectory.GetMetadata ("Hash");
+			var filename = !string.IsNullOrEmpty (hash) ? hash : "compiled";
+			var outputArchive = Path.Combine (FlatArchivesDirectory, $"{filename}.flata");
 			var success = RunAapt (GenerateCommandLineCommands (resourceDirectory, outputArchive), output);
 			if (success && File.Exists (Path.Combine (WorkingDirectory, outputArchive))) {
 				archives.Add (new TaskItem (outputArchive));

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -29,9 +29,9 @@ namespace Xamarin.Android.Tasks {
 
 		public string PackageName { get; set; }
 
-		public ITaskItem [] AdditionalResourceDirectories { get; set; }
+		public ITaskItem [] AdditionalResourceArchives { get; set; }
 
-		public ITaskItem[] AdditionalAndroidResourcePaths { get; set; }
+		public ITaskItem [] AdditionalAndroidResourcePaths { get; set; }
 
 		public ITaskItem [] LibraryProjectJars { get; set; }
 
@@ -84,7 +84,7 @@ namespace Xamarin.Android.Tasks {
 			Log.LogDebugMessage ("  UncompressedFileExtensions: {0}", UncompressedFileExtensions);
 			Log.LogDebugMessage ("  ExtraPackages: {0}", ExtraPackages);
 			Log.LogDebugTaskItems ("  ResourceDirectories: ", ResourceDirectories);
-			Log.LogDebugTaskItems ("  AdditionalResourceDirectories: ", AdditionalResourceDirectories);
+			Log.LogDebugTaskItems ("  AdditionalResourceArchives: ", AdditionalResourceArchives);
 			Log.LogDebugTaskItems ("  AdditionalAndroidResourcePaths: ", AdditionalAndroidResourcePaths);
 			Log.LogDebugTaskItems ("  LibraryProjectJars: ", LibraryProjectJars);
 			Log.LogDebugMessage ("  ExtraArgs: {0}", ExtraArgs);
@@ -159,21 +159,9 @@ namespace Xamarin.Android.Tasks {
 			if (PackageName != null)
 				cmd.AppendSwitchIfNotNull ("--custom-package ", PackageName.ToLowerInvariant ());
 			
-			if (AdditionalResourceDirectories != null) {
-				foreach (var dir in AdditionalResourceDirectories) {
-					if (!Directory.Exists (dir.ItemSpec))
-						continue;
-					var flatArchive = Path.Combine (dir.ItemSpec, "..", "compiled.flata");
-					if (!File.Exists (flatArchive))
-						continue;
-					cmd.AppendSwitchIfNotNull ("-R ", flatArchive);
-				}
-			}
-			if (AdditionalAndroidResourcePaths != null) {
-				foreach (var dir in AdditionalAndroidResourcePaths) {
-					if (!Directory.Exists (dir.ItemSpec))
-						continue;
-					var flatArchive = Path.Combine (dir.ItemSpec, "compiled.flata");
+			if (AdditionalResourceArchives != null) {
+				foreach (var dir in AdditionalResourceArchives) {
+					var flatArchive = dir.ItemSpec;
 					if (!File.Exists (flatArchive))
 						continue;
 					cmd.AppendSwitchIfNotNull ("-R ", flatArchive);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -75,25 +75,6 @@ namespace Xamarin.Android.Tasks {
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("Aapt2Link Task");
-			Log.LogDebugMessage ("  ToolPath: {0}", ToolPath);
-			Log.LogDebugMessage ("  AssetsDirectory: {0}", AssetsDirectory);
-			Log.LogDebugTaskItems ("  ManifestFiles: ", ManifestFiles);
-			Log.LogDebugMessage ("  JavaDesignerOutputDirectory: {0}", JavaDesignerOutputDirectory);
-			Log.LogDebugMessage ("  PackageName: {0}", PackageName);
-			Log.LogDebugMessage ("  UncompressedFileExtensions: {0}", UncompressedFileExtensions);
-			Log.LogDebugMessage ("  ExtraPackages: {0}", ExtraPackages);
-			Log.LogDebugTaskItems ("  ResourceDirectories: ", ResourceDirectories);
-			Log.LogDebugTaskItems ("  AdditionalResourceArchives: ", AdditionalResourceArchives);
-			Log.LogDebugTaskItems ("  AdditionalAndroidResourcePaths: ", AdditionalAndroidResourcePaths);
-			Log.LogDebugTaskItems ("  LibraryProjectJars: ", LibraryProjectJars);
-			Log.LogDebugMessage ("  ExtraArgs: {0}", ExtraArgs);
-			Log.LogDebugMessage ("  CreatePackagePerAbi: {0}", CreatePackagePerAbi);
-			Log.LogDebugMessage ("  ResourceNameCaseMap: {0}", ResourceNameCaseMap);
-			Log.LogDebugMessage ("  VersionCodePattern: {0}", VersionCodePattern);
-			Log.LogDebugMessage ("  VersionCodeProperties: {0}", VersionCodeProperties);
-			Log.LogDebugMessage ("  ResourceSymbolsTextFile: {0}", ResourceSymbolsTextFile);
-			Log.LogDebugMessage ("  CompiledResourceFlatArchive: {0}", CompiledResourceFlatArchive);
 			if (CreatePackagePerAbi)
 				Log.LogDebugMessage ("  SupportedAbis: {0}", SupportedAbis);
 			

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ComputeHash.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ComputeHash.cs
@@ -14,8 +14,15 @@ namespace Xamarin.Android.Tasks {
 		[Required]
 		public ITaskItem [] Source { get; set; }
 
+		public bool CopyMetaData { get; set; }
+
 		[Output]
 		public ITaskItem [] Output { get => output.ToArray (); }
+
+		public ComputeHash()
+		{
+			CopyMetaData = true;
+		}
 
 		public override bool Execute ()
 		{
@@ -23,9 +30,12 @@ namespace Xamarin.Android.Tasks {
 			using (var sha1 = SHA1.Create ()) {
 
 				foreach (var item in Source) {
-					output.Add (new TaskItem (item.ItemSpec, new Dictionary<string, string> () {
+					var newItem = new TaskItem(item.ItemSpec, new Dictionary<string, string>() {
 						{ "Hash", HashItemSpec (sha1, item.ItemSpec) }
-					}));
+					});
+					if (CopyMetaData)
+						item.CopyMetadataTo (newItem);
+					output.Add (newItem);
 				}
 				Log.LogDebugTaskItems ("Output : ", Output);
 				return !Log.HasLoggedErrors;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ComputeHash.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ComputeHash.cs
@@ -14,15 +14,10 @@ namespace Xamarin.Android.Tasks {
 		[Required]
 		public ITaskItem [] Source { get; set; }
 
-		public bool CopyMetaData { get; set; }
+		public bool CopyMetaData { get; set; } = true;
 
 		[Output]
 		public ITaskItem [] Output { get => output.ToArray (); }
-
-		public ComputeHash()
-		{
-			CopyMetaData = true;
-		}
 
 		public override bool Execute ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1409,5 +1409,76 @@ namespace UnnamedProject
 				Assert.IsTrue (StringAssertEx.ContainsText (r_java_contents, textView1), $"android/support/compat/R.java should contain `{textView1}`!");
 			}
 		}
+
+		// https://github.com/xamarin/xamarin-android/issues/2205
+		[Test]
+		public void Issue2205 ([Values(false, true)] bool useAapt2)
+		{
+			var proj = new XamarinAndroidApplicationProject();
+			proj.SetProperty("AndroidUseAapt2", useAapt2.ToString());
+			proj.Packages.Add(KnownPackages.Android_Arch_Core_Common_26_1_0);
+			proj.Packages.Add(KnownPackages.Android_Arch_Lifecycle_Common_26_1_0);
+			proj.Packages.Add(KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0);
+			proj.Packages.Add(KnownPackages.AndroidSupportV4_27_0_2_1);
+			proj.Packages.Add(KnownPackages.SupportCompat_27_0_2_1);
+			proj.Packages.Add(KnownPackages.SupportCoreUI_27_0_2_1);
+			proj.Packages.Add(KnownPackages.SupportCoreUtils_27_0_2_1);
+			proj.Packages.Add(KnownPackages.SupportDesign_27_0_2_1);
+			proj.Packages.Add(KnownPackages.SupportFragment_27_0_2_1);
+			proj.Packages.Add(KnownPackages.SupportMediaCompat_27_0_2_1);
+			proj.Packages.Add(KnownPackages.SupportV7AppCompat_27_0_2_1);
+			proj.Packages.Add(KnownPackages.SupportV7CardView_27_0_2_1);
+			proj.Packages.Add(KnownPackages.SupportV7MediaRouter_27_0_2_1);
+			proj.Packages.Add(KnownPackages.SupportV7RecyclerView_27_0_2_1);
+			proj.Packages.Add(KnownPackages.Xamarin_GooglePlayServices_Gcm);
+			proj.Packages.Add(KnownPackages.Xamarin_GooglePlayServices_Tasks);
+			proj.Packages.Add(KnownPackages.Xamarin_GooglePlayServices_Iid);
+			proj.Packages.Add(KnownPackages.Xamarin_GooglePlayServices_Basement);
+			proj.Packages.Add(KnownPackages.Xamarin_GooglePlayServices_Base);
+			proj.OtherBuildItems.Add(new BuildItem("GoogleServicesJson", () => @"{
+    ""project_info"": {
+        ""project_number"": ""12351255213413432"",
+        ""project_id"": ""12341234-app"",
+    },
+    ""client"": [
+        {
+            ""client_info"": {
+                ""mobilesdk_app_id"": ""1:111111111:android:asdfasdf"",
+                ""android_client_info"": {
+                    ""package_name"": ""com.app.apppp""
+                }
+            },
+            ""oauth_client"": [
+                {
+                    ""client_id"": ""dddddddddddddddddd.apps.googleusercontent.com"",
+                    ""client_type"": 3
+                }
+            ],
+            ""api_key"": [
+                {
+                    ""current_key"": ""aaaaaaapppp1123423""
+                }
+            ],
+            ""services"": {
+                ""analytics_service"": {
+                    ""status"": 1
+                },
+                ""appinvite_service"": {
+                    ""status"": 1,
+                    ""other_platform_oauth_client"": []
+                },
+                ""ads_service"": {
+                    ""status"": 2
+                }
+            }
+        }
+    ],
+    ""configuration_version"": ""1""
+}"));
+			using (var b = CreateApkBuilder(Path.Combine("temp", TestName)))
+			{
+				Assert.IsTrue(b.Build(proj), "first build should have succeeded");
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -608,6 +608,60 @@ namespace Xamarin.ProjectTools
 			Id = "Xamarin.Build.Download",
 			Version = "0.4.11",
 		};
+		public static Package Xamarin_GooglePlayServices_Base = new Package {
+			Id = "Xamarin.GooglePlayServices.Base",
+	    		Version = "60.1142.1",
+			TargetFramework = "MonoAndroid80",
+	    		References = {
+				new BuildItem.Reference ("Xamarin.GooglePlayServices.Base") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.GooglePlayServices.Base.60.1142.1\\lib\\MonoAndroid80\\Xamarin.GooglePlayServices.Base.dll"
+				}
+			},
+		};
+		public static Package Xamarin_GooglePlayServices_Basement = new Package
+		{
+			Id = "Xamarin.GooglePlayServices.Basement",
+			Version = "60.1142.1",
+			TargetFramework = "MonoAndroid80",
+			References = {
+				new BuildItem.Reference ("Xamarin.GooglePlayServices.Basement") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.GooglePlayServices.Basement.60.1142.1\\lib\\MonoAndroid80\\Xamarin.GooglePlayServices.Basement.dll"
+				}
+			},
+		};
+		public static Package Xamarin_GooglePlayServices_Tasks = new Package
+		{
+			Id = "Xamarin.GooglePlayServices.Tasks",
+			Version = "60.1142.1",
+			TargetFramework = "MonoAndroid80",
+			References = {
+				new BuildItem.Reference ("Xamarin.GooglePlayServices.Tasks") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.GooglePlayServices.Tasks.60.1142.1\\lib\\MonoAndroid80\\Xamarin.GooglePlayServices.Tasks.dll"
+				}
+			},
+		};
+		public static Package Xamarin_GooglePlayServices_Iid = new Package
+		{
+			Id = "Xamarin.GooglePlayServices.Iid",
+			Version = "60.1142.1",
+			TargetFramework = "MonoAndroid80",
+			References = {
+				new BuildItem.Reference ("Xamarin.GooglePlayServices.Iid") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.GooglePlayServices.Iid.60.1142.1\\lib\\MonoAndroid80\\Xamarin.GooglePlayServices.Iid.dll"
+				}
+			},
+		};
+		public static Package Xamarin_GooglePlayServices_Gcm = new Package
+		{
+			Id = "Xamarin.GooglePlayServices.Gcm",
+			Version = "60.1142.1",
+			TargetFramework = "MonoAndroid80",
+			References = {
+				new BuildItem.Reference ("Xamarin.GooglePlayServices.Gcm") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.GooglePlayServices.Gcm.60.1142.1\\lib\\MonoAndroid80\\Xamarin.GooglePlayServices.Gcm.dll"
+				}
+			},
+		};
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2371,7 +2371,7 @@ because xbuild doesn't support framework reference assemblies.
     OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)"
     OutputFile="$(_PackagedResources)"
     AdditionalResourceArchives="@(_LibraryResourceHashDirectories->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).flata')"
-	AdditionalAndroidResourcePaths="@(_LibraryResourceHashDirectories)"
+    AdditionalAndroidResourcePaths="@(_LibraryResourceHashDirectories)"
     YieldDuringToolExecution="$(YieldDuringToolExecution)"
     PackageName="$(_AndroidPackage)"
     ApplicationName="$(_AndroidPackage)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -275,6 +275,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<_AndroidAapt2VersionFile>$(IntermediateOutputPath)aapt2.version</_AndroidAapt2VersionFile>
 	<_AndroidNuGetStampFile>$(IntermediateOutputPath)$(MSBuildProjectName).nuget.stamp</_AndroidNuGetStampFile>
 	<_AndroidIntermediateDesignTimeBuildDirectory>$(IntermediateOutputPath)designtime\</_AndroidIntermediateDesignTimeBuildDirectory>
+	<_AndroidLibraryFlatArchivesDirectory>$(IntermediateOutputPath)flata\</_AndroidLibraryFlatArchivesDirectory>
 
 	<!-- $(EnableProguard) is an obsolete property that should be removed at some stage. -->
 	<AndroidEnableProguard Condition="'$(AndroidEnableProguard)'==''">$(EnableProguard)</AndroidEnableProguard>
@@ -1322,13 +1323,17 @@ because xbuild doesn't support framework reference assemblies.
 	<CollectNonEmptyDirectories Directories="@(LibraryResourceDirectories);@(_AdditonalAndroidResourceCachePaths->'%(Identity)\res')">
 		<Output TaskParameter="Output" ItemName="_LibraryResourceDirectories" />
 	</CollectNonEmptyDirectories>
+	<ComputeHash Source="@(_LibraryResourceDirectories)"	>
+		<Output TaskParameter="Output" ItemName="_LibraryResourceHashDirectories" />
+	</ComputeHash>
 </Target>
 
 <Target Name="_CompileAndroidLibraryResources" DependsOnTargets="_CollectLibraryResourceDirectories"
 		Condition="'$(_AndroidUseAapt2)' == 'True' And '$(DesignTimeBuild)' != 'True' "
-		Inputs="%(_LibraryResourceDirectories.FileFound)"
-		Outputs="%(_LibraryResourceDirectories.Identity)\..\compiled.stamp"
+		Inputs="%(_LibraryResourceHashDirectories.FileFound)"
+		Outputs="$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).stamp"
 	>
+	<MakeDir Directories="$(_AndroidLibraryFlatArchivesDirectory)" Condition="!Exists('$(_AndroidLibraryFlatArchivesDirectory)')" />
 	<ConvertResourcesCases
 		Condition=" '@(_LibraryResourceDirectories)' != '' "
 		ContinueOnError="$(DesignTimeBuild)"
@@ -1336,27 +1341,28 @@ because xbuild doesn't support framework reference assemblies.
 		ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
 		AcwMapFile="$(_AcwMapFile)"
 		CustomViewMapFile="$(_CustomViewMapFile)"
-		AndroidConversionFlagFile="%(_LibraryResourceDirectories.Identity)\..\compiled.flata"
+		AndroidConversionFlagFile="$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).stamp"
 	/>
 	<Aapt2Compile
-		Condition=" '@(_LibraryResourceDirectories)' != '' "
+		Condition=" '@(_LibraryResourceHashDirectories)' != '' "
 		ContinueOnError="$(DesignTimeBuild)"
-		ResourceDirectories="@(_LibraryResourceDirectories)"
+		ResourceDirectories="@(_LibraryResourceHashDirectories)"
 		ExplicitCrunch="$(AndroidExplicitCrunch)"
 		ExtraArgs="$(AndroidAapt2CompileExtraArgs)"
+		FlatArchivesDirectory="$(_AndroidLibraryFlatArchivesDirectory)"
 		ToolPath="$(Aapt2ToolPath)"
 		ToolExe="$(Aapt2ToolExe)"
 	/>
 	<Touch
-			Files="@(_LibraryResourceDirectories->'%(Identity)\..\compiled.stamp')"
+			Files="$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).stamp"
 			AlwaysCreate="True"
 	/>
 	<ItemGroup>
-		<FileWrites Include="@(_LibraryResourceDirectories.Identity->'%(Identity)\..\compiled.flata')"
-				Condition="Exists ('@(_LibraryResourceDirectories.Identity->'%(Identity)\..\compiled.flata')')"
+		<FileWrites Include="$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).flata"
+				Condition="Exists ('$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).flata')"
 		/>
-		<FileWrites Include="@(_LibraryResourceDirectories.Identity->'%(Identity)\..\compiled.stamp')"
-				Condition="Exists ('@(_LibraryResourceDirectories.Identity->'%(Identity)\..\compiled.stamp')')"
+		<FileWrites Include="$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).stamp"
+				Condition="Exists ('$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).stamp')"
 		/>
 	</ItemGroup>
 </Target>
@@ -1364,8 +1370,9 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_CompileResources"
 		Condition="'$(_AndroidUseAapt2)' == 'True'"
 		Inputs="@(AndroidResource)"
-		Outputs="$(IntermediateOutputPath)\compiled.flata"
+		Outputs="$(_AndroidLibraryFlatArchivesDirectory)\compiled.flata"
 	>
+	<MakeDir Directories="$(_AndroidLibraryFlatArchivesDirectory)" Condition="!Exists('$(_AndroidLibraryFlatArchivesDirectory)')" />
 	<!-- Change cases so we support mixed case resource names -->
 	<ConvertResourcesCases
 		ContinueOnError="$(DesignTimeBuild)"
@@ -1373,7 +1380,7 @@ because xbuild doesn't support framework reference assemblies.
 		ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
 		AcwMapFile="$(_AcwMapFile)"
 		CustomViewMapFile="$(_CustomViewMapFile)"
-		AndroidConversionFlagFile="$(IntermediateOutputPath)\compiled.flata"
+		AndroidConversionFlagFile="$(_AndroidLibraryFlatArchivesDirectory)\compiled.flata"
 	/>
 	<Aapt2Compile
 		ContinueOnError="$(DesignTimeBuild)"
@@ -1381,11 +1388,12 @@ because xbuild doesn't support framework reference assemblies.
 		ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
 		ExplicitCrunch="$(AndroidExplicitCrunch)"
 		ExtraArgs="$(AndroidAapt2CompileExtraArgs)"
+		FlatArchivesDirectory="$(_AndroidLibraryFlatArchivesDirectory)"
 		ToolPath="$(Aapt2ToolPath)"
 		ToolExe="$(Aapt2ToolExe)"
 	/>
 	<ItemGroup>
-		<FileWrites Include="$(IntermediateOutputPath)\compiled.flata" />
+		<FileWrites Include="$(_AndroidLibraryFlatArchivesDirectory)\compiled.flata" />
 	</ItemGroup>
 </Target>
 
@@ -1545,12 +1553,12 @@ because xbuild doesn't support framework reference assemblies.
    UseShortFileNames="$(UseShortFileNames)"
    ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
    OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)"
-   AdditionalResourceDirectories="@(LibraryResourceDirectories)"
-   AdditionalAndroidResourcePaths="@(_AdditonalAndroidResourceCachePaths)"
+   AdditionalResourceArchives="@(_LibraryResourceHashDirectories->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).flata')"
+   AdditionalAndroidResourcePaths="@(_LibraryResourceHashDirectories)"
    ApplicationName="$(_AndroidPackage)"
    JavaPlatformJarPath="$(JavaPlatformJarPath)"
    JavaDesignerOutputDirectory="$(IntermediateOutputPath)android\src"
-   CompiledResourceFlatArchive="$(IntermediateOutputPath)\compiled.flata"
+   CompiledResourceFlatArchive="$(_AndroidLibraryFlatArchivesDirectory)\compiled.flata"
    ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
    ResourceDirectories="$(MonoAndroidResDirIntermediate)"
    AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
@@ -1708,7 +1716,7 @@ because xbuild doesn't support framework reference assemblies.
 	/>
 
 	<Aapt2Link
-		Condition="'$(_AndroidResourceDesignerFile)' != '' And '$(_AndroidUseAapt2)' == 'True' And Exists ('$(IntermediateOutputPath)\compiled.flata')"
+		Condition="'$(_AndroidResourceDesignerFile)' != '' And '$(_AndroidUseAapt2)' == 'True' And Exists ('$(_AndroidLibraryFlatArchivesDirectory)\compiled.flata')"
 		ContinueOnError="$(DesignTimeBuild)"
 		ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
 		AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
@@ -1720,10 +1728,10 @@ because xbuild doesn't support framework reference assemblies.
 		ApplicationName="$(_AndroidPackage)"
 		JavaPlatformJarPath="$(JavaPlatformJarPath)"
 		JavaDesignerOutputDirectory="$(ResgenTemporaryDirectory)"
-		CompiledResourceFlatArchive="$(IntermediateOutputPath)\compiled.flata"
+		CompiledResourceFlatArchive="$(_AndroidLibraryFlatArchivesDirectory)\compiled.flata"
 		ManifestFiles="$(ResgenTemporaryDirectory)\AndroidManifest.xml"
-		AdditionalResourceDirectories="@(LibraryResourceDirectories)"
-		AdditionalAndroidResourcePaths="@(_AdditonalAndroidResourceCachePaths)"
+		AdditionalResourceArchives="@(_LibraryResourceHashDirectories->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).flata')"
+		AdditionalAndroidResourcePaths="@(_LibraryResourceHashDirectories)"
 		YieldDuringToolExecution="$(YieldDuringToolExecution)"
 		ResourceSymbolsTextFile="$(IntermediateOutputPath)R.txt"
 		ResourceDirectories="$(MonoAndroidResDirIntermediate)"
@@ -2351,7 +2359,7 @@ because xbuild doesn't support framework reference assemblies.
   />
   <Aapt2Link
     Condition="'$(_AndroidUseAapt2)' == 'True'"
-    CompiledResourceFlatArchive="$(IntermediateOutputPath)\compiled.flata"
+    CompiledResourceFlatArchive="$(_AndroidLibraryFlatArchivesDirectory)\compiled.flata"
     ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
     ResourceDirectories="$(MonoAndroidResDirIntermediate)"
     AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
@@ -2359,8 +2367,8 @@ because xbuild doesn't support framework reference assemblies.
     ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
     OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)"
     OutputFile="$(_PackagedResources)"
-    AdditionalResourceDirectories="@(LibraryResourceDirectories)"
-    AdditionalAndroidResourcePaths="@(_AdditonalAndroidResourceCachePaths)"
+    AdditionalResourceArchives="@(_LibraryResourceHashDirectories->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).flata')"
+	AdditionalAndroidResourcePaths="@(_LibraryResourceHashDirectories)"
     YieldDuringToolExecution="$(YieldDuringToolExecution)"
     PackageName="$(_AndroidPackage)"
     ApplicationName="$(_AndroidPackage)"
@@ -3066,6 +3074,7 @@ because xbuild doesn't support framework reference assemblies.
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)proguard" Condition="Exists ('$(MonoAndroidIntermediate)proguard')" />
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediateResourceCache)" Condition="Exists ('$(MonoAndroidIntermediateResourceCache)')" />
 	<RemoveDirFixed Directories="$(_AndroidAotBinDirectory)" Condition="Exists ('$(_AndroidAotBinDirectory)')" />
+	<RemoveDirFixed Directories="$(_AndroidLibraryFlatArchivesDirectory)" Condition="Exists ('$(_AndroidLibraryFlatArchivesDirectory)')" />
 	<Delete Files="$(IntermediateOutputPath)_dex_stamp" />
  	<Delete Files="$(MonoAndroidIntermediate)R.cs.flag" />
 	<Delete Files="$(MonoAndroidIntermediate)acw-map.txt" />
@@ -3078,7 +3087,6 @@ because xbuild doesn't support framework reference assemblies.
 	<Delete Files="$(MonoAndroidIntermediate)stub_application_data.txt" />
 	<Delete Files="$(IntermediateOutputPath)_javac.stamp" />
 	<Delete Files="$(IntermediateOutputPath)_javastubs.stamp" />
-	<Delete Files="$(IntermediateOutputPath)compiled.flata" />
 	<Delete Files="$(_AndroidResFlagFile)" />
 	<Delete Files="$(_AndroidLinkFlag)" />
 	<Delete Files="$(_AndroidComponentResgenFlagFile)" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1319,7 +1319,9 @@ because xbuild doesn't support framework reference assemblies.
 	</ResolveLibraryProjectImports>
 </Target>
 
-<Target Name="_CollectLibraryResourceDirectories">
+<Target Name="_CollectLibraryResourceDirectories"
+		Condition="'$(_AndroidUseAapt2)' == 'True'"
+	>
 	<CollectNonEmptyDirectories Directories="@(LibraryResourceDirectories);@(_AdditonalAndroidResourceCachePaths->'%(Identity)\res')">
 		<Output TaskParameter="Output" ItemName="_LibraryResourceDirectories" />
 	</CollectNonEmptyDirectories>
@@ -1329,7 +1331,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_CompileAndroidLibraryResources" DependsOnTargets="_CollectLibraryResourceDirectories"
-		Condition="'$(_AndroidUseAapt2)' == 'True' And '$(DesignTimeBuild)' != 'True' "
+		Condition="'$(_AndroidUseAapt2)' == 'True'"
 		Inputs="%(_LibraryResourceHashDirectories.FileFound)"
 		Outputs="$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).stamp"
 	>
@@ -1513,6 +1515,7 @@ because xbuild doesn't support framework reference assemblies.
 		_GetAdditionalResourcesFromAssemblies
 		;_CreateAdditionalResourceCache
 		;_CollectAdditionalResourceFiles
+		;_CollectLibraryResourceDirectories
 		;_CompileAndroidLibraryResources
 		;_CompileResources
 	</_GenerateJavaDesignerForComponentDependsOnTargets>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1360,12 +1360,8 @@ because xbuild doesn't support framework reference assemblies.
 			AlwaysCreate="True"
 	/>
 	<ItemGroup>
-		<FileWrites Include="$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).flata"
-				Condition="Exists ('$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).flata')"
-		/>
-		<FileWrites Include="$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).stamp"
-				Condition="Exists ('$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).stamp')"
-		/>
+		<FileWrites Include="$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).flata" />
+		<FileWrites Include="$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).stamp" />
 	</ItemGroup>
 </Target>
 


### PR DESCRIPTION
Fixes #2205

The problem here is on the first build the compiled.flata archive only contains

```
Archive:  compiled.flata
Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
--------  ------  ------- ---- ---------- ----- --------  ----
     400  Stored      400   0% 01-01-1980 01:00 8ade13a7  values_goog_svcs_json.arsc.flat
--------          -------  ---                            -------
     400              400   0%                            1 file
```

which suggested that something is overwriting the compiled.flata archive created by `_CompileResources`.

The actual problem. The `_CompileAndroidLibraryResources` target is processing the directory for the `GooglePlayServicesJson` items. And as a result its creating a compiled.flata archive in the same place as the main Resource directory compiled.flata archive is located. As a result the `_CompileResources` never runs. This was because we hard coded `$(path)\..\compiled.flata` as the location for the archive. This was based on the assumption that library resources would exist in `obj\$(Configuration)\lp\xx\jl\res`. This would mean the archive would end up in `obj\$(Configuration)\lp\xx\jl`. However for the `GooglePlayServicesJson`, its directory is created in `obj\$(Configuration)\xx`. As a result the archive it created in `obj\$(Configuration)` .. i.e in the same place as the main one. And because it exists.. we don't re-create it.

So the solution is to move all the archives into a dedicated folder. We generate a hash based on the path of the resource directory to create a unique archive name. We then output all the items into `obj\$(Configuration)\flata`. The main archive is still called `compiled.flata` but it output in the same place.  
