### PR TITLE
[build] bump the emulator to 5264690

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -122,7 +122,7 @@
     <AndroidToolPath Condition=" '$(AndroidToolPath)' == '' ">$(AndroidSdkFullPath)\tools</AndroidToolPath>
     <AndroidToolsBinPath Condition=" '$(AndroidToolsBinPath)' == '' ">$(AndroidToolPath)\bin</AndroidToolsBinPath>
     <AndroidToolExe Condition=" '$(AndroidToolExe)' == '' ">android</AndroidToolExe>
-    <EmulatorVersion Condition=" '$(EmulatorVersion)' == '' ">5194135</EmulatorVersion>
+    <EmulatorVersion Condition=" '$(EmulatorVersion)' == '' ">5264690</EmulatorVersion>
     <EmulatorToolPath Condition=" '$(EmulatorToolPath)' == '' ">$(AndroidSdkFullPath)\emulator</EmulatorToolPath>
     <EmulatorToolExe Condition=" '$(EmulatorToolExe)' == '' ">emulator</EmulatorToolExe>
     <NdkBuildPath Condition=" '$(NdkBuildPath)' == '' And '$(HostOS)' != 'Windows' ">$(AndroidNdkDirectory)\ndk-build</NdkBuildPath>


### PR DESCRIPTION
Context: http://dl-ssl.google.com/android/repository/repository2-1.xml

Mainly doing this to make sure the following changes are sound:

* e84e502
* 7b16dd5

Details I'm seeing from the manifest:

    Generated from:ab bid:5264690 branch:aosp-emu-3.0-release
    Built on: Mon Jan 28 16:33:00 2019.