### PR TITLE
[Xamarin.Android.Build.Tasks] remove the need for d8.jar

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -210,11 +210,6 @@ when packaing Release applications.
 
     This property is `False` by default.
 
--   **AndroidD8JarPath** &ndash; The path to `d8.jar` for use with the
-    d8 dex-compiler. Defaults to a path in the Xamarin.Android
-    installation. For further information see our documentation on [D8
-    and R8][d8-r8].
-
 -   **AndroidDexTool** &ndash; An enum-style property with valid
     values of `dx` or `d8`. Indicates which Android [dex][dex]
     compiler is used during the Xamarin.Android build process.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/D8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/D8.cs
@@ -44,6 +44,8 @@ namespace Xamarin.Android.Tasks
 			return GetCommandLineBuilder ().ToString ();
 		}
 
+		protected virtual string MainClass => "com.android.tools.r8.D8";
+
 		protected virtual CommandLineBuilder GetCommandLineBuilder ()
 		{
 			var cmd = new CommandLineBuilder ();
@@ -52,7 +54,8 @@ namespace Xamarin.Android.Tasks
 				cmd.AppendSwitch (JavaOptions);
 			}
 			cmd.AppendSwitchIfNotNull ("-Xmx", JavaMaximumHeapSize);
-			cmd.AppendSwitchIfNotNull ("-jar ", JarPath);
+			cmd.AppendSwitchIfNotNull ("-classpath ", JarPath);
+			cmd.AppendSwitch (MainClass);
 
 			if (!string.IsNullOrEmpty (ExtraArguments))
 				cmd.AppendSwitch (ExtraArguments); // it should contain "--dex".

--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -31,6 +31,8 @@ namespace Xamarin.Android.Tasks
 		public string ProguardCommonXamarinConfiguration { get; set; }
 		public string ProguardConfigurationFiles { get; set; }
 
+		protected override string MainClass => "com.android.tools.r8.SwissArmyKnife";
+
 		string temp;
 
 		public override bool Execute ()

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -978,12 +978,6 @@ because xbuild doesn't support framework reference assemblies.
 		/>
 	</CreateProperty>
 
-	<CreateProperty Value="$(MonoAndroidToolsDirectory)\d8.jar">
-		<Output TaskParameter="Value" PropertyName="AndroidD8JarPath"
-				Condition="'$(AndroidD8JarPath)' == ''"
-		/>
-	</CreateProperty>
-
 	<CreateProperty Value="--dex --no-strict">
 		<Output TaskParameter="Value" PropertyName="DxExtraArguments"
 			Condition="'$(DxExtraArguments)' == ''"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
@@ -31,10 +31,6 @@ Copyright (C) 2018 Xamarin. All rights reserved.
     </PropertyGroup>
 
     <Error
-        Condition=" !Exists('$(AndroidD8JarPath)') "
-        Text="d8.jar does not exist (AndroidD8JarPath property has to point to a valid file (current value: '$(AndroidD8JarPath)')."
-    />
-    <Error
         Condition=" !Exists('$(AndroidR8JarPath)') "
         Text="r8.jar does not exist (AndroidR8JarPath property has to point to a valid file (current value: '$(AndroidR8JarPath)')."
     />
@@ -114,7 +110,7 @@ Copyright (C) 2018 Xamarin. All rights reserved.
         ToolPath="$(JavaToolPath)"
         JavaMaximumHeapSize="$(JavaMaximumHeapSize)"
         JavaOptions="$(JavaOptions)"
-        JarPath="$(AndroidD8JarPath)"
+        JarPath="$(AndroidR8JarPath)"
         AndroidManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
         OutputDirectory="$(IntermediateOutputPath)android\bin"
         Debug="$(AndroidIncludeDebugSymbols)"

--- a/src/r8/r8.targets
+++ b/src/r8/r8.targets
@@ -32,7 +32,7 @@
         Value="$([System.IO.Path]::GetFullPath('$(ChromeToolsDirectory)'))$(PathSeparator)$(_OriginalPath)"
     />
     <Exec
-      Command="python tools\gradle.py d8 r8 $(_GradleArgs)"
+      Command="python tools\gradle.py r8 $(_GradleArgs)"
       EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory)"
       WorkingDirectory="..\..\external\r8"
     />
@@ -44,7 +44,7 @@
 
   <Target Name="_CopyR8">
     <Copy
-        SourceFiles="..\..\external\r8\build\libs\d8.jar;..\..\external\r8\build\libs\r8.jar"
+        SourceFiles="..\..\external\r8\build\libs\r8.jar"
         DestinationFolder="$(XAInstallPrefix)xbuild\Xamarin\Android\"
         SkipUnchangedFiles="true"
     />
@@ -54,9 +54,7 @@
     <PropertyGroup>
       <_OriginalPath>$(PATH)</_OriginalPath>
     </PropertyGroup>
-    <Delete
-        Files="$(XAInstallPrefix)xbuild\Xamarin\Android\d8.jar;$(XAInstallPrefix)xbuild\Xamarin\Android\r8.jar;"
-    />
+    <Delete Files="$(XAInstallPrefix)xbuild\Xamarin\Android\r8.jar" />
     <Xamarin.Android.BuildTools.PrepTasks.SetEnvironmentVariable
         Name="PATH"
         Value="$([System.IO.Path]::GetFullPath('$(ChromeToolsDirectory)'))$(PathSeparator)$(_OriginalPath)"


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2461

Xamarin.Android has been building and shipping both `d8.jar` and
`r8.jar`. These are quite large (~23MB!), due to a large amount of
Java code.

Looking at the *only* difference of the two jar files:

    diff -rup d8/META-INF/MANIFEST.MF r8/META-INF/MANIFEST.MF
    --- d8/META-INF/MANIFEST.MF	2018-11-21 14:36:48.000000000 -0500
    +++ r8/META-INF/MANIFEST.MF	2018-11-21 14:36:44.000000000 -0500
    @@ -1,3 +1,3 @@
    Manifest-Version: 1.0
    -Main-Class: com.android.tools.r8.D8
    +Main-Class: com.android.tools.r8.SwissArmyKnife

We can just use the single `r8.jar` and invoke a different
`Main-Class`. This will save us ~20MB of install size.

## Changes

* `r8.targets` no longer builds `d8.jar`.
* Removed the `$(AndroidD8JarPath)` MSBuild property.
* The `<D8/>` and `<R8/>` MSBuild tasks use `java -classpath r8.jar
  com.android.tools.r8.D8` or `com.android.tools.r8.SwissArmyKnife`
  respectively.

## Downstream in monodroid

I will need to remove `d8.jar` from the pkg installer.