### PR TITLE
[build-tools] Write the intrumentation timing output again

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
@@ -78,7 +78,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 					ArgumentsString = $"{AdbTarget} {AdbOptions} logcat -v threadtime -d",
 					MergeStdoutAndStderr = false,
 					StdoutFilePath = LogcatFilename,
-					StdoutAppend = File.Exists (LogcatFilename),
+					StdoutAppend = true,
 				},
 
 				new CommandInfo {

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
@@ -76,6 +76,9 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 				new CommandInfo {
 					ArgumentsString = $"{AdbTarget} {AdbOptions} logcat -v threadtime -d",
+					MergeStdoutAndStderr = false,
+					StdoutFilePath = LogcatFilename,
+					StdoutAppend = File.Exists (LogcatFilename),
 				},
 
 				new CommandInfo {

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunUITests.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunUITests.cs
@@ -35,7 +35,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 					ArgumentsString = $"{AdbTarget} {AdbOptions} logcat -v threadtime -d",
 					MergeStdoutAndStderr = false,
 					StdoutFilePath = LogcatFilename,
-					StdoutAppend = File.Exists (LogcatFilename)
+					StdoutAppend = true,
 				},
 			};
 		}


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/2371

After https://github.com/xamarin/xamarin-android/pull/2125, the
`RunInstrumentationTests` task stopped writing the logcat output to
the `LogcatFilename` specified as parameter.

That resulted in missing input files for the `ProcessLogcatTiming`
task.