### PR TITLE
Pipeline build: Retries for better network resiliency

### DIFF
--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -173,9 +173,9 @@ timestamps {
             }
 
             echo "publishBuildFilePaths: ${publishBuildFilePaths}"
-            def stageStatus = publishPackages(publishBuildFilePaths)
-            if (stageStatus != 0) {
-                error "publish packages to Azure FAILED, status: ${stageStatus}"    // Ensure stage is labeled as 'failed' and red failure indicator is displayed in Jenkins pipeline steps view
+            def commandStatus = publishPackages(publishBuildFilePaths)
+            if (commandStatus != 0) {
+                error "publish packages to Azure FAILED, status: ${commandStatus}"    // Ensure stage is labeled as 'failed' and red failure indicator is displayed in Jenkins pipeline steps view
             }
         }
 
@@ -193,7 +193,7 @@ timestamps {
 
             commandStatus = sh (script: "make run-all-tests CONFIGURATION=${env.BuildFlavor}" + (skipNunitTests ? " SKIP_NUNIT_TESTS=1" : ""), returnStatus: true)
             if (commandStatus != 0) {
-                error "run-all-tests FAILED, status: ${stageStatus}"     // Ensure stage is labeled as 'failed' and red failure indicator is displayed in Jenkins pipeline steps view
+                error "run-all-tests FAILED, status: ${commandStatus}"     // Ensure stage is labeled as 'failed' and red failure indicator is displayed in Jenkins pipeline steps view
             }
         }
 
@@ -216,9 +216,9 @@ timestamps {
             def publishTestFilePaths = "${XADir}/xa-test-results*,${XADir}/test-errors.zip"
 
             echo "publishTestFilePaths: ${publishTestFilePaths}"
-            def stageStatus = publishPackages(publishTestFilePaths)
-            if (stageStatus != 0) {
-                error "publish test error logs to Azure FAILED, status: ${stageStatus}"    // Ensure stage is labeled as 'failed' and red failure indicator is displayed in Jenkins pipeline steps view
+            def commandStatus = publishPackages(publishTestFilePaths)
+            if (commandStatus != 0) {
+                error "publish test error logs to Azure FAILED, status: ${commandStatus}"    // Ensure stage is labeled as 'failed' and red failure indicator is displayed in Jenkins pipeline steps view
             }
         }
 

--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -165,7 +165,7 @@ timestamps {
             }
         }
 
-        stageWithTimeout('publish packages to Azure', 10, 'MINUTES', '', true, 3) {    // Typically takes less than a minute
+        stageWithTimeout('publish packages to Azure', 30, 'MINUTES', '', true, 3) {    // Typically takes less than a minute, but provide ample time in situations where logs may be quite large
             def publishBuildFilePaths = "${XADir}/xamarin.android-oss*.zip,${XADir}/bin/Build*/Xamarin.Android.Sdk*.vsix,${XADir}/build-status*,${XADir}/xa-build-status*";
 
             if (!isPr) {
@@ -197,7 +197,7 @@ timestamps {
             }
         }
 
-        stageWithTimeout('publish test error logs to Azure', 10, 'MINUTES', '', false, 3) {  // Typically takes less than a minute
+        stageWithTimeout('publish test error logs to Azure', 30, 'MINUTES', '', false, 3) {  // Typically takes less than a minute, but provide ample time in situations where logs may be quite large
             echo "packaging test error logs"
 
             publishHTML target: [

--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -19,7 +19,7 @@ def stageWithTimeout(stageName, timeoutValue, timeoutUnit, directory, fatal, ctA
                 timeout(time: timeoutValue, unit: timeoutUnit) {
                     dir(directory) {
                         if (retryAttempt > 0) {
-                            echo "ERROR : Stage ${stageName} failed on try #${retryAttempt}. Waiting ${waitSecondsBeforeRetry} seconds"
+                            echo "WARNING : Stage ${stageName} failed on try #${retryAttempt}. Waiting ${waitSecondsBeforeRetry} seconds"
                             sleep(waitSecondsBeforeRetry)
                             echo "Retrying ..."
                             waitSecondsBeforeRetry = waitSecondsBeforeRetry * 2


### PR DESCRIPTION
With the xamarin-android build being applied to PR builds, it is critical that the build be made more resilient to connectivity glitches.  There is one such case where the build failed during the checkout stage due to known network issues.  There is a good chance in that that the checkout stage would have succeeded if given another chance.  

Added retry capability to the build.groovy pipeline script, which includes a wait between retries. The wait increases exponentially on each retry.  Retries have been enabled for stages that depend on connectivity for checkout and publishing of results.  These stages are good candidates for retry as they will most likely fail due to connectivity issues as opposed to an issue within the code being built.

Build failure as inspiration for this PR:
https://jenkins.mono-project.com/job/xamarin-android-pr-pipeline-release/30

Additionally, bumped up the timeouts for the publishing stages as they involve publishing of build logs that in some situations can turn out to be quite large.

Includes a fix for a rogue use of a stageStatus variable. Updated all stages to align on using commandStatus as the variable name.