### PR TITLE
[Xamarin.Android.Build.Tasks] helpers for AsyncTask + TPL

### DIFF
--- a/Documentation/guides/messages/xa0000.md
+++ b/Documentation/guides/messages/xa0000.md
@@ -1,7 +1,27 @@
 # Compiler Error XA0000
 
-This error means you are using a `$(TargetFrameworkVersion)` which cannot be 
-mapped to a valid android api-level. 
+An unhandled exception (or error case) was encountered in one of
+Xamarin.Android's MSBuild tasks.
 
-Check you have selected a valid `$(TargetFrameworkVersion)` and the required
-android api-level is installed in `$(AndroidSdkDirectory)\platforms`.
+Consider submitting a [bug][bug] if you are getting this warning under
+normal circumstances.
+
+[bug]: https://github.com/xamarin/xamarin-android/wiki/Submitting-Bugs,-Feature-Requests,-and-Pull-Requests
+
+## Examples
+
+* An exception was thrown and logged, including a C# exception stack
+  trace showing where the failure occurred.
+
+Solution:
+
+Likely, the only option is to submit a [bug][bug].
+
+* You are using a `$(TargetFrameworkVersion)` which cannot be mapped
+  to a valid android api-level. 
+
+Solution:
+
+Check you have selected a valid `$(TargetFrameworkVersion)` and the
+required android api-level is installed in
+`$(AndroidSdkDirectory)\platforms`.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -12,7 +12,6 @@ using Microsoft.Build.Framework;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using Xamarin.Android.Tools;
-using ThreadingTasks = System.Threading.Tasks;
 using Xamarin.Build;
 
 namespace Xamarin.Android.Tasks
@@ -236,9 +235,7 @@ namespace Xamarin.Android.Tasks
 				resourceDirectory = Path.Combine (WorkingDirectory, resourceDirectory);
 			Yield ();
 			try {
-				var task = ThreadingTasks.Task.Run (() => {
-					DoExecute ();
-				}, CancellationToken);
+				var task = this.RunTask (DoExecute);
 
 				task.ContinueWith (Complete);
 
@@ -256,12 +253,7 @@ namespace Xamarin.Android.Tasks
 
 			assemblyMap.Load (Path.Combine (WorkingDirectory, AssemblyIdentityMapFile));
 
-			ThreadingTasks.ParallelOptions options = new ThreadingTasks.ParallelOptions {
-				CancellationToken = CancellationToken,
-				TaskScheduler = ThreadingTasks.TaskScheduler.Default,
-			};
-
-			ThreadingTasks.Parallel.ForEach (ManifestFiles, options, ProcessManifest);
+			this.ParallelForEach (ManifestFiles, ProcessManifest);
 		}
 
 		protected string GenerateCommandLineCommands (string ManifestFile, string currentAbi, string currentResourceOutputFile)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -12,7 +12,6 @@ using Microsoft.Build.Framework;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using Xamarin.Android.Tools;
