### PR TITLE
[Xamarin.Android.Build.Tasks] Check a jar has .class files in it.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/DetermineJavaLibrariesToCompile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/DetermineJavaLibrariesToCompile.cs
@@ -65,7 +65,9 @@ namespace Xamarin.Android.Tasks
 			var distinct  = MonoAndroidHelper.DistinctFilesByContent (jars);
 
 			var javaLibrariesToCompile = new List<ITaskItem> ();
-			var referenceJavaLibraries = new List<ITaskItem> (ExternalJavaLibraries ?? Enumerable.Empty<ITaskItem> ());
+			var referenceJavaLibraries = new List<ITaskItem> ();
+			if (ExternalJavaLibraries != null)
+				referenceJavaLibraries.AddRange (ExternalJavaLibraries);
 
 			foreach (var item in distinct) {
 				if (!HasClassFiles (item.ItemSpec))

--- a/src/Xamarin.Android.Build.Tasks/Tasks/DetermineJavaLibrariesToCompile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/DetermineJavaLibrariesToCompile.cs
@@ -89,9 +89,7 @@ namespace Xamarin.Android.Tasks
 
 		bool HasClassFiles (string jar)
 		{
-			return Files.ZipContains (jar, (zip)=> {
-				return zip.Any (x => x.FullName.EndsWith (".class", StringComparison.OrdinalIgnoreCase));
-			});
+			return Files.ZipAny (jar, entry => entry.FullName.EndsWith (".class", StringComparison.OrdinalIgnoreCase));
 		}
 
 		bool IsExcluded (string jar)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -390,6 +390,7 @@ namespace Xamarin.Android.Build.Tests
 		protected virtual void CleanupTest ()
 		{
 			TestContext.Out.WriteLine ($"[TESTLOG] Test {TestName} Complete");
+			TestContext.Out.WriteLine ($"[TESTLOG] Test {TestName} Outcome={TestContext.CurrentContext.Result.Outcome.Status}");
 			TestContext.Out.Flush ();
 			if (System.Diagnostics.Debugger.IsAttached || TestContext.CurrentContext.Test.Properties ["Output"] == null)
 					return;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -281,6 +281,13 @@ namespace Xamarin.Android.Tools {
 			return ZipArchive.Open (filename, FileMode.Open, strictConsistencyChecks: strictConsistencyChecks);
 		}
 
+		public static bool ZipContains (string filename, Func<ZipArchive, bool> filter)
+		{
+			using (var zip = ReadZipFile (filename)) {
+				return filter (zip);
+			}
+		}
+
 		public static bool ExtractAll (ZipArchive zip, string destination, Action<int, int> progressCallback = null, Func<string, string> modifyCallback = null,
 			Func<string, bool> deleteCallback = null)
 		{

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -285,7 +285,7 @@ namespace Xamarin.Android.Tools {
 		public static bool ZipAny (string filename, Func<ZipEntry, bool> filter)
 		{
 			using (var zip = ReadZipFile (filename)) {
-				return zip.Any (zip);
+				return zip.Any (filter);
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Security.Cryptography;
 
 using Xamarin.Tools.Zip;
@@ -281,10 +282,10 @@ namespace Xamarin.Android.Tools {
 			return ZipArchive.Open (filename, FileMode.Open, strictConsistencyChecks: strictConsistencyChecks);
 		}
 
-		public static bool ZipContains (string filename, Func<ZipArchive, bool> filter)
+		public static bool ZipAny (string filename, Func<ZipEntry, bool> filter)
 		{
 			using (var zip = ReadZipFile (filename)) {
-				return filter (zip);
+				return zip.Any (zip);
 			}
 		}
 


### PR DESCRIPTION
We have found an issue with our fastdev support when
it comes across a `.jar` file which does NOT contain
any `.class` files.

As part of our fastdev system we convert all the
`.jar` files we need to `.dex` files so they
can be fast deployed.

If we come across a `.jar` file which does not
contain any `.class` files `dx` exists with the
following error

	no classes!

This causes the build to fail. So what we need to do
is check that a `.jar` has `.class` files in it.
This commit also reworks some code to not use Linq
in favour of a standard foreach loop.