### PR TITLE
[mono-2018-10] [build] Download correct mono archive URL

### DIFF
--- a/src/mono-runtimes/ProfileAssemblies.projitems
+++ b/src/mono-runtimes/ProfileAssemblies.projitems
@@ -263,11 +263,5 @@
     <MonoTestAssembly Include="monodroid_System.Xml.Linq_test.dll">
       <SourcePath>System.Xml.Linq</SourcePath>
     </MonoTestAssembly>
-    <MonoTestAssembly Include="System.Runtime.CompilerServices.Unsafe.dll">
-      <!-- This is referenced by monodroid_corlib_xunit-test.dll -->
-      <SourcePath>System.Runtime.CompilerServices.Unsafe</SourcePath>
-      <TestType>reference</TestType>
-    </MonoTestAssembly>
-    <MonoTestRunner Include="nunitlite.dll" />
   </ItemGroup>
 </Project>

--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -24,6 +24,7 @@
     <MonoDocCopyItem Include="monodoc.dll.config" />
   </ItemGroup>
   <UsingTask AssemblyFile="$(_SourceTopDir)\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.GetNugetPackageBasePath" />
+  <UsingTask AssemblyFile="$(_SourceTopDir)\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.UnzipDirectoryChildren" />
   <ItemGroup>
     <_MonoDocCopyItems Include="@(MonoDocCopyItem->'$(_MonoProfileToolsDir)\%(Identity)')" />
   </ItemGroup>
@@ -66,16 +67,8 @@
     <_BclAssembly Include="@(MonoProfileAssembly)" />
     <_BclExcludeDebugSymbols  Include="System.Windows.dll" />
     <_BclExcludeDebugSymbols  Include="System.Xml.Serialization.dll" />
-    <_BclTestAssemblyDestination  Include="@(MonoTestAssembly->'$(XAInstallPrefix)\..\..\bcl-tests\%(Identity)')" />
-    <_BclTestAssemblyDestination
-        Include="@(MonoTestAssembly->'$(XAInstallPrefix)\..\..\bcl-tests\%(Filename).pdb')"
-        Exclude="$(XAInstallPrefix)\..\..\bcl-tests\System.Runtime.CompilerServices.Unsafe.pdb"
-    />
-    <_BclTestAssemblyDestination  Include="@(MonoTestRunner->'$(XAInstallPrefix)\..\..\bcl-tests\%(Identity)')" />
-    <_BclTestAssemblyDestination  Include="@(MonoTestRunner->'$(XAInstallPrefix)\..\..\bcl-tests\%(Filename).pdb')" />
   </ItemGroup>
   <ItemGroup>
-    <_BclTestOutput Include="@(_BclTestAssemblyDestination)" />
     <_BclTestOutput Include="$(XAInstallPrefix)\..\..\bcl-tests\bcl-tests.zip" />
   </ItemGroup>
   <ItemGroup>
@@ -176,7 +169,7 @@
       <Output TaskParameter="CommitHash"   PropertyName="_MonoGitCommitHash" />
     </GitCommitHash>
     <PropertyGroup>
-      <_MonoArchiveName>android-$(_MonoSdksConfiguration)-$(_MonoGitCommitHash)-$(HostOS)</_MonoArchiveName>
+      <_MonoArchiveName>android-$(_MonoSdksConfiguration)-$(HostOS)-$(_MonoGitCommitHash)</_MonoArchiveName>
     </PropertyGroup>
   </Target>
 
@@ -257,13 +250,13 @@
           Include="@(_MonoRuntime->'$(_MSBuildDir)\lib\%(Identity)\%(OutputMonoPosixHelperFilename).d.%(NativeLibraryExtension)')"
       />
       <_RuntimeEglibHeaderSource
-          Include="@(_MonoRuntime->'$(MonoSourceFullPath)\sdks\builds\android-%(Identity)-$(_MonoSdksConfiguration)\mono\eglib\eglib-config.h')"
+          Include="@(_MonoRuntime->'$(MonoSourceFullPath)\sdks\out\android-%(Identity)-$(_MonoSdksConfiguration)\share\mono-2.0\mono\eglib\eglib-config.h')"
       />
       <_RuntimeEglibHeaderOutput
           Include="@(_MonoRuntime->'$(_OutputIncludeDir)%(Identity)\eglib\eglib-config.h')"
       />
       <_MonoConstsSource
