### PR TITLE
[download-bundle] updated URLs, take 2!

### DIFF
--- a/build-tools/download-bundle/download-bundle.targets
+++ b/build-tools/download-bundle/download-bundle.targets
@@ -19,9 +19,9 @@
       Inputs="download-bundle.csproj"
       Outputs="$(_BundlePath)">
     <PropertyGroup>
-      <_AzureJobUri Condition=" '$(Configuration)' == 'Debug' ">xamarin-android-debug/bin/</_AzureJobUri>
-      <_AzureJobUri Condition=" '$(Configuration)' != 'Debug' ">xamarin-android/bin/</_AzureJobUri>
-      <XABundleDownloadPrefix Condition=" '$(XABundleDownloadPrefix)' == '' ">$(_AzureBaseUri)$(_AzureJobUri)$(Configuration)</XABundleDownloadPrefix>
+      <_AzureJobUri Condition=" '$(Configuration)' == 'Debug' ">xamarin-android-debug</_AzureJobUri>
+      <_AzureJobUri Condition=" '$(Configuration)' != 'Debug' ">xamarin-android</_AzureJobUri>
+      <XABundleDownloadPrefix Condition=" '$(XABundleDownloadPrefix)' == '' ">$(_AzureBaseUri)$(_AzureJobUri)/xamarin-android/bin/$(Configuration)</XABundleDownloadPrefix>
     </PropertyGroup>
     <DownloadUri
         ContinueOnError="True"


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-debug
Context: https://github.com/xamarin/xamarin-android/pull/2457

dd498d2 was an attempt to fix our Jenkins configuration + bundle
downloads. However, when I tested the latest bundle I found a new
problem...

The current URLs are of the form:

    Debug:   https://xamjenkinsartifact.azureedge.net/mono-jenkins/xamarin-android-debug/xamarin-android/bin/Debug/...-Debug-...zip
    Release: https://xamjenkinsartifact.azureedge.net/mono-jenkins/xamarin-android/bin/Release/...-Release-...zip

The `xamarin-android-debug` job is using `${JOB_NAME}` as the "virtual
directory" to upload to. The `xamarin-android` Release job is not...
`xamarin-android` is automatically being appended due to the directory
structure of the Jenkins workspace.

So to fix this, and keep the jobs uploading to different paths:

1. I set the "virtual directory" to `${JOB_NAME}` on the Release job.
2. I fixed up the URLs again in `download-bundle.targets`, so they now
   append `xamarin-android` appropriately.

I think this is the best option, since it probably isn't safe for both
jobs to upload to the same "virtual directory".