### PR TITLE
[Xamarin.Android.Build.Tasks] lock needed in <Aapt2Compile/>

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
@@ -18,6 +18,7 @@ namespace Xamarin.Android.Tasks {
 	
 	public class Aapt2Compile : Aapt2 {
 
+		readonly object lockObject = new object ();
 		List<ITaskItem> archives = new List<ITaskItem> ();
 
 		public bool ExplicitCrunch { get; set; }
@@ -75,7 +76,8 @@ namespace Xamarin.Android.Tasks {
 			var outputArchive = Path.Combine (FlatArchivesDirectory, $"{filename}.flata");
 			var success = RunAapt (GenerateCommandLineCommands (resourceDirectory, outputArchive), output);
 			if (success && File.Exists (Path.Combine (WorkingDirectory, outputArchive))) {
-				archives.Add (new TaskItem (outputArchive));
+				lock (lockObject)
+					archives.Add (new TaskItem (outputArchive));
 			}
 			foreach (var line in output) {
 				if (line.StdError) {


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/2881
Context: http://build.devdiv.io/2531303

I have noticed a random failure in our MSBuild tests such as:

    E:\A\_work\1214\s\bin\Release\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Aapt2.targets(84,3): One or more errors occurred.
        at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
        at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
        at System.Threading.Tasks.Task.Wait()
        at System.Threading.Tasks.Parallel.ForWorker[TLocal](Int32 fromInclusive, Int32 toExclusive, ParallelOptions parallelOptions, Action`1 body, Action`2 bodyWithState, Func`4 bodyWithLocal, Func`1 localInit, Action`1 localFinally)
        at System.Threading.Tasks.Parallel.ForEachWorker[TSource,TLocal](TSource[] array, ParallelOptions parallelOptions, Action`1 body, Action`2 bodyWithState, Action`3 bodyWithStateAndIndex, Func`4 bodyWithStateAndLocal, Func`5 bodyWithEverything, Func`1 localInit, Action`1 localFinally)
        at System.Threading.Tasks.Parallel.ForEachWorker[TSource,TLocal](IEnumerable`1 source, ParallelOptions parallelOptions, Action`1 body, Action`2 bodyWithState, Action`3 bodyWithStateAndIndex, Func`4 bodyWithStateAndLocal, Func`5 bodyWithEverything, Func`1 localInit, Action`1 localFinally)
        at System.Threading.Tasks.Parallel.ForEach[TSource](IEnumerable`1 source, ParallelOptions parallelOptions, Action`1 body)
        at Xamarin.Android.Tasks.Aapt2Compile.DoExecute()
        at Xamarin.Android.Tasks.Aapt2Compile.<Execute>b__15_0()
        at System.Threading.Tasks.Task.InnerInvoke()
        at System.Threading.Tasks.Task.Execute() [E:\A\_work\1214\s\bin\TestRelease\temp\BuildAMassiveApp\App1\App1.csproj]

So an exception during `Parallel.ForEach` isn't logged in a nice way
at all with MSBuild...

Additionally, the `aapt2 compile` calls before this do not list any
errors...

So with #2881, I added `try-catch` to log the inner exception:

    Unhandled exception: System.IndexOutOfRangeException: Index was outside the bounds of the array.
        at System.Collections.Generic.List`1.Add(T item)
        at Xamarin.Android.Tasks.Aapt2Compile.ProcessDirectory(ITaskItem resourceDirectory)

That is when I spotted the issue:

* Running `Parallel.ForEach` on `ProcessDirectory`
* Parallel calls to `archives.Add()`, where `archives` is a
  `List<ITaskItem>` instance variable in the MSBuild task.

The simple fix here is to put a `lock(foo)` around the `.Add()` call.

I will improve the error logging in #2881.