### PR TITLE
Improve timing accuracy and efficiency

### DIFF
--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -1935,7 +1935,6 @@ Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobject
 	timing_period total_time;
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
 		total_time.mark_start ();
-		log_info (LOG_TIMING, "Runtime.init: start");
 	}
 
 	android_api_level = GetAndroidSdkVersion (env, loader);


### PR DESCRIPTION
Current timing code in monodroid-glue.cc uses the `gettimeofday` which provides
a most a microsecond accuracy, not enough for certain measurements.
Additionally, current code rounds it up to the millisecond boundery, making the
measurements very inaccurate. Also, `gettimeofday` is quite heavy in terms of
time spent in the syscall.

Replace `gettimeofday` with a call to `clock_gettime` when targetting Android or
Linux. This allows us to specify an alternative lock source, `CLOCK_MONOTONIC`,
which is very accurate and fast (not as fast as `CLOCK_MONOTONIC_COARSE` but
with higher resolution, thus better suited for our needs).

In addition, introduce a small collection of structures to be used for timing
instead of the currently used `long long` variables. Also introduced are the
`Util` class APIs to record the time (using the new `timing_period` structure
which has members to mark both the start and the end of the timing period - the
`start` and `end` fields, respectively) as well as a function to calculate the
difference between times stored in `time_period`. Structure representing the
difference supports reporting in seconds + milliseconds + nanoseconds.