### PR TITLE
[Xamarin.Android.Build.Tasks] Clean up redundant files.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1884,7 +1884,31 @@ because xbuild doesn't support framework reference assemblies.
     <_RuntimeDex>$(MSBuildThisFileDirectory)\java_runtime.dex</_RuntimeDex>
   </PropertyGroup>
 </Target>
-  
+
+<Target Name="_CleanupOldStaticResources"
+    Condition="Exists ('$(MonoAndroidIntermediate)android\src\mono\app\ApplicationRegistration.java')">
+  <ItemGroup>
+    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\MultiDexLoader.java" />
+    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\android\ResourcePatcher.java" />
+    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\MonoPackageManager.java" />
+    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\IncrementalClassLoader.java" />
+    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\Placeholder.java" />
+    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\app\ApplicationRegistration.java" />
+    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\app\NotifyTimeZoneChanges.java" />
+    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\MonkeyPatcher.java" />
+    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\android\incrementaldeployment\MultiDexLoader.class" />
+    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\android\ResourcePatcher.class" />
+    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\MonoPackageManager.class" />
+    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\MonoPackageManager_Resources.class" />
+    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\android\incrementaldeployment\IncrementalClassLoader*.class" />
+    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\android\incrementaldeployment\Placeholder.class" />
+    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\android\app\ApplicationRegistration.class" />
+    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\android\app\NotifyTimeZoneChanges.class" />
+    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\android\MonkeyPatcher.class" />
+  </ItemGroup>
+  <Delete Files="@(_OldStaticResources)" />
+</Target>
+
 <Target Name="_GetMonoPlatformJarPath">
   <GetMonoPlatformJar TargetFrameworkDirectory="$(TargetFrameworkDirectory)">
     <Output TaskParameter="MonoPlatformJarPath" PropertyName="MonoPlatformJarPath" />
@@ -1895,7 +1919,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_AddStaticResources"
 		Inputs="$(MonoPlatformJarPath);$(_AndroidBuildPropertiesCache)"
 		Outputs="$(_AndroidStaticResourcesFlag)"
-		DependsOnTargets="_CollectRuntimeJarFilenames;$(_BeforeAddStaticResources);_GetMonoPlatformJarPath">
+		DependsOnTargets="_CollectRuntimeJarFilenames;$(_BeforeAddStaticResources);_CleanupOldStaticResources;_GetMonoPlatformJarPath">
 	<CopyResource ResourceName="machine.config" OutputPath="$(MonoAndroidIntermediateAssetsDir)machine.config" />
   <CopyResource
     ResourceName="MonoRuntimeProvider.Bundled.java"


### PR DESCRIPTION
Commit 121b81aa added the new `runtime_java.jar`.
What it did not take into account was what happens
when a user upgrades but does not do a clean build.

What happens is we have old redundant files left
in the `$(IntermediateOutputPath)android\src` and
`$(IntermediateOutputPath)android\bin\classes`.

This then causes errors such as

	error: duplicate class: mono.MonoPackageManager_Resources

when compiling the java code.

So what we need to do is clean up after ourselves. We do
this by checking to see if the following file exists

	$(MonoAndroidIntermediate)android\src\mono\app\ApplicationRegistration.java

If that file is there, then we need to clean up all the
other known files. We can not do a clean all the time since
we still generate `MonoPackageManager_Resources`. The
contents have changed though. So if the above file is in
place, we can safely remove all the others.