### PR TITLE
[Xamarin.Android.Build.Tasks] Correct Android NDK existence check

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -81,7 +81,8 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			NdkUtil.Init (AndroidNdkDirectory);
+			if (!NdkUtil.Init (Log, AndroidNdkDirectory))
+				return false;
 
 			try {
 				return DoExecute ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
@@ -57,7 +57,8 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ("SupportedAbis: {0}", SupportedAbis);
 			Log.LogDebugMessage ("AutoDeps: {0}", AutoDeps);
 
-			NdkUtil.Init (AndroidNdkDirectory);
+			if (!NdkUtil.Init (Log, AndroidNdkDirectory))
+				return false;
 
 			try {
 				return DoExecute ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
@@ -20,18 +20,8 @@ namespace Xamarin.Android.Tasks
 
 		public static bool UsingClangNDK => usingClangNDK;
 
-		public static void Init (string ndkPath)
+		public static bool Init (TaskLoggingHelper log, string ndkPath)
 		{
-			Version ndkVersion;
-			usingClangNDK = GetNdkToolchainRelease (ndkPath, out ndkVersion) && ndkVersion.Major >= 19;
-		}
-
-		public static bool ValidateNdkPlatform (TaskLoggingHelper log, string ndkPath, AndroidTargetArch arch, bool enableLLVM)
-		{
-			if (!UsingClangNDK)
-				return NdkUtilOld.ValidateNdkPlatform (log, ndkPath, arch, enableLLVM);
-
-			// Check that we have a compatible NDK version for the targeted ABIs.
 			Version ndkVersion;
 			bool hasNdkVersion = GetNdkToolchainRelease (ndkPath ?? "", out ndkVersion);
 
@@ -41,6 +31,20 @@ namespace Xamarin.Android.Tasks
 						"or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.");
 				return false;
 			}
+
+			usingClangNDK = ndkVersion.Major >= 19;
+
+			return true;
+		}
+
+		public static bool ValidateNdkPlatform (TaskLoggingHelper log, string ndkPath, AndroidTargetArch arch, bool enableLLVM)
+		{
+			if (!UsingClangNDK)
+				return NdkUtilOld.ValidateNdkPlatform (log, ndkPath, arch, enableLLVM);
+
+			// Check that we have a compatible NDK version for the targeted ABIs.
+			Version ndkVersion;
+			bool hasNdkVersion = GetNdkToolchainRelease (ndkPath, out ndkVersion);
 
 			if (hasNdkVersion && ndkVersion.Major < 19) {
 				log.LogMessage (MessageImportance.High,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/NdkUtilTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/NdkUtilTests.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Android.Build.Tests.Tasks {
 				var ndkDir = builder.AndroidNdkDirectory;
 				var sdkDir = builder.AndroidSdkDirectory;
 				MonoAndroidHelper.AndroidSdk = new AndroidSdkInfo ((arg1, arg2) => { }, sdkDir, ndkDir);
-				NdkUtil.Init (ndkDir);
+				NdkUtil.Init (log, ndkDir);
 				var platforms = NdkUtil.GetSupportedPlatforms (ndkDir);
 				Assert.AreNotEqual (0, platforms.Count (), "No platforms found");
 				var arch = AndroidTargetArch.X86;


### PR DESCRIPTION
Fixes the test failures introduced in: https://github.com/xamarin/xamarin-android/pull/2709

I initially authored the changes in [#2709][0] against a `master` commit
that was a few before the [switch to Android NDK r19][1].  When I
locally merged the changes onto the tip of `master`, I didn't notice
that the `MakeBundleNativeCodeExternal` and `Aot` tasks were now calling
the new method `NdkUtil.Init()` before `NdkUtil.ValidateNdkPlatform()`.
And unfortunately since there was some urgency to get the corresponding
backport ready for the `d16-0` branch, I didn't get a chance to re-build
and re-test locally against the tip of `master`.  Long story short, to
support the new order of method calls, the NDK existence check now needs
to happen at the time of the call to `GetNdkToolchainRelease()` in
`NdkUtil.Init()`.

[0]: https://github.com/xamarin/xamarin-android/pull/2709
[1]: https://github.com/xamarin/xamarin-android/commit/06e920c18b71a165eded0a5782f1a285ef20a4bc