### PR TITLE
[monodroid] Make it possible to measure jit times

### DIFF
--- a/src/monodroid/jni/dylib-mono.cc
+++ b/src/monodroid/jni/dylib-mono.cc
@@ -143,6 +143,7 @@ bool DylibMono::init (void *libmono_handle)
 	LOAD_SYMBOL_CAST(mono_use_llvm, int*)
 	LOAD_SYMBOL_NO_PREFIX(mono_aot_register_module)
 	LOAD_SYMBOL(mono_profiler_create)
+	LOAD_SYMBOL(mono_profiler_set_jit_begin_callback)
 	LOAD_SYMBOL(mono_profiler_set_jit_done_callback)
 	LOAD_SYMBOL(mono_profiler_set_thread_started_callback)
 	LOAD_SYMBOL(mono_profiler_set_thread_stopped_callback)
@@ -681,6 +682,15 @@ DylibMono::profiler_install_thread (MonoProfilerHandle handle, MonoThreadStarted
 
 	mono_profiler_set_thread_started_callback (handle, start_ftn);
 	mono_profiler_set_thread_stopped_callback (handle, end_ftn);
+}
+
+void
+DylibMono::profiler_set_jit_begin_callback (MonoProfilerHandle handle, MonoJitBeginEventFunc begin_ftn)
+{
+	if (mono_profiler_set_jit_begin_callback == nullptr)
+		return;
+
+	mono_profiler_set_jit_begin_callback (handle, begin_ftn);
 }
 
 void

--- a/src/monodroid/jni/dylib-mono.h
+++ b/src/monodroid/jni/dylib-mono.h
@@ -162,6 +162,7 @@ inline MonoCounters& operator |= (MonoCounters& left, MonoCounters right)
 #endif
 
 typedef void (*MonoDomainFunc) (MonoDomain *domain, void* user_data);
+typedef void (*MonoJitBeginEventFunc) (MonoProfiler *prof, MonoMethod *method);
 typedef void (*MonoJitDoneEventFunc) (MonoProfiler *prof, MonoMethod *method, MonoJitInfo* jinfo);
 typedef void (*MonoThreadStartedEventFunc) (MonoProfiler *prof, uintptr_t tid);
 typedef void (*MonoThreadStoppedEventFunc) (MonoProfiler *prof, uintptr_t tid);
@@ -450,6 +451,7 @@ class DylibMono
 	typedef int                    (*monodroid_mono_runtime_set_main_args_fptr) (int argc, char* argv[]);
 	typedef void                   (*mono_aot_register_module_fptr) (void* aot_info);
 	typedef MonoProfilerHandle     (*monodroid_mono_profiler_create_fptr) (MonoProfiler* profiler);
+	typedef void                   (*monodroid_mono_profiler_set_jit_begin_callback_fptr) (MonoProfilerHandle handle, MonoJitBeginEventFunc begin_ftn);
 	typedef void                   (*monodroid_mono_profiler_set_jit_done_callback_fptr) (MonoProfilerHandle handle, MonoJitDoneEventFunc done_ftn);
 	typedef void                   (*monodroid_mono_profiler_set_thread_started_callback_fptr) (MonoProfilerHandle handle, MonoThreadStartedEventFunc start_ftn);
 	typedef void                   (*monodroid_mono_profiler_set_thread_stopped_callback_fptr) (MonoProfilerHandle handle, MonoThreadStoppedEventFunc stopped_ftn);
@@ -549,6 +551,7 @@ struct DylibMono {
 	monodroid_mono_profiler_set_jit_done_callback_fptr              mono_profiler_set_jit_done_callback;
 	monodroid_mono_profiler_set_thread_started_callback_fptr        mono_profiler_set_thread_started_callback;
 	monodroid_mono_profiler_set_thread_stopped_callback_fptr        mono_profiler_set_thread_stopped_callback;
+	monodroid_mono_profiler_set_jit_begin_callback_fptr             mono_profiler_set_jit_begin_callback;
 
 #ifdef __cplusplus
 	bool initialized;
@@ -652,6 +655,7 @@ public:
 	void* object_unbox (MonoObject *obj);
 	MonoProfilerHandle profiler_create ();
 	void profiler_install_thread (MonoProfilerHandle handle, MonoThreadStartedEventFunc start_ftn, MonoThreadStoppedEventFunc end_ftn);
+	void profiler_set_jit_begin_callback (MonoProfilerHandle handle, MonoJitBeginEventFunc begin_ftn);
 	void profiler_set_jit_done_callback (MonoProfilerHandle handle, MonoJitDoneEventFunc done_ftn);
 	void property_set_value (MonoProperty *prop, void *obj, void **params, MonoObject **exc);
 	void register_bundled_assemblies (const MonoBundledAssembly **assemblies);


### PR DESCRIPTION
Get more information with `debug.mono.log` property set to `timing`.

It hooks up to the profiler's `jit_begin` and `jit_done` events and
prints the method JIT begin and done times to `methods.txt`

Example output:

    JIT method begin: Android.Runtime.JNIEnv:Initialize (Android.Runtime.JnienvInitializeArgs*) elapsed: 0s:97::383916
    JIT method begin: Android.Runtime.JNIEnv:.cctor () elapsed: 0s:99::500999
    JIT method  done: Android.Runtime.JNIEnv:.cctor () elapsed: 0s:99::626468
    JIT method begin: (wrapper runtime-invoke) object:runtime_invoke_void (object,intptr,intptr,intptr) elapsed: 0s:99::695999
    JIT method  done: (wrapper runtime-invoke) object:runtime_invoke_void (object,intptr,intptr,intptr) elapsed: 0s:99::913551
    JIT method begin: Android.Runtime.JNIEnv/<>c:.cctor () elapsed: 0s:100::263916
    JIT method  done: Android.Runtime.JNIEnv/<>c:.cctor () elapsed: 0s:100::326989
    JIT method begin: Android.Runtime.JNIEnv/<>c:.ctor () elapsed: 0s:100::341312
    JIT method  done: Android.Runtime.JNIEnv/<>c:.ctor () elapsed: 0s:100::388082
    JIT method  done: Android.Runtime.JNIEnv:Initialize (Android.Runtime.JnienvInitializeArgs*) elapsed: 0s:102::238083