### PR TITLE
[build-status] Archive the tests logcat output

### DIFF
--- a/build-tools/scripts/Packaging.mk
+++ b/build-tools/scripts/Packaging.mk
@@ -73,7 +73,8 @@ _BUILD_STATUS_BUNDLE_INCLUDE = \
 	$(shell find . -name 'CMakeCache.txt') \
 	$(shell find . -name 'config.h') \
 	$(shell find . -name '.ninja_log') \
-	$(shell find . -name 'android-*.config.cache')
+	$(shell find . -name 'android-*.config.cache') \
+	$(wildcard tests/logcat-$(CONFIGURATION)-*.txt)
 
 _BUILD_STATUS_BASENAME   = xa-build-status-v$(PRODUCT_VERSION).$(-num-commits-since-version-change)_$(OS_NAME)-$(OS_ARCH)_$(GIT_BRANCH)_$(GIT_COMMIT)-$(CONFIGURATION)
 _BUILD_STATUS_ZIP_OUTPUT = $(_BUILD_STATUS_BASENAME).$(ZIP_EXTENSION)


### PR DESCRIPTION
It is useful to have the logcat output in case one wants to analyze
tests run, even when the test didn't fail