### PR TITLE
[Xamarin.Android.Build.Tasks] Provide file.encoding for dx tool

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidUpdateResDir.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidUpdateResDir.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Text;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
 using System.IO;
@@ -96,8 +97,8 @@ namespace Xamarin.Android.Tasks
 					if (string.IsNullOrEmpty (rel)) {
 						rel = item.GetMetadata ("Identity");
 						if (!string.IsNullOrEmpty (ProjectDir)) {
-							var fullRelPath = Path.GetFullPath (rel);
-							var fullProjectPath = Path.GetFullPath (ProjectDir);
+							var fullRelPath = Path.GetFullPath (rel).Normalize (NormalizationForm.FormC);
+							var fullProjectPath = Path.GetFullPath (ProjectDir).Normalize (NormalizationForm.FormC);
 							if (fullRelPath.StartsWith (fullProjectPath)) {
 								rel = fullRelPath.Replace (fullProjectPath, string.Empty);
 							}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileToDalvik.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileToDalvik.cs
@@ -82,11 +82,18 @@ namespace Xamarin.Android.Tasks
 					cmd.AppendSwitch (JavaOptions);		
 				}
 
+				cmd.AppendSwitchIfNotNull ("-Dfile.encoding=", "UTF8");
 				// Add the specific -XmxN to override the default heap size for the JVM
 				// N can be in the form of Nm or NGB (e.g 100m or 1GB ) 
 				cmd.AppendSwitchIfNotNull("-Xmx", JavaMaximumHeapSize);
 
 				cmd.AppendSwitchIfNotNull ("-jar ", Path.Combine (DxJarPath));
+			} else {
+				// To pass additional java parameters to `dx` you must 
+				// provide the parameter without the leading `-` 
+				// the dx tool will add that in after stripping off
+				// the `-J`
+				cmd.AppendSwitchIfNotNull ("-JDfile.encoding=", "UTF8");
 			}
 
 			cmd.AppendSwitch (DxExtraArguments);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2332,7 +2332,7 @@ public class Test
 		}
 
 		[Test]
-		public void BuildApplicationWithSpacesInPath ([Values (true, false)] bool enableMultiDex, [Values ("dx", "d8")] string dexTool, [Values ("", "proguard", "r8")] string linkTool)
+		public void BuildApplicationWithSpacesInPathAndÜmläüts ([Values (true, false)] bool enableMultiDex, [Values ("dx", "d8")] string dexTool, [Values ("", "proguard", "r8")] string linkTool)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
@@ -2368,7 +2368,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 </Project>
 ",
 			});
-			using (var b = CreateApkBuilder (Path.Combine ("temp", $"BuildReleaseAppWithA InIt({enableMultiDex}{dexTool}{linkTool})"))) {
+			using (var b = CreateApkBuilder (Path.Combine ("temp", $"BuildReleaseAppWithA InItAndÜmläüts({enableMultiDex}{dexTool}{linkTool})"))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				Assert.IsFalse (b.LastBuildOutput.ContainsText ("Duplicate zip entry"), "Should not get warning about [META-INF/MANIFEST.MF]");
 


### PR DESCRIPTION
Fixes #2685

In commit 8571a7f we switched the `CompileToDalvik` task over
to use the `--input-list` argument. This helped reduce the
overall length of the command line arguments passed. It
had a side effect of causing a problem if the path
contained non-ASCII characters. We end up with the
following error

	java.io.FileNotFoundException: C:\Temp\Scratch.├£ml├ñ├╝ts\Scratch.├£ml├ñ├╝ts\obj\Debug\90\android\bin\classes.zip (The system cannot find the path specified)

This is because while the `input-list` file is fine,
the paths within it might contain non-ASCII characters.
So we need to let java know that, we can do that via the

	file.encoding=UTF8

argument. `CompileToDalvik` can be run in two modes, the first
is just invoking the `dx` executable. The second is invoking
the `dx.jar` via `java`. Both of these need to be supported.

For the normal `java` invocation we can just pass the argument
as normal via `-Dfile.encoding=UTF8`. However for `dx` that is
not a valid argument. We instead need to provide it via

	-JDfile.encoding=UTF8

The `-J` tells `dx` that this is a `java` argument. `dx` will then
take everything after the `-J` , prepend a `-` and pass that to
`java`.

One of the unit tests has been updated to include non-ASCII
characters.