### PR TITLE
[Xamarin.Android.Build.Tasks] <FilterAssemblies/> support missing TFI

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3636,6 +3636,36 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "The \"LinkAssemblies\" task failed unexpectedly"), "The LinkAssemblies MSBuild task should not run!");
 			}
 		}
+
+		/// <summary>
+		/// This assembly weirdly has no [assembly: System.Runtime.Versioning.TargetFrameworkAttribute()], at all...
+		/// </summary>
+		[Test]
+		public void AssemblyWithMissingTargetFramework ()
+		{
+			var proj = new XamarinFormsAndroidApplicationProject {
+				AndroidResources = {
+					new AndroidItem.AndroidResource ("Resources\\layout\\test.axml") {
+						TextContent = () => 
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<ScrollView
+    xmlns:android=""http://schemas.android.com/apk/res/android""
+    xmlns:local=""http://schemas.android.com/apk/res-auto"">
+    <refractored.controls.CircleImageView local:civ_border_width=""0dp"" />
+</ScrollView>"
+					}
+				}
+			};
+			proj.PackageReferences.Add (KnownPackages.CircleImageView);
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "build should have succeeded.");
+
+				// We should have a java stub
+				var intermediate = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath);
+				var javaStub = Path.Combine (intermediate, "android", "src", "md54908d67eb9afef4acc92753cc61471e9", "CircleImageView.java");
+				FileAssert.Exists (javaStub);
+			}
+		}
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/FilterAssembliesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/FilterAssembliesTests.cs
@@ -1,0 +1,102 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xamarin.Android.Tasks;
+using Xamarin.Tools.Zip;
+using TaskItem = Microsoft.Build.Utilities.TaskItem;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	public class FilterAssembliesTests : BaseTest
+	{
+		HttpClient httpClient = new HttpClient ();
+		string tempDirectory;
+
+		[SetUp]
+		public void Setup ()
+		{
+			tempDirectory = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
+			Directory.CreateDirectory (tempDirectory);
+		}
+
+		[TearDown]
+		public void TearDown ()
+		{
+			Directory.Delete (tempDirectory, recursive: true);
+		}
+
+		async Task<string> DownloadFromNuGet (string url)
+		{
+			var response = await httpClient.GetAsync (url);
+			response.EnsureSuccessStatusCode ();
+			var temp = Path.Combine (tempDirectory, Path.GetRandomFileName ());
+			using (var httpStream = await response.Content.ReadAsStreamAsync ())
+			using (var fileStream = File.Create (temp)) {
+				await httpStream.CopyToAsync (fileStream);
+			}
+			return temp;
+		}
+
+		async Task<string []> GetAssembliesFromNuGet (string url, string path)
+		{
+			var assemblies = new List<string> ();
+			var nuget = await DownloadFromNuGet (url);
+			using (var zip = ZipArchive.Open (nuget, FileMode.Open)) {
+				foreach (var entry in zip) {
+					if (entry.FullName.StartsWith (path, StringComparison.OrdinalIgnoreCase) &&
+						entry.FullName.EndsWith (".dll", StringComparison.OrdinalIgnoreCase)) {
+						var temp = Path.Combine (tempDirectory, Path.GetFileName (entry.NativeFullName));
+						assemblies.Add (temp);
+						using (var fileStream = File.Create (temp)) {
+							entry.Extract (fileStream);
+						}
+					}
+				}
+			}
+			return assemblies.ToArray ();
+		}
+
+		string [] Run (params string [] assemblies)
+		{
+			var task = new FilterAssemblies {
+				BuildEngine = new MockBuildEngine (TestContext.Out),
+				TargetFrameworkIdentifier = "MonoAndroid",
+				FallbackReference = "Mono.Android",
+				InputAssemblies = assemblies.Select (a => new TaskItem (a)).ToArray (),
+			};
+			Assert.IsTrue (task.Execute (), "task.Execute() should have succeeded.");
+			return task.OutputAssemblies.Select (a => Path.GetFileName (a.ItemSpec)).ToArray ();
+		}
+
+		[Test]
+		public async Task CircleImageView ()
+		{
+			var assemblies = await GetAssembliesFromNuGet (
+				"https://www.nuget.org/api/v2/package/Refractored.Controls.CircleImageView/1.0.1",
+				"lib/MonoAndroid10/");
+			var actual = Run (assemblies);
+			var expected = new [] { "Refractored.Controls.CircleImageView.dll" };
+			CollectionAssert.AreEqual (expected, actual);
+		}
+
+		[Test]
+		public async Task XamarinForms ()
+		{
+			var assemblies = await GetAssembliesFromNuGet (
+				"https://www.nuget.org/api/v2/package/Xamarin.Forms/3.6.0.220655",
+				"lib/MonoAndroid90/");
+			var actual = Run (assemblies);
+			var expected = new [] {
+				"FormsViewGroup.dll",
+				"Xamarin.Forms.Platform.Android.dll",
+				"Xamarin.Forms.Platform.dll",
+			};
+			CollectionAssert.AreEqual (expected, actual);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -35,6 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="nunit.framework">
@@ -97,6 +98,7 @@
     <Compile Include="ManagedResourceParserTests.cs" />
     <Compile Include="Tasks\BundleToolTests.cs" />
     <Compile Include="Tasks\CopyResourceTests.cs" />
+    <Compile Include="Tasks\FilterAssembliesTests.cs" />
     <Compile Include="Tasks\GenerateLibraryResourcesTests.cs" />
     <Compile Include="Tasks\KeyToolTests.cs" />
     <Compile Include="Aapt2Tests.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -726,6 +726,16 @@ namespace Xamarin.ProjectTools
 				}
 			},
 		};
