### PR TITLE
[Xamarin.Android.Build.Tasks] Fix Aar directory resolution.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -397,8 +397,16 @@ namespace Xamarin.Android.Tasks
 				string assetsDir = Path.Combine (importsDir, "assets");
 
 				var stamp = new FileInfo (Path.Combine (outdir.FullName, Path.GetFileNameWithoutExtension (aarFile.ItemSpec) + ".stamp"));
-				if (stamp.Exists && stamp.LastWriteTimeUtc > new FileInfo (aarFile.ItemSpec).LastWriteTimeUtc)
+				if (stamp.Exists && stamp.LastWriteTimeUtc > new FileInfo (aarFile.ItemSpec).LastWriteTimeUtc) {
+					if (Directory.Exists (resDir))
+						resolvedResourceDirectories.Add (new TaskItem (resDir, new Dictionary<string, string> {
+							{ OriginalFile, Path.GetFullPath (aarFile.ItemSpec) },
+							{ SkipAndroidResourceProcessing, "True" },
+						}));
+					if (Directory.Exists (assetsDir))
+						resolvedAssetDirectories.Add (assetsDir);
 					continue;
+				}
 				// temporarily extracted directory will look like:
 				// _lp_/[aarFile]
 				using (var zip = MonoAndroidHelper.ReadZipFile (aarFile.ItemSpec)) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2103,7 +2103,7 @@ namespace App1
 				Assert.IsFalse (builder.Output.IsTargetSkipped ("_ResolveLibraryProjectImports"),
 					"_ResolveLibraryProjectImports should have run.");
 
-				var doc = XDocument.Load (cache);
+				doc = XDocument.Load (cache);
 				var count = doc.Elements ("Paths").Elements ("ResolvedResourceDirectories").Count ();
 				Assert.AreEqual (expectedCount, count, "The same number of resource directories should have been resolved.");
 


### PR DESCRIPTION
Fixed #2408

As part of the speed up process when extracting resources
from assemblies and Aar files, we dont re-extract if
the stamp file is newer than the assembly.

The problem with that was in the case of Aar files we
were NOT adding the `res` or `asset` directories to
the list of resolved directories when we skipped extraction.
As a result we got less `res` directories on a second
build.

This commit fixes that.