### PR TITLE
[Xamarin.Android.Build.Tasks] _LinkAssembliesNoShrink inputs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2054,7 +2054,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_LinkAssembliesNoShrink"
   Condition="'$(AndroidLinkMode)' == 'None'"
-  Inputs="@(ResolvedUserAssemblies);$(_AndroidBuildPropertiesCache)"
+  Inputs="@(_ResolvedUserMonoAndroidAssemblies);$(_AndroidBuildPropertiesCache)"
   Outputs="$(_AndroidLinkFlag)">
 
     <LinkAssemblies


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/xamarin-android/commit/5ec3e3abf4d5f59954d7f55701a1a13d301ef757

In 5ec3e3a, I used a new `@(_ResolvedUserMonoAndroidAssemblies)` item
group to improve incremental build performance. Targets that only need
to perform work with `MonoAndroid` assemblies, can be skipped unless a
`MonoAndroid` assembly changes.

We can use this same technique with the linker for builds with
`LinkMode=None`. The only steps in this case are:

    if (options.LinkNone) {
        pipeline.AppendStep (new FixAbstractMethodsStep ());
        pipeline.AppendStep (new OutputStep ());
        return pipeline;
    }

`FixAbstractMethodsStep` only applies to `MonoAndroid` assemblies, so
we can use `@(_ResolvedUserMonoAndroidAssemblies)` to decide if
`_LinkAssembliesNoShrink` can be skipped.

For an incremental build with a XAML change, this target was taking:

    424 ms  LinkAssemblies                             1 calls

This was the Xamarin.Forms app in this repo. I would say this improves
incremental build times by about 400ms for small apps.