### PR TITLE
[Xamarin.Android.Build.Tasks] fix missing $(_AfterCompileDex)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -564,6 +564,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     _ValidateAndroidPackageProperties;
     $(BuildDependsOn);
     _CompileDex;
+    $(_AfterCompileDex);
     $(_PostBuildTargets)
   </BuildDependsOn>
 </PropertyGroup>
@@ -589,6 +590,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <_BeforeIncrementalClean Condition=" '$(AndroidApplication)' == 'True' ">
     _PrepareAssemblies;
     _CompileDex;
+    $(_AfterCompileDex);
     _AddFilesToFileWrites;
   </_BeforeIncrementalClean>
   <_BeforeIncrementalClean Condition=" '$(AndroidApplication)' != 'True' ">


### PR DESCRIPTION
Continuing the effort to remove `BeforeTargets` and `AfterTargets`, I
am now making changes in monodroid.

One such case is an MSBuild target that needs to run *after*
`_CompileDex`, which is using `AfterTargets` right now.

We already have `$(_AfterCompileDex)`, but it is not specified in
xamarin-android everywhere it needs to be. Anywhere that `_CompileDex`
is listed as a `DependsOnTargets`, we need to list
`$(_AfterCompileDex)` as well.

This change should allow me to finish up the changes in monodroid.