### PR TITLE
[tests] Run tests in parallel

### DIFF
--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -21,9 +21,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "remap-assembly-ref", "build
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core", "Core", "{04E3E11E-B47D-4599-8AFC-50515A95E715}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Java.Interop", "external\Java.Interop\src\Java.Interop\Java.Interop.csproj", "{94BD81F7-B06F-4295-9636-F8A3B6BDC762}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Java.Interop", "external\Java.Interop\src\Java.Interop\Java.Interop.csproj", "{94BD81F7-B06F-4295-9636-F8A3B6BDC762}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Java.Interop.Export", "external\Java.Interop\src\Java.Interop.Export\Java.Interop.Export.csproj", "{B501D075-6183-4E1D-92C9-F7B5002475B1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Java.Interop.Export", "external\Java.Interop\src\Java.Interop.Export\Java.Interop.Export.csproj", "{B501D075-6183-4E1D-92C9-F7B5002475B1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "generator", "external\Java.Interop\tools\generator\generator.csproj", "{D14A1B5C-2060-4930-92BE-F7190256C735}"
 EndProject
@@ -41,7 +41,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{864062D3
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "jcw-gen", "external\Java.Interop\tools\jcw-gen\jcw-gen.csproj", "{52C7D9B6-E8C8-47D0-9471-652D278D7D77}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "jnimarshalmethod-gen", "external\Java.Interop\tools\jnimarshalmethod-gen\Xamarin.Android.Tools.JniMarshalMethodGenerator.csproj", "{D1295A8F-4F42-461D-A046-564476C10002}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Android.Tools.JniMarshalMethodGenerator", "external\Java.Interop\tools\jnimarshalmethod-gen\Xamarin.Android.Tools.JniMarshalMethodGenerator.csproj", "{D1295A8F-4F42-461D-A046-564476C10002}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Java.Interop.Tools.JavaCallableWrappers", "external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers.csproj", "{D18FCF91-8876-48A0-A693-2DC1E7D3D80A}"
 EndProject
@@ -131,7 +131,14 @@ Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems*{3f1f2f50-af1a-4a5a-bedb-193372f068d7}*SharedItemsImports = 4
 		src\Xamarin.Android.Build.Tasks\Tests\Xamarin.Android.Build.Tests\Xamarin.Android.Build.Tests.Shared.projitems*{53e4abf0-1085-45f9-b964-dcae4b819998}*SharedItemsImports = 4
+		src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems*{66cf299a-ce95-4131-bcd8-db66e30c4bf7}*SharedItemsImports = 4
+		src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems*{74598f5c-b8cc-4ce6-8ee2-ab9ca1400076}*SharedItemsImports = 13
 		src\Xamarin.Android.Build.Tasks\Tests\Xamarin.Android.Build.Tests\Xamarin.Android.Build.Tests.Shared.projitems*{bd1d66bf-5ac7-4926-8ebe-b2198a112eb0}*SharedItemsImports = 13
+		external\Java.Interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems*{d1295a8f-4f42-461d-a046-564476c10002}*SharedItemsImports = 4
+		external\Java.Interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems*{d18fcf91-8876-48a0-a693-2dc1e7d3d80a}*SharedItemsImports = 4
+		external\Java.Interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems*{e0890301-f75f-40e7-b008-54c28b3ba542}*SharedItemsImports = 4
+		external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems*{e0890301-f75f-40e7-b008-54c28b3ba542}*SharedItemsImports = 4
+		external\Java.Interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems*{fe789f04-5e95-42c5-aef1-e33f8df06b3f}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|AnyCPU = Debug|AnyCPU
@@ -170,6 +177,10 @@ Global
 		{94BD81F7-B06F-4295-9636-F8A3B6BDC762}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{94BD81F7-B06F-4295-9636-F8A3B6BDC762}.Release|AnyCPU.ActiveCfg = Release|Any CPU
 		{94BD81F7-B06F-4295-9636-F8A3B6BDC762}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{B501D075-6183-4E1D-92C9-F7B5002475B1}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{B501D075-6183-4E1D-92C9-F7B5002475B1}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{B501D075-6183-4E1D-92C9-F7B5002475B1}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{B501D075-6183-4E1D-92C9-F7B5002475B1}.Release|AnyCPU.Build.0 = Release|Any CPU
 		{D14A1B5C-2060-4930-92BE-F7190256C735}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
 		{D14A1B5C-2060-4930-92BE-F7190256C735}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{D14A1B5C-2060-4930-92BE-F7190256C735}.Release|AnyCPU.ActiveCfg = Release|Any CPU
@@ -342,22 +353,18 @@ Global
 		{1E5501E8-49C1-4659-838D-CC9720C5208F}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{1E5501E8-49C1-4659-838D-CC9720C5208F}.Release|AnyCPU.ActiveCfg = Release|Any CPU
 		{1E5501E8-49C1-4659-838D-CC9720C5208F}.Release|AnyCPU.Build.0 = Release|Any CPU
-		{D93CAC27-3893-42A3-99F1-2BCA72E186F4}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
-		{D93CAC27-3893-42A3-99F1-2BCA72E186F4}.Debug|AnyCPU.Build.0 = Debug|Any CPU
-		{D93CAC27-3893-42A3-99F1-2BCA72E186F4}.Release|AnyCPU.ActiveCfg = Release|Any CPU
-		{D93CAC27-3893-42A3-99F1-2BCA72E186F4}.Release|AnyCPU.Build.0 = Release|Any CPU
-		{B501D075-6183-4E1D-92C9-F7B5002475B1}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
-		{B501D075-6183-4E1D-92C9-F7B5002475B1}.Debug|AnyCPU.Build.0 = Debug|Any CPU
-		{B501D075-6183-4E1D-92C9-F7B5002475B1}.Release|AnyCPU.ActiveCfg = Release|Any CPU
-		{B501D075-6183-4E1D-92C9-F7B5002475B1}.Release|AnyCPU.Build.0 = Release|Any CPU
-		{1DA0CB12-5508-4E83-A242-0C8D6D99A49B}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
-		{1DA0CB12-5508-4E83-A242-0C8D6D99A49B}.Debug|AnyCPU.Build.0 = Debug|Any CPU
-		{1DA0CB12-5508-4E83-A242-0C8D6D99A49B}.Release|AnyCPU.ActiveCfg = Release|Any CPU
-		{1DA0CB12-5508-4E83-A242-0C8D6D99A49B}.Release|AnyCPU.Build.0 = Release|Any CPU
 		{1BAFA0CC-0377-46CE-AB7B-7BB2E7B62F63}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
 		{1BAFA0CC-0377-46CE-AB7B-7BB2E7B62F63}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{1BAFA0CC-0377-46CE-AB7B-7BB2E7B62F63}.Release|AnyCPU.ActiveCfg = Release|Any CPU
 		{1BAFA0CC-0377-46CE-AB7B-7BB2E7B62F63}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{D93CAC27-3893-42A3-99F1-2BCA72E186F4}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{D93CAC27-3893-42A3-99F1-2BCA72E186F4}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{D93CAC27-3893-42A3-99F1-2BCA72E186F4}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{D93CAC27-3893-42A3-99F1-2BCA72E186F4}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{1DA0CB12-5508-4E83-A242-0C8D6D99A49B}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{1DA0CB12-5508-4E83-A242-0C8D6D99A49B}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{1DA0CB12-5508-4E83-A242-0C8D6D99A49B}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{1DA0CB12-5508-4E83-A242-0C8D6D99A49B}.Release|AnyCPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -370,7 +377,6 @@ Global
 		{AFB8F6D1-6EA9-42C3-950B-98F34C669AD2} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 		{3FC3E78B-F7D4-42EA-BBE8-4535DF42BFF8} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 		{C876DA71-8573-4CEF-9149-716D72455ED4} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
-		{2C1C68CD-CFED-4DEB-A2D3-61D6932F3E8E} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 		{94BD81F7-B06F-4295-9636-F8A3B6BDC762} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{D14A1B5C-2060-4930-92BE-F7190256C735} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{FE789F04-5E95-42C5-AEF1-E33F8DF06B3F} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
@@ -399,6 +405,7 @@ Global
 		{E248B2CA-303B-4645-ADDC-9D4459D550FD} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{C9FF2E4D-D927-479E-838B-647C16763F64} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{0DE278D6-000F-4001-BB98-187C0AF58A61} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
+		{2C1C68CD-CFED-4DEB-A2D3-61D6932F3E8E} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 		{1640725C-4DB8-4D8D-BC96-74E688A06EEF} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 		{7CE69551-BD73-4726-ACAA-AAF89C84BAF8} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 		{15945D4B-FF56-4BCC-B598-2718D199DD08} = {864062D3-A415-4A6F-9324-5820237BA058}

--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -5,6 +5,7 @@
     <_TopDir>$(MSBuildThisFileDirectory)..\..</_TopDir>
   </PropertyGroup>
   <Import Project="$(_TopDir)\Configuration.props" />
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.RunParallelTargets" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.SetEnvironmentVariable" />
   <PropertyGroup>
     <_Runtime Condition=" '$(HostOS)' != 'Windows' ">$(ManagedRuntime)</_Runtime>
@@ -154,38 +155,13 @@
     <_RunTestTarget Include="RunPerformanceTests" />
   </ItemGroup>
   <Target Name="RunAllTests">
-    <MSBuild
-        Condition=" '$(HostOS)' == 'Windows' "
+    <RunParallelTargets
         ContinueOnError="ErrorAndContinue"
-        Projects="$(MSBuildThisFileDirectory)RunTests.targets"
-        RunEachTargetSeparately="True"
+        Configuration="$(Configuration)"
+        MSBuildBinaryLogParameterPrefix="$(_XABinLogPrefix)"
+        MSBuildBinPath="$(MSBuildBinPath)"
+        ProjectFile="$(MSBuildThisFileDirectory)RunTests.targets"
         Targets="@(_RunParallelTestTarget)"
-    />
-    <ItemGroup Condition=" '$(USE_MSBUILD)' == '1' ">
-      <_RunParallelTestTarget>
-        <_BinLog>$(_XABinLogPrefix)-$([System.DateTime]::Now.ToString ("yyyyMMddTHHmmss"))-Target-%(Identity).binlog"</_BinLog>
-      </_RunParallelTestTarget>
-    </ItemGroup>
-    <ItemGroup>
-      <_Commands Include="@(_RunParallelTestTarget->'echo Executing in background: msbuild $(MSBuildThisFileDirectory)RunTests.targets %(_BinLog) /t:%(Identity)')" />
-      <_Commands Include="@(_RunParallelTestTarget->'msbuild $(MSBuildThisFileDirectory)RunTests.targets %(_BinLog) /t:%(Identity) &amp;')" />
-      <_Commands Include="wait" />
-      <_Commands Include="exit 0" />
-    </ItemGroup>
-    <PropertyGroup>
-      <_ParallelTargets>$(MSBuildThisFileDirectory)..\..\bin\Test$(Configuration)\parallel-targets.sh</_ParallelTargets>
-    </PropertyGroup>
-    <WriteLinesToFile
-        File="$(_ParallelTargets)"
-        Lines="@(_Commands)"
-        Overwrite="True"
-    />
-    <Exec
-        Condition=" '$(HostOS)' != 'Windows' "
-        ContinueOnError="ErrorAndContinue"
-        IgnoreStandardErrorWarningFormat="true"
-        WorkingDirectory="$(_TopDir)"
-        Command="bash &quot;$(_ParallelTargets)&quot;"
     />
     <MSBuild
          ContinueOnError="ErrorAndContinue"

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/RunParallelTargets.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/RunParallelTargets.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.BuildTools.PrepTasks.Xamarin.Android.BuildTools.PrepTasks
+{
+	public class RunParallelTargets : Task
+	{
+		[Required]
+		public ITaskItem        ProjectFile                             {get; set;}
+
+		public string           Configuration                           {get; set;}
+
+		public string           MSBuildBinPath                          {get; set;}
+
+		public string           MSBuildBinaryLogParameterPrefix         {get; set;}
+
+		public ITaskItem[]      Targets                                 {get; set;}
+
+		public override bool Execute ()
+		{
+			if (Targets?.Length == 0)
+				return true;
+
+			var processes = new Process [Targets.Length];
+			for (int i = 0; i < Targets.Length; ++i) {
+				processes[i]  = CreateProcess (Targets[i].ItemSpec);
+			}
+
+			bool success  = true;
+			for (int i = 0; i < processes.Length; ++i) {
+				processes[i].WaitForExit ();
+				if (processes[i].ExitCode != 0) {
+					Log.LogError ($"Execution of target {Targets [i].ItemSpec} exited with code {processes [i].ExitCode}.");
+					success = false;
+				}
+			}
+			return success;
+		}
+
+		Process CreateProcess (string target)
+		{
+			var binlogOption  = "";
+			if (!string.IsNullOrEmpty (MSBuildBinaryLogParameterPrefix)) {
+				var date  = DateTime.Now.ToString ("yyyyMMddTHHmmss");
+				// -$([System.DateTime]::Now.ToString ("yyyyMMddTHHmmss"))-Target-%(Identity).binlog
+				binlogOption = $"{MSBuildBinaryLogParameterPrefix}-{date}-Target-{target}.binlog\"";
+			}
+			var config      = string.IsNullOrEmpty (Configuration) ? "" : $"/p:Configuration={Configuration}";
+			var command     = $"{config} \"{ProjectFile.ItemSpec}\" {binlogOption} /t:{target}";
+			var msbuild     = (string.IsNullOrEmpty (MSBuildBinPath) || Path.DirectorySeparatorChar == '/')
+				? "msbuild"
+				: Path.Combine (MSBuildBinPath, "msbuild");
+			var parameters  = new ProcessStartInfo (msbuild, command) {
+				CreateNoWindow    = true,
+				UseShellExecute   = false,
+				WindowStyle       = ProcessWindowStyle.Hidden,
+			};
+			var process     = Process.Start (parameters);
+			return process;
+		}
+	}
+}

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\GitBlame.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\GitCommitsInRange.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\ReplaceFileContents.cs" />
+    <Compile Include="Xamarin.Android.BuildTools.PrepTasks\RunParallelTargets.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\PrepareInstall.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\AcceptAndroidSdkLicenses.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\Sleep.cs" />


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/1331/
Context: https://github.com/xamarin/xamarin-android/issues/2397
Context: 5eae6e55190e3c30d3844c92d557128f872caa22

Commit 91a39725 updated `make run-all-tests` so that certain MSBuild
unit test targets would be run in parallel, but had two flaws:

 1. It only worked on non-Windows platforms.
 2. It ignored many errors.

Commit 91a39725 only worked on non-Windows platforms because it worked
by generating a **bash**(1)-compatible shell script which
*backgrounded* the target invocations.  Errors were ignored because
the generated script always exited with an error code of 0:

        msbuild RunTests.targets /t:RunNUnitTests &
        msbuild RunTests.targets /t:RunApkTests &
        # ...
        exit 0

Such a script won't easily run on Windows, and the `msbuild` exit
codes were ignored because I couldn't think of a good and "reasonable"
way to capture them.  (To be fair, Google/StackOverflow/etc. did show
various ways to capture the exit codes for backgrounded pipelines.
I considered them all to be largely *unreadable*.)

Additionally, I didn't think that this would necessarily be a problem:
if a unit test failed, it should report the failure in one of the
NUnit `.xml` files -- largely so that we wouldn't need to read the
Jenkins Console Output to see what the *actual* error was! -- and thus
ignoring the exit status shouldn't be a problem.

Turns Out...that's wrong.  We have observed builds which are "green"
-- no errors! -- but in which there *were* failures, and the failures
weren't reported *because* the `parallel-targets.sh` script didn't
report that anything was wrong!

Consider issue #2397: we want to *ensure* that timing collection
works, so that we can reliably update our [Tests times page][0].

For example, commit 5eae6e55 added a check so that we would error out
if the required file didn't exist.

The problem is, the file doesn't exist:

        error : Input file 'logcat-Release-Bundle-Mono.Android_TestsMultiDex.txt' doesn't exist.

Yet the build is green!

The reason *why* the build is green is because the `RunApkTests`
target is executed by `parallel-targets.sh`, and since
`parallel-targets.sh` was "ignoring" all errors because of it's
`exit 0`, the error that commit 5eae6e55 attempted to insert was
*still* ignored.

Doh!

Fix both issues: since sanely capturing background process exit codes
is not "reasonably easy" to do in **bash**(1), *Don't Use Bash*.
Instead, introduce a new `<RunParallelTargets/>` task which uses
`System.Diagnostics.Process` to run the targets in the background,
then (sanely) wait for them to complete and perform any necessary
error checking.

This has the added benefit that it *also* now works on Windows.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/plot/Tests%20times/