### PR TITLE
[tests] use a "real" Xamarin.Forms app

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2378,7 +2378,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 					}
 				}
 				packages.Clear ();
-				packages.Add (KnownPackages.XamarinForms_3_0_0_561731);
+				packages.Add (KnownPackages.XamarinForms_3_1_0_697729);
 				packages.Add (KnownPackages.Android_Arch_Core_Common_26_1_0);
 				packages.Add (KnownPackages.Android_Arch_Lifecycle_Common_26_1_0);
 				packages.Add (KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -338,6 +338,15 @@ namespace Xamarin.ProjectTools
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v7.MediaRouter.27.0.2.1\\lib\\MonoAndroid81\\Xamarin.Android.Support.v7.MediaRouter.dll" }
 			}
 		};
+		public static Package VectorDrawable_27_0_2_1 = new Package {
+			Id = "Xamarin.Android.Support.Vector.Drawable",
+			Version = "27.0.2.1",
+			TargetFramework = "MonoAndroid81",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.Vector.Drawable") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.Vector.Drawable.27.0.2.1\\lib\\MonoAndroid81\\Xamarin.Android.Support.Vector.Drawable.dll" }
+			},
+		};
 		public static Package SupportV7Palette_22_1_1_1 = new Package {
 			Id = "Xamarin.Android.Support.v7.Palette",
 			Version = "22.1.1.1",
@@ -445,25 +454,25 @@ namespace Xamarin.ProjectTools
 				},
 			}
 		};
-		public static Package XamarinForms_3_0_0_561731 = new Package {
+		public static Package XamarinForms_3_1_0_697729 = new Package {
 			Id = "Xamarin.Forms",
-			Version = "3.0.0.561731",
+			Version = "3.1.0.697729",
 			TargetFramework = "MonoAndroid10",
 			References =  {
 				new BuildItem.Reference ("Xamarin.Forms.Platform.Android") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.0.0.561731\\lib\\MonoAndroid10\\Xamarin.Forms.Platform.Android.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.1.0.697729\\lib\\MonoAndroid10\\Xamarin.Forms.Platform.Android.dll"
 				},
 				new BuildItem.Reference ("FormsViewGroup") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.0.0.561731\\lib\\MonoAndroid10\\FormsViewGroup.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.1.0.697729\\lib\\MonoAndroid10\\FormsViewGroup.dll"
 				},
 				new BuildItem.Reference ("Xamarin.Forms.Core") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.0.0.561731\\lib\\MonoAndroid10\\Xamarin.Forms.Core.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.1.0.697729\\lib\\MonoAndroid10\\Xamarin.Forms.Core.dll"
 				},
 				new BuildItem.Reference ("Xamarin.Forms.Xaml") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.0.0.561731\\lib\\MonoAndroid10\\Xamarin.Forms.Xaml.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.1.0.697729\\lib\\MonoAndroid10\\Xamarin.Forms.Xaml.dll"
 				},
 				new BuildItem.Reference ("Xamarin.Forms.Platform") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.0.0.561731\\lib\\MonoAndroid10\\Xamarin.Forms.Platform.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.1.0.697729\\lib\\MonoAndroid10\\Xamarin.Forms.Platform.dll"
 				},
 			}
 		};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
@@ -1,34 +1,90 @@
 ﻿using System;
-using Microsoft.Build.Construction;
+using System.IO;
 
