### PR TITLE
[installers] Share installer payload generation logic

### DIFF
--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -129,6 +129,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "download-bundle", "build-to
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "jit-times", "tools\jit-times\jit-times.csproj", "{F3CFF31C-037B-450F-B22D-1D6E529B2DCC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "create-pkg", "build-tools\create-pkg\create-pkg.csproj", "{46529930-A5CC-4205-A50D-0AAAC639F082}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems*{3f1f2f50-af1a-4a5a-bedb-193372f068d7}*SharedItemsImports = 4
@@ -371,6 +373,10 @@ Global
 		{F3CFF31C-037B-450F-B22D-1D6E529B2DCC}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{F3CFF31C-037B-450F-B22D-1D6E529B2DCC}.Release|AnyCPU.ActiveCfg = Release|Any CPU
 		{F3CFF31C-037B-450F-B22D-1D6E529B2DCC}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{46529930-A5CC-4205-A50D-0AAAC639F082}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{46529930-A5CC-4205-A50D-0AAAC639F082}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{46529930-A5CC-4205-A50D-0AAAC639F082}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{46529930-A5CC-4205-A50D-0AAAC639F082}.Release|AnyCPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -432,6 +438,7 @@ Global
 		{1E5501E8-49C1-4659-838D-CC9720C5208F} = {CAB438D8-B0F5-4AF0-BEBD-9E2ADBD7B483}
 		{1BAFA0CC-0377-46CE-AB7B-7BB2E7B62F63} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{F3CFF31C-037B-450F-B22D-1D6E529B2DCC} = {864062D3-A415-4A6F-9324-5820237BA058}
+		{46529930-A5CC-4205-A50D-0AAAC639F082} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {53A1F287-EFB2-4D97-A4BB-4A5E145613F6}

--- a/build-tools/create-pkg/create-pkg.csproj
+++ b/build-tools/create-pkg/create-pkg.csproj
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{46529930-A5CC-4205-A50D-0AAAC639F082}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>createpkg</RootNamespace>
+    <AssemblyName>create-pkg</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <OutputPath>..\..\bin\Build$(Configuration)</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="distribution.xml.in" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="create-pkg.targets" />
+</Project>

