### PR TITLE
 Revert "[Xamarin.Android.Build.Tasks] deletebinobj fix for resources

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1373,43 +1373,6 @@ namespace UnnamedProject
 			}
 		}
 
-		[Test]
-		public void CustomViewAddResourceId ([Values (false, true)] bool useAapt2)
-		{
-			var proj = new XamarinAndroidApplicationProject ();
-			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
-			proj.LayoutMain = proj.LayoutMain.Replace ("</LinearLayout>", "<android.support.design.widget.BottomNavigationView android:id=\"@+id/navigation\" /></LinearLayout>");
-			proj.Packages.Add (KnownPackages.Android_Arch_Core_Common_26_1_0);
-			proj.Packages.Add (KnownPackages.Android_Arch_Lifecycle_Common_26_1_0);
-			proj.Packages.Add (KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0);
-			proj.Packages.Add (KnownPackages.AndroidSupportV4_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportCompat_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportCoreUI_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportCoreUtils_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportDesign_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportFragment_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportMediaCompat_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportV7AppCompat_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportV7CardView_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportV7MediaRouter_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportV7RecyclerView_27_0_2_1);
-			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
-				Assert.IsTrue (b.Build (proj), "first build should have succeeded");
-
-				//Add a new android:id
-				var textView1 = "textView1";
-				proj.LayoutMain = proj.LayoutMain.Replace ("</LinearLayout>", $"<TextView android:id=\"@+id/{textView1}\" /></LinearLayout>");
-				proj.Touch (@"Resources\layout\Main.axml");
-
-				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "second build should have succeeded");
-
-				var r_java = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "src", "android", "support", "compat", "R.java");
-				FileAssert.Exists (r_java);
-				var r_java_contents = File.ReadAllLines (r_java);
-				Assert.IsTrue (StringAssertEx.ContainsText (r_java_contents, textView1), $"android/support/compat/R.java should contain `{textView1}`!");
-			}
-		}
-
 		// https://github.com/xamarin/xamarin-android/issues/2205
 		[Test]
 		public void Issue2205 ([Values(false, true)] bool useAapt2)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -192,11 +192,19 @@ namespace Xamarin.Android.Tests
 				FileAssert.Exists (designtime_build_props, "designtime/build.props should exist after the second `Build`.");
 
 				//NOTE: none of these targets should run, since we have not actually changed anything!
-				Assert.IsTrue (b.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "`_UpdateAndroidResgen` should be skipped!");
-				//TODO: We would like for this assertion to work, but the <Compile /> item group changes between DTB and regular builds
-				//      $(IntermediateOutputPath)designtime\Resource.designer.cs -> Resources\Resource.designer.cs
-				//      And so the built assembly changes between DTB and regular build, triggering `_LinkAssembliesNoShrink`
-				//Assert.IsTrue (b.Output.IsTargetSkipped ("_LinkAssembliesNoShrink"), "`_LinkAssembliesNoShrink` should be skipped!");
+				var targetsToBeSkipped = new [] {
+					//TODO: We would like for this assertion to work, but the <Compile /> item group changes between DTB and regular builds
+					//      $(IntermediateOutputPath)designtime\Resource.designer.cs -> Resources\Resource.designer.cs
+					//      And so the built assembly changes between DTB and regular build, triggering `_LinkAssembliesNoShrink`
+					//"_LinkAssembliesNoShrink",
+					"_UpdateAndroidResgen",
+					"_GenerateJavaDesignerForComponent",
+					"_BuildLibraryImportsCache",
+					"_CompileJava",
+				};
+				foreach (var targetName in targetsToBeSkipped) {
+					Assert.IsTrue (b.Output.IsTargetSkipped (targetName), $"`{targetName}` should be skipped!");
+				}
 
 				b.Target = "Clean";
 				Assert.IsTrue (b.Build (proj), "clean should have succeeded.");
@@ -318,7 +326,9 @@ namespace Xamarin.Android.Tests
 				var targetsToBeSkipped = new [] {
 					isRelease ? "_LinkAssembliesShrink" : "_LinkAssembliesNoShrink",
 					"_UpdateAndroidResgen",
+					"_GenerateJavaDesignerForComponent",
 					"_BuildLibraryImportsCache",
+					"_CompileJava",
 				};
 				foreach (var targetName in targetsToBeSkipped) {
 					Assert.IsTrue (b.Output.IsTargetSkipped (targetName), $"`{targetName}` should be skipped!");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
@@ -50,7 +50,7 @@ namespace Xamarin.ProjectTools
 			bool found = false;
 			foreach (var line in Builder.LastBuildOutput) {
 					found = line.Contains (string.Format ("Target {0} skipped due to ", target))
-					            || line.Contains (string.Format ("Skipping target \"{0}\" because it has no outputs.", target))
+					            || line.Contains (string.Format ("Skipping target \"{0}\" because it has no ", target)) //NOTE: message can say `inputs` or `outputs`
 					            || line.Contains (string.Format ("Target \"{0}\" skipped, due to", target))
 					            || line.Contains (string.Format ("Skipping target \"{0}\" because its outputs are up-to-date", target))
 					            || line.Contains (string.Format ("target {0}, skipping", target))

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1533,7 +1533,7 @@ because xbuild doesn't support framework reference assemblies.
 </PropertyGroup>
 
 <Target Name="_GenerateJavaDesignerForComponent"
-  Inputs="@(_AdditonalAndroidResourceCacheFiles);@(_LibraryResourceDirectoryStamps);$(_AndroidResgenFlagFile)"
+  Inputs="@(_AdditonalAndroidResourceCacheFiles);@(_LibraryResourceDirectoryStamps)"
   Outputs="$(_AndroidComponentResgenFlagFile)"
   DependsOnTargets="$(_GenerateJavaDesignerForComponentDependsOnTargets)">
 
@@ -1552,6 +1552,7 @@ because xbuild doesn't support framework reference assemblies.
    ResourceDirectory="$(MonoAndroidResDirIntermediate)"
    AdditionalResourceDirectories="@(LibraryResourceDirectories)"
    AdditionalAndroidResourcePaths="@(_AdditonalAndroidResourceCachePaths)"
+   AndroidComponentResgenFlagFile="$(_AndroidComponentResgenFlagFile)"
    ToolPath="$(AaptToolPath)"
    ToolExe="$(AaptToolExe)"
    ApiLevel="$(_AndroidTargetSdkVersion)"
@@ -1564,6 +1565,7 @@ because xbuild doesn't support framework reference assemblies.
  <Aapt2Link
    Condition="'$(_AndroidUseAapt2)' == 'True'"
    ContinueOnError="$(DesignTimeBuild)"
+   AndroidComponentResgenFlagFile="$(_AndroidComponentResgenFlagFile)"
    UseShortFileNames="$(UseShortFileNames)"
    ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
    OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)"


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/2216#issuecomment-428731234

This reverts commit fab260dfab1e2b7837e9c9e0e665007cb3156374.

This commit relies on other commits in master, which otherwise causes a regression as mentioned in #2216:

```
Building target "_GenerateJavaDesignerForComponent" completely.
Input file "obj\Debug\81\R.cs.flag" is newer than output file "obj\Debug\81\Component.R.cs.flag".
```

This target shouldn't be running in a build with no changes.

I also incorporated test changes from master @ 647659e8, which catches the regression in #2216. It will be helpful to add this test in d15-9 going forward.