### PR TITLE
Enable Aapt2 by default

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
@@ -22,7 +22,8 @@ namespace Xamarin.Android.Tasks {
 				var firstFile = Directory.EnumerateFiles(directory.ItemSpec, "*.*", SearchOption.AllDirectories).FirstOrDefault ();
 				if (firstFile != null) {
 					var taskItem = new TaskItem (directory.ItemSpec, new Dictionary<string, string> () {
-						{"FileFound", Path.GetFullPath (Path.Combine (directory.ItemSpec, "..", "..")) + ".stamp" }
+						{"FileFound", firstFile },
+						{"StampFile", Path.GetFullPath (Path.Combine (directory.ItemSpec, "..", "..")) + ".stamp" },
 					});
 					directory.CopyMetadataTo (taskItem);
 					output.Add (taskItem);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Android.Tasks {
 				var firstFile = Directory.EnumerateFiles(directory.ItemSpec, "*.*", SearchOption.AllDirectories).FirstOrDefault ();
 				if (firstFile != null) {
 					var taskItem = new TaskItem (directory.ItemSpec, new Dictionary<string, string> () {
-						{"FileFound", firstFile}
+						{"FileFound", Path.GetFullPath (Path.Combine (directory.ItemSpec, "..", "..")) + ".stamp" }
 					});
 					directory.CopyMetadataTo (taskItem);
 					output.Add (taskItem);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1225,7 +1225,7 @@ namespace Lib1 {
 		}
 
 		[Test]
-		public void CheckMaxResWarningIsEmittedAsAWarning()
+		public void CheckMaxResWarningIsEmittedAsAWarning([Values (false, true)] bool useAapt2)
 		{
 			var path = Path.Combine ("temp", TestName);
 			var proj = new XamarinAndroidApplicationProject () {
@@ -1237,6 +1237,7 @@ namespace Lib1 {
 					},
 				},
 			};
+			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
 			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values-v27\\Strings.xml") {
 				TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
 <resources>
@@ -1248,8 +1249,12 @@ namespace Lib1 {
 					Assert.Ignore ($"Skipping Test. TargetFrameworkVersion {proj.TargetFrameworkVersion} was not available.");
 				}
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
-				var expected = builder.RunningMSBuild ? "warning APT0000: max res 26, skipping values-v27" : "warning APT0000: warning : max res 26, skipping values-v27";
-				StringAssertEx.Contains (expected, builder.LastBuildOutput, "Build output should contain an APT0000 warning about 'max res 26, skipping values-v27'");
+				if (useAapt2) {
+					StringAssertEx.DoesNotContain ("APT0000", builder.LastBuildOutput, "Build output should not contain an APT0000 warning");
+				} else {
+					var expected = builder.RunningMSBuild ? "warning APT0000: max res 26, skipping values-v27" : "warning APT0000: warning : max res 26, skipping values-v27";
+					StringAssertEx.Contains (expected, builder.LastBuildOutput, "Build output should contain an APT0000 warning about 'max res 26, skipping values-v27'");
+				}
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
@@ -24,6 +24,19 @@ namespace Foo.Foo
 			global::Android.Runtime.ResourceIdManager.UpdateIdValues();
 		}
 		
+		public partial class Animation
+		{
+			
+			static Animation()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Animation()
+			{
+			}
+		}
+		
 		public partial class Animator
 		{
 			
@@ -52,6 +65,45 @@ namespace Foo.Foo
 			}
 			
 			private Array()
+			{
+			}
+		}
+		
+		public partial class Attribute
+		{
+			
+			static Attribute()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Attribute()
+			{
+			}
+		}
+		
+		public partial class Boolean
+		{
+			
+			static Boolean()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Boolean()
+			{
+			}
+		}
+		
+		public partial class Color
+		{
+			
+			static Color()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Color()
 			{
 			}
 		}
@@ -122,6 +174,32 @@ namespace Foo.Foo
 			}
 			
 			private Id()
+			{
+			}
+		}
+		
+		public partial class Integer
+		{
+			
+			static Integer()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Integer()
+			{
+			}
+		}
+		
+		public partial class Interpolator
+		{
+			
+			static Interpolator()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Interpolator()
 			{
 			}
 		}
@@ -231,6 +309,32 @@ namespace Foo.Foo
 			}
 		}
 		
+		public partial class Style
+		{
+			
+			static Style()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Style()
+			{
+			}
+		}
+		
+		public partial class Styleable
+		{
+			
+			static Styleable()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Styleable()
+			{
+			}
+		}
+		
 		public partial class Transition
 		{
 			
@@ -243,6 +347,19 @@ namespace Foo.Foo
 			}
 			
 			private Transition()
