### PR TITLE
[samples] use $(DebugType) portable

### DIFF
--- a/samples/HelloWorld/HelloLibrary/HelloLibrary.csproj
+++ b/samples/HelloWorld/HelloLibrary/HelloLibrary.csproj
@@ -14,10 +14,10 @@
     <FileAlignment>512</FileAlignment>
     <AndroidApplication>false</AndroidApplication>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
@@ -26,7 +26,6 @@
     <AndroidLinkMode>None</AndroidLinkMode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
@@ -36,7 +35,6 @@
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Bundle|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Bundle\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/samples/HelloWorld/HelloWorld.csproj
+++ b/samples/HelloWorld/HelloWorld.csproj
@@ -17,6 +17,7 @@
     <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <AndroidDexTool Condition=" '$(AndroidDexTool)' == '' ">d8</AndroidDexTool>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
   <Import
       Condition="Exists('..\..\Configuration.props')"


### PR DESCRIPTION
In 1fb7983, a new `HelloLibrary.csproj` was added, but it had some
settings that cause `pdb2mdb` to run:

    <DebugType>full</DebugType>
    ...
    <DebugType>pdbonly</DebugType>

I switched the "Hello World" projects to use `$(DebugType)` `portable`,
so that portable pdb files are always generated as part of their
build.

This way when profiling builds on Windows, I don't have to account for
the `<ConvertDebuggingFiles/>` MSBuild task taking time.