### PR TITLE
[build] use a repository-wide NuGet.config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ HOMEBREW_PREFIX := $prefix
 endif
 
 ifneq ($(V),0)
-MONO_OPTIONS += --debug
+MONO_OPTIONS   += --debug
+NUGET_VERBOSITY = -Verbosity Detailed
 endif
 
 ifneq ($(MONO_OPTIONS),)
@@ -122,8 +123,8 @@ $(eval $(call create_cmake_toolchain,mingw-32.cmake))
 $(eval $(call create_cmake_toolchain,mingw-64.cmake))
 
 prepare-external: prepare-deps
-	nuget restore $(SOLUTION)
-	nuget restore Xamarin.Android-Tests.sln
+	nuget restore $(NUGET_VERBOSITY) $(SOLUTION)
+	nuget restore $(NUGET_VERBOSITY) Xamarin.Android-Tests.sln
 	(cd external/xamarin-android-tools && make prepare CONFIGURATION=$(CONFIGURATION))
 	(cd $(call GetPath,JavaInterop) && make prepare CONFIGURATION=$(CONFIGURATION) JI_MAX_JDK=8)
 	(cd $(call GetPath,JavaInterop) && make bin/Build$(CONFIGURATION)/JdkInfo.props CONFIGURATION=$(CONFIGURATION) JI_MAX_JDK=8)

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <!-- ensure only the sources defined below are used -->
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -4,6 +4,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <_TopDir>$(MSBuildThisFileDirectory)..\..</_TopDir>
     <_NuGet>.nuget\NuGet.exe</_NuGet>
+    <_NuGetVerbosity>-Verbosity Detailed</_NuGetVerbosity>
   </PropertyGroup>
   <Import Project="$(_TopDir)\Configuration.props" />
   <UsingTask AssemblyFile="$(_TopDir)\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.JdkInfo" />
@@ -16,14 +17,34 @@
     <Exec Command="git submodule update --init --recursive" WorkingDirectory="$(_TopDir)" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\xa-prep-tasks\xa-prep-tasks.csproj" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\download-bundle\download-bundle.csproj" />
-    <Exec Command="$(_NuGet) restore Xamarin.Android.sln" WorkingDirectory="$(_TopDir)" />
-    <Exec Command="$(_NuGet) restore external\Java.Interop\Java.Interop.sln" WorkingDirectory="$(_TopDir)" />
-    <Exec Command="$(_NuGet) restore external\LibZipSharp\libZipSharp.sln" WorkingDirectory="$(_TopDir)" />
-    <Exec Command="$(_NuGet) restore external\xamarin-android-tools\Xamarin.Android.Tools.sln" WorkingDirectory="$(_TopDir)" />
+    <Exec
+        Command="$(_NuGet) restore $(_NuGetVerbosity) Xamarin.Android.sln"
+        WorkingDirectory="$(_TopDir)"
+        IgnoreStandardErrorWarningFormat="True"
+    />
+    <Exec
+        Command="$(_NuGet) restore $(_NuGetVerbosity) external\Java.Interop\Java.Interop.sln"
+        WorkingDirectory="$(_TopDir)"
+        IgnoreStandardErrorWarningFormat="True"
+    />
+    <Exec
+        Command="$(_NuGet) restore $(_NuGetVerbosity) external\LibZipSharp\libZipSharp.sln"
+        WorkingDirectory="$(_TopDir)"
+        IgnoreStandardErrorWarningFormat="True"
+    />
+    <Exec
+        Command="$(_NuGet) restore $(_NuGetVerbosity) external\xamarin-android-tools\Xamarin.Android.Tools.sln"
+        WorkingDirectory="$(_TopDir)"
+        IgnoreStandardErrorWarningFormat="True"
+    />
     <MSBuild Projects="tests\Xamarin.Forms-Performance-Integration\Xamarin.Forms.Performance.Integration.csproj" Targets="Restore" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\android-toolchain\android-toolchain.csproj" />
     <!--NOTE: need to restore test sln *after* android-toolchain has the Android SDK in place-->
