### PR TITLE
[sqlite-xamarin] Update ThirdPartyNotice information

### DIFF
--- a/external/sqlite.tpnitems
+++ b/external/sqlite.tpnitems
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition=" '$(TpnIncludeExternalDependencies)' == 'True' ">
-    <ThirdPartyNotice Include="xamarin/sqlite">
+    <ThirdPartyNotice Include="sqlite/sqlite">
       <LicenseFile>$(MSBuildThisFileDirectory)\sqlite\dist\NOTICE</LicenseFile>
+      <SourceUrl>https://github.com/xamarin/sqlite/tree/master/dist/</SourceUrl>
+    </ThirdPartyNotice>
+    <ThirdPartyNotice Include="xamarin/sqlite">
+      <LicenseFile>$(MSBuildThisFileDirectory)\..\build-tools\license-data\Apache-2.0.txt</LicenseFile>
       <SourceUrl>https://github.com/xamarin/sqlite/</SourceUrl>
     </ThirdPartyNotice>
   </ItemGroup>

--- a/external/sqlite.tpnitems
+++ b/external/sqlite.tpnitems
@@ -6,7 +6,7 @@
       <SourceUrl>https://github.com/xamarin/sqlite/tree/master/dist/</SourceUrl>
     </ThirdPartyNotice>
     <ThirdPartyNotice Include="xamarin/sqlite">
-      <LicenseFile>$(MSBuildThisFileDirectory)\..\build-tools\license-data\Apache-2.0.txt</LicenseFile>
+      <LicenseFile>$(MSBuildThisFileDirectory)..\build-tools\license-data\Apache-2.0.txt</LicenseFile>
       <SourceUrl>https://github.com/xamarin/sqlite/</SourceUrl>
     </ThirdPartyNotice>
   </ItemGroup>


### PR DESCRIPTION
The `xamarin/sqlite` repo contains two related-yet-distinct sets of
source code:

 1. The SQLite source code, in which the authors have disclaimed
    copyright, dedicating it to the public domain, and

 2. Google's additions for use on Android, which is licensed under the
    Apache-2.0 license.

We've been omitting (2) in favor of (1), which isn't quite right.

Update `sqlite.tpnitems` so that *both* sources are listed.  This will
cause `sqlite/sqlite` to be listed, along with it's disclaimer of
copyright, alongside `xamarin/sqlite` with the Apache 2.0 license.