### PR TITLE
[build] CMakeLists.txt fixes for sqlite on Windows

### DIFF
--- a/src/sqlite-xamarin/CMakeLists.txt
+++ b/src/sqlite-xamarin/CMakeLists.txt
@@ -127,9 +127,7 @@ endforeach(arg)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${LOCAL_C_FLAGS}")
 
-set(SQLITE_XAMARIN_SOURCES
-  ${SQLITE_SOURCE_DIR}/dist/sqlite3.c
-  )
+file(TO_CMAKE_PATH "${SQLITE_SOURCE_DIR}/dist/sqlite3.c" SQLITE_XAMARIN_SOURCES)
 
 set(SOURCES_FRAGMENT_FILE "sources.projitems")
 file(WRITE ${SOURCES_FRAGMENT_FILE} "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n\


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2271
Context: https://github.com/xamarin/xamarin-android/commit/673757d85ce9d3d14745f01d3c34a6c24e00126e
Context: https://cmake.org/cmake/help/v3.3/command/file.html

`cmake` mandates a uniform way of presenting filesystem paths across
all the operating systems it supports - it requires that path segments
are separated with the `/` character.

In 673757d8, we faced a similar problem, but used a string replace as
a fix:

    string(REPLACE "\\" "/" MY_PATH ${MY_PATH})

There is a proper, more "portable" way to do this, such as:

    file(TO_CMAKE_PATH "${MY_PATH}" MY_PATH)

Using this for `SQLITE_XAMARIN_SOURCES` fixes the sqlite build on
Windows.