### PR TITLE
[Xamarin.Android.Tools.BootstrapTasks] RenameTestCases errors

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
@@ -5,12 +5,15 @@ using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 
+#if !APP
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+#endif  // !APP
 
 namespace Xamarin.Android.Tools.BootstrapTasks
 {
-	public class RenameTestCases : Task
+#if !APP
+	public partial class RenameTestCases : Task
 	{
 		public                  bool                DeleteSourceFiles           { get; set; }
 		public                  string              Configuration               { get; set; }
@@ -24,29 +27,32 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 		public override bool Execute ()
 		{
-			Log.LogMessage (MessageImportance.Low, $"Task {nameof (RenameTestCases)}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (Configuration)}: {Configuration}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (DeleteSourceFiles)}: {DeleteSourceFiles}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (DestinationFolder)}: {DestinationFolder}");
-			Log.LogMessage (MessageImportance.Low, $"  {nameof (SourceFile)}: {SourceFile}");
-
 			var createdFiles    = new List<ITaskItem> ();
 			var testNameSuffix  = string.IsNullOrWhiteSpace (Configuration)
 				? ""
 				: $" / {Configuration}";
 			var dest            = GetFixedUpPath (SourceFile, testNameSuffix);
+			var fixedUp         = false;
 
 			try {
 				FixupTestResultFile (SourceFile, dest, testNameSuffix);
+				fixedUp = true;
 			}
 			catch (Exception e) {
-				Log.LogError ($"Unable to process `{SourceFile}`.  Is it empty?  (Did a unit test runner SIGSEGV?)");
-				CreateErrorResultsFile (dest, e);
-				Log.LogErrorFromException (e);
+				Log.LogWarning ($"Unable to process `{SourceFile}`.  Is it empty?  (Did a unit test runner SIGSEGV?)");
+				Log.LogWarningFromException (e);
+				CreateErrorResultsFile (SourceFile, dest, e);
+			}
+
+			if (DeleteSourceFiles && Path.GetFullPath (SourceFile) != Path.GetFullPath (dest)) {
+				File.Delete (SourceFile);
 			}
 
 			var item    = new TaskItem (dest);
 			item.SetMetadata ("SourceFile", SourceFile);
+			if (!fixedUp) {
+				item.SetMetadata ("Invalid", "True");
+			}
 			createdFiles.Add (item);
 
 			CreatedFiles    = createdFiles.ToArray ();
@@ -56,7 +62,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				Log.LogMessage (MessageImportance.Low, $"    [Output] {f}:");
 			}
 
-			return !Log.HasLoggedErrors;
+			return true;
 		}
 
 		string GetFixedUpPath (string source, string testNameSuffix)
@@ -66,38 +72,6 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				Path.GetExtension (source);
 			var dest = Path.Combine (DestinationFolder, destFilename);
 			return dest;
-		}
-
-		void CreateErrorResultsFile (string dest, Exception e)
-		{
-			var doc = new XDocument (
-				new XElement ("test-results",
-					new XAttribute ("date", DateTime.Now.ToString ("yyyy-MM-dd")),
-					new XAttribute ("errors", "1"),
-					new XAttribute ("failures", "0"),
-					new XAttribute ("ignored", "0"),
-					new XAttribute ("inconclusive", "0"),
-					new XAttribute ("invalid", "0"),
-					new XAttribute ("name", dest),
-					new XAttribute ("not-run", "0"),
-					new XAttribute ("skipped", "0"),
-					new XAttribute ("time", DateTime.Now.ToString ("HH:mm:ss")),
-					new XAttribute ("total", "1"),
-					new XElement ("test-suite",
-						new XAttribute ("type", "APK-File"),
-						new XAttribute ("name", dest),
-						new XAttribute ("executed", "True"),
-						new XAttribute ("result", "Failure"),
-						new XAttribute ("success", "False"),
-						new XAttribute ("time", "0"),
-						new XAttribute ("asserts", "0"),
-						new XElement ("results",
-							new XElement ("test-case",
-								new XAttribute ("name", Path.GetFileName (dest)),
-								new XElement ("failure",
-									new XElement ("message", $"Error processing `{SourceFile}`.  Check the build log for execution errors."),
-									new XElement ("stack-trace", e.ToString ())))))));
-			doc.Save (dest);
 		}
 
 		void FixupTestResultFile (string source, string dest, string testNameSuffix)
