### PR TITLE
[build] Use system cmake and ninja to build mingw deps and libzip

### DIFF
--- a/build-tools/dependencies/dependencies.projitems
+++ b/build-tools/dependencies/dependencies.projitems
@@ -16,6 +16,12 @@
     <RequiredProgram Include="automake"             Condition=" '$(HostOS)' == 'Darwin' ">
       <Homebrew>automake</Homebrew>
     </RequiredProgram>
+    <RequiredProgram Include="cmake"                Condition=" '$(HostOS)' == 'Darwin' ">
+      <Homebrew>cmake</Homebrew>
+    </RequiredProgram>
+    <RequiredProgram Include="ninja"                Condition=" '$(HostOS)' == 'Darwin' ">
+      <Homebrew>ninja</Homebrew>
+    </RequiredProgram>
     <RequiredPackage Include="mingw-zlib"           Condition=" '$(HostOS)' == 'Darwin' And ( $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:')) Or $(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:')) )">
       <Homebrew>xamarin/xamarin-android-windeps/mingw-zlib</Homebrew>
       <HomebrewTap>xamarin/xamarin-android-windeps</HomebrewTap>

--- a/build-tools/mingw-dependencies/mingw-dependencies.projitems
+++ b/build-tools/mingw-dependencies/mingw-dependencies.projitems
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <CMake>cmake</CMake>
+    <Ninja>ninja</Ninja>
     <_OutputSubdir32>x86</_OutputSubdir32>
     <_OutputSubdir64>x86_64</_OutputSubdir64>
-    <_CommonCmakeProjectFlags>-DCMAKE_MAKE_PROGRAM=$(NinjaPath) -GNinja -DBUILD_TESTS=OFF</_CommonCmakeProjectFlags>
+    <_CommonCmakeProjectFlags>-DCMAKE_MAKE_PROGRAM=$(Ninja) -GNinja -DBUILD_TESTS=OFF</_CommonCmakeProjectFlags>
     <_CmakeNoSharedLibsFlags>-DBUILD_SHARED_LIBS=OFF</_CmakeNoSharedLibsFlags>
     <_CmakeWithSharedLibsFlags>-DBUILD_SHARED_LIBS=ON</_CmakeWithSharedLibsFlags>
     <_CMakeFlags32>-DCMAKE_INSTALL_PREFIX=$(MingwDependenciesRootDirectory)\$(_OutputSubdir32)</_CMakeFlags32>
@@ -11,6 +13,8 @@
   </PropertyGroup>
   <ItemGroup>
     <_CmakeMingwDependency Include="dlfcn-win32-64" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+      <CMake>$(CMake)</CMake>
+      <Ninja>$(Ninja)</Ninja>
       <Submodule>dlfcn-win32</Submodule>
       <CMakeToolchainFile>..\..\bin\Build$(Configuration)\mingw-64.cmake</CMakeToolchainFile>
       <CMakeExtraFlags>$(_CommonCmakeProjectFlags) $(_CMakeFlags64) $(_CmakeNoSharedLibsFlags)</CMakeExtraFlags>
@@ -19,6 +23,8 @@
     </_CmakeMingwDependency>
 
     <_CmakeMingwDependency Include="dlfcn-win32-32" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:'))">
+      <CMake>$(CMake)</CMake>
+      <Ninja>$(Ninja)</Ninja>
       <Submodule>dlfcn-win32</Submodule>
       <CMakeToolchainFile>..\..\bin\Build$(Configuration)\mingw-32.cmake</CMakeToolchainFile>
       <CMakeExtraFlags>$(_CommonCmakeProjectFlags) $(_CMakeFlags32) $(_CmakeNoSharedLibsFlags)</CMakeExtraFlags>
@@ -27,6 +33,8 @@
     </_CmakeMingwDependency>
 
     <_CmakeMingwDependency Include="mman-win32-64" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+      <CMake>$(CMake)</CMake>
+      <Ninja>$(Ninja)</Ninja>
       <Submodule>mman-win32</Submodule>
       <CMakeToolchainFile>..\..\bin\Build$(Configuration)\mingw-64.cmake</CMakeToolchainFile>
       <CMakeExtraFlags>$(_CommonCmakeProjectFlags) $(_CMakeFlags64) $(_CmakeNoSharedLibsFlags)</CMakeExtraFlags>
@@ -35,6 +43,8 @@
     </_CmakeMingwDependency>
 
     <_CmakeMingwDependency Include="mman-win32-32" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:'))">
