### PR TITLE
[Xamarin.Android.Build.Tasks] fix ManagedResourceParser API breakage

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
@@ -24,19 +24,6 @@ namespace Foo.Foo
 			global::Android.Runtime.ResourceIdManager.UpdateIdValues();
 		}
 		
-		public partial class Animation
-		{
-			
-			static Animation()
-			{
-				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-			}
-			
-			private Animation()
-			{
-			}
-		}
-		
 		public partial class Animator
 		{
 			
@@ -78,32 +65,6 @@ namespace Foo.Foo
 			}
 			
 			private Attribute()
-			{
-			}
-		}
-		
-		public partial class Boolean
-		{
-			
-			static Boolean()
-			{
-				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-			}
-			
-			private Boolean()
-			{
-			}
-		}
-		
-		public partial class Color
-		{
-			
-			static Color()
-			{
-				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-			}
-			
-			private Color()
 			{
 			}
 		}
@@ -174,32 +135,6 @@ namespace Foo.Foo
 			}
 			
 			private Id()
-			{
-			}
-		}
-		
-		public partial class Integer
-		{
-			
-			static Integer()
-			{
-				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-			}
-			
-			private Integer()
-			{
-			}
-		}
-		
-		public partial class Interpolator
-		{
-			
-			static Interpolator()
-			{
-				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-			}
-			
-			private Interpolator()
 			{
 			}
 		}
@@ -309,32 +244,6 @@ namespace Foo.Foo
 			}
 		}
 		
-		public partial class Style
-		{
-			
-			static Style()
-			{
-				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-			}
-			
-			private Style()
-			{
-			}
-		}
-		
-		public partial class Styleable
-		{
-			
-			static Styleable()
-			{
-				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-			}
-			
-			private Styleable()
-			{
-			}
-		}
-		
 		public partial class Transition
 		{
 			
@@ -347,19 +256,6 @@ namespace Foo.Foo
 			}
 			
 			private Transition()
-			{
-			}
-		}
-		
-		public partial class Xml
-		{
-			
-			static Xml()
-			{
-				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-			}
-			
-			private Xml()
 			{
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -108,28 +108,50 @@ namespace Xamarin.Android.Tasks
 			SortMembers (xml);
 
 
-			resources.Members.Add (animation);
-			resources.Members.Add (animator);
-			resources.Members.Add (arrays);
+			if (animation.Members.Count > 1)
+				resources.Members.Add (animation);
+			if (animator.Members.Count > 1)
+				resources.Members.Add (animator);
+			if (arrays.Members.Count > 1)
+				resources.Members.Add (arrays);
+			//NOTE: aapt always emits Resource.Attribute, so we are replicating that
 			resources.Members.Add (attrib);
-			resources.Members.Add (boolean);
-			resources.Members.Add (colors);
-			resources.Members.Add (dimension);
-			resources.Members.Add (drawable);
-			resources.Members.Add (font);
-			resources.Members.Add (ids);
-			resources.Members.Add (ints);
-			resources.Members.Add (interpolators);
-			resources.Members.Add (layout);
-			resources.Members.Add (menu);
-			resources.Members.Add (mipmaps);
-			resources.Members.Add (raw);
-			resources.Members.Add (plurals);
-			resources.Members.Add (strings);
-			resources.Members.Add (style);
-			resources.Members.Add (styleable);
-			resources.Members.Add (transition);
-			resources.Members.Add (xml);
+			if (boolean.Members.Count > 1)
+				resources.Members.Add (boolean);
+			if (colors.Members.Count > 1)
+				resources.Members.Add (colors);
+			if (dimension.Members.Count > 1)
+				resources.Members.Add (dimension);
+			if (drawable.Members.Count > 1)
+				resources.Members.Add (drawable);
+			if (font.Members.Count > 1)
+				resources.Members.Add (font);
+			if (ids.Members.Count > 1)
+				resources.Members.Add (ids);
+			if (ints.Members.Count > 1)
+				resources.Members.Add (ints);
+			if (interpolators.Members.Count > 1)
+				resources.Members.Add (interpolators);
+			if (layout.Members.Count > 1)
+				resources.Members.Add (layout);
+			if (menu.Members.Count > 1)
+				resources.Members.Add (menu);
+			if (mipmaps.Members.Count > 1)
+				resources.Members.Add (mipmaps);
+			if (raw.Members.Count > 1)
+				resources.Members.Add (raw);
+			if (plurals.Members.Count > 1)
+				resources.Members.Add (plurals);
+			if (strings.Members.Count > 1)
+				resources.Members.Add (strings);
+			if (style.Members.Count > 1)
+				resources.Members.Add (style);
+			if (styleable.Members.Count > 1)
+				resources.Members.Add (styleable);
+			if (transition.Members.Count > 1)
+				resources.Members.Add (transition);
+			if (xml.Members.Count > 1)
+				resources.Members.Add (xml);
 
 			return resources;
 		}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/2546
Changes: https://github.com/xamarin/xamarin-android-api-compatibility/compare/ec562e9...3fe4561

Bumps to xamarin/xamarin-android-api-compatibility/master@3fe4561

This partially reverts 0f91aea.

In #2546, we experienced a bit of API breakage when disabling
`$(AndroidUseAapt2)`. We want to fix the breakage in master, but keep
`$(AndroidUseAapt2)` turned on by default.

We need to put the `ManagedResourceParser` back the way it was before
0f91aea, except for `Resource.Attribute`.

Since `aapt`(1) always emits this class, we should replicate that.