### PR TITLE
[Linux, build] Ignore more native Windows binaries on packaging

### DIFF
--- a/build-tools/debian-metadata/rules
+++ b/build-tools/debian-metadata/rules
@@ -16,6 +16,9 @@ override_dh_shlibdeps:
 
 override_dh_install:
 	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/cross-*.exe*
+	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/llc.exe
+	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/opt.exe
+
 	dh_install
 
 override_dh_clideps:


### PR DESCRIPTION
Augment https://github.com/xamarin/xamarin-android/commit/01578999d04d5510a2e2680f805e803e65c76467 to ignore a couple more native Windows binaries when building a Debian package.
