### PR TITLE
[Xamarin.Android.Build.Tasks] bring in MonoRuntimeProvider

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Generator/Generator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Generator/Generator.cs
@@ -1,13 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Mono.Cecil;
-using Microsoft.Build.Utilities;
-
-using Java.Interop.Tools.Diagnostics;
+﻿using Java.Interop.Tools.Diagnostics;
 using Java.Interop.Tools.JavaCallableWrappers;
+using Microsoft.Build.Utilities;
+using Mono.Cecil;
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
+using System.Text;
 
 namespace Xamarin.Android.Tasks
 {
@@ -15,6 +14,8 @@ namespace Xamarin.Android.Tasks
 	{
 		public static bool CreateJavaSources (TaskLoggingHelper log, IEnumerable<TypeDefinition> javaTypes, string outputPath, string applicationJavaClass, bool useSharedRuntime, bool generateOnCreateOverrides, bool hasExportReference)
 		{
+			string monoInit = GetMonoInitSource (useSharedRuntime);
+
 			bool ok = true;
 			using (var memoryStream = new MemoryStream ())
 			using (var writer = new StreamWriter (memoryStream)) {
@@ -24,9 +25,9 @@ namespace Xamarin.Android.Tasks
 
 					try {
 						var jti = new JavaCallableWrapperGenerator (t, log.LogWarning) {
-							UseSharedRuntime = useSharedRuntime,
 							GenerateOnCreateOverrides = generateOnCreateOverrides,
 							ApplicationJavaClass = applicationJavaClass,
+							MonoRuntimeInitialization = monoInit,
 						};
 
 						jti.Generate (writer);
@@ -57,6 +58,30 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 			return ok;
+		}
+
+		static string GetMonoInitSource (bool useSharedRuntime)
+		{
+			// Lookup the mono init section from MonoRuntimeProvider:
+			// Mono Runtime Initialization {{{
+			// }}}
+			var builder = new StringBuilder ();
+			var suffix = useSharedRuntime ? "Shared" : "Bundled";
+			var assembly = Assembly.GetExecutingAssembly ();
+			using (var s = assembly.GetManifestResourceStream ($"MonoRuntimeProvider.{suffix}.java"))
+			using (var reader = new StreamReader (s)) {
+				bool copy = false;
+				string line;
+				while ((line = reader.ReadLine ()) != null) {
+					if (string.CompareOrdinal ("\t\t// Mono Runtime Initialization {{{", line) == 0)
+						copy = true;
+					if (copy)
+						builder.AppendLine (line);
+					if (string.CompareOrdinal ("\t\t// }}}", line) == 0)
+						break;
+				}
+			}
+			return builder.ToString ();
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Resources/MonoRuntimeProvider.Bundled.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/MonoRuntimeProvider.Bundled.java
@@ -1,0 +1,57 @@
+package mono;
+
+import android.util.Log;
+
+public class MonoRuntimeProvider
+	extends android.content.ContentProvider
+{
+	public MonoRuntimeProvider ()
+	{
+	}
+
+	@Override
+	public boolean onCreate ()
+	{
+		return true;
+	}
+
+	@Override
+	public void attachInfo (android.content.Context context, android.content.pm.ProviderInfo info)
+	{
+		// Mono Runtime Initialization {{{
+		mono.MonoPackageManager.LoadApplication (context, context.getApplicationInfo (), new String[]{context.getApplicationInfo ().sourceDir});
+		// }}}
+		super.attachInfo (context, info);
+	}
+
+	@Override
+	public android.database.Cursor query (android.net.Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder)
+	{
+		throw new RuntimeException ("This operation is not supported.");
+	}
+
+	@Override
+	public String getType (android.net.Uri uri)
+	{
+		throw new RuntimeException ("This operation is not supported.");
+	}
+
+	@Override
+	public android.net.Uri insert (android.net.Uri uri, android.content.ContentValues initialValues)
+	{
+		throw new RuntimeException ("This operation is not supported.");
+	}
+
+	@Override
+	public int delete (android.net.Uri uri, String where, String[] whereArgs)
+	{
+		throw new RuntimeException ("This operation is not supported.");
+	}
+
+	@Override
+	public int update (android.net.Uri uri, android.content.ContentValues values, String where, String[] whereArgs)
+	{
+		throw new RuntimeException ("This operation is not supported.");
+	}
+}
+

--- a/src/Xamarin.Android.Build.Tasks/Resources/MonoRuntimeProvider.Shared.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/MonoRuntimeProvider.Shared.java
@@ -1,0 +1,83 @@
+package mono;
+
+public class MonoRuntimeProvider
+	extends android.content.ContentProvider
+{
+	public MonoRuntimeProvider ()
+	{
+	}
+
+	@Override
+	public boolean onCreate ()
+	{
+		return true;
+	}
+
+	@Override
+	public void attachInfo (android.content.Context context, android.content.pm.ProviderInfo info)
+	{
+		// Mono Runtime Initialization {{{
+		android.content.pm.ApplicationInfo apiInfo = null;
+
+		String platformPackage	= mono.MonoPackageManager.getApiPackageName ();
+		if (platformPackage != null) {
+			Throwable t = null;
+			try {
+				apiInfo = context.getPackageManager ().getApplicationInfo (platformPackage, 0);
+			} catch (android.content.pm.PackageManager.NameNotFoundException e) {
+				// ignore
+			}
+			if (apiInfo == null) {
+				try {
+					apiInfo = context.getPackageManager ().getApplicationInfo ("Xamarin.Android.Platform", 0);
+				} catch (android.content.pm.PackageManager.NameNotFoundException e) {
+					t = e;
+				}
+			}
+			if (apiInfo == null)
+				throw new RuntimeException ("Unable to find application " + platformPackage + " or Xamarin.Android.Platform!", t);
+		}
+		try {
+			android.content.pm.ApplicationInfo runtimeInfo = context.getPackageManager ().getApplicationInfo ("Mono.Android.DebugRuntime", 0);
+			mono.MonoPackageManager.LoadApplication (context, runtimeInfo,
+					apiInfo != null
+					? new String[]{runtimeInfo.sourceDir, apiInfo.sourceDir, context.getApplicationInfo ().sourceDir}
+					: new String[]{runtimeInfo.sourceDir, context.getApplicationInfo ().sourceDir});
+		} catch (android.content.pm.PackageManager.NameNotFoundException e) {
+			throw new RuntimeException ("Unable to find application Mono.Android.DebugRuntime!", e);
+		}
+		// }}}
+		super.attachInfo (context, info);
+	}
+
+	@Override
+	public android.database.Cursor query (android.net.Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder)
+	{
+		throw new RuntimeException ("This operation is not supported.");
+	}
+
+	@Override
+	public String getType (android.net.Uri uri)
+	{
+		throw new RuntimeException ("This operation is not supported.");
+	}
+
+	@Override
+	public android.net.Uri insert (android.net.Uri uri, android.content.ContentValues initialValues)
+	{
+		throw new RuntimeException ("This operation is not supported.");
+	}
+
+	@Override
+	public int delete (android.net.Uri uri, String where, String[] whereArgs)
+	{
+		throw new RuntimeException ("This operation is not supported.");
+	}
+
+	@Override
+	public int update (android.net.Uri uri, android.content.ContentValues values, String where, String[] whereArgs)
+	{
+		throw new RuntimeException ("This operation is not supported.");
+	}
+}
+

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyResource.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyResource.cs
@@ -19,11 +19,10 @@ namespace Xamarin.Android.Tasks
 		public string OutputPath { get; set; }
 
 		static readonly Assembly ExecutingAssembly = Assembly.GetExecutingAssembly ();
-		static readonly Assembly JcwGenAssembly = typeof (JavaCallableWrapperGenerator).Assembly;
 
 		public override bool Execute ()
 		{
-			using (var from = GetManifestResourceStream (ResourceName)) {
+			using (var from = ExecutingAssembly.GetManifestResourceStream (ResourceName)) {
 				if (from == null) {
 					Log.LogCodedError ("XA0116", $"Unable to find `EmbeddedResource` of name `{ResourceName}`.");
 					return false;
@@ -36,11 +35,6 @@ namespace Xamarin.Android.Tasks
 			}
 
 			return true;
-		}
-
-		Stream GetManifestResourceStream (string name)
-		{
-			return ExecutingAssembly.GetManifestResourceStream (name) ?? JcwGenAssembly.GetManifestResourceStream (name);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -244,7 +244,7 @@ namespace Xamarin.Android.Tasks
 
 			// Create additional runtime provider java sources.
 			string providerTemplateFile = UseSharedRuntime ? "MonoRuntimeProvider.Shared.java" : "MonoRuntimeProvider.Bundled.java";
-			string providerTemplate = GetResource<JavaCallableWrapperGenerator> (providerTemplateFile);
+			string providerTemplate = GetResource (providerTemplateFile);
 			
 			foreach (var provider in additionalProviders) {
 				var contents = providerTemplate.Replace ("MonoRuntimeProvider", provider);
@@ -274,16 +274,16 @@ namespace Xamarin.Android.Tasks
 			SaveResource (notifyTimeZoneChangesFile, notifyTimeZoneChangesFile, real_app_dir, template => template);
 		}
 
-		string GetResource <T> (string resource)
+		string GetResource (string resource)
 		{
-			using (var stream = typeof (T).Assembly.GetManifestResourceStream (resource))
+			using (var stream = GetType ().Assembly.GetManifestResourceStream (resource))
 			using (var reader = new StreamReader (stream))
 				return reader.ReadToEnd ();
 		}
 
 		void SaveResource (string resource, string filename, string destDir, Func<string, string> applyTemplate)
 		{
-			string template = GetResource<GenerateJavaStubs> (resource);
+			string template = GetResource (resource);
 			template = applyTemplate (template);
 			MonoAndroidHelper.CopyIfStringChanged (template, Path.Combine (destDir, filename));
 		}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -650,6 +650,12 @@
     <EmbeddedResource Include="Resources\MonoPackageManager.java">
       <LogicalName>MonoPackageManager.java</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="Resources\MonoRuntimeProvider.Bundled.java">
+      <LogicalName>MonoRuntimeProvider.Bundled.java</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\MonoRuntimeProvider.Shared.java">
+      <LogicalName>MonoRuntimeProvider.Shared.java</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="Resources\Seppuku.java">
       <LogicalName>Seppuku.java</LogicalName>
     </EmbeddedResource>


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/pull/422
Context: https://github.com/xamarin/xamarin-android/pull/2841

Bump to xamarin/java.interop/master@7c7eae3a

Changes: https://github.com/xamarin/java.interop/compare/f84c236e...7c7eae3a

In an effort to consolidate our Java source code, there are a couple
files that should be moved into xamarin-android:

* `MonoRuntimeProvider.Bundled.java`
* `MonoRuntimeProvider.Shared.java`

This gives us more flexibility in Xamarin.Android to change these
files, in cases such as:

* Is the shared runtime used?
* Is it a specific API level?
* Could we call into some pre-compiled code instead?

I moved the files, and left them as-is.

The only other changes are due to
`Java.Interop.Tools.JavaCallableWrappers.csproj` no longer containing
resources:

* The `<CopyResource/>` MSBuild task can just look in the executing
  assembly.
* The`<GenerateJavaStubs/>` MSBuild task can just look in the
  executing assembly.