--- a/build-tools/create-pkg/create-pkg.targets
+++ b/build-tools/create-pkg/create-pkg.targets
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\installers\create-installers.targets" />
+  <PropertyGroup>
+    <BuildDependsOn>ResolveReferences</BuildDependsOn>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PkgInstallDir>/</PkgInstallDir>
+    <PkgInstallDir Condition="$([MSBuild]::IsOsPlatform(Linux))">/usr</PkgInstallDir>
+    <PayloadDir>$(OutputPath)\pkg\archive</PayloadDir>
+    <PkgOutputPath>$(OutputPath)\pkg\packages</PkgOutputPath>
+    <PkgResourcesPath>$(OutputPath)\pkg\resources</PkgResourcesPath>
+    <PkgDistributionDestination>$(OutputPath)\pkg\distribution.xml</PkgDistributionDestination>
+    <PkgLicenseSrcEn Condition="'$(PkgLicenseSrcEn)' == ''">$(XamarinAndroidSourcePath)\LICENSE</PkgLicenseSrcEn>
+    <PkgLicenseDestinationEn>$(PkgResourcesPath)\en.lproj</PkgLicenseDestinationEn>
+    <PkgScriptsDir>$(MSBuildThisFileDirectory)scripts</PkgScriptsDir>
+    <UpdateInfoGuid>d1ec039f-f3db-468b-a508-896d7c382999</UpdateInfoGuid>
+  </PropertyGroup>
+  <Target Name="_CopyFilesToPayloadDir"
+      DependsOnTargets="ConstructInstallerItems;GetXAVersion" >
+    <PropertyGroup>
+      <XAFrameworkDir>$(PayloadDir)\Library\Frameworks\Xamarin.Android.framework\Versions\$(XAVersion)</XAFrameworkDir>
+      <MonoFrameworkExternalDir>$(PayloadDir)\Library\Frameworks\Mono.framework\External</MonoFrameworkExternalDir>
+      <MSBuildTargetsDir>$(XAFrameworkDir)\lib\xamarin.android\xbuild\Xamarin\Android</MSBuildTargetsDir>
+      <MSBuildFrameworksDir>$(XAFrameworkDir)\lib\xamarin.android\xbuild-frameworks\MonoAndroid</MSBuildFrameworksDir>
+    </PropertyGroup>
+    <RemoveDir Directories="$(PayloadDir)" />
+    <Copy
+        SourceFiles="@(FrameworkItemsUnix)"
+        DestinationFiles="@(FrameworkItemsUnix->'$(MSBuildFrameworksDir)\%(RelativePath)')"
+    />
+    <Copy
+        SourceFiles="@(MSBuildItemsUnix)"
+        DestinationFiles="@(MSBuildItemsUnix->'$(MSBuildTargetsDir)\%(RelativePath)')"
+    />
+    <Copy
+        SourceFiles="@(XATargetsSrcFiles)"
+        DestinationFolder="$(XAFrameworkDir)\lib\xamarin.android\xbuild\Xamarin"
+    />
+    <Copy
+        SourceFiles="@(LegacyTargetsFiles)"
+        DestinationFolder="$(XAFrameworkDir)\lib\xamarin.android\xbuild\Novell"
+    />
+    <Copy
+        SourceFiles="@(MonoDocFiles)"
+        DestinationFolder="$(XAFrameworkDir)\lib\monodoc"
+    />
+    <Copy
+        SourceFiles="@(VersionFiles);$(PkgLicenseSrcEn)"
+        DestinationFolder="$(XAFrameworkDir)"
+    />
+  </Target>
+  <Target Name="_CreateSymbolicLinks"
+      DependsOnTargets="_CopyFilesToPayloadDir">
+    <Exec WorkingDirectory="$(PayloadDir)\Library\Frameworks\Xamarin.Android.framework\Versions"
+        Command="ln -fs $(XAVersion) Current"
+    />
+    <!-- Required for VS Mac Updater -->
+    <MakeDir Directories="$(PayloadDir)\Developer" />
+    <Exec WorkingDirectory="$(PayloadDir)\Developer"
+        Command="ln -fs &quot;../Library/Frameworks/Xamarin.Android.framework/Versions/Current&quot; MonoAndroid"
+    />
+    <Exec WorkingDirectory="$(MSBuildTargetsDir)\lib"
+        Command="ln -fs host-$(HostOS) host"
+    />
+    <MakeDir Directories="$(MonoFrameworkExternalDir)\xbuild" />
+    <Exec WorkingDirectory="$(MonoFrameworkExternalDir)\xbuild"
+        Command="ln -fs &quot;../../../Xamarin.Android.framework/Versions/$(XAVersion)/lib/xamarin.android/xbuild/Novell&quot; ."
+    />
+    <MakeDir Directories="$(MonoFrameworkExternalDir)\xbuild\Xamarin" />
+    <Exec WorkingDirectory="$(MonoFrameworkExternalDir)\xbuild\Xamarin"
+        Command="ln -fs &quot;../../../../Xamarin.Android.framework/Versions/$(XAVersion)/lib/xamarin.android/xbuild/Xamarin/Android&quot; ."
+    />
+    <MakeDir Directories="$(MonoFrameworkExternalDir)\xbuild-frameworks" />
+    <Exec WorkingDirectory="$(MonoFrameworkExternalDir)\xbuild-frameworks"
+        Command="ln -fs &quot;../../../Xamarin.Android.framework/Versions/$(XAVersion)/lib/xamarin.android/xbuild-frameworks/MonoAndroid&quot; ."
+    />
+    <MakeDir Directories="$(MonoFrameworkExternalDir)\monodoc" />
+    <Exec WorkingDirectory="$(MonoFrameworkExternalDir)\monodoc"
+        Command="ln -fs &quot;../../../Xamarin.Android.framework/Versions/$(XAVersion)/lib/monodoc/MonoAndroid-docs.source&quot; ."
+    />
+    <Exec WorkingDirectory="$(MonoFrameworkExternalDir)\monodoc"
+        Command="ln -fs &quot;../../../Xamarin.Android.framework/Versions/$(XAVersion)/lib/monodoc/MonoAndroid-lib.tree&quot; ."
+    />
+    <Exec WorkingDirectory="$(MonoFrameworkExternalDir)\monodoc"
+        Command="ln -fs &quot;../../../Xamarin.Android.framework/Versions/$(XAVersion)/lib/monodoc/MonoAndroid-lib.zip&quot; ."
+    />
+  </Target>
+  <Target Name="_FinalizePayload"
+      DependsOnTargets="_CreateSymbolicLinks">
+    <ReplaceFileContents
+        SourceFile="distribution.xml.in"
+        DestinationFile="$(PkgDistributionDestination)"
+        Replacements="@PACKAGE_TITLE@=Xamarin.Android $(ProductVersion)"
+    />
+    <Exec
+        WorkingDirectory="$(XamarinAndroidSourcePath)"
+        ConsoleToMSBuild="true"
+        Command="git log --no-color --first-parent -n1 --pretty=format:%ct">
+      <Output TaskParameter="ConsoleOutput" PropertyName="UpdateInfoVersion" />
+    </Exec>
+    <WriteLinesToFile
+        File="$(XAFrameworkDir)\updateinfo"
+        Lines="$(UpdateInfoGuid) $(UpdateInfoVersion)"
+        Overwrite="true"
+    />
+    <MakeDir Directories="$(PkgLicenseDestinationEn)" />
+    <Copy
+        SourceFiles="$(PkgLicenseSrcEn)"
+        DestinationFiles="$(PkgLicenseDestinationEn)\License"
+    />
+  </Target>
+  <Target Name="CreatePkg"
+      Condition=" '$(HostOS)' == 'Darwin' "
+      DependsOnTargets="_FinalizePayload">
+    <MakeDir Directories="$(PkgOutputPath)"/>
+    <PropertyGroup>
+        <PkgProductOutputPath Condition="'$(PkgProductOutputPath)' == ''">$(OutputPath)Xamarin.Android.Sdk-$(XAOSSInstallerSuffix).pkg</PkgProductOutputPath>
+    </PropertyGroup>
+    <ItemGroup>
+      <PkgBuildArgs Include="--root &quot;$(PayloadDir)&quot;" />
+      <PkgBuildArgs Include="--identifier com.xamarin.android.pkg" />
+      <PkgBuildArgs Include="--version $(XAVersion)"/>
+      <PkgBuildArgs Include="--install-location &quot;$(PkgInstallDir)&quot; "/>
+      <PkgBuildArgs Include="--scripts &quot;$(PkgScriptsDir)&quot; "/>
+      <PkgBuildArgs Include="&quot;$(PkgOutputPath)/xamarin.android.pkg&quot; "/>
+    </ItemGroup>
+    <Exec Command="pkgbuild @(PkgBuildArgs, ' ')" />
+    <ItemGroup>
+      <ProductBuildArgs Include="--resources &quot;$(PkgResourcesPath)&quot;" />
+      <ProductBuildArgs Include="--distribution &quot;$(PkgDistributionDestination)&quot;" />
+      <ProductBuildArgs Include="--package-path &quot;$(PkgOutputPath)&quot;" />
+      <ProductBuildArgs Include="&quot;$(PkgProductOutputPath)&quot;" />
+    </ItemGroup>
+    <Exec Command="productbuild @(ProductBuildArgs, ' ')" />
+  </Target>
+</Project>

