### PR TITLE
[monodroid] Fix runtime crash when using fastdev typemaps

### DIFF
--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -47,6 +47,7 @@ const char *EmbeddedAssemblies::suffixes[] = {
 };
 
 constexpr char EmbeddedAssemblies::assemblies_prefix[];
+constexpr char EmbeddedAssemblies::override_typemap_entry_name[];
 
 
 void EmbeddedAssemblies::set_assemblies_prefix (const char *prefix)
@@ -500,10 +501,10 @@ EmbeddedAssemblies::try_load_typemaps_from_directory (const char *path)
 			int len = androidSystem.monodroid_read_file_into_memory (file_path, &val);
 			if (len > 0 && val != nullptr) {
 				if (utils.monodroid_dirent_hasextension (e, ".mj")) {
-					if (!add_type_mapping (&managed_to_java_maps, file_path, nullptr, ((const char*)val)))
+					if (!add_type_mapping (&managed_to_java_maps, file_path, override_typemap_entry_name, ((const char*)val)))
 						delete[] val;
 				} else if (utils.monodroid_dirent_hasextension (e, ".jm")) {
-					if (!add_type_mapping (&java_to_managed_maps, file_path, nullptr, ((const char*)val)))
+					if (!add_type_mapping (&java_to_managed_maps, file_path, override_typemap_entry_name, ((const char*)val)))
 						delete[] val;
 				}
 			}

--- a/src/monodroid/jni/embedded-assemblies.h
+++ b/src/monodroid/jni/embedded-assemblies.h
@@ -15,6 +15,7 @@ namespace xamarin { namespace android { namespace internal {
 	{
 	private:
 		static constexpr char assemblies_prefix[] = "assemblies/";
+		static constexpr char override_typemap_entry_name[] = ".__override__";
 		static const char *suffixes[];
 
 	public:


### PR DESCRIPTION
When using fastdev typemaps we get the following error

```
01-31 10:57:34.336  5802  5802 F libc    : Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0 in tid 5802 (haredandroidios), pid 5802 (haredandroidios)
01-31 10:57:34.358  5829  5829 I crash_dump32: obtaining output fd from tombstoned, type: kDebuggerdTombstone
01-31 10:57:34.358  1685  1685 I /system/bin/tombstoned: received crash request for pid 5802
01-31 10:57:34.359  5829  5829 I crash_dump32: performing dump of process 5802 (target tid = 5802)
01-31 10:57:34.363  5829  5829 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
01-31 10:57:34.363  5829  5829 F DEBUG   : Build fingerprint: 'Android/sdk_phone_x86/generic_x86:9/PSR1.180720.012/4923214:userdebug/test-keys'
01-31 10:57:34.363  5829  5829 F DEBUG   : Revision: '0'
01-31 10:57:34.363  5829  5829 F DEBUG   : ABI: 'x86'
01-31 10:57:34.363  5829  5829 F DEBUG   : pid: 5802, tid: 5802, name: haredandroidios  >>> com.xamarin.blankformssharedandroidios <<<
01-31 10:57:34.363  5829  5829 F DEBUG   : signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0
01-31 10:57:34.363  5829  5829 F DEBUG   : Cause: null pointer dereference
01-31 10:57:34.363  5829  5829 F DEBUG   :     eax 00000000  ebx e6b2e754  ecx 00000000  edx 00000000
01-31 10:57:34.363  5829  5829 F DEBUG   :     edi e0cc58f0  esi 00000000
01-31 10:57:34.363  5829  5829 F DEBUG   :     ebp ffd85ff8  esp ffd85fcc  eip e6a60532
01-31 10:57:34.459  5829  5829 F DEBUG   :
01-31 10:57:34.459  5829  5829 F DEBUG   : backtrace:
01-31 10:57:34.459  5829  5829 F DEBUG   :     #00 pc 0001e532  /system/lib/libc.so (strlen+18)
01-31 10:57:34.459  5829  5829 F DEBUG   :     #01 pc 00075952  /system/lib/libc.so (strdup+34)
01-31 10:57:34.459  5829  5829 F DEBUG   :     #02 pc 0000f6ab  /data/app/com.xamarin.blankformssharedandroidios-nCq7hL5Bz-TYILJl3W97zw==/lib/x86/libmonodroid.so (xamarin::android::internal::EmbeddedAssemblies::add_type_mapping(xamarin::android::internal::TypeMappingInfo**, char const*, char const*, char const*)+667)
01-31 10:57:34.459  5829  5829 F DEBUG   :     #03 pc 00010ed7  /data/app/com.xamarin.blankformssharedandroidios-nCq7hL5Bz-TYILJl3W97zw==/lib/x86/libmonodroid.so (xamarin::android::internal::EmbeddedAssemblies::try_load_typemaps_from_directory(char const*)+871)
01-31 10:57:34.459  5829  5829 F DEBUG   :     #04 pc 000233b8  /data/app/com.xamarin.blankformssharedandroidios-nCq7hL5Bz-TYILJl3W97zw==/lib/x86/libmonodroid.so (gather_bundled_assemblies(_JNIEnv*, xamarin::android::jstring_array_wrapper&, bool, int*)+248)
01-31 10:57:34.459  5829  5829 F DEBUG   :     #05 pc 000229c6  /data/app/com.xamarin.blankformssharedandroidios-nCq7hL5Bz-TYILJl3W97zw==/lib/x86/libmonodroid.so (create_domain(_JNIEnv*, _jclass*, xamarin::android::jstring_array_wrapper&, _jstring*, _jobject*, bool)+166)
01-31 10:57:34.459  5829  5829 F DEBUG   :     #06 pc 0001f20c  /data/app/com.xamarin.blankformssharedandroidios-nCq7hL5Bz-TYILJl3W97zw==/lib/x86/libmonodroid.so (create_and_initialize_domain(_JNIEnv*, _jclass*, xamarin::android::jstring_array_wrapper&, _jobjectArray*, _jobject*, bool)+204)
01-31 10:57:34.460  5829  5829 F DEBUG   :     #07 pc 0001c7af  /data/app/com.xamarin.blankformssharedandroidios-nCq7hL5Bz-TYILJl3W97zw==/lib/x86/libmonodroid.so (Java_mono_android_Runtime_init+4255)
```

The was down to the `try_load_typemaps_from_directory` passing a
`nullptr` to the `add_type_mapping` method. This method was
calling `strdup`, which does NOT like `nullptr`.

Since the `source_entry` argument is only used for logging we
migth as well create a constant string with a value of
`.__override__` so that if there is a problem we can see
from the logs this was a fastdev issue.