### PR TITLE
[Xamarin.Android.Build.Tasks] Install should skip Build when inside the IDE

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -97,7 +97,6 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = true,
 			};
 			proj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", "True");
-			proj.SetProperty ("BuildingInsideVisualStudio", "True");
 			using (var b = CreateApkBuilder (path)) {
 				b.Target = "Compile";
 				Assert.IsTrue(b.Build (proj), "DesignTime Build should have succeeded");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -498,15 +498,9 @@ namespace App1
 				if (!Directory.Exists (builder.MicrosoftNetSdkDirectory))
 					Assert.Ignore ("Microsoft.NET.Sdk not found.");
 				using (var ab = CreateApkBuilder (Path.Combine (path, app.ProjectName), cleanupOnDispose: false)) {
-					builder.RequiresMSBuild = true;
-					builder.Target = "Restore";
-					Assert.IsTrue (builder.Build (netStandardProject), "XamFormsSample Nuget packages should have been restored.");
-					builder.Target = "Build";
+					builder.RequiresMSBuild =
+						ab.RequiresMSBuild = true;
 					Assert.IsTrue (builder.Build (netStandardProject), "XamFormsSample should have built.");
-					ab.RequiresMSBuild = true;
-					ab.Target = "Restore";
-					Assert.IsTrue (ab.Build (app), "App should have built.");
-					ab.Target = "SignAndroidPackage";
 					Assert.IsTrue (ab.Build (app), "App should have built.");
 					var apk = Path.Combine (Root, ab.ProjectDirectory,
 						app.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
@@ -523,8 +517,7 @@ namespace App1
 					}
 					if (!HasDevices)
 						Assert.Ignore ("Skipping Installation. No devices available.");
-					ab.Target = "Install";
-					Assert.IsTrue (ab.Build (app), "App should have installed.");
+					Assert.IsTrue (ab.RunTarget (app, "Install"), "App should have installed.");
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BuildHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BuildHelper.cs
@@ -14,7 +14,8 @@ namespace Xamarin.Android.Build.Tests
 		public static ProjectBuilder CreateApkBuilder (string directory, bool cleanupAfterSuccessfulBuild = false, bool cleanupOnDispose = true)
 		{
 			var ret = CreateDllBuilder (directory, cleanupAfterSuccessfulBuild, cleanupOnDispose);
-			ret.Target = "SignAndroidPackage";
+			//NOTE: since $(BuildingInsideVisualStudio) is set, Build will not happen by default
+			ret.Target = "Build,SignAndroidPackage";
 			return ret;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -24,6 +24,10 @@ namespace Xamarin.ProjectTools
 		string buildLogFullPath;
 		public bool IsUnix { get; set; }
 		public bool RunningMSBuild { get; set; }
+		/// <summary>
+		/// This passes /p:BuildingInsideVisualStudio=True, command-line to MSBuild
+		/// </summary>
+		public bool BuildingInsideVisualStudio { get; set; } = true;
 		public LoggerVerbosity Verbosity { get; set; }
 		public IEnumerable<string> LastBuildOutput {
 			get {
@@ -341,10 +345,10 @@ namespace Xamarin.ProjectTools
 			var psi   = new ProcessStartInfo (XABuildExe);
 			args.AppendFormat ("{0} /t:{1} /restore {2}",
 				QuoteFileName(Path.Combine (XABuildPaths.TestOutputDirectory, projectOrSolution)), target, logger);
-			if (RunningMSBuild)
+			args.Append ($" /p:BuildingInsideVisualStudio={BuildingInsideVisualStudio}");
+			if (BuildingInsideVisualStudio && RunningMSBuild) {
 				args.Append (" /p:BuildingOutOfProcess=true");
-			else
-				args.Append (" /p:UseHostCompilerIfAvailable=false /p:BuildingInsideVisualStudio=true");
+			}
 			if (!string.IsNullOrEmpty (AndroidSdkDirectory)) {
 				args.AppendFormat (" /p:AndroidSdkDirectory=\"{0}\" ", AndroidSdkDirectory);
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
@@ -30,7 +30,6 @@ namespace Xamarin.ProjectTools
 			SetProperty ("ConsolePause", "false");
 			SetProperty ("RootNamespace", () => RootNamespace ?? ProjectName);
 			SetProperty ("AssemblyName", () => AssemblyName ?? ProjectName);
-			SetProperty ("BuildingInsideVisualStudio", "True");
 			SetProperty ("BaseIntermediateOutputPath", "obj\\", " '$(BaseIntermediateOutputPath)' == '' ");
 
 			SetProperty (DebugProperties, "DebugSymbols", "true");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -76,35 +76,31 @@ namespace Xamarin.ProjectTools
 
 		public bool Restore (XamarinProject project, bool doNotCleanupOnUpdate = false)
 		{
-			var oldTarget = Target;
-			Target = "Restore";
-			try {
-				return Build (project, doNotCleanupOnUpdate);
-			} finally {
-				Target = oldTarget;
-			}
+			return RunTarget (project, "Restore", doNotCleanupOnUpdate);
 		}
 
 		public bool Clean (XamarinProject project, bool doNotCleanupOnUpdate = false)
 		{
-			var oldTarget = Target;
-			Target = "Clean";
-			try {
-				return Build (project, doNotCleanupOnUpdate);
-			}
-			finally {
-				Target = oldTarget;
-			}
+			return RunTarget (project, "Clean", doNotCleanupOnUpdate);
 		}
 
 		public bool UpdateAndroidResources (XamarinProject project, bool doNotCleanupOnUpdate = false, string [] parameters = null, Dictionary<string, string> environmentVariables = null)
 		{
+			return RunTarget (project, "UpdateAndroidResources", doNotCleanupOnUpdate, parameters, environmentVariables);
+		}
+
+		public bool DesignTimeBuild (XamarinProject project, bool doNotCleanupOnUpdate = false)
+		{
+			return RunTarget (project, "Compile", doNotCleanupOnUpdate, parameters: new string [] { "DesignTimeBuild=True" });
+		}
+
+		public bool RunTarget (XamarinProject project, string target, bool doNotCleanupOnUpdate = false, string [] parameters = null, Dictionary<string, string> environmentVariables = null)
+		{
 			var oldTarget = Target;
-			Target = "UpdateAndroidResources";
+			Target = target;
 			try {
 				return Build (project, doNotCleanupOnUpdate: doNotCleanupOnUpdate, parameters: parameters, environmentVariables: environmentVariables);
-			}
-			finally {
+			} finally {
 				Target = oldTarget;
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -3163,7 +3163,21 @@ because xbuild doesn't support framework reference assemblies.
 	<Delete Files="%(ApkAbiFilesUnaligned.FullPath)" />
 </Target>
 
-<Target Name="SignAndroidPackage" DependsOnTargets="Build;Package;_Sign">
+<PropertyGroup>
+  <SignAndroidPackageDependsOn Condition=" '$(BuildingInsideVisualStudio)' != 'True' ">
+    Build;
+    Package;
+    _Sign;
+  </SignAndroidPackageDependsOn>
+  <!-- When inside an IDE, Build has just been run. This is a minimal list of targets for SignAndroidPackage. -->
+  <SignAndroidPackageDependsOn Condition=" '$(BuildingInsideVisualStudio)' == 'True' ">
+    _CreatePropertiesCache;
+    ResolveReferences;
+    _CopyPackage;
+    _Sign;
+  </SignAndroidPackageDependsOn>
+</PropertyGroup>
+<Target Name="SignAndroidPackage" DependsOnTargets="$(SignAndroidPackageDependsOn)">
 </Target>
 
 <PropertyGroup>

--- a/tests/CodeBehind/UnitTests/BuildTests.cs
+++ b/tests/CodeBehind/UnitTests/BuildTests.cs
@@ -16,6 +16,11 @@ namespace CodeBehindUnitTests
 {
 	sealed class LocalBuilder : Builder
 	{
+		public LocalBuilder ()
+		{
+			BuildingInsideVisualStudio = false;
+		}
+		
 		public bool Build (string projectOrSolution, string target, string[] parameters = null, Dictionary<string, string> environmentVariables = null)
 		{
 			return BuildInternal (projectOrSolution, target, parameters, environmentVariables);
@@ -533,6 +538,7 @@ namespace CodeBehindUnitTests
 		{
 			string temporaryProjectDir = PrepareProject (testName);
 			LocalBuilder builder = GetBuilder ($"{ProjectName}.{testName}");
+			builder.BuildingInsideVisualStudio = dtb;
 			var testInfo = new TestProjectInfo (ProjectName, testName, temporaryProjectDir, TestOutputDir);
 
 			try {

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/BuildTests.cs
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/BuildTests.cs
@@ -20,6 +20,11 @@ namespace Xamarin.Android.MakeBundle.UnitTests
 {
 	sealed class LocalBuilder : Builder
 	{
+		public LocalBuilder ()
+		{
+			BuildingInsideVisualStudio = false;
+		}
+
 		public bool Build (string projectOrSolution, string target, string[] parameters = null, Dictionary<string, string> environmentVariables = null)
 		{
 			return BuildInternal (projectOrSolution, target, parameters, environmentVariables);

--- a/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/BuildTests.cs
+++ b/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/BuildTests.cs
@@ -20,6 +20,11 @@ namespace EmbeddedDSOUnitTests
 {
 	sealed class LocalBuilder : Builder
 	{
+		public LocalBuilder ()
+		{
+			BuildingInsideVisualStudio = false;
+		}
+
 		public bool Build (string projectOrSolution, string target, string[] parameters = null, Dictionary<string, string> environmentVariables = null)
 		{
 			return BuildInternal (projectOrSolution, target, parameters, environmentVariables);


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/wiki/IDE-Performance-Results
Context: https://github.com/jonathanpeppers/HelloWorld

When doing some performance measurements *inside* of Visual Studio, I
noticed we seem to have significant overhead in a build with no
changes.

In a "Hello World" Xamarin.Forms app:

    Preparation Time: 00:03.9
    Launch Time:      00:02.5

Where `Preparation Time` is everything MSBuild, and `Launch Time` is
the time it takes to start the Android application and attach the
debugger.

`Preparation Time` is effectively:

    msbuild Foo.Android.csproj /p:BuildingInsideVisualStudio=True /t:Build
    msbuild Foo.Android.csproj /p:BuildingInsideVisualStudio=True /t:Install

One concern here is that `Install` depends on `SignAndroidPackage`,
which depends on `Build`. We are doing a lot of MSBuild work here
twice, since MSBuild needs to run through certain targets twice and
decide they can be skipped. This work is "not free" and mostly
involved MSBuild evaluating properties and time stamps on files.

What I found we could do here is skip `Build` on the `Install` target
when `$(BuildingInsideVisualStudio)` is `True`. Due to the dependency
chain, this also affects `SignAndroidPackage`.

The minimal list of targets for `SignAndroidPackage` that still work:

- `_CreatePropertiesCache`
- `ResolveReferences`
- `_CopyPackage`
- `_Sign`

Initial results from the IDE show:

    Preparation Time: 00:02.06s

This is a ~2 second saving on the inner dev loop!

## MSBuild Tests ##

Since our MSBuild tests set `$(BuildingInsideVisualStudio)`, a lot of
our tests might break. We might have to add an additional call to
`Build` in each failing test.

The way I worked around this was to make the `CreateApkBuilder` method
run `Build,SignAndroidPackage` by default. Originally there were 248
test failures.

I also did some other cleanup:

- Added a `ProjectBuilder.RunTarget` method, so tests can more easily
  run custom targets and not modify the `Target` property:
  `builder.RunTarget ("Foo")`.
- Added `ProjectBuilder.DesignTimeBuild`.
- `Builder` now has a `BuildingInsideVisualStudio` property to toggle
  the value as a command-line global property. We were putting this in
  the `csproj`, which seems a bit different than what IDEs are
  actually doing...

Also added a `BuildOutsideVisualStudio` test to verify the
`SignAndroidPackage` target works by itself *outside* of IDEs.