### PR TITLE
[build] use RegisterTaskObject in <GitCommitInfo/>

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Android.Tools.BootstrapTasks</RootNamespace>
     <AssemblyName>Xamarin.Android.Tools.BootstrapTasks</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <Import Project="..\..\build-tools\scripts\MSBuildReferences.projitems" />

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitCommitInfo.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/GitCommitInfo.cs
@@ -34,6 +34,14 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 
 		public override bool Execute ()
 		{
+			var key = (WorkingDirectory, XASourceDirectory, SubmoduleName, GitRemoteName);
+			var cached = BuildEngine4.GetRegisteredTaskObject (key, RegisteredTaskObjectLifetime.Build) as string;
+			if (!string.IsNullOrEmpty (cached)) {
+				Log.LogMessage (MessageImportance.Normal, "Using cached information from earlier in the build");
+				CommitInfo = cached;
+				goto outOfHere;
+			}
+
 			if (String.IsNullOrEmpty (GitPath?.Trim ()))
 				GitPath = "git";
 
@@ -147,6 +155,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 			Log.LogMessage (MessageImportance.Low, $"  Repository: {repo}");
 
 			CommitInfo = $"{organization}/{repo}/{branch}@{commit}";
+			BuildEngine4.RegisterTaskObject (key, CommitInfo, RegisteredTaskObjectLifetime.Build, allowEarlyCollection: false);
 
 		  outOfHere:
 			return !Log.HasLoggedErrors;

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Android.BuildTools.PrepTasks</RootNamespace>
     <AssemblyName>xa-prep-tasks</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <Import Project="..\..\build-tools\scripts\MSBuildReferences.projitems" />


### PR DESCRIPTION
When building `Xamarin.Android.sln` (even with no changes),
`<GitCommitInfo/>` runs 15 times, which takes about 6 seconds on my
machine.

Reviewing the input values to `<GitCommitInfo/>`, 2/3 of the calls
seem to be duplicate. This is a classic example where
`RegisterTaskObject` can help.

I cached the `CommitInfo` output property using the important inputs
as a key to `RegisterTaskObject`:

* `WorkingDirectory`
* `XASourceDirectory`
* `SubmoduleName`
* `GitRemoteName`

I used the simple syntax for creating a C# tuple as the lookup key. I
had to update the TFV of two projects to v4.7 to use the simplified
tuple syntax. I prefer this over `Tuple<string,string,string,string>`.

This saves ~4 seconds on incremental builds of `Xamarin.Android.sln`.