### PR TITLE
[build] Use `libncurses-dev` on Debian + friends

### DIFF
--- a/build-tools/scripts/dependencies/debian-common.sh
+++ b/build-tools/scripts/dependencies/debian-common.sh
@@ -6,6 +6,7 @@ DEBIAN_COMMON_DEPS="autoconf
 	gcc-mingw-w64
 	git
 	libtool
+	libncurses-dev
 	libz-mingw-w64-dev
 	libzip4
 	linux-libc-dev

--- a/build-tools/scripts/dependencies/linux-prepare-Debian.sh
+++ b/build-tools/scripts/dependencies/linux-prepare-Debian.sh
@@ -1,13 +1,5 @@
 . "`dirname $0`"/debian-common.sh
 
-MAJOR=$(echo $1 | cut -d '.' -f 1)
-
-if [ $MAJOR -ge 10 ]; then
-    DISTRO_DEPS="$DISTRO_DEPS libncurses6"
-else
-    DISTRO_DEPS="$DISTRO_DEPS libncurses5"
-fi
-
 DISTRO_DEPS="$DEBIAN_COMMON_DEPS $DISTRO_DEPS \
     zlib1g-dev
 "

--- a/build-tools/scripts/dependencies/ubuntu-common.sh
+++ b/build-tools/scripts/dependencies/ubuntu-common.sh
@@ -1,5 +1,3 @@
-DISTRO_DEPS="$DISTRO_DEPS libncurses5"
-
 if [ "$OS_ARCH" = "x86_64" ]; then
     DISTRO_DEPS="$DISTRO_DEPS
 	libx32tinfo-dev


### PR DESCRIPTION
Instead of relying on a specific soversion of libncurses, depend on its
development package which will always install the current, and expected,
version.

[Kudos to][0] @laarmen for the suggestion :)

[0]: https://github.com/laarmen