### PR TITLE
[Xamarin.Android.Build.Tools] Bump android Tools versions.

### DIFF
--- a/Documentation/workflow/HowToAddNewApiLevel.md
+++ b/Documentation/workflow/HowToAddNewApiLevel.md
@@ -76,3 +76,16 @@ Enumification work can be delayed and only the final API has to be enumified.
 Note that there are documented and undocumented XML nodes, and we don't have to deal with undocumented ones.
 
 Android P introduced no documented XML artifact.
+
+7) Update Android Tooling Versions
+
+These sre located in [Xamarin.Android.Common.props.in](../../src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in). The following MSBuild properties need to be updated to ensure 
+the latest tool versions are being used.
+
+`AndroidSdkBuildToolsVersion`
+`AndroidSdkPlatformToolsVersion`
+`AndroidSdkToolsVersion`
+
+The major version should match the new API level. For Android P this will be 28.x.x . If a version which exactly matches the API Level is not available then the latest version should be used.
+
+

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -13,8 +13,8 @@
 		<AndroidResourceGeneratorTargetName>UpdateGeneratedFiles</AndroidResourceGeneratorTargetName>
 		<AndroidUseAapt2 Condition=" '$(AndroidUseAapt2)' == '' ">True</AndroidUseAapt2>
 		<AndroidUseManagedDesignTimeResourceGenerator Condition=" '$(AndroidUseManagedDesignTimeResourceGenerator)' == '' And '$(OS)' != 'Windows_NT' ">False</AndroidUseManagedDesignTimeResourceGenerator>
-		<AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">27.0.3</AndroidSdkBuildToolsVersion>
-		<AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">27.0.1</AndroidSdkPlatformToolsVersion>
+		<AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">28.0.3</AndroidSdkBuildToolsVersion>
+		<AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">28.0.0</AndroidSdkPlatformToolsVersion>
 		<AndroidSdkToolsVersion Condition="'$(AndroidSdkToolsVersion)' == ''">26.1.1</AndroidSdkToolsVersion>
 		<AndroidNdkVersion Condition="'$(AndroidNdkVersion)' == ''">16.1</AndroidNdkVersion>
 		<BundleToolVersion Condition="'$(BundleToolVersion)' == ''">@BUNDLETOOL_VERSION@</BundleToolVersion>


### PR DESCRIPTION
Fixes #2433

We should be using the latest versions of the android tooling
if possible. If we can we should try to match the major version
with the max API level we support. In this case we are on Android
P, API Level 28. So we should be using the 28.x.x versions of
the tooling.

Since not all of the tools have a 28.x.x version, in those cases
we should just use the very latest.