### PR TITLE
[msbuild] Enable nuget package resolution

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -37,6 +37,46 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void BuildBasicApplicationWithNuGetPackageConflicts ()
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				PackageReferences = {
+					new Package () {
+						Id = "System.Buffers",
+						Version = "4.4.0",
+						TargetFramework = "monoandroid90",
+					},
+					new Package () {
+						Id = "System.Memory",
+						Version = "4.5.1",
+						TargetFramework = "monoandroid90",
+					},
+				}
+			};
+
+			proj.Sources.Add (new BuildItem ("Compile", "IsAndroidDefined.fs") {
+				TextContent = () => @"
+using System;
+
+class MemTest {
+	static void Test ()
+	{
+		var x = new Memory<int> ().Length;
+		Console.WriteLine (x);
+
+		var array = new byte [100];
+		var arraySpan = new Span<byte> (array);
+		Console.WriteLine (arraySpan.IsEmpty);
+	}
+}"
+			});
+
+			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationWithNuGetPackageConflicts")) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
+		[Test]
 		[Category ("Minor")]
 		public void BuildBasicApplicationFSharp ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.CSharp.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.CSharp.targets
@@ -37,6 +37,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
         <IsXBuild Condition="'$(MSBuildRuntimeVersion)' == ''">true</IsXBuild>
         <EnableDefaultOutputPaths Condition=" '$(EnableDefaultOutputPaths)' == '' And '$(OS)' != 'Windows_NT' ">false</EnableDefaultOutputPaths>
         <EnableDefaultOutputPaths Condition=" '$(EnableDefaultOutputPaths)' == '' ">true</EnableDefaultOutputPaths>
+        <!-- Enable nuget package conflict resolution -->
+        <ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
     </PropertyGroup>
     <!-- Force Xbuild to behave like msbuild -->
     <PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -16,6 +16,9 @@
 		<AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">27.0.1</AndroidSdkPlatformToolsVersion>
 		<AndroidSdkToolsVersion Condition="'$(AndroidSdkToolsVersion)' == ''">26.1.1</AndroidSdkToolsVersion>
 		<AndroidNdkVersion Condition="'$(AndroidNdkVersion)' == ''">16.1</AndroidNdkVersion>
+
+		<!-- Enable nuget package conflict resolution -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
 	</PropertyGroup>
 	<ItemDefinitionGroup>
 		<AndroidResource>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
@@ -32,6 +32,8 @@ Copyright (C) 2012 Xamarin. All rights reserved.
              Disable generation to avoid "bizarre" build errors. -->
         <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
         <_AndroidResourceDesigner>Resource.designer.fs</_AndroidResourceDesigner>
+        <!-- Enable nuget package conflict resolution -->
+        <ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
     </PropertyGroup>
     <!-- Force Xbuild to behave like msbuild -->
     <PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.VisualBasic.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.VisualBasic.targets
@@ -29,6 +29,8 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <AndroidLinkMode Condition="'$(AndroidLinkMode)' == ''">SdkOnly</AndroidLinkMode>
     <UseHostCompilerIfAvailable>false</UseHostCompilerIfAvailable>
     <NoStdLib>true</NoStdLib>
+    <!-- Enable nuget package conflict resolution -->
+    <ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.VisualBasic.targets" />
   <Import Project="Xamarin.Android.Common.targets" />


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/10602 .

From the issue:
```
We need to enable this to support the system assemblies conflict
resolution which we now rely on for any new packages to enhance
developers experience and get us out of dependency on specific package
versions.
```