### PR TITLE
[r8] bump to 1.3.52

### DIFF
--- a/src/r8/build.gradle
+++ b/src/r8/build.gradle
@@ -2,13 +2,15 @@ plugins {
     id 'java'
 }
 
+// See: https://r8.googlesource.com/r8/+/refs/tags/1.3.52/build.gradle#52
 repositories {
+    maven { url 'https://maven.google.com' }
+    maven { url 'https://kotlin.bintray.com/kotlinx' }
     mavenCentral()
-    google()
 }
 
 dependencies {
-    compile group: 'com.android.tools', name: 'r8', version: '1.2.52'
+    compile group: 'com.android.tools', name: 'r8', version: '1.3.52'
 }
 
 jar {


### PR DESCRIPTION
Context: https://mvnrepository.com/artifact/com.android.tools/r8/1.3.52
Context: https://r8.googlesource.com/r8/+/refs/tags/1.3.52/build.gradle#52

Update r8 to the latest stable release on Maven.

There is also now some dependencies on packages at:

    https://kotlin.bintray.com/kotlinx

I updated the `repositories` defined in `build.gradle` to match what r8's source code has.