### PR TITLE
Annotate attributes with resource category hint for the IDE

### DIFF
--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 using Android.Content.PM;
 using Android.Views;
@@ -52,7 +53,9 @@ namespace Android.App
 #if ANDROID_11
 		public bool                   HardwareAccelerated     {get; set;}
 #endif
+		[Category("@drawable;@mipmap")]
 		public string                 Icon                    {get; set;}
+		[Category("@string")]
 		public string                 Label                   {get; set;}
 		public LaunchMode             LaunchMode              {get; set;}
 #if ANDROID_23
@@ -99,6 +102,7 @@ namespace Android.App
 		public WindowRotationAnimation      RotationAnimation    {get; set;}
 #endif
 #if ANDROID_25
+		[Category("@drawable;@mipmap")]
 		public string                 RoundIcon               {get; set;}
 #endif
 #if ANDROID_23
@@ -120,6 +124,7 @@ namespace Android.App
 #endif
 		public bool                   StateNotNeeded          {get; set;}
 		public string                 TaskAffinity            {get; set;}
+		[Category("@style")]
 		public string                 Theme                   {get; set;}
 #if ANDROID_27
 		public bool                   TurnScreenOn            {get; set;}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ActivityAttribute.cs
@@ -53,9 +53,9 @@ namespace Android.App
 #if ANDROID_11
 		public bool                   HardwareAccelerated     {get; set;}
 #endif
-		[Category("@drawable;@mipmap")]
+		[Category ("@drawable;@mipmap")]
 		public string                 Icon                    {get; set;}
-		[Category("@string")]
+		[Category ("@string")]
 		public string                 Label                   {get; set;}
 		public LaunchMode             LaunchMode              {get; set;}
 #if ANDROID_23
@@ -102,7 +102,7 @@ namespace Android.App
 		public WindowRotationAnimation      RotationAnimation    {get; set;}
 #endif
 #if ANDROID_25
-		[Category("@drawable;@mipmap")]
+		[Category ("@drawable;@mipmap")]
 		public string                 RoundIcon               {get; set;}
 #endif
 #if ANDROID_23
@@ -124,7 +124,7 @@ namespace Android.App
 #endif
 		public bool                   StateNotNeeded          {get; set;}
 		public string                 TaskAffinity            {get; set;}
-		[Category("@style")]
+		[Category ("@style")]
 		public string                 Theme                   {get; set;}
 #if ANDROID_27
 		public bool                   TurnScreenOn            {get; set;}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ApplicationAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ApplicationAttribute.cs
