### PR TITLE
Move all MSBuild tests over to use `PackageReference`.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -135,7 +135,7 @@ using System.Runtime.CompilerServices;
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
-				Packages = {
+				PackageReferences = {
 					KnownPackages.SupportMediaCompat_25_4_0_1,
 					KnownPackages.SupportFragment_25_4_0_1,
 					KnownPackages.SupportCoreUtils_25_4_0_1,
@@ -284,10 +284,10 @@ using System.Runtime.CompilerServices;
 					proj.AndroidResources.Add (image1); 
 				}
 				proj.References.Add (new BuildItem ("ProjectReference", "..\\Library1\\Library1.csproj"));
-				proj.Packages.Add (KnownPackages.AndroidSupportV4_21_0_3_0);
-				proj.Packages.Add (KnownPackages.SupportV7AppCompat_21_0_3_0);
-				proj.Packages.Add (KnownPackages.SupportV7MediaRouter_21_0_3_0);
-				proj.Packages.Add (KnownPackages.GooglePlayServices_22_0_0_2);
+				proj.PackageReferences.Add (KnownPackages.AndroidSupportV4_21_0_3_0);
+				proj.PackageReferences.Add (KnownPackages.SupportV7AppCompat_21_0_3_0);
+				proj.PackageReferences.Add (KnownPackages.SupportV7MediaRouter_21_0_3_0);
+				proj.PackageReferences.Add (KnownPackages.GooglePlayServices_22_0_0_2);
 				proj.AndroidExplicitCrunch = explicitCrunch;
 				proj.SetProperty ("TargetFrameworkVersion", "v5.0");
 				using (var b = CreateApkBuilder (Path.Combine (projectPath, "Application1"), false, false)) {
@@ -425,9 +425,9 @@ namespace UnnamedProject
 	}
 }"
 			});
-			proj.Packages.Add (KnownPackages.AndroidSupportV4_22_1_1_1);
-			proj.Packages.Add (KnownPackages.SupportV7AppCompat_22_1_1_1);
-			proj.Packages.Add (KnownPackages.SupportV7Palette_22_1_1_1);
+			proj.PackageReferences.Add (KnownPackages.AndroidSupportV4_22_1_1_1);
+			proj.PackageReferences.Add (KnownPackages.SupportV7AppCompat_22_1_1_1);
+			proj.PackageReferences.Add (KnownPackages.SupportV7Palette_22_1_1_1);
 			proj.SetProperty ("TargetFrameworkVersion", "v5.0");
 			proj.SetProperty (proj.DebugProperties, "JavaMaximumHeapSize", "1G");
 			proj.SetProperty (proj.ReleaseProperties, "JavaMaximumHeapSize", "1G");
@@ -617,8 +617,8 @@ namespace UnnamedProject
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
 			};
-			proj.Packages.Add (KnownPackages.AndroidSupportV4_21_0_3_0);
-			proj.Packages.Add (KnownPackages.SupportV7AppCompat_21_0_3_0);
+			proj.PackageReferences.Add (KnownPackages.AndroidSupportV4_21_0_3_0);
+			proj.PackageReferences.Add (KnownPackages.SupportV7AppCompat_21_0_3_0);
 			proj.SetProperty ("TargetFrameworkVersion", "v5.0");
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				b.Verbosity = LoggerVerbosity.Diagnostic;
@@ -983,7 +983,7 @@ namespace UnnamedProject
 </resources>",
 					}
 				},
