### PR TITLE
[Xamarin.Android.Build.Tasks] Handle bad `res` data.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
@@ -19,6 +19,8 @@ namespace Xamarin.Android.Tasks {
 		public override bool Execute ()
 		{
 			foreach (var directory in Directories) {
+				if (!Directory.Exists (directory.ItemSpec))
+					continue;
 				var firstFile = Directory.EnumerateFiles(directory.ItemSpec, "*.*", SearchOption.AllDirectories).FirstOrDefault ();
 				if (firstFile != null) {
 					var taskItem = new TaskItem (directory.ItemSpec, new Dictionary<string, string> () {


### PR DESCRIPTION
Some of the designer tests upstream are producing
errors such as

	The "CollectNonEmptyDirectories" task failed unexpectedly.
	error MSB4018: System.IO.DirectoryNotFoundException: Could not find `res`

We should not be crashing out of the directory does
not exist. We should just skip it since this task is
called `CollectNonEmptyDirectories`, and not existing
means its empty.