### PR TITLE
Avoid play store warnings when building libraries

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -38,7 +38,7 @@
 + [XA0110](xa0110.md): Disabling $(AndroidExplicitCrunch) as it is not supported by `aapt2`. If you wish to use $(AndroidExplicitCrunch) please set $(AndroidUseAapt2) to false.
 + [XA0111](xa0111.md): Could not get the `aapt2` version. Please check it is installed correctly.
 + [XA0112](xa0112.md): `aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.
-+ [XA0113](xa0113.md): Google Play requires that new applications must use a `$(TargetFrameworkVersion)` of v8.0 (API level 26) or above.
++ [XA0113](xa0113.md): Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above.
 + [XA0114](xa0114.md): Google Play requires that application updates must use a `$(TargetFrameworkVersion)` of v8.0 (API level 26) or above.
 + [XA0115](xa0115.md): Invalid value 'armeabi' in $(AndroidSupportedAbis). This ABI is no longer supported. Please update your project properties.
 + [XA0116](xa0116.md): Unable to find `EmbeddedResource` of name `{ResourceName}`.

--- a/Documentation/guides/messages/xa0113.md
+++ b/Documentation/guides/messages/xa0113.md
@@ -1,9 +1,9 @@
 ﻿# Compiler Warning XA0113
 
-As of August 1st 2018 any new application uploaded to the google play
-store needs to target v8.0 (API 26) or above. If you are seeing this
-warning, you should update the `$(TargetFrameworkVersion)` of your projects
-to be v8.0 or above.
+As of August 1st 2018, new applications and application updates uploaded
+to the Google Play store need to target v8.0 (API 26) or above. If you are
+seeing this warning, you should update the `$(TargetFrameworkVersion)` of
+your projects to be v8.0 or above.
 
 If you are not targeting the Google Play store and wish to hide these
 warnings you can make use of the `/nowarn:XA0113` command line switch. 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
@@ -29,6 +29,8 @@ namespace Xamarin.Android.Tasks
 
 		public bool AotAssemblies { get; set; }
 
+		public bool AndroidApplication { get; set; } = true;
+
 		[Output]
 		public string TargetFrameworkVersion { get; set; }
 
@@ -185,11 +187,9 @@ namespace Xamarin.Android.Tasks
 			}
 
 			int apiLevel;
-			if (int.TryParse (AndroidApiLevel, out apiLevel)) {
+			if (AndroidApplication && int.TryParse (AndroidApiLevel, out apiLevel)) {
 				if (apiLevel < 26)
-					Log.LogCodedWarning ("XA0113", $"Google Play requires that new applications must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {TargetFrameworkVersion} (API level {AndroidApiLevel}).");
-				if (apiLevel < 26)
-					Log.LogCodedWarning ("XA0114", $"Google Play requires that application updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {TargetFrameworkVersion} (API level {AndroidApiLevel}).");
+					Log.LogCodedWarning ("XA0113", $"Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {TargetFrameworkVersion} (API level {AndroidApiLevel}).");
 				if (apiLevel < 19)
 					Log.LogCodedWarning ("XA0117", $"The TargetFrameworkVersion {TargetFrameworkVersion} is deprecated. Please update it to be v4.4 or higher.");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
@@ -188,7 +188,7 @@ namespace Xamarin.Android.Build.Tests {
 				UseLatestAndroidPlatformSdk = useLatestAndroidSdk,
 				AotAssemblies = false,
 				SequencePointsMode = "None",
-                AndroidApplication = true,
+				AndroidApplication = true,
 			};
 			Assert.AreEqual (expectedTaskResult, resolveSdks.Execute () && validateJavaVersion.Execute () && androidTooling.Execute (), $"Tasks should have {(expectedTaskResult ? "succeeded" : "failed" )}.");
 			Assert.AreEqual (expectedTargetFramework, androidTooling.TargetFrameworkVersion, $"TargetFrameworkVersion should be {expectedTargetFramework} but was {androidTooling.TargetFrameworkVersion}");
@@ -241,8 +241,8 @@ namespace Xamarin.Android.Build.Tests {
 				UseLatestAndroidPlatformSdk = false,
 				AotAssemblies = false,
 				SequencePointsMode = "None",
-                AndroidApplication = true,
-            };
+				AndroidApplication = true,
+			};
 			var start = DateTime.UtcNow;
 			Assert.IsTrue (resolveSdks.Execute (), "ResolveSdks should succeed!");
 			Assert.IsTrue (validateJavaVersion.Execute (), "ValidateJavaVersion should succeed!");
@@ -402,8 +402,8 @@ namespace Xamarin.Android.Build.Tests {
 				AndroidSdkPath = androidSdkPath,
 				UseLatestAndroidPlatformSdk = true,
 				TargetFrameworkVersion = userSelected,
-                AndroidApplication = true,
-            };
+				AndroidApplication = true,
+			};
 			Assert.IsTrue (resolveSdks.Execute (), "ResolveSdks should succeed!");
 			Assert.IsTrue (androidTooling.Execute (), "ResolveAndroidTooling should succeed!");
 			Assert.AreEqual (androidApiLevel, androidTooling.AndroidApiLevel, $"AndroidApiLevel should be {androidApiLevel}");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ResolveSdksTaskTests.cs
@@ -188,6 +188,7 @@ namespace Xamarin.Android.Build.Tests {
 				UseLatestAndroidPlatformSdk = useLatestAndroidSdk,
 				AotAssemblies = false,
 				SequencePointsMode = "None",
+                AndroidApplication = true,
 			};
 			Assert.AreEqual (expectedTaskResult, resolveSdks.Execute () && validateJavaVersion.Execute () && androidTooling.Execute (), $"Tasks should have {(expectedTaskResult ? "succeeded" : "failed" )}.");
 			Assert.AreEqual (expectedTargetFramework, androidTooling.TargetFrameworkVersion, $"TargetFrameworkVersion should be {expectedTargetFramework} but was {androidTooling.TargetFrameworkVersion}");
@@ -240,7 +241,8 @@ namespace Xamarin.Android.Build.Tests {
 				UseLatestAndroidPlatformSdk = false,
 				AotAssemblies = false,
 				SequencePointsMode = "None",
-			};
+                AndroidApplication = true,
+            };
 			var start = DateTime.UtcNow;
 			Assert.IsTrue (resolveSdks.Execute (), "ResolveSdks should succeed!");
 			Assert.IsTrue (validateJavaVersion.Execute (), "ValidateJavaVersion should succeed!");
@@ -400,7 +402,8 @@ namespace Xamarin.Android.Build.Tests {
 				AndroidSdkPath = androidSdkPath,
 				UseLatestAndroidPlatformSdk = true,
 				TargetFrameworkVersion = userSelected,
-			};
+                AndroidApplication = true,
+            };
 			Assert.IsTrue (resolveSdks.Execute (), "ResolveSdks should succeed!");
 			Assert.IsTrue (androidTooling.Execute (), "ResolveAndroidTooling should succeed!");
 			Assert.AreEqual (androidApiLevel, androidTooling.AndroidApiLevel, $"AndroidApiLevel should be {androidApiLevel}");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -749,6 +749,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<ResolveAndroidTooling
 			TargetFrameworkVersion="$(TargetFrameworkVersion)"
 			AndroidApiLevel="$(AndroidApiLevel)"
+			AndroidApplication="$(AndroidApplication)"
 			AndroidSdkPath="$(_AndroidSdkDirectory)"
 			AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
 			UseLatestAndroidPlatformSdk="$(AndroidUseLatestPlatformSdk)"
@@ -757,8 +758,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 			SequencePointsMode="$(_AndroidSequencePointsMode)"
 			ProjectFilePath="$(MSBuildProjectFullPath)"			
 			LintToolPath="$(LintToolPath)"
-			ZipAlignPath="$(ZipAlignToolPath)"
-			AndroidApplication="$(AndroidApplication)">
+			ZipAlignPath="$(ZipAlignToolPath)">
 		<Output TaskParameter="TargetFrameworkVersion"      PropertyName="TargetFrameworkVersion" />
 		<Output TaskParameter="AndroidApiLevel"             PropertyName="_AndroidApiLevel"            Condition="'$(_AndroidApiLevel)' == ''" />
 		<Output TaskParameter="AndroidApiLevelName"         PropertyName="_AndroidApiLevelName" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -757,7 +757,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 			SequencePointsMode="$(_AndroidSequencePointsMode)"
 			ProjectFilePath="$(MSBuildProjectFullPath)"			
 			LintToolPath="$(LintToolPath)"
-			ZipAlignPath="$(ZipAlignToolPath)">
+			ZipAlignPath="$(ZipAlignToolPath)"
+			AndroidApplication="$(AndroidApplication)">
 		<Output TaskParameter="TargetFrameworkVersion"      PropertyName="TargetFrameworkVersion" />
 		<Output TaskParameter="AndroidApiLevel"             PropertyName="_AndroidApiLevel"            Condition="'$(_AndroidApiLevel)' == ''" />
 		<Output TaskParameter="AndroidApiLevelName"         PropertyName="_AndroidApiLevelName" />


### PR DESCRIPTION
When you compile a library you might not want to target the latest SDK, as it could hose users targeting lower-end api-levels. However you currently get a warning that really only applies to applications, and not class libraries.
This PR skips the API Level check when the target isn't an application.
Also there were two near-identical warnings on the same check, so I consolidated those into a single warning (it looks like this was historical as updates vs new apps were on different timelines)

@jonathanpeppers 