### PR TITLE
[monodroid] Fix regression in monodroid_dylib_mono_init

### DIFF
--- a/src/monodroid/jni/dylib-mono.cc
+++ b/src/monodroid/jni/dylib-mono.cc
@@ -17,6 +17,8 @@ using namespace xamarin::android;
 /*
   this function is used from JavaInterop and should be treated as public API
   https://github.com/xamarin/java.interop/blob/master/src/java-interop/java-interop-gc-bridge-mono.c#L266
+
+  it should also accept libmono_path = NULL parameter
 */
 int monodroid_dylib_mono_init (struct DylibMono *mono_imports, const char *libmono_path)
 {

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -4246,12 +4246,18 @@ extern "C" void monodroid_dylib_mono_free (DylibMono *mono_imports)
 	delete mono_imports;
 }
 
+/*
+  this function is used from JavaInterop and should be treated as public API
+  https://github.com/xamarin/java.interop/blob/master/src/java-interop/java-interop-gc-bridge-mono.c#L266
+
+  it should also accept libmono_path = NULL parameter
+*/
 extern "C" int monodroid_dylib_mono_init (DylibMono *mono_imports, const char *libmono_path)
 {
 	if (mono_imports == nullptr)
 		return FALSE;
 
-	void *libmono_handle = androidSystem.load_dso_from_any_directories(libmono_path, RTLD_LAZY | RTLD_GLOBAL);
+	void *libmono_handle = libmono_path ? androidSystem.load_dso_from_any_directories(libmono_path, RTLD_LAZY | RTLD_GLOBAL) : dlopen (libmono_path, RTLD_LAZY | RTLD_GLOBAL);;
 	return mono_imports->init (libmono_handle) ? TRUE : FALSE;
 }
 


### PR DESCRIPTION
Recent move of libmonodroid to C++ broke the
`monodroid_dylib_mono_init` usage with *NULL* libmono_path parameter,
which is needed at
https://github.com/xamarin/java.interop/blob/master/src/java-interop/java-interop-gc-bridge-mono.c#L266

That led to the following crash:

    Assertion failed: (directories), function load_dso_from_specified_dirs, file /Users/rodo/git/xa5/src/monodroid/jni/monodroid-glue.cc, line 761.
    Stacktrace:

      at <unknown> <0xffffffff>
      at (wrapper managed-to-native) Java.Interop.NativeMethods.java_interop_gc_bridge_new (intptr) [0x00002] in <fe331788190c4039ae28220ef452fac0>:0
      at Java.Interop.MonoRuntimeValueManager.OnSetRuntime (Java.Interop.JniRuntime) [0x0002c] in <fe331788190c4039ae28220ef452fac0>:0
      at Java.Interop.JniRuntime.SetRuntime<T_REF> (T_REF) [0x00012] in <ad161b8c9963497ea547279f476a6d30>:0
      at Java.Interop.JniRuntime.SetValueManager (Java.Interop.JniRuntime/CreationOptions) [0x0001a] in <ad161b8c9963497ea547279f476a6d30>:0
      at Java.Interop.JniRuntime..ctor (Java.Interop.JniRuntime/CreationOptions) [0x0008e] in <ad161b8c9963497ea547279f476a6d30>:0
      at Java.Interop.JreRuntime..ctor (Java.Interop.JreRuntimeOptions) [0x00007] in <fe331788190c4039ae28220ef452fac0>:0
      at Java.Interop.JreRuntimeOptions.CreateJreVM () [0x00000] in <fe331788190c4039ae28220ef452fac0>:0
      at Xamarin.Android.Tools.JniMarshalMethodGenerator.App.CreateJavaVM (string) [0x0000d] in <58fdaf202214494cab0a9596f65c9573>:0
      at Xamarin.Android.Tools.JniMarshalMethodGenerator.App.ProcessAssemblies (System.Collections.Generic.List`1<string>) [0x00000] in <58fdaf202214494cab0a9596f65c9573>:0
      at (wrapper remoting-invoke-with-check) Xamarin.Android.Tools.JniMarshalMethodGenerator.App.ProcessAssemblies (System.Collections.Generic.List`1<string>) [0x00032] in <58fdaf202214494cab0a9596f65c9573>:0
      at (wrapper xdomain-dispatch) Xamarin.Android.Tools.JniMarshalMethodGenerator.App.ProcessAssemblies (object,byte[]&,byte[]&) [0x00023] in <58fdaf202214494cab0a9596f65c9573>:0
      at (wrapper xdomain-invoke) Xamarin.Android.Tools.JniMarshalMethodGenerator.App.ProcessAssemblies (System.Collections.Generic.List`1<string>) <0x001db>
      at (wrapper remoting-invoke-with-check) Xamarin.Android.Tools.JniMarshalMethodGenerator.App.ProcessAssemblies (System.Collections.Generic.List`1<string>) [0x00000] in <58fdaf202214494cab0a9596f65c9573>:0
      at Xamarin.Android.Tools.JniMarshalMethodGenerator.App.Main (string[]) <0x001aa>
      at (wrapper runtime-invoke) <Module>.runtime_invoke_int_object (object,intptr,intptr,intptr) <0x0010c>

    Native stacktrace:

    	0   mono                                0x0000000105f92b38 mono_handle_native_crash + 264
    	1   libsystem_platform.dylib            0x00007fff606e9b3d _sigtramp + 29
    	2   ???                                 0x0000000000000048 0x0 + 72
    	3   libsystem_c.dylib                   0x00007fff605a81c9 abort + 127
    	4   libsystem_c.dylib                   0x00007fff60570868 basename_r + 0
    	5   libmono-android.debug.dylib         0x0000000109421189 _ZN7xamarin7android8internal13AndroidSystem28load_dso_from_specified_dirsEPPKciS4_i + 89
    	6   libmono-android.debug.dylib         0x0000000109421284 _ZN7xamarin7android8internal13AndroidSystem26load_dso_from_app_lib_dirsEPKci + 52
    	7   libmono-android.debug.dylib         0x0000000109421334 _ZN7xamarin7android8internal13AndroidSystem29load_dso_from_any_directoriesEPKci + 84
    	8   libmono-android.debug.dylib         0x000000010942a73c monodroid_dylib_mono_init + 60
    	9   libmono-android.debug.dylib         0x0000000109411dc8 java_interop_gc_bridge_new + 56