### PR TITLE
[Xamarin.Android.Build.Tasks] fix _CopyIntermediateAssemblies outputs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1974,8 +1974,8 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_CopyIntermediateAssemblies"
-	Inputs="@(ResolvedUserAssemblies)"
-	Outputs="@(ResolvedUserAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
+	Inputs="@(ResolvedUserAssemblies);@(_AndroidResolvedSatellitePaths)"
+	Outputs="$(IntermediateOutputPath)_copyintermediate.stamp"
 	DependsOnTargets="_ResolveAssemblies;_ResolveSatellitePaths;_CreatePackageWorkspace;_CreateIntermediateAssembliesDir;_CopyConfigFiles">
 	<!-- Make a copy of every assembly we need in assemblies -->
 	<CopyIfChanged
@@ -1987,6 +1987,10 @@ because xbuild doesn't support framework reference assemblies.
 		DestinationFiles="@(_AndroidResolvedSatellitePaths->'$(MonoAndroidLinkerInputDir)%(DestinationSubDirectory)%(Filename)%(Extension)')"
 	/>
 	<Delete Files="@(ResolvedAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension).mdb')" />
+	<Touch Files="$(IntermediateOutputPath)_copyintermediate.stamp" AlwaysCreate="True" />
+	<ItemGroup>
+		<FileWrites Include="$(IntermediateOutputPath)_copyintermediate.stamp" />
+	</ItemGroup>
 </Target>
 
 <Target Name="_CollectConfigFiles"
@@ -3103,6 +3107,7 @@ because xbuild doesn't support framework reference assemblies.
 	<Delete Files="$(MonoAndroidIntermediate)stub_application_data.txt" />
 	<Delete Files="$(IntermediateOutputPath)_javac.stamp" />
 	<Delete Files="$(IntermediateOutputPath)_javastubs.stamp" />
+	<Delete Files="$(IntermediateOutputPath)_copyintermediate.stamp" />
 	<Delete Files="$(_AndroidResFlagFile)" />
 	<Delete Files="$(_AndroidLinkFlag)" />
 	<Delete Files="$(_AndroidComponentResgenFlagFile)" />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/2247
Context: https://github.com/xamarin/xamarin-android/pull/2128

The `_CopyIntermediateAssemblies` target has a bug for incremental
builds, reproduced by the following:
- Build a Xamarin.Android app project
- `touch` the project's assembly in `$(IntermediateOutputPath)`
- Build a second time. `_CopyIntermediateAssemblies` will run as
  expected.
- Build a third time. `_CopyIntermediateAssemblies` will still run!

When in this state, `_CopyIntermediateAssemblies` will always run.
This is bad because it triggers other expensive targets like
`_UpdateAndroidResgen` _every time_.

I believe I introduced this in #2128, which was when I saw
`_CopyIntermediateAssemblies` taking more time than it used to. It was
a good tradeoff though, since it prevented `_UpdateAndroidResgen` from
running too often. 15.9 does not have #2128.

To fix this problem properly, I introduced a new
`_copyintermediate.stamp` file to be used as the `Outputs` of the
target. In addition to fixing our incremental build here, there should
be performance gains in only verifying the timestamp of one file in
`Outputs`.

The `Inputs` of the `_CopyIntermediateAssemblies` were also incorrect,
as it was not using the "satellite" assembly files as an input.

This does not fully complete #2247, as there are two other targets
listed I need to investigate further. These are likely unrelated to
the changes in #2128.