### PR TITLE
Disable ILRepack target on Linux

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/ILRepack.targets
+++ b/src/Xamarin.Android.Build.Tasks/ILRepack.targets
@@ -4,7 +4,7 @@
 	<PropertyGroup>
 		<_ILRepacker_stamp>$(IntermediateOutputPath)ILRepacker.stamp</_ILRepacker_stamp>
 	</PropertyGroup>
-	<Target Name="ILRepacker"
+	<Target Name="ILRepacker" Condition=" '$(HostOS)' != 'Linux' "
 			AfterTargets="AfterBuild"
 			Inputs="$(OutputPath)\$(AssemblyName).dll"
 			Outputs="$(_ILRepacker_stamp)">


### PR DESCRIPTION
When building the `Xamarin.Android.Build.Tasks.dll` assembly we merge it with a
number of assemblies in order to avoid problems when the IDE loads a different
version of any of those assemblies, which can potentially break XA.

Unfortunately, the merging process crashes the build on Linux:

```
Stacktrace:

  at <unknown> <0xffffffff>
  at (wrapper managed-to-native) System.MonoCustomAttrs.IsDefinedInternal (System.Reflection.ICustomAttributeProvider,System.Type) [0x00021] in <fb4ca01ee4cf488c95b864932a850791>:0
  at System.MonoCustomAttrs.IsDefined (System.Reflection.ICustomAttributeProvider,System.Type,bool) [0x00027] in <fb4ca01ee4cf488c95b864932a850791>:0
  at System.RuntimeType.IsDefined (System.Type,bool) [0x00038] in <fb4ca01ee4cf488c95b864932a850791>:0
  at Microsoft.Build.Shared.LoadedType.HasLoadInSeparateAppDomainAttribute () [0x00024] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at Microsoft.Build.Shared.LoadedType..ctor (System.Type,Microsoft.Build.Shared.AssemblyLoadInfo,System.Reflection.Assembly) [0x00041] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at Microsoft.Build.Shared.TypeLoader/AssemblyInfoToLoadedTypes.GetLoadedTypeByTypeName (string) [0x0005a] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at Microsoft.Build.Shared.TypeLoader.GetLoadedType (System.Collections.Concurrent.ConcurrentDictionary`2<System.Func`3<System.Type, object, bool>, System.Collections.Concurrent.ConcurrentDictionary`2<Microsoft.Build.Shared.AssemblyLoadInfo, Microsoft.Build.Shared.TypeLoader/AssemblyInfoToLoadedTypes>>,string,Microsoft.Build.Shared.AssemblyLoadInfo) [0x00042] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at Microsoft.Build.Shared.TypeLoader.Load (string,Microsoft.Build.Shared.AssemblyLoadInfo) [0x00008] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at Microsoft.Build.BackEnd.AssemblyTaskFactory.InitializeFactory (Microsoft.Build.Shared.AssemblyLoadInfo,string,System.Collections.Generic.IDictionary`2<string, Microsoft.Build.Framework.TaskPropertyInfo>,string,System.Collections.Generic.IDictionary`2<string, string>,bool,Microsoft.Build.BackEnd.Logging.TargetLoggingContext,Microsoft.Build.Construction.ElementLocation,string) [0x00058] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at Microsoft.Build.Execution.TaskRegistry/RegisteredTaskRecord.GetTaskFactory (Microsoft.Build.BackEnd.Logging.TargetLoggingContext,Microsoft.Build.Construction.ElementLocation,string) [0x000b8] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at Microsoft.Build.Execution.TaskRegistry/RegisteredTaskRecord.CanTaskBeCreatedByFactory (string,string,System.Collections.Generic.IDictionary`2<string, string>,Microsoft.Build.BackEnd.Logging.TargetLoggingContext,Microsoft.Build.Construction.ElementLocation) [0x0003b] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at Microsoft.Build.Execution.TaskRegistry.GetMatchingRegistration (string,System.Collections.Generic.List`1<Microsoft.Build.Execution.TaskRegistry/RegisteredTaskRecord>,string,System.Collections.Generic.IDictionary`2<string, string>,Microsoft.Build.BackEnd.Logging.TargetLoggingContext,Microsoft.Build.Construction.ElementLocation) [0x0001a] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at Microsoft.Build.Execution.TaskRegistry.GetTaskRegistrationRecord (string,string,System.Collections.Generic.IDictionary`2<string, string>,bool,Microsoft.Build.BackEnd.Logging.TargetLoggingContext,Microsoft.Build.Construction.ElementLocation,bool&) [0x00169] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at Microsoft.Build.Execution.TaskRegistry.GetRegisteredTask (string,string,System.Collections.Generic.IDictionary`2<string, string>,bool,Microsoft.Build.BackEnd.Logging.TargetLoggingContext,Microsoft.Build.Construction.ElementLocation) [0x00010] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at Microsoft.Build.BackEnd.TaskExecutionHost.FindTaskInRegistry (System.Collections.Generic.IDictionary`2<string, string>) [0x00064] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.FindTask (System.Collections.Generic.IDictionary`2<string, string>) [0x0000b] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at Microsoft.Build.BackEnd.TaskBuilder/<ExecuteBucket>d__19.MoveNext () [0x0011e] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<Microsoft.Build.BackEnd.WorkUnitResult>.Start<Microsoft.Build.BackEnd.TaskBuilder/<ExecuteBucket>d__19> (Microsoft.Build.BackEnd.TaskBuilder/<ExecuteBucket>d__19&) [0x00033] in <fb4ca01ee4cf488c95b864932a850791>:0
  at Microsoft.Build.BackEnd.TaskBuilder.ExecuteBucket (Microsoft.Build.BackEnd.TaskHost,Microsoft.Build.BackEnd.ItemBucket,Microsoft.Build.BackEnd.TaskExecutionMode,System.Collections.Generic.Dictionary`2<string, string>) [0x00048] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at Microsoft.Build.BackEnd.TaskBuilder/<ExecuteTask>d__18.MoveNext () [0x0016a] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<Microsoft.Build.BackEnd.WorkUnitResult>.Start<Microsoft.Build.BackEnd.TaskBuilder/<ExecuteTask>d__18> (Microsoft.Build.BackEnd.TaskBuilder/<ExecuteTask>d__18&) [0x00033] in <fb4ca01ee4cf488c95b864932a850791>:0
  at Microsoft.Build.BackEnd.TaskBuilder.ExecuteTask (Microsoft.Build.BackEnd.TaskExecutionMode,Microsoft.Build.BackEnd.Lookup) [0x00037] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at Microsoft.Build.BackEnd.TaskBuilder/<ExecuteTask>d__13.MoveNext () [0x00193] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<Microsoft.Build.BackEnd.WorkUnitResult>.Start<Microsoft.Build.BackEnd.TaskBuilder/<ExecuteTask>d__13> (Microsoft.Build.BackEnd.TaskBuilder/<ExecuteTask>d__13&) [0x00033] in <fb4ca01ee4cf488c95b864932a850791>:0
  at Microsoft.Build.BackEnd.TaskBuilder.ExecuteTask (Microsoft.Build.BackEnd.Logging.TargetLoggingContext,Microsoft.Build.BackEnd.BuildRequestEntry,Microsoft.Build.BackEnd.ITargetBuilderCallback,Microsoft.Build.Execution.ProjectTargetInstanceChild,Microsoft.Build.BackEnd.TaskExecutionMode,Microsoft.Build.BackEnd.Lookup,Microsoft.Build.BackEnd.Lookup,System.Threading.CancellationToken) [0x0006c] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at Microsoft.Build.BackEnd.TargetEntry/<ProcessBucket>d__52.MoveNext () [0x00091] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<Microsoft.Build.BackEnd.WorkUnitResult>.Start<Microsoft.Build.BackEnd.TargetEntry/<ProcessBucket>d__52> (Microsoft.Build.BackEnd.TargetEntry/<ProcessBucket>d__52&) [0x00033] in <fb4ca01ee4cf488c95b864932a850791>:0
  at Microsoft.Build.BackEnd.TargetEntry.ProcessBucket (Microsoft.Build.BackEnd.ITaskBuilder,Microsoft.Build.BackEnd.Logging.TargetLoggingContext,Microsoft.Build.BackEnd.TaskExecutionMode,Microsoft.Build.BackEnd.Lookup,Microsoft.Build.BackEnd.Lookup) [0x00051] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at Microsoft.Build.BackEnd.TargetEntry/<ExecuteTarget>d__45.MoveNext () [0x002bb] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start<Microsoft.Build.BackEnd.TargetEntry/<ExecuteTarget>d__45> (Microsoft.Build.BackEnd.TargetEntry/<ExecuteTarget>d__45&) [0x00033] in <fb4ca01ee4cf488c95b864932a850791>:0
  at Microsoft.Build.BackEnd.TargetEntry.ExecuteTarget (Microsoft.Build.BackEnd.ITaskBuilder,Microsoft.Build.BackEnd.BuildRequestEntry,Microsoft.Build.BackEnd.Logging.ProjectLoggingContext,System.Threading.CancellationToken) [0x00048] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at Microsoft.Build.BackEnd.TargetBuilder/<ProcessTargetStack>d__21.MoveNext () [0x00430] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at System.Runtime.CompilerServices.AsyncMethodBuilderCore/MoveNextRunner.InvokeMoveNext (object) [0x00000] in <fb4ca01ee4cf488c95b864932a850791>:0
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext,System.Threading.ContextCallback,object,bool) [0x00071] in <fb4ca01ee4cf488c95b864932a850791>:0
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext,System.Threading.ContextCallback,object,bool) [0x00000] in <fb4ca01ee4cf488c95b864932a850791>:0
  at System.Runtime.CompilerServices.AsyncMethodBuilderCore/MoveNextRunner.Run () [0x00024] in <fb4ca01ee4cf488c95b864932a850791>:0
  at System.Threading.Tasks.TaskSchedulerAwaitTaskContinuation/<>c.<Run>b__2_0 (object) [0x00000] in <fb4ca01ee4cf488c95b864932a850791>:0
  at System.Threading.Tasks.Task.InnerInvoke () [0x00025] in <fb4ca01ee4cf488c95b864932a850791>:0
  at System.Threading.Tasks.Task.Execute () [0x00000] in <fb4ca01ee4cf488c95b864932a850791>:0
  at System.Threading.Tasks.Task.ExecutionContextCallback (object) [0x00000] in <fb4ca01ee4cf488c95b864932a850791>:0
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext,System.Threading.ContextCallback,object,bool) [0x00071] in <fb4ca01ee4cf488c95b864932a850791>:0
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext,System.Threading.ContextCallback,object,bool) [0x00000] in <fb4ca01ee4cf488c95b864932a850791>:0
  at System.Threading.Tasks.Task.ExecuteWithThreadLocal (System.Threading.Tasks.Task&) [0x00034] in <fb4ca01ee4cf488c95b864932a850791>:0
  at System.Threading.Tasks.Task.ExecuteEntry (bool) [0x0004a] in <fb4ca01ee4cf488c95b864932a850791>:0
  at System.Threading.Tasks.TaskScheduler.TryExecuteTask (System.Threading.Tasks.Task) [0x00014] in <fb4ca01ee4cf488c95b864932a850791>:0
  at Microsoft.Build.BackEnd.RequestBuilder/DedicatedThreadsTaskScheduler.<InjectThread>b__6_0 () [0x0001c] in <63bca7756d124ea392a81ca1b2d26b9c>:0
  at System.Threading.ThreadHelper.ThreadStart_Context (object) [0x00014] in <fb4ca01ee4cf488c95b864932a850791>:0
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext,System.Threading.ContextCallback,object,bool) [0x00071] in <fb4ca01ee4cf488c95b864932a850791>:0
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext,System.Threading.ContextCallback,object,bool) [0x00000] in <fb4ca01ee4cf488c95b864932a850791>:0
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext,System.Threading.ContextCallback,object) [0x0002b] in <fb4ca01ee4cf488c95b864932a850791>:0
  at System.Threading.ThreadHelper.ThreadStart () [0x00008] in <fb4ca01ee4cf488c95b864932a850791>:0
  at (wrapper runtime-invoke) object.runtime_invoke_void__this__ (object,intptr,intptr,intptr) [0x00020] in <fb4ca01ee4cf488c95b864932a850791>:0
