### PR TITLE
[build] Publish API Compatibility Checks

### DIFF
--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -188,6 +188,17 @@ timestamps {
         stageWithTimeout('publish test error logs to Azure', 10, 'MINUTES', '', false) {  // Typically takes less than a minute
             echo "packaging test error logs"
 
+            publishHTML target: [
+                allowMissing:           true,
+                alwaysLinkToLastBuild:  false,
+                escapeUnderscores:      true,
+                includes:               '**/*',
+                keepAll:                true,
+                reportDir:              "xamarin-android/bin/Test${env.BuildFlavor}/compatibility",
+                reportFiles:            '*.html',
+                reportName:             'API Compatibility Checks'
+            ]
+
             sh "make -C ${XADir} -k package-test-results CONFIGURATION=${env.BuildFlavor}"
 
             def publishTestFilePaths = "${XADir}/xa-test-results*,${XADir}/test-errors.zip"

--- a/build-tools/scripts/Packaging.mk
+++ b/build-tools/scripts/Packaging.mk
@@ -59,11 +59,12 @@ package-deb: $(ZIP_OUTPUT)
 	cd $(ZIP_OUTPUT_BASENAME) && dpkg-buildpackage -us -uc -rfakeroot
 
 _TEST_RESULTS_BUNDLE_INCLUDE = \
-	$(wildcard bin/Test$(CONFIGURATION)/temp) \
 	$(wildcard TestResult-*.xml) \
+	$(wildcard bin/Test$(CONFIGURATION)/compatibility) \
+	$(wildcard bin/Test$(CONFIGURATION)/temp) \
+	$(wildcard bin/Test$(CONFIGURATION)/msbuild*.binlog*) \
 	$(wildcard bin/Test$(CONFIGURATION)/TestOutput-*.txt) \
 	$(wildcard bin/Test$(CONFIGURATION)/Timing_*) \
-	$(wildcard bin/Test$(CONFIGURATION)/msbuild*.binlog*) \
 	$(wildcard *.csv)
 
 _TEST_RESULTS_BASENAME   = xa-test-results-v$(PRODUCT_VERSION).$(-num-commits-since-version-change)_$(OS_NAME)-$(OS_ARCH)_$(GIT_BRANCH)_$(GIT_COMMIT)-$(CONFIGURATION)

--- a/tests/api-compatibility/api-compatibility.mk
+++ b/tests/api-compatibility/api-compatibility.mk
@@ -13,12 +13,12 @@ FRAMEWORK_DIR     = bin/$(CONFIGURATION)/lib/xamarin.android/xbuild-frameworks/M
 
 
 run-api-compatibility-tests: $(MONO_API_HTML) $(MONO_API_INFO)
-	mkdir -p bin/Build$(CONFIGURATION)/compatibility
+	mkdir -p bin/Test$(CONFIGURATION)/compatibility
 	make -C external/xamarin-android-api-compatibility check \
 		STABLE_FRAMEWORKS="$(STABLE_FRAMEWORKS)" \
 		MONO_API_HTML="$(RUNTIME) $(abspath $(MONO_API_HTML))" \
 		MONO_API_INFO="$(RUNTIME) $(abspath $(MONO_API_INFO))" \
-		HTML_OUTPUT_DIR="$(abspath bin/Build$(CONFIGURATION)/compatibility)" \
+		HTML_OUTPUT_DIR="$(abspath bin/Test$(CONFIGURATION)/compatibility)" \
 		XA_FRAMEWORK_DIR="$(abspath $(FRAMEWORK_DIR))"
 
 $(MONO_API_HTML): $(wildcard $(MONO_API_HTML_DIR)/*.cs) $(MONO_OPTIONS_SRC)


### PR DESCRIPTION
The `make run-api-compatibility-tests` target may create a set of HTML
files within `bin/Build$(Configuration)/compatibility`, which would
create an **API Compatibility Checks** "side-bar" for *freestyle*
builds, reporting any API breakage.

This functionality is lost with the new Pipeline builds.

Add a `publishHTML` invocation to `build.groovy` so that API brekage
can be nicely reported when it occurs.

Additionally, update `tests/api-compatibility` so that the test
results are placed into the `bin/Test$(Configuration)` directory, not
`bin/Build$(Configuration)`, and update `make package-test-results` to
include the API compatibility results.