### PR TITLE
[tests] mark flaky tests NonParallelizable

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -316,6 +316,7 @@ using System.Runtime.CompilerServices;
 		}
 
 		[Test]
+		[NonParallelizable]
 		/// <summary>
 		/// Based on https://bugzilla.xamarin.com/show_bug.cgi?id=29263
 		/// </summary>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -264,6 +264,7 @@ using System.Runtime.CompilerServices;
 		}
 
 		[Test]
+		[NonParallelizable]
 		public void Check9PatchFilesAreProcessed ([Values(false, true)] bool explicitCrunch)
 		{
 			var projectPath = string.Format ("temp/Check9PatchFilesAreProcessed_{0}", explicitCrunch.ToString ());
@@ -1416,6 +1417,7 @@ namespace UnnamedProject
 
 		// https://github.com/xamarin/xamarin-android/issues/2205
 		[Test]
+		[NonParallelizable]
 		public void Issue2205 ([Values (false, true)] bool useAapt2)
 		{
 			var proj = new XamarinAndroidApplicationProject ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -57,6 +57,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[NonParallelizable]
 		public void SkipConvertResourcesCases ([Values (false, true)] bool useAapt2)
 		{
 			var target = "ConvertResourcesCases";
@@ -341,6 +342,7 @@ namespace UnamedProject
 		}
 
 		[Test]
+		[NonParallelizable]
 		public void CheckTimestamps ([Values (true, false)] bool isRelease)
 		{
 			var start = DateTime.UtcNow.AddSeconds (-1);
@@ -1786,6 +1788,7 @@ namespace App1
 		}
 
 		[Test]
+		[NonParallelizable]
 		public void BuildWithNativeLibraries ([Values (true, false)] bool isRelease)
 		{
 			var dll = new XamarinAndroidLibraryProject () {


### PR DESCRIPTION
Context: http://build.devdiv.io/2279876&view=ms.vss-test-web.test-result-details

There are about 5 tests that seem to fail a lot on new build machines.

The errors are generally related to file sharing:

    The last access/last write time on file "C:\Users\dlab14\.nuget\packages\xamarin.forms\3.1.0.697729\lib\MonoAndroid10\FormsViewGroup.dll.mdb" cannot be set.
    Access to the path 'C:\Users\dlab14\.nuget\packages\xamarin.forms\3.1.0.697729\lib\MonoAndroid10\FormsViewGroup.dll.mdb' is denied.

Or another example:

    C:\Users\dlab14\.nuget\packages\xamarin.build.download\0.4.9\build\Xamarin.Build.Download.targets(114,3): The process cannot access the file 'C:\Users\dlab14\.nuget\packages\xamarin.googleplayservices.gcm\60.1142.1\lib\MonoAndroid80\Xamarin.GooglePlayServices.Gcm.dll' because it is being used by another process.
        at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
        at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
        at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share)
        at Mono.Cecil.ModuleDefinition.GetFileStream(String fileName, FileMode mode, FileAccess access, FileShare share)
        at Mono.Cecil.ModuleDefinition.Write(String fileName, WriterParameters parameters)
        at Xamarin.Build.Download.BaseXamarinBuildResourceRestore.MergeResources(IAssemblyResolver resolver, String originalAsmPath, String mergedAsmPath, String assemblyName, List`1 resourceItems) [E:\A\_work\165\s\bin\TestDebug\temp\Issue2205False\UnnamedProject.csproj]

To solve this problem, I've went through various failing builds and
marked flaky tests `[NonParallelizable]`. I am hoping this will
improve the reliability of these tests.