### PR TITLE
[monodroid] Use right calling convention on Windows

### DIFF
--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -205,6 +205,10 @@ if (ENABLE_TIMING)
   add_definitions("-DMONODROID_TIMING=1")
 endif()
 
+if (WIN32)
+  include_directories(BEFORE "jni/win32")
+endif()
+
 add_definitions("-DHAVE_CONFIG_H")
 add_definitions("-D_REENTRANT")
 add_definitions("-DDYLIB_MONO")

--- a/src/monodroid/jni/win32/jni_md.h
+++ b/src/monodroid/jni/win32/jni_md.h
@@ -1,0 +1,12 @@
+#ifndef __MONODROID_WIN32_JNI_MD_H__
+#define __MONODROID_WIN32_JNI_MD_H__
+
+#define JNICALL __stdcall
+#define JNIEXPORT __declspec(dllexport)
+#define JNIIMPORT __declspec(dllimport)
+
+typedef signed char jbyte;
+typedef __int32     jint;
+typedef __int64     jlong;
+
+#endif


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/issues/403

Make sure we use `__stdcall` when crosscompiling for mxe/win.

This allows us to crosscompile for Windows without installing Java SDK
for Windows.

The include path is put BEFORE other includes, so that the `jni_md.h`
is found before the one in Mac JDK, in `darwin` SDK subdirectory (like
`/Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home/include/darwin`).