### PR TITLE
[Linux,Build] Additional LLVM32 build dependencies added

### DIFF
--- a/build-tools/scripts/dependencies/linux-prepare-Debian.sh
+++ b/build-tools/scripts/dependencies/linux-prepare-Debian.sh
@@ -4,4 +4,10 @@ DISTRO_DEPS="$DEBIAN_COMMON_DEPS \
     zlib1g-dev
 "
 
+if [ "$OS_ARCH" = "x86_64" ]; then
+	DISTRO_DEPS="$DISTRO_DEPS lib32tinfo-dev"
+else
+	DISTRO_DEPS="$DISTRO_DEPS lib64ncurses5-dev"
+fi
+
 debian_install

--- a/build-tools/scripts/dependencies/linux-prepare-LinuxMint.sh
+++ b/build-tools/scripts/dependencies/linux-prepare-LinuxMint.sh
@@ -2,6 +2,12 @@
 
 DISTRO_DEPS="$DEBIAN_COMMON_DEPS"
 
+if [ "$OS_ARCH" = "x86_64" ]; then
+    DISTRO_DEPS="$DISTRO_DEPS lib32tinfo-dev"
+else
+    DISTRO_DEPS="$DISTRO_DEPS libtinfo-dev"
+fi
+
 MAJOR=$(echo $1 | cut -d '.' -f 1)
 MINOR=$(echo $1 | cut -d '.' -f 2)
 

--- a/build-tools/scripts/dependencies/linux-prepare-Ubuntu.sh
+++ b/build-tools/scripts/dependencies/linux-prepare-Ubuntu.sh
@@ -2,6 +2,12 @@
 
 DISTRO_DEPS="$DEBIAN_COMMON_DEPS"
 
+if [ "$OS_ARCH" = "x86_64" ]; then
+	DISTRO_DEPS="$DISTRO_DEPS lib32ncurses-dev "
+else
+	DISTRO_DEPS="$DISTRO_DEPS lib64ncurses-dev"
+fi
+
 MAJOR=$(echo $1 | cut -d '.' -f 1)
 MINOR=$(echo $1 | cut -d '.' -f 2)
 


### PR DESCRIPTION
The new LLVM used by Mono requires the `libtinfo.so` library both for 64-bit and
32-bit builds. Add appropriate packages to the list of dependencies.