### PR TITLE
[Xamarin.Android.Build.Tasks] Fix Aar directory resolution. (#2424)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -331,10 +331,7 @@ namespace Xamarin.Android.Tasks
 				var stamp = new FileInfo (Path.Combine (outdir.FullName, Path.GetFileNameWithoutExtension (aarFile.ItemSpec) + ".stamp"));
 				if (stamp.Exists && stamp.LastWriteTimeUtc > new FileInfo (aarFile.ItemSpec).LastWriteTimeUtc) {
 					if (Directory.Exists (resDir))
-						resolvedResourceDirectories.Add (new TaskItem (resDir, new Dictionary<string, string> {
-							{ OriginalFile, Path.GetFullPath (aarFile.ItemSpec) },
-							{ SkipAndroidResourceProcessing, "True" },
-						}));
+						resolvedResourceDirectories.Add (resDir);
 					if (Directory.Exists (assetsDir))
 						resolvedAssetDirectories.Add (assetsDir);
 					continue;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -329,8 +329,16 @@ namespace Xamarin.Android.Tasks
 				string assetsDir = Path.Combine (importsDir, "assets");
 
 				var stamp = new FileInfo (Path.Combine (outdir.FullName, Path.GetFileNameWithoutExtension (aarFile.ItemSpec) + ".stamp"));
-				if (stamp.Exists && stamp.LastWriteTimeUtc > new FileInfo (aarFile.ItemSpec).LastWriteTimeUtc)
+				if (stamp.Exists && stamp.LastWriteTimeUtc > new FileInfo (aarFile.ItemSpec).LastWriteTimeUtc) {
+					if (Directory.Exists (resDir))
+						resolvedResourceDirectories.Add (new TaskItem (resDir, new Dictionary<string, string> {
+							{ OriginalFile, Path.GetFullPath (aarFile.ItemSpec) },
+							{ SkipAndroidResourceProcessing, "True" },
+						}));
+					if (Directory.Exists (assetsDir))
+						resolvedAssetDirectories.Add (assetsDir);
 					continue;
+				}
 				// temporarily extracted directory will look like:
 				// _lp_/[aarFile]
 				using (var zip = MonoAndroidHelper.ReadZipFile (aarFile.ItemSpec)) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1904,7 +1904,9 @@ namespace App1
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestName), false, false)) {
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
 				var assemblyMap = builder.Output.GetIntermediaryPath (Path.Combine ("lp", "map.cache"));
+				var cache = builder.Output.GetIntermediaryPath ("libraryprojectimports.cache");
 				Assert.IsTrue (File.Exists (assemblyMap), $"{assemblyMap} should exist.");
+				Assert.IsTrue (File.Exists (cache), $"{cache} should exist.");
 				var assemblyIdentityMap = new List<string> ();
 				foreach (var s in File.ReadLines (assemblyMap)) {
 					assemblyIdentityMap.Add (s);
@@ -1915,10 +1917,18 @@ namespace App1
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
 				Assert.IsTrue (builder.Output.IsTargetSkipped ("_ResolveLibraryProjectImports"),
 					"_ResolveLibraryProjectImports should not have run.");
+
+				var doc = XDocument.Load (cache);
+				var expectedCount = doc.Elements ("Paths").Elements ("ResolvedResourceDirectories").Count ();
+
 				aar.Timestamp = DateTime.UtcNow.Add (TimeSpan.FromMinutes (2));
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
 				Assert.IsFalse (builder.Output.IsTargetSkipped ("_ResolveLibraryProjectImports"),
 					"_ResolveLibraryProjectImports should have run.");
+
+				doc = XDocument.Load (cache);
+				var count = doc.Elements ("Paths").Elements ("ResolvedResourceDirectories").Count ();
+				Assert.AreEqual (expectedCount, count, "The same number of resource directories should have been resolved.");
 
 			}
 		}


### PR DESCRIPTION
* [Xamarin.Android.Build.Tasks] Fix Aar directory resolution.

Fixed #2408

As part of the speed up process when extracting resources
from assemblies and Aar files, we dont re-extract if
the stamp file is newer than the assembly.

The problem with that was in the case of Aar files we
were NOT adding the `res` or `asset` directories to
the list of resolved directories when we skipped extraction.
As a result we got less `res` directories on a second
build.

This commit fixes that.

* Add Unit Test

* Fix Compile Error