### PR TITLE
[tests] BuildAfterUpgradingNuGet should be NonParallelizable

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2525,6 +2525,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 
 		//This test validates the _CleanIntermediateIfNuGetsChange target
 		[Test]
+		[NonParallelizable]
 		public void BuildAfterUpgradingNuget ([Values (false, true)] bool usePackageReference)
 		{
 			var proj = new XamarinAndroidApplicationProject ();


### PR DESCRIPTION
Context: http://build.devdiv.io/2307677

The `BuildAfterUpgradingNuGet` test has been failing with:

    Xamarin.ProjectTools.FailedBuildException : Build failure: UnnamedProject.csprojBuild log recorded

Reviewing the log, we are getting:

    NuGet.targets(114,5): The process cannot access the file 'xamarin.forms.2.3.4.231.nupkg' because it is being used by another process.

It looks like two NuGet restores in parallel are stepping on each
other.

This has happened a couple builds in a row, so I think it is worth
adding the `[NonParallelizable]` attribute on this test.