### PR TITLE
[build] support for building with VS 2019

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -13,6 +13,10 @@
   />
   <PropertyGroup>
     <ProductVersion>9.2.99</ProductVersion>
+    <!-- TFV for all projects, try v4.7.2 but fallback if needed -->
+    <_StandardLibraryPath>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries('.NETFramework', 'v4.7.2', ''))</_StandardLibraryPath>
+    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' And '$(_StandardLibraryPath)' != '' ">v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v4.7.1</TargetFrameworkVersion>
     <!-- Used by the `build-tools/create-vsix` build so that `Mono.Android.Export.dll`/etc. are only included *once* -->
     <!-- Should correspond to the first value from `$(API_LEVELS)` in `build-tools/scripts/BuildEverything.mk` -->
     <AndroidFirstFrameworkVersion Condition="'$(AndroidFirstFrameworkVersion)' == ''">v4.4</AndroidFirstFrameworkVersion>

--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -135,6 +135,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "jit-times", "tools\jit-time
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "create-pkg", "build-tools\create-pkg\create-pkg.csproj", "{46529930-A5CC-4205-A50D-0AAAC639F082}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "vswhere", "tools\vswhere\vswhere.csproj", "{DBDC804F-8406-4F5E-83C6-720CB0CB6C6F}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems*{3f1f2f50-af1a-4a5a-bedb-193372f068d7}*SharedItemsImports = 4
@@ -389,6 +391,10 @@ Global
 		{46529930-A5CC-4205-A50D-0AAAC639F082}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{46529930-A5CC-4205-A50D-0AAAC639F082}.Release|AnyCPU.ActiveCfg = Release|Any CPU
 		{46529930-A5CC-4205-A50D-0AAAC639F082}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{DBDC804F-8406-4F5E-83C6-720CB0CB6C6F}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{DBDC804F-8406-4F5E-83C6-720CB0CB6C6F}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{DBDC804F-8406-4F5E-83C6-720CB0CB6C6F}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{DBDC804F-8406-4F5E-83C6-720CB0CB6C6F}.Release|AnyCPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -453,6 +459,7 @@ Global
 		{46529930-A5CC-4205-A50D-0AAAC639F082} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 		{0C31DE30-F9DF-4312-BFFE-DCAD558CCF08} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{A0AEF446-3368-4591-9DE6-BC3B2B33337D} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
+		{DBDC804F-8406-4F5E-83C6-720CB0CB6C6F} = {864062D3-A415-4A6F-9324-5820237BA058}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {53A1F287-EFB2-4D97-A4BB-4A5E145613F6}

--- a/build-tools/ThirdPartyNotices/ThirdPartyNotices.csproj
+++ b/build-tools/ThirdPartyNotices/ThirdPartyNotices.csproj
@@ -4,7 +4,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{748AD9A9-5829-42DF-8B11-15A6FB89CB13}</ProjectGuid>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Android.Tools.BootstrapTasks</RootNamespace>
     <AssemblyName>Xamarin.Android.Tools.BootstrapTasks</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <Import Project="..\..\build-tools\scripts\MSBuildReferences.projitems" />

--- a/build-tools/android-toolchain/android-toolchain.csproj
+++ b/build-tools/android-toolchain/android-toolchain.csproj
@@ -4,7 +4,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{8FF78EB6-6FC8-46A7-8A15-EBBA9045C5FA}</ProjectGuid>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/build-tools/api-merge/api-merge.csproj
+++ b/build-tools/api-merge/api-merge.csproj
@@ -7,7 +7,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>apimerge</RootNamespace>
     <AssemblyName>api-merge</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/build-tools/api-xml-adjuster/api-xml-adjuster.csproj
+++ b/build-tools/api-xml-adjuster/api-xml-adjuster.csproj
@@ -7,7 +7,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Xamarin.Android.Tools</RootNamespace>
     <AssemblyName>api-xml-adjuster</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/build-tools/create-bundle/create-bundle.csproj
+++ b/build-tools/create-bundle/create-bundle.csproj
@@ -4,7 +4,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{1640725C-4DB8-4D8D-BC96-74E688A06EEF}</ProjectGuid>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/build-tools/create-pkg/create-pkg.csproj
+++ b/build-tools/create-pkg/create-pkg.csproj
@@ -7,9 +7,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>createpkg</RootNamespace>
     <AssemblyName>create-pkg</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <OutputPath>..\..\bin\Build$(Configuration)</OutputPath>
   </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/build-tools/create-vsix/create-vsix.csproj
