### PR TITLE
[Xamarin.Android.Build.Tasks] Support CustomViews with Aapt2

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
@@ -84,8 +84,8 @@ namespace Xamarin.Android.Tasks {
 				if (resdir == null) {
 					continue;
 				}
-				var hash = resdir?.GetMetadata ("Hash") ?? null;
-				var stamp = resdir?.GetMetadata ("StampFile") ?? null;
+				var hash = resdir.GetMetadata ("Hash");
+				var stamp = resdir.GetMetadata ("StampFile");
 				var filename = !string.IsNullOrEmpty (hash) ? hash : "compiled";
 				var stampFile = !string.IsNullOrEmpty (stamp) ? stamp : $"{filename}.stamp";
 				Log.LogDebugMessage ($"{filename} {stampFile}");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
@@ -23,6 +23,9 @@ namespace Xamarin.Android.Tasks {
 
 		public ITaskItem [] ResourceDirectories { get; set; }
 
+		[Output]
+		public ITaskItem [] Processed { get; set; }
+
 		public override bool Execute ()
 		{
 			var resource_name_case_map = MonoAndroidHelper.LoadResourceCaseMap (ResourceNameCaseMap);
@@ -75,7 +78,20 @@ namespace Xamarin.Android.Tasks {
 					}
 				}
 			}
-
+			var output = new List<ITaskItem> ();
+			foreach (var file in processed) {
+				ITaskItem resdir = ResourceDirectories?.FirstOrDefault (x => file.StartsWith (x.ItemSpec)) ?? null;
+				var hash = resdir?.GetMetadata ("Hash") ?? null;
+				var stamp = resdir?.GetMetadata ("StampFile") ?? null;
+				var filename = !string.IsNullOrEmpty (hash) ? hash : "compiled";
+				var stampFile = !string.IsNullOrEmpty (stamp) ? stamp : $"{filename}.stamp";
+				Log.LogDebugMessage ($"{filename} {stampFile}");
+				output.Add (new TaskItem (file, new Dictionary<string, string> {
+					{ "StampFile" , $"{stampFile}" },
+					{ "Hash" , $"{filename}" },
+				}));
+			}
+			Processed = output.ToArray ();
 			return !Log.HasLoggedErrors;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
@@ -81,6 +81,9 @@ namespace Xamarin.Android.Tasks {
 			var output = new List<ITaskItem> ();
 			foreach (var file in processed) {
 				ITaskItem resdir = ResourceDirectories?.FirstOrDefault (x => file.StartsWith (x.ItemSpec)) ?? null;
+				if (resdir == null) {
+					continue;
+				}
 				var hash = resdir?.GetMetadata ("Hash") ?? null;
 				var stamp = resdir?.GetMetadata ("StampFile") ?? null;
 				var filename = !string.IsNullOrEmpty (hash) ? hash : "compiled";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -461,6 +461,8 @@ namespace UnnamedProject
 				Assert.AreEqual ("@color/deep_purple_A200", item.Value, "item value should be @color/deep_purple_A200");
 				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "AndroidResgen: Warning while updating Resource XML"),
 					"Warning while processing resources should not have been raised.");
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsTrue (b.IsTargetSkipped ("_GenerateJavaStubs"), "Target _GenerateJavaStubs should have been skipped");
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -462,7 +462,7 @@ namespace UnnamedProject
 				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "AndroidResgen: Warning while updating Resource XML"),
 					"Warning while processing resources should not have been raised.");
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				Assert.IsTrue (b.IsTargetSkipped ("_GenerateJavaStubs"), "Target _GenerateJavaStubs should have been skipped");
+				Assert.IsTrue (b.Output.IsTargetSkipped ("_GenerateJavaStubs"), "Target _GenerateJavaStubs should have been skipped");
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ZipArchiveExTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ZipArchiveExTests.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Android.Build.Tests
 				}
 			}
 
-			Assert.AreEqual (expected.Trim (), builder.ToString ().Trim ());
+			Assert.AreEqual (expected.Trim ().Replace("\r\n", "\n"), builder.ToString ().Trim ().Replace("\r\n", "\n"));
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1423,13 +1423,17 @@ because xbuild doesn't support framework reference assemblies.
 		ToolPath="$(Aapt2ToolPath)"
 		ToolExe="$(Aapt2ToolExe)"
 	/>
+	<ItemGroup>
+		<_HashStampFiles Include="@(_LibraryResourceHashDirectories->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).stamp')" />
+		<_HashFlataFiles Include="@(_LibraryResourceHashDirectories->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).flata')" />
+	</ItemGroup>
 	<Touch
-			Files="@(_LibraryResourceHashDirectories->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).stamp')"
+			Files="@(_HashStampFiles)"
 			AlwaysCreate="True"
 	/>
 	<ItemGroup>
-		<FileWrites Include="@(_LibraryResourceHashDirectories->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).flata')" />
-		<FileWrites Include="@(_LibraryResourceHashDirectories->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).stamp')" />
+		<FileWrites Include="@(_HashStampFiles)" />
+		<FileWrites Include="@(_HashFlataFiles)" />
 	</ItemGroup>
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1409,8 +1409,8 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_CompileAndroidLibraryResources" DependsOnTargets="_ConvertLibraryResourcesCases"
 		Condition="'$(_AndroidUseAapt2)' == 'True'"
