### PR TITLE
[Xamarin.Android.Build.Tasks] Support Filtering Assemblies

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
@@ -105,10 +105,11 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   </ItemGroup>
 </Target>
 
-<Target Name="_CompileResources"
+<Target Name="_ConvertResourcesCases"
     Condition=" '$(_AndroidUseAapt2)' == 'True' "
     Inputs="@(AndroidResource)"
-    Outputs="$(_AndroidLibraryFlatArchivesDirectory)\compiled.stamp"
+    Outputs="$(_AndroidStampDirectory)_ConvertResourcesCases.stamp"
+    DependsOnTargets="$(_BeforeConvertResourcesCases)"
   >
   <MakeDir Directories="$(_AndroidLibraryFlatArchivesDirectory)" Condition="!Exists('$(_AndroidLibraryFlatArchivesDirectory)')" />
   <!-- Change cases so we support mixed case resource names -->
@@ -116,11 +117,20 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       ContinueOnError="$(DesignTimeBuild)"
       AcwMapFile="$(_AcwMapFile)"
       AdditionalResourceDirectories="@(_LibraryResourceDirectories)"
-      AndroidConversionFlagFile="$(_AndroidLibraryFlatArchivesDirectory)\compiled.flata"
+      AndroidConversionFlagFile="$(_AndroidStampDirectory)_ConvertResourcesCases.stamp"
       CustomViewMapFile="$(_CustomViewMapFile)"
       ResourceDirectories="$(MonoAndroidResDirIntermediate)"
       ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
   />
+  <Touch Files="$(_AndroidStampDirectory)_ConvertResourcesCases.stamp" AlwaysCreate="True" />
+</Target>
+
+<Target Name="_CompileResources"
+    Condition=" '$(_AndroidUseAapt2)' == 'True' "
+    Inputs="@(AndroidResource)"
+    Outputs="$(_AndroidLibraryFlatArchivesDirectory)\_CompileResources.stamp"
+    DependsOnTargets="$(_BeforeCompileResources);_ConvertResourcesCases"
+  >
   <Aapt2Compile
       ContinueOnError="$(DesignTimeBuild)"
       ExplicitCrunch="$(AndroidExplicitCrunch)"
@@ -131,10 +141,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       ToolPath="$(Aapt2ToolPath)"
       ToolExe="$(Aapt2ToolExe)"
   />
-  <Touch Files="$(_AndroidLibraryFlatArchivesDirectory)\compiled.stamp" AlwaysCreate="True" />
+  <Touch Files="$(_AndroidLibraryFlatArchivesDirectory)\_CompileResources.stamp" AlwaysCreate="True" />
   <ItemGroup>
     <FileWrites Include="$(_AndroidLibraryFlatArchivesDirectory)\compiled.flata" />
