### PR TITLE
[Mono.Android] Remove CS2002 build warnings

### DIFF
--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -92,12 +92,13 @@
       <_TypeMap>--type-map-report=$(IntermediateOutputPath)mcw\type-mapping.txt</_TypeMap>
       <_Api>$(IntermediateOutputPath)mcw\api.xml</_Api>
       <_Dirs>--enumdir=$(IntermediateOutputPath)mcw</_Dirs>
+      <_FullIntermediateOutputPath>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)'))</_FullIntermediateOutputPath>
     </PropertyGroup>
     <Exec
         Command="$(ManagedRuntime) $(Generator) $(_GenFlags) $(_ApiLevel) $(_Out) $(_Codegen) $(_Fixup) $(_Enums1) $(_Enums2) $(_Versions) $(_Annotations) $(_Assembly) $(_TypeMap) $(_Dirs) $(_Api)"
     />
     <ItemGroup>
-      <Compile Include="$(IntermediateOutputPath)mcw\**\*.cs" />
+      <Compile Include="$(_FullIntermediateOutputPath)\mcw\**\*.cs" KeepDuplicates="False" />
     </ItemGroup>
     <XmlPeek
         Namespaces="&lt;Namespace Prefix='msbuild' Uri='http://schemas.microsoft.com/developer/msbuild/2003' /&gt;"

--- a/src/Mono.Android/Test/Mono.Android-Test.Shared.projitems
+++ b/src/Mono.Android/Test/Mono.Android-Test.Shared.projitems
@@ -12,7 +12,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)\Resources\Resource.designer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Properties\AssemblyInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Android.App\ApplicationTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Android.Content.Res\AssetManagerTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Android.Content\IntentTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Android.Graphics\GraphicsTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Android.Runtime\CharSequenceTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Android.Runtime\JavaCollectionTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Android.Runtime\JnienvArrayMarshaling.cs" />
@@ -39,6 +41,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Android.RuntimeTests\MainActivity.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Android.RuntimeTests\MyIntent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Android.RuntimeTests\NonJavaObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Android.RuntimeTests\NUnitInstrumentation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Android.RuntimeTests\TestInstrumentation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Android.OS\BundleTest.cs" />
   </ItemGroup>

--- a/src/Mono.Android/Test/Mono.Android-Tests.csproj
+++ b/src/Mono.Android/Test/Mono.Android-Tests.csproj
@@ -55,43 +55,6 @@
     <Reference Include="Xamarin.Android.NUnitLite" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Resources\Resource.designer.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Android.App\ApplicationTest.cs" />
-    <Compile Include="Android.Content\IntentTest.cs" />
-    <Compile Include="Android.Content.Res\AssetManagerTest.cs" />
-    <Compile Include="Android.Graphics\GraphicsTest.cs" />
-    <Compile Include="Android.Runtime\CharSequenceTest.cs" />
-    <Compile Include="Android.Runtime\JavaCollectionTest.cs" />
-    <Compile Include="Android.Runtime\JnienvArrayMarshaling.cs" />
-    <Compile Include="Android.Runtime\XmlReaderPullParserTest.cs" />
-    <Compile Include="Android.Runtime\XmlReaderResourceParserTest.cs" />
-    <Compile Include="Android.Widget\AdapterTests.cs" />
-    <Compile Include="Java.Interop\JavaConvertTest.cs" />
-    <Compile Include="Java.Lang\ObjectArrayMarshaling.cs" />
-    <Compile Include="Java.Lang\ObjectTest.cs" />
-    <Compile Include="Java.Interop\JnienvTest.cs" />
-    <Compile Include="System\AppDomainTest.cs" />
-    <Compile Include="System\AssemblyInformationalVersionAttributeTest.cs" />
-    <Compile Include="System\ExceptionTest.cs" />
-    <Compile Include="System\TimeZoneTest.cs" />
-    <Compile Include="System.IO\DriveInfoTest.cs" />
-    <Compile Include="System.IO.Compression\GZipStreamTest.cs" />
-    <Compile Include="System.Net\ProxyTest.cs" />
-    <Compile Include="System.Net\SslTest.cs" />
-    <Compile Include="System.Net\NetworkInterfaces.cs" />
-    <Compile Include="System.Threading\InterlockedTest.cs" />
-    <Compile Include="Java.Interop\JavaObjectExtensionsTests.cs" />
-    <Compile Include="Xamarin.Android.Net\AndroidClientHandlerTests.cs" />
-    <Compile Include="Xamarin.Android.Net\HttpClientIntegrationTests.cs" />
-    <Compile Include="Xamarin.Android.RuntimeTests\MainActivity.cs" />
-    <Compile Include="Xamarin.Android.RuntimeTests\MyIntent.cs" />
-    <Compile Include="Xamarin.Android.RuntimeTests\NonJavaObject.cs" />
-    <Compile Include="Xamarin.Android.RuntimeTests\NUnitInstrumentation.cs" />
-    <Compile Include="Xamarin.Android.RuntimeTests\TestInstrumentation.cs" />
-    <Compile Include="Android.OS\BundleTest.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="Resources\AboutResources.txt" />
     <None Include="Assets\AboutAssets.txt" />
     <None Include="Properties\AndroidManifest.xml" />