-		Inputs="%(_LibraryResourceHashDirectories.StampFile)"
-		Outputs="$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).stamp"
+		Inputs="@(_LibraryResourceHashDirectories->'%(StampFile)')"
+		Outputs="@(_LibraryResourceHashDirectories->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).stamp')"
 	>
 	<MakeDir Directories="$(_AndroidLibraryFlatArchivesDirectory)" Condition="!Exists('$(_AndroidLibraryFlatArchivesDirectory)')" />
 	<Aapt2Compile
@@ -1424,19 +1424,19 @@ because xbuild doesn't support framework reference assemblies.
 		ToolExe="$(Aapt2ToolExe)"
 	/>
 	<Touch
-			Files="$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).stamp"
+			Files="@(_LibraryResourceHashDirectories->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).stamp')"
 			AlwaysCreate="True"
 	/>
 	<ItemGroup>
-		<FileWrites Include="$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).flata" />
-		<FileWrites Include="$(_AndroidLibraryFlatArchivesDirectory)%(_LibraryResourceHashDirectories.Hash).stamp" />
+		<FileWrites Include="@(_LibraryResourceHashDirectories->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).flata')" />
+		<FileWrites Include="@(_LibraryResourceHashDirectories->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).stamp')" />
 	</ItemGroup>
 </Target>
 
 <Target Name="_CompileResources"
 		Condition="'$(_AndroidUseAapt2)' == 'True'"
 		Inputs="@(AndroidResource)"
-		Outputs="$(_AndroidLibraryFlatArchivesDirectory)\compiled.flata"
+		Outputs="$(_AndroidLibraryFlatArchivesDirectory)\compiled.stamp"
 	>
 	<MakeDir Directories="$(_AndroidLibraryFlatArchivesDirectory)" Condition="!Exists('$(_AndroidLibraryFlatArchivesDirectory)')" />
 	<!-- Change cases so we support mixed case resource names -->
@@ -1459,8 +1459,10 @@ because xbuild doesn't support framework reference assemblies.
 		ToolPath="$(Aapt2ToolPath)"
 		ToolExe="$(Aapt2ToolExe)"
 	/>
+	<Touch Files="$(_AndroidLibraryFlatArchivesDirectory)\compiled.stamp" AlwaysCreate="True" />
 	<ItemGroup>
 		<FileWrites Include="$(_AndroidLibraryFlatArchivesDirectory)\compiled.flata" />
+		<FileWrites Include="$(_AndroidLibraryFlatArchivesDirectory)\compiled.stamp" />
 	</ItemGroup>
 </Target>
 
@@ -2350,8 +2352,28 @@ because xbuild doesn't support framework reference assemblies.
 	Condition="Exists('$(_CustomViewMapFile)')"
 	CustomViewMapFile="$(_CustomViewMapFile)"
 	AcwMapFile="$(_AcwMapFile)"
-	ResourceDirectories="$(MonoAndroidResDirIntermediate);@(LibraryResourceDirectories)"
+	ResourceDirectories="$(MonoAndroidResDirIntermediate);@(_LibraryResourceHashDirectories)"
 	ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
+  >
+    <Output TaskParameter="Processed" ItemName="_ProcessedCustomViews" />	
+  </ConvertCustomView>
+  <Delete Files="@(_ProcessedCustomViews->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).stamp')"
+    Condition=" '$(AndroidUseAapt2)' == 'True' And '@(_ProcessedCustomViews)' != '' "
+  />
+  <Aapt2Compile
+    Condition=" '$(AndroidUseAapt2)' == 'True' And '@(_ProcessedCustomViews)' != '' "
+    ContinueOnError="$(DesignTimeBuild)"
+    ResourceDirectories="@(_LibraryResourceHashDirectories);$(MonoAndroidResDirIntermediate)"
+    ExplicitCrunch="$(AndroidExplicitCrunch)"
+    ExtraArgs="$(AndroidAapt2CompileExtraArgs)"
+    FlatArchivesDirectory="$(_AndroidLibraryFlatArchivesDirectory)"
+    ToolPath="$(Aapt2ToolPath)"
+    ToolExe="$(Aapt2ToolExe)">
+    <Output TaskParameter="CompiledResourceFlatArchives" ItemName="_UpdatedFlatArchives" />	
+  </Aapt2Compile>
+  <Touch Files="@(_UpdatedFlatArchives->'$(_AndroidLibraryFlatArchivesDirectory)\%(Filename).stamp')"
+    Condition=" '$(AndroidUseAapt2)' == 'True' And '@(_UpdatedFlatArchives)' != '' "
+    AlwaysCreate="True"
   />
   <Touch Files="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp" AlwaysCreate="True" />
 </Target>


### PR DESCRIPTION
Fixes #2501 

There is a problem with our `aapt2` support where
custom views do not have their namespaces replaced
with the `{md5}` hash which is generated by
`GenerateJavaStubs`.

This is due to the order in which we need to do certain
operations. For `aapt2` we need to run `aapt2 compile` to
generate the `flata` archives, these are then passed to
`aapt2 link` to generate the `packaged_resources` archive.
The idea was to get the `compile` step done early in
the build so we could reuse the `flata` archives.
We have to do this for generating the `Resources.desinger.cs`.

The problem is `GenerateJavaStubs` does not run until AFTER
`CoreCompile` at this point the `flata` archives are already
in place. As a result they do not include the fixed up
custom views. So to work around this issue we need to run
`aapt2 compile` after `GenerateJavaStubs` for those items
which contain custom views.