-    <FileWrites Include="$(_AndroidLibraryFlatArchivesDirectory)\compiled.stamp" />
   </ItemGroup>
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -235,7 +235,10 @@ namespace Xamarin.Android.Tasks
 
 			int count = 0;
 			foreach (ITaskItem assembly in ResolvedUserAssemblies) {
-
+				if (bool.TryParse (assembly.GetMetadata ("AndroidSkipAddToPackage"), out bool value) && value) {
+					Log.LogDebugMessage ($"Skipping {assembly.ItemSpec} due to 'AndroidSkipAddToPackage' == 'true' ");
+					continue;
+				}
 				if (MonoAndroidHelper.IsReferenceAssembly (assembly.ItemSpec)) {
 					Log.LogCodedWarning ("XA0107", assembly.ItemSpec, 0, "{0} is a Reference Assembly!", assembly.ItemSpec);
 				}
@@ -271,6 +274,10 @@ namespace Xamarin.Android.Tasks
 			count = 0;
 			// Add framework assemblies
 			foreach (ITaskItem assembly in ResolvedFrameworkAssemblies) {
+				if (bool.TryParse (assembly.GetMetadata ("AndroidSkipAddToPackage"), out bool value) && value) {
+					Log.LogDebugMessage ($"Skipping {assembly.ItemSpec} due to 'AndroidSkipAddToPackage' == 'true' ");
+					continue;
+				}
 				if (MonoAndroidHelper.IsReferenceAssembly (assembly.ItemSpec)) {
 					Log.LogCodedWarning ("XA0107", assembly.ItemSpec, 0, "{0} is a Reference Assembly!", assembly.ItemSpec);
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -52,10 +52,10 @@ namespace Xamarin.Android.Tasks
 		void FixupResources (Dictionary<string, string> acwMap)
 		{
 			foreach (var dir in ResourceDirectories) {
-				var skipResourceProcessing = dir.GetMetadata (ResolveLibraryProjectImports.SkipAndroidResourceProcessing);
+				var skipResourceProcessing = dir.GetMetadata (ResolveLibraryProjectImports.AndroidSkipResourceProcessing);
 				if (skipResourceProcessing != null && skipResourceProcessing.Equals ("true", StringComparison.OrdinalIgnoreCase)) {
 					var originalFile = dir.GetMetadata (ResolveLibraryProjectImports.OriginalFile);
-					Log.LogDebugMessage ($"Skipping: `{dir.ItemSpec}` via `{ResolveLibraryProjectImports.SkipAndroidResourceProcessing}`, original file: `{originalFile}`...");
+					Log.LogDebugMessage ($"Skipping: `{dir.ItemSpec}` via `{ResolveLibraryProjectImports.AndroidSkipResourceProcessing}`, original file: `{originalFile}`...");
 					continue;
 				}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateManagedAidlProxies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateManagedAidlProxies.cs
@@ -48,8 +48,9 @@ namespace Xamarin.Android.Tasks
 			if (!string.IsNullOrEmpty (OutputNamespace))
 				opts.OutputNS = OutputNamespace;
 
-			foreach (var file in References)
+			foreach (var file in References) {
 				opts.AddReference (file.ItemSpec);
+			}
 			foreach (var file in SourceAidlFiles)
 				opts.AddFile (file.ItemSpec);
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -80,12 +80,12 @@ namespace Xamarin.Android.Tasks
 			var doc = AndroidAppManifest.Load (Manifest, MonoAndroidHelper.SupportedVersions);
 			int minApiVersion = doc.MinSdkVersion == null ? 4 : (int) doc.MinSdkVersion;
 			// We need to include any special assemblies in the Assemblies list
-			var assemblies = ResolvedUserAssemblies.Select (p => p.ItemSpec)
+			var assemblies = ResolvedUserAssemblies
 				.Concat (MonoAndroidHelper.GetFrameworkAssembliesToTreatAsUserAssemblies (ResolvedAssemblies))						
 				.ToList ();
 			var mainFileName = Path.GetFileName (MainAssembly);
 			Func<string,string,bool> fileNameEq = (a,b) => a.Equals (b, StringComparison.OrdinalIgnoreCase);
-			assemblies = assemblies.Where (a => fileNameEq (a, mainFileName)).Concat (assemblies.Where (a => !fileNameEq (a, mainFileName))).ToList ();
+			assemblies = assemblies.Where (a => fileNameEq (a.ItemSpec, mainFileName)).Concat (assemblies.Where (a => !fileNameEq (a.ItemSpec, mainFileName))).ToList ();
 
 			using (var stream = new MemoryStream ())
 			using (var pkgmgr = new StreamWriter (stream)) {
@@ -97,7 +97,7 @@ namespace Xamarin.Android.Tasks
 
 				pkgmgr.WriteLine ("\t\t/* We need to ensure that \"{0}\" comes first in this list. */", mainFileName);
 				foreach (var assembly in assemblies) {
-					pkgmgr.WriteLine ("\t\t\"" + Path.GetFileName (assembly) + "\",");
+					pkgmgr.WriteLine ("\t\t\"" + Path.GetFileName (assembly.ItemSpec) + "\",");
 				}
 
 				// Write the assembly dependencies

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
@@ -53,6 +53,8 @@ namespace Xamarin.Android.Tasks
 		string CachePath;
 		MD5 md5 = MD5.Create ();
 
+		internal const string AndroidSkipResourceExtraction = "AndroidSkipResourceExtraction";
+
 		public GetAdditionalResourcesFromAssemblies ()
 		{
 		}
@@ -403,6 +405,10 @@ namespace Xamarin.Android.Tasks
 				: Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData), CacheBaseDir);
 
 				foreach (var assemblyItem in Assemblies) {
+					if (bool.TryParse (assemblyItem.GetMetadata (AndroidSkipResourceExtraction), out bool value) && value) {
+						LogDebugMessage ($"Skipping {assemblyItem.ItemSpec} due to 'AndroidSkipResourceExtraction' == 'true' ");
+						continue;
+					}
 					string fullPath = Path.GetFullPath (assemblyItem.ItemSpec);
 					if (DesignTimeBuild && !File.Exists (fullPath)) {
 						LogWarning ("Failed to load '{0}'. Check the file exists or the project has been built.", fullPath);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -90,7 +90,6 @@ namespace Xamarin.Android.Tasks
 				foreach (var assembly in Assemblies) {
 					var assembly_path = Path.GetDirectoryName (assembly.ItemSpec);
 					resolver.AddSearchDirectory (assembly_path);
-
 					// Add each user assembly and all referenced assemblies (recursive)
 					string resolved_assembly = resolver.Resolve (assembly.ItemSpec);
 					if (MonoAndroidHelper.IsReferenceAssembly (resolved_assembly)) {
@@ -102,6 +101,7 @@ namespace Xamarin.Android.Tasks
 							continue;
 						}
 					}
+					LogDebugMessage ($"Adding {resolved_assembly} to topAssemblyReferences");
 					topAssemblyReferences.Add (resolved_assembly);
 					var taskItem = new TaskItem (assembly) {
 						ItemSpec = Path.GetFullPath (resolved_assembly),

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -169,7 +169,7 @@ class MemTest {
 							//Processing: obj\Debug\res\layout\main.xml   10/29/2018 8:19:36 PM > 1/1/0001 12:00:00 AM
 							processed.Add (line);
 						} else if (line.IndexOf ("Skipping:", StringComparison.OrdinalIgnoreCase) >= 0) {
-							//Skipping: `obj\Debug\lp\5\jl\res` via `SkipAndroidResourceProcessing`, original file: `bin\TestDebug\temp\packages\Xamarin.Android.Support.Compat.27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Compat.dll`...
+							//Skipping: `obj\Debug\lp\5\jl\res` via `AndroidSkipResourceProcessing`, original file: `bin\TestDebug\temp\packages\Xamarin.Android.Support.Compat.27.0.2.1\lib\MonoAndroid81\Xamarin.Android.Support.Compat.dll`...
 							skipped.Add (line);
 						}
 					}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -487,11 +487,11 @@ namespace Xamarin.Android.Tasks
 		}
 
 #if MSBUILD
-		internal static IEnumerable<string> GetFrameworkAssembliesToTreatAsUserAssemblies (ITaskItem[] resolvedAssemblies) 
+		internal static IEnumerable<ITaskItem> GetFrameworkAssembliesToTreatAsUserAssemblies (ITaskItem[] resolvedAssemblies) 
 		{		
 			return resolvedAssemblies
 				.Where (f => Array.BinarySearch (FrameworkAssembliesToTreatAsUserAssemblies, Path.GetFileName (f.ItemSpec), StringComparer.OrdinalIgnoreCase) >= 0)
-				.Select(p => p.ItemSpec);
+				.Select(p => p);
 		}
 #endif
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -487,19 +487,23 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<MakeDir Directories="$(_AndroidStampDirectory)" Condition=" !Exists('$(_AndroidStampDirectory)') " />
 	<MakeDir Directories="$(_AndroidIntermediateDesignTimeBuildDirectory)" Condition=" !Exists ('$(_AndroidIntermediateDesignTimeBuildDirectory)') " />
 </Target>
+
+<ItemGroup>
+	<AndroidCustomMetaDataForReferences Include="@(_AndroidAssemblySkipCases)" />
+</ItemGroup>
 	
 <Target Name="_AddAndroidCustomMetaData">
   <AppendCustomMetadataToItemGroup
       Condition="'$(AndroidApplication)' != '' And $(AndroidApplication)"
       Inputs="@(ReferencePath)"
-      MetaDataItems="@(_AndroidAssemblySkipCases)"
+      MetaDataItems="@(AndroidCustomMetaDataForReferences)"
     >
     <Output TaskParameter="Output" ItemName="_ReferencePath" />
   </AppendCustomMetadataToItemGroup>
   <AppendCustomMetadataToItemGroup
       Condition="'$(AndroidApplication)' != '' And $(AndroidApplication)"
       Inputs="@(ReferenceDependencyPaths)"
-      MetaDataItems="@(_AndroidAssemblySkipCases)"
+      MetaDataItems="@(AndroidCustomMetaDataForReferences)"
     >
     <Output TaskParameter="Output" ItemName="_ReferenceDependencyPaths" />
   </AppendCustomMetadataToItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.SkipCases.projitems
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.SkipCases.projitems
@@ -16,7 +16,7 @@ Copyright (C) 2018 Xamarin. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemDefinitionGroup>
     <_AndroidAssemblySkipCases>
-      <SkipAndroidResourceProcessing>True</SkipAndroidResourceProcessing>
+      <AndroidSkipResourceProcessing>True</AndroidSkipResourceProcessing>
     </_AndroidAssemblySkipCases>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Context #2895 

As part of the AndroidX migration system we need to
be able to skip over the older support library
assemblies for certain build steps.

The following metadata is supported on the `ReferencePath`
and `ReferenceDependencyPaths` ItemGroups.

	AndroidSkipAddToPackage
	AndroidSkipResourceProcessing
	AndroidSkipJavaStubGeneration
	AndroidSkipResourceExtraction

`AndroidSkipResourceProcessing` is the renamed
`SkipAndroidResourceProcessing` metadata item.
This is used to skip case conversion on those
resources.

`AndroidSkipResourceExtraction` will stop the
resources in that library being extracted into
the `IntermediateOutputPath`.

`AndroidSkipJavaStubGeneration` when `true` this
item will stop java code being generated for the
library in quetion.

`AndroidSkipAddToPackage` is used by `BuildApk`
task to skip over the library and NOT add it to
the final APK.

To use these new metadata items you can define your
own `ItemGroup` as follows

	<ItemGroup>
		<_MyStuff Include="Xamarin.Android.Support.v4">
			<AndroidSkipAddToPackage>True</AndroidSkipAddToPackage>
		</_MyStuff>
	</ItemGroup>

Then add this new `ItemGroup` to the `AndroidCustomMetaDataForReferences`
like so.

	<ItemGroup>
		<AndroidCustomMetaDataForReferences Include="@(_MyStuff)" />
	</ItemGroup>

The `AndroidCustomMetaDataForReferences` ItemGroup will then
be processed by the `_AddAndroidCustomMetaData` target. This
will add the new metadata to the `ReferencePath`
and `ReferenceDependencyPaths` ItemGroups.