### PR TITLE
[build] Add `$(CONFIGURATION)` to package-build-status output

### DIFF
--- a/build-tools/scripts/Packaging.mk
+++ b/build-tools/scripts/Packaging.mk
@@ -66,7 +66,7 @@ _TEST_ERRORS_BASENAME   = xa-test-errors-v$(PRODUCT_VERSION).$(-num-commits-sinc
 
 _BUILD_STATUS_BUNDLE_INCLUDE = \
 	Configuration.OperatingSystem.props \
-	$(wildcard bin/Build*/msbuild*.binlog) \
+	$(wildcard bin/Build$(CONFIGURATION)/msbuild*.binlog) \
 	$(shell find . -name 'config.log') \
 	$(shell find . -name 'config.status') \
 	$(shell find . -name 'config.h') \
@@ -75,7 +75,7 @@ _BUILD_STATUS_BUNDLE_INCLUDE = \
 	$(shell find . -name '.ninja_log') \
 	$(shell find . -name 'android-*.config.cache')
 
-_BUILD_STATUS_BASENAME   = xa-build-status-v$(PRODUCT_VERSION).$(-num-commits-since-version-change)_$(OS_NAME)-$(OS_ARCH)_$(GIT_BRANCH)_$(GIT_COMMIT)
+_BUILD_STATUS_BASENAME   = xa-build-status-v$(PRODUCT_VERSION).$(-num-commits-since-version-change)_$(OS_NAME)-$(OS_ARCH)_$(GIT_BRANCH)_$(GIT_COMMIT)-$(CONFIGURATION)
 _BUILD_STATUS_ZIP_OUTPUT = $(_BUILD_STATUS_BASENAME).$(ZIP_EXTENSION)
 
 ifneq ($(wildcard Configuration.Override.props),)


### PR DESCRIPTION
Context: ae093bf0a103863e9325afd7e2fedbff1b78648e
Context: faaa908b2f0fcdae907bd12233efb0febb04fe91

Update the `make package-build-status` output so that
`xa-build-status*.zip` becomes
`xa-build-status*-$(CONFIGURATION).zip`, ensuring that Debug and
Release build outputs go to separate filenames.

The current plan is to eventually alter the [xamarin-android][0] job
so that it builds *only Release artifacts* by default, and add a new
`xamarin-android-debug` job which builds Debug configuration
artifacts.  Both jobs will still upload their artifacts to the same
URL -- which doesn't contain a JOB number; see ea89a667 -- thus the
`xa-build-status*.zip` file needs to contain `$(CONFIGURATION)` so
that the two jobs don't overwrite each other's outputs.

[0]: https://jenkins.mono-project.com//view/Xamarin.Android/job/xamarin-android/