### PR TITLE
[mono-runtimes] `make` output is of Low importance

### DIFF
--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -125,11 +125,11 @@ timestamps {
         }
 
         stageWithTimeout('prepare deps', 30, 'MINUTES', XADir, true) {    // Typically takes less than 2 minutes
-            sh "make prepare-deps CONFIGURATION=${env.BuildFlavor} MSBUILD_ARGS='$MSBUILD_AUTOPROVISION_ARGS'"
+            sh "make prepare-deps CONFIGURATION=${env.BuildFlavor} V=1 MSBUILD_ARGS='$MSBUILD_AUTOPROVISION_ARGS'"
         }
 
         stageWithTimeout('build', 6, 'HOURS', XADir, true) {    // Typically takes less than one hour except a build on a new bot to populate local caches can take several hours
-            sh "make prepare ${buildTarget} CONFIGURATION=${env.BuildFlavor} MSBUILD_ARGS='$MSBUILD_AUTOPROVISION_ARGS'"
+            sh "make prepare ${buildTarget} CONFIGURATION=${env.BuildFlavor} V=1 MSBUILD_ARGS='$MSBUILD_AUTOPROVISION_ARGS'"
         }
 
         stageWithTimeout('create vsix', 30, 'MINUTES', XADir, true) {    // Typically takes less than 5 minutes
@@ -141,7 +141,7 @@ timestamps {
         }
 
         stageWithTimeout('build tests', 30, 'MINUTES', XADir, true) {    // Typically takes less than 10 minutes
-            sh "make all-tests CONFIGURATION=${env.BuildFlavor}"
+            sh "make all-tests CONFIGURATION=${env.BuildFlavor} V=1"
         }
 
         stageWithTimeout('process build results', 10, 'MINUTES', XADir, true) {    // Typically takes less than a minute
@@ -179,7 +179,7 @@ timestamps {
                 echo "Run all tests: Labels on the PR: 'full-mono-integration-build' (${hasPrLabelFullMonoIntegrationBuild}) and/or 'run-tests-release' (${hasPrLabelRunTestsRelease})"
             }
 
-            commandStatus = sh (script: "make run-all-tests CONFIGURATION=${env.BuildFlavor}" + (skipNunitTests ? " SKIP_NUNIT_TESTS=1" : ""), returnStatus: true)
+            commandStatus = sh (script: "make run-all-tests CONFIGURATION=${env.BuildFlavor} V=1" + (skipNunitTests ? " SKIP_NUNIT_TESTS=1" : ""), returnStatus: true)
             if (commandStatus != 0) {
                 error "run-all-tests FAILED, status: ${stageStatus}"     // Ensure stage is labeled as 'failed' and red failure indicator is displayed in Jenkins pipeline steps view
             }

--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -301,6 +301,7 @@
         Condition=" !Exists('$(MonoSourceFullPath)\sdks\out\.stamp-$(_MonoArchiveName)-download') "
         Command="make DISABLE_IOS=1 $(MakeConcurrency) @(_MonoRuntime->'package-android-%(Identity)', ' ') @(_MonoCrossRuntime->'package-android-%(Identity)', ' ') @(_MonoBcl->'package-android-%(Identity)', ' ') @(_LlvmRuntime->'provision-llvm-%(Identity)', ' ') $(_MonoSdksParameters)"
         IgnoreStandardErrorWarningFormat="True"
+        StandardOutputImportance="Low"
         WorkingDirectory="$(MonoSourceFullPath)\sdks\builds"
     />
     <Touch
@@ -616,6 +617,7 @@
         Condition=" '@(_MonoRuntime)' != '' Or '@(_MonoCrossRuntime)' != '' Or '@(_LlvmRuntime)' != '' "
         Command="make $(MakeConcurrency) @(_MonoRuntime->'clean-android-%(Identity)', ' ') @(_MonoCrossRuntime->'clean-android-%(Identity)', ' ') @(_MonoBcl->'clean-android-%(Identity)', ' ') @(_LlvmRuntime->'clean-llvm-%(Identity)', ' ') $(_MonoSdksParameters)"
         IgnoreStandardErrorWarningFormat="True"
+        StandardOutputImportance="Low"
         WorkingDirectory="$(MonoSourceFullPath)\sdks\builds"
     />
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/2790
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-pr-builder-release/1001/

Mono bumps are expected to be time consuming.  They can also be
expected to produce *lots* of build log output.

What's unexpected is the *vast size* of the build logs: a "normal" PR
build log is usually ~20-30MB in size.  Add in a complete mono bump,
and the build log becomes 1.4GB.

Take a page out of commit 987a05fa8: the Console log has "normal"
verbosity, and `.binlog` files are produced which contain "diagnostic"
level output.  Why does the Console log for mono bumps need to be so
ginormous?

The answer is, they don't.

Update the `<Exec/>` tasks within `mono-runtimes.targets` so that
`StandardOutputImportance="Low"` is specified.  This will *hide*
mono's build messages from the normal Console output, while preserving
the build logs within the `.binlog` files.

This should make the default Console log significantly smaller, which
in turn will allow the Jenkins **Failure Cause Management** scanning
to be effective.  (If the Console log is too large, then the error
indicators that Failure Cause Management aren't actually checked.)

If the full mono build log is necessary, it can still be obtained from
the `.binlog` files within the `xa-build-status*.zip` package.