### PR TITLE
[create-pkg] Install `ThirdPartyNotices.txt` on macOS

### DIFF
--- a/build-tools/create-pkg/create-pkg.targets
+++ b/build-tools/create-pkg/create-pkg.targets
@@ -46,7 +46,7 @@
         DestinationFolder="$(XAFrameworkDir)\lib\monodoc"
     />
     <Copy
-        SourceFiles="@(VersionFiles);$(PkgLicenseSrcEn)"
+        SourceFiles="$(PkgLicenseSrcEn);@(ThirdPartyNotice);@(VersionFiles)"
         DestinationFolder="$(XAFrameworkDir)"
     />
   </Target>

--- a/build-tools/create-vsix/create-vsix.targets
+++ b/build-tools/create-vsix/create-vsix.targets
@@ -22,7 +22,7 @@
     </ReferenceAssemblies>
     <ThirdPartyNotice>
       <IncludeInVSIX>True</IncludeInVSIX>
-      <VSIXSubPath/>
+      <VSIXSubPath>/</VSIXSubPath>
       <InstallRoot/>
     </ThirdPartyNotice>
   </ItemDefinitionGroup>
@@ -45,9 +45,6 @@
       <MSBuild Include="@(VersionFiles)" >
         <VSIXSubPath>Xamarin/Android/</VSIXSubPath>
       </MSBuild>
-      <ThirdPartyNotice Include="$(RootBuildDir)\lib\xamarin.android\ThirdPartyNotices.txt">
-        <VSIXSubPath>/</VSIXSubPath>
-      </ThirdPartyNotice>
     </ItemGroup>
     <ItemGroup>
       <Content Include="@(MSBuild)" />

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -230,6 +230,9 @@
     <LegacyTargetsFiles Include="$(RootBuildDir)\lib\xamarin.android\xbuild\Novell\Novell.MonoDroid.CSharp.targets" />
   </ItemGroup>
   <ItemGroup>
+    <ThirdPartyNotice Include="$(RootBuildDir)\lib\xamarin.android\ThirdPartyNotices.txt" />
+  </ItemGroup>
+  <ItemGroup>
     <VersionFiles Include="$(RootBuildDir)\Version" />
     <VersionFiles Include="$(RootBuildDir)\Version.commit" />
     <VersionFiles Include="$(RootBuildDir)\Version.rev" />


### PR DESCRIPTION
The `ThirdPartyNotices.txt` file is a comprehensive listing of all 3rd
party code which is included in a Xamarin.Android distribution; see
also commit 2bd13c4a.

Commit 2bd13c4a also added `ThirdPartyNotices.txt` to the `.vsix`
installer, allowing it to be read *without* needing to install the
`.vsix` file on Windows; simply `unzip`ing the `.vsix` would allow it
to be viewed.

Unfortunately, we forgot to add `ThirdPartyNotices.txt` to the macOS
installer, and thus e83ba0dd likewise doesn't install it.

Update `build-tools/create-pkg` so that `ThirdPartyNotices.txt` is
installed on macOS into the path:

	/Library/Frameworks/Xamarin.Android.framework/Versions/Current/ThirdPartyNotices.txt