### PR TITLE
spec & prototype of Android App Bundles

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -140,6 +140,7 @@
     <EmulatorToolExe Condition=" '$(EmulatorToolExe)' == '' ">emulator</EmulatorToolExe>
     <NdkBuildPath Condition=" '$(NdkBuildPath)' == '' And '$(HostOS)' != 'Windows' ">$(AndroidNdkDirectory)\ndk-build</NdkBuildPath>
     <NdkBuildPath Condition=" '$(NdkBuildPath)' == '' And '$(HostOS)' == 'Windows' ">$(AndroidNdkDirectory)\ndk-build.cmd</NdkBuildPath>
+    <BundleToolJarPath Condition=" '$(BundleToolJarPath)' == '' ">$(XAInstallPrefix)xbuild\Xamarin\Android\bundletool-all-$(XABundleToolVersion).jar</BundleToolJarPath>
   </PropertyGroup>
   <!--
     "Fixup" $(AndroidSupportedHostJitAbis) so that Condition attributes elsewhere

--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -499,6 +499,23 @@ when packaging Release applications.
 
     Added in Xamarin.Android 8.3.
 
+-   **AndroidPackageFormat** &ndash; An enum-style property with valid
+    values of `apk` or `aab`. This indicates if you want to package
+    the Android application as an [APK file][apk], or [Android App
+    Bundle][bundle]. App Bundles are a new format for `Release` builds
+    that are intended for submission on Google Play. This value
+    currently defaults to `apk`.
+
+    When `$(AndroidPackageFormat)` is set to `aab`, other MSBuild
+    properties are set, which are required for Android App Bundles:
+
+    * `$(AndroidUseAapt2)` is `True`.
+    * `$(AndroidUseApkSigner)` is `False`.
+    * `$(AndroidCreatePackagePerAbi)` is `False`.
+
+[apk]: https://en.wikipedia.org/wiki/Android_application_package]
+[bundle]: https://developer.android.com/platform/technology/app-bundle
+
 -   **AndroidR8JarPath** &ndash; The path to `r8.jar` for use with the
     r8 dex-compiler and shrinker. Defaults to a path in the
     Xamarin.Android installation. For further information see our

