### PR TITLE
[xa-prep-tasks] use JdkInfo to find JavaSdkDirectory

### DIFF
--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -26,6 +26,7 @@
         AndroidSdkPath="$(AndroidSdkDirectory)"
         AndroidNdkPath="$(AndroidNdkDirectory)"
         JavaSdkPath="$(JavaSdkDirectory)"
+        MaxJdkVersion="$(MaxJdkVersion)"
         Output="$(_TopDir)\external\Java.Interop\bin\Build$(Configuration)\JdkInfo.props">
       <Output TaskParameter="JavaSdkDirectory" PropertyName="_JavaSdkDirectory" />
     </JdkInfo>


### PR DESCRIPTION
On Windows, if you have Microsoft OpenJDK installed, you currently
needed a `Configuration.Override.props` such as:

    <Project>
      <PropertyGroup>
        <JavaSdkDirectory>C:\Program Files (x86)\Java\jdk1.8.0_161</JavaSdkDirectory>
      </PropertyGroup>
    </Project>

The Xamarin.Android build can't currently work with Microsoft OpenJDK,
because it is missing header files.

I've updated the `JdkInfo` MSBuild task to match a similar task in
Java.Interop. It now validates that JDKs are < `$(MaxJdkVersion)`, and
contain valid header files. `$(MaxJdkVersion)` defaults to 8.0 if it
is blank.

Now I am able to build Xamarin.Android on a Windows machine with
multiple JDKs and it picks the correct one.