### PR TITLE
[android-toolchain] less http in parallel

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -45,8 +45,13 @@
       Outputs="@(_DownloadedItem)">
     <MakeDir Directories="$(AndroidToolchainCacheDirectory)" />
     <DownloadUri
-        SourceUris="@(_PlatformAndroidSdkItem->'$(AndroidUri)/%(RelUrl)%(Identity).zip');@(_PlatformAndroidNdkItem->'$(AndroidUri)/%(RelUrl)%(Identity).zip')"
-        DestinationFiles="@(_PlatformAndroidSdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity).zip');@(_PlatformAndroidNdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity).zip')">
+        SourceUris="@(_PlatformAndroidSdkItem->'$(AndroidUri)/%(RelUrl)%(Identity).zip')"
+        DestinationFiles="@(_PlatformAndroidSdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity).zip')">
+      <Output TaskParameter="DestinationFiles" ItemName="_DownloadedItem" />
+    </DownloadUri>
+    <DownloadUri
+        SourceUris="@(_PlatformAndroidNdkItem->'$(AndroidUri)/%(RelUrl)%(Identity).zip')"
+        DestinationFiles="@(_PlatformAndroidNdkItem->'$(AndroidToolchainCacheDirectory)\%(Identity).zip')">
       <Output TaskParameter="DestinationFiles" ItemName="_DownloadedItem" />
     </DownloadUri>
     <DownloadUri


### PR DESCRIPTION
Context: http://build.devdiv.io/2255858

On VSTS, I've been occasionally seeing:

    android-toolchain.targets(47,5): Error : Unable to download URL `https://dl.google.com/android/repository/android-ndk-r14b-windows-x86_64.zip` to `C:\Users\dlab14\android-archives\android-ndk-r14b-windows-x86_64.zip`: Exception of type 'System.OutOfMemoryException' was thrown.
    android-toolchain.targets(47,5): Error : Exception of type 'System.OutOfMemoryException' was thrown.

This is likely one of the larger files we download.

But I think we have correct usage of `HttpClient` here:

    using (var r = await client.GetAsync (uri, source.Token)) {
        r.EnsureSuccessStatusCode ();
        using (var s = await r.Content.ReadAsStreamAsync ())
        using (var o = File.OpenWrite (tempPath)) {
            await s.CopyToAsync (o, 4096, source.Token);
        }
    }

So I believe we just have too many HTTP requests in-flight at once.

Looking at `android-toolchain.targets`, it looks like we were running
all the Android SDK + NDK requests in parallel.

I reworked this to run the SDK requests, then the NDK requests in a
second step.

Hopefully, this will improve the OOM we are getting.