### PR TITLE
Typename mapping + environment assembly generator

### DIFF
--- a/build-tools/scripts/XABuildConfig.cs.in
+++ b/build-tools/scripts/XABuildConfig.cs.in
@@ -15,6 +15,7 @@ namespace Xamarin.Android.Tools
 			{        "arm", @NDK_ARMEABI_V7_API@},
 			{  "arm64-v8a", @NDK_ARM64_V8A_API@},
 			{      "arm64", @NDK_ARM64_V8A_API@},
+			{    "aarch64", @NDK_ARM64_V8A_API@},
 			{        "x86", @NDK_X86_API@},
 			{     "x86_64", @NDK_X86_64_API@},
 		};

--- a/src/Mono.Android/java/mono/android/Runtime.java
+++ b/src/Mono.Android/java/mono/android/Runtime.java
@@ -11,7 +11,7 @@ public class Runtime {
 	{
 	}
 
-	public static native void init (String lang, String[] runtimeApks, String runtimeDataDir, String[] appDirs, ClassLoader loader, String[] externalStorageDirs, String[] assemblies, String packageName, int apiLevel, String[] environmentVariables);
+	public static native void init (String lang, String[] runtimeApks, String runtimeDataDir, String[] appDirs, ClassLoader loader, String[] externalStorageDirs, String[] assemblies, int apiLevel);
 	public static native void register (String managedType, java.lang.Class nativeClass, String methods);
 	public static native void notifyTimeZoneChanged ();
 	public static native int createNewContext (String[] runtimeApks, String[] assemblies, ClassLoader loader);

--- a/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.java
@@ -46,6 +46,12 @@ public class MonoPackageManager {
 							external0,
 							"../legacy/Android/data/" + context.getPackageName () + "/files/.__override__").getAbsolutePath ();
 
+				// Preload DSOs libmonodroid.so depends on so that the dynamic
+				// linker can resolve them when loading monodroid. This is not
+				// needed in the latest Android versions but is required in at least
+				// API 16 and since there's no inherent negative effect of doing it,
+				// we can do it unconditionally.
+				System.loadLibrary("xamarin-app");
 				System.loadLibrary("monodroid");
 
 				Runtime.init (
@@ -63,9 +69,7 @@ public class MonoPackageManager {
 							externalLegacyDir
 						},
 						MonoPackageManager_Resources.Assemblies,
-						context.getPackageName (),
-						android.os.Build.VERSION.SDK_INT,
-						mono.android.app.XamarinAndroidEnvironmentVariables.Variables);
+						android.os.Build.VERSION.SDK_INT);
 				
 				mono.android.app.ApplicationRegistration.registerApplications ();
 				

