### PR TITLE
Fix pipeline build publish location

### DIFF
--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -134,10 +134,7 @@ timestamps {
         stageWithTimeout('publish test error logs to Azure', 10, 'MINUTES', '', false) {  // Typically takes less than a minute
             echo "packaging test error logs"
 
-            sh """
-                cd ${XADir}
-                make package-test-errors
-               """
+            sh "make -C ${XADir} -k package-test-errors"
 
             def publishTestFilePaths = "${XADir}/xa-test-errors*"
             echo "publishTestFilePaths: ${publishTestFilePaths}"

--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -65,7 +65,8 @@ timestamps {
 
             def buildType = isPr ? 'PR' : 'CI'
 
-            echo "Job: ${env.JOB_BASE_NAME}"
+            echo "Job base name: ${env.JOB_BASE_NAME}"
+            echo "Job name: ${env.JOB_NAME}"
             echo "Branch: ${branch}"
             echo "Commit: ${commit}"
             echo "Build type: ${buildType}"
@@ -110,8 +111,8 @@ timestamps {
             }
         }
 
-        stageWithTimeout('publish packages to Azure', 10, 'MINUTES', XADir, true) {    // Typically takes less than a minute
-            def publishBuildFilePaths = "xamarin.android-oss*.zip,bin/${env.BuildFlavor}/bundle-*.zip,bin/Build*/Xamarin.Android.Sdk*.vsix,prepare-image-dependencies.sh,build-status*,xa-build-status*";
+        stageWithTimeout('publish packages to Azure', 10, 'MINUTES', '', true) {    // Typically takes less than a minute
+            def publishBuildFilePaths = "${XADir}/xamarin.android-oss*.zip,${XADir}/bin/${env.BuildFlavor}/bundle-*.zip,${XADir}/bin/Build*/Xamarin.Android.Sdk*.vsix,${XADir}/prepare-image-dependencies.sh,${XADir}/build-status*,${XADir}/xa-build-status*";
             echo "publishBuildFilePaths: ${publishBuildFilePaths}"
             def stageStatus = publishPackages(publishBuildFilePaths)
             if (stageStatus != 0) {
@@ -131,11 +132,11 @@ timestamps {
             }
         }
 
-        stageWithTimeout('publish test error logs to Azure', 10, 'MINUTES', XADir, false) {  // Typically takes less than a minute
+        stageWithTimeout('publish test error logs to Azure', 10, 'MINUTES', '', false) {  // Typically takes less than a minute
             echo "packaging test error logs"
             sh "make package-test-errors"
 
-            def publishTestFilePaths = "xa-test-errors*"
+            def publishTestFilePaths = "${XADir}/xa-test-errors*"
             echo "publishTestFilePaths: ${publishTestFilePaths}"
             def stageStatus = publishPackages(publishTestFilePaths)
             if (stageStatus != 0) {

--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -133,7 +133,11 @@ timestamps {
 
         stageWithTimeout('publish test error logs to Azure', 10, 'MINUTES', '', false) {  // Typically takes less than a minute
             echo "packaging test error logs"
-            sh "make package-test-errors"
+
+            sh """
+                cd ${XADir}
+                make package-test-errors
+               """
 
             def publishTestFilePaths = "${XADir}/xa-test-errors*"
             echo "publishTestFilePaths: ${publishTestFilePaths}"

--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -65,8 +65,7 @@ timestamps {
 
             def buildType = isPr ? 'PR' : 'CI'
 
-            echo "Job base name: ${env.JOB_BASE_NAME}"
-            echo "Job name: ${env.JOB_NAME}"
+            echo "Job: ${env.JOB_BASE_NAME}"
             echo "Branch: ${branch}"
             echo "Commit: ${commit}"
             echo "Build type: ${buildType}"


### PR DESCRIPTION
Related to PR #2743.  Prior to the Xamarin.Android (release) build moving from a freestyle to a pipeline build, the publish location included both the job name (xamarin-android) *and* the checkout directory name (xamarin-android) in the publish url path such as the following - note the redundant xamarin-android names (JOB_NAME/DIR_NAME) at the end:
http://xamjenkinsartifact.blob.core.windows.net/mono-jenkins-eval/xamarin-android/xamarin-android

After moving to the pipeline build based on the build.groovy jenkinsfile, the publish location changed to the following:
http://xamjenkinsartifact.blob.core.windows.net/mono-jenkins-eval/xamarin-android

This breaks anyone or any system that is looking for published packages in the original location.

The problem was introduced when the publish operation was inadvertently changed to execute from within the xamarin-android checkout directory.  Consequently, the directory itself was not included in the publish path.

The fix is to blank out the directory specifier and update the list of relative publish paths such that the publish command runs from the Jenkins workspace root directory, which is the parent of the xamarin-android checkout directory.  Consequently, the xamarin-android checkout directory now gets included in the publish link url.