--- a/Documentation/guides/app-bundles.md
+++ b/Documentation/guides/app-bundles.md
@@ -1,0 +1,426 @@
+This is the Android App Bundle and `bundletool` integration
+specification for Xamarin.Android.
+
+# What are "app bundles"?
+
+[Android App Bundles][app_bundle] are a new publishing format for
+Google Play that has a wide array of benefits.
+
+* You no longer have to upload multiple APKs to Google Play:
+
+    > With the Android App Bundle, you build one artifact that
+    > includes all of your app's compiled code, resources, and native
+    > libraries for your app. You no longer need to build, sign,
+    > upload, and manage version codes for multiple APKs.
+
+* "Dynamic Delivery" provides an optimized APK download from Google
+  Play:
+
+    > Google Play’s Dynamic Delivery uses your Android App Bundle to
+    > build and serve APKs that are optimized for each device
+    > configuration. This results in a smaller app download for
+    > end-users by removing unused code and resources needed for other
+    > devices.
+
+These first two features of Android App Bundles are a natural fit for
+Xamarin.Android apps. The first version of `bundletool` support in
+Xamarin.Android will focus on these two benefits.
+
+*Unfortunately* the next two features will be more involved. We could
+perhaps support them in Xamarin.Android down the road.
+
+* Support for "Instant Apps":
+
+    > Instant-enable your Android App Bundle, so that users can launch
+    > an instant app entry point module from the Try Now button on
+    > Google Play and web links without installation.
+
+Xamarin.Android does not yet have full support for [Instant
+Apps][instant_apps], in general. There would likely be some changes
+needed to the runtime, and there is a file size limit on the base APK
+size. App Bundles won't necessarily help anything for this.
+
+* Deliver features on-demand:
+
+    > Further reduce the size of your app by installing only the
+    > features that the majority of your audience use. Users can
+    > download and install dynamic features when they’re needed. Use
+    > Android Studio 3.2 to build apps with dynamic features, and join
+    > the beta program to publish them on Google Play.
+
+For Xamarin.Android to implement this feature, I believe Instant App
+support is needed first.
+
+For more information on App Bundles, visit the [getting
+started][getting_started] guide.
+
+[app_bundle]: https://developer.android.com/platform/technology/app-bundle
+[instant_apps]: https://developer.android.com/topic/google-play-instant
+[getting_started]: https://developer.android.com/guide/app-bundle/
+
+# What is `bundletool`?
+
+[bundletool][bundletool] is the underlying command-line tool that
+gradle, Android Studio, and Google Play use for working with Android
+App Bundles.
+
+Xamarin.Android will need to run `bundletool` for the following cases:
+
+* Create an Android App Bundle from a "base" zip file
+* Create an APK Set (`.apks` file) from an Android App Bundle
+* Deploy an APK Set (`.apks` file) to a device or emulator
+
+The help text for `bundletool` reads:
+
+```
+Synopsis: bundletool <command> ...
+
+Use 'bundletool help <command>' to learn more about the given command.
+
+build-bundle command:
+    Builds an Android App Bundle from a set of Bundle modules provided as zip
+    files.
+
+build-apks command:
+    Generates an APK Set archive containing either all possible split APKs and
+    standalone APKs or APKs optimized for the connected device (see connected-
+    device flag).
+
+extract-apks command:
+    Extracts from an APK Set the APKs that should be installed on a given
+    device.
+
+get-device-spec command:
+    Writes out a JSON file containing the device specifications (i.e. features
+    and properties) of the connected Android device.
+
+install-apks command:
+    Installs APKs extracted from an APK Set to a connected device. Replaces
+    already installed package.
+
+validate command:
+    Verifies the given Android App Bundle is valid and prints out information
+    about it.
+
+dump command:
+    Prints files or extract values from the bundle in a human-readable form.
+
+get-size command:
+    Computes the min and max download sizes of APKs served to different devices
+    configurations from an APK Set.
+
+version command:
+    Prints the version of BundleTool.
+```
+
+The source code for `bundletool` is on [Github][github]!
+
+[bundletool]: https://developer.android.com/studio/command-line/bundletool
+[github]: https://github.com/google/bundletool
+
+# Implementation
+
+To enable app bundles, a new MSBuild property is needed:
+
+```xml
+<AndroidPackageFormat>aab</AndroidPackageFormat>
+```
+
+`$(AndroidPackageFormat)` will default to `apk` for the current
+Xamarin.Android behavior.
+
+Due to the various requirements for Android App Bundles, here are a
+reasonable set of defaults for `bundletool`:
+```xml
+<AndroidPackageFormat       Condition=" '$(AndroidPackageFormat)' == '' ">apk</AndroidPackageFormat>
+<AndroidUseAapt2            Condition=" '$(AndroidPackageFormat)' == 'aab' ">True</AndroidUseAapt2>
+<AndroidUseApkSigner        Condition=" '$(AndroidPackageFormat)' == 'aab' ">False</AndroidUseApkSigner>
+<AndroidCreatePackagePerAbi Condition=" '$(AndroidCreatePackagePerAbi)' == 'aab' ">False</AndroidCreatePackagePerAbi>
+```
+
+Adding `<AndroidPackageFormat>` for Android App Bundles would most
+commonly be enabled in `Release` builds for submission to Google Play:
+
+```xml
+<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <AndroidPackageFormat>apk</AndroidPackageFormat>
+</PropertyGroup>
+<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <AndroidPackageFormat>aab</AndroidPackageFormat>
+</PropertyGroup>
+```
+
+Using `$(AndroidPackageFormat)` could impact build times, since it
+takes some time for `bundletool` to generate an app bundle and
+device-specific APK set to be deployed. It would make sense, in a
+given Xamarin.Android `.csproj` file to use `apk` for `Debug` builds
+and `aab` for `Release` builds.
+
+## aapt2
+
+The first requirement is that App Bundles require a special protobuf
+format for resource files that can only be produced by `aapt2`. Adding
+the `--proto-format` flag to the `aapt2` call produces a
+`resources.pb` file:
+
+```
+aapt2 link [options] -o arg --manifest arg files...
+
+Options:
+...
+
+--proto-format
+
+Generates compiled resources in Protobuf format.
+Suitable as input to the bundle tool for generating an App Bundle.
+```
+
+This command-line switch is new in `aapt2` and can only be used with
+the version of `aapt2` from Maven. We are now shipping this new
+version in Xamarin.Android.
+
+## Generate a base ZIP file
+
+Once we have a `resources.pb` file, we must generate a [base ZIP
+file][zip_format] of the following structure:
+
+* `manifest/AndroidManifest.xml`: in protobuf format
+* `dex/`: all `.dex` files
+* `res/`: all Android resources
+* `assets/`: all Android assets
+* `lib/`: all native libraries (`.so` files)
+* `root/`: any arbitrary files that need to go in the root of the
+  final APK on-device. Xamarin.Android will need to put .NET
+  assemblies in `root/assemblies`.
+* `resources.pb`: the resource table in protobuf format
+
+See the [.aab format spec][aab_format] for further detail.
+
+[zip_format]: https://developer.android.com/studio/build/building-cmdline#package_pre-compiled_code_and_resources
+[aab_format]: https://developer.android.com/guide/app-bundle#aab_format
+
+## BundleConfig.json
+
+Since .NET assemblies and typemap files must remain uncompressed in
+Xamarin.Android apps, we will also need to specify a
+`BundleConfig.json` file:
+
+```json
+{
+  "compression": {
+    "uncompressedGlob": ["typemap.mj", "typemap.jm", "assemblies/*"]
+  }
+}
+```
+
+We also must include rules for what is specified in
+`$(AndroidStoreUncompressedFileExtensions)`, which is currently a
+delimited list of file extensions. Prepending `**/*` to each extension
+should match the glob-pattern syntax that `bundletool` expects.
+
+See details about `BundleConfig.json` in the [app bundle
+documentation][bundleconfig_json], or the [proto3 declaration on
+Github][bundleconfig_proto].
+
+From here we can generate a `.aab` file with:
+
+```
+bundletool build-bundle --modules=base.zip --output=foo.aab --config=BundleConfig.json
+```
+
+[bundleconfig_json]: https://developer.android.com/studio/build/building-cmdline#bundleconfig
+[bundleconfig_proto]: https://github.com/google/bundletool/blob/8e3aef8dd8ba239874008df33324b6f343261139/src/main/proto/config.proto
+
+## Native Libraries
+
+It appears that app bundles use `android:extractNativeLibs="false"` by
+default, so that native libraries remain in the APK, but stored
+uncompressed.
+
+They take it even further, in that the current default behavior
+(`extractNativeLibs="true"`) cannot be enabled, and is only enabled on
+older API levels:
+
+    // Only the split APKs targeting devices below Android M should be compressed. Instant apps
+    // always support uncompressed native libraries (even on Android L), because they are not always
+    // executed by the Android platform.
+
+This means that developer's `extractNativeLibs` setting in their
+`AndroidManifest.xml` is basically ignored. See [bundletool's source
+code][nativelibs] for details.
+
+[nativelibs]: https://github.com/google/bundletool/blob/fe1129820cb263b3fef18ab7e95d80c228c065a1/src/main/java/com/android/tools/build/bundletool/splitters/NativeLibrariesCompressionSplitter.java#L74-L78
+
+## Signing
+
+App Bundles can only be signed with `jarsigner` (not `apksigner`). App
+Bundles do not need to use `zipalign`. Xamarin.Android should go ahead
+and sign the `.aab` file the same as it currently does for `.apk`
+files. A `com.company.app-Signed.aab` file will be generated in
+`$(OutputPath)`, to match our current behavior with APK files.
+
+Google Play has recently added support for [doing the final,
+production signing][app_signing], but Xamarin.Android should sign App
+Bundles with what is configured in the existing MSBuild properties.
+
+[app_signing]: https://developer.android.com/studio/publish/app-signing
+
+## Deployment
+
+### Create a device-specific APK Set
+
+First, we will need to invoke `bundletool` to create an APK set:
+
+```
+bundletool build-apks --bundle=foo.aab --output=foo.apks
+```
+
+Running the [build-apks][build_apks] command, generates a `.apks` file.
+
+The help text for `bundletool build-apks` reads:
+
+```
+Description:
+    Generates an APK Set archive containing either all possible split APKs and
+    standalone APKs or APKs optimized for the connected device (see connected-
+    device flag).
+
+Synopsis:
+    bundletool build-apks
+        --bundle=<bundle.aab>
+        --output=<output.apks>
+        [--aapt2=<path/to/aapt2>]
+        [--adb=<path/to/adb>]
+        [--connected-device]
+        [--device-id=<device-serial-name>]
+        [--device-spec=<device-spec.json>]
+        [--key-pass=<key-password>]
+        [--ks=<path/to/keystore>]
+        [--ks-key-alias=<key-alias>]
+        [--ks-pass=<[pass|file]:value>]
+        [--max-threads=<num-threads>]
+        [--mode=<default|universal|system|system_compressed>]
+        [--optimize-for=<abi|screen_density|language>]
+        [--overwrite]
+
+Flags:
+    --bundle: Path to the Android App Bundle to generate APKs from.
+
+    --output: Path to where the APK Set archive should be created.
+
+    --aapt2: (Optional) Path to the aapt2 binary to use.
+
+    --adb: (Optional) Path to the adb utility. If absent, an attempt will be
+        made to locate it if the ANDROID_HOME environment variable is set. Used
+        only if connected-device flag is set.
+
+    --connected-device: (Optional) If set, will generate APK Set optimized for
+        the connected device. The generated APK Set will only be installable on
+        that specific class of devices. This flag should be only be set with --
+        mode=default flag.
+
+    --device-id: (Optional) Device serial name. If absent, this uses the
+        ANDROID_SERIAL environment variable. Either this flag or the environment
+        variable is required when more than one device or emulator is connected.
+        Used only if connected-device flag is set.
+
+    --device-spec: (Optional) Path to the device spec file generated by the
+        'get-device-spec' command. If present, it will generate an APK Set
+        optimized for the specified device spec. This flag should be only be set
+        with --mode=default flag.
+
+    --key-pass: (Optional) Password of the key in the keystore to use to sign
+        the generated APKs. If provided, must be prefixed with either 'pass:'
+        (if the password is passed in clear text, e.g. 'pass:qwerty') or 'file:'
+        (if the password is the first line of a file, e.g. 'file:
+        /tmp/myPassword.txt'). If this flag is not set, the keystore password
+        will be tried. If that fails, the password will be requested on the
+        prompt.
+
+    --ks: (Optional) Path to the keystore that should be used to sign the
+        generated APKs. If not set, the default debug keystore will be used if
+        it exists. If not found the APKs will not be signed. If set, the flag
+        'ks-key-alias' must also be set.
+
+    --ks-key-alias: (Optional) Alias of the key to use in the keystore to sign
+        the generated APKs.
+
+    --ks-pass: (Optional) Password of the keystore to use to sign the generated
+        APKs. If provided, must be prefixed with either 'pass:' (if the password
+        is passed in clear text, e.g. 'pass:qwerty') or 'file:' (if the password
+        is the first line of a file, e.g. 'file:/tmp/myPassword.txt'). If this
+        flag is not set, the password will be requested on the prompt.
+
+    --max-threads: (Optional) Sets the maximum number of threads to use
+        (default: 4).
+
+    --mode: (Optional) Specifies which mode to run 'build-apks' command against.
+        Acceptable values are 'default|universal|system|system_compressed'. If
+        not set or set to 'default' we generate split, standalone and instant
+        APKs. If set to 'universal' we generate universal APK. If set to
+        'system' we generate APKs for system image. If set to
+        'system_compressed' we generate compressed APK and an additional
+        uncompressed stub APK (containing only Android manifest) for the system
+        image.
+
+    --optimize-for: (Optional) If set, will generate APKs with optimizations for
+        the given dimensions. Acceptable values are
+        'abi|screen_density|language'. This flag should be only be set with --
+        mode=default flag.
+
+    --overwrite: (Optional) If set, any previous existing output will be
+        overwritten.
+```
+
+### Deploy an APK set
+
+To deploy a `.apks` file to a connected device:
+
+```
+bundletool install-apks --apks=foo.apks
+```
+
+The [install-apks][install_apks] command will *finally* get the app
+onto the device!
+
+The help text for `bundletool install-apks` reads:
+
+```
+Description:
+    Installs APKs extracted from an APK Set to a connected device. Replaces
+    already installed package.
+
+    This will extract from the APK Set archive and install only the APKs that
+    would be served to that device. If the app is not compatible with the device
+    or if the APK Set archive was generated for a different type of device, this
+    command will fail.
+
+Synopsis:
+    bundletool install-apks
+        --apks=<archive.apks>
+        [--adb=<path/to/adb>]
+        [--allow-downgrade]
+        [--device-id=<device-serial-name>]
+        [--modules=<base,module1,module2>]
+
+Flags:
+    --apks: Path to the archive file generated by the 'build-apks' command.
+
+    --adb: (Optional) Path to the adb utility. If absent, an attempt will be
+        made to locate it if the ANDROID_HOME environment variable is set.
+
+    --allow-downgrade: (Optional) If set, allows APKs to be installed on the
+        device even if the app is already installed with a lower version code.
+
+    --device-id: (Optional) Device serial name. If absent, this uses the
+        ANDROID_SERIAL environment variable. Either this flag or the environment
+        variable is required when more than one device or emulator is connected.
+
+    --modules: (Optional) List of modules to be installed, or "_ALL_" for all
+        modules. Defaults to modules installed during first install, i.e. not
+        on-demand. Note that the dependent modules will also be installed. The
+        value of this flag is ignored if the device receives a standalone APK.
+```
+
+[build_apks]: https://developer.android.com/studio/command-line/bundletool#generate_apks
+[install_apks]: https://developer.android.com/studio/command-line/bundletool#deploy_with_bundletool

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -40,12 +40,14 @@
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Adb.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Android.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Ant.cs" />
+    <Compile Include="Xamarin.Android.Tools.BootstrapTasks\BundleTool.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\CheckAdbTarget.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\CreateAndroidEmulator.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Emulator.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GenerateMonoDroidIncludes.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GenerateProfile.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GetNugetPackageBasePath.cs" />
+    <Compile Include="Xamarin.Android.Tools.BootstrapTasks\OS.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\ProcessMSBuildTiming.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\RenameTestCases.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\StartAndroidEmulator.cs" />

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/BundleTool.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/BundleTool.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.IO;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	public class BundleTool : ToolTask
+	{
+		[Required]
+		public string JarPath { get; set; }
+
+		[Required]
+		public string Arguments { get; set; }
+
+		public string AdbToolPath { get; set; }
+
+		public string AdbToolExe { get; set; }
+
+		public string KeyStore { get; set; }
+
+		public string KeyAlias { get; set; }
+
+		public string KeyPass { get; set; }
+
+		public string StorePass { get; set; }
+
+		protected override string ToolName {
+			get { return OS.IsWindows ? "java.exe" : "java"; }
+		}
+
+		protected override string GenerateFullPathToTool ()
+		{
+			return Path.Combine (ToolPath, ToolExe);
+		}
+
+		protected override string GenerateCommandLineCommands ()
+		{
+			var cmd = new CommandLineBuilder ();
+			cmd.AppendSwitchIfNotNull ("-jar ", JarPath);
+			cmd.AppendTextUnquoted (" " + Arguments);
+			if (!string.IsNullOrEmpty (AdbToolPath)) {
+				var adb = !string.IsNullOrEmpty (AdbToolExe) ? AdbToolExe : "adb";
+				if (OS.IsWindows && !adb.EndsWith (".exe", StringComparison.OrdinalIgnoreCase)) {
+					adb += ".exe";
+				}
+				cmd.AppendSwitchIfNotNull ("--adb ", Path.Combine (AdbToolPath, adb));
+			}
+			cmd.AppendSwitchIfNotNull ("--ks ", KeyStore);
+			cmd.AppendSwitchIfNotNull ("--ks-key-alias ", KeyAlias);
+			if (!string.IsNullOrEmpty (KeyPass))
+				cmd.AppendSwitchIfNotNull ("--key-pass ", $"pass:{KeyPass}");
+			if (!string.IsNullOrEmpty (StorePass))
+				cmd.AppendSwitchIfNotNull ("--ks-pass ", $"pass:{StorePass}");
+			return cmd.ToString ();
+		}
+	}
+}

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/BundleTool.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/BundleTool.cs
@@ -8,6 +8,9 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 	public class BundleTool : ToolTask
 	{
 		[Required]
+		public string JavaPath { get; set; }
+
+		[Required]
 		public string JarPath { get; set; }
 
 		[Required]
@@ -25,14 +28,9 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 		public string StorePass { get; set; }
 
-		protected override string ToolName {
-			get { return OS.IsWindows ? "java.exe" : "java"; }
-		}
+		protected override string ToolName => Path.GetFileName (JavaPath);
 
-		protected override string GenerateFullPathToTool ()
-		{
-			return Path.Combine (ToolPath, ToolExe);
-		}
+		protected override string GenerateFullPathToTool () => JavaPath;
 
 		protected override string GenerateCommandLineCommands ()
 		{

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/OS.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/OS.cs
@@ -1,0 +1,9 @@
+﻿using System.IO;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	static class OS
+	{
+		public static bool IsWindows => Path.DirectorySeparatorChar == '\\';
+	}
+}

--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -28,6 +28,7 @@
     <_ApkTestProject Include="$(_TopDir)\tests\BCL-Tests\Xamarin.Android.Bcl-Tests\Xamarin.Android.Bcl-Tests.csproj" />
     <_ApkTestProject Include="$(_TopDir)\tests\Xamarin.Forms-Performance-Integration\Droid\Xamarin.Forms.Performance.Integration.Droid.csproj" />
     <_ApkTestProject Include="$(_TopDir)\tests\EmbeddedDSOs\EmbeddedDSO\EmbeddedDSO.csproj" />
+    <_ApkTestProject Include="$(_TopDir)\tests\Runtime-AppBundle\Mono.Android-TestsAppBundle.csproj" />
     <_ApkTestProject Include="$(_TopDir)\tests\Runtime-MultiDex\Mono.Android-TestsMultiDex.csproj" />
     <_ApkTestProjectAot Include="$(_TopDir)\src\Mono.Android\Test\Mono.Android-Tests.csproj" />
     <_ApkTestProjectBundle Include="$(_TopDir)\src\Mono.Android\Test\Mono.Android-Tests.csproj" />

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.Adb" />
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.BundleTool" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.CheckAdbTarget" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.CreateAndroidEmulator" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.RenameTestCases" />
@@ -16,6 +17,11 @@
     <_TestImageName>XamarinAndroidTestRunner</_TestImageName>
     <_AdbEmulatorPort>5570</_AdbEmulatorPort>
   </PropertyGroup>
+
+  <ItemGroup>
+    <_AllArchives Include="@(TestApk)" />
+    <_AllArchives Include="@(TestAab)" />
+  </ItemGroup>
 
   <Target Name="AcquireAndroidTarget">
     <Xamarin.Android.Tools.BootstrapTasks.CheckAdbTarget
@@ -160,19 +166,50 @@
     />
   </Target>
 
+  <Target Name="DeployTestAabs"
+      Condition=" '@(TestAab)' != '' ">
+    <PropertyGroup>
+      <_KeyStore>..\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Resources\Base\test.keystore</_KeyStore>
+      <_KeyAlias>mykey</_KeyAlias>
+      <_KeyPass>android</_KeyPass>
+      <_StorePass>android</_StorePass>
+    </PropertyGroup>
+    <Xamarin.Android.Tools.BootstrapTasks.BundleTool
+        Arguments="build-apks --connected-device --overwrite --mode default --bundle &quot;%(TestAab.Identity)&quot; --output &quot;%(TestAab.Identity).apks&quot;"
+        ContinueOnError="ErrorAndContinue"
+        ToolPath="$(JavaSdkDirectory)\bin"
+        JarPath="$(BundleToolJarPath)"
+        AdbToolExe="$(AdbToolExe)"
+        AdbToolPath="$(AdbToolPath)"
+        KeyStore="$([System.IO.Path]::GetFullPath ('$(_KeyStore)'))"
+        KeyAlias="$(_KeyAlias)"
+        KeyPass="$(_KeyPass)"
+        StorePass="$(_StorePass)"
+    />
+    <!-- modules: List of modules to be installed, or "_ALL_" for all modules.-->
+    <Xamarin.Android.Tools.BootstrapTasks.BundleTool
+        Arguments="install-apks --modules _ALL_ --apks &quot;%(TestAab.Identity).apks&quot;"
+        ContinueOnError="ErrorAndContinue"
+        ToolPath="$(JavaSdkDirectory)\bin"
+        JarPath="$(BundleToolJarPath)"
+        AdbToolExe="$(AdbToolExe)"
+        AdbToolPath="$(AdbToolPath)"
+    />
+  </Target>
+
   <Target Name="UndeployTestApks"
-      Condition=" '@(TestApk)' != '' ">
+      Condition=" '@(_AllArchives)' != '' ">
     <Xamarin.Android.Tools.BootstrapTasks.Adb
-        Arguments="$(_AdbTarget) $(AdbOptions) uninstall &quot;%(TestApk.Package)&quot;"
+        Arguments="$(_AdbTarget) $(AdbOptions) uninstall &quot;%(_AllArchives.Package)&quot;"
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)"
         Timeout="120000"
