### PR TITLE
[Xamarin.Android.Build.Tasks] fix DTBs for binding projects with aar files

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -139,6 +139,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 
     <CompileDependsOn>
       _SetupDesignTimeBuildForCompile;
+      AddLibraryJarsToBind;
       $(CompileDependsOn);
     </CompileDependsOn>
 


### PR DESCRIPTION
Fixes: http://feedback.devdiv.io/335298
Context: https://github.com/xamarin/XamarinComponents/tree/master/Android/ARCore/samples

The linked example was failing a design-time build with:

    "XamarinComponents\Android\ARCore\source\Google.ARCore.csproj" ->
        (CoreCompile target) ->
        Additions\Additions.cs(63,101,63,107): error CS0234: The type or namespace name 'Anchor' does not exist in the namespace 'Google.AR.Core' (are you missing an assembly reference?)

Usage of the `Anchor` type had sqiggly Intellisense errors in Visual
Studio. Building the project was successful, however.

Looking further, the contents of `obj\Debug\api.xml` seemed _wrong_
after a design-time build:

    <api></api>

Reviewing the log, the `<ClassParse />` MSBuild task had no inputs:

    ClassParse
        ClassParse Task
        OutputFile: obj\Debug\api.xml.class-parse
        SourceJars:
        DocumentationPaths:

So it looks, like using `LibraryProjectZip` build items need
additional MSBuild targets to run in order to work properly.

I could get things working with the following workaround in the
project file:

    <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
    <!-- Workaround -->
    <PropertyGroup>
        <CompileDependsOn>
            AddLibraryJarsToBind;
            $(CompileDependsOn);
        </CompileDependsOn>
    </PropertyGroup>

I added the equivalent fix in `Xamarin.Android.Bindings.targets` as
well as a test for this scenario.

Future changes:
- Design-time builds for binding projects are quite slow. In the
  example above, it was taking around 16 seconds on my machine. This
  will very likely count as a UI hang in Visual Studio.
- I will file an issue for this, as I don't know how important it is
  to improve, and how many developers are using binding projects.