### PR TITLE
[Xamarin.Android.Build.Tasks] support F# 4.5 Windows path

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
@@ -42,6 +42,9 @@ Copyright (C) 2012 Xamarin. All rights reserved.
     </PropertyGroup>
     <!-- xbuild searches multiple MSBuildExtensionsPath32, but only in the Import element, so we can't determine this with a variable -->
     <Import
+      Condition="'$(Language)' != 'F#' And Exists('$(MSBuildToolsPath32)\..\..\..\Common7\IDE\CommonExtensions\Microsoft\FSharp\Microsoft.FSharp.Targets')"
+      Project="$(MSBuildToolsPath32)\..\..\..\Common7\IDE\CommonExtensions\Microsoft\FSharp\Microsoft.FSharp.Targets" />
+    <Import
       Condition="'$(Language)' != 'F#' And Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')"
       Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets" />
     <Import


### PR DESCRIPTION
Context: https://devblogs.microsoft.com/dotnet/announcing-f-4-5/

Since VS 15.8 on Windows, F# 4.5 is now installed along with Visual
Studio to support side-by-side installations. Previously F# was
installed in a system-wide location specified by `%FSHARPINSTALLDIR%`:

    C:\Program Files (x86)\Microsoft SDKs\F#\10.1\Framework\v4.0\

The new locations are, for example:

    C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\FSharp
    C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\Common7\IDE\CommonExtensions\Microsoft\FSharp

I have also seen a few instances where our F#-related MSBuild tests
failed on Windows, failing to import `Microsoft.FSharp.targets`:

    bin\TestRelease\temp\BuildBasicApplicationFSharp\UnnamedProject.fsproj error MSB4057:
        The target "Build" does not exist in the project.

In this case, *all* of our probing for `Microsoft.FSharp.targets`
failed:

    NoImport: $(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets at (44;5) Not imported due to false condition; ('$(Language)' != 'F#' And Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')) was evaluated as ('' != 'F#' And Exists('E:\A\_work\382\s\bin\Release\lib\xamarin.android\xbuild\Microsoft\VisualStudio\v15.0\FSharp\Microsoft.FSharp.Targets')).
    NoImport: $(FSharpInstallDir)Microsoft.FSharp.Targets at (47;5) Not imported due to false condition; ('$(Language)' != 'F#' And Exists('$(FSharpInstallDir)Microsoft.FSharp.Targets')) was evaluated as ('' != 'F#' And Exists('Microsoft.FSharp.Targets')).
    NoImport: $(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.1\Framework\v4.0\Microsoft.FSharp.Targets at (50;5) Not imported due to false condition; ('$(Language)' != 'F#' And Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.1\Framework\v4.0\Microsoft.FSharp.Targets')) was evaluated as ('' != 'F#' And Exists('E:\A\_work\382\s\bin\Release\lib\xamarin.android\xbuild\..\Microsoft SDKs\F#\4.1\Framework\v4.0\Microsoft.FSharp.Targets')).
    NoImport: $(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets at (53;5) Not imported due to false condition; ('$(Language)' != 'F#' And Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets')) was evaluated as ('' != 'F#' And Exists('E:\A\_work\382\s\bin\Release\lib\xamarin.android\xbuild\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets')).
    NoImport: $(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets at (56;5) Not imported due to false condition; ('$(Language)' != 'F#' And Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets')) was evaluated as ('' != 'F#' And Exists('E:\A\_work\382\s\bin\Release\lib\xamarin.android\xbuild\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets')).

So the fix here is to add an extra `<Import/>` for:

    $(MSBuildToolsPath32)\..\..\..\Common7\IDE\CommonExtensions\Microsoft\FSharp\Microsoft.FSharp.Targets

I found this path when digging through binlogs, which is how NuGet's
MSBuild targets are imported:

    <PropertyGroup>
      <NuGetRestoreTargets Condition="'$(NuGetRestoreTargets)'==''">$(MSBuildToolsPath32)\..\..\..\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.targets</NuGetRestoreTargets>
      ...
      </PropertyGroup>
    <Import Condition="Exists('$(NuGetRestoreTargets)')" Project="$(NuGetRestoreTargets)" />

Currently, I think you would have to modify `%FSHARPINSTALLDIR%` to
use F# 4.5 with Xamarin.Android on Windows.