### PR TITLE
[linux] Fix the build, by ignoring libwinpthread-1.dll dependency

### DIFF
--- a/build-tools/debian-metadata/rules
+++ b/build-tools/debian-metadata/rules
@@ -28,6 +28,7 @@ override_dh_clideps:
 		--exclude-moduleref=dbghelp.dll \
 		--exclude-moduleref=fusion \
 		--exclude-moduleref=fusion.dll \
+		--exclude-moduleref=libwinpthread-1.dll \
 		--exclude-moduleref=lzo.dll \
 		--exclude-moduleref=mscoree.dll \
 		--exclude-moduleref=mscorwks.dll \


### PR DESCRIPTION
The Linux build [is busted][0]:

	dh_clideps -X/usr/lib/xamarin.android/xbuild-frameworks/ \
	...
	Unhandled Exception:
	IKVM.Reflection.BadImageFormatException: Exception of type 'IKVM.Reflection.BadImageFormatException' was thrown.
	  at IKVM.Reflection.Reader.PEReader.RvaToFileOffset (System.UInt32 rva) [0x00070] in <f3855a9b922743e79049757cdcdbb705>:0
	  at IKVM.Reflection.Reader.ModuleReader.Read (System.IO.Stream stream, System.Boolean mapped) [0x0004c] in <f3855a9b922743e79049757cdcdbb705>:0
	  at IKVM.Reflection.Reader.ModuleReader..ctor (IKVM.Reflection.Reader.AssemblyReader assembly, IKVM.Reflection.Universe universe, System.IO.Stream stream, System.String location, System.Boolean mapped) [0x0005b] in <f3855a9b922743e79049757cdcdbb705>:0
	  at IKVM.Reflection.Universe.OpenRawModule (System.IO.Stream stream, System.String location, System.Boolean mapped) [0x00028] in <f3855a9b922743e79049757cdcdbb705>:0
	  at IKVM.Reflection.Universe.OpenRawModule (System.IO.Stream stream, System.String location) [0x00000] in <f3855a9b922743e79049757cdcdbb705>:0
	  at Ildasm.TableDumper..ctor (System.String inputFile) [0x0002d] in <f3855a9b922743e79049757cdcdbb705>:0
	  at Ildasm.Program.Main (System.String[] args) [0x00307] in <f3855a9b922743e79049757cdcdbb705>:0
	dh_clideps: cli_parser call failed: 'LANG=C MONO_PATH= MONO_GAC_PREFIX=  /usr/bin/ikdasm --moduleref libwinpthread-1.dll 2>&1 > /tmp/dh_clideps.s9Ph' rc: 256

`libwinpthread-1.dll` is a Windows native shared library, *not* an
assembly, and thus it cannot be `ildasm`ed.

This build failure was presumably introduced with commit 4ccbeb74,
which added `libwinpthread-1.dll` to the build.

Add `libwinpthread-1.dll` to the `dh_clideps --exclude-moduleref` list
to avoid this error.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-linux-release/1051/console