-          Include="$(MonoSourceFullPath)\mcs\build\common\Consts.cs"
+          Include="$(MonoSourceFullPath)\sdks\out\android-bcl\monodroid\Consts.cs"
       />
       <_MonoConstsOutput
           Include="$(_OutputIncludeDir)Consts.cs"
@@ -273,23 +266,26 @@
 
   <Target Name="_DownloadArchive"
       DependsOnTargets="_GetMonoGitCommitHash"
-      Condition=" !Exists('$(MonoSourceFullPath)\sdks\out\.stamp-$(_MonoArchiveName)-build') And !Exists('$(MonoSourceFullPath)\sdks\out\.stamp-$(_MonoArchiveName)-download') " >
+      Inputs="$(AndroidToolchainCacheDirectory)\$(_MonoArchiveName).zip"
+      Outputs="$(MonoSourceFullPath)\sdks\out\.stamp-$(_MonoArchiveName)-download"
+      Condition=" !Exists('$(MonoSourceFullPath)\sdks\out\.stamp-$(_MonoArchiveName)-build') And '$(DisableDownloadArchive)' == '' " >
     <MakeDir
         Directories="$(MonoSourceFullPath)\sdks\out"
     />
     <DownloadUri
-        SourceUris="https://xamjenkinsartifact.blob.core.windows.net/mono-sdks/$(_MonoArchiveName).tar.gz"
-        DestinationFiles="$(AndroidToolchainCacheDirectory)\$(_MonoArchiveName).tar.gz"
+        SourceUris="https://xamjenkinsartifact.azureedge.net/mono-sdks/$(_MonoArchiveName).zip"
+        DestinationFiles="$(AndroidToolchainCacheDirectory)\$(_MonoArchiveName).zip"
         ContinueOnError="True"
     />
-    <Exec
-        Condition=" Exists('$(AndroidToolchainCacheDirectory)\$(_MonoArchiveName).tar.gz') "
-        Command="tar -xvf $(AndroidToolchainCacheDirectory)\$(_MonoArchiveName).tar.gz"
-        IgnoreStandardErrorWarningFormat="True"
-        WorkingDirectory="$(MonoSourceFullPath)\sdks\out"
+    <UnzipDirectoryChildren
+        Condition=" Exists('$(AndroidToolchainCacheDirectory)\$(_MonoArchiveName).zip') "
+        HostOS="$(HostOS)"
+        SourceFiles="$(AndroidToolchainCacheDirectory)\$(_MonoArchiveName).zip"
+        DestinationFolder="$(MonoSourceFullPath)\sdks\out"
+        NoSubdirectory="True"
     />
     <Touch
-        Condition=" Exists('$(AndroidToolchainCacheDirectory)\$(_MonoArchiveName).tar.gz') "
+        Condition=" Exists('$(AndroidToolchainCacheDirectory)\$(_MonoArchiveName).zip') "
         Files="$(MonoSourceFullPath)\sdks\out\.stamp-$(_MonoArchiveName)-download"
         AlwaysCreate="True"
     />
@@ -314,51 +310,32 @@
   <Target Name="_InstallRuntimes"
       DependsOnTargets="_GetRuntimesOutputItems"
       Inputs="@(_RuntimeSource);@(_RuntimeBinarySource);@(_CrossRuntimeBinarySource);@(_ProfilerSource);@(_MonoPosixHelperSource);@(_RuntimeEglibHeaderSource);@(_MonoBtlsSource)"
-      Outputs="@(_InstallRuntimeOutput);@(_InstallRuntimeBinaryOutput);@(_InstallCrossRuntimeBinaryOutput);@(_InstallProfilerOutput);@(_InstallMonoPosixHelperOutput);@(_RuntimeEglibHeaderOutput)">
+      Outputs="@(_InstallRuntimeOutput);@(_InstallRuntimeBinaryOutput);@(_InstallCrossRuntimeBinaryOutput);@(_InstallProfilerOutput);@(_InstallMonoPosixHelperOutput);@(_RuntimeEglibHeaderOutput);do-not-cache">
     <ItemGroup>
