### PR TITLE
Don't propagate the Authorization header on redirect

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -454,6 +454,9 @@ namespace Xamarin.Android.Net
 					ParseCookies (ret, connectionUri);
 				}
 
+				// We don't want to pass the authorization header onto the next location
+				request.Headers.Authorization = null;
+
 				return ret;
 			}
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/1924

The `Authorization` HTTP header should not be passed on to the next location
when redirecting. Make sure it is removed before following the redirect.