### PR TITLE
[Xamarin.ProjectTools] check for /msbuild/ in $(FrameworkSdkRoot)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -287,8 +287,18 @@ namespace Xamarin.ProjectTools
 					process.WaitForExit ();
 					frameworkSDKRoot = process.StandardOutput.ReadToEnd ().Trim ();
 				}
+
+				//NOTE: some machines aren't returning /msbuild/ on the end
+				//      macOS should be /Library/Frameworks/Mono.framework/Versions/5.18.0/lib/mono/msbuild/
+				var dir = Path.GetFileName (frameworkSDKRoot.TrimEnd (Path.DirectorySeparatorChar));
+				if (dir != "msbuild") {
+					var path = Path.Combine (frameworkSDKRoot, "msbuild");
+					if (Directory.Exists (path))
+						frameworkSDKRoot = path;
+				}
 			}
-			Console.WriteLine ($"Using $(FrameworkSDKRoot): {frameworkSDKRoot}");
+			if (!string.IsNullOrEmpty (frameworkSDKRoot))
+				Console.WriteLine ($"Using $(FrameworkSDKRoot): {frameworkSDKRoot}");
 		}
 
 		public void Dispose ()


### PR DESCRIPTION
Downstream in monodroid, we are still seeing a failure in
`NetStandardReferenceTest`:

    Using $(FrameworkSDKRoot): /Library/Frameworks/Mono.framework/Versions/5.18.0/lib/mono/
    [TESTLOG] Test NetStandardReferenceTest Complete
    ...
    Microsoft.NET.Sdk not found:

But if I test on my machine `$(FrameworkSDKRoot)` is:

    /Library/Frameworks/Mono.framework/Versions/5.18.0/lib/mono/msbuild/

Both the build machine and mine have the same version of Mono.

I think we should just make sure the path we are using includes
`/msbuild/` and append the directory if needed.

Other change:

* On Windows, it was always logging `Using $(FrameworkSDKRoot): `. So
  let's not log that if it is blank.