### PR TITLE
[tests] Rework logcat-*.txt handling

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
@@ -43,7 +43,9 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			catch (Exception e) {
 				Log.LogWarning ($"Unable to process `{SourceFile}`.  Is it empty?  (Did a unit test runner SIGSEGV?)");
 				Log.LogWarningFromException (e);
-				CreateErrorResultsFile (SourceFile, dest, Configuration, e);
+				CreateErrorResultsFile (SourceFile, dest, Configuration, e, m => {
+						Log.LogMessage (MessageImportance.Low, m);
+				});
 			}
 
 			if (DeleteSourceFiles && Path.GetFullPath (SourceFile) != Path.GetFullPath (dest)) {
@@ -103,9 +105,9 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 	partial class RenameTestCases {
 
-		static void CreateErrorResultsFile (string sourceFile, string destFile, string config, Exception e)
+		static void CreateErrorResultsFile (string sourceFile, string destFile, string config, Exception e, Action<string> logDebugMessage)
 		{
-			GetTestCaseInfo (sourceFile, Path.GetDirectoryName (destFile), config, out var testSuiteName, out var testCaseName, out var logcatPath);
+			GetTestCaseInfo (sourceFile, Path.GetDirectoryName (destFile), config, logDebugMessage, out var testSuiteName, out var testCaseName, out var logcatPath);
 			var contents  = new StringBuilder ();
 			if (File.Exists (sourceFile)) {
 				contents.Append (File.ReadAllText (sourceFile));
@@ -151,18 +153,20 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		// Example `DestinationFolder`:
 		//   /Users/builder/jenkins/workspace/xamarin-android-pr-builder-release/xamarin-android/
 		// Example `adb logcat`:
-		//   /Users/builder/jenkins/workspace/xamarin-android-pr-builder-release/xamarin-android/tests/logcat-Release-Mono.Android_Tests.txt
+		//   /Users/builder/jenkins/workspace/xamarin-android-pr-builder-release/xamarin-android/bin/TestRelease/logcat-Release-Mono.Android_Tests.txt
 		//
 		// We need to extract the "base" test name from `SourceFile`, and use that to construct `logcatPath`
-		static void GetTestCaseInfo (string sourceFile, string destinationFolder, string config, out string testSuiteName, out string testCaseName, out string logcatPath)
+		static void GetTestCaseInfo (string sourceFile, string destinationFolder, string config, Action<string> logDebugMessage, out string testSuiteName, out string testCaseName, out string logcatPath)
 		{
 			var name        = Path.GetFileNameWithoutExtension (sourceFile);
 			if (name.StartsWith ("TestResult-"))
 				name    = name.Substring ("TestResult-".Length);
 			testSuiteName   = name;
 			testCaseName    = $"Possible Crash / {config}";
-			logcatPath      = Path.Combine (destinationFolder, "tests", $"logcat-{config}-{name}.txt");
+			logcatPath      = Path.Combine (destinationFolder, "bin", $"Test{config}", $"logcat-{config}-{name}.txt");
+			logDebugMessage ($"Looking for `adb logcat` output in the file: {logcatPath}");
 			if (!File.Exists (logcatPath)) {
+				logDebugMessage ($"Could not find file `{logcatPath}`.  Will not be including `adb logcat` output.");
 				logcatPath      = null;
 			}
 		}
@@ -187,7 +191,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			string destFile       = args [0];
 			string sourceFile     = args.Length > 1 ? args [1] : "source.xml";
 			string config         = args.Length > 2 ? args [2] : "Debug";
-			CreateErrorResultsFile (sourceFile, destFile, config, new Exception ("Wee!!!"));
+			CreateErrorResultsFile (sourceFile, destFile, config, new Exception ("Wee!!!"), Console.WriteLine);
 		}
 	}
 #endif  // APP

--- a/build-tools/scripts/Packaging.mk
+++ b/build-tools/scripts/Packaging.mk
@@ -73,8 +73,9 @@ package-deb: $(ZIP_OUTPUT)
 _TEST_RESULTS_BUNDLE_INCLUDE = \
 	$(wildcard TestResult-*.xml) \
 	$(wildcard bin/Test$(CONFIGURATION)/compatibility) \
-	$(wildcard bin/Test$(CONFIGURATION)/temp) \
+	$(wildcard bin/Test$(CONFIGURATION)/logcat*) \
 	$(wildcard bin/Test$(CONFIGURATION)/msbuild*.binlog*) \
+	$(wildcard bin/Test$(CONFIGURATION)/temp) \
 	$(wildcard bin/Test$(CONFIGURATION)/TestOutput-*.txt) \
 	$(wildcard bin/Test$(CONFIGURATION)/Timing_*) \
 	$(wildcard *.csv)
@@ -95,8 +96,7 @@ _BUILD_STATUS_BUNDLE_INCLUDE = \
 	$(shell find . -name 'CMakeCache.txt') \
 	$(shell find . -name 'config.h') \
 	$(shell find . -name '.ninja_log') \
-	$(shell find . -name 'android-*.config.cache') \
-	$(wildcard tests/logcat-$(CONFIGURATION)-*.txt)
+	$(shell find . -name 'android-*.config.cache')
 
 _BUILD_STATUS_BASENAME   = xa-build-status-v$(PRODUCT_VERSION).$(-num-commits-since-version-change)_$(OS_NAME)-$(OS_ARCH)_$(GIT_BRANCH)_$(GIT_COMMIT)-$(CONFIGURATION)
 _BUILD_STATUS_ZIP_OUTPUT = $(_BUILD_STATUS_BASENAME).$(ZIP_EXTENSION)

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -184,7 +184,7 @@
     <PropertyGroup>
       <_IncludeCategories Condition=" '$(IncludeCategories)' != '' ">include=$(IncludeCategories)</_IncludeCategories>
       <_ExcludeCategories Condition=" '$(ExcludeCategories)' != '' ">exclude=$(ExcludeCategories)</_ExcludeCategories>
-      <_LogcatFilenameBase>logcat-$(Configuration)$(TestsFlavor)</_LogcatFilenameBase>
+      <_LogcatFilenameBase>$(MSBuildThisFileDirectory)..\..\bin\Test$(Configuration)\logcat-$(Configuration)$(TestsFlavor)</_LogcatFilenameBase>
     </PropertyGroup>
     <RunInstrumentationTests
         Condition=" '%(TestApkInstrumentation.Identity)' != ''"


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/job/xamarin-android-pr-pipeline-release/231/testReport/Xamarin.Android.Bcl_Tests/xunit/Possible_Crash___Release/

Sometimes an on-device test crashes, but the `adb logcat` output is
*not* included into the NUnit error report that `<RenameTestCases/>`
generates.  This is annoying, as it requires that we download the
`xa-test-results*.zip` file to obtain the actual `adb logcat` output,
which is time-consuming and not entirely obvious.

Additionally, I don't understand *why* the `adb logcat` output isn't
being included; the test execution log states:

	Task "RunInstrumentationTests"
	  ...
	  Task Parameter:NUnit2TestResultsFile=…/xamarin-android/tests/../bin/TestRelease/TestResult-Xamarin.Android.Bcl_Tests.xunit.xml
	  ...
	  Executing: /Users/builder/android-toolchain/sdk/platform-tools/adb -s emulator-5570  shell am instrument  -e "loglevel Verbose" -w "Xamarin.Android.Bcl_Tests/xamarin.android.bcltests.XUnitInstrumentation"
	  INSTRUMENTATION_RESULT: shortMsg=Process crashed.
	  INSTRUMENTATION_CODE: 0
	  Executing: /Users/builder/android-toolchain/sdk/platform-tools/adb -s emulator-5570  logcat -v threadtime -d
	    appending stdout to file: logcat-Release-Xamarin.Android.Bcl_Tests.txt
	  --------- beginning of main

Note the second-to-last line: `appending stdout to file`.

`<RenameTestCases/>` *should* be looking for
`logcat-Release-Xamarin.Android.Bcl_Tests.txt`, the file appended to
above, yet it isn't being found; if it were, it would be in the
`TestResult-Xamarin.Android.Bcl_Tests.xunit.xml` file and part of the
Jenkins-displayed error message!

This "feels like" there's a mismatch in directories being used to
store the `logcat-*` files, which is why they're not found.

To attempt to address this, let's be more specific: instead of relying
on the current-working-directory, provide full path names to the
`logcat-*` files to create, by way of `$(MSBuildThisFileDirectory)`.
Additionally, change the directory that the `logcat-*` files are
stored from `$(topdir)/tests` to `$(topdir)/bin/Test$(Configuration)`.
This prevents "polluting" the `tests` directory and is more
consistent.

Additionally, update `<RenameTestCases/>` so that it logs which
`adb logcat` file it's attempting to read, so that if there *is* a
directory mismatch, we can better diagnose it.

Finally, update `make package-build-status` and
`make package-test-results` so that the `logcat-*` files are actually
packaged.  As per commit e138034e, `make package-build-status` is
executed *before* unit tests are run, meaning there will not be any
`logcat-*` files to include in `make package-build-status`.  Remove
the `logcat-*` files from `make package-build-status`, and update
`make package-test-results` to instead include the `logcat-*` files.