### PR TITLE
[Xamarin.Android.Build.Tasks] move properties so they exist in binding projects

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -31,6 +31,17 @@ namespace Xamarin.Android.Build.Tests
 			proj.AndroidClassParser = classParser;
 			using (var b = CreateDllBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+
+				//A list of properties we check exist in binding projects
+				var properties = new [] {
+					"AndroidSdkBuildToolsVersion",
+					"AndroidSdkPlatformToolsVersion",
+					"AndroidSdkToolsVersion",
+					"AndroidNdkVersion",
+				};
+				foreach (var property in properties) {
+					Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, property + " = "), $"$({property}) should be set!");
+				}
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -138,8 +138,8 @@
   <Target Name="_GenerateXACommonProps"
       DependsOnTargets="ResolveReferences;GetXAVersionInfo"
       BeforeTargets="DeployOutputFiles"
-      Inputs="Xamarin.Android.Common.props.in Xamarin.Android.BuildInfo.txt.in"
-      Outputs="Xamarin.Android.Common.props Xamarin.Android.BuildInfo.txt">
+      Inputs="Xamarin.Android.Common.props.in;Xamarin.Android.BuildInfo.txt.in"
+      Outputs="Xamarin.Android.Common.props;Xamarin.Android.BuildInfo.txt">
     <ReplaceFileContents
         SourceFile="Xamarin.Android.BuildInfo.txt.in"
         DestinationFile="Xamarin.Android.BuildInfo.txt"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -12,6 +12,10 @@
 		<AndroidResourceGeneratorTargetName>UpdateGeneratedFiles</AndroidResourceGeneratorTargetName>
 		<AndroidUseAapt2 Condition=" '$(AndroidUseAapt2)' == '' ">False</AndroidUseAapt2>
 		<AndroidUseManagedDesignTimeResourceGenerator Condition=" '$(AndroidUseManagedDesignTimeResourceGenerator)' == '' And '$(OS)' != 'Windows_NT' ">False</AndroidUseManagedDesignTimeResourceGenerator>
+		<AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">27.0.3</AndroidSdkBuildToolsVersion>
+		<AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">27.0.1</AndroidSdkPlatformToolsVersion>
+		<AndroidSdkToolsVersion Condition="'$(AndroidSdkToolsVersion)' == ''">26.1.1</AndroidSdkToolsVersion>
+		<AndroidNdkVersion Condition="'$(AndroidNdkVersion)' == ''">16.1</AndroidNdkVersion>
 	</PropertyGroup>
 	<ItemDefinitionGroup>
 		<AndroidResource>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -250,11 +250,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	     Disable generation to avoid "bizarre" build errors. -->
 	<GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
 
-	<AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">27.0.3</AndroidSdkBuildToolsVersion>
-	<AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">27.0.1</AndroidSdkPlatformToolsVersion>
-	<AndroidSdkToolsVersion Condition="'$(AndroidSdkToolsVersion)' == ''">26.1.1</AndroidSdkToolsVersion>
-	<AndroidNdkVersion Condition="'$(AndroidNdkVersion)' == ''">16.1</AndroidNdkVersion>
-
 	<AndroidDebugKeyAlgorithm Condition=" '$(AndroidDebugKeyAlgorithm)' == '' ">RSA</AndroidDebugKeyAlgorithm>
 	<AndroidDebugKeyValidity Condition=" '$(AndroidDebugKeyValidity)' == '' ">10950</AndroidDebugKeyValidity>
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2452

Some of our Xamarin components on NuGet need to take advantage of the
`$(AndroidSdkBuildToolsVersion)` property. However, this property does
not exist in a binding project.

It appears we need to move some important properties:

* `$(AndroidSdkBuildToolsVersion)`
* `$(AndroidSdkPlatformToolsVersion)`
* `$(AndroidSdkToolsVersion)`
* `$(AndroidNdkVersion)`

From `Xamarin.Android.Common.targets` to
`Xamarin.Android.Common.props`, since binding projects only import the
`*.props` file.

Other changes:

* I updated a binding project test, to verify these properties are
  set.
* `Xamarin.Android.Build.Tasks.targets`, which generates
  `Xamarin.Android.Common.props` was using a space character as a
  delimiter? I wasn't aware this even worked, so I switched this to a
  `;`. This seems more standard.