### PR TITLE
 [build] use <ProjectReference /> instead of <MSBuild />

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -5,20 +5,12 @@
   <PropertyGroup>
     <BuildDependsOn>
       ResolveReferences;
-      _CopyBootstrapTasksAssembly;
       _DownloadItems;
       _UnzipFiles;
       _CreateMxeToolchains;
       _AcceptAndroidSdkLicenses;
     </BuildDependsOn>
   </PropertyGroup>
-  <Target Name="_CopyBootstrapTasksAssembly"
-      Outputs="$(OutputPath)\Xamarin.Android.Tools.BootstrapTasks.dll">
-    <MSBuild
-        Projects="..\Xamarin.Android.Tools.BootstrapTasks\Xamarin.Android.Tools.BootstrapTasks.csproj"
-        Properties="OutputPath=$(AndroidToolchainDirectory)\"
-    />
-  </Target>
   <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.UnzipDirectoryChildren" />
   <Target Name="_DetermineItems">
     <CreateItem

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -346,6 +346,11 @@
       <Name>api-merge</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\..\build-tools\api-xml-adjuster\api-xml-adjuster.csproj">
+      <Project>{8A6CB07C-E493-4A4F-AB94-038645A27118}</Project>
+      <Name>api-xml-adjuster</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
     <ProjectReference Include="..\..\build-tools\jnienv-gen\jnienv-gen.csproj">
       <Project>{AFB8F6D1-6EA9-42C3-950B-98F34C669AD2}</Project>
       <Name>jnienv-gen</Name>

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -54,18 +54,10 @@
   </Target>
   <Target Name="_GenerateApiDescription"
       BeforeTargets="_GenerateBinding"
+      DependsOnTargets="ResolveReferences"
       Inputs="..\..\bin\Build$(Configuration)\api\api-$(AndroidPlatformId).xml.in"
       Outputs="$(IntermediateOutputPath)mcw\api.xml">
     <MakeDir Directories="$(IntermediateOutputPath)mcw" />
-    <!-- This build targets is lame and designed in bogus mindset. ProjectReference is never designed properly to resolve required build
-    steps in explicitly-specifiable manner, and this target is actually
-    being built before ProjectReferences, therefore manual MSBuild
-    invocation is mandatory.
-    
-    It is a result of lame dependency resolution hack, or design mistake
-    by choosing bogus technology called MSBuild.
-    -->
-    <MSBuild Projects="..\..\build-tools\api-xml-adjuster\api-xml-adjuster.csproj" />
     <ItemGroup>
       <_AndroidProfile Include="..\..\bin\Build$(Configuration)\api\api-*.xml.in" />
     </ItemGroup>


### PR DESCRIPTION
We have something weird going when building Xamarin.Android itself:

    msbuild Xamarin.Android.sln
    msbuild Xamarin.Android.sln

You would assume that the second command would be a no-op, but it's
not...

`xa-prep-tasks.csproj` and `Xamarin.Android.Tools.BootstrapTasks`
seems to build *every* time. You can see the `CoreCompile` target
running, which is even worse on Windows, where the output assembly
file might be locked!

I found two cases where we are calling the `<MSBuild/>` MSBuild task,
where `<ProjectReference/>` would be more appropriate:

- `android-toolchain.targets` - had an `<MSBuild />` call to build
  `Xamarin.Android.Tools.BootstrapTasks`, but it *also* had a
  `<ProjectReference/>`. Removing it worked fine, and solved the
  problem.
- `Mono.Android.targets` - was manually building `api-xml-adjuster`.
  `<ProjectReference/>` would have worked fine here, but you need
  `DependsOnTargets="ResolveReferences"` for it to work.

There are still additional MSBuild targets in our build that are
running every time, but this is a decent start to fix some of them.