### PR TITLE
Initialize SystemDependencyProvider on startup.

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -195,6 +195,8 @@ namespace Android.Runtime {
 			androidRuntime = new AndroidRuntime (args->env, args->javaVm, androidSdkVersion > 10, args->grefLoader, args->Loader_loadClass);
 #endif // JAVA_INTEROP
 
+			Mono.SystemDependencyProvider.Initialize ();
+
 			if (Logger.LogTiming) {
 				elapsed = stopper.ElapsedMilliseconds;
 				totalElapsed += elapsed;


### PR DESCRIPTION
Requires https://github.com/mono/mono/pull/13106 to be backported and Mono bumped.

This will fix https://github.com/xamarin/xamarin-android/issues/2679.