### PR TITLE
[Xamarin.Android.Build.Tasks] fix for missing content provider

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -53,6 +53,7 @@ namespace Xamarin.Android.Tasks
 
 		public bool EmbedAssemblies { get; set; }
 		public bool NeedsInternet   { get; set; }
+		public bool InstantRunEnabled { get; set; }
 
 		public bool UseSharedRuntime { get; set; }
 
@@ -69,27 +70,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("GenerateJavaStubs Task");
-			Log.LogDebugMessage ("  ManifestTemplate: {0}", ManifestTemplate);
-			Log.LogDebugMessage ("  Debug: {0}", Debug);
-			Log.LogDebugMessage ("  MultiDex: {0}", MultiDex);
-			Log.LogDebugMessage ("  ApplicationName: {0}", ApplicationName);
-			Log.LogDebugMessage ("  PackageName: {0}", PackageName);
-			Log.LogDebugMessage ("  AndroidSdkDir: {0}", AndroidSdkDir);
-			Log.LogDebugMessage ("  AndroidSdkPlatform: {0}", AndroidSdkPlatform);
-			Log.LogDebugMessage ($"  {nameof (ErrorOnCustomJavaObject)}: {ErrorOnCustomJavaObject}");
-			Log.LogDebugMessage ("  OutputDirectory: {0}", OutputDirectory);
-			Log.LogDebugMessage ("  MergedAndroidManifestOutput: {0}", MergedAndroidManifestOutput);
-			Log.LogDebugMessage ("  UseSharedRuntime: {0}", UseSharedRuntime);
-			Log.LogDebugTaskItems ("  ResolvedAssemblies:", ResolvedAssemblies);
-			Log.LogDebugTaskItems ("  ResolvedUserAssemblies:", ResolvedUserAssemblies);
-			Log.LogDebugTaskItems ("  FrameworkDirectories: ", FrameworkDirectories);
-			Log.LogDebugMessage ("  BundledWearApplicationName: {0}", BundledWearApplicationName);
-			Log.LogDebugTaskItems ("  MergedManifestDocuments:", MergedManifestDocuments);
-			Log.LogDebugMessage ("  PackageNamingPolicy: {0}", PackageNamingPolicy);
-			Log.LogDebugMessage ("  ApplicationJavaClass: {0}", ApplicationJavaClass);
-			Log.LogDebugTaskItems ("  ManifestPlaceholders: ", ManifestPlaceholders);
-
 			try {
 				// We're going to do 3 steps here instead of separate tasks so
 				// we can share the list of JLO TypeDefinitions between them
@@ -235,6 +215,7 @@ namespace Xamarin.Android.Tasks
 			manifest.Debug = Debug;
 			manifest.MultiDex = MultiDex;
 			manifest.NeedsInternet = NeedsInternet;
+			manifest.InstantRunEnabled = InstantRunEnabled;
 
 			var additionalProviders = manifest.Merge (all_java_types, selectedWhitelistAssemblies, ApplicationJavaClass, EmbedAssemblies, BundledWearApplicationName, MergedManifestDocuments);
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3263,6 +3263,27 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 			}
 		}
 
