### PR TITLE
[build] fixes for failing Windows build

### DIFF
--- a/src/r8/r8.targets
+++ b/src/r8/r8.targets
@@ -5,7 +5,7 @@
 
   <PropertyGroup>
     <!--NOTE: we don't want a gradle daemon locking directories on Windows-->
-    <_GradleArgs>--no-daemon</_GradleArgs>
+    <_GradleArgs>--stacktrace --no-daemon</_GradleArgs>
     <BuildDependsOn>
       ResolveReferences;
       _BuildR8;

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask AssemblyFile="..\..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
   <Target Name="BuildNativeLibs"
       DependsOnTargets="AndroidPrepareForBuild"
       Inputs="jni\simple-lib.c;jni\Android.mk"
@@ -38,15 +39,24 @@
         WorkingDirectory="$(OutputPath)\native-lib-2"
     />
   </Target>
+  <Target Name="_ReplaceGradleFile"
+      Inputs="java\JavaLib\library\build.gradle.in"
+      Outputs="java\JavaLib\library\build.gradle">
+    <ReplaceFileContents
+        SourceFile="java\JavaLib\library\build.gradle.in"
+        DestinationFile="java\JavaLib\library\build.gradle"
+        Replacements="@BUILD_TOOLS_VERSION@=$(XABuildToolsFolder)"
+    />
+  </Target>
   <Target Name="BuildJavaLibs"
-      DependsOnTargets="AndroidPrepareForBuild"
-      Inputs="java\JavaLib\project.properties"
+      DependsOnTargets="AndroidPrepareForBuild;_ReplaceGradleFile"
+      Inputs="java\JavaLib\project.properties;java\JavaLib\library\build.gradle"
       Outputs="$(OutputPath)JavaLib.zip">
     <PropertyGroup>
       <_Jdk9Modules Condition="$(_JdkVersion.StartsWith ('9'))">JAVA_OPTS="--add-modules java.xml.bind"</_Jdk9Modules>
     </PropertyGroup>
     <Exec
-        EnvironmentVariables="ANDROID_HOME=$(AndroidSdkDirectory);JAVA_HOME=$(JavaSdkDirectory)"
+        EnvironmentVariables="ANDROID_HOME=$(AndroidSdkDirectory);ANDROID_NDK_HOME=$(AndroidNdkDirectory);JAVA_HOME=$(JavaSdkDirectory)"
         Command="$(_Jdk9Modules) .\gradlew assembleDebug --stacktrace --no-daemon"
         WorkingDirectory="$(MSBuildThisFileDirectory)java\JavaLib"
     />

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/java/JavaLib/library/.gitignore
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/java/JavaLib/library/.gitignore
@@ -1,1 +1,3 @@
 /build
+# Generated
+/build.gradle

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/java/JavaLib/library/build.gradle.in
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/java/JavaLib/library/build.gradle.in
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion "@BUILD_TOOLS_VERSION@"
 
     defaultConfig {
         minSdkVersion 19


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/2019
Context: http://build.devdiv.io/2168276
Context: http://build.devdiv.io/2169681

Since 4bb4b2e, our builds have been failing on VSTS on Windows.
Jenkins is green, however.

Currently getting a failure in
`Xamarin.Android.LibraryProjectZip-LibBinding.csproj` such as:

    2018-10-31T14:02:28.8336608Z    .\gradlew assembleDebug --stacktrace --no-daemon
    2018-10-31T14:02:40.7122197Z   NDK is missing a "platforms" directory.
    2018-10-31T14:02:40.7122937Z   If you are using NDK, verify the ndk.dir is set to a valid NDK directory.  It is currently set to C:\Users\dlab14\android-toolchain\sdk\ndk-bundle.
    2018-10-31T14:02:40.7124870Z   If you are not using NDK, unset the NDK variable from ANDROID_NDK_HOME or local.properties to remove this warning.

It doesn't really make sense to me why this started happening with
d8/r8 support... The `~\android-toolchain\sdk\ndk-bundle` path seems
completely wrong.

However, it looks like we should be setting
`ANDROID_NDK_HOME=$(AndroidNdkDirectory)`.

After that change, we got a new error:

    2018-10-31T17:19:30.1558223Z   Checking the license for package Android SDK Build-Tools 25.0.2 in C:\Users\dlab14\android-toolchain\sdk\licenses
    2018-10-31T17:19:30.1562674Z EXEC : warning : License for package Android SDK Build-Tools 25.0.2 not accepted. [E:\A\_work\14\s\tests\CodeGen-Binding\Xamarin.Android.LibraryProjectZip-LibBinding\Xamarin.Android.LibraryProjectZip-LibBinding.csproj]

So this is the actual problem!

In fa57aa8, I changed `android-toolchain` to not run
`<AcceptAndroidSdkLicense/>` all the time. That was actually making
this `.\gradlew` command successfully install Android SDK Build-Tools
25.0.2 and use it without a license prompt. We started seeing the
problem since 4bb4b2e, because it caused a new
`~\android-toolchain\sdk` directory to get setup.

The fix here is to just use Build-Tools 28.0.0, since that is the
version we boostrap and install during our build.

But we would never actually remember to update this value... So we
should make a `build.gradle.in` file, and replace with our existing
property from `Configuration.props`:

    <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">28.0.0</XABuildToolsFolder>

Other changes:
- Added `--stacktrace` to the gradle calls in `r8.targets`, so we get
  better error messages. It also matches the gradle command in
  `Xamarin.Android.LibraryProjectZip-LibBinding.csproj`.