### PR TITLE
[tests] Fix msbuild response file usage

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -365,12 +365,13 @@ namespace Xamarin.ProjectTools
 			var start = DateTime.UtcNow;
 			var args  = new StringBuilder ();
 			var psi   = new ProcessStartInfo (XABuildExe);
-			var responseFile = Path.Combine (XABuildPaths.TestOutputDirectory, Path.GetDirectoryName (projectOrSolution), "msbuild.rsp");
+			var responseFile = Path.Combine (XABuildPaths.TestOutputDirectory, Path.GetDirectoryName (projectOrSolution), "project.rsp");
 			args.AppendFormat ("{0} /t:{1} {2}",
 					QuoteFileName (Path.Combine (XABuildPaths.TestOutputDirectory, projectOrSolution)), target, logger);
 			if (AutomaticNuGetRestore && restore) {
 				args.Append (" /restore");
 			}
+			args.Append ($" @\"{responseFile}\"");
 			using (var sw = new StreamWriter (responseFile, append: false, encoding: Encoding.UTF8)) {
 				sw.WriteLine ($" /p:BuildingInsideVisualStudio={BuildingInsideVisualStudio}");
 				if (BuildingInsideVisualStudio && RunningMSBuild) {


### PR DESCRIPTION
Commit https://github.com/xamarin/xamarin-android/commit/578e781ba added support
for using the `msbuild.rsp` response file when running tests in order to work
around issues with diacritic characters on the command line. The commit assumed
that the response file will be picked up automatically if it's found in
the *project root directory*, however this is not the case as the response file
is [documented][0] to exist in the same directory as `msbuild.exe` and thus some
tests (EmbededDSOs, CodeBehind) were failing to build since important properties
required for them to work were only in the response file and not specified on
the command line passed to `msbuild.exe`.

We missed the issue because Jenkins gave us a false-positive green build for
those changes where in reality the tests did [not run at all][1]

This fix appends `@"/path/to/msbuild.rsp"` to the msbuild's command line.

[0]: https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-response-files?view=vs-2017
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/1505/testReport/EmbeddedDSOUnitTests/