### PR TITLE
[tests] Run the XForms test also in Debug and Release/AOT

### DIFF
--- a/tests/RunApkTests.targets
+++ b/tests/RunApkTests.targets
@@ -20,7 +20,7 @@
   <Import Project="..\tests\CodeGen-Binding\Xamarin.Android.JcwGen-Tests\Xamarin.Android.JcwGen-Tests.projitems" Condition=" '$(AotAssemblies)' != 'True' " />
   <Import Project="..\tests\EmbeddedDSOs\EmbeddedDSO\EmbeddedDSO.projitems" />
   <Import Project="..\tests\locales\Xamarin.Android.Locale-Tests\Xamarin.Android.Locale-Tests.projitems"  Condition=" '$(AotAssemblies)' != 'True' " />
-  <Import Project="..\tests\Xamarin.Forms-Performance-Integration\Droid\Xamarin.Forms.Performance.Integration.Droid.projitems"  Condition=" '$(Configuration)' == 'Release' And '$(AotAssemblies)' != 'true' " />
+  <Import Project="..\tests\Xamarin.Forms-Performance-Integration\Droid\Xamarin.Forms.Performance.Integration.Droid.projitems" />
   <Import Project="..\tests\Runtime-MultiDex\Mono.Android-TestsMultiDex.projitems" />
   <Import Project="..\build-tools\scripts\TestApks.targets" />
   <PropertyGroup>


### PR DESCRIPTION
I think we want to run and measure this test in all configurations,
the same as we do for Mono.Android-Tests.