### PR TITLE
[Xamarin.Android.Build.Tasks] Add `CopyResource` items to `FileWrites`.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 
 			var proj = new XamarinFormsAndroidApplicationProject ();
-			proj.MainActivity = proj.DefaultMainActivity.Replace ("public class MainActivity : Activity", "public class MainActivity : Xamarin.Forms.Platform.Android.FormsAppCompatActivity");
+
 
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				//We don't want these things stepping on each other
@@ -285,7 +285,6 @@ namespace UnamedProject
 				IsRelease = isRelease,
 				
 			};
-			proj.MainActivity = proj.DefaultMainActivity.Replace ("public class MainActivity : Activity", "public class MainActivity : Xamarin.Forms.Platform.Android.FormsAppCompatActivity");
 
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				//To be sure we are at a clean state
@@ -1597,7 +1596,6 @@ namespace App1
 					new BuildItem ("ProjectReference","..\\Library1\\Library1.csproj"),
 				},
 			};
-			app.MainActivity = app.DefaultMainActivity.Replace ("public class MainActivity : Activity", "public class MainActivity : Xamarin.Forms.Platform.Android.FormsAppCompatActivity");
 			//LinkSkip one assembly that contains __AndroidLibraryProjects__.zip
 			string linkSkip = KnownPackages.SupportV7AppCompat_27_0_2_1.Id;
 			app.SetProperty ("AndroidLinkSkip", linkSkip);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -64,25 +64,8 @@ namespace Xamarin.Android.Build.Tests
 				Assert.Ignore ("Currently ignoring this test on non-Windows platforms.");
 			}
 
-			var proj = new XamarinAndroidApplicationProject ();
+			var proj = new XamarinFormsAndroidApplicationProject ();
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("public class MainActivity : Activity", "public class MainActivity : Xamarin.Forms.Platform.Android.FormsAppCompatActivity");
-
-			var packages = proj.Packages;
-			packages.Add (KnownPackages.XamarinForms_3_0_0_561731);
-			packages.Add (KnownPackages.Android_Arch_Core_Common_26_1_0);
-			packages.Add (KnownPackages.Android_Arch_Lifecycle_Common_26_1_0);
-			packages.Add (KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0);
-			packages.Add (KnownPackages.AndroidSupportV4_27_0_2_1);
-			packages.Add (KnownPackages.SupportCompat_27_0_2_1);
-			packages.Add (KnownPackages.SupportCoreUI_27_0_2_1);
-			packages.Add (KnownPackages.SupportCoreUtils_27_0_2_1);
-			packages.Add (KnownPackages.SupportDesign_27_0_2_1);
-			packages.Add (KnownPackages.SupportFragment_27_0_2_1);
-			packages.Add (KnownPackages.SupportMediaCompat_27_0_2_1);
-			packages.Add (KnownPackages.SupportV7AppCompat_27_0_2_1);
-			packages.Add (KnownPackages.SupportV7CardView_27_0_2_1);
-			packages.Add (KnownPackages.SupportV7MediaRouter_27_0_2_1);
-			packages.Add (KnownPackages.SupportV7RecyclerView_27_0_2_1);
 
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				//We don't want these things stepping on each other
@@ -298,34 +281,11 @@ namespace UnamedProject
 		public void CheckTimestamps ([Values (true, false)] bool isRelease)
 		{
 			var start = DateTime.UtcNow.AddSeconds (-1);
-			var proj = new XamarinAndroidApplicationProject {
+			var proj = new XamarinFormsAndroidApplicationProject {
 				IsRelease = isRelease,
-				AndroidResources = {
-					new AndroidItem.AndroidResource ("Resources\\layout\\Tabbar.axml") {
-						TextContent = () => {
-							return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<android.support.design.widget.TabLayout xmlns:android=\"http://schemas.android.com/apk/res/android\" xmlns:app=\"http://schemas.android.com/apk/res-auto\" android:id=\"@+id/sliding_tabs\" android:background=\"?attr/colorPrimary\" android:theme=\"@style/ThemeOverlay.AppCompat.Dark.ActionBar\" app:tabIndicatorColor=\"@android:color/white\" app:tabGravity=\"fill\" app:tabMode=\"fixed\" />";
-						}
-					}
-				}
+				
 			};
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("public class MainActivity : Activity", "public class MainActivity : Xamarin.Forms.Platform.Android.FormsAppCompatActivity");
-
-			var packages = proj.Packages;
-			packages.Add (KnownPackages.XamarinForms_3_0_0_561731);
-			packages.Add (KnownPackages.Android_Arch_Core_Common_26_1_0);
-			packages.Add (KnownPackages.Android_Arch_Lifecycle_Common_26_1_0);
-			packages.Add (KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0);
-			packages.Add (KnownPackages.AndroidSupportV4_27_0_2_1);
-			packages.Add (KnownPackages.SupportCompat_27_0_2_1);
-			packages.Add (KnownPackages.SupportCoreUI_27_0_2_1);
-			packages.Add (KnownPackages.SupportCoreUtils_27_0_2_1);
-			packages.Add (KnownPackages.SupportDesign_27_0_2_1);
-			packages.Add (KnownPackages.SupportFragment_27_0_2_1);
-			packages.Add (KnownPackages.SupportMediaCompat_27_0_2_1);
-			packages.Add (KnownPackages.SupportV7AppCompat_27_0_2_1);
-			packages.Add (KnownPackages.SupportV7CardView_27_0_2_1);
-			packages.Add (KnownPackages.SupportV7MediaRouter_27_0_2_1);
-			packages.Add (KnownPackages.SupportV7RecyclerView_27_0_2_1);
 
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				//To be sure we are at a clean state
@@ -1630,7 +1590,7 @@ namespace App1
 					},
 				},
 			};
