### PR TITLE
[Xamarin.Android.Build.Tasks] skip ValidateJavaVersion on DTB

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -715,6 +715,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		<Output TaskParameter="MonoAndroidBinPath"        PropertyName="MonoAndroidBinDirectory" />
 	</ResolveSdks>
 	<ValidateJavaVersion
+			Condition=" '$(DesignTimeBuild)' != 'True' "
 			TargetFrameworkVersion="$(TargetFrameworkVersion)"
 			AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
 			JavaSdkPath="$(_JavaSdkDirectory)"


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2410

One of the key metrics tracked in Visual Studio is the time it takes
for "solution create" to complete. Xamarin.Android would contribute to
this time from the duration of an initial design-time build.

`ValidateJavaVersion` is one of the slower tasks during a DTB:

    ValidateJavaVersion = 280 ms

I have seen reports of this taking 500ms sometimes. Subsequent calls
of `<ValidateJavaVersion/>` are cached, but that does not help the
first DTB on "solution create".

Looking at the task, it's main job is to emit errors/warnings, and
then it sets two properties:

- `_JdkVersion`
- `_DefaultJdkVersion`

These are only used by the `_AdjustJavacVersionArguments` target,
which doesn't run during DTB.

We can just skip `<ValidateJavaVersion/>` on DTB: easily ~300ms saved!