### PR TITLE
[tests] fix SetupDependenciesForDesigner test

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1525,7 +1525,7 @@ namespace UnnamedProject
 				Assert.IsTrue (appb.Build (proj, parameters: new [] { "DesignTimeBuild=True" }), "design-time build should have succeeded.");
 
 				//Now a full build
-				Assert.IsTrue (libb.Build (proj), "library build should have succeeded.");
+				Assert.IsTrue (libb.Build (lib), "library build should have succeeded.");
 				appb.Target = "SignAndroidPackage";
 				Assert.IsTrue (appb.Build (proj), "app build should have succeeded.");
 			}


### PR DESCRIPTION
Context: http://build.devdiv.io/2342466

This test randomly failed on a PR with:

    Xamarin.Android.Common.targets(2160,5): error MSB4018: The "LinkAssemblies" task failed unexpectedly.
        System.IO.FileNotFoundException: Could not load assembly 'App1, Version=0.0.0.0, Culture=neutral, PublicKeyToken='. Perhaps it doesn't exist in the Mono for Android profile?
        File name: 'App1.dll'
            at Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.Resolve(AssemblyNameReference reference, ReaderParameters parameters) in E:\A\_work\1259\s\external\Java.Interop\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil\DirectoryAssemblyResolver.cs:line 241
            at Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.Resolve(String fullName, ReaderParameters parameters) in E:\A\_work\1259\s\external\Java.Interop\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil\DirectoryAssemblyResolver.cs:line 186
            at Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.Resolve(String fullName) in E:\A\_work\1259\s\external\Java.Interop\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil\DirectoryAssemblyResolver.cs:line 181
            at Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.GetAssembly(String fileName) in E:\A\_work\1259\s\external\Java.Interop\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil\DirectoryAssemblyResolver.cs:line 176
            at Xamarin.Android.Tasks.LinkAssemblies.Execute(DirectoryAssemblyResolver res)
            at Xamarin.Android.Tasks.LinkAssemblies.Execute()
            at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
            at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext() [E:\A\_work\1259\s\bin\TestDebug\temp\SetupDependenciesForDesigner\Library1\App1.csproj]

What is weird, is that all the files from the build are found in:

    bin\TestDebug\temp\SetupDependenciesForDesigner\Library1

There should be an `App1` directory?

Then I spotted the problem:

    Assert.IsTrue (libb.Build (proj), "library build should have succeeded.");

`libb` should be building the library project instead of the app
project, whoops!