### PR TITLE
[build] improve XA's build for proguard & r8

### DIFF
--- a/src/proguard/proguard.targets
+++ b/src/proguard/proguard.targets
@@ -1,6 +1,17 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll"  TaskName="Xamarin.Android.Tools.BootstrapTasks.Ant" />
-  <Target Name="_BuildProGuard">
+  <PropertyGroup>
+    <_OutputJar>$(OutputPath)lib\proguard.jar</_OutputJar>
+    <_OutputBat>$(OutputPath)bin\proguard.bat</_OutputBat>
+    <_OutputSh>$(OutputPath)bin\proguard.sh</_OutputSh>
+    <_OutputLicense>$(OutputPath)license.html</_OutputLicense>
+  </PropertyGroup>
+  <ItemGroup>
+    <_Outputs Include="$(_OutputJar);$(_OutputBat);$(_OutputSh);$(_OutputLicense)" />
+  </ItemGroup>
+  <Target Name="_BuildProGuard"
+      Inputs="$(MSBuildThisFile);$(ProGuardSourceFullPath)\buildscripts\build.xml"
+      Outputs="@(_Outputs)">
     <Ant
         Arguments="$(AntProguardBuildAdditionalArguments) -f buildscripts\build.xml proguard"
         ToolPath="$(AntToolPath)"
@@ -10,27 +21,24 @@
     <MakeDir Directories="$(OutputPath)" />
     <Copy
         SourceFiles="..\..\external\proguard\lib\proguard.jar"
-        DestinationFiles="$(OutputPath)\lib\proguard.jar"
+        DestinationFiles="$(_OutputJar)"
     />
     <Copy
         SourceFiles="..\..\external\proguard\bin\proguard.bat"
-        DestinationFiles="$(OutputPath)\bin\proguard.bat"
+        DestinationFiles="$(_OutputBat)"
     />
     <Copy
         SourceFiles="..\..\external\proguard\bin\proguard.sh"
-        DestinationFiles="$(OutputPath)\bin\proguard.sh"
+        DestinationFiles="$(_OutputSh)"
     />
     <Copy
         SourceFiles="..\..\external\proguard\docs\license.html"
-        DestinationFiles="$(OutputPath)\license.html"
+        DestinationFiles="$(_OutputLicense)"
     />
+    <Touch Files="@(_Outputs)" />
   </Target>
-  <Target Name="_CleanProGuard"
-      AfterTargets="Clean">
-    <Delete Files="$(OutputPath)\license.html" />
-    <Delete Files="$(OutputPath)\lib\proguard.jar" />
-    <Delete Files="$(OutputPath)\bin\proguard.sh" />
-    <Delete Files="$(OutputPath)\bin\proguard.bat" />
+  <Target Name="Clean">
+    <Delete Files="@(_Outputs)" />
     <Ant
         Arguments="-f buildscripts\build.xml clean"
         ToolPath="$(AntToolPath)"
@@ -38,8 +46,6 @@
         WorkingDirectory="$(ProGuardSourceFullPath)"
     />
   </Target>
-  <Target Name="CoreCompile"
-      DependsOnTargets="_BuildProGuard">
-  </Target>
+  <Target Name="CoreCompile" />
 </Project>
 

--- a/src/r8/r8.targets
+++ b/src/r8/r8.targets
@@ -14,7 +14,9 @@
   <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
   <Target Name="Clean" DependsOnTargets="$(CleanDependsOn)" />
 
-  <Target Name="_BuildR8">
+  <Target Name="_BuildR8"
+      Inputs="$(MSBuildThisFile);build.gradle"
+      Outputs="$(_Destination)">
     <Exec
         Command="&quot;$(GradleWPath)&quot; jar $(GradleArgs)"
         EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
@@ -23,8 +25,8 @@
     <Copy
         SourceFiles="build\libs\r8.jar"
         DestinationFiles="$(_Destination)"
-        SkipUnchangedFiles="True"
     />
+    <Touch Files="$(_Destination)" />
   </Target>
 
   <Target Name="_CleanR8">


### PR DESCRIPTION
If you build `Xamarin.Android.sln`, a lot of stuff happens even if
there are no changes...

Our build doesn't follow our own "MSBuild Best Practices", and we have
a few MSBuild targets that always run.

## r8.csproj ##

The main problem here was that we were invoking `gradlew` every time,
and it takes quite a while to startup when using the `--no-daemon`
switch.

I added proper `Inputs` and `Outputs` for the `_BuildR8` MSBuild
target, as well as a `<Touch/>` call.

These changes saved 6 seconds(!!!) on incremental builds of
`Xamarin.Android.sln`.

## proguard.csproj ##

This project was invoking `<Ant/>` and copying files every time.

I cleaned this project up a bit by creating an `@(_Outputs)` item
group to be used throughout. Adding `Inputs` and `Outputs` to
`_BuildProGuard` and a `<Touch/>` call fixed the incremental build.

The `Clean` target was actually broken. Since there is a chain of
`<ProjectReference/>` here, `Xamarin.Android.Tools.BootstrapTasks`
containing the `<Ant/>` MSBuild task gets cleaned! Then the actual
call to `<Ant/>` fails due to the assembly being missing. The fix here
is to just completely replace the `Clean` target with our own, so
`<ProjectReference/>` will not be cleaned. This is the same behavior
`r8.csproj` already had.

There was also a general problem with the `CoreCompile` target. I
don't think it is appropriate to run `<Ant/>` during a design-time
build in Visual Studio. I just made this target empty--I think it is
here to appease OmniSharp.

These changes saved ~2 seconds on incremental builds of
`Xamarin.Android.sln`.

This brings us to a grand total of ~8 seconds saved.