### PR TITLE
[create-bundle] Include satellite assemblies

### DIFF
--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -69,6 +69,7 @@
     <_BclExcludeDebugSymbols  Include="System.Windows.dll" />
     <_BclExcludeDebugSymbols  Include="System.Xml.Serialization.dll" />
     <_BclTestAssemblyDestination  Include="@(MonoTestAssembly->'$(XAInstallPrefix)\..\..\bcl-tests\%(Identity)')" />
+    <_BclTestAssemblyDestination  Include="@(MonoTestSatelliteAssembly->'$(XAInstallPrefix)\..\..\bcl-tests\%(Identity)')" />
     <_BclTestAssemblyDestination
         Include="@(MonoTestAssembly->'$(XAInstallPrefix)\..\..\bcl-tests\%(Filename).pdb')"
         Exclude="$(XAInstallPrefix)\..\..\bcl-tests\System.Runtime.CompilerServices.Unsafe.pdb"
@@ -290,6 +291,18 @@
           Include="$(_OutputIncludeDir)Consts.cs"
       />
     </ItemGroup>
+    <ItemGroup>
+      <_BclTestAssemblyReference Include="@(MonoTestAssembly)" Condition="'%(MonoTestAssembly.TestType)' == 'reference'" />
+      <_BclTestAssembly  Include="@(MonoTestAssembly)" Condition="'%(MonoTestAssembly.TestType)' == '' Or '%(MonoTestAssembly.TestType)' == 'xunit' " />
+      <_BclTestAssemblySource Include="@(_BclTestAssemblyReference->'$(_MonoProfileDir)\%(Identity)')" />
+      <_BclTestAssemblySource Include="@(_BclTestAssemblyReference->'$(_MonoProfileDir)\%(Filename).pdb')" Condition="Exists('@(_BclTestAssemblyReference->'$(_MonoProfileDir)\%(Filename).pdb')')" />
+      <_BclTestAssemblySource Include="@(_BclTestAssembly->'$(_MonoProfileDir)\tests\%(Identity)')" />
+      <_BclTestAssemblySource Include="@(_BclTestAssembly->'$(_MonoProfileDir)\tests\%(Filename).pdb')" />
+      <_BclTestAssemblySource Include="@(MonoTestRunner->'$(_MonoProfileDir)\%(Identity)')" />
+      <_BclTestAssemblySource Include="@(MonoTestRunner->'$(_MonoProfileDir)\%(Filename).pdb')" />
+      <_BclTestSatelliteAssemblySource  Include="@(MonoTestSatelliteAssembly->'$(_MonoProfileDir)\tests\%(Identity)')" />
+      <_BclTestSatelliteAssemblyDest    Include="@(MonoTestSatelliteAssembly->'$(XAInstallPrefix)\..\..\bcl-tests\%(Identity)')" />
+    </ItemGroup>
   </Target>
 
   <Target Name="_DownloadArchive"
@@ -341,20 +354,8 @@
 
   <Target Name="_InstallRuntimes"
       DependsOnTargets="_GetRuntimesOutputItems"
-      Inputs="@(_RuntimeSource);@(_RuntimeBinarySource);@(_CrossRuntimeBinarySource);@(_ProfilerSource);@(_MonoPosixHelperSource);@(_RuntimeEglibHeaderSource);@(_MonoBtlsSource)"
-      Outputs="@(_InstallRuntimeOutput);@(_InstallRuntimeBinaryOutput);@(_InstallCrossRuntimeBinaryOutput);@(_InstallProfilerOutput);@(_InstallMonoPosixHelperOutput);@(_RuntimeEglibHeaderOutput)">
-    <ItemGroup>
-      <_BclTestAssemblyReference Include="@(MonoTestAssembly)" Condition="'%(MonoTestAssembly.TestType)' == 'reference'" />
-      <_BclTestAssembly  Include="@(MonoTestAssembly)" Condition="'%(MonoTestAssembly.TestType)' == '' Or '%(MonoTestAssembly.TestType)' == 'xunit' " />
-      <_BclTestAssemblySource Include="@(_BclTestAssemblyReference->'$(_MonoProfileDir)\%(Identity)')" />
-      <_BclTestAssemblySource Include="@(_BclTestAssemblyReference->'$(_MonoProfileDir)\%(Filename).pdb')" Condition="Exists('@(_BclTestAssemblyReference->'$(_MonoProfileDir)\%(Filename).pdb')')" />
-      <_BclTestAssemblySource Include="@(_BclTestAssembly->'$(_MonoProfileDir)\tests\%(Identity)')" />
-      <_BclTestAssemblySource Include="@(_BclTestAssembly->'$(_MonoProfileDir)\tests\%(Filename).pdb')" />
-      <_BclTestAssemblySource Include="@(MonoTestRunner->'$(_MonoProfileDir)\%(Identity)')" />
-      <_BclTestAssemblySource Include="@(MonoTestRunner->'$(_MonoProfileDir)\%(Filename).pdb')" />
-      <_BclTestSatelliteAssemblySource  Include="@(MonoTestSatelliteAssembly->'$(_MonoProfileDir)\tests\%(Identity)')" />
-      <_BclTestSatelliteAssemblyDest    Include="@(MonoTestSatelliteAssembly->'$(XAInstallPrefix)\..\..\bcl-tests\%(Identity)')" />
-    </ItemGroup>
+      Inputs="@(_BclTestAssemblySource);@(_BclTestSatelliteAssemblySource);@(_RuntimeSource);@(_RuntimeBinarySource);@(_CrossRuntimeBinarySource);@(_ProfilerSource);@(_MonoPosixHelperSource);@(_RuntimeEglibHeaderSource);@(_MonoBtlsSource)"
+      Outputs="@(_BclTestSatelliteAssemblyDest);@(_InstallRuntimeOutput);@(_InstallRuntimeBinaryOutput);@(_InstallCrossRuntimeBinaryOutput);@(_InstallProfilerOutput);@(_InstallMonoPosixHelperOutput);@(_RuntimeEglibHeaderOutput)">
     <Copy
         SourceFiles="@(_BclTestAssemblySource)"
         DestinationFolder="$(XAInstallPrefix)\..\..\bcl-tests"


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/406/
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/407/

Commit 333b98b3 inadvertently broke all subsequent commits:

	xamarin-android/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets(15,5):
	error MSB3030: Could not copy the file "../../../bin/Release/bcl-tests/es-ES/monodroid_corlib_test.resources.dll" because it was not found.

Note, however, that commit 333b98b3 *itself* [built][0].

What went wrong is that the `_InstallRuntimes` target within
`src/mono-runtimes/mono-runtimes.targets` wouldn't consistently copy
the unit test satellite assemblies from the mono archive into the
build tree, nor -- more importantly! -- include the satellite
assemblies into the mono bundle, because the satellite assemblies
weren't added to `@(_BclTestAssemblyDestination)`/`@(_BclTestOutput)`
/`@(BundleItem).

Without being included into the mono bundle, the
`Xamarin.Android.Bcl-Tests.csproj` could not build.

(Commit 333b98b3 *itself* built because it was responsible for
*creating* the mono bundle, not using it, and as part of the "prep
work" it copied `es-ES/monodroid_corlib_test.resources.dll` into the
expected directory, but neglected to include it into the bundle.)

Update `src/mono-runtimes/mono-runtimes.targets` so that
`@(MonoTestSatelliteAssembly)` are included into the bundle, and
update the `_InstallRuntimes` target so that the test assemblies and
related files are considered as Inputs & Outputs.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/404/