### PR TITLE
[C++] Cosmetic changes to the code: NULL -> nullptr

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,6 +27,7 @@
 /src/Xamarin.Android.Build.Tasks/Linker @radekdoulik
 /src/Xamarin.Android.NamingCustomAttributes @jonpryor
 /src/Xamarin.Android.Tools.Aidl @jonpryor
+/src/monodroid/ @jonpryor @grendello
 /tests/TestRunner.* @grendello
 /tests/BCL-Tests @grendello
 /tests/CodeBehind @grendello

--- a/src/monodroid/jni/android-system.cc
+++ b/src/monodroid/jni/android-system.cc
@@ -68,7 +68,7 @@ AndroidSystem::lookup_system_property (const char *name)
 	for ( ; p ; p = p->next)
 		if (strcmp (p->name, name) == 0)
 			return p;
-	return NULL;
+	return nullptr;
 }
 
 void
@@ -109,7 +109,7 @@ AndroidSystem::add_system_property (const char *name, const char *value)
 void
 AndroidSystem::monodroid_strreplace (char *buffer, char old_char, char new_char)
 {
-	if (buffer == NULL)
+	if (buffer == nullptr)
 		return;
 	while (*buffer != '\0') {
 		if (*buffer == old_char)
@@ -207,12 +207,12 @@ AndroidSystem::monodroid_get_system_property (const char *name, char **value)
 	BundledProperty *p;
 
 	if (value)
-		*value = NULL;
+		*value = nullptr;
 
 	pvalue  = sp_value;
 	len     = _monodroid__system_property_get (name, sp_value, sizeof (sp_value));
 
-	if (len <= 0 && (p = lookup_system_property (name)) != NULL) {
+	if (len <= 0 && (p = lookup_system_property (name)) != nullptr) {
 		pvalue  = p->value;
 		len     = p->value_len;
 	}
@@ -232,10 +232,10 @@ AndroidSystem::monodroid_read_file_into_memory (const char *path, char **value)
 {
 	int r = 0;
 	if (value) {
-		*value = NULL;
+		*value = nullptr;
 	}
 	FILE *fp = utils.monodroid_fopen (path, "r");
-	if (fp != NULL) {
+	if (fp != nullptr) {
 		struct stat fileStat;
 		if (fstat (fileno (fp), &fileStat) == 0) {
 			r = fileStat.st_size+1;
@@ -254,10 +254,10 @@ AndroidSystem::_monodroid_get_system_property_from_file (const char *path, char 
 	int i;
 
 	if (value)
-		*value = NULL;
+		*value = nullptr;
 
 	FILE* fp = utils.monodroid_fopen (path, "r");
-	if (fp == NULL)
+	if (fp == nullptr)
 		return 0;
 
 	struct stat fileStat;
@@ -300,7 +300,7 @@ AndroidSystem::monodroid_get_system_property_from_overrides (const char *name, c
 			log_info (LOG_DEFAULT, "Trying to get property from %s", overide_file);
 			result = _monodroid_get_system_property_from_file (overide_file, value);
 			free (overide_file);
-			if (result <= 0 || value == NULL || (*value) == NULL || strlen (*value) == 0) {
+			if (result <= 0 || value == nullptr || (*value) == nullptr || strlen (*value) == 0) {
 				continue;
 			}
 			log_info (LOG_DEFAULT, "Property '%s' from  %s has value '%s'.", name, override_dirs [oi], *value);
@@ -321,7 +321,7 @@ AndroidSystem::create_update_dir (char *override_dir)
 	 * However, if any logging is enabled (which should _not_ happen with
 	 * pre-loaded apps!), we need the .__override__ directory...
 	 */
-	if (log_categories == 0 && utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_PROFILE_PROPERTY, NULL) == 0) {
+	if (log_categories == 0 && utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_PROFILE_PROPERTY, nullptr) == 0) {
 		return;
 	}
 #endif
@@ -353,13 +353,13 @@ AndroidSystem::copy_native_libraries_to_internal_location ()
 		char *dir_path = utils.path_combine (override_dirs [i], "lib");
 		log_warn (LOG_DEFAULT, "checking directory: `%s`", dir_path);
 
-		if (dir_path == NULL || !utils.directory_exists (dir_path)) {
+		if (dir_path == nullptr || !utils.directory_exists (dir_path)) {
 			log_warn (LOG_DEFAULT, "directory does not exist: `%s`", dir_path);
 			free (dir_path);
 			continue;
 		}
 
-		if ((dir = utils.monodroid_opendir (dir_path)) == NULL) {
+		if ((dir = utils.monodroid_opendir (dir_path)) == nullptr) {
 			log_warn (LOG_DEFAULT, "could not open directory: `%s`", dir_path);
 			free (dir_path);
 			continue;
@@ -453,7 +453,7 @@ AndroidSystem::get_libmonosgen_path ()
 #ifndef RELEASE
 	if (!is_embedded_dso_mode_enabled ()) {
 		for (i = 0; i < MAX_OVERRIDES; ++i) {
-			if (override_dirs [i] == NULL)
+			if (override_dirs [i] == nullptr)
 				continue;
 			log_fatal (LOG_DEFAULT, "  %s", override_dirs [i]);
 		}
@@ -477,9 +477,9 @@ AndroidSystem::get_full_dso_path (const char *base_dir, const char *dso_path, mo
 
 	*needs_free = FALSE;
 	if (!dso_path)
-		return NULL;
+		return nullptr;
 
-	if (base_dir == NULL || utils.is_path_rooted (dso_path))
+	if (base_dir == nullptr || utils.is_path_rooted (dso_path))
 		return (char*)dso_path; // Absolute path or no base path, can't do much with it
 
 	char *full_path = utils.path_combine (base_dir, dso_path);
@@ -490,17 +490,17 @@ AndroidSystem::get_full_dso_path (const char *base_dir, const char *dso_path, mo
 void*
 AndroidSystem::load_dso (const char *path, int dl_flags, mono_bool skip_exists_check)
 {
-	if (path == NULL)
-		return NULL;
+	if (path == nullptr)
+		return nullptr;
 
 	log_info (LOG_ASSEMBLY, "Trying to load shared library '%s'", path);
 	if (!skip_exists_check && !is_embedded_dso_mode_enabled () && !utils.file_exists (path)) {
 		log_info (LOG_ASSEMBLY, "Shared library '%s' not found", path);
-		return NULL;
+		return nullptr;
 	}
 
 	void *handle = dlopen (path, dl_flags);
-	if (handle == NULL && utils.should_log (LOG_ASSEMBLY))
+	if (handle == nullptr && utils.should_log (LOG_ASSEMBLY))
 		log_info_nocheck (LOG_ASSEMBLY, "Failed to load shared library '%s'. %s", path, dlerror ());
 	return handle;
 }
@@ -509,21 +509,21 @@ void*
 AndroidSystem::load_dso_from_specified_dirs (const char **directories, int num_entries, const char *dso_name, int dl_flags)
 {
 	assert (directories);
-	if (dso_name == NULL)
-		return NULL;
+	if (dso_name == nullptr)
+		return nullptr;
 
 	mono_bool needs_free = FALSE;
-	char *full_path = NULL;
+	char *full_path = nullptr;
 	for (int i = 0; i < num_entries; i++) {
 		full_path = get_full_dso_path (directories [i], dso_name, &needs_free);
 		void *handle = load_dso (full_path, dl_flags, FALSE);
 		if (needs_free)
 			free (full_path);
-		if (handle != NULL)
+		if (handle != nullptr)
 			return handle;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 void*
@@ -536,7 +536,7 @@ void*
 AndroidSystem::load_dso_from_override_dirs (const char *name, int dl_flags)
 {
 #ifdef RELEASE
-	return NULL;
+	return nullptr;
 #else
 	return load_dso_from_specified_dirs (const_cast<const char**> (AndroidSystem::override_dirs), AndroidSystem::MAX_OVERRIDES, name, dl_flags);
 #endif
@@ -546,7 +546,7 @@ void*
 AndroidSystem::load_dso_from_any_directories (const char *name, int dl_flags)
 {
 	void *handle = load_dso_from_override_dirs (name, dl_flags);
-	if (handle == NULL)
+	if (handle == nullptr)
 		handle = load_dso_from_app_lib_dirs (name, dl_flags);
 	return handle;
 }
@@ -563,17 +563,17 @@ AndroidSystem::get_existing_dso_path_on_disk (const char *base_dir, const char *
 
 	*needs_free = FALSE;
 	free (dso_path);
-	return NULL;
+	return nullptr;
 }
 
 void
 AndroidSystem::dso_alloc_cleanup (char **dso_path, mono_bool *needs_free)
 {
 	assert (needs_free);
-	if (dso_path != NULL) {
+	if (dso_path != nullptr) {
 		if (*needs_free)
 			free (*dso_path);
-		*dso_path = NULL;
+		*dso_path = nullptr;
 	}
 	*needs_free = FALSE;
 }
@@ -585,28 +585,28 @@ AndroidSystem::get_full_dso_path_on_disk (const char *dso_name, mono_bool *needs
 
 	*needs_free = FALSE;
 	if (is_embedded_dso_mode_enabled ())
-		return NULL;
+		return nullptr;
 
 	char *dso_path = nullptr;
 #ifndef RELEASE
 	for (int i = 0; i < AndroidSystem::MAX_OVERRIDES; i++) {
-		if (AndroidSystem::override_dirs [i] == NULL)
+		if (AndroidSystem::override_dirs [i] == nullptr)
 			continue;
 		dso_path = get_existing_dso_path_on_disk (AndroidSystem::override_dirs [i], dso_name, needs_free);
-		if (dso_path != NULL)
+		if (dso_path != nullptr)
 			return dso_path;
 		dso_alloc_cleanup (&dso_path, needs_free);
 	}
 #endif
 	for (int i = 0; i < app_lib_directories_size; i++) {
 		dso_path = get_existing_dso_path_on_disk (app_lib_directories [i], dso_name, needs_free);
-		if (dso_path != NULL)
+		if (dso_path != nullptr)
 			return dso_path;
 		dso_alloc_cleanup (&dso_path, needs_free);
 	}
 
 
-	return NULL;
+	return nullptr;
 }
 
 int
@@ -621,10 +621,10 @@ AndroidSystem::count_override_assemblies (void)
 
 		const char *dir_path = override_dirs [i];
 
-		if (dir_path == NULL || !utils.directory_exists (dir_path))
+		if (dir_path == nullptr || !utils.directory_exists (dir_path))
 			continue;
 
-		if ((dir = utils.monodroid_opendir (dir_path)) == NULL)
+		if ((dir = utils.monodroid_opendir (dir_path)) == nullptr)
 			continue;
 
 		while (readdir_r (dir, &b, &e) == 0 && e) {
@@ -684,7 +684,7 @@ void
 AndroidSystem::copy_file_to_internal_location (char *to_dir, char *from_dir, char *file)
 {
 	char *from_file = utils.path_combine (from_dir, file);
-	char *to_file   = NULL;
+	char *to_file   = nullptr;
 
 	do {
 		if (!from_file || !utils.file_exists (from_file))
@@ -836,7 +836,7 @@ AndroidSystem::setup_process_args_apk (const char *apk, int index, int apk_count
 void
 AndroidSystem::setup_process_args (JNIEnv *env, jstring_array_wrapper &runtimeApks)
 {
-	for_each_apk (env, runtimeApks, &AndroidSystem::setup_process_args_apk, NULL);
+	for_each_apk (env, runtimeApks, &AndroidSystem::setup_process_args_apk, nullptr);
 }
 
 void
@@ -870,7 +870,7 @@ AndroidSystem::readdir_r (_WDIR *dirp, struct _wdirent *entry, struct _wdirent *
 	entry = _wreaddir (dirp);
 	*result = entry;
 
-	if (entry == NULL && errno != 0)
+	if (entry == nullptr && errno != 0)
 		error_code = -1;
 
 	return error_code;

--- a/src/monodroid/jni/cpu-arch-detect.cc
+++ b/src/monodroid/jni/cpu-arch-detect.cc
@@ -162,7 +162,7 @@ get_running_on_cpu_apple (unsigned short *running_on_cpu)
 	size_t length;
 
 	length = sizeof (cputype);
-	sysctlbyname ("hw.cputype", &cputype, &length, NULL, 0);
+	sysctlbyname ("hw.cputype", &cputype, &length, nullptr, 0);
 	switch (cputype) {
 		case CPU_TYPE_X86:
 			*running_on_cpu = CPU_KIND_X86;

--- a/src/monodroid/jni/debug.cc
+++ b/src/monodroid/jni/debug.cc
@@ -110,7 +110,7 @@ Debug::start_connection (char *options)
 
 	parse_options (options, &opts);
 
-	cur_time = time (NULL);
+	cur_time = time (nullptr);
 
 	if (opts.timeout_time && cur_time > opts.timeout_time) {
 		log_warn (LOG_DEBUGGER, "Not connecting to IDE as the timeout value has been reached; current-time: %lli  timeout: %lli", cur_time, opts.timeout_time);
@@ -120,7 +120,7 @@ Debug::start_connection (char *options)
 	if (!conn_port)
 		return 0;
 
-	res = pthread_create (&conn_thread_id, NULL, xamarin::android::conn_thread, this);
+	res = pthread_create (&conn_thread_id, nullptr, xamarin::android::conn_thread, this);
 	if (res) {
 		log_error (LOG_DEFAULT, "Failed to create connection thread: %s", strerror (errno));
 		return 1;
@@ -139,7 +139,7 @@ inline int
 Debug::process_connection (int fd)
 {
 	// make sure the fd/socket blocks on reads/writes
-	fcntl (fd, F_SETFL, fcntl (fd, F_GETFL, NULL) & ~O_NONBLOCK);
+	fcntl (fd, F_SETFL, fcntl (fd, F_GETFL, nullptr) & ~O_NONBLOCK);
 
 	while (TRUE) {
 		char command [257];
@@ -213,7 +213,7 @@ Debug::handle_server_connection (void)
 	}
 
 	// Make the socket non-blocking
-	flags = fcntl (listen_socket, F_GETFL, NULL);
+	flags = fcntl (listen_socket, F_GETFL, nullptr);
 	flags |= O_NONBLOCK;
 	fcntl (listen_socket, F_SETFL, flags);
 
@@ -234,7 +234,7 @@ Debug::handle_server_connection (void)
 
 		do {
 			// Calculate how long we can wait if we can only work for 2s since we started
-			gettimeofday (&now, NULL);
+			gettimeofday (&now, nullptr);
 			if (start.tv_sec == 0) {
 				start.tv_sec = now.tv_sec;
 				start.tv_usec = now.tv_usec;
@@ -254,7 +254,7 @@ Debug::handle_server_connection (void)
 
 			// LOG ("MonoTouch: Waiting for connections from XS, sec: %i usec: %i\n", (int) tv.tv_sec, (int) tv.tv_usec);
 
-			if ((rv = select (listen_socket + 1, &rset, NULL, NULL, &tv)) == 0) {
+			if ((rv = select (listen_socket + 1, &rset, nullptr, nullptr, &tv)) == 0) {
 				// timeout hit, no connections available.
 				log_info (LOG_DEFAULT, "Listened2 for connections from XS for 2 seconds, nobody connected.\n");
 				rv = 3;
@@ -313,6 +313,6 @@ xamarin::android::conn_thread (void *arg)
 		exit (FATAL_EXIT_DEBUGGER_CONNECT);
 	}
 
-	return NULL;
+	return nullptr;
 }
 #endif /* DEBUG */

--- a/src/monodroid/jni/dylib-mono.cc
+++ b/src/monodroid/jni/dylib-mono.cc
@@ -18,11 +18,11 @@ using namespace xamarin::android;
   this function is used from JavaInterop and should be treated as public API
   https://github.com/xamarin/java.interop/blob/master/src/java-interop/java-interop-gc-bridge-mono.c#L266
 
-  it should also accept libmono_path = NULL parameter
+  it should also accept libmono_path = nullptr parameter
 */
 int monodroid_dylib_mono_init (DylibMono *mono_imports, const char *libmono_path)
 {
-	if (mono_imports == NULL)
+	if (mono_imports == nullptr)
 		return FALSE;
 
 	/*

--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -69,12 +69,12 @@ open_from_bundles (MonoAssemblyName *aname, char **assemblies_path, void *user_d
 	char *ename;
 	size_t si;
 
-	MonoAssembly *a = NULL;
+	MonoAssembly *a = nullptr;
 
-	int name_len = culture == NULL ? 0 : strlen (culture) + 1;
+	int name_len = culture == nullptr ? 0 : strlen (culture) + 1;
 	name_len += strlen (reinterpret_cast<const char*> (mono->assembly_name_get_name (aname)));
 	name = static_cast<char*> (utils.xmalloc (name_len + sizeof (".exe") + 1));
-	if (culture != NULL && strlen (culture) > 0)
+	if (culture != nullptr && strlen (culture) > 0)
 		sprintf (name, "%s/%s", culture, (const char*) mono->assembly_name_get_name (aname));
 	else
 		sprintf (name, "%s", (const char*) mono->assembly_name_get_name (aname));
@@ -86,7 +86,7 @@ open_from_bundles (MonoAssemblyName *aname, char **assemblies_path, void *user_d
 		".exe",
 	};
 
-	for (si = 0; si < sizeof (suffixes)/sizeof (suffixes [0]) && a == NULL; ++si) {
+	for (si = 0; si < sizeof (suffixes)/sizeof (suffixes [0]) && a == nullptr; ++si) {
 		MonoBundledAssembly **p;
 
 		*ename = '\0';
@@ -94,14 +94,14 @@ open_from_bundles (MonoAssemblyName *aname, char **assemblies_path, void *user_d
 
 		log_info (LOG_ASSEMBLY, "open_from_bundles: looking for bundled name: '%s'", name);
 
-		for (p = bundled_assemblies; p != NULL && *p; ++p) {
-			MonoImage *image = NULL;
+		for (p = bundled_assemblies; p != nullptr && *p; ++p) {
+			MonoImage *image = nullptr;
 			MonoImageOpenStatus status;
 			const MonoBundledAssembly *e = *p;
 
 			if (strcmp (e->name, name) == 0 &&
-					(image  = mono->image_open_from_data_with_name ((char*) e->data, e->size, 0, NULL, ref_only, name)) != NULL &&
-					(a      = mono->assembly_load_from_full (image, name, &status, ref_only)) != NULL) {
+					(image  = mono->image_open_from_data_with_name ((char*) e->data, e->size, 0, nullptr, ref_only, name)) != nullptr &&
+					(a      = mono->assembly_load_from_full (image, name, &status, ref_only)) != nullptr) {
 				mono->config_for_assembly (image);
 				break;
 			}
@@ -146,28 +146,28 @@ MONO_API const char *
 monodroid_typemap_java_to_managed (const char *java)
 {
 	struct TypeMappingInfo *info;
-	for (info = java_to_managed_maps; info != NULL; info = info->next) {
+	for (info = java_to_managed_maps; info != nullptr; info = info->next) {
 		/* log_warn (LOG_DEFAULT, "# jonp: checking file: %s!%s for type '%s'", info->source_apk, info->source_entry, java); */
 		const char *e = reinterpret_cast<const char*> (bsearch (java, info->mapping, info->num_entries, info->entry_length, TypeMappingInfo_compare_key));
-		if (e == NULL)
+		if (e == nullptr)
 			continue;
 		return e + info->value_offset;
 	}
-	return NULL;
+	return nullptr;
 }
 
 MONO_API const char *
 monodroid_typemap_managed_to_java (const char *managed)
 {
 	struct TypeMappingInfo *info;
-	for (info = managed_to_java_maps; info != NULL; info = info->next) {
+	for (info = managed_to_java_maps; info != nullptr; info = info->next) {
 		/* log_warn (LOG_DEFAULT, "# jonp: checking file: %s!%s for type '%s'", info->source_apk, info->source_entry, managed); */
 		const char *e = reinterpret_cast <const char*> (bsearch (managed, info->mapping, info->num_entries, info->entry_length, TypeMappingInfo_compare_key));
-		if (e == NULL)
+		if (e == nullptr)
 			continue;
 		return e + info->value_offset;
 	}
-	return NULL;
+	return nullptr;
 }
 
 static void
@@ -178,12 +178,12 @@ extract_int (const char **header, const char *source_apk, const char *source_ent
 	int   key_name_len      = 0;
 	char  scanf_format [20] = { 0, };
 
-	if (header == NULL || *header == NULL)
+	if (header == nullptr || *header == nullptr)
 		return;
 
 	key_name_len    = strlen (key_name);
 	if (key_name_len >= (sizeof (scanf_format) - sizeof ("=%d%n"))) {
-		*header = NULL;
+		*header = nullptr;
 		return;
 	}
 
@@ -193,7 +193,7 @@ extract_int (const char **header, const char *source_apk, const char *source_ent
 	if (read != 1) {
 		log_warn (LOG_DEFAULT, "Could not read header '%s' value from '%s!%s': read %i elements, expected 1 element. Contents: '%s'",
 				key_name, source_apk, source_entry, read, *header);
-		*header = NULL;
+		*header = nullptr;
 		return;
 	}
 	*header = *header + consumed + 1;
@@ -224,7 +224,7 @@ add_type_mapping (struct TypeMappingInfo **info, const char *source_apk, const c
 			(p->num_entries <= 0) ||
 			(p->entry_length <= 0) ||
 			(p->value_offset >= p->entry_length) ||
-			(p->mapping == NULL)) {
+			(p->mapping == nullptr)) {
 		log_warn (LOG_DEFAULT, "Could not read type mapping file '%s!%s'. Ignoring...", source_apk, source_entry);
 		free (p);
 		return false;
@@ -256,7 +256,7 @@ md_mmap_apk_file (int fd, uLong offset, uLong size, const char* filename, const 
 	uLong offsetPage      = offset - offsetFromPage;
 	uLong offsetSize      = size + offsetFromPage;
 	
-	mmap_info.area        = mmap (NULL, offsetSize, PROT_READ, MAP_PRIVATE, fd, offsetPage);
+	mmap_info.area        = mmap (nullptr, offsetSize, PROT_READ, MAP_PRIVATE, fd, offsetPage);
 	if (mmap_info.area == MAP_FAILED) {
 		log_fatal (LOG_DEFAULT, "Could not `mmap` apk `%s` entry `%s`: %s", apk, filename, strerror (errno));
 		exit (FATAL_EXIT_CANNOT_FIND_APK);
@@ -278,7 +278,7 @@ md_mmap_open_file (void *opaque, const char *filename, int mode)
 {
 	if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER) == ZLIB_FILEFUNC_MODE_READ)
 		return utils.xcalloc (1, sizeof (int));
-	return NULL;
+	return nullptr;
 }
 
 static uLong
@@ -337,7 +337,7 @@ register_debug_symbols_for_assembly (DylibMono *mono, const char *entry_name, Mo
 	if (strncmp (assembly->name, entry_basename, strlen (assembly->name)) != 0) {
 		// That failed; try for System.dll, System.pdb case
 		const char *eb_ext  = strrchr (entry_basename, '.');
-		if (eb_ext == NULL)
+		if (eb_ext == nullptr)
 			return 0;
 		int basename_len    = eb_ext - entry_basename;
 		assert (basename_len > 0 && "basename must have a length!");
@@ -380,12 +380,12 @@ gather_bundled_assemblies_from_apk (
 	zlib_filefunc_def funcs = {
 		md_mmap_open_file,  // zopen_file,
 		md_mmap_read_file,  // zread_file,
-		NULL,               // zwrite_file,
+		nullptr,               // zwrite_file,
 		md_mmap_tell_file,  // ztell_file,
 		md_mmap_seek_file,  // zseek_file,
 		md_mmap_close_file, // zclose_file
 		md_mmap_error_file, // zerror_file
-		NULL                // opaque
+		nullptr                // opaque
 	};
 
 	if ((fd = open (apk, O_RDONLY)) < 0) {
@@ -396,7 +396,7 @@ gather_bundled_assemblies_from_apk (
 
 	funcs.opaque = &fd;
 
-	if ((file = unzOpen2 (NULL, &funcs)) != NULL) {
+	if ((file = unzOpen2 (nullptr, &funcs)) != nullptr) {
 		do {
 			unz_file_info info;
 			uLong offset;
@@ -406,9 +406,9 @@ gather_bundled_assemblies_from_apk (
 			int entry_is_overridden = FALSE;
 
 			cur_entry_name [0] = 0;
-			if (unzGetCurrentFileInfo (file, &info, cur_entry_name, sizeof (cur_entry_name)-1, NULL, 0, NULL, 0) != UNZ_OK ||
+			if (unzGetCurrentFileInfo (file, &info, cur_entry_name, sizeof (cur_entry_name)-1, nullptr, 0, nullptr, 0) != UNZ_OK ||
 					info.compression_method != 0 ||
-					unzOpenCurrentFile3 (file, NULL, NULL, 1, NULL) != UNZ_OK ||
+					unzOpenCurrentFile3 (file, nullptr, nullptr, 1, nullptr) != UNZ_OK ||
 					unzGetRawFileOffset (file, &offset) != UNZ_OK) {
 				continue;
 			}
@@ -442,7 +442,7 @@ gather_bundled_assemblies_from_apk (
 			if ((utils.ends_with (cur_entry_name, ".mdb") || utils.ends_with (cur_entry_name, ".pdb")) &&
 					register_debug_symbols &&
 					!entry_is_overridden &&
-					*bundle != NULL) {
+					*bundle != nullptr) {
 				md_mmap_info map_info = md_mmap_apk_file(fd, offset, info.uncompressed_size, cur_entry_name, apk);
 				if (register_debug_symbols_for_assembly (mono, cur_entry_name, (*bundle) [*bundle_count-1],
 						(const mono_byte*)map_info.area,
@@ -451,7 +451,7 @@ gather_bundled_assemblies_from_apk (
 			}
 
 			if (utils.ends_with (cur_entry_name, ".config") &&
-					*bundle != NULL) {
+					*bundle != nullptr) {
 				char *assembly_name = utils.monodroid_strdup_printf ("%s", basename (cur_entry_name));
 				// Remove '.config' suffix
 				*strrchr (assembly_name, '.') = '\0';
@@ -509,17 +509,17 @@ try_load_typemaps_from_directory (const char *path)
 {
 	// read the entire typemap file into a string
 	// process the string using the add_type_mapping
-	char *val = NULL;
+	char *val = nullptr;
 	monodroid_dir_t *dir;
 	monodroid_dirent_t b, *e;
 	char *dir_path = utils.path_combine (path, "typemaps");
-	if (dir_path == NULL || !utils.directory_exists (dir_path)) {
+	if (dir_path == nullptr || !utils.directory_exists (dir_path)) {
 		log_warn (LOG_DEFAULT, "directory does not exist: `%s`", dir_path);
 		free (dir_path);
 		return 0;
 	}
 
-	if ((dir = utils.monodroid_opendir (dir_path)) == NULL) {
+	if ((dir = utils.monodroid_opendir (dir_path)) == nullptr) {
 		log_warn (LOG_DEFAULT, "could not open directory: `%s`", dir_path);
 		free (dir_path);
 		return 0;
@@ -534,13 +534,13 @@ try_load_typemaps_from_directory (const char *path)
 		char *file_path = utils.path_combine (dir_path, file_name);
 		if (utils.monodroid_dirent_hasextension (e, ".mj") || utils.monodroid_dirent_hasextension (e, ".jm")) {
 			int len = androidSystem.monodroid_read_file_into_memory (file_path, &val);
-			if (len > 0 && val != NULL) {
+			if (len > 0 && val != nullptr) {
 				if (utils.monodroid_dirent_hasextension (e, ".mj")) {
-					if (!add_type_mapping (&managed_to_java_maps, file_path, NULL, ((const char*)val)))
+					if (!add_type_mapping (&managed_to_java_maps, file_path, nullptr, ((const char*)val)))
 						free (val);
 				}
 				if (utils.monodroid_dirent_hasextension (e, ".jm")) {
-					if (!add_type_mapping (&java_to_managed_maps, file_path, NULL, ((const char*)val)))
+					if (!add_type_mapping (&java_to_managed_maps, file_path, nullptr, ((const char*)val)))
 						free (val);
 				}
 			}
@@ -568,7 +568,7 @@ monodroid_embedded_assemblies_register_from (
 
 	if (bundled_assemblies) {
 		bundled_assemblies  = reinterpret_cast <MonoBundledAssembly**> (utils.xrealloc (bundled_assemblies, sizeof(void*)*(bundled_assemblies_count + 1)));
-		bundled_assemblies [bundled_assemblies_count] = NULL;
+		bundled_assemblies [bundled_assemblies_count] = nullptr;
 	}
 
 	return bundled_assemblies_count;

--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -380,12 +380,12 @@ gather_bundled_assemblies_from_apk (
 	zlib_filefunc_def funcs = {
 		md_mmap_open_file,  // zopen_file,
 		md_mmap_read_file,  // zread_file,
-		nullptr,               // zwrite_file,
+		nullptr,            // zwrite_file,
 		md_mmap_tell_file,  // ztell_file,
 		md_mmap_seek_file,  // zseek_file,
 		md_mmap_close_file, // zclose_file
 		md_mmap_error_file, // zerror_file
-		nullptr                // opaque
+		nullptr             // opaque
 	};
 
 	if ((fd = open (apk, O_RDONLY)) < 0) {

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -171,21 +171,21 @@ char *xamarin::android::internal::external_legacy_override_dir;
 /* Set of Windows-specific utility/reimplementation of Unix functions */
 #ifdef WINDOWS
 
-static char *msbuild_folder_path = NULL;
+static char *msbuild_folder_path = nullptr;
 
 static const char*
 get_xamarin_android_msbuild_path (void)
 {
 	const char *suffix = "MSBuild\\Xamarin\\Android";
-	char *base_path = NULL;
-	wchar_t *buffer = NULL;
+	char *base_path = nullptr;
+	wchar_t *buffer = nullptr;
 
-	if (msbuild_folder_path != NULL)
+	if (msbuild_folder_path != nullptr)
 		return msbuild_folder_path;
 
 	// Get the base path for 'Program Files' on Windows
-	if (!SUCCEEDED (SHGetKnownFolderPath (FOLDERID_ProgramFilesX86, 0, NULL, &buffer))) {
-		if (buffer != NULL)
+	if (!SUCCEEDED (SHGetKnownFolderPath (FOLDERID_ProgramFilesX86, 0, nullptr, &buffer))) {
+		if (buffer != nullptr)
 			CoTaskMemFree (buffer);
 		// returns current directory if a global one couldn't be found
 		return ".";
@@ -219,7 +219,7 @@ static void
 setup_bundled_app (const char *dso_name)
 {
 	static int dlopen_flags = RTLD_LAZY;
-	void *libapp = NULL;
+	void *libapp = nullptr;
 
 	if (androidSystem.is_embedded_dso_mode_enabled ()) {
 		log_info (LOG_DEFAULT, "bundle app: embedded DSO mode");
@@ -228,15 +228,15 @@ setup_bundled_app (const char *dso_name)
 		mono_bool needs_free = FALSE;
 		log_info (LOG_DEFAULT, "bundle app: normal mode");
 		char *bundle_path = androidSystem.get_full_dso_path_on_disk (dso_name, &needs_free);
-		log_info (LOG_DEFAULT, "bundle_path == %s", bundle_path ? bundle_path : "<NULL>");
-		if (bundle_path == NULL)
+		log_info (LOG_DEFAULT, "bundle_path == %s", bundle_path ? bundle_path : "<nullptr>");
+		if (bundle_path == nullptr)
 			return;
 		log_info (LOG_BUNDLE, "Attempting to load bundled app from %s", bundle_path);
 		libapp = androidSystem.load_dso (bundle_path, dlopen_flags, TRUE);
 		free (bundle_path);
 	}
 
-	if (libapp == NULL) {
+	if (libapp == nullptr) {
 		log_info (LOG_DEFAULT, "No libapp!");
 		if (!androidSystem.is_embedded_dso_mode_enabled ()) {
 			log_fatal (LOG_BUNDLE, "bundled app initialization error");
@@ -345,9 +345,9 @@ thread_start (MonoProfiler *prof, uintptr_t tid)
 	JNIEnv* env;
 	int r;
 #ifdef PLATFORM_ANDROID
-	r = osBridge.get_jvm ()->AttachCurrentThread (&env, NULL);
+	r = osBridge.get_jvm ()->AttachCurrentThread (&env, nullptr);
 #else   // ndef PLATFORM_ANDROID
-	r = osBridge.get_jvm ()->AttachCurrentThread ((void**) &env, NULL);
+	r = osBridge.get_jvm ()->AttachCurrentThread ((void**) &env, nullptr);
 #endif  // ndef PLATFORM_ANDROID
 	if (r != JNI_OK) {
 #if DEBUG
@@ -391,19 +391,19 @@ MonoAssembly*
 open_from_update_dir (MonoAssemblyName *aname, char **assemblies_path, void *user_data)
 {
 	int fi, oi;
-	MonoAssembly *result = NULL;
+	MonoAssembly *result = nullptr;
 	int found = 0;
 	const char *culture = reinterpret_cast<const char*> (monoFunctions.assembly_name_get_culture (aname));
 	const char *name    = reinterpret_cast<const char*> (monoFunctions.assembly_name_get_name (aname));
 	char *pname;
 
 	for (oi = 0; oi < AndroidSystem::MAX_OVERRIDES; ++oi)
-		if (androidSystem.get_override_dir (oi) != NULL && utils.directory_exists (androidSystem.get_override_dir (oi)))
+		if (androidSystem.get_override_dir (oi) != nullptr && utils.directory_exists (androidSystem.get_override_dir (oi)))
 			found = 1;
 	if (!found)
-		return NULL;
+		return nullptr;
 
-	if (culture != NULL && strlen (culture) > 0)
+	if (culture != nullptr && strlen (culture) > 0)
 		pname = utils.path_combine (culture, name);
 	else
 		pname = utils.monodroid_strdup_printf ("%s", name);
@@ -414,15 +414,15 @@ open_from_update_dir (MonoAssemblyName *aname, char **assemblies_path, void *use
 		"%s" MONODROID_PATH_SEPARATOR "%s.exe",
 	};
 
-	for (fi = 0; fi < sizeof (formats)/sizeof (formats [0]) && result == NULL; ++fi) {
+	for (fi = 0; fi < sizeof (formats)/sizeof (formats [0]) && result == nullptr; ++fi) {
 		for (oi = 0; oi < AndroidSystem::MAX_OVERRIDES; ++oi) {
 			char *fullpath;
-			if (androidSystem.get_override_dir (oi) == NULL || !utils.directory_exists (androidSystem.get_override_dir (oi)))
+			if (androidSystem.get_override_dir (oi) == nullptr || !utils.directory_exists (androidSystem.get_override_dir (oi)))
 				continue;
 			fullpath = utils.monodroid_strdup_printf (formats [fi], androidSystem.get_override_dir (oi), pname);
 			log_info (LOG_ASSEMBLY, "open_from_update_dir: trying to open assembly: %s\n", fullpath);
 			if (utils.file_exists (fullpath))
-				result = monoFunctions.assembly_open_full (fullpath, NULL, 0);
+				result = monoFunctions.assembly_open_full (fullpath, nullptr, 0);
 			free (fullpath);
 			if (result) {
 				// TODO: register .mdb, .pdb file
@@ -448,7 +448,7 @@ should_register_file (const char *filename, void *user_data)
 		char *p;
 
 		const char *odir = androidSystem.get_override_dir (i);
-		if (odir == NULL)
+		if (odir == nullptr)
 			continue;
 
 		p       = utils.path_combine (odir, filename);
@@ -468,7 +468,7 @@ static void
 gather_bundled_assemblies (JNIEnv *env, jstring_array_wrapper &runtimeApks, mono_bool register_debug_symbols, int *out_user_assemblies_count)
 {
 	monodroid_embedded_assemblies_set_register_debug_symbols (register_debug_symbols);
-	monodroid_embedded_assemblies_set_should_register (should_register_file, NULL);
+	monodroid_embedded_assemblies_set_should_register (should_register_file, nullptr);
 #ifndef RELEASE
 	for (size_t i = 0; i < AndroidSystem::MAX_OVERRIDES; ++i) {
 		const char *p = androidSystem.get_override_dir (i);
@@ -502,7 +502,7 @@ int monodroid_debug_connect (int sock, struct sockaddr_in addr) {
 	socklen_t len;
 	int val = 0;
 
-	flags = fcntl (sock, F_GETFL, NULL);
+	flags = fcntl (sock, F_GETFL, nullptr);
 	flags |= O_NONBLOCK;
 	fcntl (sock, F_SETFL, flags);
 
@@ -533,7 +533,7 @@ int monodroid_debug_connect (int sock, struct sockaddr_in addr) {
 		}
 	}
 
-	flags = fcntl (sock, F_GETFL, NULL);
+	flags = fcntl (sock, F_GETFL, nullptr);
 	flags &= (~O_NONBLOCK);
 	fcntl (sock, F_SETFL, flags);
 
@@ -554,7 +554,7 @@ monodroid_debug_accept (int sock, struct sockaddr_in addr)
 	if (res < 0)
 		return -2;
 
-	accepted = accept (sock, NULL, NULL);
+	accepted = accept (sock, nullptr, nullptr);
 	if (accepted < 0)
 		return -3;
 
@@ -603,7 +603,7 @@ parse_gdb_options (void)
 
 		v = atoll (val + strlen ("wait:"));
 		if (v > 100000) {
-			time_t secs = time (NULL);
+			time_t secs = time (nullptr);
 
 			if (v + 10 < secs) {
 				log_warn (LOG_DEFAULT, "Found stale %s property with value '%s', not waiting.", Debug::DEBUG_MONO_GDB_PROPERTY, val);
@@ -643,7 +643,7 @@ parse_runtime_args (char *runtime_args, RuntimeOptions *options)
 		const char *arg = *ptr;
 
 		if (!strncmp (arg, "debug", 5)) {
-			char *host = NULL;
+			char *host = nullptr;
 			int sdb_port = 1000, out_port = -1;
 
 			options->debug = 1;
@@ -719,7 +719,7 @@ parse_runtime_args (char *runtime_args, RuntimeOptions *options)
 static void
 set_debug_options (void)
 {
-	if (utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_DEBUG_PROPERTY, NULL) == 0)
+	if (utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_DEBUG_PROPERTY, nullptr) == 0)
 		return;
 
 	register_debug_symbols = 1;
@@ -729,7 +729,7 @@ set_debug_options (void)
 #ifdef ANDROID
 #ifdef DEBUG
 static const char *soft_breakpoint_kernel_list[] = {
-	"2.6.32.21-g1e30168", NULL
+	"2.6.32.21-g1e30168", nullptr
 };
 
 static int
@@ -791,7 +791,7 @@ mono_runtime_init (char *runtime_args)
 #if defined (DEBUG) && !defined (WINDOWS)
 	memset(&options, 0, sizeof (options));
 
-	cur_time = time (NULL);
+	cur_time = time (nullptr);
 
 	if (!parse_runtime_args (runtime_args, &options)) {
 		log_error (LOG_DEFAULT, "Failed to parse runtime args: '%s'", runtime_args);
@@ -879,7 +879,7 @@ mono_runtime_init (char *runtime_args)
 
 		profile_events |= MonoProfileFlags::MONO_PROFILE_JIT_COMPILATION;
 	}
-	monoFunctions.profiler_install ((MonoProfiler*)&monodroid_profiler, NULL);
+	monoFunctions.profiler_install ((MonoProfiler*)&monodroid_profiler, nullptr);
 	monoFunctions.profiler_set_events (profile_events);
 	monoFunctions.profiler_install_thread (reinterpret_cast<void*> (thread_start), reinterpret_cast<void*> (thread_end));
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
@@ -940,7 +940,7 @@ mono_runtime_init (char *runtime_args)
 	 */
 	monodroid_embedded_assemblies_install_preload_hook (&monoFunctions);
 #ifndef RELEASE
-	monoFunctions.install_assembly_preload_hook (open_from_update_dir, NULL);
+	monoFunctions.install_assembly_preload_hook (open_from_update_dir, nullptr);
 #endif
 }
 
@@ -972,23 +972,23 @@ create_domain (JNIEnv *env, jclass runtimeClass, jstring_array_wrapper &runtimeA
 		// Check that our corlib is coherent with the version of Mono we loaded otherwise
 		// tell the IDE that the project likely need to be recompiled.
 		char* corlib_error_message = monoFunctions.check_corlib_version ();
-		if (corlib_error_message == NULL) {
+		if (corlib_error_message == nullptr) {
 			if (!androidSystem.monodroid_get_system_property ("xamarin.studio.fakefaultycorliberrormessage", &corlib_error_message)) {
 				free (corlib_error_message);
-				corlib_error_message = NULL;
+				corlib_error_message = nullptr;
 			}
 		}
-		if (corlib_error_message != NULL) {
+		if (corlib_error_message != nullptr) {
 			jclass ex_klass = env->FindClass ("mono/android/MonoRuntimeException");
 			env->ThrowNew (ex_klass, corlib_error_message);
 			free (corlib_error_message);
-			return NULL;
+			return nullptr;
 		}
 
 		// Load a basic environment for the RootDomain if run on desktop so that we can unload
 		// and reload most assemblies including Mono.Android itself
 		MonoAssemblyName *aname = monoFunctions.assembly_name_new ("System");
-		monoFunctions.assembly_load_full (aname, NULL, NULL, 0);
+		monoFunctions.assembly_load_full (aname, nullptr, nullptr, 0);
 		monoFunctions.assembly_name_free (aname);
 	}
 
@@ -1025,7 +1025,7 @@ _monodroid_timezone_get_default_id (void)
 	jmethodID getID      = env->GetMethodID (TimeZone_class, "getID",      "()Ljava/lang/String;");
 	jobject d            = env->CallStaticObjectMethod (TimeZone_class, getDefault);
 	jstring id           = reinterpret_cast<jstring> (env->CallObjectMethod (d, getID));
-	const char *mutf8    = env->GetStringUTFChars (id, NULL);
+	const char *mutf8    = env->GetStringUTFChars (id, nullptr);
 	char *def_id         = utils.monodroid_strdup_printf ("%s", mutf8);
 
 	env->ReleaseStringUTFChars (id, mutf8);
@@ -1068,7 +1068,7 @@ MONO_API int
 _monodroid_get_display_dpi (float *x_dpi, float *y_dpi)
 {
 	void *args[2];
-	MonoObject *exc = NULL;
+	MonoObject *exc = nullptr;
 
 	if (!x_dpi) {
 		log_error (LOG_DEFAULT, "Internal error: x_dpi parameter missing in get_display_dpi");
@@ -1105,7 +1105,7 @@ _monodroid_get_display_dpi (float *x_dpi, float *y_dpi)
 
 	args [0] = x_dpi;
 	args [1] = y_dpi;
-	utils.monodroid_runtime_invoke (domain != nullptr ? domain : monoFunctions.get_root_domain (), runtime_GetDisplayDPI, NULL, args, &exc);
+	utils.monodroid_runtime_invoke (domain != nullptr ? domain : monoFunctions.get_root_domain (), runtime_GetDisplayDPI, nullptr, args, &exc);
 	if (exc) {
 		*x_dpi = DEFAULT_X_DPI;
 		*y_dpi = DEFAULT_Y_DPI;
@@ -1202,7 +1202,7 @@ init_android_runtime (MonoDomain *domain, JNIEnv *env, jclass runtimeClass, jobj
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
 		partial_time.mark_start ();
 
-	utils.monodroid_runtime_invoke (domain, method, NULL, args, NULL);
+	utils.monodroid_runtime_invoke (domain, method, nullptr, args, nullptr);
 
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
 		partial_time.mark_end ();
@@ -1228,7 +1228,7 @@ shutdown_android_runtime (MonoDomain *domain)
 	MonoClass *runtime = get_android_runtime_class (domain);
 	MonoMethod *method = monoFunctions.class_get_method_from_name (runtime, "Exit", 0);
 
-	utils.monodroid_runtime_invoke (domain, method, NULL, NULL, NULL);
+	utils.monodroid_runtime_invoke (domain, method, nullptr, nullptr, nullptr);
 }
 
 static void
@@ -1241,14 +1241,14 @@ propagate_uncaught_exception (MonoDomain *domain, JNIEnv *env, jobject javaThrea
 	args[0] = &env;
 	args[1] = &javaThread;
 	args[2] = &javaException;
-	utils.monodroid_runtime_invoke (domain, method, NULL, args, NULL);
+	utils.monodroid_runtime_invoke (domain, method, nullptr, args, nullptr);
 }
 
 #if DEBUG
 static void
 setup_gc_logging (void)
 {
-	gc_spew_enabled = utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_GC_PROPERTY, NULL) > 0;
+	gc_spew_enabled = utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_GC_PROPERTY, nullptr) > 0;
 	if (gc_spew_enabled) {
 		log_categories |= LOG_GC;
 	}
@@ -1271,19 +1271,19 @@ static void*
 monodroid_dlopen (const char *name, int flags, char **err, void *user_data)
 {
 	int dl_flags = convert_dl_flags (flags);
-	void *h = NULL;
-	char *full_name = NULL;
-	char *basename = NULL;
+	void *h = nullptr;
+	char *full_name = nullptr;
+	char *basename = nullptr;
 	mono_bool libmonodroid_fallback = FALSE;
 
-	/* name is NULL when we're P/Invoking __Internal, so remap to libmonodroid */
-	if (name == NULL) {
+	/* name is nullptr when we're P/Invoking __Internal, so remap to libmonodroid */
+	if (name == nullptr) {
 		name = "libmonodroid.so";
 		libmonodroid_fallback = TRUE;
 	}
 
 	h = androidSystem.load_dso_from_any_directories (name, dl_flags);
-	if (h != NULL) {
+	if (h != nullptr) {
 		goto done_and_out;
 	}
 
@@ -1298,7 +1298,7 @@ monodroid_dlopen (const char *name, int flags, char **err, void *user_data)
 	}
 
 	basename = const_cast<char*> (strrchr (name, '/'));
-	if (basename != NULL)
+	if (basename != nullptr)
 		basename++;
 	else
 		basename = (char*)name;
@@ -1306,7 +1306,7 @@ monodroid_dlopen (const char *name, int flags, char **err, void *user_data)
 	basename = monodroid_strdup_printf ("libaot-%s", basename);
 	h = androidSystem.load_dso_from_any_directories (basename, dl_flags);
 
-	if (h != NULL && XA_UNLIKELY (utils.should_log (LOG_ASSEMBLY)))
+	if (h != nullptr && XA_UNLIKELY (utils.should_log (LOG_ASSEMBLY)))
 		log_info_nocheck (LOG_ASSEMBLY, "Loaded AOT image '%s'", basename);
 
   done_and_out:
@@ -1458,7 +1458,7 @@ monodroid_profiler_load (const char *libmono_path, const char *desc, const char 
 	const char* col = strchr (desc, ':');
 	char *mname;
 
-	if (col != NULL) {
+	if (col != nullptr) {
 		mname = new char [col - desc + 1];
 		strncpy (mname, desc, col - desc);
 		mname [col - desc] = 0;
@@ -1472,14 +1472,14 @@ monodroid_profiler_load (const char *libmono_path, const char *desc, const char 
 	void *handle = androidSystem.load_dso_from_any_directories (libname, dlopen_flags);
 	found = load_profiler_from_handle (handle, desc, mname);
 
-	if (!found && libmono_path != NULL) {
+	if (!found && libmono_path != nullptr) {
 		char *full_path = utils.path_combine (libmono_path, libname);
 		handle = androidSystem.load_dso (full_path, dlopen_flags, FALSE);
 		free (full_path);
 		found = load_profiler_from_handle (handle, desc, mname);
 	}
 
-	if (found && logfile != NULL)
+	if (found && logfile != nullptr)
 		utils.set_world_accessable (logfile);
 
 	if (!found)
@@ -1533,7 +1533,7 @@ set_profile_options (JNIEnv *env)
 		output = utils.path_combine (androidSystem.get_override_dir (0), filename);
 		ovalue = utils.monodroid_strdup_printf ("%s%soutput=%s",
 				value,
-				col == NULL ? ":" : ",",
+				col == nullptr ? ":" : ",",
 				output);
 		free (value);
 		free (extension);
@@ -1681,7 +1681,7 @@ start_profiling (void)
 		return;
 
 	log_info (LOG_DEFAULT, "Loading profiler: '%s'", profiler_description);
-	monodroid_profiler_load (runtime_libdir, profiler_description, NULL);
+	monodroid_profiler_load (runtime_libdir, profiler_description, nullptr);
 }
 
 #endif  // def DEBUG
@@ -1717,7 +1717,7 @@ disable_external_signal_handlers (void)
 MONO_API void
 _monodroid_counters_dump (const char *format, ...)
 {
-	if (counters == NULL)
+	if (counters == nullptr)
 		return;
 
 	va_list args;
@@ -1833,13 +1833,13 @@ Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobject
 #endif
 	setup_bundled_app ("libmonodroid_bundle_app.so");
 
-	if (runtimeNativeLibDir != NULL) {
+	if (runtimeNativeLibDir != nullptr) {
 		jstr = runtimeNativeLibDir;
 		runtime_libdir = strdup (jstr.get_cstr ());
 		log_warn (LOG_DEFAULT, "Using runtime path: %s", runtime_libdir);
 	}
 
-	void *libmonosgen_handle = NULL;
+	void *libmonosgen_handle = nullptr;
 
 	/*
 	 * We need to use RTLD_GLOBAL so that libmono-profiler-log.so can resolve
@@ -1850,7 +1850,7 @@ Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobject
 		libmonosgen_handle = androidSystem.load_dso_from_any_directories (AndroidSystem::MONO_SGEN_SO, sgen_dlopen_flags);
 	}
 
-	if (libmonosgen_handle == NULL)
+	if (libmonosgen_handle == nullptr)
 		libmonosgen_handle = androidSystem.load_dso (androidSystem.get_libmonosgen_path (), sgen_dlopen_flags, FALSE);
 
 	if (!monoFunctions.init (libmonosgen_handle)) {
@@ -1868,7 +1868,7 @@ Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobject
 		free (counters_path);
 	}
 
-	monoFunctions.dl_fallback_register (monodroid_dlopen, monodroid_dlsym, NULL, NULL);
+	monoFunctions.dl_fallback_register (monodroid_dlopen, monodroid_dlsym, nullptr, nullptr);
 
 	set_profile_options (env);
 
@@ -1887,7 +1887,7 @@ Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobject
 			}
 
 			/* Wait for XS to configure debugging/profiling */
-			gettimeofday(&wait_tv, NULL);
+			gettimeofday(&wait_tv, nullptr);
 			wait_ts.tv_sec = wait_tv.tv_sec + 2;
 			wait_ts.tv_nsec = wait_tv.tv_usec * 1000;
 			start_debugging ();
@@ -1974,12 +1974,12 @@ JNICALL Java_mono_android_Runtime_register (JNIEnv *env, jclass klass, jstring m
 		total_time.mark_start ();
 
 	managedType_len = env->GetStringLength (managedType);
-	managedType_ptr = env->GetStringChars (managedType, NULL);
+	managedType_ptr = env->GetStringChars (managedType, nullptr);
 
 	methods_len = env->GetStringLength (methods);
-	methods_ptr = env->GetStringChars (methods, NULL);
+	methods_ptr = env->GetStringChars (methods, nullptr);
 
-	mt_ptr = env->GetStringUTFChars (managedType, NULL);
+	mt_ptr = env->GetStringUTFChars (managedType, nullptr);
 	type = utils.monodroid_strdup_printf ("%s", mt_ptr);
 	env->ReleaseStringUTFChars (managedType, mt_ptr);
 
@@ -1992,7 +1992,7 @@ JNICALL Java_mono_android_Runtime_register (JNIEnv *env, jclass klass, jstring m
 	monoFunctions.jit_thread_attach (domain);
 	// Refresh current domain as it might have been modified by the above call
 	domain = monoFunctions.domain_get ();
-	utils.monodroid_runtime_invoke (domain, registerType, NULL, args, NULL);
+	utils.monodroid_runtime_invoke (domain, registerType, nullptr, args, nullptr);
 
 	env->ReleaseStringChars (managedType, managedType_ptr);
 	env->ReleaseStringChars (methods, methods_ptr);
@@ -2059,7 +2059,7 @@ JNICALL Java_mono_android_Runtime_destroyContexts (JNIEnv *env, jclass klass, ji
 	monoFunctions.jit_thread_attach (root_domain);
 	current_context_id = -1;
 
-	jint *contextIDs = env->GetIntArrayElements (array, NULL);
+	jint *contextIDs = env->GetIntArrayElements (array, nullptr);
 	jsize count = env->GetArrayLength (array);
 
 	log_info (LOG_DEFAULT, "Cleaning %d domains", count);
@@ -2069,7 +2069,7 @@ JNICALL Java_mono_android_Runtime_destroyContexts (JNIEnv *env, jclass klass, ji
 		int domain_id = contextIDs[i];
 		MonoDomain *domain = monoFunctions.domain_get_by_id (domain_id);
 
-		if (domain == NULL)
+		if (domain == nullptr)
 			continue;
 		log_info (LOG_DEFAULT, "Shutting down domain `%d'", contextIDs[i]);
 		shutdown_android_runtime (domain);
@@ -2081,7 +2081,7 @@ JNICALL Java_mono_android_Runtime_destroyContexts (JNIEnv *env, jclass klass, ji
 		int domain_id = contextIDs[i];
 		MonoDomain *domain = monoFunctions.domain_get_by_id (domain_id);
 
-		if (domain == NULL)
+		if (domain == nullptr)
 			continue;
 		log_info (LOG_DEFAULT, "Unloading domain `%d'", contextIDs[i]);
 		monoFunctions.domain_unload (domain);
@@ -2129,7 +2129,7 @@ extern "C" void monodroid_dylib_mono_free (DylibMono *mono_imports)
   this function is used from JavaInterop and should be treated as public API
   https://github.com/xamarin/java.interop/blob/master/src/java-interop/java-interop-gc-bridge-mono.c#L266
 
-  it should also accept libmono_path = NULL parameter
+  it should also accept libmono_path = nullptr parameter
 */
 extern "C" int monodroid_dylib_mono_init (DylibMono *mono_imports, const char *libmono_path)
 {

--- a/src/monodroid/jni/monodroid-networkinfo.cc
+++ b/src/monodroid/jni/monodroid-networkinfo.cc
@@ -117,7 +117,7 @@ _monodroid_get_network_interface_state (const char *ifname, mono_bool *is_up, mo
 	if (!ret)
 		log_warn (LOG_NET, "Unable to determine interface '%s' state using Java API", ifname);
 
-	if (networkInterface != NULL && env != NULL) {
+	if (networkInterface != nullptr && env != nullptr) {
 		env->DeleteLocalRef (networkInterface);
 	}
 
@@ -128,14 +128,14 @@ _monodroid_get_network_interface_state (const char *ifname, mono_bool *is_up, mo
 MONO_API mono_bool
 _monodroid_get_network_interface_up_state (const char *ifname, mono_bool *is_up)
 {
-	return _monodroid_get_network_interface_state (ifname, is_up, NULL);
+	return _monodroid_get_network_interface_state (ifname, is_up, nullptr);
 }
 
 /* !DO NOT REMOVE! Used by Mono BCL (System.Net.NetworkInformation.NetworkInterface) */
 MONO_API mono_bool
 _monodroid_get_network_interface_supports_multicast (const char *ifname, mono_bool *supports_multicast)
 {
-	return _monodroid_get_network_interface_state (ifname, NULL, supports_multicast);
+	return _monodroid_get_network_interface_state (ifname, nullptr, supports_multicast);
 }
 
 /* !DO NOT REMOVE! Used by Mono BCL (System.Net.NetworkInformation.UnixIPInterfaceProperties) */
@@ -146,7 +146,7 @@ _monodroid_get_dns_servers (void **dns_servers_array)
 		log_warn (LOG_NET, "Unable to get DNS servers, no location to store data in");
 		return -1;
 	}
-	*dns_servers_array = NULL;
+	*dns_servers_array = nullptr;
 
 	size_t  len;
 	char   *dns;
@@ -157,7 +157,7 @@ _monodroid_get_dns_servers (void **dns_servers_array)
 		prop_name [7] = (char)(i + 0x31);
 		len = monodroid_get_system_property (prop_name, &dns);
 		if (len == 0) {
-			dns_servers [i] = NULL;
+			dns_servers [i] = nullptr;
 			continue;
 		}
 		dns_servers [i] = strndup (dns, len);

--- a/src/monodroid/jni/osbridge.cc
+++ b/src/monodroid/jni/osbridge.cc
@@ -74,7 +74,7 @@ static pid_t gettid ()
 	return syscall (SYS_gettid);
 #else
 	uint64_t tid;
-	pthread_threadid_np (NULL, &tid);
+	pthread_threadid_np (nullptr, &tid);
 	return (pid_t)tid;
 #endif
 }
@@ -86,11 +86,11 @@ OSBridge::clear_mono_java_gc_bridge_info ()
 {
 	for (uint32_t c = 0; c < NUM_GC_BRIDGE_TYPES; c++) {
 		MonoJavaGCBridgeInfo *info = &mono_java_gc_bridge_info [c];
-		info->klass = NULL;
-		info->handle = NULL;
-		info->handle_type = NULL;
-		info->refs_added = NULL;
-		info->weak_handle = NULL;
+		info->klass = nullptr;
+		info->handle = nullptr;
+		info->handle_type = nullptr;
+		info->refs_added = nullptr;
+		info->weak_handle = nullptr;
 	}
 }
 
@@ -101,7 +101,7 @@ OSBridge::get_gc_bridge_index (MonoClass *klass)
 
 	for (uint32_t i = 0; i < NUM_GC_BRIDGE_TYPES; ++i) {
 		MonoClass *k = mono_java_gc_bridge_info [i].klass;
-		if (k == NULL) {
+		if (k == nullptr) {
 			f++;
 			continue;
 		}
@@ -118,20 +118,20 @@ OSBridge::get_gc_bridge_info_for_class (MonoClass *klass)
 {
 	int   i;
 
-	if (klass == NULL)
-		return NULL;
+	if (klass == nullptr)
+		return nullptr;
 
 	i   = get_gc_bridge_index (klass);
 	if (i < 0)
-		return NULL;
+		return nullptr;
 	return &mono_java_gc_bridge_info [i];
 }
 
 OSBridge::MonoJavaGCBridgeInfo *
 OSBridge::get_gc_bridge_info_for_object (MonoObject *object)
 {
-	if (object == NULL)
-		return NULL;
+	if (object == nullptr)
+		return nullptr;
 	return get_gc_bridge_info_for_class (monoFunctions.object_get_class (object));
 }
 
@@ -150,7 +150,7 @@ char
 OSBridge::get_object_ref_type (JNIEnv *env, void *handle)
 {
 	jobjectRefType value;
-	if (handle == NULL)
+	if (handle == nullptr)
 		return 'I';
 	value = env->GetObjectRefType (reinterpret_cast<jobject> (handle));
 	switch (value) {
@@ -407,7 +407,7 @@ OSBridge::take_global_ref_2_1_compat (JNIEnv *env, MonoObject *obj)
 	int type = JNIGlobalRefType;
 
 	MonoJavaGCBridgeInfo    *bridge_info    = get_gc_bridge_info_for_object (obj);
-	if (bridge_info == NULL)
+	if (bridge_info == nullptr)
 		return 0;
 
 	monoFunctions.field_get_value (obj, bridge_info->weak_handle, &weak);
@@ -425,12 +425,12 @@ OSBridge::take_global_ref_2_1_compat (JNIEnv *env, MonoObject *obj)
 	}
 	_monodroid_weak_gref_delete (weak, get_object_ref_type (env, weak), "finalizer", gettid(), __PRETTY_FUNCTION__, 0);
 	env->DeleteGlobalRef (weak);
-	weak = NULL;
+	weak = nullptr;
 	monoFunctions.field_set_value (obj, bridge_info->weak_handle, &weak);
 
 	monoFunctions.field_set_value (obj, bridge_info->handle, &handle);
 	monoFunctions.field_set_value (obj, bridge_info->handle_type, &type);
-	return handle != NULL;
+	return handle != nullptr;
 }
 
 mono_bool
@@ -440,7 +440,7 @@ OSBridge::take_weak_global_ref_2_1_compat (JNIEnv *env, MonoObject *obj)
 	jobject handle, weakglobal;
 
 	MonoJavaGCBridgeInfo    *bridge_info    = get_gc_bridge_info_for_object (obj);
-	if (bridge_info == NULL)
+	if (bridge_info == nullptr)
 		return 0;
 
 	monoFunctions.field_get_value (obj, bridge_info->handle, &handle);
@@ -468,7 +468,7 @@ OSBridge::take_global_ref_jni (JNIEnv *env, MonoObject *obj)
 	int type = JNIGlobalRefType;
 
 	MonoJavaGCBridgeInfo    *bridge_info    = get_gc_bridge_info_for_object (obj);
-	if (bridge_info == NULL)
+	if (bridge_info == nullptr)
 		return 0;
 
 	monoFunctions.field_get_value (obj, bridge_info->handle, &weak);
@@ -487,13 +487,13 @@ OSBridge::take_global_ref_jni (JNIEnv *env, MonoObject *obj)
 			"finalizer", gettid (), "take_global_ref_jni", 0);
 	env->DeleteWeakGlobalRef (weak);
 	if (!handle) {
-		void *old_handle = NULL;
+		void *old_handle = nullptr;
 
 		monoFunctions.field_get_value (obj, bridge_info->handle, &old_handle);
 	}
 	monoFunctions.field_set_value (obj, bridge_info->handle, &handle);
 	monoFunctions.field_set_value (obj, bridge_info->handle_type, &type);
-	return handle != NULL;
+	return handle != nullptr;
 }
 
 mono_bool
@@ -503,7 +503,7 @@ OSBridge::take_weak_global_ref_jni (JNIEnv *env, MonoObject *obj)
 	int type = JNIWeakGlobalRefType;
 
 	MonoJavaGCBridgeInfo    *bridge_info    = get_gc_bridge_info_for_object (obj);
-	if (bridge_info == NULL)
+	if (bridge_info == nullptr)
 		return 0;
 
 	monoFunctions.field_get_value (obj, bridge_info->handle, &handle);
@@ -553,11 +553,11 @@ OSBridge::gc_is_bridge_object (MonoObject *object)
 	void *handle;
 
 	MonoJavaGCBridgeInfo    *bridge_info    = get_gc_bridge_info_for_object (object);
-	if (bridge_info == NULL)
+	if (bridge_info == nullptr)
 		return 0;
 
 	monoFunctions.field_get_value (object, bridge_info->handle, &handle);
-	if (handle == NULL) {
+	if (handle == nullptr) {
 #if DEBUG
 		MonoClass *mclass = monoFunctions.object_get_class (object);
 		log_info (LOG_GC, "object of class %s.%s with null handle",
@@ -626,7 +626,7 @@ OSBridge::describe_target (OSBridge::AddReferenceTarget target)
 mono_bool
 OSBridge::add_reference (JNIEnv *env, OSBridge::AddReferenceTarget target, OSBridge::AddReferenceTarget reffed_target)
 {
-	MonoJavaGCBridgeInfo *bridge_info = NULL, *reffed_bridge_info = NULL;
+	MonoJavaGCBridgeInfo *bridge_info = nullptr, *reffed_bridge_info = nullptr;
 	jobject handle, reffed_handle;
 
 	if (!load_reference_target (target, &bridge_info, &handle))
@@ -731,7 +731,7 @@ void
 OSBridge::gc_prepare_for_java_collection (JNIEnv *env, int num_sccs, MonoGCBridgeSCC **sccs, int num_xrefs, MonoGCBridgeXRef *xrefs)
 {
 	/* Some SCCs might have no IGCUserPeers associated with them, so we must create one */
-	jobject temporary_peers = NULL;     // This is an ArrayList
+	jobject temporary_peers = nullptr;     // This is an ArrayList
 	int temporary_peer_count = 0;       // Number of items in temporary_peers
 
 	/* Before looking at xrefs, scan the SCCs. During collection, an SCC has to behave like a
@@ -849,7 +849,7 @@ OSBridge::gc_cleanup_after_java_collection (JNIEnv *env, int num_sccs, MonoGCBri
 			obj = sccs [i]->objs [j];
 
 			bridge_info = get_gc_bridge_info_for_object (obj);
-			if (bridge_info == NULL)
+			if (bridge_info == nullptr)
 				continue;
 			monoFunctions.field_get_value (obj, bridge_info->handle, &jref);
 			if (jref) {
@@ -895,7 +895,7 @@ OSBridge::java_gc (JNIEnv *env)
 void
 OSBridge::set_bridge_processing_field (MonodroidBridgeProcessingInfo *list, mono_bool value)
 {
-	for ( ; list != NULL; list = list->next) {
+	for ( ; list != nullptr; list = list->next) {
 		MonoClassField *bridge_processing_field = list->bridge_processing_field;
 		MonoVTable *jnienv_vtable = list->jnienv_vtable;
 		monoFunctions.field_static_set_value (jnienv_vtable, bridge_processing_field, &value);
@@ -1094,16 +1094,16 @@ void
 OSBridge::remove_monodroid_domain (MonoDomain *domain)
 {
 	MonodroidBridgeProcessingInfo *node = domains_list;
-	MonodroidBridgeProcessingInfo *prev = NULL;
+	MonodroidBridgeProcessingInfo *prev = nullptr;
 
-	while (node != NULL) {
+	while (node != nullptr) {
 		if (node->domain != domain) {
 			prev = node;
 			node = node->next;
 			continue;
 		}
 
-		if (prev != NULL)
+		if (prev != nullptr)
 			prev->next = node->next;
 		else
 			domains_list = node->next;

--- a/src/monodroid/jni/timezones.cc
+++ b/src/monodroid/jni/timezones.cc
@@ -48,9 +48,9 @@ clear_time_zone_caches_within_domain (void *user_data)
 
 	mono->runtime_invoke (
 			AndroidEnvironment_NotifyTimeZoneChanged, /* method */
-			nullptr,                                     /* obj    */
-			nullptr,                                     /* args   */
-			nullptr                                      /* exc    */
+			nullptr,                                  /* obj    */
+			nullptr,                                  /* args   */
+			nullptr                                   /* exc    */
 	);
 }
 

--- a/src/monodroid/jni/timezones.cc
+++ b/src/monodroid/jni/timezones.cc
@@ -35,7 +35,7 @@ init (DylibMono *mono)
 	AndroidEnvironment                        = mono->class_from_name (Mono_Android_image,  "Android.Runtime",  "AndroidEnvironment");
 	AndroidEnvironment_NotifyTimeZoneChanged  = mono->class_get_method_from_name (AndroidEnvironment, "NotifyTimeZoneChanged", 0);
 
-	if (AndroidEnvironment_NotifyTimeZoneChanged == NULL) {
+	if (AndroidEnvironment_NotifyTimeZoneChanged == nullptr) {
 		log_fatal (LOG_DEFAULT, "Unable to find Android.Runtime.AndroidEnvironment.NotifyTimeZoneChanged()!");
 		exit (FATAL_EXIT_MISSING_ASSEMBLY);
 	}
@@ -48,9 +48,9 @@ clear_time_zone_caches_within_domain (void *user_data)
 
 	mono->runtime_invoke (
 			AndroidEnvironment_NotifyTimeZoneChanged, /* method */
-			NULL,                                     /* obj    */
-			NULL,                                     /* args   */
-			NULL                                      /* exc    */
+			nullptr,                                     /* obj    */
+			nullptr,                                     /* args   */
+			nullptr                                      /* exc    */
 	);
 }
 

--- a/src/monodroid/jni/util.cc
+++ b/src/monodroid/jni/util.cc
@@ -88,18 +88,18 @@ Util::ends_with (const char *str, const char *end)
 
 	p = const_cast<char*> (strstr (str, end));
 
-	return p != NULL && p [strlen (end)] == 0;
+	return p != nullptr && p [strlen (end)] == 0;
 }
 
 char*
 Util::path_combine(const char *path1, const char *path2)
 {
-	// Don't let erroneous NULL parameters situation propagate
-	assert (path1 != NULL || path2 != NULL);
+	// Don't let erroneous nullptr parameters situation propagate
+	assert (path1 != nullptr || path2 != nullptr);
 
-	if (path1 == NULL)
+	if (path1 == nullptr)
 		return strdup (path2);
-	if (path2 == NULL)
+	if (path2 == nullptr)
 		return strdup (path1);
 	return monodroid_strdup_printf ("%s" MONODROID_PATH_SEPARATOR "%s", path1, path2);
 }
@@ -107,7 +107,7 @@ Util::path_combine(const char *path1, const char *path2)
 void
 Util::add_to_vector (char ***vector, int size, char *token)
 {
-	*vector = *vector == NULL ? 
+	*vector = *vector == nullptr ? 
 		(char **)xmalloc(2 * sizeof(*vector)) :
 		(char **)xrealloc(*vector, (size + 1) * sizeof(*vector));
 		
@@ -118,9 +118,9 @@ void
 Util::monodroid_strfreev (char **str_array)
 {
 	char **orig = str_array;
-	if (str_array == NULL)
+	if (str_array == nullptr)
 		return;
-	while (*str_array != NULL){
+	while (*str_array != nullptr){
 		free (*str_array);
 		str_array++;
 	}
@@ -140,7 +140,7 @@ Util::monodroid_strsplit (const char *str, const char *delimiter, int max_tokens
 		size++;
 		str += strlen (delimiter);
 	} else {
-		vector = NULL;
+		vector = nullptr;
 	}
 
 	while (*str && !(max_tokens > 0 && size >= max_tokens)) {
@@ -185,11 +185,11 @@ Util::monodroid_strsplit (const char *str, const char *delimiter, int max_tokens
 		size++;
 	}
 	
-	if (vector == NULL) {
+	if (vector == nullptr) {
 		vector = (char **) xmalloc (2 * sizeof (vector));
-		vector [0] = NULL;
+		vector [0] = nullptr;
 	} else if (size > 0) {
-		vector[size - 1] = NULL;
+		vector[size - 1] = nullptr;
 	}
 	
 	return vector;
@@ -323,11 +323,11 @@ Util::monodroid_store_package_name (const char *name)
 int
 Util::monodroid_get_namespaced_system_property (const char *name, char **value)
 {
-	char *local_value = NULL;
+	char *local_value = nullptr;
 	int result = -1;
 
 	if (value)
-		*value = NULL;
+		*value = nullptr;
 
 	if (strlen (package_property_suffix) > 0) {
 		log_info (LOG_DEFAULT, "Trying to get property %s.%s", name, package_property_suffix);
@@ -371,10 +371,10 @@ Util::monodroid_load_assembly (MonoDomain *domain, const char *basename)
 
 	if (domain != current) {
 		monoFunctions.domain_set (domain, FALSE);
-		assm  = monoFunctions.assembly_load_full (aname, NULL, &status, 0);
+		assm  = monoFunctions.assembly_load_full (aname, nullptr, &status, 0);
 		monoFunctions.domain_set (current, FALSE);
 	} else {
-		assm  = monoFunctions.assembly_load_full (aname, NULL, &status, 0);
+		assm  = monoFunctions.assembly_load_full (aname, nullptr, &status, 0);
 	}
 
 	monoFunctions.assembly_name_free (aname);
@@ -425,16 +425,16 @@ Util::monodroid_create_appdomain (MonoDomain *parent_domain, const char *friendl
 	MonoObject *setup = monoFunctions.object_new (parent_domain, appdomain_setup_klass);
 	MonoString *mono_friendly_name = monoFunctions.string_new (parent_domain, friendly_name);
 	MonoString *mono_shadow_copy = monoFunctions.string_new (parent_domain, shadow_copy ? "true" : "false");
-	MonoString *mono_shadow_copy_dirs = shadow_directories == NULL ? NULL : monoFunctions.string_new (parent_domain, shadow_directories);
+	MonoString *mono_shadow_copy_dirs = shadow_directories == nullptr ? nullptr : monoFunctions.string_new (parent_domain, shadow_directories);
 
-	monodroid_property_set (parent_domain, shadow_copy_prop, setup, reinterpret_cast<void**> (&mono_shadow_copy), NULL);
-	if (mono_shadow_copy_dirs != NULL)
-		monodroid_property_set (parent_domain, shadow_copy_dirs_prop, setup, reinterpret_cast<void**> (&mono_shadow_copy_dirs), NULL);
+	monodroid_property_set (parent_domain, shadow_copy_prop, setup, reinterpret_cast<void**> (&mono_shadow_copy), nullptr);
+	if (mono_shadow_copy_dirs != nullptr)
+		monodroid_property_set (parent_domain, shadow_copy_dirs_prop, setup, reinterpret_cast<void**> (&mono_shadow_copy_dirs), nullptr);
 
-	void *args[3] = { mono_friendly_name, NULL, setup };
-	MonoObject *appdomain = monodroid_runtime_invoke (parent_domain, create_domain, NULL, args, NULL);
-	if (appdomain == NULL)
-		return NULL;
+	void *args[3] = { mono_friendly_name, nullptr, setup };
+	MonoObject *appdomain = monodroid_runtime_invoke (parent_domain, create_domain, nullptr, args, nullptr);
+	if (appdomain == nullptr)
+		return nullptr;
 
 	return monoFunctions.domain_from_appdomain (appdomain);
 }
@@ -505,9 +505,9 @@ Util::set_user_executable (const char *path)
 MonoClass*
 Util::monodroid_get_class_from_name (MonoDomain *domain, const char* assembly, const char *_namespace, const char *type)
 {
-	MonoAssembly *assm = NULL;
-	MonoImage *image = NULL;
-	MonoClass *result = NULL;
+	MonoAssembly *assm = nullptr;
+	MonoImage *image = nullptr;
+	MonoClass *result = nullptr;
 	MonoAssemblyName *aname = monoFunctions.assembly_name_new (assembly);
 	MonoDomain *current = monoFunctions.domain_get ();
 
@@ -515,7 +515,7 @@ Util::monodroid_get_class_from_name (MonoDomain *domain, const char* assembly, c
 		monoFunctions.domain_set (domain, FALSE);
 
 	assm = monoFunctions.assembly_loaded (aname);
-	if (assm != NULL) {
+	if (assm != nullptr) {
 		image = monoFunctions.assembly_get_image (assm);
 		result = monoFunctions.class_from_name (image, _namespace, type);
 	}
@@ -531,7 +531,7 @@ Util::monodroid_get_class_from_name (MonoDomain *domain, const char* assembly, c
 MonoClass*
 Util::monodroid_get_class_from_image (MonoDomain *domain, MonoImage *image, const char *_namespace, const char *type)
 {
-	MonoClass *result = NULL;
+	MonoClass *result = nullptr;
 	MonoDomain *current = monoFunctions.domain_get ();
 
 	if (domain != current)

--- a/src/monodroid/jni/xamarin_getifaddrs.cc
+++ b/src/monodroid/jni/xamarin_getifaddrs.cc
@@ -688,7 +688,7 @@ fill_ll_address (struct sockaddr_ll_extended **sa, struct ifinfomsg *net_interfa
 	if (rta_payload_length > sizeof ((*sa)->sll_addr)) {
 		log_info (LOG_NETLINK, "Address is too long to place in sockaddr_ll (%d > %d)", rta_payload_length, sizeof ((*sa)->sll_addr));
 		delete *sa;
-		*sa = nullptr;
+		*sa = NULL;
 		return -1;
 	}
 	
@@ -705,7 +705,7 @@ find_interface_by_index (int index, struct _monodroid_ifaddrs **ifaddrs_head)
 {
 	struct _monodroid_ifaddrs *cur;
 	if (!ifaddrs_head || !*ifaddrs_head)
-		return nullptr;
+		return NULL;
 
 	/* Normally expensive, but with the small amount of links in the chain we'll deal with it's not
 	 * worth the extra houskeeping and memory overhead
@@ -719,7 +719,7 @@ find_interface_by_index (int index, struct _monodroid_ifaddrs **ifaddrs_head)
 		cur = cur->ifa_next;
 	}
 
-	return nullptr;
+	return NULL;
 }
 
 static char *
@@ -818,7 +818,7 @@ get_link_address (const struct nlmsghdr *message, struct _monodroid_ifaddrs **if
 	ssize_t length = 0;
 	struct rtattr *attribute;
 	struct ifaddrmsg *net_address;
-	struct _monodroid_ifaddrs *ifa = nullptr;
+	struct _monodroid_ifaddrs *ifa = NULL;
 	struct sockaddr **sa;
 	int payload_size;
 
@@ -842,7 +842,7 @@ get_link_address (const struct nlmsghdr *message, struct _monodroid_ifaddrs **if
 	while (RTA_OK (attribute, length)) {
 		payload_size = RTA_PAYLOAD (attribute);
 		log_debug (LOG_NETLINK, "     attribute payload_size == %u\n", payload_size);
-		sa = nullptr;
+		sa = NULL;
 		
 		switch (attribute->rta_type) {
 			case IFA_LABEL: {
@@ -967,8 +967,8 @@ get_link_info (const struct nlmsghdr *message)
 	ssize_t length;
 	struct rtattr *attribute;
 	struct ifinfomsg *net_interface;
-	struct _monodroid_ifaddrs *ifa = nullptr;
-	struct sockaddr_ll_extended *sa = nullptr;
+	struct _monodroid_ifaddrs *ifa = NULL;
+	struct sockaddr_ll_extended *sa = NULL;
 
 	assert (message);
 	net_interface = reinterpret_cast <ifinfomsg*> (NLMSG_DATA (message));
@@ -1031,7 +1031,7 @@ get_link_info (const struct nlmsghdr *message)
 		delete sa;
 	free_single_xamarin_ifaddrs (&ifa);
 	
-	return nullptr;
+	return NULL;
 }
 #else
 void


### PR DESCRIPTION
In effort to morph our current code to modern C++, this commit replaces all the
`NULL` macro instances with the C++ standard `nullptr` type. No functional
changes are present in this commit.

The only exception here is the `xamarin_getifaddrs.cc` file in which the reverse
operation is done - replacement of `nullptr` with `NULL`. The reason for this is
that the file is destined to be moved to the Mono codebase at some point and so,
at least for now, it should remain standard C99