### PR TITLE
[installer] Install `Xamarin.Build.AsyncTask.dll`

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -117,6 +117,7 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.Bytecode.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.JavaDocImporter.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.VisualBasic.targets" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Build.AsyncTask.dll" />
   </ItemGroup>
   <ItemGroup>
     <_MSBuildTargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\Xamarin.Android.Bindings.After.targets" />


### PR DESCRIPTION
Commit f80a641c broke the installers, as it added a dependency on
`Xamarin.Build.AsyncTask.dll` to `Xamarin.Android.Build.Tasks.dll`,
but forgot to install `Xamarin.Build.AsyncTask.dll` to the installer.

The result is that the installation is unusable:

	error MSB4062: The "Xamarin.Android.Tasks.ResolveSdks" task could not be loaded from the assembly …/Xamarin/Android/Xamarin.Android.Build.Tasks.dll. Exception of type 'System.Reflection.ReflectionTypeLoadException' was thrown.
	error MSB4062: Could not load file or assembly 'Xamarin.Build.AsyncTask, Version=0.3.4.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies.

Add `Xamarin.Build.AsyncTask.dll` to the installation.