### PR TITLE
[mono-runtimes] Fully populate RedistList\FrameworkList.xml

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -42,6 +42,7 @@
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Ant.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\CheckAdbTarget.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\CreateAndroidEmulator.cs" />
+    <Compile Include="Xamarin.Android.Tools.BootstrapTasks\CreateFrameworkList.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Emulator.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GenerateMonoDroidIncludes.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\GenerateProfile.cs" />

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateFrameworkList.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateFrameworkList.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	public class CreateFrameworkList : Task
+	{
+		[Required]
+		public                  ITaskItem       FrameworkListFile           { get; set; }
+
+		[Required]
+		public                  ITaskItem       FrameworkDirectory          { get; set; }
+
+		[Required]
+		public                  ITaskItem[]     FrameworkFiles              { get; set; }
+
+		public                  ITaskItem[]     FrameworkFileOverrides      { get; set; }
+
+		[Required]
+		public                  string          Redist                      { get; set; }
+
+		[Required]
+		public                  string          Name                        { get; set; }
+
+		public override bool Execute()
+		{
+			var files = new List<ITaskItem>(FrameworkFiles);
+			files.Sort ((x, y) => {
+					var a = Path.GetFileNameWithoutExtension (x.ItemSpec);
+					var b = Path.GetFileNameWithoutExtension (y.ItemSpec);
+					return string.Compare (a, b, StringComparison.OrdinalIgnoreCase);
+			});
+			var contents = new XElement ("FileList",
+					new XAttribute ("Redist", Redist),
+					new XAttribute ("Name", Name),
+					files.Select (f => ToFileElement (f)));
+			contents.Save (FrameworkListFile.ItemSpec);
+			return true;
+		}
+
+		XElement ToFileElement (ITaskItem file)
+		{
+			var path = Path.Combine (FrameworkDirectory.ItemSpec, file.ItemSpec);
+			if (!File.Exists (path)) {
+				path = Path.Combine (FrameworkDirectory.ItemSpec, "Facades", file.ItemSpec);
+			}
+
+			var assemblyName    = AssemblyName.GetAssemblyName (path);
+
+			var taskVersion     = Nullable (file.GetMetadata ("Version"));
+			var overrideVersion = Nullable (FrameworkFileOverrides?.FirstOrDefault (o => o.ItemSpec == file.ItemSpec)?.GetMetadata ("Version"));
+			var assemblyVersion = assemblyName.Version.ToString ();
+			var version         = taskVersion ?? overrideVersion ?? assemblyVersion;
+
+			var publicKeyToken  = string.Join ("", assemblyName.GetPublicKeyToken ().Select(b => b.ToString ("x2")));
+
+			return new XElement ("File",
+					new XAttribute ("AssemblyName", assemblyName.Name),
+					new XAttribute ("Version", version),
+					new XAttribute ("PublicKeyToken", publicKeyToken),
+					new XAttribute ("ProcessorArchitecture", assemblyName.ProcessorArchitecture.ToString ()));
+		}
+
+		static string Nullable (string value) => string.IsNullOrEmpty (value) ? null : value;
+	}
+}

--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -5,6 +5,7 @@
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.GitCommitHash" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.GitCommitHash" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll"  TaskName="Xamarin.Android.BuildTools.PrepTasks.SystemUnzip" />
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll"  TaskName="Xamarin.Android.Tools.BootstrapTasks.CreateFrameworkList" />
   <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
   <PropertyGroup>
     <_SourceTopDir>..\..</_SourceTopDir>
@@ -569,15 +570,20 @@
         Files="@(_BclInstalledItem)"
     />
     <ItemGroup>
-      <FrameworkList Include="&lt;FileList Redist=&quot;MonoAndroid&quot; Name=&quot;Xamarin.Android Base Class Libraries&quot;&gt;" />
-      <FrameworkList Include="  &lt;File AssemblyName=&quot;System.Buffers&quot;    Version=&quot;4.0.99.0&quot; /&gt;" />
-      <FrameworkList Include="  &lt;File AssemblyName=&quot;System.Memory&quot;     Version=&quot;4.0.99.0&quot; /&gt;" />
-      <FrameworkList Include="&lt;/FileList&gt;" />
+      <_VersionOverride Include="System.Buffers.dll">
+        <Version>4.0.99.0</Version>
+      </_VersionOverride>
+      <_VersionOverride Include="System.Memory.dll">
+        <Version>4.0.99.0</Version>
+      </_VersionOverride>
     </ItemGroup>
-    <WriteLinesToFile
-        File="$(_BclFrameworkDir)RedistList\FrameworkList.xml"
-        Lines="@(FrameworkList)"
-        Overwrite="True"
+    <CreateFrameworkList
+        Redist="MonoAndroid"
+        Name="Xamarin.Android Base Class Libraries"
+        FrameworkListFile="$(_BclFrameworkDir)RedistList\FrameworkList.xml"
+        FrameworkDirectory="$(_BclFrameworkDir)"
+        FrameworkFiles="@(MonoFacadeAssembly);@(MonoProfileAssembly)"
+        FrameworkFileOverrides="@(_VersionOverride)"
     />
   </Target>
 


### PR DESCRIPTION
Fixes: TODO

Context: commit d4fb5e5bd6721f0fe7f1e95648342d9004474014

There was some unfortunate fallout from d4fb5e5b, in which
`FrameworkList.xml` was updated to contain `<File/>` entries for
`System.Buffers.dll` and `System.Memory.dll`: it changed the
`FrameworkList.xml` semantics from "include all the files in this
directory" to "include *only* the specified `<File/>`s."

This in turn means that when editing the Assembly References within
Visual Studio for Mac, the *only* BCL assemblies shown are for
`System.Buffers.dll` and `System.Memory.dll`!

Oops. :-(

Furthermore, there are (at present) *185* files which need to be
listed, between the "real" assemblies and the Facade assemblies.

This is *not* a list I want to manually maintain or otherwise keep up
to date.

Add a new `<CreateFrameworkList/>` MSBuild task to generate
`FrameworkList.xml` for us instead.  It uses the
`System.Reflection.Metadata` NuGet package to extract the assembly
version and PublicKeyToken.  With those in hand, it can then generate
the entire `FrameworkList.xml` listing, using `@(MonoFacadeAssembly)`
and `@(MonoProfileAssembly)` (in
`src/mono-runtimes/ProfileAssemblies.projitems`).  Whenever those item
groups change (e.g. on mono bumps), we'll automatically generate an
appropriate `FrameworkList.xml` file including those new assemblies.