+++ b/build-tools/create-vsix/create-vsix.csproj
@@ -8,7 +8,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Android.Sdk</RootNamespace>
     <AssemblyName>Xamarin.Android.Sdk</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <CreateVsixContainer Condition=" '$(CreateVsixContainer)' == '' ">False</CreateVsixContainer>
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>False</CopyOutputSymbolsToOutputDirectory>
@@ -25,6 +24,7 @@
     <ExtensionInstallationFolder>Xamarin\Xamarin.Android.Sdk</ExtensionInstallationFolder>
     <OutputPath>bin\$(Configuration)</OutputPath>
   </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' " />
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' " />
   <ItemGroup>

--- a/build-tools/dependencies/dependencies.csproj
+++ b/build-tools/dependencies/dependencies.csproj
@@ -4,7 +4,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{C845ECC0-2ED3-498E-8EA8-02EF7AC6E9AD}</ProjectGuid>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <Import Project="dependencies.targets" />

--- a/build-tools/download-bundle/download-bundle.csproj
+++ b/build-tools/download-bundle/download-bundle.csproj
@@ -5,7 +5,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{1DA0CB12-5508-4E83-A242-0C8D6D99A49B}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <Import Project="download-bundle.targets" />

--- a/build-tools/jnienv-gen/jnienv-gen.csproj
+++ b/build-tools/jnienv-gen/jnienv-gen.csproj
@@ -7,7 +7,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Xamarin.Android.JniEnv</RootNamespace>
     <AssemblyName>jnienv-gen</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/build-tools/mingw-dependencies/mingw-dependencies.csproj
+++ b/build-tools/mingw-dependencies/mingw-dependencies.csproj
@@ -5,7 +5,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{2C1C68CD-CFED-4DEB-A2D3-61D6932F3E8E}</ProjectGuid>
     <ForceBuildProjectFilePath>$(MSBuildThisFileFullPath)</ForceBuildProjectFilePath>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/build-tools/proprietary/proprietary.csproj
+++ b/build-tools/proprietary/proprietary.csproj
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <ProjectGuid>{D93CAC27-3893-42A3-99F1-2BCA72E186F4}</ProjectGuid>
     <CopyBuildOutputToOutputDirectory>False</CopyBuildOutputToOutputDirectory>
   </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\..\bin\Debug</OutputPath>
   </PropertyGroup>
@@ -20,6 +20,5 @@
       PrepareForRun;
     </BuildDependsOn>
   </PropertyGroup>
-  <Import Project="..\..\Configuration.props" />
   <Import Project="proprietary.targets" />
 </Project>

--- a/build-tools/remap-assembly-ref/remap-assembly-ref.csproj
+++ b/build-tools/remap-assembly-ref/remap-assembly-ref.csproj
@@ -7,7 +7,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>remapassemblyref</RootNamespace>
     <AssemblyName>remap-assembly-ref</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/build-tools/timing/timing.csproj
+++ b/build-tools/timing/timing.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <ProjectGuid>{37CAA28C-40BE-4253-BA68-CC5D7316A617}</ProjectGuid>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />

--- a/build-tools/unix-distribution-setup/unix-distribution-setup.csproj
+++ b/build-tools/unix-distribution-setup/unix-distribution-setup.csproj
@@ -4,8 +4,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{2CF172E5-BDAE-4ABA-8BC8-08040ED3E77A}</ProjectGuid>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkMoniker>.NETFramework,Version=v4.5.1</TargetFrameworkMoniker>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Android.BuildTools.PrepTasks</RootNamespace>
     <AssemblyName>xa-prep-tasks</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <Import Project="..\..\build-tools\scripts\MSBuildReferences.projitems" />

--- a/src/System.Drawing.Primitives/System.Drawing.Primitives.csproj
+++ b/src/System.Drawing.Primitives/System.Drawing.Primitives.csproj
@@ -3,7 +3,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{C9FF2E4D-D927-479E-838B-647C16763F64}</ProjectGuid>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Xamarin.Android.Build.Tasks/ILRepack.targets
+++ b/src/Xamarin.Android.Build.Tasks/ILRepack.targets
@@ -26,6 +26,7 @@
 				Internalize="true"
 				Verbose="true"
 				DebugInfo="true"
+				TargetPlatformDirectory="$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries('.NETFramework', $(TargetFrameworkVersion), ''))"
 				InternalizeExclude="@(DoNotInternalizeAssemblies)"
 				InputAssemblies="$(OutputPath)\$(AssemblyName).dll;@(_InputAssembliesThatExist)"
 				LibraryPath="$(OutputPath)"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\..\..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -7,7 +8,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Android.Build.Tests</RootNamespace>
     <AssemblyName>Xamarin.Android.Build.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <_MSBuildExtension Condition=" '$(OS)' == 'Windows_NT' ">exe</_MSBuildExtension>
     <_MSBuildExtension Condition=" '$(OS)' != 'Windows_NT' ">dll</_MSBuildExtension>
     <_MSBuildToolsPath Condition=" !$(MSBuildToolsPath.Contains('xbuild')) ">$(MSBuildToolsPath)</_MSBuildToolsPath>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/packages.config