--- a/build-tools/create-pkg/distribution.xml.in
+++ b/build-tools/create-pkg/distribution.xml.in
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<installer-gui-script minSpecVersion="1">
+  <license file="License" mime-type="application/rtf" />
+  <title>@PACKAGE_TITLE@</title>
+  <pkg-ref id="xamarin.android">
+    <bundle-version/>
+  </pkg-ref>
+  <choices-outline>
+    <line choice="default">
+      <line choice="xamarin.android"/>
+    </line>
+  </choices-outline>
+  <choice id="default"/>
+  <choice id="xamarin.android" visible="false">
+    <pkg-ref id="xamarin.android"/>
+  </choice>
+  <pkg-ref id="xamarin.android">#xamarin.android.pkg</pkg-ref>
+</installer-gui-script>

--- a/build-tools/create-pkg/scripts/preinstall
+++ b/build-tools/create-pkg/scripts/preinstall
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+INSTALLATION_ROOT=/Library/Frameworks/Xamarin.Android.framework/Versions
+PREVIOUS_VERSION=$(readlink "$INSTALLATION_ROOT/Current")
+PREVIOUS_VERSION_PATH="$INSTALLATION_ROOT/$PREVIOUS_VERSION"
+
+# Ensure previously installed version is removed.
+if [ -d "$PREVIOUS_VERSION_PATH" ]; then
+	rm -rf "$PREVIOUS_VERSION_PATH"
+fi
+

--- a/build-tools/create-vsix/create-vsix.csproj
+++ b/build-tools/create-vsix/create-vsix.csproj
@@ -27,7 +27,6 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' " />
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' " />
-  <Import Project="..\..\Configuration.props" />
   <ItemGroup>
     <Compile Include="AndroidSdkPackage.cs" />
     <Content Include="Resources\AndroidSdkPackage.ico">

--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\scripts\XAVersionInfo.targets" />
-  <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"   TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
+  <Import Project="..\installers\create-installers.targets" />
   <PropertyGroup>
     <!-- Don't ever deploy, since that won't work on Mac -->
     <DeployExtension>False</DeployExtension>
@@ -9,7 +8,6 @@
       $(PrepareForBuildDependsOn);
       AddContent
     </PrepareForBuildDependsOn>
-    <LibDir>..\..\bin\$(Configuration)\lib\xamarin.android\</LibDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <MSBuild>
@@ -28,106 +26,34 @@
       <InstallRoot/>
     </ThirdPartyNotice>
   </ItemDefinitionGroup>
-  <Target Name="AddContent"
+   <Target Name="AddContent"
+      DependsOnTargets="ConstructInstallerItems"
       Returns="@(MSBuild);@(ReferenceAssemblies)">
-    <ReadLinesFromFile File="$(LibDir)\xbuild-frameworks\.__sys_links.txt">
-      <Output TaskParameter="Lines" ItemName="_SymLinks"/>
-    </ReadLinesFromFile>
     <ItemGroup>
