### PR TITLE
[create-vsix] fix for building the VSIX on Windows

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -114,7 +114,7 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Tools.Diagnostics.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.Tools.JavaCallableWrappers.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Runtime.Environment.dll" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Runtime.Environment.dll.config" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Runtime.Environment.dll.config" Condition=" '$(HostOS)' != 'Windows' " />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\jcw-gen.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\jnimarshalmethod-gen.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\LayoutBinding.cs" />
@@ -127,7 +127,7 @@
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmonosgen-2.0.so')" />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libsqlite3_xamarin.so')" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\libZipSharp.dll" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\libZipSharp.dll.config" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\libZipSharp.dll.config" Condition=" '$(HostOS)' != 'Windows' " />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\logcat-parse.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\mdoc.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\mkbundle.exe" />
@@ -178,8 +178,8 @@
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\libzip.dll" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\x64\libzip.dll" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\proguard\bin\proguard.bat" />
-    <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libmono-android.debug.dll" />
-    <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libmono-android.release.dll" />
+    <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libmono-android.debug.dll"   Condition=" '$(HostOS)' != 'Windows' " />
+    <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libmono-android.release.dll" Condition=" '$(HostOS)' != 'Windows' " />
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libMonoPosixHelper.dll" />
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libmonosgen-2.0.dll" />
   </ItemGroup>


### PR DESCRIPTION
Context: http://build.devdiv.io/2492963

e83ba0d made quite a few changes to consolidate our installers, yay!

But we started getting a build failure on Azure DevOps:

    CreateVsixContainer:
    Creating VSIX Container...
    Creating the package with the following compression level. "Normal".
        E:\A\_work\484\s\packages\Microsoft.VSSDK.BuildTools.15.0.26201\tools\VSSDK\Microsoft.VsSDK.targets(590,5): error VSSDK1025: Could not add the file "E:\A\_work\484\s\\bin\Release\\lib\xamarin.android\xbuild\Xamarin\Android\Java.Runtime.Environment.dll.config" to the zip package "bin\Release\Xamarin.Android.Sdk-OSS-9.2.99.66_HEAD_b77c037.vsix". Could not find file 'E:\A\_work\484\s\bin\Release\lib\xamarin.android\xbuild\Xamarin\Android\Java.Runtime.Environment.dll.config'. [E:\A\_work\484\s\build-tools\create-vsix\create-vsix.csproj]
        Done Building Project "E:\A\_work\484\s\build-tools\create-vsix\create-vsix.csproj" (default targets) -- FAILED.

Currently, there are a few files that are missing when you build on
Windows:

* `Java.Runtime.Environment.dll.config` is created with make:
  https://github.com/xamarin/java.interop/blob/bd8662998aa3b807bd3abdbc11a006a22c97cfb3/Makefile#L87-L89
* `libZipSharp.dll.config` is created with unix commands:
  https://github.com/grendello/LibZipSharp/blob/44de300d48ac49effa74405850b75cd4216c4fdd/libZipSharp.csproj#L189-L195
* `libmono-android.debug.dll` and `libmono-android.release.dll` are
  not currently built on Windows hosts targeting Windows.

We could certainly improve things in this area, but this will get our
Windows build green again.