### PR TITLE
[Xamarin.Android.Build.Tasks] don't copy pdb/mdb to $(OutputPath)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1993,14 +1993,12 @@ because xbuild doesn't support framework reference assemblies.
 		Outputs="$(_AndroidStampDirectory)_CopyPdbFiles.stamp"
 		DependsOnTargets="_ConvertPdbFiles">
 	<ItemGroup>
-		<_CopyPdbFilesOutputFiles Include="@(_ResolvedPortablePdbFiles->'$(OutputPath)%(Filename)%(Extension)')" />
 		<_CopyPdbFilesLinkerFiles Include="@(_ResolvedPortablePdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')" />
 	</ItemGroup>
-	<CopyIfChanged SourceFiles="@(_ResolvedPortablePdbFiles)" DestinationFiles="@(_CopyPdbFilesOutputFiles)" />
 	<CopyIfChanged SourceFiles="@(_ResolvedPortablePdbFiles)" DestinationFiles="@(_CopyPdbFilesLinkerFiles)" />
 	<Touch Files="$(_AndroidStampDirectory)_CopyPdbFiles.stamp" AlwaysCreate="True" />
 	<ItemGroup>
-		<FileWrites Include="@(_CopyPdbFilesOutputFiles);@(_CopyPdbFilesLinkerFiles)" />
+		<FileWrites Include="@(_CopyPdbFilesLinkerFiles)" />
 	</ItemGroup>
 </Target>
 
@@ -2009,14 +2007,12 @@ because xbuild doesn't support framework reference assemblies.
 		Outputs="$(_AndroidStampDirectory)_CopyMdbFiles.stamp"
 		DependsOnTargets="_CollectMdbFiles">
 	<ItemGroup>
-		<_CopyMdbFilesOutputFiles Include="@(_ResolvedMdbFiles->'$(OutputPath)%(Filename)%(Extension)')" />
 		<_CopyMdbFilesLinkerFiles Include="@(_ResolvedMdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')" />
 	</ItemGroup>
-	<CopyIfChanged SourceFiles="@(_ResolvedMdbFiles)" DestinationFiles="@(_CopyMdbFilesOutputFiles)" />
 	<CopyIfChanged SourceFiles="@(_ResolvedMdbFiles)" DestinationFiles="@(_CopyMdbFilesLinkerFiles)" />
 	<Touch Files="$(_AndroidStampDirectory)_CopyMdbFiles.stamp" AlwaysCreate="True" />
 	<ItemGroup>
-		<FileWrites Include="@(_CopyMdbFilesOutputFiles);@(_CopyMdbFilesLinkerFiles)" />
+		<FileWrites Include="@(_CopyMdbFilesLinkerFiles)" />
 	</ItemGroup>
 </Target>
 	


### PR DESCRIPTION
Looking at the build output of a simple app:

    > ls .\samples\HelloWorld\bin\Debug\*.pdb
      Length Name
      ------ ----
        1024 HelloLibrary.pdb
        1304 HelloWorld.pdb
    13943324 Mono.Android.pdb
      153048 Mono.Security.pdb
     1545052 mscorlib.pdb
      106160 System.ComponentModel.Composition.pdb
      393532 System.Core.pdb
       43076 System.Net.Http.pdb
      795468 System.pdb
      325732 System.Runtime.Serialization.pdb
       77008 System.ServiceModel.Internals.pdb
      917588 System.Xml.pdb

There are *not* accompanying `.dll` files for many of these symbols.
Some of these symbols are also quite big!

I don't think we need to be copying these files to `$(OutputPath)` at
all; it doesn't make sense if their accompanying assembly isn't there!

If we remove the `<CopyIfChanged/>` calls in our targets, MSBuild will
handle copying the appropriate symbol files that are needed.

After this change, the directory looks like:

    > ls .\samples\HelloWorld\bin\Debug\*.pdb
      Length Name
      ------ ----
      1024 HelloLibrary.pdb
      1304 HelloWorld.pdb

## Results ##

I did a performance comparison using the Xamarin.Forms app in this
repo. It seems the extra `<CopyIfChanged/>` call was taking between
25-50ms, but the bigger savings here is to not copy a 13MB
Mono.Android.pdb file. There could be bigger savings for developers
that have slower hardware (or don't have SSDs).

Overall it seems this change saves up to 50ms for a small project on
initial build, or incremental builds where an assembly changed.