### PR TITLE
[Xamarin.Android.Build.Tasks] <ValidateJavaVersion/> needed for designer

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -715,7 +715,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		<Output TaskParameter="MonoAndroidBinPath"        PropertyName="MonoAndroidBinDirectory" />
 	</ResolveSdks>
 	<ValidateJavaVersion
-			Condition=" '$(DesignTimeBuild)' != 'True' "
+			Condition=" '$(DesignTimeBuild)' != 'True' Or '$(AndroidUseManagedDesignTimeResourceGenerator)' != 'True' "
 			TargetFrameworkVersion="$(TargetFrameworkVersion)"
 			AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
 			JavaSdkPath="$(_JavaSdkDirectory)"


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/2410

In 3eb41a0, I added a good performance improvement for the initial
design-time build (solution create).

However, we have tests downstream in monodroid that check if MSBuild
targets called by the Android designer are working. Apparently, these
targets need `$(_JdkVersion)`, whoops! Glad we have that test!

The Android designer also sets
`$(AndroidUseManagedDesignTimeResourceGenerator)` to `False`. We can
check for this and allow the `<ValidateJavaVersion/>` MSBuild task to
run in this case.