-      <_BclTestAssemblyReference Include="@(MonoTestAssembly)" Condition="'%(MonoTestAssembly.TestType)' == 'reference'" />
-      <_BclTestAssembly  Include="@(MonoTestAssembly)" Condition="'%(MonoTestAssembly.TestType)' == '' Or '%(MonoTestAssembly.TestType)' == 'xunit' " />
-      <_BclTestAssemblySource Include="@(_BclTestAssemblyReference->'$(_MonoProfileDir)\%(Identity)')" />
-      <_BclTestAssemblySource Include="@(_BclTestAssemblyReference->'$(_MonoProfileDir)\%(Filename).pdb')" Condition="Exists('@(_BclTestAssemblyReference->'$(_MonoProfileDir)\%(Filename).pdb')')" />
-      <_BclTestAssemblySource Include="@(_BclTestAssembly->'$(_MonoProfileDir)\tests\%(Identity)')" />
-      <_BclTestAssemblySource Include="@(_BclTestAssembly->'$(_MonoProfileDir)\tests\%(Filename).pdb')" />
-      <_BclTestAssemblySource Include="@(MonoTestRunner->'$(_MonoProfileDir)\%(Identity)')" />
-      <_BclTestAssemblySource Include="@(MonoTestRunner->'$(_MonoProfileDir)\%(Filename).pdb')" />
+      <_BclTest Include="$(_MonoProfileDir)\tests\**\*" />
+      <!-- This is referenced by monodroid_corlib_xunit-test.dll -->
+      <_BclTest Include="$(_MonoProfileDir)\System.Runtime.CompilerServices.Unsafe.dll" />
     </ItemGroup>
     <Copy
-        SourceFiles="@(_BclTestAssemblySource)"
-        DestinationFolder="$(XAInstallPrefix)\..\..\bcl-tests"
+        SourceFiles="@(_BclTest)"
+        DestinationFiles="@(_BclTest->'$(XAInstallPrefix)..\..\bcl-tests\%(RecursiveDir)%(Filename)%(Extension)')"
     />
-    <Touch
-        Files="@(_BclTestAssemblySource->'$(XAInstallPrefix)\..\..\bcl-tests\%(Filename)%(Extension)')"
-    />
+    <Touch Files="@(_BclTest->'$(XAInstallPrefix)..\..\bcl-tests\%(RecursiveDir)%(Filename)%(Extension)')" />
     <ItemGroup>
-      <_BclTestContent      Include="$(MonoSourceFullPath)\mcs\class\%(MonoTestAssembly.SourcePath)\Test\**\*.*" />
-      <_BclTestContent      Remove="$(MonoSourceFullPath)\mcs\class\%(MonoTestAssembly.SourcePath)\Test\**\*.cs" />
-      <_BclTestContent      Remove="$(MonoSourceFullPath)\mcs\class\%(MonoTestAssembly.SourcePath)\Test\**\.gitattributes" />
-      <_BclTestContentDest  Include="@(_BclTestContent->'$(XAInstallPrefix)\..\..\bcl-tests\Test\%(RecursiveDir)%(Filename)%(Extension)')" />
-    </ItemGroup>
-    <ItemGroup>
-      <_ZipTestContent      Include="$(MonoSourceFullPath)\mcs\class\System.IO.Compression.FileSystem\foo\**\*.*" />
-      <_ZipTestContentDest  Include="@(_ZipTestContent->'$(XAInstallPrefix)\..\..\bcl-tests\foo\%(RecursiveDir)%(Filename)%(Extension)')" />
-      <_BclTestContent      Include="@(_ZipTestContent)" />
-      <_BclTestContentDest  Include="@(_ZipTestContentDest)" />
+      <_BclTestContent Include="$(MonoSourceFullPath)\mcs\class\%(MonoTestAssembly.SourcePath)\Test\**\*" Condition=" '%(MonoTestAssembly.SourcePath)' != '' " />
+      <_BclTestContent Remove="$(MonoSourceFullPath)\mcs\class\%(MonoTestAssembly.SourcePath)\Test\**\*.cs" Condition=" '%(MonoTestAssembly.SourcePath)' != '' " />
+      <_BclTestContent Remove="$(MonoSourceFullPath)\mcs\class\%(MonoTestAssembly.SourcePath)\Test\**\.gitattributes" Condition=" '%(MonoTestAssembly.SourcePath)' != '' " />
     </ItemGroup>
     <Copy
         SourceFiles="@(_BclTestContent)"
