### PR TITLE
Update SQLite to 3.26.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -41,7 +41,7 @@
 [submodule "external/sqlite"]
     path = external/sqlite
     url = https://github.com/xamarin/sqlite.git
-    branch = 3.25.2
+    branch = 3.26.0
 [submodule "external/xamarin-android-api-compatibility"]
     path = external/xamarin-android-api-compatibility
     url = https://github.com/xamarin/xamarin-android-api-compatibility.git


### PR DESCRIPTION
Context: https://blade.tencent.com/magellan/index_en.html
Context: https://worthdoingbadly.com/sqlitebug/

Includes SQLite fixes between 2018-09-25 and 2018-12-01, bringing us
to SQLite 3.26.0.