### PR TITLE
[tests] add a test using Xamarin.Forms.Maps

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -120,6 +120,15 @@ class MemTest {
 		}
 
 		[Test]
+		public void BuildXamarinFormsMapsApplication ()
+		{
+			var proj = new XamarinFormsMapsApplicationProject ();
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
+		[Test]
 		[NonParallelizable]
 		public void SkipConvertResourcesCases ([Values (false, true)] bool useAapt2)
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -486,6 +486,19 @@ namespace Xamarin.ProjectTools
 				},
 			}
 		};
+		public static Package XamarinFormsMaps_3_6_0_220655 = new Package {
+			Id = "Xamarin.Forms.Maps",
+			Version = "3.6.0.220655",
+			TargetFramework = "MonoAndroid90",
+			References =  {
+				new BuildItem.Reference ("Xamarin.Forms.Maps.Android") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.Maps.3.6.0.220655\\lib\\MonoAndroid90\\Xamarin.Forms.Maps.Android.dll"
+				},
+				new BuildItem.Reference ("Xamarin.Forms.Maps") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.Maps.3.6.0.220655\\lib\\MonoAndroid90\\Xamarin.Forms.Maps.dll"
+				},
+			}
+		};
 		public static Package CocosSharp_PCL_Shared_1_5_0_0 = new Package {
 			Id = "CocosSharp.PCL.Shared", 
 			Version = "1.5.0.0",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
@@ -56,7 +56,7 @@ namespace Xamarin.ProjectTools
 				TextContent = () => Toolbar_axml,
 			});
 			OtherBuildItems.Add (new BuildItem ("EmbeddedResource", "MainPage.xaml") {
-				TextContent = () => ProcessSourceTemplate (MainPage_xaml),
+				TextContent = MainPageXaml,
 			});
 			Sources.Add (new BuildItem.Source ("MainPage.xaml.cs") {
 				TextContent = () => ProcessSourceTemplate (MainPage_xaml_cs),
@@ -70,5 +70,7 @@ namespace Xamarin.ProjectTools
 
 			MainActivity = default_main_activity_cs;
 		}
+
+		protected virtual string MainPageXaml () => ProcessSourceTemplate (MainPage_xaml);
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsMapsApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsMapsApplicationProject.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.IO;
+
+namespace Xamarin.ProjectTools
+{
+	public class XamarinFormsMapsApplicationProject : XamarinFormsAndroidApplicationProject
+	{
+		static readonly string MainPageMaps_xaml;
+
+		static XamarinFormsMapsApplicationProject ()
+		{
+			using (var sr = new StreamReader (typeof (XamarinAndroidApplicationProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Forms.MainPageMaps.xaml")))
+				MainPageMaps_xaml = sr.ReadToEnd ();
+		}
+
+		public XamarinFormsMapsApplicationProject ()
+		{
+			PackageReferences.Add (KnownPackages.XamarinFormsMaps_3_6_0_220655);
+			MainActivity = MainActivity.Replace ("//${AFTER_FORMS_INIT}", "Xamarin.FormsMaps.Init (this, savedInstanceState);");
+			//NOTE: API_KEY metadata just has to *exist*
+			AndroidManifest = AndroidManifest.Replace ("</application>", "<meta-data android:name=\"com.google.android.maps.v2.API_KEY\" android:value=\"\" /></application>");
+		}
+
+		protected override string MainPageXaml () => ProcessSourceTemplate (MainPageMaps_xaml);
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/MainActivity.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/MainActivity.cs
@@ -19,6 +19,7 @@ namespace ${ROOT_NAMESPACE}
 
 			base.OnCreate (savedInstanceState);
 			global::Xamarin.Forms.Forms.Init (this, savedInstanceState);
+			//${AFTER_FORMS_INIT}
 			LoadApplication (new App ());
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/MainPageMaps.xaml
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/MainPageMaps.xaml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:maps="clr-namespace:Xamarin.Forms.Maps;assembly=Xamarin.Forms.Maps"
+             x:Class="${ROOT_NAMESPACE}.MainPage">
+    <StackLayout>
+        <maps:Map MapType="Street" />
+    </StackLayout>
+</ContentPage>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -36,6 +36,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Android\XamarinFormsMapsApplicationProject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Common\BuildActions.cs" />
     <Compile Include="Common\BuildItem.cs" />
@@ -132,6 +133,7 @@
     <EmbeddedResource Include="Resources\Forms\App.xaml.cs" />
     <EmbeddedResource Include="Resources\Forms\MainPage.xaml" />
     <EmbeddedResource Include="Resources\Forms\MainPage.xaml.cs" />
+    <EmbeddedResource Include="Resources\Forms\MainPageMaps.xaml" />
     <EmbeddedResource Include="Resources\Forms\Tabbar.axml" />
     <EmbeddedResource Include="Resources\Forms\Toolbar.axml" />
     <EmbeddedResource Include="Resources\Forms\colors.xml" />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/2836#issuecomment-476347029

We have noticed apps using Xamarin.Forms.Maps might be close to
hitting the dex limit for fields.

An example from @PureWeen:

    1>  trouble writing output: Too many field references to fit in one dex file: 70468; max is 65536.

We think the way Xamarin.Android invokes `aapt` (or `aapt2`) might be
creating `R.java` files with more fields than are needed.

Step 1 is to add a test project that uses Xamarin.Forms.Maps: we did
not have one.