-				Packages = {
+				PackageReferences = {
 					new Package (KnownPackages.AndroidSupportV13_21_0_3_0, audoAddReferences:true),
 					new Package (KnownPackages.AndroidSupportV4_21_0_3_0, audoAddReferences:true),
 					new Package (KnownPackages.SupportV7AppCompat_21_0_3_0, audoAddReferences:true),
@@ -1147,7 +1147,7 @@ namespace Lib1 {
 				References = {
 					new BuildItem.ProjectReference (@"..\Lib1\Lib1.csproj", libProj.ProjectName, libProj.ProjectGuid),
 				},
-				Packages = {
+				PackageReferences = {
 					KnownPackages.SupportMediaCompat_25_4_0_1,
 					KnownPackages.SupportFragment_25_4_0_1,
 					KnownPackages.SupportCoreUtils_25_4_0_1,
@@ -1378,20 +1378,20 @@ namespace UnnamedProject
 			var proj = new XamarinAndroidApplicationProject ();
 			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
 			proj.LayoutMain = proj.LayoutMain.Replace ("</LinearLayout>", "<android.support.design.widget.BottomNavigationView android:id=\"@+id/navigation\" /></LinearLayout>");
-			proj.Packages.Add (KnownPackages.Android_Arch_Core_Common_26_1_0);
-			proj.Packages.Add (KnownPackages.Android_Arch_Lifecycle_Common_26_1_0);
-			proj.Packages.Add (KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0);
-			proj.Packages.Add (KnownPackages.AndroidSupportV4_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportCompat_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportCoreUI_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportCoreUtils_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportDesign_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportFragment_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportMediaCompat_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportV7AppCompat_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportV7CardView_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportV7MediaRouter_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportV7RecyclerView_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.Android_Arch_Core_Common_26_1_0);
+			proj.PackageReferences.Add (KnownPackages.Android_Arch_Lifecycle_Common_26_1_0);
+			proj.PackageReferences.Add (KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0);
+			proj.PackageReferences.Add (KnownPackages.AndroidSupportV4_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.SupportCompat_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.SupportCoreUI_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.SupportCoreUtils_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.SupportDesign_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.SupportFragment_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.SupportMediaCompat_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.SupportV7AppCompat_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.SupportV7CardView_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.SupportV7MediaRouter_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.SupportV7RecyclerView_27_0_2_1);
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "first build should have succeeded");
 
@@ -1415,30 +1415,31 @@ namespace UnnamedProject
 		{
 			var proj = new XamarinAndroidApplicationProject ();
 			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
-			proj.Packages.Add (KnownPackages.Android_Arch_Core_Common_26_1_0);
-			proj.Packages.Add (KnownPackages.Android_Arch_Lifecycle_Common_26_1_0);
-			proj.Packages.Add (KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0);
-			proj.Packages.Add (KnownPackages.AndroidSupportV4_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportCompat_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportCoreUI_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportCoreUtils_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportDesign_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportFragment_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportMediaCompat_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportV7AppCompat_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportV7CardView_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportV7MediaRouter_27_0_2_1);
-			proj.Packages.Add (KnownPackages.SupportV7RecyclerView_27_0_2_1);
-			proj.Packages.Add (KnownPackages.Xamarin_GooglePlayServices_Gcm);
-			proj.Packages.Add (KnownPackages.Xamarin_GooglePlayServices_Tasks);
-			proj.Packages.Add (KnownPackages.Xamarin_GooglePlayServices_Iid);
-			proj.Packages.Add (KnownPackages.Xamarin_GooglePlayServices_Basement);
-			proj.Packages.Add (KnownPackages.Xamarin_GooglePlayServices_Base);
+			proj.PackageReferences.Add (KnownPackages.Android_Arch_Core_Common_26_1_0);
+			proj.PackageReferences.Add (KnownPackages.Android_Arch_Lifecycle_Common_26_1_0);
+			proj.PackageReferences.Add (KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0);
+			proj.PackageReferences.Add (KnownPackages.AndroidSupportV4_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.SupportCompat_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.SupportCoreUI_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.SupportCoreUtils_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.SupportDesign_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.SupportFragment_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.SupportMediaCompat_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.SupportV7AppCompat_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.SupportV7CardView_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.SupportV7MediaRouter_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.SupportV7RecyclerView_27_0_2_1);
+			proj.PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Gcm);
+			proj.PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Tasks);
+			proj.PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Iid);
+			proj.PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Basement);
+			proj.PackageReferences.Add (KnownPackages.Xamarin_GooglePlayServices_Base);
 			proj.OtherBuildItems.Add (new BuildItem ("GoogleServicesJson", "googleservices.json") {
+				Encoding = Encoding.ASCII,
 				TextContent = () => @"{
     ""project_info"": {
         ""project_number"": ""12351255213413432"",
-        ""project_id"": ""12341234-app"",
+        ""project_id"": ""12341234-app""
     },
     ""client"": [
         {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -83,7 +83,7 @@ namespace Xamarin.Android.Build.Tests
 				UseLatestPlatformSdk = true,
 				IsRelease = true,
 			};
-			proj.Packages.Add (KnownPackages.AndroidSupportV4_22_1_1_1);
+			proj.PackageReferences.Add (KnownPackages.AndroidSupportV4_22_1_1_1);
 			proj.Jars.Add (new AndroidItem.LibraryProjectZip ("Jars\\android-crop-1.0.1.aar") {
 				WebContent = "https://jcenter.bintray.com/com/soundcloud/android/android-crop/1.0.1/android-crop-1.0.1.aar"
 			});
@@ -109,7 +109,7 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = true,
 			};
 			proj.AndroidClassParser = classParser;
-			proj.Packages.Add (KnownPackages.AndroidSupportV4_22_1_1_1);
+			proj.PackageReferences.Add (KnownPackages.AndroidSupportV4_22_1_1_1);
 			proj.Jars.Add (new AndroidItem.LibraryProjectZip ("Jars\\aFileChooserBinaries.zip") {
 				WebContentFileNameFromAzure = "aFileChooserBinaries.zip"
 			});
@@ -384,7 +384,7 @@ namespace Foo {
 	<attr path=""/api/package[@name='com.actionbarsherlock.view']"" name=""managedName"">Xamarin.ActionbarSherlockBinding.Views</attr>
 </metadata>",
 			};
-			binding.Packages.Add (KnownPackages.AndroidSupportV4_22_1_1_1);
+			binding.PackageReferences.Add (KnownPackages.AndroidSupportV4_22_1_1_1);
 			using (var bindingBuilder = CreateDllBuilder (Path.Combine ("temp", "RemoveEventHandlerResolution", "Binding"))) {
 				Assert.IsTrue (bindingBuilder.Build (binding), "binding build should have succeeded");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -339,10 +339,10 @@ namespace Lib2
 
 				var intermediate = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath);
 				var filesToTouch = new [] {
+					Path.Combine (intermediate, "..", "project.assets.json"),
 					Path.Combine (intermediate, "build.props"),
 					Path.Combine (intermediate, proj.ProjectName + ".dll"),
 					Path.Combine (intermediate, "android", "assets", proj.ProjectName + ".dll"),
-					Path.Combine (Root, b.ProjectDirectory, "packages.config"),
 				};
 				foreach (var file in filesToTouch) {
 					FileAssert.Exists (file);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -533,7 +533,7 @@ namespace Bug12935
 				References = {
 					new BuildItem.ProjectReference ("..\\Binding1\\Binding1.csproj", lib.ProjectGuid)
 				},
-				Packages = {
+				PackageReferences = {
 					KnownPackages.SupportMediaCompat_25_4_0_1,
 					KnownPackages.SupportFragment_25_4_0_1,
 					KnownPackages.SupportCoreUtils_25_4_0_1,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -100,7 +100,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
-				Packages = {
+				PackageReferences = {
 					new Package () {
 						Id = "System.Runtime.InteropServices.WindowsRuntime",
 						Version = "4.0.1",
@@ -174,7 +174,7 @@ namespace Xamarin.Android.Build.Tests
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 			};
-			proj.Packages.Add(KnownPackages.SQLitePCLRaw_Core);
+			proj.PackageReferences.Add(KnownPackages.SQLitePCLRaw_Core);
 			proj.SetProperty(proj.ReleaseProperties, KnownProperties.AndroidSupportedAbis, "x86");
 			proj.SetProperty (proj.ReleaseProperties, "AndroidStoreUncompressedFileExtensions", compressNativeLibraries ? "" : ".so");
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -525,11 +525,11 @@ namespace Xamarin.ProjectTools
 		};
 		public static Package Xamarin_Android_FSharp_ResourceProvider_Runtime = new Package {
 			Id = "Xamarin.Android.FSharp.ResourceProvider",
-			Version = "1.0.0.13",
+			Version = "1.0.0.28",
 			TargetFramework = "monoandroid71",
 			References = {
 				new BuildItem.Reference ("Xamarin.Android.FSharp.ResourceProvider.Runtime") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.FSharp.ResourceProvider.1.0.0.13\\lib\\Xamarin.Android.FSharp.ResourceProvider.Runtime.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.FSharp.ResourceProvider.1.0.0.28\\lib\\Xamarin.Android.FSharp.ResourceProvider.Runtime.dll"
 				},
 			}
 		};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidCommonProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidCommonProject.cs
@@ -89,8 +89,8 @@ namespace Xamarin.ProjectTools
 				base.Language = value;
 				if (value == XamarinAndroidProjectLanguage.FSharp) {
 					// add the stuff needed for FSharp
-					Packages.Add (KnownPackages.FSharp_Core_Latest);
-					Packages.Add (KnownPackages.Xamarin_Android_FSharp_ResourceProvider_Runtime);
+					PackageReferences.Add (KnownPackages.FSharp_Core_Latest);
+					PackageReferences.Add (KnownPackages.Xamarin_Android_FSharp_ResourceProvider_Runtime);
 					Sources.Remove (resourceDesigner);
 					OtherBuildItems.Add (new BuildItem.NoActionResource (() => "Resources\\Resource.designer" + Language.DefaultDesignerExtension) { TextContent = () => string.Empty });
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidWearApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidWearApplicationProject.cs
@@ -29,8 +29,8 @@ namespace Xamarin.ProjectTools
 		{
 			TargetFrameworkVersion = Versions.KitkatWatch;
 			UseLatestPlatformSdk = false;
-			Packages.Add (KnownPackages.AndroidSupportV13Kitkat);
-			Packages.Add (KnownPackages.AndroidWear);
+			PackageReferences.Add (KnownPackages.AndroidSupportV13Kitkat);
+			PackageReferences.Add (KnownPackages.AndroidWear);
 
 			MainActivity = default_main_activity;
 			StringsXml = default_strings_xml;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
@@ -41,22 +41,22 @@ namespace Xamarin.ProjectTools
 			: base (debugConfigurationName, releaseConfigurationName)
 		{
 			var forms = KnownPackages.XamarinForms_3_1_0_697729;
-			Packages.Add (forms);
-			Packages.Add (KnownPackages.Android_Arch_Core_Common_26_1_0);
-			Packages.Add (KnownPackages.Android_Arch_Lifecycle_Common_26_1_0);
-			Packages.Add (KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0);
-			Packages.Add (KnownPackages.AndroidSupportV4_27_0_2_1);
-			Packages.Add (KnownPackages.SupportCompat_27_0_2_1);
-			Packages.Add (KnownPackages.SupportCoreUI_27_0_2_1);
-			Packages.Add (KnownPackages.SupportCoreUtils_27_0_2_1);
-			Packages.Add (KnownPackages.SupportDesign_27_0_2_1);
-			Packages.Add (KnownPackages.SupportFragment_27_0_2_1);
-			Packages.Add (KnownPackages.SupportMediaCompat_27_0_2_1);
-			Packages.Add (KnownPackages.SupportV7AppCompat_27_0_2_1);
-			Packages.Add (KnownPackages.SupportV7CardView_27_0_2_1);
-			Packages.Add (KnownPackages.SupportV7MediaRouter_27_0_2_1);
-			Packages.Add (KnownPackages.SupportV7RecyclerView_27_0_2_1);
-			Packages.Add (KnownPackages.VectorDrawable_27_0_2_1);
+			PackageReferences.Add (forms);
+			PackageReferences.Add (KnownPackages.Android_Arch_Core_Common_26_1_0);
+			PackageReferences.Add (KnownPackages.Android_Arch_Lifecycle_Common_26_1_0);
+			PackageReferences.Add (KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0);
+			PackageReferences.Add (KnownPackages.AndroidSupportV4_27_0_2_1);
+			PackageReferences.Add (KnownPackages.SupportCompat_27_0_2_1);
+			PackageReferences.Add (KnownPackages.SupportCoreUI_27_0_2_1);
+			PackageReferences.Add (KnownPackages.SupportCoreUtils_27_0_2_1);
+			PackageReferences.Add (KnownPackages.SupportDesign_27_0_2_1);
+			PackageReferences.Add (KnownPackages.SupportFragment_27_0_2_1);
+			PackageReferences.Add (KnownPackages.SupportMediaCompat_27_0_2_1);
+			PackageReferences.Add (KnownPackages.SupportV7AppCompat_27_0_2_1);
+			PackageReferences.Add (KnownPackages.SupportV7CardView_27_0_2_1);
+			PackageReferences.Add (KnownPackages.SupportV7MediaRouter_27_0_2_1);
+			PackageReferences.Add (KnownPackages.SupportV7RecyclerView_27_0_2_1);
+			PackageReferences.Add (KnownPackages.VectorDrawable_27_0_2_1);
 
 			AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values\\colors.xml") {
 				TextContent = () => colors_xml,
@@ -82,7 +82,6 @@ namespace Xamarin.ProjectTools
 			Sources.Add (new BuildItem.Source ("App.xaml.cs") {
 				TextContent = () => ProcessSourceTemplate (App_xaml_cs),
 			});
-			Imports.Add (new Import ($@"..\packages\{forms.Id}.{forms.Version}\build\netstandard2.0\Xamarin.Forms.targets"));
 
 			MainActivity = default_main_activity_cs;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -287,7 +287,7 @@ namespace Xamarin.ProjectTools
 			var start = DateTime.UtcNow;
 			var args  = new StringBuilder ();
 			var psi   = new ProcessStartInfo (XABuildExe);
-			args.AppendFormat ("{0} /t:{1} {2}",
+			args.AppendFormat ("{0} /t:{1} /restore {2}",
 				QuoteFileName(Path.Combine (XABuildPaths.TestOutputDirectory, projectOrSolution)), target, logger);
 			if (RunningMSBuild)
 				args.Append (" /p:BuildingOutOfProcess=true");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -1,6 +1,7 @@
 ﻿﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Diagnostics;
 using Microsoft.Build.Framework;
 
@@ -61,7 +62,7 @@ namespace Xamarin.ProjectTools
 			Save (project, doNotCleanupOnUpdate, saveProject);
 
 			Output = project.CreateBuildOutput (this);
-
+			
 			project.NuGetRestore (Path.Combine (XABuildPaths.TestOutputDirectory, ProjectDirectory), PackagesDirectory);
 
 			bool result = BuildInternal (Path.Combine (ProjectDirectory, project.ProjectFilePath), Target, parameters, environmentVariables);
@@ -71,6 +72,17 @@ namespace Xamarin.ProjectTools
 				Cleanup ();
 			last_build_result = result;
 			return result;
+		}
+
+		public bool Restore (XamarinProject project, bool doNotCleanupOnUpdate = false)
+		{
+			var oldTarget = Target;
+			Target = "Restore";
+			try {
+				return Build (project, doNotCleanupOnUpdate);
+			} finally {
+				Target = oldTarget;
+			}
 		}
 
 		public bool Clean (XamarinProject project, bool doNotCleanupOnUpdate = false)


### PR DESCRIPTION
WIP. 

In a effort to reduce our dependency on external resources we should not be relying on `Nuget.exe` to restore packages. We should instead be using `msbuild /t:Restore`. 
That only works with `PackageReference` though. So lets move all of our Nuget references in the MSBuild tests over to use that system. We can then hopefully remove the dependency on `Nuget.exe`