### PR TITLE
[build-tools] Fix the RunUI task to wait

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunUITests.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunUITests.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		[Required]
 		public                  string              LogcatFilename              { get; set; }
 
-		protected virtual void AfterCommand (int commandIndex, CommandInfo info)
+		protected override void AfterCommand (int commandIndex, CommandInfo info)
 		{
 			if (commandIndex != StateRunTests)
 				return;


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/2552

Use override in the right place. Probably a typo, which made the
logcat output unusable, because the `AfterCommand` was never called
and we gathered the logcat directly after launching the
activity. Instead of waiting before collecting the logcat.

My wild guess is that older compiler versions worked differenly and so
it worked for some time.