### PR TITLE
[tests] Emit error when timing input is missing

### DIFF
--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -215,7 +215,7 @@
         Timeout="300000">
     </RunUITests>
     <ProcessLogcatTiming
-        Condition=" '%(TestApk.TimingDefinitionsFilename)' != '' And Exists ('$(_LogcatFilenameBase)-%(TestApk.Package).txt')"
+        Condition=" '%(TestApk.TimingDefinitionsFilename)' != ''"
         ContinueOnError="ErrorAndContinue"
         InputFilename="$(_LogcatFilenameBase)-%(TestApk.Package).txt"
         ApplicationPackageName="%(TestApk.Package)"

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ProcessLogcatTiming.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ProcessLogcatTiming.cs
@@ -17,6 +17,10 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 		public override bool Execute ()
 		{
 			LoadDefinitions ();
+
+			if (!CheckInputFile ())
+				return false;
+
 			using (var reader = new StreamReader (InputFilename)) {
 				string line;
 				var procIdentification = string.IsNullOrEmpty (Activity) ? $"added application {ApplicationPackageName}" : $"activity {Activity}";

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ProcessPlotInput.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ProcessPlotInput.cs
@@ -54,9 +54,23 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 			}
 		}
 
+		protected bool CheckInputFile ()
+		{
+			if (File.Exists (InputFilename))
+				return true;
+
+			Log.LogError ($"Input file '{InputFilename}' doesn't exist.");
+
+			return false;
+		}
+
 		public override bool Execute ()
 		{
 			LoadDefinitions ();
+
+			if (!CheckInputFile ())
+				return false;
+
 			using (var reader = new StreamReader (InputFilename)) {
 				string line;
 


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/2397

Make sure that we don't break the timing measurements again, when the *logcat*
output is not collected. The PR build should fail in such case.