### PR TITLE
[r8] fixes to building with gradle

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -106,9 +106,12 @@
         DestinationFolder="$(ChromeToolsDirectory)"
     />
     <AcceptAndroidSdkLicenses AndroidSdkDirectory="$(AndroidSdkDirectory)" JavaSdkDirectory="$(JavaSdkDirectory)" />
+    <PropertyGroup>
+      <_GClientEnv Condition=" '$(JavaSdkDirectory)' != '' ">JAVA_HOME=$(JavaSdkDirectory)</_GClientEnv>
+    </PropertyGroup>
     <Exec
       Command=".\gclient --version"
-      EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory)"
+      EnvironmentVariables="$(_GClientEnv)"
       WorkingDirectory="$(ChromeToolsDirectory)"
     />
     <Touch

--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -2,7 +2,6 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.AcceptAndroidSdkLicenses" />
   <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.GitCommitHash" />
-  <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.SetEnvironmentVariable" />
   <PropertyGroup>
     <BuildDependsOn>
       ResolveReferences;
@@ -69,9 +68,6 @@
       DependsOnTargets="_DetermineItems"
       Inputs="@(_DownloadedItem)"
       Outputs="@(_SdkStampFiles);$(AndroidToolchainDirectory)\ndk\.stamp-ndk">
-    <PropertyGroup>
-      <_OriginalPath>$(PATH)</_OriginalPath>
-    </PropertyGroup>
     <CreateItem
         Include="@(_PlatformAndroidSdkItem->'$(AndroidToolchainCacheDirectory)\%(_PlatformAndroidSdkItem.Identity).zip'">
       <Output TaskParameter="Include" ItemName="_AndroidSdkItems"/>
@@ -110,15 +106,7 @@
         DestinationFolder="$(ChromeToolsDirectory)"
     />
     <AcceptAndroidSdkLicenses AndroidSdkDirectory="$(AndroidSdkDirectory)" JavaSdkDirectory="$(JavaSdkDirectory)" />
-    <Xamarin.Android.BuildTools.PrepTasks.SetEnvironmentVariable
-        Name="PATH"
-        Value="$([System.IO.Path]::GetFullPath('$(ChromeToolsDirectory)'))$(PathSeparator)$(_OriginalPath)"
-    />
-    <Exec Command="gclient --version" />
-    <Xamarin.Android.BuildTools.PrepTasks.SetEnvironmentVariable
-        Name="PATH"
-        Value="$(_OriginalPath)"
-    />
+    <Exec Command=".\gclient --version" WorkingDirectory="$(ChromeToolsDirectory)" />
     <Touch
         Files="@(_SdkStampFiles);$(AndroidToolchainDirectory)\ndk\.stamp-ndk"
         AlwaysCreate="True"

--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -106,7 +106,11 @@
         DestinationFolder="$(ChromeToolsDirectory)"
     />
     <AcceptAndroidSdkLicenses AndroidSdkDirectory="$(AndroidSdkDirectory)" JavaSdkDirectory="$(JavaSdkDirectory)" />
-    <Exec Command=".\gclient --version" WorkingDirectory="$(ChromeToolsDirectory)" />
+    <Exec
+      Command=".\gclient --version"
+      EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory)"
+      WorkingDirectory="$(ChromeToolsDirectory)"
+    />
     <Touch
         Files="@(_SdkStampFiles);$(AndroidToolchainDirectory)\ndk\.stamp-ndk"
         AlwaysCreate="True"

--- a/src/r8/r8.targets
+++ b/src/r8/r8.targets
@@ -1,11 +1,10 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.DownloadUri" />
-  <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.SetEnvironmentVariable" />
   <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.UnzipDirectoryChildren" />
 
   <PropertyGroup>
     <!--NOTE: we don't want a gradle daemon locking directories on Windows-->
-    <_GradleArgs>--no-daemon</_GradleArgs>
+    <_GradleArgs>--stacktrace --no-daemon</_GradleArgs>
     <BuildDependsOn>
       ResolveReferences;
       _BuildR8;
@@ -20,25 +19,13 @@
 
   <!--
     NOTE: depot_tools has an odd requirement of being in PATH
-    I am also getting some odd failures on Windows, if not specifying namespace for <SetEnvironmentVariable />
   -->
 
   <Target Name="_BuildR8">
-    <PropertyGroup>
-      <_OriginalPath>$(PATH)</_OriginalPath>
-    </PropertyGroup>
-    <Xamarin.Android.BuildTools.PrepTasks.SetEnvironmentVariable
-        Name="PATH"
-        Value="$([System.IO.Path]::GetFullPath('$(ChromeToolsDirectory)'))$(PathSeparator)$(_OriginalPath)"
-    />
     <Exec
       Command="python tools\gradle.py d8 r8 $(_GradleArgs)"
-      EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory)"
+      EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);PATH=$(ChromeToolsDirectory)"
       WorkingDirectory="..\..\external\r8"
-    />
-    <Xamarin.Android.BuildTools.PrepTasks.SetEnvironmentVariable
-        Name="PATH"
-        Value="$(_OriginalPath)"
     />
   </Target>
 
