### PR TITLE
[Xamarin.Android.Build.Tasks] Obsolete OpenTK 0.9.3

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -56,6 +56,7 @@
 + [XA1006](xa1006.md): Your application is running on a version of Android ({compileSdk}) that is more recent than your targetSdkVersion specifies ({targetSdk}). Set your targetSdkVersion to the highest version of Android available to match your TargetFrameworkVersion ({compileSdk}).
 + [XA1007](xa1007.md): The minSdkVersion ({minSdk}) is greater than targetSdkVersion. Please change the value such that minSdkVersion is less than or equal to targetSdkVersion ({targetSdk}).
 + [XA1008](xa1008.md): The TargetFrameworkVersion ({compileSdk}) should not be lower than targetSdkVersion ({targetSdk})
++ [XA1009](xa1009.md): The {assembly} is Obsolete. Please upgrade to {assembly} {version}
 
 ### XA2xxx Linker
 

--- a/Documentation/guides/messages/xa1009.md
+++ b/Documentation/guides/messages/xa1009.md
@@ -1,0 +1,5 @@
+# Compiler Warning XA1009
+
+The {assembly} is Obsolete. It will probably be removed
+in the next release of Xamarin.Android. To correct this
+issue upgrade to the stated version of the assembly.

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1830,6 +1830,14 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="PackageForAndroid"
 	DependsOnTargets="SetWearAppTargetToPackageForAndroid;Build;_CopyPackage" />
 	
+<Target Name="_CheckForObsoleteAssemblies">
+	<PropertyGroup>
+		<_ObsoleteAssemblies>@(ResolvedFrameworkAssemblies)</_ObsoleteAssemblies>
+	</PropertyGroup>
+	<Warning Code="XA1009" Text="OpenTK 0.9.3 is Obsolete. Please upgrade to OpenTK 1.0"
+			Condition="$(_ObsoleteAssemblies.Contains('OpenTK.dll'))" />
+</Target>
+
 <Target Name="_ResolveAssemblies">
 	<!--- Remove the ImplicitlyExpandDesignTimeFacades assemblies. We have already build the app there are not required for packaging  -->
 	<ItemGroup>
@@ -2131,6 +2139,7 @@ because xbuild doesn't support framework reference assemblies.
 <PropertyGroup>
 	<_PrepareAssembliesDependsOnTargets>
 		_ResolveAssemblies
+		;_CheckForObsoleteAssemblies
 		;_ResolveSatellitePaths
 		;_CreatePackageWorkspace
 		;_CopyIntermediateAssemblies


### PR DESCRIPTION
We want to remove OpenTK 0.9.3 in the next major
release of Xamarin.Android. This commit adds a
warning so that users will have a chance to
update their projects.