-    <Exec Command="$(_NuGet) restore Xamarin.Android-Tests.sln" WorkingDirectory="$(_TopDir)" />
+    <Exec
+        Command="$(_NuGet) restore $(_NuGetVerbosity) Xamarin.Android-Tests.sln"
+        WorkingDirectory="$(_TopDir)"
+        IgnoreStandardErrorWarningFormat="True"
+    />
     <JdkInfo
         AndroidSdkPath="$(AndroidSdkDirectory)"
         AndroidNdkPath="$(AndroidNdkDirectory)"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -462,7 +462,7 @@ namespace UnnamedProject
 				Assert.AreEqual ("@color/deep_purple_A200", item.Value, "item value should be @color/deep_purple_A200");
 				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "AndroidResgen: Warning while updating Resource XML"),
 					"Warning while processing resources should not have been raised.");
-				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "Build should have succeeded.");
 				Assert.IsTrue (b.Output.IsTargetSkipped ("_GenerateJavaStubs"), "Target _GenerateJavaStubs should have been skipped");
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -52,6 +52,12 @@ namespace Xamarin.ProjectTools
 				if (Directory.Exists (PackagesDirectory))
 					Directory.Delete (PackagesDirectory, true);
 				project.Populate (ProjectDirectory, files);
+
+				// Copy our solution's NuGet.config
+				var nuget_config = Path.Combine (XABuildPaths.TopDirectory, "NuGet.config");
+				if (File.Exists (nuget_config)) {
+					File.Copy (nuget_config, Path.Combine (Root, ProjectDirectory, "NuGet.config"), overwrite: true);
+				}
 			}
 			else
 				project.UpdateProjectFiles (ProjectDirectory, files, doNotCleanupOnUpdate);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -290,7 +290,7 @@ namespace Xamarin.ProjectTools
 			var isWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
 			var nuget = Path.Combine (Root, "NuGet.exe");
 			var psi = new ProcessStartInfo (isWindows ? nuget : "mono") {
-				Arguments = $"{(isWindows ? "" : "\"" + nuget + "\"")} restore -PackagesDirectory \"{Path.Combine (Root, directory, "..", "packages")}\" \"{Path.Combine (Root, directory, "packages.config")}\"",
+				Arguments = $"{(isWindows ? "" : "\"" + nuget + "\"")} restore -Verbosity Detailed -PackagesDirectory \"{Path.Combine (Root, directory, "..", "packages")}\" \"{Path.Combine (Root, directory, "packages.config")}\"",
 				CreateNoWindow = true,
 				UseShellExecute = false,
 				WindowStyle = ProcessWindowStyle.Hidden,


### PR DESCRIPTION
Context: https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior
Context: http://build.devdiv.io/2500191
Context: https://github.com/xamarin/xamarin-android/pull/2859#issuecomment-476691256

We are randomly getting failures during Windows builds such as:

    NuGet.targets(114,5): Unable to load the service index for source https://someurl.visualstudio.com/_packaging/Dev/nuget/v3/index.json.
        Response status code does not indicate success: 401 (Unauthorized).

It appears that some of our build machines on Azure DevOps have a
global (or user-level) `NuGet.Config` file that points to a NuGet feed
we don't have access to.

The way we can workaround this, is to provide our own `NuGet.config`
file that *only* uses the official nuget.org feed.

* We can put a top-level `NuGet.config` next to our SLN files.
* We also need to use this file during MSBuild tests.

I also made sure any calls to `nuget restore` are giving us the
highest log information via `-Verbosity Detailed`. This will tell us
what `NuGet.config` files and feeds are used.

Also in `PrepareWindows.targets`, any `<Exec/>` calls that run
`NuGet.exe` need `IgnoreStandardErrorWarningFormat` set. Otherwise
MSBuild treats certain output as errors.