### PR TITLE
[Xamarin.Android.Build.Tasks] `ResourcePatcher` for API 19+.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CopyResourceTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CopyResourceTests.cs
@@ -38,6 +38,8 @@ namespace Xamarin.Android.Build.Tests
 			new object[] { "IncrementalClassLoader.java" },
 			new object[] { "MultiDexLoader.java" },
 			new object[] { "Placeholder.java" },
+	    		new object[] { "ResourcePatcher.java" },
+			new object[] { "MonkeyPatcher.java" },
 		};
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -359,9 +359,10 @@ namespace Xamarin.Android.Tasks {
 
 			var providerNames = AddMonoRuntimeProviders (app);
 
-			if (Debug && !embed)
-				app.Add (CreateMonoRuntimeProvider ("mono.android.ResourcePatcher", null, initOrder: --AppInitOrder));
-				
+			if (Debug && !embed) {
+				if (int.TryParse (SdkVersion, out int apiLevel) && apiLevel >= 19)
+					app.Add(CreateMonoRuntimeProvider ("mono.android.ResourcePatcher", null, initOrder: --AppInitOrder));
+			}
 			if (Debug) {
 				app.Add (new XComment ("suppress ExportedReceiver"));
 				app.Add (new XElement ("receiver",

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -361,7 +361,7 @@ namespace Xamarin.Android.Tasks {
 
 			if (Debug && !embed) {
 				if (int.TryParse (SdkVersion, out int apiLevel) && apiLevel >= 19)
-					app.Add(CreateMonoRuntimeProvider ("mono.android.ResourcePatcher", null, initOrder: --AppInitOrder));
+					app.Add (CreateMonoRuntimeProvider ("mono.android.ResourcePatcher", null, initOrder: --AppInitOrder));
 			}
 			if (Debug) {
 				app.Add (new XComment ("suppress ExportedReceiver"));


### PR DESCRIPTION
The instant run fast deployment modifications are only enabled if the developer is targeting API 19 or above. So we should only include the `ResourcePatcher` and `MonkeyPatcher` files if the same conditions are met. 