### PR TITLE
[mono-2019-02][Xamarin.Android.BCL_Tests] Copy xunit tests to IntermediateOutputPath

### DIFF
--- a/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets
+++ b/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets
@@ -32,7 +32,7 @@
     <Exec
         Command="$(RemapAssemblyRefTool) &quot;%(_Source.Identity)&quot; &quot;$(IntermediateOutputPath)%(_Source.Filename)%(_Source.Extension)&quot; nunitlite &quot;$(_NUnit)&quot;"
     />
-    <!-- nothing to remap for the xunit tests, but we still need them in the intermediate output path in order to resolve their references. -->
+    <!-- Nothing to remap for the xunit tests, but we still need them in the intermediate output path in order to resolve their references. -->
     <ItemGroup>
       <_XunitTestAssembly Include="@(MonoTestAssembly->'..\..\..\bin\$(Configuration)\bcl-tests\%(Identity)')"  Condition="%(MonoTestAssembly.TestType) == 'xunit'" />
     </ItemGroup>

--- a/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets
+++ b/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets
@@ -32,6 +32,11 @@
     <Exec
         Command="$(RemapAssemblyRefTool) &quot;%(_Source.Identity)&quot; &quot;$(IntermediateOutputPath)%(_Source.Filename)%(_Source.Extension)&quot; nunitlite &quot;$(_NUnit)&quot;"
     />
+    <!-- nothing to remap for the xunit tests, but we still need them in the intermediate output path in order to resolve their references. -->
+    <ItemGroup>
+      <_XunitTestAssembly Include="@(MonoTestAssembly->'..\..\..\bin\$(Configuration)\bcl-tests\%(Identity)')"  Condition="%(MonoTestAssembly.TestType) == 'xunit'" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_XunitTestAssembly)" DestinationFolder="$(IntermediateOutputPath)" />
     <ItemGroup>
       <_DebugSymbol
           Include="..\..\..\bin\$(Configuration)\bcl-tests\%(MonoTestAssembly.Filename).pdb"


### PR DESCRIPTION
so that their references can be resolved

Otherwise, any referenced assemblies that are only used by the xunit testsuites
will not be included in the APK.


---

I'm not sure if this is the best way - with this the XUnit test assemblies all end up inside the APK in the `assemblies/` folder (the same way that all the NUnit test assemblies already do) - which means they're duplicated in the `Xamarin.Android.BCL_Test.apk` - they're included once more in the `bcl-tests.zip` that's embedded as a resource in the `assemblies/Xamarin.Android.Bcl_Tests.dll` inside the APK.

But I've been told that that's a know issue that will be dealt with separately.