### PR TITLE
[Xamarin.Android.Build.Tasks] fix incremental ResolveLibraryProjectImports

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -233,6 +233,11 @@ namespace Xamarin.Android.Tasks
 					if (Directory.Exists (binAssemblyDir))
 						resolvedAssetDirectories.Add (binAssemblyDir);
 #endif
+					if (Directory.Exists (importsDir)) {
+						foreach (var file in Directory.EnumerateFiles (importsDir, "*.jar", SearchOption.AllDirectories)) {
+							AddJar (jars, Path.GetFullPath (file));
+						}
+					}
 					if (Directory.Exists (resDir)) {
 						var taskItem = new TaskItem (Path.GetFullPath (resDir), new Dictionary<string, string> {
 							{ OriginalFile, assemblyPath },
@@ -376,6 +381,11 @@ namespace Xamarin.Android.Tasks
 				string stampHash = File.Exists (stamp) ? File.ReadAllText (stamp) : null;
 				if (aarHash == stampHash) {
 					Log.LogDebugMessage ("Skipped {0}: extracted files are up to date", aarFile.ItemSpec);
+					if (Directory.Exists (importsDir)) {
+						foreach (var file in Directory.EnumerateFiles (importsDir, "*.jar", SearchOption.AllDirectories)) {
+							AddJar (jars, Path.GetFullPath (file));
+						}
+					}
 					if (Directory.Exists (resDir))
 						resolvedResourceDirectories.Add (new TaskItem (Path.GetFullPath (resDir), new Dictionary<string, string> {
 							{ OriginalFile, Path.GetFullPath (aarFile.ItemSpec) },
@@ -428,12 +438,16 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		void AddJar (ICollection<string> jars, string destination, string path)
+		static void AddJar (ICollection<string> jars, string destination, string path)
 		{
-			var dir = Path.GetFullPath (destination);
-			var jar = Path.Combine (dir, path);
-			if (!jars.Contains (jar))
-				jars.Add (jar);
+			var fullPath = Path.GetFullPath (Path.Combine (destination, path));
+			AddJar (jars, fullPath);
+		}
+
+		static void AddJar (ICollection<string> jars, string fullPath)
+		{
+			if (!jars.Contains (fullPath))
+				jars.Add (fullPath);
 		}
 
 		void WriteAllText (string path, string contents, bool preserveTimestamp)


### PR DESCRIPTION
The designer's integration tests have been failing on master, due to:

* The `GetExtraLibraryLocationsForDesigner` MSBuild target returns
  `ExtraJarLocation` and `ExtraResourceLocation` target outputs.
* `ExtraJarLocation` was blank in the tests?

Investigating further, the cache file this target reads from,
`obj\Debug\designtime\libraryprojectsimports.cache`, seemed to be
*wrong*:

    <Paths><Jars />...</Paths>

The `*.jar` files existed in `obj\Debug\lp`, but this cache file was
incorrect?

In 98d881b, I reworked `<ResolveLibraryProjectImports/>` so that we
could avoid #deletebinobj problems with file timestamps by using
hashes instead.

The `_ResolveLibraryProjectImports` target and
`<ResolveLibraryProjectImports/>` task have some optimizations for
incremental builds:

* The `_ResolveLibraryProjectImports` target uses a stamp file, to
  know if it should be skipped.
* The `<ResolveLibraryProjectImports/>` task uses a hash per file to
  decide if it should skip an individual file: extracting files from
  `__AndroidLibraryProjects__.zip` in .NET assemblies or AAR files.

However, in 98d881b I introduced a new problem:

* The old code used to do a recursive file search for `*.jar` at the
  end of the MSBuild task, which is written to the cache file. (Note
  the `[Output]` property is unused)
* I changed this to append the list of `*.jar` files as files were
  extracted.

Unfortunately, incremental builds were not returning a list of `*.jar`
files!

Things could break in two cases:

1. The designer tests: run a DTB,
   `GetExtraLibraryLocationsForDesigner`, then a full `Build`, and
   `GetExtraLibraryLocationsForDesigner` again. A DTB followed by a
   full build triggers `_ResolveLibraryProjectImports` to run, because
   the `$(_AndroidBuildPropertiesCache)` input is in a different
   directory for DTBs. `<Jars/>` is empty.
2. Build, update a referenced assembly, build again.
   `_ResolveLibraryProjectImports` runs and `<Jars/>` is empty.
   (You could also delete `_ResolveLibraryProjectImports.stamp`)

I changed `<ResolveLibraryProjectImports/>` to:

* If the task decides to skip extraction on a .NET assembly or `.aar`
  file...
* Do a search for `*.jar` files within the sub-directory of extracted
  files, instead of all of `lp`.

I think this is better than the old behavior.

I added some tests to validate things are working properly--on the
designer side, and incremental builds.