+      <CMake>$(CMake)</CMake>
+      <Ninja>$(Ninja)</Ninja>
       <Submodule>mman-win32</Submodule>
       <CMakeToolchainFile>..\..\bin\Build$(Configuration)\mingw-32.cmake</CMakeToolchainFile>
       <CMakeExtraFlags>$(_CommonCmakeProjectFlags) $(_CMakeFlags32) $(_CmakeNoSharedLibsFlags)</CMakeExtraFlags>

--- a/build-tools/mingw-dependencies/mingw-dependencies.targets
+++ b/build-tools/mingw-dependencies/mingw-dependencies.targets
@@ -30,7 +30,7 @@
       Outputs="$(IntermediateOutputPath)\%(_CmakeMingwDependency.Identity)\build.ninja">
     <MakeDir Directories="@(_CmakeMingwDependency->'$(IntermediateOutputPath)\%(Identity)')" />
     <Exec
-        Command="$(CmakePath) -DCMAKE_TOOLCHAIN_FILE=$(MSBuildThisFileDirectory)\%(_CmakeMingwDependency.CMakeToolchainFile) %(_CmakeMingwDependency.CMakeExtraFlags) $(_SubmoduleTopDir)\%(_CmakeMingwDependency.Submodule)"
+        Command="%(_CmakeMingwDependency.CMake) -DCMAKE_TOOLCHAIN_FILE=$(MSBuildThisFileDirectory)\%(_CmakeMingwDependency.CMakeToolchainFile) %(_CmakeMingwDependency.CMakeExtraFlags) $(_SubmoduleTopDir)\%(_CmakeMingwDependency.Submodule)"
         WorkingDirectory="$(IntermediateOutputPath)\%(_CmakeMingwDependency.Identity)"
     />
   </Target>
@@ -40,11 +40,11 @@
       Inputs="$(IntermediateOutputPath)\%(_CmakeMingwDependency.Identity)\build.ninja"
       Outputs="@(_CmakeMingwDependency->'%(DestinationDirectory)\%(OutputLibrary)')">
     <Exec
-        Command="$(NinjaPath) -v $(MakeConcurrency)"
+        Command="%(_CmakeMingwDependency.Ninja) -v $(MakeConcurrency)"
         WorkingDirectory="$(IntermediateOutputPath)\%(_CmakeMingwDependency.Identity)"
     />
     <Exec
-        Command="$(NinjaPath) -v install"
+        Command="%(_CmakeMingwDependency.Ninja) -v install"
         WorkingDirectory="$(IntermediateOutputPath)\%(_CmakeMingwDependency.Identity)"
     />
     <Touch Files="@(_CmakeMingwDependency->'%(DestinationDirectory)\%(OutputLibrary)')" />

--- a/src/libzip-windows/libzip-windows.projitems
+++ b/src/libzip-windows/libzip-windows.projitems
@@ -1,17 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition=" '$(HostOS)' == 'Linux' or '$(HostOS)' == 'Darwin' ">
-    <CMakeFlagsCommon>-GNinja -DCMAKE_MAKE_PROGRAM="$(NinjaPath)" -DCMAKE_POLICY_DEFAULT_CMP0074=NEW</CMakeFlagsCommon>
+    <CMake>cmake</CMake>
+    <Ninja>ninja</Ninja>
+    <CMakeFlagsCommon>-GNinja -DCMAKE_MAKE_PROGRAM="$(Ninja)" -DCMAKE_POLICY_DEFAULT_CMP0074=NEW</CMakeFlagsCommon>
     <CMakeFlags32>-DCMAKE_TOOLCHAIN_FILE=..\..\bin\Build$(Configuration)\mingw-32.cmake $(CMakeFlagsCommon) -DZLIB_ROOT=$(MingwZlibRootDirectory32) -DZLIB_LIBRARY=$(MingwZlibRootDirectory32)\lib\$(MingwZlibLibraryName) -DZLIB_INCLUDE_DIR=$(MingwZlibRootDirectory32)\include</CMakeFlags32>
     <CMakeFlags64>-DCMAKE_TOOLCHAIN_FILE=..\..\bin\Build$(Configuration)\mingw-64.cmake $(CMakeFlagsCommon) -DZLIB_ROOT=$(MingwZlibRootDirectory64) -DZLIB_LIBRARY=$(MingwZlibRootDirectory64)\lib\$(MingwZlibLibraryName) -DZLIB_INCLUDE_DIR=$(MingwZlibRootDirectory64)\include</CMakeFlags64>
   </PropertyGroup>
   <ItemGroup>
     <_LibZipTarget Include="host-mxe-Win64" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win64:'))">
