### PR TITLE
When $(AndroidResgenFile) is empty, set AndroidUseIntermediateDesignerFile=true

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -242,6 +242,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidLintDisabledIssues Condition=" '$(AndroidLintDisabledIssues)' == ''"></AndroidLintDisabledIssues>
 	<AndroidLintChecks Condition=" '$(AndroidLintChecks)' == ''"></AndroidLintChecks>
 	<AndroidLintEnabled Condition=" '$(AndroidLintEnabled)' == ''">False</AndroidLintEnabled>
+	<AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' and '$(AndroidResgenFile )' == '' ">True</AndroidUseIntermediateDesignerFile>
 	<AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">False</AndroidUseIntermediateDesignerFile>
 
 	<!-- Google Play Store Checks -->


### PR DESCRIPTION
If someone had a previously unfolded template (or currently, since we still add the Resource.designer.cs file under Resources, but likely to change), in order to upgrade to the intermediate codegen, they have to both delete the existing file, remove the AndroidResgenFile property (since it's meaningless now, but removing it isn't required) and add AndroidUseIntermediateDesignerFile=true. 

This makes it so that just removing the `AndroidResgenFile` property is interpreted as "use the new thing" implicitly, so we have a cleaner .csproj in the end, which has the right behavior OOB.

Fixes #2908 