### PR TITLE
[tests] avoid shared dirs for parallel MSBuild tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -255,7 +255,6 @@ using System.Runtime.CompilerServices;
 		}
 
 		[Test]
-		[NonParallelizable]
 		public void Check9PatchFilesAreProcessed ([Values(false, true)] bool explicitCrunch)
 		{
 			var projectPath = string.Format ("temp/Check9PatchFilesAreProcessed_{0}", explicitCrunch.ToString ());
@@ -307,7 +306,6 @@ using System.Runtime.CompilerServices;
 		}
 
 		[Test]
-		[NonParallelizable]
 		/// <summary>
 		/// Based on https://bugzilla.xamarin.com/show_bug.cgi?id=29263
 		/// </summary>
@@ -1430,7 +1428,6 @@ namespace UnnamedProject
 
 		// https://github.com/xamarin/xamarin-android/issues/2205
 		[Test]
-		[NonParallelizable]
 		public void Issue2205 ([Values (false, true)] bool useAapt2)
 		{
 			var proj = new XamarinAndroidApplicationProject ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -120,7 +120,6 @@ class MemTest {
 		}
 
 		[Test]
-		[NonParallelizable]
 		public void SkipConvertResourcesCases ([Values (false, true)] bool useAapt2)
 		{
 			var target = "ConvertResourcesCases";
@@ -405,7 +404,6 @@ namespace UnamedProject
 		}
 
 		[Test]
-		[NonParallelizable]
 		public void CheckTimestamps ([Values (true, false)] bool isRelease)
 		{
 			var start = DateTime.UtcNow.AddSeconds (-1);
@@ -1861,7 +1859,6 @@ namespace App1
 		}
 
 		[Test]
-		[NonParallelizable]
 		public void BuildWithNativeLibraries ([Values (true, false)] bool isRelease)
 		{
 			var dll = new XamarinAndroidLibraryProject () {
@@ -2569,7 +2566,6 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 
 		//This test validates the _CleanIntermediateIfNuGetsChange target
 		[Test]
-		[NonParallelizable]
 		public void BuildAfterUpgradingNuget ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -2621,7 +2617,6 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		}
 
 		[Test]
-		[NonParallelizable]
 		public void CompileBeforeUpgradingNuGet ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -3125,7 +3120,6 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		}
 
 		[Test]
-		[NonParallelizable]
 		public void BuildAMassiveApp()
 		{
 			var testPath = Path.Combine("temp", "BuildAMassiveApp");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3123,7 +3123,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		public void BuildAMassiveApp()
 		{
 			var testPath = Path.Combine("temp", "BuildAMassiveApp");
-			TestContext.CurrentContext.Test.Properties ["Output"] = new string [] { Path.Combine (Root, testPath) };
+			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = Path.Combine (Root, testPath);
 			var sb = new SolutionBuilder("BuildAMassiveApp.sln") {
 				SolutionPath = Path.Combine(Root, testPath),
 				Verbosity = LoggerVerbosity.Diagnostic,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -312,6 +312,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[NonParallelizable] //This uses a connected device
 		public void NetStandardReferenceTest ()
 		{
 			var netStandardProject = new DotNetStandard () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MakeBundleNativeCodeExternalTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MakeBundleNativeCodeExternalTests.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Android.Build.Tests {
 				messages: messages = new List<BuildMessageEventArgs> ());
 
 			path = Path.Combine (Root, "temp", TestName);
-			TestContext.CurrentContext.Test.Properties ["Output"] = new string [] { path };
+			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = path;
 		}
 
 		[TestCase (null)]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -380,8 +380,9 @@ namespace Xamarin.Android.Build.Tests
 		{
 			TestContext.Out.WriteLine ($"[TESTLOG] Test {TestName} Complete");
 			TestContext.Out.Flush ();
-			var outputDir = TestOutputDirectories [TestContext.CurrentContext.Test.ID];
-			if (System.Diagnostics.Debugger.IsAttached || string.IsNullOrEmpty (outputDir))
+			if (!TestOutputDirectories.TryGetValue (TestContext.CurrentContext.Test.ID, out string outputDir))
+				return;
+			if (Debugger.IsAttached || string.IsNullOrEmpty (outputDir))
 				return;
 			// find the "root" directory just below "temp" and clean from there because
 			// some tests create multiple subdirectories

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -15,6 +16,8 @@ namespace Xamarin.Android.Build.Tests
 {
 	public class BaseTest
 	{
+		public static ConcurrentDictionary<string, string> TestOutputDirectories = new ConcurrentDictionary<string, string> ();
+
 		[SetUpFixture]
 		public class SetUp
 		{
@@ -297,13 +300,13 @@ namespace Xamarin.Android.Build.Tests
 
 		protected ProjectBuilder CreateApkBuilder (string directory, bool cleanupAfterSuccessfulBuild = false, bool cleanupOnDispose = false)
 		{
-			TestContext.CurrentContext.Test.Properties ["Output"] = new string [] { Path.Combine (Root, directory) };
+			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = Path.Combine (Root, directory);
 			return BuildHelper.CreateApkBuilder (directory, cleanupAfterSuccessfulBuild, cleanupOnDispose);
 		}
 
 		protected ProjectBuilder CreateDllBuilder (string directory, bool cleanupAfterSuccessfulBuild = false, bool cleanupOnDispose = false)
 		{
-			TestContext.CurrentContext.Test.Properties ["Output"] = new string [] { Path.Combine (Root, directory) };
+			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = Path.Combine (Root, directory);
 			return BuildHelper.CreateDllBuilder (directory, cleanupAfterSuccessfulBuild, cleanupOnDispose);
 		}
 
@@ -377,14 +380,12 @@ namespace Xamarin.Android.Build.Tests
 		{
 			TestContext.Out.WriteLine ($"[TESTLOG] Test {TestName} Complete");
 			TestContext.Out.Flush ();
-			if (System.Diagnostics.Debugger.IsAttached || TestContext.CurrentContext.Test.Properties ["Output"] == null)
-					return;
+			var outputDir = TestOutputDirectories [TestContext.CurrentContext.Test.ID];
+			if (System.Diagnostics.Debugger.IsAttached || string.IsNullOrEmpty (outputDir))
+				return;
 			// find the "root" directory just below "temp" and clean from there because
 			// some tests create multiple subdirectories
-			var items = (IList)TestContext.CurrentContext.Test.Properties ["Output"];
-			if (items.Count == 0)
-				return;
-			var output = Path.GetFullPath (items[0].ToString ());
+			var output = Path.GetFullPath (outputDir);
 			while (!Directory.GetParent (output).Name.EndsWith ("temp", StringComparison.OrdinalIgnoreCase)) {
 					output = Directory.GetParent (output).FullName;
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -386,12 +386,12 @@ namespace Xamarin.ProjectTools
 					sw.WriteLine (" /p:BuildingOutOfProcess=true");
 				}
 				if (!string.IsNullOrEmpty (AndroidSdkDirectory)) {
-					sw.WriteLine ($" /p:AndroidSdkDirectory=\"{EscapeForResponseFile (AndroidSdkDirectory)}\" ");
+					sw.WriteLine ($" /p:AndroidSdkDirectory=\"{AndroidSdkDirectory}\" ");
 				}
 				if (!string.IsNullOrEmpty (AndroidNdkDirectory)) {
-					sw.WriteLine ($" /p:AndroidNdkDirectory=\"{EscapeForResponseFile (AndroidNdkDirectory)}\" ");
+					sw.WriteLine ($" /p:AndroidNdkDirectory=\"{AndroidNdkDirectory}\" ");
 				}
-				sw.WriteLine ($" /p:XamarinBuildDownloadDir=\"{EscapeForResponseFile (xamarinBuildDownloadDir)}\" ");
+				sw.WriteLine ($" /p:RestorePackagesPath=\"{nugetDir}\" ");
 				if (parameters != null) {
 					foreach (var param in parameters) {
 						sw.WriteLine (" /p:{0}", param);
@@ -403,9 +403,9 @@ namespace Xamarin.ProjectTools
 				}
 				if (RunningMSBuild) {
 					psi.EnvironmentVariables ["MSBUILD"] = "msbuild";
-					sw.WriteLine ($" /bl:\"{EscapeForResponseFile (Path.Combine (projectDir, "msbuild.binlog"))}\"");
+					sw.WriteLine ($" /bl:\"{Path.Combine (projectDir, "msbuild.binlog")}\"");
 				}
-				psi.EnvironmentVariables ["NUGET_PACKAGES"] = nugetDir;
+				psi.EnvironmentVariables ["XamarinBuildDownloadDir"] = xamarinBuildDownloadDir;
 				if (environmentVariables != null) {
 					foreach (var kvp in environmentVariables) {
 						psi.EnvironmentVariables [kvp.Key] = kvp.Value;
@@ -523,8 +523,6 @@ namespace Xamarin.ProjectTools
 
 			return result;
 		}
-
-		string EscapeForResponseFile (string path) => IsUnix ? path : path.Replace (@"\", @"\\");
 
 		bool IsRunningInIDE {
 			get {


### PR DESCRIPTION
Running our MSBuild NUnit tests can have quite a few random failures
due to shared directories:

* `%UserProfile%\.nuget` contains a system-wide cache of NuGet
  packages. Commonly the MSBuild `Restore` target can fail if two
  process restore the same package at the same time.
* `%LocalAppData%\XamarinBuildDownloadCache` commonly the
  Xamarin.Build.Download NuGet can fail if two processes try to
  dowload files at the same time.

These issues happen on a clean build machine (that has never built
xamarin-android). This can happen on macOS as well, but the paths are
different.

An improvement in our sanity here, would be to configure these
directories so they use a path on a per-test basis.

So for NuGet:

https://docs.microsoft.com/en-us/nuget/consume-packages/managing-the-global-packages-and-cache-folders

We can set the `NUGET_PACKAGES` environment variable to a `.nuget`
directory in the project directory of each test.

For Xamarin.Build.Download:

https://github.com/xamarin/XamarinComponents/blob/5e89e3cc935cea98e7f7ac4cefa6f51ca0262d6f/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.targets#L12

We can set the `$(XamarinBuildDownloadDir)` MSBuild property to an
`xbd` directory.

However, in practice this property required a trailing slash, which
opened a problem with our our response files are generated in tests:

    /p:XamarinBuildDownloadDir="C:\src\xamarin-android\bin\TestDebug\temp\Foo Bar\xbd\"

The `\"` at the end is effectively escaping the `"`, so the property
contains the `"`.

The fix is to escape all `\` characters in this response file:

    /p:XamarinBuildDownloadDir="C:\\src\\xamarin-android\\bin\\TestDebug\\temp\\Foo Bar\\xbd\\"

Now everything works.

I chose short directory names for `.nuget` and `xbd` to avoid
`MAX_PATH` issues.

I also removed `[NonParallelizable]` from several MSBuild tests. We
should only keep them on a few tests that rely on an operation
completing in a length of time.