### PR TITLE
Don't include host *.so libraries in the APK

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2871,10 +2871,16 @@ because xbuild doesn't support framework reference assemblies.
 	<PropertyGroup>
 		<_Assemblies>@(_ResolvedFrameworkAssemblies)</_Assemblies>
 	</PropertyGroup>
-	<ItemGroup>
-		<AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)\lib\*\libsqlite3_xamarin.so" Condition="$(_Assemblies.Contains('Mono.Data.Sqlite.dll'))" />
-		<AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)\lib\*\libMonoPosixHelper.so" Condition="$(_Assemblies.Contains('Mono.Posix.dll'))" />
-	</ItemGroup>
+    <ItemGroup>
+      <_TargetArchitecture Include="$(_Android32bitArchitectures);$(_Android64bitArchitectures)" />
+    </ItemGroup>
+    <ItemGroup>
+      <_TargetLibDir Include="$(MSBuildThisFileDirectory)lib\%(_TargetArchitecture.Identity)" Condition=" Exists('$(MSBuildThisFileDirectory)lib\%(_TargetArchitecture.Identity)') "/>
+    </ItemGroup>
+    <ItemGroup>
+      <AndroidNativeLibrary Include="%(_TargetLibDir.Identity)\libsqlite3_xamarin.so" Condition="$(_Assemblies.Contains('Mono.Data.Sqlite.dll'))" />
+      <AndroidNativeLibrary Include="%(_TargetLibDir.Identity)\libMonoPosixHelper.so" Condition="$(_Assemblies.Contains('Mono.Posix.dll'))" />
+    </ItemGroup>
 </Target>
 
 <PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2868,19 +2868,19 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 	
 <Target Name="_IncludeNativeSystemLibraries">
-	<PropertyGroup>
-		<_Assemblies>@(_ResolvedFrameworkAssemblies)</_Assemblies>
-	</PropertyGroup>
-    <ItemGroup>
-      <_TargetArchitecture Include="$(_Android32bitArchitectures);$(_Android64bitArchitectures)" />
-    </ItemGroup>
-    <ItemGroup>
-      <_TargetLibDir Include="$(MSBuildThisFileDirectory)lib\%(_TargetArchitecture.Identity)" Condition=" Exists('$(MSBuildThisFileDirectory)lib\%(_TargetArchitecture.Identity)') "/>
-    </ItemGroup>
-    <ItemGroup>
-      <AndroidNativeLibrary Include="%(_TargetLibDir.Identity)\libsqlite3_xamarin.so" Condition="$(_Assemblies.Contains('Mono.Data.Sqlite.dll'))" />
-      <AndroidNativeLibrary Include="%(_TargetLibDir.Identity)\libMonoPosixHelper.so" Condition="$(_Assemblies.Contains('Mono.Posix.dll'))" />
-    </ItemGroup>
+  <PropertyGroup>
+    <_Assemblies>@(_ResolvedFrameworkAssemblies)</_Assemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <_TargetArchitecture Include="$(_Android32bitArchitectures);$(_Android64bitArchitectures)" />
+  </ItemGroup>
+  <ItemGroup>
+    <_TargetLibDir Include="$(MSBuildThisFileDirectory)lib\%(_TargetArchitecture.Identity)" Condition=" Exists('$(MSBuildThisFileDirectory)lib\%(_TargetArchitecture.Identity)') "/>
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidNativeLibrary Include="%(_TargetLibDir.Identity)\libsqlite3_xamarin.so" Condition="$(_Assemblies.Contains('Mono.Data.Sqlite.dll'))" />
+    <AndroidNativeLibrary Include="%(_TargetLibDir.Identity)\libMonoPosixHelper.so" Condition="$(_Assemblies.Contains('Mono.Posix.dll'))" />
+  </ItemGroup>
 </Target>
 
 <PropertyGroup>


### PR DESCRIPTION
APK building process includes a step to put native libraries (Mono runtime,
Xamarin.Android runtime etc) into the archive. This is done by including known
`*.so` files from the per-architecture library directories in the
Xamarin.Android source tree or from a location on the end user's computer.
Unfortunately, currently this process uses a glob pattern to find the required
libraries which may include Linux host libraries with those names, thus
producing the following error when attempting to build any application which
needs to embed SQLite, libMonoPosixHelper or (in the `mono-2018-10` branch)
libmono-native DSOs:

    Adding native library: bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/lib/arm64-v8a/libmono-profiler-log.so (APK path: lib/arm64-v8a/libmono-profiler-log.so) (TaskId:320)
      bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/lib/host-Linux/libmono-native.so : error XA4301: Cannot determine abi of native library
      bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/lib/host-Linux/libmono-native.so. [xamarin-forms-samples/FormsGallery/FormsGallery/FormsGallery.Android/FormsGallery.Android.csproj]

This commit fixes the issue by constructing paths to all the supported ABI
locations before attempting to include the shared libraries from them, thus
forgoing the need to use the glob pattern and removing the problem.