### PR TITLE
[Xamarin.Android.Build.Tasks] _ValidateResourceCache incremental build issue

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2068,6 +2068,7 @@ namespace App1
 					Directory.Delete (embedded, recursive: true);
 				}
 				Assert.IsTrue (builder.Build (proj), "Second Build should have succeeded");
+				Assert.IsFalse (builder.Output.IsTargetSkipped ("_BuildAdditionalResourcesCache"), "`_BuildAdditionalResourcesCache` should not be skipped!");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -492,7 +492,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	>
 		<Output TaskParameter="IsResourceCacheValid" PropertyName="_IsResourceCacheValid" />
 	</ReadAdditionalResourcesFromAssemblyCache>
-	<Delete Files="$(_AndroidResourcePathsCache)" Condition=" '$(_IsResourceCacheValid)' == 'False' " />
+	<Delete Files="$(_AndroidResourcePathsCache);$(_AndroidStampDirectory)_BuildAdditionalResourcesCache.stamp" Condition=" '$(_IsResourceCacheValid)' == 'False' " />
 	<PropertyGroup>
 		<NugetPackagesConfig Condition="Exists('$(MSBuildProjectDirectory)\packages.config')">$(MSBuildProjectDirectory)\packages.config</NugetPackagesConfig>
 	</PropertyGroup>


### PR DESCRIPTION
If the `_ValidateResourceCache` MSBuild target deems the cache file
invalid:

    <Delete Files="$(_AndroidResourcePathsCache)" Condition=" '$(_IsResourceCacheValid)' == 'False' " />

The problem is that the `_BuildAdditionalResourcesCache` will be
skipped!

    <Target Name="_BuildAdditionalResourcesCache"
        Inputs="@(ReferencePath);@(ReferenceDependencyPaths);$(MSBuildProjectFullPath);$(NugetPackagesConfig);$(_AndroidBuildPropertiesCache)"
        Outputs="$(_AndroidStampDirectory)_BuildAdditionalResourcesCache.stamp"

In eca09c89, I fixed a problem with `_BuildAdditionalResourcesCache`
running on every build by introducing a stamp file.

Since the `Outputs` are now the stamp file, we need to *also* delete
the stamp file when `'$(_IsResourceCacheValid)' == 'False'`. We had a
test checking this exact problem, but it wasn't verifying that
`_BuildAdditionalResourcesCache` wasn't skipped.