-      <_FirstFrameworkFile  Include="Mono.Android.Export.dll" />
-      <_FirstFrameworkFile  Include="Mono.Android.Export.pdb" />
-      <_FirstFrameworkFile  Include="OpenTK-1.0.dll" />
-      <_FirstFrameworkFile  Include="OpenTK-1.0.pdb" />
-      <_FirstFrameworkFile  Include="OpenTK-1.0.xml" />
-      <_FirstFrameworkFile  Include="OpenTK.dll" />
-      <_FirstFrameworkFile  Include="OpenTK.pdb" />
-      <_FirstFrameworkFile  Include="OpenTK.xml" />
-    </ItemGroup>
-    <ItemGroup>
-      <MSBuild Include="$(LibDir)xbuild\Novell\**\*.*" />
-      <MSBuild>
-        <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Novell/%(RecursiveDir)</VSIXSubPath>
-      </MSBuild>
-      <MSBuild Include="$(LibDir)xbuild\Xamarin\**\*.*" />
-      <MSBuild>
-        <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Xamarin/%(RecursiveDir)</VSIXSubPath>
-      </MSBuild>
-      <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\lib\host-Darwin\**\*.*" />
-      <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\lib\host-Linux\**\*.*" />
-      <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\Darwin\**\*.*" />
-      <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\Linux\**\*.*" />
-      <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\**\*.dylib" />
-      <MSBuild Remove="$(LibDir)xbuild\Xamarin\Android\**\*.pdb" />
-      <MSBuild
-          Condition=" '$(Configuration)' != 'Debug' "
-          Remove="$(LibDir)xbuild\Xamarin\Android\**\*.d.so"
-      />
-      <MSBuild Include="..\..\src\Xamarin.Android.Build.Tasks\MSBuild\Xamarin\**\*.*" />
-      <MSBuild>
-        <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Xamarin/%(RecursiveDir)</VSIXSubPath>
-      </MSBuild>
-      <MSBuild>
-        <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Xamarin/Android/%(RecursiveDir)</VSIXSubPath>
-      </MSBuild>
-      <MSBuild>
-        <VSIXSubPath Condition=" '%(VSIXSubPath)' == 'Xamarin/Android/lib/host-mxe-Win64/' ">Xamarin/Android/</VSIXSubPath>
-      </MSBuild>
-      <MSBuild Remove="$(LibDir)xbuild\**\*.d.dll" />
-      <MSBuild Remove="$(LibDir)xbuild\**\*.d.exe" />
-      <ReferenceAssemblies Include="$(LibDir)xbuild-frameworks\**\*.*" />
-      <ReferenceAssemblies Remove="$(LibDir)xbuild-frameworks\.__sys_links.txt" />
-      <ReferenceAssemblies
-          Condition=" '@(_SymLinks)' != '' "
-          Remove="$(LibDir)xbuild-frameworks\%(_SymLinks.Identity)\**\*.*"
-      />
-      <ReferenceAssemblies Remove="$(LibDir)xbuild-frameworks\**\*.dylib" />
-      <ReferenceAssemblies Remove="$(LibDir)xbuild-frameworks\**\libZipSharp*.*" />
-    </ItemGroup>
-    <ItemGroup Condition="Exists('$(LibDir)xbuild-frameworks\MonoAndroid\$(AndroidFirstFrameworkVersion)')">
-      <ReferenceAssemblies Remove="$(LibDir)xbuild-frameworks\**\%(_FirstFrameworkFile.Identity)" />
-      <ReferenceAssemblies
-          Condition=" Exists ('$(LibDir)xbuild-frameworks\MonoAndroid\$(AndroidFirstFrameworkVersion)\%(_FirstFrameworkFile.Identity)') "
-          Include="$(LibDir)xbuild-frameworks\MonoAndroid\$(AndroidFirstFrameworkVersion)\%(_FirstFrameworkFile.Identity)">
-        <VSIXSubPath>Microsoft/Framework/MonoAndroid/$(AndroidFirstFrameworkVersion)/</VSIXSubPath>
+      <ReferenceAssemblies Include="@(FrameworkItemsWin)" >
+        <VSIXSubPath>Microsoft/Framework/MonoAndroid/$([System.IO.Path]::GetDirectoryName(%(RelativePath)))</VSIXSubPath>
       </ReferenceAssemblies>
-    </ItemGroup>
-    <ItemGroup>
-      <ReferenceAssemblies>
-        <VSIXSubPath Condition=" '%(VSIXSubPath)' == '' ">Microsoft/Framework/%(RecursiveDir)</VSIXSubPath>
-      </ReferenceAssemblies>
-      <ThirdPartyNotice Include="$(LibDir)\ThirdPartyNotices.txt">
+      <MSBuild Include="@(MSBuildItemsWin)" >
+        <VSIXSubPath>Xamarin/Android/$([System.IO.Path]::GetDirectoryName(%(RelativePath)))</VSIXSubPath>
+      </MSBuild>
+      <MSBuild Include="@(XATargetsSrcFiles)" >
+        <VSIXSubPath>Xamarin/</VSIXSubPath>
+      </MSBuild>
+      <MSBuild Include="@(LegacyTargetsFiles)" >
+        <VSIXSubPath>Novell/</VSIXSubPath>
+      </MSBuild>
+      <MSBuild Include="@(VersionFiles)" >
+        <VSIXSubPath>Xamarin/Android/</VSIXSubPath>
+      </MSBuild>
+      <ThirdPartyNotice Include="$(RootBuildDir)\lib\xamarin.android\ThirdPartyNotices.txt">
         <VSIXSubPath>/</VSIXSubPath>
       </ThirdPartyNotice>
-    </ItemGroup>
-    <!-- https://bugzilla.xamarin.com/show_bug.cgi?id=54804
-      Mono's `ZipPackage` mis-handles files w/o an extension,
-      causing VS to state that the .vsix is invalid.
-      Remove these files for now.
-      -->
-    <ItemGroup>
-      <_MSBuildFilesWithoutExtension
-          Condition=" '%(Extension)' == '' "
-          Include="@(MSBuild)"
-      />
-      <MSBuild Remove="@(_MSBuildFilesWithoutExtension)" />
-      <_ReferenceFilesWithoutExtension
-          Condition=" '%(Extension)' == '' "
-          Include="@(ReferenceAssemblies)"
-      />
-      <ReferenceAssemblies Remove="@(_ReferenceFilesWithoutExtension)" />
     </ItemGroup>
     <ItemGroup>
       <Content Include="@(MSBuild)" />
       <Content Include="@(ReferenceAssemblies)" />
       <Content Include="@(ThirdPartyNotice)" />
     </ItemGroup>
-  </Target>
-  <Target Name="GetVsixVersion"
-      DependsOnTargets="GetXAVersionInfo"
-      Returns="$(VsixVersion)">
-    <PropertyGroup>
-      <VsixVersion>$(ProductVersion).$(XAVersionCommitCount)</VsixVersion>
-    </PropertyGroup>
   </Target>
   <Target Name="FixupTargetVsixContainer"
       BeforeTargets="VSIXContainerProjectOutputGroup;CreateVsixContainer"
