### PR TITLE
[monodroid] fix path to macOS libmonosgen-2.0.dylib

### DIFF
--- a/src/monodroid/jni/android-system.h
+++ b/src/monodroid/jni/android-system.h
@@ -59,7 +59,7 @@ namespace xamarin { namespace android { namespace internal
 #elif LINUX
 		static constexpr char SYSTEM_LIB_PATH[] = "/usr/lib";
 #elif APPLE_OS_X
-		static constexpr char SYSTEM_LIB_PATH[] = "/Library/Frameworks/Xamarin.Android.framework/Libraries/";
+		static constexpr char SYSTEM_LIB_PATH[] = "/Library/Frameworks/Xamarin.Android.framework/Versions/Current/lib/xamarin.android/xbuild/Xamarin/Android/lib/host-Darwin";
 #elif WINDOWS
 		static const char *SYSTEM_LIB_PATH;
 #else


### PR DESCRIPTION
Recent changes to the installer have broken the Android designer's
integration tests.

`libmonodroid.so` is failing to startup with:

    [monodroid] Setting up for DSO lookup in app data directories
    [monodroid] Creating public update directory: `/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpo8EG0J.tmp/.__override__`
    [monodroid] Trying to get property debug.mono.gc.4c07178b
    [monodroid] Trying to get property from /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpo8EG0J.tmp/.__override__/debug.mono.gc
    [monodroid] Trying to get property debug.mono.env.4c07178b
    [monodroid] Trying to get property from /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpo8EG0J.tmp/.__override__/debug.mono.env
    [monodroid] Using override path: /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpo8EG0J.tmp/.__override__
    [monodroid] Using override path: /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpo8EG0J.tmp
    [monodroid] Using override path: /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpo8EG0J.tmp
    [monodroid] bundle app: normal mode
    [monodroid] bundle_path == <nullptr>
    [monodroid] Using runtime path: /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/
    [monodroid] checking directory: `/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpo8EG0J.tmp/.__override__/lib`
    [monodroid] directory does not exist: `/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpo8EG0J.tmp/.__override__/lib`
    [monodroid] checking directory: `/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpo8EG0J.tmp/lib`
    [monodroid] directory does not exist: `/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpo8EG0J.tmp/lib`
    [monodroid] checking directory: `/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpo8EG0J.tmp/lib`
    [monodroid] directory does not exist: `/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpo8EG0J.tmp/lib`
    [monodroid] Trying to load sgen from: /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpo8EG0J.tmp/.__override__/libmonosgen-2.0.dylib
    [monodroid] Trying to load sgen from: /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpo8EG0J.tmp/libmonosgen-2.0.dylib
    [monodroid] Trying to load sgen from: /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpo8EG0J.tmp/libmonosgen-2.0.dylib
    [monodroid] Trying to load sgen from: /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/data/libmonosgen-2.0.dylib
    [monodroid] Trying to load sgen from: /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T//libmonosgen-64bit-2.0.dylib
    [monodroid] Trying to load sgen from: /Library/Frameworks/Xamarin.Android.framework/Libraries//libmonosgen-2.0.dylib
    [monodroid] Cannot find 'libmonosgen-2.0.dylib'. Looked in the following locations:
    [monodroid]   /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpo8EG0J.tmp/.__override__
    [monodroid]   /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpo8EG0J.tmp
    [monodroid]   /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpo8EG0J.tmp
    [monodroid]   /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/data
    [monodroid] Do you have a shared runtime build of your app with AndroidManifest.xml android:minSdkVersion < 10 while running on a 64-bit Android 5.0 target? This combination is not supported.
    [monodroid] Please either set android:minSdkVersion >= 10 or use a build without the shared runtime (like default Release configuration).

Looking at a successful build, the last path is being used:

    [monodroid] Trying to load sgen from: /Library/Frameworks/Xamarin.Android.framework/Libraries//libmonosgen-2.0.dylib
    [monodroid] Loading Mono symbols...

We recently (and intentionally) removed the `Libraries` and `Commands`
symlinks from the pkg installer:

    $ ls -la /Library/Frameworks/Xamarin.Android.framework/
    total 0
    drwxr-xr-x   5 root  wheel   160 Mar 21 17:28 .
    drwxr-xr-x  14 root  wheel   448 Dec 19 09:44 ..
    lrwxr-xr-x   1 root  wheel    20 Mar 21 16:43 Commands -> Versions/Current/bin
    lrwxr-xr-x   1 root  wheel    20 Mar 21 16:43 Libraries -> Versions/Current/lib
    drwxr-xr-x  42 root  wheel  1344 Mar 21 16:43 Versions

Looking through the designer's source (and other private repos), I
couldn't find any usage of this `Libraries` symlink.

Then I found:

    #elif APPLE_OS_X
        static constexpr char SYSTEM_LIB_PATH[] = "/Library/Frameworks/Xamarin.Android.framework/Libraries/";

So if we used the path, it still would not be quite right:

    /Library/Frameworks/Xamarin.Android.framework/Versions/Current/lib

There used to be a duplicate copy of `libmonosgen-2.0.dylib` in this
location, but the latest changes to the installer have removed this
file as well.

We should actually use:

    /Library/Frameworks/Xamarin.Android.framework/Versions/Current/lib/xamarin.android/xbuild/Xamarin/Android/lib/host-Darwin

We also don't need the trailing `/`.