### PR TITLE
[tests] mark a couple flaky tests [NonParallelizable]

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -435,6 +435,7 @@ namespace UnamedProject
 		}
 
 		[Test]
+		[NonParallelizable]
 		public void BuildApplicationAndClean ([Values (false, true)] bool isRelease)
 		{
 			var proj = new XamarinFormsAndroidApplicationProject {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -343,6 +343,7 @@ namespace Lib2
 
 		//https://github.com/xamarin/xamarin-android/issues/2247
 		[Test]
+		[NonParallelizable]
 		public void AppProjectTargetsDoNotBreak ()
 		{
 			var targets = new List<string> {


### PR DESCRIPTION
Context: http://build.devdiv.io/2461019

I've noticed two tests can fail on a clean Windows machine.

One example is a build error in `BuildApplicationAndClean`:

    Xamarin.Android.Common.targets(2108,2): error MSB3374: The last access/last write time on file "C:\Users\dlab14\.nuget\packages\xamarin.forms\3.1.0.697729\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll.mdb" cannot be set. The process cannot access the file 'C:\Users\dlab14\.nuget\packages\xamarin.forms\3.1.0.697729\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll.mdb' because it is being used by another process.

Another example is a target running when it shouldn't in
`AppProjectTargetsDoNotBreak`:

    Input file "C:\Users\dlab14\.nuget\packages\xamarin.forms\3.1.0.697729\lib\MonoAndroid10\FormsViewGroup.dll.mdb" is newer than output file "obj\Debug\stamp\_CopyMdbFiles.stamp".

I think both are caused by tests running in parallel. I'm hoping
`[NonParallelizable]` will make these tests less flaky.