### PR TITLE
[Xamarin.Android.Build.Tasks] <GenerateJavaStubs/> improvements

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -481,8 +481,10 @@ namespace Lib2
 			app.SetProperty ("AndroidUseSharedRuntime", false.ToString ());
 
 			int count = 0;
-			var lib = new XamarinAndroidLibraryProject {
+			var lib = new DotNetStandard {
 				ProjectName = "MyLibrary",
+				Sdk = "Microsoft.NET.Sdk",
+				TargetFramework = "netstandard2.0",
 				Sources = {
 					new BuildItem.Source ("Bar.cs") {
 						TextContent = () => "public class Bar { public Bar () { System.Console.WriteLine (" + count++ + "); } }"
@@ -503,8 +505,10 @@ namespace Lib2
 				Assert.IsTrue (appBuilder.Build (app, doNotCleanupOnUpdate: true, saveProject: false), "second app build should have succeeded.");
 
 				var targetsShouldSkip = new [] {
-					//TODO: perhaps more targets will skip here eventually?
 					"CoreCompile",
+					"_BuildLibraryImportsCache",
+					"_ResolveLibraryProjectImports",
+					"_GenerateJavaStubs",
 				};
 				foreach (var target in targetsShouldSkip) {
 					Assert.IsTrue (appBuilder.Output.IsTargetSkipped (target), $"`{target}` should be skipped!");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -341,7 +341,6 @@ namespace Xamarin.Android.Build.Tests
 		public void NetStandardReferenceTest ()
 		{
 			var netStandardProject = new DotNetStandard () {
-				Language = XamarinAndroidProjectLanguage.CSharp,
 				ProjectName = "XamFormsSample",
 				ProjectGuid = Guid.NewGuid ().ToString (),
 				Sdk = "Microsoft.NET.Sdk",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetStandard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetStandard.cs
@@ -7,7 +7,6 @@ namespace Xamarin.ProjectTools
 {
 	public class DotNetStandard : XamarinProject
 	{
-
 		public override string ProjectTypeGuid {
 			get {
 				return string.Empty;
@@ -20,7 +19,12 @@ namespace Xamarin.ProjectTools
 			OtherBuildItems = new List<BuildItem> ();
 			SetProperty (CommonProperties, "DebugType", "full");
 			ItemGroupList.Add (Sources);
+			Language = XamarinAndroidProjectLanguage.CSharp;
 		}
+
+		// NetStandard projects always need to restore
+		public override bool ShouldRestorePackageReferences => true;
+
 		public string PackageTargetFallback {
 			get { return GetProperty ("PackageTargetFallback"); }
 			set { SetProperty ("PackageTargetFallback", value); }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
@@ -72,11 +72,6 @@ namespace Xamarin.ProjectTools
 			set { SetProperty (ActiveConfigurationProperties, KnownProperties.IntermediateOutputPath, value); }
 		}
 
-		public BuildItem GetItem (string include)
-		{
-			return ItemGroupList.SelectMany (g => g).First (i => i.Include ().Equals (include, StringComparison.OrdinalIgnoreCase));
-		}
-
 		public void AddReferences (params string [] references)
 		{
 			foreach (var s in references)
@@ -87,12 +82,6 @@ namespace Xamarin.ProjectTools
 		{
 			foreach (var s in sources)
 				Sources.Add (new BuildItem.Source (s));
-		}
-
-		public void Touch (params string [] itemPaths)
-		{
-			foreach (var item in itemPaths)
-				GetItem (item).Timestamp = DateTimeOffset.UtcNow;
 		}
 
 		public virtual ProjectRootElement Construct ()

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -73,7 +73,7 @@ namespace Xamarin.ProjectTools
 				project.NuGetRestore (Path.Combine (XABuildPaths.TestOutputDirectory, ProjectDirectory), PackagesDirectory);
 			}
 
-			bool result = BuildInternal (Path.Combine (ProjectDirectory, project.ProjectFilePath), Target, parameters, environmentVariables, restore: project.PackageReferences?.Count > 0);
+			bool result = BuildInternal (Path.Combine (ProjectDirectory, project.ProjectFilePath), Target, parameters, environmentVariables, restore: project.ShouldRestorePackageReferences);
 			built_before = true;
 
 			if (CleanupAfterSuccessfulBuild)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/SolutionBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/SolutionBuilder.cs
@@ -67,7 +67,7 @@ namespace Xamarin.ProjectTools
 
 		public bool BuildProject(XamarinProject project, string target = "Build")
 		{
-			BuildSucceeded = BuildInternal(Path.Combine (SolutionPath, project.ProjectName, project.ProjectFilePath), target, restore: project.PackageReferences?.Count > 0);
+			BuildSucceeded = BuildInternal(Path.Combine (SolutionPath, project.ProjectName, project.ProjectFilePath), target, restore: project.ShouldRestorePackageReferences);
 			return BuildSucceeded;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -31,6 +31,7 @@ namespace Xamarin.ProjectTools
 		public IList<Package> Packages { get; private set; }
 		public IList<BuildItem> References { get; private set; }
 		public IList<Package> PackageReferences { get; private set; }
+		public virtual bool ShouldRestorePackageReferences => PackageReferences?.Count > 0;
 		public IList<Import> Imports { get; private set; }
 		PropertyGroup common, debug, release;
 
@@ -118,6 +119,17 @@ namespace Xamarin.ProjectTools
 				prop.Condition = condition;
 				prop.Value = value;
 			}
+		}
+
+		public BuildItem GetItem (string include)
+		{
+			return ItemGroupList.SelectMany (g => g).First (i => i.Include ().Equals (include, StringComparison.OrdinalIgnoreCase));
+		}
+
+		public void Touch (params string [] itemPaths)
+		{
+			foreach (var item in itemPaths)
+				GetItem (item).Timestamp = DateTimeOffset.UtcNow;
 		}
 
 		string project_file_path;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -495,7 +495,6 @@ namespace Xamarin.Android.Tasks
 		}
 #endif
 
-		internal static readonly string [] FrameworkAttributeLookupTargets = {"Mono.Android.GoogleMaps.dll"};
 		internal static readonly string [] FrameworkEmbeddedJarLookupTargets = {
 			"Mono.Android.Support.v13.dll",
 			"Mono.Android.Support.v4.dll",
@@ -507,7 +506,6 @@ namespace Xamarin.Android.Tasks
 		};
 		// MUST BE SORTED CASE-INSENSITIVE
 		internal static readonly string[] FrameworkAssembliesToTreatAsUserAssemblies = {
-			"Mono.Android.GoogleMaps.dll",
 			"Mono.Android.Support.v13.dll",
 			"Mono.Android.Support.v4.dll",
 			"Xamarin.Android.NUnitLite.dll",

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2221,7 +2221,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_GenerateJavaStubs"
   DependsOnTargets="_SetLatestTargetFrameworkVersion;_PrepareAssemblies;$(_AfterPrepareAssemblies)"
-  Inputs="$(MSBuildAllProjects);@(_ResolvedAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(_AndroidResourceDest)"
+  Inputs="$(MSBuildAllProjects);@(_ResolvedUserMonoAndroidAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(_AndroidResourceDest)"
   Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
   <GenerateJavaStubs
     ResolvedAssemblies="@(_ResolvedAssemblies)"


### PR DESCRIPTION
I went through the `_GenerateJavaStubs` MSBuild target and the
`<GenerateJavaStubs/>` MSBuild task. There was an "easy" win to
improve incremental build performance. I also made a few other general
improvements to `<GenerateJavaStubs/>`.

## Inputs & Outputs ##

`_GenerateJavaStubs` has `Inputs` of:

    Inputs="$(MSBuildAllProjects);@(_ResolvedAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(_AndroidResourceDest)"

Lets say a NetStandard assembly changes, such as a XAML change in a
Xamarin.Forms app. In this case `_GenerateJavaStubs` does not actually
need to run again.

We can use `@(_ResolvedUserMonoAndroidAssemblies)` as an input instead
of `@(_ResolvedAssemblies)`.

This is the biggest win--to skip this target completely.

## selectedWhitelistAssemblies ##

`ManifestDocument` had the concept of a "whitelist" assembly, which
currently consisted of a single assembly:

    internal static readonly string [] FrameworkAttributeLookupTargets = {"Mono.Android.GoogleMaps.dll"};

`Mono.Android.GoogleMaps.dll` no longer exists, so I was able to
remove a bit of code that still used that dead codepath.

## Typemaps ##

Just a couple minor improvements here:

* Fixed the usage of the `[Obsolete]` constructor for
  `TypeNameMapGenerator`. Using a `(TaskLevel level, string value)`
  callback instead.
* I reused the `MemoryStream` and got rid of the `UpdateWhenChanged`
  method.

## Tests ##

I updated the `IncrementalBuildTest.ProduceReferenceAssembly` test
quite a bit:

* The library project using `$(ProduceReferenceAssembly)` is now a
  NetStandard library.
* I check all the targets that should be skipped from now on.

I made a few changes in `Xamarin.ProjectTools` to clean things up:

* The `DotNetStandard` class should just define
  `Language=XamarinAndroidProjectLanguage.CSharp` by default.
* Added a `ShouldRestorePackageReferences` property for deciding if we
  pass `/restore` or not.
* The `DotNetStandard` class always needs to use `/restore`, even if
  there are no `PackageReferences`.
* I moved a couple methods from `DotNetXamarinProject` to
  `XamarinProject` so the `DotNetStandard` has them.

## Results ##

Testing the Xamarin.Forms project in this repo. A fresh build I wasn't
able to see a noticeable improvement.

*However*, an incremental build with XAML-change:

    Before:
      861 ms  _GenerateJavaStubs                         1 calls
    After:
      n/a

The target is skipped now:

    _GenerateJavaStubs:
    Skipping target "_GenerateJavaStubs" because all output files are up-to-date with respect to the input files.

Overall this seems to be ~800ms better for incremental builds with
XAML changes.