### PR TITLE
Runtime startup performance improvements

### DIFF
--- a/build-tools/scripts/cmake-common.props
+++ b/build-tools/scripts/cmake-common.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <_CmakeCommonFlags>-GNinja -DCMAKE_MAKE_PROGRAM=$(NinjaPath)</_CmakeCommonFlags>
-    <_CmakeAndroidFlags>$(_CmakeCommonFlags) -DANDROID_TOOLCHAIN=clang -DANDROID_NATIVE_API_LEVEL=$(AndroidNdkApiLevel) -DANDROID_PLATFORM=android-$(AndroidNdkApiLevel) -DCMAKE_TOOLCHAIN_FILE=$(AndroidNdkDirectory)\build\cmake\android.toolchain.cmake -DANDROID_NDK=$(AndroidNdkDirectory)</_CmakeAndroidFlags>
+    <_CmakeAndroidFlags>$(_CmakeCommonFlags) -DANDROID_STL="system" -DANDROID_CPP_FEATURES="" -DANDROID_TOOLCHAIN=clang -DANDROID_NATIVE_API_LEVEL=$(AndroidNdkApiLevel) -DANDROID_PLATFORM=android-$(AndroidNdkApiLevel) -DCMAKE_TOOLCHAIN_FILE=$(AndroidNdkDirectory)\build\cmake\android.toolchain.cmake -DANDROID_NDK=$(AndroidNdkDirectory)</_CmakeAndroidFlags>
   </PropertyGroup>
 </Project>

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -152,15 +152,16 @@ namespace Android.Runtime {
 		{
 			Logger.Categories = (LogCategories) args->logCategories;
 
-			var __start = new DateTime ();
+			Stopwatch stopper = null;
+			long elapsed, totalElapsed = 0;
 			if (Logger.LogTiming) {
-				__start = DateTime.UtcNow;
-				Logger.Log (LogLevel.Info,
-						"monodroid-timing",
-						"JNIEnv.Initialize start: " + (__start - new DateTime (1970, 1, 1)).TotalMilliseconds);
-				Logger.Log (LogLevel.Info,
-						"monodroid-timing",
-						"JNIEnv.Initialize: Logger JIT/etc. time: " + (DateTime.UtcNow - new DateTime (1970, 1, 1)).TotalMilliseconds + " [elapsed: " + (DateTime.UtcNow - __start).TotalMilliseconds + " ms]");
+				stopper = new Stopwatch ();
+				stopper.Start ();
+				Logger.Log (LogLevel.Info, "monodroid-timing", "JNIEnv.Initialize start");
+				elapsed = stopper.ElapsedMilliseconds;
+				totalElapsed += elapsed;
+				Logger.Log (LogLevel.Info, "monodroid-timing", $"JNIEnv.Initialize: Logger JIT/etc. time: elapsed {elapsed} ms]");
+				stopper.Restart ();
 			}
 
 			gref_gc_threshold = args->grefGcThreshold;
@@ -195,16 +196,14 @@ namespace Android.Runtime {
 #endif // JAVA_INTEROP
 
 			if (Logger.LogTiming) {
-				var __end = DateTime.UtcNow;
-				Logger.Log (LogLevel.Info,
-						"monodroid-timing",
-						"JNIEnv.Initialize: time: " + (__end - new DateTime (1970, 1, 1)).TotalMilliseconds + " [elapsed: " + (__end - __start).TotalMilliseconds + " ms]");
-				__start = DateTime.UtcNow;
+				elapsed = stopper.ElapsedMilliseconds;
+				totalElapsed += elapsed;
+				Logger.Log (LogLevel.Info, "monodroid-timing", $"JNIEnv.Initialize: managed runtime init time: elapsed {elapsed} ms]");
+				stopper.Restart ();
 				var _ = Java.Interop.TypeManager.jniToManaged;
-				__end = DateTime.UtcNow;
-				Logger.Log (LogLevel.Info,
-						"monodroid-timing",
-						"JNIEnv.Initialize: TypeManager init time: " + (__end - new DateTime (1970, 1, 1)).TotalMilliseconds + " [elapsed: " + (__end - __start).TotalMilliseconds + " ms]");
+				elapsed = stopper.ElapsedMilliseconds;
+				totalElapsed += elapsed;
+				Logger.Log (LogLevel.Info, "monodroid-timing", $"JNIEnv.Initialize: TypeManager init time: elapsed {elapsed} ms]");
 			}
 
 			AllocObjectSupported = androidSdkVersion > 10;
@@ -238,10 +237,10 @@ namespace Android.Runtime {
 					Java.Lang.Thread.DefaultUncaughtExceptionHandler = defaultUncaughtExceptionHandler;
 			}
 
-			if (Logger.LogTiming)
-				Logger.Log (LogLevel.Info,
-						"monodroid-timing",
-						"JNIEnv.Initialize end: " + (DateTime.UtcNow - new DateTime (1970, 1, 1)).TotalMilliseconds);
+			if (Logger.LogTiming) {
+				totalElapsed += stopper.ElapsedMilliseconds;
+				Logger.Log (LogLevel.Info, "monodroid-timing", $"JNIEnv.Initialize end: elapsed {totalElapsed} ms");
+			}
 		}
 
 		internal static void Exit ()

--- a/src/Mono.Android/java/mono/android/Runtime.java
+++ b/src/Mono.Android/java/mono/android/Runtime.java
@@ -1,12 +1,17 @@
 package mono.android;
 
 public class Runtime {
+	static java.lang.Class java_lang_Class = java.lang.Class.class;;
+	static java.lang.Class java_lang_System = java.lang.System.class;
+	static java.lang.Class java_util_TimeZone = java.util.TimeZone.class;
+	static java.lang.Class mono_android_IGCUserPeer = mono.android.IGCUserPeer.class;
+	static java.lang.Class mono_android_GCUserPeer = mono.android.GCUserPeer.class;
 
 	private Runtime ()
 	{
 	}
 
-	public static native void init (String lang, String[] runtimeApks, String runtimeDataDir, String[] appDirs, ClassLoader loader, String[] externalStorageDirs, String[] assemblies, String packageName);
+	public static native void init (String lang, String[] runtimeApks, String runtimeDataDir, String[] appDirs, ClassLoader loader, String[] externalStorageDirs, String[] assemblies, String packageName, int apiLevel, String[] environmentVariables);
 	public static native void register (String managedType, java.lang.Class nativeClass, String methods);
 	public static native void notifyTimeZoneChanged ();
 	public static native int createNewContext (String[] runtimeApks, String[] assemblies, ClassLoader loader);

--- a/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.java
@@ -63,7 +63,9 @@ public class MonoPackageManager {
 							externalLegacyDir
 						},
 						MonoPackageManager_Resources.Assemblies,
-						context.getPackageName ());
+						context.getPackageName (),
+						android.os.Build.VERSION.SDK_INT,
+						mono.android.app.XamarinAndroidEnvironmentVariables.Variables);
 				
 				mono.android.app.ApplicationRegistration.registerApplications ();
 				

--- a/src/Xamarin.Android.Build.Tasks/Resources/XamarinAndroidEnvironmentVariables.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/XamarinAndroidEnvironmentVariables.java
@@ -1,0 +1,9 @@
+package mono.android.app;
+
+public class XamarinAndroidEnvironmentVariables
+{
+	// Variables are specified the in "name", "value" pairs
+	public static final String[] Variables = new String[] {
+//@ENVVARS@
+	};
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -45,8 +45,6 @@ namespace Xamarin.Android.Tasks
 
 		public ITaskItem[] BundleNativeLibraries { get; set; }
 
-		public ITaskItem[] Environments { get; set; }
-
 		public ITaskItem[] TypeMappings { get; set; }
 
 		[Required]
@@ -74,27 +72,16 @@ namespace Xamarin.Android.Tasks
 
 		public bool PreferNativeLibrariesWithDebugSymbols { get; set; }
 
-		public string AndroidAotMode { get; set; }		
-
 		public string AndroidSequencePointsMode { get; set; }
 
-		public bool EnableLLVM { get; set; }
-
-		public bool EnableSGenConcurrent { get; set; }
-
 		public string AndroidEmbedProfilers { get; set; }
-		public string HttpClientHandlerType { get; set; }
 		public string TlsProvider { get; set; }
 		public string UncompressedFileExtensions { get; set; }
-
 
 		static  readonly    string          MSBuildXamarinAndroidDirectory      = Path.GetDirectoryName (typeof (BuildApk).Assembly.Location);
 
 		[Output]
 		public ITaskItem[] OutputFiles { get; set; }
-
-		[Output]
-		public string BuildId { get; set; }
 
 		bool _Debug {
 			get {
@@ -103,8 +90,6 @@ namespace Xamarin.Android.Tasks
 		}
 
 		SequencePointsMode sequencePointsMode = SequencePointsMode.None;
-
-		Guid buildId = Guid.NewGuid ();
 		
 		public ITaskItem[] LibraryProjectJars { get; set; }
 		string [] uncompressedFileExtensions;
@@ -125,7 +110,6 @@ namespace Xamarin.Android.Tasks
 				if (EmbedAssemblies && !BundleAssemblies)
 					AddAssemblies (apk);
 
-				AddEnvironment (apk);
 				AddRuntimeLibraries (apk, supportedAbis);
 				apk.Flush();
 				AddNativeLibraries (files, supportedAbis);
@@ -206,11 +190,9 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  Debug: {0}", Debug ?? "no");
 			Log.LogDebugMessage ("  PreferNativeLibrariesWithDebugSymbols: {0}", PreferNativeLibrariesWithDebugSymbols);
 			Log.LogDebugMessage ("  EmbedAssemblies: {0}", EmbedAssemblies);
-			Log.LogDebugMessage ("  AndroidAotMode: {0}", AndroidAotMode);
 			Log.LogDebugMessage ("  AndroidSequencePointsMode: {0}", AndroidSequencePointsMode);
 			Log.LogDebugMessage ("  CreatePackagePerAbi: {0}", CreatePackagePerAbi);
 			Log.LogDebugMessage ("  UncompressedFileExtensions: {0}", UncompressedFileExtensions);
-			Log.LogDebugTaskItems ("  Environments:", Environments);
 			Log.LogDebugTaskItems ("  ResolvedUserAssemblies:", ResolvedUserAssemblies);
 			Log.LogDebugTaskItems ("  ResolvedFrameworkAssemblies:", ResolvedFrameworkAssemblies);
 			Log.LogDebugTaskItems ("  NativeLibraries:", NativeLibraries);
@@ -220,8 +202,6 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugTaskItems ("  JavaLibraries:", JavaLibraries);
 			Log.LogDebugTaskItems ("  LibraryProjectJars:", LibraryProjectJars);
 			Log.LogDebugTaskItems ("  AdditionalNativeLibraryReferences:", AdditionalNativeLibraryReferences);
-			Log.LogDebugTaskItems ("  HttpClientHandlerType:", HttpClientHandlerType);
-			Log.LogDebugMessage ("  TlsProvider: {0}", TlsProvider);
 
 			Aot.TryGetSequencePointsMode (AndroidSequencePointsMode, out sequencePointsMode);
 
@@ -245,10 +225,6 @@ namespace Xamarin.Android.Tasks
 						outputFiles.Add (Path.Combine (path, String.Format ("{0}-{1}.apk", apk, abi)));
 					}
 			}
-
-			BuildId = buildId.ToString ();
-
-			Log.LogDebugMessage ("  [Output] BuildId: {0}", BuildId);
 
 			OutputFiles = outputFiles.Select (a => new TaskItem (a)).ToArray ();
 
@@ -347,83 +323,6 @@ namespace Xamarin.Android.Tasks
 				return "assemblies/" + culture;
 			}
 			return "assemblies";
