### PR TITLE
[build] evaluate GetPathToStandardLibraries only when TFV is missing

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -14,7 +14,7 @@
   <PropertyGroup>
     <ProductVersion>9.2.99</ProductVersion>
     <!-- TFV for all projects, try v4.7.2 but fallback if needed -->
-    <_StandardLibraryPath>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries('.NETFramework', 'v4.7.2', ''))</_StandardLibraryPath>
+    <_StandardLibraryPath Condition=" '$(TargetFrameworkVersion)' == '' ">$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries('.NETFramework', 'v4.7.2', ''))</_StandardLibraryPath>
     <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' And '$(_StandardLibraryPath)' != '' ">v4.7.2</TargetFrameworkVersion>
     <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v4.7.1</TargetFrameworkVersion>
     <!-- Used by the `build-tools/create-vsix` build so that `Mono.Android.Export.dll`/etc. are only included *once* -->


### PR DESCRIPTION
Downstream in monodroid, we are getting a build error such as:

    OpenTK-0.9.JCW.csproj: error : /Users/builder/jenkins/workspace/monodroid-pr/monodroid/src/OpenGLES/OpenTK-0.9.JCW.csproj:
        /Users/builder/jenkins/workspace/monodroid-pr/monodroid/external/xamarin-android/Configuration.props: Project file could not be imported, it was being imported by /Users/builder/jenkins/workspace/monodroid-pr/monodroid/src/OpenGLES/OpenTK-0.9.JCW.csproj: Microsoft.Build.Utilities.ToolLocationHelper
    OpenTK-0.9.JCW.csproj: Microsoft.Build.BuildEngine.InvalidProjectFileException: /Users/builder/jenkins/workspace/monodroid-pr/monodroid/src/OpenGLES/OpenTK-0.9.JCW.csproj: /Users/builder/jenkins/workspace/monodroid-pr/monodroid/external/xamarin-android/Configuration.props: Project file could not be imported, it was being imported by /Users/builder/jenkins/workspace/monodroid-pr/monodroid/src/OpenGLES/OpenTK-0.9.JCW.csproj: Microsoft.Build.Utilities.ToolLocationHelper ---> Microsoft.Build.BuildEngine.InvalidProjectFileException: /Users/builder/jenkins/workspace/monodroid-pr/monodroid/external/xamarin-android/Configuration.props: Project file could not be imported, it was being imported by /Users/builder/jenkins/workspace/monodroid-pr/monodroid/src/OpenGLES/OpenTK-0.9.JCW.csproj: Microsoft.Build.Utilities.ToolLocationHelper ---> System.NotImplementedException: Microsoft.Build.Utilities.ToolLocationHelper
        at Microsoft.Build.BuildEngine.Expression.GetTypeForStaticMethod (System.String typeName) [0x00522] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.Expression.ParsePropertyFunction (System.String text, System.Int32& pos) [0x0003c] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.Expression.ExtractProperties (System.String text) [0x0009c] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.Expression.Parse (System.String expression, Microsoft.Build.BuildEngine.ParseOptions options) [0x000e9] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.Expression.ParseAs[T] (System.String expression, Microsoft.Build.BuildEngine.ParseOptions options, Microsoft.Build.BuildEngine.Project project, Microsoft.Build.BuildEngine.ExpressionOptions exprOptions) [0x00005] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.BuildProperty.Evaluate () [0x00019] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.BuildPropertyGroup.Evaluate () [0x0003a] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.GroupingCollection.EvaluateBuildPropertyGroup (Microsoft.Build.BuildEngine.BuildPropertyGroup bpg) [0x00024] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.GroupingCollection.Evaluate (Microsoft.Build.BuildEngine.EvaluationType type) [0x00033] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.Project.AddImport (System.Xml.XmlElement xmlElement, Microsoft.Build.BuildEngine.ImportedProject importingProject, System.Boolean evaluate_properties) [0x0001e] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.Project.ProcessElements (System.Xml.XmlElement rootElement, Microsoft.Build.BuildEngine.ImportedProject ip) [0x00213] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.Import.Evaluate (System.Boolean ignoreMissingImports) [0x0008d] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.Project.AddSingleImport (System.Xml.XmlElement xmlElement, System.String projectPath, Microsoft.Build.BuildEngine.ImportedProject importingProject, System.String from_source_msg) [0x00142] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.Project+<>c__DisplayClass110_0.<AddImport>b__0 (System.String importPath, System.String from_source_msg) [0x00000] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.Import.ForEachExtensionPathTillFound (System.Xml.XmlElement xmlElement, Microsoft.Build.BuildEngine.Project project, Microsoft.Build.BuildEngine.ImportedProject importingProject, System.Func`3[T1,T2,TResult] func) [0x001d7] in <64f40797b3d54493a3cca81a221ded16>:0
        --- End of inner exception stack trace ---
        at Microsoft.Build.BuildEngine.Import.ForEachExtensionPathTillFound (System.Xml.XmlElement xmlElement, Microsoft.Build.BuildEngine.Project project, Microsoft.Build.BuildEngine.ImportedProject importingProject, System.Func`3[T1,T2,TResult] func) [0x00205] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.Project.AddImport (System.Xml.XmlElement xmlElement, Microsoft.Build.BuildEngine.ImportedProject importingProject, System.Boolean evaluate_properties) [0x0006e] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.Project.ProcessElements (System.Xml.XmlElement rootElement, Microsoft.Build.BuildEngine.ImportedProject ip) [0x00213] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.Project.ProcessXml () [0x000b6] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.Project.DoLoad (System.IO.TextReader textReader) [0x000fe] in <64f40797b3d54493a3cca81a221ded16>:0
        --- End of inner exception stack trace ---
        at Microsoft.Build.BuildEngine.Project.DoLoad (System.IO.TextReader textReader) [0x0012f] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.Project.Load (System.String projectFileName, Microsoft.Build.BuildEngine.ProjectLoadSettings projectLoadSettings) [0x00123] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.Project.Load (System.String projectFileName) [0x00000] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.Engine.BuildProjectFileInternal (System.String projectFile, System.String[] targetNames, Microsoft.Build.BuildEngine.BuildPropertyGroup globalProperties, System.Collections.IDictionary targetOutputs, Microsoft.Build.BuildEngine.BuildSettings buildFlags, System.String toolsVersion) [0x0009f] in <64f40797b3d54493a3cca81a221ded16>:0
        at Microsoft.Build.BuildEngine.Engine.BuildProjectFile (System.String projectFile, System.String[] targetNames, Microsoft.Build.BuildEngine.BuildPropertyGroup globalProperties, System.Collections.IDictionary targetOutputs, Microsoft.Build.BuildEngine.BuildSettings buildFlags, System.String toolsVersion) [0x00008] in <64f40797b3d54493a3cca81a221ded16>:0

Since it says:

    Configuration.props: Project file could not be imported

I think it is crashing at:

    <_StandardLibraryPath>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries('.NETFramework', 'v4.7.2', ''))</_StandardLibraryPath>

This line should be conditional if `$(TargetFrameworkVersion)` is
blank. Hopefully this will avoid the call to
`Microsoft.Build.BuildEngine.Expression.GetTypeForStaticMethod`, which
*should* prevent this crash.