### PR TITLE
[build] api-xml-adjuster needs TFV 4.6.1 on Windows

### DIFF
--- a/build-tools/api-xml-adjuster/api-xml-adjuster.csproj
+++ b/build-tools/api-xml-adjuster/api-xml-adjuster.csproj
@@ -7,7 +7,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Xamarin.Android.Tools</RootNamespace>
     <AssemblyName>api-xml-adjuster</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
Since c93a8af changed some projects to netstandard 2.0, we also need
this project to be 4.6.1:

    Microsoft.Common.CurrentVersion.targets(2110,5): Warning MSB3274: The primary reference "E:\A\_work\34\s\external\Java.Interop\bin\Debug\Xamarin.Android.Tools.ApiXmlAdjuster.dll" could not be resolved because it was built against the ".NETFramework,Version=v4.6.1" framework. This is a higher version than the currently targeted framework ".NETFramework,Version=v4.5".

Which causes the error:

    build-tools\api-xml-adjuster\Program.cs(12,18): Error CS0246: The type or namespace name 'JavaApi' could not be found (are you missing a using directive or an assembly reference?)

This doesn't seem to be a problem on Mono, just .NET framework.