### PR TITLE
[plots] Do not mix Release and Release/Bundle measurements

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -91,7 +91,9 @@
     <XAIntegratedTests Condition="'$(XAIntegratedTests)' == ''">False</XAIntegratedTests>
     <XAIncludeProprietaryBits Condition="'$(XAIncludeProprietaryBits)' == ''">False</XAIncludeProprietaryBits>
     <PathSeparator>$([System.IO.Path]::PathSeparator)</PathSeparator>
-    <TestsAotName Condition=" '$(AotAssemblies)' == 'true' ">-Aot</TestsAotName>
+    <_TestsAotName Condition=" '$(AotAssemblies)' == 'true' ">-Aot</_TestsAotName>
+    <_TestsBundleName Condition=" '$(BundleAssemblies)' == 'true' ">-Bundle</_TestsBundleName>
+    <TestsFlavor>$(_TestsAotName)$(_TestsBundleName)</TestsFlavor>
   </PropertyGroup>
   <PropertyGroup>
     <_MingwPrefixTail Condition=" '$(HostOS)' == 'Darwin' ">.static</_MingwPrefixTail>

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -184,7 +184,7 @@
     <PropertyGroup>
       <_IncludeCategories Condition=" '$(IncludeCategories)' != '' ">include=$(IncludeCategories)</_IncludeCategories>
       <_ExcludeCategories Condition=" '$(ExcludeCategories)' != '' ">exclude=$(ExcludeCategories)</_ExcludeCategories>
-      <_LogcatFilenameBase>logcat-$(Configuration)$(TestsAotName)</_LogcatFilenameBase>
+      <_LogcatFilenameBase>logcat-$(Configuration)$(TestsFlavor)</_LogcatFilenameBase>
     </PropertyGroup>
     <RunInstrumentationTests
         Condition=" '%(TestApkInstrumentation.Identity)' != ''"
@@ -222,7 +222,7 @@
         ResultsFilename="%(TestApk.TimingResultsFilename)"
         DefinitionsFilename="%(TestApk.TimingDefinitionsFilename)"
         AddResults="true"
-        LabelSuffix="-$(Configuration)$(TestsAotName)"
+        LabelSuffix="-$(Configuration)$(TestsFlavor)"
         Activity="%(TestApk.Activity)" />
   </Target>
   <Target Name="RenameTestCases">
@@ -258,7 +258,7 @@
       Condition=" '@(TestApk)' != '' ">
     <RenameTestCases
         Condition=" '%(TestApkInstrumentation.ResultsPath)' != '' "
-        Configuration="$(Configuration)$(TestsAotName)"
+        Configuration="$(Configuration)$(TestsFlavor)"
         DeleteSourceFiles="True"
         DestinationFolder="$(MSBuildThisFileDirectory)..\.."
         SourceFile="%(TestApkInstrumentation.ResultsPath)"
@@ -287,7 +287,7 @@
         ResultsFilename="%(TestApk.ApkSizesResultsFilename)"
         DefinitionsFilename="%(TestApk.ApkSizesDefinitionFilename)"
         AddResults="True"
-        LabelSuffix="-$(Configuration)$(TestsAotName)"
+        LabelSuffix="-$(Configuration)$(TestsFlavor)"
         ContinueOnError="ErrorAndContinue"
     />
   </Target>

--- a/src/Mono.Android/Test/Mono.Android-Tests.projitems
+++ b/src/Mono.Android/Test/Mono.Android-Tests.projitems
@@ -11,7 +11,7 @@
       <ResultsPath>$(OutputPath)TestResult-Mono.Android_Tests.xml</ResultsPath>
       <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)..\..\..\build-tools\scripts\TimingDefinitions.txt</TimingDefinitionsFilename>
       <TimingResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-Mono.Android_Tests-times.csv</TimingResultsFilename>
-      <ApkSizesInputFilename>apk-sizes-$(_MonoAndroidTestPackage)-$(Configuration)$(TestsAotName).txt</ApkSizesInputFilename>
+      <ApkSizesInputFilename>apk-sizes-$(_MonoAndroidTestPackage)-$(Configuration)$(TestsFlavor).txt</ApkSizesInputFilename>
       <ApkSizesDefinitionFilename>$(MSBuildThisFileDirectory)..\..\..\build-tools\scripts\ApkSizesDefinitions.txt</ApkSizesDefinitionFilename>
       <ApkSizesResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-Mono.Android_Tests-values.csv</ApkSizesResultsFilename>
     </TestApk>

--- a/tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.projitems
+++ b/tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.projitems
@@ -7,7 +7,7 @@
       <ResultsPath>$(MSBuildThisFileDirectory)..\..\TestResult-Mono.Android_TestsMultiDex.xml</ResultsPath>
       <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)..\..\build-tools\scripts\TimingDefinitions.txt</TimingDefinitionsFilename>
       <TimingResultsFilename>$(MSBuildThisFileDirectory)..\..\TestResult-Mono.Android_TestsMultiDex-times.csv</TimingResultsFilename>
-      <ApkSizesInputFilename>apk-sizes-$(_MonoAndroidTestPackage)-$(Configuration)$(TestsAotName).txt</ApkSizesInputFilename>
+      <ApkSizesInputFilename>apk-sizes-$(_MonoAndroidTestPackage)-$(Configuration)$(TestsFlavor).txt</ApkSizesInputFilename>
       <ApkSizesDefinitionFilename>$(MSBuildThisFileDirectory)apk-sizes-definitions.txt</ApkSizesDefinitionFilename>
       <ApkSizesResultsFilename>$(MSBuildThisFileDirectory)..\..\TestResult-Mono.Android_TestsMultDex-values.csv</ApkSizesResultsFilename>
     </TestApk>

--- a/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.projitems
+++ b/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.projitems
@@ -10,7 +10,7 @@
       <ResultsPath></ResultsPath>
       <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)timing-definitions.txt</TimingDefinitionsFilename>
       <TimingResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-Xamarin.Forms_Test-times.csv</TimingResultsFilename>
-      <ApkSizesInputFilename>apk-sizes-$(_XamarinFormsIntergationPackage)-$(Configuration)$(TestsAotName).txt</ApkSizesInputFilename>
+      <ApkSizesInputFilename>apk-sizes-$(_XamarinFormsIntergationPackage)-$(Configuration)$(TestsFlavor).txt</ApkSizesInputFilename>
       <ApkSizesDefinitionFilename>$(MSBuildThisFileDirectory)..\..\..\build-tools\scripts\ApkSizesDefinitions.txt</ApkSizesDefinitionFilename>
       <ApkSizesResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-Xamarin.Forms_Tests-values.csv</ApkSizesResultsFilename>
     </TestApk>


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/2400

With https://github.com/xamarin/xamarin-android/pull/1683 we started
to run and measure the apk tests with `BundleAssemblies=True` as
well. To not mix and repeat these measurements with other ones,
introduce `TestsFlavor` property in place of `TestsAotName` to
distinguish the apk tests runs when collecting and processing
measurements data.

It is similar to what we did with AOT before.

Example content of TestResult-Mono.Android_Tests-times.csv after the
fix:

    last-Release,JNI.init-Release,init-Release,NUnit.results-Release,last-Release-Aot,JNI.init-Release-Aot,init-Release-Aot,NUnit.results-Release-Aot,last-Release-Bundle,JNI.init-Release-Bundle,init-Release-Bundle,NUnit.results-Release-Bundle
    518,116,116,8347,647,86,86,7670,755,159,159,8416