### PR TITLE
[build] use WorkingDirectory for <GitBlame/>

### DIFF
--- a/build-tools/scripts/XAVersionInfo.targets
+++ b/build-tools/scripts/XAVersionInfo.targets
@@ -51,7 +51,7 @@
   <Target Name="GetXAVersionInfo"
       DependsOnTargets="_GetSubmodulesVersionInfo">
     <GitBlame
-        FileName="$(XamarinAndroidSourcePath)\Configuration.props"
+        FileName="Configuration.props"
         LineFilter="&lt;ProductVersion&gt;"
         WorkingDirectory="$(XamarinAndroidSourcePath)"
         ToolPath="$(GitToolPath)"

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitBlame.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitBlame.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 
 		protected override string GenerateCommandLineCommands ()
 		{
-			return $"blame \"{Path.GetFullPath (FileName.ItemSpec)}\"";
+			return $"blame \"{FileName.ItemSpec}\"";
 		}
 
 		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)


### PR DESCRIPTION
Downstream in monodroid, I'm getting a build failure such as:

    /usr/bin/git blame "/full/path/to/external/xamarin-android/Configuration.props"
    XAVersionInfo.targets(53,5): error MSB6006: "git" exited with code 128.
    XAVersionInfo.targets(61,5): error MSB4044: The "GitCommitsInRange" task was not given a value for the required parameter "StartCommit".

If I run the git command manually:

    fatal: not a git repository (or any of the parent directories): .git

It seems we shouldn't be using a full path here, but use
`WorkingDirectory` instead? Maybe it will not work if
`xamarin-android` is a submodule?

This has somehow been working in the past, so perhaps my version of
git is the cause?

    $ git --version
    git version 2.17.1 (Apple Git-112)