### PR TITLE
[tests] Make the Mono.Android_TestsMultiDex run

### DIFF
--- a/tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.projitems
+++ b/tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.projitems
@@ -1,15 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_PackageName>Mono.Android_TestsMultiDex</_PackageName>
+  </PropertyGroup>
   <ItemGroup>
-    <TestApk Include="$(OutputPath)Mono.Android_TestsMultiDex-Signed.apk">
-      <Package>Mono.Android_TestsMultiDex</Package>
+    <TestApk Include="$(OutputPath)$(_PackageName)-Signed.apk">
+      <Package>$(_PackageName)</Package>
       <InstrumentationType>xamarin.android.runtimetests.TestInstrumentation</InstrumentationType>
-      <ResultsPath>$(MSBuildThisFileDirectory)..\..\TestResult-Mono.Android_TestsMultiDex.xml</ResultsPath>
+      <ResultsPath>$(MSBuildThisFileDirectory)..\..\TestResult-$(_PackageName).xml</ResultsPath>
       <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)..\..\build-tools\scripts\TimingDefinitions.txt</TimingDefinitionsFilename>
-      <TimingResultsFilename>$(MSBuildThisFileDirectory)..\..\TestResult-Mono.Android_TestsMultiDex-times.csv</TimingResultsFilename>
-      <ApkSizesInputFilename>apk-sizes-$(_MonoAndroidTestPackage)-$(Configuration)$(TestsFlavor).txt</ApkSizesInputFilename>
+      <TimingResultsFilename>$(MSBuildThisFileDirectory)..\..\TestResult-$(_PackageName)-times.csv</TimingResultsFilename>
+      <ApkSizesInputFilename>apk-sizes-$(_PackageName)-$(Configuration)$(TestsFlavor).txt</ApkSizesInputFilename>
       <ApkSizesDefinitionFilename>$(MSBuildThisFileDirectory)apk-sizes-definitions.txt</ApkSizesDefinitionFilename>
-      <ApkSizesResultsFilename>$(MSBuildThisFileDirectory)..\..\TestResult-Mono.Android_TestsMultDex-values.csv</ApkSizesResultsFilename>
+      <ApkSizesResultsFilename>$(MSBuildThisFileDirectory)..\..\TestResult-$(_PackageName)-values.csv</ApkSizesResultsFilename>
     </TestApk>
+  </ItemGroup>
+
+  <ItemGroup>
+    <TestApkInstrumentation Include="xamarin.android.runtimetests.TestInstrumentation">
+      <Package>$(_PackageName)</Package>
+      <ResultsPath>$(OutputPath)TestResult-$(_PackageName).xml</ResultsPath>
+    </TestApkInstrumentation>
+
+    <TestApkPermission Include="READ_EXTERNAL_STORAGE">
+      <Package>$(_PackageName)</Package>
+    </TestApkPermission>
+
+    <TestApkPermission Include="WRITE_EXTERNAL_STORAGE">
+      <Package>$(_PackageName)</Package>
+    </TestApkPermission>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We see these errors in our jenkins builds:

    /Users/builder/jenkins/workspace/xamarin-android-pr-builder-release/xamarin-android/build-tools/scripts/TestApks.targets(217,5): error : Input file 'logcat-Release-Aot-Mono.Android_TestsMultiDex.txt' doesn't exist. [/Users/builder/jenkins/workspace/xamarin-android-pr-builder-release/xamarin-android/tests/RunApkTests.targets]
      Build continuing because "ContinueOnError" on the task "ProcessLogcatTiming" is set to "ErrorAndContinue".

Turns out, that the reason for that is, that the
`Mono.Android_TestsMultiDex` test is not run, because no
`RunInstrumentationTests` nor `RunUITests` is used as their condition
clauses are resolved as **false**.

This is fixed by adding `TestApkInstrumentation` (and
`TestApkPermission` plus `TestApkPermission`) item groups. This makes
the test run thru the `RunInstrumentationTests` task.