### PR TITLE
[Xamarin.Android.Build.Tasks] _ResolveAssemblies better handle missing assemblies

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1481,5 +1481,54 @@ namespace UnnamedProject
 				Assert.IsTrue (b.Build (proj), "first build should have succeeded");
 			}
 		}
+
+		[Test]
+		public void SetupDependenciesForDesigner ()
+		{
+			var path = Path.Combine ("temp", TestName);
+			var lib = new XamarinAndroidLibraryProject {
+				ProjectName = "Library1",
+				OtherBuildItems = {
+					new AndroidItem.AndroidAsset ("Assets\\foo.txt") {
+						TextContent =  () => "Bar",
+					},
+				},
+			};
+			var proj = new XamarinFormsAndroidApplicationProject {
+				ProjectName = "App1",
+				References = { new BuildItem ("ProjectReference", "..\\Library1\\Library1.csproj") },
+			};
+			proj.Imports.Add (new Import ("Designer.targets") {
+				TextContent = () => @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project ToolsVersion=""4.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+<PropertyGroup>
+  <AndroidUseManagedDesignTimeResourceGenerator>False</AndroidUseManagedDesignTimeResourceGenerator>
+  <SetupDependenciesForDesignerDependsOn>
+    UpdateAndroidResources;
+    _AdjustJavacVersionArguments;
+    _GeneratePackageManagerJavaForDesigner;
+    _GetMonoPlatformJarPath;
+    _DetermineJavaLibrariesToCompile;
+  </SetupDependenciesForDesignerDependsOn>
+</PropertyGroup>
+<Target Name=""SetupDependenciesForDesigner"" DependsOnTargets=""$(SetupDependenciesForDesignerDependsOn)"">
+</Target>
+<Target Name=""_GeneratePackageManagerJavaForDesigner"" DependsOnTargets=""_AddStaticResources;_ResolveAssemblies"">
+</Target>
+</Project>
+",
+			});
+			using (var libb = CreateDllBuilder (Path.Combine (path, lib.ProjectName)))
+			using (var appb = CreateApkBuilder (Path.Combine (path, proj.ProjectName))) {
+				libb.Save (lib);
+				appb.Target = "SetupDependenciesForDesigner";
+				Assert.IsTrue (appb.Build (proj, parameters: new [] { "DesignTimeBuild=True" }), "design-time build should have succeeded.");
+
+				//Now a full build
+				Assert.IsTrue (libb.Build (proj), "library build should have succeeded.");
+				appb.Target = "SignAndroidPackage";
+				Assert.IsTrue (appb.Build (proj), "app build should have succeeded.");
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1920,9 +1920,9 @@ because xbuild doesn't support framework reference assemblies.
 		<FilteredAssemblies Include="$(OutDir)$(TargetFileName)"
 				Condition="Exists ('$(OutDir)$(TargetFileName)')" />
 		<FilteredAssemblies Include="@(ReferenceCopyLocalPaths)"
-				Condition="'%(ReferenceCopyLocalPaths.ResolvedFrom)' != 'ImplicitlyExpandDesignTimeFacades' And '%(ReferenceCopyLocalPaths.Extension)' == '.dll' And '%(ReferenceCopyLocalPaths.RelativeDir)' == '' "/>
+				Condition="'%(ReferenceCopyLocalPaths.ResolvedFrom)' != 'ImplicitlyExpandDesignTimeFacades' And '%(ReferenceCopyLocalPaths.Extension)' == '.dll' And '%(ReferenceCopyLocalPaths.RelativeDir)' == '' And Exists('%(ReferenceCopyLocalPaths.Identity)') "/>
 		<FilteredAssemblies Include="@(ReferencePath)"
-				Condition="'%(ReferencePath.ResolvedFrom)' != 'ImplicitlyExpandDesignTimeFacades' "/>
+				Condition="'%(ReferencePath.ResolvedFrom)' != 'ImplicitlyExpandDesignTimeFacades' And Exists('%(ReferencePath.Identity)') "/>
 	</ItemGroup>
 	<!-- Find all the assemblies this app requires -->
 	<ResolveAssemblies


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2548
Fixes: http://work.devdiv.io/753650

In the case of the Android designer, a `SetupDependenciesForDesigner`
target is run as a way to "build enough" things for the designer to
work.

The problem is if a `<ProjectReference/>` hasn't built yet, the
`_ResolveAssemblies` target can fail:

    "HelloForms.Android.csproj" (SetupDependenciesForDesigner target) (1:7) ->
    (_ResolveAssemblies target) ->
    Xamarin.Android.Common.targets(1898,2): error : Exception while loading assemblies: System.InvalidOperationException: Failed to load assembly HelloForms\bin\Debug\netstandard2.0\HelloForms.dll
    Xamarin.Android.Common.targets(1898,2): error :    at Xamarin.Android.Tasks.ResolveAssemblies.Execute(DirectoryAssemblyResolver resolver)

In this case, I ran:

    msbuild .\HelloForms\HelloForms.Android\HelloForms.Android.csproj /t:SetupDependenciesForDesigner /p:DesignTimeBuild=true /p:AndroidUseManagedDesignTimeResourceGenerator=false /restore /bl

From a fresh checkout of this sample:

https://github.com/jonathanpeppers/HelloWorld/

To fix this problem, we can add an `Exists` check in the `Condition`
for assemblies passed into the `<ResolveAssemblies/>` MSBuild task. I
don't think this will have any negative consequences, since we are
already doing a check for `Exists ('$(OutDir)$(TargetFileName)')`.

I also setup a new test that emulates what happens with
`SetupDependenciesForDesigner`. This should also help us make sure we
aren't breaking the designer in this repo.

Downstream in monodroid, we should also make sure the designer tests
we have there are using a `<ProjectReference/>`.