### PR TITLE
[build] Do not build obsolete Mono.Android assemblies

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -15,7 +15,7 @@
     <ProductVersion>9.1.199</ProductVersion>
     <!-- Used by the `build-tools/create-vsix` build so that `Mono.Android.Export.dll`/etc. are only included *once* -->
     <!-- Should correspond to the first value from `$(API_LEVELS)` in `build-tools/scripts/BuildEverything.mk` -->
-    <AndroidFirstFrameworkVersion Condition="'$(AndroidFirstFrameworkVersion)' == ''">v2.3</AndroidFirstFrameworkVersion>
+    <AndroidFirstFrameworkVersion Condition="'$(AndroidFirstFrameworkVersion)' == ''">v4.4</AndroidFirstFrameworkVersion>
     <_IsRunningNuGetRestore Condition="$(RestoreTaskAssemblyFile.EndsWith('NuGet.exe', StringComparison.InvariantCultureIgnoreCase))">True</_IsRunningNuGetRestore>
     <!-- *Latest* *stable* API level binding that we support; used when building src/Xamarin.Android.Build.Tasks -->
     <AndroidLatestStableApiLevel Condition="'$(AndroidLatestStableApiLevel)' == ''">28</AndroidLatestStableApiLevel>

--- a/Documentation/building/configuration.md
+++ b/Documentation/building/configuration.md
@@ -29,7 +29,7 @@ Overridable MSBuild properties include:
 
   * `$(AndroidFirstFrameworkVersion)`: The first `$(TargetFrameworkVersion)`
     which will be built by `make jenkins` and included in the installer.
-    Currently `v2.3`, but will be changed when we drop support for API-10.
+    Currently `v4.4`.
     This controls what is included in `build-tools/create-vsix` packages.
 
   * `$(AndroidFrameworkVersion)`: The Xamarin.Android `$(TargetFrameworkVersion)`

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -23,13 +23,13 @@ ZIP_OUTPUT            = $(ZIP_OUTPUT_BASENAME).$(ZIP_EXTENSION)
 ## The following values *must* use SPACE, **not** TAB, to separate values.
 
 # $(ALL_API_LEVELS) and $(ALL_FRAMEWORKS) must be kept in sync w/ each other
-ALL_API_LEVELS    = 1 2 3 4 5 6 7 8 9 10    11  12  13  14  15      16    17    18    19    20        21    22    23    24    25    26    27    28
+ALL_API_LEVELS    = 1 2 3 4 5 6 7 8 9 10  11  12  13  14  15  16  17  18  19    20        21    22    23    24    25    26    27    28
 # this was different from ALL_API_LEVELS when API Level 26 was "O". Same could happen in the future.
-ALL_PLATFORM_IDS  = 1 2 3 4 5 6 7 8 9 10    11  12  13  14  15      16    17    18    19    20        21    22    23    24    25    26    27    28
+ALL_PLATFORM_IDS  = 1 2 3 4 5 6 7 8 9 10  11  12  13  14  15  16  17  18  19    20        21    22    23    24    25    26    27    28
 # supported api levels
-ALL_FRAMEWORKS    = _ _ _ _ _ _ _ _ _ v2.3  _   _   _   _   v4.0.3  v4.1  v4.2  v4.3  v4.4  v4.4.87   v5.0  v5.1  v6.0  v7.0  v7.1  v8.0  v8.1  v9.0
-API_LEVELS        =                   10                    15      16    17    18    19    20        21    22    23    24    25    26    27    28
-STABLE_API_LEVELS =                   10                    15      16    17    18    19    20        21    22    23    24    25    26    27    28
+ALL_FRAMEWORKS    = _ _ _ _ _ _ _ _ _ _   _   _   _   _   _   _   _   _   v4.4  v4.4.87   v5.0  v5.1  v6.0  v7.0  v7.1  v8.0  v8.1  v9.0
+API_LEVELS        =                                                       19    20        21    22    23    24    25    26    27    28
+STABLE_API_LEVELS =                                                       19    20        21    22    23    24    25    26    27    28
 
 ## The preceding values *must* use SPACE, **not** TAB, to separate values.
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2117,15 +2117,15 @@ namespace App1
 				IsRelease = isRelease,
 			};
 			proj.SetProperty ("AndroidUseLatestPlatformSdk", "False");
-			proj.SetProperty ("TargetFrameworkVersion", "v2.3");
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
-				if (!Directory.Exists (Path.Combine (builder.FrameworkLibDirectory, "xbuild-frameworks", "MonoAndroid", "v2.3")))
+				builder.GetTargetFrameworkVersionRange (out var _, out string firstFrameworkVersion, out var _, out string lastFrameworkVersion);
+				proj.SetProperty ("TargetFrameworkVersion", firstFrameworkVersion);
+				if (!Directory.Exists (Path.Combine (builder.FrameworkLibDirectory, "xbuild-frameworks", "MonoAndroid", firstFrameworkVersion)))
 					Assert.Ignore ("This is a Pull Request Build. Ignoring test.");
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
-				Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, $"Output Property: TargetFrameworkVersion=v2.3"), "TargetFrameworkVerson should be v2.3");
-				Assert.IsTrue (builder.Build (proj, parameters: new [] { "TargetFrameworkVersion=v4.4" }), "Build should have succeeded.");
-				Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, $"Output Property: TargetFrameworkVersion=v4.4"), "TargetFrameworkVerson should be v4.4");
-
+				Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, $"Output Property: TargetFrameworkVersion={firstFrameworkVersion}"), $"TargetFrameworkVerson should be {firstFrameworkVersion}");
+				Assert.IsTrue (builder.Build (proj, parameters: new [] { $"TargetFrameworkVersion={lastFrameworkVersion}" }), "Build should have succeeded.");
+				Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, $"Output Property: TargetFrameworkVersion={lastFrameworkVersion}"), $"TargetFrameworkVersion should be {lastFrameworkVersion}");
 			}
 		}
 
