### PR TITLE
[sqlite] Unhide symbols in the native library

### DIFF
--- a/build-tools/cmake/xa_macros.cmake
+++ b/build-tools/cmake/xa_macros.cmake
@@ -28,13 +28,17 @@ macro(linker_has_flag _flag)
 endmacro()
 
 macro(xa_common_prepare)
+  if(NOT DSO_SYMBOL_VISIBILITY)
+    set(DSO_SYMBOL_VISIBILITY "hidden")
+  endif()
+
   # Don't put the leading '-' in options
   set(XA_COMPILER_FLAGS
     fno-strict-aliasing
     ffunction-sections
     funswitch-loops
     finline-limit=300
-    fvisibility=hidden
+    fvisibility=${DSO_SYMBOL_VISIBILITY}
     fstack-protector
     flto
     Wa,--noexecstack

--- a/src/Mono.Android/Test/Mono.Android-Test.Shared.projitems
+++ b/src/Mono.Android/Test/Mono.Android-Test.Shared.projitems
@@ -44,5 +44,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Android.RuntimeTests\NUnitInstrumentation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Android.RuntimeTests\TestInstrumentation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Android.OS\BundleTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Mono.Data.Sqlite\SqliteTests.cs" />
   </ItemGroup>
 </Project>

--- a/src/Mono.Android/Test/Mono.Android-Tests.csproj
+++ b/src/Mono.Android/Test/Mono.Android-Tests.csproj
@@ -49,9 +49,11 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="Mono.Android" />
     <Reference Include="Mono.Android.Export" />
+    <Reference Include="Mono.Data.Sqlite" />
     <Reference Include="Xamarin.Android.NUnitLite" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Mono.Android/Test/Mono.Data.Sqlite/SqliteTests.cs
+++ b/src/Mono.Android/Test/Mono.Data.Sqlite/SqliteTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+
+using Android.App;
+using Android.Content;
+using Android.Runtime;
+
+using Mono.Data.Sqlite;
+
+using NUnit.Framework;
+
+namespace Mono.Data.Sqlite.Tests
+{
+	[TestFixture]
+	public class SqliteTests
+	{
+		class ItemsDb
+		{
+			public static readonly Dictionary <string, string> dbItems = new Dictionary <string, string> (StringComparer.Ordinal) {
+				{"sample", "text"},
+				{"more", "items"},
+				{"another", "item"},
+			};
+
+			public static readonly ItemsDb Instance;
+
+			static readonly string fileName = "items.db3";
+			string dbPath;
+			bool dbInitialized;
+
+			static ItemsDb ()
+			{
+				if ((int)Android.OS.Build.VERSION.SdkInt < 8) {
+					return;
+				}
+
+				Instance = new ItemsDb ();
+			}
+
+			ItemsDb ()
+			{
+				dbPath = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), fileName);
+			}
+
+			SqliteConnection GetConnection ()
+			{
+				var conn = new SqliteConnection ("Data Source=" + dbPath);
+				return InitDb (conn);
+			}
+
+			SqliteConnection InitDb (SqliteConnection conn)
+			{
+				if (dbInitialized)
+					return conn;
+
+				if (File.Exists (dbPath))
+					File.Delete (dbPath);
+
+				SqliteConnection.CreateFile (dbPath);
+				dbInitialized = true;
+
+				var commands = new List <string> {
+					"CREATE TABLE ITEMS (Key ntext, Value ntext);",
+				};
+
+				foreach (var kvp in dbItems) {
+					commands.Add ($"INSERT INTO [Items] ([Key], [Value]) VALUES ('{kvp.Key}', '{kvp.Value}')");
+				}
+
+				foreach (string cmd in commands) {
+					WithCommand (c => {
+						c.CommandText = cmd;
+						c.ExecuteNonQuery ();
+					});
+				}
+
+				return conn;
+			}
+
+			public void WithConnection (Action<SqliteConnection> action)
+			{
+				var connection = GetConnection ();
+				try {
+					connection.Open ();
+					action (connection);
+				} finally {
+					connection.Close ();
+				}
+			}
+
+			public void WithCommand (Action<SqliteCommand> command)
+			{
+				WithConnection (conn => {
+					using (var cmd = conn.CreateCommand ())
+						command (cmd);
+				});
+			}
+		}
+
+		[Test]
+		public void BasicFunctionality ()
+		{
+			if (ItemsDb.Instance == null) {
+                                Assert.Ignore ("SQLite is not supported on this platform.");
+                                return;
+                        }
+
+			var dbContents = new Dictionary<string, string> (StringComparer.Ordinal);
+                        ItemsDb.Instance.WithCommand (c => {
+                                        c.CommandText = "SELECT [Key], [Value] FROM [Items]";
+                                        var r = c.ExecuteReader ();
+                                        while (r.Read()) {
+						dbContents.Add (r ["Key"].ToString (), r ["Value"].ToString ());
+                                        }
+                        });
+
+			AssertDictionariesAreEqual (ItemsDb.dbItems, dbContents);
+                        do {
+                                ItemsDb.Instance.WithCommand (c => {
+                                                c.CommandText = "CREATE TABLE TESTTABLE (DATA blob not null)";
+                                                c.ExecuteNonQuery ();
+                                });
+                                ItemsDb.Instance.WithCommand (c => {
+                                                c.CommandText = "SELECT * FROM TESTTABLE";
+                                                using (var r = c.ExecuteReader ()) {
+                                                        string typeName = r.GetDataTypeName (0);
+                                                        Assert.IsFalse (typeName != "blob", $"Bug in DbDataReader.GetDataTypeName: should be 'blob', got: {typeName}");
+                                                }
+                                });
+                                ItemsDb.Instance.WithCommand (c => {
+                                                c.CommandText = "DROP TABLE TESTTABLE";
+                                                c.ExecuteNonQuery ();
+                                });
+                        } while (false);
+		}
+
+		static void AssertDictionariesAreEqual (Dictionary <string, string> expected, Dictionary <string, string> dict)
+		{
+			Assert.AreEqual (expected.Count, dict.Count, $"Number of entries read from the database ({dict.Count}) is different than expected ({expected.Count})");
+
+			foreach (var kvp in expected) {
+				string value;
+
+				Assert.IsTrue (dict.TryGetValue (kvp.Key, out value), $"Database does not contain expected entry with key '{kvp.Key}'");
+				Assert.AreEqual (kvp.Value, value, $"Database has a different value for key '{kvp.Key}': '{value}' instead of '{kvp.Value}'");
+			}
+		}
+	}
+}

