### PR TITLE
[Xamarin.Android.Build.Tasks] handle missing AndroidSdkPath better

### DIFF
--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -17,12 +17,13 @@
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\xa-prep-tasks\xa-prep-tasks.csproj" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\download-bundle\download-bundle.csproj" />
     <Exec Command="$(_NuGet) restore Xamarin.Android.sln" WorkingDirectory="$(_TopDir)" />
-    <Exec Command="$(_NuGet) restore Xamarin.Android-Tests.sln" WorkingDirectory="$(_TopDir)" />
     <Exec Command="$(_NuGet) restore external\Java.Interop\Java.Interop.sln" WorkingDirectory="$(_TopDir)" />
     <Exec Command="$(_NuGet) restore external\LibZipSharp\libZipSharp.sln" WorkingDirectory="$(_TopDir)" />
     <Exec Command="$(_NuGet) restore external\xamarin-android-tools\Xamarin.Android.Tools.sln" WorkingDirectory="$(_TopDir)" />
     <MSBuild Projects="tests\Xamarin.Forms-Performance-Integration\Xamarin.Forms.Performance.Integration.csproj" Targets="Restore" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\android-toolchain\android-toolchain.csproj" />
+    <!--NOTE: need to restore test sln *after* android-toolchain has the Android SDK in place-->
+    <Exec Command="$(_NuGet) restore Xamarin.Android-Tests.sln" WorkingDirectory="$(_TopDir)" />
     <JdkInfo
         AndroidSdkPath="$(AndroidSdkDirectory)"
         AndroidNdkPath="$(AndroidNdkDirectory)"

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
@@ -326,18 +326,20 @@ namespace Xamarin.Android.Tasks
 
 		int GetMaxInstalledApiLevel ()
 		{
-			string platformsDir = Path.Combine (AndroidSdkPath, "platforms");
-			var apiIds = Directory.EnumerateDirectories (platformsDir)
-				.Select (platformDir => Path.GetFileName (platformDir))
-				.Where (dir => dir.StartsWith ("android-", StringComparison.OrdinalIgnoreCase))
-				.Select (dir => dir.Substring ("android-".Length))
-				.Select (apiName => MonoAndroidHelper.SupportedVersions.GetIdFromApiLevel (apiName));
 			int maxApiLevel = int.MinValue;
-			foreach (var id in apiIds) {
-				int? v = MonoAndroidHelper.SupportedVersions.GetApiLevelFromId (id);
-				if (!v.HasValue)
-					continue;
-				maxApiLevel = Math.Max (maxApiLevel, v.Value);
+			string platformsDir = Path.Combine (AndroidSdkPath, "platforms");
+			if (Directory.Exists (platformsDir)) {
+				var apiIds = Directory.EnumerateDirectories (platformsDir)
+					.Select (platformDir => Path.GetFileName (platformDir))
+					.Where (dir => dir.StartsWith ("android-", StringComparison.OrdinalIgnoreCase))
+					.Select (dir => dir.Substring ("android-".Length))
+					.Select (apiName => MonoAndroidHelper.SupportedVersions.GetIdFromApiLevel (apiName));
+				foreach (var id in apiIds) {
+					int? v = MonoAndroidHelper.SupportedVersions.GetApiLevelFromId (id);
+					if (!v.HasValue)
+						continue;
+					maxApiLevel = Math.Max (maxApiLevel, v.Value);
+				}
 			}
 			if (maxApiLevel < 0)
 				Log.LogCodedError ("XA5300",


### PR DESCRIPTION
Context: http://build.devdiv.io/2288139

A build on VSTS hit the error:

    Error MSB4018: The "ResolveAndroidTooling" task failed unexpectedly. [E:\A\_work\165\s\tests\TestRunner.Core\TestRunner.Core.csproj]
    Error MSB4018: System.IO.DirectoryNotFoundException: Could not find a part of the path 'C:\Users\dlab14\android-toolchain\sdk\platforms'. [E:\A\_work\165\s\tests\TestRunner.Core\TestRunner.Core.csproj]
    Error MSB4018: at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath) [E:\A\_work\165\s\tests\TestRunner.Core\TestRunner.Core.csproj]
    Error MSB4018: at System.IO.FileSystemEnumerableIterator`1.CommonInit() [E:\A\_work\165\s\tests\TestRunner.Core\TestRunner.Core.csproj]
    Error MSB4018: at System.IO.FileSystemEnumerableIterator`1..ctor(String path, String originalUserPath, String searchPattern, SearchOption searchOption, SearchResultHandler`1 resultHandler, Boolean checkHost) [E:\A\_work\165\s\tests\TestRunner.Core\TestRunner.Core.csproj]
    Error MSB4018: at System.IO.Directory.EnumerateDirectories(String path) [E:\A\_work\165\s\tests\TestRunner.Core\TestRunner.Core.csproj]
    Error MSB4018: at Xamarin.Android.Tasks.ResolveAndroidTooling.GetMaxInstalledApiLevel() [E:\A\_work\165\s\tests\TestRunner.Core\TestRunner.Core.csproj]
    Error MSB4018: at Xamarin.Android.Tasks.ResolveAndroidTooling.ValidateApiLevels() [E:\A\_work\165\s\tests\TestRunner.Core\TestRunner.Core.csproj]
    Error MSB4018: at Xamarin.Android.Tasks.ResolveAndroidTooling.Execute() [E:\A\_work\165\s\tests\TestRunner.Core\TestRunner.Core.csproj]
    Error MSB4018: at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute() [E:\A\_work\165\s\tests\TestRunner.Core\TestRunner.Core.csproj]
    Error MSB4018: at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext() [E:\A\_work\165\s\tests\TestRunner.Core\TestRunner.Core.csproj]

Reviewing the stack trace, it looks like we are calling
`Directory.EnumerateDirectories` without checking `Directory.Exists`.

With this change, we should fail with a proper error code.

### So what caused this? ###

It appears that when you run this on a clean Windows machine (no
Android SDK):

    msbuild Xamarin.Android.sln /t:Prepare

This call fails in `PrepareWindows.targets`:

    <Exec Command="$(_NuGet) restore Xamarin.Android-Tests.sln" WorkingDirectory="$(_TopDir)" />

NuGet is using the system's Xamarin.Android MSBuild targets, and they
are failing on this error.

What we should do, is run this NuGet restore after
`android-toolchain.csproj` has been built. I am not sure how this was
working prior to VS 15.9.