### PR TITLE
[Xamarin.Android.Build.Tasks] Run ILRepack if `NuGet.ProjectModel` Exists

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/ILRepack.targets
+++ b/src/Xamarin.Android.Build.Tasks/ILRepack.targets
@@ -1,28 +1,24 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\packages\ILRepack.Lib.MSBuild.Task.2.0.15.4\build\ILRepack.Lib.MSBuild.Task.dll" TaskName="ILRepack" />
-	<PropertyGroup>
-		<_ILRepacker_stamp>$(IntermediateOutputPath)ILRepacker.stamp</_ILRepacker_stamp>
-	</PropertyGroup>
-	<Target Name="ILRepacker" Condition=" '$(HostOS)' != 'Linux' "
-			AfterTargets="AfterBuild"
-			Inputs="$(OutputPath)\$(AssemblyName).dll"
-			Outputs="$(_ILRepacker_stamp)">
-		<ItemGroup>
-			<InputAssemblies Include="$(OutputPath)\NuGet.ProjectModel.dll" />
-			<InputAssemblies Include="$(OutputPath)\Newtonsoft.Json.dll" />
-			<InputAssemblies Include="$(OutputPath)\NuGet.Common.dll" />
-			<InputAssemblies Include="$(OutputPath)\NuGet.Protocol.dll" />
-			<InputAssemblies Include="$(OutputPath)\NuGet.Frameworks.dll" />
-			<InputAssemblies Include="$(OutputPath)\NuGet.LibraryModel.dll" />
-			<InputAssemblies Include="$(OutputPath)\NuGet.Versioning.dll" />
-			<InputAssemblies Include="$(OutputPath)\NuGet.Packaging.dll" />
-			<InputAssemblies Include="$(OutputPath)\NuGet.Packaging.Core.dll" />
-			<InputAssemblies Include="$(OutputPath)\NuGet.DependencyResolver.Core.dll" />
-			<InputAssemblies Include="$(OutputPath)\NuGet.Configuration.dll" />
-			<InputAssemblies Include="$(OutputPath)\System.Collections.Immutable.dll" />
-			<InputAssemblies Include="$(OutputPath)\System.Reflection.Metadata.dll" />
-		</ItemGroup>
+	<ItemGroup>
+		<InputAssemblies Include="$(OutputPath)\Newtonsoft.Json.dll" />
+		<InputAssemblies Include="$(OutputPath)\NuGet.Common.dll" />
+		<InputAssemblies Include="$(OutputPath)\NuGet.Configuration.dll" />
+		<InputAssemblies Include="$(OutputPath)\NuGet.DependencyResolver.Core.dll" />
+		<InputAssemblies Include="$(OutputPath)\NuGet.Frameworks.dll" />
+		<InputAssemblies Include="$(OutputPath)\NuGet.LibraryModel.dll" />
+		<InputAssemblies Include="$(OutputPath)\NuGet.Packaging.dll" />
+		<InputAssemblies Include="$(OutputPath)\NuGet.Packaging.Core.dll" />
+		<InputAssemblies Include="$(OutputPath)\NuGet.ProjectModel.dll" />
+		<InputAssemblies Include="$(OutputPath)\NuGet.Protocol.dll" />
+		<InputAssemblies Include="$(OutputPath)\NuGet.Versioning.dll" />
+		<InputAssemblies Include="$(OutputPath)\System.Collections.Immutable.dll" />
+		<InputAssemblies Include="$(OutputPath)\System.Reflection.Metadata.dll" />
+	</ItemGroup>
+	<Target Name="ILRepacker"
+			AfterTargets="CopyFilesToOutputDirectory"
+			Condition="Exists ('$(OutputPath)\NuGet.ProjectModel.dll') And '$(HostOS)' != 'Linux' ">
 		<ILRepack Parallel="true"
 				Internalize="true"
 				Verbose="true"
@@ -34,6 +30,5 @@
 				OutputFile="$(OutputPath)\$(AssemblyName).dll"
 		/>
 		<Delete Files="@(InputAssemblies)" />
-		<Touch AlwaysCreate="True" Files="$(_ILRepacker_stamp)" />
 	</Target>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/ILRepack.targets
+++ b/src/Xamarin.Android.Build.Tasks/ILRepack.targets
@@ -16,25 +16,23 @@
 		<InputAssemblies Include="$(OutputPath)\System.Collections.Immutable.dll" />
 		<InputAssemblies Include="$(OutputPath)\System.Reflection.Metadata.dll" />
 	</ItemGroup>
