### PR TITLE
[java-runtime] Remove final from MonoPackageManager_Resources

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -81,7 +81,7 @@ namespace Xamarin.Android.Tasks
 
 				// Write all the user assemblies
 				pkgmgr.WriteLine ("public class MonoPackageManager_Resources {");
-				pkgmgr.WriteLine ("\tpublic static final String[] Assemblies = new String[]{");
+				pkgmgr.WriteLine ("\tpublic static String[] Assemblies = new String[]{");
 
 				pkgmgr.WriteLine ("\t\t/* We need to ensure that \"{0}\" comes first in this list. */", mainFileName);
 				foreach (var assembly in assemblies) {
@@ -90,7 +90,7 @@ namespace Xamarin.Android.Tasks
 
 				// Write the assembly dependencies
 				pkgmgr.WriteLine ("\t};");
-				pkgmgr.WriteLine ("\tpublic static final String[] Dependencies = new String[]{");
+				pkgmgr.WriteLine ("\tpublic static String[] Dependencies = new String[]{");
 
 				//foreach (var assembly in assemblies.Except (args.Assemblies)) {
 				//        if (args.SharedRuntime && !Toolbox.IsInSharedRuntime (assembly))
@@ -100,7 +100,7 @@ namespace Xamarin.Android.Tasks
 				pkgmgr.WriteLine ("\t};");
 
 				// Write the platform api apk we need
-				pkgmgr.WriteLine ("\tpublic static final String ApiPackageName = {0};", shared_runtime
+				pkgmgr.WriteLine ("\tpublic static String ApiPackageName = {0};", shared_runtime
 						? string.Format ("\"Mono.Android.Platform.ApiLevel_{0}\"",
 							MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (TargetFrameworkVersion))
 						: "null");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DesignerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DesignerTests.cs
@@ -241,7 +241,7 @@ namespace UnnamedProject
 							builder.AppendLine (line.Trim ());
 						}
 					} else {
-						found = line.Contains ("public static final String[] Assemblies = new String[]{");
+						found = line.Contains ("public static String[] Assemblies = new String[]{");
 					}
 				}
 			}

--- a/src/java-runtime/java/mono/android/MonoPackageManager_Resources.java
+++ b/src/java-runtime/java/mono/android/MonoPackageManager_Resources.java
@@ -5,10 +5,10 @@ import java.util.Arrays;
 
 
 public class MonoPackageManager_Resources {
-	public static final String[] Assemblies = new String[]{
+	public static String[] Assemblies = new String[]{
 	};
-	public static final String[] Dependencies = new String[]{
+	public static String[] Dependencies = new String[]{
 	};
-	public static final String ApiPackageName = null;
+	public static String ApiPackageName = null;
 }
 


### PR DESCRIPTION
In commit 75023bd2 we noticed an issue the
value of `MonoPackageManager_Resouces.ApiPackageName` was
`""` even after it was replaced at built time with a new
`.class` file which contained an actual value.

The fix in that PR was to make the temp file in java-runtime
have a value of `null` rather than `""`. This made thing work
but we didn't know WHY.

After some more investigation it turns out that the value
was being inlined by the java compiler.

	public static java.lang.String getApiPackageName();
	    descriptor: ()Ljava/lang/String;
	    Code:
	       0: ldc           #48                 // String
	       2: areturn

The code above is pointing to a string in the Constants table.
What we were expecting was that the statick method would be
called in the file generated by the build system. Making
the temp file have a `null` rather than `""` resulted in the
following code

	public static java.lang.String getApiPackageName();
	    descriptor: ()Ljava/lang/String;
	    Code:
	       0: getstatic     #47                 // Field mono/MonoPackageManager_Resources.ApiPackageName:Ljava/lang/String;
	       3: areturn

This is why changing to `null` worked. It prevented the compiler
from inlining the value.

This commit removes the `final` keyword from the `MonoPackageManager_Resources`
class fields to make sure that they never get inlined.