@@ -30,6 +30,7 @@ namespace Android.App {
 		public string                 Banner                  {get; set;}
 #endif
 		public bool                   Debuggable              {get; set;}
+		[Category("@string")]
 		public string                 Description             {get; set;}
 #if ANDROID_24
 		public bool                   DirectBootAware         {get; set;}
@@ -46,13 +47,16 @@ namespace Android.App {
 		public bool                   HardwareAccelerated     {get; set;}
 #endif
 		public bool                   HasCode                 {get; set;}
+		[Category("@drawable;@mipmap")]
 		public string                 Icon                    {get; set;}
 		public bool                   KillAfterRestore        {get; set;}
 #if ANDROID_11
 		public bool                   LargeHeap               {get; set;}
 #endif
+		[Category("@string")]
 		public string                 Label                   {get; set;}
 #if ANDROID_11
+		[Category("@drawable;@mipmap")]
 		public string                 Logo                    {get; set;}
 #endif
 		public Type                   ManageSpaceActivity     {get; set;}
@@ -70,12 +74,14 @@ namespace Android.App {
 		public string                 RestrictedAccountType   {get; set;}
 #endif
 #if ANDROID_25
+		[Category("@drawable;@mipmap")]
 		public string                 RoundIcon               {get; set;}
 #endif
 #if ANDROID_17
 		public bool                   SupportsRtl             {get; set;}
 #endif
 		public string                 TaskAffinity            {get; set;}
+		[Category("@style")]
 		public string                 Theme                   {get; set;}
 #if ANDROID_14
 		public UiOptions              UiOptions               {get; set;}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ApplicationAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ApplicationAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 using Android.Content.PM;
 using Android.Views;

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ApplicationAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ApplicationAttribute.cs
@@ -31,7 +31,7 @@ namespace Android.App {
 		public string                 Banner                  {get; set;}
 #endif
 		public bool                   Debuggable              {get; set;}
-		[Category("@string")]
+		[Category ("@string")]
 		public string                 Description             {get; set;}
 #if ANDROID_24
 		public bool                   DirectBootAware         {get; set;}
@@ -48,16 +48,16 @@ namespace Android.App {
 		public bool                   HardwareAccelerated     {get; set;}
 #endif
 		public bool                   HasCode                 {get; set;}
-		[Category("@drawable;@mipmap")]
+		[Category ("@drawable;@mipmap")]
 		public string                 Icon                    {get; set;}
 		public bool                   KillAfterRestore        {get; set;}
 #if ANDROID_11
 		public bool                   LargeHeap               {get; set;}
 #endif
-		[Category("@string")]
+		[Category ("@string")]
 		public string                 Label                   {get; set;}
 #if ANDROID_11
-		[Category("@drawable;@mipmap")]
+		[Category ("@drawable;@mipmap")]
 		public string                 Logo                    {get; set;}
 #endif
 		public Type                   ManageSpaceActivity     {get; set;}
@@ -75,14 +75,14 @@ namespace Android.App {
 		public string                 RestrictedAccountType   {get; set;}
 #endif
 #if ANDROID_25
-		[Category("@drawable;@mipmap")]
+		[Category ("@drawable;@mipmap")]
 		public string                 RoundIcon               {get; set;}
 #endif
 #if ANDROID_17
 		public bool                   SupportsRtl             {get; set;}
 #endif
 		public string                 TaskAffinity            {get; set;}
-		[Category("@style")]
+		[Category ("@style")]
 		public string                 Theme                   {get; set;}
 #if ANDROID_14
 		public UiOptions              UiOptions               {get; set;}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/InstrumentationAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/InstrumentationAttribute.cs
@@ -14,10 +14,13 @@ namespace Android.App {
 
 		public bool                   FunctionalTest  {get; set;}
 		public bool                   HandleProfiling {get; set;}
+		[Category("@drawable;@mipmap")]
 		public string                 Icon            {get; set;}
+		[Category("@string")]
 		public string                 Label           {get; set;}
 		public string                 Name            {get; set;}
 #if ANDROID_25
+		[Category("@drawable;@mipmap")]
 		public string                 RoundIcon               {get; set;}
 #endif
 		public string                 TargetPackage   {get; set;}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/InstrumentationAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/InstrumentationAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 namespace Android.App {
 

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/InstrumentationAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/InstrumentationAttribute.cs
@@ -15,13 +15,13 @@ namespace Android.App {
 
 		public bool                   FunctionalTest  {get; set;}
 		public bool                   HandleProfiling {get; set;}
-		[Category("@drawable;@mipmap")]
+		[Category ("@drawable;@mipmap")]
 		public string                 Icon            {get; set;}
-		[Category("@string")]
+		[Category ("@string")]
 		public string                 Label           {get; set;}
 		public string                 Name            {get; set;}
 #if ANDROID_25
-		[Category("@drawable;@mipmap")]
+		[Category ("@drawable;@mipmap")]
 		public string                 RoundIcon               {get; set;}
 #endif
 		public string                 TargetPackage   {get; set;}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ServiceAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ServiceAttribute.cs
@@ -23,17 +23,17 @@ namespace Android.App {
 #endif
 		public bool                   Enabled                 {get; set;}
 		public bool                   Exported                {get; set;}
-		[Category("@drawable;@mipmap")]
+		[Category ("@drawable;@mipmap")]
 		public string                 Icon                    {get; set;}
 #if ANDROID_16
 		public bool                   IsolatedProcess         {get; set;}
 #endif
-		[Category("@string")]
+		[Category ("@string")]
 		public string                 Label                   {get; set;}
 		public string                 Permission              {get; set;}
 		public string                 Process                 {get; set;}
 #if ANDROID_25
-		[Category("@drawable;@mipmap")]
+		[Category ("@drawable;@mipmap")]
 		public string                 RoundIcon               {get; set;}
 #endif
 	}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ServiceAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ServiceAttribute.cs
@@ -22,14 +22,17 @@ namespace Android.App {
 #endif
 		public bool                   Enabled                 {get; set;}
 		public bool                   Exported                {get; set;}
+		[Category("@drawable;@mipmap")]
 		public string                 Icon                    {get; set;}
 #if ANDROID_16
 		public bool                   IsolatedProcess         {get; set;}
 #endif
+		[Category("@string")]
 		public string                 Label                   {get; set;}
 		public string                 Permission              {get; set;}
 		public string                 Process                 {get; set;}
 #if ANDROID_25
+		[Category("@drawable;@mipmap")]
 		public string                 RoundIcon               {get; set;}
 #endif
 	}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ServiceAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ServiceAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 using Android.Content.PM;
 using Android.Views;

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.Content/BroadcastReceiverAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.Content/BroadcastReceiverAttribute.cs
@@ -16,17 +16,17 @@ namespace Android.Content {
 		public bool                   DirectBootAware         {get; set;}
 		public bool                   Enabled                 {get; set;}
 		public bool                   Exported                {get; set;}
-		[Category("@string")]
+		[Category ("@string")]
 		public string                 Description             {get; set;}
-		[Category("@drawable;@mipmap")]
+		[Category ("@drawable;@mipmap")]
 		public string                 Icon                    {get; set;}
-		[Category("@string")]
+		[Category ("@string")]
 		public string                 Label                   {get; set;}
 		public string                 Name                    {get; set;}
 		public string                 Permission              {get; set;}
 		public string                 Process                 {get; set;}
 #if ANDROID_25
-		[Category("@drawable;@mipmap")]
+		[Category ("@drawable;@mipmap")]
 		public string                 RoundIcon               {get; set;}
 #endif
 	}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.Content/BroadcastReceiverAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.Content/BroadcastReceiverAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 namespace Android.Content {
 

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.Content/BroadcastReceiverAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.Content/BroadcastReceiverAttribute.cs
@@ -15,13 +15,17 @@ namespace Android.Content {
 		public bool                   DirectBootAware         {get; set;}
 		public bool                   Enabled                 {get; set;}
 		public bool                   Exported                {get; set;}
+		[Category("@string")]
 		public string                 Description             {get; set;}
+		[Category("@drawable;@mipmap")]
 		public string                 Icon                    {get; set;}
+		[Category("@string")]
 		public string                 Label                   {get; set;}
 		public string                 Name                    {get; set;}
 		public string                 Permission              {get; set;}
 		public string                 Process                 {get; set;}
 #if ANDROID_25
+		[Category("@drawable;@mipmap")]
 		public string                 RoundIcon               {get; set;}
 #endif
 	}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.Content/ContentProviderAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.Content/ContentProviderAttribute.cs
@@ -24,8 +24,10 @@ namespace Android.Content {
 		public bool                   Enabled                 {get; set;}
 		public bool                   Exported                {get; set;}
 		public bool                   GrantUriPermissions     {get; set;}
+		[Category("@drawable;@mipmap")]
 		public string                 Icon                    {get; set;}
 		public int                    InitOrder               {get; set;}
+		[Category("@string")]
 		public string                 Label                   {get; set;}
 		public bool                   MultiProcess            {get; set;}
 		public string                 Name                    {get; set;}
@@ -33,6 +35,7 @@ namespace Android.Content {
 		public string                 Process                 {get; set;}
 		public string                 ReadPermission          {get; set;}
 #if ANDROID_25
+		[Category("@drawable;@mipmap")]
 		public string                 RoundIcon               {get; set;}
 #endif
 		public bool                   Syncable                {get; set;}

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.Content/ContentProviderAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.Content/ContentProviderAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 namespace Android.Content {
 

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.Content/ContentProviderAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.Content/ContentProviderAttribute.cs
@@ -25,10 +25,10 @@ namespace Android.Content {
 		public bool                   Enabled                 {get; set;}
 		public bool                   Exported                {get; set;}
 		public bool                   GrantUriPermissions     {get; set;}
-		[Category("@drawable;@mipmap")]
+		[Category ("@drawable;@mipmap")]
 		public string                 Icon                    {get; set;}
 		public int                    InitOrder               {get; set;}
-		[Category("@string")]
+		[Category ("@string")]
 		public string                 Label                   {get; set;}
 		public bool                   MultiProcess            {get; set;}
 		public string                 Name                    {get; set;}
@@ -36,7 +36,7 @@ namespace Android.Content {
 		public string                 Process                 {get; set;}
 		public string                 ReadPermission          {get; set;}
 #if ANDROID_25
-		[Category("@drawable;@mipmap")]
+		[Category ("@drawable;@mipmap")]
 		public string                 RoundIcon               {get; set;}
 #endif
 		public bool                   Syncable                {get; set;}


### PR DESCRIPTION
The code completion experience can be improved if the editor knew
which string properties typically come from resources so a completion
suggestion can be provided that is filtered to the type of resource
the property should be pointing to (i.e. `@(string)` vs `@(drawable)`).

Fixes https://github.com/xamarin/xamarin-android/issues/2862