### PR TITLE
[xa-prep-tasks] "stream" http requests

### DIFF
--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/DownloadUri.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/DownloadUri.cs
@@ -79,7 +79,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks {
 
 			Log.LogMessage (MessageImportance.Normal, $"Downloading `{uri}` to `{tempPath}`.");
 			try {
-				using (var r = await client.GetAsync (uri, source.Token)) {
+				using (var r = await client.GetAsync (uri, HttpCompletionOption.ResponseHeadersRead, source.Token)) {
 					r.EnsureSuccessStatusCode ();
 					using (var s = await r.Content.ReadAsStreamAsync ())
 					using (var o = File.OpenWrite (tempPath)) {


### PR DESCRIPTION
Context: http://build.devdiv.io/2271113
Context: http://www.tugberkugurlu.com/archive/efficiently-streaming-large-http-responses-with-httpclient

We are still getting random OOM errors on Windows/VSTS:

    android-toolchain.targets(52,5): Error : Unable to download URL `https://dl.google.com/android/repository/android-ndk-r14b-windows-x86_64.zip` to `C:\Users\dlab14\android-archives\android-ndk-r14b-windows-x86_64.zip`: Exception of type 'System.OutOfMemoryException' was thrown.

It turns out that if you don't specify
`HttpCompletionOption.ResponseHeadersRead`, then the entire request
body is buffered into a `MemoryStream`! This setting is what signals
the `HttpClient` to *NOT* buffer anything, so you can stream the file
to disk.

Since several of our Android SDK/NDK files are ~500MB, we could
definitely hit OOM when running several downloads in parallel.