### PR TITLE
[Xamarin.Android.Build.Tasks] designer needs full paths in libraryprojectimports.cache

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -214,7 +214,7 @@ namespace Xamarin.Android.Tasks
 				//string binAssemblyDir = Path.Combine (importsDir, "bin", "assets");
 #endif
 				string resDir = Path.Combine (importsDir, "res");
-				string assemblyDir = Path.Combine (importsDir, "assets");
+				string assetsDir = Path.Combine (importsDir, "assets");
 
 				// Skip already-extracted resources.
 				var stamp = new FileInfo (Path.Combine (outdir.FullName, assemblyIdentName + ".stamp"));
@@ -229,15 +229,15 @@ namespace Xamarin.Android.Tasks
 						resolvedAssetDirectories.Add (binAssemblyDir);
 #endif
 					if (Directory.Exists (resDir)) {
-						var taskItem = new TaskItem (resDir, new Dictionary<string, string> {
+						var taskItem = new TaskItem (Path.GetFullPath (resDir), new Dictionary<string, string> {
 							{ OriginalFile, assemblyPath },
 						});
 						if (assembliesToSkip.Contains (assemblyFileName))
 							taskItem.SetMetadata (SkipAndroidResourceProcessing, "True");
 						resolvedResourceDirectories.Add (taskItem);
 					}
-					if (Directory.Exists (assemblyDir))
-						resolvedAssetDirectories.Add (assemblyDir);
+					if (Directory.Exists (assetsDir))
+						resolvedAssetDirectories.Add (Path.GetFullPath (assetsDir));
 					foreach (var env in Directory.EnumerateFiles (outDirForDll, "__AndroidEnvironment__*", SearchOption.TopDirectoryOnly)) {
 						resolvedEnvironments.Add (env);
 					}
@@ -350,15 +350,15 @@ namespace Xamarin.Android.Tasks
 							resolvedAssetDirectories.Add (binAssemblyDir);
 #endif
 						if (Directory.Exists (resDir)) {
-							var taskItem = new TaskItem (resDir, new Dictionary<string, string> {
+							var taskItem = new TaskItem (Path.GetFullPath (resDir), new Dictionary<string, string> {
 								{ OriginalFile, assemblyPath }
 							});
 							if (assembliesToSkip.Contains (assemblyFileName))
 								taskItem.SetMetadata (SkipAndroidResourceProcessing, "True");
 							resolvedResourceDirectories.Add (taskItem);
 						}
-						if (Directory.Exists (assemblyDir))
-							resolvedAssetDirectories.Add (assemblyDir);
+						if (Directory.Exists (assetsDir))
+							resolvedAssetDirectories.Add (Path.GetFullPath (assetsDir));
 					}
 				}
 
@@ -382,12 +382,12 @@ namespace Xamarin.Android.Tasks
 				var stamp = new FileInfo (Path.Combine (outdir.FullName, Path.GetFileNameWithoutExtension (aarFile.ItemSpec) + ".stamp"));
 				if (stamp.Exists && stamp.LastWriteTimeUtc > new FileInfo (aarFile.ItemSpec).LastWriteTimeUtc) {
 					if (Directory.Exists (resDir))
-						resolvedResourceDirectories.Add (new TaskItem (resDir, new Dictionary<string, string> {
+						resolvedResourceDirectories.Add (new TaskItem (Path.GetFullPath (resDir), new Dictionary<string, string> {
 							{ OriginalFile, Path.GetFullPath (aarFile.ItemSpec) },
 							{ SkipAndroidResourceProcessing, "True" },
 						}));
 					if (Directory.Exists (assetsDir))
-						resolvedAssetDirectories.Add (assetsDir);
+						resolvedAssetDirectories.Add (Path.GetFullPath (assetsDir));
 					continue;
 				}
 				// temporarily extracted directory will look like:
@@ -415,12 +415,12 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 				if (Directory.Exists (resDir))
-					resolvedResourceDirectories.Add (new TaskItem (resDir, new Dictionary<string, string> {
+					resolvedResourceDirectories.Add (new TaskItem (Path.GetFullPath (resDir), new Dictionary<string, string> {
 						{ OriginalFile, Path.GetFullPath (aarFile.ItemSpec) },
 						{ SkipAndroidResourceProcessing, "True" },
 					}));
 				if (Directory.Exists (assetsDir))
-					resolvedAssetDirectories.Add (assetsDir);
+					resolvedAssetDirectories.Add (Path.GetFullPath (assetsDir));
 			}
 			foreach (var f in outdir.EnumerateFiles ("*.jar", SearchOption.AllDirectories)
 					.Select (fi => fi.FullName)) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2164,6 +2164,15 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 				var count = doc.Elements ("Paths").Elements ("ResolvedResourceDirectories").Count ();
 				Assert.AreEqual (expectedCount, count, "The same number of resource directories should have been resolved.");
 
+				//NOTE: the designer requires the paths to be full paths
+				foreach (var paths in doc.Elements ("Paths")) {
+					foreach (var element in paths.Elements ()) {
+						var path = element.Value;
+						if (!string.IsNullOrEmpty (path)) {
+							Assert.IsTrue (path == Path.GetFullPath (path), $"`{path}` is not a full path!");
+						}
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
The Xamarin.Android designer uses the paths found in
`libraryprojectimports.cache`, and recently was coming up with some
odd paths in test failures:

    C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\Common7\IDE\obj\Debug\90\lp\2\jl\res

Looking at the contents of `libraryprojectimports.cache`, some of the
paths were no longer full paths:

    <Paths>
    ...
      <ResolvedResourceDirectories>
        <ResolvedResourceDirectory>obj\Debug\81\lp\6\jl\res</ResolvedResourceDirectory>
        <ResolvedResourceDirectory>obj\Debug\81\lp\9\jl\res</ResolvedResourceDirectory>
        <ResolvedResourceDirectory>obj\Debug\81\lp\11\jl\res</ResolvedResourceDirectory>
        <ResolvedResourceDirectory>obj\Debug\81\lp\12\jl\res</ResolvedResourceDirectory>
        <ResolvedResourceDirectory>obj\Debug\81\lp\13\jl\res</ResolvedResourceDirectory>
        <ResolvedResourceDirectory>obj\Debug\81\lp\14\jl\res</ResolvedResourceDirectory>
      </ResolvedResourceDirectories>
    ...
    </Paths>

In 02c07ed, we inadvertently lost the full paths when LINQ was
removed. Things worked fine during regular builds, but not within the
context of the designer.

Changes:

- Anywhere we add to `resolvedResourceDirectories`, should use
  `Path.GetFullPath`
- Same with `resolvedAssetDirectories`
- Fixed a place where an `assemblyDir` variable made more sense to be
  named `assetsDir`.