### PR TITLE
[timing] don't use --depth=1 for git clone

### DIFF
--- a/build-tools/timing/timing.targets
+++ b/build-tools/timing/timing.targets
@@ -76,7 +76,7 @@
     />
     <Git
         Condition=" '%(XACaptureBuildTimingProject.Repo)' != '' "
-        Arguments="clone &quot;%(XACaptureBuildTimingProject.Repo)&quot; --depth=1 &quot;%(XACaptureBuildTimingProject.DirectoryFullPath)&quot;"
+        Arguments="clone &quot;%(XACaptureBuildTimingProject.Repo)&quot; &quot;%(XACaptureBuildTimingProject.DirectoryFullPath)&quot;"
         WorkingDirectory="$(_TopDir)"
         ToolPath="$(GitToolPath)"
         ToolExe="$(GitToolExe)"


### PR DESCRIPTION
Context: https://github.com/Microsoft/SmartHotel360-Mobile

Downstream in monodroid we building the SmartHotel360 app as part of
our MSBuild timings.

The problem is the following set of git commands:

    git clone https://github.com/Microsoft/SmartHotel360-Mobile.git --depth=1
    git checkout ad41901761df12802ab332d78b9eedb3248f3f1e

If ad41901761df12802ab332d78b9eedb3248f3f1e is not the latest commit,
this command will fail with:

    fatal: reference is not a tree: ad41901761df12802ab332d78b9eedb3248f3f1e

I invadvertantly broke this by updating our fork to latest
Microsoft/SmartHotel360-Mobile/master. Whoops!

Some options to fix this would be:

1. Create a branch, then don't ever touch it! Use `--branch` during
   the `git clone`.
2. Don't use `--depth=1` at all.

Looking into it `--depth=1` is not saving us that much on this repo,
it has around 300 commits now and only saves 16MB of disk space. This
seems a lot simpler, and we don't have to worry about future commits
breaking anything.