-        DestinationFiles="@(_BclTestContentDest)"
+        DestinationFiles="@(_BclTestContent->'$(XAInstallPrefix)..\..\bcl-tests\Test\%(RecursiveDir)%(Filename)%(Extension)')"
     />
-    <Exec
-        Condition="!Exists('$(XAInstallPrefix)\..\..\bcl-tests\Test\test.db')"
-        Command="sqlite3 &quot;$(XAInstallPrefix)\..\..\bcl-tests\Test\test.db&quot; &lt; &quot;$(MonoSourceFullPath)\mcs\class\Mono.Data.Sqlite\Test\test.sql&quot;"
-    />
+    <Touch Files="@(_BclTestContent->'$(XAInstallPrefix)..\..\bcl-tests\Test\%(RecursiveDir)%(Filename)%(Extension)')" />
     <Exec
         Command="zip -r bcl-tests.zip ."
-        WorkingDirectory="$(XAInstallPrefix)\..\..\bcl-tests"
+        WorkingDirectory="$(XAInstallPrefix)..\..\bcl-tests"
     />
-    <Touch
-        Files="$(XAInstallPrefix)\..\..\bcl-tests\bcl-tests.zip"
-    />
+    <Touch Files="$(XAInstallPrefix)..\..\bcl-tests\bcl-tests.zip" />
 
     <MakeDir
         Directories="$(_MSBuildDir)\lib\%(_MonoRuntime.Identity)"
@@ -615,8 +592,8 @@
     />
 
     <ItemGroup>
-      <_StampFiles Include="$(MonoSourceFullPath)\sdks\out\.stamp-android-$(_MonoSdksConfiguration)-*-$(HostOS)-build"/>
-      <_StampFiles Include="$(MonoSourceFullPath)\sdks\out\.stamp-android-$(_MonoSdksConfiguration)-*-$(HostOS)-download"/>
+      <_StampFiles Include="$(MonoSourceFullPath)\sdks\out\.stamp-android-$(_MonoSdksConfiguration)-$(HostOS)-*-build"/>
+      <_StampFiles Include="$(MonoSourceFullPath)\sdks\out\.stamp-android-$(_MonoSdksConfiguration)-$(HostOS)-*-download"/>
     </ItemGroup>
     <Delete Files="@(_StampFiles)" />
   </Target>

--- a/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/NUnitInstrumentation.cs
+++ b/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/NUnitInstrumentation.cs
@@ -6,6 +6,8 @@ using System.Text;
 
 using Android.App;
 using Android.Runtime;
+using Android.Util;
+
 using Xamarin.Android.UnitTests;
 using Xamarin.Android.UnitTests.NUnit;
 
