### PR TITLE
[scripts] Check if the CrossCompiler is available.

### DIFF
--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -115,10 +115,10 @@
     <PropertyGroup>
       <_HostOS>$(HostOS)</_HostOS>
       <_ExeExtension></_ExeExtension>
-      <_HostOS Condition="'$(_HostOS)' == 'Windows'"></_HostOS>
-      <_ExeExtension Condition="'$(_HostOS)' == 'Windows'">.exe</_ExeExtension>
-      <_CrossCompilerAvailable Condition="Exists('$(_TopDir)\bin\$(Configuration)\lib\xamarin-android\xbuild\Xamarin\Android\$(_HostOS)\cross-arm$(_ExeExtension)')">False</_CrossCompilerAvailable>
-      <_CrossCompilerAvailable Condition="'$(_CrossCompilerAvailable)' == ''">False</_CrossCompilerAvailable>
+      <_HostOS Condition=" '$(_HostOS)' == 'Windows' "></_HostOS>
+      <_ExeExtension Condition=" '$(_HostOS)' == 'Windows' ">.exe</_ExeExtension>
+      <_CrossCompilerAvailable Condition="Exists('$(_TopDir)\bin\$(Configuration)\lib\xamarin-android\xbuild\Xamarin\Android\$(_HostOS)\cross-arm$(_ExeExtension)')">True</_CrossCompilerAvailable>
+      <_CrossCompilerAvailable Condition=" '$(_CrossCompilerAvailable)' == '' ">False</_CrossCompilerAvailable>
     </PropertyGroup>
     <ItemGroup Condition=" '$(USE_MSBUILD)' == '1' ">
       <_ApkTestProjectAot>
@@ -127,12 +127,12 @@
     </ItemGroup>
     <Exec 
         Command="$(_XABuild) %(_ApkTestProjectAot.Identity) %(_ApkTestProjectAot._BinLog) /t:SignAndroidPackage $(_XABuildProperties) /p:AotAssemblies=True"
-        Condition=" '$(Configuration)' == 'Release' And '$(_CrossCompilerAvailable)' == 'True' "
+        Condition=" '$(_CrossCompilerAvailable)' == 'True' "
     />
     <MSBuild 
         ContinueOnError="ErrorAndContinue"
         Projects="$(_TopDir)\tests\RunApkTests.targets"
-        Condition=" '$(Configuration)' == 'Release' And '$(_CrossCompilerAvailable)' == 'True' "
+        Condition=" '$(_CrossCompilerAvailable)' == 'True' "
         Properties="AotAssemblies=True"
     />
     <ItemGroup Condition=" '$(USE_MSBUILD)' == '1' ">
@@ -142,12 +142,12 @@
     </ItemGroup>
     <Exec
         Command="$(_XABuild) %(_ApkTestProjectBundle.Identity) %(_ApkTestProjectBundle._BinLog) /t:SignAndroidPackage $(_XABuildProperties) /p:BundleAssemblies=True /p:EmbedAssembliesIntoApk=True"
-        Condition=" '$(Configuration)' == 'Release' And '$(_CrossCompilerAvailable)' == 'True' "
+        Condition=" '$(_CrossCompilerAvailable)' == 'True' "
     />
     <MSBuild
         ContinueOnError="ErrorAndContinue"
         Projects="$(_TopDir)\tests\RunApkTests.targets"
-        Condition=" '$(Configuration)' == 'Release' And '$(_CrossCompilerAvailable)' == 'True' "
+        Condition=" '$(_CrossCompilerAvailable)' == 'True' "
         Properties="BundleAssemblies=True"
     />
   </Target>

--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -112,6 +112,14 @@
         ContinueOnError="ErrorAndContinue"
         Projects="$(_TopDir)\tests\RunApkTests.targets"
     />
+    <PropertyGroup>
+      <_HostOS>$(HostOS)</_HostOS>
+      <_ExeExtension></_ExeExtension>
+      <_HostOS Condition="'$(_HostOS)' == 'Windows'"></_HostOS>
+      <_ExeExtension Condition="'$(_HostOS)' == 'Windows'">.exe</_ExeExtension>
+      <_CrossCompilerAvailable Condition="Exists('$(_TopDir)\bin\$(Configuration)\lib\xamarin-android\xbuild\Xamarin\Android\$(_HostOS)\cross-arm$(_ExeExtension)')">False</_CrossCompilerAvailable>
+      <_CrossCompilerAvailable Condition="'$(_CrossCompilerAvailable)' == ''">False</_CrossCompilerAvailable>
+    </PropertyGroup>
     <ItemGroup Condition=" '$(USE_MSBUILD)' == '1' ">
       <_ApkTestProjectAot>
         <_BinLog>$(_XABinLogPrefix)-$([System.DateTime]::Now.ToString ("yyyyMMddTHHmmss"))-%(Filename)-AOT.binlog"</_BinLog>
@@ -119,12 +127,12 @@
     </ItemGroup>
     <Exec 
         Command="$(_XABuild) %(_ApkTestProjectAot.Identity) %(_ApkTestProjectAot._BinLog) /t:SignAndroidPackage $(_XABuildProperties) /p:AotAssemblies=True"
-        Condition=" '$(Configuration)' == 'Release' "
+        Condition=" '$(Configuration)' == 'Release' And '$(_CrossCompilerAvailable)' == 'True' "
     />
     <MSBuild 
         ContinueOnError="ErrorAndContinue"
         Projects="$(_TopDir)\tests\RunApkTests.targets"
-        Condition=" '$(Configuration)' == 'Release' "
+        Condition=" '$(Configuration)' == 'Release' And '$(_CrossCompilerAvailable)' == 'True' "
         Properties="AotAssemblies=True"
     />
     <ItemGroup Condition=" '$(USE_MSBUILD)' == '1' ">
@@ -134,12 +142,12 @@
     </ItemGroup>
     <Exec
         Command="$(_XABuild) %(_ApkTestProjectBundle.Identity) %(_ApkTestProjectBundle._BinLog) /t:SignAndroidPackage $(_XABuildProperties) /p:BundleAssemblies=True /p:EmbedAssembliesIntoApk=True"
-        Condition=" '$(Configuration)' == 'Release' "
+        Condition=" '$(Configuration)' == 'Release' And '$(_CrossCompilerAvailable)' == 'True' "
     />
     <MSBuild
         ContinueOnError="ErrorAndContinue"
         Projects="$(_TopDir)\tests\RunApkTests.targets"
-        Condition=" '$(Configuration)' == 'Release' "
+        Condition=" '$(Configuration)' == 'Release' And '$(_CrossCompilerAvailable)' == 'True' "
         Properties="BundleAssemblies=True"
     />
   </Target>


### PR DESCRIPTION
For PR builds we build i `Release` mode but we
dont build the cross compiler tooling. As a result
our `RunApkTests` will fail when try try to use
`AotAssemblies` or `BundleAssemblies`.

So we should check that the tooling exists before
we try to use it.