### PR DESCRIPTION
There are two scenarios of consequence when building
`src/Mono.Android/Mono.Android.csproj`:

 1. When it hasn't previously built, e.g. a fresh checkout or
    `git clean`'d tree.

 2. When it *has* been previously built.

When building `Mono.Android.csproj` for the first time, there are 38
warnings produced.

When building `Mono.Android.csproj` afterward, there are *4400*
warnings, 3862 of which are CS2002 warnings:

	warning CS2002: Source file 'obj/Debug/android-28/mcw/Android.AccessibilityServices.AccessibilityButtonController.cs' specified multiple times
	...

What's going on here?

The cause is twofold: commit 98880bd5, and MSBuild's behavior of
evaluating `<ItemGroup/>` and `<PropertyGroup/>`s for Targets which
are *not executed*.

Prior to commit 98880bd5, initial builds would *fail*, as per
commit 5777337e:

> One SNAFU: currently, Mono.Android.csproj conditinally `<Import/>`s
> a `Mono.Android.projitems` file generated by Java.Interop's
> `generator` tool, which contains a list of all the generated files.
>
> When the project is first loaded, `Mono.Android.projitems` will not
> exist, so on that initial build, source code will be generated but
> xbuild won't re-read `Mono.Android.projitems` (once it exists).
> This will result in a failing build.
>
> Simply rebuild the project to get a valid build, or use the `make all`
> Makefile target.

This was fixed in commit 98880bd5 by introducing a Target-local
`@(Compile)` declaration which included all of the generated files,
but this fix did not take MSBuild's behavior into consideration
(because `xbuild` was the default build engine at the time, and
MSBuild's "let's evaluate property- and item-groups even for
non-executed targets!" behavior wasn't known to us).

Thus, on `Mono.Android.csproj` rebuild the following occurs:

 1. `$(IntermediateOutputPath)mcw\Mono.Android.projitems` is
    `<Import/>`ed, because it exists.  This populates `@(Compile)`
    with `/Full/Path/To/obj/Debug/android-28/mcw/*.cs` entries,
    because `Mono.Android.projitems` uses
    `$(MSBuildThisFileDirectory)` when adding entries.

 2. The `@(Compile)` definition within `_GenerateBinding` is
    *evaluated*, even though the `_GenerateBinding` target
    *is not executed*.  This populates `@(Compile)` with
    `obj/Debug/android-28/mcw/*.cs` entries.

    Note that this is a *relative path*, while
    (1) is an *absolute path*.

 3. Both (1) and (2) are passed to the `<Csc/>` task, which emits the
    CS2002 warnings.

The fix is twofold:

 1. Update (2) so that it generates full paths instead of relative
    paths, which allows...

 2. ...the `@(Compile)` group to include `KeepDuplicates="False"`.

The [`KeepDuplicates` attribute][0] "specifies whether an item should
be added to the target group if the item is an exact duplicate of an
existing item."  By using full paths consistently, we allow the "exact
duplicate" to be matched and prevent the addition of duplicates to the
`@(Compile)` group, in turn avoiding the emission of CS2002 warnings.

[0]: https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-items?view=vs-2017