### PR TITLE
[tests] Create test results, when processing logcat output fails

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
@@ -10,6 +10,8 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 #endif  // !APP
 
+using Xamarin.Android.BuildTools.PrepTasks;
+
 namespace Xamarin.Android.Tools.BootstrapTasks
 {
 #if !APP
@@ -137,55 +139,11 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				}
 			}
 
-			var doc       = new XDocument (
-				new XElement ("test-results",
-					new XAttribute ("date", DateTime.Now.ToString ("yyyy-MM-dd")),
-					new XAttribute ("errors", "1"),
-					new XAttribute ("failures", "0"),
-					new XAttribute ("ignored", "0"),
-					new XAttribute ("inconclusive", "0"),
-					new XAttribute ("invalid", "0"),
-					new XAttribute ("name", destFile),
-					new XAttribute ("not-run", "0"),
-					new XAttribute ("skipped", "0"),
-					new XAttribute ("time", DateTime.Now.ToString ("HH:mm:ss")),
-					new XAttribute ("total", "1"),
-					new XElement ("environment",
-						new XAttribute ("nunit-version", "3.6.0.0"),
-						new XAttribute ("clr-version", "4.0.30319.42000"),
-						new XAttribute ("os-version", "Unix 15.6.0.0"),
-						new XAttribute ("platform", "Unix"),
-						new XAttribute ("cwd", Environment.CurrentDirectory),
-						new XAttribute ("machine-name", Environment.MachineName),
-						new XAttribute ("user", Environment.UserName),
-						new XAttribute ("user-domain", Environment.MachineName)),
-					new XElement ("culture-info",
-						new XAttribute ("current-culture", "en-US"),
-						new XAttribute ("current-uiculture", "en-US")),
-					new XElement ("test-suite",
-						new XAttribute ("type", "APK-File"),
-						new XAttribute ("name", testSuiteName),
-						new XAttribute ("executed", "True"),
-						new XAttribute ("result", "Failure"),
-						new XAttribute ("success", "False"),
-						new XAttribute ("time", "0"),
-						new XAttribute ("asserts", "0"),
-						new XElement ("results",
-							new XElement ("test-case",
-								new XAttribute ("name", testCaseName),
-								new XAttribute ("executed", "True"),
-								new XAttribute ("result", "Error"),
-								new XAttribute ("success", "False"),
-								new XAttribute ("time", "0.0"),
-								new XAttribute ("asserts", "1"),
-								new XElement ("failure",
-									new XElement ("message",
-										$"Error processing `{sourceFile}`.  " +
-										$"Check the build log for execution errors.{Environment.NewLine}" +
-										$"File contents:{Environment.NewLine}",
-										new XCData (contents.ToString ())),
-									new XElement ("stack-trace", e.ToString ())))))));
-			doc.Save (destFile);
+			var message = $"Error processing `{sourceFile}`.  " +
+				$"Check the build log for execution errors.{Environment.NewLine}" +
+				$"File contents:{Environment.NewLine}";
+
+			ErrorResultsHelper.CreateErrorResultsFile (destFile, testSuiteName, testCaseName, e, message, contents.ToString ());
 		}
 
 		// Example `SourceFile`:
@@ -212,9 +170,9 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 #if APP
 	// Compile:
-	//   csc build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs /out:test.exe /d:APP /r:System.Xml.Linq.dll
+	//   csc build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs /out:test.exe /d:APP /r:System.Xml.Linq.dll /r:bin/BuildDebug/xa-prep-tasks.dll
 	// Run:
