### PR TITLE
[Xamarin.Android.Build.Tasks] Add `directBootAware` if needed.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1525,7 +1525,7 @@ namespace UnnamedProject
 				Assert.IsTrue (appb.Build (proj, parameters: new [] { "DesignTimeBuild=True" }), "design-time build should have succeeded.");
 
 				//Now a full build
-				Assert.IsTrue (libb.Build (proj), "library build should have succeeded.");
+				Assert.IsTrue (libb.Build (lib), "library build should have succeeded.");
 				appb.Target = "SignAndroidPackage";
 				Assert.IsTrue (appb.Build (proj), "app build should have succeeded.");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -266,6 +266,8 @@ namespace Bug12935
 				Assert.IsNotNull (le, "no activity element found");
 				Assert.IsTrue (doc.XPathSelectElements ("//activity[@android:directBootAware='true']", nsResolver).Any (),
 						   "'activity' element is not generated as expected.");
+				Assert.IsTrue (doc.XPathSelectElements ("//provider[@android:name='mono.MonoRuntimeProvider' and @android:directBootAware='true']", nsResolver).Any (),
+						   "'provider' element is not generated as expected.");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -666,9 +666,12 @@ namespace Xamarin.Android.Tasks {
 		public bool DirectBootAware ()
 		{
 			var processAttrName = androidNs.GetName ("directBootAware");
+			var appAttr = app.Attribute (processAttrName);
+			if (appAttr != null && bool.TryParse (appAttr.Value, out bool value) && value)
+					return true;
 			foreach (XElement el in app.Elements ()) {
-				var proc = el.Attribute (processAttrName);
-				if (proc != null && bool.TryParse (proc.Value, out bool value) && value)
+				var elAttr = el.Attribute (processAttrName);
+				if (elAttr != null && bool.TryParse (elAttr.Value, out bool value) && value)
 					return true;
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -667,11 +667,12 @@ namespace Xamarin.Android.Tasks {
 		{
 			var processAttrName = androidNs.GetName ("directBootAware");
 			var appAttr = app.Attribute (processAttrName);
-			if (appAttr != null && bool.TryParse (appAttr.Value, out bool value) && value)
-					return true;
+			bool value;
+			if (appAttr != null && bool.TryParse (appAttr.Value, out value) && value)
+				return true;
 			foreach (XElement el in app.Elements ()) {
 				var elAttr = el.Attribute (processAttrName);
-				if (elAttr != null && bool.TryParse (elAttr.Value, out bool value) && value)
+				if (elAttr != null && bool.TryParse (elAttr.Value, out value) && value)
 					return true;
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs
@@ -630,10 +630,12 @@ namespace Xamarin.Android.Tasks {
 
 		XElement CreateMonoRuntimeProvider (string name, string processName, int initOrder)
 		{
+			var directBootAware = DirectBootAware ();
 			return new XElement ("provider",
 						new XAttribute (androidNs + "name", name),
 						new XAttribute (androidNs + "exported", "false"),
 						new XAttribute (androidNs + "initOrder", initOrder),
+						directBootAware ? new XAttribute (androidNs + "directBootAware", "true") : null,
 						processName == null ? null : new XAttribute (androidNs + "process", processName),
 						new XAttribute (androidNs + "authorities", PackageName + "." + name + ".__mono_init__"));
 		}
@@ -656,6 +658,22 @@ namespace Xamarin.Android.Tasks {
 
 			// If android:extractNativeLibs is omitted, returns true.
 			return true;
+		}
+
+		/// <summary>
+		/// Returns true if an element has the @android:directBootAware attribute and its 'true'
+		/// </summary>
+		public bool DirectBootAware ()
+		{
+			var processAttrName = androidNs.GetName ("directBootAware");
+			foreach (XElement el in app.Elements ()) {
+				var proc = el.Attribute (processAttrName);
+				if (proc != null && bool.TryParse (proc.Value, out bool value) && value)
+					return true;
+			}
+
+			// If android:directBootAware is omitted, returns false.
+			return false;
 		}
 
 		XElement ActivityFromTypeDefinition (TypeDefinition type, string name, int targetSdkVersion)

--- a/tests/EmbeddedDSOs/EmbeddedDSO/Properties/AndroidManifest.xml
+++ b/tests/EmbeddedDSOs/EmbeddedDSO/Properties/AndroidManifest.xml
@@ -4,6 +4,6 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
-    <application android:allowBackup="true" android:icon="@mipmap/icon" android:label="@string/app_name" android:theme="@android:style/Theme.Material" android:extractNativeLibs="false">
+    <application android:allowBackup="true" android:icon="@mipmap/icon" android:label="@string/app_name" android:theme="@android:style/Theme.Material" android:extractNativeLibs="false" android:directBooAware="true">
     </application>
 </manifest>

--- a/tests/EmbeddedDSOs/EmbeddedDSO/Properties/AndroidManifest.xml
+++ b/tests/EmbeddedDSOs/EmbeddedDSO/Properties/AndroidManifest.xml
@@ -4,6 +4,6 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
-    <application android:allowBackup="true" android:icon="@mipmap/icon" android:label="@string/app_name" android:theme="@android:style/Theme.Material" android:extractNativeLibs="false" android:directBooAware="true">
+    <application android:allowBackup="true" android:icon="@mipmap/icon" android:label="@string/app_name" android:theme="@android:style/Theme.Material" android:extractNativeLibs="false" android:directBootAware="true">
     </application>
 </manifest>


### PR DESCRIPTION
Fixes #2081

If a user needs to use the `directBootAware` attribute on
an `application`, `activity` or `service` we also need
to include it on the `MonoRuntimeProvider` so that
native libraries can be resolved correctly. Not doing
so results in the following

	java.lang.UnsatisfiedLinkError: No implementation found for void mono.android.Runtime.register

This commit looks to see if any elements in the manifest
contain `directBootAware`. If there are , then we also
include it in the `provider`.