@@ -110,9 +84,6 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			}
 
 			doc.Save (dest);
-			if (DeleteSourceFiles && Path.GetFullPath (source) != Path.GetFullPath (dest)) {
-				File.Delete (source);
-			}
 		}
 
 		void FixupNUnit2Results (XDocument doc, string testNameSuffix)
@@ -126,4 +97,84 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			}
 		}
 	}
+#endif  // !APP
+
+	partial class RenameTestCases {
+
+		static void CreateErrorResultsFile (string source, string dest, Exception e)
+		{
+			var contents  = File.Exists (source)
+				? File.ReadAllText (source)
+				: "";
+
+			var doc       = new XDocument (
+				new XElement ("test-results",
+					new XAttribute ("date", DateTime.Now.ToString ("yyyy-MM-dd")),
+					new XAttribute ("errors", "1"),
+					new XAttribute ("failures", "0"),
+					new XAttribute ("ignored", "0"),
+					new XAttribute ("inconclusive", "0"),
+					new XAttribute ("invalid", "0"),
+					new XAttribute ("name", dest),
+					new XAttribute ("not-run", "0"),
+					new XAttribute ("skipped", "0"),
+					new XAttribute ("time", DateTime.Now.ToString ("HH:mm:ss")),
+					new XAttribute ("total", "1"),
+					new XElement ("environment",
+						new XAttribute ("nunit-version", "3.6.0.0"),
+						new XAttribute ("clr-version", "4.0.30319.42000"),
+						new XAttribute ("os-version", "Unix 15.6.0.0"),
+						new XAttribute ("platform", "Unix"),
+						new XAttribute ("cwd", Environment.CurrentDirectory),
+						new XAttribute ("machine-name", Environment.MachineName),
+						new XAttribute ("user", Environment.UserName),
+						new XAttribute ("user-domain", Environment.MachineName)),
+					new XElement ("culture-info",
+						new XAttribute ("current-culture", "en-US"),
+						new XAttribute ("current-uiculture", "en-US")),
+					new XElement ("test-suite",
+						new XAttribute ("type", "APK-File"),
+						new XAttribute ("name", dest),
+						new XAttribute ("executed", "True"),
+						new XAttribute ("result", "Failure"),
+						new XAttribute ("success", "False"),
+						new XAttribute ("time", "0"),
+						new XAttribute ("asserts", "0"),
+						new XElement ("results",
+							new XElement ("test-case",
+								new XAttribute ("name", Path.GetFileName (dest)),
+								new XAttribute ("executed", "True"),
+								new XAttribute ("result", "Error"),
+								new XAttribute ("success", "False"),
+								new XAttribute ("time", "0.0"),
+								new XAttribute ("asserts", "1"),
+								new XElement ("failure",
+									new XElement ("message",
+										$"Error processing `{source}`.  " +
+										$"Check the build log for execution errors.{Environment.NewLine}" +
+										$"File contents:{Environment.NewLine}",
+										new XCData (contents)),
+									new XElement ("stack-trace", e.ToString ())))))));
+			doc.Save (dest);
+		}
+	}
+
+#if APP
+	// Compile:
+	//   csc build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs /out:test.exe /d:APP /r:System.Xml.Linq.dll
+	// Run:
+	//   mono test.exe test.xml
+	// Validate:
+	//   curl -o Results.xsd https://nunit.org/docs/files/Results.xsd
+	//   MONO_XMLTOOL_ERROR_DETAILS=yes mono-xmltool  --validate Results.xsd test.xml
+	partial class RenameTestCases {
+
+		public static void Main (string[] args)
+		{
+			foreach (var file in args) {
+				CreateErrorResultsFile ("source.xml", file, new Exception ("Wee!!!"));
+			}
+		}
+	}
+#endif  // APP
 }

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -251,7 +251,12 @@
         Configuration="$(Configuration)"
         DeleteSourceFiles="$(_DeleteSource)"
         SourceFile="%(_RenameSource.Identity)"
-        DestinationFolder="%(_RenameSource.DestinationFolder)"
+        DestinationFolder="%(_RenameSource.DestinationFolder)">
+      <Output TaskParameter="CreatedFiles" ItemName="_RenameFailed"/>
+    </RenameTestCases>
+    <Error
+        Condition=" '%(_RenameFailed.Invalid)' != '' "
+        Text="One or more of the unit tests failed to produce an NUnit XML file.  Did a unit test runner crash?"
     />
   </Target>
   <Target Name="RenameApkTestCases"


