### PR TITLE
[Xamarin.Android.Build.Tasks] prepend to $(_ResolveMonoAndroidSdksDependsOn)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -844,6 +844,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	</_OnResolveMonoAndroidSdks>
 	<_ResolveMonoAndroidSdksDependsOn>
 		GetReferenceAssemblyPaths;
+		$(_ResolveMonoAndroidSdksDependsOn);
 	</_ResolveMonoAndroidSdksDependsOn>
 </PropertyGroup>
 


### PR DESCRIPTION
Downstream in monodroid, we are having an evaluation ordering problem
with our MSBuild targets. We were intending to append a target to
`$(_ResolveMonoAndroidSdksDependsOn)`, but in fact the opposite is
happening:

    Property reassignment: $(_ResolveMonoAndroidSdksDependsOn)="
            GetReferenceAssemblyPaths;
        " (previous value: "

            ;_SetupInstantRun
        ") at Xamarin.Android.Common.targets (868,2)

xamarin-android is overwriting what monodroid has for the value!

The problem was our ordering of `<Import/>`

    <Import Project="Xamarin.Android.Common.Debugging.props" />
    ...
    <_ResolveMonoAndroidSdksDependsOn>
      GetReferenceAssemblyPaths;
    </_ResolveMonoAndroidSdksDependsOn>
    ...
    <Import Project="Xamarin.Android.Common.Debugging.targets" />

The `.props` file was setting an initial value for
`$(_ResolveMonoAndroidSdksDependsOn)`. This wast just opposite
of what I thought was setup, since we import the `.targets` last.

The fix here is to do:

    <_ResolveMonoAndroidSdksDependsOn>
      GetReferenceAssemblyPaths;
      $(_ResolveMonoAndroidSdksDependsOn);
    </_ResolveMonoAndroidSdksDependsOn>