### PR TITLE
[Xamarin.Android.Build.Tasks] Fix Ndk .exe lookup.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
@@ -153,7 +153,9 @@ namespace Xamarin.Android.Tasks
 				toolName = $"{toolName}{extension}";
 			else
 				toolName = $"{toolchainPrefix}-{toolName}{extension}";
-			string toolPath  = Path.Combine (toolchainDir, "bin", toolName);
+
+			string toolExe  = MonoAndroidHelper.GetExecutablePath (binDir, toolName);
+			string toolPath  = Path.Combine (toolchainDir, "bin", toolExe);
 			if (File.Exists (toolPath))
 				return toolPath;
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
@@ -154,8 +154,9 @@ namespace Xamarin.Android.Tasks
 			else
 				toolName = $"{toolchainPrefix}-{toolName}{extension}";
 
+			string binDir = Path.Combine (toolchainDir, "bin");
 			string toolExe  = MonoAndroidHelper.GetExecutablePath (binDir, toolName);
-			string toolPath  = Path.Combine (toolchainDir, "bin", toolExe);
+			string toolPath  = Path.Combine (binDir, toolExe);
 			if (File.Exists (toolPath))
 				return toolPath;
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtilsOld.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtilsOld.cs
@@ -73,7 +73,7 @@ namespace Xamarin.Android.Tasks
 			string extension = OS.IsWindows ? ".exe" : string.Empty;
 			List<string> toolPaths  = null;
 			foreach (var platbase in toolchains) {
-				string path = Path.Combine (platbase, "prebuilt", MonoAndroidHelper.AndroidSdk.AndroidNdkHostPlatform, "bin", GetNdkToolchainPrefix (arch) + tool + extension);
+				string path = MonoAndroidHelper.GetExecutablePath (Path.Combine (platbase, "prebuilt", MonoAndroidHelper.AndroidSdk.AndroidNdkHostPlatform, "bin"), GetNdkToolchainPrefix (arch) + tool);
 				if (File.Exists (path))
 					return path;
 				if (toolPaths == null)
@@ -81,7 +81,7 @@ namespace Xamarin.Android.Tasks
 				toolPaths.Add (path);
 			}
 			{
-				string path = Path.Combine (androidNdkPath, "prebuilt", MonoAndroidHelper.AndroidSdk.AndroidNdkHostPlatform, "bin", tool);
+				string path = MonoAndroidHelper.GetExecutablePath (Path.Combine (androidNdkPath, "prebuilt", MonoAndroidHelper.AndroidSdk.AndroidNdkHostPlatform, "bin"), tool);
 				if (File.Exists (path))
 					return path;
 				if (toolPaths == null)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtilsOld.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtilsOld.cs
@@ -73,7 +73,7 @@ namespace Xamarin.Android.Tasks
 			string extension = OS.IsWindows ? ".exe" : string.Empty;
 			List<string> toolPaths  = null;
 			foreach (var platbase in toolchains) {
-				string path = MonoAndroidHelper.GetExecutablePath (Path.Combine (platbase, "prebuilt", MonoAndroidHelper.AndroidSdk.AndroidNdkHostPlatform, "bin"), GetNdkToolchainPrefix (arch) + tool);
+				string path = Path.Combine (platbase, "prebuilt", MonoAndroidHelper.AndroidSdk.AndroidNdkHostPlatform, "bin", GetNdkToolchainPrefix (arch) + tool + extension);
 				if (File.Exists (path))
 					return path;
 				if (toolPaths == null)
@@ -81,7 +81,7 @@ namespace Xamarin.Android.Tasks
 				toolPaths.Add (path);
 			}
 			{
-				string path = MonoAndroidHelper.GetExecutablePath (Path.Combine (androidNdkPath, "prebuilt", MonoAndroidHelper.AndroidSdk.AndroidNdkHostPlatform, "bin"), tool);
+				string path = Path.Combine (androidNdkPath, "prebuilt", MonoAndroidHelper.AndroidSdk.AndroidNdkHostPlatform, "bin", tool);
 				if (File.Exists (path))
 					return path;
 				if (toolPaths == null)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/NdkUtilTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/NdkUtilTests.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xamarin.Android.Tasks;
+using Xamarin.Android.Tools;
+using Xamarin.ProjectTools;
+
+namespace Xamarin.Android.Build.Tests.Tasks {
+
+	[TestFixture]
+	public class NdkUtilTests : BaseTest {
+
+		List<BuildErrorEventArgs> errors;
+		List<BuildWarningEventArgs> warnings;
+		MockBuildEngine engine;
+
+		[SetUp]
+		public void Setup ()
+		{
+			engine = new MockBuildEngine (TestContext.Out, errors = new List<BuildErrorEventArgs> (), warnings = new List<BuildWarningEventArgs> ());
+		}
+
+		[Test]
+		public void TestNdkUtil ()
+		{
+			var log = new TaskLoggingHelper (engine, TestName);
+			using (var builder = new Builder ()) {
+				builder.ResolveSdks ();
+				var ndkDir = builder.AndroidNdkDirectory;
+				var sdkDir = builder.AndroidSdkDirectory;
+				MonoAndroidHelper.AndroidSdk = new AndroidSdkInfo ((arg1, arg2) => { }, sdkDir, ndkDir);
+				NdkUtil.Init (ndkDir);
+				var platforms = NdkUtil.GetSupportedPlatforms (ndkDir);
+				Assert.AreNotEqual (0, platforms.Count (), "No platforms found");
+				var arch = AndroidTargetArch.X86;
+				Assert.IsTrue (NdkUtil.ValidateNdkPlatform (log, ndkDir, arch, enableLLVM: false));
+				Assert.AreEqual (0, errors.Count, "NdkUtil.ValidateNdkPlatform should not have returned false.");
+				int level = NdkUtil.GetMinimumApiLevelFor (arch, ndkDir);
+				Assert.AreEqual (14, level, $"Min Api Level for {arch} should be 14.");
+				var compilerNoQuotes = NdkUtil.GetNdkTool (ndkDir, arch, "gcc", level);
+				Assert.AreEqual (0, errors.Count, "NdkUtil.GetNdkTool should not have errored.");
+				Assert.NotNull (compilerNoQuotes, "NdkUtil.GetNdkTool returned null.");
+				var gas = NdkUtil.GetNdkTool (ndkDir, arch, "as", level);
+				Assert.AreEqual (0, errors.Count, "NdkUtil.GetNdkTool should not have errored.");
+				Assert.NotNull (gas, "NdkUtil.GetNdkTool returned null.");
+				var inc = NdkUtil.GetNdkPlatformIncludePath (ndkDir, arch, level);
+				Assert.NotNull (inc, " NdkUtil.GetNdkPlatformIncludePath should not return null");
+				var libPath = NdkUtil.GetNdkPlatformLibPath (ndkDir, arch, level);
+				Assert.NotNull (libPath, "NdkUtil.GetNdkPlatformLibPath  should not return null");
+				string ld = NdkUtil.GetNdkTool (ndkDir, arch, "ld", level);
+				Assert.AreEqual (0, errors.Count, "NdkUtil.GetNdkTool should not have errored.");
+				Assert.NotNull (ld, "NdkUtil.GetNdkTool returned null.");
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/NdkUtilTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/NdkUtilTests.cs
@@ -41,7 +41,8 @@ namespace Xamarin.Android.Build.Tests.Tasks {
 				Assert.IsTrue (NdkUtil.ValidateNdkPlatform (log, ndkDir, arch, enableLLVM: false));
 				Assert.AreEqual (0, errors.Count, "NdkUtil.ValidateNdkPlatform should not have returned false.");
 				int level = NdkUtil.GetMinimumApiLevelFor (arch, ndkDir);
-				Assert.AreEqual (14, level, $"Min Api Level for {arch} should be 14.");
+				int expected = IsWindows ? 16 : 14;
+				Assert.AreEqual (expected, level, $"Min Api Level for {arch} should be {expected}.");
 				var compilerNoQuotes = NdkUtil.GetNdkTool (ndkDir, arch, "gcc", level);
 				Assert.AreEqual (0, errors.Count, "NdkUtil.GetNdkTool should not have errored.");
 				Assert.NotNull (compilerNoQuotes, "NdkUtil.GetNdkTool returned null.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/NdkUtilTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/NdkUtilTests.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Android.Build.Tests.Tasks {
 				Assert.IsTrue (NdkUtil.ValidateNdkPlatform (log, ndkDir, arch, enableLLVM: false));
 				Assert.AreEqual (0, errors.Count, "NdkUtil.ValidateNdkPlatform should not have returned false.");
 				int level = NdkUtil.GetMinimumApiLevelFor (arch, ndkDir);
-				int expected = IsWindows ? 16 : 14;
+				int expected = 16;
 				Assert.AreEqual (expected, level, $"Min Api Level for {arch} should be {expected}.");
 				var compilerNoQuotes = NdkUtil.GetNdkTool (ndkDir, arch, "gcc", level);
 				Assert.AreEqual (0, errors.Count, "NdkUtil.GetNdkTool should not have errored.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -89,6 +89,7 @@
     <Compile Include="ZipArchiveExTests.cs" />
     <Compile Include="ConvertResourcesCasesTests.cs" />
     <Compile Include="..\..\..\..\bin\Build$(Configuration)\XABuildConfig.cs" />
+    <Compile Include="Tasks\NdkUtilTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Expected\GenerateDesignerFileExpected.cs">

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -583,15 +583,14 @@ namespace Xamarin.Android.Tasks
 
 		public static IEnumerable<string> Executables (string executable)
 		{
-			yield return executable;
 			var pathExt = Environment.GetEnvironmentVariable ("PATHEXT");
 			var pathExts = pathExt?.Split (new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
 
-			if (pathExts == null)
-				yield break;
-
-			foreach (var ext in pathExts)
-				yield return Path.ChangeExtension (executable, ext);
+			if (pathExts != null) {
+				foreach (var ext in pathExts)
+					yield return Path.ChangeExtension (executable, ext);
+			}
+			yield return executable;
 		}
 
 		public static string TryGetAndroidJarPath (TaskLoggingHelper log, string platform)


### PR DESCRIPTION
The r19 Ndk on windows does not use `.exe` files
for some of its compiler tools. It uses `.cmd`.
As a result our current setup will not find these
files and you end up with errors like

	error XA5101: Toolchain utility 'armv7a-linux-androideabi16-clang.exe' for target Arm was not found. Tried in path: "C:\Users\dlab14\android-toolchain\ndk\toolchains\llvm\prebuilt\windows-x86_64"

This commit changes the code to use the
`MonoAndroidHelper.GetExecutablePath` method which
uses the `PATHEXT` environment variable to search
for various exe file extensions.