### PR TITLE
[Xamarin.Android.Build.Tasks] Fix a weird error with `_CopyPackage`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2866,16 +2866,17 @@ because xbuild doesn't support framework reference assemblies.
   </BuildApk>
 </Target>
 
-<PropertyGroup>
-	<_CopyPackageInputs>
-		$(MSBuildAllProjects)
-		;@(ReferencePath)
-		;@(ReferenceDependencyPaths)
-		;$(ApkFileIntermediate)
-		;$(_AndroidBuildPropertiesCache)
-		;@(ApkFiles)
-	</_CopyPackageInputs>
-</PropertyGroup>
+<Target Name="_ResolveCopyPackageInputs">
+	<PropertyGroup>
+		<_CopyPackageInputs>
+			;@(ReferencePath)
+			;@(ReferenceDependencyPaths)
+			;$(ApkFileIntermediate)
+			;$(_AndroidBuildPropertiesCache)
+			;@(ApkFiles)
+		</_CopyPackageInputs>
+	</PropertyGroup>
+</Target>
 
 <Target Name="_DefineBuildTargetAbis" DependsOnTargets="$(_BeforeDefineBuildTargetAbis)">
 	<CreateProperty Value="$(AndroidSupportedAbis)" Condition="'$(_BuildTargetAbis)' == ''">
@@ -2888,6 +2889,7 @@ because xbuild doesn't support framework reference assemblies.
 	<_CopyPackageDependsOn>
 		_DefineBuildTargetAbis
 		;_BuildApkEmbed
+		;_ResolveCopyPackageInputs
 	</_CopyPackageDependsOn>
 </PropertyGroup>
 


### PR DESCRIPTION
We had an issue where the `_CopyPackageInputs` was occasionally
NOT including a changed apk! It was really weird.

So lets rework this to define the `_CopyPackageInputs`
Property within a Target. This should allow it to pick
up and dynamically added Items.