### PR TITLE
[Xamarin.Android.Build.Tasks] Support comma separators for armeabi error

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3267,11 +3267,13 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 		}
 
 		[Test]
-		public void XA0115 ()
+		[TestCase ("armeabi;armeabi-v7a", TestName = "XA0115")]
+		[TestCase ("armeabi,armeabi-v7a", TestName = "XA0115Commas")]
+		public void XA0115 (string abis)
 		{
 			var proj = new XamarinAndroidApplicationProject ();
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, "armeabi;armeabi-v7a");
-			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
+			proj.SetProperty (KnownProperties.AndroidSupportedAbis, abis);
+			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				builder.ThrowOnBuildFailure = false;
 				Assert.IsFalse (builder.Build (proj), "Build should have failed with XA0115.");
 				StringAssertEx.Contains ($"error XA0115", builder.LastBuildOutput, "Error should be XA0115");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1055,7 +1055,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_CheckSupportedAbis">
 	<PropertyGroup>
-		<_RequestedAbis>;$(AndroidSupportedAbis);</_RequestedAbis>
+		<_RequestedAbis>;$(AndroidSupportedAbis.Replace(',', ';'));</_RequestedAbis>
 	</PropertyGroup>
 	<Error Code="XA0115"
 			Condition="$(_RequestedAbis.Contains(';armeabi;'))"


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2507
Fixes: https://developercommunity.visualstudio.com/content/problem/400751/xamarin-android-build-failed-due-to-missing-folder.html
Context: https://github.com/xamarin/xamarin-android/issues/2173
Context: https://github.com/xamarin/xamarin-android/pull/2180