### PR TITLE
[Xamarin.Android.Build.Tasks] remove unused Inputs/Outputs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1989,9 +1989,7 @@ because xbuild doesn't support framework reference assemblies.
 	<Delete Files="@(ResolvedAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension).mdb')" />
 </Target>
 
-<Target Name="_CollectConfigFiles"
-		Inputs="@(ResolvedAssemblies)"
-		Outputs="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')" >
+<Target Name="_CollectConfigFiles">
 	<GetFilesThatExist
 			Files="@(ResolvedAssemblies->'%(identity).config')">
 		<Output TaskParameter="FilesThatExist" ItemName="_ResolvedConfigFiles" />
@@ -2009,8 +2007,6 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_CollectMdbFiles"
-		Inputs="@(ResolvedAssemblies->'%(RootDir)%(Directory)%(Filename)%(Extension)')"
-		Outputs="@(ResolvedAssemblies->'%(RootDir)%(Directory)%(Filename)%(Extension).mdb')"
 		DependsOnTargets="_CollectPdbFiles">
 	<GetFilesThatExist
 			Files="@(ResolvedAssemblies->'%(RootDir)%(Directory)%(Filename)%(Extension).mdb')"
@@ -2020,9 +2016,7 @@ because xbuild doesn't support framework reference assemblies.
 	</GetFilesThatExist>
 </Target>
 
-<Target Name="_CollectPdbFiles"
-		Inputs="@(ResolvedAssemblies->'%(RootDir)%(Directory)%(Filename).pdb')"
-		Outputs="@(ResolvedAssemblies->'%(RootDir)%(Directory)%(Filename)%(Extension).mdb')">
+<Target Name="_CollectPdbFiles">
 	<CollectPdbFiles
 			ResolvedAssemblies="@(ResolvedAssemblies->'%(RootDir)%(Directory)%(Filename).pdb')">
 		<Output TaskParameter="PdbFiles" ItemName="_ResolvedPdbFiles" />


### PR DESCRIPTION
While reviewing our MSBuild targets, I noticed three targets that
declared `Inputs` and `Outputs`, but did not actually update any
files:

- `_CollectConfigFiles`
- `_CollectMdbFiles`
- `_CollectPdbFiles`

This means that MSBuild was unnecessarily looking at files to see if
they exist, and might be comparing timestamps as well. The targets
would also _always_ run, so it doesn't matter to have `Inputs` and
`Outputs` in these targets at all!

I basically removed these `Inputs` and `Outputs`, and saw a
performance gain with just doing that. I also saw performance gains to
targets that depend on these three targets. Since `Inputs` and
`Outputs` timing is internal to MSBuild, I am not sure where the
actual time is being tallied here.

    Before:
        1 ms  _CopyConfigFiles                           1 calls
        3 ms  _CopyMdbFiles                              2 calls
        3 ms  _CollectMdbFiles                           1 calls
        4 ms  _CopyPdbFiles                              1 calls
        5 ms  _CollectPdbFiles                           1 calls
        5 ms  _CollectConfigFiles                        1 calls
       20 ms  _ConvertPdbFiles                           1 calls

A total of ~46ms

    After:
        0 ms  _ConvertPdbFiles                           1 calls
        0 ms  _CopyPdbFiles                              1 calls
        1 ms  _CollectMdbFiles                           1 calls
        1 ms  _CopyMdbFiles                              2 calls
        1 ms  _CopyConfigFiles                           1 calls
        2 ms  _CollectConfigFiles                        1 calls
        5 ms  _CollectPdbFiles                           1 calls

A total of ~10ms

An overall improvement of ~36ms.

This was the `samples/HelloWorld` project in this repo, a build with
no changes. I suspect the improvement would be even better for larger
projects.