### PR TITLE
[Xamarin.Android.Build.Tasks] warning if minSdkVersion < 9

### DIFF
--- a/Documentation/guides/messages/xa4216.md
+++ b/Documentation/guides/messages/xa4216.md
@@ -1,0 +1,12 @@
+# Compiler Warning XA4216
+
+This warning indicates your application is targeting an API level that
+Xamarin.Android does not support.
+
+Raise the value of `//uses-sdk/@android:minSdkVersion` or
+`//uses-sdk/@android:targetSdkVersion` in `AndroidManifest.xml` to a
+higher API level that is supported.
+
+Example message:
+
+    warning XA4216: AndroidManifest.xml //uses-sdk/@android:minSdkVersion '8' is less than API-9, this configuration is not supported.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
@@ -54,14 +54,14 @@ namespace Xamarin.Android.Tasks
 								platform = target_sdk.Value;
 
 							var min_sdk = uses_sdk.Attribute (androidNs + "minSdkVersion");
-							if (!int.TryParse (min_sdk?.Value, out int minSdkVersion) || minSdkVersion < MinSupportedSdkVersion) {
+							if (min_sdk != null && (!int.TryParse (min_sdk.Value, out int minSdkVersion) || minSdkVersion < MinSupportedSdkVersion)) {
 								LogWarningForManifest (
 										warningCode:      "XA4216",
 										attribute:        min_sdk,
 										message:          "AndroidManifest.xml //uses-sdk/@android:minSdkVersion '{0}' is less than API-{1}, this configuration is not supported.",
 										messageArgs:      new object [] { min_sdk?.Value, MinSupportedSdkVersion }
 								);
-							} else if (!int.TryParse (target_sdk?.Value, out int targetSdkVersion) || targetSdkVersion < MinSupportedSdkVersion) {
+							} else if (target_sdk != null && (!int.TryParse (target_sdk.Value, out int targetSdkVersion) || targetSdkVersion < MinSupportedSdkVersion)) {
 								LogWarningForManifest (
 										warningCode:      "XA4216",
 										attribute:        target_sdk,

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
@@ -61,7 +61,8 @@ namespace Xamarin.Android.Tasks
 										message:          "AndroidManifest.xml //uses-sdk/@android:minSdkVersion '{0}' is less than API-{1}, this configuration is not supported.",
 										messageArgs:      new object [] { min_sdk?.Value, MinSupportedSdkVersion }
 								);
-							} else if (target_sdk != null && (!int.TryParse (target_sdk.Value, out int targetSdkVersion) || targetSdkVersion < MinSupportedSdkVersion)) {
+							}
+							if (target_sdk != null && (!int.TryParse (target_sdk.Value, out int targetSdkVersion) || targetSdkVersion < MinSupportedSdkVersion)) {
 								LogWarningForManifest (
 										warningCode:      "XA4216",
 										attribute:        target_sdk,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3484,6 +3484,23 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 				Assert.IsTrue (appb.Build (proj), "build should have succeeded.");
 			}
 		}
+
+		[Test]
+		public void WarningForMinSdkVersion ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.AndroidManifest = proj.AndroidManifest.Replace ("<uses-sdk />", "<uses-sdk android:minSdkVersion=\"8\" />");
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsTrue (
+					StringAssertEx.ContainsText (
+						b.LastBuildOutput,
+						"warning XA4216: AndroidManifest.xml //uses-sdk/@android:minSdkVersion '8' is less than API-9, this configuration is not supported."
+					),
+					"Should receive a warning when //uses-sdk/@android:minSdkVersion=\"8\""
+				);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2692

Xamarin.Android does not currently support devices less than API-9.
The resulting `.apk` file will reference the
[`ApplicationInfo.nativeLibraryDir` field][1], which was added in
API-9, and thus may prevent `classes.dex` from being loaded.

A XA4216 warning is now issued, stating that this configuration
is not supported. Added a test verifying this warning.

[1]: https://developer.android.com/reference/android/content/pm/ApplicationInfo#nativeLibraryDir