### PR TITLE
Add support for background builds when the IDE supports them

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -591,6 +591,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		UpdateAndroidResources;
 		$(ApplicationResolveReferencesDependsOn);
 	</ResolveReferencesDependsOn>
+	<BackgroundBuildDependsOn>$(BackgroundBuildDependsOn);UpdateAndroidResources</BackgroundBuildDependsOn>
 </PropertyGroup>
 
 <PropertyGroup Condition="'$(AndroidApplication)' != '' And $(AndroidApplication)">
@@ -1290,7 +1291,9 @@ because xbuild doesn't support framework reference assemblies.
 	DependsOnTargets="$(CoreResolveReferencesDependsOn);_CreatePropertiesCache;_CheckForDeletedResourceFile;_ComputeAndroidResourcePaths;_UpdateAndroidResgen;_CreateManagedLibraryResourceArchive;_GenerateJavaDesignerForComponent"> 
 </Target>
 
-<Target Name="UpdateAndroidResources" DependsOnTargets="_SetupDesignTimeBuildForCompile;_ManagedUpdateAndroidResgen;_UpdateAndroidResources" />
+<Target Name="UpdateAndroidResources" 
+	Condition=" '$(DesignTimeBuild)' != 'True' Or '$(BackgroundBuildSupported)' != 'True' Or '$(BackgroundBuild)' == 'True' "
+	DependsOnTargets="_SetupDesignTimeBuildForCompile;_ManagedUpdateAndroidResgen;_UpdateAndroidResources" />
 		
 <!-- Handle a case where the designer file has been deleted, but the flag file still exists -->
 <Target Name="_CheckForDeletedResourceFile">


### PR DESCRIPTION
In order to take the most expensive target in a DTB (`UpdateAndroidResources`) out 
of the DTB, the IDE can monitor design-time builds and schedule a background build 
to run after the DTB finishes. 

When the IDE supports background builds, the  `BackgroundBuildSupported` will be 
true, and in that case, the `BackgroundBuild` target will run after the DTB finishes. To 
schedule targets to run as part of that background build, they need to be added to 
the `BackgroundBuildDependsOn` property. 

Targets can selectively disable themselves on DTBs when the background build is 
supported by checking for both `'$(BackgroundBuildSupported)' == 'true'` and the 
`'$(BackgroundBuild)' == 'true'` property, which is set for those builds. 

The background build queuing will be based on the following condition: a regular design
time build was triggered and the targets run were either "Compile" or any target
that contains "DesignTime" in its name (this excludes queuing a background build
when a target like `GetFrameworkPaths` or `GetTargetPath` is run in a DTB, for
example).

Note that `Inputs`/`Outputs` on the targets, as well as any `DependsOnTargets`
specified remain the same as before. The effect is that expensive targets that caused
a slow DTB before, can now be scheduled to run *after* the build finishes (this is
when the background build is queued).

It's entirely opt-in (if no targets are specified for `BackgroundBuildDependsOn`
it will be essentially a no-op run).

Finally, when a regular build starts, the existing background build will be waited for 
completion before continuing, to ensure no concurrency happens.