### PR TITLE
[Xamarin.Android.Build.Tasks] Ignore XA0115 for Shared Runtime builds.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1032,7 +1032,7 @@ because xbuild doesn't support framework reference assemblies.
 		<_RequestedAbis>;$(AndroidSupportedAbis);</_RequestedAbis>
 	</PropertyGroup>
 	<Error Code="XA0115"
-			Condition="$(_RequestedAbis.Contains(';armeabi;'))"
+			Condition="$(_RequestedAbis.Contains(';armeabi;')) And '$(AndroidUseSharedRuntime)' != 'True'"
 			Text="Invalid value 'armeabi' in %24(AndroidSupportedAbis). This ABI is no longer supported. Please update your project properties."
 	/>
 </Target>


### PR DESCRIPTION
Fixes #2289

When doing debug shared runtime builds the user generally does
not care what abi is used. As a result we should only be showing
the `XA0115` warning when they are NOT using the shared runtime.