@@ -35,7 +37,6 @@ namespace UnitTestRunner
 
 		void CommonInit ()
 		{
-			TestAssembliesGlobPattern = "*_test.dll";
 			string cacheDir = Path.Combine (Application.Context.CacheDir.AbsolutePath, DefaultLogTag);
 			using (var files = typeof (NUnitInstrumentation).Assembly.GetManifestResourceStream ("bcl-tests.zip")) {
 				ExtractAssemblies (cacheDir, files);
@@ -73,13 +74,34 @@ namespace UnitTestRunner
 
 		protected override IList<TestAssemblyInfo> GetTestAssemblies()
 		{
-			IList<TestAssemblyInfo> ret = base.GetTestAssemblies();
+			var ret = new List<TestAssemblyInfo> ();
 
-			if (ret == null)
-				ret = new List<TestAssemblyInfo> ();
+			using (var stream = typeof (NUnitInstrumentation).Assembly.GetManifestResourceStream ("nunit-assemblies.txt"))
+			using (var reader = new StreamReader (stream)) {
+				string line;
+				while ((line = reader.ReadLine ()) != null) {
+					string file = Path.Combine (TestsDirectory, line);
 
-			Assembly asm = typeof (BclTests.HttpClientTest).Assembly;
-			ret.Add (new TestAssemblyInfo (asm, asm.Location ?? String.Empty));
+					try {
+						Log.Info (LogTag, $"Adding test assembly: {file}");
+
+						Assembly asm = LoadTestAssembly (file);
+						if (asm == null)
+							continue;
+
+						// We store full path since Assembly.Location is not reliable on Android - it may hold a relative
+						// path or no path at all
+						ret.Add (new TestAssemblyInfo (asm, file));
+					} catch (Exception e) {
+						throw new InvalidOperationException ($"Unable to load test assembly: {file}", e);
+					}
+				}
+			}
+
+			{
+				Assembly asm = typeof (BclTests.HttpClientTest).Assembly;
+				ret.Add (new TestAssemblyInfo (asm, asm.Location ?? String.Empty));
+			}
 
 			return ret;
 		}

--- a/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/XUnitInstrumentation.cs
+++ b/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/XUnitInstrumentation.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Text;
 
 using Android.App;
 using Android.Runtime;
+using Android.Util;
 
+using Xamarin.Android.UnitTests;
 using Xamarin.Android.UnitTests.XUnit;
 
 namespace xUnitTestRunner
@@ -34,11 +37,12 @@ namespace xUnitTestRunner
 
 		void CommonInit ()
 		{
-			TestAssembliesGlobPattern = "*_xunit-test.dll";
 			string cacheDir = Path.Combine (Application.Context.CacheDir.AbsolutePath, DefaultLogTag);
 			using (var files = typeof (XUnitInstrumentation).Assembly.GetManifestResourceStream ("bcl-tests.zip")) {
 				ExtractAssemblies (cacheDir, files);
 			}
+
+			TestsDirectory = cacheDir;
 		}
 
 		protected override void ConfigureFilters (XUnitTestRunner runner)
@@ -78,6 +82,35 @@ namespace xUnitTestRunner
 			}
 
 			runner.SetFilters (filters);
+		}
+
+		protected override IList<TestAssemblyInfo> GetTestAssemblies()
+		{
+			var ret = new List<TestAssemblyInfo> ();
+
+			using (var stream = typeof (XUnitInstrumentation).Assembly.GetManifestResourceStream ("xunit-assemblies.txt"))
+			using (var reader = new StreamReader (stream)) {
+				string line;
+				while ((line = reader.ReadLine ()) != null) {
+					string file = Path.Combine (TestsDirectory, line);
+
+					try {
+						Log.Info (LogTag, $"Adding test assembly: {file}");
+
+						Assembly asm = LoadTestAssembly (file);
+						if (asm == null)
+							continue;
+
+						// We store full path since Assembly.Location is not reliable on Android - it may hold a relative
+						// path or no path at all
+						ret.Add (new TestAssemblyInfo (asm, file));
+					} catch (Exception e) {
+						throw new InvalidOperationException ($"Unable to load test assembly: {file}", e);
+					}
+				}
+			}
+
+			return ret;
 		}
 	}
 }

--- a/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj
+++ b/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj
@@ -83,6 +83,12 @@
     <None Include="Properties\AndroidManifest.xml" />
     <None Include="Assets\AboutAssets.txt" />
     <None Include="packages.config" />
+    <EmbeddedResource Include="xunit-assemblies.txt">
+      <LogicalName>xunit-assemblies.txt</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="nunit-assemblies.txt">
+      <LogicalName>nunit-assemblies.txt</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="xunit-excluded-tests.txt">
       <LogicalName>xunit-excluded-tests.txt</LogicalName>
     </EmbeddedResource>

