### PR TITLE
[tests] don't enable $(AndroidGenerateJniMarshalMethods) on Windows

### DIFF
--- a/src/Mono.Android/Test/Mono.Android-Tests.csproj
+++ b/src/Mono.Android/Test/Mono.Android-Tests.csproj
@@ -43,7 +43,7 @@
     <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AndroidLinkTool Condition=" '$(AndroidLinkTool)' == '' ">r8</AndroidLinkTool>
-    <AndroidGenerateJniMarshalMethods>True</AndroidGenerateJniMarshalMethods>
+    <AndroidGenerateJniMarshalMethods Condition=" '$(HostOS)' == 'Darwin' ">True</AndroidGenerateJniMarshalMethods>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
+++ b/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
@@ -42,7 +42,7 @@
     <AndroidManagedSymbols>true</AndroidManagedSymbols>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <AndroidLinkTool Condition=" '$(AndroidLinkTool)' == '' ">r8</AndroidLinkTool>
-    <AndroidGenerateJniMarshalMethods Condition=" '$(HostOS)' != 'Linux' ">True</AndroidGenerateJniMarshalMethods>
+    <AndroidGenerateJniMarshalMethods Condition=" '$(HostOS)' == 'Darwin' ">True</AndroidGenerateJniMarshalMethods>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build?definitionId=7212
Context: http://build.devdiv.io/2391004

We are in the process of switching the Windows build on Azure DevOps
to build in `Release` `$(Configuration)`. This will more closely match
what we are doing on Jenkins for other platforms.

Unfortunately we get the following build failure in `Release`:

    >.\bin\Release\bin\xabuild Xamarin.Android-Tests.sln /p:Configuration=Release
    ...
    bin\Release\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Common.targets(2193,5): error MSB4018: The "LinkAssemblies" task failed unexpectedly.
    System.NullReferenceException: Object reference not set to an instance of an object.
        at MonoDroid.Tuner.MonoDroidMarkStep.UpdateMarshalTypes()
        at MonoDroid.Tuner.MonoDroidMarkStep.Process(LinkContext context)
        at Mono.Linker.Pipeline.Process(LinkContext context)
        at MonoDroid.Tuner.Linker.Process(LinkerOptions options, ILogger logger, LinkContext& context)
        at Xamarin.Android.Tasks.LinkAssemblies.Execute(DirectoryAssemblyResolver res)
        at Xamarin.Android.Tasks.LinkAssemblies.Execute()
        at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
        at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext() [tests\Xamarin.Forms-Performance-Integration\Droid\Xamarin.Forms.Performance.Integration.Droid.csproj]

It looks like these two projects are enabling
`$(AndroidGenerateJniMarshalMethods)`:

* Mono.Android-Tests.csproj
* Xamarin.Forms.Performance.Integration.Droid.csproj

Since `$(AndroidGenerateJniMarshalMethods)` isn't supported yet on
Windows (and apparently Linux?), I've switched the projects to only
enable the option on macOS.