### PR TITLE
[android-toolchain] update to 28.0.2 platform-tools

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -100,7 +100,7 @@
     <AllSupportedTargetAndroidAbis>$(AllSupported32BitTargetAndroidAbis);$(AllSupported64BitTargetAndroidAbis)</AllSupportedTargetAndroidAbis>
     <XABuildToolsVersion>28.0.3</XABuildToolsVersion>
     <XABuildToolsFolder Condition="'$(XABuildToolsFolder)' == ''">28.0.3</XABuildToolsFolder>
-    <XAPlatformToolsVersion>28.0.0</XAPlatformToolsVersion>
+    <XAPlatformToolsVersion>28.0.2</XAPlatformToolsVersion>
     <XAIntegratedTests Condition="'$(XAIntegratedTests)' == ''">False</XAIntegratedTests>
     <XAIncludeProprietaryBits Condition="'$(XAIncludeProprietaryBits)' == ''">False</XAIncludeProprietaryBits>
     <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">0.8.0</XABundleToolVersion>


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/451/testReport/junit/Mono/Android_TestsMultiDex/Possible_Crash___Release/
Context: https://developer.android.com/studio/releases/platform-tools

We have been seeing `adb` crash during our APK tests:

    Task "RunInstrumentationTests" (TaskId:274)
    ...
    Executing: /Users/builder/android-toolchain/sdk/platform-tools/adb -s emulator-5570  logcat -v threadtime -d (TaskId:274)
        appending stdout to file: /Users/builder/jenkins/workspace/xamarin-android/xamarin-android/build-tools/scripts/../../bin/TestRelease/logcat-Release-Bundle-Mono.Android_TestsMultiDex.txt (TaskId:274)
    /Users/builder/jenkins/workspace/xamarin-android/xamarin-android/build-tools/scripts/TestApks.targets(226,5): warning : * daemon not running; starting now at tcp:5037 [/Users/builder/jenkins/workspace/xamarin-android/xamarin-android/tests/RunApkTests.targets]
    /Users/builder/jenkins/workspace/xamarin-android/xamarin-android/build-tools/scripts/TestApks.targets(226,5): warning : * daemon started successfully [/Users/builder/jenkins/workspace/xamarin-android/xamarin-android/tests/RunApkTests.targets]
    ...

This log message is starting the `adb` daemon when it *should* have
already been running.

Looking at the release notes for `platform-tools`, there is some
mention of fixes for `adb` for 28.0.1 and 28.0.2.

Let's update `platform-tools` and see if this problem gets any better.