-	//   mono test.exe test.xml
+	//   MONO_PATH=bin/BuildDebug mono test.exe test.xml
 	// Validate:
 	//   curl -o Results.xsd https://nunit.org/docs/files/Results.xsd
 	//   MONO_XMLTOOL_ERROR_DETAILS=yes mono-xmltool  --validate Results.xsd test.xml

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ErrorResultsHelper.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ErrorResultsHelper.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Xml.Linq;
+
+namespace Xamarin.Android.BuildTools.PrepTasks
+{
+	public static class ErrorResultsHelper
+	{
+		public static void CreateErrorResultsFile (string destFile, string testSuiteName, string testCaseName, Exception e, string message, string contents = null)
+		{
+			var messageElement = new XElement ("message", message);
+
+			if (contents != null)
+				messageElement.Add (new XCData (contents));
+
+			var failureElement = new XElement ("failure", messageElement);
+
+			if (e != null)
+				failureElement.Add (new XElement ("stack-trace", e.ToString ()));
+
+			var doc = new XDocument (
+				new XElement ("test-results",
+					new XAttribute ("date", DateTime.Now.ToString ("yyyy-MM-dd")),
+					new XAttribute ("errors", "1"),
+					new XAttribute ("failures", "0"),
+					new XAttribute ("ignored", "0"),
+					new XAttribute ("inconclusive", "0"),
+					new XAttribute ("invalid", "0"),
+					new XAttribute ("name", destFile),
+					new XAttribute ("not-run", "0"),
+					new XAttribute ("skipped", "0"),
+					new XAttribute ("time", DateTime.Now.ToString ("HH:mm:ss")),
+					new XAttribute ("total", "1"),
+					new XElement ("environment",
+						new XAttribute ("nunit-version", "3.6.0.0"),
+						new XAttribute ("clr-version", "4.0.30319.42000"),
+						new XAttribute ("os-version", "Unix 15.6.0.0"),
+						new XAttribute ("platform", "Unix"),
+						new XAttribute ("cwd", Environment.CurrentDirectory),
+						new XAttribute ("machine-name", Environment.MachineName),
+						new XAttribute ("user", Environment.UserName),
+						new XAttribute ("user-domain", Environment.MachineName)),
+					new XElement ("culture-info",
+						new XAttribute ("current-culture", "en-US"),
+						new XAttribute ("current-uiculture", "en-US")),
+					new XElement ("test-suite",
+						new XAttribute ("type", "APK-File"),
+						new XAttribute ("name", testSuiteName),
+						new XAttribute ("executed", "True"),
+						new XAttribute ("result", "Failure"),
+						new XAttribute ("success", "False"),
+						new XAttribute ("time", "0"),
+						new XAttribute ("asserts", "0"),
+						new XElement ("results",
+							new XElement ("test-case",
+								new XAttribute ("name", testCaseName),
+								new XAttribute ("executed", "True"),
+								new XAttribute ("result", "Error"),
+								new XAttribute ("success", "False"),
+								new XAttribute ("time", "0.0"),
+								new XAttribute ("asserts", "1"),
+								failureElement)))));
+			doc.Save (destFile);
+		}
+	}
+}

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ProcessPlotInput.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ProcessPlotInput.cs
@@ -59,7 +59,15 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 			if (File.Exists (InputFilename))
 				return true;
 
-			Log.LogError ($"Input file '{InputFilename}' doesn't exist.");
+			var errorMessage = $"Input file '{InputFilename}' doesn't exist.";
+			Log.LogError (errorMessage);
+
+			ErrorResultsHelper.CreateErrorResultsFile (
+				Path.ChangeExtension (ResultsFilename, null) + LabelSuffix + ".xml",
+				ApplicationPackageName,
+				"logcat output",
+				new Exception (errorMessage),
+				$"Input file '{InputFilename}' doesn't exist. It might be caused by various reasons. Among them: the test crashed or test did not run.");
 
 			return false;
 		}

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
@@ -32,6 +32,8 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -59,6 +61,7 @@
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\ProcessLogcatTiming.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\CreateFilePaths.cs" />
     <Compile Include="Xamarin.Android.BuildTools.PrepTasks\NDKInfo.cs" />
+    <Compile Include="Xamarin.Android.BuildTools.PrepTasks\ErrorResultsHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\external\xamarin-android-tools\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj">


### PR DESCRIPTION
It is usually hard to notice the problem, when logcat processing fails
because of the logcat file missing. Thus it will make it easier to
find, when we create `TestResults` file with an error, similar to
`RenameTestCases` task.
