### PR TITLE
[docs] Add doc import and export MSBuild targets

### DIFF
--- a/Before.Xamarin.Android.sln.targets
+++ b/Before.Xamarin.Android.sln.targets
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)build-tools\scripts\ImportExportDocs.targets" />
   <Import Project="$(MSBuildThisFileDirectory)build-tools\scripts\PrepareWindows.targets" Condition=" '$(OS)' == 'Windows_NT' " />
   <Import Project="$(MSBuildThisFileDirectory)build-tools\scripts\RunTests.targets" />
 </Project>

--- a/build-tools/scripts/ImportExportDocs.targets
+++ b/build-tools/scripts/ImportExportDocs.targets
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_TopDirImportExportDocs>$(MSBuildThisFileDirectory)..\..\</_TopDirImportExportDocs>
+    <XamarinDocsPath Condition=" '$(XamarinDocsPath)' == '' ">$(_TopDirImportExportDocs)..\xamarin-docs\</XamarinDocsPath>
+    <XamarinEngineeringDocsPath Condition=" '$(XamarinEngineeringDocsPath)' == '' ">$(_TopDirImportExportDocs)..\xamarin-engineering-docs-pr\</XamarinEngineeringDocsPath>
+    <_XamarinDocsPath>$([MSBuild]::EnsureTrailingSlash($(XamarinDocsPath)))</_XamarinDocsPath>
+    <_XamarinEngineeringDocsPath>$([MSBuild]::EnsureTrailingSlash($(XamarinEngineeringDocsPath)))</_XamarinEngineeringDocsPath>
+  </PropertyGroup>
+  <Target Name="ImportXamarinDocs">
+    <Copy
+        SourceFiles="$(_XamarinDocsPath)docs\android\deploy-test\building-apps\build-process.md"
+        DestinationFiles="$(_TopDirImportExportDocs)Documentation\guides\BuildProcess.md"
+        SkipUnchangedFiles="true"
+    />
+  </Target>
+  <Target Name="ExportXamarinDocs">
+    <Copy
+        SourceFiles="$(_TopDirImportExportDocs)Documentation\guides\BuildProcess.md"
+        DestinationFiles="$(_XamarinDocsPath)docs\android\deploy-test\building-apps\build-process.md"
+        SkipUnchangedFiles="true"
+    />
+  </Target>
+  <Target Name="ImportXamarinEngineeringDocs">
+    <ItemGroup>
+      <_MessageDocumentationFile
+          Include="$(_XamarinEngineeringDocsPath)docs\android\errors-and-warnings\*.md"
+          Exclude="$(_XamarinEngineeringDocsPath)docs\android\errors-and-warnings\TOC.md;$(XamarinEngineeringDocsPath)docs\android\errors-and-warnings\index.md"
+      />
+      <_MessageDocumentationImages
+          Include="$(_XamarinEngineeringDocsPath)docs\android\errors-and-warnings\images\*"
+      />
+    </ItemGroup>
+    <Copy
+        SourceFiles="@(_MessageDocumentationFile)"
+        DestinationFolder="$(_TopDirImportExportDocs)Documentation\guides\messages"
+        SkipUnchangedFiles="true"
+    />
+    <Copy
+        SourceFiles="@(_MessageDocumentationImages)"
+        DestinationFolder="$(_TopDirImportExportDocs)Documentation\guides\messages\images"
+        SkipUnchangedFiles="true"
+    />
+    <Copy
+        SourceFiles="$(_XamarinEngineeringDocsPath)docs\android\errors-and-warnings\index.md"
+        DestinationFiles="$(_TopDirImportExportDocs)Documentation\guides\messages\README.md"
+        SkipUnchangedFiles="true"
+    />
+  </Target>
+  <Target Name="ExportXamarinEngineeringDocs">
+    <ItemGroup>
+      <_MessageDocumentationFile
+          Include="$(_TopDirImportExportDocs)Documentation\guides\messages\*.md"
+          Exclude="$(_TopDirImportExportDocs)Documentation\guides\messages\README.md"
+      />
+      <_MessageDocumentationImages
+          Include="$(_TopDirImportExportDocs)Documentation\guides\messages\images\*"
+      />
+    </ItemGroup>
+    <Copy
+        SourceFiles="@(_MessageDocumentationFile)"
+        DestinationFolder="$(_XamarinEngineeringDocsPath)docs\android\errors-and-warnings\"
+        SkipUnchangedFiles="true"
+    />
+    <Copy
+        SourceFiles="@(_MessageDocumentationImages)"
+        DestinationFolder="$(_XamarinEngineeringDocsPath)docs\android\errors-and-warnings\images"
+        SkipUnchangedFiles="true"
+    />
+    <Copy
+        SourceFiles="$(_TopDirImportExportDocs)Documentation\guides\messages\README.md"
+        DestinationFiles="$(_XamarinEngineeringDocsPath)docs\android\errors-and-warnings\index.md"
+        SkipUnchangedFiles="true"
+    />
+    <ReadLinesFromFile File="$(_TopDirImportExportDocs)Documentation\guides\messages\README.md">
+      <Output
+          TaskParameter="Lines"
+          ItemName="_MessageDocsReadmeLines"
+      />
+    </ReadLinesFromFile>
+    <ItemGroup>
+      <_MessageDocsTocLines Include="# [Errors and Warnings](index.md)" />
+      <_MessageDocsTocLines
+          Include="$([System.Text.RegularExpressions.Regex]::Replace($([System.Text.RegularExpressions.Regex]::Replace('%(_MessageDocsReadmeLines.Identity)', '^\s*\+\s', '### ')), '\):.*', ')'))"
+          Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(_MessageDocsReadmeLines.Identity)', '^\s*\+\s*\[[^\]]*\]\(.*\):|^##'))"
+      />
+    </ItemGroup>
+    <WriteLinesToFile
+        File="$(_XamarinEngineeringDocsPath)docs\android\errors-and-warnings\TOC.md"
+        Lines="@(_MessageDocsTocLines)"
+        Overwrite="true"
+        WriteOnlyWhenDifferent="true"
+        Encoding="ascii"
+    />
+  </Target>
+</Project>


### PR DESCRIPTION
Add a few helper MSBuild targets to facilitate copying documents in the
xamarin-android repository to and from the corresponding files in the
MicrosoftDocs/xamarin-docs and MicrosoftDocs/xamarin-engineering-docs-pr
repositories.

For example, to update content from xamarin-android into a local
checkout of the xamarin-docs repository, run a command like:

    msbuild -t:ExportXamarinDocs -p:XamarinDocsPath=/path/to/xamarin-docs/ Xamarin.Android.sln

The `ExportXamarinDocs` target currently only copies the
`Documentation/guides/BuildProcess.md` guide.

Similarly, to update content from the xamarin-android into a local
checkout of the xamarin-engineering-docs-pr repository, run a command
like:

    msbuild -t:ExportXamarinEngineeringDocs -p:XamarinEngineeringDocsPath=/path/to/xamarin-engineering-docs-pr/ Xamarin.Android.sln

The `ExportXamarinEngineeringDocs` currently covers all the files in the
`Documentation/guides/messages` directory.  It also generates a `TOC.md`
file for the xamarin-engineering-docs-pr repo by running a few regular
expression replacements on the contents of the `README.md` file.