### PR TITLE
[Xamarin.Android.Build.Tasks] #deletebinobj bug with stale jars

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -357,10 +357,25 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 
-				if (Directory.Exists (importsDir) && assemblyHash != stampHash) {
-					Log.LogDebugMessage ($"Saving hash to {stamp}, changes: {updated}");
-					//NOTE: if the hash is different we always want to write the file, but preserve the timestamp if no changes
-					WriteAllText (stamp, assemblyHash, preserveTimestamp: !updated);
+				if (Directory.Exists (importsDir)) {
+					// Delete unknown files in the top directory of importsDir
+					foreach (var file in Directory.EnumerateFiles (importsDir, "*")) {
+						var fullPath = Path.GetFullPath (file);
+						if (file.StartsWith ("__AndroidEnvironment__", StringComparison.OrdinalIgnoreCase) && !resolvedEnvironments.Contains (fullPath)) {
+							Log.LogDebugMessage ($"Deleting unknown AndroidEnvironment file: {Path.GetFileName (file)}");
+							File.Delete (fullPath);
+							updated = true;
+						} else if (file.EndsWith (".jar", StringComparison.OrdinalIgnoreCase) && !jars.Contains (fullPath)) {
+							Log.LogDebugMessage ($"Deleting unknown jar: {Path.GetFileName (file)}");
+							File.Delete (fullPath);
+							updated = true;
+						}
+					}
+					if (assemblyHash != stampHash) {
+						Log.LogDebugMessage ($"Saving hash to {stamp}, changes: {updated}");
+						//NOTE: if the hash is different we always want to write the file, but preserve the timestamp if no changes
+						WriteAllText (stamp, assemblyHash, preserveTimestamp: !updated);
+					}
 				}
 			}
 			foreach (var aarFile in AarLibraries ?? new ITaskItem[0]) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -98,6 +98,28 @@ class MemTest {
 		}
 
 		[Test]
