### PR TITLE
[Xamarin.Android.Build.Tasks] move $(AdbTarget) out of build.props

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -316,6 +316,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<_AndroidSequencePointsMode Condition=" '$(_AndroidSequencePointsMode)' == ''">None</_AndroidSequencePointsMode>
 	<_InstantRunEnabled Condition=" '$(_InstantRunEnabled)' == '' ">False</_InstantRunEnabled>
 	<_AndroidBuildPropertiesCache>$(IntermediateOutputPath)build.props</_AndroidBuildPropertiesCache>
+	<_AdbPropertiesCache>$(IntermediateOutputPath)adb.props</_AdbPropertiesCache>
 	<_AndroidDesignTimeBuildPropertiesCache>$(_AndroidIntermediateDesignTimeBuildDirectory)build.props</_AndroidDesignTimeBuildPropertiesCache>
 	<AndroidGenerateJniMarshalMethods Condition=" '$(AndroidGenerateJniMarshalMethods)' == '' ">False</AndroidGenerateJniMarshalMethods>
 	<AndroidMakeBundleKeepTemporaryFiles Condition=" '$(AndroidMakeBundleKeepTemporaryFiles)' == '' ">False</AndroidMakeBundleKeepTemporaryFiles>
@@ -1227,8 +1228,6 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="OS=$(OS)" />
 		<_PropertyCacheItems Include="DesignTimeBuild=$(DesignTimeBuild)" />
 		<_PropertyCacheItems Include="AndroidIncludeDebugSymbols=$(AndroidIncludeDebugSymbols)" />
-		<_PropertyCacheItems Include="AdbTarget=$(AdbTarget)" />
-		<_PropertyCacheItems Include="AdbOptions=$(AdbOptions)" />
 	</ItemGroup>
 	<MakeDir Directories="$(_AndroidStampDirectory)" Condition="!Exists('$(_AndroidStampDirectory)')" />
 	<WriteLinesToFile
@@ -1237,6 +1236,17 @@ because xbuild doesn't support framework reference assemblies.
 			Overwrite="true"
 			WriteOnlyWhenDifferent="true"
 	/>
+	<WriteLinesToFile
+			Condition=" '$(DesignTimeBuild)' != 'True' "
+			File="$(_AdbPropertiesCache)"
+			Lines="AdbTarget=$(AdbTarget);AdbOptions=$(AdbOptions)"
+			Overwrite="true"
+			WriteOnlyWhenDifferent="true"
+	/>
+	<ItemGroup>
+		<FileWrites Include="$(_AndroidBuildPropertiesCache)" />
+		<FileWrites Include="$(_AdbPropertiesCache)" />
+	</ItemGroup>
 </Target>
 
 <PropertyGroup>
@@ -3177,6 +3187,7 @@ because xbuild doesn't support framework reference assemblies.
 	<Delete Files="$(_AndroidLintConfigFile)" />
 	<Delete Files="$(_AndroidResourceDesignerFile)" Condition=" '$(AndroidUseIntermediateDesignerFile)' == 'True' " />
 	<Delete Files="$(_AndroidBuildPropertiesCache)" />
+	<Delete Files="$(_AdbPropertiesCache)" />
 	<Delete Files="$(_AndroidLibraryImportsCache)" />
 	<Delete Files="$(_AndroidLibraryImportsCache).stamp" />
 	<Delete Files="$(_AndroidStaticResourcesFlag)" />


### PR DESCRIPTION
`$(IntermediateOutputPath)build.props`, or
`$(_AndroidBuildPropertiesCache)` is a file used as an `Input` to many
MSBuild targets. We write many *important* properties in this file as
a mechanism to trigger most of the build to rerun. So for example, if
you enabled proguard, the `$(AndroidEnableProguard)` MSBuild property
would re-run a lot of the build, such as `_CompileJava`,
`_CompileDex`, etc.

Right now there are two problematic properties in this file:
- `$(AdbTarget)`
- `$(AdbOptions)`

This means if you switched from a different Android deploy target:
emulator to device, or just a different device--it would run a full
build! `$(AdbTarget)` and `$(AdbOptions)` need to trigger MSBuild
targets related to "Fast Deployment" to re-run, but not everything.
What makes matters even worse, is sometimes design-time builds will
pass a blank `$(AdbTarget)`. This causes expensive targets to run
again.

I've moved these properties to a new file:
- `$(IntermediateOutputPath)adb.props` or
- `$(_AdbPropertiesCache)`

Then downstream in monodroid, there is a single line that needs to be
changed from `$(_AdbPropertiesCache)` to `$(_AdbPropertiesCache)`.
This will re-trigger the APK to be installed when devices change.