### PR TITLE
[Xamarin.Android.Build.Tasks] target to simplify @(FileWrites)

### DIFF
--- a/Documentation/guides/MSBuildBestPractices.md
+++ b/Documentation/guides/MSBuildBestPractices.md
@@ -220,8 +220,16 @@ We should also name the stamp file the same as the target, such as:
     Outputs="$(_AndroidStampDirectory)_ResolveLibraryProjectImports.stamp">
   <!-- ... -->
   <Touch Files="$(_AndroidStampDirectory)_ResolveLibraryProjectImports.stamp" AlwaysCreate="True" />
+</Target>
+```
+
+Do we need `FileWrites` here? Nope. The `_AddFilesToFileWrites`
+target takes care of it, so we can't as easily mess it up:
+
+```xml
+<Target Name="_AddFilesToFileWrites" BeforeTargets="IncrementalClean">
   <ItemGroup>
-    <FileWrites Include="$(_AndroidStampDirectory)_ResolveLibraryProjectImports.stamp" />
+    <FileWrites Include="$(_AndroidStampDirectory)*.stamp" />
   </ItemGroup>
 </Target>
 ```

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -469,7 +469,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <Touch Files="$(_AndroidStampDirectory)_BuildAdditionalResourcesCache.stamp" AlwaysCreate="True" />
   <ItemGroup>
     <FileWrites Include="$(_AndroidResourcePathsCache)" Condition=" Exists ('$(_AndroidResourcePathsCache)') " />
-    <FileWrites Include="$(_AndroidStampDirectory)_BuildAdditionalResourcesCache.stamp" />
   </ItemGroup>
 </Target>
 
@@ -662,9 +661,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <CallTarget Targets="_CleanMonoAndroidIntermediateDir" Condition=" Exists ('$(_AndroidStampDirectory)_CleanIntermediateIfNuGetsChange.stamp') " />
   <MakeDir Directories="$(_AndroidStampDirectory)" Condition=" !Exists('$(_AndroidStampDirectory)') " />
   <Touch Files="$(_AndroidStampDirectory)_CleanIntermediateIfNuGetsChange.stamp" AlwaysCreate="true" />
-  <ItemGroup>
-    <FileWrites Include="$(_AndroidStampDirectory)_CleanIntermediateIfNuGetsChange.stamp" />
-  </ItemGroup>
 </Target>
 
 <Target Name="_ResolveMonoAndroidFramework" DependsOnTargets="GetReferenceAssemblyPaths" >
@@ -1323,9 +1319,6 @@ because xbuild doesn't support framework reference assemblies.
 		OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)">
 	</ResolveLibraryProjectImports>
 	<Touch Files="$(_AndroidStampDirectory)_ResolveLibraryProjectImports.stamp" AlwaysCreate="True" />
-	<ItemGroup>
-		<FileWrites Include="$(_AndroidStampDirectory)_ResolveLibraryProjectImports.stamp" />
-	</ItemGroup>
 </Target>
 
 <Target Name="_CollectLibraryResourceDirectories"
@@ -1990,9 +1983,6 @@ because xbuild doesn't support framework reference assemblies.
 	/>
 	<Delete Files="@(ResolvedAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension).mdb')" />
 	<Touch Files="$(_AndroidStampDirectory)_CopyIntermediateAssemblies.stamp" AlwaysCreate="True" />
-	<ItemGroup>
-		<FileWrites Include="$(_AndroidStampDirectory)_CopyIntermediateAssemblies.stamp" />
-	</ItemGroup>
 </Target>
 
 <Target Name="_CollectConfigFiles">
@@ -2298,9 +2288,6 @@ because xbuild doesn't support framework reference assemblies.
     TargetFrameworkVersion="$(TargetFrameworkVersion)" 
     Manifest="$(IntermediateOutputPath)android\AndroidManifest.xml" />
   <Touch Files="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp" AlwaysCreate="True" />
-  <ItemGroup>
-    <FileWrites Include="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp" />
-  </ItemGroup>
 </Target>
 
 <PropertyGroup>
@@ -3057,6 +3044,13 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="Sign" 	DependsOnTargets="Build;_ResolveAndroidSigningKey;_Sign" />
 
 <!-- Cleaning -->
+
+<Target Name="_AddFilesToFileWrites" BeforeTargets="IncrementalClean">
+  <ItemGroup>
+    <!-- When following the naming convention for stamp files, this target handles FileWrites -->
+    <FileWrites Include="$(_AndroidStampDirectory)*.stamp" />
+  </ItemGroup>
+</Target>
 
 <Target Name="_CleanMsymArchive">
 	<GetAndroidPackageName ManifestFile="$(ProjectDir)$(AndroidManifest)" AssemblyName="$(AssemblyName)">


### PR DESCRIPTION
In our "MSBuild Best Practices" guide, the convention for using a
"stamp" file has a bit of boilerplate...

    <Target Name="_MyTarget"
        Inputs="..."
        Outputs="$(_AndroidStampDirectory)_MyTarget.stamp">
      <!--...-->
      <Touch Files="$(_AndroidStampDirectory)_MyTarget.stamp" AlwaysCreate="True" />
      <ItemGroup>
        <FileWrites Include="$(_AndroidStampDirectory)_MyTarget.stamp" />
      </ItemGroup>
    </Target>

It would be reasonably easy to mess this up.

If we add a new `_AddFilesToFileWrites` target that automatically adds
`$(_AndroidStampDirectory)*.stamp` to `FileWrites`, we can simplify
things:

    <Target Name="_MyTarget"
        Inputs="..."
        Outputs="$(_AndroidStampDirectory)_MyTarget.stamp">
      <!--...-->
      <Touch Files="$(_AndroidStampDirectory)_MyTarget.stamp" AlwaysCreate="True" />
    </Target>

This should be less prone to mistakes.