+		public void BuildBasicApplicationAppCompat ([Values (true, false)] bool usePackageReference)
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			var packages = usePackageReference ? proj.PackageReferences : proj.Packages;
+			packages.Add (KnownPackages.SupportV7AppCompat_27_0_2_1);
+			// packages.config needs every dependency listed
+			if (!usePackageReference) {
+				packages.Add (KnownPackages.Android_Arch_Core_Common_26_1_0);
+				packages.Add (KnownPackages.Android_Arch_Lifecycle_Common_26_1_0);
+				packages.Add (KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0);
+				packages.Add (KnownPackages.SupportFragment_27_0_2_1);
+				packages.Add (KnownPackages.SupportCompat_27_0_2_1);
+				packages.Add (KnownPackages.SupportCoreUI_27_0_2_1);
+				packages.Add (KnownPackages.SupportCoreUtils_27_0_2_1);
+			}
+			proj.MainActivity = proj.DefaultMainActivity.Replace ("public class MainActivity : Activity", "public class MainActivity : Android.Support.V7.App.AppCompatActivity");
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
+		[Test]
 		[NonParallelizable]
 		public void SkipConvertResourcesCases ([Values (false, true)] bool useAapt2)
 		{
@@ -2548,29 +2570,24 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		//This test validates the _CleanIntermediateIfNuGetsChange target
 		[Test]
 		[NonParallelizable]
-		public void BuildAfterUpgradingNuget ([Values (false, true)] bool usePackageReference)
+		public void BuildAfterUpgradingNuget ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("public class MainActivity : Activity", "public class MainActivity : Xamarin.Forms.Platform.Android.FormsAppCompatActivity");
 
-			var packages = usePackageReference ? proj.PackageReferences : proj.Packages;
-			packages.Add (KnownPackages.XamarinForms_2_3_4_231);
-			packages.Add (KnownPackages.AndroidSupportV4_25_4_0_1);
-			packages.Add (KnownPackages.SupportCompat_25_4_0_1);
-			packages.Add (KnownPackages.SupportCoreUI_25_4_0_1);
-			packages.Add (KnownPackages.SupportCoreUtils_25_4_0_1);
-			packages.Add (KnownPackages.SupportDesign_25_4_0_1);
-			packages.Add (KnownPackages.SupportFragment_25_4_0_1);
-			packages.Add (KnownPackages.SupportMediaCompat_25_4_0_1);
-			packages.Add (KnownPackages.SupportV7AppCompat_25_4_0_1);
-			packages.Add (KnownPackages.SupportV7CardView_25_4_0_1);
-			packages.Add (KnownPackages.SupportV7MediaRouter_25_4_0_1);
+			proj.PackageReferences.Add (KnownPackages.XamarinForms_2_3_4_231);
+			proj.PackageReferences.Add (KnownPackages.AndroidSupportV4_25_4_0_1);
+			proj.PackageReferences.Add (KnownPackages.SupportCompat_25_4_0_1);
+			proj.PackageReferences.Add (KnownPackages.SupportCoreUI_25_4_0_1);
+			proj.PackageReferences.Add (KnownPackages.SupportCoreUtils_25_4_0_1);
+			proj.PackageReferences.Add (KnownPackages.SupportDesign_25_4_0_1);
+			proj.PackageReferences.Add (KnownPackages.SupportFragment_25_4_0_1);
+			proj.PackageReferences.Add (KnownPackages.SupportMediaCompat_25_4_0_1);
+			proj.PackageReferences.Add (KnownPackages.SupportV7AppCompat_25_4_0_1);
+			proj.PackageReferences.Add (KnownPackages.SupportV7CardView_25_4_0_1);
+			proj.PackageReferences.Add (KnownPackages.SupportV7MediaRouter_25_4_0_1);
 
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
-				if (usePackageReference) {
-					b.RequiresMSBuild = true;
-					b.Target = "Restore,Build";
-				}
 				//[TearDown] will still delete if test outcome successful, I need logs if assertions fail but build passes
 				b.CleanupAfterSuccessfulBuild =
 					b.CleanupOnDispose = false;
@@ -2585,29 +2602,9 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				string build_props = b.Output.GetIntermediaryPath ("build.props");
 				FileAssert.Exists (build_props, "build.props should exist after first build.");
 
-				if (!usePackageReference) {
-					foreach (var p in proj.Packages) {
-						foreach (var r in p.References) {
-							proj.References.Remove (r);
-						}
-					}
-				}
-				packages.Clear ();
-				packages.Add (KnownPackages.XamarinForms_3_1_0_697729);
-				packages.Add (KnownPackages.Android_Arch_Core_Common_26_1_0);
-				packages.Add (KnownPackages.Android_Arch_Lifecycle_Common_26_1_0);
-				packages.Add (KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0);
-				packages.Add (KnownPackages.AndroidSupportV4_27_0_2_1);
-				packages.Add (KnownPackages.SupportCompat_27_0_2_1);
-				packages.Add (KnownPackages.SupportCoreUI_27_0_2_1);
-				packages.Add (KnownPackages.SupportCoreUtils_27_0_2_1);
-				packages.Add (KnownPackages.SupportDesign_27_0_2_1);
-				packages.Add (KnownPackages.SupportFragment_27_0_2_1);
-				packages.Add (KnownPackages.SupportMediaCompat_27_0_2_1);
-				packages.Add (KnownPackages.SupportV7AppCompat_27_0_2_1);
-				packages.Add (KnownPackages.SupportV7CardView_27_0_2_1);
-				packages.Add (KnownPackages.SupportV7MediaRouter_27_0_2_1);
-				packages.Add (KnownPackages.SupportV7RecyclerView_27_0_2_1);
+				proj.PackageReferences.Clear ();
+				//NOTE: we can get all the other dependencies transitively, yay!
+				proj.PackageReferences.Add (KnownPackages.XamarinForms_3_6_0_220655);
 				b.Save (proj, doNotCleanupOnUpdate: true);
 				Assert.IsTrue (b.Build (proj), "second build should have succeeded.");
 				Assert.IsFalse (b.Output.IsTargetSkipped ("_CleanIntermediateIfNuGetsChange"), "`_CleanIntermediateIfNuGetsChange` should have run!");
@@ -2649,24 +2646,11 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				Assert.IsTrue (b.DesignTimeBuild (proj), "design-time build should have succeeded.");
 
 				proj.PackageReferences.Clear ();
-				proj.PackageReferences.Add (KnownPackages.XamarinForms_3_1_0_697729);
-				proj.PackageReferences.Add (KnownPackages.Android_Arch_Core_Common_26_1_0);
-				proj.PackageReferences.Add (KnownPackages.Android_Arch_Lifecycle_Common_26_1_0);
-				proj.PackageReferences.Add (KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0);
-				proj.PackageReferences.Add (KnownPackages.AndroidSupportV4_27_0_2_1);
-				proj.PackageReferences.Add (KnownPackages.SupportCompat_27_0_2_1);
-				proj.PackageReferences.Add (KnownPackages.SupportCoreUI_27_0_2_1);
-				proj.PackageReferences.Add (KnownPackages.SupportCoreUtils_27_0_2_1);
-				proj.PackageReferences.Add (KnownPackages.SupportDesign_27_0_2_1);
-				proj.PackageReferences.Add (KnownPackages.SupportFragment_27_0_2_1);
-				proj.PackageReferences.Add (KnownPackages.SupportMediaCompat_27_0_2_1);
-				proj.PackageReferences.Add (KnownPackages.SupportV7AppCompat_27_0_2_1);
-				proj.PackageReferences.Add (KnownPackages.SupportV7CardView_27_0_2_1);
-				proj.PackageReferences.Add (KnownPackages.SupportV7MediaRouter_27_0_2_1);
-				proj.PackageReferences.Add (KnownPackages.SupportV7RecyclerView_27_0_2_1);
-				b.Save (proj, doNotCleanupOnUpdate: true);
-				Assert.IsTrue (b.Build (proj), "second build should have succeeded.");
+				//NOTE: we can get all the other dependencies transitively, yay!
+				proj.PackageReferences.Add (KnownPackages.XamarinForms_3_6_0_220655);
+				Assert.IsTrue (b.Build (proj, saveProject: true, doNotCleanupOnUpdate: true), "second build should have succeeded.");
 				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "Refreshing Xamarin.Android.Support.v7.AppCompat.dll"), "`ResolveLibraryProjectImports` should not skip `Xamarin.Android.Support.v7.AppCompat.dll`!");
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "Deleting unknown jar: support-annotations.jar"), "`support-annotations.jar` should be deleted!");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -353,7 +353,6 @@ namespace Lib2
 				"_CleanIntermediateIfNuGetsChange",
 				"_CopyConfigFiles",
 				"_CopyPdbFiles",