@@ -2553,14 +2553,15 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				IsRelease = true,
 			};
 			proj.SetProperty ("AndroidUseLatestPlatformSdk", "False");
-			proj.SetProperty ("TargetFrameworkVersion", "v2.3");
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
-				if (!Directory.Exists (Path.Combine (builder.FrameworkLibDirectory, "xbuild-frameworks", "MonoAndroid", "v2.3")))
+				builder.GetTargetFrameworkVersionRange (out var _, out string firstFrameworkVersion, out var _, out string lastFrameworkVersion);
+				proj.SetProperty ("TargetFrameworkVersion", firstFrameworkVersion);
+				if (!Directory.Exists (Path.Combine (builder.FrameworkLibDirectory, "xbuild-frameworks", "MonoAndroid", firstFrameworkVersion)))
 					Assert.Ignore ("This is a Pull Request Build. Ignoring test.");
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
-				Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, $"Output Property: TargetFrameworkVersion=v2.3"), "TargetFrameworkVerson should be v2.3");
-				Assert.IsTrue (builder.Build (proj, parameters: new [] { "TargetFrameworkVersion=v4.4" }), "Build should have succeeded.");
-				Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, $"Output Property: TargetFrameworkVersion=v4.4"), "TargetFrameworkVerson should be v4.4");
+				Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, $"Output Property: TargetFrameworkVersion={firstFrameworkVersion}"), $"TargetFrameworkVersion should be {firstFrameworkVersion}");
+				Assert.IsTrue (builder.Build (proj, parameters: new [] { $"TargetFrameworkVersion={lastFrameworkVersion}" }), "Build should have succeeded.");
+				Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, $"Output Property: TargetFrameworkVersion={lastFrameworkVersion}"), $"TargetFrameworkVersion should be {lastFrameworkVersion}");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -62,7 +62,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <AndroidUseLatestPlatformSdk Condition="'$(AndroidUseLatestPlatformSdk)' == ''">False</AndroidUseLatestPlatformSdk>
     <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
     <MonoAndroidVersion>v5.0</MonoAndroidVersion>
-    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == '' And '$(AndroidUseLatestPlatformSdk)' == 'False'">v2.3</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == '' And '$(AndroidUseLatestPlatformSdk)' == 'False'">v4.4</TargetFrameworkVersion>
     <UseShortFileNames Condition="'$(UseShortFileNames)' == ''">True</UseShortFileNames>
     <UseShortGeneratorFileNames Condition="'$(UseShortGeneratorFileNames)' == ''">False</UseShortGeneratorFileNames>
     <AndroidClassParser Condition=" '$(AndroidClassParser)' == '' ">jar2xml</AndroidClassParser>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.CSharp.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.CSharp.targets
@@ -27,7 +27,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
     <PropertyGroup>
         <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
-        <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v2.3</TargetFrameworkVersion>
+        <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v4.4</TargetFrameworkVersion>
         <AndroidLinkMode Condition="'$(AndroidLinkMode)' == ''">SdkOnly</AndroidLinkMode>
         <!-- The .NET SGEN tool cannot process Xamarin.Android assemblies because
              our mscorlib.dll isn't properly signed, as far as its concerned.

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
@@ -25,7 +25,7 @@ Copyright (C) 2012 Xamarin. All rights reserved.
             Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
     <PropertyGroup>
         <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
-        <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v2.3</TargetFrameworkVersion>
+        <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v4.4</TargetFrameworkVersion>
         <AndroidLinkMode Condition="'$(AndroidLinkMode)' == ''">SdkOnly</AndroidLinkMode>
         <!-- The .NET SGEN tool cannot process Xamarin.Android assemblies because
              our mscorlib.dll isn't properly signed, as far as its concerned.

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.VisualBasic.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.VisualBasic.targets
@@ -25,7 +25,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
             Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
   <PropertyGroup>
     <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v2.3</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v4.4</TargetFrameworkVersion>
     <AndroidLinkMode Condition="'$(AndroidLinkMode)' == ''">SdkOnly</AndroidLinkMode>
     <UseHostCompilerIfAvailable>false</UseHostCompilerIfAvailable>
     <NoStdLib>true</NoStdLib>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/1032

We previously obsoleted support for API levels earlier than API-19;
see commit 66e1b655.

Next up: stop *building* `Mono.Android.dll` and related assemblies for
API levels earlier than API-19, and stop *shipping* `Mono.Android.dll`
assemblies for `$(TargetFrameworkVersion)` values before `v4.4` (19).

PR #1032 previously tried to do this, and failed, because it attempted
to do "too much," removing code from `Mono.Android.dll` *as well as*
removing support for *building* the obsolete API levels.

Simplify things by *just* altering the build system and *not* the
source code within `Mono.Android.dll`.