--- a/src/Xamarin.Android.Build.Tasks/Resources/XamarinAndroidEnvironmentVariables.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/XamarinAndroidEnvironmentVariables.java
@@ -1,9 +1,0 @@
-package mono.android.app;
-
-public class XamarinAndroidEnvironmentVariables
-{
-	// Variables are specified the in "name", "value" pairs
-	public static final String[] Variables = new String[] {
-//@ENVVARS@
-	};
-}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -16,11 +16,12 @@ using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
-	public enum AotMode
+	public enum AotMode : uint
 	{
-		Normal,
-		Hybrid,
-		Full
+		None      = 0x0000,
+		Normal    = 0x0001,
+		Hybrid    = 0x0002,
+		Full      = 0x0003,
 	}
 
 	public enum SequencePointsMode {
@@ -98,6 +99,9 @@ namespace Xamarin.Android.Tasks
 
 			switch ((androidAotMode ?? string.Empty).ToLowerInvariant().Trim())
 			{
+			case "none":
+				aotMode = AotMode.None;
+				return true;
 			case "normal":
 				aotMode = AotMode.Normal;
 				return true;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using ThreadingTasks = System.Threading.Tasks;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks
+{
+	public class CompileNativeAssembly : AsyncTask
+	{
+		sealed class Config
+		{
+			public string AssemblerPath;
+			public string AssemblerOptions;
+			public string InputSource;
+		}
+
+		[Required]
+		public ITaskItem[] Sources { get; set; }
+
+		[Required]
+		public bool DebugBuild { get; set; }
+
+		[Required]
+		public string WorkingDirectory { get; set; }
+
+		public override bool Execute ()
+		{
+			try {
+				return DoExecute ();
+			} catch (Exception e) {
+				Log.LogCodedError ("XA3001", $"{e}");
+				return false;
+			}
+		}
+
+		bool DoExecute ()
+		{
+			Yield ();
+			try {
+				var task = ThreadingTasks.Task.Run ( () => RunParallelAssembler (), Token);
+				task.ContinueWith (Complete);
+
+				base.Execute ();
+
+				if (!task.Result)
+					return false;
+			} finally {
+				Reacquire ();
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+
+		bool RunParallelAssembler ()
+		{
+			try {
+				ThreadingTasks.ParallelOptions options = new ThreadingTasks.ParallelOptions {
+					CancellationToken = Token,
+					TaskScheduler = ThreadingTasks.TaskScheduler.Default,
+				};
+
+				ThreadingTasks.Parallel.ForEach (GetAssemblerConfigs (), options,
+					config => {
+						if (!RunAssembler (config)) {
+							LogCodedError ("XA3001", $"Could not compile native assembly file: {Path.GetFileName (config.InputSource)}");
+							Cancel ();
+							return;
+						}
+					}
+				);
+			} catch (OperationCanceledException) {
+				return false;
+			}
+
+			return true;
+		}
+
+		bool RunAssembler (Config config)
+		{
+			var stdout_completed = new ManualResetEvent (false);
+			var stderr_completed = new ManualResetEvent (false);
+			var psi = new ProcessStartInfo () {
+				FileName = config.AssemblerPath,
+				Arguments = config.AssemblerOptions,
+				UseShellExecute = false,
+				RedirectStandardOutput = true,
+				RedirectStandardError = true,
+				CreateNoWindow = true,
+				WindowStyle = ProcessWindowStyle.Hidden,
+				WorkingDirectory = WorkingDirectory,
+			};
+
+			string assemblerName = Path.GetFileName (config.AssemblerPath);
+			LogDebugMessage ($"[Native Assembler] {psi.FileName} {psi.Arguments}");
+			using (var proc = new Process ()) {
+				proc.OutputDataReceived += (s, e) => {
+					if (e.Data != null)
+						OnOutputData (assemblerName, s, e);
+					else
+						stdout_completed.Set ();
+				};
+
+				proc.ErrorDataReceived += (s, e) => {
+					if (e.Data != null)
+						OnErrorData (assemblerName, s, e);
+					else
+						stderr_completed.Set ();
+				};
+
+				proc.StartInfo = psi;
+				proc.Start ();
+				proc.BeginOutputReadLine ();
+				proc.BeginErrorReadLine ();
+				Token.Register (() => { try { proc.Kill (); } catch (Exception) { } });
+				proc.WaitForExit ();
+
+				if (psi.RedirectStandardError)
+					stderr_completed.WaitOne (TimeSpan.FromSeconds (30));
+
+				if (psi.RedirectStandardOutput)
+					stdout_completed.WaitOne (TimeSpan.FromSeconds (30));
+
+				return proc.ExitCode == 0;
+			}
+		}
+
+		IEnumerable<Config> GetAssemblerConfigs ()
+		{
+			string sdkBinDirectory = MonoAndroidHelper.GetOSBinPath ();
+			foreach (ITaskItem item in Sources) {
+				string abi = item.GetMetadata ("abi");
+				string prefix = String.Empty;
+				AndroidTargetArch arch;
+
+				switch (abi) {
+					case "armeabi-v7a":
+						prefix = Path.Combine (sdkBinDirectory, "arm-linux-androideabi");
+						arch = AndroidTargetArch.Arm;
+						break;
+
+					case "arm64":
+					case "arm64-v8a":
+					case "aarch64":
+						prefix = Path.Combine (sdkBinDirectory, "aarch64-linux-android");
+						arch = AndroidTargetArch.Arm64;
+						break;
+
+					case "x86":
+						prefix = Path.Combine (sdkBinDirectory, "i686-linux-android");
+						arch = AndroidTargetArch.X86;
+						break;
+
+					case "x86_64":
+						prefix = Path.Combine (sdkBinDirectory, "x86_64-linux-android");
+						arch = AndroidTargetArch.X86_64;
+						break;
+
+					default:
+						throw new Exception ("Unsupported Android target architecture ABI: " + abi);
+				}
+
+				// We don't need the directory since our WorkingDirectory is (and must be) where all the
+				// sources are (because of the typemap.inc file being included by the other sources with
+				// a relative path of `.`)
+				string sourceFile = Path.GetFileName (item.ItemSpec);
+				var assemblerOptions = new List<string> {
+					"--warn",
+					"-o",
+					QuoteFileName (sourceFile.Replace (".s", ".o"))
+				};
+
+				if (DebugBuild)
+					assemblerOptions.Add ("-g");
+
+				assemblerOptions.Add (QuoteFileName (sourceFile));
+
+				yield return new Config {
+					InputSource = item.ItemSpec,
+					AssemblerPath = $"{prefix}-as",
+					AssemblerOptions = String.Join (" ", assemblerOptions),
+				};
+			}
+		}
+
+		void OnOutputData (string assemblerName, object sender, DataReceivedEventArgs e)
+		{
+			if (e.Data != null)
+				LogMessage ($"[{assemblerName} stdout] {e.Data}");
+		}
+
+		void OnErrorData (string assemblerName, object sender, DataReceivedEventArgs e)
+		{
+			if (e.Data != null)
+				LogMessage ($"[{assemblerName} stderr] {e.Data}");
+		}
+
+		static string QuoteFileName (string fileName)
+		{
+			var builder = new CommandLineBuilder ();
+			builder.AppendFileNameIfNotNull (fileName);
+			return builder.ToString ();
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkApplicationDSOs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkApplicationDSOs.cs
@@ -1,0 +1,260 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using ThreadingTasks = System.Threading.Tasks;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks
+{
+	public class LinkApplicationDSOs : AsyncTask
+	{
+		sealed class Config
+		{
+			public string LinkerPath;
+			public string LinkerOptions;
+			public string OutputDSO;
+		}
+
+		sealed class InputFiles
+		{
+			public List<string> ObjectFiles;
+			public string OutputDSO;
+		}
+
+		[Required]
+		public ITaskItem[] ObjectFiles { get; set; }
+
+		[Required]
+		public ITaskItem[] ApplicationDSOs { get; set; }
+
+		[Required]
+		public bool DebugBuild { get; set; }
+
+		[Required]
+		public string AndroidNdkDirectory { get; set; }
+
+		public override bool Execute ()
+		{
+			try {
+				return DoExecute ();
+			} catch (Exception e) {
+				Log.LogCodedError ("XA3001", $"{e}");
+				return false;
+			}
+		}
+
+		bool DoExecute ()
+		{
+			Yield ();
+			try {
+				var task = ThreadingTasks.Task.Run ( () => RunParallelLinker (), Token);
+				task.ContinueWith (Complete);
+
+				base.Execute ();
+
+				if (!task.Result)
+					return false;
+			} finally {
+				Reacquire ();
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+
+		bool RunParallelLinker ()
+		{
+			try {
+				ThreadingTasks.ParallelOptions options = new ThreadingTasks.ParallelOptions {
+					CancellationToken = Token,
+					TaskScheduler = ThreadingTasks.TaskScheduler.Default,
+				};
+
+				ThreadingTasks.Parallel.ForEach (GetLinkerConfigs (), options,
+								 config => {
+									 if (!RunLinker (config)) {
+										 LogCodedError ("XA3001", $"Could not link native shared library: {Path.GetFileName (config.OutputDSO)}");
+										 Cancel ();
+										 return;
+									 }
+								 }
+				);
+			} catch (OperationCanceledException) {
+				return false;
+			}
+
+			return true;
+		}
+
+		bool RunLinker (Config config)
+		{
+			var stdout_completed = new ManualResetEvent (false);
+			var stderr_completed = new ManualResetEvent (false);
+			var psi = new ProcessStartInfo () {
+				FileName = config.LinkerPath,
+				Arguments = config.LinkerOptions,
+				UseShellExecute = false,
+				RedirectStandardOutput = true,
+				RedirectStandardError = true,
+				CreateNoWindow = true,
+				WindowStyle = ProcessWindowStyle.Hidden,
+			};
+
+			string targetDir = Path.GetDirectoryName (config.OutputDSO);
+			if (!Directory.Exists (targetDir))
+				Directory.CreateDirectory (targetDir);
+
+			string linkerName = Path.GetFileName (config.LinkerPath);
+			LogDebugMessage ($"[Native Linker] {psi.FileName} {psi.Arguments}");
+			using (var proc = new Process ()) {
+				proc.OutputDataReceived += (s, e) => {
+					if (e.Data != null)
+						OnOutputData (linkerName, s, e);
+					else
+						stdout_completed.Set ();
+				};
+
+				proc.ErrorDataReceived += (s, e) => {
+					if (e.Data != null)
+						OnErrorData (linkerName, s, e);
+					else
+						stderr_completed.Set ();
+				};
+
+				proc.StartInfo = psi;
+				proc.Start ();
+				proc.BeginOutputReadLine ();
+				proc.BeginErrorReadLine ();
+				Token.Register (() => { try { proc.Kill (); } catch (Exception) { } });
+				proc.WaitForExit ();
+
+				if (psi.RedirectStandardError)
+					stderr_completed.WaitOne (TimeSpan.FromSeconds (30));
+
+				if (psi.RedirectStandardOutput)
+					stdout_completed.WaitOne (TimeSpan.FromSeconds (30));
+
+				return proc.ExitCode == 0;
+			}
+		}
+
+		IEnumerable<Config> GetLinkerConfigs ()
+		{
+			var abis = new Dictionary <string, InputFiles> (StringComparer.Ordinal);
+			ITaskItem[] dsos = ApplicationDSOs;
+			foreach (ITaskItem item in dsos) {
+				string abi = item.GetMetadata ("abi");
+				abis [abi] = GatherFilesForABI(item.ItemSpec, abi, ObjectFiles);
+			}
+
+			foreach (var kvp in abis) {
+				string abi = kvp.Key;
+				InputFiles inputs = kvp.Value;
+				AndroidTargetArch arch;
+
+				var linkerArgs = new List <string> {
+					"--unresolved-symbols=ignore-in-shared-libs",
+					"--export-dynamic",
+					"-soname", "libxamarin-app.so",
+					"-z", "relro",
+					"-z", "noexecstack",
+					"--enable-new-dtags",
+					"--eh-frame-hdr",
+					"-shared",
+					"--build-id",
+					"--warn-shared-textrel",
+					"--fatal-warnings",
+					"-o", QuoteFileName (inputs.OutputDSO),
+//					"--allow-shlib-undefined",
+				};
+
+				string elf_arch;
+				switch (abi) {
+					case "armeabi-v7a":
+						arch = AndroidTargetArch.Arm;
+						linkerArgs.Add ("-X");
+						elf_arch = "armelf_linux_eabi";
+						break;
+
+					case "arm64":
+					case "arm64-v8a":
+					case "aarch64":
+						arch = AndroidTargetArch.Arm64;
+						linkerArgs.Add ("--fix-cortex-a53-843419");
+						elf_arch = "aarch64linux";
+						break;
+
+					case "x86":
+						arch = AndroidTargetArch.X86;
+						elf_arch = "elf_i386";
+						break;
+
+					case "x86_64":
+						arch = AndroidTargetArch.X86_64;
+						elf_arch = "elf_x86_64";
+						break;
+
+					default:
+						throw new Exception ("Unsupported Android target architecture ABI: " + abi);
+				}
+
+				linkerArgs.Add ("-m");
+				linkerArgs.Add (elf_arch);
+
+				foreach (string file in inputs.ObjectFiles) {
+					linkerArgs.Add (QuoteFileName (file));
+				}
+
+				yield return new Config {
+					LinkerPath = NdkUtil.GetNdkTool (AndroidNdkDirectory, arch, "ld", XABuildConfig.ArchAPILevels [abi]),
+					LinkerOptions = String.Join (" ", linkerArgs),
+					OutputDSO = inputs.OutputDSO,
+				};
+			}
+		}
+
+		InputFiles GatherFilesForABI (string runtimeDSO, string abi, ITaskItem[] objectFiles)
+		{
+			return new InputFiles {
+				OutputDSO = runtimeDSO,
+				ObjectFiles = GetItemsForABI (abi, objectFiles),
+			};
+		}
+
+		List<string> GetItemsForABI (string abi, ITaskItem[] items)
+		{
+			var ret = new List <string> ();
+			foreach (ITaskItem item in items) {
+				if (String.Compare (abi, item.GetMetadata ("abi"), StringComparison.Ordinal) != 0)
+					continue;
+				ret.Add (item.ItemSpec);
+			}
+
+			return ret;
+		}
+
+		void OnOutputData (string linkerName, object sender, DataReceivedEventArgs e)
+		{
+			if (e.Data != null)
+				LogMessage ($"[{linkerName} stdout] {e.Data}");
+		}
+
+		void OnErrorData (string linkerName, object sender, DataReceivedEventArgs e)
+		{
+			if (e.Data != null)
+				LogMessage ($"[{linkerName} stderr] {e.Data}");
+		}
+
+		static string QuoteFileName (string fileName)
+		{
+			var builder = new CommandLineBuilder ();
+			builder.AppendFileNameIfNotNull (fileName);
+			return builder.ToString ();
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using System.Threading;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -16,9 +17,16 @@ namespace Xamarin.Android.Tasks
 {
 	public static class NdkUtil
 	{
+		// We need it to work fine during our tests which are executed at the same time in various threads.
+		[ThreadStatic]
 		static bool usingClangNDK;
 
 		public static bool UsingClangNDK => usingClangNDK;
+
+		public static bool Init (string ndkPath)
+		{
+			return Init (null, ndkPath); // For tests which don't have access to a TaskLoggingHelper
+		}
 
 		public static bool Init (TaskLoggingHelper log, string ndkPath)
 		{
@@ -26,9 +34,11 @@ namespace Xamarin.Android.Tasks
 			bool hasNdkVersion = GetNdkToolchainRelease (ndkPath ?? "", out ndkVersion);
 
 			if (!hasNdkVersion) {
-				log.LogCodedError ("XA5101",
-						"Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, " +
-						"or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.");
+				if (log != null) {
+					log.LogCodedError ("XA5101",
+							   "Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, " +
+							   "or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.");
+				}
 				return false;
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -46,6 +46,8 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void CheckBuildIdIsUnique ()
 		{
+			const string supportedAbis = "armeabi-v7a;x86";
+
 			Dictionary<string, string> buildIds = new Dictionary<string, string> ();
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
@@ -54,8 +56,9 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetProperty (proj.ReleaseProperties, "DebugSymbols", "true");
 			proj.SetProperty (proj.ReleaseProperties, "DebugType", "PdbOnly");
 			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidCreatePackagePerAbi, "true");
-			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidSupportedAbis, "armeabi-v7a;x86");
+			proj.SetProperty (proj.ReleaseProperties, KnownProperties.AndroidSupportedAbis, supportedAbis);
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
+				b.CleanupOnDispose = false;
 				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
 				b.ThrowOnBuildFailure = false;
 				Assert.IsTrue (b.Build (proj), "first build failed");
@@ -67,26 +70,15 @@ namespace Xamarin.Android.Build.Tests
 				//NOTE: Windows is still generating mdb files here
 				extension = IsWindows ? "dll.mdb" : "pdb";
 				Assert.IsTrue (allFilesInArchive.Any (x => Path.GetFileName (x) == $"{proj.ProjectName}.{extension}"), $"{proj.ProjectName}.{extension} should exist in {archivePath}");
-				string javaEnv = Path.Combine (Root, b.ProjectDirectory,
-							       proj.IntermediateOutputPath, "android", "src", "mono", "android", "app", "XamarinAndroidEnvironmentVariables.java");
-				Assert.IsTrue (File.Exists (javaEnv), $"Java environment source does not exist at {javaEnv}");
 
-				string[] lines = File.ReadAllLines (javaEnv);
+				string intermediateOutputDir = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath);
+				List<string> envFiles = EnvironmentHelper.GatherEnvironmentFiles (intermediateOutputDir, supportedAbis, true);
+				Dictionary<string, string> envvars = EnvironmentHelper.ReadEnvironmentVariables (envFiles);
+				Assert.IsTrue (envvars.Count > 0, $"No environment variables defined");
 
-				Assert.IsTrue (lines.Any (x => x.Contains ("\"XAMARIN_BUILD_ID\",")),
-					       "The environment should contain a XAMARIN_BUILD_ID");
-
-				string buildID = lines.First (x => x.Contains ("\"XAMARIN_BUILD_ID\","))
-					.Trim ()
-					.Replace ("\", \"", "=")
-					.Replace ("\",", String.Empty)
-					.Replace ("\"", String.Empty);
+				string buildID;
+				Assert.IsTrue (envvars.TryGetValue ("XAMARIN_BUILD_ID", out buildID), "The environment should contain a XAMARIN_BUILD_ID");
 				buildIds.Add ("all", buildID);
-
-				string dexFile = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "bin", "classes.dex");
-				Assert.IsTrue (File.Exists (dexFile), $"dex file does not exist at {dexFile}");
-				Assert.IsTrue (DexUtils.ContainsClass ("Lmono/android/app/XamarinAndroidEnvironmentVariables;", dexFile, b.AndroidSdkDirectory),
-					       $"dex file {dexFile} does not contain the XamarinAndroidEnvironmentVariables class");
 
 				var msymDirectory = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, proj.PackageName + ".apk.mSYM");
 				Assert.IsTrue (File.Exists (Path.Combine (msymDirectory, "manifest.xml")), "manifest.xml should exist in", msymDirectory);
@@ -98,7 +90,9 @@ namespace Xamarin.Android.Build.Tests
 				var buildId = buildIds.First ().Value;
 				Assert.IsTrue (doc.Element ("mono-debug")
 					.Elements ()
-					.Any (x => x.Name == "build-id" && x.Value == buildId.Replace ("XAMARIN_BUILD_ID=", "")), "build-id is has an incorrect value.");
+					.Any (x => x.Name == "build-id" && x.Value == buildId), "build-id is has an incorrect value.");
+
+				EnvironmentHelper.AssertValidEnvironmentDSO (intermediateOutputDir, AndroidSdkPath, AndroidNdkPath, supportedAbis);
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/EnvironmentHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/EnvironmentHelper.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+using NUnit.Framework;
+using Xamarin.Android.Tasks;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Build.Tests
+{
+	class EnvironmentHelper
+	{
+		static readonly object ndkInitLock = new object ();
+		static readonly char[] readElfFieldSeparator = new [] { ' ', '\t' };
+		static readonly Regex stringLabelRegex = new Regex ("^\\.L\\.str\\.[0-9]+:", RegexOptions.Compiled);
+
+		static readonly HashSet <string> expectedPointerTypes = new HashSet <string> (StringComparer.Ordinal) {
+			".long",
+			".quad",
+			".xword"
+		};
+
+		static readonly string[] requiredDSOSymbols = {
+			"app_environment_variables",
+			"app_system_properties",
+			"application_config",
+			"jm_typemap",
+			"jm_typemap_header",
+			"mj_typemap",
+			"mj_typemap_header",
+			"mono_aot_mode_name",
+		};
+
+		// Reads all the environment files, makes sure they contain the same environment variables (both count
+		// and contents) and then returns a dictionary filled with the variables.
+		public static Dictionary<string, string> ReadEnvironmentVariables (List<string> envFilePaths)
+		{
+			if (envFilePaths.Count == 0)
+				return null;
+
+			Dictionary<string, string> envvars = ReadEnvironmentVariables (envFilePaths [0]);
+			if (envFilePaths.Count == 1)
+				return envvars;
+
+			for (int i = 1; i < envFilePaths.Count; i++) {
+				AssertDictionariesAreEqual (envvars, envFilePaths [0], ReadEnvironmentVariables (envFilePaths[i]), envFilePaths[i]);
+			}
+
+			return envvars;
+		}
+
+		static Dictionary<string, string> ReadEnvironmentVariables (string envFile)
+		{
+			string[] lines = File.ReadAllLines (envFile, Encoding.UTF8);
+			var strings = new Dictionary<string, string> (StringComparer.Ordinal);
+			var pointers = new List <string> ();
+
+			bool gatherPointers = false;
+			for (int i = 0; i < lines.Length; i++) {
+				string[] field;
+				string line = lines [i];
+				if (stringLabelRegex.IsMatch (line)) {
+					string label = line.Substring (0, line.Length - 1);
+
+					line = lines [++i];
+					field = GetField (envFile, line, i);
+
+					AssertFieldType (envFile, ".asciz", field [0], i);
+					strings [label] = AssertIsAssemblerString (envFile, field [1], i);
+					continue;
+				}
+
+				if (String.Compare ("app_environment_variables:", line.Trim (), StringComparison.Ordinal) == 0) {
+					gatherPointers = true;
+					continue;
+				}
+
+				if (!gatherPointers)
+					continue;
+
+				field = GetField (envFile, line, i);
+				if (String.Compare (".size", field [0], StringComparison.Ordinal) == 0) {
+					Assert.IsTrue (field [1].StartsWith ("app_environment_variables", StringComparison.Ordinal), $"Mismatched .size directive in '{envFile}:{i}'");
+					break; // We've reached the end of the environment variable array
+				}
+
+				Assert.IsTrue (expectedPointerTypes.Contains (field [0]), $"Unexpected pointer field type in '{envFile}:{i}': {field [0]}");
+				pointers.Add (field [1].Trim ());
+			}
+
+			var ret = new Dictionary <string, string> (StringComparer.Ordinal);
+			if (pointers.Count == 0)
+				return ret;
+
+			Assert.IsTrue (pointers.Count % 2 == 0, "Environment variable array must have an even number of elements");
+			for (int i = 0; i < pointers.Count; i += 2) {
+				string name;
+
+				Assert.IsTrue (strings.TryGetValue (pointers [i], out name), $"[name] String with label '{pointers [i]}' not found in '{envFile}'");
+				Assert.IsFalse (String.IsNullOrEmpty (name), $"Environment variable name must not be null or empty in {envFile} for string label '{pointers [i]}'");
+
+				string value;
+				Assert.IsTrue (strings.TryGetValue (pointers [i + 1], out value), $"[value] String with label '{pointers [i + 1]}' not found in '{envFile}'");
+				Assert.IsNotNull (value, $"Environnment variable value must not be null in '{envFile}' for string label '{pointers [i + 1]}'");
+
+				ret [name] = value;
+			}
+
+			return ret;
+		}
+
+		static string[] GetField (string file, string line, int lineNumber)
+		{
+			string[] ret = line?.Trim ()?.Split ('\t');
+			Assert.AreEqual (2, ret.Length, $"Invalid assembler field format in file '{file}:{lineNumber}': '{line}'");
+
+			return ret;
+		}
+
+		static void AssertFieldType (string file, string expectedType, string value, int lineNumber)
+		{
+			Assert.AreEqual (expectedType, value, $"Expected the '{expectedType}' field type in file '{file}:{lineNumber}': {value}");
+		}
+
+		static string AssertIsAssemblerString (string file, string value, int lineNumber)
+		{
+			string v = value.Trim ();
+			Assert.IsTrue (v.StartsWith ("\"") && v.EndsWith("\""), $"Field value is not a valid assembler string in '{file}:{lineNumber}': {v}");
+			return v.Trim ('"');
+		}
+
+		static void AssertDictionariesAreEqual (Dictionary <string, string> d1, string d1FileName, Dictionary <string, string> d2, string d2FileName)
+		{
+			Assert.AreEqual (d1.Count, d2.Count, $"File '{d2FileName}' has a different number of environment variables than file '{d2FileName}'");
+
+			foreach (var kvp in d1) {
+				string value;
+
+				Assert.IsTrue (d2.TryGetValue (kvp.Key, out value), $"File '{d2FileName}' does not contain environment variable '{kvp.Key}'");
+				Assert.AreEqual (kvp.Value, value, $"Value of environnment variable '{kvp.Key}' is different in file '{d2FileName}' than in file '{d1FileName}'");
+			}
+		}
+
+		public static List<string> GatherEnvironmentFiles (string outputDirectoryRoot, string supportedAbis, bool required)
+		{
+			var environmentFiles = new List <string> ();
+
+			foreach (string abi in supportedAbis.Split (';')) {
+				string envFilePath = Path.Combine (outputDirectoryRoot, "android", $"environment.{abi}.s");
+
+				Assert.IsTrue (File.Exists (envFilePath), $"Environment file {envFilePath} does not exist");
+				environmentFiles.Add (envFilePath);
+			}
+
+			if (required)
+				Assert.AreNotEqual (0, environmentFiles.Count, "No environment files found");
+
+			return environmentFiles;
+		}
+
+		public static void AssertValidEnvironmentDSO (string outputDirectoryRoot, string sdkDirectory, string ndkDirectory, string supportedAbis)
+		{
+			NdkUtil.Init (ndkDirectory);
+			MonoAndroidHelper.AndroidSdk = new AndroidSdkInfo ((arg1, arg2) => {}, sdkDirectory, ndkDirectory);
+
+			AndroidTargetArch arch;
+
+			foreach (string abi in supportedAbis.Split (';')) {
+				switch (abi) {
+					case "armeabi-v7a":
+						arch = AndroidTargetArch.Arm;
+						break;
+
+					case "arm64":
+					case "arm64-v8a":
+					case "aarch64":
+						arch = AndroidTargetArch.Arm64;
+						break;
+
+					case "x86":
+						arch = AndroidTargetArch.X86;
+						break;
+
+					case "x86_64":
+						arch = AndroidTargetArch.X86_64;
+						break;
+
+					default:
+						throw new Exception ("Unsupported Android target architecture ABI: " + abi);
+				}
+
+				string envDSO = Path.Combine (outputDirectoryRoot, "app_dsos", abi, "libxamarin-app.so");
+				Assert.IsTrue (File.Exists (envDSO), $"Application environment DSO '{envDSO}' must exist");
+
+				// API level doesn't matter in this case
+				AssertDSOHasRequiredSymbols (envDSO, NdkUtil.GetNdkTool (ndkDirectory, arch, "readelf", 0));
+			}
+		}
+
+		static void AssertDSOHasRequiredSymbols (string dsoPath, string readElfPath)
+		{
+			var psi = new ProcessStartInfo {
+				FileName = readElfPath,
+				Arguments = $"--dyn-syms \"{dsoPath}\"",
+				CreateNoWindow = true,
+				WindowStyle = ProcessWindowStyle.Hidden,
+				UseShellExecute = false,
+				RedirectStandardError = true,
+				RedirectStandardOutput = true,
+			};
+
+			psi.StandardOutputEncoding = Encoding.UTF8;
+			psi.StandardErrorEncoding = Encoding.UTF8;
+
+			var stdout_completed = new ManualResetEventSlim (false);
+			var stderr_completed = new ManualResetEventSlim (false);
+			var stdout_lines = new List <string> ();
+			var stderr_lines = new List <string> ();
+
+			using (var process = new Process ()) {
+				process.StartInfo = psi;
+				process.OutputDataReceived += (s, e) => {
+					if (e.Data != null)
+						stdout_lines.Add (e.Data);
+					else
+						stdout_completed.Set ();
+				};
+
+				process.ErrorDataReceived += (s, e) => {
+					if (e.Data != null)
+						stderr_lines.Add (e.Data);
+					else
+						stderr_completed.Set ();
+				};
+
+				process.Start ();
+				process.BeginOutputReadLine ();
+				process.BeginErrorReadLine ();
+				bool exited = process.WaitForExit ((int)TimeSpan.FromSeconds (60).TotalMilliseconds);
+				bool stdout_done = stdout_completed.Wait (TimeSpan.FromSeconds (30));
+				bool stderr_done = stderr_completed.Wait (TimeSpan.FromSeconds (30));
+
+				if (!exited)
+					TestContext.Out.WriteLine ($"{psi.FileName} {psi.Arguments} timed out");
+				if (process.ExitCode != 0)
+					TestContext.Out.WriteLine ($"{psi.FileName} {psi.Arguments} returned with error code {process.ExitCode}");
+
+				if (!exited || process.ExitCode != 0) {
+					DumpLines ("stdout", stdout_lines);
+					DumpLines ("stderr", stderr_lines);
+					Assert.Fail ($"Failed to validate application environment DSO '{dsoPath}'");
+				}
+			}
+
+			var symbols = new HashSet<string> (StringComparer.Ordinal);
+			foreach (string line in stdout_lines) {
+				string[] fields = line.Split (readElfFieldSeparator, StringSplitOptions.RemoveEmptyEntries);
+				if (fields.Length < 8 || !fields [0].EndsWith (":", StringComparison.Ordinal))
+					continue;
+				string symbolName = fields [7].Trim ();
+				if (String.IsNullOrEmpty (symbolName))
+					continue;
+
+				symbols.Add (symbolName);
+			}
+
+			foreach (string symbol in requiredDSOSymbols) {
+				Assert.IsTrue (symbols.Contains (symbol), $"Symbol '{symbol}' is missing from '{dsoPath}'");
+			}
+		}
+
+		static void DumpLines (string streamName, List <string> lines)
+		{
+			if (lines == null || lines.Count == 0)
+				return;
+
+			TestContext.Out.WriteLine ($"{streamName}:");
+			foreach (string line in lines) {
+				TestContext.Out.WriteLine (line);
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
@@ -22,5 +22,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\FilesTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\MockBuildEngine.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\MonoAndroidHelperTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\EnvironmentHelper.cs" />
   </ItemGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ARMNativeAssemblerTargetProvider.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ARMNativeAssemblerTargetProvider.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+
+namespace Xamarin.Android.Tasks
+{
+	class ARMNativeAssemblerTargetProvider : NativeAssemblerTargetProvider
+	{
+		public override bool Is64Bit { get; }
+		public override string PointerFieldType { get; }
+		public override string TypePrefix { get; }
+
+		public ARMNativeAssemblerTargetProvider (bool is64Bit)
+		{
+			Is64Bit = is64Bit;
+			PointerFieldType = is64Bit ? ".xword" : ".long";
+			TypePrefix = is64Bit ? "@" : "%";
+		}
+
+		public override string MapType <T> ()
+		{
+			if (typeof(T) == typeof(Int32) || typeof(T) == typeof(UInt32))
+				return Is64Bit ? ".word" : ".long";
+			return base.MapType <T> ();
+		}
+
+		public override void WriteFileHeader (StreamWriter output, string indent)
+		{
+			output.Write ($"{indent}.arch{indent}");
+			output.WriteLine (Is64Bit ? "armv8-a" : "armv7-a");
+
+			if (!Is64Bit) {
+				output.WriteLine ($"{indent}.syntax unified");
+				output.WriteLine ($"{indent}.eabi_attribute 67, \"2.09\"{indent}@ Tag_conformance");
+				output.WriteLine ($"{indent}.eabi_attribute 6, 10{indent}@ Tag_CPU_arch");
+				output.WriteLine ($"{indent}.eabi_attribute 7, 65{indent}@ Tag_CPU_arch_profile");
+				output.WriteLine ($"{indent}.eabi_attribute 8, 1{indent}@ Tag_ARM_ISA_use");
+				output.WriteLine ($"{indent}.eabi_attribute 9, 2{indent}@ Tag_THUMB_ISA_use");
+				output.WriteLine ($"{indent}.fpu{indent}vfpv3-d16");
+				output.WriteLine ($"{indent}.eabi_attribute 34, 1{indent}@ Tag_CPU_unaligned_access");
+				output.WriteLine ($"{indent}.eabi_attribute 15, 1{indent}@ Tag_ABI_PCS_RW_data");
+				output.WriteLine ($"{indent}.eabi_attribute 16, 1{indent}@ Tag_ABI_PCS_RO_data");
+				output.WriteLine ($"{indent}.eabi_attribute 17, 2{indent}@ Tag_ABI_PCS_GOT_use");
+				output.WriteLine ($"{indent}.eabi_attribute 20, 2{indent}@ Tag_ABI_FP_denormal");
+				output.WriteLine ($"{indent}.eabi_attribute 21, 0{indent}@ Tag_ABI_FP_exceptions");
+				output.WriteLine ($"{indent}.eabi_attribute 23, 3{indent}@ Tag_ABI_FP_number_model");
+				output.WriteLine ($"{indent}.eabi_attribute 24, 1{indent}@ Tag_ABI_align_needed");
+				output.WriteLine ($"{indent}.eabi_attribute 25, 1{indent}@ Tag_ABI_align_preserved");
+				output.WriteLine ($"{indent}.eabi_attribute 38, 1{indent}@ Tag_ABI_FP_16bit_format");
+				output.WriteLine ($"{indent}.eabi_attribute 18, 4{indent}@ Tag_ABI_PCS_wchar_t");
+				output.WriteLine ($"{indent}.eabi_attribute 26, 2{indent}@ Tag_ABI_enum_size");
+				output.WriteLine ($"{indent}.eabi_attribute 14, 0{indent}@ Tag_ABI_PCS_R9_use");
+			}
+
+			base.WriteFileHeader (output, indent);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGenerator.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Xamarin.Android.Tasks
+{
+	class ApplicationConfigNativeAssemblyGenerator : NativeAssemblyGenerator
+	{
+		SortedDictionary <string, string> environmentVariables;
+		SortedDictionary <string, string> systemProperties;
+		uint stringCounter = 0;
+
+		public bool IsBundledApp { get; set; }
+		public bool UsesEmbeddedDSOs { get; set; }
+		public bool UsesMonoAOT { get; set; }
+		public bool UsesMonoLLVM { get; set; }
+		public string MonoAOTMode { get; set; }
+		public string AndroidPackageName { get; set; }
+
+		public ApplicationConfigNativeAssemblyGenerator (NativeAssemblerTargetProvider targetProvider, IDictionary<string, string> environmentVariables, IDictionary<string, string> systemProperties)
+			: base (targetProvider)
+		{
+			if (environmentVariables != null)
+				this.environmentVariables = new SortedDictionary<string, string> (environmentVariables, StringComparer.Ordinal);
+			if (systemProperties != null)
+				this.systemProperties = new SortedDictionary<string, string> (systemProperties, StringComparer.Ordinal);
+		}
+
+		protected override void WriteSymbols (StreamWriter output)
+		{
+			if (String.IsNullOrEmpty (AndroidPackageName))
+				throw new InvalidOperationException ("Android package name must be set");
+
+			if (UsesMonoAOT && String.IsNullOrEmpty (MonoAOTMode))
+				throw new InvalidOperationException ("Mono AOT enabled but no AOT mode specified");
+
+			string stringLabel = GetStringLabel ();
+			WriteData (output, AndroidPackageName, stringLabel);
+
+			WriteDataSection (output, "application_config");
+			WriteSymbol (output, "application_config", TargetProvider.GetStructureAlignment (true), isGlobal: true, alwaysWriteSize: true, structureWriter: () => {
+				uint size = WriteData (output, UsesMonoLLVM);
+				size += WriteData (output, UsesMonoAOT);
+				size += WriteData (output, UsesEmbeddedDSOs);
+				size += WriteData (output, IsBundledApp);
+				size += WriteData (output, environmentVariables == null ? 0 : environmentVariables.Count);
+				size += WritePointer (output, stringLabel);
+
+				return size;
+			});
+
+			WriteData (output, MonoAOTMode ?? String.Empty, "mono_aot_mode_name", isGlobal: true);
+			WriteNameValueStringArray (output, "app_environment_variables", environmentVariables);
+			WriteNameValueStringArray (output, "app_system_properties", systemProperties);
+		}
+
+		void WriteNameValueStringArray (StreamWriter output, string label, SortedDictionary<string, string> entries)
+		{
+			if (entries == null || entries.Count == 0) {
+				WriteDataSection (output, label);
+				WriteSymbol (output, label, TargetProvider.GetStructureAlignment (true), isGlobal: true, alwaysWriteSize: true, structureWriter: null);
+				return;
+			}
+
+			var entry_labels = new List <string> ();
+			foreach (var kvp in entries) {
+				string name = kvp.Key;
+				string value = kvp.Value;
+				string stringLabel = GetStringLabel ();
+				WriteData (output, name, stringLabel);
+				entry_labels.Add (stringLabel);
+
+				stringLabel = GetStringLabel ();
+				WriteData (output, value, stringLabel);
+				entry_labels.Add (stringLabel);
+
+			}
+
+			WriteDataSection (output, label);
+			WriteSymbol (output, label, TargetProvider.GetStructureAlignment (true), isGlobal: true, alwaysWriteSize: true, structureWriter: () => {
+				uint size = 0;
+
+				foreach (string l in entry_labels) {
+					size += WritePointer (output, l);
+				}
+
+				return size;
+			});
+		}
+
+		void WriteDataSection (StreamWriter output, string tag)
+		{
+			WriteSection (output, $".data.{tag}", hasStrings: false, writable: true);
+		}
+
+		string GetStringLabel ()
+		{
+			stringCounter++;
+			return $".L.str.{stringCounter}";
+		}
+	};
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NativeAssemblerTargetProvider.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NativeAssemblerTargetProvider.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO;
+
+namespace Xamarin.Android.Tasks
+{
+	abstract class NativeAssemblerTargetProvider
+	{
+		public abstract bool Is64Bit { get; }
+		public abstract string PointerFieldType { get; }
+		public abstract string TypePrefix { get; }
+
+		public virtual string MapType <T> ()
+		{
+			if (typeof(T) == typeof(byte))
+				return ".byte";
+
+			if (typeof(T) == typeof(bool))
+				return ".byte";
+
+			if (typeof(T) == typeof(string))
+				return ".asciz";
+
+			throw new InvalidOperationException ($"Unable to map managed type {typeof(T)} to native assembly type");
+		}
+
+		public virtual uint GetTypeSize <T> (T field)
+		{
+			return GetTypeSize <T> ();
+		}
+
+		public virtual uint GetTypeSize <T> ()
+		{
+			if (typeof(T) == typeof(byte))
+				return 1u;
+
+			if (typeof(T) == typeof(bool))
+				return 1u;
+
+			if (typeof(T) == typeof(string))
+				return GetPointerSize();
+
+			if (typeof(T) == typeof(Int32) || typeof(T) == typeof(UInt32))
+				return 4u;
+
+			if (typeof(T) == typeof(Int64) || typeof(T) == typeof(UInt64))
+				return 8u;
+
+			throw new InvalidOperationException ($"Unable to map managed type {typeof(T)} to native assembly type");
+		}
+
+		public virtual uint GetStructureAlignment (bool hasPointers)
+		{
+			return (!hasPointers || !Is64Bit) ? 2u : 3u;
+		}
+
+		public virtual uint GetPointerSize ()
+		{
+			return Is64Bit ? 8u : 4u;
+		}
+
+		public virtual void WriteFileHeader (StreamWriter output, string indent)
+		{
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NativeAssemblyDataStream.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NativeAssemblyDataStream.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.IO;
+using System.Text;
+
+namespace Xamarin.Android.Tasks
+{
+	class NativeAssemblyDataStream : Stream
+	{
+		const uint MapVersionFound     = 0x0001;
+		const uint MapEntryCountFound  = 0x0002;
+		const uint MapEntryLengthFound = 0x0004;
+		const uint MapValueOffsetFound = 0x0008;
+		const uint MapEverythingFound  = MapVersionFound | MapEntryCountFound | MapEntryLengthFound | MapValueOffsetFound;
+
+		const string MapFieldVersion     = "version";
+		const string MapFieldEntryCount  = "entry-count";
+		const string MapFieldEntryLength = "entry-len";
+		const string MapFieldValueOffset = "value-offset";
+
+		const uint MaxFieldsInRow = 32;
+
+		MemoryStream outputStream;
+		StreamWriter outputWriter;
+		bool firstWrite = true;
+		uint rowFieldCounter;
+		SHA1CryptoServiceProvider sha1;
+		bool hashingFinished;
+		uint byteCount = 0;
+
+		public int MapVersion     { get; set; } = -1;
+		public int MapEntryCount  { get; set; } = -1;
+		public int MapEntryLength { get; set; } = -1;
+		public int MapValueOffset { get; set; } = -1;
+		public uint MapByteCount => byteCount;
+
+		public override bool CanRead => outputStream.CanRead;
+		public override bool CanSeek => outputStream.CanSeek;
+		public override bool CanWrite => outputStream.CanWrite;
+		public override long Length => outputStream.Length;
+
+		public override long Position {
+			get => outputStream.Position;
+			set => outputStream.Position = value;
+		}
+
+		public NativeAssemblyDataStream ()
+		{
+			outputStream = new MemoryStream ();
+			outputWriter = new StreamWriter (outputStream, new UTF8Encoding (false));
+			sha1 = new SHA1CryptoServiceProvider ();
+			sha1.Initialize ();
+		}
+
+		public byte[] GetStreamHash ()
+		{
+			if (!hashingFinished) {
+				sha1.TransformFinalBlock (new byte[0], 0, 0);
+				hashingFinished = true;
+			}
+
+			return sha1.Hash;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			base.Dispose (disposing);
+			if (!disposing)
+				return;
+
+			outputWriter.Dispose ();
+			outputWriter = null;
+			outputStream = null;
+		}
+
+		public override void Flush ()
+		{
+			outputWriter.Flush ();
+			outputStream.Flush ();
+		}
+
+		public override int Read (byte[] buffer, int offset, int count)
+		{
+			return outputStream.Read (buffer, offset, count);
+		}
+
+		public override long Seek (long offset, SeekOrigin origin)
+		{
+			return outputStream.Seek (offset, origin);
+		}
+
+		public override void SetLength (long value)
+		{
+			outputStream.SetLength (value);
+		}
+
+		public override void Write (byte[] buffer, int offset, int count)
+		{
+			if (buffer == null)
+				throw new ArgumentNullException (nameof (buffer));
+			if (offset < 0)
+				throw new ArgumentOutOfRangeException (nameof (offset));
+			if (count < 0)
+				throw new ArgumentOutOfRangeException (nameof (count));
+			if (offset + count > buffer.Length)
+				throw new ArgumentException ($"The sum of the '{nameof (offset)}' and '{nameof (count)}' arguments is greater than the buffer length");
+			if (outputWriter == null)
+				throw new ObjectDisposedException (this.GetType ().Name);
+
+			if (!hashingFinished)
+				sha1.TransformBlock (buffer, offset, count, null, 0);
+
+			if (firstWrite) {
+				// Kind of a backward thing to do, but I wanted to avoid having to modfy (and bump the
+				// submodule of) Java.Interop. This should be Safe Enough™ (until it's not)
+				string line = Encoding.UTF8.GetString (buffer, offset, count);
+
+				// Format used by Java.Interop.Tools.JavaCallableWrappers.TypeNameMapGenerator:
+				//
+				//  "version=1\u0000entry-count={0}\u0000entry-len={1}\u0000value-offset={2}\u0000"
+				//
+				string[] parts = line.Split ('\u0000');
+				if (parts.Length != 5)
+					HeaderFormatError ("invalid number of fields");
+
+				// Let's be just slightly flexible :P
+				uint foundMask = 0;
+				foreach (string p in parts) {
+					string field = p.Trim ();
+					if (String.IsNullOrEmpty (field))
+						continue;
+
+					string[] fieldParts = field.Split(new char[]{'='}, 2);
+					if (fieldParts.Length != 2)
+						HeaderFormatError ($"invalid field format '{field}'");
+
+					switch (fieldParts [0]) {
+						case MapFieldVersion:
+							foundMask |= MapVersionFound;
+							MapVersion = GetHeaderInteger (fieldParts[0], fieldParts [1]);
+							break;
+
+						case MapFieldEntryCount:
+							foundMask |= MapEntryCountFound;
+							MapEntryCount = GetHeaderInteger (fieldParts[0], fieldParts [1]);
+							break;
+
+						case MapFieldEntryLength:
+							foundMask |= MapEntryLengthFound;
+							MapEntryLength = GetHeaderInteger (fieldParts[0], fieldParts [1]);
+							break;
+
+						case MapFieldValueOffset:
+							foundMask |= MapValueOffsetFound;
+							MapValueOffset = GetHeaderInteger (fieldParts[0], fieldParts [1]);
+							break;
+
+						default:
+							HeaderFormatError ($"unknown field '{fieldParts [0]}'");
+							break;
+					}
+				}
+
+				if (foundMask != MapEverythingFound) {
+					var missingFields = new List <string> ();
+					if ((foundMask & MapVersionFound) == 0)
+						missingFields.Add (MapFieldVersion);
+					if ((foundMask & MapEntryCountFound) == 0)
+						missingFields.Add (MapFieldEntryCount);
+					if ((foundMask & MapEntryLengthFound) == 0)
+						missingFields.Add (MapFieldEntryLength);
+					if ((foundMask & MapValueOffsetFound) == 0)
+						missingFields.Add (MapFieldValueOffset);
+
+					var sb = new StringBuilder ("missing header field");
+					if (missingFields.Count > 1)
+						sb.Append ('s');
+					sb.Append (": ");
+					sb.Append (String.Join (", ", missingFields));
+					HeaderFormatError (sb.ToString ());
+				}
+
+				firstWrite = false;
+				rowFieldCounter = 0;
+				return;
+			}
+
+			for (int i = 0; i < count; i++) {
+				byteCount++;
+				if (rowFieldCounter == 0)
+					outputWriter.Write ("\t.byte ");
+
+				byte b = buffer [offset + i];
+				if (rowFieldCounter > 0)
+					outputWriter.Write (", ");
+				outputWriter.Write ($"0x{b:x02}");
+
+				rowFieldCounter++;
+				if (rowFieldCounter > MaxFieldsInRow) {
+					rowFieldCounter = 0;
+					outputWriter.WriteLine ();
+				}
+			}
+
+			void HeaderFormatError (string whatsWrong)
+			{
+				throw new InvalidOperationException ($"Java.Interop.Tools.JavaCallableWrappers.TypeNameMapGenerator header format changed: {whatsWrong}");
+			}
+
+			int GetHeaderInteger (string name, string value)
+			{
+				int ret;
+				if (!Int32.TryParse (value, out ret))
+					HeaderFormatError ($"failed to parse integer value from '{value}' for field '{name}'");
+				return ret;
+			}
+		}
+	};
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NativeAssemblyGenerator.cs
@@ -1,0 +1,195 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace Xamarin.Android.Tasks
+{
+	abstract class NativeAssemblyGenerator
+	{
+		protected string Indent { get; } = "\t";
+		protected NativeAssemblerTargetProvider TargetProvider { get; }
+
+		protected NativeAssemblyGenerator (NativeAssemblerTargetProvider targetProvider)
+		{
+			if (targetProvider == null)
+				throw new ArgumentNullException (nameof (targetProvider));
+			TargetProvider = targetProvider;
+		}
+
+		public void Write (StreamWriter output, string outputFileName)
+		{
+			if (output == null)
+				throw new ArgumentNullException (nameof (output));
+
+			WriteFileHeader (output, outputFileName);
+			WriteSymbols (output);
+			output.Flush ();
+		}
+
+		protected virtual void WriteSymbols (StreamWriter output)
+		{
+		}
+
+		protected string HashToHex (byte[] dataHash)
+		{
+			var sb = new StringBuilder ();
+			foreach (byte b in dataHash)
+				sb.Append ($"{b:x02}");
+			return sb.ToString ();
+		}
+
+		protected void WriteEndLine (StreamWriter output, string comment = null, bool indent = true)
+		{
+			if (!String.IsNullOrEmpty (comment)) {
+				if (indent)
+					output.Write (Indent);
+				WriteComment (output, comment);
+			}
+			output.WriteLine ();
+		}
+
+		protected void WriteComment (StreamWriter output, string comment, bool indent = true)
+		{
+			output.Write ($"{(indent ? Indent : String.Empty)}/* {comment} */");
+		}
+
+		protected void WriteCommentLine (StreamWriter output, string comment, bool indent = true)
+		{
+			WriteComment (output, comment);
+			output.WriteLine ();
+		}
+
+		protected virtual void WriteFileHeader (StreamWriter output, string outputFileName)
+		{
+			TargetProvider.WriteFileHeader (output, Indent);
+			output.WriteLine ($"{Indent}.file{Indent}\"{Path.GetFileName (outputFileName)}\"");
+		}
+
+		protected virtual void WriteSection (StreamWriter output, string sectionName, bool hasStrings, bool writable)
+		{
+			output.Write ($"{Indent}.section{Indent}{sectionName},\"a"); // a - section is allocatable
+			if (hasStrings)
+				output.Write ("MS"); // M - section is mergeable, S - section contains zero-terminated strings
+			else if (writable)
+				output.Write ("w");
+
+			output.Write ($"\",{TargetProvider.TypePrefix}progbits");
+			if (hasStrings)
+				output.Write (",1");
+			output.WriteLine ();
+		}
+
+		// `alignBits` indicates the number of lowest bits that have to be cleared to 0 in order to align the
+		// following data structure, thus `2` would mean "align to 4 bytes", `3' would be "align to 8 bytes"
+		// etc. In general, if the data field contains a pointer the alignment should be to the platform's
+		// native pointer size, if not it should be 2 (for 4-byte alignment) in the case of the targets we
+		// support. Alignment is not necessary for standalone fields (i.e. not parts of a structure)
+		protected void WriteSymbol <T> (StreamWriter output, T symbolValue, string symbolName, ulong size, uint alignBits, bool isGlobal, bool isObject, bool alwaysWriteSize)
+		{
+			WriteSymbol (output, TargetProvider.MapType<T>(), QuoteValue (symbolValue), symbolName, size, alignBits, isGlobal, isObject, alwaysWriteSize);
+		}
+
+		protected void WriteSymbol (StreamWriter output, string symbolType, string symbolValue, string symbolName, ulong size, uint alignBits, bool isGlobal, bool isObject, bool alwaysWriteSize)
+		{
+			if (isObject)
+				output.WriteLine ($"{Indent}.type{Indent}{symbolName}, {TargetProvider.TypePrefix}object");
+			if (alignBits > 0)
+				output.WriteLine ($"{Indent}.p2align{Indent}{alignBits}");
+			if (isGlobal)
+				output.WriteLine ($"{Indent}.global{Indent}{symbolName}");
+			if (!String.IsNullOrEmpty (symbolName))
+				output.WriteLine ($"{symbolName}:");
+			if (!String.IsNullOrEmpty (symbolType) && !String.IsNullOrEmpty (symbolValue))
+				output.WriteLine ($"{Indent}{symbolType}{Indent}{symbolValue}");
+			if (alwaysWriteSize || size > 0)
+				output.WriteLine ($"{Indent}.size{Indent}{symbolName}, {size}");
+		}
+
+		protected void WriteSymbol (StreamWriter output, string label, uint size, bool isGlobal, bool isObject, bool alwaysWriteSize)
+		{
+			WriteSymbol (output, null, null, label, size, alignBits: 0, isGlobal: isGlobal, isObject: isObject, alwaysWriteSize: alwaysWriteSize);
+		}
+
+		protected void WriteSymbol (StreamWriter output, string symbolName, uint alignBits, bool isGlobal, bool alwaysWriteSize, Func<uint> structureWriter)
+		{
+			output.WriteLine ($"{Indent}.type{Indent}{symbolName}, {TargetProvider.TypePrefix}object");
+			if (alignBits > 0)
+				output.WriteLine ($"{Indent}.p2align{Indent}{alignBits}");
+			if (isGlobal)
+				output.WriteLine ($"{Indent}.global{Indent}{symbolName}");
+			if (!String.IsNullOrEmpty (symbolName))
+				output.WriteLine ($"{symbolName}:");
+
+			uint size = structureWriter != null ? structureWriter () : 0u;
+			if (alwaysWriteSize || size > 0)
+				output.WriteLine ($"{Indent}.size{Indent}{symbolName}, {size}");
+		}
+
+		protected virtual string QuoteValue <T> (T value)
+		{
+			if (typeof(T) == typeof(string))
+				return $"\"{value}\"";
+
+			if (typeof(T) == typeof(bool))
+				return (bool)((object)value) ? "1" : "0";
+
+			return $"{value}";
+		}
+
+		protected uint WritePointer (StreamWriter output, string targetName, string label = null, bool isGlobal = false)
+		{
+			if (String.IsNullOrEmpty (targetName))
+				throw new ArgumentException ("must not be null or empty", nameof (targetName));
+			WriteSymbol (output, TargetProvider.PointerFieldType, targetName, label, size: 0, alignBits: 0, isGlobal: isGlobal, isObject: false, alwaysWriteSize: false);
+			return TargetProvider.GetPointerSize ();
+		}
+
+		protected uint WriteData (StreamWriter output, string value, string label, bool isGlobal = false)
+		{
+			if (String.IsNullOrEmpty (label))
+				throw new ArgumentException ("must not be null or empty", nameof (label));
+			if (value == null)
+				value = String.Empty;
+
+			WriteSection (output, $".rodata.{label}", hasStrings: true, writable: false);
+			WriteSymbol (output, value, label, size: (ulong)(value.Length + 1), alignBits: 0, isGlobal: isGlobal, isObject: true, alwaysWriteSize: true);
+			return TargetProvider.GetTypeSize (value);
+		}
+
+		protected uint WriteData (StreamWriter output, byte value, string label = null, bool isGlobal = false)
+		{
+			WriteSymbol (output, value, label, size: 0, alignBits: 0, isGlobal: isGlobal, isObject: false, alwaysWriteSize: false);
+			return TargetProvider.GetTypeSize (value);
+		}
+
+		protected uint WriteData (StreamWriter output, Int32 value, string label = null, bool isGlobal = false)
+		{
+			WriteSymbol (output, value, label, size: 0, alignBits: 0, isGlobal: isGlobal, isObject: false, alwaysWriteSize: false);
+			return TargetProvider.GetTypeSize (value);
+		}
+
+		protected uint WriteData (StreamWriter output, UInt32 value, string label = null, bool isGlobal = false)
+		{
+			WriteSymbol (output, value, label, size: 0, alignBits: 0, isGlobal: isGlobal, isObject: false, alwaysWriteSize: false);
+			return TargetProvider.GetTypeSize (value);
+		}
+
+		protected uint WriteData (StreamWriter output, Int64 value, string label = null, bool isGlobal = false)
+		{
+			WriteSymbol (output, value, label, size: 0, alignBits: 0, isGlobal: isGlobal, isObject: false, alwaysWriteSize: false);
+			return TargetProvider.GetTypeSize (value);
+		}
+
+		protected uint WriteData (StreamWriter output, UInt64 value, string label = null, bool isGlobal = false)
+		{
+			WriteSymbol (output, value, label, size: 0, alignBits: 0, isGlobal: isGlobal, isObject: false, alwaysWriteSize: false);
+			return TargetProvider.GetTypeSize (value);
+		}
+
+		protected uint WriteData (StreamWriter output, bool value, string label = null, bool isGlobal = false)
+		{
+			WriteSymbol (output, value, label, size: 0, alignBits: 0, isGlobal: isGlobal, isObject: false, alwaysWriteSize: false);
+			return TargetProvider.GetTypeSize (value);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingNativeAssemblyGenerator.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace Xamarin.Android.Tasks
+{
+	class TypeMappingNativeAssemblyGenerator : NativeAssemblyGenerator
+	{
+		NativeAssemblyDataStream dataStream;
+		string dataFileName;
+		uint dataSize;
+		string mappingFieldName;
+
+		public TypeMappingNativeAssemblyGenerator (NativeAssemblerTargetProvider targetProvider, NativeAssemblyDataStream dataStream, string dataFileName, uint dataSize, string mappingFieldName)
+			: base (targetProvider)
+		{
+			if (dataStream == null)
+				throw new ArgumentNullException (nameof (dataStream));
+			if (String.IsNullOrEmpty (dataFileName))
+				throw new ArgumentException ("must not be null or empty", nameof (dataFileName));
+			if (String.IsNullOrEmpty (mappingFieldName))
+				throw new ArgumentException ("must not be null or empty", nameof (mappingFieldName));
+
+			this.dataStream = dataStream;
+			this.dataFileName = dataFileName;
+			this.dataSize = dataSize;
+			this.mappingFieldName = mappingFieldName;
+		}
+
+		protected override void WriteFileHeader (StreamWriter output, string outputFileName)
+		{
+			// The hash is written to make sure the assembly file which includes the data one is
+			// actually different whenever the data changes. Relying on mapping header values for this
+			// purpose would not be enough since the only change to the mapping might be a single-character
+			// change in one of the type names and we must be sure the assembly is rebuilt in all cases,
+			// thus the SHA1.
+			WriteEndLine (output, $"Data SHA1: {HashToHex (dataStream.GetStreamHash ())}", false);
+			base.WriteFileHeader (output, outputFileName);
+		}
+
+		protected override void WriteSymbols (StreamWriter output)
+		{
+			WriteMappingHeader (output, dataStream, mappingFieldName);
+			WriteCommentLine (output, "Mapping data");
+			WriteSymbol (output, mappingFieldName, dataSize, isGlobal: true, isObject: true, alwaysWriteSize: true);
+			output.WriteLine ($"{Indent}.include{Indent}\"{dataFileName}\"");
+		}
+
+		void WriteMappingHeader (StreamWriter output, NativeAssemblyDataStream dataStream, string mappingFieldName)
+		{
+			output.WriteLine ();
+			WriteCommentLine (output, "Mapping header");
+			WriteSection (output, $".data.{mappingFieldName}", hasStrings: false, writable: true);
+			WriteSymbol (output, $"{mappingFieldName}_header", alignBits: 2, isGlobal: true, alwaysWriteSize: true, structureWriter: () => {
+				WriteCommentLine (output, "version");
+				WriteData (output, dataStream.MapVersion);
+
+				WriteCommentLine (output, "entry-count");
+				WriteData (output, dataStream.MapEntryCount);
+
+				WriteCommentLine (output, "entry-length");
+				WriteData (output, dataStream.MapEntryLength);
+
+				WriteCommentLine (output, "value-offset");
+				WriteData (output, dataStream.MapValueOffset);
+				return 16;
+			});
+			output.WriteLine ();
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/X86NativeAssemblerTargetProvider.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/X86NativeAssemblerTargetProvider.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Xamarin.Android.Tasks
+{
+	class X86NativeAssemblerTargetProvider : NativeAssemblerTargetProvider
+	{
+		public override bool Is64Bit { get; }
+		public override string PointerFieldType { get; }
+		public override string TypePrefix { get; } = "@";
+
+		public X86NativeAssemblerTargetProvider (bool is64Bit)
+		{
+			Is64Bit = is64Bit;
+			PointerFieldType = is64Bit ? ".quad" : ".long";
+		}
+
+		public override string MapType <T> ()
+		{
+			if (typeof(T) == typeof(Int32) || typeof(T) == typeof(UInt32))
+				return ".long";
+			return base.MapType <T> ();
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -588,6 +588,15 @@
     <Compile Include="Tasks\LayoutWidget.cs" />
     <Compile Include="Tasks\CancelableTask.cs" />
     <Compile Include="..\..\bin\Build$(Configuration)\XABuildConfig.cs" />
+    <Compile Include="Utilities\NativeAssemblyDataStream.cs" />
+    <Compile Include="Utilities\NativeAssemblyGenerator.cs" />
+    <Compile Include="Utilities\NativeAssemblerTargetProvider.cs" />
+    <Compile Include="Utilities\ARMNativeAssemblerTargetProvider.cs" />
+    <Compile Include="Utilities\X86NativeAssemblerTargetProvider.cs" />
+    <Compile Include="Utilities\TypeMappingNativeAssemblyGenerator.cs" />
+    <Compile Include="Utilities\ApplicationConfigNativeAssemblyGenerator.cs" />
+    <Compile Include="Tasks\CompileNativeAssembly.cs" />
+    <Compile Include="Tasks\LinkApplicationDSOs.cs" />
     <None Include="Resources\desugar_deploy.jar">
       <Link>desugar_deploy.jar</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -694,9 +703,6 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Resources\ResourcePatcher.java">
       <LogicalName>ResourcePatcher.java</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Resources\XamarinAndroidEnvironmentVariables.java">
-      <LogicalName>XamarinAndroidEnvironmentVariables.java</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -9,6 +9,7 @@
     <_SharedRuntimeBuildPath Condition=" '$(_SharedRuntimeBuildPath)' == '' ">$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\</_SharedRuntimeBuildPath>
     <_GeneratedProfileClass>$(MSBuildThisFileDirectory)$(IntermediateOutputPath)Profile.g.cs</_GeneratedProfileClass>
     <BuildDependsOn>
+      _CopyNDKTools;
       _GenerateXACommonProps;
       $(BuildDependsOn);
       _CopyExtractedMultiDexJar;
@@ -120,6 +121,43 @@
     <_SharedRuntimeAssemblies Include="$(_SharedRuntimeBuildPath)$(AndroidFrameworkVersion)\OpenTK.dll" />
     <_SharedRuntimeAssemblies Include="$(_SharedRuntimeBuildPath)$(AndroidFrameworkVersion)\OpenTK-1.0.dll" />
   </ItemGroup>
+  <Target Name="_PrepareNDKToolsItems">
+    <PropertyGroup>
+      <_PrebuiltToolchainDir Condition=" '$(HostOS)' == 'Linux' ">linux-x86_64</_PrebuiltToolchainDir>
+      <_PrebuiltToolchainDir Condition=" '$(HostOS)' == 'Darwin' ">darwin-x86_64</_PrebuiltToolchainDir>
+      <_PrebuiltToolchainDir Condition=" '$(HostOS)' == 'Windows' And '$(HostBits)' == '64' ">windows-x86_64</_PrebuiltToolchainDir>
+      <_PrebuiltToolchainDir Condition=" '$(HostOS)' == 'Windows' And '$(HostBits)' == '32' ">windows</_PrebuiltToolchainDir>
+    </PropertyGroup>
+    <ItemGroup>
+      <_ToolchainPrefix Include="aarch64-linux-android">
+        <ToolPrefix>aarch64-linux-android</ToolPrefix>
+      </_ToolchainPrefix>
+      <_ToolchainPrefix Include="arm-linux-androideabi">
+        <ToolPrefix>arm-linux-androideabi</ToolPrefix>
+      </_ToolchainPrefix>
+      <_ToolchainPrefix Include="x86">
+        <ToolPrefix>i686-linux-android</ToolPrefix>
+      </_ToolchainPrefix>
+      <_ToolchainPrefix Include="x86_64">
+        <ToolPrefix>x86_64-linux-android</ToolPrefix>
+      </_ToolchainPrefix>
+    </ItemGroup>
+    <ItemGroup>
+      <_NDKToolSource Include="$(AndroidNdkFullPath)/toolchains/%(_ToolchainPrefix.Identity)-4.9/prebuilt/$(_PrebuiltToolchainDir)/bin/%(_ToolchainPrefix.ToolPrefix)-as" />
+      <_NDKToolDestination Include="$(XAInstallPrefix)xbuild\Xamarin\Android\$(HostOS)\%(_ToolchainPrefix.ToolPrefix)-as" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_CopyNDKTools"
+          DependsOnTargets="_PrepareNDKToolsItems"
+          Inputs="@(_NDKToolSource)"
+          Outputs="@(_NDKToolDestination)">
+    <Copy
+        SourceFiles="@(_NDKToolSource)"
+        DestinationFiles="@(_NDKToolDestination)"
+    />
+  </Target>
+
   <Target Name="_GenerateMonoAndroidEnums"
       BeforeTargets="CoreCompile"
       Inputs="..\Mono.Android\obj\$(Configuration)\android-$(AndroidLatestStableApiLevel)\mcw\api.xml"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -103,6 +103,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.Proguard" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.DetermineJavaLibrariesToCompile" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CreateMultiDexMainDexClassList" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.CompileNativeAssembly" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.LinkApplicationDSOs" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 
 <!--
 *******************************************
@@ -274,6 +276,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<_AndroidLibraryFlatArchivesDirectory>$(IntermediateOutputPath)flata\</_AndroidLibraryFlatArchivesDirectory>
 	<_AndroidStampDirectory>$(IntermediateOutputPath)stamp\</_AndroidStampDirectory>
 	<_AndroidBuildIdFile>$(IntermediateOutputPath)buildid.txt</_AndroidBuildIdFile>
+        <_AndroidApplicationDSOPath>$(IntermediateOutputPath)app_dsos\</_AndroidApplicationDSOPath>
 	<_ResolvedUserAssembliesHashFile>$(IntermediateOutputPath)resolvedassemblies.hash</_ResolvedUserAssembliesHashFile>
 
 	<!-- $(EnableProguard) is an obsolete property that should be removed at some stage. -->
@@ -317,6 +320,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<_AndroidDesignTimeBuildPropertiesCache>$(_AndroidIntermediateDesignTimeBuildDirectory)build.props</_AndroidDesignTimeBuildPropertiesCache>
 	<AndroidGenerateJniMarshalMethods Condition=" '$(AndroidGenerateJniMarshalMethods)' == '' ">False</AndroidGenerateJniMarshalMethods>
 	<AndroidMakeBundleKeepTemporaryFiles Condition=" '$(AndroidMakeBundleKeepTemporaryFiles)' == '' ">False</AndroidMakeBundleKeepTemporaryFiles>
+        <_NativeAssemblySourceDir>$(IntermediateOutputPath)android\</_NativeAssemblySourceDir>
 </PropertyGroup>
 
 <Choose>
@@ -2302,10 +2306,22 @@ because xbuild doesn't support framework reference assemblies.
   </CreateItem>
 </Target>
 
+<Target Name="_PrepareNativeAssemblySources">
+  <ItemGroup>
+    <_BuiltAbis Include="$(_BuildTargetAbis)" />
+    <_TypeMapAssemblySource Include="$(_NativeAssemblySourceDir)typemap.jm.%(_BuiltAbis.Identity).s">
+      <abi>%(_BuiltAbis.Identity)</abi>
+    </_TypeMapAssemblySource>
+    <_TypeMapAssemblySource Include="$(_NativeAssemblySourceDir)typemap.mj.%(_BuiltAbis.Identity).s">
+      <abi>%(_BuiltAbis.Identity)</abi>
+    </_TypeMapAssemblySource>
+  </ItemGroup>
+</Target>
+
 <Target Name="_GenerateJavaStubs"
-  DependsOnTargets="_SetLatestTargetFrameworkVersion;_PrepareAssemblies;$(_AfterPrepareAssemblies)"
+  DependsOnTargets="_SetLatestTargetFrameworkVersion;_PrepareAssemblies;$(_AfterPrepareAssemblies);_PrepareNativeAssemblySources"
   Inputs="$(MSBuildAllProjects);@(_ResolvedAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(_AndroidResourceDest)"
-  Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
+  Outputs="@(_TypeMapAssemblySource);$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
   <GenerateJavaStubs
     ResolvedAssemblies="@(_ResolvedAssemblies)"
     ResolvedUserAssemblies="@(_ResolvedUserMonoAndroidAssemblies)"
@@ -2330,8 +2346,8 @@ because xbuild doesn't support framework reference assemblies.
 	ApplicationJavaClass="$(AndroidApplicationJavaClass)"
 	FrameworkDirectories="$(_XATargetFrameworkDirectories);$(_XATargetFrameworkDirectories)Facades"
 	AcwMapFile="$(_AcwMapFile)"
-	CacheFile="$(IntermediateOutputPath)javastubs.cache">
-  </GenerateJavaStubs>
+	CacheFile="$(IntermediateOutputPath)javastubs.cache"
+	SupportedAbis="$(_BuildTargetAbis)"/>
   <ConvertCustomView
 	Condition="Exists('$(_CustomViewMapFile)')"
 	CustomViewMapFile="$(_CustomViewMapFile)"
@@ -2386,17 +2402,26 @@ because xbuild doesn't support framework reference assemblies.
   </GetAddOnPlatformLibraries>
 </Target>
 
+<Target Name="_PrepareEnvironmentAssemblySources">
+  <ItemGroup>
+    <_BuiltAbis Include="$(_BuildTargetAbis)" />
+    <_EnvironmentAssemblySource Include="$(_NativeAssemblySourceDir)environment.%(_BuiltAbis.Identity).s">
+      <abi>%(_BuiltAbis.Identity)</abi>
+    </_EnvironmentAssemblySource>
+  </ItemGroup>
+</Target>
+
 <Target Name="_GeneratePackageManagerJava"
-  DependsOnTargets="_GetAddOnPlatformLibraries;_AddStaticResources;$(_AfterAddStaticResources);_PrepareAssemblies"
+  DependsOnTargets="_GetAddOnPlatformLibraries;_AddStaticResources;$(_AfterAddStaticResources);_PrepareAssemblies;_PrepareEnvironmentAssemblySources"
   Inputs="$(MSBuildAllProjects);$(_ResolvedUserAssembliesHashFile);$(MSBuildProjectFile);$(_AndroidBuildPropertiesCache)"
-  Outputs="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp">
+  Outputs="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp;@(_EnvironmentAssemblySource)">
   <!-- Create java needed for Mono runtime -->
   <GeneratePackageManagerJava
     ResolvedAssemblies="@(_ResolvedAssemblies)"
     ResolvedUserAssemblies="@(_ResolvedUserAssemblies)"
     MainAssembly="$(MonoAndroidLinkerInputDir)$(TargetFileName)"
     OutputDirectory="$(IntermediateOutputPath)android\src\mono"
-    EnvironmentOutputDirectory="$(IntermediateOutputPath)android\src\mono\android\app"
+    EnvironmentOutputDirectory="$(IntermediateOutputPath)android"
     UseSharedRuntime="$(AndroidUseSharedRuntime)"
     TargetFrameworkVersion="$(TargetFrameworkVersion)" 
     Manifest="$(IntermediateOutputPath)android\AndroidManifest.xml"
@@ -2408,6 +2433,9 @@ because xbuild doesn't support framework reference assemblies.
     Debug="$(AndroidIncludeDebugSymbols)"
     AndroidSequencePointsMode="$(_SequencePointsMode)"
     EnableSGenConcurrent="$(AndroidEnableSGenConcurrent)"
+    IsBundledApplication="$(BundleAssemblies)"
+    SupportedAbis="$(_BuildTargetAbis)"
+    AndroidPackageName="$(_AndroidPackage)"
   >
     <Output TaskParameter="BuildId" PropertyName="_XamarinBuildId" />
   </GeneratePackageManagerJava>
@@ -2848,6 +2876,56 @@ because xbuild doesn't support framework reference assemblies.
 	</ItemGroup>
 </Target>
 
+<Target Name="_PrepareNativeAssemblyItems">
+  <ItemGroup>
+    <_NativeAssemblyTarget Include="@(_TypeMapAssemblySource->Replace('.s', '.o'))">
+      <abi>%(_TypeMapAssemblySource.abi)</abi>
+    </_NativeAssemblyTarget>
+    <_NativeAssemblyTarget Include="@(_EnvironmentAssemblySource->Replace('.s', '.o'))">
+      <abi>%(_EnvironmentAssemblySource.abi)</abi>
+    </_NativeAssemblyTarget>
+  </ItemGroup>
+</Target>
+
+<Target Name="_CompileNativeAssemblySources"
+        DependsOnTargets="_PrepareNativeAssemblyItems"
+        Inputs="@(_TypeMapAssemblySource);@(_EnvironmentAssemblySource)"
+        Outputs="@(_NativeAssemblyTarget)">
+        <CompileNativeAssembly
+            Sources="@(_TypeMapAssemblySource);@(_EnvironmentAssemblySource)"
+            DebugBuild="$(AndroidIncludeDebugSymbols)"
+            WorkingDirectory="$(_NativeAssemblySourceDir)"/>
+</Target>
+
+<Target Name="_PrepareApplicationDSOItems">
+  <ItemGroup>
+    <_XARuntimeArchitecture Include="$(_Android32bitArchitectures)"/>
+    <_XARuntimeArchitecture Include="$(_Android64bitArchitectures)"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <_ApplicationDSO Include="$(_AndroidApplicationDSOPath)%(_XARuntimeArchitecture.Identity)\libxamarin-app.so"
+                     Condition=" $(_BuildTargetAbis.Contains ('%(_XARuntimeArchitecture.Identity)')) ">
+      <abi>%(_XARuntimeArchitecture.Identity)</abi>
+    </_ApplicationDSO>
+  </ItemGroup>
+</Target>
+
+<Target Name="_CreateApplicationDSOs"
+        DependsOnTargets="_CompileNativeAssemblySources;_PrepareApplicationDSOItems"
+        Inputs="@(_NativeAssemblyTarget)"
+        Outputs="@(_ApplicationDSO)">
+        <LinkApplicationDSOs
+            ObjectFiles="@(_NativeAssemblyTarget)"
+            ApplicationDSOs="@(_ApplicationDSO)"
+            DebugBuild="$(AndroidIncludeDebugSymbols)"
+            AndroidNdkDirectory="$(_AndroidNdkDirectory)"
+            />
+  <ItemGroup>
+    <FileWrites Include="@(_ApplicationDSO)" />
+  </ItemGroup>
+</Target>
+
 <PropertyGroup>
 	<_PrepareBuildApkDependsOnTargets>
 		_SetLatestTargetFrameworkVersion;
@@ -2864,7 +2942,8 @@ because xbuild doesn't support framework reference assemblies.
 		_CreateBaseApk;
 		_PrepareAssemblies;
 		_ResolveSatellitePaths;
-		_CheckApkPerAbiFlag
+		_CheckApkPerAbiFlag;
+		_CreateApplicationDSOs;
 		;_LintChecks
 		;_IncludeNativeSystemLibraries
 	</_PrepareBuildApkDependsOnTargets>
@@ -2934,6 +3013,7 @@ because xbuild doesn't support framework reference assemblies.
  	<Output TaskParameter="OutputNativeLibraries" PropertyName="_BundleResultNativeLibraries" />
   </MakeBundleNativeCodeExternal>
   <!-- Put the assemblies and native libraries in the apk -->
+  <!--    TypeMappings="$(_AndroidTypeMappingJavaToManaged);$(_AndroidTypeMappingManagedToJava)" -->
   <BuildApk
     AndroidNdkDirectory="$(_AndroidNdkDirectory)"
     ApkInputPath="$(_PackagedResources)"
@@ -2944,6 +3024,7 @@ because xbuild doesn't support framework reference assemblies.
     ResolvedUserAssemblies="@(_ResolvedUserAssemblies);@(_AndroidResolvedSatellitePaths)"
     ResolvedFrameworkAssemblies="@(_ShrunkFrameworkAssemblies)"
     NativeLibraries="@(AndroidNativeLibrary)"
+    ApplicationDSOs="@(_ApplicationDSO)"
     AdditionalNativeLibraryReferences="@(_AdditionalNativeLibraryReferences)"
     EmbeddedNativeLibraryAssemblies="$(OutDir)$(TargetFileName);@(ReferencePath);@(ReferenceDependencyPaths)"
     DalvikClasses="@(_DexFile)"
@@ -2952,7 +3033,6 @@ because xbuild doesn't support framework reference assemblies.
     UseSharedRuntime="$(AndroidUseSharedRuntime)"
     Debug="$(AndroidIncludeDebugSymbols)"
     PreferNativeLibrariesWithDebugSymbols="$(AndroidPreferNativeLibrariesWithDebugSymbols)"
-    TypeMappings="$(_AndroidTypeMappingJavaToManaged);$(_AndroidTypeMappingManagedToJava)"
     JavaSourceFiles="@(AndroidJavaSource)"
     JavaLibraries="@(AndroidJavaLibrary)"
     AndroidSequencePointsMode="$(_SequencePointsMode)"

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -223,6 +223,13 @@ if(UNIX)
     )
 endif()
 
+set(XAMARIN_APP_STUB_SOURCES ${SOURCES_DIR}/application_dso_stub.cc)
+add_library(xamarin-app SHARED ${XAMARIN_APP_STUB_SOURCES})
+set_target_properties(xamarin-app
+  PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+  )
+
 set(SOURCES_FRAGMENT_FILE "sources.projitems")
 file(WRITE ${SOURCES_FRAGMENT_FILE} "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n\
 <Project xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">\n\
@@ -247,4 +254,4 @@ elseif(NOT ANDROID)
   set(LINK_LIBS "-pthread ${LINK_LIBS} -ldl")
 endif()
 
-target_link_libraries(${MONO_ANDROID_LIB} ${LINK_LIBS})
+target_link_libraries(${MONO_ANDROID_LIB} ${LINK_LIBS} xamarin-app)

--- a/src/monodroid/jni/android-system.cc
+++ b/src/monodroid/jni/android-system.cc
@@ -1,9 +1,11 @@
 #include <limits.h>
 #include <string.h>
+#include <stdlib.h>
 #include <errno.h>
 #include <assert.h>
 #include <ctype.h>
 #include <dlfcn.h>
+#include <fcntl.h>
 
 #ifdef ANDROID
 #include <sys/system_properties.h>
@@ -24,20 +26,27 @@
 #include "monodroid.h"
 #include "monodroid-glue-internal.h"
 #include "jni-wrappers.h"
+#include "typemap.h"
 
+#if defined (DEBUG) || !defined (ANDROID)
 namespace xamarin { namespace android { namespace internal {
 	struct BundledProperty {
-		char *name;
-		char *value;
-		int   value_len;
+		char     *name;
+		char     *value;
+		uint32_t  value_len;
 		struct BundledProperty *next;
 	};
 }}}
+#endif // DEBUG || !ANDROID
 
 using namespace xamarin::android;
 using namespace xamarin::android::internal;
 
+#if defined (DEBUG) || !defined (ANDROID)
 BundledProperty *AndroidSystem::bundled_properties = nullptr;
+constexpr char AndroidSystem::OVERRIDE_ENVIRONMENT_FILE_NAME[];
+#endif // DEBUG || !ANDROID
+
 char* AndroidSystem::override_dirs [MAX_OVERRIDES];
 const char **AndroidSystem::app_lib_directories;
 size_t AndroidSystem::app_lib_directories_size = 0;
@@ -70,6 +79,7 @@ static constexpr uint32_t PROP_NAME_MAX = 32;
 static constexpr uint32_t PROP_VALUE_MAX = 92;
 #endif
 
+#if defined (DEBUG) || !defined (ANDROID)
 BundledProperty*
 AndroidSystem::lookup_system_property (const char *name)
 {
@@ -79,7 +89,34 @@ AndroidSystem::lookup_system_property (const char *name)
 			return p;
 	return nullptr;
 }
+#endif // DEBUG || !ANDROID
 
+const char*
+AndroidSystem::lookup_system_property (const char *name, uint32_t &value_len)
+{
+	value_len = 0;
+#if defined (DEBUG) || !defined (ANDROID)
+	BundledProperty *p = lookup_system_property (name);
+	if (p != nullptr) {
+		value_len = p->value_len;
+		return p->name;
+	}
+#endif // DEBUG || !ANDROID
+
+	if (application_config.system_property_count == 0)
+		return nullptr;
+
+	for (uint32_t i = 0; i < application_config.system_property_count; i++) {
+		if (strcmp (app_system_properties [i], name) == 0) {
+			value_len = strlen (app_system_properties [i]);
+			return app_system_properties [i];
+		}
+	}
+
+	return nullptr;
+}
+
+#if defined (DEBUG) || !defined (ANDROID)
 void
 AndroidSystem::add_system_property (const char *name, const char *value)
 {
@@ -114,6 +151,7 @@ AndroidSystem::add_system_property (const char *name, const char *value)
 	p->next             = bundled_properties;
 	bundled_properties  = p;
 }
+#endif // DEBUG || !ANDROID
 
 #ifndef ANDROID
 void
@@ -187,10 +225,13 @@ AndroidSystem::monodroid_get_system_property (const char *name, char **value)
 	char *pvalue = sp_value;
 	int len = _monodroid__system_property_get (name, sp_value, sizeof (sp_value));
 
-	BundledProperty *p;
-	if (len <= 0 && (p = lookup_system_property (name)) != nullptr) {
-		pvalue  = p->value;
-		len     = p->value_len;
+	if (len <= 0) {
+		uint32_t plen;
+		const char *v = lookup_system_property (name, plen);
+		if (v != nullptr) {
+			pvalue  = const_cast<char*> (v);
+			len     = static_cast<int> (plen);
+		}
 	}
 
 	if (len >= 0 && value) {
@@ -225,6 +266,7 @@ AndroidSystem::monodroid_read_file_into_memory (const char *path, char **value)
 	return r;
 }
 
+#if defined (DEBUG) || !defined (ANDROID)
 int
 AndroidSystem::_monodroid_get_system_property_from_file (const char *path, char **value)
 {
@@ -262,10 +304,12 @@ AndroidSystem::_monodroid_get_system_property_from_file (const char *path, char 
 	}
 	return len;
 }
+#endif
 
 int
 AndroidSystem::monodroid_get_system_property_from_overrides (const char *name, char ** value)
 {
+#if defined (DEBUG) || !defined (ANDROID)
 	int result = -1;
 
 	for (size_t oi = 0; oi < MAX_OVERRIDES; ++oi) {
@@ -281,6 +325,7 @@ AndroidSystem::monodroid_get_system_property_from_overrides (const char *name, c
 			return result;
 		}
 	}
+#endif
 	return 0;
 }
 
@@ -718,85 +763,156 @@ AndroidSystem::get_gref_gc_threshold ()
 	return static_cast<int> ((max_gref_count * 90LL) / 100LL);
 }
 
+#if defined (DEBUG) || !defined (ANDROID)
 void
-AndroidSystem::setup_environment (jstring_wrapper& name, jstring_wrapper& value)
+AndroidSystem::setup_environment (const char *name, const char *value)
 {
-	const char *k = name.get_cstr ();
-
-	if (k == nullptr || *k == '\0')
+	if (name == nullptr || *name == '\0')
 		return;
 
-	const char *v = value.get_cstr ();
-	if (v == nullptr || *v == '\0')
+	const char *v = value;
+	if (v == nullptr)
 		v = "";
 
-	if (isupper (k [0]) || k [0] == '_') {
-		if (k [0] == '_') {
-			if (strcmp (k, "__XA_DSO_IN_APK") == 0) {
-				knownEnvVars.DSOInApk = true;
-				return;
-			}
-		}
-
-		setenv (k, v, 1);
+	if (isupper (name [0]) || name [0] == '_') {
+		setenv (name, v, 1);
 		return;
 	}
 
-	if (k [0] == 'm') {
-		if (strcmp (k, "mono.aot") == 0) {
-			if (*v == '\0') {
-				knownEnvVars.MonoAOT = MonoAotMode::MONO_AOT_MODE_NONE;
-				return;
-			}
-
-			switch (v [0]) {
-				case 'n':
-					knownEnvVars.MonoAOT = MonoAotMode::MONO_AOT_MODE_NORMAL;
-					break;
-
-				case 'h':
-					knownEnvVars.MonoAOT = MonoAotMode::MONO_AOT_MODE_HYBRID;
-					break;
-
-				case 'f':
-					knownEnvVars.MonoAOT = MonoAotMode::MONO_AOT_MODE_FULL;
-					break;
-
-				default:
-					knownEnvVars.MonoAOT = MonoAotMode::MONO_AOT_MODE_UNKNOWN;
-					break;
-			}
-
-			if (knownEnvVars.MonoAOT != MonoAotMode::MONO_AOT_MODE_UNKNOWN)
-				log_info (LOG_DEFAULT, "Mono AOT mode: %s", v);
-			else
-				log_warn (LOG_DEFAULT, "Unknown Mono AOT mode: %s", v);
-
-			return;
-		}
-
-		if (strcmp (k, "mono.llvm") == 0) {
-			knownEnvVars.MonoLLVM = true;
-			return;
-		}
-	}
-
-	add_system_property (k, v);
+	add_system_property (name, v);
 }
 
 void
-AndroidSystem::setup_environment (JNIEnv *env, jobjectArray environmentVariables)
+AndroidSystem::setup_environment_from_override_file (const char *path)
 {
-	jsize envvarsLength = env->GetArrayLength (environmentVariables);
-	if (envvarsLength == 0)
+	monodroid_stat_t sbuf;
+	if (utils.monodroid_stat (path, &sbuf) < 0) {
+		log_warn (LOG_DEFAULT, "Failed to stat the environment override file %s: %s", path, strerror (errno));
+		return;
+	}
+
+	int fd = open (path, O_RDONLY);
+	if (fd < 0) {
+		log_warn (LOG_DEFAULT, "Failed to open the environment override file %s: %s", path, strerror (errno));
+		return;
+	}
+
+	char    *buf = new char [sbuf.st_size];
+	ssize_t  nread = read (fd, buf, sbuf.st_size);
+	if (nread < 0) {
+		log_warn (LOG_DEFAULT, "Failed to read the environment override file %s: %s", path, strerror (errno));
+		delete[] buf;
+		return;
+	}
+
+	// The file format is as follows (no newlines are used, this is just for illustration
+	// purposes, comments aren't part of the file either):
+	//
+	// # 10 ASCII characters formattted as a C++ hexadecimal number terminated with NUL: name
+	// # width (including the terminating NUL)
+	// 0x00000000\0
+	//
+	// # 10 ASCII characters formattted as a C++ hexadecimal number terminated with NUL: value
+	// # width (including the terminating NUL)
+	// 0x00000000\0
+	//
+	// # Variable name, terminated with NUL and padded to [name width] with NUL characters
+	// name\0
+	//
+	// # Variable value, terminated with NUL and padded to [value width] with NUL characters
+	// value\0
+	if (nread < OVERRIDE_ENVIRONMENT_FILE_HEADER_SIZE) {
+		log_warn (LOG_DEFAULT, "Invalid format of the environment override file %s: malformatted header", path);
+		delete[] buf;
+		return;
+	}
+
+	char *endptr;
+	unsigned long name_width = strtoul (buf, &endptr, 16);
+	if ((name_width == ULONG_MAX && errno == ERANGE) || (*buf != '\0' && *endptr != '\0')) {
+		log_warn (LOG_DEFAULT, "Malformed header of the environment override file %s: name width has invalid format", path);
+		delete[] buf;
+		return;
+	}
+
+	unsigned long value_width = strtoul (buf + 11, &endptr, 16);
+	if ((value_width == ULONG_MAX && errno == ERANGE) || (*buf != '\0' && *endptr != '\0')) {
+		log_warn (LOG_DEFAULT, "Malformed header of the environment override file %s: value width has invalid format", path);
+		delete[] buf;
+		return;
+	}
+
+	uint64_t data_width = name_width + value_width;
+	if (data_width > sbuf.st_size - OVERRIDE_ENVIRONMENT_FILE_HEADER_SIZE || (sbuf.st_size - OVERRIDE_ENVIRONMENT_FILE_HEADER_SIZE) % data_width != 0) {
+		log_warn (LOG_DEFAULT, "Malformed environment override file %s: invalid data size", path);
+		delete[] buf;
+		return;
+	}
+
+	uint64_t data_size = sbuf.st_size;
+	char *name = buf + OVERRIDE_ENVIRONMENT_FILE_HEADER_SIZE;
+	while (data_size > 0 && data_size >= data_width) {
+		if (*name == '\0') {
+			log_warn (LOG_DEFAULT, "Malformed environment override file %s: name at offset %lu is empty", path, name - buf);
+			delete[] buf;
+			return;
+		}
+
+		log_debug (LOG_DEFAULT, "Setting environment variable from the override file %s: '%s' = '%s'", path, name, name + name_width);
+		setup_environment (name, name + name_width);
+		name += data_width;
+		data_size -= data_width;
+	}
+
+	delete[] buf;
+
+}
+#endif // DEBUG || !ANDROID
+
+void
+AndroidSystem::setup_environment ()
+{
+	if (application_config.uses_mono_aot) {
+		switch (mono_aot_mode_name [0]) {
+			case 'n':
+				aotMode = MonoAotMode::MONO_AOT_MODE_NORMAL;
+				break;
+
+			case 'h':
+				aotMode = MonoAotMode::MONO_AOT_MODE_HYBRID;
+				break;
+
+			case 'f':
+				aotMode = MonoAotMode::MONO_AOT_MODE_FULL;
+				break;
+
+			default:
+				aotMode = MonoAotMode::MONO_AOT_MODE_UNKNOWN;
+				break;
+		}
+
+		if (aotMode != MonoAotMode::MONO_AOT_MODE_UNKNOWN)
+			log_info (LOG_DEFAULT, "Mono AOT mode: %s", mono_aot_mode_name);
+		else
+			log_warn (LOG_DEFAULT, "Unknown Mono AOT mode: %s", mono_aot_mode_name);
+	}
+
+	if (application_config.environment_variable_count == 0)
 		return;
 
-	jstring_wrapper name (env), value (env);
-	for (jsize i = 0; (i + 1) < envvarsLength; i += 2) {
-		name = reinterpret_cast<jstring> (env->GetObjectArrayElement (environmentVariables, i));
-		value = reinterpret_cast<jstring> (env->GetObjectArrayElement (environmentVariables, i + 1));
-		setup_environment (name, value);
+	for (size_t i = 0; i < application_config.environment_variable_count; i++) {
+		setenv (app_environment_variables [i], app_environment_variables [i + 1], 1);
 	}
+#if defined (DEBUG) || !defined (ANDROID)
+	// TODO: for debug read from file in the override directory named `environment`
+	for (size_t oi = 0; oi < MAX_OVERRIDES; oi++) {
+		char *env_override_file = utils.path_combine (override_dirs [oi], OVERRIDE_ENVIRONMENT_FILE_NAME);
+		if (utils.file_exists (env_override_file)) {
+			setup_environment_from_override_file (env_override_file);
+		}
+		delete[] env_override_file;
+	}
+#endif
 }
 
 void

--- a/src/monodroid/jni/application_dso_stub.cc
+++ b/src/monodroid/jni/application_dso_stub.cc
@@ -1,0 +1,24 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "typemap.h"
+
+TypeMapHeader jm_typemap_header = { 1, 2, 3, 4 };
+uint8_t jm_typemap[] = { 0 };
+
+TypeMapHeader mj_typemap_header = { 1, 2, 3, 4 };
+uint8_t mj_typemap[] = { 0 };
+
+ApplicationConfig application_config = {
+	.uses_mono_llvm = false,
+	.uses_mono_aot = false,
+	.uses_embedded_dsos = false,
+	.is_a_bundled_app = false,
+	.environment_variable_count = 0,
+	.system_property_count = 0,
+	.android_package_name = "com.xamarin.test",
+};
+
+const char* mono_aot_mode_name = "";
+const char* app_environment_variables[] = {};
+const char* app_system_properties[] = {};

--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -19,8 +19,10 @@ extern "C" {
 #include "embedded-assemblies.h"
 #include "globals.h"
 #include "monodroid-glue.h"
+#include "typemap.h"
 
 namespace xamarin { namespace android { namespace internal {
+#if defined (DEBUG) || !defined (ANDROID)
 	struct TypeMappingInfo {
 		char                     *source_apk;
 		char                     *source_entry;
@@ -30,6 +32,7 @@ namespace xamarin { namespace android { namespace internal {
 		const   char             *mapping;
 		TypeMappingInfo          *next;
 	};
+#endif // DEBUG || !ANDROID
 
 	struct md_mmap_info {
 		void   *area;
@@ -47,8 +50,9 @@ const char *EmbeddedAssemblies::suffixes[] = {
 };
 
 constexpr char EmbeddedAssemblies::assemblies_prefix[];
+#if defined (DEBUG) || !defined (ANDROID)
 constexpr char EmbeddedAssemblies::override_typemap_entry_name[];
-
+#endif
 
 void EmbeddedAssemblies::set_assemblies_prefix (const char *prefix)
 {
@@ -132,8 +136,18 @@ EmbeddedAssemblies::TypeMappingInfo_compare_key (const void *a, const void *b)
 }
 
 inline const char*
+EmbeddedAssemblies::find_entry_in_type_map (const char *name, uint8_t map[], TypeMapHeader& header)
+{
+	const char *e = reinterpret_cast<const char*> (bsearch (name, map, header.entry_count, header.entry_length, TypeMappingInfo_compare_key ));
+	if (e == nullptr)
+		return nullptr;
+	return e + header.value_offset;
+}
+
+inline const char*
 EmbeddedAssemblies::typemap_java_to_managed (const char *java)
 {
+#if defined (DEBUG) || !defined (ANDROID)
 	for (TypeMappingInfo *info = java_to_managed_maps; info != nullptr; info = info->next) {
 		/* log_warn (LOG_DEFAULT, "# jonp: checking file: %s!%s for type '%s'", info->source_apk, info->source_entry, java); */
 		const char *e = reinterpret_cast<const char*> (bsearch (java, info->mapping, info->num_entries, info->entry_length, TypeMappingInfo_compare_key));
@@ -141,12 +155,14 @@ EmbeddedAssemblies::typemap_java_to_managed (const char *java)
 			continue;
 		return e + info->value_offset;
 	}
-	return nullptr;
+#endif
+	return find_entry_in_type_map (java, jm_typemap, jm_typemap_header);
 }
 
 inline const char*
 EmbeddedAssemblies::typemap_managed_to_java (const char *managed)
 {
+#if defined (DEBUG) || !defined (ANDROID)
 	for (TypeMappingInfo *info = managed_to_java_maps; info != nullptr; info = info->next) {
 		/* log_warn (LOG_DEFAULT, "# jonp: checking file: %s!%s for type '%s'", info->source_apk, info->source_entry, managed); */
 		const char *e = reinterpret_cast <const char*> (bsearch (managed, info->mapping, info->num_entries, info->entry_length, TypeMappingInfo_compare_key));
@@ -154,7 +170,8 @@ EmbeddedAssemblies::typemap_managed_to_java (const char *managed)
 			continue;
 		return e + info->value_offset;
 	}
-	return nullptr;
+#endif
+	return find_entry_in_type_map (managed, mj_typemap, mj_typemap_header);
 }
 
 MONO_API const char *
@@ -169,6 +186,7 @@ monodroid_typemap_managed_to_java (const char *managed)
 	return embeddedAssemblies.typemap_managed_to_java (managed);
 }
 
+#if defined (DEBUG) || !defined (ANDROID)
 void
 EmbeddedAssemblies::extract_int (const char **header, const char *source_apk, const char *source_entry, const char *key_name, int *value)
 {
@@ -235,6 +253,7 @@ EmbeddedAssemblies::add_type_mapping (TypeMappingInfo **info, const char *source
 	}
 	return true;
 }
+#endif // DEBUG || !ANDROID
 
 md_mmap_info
 EmbeddedAssemblies::md_mmap_apk_file (int fd, uLong offset, uLong size, const char* filename, const char* apk)
@@ -381,17 +400,6 @@ EmbeddedAssemblies::gather_bundled_assemblies_from_apk (const char* apk, monodro
 				continue;
 			}
 
-			if (utils.ends_with (cur_entry_name, ".jm")) {
-				md_mmap_info map_info   = md_mmap_apk_file (fd, offset, info.uncompressed_size, cur_entry_name, apk);
-				add_type_mapping (&java_to_managed_maps, apk, cur_entry_name, (const char*)map_info.area);
-				continue;
-			}
-			if (utils.ends_with (cur_entry_name, ".mj")) {
-				md_mmap_info map_info   = md_mmap_apk_file (fd, offset, info.uncompressed_size, cur_entry_name, apk);
-				add_type_mapping (&managed_to_java_maps, apk, cur_entry_name, (const char*)map_info.area);
-				continue;
-			}
-
 			const char *prefix = get_assemblies_prefix();
 			if (strncmp (prefix, cur_entry_name, strlen (prefix)) != 0)
 				continue;
@@ -469,6 +477,7 @@ EmbeddedAssemblies::gather_bundled_assemblies_from_apk (const char* apk, monodro
 	return true;
 }
 
+#if defined (DEBUG) || !defined (ANDROID)
 void
 EmbeddedAssemblies::try_load_typemaps_from_directory (const char *path)
 {
@@ -514,6 +523,7 @@ EmbeddedAssemblies::try_load_typemaps_from_directory (const char *path)
 	free (dir_path);
 	return;
 }
+#endif
 
 size_t
 EmbeddedAssemblies::register_from (const char *apk_file, monodroid_should_register should_register)

--- a/src/monodroid/jni/embedded-assemblies.h
+++ b/src/monodroid/jni/embedded-assemblies.h
@@ -7,15 +7,21 @@
 #include "unzip.h"
 #include "ioapi.h"
 
+struct TypeMapHeader;
+
 namespace xamarin { namespace android { namespace internal {
+#if defined (DEBUG) || !defined (ANDROID)
 	struct TypeMappingInfo;
+#endif
 	struct md_mmap_info;
 
 	class EmbeddedAssemblies
 	{
 	private:
 		static constexpr char assemblies_prefix[] = "assemblies/";
+#if defined (DEBUG) || !defined (ANDROID)
 		static constexpr char override_typemap_entry_name[] = ".__override__";
+#endif
 		static const char *suffixes[];
 
 	public:
@@ -23,7 +29,9 @@ namespace xamarin { namespace android { namespace internal {
 		using monodroid_should_register = bool (*)(const char *filename);
 
 	public:
+#if defined (DEBUG) || !defined (ANDROID)
 		void try_load_typemaps_from_directory (const char *path);
+#endif
 		void install_preload_hooks ();
 		const char* typemap_java_to_managed (const char *java);
 		const char* typemap_managed_to_java (const char *managed);
@@ -53,7 +61,9 @@ namespace xamarin { namespace android { namespace internal {
 		bool gather_bundled_assemblies_from_apk (const char* apk, monodroid_should_register should_register);
 		MonoAssembly* open_from_bundles (MonoAssemblyName* aname, bool ref_only);
 		void extract_int (const char **header, const char *source_apk, const char *source_entry, const char *key_name, int *value);
+#if defined (DEBUG) || !defined (ANDROID)
 		bool add_type_mapping (TypeMappingInfo **info, const char *source_apk, const char *source_entry, const char *addr);
+#endif // DEBUG || !ANDROID
 		bool register_debug_symbols_for_assembly (const char *entry_name, MonoBundledAssembly *assembly, const mono_byte *debug_contents, int debug_size);
 
 		static md_mmap_info md_mmap_apk_file (int fd, uLong offset, uLong size, const char* filename, const char* apk);
@@ -67,6 +77,7 @@ namespace xamarin { namespace android { namespace internal {
 		static MonoAssembly* open_from_bundles_full (MonoAssemblyName *aname, char **assemblies_path, void *user_data);
 		static MonoAssembly* open_from_bundles_refonly (MonoAssemblyName *aname, char **assemblies_path, void *user_data);
 		static int TypeMappingInfo_compare_key (const void *a, const void *b);
+		const char *find_entry_in_type_map (const char *name, uint8_t map[], TypeMapHeader& header);
 
 		const char* get_assemblies_prefix () const
 		{
@@ -77,8 +88,10 @@ namespace xamarin { namespace android { namespace internal {
 		bool                   register_debug_symbols;
 		MonoBundledAssembly  **bundled_assemblies;
 		size_t                 bundled_assemblies_count;
+#if defined (DEBUG) || !defined (ANDROID)
 		TypeMappingInfo       *java_to_managed_maps;
 		TypeMappingInfo       *managed_to_java_maps;
+#endif // DEBUG || !ANDROID
 		const char            *assemblies_prefix_override = nullptr;
 	};
 }}}

--- a/src/monodroid/jni/mono_android_Runtime.h
+++ b/src/monodroid/jni/mono_android_Runtime.h
@@ -10,10 +10,10 @@ extern "C" {
 /*
  * Class:     mono_android_Runtime
  * Method:    init
- * Signature: (Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/ClassLoader;[Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;I;Ljava/lang/String)V
+ * Signature: (Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/ClassLoader;[Ljava/lang/String;[Ljava/lang/String;I)V
  */
 JNIEXPORT void JNICALL Java_mono_android_Runtime_init
-  (JNIEnv *, jclass, jstring, jobjectArray, jstring, jobjectArray, jobject, jobjectArray, jobjectArray, jstring, jint, jobjectArray);
+  (JNIEnv *, jclass, jstring, jobjectArray, jstring, jobjectArray, jobject, jobjectArray, jobjectArray, jint);
 
 /*
  * Class:     mono_android_Runtime

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -65,6 +65,7 @@ extern "C" {
 #include "mkbundle-api.h"
 #include "monodroid-glue-internal.h"
 #include "globals.h"
+#include "typemap.h"
 
 #ifndef WINDOWS
 #include "xamarin_getifaddrs.h"
@@ -215,6 +216,9 @@ mono_mkbundle_initialize_mono_api_ptr mono_mkbundle_initialize_mono_api;
 static void
 setup_bundled_app (const char *dso_name)
 {
+	if (!application_config.is_a_bundled_app)
+		return;
+
 	static int dlopen_flags = RTLD_LAZY;
 	void *libapp = nullptr;
 
@@ -479,7 +483,7 @@ should_register_file (const char *filename)
 static void
 gather_bundled_assemblies (JNIEnv *env, jstring_array_wrapper &runtimeApks, bool register_debug_symbols, int *out_user_assemblies_count)
 {
-#ifndef RELEASE
+#if defined(DEBUG) || !defined (ANDROID)
 	for (size_t i = 0; i < AndroidSystem::MAX_OVERRIDES; ++i) {
 		const char *p = androidSystem.get_override_dir (i);
 		if (!utils.directory_exists (p))
@@ -1174,6 +1178,7 @@ init_android_runtime (MonoDomain *domain, JNIEnv *env, jclass runtimeClass, jobj
 		lookup_bridge_info (domain, image, &osBridge.get_java_gc_bridge_type (i), &osBridge.get_java_gc_bridge_info (i));
 	}
 
+	// TODO: try looking up the method by its token
 	runtime                             = utils.monodroid_get_class_from_image (domain, image, "Android.Runtime", "JNIEnv");
 	method                              = monoFunctions.class_get_method_from_name (runtime, "Initialize", 1);
 
@@ -1804,8 +1809,7 @@ create_and_initialize_domain (JNIEnv* env, jclass runtimeClass, jstring_array_wr
 JNIEXPORT void JNICALL
 Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApksJava,
                                 jstring runtimeNativeLibDir, jobjectArray appDirs, jobject loader,
-                                jobjectArray externalStorageDirs, jobjectArray assemblies, jstring packageName,
-                                jint apiLevel, jobjectArray environmentVariables)
+                                jobjectArray externalStorageDirs, jobjectArray assemblies, jint apiLevel)
 {
 	init_logging_categories ();
 
@@ -1818,13 +1822,12 @@ Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobject
 
 	TimeZone_class = utils.get_class_from_runtime_field (env, klass, "java_util_TimeZone", true);
 
-	jstring_wrapper jstr (env, packageName);
-	utils.monodroid_store_package_name (jstr.get_cstr ());
+	utils.monodroid_store_package_name (application_config.android_package_name);
 
-	jstr = lang;
+	jstring_wrapper jstr (env, lang);
 	set_environment_variable (env, "LANG", jstr);
 
-	androidSystem.setup_environment (env, environmentVariables);
+	androidSystem.setup_environment ();
 
 	jstr = reinterpret_cast <jstring> (env->GetObjectArrayElement (appDirs, 1));
 	set_environment_variable_for_directory (env, "TMPDIR", jstr);

--- a/src/monodroid/jni/typemap.h
+++ b/src/monodroid/jni/typemap.h
@@ -1,0 +1,39 @@
+// Dear Emacs, this is a -*- C++ -*- header
+#ifndef __XAMARIN_ANDROID_TYPEMAP_H
+#define __XAMARIN_ANDROID_TYPEMAP_H
+
+#include <stdint.h>
+
+#include "monodroid.h"
+
+struct TypeMapHeader
+{
+	uint32_t version;
+	uint32_t entry_count;
+	uint32_t entry_length;
+	uint32_t value_offset;
+};
+
+struct ApplicationConfig
+{
+	bool uses_mono_llvm;
+	bool uses_mono_aot;
+	bool uses_embedded_dsos;
+	bool is_a_bundled_app;
+	uint32_t environment_variable_count;
+	uint32_t system_property_count;
+	const char *android_package_name;
+};
+
+MONO_API TypeMapHeader jm_typemap_header;
+MONO_API uint8_t jm_typemap[];
+
+MONO_API TypeMapHeader mj_typemap_header;
+MONO_API uint8_t mj_typemap[];
+
+MONO_API ApplicationConfig application_config;
+MONO_API const char* app_environment_variables[];
+MONO_API const char* app_system_properties[];
+
+MONO_API const char* mono_aot_mode_name;
+#endif // __XAMARIN_ANDROID_TYPEMAP_H

--- a/src/monodroid/monodroid.targets
+++ b/src/monodroid/monodroid.targets
@@ -32,13 +32,13 @@
     <!-- CMAKE_RUNTIME_OUTPUT_DIRECTORY is provided for the mxe/mingw cross builds. DLL outputs are treated as _runtime_ objects (as opposed to _library_ ones for .so, .dylib etc) by cmake
          and so in order to put libmono-android.*.dll in the output dir we need to set this property. Since we build no executables here, it won't affect the non-DLL outputs.  -->
     <Exec
-        Command="$(CmakePath) %(_HostRuntime.CmakeFlags) -DCONFIGURATION=Release -DCMAKE_BUILD_TYPE=Debug -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(OutputPath)/%(_HostRuntime.OutputDirectory) -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=$(OutputPath)/%(_HostRuntime.OutputDirectory) $(MSBuildThisFileDirectory)"
+        Command="$(CmakePath) %(_HostRuntime.CmakeFlags) -DCONFIGURATION=Release -DCMAKE_BUILD_TYPE=Debug -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$(OutputPath)/%(_HostRuntime.OutputDirectory) -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(OutputPath)/%(_HostRuntime.OutputDirectory) -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=$(OutputPath)/%(_HostRuntime.OutputDirectory) $(MSBuildThisFileDirectory)"
         WorkingDirectory="$(IntermediateOutputPath)%(_HostRuntime.OutputDirectory)-Debug"
     />
 
     <MakeDir Directories="$(IntermediateOutputPath)%(_HostRuntime.OutputDirectory)-Release" />
     <Exec
-        Command="$(CmakePath) %(_HostRuntime.CmakeFlags) -DSTRIP_DEBUG=ON -DCONFIGURATION=Debug -DCMAKE_BUILD_TYPE=Release -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(OutputPath)/%(_HostRuntime.OutputDirectory) -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=$(OutputPath)/%(_HostRuntime.OutputDirectory) $(MSBuildThisFileDirectory)"
+        Command="$(CmakePath) %(_HostRuntime.CmakeFlags) -DSTRIP_DEBUG=ON -DCONFIGURATION=Debug -DCMAKE_BUILD_TYPE=Release -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$(OutputPath)/%(_HostRuntime.OutputDirectory) -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(OutputPath)/%(_HostRuntime.OutputDirectory) -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=$(OutputPath)/%(_HostRuntime.OutputDirectory) $(MSBuildThisFileDirectory)"
         WorkingDirectory="$(IntermediateOutputPath)%(_HostRuntime.OutputDirectory)-Release"
     />
   </Target>
@@ -48,13 +48,13 @@
       Outputs="@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\CMakeCache.txt');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\CMakeCache.txt')">
     <MakeDir Directories="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Debug" />
     <Exec
-        Command="$(CmakePath) $(_CmakeAndroidFlags) -DCONFIGURATION=Release -DCMAKE_BUILD_TYPE=Debug -DANDROID_NATIVE_API_LEVEL=%(AndroidSupportedTargetJitAbi.ApiLevel) -DANDROID_PLATFORM=android-%(AndroidSupportedTargetJitAbi.ApiLevel) -DANDROID_ABI=%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(OutputPath)%(AndroidSupportedTargetJitAbi.Identity) $(MSBuildThisFileDirectory)"
+        Command="$(CmakePath) $(_CmakeAndroidFlags) -DCONFIGURATION=Release -DCMAKE_BUILD_TYPE=Debug -DANDROID_NATIVE_API_LEVEL=%(AndroidSupportedTargetJitAbi.ApiLevel) -DANDROID_PLATFORM=android-%(AndroidSupportedTargetJitAbi.ApiLevel) -DANDROID_ABI=%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$(OutputPath)%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(OutputPath)%(AndroidSupportedTargetJitAbi.Identity) $(MSBuildThisFileDirectory)"
         WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Debug"
     />
 
     <MakeDir Directories="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Release" />
     <Exec
-        Command="$(CmakePath) $(_CmakeAndroidFlags) -DSTRIP_DEBUG=ON -DCONFIGURATION=Debug -DCMAKE_BUILD_TYPE=Release -DANDROID_NATIVE_API_LEVEL=%(AndroidSupportedTargetJitAbi.ApiLevel) -DANDROID_PLATFORM=android-%(AndroidSupportedTargetJitAbi.ApiLevel) -DANDROID_ABI=%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(OutputPath)%(AndroidSupportedTargetJitAbi.Identity) $(MSBuildThisFileDirectory)"
+        Command="$(CmakePath) $(_CmakeAndroidFlags) -DSTRIP_DEBUG=ON -DCONFIGURATION=Debug -DCMAKE_BUILD_TYPE=Release -DANDROID_NATIVE_API_LEVEL=%(AndroidSupportedTargetJitAbi.ApiLevel) -DANDROID_PLATFORM=android-%(AndroidSupportedTargetJitAbi.ApiLevel) -DANDROID_ABI=%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$(OutputPath)%(AndroidSupportedTargetJitAbi.Identity) -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(OutputPath)%(AndroidSupportedTargetJitAbi.Identity) $(MSBuildThisFileDirectory)"
         WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Release"
     />
   </Target>
@@ -62,7 +62,7 @@
   <Target Name="_BuildAndroidRuntimes"
       DependsOnTargets="_ConfigureAndroidRuntimes"
       Inputs="@(_MonodroidSource);@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\CMakeCache.txt');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\CMakeCache.txt');jni\*.cc;jni\*.h;jni\**\*.c;;..\..\build-tools\scripts\Ndk.targets"
-      Outputs="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.so')">
+      Outputs="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.debug.so');@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(Identity)\libmono-android.release.so');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Debug\libxamarin-app.so');@(AndroidSupportedTargetJitAbi->'$(IntermediateOutputPath)\%(Identity)-Release\libxamarin-app.so')">
     <Exec
         Command="$(NinjaPath) -v"
         WorkingDirectory="$(IntermediateOutputPath)%(AndroidSupportedTargetJitAbi.Identity)-Debug"

--- a/tests/EmbeddedDSOs/EmbeddedDSO/EmbeddedDSO.csproj
+++ b/tests/EmbeddedDSOs/EmbeddedDSO/EmbeddedDSO.csproj
@@ -17,7 +17,7 @@
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
-    <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
+    <AndroidSupportedAbis>armeabi-v7a;arm64-v8a;x86;x86_64</AndroidSupportedAbis>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(UnitTestsMode)' == 'true' ">


### PR DESCRIPTION
Xamarin.Android needs a lot of information on the runtime in order to do its
tasks. Among this is are two bits of information that are used in the runtime
startup: type mappings (java-to-managed and managed-to-java) and environment
settings (variables and system properties). So far, Xamarin.Android used these
bits of data (generated on the application build time) by loading them and
parsing dynamically during startup. However, none of this data is *actually*
dynamic - it's known beforehand and should be stored as static data right in the
application. The problem with this idea, however, was that we had no way to put
that information into the application native bits on the build time: it would
require the presence of a compiler (or native assembler) as well as the native
linker for the target platforms. Until recently, it meant having to have the
Android NDK installed, a pretty hefty requirement. However, right now Android
SDK ships the native linker with its `build-tools` package and we can bundle in
our packages the, relatively small, `gas` native assembler for all the
architectures we support which allows us to generate simple native assembler
code, compile it and link into a shared library **when packaging** the
application.

The way it works is that during Xamarin.Android build we also build a stub
`libxamarin-app.so` library which the XA runtime is linked against. That stub
library is **not** shipped with XA, instead the version we generate on the build
time is packaged together with the runtime inside the APK. Since it's
abi-compatible with the one built previously, the dynamic loader doesn't care
and loads everything just fine.

This allows us to dispense with memory allocation, loading (potentially large)
files from the apk (lots of I/O, slow), parsing text files to set environment
variables (this also includes memory allocation). All of the data is loaded for
us by Android and we simply access global variables from the `libxamarin-app.so`
library.

The process, however, can be time consuming (sort of...) and in order to allow
fast deployment to work as quickly as possible, the debug (and desktop/host -
for the benefit of the UI Designer) builds of the runtime also contain code to
load both type maps and environment variables from files stored inside one of
the override directories.

The changes got us a speed-up of ~20ms for a release build of a Xamarin.Forms
app on Pixel 3 XL.