### PR TITLE
[Xamarin.Android.Build.Tasks] fix for <Aapt/>

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -328,9 +328,14 @@ namespace Xamarin.Android.Tasks
 				cmd.AppendSwitchIfNotNull ("-F ", currentResourceOutputFile + ".bk");
 			// The order of -S arguments is *important*, always make sure this one comes FIRST
 			cmd.AppendSwitchIfNotNull ("-S ", resourceDirectory.TrimEnd ('\\'));
-			if (AdditionalResourceDirectories != null)
-				foreach (var resdir in AdditionalResourceDirectories)
-					cmd.AppendSwitchIfNotNull ("-S ", resdir.ItemSpec.TrimEnd ('\\'));
+			if (AdditionalResourceDirectories != null) {
+				foreach (var dir in AdditionalResourceDirectories) {
+					var resdir = dir.ItemSpec.TrimEnd ('\\');
+					if (Directory.Exists (resdir)) {
+						cmd.AppendSwitchIfNotNull ("-S ", resdir);
+					}
+				}
+			}
 			if (AdditionalAndroidResourcePaths != null) {
 				foreach (var dir in AdditionalAndroidResourcePaths) {
 					var resdir = Path.Combine (dir.ItemSpec, "res");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -331,9 +331,14 @@ namespace Xamarin.Android.Tasks
 			if (AdditionalResourceDirectories != null)
 				foreach (var resdir in AdditionalResourceDirectories)
 					cmd.AppendSwitchIfNotNull ("-S ", resdir.ItemSpec.TrimEnd ('\\'));
-			if (AdditionalAndroidResourcePaths != null)
-				foreach (var dir in AdditionalAndroidResourcePaths)
-					cmd.AppendSwitchIfNotNull ("-S ", Path.Combine (dir.ItemSpec.TrimEnd (System.IO.Path.DirectorySeparatorChar), "res"));
+			if (AdditionalAndroidResourcePaths != null) {
+				foreach (var dir in AdditionalAndroidResourcePaths) {
+					var resdir = Path.Combine (dir.ItemSpec, "res");
+					if (Directory.Exists (resdir)) {
+						cmd.AppendSwitchIfNotNull ("-S ", resdir);
+					}
+				}
+			}
 
 			if (LibraryProjectJars != null)
 				foreach (var jar in LibraryProjectJars)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2130,6 +2130,7 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 		}
 
 		[Test]
+		[NonParallelizable] //This test deletes files in CachePath, a shared directory
 		public void ResourceExtraction ([Values (true, false)] bool useAapt2)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
@@ -2141,7 +2142,7 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 			};
 			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
 			proj.SetProperty ("TargetFrameworkVersion", "v5.0");
-			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
+			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
 				var targetAar = Path.Combine (CachePath, "Xamarin.Android.Support.v7.AppCompat", "23.1.1.0",
 					"content", "m2repository", "com", "android", "support", "appcompat-v7", "23.1.1", "appcompat-v7-23.1.1.aar");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2130,14 +2130,16 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 		}
 
 		[Test]
-		public void ResourceExtraction ()
+		public void ResourceExtraction ([Values (true, false)] bool useAapt2)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 				PackageReferences = {
 					KnownPackages.AndroidSupportV4_23_1_1_0,
+					KnownPackages.AndroidSupportCustomTabs_23_1_1_0,
 					KnownPackages.SupportV7AppCompat_23_1_1_0,
 				},
 			};
+			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
 			proj.SetProperty ("TargetFrameworkVersion", "v5.0");
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -94,6 +94,15 @@ namespace Xamarin.ProjectTools
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v13.21.0.3.0\\lib\\MonoAndroid10\\Xamarin.Android.Support.v4.dll" }
 			}
 		};
+		public static Package AndroidSupportCustomTabs_23_1_1_0 = new Package () {
+			Id = "Xamarin.Android.Support.CustomTabs",
+			Version = "23.1.1.0",
+			TargetFramework = "MonoAndroid10",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.CustomTabs") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.CustomTabs.23.1.1.0\\lib\\MonoAndroid403\\Xamarin.Android.Support.CustomTabs.dll" }
+			}
+		};
 		public static Package AndroidWear = new Package () {
 			Id = "Xamarin.Android.Wear",
 			Version = "1.0.0-preview7",


### PR DESCRIPTION
Context: http://build.devdiv.io/2527883

Our integration build for the Xamarin designer has caught a bug in the
following situation:

* macOS-only (Windows is OK)
* `$(AndroidUseAapt2)` is `False`
* Using `Xamarin.Android.Support.CustomTabs` version 23.x

I was able to reproduce the problem by changing the
`BuildTest.ResourceExtraction` test.

The error message is:

    /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Android/Xamarin.Android.Common.targets(1765,2):
        error APT0000: resource directory '/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/ADT-0/RT-MyDriving-1/MyDriving.Android/obj/Debug/resourcecache/3288F845948C6081AB114E82B328E204/res' does not exist

The reason this fails is that this particular library does not have a
`res` directory:

    $ ls -l ~/.local/share/Xamarin/Xamarin.Android.Support.CustomTabs/23.1.1.0/embedded
    total 64
     8 -rw-r--r--  1 jonathanpeppers  staff    861 Mar 26 11:18 AndroidManifest.xml
     0 drwxr-xr-x  3 jonathanpeppers  staff     96 Mar 26 11:18 aapt
    56 -rw-r--r--  1 jonathanpeppers  staff  24743 Mar 26 11:18 classes.jar

The fix is to add a `Directory.Exists` check, this seems to fix the
unit test *and* the failing project used by the designer build.