### PR TITLE
[Xamarin.Android.Build.Tasks] remove more %temp% file usage

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -547,20 +547,17 @@ namespace Xamarin.Android.Tasks
 			return map;
 		}
 
-		public static void SaveCustomViewMapFile (IBuildEngine4 engine, string mapFile, Dictionary<string, HashSet<string>> map)
+		public static bool SaveCustomViewMapFile (IBuildEngine4 engine, string mapFile, Dictionary<string, HashSet<string>> map)
 		{
 			engine?.RegisterTaskObject (mapFile, map, RegisteredTaskObjectLifetime.Build, allowEarlyCollection: false);
-			var temp = Path.GetTempFileName ();
-			try {
-				using (var m = new StreamWriter (temp)) {
-					foreach (var i in map.OrderBy (x => x.Key)) {
-						foreach (var v in i.Value.OrderBy (x => x))
-							m.WriteLine ($"{i.Key};{v}");
-					}
+			using (var stream = new MemoryStream ())
+			using (var writer = new StreamWriter (stream)) {
+				foreach (var i in map.OrderBy (x => x.Key)) {
+					foreach (var v in i.Value.OrderBy (x => x))
+						writer.WriteLine ($"{i.Key};{v}");
 				}
-				CopyIfChanged (temp, mapFile);
-			} finally {
-				File.Delete (temp);
+				writer.Flush ();
+				return CopyIfStreamChanged (stream, mapFile);
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/XDocumentExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/XDocumentExtensions.cs
@@ -44,14 +44,11 @@ namespace Xamarin.Android.Tasks
 
 		public static bool SaveIfChanged (this XDocument document, string fileName)
 		{
-			var tempFile = System.IO.Path.GetTempFileName ();
-			try {
-				using (var stream = File.OpenWrite (tempFile))
-				using (var xw = new Monodroid.LinePreservedXmlWriter (new StreamWriter (stream)))
-					xw.WriteNode (document.CreateNavigator (), false);
-				return MonoAndroidHelper.CopyIfChanged (tempFile, fileName);
-			} finally {
-				File.Delete (tempFile);
+			using (var stream = new MemoryStream ())
+			using (var xw = new Monodroid.LinePreservedXmlWriter (new StreamWriter (stream))) {
+				xw.WriteNode (document.CreateNavigator (), false);
+				xw.Flush ();
+				return MonoAndroidHelper.CopyIfStreamChanged (stream, fileName);
 			}
 		}
 	}


### PR DESCRIPTION
In various places throughout our build, we are still using a pattern
such as:

    try {
        var temp = Path.GetTempFileName ();
        //Write to the file
        MonoAndroidHelper.CopyIfChanged (temp, dest);
    } finally {
        File.Delete (temp);
    }

Or sometimes variations that aren't even as nice as this...

We can instead use the new `MonoAndroidHelper.CopyIfStreamChanged`
method and not use any temp files.

## CopyResource ##

This MSBuild task had its own `CopyIfStreamChanged` behavior, and it
has been around a while. I was able to remove a lot of code from this
MSBuild task; it is much simpler now.

Other changes:

- We don't really need an extra `Run` method here.
- If we are putting `Assembly.GetExecutingAssembly ()` in a static
  variable, let's put the jcwgen assembly in one as well.
- Use string interpolation: `$`

## GeneratePackageManagerJava, MonoAndroidHelper, and XDocumentExtensions ##

Each had a simple example of using a temp file that could be changed
to use `CopyIfStreamChanged` instead.

## Results ##

I couldn't really see a build performance improvement, but it should
be slightly better. Most of these changes result in cleaner code, and
less temp files!