-	IgnoreExitCode="true"
+        IgnoreExitCode="true"
     />
   </Target>
 
   <Target Name="RunTestApks"
-      Condition=" '@(TestApk)' != '' ">
+      Condition=" '@(_AllArchives)' != '' ">
     <Xamarin.Android.Tools.BootstrapTasks.Adb
         Condition=" '@(TestApkPermission)' != '' "
         IgnoreExitCode="True"
@@ -204,26 +241,26 @@
       <Output TaskParameter="FailedToRun" ItemName="_FailedComponent"/>
     </RunInstrumentationTests>
     <RunUITests
-        Condition=" '%(TestApk.Activity)' != '' "
+        Condition=" '%(_AllArchives.Activity)' != '' "
         ContinueOnError="ErrorAndContinue"
         AdbTarget="$(_AdbTarget)"
         AdbOptions="$(AdbOptions)"
-        Activity="%(TestApk.Activity)"
-        LogcatFilename="$(_LogcatFilenameBase)-%(TestApk.Package).txt"
+        Activity="%(_AllArchives.Activity)"
+        LogcatFilename="$(_LogcatFilenameBase)-%(_AllArchives.Package).txt"
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)"
         Timeout="300000">
     </RunUITests>
     <ProcessLogcatTiming
-        Condition=" '%(TestApk.TimingDefinitionsFilename)' != ''"
+        Condition=" '%(_AllArchives.TimingDefinitionsFilename)' != ''"
         ContinueOnError="ErrorAndContinue"
-        InputFilename="$(_LogcatFilenameBase)-%(TestApk.Package).txt"
-        ApplicationPackageName="%(TestApk.Package)"
-        ResultsFilename="%(TestApk.TimingResultsFilename)"
-        DefinitionsFilename="%(TestApk.TimingDefinitionsFilename)"
+        InputFilename="$(_LogcatFilenameBase)-%(_AllArchives.Package).txt"
+        ApplicationPackageName="%(_AllArchives.Package)"
+        ResultsFilename="%(_AllArchives.TimingResultsFilename)"
+        DefinitionsFilename="%(_AllArchives.TimingDefinitionsFilename)"
         AddResults="true"
         LabelSuffix="-$(Configuration)$(TestsFlavor)"
-        Activity="%(TestApk.Activity)" />
+        Activity="%(_AllArchives.Activity)" />
   </Target>
   <Target Name="RenameTestCases">
     <Error
@@ -273,25 +310,25 @@
   <Target Name="RecordApkSizes"
       Condition=" '$(HostOS)' != 'Windows' ">
     <Exec
-        Condition=" '$(HostOS)' == 'Darwin' And '%(TestApk.ApkSizesDefinitionFilename)' != '' "
-        Command="stat -f &quot;stat: %z %N&quot; &quot;%(TestApk.Identity)&quot; > &quot;$(OutputPath)%(TestApk.ApkSizesInputFilename)&quot;"
+        Condition=" '$(HostOS)' == 'Darwin' And '%(_AllArchives.ApkSizesDefinitionFilename)' != '' "
+        Command="stat -f &quot;stat: %z %N&quot; &quot;%(_AllArchives.Identity)&quot; > &quot;$(OutputPath)%(_AllArchives.ApkSizesInputFilename)&quot;"
         ContinueOnError="ErrorAndContinue"
     />
     <Exec
-        Condition=" '$(HostOS)' == 'Linux'  And '%(TestApk.ApkSizesDefinitionFilename)' != '' "
-        Command="stat -c &quot;stat: %s %N&quot; &quot;%(TestApk.Identity)&quot; > &quot;$(OutputPath)%(TestApk.ApkSizesInputFilename)&quot;"
+        Condition=" '$(HostOS)' == 'Linux'  And '%(_AllArchives.ApkSizesDefinitionFilename)' != '' "
+        Command="stat -c &quot;stat: %s %N&quot; &quot;%(_AllArchives.Identity)&quot; > &quot;$(OutputPath)%(_AllArchives.ApkSizesInputFilename)&quot;"
         ContinueOnError="ErrorAndContinue"
     />
     <Exec
-        Condition=" '%(TestApk.ApkSizesDefinitionFilename)' != '' "
-        Command="unzip -l &quot;%(TestApk.Identity)&quot; >> &quot;$(OutputPath)%(TestApk.ApkSizesInputFilename)&quot;"
+        Condition=" '%(_AllArchives.ApkSizesDefinitionFilename)' != '' "
+        Command="unzip -l &quot;%(_AllArchives.Identity)&quot; >> &quot;$(OutputPath)%(_AllArchives.ApkSizesInputFilename)&quot;"
         ContinueOnError="ErrorAndContinue" />
     <ProcessPlotInput
-        Condition=" '%(TestApk.ApkSizesDefinitionFilename)' != '' "
-        InputFilename="$(OutputPath)%(TestApk.ApkSizesInputFilename)"
-        ApplicationPackageName="%(TestApk.Package)"
-        ResultsFilename="%(TestApk.ApkSizesResultsFilename)"
-        DefinitionsFilename="%(TestApk.ApkSizesDefinitionFilename)"
+        Condition=" '%(_AllArchives.ApkSizesDefinitionFilename)' != '' "
+        InputFilename="$(OutputPath)%(_AllArchives.ApkSizesInputFilename)"
+        ApplicationPackageName="%(_AllArchives.Package)"
+        ResultsFilename="%(_AllArchives.ApkSizesResultsFilename)"
+        DefinitionsFilename="%(_AllArchives.ApkSizesDefinitionFilename)"
         AddResults="True"
         LabelSuffix="-$(Configuration)$(TestsFlavor)"
         ContinueOnError="ErrorAndContinue"

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -177,7 +177,7 @@
     <Xamarin.Android.Tools.BootstrapTasks.BundleTool
         Arguments="build-apks --connected-device --overwrite --mode default --bundle &quot;%(TestAab.Identity)&quot; --output &quot;%(TestAab.Identity).apks&quot;"
         ContinueOnError="ErrorAndContinue"
-        ToolPath="$(JavaSdkDirectory)\bin"
+        JavaPath="$(JavaPath)"
         JarPath="$(BundleToolJarPath)"
         AdbToolExe="$(AdbToolExe)"
         AdbToolPath="$(AdbToolPath)"
@@ -190,7 +190,7 @@
     <Xamarin.Android.Tools.BootstrapTasks.BundleTool
         Arguments="install-apks --modules _ALL_ --apks &quot;%(TestAab.Identity).apks&quot;"
         ContinueOnError="ErrorAndContinue"
-        ToolPath="$(JavaSdkDirectory)\bin"
+        JavaPath="$(JavaPath)"
         JarPath="$(BundleToolJarPath)"
         AdbToolExe="$(AdbToolExe)"
         AdbToolPath="$(AdbToolPath)"

--- a/build-tools/scripts/Windows-Configuration.OperatingSystem.props.in
+++ b/build-tools/scripts/Windows-Configuration.OperatingSystem.props.in
@@ -12,5 +12,6 @@
     <JavaSdkDirectory>@JAVA_HOME@</JavaSdkDirectory>
     <JavaCPath>$(JavaSdkDirectory)\bin\javac.exe</JavaCPath>
     <JarPath>$(JavaSdkDirectory)\bin\jar.exe</JarPath>
+    <JavaPath>$(JavaSdkDirectory)\bin\java.exe</JavaPath>
   </PropertyGroup>
 </Project>

--- a/build-tools/scripts/generate-os-info
+++ b/build-tools/scripts/generate-os-info
@@ -194,6 +194,7 @@ cat <<EOF > "$1"
         <HostCxx64 Condition=" '\$(HostCxx64)' == '' ">$HOST_CXX64</HostCxx64>
         <JavaCPath Condition=" '\$(JavaCPath)' == '' ">javac</JavaCPath>
         <JarPath Condition=" '\$(JarPath)' == '' ">jar</JarPath>
+        <JavaPath Condition=" '\$(JavaPath)' == '' ">java</JavaPath>
         <HostHomebrewPrefix Condition=" '\$(HostHomebrewPrefix)' == '' ">$HOST_HOMEBREW_PREFIX</HostHomebrewPrefix>
     </PropertyGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Generator/Generator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Generator/Generator.cs
