### PR TITLE
[Xamarin.Android.Build.Tasks] ILRepack SRM

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/ILRepack.targets
+++ b/src/Xamarin.Android.Build.Tasks/ILRepack.targets
@@ -20,6 +20,8 @@
 			<InputAssemblies Include="$(OutputPath)\NuGet.Packaging.Core.dll" />
 			<InputAssemblies Include="$(OutputPath)\NuGet.DependencyResolver.Core.dll" />
 			<InputAssemblies Include="$(OutputPath)\NuGet.Configuration.dll" />
+			<InputAssemblies Include="$(OutputPath)\System.Collections.Immutable.dll" />
+			<InputAssemblies Include="$(OutputPath)\System.Reflection.Metadata.dll" />
 		</ItemGroup>
 		<ILRepack Parallel="true"
 				Internalize="true"

--- a/tools/xabuild/xabuild.csproj
+++ b/tools/xabuild/xabuild.csproj
@@ -37,9 +37,6 @@
     <Reference Include="MSBuild">
       <HintPath>$(MSBuildReferencePath)\MSBuild.$(_MSBuildExtension)</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.Metadata" Condition=" '$(OS)' != 'Windows_NT' ">
-      <HintPath>$(MSBuildReferencePath)\System.Reflection.Metadata.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />

--- a/tools/xabuild/xabuild.csproj
+++ b/tools/xabuild/xabuild.csproj
@@ -37,6 +37,9 @@
     <Reference Include="MSBuild">
       <HintPath>$(MSBuildReferencePath)\MSBuild.$(_MSBuildExtension)</HintPath>
     </Reference>
+    <Reference Include="System.Reflection.Metadata" Condition=" '$(OS)' != 'Windows_NT' ">
+      <HintPath>$(MSBuildReferencePath)\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />


### PR DESCRIPTION
Downstream in monodroid, I attempted to use the final pkg file for the
Xamarin.Android commercial product.

Unfortunately, building a Xamarin.Android project fail with:

    $ msbuild HelloForms/HelloForms.Android/HelloForms.Android.csproj /t:SignAndroidPackage /restore /bl
    ...
    "HelloWorld/HelloForms/HelloForms.Android/HelloForms.Android.csproj" (SignAndroidPackage target) (1:7) ->
    (_ResolveAssemblies target) ->
    Xamarin.Android.Common.targets(1930,2): error : Exception while loading assemblies: System.MissingMethodException: Method not found: System.Reflection.AssemblyName System.Reflection.Metadata.AssemblyDefinition.GetAssemblyName() [HelloWorld/HelloForms/HelloForms.Android/HelloForms.Android.csproj]
    Xamarin.Android.Common.targets(1930,2): error :   at Xamarin.Android.Tasks.ResolveAssemblies.AddAssemblyReferences (Xamarin.Android.Tasks.MetadataResolver resolver, System.Collections.Generic.Dictionary`2[TKey,TValue] assemblies, System.String assemblyPath, System.Collections.Generic.List`1[T] resolutionPath) [0x0003b] in <41aa6ba2d5de4e9284e4372b8c641c57>:0  [HelloWorld/HelloForms/HelloForms.Android/HelloForms.Android.csproj]
    Xamarin.Android.Common.targets(1930,2): error :   at Xamarin.Android.Tasks.ResolveAssemblies.Execute (Xamarin.Android.Tasks.MetadataResolver resolver) [0x001bf] in <41aa6ba2d5de4e9284e4372b8c641c57>:0  [HelloWorld/HelloForms/HelloForms.Android/HelloForms.Android.csproj]

        1 Error(s)

It seems that MSBuild has its own `System.Reflection.Metadata.dll`:

    /Library/Frameworks/Mono.framework/Versions/Current/lib//mono/msbuild/15.0/bin/System.Reflection.Metadata.dll

It appears that this assembly is getting loaded instead of ours.

To fix this, I added the two assemblies needed by
`System.Reflection.Metadata` to `ILRepack.targets`.

After building a new "IL merged" `Xamarin.Android.Build.Tasks.dll` and
putting it into my system Xamarin.Android install, it fixed the
problem.

## Other changes ##

In c22475d, I removed a reference to `System.Reflection.Metadata` in
`xabuild.csproj` (part of MSBuild).

We need this again, since it breaks the build on macOS to remove it. I
suspect it was working in the interim, because we had our own copy of
`System.Reflection.Metadata` that is now IL merged.