### PR TITLE
[mono-sdks] <DownloadUri/> should not run during design-time builds

### DIFF
--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -627,7 +627,4 @@
     <Delete Files="@(_StampFiles)" />
   </Target>
 
-  <Target Name="CoreCompile"
-      DependsOnTargets="_Build">
-  </Target>
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2350

Most of the logic in `mono-runtimes.csproj` was happening during
`CoreCompile`. The problem with this is that design-time builds in
Visual Studio runs `CoreCompile`. The `Task.Wait` in `<DownloadUri/>`
causes a hang.

It turns out we could just completely remove the following target:

    <Target Name="CoreCompile"
        DependsOnTargets="_Build">
    </Target>

`_Build` still runs appropriately. `_BuildUnlessCached` will call
`ForceBuild` or `_Build` depending if things are cached.