### PR TITLE
[build] Bump cmake to 3.10 and the NDK to 19b

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -58,8 +58,8 @@
     <AndroidMxeInstallPrefix Condition=" '$(HostOS)' == 'Darwin' ">$(HostHomebrewPrefix)</AndroidMxeInstallPrefix>
     <AndroidSdkDirectory Condition=" '$(AndroidSdkDirectory)' == '' ">$(AndroidToolchainDirectory)\sdk</AndroidSdkDirectory>
     <AndroidNdkDirectory Condition=" '$(AndroidNdkDirectory)' == '' ">$(AndroidToolchainDirectory)\ndk</AndroidNdkDirectory>
-    <AndroidCmakeVersion Condition=" '$(AndroidCmakeVersion)' == '' ">3.6.4111459</AndroidCmakeVersion>
-    <AndroidCmakeVersionPath Condition=" '$(AndroidCmakeVersionPath)' == '' ">$(AndroidCmakeVersion)</AndroidCmakeVersionPath>
+    <AndroidCmakeVersion Condition=" '$(AndroidCmakeVersion)' == '' ">3.10.2</AndroidCmakeVersion>
+    <AndroidCmakeVersionPath Condition=" '$(AndroidCmakeVersionPath)' == '' ">$(AndroidCmakeVersion).4988404</AndroidCmakeVersionPath>
     <AndroidSdkCmakeDirectory>$(AndroidSdkDirectory)\cmake\$(AndroidCmakeVersionPath)</AndroidSdkCmakeDirectory>
     <CmakePath Condition=" '$(CmakePath)' == '' ">$(AndroidSdkCmakeDirectory)\bin\cmake</CmakePath>
     <NinjaPath Condition=" '$(NinjaPath)' == '' ">$(AndroidSdkCmakeDirectory)\bin\ninja</NinjaPath>

--- a/build-tools/scripts/Ndk.targets
+++ b/build-tools/scripts/Ndk.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <AndroidNdkVersion Condition=" '$(AndroidNdkVersion)' == '' ">19</AndroidNdkVersion>
+    <AndroidNdkVersion Condition=" '$(AndroidNdkVersion)' == '' ">19b</AndroidNdkVersion>
     <AndroidNdkApiLevel_ArmV7a Condition=" '$(AndroidNdkApiLevel_ArmV7a)' == '' ">16</AndroidNdkApiLevel_ArmV7a>
     <AndroidNdkApiLevel_ArmV8a Condition=" '$(AndroidNdkApiLevel_ArmV8a)' == '' ">21</AndroidNdkApiLevel_ArmV8a>
     <AndroidNdkApiLevel_X86 Condition=" '$(AndroidNdkApiLevel_X86)' == '' ">16</AndroidNdkApiLevel_X86>


### PR DESCRIPTION
`cmake` 3.10 is the current version of the tool in the Android SDK,
an update from the much older 3.6. This update brings it closer to
the host `cmake` versions (currently mostly 3.12.*)

Bump NDK to release [19b][0] (a.k.a. 19.1), with the following changes:

 * [Issue 855][1]: ndk-build automatically disables multithreaded
   linking for LLD on Windows, where it may hang. It is not
   possible for the NDK to detect this situation for CMake,
   so CMake users and custom build systems must pass
   `-Wl,--no-threads` when linking with LLD on Windows.
 * [Issue 849][2]: Fixed unused command line argument warning when
   using standalone toolchains to compile C code.
 * [Issue 890][3]: Fixed CMAKE_FIND_ROOT_PATH. CMake projects will
   no longer search the host's sysroot for headers and libraries.
 * [Issue 907][4]: Fixed find_path for NDK headers in CMake.

[0]: https://github.com/android-ndk/ndk/wiki/Changelog-r19#r19b
[1]: https://github.com/android-ndk/ndk/issues/855
[2]: https://github.com/android-ndk/ndk/issues/849
[3]: https://github.com/android-ndk/ndk/issues/890
[4]: https://github.com/android-ndk/ndk/issues/907