### PR TITLE
[libzip] remove CopyToOutputDirectory

### DIFF
--- a/src/libzip/libzip.targets
+++ b/src/libzip/libzip.targets
@@ -33,9 +33,7 @@
     />
   </Target>
   <ItemGroup>
-    <Content Include="@(_LibZipTarget->'$(_LibZipOutputPath)%(OutputLibrary)')">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    <Content Include="@(_LibZipTarget->'$(_LibZipOutputPath)%(OutputLibrary)')" />
   </ItemGroup>
   <ItemGroup>
     <_LibZipTargetMakefile Include="@(_LibZipTarget->'$(IntermediateOutputPath)\%(Identity)\Makefile')" />


### PR DESCRIPTION
Downstream in monodroid, we are getting a build failure such as:

    "/Users/builder/jenkins/workspace/monodroid-pr/monodroid/tools/msbuild/Xamarin.Android.Build.Tasks.sln" (default target) (1) ->
    "/Users/builder/jenkins/workspace/monodroid-pr/monodroid/tools/msbuild/Xamarin.Android.Build.Debugging.Tasks.csproj" (default target) (6) ->
    (_CopyOutOfDateSourceItemsToOutputDirectoryAlways target) ->
    /Library/Frameworks/Mono.framework/Versions/5.18.0/lib/mono/msbuild/15.0/bin/Microsoft.Common.CurrentVersion.targets(4584,5): error MSB3027: Could not copy "/Users/builder/jenkins/workspace/monodroid-pr/monodroid/external/xamarin-android/bin/Release/lib/xamarin.android/xbuild/Xamarin/Android/libzip.5.0.dylib" to "/Users/builder/jenkins/workspace/monodroid-pr/monodroid/out/lib/xamarin.android/xbuild/Xamarin/Android/libzip.5.0.dylib". Exceeded retry count of 10. Failed.  [/Users/builder/jenkins/workspace/monodroid-pr/monodroid/tools/msbuild/Xamarin.Android.Build.Debugging.Tasks.csproj]
    /Library/Frameworks/Mono.framework/Versions/5.18.0/lib/mono/msbuild/15.0/bin/Microsoft.Common.CurrentVersion.targets(4584,5): error MSB3021: Unable to copy file "/Users/builder/jenkins/workspace/monodroid-pr/monodroid/external/xamarin-android/bin/Release/lib/xamarin.android/xbuild/Xamarin/Android/libzip.5.0.dylib" to "/Users/builder/jenkins/workspace/monodroid-pr/monodroid/out/lib/xamarin.android/xbuild/Xamarin/Android/libzip.5.0.dylib". Sharing violation on path /Users/builder/jenkins/workspace/monodroid-pr/monodroid/external/xamarin-android/bin/Release/lib/xamarin.android/xbuild/Xamarin/Android/libzip.5.0.dylib" or "/Users/builder/jenkins/workspace/monodroid-pr/monodroid/out/lib/xamarin.android/xbuild/Xamarin/Android/libzip.5.0.dylib [/Users/builder/jenkins/workspace/monodroid-pr/monodroid/tools/msbuild/Xamarin.Android.Build.Debugging.Tasks.csproj]

        27 Warning(s)
        2 Error(s)

Or TLDR:

    Sharing violation on path /Users/builder/jenkins/workspace/monodroid-pr/monodroid/external/xamarin-android/bin/Release/lib/xamarin.android/xbuild/Xamarin/Android/libzip.5.0.dylib"

Reviewing `libzip.targets`, we are setting
`%(CopyToOutputDirectory)=Always`, but then still are manually copying
the file:

    <Content Include="@(_LibZipTarget->'$(_LibZipOutputPath)%(OutputLibrary)')">
      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
    </Content>
    ....
    <Copy
        SourceFiles="@(_LibZipTarget->'$(IntermediateOutputPath)\%(Identity)\%(OutputLibraryPath)')"
        DestinationFiles="@(_LibZipTarget->'$(_LibZipOutputPath)%(OutputLibrary)')"
    />

I ran `Build`, `Build`, and `Rebuild` on this project, and the
`Inputs` and `Outputs` appear to be working correctly. We just have a
spot where having various `<ProjectReference/>` to `libzip.csproj`
seems to cause the file sharing issue.

Removing the `%(CopyToOutputDirectory)` item metadata fixes the file
sharing violation locally. This seems like the simplest fix.