### PR TITLE
[build] create-vsix.csproj should have Release configuration

### DIFF
--- a/build-tools/create-vsix/create-vsix.csproj
+++ b/build-tools/create-vsix/create-vsix.csproj
@@ -25,6 +25,8 @@
     <ExtensionInstallationFolder>Xamarin\Xamarin.Android.Sdk</ExtensionInstallationFolder>
     <OutputPath>bin\$(Configuration)</OutputPath>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' " />
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' " />
   <Import Project="..\..\Configuration.props" />
   <ItemGroup>
     <Compile Include="AndroidSdkPackage.cs" />


### PR DESCRIPTION
Downstream in monodroid, we are getting a build error during a
`Release` build:

    xamarin-android/src/libzip/libzip.targets(16,5): error MSB4062: The "Xamarin.Android.BuildTools.PrepTasks.GitCommitTime" task could not be loaded from the assembly xamarin-android/build-tools/scripts/../../bin/BuildDebug/xa-prep-tasks.dll. Invalid Image Confirm that the <UsingTask> declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.

The path here is wrong, we should not be looking in `BuildDebug`
during a `Release` build.

I opened Xamarin.Android.sln in Visual Studio (on Windows), and in the
`Configuration Manager` `create-vsix.csproj` was listed as building
`Debug` for `Release` builds! The dropdown would not even let me
select `Release`, it seemed the IDE did not think there was a
`Release` configuration in the project at all!

![image](https://user-images.githubusercontent.com/840039/50293476-49d73b80-0439-11e9-8a21-2f4661b6345f.png)

This would imply that the following `<ProjectReference/>` in
`create-vsix.csproj` would be built in `Debug`:

    <ProjectReference Include="..\xa-prep-tasks\xa-prep-tasks.csproj">
      <Project>{7CE69551-BD73-4726-ACAA-AAF89C84BAF8}</Project>
      <Name>xa-prep-tasks</Name>
      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
      <Private>False</Private>
    </ProjectReference>

To fix this I added these lines to `create-vsix.csproj`:

    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' " />
    <PropertyGroup Condition=" '$(Configuration)' == 'Release' " />

Then the IDE allowed me to select `Release`! Of course, the IDE made
lots of other random changes we won't understand, since the `*.sln`
file format is not human readable.

This is not the same project we are getting an error from, but this
*does* seem like a problem.