### PR TITLE
[Xamarin.ProjectTools] change Now to UtcNow

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -241,9 +241,9 @@ using System.Runtime.CompilerServices;
 				Assert.IsTrue (
 					b.Output.IsTargetSkipped ("_LinkAssembliesNoShrink"),
 					"The Target _LinkAssembliesNoShrink should have been skipped");
-				image1.Timestamp = DateTime.UtcNow;
+				image1.Timestamp = DateTimeOffset.UtcNow;
 				var layout = proj.AndroidResources.First (x => x.Include() == "Resources\\layout\\Main.axml");
-				layout.Timestamp = DateTime.UtcNow;
+				layout.Timestamp = DateTimeOffset.UtcNow;
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate:true, saveProject: false), "Third build was supposed to build without errors");
 				Assert.IsFalse (
 					b.Output.IsTargetSkipped ("_UpdateAndroidResgen"),
@@ -528,7 +528,7 @@ namespace UnnamedProject
 				Assert.IsTrue ((File.GetAttributes (designerPath) & FileAttributes.ReadOnly) == FileAttributes.ReadOnly,
 					"{0} should be read only", designerPath);
 				var main = proj.AndroidResources.First (x => x.Include () == "Resources\\layout\\Main.axml");
-				main.Timestamp = DateTime.UtcNow;
+				main.Timestamp = DateTimeOffset.UtcNow;
 				main.TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
 <LinearLayout xmlns:android=""http://schemas.android.com/apk/res/android""
 	android:orientation=""vertical""
@@ -867,7 +867,7 @@ namespace UnnamedProject
 <resources>
 	<string name=""greeting"">Foo</string>
 </resources>";
-					strings_de.Timestamp = DateTime.Now;
+					strings_de.Timestamp = DateTimeOffset.UtcNow;
 
 					Assert.IsTrue (dllBuilder.Build (library), "Third Library1 build should have succeeded");
 					Assert.IsTrue (b.Build (project), "Third Applications1 build should have succeeded");
@@ -946,7 +946,7 @@ namespace UnnamedProject
 	<color name=""dark_red"">#FFFFFF</color>
 	<color name=""xamarin_green"">#00AA00</color>
 </resources>";
-					values.Timestamp = DateTime.Now;
+					values.Timestamp = DateTimeOffset.UtcNow;
 					Assert.IsTrue (b.Build (proj), "Third Build should have succeeded");
 
 					Assert.IsTrue (File.Exists (colorsXml), "{0} should exist", colorsXml);
@@ -996,7 +996,7 @@ namespace UnnamedProject
 
 				var theme = proj.AndroidResources.First (x => x.Include () == "Resources\\values\\Theme.xml");
 				theme.Deleted = true;
-				theme.Timestamp = DateTime.Now;
+				theme.Timestamp = DateTimeOffset.UtcNow;
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
 
 				Assert.IsFalse (File.Exists (Path.Combine (Root, builder.ProjectDirectory, proj.IntermediateOutputPath, "res", "values", "theme.xml")),
@@ -1048,7 +1048,7 @@ namespace Lib1 {
 					appBuilder.Verbosity = LoggerVerbosity.Diagnostic;
 					Assert.IsTrue (appBuilder.Build (appProj), "Application Build should have succeeded.");
 					Assert.IsFalse (appBuilder.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "_UpdateAndroidResgen target not should be skipped.");
-					foo.Timestamp = DateTime.UtcNow;
+					foo.Timestamp = DateTimeOffset.UtcNow;
 					Assert.IsTrue (libBuilder.Build (libProj, doNotCleanupOnUpdate: true, saveProject: false), "Library project should have built");
 					Assert.IsTrue (libBuilder.Output.IsTargetSkipped ("_CreateManagedLibraryResourceArchive"), "_CreateManagedLibraryResourceArchive should be skipped.");
 					Assert.IsTrue (appBuilder.Build (appProj, doNotCleanupOnUpdate: true, saveProject: false), "Application Build should have succeeded.");
@@ -1058,7 +1058,7 @@ namespace Lib1 {
 	<color name=""theme_devicedefault_background"">#00000000</color>
 	<color name=""theme_devicedefault_background2"">#ffffffff</color>
 </resources>";
-					theme.Timestamp = DateTime.UtcNow;
+					theme.Timestamp = DateTimeOffset.UtcNow;
 					Assert.IsTrue (libBuilder.Build (libProj, doNotCleanupOnUpdate: true, saveProject: false), "Library project should have built");
 					Assert.IsFalse (libBuilder.Output.IsTargetSkipped ("_CreateManagedLibraryResourceArchive"), "_CreateManagedLibraryResourceArchive should not be skipped.");
 					Assert.IsTrue (appBuilder.Build (appProj, doNotCleanupOnUpdate: true, saveProject: false), "Application Build should have succeeded.");
@@ -1066,7 +1066,7 @@ namespace Lib1 {
 					Assert.IsTrue (text.Contains ("theme_devicedefault_background2"), "Resource.designer.cs was not updated.");
 					Assert.IsFalse (appBuilder.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "_UpdateAndroidResgen target should NOT be skipped.");
 					theme.Deleted = true;
-					theme.Timestamp = DateTime.UtcNow;
+					theme.Timestamp = DateTimeOffset.UtcNow;
 					Assert.IsTrue (libBuilder.Build (libProj, saveProject: true), "Library project should have built");
 					var themeFile = Path.Combine (Root, path, libProj.ProjectName, libProj.IntermediateOutputPath, "res", "values", "theme.xml");
 					Assert.IsTrue (!File.Exists (themeFile), $"{themeFile} should have been deleted.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -980,7 +980,7 @@ namespace UnnamedProject {
 				Assert.IsTrue (
 					b.Output.IsTargetSkipped ("_LinkAssembliesShrink"),
 					"the _LinkAssembliesShrink target should not run");
-				foo.Timestamp = DateTime.UtcNow;
+				foo.Timestamp = DateTimeOffset.UtcNow;
 				Assert.IsTrue (b.Build (proj), "third build failed");
 				Assert.IsFalse (b.Output.IsTargetSkipped ("CoreCompile"),
 					"the Core Compile target should run");
@@ -1165,7 +1165,7 @@ namespace App1
 					b.Output.IsTargetSkipped ("_CopyMdbFiles"),
 					"the _CopyMdbFiles target should be skipped");
 				var lastTime = File.GetLastWriteTimeUtc (pdbToMdbPath);
-				pdb.Timestamp = DateTime.UtcNow;
+				pdb.Timestamp = DateTimeOffset.UtcNow;
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "third build failed");
 				Assert.IsFalse (
 					b.Output.IsTargetSkipped ("_CopyMdbFiles"),
@@ -2049,7 +2049,7 @@ namespace App1
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
 				Assert.IsTrue (builder.Output.IsTargetSkipped ("_ResolveLibraryProjectImports"),
 					"_ResolveLibraryProjectImports should not have run.");
-				aar.Timestamp = DateTime.UtcNow.Add (TimeSpan.FromMinutes (2));
+				aar.Timestamp = DateTimeOffset.UtcNow.Add (TimeSpan.FromMinutes (2));
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
 				Assert.IsFalse (builder.Output.IsTargetSkipped ("_ResolveLibraryProjectImports"),
 					"_ResolveLibraryProjectImports should have run.");
@@ -2399,7 +2399,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				FileAssert.Exists (build_props, "build.props should exist after first build.");
 				proj.PackageReferences.Add (KnownPackages.SupportV7CardView_24_2_1);
 				foreach (var reference in KnownPackages.SupportV7CardView_24_2_1.References) {
-					reference.Timestamp = DateTimeOffset.Now;
+					reference.Timestamp = DateTimeOffset.UtcNow;
 					proj.References.Add (reference);
 				}
 				b.Save (proj, doNotCleanupOnUpdate: true);
@@ -2576,7 +2576,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 					"the _CopyMdbFiles target should be skipped");
 				b.BuildLogFile = "build2.log";
 				var lastTime = File.GetLastWriteTimeUtc (pdbToMdbPath);
-				pdb.Timestamp = DateTime.UtcNow;
+				pdb.Timestamp = DateTimeOffset.UtcNow;
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "third build failed");
 				Assert.IsFalse (
 					b.Output.IsTargetSkipped ("_CopyMdbFiles"),

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -134,7 +134,7 @@ namespace Lib
 				Assert.IsTrue (b.LastBuildOutput.ContainsText ("LogicalName=__AndroidLibraryProjects__.zip") ||
 						b.LastBuildOutput.ContainsText ("Lib.obj.Debug.__AndroidLibraryProjects__.zip,__AndroidLibraryProjects__.zip"),
 						"The LogicalName for __AndroidLibraryProjects__.zip should be set.");
-				class1Source.Timestamp = DateTime.UtcNow.Add (TimeSpan.FromMinutes (1));
+				class1Source.Timestamp = DateTimeOffset.UtcNow.Add (TimeSpan.FromMinutes (1));
 				Assert.IsTrue (b.Build (lib), "Build should have succeeded.");
 				Assert.IsTrue (b.LastBuildOutput.ContainsText ("LogicalName=__AndroidLibraryProjects__.zip") ||
 						b.LastBuildOutput.ContainsText ("Lib.obj.Debug.__AndroidLibraryProjects__.zip,__AndroidLibraryProjects__.zip"),
@@ -181,7 +181,6 @@ public class TestMe {
 	}
 }",
 						Encoding = Encoding.ASCII,
-						Timestamp = DateTimeOffset.Now,
 					}
 				},
 			};
@@ -219,7 +218,6 @@ public class TestMe {
 					new BuildItem (AndroidBuildActions.EmbeddedNativeLibrary, "libs/armeabi-v7a/libfoo.so") {
 						TextContent = () => string.Empty,
 						Encoding = Encoding.ASCII,
-						Timestamp = DateTimeOffset.Now,
 					}
 				},
 				Sources = {
@@ -249,7 +247,6 @@ namespace Lib
 					new BuildItem (AndroidBuildActions.EmbeddedNativeLibrary, "libs/armeabi-v7a/libfoo2.so") {
 						TextContent = () => string.Empty,
 						Encoding = Encoding.ASCII,
-						Timestamp = DateTimeOffset.Now,
 					},
 					new BuildItem.ProjectReference (@"..\Lib\Lib.csproj", "Lib", lib.ProjectGuid) {
 					}
@@ -297,7 +294,7 @@ namespace Lib2
 						Assert.IsNotNull (libfoo, "libfoo.so should exist in the .apk");
 
 						so.TextContent = () => "newValue";
-						so.Timestamp = DateTimeOffset.Now;
+						so.Timestamp = DateTimeOffset.UtcNow;
 						Assert.IsTrue (libbuilder.Build (lib), "lib 2nd. build failed");
 						Assert.IsTrue (libbuilder2.Build (lib2), "lib 2nd. build failed");
 						Assert.IsTrue (builder.Build (app), "app 2nd. build failed");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
@@ -93,7 +93,7 @@ namespace Xamarin.ProjectTools
 		public void Touch (params string [] itemPaths)
 		{
 			foreach (var item in itemPaths)
-				GetItem (item).Timestamp = DateTimeOffset.Now;
+				GetItem (item).Timestamp = DateTimeOffset.UtcNow;
 		}
 
 		public virtual ProjectRootElement Construct ()


### PR DESCRIPTION
Downstream in `monodroid` we are getting a random test failure with a
test case such as:

    proj.Touch ("SomeFile");
    Assert.IsTrue (b.Build (proj, true, null, false));

It seems from the build log that `SomeFile` was not actually updated.

So looking at `Touch`, it uses `Now` instead of `UtcNow`:

    foreach (var item in itemPaths)
        GetItem (item).Timestamp = DateTimeOffset.Now;

But the code deciding to save a file or not uses `LastWriteTimeUtc`:

    var needsUpdate = (!File.Exists (path) || p.Timestamp == null || p.Timestamp.Value > new DateTimeOffset (new FileInfo (path).LastWriteTimeUtc));

We should be using `Utc` everywhere. I've gone through
Xamarin.ProjectTools and the MSBuild tests to use `UtcNow` where
needed. Some places I also changed to use `DateTimeOffset` instead of
`DateTime` for consistency.

Some places were setting `Timestamp` on new files, which isn't really
needed. I just removed these.

Hopefully some of our random test failures will improve.