--- a/src/sqlite-xamarin/CMakeLists.txt
+++ b/src/sqlite-xamarin/CMakeLists.txt
@@ -70,6 +70,7 @@ if (NOT ANDROID_NDK_MAJOR OR ANDROID_NDK_MAJOR LESS 20)
   add_definitions("-D__ANDROID_API_Q__=29")
 endif()
 
+set(DSO_SYMBOL_VISIBILITY "default")
 xa_common_prepare()
 # Don't put the leading '-' in options
 set(TEST_COMPILER_ARGS ${XA_COMPILER_FLAGS})

--- a/tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.csproj
+++ b/tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.csproj
@@ -51,9 +51,11 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="Mono.Android" />
     <Reference Include="Mono.Android.Export" />
+    <Reference Include="Mono.Data.Sqlite" />
     <Reference Include="Xamarin.Android.NUnitLite" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Runtime-MultiDex/Resources/Resource.designer.cs
+++ b/tests/Runtime-MultiDex/Resources/Resource.designer.cs
@@ -35,7 +35,6 @@ namespace Xamarin.Android.RuntimeTests
 			global::Xamarin.Android.UnitTests.NUnit.Resource.Id.ResultMessage = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultMessage;
 			global::Xamarin.Android.UnitTests.NUnit.Resource.Id.ResultResultState = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultResultState;
 			global::Xamarin.Android.UnitTests.NUnit.Resource.Id.ResultRunSingleMethodTest = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultRunSingleMethodTest;
