### PR TITLE
[Xamarin.Android.Build.Tasks] <GenerateJavaStubs/> only for MonoAndroid assemblies

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2294,6 +2294,12 @@ because xbuild doesn't support framework reference assemblies.
     Condition="'$(AndroidLinkMode)' != 'None' AND '$(AndroidUseSharedRuntime)' != 'true'">
     <Output TaskParameter="Include" ItemName="_ShrunkFrameworkAssemblies" />
   </CreateItem>
+
+  <CreateItem
+    Include="@(_ResolvedUserAssemblies)"
+    Condition="'%(_ResolvedUserAssemblies.TargetFrameworkIdentifier)' == 'MonoAndroid'">
+    <Output TaskParameter="Include" ItemName="_ResolvedUserMonoAndroidAssemblies" />
+  </CreateItem>
 </Target>
 
 <Target Name="_GenerateJavaStubs"
@@ -2302,7 +2308,7 @@ because xbuild doesn't support framework reference assemblies.
   Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
   <GenerateJavaStubs
     ResolvedAssemblies="@(_ResolvedAssemblies)"
-    ResolvedUserAssemblies="@(_ResolvedUserAssemblies)"
+    ResolvedUserAssemblies="@(_ResolvedUserMonoAndroidAssemblies)"
     ErrorOnCustomJavaObject="$(AndroidErrorOnCustomJavaObject)"
 	ManifestTemplate="$(_AndroidManifestAbs)"
 	MergedManifestDocuments="@(ExtractedManifestDocuments)"


### PR DESCRIPTION
Currently the `<GenerateJavaStubs/>` MSBuild task will load and
iterate over NetStandard or PCL assemblies. It simply looks at all
items in `@(_ResolvedUserAssemblies)` and writes Java stubs if needed.

We could look at the `TargetFrameworkIdentifier` and *only* do this
work for `MonoAndroid` assemblies.

To make this work:

- The `<ResolveAssemblies/>` MSBuild task needs to parse the
  `TargetFrameworkIdentifier` and add it to the item metadata for each
  assembly.
- `<GenerateJavaStubs/>` should use a subset of
  `@(_ResolvedUserAssemblies)` where `TargetFrameworkIdentifier` is
  `MonoAndroid`.

Results:

    Before
        First:       1200 ms  GenerateJavaStubs                          1 calls
        Incremental: 1047 ms  GenerateJavaStubs                          1 calls
    After
        First:       1084 ms  GenerateJavaStubs                          1 calls
        Incremental:  868 ms  GenerateJavaStubs                          1 calls

This seems to save ~200ms in the Xamarin.Forms integration project in
this repo. Projects using lots of NetStandard/PCL assemblies should
see a bigger benefit.