@@ -8,6 +8,6 @@
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net451" />
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net451" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.6.0" targetFramework="net451" />
-  <package id="NUnit3TestAdapter" version="3.12.0" targetFramework="net472" />
+  <package id="NUnit3TestAdapter" version="3.12.0" targetFramework="net451" />
   <package id="Unofficial.Ionic.Zip" version="1.9.1.8" targetFramework="net45" />
 </packages>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/packages.config
@@ -8,5 +8,6 @@
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net451" />
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net451" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.6.0" targetFramework="net451" />
+  <package id="NUnit3TestAdapter" version="3.12.0" targetFramework="net472" />
   <package id="Unofficial.Ionic.Zip" version="1.9.1.8" targetFramework="net45" />
 </packages>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -7,9 +7,9 @@ using System.Text;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
-using System.Xml;
 using System.Xml.XPath;
 using System.Xml.Linq;
+using Xamarin.Android.Tools.VSWhere;
 
 using XABuildPaths = Xamarin.Android.Build.Paths;
 
@@ -49,23 +49,17 @@ namespace Xamarin.ProjectTools
 		/// </summary>
 		public bool AutomaticNuGetRestore { get; set; } = true;
 
-		string GetVisualStudio2017Directory ()
+		static string visualStudioDirectory;
+
+		string GetVisualStudioDirectory ()
 		{
-			var editions = new [] {
-				"Enterprise",
-				"Professional",
-				"Community",
-				"BuildTools"
-			};
+			//We should cache and reuse this value, so we don't run vswhere.exe so much
+			if (!string.IsNullOrEmpty (visualStudioDirectory))
+				return visualStudioDirectory;
 
-			var x86 = Environment.GetFolderPath (Environment.SpecialFolder.ProgramFilesX86);
-			foreach (var edition in editions) {
-				var dir = Path.Combine (x86, "Microsoft Visual Studio", "2017", edition);
-				if (Directory.Exists (dir))
-					return dir;
-			}
-
-			return null;
+			var locator = new MSBuildLocator ();
+			locator.Locate ();
+			return visualStudioDirectory = locator.VisualStudioDirectory;
 		}
 
 		public string XABuildExe {
@@ -128,7 +122,7 @@ namespace Xamarin.ProjectTools
 					if (Directory.Exists (Path.Combine (outdir, "lib")) && File.Exists (Path.Combine (outdir, libmonodroidPath)))
 						return Path.Combine (outdir, "lib", "xamarin.android");
 
-					var visualStudioDirectory = GetVisualStudio2017Directory ();
+					var visualStudioDirectory = GetVisualStudioDirectory ();
 					if (!string.IsNullOrEmpty (visualStudioDirectory))
 						return Path.Combine (visualStudioDirectory, "MSBuild", "Xamarin", "Android");
 
@@ -148,7 +142,7 @@ namespace Xamarin.ProjectTools
 	
 					return string.Empty;
 				}
