### PR TITLE
[build] Use specific ninja binary for libzip builds

### DIFF
--- a/src/libzip-windows/libzip-windows.projitems
+++ b/src/libzip-windows/libzip-windows.projitems
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition=" '$(HostOS)' == 'Linux' or '$(HostOS)' == 'Darwin' ">
-    <CMakeFlagsCommon>-GNinja -DCMAKE_POLICY_DEFAULT_CMP0074=NEW</CMakeFlagsCommon>
+    <CMakeFlagsCommon>-GNinja -DCMAKE_MAKE_PROGRAM="$(NinjaPath)" -DCMAKE_POLICY_DEFAULT_CMP0074=NEW</CMakeFlagsCommon>
     <CMakeFlags32>-DCMAKE_TOOLCHAIN_FILE=..\..\bin\Build$(Configuration)\mingw-32.cmake $(CMakeFlagsCommon) -DZLIB_ROOT=$(MingwZlibRootDirectory32) -DZLIB_LIBRARY=$(MingwZlibRootDirectory32)\lib\$(MingwZlibLibraryName) -DZLIB_INCLUDE_DIR=$(MingwZlibRootDirectory32)\include</CMakeFlags32>
     <CMakeFlags64>-DCMAKE_TOOLCHAIN_FILE=..\..\bin\Build$(Configuration)\mingw-64.cmake $(CMakeFlagsCommon) -DZLIB_ROOT=$(MingwZlibRootDirectory64) -DZLIB_LIBRARY=$(MingwZlibRootDirectory64)\lib\$(MingwZlibLibraryName) -DZLIB_INCLUDE_DIR=$(MingwZlibRootDirectory64)\include</CMakeFlags64>
   </PropertyGroup>

--- a/src/libzip/libzip.projitems
+++ b/src/libzip/libzip.projitems
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_CMakeCommonFlags>-GNinja -DBUILD_SHARED_LIBS=ON</_CMakeCommonFlags>
+    <_CMakeCommonFlags>-GNinja -DCMAKE_MAKE_PROGRAM="$(NinjaPath)" -DBUILD_SHARED_LIBS=ON</_CMakeCommonFlags>
   </PropertyGroup>
   <ItemGroup>
     <_LibZipTarget Include="host-Darwin" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">


### PR DESCRIPTION
Commit f44de8e987a6fc5e80c24308dd51b7a674940773 made a change to build Windows
libraries with a specific `ninja` binary. However, it seems that there are more
places where this ninja treatment is necessary.

This commit applies the treatment to both host and Windows `libzip` builds.