### PR TITLE
[tests] Help track down an apparent mono hang

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -71,8 +71,8 @@
     <JavaInteropSourceDirectory Condition=" '$(JavaInteropSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\Java.Interop</JavaInteropSourceDirectory>
     <LlvmSourceDirectory Condition=" '$(LlvmSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\llvm</LlvmSourceDirectory>
     <MonoSourceDirectory>$(MSBuildThisFileDirectory)external\mono</MonoSourceDirectory>
-    <MonoRequiredMinimumVersion Condition=" '$(MonoRequiredMinimumVersion)' == '' ">5.18.0</MonoRequiredMinimumVersion>
-    <MonoRequiredMaximumVersion Condition=" '$(MonoRequiredMaximumVersion)' == '' ">5.19.0</MonoRequiredMaximumVersion>
+    <MonoRequiredMinimumVersion Condition=" '$(MonoRequiredMinimumVersion)' == '' ">5.16.0</MonoRequiredMinimumVersion>
+    <MonoRequiredMaximumVersion Condition=" '$(MonoRequiredMaximumVersion)' == '' ">5.17.0</MonoRequiredMaximumVersion>
     <IgnoreMaxMonoVersion Condition=" '$(IgnoreMaxMonoVersion)' == '' ">True</IgnoreMaxMonoVersion>
     <MonoRequiredDarwinMinimumVersion>$(MonoRequiredMinimumVersion).0</MonoRequiredDarwinMinimumVersion>
     <LinkerSourceDirectory>$(MSBuildThisFileDirectory)external\mono\external\linker</LinkerSourceDirectory>

--- a/Configuration.props
+++ b/Configuration.props
@@ -71,8 +71,8 @@
     <JavaInteropSourceDirectory Condition=" '$(JavaInteropSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\Java.Interop</JavaInteropSourceDirectory>
     <LlvmSourceDirectory Condition=" '$(LlvmSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\llvm</LlvmSourceDirectory>
     <MonoSourceDirectory>$(MSBuildThisFileDirectory)external\mono</MonoSourceDirectory>
-    <MonoRequiredMinimumVersion Condition=" '$(MonoRequiredMinimumVersion)' == '' ">5.16.0</MonoRequiredMinimumVersion>
-    <MonoRequiredMaximumVersion Condition=" '$(MonoRequiredMaximumVersion)' == '' ">5.17.0</MonoRequiredMaximumVersion>
+    <MonoRequiredMinimumVersion Condition=" '$(MonoRequiredMinimumVersion)' == '' ">5.18.0</MonoRequiredMinimumVersion>
+    <MonoRequiredMaximumVersion Condition=" '$(MonoRequiredMaximumVersion)' == '' ">5.19.0</MonoRequiredMaximumVersion>
     <IgnoreMaxMonoVersion Condition=" '$(IgnoreMaxMonoVersion)' == '' ">True</IgnoreMaxMonoVersion>
     <MonoRequiredDarwinMinimumVersion>$(MonoRequiredMinimumVersion).0</MonoRequiredDarwinMinimumVersion>
     <LinkerSourceDirectory>$(MSBuildThisFileDirectory)external\mono\external\linker</LinkerSourceDirectory>