+		public static Package CircleImageView = new Package {
+			Id = "Refractored.Controls.CircleImageView",
+			Version = "1.0.1",
+			TargetFramework = "MonoAndroid10",
+			References = {
+				new BuildItem.Reference ("Refractored.Controls.CircleImageView") {
+					MetadataValues = "HintPath=..\\packages\\Refractored.Controls.CircleImageView.1.0.1\\lib\\MonoAndroid10\\Refractored.Controls.CircleImageView.dll"
+				}
+			},
+		};
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -506,6 +506,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <FilterAssemblies
       DesignTimeBuild="$(DesignTimeBuild)"
       TargetFrameworkIdentifier="MonoAndroid"
+      FallbackReference="Mono.Android"
       InputAssemblies="@(_ReferencePath);@(_ReferenceDependencyPaths)">
     <Output TaskParameter="OutputAssemblies" ItemName="_MonoAndroidReferencePath" />
   </FilterAssemblies>
@@ -2213,7 +2214,7 @@ because xbuild doesn't support framework reference assemblies.
 
   <CreateItem
     Include="@(_ResolvedUserAssemblies)"
-    Condition="'%(_ResolvedUserAssemblies.TargetFrameworkIdentifier)' == 'MonoAndroid'">
+    Condition="'%(_ResolvedUserAssemblies.TargetFrameworkIdentifier)' == 'MonoAndroid' Or '%(_ResolvedUserAssemblies.HasMonoAndroidReference)' == 'True'">
     <Output TaskParameter="Include" ItemName="_ResolvedUserMonoAndroidAssemblies" />
   </CreateItem>
 </Target>


### PR DESCRIPTION
Context: https://www.nuget.org/packages/Refractored.Controls.CircleImageView/
Context: https://github.com/Azure-Samples/MyDriving
Context: https://github.com/xamarin/xamarin-android/pull/2934

The MyDriving sample app currently fails to build on master with:

    Resources/layout/fragment_profile.axml(2): error APT0000: attribute civ_border_width (aka com.microsoft.mydriving:civ_border_width) not found.

The failure happens with both `aapt` and `aapt2`.

