### PR TITLE
Revert "[Xamarin.Android.Build.Tasks] Ignore XA0115 for Shared Runtime builds. (#2293)"

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1032,7 +1032,7 @@ because xbuild doesn't support framework reference assemblies.
 		<_RequestedAbis>;$(AndroidSupportedAbis);</_RequestedAbis>
 	</PropertyGroup>
 	<Error Code="XA0115"
-			Condition="$(_RequestedAbis.Contains(';armeabi;')) And '$(AndroidUseSharedRuntime)' != 'True'"
+			Condition="$(_RequestedAbis.Contains(';armeabi;'))"
 			Text="Invalid value 'armeabi' in %24(AndroidSupportedAbis). This ABI is no longer supported. Please update your project properties."
 	/>
 </Target>


### PR DESCRIPTION
This reverts commit dfd695ece835a179dfef4bb276a5a3a6133af586.

This is because on master we have removed `armeabi` completely.
As a result we WANT to raise an error is this is used anywhere.
Its not used in the shared runtime anymore so this "fix" is
not needed.