@@ -160,11 +86,7 @@
   <Target Name="_GetVsixPath"
       DependsOnTargets="GetXAVersionInfo">
     <PropertyGroup>
-      <_Branch>$(XAVersionBranch.Replace ('/', '-'))</_Branch>
-      <_Branch>$(_Branch.Replace ('\', '-'))</_Branch>
-    </PropertyGroup>
-    <PropertyGroup>
-      <VsixPath Condition=" '$(VsixPath)' == '' ">..\..\bin\Build$(Configuration)\$(AssemblyName)-OSS-$(ProductVersion).$(XAVersionCommitCount)_$(_Branch)_$(XAVersionHash).vsix</VsixPath>
+      <VsixPath Condition=" '$(VsixPath)' == '' ">..\..\bin\Build$(Configuration)\$(AssemblyName)-$(XAOSSInstallerSuffix).vsix</VsixPath>
       <_VsixDir>$([System.IO.Path]::GetDirectoryName ($(VsixPath)))</_VsixDir>
     </PropertyGroup>
   </Target>

--- a/build-tools/create-vsix/source.extension.vsixmanifest
+++ b/build-tools/create-vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="Xamarin.Android.Sdk" Version="|create-vsix;GetVsixVersion|" Language="en-US" Publisher="Xamarin" />
+    <Identity Id="Xamarin.Android.Sdk" Version="|create-vsix;GetXAVersion|" Language="en-US" Publisher="Xamarin" />
     <DisplayName>Xamarin.Android SDK</DisplayName>
     <Description xml:space="preserve">Xamarin.Android SDK</Description>
     <Icon>Resources\AndroidSdkPackage.ico</Icon>

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -1,0 +1,308 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\Configuration.props" />
+  <Import Project="..\scripts\XAVersionInfo.targets" />
+  <Import Project="..\..\src\mono-runtimes\ProfileAssemblies.projitems" />
+  <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
+  <PropertyGroup>
+    <RootBuildDir>$(XamarinAndroidSourcePath)\bin\$(Configuration)\</RootBuildDir>
+    <FrameworkSrcDir>$(RootBuildDir)\lib\xamarin.android\xbuild-frameworks\MonoAndroid</FrameworkSrcDir>
+    <MSBuildSrcDir>$(RootBuildDir)\lib\xamarin.android\xbuild\Xamarin\Android</MSBuildSrcDir>
+    <MSBuildTargetsSrcDir>$(XamarinAndroidSourcePath)\src\Xamarin.Android.Build.Tasks\MSBuild\Xamarin\Android</MSBuildTargetsSrcDir>
+    <FirstInstallerFrameworkVersion Condition="Exists('$(FrameworkSrcDir)\$(AndroidFirstFrameworkVersion)')">$(AndroidFirstFrameworkVersion)</FirstInstallerFrameworkVersion>
+    <FirstInstallerFrameworkVersion Condition="'$(FirstInstallerFrameworkVersion)' == ''">$(AndroidLatestStableFrameworkVersion)</FirstInstallerFrameworkVersion>
+    <BclFrameworkVersion>v1.0</BclFrameworkVersion>
+    <LibExtension Condition=" '$(HostOS)' == 'Darwin' ">dylib</LibExtension>
+    <LibExtension Condition=" '$(HostOS)' == 'Linux' ">so</LibExtension>
+    <LibExtension Condition=" '$(HostOS)' == 'Windows' ">dll</LibExtension>
+    <IncludeMonoBundleComponents Condition="'$(IncludeMonoBuildComponents)' == ''">True</IncludeMonoBundleComponents>
+  </PropertyGroup>
+  <ItemGroup>
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\AndroidApiInfo.xml" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\mono.android.dex" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\Mono.Android.dll" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\mono.android.jar" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\Mono.Android.pdb" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\RedistList\FrameworkList.xml" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\Mono.Android.Export.dll" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\Mono.Android.Export.pdb" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\OpenTK-1.0.dll" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\OpenTK-1.0.pdb" />
+    <_FrameworkFiles Include="@(MonoFacadeAssembly->'$(FrameworkSrcDir)\$(BclFrameworkVersion)\Facades\%(Identity)')" />
+    <_FrameworkFiles Include="@(MonoProfileAssembly->'$(FrameworkSrcDir)\$(BclFrameworkVersion)\%(Identity)')" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Java.Interop.dll" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Mono.Data.Sqlite.dll.config" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Mono.Posix.dll" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\RedistList\FrameworkList.xml" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\System.EnterpriseServices.dll" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Xamarin.Android.NUnitLite.dll" />
+    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\OpenTK-1.0.xml" />
+  </ItemGroup>
+  <!-- Support for PR builds -->
+  <ItemGroup Condition="Exists('$(FrameworkSrcDir)\$(AndroidFirstFrameworkVersion)')">
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v4.4.87\AndroidApiInfo.xml" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v4.4.87\mono.android.dex" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v4.4.87\Mono.Android.dll" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v4.4.87\mono.android.jar" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v4.4.87\Mono.Android.pdb" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v4.4.87\RedistList\FrameworkList.xml" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.0\AndroidApiInfo.xml" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.0\mono.android.dex" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.0\Mono.Android.dll" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.0\mono.android.jar" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.0\Mono.Android.pdb" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.0\RedistList\FrameworkList.xml" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.1\AndroidApiInfo.xml" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.1\mono.android.dex" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.1\Mono.Android.dll" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.1\mono.android.jar" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.1\Mono.Android.pdb" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.1\RedistList\FrameworkList.xml" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v6.0\AndroidApiInfo.xml" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v6.0\mono.android.dex" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v6.0\Mono.Android.dll" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v6.0\mono.android.jar" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v6.0\Mono.Android.pdb" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v6.0\RedistList\FrameworkList.xml" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.0\AndroidApiInfo.xml" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.0\mono.android.dex" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.0\Mono.Android.dll" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.0\mono.android.jar" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.0\Mono.Android.pdb" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.0\RedistList\FrameworkList.xml" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.1\AndroidApiInfo.xml" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.1\mono.android.dex" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.1\Mono.Android.dll" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.1\mono.android.jar" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.1\Mono.Android.pdb" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.1\RedistList\FrameworkList.xml" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.0\AndroidApiInfo.xml" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.0\mono.android.dex" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.0\Mono.Android.dll" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.0\mono.android.jar" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.0\Mono.Android.pdb" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.0\RedistList\FrameworkList.xml" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.1\AndroidApiInfo.xml" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.1\mono.android.dex" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.1\Mono.Android.dll" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.1\mono.android.jar" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.1\Mono.Android.pdb" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.1\RedistList\FrameworkList.xml" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(AndroidLatestFrameworkVersion)\AndroidApiInfo.xml" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(AndroidLatestFrameworkVersion)\mono.android.dex" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(AndroidLatestFrameworkVersion)\Mono.Android.dll" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(AndroidLatestFrameworkVersion)\mono.android.jar" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(AndroidLatestFrameworkVersion)\Mono.Android.pdb" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(AndroidLatestFrameworkVersion)\RedistList\FrameworkList.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\android-support-multidex.jar" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\cil-strip.exe" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\class-parse.exe" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\desugar_deploy.jar" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\FSharp.Compiler.CodeDom.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\FSharp.Core.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\generator.exe" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\HtmlAgilityPack.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\illinkanalyzer.exe" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Irony.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\javadoc-to-mdoc.exe" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.dll.config" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Export.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Tools.Cecil.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Tools.Diagnostics.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Tools.JavaCallableWrappers.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Runtime.Environment.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Runtime.Environment.dll.config" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\jcw-gen.exe" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\jnimarshalmethod-gen.exe" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\LayoutBinding.cs" />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-android.debug.so')" />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-android.release.so')" />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-btls-shared.so')" />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-profiler-aot.so')" />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-profiler-log.so')" />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libMonoPosixHelper.so')" />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmonosgen-2.0.so')" />
+    <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libsqlite3_xamarin.so')" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\libZipSharp.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\libZipSharp.dll.config" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\logcat-parse.exe" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\mdoc.exe" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\mkbundle.exe" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\mkbundle-api.h" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\mono-symbolicate.exe" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.CSharp.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Options.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Terminal.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\monodoc.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\MULTIDEX_JAR_LICENSE" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\proguard\lib\proguard.jar"/>
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\proguard\license.html" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\r8.jar" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\SgmlReaderDll.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Analysis.targets" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Bindings.targets" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Build.Tasks.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.BuildInfo.txt" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Cecil.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Cecil.Mdb.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Common.props" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Common.targets" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.CSharp.targets" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.D8.targets" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Designer.targets" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.FSharp.targets" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.PCLSupport.props" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.PCLSupport.targets" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.SkipCases.projitems" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.Aidl.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.AndroidSdk.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.AnnotationSupport.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.ApiXmlAdjuster.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.Bytecode.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.JavaDocImporter.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.VisualBasic.targets" />
+  </ItemGroup>
+  <ItemGroup>
+    <_MSBuildTargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\Xamarin.Android.Bindings.After.targets" />
+    <_MSBuildTargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\Xamarin.Android.Bindings.Before.targets" />
+    <_MSBuildTargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\Xamarin.Android.Common\ImportAfter\Microsoft.Cpp.Android.targets" />
+    <_MSBuildTargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\Xamarin.Android.Common.After.targets" />
+    <_MSBuildTargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\Xamarin.Android.Common.Before.targets" />
+    <_MSBuildTargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\Xamarin.Android.DefaultOutputPaths.targets" />
+  </ItemGroup>
+  <ItemGroup>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\jit-times.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\libzip.dll" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\x64\libzip.dll" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\proguard\bin\proguard.bat" />
+    <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libmono-android.debug.dll" />
+    <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libmono-android.release.dll" />
+    <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libMonoPosixHelper.dll" />
+    <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libmonosgen-2.0.dll" />
+  </ItemGroup>
+  <ItemGroup>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\illinkanalyzer" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\jit-times" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\mono" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\mono-symbolicate" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-android.debug.$(LibExtension)" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-android.release.$(LibExtension)" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-profiler-aot.$(LibExtension)" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-profiler-log.$(LibExtension)" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libMonoPosixHelper.$(LibExtension)" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmonosgen-2.0.$(LibExtension)" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\libzip.5.0.$(LibExtension)" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\proguard\bin\proguard.sh" />
+  </ItemGroup>
+  <!-- Allow us to exclude mono bundle files for PR builds -->
+  <ItemGroup Condition="'$(IncludeMonoBundleComponents)' == 'True'">
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\cross-arm.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\cross-arm64.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\cross-x86.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\cross-x86_64.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\llc.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\opt.exe" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\cross-arm" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\cross-arm64" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\cross-x86" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\cross-x86_64" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\llc" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\opt" />
+  </ItemGroup>
+  <ItemGroup>
+    <XATargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\..\Xamarin.Android.Sdk.props" />
+    <XATargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\..\Xamarin.Android.Sdk.targets" />
+  </ItemGroup>
+  <ItemGroup>
+    <LegacyTargetsFiles Include="$(RootBuildDir)\lib\xamarin.android\xbuild\Novell\MonoDroid.FSharp.targets" />
+    <LegacyTargetsFiles Include="$(RootBuildDir)\lib\xamarin.android\xbuild\Novell\Novell.MonoDroid.Common.targets" />
+    <LegacyTargetsFiles Include="$(RootBuildDir)\lib\xamarin.android\xbuild\Novell\Novell.MonoDroid.CSharp.targets" />
+  </ItemGroup>
+  <ItemGroup>
+    <VersionFiles Include="$(RootBuildDir)\Version" />
+    <VersionFiles Include="$(RootBuildDir)\Version.commit" />
+    <VersionFiles Include="$(RootBuildDir)\Version.rev" />
+  </ItemGroup>
+  <!-- monodroid -->
+  <ItemGroup Condition="Exists('$(MSBuildSrcDir)\Mono.Android.DebugRuntime-debug.apk')">
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\OpenTK.dll" />
+    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\OpenTK.pdb" />
+    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\OpenTK.xml" />
+    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\Mono.Android.xml" />
+    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\v4.4.87\Mono.Android.xml" />
+    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\v5.0\Mono.Android.xml" />
+    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\v5.1\Mono.Android.xml" />
+    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\v6.0\Mono.Android.xml" />
+    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\v7.0\Mono.Android.xml" />
+    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\v7.1\Mono.Android.xml" />
+    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\v8.0\Mono.Android.xml" />
+    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\v8.1\Mono.Android.xml" />
+    <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(AndroidLatestFrameworkVersion)\Mono.Android.xml" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\ICSharpCode.SharpZipLib.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\INIFileParser.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\jar2xml.jar" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.AndroidTools.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Android.DebugRuntime-arm64-v8a.apk" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Android.DebugRuntime-armeabi-v7a.apk" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Android.DebugRuntime-debug.apk" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Android.DebugRuntime-debug.xml" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Android.DebugRuntime-x86.apk" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Android.DebugRuntime-x86_64.apk" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Analysis.Compatibility.targets" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Analysis.targets" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Analysis.Tasks.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Build.Debugging.Tasks.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Common.Debugging.props" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Common.Debugging.targets" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.ResourceProcessors.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.AndroidTools.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Installer.AndroidSDK.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Installer.Build.Tasks.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Installer.Common.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Installer.Common.targets" />
+    <LegacyTargetsFiles Include="$(RootBuildDir)\lib\xamarin.android\xbuild\Novell\Xamarin.Android.Bindings.targets" />
+    <LegacyTargetsFiles Include="$(RootBuildDir)\lib\xamarin.android\xbuild\Novell\Xamarin.Android.VisualBasic.targets" />
+    <MonoDocFiles Include="$(RootBuildDir)\lib\monodoc\MonoAndroid-docs.source" />
+    <MonoDocFiles Include="$(RootBuildDir)\lib\monodoc\MonoAndroid-lib.tree" />
+    <MonoDocFiles Include="$(RootBuildDir)\lib\monodoc\MonoAndroid-lib.zip" />
+  </ItemGroup>
+  <Target Name="ConstructInstallerItems"
+      Returns="@(FrameworkItemsWin);@(FrameworkItemsUnix);@(MSBuildItemsWin);@(MSBuildItemsUnix)">
+    <ItemGroup>
+      <FrameworkItemsWin Include="@(_FrameworkFiles);@(_FrameworkFilesWin)">
+        <RelativePath>$([MSBuild]::MakeRelative($(FrameworkSrcDir), %(FullPath)))</RelativePath>
+      </FrameworkItemsWin>
+      <FrameworkItemsUnix Include="@(_FrameworkFiles)">
+        <RelativePath>$([MSBuild]::MakeRelative($(FrameworkSrcDir), %(FullPath)))</RelativePath>
+      </FrameworkItemsUnix>
+      <MSBuildItemsWin Include="@(_MSBuildFiles);@(_MSBuildFilesWin)">
+        <RelativePath>$([MSBuild]::MakeRelative($(MSBuildSrcDir), %(FullPath)))</RelativePath>
+      </MSBuildItemsWin>
+      <MSBuildItemsWin Include="@(_MSBuildTargetsSrcFiles)">
+        <RelativePath>$([MSBuild]::MakeRelative($(MSBuildTargetsSrcDir), %(FullPath)))</RelativePath>
+      </MSBuildItemsWin>
+      <MSBuildItemsWin Include="@(_MSBuildLibHostFilesWin)">
+        <RelativePath>%(Filename)%(Extension)</RelativePath>
+      </MSBuildItemsWin>
+      <MSBuildItemsUnix Include="@(_MSBuildFiles);@(_MSBuildFilesUnix)">
+        <RelativePath>$([MSBuild]::MakeRelative($(MSBuildSrcDir), %(FullPath)))</RelativePath>
+      </MSBuildItemsUnix>
+      <MSBuildItemsUnix Include="@(_MSBuildTargetsSrcFiles)">
+        <RelativePath>$([MSBuild]::MakeRelative($(MSBuildTargetsSrcDir), %(FullPath)))</RelativePath>
+      </MSBuildItemsUnix>
+    </ItemGroup>
+  </Target>
+  <Target Name="GetXAVersion"
+      DependsOnTargets="GetXAVersionInfo"
+      Returns="$(XAVersion)">
+    <PropertyGroup>
+      <XAVersion>$(ProductVersion).$(XAVersionCommitCount)</XAVersion>
+      <_Branch>$(XAVersionBranch.Replace ('/', '-'))</_Branch>
+      <_Branch>$(_Branch.Replace ('\', '-'))</_Branch>
+      <XAOSSInstallerSuffix>OSS-$(ProductVersion).$(XAVersionCommitCount)_$(_Branch)_$(XAVersionHash)</XAOSSInstallerSuffix>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/build-tools/scripts/Packaging.mk
+++ b/build-tools/scripts/Packaging.mk
@@ -6,6 +6,17 @@ _BUNDLE_ZIPS_INCLUDE  = \
 _BUNDLE_ZIPS_EXCLUDE  = \
 	$(ZIP_OUTPUT_BASENAME)/bin/*/bundle-*.zip
 
+create-installers: create-pkg create-vsix
+
+create-pkg:
+	MONO_IOMAP=all MONO_OPTIONS="$(MONO_OPTIONS)" $(call MSBUILD_BINLOG,create-pkg) /p:Configuration=$(CONFIGURATION) /t:CreatePkg \
+		build-tools/create-pkg/create-pkg.csproj \
+		$(if $(PACKAGE_VERSION),/p:ProductVersion="$(PACKAGE_VERSION)") \
+		$(if $(PACKAGE_VERSION_REV),/p:XAVersionCommitCount="$(PACKAGE_VERSION_REV)") \
+		$(if $(PKG_LICENSE_EN),/p:PkgLicenseSrcEn="$(PKG_LICENSE_EN)") \
+		$(if $(PKG_OUTPUT_PATH),/p:PkgProductOutputPath="$(PKG_OUTPUT_PATH)") \
+		$(if $(_MSBUILD_ARGS),"$(_MSBUILD_ARGS)")
+
 create-vsix:
 	MONO_IOMAP=all MONO_OPTIONS="$(MONO_OPTIONS)" $(call MSBUILD_BINLOG,create-vsix) /p:Configuration=$(CONFIGURATION) /p:CreateVsixContainer=True \
 		build-tools/create-vsix/create-vsix.csproj \
@@ -16,7 +27,8 @@ create-vsix:
 		$(if $(REPO_NAME),/p:XARepositoryName="$(REPO_NAME)") \
 		$(if $(PACKAGE_HEAD_BRANCH),/p:XAVersionBranch="$(PACKAGE_HEAD_BRANCH)") \
 		$(if $(PACKAGE_VERSION_REV),/p:XAVersionCommitCount="$(PACKAGE_VERSION_REV)") \
-		$(if $(COMMIT),/p:XAVersionHash="$(COMMIT)")
+		$(if $(COMMIT),/p:XAVersionHash="$(COMMIT)") \
+		$(if $(_MSBUILD_ARGS),"$(_MSBUILD_ARGS)")
 
 package-oss-name:
 	@echo ZIP_OUTPUT=$(ZIP_OUTPUT)


### PR DESCRIPTION
Introduces a new `create-pkg` project next to `create-vsix` to be used
in a similar way to create a macOS installer for xamarin-android. The
`build-tools/installers/create-installers.targets` file has also been
added to keep track of all of the content we require in both our macOS
and Windows installers. These shared items, properties, and targets are
used by both installer projects to ensure uniformity between the two
installers we produce.

The `ConstructInstallerItems` target determines the majority of the files
which should end up in the installer. Behavior will vary depending on the
existance of certain files or the values of certain msbuild properties.
This was done intentionally to be able to support creating installers for
PR builds, open source packages, and commercial packages.

The `AndroidFirstFrameworkVersion`, `AndroidLatestStableFrameworkVersion`,
and `AndroidLatestFrameworkVersion` MSBuild properties (along with some
hardcoded values) are used to determine which API levels the installer
will support.

The `AndroidSupportedTargetJitAbi` MSBuild property is used to determine
which Android ABIs the installer will support.

The `IncludeMonoBundleComponents` MSBuild property is used to determine
whether or not the components which come from a full mono integration
build should be included in the installers.

The new `create-installers` make target will attempt to package all of
the relevant files for every ABI specified in the `ALL_JIT_ABIS` variable
in `build-tools/scripts/BuildEverything.mk`. This behavior can be
overridden by specifying an empty value for `_MSBUILD_ARGS` when calling
the `create-installers` make rule (as build.groovy does), or by providing
an alternate value for `/p:AndroidSupportedTargetJitAbis` when building
either installer directly from MSBuild.

The build.groovy script has been updated to handle creating different
installer types for PR builds and full builds. Our macOS PR builds will
now build a mxe-win flavored version of `libmono-android`, so that it can
be included in a vsix installer and used to extend test coverage for our
PR builds in the future. PR builds will also package a limited set of
Android ABI support as briefly mentioned above.

A new pkg preinstall script has also been added to fix an issue that
would result in old installations being left on disk. Now, the macOS
installer will attempt to remove the version currently symlinked to
`/Library/Frameworks/Xamarin.Android.framework/Versions/Current`
before running.

Fixes #2686.