### PR TITLE
[Xamarin.Android.Build.Tasks] Extract .so files to the `lp` directory

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/StripEmbeddedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/StripEmbeddedLibraries.cs
@@ -18,7 +18,9 @@ namespace MonoDroid.Tuner
 				return;
 
 			var fileName = assembly.Name.Name + ".dll";
-			if (MonoAndroidHelper.IsFrameworkAssembly (fileName) && !MonoAndroidHelper.FrameworkEmbeddedJarLookupTargets.Contains (fileName))
+			if (MonoAndroidHelper.IsFrameworkAssembly (fileName) &&
+					!MonoAndroidHelper.FrameworkEmbeddedJarLookupTargets.Contains (fileName) &&
+					!MonoAndroidHelper.FrameworkEmbeddedNativeLibraryAssemblies.Contains (fileName))
 				return;
 
 			bool assembly_modified = false;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1770,6 +1770,9 @@ namespace App1
 			var dll2 = new XamarinAndroidLibraryProject () {
 				ProjectName = "Library2",
 				IsRelease = isRelease,
+				References = {
+					new BuildItem ("ProjectReference","..\\Library1\\Library1.csproj"),
+				},
 				OtherBuildItems = {
 					new AndroidItem.EmbeddedNativeLibrary ("foo\\armeabi-v7a\\libtest1.so") {
 						BinaryContent = () => new byte[10],
@@ -1786,6 +1789,8 @@ namespace App1
 				References = {
 					new BuildItem ("ProjectReference","..\\Library1\\Library1.csproj"),
 					new BuildItem ("ProjectReference","..\\Library2\\Library2.csproj"),
+					new BuildItem.Reference ("Mono.Data.Sqlite"),
+					new BuildItem.Reference ("Mono.Posix"),
 				},
 				OtherBuildItems = {
 					new AndroidItem.AndroidNativeLibrary ("armeabi-v7a\\libRSSupport.so") {
@@ -1823,6 +1828,14 @@ namespace App1
 							Assert.IsNotNull (data, "libtest1.so for armeabi-v7a should exist in the apk.");
 							data = ZipHelper.ReadFileFromZip (zipFile, "lib/armeabi-v7a/libRSSupport.so");
 							Assert.IsNotNull (data, "libRSSupport.so for armeabi-v7a should exist in the apk.");
+							data = ZipHelper.ReadFileFromZip (zipFile, "lib/x86/libsqlite3_xamarin.so");
+							Assert.IsNotNull (data, "libsqlite3_xamarin.so for x86 should exist in the apk.");
+							data = ZipHelper.ReadFileFromZip (zipFile, "lib/armeabi-v7a/libsqlite3_xamarin.so");
+							Assert.IsNotNull (data, "libsqlite3_xamarin.so for armeabi-v7a should exist in the apk.");
+							data = ZipHelper.ReadFileFromZip (zipFile, "lib/x86/libMonoPosixHelper.so");
+							Assert.IsNotNull (data, "libMonoPosixHelper.so for x86 should exist in the apk.");
+							data = ZipHelper.ReadFileFromZip (zipFile, "lib/armeabi-v7a/libMonoPosixHelper.so");
+							Assert.IsNotNull (data, "libMonoPosixHelper.so for armeabi-v7a should exist in the apk.");
 						}
 					}
 				}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -487,6 +487,10 @@ namespace Xamarin.Android.Tasks
 			"Mono.Android.Support.v4.dll",
 			"Xamarin.Android.NUnitLite.dll", // AndroidResources
 		};
+		internal static readonly string [] FrameworkEmbeddedNativeLibraryAssemblies = {
+			"Mono.Data.Sqlite.dll",
+			"Mono.Posix.dll",
+		};
 		// MUST BE SORTED CASE-INSENSITIVE
 		internal static readonly string[] FrameworkAssembliesToTreatAsUserAssemblies = {
 			"Mono.Android.GoogleMaps.dll",

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -314,6 +314,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 		Assemblies="@(ReferencePath);@(ReferenceDependencyPaths)"
 		AarLibraries="@(AndroidAarLibrary)"
 		ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
+		NativeImportsDirectory="$(_NativeLibraryImportsDirectoryName)"
 		UseShortFileNames="$(UseShortFileNames)"
 		OutputDirectory="$(IntermediateOutputPath)"
 		AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1345,6 +1345,7 @@ because xbuild doesn't support framework reference assemblies.
 		Assemblies="@(ReferencePath);@(ReferenceDependencyPaths)"
 		AarLibraries="@(AndroidAarLibrary)"
 		ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
+		NativeImportsDirectory="$(_NativeLibraryImportsDirectoryName)"
 		UseShortFileNames="$(UseShortFileNames)"
 		OutputDirectory="$(IntermediateOutputPath)"
 		AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"


### PR DESCRIPTION
To improve fast deployment even further we need to alter
the way we deal with native libraries in refernced
assemblies.

Currently these libraries are extracted as part of the
`BuildApk` task. As a result if a native library is
updated we need to build the whole `.apk` again.

We should extract the `__AndroidNativeLibraries__.zip` contents
into the `$(IntermediateOutputDir)\lp\{assmelby}\nl` directory
as part of the `ResolveLibraryProjectImports` task.
This way the existing `GetImportedLibraries` task will
then pick those `.so` files up and add them to the
`@(NativeLibraries)` Item Group. This will then be picked up
by `BuildApk` as normal in a release build.

However for a debug build we can skip putting these files
in the `.apk` and Fast deploy them instead.