@@ -51,24 +38,13 @@
   </Target>
 
   <Target Name="_CleanR8">
-    <PropertyGroup>
-      <_OriginalPath>$(PATH)</_OriginalPath>
-    </PropertyGroup>
     <Delete
         Files="$(XAInstallPrefix)xbuild\Xamarin\Android\d8.jar;$(XAInstallPrefix)xbuild\Xamarin\Android\r8.jar;"
     />
-    <Xamarin.Android.BuildTools.PrepTasks.SetEnvironmentVariable
-        Name="PATH"
-        Value="$([System.IO.Path]::GetFullPath('$(ChromeToolsDirectory)'))$(PathSeparator)$(_OriginalPath)"
-    />
     <Exec
       Command="python tools\gradle.py clean $(_GradleArgs)"
-      EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory)"
+      EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);PATH=$(ChromeToolsDirectory)"
       WorkingDirectory="..\..\external\r8"
-    />
-    <Xamarin.Android.BuildTools.PrepTasks.SetEnvironmentVariable
-        Name="PATH"
-        Value="$(_OriginalPath)"
     />
   </Target>
 

--- a/src/r8/r8.targets
+++ b/src/r8/r8.targets
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <!--NOTE: we don't want a gradle daemon locking directories on Windows-->
     <_GradleArgs>--stacktrace --no-daemon</_GradleArgs>
+    <_GradleEnv Condition=" '$(JavaSdkDirectory)' != '' ">JAVA_HOME=$(JavaSdkDirectory)</_GradleEnv>
     <BuildDependsOn>
       ResolveReferences;
       _BuildR8;
@@ -24,8 +25,8 @@
   <Target Name="_BuildR8">
     <Exec
       Command="python tools\gradle.py d8 r8 $(_GradleArgs)"
-      EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);PATH=$(ChromeToolsDirectory)"
       WorkingDirectory="..\..\external\r8"
+      EnvironmentVariables="$(_GradleEnv)"
     />
   </Target>
 
@@ -43,8 +44,8 @@
     />
     <Exec
       Command="python tools\gradle.py clean $(_GradleArgs)"
-      EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);PATH=$(ChromeToolsDirectory)"
       WorkingDirectory="..\..\external\r8"
+      EnvironmentVariables="$(_GradleEnv)"
     />
   </Target>
 

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
@@ -46,7 +46,7 @@
       <_Jdk9Modules Condition="$(_JdkVersion.StartsWith ('9'))">JAVA_OPTS="--add-modules java.xml.bind"</_Jdk9Modules>
     </PropertyGroup>
     <Exec
-        EnvironmentVariables="ANDROID_HOME=$(AndroidSdkDirectory);JAVA_HOME=$(JavaSdkDirectory)"
+        EnvironmentVariables="ANDROID_HOME=$(AndroidSdkDirectory);ANDROID_NDK_HOME=$(AndroidNdkDirectory);JAVA_HOME=$(JavaSdkDirectory)"
         Command="$(_Jdk9Modules) .\gradlew assembleDebug --stacktrace --no-daemon"
         WorkingDirectory="$(MSBuildThisFileDirectory)java\JavaLib"
     />

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/java/JavaLib/library/build.gradle
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/java/JavaLib/library/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion "28.0.0"
 
     defaultConfig {
         minSdkVersion 19


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/2019

Since 4bb4b2e, our builds have been failing on VSTS on macOS and
Windows. Jenkins is green, however.

## macOS

Currently getting a failure building `r8` such as:

    2018-10-30T20:19:05.2225960Z   * What went wrong:
    2018-10-30T20:19:05.2227400Z   Could not determine java version from '11.0.1'.

So I believe the problem here is that Java 11 is in `$PATH`, and this
is only a scenario on the VSTS macOS build agents.

It turns out I was able to clean up quite a bit in `r8.targets`:
- We don't need to call `SetEnvironmentVariable`, I was able to set
  `EnvironmentVariables="...;PATH=$(ChromeToolsDirectory)"` and things
  still worked fine.
- We should pass `--stacktrace` to gradle so that we get detailed
  error messages on a failure.

## Windows

Currently getting a failure in
`Xamarin.Android.LibraryProjectZip-LibBinding.csproj` such as:

    2018-10-31T14:02:28.8336608Z    .\gradlew assembleDebug --stacktrace --no-daemon
    2018-10-31T14:02:40.7122197Z   NDK is missing a "platforms" directory.
    2018-10-31T14:02:40.7122937Z   If you are using NDK, verify the ndk.dir is set to a valid NDK directory.  It is currently set to C:\Users\dlab14\android-toolchain\sdk\ndk-bundle.
    2018-10-31T14:02:40.7124870Z   If you are not using NDK, unset the NDK variable from ANDROID_NDK_HOME or local.properties to remove this warning.

It doesn't really make sense to me why this started happening with
d8/r8 support... The `~\android-toolchain\sdk\ndk-bundle` path seems
completely wrong.

However, it looks like we should be setting
`ANDROID_NDK_HOME=$(AndroidNdkDirectory)`. This is the only other
place we are calling `gradle`, so it is somehow *related* to the d8/r8
changes.