### PR TITLE
[build] <AcceptAndroidSdkLicense/> should not always run

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -8,7 +8,6 @@
       _DownloadItems;
       _UnzipFiles;
       _CreateMxeToolchains;
-      _AcceptAndroidSdkLicenses;
     </BuildDependsOn>
   </PropertyGroup>
   <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.UnzipDirectoryChildren" />
@@ -88,13 +87,11 @@
         SourceFiles="@(_PlatformAntItem->'$(AndroidToolchainCacheDirectory)\%(Identity).zip')"
         DestinationFolder="$(AntDirectory)"
     />
+    <AcceptAndroidSdkLicenses AndroidSdkDirectory="$(AndroidSdkDirectory)" JavaSdkDirectory="$(JavaSdkDirectory)" />
     <Touch
         Files="@(_SdkStampFiles);$(AndroidToolchainDirectory)\ndk\.stamp-ndk"
         AlwaysCreate="True"
     />
-  </Target>
-  <Target Name="_AcceptAndroidSdkLicenses">
-    <AcceptAndroidSdkLicenses AndroidSdkDirectory="$(AndroidSdkDirectory)" JavaSdkDirectory="$(JavaSdkDirectory)" />
   </Target>
   <Target Name="_CreateMxeToolchains"
       Condition=" '$(HostOS)' != 'Windows' And '$(NeedMxe)' == 'true' And ($(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:')))"


### PR DESCRIPTION
On my machine, `<AcceptAndroidSdkLicense/>` is taking about ~1.5 sec
and runs even in a build with no changes.

We can run it as part of the `_UnzipFiles` target, removing the
`_AcceptAndroidSdkLicenses` target completely. We only need to
re-accept the licenses after new zip files are extracted.

This should save us about 1.5 seconds on any incremental build of
Xamarin.Android itself.