### PR TITLE
Deploy target

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -3313,7 +3313,14 @@ because xbuild doesn't support framework reference assemblies.
 </PropertyGroup>
 
 <Target Name="_Deploy">
-  <Exec Command="&quot;$(AdbToolPath)\adb&quot; $(AdbTarget) install -r &quot;$(ApkFileSigned)&quot;" />
+  <PropertyGroup>
+    <_DeployCommand>&quot;$(AdbToolPath)\adb&quot; $(AdbTarget) install -r &quot;$(ApkFileSigned)&quot;</_DeployCommand>
+  </PropertyGroup>
+  <Exec Command="$(_DeployCommand)" ContinueOnError="true" ConsoleToMSBuild="true">
+    <Output TaskParameter="ExitCode" PropertyName="_DeployEditCode" />
+    <Output TaskParameter="ConsoleOutput" PropertyName="_DeployConsoleOutput" />
+  </Exec>
+  <Error Text="$(_DeployCommand) exitied with code $(_DeployEditCode): $(_DeployConsoleOutput)" Condition="'$(_DeployEditCode)' != '0'" />
 </Target>
 
 <Target Name="Install"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -3320,7 +3320,7 @@ because xbuild doesn't support framework reference assemblies.
     <Output TaskParameter="ExitCode" PropertyName="_DeployEditCode" />
     <Output TaskParameter="ConsoleOutput" PropertyName="_DeployConsoleOutput" />
   </Exec>
-  <Error Text="$(_DeployCommand) exitied with code $(_DeployEditCode): $(_DeployConsoleOutput)" Condition="'$(_DeployEditCode)' != '0'" />
+  <Error Text="The command &quot;$(_DeployCommand)&quot; exitied with code $(_DeployEditCode): $(_DeployConsoleOutput)" Condition="'$(_DeployEditCode)' != '0'" />
 </Target>
 
 <Target Name="Install"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -3316,11 +3316,22 @@ because xbuild doesn't support framework reference assemblies.
   <PropertyGroup>
     <_DeployCommand>&quot;$(AdbToolPath)\adb&quot; $(AdbTarget) install -r &quot;$(ApkFileSigned)&quot;</_DeployCommand>
   </PropertyGroup>
-  <Exec Command="$(_DeployCommand)" ContinueOnError="true" ConsoleToMSBuild="true">
-    <Output TaskParameter="ExitCode" PropertyName="_DeployEditCode" />
-    <Output TaskParameter="ConsoleOutput" PropertyName="_DeployConsoleOutput" />
+  <Exec
+      ContinueOnError="True"
+      Command="$(_DeployCommand)"
+      ConsoleToMSBuild="True">
+    <Output TaskParameter="ExitCode"      PropertyName="_DeployExitCode" />
+    <Output TaskParameter="ConsoleOutput" ItemName="_DeployConsoleOutput" />
   </Exec>
-  <Error Text="The command &quot;$(_DeployCommand)&quot; exitied with code $(_DeployEditCode): $(_DeployConsoleOutput)" Condition="'$(_DeployEditCode)' != '0'" />
+  <ItemGroup>
+    <_AdbError Include="The command `$(_DeployCommand)` exited with code $(_DeployExitCode):" />
+    <_AdbError Include="@(_DeployConsoleOutput->'  %(Identity)')" />
+  </ItemGroup>
+  <Error
+      Condition=" '$(_DeployExitCode)' != '0' "
+      Code="ADB0000"
+      Text="@(_AdbError, '%0a')"
+  />
 </Target>
 
 <Target Name="Install"


### PR DESCRIPTION
When adb fails it is difficult to understand thats going on especially from IDE where an user usually observes only error messages, something like: 
```
MyAndroidProject
   ...\Xamarin\Android\Xamarin.Android.Common.targets(3281,3): error MSB3073: 
The command ""C:\Program Files (x86)\Android\android-sdk\platform-tools\\adb" -s emulator-5554 install -r "bin\Debug\com.companyname.MyAndroidProject-Signed.apk"" exited with code 1.
```

It is better to have an error message like
```
MyAndroidProject
  ...\Xamarin\Android\Xamarin.Android.Common.targets(3285,9): error : 
The command ""C:\Program Files (x86)\Android\android-sdk\platform-tools\\adb" -s emulator-5554 install -r "bin\Debug\com.companyname.MyAndroidProject-Signed.apk"" exitied with code 1: 
adb: failed to install bin\Debug\com.companyname.MyAndroidProject-Signed.apk: Failure [INSTALL_PARSE_FAILED_UNEXPECTED_EXCEPTION: Failed to parse /data/app/vmdl192544199.tmp/base.apk: AndroidManifest.xml]
```