### PR TITLE
[mono-2018-10] Bundle libmono-native

### DIFF
--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -184,11 +184,35 @@
       <_RuntimeSource
           Include="@(_MonoRuntime->'$(MonoSourceFullPath)\sdks\out\android-%(Identity)-$(_MonoSdksConfiguration)\lib\%(NativeLibraryPrefix)%(OutputRuntimeFilename).%(NativeLibraryExtension)')"
       />
+      <_RuntimeSource
+          Condition=" 'host-Darwin' == '%(Identity)' "
+          Include="@(_MonoRuntime->'$(MonoSourceFullPath)\sdks\out\android-%(Identity)-$(_MonoSdksConfiguration)\lib\%(NativeLibraryPrefix)libmono-native-compat.%(NativeLibraryExtension)')"
+      />
+      <_RuntimeSource
+          Condition=" 'host-Darwin' != '%(Identity)' And 'host-mxe-Win32' != '%(Identity)' And 'host-mxe-Win64' != '%(Identity)' "
+          Include="@(_MonoRuntime->'$(MonoSourceFullPath)\sdks\out\android-%(Identity)-$(_MonoSdksConfiguration)\lib\%(NativeLibraryPrefix)libmono-native.%(NativeLibraryExtension)')"
+      />
       <_InstallRuntimeOutput
           Include="@(_MonoRuntime->'$(_MSBuildDir)\lib\%(Identity)\%(OutputRuntimeFilename).%(NativeLibraryExtension)')"
       />
+      <_InstallRuntimeOutput
+          Condition=" 'host-Darwin' == '%(Identity)' "
+          Include="@(_MonoRuntime->'$(_MSBuildDir)\lib\%(Identity)\libmono-native.%(NativeLibraryExtension)')"
+      />
+       <_InstallRuntimeOutput
+          Condition=" 'host-Darwin' != '%(Identity)' And 'host-mxe-Win32' != '%(Identity)' And 'host-mxe-Win64' != '%(Identity)'"
+          Include="@(_MonoRuntime->'$(_MSBuildDir)\lib\%(Identity)\libmono-native.%(NativeLibraryExtension)')"
+      />
       <_InstallUnstrippedRuntimeOutput
           Include="@(_MonoRuntime->'$(_MSBuildDir)\lib\%(Identity)\%(OutputRuntimeFilename).d.%(NativeLibraryExtension)')"
+      />
+      <_InstallUnstrippedRuntimeOutput
+          Condition=" 'host-Darwin' == '%(Identity)' "
+          Include="@(_MonoRuntime->'$(_MSBuildDir)\lib\%(Identity)\libmono-native.d.%(NativeLibraryExtension)')"
+      />
+      <_InstallUnstrippedRuntimeOutput
+          Condition=" 'host-Darwin' != '%(Identity)' And 'host-mxe-Win32' != '%(Identity)' And 'host-mxe-Win64' != '%(Identity)'"
+          Include="@(_MonoRuntime->'$(_MSBuildDir)\lib\%(Identity)\libmono-native.d.%(NativeLibraryExtension)')"
       />
       <_RuntimeBinarySource
           Condition=" 'host-$(HostOS)' == '%(Identity)' "
@@ -392,6 +416,10 @@
     <Exec
         Condition=" '$(Configuration)' != 'Debug' Or '%(_MonoRuntime.NativeLibraryExtension)' == 'dll' "
         Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(_MSBuildDir)\lib\%(_MonoRuntime.Identity)\%(_MonoRuntime.OutputRuntimeFilename).%(_MonoRuntime.NativeLibraryExtension)&quot;"
+    />
+    <Exec
+        Condition=" ('$(Configuration)' != 'Debug' Or '%(_MonoRuntime.NativeLibraryExtension)' == 'dll') And ('host-mxe-Win32' != '%(Identity)' And 'host-mxe-Win64' != '%(Identity)') "
+        Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(_MSBuildDir)\lib\%(_MonoRuntime.Identity)\libmono-native.%(_MonoRuntime.NativeLibraryExtension)&quot;"
     />
     <Touch Files="@(_InstallRuntimeOutput);@(_InstallUnstrippedRuntimeOutput)" />
 


### PR DESCRIPTION
This is based on https://github.com/xamarin/xamarin-android/pull/2658#issuecomment-458784895, amended for some intricacies of libmono-native building.

This produced fully jumbled output such as (while in `bin/Release/lib/xamarin.android/xbuild/Xamarin/Android/lib`):

```
➜  file host-Darwin/libmono-native.dylib
host-Darwin/libmono-native.dylib: ELF 32-bit LSB pie executable Intel 80386, version 1 (SYSV), dynamically linked, interpreter /system/bin/linker, with debug_info, not stripped
➜  file armeabi-v7a/libmono-native.so
armeabi-v7a/libmono-native.so: Mach-O 64-bit dynamically linked shared library x86_64
```

while at the same time (in `external/mono/sdks/out`):
```
➜  file android-host-Darwin-release/lib/libmono-native-unified.dylib
android-host-Darwin-release/lib/libmono-native-unified.dylib: Mach-O 64-bit dynamically linked shared library x86_64
➜  out:file android-armeabi-v7a-release/lib/libmono-native.so
android-armeabi-v7a-release/lib/libmono-native.so: ELF 32-bit LSB pie executable ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /system/bin/linker, with debug_info, not stripped
```

/cc @jonp @marek-safar 