### PR TITLE
Bump to xamarin/Java.Interop/master@706e4cc4

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -69,6 +69,7 @@ namespace Android.Runtime {
 			ObjectReferenceManager  = new AndroidObjectReferenceManager ();
 			TypeManager             = new AndroidTypeManager ();
 			ValueManager            = new AndroidValueManager ();
+			UseMarshalMemberBuilder = false;
 		}
 	}
 


### PR DESCRIPTION
Adds a
`Java.Interop.JniRuntime.CreationOptions.UseMarshalMemberBuilder`
property which controls whether or not `Java.Interop.Export.dll` is
loaded during `JniRuntime` creation.

Xamarin.Android currently doesn't build, bundle, or otherwise include
`Java.Interop.Export.dll`, and thus the attempted assembly load
*always fails*, which is "fine" -- the exception is handled
appropriately -- but attempted load and corresponding exception
appears to add about ~100ms to process startup, which is insane.

Set `JniRuntime.CreationOptions.UseMarshalMemberBuilder=false` so that
we don't attempt to load this assembly, which should help our process
startup times.