### PR TITLE
[Linux build] Debian/testing has libncurses6 instead of libncurses5

### DIFF
--- a/build-tools/scripts/dependencies/debian-common.sh
+++ b/build-tools/scripts/dependencies/debian-common.sh
@@ -5,7 +5,6 @@ DEBIAN_COMMON_DEPS="autoconf
 	g++-mingw-w64
 	gcc-mingw-w64
 	git
-	libncurses5
 	libtool
 	libz-mingw-w64-dev
 	libzip4

--- a/build-tools/scripts/dependencies/linux-prepare-Debian.sh
+++ b/build-tools/scripts/dependencies/linux-prepare-Debian.sh
@@ -1,6 +1,14 @@
 . "`dirname $0`"/debian-common.sh
 
-DISTRO_DEPS="$DEBIAN_COMMON_DEPS \
+MAJOR=$(echo $1 | cut -d '.' -f 1)
+
+if [ $MAJOR -ge 10 ]; then
+    DISTRO_DEPS="$DISTRO_DEPS libncurses6"
+else
+    DISTRO_DEPS="$DISTRO_DEPS libncurses5"
+fi
+
+DISTRO_DEPS="$DEBIAN_COMMON_DEPS $DISTRO_DEPS \
     zlib1g-dev
 "
 

--- a/build-tools/scripts/dependencies/ubuntu-common.sh
+++ b/build-tools/scripts/dependencies/ubuntu-common.sh
@@ -1,3 +1,5 @@
+DISTRO_DEPS="$DISTRO_DEPS libncurses5"
+
 if [ "$OS_ARCH" = "x86_64" ]; then
     DISTRO_DEPS="$DISTRO_DEPS
 	libx32tinfo-dev


### PR DESCRIPTION
We're trying to upgrade our Linux build bots to a newer version of Debian in
hopes to fix a problem with cross-building LLVM for Windows with MinGW. However,
Debian/testing (codename buster) does not install `libncurses5` by default,
instead it comes with `libncurses6` which makes the preparation phase of the
build fail.

This commit adds a check for Debian version and adjusts the package list
accordingly.