### PR TITLE
[Xamarin.Android.Build.Tasks] don't use so many temp files

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -70,17 +70,23 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
+			var temp = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
 			try {
+				Directory.CreateDirectory (temp);
+
 				// We're going to do 3 steps here instead of separate tasks so
 				// we can share the list of JLO TypeDefinitions between them
 				using (var res = new DirectoryAssemblyResolver (this.CreateTaskLogger (), loadDebugSymbols: true)) {
-					Run (res);
+					Run (res, temp);
 				}
-			}
-			catch (XamarinAndroidException e) {
+			} catch (XamarinAndroidException e) {
 				Log.LogCodedError (string.Format ("XA{0:0000}", e.Code), e.MessageWithoutCode);
 				if (MonoAndroidHelper.LogInternalExceptions)
 					Log.LogMessage (e.ToString ());
+			} finally {
+				// Delete our temp directory
+				if (Directory.Exists (temp))
+					Directory.Delete (temp, true);
 			}
 
 			if (Log.HasLoggedErrors) {
@@ -95,12 +101,10 @@ namespace Xamarin.Android.Tasks
 			return !Log.HasLoggedErrors;
 		}
 
-		void Run (DirectoryAssemblyResolver res)
+		void Run (DirectoryAssemblyResolver res, string temp)
 		{
 			PackageNamingPolicy pnp;
 			JavaNativeTypeManager.PackageNamingPolicy = Enum.TryParse (PackageNamingPolicy, out pnp) ? pnp : PackageNamingPolicyEnum.LowercaseHash;
-			var temp = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
-			Directory.CreateDirectory (temp);
 
 			foreach (var dir in FrameworkDirectories) {
 				if (Directory.Exists (dir.ItemSpec))
@@ -111,9 +115,10 @@ namespace Xamarin.Android.Tasks
 			
 			// Put every assembly we'll need in the resolver
 			foreach (var assembly in ResolvedAssemblies) {
-				res.Load (Path.GetFullPath (assembly.ItemSpec));
+				var assemblyFullPath = Path.GetFullPath (assembly.ItemSpec);
+				res.Load (assemblyFullPath);
 				if (MonoAndroidHelper.FrameworkAttributeLookupTargets.Any (a => Path.GetFileName (assembly.ItemSpec) == a))
-					selectedWhitelistAssemblies.Add (Path.GetFullPath (assembly.ItemSpec));
+					selectedWhitelistAssemblies.Add (assemblyFullPath);
 			}
 
 			// However we only want to look for JLO types in user code
@@ -133,7 +138,7 @@ namespace Xamarin.Android.Tasks
 			var java_types = all_java_types.Where (t => !JavaTypeScanner.ShouldSkipJavaCallableWrapperGeneration (t));
 
 			// Step 2 - Generate Java stub code
-			var keep_going = Generator.CreateJavaSources (
+			var success = Generator.CreateJavaSources (
 				Log,
 				java_types,
 				temp,
@@ -141,64 +146,54 @@ namespace Xamarin.Android.Tasks
 				UseSharedRuntime,
 				int.Parse (AndroidSdkPlatform) <= 10,
 				ResolvedAssemblies.Any (assembly => Path.GetFileName (assembly.ItemSpec) == "Mono.Android.Export.dll"));
-
-			var temp_map_file = Path.Combine (temp, "acw-map.temp");
+			if (!success)
+				return;
 
 			// We need to save a map of .NET type -> ACW type for resource file fixups
 			var managed = new Dictionary<string, TypeDefinition> ();
 			var java    = new Dictionary<string, TypeDefinition> ();
-			var acw_map = new StreamWriter (temp_map_file);
+			using (var stream = new MemoryStream ())
+			using (var acw_map = new StreamWriter (stream)) {
+				foreach (var type in java_types) {
+					string managedKey = type.FullName.Replace ('/', '.');
+					string javaKey = JavaNativeTypeManager.ToJniName (type).Replace ('/', '.');
 
-			foreach (var type in java_types) {
-				string managedKey = type.FullName.Replace ('/', '.');
-				string javaKey    = JavaNativeTypeManager.ToJniName (type).Replace ('/', '.');
+					acw_map.WriteLine ("{0};{1}", type.GetPartialAssemblyQualifiedName (), javaKey);
 
-				acw_map.WriteLine ("{0};{1}", type.GetPartialAssemblyQualifiedName (), javaKey);
-
-				TypeDefinition conflict;
-				if (managed.TryGetValue (managedKey, out conflict)) {
-					Log.LogWarning (
-							"Duplicate managed type found! Mappings between managed types and Java types must be unique. " +
-							"First Type: '{0}'; Second Type: '{1}'.",
-							conflict.GetAssemblyQualifiedName (),
-							type.GetAssemblyQualifiedName ());
-					Log.LogWarning (
-							"References to the type '{0}' will refer to '{1}'.",
-							managedKey, conflict.GetAssemblyQualifiedName ());
-					continue;
+					TypeDefinition conflict;
+					if (managed.TryGetValue (managedKey, out conflict)) {
+						Log.LogWarning (
+								"Duplicate managed type found! Mappings between managed types and Java types must be unique. " +
+								"First Type: '{0}'; Second Type: '{1}'.",
+								conflict.GetAssemblyQualifiedName (),
+								type.GetAssemblyQualifiedName ());
+						Log.LogWarning (
+								"References to the type '{0}' will refer to '{1}'.",
+								managedKey, conflict.GetAssemblyQualifiedName ());
+						continue;
+					}
+					if (java.TryGetValue (javaKey, out conflict)) {
+						Log.LogError (
+								"Duplicate Java type found! Mappings between managed types and Java types must be unique. " +
+								"First Type: '{0}'; Second Type: '{1}'",
+								conflict.GetAssemblyQualifiedName (),
+								type.GetAssemblyQualifiedName ());
+						success = false;
+						continue;
+					}
+					managed.Add (managedKey, type);
+					java.Add (javaKey, type);
+					acw_map.WriteLine ("{0};{1}", managedKey, javaKey);
+					acw_map.WriteLine ("{0};{1}", JavaNativeTypeManager.ToCompatJniName (type).Replace ('/', '.'), javaKey);
 				}
-				if (java.TryGetValue (javaKey, out conflict)) {
-					Log.LogError (
-							"Duplicate Java type found! Mappings between managed types and Java types must be unique. " +
-							"First Type: '{0}'; Second Type: '{1}'",
-							conflict.GetAssemblyQualifiedName (),
-							type.GetAssemblyQualifiedName ());
-					keep_going = false;
-					continue;
-				}
-				managed.Add (managedKey, type);
-				java.Add (javaKey, type);
-				acw_map.WriteLine ("{0};{1}", managedKey, javaKey);
-				acw_map.WriteLine ("{0};{1}", JavaNativeTypeManager.ToCompatJniName (type).Replace ('/', '.'), javaKey);
+
+				acw_map.Flush ();
+				MonoAndroidHelper.CopyIfStreamChanged (stream, AcwMapFile);
 			}
-
-			acw_map.Close ();
-
-			//The previous steps found an error, so we must abort and not generate any further output
-			//We must do so subsequent unchanged builds fail too.
-			if (!keep_going) {
-				File.Delete (temp_map_file);
-				return;
-			}
-
-			MonoAndroidHelper.CopyIfChanged (temp_map_file, AcwMapFile);
-
-			try { File.Delete (temp_map_file); } catch (Exception) { }
 
 			// Only overwrite files if the contents actually changed
 			foreach (var file in Directory.GetFiles (temp, "*", SearchOption.AllDirectories)) {
-				var dest = Path.GetFullPath (Path.Combine (OutputDirectory, "src", file.Substring (temp.Length + 1)));
-
+				var dest = Path.Combine (OutputDirectory, "src", file.Substring (temp.Length + 1));
 				MonoAndroidHelper.CopyIfChanged (file, dest);
 			}
 
@@ -219,38 +214,24 @@ namespace Xamarin.Android.Tasks
 
 			var additionalProviders = manifest.Merge (all_java_types, selectedWhitelistAssemblies, ApplicationJavaClass, EmbedAssemblies, BundledWearApplicationName, MergedManifestDocuments);
 
-			var temp_manifest = Path.Combine (temp, "AndroidManifest.xml");
-			var real_manifest = Path.GetFullPath (MergedAndroidManifestOutput);
+			using (var stream = new MemoryStream ()) {
+				manifest.Save (stream);
 
-			manifest.Save (temp_manifest);
-
-			// Only write the new manifest if it actually changed
-			MonoAndroidHelper.CopyIfChanged (temp_manifest, real_manifest);
+				// Only write the new manifest if it actually changed
+				MonoAndroidHelper.CopyIfStreamChanged (stream, MergedAndroidManifestOutput);
+			}
 
 			// Create additional runtime provider java sources.
 			string providerTemplateFile = UseSharedRuntime ? "MonoRuntimeProvider.Shared.java" : "MonoRuntimeProvider.Bundled.java";
-			string providerTemplate = new StreamReader (typeof (JavaCallableWrapperGenerator).Assembly.GetManifestResourceStream (providerTemplateFile)).ReadToEnd ();
+			string providerTemplate = GetResource<JavaCallableWrapperGenerator> (providerTemplateFile);
 			
 			foreach (var provider in additionalProviders) {
-				var temp_provider = Path.Combine (temp, provider + ".java");
-				File.WriteAllText (temp_provider, providerTemplate.Replace ("MonoRuntimeProvider", provider));
-				var real_provider_dir = Path.GetFullPath (Path.Combine (OutputDirectory, "src", "mono"));
-				Directory.CreateDirectory (real_provider_dir);
-				var real_provider = Path.Combine (real_provider_dir, provider + ".java");
-				MonoAndroidHelper.CopyIfChanged (temp_provider, real_provider);
+				var contents = providerTemplate.Replace ("MonoRuntimeProvider", provider);
+				var real_provider = Path.Combine (OutputDirectory, "src", "mono", provider + ".java");
+				MonoAndroidHelper.CopyIfStringChanged (contents, real_provider);
 			}
 
 			// Create additional application java sources.
-			
-			Action<string,string,string,Func<string,string>> save = (resource, filename, destDir, applyTemplate) => {
-				string temp_file = Path.Combine (temp, filename);
-				string template = applyTemplate (new StreamReader (typeof (GenerateJavaStubs).Assembly.GetManifestResourceStream (resource)).ReadToEnd ());
-				File.WriteAllText (temp_file, template);
-				Directory.CreateDirectory (destDir);
-				var real_file = Path.Combine (destDir, filename);
-				MonoAndroidHelper.CopyIfChanged (temp_file, real_file);
-			};
-			
 			StringWriter regCallsWriter = new StringWriter ();
 			regCallsWriter.WriteLine ("\t\t// Application and Instrumentation ACWs must be registered first.");
 			foreach (var type in java_types) {
@@ -262,17 +243,28 @@ namespace Xamarin.Android.Tasks
 			}
 			regCallsWriter.Close ();
 
-			var real_app_dir = Path.GetFullPath (Path.Combine (OutputDirectory, "src", "mono", "android", "app"));
+			var real_app_dir = Path.Combine (OutputDirectory, "src", "mono", "android", "app");
 			string applicationTemplateFile = "ApplicationRegistration.java";
-			save (applicationTemplateFile, applicationTemplateFile, real_app_dir,
+			SaveResource (applicationTemplateFile, applicationTemplateFile, real_app_dir,
 				template => template.Replace ("// REGISTER_APPLICATION_AND_INSTRUMENTATION_CLASSES_HERE", regCallsWriter.ToString ()));
 			
 			// Create NotifyTimeZoneChanges java sources.
 			string notifyTimeZoneChangesFile = "NotifyTimeZoneChanges.java";
-			save (notifyTimeZoneChangesFile, notifyTimeZoneChangesFile, real_app_dir, template => template);
-			
-			// Delete our temp directory
-			try { Directory.Delete (temp, true); } catch (Exception) { }
+			SaveResource (notifyTimeZoneChangesFile, notifyTimeZoneChangesFile, real_app_dir, template => template);
+		}
+
+		string GetResource <T> (string resource)
+		{
+			using (var stream = typeof (T).Assembly.GetManifestResourceStream (resource))
+			using (var reader = new StreamReader (stream))
+				return reader.ReadToEnd ();
+		}
+
+		void SaveResource (string resource, string filename, string destDir, Func<string, string> applyTemplate)
+		{
+			string template = GetResource<GenerateJavaStubs> (resource);
+			template = applyTemplate (template);
+			MonoAndroidHelper.CopyIfStringChanged (template, Path.Combine (destDir, filename));
 		}
 
 		void WriteTypeMappings (List<TypeDefinition> types)
@@ -287,11 +279,10 @@ namespace Xamarin.Android.Tasks
 
 		void UpdateWhenChanged (string path, Action<Stream> generator)
 		{
-			var np  = path + ".new";
-			using (var o = File.OpenWrite (np))
-				generator (o);
-			MonoAndroidHelper.CopyIfChanged (np, path);
-			File.Delete (np);
+			using (var stream = new MemoryStream ()) {
+				generator (stream);
+				MonoAndroidHelper.CopyIfStreamChanged (stream, path);
+			}
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
@@ -239,12 +239,8 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 			}
-			
-			var temp_o  = Path.Combine (Path.GetDirectoryName (file), "__" + Path.GetFileName (file) + ".new");
-			using (TextWriter o = File.CreateText (temp_o))
-				o.Write (code);
-			MonoAndroidHelper.CopyIfChanged (temp_o, file);
-			try { File.Delete (temp_o); } catch (Exception) { }
+
+			MonoAndroidHelper.CopyIfStringChanged (code, file);
 		}
 
 		private void AddRename (string android, string user)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/MonoAndroidHelperTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/MonoAndroidHelperTests.cs
@@ -1,0 +1,136 @@
+﻿using System.IO;
+using NUnit.Framework;
+using Xamarin.Android.Tasks;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	public class MonoAndroidHelperTests
+	{
+		string temp;
+
+		[SetUp]
+		public void SetUp ()
+		{
+			temp = Path.Combine (Path.GetTempPath (), TestContext.CurrentContext.Test.Name);
+		}
+
+		[TearDown]
+		public void TearDown ()
+		{
+			File.Delete (temp);
+		}
+
+		[Test]
+		public void CopyIfStringChanged ()
+		{
+			var foo = "bar";
+			Assert.IsTrue (MonoAndroidHelper.CopyIfStringChanged (foo, temp), "Should write on new file.");
+			FileAssert.Exists (temp);
+			Assert.IsFalse (MonoAndroidHelper.CopyIfStringChanged (foo, temp), "Should *not* write unless changed.");
+			foo += "\n";
+			Assert.IsTrue (MonoAndroidHelper.CopyIfStringChanged (foo, temp), "Should write when changed.");
+		}
+
+		[Test]
+		public void CopyIfBytesChanged ()
+		{
+			var foo = new byte [32];
+			Assert.IsTrue (MonoAndroidHelper.CopyIfBytesChanged (foo, temp), "Should write on new file.");
+			FileAssert.Exists (temp);
+			Assert.IsFalse (MonoAndroidHelper.CopyIfBytesChanged (foo, temp), "Should *not* write unless changed.");
+			foo [0] = 0xFF;
+			Assert.IsTrue (MonoAndroidHelper.CopyIfBytesChanged (foo, temp), "Should write when changed.");
+		}
+
+		[Test]
+		public void CopyIfStreamChanged ()
+		{
+			using (var foo = new MemoryStream ())
+			using (var writer = new StreamWriter (foo)) {
+				writer.WriteLine ("bar");
+				writer.Flush ();
+
+				Assert.IsTrue (MonoAndroidHelper.CopyIfStreamChanged (foo, temp), "Should write on new file.");
+				FileAssert.Exists (temp);
+				Assert.IsFalse (MonoAndroidHelper.CopyIfStreamChanged (foo, temp), "Should *not* write unless changed.");
+				writer.WriteLine ();
+				writer.Flush ();
+				Assert.IsTrue (MonoAndroidHelper.CopyIfStreamChanged (foo, temp), "Should write when changed.");
+			}
+		}
+
+		[Test]
+		public void CopyIfStringChanged_NewDirectory ()
+		{
+			temp = Path.Combine (temp, "foo.txt");
+
+			var foo = "bar";
+			Assert.IsTrue (MonoAndroidHelper.CopyIfStringChanged (foo, temp), "Should write on new file.");
+			FileAssert.Exists (temp);
+		}
+
+		[Test]
+		public void CopyIfBytesChanged_NewDirectory ()
+		{
+			temp = Path.Combine (temp, "foo.bin");
+
+			var foo = new byte [32];
+			Assert.IsTrue (MonoAndroidHelper.CopyIfBytesChanged (foo, temp), "Should write on new file.");
+			FileAssert.Exists (temp);
+		}
+
+		[Test]
+		public void CopyIfStreamChanged_NewDirectory ()
+		{
+			temp = Path.Combine (temp, "foo.txt");
+
+			using (var foo = new MemoryStream ())
+			using (var writer = new StreamWriter (foo)) {
+				writer.WriteLine ("bar");
+				writer.Flush ();
+
+				Assert.IsTrue (MonoAndroidHelper.CopyIfStreamChanged (foo, temp), "Should write on new file.");
+				FileAssert.Exists (temp);
+			}
+		}
+
+		[Test]
+		public void CopyIfStringChanged_Readonly ()
+		{
+			File.WriteAllText (temp, "");
+			File.SetAttributes (temp, FileAttributes.ReadOnly);
+
+			var foo = "bar";
+			Assert.IsTrue (MonoAndroidHelper.CopyIfStringChanged (foo, temp), "Should write on new file.");
+			FileAssert.Exists (temp);
+		}
+
+		[Test]
+		public void CopyIfBytesChanged_Readonly ()
+		{
+			File.WriteAllText (temp, "");
+			File.SetAttributes (temp, FileAttributes.ReadOnly);
+
+			var foo = new byte [32];
+			Assert.IsTrue (MonoAndroidHelper.CopyIfBytesChanged (foo, temp), "Should write on new file.");
+			FileAssert.Exists (temp);
+		}
+
+		[Test]
+		public void CopyIfStreamChanged_Readonly ()
+		{
+			File.WriteAllText (temp, "");
+			File.SetAttributes (temp, FileAttributes.ReadOnly);
+
+			using (var foo = new MemoryStream ())
+			using (var writer = new StreamWriter (foo)) {
+				writer.WriteLine ("bar");
+				writer.Flush ();
+
+				Assert.IsTrue (MonoAndroidHelper.CopyIfStreamChanged (foo, temp), "Should write on new file.");
+				FileAssert.Exists (temp);
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
@@ -20,6 +20,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\BaseTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\BuildHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\MockBuildEngine.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\MonoAndroidHelperTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)Utilities\" />

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography;
 
 using Xamarin.Tools.Zip;
 using System.Collections.Generic;
+using System.Text;
 #if MSBUILD
 using Microsoft.Build.Utilities;
 using Xamarin.Android.Tasks;
@@ -69,6 +70,43 @@ namespace Xamarin.Android.Tools {
 			}/* else
 				Console.WriteLine ("Skipping copying {0}, unchanged", Path.GetFileName (destination));*/
 
+			return false;
+		}
+
+		public static bool CopyIfStringChanged (string contents, string destination)
+		{
+			var bytes = Encoding.UTF8.GetBytes (contents);
+			return CopyIfBytesChanged (bytes, destination);
+		}
+
+		public static bool CopyIfBytesChanged (byte[] bytes, string destination)
+		{
+			if (HasBytesChanged (bytes, destination)) {
+				var directory = Path.GetDirectoryName (destination);
+				if (!string.IsNullOrEmpty (directory))
+					Directory.CreateDirectory (directory);
+
+				MonoAndroidHelper.SetWriteable (destination);
+				File.WriteAllBytes (destination, bytes);
+				return true;
+			}
+			return false;
+		}
+
+		public static bool CopyIfStreamChanged (Stream stream, string destination)
+		{
+			if (HasStreamChanged (stream, destination)) {
+				var directory = Path.GetDirectoryName (destination);
+				if (!string.IsNullOrEmpty (directory))
+					Directory.CreateDirectory (directory);
+
+				MonoAndroidHelper.SetWriteable (destination);
+				using (var fileStream = File.Create (destination)) {
+					stream.Position = 0; //HasStreamChanged read to the end
+					stream.CopyTo (fileStream);
+				}
+				return true;
+			}
 			return false;
 		}
 
@@ -162,7 +200,39 @@ namespace Xamarin.Android.Tools {
 			var src_hash = HashFile (source);
 			var dst_hash = HashFile (destination);
 
-			// If the hashed don't match, then the file has changed
+			// If the hashes don't match, then the file has changed
+			if (src_hash != dst_hash)
+				return true;
+
+			return false;
+		}
+
+		public static bool HasStreamChanged (Stream source, string destination)
+		{
+			//If destination is missing, that's definitely a change
+			if (!File.Exists (destination))
+				return true;
+
+			var src_hash = HashStream (source);
+			var dst_hash = HashFile (destination);
+
+			// If the hashes don't match, then the file has changed
+			if (src_hash != dst_hash)
+				return true;
+
+			return false;
+		}
+
+		public static bool HasBytesChanged (byte [] bytes, string destination)
+		{
+			//If destination is missing, that's definitely a change
+			if (!File.Exists (destination))
+				return true;
+
+			var src_hash = HashBytes (bytes);
+			var dst_hash = HashFile (destination);
+
+			// If the hashes don't match, then the file has changed
 			if (src_hash != dst_hash)
 				return true;
 
@@ -272,8 +342,15 @@ namespace Xamarin.Android.Tools {
 
 		public static string HashString (string s)
 		{
+			var bytes = Encoding.UTF8.GetBytes (s);
+			return HashBytes (bytes);
+		}
+
+		public static string HashBytes (byte [] bytes)
+		{
 			using (HashAlgorithm hashAlg = new SHA1Managed ()) {
-				return HashFile (s, hashAlg);
+				byte [] hash = hashAlg.ComputeHash (bytes);
+				return BitConverter.ToString (hash);
 			}
 		}
 
@@ -288,13 +365,14 @@ namespace Xamarin.Android.Tools {
 		{
 			using (Stream file = new FileStream (filename, FileMode.Open, FileAccess.Read)) {
 				byte[] hash = hashAlg.ComputeHash (file);
-
 				return BitConverter.ToString (hash);
 			}
 		}
 
 		public static string HashStream (Stream stream)
 		{
+			stream.Position = 0;
+
 			using (HashAlgorithm hashAlg = new SHA1Managed ()) {
 				byte[] hash = hashAlg.ComputeHash (stream);
 				return BitConverter.ToString (hash);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -928,7 +928,13 @@ namespace Xamarin.Android.Tasks {
 		
 		public void Save (string filename)
 		{
-			using (var file = new StreamWriter (filename, false, new UTF8Encoding (false)))
+			using (var file = new StreamWriter (filename, append: false, encoding: new UTF8Encoding (false)))
+				Save (file);
+		}
+
+		public void Save (Stream stream)
+		{
+			using (var file = new StreamWriter (stream, new UTF8Encoding (false), bufferSize: 1024, leaveOpen: true))
 				Save (file);
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -386,6 +386,21 @@ namespace Xamarin.Android.Tasks
 			return Files.CopyIfChanged (source, destination);
 		}
 
+		public static bool CopyIfStringChanged (string contents, string destination)
+		{
+			return Files.CopyIfStringChanged (contents, destination);
+		}
+
+		public static bool CopyIfBytesChanged (byte [] bytes, string destination)
+		{
+			return Files.CopyIfBytesChanged (bytes, destination);
+		}
+
+		public static bool CopyIfStreamChanged (Stream source, string destination)
+		{
+			return Files.CopyIfStreamChanged (source, destination);
+		}
+
 		public static bool CopyIfZipChanged (Stream source, string destination)
 		{
 			return Files.CopyIfZipChanged (source, destination);


### PR DESCRIPTION
In many places throughout the Xamarin.Android build, we have a pattern
of:

- Generate a temp file.
- Use `MonoAndroidHelper.CopyIfChanged` to put the file in the
  destination. This reads both files, doing a hash comparison before
  deciding to write or not.
- Delete the temp file.

Sometimes the temp file is actually in `%TEMP%`, but other times we
append `.new` to the destination file. The case of `.new` can collide
if two builds are running at once (example caused by a known VS for
Mac issue).

Thinking about this, in cases with small files, we can make a simple
optimization:

- Generate the file in-memory.
- Use a new `MonoAndroidHelper.CopyStreamIfChanged` method`.

This has several benefits:

- We never write a file to disk when there are no changes.
- We don't have to *remember* to delete the file.
- The code, in general, is slightly simpler.

The only place we likely shouldn't use this new pattern, would be if
the file was huge.

## Changes ##

I added new APIs for:

- `Files.HasStreamChanged` - to compare a `Stream` in memory
- `Files.HasBytesChanged` - to compare a `byte[]` in memory
- `Files.CopyIfStreamChanged`
- `Files.CopyIfStringChanged` - some cases we have a `string`
- `Files.CopyIfBytesChanged` - this supports `string`
- `MonoAndroidHelper.CopyIfStreamChanged`
- `MonoAndroidHelper.CopyIfStringChanged`
- `MonoAndroidHelper.CopyIfBytesChanged`

I changed the following MSBuild tasks, mostly to test out the new
behavior:

- `GenerateResourceDesigner` was using a `.new` file.
- `GenerateJavaStubs` was using temp files in many places. I was able
  to fix up all the places except where `Generator.CreateJavaSources`
  writes Java code to an output directory.

I made other general refactoring in `GenerateJavaStubs`:

- The top-level `temp` directory we still use, should be deleted in a
  `try-finally`!
- Since we don't have to worry about deleting a `temp_map_file`, we
  can return earlier if `Generator.CreateJavaSources` fails.
- A `GetResource<T>` method, cleans up the places reading from
  `EmbeddedResource` files. I also changed it up to properly `Dispose`
  things.
- A `save` anonymous method/delegate should just be a `SaveResource`
  *regular* method.
- A few places were calling `Path.GetFullPath` unecessarily. Since
  this method accesses the file system, we should skip it unless the
  full path is actually needed.

I also added some tests for the new APIs in `MonoAndroidHelper`.

## Results ##

I did three test runs, because I was getting varying times for
`GenerateJavaStubs`. This is the Xamarin.Forms integration project in
this repo:

    Before (Clean Build):
    1. 1587 ms  GenerateJavaStubs                          1 calls
    2. 1503 ms  GenerateJavaStubs                          1 calls
    3. 1553 ms  GenerateJavaStubs                          1 calls

    After (Clean Build):
    1. 1424 ms  GenerateJavaStubs                          1 calls
    2. 1461 ms  GenerateJavaStubs                          1 calls
    3. 1529 ms  GenerateJavaStubs                          1 calls

    Before (Incremental):
    1. 1775 ms  GenerateJavaStubs                          1 calls
    2. 1490 ms  GenerateJavaStubs                          1 calls
    3. 1664 ms  GenerateJavaStubs                          1 calls

    After (Incremental):
    1. 1443 ms  GenerateJavaStubs                          1 calls
    2. 1480 ms  GenerateJavaStubs                          1 calls
    3. 1589 ms  GenerateJavaStubs                          1 calls

`GenerateJavaStubs` is now consistently faster, but it's hard to tell
how much. I feel it is likely 100ms better. I have an SSD, so I'd
expect developers with an HDD to see even bigger improvments.

I could not see a difference in `GenerateResourceDesigner`, likely
since it wrote only a single temp file.

Next steps would be to make changes in Java.Interop so we could get
the same `CopyIfStreamChanged` behavior for *all* generated Java
files. There are likely other MSBuild tasks to change as well.