### PR TITLE
[vswhere] set WorkingDirectory

### DIFF
--- a/tools/vswhere/MSBuildLocator.cs
+++ b/tools/vswhere/MSBuildLocator.cs
@@ -46,6 +46,7 @@ namespace Xamarin.Android.Tools.VSWhere
 		{
 			var info = new ProcessStartInfo {
 				FileName = fileName,
+				WorkingDirectory = Path.GetDirectoryName (fileName),
 				Arguments = args,
 				UseShellExecute = false,
 				RedirectStandardOutput = true,


### PR DESCRIPTION
Context: http://build.devdiv.io/2547192
Context: https://stackoverflow.com/questions/990562/win32exception-the-directory-name-is-invalid

We seem to have hit an odd failure during the MSBuild tests:

    Unhandled Exception: System.ComponentModel.Win32Exception: The directory name is invalid
        at System.Diagnostics.Process.StartWithCreateProcess(ProcessStartInfo startInfo)
        at System.Diagnostics.Process.Start()
        at System.Diagnostics.Process.Start(ProcessStartInfo startInfo)
        at Xamarin.Android.Tools.VSWhere.MSBuildLocator.Exec(String fileName, String args) in E:\A\_work\1404\s\tools\vswhere\MSBuildLocator.cs:line 55
        at Xamarin.Android.Tools.VSWhere.MSBuildLocator.QueryLatest() in E:\A\_work\1404\s\tools\vswhere\MSBuildLocator.cs:line 28
        at Xamarin.Android.Build.XABuildPaths..ctor() in E:\A\_work\1404\s\tools\xabuild\XABuildPaths.cs:line 124
        at Xamarin.Android.Build.XABuild.Main() in E:\A\_work\1404\s\tools\xabuild\XABuild.cs:line 17

From looking up other examples of this error on the web, it seems that
a weird `WorkingDirectory` from the build environment would cause
this? `WorkingDirectory` was not set at all, so we would pickup
whatever the default is.

Let's just set `ProcessStartInfo.WorkingDirectory` to avoid a
potential problem here.