### PR TITLE
[Xamarin.Android.Build.Tasks] use NDKMinimumApiAvailable for minSdkVersion warning

### DIFF
--- a/Documentation/guides/messages/xa4216.md
+++ b/Documentation/guides/messages/xa4216.md
@@ -9,4 +9,4 @@ higher API level that is supported.
 
 Example message:
 
-    warning XA4216: AndroidManifest.xml //uses-sdk/@android:minSdkVersion '8' is less than API-9, this configuration is not supported.
+    warning XA4216: AndroidManifest.xml //uses-sdk/@android:minSdkVersion '15' is less than API-16, this configuration is not supported.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
@@ -13,7 +13,6 @@ namespace Xamarin.Android.Tasks
 {
 	public class GetJavaPlatformJar : Task
 	{
-		const int MinSupportedSdkVersion = 9;
 		private XNamespace androidNs = "http://schemas.android.com/apk/res/android";
 
 		[Required]
@@ -54,20 +53,20 @@ namespace Xamarin.Android.Tasks
 								platform = target_sdk.Value;
 
 							var min_sdk = uses_sdk.Attribute (androidNs + "minSdkVersion");
-							if (min_sdk != null && (!int.TryParse (min_sdk.Value, out int minSdkVersion) || minSdkVersion < MinSupportedSdkVersion)) {
+							if (min_sdk != null && (!int.TryParse (min_sdk.Value, out int minSdkVersion) || minSdkVersion < XABuildConfig.NDKMinimumApiAvailable)) {
 								LogWarningForManifest (
 										warningCode:      "XA4216",
 										attribute:        min_sdk,
 										message:          "AndroidManifest.xml //uses-sdk/@android:minSdkVersion '{0}' is less than API-{1}, this configuration is not supported.",
-										messageArgs:      new object [] { min_sdk?.Value, MinSupportedSdkVersion }
+										messageArgs:      new object [] { min_sdk?.Value, XABuildConfig.NDKMinimumApiAvailable }
 								);
 							}
-							if (target_sdk != null && (!int.TryParse (target_sdk.Value, out int targetSdkVersion) || targetSdkVersion < MinSupportedSdkVersion)) {
+							if (target_sdk != null && (!int.TryParse (target_sdk.Value, out int targetSdkVersion) || targetSdkVersion < XABuildConfig.NDKMinimumApiAvailable)) {
 								LogWarningForManifest (
 										warningCode:      "XA4216",
 										attribute:        target_sdk,
 										message:          "AndroidManifest.xml //uses-sdk/@android:targetSdkVersion '{0}' is less than API-{1}, this configuration is not supported.",
-										messageArgs:      new object [] { target_sdk?.Value, MinSupportedSdkVersion }
+										messageArgs:      new object [] { target_sdk?.Value, XABuildConfig.NDKMinimumApiAvailable }
 								);
 							}
 						}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -11,6 +11,7 @@ using System.Xml.Linq;
 using Microsoft.Build.Framework;
 using Mono.Cecil;
 using NUnit.Framework;
+using Xamarin.Android.Tools;
 using Xamarin.ProjectTools;
 
 namespace Xamarin.Android.Build.Tests
@@ -3488,16 +3489,18 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 		[Test]
 		public void WarningForMinSdkVersion ()
 		{
+			int minSdkVersion = XABuildConfig.NDKMinimumApiAvailable;
+			int tooLowSdkVersion = minSdkVersion - 1;
 			var proj = new XamarinAndroidApplicationProject ();
-			proj.AndroidManifest = proj.AndroidManifest.Replace ("<uses-sdk />", "<uses-sdk android:minSdkVersion=\"8\" />");
+			proj.AndroidManifest = proj.AndroidManifest.Replace ("<uses-sdk />", $"<uses-sdk android:minSdkVersion=\"{tooLowSdkVersion}\" />");
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				Assert.IsTrue (
 					StringAssertEx.ContainsText (
 						b.LastBuildOutput,
-						"warning XA4216: AndroidManifest.xml //uses-sdk/@android:minSdkVersion '8' is less than API-9, this configuration is not supported."
+						$"warning XA4216: AndroidManifest.xml //uses-sdk/@android:minSdkVersion '{tooLowSdkVersion}' is less than API-{minSdkVersion}, this configuration is not supported."
 					),
-					"Should receive a warning when //uses-sdk/@android:minSdkVersion=\"8\""
+					$"Should receive a warning when //uses-sdk/@android:minSdkVersion=\"{tooLowSdkVersion}\""
 				);
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -88,7 +88,6 @@
     <Compile Include="Tasks\ValidateJavaVersionTests.cs" />
     <Compile Include="ZipArchiveExTests.cs" />
     <Compile Include="ConvertResourcesCasesTests.cs" />
-    <Compile Include="..\..\..\..\bin\Build$(Configuration)\XABuildConfig.cs" />
     <Compile Include="Tasks\NdkUtilTests.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/2698

In #2698, we added a new build warning for projects using a
`//uses-sdk/@android:minSdkVersion` lower than Xamarin.Android
supports. This change checking for API-9 was appropriate for 16.0, but
not 16.1/master.

We should instead use `XABuildConfig.NDKMinimumApiAvailable` to decide
to show these warnings or not. I updated the relevant test &
warning code documentation about this as well.

## Other changes ##

While using `XABuildConfig` in `Xamarin.Android.Build.Tests`, I
noticed a compiler warning. It seems the type was found twice, since
it has a reference to `Xamarin.Android.Build.Tasks`. We can remove the
`<Compile/>` item for `XABuildConfig.cs` in this project.