### PR TITLE
[Xamarin.Android.Build.Tasks] fix for "build-less" designer

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1502,7 +1502,7 @@ because xbuild doesn't support framework reference assemblies.
 </PropertyGroup>
 
 <Target Name="_BuildLibraryImportsCache"
-		Inputs="$(MSBuildProjectFullPath);@(ReferencePath);@(ReferenceDependencyPaths);$(_AndroidBuildPropertiesCache)"
+		Inputs="$(MSBuildProjectFullPath);@(ReferencePath);@(ReferenceDependencyPaths);$(_AndroidBuildPropertiesCache);$(_AndroidLibraryProjectImportsCache)"
 		Outputs="$(_AndroidLibraryImportsCache).stamp">
 	<GetImportedLibraries TargetDirectory="$(_AndroidLibrayProjectIntermediatePath)"
 			CacheFile="$(_AndroidLibraryImportsCache)">


### PR DESCRIPTION
Fixes: http://work.devdiv.io/813889

Backport to `d16-0`:

* Had to remove the change to `DesignerTests.cs`, since this test
  doesn't exist here.

In VS for Mac 2019 Preview, a specific scenario is broken:

1. Download the repro (the creatively-named, perhaps legendary?
   `App72.sln`)
2. Delete the `bin` and `obj` directories
3. Open a new VS for Mac instance. (`Automatic NuGet restore` should
   be off)
4. Open the solution, wait for any build progress to complete such as
   `Updating resources...`, etc.
5. Restore NuGet packages via `Project->Restore NuGet Packages`
6. Open `MainPage.xaml`: designer displays a gray rectangle that says
   "AndroidFormsPreviewerRenderer"

Doing a full Build solves the problem, but this is the whole point of
the "build-less" designer/previewer feature in Dev16.

Behind the scenes, the failure is the `SetupDependenciesForDesigner`
MSBuild target. Opening the designer's log file, there are lots and
lots of `javac` errors, such as:

    ERROR: :   :  error: cannot find symbol
        public Toolbar_NavigationOnClickEventDispatcher (android.support.v7.widget.Toolbar p0)
    symbol:   class Toolbar
    location: package android.support.v7.widget

Doing more digging, I was able to reproduce the problem with a bash
script:

    PROJ='App72/App72.Android/App72.Android.csproj'
    SLN='App72.sln'
    MSBUILD_ARGS='/nologo /v:quiet /p:DesignTimeBuild=True /p:BuildingInsideVisualStudio=True'
    DESIGNER_ARGS='/p:AndroidUseManagedDesignTimeResourceGenerator=False'
    MSBUILD=msbuild

    # If you have a local xamarin-android build
    MSBUILD="$HOME/Desktop/Git/xamarin-android/bin/Debug/bin/xabuild"

    rm logs.zip *.binlog
    rm -r App72/App72.Android/obj App72/App72.Android/bin

    $MSBUILD $PROJ $MSBUILD_ARGS \
        /t:UpdateAndroidResources /bl:dtb1.binlog

    $MSBUILD $SLN $MSBUILD_ARGS /t:Restore /bl:restore.binlog

    $MSBUILD $PROJ $MSBUILD_ARGS $DESIGNER_ARGS \
        /t:SetupDependenciesForDesigner /bl:designer2.binlog

    zip logs.zip *.binlog

At this point, I could also reproduce the problem with
xamarin-android/master. So, this is a not something we've fixed in
master.

Now... We have `DesignerTests.DesignerBeforeNuGetRestore` which does
almost *exactly* what this script is doing!

But then I tried splitting apart the NuGet restore, to more closely
match the script. When calling `/t:Restore` in a separate MSBuild
call, the existing test we have failed in the exact same way as the
script: many `javac` errors.

I reviewed the `binlog` file, looking for any interesting MSBuild
targets that were skipped:

    Skipping target "_BuildLibraryImportsCache" because all output files are up-to-date with respect to the input files.

Going back through @alanmcgovern's notes, he could resolve the problem
by deleting this file:

    obj/Debug/designtime/libraryimports.cache.stamp

But then reviewing, the `Inputs` for `_BuildLibraryImportsCache`, they
didn't seem to be correct?

    <Target Name="_BuildLibraryImportsCache"
        Inputs="$(MSBuildProjectFullPath);@(ReferencePath);@(ReferenceDependencyPaths);$(_AndroidBuildPropertiesCache)"
        Outputs="$(_AndroidLibraryImportsCache).stamp">
      <GetImportedLibraries ... CacheFile="$(_AndroidLibraryImportsCache)" />
      <Touch Files="$(_AndroidLibraryImportsCache).stamp" AlwaysCreate="True" />

If `<GetImportedLibraries/>` operates on
`$(_AndroidLibraryProjectImportsCache)`, shouldn't it be an `Input`?

Sure enough, adding one more input solved the problem.

I looked through our git history, and these `Inputs` have been this
way at least since 2016. So this bug has just been here a while?