### PR TITLE
[Xamarin.Android.Build.Tasks] aapt2, move ConvertResourcesCases to a new target

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1363,12 +1363,10 @@ because xbuild doesn't support framework reference assemblies.
 	</ComputeHash>
 </Target>
 
-<Target Name="_CompileAndroidLibraryResources" DependsOnTargets="_CollectLibraryResourceDirectories"
+<Target Name="_ConvertLibraryResourcesCases" DependsOnTargets="_CollectLibraryResourceDirectories"
 		Condition="'$(_AndroidUseAapt2)' == 'True'"
-		Inputs="%(_LibraryResourceHashDirectories.FileFound)"
-		Outputs="$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).stamp"
-	>
-	<MakeDir Directories="$(_AndroidLibraryFlatArchivesDirectory)" Condition="!Exists('$(_AndroidLibraryFlatArchivesDirectory)')" />
+		Inputs="@(_LibraryResourceHashDirectories->'%(FileFound)')"
+		Outputs="$(_AndroidStampDirectory)_ConvertLibraryResourcesCases.stamp">
 	<ConvertResourcesCases
 		Condition=" '@(_LibraryResourceDirectories)' != '' "
 		ContinueOnError="$(DesignTimeBuild)"
@@ -1376,8 +1374,17 @@ because xbuild doesn't support framework reference assemblies.
 		ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
 		AcwMapFile="$(_AcwMapFile)"
 		CustomViewMapFile="$(_CustomViewMapFile)"
-		AndroidConversionFlagFile="$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).stamp"
+		AndroidConversionFlagFile="$(_AndroidStampDirectory)_ConvertLibraryResourcesCases.stamp"
 	/>
+	<Touch Files="$(_AndroidStampDirectory)_ConvertLibraryResourcesCases.stamp" AlwaysCreate="True" />
+</Target>
+
+<Target Name="_CompileAndroidLibraryResources" DependsOnTargets="_ConvertLibraryResourcesCases"
+		Condition="'$(_AndroidUseAapt2)' == 'True'"
+		Inputs="%(_LibraryResourceHashDirectories.FileFound)"
+		Outputs="$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).stamp"
+	>
+	<MakeDir Directories="$(_AndroidLibraryFlatArchivesDirectory)" Condition="!Exists('$(_AndroidLibraryFlatArchivesDirectory)')" />
 	<Aapt2Compile
 		Condition=" '@(_LibraryResourceHashDirectories)' != '' "
 		ContinueOnError="$(DesignTimeBuild)"


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2356

When `$(AndroidUseAapt2)=True`, if you look for a log entry of a file
that is processed:

    Processing: C:\Users\myuser\Desktop\Git\xamarin-android\tests\Xamarin.Forms-Performance-Integration\Droid\obj\Debug\90\lp\22\jl\res\values\values.xml   10/30/2018 4:28:18 PM > 1/1/0001 12:00:00 AM

You will see this repeated several times (9 in case of a Xamarin.Forms
project).

It turns out, since the `_CompileAndroidLibraryResources` target is
batched, it is called once per item of
`@(_LibraryResourceHashDirectories)`:

    <Target Name="_CompileAndroidLibraryResources" DependsOnTargets="_CollectLibraryResourceDirectories"
            Condition="'$(_AndroidUseAapt2)' == 'True'"
            Inputs="%(_LibraryResourceHashDirectories.FileFound)"
            Outputs="$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).stamp">
    ...
    <ConvertResourcesCases ... />
    <Aapt2Compile ... />
    ...
    </Target>

It calls `ConvertResourcesCases` for each call, which is not ideal.
`ConvertResourcesCases` operates on the whole tree of resources, so it
really should just run once: *before* `<Aapt2Compile/>`.

I think the fix here is:

- Move `ConvertResourcesCases` to a new
  `_ConvertLibraryResourcesCases` target
- The new target's `Inputs` should be
  `@(_LibraryResourceHashDirectories->'%(FileFound)')` and *not* batched.
- The new target's `Outputs` should be a new stamp file following our
  new convention.
- The new stamp file should also be used as
  `AndroidConversionFlagFile`.
- `_CompileAndroidLibraryResources` now depends on
  `_ConvertLibraryResourcesCases`, and it should only run on the first
  batched instance of `_CompileAndroidLibraryResources`.