### PR TITLE
[Tests] Upgrade all the tests to the latest stable NUnit.

### DIFF
--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -9,7 +9,7 @@
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.SetEnvironmentVariable" />
   <PropertyGroup>
     <_Runtime Condition=" '$(HostOS)' != 'Windows' ">$(ManagedRuntime)</_Runtime>
-    <_NUnit>$(_Runtime) packages\NUnit.ConsoleRunner.3.7.0\tools\nunit3-console.exe</_NUnit>
+    <_NUnit>$(_Runtime) packages\NUnit.ConsoleRunner.3.9.0\tools\nunit3-console.exe</_NUnit>
     <_Test Condition=" '$(TEST)' != '' ">--test=&quot;$(TEST)&quot;</_Test>
     <_XABuild>$(_TopDir)\bin\$(Configuration)\bin\xabuild</_XABuild>
     <_XABinLogPrefix>/v:normal /binaryLogger:"$(MSBuildThisFileDirectory)\..\..\bin\Test$(Configuration)\msbuild</_XABinLogPrefix>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3170,7 +3170,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		public void BuildAMassiveApp()
 		{
 			var testPath = Path.Combine("temp", "BuildAMassiveApp");
-			TestContext.CurrentContext.Test.Properties ["Output"] = new string [] { Path.Combine (Root, testPath) };
+			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = Path.Combine (Root, testPath);
 			var sb = new SolutionBuilder("BuildAMassiveApp.sln") {
 				SolutionPath = Path.Combine(Root, testPath),
 				Verbosity = LoggerVerbosity.Diagnostic,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MakeBundleNativeCodeExternalTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MakeBundleNativeCodeExternalTests.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Android.Build.Tests {
 				messages: messages = new List<BuildMessageEventArgs> ());
 
 			path = Path.Combine (Root, "temp", TestName);
-			TestContext.CurrentContext.Test.Properties ["Output"] = new string [] { path };
+			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = path;
 		}
 
 		[TestCase (null)]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -15,7 +16,7 @@ namespace Xamarin.Android.Build.Tests
 {
 	public class BaseTest
 	{
-		public static Dictionary<string, string> TestOutputDirectories = new Dictionary<string, string> ();
+		public static ConcurrentDictionary<string, string> TestOutputDirectories = new ConcurrentDictionary<string, string> ();
 
 		[SetUpFixture]
 		public class SetUp

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -405,7 +405,9 @@ namespace Xamarin.Android.Build.Tests
 			TestContext.Out.WriteLine ($"[TESTLOG] Test {TestName} Complete");
 			TestContext.Out.WriteLine ($"[TESTLOG] Test {TestName} Outcome={TestContext.CurrentContext.Result.Outcome.Status}");
 			TestContext.Out.Flush ();
-			var outputDir = TestOutputDirectories [TestContext.CurrentContext.Test.ID];
+			string outputDir = null;
+			if (!TestOutputDirectories.TryGetValue (TestContext.CurrentContext.Test.ID, out outputDir))
+				return;
 			if (System.Diagnostics.Debugger.IsAttached || string.IsNullOrEmpty (outputDir))
 					return;
 			// find the "root" directory just below "temp" and clean from there because

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -15,6 +15,8 @@ namespace Xamarin.Android.Build.Tests
 {
 	public class BaseTest
 	{
+		public static Dictionary<string, string> TestOutputDirectories = new Dictionary<string, string> ();
+
 		[SetUpFixture]
 		public class SetUp
 		{
@@ -321,13 +323,13 @@ namespace Xamarin.Android.Build.Tests
 
 		protected ProjectBuilder CreateApkBuilder (string directory, bool cleanupAfterSuccessfulBuild = false, bool cleanupOnDispose = false)
 		{
-			TestContext.CurrentContext.Test.Properties ["Output"] = new string [] { Path.Combine (Root, directory) };
+			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = Path.Combine (Root, directory);
 			return BuildHelper.CreateApkBuilder (directory, cleanupAfterSuccessfulBuild, cleanupOnDispose);
 		}
 
 		protected ProjectBuilder CreateDllBuilder (string directory, bool cleanupAfterSuccessfulBuild = false, bool cleanupOnDispose = false)
 		{
-			TestContext.CurrentContext.Test.Properties ["Output"] = new string [] { Path.Combine (Root, directory) };
+			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = Path.Combine (Root, directory);
 			return BuildHelper.CreateDllBuilder (directory, cleanupAfterSuccessfulBuild, cleanupOnDispose);
 		}
 
@@ -402,14 +404,12 @@ namespace Xamarin.Android.Build.Tests
 			TestContext.Out.WriteLine ($"[TESTLOG] Test {TestName} Complete");
 			TestContext.Out.WriteLine ($"[TESTLOG] Test {TestName} Outcome={TestContext.CurrentContext.Result.Outcome.Status}");
 			TestContext.Out.Flush ();
-			if (System.Diagnostics.Debugger.IsAttached || TestContext.CurrentContext.Test.Properties ["Output"] == null)
+			var outputDir = TestOutputDirectories [TestContext.CurrentContext.Test.ID];
+			if (System.Diagnostics.Debugger.IsAttached || string.IsNullOrEmpty (outputDir))
 					return;
 			// find the "root" directory just below "temp" and clean from there because
 			// some tests create multiple subdirectories
-			var items = (IList)TestContext.CurrentContext.Test.Properties ["Output"];
-			if (items.Count == 0)
-				return;
-			var output = Path.GetFullPath (items[0].ToString ());
+			var output = Path.GetFullPath (outputDir);
 			while (!Directory.GetParent (output).Name.EndsWith ("temp", StringComparison.OrdinalIgnoreCase)) {
 					output = Directory.GetParent (output).FullName;
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -38,7 +38,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="nunit.framework">
-      <HintPath>..\..\..\..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
+      <HintPath>..\..\..\..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <!-- Because Xamarin.Android.Build.Tasks.csproj doesn't build in VsForMac :(
     <Reference Include="Xamarin.Android.Build.Tasks" Condition="Exists('$(OutputPath)..\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Build.Tasks.dll')">

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/packages.config
@@ -3,9 +3,9 @@
   <package id="Microsoft.Build.Framework" version="14.3.0" targetFramework="net472" />
   <package id="Microsoft.Build.Tasks.Core" version="14.3.0" targetFramework="net472" />
   <package id="Microsoft.Build.Utilities.Core" version="14.3.0" targetFramework="net472" />
-  <package id="NUnit" version="3.7.1" targetFramework="net451" />
-  <package id="NUnit.Console" version="3.7.0" targetFramework="net451" />
-  <package id="NUnit.ConsoleRunner" version="3.7.0" targetFramework="net451" />
+  <package id="NUnit" version="3.11.0" targetFramework="net462" />
+  <package id="NUnit.Console" version="3.9.0" targetFramework="net472" />
+  <package id="NUnit.ConsoleRunner" version="3.9.0" targetFramework="net472" />
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net451" />
   <package id="NUnit.Extension.NUnitV2Driver" version="3.7.0" targetFramework="net451" />
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net451" />

--- a/tests/CodeBehind/UnitTests/CodeBehindUnitTests.csproj
+++ b/tests/CodeBehind/UnitTests/CodeBehindUnitTests.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="nunit.framework">
-      <HintPath>..\..\..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/CodeBehind/UnitTests/packages.config
+++ b/tests/CodeBehind/UnitTests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.7.1" targetFramework="net451" />
+  <package id="NUnit" version="3.11.0" targetFramework="net462" />
 </packages>

--- a/tests/CodeBehind/UnitTests/run.sh
+++ b/tests/CodeBehind/UnitTests/run.sh
@@ -4,4 +4,4 @@ export USE_MSBUILD=1
 export MSBUILD=msbuild
 msbuild CodeBehindUnitTests.csproj
 cd ../../../
-exec mono --debug packages/NUnit.ConsoleRunner.3.7.0/tools/nunit3-console.exe bin/TestDebug/CodeBehind/CodeBehindUnitTests.dll
+exec mono --debug packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe bin/TestDebug/CodeBehind/CodeBehindUnitTests.dll

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/BuildTests.cs
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/BuildTests.cs
@@ -69,7 +69,7 @@ namespace Xamarin.Android.MakeBundle.UnitTests
 			TestOutputDir = Path.Combine (XABuildPaths.TestOutputDirectory, "CodeGen-MkBundle");
 		}
 
-		[SetUp]
+		[OneTimeSetUp]
 		public void BuildProject ()
 		{
 			if (File.Exists (Config.LlvmReadobj)) {

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/BuildTests.cs
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/BuildTests.cs
@@ -69,7 +69,7 @@ namespace Xamarin.Android.MakeBundle.UnitTests
 			TestOutputDir = Path.Combine (XABuildPaths.TestOutputDirectory, "CodeGen-MkBundle");
 		}
 
-		[TestFixtureSetUp]
+		[SetUp]
 		public void BuildProject ()
 		{
 			if (File.Exists (Config.LlvmReadobj)) {

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Xamarin.Android.MakeBundle-UnitTests.csproj
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Xamarin.Android.MakeBundle-UnitTests.csproj
@@ -32,7 +32,7 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="nunit.framework">
-      <HintPath>..\..\..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/packages.config
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.7.1" targetFramework="net451" />
+  <package id="NUnit" version="3.11.0" targetFramework="net462" />
 </packages>

--- a/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/BuildTests.cs
+++ b/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/BuildTests.cs
@@ -66,7 +66,7 @@ namespace EmbeddedDSOUnitTests
 			};
 		}
 
-		[TestFixtureSetUp]
+		[SetUp]
 		public void BuildProject ()
 		{
 			testProjectPath = PrepareProject (ProjectName);

--- a/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/BuildTests.cs
+++ b/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/BuildTests.cs
@@ -66,10 +66,10 @@ namespace EmbeddedDSOUnitTests
 			};
 		}
 
-		[SetUp]
+		[OneTimeSetUp]
 		public void BuildProject ()
 		{
-			testProjectPath = PrepareProject (TestContext.CurrentContext.Test.Name);
+			testProjectPath = PrepareProject (ProjectName);
 			string projectPath = Path.Combine (testProjectPath, $"{ProjectName}.csproj");
 			LocalBuilder builder = GetBuilder ("EmbeddedDSO");
 			bool success = builder.Build (projectPath, "SignAndroidPackage", new [] { "UnitTestsMode=true" });

--- a/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/BuildTests.cs
+++ b/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/BuildTests.cs
@@ -69,7 +69,7 @@ namespace EmbeddedDSOUnitTests
 		[SetUp]
 		public void BuildProject ()
 		{
-			testProjectPath = PrepareProject (ProjectName);
+			testProjectPath = PrepareProject (TestContext.CurrentContext.Test.Name);
 			string projectPath = Path.Combine (testProjectPath, $"{ProjectName}.csproj");
 			LocalBuilder builder = GetBuilder ("EmbeddedDSO");
 			bool success = builder.Build (projectPath, "SignAndroidPackage", new [] { "UnitTestsMode=true" });

--- a/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/EmbeddedDSO-UnitTests.csproj
+++ b/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/EmbeddedDSO-UnitTests.csproj
@@ -32,7 +32,7 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="nunit.framework">
-      <HintPath>..\..\..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/packages.config
+++ b/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.7.1" targetFramework="net451" />
+  <package id="NUnit" version="3.11.0" targetFramework="net462" />
 </packages>

--- a/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/run.sh
+++ b/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/run.sh
@@ -4,4 +4,4 @@ export USE_MSBUILD=1
 export MSBUILD=msbuild
 msbuild EmbeddedDSO-UnitTests.csproj
 cd ../../../
-exec mono --debug packages/NUnit.ConsoleRunner.3.7.0/tools/nunit3-console.exe bin/TestDebug/EmbeddedDSO/EmbeddedDSOUnitTests.dll
+exec mono --debug packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe bin/TestDebug/EmbeddedDSO/EmbeddedDSOUnitTests.dll


### PR DESCRIPTION
A couple of things needed to change during this upgrade. 

The code `Properties` Dictionary is now readonly in `3.11.0` so the following code no longer works.

```
TestContext.CurrentContext.Test.Properties ["Output"]
```

So we have to remove it in favour of maintaining a local dictionary of test directories which we can use the clean up once a test passes.
