### PR TITLE
[installers] use @(AndroidApiInfo) for frameworks list

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -3,6 +3,7 @@
   <Import Project="..\..\Configuration.props" />
   <Import Project="..\scripts\XAVersionInfo.targets" />
   <Import Project="..\..\src\mono-runtimes\ProfileAssemblies.projitems" />
+  <Import Project="..\..\src\Mono.Android\Mono.Android.projitems" />
   <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
   <PropertyGroup>
     <RootBuildDir>$(XamarinAndroidSourcePath)\bin\$(Configuration)\</RootBuildDir>
@@ -37,63 +38,6 @@
     <_FrameworkFiles Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\System.EnterpriseServices.dll" />
     <_FrameworkFiles Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Xamarin.Android.NUnitLite.dll" />
     <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\OpenTK-1.0.xml" />
-  </ItemGroup>
-  <!-- Support for PR builds -->
-  <ItemGroup Condition="Exists('$(FrameworkSrcDir)\$(AndroidFirstFrameworkVersion)')">
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v4.4.87\AndroidApiInfo.xml" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v4.4.87\mono.android.dex" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v4.4.87\Mono.Android.dll" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v4.4.87\mono.android.jar" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v4.4.87\Mono.Android.pdb" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v4.4.87\RedistList\FrameworkList.xml" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.0\AndroidApiInfo.xml" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.0\mono.android.dex" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.0\Mono.Android.dll" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.0\mono.android.jar" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.0\Mono.Android.pdb" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.0\RedistList\FrameworkList.xml" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.1\AndroidApiInfo.xml" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.1\mono.android.dex" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.1\Mono.Android.dll" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.1\mono.android.jar" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.1\Mono.Android.pdb" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v5.1\RedistList\FrameworkList.xml" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v6.0\AndroidApiInfo.xml" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v6.0\mono.android.dex" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v6.0\Mono.Android.dll" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v6.0\mono.android.jar" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v6.0\Mono.Android.pdb" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v6.0\RedistList\FrameworkList.xml" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.0\AndroidApiInfo.xml" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.0\mono.android.dex" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.0\Mono.Android.dll" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.0\mono.android.jar" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.0\Mono.Android.pdb" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.0\RedistList\FrameworkList.xml" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.1\AndroidApiInfo.xml" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.1\mono.android.dex" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.1\Mono.Android.dll" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.1\mono.android.jar" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.1\Mono.Android.pdb" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v7.1\RedistList\FrameworkList.xml" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.0\AndroidApiInfo.xml" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.0\mono.android.dex" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.0\Mono.Android.dll" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.0\mono.android.jar" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.0\Mono.Android.pdb" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.0\RedistList\FrameworkList.xml" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.1\AndroidApiInfo.xml" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.1\mono.android.dex" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.1\Mono.Android.dll" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.1\mono.android.jar" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.1\Mono.Android.pdb" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\v8.1\RedistList\FrameworkList.xml" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(AndroidLatestFrameworkVersion)\AndroidApiInfo.xml" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(AndroidLatestFrameworkVersion)\mono.android.dex" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(AndroidLatestFrameworkVersion)\Mono.Android.dll" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(AndroidLatestFrameworkVersion)\mono.android.jar" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(AndroidLatestFrameworkVersion)\Mono.Android.pdb" />
-    <_FrameworkFiles Include="$(FrameworkSrcDir)\$(AndroidLatestFrameworkVersion)\RedistList\FrameworkList.xml" />
   </ItemGroup>
   <ItemGroup>
     <_MSBuildFiles Include="$(MSBuildSrcDir)\android-support-multidex.jar" />
@@ -288,6 +232,14 @@
   <Target Name="ConstructInstallerItems"
       Returns="@(FrameworkItemsWin);@(FrameworkItemsUnix);@(MSBuildItemsWin);@(MSBuildItemsUnix)">
     <ItemGroup>
+      <_FrameworkDirs Include="@(AndroidApiInfo->'$(FrameworkSrcDir)\%(Identity)')" />
+      <_FrameworkDirsThatExist Condition="Exists('%(Identity)')" Include="@(_FrameworkDirs)" />
+      <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\AndroidApiInfo.xml')" />
+      <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\mono.android.dex')" />
+      <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\Mono.Android.dll')" />
+      <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\mono.android.jar')" />
+      <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\Mono.Android.pdb')" />
+      <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\RedistList\FrameworkList.xml')" />
       <FrameworkItemsWin Include="@(_FrameworkFiles);@(_FrameworkFilesWin)">
         <RelativePath>$([MSBuild]::MakeRelative($(FrameworkSrcDir), %(FullPath)))</RelativePath>
       </FrameworkItemsWin>


