### PR TITLE
[tests] Make the RunUITests timeout longer

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunUITests.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunUITests.cs
@@ -20,8 +20,8 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			if (commandIndex != StateRunTests)
 				return;
 
-			Log.LogMessage (MessageImportance.Low, $"  going to wait for 15 seconds");
-			System.Threading.Thread.Sleep (15000);
+			Log.LogMessage (MessageImportance.Low, $"  going to wait for 30 seconds");
+			System.Threading.Thread.Sleep (30000);
 		}
 
 		protected override List <CommandInfo> GenerateCommandArguments ()


### PR DESCRIPTION
Hopefully it will solve https://github.com/xamarin/xamarin-android/issues/2477

The android emulator got slower on the build bots some time ago, so
increase the timeout length to 30 seconds for UI test runs.