### PR TITLE
[android-toolchain] mirror depot_tools in Azure storage

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <AndroidUri Condition=" '$(AndroidUri)' == '' ">https://dl.google.com/android/repository</AndroidUri>
     <AntUri Condition=" '$(AntUri)' == '' ">https://archive.apache.org/dist/ant/binaries</AntUri>
-    <ChromeUri Condition=" '$(ChromeUri)' == '' ">https://storage.googleapis.com/chrome-infra</ChromeUri>
+    <!--NOTE: Mirrored to Azure, originally at: https://storage.googleapis.com/chrome-infra -->
+    <ChromeUri Condition=" '$(ChromeUri)' == '' ">https://xamjenkinsartifact.azureedge.net/mono-jenkins/xamarin-android/depot_tools</ChromeUri>
   </PropertyGroup>
   <ItemGroup>
     <AndroidNdkItem Include="android-ndk-r14b-linux-x86_64">
@@ -168,10 +169,9 @@
       depot_tools, a set of git extensions from Chromium
       http://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html
     -->
-    <ChromeItem Include="depot_tools">
+    <ChromeItem Include="depot_tools-crc32c=JBYDJw==">
       <HostOS></HostOS>
       <NoSubdirectory>True</NoSubdirectory>
-      <HashHeader>x-goog-hash</HashHeader>
     </ChromeItem>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
In 4bb4b2e, we added a `%(HashHeader)` value for invalidating cached
downloads in `android-toolchain.csproj`. It's primary use was for a
`depot_tools.zip` file, which is a dependency of building r8.

However...

Quite frequently we are seeing `depot_tools.zip` *change* and it gets
re-downloaded:

    Hash found using 'x-goog-hash', destination file changing to 'C:\Users\myuser\android-archives\depot_tools-crc32c=JBYDJw==.zip'.
    Downloading `https://storage.googleapis.com/chrome-infra/depot_tools.zip` to `C:\Users\myuser\android-archives\.depot_tools-crc32c=JBYDJw==.zip.download`.

Since we can't really count on a "version" of this file we are
downloading, I have mirrored it to the Azure storage account we are
already using for tests:

    https://xamjenkinsartifact.azureedge.net/mono-jenkins/xamarin-android/depot_tools/depot_tools-crc32c=JBYDJw==.zip

This URL will be reliable for our build, and we can update as needed
on-demand.