### PR TITLE
[Xamarin.Android.Build.Tasks] Improve Android NDK validation errors

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -305,10 +305,6 @@ namespace Xamarin.Android.Tasks
 			if (!Directory.Exists (AotOutputDirectory))
 				Directory.CreateDirectory (AotOutputDirectory);
 
-			// Check that we have a compatible NDK version for the targeted ABIs.
-			NdkUtil.NdkVersion ndkVersion;
-			bool hasNdkVersion = NdkUtil.GetNdkToolchainRelease (AndroidNdkDirectory, out ndkVersion);
-
 			var sdkBinDirectory = MonoAndroidHelper.GetOSBinPath ();
 
 			var abis = SupportedAbis.Split (new char[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
@@ -57,10 +57,6 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("SupportedAbis: {0}", SupportedAbis);
 			Log.LogDebugMessage ("AutoDeps: {0}", AutoDeps);
 			try {
-				if (String.IsNullOrEmpty (AndroidNdkDirectory)) {
-					Log.LogCodedError ("XA5101", "Could not locate Android NDK. Please make sure to configure path to NDK in SDK Locations or set via /p:AndroidNdkDirectory in the MSBuild/xbuild argument.");
-					return false;
-				}
 				return DoExecute ();
 			} catch (XamarinAndroidException e) {
 				Log.LogCodedError (string.Format ("XA{0:0000}", e.Code), e.MessageWithoutCode);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
@@ -20,7 +20,14 @@ namespace Xamarin.Android.Tasks
 		{
 			// Check that we have a compatible NDK version for the targeted ABIs.
 			NdkUtil.NdkVersion ndkVersion;
-			bool hasNdkVersion = NdkUtil.GetNdkToolchainRelease (ndkPath, out ndkVersion);
+			bool hasNdkVersion = NdkUtil.GetNdkToolchainRelease (ndkPath ?? "", out ndkVersion);
+
+			if (!hasNdkVersion) {
+				log.LogCodedError ("XA5101",
+						"Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, " +
+						"or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.");
+				return false;
+			}
 
 			if (NdkUtil.IsNdk64BitArch(arch) && hasNdkVersion && ndkVersion.Version < 10) {
 				log.LogMessage (MessageImportance.High,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MakeBundleNativeCodeExternalTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MakeBundleNativeCodeExternalTests.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.Build.Framework;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using Xamarin.Android.Tasks;
+
+namespace Xamarin.Android.Build.Tests {
+
+	[TestFixture]
+	public class MakeBundleNativeCodeExternalTests : BaseTest {
+		List<BuildErrorEventArgs> errors;
+		List<BuildWarningEventArgs> warnings;
+		List<BuildMessageEventArgs> messages;
+		MockBuildEngine engine;
+		string path;
+
+		[SetUp]
+		public void Setup ()
+		{
+			engine = new MockBuildEngine (TestContext.Out,
+				errors: errors = new List<BuildErrorEventArgs> (),
+				warnings: warnings = new List<BuildWarningEventArgs> (),
+				messages: messages = new List<BuildMessageEventArgs> ());
+
+			path = Path.Combine (Root, "temp", TestName);
+			TestContext.CurrentContext.Test.Properties ["Output"] = new string [] { path };
+		}
+
+		[TestCase (null)]
+		[TestCase ("")]
+		[TestCase ("DoesNotExist")]
+		public void XA5101AndroidNdkNotFound (string androidNdkDirectory)
+		{
+			var task1 = new MakeBundleNativeCodeExternal {
+				BuildEngine = engine,
+				AndroidNdkDirectory = androidNdkDirectory,
+				Assemblies = new ITaskItem [0],
+				SupportedAbis = "armeabi-v7a",
+				TempOutputPath = path,
+				ToolPath = "",
+				BundleApiPath = ""
+			};
+
+			Assert.IsFalse (task1.Execute (), "Task should fail!");
+			BuildErrorEventArgs error1 = errors [0];
+			Assert.AreEqual ("XA5101", error1.Code);
+			StringAssert.Contains (" NDK ", error1.Message);
+			StringAssert.Contains ("AndroidNdkDirectory", error1.Message);
+			StringAssert.Contains ("SDK Manager", error1.Message);
+
+			var task2 = new Aot {
+				BuildEngine = engine,
+				AndroidNdkDirectory = androidNdkDirectory,
+				AndroidAotMode = "normal",
+				AndroidApiLevel = "28",
+				ResolvedAssemblies = new ITaskItem [0],
+				SupportedAbis = "armeabi-v7a",
+				AotOutputDirectory = path,
+				IntermediateAssemblyDir = path
+			};
+
+			Assert.IsFalse (task2.Execute (), "Task should fail!");
+			BuildErrorEventArgs error2 = errors [1];
+			Assert.AreEqual (error1.Message, error2.Message, "Aot and MakeBundleNativeCodeExternal should produce the same error messages.");
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Tasks\CopyResourceTests.cs" />
     <Compile Include="Tasks\KeyToolTests.cs" />
     <Compile Include="Aapt2Tests.cs" />
+    <Compile Include="Tasks\MakeBundleNativeCodeExternalTests.cs" />
     <Compile Include="Tasks\ValidateJavaVersionTests.cs" />
     <Compile Include="ZipArchiveExTests.cs" />
     <Compile Include="ConvertResourcesCasesTests.cs" />


### PR DESCRIPTION
Backport of: https://github.com/xamarin/xamarin-android/pull/2709
Fixes: https://github.com/xamarin/xamarin-android/issues/2708

Move the check for a `null` or empty `AndroidNdkDirectory` from
`MakeBundleNativeCodeExternal.Execute()` into
`NdkUtil.ValidateNdkPlatform()`, and update the error message.  Make
`ValidateNdkPlatform()` fail with that same error if it cannot get the
version of the NDK.  That way, the `MakeBundleNativeCodeExternal` and
`Aot` tasks will both hit that new updated error first before they try
to call any other methods from `NdkUtil`.  This solves the problems from
the linked issue.  In short, the two tasks were each producing a
different error message when invoked with an invalid or missing
`AndroidNdkDirectory`, and neither message suggested how to resolve the
error.

Also remove a related piece of dead code from the `Aot` task.