### PR TITLE
[java-runtime] Remove debug files from java_runtime.jar

### DIFF
--- a/src/java-runtime/java-runtime.targets
+++ b/src/java-runtime/java-runtime.targets
@@ -6,10 +6,7 @@
     <OutputDex>$(OutputPath)java_runtime.dex</OutputDex>
     <IntermediateRuntimeOutputPath>$(IntermediateOutputPath)release</IntermediateRuntimeOutputPath>
     <IntermediateRuntimeClassesTxt>$(IntermediateOutputPath)release.txt</IntermediateRuntimeClassesTxt>
-    <RemoveItems>java\mono\android\debug\MultiDexLoader.java</RemoveItems>
-    <RemoveItems>java\mono\android\MonkeyPatcher.java</RemoveItems>
-    <RemoveItems>java\mono\android\ResourcePatcher.java</RemoveItems>
-    <RemoveItems>java\mono\android\Seppuku.java</RemoveItems>
+    <RemoveItems>java\mono\android\debug\MultiDexLoader.java;java\mono\android\MonkeyPatcher.java;java\mono\android\ResourcePatcher.java;java\mono\android\Seppuku.java</RemoveItems>
   </_RuntimeOutput>
   <_RuntimeOutput Include="$(OutputPath)java_runtime_fastdev.jar">
     <OutputJar>$(OutputPath)java_runtime_fastdev.jar</OutputJar>
@@ -21,7 +18,7 @@
 </ItemGroup>
 <Target Name="Build" 
       Inputs="@(AllRuntimeSource)"
-      Outputs="@(_RuntimeOutput)"
+      Outputs="%(_RuntimeOutput.OutputJar)"
 >
   <MakeDir Directories="%(_RuntimeOutput.IntermediateRuntimeOutputPath)" />
   <MakeDir Directories="$(OutputPath)" />

--- a/src/java-runtime/java/mono/android/MonoPackageManager.java
+++ b/src/java-runtime/java/mono/android/MonoPackageManager.java
@@ -106,7 +106,7 @@ public class MonoPackageManager {
 		return MonoPackageManager_Resources.ApiPackageName;
 	}
 }
-class MonoPackageManager_Resources {
+public class MonoPackageManager_Resources {
 	public static final String[] Assemblies = new String[]{
 	};
 	public static final String[] Dependencies = new String[]{

--- a/src/java-runtime/java/mono/android/MonoPackageManager.java
+++ b/src/java-runtime/java/mono/android/MonoPackageManager.java
@@ -106,11 +106,4 @@ public class MonoPackageManager {
 		return MonoPackageManager_Resources.ApiPackageName;
 	}
 }
-public class MonoPackageManager_Resources {
-	public static final String[] Assemblies = new String[]{
-	};
-	public static final String[] Dependencies = new String[]{
-	};
-	public static final String ApiPackageName = "";
-}
 

--- a/src/java-runtime/java/mono/android/MonoPackageManager_Resources.java
+++ b/src/java-runtime/java/mono/android/MonoPackageManager_Resources.java
@@ -9,6 +9,6 @@ public class MonoPackageManager_Resources {
 	};
 	public static final String[] Dependencies = new String[]{
 	};
-	public static final String ApiPackageName = "";
+	public static final String ApiPackageName = null;
 }
 

--- a/src/java-runtime/java/mono/android/MonoPackageManager_Resources.java
+++ b/src/java-runtime/java/mono/android/MonoPackageManager_Resources.java
@@ -1,0 +1,14 @@
+package mono;
+
+import java.lang.String;
+import java.util.Arrays;
+
+
+public class MonoPackageManager_Resources {
+	public static final String[] Assemblies = new String[]{
+	};
+	public static final String[] Dependencies = new String[]{
+	};
+	public static final String ApiPackageName = "";
+}
+


### PR DESCRIPTION
Commit xxxx added the new java_runtime.jar and
java_runtime_fastdev.jar files. The idea is the
java_runtime.jar was the release version of the
runtime. It should NOT contain files such as

	mono/android/ResourcePatcher.class
	mono/android/Seppuku.class
	mono/android/MonkeyPatcher.class

These are for fast dev only.

However we were including these files!!

This was because of a couple of problems.
1) The `RemoveItems` property of `_RuntimeOutput` was being
treated like an ItemGroup when it is infact a property.
So we need to semi-colon seperate the items to make sure
they are ALL removed rather then it just being the last one
listed.

2) Because the `Inputs` was changed to `@(_RuntimeOutput)`
it means the target will run only ONCE. As a result both the
`release.txt` and `fastdev.txt` files contained the SAME
file list. What we should have been doing was using Target
Batching via

	%(_RuntimeOutput.OutputJar)

This makes sure the target runs for EACH output. This will
result in the behaviour we want, i.e  the files listed
above NOT being in the release version of the jar.