### PR DESCRIPTION
Our installers are currently missing `v9.0`:

    $ zipinfo ~/Downloads/Xamarin.Android.Sdk-OSS-9.2.99.95_master_58137da.vsix | grep Mono.Android.dll
    -rw----     0.0 fat 17827328 b- defN 19-Mar-22 15:14 $ReferenceAssemblies/Microsoft/Framework/MonoAndroid/v4.4/Mono.Android.dll
    -rw----     0.0 fat 17888256 b- defN 19-Mar-22 15:15 $ReferenceAssemblies/Microsoft/Framework/MonoAndroid/v4.4.87/Mono.Android.dll
    -rw----     0.0 fat 19628544 b- defN 19-Mar-22 15:15 $ReferenceAssemblies/Microsoft/Framework/MonoAndroid/v5.0/Mono.Android.dll
    -rw----     0.0 fat 19720704 b- defN 19-Mar-22 15:15 $ReferenceAssemblies/Microsoft/Framework/MonoAndroid/v5.1/Mono.Android.dll
    -rw----     0.0 fat 20758528 b- defN 19-Mar-22 15:15 $ReferenceAssemblies/Microsoft/Framework/MonoAndroid/v6.0/Mono.Android.dll
    -rw----     0.0 fat 22979584 b- defN 19-Mar-22 15:15 $ReferenceAssemblies/Microsoft/Framework/MonoAndroid/v7.0/Mono.Android.dll
    -rw----     0.0 fat 23044096 b- defN 19-Mar-22 15:15 $ReferenceAssemblies/Microsoft/Framework/MonoAndroid/v7.1/Mono.Android.dll
    -rw----     0.0 fat 24596480 b- defN 19-Mar-22 15:15 $ReferenceAssemblies/Microsoft/Framework/MonoAndroid/v8.0/Mono.Android.dll
    -rw----     0.0 fat 24669184 b- defN 19-Mar-22 15:15 $ReferenceAssemblies/Microsoft/Framework/MonoAndroid/v8.1/Mono.Android.dll
    -rw----     0.0 fat 26605568 b- defN 19-Mar-22 15:15 $ReferenceAssemblies/Microsoft/Framework/MonoAndroid/v9.0.99/Mono.Android.dll

When we added API-Q, a new *unstable* framework is preventing the
latest *stable* framework from being added to the installer.

What we can do instead, is import `Mono.Android.projitems` and use
its `@(AndroidApiInfo)` item group.

    <AndroidApiInfo Include="v9.0">
      <Name>Pie</Name>
      <Level>28</Level>
      <Id>28</Id>
      <Stable>True</Stable>
    </AndroidApiInfo>
    <AndroidApiInfo Include="v9.0.99">
      <Name>Q</Name>
      <Level>29</Level>
      <Id>Q</Id>
      <Stable>False</Stable>
    </AndroidApiInfo>

Unfortunately, getting the MSBuild transform right was quite tricky...

At first, I just tried updating the existing `<ItempGroup/>`:

    <ItemGroup>
      <_FrameworkDirs Include="@(AndroidApiInfo->'$(FrameworkSrcDir)\%(Identity)')" />
      <_FrameworkDirsThatExist Condition="Exists('%(Identity)')" Include="@(_FrameworkDirs)" />
      <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\AndroidApiInfo.xml')" />
      <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\mono.android.dex')" />
      <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\Mono.Android.dll')" />
      <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\mono.android.jar')" />
      <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\Mono.Android.pdb')" />
      <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\RedistList\FrameworkList.xml')" />
    </ItemGroup>

This construct fails with:

    error MSB4190: The reference to the built-in metadata "Identity" at position 8 is not allowed in this condition "Exists('%(Identity)')".

However, it works when moved *inside* a target? I am guessing that
`%(Identity)` does not exist at evaluation time. MSBuild is a weird
thing.

I just put this `<ItemGroup/>` inside the `ConstructInstallerItems`
MSBuild target.

This should make things future proof for new TFVs, but also allow PR
builds to work.