### PR DESCRIPTION
Context: https://gitter.im/xamarin/xamarin-android?at=5be467157326df140ed4fe2b
Context: https://gitter.im/xamarin/xamarin-android?at=5be46a0c7326df140ed51325
Context: https://gitter.im/xamarin/xamarin-android?at=5be46dd37326df140ed527d1

The `<RenameTestCases/>` task was added in 385699a5 to update the
`//test-case/@name` attribute value to contain the Configuration from
which the test came from.

As part of its operation, it would occasionally encounter NUnit XML
files which were *invalid*, usually because `nunit-console` crashed;
see also 0ec00e12, which updated `<RenameTestCases/>` semantics so
that *if* an NUnit file were invalid, it would generate a "new" NUnit
XML file containing a generic error message.

The problem is, this attempt at reporting *any* error message is still
failing.  Take for example [Jenkins build 1257][0], which
[reports *no* unit test failures][1], but the build log contains:

        error : Unable to process `…/xamarin-android/external/Java.Interop/TestResult-Java.Interop-PerformanceTests.xml`.  Is it empty?  (Did a unit test runner SIGSEGV?)

This is *precisely* what 0ec00e12 (and 1db436c6) attempted to address:
*surface* that error so that it's shown in the `testReport` URL.

[Further investigation][2] suggests that there are (at least?) three
remaining problems around `<RenameTestCases/>`:

 1. The `<RenameTestCases/>` task ***cannot report errors***.
 2. When the "generic error" XML was generated, the *source* file
    was not removed.
 3. The NUnit XML `<RenameTestCases/>` generated was invalid.

The `<RenameTestCases/>` task cannot fail -- cannot return `false`
from `RenameTestCases.Execute()` -- because it is used within an
[MSBuild Task Batching][3] context, and is thus executed *separately*
for each `@(_RenameSource)` value.  If one invocation fails, then all
following `@(_RenameSource)` values *are not processed*.

Additionally, `<RenameTestCases/>` is *supposed* to delete the source
file once it has renamed the tests within it.  However, if the source
file was invalid (*usually* an empty file), the output file was
created but the source file was not removed, unlike the "normal"
non-error case.  This results in empty output files later in the unit
test process.

Finally, the "generic error" `<RenameTestCases/>` generated
didn't validate against the [NUnit XSD][4]:

        WARNING: At line 5 of file:…/xamarin-android/TestResult-Java.Interop-PerformanceTests-Debug.xml:cvc-complex-type.4: Attribute 'executed' must appear on element 'test-case'.

This is presumably why the `testReport` URL doesn't show these.

Fix all of these problems:

 1. Update `<RenameTestCases/>` so that instead of reporting errors it
    instead reports *warnings*, and it *always* returns `true` (unless
    there's an unhandled exception elsewhere, which *should* fail).

    When an "invalid" NUnit file is created, it also sets
    `%(_RenameFailed.Invalid)`, so that the `RenameTestCases` target
    can emit an error once all `@(_RenameSource)` files are processed.

 2. Update `<RenameTestCases/>` so that `RenameTestCases.SourceFile`
    is consistently deleted, by moving the `DeleteSourceFiles` check
    out of `FixupTestResultFile()` and into `Execute()`.

 3. Update `<RenameTestCases/>` so that the XML it generates will
    validate.

    To assist in this, `RenameTestCases.cs` now contains a `Main()`
    method, which will exist if it's compiled with `APP` defined.

The "generic error" XML output can thus be validated, using
`mono-xmltool`:

        csc build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs /out:test.exe /d:APP /r:System.Xml.Linq.dll
        mono test.exe test.xml
        curl -o Results.xsd https://nunit.org/docs/files/Results.xsd
        MONO_XMLTOOL_ERROR_DETAILS=yes mono-xmltool  --validate Results.xsd test.xml

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/1257
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/1257/testReport/
[2]: https://gitter.im/xamarin/xamarin-android?at=5be467157326df140ed4fe2b
[3]: https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-batching?view=vs-2017#task-batching
[4]: https://nunit.org/docs/files/Results.xsd