--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,8 @@ $(eval $(call CREATE_THIRD_PARTY_NOTICES_RULE,ThirdPartyNotices.txt,foundation,F
 $(eval $(call CREATE_THIRD_PARTY_NOTICES_RULE,bin/$(CONFIGURATION)/lib/xamarin.android/ThirdPartyNotices.txt,$(THIRD_PARTY_NOTICE_LICENSE_TYPE),True,False))
 
 run-all-tests:
+	# For debugging a mono "hang"; see e.g. https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/1239/console
+	MONO_LOG_LEVEL=debug MONO_LOG_MASK=io-layer-process \
 	$(call MSBUILD_BINLOG,run-all-tests) $(TEST_TARGETS) /t:RunAllTests
 	$(MAKE) run-api-compatibility-tests
 

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ $(eval $(call CREATE_THIRD_PARTY_NOTICES_RULE,bin/$(CONFIGURATION)/lib/xamarin.a
 
 run-all-tests:
 	# For debugging a mono "hang"; see e.g. https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/1239/console
-	MONO_LOG_LEVEL=debug MONO_LOG_MASK=io-layer-process \
+	MONO_LOG_LEVEL=debug MONO_LOG_MASK=io-layer-process MONO_LOG_DEST=syslog \
 	$(call MSBUILD_BINLOG,run-all-tests) $(TEST_TARGETS) /t:RunAllTests
 	$(MAKE) run-api-compatibility-tests
 

--- a/build-tools/dependencies/dependencies.projitems
+++ b/build-tools/dependencies/dependencies.projitems
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_DarwinMonoFramework>MonoFramework-MDK-5.16.0.106.macos10.xamarin.universal.pkg</_DarwinMonoFramework>
+    <_DarwinMonoFramework>MonoFramework-MDK-5.18.0.189.macos10.xamarin.universal.pkg</_DarwinMonoFramework>
     <_AptGetInstall>apt-get -f -u install</_AptGetInstall>
   </PropertyGroup>
   <ItemGroup>
@@ -59,7 +59,7 @@
       <MaximumVersion Condition=" '$(IgnoreMaxMonoVersion)' == '' Or '$(IgnoreMaxMonoVersion)' == 'False' " >$(MonoRequiredMaximumVersion)</MaximumVersion>
       <DarwinMinimumVersion>$(MonoRequiredDarwinMinimumVersion)</DarwinMinimumVersion>
       <CurrentVersionCommand>$(MSBuildThisFileDirectory)..\scripts\mono-version</CurrentVersionCommand>
-      <DarwinMinimumUrl>https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2018-06/78/341142d7656f43239a041b2c44f00acfb8fa7c59/$(_DarwinMonoFramework)</DarwinMinimumUrl>
+      <DarwinMinimumUrl>https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2018-08/153/53a21a0e8449257c67f4410976f77e3c67ca68ea/$(_DarwinMonoFramework)</DarwinMinimumUrl>
       <DarwinInstall>installer -pkg "$(AndroidToolchainCacheDirectory)\$(_DarwinMonoFramework)" -target /</DarwinInstall>
     </RequiredProgram>
   </ItemGroup>

--- a/build-tools/dependencies/dependencies.projitems
+++ b/build-tools/dependencies/dependencies.projitems
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_DarwinMonoFramework>MonoFramework-MDK-5.18.0.189.macos10.xamarin.universal.pkg</_DarwinMonoFramework>
+    <_DarwinMonoFramework>MonoFramework-MDK-pr@59fa440c6e5-dirty-5.16.0.220.macos10.xamarin.universal.pkg</_DarwinMonoFramework>
     <_AptGetInstall>apt-get -f -u install</_AptGetInstall>
   </PropertyGroup>
   <ItemGroup>
@@ -59,7 +59,7 @@
       <MaximumVersion Condition=" '$(IgnoreMaxMonoVersion)' == '' Or '$(IgnoreMaxMonoVersion)' == 'False' " >$(MonoRequiredMaximumVersion)</MaximumVersion>
       <DarwinMinimumVersion>$(MonoRequiredDarwinMinimumVersion)</DarwinMinimumVersion>
       <CurrentVersionCommand>$(MSBuildThisFileDirectory)..\scripts\mono-version</CurrentVersionCommand>
-      <DarwinMinimumUrl>https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2018-08/153/53a21a0e8449257c67f4410976f77e3c67ca68ea/$(_DarwinMonoFramework)</DarwinMinimumUrl>
+	  <DarwinMinimumUrl>https://xamjenkinsartifact.azureedge.net/build-package-osx-mono-pullrequest/pr/252/59fa440c6e54c0d02c3219069ef3b60990cb406a/$(_DarwinMonoFramework)</DarwinMinimumUrl>
       <DarwinInstall>installer -pkg "$(AndroidToolchainCacheDirectory)\$(_DarwinMonoFramework)" -target /</DarwinInstall>
     </RequiredProgram>
   </ItemGroup>


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/1239/console

Sometimes a Jenkins build will timeout when executing the
xamarin-android unit tests.  The timeout *apepars* to occur when
`mono` is used to execute a process, the process "finishes," but the
process never actually *exits*, thus "hanging".

For example, [consider this build log fragment][0] (with timestamps):

	23:37:48   Build succeeded.
	23:37:48       0 Warning(s)
	23:37:48       0 Error(s)
	23:37:48
	23:37:48   Time Elapsed 01:23:14.60
	02:37:48 Build timed out (after 180 minutes). Marking the build as aborted.

The "Build succeeded" message comes from an `msbuild` invocation.
Once `msbuild` finished, we would expect it's process to exit.
*It didn't*.  Instead, the underlying `mono` process is *not* exiting,
presumably deadlocked, until the overall job times out and is killed.

We had hoped to further diagnose things by altering just the Jenkins
job script, but exporting the `$MONO_LOG_LEVEL` environment variable
causes `mono` to print out lots of debug messages with a `Mono: `
prefix, which causes the computed `$(PRODUCT_VERSION)` value (in
`build-tools/scripts/BuildEverything.mk`) to be "bonkers," resulting
in [`make` not being happy with us][1]:

	+ make run-all-tests CONFIGURATION=Release V=1
	build-tools/scripts/BuildEverything.mk:86: *** multiple target patterns.  Stop.

I've removed the `$MONO_LOG_LEVEL` export from the Jenkins job, and
instead we'll export
`MONO_LOG_LEVEL=debug MONO_LOG_MASK=io-layer-process` within the
`make run-all-tests` target so that we can obtain our debugging
assistance.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/1237/console
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/1241/