### PR TITLE
[Xamarin.Android.Build.Tasks] remove usage of Before/AfterTargets

### DIFF
--- a/Documentation/guides/MSBuildBestPractices.md
+++ b/Documentation/guides/MSBuildBestPractices.md
@@ -301,7 +301,7 @@ Instead you should use:
     $(BuildDependsOn);
     _LinkAssemblies;
   </BuildDependsOn>
-</PropertyGrou>
+</PropertyGroup>
 ```
 
 Unfortunately, not all targets will have a `$(XDependsOn)` property.

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3572,6 +3572,20 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 				);
 			}
 		}
+
+		[Test]
+		public void CompilerErrorShouldNotRunLinkAssemblies ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.Sources.Add (new BuildItem.Source ("SyntaxError.cs") {
+				TextContent = () => "class SyntaxError {"
+			});
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				b.ThrowOnBuildFailure = false;
+				Assert.IsFalse (b.Build (proj), "Build should have failed.");
+				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "The \"LinkAssemblies\" task failed unexpectedly"), "The LinkAssemblies MSBuild task should not run!");
+			}
+		}
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -580,6 +580,20 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     $(BuildDependsOn);
   </BuildDependsOn>
 </PropertyGroup>
+
+<PropertyGroup>
+  <_BeforeIncrementalClean Condition=" '$(AndroidApplication)' == 'True' ">
+    _PrepareAssemblies;
+    _CompileDex;
+    _AddFilesToFileWrites;
+  </_BeforeIncrementalClean>
+  <_BeforeIncrementalClean Condition=" '$(AndroidApplication)' != 'True' ">
+    _AddFilesToFileWrites;
+  </_BeforeIncrementalClean>
+  <CoreBuildDependsOn>
+    $([MSBuild]::Unescape($(CoreBuildDependsOn.Replace('IncrementalClean;', '$(_BeforeIncrementalClean);IncrementalClean;'))))
+  </CoreBuildDependsOn>
+</PropertyGroup>
   
  <PropertyGroup>
    <CompileDependsOn>
@@ -693,9 +707,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <Touch Files="$(_AndroidStampDirectory)_CleanIntermediateIfNuGetsChange.stamp" AlwaysCreate="true" />
 </Target>
 
-<Target Name="_ResolveMonoAndroidFramework" DependsOnTargets="GetReferenceAssemblyPaths" >
-</Target>
-
 <Target Name="_AddAndroidDefines"
 		DependsOnTargets="$(_OnResolveMonoAndroidSdks)">
 </Target>
@@ -708,13 +719,21 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	</GetReferenceAssemblyPaths>
 </Target>
 
+<!--
+  NOTE:
+  This target runs during Restore, and there is no $(RestoreDependsOn) property.
+  There appears to be no other way to do this other than use BeforeTargets.
+-->
 <Target Name="_SetLatestTargetFrameworkVersionForPackageReference"
     Condition=" '$(AndroidUseLatestPlatformSdk)' == 'True' "
     BeforeTargets="_GetRestoreTargetFrameworksOutput"
     DependsOnTargets="_SetLatestTargetFrameworkVersion">
 </Target>
 
-<Target Name="_SetLatestTargetFrameworkVersion" DependsOnTargets="_GetReferenceAssemblyPaths">
+<Target Name="_SetLatestTargetFrameworkVersion" DependsOnTargets="_ResolveSdks;_CreateAapt2VersionCache">
+</Target>
+
+<Target Name="_ResolveSdks" DependsOnTargets="_GetReferenceAssemblyPaths">
 	<ResolveSdks
 			AndroidSdkPath="$(AndroidSdkDirectory)"
 			AndroidNdkPath="$(AndroidNdkDirectory)"
@@ -820,7 +839,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 <Target Name="_CreateAapt2VersionCache"
 		DependsOnTargets="_ReadAapt2VersionCache"
-		AfterTargets="_SetLatestTargetFrameworkVersion"
 		Condition="'$(_AndroidUseAapt2)' == 'True' And '$(_Aapt2Version)' != '@(_Aapt2VersionCache)'"
 	>
 	<MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" />
@@ -838,21 +856,15 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<Delete Files="@(_CompiledFlataArchive);@(_CompiledFlataStamp)" Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'" />
 </Target>
 
-<Target Name="_SetupApplicationJavaClass" AfterTargets="_ResolveMonoAndroidSdks" DependsOnTargets="$(_BeforeSetupApplicationJavaClass)">
-	<PropertyGroup>
-		<AndroidApplicationJavaClass Condition="'$(AndroidApplicationJavaClass)' == '' And $(AndroidEnableMultiDex)">android.support.multidex.MultiDexApplication</AndroidApplicationJavaClass>
-		<AndroidApplicationJavaClass Condition="'$(AndroidApplicationJavaClass)' == ''">android.app.Application</AndroidApplicationJavaClass>
-	</PropertyGroup>
-	<Message Text="Application Java class: $(AndroidApplicationJavaClass)" />
-</Target>
-
-
 <PropertyGroup>
 	<_OnResolveMonoAndroidSdks>
 		_ResolveMonoAndroidSdks
 		;_ValidateAndroidPackageProperties
 		;$(_AfterResolveMonoAndroidSdks)
 	</_OnResolveMonoAndroidSdks>
+	<_ResolveMonoAndroidSdksDependsOn>
+		GetReferenceAssemblyPaths;
+	</_ResolveMonoAndroidSdksDependsOn>
 </PropertyGroup>
 
 <!--
@@ -860,7 +872,7 @@ Resolves tools paths and SDK paths, and verifies everything is installed.
 If the framework directories haven't been resolved, it takes care of those too,
 because xbuild doesn't support framework reference assemblies.
  -->
-<Target Name="_ResolveMonoAndroidSdks" DependsOnTargets="_ResolveMonoAndroidFramework">
+<Target Name="_ResolveMonoAndroidSdks" DependsOnTargets="$(_ResolveMonoAndroidSdksDependsOn)">
 
 	<Error Text="Could not locate MonoAndroid SDK." Condition="'$(MonoAndroidToolsDirectory)'==''" />
 	<Error Text="Could not locate Android SDK. Please set via /p:AndroidSdkDirectory." Condition="'$(_AndroidSdkDirectory)'==''" />
@@ -1048,6 +1060,13 @@ because xbuild doesn't support framework reference assemblies.
 	<PropertyGroup>
 		<DefineConstants>$(DefineConstants);@(AndroidDefineConstants)</DefineConstants>
 	</PropertyGroup>
+
+	<!-- Setup $(AndroidApplicationJavaClass) -->
+	<PropertyGroup>
+		<AndroidApplicationJavaClass Condition="'$(AndroidApplicationJavaClass)' == '' And $(AndroidEnableMultiDex)">android.support.multidex.MultiDexApplication</AndroidApplicationJavaClass>
+		<AndroidApplicationJavaClass Condition="'$(AndroidApplicationJavaClass)' == ''">android.app.Application</AndroidApplicationJavaClass>
+	</PropertyGroup>
+	<Message Text="Application Java class: $(AndroidApplicationJavaClass)" />
 </Target>
 
 <Target Name="AndroidPrepareForBuild" DependsOnTargets="$(_OnResolveMonoAndroidSdks)" />
@@ -2239,15 +2258,10 @@ because xbuild doesn't support framework reference assemblies.
 		;_CopyMdbFiles
 		;_LinkAssemblies
 	</_PrepareAssembliesDependsOnTargets>
-	<_PrepareAssembliesBeforeTargets Condition=" '$(AndroidApplication)' == 'True' ">
-		IncrementalClean;
-		_CleanGetCurrentAndPriorFileWrites;
-	</_PrepareAssembliesBeforeTargets>
 </PropertyGroup>
   
 <Target Name="_PrepareAssemblies"
-    DependsOnTargets="$(_PrepareAssembliesDependsOnTargets)"
-    BeforeTargets="$(_PrepareAssembliesBeforeTargets)">
+    DependsOnTargets="$(_PrepareAssembliesDependsOnTargets)">
   <!-- Update our assembly lists to the copies for linking.  We also need to verify
        they still exist cause linking will delete them if they aren't used -->
   <GetFilesThatExist
@@ -2803,15 +2817,10 @@ because xbuild doesn't support framework reference assemblies.
 		_CompileToDalvikWithDx;
 		_CompileToDalvikWithD8;
 	</_CompileDexDependsOn>
-	<_CompileDexBeforeTargets Condition=" '$(AndroidApplication)' == 'True' ">
-		IncrementalClean;
-		_CleanGetCurrentAndPriorFileWrites;
-	</_CompileDexBeforeTargets>
 </PropertyGroup>
 
 <Target Name="_CompileDex"
-		DependsOnTargets="$(_CompileDexDependsOn)"
-		BeforeTargets="$(_CompileDexBeforeTargets)">
+		DependsOnTargets="$(_CompileDexDependsOn)">
 	<ItemGroup>
 		<_DexFile Include="$(IntermediateOutputPath)android\bin\dex\*.dex" />
 		<_DexFile Include="$(IntermediateOutputPath)android\bin\*.dex" />
@@ -3259,7 +3268,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <!-- Cleaning -->
 
-<Target Name="_AddFilesToFileWrites" BeforeTargets="IncrementalClean;_CleanGetCurrentAndPriorFileWrites">
+<Target Name="_AddFilesToFileWrites">
   <ItemGroup>
     <!-- When following the naming convention for stamp files, this target handles FileWrites -->
     <FileWrites Include="$(_AndroidStampDirectory)*.stamp" />


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/MSBuildIncrementalClean

Through research into MSBuild, there are two problem we generally want
to fix:

* We have targets we want to run *before* `IncrementalClean`. Our
  current implementation uses a private MSBuild target to achieve
  this.
* We have use of `BeforeTargets` and `AfterTargets`, which causes some
  problems.

One problem we have, is that usage of `AfterTargets` causes C#
compiler errors to produce extra (and confusing errors):

    MainActivity.cs(9,7): error CS0246: The type or namespace name 'ClassLibrary1' could not be found (are you missing a using directive or an assembly reference?)

Would also trigger this:

    C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Xamarin\Android\Xamarin.Android.Common.targets(2160,5): error MSB4018: The "LinkAssemblies" task failed unexpectedly.
    System.IO.FileNotFoundException: Could not load assembly 'App1, Version=0.0.0.0, Culture=neutral, PublicKeyToken='. Perhaps it doesn't exist in the Mono for Android profile?
        File name: 'App1.dll'
        at Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.Resolve(AssemblyNameReference reference, ReaderParameters parameters)
        at Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.GetAssembly(String fileName)
        at Xamarin.Android.Tasks.LinkAssemblies.Execute(DirectoryAssemblyResolver res)
        at Xamarin.Android.Tasks.LinkAssemblies.Execute()
        at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
        at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext() [C:\Users\joaqu\source\repos\ClassLibrary21\App1\App1.csproj]

And to make matters worse, the noisy/ignorable error is displayed
first in the list in the IDE!

Going through our targets here, there was a decent bit of rework
needed. I also updated our MSBuild "best practices" docs.

## IncrementalClean ##

Using a new technique I figured out:

    <PropertyGroup>
      <!--Add to this property as needed here-->
      <_BeforeIncrementalClean>
        _AddFilesToFileWrites;
      </_BeforeIncrementalClean>
      <CoreBuildDependsOn>
        $([MSBuild]::Unescape($(CoreBuildDependsOn.Replace('IncrementalClean;', '$(_BeforeIncrementalClean);IncrementalClean;'))))
      </CoreBuildDependsOn>
    </PropertyGroup>

We can specify targets that need to run *before* `IncrementalClean`
without using `BeforeTargets`.

I then went through and fixed the following targets:

* `_AddFilesToFileWrites`
* `_CompileDex`
* `_PrepareAssemblies`

## _SetupApplicationJavaClass ##

This target had:

    <Target Name="_SetupApplicationJavaClass" AfterTargets="_ResolveMonoAndroidSdks" DependsOnTargets="$(_BeforeSetupApplicationJavaClass)">

I moved the contents of this target to `_ResolveMonoAndroidSdks`.

Usage of `$(_BeforeSetupApplicationJavaClass)` will need to change to
use `$(_ResolveMonoAndroidSdksDependsOn)` instead.

## _ResolveMonoAndroidFramework ##

This target was empty, and I could not find anything using it.

    <Target Name="_ResolveMonoAndroidFramework" DependsOnTargets="GetReferenceAssemblyPaths" />

I removed it, and used `GetReferenceAssemblyPaths` where applicable.

## _SetLatestTargetFrameworkVersion ##

`_CreateAapt2VersionCache` was using
`AfterTargets="_SetLatestTargetFrameworkVersion"`, so this target
needed to be reworked.

I renamed `_SetLatestTargetFrameworkVersion` to `_ResolveSdks`.

I created a new, empty `_SetLatestTargetFrameworkVersion` target that
depends on:

* `_ResolveSdks` then
* `_CreateAapt2VersionCache`

## Changes needed in monodroid ##

* Usage of `$(_BeforeSetupApplicationJavaClass)` will need to use
  `$(_ResolveMonoAndroidSdksDependsOn)`
* Need to do a general audit for `BeforeTargets` & `AfterTargets`