### PR TITLE
[Xamarin.Android.Build.Tasks] fix Inputs/Outputs for _LinkAssemblies*

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2137,8 +2137,8 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_LinkAssembliesNoShrink"
   Condition="'$(AndroidLinkMode)' == 'None'"
-  Inputs="@(ResolvedUserAssemblies)"
-  Outputs="@(ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')">
+  Inputs="@(ResolvedUserAssemblies);$(_AndroidBuildPropertiesCache)"
+  Outputs="$(_AndroidLinkFlag)">
 
     <LinkAssemblies
       UseSharedRuntime="$(AndroidUseSharedRuntime)"
@@ -2152,17 +2152,11 @@ because xbuild doesn't support framework reference assemblies.
       LinkOnlyNewerThan="$(_AndroidLinkFlag)"
       ResolvedAssemblies="@(ResolvedAssemblies)" />
 
-    <!--NOTE: the linker's use of File.Copy requires us to update the timestamps of output files -->
-    <ItemGroup>
-      <_LinkAssembliesNoShrinkFiles Include="$(MonoAndroidIntermediateAssemblyDir)*" />
-    </ItemGroup>
-    <Touch Files="@(_LinkAssembliesNoShrinkFiles)" />
-
-    <!-- We don't have to depend on flag file for NoShrink, but it is used to check timestamp -->
+    <!-- We have to use a flag instead of normal outputs because linking can delete unused assemblies -->
     <Touch Files="$(_AndroidLinkFlag)" AlwaysCreate="true" />
     <ItemGroup>
       <FileWrites Include="$(_AndroidLinkFlag)" />
-      <FileWrites Include="@(_LinkAssembliesNoShrinkFiles)" />
+      <FileWrites Include="$(MonoAndroidIntermediateAssemblyDir)*" />
     </ItemGroup>
 </Target>
 	
@@ -2195,17 +2189,11 @@ because xbuild doesn't support framework reference assemblies.
       HttpClientHandlerType="$(AndroidHttpClientHandlerType)"
       TlsProvider="$(AndroidTlsProvider)" />
 
-    <!--NOTE: the linker's use of File.Copy requires us to update the timestamps of output files -->
-    <ItemGroup>
-      <_LinkAssembliesShrinkFiles Include="$(MonoAndroidIntermediateAssetsDir)*" />
-    </ItemGroup>
-    <Touch Files="@(_LinkAssembliesShrinkFiles)" />
-
     <!-- We have to use a flag instead of normal outputs because linking can delete unused assemblies -->
     <Touch Files="$(_AndroidLinkFlag)" AlwaysCreate="true" />
     <ItemGroup>
       <FileWrites Include="$(_AndroidLinkFlag)" />
-      <FileWrites Include="@(_LinkAssembliesShrinkFiles)" />
+      <FileWrites Include="$(MonoAndroidIntermediateAssetsDir)*" />
     </ItemGroup>
 </Target>
 


### PR DESCRIPTION
Downstream in monodroid, we are seeing an issue with "Fast Deployment":

1. An incremental build occurs; one or more assemblies change.
2. We still seem to deploy *every* assembly.

This started happening in 539954c, since I corrected the directory
that `_LinkAssembliesNoShrink` was touching files in.

`_LinkAssembliesNoShrink` was setup to:

1. Its `Outputs` were assemblies produced by the linker.
2. A `<Touch/>` command was updating timestamps of these assemblies.

Refactoring this target to more closely match `_LinkAssembliesShrink`
actually seems more correct here:

1. `Inputs` should include `$(_AndroidBuildPropertiesCache)`. Whoops!
2. `Outputs` should be the `$(_AndroidLinkFlag)` file.
3. We can do away with the `@(_LinkAssembliesNoShrinkFiles)` item
   group, and just directly add to `@(FileWrites)`.

Since we have improvements earlier in the build chain, I don't think
we need to `<Touch/>` the assemblies output from the linker at all
here.

I made similar adjustments in `_LinkAssembliesShrink` so it matches
`_LinkAssembliesNoShrink`.