### PR TITLE
[Xamarin.Android.Build.Tasks] De-pluralize @(AndroidAotProfile)

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -281,7 +281,7 @@ when packaging Release applications.
     determines whether or not the AOT profiles are used during the
     Ahead-of-Time compilation.
 
-    The profiles are listed in `AndroidAotProfiles` item group. This
+    The profiles are listed in `AndroidAotProfile` item group. This
     ItemGroup contains default profile(s). It can be overriden by
     removing the existing one(s) and adding own AOT profiles.
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2870,10 +2870,10 @@ because xbuild doesn't support framework reference assemblies.
     <_StartupAotProfile Condition="'$(_StartupAotProfile)' == ''">startup.aotprofile</_StartupAotProfile>
   </PropertyGroup>
   <ItemGroup>
-    <AndroidAotProfiles Include="$(MSBuildThisFileDirectory)$(_StartupAotProfile)" />
+    <AndroidAotProfile Include="$(MSBuildThisFileDirectory)$(_StartupAotProfile)" />
   </ItemGroup>
   <ItemGroup Condition="'$(AndroidEnableProfiledAot)' == 'True'">
-    <_AotProfiles Include="@(AndroidAotProfiles)" />
+    <_AotProfiles Include="@(AndroidAotProfile)" />
   </ItemGroup>
   <Aot
 	Condition="'$(AotAssemblies)' == 'True'"


### PR DESCRIPTION
MSBuild naming convention is for item groups to be *singular*, not
plural, names.  For example, `@(Compile)`, `@(Reference)`, etc.

Rename `@(AndroidAotProfiles)` to `@(AndroidAotProfile)` to be
consistent with this convention.