### PR TITLE
[tests] fix BuildNativeLibs for MultiDex/AppBundle tests

### DIFF
--- a/tests/Runtime-AppBundle/Mono.Android-TestsAppBundle.targets
+++ b/tests/Runtime-AppBundle/Mono.Android-TestsAppBundle.targets
@@ -1,19 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_MonoAndroidTestDir>$(MSBuildThisFileDirectory)..\..\src\Mono.Android\Test\</_MonoAndroidTestDir>
+  </PropertyGroup>
   <ItemGroup>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\..\src\Mono.Android\Test\libs\arm64-v8a\libreuse-threads.so" />
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\..\src\Mono.Android\Test\libs\armeabi-v7a\libreuse-threads.so" />
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\..\src\Mono.Android\Test\libs\x86\libreuse-threads.so" />
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\..\src\Mono.Android\Test\libs\x86_64\libreuse-threads.so" />
+    <AndroidNativeLibrary Include="$(_MonoAndroidTestDir)libs\arm64-v8a\libreuse-threads.so" />
+    <AndroidNativeLibrary Include="$(_MonoAndroidTestDir)libs\armeabi-v7a\libreuse-threads.so" />
+    <AndroidNativeLibrary Include="$(_MonoAndroidTestDir)libs\x86\libreuse-threads.so" />
+    <AndroidNativeLibrary Include="$(_MonoAndroidTestDir)libs\x86_64\libreuse-threads.so" />
   </ItemGroup>
   <Import Project="Mono.Android-TestsAppBundle.projitems" />
   <Import Project="..\..\build-tools\scripts\TestApks.targets" />
   <Target Name="BuildNativeLibs"
       BeforeTargets="Build"
       DependsOnTargets="AndroidPrepareForBuild"
-      Inputs="$(MSBuildThisFileDirectory)..\..\src\Mono.Android\Test\jni\reuse-threads.c;$(MSBuildThisFileDirectory)..\..\src\Mono.Android\Test\jni\Android.mk"
+      Inputs="$(_MonoAndroidTestDir)jni\reuse-threads.c;$(_MonoAndroidTestDir)jni\Android.mk"
       Outputs="@(AndroidNativeLibrary)">
     <Error Text="Could not locate Android NDK." Condition="!Exists ('$(NdkBuildPath)')" />
-    <Exec Command="&quot;$(NdkBuildPath)&quot;" />
+    <Exec Command="&quot;$(NdkBuildPath)&quot;" WorkingDirectory="$(_MonoAndroidTestDir)" />
   </Target>
 </Project>

--- a/tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.targets
+++ b/tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.targets
@@ -1,19 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_MonoAndroidTestDir>$(MSBuildThisFileDirectory)..\..\src\Mono.Android\Test\</_MonoAndroidTestDir>
+  </PropertyGroup>
   <ItemGroup>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\..\src\Mono.Android\Test\libs\arm64-v8a\libreuse-threads.so" />
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\..\src\Mono.Android\Test\libs\armeabi-v7a\libreuse-threads.so" />
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\..\src\Mono.Android\Test\libs\x86\libreuse-threads.so" />
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\..\src\Mono.Android\Test\libs\x86_64\libreuse-threads.so" />
+    <AndroidNativeLibrary Include="$(_MonoAndroidTestDir)libs\arm64-v8a\libreuse-threads.so" />
+    <AndroidNativeLibrary Include="$(_MonoAndroidTestDir)libs\armeabi-v7a\libreuse-threads.so" />
+    <AndroidNativeLibrary Include="$(_MonoAndroidTestDir)libs\x86\libreuse-threads.so" />
+    <AndroidNativeLibrary Include="$(_MonoAndroidTestDir)libs\x86_64\libreuse-threads.so" />
   </ItemGroup>
   <Import Project="Mono.Android-TestsMultiDex.projitems" />
   <Import Project="..\..\build-tools\scripts\TestApks.targets" />
   <Target Name="BuildNativeLibs"
       BeforeTargets="Build"
       DependsOnTargets="AndroidPrepareForBuild"
-      Inputs="$(MSBuildThisFileDirectory)..\..\src\Mono.Android\Test\jni\reuse-threads.c;$(MSBuildThisFileDirectory)..\..\src\Mono.Android\Test\jni\Android.mk"
+      Inputs="$(_MonoAndroidTestDir)jni\reuse-threads.c;$(_MonoAndroidTestDir)jni\Android.mk"
       Outputs="@(AndroidNativeLibrary)">
     <Error Text="Could not locate Android NDK." Condition="!Exists ('$(NdkBuildPath)')" />
-    <Exec Command="&quot;$(NdkBuildPath)&quot;" />
+    <Exec Command="&quot;$(NdkBuildPath)&quot;" WorkingDirectory="$(_MonoAndroidTestDir)" />
   </Target>
 </Project>


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/job/xamarin-android-pr-pipeline-release/505/

If `Mono.Android-Tests.csproj` fails to build, you get further errors down the line, such as:

    BuildNativeLibs:
    "/Users/builder/android-toolchain/ndk/ndk-build"
        /Users/builder/android-toolchain/ndk/build/core/build-local.mk:151: *** Android NDK: Aborting    .  Stop.
        Android NDK: Could not find application project directory !
        Android NDK: Please define the NDK_PROJECT_PATH variable to point to it.
        make[1]: Entering directory `/Users/builder/jenkins/workspace/xamarin-android-pr-pipeline-release/xamarin-android/tests/Runtime-MultiDex'
        make[1]: Leaving directory `/Users/builder/jenkins/workspace/xamarin-android-pr-pipeline-release/xamarin-android/tests/Runtime-MultiDex'
    /Users/builder/jenkins/workspace/xamarin-android-pr-pipeline-release/xamarin-android/tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.targets(17,5): error MSB3073: The command ""/Users/builder/android-toolchain/ndk/ndk-build"" exited with code 2. [/Users/builder/jenkins/workspace/xamarin-android-pr-pipeline-release/xamarin-android/tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.csproj]

It looks like this also happens if you just try to build either of
these projects before `Mono.Android-Tests.csproj`:

* `tests\Runtime-MultiDex\Mono.Android-TestsMultiDex.csproj`
* `tests\Runtime-AppBundle\Mono.Android-TestsAppBundle.csproj`

I cleaned up these two projects to use a `$(_MonoAndroidTestDir)`
property. I also added a `WorkingDirectory` to the `<Exec/>` call,
which fixes the problem.