### PR TITLE
[mono-runtimes] Don't strip libmono-native

### DIFF
--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -417,10 +417,6 @@
         Condition=" '$(Configuration)' != 'Debug' Or '%(_MonoRuntime.NativeLibraryExtension)' == 'dll' "
         Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(_MSBuildDir)\lib\%(_MonoRuntime.Identity)\%(_MonoRuntime.OutputRuntimeFilename).%(_MonoRuntime.NativeLibraryExtension)&quot;"
     />
-    <Exec
-        Condition=" ('$(Configuration)' != 'Debug' Or '%(_MonoRuntime.NativeLibraryExtension)' == 'dll') And ('host-mxe-Win32' != '%(Identity)' And 'host-mxe-Win64' != '%(Identity)') "
-        Command="&quot;%(_MonoRuntime.Strip)&quot; %(_MonoRuntime.StripFlags) &quot;$(_MSBuildDir)\lib\%(_MonoRuntime.Identity)\libmono-native.%(_MonoRuntime.NativeLibraryExtension)&quot;"
-    />
     <Touch Files="@(_InstallRuntimeOutput);@(_InstallUnstrippedRuntimeOutput)" />
 
     <Copy


### PR DESCRIPTION
This ends up removing all symbols from the library (`nm armeabi-v7a/libmono-native.so | wc -l` = 0). We probably need to eventually amend with a 'symbols to keep' list