-		}
-
-		void AddEnvironment (ZipArchiveEx apk)
-		{
-			var environment = new StringWriter () {
-				NewLine = "\n",
-			};
-
-			if (EnableLLVM) {
-				environment.WriteLine ("mono.llvm=true");
-			}
-
-			AotMode aotMode;
-			if (AndroidAotMode != null && Aot.GetAndroidAotMode(AndroidAotMode, out aotMode)) {
-				environment.WriteLine ("mono.aot={0}", aotMode.ToString().ToLowerInvariant());
-			}
-
-			const string defaultLogLevel = "MONO_LOG_LEVEL=info";
-			const string defaultMonoDebug = "MONO_DEBUG=gen-compact-seq-points";
-			const string defaultHttpMessageHandler = "XA_HTTP_CLIENT_HANDLER_TYPE=System.Net.Http.HttpClientHandler, System.Net.Http";
-			const string defaultTlsProvider = "XA_TLS_PROVIDER=btls";
-			string xamarinBuildId = string.Format ("XAMARIN_BUILD_ID={0}", buildId);
-
-			bool haveLogLevel = false;
-			bool haveMonoDebug = false;
-			bool havebuildId = false;
-			bool haveHttpMessageHandler = false;
-			bool haveTlsProvider = false;
-			bool haveMonoGCParams = false;
-
-			foreach (ITaskItem env in Environments ?? new TaskItem[0]) {
-				environment.WriteLine ("## Source File: {0}", env.ItemSpec);
-				foreach (string line in File.ReadLines (env.ItemSpec)) {
-					var lineToWrite = line;
-					if (lineToWrite.StartsWith ("MONO_LOG_LEVEL=", StringComparison.Ordinal))
-						haveLogLevel = true;
-					if (lineToWrite.StartsWith ("MONO_GC_PARAMS=", StringComparison.Ordinal))
-						haveMonoGCParams = true;
-					if (lineToWrite.StartsWith ("XAMARIN_BUILD_ID=", StringComparison.Ordinal))
-						havebuildId = true;
-					if (lineToWrite.StartsWith ("MONO_DEBUG=", StringComparison.Ordinal)) {
-						haveMonoDebug = true;
-						if (sequencePointsMode != SequencePointsMode.None && !lineToWrite.Contains ("gen-compact-seq-points"))
-							lineToWrite = line  + ",gen-compact-seq-points";
-					}
-					if (lineToWrite.StartsWith ("XA_HTTP_CLIENT_HANDLER_TYPE=", StringComparison.Ordinal))
-						haveHttpMessageHandler = true;
-					if (lineToWrite.StartsWith ("XA_TLS_PROVIDER=", StringComparison.Ordinal))
-						haveTlsProvider = true;
-					environment.WriteLine (lineToWrite);
-				}
-			}
-
-			if (_Debug && !haveLogLevel) {
-				environment.WriteLine (defaultLogLevel);
-			}
-
-			if (sequencePointsMode != SequencePointsMode.None && !haveMonoDebug) {
-				environment.WriteLine (defaultMonoDebug);
-			}
-
-			if (!havebuildId)
-				environment.WriteLine (xamarinBuildId);
-
-			if (!haveHttpMessageHandler)
-				environment.WriteLine (HttpClientHandlerType == null ? defaultHttpMessageHandler : $"XA_HTTP_CLIENT_HANDLER_TYPE={HttpClientHandlerType.Trim ()}");
-			if (!haveTlsProvider)
-				environment.WriteLine (TlsProvider == null ? defaultTlsProvider : $"XA_TLS_PROVIDER={TlsProvider.Trim ()}");
-			if (!haveMonoGCParams) {
-				if (EnableSGenConcurrent)
-					environment.WriteLine ("MONO_GC_PARAMS=major=marksweep-conc");
-				else
-					environment.WriteLine ("MONO_GC_PARAMS=major=marksweep");
-			}
-
-			apk.Archive.AddEntry ("environment", environment.ToString (),
-					new UTF8Encoding (encoderShouldEmitUTF8Identifier:false));
 		}
 
 		class LibInfo

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -13,6 +13,10 @@ namespace Xamarin.Android.Tasks
 {
 	public class GeneratePackageManagerJava : Task
 	{
+		const string EnvironmentFileName = "XamarinAndroidEnvironmentVariables.java";
+
+		Guid buildId = Guid.NewGuid ();
+
 		[Required]
 		public ITaskItem[] ResolvedAssemblies { get; set; }
 
@@ -21,6 +25,9 @@ namespace Xamarin.Android.Tasks
 
 		[Required]
 		public string OutputDirectory { get; set; }
+
+		[Required]
+		public string EnvironmentOutputDirectory { get; set; }
 
 		[Required]
 		public string UseSharedRuntime { get; set; }
@@ -34,6 +41,24 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string Manifest { get; set; }
 
+		public string Debug { get; set; }
+		public ITaskItem[] Environments { get; set; }
+		public string AndroidAotMode { get; set; }
+		public bool EnableLLVM { get; set; }
+		public string HttpClientHandlerType { get; set; }
+		public string TlsProvider { get; set; }
+		public string AndroidSequencePointsMode { get; set; }
+		public bool EnableSGenConcurrent { get; set; }
+
+		[Output]
+		public string BuildId { get; set; }
+
+		bool _Debug {
+			get {
+				return string.Equals (Debug, "true", StringComparison.OrdinalIgnoreCase);
+			}
+		}
+
 		public override bool Execute ()
 		{
 			Log.LogDebugMessage ("GeneratePackageManagerJava Task");
@@ -44,6 +69,9 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("  MainAssembly: {0}", MainAssembly);
 			Log.LogDebugTaskItems ("  ResolvedAssemblies:", ResolvedAssemblies);
 			Log.LogDebugTaskItems ("  ResolvedUserAssemblies:", ResolvedUserAssemblies);
+
+			BuildId = buildId.ToString ();
+			Log.LogDebugMessage ("  [Output] BuildId: {0}", BuildId);
 
 			var shared_runtime = string.Compare (UseSharedRuntime, "true", true) == 0;
 			var doc = AndroidAppManifest.Load (Manifest, MonoAndroidHelper.SupportedVersions);
@@ -103,10 +131,131 @@ namespace Xamarin.Android.Tasks
 			MonoAndroidHelper.CopyIfChanged (temp, dest);
 
 			try { File.Delete (temp); } catch (Exception) { }
-			
-			try { File.Delete (temp); } catch (Exception) { }
+
+			AddEnvironment ();
 
 			return !Log.HasLoggedErrors;
+		}
+
+		static readonly string[] defaultLogLevel = {"MONO_LOG_LEVEL", "info"};
+		static readonly string[] defaultMonoDebug = {"MONO_DEBUG", "gen-compact-seq-points"};
+		static readonly string[] defaultHttpMessageHandler = {"XA_HTTP_CLIENT_HANDLER_TYPE", "System.Net.Http.HttpClientHandler, System.Net.Http"};
+		static readonly string[] defaultTlsProvider = {"XA_TLS_PROVIDER", "btls"};
+
+		void AddEnvironment ()
+		{
+			var environment = new StringWriter () {
+				NewLine = "\n",
+			};
+
+			if (EnableLLVM) {
+				WriteEnvironment ("mono.llvm", "true");
+			}
+
+			AotMode aotMode;
+			if (AndroidAotMode != null && Aot.GetAndroidAotMode (AndroidAotMode, out aotMode)) {
+				WriteEnvironment ("mono.aot", aotMode.ToString ().ToLowerInvariant());
+			}
+
+			bool haveLogLevel = false;
+			bool haveMonoDebug = false;
+			bool havebuildId = false;
+			bool haveHttpMessageHandler = false;
+			bool haveTlsProvider = false;
+			bool haveMonoGCParams = false;
+
+			SequencePointsMode sequencePointsMode;
+			if (!Aot.TryGetSequencePointsMode (AndroidSequencePointsMode, out sequencePointsMode))
+				sequencePointsMode = SequencePointsMode.None;
+
+			foreach (ITaskItem env in Environments ?? new TaskItem[0]) {
+				environment.WriteLine ("\t\t// Source File: {0}", env.ItemSpec);
+				foreach (string line in File.ReadLines (env.ItemSpec)) {
+					var lineToWrite = line;
+					if (lineToWrite.StartsWith ("MONO_LOG_LEVEL=", StringComparison.Ordinal))
+						haveLogLevel = true;
+					if (lineToWrite.StartsWith ("MONO_GC_PARAMS=", StringComparison.Ordinal))
+						haveMonoGCParams = true;
+					if (lineToWrite.StartsWith ("XAMARIN_BUILD_ID=", StringComparison.Ordinal))
+						havebuildId = true;
+					if (lineToWrite.StartsWith ("MONO_DEBUG=", StringComparison.Ordinal)) {
+						haveMonoDebug = true;
+						if (sequencePointsMode != SequencePointsMode.None && !lineToWrite.Contains ("gen-compact-seq-points"))
+							lineToWrite = line  + ",gen-compact-seq-points";
+					}
+					if (lineToWrite.StartsWith ("XA_HTTP_CLIENT_HANDLER_TYPE=", StringComparison.Ordinal))
+						haveHttpMessageHandler = true;
+					if (lineToWrite.StartsWith ("XA_TLS_PROVIDER=", StringComparison.Ordinal))
+						haveTlsProvider = true;
+					WriteEnvironmentLine (lineToWrite);
+				}
+			}
+
+			if (_Debug && !haveLogLevel) {
+				WriteEnvironment (defaultLogLevel[0], defaultLogLevel[1]);
+			}
+
+			if (sequencePointsMode != SequencePointsMode.None && !haveMonoDebug) {
+				WriteEnvironment (defaultMonoDebug[0], defaultMonoDebug[1]);
+			}
+
+			if (!havebuildId)
+				WriteEnvironment ("XAMARIN_BUILD_ID", buildId.ToString ());
+
+			if (!haveHttpMessageHandler) {
+				if (HttpClientHandlerType == null)
+					WriteEnvironment (defaultHttpMessageHandler[0], defaultHttpMessageHandler[1]);
+				else
+					WriteEnvironment ("XA_HTTP_CLIENT_HANDLER_TYPE", HttpClientHandlerType.Trim ());
+			}
+
+			if (!haveTlsProvider) {
+				if (TlsProvider == null)
+					WriteEnvironment (defaultTlsProvider[0], defaultTlsProvider[1]);
+				else
+					WriteEnvironment ("XA_TLS_PROVIDER", TlsProvider.Trim ());
+			}
+
+			if (!haveMonoGCParams) {
+				if (EnableSGenConcurrent)
+					WriteEnvironment ("MONO_GC_PARAMS", "major=marksweep-conc");
+				else
+					WriteEnvironment ("MONO_GC_PARAMS", "major=marksweep");
+			}
+
+			string environmentTemplate;
+			using (var sr = new StreamReader (typeof (BuildApk).Assembly.GetManifestResourceStream (EnvironmentFileName))) {
+				environmentTemplate = sr.ReadToEnd ();
+			}
+
+			using (var ms = new MemoryStream ()) {
+				using (var sw = new StreamWriter (ms)) {
+					sw.Write (environmentTemplate.Replace ("//@ENVVARS@", environment.ToString ()));
+					sw.Flush ();
+
+					string dest = Path.GetFullPath (Path.Combine (EnvironmentOutputDirectory, EnvironmentFileName));
+					MonoAndroidHelper.CopyIfStreamChanged (ms, dest);
+				}
+			}
+
+			void WriteEnvironment (string name, string value)
+			{
+				environment.WriteLine ($"\t\t\"{ValidJavaString (name)}\", \"{ValidJavaString (value)}\",");
+			}
+
+			void WriteEnvironmentLine (string line)
+			{
+				if (String.IsNullOrEmpty (line))
+					return;
+
+				string[] nv = line.Split (new char[]{'='}, 2);
+				WriteEnvironment (nv[0].Trim (), nv.Length < 2 ? String.Empty : nv[1].Trim ());
+			}
+
+			string ValidJavaString (string s)
+			{
+				return s.Replace ("\"", "\\\"");
+			}
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -686,6 +686,9 @@
     <EmbeddedResource Include="Resources\ResourcePatcher.java">
       <LogicalName>ResourcePatcher.java</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="Resources\XamarinAndroidEnvironmentVariables.java">
+      <LogicalName>XamarinAndroidEnvironmentVariables.java</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Android.Tools.Aidl\Xamarin.Android.Tools.Aidl.csproj">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2341,10 +2341,21 @@ because xbuild doesn't support framework reference assemblies.
     ResolvedAssemblies="@(_ResolvedAssemblies)"
     ResolvedUserAssemblies="@(_ResolvedUserAssemblies)"
     MainAssembly="$(MonoAndroidLinkerInputDir)$(TargetFileName)"
-    OutputDirectory="$(IntermediateOutputPath)android\src\mono" 
+    OutputDirectory="$(IntermediateOutputPath)android\src\mono"
+    EnvironmentOutputDirectory="$(IntermediateOutputPath)android\src\mono\android\app"
     UseSharedRuntime="$(AndroidUseSharedRuntime)"
     TargetFrameworkVersion="$(TargetFrameworkVersion)" 
-    Manifest="$(IntermediateOutputPath)android\AndroidManifest.xml" />
+    Manifest="$(IntermediateOutputPath)android\AndroidManifest.xml"
+    Environments="@(AndroidEnvironment);@(LibraryEnvironments)"
+    AndroidAotMode="$(AndroidAotMode)"
+    EnableLLVM="$(EnableLLVM)"
+    HttpClientHandlerType="$(AndroidHttpClientHandlerType)"
+    TlsProvider="$(AndroidTlsProvider)"
+    Debug="$(AndroidIncludeDebugSymbols)"
+    AndroidSequencePointsMode="$(_SequencePointsMode)"
+    EnableSGenConcurrent="$(AndroidEnableSGenConcurrent)">
+    <Output TaskParameter="BuildId" PropertyName="_XamarinBuildId" />
+  </GeneratePackageManagerJava>
   <Touch Files="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp" AlwaysCreate="True" />
 </Target>
 
@@ -2866,7 +2877,6 @@ because xbuild doesn't support framework reference assemblies.
     BundleAssemblies="$(BundleAssemblies)"
     BundleNativeLibraries="$(_BundleResultNativeLibraries)"
     EmbedAssemblies="$(EmbedAssembliesIntoApk)"
-    Environments="@(AndroidEnvironment);@(LibraryEnvironments)"
     ResolvedUserAssemblies="@(_ResolvedUserAssemblies);@(_AndroidResolvedSatellitePaths)"
     ResolvedFrameworkAssemblies="@(_ShrunkFrameworkAssemblies)"
     NativeLibraries="@(AndroidNativeLibrary)"
@@ -2879,18 +2889,13 @@ because xbuild doesn't support framework reference assemblies.
     Debug="$(AndroidIncludeDebugSymbols)"
     PreferNativeLibrariesWithDebugSymbols="$(AndroidPreferNativeLibrariesWithDebugSymbols)"
     TypeMappings="$(_AndroidTypeMappingJavaToManaged);$(_AndroidTypeMappingManagedToJava)"
-    AndroidAotMode="$(AndroidAotMode)"
-    EnableLLVM="$(EnableLLVM)"
     JavaSourceFiles="@(AndroidJavaSource)"
     JavaLibraries="@(AndroidJavaLibrary)"
     AndroidSequencePointsMode="$(_SequencePointsMode)"
     LibraryProjectJars="@(ExtractedJarImports)"
     AndroidEmbedProfilers="$(AndroidEmbedProfilers)"
-    HttpClientHandlerType="$(AndroidHttpClientHandlerType)"
     TlsProvider="$(AndroidTlsProvider)"
-    UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)"
-    EnableSGenConcurrent="$(AndroidEnableSGenConcurrent)">
-    <Output TaskParameter="BuildId" PropertyName="_XamarinBuildId" />
+    UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)">
     <Output TaskParameter="OutputFiles" ItemName="ApkFiles" />
   </BuildApk>
 </Target>

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -89,6 +89,9 @@ set(TEST_COMPILER_ARGS
   finline-limit=300
   fvisibility=hidden
   fstack-protector
+  fno-rtti
+  fno-exceptions
+  flto
   Wa,--noexecstack
   Wformat
   Werror=format-security
@@ -238,6 +241,7 @@ set(SOURCES_DIR ${TOP_DIR}/jni)
 set(MONODROID_SOURCES
   ${MONODROID_SOURCES}
   ${MONO_PATH}/support/zlib-helper.c
+  ${SOURCES_DIR}/new_delete.cc
   ${SOURCES_DIR}/android-system.cc
   ${SOURCES_DIR}/cpu-arch-detect.cc
   ${SOURCES_DIR}/debug-constants.cc

--- a/src/monodroid/jni/debug.cc
+++ b/src/monodroid/jni/debug.cc
@@ -195,8 +195,8 @@ Debug::handle_server_connection (void)
 
 	flags = 1;
 	rv = setsockopt (listen_socket, SOL_SOCKET, SO_REUSEADDR, &flags, sizeof (flags));
-	if (rv == -1) {
-		log_info (LOG_DEFAULT, "Could not set SO_REUSEADDR on the listening socket (%s)", strerror (errno));
+	if (rv == -1 && utils.should_log (LOG_DEFAULT)) {
+		log_info_nocheck (LOG_DEFAULT, "Could not set SO_REUSEADDR on the listening socket (%s)", strerror (errno));
 		// not a fatal failure
 	}
 

--- a/src/monodroid/jni/dylib-mono.cc
+++ b/src/monodroid/jni/dylib-mono.cc
@@ -60,6 +60,11 @@ bool DylibMono::init (void *libmono_handle)
 #define LOAD_SYMBOL(symbol) LOAD_SYMBOL_CAST(symbol, monodroid_ ##symbol ##_fptr)
 #define LOAD_SYMBOL_NO_PREFIX(symbol) LOAD_SYMBOL_CAST(symbol, symbol ##_fptr)
 
+	timing_period total_time;
+	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
+		total_time.mark_start ();
+	}
+
 	LOAD_SYMBOL(mono_add_internal_call)
 	LOAD_SYMBOL(mono_assembly_get_image)
 	LOAD_SYMBOL(mono_assembly_load_from_full)
@@ -137,6 +142,13 @@ bool DylibMono::init (void *libmono_handle)
 	LOAD_SYMBOL(mono_thread_current)
 	LOAD_SYMBOL_CAST(mono_use_llvm, int*)
 	LOAD_SYMBOL_NO_PREFIX(mono_aot_register_module)
+
+	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
+		total_time.mark_end ();
+
+		timing_diff diff (total_time);
+		log_info_nocheck (LOG_TIMING, "DylibMono.init: end, total time; elapsed: %lis:%lu::%lu", diff.sec, diff.ms, diff.ns);
+	}
 
 	if (symbols_missing) {
 		log_fatal (LOG_DEFAULT, "Failed to load some Mono symbols, aborting...");

--- a/src/monodroid/jni/dylib-mono.h
+++ b/src/monodroid/jni/dylib-mono.h
@@ -344,7 +344,9 @@ enum MonoAotMode {
 	MONO_AOT_MODE_HYBRID,
 	/* Enables full AOT mode, JIT is disabled and not allowed,
 	 * equivalent to mono_jit_set_aot_only (true) */
-	MONO_AOT_MODE_FULL
+	MONO_AOT_MODE_FULL,
+
+	MONO_AOT_MODE_UNKNOWN = 0xBADBAD
 };
 #ifndef __cplusplus
 typedef int MonoAotMode;

--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -1,7 +1,7 @@
 #include <assert.h>
 #include <stdio.h>
-#include <cstdlib>
-#include <cstring>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <fcntl.h>
@@ -72,7 +72,7 @@ open_from_bundles (MonoAssemblyName *aname, char **assemblies_path, void *user_d
 	MonoAssembly *a = NULL;
 
 	int name_len = culture == NULL ? 0 : strlen (culture) + 1;
-	name_len += std::strlen (reinterpret_cast<const char*> (mono->assembly_name_get_name (aname)));
+	name_len += strlen (reinterpret_cast<const char*> (mono->assembly_name_get_name (aname)));
 	name = static_cast<char*> (utils.xmalloc (name_len + sizeof (".exe") + 1));
 	if (culture != NULL && strlen (culture) > 0)
 		sprintf (name, "%s/%s", culture, (const char*) mono->assembly_name_get_name (aname));
@@ -108,8 +108,8 @@ open_from_bundles (MonoAssemblyName *aname, char **assemblies_path, void *user_d
 		}
 	}
 	free (name);
-	if (a) {
-		log_info (LOG_ASSEMBLY, "open_from_bundles: loaded assembly: %p\n", a);
+	if (a && utils.should_log (LOG_ASSEMBLY)) {
+		log_info_nocheck (LOG_ASSEMBLY, "open_from_bundles: loaded assembly: %p\n", a);
 	}
 	return a;
 }
@@ -139,7 +139,7 @@ monodroid_embedded_assemblies_install_preload_hook (DylibMono *imports)
 static int
 TypeMappingInfo_compare_key (const void *a, const void *b)
 {
-	return std::strcmp (reinterpret_cast <const char*> (a), reinterpret_cast <const char*> (b));
+	return strcmp (reinterpret_cast <const char*> (a), reinterpret_cast <const char*> (b));
 }
 
 MONO_API const char *
@@ -148,7 +148,7 @@ monodroid_typemap_java_to_managed (const char *java)
 	struct TypeMappingInfo *info;
 	for (info = java_to_managed_maps; info != NULL; info = info->next) {
 		/* log_warn (LOG_DEFAULT, "# jonp: checking file: %s!%s for type '%s'", info->source_apk, info->source_entry, java); */
-		const char *e = reinterpret_cast<const char*> (std::bsearch (java, info->mapping, info->num_entries, info->entry_length, TypeMappingInfo_compare_key));
+		const char *e = reinterpret_cast<const char*> (bsearch (java, info->mapping, info->num_entries, info->entry_length, TypeMappingInfo_compare_key));
 		if (e == NULL)
 			continue;
 		return e + info->value_offset;
@@ -162,7 +162,7 @@ monodroid_typemap_managed_to_java (const char *managed)
 	struct TypeMappingInfo *info;
 	for (info = managed_to_java_maps; info != NULL; info = info->next) {
 		/* log_warn (LOG_DEFAULT, "# jonp: checking file: %s!%s for type '%s'", info->source_apk, info->source_entry, managed); */
-		const char *e = reinterpret_cast <const char*> (std::bsearch (managed, info->mapping, info->num_entries, info->entry_length, TypeMappingInfo_compare_key));
+		const char *e = reinterpret_cast <const char*> (bsearch (managed, info->mapping, info->num_entries, info->entry_length, TypeMappingInfo_compare_key));
 		if (e == NULL)
 			continue;
 		return e + info->value_offset;
@@ -480,7 +480,7 @@ gather_bundled_assemblies_from_apk (
 			psize = (unsigned int*) &cur->size;
 			*psize = info.uncompressed_size;
 
-			if ((log_categories & LOG_ASSEMBLY) != 0) {
+			if (utils.should_log (LOG_ASSEMBLY)) {
 				const char *p = (const char*) cur->data;
 
 				char header[9];
@@ -489,7 +489,7 @@ gather_bundled_assemblies_from_apk (
 					header[i] = isprint (p [i]) ? p [i] : '.';
 				header [sizeof(header)-1] = '\0';
 
-				log_info (LOG_ASSEMBLY, "file-offset: % 8x  start: %08p  end: %08p  len: % 12i  zip-entry:  %s name: %s [%s]",
+				log_info_nocheck (LOG_ASSEMBLY, "file-offset: % 8x  start: %08p  end: %08p  len: % 12i  zip-entry:  %s name: %s [%s]",
 						(int) offset, cur->data, cur->data + *psize, (int) info.uncompressed_size, cur_entry_name, cur->name, header);
 			}
 

--- a/src/monodroid/jni/globals.h
+++ b/src/monodroid/jni/globals.h
@@ -6,6 +6,7 @@
 #include "util.h"
 #include "debug.h"
 #include "monodroid-glue-internal.h"
+#include "cppcompat.h"
 
 extern xamarin::android::DylibMono monoFunctions;
 extern xamarin::android::Util utils;

--- a/src/monodroid/jni/jni-wrappers.h
+++ b/src/monodroid/jni/jni-wrappers.h
@@ -1,0 +1,179 @@
+// Dear Emacs, this is a -*- C++ -*- header
+#ifndef __JNI_WRAPPERS_H
+#define __JNI_WRAPPERS_H
+
+#include <assert.h>
+#include <jni.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+
+namespace xamarin { namespace android
+{
+	class jstring_array_wrapper;
+
+	class jstring_wrapper
+	{
+	public:
+		explicit jstring_wrapper (JNIEnv *env) noexcept
+			: env (env),
+			  jstr (nullptr)
+		{
+			assert (env);
+		}
+
+		explicit jstring_wrapper (JNIEnv *env, const jobject jo) noexcept
+			: env (env),
+			  jstr (reinterpret_cast<jstring> (jo))
+		{
+			assert (env);
+		}
+
+		explicit jstring_wrapper (JNIEnv *env, const jstring js) noexcept
+			: env (env),
+			  jstr (js)
+		{
+			assert (env);
+		}
+
+		jstring_wrapper (const jstring_wrapper&) = delete;
+
+		~jstring_wrapper () noexcept
+		{
+			release ();
+		}
+
+		jstring_wrapper& operator=(const jstring_wrapper&) = delete;
+
+		const char* get_cstr () noexcept
+		{
+			if (cstr == nullptr && env != nullptr)
+				cstr = env->GetStringUTFChars (jstr, nullptr);
+
+			return cstr;
+		}
+
+		jstring_wrapper& operator= (const jobject new_jo) noexcept
+		{
+			assign (reinterpret_cast<jstring> (new_jo));
+			return *this;
+		}
+
+		jstring_wrapper& operator= (const jstring new_js) noexcept
+		{
+			assign (new_js);
+			return *this;
+		}
+
+	protected:
+		void release () noexcept
+		{
+			if (jstr == nullptr || cstr == nullptr || env == nullptr)
+				return;
+			env->ReleaseStringUTFChars (jstr, cstr);
+			jobjectRefType type = env->GetObjectRefType (jstr);
+			switch (type) {
+				case JNILocalRefType:
+					env->DeleteLocalRef (jstr);
+					break;
+
+				case JNIGlobalRefType:
+					env->DeleteGlobalRef (jstr);
+					break;
+
+				case JNIWeakGlobalRefType:
+					env->DeleteWeakGlobalRef (jstr);
+					break;
+
+				case JNIInvalidRefType: // To hush compiler warning
+					break;
+			}
+
+			jstr = nullptr;
+			cstr = nullptr;
+		}
+
+		void assign (const jstring new_js) noexcept
+		{
+			release ();
+			if (new_js == nullptr)
+				return;
+
+			jstr = new_js;
+			cstr = nullptr;
+		}
+
+		friend class jstring_array_wrapper;
+
+	private:
+		jstring_wrapper ()
+			: env (nullptr),
+			  jstr (nullptr)
+		{}
+
+	private:
+		JNIEnv *env;
+		jstring jstr;
+		const char *cstr = nullptr;
+	};
+
+	class jstring_array_wrapper
+	{
+	public:
+		explicit jstring_array_wrapper (JNIEnv *env) noexcept
+			: env (env),
+			  arr (nullptr),
+			  len (0)
+		{
+			assert (env);
+		}
+
+		explicit jstring_array_wrapper (JNIEnv *env, jobjectArray arr)
+			: env (env),
+			  arr (arr)
+		{
+			assert (env);
+			assert (arr);
+			len = env->GetArrayLength (arr);
+			if (len > sizeof (static_wrappers) / sizeof (jstring_wrapper))
+				wrappers = new jstring_wrapper [len];
+			else
+				wrappers = static_wrappers;
+		}
+
+		~jstring_array_wrapper () noexcept
+		{
+			if (wrappers != nullptr && wrappers != static_wrappers)
+				delete[] wrappers;
+		}
+
+		size_t get_length () const noexcept
+		{
+			return len;
+		}
+
+		jstring_wrapper& operator[] (size_t index) noexcept
+		{
+			if (index >= len)
+				return invalid_wrapper;
+
+			if (wrappers [index].env == nullptr) {
+				wrappers [index].env = env;
+				wrappers [index].jstr = reinterpret_cast <jstring> (env->GetObjectArrayElement (arr, index));
+			}
+
+			return wrappers [index];
+		}
+
+	private:
+		JNIEnv *env;
+		jobjectArray arr;
+		size_t len;
+		jstring_wrapper *wrappers;
+		jstring_wrapper  static_wrappers[5];
+		jstring_wrapper  invalid_wrapper;
+	};
+}}
+
+#endif // __cplusplus
+#endif // __JNI_WRAPPERS_H

--- a/src/monodroid/jni/mono_android_Runtime.h
+++ b/src/monodroid/jni/mono_android_Runtime.h
@@ -10,10 +10,10 @@ extern "C" {
 /*
  * Class:     mono_android_Runtime
  * Method:    init
- * Signature: (Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/ClassLoader;[Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)V
+ * Signature: (Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/ClassLoader;[Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;I;Ljava/lang/String)V
  */
 JNIEXPORT void JNICALL Java_mono_android_Runtime_init
-  (JNIEnv *, jclass, jstring, jobjectArray, jstring, jobjectArray, jobject, jobjectArray, jobjectArray, jstring);
+  (JNIEnv *, jclass, jstring, jobjectArray, jstring, jobjectArray, jobject, jobjectArray, jobjectArray, jstring, jint, jobjectArray);
 
 /*
  * Class:     mono_android_Runtime

--- a/src/monodroid/jni/monodroid-glue-internal.h
+++ b/src/monodroid/jni/monodroid-glue-internal.h
@@ -13,7 +13,6 @@ namespace xamarin { namespace android { namespace internal
 	extern char *external_override_dir;
 	extern char *external_legacy_override_dir;
 	extern char *runtime_libdir;
-	extern int   embedded_dso_mode;
 
 	class MonodroidRuntime
 	{

--- a/src/monodroid/jni/monodroid.h
+++ b/src/monodroid/jni/monodroid.h
@@ -25,7 +25,13 @@
 #ifdef __cplusplus
 #define MONO_API extern "C" MONO_API_DEF
 #else
-#define MONO_API MONO_API_DEF
+
+/* Use our own definition, to stay consistent */
+#if defined (MONO_API)
+#undef MONO_API
 #endif
+#define MONO_API MONO_API_DEF
+
+#endif /* __cplusplus */
 
 #endif  /* defined __MONODROID_H */

--- a/src/monodroid/jni/new_delete.cc
+++ b/src/monodroid/jni/new_delete.cc
@@ -1,0 +1,79 @@
+#include <stdlib.h>
+#include <new>
+
+extern "C" {
+#include "java-interop-util.h"
+}
+
+static void*
+do_alloc (size_t size)
+{
+	return ::malloc (size == 0 ? 1 : size);
+}
+
+void*
+operator new (size_t size)
+{
+	void* p = do_alloc (size);
+	if (p == nullptr) {
+		log_fatal (LOG_DEFAULT, "Out of memory in the `new` operator");
+		exit (FATAL_EXIT_OUT_OF_MEMORY);
+	}
+
+	return p;
+}
+
+void*
+operator new (size_t size, const std::nothrow_t&) noexcept
+{
+	return do_alloc (size);
+}
+
+void*
+operator new[] (size_t size)
+{
+	return ::operator new (size);
+}
+
+void*
+operator new[] (size_t size, const std::nothrow_t&) noexcept
+{
+	return do_alloc (size);
+}
+
+void
+operator delete (void* ptr) noexcept
+{
+	if (ptr)
+		::free (ptr);
+}
+
+void
+operator delete (void* ptr, const std::nothrow_t&) noexcept
+{
+	::operator delete (ptr);
+}
+
+void
+operator delete (void* ptr, size_t) noexcept
+{
+	::operator delete (ptr);
+}
+
+void
+operator delete[] (void* ptr) noexcept
+{
+	::operator delete (ptr);
+}
+
+void
+operator delete[] (void* ptr, const std::nothrow_t&) noexcept
+{
+	::operator delete[] (ptr);
+}
+
+void
+operator delete[] (void* ptr, size_t) noexcept
+{
+	::operator delete[] (ptr);
+}

--- a/src/monodroid/jni/osbridge.cc
+++ b/src/monodroid/jni/osbridge.cc
@@ -1,5 +1,5 @@
-#include <cassert>
-#include <cstring>
+#include <assert.h>
+#include <string.h>
 
 #include <sys/types.h>
 #if defined (LINUX) || defined (__linux__) || defined (__linux)
@@ -927,8 +927,10 @@ OSBridge::gc_cross_references (int num_sccs, MonoGCBridgeSCC **sccs, int num_xre
 			}
 		}
 
-		for (i = 0; i < num_xrefs; ++i)
-			log_info (LOG_GC, "xref [%d] %d -> %d", i, xrefs [i].src_scc_index, xrefs [i].dst_scc_index);
+		if (utils.should_log (LOG_GC)) {
+			for (i = 0; i < num_xrefs; ++i)
+				log_info_nocheck (LOG_GC, "xref [%d] %d -> %d", i, xrefs [i].src_scc_index, xrefs [i].dst_scc_index);
+		}
 	}
 #endif
 
@@ -1062,10 +1064,10 @@ OSBridge::initialize_on_onload (JavaVM *vm, JNIEnv *env)
 }
 
 void
-OSBridge::initialize_on_runtime_init (JNIEnv *env)
+OSBridge::initialize_on_runtime_init (JNIEnv *env, jclass runtimeClass)
 {
 	assert (env != nullptr);
-	GCUserPeer_class      = reinterpret_cast<jclass> (lref_to_gref (env, env->FindClass ("mono/android/GCUserPeer")));
+	GCUserPeer_class      = utils.get_class_from_runtime_field(env, runtimeClass, "mono_android_GCUserPeer", true);
 	GCUserPeer_ctor       = env->GetMethodID (GCUserPeer_class, "<init>", "()V");
 	assert ( (GCUserPeer_class && GCUserPeer_ctor) || !"Failed to load mono.android.GCUserPeer!" );
 }

--- a/src/monodroid/jni/osbridge.h
+++ b/src/monodroid/jni/osbridge.h
@@ -107,7 +107,7 @@ namespace xamarin { namespace android { namespace internal
 		int get_gref_gc_threshold ();
 		JNIEnv* ensure_jnienv ();
 		void initialize_on_onload (JavaVM *vm, JNIEnv *env);
-		void initialize_on_runtime_init (JNIEnv *env);
+		void initialize_on_runtime_init (JNIEnv *env, jclass runtimeClass);
 		void add_monodroid_domain (MonoDomain *domain);
 		void remove_monodroid_domain (MonoDomain *domain);
 		void on_destroy_contexts ();

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -26,7 +26,7 @@
 
   <Target Name="_ConfigureHostRuntimes"
       DependsOnTargets="_CreateMacMxeCmakeToolchainFiles"
-      Inputs="CMakeLists.txt"
+      Inputs="CMakeLists.txt;..\..\build-tools\scripts\cmake-common.props"
       Outputs="@(_HostRuntime->'$(IntermediatePath)%(OutputDirectory)-Debug\CMakeCache.txt');@(_HostRuntime->'$(IntermediatePath)%(OutputDirectory)-Release\CMakeCache.txt')">
     <MakeDir Directories="$(IntermediateOutputPath)%(_HostRuntime.OutputDirectory)-Debug" />
     <!-- CMAKE_RUNTIME_OUTPUT_DIRECTORY is provided for the mxe/mingw cross builds. DLL outputs are treated as _runtime_ objects (as opposed to _library_ ones for .so, .dylib etc) by cmake
@@ -44,7 +44,7 @@
   </Target>
 
   <Target Name="_ConfigureAndroidRuntimes"
-      Inputs="CMakeLists.txt"
+      Inputs="CMakeLists.txt;..\..\build-tools\scripts\cmake-common.props"
       Outputs="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\CMakeCache.txt');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\CMakeCache.txt')">
     <MakeDir Directories="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Debug" />
     <Exec
@@ -61,7 +61,7 @@
 
   <Target Name="_BuildAndroidRuntimes"
       DependsOnTargets="_ConfigureAndroidRuntimes"
-      Inputs="@(_MonodroidSource);@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\CMakeCache.txt');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\CMakeCache.txt')"
+      Inputs="@(_MonodroidSource);@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\CMakeCache.txt');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\CMakeCache.txt');jni\*.cc;jni\*.h;jni\**\*.c"
       Outputs="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.so')">
     <Exec
         Command="$(NinjaPath) -v"
@@ -76,7 +76,7 @@
 
   <Target Name="_BuildHostRuntimes"
       DependsOnTargets="_GetBuildHostRuntimes;_CreateJavaInteropDllConfigs;_ConfigureHostRuntimes"
-      Inputs="@(_MonodroidSource);@(_HostRuntime->'$(IntermediatePath)%(OutputDirectory)-Debug\CMakeCache.txt');@(_HostRuntime->'$(IntermediatePath)%(OutputDirectory)-Release\CMakeCache.txt')"
+      Inputs="@(_MonodroidSource);@(_HostRuntime->'$(IntermediatePath)%(OutputDirectory)-Debug\CMakeCache.txt');@(_HostRuntime->'$(IntermediatePath)%(OutputDirectory)-Release\CMakeCache.txt');jni\*.cc;jni\*.h;jni\**\*.c"
       Outputs="@(_HostRuntime->'$(OutputPath)%(OutputDirectory)\libmono-android.debug.%(NativeLibraryExtension)');@(_HostRuntime->'$(OutputPath)%(OutputDirectory)\libmono-android.release.%(NativeLibraryExtension)')">
     <Message Text="Building host runtime %(_HostRuntime.Identity) in $(OutputPath)%(_HostRuntime.OutputDirectory)"/>
     <MakeDir Directories="$(OutputPath)%(_HostRuntime.OutputDirectory)" />

--- a/tests/Xamarin.Forms-Performance-Integration/Droid/Properties/AndroidManifest.xml
+++ b/tests/Xamarin.Forms-Performance-Integration/Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Xamarin.Forms_Performance_Integration">
-	<uses-sdk android:minSdkVersion="15" />
+	<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="26" />
 	<application android:label="Xamarin.Forms.Performance.Integration"></application>
 </manifest>

--- a/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
+++ b/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
@@ -18,6 +18,7 @@
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <AndroidUseAapt2 Condition="'$(AndroidUseAapt2)' == ''">True</AndroidUseAapt2>
     <AndroidDexTool Condition=" '$(AndroidDexTool)' == '' ">d8</AndroidDexTool>
+    <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
   </PropertyGroup>
   <Import Project="..\..\..\Configuration.props" />
   <PropertyGroup>
@@ -40,9 +41,8 @@
     <WarningLevel>4</WarningLevel>
     <AndroidManagedSymbols>true</AndroidManagedSymbols>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
-    <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
     <AndroidLinkTool Condition=" '$(AndroidLinkTool)' == '' ">r8</AndroidLinkTool>
-    <AndroidGenerateJniMarshalMethods>True</AndroidGenerateJniMarshalMethods>
+    <AndroidGenerateJniMarshalMethods Condition=" '$(HostOS)' != 'Linux' ">True</AndroidGenerateJniMarshalMethods>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
The goal of this commit is to make Xamarin.Android apps start faster. The
changes are focused only around the very first stage of application startup -
between Android invoking our Java startup code (MonoPackageManager) and the end
of our `Runtime.init` (`Java_mono_android_Runtime_init` in the native runtime)
which is when the user application is fully initialized and ready to start is
launcher Activity.

In order to achieve the goal, the following changes were made:

 * Java class lookup ("reflection").
   We used to call the `FindClass` JNI function as part of the startup at a cost
   of several milliseconds. We now put the class handles (accessed with the
   `.class` Java accessor) in the `Runtime` class and initialize them from the
   static constructor. We then read those fields from within `Runtime.init`,
   which is passed a reference to the Java instance of the Runtime class.
   Additonally, a handful of class field/method lookups were moved out of the
   init code so that the code that doesn't use them doesn't have to pay the tax.

 * Android API level is passed to `Runtime.init` from Java instead of using JNI
   from the native code.

 * Limit logging.
   Previously whenever any of the `log_{info,debug}` functions were called we'd
   spend time preparing all the parameters to pass to the function, sometimes
   involving memory allocation, function calls, etc - only to discard all of
   that work **inside** the `log_*` call because the logging category used in
   that call was disabled. Now we check whether the category is enabled before
   we set out to construct the parameters.

 * Java/JNI type wrappers for string and array of strings.
   This both a convenience/correctness as well as a performance change.
   Introduced are two C++ wrapper classes for the `jstring` and `object array`
   types (specialized for object == jstring) which take care of efficiently
   caching the retrieved strings as well as of correctly deleting local
   references to the obtained objects. Both classes, `jstring_wrapper` and
   `jstring_array_wrapper` are optimized so that they compile into the
   equivalent of the current, hand-written, code. They also take care to make
   the minimum necessary number of calls in order to access the strings, both
   standalone and from arrays, as well as to release the resources.
   The string and array wrappers are passed around as references, thus using the
   minimum amount of memory.

 * Do not preload managed assemblies.
   We used to preload all of the application assemblies in order to find and
   invoke type initializers. This resulted in the list of assemblies being
   processed twice at the great expense of time. We now don't call the type
   initializers at all and the assemblies are loaded on demand.

 * Do not store application environment variables in a file inside the apk.
   The textual file used to be read from the apk(s) early in the process,
   requiring iteration over all the application apk files, opening each of them,
   browsing through the ZIP entries and, finally, reading the file line by line,
   parsing into the name and value parts to create either a
   property (`mono.aot`, `mono.llvm`) or any environment variables requested by
   the application developer (or the XA runtime).
   To speed the process up, this commit replaces the text file with a Java class
   generated during application build which contains an array of `"name",
   "value"` pairs. The class is passed to `Java_mono_android_Runtime_init` and
   its elements are used to create the requested environment variables. A
   handful of variables is special-cased in that they are not placed in the
   environment but rather to set flags in the `AndroidSystem` class. The
   variables are `mono.aot`, `mono.llvm` and `__XA_DSO_IN_APK`. This allowed to
   remove calls to create (fake) system properties as well as `getenv` in the
   init native function.

 * Don't try load LLVM.so when it won't be there because we're not using llvm

 * Convert package name to hash using optimized code without calling snprintf

 * Desktop build is determined on compile time instead of dynamically

 * xamarin_getifaddrs are initialized on demand, not at the startup.

Startup time improvements for the XF integration test app (average, Pixel 3 XL):

  * Debug mode:
    Old: 1s 440ms
    New: 1s 100ms

  * Release mode:
    Old: 650ms
    New: 270ms