### PR TITLE
[Xamarin.Android.Build.Tasks] set $(AndroidSdkDirectory) if blank

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -174,6 +174,9 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
         AndroidNdkPath="$(AndroidNdkDirectory)"
         JavaSdkPath="$(JavaSdkDirectory)"
         ReferenceAssemblyPaths="$(_XATargetFrameworkDirectories)">
+      <Output TaskParameter="AndroidNdkPath"            PropertyName="AndroidNdkDirectory" Condition=" '$(AndroidNdkDirectory)' == '' " />
+      <Output TaskParameter="AndroidSdkPath"            PropertyName="AndroidSdkDirectory" Condition=" '$(AndroidSdkDirectory)' == '' " />
+      <Output TaskParameter="JavaSdkPath"               PropertyName="JavaSdkDirectory"    Condition=" '$(JavaSdkDirectory)' == '' " />
       <Output TaskParameter="AndroidNdkPath"            PropertyName="_AndroidNdkDirectory" />
       <Output TaskParameter="AndroidSdkPath"            PropertyName="_AndroidSdkDirectory" />
       <Output TaskParameter="JavaSdkPath"               PropertyName="_JavaSdkDirectory" />


### PR DESCRIPTION
Commit 6e7be95b, applied to `Xamarin.Android.Binding.targets` too.

As with 6e7be95b, a downstream project in `monodroid` imports
`Xamarin.Android.Bindings.targets` and uses `$(JavaSdkDirectory)`
without otherwise setting it, resulting in build failures when it
attempts to execute `/bin/javac`.

As with 6e7be95b, set the `$(JavaSdkPath)`, `$(AndroidNdkPath)`, and
`$(AndroidSdkPath)` MSBuild properties if they're not already set.