### PR TITLE
[tests] Add TestsFlavor parameter to RenameTestCases task

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 	{
 		public                  bool                DeleteSourceFiles           { get; set; }
 		public                  string              Configuration               { get; set; }
+		public                  string              TestsFlavor                 { get; set; }
 		[Required]
 		public                  string              SourceFile                  { get; set; }
 		[Required]
@@ -43,7 +44,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			catch (Exception e) {
 				Log.LogWarning ($"Unable to process `{SourceFile}`.  Is it empty?  (Did a unit test runner SIGSEGV?)");
 				Log.LogWarningFromException (e);
-				CreateErrorResultsFile (SourceFile, dest, Configuration, e, m => {
+				CreateErrorResultsFile (SourceFile, dest, Configuration, TestsFlavor, e, m => {
 						Log.LogMessage (MessageImportance.Low, m);
 				});
 			}
@@ -105,9 +106,9 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 	partial class RenameTestCases {
 
-		static void CreateErrorResultsFile (string sourceFile, string destFile, string config, Exception e, Action<string> logDebugMessage)
+		static void CreateErrorResultsFile (string sourceFile, string destFile, string config, string flavor, Exception e, Action<string> logDebugMessage)
 		{
-			GetTestCaseInfo (sourceFile, Path.GetDirectoryName (destFile), config, logDebugMessage, out var testSuiteName, out var testCaseName, out var logcatPath);
+			GetTestCaseInfo (sourceFile, Path.GetDirectoryName (destFile), config, flavor, logDebugMessage, out var testSuiteName, out var testCaseName, out var logcatPath);
 			var contents  = new StringBuilder ();
 			if (File.Exists (sourceFile)) {
 				contents.Append (File.ReadAllText (sourceFile));
@@ -156,14 +157,14 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		//   /Users/builder/jenkins/workspace/xamarin-android-pr-builder-release/xamarin-android/bin/TestRelease/logcat-Release-Mono.Android_Tests.txt
 		//
 		// We need to extract the "base" test name from `SourceFile`, and use that to construct `logcatPath`
-		static void GetTestCaseInfo (string sourceFile, string destinationFolder, string config, Action<string> logDebugMessage, out string testSuiteName, out string testCaseName, out string logcatPath)
+		static void GetTestCaseInfo (string sourceFile, string destinationFolder, string config, string flavor, Action<string> logDebugMessage, out string testSuiteName, out string testCaseName, out string logcatPath)
 		{
 			var name        = Path.GetFileNameWithoutExtension (sourceFile);
 			if (name.StartsWith ("TestResult-"))
 				name    = name.Substring ("TestResult-".Length);
 			testSuiteName   = name;
 			testCaseName    = $"Possible Crash / {config}";
-			logcatPath      = Path.Combine (destinationFolder, "bin", $"Test{config}", $"logcat-{config}-{name}.txt");
+			logcatPath      = Path.Combine (destinationFolder, "bin", $"Test{config}", $"logcat-{config}{flavor}-{name}.txt");
 			logDebugMessage ($"Looking for `adb logcat` output in the file: {logcatPath}");
 			if (!File.Exists (logcatPath)) {
 				logDebugMessage ($"Could not find file `{logcatPath}`.  Will not be including `adb logcat` output.");
@@ -191,7 +192,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			string destFile       = args [0];
 			string sourceFile     = args.Length > 1 ? args [1] : "source.xml";
 			string config         = args.Length > 2 ? args [2] : "Debug";
-			CreateErrorResultsFile (sourceFile, destFile, config, new Exception ("Wee!!!"), Console.WriteLine);
+			CreateErrorResultsFile (sourceFile, destFile, config, "", new Exception ("Wee!!!"), Console.WriteLine);
 		}
 	}
 #endif  // APP

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -263,10 +263,11 @@
       Condition=" '@(TestApk)' != '' ">
     <RenameTestCases
         Condition=" '%(TestApkInstrumentation.ResultsPath)' != '' "
-        Configuration="$(Configuration)$(TestsFlavor)"
+        Configuration="$(Configuration)"
         DeleteSourceFiles="True"
         DestinationFolder="$(MSBuildThisFileDirectory)..\.."
         SourceFile="%(TestApkInstrumentation.ResultsPath)"
+        TestsFlavor="$(TestsFlavor)"
     />
   </Target>
   <Target Name="RecordApkSizes"


### PR DESCRIPTION
After adding more logging in
https://github.com/xamarin/xamarin-android/commit/a6eb47aea, it turned
out that the path to the logcat file is wrong. Note the directory of
the logcat in the following log message:

    Could not find file `/Users/builder/jenkins/workspace/xamarin-android-pr-pipeline-release/xamarin-android/build-tools/scripts/../../bin/TestRelease-Profiled-Aot/logcat-Release-Profiled-Aot-Mono.Android_Tests.txt`.  Will not be including `adb logcat` output.

The `bin/TestRelease-Profiled-Aot/` part should be `bin/TestRelease/`
instead.

This patch changes it so, that we pass `Configuration` and
`TestsFlavor` separately to the task and the logcat path should now be
correct.