### PR TITLE
[Xamarin.Android.Build.Tasks] Check for `_._` in the Nuget path.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -192,6 +192,10 @@ namespace Xamarin.Android.Tasks
 				path = Path.Combine (folder.Path, libraryPath.Path, runtime.Path).Replace('/', Path.DirectorySeparatorChar);
 				if (!File.Exists (path))
 					continue;
+				// _._ means its provided by the framework. However if we get here
+				// its NOT. So lets use what we got in the first place.
+				if (Path.GetFileName (path) == "_._")
+					return assemblyPath;
 				return path;
 			}
 			return null;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -426,6 +426,10 @@ namespace XamFormsSample
 					KnownPackages.SupportCompat_25_4_0_1,
 					KnownPackages.SupportV7AppCompat_25_4_0_1,
 					KnownPackages.XamarinForms_2_3_4_231,
+					new Package () {
+						Id = "System.Runtime.Loader",
+						Version = "4.3.0",
+					},
 				}
 			};
 			app.MainActivity = @"using System;


### PR DESCRIPTION
Context https://devdiv.visualstudio.com/DevDiv/_workitems/edit/679400

When we try to resolve the `runtime` assembly we may well
get a `_._` instead of the filename. This usually means
that the assembly will be provided by the framework. When
this happens we get the following error

	 Error: Exception while loading assemblies: Java.Interop.Tools.Diagnostics.XamarinAndroidException: error XA0009: Error while loading assembly: /Users/tamasszadvari/.nuget/packages/system.runtime.loader/4.3.0/lib/MonoAndroid10/_._

So we should really be ignoring this particular senario.