### PR TITLE
[tests] Fix a typo which supressed the AOT test runs

### DIFF
--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -117,7 +117,7 @@
       <_ExeExtension></_ExeExtension>
       <_HostOS Condition=" '$(_HostOS)' == 'Windows' "></_HostOS>
       <_ExeExtension Condition=" '$(_HostOS)' == 'Windows' ">.exe</_ExeExtension>
-      <_CrossCompilerAvailable Condition="Exists('$(_TopDir)\bin\$(Configuration)\lib\xamarin-android\xbuild\Xamarin\Android\$(_HostOS)\cross-arm$(_ExeExtension)')">True</_CrossCompilerAvailable>
+      <_CrossCompilerAvailable Condition="Exists('$(_TopDir)\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\$(_HostOS)\cross-arm$(_ExeExtension)')">True</_CrossCompilerAvailable>
       <_CrossCompilerAvailable Condition=" '$(_CrossCompilerAvailable)' == '' ">False</_CrossCompilerAvailable>
     </PropertyGroup>
     <ItemGroup Condition=" '$(USE_MSBUILD)' == '1' ">


### PR DESCRIPTION
The
https://github.com/xamarin/xamarin-android/commit/e22345162a25a7aa9d1ca35c590253d5462e9660
made the AOT tests conditional. Unfortunately it contained a typo in
the path, which prevented the AOT runs, because the condition was
always resolved as False.