### PR TITLE
[Xamarin.Android.Build.Tests] Add framework for Commercial Builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -508,7 +508,7 @@ namespace UnnamedProject
 		};
 
 		[Test]
-		[TestCaseSource("ReleaseLanguage")]
+		[TestCaseSource(nameof (ReleaseLanguage))]
 		public void CheckResourceDesignerIsCreated (bool isRelease, ProjectLanguage language)
 		{
 			//Due to the MSBuild project automatically sorting <ItemGroup />, we can't possibly get the F# projects to build here on Windows
@@ -535,7 +535,7 @@ namespace UnnamedProject
 		}
 
 		[Test]
-		[TestCaseSource("ReleaseLanguage")]
+		[TestCaseSource(nameof (ReleaseLanguage))]
 		public void CheckResourceDesignerIsUpdatedWhenReadOnly (bool isRelease, ProjectLanguage language)
 		{
 			//Due to the MSBuild project automatically sorting <ItemGroup />, we can't possibly get the F# projects to build here on Windows
@@ -577,7 +577,7 @@ namespace UnnamedProject
 		}
 
 		[Test]
-		[TestCaseSource("ReleaseLanguage")]
+		[TestCaseSource(nameof (ReleaseLanguage))]
 		public void CheckOldResourceDesignerIsNotUsed (bool isRelease, ProjectLanguage language)
 		{
 			if (language == XamarinAndroidProjectLanguage.FSharp)
@@ -608,7 +608,7 @@ namespace UnnamedProject
 
 		// ref https://bugzilla.xamarin.com/show_bug.cgi?id=30089
 		[Test]
-		[TestCaseSource("ReleaseLanguage")]
+		[TestCaseSource(nameof (ReleaseLanguage))]
 		public void CheckOldResourceDesignerWithWrongCasingIsRemoved (bool isRelease, ProjectLanguage language)
 		{
 			if (language == XamarinAndroidProjectLanguage.FSharp)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Android.Build.Tests
 		};
 
 		[Test]
-		[TestCaseSource ("ClassParseOptions")]
+		[TestCaseSource (nameof (ClassParseOptions))]
 		public void BuildBasicBindingLibrary (string classParser)
 		{
 			var proj = new XamarinAndroidBindingProject () {
@@ -46,7 +46,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[TestCaseSource ("ClassParseOptions")]
+		[TestCaseSource (nameof (ClassParseOptions))]
 		public void CleanBasicBindingLibrary (string classParser)
 		{
 			var proj = new XamarinAndroidBindingProject () {
@@ -69,7 +69,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[TestCaseSource ("ClassParseOptions")]
+		[TestCaseSource (nameof (ClassParseOptions))]
 		public void BuildAarBindigLibraryStandalone (string classParser)
 		{
 			var proj = new XamarinAndroidBindingProject () {
@@ -87,7 +87,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[TestCaseSource ("ClassParseOptions")]
+		[TestCaseSource (nameof (ClassParseOptions))]
 		public void BuildAarBindigLibraryWithNuGetPackageOfJar (string classParser)
 		{
 			var proj = new XamarinAndroidBindingProject () {
@@ -112,7 +112,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[TestCaseSource ("ClassParseOptions")]
+		[TestCaseSource (nameof (ClassParseOptions))]
 		public void BuildLibraryZipBindigLibraryWithAarOfJar (string classParser)
 		{
 			var proj = new XamarinAndroidBindingProject () {
@@ -462,7 +462,7 @@ AAAA==";
 		}
 
 		[Test]
-		[TestCaseSource ("ClassParseOptions")]
+		[TestCaseSource (nameof (ClassParseOptions))]
 		public void DesignTimeBuild (string classParser)
 		{
 			var proj = new XamarinAndroidBindingProject {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.OSS.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.OSS.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Android.Build.Tests
 	public partial class BuildTest : BaseTest
 	{
 #pragma warning disable 414
-		static object [] AotChecks = new object [] {
+		static object [] AotChecks () => new object [] {
 			new object[] {
 				/* supportedAbis */   "armeabi-v7a",
 				/* enableLLVM */      false,
@@ -53,16 +53,9 @@ namespace Xamarin.Android.Build.Tests
 				/* enableLLVM */      true,
 				/* expectedResult */  true,
 			},
-		};
-
-		static object [] TakeSimpleFlag = new object [] {
-			new Object [] { false },
-			// Disabled because Jack DOESN'T work
-			// re-enable once it does.
-			//new Object [] { true },
 		};
 		// useJackAndJill, useLatestSdk
-		static object [] JackFlagAndFxVersion = new object [] {
+		static object [] JackFlagAndFxVersion () => new object [] {
 			new Object [] { false, "v7.1" },
 			// Disabled because Jack DOESN'T work
 			// re-enable once it does.
@@ -70,7 +63,7 @@ namespace Xamarin.Android.Build.Tests
 			//new Object [] { true, true },
 		};
 
-		static object [] RuntimeChecks = new object [] {
+		static object [] RuntimeChecks () => new object [] {
 			new object[] {
 				/* supportedAbi */     new string[] { "armeabi-v7a"},
 				/* debugSymbols */     true ,
@@ -137,7 +130,7 @@ namespace Xamarin.Android.Build.Tests
 			},
 		};
 
-		static object [] SequencePointChecks = new object [] {
+		static object [] SequencePointChecks () => new object [] {
 			new object[] {
 				/* isRelease */          false,
 				/* monoSymbolArchive */  false ,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -667,7 +667,7 @@ namespace UnamedProject
 		}
 
 		[Test]
-		[TestCaseSource ("AotChecks")]
+		[TestCaseSource (nameof (AotChecks))]
 		[Category ("Minor")]
 		public void BuildAotApplication (string supportedAbis, bool enableLLVM, bool expectedResult)
 		{
@@ -738,7 +738,7 @@ namespace UnamedProject
 		}
 
 		[Test]
-		[TestCaseSource ("AotChecks")]
+		[TestCaseSource (nameof (AotChecks))]
 		[Category ("Minor")]
 		public void BuildAotApplicationAndBundle (string supportedAbis, bool enableLLVM, bool expectedResult)
 		{
@@ -864,7 +864,7 @@ namespace UnamedProject
 		}
 
 		[Test]
-		[TestCaseSource ("JackFlagAndFxVersion")]
+		[TestCaseSource (nameof (JackFlagAndFxVersion))]
 		public void BuildMultiDexApplication (bool useJackAndJill, string fxVersion)
 		{
 			var proj = CreateMultiDexRequiredApplication ();
@@ -1606,7 +1606,7 @@ namespace App1
 #pragma warning restore 414
 
 		[Test]
-		[TestCaseSource ("AndroidStoreKeyTests")]
+		[TestCaseSource (nameof (AndroidStoreKeyTests))]
 		public void TestAndroidStoreKey (bool isRelease, string androidKeyStore, string expected)
 		{
 			byte [] data;
@@ -1647,7 +1647,7 @@ namespace App1
 #pragma warning restore 414
 
 		[Test]
-		[TestCaseSource ("BuildApplicationWithJavaSourceChecks")]
+		[TestCaseSource (nameof (BuildApplicationWithJavaSourceChecks))]
 		public void BuildApplicationWithJavaSource (bool isRelease, bool expectedResult)
 		{
 			var path = String.Format ("temp/BuildApplicationWithJavaSource_{0}_{1}",
@@ -1678,7 +1678,7 @@ namespace App1
 		}
 
 		[Test]
-		[TestCaseSource ("RuntimeChecks")]
+		[TestCaseSource (nameof (RuntimeChecks))]
 		public void CheckWhichRuntimeIsIncluded (string[] supportedAbi, bool debugSymbols, string debugType, bool? optimize, bool? embedassebmlies, string expectedRuntime) {
 			var proj = new XamarinAndroidApplicationProject ();
 			proj.SetProperty (proj.ActiveConfigurationProperties, "DebugSymbols", debugSymbols);
@@ -1718,7 +1718,7 @@ namespace App1
 		}
 
 		[Test]
-		[TestCaseSource ("SequencePointChecks")]
+		[TestCaseSource (nameof (SequencePointChecks))]
 		public void CheckSequencePointGeneration (bool isRelease, bool monoSymbolArchive, bool aotAssemblies,
 			bool debugSymbols, string debugType, bool embedMdb, string expectedRuntime)
 		{
@@ -2248,7 +2248,7 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 #pragma warning restore 414
 
 		[Test]
-		[TestCaseSource ("GeneratorValidateEventNameArgs")]
+		[TestCaseSource (nameof (GeneratorValidateEventNameArgs))]
 		public void GeneratorValidateEventName (bool failureExpected, bool warningExpected, string metadataFixup, string methodArgs)
 		{
 			string java = @"
@@ -2318,7 +2318,7 @@ public class Test
 #pragma warning restore 414
 
 		[Test]
-		[TestCaseSource ("GeneratorValidateMultiMethodEventNameArgs")]
+		[TestCaseSource (nameof (GeneratorValidateMultiMethodEventNameArgs))]
 		public void GeneratorValidateMultiMethodEventName (bool failureExpected, string expectedWarning, string metadataFixup, string methodArgs)
 		{
 			string java = @"
@@ -2523,7 +2523,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 
 
 		[Test]
-		[TestCaseSource ("TlsProviderTestCases")]
+		[TestCaseSource (nameof (TlsProviderTestCases))]
 		public void BuildWithTlsProvider (string androidTlsProvider, bool isRelease, bool expected)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
@@ -3008,7 +3008,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 #pragma warning restore 414
 
 		[Test]
-		[TestCaseSource ("validateJavaVersionTestCases")]
+		[TestCaseSource (nameof (validateJavaVersionTestCases))]
 		public void ValidateJavaVersion (string targetFrameworkVersion, string buildToolsVersion, string javaVersion, string latestSupportedJavaVersion, bool expectedResult) 
 		{
 			var path = Path.Combine ("temp", $"ValidateJavaVersion_{targetFrameworkVersion}_{buildToolsVersion}_{latestSupportedJavaVersion}_{javaVersion}");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -395,7 +395,7 @@ namespace Bug12935
 		};
 
 		[Test]
-		[TestCaseSource("VersionCodeTestSource")]
+		[TestCaseSource(nameof (VersionCodeTestSource))]
 		public void VersionCodeTests (bool seperateApk, string abis, string versionCode, bool useLegacy, string versionCodePattern, string versionCodeProperties, bool shouldBuild, string expectedVersionCode)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
@@ -475,7 +475,7 @@ namespace Bug12935
 		}
 
 		[Test]
-		[TestCaseSource ("DebuggerAttributeCases")]
+		[TestCaseSource (nameof (DebuggerAttributeCases))]
 		public void DebuggerAttribute (string debugType, bool isRelease, bool expected)
 		{
 			var proj = new XamarinAndroidApplicationProject () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CopyResourceTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CopyResourceTests.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Android.Build.Tests
 		};
 
 		[Test]
-		[TestCaseSource ("EmbeddedResources")]
+		[TestCaseSource (nameof (EmbeddedResources))]
 		public void FilesThatAreExpected (string resourceName)
 		{
 			var task = new CopyResource {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -28,6 +28,11 @@ namespace Xamarin.Android.Build.Tests
 				private set;
 			}
 
+			public static bool CommercialBuildAvailable {
+				get;
+				private set;
+			}
+
 			[OneTimeSetUp]
 			public void BeforeAllTests ()
 			{
@@ -52,6 +57,9 @@ namespace Xamarin.Android.Build.Tests
 					}
 				} catch (Exception ex) {
 					Console.Error.WriteLine ("Failed to determine whether there is Android target emulator or not: " + ex);
+				}
+				using (var builder = new Builder ()) {
+					CommercialBuildAvailable = File.Exists (Path.Combine (builder.AndroidMSBuildDirectory, "Xamarin.Android.Common.Debugging.targets"));
 				}
 			}
 
@@ -108,6 +116,8 @@ namespace Xamarin.Android.Build.Tests
 				return Path.GetFullPath (XABuildPaths.TestOutputDirectory);
 			}
 		}
+
+		public bool CommercialBuildAvailable => SetUp.CommercialBuildAvailable;
 
 		char [] invalidChars = { '{', '}', '(', ')', '$', ':', ';', '\"', '\'', ',', '=' };
 


### PR DESCRIPTION
We want to move all of our unit tests into one place.
This means that tests now need to know if they are
running against a Open Source build or a Commercial
build.

We detect that by looking for the
`Xamarin.Android.Common.Debugging.targets` in the
Android MSBuild directory.

We also change over the TestCaseSource in the
`BuildTest.OSS.cs` to be methods rather than
properties. This is so we can (in the future)
dynamically update the items to test both the
Open Source and Commercial build behavour.
There are differences between the two builds
(like fastdev) so the test cases are not always
the same.

We also updated ALL the `TestCaseSource` attributes
to name use of `nameof` rather than strings.