### PR TITLE
[mingw] Make sure all 64-bit Windows libraries use static libgcc

### DIFF
--- a/build-tools/scripts/mingw-64.cmake.in
+++ b/build-tools/scripts/mingw-64.cmake.in
@@ -22,3 +22,17 @@ set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 set(BUILD_SHARED_LIBS ON)
+
+set(XA_COMPILER_FLAGS "-static-libgcc")
+
+# Set or retrieve the cached flags.
+# This is necessary in case the user sets/changes flags in subsequent
+# configures. If we included our flags in here, they would get
+# overwritten.
+set(CMAKE_C_FLAGS ""
+        CACHE STRING "Flags used by the compiler during all build types.")
+set(CMAKE_CXX_FLAGS ""
+        CACHE STRING "Flags used by the compiler during all build types.")
+
+set(CMAKE_C_FLAGS             "${XA_COMPILER_FLAGS} ${CMAKE_C_FLAGS}")
+set(CMAKE_CXX_FLAGS           "${XA_COMPILER_FLAGS} ${CMAKE_CXX_FLAGS}")

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -124,7 +124,7 @@ else()
   if(WIN32 OR MINGW)
     message(STATUS "Win32 or MinGW")
     set(EXTRA_COMPILER_FLAGS "${EXTRA_COMPILER_FLAGS} -DWINDOWS -DNTDDI_VERSION=NTDDI_VISTA -D_WIN32_WINNT=_WIN32_WINNT_VISTA -fomit-frame-pointer")
-    set(EXTRA_LINKER_FLAGS "${EXTRA_LINKER_FLAGS} -ldl -lmman -pthread -lwsock32 -lshlwapi -lpsapi")
+    set(EXTRA_LINKER_FLAGS "${EXTRA_LINKER_FLAGS} -ldl -lmman -static -pthread -dynamic -lwsock32 -lshlwapi -lpsapi")
 
     if (MINGW_TARGET_32)
       set(ANDROID_ABI "host-mxe-Win32")


### PR DESCRIPTION
Context: 24934c0617683349510b1f3ca2d0c06f42e9c850

MinGW builds of shared libraries may (depending on what the source
code uses) link against `libgcc` in a few variations.  The default
work mode is to use the shared library but since it's specific to
gcc/MinGW, it will not be found on the target system and the library
will fail to load.

  There are two solutions for this:

    * Distribute all the referenced DLLs
    * Link them in statically

This commit takes the second approach, implemented in the way that
will affect all the libraries we build for Windows.