-			global::Xamarin.Android.UnitTests.NUnit.Resource.Id.ResultStackTrace = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultStackTrace;
 			global::Xamarin.Android.UnitTests.NUnit.Resource.Id.ResultsFailed = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultsFailed;
 			global::Xamarin.Android.UnitTests.NUnit.Resource.Id.ResultsId = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultsId;
 			global::Xamarin.Android.UnitTests.NUnit.Resource.Id.ResultsIgnored = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultsIgnored;
@@ -43,6 +42,7 @@ namespace Xamarin.Android.RuntimeTests
 			global::Xamarin.Android.UnitTests.NUnit.Resource.Id.ResultsMessage = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultsMessage;
 			global::Xamarin.Android.UnitTests.NUnit.Resource.Id.ResultsPassed = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultsPassed;
 			global::Xamarin.Android.UnitTests.NUnit.Resource.Id.ResultsResult = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultsResult;
+			global::Xamarin.Android.UnitTests.NUnit.Resource.Id.ResultStackTrace = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultStackTrace;
 			global::Xamarin.Android.UnitTests.NUnit.Resource.Id.RunTestsButton = global::Xamarin.Android.RuntimeTests.Resource.Id.RunTestsButton;
 			global::Xamarin.Android.UnitTests.NUnit.Resource.Id.TestSuiteListView = global::Xamarin.Android.RuntimeTests.Resource.Id.TestSuiteListView;
 			global::Xamarin.Android.UnitTests.NUnit.Resource.Layout.options = global::Xamarin.Android.RuntimeTests.Resource.Layout.options;
@@ -58,7 +58,6 @@ namespace Xamarin.Android.RuntimeTests
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultMessage = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultMessage;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultResultState = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultResultState;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultRunSingleMethodTest = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultRunSingleMethodTest;
-			global::Xamarin.Android.NUnitLite.Resource.Id.ResultStackTrace = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultStackTrace;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsFailed = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultsFailed;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsId = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultsId;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsIgnored = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultsIgnored;
@@ -66,6 +65,7 @@ namespace Xamarin.Android.RuntimeTests
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsMessage = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultsMessage;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsPassed = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultsPassed;
 			global::Xamarin.Android.NUnitLite.Resource.Id.ResultsResult = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultsResult;
+			global::Xamarin.Android.NUnitLite.Resource.Id.ResultStackTrace = global::Xamarin.Android.RuntimeTests.Resource.Id.ResultStackTrace;
 			global::Xamarin.Android.NUnitLite.Resource.Id.RunTestsButton = global::Xamarin.Android.RuntimeTests.Resource.Id.RunTestsButton;
 			global::Xamarin.Android.NUnitLite.Resource.Id.TestSuiteListView = global::Xamarin.Android.RuntimeTests.Resource.Id.TestSuiteListView;
 			global::Xamarin.Android.NUnitLite.Resource.Layout.options = global::Xamarin.Android.RuntimeTests.Resource.Layout.options;