/proc/self/maps:
4064c000-4065c000 rwxp 00000000 00:00 0
408f7000-40c47000 rwxp 00000000 00:00 0
55fb7f664000-55fb7fab7000 r-xp 00000000 08:11 3816145                    /usr/bin/mono-sgen
55fb7fcb7000-55fb7fcbd000 r--p 00453000 08:11 3816145                    /usr/bin/mono-sgen
55fb7fcbd000-55fb7fcc3000 rw-p 00459000 08:11 3816145                    /usr/bin/mono-sgen
55fb7fcc3000-55fb7fcd9000 rw-p 00000000 00:00 0
55fb819db000-55fb821ec000 rw-p 00000000 00:00 0                          [heap]
7fc193300000-7fc193400000 rw-p 00000000 00:00 0
7fc193500000-7fc193600000 rw-p 00000000 00:00 0
7fc193700000-7fc193800000 rw-p 00000000 00:00 0
7fc193874000-7fc1938f4000 rw-p 00000000 00:00 0
7fc1938f8000-7fc193978000 rw-p 00000000 00:00 0
7fc19397c000-7fc1939fc000 rw-p 00000000 00:00 0
7fc193a00000-7fc193b00000 rw-p 00000000 00:00 0
7fc193b7c000-7fc193bfc000 rw-p 00000000 00:00 0
7fc193c00000-7fc193d00000 rw-p 00000000 00:00 0
7fc193d7c000-7fc193dfc000 rw-p 00000000 00:00 0
7fc193e00000-7fc193f00000 rw-p 00000000 00:00 0
7fc193f7c000-7fc193ffc000 rw-p 00000000 00:00 0
7fc194000000-7fc194021000 rw-p 00000000 00:00 0
7fc194021000-7fc198000000 ---p 00000000 00:00 0
7fc19806b000-7fc198107000 r--p 00000000 08:11 3944020                    /mnt/jenkins/workspace/xamarin-android-linux/xamarin-android/packages/NuGet.Protocol.4.6.0/lib/net46/NuGet.Protocol.dll
7fc198107000-7fc1981aa000 r--p 00000000 08:11 3943977                    /mnt/jenkins/workspace/xamarin-android-linux/xamarin-android/packages/Newtonsoft.Json.11.0.1/lib/net45/Newtonsoft.Json.dll
7fc1981aa000-7fc198300000 r--p 00000000 08:11 3943944                    /mnt/jenkins/workspace/xamarin-android-linux/xamarin-android/packages/FSharp.Core.3.1.2.5/lib/net40/FSharp.Core.dll
7fc198300000-7fc198400000 rw-p 00000000 00:00 0
Memory around native instruction pointer (0x55fb7f867330):
0x55fb7f867320  dc ff 11 00 ba f4 04 00 00 31 c0 e8 e0 69 11 00  .........1...i..
0x55fb7f867330  8b 06 48 83 c4 08 c3 66 0f 1f 84 00 00 00 00 00  ..H....f........
0x55fb7f867340  0f b7 06 48 83 c4 08 c3 0f 1f 84 00 00 00 00 00  ...H............
0x55fb7f867350  0f be 06 48 83 c4 08 c3 0f 1f 84 00 00 00 00 00  ...H............

