### PR TITLE
[Xamarin.ProjectTools] fix LatestTargetFrameworkVersion

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -189,7 +189,7 @@ namespace Xamarin.ProjectTools
 				string v = Path.GetFileName (dir).Replace ("v", "");
 				if (!Version.TryParse (v, out version))
 					continue;
-				if (latest.Major < version.Major && latest.Minor <= version.Minor) {
+				if (latest < version) {
 					var apiInfo = Path.Combine (dir, "AndroidApiInfo.xml");
 					if (File.Exists (apiInfo)) {
 						var doc = XDocument.Load (apiInfo);


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/1252/testReport/

There are currently some test failures on xamarin-android/master:

    Xamarin.Android.Build.Tests.BuildTest.CheckLintErrorsAndWarnings
    ...
    (Restore target) -> 
       /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin/NuGet.targets : error : Package 
    Xamarin.Android.Support.v4 27.0.2.1 is not compatible with monoandroid43 (MonoAndroid,Version=v4.3).

The problem is that somehow `TargetFrameworkVersion` is getting set to `v4.3`?

Reviewing this code:

    if (latest.Major < version.Major && latest.Minor <= version.Minor)

We should just use the `<` operator on `System.Version` instead.