-				"_CopyMdbFiles",
 			};
 			var proj = new XamarinFormsAndroidApplicationProject {
 				OtherBuildItems = {
@@ -368,6 +367,7 @@ namespace Lib2
 			if (IsWindows) {
 				//NOTE: pdb2mdb will run on Windows on the current project's symbols if DebugType=Full
 				proj.SetProperty (proj.DebugProperties, "DebugType", "Full");
+				targets.Add ("_CopyMdbFiles");
 				targets.Add ("_ConvertPdbFiles");
 			}
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -464,25 +464,25 @@ namespace Xamarin.ProjectTools
 				},
 			}
 		};
-		public static Package XamarinForms_3_1_0_697729 = new Package {
+		public static Package XamarinForms_3_6_0_220655 = new Package {
 			Id = "Xamarin.Forms",
-			Version = "3.1.0.697729",
-			TargetFramework = "MonoAndroid10",
+			Version = "3.6.0.220655",
+			TargetFramework = "MonoAndroid90",
 			References =  {
 				new BuildItem.Reference ("Xamarin.Forms.Platform.Android") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.1.0.697729\\lib\\MonoAndroid10\\Xamarin.Forms.Platform.Android.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.6.0.220655\\lib\\MonoAndroid90\\Xamarin.Forms.Platform.Android.dll"
 				},
 				new BuildItem.Reference ("FormsViewGroup") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.1.0.697729\\lib\\MonoAndroid10\\FormsViewGroup.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.6.0.220655\\lib\\MonoAndroid90\\FormsViewGroup.dll"
 				},
 				new BuildItem.Reference ("Xamarin.Forms.Core") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.1.0.697729\\lib\\MonoAndroid10\\Xamarin.Forms.Core.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.6.0.220655\\lib\\MonoAndroid90\\Xamarin.Forms.Core.dll"
 				},
 				new BuildItem.Reference ("Xamarin.Forms.Xaml") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.1.0.697729\\lib\\MonoAndroid10\\Xamarin.Forms.Xaml.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.6.0.220655\\lib\\MonoAndroid90\\Xamarin.Forms.Xaml.dll"
 				},
 				new BuildItem.Reference ("Xamarin.Forms.Platform") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.1.0.697729\\lib\\MonoAndroid10\\Xamarin.Forms.Platform.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.6.0.220655\\lib\\MonoAndroid90\\Xamarin.Forms.Platform.dll"
 				},
 			}
 		};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
