### PR TITLE
Use correct `strip` path when building with mono archives

### DIFF
--- a/src/mono-runtimes/mono-runtimes.projitems
+++ b/src/mono-runtimes/mono-runtimes.projitems
@@ -4,9 +4,16 @@
     <_MonoBcl Include="bcl" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <_NDKToolchainArch Condition=" '$(HostOS)' == 'Linux' ">linux-x86_64</_NDKToolchainArch>
+    <_NDKToolchainArch Condition=" '$(HostOS)' == 'Darwin' ">darwin-x86_64</_NDKToolchainArch>
+    <_NDKToolchainArch Condition=" '$(HostOS)' == 'Windows' ">windows</_NDKToolchainArch>
+    <_NDKToolchainPrefix>$(AndroidNdkFullPath)\toolchains\llvm\prebuilt\$(_NDKToolchainArch)</_NDKToolchainPrefix>
+  </PropertyGroup>
+
   <ItemGroup>
     <_MonoRuntime Include="armeabi-v7a" Condition=" $(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':armeabi-v7a:')) ">
-      <Strip>$(AndroidToolchainDirectory)\toolchains\armeabi-v7a-clang\bin\arm-linux-androideabi-strip</Strip>
+      <Strip>$(_NDKToolchainPrefix)\bin\arm-linux-androideabi-strip</Strip>
       <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
       <NativeLibraryExtension>so</NativeLibraryExtension>
       <CanStripNativeLibrary>True</CanStripNativeLibrary>
@@ -16,7 +23,7 @@
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
     <_MonoRuntime Include="arm64-v8a" Condition=" $(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':arm64-v8a:')) ">
-      <Strip>$(AndroidToolchainDirectory)\toolchains\arm64-v8a-clang\bin\aarch64-linux-android-strip</Strip>
+      <Strip>$(_NDKToolchainPrefix)\bin\aarch64-linux-android-strip</Strip>
       <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
       <NativeLibraryExtension>so</NativeLibraryExtension>
       <CanStripNativeLibrary>True</CanStripNativeLibrary>
@@ -26,7 +33,7 @@
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
     <_MonoRuntime Include="x86" Condition=" $(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':x86:')) ">
-      <Strip>$(AndroidToolchainDirectory)\toolchains\x86-clang\bin\i686-linux-android-strip</Strip>
+      <Strip>$(_NDKToolchainPrefix)\bin\i686-linux-android-strip</Strip>
       <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
       <NativeLibraryExtension>so</NativeLibraryExtension>
       <CanStripNativeLibrary>True</CanStripNativeLibrary>
@@ -36,7 +43,7 @@
       <OutputMonoPosixHelperFilename>libMonoPosixHelper</OutputMonoPosixHelperFilename>
     </_MonoRuntime>
     <_MonoRuntime Include="x86_64" Condition=" $(AndroidSupportedTargetJitAbisForConditionalChecks.Contains (':x86_64:')) ">
-      <Strip>$(AndroidToolchainDirectory)\toolchains\x86_64-clang\bin\x86_64-linux-android-strip</Strip>
+      <Strip>$(_NDKToolchainPrefix)\bin\x86_64-linux-android-strip</Strip>
       <OutputRuntimeFilename>libmonosgen-2.0</OutputRuntimeFilename>
       <NativeLibraryExtension>so</NativeLibraryExtension>
       <CanStripNativeLibrary>True</CanStripNativeLibrary>


### PR DESCRIPTION
Mono Android build still creates a standalone NDK toolchain as part of its
provisioning step and places it in `~/android-toolchain/toolchains` and its
subdirectories. Xamarin.Android then uses this location to find the `strip`
utility which we call after the build is done. However, when Mono archives are
used and the Mono build does *not* take place, the standalone toolchain is never
created (as Xamarin.Android itself doesn't use it) and thus we fail to find the
required `strip` binaries and the build fails

This commit fixes the problem by always using strip from the prebuilt toolchains
as shipped with the NDK.