### PR TITLE
[Xamarin.Android.Build.Tasks] Fix Various `Lint` Issues

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1396,10 +1396,15 @@ namespace App1
 		{
 			FixLintOnWindows ();
 
-			var proj = new XamarinAndroidApplicationProject ();
-			proj.UseLatestPlatformSdk = true;
+			var proj = new XamarinAndroidApplicationProject () {
+				PackageReferences = {
+					KnownPackages.AndroidSupportV4_27_0_2_1,
+					KnownPackages.SupportConstraintLayout_1_0_2_2,
+				},
+			};
+			proj.UseLatestPlatformSdk = false;
 			proj.SetProperty ("AndroidLintEnabled", true.ToString ());
-			proj.SetProperty ("AndroidLintDisabledIssues", "StaticFieldLeak,ObsoleteSdkInt");
+			proj.SetProperty ("AndroidLintDisabledIssues", "StaticFieldLeak,ObsoleteSdkInt,AllowBackup");
 			proj.SetProperty ("AndroidLintEnabledIssues", "");
 			proj.SetProperty ("AndroidLintCheckIssues", "");
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("public class MainActivity : Activity", @"
@@ -1410,9 +1415,34 @@ namespace App1
 		)]
 		public class MainActivity : Activity
 			");
-			using (var b = CreateApkBuilder ("temp/CheckLintErrorsAndWarnings")) {
+			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\layout\\test.axml") {
+				TextContent = () => {
+					return @"<?xml version=""1.0"" encoding=""utf-8""?>
+<ConstraintLayout xmlns:android=""http://schemas.android.com/apk/res/android""
+	xmlns:app=""http://schemas.android.com/apk/res-auto""
+	android:orientation=""vertical""
+	android:layout_width=""fill_parent""
+	android:layout_height=""fill_parent"">
+	<TextView android:id=""@+id/foo""
+		android:layout_width=""150dp""
+		android:layout_height=""wrap_content""
+		app:layout_constraintTop_toTopOf=""parent""
+	/>
+</ConstraintLayout>";
+				}
+			});
+			using (var b = CreateApkBuilder ("temp/CheckLintErrorsAndWarnings", cleanupOnDispose: false)) {
+				string apiLevel;
+				proj.TargetFrameworkVersion = b.LatestTargetFrameworkVersion (out apiLevel);
+				proj.AndroidManifest = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" android:versionCode=""1"" android:versionName=""1.0"" package=""UnamedProject.UnamedProject"">
+	<uses-sdk android:minSdkVersion=""24"" android:targetSdkVersion=""{APILEVEL}"" />
+	<application android:label=""${PROJECT_NAME}"">
+	</application >
+</manifest> ".Replace ("{APILEVEL}", apiLevel);
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				StringAssertEx.DoesNotContain ("XA0102", b.LastBuildOutput);
+				StringAssertEx.DoesNotContain ("XA0102", b.LastBuildOutput, "Output should not contain any XA0102 warnings");
+				StringAssertEx.DoesNotContain ("XA0103", b.LastBuildOutput, "Output should not contain any XA0103 errors");
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -338,6 +338,16 @@ namespace Xamarin.ProjectTools
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v7.MediaRouter.27.0.2.1\\lib\\MonoAndroid81\\Xamarin.Android.Support.v7.MediaRouter.dll" }
 			}
 		};
+		public static Package SupportConstraintLayout_1_0_2_2 = new Package {
+			Id = "Xamarin.Android.Support.Constraint.Layout",
+			Version = "1.0.2.2",
+			TargetFramework = "MonoAndroid70",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.Constraint.Layout") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.Constraint.Layout.1.0.2.2\\lib\\MonoAndroid70\\Xamarin.Android.Support.Constraint.Layout.dll"
+				}
+			}
+		};
 		public static Package VectorDrawable_27_0_2_1 = new Package {
 			Id = "Xamarin.Android.Support.Vector.Drawable",
 			Version = "27.0.2.1",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -7,6 +7,9 @@ using System.Text;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Xml;
+using System.Xml.XPath;
+using System.Xml.Linq;
 
 using XABuildPaths = Xamarin.Android.Build.Paths;
 
@@ -170,7 +173,12 @@ namespace Xamarin.ProjectTools
 		}
 
 		public string LatestTargetFrameworkVersion () {
+			return LatestTargetFrameworkVersion (out string apiLevel);
+		}
+
+		public string LatestTargetFrameworkVersion (out string apiLevel) {
 			Version latest = new Version (1, 0);
+			apiLevel = "1";
 			var outdir = FrameworkLibDirectory;
 			var path = Path.Combine (outdir, "xbuild-frameworks", "MonoAndroid");
 			if (!Directory.Exists(path)) {
@@ -181,8 +189,14 @@ namespace Xamarin.ProjectTools
 				string v = Path.GetFileName (dir).Replace ("v", "");
 				if (!Version.TryParse (v, out version))
 					continue;
-				if (latest.Major < version.Major && latest.Minor <= version.Minor)
+				if (latest.Major < version.Major && latest.Minor <= version.Minor) {
+					var apiInfo = Path.Combine (dir, "AndroidApiInfo.xml");
+					if (File.Exists (apiInfo)) {
+						var doc = XDocument.Load (apiInfo);
+						apiLevel = doc.XPathSelectElement ("/AndroidApiInfo/Level")?.Value ?? apiLevel;
+					}
 					latest = version;
+				}
 			}
 			return "v" + latest.ToString (2);
 		}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1086,7 +1086,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_LintChecks" Condition=" '$(AndroidLintEnabled)' == 'True' ">
 	<Lint
-		TargetDirectory="$(IntermediateOutputPath)"
+		TargetDirectory="$(IntermediateOutputPath)android"
 		EnabledIssues="$(AndroidLintEnabledIssues)"
 		DisabledIssues="$(AndroidLintDisabledIssues)"
 		CheckIssues="$(AndroidLintCheckIssues)"


### PR DESCRIPTION
Fixes #2360, #2361, #2362, #2363

When running the `Lint` checks on an application we
provide a path to a `project` directory. This is
currently the `$(IntermediateOutputPath)`. The problem
with this is that it also includes the `lp` directory.
The `lp` directory contains ALL the resources and
Manifest files for the library projects. As a result
if you are referencing support packages ALL of those
items are checked too.

It turns out that most of the Manifest files shipped
with the libraries are not complete or will cause
`lint` errors or warnings.

So what we need to do is point the `lint` check at
the `$(IntermediateOutputPath)android`. This will restrict
the checks to the files which the Build system
produces (the java code, and the final app manifest).

This PR includes an updated unit test which tests all
the issues raised in the bug reports.