### PR TITLE
[build] Small CMake reorganization

### DIFF
--- a/build-tools/cmake/xa_macros.cmake
+++ b/build-tools/cmake/xa_macros.cmake
@@ -1,0 +1,71 @@
+# Trying to perform the tests in the foreach loop unfortunately fails...
+# CMake appears to run the check only once, for the first entry in the list,
+# probably caching the result using the <var> name and so further tests aren't
+# performed.
+macro(c_compiler_has_flag _flag)
+  string(REGEX REPLACE "-|,|=" "_" flag_name ${_flag})
+  check_c_compiler_flag(-${_flag} HAS_${flag_name}_C)
+  if (HAS_${flag_name}_C)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -${_flag}")
+  endif()
+endmacro(c_compiler_has_flag)
+
+macro(cxx_compiler_has_flag _flag)
+  string(REGEX REPLACE "-|,|=" "_" flag_name ${_flag})
+  check_cxx_compiler_flag(-${_flag} HAS_${flag_name}_CXX)
+  if (HAS_${flag_name}_CXX)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -${_flag}")
+  endif()
+endmacro(cxx_compiler_has_flag)
+
+macro(linker_has_flag _flag)
+  string(REGEX REPLACE "-|,|=" "_" flag_name ${_flag})
+  set(CMAKE_REQUIRED_FLAGS "-${_flag}")
+  check_c_compiler_flag("" HAS_${flag_name}_LINKER)
+  if(HAS_${flag_name}_LINKER)
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -${_flag}")
+  endif()
+endmacro()
+
+macro(xa_common_prepare)
+  # Don't put the leading '-' in options
+  set(XA_COMPILER_FLAGS
+    fno-strict-aliasing
+    ffunction-sections
+    funswitch-loops
+    finline-limit=300
+    fvisibility=hidden
+    fstack-protector
+    flto
+    Wa,--noexecstack
+    Wformat
+    Werror=format-security
+    Wall
+    )
+
+  if(CMAKE_BUILD_TYPE STREQUAL Debug)
+    set(XA_COMPILER_ARGS ${XA_COMPILER_ARGS} ggdb3 fno-omit-frame-pointer O0)
+  else()
+    set(XA_COMPILER_ARGS ${XA_COMPILER_ARGS} g fomit-frame-pointer O2)
+    add_definitions("-DRELEASE")
+  endif()
+
+  set(XA_LINKER_ARGS
+    Wl,-z,now
+    Wl,-z,relro
+    Wl,-z,noexecstack
+    Wl,--no-undefined
+    )
+
+  if(MINGW)
+    set(XA_LINKER_ARGS
+      ${XA_LINKER_ARGS}
+      Wl,--export-all-symbols
+      )
+  else()
+    set(XA_LINKER_ARGS
+      ${XA_LINKER_ARGS}
+      Wl,--export-dynamic
+      )
+  endif()
+endmacro()

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -10,6 +10,7 @@ option(DISABLE_DEBUG "Disable the built-in debugging code" OFF)
 include(CheckIncludeFiles)
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
+include("../../build-tools/cmake/xa_macros.cmake")
 
 set(JAVA_INTEROP_SRC_PATH "../../external/Java.Interop/src/java-interop")
 string(REPLACE "\\" "/" TOP_DIR ${CMAKE_SOURCE_DIR})
@@ -55,62 +56,17 @@ if(MINGW)
   endif()
 endif()
 