@@ -12,9 +12,10 @@ namespace Xamarin.Android.Tasks
 {
 	class Generator
 	{
-		public static bool CreateJavaSources (TaskLoggingHelper log, IEnumerable<TypeDefinition> javaTypes, string outputPath, string applicationJavaClass, bool useSharedRuntime, bool generateOnCreateOverrides, bool hasExportReference)
+		public static bool CreateJavaSources (TaskLoggingHelper log, IEnumerable<TypeDefinition> javaTypes, string outputPath, 
+			string applicationJavaClass, string androidSdkPlatform, bool useSharedRuntime, bool generateOnCreateOverrides, bool hasExportReference)
 		{
-			string monoInit = GetMonoInitSource (useSharedRuntime);
+			string monoInit = GetMonoInitSource (androidSdkPlatform, useSharedRuntime);
 
 			bool ok = true;
 			using (var memoryStream = new MemoryStream ())
@@ -60,15 +61,19 @@ namespace Xamarin.Android.Tasks
 			return ok;
 		}
 
-		static string GetMonoInitSource (bool useSharedRuntime)
+		static string GetMonoInitSource (string androidSdkPlatform, bool useSharedRuntime)
 		{
 			// Lookup the mono init section from MonoRuntimeProvider:
 			// Mono Runtime Initialization {{{
 			// }}}
 			var builder = new StringBuilder ();
-			var suffix = useSharedRuntime ? "Shared" : "Bundled";
+			var runtime = useSharedRuntime ? "Shared" : "Bundled";
+			var api = "";
+			if (int.TryParse (androidSdkPlatform, out int apiLevel) && apiLevel < 21) {
+				api = ".20";
+			}
 			var assembly = Assembly.GetExecutingAssembly ();
-			using (var s = assembly.GetManifestResourceStream ($"MonoRuntimeProvider.{suffix}.java"))
+			using (var s = assembly.GetManifestResourceStream ($"MonoRuntimeProvider.{runtime}{api}.java"))
 			using (var reader = new StreamReader (s)) {
 				bool copy = false;
 				string line;

--- a/src/Xamarin.Android.Build.Tasks/Resources/MonoRuntimeProvider.Bundled.20.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/MonoRuntimeProvider.Bundled.20.java
@@ -19,20 +19,7 @@ public class MonoRuntimeProvider
 	public void attachInfo (android.content.Context context, android.content.pm.ProviderInfo info)
 	{
 		// Mono Runtime Initialization {{{
-		android.content.pm.ApplicationInfo applicationInfo = context.getApplicationInfo ();
-		String[] apks = null;
-		if (android.os.Build.VERSION.SDK_INT >= 21) {
-			String[] splitApks = applicationInfo.splitPublicSourceDirs;
-			if (splitApks != null && splitApks.length > 0) {
-				apks = new String[splitApks.length + 1];
-				apks [0] = applicationInfo.sourceDir;
-				System.arraycopy (splitApks, 0, apks, 1, splitApks.length);
-			}
-		}
-		if (apks == null) {
-			apks = new String[] { applicationInfo.sourceDir };
-		}
-		mono.MonoPackageManager.LoadApplication (context, applicationInfo, apks);
+		mono.MonoPackageManager.LoadApplication (context, context.getApplicationInfo (), new String[]{context.getApplicationInfo ().sourceDir});
 		// }}}
 		super.attachInfo (context, info);
 	}

--- a/src/Xamarin.Android.Build.Tasks/Resources/MonoRuntimeProvider.Shared.20.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/MonoRuntimeProvider.Shared.20.java
@@ -23,12 +23,6 @@ public class MonoRuntimeProvider
 		android.content.pm.PackageManager packageManager = context.getPackageManager ();
 		java.util.List<String> apks = new java.util.ArrayList<String> ();
 		apks.add (applicationInfo.sourceDir);
-		if (android.os.Build.VERSION.SDK_INT >= 21) {
-			String[] splitApks = applicationInfo.splitPublicSourceDirs;
-			if (splitApks != null && splitApks.length > 0) {
-				java.util.Collections.addAll (apks, splitApks);
-			}
-		}
 		String platformPackage	= mono.MonoPackageManager.getApiPackageName ();
 		if (platformPackage != null) {
 			try {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -70,6 +70,8 @@ namespace Xamarin.Android.Tasks {
 
 		public bool NonConstantId { get; set; }
 
+		public bool ProtobufFormat { get; set; }
+
 		AssemblyIdentityMap assemblyMap = new AssemblyIdentityMap ();
 		List<string> tempFiles = new List<string> ();
 
@@ -167,6 +169,9 @@ namespace Xamarin.Android.Tasks {
 
 			if (!string.IsNullOrEmpty (ResourceSymbolsTextFile))
 				cmd.AppendSwitchIfNotNull ("--output-text-symbols ", ResourceSymbolsTextFile);
+
+			if (ProtobufFormat)
+				cmd.AppendSwitch ("--proto-format");
 
 			var extraArgsExpanded = ExpandString (ExtraArgs);
 			if (extraArgsExpanded != ExtraArgs)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
@@ -34,10 +34,14 @@ namespace Xamarin.Android.Tasks
 
 		public string SigningAlgorithm { get; set; }
 
+		public string FileSuffix { get; set; }
+
 		protected override string DefaultErrorCode => "ANDJS0000";
 
 		protected override string GenerateCommandLineCommands ()
 		{
+			var fileName = Path.GetFileNameWithoutExtension (UnsignedApk);
+			var extension = Path.GetExtension (UnsignedApk);
 			var cmd = new CommandLineBuilder ();
 
 			cmd.AppendSwitchIfNotNull ("-tsa ", TimestampAuthorityUrl);
@@ -47,7 +51,7 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitchIfNotNull ("-keypass ", KeyPass);
 			cmd.AppendSwitchIfNotNull ("-digestalg ", "SHA1");
 			cmd.AppendSwitchIfNotNull ("-sigalg ", string.IsNullOrWhiteSpace (SigningAlgorithm) ? "md5withRSA" : SigningAlgorithm);
-			cmd.AppendSwitchIfNotNull ("-signedjar ", String.Format ("{0}{1}{2}-Signed-Unaligned.apk", SignedApkDirectory, Path.DirectorySeparatorChar, Path.GetFileNameWithoutExtension (UnsignedApk)));
+			cmd.AppendSwitchIfNotNull ("-signedjar ", Path.Combine (SignedApkDirectory, $"{fileName}{FileSuffix}{extension}" ));
 
 			cmd.AppendFileNameIfNotNull (UnsignedApk);
 			cmd.AppendSwitch (KeyAlias);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApkSet.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApkSet.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.IO;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// Invokes `bundletool` to create an APK set (.apks file)
+	/// 
+	/// Usage: bundletool build-apks --bundle=foo.aab --output=foo.apks
+	/// </summary>
+	public class BuildApkSet : BundleTool
+	{
+		[Required]
+		public string AppBundle { get; set; }
+
+		[Required]
+		public string Output { get; set; }
+
+		/// <summary>
+		/// This is used to detect the attached device and generate an APK set specifically for it
+		/// </summary>
+		[Required]
+		public string AdbToolPath { get; set; }
+
+		public string AdbToolExe { get; set; }
+
+		public string AdbToolName => OS.IsWindows ? "adb.exe" : "adb";
+
+		[Required]
+		public string Aapt2ToolPath { get; set; }
+
+		public string Aapt2ToolExe { get; set; }
+
+		public string Aapt2ToolName => OS.IsWindows ? "aapt2.exe" : "aapt2";
+
+		[Required]
+		public string KeyStore { get; set; }
+
+		[Required]
+		public string KeyAlias { get; set; }
+
+		[Required]
+		public string KeyPass { get; set; }
+
+		[Required]
+		public string StorePass { get; set; }
+
+		public override bool Execute ()
+		{
+			//NOTE: bundletool will not overwrite
+			if (File.Exists (Output))
+				File.Delete (Output);
+
+			base.Execute ();
+
+			return !Log.HasLoggedErrors;
+		}
+
+		protected override CommandLineBuilder GetCommandLineBuilder ()
+		{
+			var adb   = string.IsNullOrEmpty (AdbToolExe) ? AdbToolName : AdbToolExe;
+			var aapt2 = string.IsNullOrEmpty (Aapt2ToolExe) ? Aapt2ToolName : Aapt2ToolExe;
+			var cmd   = base.GetCommandLineBuilder ();
+			cmd.AppendSwitch ("build-apks");
+			cmd.AppendSwitch ("--connected-device");
+			cmd.AppendSwitchIfNotNull ("--bundle ", AppBundle);
+			cmd.AppendSwitchIfNotNull ("--output ", Output);
+			cmd.AppendSwitchIfNotNull ("--mode ", "default");
+			cmd.AppendSwitchIfNotNull ("--adb ", Path.Combine (AdbToolPath, adb));
+			cmd.AppendSwitchIfNotNull ("--aapt2 ", Path.Combine (Aapt2ToolPath, aapt2));
+			cmd.AppendSwitchIfNotNull ("--ks ", KeyStore);
+			cmd.AppendSwitchIfNotNull ("--ks-key-alias ", KeyAlias);
+			cmd.AppendSwitchIfNotNull ("--key-pass ", $"pass:{KeyPass}");
+			cmd.AppendSwitchIfNotNull ("--ks-pass ", $"pass:{StorePass}");
+			return cmd;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// Invokes `bundletool` to create an Android App Bundle (.aab file)
+	/// 
+	/// Usage: bundletool build-bundle --modules=base.zip --output=foo.aab --config=BundleConfig.json
+	/// </summary>
+	public class BuildAppBundle : BundleTool
+	{
+		[Required]
+		public string BaseZip { get; set; }
+
+		[Required]
+		public string Output { get; set; }
+
+		public string UncompressedFileExtensions { get; set; }
+
+		string temp;
+
+		public override bool Execute ()
+		{
+			temp = Path.GetTempFileName ();
+			try {
+				var uncompressed = new List<string> {
+					"typemap.mj",
+					"typemap.jm",
+					"assemblies/*",
+				};
+				if (!string.IsNullOrEmpty (UncompressedFileExtensions)) {
+					//NOTE: these are file extensions, that need converted to glob syntax
+					var split = UncompressedFileExtensions.Split (new char [] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries);
+					foreach (var extension in split) {
+						uncompressed.Add ("**/*" + extension);
+					}
+				}
+				var json = JsonConvert.SerializeObject (new {
+					compression = new {
+						uncompressedGlob = uncompressed,
+					}
+				});
+				Log.LogDebugMessage ("BundleConfig.json: {0}", json);
+				File.WriteAllText (temp, json);
+
+				//NOTE: bundletool will not overwrite
+				if (File.Exists (Output))
+					File.Delete (Output);
+
+				base.Execute ();
+			} finally {
+				File.Delete (temp);
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+
+		protected override CommandLineBuilder GetCommandLineBuilder ()
+		{
+			var cmd = base.GetCommandLineBuilder ();
+			cmd.AppendSwitch ("build-bundle");
+			cmd.AppendSwitchIfNotNull ("--modules ", BaseZip);
+			cmd.AppendSwitchIfNotNull ("--output ", Output);
+			cmd.AppendSwitchIfNotNull ("--config ", temp);
+			return cmd;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildBaseAppBundle.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildBaseAppBundle.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.IO;
+using Xamarin.Tools.Zip;
+
+namespace Xamarin.Android.Tasks
+{
+	public class BuildBaseAppBundle : BuildApk
+	{
+		/// <summary>
+		/// Files that need to land in the final APK need to go in `root/`
+		/// </summary>
+		protected override string RootPath => "root/";
+
+		/// <summary>
+		/// `.dex` files should be in `dex/`
+		/// </summary>
+		protected override string DalvikPath => "dex/";
+
+		/// <summary>
+		/// Nothing needs to be compressed with app bundles. BundleConfig.json specifies the final compression mode.
+		/// </summary>
+		protected override CompressionMethod UncompressedMethod => CompressionMethod.Default;
+
+		/// <summary>
+		/// aapt2 is putting AndroidManifest.xml in the root of the archive instead of at manifest/AndroidManifest.xml that bundletool expects.
+		/// I see no way to change this behavior, so we can move the file for now:
+		/// https://github.com/aosp-mirror/platform_frameworks_base/blob/e80b45506501815061b079dcb10bf87443bd385d/tools/aapt2/LoadedApk.h#L34
+		/// </summary>
+		protected override void FixupArchive (ZipArchiveEx zip)
+		{
+			var entry = zip.Archive.ReadEntry ("AndroidManifest.xml");
+			using (var stream = new MemoryStream ()) {
+				entry.Extract (stream);
+				stream.Position = 0;
+				zip.Archive.AddEntry ("manifest/AndroidManifest.xml", stream);
+				zip.Archive.DeleteEntry (entry);
+				zip.Flush ();
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BundleTool.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BundleTool.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+
+namespace Xamarin.Android.Tasks
+{
+	public abstract class BundleTool : JavaToolTask
+	{
+		[Required]
+		public string JarPath { get; set; }
+
+		protected override string GenerateCommandLineCommands ()
+		{
+			return GetCommandLineBuilder ().ToString ();
+		}
+
+		protected virtual CommandLineBuilder GetCommandLineBuilder ()
+		{
+			var cmd = new CommandLineBuilder ();
+
+			if (!string.IsNullOrEmpty (JavaOptions)) {
+				cmd.AppendSwitch (JavaOptions);
+			}
+			cmd.AppendSwitchIfNotNull ("-Xmx", JavaMaximumHeapSize);
+			cmd.AppendSwitchIfNotNull ("-jar ", JarPath);
+
+			return cmd;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -138,6 +138,7 @@ namespace Xamarin.Android.Tasks
 				java_types,
 				Path.Combine (OutputDirectory, "src"),
 				ApplicationJavaClass,
+				AndroidSdkPlatform,
 				UseSharedRuntime,
 				int.Parse (AndroidSdkPlatform) <= 10,
 				ResolvedAssemblies.Any (assembly => Path.GetFileName (assembly.ItemSpec) == "Mono.Android.Export.dll"));

--- a/src/Xamarin.Android.Build.Tasks/Tasks/InstallApkSet.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/InstallApkSet.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.IO;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// Invokes `bundletool` to install an APK set to an attached device
+	/// 
+	/// Usage: bundletool install-apks --apks=foo.apks
+	/// </summary>
+	public class InstallApkSet : BundleTool
+	{
+		[Required]
+		public string ApkSet { get; set; }
+
+		[Required]
+		public string AdbToolPath { get; set; }
+
+		public string AdbToolExe { get; set; }
+
+		public string AdbToolName => OS.IsWindows ? "adb.exe" : "adb";
+
+		protected override CommandLineBuilder GetCommandLineBuilder ()
+		{
+			var adb = string.IsNullOrEmpty (AdbToolExe) ? AdbToolName : AdbToolExe;
+			var cmd = base.GetCommandLineBuilder ();
+			cmd.AppendSwitch ("install-apks");
+			cmd.AppendSwitchIfNotNull ("--apks ", ApkSet);
+			cmd.AppendSwitchIfNotNull ("--adb ", Path.Combine (AdbToolPath, adb));
+			cmd.AppendSwitch ("--allow-downgrade");
+
+			// --modules: List of modules to be installed, or "_ALL_" for all modules.
+			// Defaults to modules installed during first install, i.e. not on-demand.
+			// Xamarin.Android won't support on-demand modules yet.
+			cmd.AppendSwitchIfNotNull ("--modules ", "_ALL_");
+			
+			return cmd;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BundleToolTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BundleToolTests.cs
@@ -1,0 +1,154 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xamarin.ProjectTools;
+using Xamarin.Tools.Zip;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	public class BundleToolTests : BaseTest
+	{
+		XamarinAndroidApplicationProject project;
+		ProjectBuilder builder;
+		string intermediate;
+		string bin;
+
+		[OneTimeSetUp]
+		public void OneTimeSetUp ()
+		{
+			project = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			//NOTE: this is here to enable adb shell run-as
+			project.AndroidManifest = project.AndroidManifest.Replace ("<application ", "<application android:debuggable=\"true\" ");
+			project.SetProperty (project.ReleaseProperties, "AndroidPackageFormat", "aab");
+
+			builder = CreateApkBuilder (Path.Combine ("temp", TestName));
+			Assert.IsTrue (builder.Build (project), "Build should have succeeded.");
+
+			var projectDir = Path.Combine (Root, builder.ProjectDirectory);
+			intermediate = Path.Combine (projectDir, project.IntermediateOutputPath);
+			bin = Path.Combine (projectDir, project.OutputPath);
+		}
+
+		[OneTimeTearDown]
+		public void OneTimeTearDown ()
+		{
+			builder.Dispose ();
+		}
+
+		string [] ListArchiveContents (string archive)
+		{
+			var entries = new List<string> ();
+			using (var zip = ZipArchive.Open (archive, FileMode.Open)) {
+				foreach (var entry in zip) {
+					entries.Add (entry.FullName);
+				}
+			}
+			entries.Sort ();
+			return entries.ToArray ();
+		}
+
+		[Test]
+		public void BaseZip ()
+		{
+			var baseZip = Path.Combine (intermediate, "android", "bin", "base.zip");
+			var contents = ListArchiveContents (baseZip);
+			CollectionAssert.AreEqual (contents, new [] {
+				"dex/classes.dex",
+				"lib/arm64-v8a/libmono-btls-shared.so",
+				"lib/arm64-v8a/libmonodroid.so",
+				"lib/arm64-v8a/libmono-native.so",
+				"lib/arm64-v8a/libmonosgen-2.0.so",
+				"lib/armeabi-v7a/libmono-btls-shared.so",
+				"lib/armeabi-v7a/libmonodroid.so",
+				"lib/armeabi-v7a/libmono-native.so",
+				"lib/armeabi-v7a/libmonosgen-2.0.so",
+				"manifest/AndroidManifest.xml",
+				"res/drawable-hdpi-v4/icon.png",
+				"res/drawable-mdpi-v4/icon.png",
+				"res/drawable-xhdpi-v4/icon.png",
+				"res/drawable-xxhdpi-v4/icon.png",
+				"res/drawable-xxxhdpi-v4/icon.png",
+				"res/layout/main.xml",
+				"resources.pb",
+				"root/assemblies/Java.Interop.dll",
+				"root/assemblies/Mono.Android.dll",
+				"root/assemblies/mscorlib.dll",
+				"root/assemblies/System.Core.dll",
+				"root/assemblies/System.dll",
+				"root/assemblies/System.Runtime.Serialization.dll",
+				"root/assemblies/UnnamedProject.dll",
+				"root/NOTICE",
+				"root/typemap.jm",
+				"root/typemap.mj"
+			});
+		}
+
+		[Test]
+		public void AppBundle ()
+		{
+			var aab = Path.Combine (intermediate, "android", "bin", "UnnamedProject.UnnamedProject.aab");
+			FileAssert.Exists (aab);
+			var contents = ListArchiveContents (aab);
+			CollectionAssert.AreEqual (contents, new [] {
+				"base/dex/classes.dex",
+				"base/lib/arm64-v8a/libmono-btls-shared.so",
+				"base/lib/arm64-v8a/libmonodroid.so",
+				"base/lib/arm64-v8a/libmono-native.so",
+				"base/lib/arm64-v8a/libmonosgen-2.0.so",
+				"base/lib/armeabi-v7a/libmono-btls-shared.so",
+				"base/lib/armeabi-v7a/libmonodroid.so",
+				"base/lib/armeabi-v7a/libmono-native.so",
+				"base/lib/armeabi-v7a/libmonosgen-2.0.so",
+				"base/manifest/AndroidManifest.xml",
+				"base/native.pb",
+				"base/res/drawable-hdpi-v4/icon.png",
+				"base/res/drawable-mdpi-v4/icon.png",
+				"base/res/drawable-xhdpi-v4/icon.png",
+				"base/res/drawable-xxhdpi-v4/icon.png",
+				"base/res/drawable-xxxhdpi-v4/icon.png",
+				"base/res/layout/main.xml",
+				"base/resources.pb",
+				"base/root/assemblies/Java.Interop.dll",
+				"base/root/assemblies/Mono.Android.dll",
+				"base/root/assemblies/mscorlib.dll",
+				"base/root/assemblies/System.Core.dll",
+				"base/root/assemblies/System.dll",
+				"base/root/assemblies/System.Runtime.Serialization.dll",
+				"base/root/assemblies/UnnamedProject.dll",
+				"base/root/NOTICE",
+				"base/root/typemap.jm",
+				"base/root/typemap.mj",
+				"BundleConfig.pb"
+			});
+		}
+
+		[Test]
+		public void AppBundleSigned ()
+		{
+			var aab = Path.Combine (bin, "UnnamedProject.UnnamedProject-Signed.aab");
+			FileAssert.Exists (aab);
+			var contents = ListArchiveContents (aab);
+			Assert.IsTrue (StringAssertEx.ContainsText (contents, "META-INF/MANIFEST.MF"), $"{aab} is not signed!");
+		}
+
+		[Test]
+		public void ApkSet ()
+		{
+			if (!HasDevices)
+				Assert.Ignore ("Skipping Installation. No devices available.");
+
+			Assert.IsTrue (builder.RunTarget (project, "Install"), "App should have installed.");
+
+			var aab = Path.Combine (intermediate, "android", "bin", "UnnamedProject.UnnamedProject.apks");
+			FileAssert.Exists (aab);
+			// Expecting: splits/base-arm64_v8a.apk, splits/base-master.apk, splits/base-xxxhdpi.apk
+			var contents = ListArchiveContents (aab).Where (a => a.EndsWith (".apk", StringComparison.OrdinalIgnoreCase)).ToArray ();
+			Assert.AreEqual (3, contents.Length, "Expecting three APKs!");
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -95,6 +95,7 @@
     <Compile Include="ResolveSdksTaskTests.cs" />
     <Compile Include="AndroidResourceTests.cs" />
     <Compile Include="ManagedResourceParserTests.cs" />
+    <Compile Include="Tasks\BundleToolTests.cs" />
     <Compile Include="Tasks\CopyResourceTests.cs" />
     <Compile Include="Tasks\GenerateLibraryResourcesTests.cs" />
     <Compile Include="Tasks\KeyToolTests.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -123,6 +123,11 @@
     <Compile Include="Tasks\Aapt2Link.cs" />
     <Compile Include="Tasks\AndroidZipAlign.cs" />
     <Compile Include="Tasks\BuildApk.cs" />
+    <Compile Include="Tasks\BuildBaseAppBundle.cs" />
+    <Compile Include="Tasks\BuildAppBundle.cs" />
+    <Compile Include="Tasks\BundleTool.cs" />
+    <Compile Include="Tasks\BuildApkSet.cs" />
+    <Compile Include="Tasks\InstallApkSet.cs" />
     <Compile Include="Tasks\CilStrip.cs" />
     <Compile Include="Tasks\ConvertDebuggingFiles.cs" />
     <Compile Include="Tasks\CheckForInvalidResourceFileNames.cs" />
@@ -660,8 +665,14 @@
     <EmbeddedResource Include="Resources\MonoRuntimeProvider.Bundled.java">
       <LogicalName>MonoRuntimeProvider.Bundled.java</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="Resources\MonoRuntimeProvider.Bundled.20.java">
+      <LogicalName>MonoRuntimeProvider.Bundled.20.java</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="Resources\MonoRuntimeProvider.Shared.java">
       <LogicalName>MonoRuntimeProvider.Shared.java</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\MonoRuntimeProvider.Shared.20.java">
+      <LogicalName>MonoRuntimeProvider.Shared.20.java</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="Linker\PreserveLists\mscorlib.xml">
       <LogicalName>mscorlib.xml</LogicalName>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1906,21 +1906,25 @@ because xbuild doesn't support framework reference assemblies.
 		DependsOnTargets="_CollectRuntimeJarFilenames;$(_BeforeAddStaticResources);_GetMonoPlatformJarPath">
 	<CopyResource ResourceName="machine.config" OutputPath="$(MonoAndroidIntermediateAssetsDir)machine.config" />
   <CopyResource
-    ResourceName="MonoRuntimeProvider.Bundled.java"
-    OutputPath="$(MonoAndroidIntermediate)android\src\mono\MonoRuntimeProvider.java"
-    Condition=" '$(AndroidUseSharedRuntime)' != 'True' And '$(_AndroidApiLevel)' &gt;= '21' " />
+      Condition=" '$(AndroidUseSharedRuntime)' != 'True' And '$(_AndroidApiLevel)' &gt;= '21' "
+      ResourceName="MonoRuntimeProvider.Bundled.java"
+      OutputPath="$(MonoAndroidIntermediate)android\src\mono\MonoRuntimeProvider.java"
+  />
   <CopyResource
-    ResourceName="MonoRuntimeProvider.Bundled.20.java"
-    OutputPath="$(MonoAndroidIntermediate)android\src\mono\MonoRuntimeProvider.java"
-    Condition=" '$(AndroidUseSharedRuntime)' != 'True' And '$(_AndroidApiLevel)' &lt; '21' " />
+      Condition=" '$(AndroidUseSharedRuntime)' != 'True' And '$(_AndroidApiLevel)' &lt; '21' "
+      ResourceName="MonoRuntimeProvider.Bundled.20.java"
+      OutputPath="$(MonoAndroidIntermediate)android\src\mono\MonoRuntimeProvider.java"
+  />
   <CopyResource
-    ResourceName="MonoRuntimeProvider.Shared.java"
-    OutputPath="$(MonoAndroidIntermediate)android\src\mono\MonoRuntimeProvider.java"
-    Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(_AndroidApiLevel)' &gt;= '21' " />
+      Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(_AndroidApiLevel)' &gt;= '21' "
+      ResourceName="MonoRuntimeProvider.Shared.java"
+      OutputPath="$(MonoAndroidIntermediate)android\src\mono\MonoRuntimeProvider.java"
+  />
   <CopyResource
-    ResourceName="MonoRuntimeProvider.Shared.20.java"
-    OutputPath="$(MonoAndroidIntermediate)android\src\mono\MonoRuntimeProvider.java"
-    Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(_AndroidApiLevel)' &lt; '21' " />
+      ResourceName="MonoRuntimeProvider.Shared.20.java"
+      OutputPath="$(MonoAndroidIntermediate)android\src\mono\MonoRuntimeProvider.java"
+      Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(_AndroidApiLevel)' &lt; '21' "
+  />
   
   <Copy
     SourceFiles="$(MonoPlatformJarPath)"
@@ -2926,43 +2930,43 @@ because xbuild doesn't support framework reference assemblies.
     <Output TaskParameter="OutputFiles" ItemName="ApkFiles" />
   </BuildApk>
   <BuildBaseAppBundle
-    Condition=" '$(AndroidPackageFormat)' == 'aab' "
-    AndroidNdkDirectory="$(_AndroidNdkDirectory)"
-    ApkInputPath="$(_PackagedResources)"
-    ApkOutputPath="$(_BaseZipIntermediate)"
-    BundleAssemblies="$(BundleAssemblies)"
-    BundleNativeLibraries="$(_BundleResultNativeLibraries)"
-    EmbedAssemblies="$(EmbedAssembliesIntoApk)"
-    ResolvedUserAssemblies="@(_ResolvedUserAssemblies);@(_AndroidResolvedSatellitePaths)"
-    ResolvedFrameworkAssemblies="@(_ShrunkFrameworkAssemblies)"
-    NativeLibraries="@(AndroidNativeLibrary)"
-    AdditionalNativeLibraryReferences="@(_AdditionalNativeLibraryReferences)"
-    EmbeddedNativeLibraryAssemblies="$(OutDir)$(TargetFileName);@(ReferencePath);@(ReferenceDependencyPaths)"
-    DalvikClasses="@(_DexFile)"
-    SupportedAbis="$(_BuildTargetAbis)"
-    CreatePackagePerAbi="False"
-    UseSharedRuntime="$(AndroidUseSharedRuntime)"
-    Debug="$(AndroidIncludeDebugSymbols)"
-    PreferNativeLibrariesWithDebugSymbols="$(AndroidPreferNativeLibrariesWithDebugSymbols)"
-    TypeMappings="$(_AndroidTypeMappingJavaToManaged);$(_AndroidTypeMappingManagedToJava)"
-    JavaSourceFiles="@(AndroidJavaSource)"
-    JavaLibraries="@(AndroidJavaLibrary)"
-    AndroidSequencePointsMode="$(_SequencePointsMode)"
-    LibraryProjectJars="@(ExtractedJarImports)"
-    AndroidEmbedProfilers="$(AndroidEmbedProfilers)"
-    TlsProvider="$(AndroidTlsProvider)"
-    UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)">
+      Condition=" '$(AndroidPackageFormat)' == 'aab' "
+      AndroidNdkDirectory="$(_AndroidNdkDirectory)"
+      ApkInputPath="$(_PackagedResources)"
+      ApkOutputPath="$(_BaseZipIntermediate)"
+      BundleAssemblies="$(BundleAssemblies)"
+      BundleNativeLibraries="$(_BundleResultNativeLibraries)"
+      EmbedAssemblies="$(EmbedAssembliesIntoApk)"
+      ResolvedUserAssemblies="@(_ResolvedUserAssemblies);@(_AndroidResolvedSatellitePaths)"
+      ResolvedFrameworkAssemblies="@(_ShrunkFrameworkAssemblies)"
+      NativeLibraries="@(AndroidNativeLibrary)"
+      AdditionalNativeLibraryReferences="@(_AdditionalNativeLibraryReferences)"
+      EmbeddedNativeLibraryAssemblies="$(OutDir)$(TargetFileName);@(ReferencePath);@(ReferenceDependencyPaths)"
+      DalvikClasses="@(_DexFile)"
+      SupportedAbis="$(_BuildTargetAbis)"
+      CreatePackagePerAbi="False"
+      UseSharedRuntime="$(AndroidUseSharedRuntime)"
+      Debug="$(AndroidIncludeDebugSymbols)"
+      PreferNativeLibrariesWithDebugSymbols="$(AndroidPreferNativeLibrariesWithDebugSymbols)"
+      TypeMappings="$(_AndroidTypeMappingJavaToManaged);$(_AndroidTypeMappingManagedToJava)"
+      JavaSourceFiles="@(AndroidJavaSource)"
+      JavaLibraries="@(AndroidJavaLibrary)"
+      AndroidSequencePointsMode="$(_SequencePointsMode)"
+      LibraryProjectJars="@(ExtractedJarImports)"
+      AndroidEmbedProfilers="$(AndroidEmbedProfilers)"
+      TlsProvider="$(AndroidTlsProvider)"
+      UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)">
     <Output TaskParameter="OutputFiles" ItemName="BaseZipFile" />
   </BuildBaseAppBundle>
   <BuildAppBundle
-    Condition=" '$(AndroidPackageFormat)' == 'aab' "
-    ToolPath="$(JavaToolPath)"
-    JavaMaximumHeapSize="$(JavaMaximumHeapSize)"
-    JavaOptions="$(JavaOptions)"
-    JarPath="$(AndroidBundleToolJarPath)"
-    BaseZip="$(_BaseZipIntermediate)"
-    Output="$(_AppBundleIntermediate)"
-    UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)"
+      Condition=" '$(AndroidPackageFormat)' == 'aab' "
+      ToolPath="$(JavaToolPath)"
+      JavaMaximumHeapSize="$(JavaMaximumHeapSize)"
+      JavaOptions="$(JavaOptions)"
+      JarPath="$(AndroidBundleToolJarPath)"
+      BaseZip="$(_BaseZipIntermediate)"
+      Output="$(_AppBundleIntermediate)"
+      UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)"
   />
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -35,6 +35,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.Aot" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CilStrip" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.BuildApk" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.BuildBaseAppBundle" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.BuildAppBundle" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.BuildApkSet" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.InstallApkSet" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CalculateAdditionalResourceCacheDirectories" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CalculateLayoutCodeBehind" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CalculateProjectDependencies" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -294,6 +298,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidEnableProguard Condition=" '$(AndroidLinkTool)' != '' ">True</AndroidEnableProguard>
 	<AndroidEnableDesugar  Condition=" '$(AndroidEnableDesugar)' == '' And ('$(AndroidDexTool)' == 'd8' Or '$(AndroidLinkTool)' == 'r8') ">True</AndroidEnableDesugar>
 	<AndroidEnableDesugar  Condition=" '$(AndroidEnableDesugar)' == '' ">False</AndroidEnableDesugar>
+	<AndroidPackageFormat       Condition=" '$(AndroidPackageFormat)' == '' ">apk</AndroidPackageFormat>
+	<AndroidUseAapt2            Condition=" '$(AndroidPackageFormat)' == 'aab' ">True</AndroidUseAapt2>
+	<AndroidUseApkSigner        Condition=" '$(AndroidPackageFormat)' == 'aab' ">False</AndroidUseApkSigner>
+	<AndroidCreatePackagePerAbi Condition=" '$(AndroidCreatePackagePerAbi)' == 'aab' ">False</AndroidCreatePackagePerAbi>
 
 	<!-- Default Java heap size to 1GB (-Xmx1G) if not specified-->
 	<JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
@@ -713,15 +721,14 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 			<Output TaskParameter="TargetSdkVersion"    PropertyName="_AndroidTargetSdkVersion" />
 	</GetJavaPlatformJar>
 
-	<CreateProperty Value="$(MonoAndroidIntermediate)android\bin\$(_AndroidPackage).apk">
-		<Output TaskParameter="Value" PropertyName="ApkFileIntermediate"/>
-	</CreateProperty>
-	<CreateProperty Value="$(OutDir)$(_AndroidPackage).apk">
-		<Output TaskParameter="Value" PropertyName="ApkFile"/>
-	</CreateProperty>
-	<CreateProperty Value="$(OutDir)$(_AndroidPackage)-Signed.apk">
-		<Output TaskParameter="Value" PropertyName="ApkFileSigned"/>
-	</CreateProperty>
+	<PropertyGroup>
+		<ApkFileIntermediate>$(MonoAndroidIntermediate)android\bin\$(_AndroidPackage).apk</ApkFileIntermediate>
+		<_BaseZipIntermediate>$(MonoAndroidIntermediate)android\bin\base.zip</_BaseZipIntermediate>
+		<_AppBundleIntermediate>$(MonoAndroidIntermediate)android\bin\$(_AndroidPackage).aab</_AppBundleIntermediate>
+		<_ApkSetIntermediate>$(MonoAndroidIntermediate)android\bin\$(_AndroidPackage).apks</_ApkSetIntermediate>
+		<ApkFile>$(OutDir)$(_AndroidPackage).apk</ApkFile>
+		<ApkFileSigned>$(OutDir)$(_AndroidPackage)-Signed.apk</ApkFileSigned>
+	</PropertyGroup>
 </Target>
 
 <Target Name="_BeforeCleanIntermediateIfNuGetsChange">
@@ -1248,6 +1255,7 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="ExplicitCrunch=$(AndroidExplicitCrunch)" />
 		<_PropertyCacheItems Include="AndroidDexTool=$(AndroidDexTool)" />
 		<_PropertyCacheItems Include="AndroidLinkTool=$(AndroidLinkTool)" />
+		<_PropertyCacheItems Include="AndroidPackageFormat=$(AndroidPackageFormat)" />
 		<_PropertyCacheItems Include="UseSharedRuntime=$(AndroidUseSharedRuntime)" />
 		<_PropertyCacheItems Include="EmbedAssembliesIntoApk=$(EmbedAssembliesIntoApk)" />
 		<_PropertyCacheItems Include="AndroidLinkMode=$(AndroidLinkMode)" />
@@ -1900,7 +1908,19 @@ because xbuild doesn't support framework reference assemblies.
   <CopyResource
     ResourceName="MonoRuntimeProvider.Bundled.java"
     OutputPath="$(MonoAndroidIntermediate)android\src\mono\MonoRuntimeProvider.java"
-    Condition="'$(AndroidUseSharedRuntime)' != 'true'" />
+    Condition=" '$(AndroidUseSharedRuntime)' != 'True' And '$(_AndroidApiLevel)' &gt;= '21' " />
+  <CopyResource
+    ResourceName="MonoRuntimeProvider.Bundled.20.java"
+    OutputPath="$(MonoAndroidIntermediate)android\src\mono\MonoRuntimeProvider.java"
+    Condition=" '$(AndroidUseSharedRuntime)' != 'True' And '$(_AndroidApiLevel)' &lt; '21' " />
+  <CopyResource
+    ResourceName="MonoRuntimeProvider.Shared.java"
+    OutputPath="$(MonoAndroidIntermediate)android\src\mono\MonoRuntimeProvider.java"
+    Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(_AndroidApiLevel)' &gt;= '21' " />
+  <CopyResource
+    ResourceName="MonoRuntimeProvider.Shared.20.java"
+    OutputPath="$(MonoAndroidIntermediate)android\src\mono\MonoRuntimeProvider.java"
+    Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(_AndroidApiLevel)' &lt; '21' " />
   
   <Copy
     SourceFiles="$(MonoPlatformJarPath)"
@@ -1911,8 +1931,7 @@ because xbuild doesn't support framework reference assemblies.
   <Touch Files="$(_AndroidStaticResourcesFlag)" AlwaysCreate="true" />
 
   <ItemGroup>
-    <FileWrites Include="$(MonoAndroidIntermediate)android\src\mono\MonoRuntimeProvider.java"
-        Condition="Exists ('$(MonoAndroidIntermediate)android\src\mono\MonoRuntimeProvider.java')" />
+    <FileWrites Include="$(MonoAndroidIntermediate)android\src\mono\MonoRuntimeProvider.java" />
     <FileWrites Include="$(MonoAndroidIntermediateAssetsDir)machine.config" />
     <FileWrites Include="$(IntermediateOutputPath)android\bin\mono.android.jar" />
     <FileWrites Include="$(_AndroidStaticResourcesFlag)" />
@@ -2258,6 +2277,10 @@ because xbuild doesn't support framework reference assemblies.
     <Output TaskParameter="EmbeddedDSOsEnabled" PropertyName="_EmbeddedDSOsEnabled" />
     <Output TaskParameter="UsesLibraries"       ItemName="AndroidExternalJavaLibrary" />
   </ReadAndroidManifest>
+  <PropertyGroup>
+    <!--NOTE: bundletool requires this, regardless of AndroidManifest.xml-->
+    <_EmbeddedDSOsEnabled Condition=" '$(AndroidPackageFormat)' == 'aab' ">True</_EmbeddedDSOsEnabled>
+  </PropertyGroup>
 </Target>
 
 <Target Name="_SetupEmbeddedDSOs"
@@ -2416,6 +2439,10 @@ because xbuild doesn't support framework reference assemblies.
     VersionCodeProperties="$(AndroidVersionCodeProperties)"
     AndroidSdkPlatform="$(_AndroidApiLevel)"
   />
+  <PropertyGroup>
+    <_ProtobufFormat Condition=" '$(AndroidPackageFormat)' == 'aab' ">True</_ProtobufFormat>
+    <_ProtobufFormat Condition=" '$(_ProtobufFormat)' == '' ">False</_ProtobufFormat>
+  </PropertyGroup>
   <Aapt2Link
     Condition="'$(_AndroidUseAapt2)' == 'True'"
     CompiledResourceFlatArchive="$(_AndroidLibraryFlatArchivesDirectory)\compiled.flata"
@@ -2440,6 +2467,7 @@ because xbuild doesn't support framework reference assemblies.
     AndroidSdkPlatform="$(_AndroidApiLevel)"
     JavaDesignerOutputDirectory="$(AaptTemporaryDirectory)"
     ManifestFiles="$(IntermediateOutputPath)android\AndroidManifest.xml"
+    ProtobufFormat="$(_ProtobufFormat)"
     ExtraArgs="$(AndroidAapt2LinkExtraArgs)"
     ToolPath="$(Aapt2ToolPath)"
     ToolExe="$(Aapt2ToolExe)"
@@ -2869,6 +2897,7 @@ because xbuild doesn't support framework reference assemblies.
   </MakeBundleNativeCodeExternal>
   <!-- Put the assemblies and native libraries in the apk -->
   <BuildApk
+    Condition=" '$(AndroidPackageFormat)' != 'aab' "
     AndroidNdkDirectory="$(_AndroidNdkDirectory)"
     ApkInputPath="$(_PackagedResources)"
     ApkOutputPath="$(ApkFileIntermediate)"
@@ -2896,6 +2925,45 @@ because xbuild doesn't support framework reference assemblies.
     UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)">
     <Output TaskParameter="OutputFiles" ItemName="ApkFiles" />
   </BuildApk>
+  <BuildBaseAppBundle
+    Condition=" '$(AndroidPackageFormat)' == 'aab' "
+    AndroidNdkDirectory="$(_AndroidNdkDirectory)"
+    ApkInputPath="$(_PackagedResources)"
+    ApkOutputPath="$(_BaseZipIntermediate)"
+    BundleAssemblies="$(BundleAssemblies)"
+    BundleNativeLibraries="$(_BundleResultNativeLibraries)"
+    EmbedAssemblies="$(EmbedAssembliesIntoApk)"
+    ResolvedUserAssemblies="@(_ResolvedUserAssemblies);@(_AndroidResolvedSatellitePaths)"
+    ResolvedFrameworkAssemblies="@(_ShrunkFrameworkAssemblies)"
+    NativeLibraries="@(AndroidNativeLibrary)"
+    AdditionalNativeLibraryReferences="@(_AdditionalNativeLibraryReferences)"
+    EmbeddedNativeLibraryAssemblies="$(OutDir)$(TargetFileName);@(ReferencePath);@(ReferenceDependencyPaths)"
+    DalvikClasses="@(_DexFile)"
+    SupportedAbis="$(_BuildTargetAbis)"
+    CreatePackagePerAbi="False"
+    UseSharedRuntime="$(AndroidUseSharedRuntime)"
+    Debug="$(AndroidIncludeDebugSymbols)"
+    PreferNativeLibrariesWithDebugSymbols="$(AndroidPreferNativeLibrariesWithDebugSymbols)"
+    TypeMappings="$(_AndroidTypeMappingJavaToManaged);$(_AndroidTypeMappingManagedToJava)"
+    JavaSourceFiles="@(AndroidJavaSource)"
+    JavaLibraries="@(AndroidJavaLibrary)"
+    AndroidSequencePointsMode="$(_SequencePointsMode)"
+    LibraryProjectJars="@(ExtractedJarImports)"
+    AndroidEmbedProfilers="$(AndroidEmbedProfilers)"
+    TlsProvider="$(AndroidTlsProvider)"
+    UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)">
+    <Output TaskParameter="OutputFiles" ItemName="BaseZipFile" />
+  </BuildBaseAppBundle>
+  <BuildAppBundle
+    Condition=" '$(AndroidPackageFormat)' == 'aab' "
+    ToolPath="$(JavaToolPath)"
+    JavaMaximumHeapSize="$(JavaMaximumHeapSize)"
+    JavaOptions="$(JavaOptions)"
+    JarPath="$(AndroidBundleToolJarPath)"
+    BaseZip="$(_BaseZipIntermediate)"
+    Output="$(_AppBundleIntermediate)"
+    UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)"
+  />
 </Target>
 
 <Target Name="_ResolveCopyPackageInputs">
@@ -3031,9 +3099,14 @@ because xbuild doesn't support framework reference assemblies.
 	Outputs="$(ApkFileSigned)"
 	DependsOnTargets="_ResolveAndroidSigningKey">
 	<ItemGroup>
-		<ApkAbiFilesIntermediate Include="$(ApkFileIntermediate)" />
-		<ApkAbiFilesIntermediate Condition="'$(AndroidCreatePackagePerAbi)' == 'true'" Include="$(MonoAndroidIntermediate)android\bin\$(_AndroidPackage)*.apk" />
+		<ApkAbiFilesIntermediate Condition=" '$(AndroidPackageFormat)' != 'aab' " Include="$(ApkFileIntermediate)" />
+		<ApkAbiFilesIntermediate Condition=" '$(AndroidPackageFormat)' == 'aab' " Include="$(_AppBundleIntermediate)" />
+		<ApkAbiFilesIntermediate Condition=" '$(AndroidPackageFormat)' != 'aab' And '$(AndroidCreatePackagePerAbi)' == 'True' " Include="$(MonoAndroidIntermediate)android\bin\$(_AndroidPackage)*.apk" />
 	</ItemGroup>
+	<PropertyGroup>
+		<_JarSignerSuffix Condition=" '$(AndroidPackageFormat)' != 'aab' ">-Signed-Unaligned</_JarSignerSuffix>
+		<_JarSignerSuffix Condition=" '$(AndroidPackageFormat)' == 'aab' ">-Signed</_JarSignerSuffix>
+	</PropertyGroup>
 	<KeyTool
 		KeyStore="$(_ApkKeyStore)"
 		KeyAlias="$(_ApkKeyAlias)"
@@ -3046,6 +3119,7 @@ because xbuild doesn't support framework reference assemblies.
 	<AndroidSignPackage Condition=" '$(AndroidUseApkSigner)' != 'true' "
 		UnsignedApk="%(ApkAbiFilesIntermediate.FullPath)"
 		SignedApkDirectory="$(OutDir)"
+		FileSuffix="$(_JarSignerSuffix)"
 		KeyStore="$(_ApkKeyStore)"
 		KeyAlias="$(_ApkKeyAlias)"
 		KeyPass="$(_ApkKeyPass)"
@@ -3093,8 +3167,8 @@ because xbuild doesn't support framework reference assemblies.
 		<ApkAbiFilesUnaligned Include="$(OutDir)$(_AndroidPackage)-Signed-Unaligned.apk" />
 		<ApkAbiFilesUnaligned Condition="'$(AndroidCreatePackagePerAbi)' == 'true'" Include="$(OutDir)$(_AndroidPackage)*-Signed-Unaligned.apk" />
 	</ItemGroup>
-	<Message Text="Unaligned android package '%(ApkAbiFilesUnaligned.FullPath)'"  Condition=" '$(AndroidUseApkSigner)' != 'true' "/>
-	<AndroidZipAlign Condition=" '$(AndroidUseApkSigner)' != 'true' "
+	<Message Text="Unaligned android package '%(ApkAbiFilesUnaligned.FullPath)'"  Condition=" '$(AndroidUseApkSigner)' != 'True' And '$(AndroidPackageFormat)' != 'aab' "/>
+	<AndroidZipAlign Condition=" '$(AndroidUseApkSigner)' != 'True' And '$(AndroidPackageFormat)' != 'aab' "
 		Source="%(ApkAbiFilesUnaligned.FullPath)"
 		DestinationDirectory="$(OutDir)"
 		ToolPath="$(ZipAlignToolPath)"
@@ -3268,11 +3342,13 @@ because xbuild doesn't support framework reference assemblies.
 <PropertyGroup>
   <InstallDependsOnTargets>
     SignAndroidPackage;
-    _Deploy
+    _DeployApk;
+    _DeployAppBundle;
   </InstallDependsOnTargets>
 </PropertyGroup>
 
-<Target Name="_Deploy">
+<Target Name="_DeployApk"
+    Condition=" '$(AndroidPackageFormat)' != 'aab' ">
   <PropertyGroup>
     <_DeployCommand>&quot;$(AdbToolPath)\adb&quot; $(AdbTarget) install -r &quot;$(ApkFileSigned)&quot;</_DeployCommand>
   </PropertyGroup>
@@ -3291,6 +3367,32 @@ because xbuild doesn't support framework reference assemblies.
       Condition=" '$(_DeployExitCode)' != '0' "
       Code="ADB0000"
       Text="@(_AdbError, '%0a')"
+  />
+</Target>
+
+<Target Name="_DeployAppBundle"
+    Condition=" '$(AndroidPackageFormat)' == 'aab' ">
+  <BuildApkSet
+      ToolPath="$(JavaToolPath)"
+      JavaMaximumHeapSize="$(JavaMaximumHeapSize)"
+      JavaOptions="$(JavaOptions)"
+      JarPath="$(AndroidBundleToolJarPath)"
+      AdbToolPath="$(AdbToolPath)"
+      Aapt2ToolPath="$(Aapt2ToolPath)"
+      AppBundle="$(_AppBundleIntermediate)"
+      Output="$(_ApkSetIntermediate)"
+      KeyStore="$(_ApkKeyStore)"
+      KeyAlias="$(_ApkKeyAlias)"
+      KeyPass="$(_ApkKeyPass)"
+      StorePass="$(_ApkStorePass)"
+  />
+  <InstallApkSet
+      ToolPath="$(JavaToolPath)"
+      JavaMaximumHeapSize="$(JavaMaximumHeapSize)"
+      JavaOptions="$(JavaOptions)"
+      JarPath="$(AndroidBundleToolJarPath)"
+      AdbToolPath="$(AdbToolPath)"
+      ApkSet="$(_ApkSetIntermediate)"
   />
 </Target>
 

--- a/tests/RunApkTests.targets
+++ b/tests/RunApkTests.targets
@@ -21,6 +21,7 @@
   <Import Project="..\tests\EmbeddedDSOs\EmbeddedDSO\EmbeddedDSO.projitems" />
   <Import Project="..\tests\locales\Xamarin.Android.Locale-Tests\Xamarin.Android.Locale-Tests.projitems"  Condition=" '$(AotAssemblies)' != 'True' " />
   <Import Project="..\tests\Xamarin.Forms-Performance-Integration\Droid\Xamarin.Forms.Performance.Integration.Droid.projitems" />
+  <Import Project="..\tests\Runtime-AppBundle\Mono.Android-TestsAppBundle.projitems" />
   <Import Project="..\tests\Runtime-MultiDex\Mono.Android-TestsMultiDex.projitems" />
   <Import Project="..\build-tools\scripts\TestApks.targets" />
 
@@ -36,6 +37,7 @@
       AcquireAndroidTarget;
       UndeployTestApks;
       DeployTestApks;
+      DeployTestAabs;
       RecordApkSizes;
       RunTestApks;
       ReleaseAndroidTarget;

--- a/tests/Runtime-AppBundle/Mono.Android-TestsAppBundle.csproj
+++ b/tests/Runtime-AppBundle/Mono.Android-TestsAppBundle.csproj
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{6E2AB0B9-FA5A-4F3A-923B-4B37F82830F1}</ProjectGuid>
+    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Xamarin.Android.RuntimeTests</RootNamespace>
+    <AndroidApplication>True</AndroidApplication>
+    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
+    <AndroidResgenClass>Resource</AndroidResgenClass>
+    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AssemblyName>Mono.Android-TestsAppBundle</AssemblyName>
+    <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
+    <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
+    <AndroidDexTool Condition=" '$(AndroidDexTool)' == '' ">d8</AndroidDexTool>
+    <AndroidPackageFormat>aab</AndroidPackageFormat>
+    <_MonoAndroidTest>..\..\src\Mono.Android\Test\</_MonoAndroidTest>
+  </PropertyGroup>
+  <Import Project="$(_MonoAndroidTest)Mono.Android-Test.Shared.projitems" Label="Shared" Condition="Exists('$(_MonoAndroidTest)Mono.Android-Test.Shared.projitems')" />
+  <Import Project="..\..\Configuration.props" />
+  <PropertyGroup>
+    <TargetFrameworkVersion>$(AndroidFrameworkVersion)</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\bin\TestDebug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidLinkMode>None</AndroidLinkMode>
+    <ConsolePause>false</ConsolePause>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\bin\TestRelease</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="Mono.Android" />
+    <Reference Include="Mono.Android.Export" />
+    <Reference Include="Mono.Data.Sqlite" />
+    <Reference Include="Xamarin.Android.NUnitLite" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Resources\AboutResources.txt" />
+    <None Include="Assets\AboutAssets.txt" />
+    <Compile Remove="$(_MonoAndroidTest)Resources\Resource.designer.cs" />
+    <Compile Include="Resources\Resource.designer.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="$(_MonoAndroidTest)Resources\drawable\Icon.png">
+      <Link>Resources\drawable\Icon.png</Link>
+    </AndroidResource>
+    <AndroidResource Include="$(_MonoAndroidTest)Resources\drawable\AndroidPressed.png">
+      <Link>Resources\drawable\AndroidPressed.png</Link>
+    </AndroidResource>
+    <AndroidResource Include="$(_MonoAndroidTest)Resources\drawable\android_focused.png">
+      <Link>Resources\drawable\android_focused.png</Link>
+    </AndroidResource>
+    <AndroidResource Include="$(_MonoAndroidTest)Resources\drawable\android_normal.png">
+      <Link>Resources\drawable\android_normal.png</Link>
+    </AndroidResource>
+    <AndroidResource Include="$(_MonoAndroidTest)Resources\drawable\android_button.xml">
+      <Link>Resources\drawable\android_button.xml</Link>
+    </AndroidResource>
+    <AndroidResource Include="$(_MonoAndroidTest)Resources\layout\uppercase_custom.axml">
+      <Link>Resources\layout\uppercase_custom.axml</Link>
+    </AndroidResource>
+    <AndroidResource Include="$(_MonoAndroidTest)Resources\layout\lowercase_custom.axml">
+      <Link>Resources\layout\lowercase_custom.axml</Link>
+    </AndroidResource>
+    <AndroidResource Include="$(_MonoAndroidTest)Resources\xml\XmlReaderResourceParser.xml">
+      <Link>Resources\xml\XmlReaderResourceParser.xml</Link>
+    </AndroidResource>
+    <AndroidResource Include="$(_MonoAndroidTest)Resources\layout\FragmentFixup.axml">
+      <Link>Resources\layout\FragmentFixup.axml</Link>
+    </AndroidResource>
+    <AndroidBoundLayout Include="$(_MonoAndroidTest)Resources\layout\Main.axml">
+      <Link>Resources\layout\Main.axml</Link>
+    </AndroidBoundLayout>
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidAsset Include="$(_MonoAndroidTest)Assets\asset1.txt">
+      <Link>Assets\asset1.txt</Link>
+    </AndroidAsset>
+    <AndroidAsset Include="$(_MonoAndroidTest)Assets\subfolder\asset2.txt">
+      <Link>Assets\subfolder\asset2.txt</Link>
+    </AndroidAsset>
+    <AndroidAsset Include="$(_MonoAndroidTest)Assets\subfolder\accept_request.png">
+      <Link>Assets\subfolder\accept_request.png</Link>
+    </AndroidAsset>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+  <Import Project="Mono.Android-TestsAppBundle.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\TestRunner.Core\TestRunner.Core.csproj">
+      <Project>{3cc4e384-4985-4d93-a34c-73f69a379fa7}</Project>
+      <Name>TestRunner.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\TestRunner.NUnit\TestRunner.NUnit.csproj">
+      <Project>{CB2335CB-0050-4020-8A05-E9614EDAA05E}</Project>
+      <Name>TestRunner.NUnit</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj" Condition=" '$(XAIntegratedTests)' == 'True' ">
+      <Name>Xamarin.Android.Build.Tasks</Name>
+      <Project>{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}</Project>
+      <Private>False</Private>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Xamarin.Android.NUnitLite\Xamarin.Android.NUnitLite.csproj" Condition=" '$(XAIntegratedTests)' == 'True' ">
+      <Name>Xamarin.Android.NUnitLite</Name>
+      <Project>{4D603AA3-3BFD-43C8-8050-0CD6C2601126}</Project>
+      <Private>False</Private>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="$(_MonoAndroidTest)Mono.Android-Test.Library\Mono.Android-Test.Library.csproj">
+      <Project>{8CB5FF58-FF95-43B9-9064-9ACE9525866F}</Project>
+      <Name>Mono.Android-Test.Library</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Properties\AndroidManifest.xml" />
+  </ItemGroup>	
+</Project>

--- a/tests/Runtime-AppBundle/Mono.Android-TestsAppBundle.projitems
+++ b/tests/Runtime-AppBundle/Mono.Android-TestsAppBundle.projitems
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_AppBundlePackageName>Mono.Android_TestsAppBundle</_AppBundlePackageName>
+  </PropertyGroup>
+  <ItemGroup>
+    <TestAab Include="$(OutputPath)$(_AppBundlePackageName)-Signed.aab">
+      <Package>$(_AppBundlePackageName)</Package>
+      <InstrumentationType>xamarin.android.runtimetests.TestInstrumentation</InstrumentationType>
+      <ResultsPath>$(MSBuildThisFileDirectory)..\..\TestResult-$(_AppBundlePackageName).xml</ResultsPath>
+      <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)..\..\build-tools\scripts\TimingDefinitions.txt</TimingDefinitionsFilename>
+      <TimingResultsFilename>$(MSBuildThisFileDirectory)..\..\TestResult-$(_AppBundlePackageName)-times.csv</TimingResultsFilename>
+    </TestAab>
+  </ItemGroup>
+
+  <ItemGroup>
+    <TestApkInstrumentation Include="xamarin.android.runtimetests.TestInstrumentation">
+      <Package>$(_AppBundlePackageName)</Package>
+      <ResultsPath>$(OutputPath)TestResult-$(_AppBundlePackageName).xml</ResultsPath>
+    </TestApkInstrumentation>
+
+    <TestApkPermission Include="READ_EXTERNAL_STORAGE">
+      <Package>$(_AppBundlePackageName)</Package>
+    </TestApkPermission>
+
+    <TestApkPermission Include="WRITE_EXTERNAL_STORAGE">
+      <Package>$(_AppBundlePackageName)</Package>
+    </TestApkPermission>
+  </ItemGroup>
+</Project>

--- a/tests/Runtime-AppBundle/Mono.Android-TestsAppBundle.targets
+++ b/tests/Runtime-AppBundle/Mono.Android-TestsAppBundle.targets
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\..\src\Mono.Android\Test\libs\arm64-v8a\libreuse-threads.so" />
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\..\src\Mono.Android\Test\libs\armeabi-v7a\libreuse-threads.so" />
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\..\src\Mono.Android\Test\libs\x86\libreuse-threads.so" />
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\..\src\Mono.Android\Test\libs\x86_64\libreuse-threads.so" />
+  </ItemGroup>
+  <Import Project="Mono.Android-TestsAppBundle.projitems" />
+  <Import Project="..\..\build-tools\scripts\TestApks.targets" />
+  <Target Name="BuildNativeLibs"
+      BeforeTargets="Build"
+      DependsOnTargets="AndroidPrepareForBuild"
+      Inputs="$(MSBuildThisFileDirectory)..\..\src\Mono.Android\Test\jni\reuse-threads.c;$(MSBuildThisFileDirectory)..\..\src\Mono.Android\Test\jni\Android.mk"
+      Outputs="@(AndroidNativeLibrary)">
+    <Error Text="Could not locate Android NDK." Condition="!Exists ('$(NdkBuildPath)')" />
+    <Exec Command="&quot;$(NdkBuildPath)&quot;" />
+  </Target>
+</Project>

--- a/tests/Runtime-AppBundle/Properties/AndroidManifest.xml
+++ b/tests/Runtime-AppBundle/Properties/AndroidManifest.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Mono.Android_TestsAppBundle">
+	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="28" />
+	<application android:label="Xamarin.Android.RuntimeTestsAppBundle" android:name="android.apptests.App" android:usesCleartextTraffic="true">
+		<activity android:name="android.apptests.RenamedActivity" android:configChanges="keyboardHidden" />
+	</application>
+	<uses-permission android:name="android.permission.INTERNET" />
+	<uses-permission android:name="android.permission.SET_TIME_ZONE" />
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+</manifest>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/2727

This is a prototype that gets us this far:

* We generate a `.aab` file
* We can generate a `.apks` file specific for an attached device
* We can *install* the `.apks` file
* The app starts successfully!

This workflow is achieved by:

* The `<Aapt2Link/>` MSBuild task needs to pass `--proto-format`.
* The `<AppBundleBaseZip/>` and `<BundleToolBuildBundle/>` MSBuild
  tasks run instead of `<BuildApk/>`.
* The `<BundleToolBuildApkSet/>` and `<BundleToolInstallApkSet/>`
  tasks run instead of `adb install`. These are somewhat odd, but they
  use the attached device to decide which format APK set is needed.
  Otherwise the APK set was 200MB!

Some notes about Android App Bundles:

* App bundles use `android:extractNativeLibs="false"`, unless the
  target device's API level is too low.
* `$(AndroidUseAapt2)` is required.
* `$(EmbedAssembliesIntoApk)` is required.
* `$(_EmbeddedDSOsEnabled)` is required, regardless of
  `android:extractNativeLibs` value in `AndroidManifest.xml`.
* `$(AndroidUseApkSigner)` is turned off.
* `$(AndroidUseSharedRuntime)` is turned off.

## Java.Interop ##

Some changes are needed in `MonoRuntimeProvider.Bundled.java` in
java.interop before we can merge this.

We need the "split apks" to be in the list of APKs by calling
`ApplicationInfo.splitPublicSourceDirs`:

https://developer.android.com/reference/android/content/pm/ApplicationInfo.html#splitPublicSourceDirs