### PR TITLE
Do not free memory that wasn't dynamically allocated

### DIFF
--- a/src/monodroid/jni/android-system.cc
+++ b/src/monodroid/jni/android-system.cc
@@ -848,9 +848,9 @@ char*
 AndroidSystem::get_libmonoandroid_directory_path ()
 {
 	wchar_t module_path[MAX_PATH];
-	HMODULE module = NULL;
+	HMODULE module = nullptr;
 
-	if (libmonoandroid_directory_path != NULL)
+	if (libmonoandroid_directory_path != nullptr)
 		return libmonoandroid_directory_path;
 
 	DWORD flags = GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT;
@@ -862,9 +862,8 @@ AndroidSystem::get_libmonoandroid_directory_path ()
 	const wchar_t *dir_path = static_cast<const wchar_t*>(&libmonoandroid_directory_path);
 
 	BOOL retval = GetModuleHandleExW (flags, dir_path, &module);
-	free (dir_path);
 	if (!retval)
-		return NULL;
+		return nullptr;
 
 	GetModuleFileNameW (module, module_path, sizeof (module_path) / sizeof (module_path[0]));
 	PathRemoveFileSpecW (module_path);


### PR DESCRIPTION
https://github.com/xamarin/xamarin-android/commit/9621be1db9e5b38b503c658df0c61c5dc49796e8 reverted previous change to send a real path to `GetModuleHandlExW` but the
reversal wasn't complete :( The call to free memory allocated for that path was
left, but with the current code `dir_path` is a pointer to a class field and
freeing it may have unknown effects.

Additionally, change some `NULL`s to C++ `nullptr`s