### PR TITLE
Typo Fix in EnumFields.xml

### DIFF
--- a/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding/Transforms/EnumFields.xml
+++ b/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv1Binding/Transforms/EnumFields.xml
@@ -9,7 +9,7 @@
     <field clr-name="Id" jni-name="Fragment_id" value="1" />
     <field clr-name="Name" jni-name="Fragment_name" value="0" />
     <field clr-name="Tag" jni-name="Fragment_tag" value="2" />
-  </type>
+  </mapping>
 
   Notes:
   - An optional "bitfield" attribute marks the enum type with [Flags].

--- a/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding/Transforms/EnumFields.xml
+++ b/tests/CodeGen-Binding/Xamarin.Android.FixJavaAbstractMethod-APIv2Binding/Transforms/EnumFields.xml
@@ -9,7 +9,7 @@
     <field clr-name="Id" jni-name="Fragment_id" value="1" />
     <field clr-name="Name" jni-name="Fragment_name" value="0" />
     <field clr-name="Tag" jni-name="Fragment_tag" value="2" />
-  </type>
+  </mapping>
 
   Notes:
   - An optional "bitfield" attribute marks the enum type with [Flags].

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib1/Transforms/EnumFields.xml
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib1/Transforms/EnumFields.xml
@@ -9,7 +9,7 @@
     <field clr-name="Id" jni-name="Fragment_id" value="1" />
     <field clr-name="Name" jni-name="Fragment_name" value="0" />
     <field clr-name="Tag" jni-name="Fragment_tag" value="2" />
-  </type>
+  </mapping>
 
   Notes:
   - An optional "bitfield" attribute marks the enum type with [Flags].

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib2/Transforms/EnumFields.xml
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib2/Transforms/EnumFields.xml
@@ -9,7 +9,7 @@
     <field clr-name="Id" jni-name="Fragment_id" value="1" />
     <field clr-name="Name" jni-name="Fragment_name" value="0" />
     <field clr-name="Tag" jni-name="Fragment_tag" value="2" />
-  </type>
+  </mapping>
 
   Notes:
   - An optional "bitfield" attribute marks the enum type with [Flags].

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib3/Transforms/EnumFields.xml
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib3/Transforms/EnumFields.xml
@@ -9,7 +9,7 @@
     <field clr-name="Id" jni-name="Fragment_id" value="1" />
     <field clr-name="Name" jni-name="Fragment_name" value="0" />
     <field clr-name="Tag" jni-name="Fragment_tag" value="2" />
-  </type>
+  </mapping>
 
   Notes:
   - An optional "bitfield" attribute marks the enum type with [Flags].

--- a/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib4/Transforms/EnumFields.xml
+++ b/tests/ResolveImports/Xamarin.Android.BindingResolveImportLib4/Transforms/EnumFields.xml
@@ -9,7 +9,7 @@
     <field clr-name="Id" jni-name="Fragment_id" value="1" />
     <field clr-name="Name" jni-name="Fragment_name" value="0" />
     <field clr-name="Tag" jni-name="Fragment_tag" value="2" />
-  </type>
+  </mapping>
 
   Notes:
   - An optional "bitfield" attribute marks the enum type with [Flags].


### PR DESCRIPTION
Some binding template file contains invalid closing tag.
These tags are in comment-out filed, so this PR will not affect other codes.

The fundamental solution is to fix following file, but I do not have access to repository that contains that file...

```
# ~/Projects/github.com/yamachu/xamarin-android $ [typo/android-binding-enum-mapping]
cat /Applications/Visual\ Studio.app/Contents/Resources/lib/monodevelop/AddIns/MonoDevelop.MonoDroid/templates/Project/BindingProject/EnumFields.xml
<enum-field-mappings>
  <!--
  This example converts the constants Fragment_id, Fragment_name,
  and Fragment_tag from android.support.v4.app.FragmentActivity.FragmentTag
  to an enum called Android.Support.V4.App.FragmentTagType with values
  Id, Name, and Tag.

  <mapping clr-enum-type="Android.Support.V4.App.FragmentTagType" jni-class="android/support/v4/app/FragmentActivity$FragmentTag">
    <field clr-name="Id" jni-name="Fragment_id" value="1" />
    <field clr-name="Name" jni-name="Fragment_name" value="0" />
    <field clr-name="Tag" jni-name="Fragment_tag" value="2" />
  </type>

  Notes:
  - An optional "bitfield" attribute marks the enum type with [Flags].
  - For Java interfaces, use "jni-interface" attribute instead of "jni-class" attribute.
  -->
</enum-field-mappings>
%
```

Although the format of following files are different from the current one, the closing tag is correct so I did not modify it.
https://github.com/xamarin/xamarin-android/blob/master/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Transforms/EnumFields.xml
https://github.com/xamarin/xamarin-android/blob/master/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests/Transforms/EnumFields.xml