### PR TITLE
[Xamarin.Android.Build.Tasks] #deletebinobj and ResolveLibraryProjectImports

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -186,19 +186,21 @@ namespace Xamarin.Android.Tasks
 				MonoAndroidHelper.SetDirectoryWriteable (Path.Combine (oldPath, ".."));
 				Directory.Delete (oldPath, recursive: true);
 			}
-			var outdir = new DirectoryInfo (OutputImportDirectory);
-			if (!outdir.Exists)
-				outdir.Create ();
+			var outdir = Path.GetFullPath (OutputImportDirectory);
+			Directory.CreateDirectory (outdir);
 
 			foreach (var assembly in Assemblies)
 				res.Load (assembly.ItemSpec);
 
-			bool updated = false;
 			// FIXME: reorder references by import priority (not sure how to do that yet)
 			foreach (var assemblyPath in Assemblies
 					.Select (a => GetTargetAssembly (a))
 					.Where (a => a != null)
 					.Distinct ()) {
+				if (DesignTimeBuild && !File.Exists (assemblyPath)) {
+					Log.LogDebugMessage ("Skipping non existant dependancy '{0}' due to design time build.", assemblyPath);
+					continue;
+				}
 				string assemblyFileName = Path.GetFileNameWithoutExtension (assemblyPath);
 				string assemblyIdentName = assemblyFileName;
 				if (UseShortFileNames) {
@@ -217,8 +219,11 @@ namespace Xamarin.Android.Tasks
 				string assetsDir = Path.Combine (importsDir, "assets");
 
 				// Skip already-extracted resources.
-				var stamp = new FileInfo (Path.Combine (outdir.FullName, assemblyIdentName + ".stamp"));
-				if (stamp.Exists && stamp.LastWriteTimeUtc > new FileInfo (assemblyPath).LastWriteTimeUtc) {
+				bool updated = false;
+				string assemblyHash = MonoAndroidHelper.HashFile (assemblyPath);
+				string stamp = Path.Combine (outdir, assemblyIdentName + ".stamp");
+				string stampHash = File.Exists (stamp) ? File.ReadAllText (stamp) : null;
+				if (assemblyHash == stampHash) {
 					Log.LogDebugMessage ("Skipped resource lookup for {0}: extracted files are up to date", assemblyPath);
 #if SEPARATE_CRUNCH
 					// FIXME: review these binResDir/binAssemblyDir thing and enable this. Eclipse does this.
@@ -244,35 +249,20 @@ namespace Xamarin.Android.Tasks
 					continue;
 				}
 
-				if (!File.Exists (assemblyPath) && DesignTimeBuild) {
-					Log.LogDebugMessage ("Skipping non existant dependancy '{0}' due to design time build.", assemblyPath);
-					continue;
-				}
-
-				Log.LogDebugMessage ("Refreshing {0}", assemblyPath);
-
-				Directory.CreateDirectory (importsDir);
+				Log.LogDebugMessage ($"Refreshing {assemblyFileName}.dll");
 
 				var assembly = res.GetAssembly (assemblyPath);
-				var assemblyLastWrite = new FileInfo (assemblyPath).LastWriteTimeUtc;
-
 				foreach (var mod in assembly.Modules) {
 					// android environment files
 					foreach (var envtxt in mod.Resources
 							.Where (r => r.Name.StartsWith ("__AndroidEnvironment__", StringComparison.OrdinalIgnoreCase))
 							.Where (r => r is EmbeddedResource)
 							.Cast<EmbeddedResource> ()) {
-						if (!Directory.Exists (outDirForDll))
-							Directory.CreateDirectory (outDirForDll);
-						var finfo = new FileInfo (Path.Combine (outDirForDll, envtxt.Name));
-						if (!finfo.Exists || finfo.LastWriteTimeUtc > assemblyLastWrite) {
-							using (var stream = envtxt.GetResourceStream ())
-							using (var fs = finfo.Create ()) {
-								stream.CopyTo (fs);
-							}
-							updated = true;
+						var outFile = Path.Combine (outDirForDll, envtxt.Name);
+						using (var stream = envtxt.GetResourceStream ()) {
+							updated |= MonoAndroidHelper.CopyIfStreamChanged (stream, outFile);
 						}
-						resolvedEnvironments.Add (finfo.FullName);
+						resolvedEnvironments.Add (Path.GetFullPath (outFile));
 					}
 
 					// embedded jars (EmbeddedJar, EmbeddedReferenceJar)
@@ -280,13 +270,9 @@ namespace Xamarin.Android.Tasks
 						.Where (r => r.Name.EndsWith (".jar", StringComparison.InvariantCultureIgnoreCase))
 						.Select (r => (EmbeddedResource) r);
 					foreach (var resjar in resjars) {
-						var outjarFile = Path.Combine (importsDir, resjar.Name);
-						var fi = new FileInfo (outjarFile);
-						if (!fi.Exists || fi.LastWriteTimeUtc > assemblyLastWrite) {
-							using (var stream = resjar.GetResourceStream ())
-							using (var outfs = File.Create (outjarFile))
-								stream.CopyTo (outfs);
-							updated = true;
+						using (var stream = resjar.GetResourceStream ()) {
+							AddJar (jars, importsDir, resjar.Name);
+							updated |= MonoAndroidHelper.CopyIfStreamChanged (stream, Path.Combine (importsDir, resjar.Name));
 						}
 					}
 
@@ -303,7 +289,7 @@ namespace Xamarin.Android.Tasks
 										.Replace ("native_library_imports/", "");
 								}, deleteCallback: (fileToDelete) => {
 									return !files.Contains (fileToDelete);
-								}, forceUpdate: false);
+								});
 							} catch (PathTooLongException ex) {
 								Log.LogCodedError ("XA4303", $"Error extracting resources from \"{assemblyPath}\": {ex}");
 								return;
@@ -323,12 +309,16 @@ namespace Xamarin.Android.Tasks
 						using (var zip = Xamarin.Tools.Zip.ZipArchive.Open (stream)) {
 							try {
 								updated |= Files.ExtractAll (zip, importsDir, modifyCallback: (entryFullName) => {
-									return entryFullName
+									var path = entryFullName
 										.Replace ("library_project_imports\\","")
 										.Replace ("library_project_imports/", "");
+									if (path.EndsWith (".jar", StringComparison.OrdinalIgnoreCase)) {
+										AddJar (jars, importsDir, path);
+									}
+									return path;
 								}, deleteCallback: (fileToDelete) => {
 									return !jars.Contains (fileToDelete);
-								}, forceUpdate: false);
+								});
 							} catch (PathTooLongException ex) {
 								Log.LogCodedError ("XA4303", $"Error extracting resources from \"{assemblyPath}\": {ex}");
 								return;
@@ -362,9 +352,10 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 
-				if (Directory.Exists (importsDir) && (updated || !stamp.Exists)) {
-						Log.LogDebugMessage ("Touch {0}", stamp.FullName);
-						stamp.Create ().Close ();
+				if (Directory.Exists (importsDir) && assemblyHash != stampHash) {
+					Log.LogDebugMessage ($"Saving hash to {stamp}, changes: {updated}");
+					//NOTE: if the hash is different we always want to write the file, but preserve the timestamp if no changes
+					WriteAllText (stamp, assemblyHash, preserveTimestamp: !updated);
 				}
 			}
 			foreach (var aarFile in AarLibraries ?? new ITaskItem[0]) {
@@ -379,8 +370,12 @@ namespace Xamarin.Android.Tasks
 				string resDir = Path.Combine (importsDir, "res");
 				string assetsDir = Path.Combine (importsDir, "assets");
 
-				var stamp = new FileInfo (Path.Combine (outdir.FullName, Path.GetFileNameWithoutExtension (aarFile.ItemSpec) + ".stamp"));
-				if (stamp.Exists && stamp.LastWriteTimeUtc > new FileInfo (aarFile.ItemSpec).LastWriteTimeUtc) {
+				bool updated = false;
+				string aarHash = MonoAndroidHelper.HashFile (aarFile.ItemSpec);
+				string stamp = Path.Combine (outdir, Path.GetFileNameWithoutExtension (aarFile.ItemSpec) + ".stamp");
+				string stampHash = File.Exists (stamp) ? File.ReadAllText (stamp) : null;
+				if (aarHash == stampHash) {
+					Log.LogDebugMessage ("Skipped {0}: extracted files are up to date", aarFile.ItemSpec);
 					if (Directory.Exists (resDir))
 						resolvedResourceDirectories.Add (new TaskItem (Path.GetFullPath (resDir), new Dictionary<string, string> {
 							{ OriginalFile, Path.GetFullPath (aarFile.ItemSpec) },
@@ -390,6 +385,9 @@ namespace Xamarin.Android.Tasks
 						resolvedAssetDirectories.Add (Path.GetFullPath (assetsDir));
 					continue;
 				}
+
+				Log.LogDebugMessage ($"Refreshing {aarFile.ItemSpec}");
+
 				// temporarily extracted directory will look like:
 				// _lp_/[aarFile]
 				using (var zip = MonoAndroidHelper.ReadZipFile (aarFile.ItemSpec)) {
@@ -399,16 +397,22 @@ namespace Xamarin.Android.Tasks
 							var entryPath = Path.GetDirectoryName (entryFullName);
 							if (entryFileName.StartsWith ("internal_impl", StringComparison.InvariantCulture)) {
 								var hash = Files.HashString (entryFileName);
-								return Path.Combine (entryPath, $"internal_impl-{hash}.jar");
+								var jar = Path.Combine (entryPath, $"internal_impl-{hash}.jar");
+								AddJar (jars, importsDir, jar);
+								return jar;
+							}
+							if (entryFullName.EndsWith (".jar", StringComparison.OrdinalIgnoreCase)) {
+								AddJar (jars, importsDir, entryFullName);
 							}
 							return entryFullName;
 						}, deleteCallback: (fileToDelete) => {
 							return !jars.Contains (fileToDelete);
-						}, forceUpdate: false);
+						});
 
-						if (Directory.Exists (importsDir) && (updated || !stamp.Exists)) {
-							Log.LogDebugMessage ("Touch {0}", stamp.FullName);
-							stamp.Create ().Close ();
+						if (Directory.Exists (importsDir) && aarHash != stampHash) {
+							Log.LogDebugMessage ($"Saving hash to {stamp}, changes: {updated}");
+							//NOTE: if the hash is different we always want to write the file, but preserve the timestamp if no changes
+							WriteAllText (stamp, aarHash, preserveTimestamp: !updated);
 						}
 					} catch (PathTooLongException ex) {
 						Log.LogErrorFromException (new PathTooLongException ($"Error extracting resources from \"{aarFile.ItemSpec}\"", ex));
@@ -422,11 +426,24 @@ namespace Xamarin.Android.Tasks
 				if (Directory.Exists (assetsDir))
 					resolvedAssetDirectories.Add (Path.GetFullPath (assetsDir));
 			}
-			foreach (var f in outdir.EnumerateFiles ("*.jar", SearchOption.AllDirectories)
-					.Select (fi => fi.FullName)) {
-				if (jars.Contains (f))
-					continue;
-				jars.Add (f);
+		}
+
+		void AddJar (ICollection<string> jars, string destination, string path)
+		{
+			var dir = Path.GetFullPath (destination);
+			var jar = Path.Combine (dir, path);
+			if (!jars.Contains (jar))
+				jars.Add (jar);
+		}
+
+		void WriteAllText (string path, string contents, bool preserveTimestamp)
+		{
+			if (preserveTimestamp && File.Exists (path)) {
+				var timestamp = File.GetLastWriteTimeUtc (path);
+				File.WriteAllText (path, contents);
+				MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (path, timestamp, Log);
+			} else {
+				File.WriteAllText (path, contents);
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2602,7 +2602,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				Assert.IsTrue (b.Build (proj), "second build should have succeeded.");
 				Assert.IsFalse (b.Output.IsTargetSkipped ("_CleanIntermediateIfNuGetsChange"), "`_CleanIntermediateIfNuGetsChange` should have run!");
 				FileAssert.Exists (nugetStamp, "`_CleanIntermediateIfNuGetsChange` did not create stamp file!");
-				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "Xamarin.Android.Support.v4.dll: extracted files are up to date"), "`ResolveLibraryProjectImports` should not skip `Xamarin.Android.Support.v4.dll`!");
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "Refreshing Xamarin.Android.Support.v7.AppCompat.dll"), "`ResolveLibraryProjectImports` should not skip `Xamarin.Android.Support.v7.AppCompat.dll`!");
 				FileAssert.Exists (build_props, "build.props should exist after second build.");
 
 				proj.MainActivity = proj.MainActivity.Replace ("clicks", "CLICKS");
@@ -2610,6 +2610,53 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				Assert.IsTrue (b.Build (proj), "third build should have succeeded.");
 				Assert.IsTrue (b.Output.IsTargetSkipped ("_CleanIntermediateIfNuGetsChange"), "A build with no changes to NuGets should *not* trigger `_CleanIntermediateIfNuGetsChange`!");
 				FileAssert.Exists (build_props, "build.props should exist after third build.");
+			}
+		}
+
+		[Test]
+		[NonParallelizable]
+		public void CompileBeforeUpgradingNuGet ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.MainActivity = proj.DefaultMainActivity.Replace ("public class MainActivity : Activity", "public class MainActivity : Xamarin.Forms.Platform.Android.FormsAppCompatActivity");
+
+			proj.PackageReferences.Add (KnownPackages.XamarinForms_2_3_4_231);
+			proj.PackageReferences.Add (KnownPackages.AndroidSupportV4_25_4_0_1);
+			proj.PackageReferences.Add (KnownPackages.SupportCompat_25_4_0_1);
+			proj.PackageReferences.Add (KnownPackages.SupportCoreUI_25_4_0_1);
+			proj.PackageReferences.Add (KnownPackages.SupportCoreUtils_25_4_0_1);
+			proj.PackageReferences.Add (KnownPackages.SupportDesign_25_4_0_1);
+			proj.PackageReferences.Add (KnownPackages.SupportFragment_25_4_0_1);
+			proj.PackageReferences.Add (KnownPackages.SupportMediaCompat_25_4_0_1);
+			proj.PackageReferences.Add (KnownPackages.SupportV7AppCompat_25_4_0_1);
+			proj.PackageReferences.Add (KnownPackages.SupportV7CardView_25_4_0_1);
+			proj.PackageReferences.Add (KnownPackages.SupportV7MediaRouter_25_4_0_1);
+
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				var projectDir = Path.Combine (Root, b.ProjectDirectory);
+				if (Directory.Exists (projectDir))
+					Directory.Delete (projectDir, true);
+				Assert.IsTrue (b.DesignTimeBuild (proj), "design-time build should have succeeded.");
+
+				proj.PackageReferences.Clear ();
+				proj.PackageReferences.Add (KnownPackages.XamarinForms_3_1_0_697729);
+				proj.PackageReferences.Add (KnownPackages.Android_Arch_Core_Common_26_1_0);
+				proj.PackageReferences.Add (KnownPackages.Android_Arch_Lifecycle_Common_26_1_0);
+				proj.PackageReferences.Add (KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0);
+				proj.PackageReferences.Add (KnownPackages.AndroidSupportV4_27_0_2_1);
+				proj.PackageReferences.Add (KnownPackages.SupportCompat_27_0_2_1);
+				proj.PackageReferences.Add (KnownPackages.SupportCoreUI_27_0_2_1);
+				proj.PackageReferences.Add (KnownPackages.SupportCoreUtils_27_0_2_1);
+				proj.PackageReferences.Add (KnownPackages.SupportDesign_27_0_2_1);
+				proj.PackageReferences.Add (KnownPackages.SupportFragment_27_0_2_1);
+				proj.PackageReferences.Add (KnownPackages.SupportMediaCompat_27_0_2_1);
+				proj.PackageReferences.Add (KnownPackages.SupportV7AppCompat_27_0_2_1);
+				proj.PackageReferences.Add (KnownPackages.SupportV7CardView_27_0_2_1);
+				proj.PackageReferences.Add (KnownPackages.SupportV7MediaRouter_27_0_2_1);
+				proj.PackageReferences.Add (KnownPackages.SupportV7RecyclerView_27_0_2_1);
+				b.Save (proj, doNotCleanupOnUpdate: true);
+				Assert.IsTrue (b.Build (proj), "second build should have succeeded.");
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "Refreshing Xamarin.Android.Support.v7.AppCompat.dll"), "`ResolveLibraryProjectImports` should not skip `Xamarin.Android.Support.v7.AppCompat.dll`!");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/FilesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/FilesTests.cs
@@ -1,0 +1,186 @@
+﻿using NUnit.Framework;
+using System.IO;
+using System.Text;
+using Xamarin.Android.Tools;
+using Xamarin.Tools.Zip;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	public class FilesTests
+	{
+		static readonly Encoding encoding = Encoding.UTF8;
+		string tempDir;
+		MemoryStream stream;
+
+		[SetUp]
+		public void SetUp ()
+		{
+			tempDir = Path.Combine (Path.GetTempPath (), TestContext.CurrentContext.Test.Name);
+			stream = new MemoryStream ();
+		}
+
+		[TearDown]
+		public void TearDown ()
+		{
+			stream.Dispose ();
+			if (Directory.Exists (tempDir))
+				Directory.Delete (tempDir, recursive: true);
+		}
+
+		void AssertFile (string path, string contents)
+		{
+			var fullPath = Path.Combine (tempDir, path);
+			FileAssert.Exists (fullPath);
+			Assert.AreEqual (contents, File.ReadAllText (fullPath), $"Contents did not match at path: {path}");
+		}
+
+		bool ExtractAll (MemoryStream stream)
+		{
+			using (var zip = ZipArchive.Open (stream)) {
+				return Files.ExtractAll (zip, tempDir);
+			}
+		}
+
+		[Test]
+		public void ExtractAll ()
+		{
+			using (var zip = ZipArchive.Create (stream)) {
+				zip.AddEntry ("a.txt", "a", encoding);
+				zip.AddEntry ("b/b.txt", "b", encoding);
+			}
+
+			bool changes = ExtractAll (stream);
+
+			Assert.IsTrue (changes, "ExtractAll should report changes.");
+			AssertFile ("a.txt", "a");
+			AssertFile (Path.Combine ("b", "b.txt"), "b");
+		}
+
+		[Test]
+		public void ExtractAll_NoChanges ()
+		{
+			using (var zip = ZipArchive.Create (stream)) {
+				zip.AddEntry ("a.txt", "a", encoding);
+				zip.AddEntry ("b/b.txt", "b", encoding);
+			}
+
+			bool changes = ExtractAll (stream);
+			Assert.IsTrue (changes, "ExtractAll should report changes.");
+
+			stream.SetLength (0);
+			using (var zip = ZipArchive.Open (stream)) {
+				zip.AddEntry ("a.txt", "a", encoding);
+				zip.AddEntry ("b/b.txt", "b", encoding);
+			}
+
+			changes = ExtractAll (stream);
+
+			Assert.IsFalse (changes, "ExtractAll should *not* report changes.");
+			AssertFile ("a.txt", "a");
+			AssertFile (Path.Combine ("b", "b.txt"), "b");
+		}
+
+		[Test]
+		public void ExtractAll_NewFile ()
+		{
+			using (var zip = ZipArchive.Create (stream)) {
+				zip.AddEntry ("a.txt", "a", encoding);
+				zip.AddEntry ("b/b.txt", "b", encoding);
+			}
+
+			bool changes = ExtractAll (stream);
+			Assert.IsTrue (changes, "ExtractAll should report changes.");
+
+			stream.SetLength (0);
+			using (var zip = ZipArchive.Open (stream)) {
+				zip.AddEntry ("a.txt", "a", encoding);
+				zip.AddEntry ("b/b.txt", "b", encoding);
+				zip.AddEntry ("c/c.txt", "c", encoding);
+			}
+
+			changes = ExtractAll (stream);
+
+			Assert.IsTrue (changes, "ExtractAll should report changes.");
+			AssertFile ("a.txt", "a");
+			AssertFile (Path.Combine ("b", "b.txt"), "b");
+			AssertFile (Path.Combine ("c", "c.txt"), "c");
+		}
+
+		[Test]
+		public void ExtractAll_FileChanged ()
+		{
+			using (var zip = ZipArchive.Create (stream)) {
+				zip.AddEntry ("foo.txt", "foo", encoding);
+			}
+
+			bool changes = ExtractAll (stream);
+			Assert.IsTrue (changes, "ExtractAll should report changes.");
+
+			stream.SetLength (0);
+			using (var zip = ZipArchive.Create (stream)) {
+				zip.AddEntry ("foo.txt", "bar", encoding);
+			}
+
+			changes = ExtractAll (stream);
+
+			Assert.IsTrue (changes, "ExtractAll should report changes.");
+			AssertFile ("foo.txt", "bar");
+		}
+
+		[Test]
+		public void ExtractAll_FileDeleted ()
+		{
+			using (var zip = ZipArchive.Create (stream)) {
+				zip.AddEntry ("a.txt", "a", encoding);
+				zip.AddEntry ("b/b.txt", "b", encoding);
+			}
+
+			bool changes = ExtractAll (stream);
+			Assert.IsTrue (changes, "ExtractAll should report changes.");
+
+			stream.SetLength (0);
+			using (var zip = ZipArchive.Open (stream)) {
+				zip.AddEntry ("a.txt", "a", encoding);
+			}
+
+			changes = ExtractAll (stream);
+
+			Assert.IsTrue (changes, "ExtractAll should report changes.");
+			AssertFile ("a.txt", "a");
+			FileAssert.DoesNotExist (Path.Combine (tempDir, "b", "b.txt"));
+		}
+
+		[Test]
+		public void ExtractAll_ModifyCallback ()
+		{
+			using (var zip = ZipArchive.Create (stream)) {
+				zip.AddEntry ("foo/a.txt", "a", encoding);
+				zip.AddEntry ("foo/b/b.txt", "b", encoding);
+			}
+
+			stream.Position = 0;
+			using (var zip = ZipArchive.Open (stream)) {
+				bool changes = Files.ExtractAll (zip, tempDir, modifyCallback: e => e.Replace ("foo/", ""));
+				Assert.IsTrue (changes, "ExtractAll should report changes.");
+			}
+
+			AssertFile ("a.txt", "a");
+			AssertFile (Path.Combine ("b", "b.txt"), "b");
+		}
+
+		[Test]
+		public void ExtractAll_MacOSFiles ()
+		{
+			using (var zip = ZipArchive.Create (stream)) {
+				zip.AddEntry ("a/.DS_Store", "a", encoding);
+				zip.AddEntry ("b/__MACOSX/b.txt", "b", encoding);
+				zip.AddEntry ("c/__MACOSX", "c", encoding);
+			}
+
+			bool changes = ExtractAll (stream);
+			Assert.IsFalse (changes, "ExtractAll should *not* report changes.");
+			DirectoryAssert.DoesNotExist (tempDir);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
@@ -19,10 +19,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)PackagingTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\BaseTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\BuildHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\FilesTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\MockBuildEngine.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\MonoAndroidHelperTests.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="$(MSBuildThisFileDirectory)Utilities\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes: http://work.devdiv.io/760829

I've recently discovered a scenario that requires a `Rebuild` to fix...

1. File -> New Xamarin.Forms Project in IDE
2. Do *not* build! Note that the IDE will do a build for Intellisense:
   design-time build in VS Windows and `UpdateAndroidResources` in VS
   Mac
3. Update NuGet packages (they are `<PackageReference/>`)
4. Build

You will likely hit `APT0000` errors and/or Java compilation errors:

    /Users/builder/Library/Developer/Xamarin/jdk/microsoft_dist_openjdk_1.8.0.10/bin/javac -J-Dfile.encoding=UTF8 -d obj/Release/android/bin/classes -classpath /Library/Frameworks/Mono.framework/External/xbuild-frameworks/MonoAndroid/v8.1/mono.android.jar:obj/Release/lp/0/jl/formsviewgroup.jar:obj/Release/lp/10/jl/bin/classes.jar:obj/Release/lp/11/jl/bin/classes.jar:obj/Release/lp/12/jl/bin/classes.jar:obj/Release/lp/13/jl/bin/classes.jar:obj/Release/lp/14/jl/bin/classes.jar:obj/Release/lp/15/jl/bin/classes.jar:obj/Release/lp/16/jl/bin/classes.jar:obj/Release/lp/17/jl/bin/classes.jar:obj/Release/lp/18/jl/bin/classes.jar:obj/Release/lp/2/jl/arch-core-common.jar:obj/Release/lp/20/jl/bin/classes.jar:obj/Release/lp/3/jl/arch-lifecycle-common.jar:obj/Release/lp/4/jl/bin/classes.jar:obj/Release/lp/5/jl/bin/classes.jar:obj/Release/lp/7/jl/bin/classes.jar:obj/Release/lp/8/jl/bin/classes.jar:obj/Release/lp/9/jl/bin/classes.jar:obj/Release/lp/6/jl/support-annotations.jar -bootclasspath /Users/builder/Library/Android/sdk/platforms/android-27/android.jar -encoding UTF-8 "@/var/folders/th/stt5g8t53jzfbz8ryh5_xrsr0000gn/T/tmp7ceebc47.tmp"
        obj/Release/android/src/mono/android/support/v7/widget/RecyclerView_ItemAnimator_ItemAnimatorFinishedListenerImplementor.java:8: error: package android.support.v7.widget.RecyclerView.ItemAnimator does not exist
                android.support.v7.widget.RecyclerView.ItemAnimator.ItemAnimatorFinishedListener

You have to `Rebuild` or #deletebinobj to solve the problem.

After digging in, I started to see problems with
`<ResolveLibraryProjectImports/>` that have just been here a while.

## Files.ExtractAll and timestamps ##

We had a `forceUpdate` flag, which is set to `false` in
`<ResolveLibraryProjectImports/>`:

    if (forceUpdate || entry.ModificationTime > dt) {
        try {
            entry.Extract (destination, fullName, FileMode.Create);
            MonoAndroidHelper.SetWriteable (outfile);
            var utcNow = DateTime.UtcNow;
            File.SetLastWriteTimeUtc (outfile, utcNow);
            File.SetLastAccessTimeUtc (outfile, utcNow);

So assuming the zip file being extracted changes, there are some
problems with what we are doing here:

* By setting `UtcNow` as the timestamp. No file would ever get
  updated... * We made this change in: c1c71d9
* We can't rely on `entry.ModificationTime`, the timestamp in a zip
  file is not reliable at all... It could be `DateTime.MinValue`,
  non-Utc, etc. We can't rely on it...

Basically I can't see how this `forceUpdate=false` setting could be
correct... So I have taken the approach to just remove it.

## ResolveLibraryProjectImports and timestamps ##

In addition to the timestamp logic in `Files.ExtractAll`, we had
similar timestamp logic on assemblies:

    var stamp = new FileInfo (Path.Combine (outdir.FullName, assemblyIdentName + ".stamp"));
    if (stamp.Exists && stamp.LastWriteTimeUtc > new FileInfo (assemblyPath).LastWriteTimeUtc) {
        // ...
        continue;

The problem here, is I don't think we can rely on the timestamps of
these assemblies either!

* `<PackagReference/>` now puts a central NuGet cache in
  `%userprofile%\.nuget`. You could have Xamarin.Forms (or other)
  NuGets cached with very old timestamps.
* Upgrading/downgrading NuGet packages of a cached NuGet could replace
  an assembly with an older timestamp than the stamp file, but we
  wouldn't extract any files!

So the fix I'm thinking here is to use hashes of these files instead
of timestamps. Any file extracted in `<ResolveLibraryProjectImports/>`
will get "re-extracted" if the hash of the file changes. We use the
same stamp files, but store hashes inside them.

## Files.ExtractAll and deleteCallback ##

After these initial set of changes, the original scenario was still
not working... `<ResolveLibraryProjectImports/>` seemed to be leaving
behind old files when NuGet packages were changed.

On incremental builds, I could get things to work properly if I added
a call to:

    Directory.Delete (importsDir, recursive: true);

This basically nuked the `lp` directory on builds where the assembly
changed.

After more digging, it seemed the semantics of `deleteCallback` were
reversed?

    if (!files.Contains (outfile) && !(deleteCallback?.Invoke (outfile) ?? true)) {
        File.Delete (outfile);

An example of `deleteCallback` from `<ResolveLibraryProjectImports/>`:

    deleteCallback: (fileToDelete) => {
        return !files.Contains (fileToDelete);
    }

This seems backwards?

Reviewing the changes in 3f3c45c (Aug 2017), we were deleting the
files here no matter what before `deleteCallback` was added.

I *think* the correct behavior here is to remove the `!`:

    if (!files.Contains (outfile) && (deleteCallback?.Invoke (outfile) ?? true)) {
        File.Delete (outfile);

Now I am seeing `<ResolveLibraryProjectImports/>` delete files. We
don't need a `Directory.Delete ()` call.

The only other place `Files.ExtractAll` is used is in the
`<GetAdditionalResourcesFromAssemblies/>` MSBuild task. Since it does
not pass a callback, I believe the new behavior is correct.

## List of jar files ##

Before we were doing a recursive search for `*.jar` files:

    outdir.EnumerateFiles ("*.jar", SearchOption.AllDirectories)

Since this could traverse a lot of directores, let's add jar files to
the list as we go. It turns out this change is also *necessary*, since
we have fixed `Files.ExtractAll` so it properly deletes files. Without
this change, jar files were getting deleted.

## Tests ##

The `CompileBeforeUpgradingNuGet` test reproduces the original
scenario.

I added a set of tests for `Files.ExtractAll` as well, which helped me
discover most of the bugs there.

One test fix:

`Xamarin.Android.Support.v4.dll` was not even *in use* when updating
Xamarin.Forms. We should be checking
`Xamarin.Android.Support.v7.AppCompat.dll` instead.

## Performance Implications ##

These changes don't seem to have a negative impace on performance:

    Before:
    1st ->      1346 ms  ResolveLibraryProjectImports
    C# change -> 346 ms  ResolveLibraryProjectImports
    After:
    1st ->      1213 ms  ResolveLibraryProjectImports
    C# change -> 366 ms  ResolveLibraryProjectImports

The initial build may be slightly faster. Incremental builds seems to
vary, but roughly be the same.

## Future Work ##

In dd36614, I added a `_CleanIntermediateIfNuGetsChange` target to
combat #deletebinobj problems such as this. I believe the fixes here
will make this target completely unnecessary.

Removing `_CleanIntermediateIfNuGetsChange` will improve build
performance when changing NuGet packages, since right now:

* A new NuGet package will trigger `_CleanIntermediateIfNuGetsChange`
* A "light clean" of `obj` occurs
* Basically everything rebuilds