### PR TITLE
Bump $(ProductVersion) to 9.2.99

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -12,7 +12,7 @@
       Condition=" Exists('$(MSBuildThisFileDirectory)Configuration.OperatingSystem.props') And '$(DoNotLoadOSProperties)' != 'True' "
   />
   <PropertyGroup>
-    <ProductVersion>9.1.199</ProductVersion>
+    <ProductVersion>9.2.99</ProductVersion>
     <!-- Used by the `build-tools/create-vsix` build so that `Mono.Android.Export.dll`/etc. are only included *once* -->
     <!-- Should correspond to the first value from `$(API_LEVELS)` in `build-tools/scripts/BuildEverything.mk` -->
     <AndroidFirstFrameworkVersion Condition="'$(AndroidFirstFrameworkVersion)' == ''">v4.4</AndroidFirstFrameworkVersion>


### PR DESCRIPTION
The latest commercial Xamarin.Android preview release coming from d16-0
is now versioned 9.2.0. A $(ProductVersion) bump is now required so that
newer versions of the Xamarin.Android .vsix installer can be installed
on top of the latest Visual Studio 2019 Previews.