### PR TITLE
[docs] Add docs for warnings XA0118 and XA1005

### DIFF
--- a/Documentation/guides/messages/xa0118.md
+++ b/Documentation/guides/messages/xa0118.md
@@ -1,0 +1,12 @@
+# Compiler Warning XA0118
+
+These warnings indicate an issue with the `$(NuGetTargetMoniker)` MSBuild
+property in a Xamarin.Android project. This property is normally generated
+automatically based on the `$(TargetFrameworkIdentifier)` and
+`$(TargetFrameworkVersion)` properties, so these warnings should not arise in
+normal use.
+
+Consider submitting a [bug][bug] if you are getting one of these warnings under
+normal circumstances.
+
+[bug]: https://github.com/xamarin/xamarin-android/wiki/Submitting-Bugs,-Feature-Requests,-and-Pull-Requests

--- a/Documentation/guides/messages/xa1005.md
+++ b/Documentation/guides/messages/xa1005.md
@@ -1,0 +1,39 @@
+# Compiler Warning XA1005
+
+When [Layout Bindings and Code-Behind][code-behind] are enabled, this warning
+will be emitted for every layout element that has the `//*/@android:id`
+attribute set and uses a fully-qualified name for the element type.
+
+For example, the warning *will* be emitted for both of the following elements:
+
+```xml
+<android.widget.TextView
+    android:id="@+id/text1" />
+<Android.Widget.TextView
+    android:id="@+id/text2" />
+```
+
+But it will *not* be emitted for elements that use just an unqualified class
+name like:
+
+```xml
+<TextView
+    android:id="@+id/text1" />
+```
+
+The "naive type name fixup" tries to ensure that any fully-qualified type name
+is a C# name rather than a Java name. First it checks a short list of known
+mappings between Java namespaces and C# namespaces, such as the mapping of
+`android.view` to `Android.Views`. For any remaining namespaces, it splits the
+namespace on `.` and capitalizes each part.
+
+To resolve this warning, change each element to use its unqualified C# class
+name or add a [`xamarin:managedType`][code-behind-attributes] attribute to each
+element that specifies the fully qualified C# name.
+
+Example message:
+- `warning XA1005: Attempting naive type name fixup for element with ID '@+id/text1' and type 'android.widget.TextView'`  
+  `warning XA1005: If the above fixup fails, please add `xamarin:managedType` attribute to the element with fully qualified managed type name of the element.`
+
+[code-behind]: ../LayoutCodeBehind.md
+[code-behind-attributes]: ../LayoutCodeBehind.md#layouqt-xml-attributes


### PR DESCRIPTION
This documentation was meant to be part of:
https://github.com/xamarin/xamarin-android/pull/2258

I accidentally removed these pages from that pull request when I was
updating it to exclude the changes for XA4214 and XA4215.

* * *
These are documentation only changes, and I'm curious to check for reference if this PR trigger is enabled in this repo, so I'll try skipping the PR build:

@monojenkins skip