### PR TITLE
[build-tools] Increase the emulator disk space.

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateAndroidEmulator.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateAndroidEmulator.cs
@@ -172,14 +172,20 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			}
 		}
 
+		bool inWarning = false;
+
 		void DefaultErrorHandler (object sender, DataReceivedEventArgs e)
 		{
-			if (string.IsNullOrEmpty (e.Data))
+			if (string.IsNullOrEmpty (e.Data)) {
+				inWarning = false;
 				return;
-			if (e.Data.StartsWith ("Warning:", StringComparison.Ordinal))
+			}
+			if (e.Data.StartsWith ("Warning:", StringComparison.Ordinal) || inWarning) {
 				Log.LogMessage ($"{e.Data}");
-			else
+				inWarning = true;
+			} else {
 				Log.LogError ($"{e.Data}");
+			}
 		}
 	}
 }

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -37,7 +37,7 @@
         ToolExe="$(AvdManagerToolExe)"
         ToolPath="$(AndroidToolsBinPath)"
         RamSizeMB="2048"
-        DataPartitionSizeMB="2048"
+        DataPartitionSizeMB="4096"
     />
     <StartAndroidEmulator
         Condition=" '$(_ValidAdbTarget)' != 'True' "


### PR DESCRIPTION
We have more and more tests running on the emulator
now. Sometimes we run out of space to run the tests.
This PR increases the disk space.

We also handle a problem with the `CreateAndroidEmulator`
error processing.  `advmanager` was returning the following
warning.

	Warning: cvc-pattern-valid: Value '' is not facet-valid with respect to pattern '[a-zA-Z0-9_-]+' for type 'idType'.
		org.xml.sax.SAXParseException; lineNumber: 134; columnNumber: 341; cvc-pattern-valid: Value '' is not facet-valid with respect to pattern '[a-zA-Z0-9_-]+' for type 'idType'.
		at com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.createSAXParseException(ErrorHandlerWrapper.java:203)
		at com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.error(ErrorHandlerWrapper.java:134)

Only the first line was being picked up as a warning, the rest
was being reported as an error. The result was the emulator
never ran!