Native stacktrace:

	/usr/bin/mono(+0x131d0d) [0x55fb7f795d0d]
	/usr/bin/mono(+0x131fb8) [0x55fb7f795fb8]
	/usr/bin/mono(+0xc5e3f) [0x55fb7f729e3f]
	/usr/bin/mono(+0x45262) [0x55fb7f6a9262]
	/lib/x86_64-linux-gnu/libpthread.so.0(+0x110c0) [0x7fc1f514e0c0]
	/usr/bin/mono(mono_metadata_decode_row_col+0x90) [0x55fb7f867330]
	/usr/bin/mono(+0x2034f9) [0x55fb7f8674f9]
	/usr/bin/mono(+0x3137cd) [0x55fb7f9777cd]
	/usr/bin/mono(mono_metadata_custom_attrs_from_index+0x61) [0x55fb7f869a91]
	/usr/bin/mono(+0x2847a5) [0x55fb7f8e87a5]
	/usr/bin/mono(+0x28577c) [0x55fb7f8e977c]
	/usr/bin/mono(+0x1e4173) [0x55fb7f848173]
```

The working theory is that it happens because the mmapped assembly data is
modified when the on-disk file is rewritten but Mono fails to see that and uses
the old metadata for the image - with the old pointers, offsets, sizes etc, now
pointing to invalid locations. Unfortunately, there's no obvious and quick fix
to this issue so this commit skips the ILRepack step when building on Linux
instead. This will *not* affect usage of XA on Linux since the merging process
is needed only for the IDEs, as previously mentioned. Builds, testing, deploying
etc from Linux will work as usual.