### PR TITLE
[build, linux] Fix for Linux pipeline PR build break

### DIFF
--- a/build-tools/automation/build.linux.groovy
+++ b/build-tools/automation/build.linux.groovy
@@ -9,8 +9,9 @@ def isStable = false            // Stable build workflow
 def publishPackages = false
 def pBuilderBindMounts = null
 def utils = null
-def prLabels = null             // Globally defined "static" list accessible within the hasPrLabel function
 def hasPrLabelFullMonoIntegrationBuild = false
+
+prLabels = null             // Globally defined "static" list accessible within the hasPrLabel function
 
 def execChRootCommand(chRootName, chRootPackages, pBuilderBindMounts, makeCommand) {
     chroot chrootName: chRootName,

--- a/build-tools/automation/build.linux.groovy
+++ b/build-tools/automation/build.linux.groovy
@@ -9,6 +9,7 @@ def isStable = false            // Stable build workflow
 def publishPackages = false
 def pBuilderBindMounts = null
 def utils = null
+def prLabels = null             // Globally defined "static" list accessible within the hasPrLabel function
 def hasPrLabelFullMonoIntegrationBuild = false
 
 def execChRootCommand(chRootName, chRootPackages, pBuilderBindMounts, makeCommand) {


### PR DESCRIPTION
**Symptom**
groovy.lang.MissingPropertyException: No such property: prLabels for class: groovy.lang.Binding

**Analysis**
This issue was not discovered in Linux pipeline CI build workflows since the PR logic was not exercised in that case.  This issue has come to light with Linux PR pipeline build workflows being switched on.

**Resolution**
Define missing global prLabels variable required by the hasPrLabel utility function

**Example of affected build**
https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-linux-pr-pipeline/18/