### PR TITLE
[Mono.Android] Call SystemDependencyProvider.Initialize()

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -191,6 +191,8 @@ namespace Android.Runtime {
 			else
 				IdentityHash = v => v;
 
+			Mono.SystemDependencyProvider.Initialize ();
+
 #if JAVA_INTEROP
 			androidRuntime = new AndroidRuntime (args->env, args->javaVm, androidSdkVersion > 10, args->grefLoader, args->Loader_loadClass);
 #endif // JAVA_INTEROP


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2679

Context: https://github.com/xamarin/xamarin-android/pull/2753

If `System.Security.Cryptography.X509Certificates.X509Certificate`
(from `mscorlib.dll`) is used *before*
`System.Security.Cryptography.X509Certificates.X509Certificate2`
(from `System.dll`), then a `PlatformNotSupportedException` is thrown:

	System.PlatformNotSupportedException: Cannot get `ISystemDependencyProvider`.
	  at Mono.DependencyInjector.get_SystemProvider ()
	  at System.Security.Cryptography.X509Certificates.X509Helper.get_CertificateProvider ()
	  at System.Security.Cryptography.X509Certificates.X509Helper.Import (System.Byte[] rawData)
	  at System.Security.Cryptography.X509Certificates.X509Certificate..ctor (System.Byte[] data)
	  at App7.MainActivity.OnCreate (Android.OS.Bundle savedInstanceState)
	  at Android.App.Activity.n_OnCreate_Landroid_os_Bundle_ (System.IntPtr jnienv, System.IntPtr native__this, System.IntPtr native_savedInstanceState)

This happens because `X509Certificate` requires that the
`Mono.DependencyInjector.SystemProvider` proeprty (in `mscorlib.dll`)
return a valid value in order to perform the certificate import, but
if `Mono.SystemDependencyProvider.Initialize()` (from `System.dll)`
isn't invoked, then `Mono.DependencyInjector.SystemProvider` throws.

See also: https://github.com/mono/mono/commit/23a209198b3f

(Aside: a *dependency injector*?!  For mobile use?!)

The fix is for `Android.Runtime.JNIEnv.Initialize()` to call
`Mono.SystemDependencyProvider.Initialize()`, so that mono's
dependency injection infrastructure is propely initialized, thus
avoiding the `PlatformNotSupportedException`.

That said, there are two *very* confusing points around this madness:

 1. The macios fix, and
 2. Why this wasn't caught before.

The call to `Mono.SystemDependencyProvider.Initialize()` was added to
the [xamarin-macios' `ObjCRuntime.Runtime` class][0] in 2018-Jul-16.
Why was the Android fix overlooked/forgotten about?

More distressing is the second point: why wasn't this problem caught
by our unit tests?  The current theory -- not yet confirmed -- is that
the `X509Certificate2` unit tests were executing before the
`X509Certificate` unit tests, and/or *something* was causing
`Mono.SystemDependencyProvider.Initialize()` to be executed *before*
the `X509Certificate` unit tests to be executed.  Regardless, our unit
tests appear to be "leaky" here, and we're not sure if this can be
improved. :-(

[0]: https://github.com/xamarin/xamarin-macios/commit/84a815beed9e090bd67f8ebaba2013c7f89902be