### PR TITLE
[tests] Xamarin.ProjectTools fix for IsTargetSkipped

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
@@ -50,7 +50,7 @@ namespace Xamarin.ProjectTools
 			bool found = false;
 			foreach (var line in Builder.LastBuildOutput) {
 					found = line.Contains (string.Format ("Target {0} skipped due to ", target))
-					            || line.Contains (string.Format ("Skipping target \"{0}\" because it has no outputs.", target))
+					            || line.Contains (string.Format ("Skipping target \"{0}\" because it has no ", target)) //NOTE: message can say `inputs` or `outputs`
 					            || line.Contains (string.Format ("Target \"{0}\" skipped, due to", target))
 					            || line.Contains (string.Format ("Skipping target \"{0}\" because its outputs are up-to-date", target))
 					            || line.Contains (string.Format ("target {0}, skipping", target))

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
@@ -49,11 +49,11 @@ namespace Xamarin.ProjectTools
 		{
 			bool found = false;
 			foreach (var line in Builder.LastBuildOutput) {
-					found = line.Contains (string.Format ("Target {0} skipped due to ", target))
-					            || line.Contains (string.Format ("Skipping target \"{0}\" because it has no ", target)) //NOTE: message can say `inputs` or `outputs`
-					            || line.Contains (string.Format ("Target \"{0}\" skipped, due to", target))
-					            || line.Contains (string.Format ("Skipping target \"{0}\" because its outputs are up-to-date", target))
-					            || line.Contains (string.Format ("target {0}, skipping", target))
+					found = line.Contains ($"Target {target} skipped due to ")
+					            || line.Contains ($"Skipping target \"{target}\" because it has no ") //NOTE: message can say `inputs` or `outputs`
+					            || line.Contains ($"Target \"{target}\" skipped, due to")
+					            || line.Contains ($"Skipping target \"{target}\" because its outputs are up-to-date")
+					            || line.Contains ($"target {target}, skipping")
 					            || line.Contains ($"Skipping target \"{target}\" because all output files are up-to-date");
 					if (found)
 						return true;


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/2285

The `IsTargetSkipped` method has a slight bug, it doesn't account for:

    Skipping target "_GenerateJavaDesignerForComponent" because it has no inputs.

Minor change here to account for either `inputs` or `outputs` in the
message. There are no test failures caused by this on master; this was
discoverd in #2285 on d15-9.

Switched to using C# string interpolation.