+			{
+			}
+		}
+		
+		public partial class Xml
+		{
+			
+			static Xml()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Xml()
 			{
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -108,50 +108,28 @@ namespace Xamarin.Android.Tasks
 			SortMembers (xml);
 
 
-			if (animation.Members.Count > 1)
-				resources.Members.Add (animation);
-			if (animator.Members.Count > 1)
-				resources.Members.Add (animator);
-			if (arrays.Members.Count > 1)
-				resources.Members.Add (arrays);
-			if (attrib.Members.Count > 1)
-				resources.Members.Add (attrib);
-			if (boolean.Members.Count > 1)
-				resources.Members.Add (boolean);
-			if (colors.Members.Count > 1)
-				resources.Members.Add (colors);
-			if (dimension.Members.Count > 1)
-				resources.Members.Add (dimension);
-			if (drawable.Members.Count > 1)
-				resources.Members.Add (drawable);
-			if (font.Members.Count > 1)
-				resources.Members.Add (font);
-			if (ids.Members.Count > 1)
-				resources.Members.Add (ids);
-			if (ints.Members.Count > 1)
-				resources.Members.Add (ints);
-			if (interpolators.Members.Count > 1)
-				resources.Members.Add (interpolators);
-			if (layout.Members.Count > 1)
-				resources.Members.Add (layout);
-			if (menu.Members.Count > 1)
-				resources.Members.Add (menu);
-			if (mipmaps.Members.Count > 1)
-				resources.Members.Add (mipmaps);
-			if (raw.Members.Count > 1)
-				resources.Members.Add (raw);
-			if (plurals.Members.Count > 1)
-				resources.Members.Add (plurals);
-			if (strings.Members.Count > 1)
-				resources.Members.Add (strings);
-			if (style.Members.Count > 1)
-				resources.Members.Add (style);
-			if (styleable.Members.Count > 1)
-				resources.Members.Add (styleable);
-			if (transition.Members.Count > 1)
-				resources.Members.Add (transition);
-			if (xml.Members.Count > 1)
-				resources.Members.Add (xml);
+			resources.Members.Add (animation);
+			resources.Members.Add (animator);
+			resources.Members.Add (arrays);
+			resources.Members.Add (attrib);
+			resources.Members.Add (boolean);
+			resources.Members.Add (colors);
+			resources.Members.Add (dimension);
+			resources.Members.Add (drawable);
+			resources.Members.Add (font);
+			resources.Members.Add (ids);
+			resources.Members.Add (ints);
+			resources.Members.Add (interpolators);
+			resources.Members.Add (layout);
+			resources.Members.Add (menu);
+			resources.Members.Add (mipmaps);
+			resources.Members.Add (raw);
+			resources.Members.Add (plurals);
+			resources.Members.Add (strings);
+			resources.Members.Add (style);
+			resources.Members.Add (styleable);
+			resources.Members.Add (transition);
+			resources.Members.Add (xml);
 
 			return resources;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -10,7 +10,7 @@
 		<MinimumSupportedJavaVersion Condition="'$(MinimumSupportedJavaVersion)' == ''">1.6.0</MinimumSupportedJavaVersion>
 		<AndroidVersionCodePattern Condition=" '$(AndroidUseLegacyVersionCode)' != 'True' And '$(AndroidVersionCodePattern)' == '' ">{abi}{versionCode:D5}</AndroidVersionCodePattern>
 		<AndroidResourceGeneratorTargetName>UpdateGeneratedFiles</AndroidResourceGeneratorTargetName>
-		<AndroidUseAapt2 Condition=" '$(AndroidUseAapt2)' == '' ">False</AndroidUseAapt2>
+		<AndroidUseAapt2 Condition=" '$(AndroidUseAapt2)' == '' ">True</AndroidUseAapt2>
 		<AndroidUseManagedDesignTimeResourceGenerator Condition=" '$(AndroidUseManagedDesignTimeResourceGenerator)' == '' And '$(OS)' != 'Windows_NT' ">False</AndroidUseManagedDesignTimeResourceGenerator>
 		<AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">27.0.3</AndroidSdkBuildToolsVersion>
 		<AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">27.0.1</AndroidSdkPlatformToolsVersion>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1373,7 +1373,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_ConvertLibraryResourcesCases" DependsOnTargets="_CollectLibraryResourceDirectories"
 		Condition="'$(_AndroidUseAapt2)' == 'True'"
-		Inputs="@(_LibraryResourceHashDirectories->'%(FileFound)')"
+		Inputs="@(_LibraryResourceHashDirectories->'%(StampFile)')"
 		Outputs="$(_AndroidStampDirectory)_ConvertLibraryResourcesCases.stamp">
 	<ConvertResourcesCases
 		Condition=" '@(_LibraryResourceDirectories)' != '' "
@@ -1389,7 +1389,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_CompileAndroidLibraryResources" DependsOnTargets="_ConvertLibraryResourcesCases"
 		Condition="'$(_AndroidUseAapt2)' == 'True'"
-		Inputs="%(_LibraryResourceHashDirectories.FileFound)"
+		Inputs="%(_LibraryResourceHashDirectories.StampFile)"
 		Outputs="$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).stamp"
 	>
 	<MakeDir Directories="$(_AndroidLibraryFlatArchivesDirectory)" Condition="!Exists('$(_AndroidLibraryFlatArchivesDirectory)')" />


### PR DESCRIPTION
This Commit enables `aapt2` as the default resource processor. 
It can be disabled by setting the `AndroidUseAapt2` to false in your csproj.

This Commit also fixes a small issue with compiling library resources. The scenario is as follows.
The main app project references a library which contains resources. 

`Resource\drawable\foo.png`
`Resource\layout\foo.xml`

On first build this works as expected. Then the user updates `foo.xml`. The next build will NOT refresh the `flata` file for the library. This is because `CollectNonEmptyDirectories` only looks for the first file in the library `res` directory. This file was then used as an input to the targets `_ConvertLibraryResourcesCases` and `_CompileAndroidLibraryResources`. The problem is that first file probably didn't change. And in this example it doesn't. As a result the `flata` file will not be updated. 

What we should have been doing was using the library `stamp` file as the inputs. This is because when we do extract new/updated files from the library that `stamp` file is modified. By using the `stamp` file for the inputs we know that those targets will be run.