+      <CMake>$(CMake)</CMake>
+      <Ninja>$(Ninja)</Ninja>
       <CMakeFlags>$(CMakeFlags64)</CMakeFlags>
       <OutputLibrary>x64/libzip.dll</OutputLibrary>
       <OutputLibraryPath>lib/libzip.dll</OutputLibraryPath>
     </_LibZipTarget>
     <_LibZipTarget Include="host-mxe-Win32" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':mxe-Win32:'))">
+      <CMake>$(CMake)</CMake>
+      <Ninja>$(Ninja)</Ninja>
       <CMakeFlags>$(CMakeFlags32)</CMakeFlags>
       <OutputLibrary>libzip.dll</OutputLibrary>
       <OutputLibraryPath>lib/libzip.dll</OutputLibraryPath>

--- a/src/libzip/libzip.projitems
+++ b/src/libzip/libzip.projitems
@@ -1,15 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_CMakeCommonFlags>-GNinja -DCMAKE_MAKE_PROGRAM="$(NinjaPath)" -DBUILD_SHARED_LIBS=ON</_CMakeCommonFlags>
+    <CMake>cmake</CMake>
+    <Ninja>ninja</Ninja>
+    <_CMakeCommonFlags>-GNinja -DCMAKE_MAKE_PROGRAM="$(Ninja)" -DBUILD_SHARED_LIBS=ON</_CMakeCommonFlags>
   </PropertyGroup>
   <ItemGroup>
     <_LibZipTarget Include="host-Darwin" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Darwin:'))">
+      <CMake>$(CMake)</CMake>
+      <Ninja>$(Ninja)</Ninja>
       <CMakeFlags>-C$(MSBuildThisFileDirectory)/CMakeCacheInitialOSX.txt -DCMAKE_OSX_ARCHITECTURES=&quot;x86_64&quot; $(_CMakeCommonFlags)</CMakeFlags>
       <OutputLibrary>libzip.5.0.dylib</OutputLibrary>
       <OutputLibraryPath>lib/libzip.5.0.dylib</OutputLibraryPath>
     </_LibZipTarget>
     <_LibZipTarget Include="host-Linux" Condition="$(AndroidSupportedHostJitAbisForConditionalChecks.Contains (':Linux:')) AND '$(_LinuxBuildLibZip)' == 'true' ">
+      <CMake>$(CMake)</CMake>
+      <Ninja>$(Ninja)</Ninja>
       <CMakeFlags> $(_CMakeCommonFlags)</CMakeFlags>
       <OutputLibrary>libzip.so</OutputLibrary>
       <OutputLibraryPath>lib/libzip.so</OutputLibraryPath>

--- a/src/libzip/libzip.targets
+++ b/src/libzip/libzip.targets
@@ -28,7 +28,7 @@
       Outputs="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)\Makefile">
     <MakeDir Directories="@(_LibZipTarget->'$(IntermediateOutputPath)\%(Identity)')" /> 
     <Exec
-        Command="$(CmakePath) %(_LibZipTarget.CMakeFlags) $(LibZipSourceFullPath)"
+        Command="%(_LibZipTarget.CMake) %(_LibZipTarget.CMakeFlags) $(LibZipSourceFullPath)"
         WorkingDirectory="@(_LibZipTarget->'$(IntermediateOutputPath)\%(Identity)')"
     />
   </Target>
@@ -43,7 +43,7 @@
       Inputs="@(_LibZipTargetMakefile)"
       Outputs="@(Content)">
     <Exec
-        Command="$(NinjaPath) -v $(MakeConcurrency)"
+        Command="%(_LibZipTarget.Ninja) -v $(MakeConcurrency)"
         WorkingDirectory="$(IntermediateOutputPath)\%(_LibZipTarget.Identity)"
      /> 
     <Copy


### PR DESCRIPTION
Commit a014bd30 reverted e84e502e in hope that we will be able to properly
bootstrap from a squeeky clean system, but that hope was failed because I missed
the fact that `mingw-dependencies` and `libzip` as well as `libzip-windows`
projects, all built during the `android-toolchain` phase used the `cmake` and
`ninja` programs provided with the Android SDK. Well, that couldn't work :P

This commit makes the above projects build with the system `cmake` and `ninja`
binaries and adds both of them to list of macOS dependencies.

If this works fine we will be able to restore e84e502e