### PR TITLE
[build] $(ZIP_OUTPUT) contains $(CONFIGURATION)

### DIFF
--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -16,7 +16,7 @@ else
 ZIP_EXTENSION         = zip
 endif
 
-ZIP_OUTPUT_BASENAME   = xamarin.android-oss_v$(PRODUCT_VERSION).$(-num-commits-since-version-change)_$(OS_NAME)-$(OS_ARCH)_$(GIT_BRANCH)_$(GIT_COMMIT)
+ZIP_OUTPUT_BASENAME   = xamarin.android-oss_v$(PRODUCT_VERSION).$(-num-commits-since-version-change)_$(OS_NAME)-$(OS_ARCH)_$(GIT_BRANCH)_$(GIT_COMMIT)-$(CONFIGURATION)
 ZIP_OUTPUT            = $(ZIP_OUTPUT_BASENAME).$(ZIP_EXTENSION)
 
 

--- a/build-tools/scripts/Packaging.mk
+++ b/build-tools/scripts/Packaging.mk
@@ -36,7 +36,7 @@ package-oss $(ZIP_OUTPUT):
 	_sl="$(ZIP_OUTPUT_BASENAME)/bin/$(CONFIGURATION)/lib/xamarin.android/xbuild/.__sys_links.txt"; \
 	if [ ! -f "$$_sl" ]; then continue; fi; \
 	for f in `cat $$_sl` ; do \
-		echo "$(ZIP_OUTPUT_BASENAME)/bin/$CONFIGURATION/lib/xamarin.android/xbuild/$$f" >> "$$_exclude_list"; \
+		echo "$(ZIP_OUTPUT_BASENAME)/bin/$(CONFIGURATION)/lib/xamarin.android/xbuild/$$f" >> "$$_exclude_list"; \
 	done
 	echo "Exclude List:"
 	cat ".__exclude_list.txt"


### PR DESCRIPTION
Context: ae093bf0a103863e9325afd7e2fedbff1b78648e

The Jenkins changes around ae093bf0 broke the
[xamarin-android-linux-release][0] build, because
`make jenkins CONFIGURATION=Debug` builds the `$(ZIP_OUTPUT)` file,
which then *only* contains the Debug-configuration artifacts, and
because `$(ZIP_OUTPUT)` already exists, it is not recreated when
`make jenkins CONFIGURATION=Release` is executedd.

Consequently, when `make package-deb CONFIGURATION=Release` is
executed, *there are no Release artifacts*, and packaging fails.

The fix?  If the intention behind ae093bf0 is to eventually build both
Debug and Release configuration artifacts on separate Jenkins jobs,
then they should likewise produce different `$(ZIP_OUTPUT)` filenames.

Include `$(CONFIGURATION)` in the `$(ZIP_OUTPUT)` filename.

Additionally, fix a typeo in ae093bf0: `$CONFIGURATION` isn't valid
within a Makefile, and thus doesn't mean what was intended.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-linux-release/656/