### PR TITLE
[Xamarin.Android.Build.Tasks] locate $(JdkJvmPath) only when needed

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveJdkJvmPath.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveJdkJvmPath.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.IO;
+using System.Linq;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// This MSBuild task's job is to find $(JdkJvmPath) used by $(AndroidGenerateJniMarshalMethods)
+	/// </summary>
+	public class ResolveJdkJvmPath : Task
+	{
+		public string JavaSdkPath { get; set; }
+
+		[Output]
+		public string JdkJvmPath { get; set; }
+
+		public override bool Execute ()
+		{
+			try {
+				JdkJvmPath = GetJvmPath ();
+			} catch (Exception e) {
+				Log.LogCodedError ("XA5300", $"Unable to find {nameof (JdkJvmPath)}{Environment.NewLine}{e}");
+				return false;
+			}
+
+			if (string.IsNullOrEmpty (JdkJvmPath)) {
+				Log.LogCodedError ("XA5300", $"{nameof (JdkJvmPath)} is blank");
+				return false;
+			}
+
+			if (!File.Exists (JdkJvmPath)) {
+				Log.LogCodedError ("XA5300", $"JdkJvmPath not found at {JdkJvmPath}");
+				return false;
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+
+		string GetJvmPath ()
+		{
+			var key = new Tuple<string, string> (nameof (ResolveJdkJvmPath), JavaSdkPath);
+			var cached = BuildEngine4.GetRegisteredTaskObject (key, RegisteredTaskObjectLifetime.AppDomain) as string;
+			if (cached != null) {
+				Log.LogDebugMessage ($"Using cached value for {nameof (JdkJvmPath)}: {cached}");
+
+				return cached;
+			}
+
+			JdkInfo info = null;
+			try {
+				info = new JdkInfo (JavaSdkPath);
+			} catch {
+				info = JdkInfo.GetKnownSystemJdkInfos (this.CreateTaskLogger ()).FirstOrDefault ();
+			}
+
+			if (info == null)
+				return null;
+
+			var path = info.JdkJvmPath;
+			if (string.IsNullOrEmpty (path))
+				return null;
+
+			BuildEngine4.RegisterTaskObject (key, path, RegisteredTaskObjectLifetime.AppDomain, allowEarlyCollection: false);
+
+			return path;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -51,9 +51,6 @@ namespace Xamarin.Android.Tasks
 		public string JavaSdkPath { get; set; }
 
 		[Output]
-		public string JdkJvmPath { get; set; }
-
-		[Output]
 		public string MonoAndroidToolsPath { get; set; }
 
 		[Output]
@@ -96,64 +93,17 @@ namespace Xamarin.Android.Tasks
 				return false;
 			}
 
-			try {
-				JdkJvmPath = GetJvmPath ();
-			} catch (Exception e) {
-				Log.LogCodedError ("XA5300", $"Unable to find {nameof (JdkJvmPath)}{Environment.NewLine}{e}");
-				return false;
-			}
-
-			if (string.IsNullOrEmpty (JdkJvmPath)) {
-				Log.LogCodedError ("XA5300", $"{nameof (JdkJvmPath)} is blank");
-				return false;
-			}
-
-			if (!File.Exists (JdkJvmPath)) {
-				Log.LogCodedError ("XA5300", $"JdkJvmPath not found at {JdkJvmPath}");
-				return false;
-			}
-
 			MonoAndroidHelper.TargetFrameworkDirectories = ReferenceAssemblyPaths;
 
 			Log.LogDebugMessage ($"{nameof (ResolveSdks)} Outputs:");
 			Log.LogDebugMessage ($"  {nameof (AndroidSdkPath)}: {AndroidSdkPath}");
 			Log.LogDebugMessage ($"  {nameof (AndroidNdkPath)}: {AndroidNdkPath}");
 			Log.LogDebugMessage ($"  {nameof (JavaSdkPath)}: {JavaSdkPath}");
-			Log.LogDebugMessage ($"  {nameof (JdkJvmPath)}: {JdkJvmPath}");
 			Log.LogDebugMessage ($"  {nameof (MonoAndroidBinPath)}: {MonoAndroidBinPath}");
 			Log.LogDebugMessage ($"  {nameof (MonoAndroidToolsPath)}: {MonoAndroidToolsPath}");
 
 			//note: this task does not error out if it doesn't find all things. that's the job of the targets
 			return !Log.HasLoggedErrors;
-		}
-
-		string GetJvmPath ()
-		{
-			var key = new Tuple<string, string> (nameof (ResolveSdks), JavaSdkPath);
-			var cached = BuildEngine4.GetRegisteredTaskObject (key, RegisteredTaskObjectLifetime.AppDomain) as string;
-			if (cached != null) {
-				Log.LogDebugMessage ($"Using cached value for {nameof (JdkJvmPath)}: {cached}");
-
-				return cached;
-			}
-
-			Xamarin.Android.Tools.JdkInfo info = null;
-			try {
-				info = new Xamarin.Android.Tools.JdkInfo (JavaSdkPath);
-			} catch {
-				info = Xamarin.Android.Tools.JdkInfo.GetKnownSystemJdkInfos (this.CreateTaskLogger ()).FirstOrDefault ();
-			}
-
-			if (info == null)
-				return null;
-
-			var path = info.JdkJvmPath;
-			if (string.IsNullOrEmpty (path))
-				return null;
-
-			BuildEngine4.RegisterTaskObject (key, path, RegisteredTaskObjectLifetime.AppDomain, allowEarlyCollection: false);
-
-			return path;
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Tasks\AndroidUpdateResDir.cs" />
     <Compile Include="Tasks\AndroidSignPackage.cs" />
     <Compile Include="Tasks\RemoveDirFixed.cs" />
+    <Compile Include="Tasks\ResolveJdkJvmPath.cs" />
     <Compile Include="Tasks\ResolveSdksTask.cs" />
     <Compile Include="Tasks\CompileToDalvik.cs" />
     <Compile Include="Tasks\AndroidToolTask.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -27,6 +27,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.ResolveSdks" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ValidateJavaVersion" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ResolveAndroidTooling" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.ResolveJdkJvmPath" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.Aapt" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.Aapt2Compile" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.Aapt2Link" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -710,10 +711,14 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		<Output TaskParameter="AndroidNdkPath"            PropertyName="_AndroidNdkDirectory" />
 		<Output TaskParameter="AndroidSdkPath"            PropertyName="_AndroidSdkDirectory" />
 		<Output TaskParameter="JavaSdkPath"               PropertyName="_JavaSdkDirectory" />
-		<Output TaskParameter="JdkJvmPath"                PropertyName="JdkJvmPath"          Condition="'$(JdkJvmPath)' == ''" />
 		<Output TaskParameter="MonoAndroidToolsPath"      PropertyName="MonoAndroidToolsDirectory" />
 		<Output TaskParameter="MonoAndroidBinPath"        PropertyName="MonoAndroidBinDirectory" />
 	</ResolveSdks>
+	<ResolveJdkJvmPath
+			JavaSdkPath="$(_JavaSdkDirectory)"
+			Condition=" '$(DesignTimeBuild)' != 'True' And '$(AndroidGenerateJniMarshalMethods)' == 'True' And '$(JdkJvmPath)' == '' ">
+		<Output TaskParameter="JdkJvmPath"                PropertyName="JdkJvmPath" />
+	</ResolveJdkJvmPath>
 	<ValidateJavaVersion
 			Condition=" '$(DesignTimeBuild)' != 'True' "
 			TargetFrameworkVersion="$(TargetFrameworkVersion)"


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2409
Context: https://github.com/xamarin/xamarin-android/wiki/Build-Performance-Results

When doing the latest performance comparison, I noticed the
`<ResolveSdks/>` MSBuild task is a bit slower:

    * VS 15.9
     80 ms  ResolveSdks                                7 calls
    * VS 16.0 p2 (master)
    127 ms  ResolveSdks                                7 calls

For `$(AndroidGenerateJniMarshalMethods)` support, we needed to locate
a new `$(JdkJvmPath)` location.

Since `<ResolveSdks/>` finds `$(JdkJvmPath)` on first build, and
design-time builds, it is worth making sure this task doesn't get any
slower. The initial design-time build happens on "solution create",
which is one of the more important metrics the VS team measures.

So I split out the logic finding `$(JdkJvmPath)` and put it in a new
`<ResolveJdkJvmPath/>` MSBuild task.

Also setup a `Condition`, so it only runs if:

- Not a `$(DesignTimeBuild)`
- `$(AndroidGenerateJniMarshalMethods)` is enabled
- `$(JdkJvmPath)` is blank

This should save ~50ms on DTBs and first builds.