This layout is using a custom view such as:

    <?xml version="1.0" encoding="utf-8"?>
    <ScrollView
        xmlns:android="http://schemas.android.com/apk/res/android"
        xmlns:local="http://schemas.android.com/apk/res-auto">
        ...
        <refractored.controls.CircleImageView local:civ_border_width="0dp" />
        ...
    </ScrollView>

This comes from the `Refractored.Controls.CircleImageView` NuGet
package.

In 5ec3e3a, I added a `<FilterAssemblies/>` MSBuild task that appears
to be to blame. It is not returning
`Refractored.Controls.CircleImageView.dll`, but it needs to!

`Refractored.Controls.CircleImageView.dll` has no `[assembly: System.Runtime.Versioning.TargetFrameworkAttribute]`...

    // C:\src\des\MyDriving\packages\Refractored.Controls.CircleImageView.1.0.1\lib\MonoAndroid10\Refractored.Controls.CircleImageView.dll
    // Refractored.Controls.CircleImageView, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
    // Global type: <Module>
    // Architecture: x86
    // Runtime: v4.0.30319
    // Hash algorithm: SHA1

    using Android.Runtime;
    using System.Reflection;
    using System.Runtime.CompilerServices;
    using System.Security;
    using System.Security.Permissions;

    [assembly: AssemblyTitle("Refractored.Controls.CircleImageView")]
    [assembly: AssemblyDescription("")]
    [assembly: AssemblyConfiguration("")]
    [assembly: AssemblyCompany("")]
    [assembly: AssemblyProduct("")]
    [assembly: AssemblyCopyright("2015 Refractored LLC/James Montemagno")]
    [assembly: AssemblyTrademark("")]
    [assembly: NamespaceMapping(Java = "de.hdodenhof.circleimageview", Managed = "Refractored.Controls")]
    [assembly: RuntimeCompatibility(WrapNonExceptionThrows = true)]
    [assembly: SecurityPermission(8, SkipVerification = true)]
    [assembly: AssemblyVersion("1.0.0.0")]
    [module: UnverifiableCode]

It is indeed a `MonoAndroid` assembly, since it references
`Mono.Android.dll`. It is weird, though...

## What should we do? ##

One idea is to look for `Mono.Android.dll` references in each
assembly *instead* of `TargetFrameworkIdentifier`.

Looking at the assemblies in Xamarin.Forms, there is a complication to
this:

* `Xamarin.Forms.Core.dll` (a NetStandard library) references
  * `Xamarin.Forms.Platform.dll` (a MonoAndroid library?) references
    * `Xamarin.Forms.Platform.Android.dll`

But `Xamarin.Forms.Platform.dll` does not reference
`Mono.Android.dll`?

So then should we "recursively" look for any reference to
`Mono.Android.dll` in a given dependency tree?

I don't think so? This would include more assemblies than we want...
In the above example `Xamarin.Forms.Core.dll` would get counted as a
"MonoAndroid" assembly.

## Conclusion ##

I think we should stick with `TargetFrameworkIdentifier`, and in the
rare case it is missing look for a `Mono.Android.dll` reference for
the single assembly. This seems like it is going to cover all cases to
me, and we still will get good performance.

So we will cover:

* `Xamarin.Forms.Platform.dll` counted as a "MonoAndroid" assembly
  since it has a `TargetFrameworkIdentifier` (but no reference).
* `Refractored.Controls.CircleImageView.dll` counted as a
  "MonoAndroid" assembly. It has no `TargetFrameworkIdentifier, but
  has a reference to `Mono.Android.dll`.

Changes include:

* `<FilterAssemblies/>` needs to also check for an assembly reference
  to `Mono.Android` as a fallback.
* `<ResolveAssemblies/>` now adds a `%(MonoAndroidReference)=True`
  item metadata.
* When creating the `@(_ResolvedUserMonoAndroidAssemblies)` item
  group, we also check for `%(MonoAndroidReference)=True`.

I added a few tests to verify these scenarios.