--- a/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets
+++ b/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets
@@ -5,71 +5,69 @@
   <Import Project="Xamarin.Android.Bcl-Tests.projitems" />
   <Import Project="..\..\..\build-tools\scripts\TestApks.targets" />
   <Import Project="..\..\..\src\mono-runtimes\ProfileAssemblies.projitems" />
+  <Target Name="_GetTestAssemblies">
+    <ItemGroup>
+      <_TestAssembly Include="..\..\..\bin\$(Configuration)\bcl-tests\monodroid_*_test.dll">
+        <!-- This is needed for the remaping from nunitlite to Xamarin.Android.NUnitLite -->
+        <TestType>nunit</TestType>
+      </_TestAssembly>
+      <_TestAssembly Include="..\..\..\bin\$(Configuration)\bcl-tests\monodroid_*_xunit-test.dll" />
+      <!-- This is referenced by monodroid_corlib_xunit-test.dll -->
+      <_TestAssembly Include="..\..\..\bin\$(Configuration)\bcl-tests\System.Runtime.CompilerServices.Unsafe.dll" />
+    </ItemGroup>
+  </Target>
   <Target Name="_AddTestAssemblies"
-      DependsOnTargets="_RemapAssemblies"
+      DependsOnTargets="_GetTestAssemblies;_RemapAssemblies"
       BeforeTargets="ResolveAssemblyReferences">
     <ItemGroup>
-      <Reference Include="@(MonoTestAssembly->'$(IntermediateOutputPath)%(Identity)')" />
-      <Reference Remove="$(IntermediateOutputPath)nunitlite.dll" />
+      <Reference Include="@(_TestAssembly->'$(IntermediateOutputPath)%(RecursiveDir)%(Filename)%(Extension)')" />
     </ItemGroup>
   </Target>
   <Target Name="_RemapAssemblies"
-      Inputs="@(MonoTestAssembly->'..\..\..\bin\$(Configuration)\bcl-tests\%(Identity)')"
-      Outputs="@(MonoTestAssembly->'$(IntermediateOutputPath)%(Identity)')">
+      DependsOnTargets="_GetTestAssemblies"
+      Inputs="@(_TestAssembly)"
+      Outputs="@(_TestAssembly->'$(IntermediateOutputPath)%(RecursiveDir)%(Filename)%(Extension)')">
     <MakeDir Directories="$(IntermediateOutputPath)" />
-    <ItemGroup>
-      <_Source  Include="@(MonoTestAssembly->'..\..\..\bin\$(Configuration)\bcl-tests\%(Identity)')" />
-    </ItemGroup>
     <ResolveAssemblyReference
         Assemblies="Xamarin.Android.NUnitLite"
         SearchPaths="$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0;$(FrameworkPathOverride)">
       <Output TaskParameter="ResolvedFiles"   PropertyName="_NUnit" />
     </ResolveAssemblyReference>
     <Exec
-        Command="$(RemapAssemblyRefTool) &quot;%(_Source.Identity)&quot; &quot;$(IntermediateOutputPath)%(_Source.Filename)%(_Source.Extension)&quot; nunitlite &quot;$(_NUnit)&quot;"
+        Condition=" '%(_TestAssembly.TestType)' == 'nunit' "
+        Command="$(RemapAssemblyRefTool) &quot;%(_TestAssembly.Identity)&quot; &quot;$(IntermediateOutputPath)%(_TestAssembly.RecursiveDir)%(_TestAssembly.Filename)%(_TestAssembly.Extension)&quot; nunitlite &quot;$(_NUnit)&quot;"
+    />
+    <Copy
+        Condition=" '%(_TestAssembly.TestType)' == '' "
+        SourceFiles="@(_TestAssembly->'..\..\..\bin\$(Configuration)\bcl-tests\%(RecursiveDir)%(Filename)%(Extension)')"
+        DestinationFiles="@(_TestAssembly->'$(IntermediateOutputPath)%(RecursiveDir)%(Filename)%(Extension)')"
+    />
+    <Copy
+        Condition="Exists('..\..\..\bin\$(Configuration)\bcl-tests\%(_TestAssembly.RecursiveDir)%(_TestAssembly.Filename).pdb')"
+        SourceFiles="@(_TestAssembly->'..\..\..\bin\$(Configuration)\bcl-tests\%(RecursiveDir)%(Filename).pdb')"
+        DestinationFiles="@(_TestAssembly->'$(IntermediateOutputPath)%(RecursiveDir)%(Filename).pdb')"
+    />
+  </Target>
+  <Target Name="_WriteAssembliesList"
+      Outputs="nunit-assemblies.txt;xunit-assemblies.txt"
+      BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <_NUnitTestAssembly Include="@(MonoTestAssembly)" Condition=" '%(MonoTestAssembly.TestType)' == '' " />
+    </ItemGroup>
+    <WriteLinestoFile
+        File="nunit-assemblies.txt"
+        Lines="@(_NUnitTestAssembly)"
+        WriteOnlyWhenDifferent="True"
+        Overwrite="True"
     />
     <ItemGroup>
