### PR TITLE
[Xamarin.Android.Build.Tests] use mono DotNet SDK install

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -496,7 +496,7 @@ namespace App1
 			var path = Path.Combine ("temp", TestContext.CurrentContext.Test.Name);
 			using (var builder = CreateDllBuilder (Path.Combine (path, netStandardProject.ProjectName), cleanupOnDispose: false)) {
 				if (!Directory.Exists (builder.MicrosoftNetSdkDirectory))
-					Assert.Ignore ("Microsoft.NET.Sdk not found.");
+					Assert.Fail ("Microsoft.NET.Sdk not found.");
 				using (var ab = CreateApkBuilder (Path.Combine (path, app.ProjectName), cleanupOnDispose: false)) {
 					builder.RequiresMSBuild =
 						ab.RequiresMSBuild = true;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/FrameworkPath.targets
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/FrameworkPath.targets
@@ -1,0 +1,5 @@
+﻿<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="Default">
+    <Message Text="$(FrameworkSDKRoot)" Importance="High" />
+  </Target>
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -143,6 +143,9 @@
     <Content Include="..\..\..\..\.nuget\NuGet.exe">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="FrameworkPath.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\external\LibZipSharp\libZipSharp.csproj">

--- a/tools/xabuild/XABuildPaths.cs
+++ b/tools/xabuild/XABuildPaths.cs
@@ -224,15 +224,24 @@ namespace Xamarin.Android.Build
 			}
 		}
 
-		string FindLatestDotNetSdk(string dotNetPath)
+		string FindLatestDotNetSdk (string dotNetPath)
 		{
-			if (Directory.Exists(dotNetPath)) {
-				var directories = from dir in Directory.EnumerateDirectories (dotNetPath)
-				                  let version = GetVersionFromDirectory (dir)
-				                  where version != null
-				                  orderby version descending
-				                  select Path.Combine (dir, "Sdks");
-				return directories.FirstOrDefault ();
+			if (Directory.Exists (dotNetPath)) {
+				Version latest = new Version (0,0);
+				string Sdk = null;
+				foreach (var dir in Directory.EnumerateDirectories (dotNetPath)) {
+					var version = GetVersionFromDirectory (dir);
+					var sdksDir = Path.Combine (dir, "Sdks");
+					if (!Directory.Exists (sdksDir))
+						sdksDir = Path.Combine (dir, "bin", "Sdks");
+					if (version != null && version > latest) {
+						if (Directory.Exists (sdksDir) && File.Exists (Path.Combine (sdksDir, "Microsoft.NET.Sdk", "Sdk", "Sdk.props"))) {
+							latest = version;
+							Sdk = sdksDir;
+						}
+					}
+				}
+				return Sdk;
 			}
 			return null;
 		}


### PR DESCRIPTION
We were using the Microsoft.NET.SDK from the
`/usr/local/share/dotnet` path for our unit
tests. However this does not seem to be installed
on our CI system. Instead we should be using the
on which is shipped with mono itself.