-# Trying to perform the tests in the foreach loop unfortunately fails...
-# CMake appears to run the check only once, for the first entry in the list,
-# probably caching the result using the <var> name and so further tests aren't
-# performed.
-macro(c_compiler_has_flag _flag)
-  check_c_compiler_flag(-${_flag} HAS_${_flag}_C)
-  if (HAS_${_flag}_C)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -${_flag}")
-  endif()
-endmacro(c_compiler_has_flag)
-
-macro(cxx_compiler_has_flag _flag)
-  check_cxx_compiler_flag(-${_flag} HAS_${_flag}_CXX)
-  if (HAS_${_flag}_CXX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -${_flag}")
-  endif()
-endmacro(cxx_compiler_has_flag)
-
-macro(linker_has_flag _flag)
-  set(CMAKE_REQUIRED_FLAGS "-${_flag}")
-  check_c_compiler_flag("" HAS_${_flag}_LINKER)
-  if(HAS_${_flag}_LINKER)
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -${_flag}")
-  endif()
-endmacro()
-
+xa_common_prepare()
 # Don't put the leading '-' in options
-set(TEST_COMPILER_ARGS
-  fno-strict-aliasing
-  ffunction-sections
-  funswitch-loops
-  finline-limit=300
-  fvisibility=hidden
-  fstack-protector
+set(TEST_COMPILER_ARGS ${XA_COMPILER_FLAGS}
   fno-rtti
   fno-exceptions
-  flto
-  Wa,--noexecstack
-  Wformat
-  Werror=format-security
-  Wall
-  mindirect-branch=thunk-inline
-  mfunction-return=thunk-inline
   )
 
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
   if(NOT DISABLE_DEBUG)
     add_definitions("-DDEBUG=1")
   endif()
-  set(TEST_COMPILER_ARGS ${TEST_COMPILER_ARGS} ggdb3 fno-omit-frame-pointer)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0")
-else()
-  set(TEST_COMPILER_ARGS ${TEST_COMPILER_ARGS} g fomit-frame-pointer O2)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -DRELEASE")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -DRELEASE")
 endif()
 
 foreach(arg ${TEST_COMPILER_ARGS})
@@ -118,24 +74,7 @@ foreach(arg ${TEST_COMPILER_ARGS})
   cxx_compiler_has_flag(${arg})
 endforeach(arg)
 
-set(TEST_LINKER_ARGS
-  Wl,-z,now
-  Wl,-z,relro
-  Wl,-z,noexecstack
-  Wl,--no-undefined
-  )
-
-if(MINGW)
-  set(TEST_LINKER_ARGS
-    ${TEST_LINKER_ARGS}
-    Wl,--export-all-symbols
-    )
-else()
-  set(TEST_LINKER_ARGS
-    ${TEST_LINKER_ARGS}
-    Wl,--export-dynamic
-    )
-endif()
+set(TEST_LINKER_ARGS ${XA_LINKER_ARGS})
 
 foreach(arg ${TEST_LINKER_ARGS})
   linker_has_flag(${arg})

--- a/src/sqlite-xamarin/CMakeLists.txt
+++ b/src/sqlite-xamarin/CMakeLists.txt
@@ -4,6 +4,7 @@ project(libsqlite-xamarin C)
 
 include(CheckIncludeFiles)
 include(CheckCCompilerFlag)
+include("../../build-tools/cmake/xa_macros.cmake")
 
 if(NOT DEFINED SQLITE_LIBRARY_NAME)
   message(FATAL_ERROR "Please set the SQLITE_LIBRARY_NAME variable on command line (-DSQLITE_LIBRARY_NAME=base_library_name)")
@@ -59,36 +60,9 @@ if (NOT ANDROID_NDK_MAJOR OR ANDROID_NDK_MAJOR LESS 17)
   add_definitions("-D__ANDROID_API_Q__=29")
 endif()
 
-macro(c_compiler_has_flag _flag)
-  check_c_compiler_flag(-${_flag} HAS_${_flag}_C)
-  if (HAS_${_flag}_C)
-    set(LOCAL_CMAKE_C_FLAGS "${LOCAL_CMAKE_C_FLAGS} -${_flag}")
-  endif()
-endmacro(c_compiler_has_flag)
-
-macro(linker_has_flag _flag)
-  set(CMAKE_REQUIRED_FLAGS "-${_flag}")
-  check_c_compiler_flag("" HAS_${_flag}_LINKER)
-  if(HAS_${_flag}_LINKER)
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -${_flag}")
-  endif()
-endmacro()
-
+xa_common_prepare()
 # Don't put the leading '-' in options
-set(TEST_COMPILER_ARGS
-  fno-strict-aliasing
-  ffunction-sections
-  funswitch-loops
-  finline-limit=300
-  fstack-protector
-  Wa,--noexecstack
-  Wformat
-  Werror=format-security
-  Wall
-  Wno-unused-parameter
-  mindirect-branch=thunk-inline
-  mfunction-return=thunk-inline
-  )
+set(TEST_COMPILER_ARGS ${XA_COMPILER_FLAGS})
 
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
   set(TEST_COMPILER_ARGS ${TEST_COMPILER_ARGS} ggdb3 fno-omit-frame-pointer)
@@ -102,24 +76,7 @@ foreach(arg ${TEST_COMPILER_ARGS})
   c_compiler_has_flag(${arg})
 endforeach(arg)
 
-set(TEST_LINKER_ARGS
-  Wl,-z,now
-  Wl,-z,relro
-  Wl,-z,noexecstack
-  Wl,--no-undefined
-  )
-
-if(MINGW)
-  set(TEST_LINKER_ARGS
-    ${TEST_LINKER_ARGS}
-    Wl,--export-all-symbols
-    )
-else()
-  set(TEST_LINKER_ARGS
-    ${TEST_LINKER_ARGS}
-    Wl,--export-dynamic
-    )
-endif()
+set(TEST_LINKER_ARGS ${XA_LINKER_ARGS})
 
 foreach(arg ${TEST_LINKER_ARGS})
   linker_has_flag(${arg})


### PR DESCRIPTION
Move some macros to a CMake module file so that they can be shared by all the
native code we build with CMake:

  * Macros to check for compiler+linker flags
  * Add a macro to set common compiler+linker flags