### PR TITLE
[tests] more logging around MicrosoftNetSdkDirectory

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -496,7 +496,7 @@ namespace App1
 			var path = Path.Combine ("temp", TestContext.CurrentContext.Test.Name);
 			using (var builder = CreateDllBuilder (Path.Combine (path, netStandardProject.ProjectName), cleanupOnDispose: false)) {
 				if (!Directory.Exists (builder.MicrosoftNetSdkDirectory))
-					Assert.Fail ("Microsoft.NET.Sdk not found.");
+					Assert.Fail ($"Microsoft.NET.Sdk not found: {builder.MicrosoftNetSdkDirectory}");
 				using (var ab = CreateApkBuilder (Path.Combine (path, app.ProjectName), cleanupOnDispose: false)) {
 					builder.RequiresMSBuild =
 						ab.RequiresMSBuild = true;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -288,6 +288,7 @@ namespace Xamarin.ProjectTools
 					frameworkSDKRoot = process.StandardOutput.ReadToEnd ().Trim ();
 				}
 			}
+			Console.WriteLine ($"Using $(FrameworkSDKRoot): {frameworkSDKRoot}");
 		}
 
 		public void Dispose ()


### PR DESCRIPTION
Downstream in monodroid, we have a test failure:

    18:56:55   1) Failed : Xamarin.Android.Build.Tests.PackagingTest.NetStandardReferenceTest
    18:56:55   Microsoft.NET.Sdk not found.
    18:56:55   at Xamarin.Android.Build.Tests.PackagingTest.NetStandardReferenceTest ()

We likely introduced this in ef7a38d, but there isn't enough logging
to see what went wrong. When I logged into the build machine the
directory we are looking for looked correct.

I changed `PackagingTest` to log the directory it used, and added a
`Console.WriteLine` call in `Builder.cs`.