### PR TITLE
[tests] Allow running only selected apk tests

### DIFF
--- a/Documentation/building/unix-instructions.md
+++ b/Documentation/building/unix-instructions.md
@@ -109,6 +109,17 @@ or via
 
 ## Running Individual `.apk` Projects
 
+You can run selected apk test by passing PACKAGES variable to
+`make run-apk-tests`. For example:
+
+    make run-apk-tests PACKAGES="Xamarin.Forms_Performance_Integration;Xamarin.Android.Locale_Tests"
+
+or with msbuild:
+
+    msbuild /t:RunApkTests tests/RunApkTests.targets /p:ApkTests='"Xamarin.Forms_Performance_Integration;Xamarin.Android.Locale_Tests"'
+
+Another possibility is to run them manually as described below.
+
 See also the [`tests/RunApkTests.targets`](../../tests/RunApkTests.targets) and
 [`build-tools/scripts/TestApks.targets`](../../build-tools/scripts/TestApks.targets)
 files.

--- a/Makefile
+++ b/Makefile
@@ -207,8 +207,12 @@ endif # $(SKIP_NUNIT_TESTS) == ''
 run-ji-tests:
 	$(call MSBUILD_BINLOG,run-ji-tests) $(TEST_TARGETS) /t:RunJavaInteropTests
 
+ifneq ($(PACKAGES),)
+APK_TESTS_PROP = /p:ApkTests='"$(PACKAGES)"'
+endif
+
 run-apk-tests:
-	$(call MSBUILD_BINLOG,run-apk-tests) $(TEST_TARGETS) /t:RunApkTests
+	$(call MSBUILD_BINLOG,run-apk-tests) $(TEST_TARGETS) /t:RunApkTests $(APK_TESTS_PROP)
 
 run-performance-tests:
 	$(call MSBUILD_BINLOG,run-performance-tests) $(TEST_TARGETS) /t:RunPerformanceTests

--- a/tests/RunApkTests.targets
+++ b/tests/RunApkTests.targets
@@ -23,8 +23,16 @@
   <Import Project="..\tests\Xamarin.Forms-Performance-Integration\Droid\Xamarin.Forms.Performance.Integration.Droid.projitems" />
   <Import Project="..\tests\Runtime-MultiDex\Mono.Android-TestsMultiDex.projitems" />
   <Import Project="..\build-tools\scripts\TestApks.targets" />
+
+  <ItemGroup Condition=" '$(ApkTests)' != '' ">
+    <_ApkTests Include="$(ApkTests)">
+      <Package>%(Identity)</Package>
+    </_ApkTests>
+  </ItemGroup>
+
   <PropertyGroup>
     <RunApkTestsDependsOn>
+      FilterApkTests;
       AcquireAndroidTarget;
       UndeployTestApks;
       DeployTestApks;
@@ -35,6 +43,20 @@
       ReportComponentFailures;
     </RunApkTestsDependsOn>
   </PropertyGroup>
+
+  <Target Name="FilterApkTests">
+    <ItemGroup Condition=" '$(ApkTests)' != '' ">
+      <TestApk Remove="@(TestApk)" Condition=" '%(Package)' != '' And '@(_ApkTests)' == '' " />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(ApkTests)' != '' ">
+      <TestApkInstrumentation Remove="@(TestApkInstrumentation)" Condition=" '%(Package)' != '' And '@(_ApkTests)' == '' " />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(ApkTests)' != '' ">
+      <TestApkPermission Remove="@(TestApkPermission)" Condition=" '%(Package)' != '' And '@(_ApkTests)' == '' " />
+    </ItemGroup>
+    <Message Text="@(TestApk) " />
+  </Target>
+
   <Target Name="RunApkTests"
       DependsOnTargets="$(RunApkTestsDependsOn)">
   </Target>


### PR DESCRIPTION
Make it possible to run selected apk tests by passing `TESTS` variable
to `make`.

Example usage:

    make run-apk-tests TESTS="Xamarin.Forms_Performance_Integration;Xamarin.Android.Locale_Tests"

Or msbuild equivalent:
    
        msbuild /t:RunApkTests tests/RunApkTests.targets /p:ApkTests='"Xamarin.Forms_Performance_Integration;Xamarin.Android.Locale_Tests"'
    
The relevant part of the output of the msbuild example above looks like:
    
        UndeployTestApks:
          Executing: /Users/rodo/android-toolchain/sdk/platform-tools/adb   uninstall "Xamarin.Android.Locale_Tests"
          Executing: /Users/rodo/android-toolchain/sdk/platform-tools/adb   uninstall "Xamarin.Forms_Performance_Integration"
        DeployTestApks:
          Executing: /Users/rodo/android-toolchain/sdk/platform-tools/adb   install "/Users/rodo/git/xa5/tests/../bin/TestDebug/Xamarin.Android.Locale_Tests-Signed.apk"
          Executing: /Users/rodo/android-toolchain/sdk/platform-tools/adb   install "/Users/rodo/git/xa5/tests/../bin/TestDebug/Xamarin.Forms_Performance_Integration-Signed.apk"
        RecordApkSizes:
          stat -f "stat: %z %N" "/Users/rodo/git/xa5/tests/../bin/TestDebug/Xamarin.Forms_Performance_Integration-Signed.apk" > "/Users/rodo/git/xa5/tests/../bin/TestDebug/apk-sizes-Xamarin.Forms_Performance_Integration-Debug.txt"
          unzip -l "/Users/rodo/git/xa5/tests/../bin/TestDebug/Xamarin.Forms_Performance_Integration-Signed.apk" >> "/Users/rodo/git/xa5/tests/../bin/TestDebug/apk-sizes-Xamarin.Forms_Performance_Integration-Debug.txt"
        RunTestApks:
          Executing: /Users/rodo/android-toolchain/sdk/platform-tools/adb   shell pm grant Xamarin.Android.Locale_Tests android.permission.READ_EXTERNAL_STORAGE
          Executing: /Users/rodo/android-toolchain/sdk/platform-tools/adb   shell pm grant Xamarin.Android.Locale_Tests android.permission.WRITE_EXTERNAL_STORAGE
          Executing: /Users/rodo/android-toolchain/sdk/platform-tools/adb   shell am instrument  -e "loglevel Verbose" -w "Xamarin.Android.Locale_Tests/xamarin.android.localetests.TestInstrumentation"
          Executing: /Users/rodo/android-toolchain/sdk/platform-tools/adb   logcat -v threadtime -d
            appending stdout to file: logcat-Debug-Xamarin.Android.Locale_Tests.txt
          Executing: /Users/rodo/android-toolchain/sdk/platform-tools/adb   logcat -c
          Executing: /Users/rodo/android-toolchain/sdk/platform-tools/adb   pull "/storage/emulated/0/Android/data/Xamarin.Android.Locale_Tests/files/Documents/TestResults.xml" "/Users/rodo/git/xa5/tests/../bin/TestDebug/TestResult-Xamarin.Android.Locale_Tests.xml"
          Executing: /Users/rodo/android-toolchain/sdk/platform-tools/adb   shell am start -n "Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity"
          Executing: /Users/rodo/android-toolchain/sdk/platform-tools/adb   logcat -v threadtime -d
            appending stdout to file: logcat-Debug-Xamarin.Forms_Performance_Integration.txt
          Executing: /Users/rodo/android-toolchain/sdk/platform-tools/adb   logcat -c