-      <_DebugSymbol
-          Include="..\..\..\bin\$(Configuration)\bcl-tests\%(MonoTestAssembly.Filename).pdb"
-          Condition="Exists('..\..\..\bin\$(Configuration)\bcl-tests\%(MonoTestAssembly.Filename).pdb')"
-      />
+      <_XUnitTestAssembly Include="@(MonoTestAssembly)" Condition=" '%(MonoTestAssembly.TestType)' == 'xunit' " />
     </ItemGroup>
-    <Copy
-        SourceFiles="@(_DebugSymbol)"
-        DestinationFolder="$(IntermediateOutputPath)"
+    <WriteLinestoFile
+        File="xunit-assemblies.txt"
+        Lines="@(_XUnitTestAssembly)"
+        WriteOnlyWhenDifferent="True"
+        Overwrite="True"
     />
-  </Target>
-  <ItemGroup>
-    <_TestResource Include="..\..\..\bin\$(Configuration)\bcl-tests\Test\resources\Resources.es-ES.resources">
-      <Culture>es-ES</Culture>
-      <Name>monodroid_corlib_test.resources.dll</Name>
-    </_TestResource>
-    <_TestResource Include="..\..\..\bin\$(Configuration)\bcl-tests\Test\resources\Resources.nn-NO.resources">
-      <Culture>nn-NO</Culture>
-      <Name>monodroid_corlib_test.resources.dll</Name>
-    </_TestResource>
-  </ItemGroup>
-  <Target Name="_CreateTestResources"
-      BeforeTargets="ResolveAssemblyReferences"
-      DependsOnTargets="_ExtractTestResources"
-      Inputs="@(_TestResource)"
-      Outputs="$(IntermediateOutputPath)%(_TestResource.Culture)\%(_TestResource.Name)">
-    <MakeDir Directories="$(IntermediateOutputPath)%(_TestResource.Culture)" />
-    <AL
-        OutputAssembly="$(IntermediateOutputPath)%(Culture)\%(Name)"
-        Version="1.0.0.0"
-        Culture="%(Culture)"
-        EmbedResources="@(_TestResource)"
-    />
-  </Target>
-  <Target Name="_ExtractTestResources"
-      Inputs="..\..\..\bin\$(Configuration)\bcl-tests\bcl-tests.zip"
-      Outputs="@(_TestResource)">
-    <SystemUnzip
-        SourceFiles="..\..\..\bin\$(Configuration)\bcl-tests\bcl-tests.zip"
-        HostOS="$(HostOS)"
-        DestinationFolder="..\..\..\bin\$(Configuration)\bcl-tests"
-    />
-    <Touch Files="@(_TestResource)" />
   </Target>
 </Project>

--- a/tests/TestRunner.Core/TestInstrumentation.cs
+++ b/tests/TestRunner.Core/TestInstrumentation.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Android.UnitTests
 		Bundle arguments;
 
 		protected abstract string LogTag { get; set; }
-		protected string TestAssembliesGlobPattern { get; set; }
+		protected string TestsDirectory { get; set; }
 		protected IList<string> TestAssemblyDirectories { get; set; }
 		protected bool GCAfterEachFixture { get; set; }
 		protected LogWriter Logger { get; } = new LogWriter ();
