### PR TITLE
[monodroid] Provide proper in-module address on Windows

### DIFF
--- a/src/monodroid/jni/android-system.cc
+++ b/src/monodroid/jni/android-system.cc
@@ -854,7 +854,13 @@ AndroidSystem::get_libmonoandroid_directory_path ()
 		return libmonoandroid_directory_path;
 
 	DWORD flags = GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT;
-	wchar_t *dir_path = utils.utf8_to_utf16 (libmonoandroid_directory_path);
+
+	// `GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS` means that `dir_path`, instead of
+	// being a filesystem path, must instead be an address within the module that
+	// we wish to obtain the HMODULE for.  Thus, while this *looks* crazy, it's
+	// correct: `&libmonoandroid_directory_path` is an address within this module.
+	const wchar_t *dir_path = static_cast<const wchar_t*>(&libmonoandroid_directory_path);
+
 	BOOL retval = GetModuleHandleExW (flags, dir_path, &module);
 	free (dir_path);
 	if (!retval)


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2300

Commit e99b02b7 [broke the Android Designer][0]:

	[monodroid] Cannot find 'libmonosgen-2.0.dll'. Looked in the following locations:
	[monodroid]   C:\Users\VssAdministrator\AppData\Local\Temp\tmpC7EC.tmp\.__override__
	[monodroid]   C:\Users\VssAdministrator\AppData\Local\Temp\tmpC7EC.tmp
	[monodroid]   C:\Users\VssAdministrator\AppData\Local\Temp\tmpC7EC.tmp
	[monodroid]   C:\Users\VSSADM~1\AppData\Local\Temp\data
	[monodroid] Do you have a shared runtime build of your app with AndroidManifest.xml android:minSdkVersion < 10 while running on a 64-bit Android 5.0 target? This combination is not supported.
	[monodroid] Please either set android:minSdkVersion >= 10 or use a build without the shared runtime (like default Release configuration).

The *cause* of the issue is that commit e99b02b7 broke this seemingly
insane-looking code, in which an *address* to a static variable --
resulting in a `char**` -- is cast (by the compiler) to a `wchar_t*`:

	GetModuleHandleExW (flags, (void*)&libmonoandroid_directory_path, &module)

The replacement *looks* saner:

	wchar_t *dir_path = utils.utf8_to_utf16 (libmonoandroid_directory_path)
	BOOL retval = GetModuleHandleExW (flags, dir_path, &module);

However, this "sane-looking" change is in fact wrong: due to the joys
of [`GetModuleHandleExW()`][1], the `lpModuleName` parameter
*need not be* an actual filesystem path.  If `dwFlags` contains
`GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS` -- which it does --  then:

> The *lpModuleName* parameter is an address in the module.

As it happens™, `&libmonoandroid_directory_path` is "an address in the
module", which is why this used to work.  After the change,
`dir_path` is either NULL or a heap-allocated value, *neither* of
which is "an address in the module."  Consequently, the e99b02b7
change meant that `GetModuleHandleExW()` always failed, and
`AndroidSystem::get_libmonoandroid_directory_path()` always returned
NULL on Windows.

The fix is to restore the pre-e99b02b7 behavior, passing "an address
in the module" as the `dir_path` parameter to `GetModuleHandleExW()`.

[0]: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2114540&view=logs
[1]: https://docs.microsoft.com/en-us/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandleexw