### PR TITLE
[Xamarin.Android.Build.Tasks] avoid FileNotFoundException in LinkAssemblies

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
@@ -154,14 +154,14 @@ namespace Xamarin.Android.Tasks
 						continue;
 
 					MonoAndroidHelper.CopyIfChanged (copysrc, assemblyDestination);
-					try {
+					var mdb = assembly.ItemSpec + ".mdb";
+					if (File.Exists (mdb)) {
 						var mdbDestination = assemblyDestination + ".mdb";
-						MonoAndroidHelper.CopyIfChanged (assembly.ItemSpec + ".mdb", mdbDestination);
-					} catch (Exception) { // skip it, mdb sometimes fails to read and it's optional
+						MonoAndroidHelper.CopyIfChanged (mdb, mdbDestination);
 					}
 					var pdb = Path.ChangeExtension (copysrc, "pdb");
 					if (File.Exists (pdb) && Files.IsPortablePdb (pdb)) {
-						var pdbDestination = Path.ChangeExtension (Path.Combine (copydst, filename), "pdb");
+						var pdbDestination = Path.ChangeExtension (assemblyDestination, "pdb");
 						MonoAndroidHelper.CopyIfChanged (pdb, pdbDestination);
 					}
 				}


### PR DESCRIPTION
Context: https://github.com/Microsoft/perfview

When reviewing the .NET exception report in PerfView, I noticed a
`FileNotFoundException` thrown for every assembly such as:

    Throw(System.IO.FileNotFoundException) Could not find file 'samples\HelloWorld\bin\Debug\HelloWorld.dll.mdb'.

All coming from the `LinkAssemblies` MSBuild task.

Reviewing the code, it appears we were affectively causing a `throw
new FileNotFoundException` + `catch` for every instance where an mdb
file was missing!

I reworked the mdb code in `LinkAssemblies` to match what we are doing
for pdb files. It is an order of magnitude faster to check
`File.Exists` over `throw` + `catch`, especially when the file will
most likely not exist.

The results seem to be a ~29ms improvement:

    Before:
    445 ms  LinkAssemblies                             1 calls
    After:
    416 ms  LinkAssemblies                             1 calls

Other changes:

- The pdb copying code here had a `Path.Combine (copydst, filename)`
  where we could use the `assemblyDestination` variable instead. This
  will give a slight perf benefit as well: not concatenating a string.