@@ -249,6 +249,10 @@ namespace Xamarin.Android.UnitTests
 				return false;
 			}
 
+			Log.Info (LogTag, "Test assemblies:");
+			foreach (var asm in assemblies)
+				Log.Info (LogTag, $"\t{asm.FullPath}");
+
 			TRunner runner = CreateRunner (Logger, arguments);
 			runner.LogTag = LogTag;
 			ConfigureFilters (runner);
@@ -292,13 +296,13 @@ namespace Xamarin.Android.UnitTests
 
 			if (TestAssemblyDirectories != null && TestAssemblyDirectories.Count > 0) {
 				foreach (string adir in TestAssemblyDirectories)
-					GetTestAssembliesFromDirectory (adir, TestAssembliesGlobPattern, ret);
+					GetTestAssembliesFromDirectory (adir, ret);
 			}
 
 			return ret;
 		}
 
-		protected virtual void GetTestAssembliesFromDirectory (string directoryPath, string globPattern, IList<TestAssemblyInfo> assemblies)
+		protected virtual void GetTestAssembliesFromDirectory (string directoryPath, IList<TestAssemblyInfo> assemblies)
 		{
 			if (String.IsNullOrEmpty (directoryPath))
 				throw new ArgumentException ("must not be null or empty", nameof (directoryPath));
@@ -306,8 +310,7 @@ namespace Xamarin.Android.UnitTests
 			if (assemblies == null)
 				throw new ArgumentNullException (nameof (assemblies));
 
-			string pattern = String.IsNullOrEmpty (globPattern) ? "*.dll" : globPattern;
-			foreach (string file in Directory.EnumerateFiles (directoryPath, pattern, SearchOption.AllDirectories)) {
+			foreach (string file in Directory.EnumerateFiles (directoryPath, "*.dll", SearchOption.AllDirectories)) {
 				Log.Info (LogTag, $"Adding test assembly: {file}");
 				Assembly asm;
 				Exception ex = null;
@@ -368,7 +371,7 @@ namespace Xamarin.Android.UnitTests
 			}
 
 			Log.Info (LogTag, "Extracted assemblies:");
-			foreach (string fi in Directory.EnumerateFiles (targetDir, "*.dll")) {
+			foreach (string fi in Directory.EnumerateFiles (targetDir, "*.dll", SearchOption.AllDirectories)) {
 				Log.Info (LogTag, $"  {fi}");
 			}
 		}

--- a/tests/TestRunner.NUnit/NUnitTestInstrumentation.cs
+++ b/tests/TestRunner.NUnit/NUnitTestInstrumentation.cs
@@ -17,7 +17,6 @@ namespace Xamarin.Android.UnitTests.NUnit
 		protected IEnumerable<string> IncludedCategories { get; set; }
 		protected IEnumerable<string> ExcludedCategories { get; set; }
 		protected IEnumerable<string> ExcludedTestNames { get; set; }
-		protected string TestsDirectory { get; set; }
 
 		protected NUnitTestInstrumentation ()
 		{


### PR DESCRIPTION
Context: https://github.com/mono/mono/blob/8e0cbf1044fb86f40c41f4317ef9154f82a94bb4/scripts/ci/pipeline/sdks-archive.groovy#L84
Context: https://jenkins.mono-project.com/view/Per-commit%20packages/job/archive-mono/

The mono archives have a different filename format than that used in
commit f970cd50.  As per [`sdks-archive.groovy`][0], the filename to
download *should* be:

	${product}-${configuration}-${platform}-${commitHash}.zip

Update `$(_MonoArchiveName)` accordingly, and fix the output paths so
that the mono archive can actually be used.  (As noted in f970cd50,
*actual* support for building with the mono archive hadn't been
tested, as one didn't exist for the mono xamarin-android uses.)

[0]: https://github.com/mono/mono/blob/8e0cbf1044fb86f40c41f4317ef9154f82a94bb4/scripts/ci/pipeline/sdks-archive.groovy