### PR TITLE
[Xamarin.Android.Build.Tasks] filter @(ReferencePath) for MonoAndroid assemblies

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// Filters a set of assemblies based on a given TargetFrameworkIdentifier
+	/// </summary>
+	public class FilterAssemblies : Task
+	{
+		[Required]
+		public string TargetFrameworkIdentifier { get; set; }
+
+		[Required]
+		public bool DesignTimeBuild { get; set; }
+
+		public ITaskItem [] InputAssemblies { get; set; }
+
+		[Output]
+		public ITaskItem [] OutputAssemblies { get; set; }
+
+		public override bool Execute ()
+		{
+			if (InputAssemblies == null)
+				return true;
+
+			var output = new List<ITaskItem> (InputAssemblies.Length);
+			foreach (var assemblyItem in InputAssemblies) {
+				if (DesignTimeBuild && !File.Exists (assemblyItem.ItemSpec)) {
+					Log.LogDebugMessage ($"Skipping non-existent dependency '{assemblyItem.ItemSpec}' during a design-time build.");
+					continue;
+				}
+				using (var pe = new PEReader (File.OpenRead (assemblyItem.ItemSpec))) {
+					var reader = pe.GetMetadataReader ();
+					var assemblyDefinition = reader.GetAssemblyDefinition ();
+					var targetFrameworkIdentifier = assemblyDefinition.GetTargetFrameworkIdentifier (reader);
+					if (targetFrameworkIdentifier == TargetFrameworkIdentifier) {
+						output.Add (assemblyItem);
+					}
+				}
+			}
+			OutputAssemblies = output.ToArray ();
+
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -200,7 +200,7 @@ namespace Xamarin.Android.Tasks
 					.Where (a => a != null)
 					.Distinct ()) {
 				if (DesignTimeBuild && !File.Exists (assemblyPath)) {
-					Log.LogDebugMessage ("Skipping non existant dependancy '{0}' due to design time build.", assemblyPath);
+					Log.LogDebugMessage ($"Skipping non-existent dependency '{assemblyPath}' during a design-time build.");
 					continue;
 				}
 				string assemblyFileName = Path.GetFileNameWithoutExtension (assemblyPath);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Tasks\CheckForInvalidResourceFileNames.cs" />
     <Compile Include="Tasks\CollectNonEmptyDirectories.cs" />
     <Compile Include="Tasks\CollectPdbFiles.cs" />
+    <Compile Include="Tasks\FilterAssemblies.cs" />
     <Compile Include="Tasks\GenerateLibraryResources.cs" />
     <Compile Include="Tasks\Generator.cs" />
     <Compile Include="Tasks\JarToXml.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -58,6 +58,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.CreateAdditionalLibraryResourceCache" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CreateMsymManifest" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.Crunch" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.FilterAssemblies" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.FindLayoutsToBind" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GenerateLayoutBindings" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GenerateLibraryResources" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -494,6 +495,12 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     <_ReferenceDependencyPaths Include="@(ReferenceDependencyPaths)"
         Condition="'$(AndroidApplication)' == '' Or !$(AndroidApplication)"/>
   </ItemGroup>
+  <FilterAssemblies
+      DesignTimeBuild="$(DesignTimeBuild)"
+      TargetFrameworkIdentifier="MonoAndroid"
+      InputAssemblies="@(_ReferencePath);@(_ReferenceDependencyPaths)">
+    <Output TaskParameter="OutputAssemblies" ItemName="_MonoAndroidReferencePath" />
+  </FilterAssemblies>
 </Target>
 
 <PropertyGroup>
@@ -503,13 +510,13 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </PropertyGroup>
 
 <Target Name="_BuildAdditionalResourcesCache"
-    Inputs="@(_ReferencePath);@(_ReferenceDependencyPaths);$(MSBuildProjectFullPath);$(NugetPackagesConfig);$(_AndroidBuildPropertiesCache)"
+    Inputs="@(_MonoAndroidReferencePath);$(MSBuildProjectFullPath);$(NugetPackagesConfig);$(_AndroidBuildPropertiesCache)"
     Outputs="$(_AndroidStampDirectory)_BuildAdditionalResourcesCache.stamp"
     DependsOnTargets="$(_BeforeBuildAdditionalResourcesCache)">
   <GetAdditionalResourcesFromAssemblies
       AndroidSdkDirectory="$(_AndroidSdkDirectory)"
       AndroidNdkDirectory="$(_AndroidNdkDirectory)"
-      Assemblies="@(_ReferencePath);@(_ReferenceDependencyPaths)"
+      Assemblies="@(_MonoAndroidReferencePath)"
       CacheFile="$(_AndroidResourcePathsCache)"
       YieldDuringToolExecution="$(YieldDuringToolExecution)"
       DesignTimeBuild="$(DesignTimeBuild)"
@@ -1389,13 +1396,13 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_ResolveLibraryProjectImports"
-		Inputs="$(ProjectAssetsFile);$(MSBuildProjectFullPath);@(_ReferencePath);@(_ReferenceDependencyPaths);$(_AndroidBuildPropertiesCache)"
+		Inputs="$(ProjectAssetsFile);$(MSBuildProjectFullPath);@(_MonoAndroidReferencePath);$(_AndroidBuildPropertiesCache)"
 		Outputs="$(_AndroidStampDirectory)_ResolveLibraryProjectImports.stamp">
 	<ResolveLibraryProjectImports
 		ContinueOnError="$(DesignTimeBuild)"
 		CacheFile="$(_AndroidLibraryProjectImportsCache)"
 		DesignTimeBuild="$(DesignTimeBuild)"
-		Assemblies="@(_ReferencePath);@(_ReferenceDependencyPaths)"
+		Assemblies="@(_MonoAndroidReferencePath)"
 		AarLibraries="@(AndroidAarLibrary)"
 		ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
 		NativeImportsDirectory="$(_NativeLibraryImportsDirectoryName)"


### PR DESCRIPTION
We have a couple MSBuild targets that need to only operate on
`MonoAndroid` assemblies:

* `_BuildAdditionalResourcesCache` is the precursor to
  Xamarin.Build.Download
* `_ResolveLibraryProjectImports` unzips
  `__AndroidLibrariesProjects__.zip`, .jar/.aar files, etc.

Both of these targets all looking at *all* assemblies, so we could
make a new item group `@(_MonoAndroidReferencePath)` and use this
instead. This would both allow the tasks inside these targets to
operate on less assemblies. It would also allow them to skip for
changes in NetStandard projects.

I added a new `<FilterAssemblies/>` MSBuild task to filter based on
the presence of this attribute in an assembly:

    [assembly: System.Runtime.Versioning.TargetFrameworkAttribute ("MonoAndroid,Version=v8.1")]

MSBuild/Roslyn populate this attribute based on the
`$(TargetFrameworkIdentifier)` of the project.

One complication is that during design-time builds, some assemblies
may not exist. I made `<FilterAssemblies/>` just skip files in this
case--using the same logic that `<ResolveLibraryProjectImports/>`
uses. (I also fixed some wording/misspelling)

## Results ##

I tested the Xamarin.Forms project in this repo.

Initial build:

    Before:
      78 ms  _BuildAdditionalResourcesCache             1 calls
    1678 ms  _ResolveLibraryProjectImports              1 calls
    After:
      47 ms  FilterAssemblies                           1 calls
      23 ms  _BuildAdditionalResourcesCache             1 calls
    1120 ms  _ResolveLibraryProjectImports              1 calls

Incremental build with XAML change:

    Before:
     62 ms  _BuildAdditionalResourcesCache             1 calls
    300 ms  _ResolveLibraryProjectImports              1 calls
    After:
     62 ms  FilterAssemblies                           1 calls
      0 ms  _BuildAdditionalResourcesCache             1 calls
     16 ms  _ResolveLibraryProjectImports              1 calls

Note that during the incremental build, since only a NetStandard
assembly was updated the following targets are skipped:

    _BuildAdditionalResourcesCache:
    Skipping target "_BuildAdditionalResourcesCache" because all output files are up-to-date with respect to the input files.
    ...
    _ResolveLibraryProjectImports:
    Skipping target "_ResolveLibraryProjectImports" because all output files are up-to-date with respect to the input files.

Overall I would say this saves ~500ms on initial build, and ~250ms on
incremental builds.