### PR TITLE
[tests] Preserve more java classes in XForms sample

### DIFF
--- a/tests/Xamarin.Forms-Performance-Integration/Droid/proguard.cfg
+++ b/tests/Xamarin.Forms-Performance-Integration/Droid/proguard.cfg
@@ -1,2 +1,4 @@
 -keep class android.support.v7.widget.** { *; }
 -dontwarn android.support.v7.widget.*
+-keep class android.support.v7.view.** { *; }
+-dontwarn android.support.v7.view.*


### PR DESCRIPTION
https://github.com/xamarin/xamarin-android/pull/2019/files introduced a crash in our
XForms test, it crashes in the middle of the startup.

It looks like we need to preserve also `android.support.v7.view.**`
classes as well.

This is the logcat output of the crash:

    E AndroidRuntime: FATAL EXCEPTION: main
    E AndroidRuntime: Process: Xamarin.Forms_Performance_Integration, PID: 8563
    E AndroidRuntime: java.lang.RuntimeException: Unable to start activity ComponentInfo{Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity}: android.view.InflateException: Binary XML file line #17: Binary XML file line #17: Error inflating class android.support.v7.view.menu.ActionMenuItemView
    E AndroidRuntime:        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2913)
    E AndroidRuntime:        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3048)
    E AndroidRuntime:        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:78)
    E AndroidRuntime:        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:108)
    E AndroidRuntime:        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:68)
    E AndroidRuntime:        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1808)
    E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:106)
    E AndroidRuntime:        at android.os.Looper.loop(Looper.java:193)
    E AndroidRuntime:        at android.app.ActivityThread.main(ActivityThread.java:6669)
    E AndroidRuntime:        at java.lang.reflect.Method.invoke(Native Method)
    E AndroidRuntime:        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
    E AndroidRuntime:        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
    E AndroidRuntime: Caused by: android.view.InflateException: Binary XML file line #17: Binary XML file line #17: Error inflating class android.support.v7.view.menu.ActionMenuItemView
    E AndroidRuntime: Caused by: android.view.InflateException: Binary XML file line #17: Error inflating class android.support.v7.view.menu.ActionMenuItemView
    E AndroidRuntime: Caused by: java.lang.NoSuchMethodException: <init> [class android.content.Context, interface android.util.AttributeSet]
    E AndroidRuntime:        at java.lang.Class.getConstructor0(Class.java:2327)
    E AndroidRuntime:        at java.lang.Class.getConstructor(Class.java:1725)
    E AndroidRuntime:        at android.view.LayoutInflater.createView(LayoutInflater.java:615)
    E AndroidRuntime:        at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:790)
    E AndroidRuntime:        at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:730)
    E AndroidRuntime:        at android.view.LayoutInflater.inflate(LayoutInflater.java:492)
    E AndroidRuntime:        at android.view.LayoutInflater.inflate(LayoutInflater.java:423)
    E AndroidRuntime:        at android.support.v7.view.menu.BaseMenuPresenter.createItemView(:1)
    E AndroidRuntime:        at android.support.v7.view.menu.BaseMenuPresenter.getItemView(:3)
    E AndroidRuntime:        at android.support.v7.widget.ActionMenuPresenter.getItemView(:3)
    E AndroidRuntime:        at android.support.v7.widget.ActionMenuPresenter.flagActionItems(:21)
    E AndroidRuntime:        at android.support.v7.view.menu.MenuBuilder.flagActionItems(:6)
    E AndroidRuntime:        at android.support.v7.view.menu.BaseMenuPresenter.updateMenuView(:3)
    E AndroidRuntime:        at android.support.v7.widget.ActionMenuPresenter.updateMenuView(:1)
    E AndroidRuntime:        at android.support.v7.view.menu.MenuBuilder.dispatchPresenterUpdate(:6)
    E AndroidRuntime:        at android.support.v7.view.menu.MenuBuilder.onItemsChanged(:4)
    E AndroidRuntime:        at android.support.v7.view.menu.MenuBuilder.onItemActionRequestChanged(:2)
    E AndroidRuntime:        at android.support.v7.view.menu.MenuItemImpl.setShowAsAction(:3)
    E AndroidRuntime:        at xamarin.forms.performance.integration.MainActivity.n_onCreate(Native Method)
    E AndroidRuntime:        at xamarin.forms.performance.integration.MainActivity.onCreate(:1)
    E AndroidRuntime:        at android.app.Activity.performCreate(Activity.java:7136)
    E AndroidRuntime:        at android.app.Activity.performCreate(Activity.java:7127)
    E AndroidRuntime:        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1271)
    E AndroidRuntime:        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2893)
    E AndroidRuntime:        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3048)
    E AndroidRuntime:        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:78)
    E AndroidRuntime:        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:108)
    E AndroidRuntime:        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:68)
    E AndroidRuntime:        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1808)
    E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:106)
    E AndroidRuntime:        at android.os.Looper.loop(Looper.java:193)
    E AndroidRuntime:        at android.app.ActivityThread.main(ActivityThread.java:6669)
    E AndroidRuntime:        at java.lang.reflect.Method.invoke(Native Method)
    E AndroidRuntime:        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
    E AndroidRuntime:        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
    W ActivityManager:   Force finishing activity Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity