### PR TITLE
[build] Upload unit test results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ $(eval $(call CREATE_THIRD_PARTY_NOTICES_RULE,bin/$(CONFIGURATION)/lib/xamarin.a
 run-all-tests:
 	@echo "PRINTING MONO VERSION"
 	mono --version
-	$(call MSBUILD_BINLOG,run-all-tests) $(TEST_TARGETS) /t:RunAllTests
+	$(call MSBUILD_BINLOG,run-all-tests,,Test) $(TEST_TARGETS) /t:RunAllTests
 	$(MAKE) run-api-compatibility-tests
 
 clean:
@@ -220,21 +220,21 @@ distclean:
 
 run-nunit-tests:
 ifeq ($(SKIP_NUNIT_TESTS),)
-	$(call MSBUILD_BINLOG,run-nunit-tests) $(TEST_TARGETS) /t:RunNUnitTests
+	$(call MSBUILD_BINLOG,run-nunit-tests,,Test) $(TEST_TARGETS) /t:RunNUnitTests
 endif # $(SKIP_NUNIT_TESTS) == ''
 
 run-ji-tests:
-	$(call MSBUILD_BINLOG,run-ji-tests) $(TEST_TARGETS) /t:RunJavaInteropTests
+	$(call MSBUILD_BINLOG,run-ji-tests,,Test) $(TEST_TARGETS) /t:RunJavaInteropTests
 
 ifneq ($(PACKAGES),)
 APK_TESTS_PROP = /p:ApkTests='"$(PACKAGES)"'
 endif
 
 run-apk-tests:
-	$(call MSBUILD_BINLOG,run-apk-tests) $(TEST_TARGETS) /t:RunApkTests $(APK_TESTS_PROP)
+	$(call MSBUILD_BINLOG,run-apk-tests,,Test) $(TEST_TARGETS) /t:RunApkTests $(APK_TESTS_PROP)
 
 run-performance-tests:
-	$(call MSBUILD_BINLOG,run-performance-tests) $(TEST_TARGETS) /t:RunPerformanceTests
+	$(call MSBUILD_BINLOG,run-performance-tests,,Test) $(TEST_TARGETS) /t:RunPerformanceTests
 
 list-nunit-tests:
 	$(MSBUILD) $(MSBUILD_FLAGS) $(TEST_TARGETS) /t:ListNUnitTests

--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -188,9 +188,9 @@ timestamps {
         stageWithTimeout('publish test error logs to Azure', 10, 'MINUTES', '', false) {  // Typically takes less than a minute
             echo "packaging test error logs"
 
-            sh "make -C ${XADir} -k package-test-errors"
+            sh "make -C ${XADir} -k package-test-results"
 
-            def publishTestFilePaths = "${XADir}/xa-test-errors*,${XADir}/test-errors.zip"
+            def publishTestFilePaths = "${XADir}/xa-test-results*,${XADir}/test-errors.zip"
 
             echo "publishTestFilePaths: ${publishTestFilePaths}"
             def stageStatus = publishPackages(publishTestFilePaths)

--- a/build-tools/scripts/Packaging.mk
+++ b/build-tools/scripts/Packaging.mk
@@ -58,11 +58,20 @@ package-deb: $(ZIP_OUTPUT)
 	cd $(ZIP_OUTPUT_BASENAME) && DEBEMAIL="Xamarin Public Jenkins (auto-signing) <releng@xamarin.com>" dch --create -v $(PRODUCT_VERSION).$(-num-commits-since-version-change) --package xamarin.android-oss --force-distribution --distribution alpha "New release - please see git log for $(GIT_COMMIT)"
 	cd $(ZIP_OUTPUT_BASENAME) && dpkg-buildpackage -us -uc -rfakeroot
 
-_TEST_ERRORS_BASENAME   = xa-test-errors-v$(PRODUCT_VERSION).$(-num-commits-since-version-change)_$(OS_NAME)-$(OS_ARCH)_$(GIT_BRANCH)_$(GIT_COMMIT)
+_TEST_RESULTS_BUNDLE_INCLUDE = \
+	$(wildcard bin/Test$(CONFIGURATION)/temp) \
+	$(wildcard TestResult-*.xml) \
+	$(wildcard bin/Test$(CONFIGURATION)/TestOutput-*.txt) \
+	$(wildcard bin/Test$(CONFIGURATION)/Timing_*) \
+	$(wildcard bin/Test$(CONFIGURATION)/msbuild*.binlog*) \
+	$(wildcard *.csv)
 
-"$(_TEST_ERRORS_BASENAME).zip" package-test-errors:
-	build-tools/scripts/ln-to.sh -r . -o "$(_TEST_ERRORS_BASENAME)" bin/Test*/temp TestResult-*.xml bin/Test*/TestOutput-*.txt bin/Test*/Timing_* *.csv $(XA_TEST_ERRORS_EXTRA)
-	zip -r "$(_TEST_ERRORS_BASENAME).zip" "$(_TEST_ERRORS_BASENAME)"
+_TEST_RESULTS_BASENAME   = xa-test-results-v$(PRODUCT_VERSION).$(-num-commits-since-version-change)_$(OS_NAME)-$(OS_ARCH)_$(GIT_BRANCH)_$(GIT_COMMIT)-$(CONFIGURATION)
+
+"$(_TEST_RESULTS_BASENAME).zip" package-test-results:
+	build-tools/scripts/ln-to.sh -r . -o "$(_TEST_RESULTS_BASENAME)" $(_TEST_RESULTS_BUNDLE_INCLUDE) \
+		$(XA_TEST_ERRORS_EXTRA)
+	zip -r "$(_TEST_RESULTS_BASENAME).zip" "$(_TEST_RESULTS_BASENAME)"
 
 _BUILD_STATUS_BUNDLE_INCLUDE = \
 	Configuration.OperatingSystem.props \

--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -12,7 +12,7 @@
     <_NUnit>$(_Runtime) packages\NUnit.ConsoleRunner.3.7.0\tools\nunit3-console.exe</_NUnit>
     <_Test Condition=" '$(TEST)' != '' ">--test=&quot;$(TEST)&quot;</_Test>
     <_XABuild>$(_TopDir)\bin\$(Configuration)\bin\xabuild</_XABuild>
-    <_XABinLogPrefix>/v:normal /binaryLogger:"$(MSBuildThisFileDirectory)\..\..\bin\Build$(Configuration)\msbuild</_XABinLogPrefix>
+    <_XABinLogPrefix>/v:normal /binaryLogger:"$(MSBuildThisFileDirectory)\..\..\bin\Test$(Configuration)\msbuild</_XABinLogPrefix>
     <_XABuildDiag Condition=" '$(USE_MSBUILD)' == '0' And '$(V)' != '' ">/v:diag </_XABuildDiag>
     <_XABuildProperties>$(_XABuildDiag)/p:Configuration=$(Configuration) /p:XAIntegratedTests=$(XAIntegratedTests)</_XABuildProperties>
   </PropertyGroup>

--- a/build-tools/scripts/msbuild.mk
+++ b/build-tools/scripts/msbuild.mk
@@ -37,10 +37,10 @@ endif   # $(MSBUILD) == msbuild
 
 ifeq ($(USE_MSBUILD),1)
 
-# $(call MSBUILD_BINLOG,name,msbuild=$(MSBUILD))
+# $(call MSBUILD_BINLOG,name,msbuild=$(MSBUILD),outdir=Build)
 define MSBUILD_BINLOG
 	$(if $(2),$(2),$(MSBUILD)) $(MSBUILD_FLAGS) /v:normal \
-		/binaryLogger:"$(dir $(realpath $(firstword $(MAKEFILE_LIST))))/bin/Build$(CONFIGURATION)/msbuild-`date +%Y%m%dT%H%M%S`-$(1).binlog"
+		/binaryLogger:"$(dir $(realpath $(firstword $(MAKEFILE_LIST))))/bin/$(if $(3),$(3),Build)$(CONFIGURATION)/msbuild-`date +%Y%m%dT%H%M%S`-$(1).binlog"
 endef
 
 else    # $(MSBUILD) != 1


### PR DESCRIPTION
There was some unexpected and unforeseen fallout from commit 241d9416:
`make package-build-status` is only run once.

This doesn't *sound* problematic -- hence the oversight -- but the
`msbuild*.binlog` files that the `xa-build-status*.zip` file contained
prior to commit 241d9416 contained *unit test execution logs*, e.g.
`msbuild-*-Target-RunApkTests.binlog`	which contains on-device
execution of the `.apk` unit tests.

However, these files don't exist until *after* the unit tests are run.
Meanwhile, `make package-build-status` is executed *before* unit tests
are run, and thus the resulting `xa-build-status*.zip` file no longer
contains unit test information!

(This makes it rather difficult to actually review anything about unit
test execution!)

The fix?  Update the `$(MSBUILD_BINLOG)` Make `define` so that it now
takes an optional 3rd parameter: part of the directory name to place
files into, which defaults to `Build`.  (This allows overriding things
so that unit-test related `.binlog` files now go into
`bin/Test$(Configuration)`, not `bin/Build$(Configuration)`.)

Additionally, *rename* the `make package-test-errors` rule to
`make package-test-results`, have it produce an `xa-test-results*.zip`
file, and include the `bin/Test$(Configuration)/msbuild*.binlog` files
into `xa-test-results*.zip`.

`make package-test-results` is executed after unit tests are executed,
so this change allows us the uploaded `xa-test-results.zip` file to
contain unit test execution results.