### PR TITLE
[Xamarin.Android.Build.Tasks] Provide file.encoding for dx tool

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -144,9 +144,16 @@ namespace Xamarin.Android.Tasks {
 				// double clicks the error, it won't take them to the obj/Debug copy
 				if (ResourceDirectories != null) {
 					foreach (var dir in ResourceDirectories) {
-						var resourceDirectoryFullPath = ResourceDirectoryFullPath (dir.ItemSpec);
+						var resourceDirectory = dir.ItemSpec;
+						var resourceDirectoryFullPath = ResourceDirectoryFullPath (resourceDirectory);
+						string newfile = null;
+						if (file.StartsWith (resourceDirectory, StringComparison.InvariantCultureIgnoreCase)) {
+							newfile = file.Substring (resourceDirectory.Length).TrimStart (Path.DirectorySeparatorChar);
+						}
 						if (file.StartsWith (resourceDirectoryFullPath, StringComparison.InvariantCultureIgnoreCase)) {
-							var newfile = file.Substring (resourceDirectoryFullPath.Length).TrimStart (Path.DirectorySeparatorChar);
+							newfile = file.Substring (resourceDirectoryFullPath.Length).TrimStart (Path.DirectorySeparatorChar);
+						}
+						if (!string.IsNullOrEmpty (newfile)) {
 							newfile = resource_name_case_map.ContainsKey (newfile) ? resource_name_case_map [newfile] : newfile;
 							newfile = Path.Combine ("Resources", newfile);
 							file = newfile;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Android.Tasks {
 
 		protected string ResourceDirectoryFullPath (string resourceDirectory)
 		{
-			return (Path.IsPathRooted (resourceDirectory) ? resourceDirectory : Path.Combine (WorkingDirectory, resourceDirectory)).TrimEnd ('\\');
+			return resourceDirectory.TrimEnd ('\\');
 		}
 
 		protected string GenerateFullPathToTool ()

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Android.Tasks {
 
 		protected string ResourceDirectoryFullPath (string resourceDirectory)
 		{
-			return resourceDirectory.TrimEnd ('\\');
+			return (Path.IsPathRooted (resourceDirectory) ? resourceDirectory : Path.Combine (WorkingDirectory, resourceDirectory)).TrimEnd ('\\');
 		}
 
 		protected string GenerateFullPathToTool ()

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
@@ -94,7 +94,7 @@ namespace Xamarin.Android.Tasks {
 			cmd.AppendSwitchIfNotNull ("-o ", outputArchive);
 			if (!string.IsNullOrEmpty (ResourceSymbolsTextFile))
 				cmd.AppendSwitchIfNotNull ("--output-text-symbols ", ResourceSymbolsTextFile);
-			cmd.AppendSwitchIfNotNull ("--dir ", dir.ItemSpec.TrimEnd ("\\"));
+			cmd.AppendSwitchIfNotNull ("--dir ", dir.ItemSpec.TrimEnd ('\\'));
 			if (ExplicitCrunch)
 				cmd.AppendSwitch ("--no-crunch");
 			if (!string.IsNullOrEmpty (ExtraArgs))

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
@@ -94,7 +94,7 @@ namespace Xamarin.Android.Tasks {
 			cmd.AppendSwitchIfNotNull ("-o ", outputArchive);
 			if (!string.IsNullOrEmpty (ResourceSymbolsTextFile))
 				cmd.AppendSwitchIfNotNull ("--output-text-symbols ", ResourceSymbolsTextFile);
-			cmd.AppendSwitchIfNotNull ("--dir ", ResourceDirectoryFullPath (dir.ItemSpec));
+			cmd.AppendSwitchIfNotNull ("--dir ", dir.ItemSpec.TrimEnd ("\\"));
 			if (ExplicitCrunch)
 				cmd.AppendSwitch ("--no-crunch");
 			if (!string.IsNullOrEmpty (ExtraArgs))

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidUpdateResDir.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidUpdateResDir.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Text;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
 using System.IO;
@@ -96,8 +97,8 @@ namespace Xamarin.Android.Tasks
 					if (string.IsNullOrEmpty (rel)) {
 						rel = item.GetMetadata ("Identity");
 						if (!string.IsNullOrEmpty (ProjectDir)) {
-							var fullRelPath = Path.GetFullPath (rel);
-							var fullProjectPath = Path.GetFullPath (ProjectDir);
+							var fullRelPath = Path.GetFullPath (rel).Normalize (NormalizationForm.FormC);
+							var fullProjectPath = Path.GetFullPath (ProjectDir).Normalize (NormalizationForm.FormC);
 							if (fullRelPath.StartsWith (fullProjectPath)) {
 								rel = fullRelPath.Replace (fullProjectPath, string.Empty);
 							}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileToDalvik.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileToDalvik.cs
@@ -82,11 +82,18 @@ namespace Xamarin.Android.Tasks
 					cmd.AppendSwitch (JavaOptions);		
 				}
 
+				cmd.AppendSwitchIfNotNull ("-Dfile.encoding=", "UTF8");
 				// Add the specific -XmxN to override the default heap size for the JVM
 				// N can be in the form of Nm or NGB (e.g 100m or 1GB ) 
 				cmd.AppendSwitchIfNotNull("-Xmx", JavaMaximumHeapSize);
 
 				cmd.AppendSwitchIfNotNull ("-jar ", Path.Combine (DxJarPath));
+			} else {
+				// To pass additional java parameters to `dx` you must 
+				// provide the parameter without the leading `-` 
+				// the dx tool will add that in after stripping off
+				// the `-J`
+				cmd.AppendSwitchIfNotNull ("-JDfile.encoding=", "UTF8");
 			}
 
 			cmd.AppendSwitch (DxExtraArguments);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2374,7 +2374,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 </Project>
 ",
 			});
-			using (var b = CreateApkBuilder (Path.Combine ("temp", $"BuildReleaseAppWithA InIt({enableMultiDex}{dexTool}{linkTool})"))) {
+			using (var b = CreateApkBuilder (Path.Combine ("temp", $"BuildReleaseAppWithA InItAndÜmläüts({enableMultiDex}{dexTool}{linkTool})"))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				Assert.IsFalse (b.LastBuildOutput.ContainsText ("Duplicate zip entry"), "Should not get warning about [META-INF/MANIFEST.MF]");
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManagedResourceParserTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManagedResourceParserTests.cs
@@ -74,9 +74,9 @@ namespace Xamarin.Android.Build.Tests {
 ";
 
 		[Test]
-		public void GenerateDesignerFile ()
+		public void GenerateDesignerFileWithÜmläüts ()
 		{
-			var path = Path.Combine ("temp", TestName);
+			var path = Path.Combine ("temp", TestName + " Some Space");
 			Directory.CreateDirectory (Path.Combine (Root, path, "res", "values"));
 			Directory.CreateDirectory (Path.Combine (Root, path, "res", "transition"));
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -347,37 +347,40 @@ namespace Xamarin.ProjectTools
 			var start = DateTime.UtcNow;
 			var args  = new StringBuilder ();
 			var psi   = new ProcessStartInfo (XABuildExe);
+			var responseFile = Path.Combine (XABuildPaths.TestOutputDirectory, Path.GetDirectoryName (projectOrSolution), "msbuild.rsp");
 			args.AppendFormat ("{0} /t:{1} {2}",
-				QuoteFileName(Path.Combine (XABuildPaths.TestOutputDirectory, projectOrSolution)), target, logger);
+					QuoteFileName (Path.Combine (XABuildPaths.TestOutputDirectory, projectOrSolution)), target, logger);
 			if (AutomaticNuGetRestore && restore) {
 				args.Append (" /restore");
 			}
-			args.Append ($" /p:BuildingInsideVisualStudio={BuildingInsideVisualStudio}");
-			if (BuildingInsideVisualStudio && RunningMSBuild) {
-				args.Append (" /p:BuildingOutOfProcess=true");
-			}
-			if (!string.IsNullOrEmpty (AndroidSdkDirectory)) {
-				args.AppendFormat (" /p:AndroidSdkDirectory=\"{0}\" ", AndroidSdkDirectory);
-			}
-			if (!string.IsNullOrEmpty (AndroidNdkDirectory)) {
-				args.AppendFormat (" /p:AndroidNdkDirectory=\"{0}\" ", AndroidNdkDirectory);
-			}
-			if (parameters != null) {
-				foreach (var param in parameters) {
-					args.AppendFormat (" /p:{0}", param);
+			using (var sw = new StreamWriter (responseFile, append: false, encoding: Encoding.UTF8)) {
+				sw.WriteLine ($" /p:BuildingInsideVisualStudio={BuildingInsideVisualStudio}");
+				if (BuildingInsideVisualStudio && RunningMSBuild) {
+					sw.WriteLine (" /p:BuildingOutOfProcess=true");
 				}
-			}
-			var msbuildArgs = Environment.GetEnvironmentVariable ("NUNIT_MSBUILD_ARGS");
-			if (!string.IsNullOrEmpty (msbuildArgs)) {
-				args.Append (msbuildArgs);
-			}
-			if (RunningMSBuild) {
-				psi.EnvironmentVariables ["MSBUILD"] = "msbuild";
-				args.Append ($" /bl:\"{Path.GetFullPath (Path.Combine (XABuildPaths.TestOutputDirectory, Path.GetDirectoryName (projectOrSolution), "msbuild.binlog"))}\"");
-			}
-			if (environmentVariables != null) {
-				foreach (var kvp in environmentVariables) {
-					psi.EnvironmentVariables [kvp.Key] = kvp.Value;
+				if (!string.IsNullOrEmpty (AndroidSdkDirectory)) {
+					sw.WriteLine (" /p:AndroidSdkDirectory=\"{0}\" ", AndroidSdkDirectory);
+				}
+				if (!string.IsNullOrEmpty (AndroidNdkDirectory)) {
+					sw.WriteLine (" /p:AndroidNdkDirectory=\"{0}\" ", AndroidNdkDirectory);
+				}
+				if (parameters != null) {
+					foreach (var param in parameters) {
+						sw.WriteLine (" /p:{0}", param);
+					}
+				}
+				var msbuildArgs = Environment.GetEnvironmentVariable ("NUNIT_MSBUILD_ARGS");
+				if (!string.IsNullOrEmpty (msbuildArgs)) {
+					sw.WriteLine (msbuildArgs);
+				}
+				if (RunningMSBuild) {
+					psi.EnvironmentVariables ["MSBUILD"] = "msbuild";
+					sw.WriteLine ($" /bl:\"{Path.GetFullPath (Path.Combine (XABuildPaths.TestOutputDirectory, Path.GetDirectoryName (projectOrSolution), "msbuild.binlog"))}\"");
+				}
+				if (environmentVariables != null) {
+					foreach (var kvp in environmentVariables) {
+						psi.EnvironmentVariables [kvp.Key] = kvp.Value;
+					}
 				}
 			}
 


### PR DESCRIPTION
Fixes: http://work.devdiv.io/784551
Fixes: https://developercommunity.visualstudio.com/content/problem/437807/v-isual-studio-2019-preview-20.html
Fixes: #2685

Context: #2688 (comment)
Context: #2688 (comment)

In commit 8571a7f we updated the `<CompileToDalvik/>` task to
generate and use a "response file" via the `--input-list` argument.
This helped reduce the overall length of the command line arguments
passed.  It had a side effect of causing a problem if the path
contains non-ASCII characters, causing the following error on Windows:

	java.io.FileNotFoundException: C:\Temp\Scratch.├£ml├ñ├╝ts\Scratch.├£ml├ñ├╝ts\obj\Debug\90\android\bin\classes.zip (The system cannot find the path specified)

This is because while the `input-list` file itself is fine, the paths
within it might contain non-ASCII characters.  We need to let java
know that, which we can do that via the `java` argument:

	-Dfile.encoding=UTF8

The `<CompileToDalvik/>` task can be run in two modes, the first is
just invoking the `dx` executable, and the second is invoking
`dx.jar` via `java`.  Both of these need to be supported.

For the normal `java` invocation we can just pass the argument with
`-Dfile.encoding=UTF8`.  However for `dx` that is not a valid
argument.  We instead need to provide it via:

	-JDfile.encoding=UTF8

The `-J` tells `dx` that this is a `java` argument.  `dx` will then
take everything after the `-J` , prepend a `-` and pass that to
`java`.

Finally, there was a [problem of Unicode Normalization Forms][0]
and `string.Replace()`.  On macOS, it is possible within the
`<AndroidComputeResPaths/>` task for `$(ProjectDir)` to use a
different filesystem normalization than `@(AndroidAsset)`, because
`@(AndroidAsset)` comes from a directory traversal and will use
Unicode Normalization Form D [(-ish)][1] on HFS+, while
`$(ProjectDir)` will come from the `msbuild` command-line invocation
performed by the unit tests and will be in Unicode Normalization
Form C, and through "luck" `string.Replace()` doesn't handle this:

	var e_acute = "\u00e9";          // http://www.fileformat.info/info/unicode/char/e9/index.htm
	var e_formc = e_acute.Normalize (System.Text.NormalizationForm.FormC);
	var e_formd = e_acute.Normalize (System.Text.NormalizationForm.FormD);
	e_formc.StartsWith (e_formd);    // true
	e_formc.Replace (e_formd, "");   // == "é" == e_formc; no replacement performed!

`<AndroidComputeResPaths>` uses `string.Replace()` to convert a "full"
path name into a "relative" path name, but as the `string.Replace()`
didn't do anything here with the mismatched Unicode Normalization,
`<AndroidComputeResPaths/>` would return *lowercased full paths* to
subsequent tasks, not the expected lowercased *relative* paths, which
ultimately results in a `Resource.designer.cs` which is *empty*:

	Task "AndroidComputeResPaths" (TaskId:62)
	    ...
	    IntermediateFiles: (TaskId:62)
	      /users/builder/jenkins/workspace/xamarin-android-pr-builder-release/xamarin-android/bin/testrelease/temp/buildreleaseappwitha initandümläüts(truedx)/resources/drawable-hdpi/icon.png (TaskId:62)
	      ... wat?! ...
	...
	MainActivity.cs(22,20,22,28): error CS0103: The name 'Resource' does not exist in the current context

Fix this problem by normalizing the strings into the same Unicode
Normalization Form *before* performing the `string.Replace()` call,
which works as expected/intended, restoring the semantics of
`<AndroidComputeResPaths>`.

Update one of the unit tests has been to use non-ASCII characters.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-pr-builder-release/623/testReport/junit/Xamarin.Android.Build.Tests.BuildTest/BuildApplicationWithSpacesInPathAndÜmläüts/_True__dx________Release/
[1]: https://en.wikipedia.org/wiki/HFS_Plus#Design