+		[Test]
+		public void FastDeploymentDoesNotAddContentProvider ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty ("_XASupportsFastDev", "True");
+			proj.SetProperty (proj.DebugProperties, KnownProperties.AndroidUseSharedRuntime, "True");
+			proj.SetProperty (proj.DebugProperties, "EmbedAssembliesIntoApk", "False");
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				//NOTE: build will fail, due to $(_XASupportsFastDev)
+				b.ThrowOnBuildFailure = false;
+				b.Build (proj);
+
+				var manifest = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "AndroidManifest.xml");
+				FileAssert.Exists (manifest);
+				var content = File.ReadAllLines (manifest);
+				var type = "mono.android.ResourcePatcher";
+
+				//NOTE: only $(AndroidFastDeploymentType) containing "dexes" should add this to the manifest
+				Assert.IsFalse (StringAssertEx.ContainsText (content, type), $"`{type}` should not exist in `AndroidManifest.xml`!");
+			}
+		}
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -86,6 +86,7 @@ namespace Xamarin.Android.Tasks {
 		public bool Debug { get; set; }
 		public bool MultiDex { get; set; }
 		public bool NeedsInternet { get; set; }
+		public bool InstantRunEnabled { get; set; }
 		public string VersionCode {
 			get {
 				XAttribute attr = doc.Root.Attribute (androidNs + "versionCode");
@@ -359,7 +360,7 @@ namespace Xamarin.Android.Tasks {
 
 			var providerNames = AddMonoRuntimeProviders (app);
 
-			if (Debug && !embed) {
+			if (Debug && !embed && InstantRunEnabled) {
 				if (int.TryParse (SdkVersion, out int apiLevel) && apiLevel >= 19)
 					app.Add (CreateMonoRuntimeProvider ("mono.android.ResourcePatcher", null, initOrder: --AppInitOrder));
 			}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2295,6 +2295,7 @@ because xbuild doesn't support framework reference assemblies.
 	Debug="$(AndroidIncludeDebugSymbols)"
 	MultiDex="$(AndroidEnableMultiDex)"
 	NeedsInternet="$(AndroidNeedsInternetPermission)"
+	InstantRunEnabled="$(_InstantRunEnabled)"
 	AndroidSdkPlatform="$(_AndroidApiLevel)"
 	AndroidSdkDir="$(_AndroidSdkDirectory)"
 	PackageName="$(_AndroidPackage)"


### PR DESCRIPTION
Using a commercial master build of Xamarin.Android, I get the
following crash at runtime:

    java.lang.RuntimeException: Unable to get provider mono.android.ResourcePatcher: java.lang.ClassNotFoundException: Didn't find class "mono.android.ResourcePatcher" on path: DexPathList[[zip file "/system/framework/org.apache.http.legacy.boot.jar", zip file "/data/app/HelloForms.HelloForms-g8b7mdSG3CF6lxWgPVIURg==/base.apk"],nativeLibraryDirectories=[/data/app/HelloForms.HelloForms-g8b7mdSG3CF6lxWgPVIURg==/lib/arm64, /data/app/HelloForms.HelloForms-g8b7mdSG3CF6lxWgPVIURg==/base.apk!/lib/arm64-v8a, /system/lib64]]
           at android.app.ActivityThread.installProvider(ActivityThread.java:6396)
           at android.app.ActivityThread.installContentProviders(ActivityThread.java:5938)
           at android.app.ActivityThread.handleBindApplication(ActivityThread.java:5853)
           at android.app.ActivityThread.access$1100(ActivityThread.java:199)
           at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1650)
           at android.os.Handler.dispatchMessage(Handler.java:106)
           at android.os.Looper.loop(Looper.java:193)
           at android.app.ActivityThread.main(ActivityThread.java:6669)
           at java.lang.reflect.Method.invoke(Native Method)
           at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
           at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)

Looking at `obj\Debug\android\AndroidManifest.xml`, I had this line:

    <provider android:name="mono.android.ResourcePatcher" android:exported="false" android:initOrder="1999999998" android:authorities="HelloForms.HelloForms.mono.android.ResourcePatcher.__mono_init__" />

This `ResourcePatcher` content provider should only be present when
the new "Enhanced" Fast Deployment is enabled.

Reviewing the code, it seemed that the `ManifestDocument` class was
adding this to the manifest in a case where it shouldn't.

Changes:

- Added checks of the `$(_InstantRunEnabled)` MSBuild property, before
  deciding if the content provider is present in the manifest file.
- Added a test to verify this scenario. I had to make use of the
  `$(_XASupportsFastDev)` property in the test.
- Removed extra input logging of `GenerateJavaStubs`.