### PR TITLE
[Xamarin.Android.Build.Tasks] Include compiled.flata in archive

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateManagedLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateManagedLibraryResourceArchive.cs
@@ -28,6 +28,8 @@ namespace Xamarin.Android.Tasks
 
 		public ITaskItem [] RemovedAndroidResourceFiles { get; set; }
 
+		public string FlatArchivesDirectory { get; set; }
+
 		[Required]
 		public string ResourceDirectory { get; set; }
 
@@ -48,8 +50,9 @@ namespace Xamarin.Android.Tasks
 					subdirInfo.Create ();
 			}
 
-			var compiledArchive = Path.Combine (ResourceDirectory, "..", "compiled.flata");
+			var compiledArchive = Path.Combine (FlatArchivesDirectory, "compiled.flata");
 			if (File.Exists (compiledArchive)) {
+				Log.LogDebugMessage ($"Coping: {compiledArchive} to {outDirInfo.FullName}");
 				MonoAndroidHelper.CopyIfChanged (compiledArchive, Path.Combine (outDirInfo.FullName, "compiled.flata"));
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1872,6 +1872,7 @@ because xbuild doesn't support framework reference assemblies.
 		AndroidJavaSources="@(AndroidJavaSource)"
 		AndroidJavaLibraries="@(AndroidJavaLibrary)"
 		AndroidResourcesInThisExactProject="@(_AndroidResourceDest)"
+		FlatArchivesDirectory="$(_AndroidLibraryFlatArchivesDirectory)"
 		RemovedAndroidResourceFiles="@(_AndroidResourceDestRemovedFiles)"
 	/>
 	<Touch Files="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip" />


### PR DESCRIPTION
Commit 960f32c5 changed the location where libraries compile
their `compiled.flata` archive. As a result this file
was NOT being included in the `ManagedLibraryResourceArchive`.

This PR fixes up the `CreateManagedLibraryResourceArchive` to
use the new location for storing the `flata` archives.