-	<Target Name="_GetInputAssembliesThatExist">
+	<Target Name="ILRepacker"
+			AfterTargets="CopyFilesToOutputDirectory"
+			Condition=" '$(HostOS)' != 'Linux' ">
 		<ItemGroup>
 			<_InputAssembliesThatExist Include="@(InputAssemblies)" Condition="Exists('%(Identity)')" />
-		</ItemGroup>
-	</Target>
-	<Target Name="ILRepacker"
-			DependsOnTargets="_GetInputAssembliesThatExist"
-			AfterTargets="CopyFilesToOutputDirectory"
-			Condition=" '@(_InputAssembliesThatExist)' != '' And '$(HostOS)' != 'Linux' ">
+		</ItemGroup>	
 		<ILRepack Parallel="true"
 				Internalize="true"
 				Verbose="true"
 				DebugInfo="true"
 				InternalizeExclude="@(DoNotInternalizeAssemblies)"
-				InputAssemblies="$(OutputPath)\$(AssemblyName).dll;@(InputAssemblies)"
+				InputAssemblies="$(OutputPath)\$(AssemblyName).dll;@(_InputAssembliesThatExist)"
 				LibraryPath="$(OutputPath)"
 				TargetKind="Dll"
 				OutputFile="$(OutputPath)\$(AssemblyName).dll"
+				Condition=" '@(_InputAssembliesThatExist)' != ''"
 		/>
-		<Delete Files="@(InputAssemblies)" />
+		<Delete Files="@(_InputAssembliesThatExist)" />
 	</Target>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/ILRepack.targets
+++ b/src/Xamarin.Android.Build.Tasks/ILRepack.targets
@@ -16,9 +16,15 @@
 		<InputAssemblies Include="$(OutputPath)\System.Collections.Immutable.dll" />
 		<InputAssemblies Include="$(OutputPath)\System.Reflection.Metadata.dll" />
 	</ItemGroup>
+	<Target Name="_GetInputAssembliesThatExist">
+		<ItemGroup>
+			<_InputAssembliesThatExist Include="@(InputAssemblies)" Condition="Exists('%(Identity)')" />
+		</ItemGroup>
+	</Target>
 	<Target Name="ILRepacker"
+			DependsOnTargets="_GetInputAssembliesThatExist"
 			AfterTargets="CopyFilesToOutputDirectory"
-			Condition="Exists ('$(OutputPath)\NuGet.ProjectModel.dll') And '$(HostOS)' != 'Linux' ">
+			Condition=" '@(_InputAssembliesThatExist)' != '' And '$(HostOS)' != 'Linux' ">
 		<ILRepack Parallel="true"
 				Internalize="true"
 				Verbose="true"


### PR DESCRIPTION
We saw the following error in the latest versions of monodroid.
	/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Android/Xamarin.Android.Common.targets(1928,2): error : Could not load file or assembly 'NuGet.ProjectModel, Version=4.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' or one of its dependencies.

After investingating it turns out that the
`Xamarin.Android.Build.Tasks` project was being run
multiple times (as expected). However the
`CopyFilesToOutputDirectory` target was being run
on the second build. This was also running the
internal target `_CopyFilesMarkedCopyLocal`.

The result of both of these targets was to copy
over the old assembly over the ILRepacked version
and copy over ALL the NuGet assemblies from the
nuget packages cache.

This then turns into the above error at build time
because the system has a different version of Nuget.
This was why we were using ILReapck in the first place.

We tried a number of different solutions. One was to update
the file in the intermediate directory which looked like
it would solve the problem initially. However in that
instance the Nuget files were still copied over to the
`$(OutputPath)` and might cause problems in the final
release. There was also another problem with ILRepack.
If we fixed up the file in the `$(IntermediateOutputPath)`
before `CopyFilesToOutputDirectory` we can end up with
ILRepack running again on the same assembly. This causes it
to pull in ALL the Nuget stuff again and we end up with a
5meg file rather than a 3meg one... Which was weird.

So the simplest solutiuon is to run ILRepack after
the `CopyFilesToOutputDirectory` target and only if
the `Nuget.ProjectModel` assembly exists in the `$(OutputPath)`.
Since the `ILRepacker` target is the one that deletes
the Nuget assemblies we can be sure that if they exist
we need to fix up the main assembly.
While this might mean that ILRepack runs twice in a build,
it does mean we get consistent output.