### PR TITLE
[monodroid] Hookup the jit_failed event as well

### DIFF
--- a/src/monodroid/jni/dylib-mono.cc
+++ b/src/monodroid/jni/dylib-mono.cc
@@ -145,6 +145,7 @@ bool DylibMono::init (void *libmono_handle)
 	LOAD_SYMBOL(mono_profiler_create)
 	LOAD_SYMBOL(mono_profiler_set_jit_begin_callback)
 	LOAD_SYMBOL(mono_profiler_set_jit_done_callback)
+	LOAD_SYMBOL(mono_profiler_set_jit_failed_callback)
 	LOAD_SYMBOL(mono_profiler_set_thread_started_callback)
 	LOAD_SYMBOL(mono_profiler_set_thread_stopped_callback)
 
@@ -700,6 +701,15 @@ DylibMono::profiler_set_jit_done_callback (MonoProfilerHandle handle, MonoJitDon
 		return;
 
 	mono_profiler_set_jit_done_callback (handle, done_ftn);
+}
+
+void
+DylibMono::profiler_set_jit_failed_callback (MonoProfilerHandle handle, MonoJitFailedEventFunc failed_ftn)
+{
+	if (mono_profiler_set_jit_failed_callback == nullptr)
+		return;
+
+	mono_profiler_set_jit_failed_callback (handle, failed_ftn);
 }
 
 void

--- a/src/monodroid/jni/dylib-mono.h
+++ b/src/monodroid/jni/dylib-mono.h
@@ -164,6 +164,7 @@ inline MonoCounters& operator |= (MonoCounters& left, MonoCounters right)
 typedef void (*MonoDomainFunc) (MonoDomain *domain, void* user_data);
 typedef void (*MonoJitBeginEventFunc) (MonoProfiler *prof, MonoMethod *method);
 typedef void (*MonoJitDoneEventFunc) (MonoProfiler *prof, MonoMethod *method, MonoJitInfo* jinfo);
+typedef void (*MonoJitFailedEventFunc) (MonoProfiler *prof, MonoMethod *method);
 typedef void (*MonoThreadStartedEventFunc) (MonoProfiler *prof, uintptr_t tid);
 typedef void (*MonoThreadStoppedEventFunc) (MonoProfiler *prof, uintptr_t tid);
 
@@ -453,6 +454,7 @@ class DylibMono
 	typedef MonoProfilerHandle     (*monodroid_mono_profiler_create_fptr) (MonoProfiler* profiler);
 	typedef void                   (*monodroid_mono_profiler_set_jit_begin_callback_fptr) (MonoProfilerHandle handle, MonoJitBeginEventFunc begin_ftn);
 	typedef void                   (*monodroid_mono_profiler_set_jit_done_callback_fptr) (MonoProfilerHandle handle, MonoJitDoneEventFunc done_ftn);
+	typedef void                   (*monodroid_mono_profiler_set_jit_failed_callback_fptr) (MonoProfilerHandle handle, MonoJitFailedEventFunc failed_ftn);
 	typedef void                   (*monodroid_mono_profiler_set_thread_started_callback_fptr) (MonoProfilerHandle handle, MonoThreadStartedEventFunc start_ftn);
 	typedef void                   (*monodroid_mono_profiler_set_thread_stopped_callback_fptr) (MonoProfilerHandle handle, MonoThreadStoppedEventFunc stopped_ftn);
 
@@ -552,6 +554,7 @@ struct DylibMono {
 	monodroid_mono_profiler_set_thread_started_callback_fptr        mono_profiler_set_thread_started_callback;
 	monodroid_mono_profiler_set_thread_stopped_callback_fptr        mono_profiler_set_thread_stopped_callback;
 	monodroid_mono_profiler_set_jit_begin_callback_fptr             mono_profiler_set_jit_begin_callback;
+	monodroid_mono_profiler_set_jit_failed_callback_fptr            mono_profiler_set_jit_failed_callback;
 
 #ifdef __cplusplus
 	bool initialized;
@@ -657,6 +660,7 @@ public:
 	void profiler_install_thread (MonoProfilerHandle handle, MonoThreadStartedEventFunc start_ftn, MonoThreadStoppedEventFunc end_ftn);
 	void profiler_set_jit_begin_callback (MonoProfilerHandle handle, MonoJitBeginEventFunc begin_ftn);
 	void profiler_set_jit_done_callback (MonoProfilerHandle handle, MonoJitDoneEventFunc done_ftn);
+	void profiler_set_jit_failed_callback (MonoProfilerHandle handle, MonoJitFailedEventFunc failed_ftn);
 	void property_set_value (MonoProperty *prop, void *obj, void **params, MonoObject **exc);
 	void register_bundled_assemblies (const MonoBundledAssembly **assemblies);
 	void register_config_for_assembly (const char* assembly_name, const char* config_xml);


### PR DESCRIPTION
Refactor the events code a bit to avoid duplication

Note: I didn't see any failed events in the log. I hoped it might shed
light on parts like this one:

    JIT method  begin: (wrapper managed-to-native) Android.Runtime.Logger:__android_log_print (Android.Runtime.LogLevel,string,string,string,intptr) elapsed: 0s:139::103087
    JIT method   done: Android.Runtime.Logger:__android_log_print (Android.Runtime.LogLevel,string,string,string,intptr) elapsed: 0s:139::226837
    JIT method   done: (wrapper managed-to-native) Android.Runtime.Logger:__android_log_print (Android.Runtime.LogLevel,string,string,string,intptr) elapsed: 0s:139::232723
    JIT method   done: Android.Runtime.Logger:__android_log_print (Android.Runtime.LogLevel,string,string,string,intptr) elapsed: 0s:139::238712

I think it is still useful to have that event hooked up, so that we
see these in our `methods.txt` log file, when it happens. Looking at
the mono code, this event is raised in case of mono error and when
generic sharable method is not created properly.