-namespace Xamarin.ProjectTools {
-	public class XamarinFormsAndroidApplicationProject : XamarinAndroidApplicationProject {
-		public XamarinFormsAndroidApplicationProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
-			: base ( debugConfigurationName, releaseConfigurationName )
+namespace Xamarin.ProjectTools
+{
+	public class XamarinFormsAndroidApplicationProject : XamarinAndroidApplicationProject
+	{
+		static readonly string default_main_activity_cs;
+		static readonly string colors_xml;
+		static readonly string styles_xml;
+		static readonly string Tabbar_axml;
+		static readonly string Toolbar_axml;
+		static readonly string MainPage_xaml;
+		static readonly string MainPage_xaml_cs;
+		static readonly string App_xaml;
+		static readonly string App_xaml_cs;
+
+		static XamarinFormsAndroidApplicationProject ()
 		{
-			Packages.Add ( KnownPackages.XamarinForms_3_0_0_561731 );
-			Packages.Add ( KnownPackages.Android_Arch_Core_Common_26_1_0 );
-			Packages.Add ( KnownPackages.Android_Arch_Lifecycle_Common_26_1_0 );
-			Packages.Add ( KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0 );
-			Packages.Add ( KnownPackages.AndroidSupportV4_27_0_2_1 );
-			Packages.Add ( KnownPackages.SupportCompat_27_0_2_1 );
-			Packages.Add ( KnownPackages.SupportCoreUI_27_0_2_1 );
-			Packages.Add ( KnownPackages.SupportCoreUtils_27_0_2_1 );
-			Packages.Add ( KnownPackages.SupportDesign_27_0_2_1 );
-			Packages.Add ( KnownPackages.SupportFragment_27_0_2_1 );
-			Packages.Add ( KnownPackages.SupportMediaCompat_27_0_2_1 );
-			Packages.Add ( KnownPackages.SupportV7AppCompat_27_0_2_1 );
-			Packages.Add ( KnownPackages.SupportV7CardView_27_0_2_1 );
-			Packages.Add ( KnownPackages.SupportV7MediaRouter_27_0_2_1 );
-			Packages.Add ( KnownPackages.SupportV7RecyclerView_27_0_2_1 );
+			using (var sr = new StreamReader (typeof (XamarinAndroidApplicationProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Forms.MainActivity.cs")))
+				default_main_activity_cs = sr.ReadToEnd ();
+			using (var sr = new StreamReader (typeof (XamarinAndroidApplicationProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Forms.colors.xml")))
+				colors_xml = sr.ReadToEnd ();
+			using (var sr = new StreamReader (typeof (XamarinAndroidApplicationProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Forms.styles.xml")))
+				styles_xml = sr.ReadToEnd ();
+			using (var sr = new StreamReader (typeof (XamarinAndroidApplicationProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Forms.Tabbar.axml")))
+				Tabbar_axml = sr.ReadToEnd ();
+			using (var sr = new StreamReader (typeof (XamarinAndroidApplicationProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Forms.Toolbar.axml")))
+				Toolbar_axml = sr.ReadToEnd ();
+			using (var sr = new StreamReader (typeof (XamarinAndroidApplicationProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Forms.MainPage.xaml")))
+				MainPage_xaml = sr.ReadToEnd ();
+			using (var sr = new StreamReader (typeof (XamarinAndroidApplicationProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Forms.MainPage.xaml.cs")))
+				MainPage_xaml_cs = sr.ReadToEnd ();
+			using (var sr = new StreamReader (typeof (XamarinAndroidApplicationProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Forms.App.xaml")))
+				App_xaml = sr.ReadToEnd ();
+			using (var sr = new StreamReader (typeof (XamarinAndroidApplicationProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Forms.App.xaml.cs")))
+				App_xaml_cs = sr.ReadToEnd ();
+		}
 
-			AndroidResources.Add ( new AndroidItem.AndroidResource ( "Resources\\layout\\Tabbar.axml" ) {
-				TextContent = () => {
-					return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<android.support.design.widget.TabLayout xmlns:android=\"http://schemas.android.com/apk/res/android\" xmlns:app=\"http://schemas.android.com/apk/res-auto\" android:id=\"@+id/sliding_tabs\" android:background=\"?attr/colorPrimary\" android:theme=\"@style/ThemeOverlay.AppCompat.Dark.ActionBar\" app:tabIndicatorColor=\"@android:color/white\" app:tabGravity=\"fill\" app:tabMode=\"fixed\" />";
-				}
-			} );
+		public XamarinFormsAndroidApplicationProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
+			: base (debugConfigurationName, releaseConfigurationName)
+		{
+			var forms = KnownPackages.XamarinForms_3_1_0_697729;
+			Packages.Add (forms);
+			Packages.Add (KnownPackages.Android_Arch_Core_Common_26_1_0);
+			Packages.Add (KnownPackages.Android_Arch_Lifecycle_Common_26_1_0);
+			Packages.Add (KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0);
+			Packages.Add (KnownPackages.AndroidSupportV4_27_0_2_1);
+			Packages.Add (KnownPackages.SupportCompat_27_0_2_1);
+			Packages.Add (KnownPackages.SupportCoreUI_27_0_2_1);
+			Packages.Add (KnownPackages.SupportCoreUtils_27_0_2_1);
+			Packages.Add (KnownPackages.SupportDesign_27_0_2_1);
+			Packages.Add (KnownPackages.SupportFragment_27_0_2_1);
+			Packages.Add (KnownPackages.SupportMediaCompat_27_0_2_1);
+			Packages.Add (KnownPackages.SupportV7AppCompat_27_0_2_1);
+			Packages.Add (KnownPackages.SupportV7CardView_27_0_2_1);
+			Packages.Add (KnownPackages.SupportV7MediaRouter_27_0_2_1);
+			Packages.Add (KnownPackages.SupportV7RecyclerView_27_0_2_1);
+			Packages.Add (KnownPackages.VectorDrawable_27_0_2_1);
 
-			MainActivity = DefaultMainActivity.Replace ( "public class MainActivity : Activity", "public class MainActivity : Xamarin.Forms.Platform.Android.FormsAppCompatActivity" );
+			AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values\\colors.xml") {
+				TextContent = () => colors_xml,
+			});
+			AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values\\styles.xml") {
+				TextContent = () => styles_xml,
+			});
+			AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\layout\\Tabbar.axml") {
+				TextContent = () => Tabbar_axml,
+			});
+			AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\layout\\Toolbar.axml") {
+				TextContent = () => Toolbar_axml,
+			});
+			OtherBuildItems.Add (new BuildItem ("EmbeddedResource", "MainPage.xaml") {
+				TextContent = () => ProcessSourceTemplate (MainPage_xaml),
+			});
+			Sources.Add (new BuildItem.Source ("MainPage.xaml.cs") {
+				TextContent = () => ProcessSourceTemplate (MainPage_xaml_cs),
+			});
+			OtherBuildItems.Add (new BuildItem ("EmbeddedResource", "App.xaml") {
+				TextContent = () => ProcessSourceTemplate (App_xaml),
+			});
+			Sources.Add (new BuildItem.Source ("App.xaml.cs") {
+				TextContent = () => ProcessSourceTemplate (App_xaml_cs),
+			});
+			Imports.Add (new Import ($@"..\packages\{forms.Id}.{forms.Version}\build\netstandard2.0\Xamarin.Forms.targets"));
+
+			MainActivity = default_main_activity_cs;
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/App.xaml
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/App.xaml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Application xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="${ROOT_NAMESPACE}.App">
+</Application>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/App.xaml.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/App.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+[assembly: XamlCompilation (XamlCompilationOptions.Compile)]
+namespace ${ROOT_NAMESPACE}
+{
+	public partial class App : Application
+	{
+		public App ()
+		{
+			InitializeComponent ();
+
+			MainPage = new MainPage ();
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/MainActivity.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/MainActivity.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+using Android.App;
+using Android.Content.PM;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+using Android.OS;
+
+namespace ${ROOT_NAMESPACE}
+{
+	[Activity (Label = "${PROJECT_NAME}", Icon = "@drawable/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
+	public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
+	{
+		protected override void OnCreate (Bundle savedInstanceState)
+		{
+			TabLayoutResource = Resource.Layout.Tabbar;
+			ToolbarResource = Resource.Layout.Toolbar;
+
+			base.OnCreate (savedInstanceState);
+			global::Xamarin.Forms.Forms.Init (this, savedInstanceState);
+			LoadApplication (new App ());
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/MainPage.xaml
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/MainPage.xaml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="${ROOT_NAMESPACE}.MainPage">
+    <StackLayout>
+        <Label Text="Welcome to Xamarin.Forms!" 
+           HorizontalOptions="Center"
+           VerticalOptions="CenterAndExpand" />
+    </StackLayout>
+</ContentPage>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/MainPage.xaml.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/MainPage.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.Forms;
+
+namespace ${ROOT_NAMESPACE}
+{
+	public partial class MainPage : ContentPage
+	{
+		public MainPage ()
+		{
+			InitializeComponent ();
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/Tabbar.axml
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/Tabbar.axml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.TabLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/sliding_tabs"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/colorPrimary"
+    android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+    app:tabIndicatorColor="@android:color/white"
+    app:tabGravity="fill"
+    app:tabMode="fixed" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/Toolbar.axml
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/Toolbar.axml
@@ -1,0 +1,9 @@
+<android.support.v7.widget.Toolbar
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/toolbar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/colorPrimary"
+    android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+    android:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/colors.xml
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/colors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="launcher_background">#FFFFFF</color>
+    <color name="colorPrimary">#3F51B5</color>
+    <color name="colorPrimaryDark">#303F9F</color>
+    <color name="colorAccent">#FF4081</color>
+</resources>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/styles.xml
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/styles.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<resources>
+
+  <style name="MainTheme" parent="MainTheme.Base">
+  </style>
+  <!-- Base theme applied no matter what API -->
+  <style name="MainTheme.Base" parent="Theme.AppCompat.Light.DarkActionBar">
+    <!--If you are using revision 22.1 please use just windowNoTitle. Without android:-->
+    <item name="windowNoTitle">true</item>
+    <!--We will be using the toolbar so no need to show ActionBar-->
+    <item name="windowActionBar">false</item>
+    <!-- Set theme colors from http://www.google.com/design/spec/style/color.html#color-color-palette -->
+    <!-- colorPrimary is used for the default action bar background -->
+    <item name="colorPrimary">#2196F3</item>
+    <!-- colorPrimaryDark is used for the status bar -->
+    <item name="colorPrimaryDark">#1976D2</item>
+    <!-- colorAccent is used as the default value for colorControlActivated
+         which is used to tint widgets -->
+    <item name="colorAccent">#FF4081</item>
+    <!-- You can also set colorControlNormal, colorControlActivated
+         colorControlHighlight and colorSwitchThumbNormal. -->
+    <item name="windowActionModeOverlay">true</item>
+
+    <item name="android:datePickerDialogTheme">@style/AppCompatDialogStyle</item>
+  </style>
+
+  <style name="AppCompatDialogStyle" parent="Theme.AppCompat.Light.Dialog">
+    <item name="colorAccent">#FF4081</item>
+  </style>
+</resources>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -128,6 +128,15 @@
     <EmbeddedResource Include="Resources\Base\classes.jar">
       <LogicalName>Xamarin.ProjectTools.Resources.Base.classes.jar</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="Resources\Forms\MainActivity.cs" />
+    <EmbeddedResource Include="Resources\Forms\App.xaml" />
+    <EmbeddedResource Include="Resources\Forms\App.xaml.cs" />
+    <EmbeddedResource Include="Resources\Forms\MainPage.xaml" />
+    <EmbeddedResource Include="Resources\Forms\MainPage.xaml.cs" />
+    <EmbeddedResource Include="Resources\Forms\Tabbar.axml" />
+    <EmbeddedResource Include="Resources\Forms\Toolbar.axml" />
+    <EmbeddedResource Include="Resources\Forms\colors.xml" />
+    <EmbeddedResource Include="Resources\Forms\styles.xml" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
In the past `XamarinFormsAndroidApplicationProject` was incomplete:
1. It was not a "real app", but the resemblance of one that merely
   _compiled_.
2. It did not have XAML or import/run Xamarin.Forms MSBuild tasks.
3. It was not an app that could startup, and render Xamarin.Forms
   content.

So I took the simplest Xamarin.Forms template from Visual Studio 2017
15.8.7, a `Blank App`:
- Added various new files as `EmbeddedResource` in
  `Xamarin.ProjectTools`.
- Used most files as-is, adding `${ROOT_NAMESPACE}` where appropriate.
- Included `Tabbar.axml`, which has a "custom view".
- Included proper XAML files.
- Imported `Xamarin.Forms.targets`, and verified that `XamlG` and
  `XamlC` are now both running.
- Added `Xamarin.Android.Support.Vector.Drawable`, which avoids a
  crash at runtime.
- Updated to Xamarin.Forms 3.1.0.

Overall, this should make any of our test cases using
`XamarinFormsAndroidApplicationProject` much closer to reality.