### PR TITLE
Bump NDK to r19c

### DIFF
--- a/build-tools/scripts/Ndk.targets
+++ b/build-tools/scripts/Ndk.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <AndroidNdkVersion Condition=" '$(AndroidNdkVersion)' == '' ">19b</AndroidNdkVersion>
+    <AndroidNdkVersion Condition=" '$(AndroidNdkVersion)' == '' ">19c</AndroidNdkVersion>
     <AndroidNdkApiLevel_ArmV7a Condition=" '$(AndroidNdkApiLevel_ArmV7a)' == '' ">16</AndroidNdkApiLevel_ArmV7a>
     <AndroidNdkApiLevel_ArmV8a Condition=" '$(AndroidNdkApiLevel_ArmV8a)' == '' ">21</AndroidNdkApiLevel_ArmV8a>
     <AndroidNdkApiLevel_X86 Condition=" '$(AndroidNdkApiLevel_X86)' == '' ">16</AndroidNdkApiLevel_X86>


### PR DESCRIPTION
Upstream [changes][0]:

 * [Issue 912][1]: Prevent the CMake toolchain file from clobbering a user
   specified `CMAKE_FIND_ROOT_PATH`.
 * [Issue 920][2]: Fix clang wrapper scripts on Windows.

[0]: https://github.com/android-ndk/ndk/wiki/Changelog-r19#r19c
[1]: https://github.com/android-ndk/ndk/issues/912
[2]: https://github.com/android-ndk/ndk/issues/920