### PR TITLE
[Mono.Android] Obsolete Mono.Android.dll for < API-19

### DIFF
--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -3,6 +3,11 @@
        regarded as obfuscated, so avoid that by explicitly marking not. -->
   <attr path="/api/package[@name='android']/class[@name='Manifest.permission']" name="obfuscated">false</attr>
 
+  <attr api-since="1" api-until="18" path="/api/package/class" name="deprecated"
+    >The assembly `Mono.Android.dll` for this API level will be removed in a future release.  Please update your `$(TargetFrameworkVersion)` to be v4.4 or greater.</attr>
+  <attr api-since="1" api-until="18" path="/api/package/interface" name="deprecated"
+    >The assembly `Mono.Android.dll` for this API level will be removed in a future release.  Please update your `$(TargetFrameworkVersion)` to be v4.4 or greater.</attr>
+
   <!-- FIXME: we should remove this fixup in the future release. It was
   introduced due to mismatching enum use, and we already marked the API as
   [Obsolete] -->


### PR DESCRIPTION
Fixes: http://work.devdiv.io/712427

For the next major release of Visual Studio, Xamarin.Android will stop
building and distributing `Mono.Android.dll` for:

  * v2.3 (API-10)
  * v4.0.3 (API-15)
  * v4.1 (API-16)
  * v4.2 (API-17)
  * v4.3 (API-18)

This will be done for the following reasons:

 1. Support for API-10 and API-15 will be dropped from the
    [Android NDK][0]:

    > Support for ICS (android-14 and android-15) will be removed from r18

 2. The [Android Support Library][1], as of release 26.0.0
    (July 2017), requires API-14 or higher:

    > Starting with Support Library version 26.0.0 (released in July 2017),
    > the minimum supported API level has changed to Android 4.0 (API level 14)
    > for all support library packages.

 3. The Android Support Library replacement, [AndroidX][2], requires
    a `compileSdkVersion` minimum value of API-28 (v9.0).

 4. As of 2018-Oct-22, the [Android Distribution Dashboard][3] shows
    that only ~3.8% of devices hitting the Google Play Store are
    running Android 4.3 (API-18) or earlier.

We want to provide a "heads-up" that these assemblies will be removed,
to give our customers an opportunity to bump their
`$(TargetFrameworkVersion)` to v4.4 or later.

To do so, add `/package/class/@deprecated` and
`/package/interface/@deprecated` XML attribute to *all bound types*,
via `metadata`, for API levels 1 through 18.  This will cause all
types to contain the following additional `[Obsolete]`:

	[ObsoleteAttribute (@"The assembly `Mono.Android.dll` for this API level will be removed in a future release.  Please bump your `$(TargetFrameworkVersion)` to be v4.4 or greater.")]

If one of these types is used from a project referencing a
`Mono.Android.dll` of v4.3 or earlier, the compiler will generate the
following warning for all such referenced types:

	MainActivity.cs(30,30): Warning CS0618: 'Activity' is obsolete:
	'The assembly `Mono.Android.dll` for this API level will be removed in a future release.
	Please bump your `$(TargetFrameworkVersion)` to be v4.4 or greater.'

[0]: https://developer.android.com/ndk/downloads/revision_history
[1]: https://developer.android.com/topic/libraries/support-library/
[2]: https://developer.android.com/jetpack/androidx/
[3]: https://developer.android.com/about/dashboards/