@@ -40,23 +40,8 @@ namespace Xamarin.ProjectTools
 		public XamarinFormsAndroidApplicationProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
 			: base (debugConfigurationName, releaseConfigurationName)
 		{
-			var forms = KnownPackages.XamarinForms_3_1_0_697729;
-			PackageReferences.Add (forms);
-			PackageReferences.Add (KnownPackages.Android_Arch_Core_Common_26_1_0);
-			PackageReferences.Add (KnownPackages.Android_Arch_Lifecycle_Common_26_1_0);
-			PackageReferences.Add (KnownPackages.Android_Arch_Lifecycle_Runtime_26_1_0);
-			PackageReferences.Add (KnownPackages.AndroidSupportV4_27_0_2_1);
-			PackageReferences.Add (KnownPackages.SupportCompat_27_0_2_1);
-			PackageReferences.Add (KnownPackages.SupportCoreUI_27_0_2_1);
-			PackageReferences.Add (KnownPackages.SupportCoreUtils_27_0_2_1);
-			PackageReferences.Add (KnownPackages.SupportDesign_27_0_2_1);
-			PackageReferences.Add (KnownPackages.SupportFragment_27_0_2_1);
-			PackageReferences.Add (KnownPackages.SupportMediaCompat_27_0_2_1);
-			PackageReferences.Add (KnownPackages.SupportV7AppCompat_27_0_2_1);
-			PackageReferences.Add (KnownPackages.SupportV7CardView_27_0_2_1);
-			PackageReferences.Add (KnownPackages.SupportV7MediaRouter_27_0_2_1);
-			PackageReferences.Add (KnownPackages.SupportV7RecyclerView_27_0_2_1);
-			PackageReferences.Add (KnownPackages.VectorDrawable_27_0_2_1);
+			//NOTE: we can get all the other dependencies transitively, yay!
+			PackageReferences.Add (KnownPackages.XamarinForms_3_6_0_220655);
 
 			AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values\\colors.xml") {
 				TextContent = () => colors_xml,


### PR DESCRIPTION
I updated usage of Xamarin.Forms to the current 3.6 stable, which has
a few benefits:

* 3.6 includes the patch where Xamarin.Forms is shipping portable
  `.pdb` files now. This prevents some of the pdb2mdb errors we see
  with our tests running in parallel.
* 3.6 does not require you to list a bunch of support libraries as
  `<PackageReference/>` for things to build. The transitive
  dependencies work, and the support library 28.x is pulled in
  automatically.

Unfortunately, I also discovered a bug when doing this...

The `CompileBeforeUpgradingNuGet` test was hitting a compiler error:

    CompileToDalvik:
      ...
      Uncaught translation error: java.lang.IllegalArgumentException: already added: Landroid/support/annotation/AnimRes;
      ...
      UNEXPECTED TOP-LEVEL EXCEPTION:
      java.lang.RuntimeException: Translation has been interrupted
      	at com.android.dx.command.dexer.Main.processAllFiles(Main.java:614)
      	at com.android.dx.command.dexer.Main.runMonoDex(Main.java:310)
      	at com.android.dx.command.dexer.Main.runDx(Main.java:288)
      	at com.android.dx.command.dexer.Main.main(Main.java:244)
      	at com.android.dx.command.Main.main(Main.java:95)
      Caused by: java.lang.InterruptedException: Too many errors
      	at com.android.dx.command.dexer.Main.processAllFiles(Main.java:606)
      	... 4 more
      Xamarin.Android.Common.targets(2821,3): java.lang.IllegalArgumentException: already added :  Landroid/support/annotation/AnimRes;

When I looked at the list of jar files, two of them didn't make sense:

    obj\Debug\lp\3\jl\com.android.support.support-annotations.jar
    obj\Debug\lp\3\jl\support-annotations.jar

Xamarin.Android.Support.Annotations 28.x includes an `EmbeddedJar`
named `com.android.support.support-annotations.jar`. In older support
library versions, the file is named `support-annotations.jar`.

Reviewing the `<ResolveLibraryProjectImports/>` MSBuild task, I don't
see what would delete old `EmbeddedJar` files? For that matter,
`AndroidEnvironment` either? Reviewing the historical source code for
`<ResolveLibraryProjectImports/>`, it seems it was always this way?

`__AndroidLibraryProjects__.zip` and `__AndroidNativeLibraries__.zip`
should be properly deleting stale files now since the fixes in 98d881b
were added.

Changes:

* At the end of `<ResolveLibraryProjectImports/>`, I added a call to
  enumerate the top directory where `AndroidEnvironment` and
  `EmbeddedJar` files are extracted.
* I added a call to delete unknown files of these types: making sure
  the hash's timestamp (of the .NET assembly we extracted from) is
  invalidated.
* I updated the various tests to use Xamarin.Forms 3.6. (which was my
  original goal here!)
* In `CompileBeforeUpgradingNuGet` I added an assertion that the log
  message where `support-annotations.jar` was deleted is present.
* In `BuildAfterUpgradingNuget` I dropped the option for
  `packages.config`, since it was making it difficult to update
  Xamarin.Forms in these tests. I added a new
  `BuildBasicApplicationAppCompat` test to cover `packages.config`
  specifically. The scenario in `BuildAfterUpgradingNuget` is not
  really affected by the "NuGet package management format".