-using ThreadingTasks = System.Threading.Tasks;
 
 namespace Xamarin.Android.Tasks {
 	
@@ -81,9 +80,7 @@ namespace Xamarin.Android.Tasks {
 			
 			Yield ();
 			try {
-				var task = ThreadingTasks.Task.Run (() => {
-					DoExecute ();
-				}, CancellationToken);
+				var task = this.RunTask (DoExecute);
 
 				task.ContinueWith (Complete);
 
@@ -102,12 +99,7 @@ namespace Xamarin.Android.Tasks {
 
 				assemblyMap.Load (Path.Combine (WorkingDirectory, AssemblyIdentityMapFile));
 
-				ThreadingTasks.ParallelOptions options = new ThreadingTasks.ParallelOptions {
-					CancellationToken = CancellationToken,
-					TaskScheduler = ThreadingTasks.TaskScheduler.Default,
-				};
-
-				ThreadingTasks.Parallel.ForEach (ManifestFiles, options, ProcessManifest);
+				this.ParallelForEach (ManifestFiles, ProcessManifest);
 			} finally {
 				foreach (var temp in tempFiles) {
 					File.Delete (temp);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -6,8 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
-// using System.Threading.Tasks conflicts with Microsoft.Build.Utilities because of the Task type
-using ThreadingTasks = System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -261,9 +259,7 @@ namespace Xamarin.Android.Tasks
 
 			Yield ();
 			try {
-				var task = ThreadingTasks.Task.Run ( () => {
-					return RunParallelAotCompiler (nativeLibs);
-				}, CancellationToken);
+				var task = this.RunTask (() => RunParallelAotCompiler (nativeLibs));
 
 				task.ContinueWith (Complete);
 
@@ -286,12 +282,7 @@ namespace Xamarin.Android.Tasks
 		bool RunParallelAotCompiler (List<string> nativeLibs)
 		{
 			try {
-				ThreadingTasks.ParallelOptions options = new ThreadingTasks.ParallelOptions {
-					CancellationToken = CancellationToken,
-					TaskScheduler = ThreadingTasks.TaskScheduler.Default,
-				};
-
-				ThreadingTasks.Parallel.ForEach (GetAotConfigs (), options,
+				this.ParallelForEach (GetAotConfigs (),
 					config => {
 						if (!config.Valid) {
 							Cancel ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
@@ -11,7 +11,6 @@ using System.Xml.XPath;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
 
-using TPL = System.Threading.Tasks;
 using Xamarin.Build;
 
 namespace Xamarin.Android.Tasks
@@ -147,15 +146,8 @@ namespace Xamarin.Android.Tasks
 				// is changed!
 				Log.LogDebugMessage ($"Parsing layouts in parallel (threshold of {ParallelGenerationThreshold} layouts met)");
 
-                                TPL.ParallelOptions options = new TPL.ParallelOptions {
-                                        CancellationToken = CancellationToken,
-                                        TaskScheduler = TPL.TaskScheduler.Default,
-                                };
-				TPL.Task.Factory.StartNew (
-					() => TPL.Parallel.ForEach (layoutsByName, options, kvp => ParseAndLoadGroup (layoutsByName, kvp.Key, kvp.Value.InputItems, ref kvp.Value.LayoutBindingItems, ref kvp.Value.LayoutPartialClassItems)),
-					CancellationToken,
-					TPL.TaskCreationOptions.None,
-					TPL.TaskScheduler.Default
+				this.RunTask (
+					() => this.ParallelForEach (layoutsByName, kvp => ParseAndLoadGroup (layoutsByName, kvp.Key, kvp.Value.InputItems, ref kvp.Value.LayoutBindingItems, ref kvp.Value.LayoutPartialClassItems))
 				).ContinueWith (t => Complete ());
 
 				base.Execute ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
@@ -9,7 +9,6 @@ using Microsoft.Build.Framework;
 using System.Text.RegularExpressions;
 using Xamarin.Android.Tools;
 using Xamarin.Android.Tools.Aidl;
-using ThreadingTasks = System.Threading.Tasks;
 using Xamarin.Build;
 
 namespace Xamarin.Android.Tasks
@@ -73,9 +72,7 @@ namespace Xamarin.Android.Tasks
 		{
 			Yield ();
 			try {
-				var task = ThreadingTasks.Task.Run ( () => {
-					DoExecute ();
-				}, CancellationToken);
+				var task = this.RunTask (DoExecute);
 
 				task.ContinueWith (Complete);
 
@@ -97,14 +94,9 @@ namespace Xamarin.Android.Tasks
 			if (!imageFiles.Any ())
 				return;
 
-			ThreadingTasks.ParallelOptions options = new ThreadingTasks.ParallelOptions {
-				CancellationToken = CancellationToken,
-				TaskScheduler = ThreadingTasks.TaskScheduler.Default,
-			};
-
 			var imageGroups = imageFiles.GroupBy (x => Path.GetDirectoryName (Path.GetFullPath (x.ItemSpec)));
 
-			ThreadingTasks.Parallel.ForEach (imageGroups, options, DoExecute);
+			this.ParallelForEach (imageGroups, DoExecute);
 
 			return;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutBindings.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutBindings.cs
@@ -11,7 +11,6 @@ using System.Xml.XPath;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
 
-using TPL = System.Threading.Tasks;
 using Xamarin.Build;
 
 namespace Xamarin.Android.Tasks
@@ -197,15 +196,8 @@ namespace Xamarin.Android.Tasks
 				// is changed!
 				Log.LogDebugMessage ($"Generating binding code in parallel (threshold of {CalculateLayoutCodeBehind.ParallelGenerationThreshold} layouts met)");
 				var fileSet = new ConcurrentBag <string> ();
-                                TPL.ParallelOptions options = new TPL.ParallelOptions {
-                                        CancellationToken = CancellationToken,
-                                        TaskScheduler = TPL.TaskScheduler.Default,
-                                };
-				TPL.Task.Factory.StartNew (
-					() => TPL.Parallel.ForEach (layoutGroups, options, kvp => GenerateSourceForLayoutGroup (generator, kvp.Value, rpath => fileSet.Add (rpath))),
-					CancellationToken,
-					TPL.TaskCreationOptions.None,
-					TPL.TaskScheduler.Default
+				this.RunTask (
+					() => this.ParallelForEach (layoutGroups, kvp => GenerateSourceForLayoutGroup (generator, kvp.Value, rpath => fileSet.Add (rpath)))
 				).ContinueWith (t => Complete ());
 				generatedFilePaths = fileSet;
 			} else {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AsyncTaskExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AsyncTaskExtensions.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xamarin.Build;
+
+namespace Xamarin.Android.Tasks
+{
+	static class AsyncTaskExtensions
+	{
+		/// <summary>
+		/// Calls Parallel.ForEach() with appropriate ParallelOptions and exception handling.
+		/// </summary>
+		public static ParallelLoopResult ParallelForEach<TSource> (this AsyncTask asyncTask, IEnumerable<TSource> source, Action<TSource> body)
+		{
+			var options = ParallelOptions (asyncTask);
+			return Parallel.ForEach (source, options, s => {
+				try {
+					body (s);
+				} catch (Exception exc) {
+					LogErrorAndCancel (asyncTask, exc);
+				}
+			});
+		}
+
+		/// <summary>
+		/// Calls Parallel.ForEach() with appropriate ParallelOptions and exception handling.
+		/// Passes an object the inner method can use for locking. The callback is of the form: (T item, object lockObject)
+		/// </summary>
+		public static ParallelLoopResult ParallelForEachWithLock<TSource> (this AsyncTask asyncTask, IEnumerable<TSource> source, Action<TSource, object> body)
+		{
+			var options = ParallelOptions (asyncTask);
+			var lockObject = new object ();
+			return Parallel.ForEach (source, options, s => {
+				try {
+					body (s, lockObject);
+				} catch (Exception exc) {
+					LogErrorAndCancel (asyncTask, exc);
+				}
+			});
+		}
+
+		static ParallelOptions ParallelOptions (AsyncTask asyncTask) => new ParallelOptions {
+			CancellationToken = asyncTask.CancellationToken,
+			TaskScheduler = TaskScheduler.Default,
+		};
+
+		static void LogErrorAndCancel (AsyncTask asyncTask, Exception exc)
+		{
+			asyncTask.LogCodedError ("XA0000", "Unhandled exception: {0}", exc);
+			asyncTask.Cancel ();
+		}
+
+		/// <summary>
+		/// Calls Task.Run() with a proper CancellationToken.
+		/// </summary>
+		public static Task RunTask (this AsyncTask asyncTask, Action body) => 
+			Task.Run (body, asyncTask.CancellationToken);
+
+
+		/// <summary>
+		/// Calls Task.Run<T>() with a proper CancellationToken.
+		/// </summary>
+		public static Task<TSource> RunTask<TSource> (this AsyncTask asyncTask, Func<TSource> body) => 
+			Task.Run (body, asyncTask.CancellationToken);
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -187,6 +187,7 @@
     <Compile Include="Linker\MonoDroid.Tuner\PreserveJavaExceptions.cs" />
     <Compile Include="Linker\MonoDroid.Tuner\PreserveJavaTypeRegistrations.cs" />
     <Compile Include="Linker\MonoDroid.Tuner\RemoveAttributes.cs" />
+    <Compile Include="Utilities\AsyncTaskExtensions.cs" />
     <Compile Include="Utilities\MSBuildExtensions.cs" />
     <Compile Include="Utilities\ZipArchiveEx.cs" />
     <Compile Include="Mono.Android\ServiceAttribute.Partial.cs" />


### PR DESCRIPTION
Unhandled exceptions from a `Parallel.ForEach` log an exception in
MSBuild such as:

    E:\A\_work\1214\s\bin\Release\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Aapt2.targets(84,3): One or more errors occurred.
        at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
        at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
        at System.Threading.Tasks.Task.Wait()
        at System.Threading.Tasks.Parallel.ForWorker[TLocal](Int32 fromInclusive, Int32 toExclusive, ParallelOptions parallelOptions, Action`1 body, Action`2 bodyWithState, Func`4 bodyWithLocal, Func`1 localInit, Action`1 localFinally)
        at System.Threading.Tasks.Parallel.ForEachWorker[TSource,TLocal](TSource[] array, ParallelOptions parallelOptions, Action`1 body, Action`2 bodyWithState, Action`3 bodyWithStateAndIndex, Func`4 bodyWithStateAndLocal, Func`5 bodyWithEverything, Func`1 localInit, Action`1 localFinally)
        at System.Threading.Tasks.Parallel.ForEachWorker[TSource,TLocal](IEnumerable`1 source, ParallelOptions parallelOptions, Action`1 body, Action`2 bodyWithState, Action`3 bodyWithStateAndIndex, Func`4 bodyWithStateAndLocal, Func`5 bodyWithEverything, Func`1 localInit, Action`1 localFinally)
        at System.Threading.Tasks.Parallel.ForEach[TSource](IEnumerable`1 source, ParallelOptions parallelOptions, Action`1 body)
        at Xamarin.Android.Tasks.Aapt2Compile.DoExecute()
        at Xamarin.Android.Tasks.Aapt2Compile.<Execute>b__15_0()
        at System.Threading.Tasks.Task.InnerInvoke()
        at System.Threading.Tasks.Task.Execute() [E:\A\_work\1214\s\bin\TestRelease\temp\BuildAMassiveApp\App1\App1.csproj]

`One or more errors occurred` is not helpful, and it looks like this
could happen in several places throughout our MSBuild tasks. The only
way to get a better error is to add a `try-catch` and manually log the
exception.

A couple extension methods can simplify where we use the PCL, and fix
this problem at the same time:

* `Parallel.ForEach` -> `this.ParallelForEach()`:
  * Can setup `ParallelOptions` & `CancellationToken`
  * Adds a `try-catch` block that reports `XA0000` on unhandled
    exceptions
  * Calls `AsyncTask.Cancel()` if there is an exception
* `this.ParallelForEachWithLock` passes an `object lockObject` to the
  inner method for any needed locking.
* `Task.Run` -> `this.RunTask()`
  * Sets up the `CancellationToken`

With these extension methods we can also drop this `using` in several
files:

    using ThreadingTasks = System.Threading.Tasks;

It is a bit annoying to have to disambiguate an MSBuild task from a
threading task.