### PR TITLE
[Xamarin.Android.Build.Tasks]  Fix problem with `_CompileJava` running always.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -188,7 +188,7 @@ namespace Xamarin.Android.Tasks
 			}
 
 			if (!havebuildId)
-				WriteEnvironment ("XAMARIN_BUILD_ID", buildId.ToString ());
+				WriteEnvironment ("XAMARIN_BUILD_ID", BuildId);
 
 			if (!haveHttpMessageHandler) {
 				if (HttpClientHandlerType == null)

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1943,13 +1943,13 @@ because xbuild doesn't support framework reference assemblies.
       <Output TaskParameter="ResolvedDoNotPackageAttributes" ItemName="_ResolvedDoNotPackageAttributes" />
   </ResolveAssemblies>
   <Hash ItemsToHash="@(ResolvedAssemblies)">
-	<Output TaskParameter="HashResult" PropertyName="_ResolvedUserAssembliesHash" />
+    <Output TaskParameter="HashResult" PropertyName="_ResolvedUserAssembliesHash" />
   </Hash>
   <WriteLinesToFile
-	File="$(_ResolvedUserAssembliesHashFile)"
-	Lines="$(_ResolvedUserAssembliesHash)"
-	Overwrite="true"
-	WriteOnlyWhenDifferent="true"
+      File="$(_ResolvedUserAssembliesHashFile)"
+      Lines="$(_ResolvedUserAssembliesHash)"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true"
   />
   <ItemGroup>
     <FileWrites Include="$(_ResolvedUserAssembliesHashFile)" />
@@ -2379,7 +2379,7 @@ because xbuild doesn't support framework reference assemblies.
 	<Output TaskParameter="AddOnPlatformLibraries" ItemName="AddOnPlatformLibraries" />
   </GetAddOnPlatformLibraries>
 </Target>
-	
+
 <Target Name="_GeneratePackageManagerJava"
   DependsOnTargets="_GetAddOnPlatformLibraries;_AddStaticResources;$(_AfterAddStaticResources);_PrepareAssemblies"
   Inputs="$(MSBuildAllProjects);$(_ResolvedUserAssembliesHashFile);$(MSBuildProjectFile);$(_AndroidBuildPropertiesCache)"
@@ -2407,10 +2407,10 @@ because xbuild doesn't support framework reference assemblies.
   </GeneratePackageManagerJava>
   <Touch Files="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp" AlwaysCreate="True" />
   <WriteLinesToFile
-    File="$(_AndroidBuildIdFile)"
-    Lines="$(_XamarinBuildId)"
-    Overwrite="true"
-    WriteOnlyWhenDifferent="true"
+      File="$(_AndroidBuildIdFile)"
+      Lines="$(_XamarinBuildId)"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true"
   />
   <ItemGroup>
     <FileWrites Include="$(_AndroidBuildIdFile)" />
@@ -3033,7 +3033,7 @@ because xbuild doesn't support framework reference assemblies.
     File="$(IntermediateOutputPath)$(CleanFile)"
     Lines="$(OutDir)$(_AndroidPackage).apk.mSYM\%(_SymbolicateFiles.RecursiveDir)%(_SymbolicateFiles.Filename)%(_SymbolicateFiles.Extension)"
     Overwrite="false"/>
-    
+
   <Delete Files="$(_UploadFlagFile)" Condition="Exists ('$(_UploadFlagFile)')" />
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -273,6 +273,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<_AndroidIntermediateDesignTimeBuildDirectory>$(IntermediateOutputPath)designtime\</_AndroidIntermediateDesignTimeBuildDirectory>
 	<_AndroidLibraryFlatArchivesDirectory>$(IntermediateOutputPath)flata\</_AndroidLibraryFlatArchivesDirectory>
 	<_AndroidStampDirectory>$(IntermediateOutputPath)stamp\</_AndroidStampDirectory>
+	<_AndroidBuildIdFile>$(IntermediateOutputPath)buildid.txt</_AndroidBuildIdFile>
+	<_ResolvedUserAssembliesHashFile>$(IntermediateOutputPath)resolvedassemblies.hash</_ResolvedUserAssembliesHashFile>
 
 	<!-- $(EnableProguard) is an obsolete property that should be removed at some stage. -->
 	<AndroidEnableProguard Condition=" '$(AndroidEnableProguard)' == '' ">$(EnableProguard)</AndroidEnableProguard>
@@ -1940,6 +1942,18 @@ because xbuild doesn't support framework reference assemblies.
       <Output TaskParameter="ResolvedSymbols" ItemName="ResolvedSymbols" />
       <Output TaskParameter="ResolvedDoNotPackageAttributes" ItemName="_ResolvedDoNotPackageAttributes" />
   </ResolveAssemblies>
+  <Hash ItemsToHash="@(ResolvedAssemblies)">
+	<Output TaskParameter="HashResult" PropertyName="_ResolvedUserAssembliesHash" />
+  </Hash>
+  <WriteLinesToFile
+	File="$(_ResolvedUserAssembliesHashFile)"
+	Lines="$(_ResolvedUserAssembliesHash)"
+	Overwrite="true"
+	WriteOnlyWhenDifferent="true"
+  />
+  <ItemGroup>
+    <FileWrites Include="$(_ResolvedUserAssembliesHashFile)" />
+  </ItemGroup>
 </Target>
 
 <Target Name="_CreatePackageWorkspace">
@@ -2365,10 +2379,10 @@ because xbuild doesn't support framework reference assemblies.
 	<Output TaskParameter="AddOnPlatformLibraries" ItemName="AddOnPlatformLibraries" />
   </GetAddOnPlatformLibraries>
 </Target>
-
+	
 <Target Name="_GeneratePackageManagerJava"
   DependsOnTargets="_GetAddOnPlatformLibraries;_AddStaticResources;$(_AfterAddStaticResources);_PrepareAssemblies"
-  Inputs="$(MSBuildAllProjects);@(_ResolvedAssemblies);@(_ResolvedUserAssemblies);$(MSBuildProjectFile);$(_AndroidBuildPropertiesCache)"
+  Inputs="$(MSBuildAllProjects);$(_ResolvedUserAssembliesHashFile);$(MSBuildProjectFile);$(_AndroidBuildPropertiesCache)"
   Outputs="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp">
   <!-- Create java needed for Mono runtime -->
   <GeneratePackageManagerJava
@@ -2387,10 +2401,20 @@ because xbuild doesn't support framework reference assemblies.
     TlsProvider="$(AndroidTlsProvider)"
     Debug="$(AndroidIncludeDebugSymbols)"
     AndroidSequencePointsMode="$(_SequencePointsMode)"
-    EnableSGenConcurrent="$(AndroidEnableSGenConcurrent)">
+    EnableSGenConcurrent="$(AndroidEnableSGenConcurrent)"
+  >
     <Output TaskParameter="BuildId" PropertyName="_XamarinBuildId" />
   </GeneratePackageManagerJava>
   <Touch Files="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp" AlwaysCreate="True" />
+  <WriteLinesToFile
+    File="$(_AndroidBuildIdFile)"
+    Lines="$(_XamarinBuildId)"
+    Overwrite="true"
+    WriteOnlyWhenDifferent="true"
+  />
+  <ItemGroup>
+    <FileWrites Include="$(_AndroidBuildIdFile)" />
+  </ItemGroup>
 </Target>
 
 <PropertyGroup>
@@ -2986,6 +3010,10 @@ because xbuild doesn't support framework reference assemblies.
     DestinationFolder="$(OutDir)$(_AndroidPackage).apk.mSYM\%(_SymbolicateFiles.RecursiveDir)"
     SkipUnchangedFiles="true"
   />
+		
+  <ReadLinesFromFile File="$(_AndroidBuildIdFile)" Condition="Exists('$(_AndroidBuildIdFile)') And '$(_XamarinBuildId)' == ''">
+    <Output TaskParameter="Lines" PropertyName="_XamarinBuildId"/>
+  </ReadLinesFromFile>
 
   <CreateMsymManifest
      Condition=" '$(_XamarinBuildId)' != '' And '$(MonoSymbolArchive)' == 'True' "
@@ -3005,7 +3033,7 @@ because xbuild doesn't support framework reference assemblies.
     File="$(IntermediateOutputPath)$(CleanFile)"
     Lines="$(OutDir)$(_AndroidPackage).apk.mSYM\%(_SymbolicateFiles.RecursiveDir)%(_SymbolicateFiles.Filename)%(_SymbolicateFiles.Extension)"
     Overwrite="false"/>
-
+    
   <Delete Files="$(_UploadFlagFile)" Condition="Exists ('$(_UploadFlagFile)')" />
 </Target>
 
@@ -3246,6 +3274,8 @@ because xbuild doesn't support framework reference assemblies.
 	<Delete Files="$(_AndroidAapt2VersionFile)" />
 	<Delete Files="$(IntermediateOutputPath)R.txt" />
 	<Delete Files="$(_AndroidMainDexListFile)" />
+	<Delete Files="$(_AndroidBuildIdFile)" />
+	<Delete Files="$(_ResolvedUserAssembliesHashFile)" />
 </Target>
 
 <Target Name="_CollectMonoAndroidOutputs" DependsOnTargets="_ValidateAndroidPackageProperties">


### PR DESCRIPTION
Commit b90d3ab7 altered where we generate the Guid for the
`XAMARIN_BUILD_ID`. This change resulted in the `_CompileJava`
target running on every build. This was because the Guid and
the resultng `AndroidEnvironment.java` file changed on every
build.

The `XAMARIN_BUILD_ID` should only change when an apk is
built. This is so the same id can be written to both the
apk and the msym archive.

There was also a problem on windows where the design time
build would trigger `_GeneratePackageManagerJava` to run.
This was down to the the following file being updated

        <Project>.csproj.CoreCompileInputs.cache

This would cause a cascade because once `_GeneratePackageManagerJava`
ran, this would then trigger `_CompileJava` and then other
targets.

Looking at `GeneratePackageManagerJava` we don't actually
use the assemblies directly within the tast. We just need
a list of the assembly names. So allot of the time we are
running this task if an assembly changes when we don't 
really need to. What we need to do is run the task when
assemblies and either added or removed from the list. 

To that end we now store a Hash of the `@(ResolvedAssemblies)`
ItemGroup in `$(IntermediateOutputPath)resolvedassemblies.hash`.
This hash is updated when the `ResolveAssemblies` target is run.
We can then use that hash file as an input to 
`_GeneratePackageManagerJava` to ensure that we only run that 
target when the list changes.

An addition change was to write the `XAMARIN_BUILD_ID` to a file
so that it can be stored between builds. This is needed because
if the `_GeneratePackageManagerJava` is skipped (due to an up to 
date build) during the package creation the property
`$(_XamarinBuildId)` would be empty. This is required for  
`CreateMsymManifest`, so we need to be able to store this value 
between builds and read it in when required. Reading 
directly from `txt` file is quicker than pulling the information
from the `XamarinAndroidEnvironmentVariables.java` file
which `_GeneratePackageManagerJava` produces.