### PR TITLE
[Xamarin.Android.Build.Tasks] random error in <Aapt2Link/>

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -101,10 +101,12 @@ namespace Xamarin.Android.Tasks {
 
 				this.ParallelForEach (ManifestFiles, ProcessManifest);
 			} finally {
-				foreach (var temp in tempFiles) {
-					File.Delete (temp);
+				lock (tempFiles) {
+					foreach (var temp in tempFiles) {
+						File.Delete (temp);
+					}
+					tempFiles.Clear ();
 				}
-				tempFiles.Clear ();
 			}
 		}
 
@@ -272,7 +274,8 @@ namespace Xamarin.Android.Tasks {
 		string GetTempFile ()
 		{
 			var temp = Path.GetTempFileName ();
-			tempFiles.Add (temp);
+			lock (tempFiles)
+				tempFiles.Add (temp);
 			return temp;
 		}
 	}


### PR DESCRIPTION
Context: http://build.devdiv.io/2547670
Context: https://github.com/xamarin/xamarin-android/pull/2911#issuecomment-478739173

We have been occasionally hitting this on CI:

    Xamarin.Android.Aapt2.targets(146,3): Value cannot be null.
    Parameter name: path
        at System.IO.File.Delete(String path)
        at Xamarin.Android.Tasks.Aapt2Link.DoExecute()
        at System.Threading.Tasks.Task.InnerInvoke()
        at System.Threading.Tasks.Task.Execute() [E:\A\_work\1214\s\bin\TestRelease\temp\CompileBeforeUpgradingNuGet\UnnamedProject.csproj]

What I think is happening:

* We call `tempFiles.Add()` during a `Parallel.ForEach`. Bad...
* Instead of an exception happening during `Add()`, a `null` is
  somehow added to the underlying array--which is corrupted.

Instead I think we should add locking around all usage of this
`tempFiles` member variable. I looked at `ConcurrentBag<T>`, but it
seemed more appropriate to use a lock because of the `foreach` +
`Clear()` calls.