### PR TITLE
Bump `ManagedRuntime` dependency

### DIFF
--- a/build-tools/dependencies/dependencies.projitems
+++ b/build-tools/dependencies/dependencies.projitems
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_DarwinMonoFramework>MonoFramework-MDK-5.18.0.162.macos10.xamarin.universal.pkg</_DarwinMonoFramework>
+    <_DarwinMonoFramework>MonoFramework-MDK-5.18.0.244.macos10.xamarin.universal.pkg</_DarwinMonoFramework>
     <_AptGetInstall>apt-get -f -u install</_AptGetInstall>
   </PropertyGroup>
   <ItemGroup>
@@ -59,7 +59,7 @@
       <MaximumVersion Condition=" '$(IgnoreMaxMonoVersion)' == '' Or '$(IgnoreMaxMonoVersion)' == 'False' " >$(MonoRequiredMaximumVersion)</MaximumVersion>
       <DarwinMinimumVersion>$(MonoRequiredDarwinMinimumVersion)</DarwinMinimumVersion>
       <CurrentVersionCommand>$(MSBuildThisFileDirectory)..\scripts\mono-version</CurrentVersionCommand>
-      <DarwinMinimumUrl>https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2018-08/128/bc9d709e704fb157eaf4935cb67d272f154cff75/$(_DarwinMonoFramework)</DarwinMinimumUrl>
+      <DarwinMinimumUrl>https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2018-08/208/725ba2a2523dffb962712695f16f2d3b0cb142ae/$(_DarwinMonoFramework)</DarwinMinimumUrl>
       <DarwinInstall>installer -pkg "$(AndroidToolchainCacheDirectory)\$(_DarwinMonoFramework)" -target /</DarwinInstall>
     </RequiredProgram>
   </ItemGroup>


### PR DESCRIPTION
Updates the minimum required MDK version to the same commit currently
referenced in external/mono. This brings in a bunch of fixes that have
since been applied to the mono/mono:2018-08 branch.

From recent testing, this also appears to resolve the Android SDK download failures
we've been seeing intermittently on machines which don't already have these
components fully cached:
```
2019-01-29T18:05:08.0179160Z (_DownloadItems target) -> 
2019-01-29T18:05:08.0180480Z   /Users/vsts/agent/2.144.2/work/1/s/external/xamarin-android/build-tools/android-toolchain/android-toolchain.targets(42,5): error : Unable to download URL `https://dl.google.com/android/repository/platform-26_r02.zip` to `/Users/vsts/android-archives/platform-26_r02.zip`: An error occurred while sending the request [/Users/vsts/agent/2.144.2/work/1/s/external/xamarin-android/build-tools/android-toolchain/android-toolchain.csproj]
2019-01-29T18:05:08.0181710Z   /Users/vsts/agent/2.144.2/work/1/s/external/xamarin-android/build-tools/android-toolchain/android-toolchain.targets(42,5): error : An error occurred while sending the request [/Users/vsts/agent/2.144.2/work/1/s/external/xamarin-android/build-tools/android-toolchain/android-toolchain.csproj]
```