### PR TITLE
[Xamarin.Android.Build.Tasks] make classes.zip optional for dexing

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileToDalvik.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileToDalvik.cs
@@ -19,6 +19,8 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string ClassesOutputDirectory { get; set; }
 
+		public string ClassesZip { get; set; }
+
 		public string DxJarPath { get; set; }
 
 		public string DxExtraArguments { get; set; }
@@ -124,10 +126,9 @@ namespace Xamarin.Android.Tasks
 					}
 				} else {
 					Log.LogDebugMessage ("  processing ClassesOutputDirectory...");
-					var zip = Path.GetFullPath (Path.Combine (ClassesOutputDirectory, "..", "classes.zip"));
-					if (File.Exists (zip)) {
-						Log.LogDebugMessage ($"    {zip}");
-						sw.WriteLine (Path.GetFullPath (zip));
+					if (!string.IsNullOrEmpty (ClassesZip) && File.Exists (ClassesZip)) {
+						Log.LogDebugMessage ($"    {ClassesZip}");
+						sw.WriteLine (Path.GetFullPath (ClassesZip));
 					}
 					foreach (var jar in JavaLibrariesToCompile) {
 						var fullPath = Path.GetFullPath (jar.ItemSpec);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/D8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/D8.cs
@@ -29,7 +29,6 @@ namespace Xamarin.Android.Tasks
 		public bool EnableDesugar { get; set; } = true;
 
 		// Java libraries to embed or reference
-		[Required]
 		public string ClassesZip { get; set; }
 		[Required]
 		public string JavaPlatformJarPath { get; set; }
@@ -83,7 +82,7 @@ namespace Xamarin.Android.Tasks
 				}
 			} else if (JavaLibrariesToEmbed != null) {
 				Log.LogDebugMessage ("  processing ClassesZip, JavaLibrariesToEmbed...");
-				if (File.Exists (ClassesZip)) {
+				if (!string.IsNullOrEmpty (ClassesZip) && File.Exists (ClassesZip)) {
 					injars.Add (ClassesZip);
 				}
 				foreach (var jar in JavaLibrariesToEmbed) {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2780,6 +2780,7 @@ because xbuild doesn't support framework reference assemblies.
     JavaMaximumHeapSize="$(JavaMaximumHeapSize)"
     JavaOptions="$(JavaOptions)"
     ClassesOutputDirectory="$(IntermediateOutputPath)android\bin\classes"
+    ClassesZip="$(IntermediateOutputPath)android\bin\classes.zip"
     ToolPath="$(DxToolPath)"
     ToolExe="$(DxToolExe)"
     UseDx="$(UseDx)"


### PR DESCRIPTION
Downstream in monodroid, we need to dex java libraries independently
for "Enhanced Fast Deployment". This means that in some cases, we
don't need to dex `classes.zip`.

So a few changes were needed:

* `<D8/>` should not have the `ClassesZip` property marked as
  `[Required]`.
* `<CompileToDalvik/>` should take `ClassesZip` as an input and use it
  if not blank. This is better than using:
  `Path.Combine (ClassesOutputDirectory, "..", "classes.zip")`