### PR TITLE
[tests] Clear the adb log ater we collect the logcat output

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
@@ -14,7 +14,8 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		const                   string              TestResultsPathResult       = "INSTRUMENTATION_RESULT: nunit2-results-path=";
 		const                   int                 StateRunInstrumentation     = 0;
 		const                   int                 StateGetLogcat              = 1;
-		const                   int                 StatePullFiles              = 2;
+		const                   int                 StateClearLogcat            = 2;
+		const                   int                 StatePullFiles              = 3;
 		const                   int                 MaxState                    = StatePullFiles;
 
 		public                  string              TestFixture                 { get; set; }
@@ -79,6 +80,10 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 					MergeStdoutAndStderr = false,
 					StdoutFilePath = LogcatFilename,
 					StdoutAppend = true,
+				},
+
+				new CommandInfo {
+					ArgumentsString = $"{AdbTarget} {AdbOptions} logcat -c",
 				},
 
 				new CommandInfo {

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunUITests.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunUITests.cs
@@ -8,6 +8,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 	{
 		const                   int                 StateRunTests               = 0;
 		const                   int                 StateGetLogcat              = 1;
+		const                   int                 StateClearLogcat            = 2;
 
 		[Required]
 		public                  string              Activity                    { get; set; }
@@ -37,6 +38,11 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 					StdoutFilePath = LogcatFilename,
 					StdoutAppend = true,
 				},
+
+				new CommandInfo {
+					ArgumentsString = $"{AdbTarget} {AdbOptions} logcat -c",
+				},
+
 			};
 		}
 	}


### PR DESCRIPTION
That way it is easier to find a problem in the logcat output as it
will only contain the information relevant to the particular test run.

As we clear it after the run, the first test logcat on a freshly
started emulator will also contain the startup info in case it is
needed.