### PR TITLE
[build] fixes for jit-times.csproj

### DIFF
--- a/tools/jit-times/jit-times.csproj
+++ b/tools/jit-times/jit-times.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>jit-times</AssemblyName>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
   </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -20,7 +21,6 @@
     <ExternalConsole>true</ExternalConsole>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
-  <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
@@ -32,7 +32,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="Mono.Options">
-      <HintPath>packages\Mono.Options.5.3.0.1\lib\net4-client\Mono.Options.dll</HintPath>
+      <HintPath>..\..\packages\Mono.Options.5.3.0.1\lib\net4-client\Mono.Options.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
`jit-times.csproj` had a couple issues that caused it to not build on
Windows:

* `Configuration.props` was imported *after* the `Debug` configuration
  settings, so `$(XAInstallPrefix)` wasn't declared.
* The reference to `Mono.Options.dll` should actually point to the
  `packages` directory at the root of this repo.