### PR TITLE
Bump SQLite to v3.27.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -41,7 +41,7 @@
 [submodule "external/sqlite"]
     path = external/sqlite
     url = https://github.com/xamarin/sqlite.git
-    branch = 3.26.0
+    branch = 3.27.1
 [submodule "external/xamarin-android-api-compatibility"]
     path = external/xamarin-android-api-compatibility
     url = https://github.com/xamarin/xamarin-android-api-compatibility.git


### PR DESCRIPTION
Upstream changes:

SQLite Release 3.27.1 On 2019-02-08

 Fix a bug in the query optimizer: an adverse interaction between the OR
 optimization and the optimization that tries to use values read directly
 from an expression index instead of recomputing the expression. Ticket
 4e8e4857d32d401f

Changes carried forward from version 3.27.0 (2019-02-07):

 * Added the VACUUM INTO command
 * Issue an SQLITE_WARNING message on the error log if a double-quoted string
   literal is used.
 * The sqlite3_normalized_sql() interface works on any prepared statement
   created using sqlite3_prepare_v2() or sqlite3_prepare_v3(). It is no longer
   necessary to use sqlite3_prepare_v3() with SQLITE_PREPARE_NORMALIZE in order
   to use sqlite3_normalized_sql().
 * Added the remove_diacritics=2 option to FTS3 and FTS5.
 * Added the SQLITE_PREPARE_NO_VTAB option to sqlite3_prepare_v3(). Use that
   option to prevent circular references to shadow tables from causing resource
   leaks.
 * Enhancements to the sqlite3_deserialize() interface:
     * Add the SQLITE_FCNTL_SIZE_LIMIT file-control for setting an upper bound
       on the size of the in-memory database created by sqlite3_deserialize. The
       default upper bound is 1GiB, or whatever alternative value is specified
       by sqlite3_config(SQLITE_CONFIG_MEMDB_MAXSIZE) and/or
       SQLITE_MEMDB_DEFAULT_MAXSIZE.
     * Honor the SQLITE_DESERIALIZE_READONLY flag, which was previously
       described in the documentation, but was previously a no-op.
     * Enhance the "deserialize" command of the TCL Interface to give it new
       "--maxsize N" and "--readonly BOOLEAN" options.
 * Enhancements to the CLI, mostly to support testing and debugging of the SQLite library itself:
     * Add support for ".open --hexdb". The "dbtotxt" utility program used to
       generate the text for the "hexdb" is added to the source tree.
     * Add support for the "--maxsize N" option on ".open --deserialize".
     * Add the "--memtrace" command-line option, to show all memory allocations
        and deallocations.
     * Add the ".eqp trace" option on builds with SQLITE_DEBUG, to enable
       bytecode program listing with indentation and PRAGMA vdbe_trace all in one
       step.
     * Add the ".progress" command for accessing the sqlite3_progress_handler()
       interface.
     * Add the "--async" option to the ".backup" command.
     * Add options "--expanded", "--normalized", "--plain", "--profile",
       "--row", "--stmt", and "--close" to the ".trace" command.
 * Increased robustness against malicious SQL that is run against a maliciously
   corrupted database.

Bug fixes:
 * Do not use a partial index to do a table scan on an IN operator.
 * Fix the query flattener so that it works on queries that contain subqueries
   that use window functions.
 * Ensure that ALTER TABLE modifies table and column names embedded in WITH
   clauses that are part of views and triggers.
 * Fix a parser bug that prevented the use of parentheses around table-valued
   functions.
 * Fix a problem with the OR optimization on indexes on expressions.
 * Fix a problem with the LEFT JOIN strength reduction optimization in which the
   optimization was being applied inappropriately due to an IS NOT NULL
   operator.
 * Fix the REPLACE command so that it is no longer able to sneak a NULL value
   into a NOT NULL column even if the NOT NULL column has a default value of
   NULL.
 * Fix a problem with the use of window functions used within correlated
   subqueries.
 * Fix the ALTER TABLE RENAME COLUMN command so that it works for tables that
   have redundant UNIQUE constraints.
 * Fix a bug that caused zeroblob values to be truncated when inserted into a
   table that uses an expression index.