### PR TITLE
[build] Use specific ninja binary for mingw cross-builds

### DIFF
--- a/build-tools/mingw-dependencies/mingw-dependencies.projitems
+++ b/build-tools/mingw-dependencies/mingw-dependencies.projitems
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <_OutputSubdir32>x86</_OutputSubdir32>
     <_OutputSubdir64>x86_64</_OutputSubdir64>
-    <_CommonCmakeProjectFlags>-GNinja -DBUILD_TESTS=OFF</_CommonCmakeProjectFlags>
+    <_CommonCmakeProjectFlags>-DCMAKE_MAKE_PROGRAM=$(NinjaPath) -GNinja -DBUILD_TESTS=OFF</_CommonCmakeProjectFlags>
     <_CmakeNoSharedLibsFlags>-DBUILD_SHARED_LIBS=OFF</_CmakeNoSharedLibsFlags>
     <_CmakeWithSharedLibsFlags>-DBUILD_SHARED_LIBS=ON</_CmakeWithSharedLibsFlags>
     <_CMakeFlags32>-DCMAKE_INSTALL_PREFIX=$(MingwDependenciesRootDirectory)\$(_OutputSubdir32)</_CMakeFlags32>


### PR DESCRIPTION
When Windows cross-build targets are enabled, Xamarin.Android builds a set of
Windows libraries our runtime is dependent on. Libraries are configured with
cmake and built with ninja. However, the exact location of the ninja binary was
not specified when configuring the libraries for build and, thus, the build may
fail if there's no `ninja` available in the host machine's PATH.

Pass to cmake full path to the Android SDK's ninja to make sure cmake finds the
binary.