### PR TITLE
[build] pin NuGet.exe to a specific version

### DIFF
--- a/build-tools/download-bundle/download-bundle.targets
+++ b/build-tools/download-bundle/download-bundle.targets
@@ -5,7 +5,7 @@
   <Import Project="..\create-bundle\bundle-path.targets" />
   <PropertyGroup>
     <_AzureBaseUri>https://xamjenkinsartifact.azureedge.net/mono-jenkins/</_AzureBaseUri>
-    <_NuGetUri>https://dist.nuget.org/win-x86-commandline/latest/nuget.exe</_NuGetUri>
+    <_NuGetUri>https://dist.nuget.org/win-x86-commandline/v4.7.1/nuget.exe</_NuGetUri>
     <_NuGetPath>$(MSBuildThisFileDirectory)\..\..\.nuget</_NuGetPath>
   </PropertyGroup>
   <Target Name="_GetBundleOutputPath"


### PR DESCRIPTION
Context: https://www.nuget.org/downloads
Context: http://build.devdiv.io/2236305

Currently we download NuGet.exe from:

    https://dist.nuget.org/win-x86-commandline/latest/nuget.exe

However, it seems that the NuGet 4.8.1 release breaks our build on
Windows...

    src\monodroid\monodroid.targets(3,3): Error MSB4019: The imported project "E:\A\_work\14\s\external\Java.Interop\bin\BuildDebug\JdkInfo.props" was not found. Confirm that the path in the <Import> declaration is correct, and that the file exists on disk. [E:\A\_work\14\s\src\monodroid\monodroid.csproj]
    src\Xamarin.Android.NUnitLite\Xamarin.Android.NUnitLite.csproj(349,3): Error MSB4019: The imported project "E:\A\_work\14\s\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" was not found. Confirm that the path in the <Import> declaration is correct, and that the file exists on disk.
    src\System.EnterpriseServices\System.EnterpriseServices.csproj(46,3): Error MSB4019: The imported project "E:\A\_work\14\s\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" was not found. Confirm that the path in the <Import> declaration is correct, and that the file exists on disk.
    src\Mono.Posix\Mono.Posix.csproj(236,3): Error MSB4019: The imported project "E:\A\_work\14\s\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" was not found. Confirm that the path in the <Import> declaration is correct, and that the file exists on disk.
    src\Mono.Data.Sqlite\Mono.Data.Sqlite.csproj(180,3): Error MSB4019: The imported project "E:\A\_work\14\s\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" was not found. Confirm that the path in the <Import> declaration is correct, and that the file exists on disk.
    src\OpenTK-1.0\OpenTK.csproj(597,3): Error MSB4019: The imported project "E:\A\_work\14\s\bin\Debug\lib\xbuild\Xamarin\Android\Xamarin.Android.CSharp.targets" was not found. Confirm that the path in the <Import> declaration is correct, and that the file exists on disk.
    build-tools\scripts\PrepareWindows.targets(19,5): Error MSB3073: The command ".nuget\NuGet.exe restore Xamarin.Android.sln" exited with code -1.

It seems if you do:

    nuget.exe restore Xamarin.Android.sln

If NuGet encounters an MSBuild targets file it cannot import, it now
errors out on the new version???

Previously this was working somehow, but for now I think it would be
simpler (and more reliable) to pin our download of NuGet.exe to a
specific version.

I will need to create a simple repro and submit an issue for NuGet.