### PR TITLE
[Xamarin.Android.Build.Tasks] use System.Reflection.Metadata in <ResolveAssemblies/>

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -263,9 +263,9 @@ namespace Xamarin.Android.Tasks
 				var attribute = reader.GetCustomAttribute (handle);
 				switch (reader.GetCustomAttributeFullName (attribute)) {
 					case "Java.Interop.DoNotPackageAttribute": {
-							var decoded = attribute.DecodeValue (DummyCustomAttributeProvider.Instance);
-							if (decoded.FixedArguments.Length > 0) {
-								string file = decoded.FixedArguments [0].Value?.ToString ();
+							var arguments = attribute.GetCustomAttributeArguments ();
+							if (arguments.FixedArguments.Length > 0) {
+								string file = arguments.FixedArguments [0].Value?.ToString ();
 								if (string.IsNullOrWhiteSpace (file))
 									LogError ("In referenced assembly {0}, Java.Interop.DoNotPackageAttribute requires non-null file name.", assembly.GetAssemblyName ().FullName);
 								do_not_package_atts.Add (Path.GetFileName (file));
@@ -273,8 +273,8 @@ namespace Xamarin.Android.Tasks
 						}
 						break;
 					case "System.Runtime.Versioning.TargetFrameworkAttribute": {
-							var decoded = attribute.DecodeValue (DummyCustomAttributeProvider.Instance);
-							foreach (var p in decoded.FixedArguments) {
+							var arguments = attribute.GetCustomAttributeArguments ();
+							foreach (var p in arguments.FixedArguments) {
 								var value = p.Value?.ToString ();
 								if (value != null && value.StartsWith ("MonoAndroid", StringComparison.Ordinal)) {
 									var values = value.Split ('=');

--- a/src/Xamarin.Android.Build.Tasks/Utilities/DummyCustomAttributeProvider.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/DummyCustomAttributeProvider.cs
@@ -8,6 +8,8 @@ namespace Xamarin.Android.Tasks
 	/// This interface allows usage such as:
 	///		CustomAttribute attribute = reader.GetCustomAttribute (handle);
 	///		CustomAttributeValue<object> decoded = attribute.DecodeValue (DummyCustomAttributeProvider.Instance);
+	/// Or better yet, used via the extension method:
+	///		CustomAttributeValue<object> decoded = attribute.GetCustomAttributeArguments ();
 	/// </summary>
 	public class DummyCustomAttributeProvider : ICustomAttributeTypeProvider<object>
 	{

--- a/src/Xamarin.Android.Build.Tasks/Utilities/DummyCustomAttributeProvider.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/DummyCustomAttributeProvider.cs
@@ -1,0 +1,32 @@
+﻿using System.Reflection.Metadata;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// A helper type for System.Reflection.Metadata. Getting the value of custom attribute arguments is a bit convoluted, if you merely want the values.
+	///
+	/// This interface allows usage such as:
+	///		CustomAttribute attribute = reader.GetCustomAttribute (handle);
+	///		CustomAttributeValue<object> decoded = attribute.DecodeValue (DummyCustomAttributeProvider.Instance);
+	/// </summary>
+	public class DummyCustomAttributeProvider : ICustomAttributeTypeProvider<object>
+	{
+		public static readonly DummyCustomAttributeProvider Instance = new DummyCustomAttributeProvider ();
+
+		public object GetPrimitiveType (PrimitiveTypeCode typeCode) => null;
+
+		public object GetSystemType () => null;
+
+		public object GetSZArrayType (object elementType) => null;
+
+		public object GetTypeFromDefinition (MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) => null;
+
+		public object GetTypeFromReference (MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) => null;
+
+		public object GetTypeFromSerializedName (string name) => null;
+
+		public PrimitiveTypeCode GetUnderlyingEnumType (object type) => default (PrimitiveTypeCode);
+
+		public bool IsSystemType (object type) => false;
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MetadataExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MetadataExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System.Reflection.Metadata;
+
+namespace Xamarin.Android.Tasks
+{
+	public static class MetadataExtensions
+	{
+		public static string GetCustomAttributeFullName (this MetadataReader reader, CustomAttribute attribute)
+		{
+			if (attribute.Constructor.Kind == HandleKind.MemberReference) {
+				var ctor = reader.GetMemberReference ((MemberReferenceHandle)attribute.Constructor);
+				var type = reader.GetTypeReference ((TypeReferenceHandle)ctor.Parent);
+				return reader.GetString (type.Namespace) + "." + reader.GetString (type.Name);
+			} else if (attribute.Constructor.Kind == HandleKind.MethodDefinition) {
+				var ctor = reader.GetMethodDefinition ((MethodDefinitionHandle)attribute.Constructor);
+				var type = reader.GetTypeDefinition (ctor.GetDeclaringType ());
+				return reader.GetString (type.Namespace) + "." + reader.GetString (type.Name);
+			}
+			return null;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MetadataExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MetadataExtensions.cs
@@ -17,5 +17,10 @@ namespace Xamarin.Android.Tasks
 			}
 			return null;
 		}
+
+		public static CustomAttributeValue<object> GetCustomAttributeArguments (this CustomAttribute attribute)
+		{
+			return attribute.DecodeValue (DummyCustomAttributeProvider.Instance);
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MetadataResolver.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MetadataResolver.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// A replacement for DirectoryAssemblyResolver, using System.Reflection.Metadata
+	/// </summary>
+	public class MetadataResolver : IDisposable
+	{
+		readonly Dictionary<string, PEReader> cache = new Dictionary<string, PEReader> ();
+		readonly List<string> searchDirectories = new List<string> ();
+
+		public MetadataReader GetAssemblyReader (string assemblyName)
+		{
+			var key = Path.GetFileNameWithoutExtension (assemblyName);
+			if (!cache.TryGetValue (key, out PEReader reader)) {
+				var assemblyPath = Resolve (assemblyName);
+				cache.Add (key, reader = new PEReader (File.OpenRead (assemblyPath)));
+			}
+			return reader.GetMetadataReader ();
+		}
+
+		public void AddSearchDirectory (string directory)
+		{
+			directory = Path.GetFullPath (directory);
+			if (!searchDirectories.Contains (directory))
+				searchDirectories.Add (directory);
+		}
+
+		public string Resolve (string assemblyName)
+		{
+			string assemblyPath = assemblyName;
+			if (!assemblyPath.EndsWith (".dll", StringComparison.OrdinalIgnoreCase)) {
+				assemblyPath += ".dll";
+			}
+			if (File.Exists (assemblyPath)) {
+				return assemblyPath;
+			}
+			foreach (var dir in searchDirectories) {
+				var path = Path.Combine (dir, assemblyPath);
+				if (File.Exists (path))
+					return path;
+			}
+
+			throw new FileNotFoundException ($"Could not load assembly '{assemblyName}'.", assemblyName);
+		}
+
+		public void Dispose ()
+		{
+			foreach (var provider in cache.Values) {
+				provider.Dispose ();
+			}
+			cache.Clear ();
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -37,7 +37,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Reflection.Metadata">
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.6.0\lib\netstandard2.0\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
     <Reference Include="Irony">
@@ -157,8 +163,11 @@
     <Compile Include="Utilities\AndroidAddOnManifest.cs" />
     <Compile Include="Mono.Android\IntentFilterAttribute.Partial.cs" />
     <Compile Include="Mono.Android\GrantUriPermissionAttribute.Partial.cs" />
+    <Compile Include="Utilities\DummyCustomAttributeProvider.cs" />
     <Compile Include="Utilities\InvalidActivityNameException.cs" />
     <Compile Include="Utilities\JavaResourceParser.cs" />
+    <Compile Include="Utilities\MetadataResolver.cs" />
+    <Compile Include="Utilities\MetadataExtensions.cs" />
     <Compile Include="Utilities\ResourceParser.cs" />
     <Compile Include="Utilities\ManagedResourceParser.cs" />
     <Compile Include="Utilities\ManifestDocumentElement.cs" />
@@ -769,11 +778,6 @@
       <Project>{94BD81F7-B06F-4295-9636-F8A3B6BDC762}</Project>
       <Name>Java.Interop</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="pdb2mdb\" />
-    <Folder Include="Linker\Linker\" />
-    <Folder Include="utils\" />
   </ItemGroup>
   <Import Project="ILRepack.targets" />
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="FSharp.Compiler.CodeDom" version="1.0.0.1" targetFramework="net45" />
   <package id="FSharp.Core" version="3.1.2.5" targetFramework="net451" />
+  <package id="ILRepack.Lib.MSBuild.Task" version="2.0.15.4" targetFramework="net462" />
   <package id="Irony" version="0.9.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net451" />
   <package id="NuGet.Common" version="4.6.0" targetFramework="net462" />
@@ -14,7 +15,8 @@
   <package id="NuGet.ProjectModel" version="4.6.0" targetFramework="net462" />
   <package id="NuGet.Protocol" version="4.6.0" targetFramework="net462" />
   <package id="NuGet.Versioning" version="4.6.0" targetFramework="net462" />
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net462" />
+  <package id="System.Reflection.Metadata" version="1.6.0" targetFramework="net462" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net462" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net462" />
-  <package id="ILRepack.Lib.MSBuild.Task" version="2.0.15.4" targetFramework="net462" />
 </packages>

--- a/tools/xabuild/xabuild.csproj
+++ b/tools/xabuild/xabuild.csproj
@@ -37,9 +37,6 @@
     <Reference Include="MSBuild">
       <HintPath>$(MSBuildReferencePath)\MSBuild.$(_MSBuildExtension)</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.Metadata" Condition=" '$(OS)' != 'Windows_NT' ">
-      <HintPath>$(MSBuildReferencePath)\System.Reflection.Metadata.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />


### PR DESCRIPTION
Context: https://github.com/dotnet/corefx/tree/master/src/System.Reflection.Metadata/src/System/Reflection/Metadata
Context: https://github.com/jonathanpeppers/Benchmarks

There is a new System.Reflection.Metadata library from corefx for
reading .NET assemblies. It is a bit more performant than Mono.Cecil
because it is a different library with different opinions.

Some notes about System.Reflection.Metadata:

- SRM has a forward "reader" style API
- SRM uses lots of structs, and you have to do an additional call to
lookup strings generally.
- SRM, as far as I have seen, doesn't have APIs to modify and write
out new assemblies.
- SRM only supports "portable" pdb files.
- SRM is not well documented yet. To discover usage, I read source
  code and/or unit tests.

From my benchmark above, it seems that SRM is 10x faster on
Windows/.NET framework and 5x faster on macOS/Mono.

So it makes sense for use to use SRM when reading assemblies (and we
don't need symbols), and continue with Mono.Cecil for the linker and
other things that modify assemblies.

There are a few places we can take advantage of SRM, but the simplest
with a reasonable impact was `ResolveAssemblies`:

    Before:
    320 ms  ResolveAssemblies                          1 calls
    After:
    112 ms  ResolveAssemblies                          1 calls

So a ~200ms savings on this MSBuild task, which runs on *every* build.
This was the Xamarin.Forms test project in this repo: a build with no
changes.

## Changes ##

- Added a `MetadataResolver` type, as a way to cache `PEReader`
  instances. This is a comparable drop-in replacement for
  `DirectoryAssemblyResolver`.
- `MonoAndroidHelper.IsReferenceAssembly` now uses
  `System.Reflection.Metadata` instead of `Mono.Cecil`. This is used
  in a few other MSBuild tasks.
- A `MetadataExtensions` provides an extension method to simplify
  getting the full name of a custom attribute. We can add more here as
  needed.

The resulting code *should* be the same, except we are using SRM over
Mono.Cecil.

## Downstream ##

We will need to add the following assemblies to the installer:

- `System.Reflection.Metadata.dll`
- `System.Collections.Immutable.dll`