### PR TITLE
[Xamarin.Android.Build.Tasks] fix designer breakage around _BuildAdditionalResourcesCache

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -91,7 +91,8 @@ using System.Runtime.CompilerServices;
 					b.Target = "Compile";
 					Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, parameters: new string [] { "DesignTimeBuild=true" }, environmentVariables: envVar),
 						"first build failed");
-					Assert.IsTrue (b.Output.IsTargetSkipped ("_BuildAdditionalResourcesCache"), "Target `_BuildAdditionalResourcesCache` should be skipped!");
+					Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "DesignTimeBuild=True. Skipping download of "),
+						"failed to skip the downloading of files.");
 					var designTimeDesigner = Path.Combine (intermediateOutputPath, "designtime", "Resource.designer.cs");
 					if (useManagedParser) {
 						FileAssert.Exists (designTimeDesigner, $"{designTimeDesigner} should have been created.");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -478,8 +478,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <Target Name="_BuildAdditionalResourcesCache"
     Inputs="@(ReferencePath);@(ReferenceDependencyPaths);$(MSBuildProjectFullPath);$(NugetPackagesConfig);$(_AndroidBuildPropertiesCache)"
     Outputs="$(_AndroidStampDirectory)_BuildAdditionalResourcesCache.stamp"
-    DependsOnTargets="$(_BeforeBuildAdditionalResourcesCache)"
-    Condition=" '$(DesignTimeBuild)' != 'True' ">
+    DependsOnTargets="$(_BeforeBuildAdditionalResourcesCache)">
   <GetAdditionalResourcesFromAssemblies
       AndroidSdkDirectory="$(_AndroidSdkDirectory)"
       AndroidNdkDirectory="$(_AndroidNdkDirectory)"
@@ -489,7 +488,11 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       DesignTimeBuild="$(DesignTimeBuild)"
       ContinueOnError="$(DesignTimeBuild)"
   />
-  <Touch Files="$(_AndroidStampDirectory)_BuildAdditionalResourcesCache.stamp" AlwaysCreate="True" />
+  <Touch
+      Condition=" '$(DesignTimeBuild)' != 'True' "
+      Files="$(_AndroidStampDirectory)_BuildAdditionalResourcesCache.stamp"
+      AlwaysCreate="True"
+  />
   <ItemGroup>
     <FileWrites Include="$(_AndroidResourcePathsCache)" Condition=" Exists ('$(_AndroidResourcePathsCache)') " />
   </ItemGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/eca09c89db42c6dbd5cd2f57c6da2196d86ff761#diff-db39bf07b89b50eaab8ab2001546310cR459

In eca09c8, I fixed cases where our MSBuild targets were running every
time. We missed some breakage happening in the designer:

1. NuGet restore on a new project
2. Designer calls `SetupDependenciesForDesigner`
3. Designer calls `GetExtraLibraryLocationsForDesigner`

`GetExtraLibraryLocationsForDesigner` was not returning all the paths
required, since `_BuildAdditionalResourcesCache` was skipped on step
no. 2!

To fix this:

* Moved the `Condition` from the target to the `<Touch/>` call.
* This should allow the target to build incrementally, but still
  prevent downloads on DTBs.

I also updated a few tests around this scenario.