@@ -90,20 +90,20 @@ namespace Xamarin.Android.RuntimeTests
 		public partial class Drawable
 		{
 			
-			// aapt resource value: 0x7f020000
-			public const int android_button = 2130837504;
+			// aapt resource value: 0x7F010003
+			public const int AndroidPressed = 2130771971;
 			
-			// aapt resource value: 0x7f020001
-			public const int android_focused = 2130837505;
+			// aapt resource value: 0x7F010000
+			public const int android_button = 2130771968;
 			
-			// aapt resource value: 0x7f020002
-			public const int android_normal = 2130837506;
+			// aapt resource value: 0x7F010001
+			public const int android_focused = 2130771969;
 			
-			// aapt resource value: 0x7f020003
-			public const int AndroidPressed = 2130837507;
+			// aapt resource value: 0x7F010002
+			public const int android_normal = 2130771970;
 			
-			// aapt resource value: 0x7f020004
-			public const int Icon = 2130837508;
+			// aapt resource value: 0x7F010004
+			public const int Icon = 2130771972;
 			
 			static Drawable()
 			{
@@ -118,80 +118,80 @@ namespace Xamarin.Android.RuntimeTests
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f060008
-			public const int OptionHostName = 2131099656;
+			// aapt resource value: 0x7F020012
+			public const int csharp_full_assembly = 2130837522;
 			
-			// aapt resource value: 0x7f060009
-			public const int OptionPort = 2131099657;
+			// aapt resource value: 0x7F020013
+			public const int csharp_legacy_fragment = 2130837523;
 			
-			// aapt resource value: 0x7f060007
-			public const int OptionRemoteServer = 2131099655;
+			// aapt resource value: 0x7F020014
+			public const int csharp_partial_assembly = 2130837524;
 			
-			// aapt resource value: 0x7f060017
-			public const int OptionsButton = 2131099671;
+			// aapt resource value: 0x7F020015
+			public const int csharp_simple_fragment = 2130837525;
 			
-			// aapt resource value: 0x7f060012
-			public const int ResultFullName = 2131099666;
+			// aapt resource value: 0x7F020016
+			public const int first_text_view = 2130837526;
 			
-			// aapt resource value: 0x7f060014
-			public const int ResultMessage = 2131099668;
+			// aapt resource value: 0x7F020017
+			public const int my_scroll_view = 2130837527;
 			
-			// aapt resource value: 0x7f060013
-			public const int ResultResultState = 2131099667;
+			// aapt resource value: 0x7F020000
+			public const int OptionHostName = 2130837504;
 			
-			// aapt resource value: 0x7f060011
-			public const int ResultRunSingleMethodTest = 2131099665;
+			// aapt resource value: 0x7F020001
+			public const int OptionPort = 2130837505;
 			
-			// aapt resource value: 0x7f060015
-			public const int ResultStackTrace = 2131099669;
+			// aapt resource value: 0x7F020002
+			public const int OptionRemoteServer = 2130837506;
 			
-			// aapt resource value: 0x7f06000d
-			public const int ResultsFailed = 2131099661;
+			// aapt resource value: 0x7F020003
+			public const int OptionsButton = 2130837507;
 			
-			// aapt resource value: 0x7f06000a
-			public const int ResultsId = 2131099658;
+			// aapt resource value: 0x7F020004
+			public const int ResultFullName = 2130837508;
 			
-			// aapt resource value: 0x7f06000e
-			public const int ResultsIgnored = 2131099662;
+			// aapt resource value: 0x7F020005
+			public const int ResultMessage = 2130837509;
 			
-			// aapt resource value: 0x7f06000f
-			public const int ResultsInconclusive = 2131099663;
+			// aapt resource value: 0x7F020006
+			public const int ResultResultState = 2130837510;
 			
-			// aapt resource value: 0x7f060010
-			public const int ResultsMessage = 2131099664;
+			// aapt resource value: 0x7F020007
+			public const int ResultRunSingleMethodTest = 2130837511;
 			
-			// aapt resource value: 0x7f06000c
-			public const int ResultsPassed = 2131099660;
+			// aapt resource value: 0x7F020009
+			public const int ResultsFailed = 2130837513;
 			
-			// aapt resource value: 0x7f06000b
-			public const int ResultsResult = 2131099659;
+			// aapt resource value: 0x7F02000A
+			public const int ResultsId = 2130837514;
 			
-			// aapt resource value: 0x7f060016
-			public const int RunTestsButton = 2131099670;
+			// aapt resource value: 0x7F02000B
+			public const int ResultsIgnored = 2130837515;
 			
-			// aapt resource value: 0x7f060018
-			public const int TestSuiteListView = 2131099672;
+			// aapt resource value: 0x7F02000C
+			public const int ResultsInconclusive = 2130837516;
 			
-			// aapt resource value: 0x7f060003
-			public const int csharp_full_assembly = 2131099651;
+			// aapt resource value: 0x7F02000D
+			public const int ResultsMessage = 2130837517;
 			
-			// aapt resource value: 0x7f060001
-			public const int csharp_legacy_fragment = 2131099649;
+			// aapt resource value: 0x7F02000E
+			public const int ResultsPassed = 2130837518;
 			
-			// aapt resource value: 0x7f060002
-			public const int csharp_partial_assembly = 2131099650;
+			// aapt resource value: 0x7F02000F
+			public const int ResultsResult = 2130837519;
 			
-			// aapt resource value: 0x7f060000
-			public const int csharp_simple_fragment = 2131099648;
+			// aapt resource value: 0x7F020008
+			public const int ResultStackTrace = 2130837512;
 			
-			// aapt resource value: 0x7f060004
-			public const int first_text_view = 2131099652;
+			// aapt resource value: 0x7F020010
+			public const int RunTestsButton = 2130837520;
 			
-			// aapt resource value: 0x7f060006
-			public const int my_scroll_view = 2131099654;
+			// aapt resource value: 0x7F020018
+			public const int second_text_view = 2130837528;
 			
-			// aapt resource value: 0x7f060005
-			public const int second_text_view = 2131099653;
+			// aapt resource value: 0x7F020011
+			public const int TestSuiteListView = 2130837521;
 			
 			static Id()
 			{
@@ -206,22 +206,22 @@ namespace Xamarin.Android.RuntimeTests
 		public partial class Layout
 		{
 			
-			// aapt resource value: 0x7f030000
+			// aapt resource value: 0x7F030000
 			public const int FragmentFixup = 2130903040;
 			
-			// aapt resource value: 0x7f030001
+			// aapt resource value: 0x7F030001
 			public const int Main = 2130903041;
 			
-			// aapt resource value: 0x7f030002
+			// aapt resource value: 0x7F030002
 			public const int options = 2130903042;
 			
-			// aapt resource value: 0x7f030003
+			// aapt resource value: 0x7F030003
 			public const int results = 2130903043;
 			
-			// aapt resource value: 0x7f030004
+			// aapt resource value: 0x7F030004
 			public const int test_result = 2130903044;
 			
-			// aapt resource value: 0x7f030005
+			// aapt resource value: 0x7F030005
 			public const int test_suite = 2130903045;
 			
 			static Layout()
@@ -237,8 +237,8 @@ namespace Xamarin.Android.RuntimeTests
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7f050000
-			public const int library_name = 2131034112;
+			// aapt resource value: 0x7F040000
+			public const int library_name = 2130968576;
 			
 			static String()
 			{
@@ -253,8 +253,8 @@ namespace Xamarin.Android.RuntimeTests
 		public partial class Xml
 		{
 			
-			// aapt resource value: 0x7f040000
-			public const int XmlReaderResourceParser = 2130968576;
+			// aapt resource value: 0x7F050000
+			public const int XmlReaderResourceParser = 2131034112;
 			
 			static Xml()
 			{


### PR DESCRIPTION
After commit
https://github.com/xamarin/xamarin-android/commit/52190d70725c0973f8dacb250cf904c70d7e1539
all the native libraries we build that use cmake were built with the
`-fvisibility=hide` compiler flag which hides all the symbols defined by the
library unless told otherwise on per-symbol basis. This is not desired for our
build of sqlite since, obviously, its functions have to be visible in order for
`Mono.Data.Sqlite` to be able to p/invoke them, otherwise we end up in a
situation when we have the following errors on the runtime:

    02-06 16:47:05.746 I/MonoDroid( 2613): UNHANDLED EXCEPTION:
    02-06 16:47:05.791 I/MonoDroid( 2613): System.TypeInitializationException: The type initializer for 'Mono.Data.Sqlite.UnsafeNativeMethods' threw an exception. ---> System.EntryPointNotFoundException: sqlite3_libversion_number
    02-06 16:47:05.792 I/MonoDroid( 2613):   at (wrapper managed-to-native) Mono.Data.Sqlite.UnsafeNativeMethods.sqlite3_libversion_number()
    02-06 16:47:05.792 I/MonoDroid( 2613):   at Mono.Data.Sqlite.UnsafeNativeMethods..cctor () [0x00000] in :0
    02-06 16:47:05.792 I/MonoDroid( 2613):    --- End of inner exception stack trace ---

caused by the failure to look up symbols in the DSO:

    02-07 11:13:07.939  8628  8628 D Mono    : DllImport attempting to load: 'libsqlite3_xamarin.so'.
    02-07 11:13:07.940  8628  8628 D Mono    : DllImport loaded library './libsqlite3_xamarin.so'.
    02-07 11:13:07.940  8628  8628 D Mono    : DllImport searching in: 'libsqlite3_xamarin.so' ('./libsqlite3_xamarin.so').
    02-07 11:13:07.940  8628  8628 D Mono    : Searching for 'sqlite3_open_v2'.
    02-07 11:13:07.940  8628  8628 D Mono    : Probing 'sqlite3_open_v2'.
    02-07 11:13:07.940  8628  8628 D Mono    : Could not find 'sqlite3_open_v2' due to 'Could not find symbol 'sqlite3_open_v2'.'.
    02-07 11:13:07.940  8628  8628 D Mono    : Probing 'sqlite3_open_v2'.
    02-07 11:13:07.940  8628  8628 D Mono    : Could not find 'sqlite3_open_v2' due to 'Could not find symbol 'sqlite3_open_v2'.'.
    02-07 11:13:07.940  8628  8628 D Mono    : Probing 'sqlite3_open_v2A'.
    02-07 11:13:07.940  8628  8628 D Mono    : Could not find 'sqlite3_open_v2A' due to 'Could not find symbol 'sqlite3_open_v2A'.'.
    02-07 11:13:07.940  8628  8628 D Mono    : Probing 'sqlite3_open_v2A'.
    02-07 11:13:07.940  8628  8628 D Mono    : Could not find 'sqlite3_open_v2A' due to 'Could not find symbol 'sqlite3_open_v2A'.'.
    02-07 11:13:07.940  8628  8628 D Mono    : DllImport searching in: 'libsqlite3_xamarin.so' ('./libsqlite3_xamarin.so').
    02-07 11:13:07.940  8628  8628 D Mono    : Searching for 'sqlite3_open'.
    02-07 11:13:07.940  8628  8628 D Mono    : Probing 'sqlite3_open'.
    02-07 11:13:07.940  8628  8628 D Mono    : Could not find 'sqlite3_open' due to 'Could not find symbol 'sqlite3_open'.'.
    02-07 11:13:07.940  8628  8628 D Mono    : Probing 'sqlite3_open'.
    02-07 11:13:07.940  8628  8628 D Mono    : Could not find 'sqlite3_open' due to 'Could not find symbol 'sqlite3_open'.'.
    02-07 11:13:07.940  8628  8628 D Mono    : Probing 'sqlite3_openA'.
    02-07 11:13:07.940  8628  8628 D Mono    : Could not find 'sqlite3_openA' due to 'Could not find symbol 'sqlite3_openA'.'.
    02-07 11:13:07.940  8628  8628 D Mono    : Probing 'sqlite3_openA'.
    02-07 11:13:07.940  8628  8628 D Mono    : Could not find 'sqlite3_openA' due to 'Could not find symbol 'sqlite3_openA'.'.
    02-07 11:13:07.941  8628  8628 D Mono    : DllImport searching in: 'libsqlite3_xamarin.so' ('./libsqlite3_xamarin.so').
    02-07 11:13:07.941  8628  8628 D Mono    : Searching for 'sqlite3_libversion_number'.
    02-07 11:13:07.941  8628  8628 D Mono    : Probing 'sqlite3_libversion_number'.
    02-07 11:13:07.941  8628  8628 D Mono    : Could not find 'sqlite3_libversion_number' due to 'Could not find symbol 'sqlite3_libversion_number'.'.
    02-07 11:13:07.941  8628  8628 D Mono    : Probing 'sqlite3_libversion_number'.
    02-07 11:13:07.941  8628  8628 D Mono    : Could not find 'sqlite3_libversion_number' due to 'Could not find symbol 'sqlite3_libversion_number'.'.

This commit rectifies the situation by making the default visibility
configurable on the per-project basis and setting it to `default` for the SQLite
build.

Also, tests are added to `Mono.Android` to make sure SQLite actually works on
device.