### PR TITLE
[build+macOS] Build with MDK 5.18.0.249

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -75,7 +75,7 @@
     <MonoRequiredMinimumVersion Condition=" '$(MonoRequiredMinimumVersion)' == '' ">5.18.0</MonoRequiredMinimumVersion>
     <MonoRequiredMaximumVersion Condition=" '$(MonoRequiredMaximumVersion)' == '' ">5.19.0</MonoRequiredMaximumVersion>
     <IgnoreMaxMonoVersion Condition=" '$(IgnoreMaxMonoVersion)' == '' ">True</IgnoreMaxMonoVersion>
-    <MonoRequiredDarwinMinimumVersion>$(MonoRequiredMinimumVersion).0</MonoRequiredDarwinMinimumVersion>
+    <MonoRequiredDarwinMinimumVersion>$(MonoRequiredMinimumVersion).249</MonoRequiredDarwinMinimumVersion>
     <LinkerSourceDirectory>$(MSBuildThisFileDirectory)external\mono\external\linker</LinkerSourceDirectory>
     <OpenTKSourceDirectory>$(MSBuildThisFileDirectory)external\opentk</OpenTKSourceDirectory>
     <LibZipSourceDirectory Condition=" '$(LibZipSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\libzip</LibZipSourceDirectory>

--- a/build-tools/dependencies/dependencies.projitems
+++ b/build-tools/dependencies/dependencies.projitems
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_DarwinMonoFramework>MonoFramework-MDK-5.18.0.244.macos10.xamarin.universal.pkg</_DarwinMonoFramework>
+    <_DarwinMonoFramework>MonoFramework-MDK-5.18.0.249.macos10.xamarin.universal.pkg</_DarwinMonoFramework>
     <_AptGetInstall>apt-get -f -u install</_AptGetInstall>
   </PropertyGroup>
   <ItemGroup>
@@ -59,7 +59,7 @@
       <MaximumVersion Condition=" '$(IgnoreMaxMonoVersion)' == '' Or '$(IgnoreMaxMonoVersion)' == 'False' " >$(MonoRequiredMaximumVersion)</MaximumVersion>
       <DarwinMinimumVersion>$(MonoRequiredDarwinMinimumVersion)</DarwinMinimumVersion>
       <CurrentVersionCommand>$(MSBuildThisFileDirectory)..\scripts\mono-version</CurrentVersionCommand>
-      <DarwinMinimumUrl>https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2018-08/208/725ba2a2523dffb962712695f16f2d3b0cb142ae/$(_DarwinMonoFramework)</DarwinMinimumUrl>
+      <DarwinMinimumUrl>https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2018-08/215/2359cba40e94accdcf5ce526572bce834d53f3aa/$(_DarwinMonoFramework)</DarwinMinimumUrl>
       <DarwinInstall>installer -pkg "$(AndroidToolchainCacheDirectory)\$(_DarwinMonoFramework)" -target /</DarwinInstall>
     </RequiredProgram>
   </ItemGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/2357
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/1239/console

We are experiencing a number of hangs from mono while running our unit
tests, seemingly around process exit; see e.g. [Jenkins build 1442][0]
which is a hang from executing `EmbeddedDSOUnitTests.dll`, or
[Jenkins build 1436][1], which is a hang from executing
`Xamarin.Android.MakeBundle-UnitTests.dll`, or...

One theory (hope? desire?) is that some of our apparent deadlocks may
be fixed by [this deadlock fix in mono][2], the fix for which is
present in `MonoFramework-MDK-5.18.0.249.macos10.xamarin.universal.pkg`.

Update `$(_DarwinMonoFramework)` and
`$(MonoRequiredDarwinMinimumVersion)` so that Mono 5.18.0.249 is
installed on our build machines.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/1442/
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/1436/
[2]: https://github.com/mono/mono/commit/2359cba40e94accdcf5ce526572bce834d53f3aa