### PR TITLE
[Xamarin.Android.Build.Tasks] not so many log messages!

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -211,25 +211,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute () 
 		{
-			Log.LogDebugMessage ("Aapt Task");
-			Log.LogDebugMessage ("  AssetDirectory: {0}", AssetDirectory);
-			Log.LogDebugTaskItems ("  ManifestFiles: ", ManifestFiles);
-			Log.LogDebugMessage ("  ResourceDirectory: {0}", ResourceDirectory);
-			Log.LogDebugMessage ("  JavaDesignerOutputDirectory: {0}", JavaDesignerOutputDirectory);
-			Log.LogDebugMessage ("  PackageName: {0}", PackageName);
-			Log.LogDebugMessage ("  UncompressedFileExtensions: {0}", UncompressedFileExtensions);
-			Log.LogDebugMessage ("  ExtraPackages: {0}", ExtraPackages);
-			Log.LogDebugTaskItems ("  AdditionalResourceDirectories: ", AdditionalResourceDirectories);
-			Log.LogDebugTaskItems ("  AdditionalAndroidResourcePaths: ", AdditionalAndroidResourcePaths);
-			Log.LogDebugTaskItems ("  LibraryProjectJars: ", LibraryProjectJars);
-			Log.LogDebugMessage ("  ExtraArgs: {0}", ExtraArgs);
-			Log.LogDebugMessage ("  CreatePackagePerAbi: {0}", CreatePackagePerAbi);
-			Log.LogDebugMessage ("  ResourceNameCaseMap: {0}", ResourceNameCaseMap);
-			Log.LogDebugMessage ("  VersionCodePattern: {0}", VersionCodePattern);
-			Log.LogDebugMessage ("  VersionCodeProperties: {0}", VersionCodeProperties);
-			if (CreatePackagePerAbi)
-				Log.LogDebugMessage ("  SupportedAbis: {0}", SupportedAbis);
-
 			resourceDirectory = ResourceDirectory.TrimEnd ('\\');
 			if (!Path.IsPathRooted (resourceDirectory))
 				resourceDirectory = Path.Combine (WorkingDirectory, resourceDirectory);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
@@ -30,11 +30,6 @@ namespace Xamarin.Android.Tasks {
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("Aapt2Compile Task");
-			Log.LogDebugMessage ("  ResourceNameCaseMap: {0}", ResourceNameCaseMap);
-			Log.LogDebugMessage ("  ResourceSymbolsTextFile: {0}", ResourceSymbolsTextFile);
-			Log.LogDebugTaskItems ("  ResourceDirectories: ", ResourceDirectories);
-
 			Yield ();
 			try {
 				var task = this.RunTask (DoExecute);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -77,9 +77,6 @@ namespace Xamarin.Android.Tasks {
 
 		public override bool Execute ()
 		{
-			if (CreatePackagePerAbi)
-				Log.LogDebugMessage ("  SupportedAbis: {0}", SupportedAbis);
-			
 			Yield ();
 			try {
 				var task = this.RunTask (DoExecute);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AdjustJavacVersionArguments.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AdjustJavacVersionArguments.cs
@@ -29,12 +29,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ($"{nameof (DefaultJdkVersion)}: {DefaultJdkVersion}");
-			Log.LogDebugMessage ("EnableProguard: {0}", EnableProguard);
-			Log.LogDebugMessage ("EnableMultiDex: {0}", EnableMultiDex);
-			Log.LogDebugMessage ($"{nameof (JdkVersion)}: {JdkVersion}");
-			Log.LogDebugMessage ("SkipJavacVersionCheck: {0}", SkipJavacVersionCheck);
-
 			if (JdkVersion.StartsWith ("9", StringComparison.OrdinalIgnoreCase)) {
 				TargetVersion = SourceVersion = DefaultJdkVersion;
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
@@ -33,12 +33,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("AndroidApkSigner:");
-			Log.LogDebugMessage ("  ApkSignerJar: {0}", ApkSignerJar);
-			Log.LogDebugMessage ("  ApkToSign: {0}", ApkToSign);
-			Log.LogDebugMessage ("  ManifestFile: {0}", ManifestFile);
-			Log.LogDebugMessage ("  AdditionalArguments: {0}", AdditionalArguments);
-
 			if (!File.Exists (GenerateFullPathToTool ())) {
 				Log.LogError ($"'{GenerateFullPathToTool ()}' does not exist. You need to install android-sdk build-tools 26.0.1 or above.");
 				return false;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidCreateDebugKey.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidCreateDebugKey.cs
@@ -19,14 +19,6 @@ namespace Xamarin.Android.Tasks
 			Validity = 30 * 365; // 30 years
 		}
 
-		public override bool Execute ()
-		{
-			Log.LogDebugMessage ("AndroidCreateDebugKey : {0}", Command);
-			Log.LogDebugMessage ("          {0}",Validity);
-			Log.LogDebugMessage ("          {0}",KeyAlgorithm);
-			return base.Execute ();
-		}
-
 		protected override CommandLineBuilder CreateCommandLine ()
 		{
 			var cmd = base.CreateCommandLine ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidUpdateResDir.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidUpdateResDir.cs
@@ -59,12 +59,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("  IntermediateDir: {0}", IntermediateDir);
-			Log.LogDebugMessage ("  Prefixes: {0}", Prefixes);
-			Log.LogDebugMessage ("  ProjectDir: {0}", ProjectDir);
-			Log.LogDebugMessage ("  LowercaseFilenames: {0}", LowercaseFilenames);
-			Log.LogDebugTaskItems ("  ResourceFiles:", ResourceFiles);
-
 			var intermediateFiles = new List<ITaskItem> ();
 			var resolvedFiles = new List<ITaskItem> ();
 			
@@ -155,11 +149,6 @@ namespace Xamarin.Android.Tasks
 		
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("RemoveUnknownFiles Task");
-			Log.LogDebugTaskItems ("Files", Files);
-			Log.LogDebugMessage ($"Directory {Directory}");
-			Log.LogDebugMessage ($"RemoveDirectories {RemoveDirectories}");
-
 			var absDir = Path.GetFullPath (Directory);
 			
 			HashSet<string> knownFiles;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidZipAlign.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidZipAlign.cs
@@ -40,16 +40,6 @@ namespace Xamarin.Android.Tasks
 				Alignment, Source.ItemSpec, DestinationDirectory.ItemSpec, Path.DirectorySeparatorChar, sourceFilename);
 		}
 
-		public override bool Execute ()
-		{
-			Log.LogDebugMessage ("AndroidZipAlign Task");
-			Log.LogDebugMessage ("  Alignment: {0}", Alignment);
-			Log.LogDebugMessage ("  Source: {0}", Source.ItemSpec);
-			Log.LogDebugMessage ("  DestinationDirectory: {0}", DestinationDirectory.ItemSpec);
-
-			return base.Execute ();
-		}
-
 		protected override string GenerateFullPathToTool ()
 		{
 			return Path.Combine (ToolPath, ToolExe);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateAdditionalResourceCacheDirectories.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateAdditionalResourceCacheDirectories.cs
@@ -23,10 +23,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("CalculateAdditionalResourceCacheDirectories Task");
-			Log.LogDebugTaskItems ("  AdditionalAndroidResourcePaths:", AdditionalAndroidResourcePaths);
-			Log.LogDebugMessage ("  CacheDirectory: {0}", CacheDirectory);
-
 			if (!AdditionalAndroidResourcePaths.Any ())
 				return true;
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
@@ -113,13 +113,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("CalculateLayoutCodeBehind Task");
-			Log.LogDebugMessage ($"  OutputLanguage: {OutputLanguage}");
-			Log.LogDebugMessage ($"  OutputFileExtension: {OutputFileExtension}");
-			Log.LogDebugMessage ($"  BaseNamespace: {BaseNamespace}");
-			Log.LogDebugMessage ($"  BindingDependenciesCacheFile: {BindingDependenciesCacheFile}");
-			Log.LogDebugTaskItems ("  BoundLayouts:", BoundLayouts);
-
 			widgetWithId = XPathExpression.Compile ("//*[@android:id and string-length(@android:id) != 0] | //include[not(@android:id)]");
 
 			GenerateLayoutBindings.BindingGeneratorLanguage gen;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckDuplicateJavaLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckDuplicateJavaLibraries.cs
@@ -14,10 +14,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugTaskItems ("  JavaSourceFiles:", JavaSourceFiles);
-			Log.LogDebugTaskItems ("  JavaLibraries:", JavaLibraries);
-			Log.LogDebugTaskItems ("  LibraryProjectJars:", LibraryProjectJars);
-
 			var jarFiles = (JavaSourceFiles != null) ? JavaSourceFiles.Where (f => f.ItemSpec.EndsWith (".jar")) : null;
 			if (jarFiles != null && JavaLibraries != null)
 				jarFiles = jarFiles.Concat (JavaLibraries);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckForRemovedItems.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckForRemovedItems.cs
@@ -20,10 +20,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("RemoveUnknownFiles Task");
-			Log.LogDebugTaskItems ("Files", Files);
-			Log.LogDebugMessage ("  Directory:", Directory);
-
 			var absDir = Path.GetFullPath (Directory);
 
 			HashSet<string> knownFiles;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckProjectItems.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckProjectItems.cs
@@ -17,10 +17,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("CheckProjectItems Task");
-			Log.LogDebugTaskItems ("  NativeLibraries:", NativeLibraries);
-			Log.LogDebugTaskItems ("  JavaLibraries:", JavaLibraries);
-			Log.LogDebugTaskItems ("  JavaSourceFiles:", JavaSourceFiles);
 			if (IsApplication && EmbeddedNativeLibraries != null && EmbeddedNativeLibraries.Length > 0) {
 				foreach (ITaskItem lib in EmbeddedNativeLibraries) {
 					Log.LogError (

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ClassParse.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ClassParse.cs
@@ -25,11 +25,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("ClassParse Task");
-			Log.LogDebugMessage ("  OutputFile: {0}", OutputFile);
-			Log.LogTaskItems ("  SourceJars: ", SourceJars);
-			Log.LogTaskItems ("  DocumentationPaths: ", DocumentationPaths);
-
 			using (var output = new StreamWriter (OutputFile, append: false, 
 						encoding: new UTF8Encoding (encoderShouldEmitUTF8Identifier: false))) {
 				Bytecode.Log.OnLog = LogEventHandler;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ComputeHash.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ComputeHash.cs
@@ -21,7 +21,6 @@ namespace Xamarin.Android.Tasks {
 
 		public override bool Execute ()
 		{
-			Log.LogDebugTaskItems ("Source : ", Source);
 			using (var sha1 = SHA1.Create ()) {
 
 				foreach (var item in Source) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertDebuggingFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertDebuggingFiles.cs
@@ -18,9 +18,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("ConvertDebuggingFiles Task");
-			Log.LogDebugMessage ("  InputFiles: {0}", Files);
-
 			var convertedFiles = new List<ITaskItem> ();
 			foreach (var file in Files) {
 				var pdb = file.ItemSpec;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyAndConvertResources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyAndConvertResources.cs
@@ -39,11 +39,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("CopyAndConvertResources Task");
-			Log.LogDebugTaskItems ("  SourceFiles:", SourceFiles);
-			Log.LogDebugTaskItems ("  DestinationFiles:", DestinationFiles);
-			Log.LogDebugMessage ("  AcwMapFile: {0}", AcwMapFile);
-
 			if (SourceFiles.Length != DestinationFiles.Length)
 				throw new ArgumentException ("source and destination count mismatch");
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyIfChanged.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyIfChanged.cs
@@ -29,10 +29,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("CopyIfChanged Task");
-			Log.LogDebugTaskItems ("  SourceFiles: {0}", SourceFiles);
-			Log.LogDebugTaskItems ("  DestinationFiles: {0}", DestinationFiles);
-
 			if (SourceFiles.Length != DestinationFiles.Length)
 				throw new ArgumentException ("source and destination count mismatch");
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateAdditionalLibraryResourceCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateAdditionalLibraryResourceCache.cs
@@ -25,9 +25,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("CreateAdditionalLibraryResourceCache Task");
-			Log.LogDebugTaskItems ("  AdditionalAndroidResourcePaths:", AdditionalAndroidResourcePaths);
-			Log.LogDebugTaskItems ("  AdditionalAndroidResourceCachePaths: ", AdditionalAndroidResourceCachePaths);
 			var copiedResources = new List<ITaskItem> ();
 
 			for (int i = 0; i < AdditionalAndroidResourcePaths.Length; i++) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
@@ -40,18 +40,6 @@ namespace Xamarin.Android.Tasks
 			if (LibraryProjectPropertiesFiles.Length == 0 && LibraryProjectZipFiles.Length == 0)
 				return true;
 			
-			Log.LogDebugMessage ("CreateLibraryResourceArchive Task");
-			Log.LogDebugMessage ("  OutputDirectory: {0}", OutputDirectory);
-			Log.LogDebugMessage ("  OutputJarsDirectory: {0}", OutputJarsDirectory);
-			Log.LogDebugMessage ("  OutputAnnotationsDirectory: {0}", OutputAnnotationsDirectory);
-			Log.LogDebugMessage ("  LibraryProjectProperties:");
-			
-			foreach (var p in LibraryProjectPropertiesFiles)
-				Log.LogDebugMessage ("    " + p.ItemSpec);
-			Log.LogDebugMessage ("  LibraryProjectZip:");
-			foreach (var z in LibraryProjectZipFiles)
-				Log.LogDebugMessage ("    " + z.ItemSpec);
-			
 			var outDirInfo = new DirectoryInfo (OutputDirectory);
 			
 			// Copy files into _LibraryProjectImportsDirectoryName (library_project_imports) dir.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateResgenManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateResgenManifest.cs
@@ -21,10 +21,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("CreateResgenManifest Task");
-			Log.LogDebugMessage ("  ManifestOutputFile: {0}", ManifestOutputFile);
-			Log.LogDebugMessage ("  PackageName: {0}", PackageName);
-
 			// <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 			//		   package="MonoAndroidApplication4.MonoAndroidApplication4" />
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateTemporaryDirectory.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateTemporaryDirectory.cs
@@ -16,8 +16,6 @@ namespace Xamarin.Android.Tasks
 		{
 			TemporaryDirectory = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
 			Directory.CreateDirectory (TemporaryDirectory);
-
-			Log.LogDebugMessage ("CreateTemporaryDirectory Task");
 			Log.LogDebugMessage ("  OUTPUT: TemporaryDirectory: {0}", TemporaryDirectory);
 
 			return true;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
@@ -86,8 +86,6 @@ namespace Xamarin.Android.Tasks
 
 		void DoExecute ()
 		{
-			LogDebugMessage ("Crunch Task");
-			LogDebugTaskItems ("  SourceFiles:", SourceFiles);
 			// copy the changed files over to a temp location for processing
 			var imageFiles = SourceFiles.Where (x => string.Equals (Path.GetExtension (x.ItemSpec),".png", StringComparison.OrdinalIgnoreCase));
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/DetermineJavaLibrariesToCompile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/DetermineJavaLibrariesToCompile.cs
@@ -35,16 +35,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("DetermineJavaLibrariesToCompile");
-			Log.LogDebugMessage ("  EnableInstantRun: {0}", EnableInstantRun);
-			Log.LogDebugMessage ("  MonoPlatformJarPaths: {0}", MonoPlatformJarPaths);
-			Log.LogDebugTaskItems ("  JavaSourceFiles:", JavaSourceFiles);
-			Log.LogDebugTaskItems ("  JavaLibraries:", JavaLibraries);
-			Log.LogDebugTaskItems ("  ExternalJavaLibraries:", ExternalJavaLibraries);
-			Log.LogDebugTaskItems ("  LibraryProjectJars:", LibraryProjectJars);
-			Log.LogDebugTaskItems ("  AdditionalJavaLibraryReferences:", AdditionalJavaLibraryReferences);
-			Log.LogDebugTaskItems ("  DoNotPackageJavaLibraries:", DoNotPackageJavaLibraries);
-
 			var jars = new List<ITaskItem> ();
 			if (!EnableInstantRun)
 				jars.AddRange (MonoPlatformJarPaths);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/FindLayoutsToBind.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/FindLayoutsToBind.cs
@@ -28,12 +28,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("FindLayoutsToBind Task");
-			Log.LogDebugMessage ($"  GenerateLayoutBindings: {GenerateLayoutBindings}");
-			Log.LogDebugMessage ($"  BindingDependenciesCacheFile: {BindingDependenciesCacheFile}");
-			Log.LogDebugTaskItems ("  BoundLayouts:", BoundLayouts);
-			Log.LogDebugTaskItems ("  ResourceFiles:", ResourceFiles);
-
 			var layouts = new Dictionary <string, ITaskItem> (StringComparer.OrdinalIgnoreCase);
 			if (GenerateLayoutBindings) {
 				Log.LogDebugMessage ("Collecting all layouts");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutBindings.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutBindings.cs
@@ -79,13 +79,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("GenerateLayoutBindings Task");
-			Log.LogDebugMessage ($"  OutputLanguage: {OutputLanguage}");
-			Log.LogDebugMessage ($"  MonoAndroidCodeBehindDir: {MonoAndroidCodeBehindDir}");
-			Log.LogDebugMessage ($"  AppNamespace: {AppNamespace}");
-			Log.LogDebugTaskItems ("  ResourceFiles:", ResourceFiles, true);
-			Log.LogDebugTaskItems ("  PartialClassFiles:", PartialClassFiles, true);
-
 			if (String.IsNullOrWhiteSpace (OutputLanguage))
 				OutputLanguage = DefaultOutputGenerator.Name;
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutCodeBehind.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutCodeBehind.cs
@@ -100,10 +100,6 @@ namespace Xamarin.Android.Tasks {
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("GenerateCodeBehindForLayout Task");
-			Log.LogDebugMessage ("  MonoAndroidCodeBehindDir: {0}", MonoAndroidCodeBehindDir);
-			Log.LogDebugTaskItems ("  ResourceFiles:", ResourceFiles);
-
 			var generatedFiles = new List<ITaskItem> ();
 
 			var generatorOptions = new CodeGeneratorOptions {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateManagedAidlProxies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateManagedAidlProxies.cs
@@ -34,13 +34,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("Task GenerateManagedAidlProxies");
-			Log.LogDebugTaskItems ("  References:", References);
-			Log.LogDebugTaskItems ("  SourceAidlFiles:", SourceAidlFiles);
-			Log.LogDebugMessage ("  IntermediateOutputDirectory: {0}", IntermediateOutputDirectory);
-			Log.LogDebugMessage ("  OutputNamespace: {0}", OutputNamespace);
-			Log.LogDebugMessage ("  ParcelableHandlingOption: {0}", ParcelableHandlingOption);
-
 			if (SourceAidlFiles.Length == 0) // nothing to do
 				return true;
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
@@ -55,17 +55,6 @@ namespace Xamarin.Android.Tasks
 			// Use "Application" as the default namespace name to work with XS.
 			Namespace = Namespace ?? "Application";
 
-			Log.LogDebugMessage ("GenerateResourceDesigner Task");
-			Log.LogDebugMessage ("  NetResgenOutputFile: {0}", NetResgenOutputFile);
-			Log.LogDebugMessage ("  JavaResgenInputFile: {0}", JavaResgenInputFile);
-			Log.LogDebugMessage ("  Namespace: {0}", Namespace);
-			Log.LogDebugMessage ("  ResourceDirectory: {0}", ResourceDirectory);
-			Log.LogDebugTaskItemsAndLogical ("  AdditionalResourceDirectories:", AdditionalResourceDirectories);
-			Log.LogDebugMessage ("  IsApplication: {0}", IsApplication);
-			Log.LogDebugMessage ("  UseManagedResourceGenerator: {0}", UseManagedResourceGenerator);
-			Log.LogDebugTaskItemsAndLogical ("  Resources:", Resources);
-			Log.LogDebugTaskItemsAndLogical ("  References:", References);
-
 			if (!File.Exists (JavaResgenInputFile) && !UseManagedResourceGenerator)
 				return true;
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
@@ -55,20 +55,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("BindingsGenerator Task");
-			Log.LogDebugMessage ("  OnlyRunXmlAdjuster: {0}", OnlyRunXmlAdjuster);
-			Log.LogDebugMessage ("  OutputDirectory: {0}", OutputDirectory);
-			Log.LogDebugMessage ("  EnumDirectory: {0}", EnumDirectory);
-			Log.LogDebugMessage ("  EnumMetadataDirectory: {0}", EnumMetadataDirectory);
-			Log.LogDebugMessage ("  ApiXmlInput: {0}", ApiXmlInput);
-			Log.LogDebugMessage ("  AssemblyName: {0}", AssemblyName);
-			Log.LogDebugMessage ("  AndroidApiLevel: {0}", AndroidApiLevel);
-			Log.LogDebugMessage ("  UseShortFileNames: {0}", UseShortFileNames);
-			Log.LogDebugTaskItems ("  TransformFiles:", TransformFiles);
-			Log.LogDebugTaskItems ("  ReferencedManagedLibraries:", ReferencedManagedLibraries);
-			Log.LogDebugTaskItems ("  AnnotationsZipFiles:", AnnotationsZipFiles);
-			Log.LogDebugTaskItems ("  TypeMappingReportFile:", TypeMappingReportFile);
-
 			Directory.CreateDirectory (OutputDirectory);
 
 			// We need to do this validation in Execute rather than GenerateCommandLineCommands

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidPackageName.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidPackageName.cs
@@ -45,10 +45,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("GetAndroidPackageName Task");
-			Log.LogDebugMessage ("  ManifestFile: {0}", ManifestFile);
-			Log.LogDebugMessage ("  AssemblyName: {0}", AssemblyName);
-
 			// If we don't have a manifest, default to using the assembly name
 			// If the assembly doesn't have a period in it, duplicate it so it does
 			PackageName = AndroidAppManifest.CanonicalizePackageName (AssemblyName);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetConvertedJavaLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetConvertedJavaLibraries.cs
@@ -20,11 +20,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("GetConvertedJavaLibraries Task");
-			Log.LogDebugMessage ("  Extension: {0}", Extension);
-			Log.LogDebugMessage ("  OutputJackDirectory: {0}", OutputJackDirectory);
-			Log.LogDebugTaskItems ("  JarsToConvert:", JarsToConvert);
-
 			var md5 = MD5.Create ();
 			ConvertedFilesToBeGenerated =
 				(JarsToConvert ?? new string [0]).Select (

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetExtraPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetExtraPackages.cs
@@ -35,8 +35,6 @@ namespace Xamarin.Android.Tasks
 			}
 
 			ExtraPackages = String.Join (":", extraPackages.Distinct ().ToArray ());
-
-			Log.LogDebugMessage ("CreateTemporaryDirectory Task");
 			Log.LogDebugMessage ("  OUTPUT: ExtraPackages: {0}", ExtraPackages);
 
 			return true;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetFilesThatExist.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetFilesThatExist.cs
@@ -22,10 +22,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("GetFilesThatExist Task");
-			Log.LogDebugTaskItems ("  Files", Files);
-			Log.LogDebugTaskItems ("  IgnoreFiles", IgnoreFiles);
-
 			FilesThatExist = Files.Where (p => File.Exists (p.ItemSpec) &&
 					(!IgnoreFiles?.Contains (p, TaskItemComparer.DefaultComparer) ?? true)).ToArray ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetMonoPlatformJar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetMonoPlatformJar.cs
@@ -20,9 +20,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("GetMonoPlatformJar Task");
-			Log.LogDebugMessage ("  TargetFrameworkDirectory: {0}", TargetFrameworkDirectory);
-			
 			var directories = TargetFrameworkDirectory.Split (new char[] { ';', ','} ,StringSplitOptions.RemoveEmptyEntries);
 
 			foreach (var dir in directories)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JarToXml.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JarToXml.cs
@@ -45,23 +45,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("JarToXml Task");
-			Log.LogDebugMessage ("  JavaOptions: {0}", JavaOptions);
-			Log.LogDebugMessage ("  JavaMaximumHeapSize: {0}", JavaMaximumHeapSize);
-			Log.LogDebugMessage ("  AndroidSdkDirectory: {0}", AndroidSdkDirectory);
-			Log.LogDebugMessage ("  AndroidApiLevel: {0}", AndroidApiLevel);
-			Log.LogDebugMessage ("  MonoAndroidToolsDirectory: {0}", MonoAndroidToolsDirectory);
-			Log.LogDebugMessage ("  JavaSdkDirectory: {0}", JavaSdkDirectory);
-			Log.LogDebugMessage ("  OutputFile: {0}", OutputFile);
-			Log.LogDebugMessage ("  DroidDocPaths: {0}", DroidDocPaths);
-			Log.LogDebugMessage ("  JavaDocPaths: {0}", JavaDocPaths);
-			Log.LogDebugMessage ("  Java7DocPaths: {0}", Java7DocPaths);
-			Log.LogDebugMessage ("  Java8DocPaths: {0}", Java8DocPaths);
-			Log.LogDebugTaskItems ("  JavaDocs: {0}", JavaDocs);
-			Log.LogDebugTaskItems ("  LibraryProjectJars:", LibraryProjectJars);
-			Log.LogDebugTaskItems ("  SourceJars:", SourceJars);
-			Log.LogDebugTaskItems ("  ReferenceJars:", ReferenceJars);
-
 			if (SourceJars == null || SourceJars.Count () == 0) {
 				Log.LogError ("At least one Java library is required for binding, this must be either 'EmbeddedJar', 'InputJar' (for jar), 'LibraryProjectZip' (for aar or zip) or 'LibraryProjectProperties' (project.properties) build action.");
 				return false;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaCompileToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaCompileToolTask.cs
@@ -37,19 +37,8 @@ namespace Xamarin.Android.Tasks
 
 		internal string TemporarySourceListFile;
 
-		public virtual void OnLogStarted ()
-		{ 
-		}
-
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("{0} Task", GetType ().Name);
-			Log.LogDebugMessage ("  StubSourceDirectory: {0}", StubSourceDirectory);
-			Log.LogDebugMessage ("  TargetFrameworkDirectory: {0}", TargetFrameworkDirectory);
-			Log.LogDebugTaskItems ("  JavaSourceFiles:", JavaSourceFiles);
-			Log.LogDebugTaskItems ("  Jars:", Jars);
-			OnLogStarted ();
-
 			GenerateResponseFile ();
 
 			var retval = base.Execute ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaDoc.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaDoc.cs
@@ -29,13 +29,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("JavaDoc Task");
-			Log.LogDebugTaskItems ("  SourceDirectories: ", SourceDirectories);
-			Log.LogDebugTaskItems ("  DestinationDirectories: ", DestinationDirectories);
-			Log.LogDebugMessage ("  JavaPlatformJar: {0}", JavaPlatformJar);
-			Log.LogDebugTaskItems ("  ReferenceJars: ", ReferenceJars);
-			Log.LogDebugTaskItems ("  ExtraArgs: ", ExtraArgs);
-
 			foreach (var dir in DestinationDirectories)
 				if (!Directory.Exists (dir))
 					Directory.CreateDirectory (dir);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
@@ -21,13 +21,6 @@ namespace Xamarin.Android.Tasks
 		public string JavacTargetVersion { get; set; }
 		public string JavacSourceVersion { get; set; }
 
-		public override void OnLogStarted ()
-		{
-			Log.LogDebugMessage ("  ClassesOutputDirectory: {0}", ClassesOutputDirectory);
-			Log.LogDebugMessage ("  JavacTargetVersion: {0}", JavacTargetVersion);
-			Log.LogDebugMessage ("  JavacSourceVersion: {0}", JavacSourceVersion);
-		}
-
 		public override bool Execute ()
 		{
 			if (!Directory.Exists (ClassesOutputDirectory))

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
@@ -185,8 +185,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("Lint Task");
-
 			if (string.IsNullOrEmpty (ToolPath) || !File.Exists (GenerateFullPathToTool ())) {
 				Log.LogCodedError ("XA5205", $"Cannot find `{ToolName}` in the Android SDK. Please set its path via /p:LintToolPath.");
 				return false;
@@ -200,18 +198,6 @@ namespace Xamarin.Android.Tasks
 						DisabledIssues = issue.Key + (!string.IsNullOrEmpty (DisabledIssues) ? "," + DisabledIssues : "");
 				}
 			}
-
-			Log.LogDebugMessage ("  TargetDirectory: {0}", TargetDirectory);
-			Log.LogDebugMessage ("  JavaSdkPath: {0}", JavaSdkPath);
-			Log.LogDebugMessage ("  EnabledChecks: {0}", EnabledIssues);
-			Log.LogDebugMessage ("  DisabledChecks: {0}", DisabledIssues);
-			Log.LogDebugMessage ("  CheckIssues: {0}", CheckIssues);
-			Log.LogDebugTaskItems ("  ConfigFiles:", ConfigFiles);
-			Log.LogDebugTaskItems ("  ResourceDirectories:", ResourceDirectories);
-			Log.LogDebugTaskItems ("  SourceDirectories:", SourceDirectories);
-			Log.LogDebugTaskItems ("  ClassDirectories:", ClassDirectories);
-			Log.LogDebugTaskItems ("  LibraryDirectories:", LibraryDirectories);
-			Log.LogDebugTaskItems ("  LibraryJars:", LibraryJars);
 
 			foreach (var issue in DisabledIssuesByVersion) {
 				if (lintToolVersion < issue.Value) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MergeResources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MergeResources.cs
@@ -30,10 +30,6 @@ namespace Xamarin.Android.Tasks
 			// ok copy all the files from Cache into dest path
 			// then copy over the App Resources
 			// emit warnings if we find duplicates.
-			Log.LogDebugMessage ("MergeResources Task");
-			Log.LogDebugTaskItems ("  SourceFiles: ", SourceFiles);
-			Log.LogDebugTaskItems ("  DestinationFiles: ", DestinationFiles);
-
 			List<int> changedFiles = new List<int> ();
 
 			merger = new ResourceMerger () {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ParseAndroidWearProjectAndManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ParseAndroidWearProjectAndManifest.cs
@@ -22,8 +22,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("ParseAndroidWearProjectAndManifest task");
-			Log.LogDebugTaskItems ("  ProjectFiles:", ProjectFiles);
 			if (ProjectFiles.Length != 1)
 				Log.LogError ("More than one Android Wear project is specified as the paired project. It can be at most one.");
 			

--- a/src/Xamarin.Android.Build.Tasks/Tasks/PrepareWearApplicationFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/PrepareWearApplicationFiles.cs
@@ -24,11 +24,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("PrepareWearApplicationFiles task");
-			Log.LogDebugTaskItems ("  WearAndroidManifestFile:", WearAndroidManifestFile);
-			Log.LogDebugTaskItems ("  IntermediateOutputPath:", IntermediateOutputPath);
-			Log.LogDebugTaskItems ("  WearApplicationApkPath:", WearApplicationApkPath);
-
 			string rawapk = "wearable_app.apk";
 			string intermediateApkPath = Path.Combine (IntermediateOutputPath, "res", "raw", rawapk);
 			string intermediateXmlFile = Path.Combine (IntermediateOutputPath, "res", "xml", "wearable_app_desc.xml");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadAdditionalResourcesFromAssemblyCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadAdditionalResourcesFromAssemblyCache.cs
@@ -34,8 +34,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("Task ReadAdditionalResourcesFromAssemblyCache");
-			Log.LogDebugMessage ("  CacheFile: {0}", CacheFile);
 			if (!File.Exists (CacheFile)) {
 				Log.LogDebugMessage ("{0} does not exist. No Additional Resources found", CacheFile);
 				return !Log.HasLoggedErrors;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadImportedLibrariesCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadImportedLibrariesCache.cs
@@ -48,8 +48,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("Task ReadImportedLibrariesCache");
-			Log.LogDebugMessage ("  CacheFile: {0}", CacheFile);
 			if (!File.Exists (CacheFile)) {
 				Log.LogDebugMessage ("{0} does not exist. No Imported Libraries found", CacheFile);
 				return !Log.HasLoggedErrors;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveRegisterAttribute.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveRegisterAttribute.cs
@@ -19,9 +19,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("RemoveRegisterAttribute Task");
-			Log.LogDebugTaskItems ("  ShrunkFrameworkAssemblies:", ShrunkFrameworkAssemblies);
-
 			// Find Mono.Android.dll
 			var mono_android = ShrunkFrameworkAssemblies.First (f => Path.GetFileNameWithoutExtension (f.ItemSpec) == "Mono.Android").ItemSpec;
 			using (var assembly = AssemblyDefinition.ReadAssembly (mono_android, new ReaderParameters { ReadWrite = true })) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Unzip.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Unzip.cs
@@ -14,10 +14,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("Unzip Task");
-			Log.LogDebugTaskItems ("  Sources: ", Sources);
-			Log.LogDebugTaskItems ("  DestinationDirectories: ", DestinationDirectories);
-
 			foreach (var pair in Sources.Zip (DestinationDirectories, (s, d) => new { Source = s, Destination = d })) {
 				if (!Directory.Exists (pair.Destination.ItemSpec))
 					Directory.CreateDirectory (pair.Destination.ItemSpec);


### PR DESCRIPTION
We used to have the pattern of including log messages at the beginning
of `Execute()` in MSBuild tasks:

    Log.LogDebugMessage ("MyMSBuildTask Task");
    Log.LogDebugMessage ("  FooProperty: {0}", FooProperty);
    Log.LogDebugTaskItems ("  BarItems: ", BarItems);

This was mostly here to improve diagnostic log output from XBuild,
which we no longer support.

MSBuild properly logs any input properties on MSBuild tasks, so we can
remove a lot of code!

There were a couple places I could go a step further:

* `<AndroidCreateDebugKey/>` and `<AndroidZipAlign/>` I could remove
  the entire `Execute()` method.
* `<JavaCompileToolTask/>` had an `OnLogStarted` method I could
  remove. `<Javac/>` also was overriding this method.

I thought this might have *some* impact on build times, since logging
and `string.Format` takes some time (it's not free!).

A build of the Xamarin.Forms app in this repo:

    # Before
    Time Elapsed 00:00:25.66
    Time Elapsed 00:00:25.36
    Time Elapsed 00:00:25.67
    # After
    Time Elapsed 00:00:24.58
    Time Elapsed 00:00:23.98
    Time Elapsed 00:00:24.98

The overall build times vary quite a bit. So if I took a conservative
estimate it seems the initial build is 500ms better?

A more revealing difference, I think, is the size of these binlog
files:

    # fresh build
    746947 before.first.binlog
    740797 after.first.binlog
    # build with no changes
    827913 before.second.binlog
    825665 after.second.binlog
    # build with xaml change
    848821 before.third.binlog
    844365 after.third.binlog

These files are compressed, so if they are 2K-6K smaller that was a
lot of log messages...