### PR TITLE
Bump Java.Interop

### DIFF
--- a/external/Java.Interop.tpnitems
+++ b/external/Java.Interop.tpnitems
@@ -118,5 +118,28 @@
       </LicenseText>
       <SourceUrl>https://github.com/mono/mono/tree/master/mcs/class/Mono.Options</SourceUrl>
     </ThirdPartyNotice>
+    <ThirdPartyNotice Include="HtmlAgilityPack">
+      <LicenseText>
+        The MIT License (MIT)
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.
+      </LicenseText>
+      <SourceUrl>https://github.com/zzzprojects/html-agility-pack</SourceUrl>
+    </ThirdPartyNotice>
   </ItemGroup>
 </Project>

--- a/external/Java.Interop.tpnitems
+++ b/external/Java.Interop.tpnitems
@@ -118,7 +118,7 @@
       </LicenseText>
       <SourceUrl>https://github.com/mono/mono/tree/master/mcs/class/Mono.Options</SourceUrl>
     </ThirdPartyNotice>
-    <ThirdPartyNotice Include="HtmlAgilityPack">
+    <ThirdPartyNotice Include="zzzprojects/HtmlAgilityPack">
       <LicenseText>
         The MIT License (MIT)
         Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Bring fix/workaround for broken Android annotation files shipped with
`platform-tools` v28.0.1 in the Android SDK.

Include `HtmlAgilityPack` in `external/Java.Interop.tpnitems`