-			var app = new XamarinAndroidApplicationProject () {
+			var app = new XamarinFormsAndroidApplicationProject () {
 				IsRelease = true,
 				AndroidLinkModeRelease = AndroidLinkMode.Full,
 				References = {
@@ -1638,21 +1598,6 @@ namespace App1
 				},
 			};
 			app.MainActivity = app.DefaultMainActivity.Replace ("public class MainActivity : Activity", "public class MainActivity : Xamarin.Forms.Platform.Android.FormsAppCompatActivity");
-			app.Packages.Add (KnownPackages.XamarinForms_3_0_0_561731);
-			app.Packages.Add (KnownPackages.Android_Arch_Core_Common_26_1_0);
-			app.Packages.Add (KnownPackages.Android_Arch_Lifecycle_Common_26_1_0);
-			app.Packages.Add (KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0);
-			app.Packages.Add (KnownPackages.AndroidSupportV4_27_0_2_1);
-			app.Packages.Add (KnownPackages.SupportCompat_27_0_2_1);
-			app.Packages.Add (KnownPackages.SupportCoreUI_27_0_2_1);
-			app.Packages.Add (KnownPackages.SupportCoreUtils_27_0_2_1);
-			app.Packages.Add (KnownPackages.SupportDesign_27_0_2_1);
-			app.Packages.Add (KnownPackages.SupportFragment_27_0_2_1);
-			app.Packages.Add (KnownPackages.SupportMediaCompat_27_0_2_1);
-			app.Packages.Add (KnownPackages.SupportV7AppCompat_27_0_2_1);
-			app.Packages.Add (KnownPackages.SupportV7CardView_27_0_2_1);
-			app.Packages.Add (KnownPackages.SupportV7MediaRouter_27_0_2_1);
-			app.Packages.Add (KnownPackages.SupportV7RecyclerView_27_0_2_1);
 			//LinkSkip one assembly that contains __AndroidLibraryProjects__.zip
 			string linkSkip = KnownPackages.SupportV7AppCompat_27_0_2_1.Id;
 			app.SetProperty ("AndroidLinkSkip", linkSkip);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -14,24 +14,26 @@ namespace Xamarin.Android.Build.Tests
 	public class IncrementalBuildTest : BaseTest
 	{
 		[Test]
-		public void CheckNothingIsDeletedByIncrementalClean ([Values (true, false)] bool enableMultiDex)
+		public void CheckNothingIsDeletedByIncrementalClean ([Values (true, false)] bool enableMultiDex, [Values (true, false)] bool useAapt2)
 		{
 			// do a release build
 			// change one of the properties (say AotAssemblies) 
 			// do another build. it should NOT hose the resource directory.
-			var path = Path.Combine ( "temp", TestName );
+			var path = Path.Combine ("temp", TestName);
 			var proj = new XamarinFormsAndroidApplicationProject () {
 				ProjectName = "App1",
 				IsRelease = true,
 			};
 			if (enableMultiDex)
-				proj.SetProperty ( "AndroidEnableMultiDex", "True" );
-			using (var b = CreateApkBuilder ( path, false, false )) {
-				Assert.IsTrue ( b.Build ( proj ), "First should have succeeded" );
-				IEnumerable<string> files = Directory.EnumerateFiles ( Path.Combine (Root, path, proj.IntermediateOutputPath ), "*.*", SearchOption.AllDirectories );
-				Assert.IsTrue ( b.Build ( proj, doNotCleanupOnUpdate: true, parameters: null, saveProject: false ), "Second should have succeeded" );
+				proj.SetProperty ("AndroidEnableMultiDex", "True");
+			if (useAapt2)
+				proj.SetProperty ("AndroidUseAapt2", "True");
+			using (var b = CreateApkBuilder (path)) {
+				Assert.IsTrue (b.Build (proj), "First should have succeeded" );
+				IEnumerable<string> files = Directory.EnumerateFiles (Path.Combine (Root, path, proj.IntermediateOutputPath), "*.*", SearchOption.AllDirectories);
+				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, parameters: null, saveProject: false), "Second should have succeeded");
 				foreach (var file in files) {
-					FileAssert.Exists ( file, $"{file} should not have been deleted!" );
+					FileAssert.Exists (file, $"{file} should not have been deleted!" );
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Android.Build.Tests
 			// change one of the properties (say AotAssemblies) 
 			// do another build. it should NOT hose the resource directory.
 			var path = Path.Combine ( "temp", TestName );
-			var proj = new XamarinAndroidApplicationProject () {
+			var proj = new XamarinFormsAndroidApplicationProject () {
 				ProjectName = "App1",
 				IsRelease = true,
 			};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
@@ -27,6 +27,8 @@ namespace Xamarin.ProjectTools {
 					return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<android.support.design.widget.TabLayout xmlns:android=\"http://schemas.android.com/apk/res/android\" xmlns:app=\"http://schemas.android.com/apk/res-auto\" android:id=\"@+id/sliding_tabs\" android:background=\"?attr/colorPrimary\" android:theme=\"@style/ThemeOverlay.AppCompat.Dark.ActionBar\" app:tabIndicatorColor=\"@android:color/white\" app:tabGravity=\"fill\" app:tabMode=\"fixed\" />";
 				}
 			} );
+
+			MainActivity = DefaultMainActivity.Replace ( "public class MainActivity : Activity", "public class MainActivity : Xamarin.Forms.Platform.Android.FormsAppCompatActivity" );
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Microsoft.Build.Construction;
+
+namespace Xamarin.ProjectTools {
+	public class XamarinFormsAndroidApplicationProject : XamarinAndroidApplicationProject {
+		public XamarinFormsAndroidApplicationProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
+			: base ( debugConfigurationName, releaseConfigurationName )
+		{
+			Packages.Add ( KnownPackages.XamarinForms_3_0_0_561731 );
+			Packages.Add ( KnownPackages.Android_Arch_Core_Common_26_1_0 );
+			Packages.Add ( KnownPackages.Android_Arch_Lifecycle_Common_26_1_0 );
+			Packages.Add ( KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0 );
+			Packages.Add ( KnownPackages.AndroidSupportV4_27_0_2_1 );
+			Packages.Add ( KnownPackages.SupportCompat_27_0_2_1 );
+			Packages.Add ( KnownPackages.SupportCoreUI_27_0_2_1 );
+			Packages.Add ( KnownPackages.SupportCoreUtils_27_0_2_1 );
+			Packages.Add ( KnownPackages.SupportDesign_27_0_2_1 );
+			Packages.Add ( KnownPackages.SupportFragment_27_0_2_1 );
+			Packages.Add ( KnownPackages.SupportMediaCompat_27_0_2_1 );
+			Packages.Add ( KnownPackages.SupportV7AppCompat_27_0_2_1 );
+			Packages.Add ( KnownPackages.SupportV7CardView_27_0_2_1 );
+			Packages.Add ( KnownPackages.SupportV7MediaRouter_27_0_2_1 );
+			Packages.Add ( KnownPackages.SupportV7RecyclerView_27_0_2_1 );
+
+			AndroidResources.Add ( new AndroidItem.AndroidResource ( "Resources\\layout\\Tabbar.axml" ) {
+				TextContent = () => {
+					return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<android.support.design.widget.TabLayout xmlns:android=\"http://schemas.android.com/apk/res/android\" xmlns:app=\"http://schemas.android.com/apk/res-auto\" android:id=\"@+id/sliding_tabs\" android:background=\"?attr/colorPrimary\" android:theme=\"@style/ThemeOverlay.AppCompat.Dark.ActionBar\" app:tabIndicatorColor=\"@android:color/white\" app:tabGravity=\"fill\" app:tabMode=\"fixed\" />";
+				}
+			} );
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Android\XamarinAndroidProject.cs" />
     <Compile Include="Android\XamarinAndroidProjectLanguage.cs" />
     <Compile Include="Android\XamarinAndroidWearApplicationProject.cs" />
+    <Compile Include="Android\XamarinFormsAndroidApplicationProject.cs" />
     <Compile Include="Android\AndroidItem.cs" />
     <Compile Include="Common\DownloadedCache.cs" />
     <Compile Include="Common\ProjectBuilder.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1959,6 +1959,9 @@ because xbuild doesn't support framework reference assemblies.
       Condition="Exists ('$(MonoAndroidIntermediate)android\src\mono\android\Seppuku.java')" />
     <FileWrites Include="$(MonoAndroidIntermediate)android\src\mono\android\app\NotifyTimeZoneChanges.java"
       Condition="Exists ('$(MonoAndroidIntermediate)android\src\mono\android\app\NotifyTimeZoneChanges.java')" />
+    <FileWrites Include="$(MonoAndroidIntermediateAssetsDir)machine.config" />
+    <FileWrites Include="$(IntermediateOutputPath)android\bin\mono.android.jar" />
+    <FileWrites Include="$(_AndroidStaticResourcesFlag)" />
   </ItemGroup>
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1950,15 +1950,15 @@ because xbuild doesn't support framework reference assemblies.
 
   <ItemGroup>
     <FileWrites Include="$(MonoAndroidIntermediate)android\src\mono\MonoRuntimeProvider.java"
-      Condition="Exists ('$(MonoAndroidIntermediate)android\src\mono\MonoRuntimeProvider.java')" />
+        Condition="Exists ('$(MonoAndroidIntermediate)android\src\mono\MonoRuntimeProvider.java')" />
     <FileWrites Include="$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\MultiDexLoader.java"
-      Condition="Exists ('$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\MultiDexLoader.java')" />
+        Condition="Exists ('$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\MultiDexLoader.java')" />
     <FileWrites Include="$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\IncrementalClassLoader.java"
-      Condition="Exists ('$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\IncrementalClassLoader.java')" />
+        Condition="Exists ('$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\IncrementalClassLoader.java')" />
     <FileWrites Include="$(MonoAndroidIntermediate)android\src\mono\android\Seppuku.java"
-      Condition="Exists ('$(MonoAndroidIntermediate)android\src\mono\android\Seppuku.java')" />
+        Condition="Exists ('$(MonoAndroidIntermediate)android\src\mono\android\Seppuku.java')" />
     <FileWrites Include="$(MonoAndroidIntermediate)android\src\mono\android\app\NotifyTimeZoneChanges.java"
-      Condition="Exists ('$(MonoAndroidIntermediate)android\src\mono\android\app\NotifyTimeZoneChanges.java')" />
+        Condition="Exists ('$(MonoAndroidIntermediate)android\src\mono\android\app\NotifyTimeZoneChanges.java')" />
     <FileWrites Include="$(MonoAndroidIntermediateAssetsDir)machine.config" />
     <FileWrites Include="$(IntermediateOutputPath)android\bin\mono.android.jar" />
     <FileWrites Include="$(_AndroidStaticResourcesFlag)" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1947,6 +1947,19 @@ because xbuild doesn't support framework reference assemblies.
   <Touch Files="$(IntermediateOutputPath)android\bin\mono.android.jar" />
   
   <Touch Files="$(_AndroidStaticResourcesFlag)" AlwaysCreate="true" />
+
+  <ItemGroup>
+    <FileWrites Include="$(MonoAndroidIntermediate)android\src\mono\MonoRuntimeProvider.java"
+      Condition="Exists ('$(MonoAndroidIntermediate)android\src\mono\MonoRuntimeProvider.java')" />
+    <FileWrites Include="$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\MultiDexLoader.java"
+      Condition="Exists ('$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\MultiDexLoader.java')" />
+    <FileWrites Include="$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\IncrementalClassLoader.java"
+      Condition="Exists ('$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\IncrementalClassLoader.java')" />
+    <FileWrites Include="$(MonoAndroidIntermediate)android\src\mono\android\Seppuku.java"
+      Condition="Exists ('$(MonoAndroidIntermediate)android\src\mono\android\Seppuku.java')" />
+    <FileWrites Include="$(MonoAndroidIntermediate)android\src\mono\android\app\NotifyTimeZoneChanges.java"
+      Condition="Exists ('$(MonoAndroidIntermediate)android\src\mono\android\app\NotifyTimeZoneChanges.java')" />
+  </ItemGroup>
 </Target>
 
 <Target Name="_CreateIntermediateAssembliesDir"
@@ -2404,6 +2417,7 @@ because xbuild doesn't support framework reference assemblies.
   <CreateItem
     Include="$(IntermediateOutputPath)android\src\\**\*.java">
     <Output TaskParameter="Include" ItemName="_JavaStubFiles" />
+    <Output TaskParameter="Include" ItemName="FileWrites" />
   </CreateItem>
 </Target>
 


### PR DESCRIPTION
Not quite sure how we ever got away with this. As part
of the build process we extract from `EmbeddedResource`
a bunch of `.java` files into the intermediate directory.

These are used for a number of things like multidex and
bootstrapping mono. For some reason we NEVER added those
to the `FileWrites` group. So there is a good chance these
files will get deleted by an incremental clean.

This was picked up by a unit test in monodroid which
deals with fast deployment.