### PR TITLE
[android-toolchain] Version the NDK `.stamp` file

### DIFF
--- a/build-tools/android-toolchain/android-toolchain.projitems
+++ b/build-tools/android-toolchain/android-toolchain.projitems
@@ -3,10 +3,17 @@
   <PropertyGroup>
     <AndroidUri Condition=" '$(AndroidUri)' == '' ">https://dl.google.com/android/repository</AndroidUri>
     <AntUri Condition=" '$(AntUri)' == '' ">https://archive.apache.org/dist/ant/binaries</AntUri>
+    <AndroidNdkVersion>r14b</AndroidNdkVersion>
   </PropertyGroup>
   <ItemGroup>
-    <AndroidNdkItem Include="android-ndk-r14b-linux-x86_64">
+    <AndroidNdkItem Include="android-ndk-$(AndroidNdkVersion)-darwin-x86_64">
+      <HostOS>Darwin</HostOS>
+    </AndroidNdkItem>
+    <AndroidNdkItem Include="android-ndk-$(AndroidNdkVersion)-linux-x86_64">
       <HostOS>Linux</HostOS>
+    </AndroidNdkItem>
+    <AndroidNdkItem Include="android-ndk-$(AndroidNdkVersion)-windows-x86_64">
+      <HostOS>Windows</HostOS>
     </AndroidNdkItem>
     <!--
       $(XABuildToolsVersion) is defined in Configuration.props
@@ -27,9 +34,6 @@
       <HostOS>Linux</HostOS>
       <DestDir>emulator</DestDir>
     </AndroidSdkItem>
-    <AndroidNdkItem Include="android-ndk-r14b-darwin-x86_64">
-      <HostOS>Darwin</HostOS>
-    </AndroidNdkItem>
     <AndroidSdkItem Include="build-tools_r$(XABuildToolsVersion)-macosx">
       <HostOS>Darwin</HostOS>
       <DestDir>build-tools\$(XABuildToolsFolder)</DestDir>
@@ -46,9 +50,6 @@
       <HostOS>Darwin</HostOS>
       <DestDir>emulator</DestDir>
     </AndroidSdkItem>
-    <AndroidNdkItem Include="android-ndk-r14b-windows-x86_64">
-      <HostOS>Windows</HostOS>
-    </AndroidNdkItem>
     <AndroidSdkItem Include="build-tools_r$(XABuildToolsVersion)-windows">
       <HostOS>Windows</HostOS>
       <DestDir>build-tools\$(XABuildToolsFolder)</DestDir>

--- a/build-tools/android-toolchain/android-toolchain.targets
+++ b/build-tools/android-toolchain/android-toolchain.targets
@@ -58,7 +58,7 @@
   <Target Name="_UnzipFiles"
       DependsOnTargets="_DetermineItems"
       Inputs="@(_DownloadedItem)"
-      Outputs="@(_SdkStampFiles);$(AndroidToolchainDirectory)\ndk\.stamp-ndk">
+      Outputs="@(_SdkStampFiles);$(AndroidToolchainDirectory)\ndk\.stamp-ndk-$(AndroidNdkVersion)">
     <PropertyGroup>
       <_OriginalPath>$(PATH)</_OriginalPath>
     </PropertyGroup>
@@ -95,7 +95,7 @@
     />
     <AcceptAndroidSdkLicenses AndroidSdkDirectory="$(AndroidSdkDirectory)" JavaSdkDirectory="$(JavaSdkDirectory)" />
     <Touch
-        Files="@(_SdkStampFiles);$(AndroidToolchainDirectory)\ndk\.stamp-ndk"
+        Files="@(_SdkStampFiles);$(AndroidToolchainDirectory)\ndk\.stamp-ndk-$(AndroidNdkVersion)"
         AlwaysCreate="True"
     />
   </Target>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/2592
Context: https://jenkins.mono-project.com/job/xamarin-android-pr-builder-release/339/console

Recall commit b28856f4 and the behavior of "forward only"
dependencies: some dependencies can only be easily "upgraded," and not
reverted.  Commit b28856f4 dealt with MXE, and "solved" the
"downgrade" problem by encoding the MXE hash into the MXE installation
directory, so that multiple MXE installations can exist.

Turns Out™, the NDK is in a similar scenario: because the
`_UnzipFiles` target within `android-toolchain.targets` only executes
when one of the input files has *changed*, e.g. a new NDK `.zip` file
was downloaded, then when the NDK is "downgraded" but the "downgraded"
NDK `.zip` *already existed*, the "older" NDK wouldn't be installed:

 1. PR #2592 is a PR to update the NDK, and is built on a machine.
    As part of building #2592, `$HOME/android-toolchain/ndk` is
    upgraded to NDK r18.

 2. As part of upgrading the build machine to NDK r18,
    `$HOME/android-archives` contains `android-ndk-*.zip` files for
    *at least* NDK r14b and r18.

 3. "Later", a different PR is executed on the same build machine.
    This different PR doesn't further change the NDK, i.e. it's still
    specifying NDK r14b, and r14b is already present on the machine.

 4. The NDK is *not* "downgraded" to r14b from r18, and the build
    attempts to use NDK r18.

The build then fails:

	xamarin-android/external/sqlite/dist/sqlite3.c(33031,9): error G3127DA5A: use of undeclared identifier 'ANDROID_FDSAN_OWNER_TYPE_SQLITE'; did you mean 'ANDROID_FDSAN_OWNER_TYPE_FILE'?
	xamarin-android/external/sqlite/dist/sqlite3.c(33616,7): error G3127DA5A: use of undeclared identifier 'ANDROID_FDSAN_OWNER_TYPE_SQLITE'; did you mean 'ANDROID_FDSAN_OWNER_TYPE_FILE'?
	xamarin-android/src/sqlite-xamarin/sqlite-xamarin.targets(27,5): error MSB3073: The command "/Users/builder/android-toolchain/sdk/cmake/3.6.4111459/bin/ninja -v" exited with code 1.

This makes for a brittle build environment.

Support NDK downgrades by embedding the NDK version into the generated
stamp file, e.g. `$HOME/android-toolchain/ndk/.stamp-ndk-r14b`.  This
allows "normal file timestamps" to be used to determine if the NDK
needs to be recreated, which will allow the build machine to recreate
the NDK when the NDK version changes.