### PR TITLE
[tests] fix for ProduceReferenceAssembly test

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -451,6 +451,10 @@ namespace Lib2
 					},
 				}
 			};
+			//NOTE: so _BuildApkEmbed runs in commercial tests
+			app.SetProperty ("EmbedAssembliesIntoApk", true.ToString ());
+			app.SetProperty ("AndroidUseSharedRuntime", false.ToString ());
+
 			int count = 0;
 			var lib = new XamarinAndroidLibraryProject {
 				ProjectName = "MyLibrary",


### PR DESCRIPTION
Downstream in monodroid (commerical product), this test is failing:

    Failed : Xamarin.Android.Build.Tests.IncrementalBuildTest.ProduceReferenceAssembly
        `_BuildApkEmbed` should *not* be skipped!

When "Fast Deployment" is enabled, the `_BuildApkFastDev` MSBuild
target runs instead of `_BuildApkEmbed`.

To workaround it, we can just disable "Fast Deployment". We are really
just wanting to make sure `CoreCompile` is skipped in this test.