-				var visualStudioDirectory = GetVisualStudio2017Directory ();
+				var visualStudioDirectory = GetVisualStudioDirectory ();
 				if (!string.IsNullOrEmpty (visualStudioDirectory)) {
 					path = Path.Combine (visualStudioDirectory, "MSBuild", "Sdks", "Microsoft.NET.Sdk");
 					if (File.Exists (Path.Combine (path, "Sdk", "Sdk.props")))

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -57,9 +57,8 @@ namespace Xamarin.ProjectTools
 			if (!string.IsNullOrEmpty (visualStudioDirectory))
 				return visualStudioDirectory;
 
-			var locator = new MSBuildLocator ();
-			locator.Locate ();
-			return visualStudioDirectory = locator.VisualStudioDirectory;
+			var instance = MSBuildLocator.QueryLatest ();
+			return visualStudioDirectory = instance.VisualStudioRootPath;
 		}
 
 		public string XABuildExe {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
@@ -131,6 +131,9 @@ namespace Xamarin.ProjectTools
 			var pn = XName.Get ("Project", "http://schemas.microsoft.com/developer/msbuild/2003");
 			var p = document.Element (pn);
 			if (p != null) {
+				//NOTE: when running tests inside VS 2019 "Current" was set here
+				p.SetAttributeValue ("ToolsVersion", "15.0");
+
 				var referenceGroup = p.Elements ().FirstOrDefault (x => x.Name.LocalName == "ItemGroup" &&  x.HasElements && x.Elements ().Any (e => e.Name.LocalName == "Reference"));
 				if (referenceGroup != null) {
 					foreach (var pr in PackageReferences) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.ProjectTools</RootNamespace>
     <AssemblyName>Xamarin.ProjectTools</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\..\..\Configuration.props" />
   <Import Project="..\..\..\..\build-tools\scripts\MSBuildReferences.projitems" />
@@ -151,6 +150,10 @@
     <ProjectReference Include="..\..\..\..\external\xamarin-android-tools\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj">
       <Project>{E34BCFA0-CAA4-412C-AA1C-75DB8D67D157}</Project>
       <Name>Xamarin.Android.Tools.AndroidSdk</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\tools\vswhere\vswhere.csproj">
+      <Project>{dbdc804f-8406-4f5e-83c6-720cb0cb6c6f}</Project>
+      <Name>vswhere</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="..\..\..\..\build-tools\scripts\libzip-references.projitems" />

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
@@ -55,13 +55,6 @@ namespace Monodroid {
 			UpdateXmlResource (null, e, acwMap);
 		}
 
-		internal static IEnumerable<T> Prepend<T> (this IEnumerable<T> l, T another) where T : XNode
-		{
-			yield return another;
-			foreach (var e in l)
-				yield return e;
-		}
-		
 		static void UpdateXmlResource (string resourcesBasePath, XElement e, Dictionary<string, string> acwMap, IEnumerable<string> additionalDirectories = null, Action<TraceLevel, string> logMessage = null, Action<string> registerCustomView = null)
 		{
 			foreach (var elem in GetElements (e).Prepend (e)) {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -9,7 +9,6 @@
     <RootNamespace>Xamarin.Android.Tasks</RootNamespace>
     <AssemblyName>Xamarin.Android.Build.Tasks</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />

--- a/src/Xamarin.Android.Tools.Aidl/Xamarin.Android.Tools.Aidl.csproj
+++ b/src/Xamarin.Android.Tools.Aidl/Xamarin.Android.Tools.Aidl.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.AndroidTools.Aidl</RootNamespace>
     <AssemblyName>Xamarin.Android.Tools.Aidl</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Xamarin.Android.Tools.JavadocImporter/Xamarin.Android.Tools.JavadocImporter.csproj
+++ b/src/Xamarin.Android.Tools.JavadocImporter/Xamarin.Android.Tools.JavadocImporter.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Android.Tools.JavadocImporter</RootNamespace>
     <AssemblyName>Xamarin.Android.Tools.JavadocImporter</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/aapt2/aapt2.csproj
+++ b/src/aapt2/aapt2.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>0c31de30-f9df-4312-bffe-dcad558ccf08</ProjectGuid>
     <OutputType>Exe</OutputType>
     <OutputPath Condition="'$(OutputPath)'==''">bin\$(Configuration)</OutputPath>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" />
   <PropertyGroup Condition="'$(Configuration)'=='Release'" />

--- a/src/bundletool/bundletool.csproj
+++ b/src/bundletool/bundletool.csproj
@@ -5,7 +5,6 @@
     <ProjectGuid>a0aef446-3368-4591-9de6-bc3b2b33337d</ProjectGuid>
     <OutputType>Exe</OutputType>
     <OutputPath Condition="'$(OutputPath)'==''">bin\$(Configuration)</OutputPath>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" />
   <PropertyGroup Condition="'$(Configuration)'=='Release'" />

--- a/src/libzip-windows/libzip-windows.csproj
+++ b/src/libzip-windows/libzip-windows.csproj
@@ -5,7 +5,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{0DE278D6-000F-4001-BB98-187C0AF58A61}</ProjectGuid>
     <ForceBuildProjectFilePath>$(MSBuildThisFileFullPath)</ForceBuildProjectFilePath>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/libzip/libzip.csproj
+++ b/src/libzip/libzip.csproj
@@ -5,7 +5,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{900A0F71-BAAD-417A-8D1A-8D330297CDD0}</ProjectGuid>
     <ForceBuildProjectFilePath>$(MSBuildThisFileFullPath)</ForceBuildProjectFilePath>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/monodroid/monodroid.csproj
+++ b/src/monodroid/monodroid.csproj
@@ -4,7 +4,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{53EE4C57-1C03-405A-8243-8DA539546C88}</ProjectGuid>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/netstandard/netstandard.csproj
+++ b/src/netstandard/netstandard.csproj
@@ -3,7 +3,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{93614CB8-4564-43B9-93B0-4AF4B3B16AAE}</ProjectGuid>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/proguard/proguard.csproj
+++ b/src/proguard/proguard.csproj
@@ -3,7 +3,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{4B9D96BB-95AB-44E8-9F87-13B12C8BCED1}</ProjectGuid>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/r8/r8.csproj
+++ b/src/r8/r8.csproj
@@ -4,7 +4,6 @@
     <ProjectGuid>1bafa0cc-0377-46ce-ab7b-7bb2e7b62f63</ProjectGuid>
     <OutputType>Exe</OutputType>
     <OutputPath Condition="'$(OutputPath)'==''">bin\$(Configuration)</OutputPath>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" />
   <PropertyGroup Condition="'$(Configuration)'=='Release'" />

--- a/src/sqlite-xamarin/sqlite-xamarin.csproj
+++ b/src/sqlite-xamarin/sqlite-xamarin.csproj
@@ -3,7 +3,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{B8F799C5-D7CE-4E09-9CE6-BAA4173E7EC8}</ProjectGuid>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/tests/CodeBehind/UnitTests/CodeBehindUnitTests.csproj
+++ b/tests/CodeBehind/UnitTests/CodeBehindUnitTests.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>CodeBehindUnitTests</RootNamespace>
     <AssemblyName>CodeBehindUnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\..\Configuration.props" />
   <Import Project="..\..\..\build-tools\scripts\MSBuildReferences.projitems" />

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Xamarin.Android.MakeBundle-UnitTests.csproj
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Xamarin.Android.MakeBundle-UnitTests.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Android.MakeBundle.UnitTests</RootNamespace>
     <AssemblyName>Xamarin.Android.MakeBundle-UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/EmbeddedDSO-UnitTests.csproj
+++ b/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/EmbeddedDSO-UnitTests.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>EmbeddedDSOUnitTests</RootNamespace>
     <AssemblyName>EmbeddedDSOUnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
   </PropertyGroup>
 
   <Import Project="..\..\..\Configuration.props" />

--- a/tools/javadoc2mdoc/javadoc2mdoc.csproj
+++ b/tools/javadoc2mdoc/javadoc2mdoc.csproj
@@ -7,7 +7,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Xamarin.Android.Tools.JavadocToMDoc</RootNamespace>
     <AssemblyName>javadoc-to-mdoc</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tools/jit-times/jit-times.csproj
+++ b/tools/jit-times/jit-times.csproj
@@ -7,7 +7,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>jittimes</RootNamespace>
     <AssemblyName>jit-times</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tools/setup-windows/setup-windows.csproj
+++ b/tools/setup-windows/setup-windows.csproj
@@ -7,7 +7,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>setupwindows</RootNamespace>
     <AssemblyName>setup-windows</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tools/vswhere/MSBuildLocator.cs
+++ b/tools/vswhere/MSBuildLocator.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace Xamarin.Android.Tools.VSWhere
+{
+	/// <summary>
+	/// https://github.com/Microsoft/vswhere/wiki/Find-MSBuild
+	/// </summary>
+	public class MSBuildLocator
+	{
+		static readonly string [] msbuildLocations = new [] {
+			// VS 2019 & Higher
+			Path.Combine ("MSBuild", "Current", "Bin", "MSBuild.exe"),
+			// VS 2017
+			Path.Combine ("MSBuild", "15.0", "Bin", "MSBuild.exe"),
+		};
+
+		/// <summary>
+		/// Adds the -prerelease flag, defaults to false
+		/// </summary>
+		public bool IncludePrerelease { get; set; } = false;
+
+		public string VisualStudioDirectory { get; private set; }
+
+		public string MSBuildPath { get; private set; }
+
+		public void Locate ()
+		{
+			var vsInstallDir = Environment.GetEnvironmentVariable ("VSINSTALLDIR");
+			if (string.IsNullOrEmpty (vsInstallDir)) {
+				var programFiles = Environment.GetFolderPath (Environment.SpecialFolder.ProgramFilesX86);
+				var vswhere = Path.Combine (programFiles, "Microsoft Visual Studio", "Installer", "vswhere.exe");
+				if (!File.Exists (vswhere))
+					throw new FileNotFoundException ("Cannot find vswhere.exe!", vswhere);
+
+				string prerelease = IncludePrerelease ? "-prerelease" : "";
+				VisualStudioDirectory = Exec (vswhere, $"-latest {prerelease} -products * -requires Microsoft.Component.MSBuild -property installationPath");
+				if (!Directory.Exists (VisualStudioDirectory)) {
+					throw new Exception ($"vswhere.exe result returned a directory that did not exist: {VisualStudioDirectory}");
+				}
+			} else {
+				VisualStudioDirectory = vsInstallDir;
+			}
+
+			foreach (var path in msbuildLocations) {
+				MSBuildPath = Path.Combine (VisualStudioDirectory, path);
+				if (File.Exists (MSBuildPath))
+					return;
+			}
+
+			throw new FileNotFoundException ("Cannot find MSBuild.exe!");
+		}
+
+		string Exec (string fileName, string args)
+		{
+			var info = new ProcessStartInfo {
+				FileName = fileName,
+				Arguments = args,
+				UseShellExecute = false,
+				RedirectStandardOutput = true,
+				CreateNoWindow = true,
+				WindowStyle = ProcessWindowStyle.Hidden,
+			};
+			using (var p = Process.Start (info)) {
+				p.WaitForExit ();
+				return p.StandardOutput.ReadToEnd ().Trim ();
+			}
+		}
+	}
+}

--- a/tools/vswhere/Properties/AssemblyInfo.cs
+++ b/tools/vswhere/Properties/AssemblyInfo.cs
@@ -1,0 +1,26 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle ("vswhere")]
+[assembly: AssemblyDescription ("")]
+[assembly: AssemblyConfiguration ("")]
+[assembly: AssemblyCompany ("Microsoft Corporation")]
+[assembly: AssemblyProduct ("")]
+[assembly: AssemblyCopyright ("")]
+[assembly: AssemblyTrademark ("")]
+[assembly: AssemblyCulture ("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion ("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]

--- a/tools/vswhere/VisualStudioInstance.cs
+++ b/tools/vswhere/VisualStudioInstance.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Xamarin.Android.Tools.VSWhere
+{
+	public class VisualStudioInstance
+	{
+		public string VisualStudioRootPath { get; set; }
+
+		public string MSBuildPath { get; set; }
+	}
+}

--- a/tools/vswhere/vswhere.csproj
+++ b/tools/vswhere/vswhere.csproj
@@ -41,6 +41,7 @@
   <ItemGroup>
     <Compile Include="MSBuildLocator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="VisualStudioInstance.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/tools/vswhere/vswhere.csproj
+++ b/tools/vswhere/vswhere.csproj
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DBDC804F-8406-4F5E-83C6-720CB0CB6C6F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Xamarin.Android.Tools.VSWhere</RootNamespace>
+    <AssemblyName>vswhere</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MSBuildLocator.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tools/xabuild/App.config
+++ b/tools/xabuild/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <startup useLegacyV2RuntimeActivationPolicy="true">
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/tools/xabuild/XABuild.cs
+++ b/tools/xabuild/XABuild.cs
@@ -100,7 +100,8 @@ namespace Xamarin.Android.Build
 			SetProperty (toolsets, "MSBuildToolsPath64", paths.MSBuildBin);
 			SetProperty (toolsets, "MSBuildExtensionsPath", paths.MSBuildExtensionsPath);
 			SetProperty (toolsets, "MSBuildExtensionsPath32", paths.MSBuildExtensionsPath);
-			SetProperty (toolsets, "RoslynTargetsPath", Path.Combine (paths.MSBuildBin, "Roslyn"));
+			if (!string.IsNullOrEmpty (paths.RoslynTargetsPath))
+				SetProperty (toolsets, "RoslynTargetsPath", paths.RoslynTargetsPath);
 			SetProperty (toolsets, "NuGetProps", paths.NuGetProps);
 			SetProperty (toolsets, "NuGetTargets", paths.NuGetTargets);
 			SetProperty (toolsets, "NuGetRestoreTargets", paths.NuGetRestoreTargets);

--- a/tools/xabuild/XABuildPaths.cs
+++ b/tools/xabuild/XABuildPaths.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Xamarin.Android.Tools.VSWhere;
 
 namespace Xamarin.Android.Build
 {
@@ -102,6 +103,13 @@ namespace Xamarin.Android.Build
 
 		public string NuGetRestoreTargets { get; private set; }
 
+		/// <summary>
+		/// The directory containing Microsoft.CSharp.Core.Targets
+		/// 
+		/// In VS 2017 and 2019, this would be: %VsInstallDir%\MSBuild\15.0\Bin\Roslyn
+		/// </summary>
+		public string RoslynTargetsPath { get; private set; }
+
 		public XABuildPaths ()
 		{
 			IsWindows                 = Environment.OSVersion.Platform == PlatformID.Win32NT;
@@ -110,34 +118,32 @@ namespace Xamarin.Android.Build
 			XABuildDirectory          = Path.GetDirectoryName (GetType ().Assembly.Location);
 			XamarinAndroidBuildOutput = Path.GetFullPath (Path.Combine (XABuildDirectory, ".."));
 
-			const string vsVersion    = "15.0";
 			string programFiles       = Environment.GetFolderPath (Environment.SpecialFolder.ProgramFilesX86);
 			string prefix             = Path.Combine (XamarinAndroidBuildOutput, "lib", "xamarin.android");
 
 			if (IsWindows) {
-				foreach (var edition in new [] { "Enterprise", "Professional", "Community", "BuildTools" }) {
-					var vsInstall = Path.Combine (programFiles, "Microsoft Visual Studio", "2017", edition);
-					if (Directory.Exists (vsInstall)) {
-						VsInstallRoot = vsInstall;
-						break;
-					}
-				}
-				if (VsInstallRoot == null)
-					VsInstallRoot = programFiles;
+				var locator = new MSBuildLocator ();
+				locator.Locate ();
+				VsInstallRoot = locator.VisualStudioDirectory;
 
 				MSBuildPath              = Path.Combine (VsInstallRoot, "MSBuild");
-				MSBuildBin               = Path.Combine (MSBuildPath, vsVersion, "Bin");
+				MSBuildBin               = Path.GetDirectoryName (locator.MSBuildPath);
 				MSBuildConfig            = Path.Combine (MSBuildBin, "MSBuild.exe.config");
 				DotNetSdkPath            = FindLatestDotNetSdk (Path.Combine (Environment.GetEnvironmentVariable ("ProgramW6432"), "dotnet", "sdk"));
 				MSBuildSdksPath          = DotNetSdkPath ?? Path.Combine (MSBuildPath, "Sdks");
 				SystemFrameworks         = Path.Combine (programFiles, "Reference Assemblies", "Microsoft", "Framework");
-				SystemTargetsDirectories = new [] { Path.Combine (MSBuildPath, vsVersion), Path.Combine (MSBuildPath, "Microsoft") };
+				string msbuildDir        = Path.GetDirectoryName (MSBuildBin);
+				SystemTargetsDirectories = new [] { msbuildDir, Path.Combine (MSBuildPath, "Microsoft") };
 				SearchPathsOS            = "windows";
-				string nuget             = Path.Combine (MSBuildPath, "Microsoft", "NuGet", vsVersion);
+				string nuget             = Path.Combine (MSBuildPath, "Microsoft", "NuGet", "16.0");
+				if (!Directory.Exists (nuget)) {
+					nuget = Path.Combine (MSBuildPath, "Microsoft", "NuGet", "15.0");
+				}
 				NuGetProps               = Path.Combine (nuget, "Microsoft.NuGet.props");
 				NuGetTargets             = Path.Combine (nuget, "Microsoft.NuGet.targets");
 				NuGetRestoreTargets      = Path.Combine (VsInstallRoot, "Common7", "IDE", "CommonExtensions", "Microsoft", "NuGet", "NuGet.targets");
 			} else {
+				const string vsVersion   = "15.0";
 				string mono              = IsMacOS ? "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono" : "/usr/lib/mono";
 				string monoExternal      = IsMacOS ? "/Library/Frameworks/Mono.framework/External/" : "/usr/lib/mono";
 				MSBuildPath              = Path.Combine (mono, "msbuild");
@@ -165,6 +171,16 @@ namespace Xamarin.Android.Build
 			MonoAndroidToolsDirectory = Path.Combine (prefix, "xbuild", "Xamarin", "Android");
 			MSBuildExeTempPath        = Path.GetTempFileName ();
 			XABuildConfig             = MSBuildExeTempPath + ".config";
+
+			var roslyn = Path.Combine (MSBuildBin, "Roslyn");
+			if (Directory.Exists (roslyn)) {
+				RoslynTargetsPath = roslyn;
+			} else {
+				//NOTE: this codepath happens with VS 2019, Roslyn is located in a 15.0 directory...
+				roslyn = Path.Combine (MSBuildPath, "15.0", "Bin", "Roslyn");
+				if (Directory.Exists (roslyn))
+					RoslynTargetsPath = roslyn;
+			}
 
 			//Android SDK and NDK
 			var pathsTargets = Path.Combine (XABuildDirectory, "..", "..", "..", "build-tools", "scripts", "Paths.targets");

--- a/tools/xabuild/XABuildPaths.cs
+++ b/tools/xabuild/XABuildPaths.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using Xamarin.Android.Tools.VSWhere;
 
@@ -122,12 +121,11 @@ namespace Xamarin.Android.Build
 			string prefix             = Path.Combine (XamarinAndroidBuildOutput, "lib", "xamarin.android");
 
 			if (IsWindows) {
-				var locator = new MSBuildLocator ();
-				locator.Locate ();
-				VsInstallRoot = locator.VisualStudioDirectory;
+				var instance = MSBuildLocator.QueryLatest ();
+				VsInstallRoot = instance.VisualStudioRootPath;
 
 				MSBuildPath              = Path.Combine (VsInstallRoot, "MSBuild");
-				MSBuildBin               = Path.GetDirectoryName (locator.MSBuildPath);
+				MSBuildBin               = Path.GetDirectoryName (instance.MSBuildPath);
 				MSBuildConfig            = Path.Combine (MSBuildBin, "MSBuild.exe.config");
 				DotNetSdkPath            = FindLatestDotNetSdk (Path.Combine (Environment.GetEnvironmentVariable ("ProgramW6432"), "dotnet", "sdk"));
 				MSBuildSdksPath          = DotNetSdkPath ?? Path.Combine (MSBuildPath, "Sdks");

--- a/tools/xabuild/xabuild.csproj
+++ b/tools/xabuild/xabuild.csproj
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="..\..\Configuration.props" />
-  <Import Project="..\..\build-tools\scripts\MSBuildReferences.projitems" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,12 +8,12 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Xamarin.Android.Build</RootNamespace>
     <AssemblyName>xabuild</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
     <_MSBuildExtension Condition=" '$(OS)' == 'Windows_NT' ">exe</_MSBuildExtension>
     <_MSBuildExtension Condition=" '$(OS)' != 'Windows_NT' ">dll</_MSBuildExtension>
   </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
+  <Import Project="..\..\build-tools\scripts\MSBuildReferences.projitems" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>x86</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
@@ -41,6 +39,10 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
+    <ProjectReference Include="..\vswhere\vswhere.csproj">
+      <Project>{dbdc804f-8406-4f5e-83c6-720cb0cb6c6f}</Project>
+      <Name>vswhere</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2627

There are several things broken when building with MSBuild 16.0 and/or
using Visual Studio 2019.

## TargetFrameworkVersion ##

Anything referencing MSBuild assemblies must now be
`TargetFrameworkVersion=v4.7.2`, since these assemblies are now
targeting it.

We should take this as an opportunity to consolidate all
`$(TargetFrameworkVersion)`, so I moved this property into
`Configuration.props`. I was able to remove the property in many
projects, and the IDE still seemed to work fine.

The only hang up is that some versions of Mono don't have v4.7.2 yet.
So I had to use the following trick:

    <_StandardLibraryPath>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries('.NETFramework', 'v4.7.2', ''))</_StandardLibraryPath>
    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' And '$(_StandardLibraryPath)' != '' ">v4.7.2</TargetFrameworkVersion>
    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v4.7.1</TargetFrameworkVersion>

See: https://github.com/Microsoft/msbuild/blob/e03296fe14152b4c84e6610d2fd2fd10f1ecba82/src/Utilities/ToolLocationHelper.cs#L1736-L1747

This allows us to fallback to v4.7.1 if we have to.

## Prepend<T> ##

With `$(TargetFrameworkVersion)` changing, this method:

    internal static IEnumerable<T> Prepend<T> (this IEnumerable<T> l, T another) where T : XNode

Now exists in the BCL, so we can remove it.

## MSBuild.exe location ##

In VS 2017, MSBuild is located in:

    %VsInstallDir%\MSBuild\15.0\Bin\MSBuild.exe

In VS 2019, it is now located in:

    %VsInstallDir%\MSBuild\Current\Bin\MSBuild.exe

Right now we have a bit of code that "finds" Visual Studio, MSBuild,
etc. so we should take this opportunity to improve it.

We originally thought about MSBuildLocator:

https://www.nuget.org/packages/Microsoft.Build.Locator/
https://github.com/Microsoft/MSBuildLocator

But the licensing of the library was concerning... We were uncertain
if we could redistribute MSBuildLocator as part of an OSS product.

For now we can just use `vswhere.exe`:

https://github.com/Microsoft/vswhere/wiki/Find-MSBuild

I made a simple `vswhere.csproj` we can reference where this
functionality is needed. Currently `xabuild` and
`Xamarin.ProjectTools` need to locate the Visual Studio directory.

## Other breakage in xabuild.exe ##

In VS 2019, the path to Roslyn is a bit odd:

    %VsInstallDir%\MSBuild\15.0\Bin\Roslyn

I had to rework things to still work when combined with a different
MSBuild location:

    %VsInstallDir%\MSBuild\Current\Bin\MSBuild.exe

Additionally, our binding redirects weren't working in this project at
all. `App.config` was *not* in the csproj!

## NUnit ##

There does not appear to be an NUnit extension available for VS 2019
yet. I frequently use the `Test Explorer` in VS to individually run
tests.

However, it looks like they are switching to a different model for
test frameworks. Each test framework ships its own "adapter" that
enables the testing UIs in Visual Studio. These are shipped on NuGet,
and so they can work without installing any extra extensions.

So we just need:

    https://www.nuget.org/packages/NUnit3TestAdapter/

This package should not affect anything on non-Windows platforms.

## ILRepack ##

With the usage of TFV=v4.7.2 we were hitting:

    "src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj" (default target) (1) ->
        (ILRepacker target) ->
        src/Xamarin.Android.Build.Tasks/ILRepack.targets(24,3): error : Failed to resolve assembly: 'netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' [src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj]

We need to specify `TargetPlatformDirectory`, path logic in `ILRepack`
appears to be failing, see:

https://github.com/Alexx999/ILRepack.Lib.MSBuild.Task/blob/72c4c3bd051a166f5e3316b55457b24034c69a1d/ILRepack.Lib.MSBuild/ILRepack.cs#L148-L151
https://github.com/Alexx999/il-repack/blob/18698fddc4bb577f676d7465a6ad271ced58abc1/ILRepack/ILRepack.cs#L450-L462

## Other repositories ##

We will need to switch to `TargetFrameworkVersion=v4.7.2` and use the
NUnit adapter in other repos:

- Downstream in `monodroid`, things will likely break without these
  changes.
- `Java.Interop` is currently *working*, but should be updated.
- `xamarin-android-tools` is currently *working*, but should be updated.