### PR TITLE
[Xamarin.Android.Build.Tasks] Fix ILRepack to use `AfterBuild`.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/ILRepack.targets
+++ b/src/Xamarin.Android.Build.Tasks/ILRepack.targets
@@ -17,7 +17,7 @@
 		<InputAssemblies Include="$(OutputPath)\System.Reflection.Metadata.dll" />
 	</ItemGroup>
 	<Target Name="ILRepacker"
-			AfterTargets="CopyFilesToOutputDirectory"
+			AfterTargets="AfterBuild"
 			Condition=" '$(HostOS)' != 'Linux' ">
 		<ItemGroup>
 			<_InputAssembliesThatExist Include="@(InputAssemblies)" Condition="Exists('%(Identity)')" />


### PR DESCRIPTION
When we changed over to use `CopyFilesToOutputDirectory` for the
`AfterTargets` value we forgot that we are still using `xbuild`
for building this branch. This results in the following warning

	Xamarin.Android.Build.Tasks.csproj:  warning : Target 'CopyFilesToOutputDirectory', not found in the project

which means the ILRepack does not run.

So this PR moves back to using `AfterBuild` for that value. This
should allow the `Xamarin.Android.Build.Tasks` assembly to be
properly repacked.