### PR TITLE
[Xamarin.Android.Build.Tasks] Fix Error in `CompileToDalvik`.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileToDalvik.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileToDalvik.cs
@@ -134,11 +134,10 @@ namespace Xamarin.Android.Tasks
 				} else {
 					Log.LogDebugMessage ("  processing ClassesOutputDirectory...");
 					var zip = Path.GetFullPath (Path.Combine (ClassesOutputDirectory, "..", "classes.zip"));
-					if (!File.Exists (zip)) {
-						throw new FileNotFoundException ($"'{zip}' does not exist. Please rebuild the project.");
+					if (File.Exists (zip)) {
+						Log.LogDebugMessage ($"    {zip}");
+						sw.WriteLine (Path.GetFullPath (zip));
 					}
-					Log.LogDebugMessage ($"    {zip}");
-					sw.WriteLine (Path.GetFullPath (zip));
 					foreach (var jar in JavaLibrariesToCompile) {
 						var fullPath = Path.GetFullPath (jar.ItemSpec);
 						Log.LogDebugMessage ($"    {fullPath}");


### PR DESCRIPTION
When using the InstantRun feature we are seeing the following
error.

	error MSB6003: The specified task executable "java" could not be run. '{path}obj/Debug/lp/2/classes.zip' does not exist. Please rebuild the project.

This is because `_CompileToDalvikLibraryJars` runs to compile
the various `.jar` files into `.dex` files for each library.
This helps to speed up incremental builds.

However the `classes.zip` will NOT exist
in these `lp` directories and nor should it.
So rather than throwing an error lets just not include
the file if it does not exist.