### PR TITLE
[Xamarin.Android.Build.Tasks] Add metadata to library imports

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -45,16 +45,16 @@ namespace Xamarin.Android.Tasks
 		public bool DesignTimeBuild { get; set; }
 
 		[Output]
-		public string [] Jars { get; set; }
+		public ITaskItem [] Jars { get; set; }
 		
 		[Output]
-		public string [] ResolvedAssetDirectories { get; set; }
+		public ITaskItem [] ResolvedAssetDirectories { get; set; }
 
 		[Output]
 		public ITaskItem [] ResolvedResourceDirectories { get; set; }
 
 		[Output]
-		public string [] ResolvedEnvironmentFiles { get; set; }
+		public ITaskItem [] ResolvedEnvironmentFiles { get; set; }
 
 		[Output]
 		public ITaskItem [] ResolvedResourceDirectoryStamps { get; set; }
@@ -77,10 +77,10 @@ namespace Xamarin.Android.Tasks
 		// Extracts library project contents under e.g. obj/Debug/[lp/*.jar | res/*/*]
 		public override bool Execute ()
 		{
-			var jars                          = new List<string> ();
+			var jars                          = new Dictionary<string, ITaskItem> ();
 			var resolvedResourceDirectories   = new List<ITaskItem> ();
-			var resolvedAssetDirectories      = new List<string> ();
-			var resolvedEnvironmentFiles      = new List<string> ();
+			var resolvedAssetDirectories      = new List<ITaskItem> ();
+			var resolvedEnvironmentFiles      = new List<ITaskItem> ();
 
 			assemblyMap.Load (AssemblyIdentityMapFile);
 			assembliesToSkip = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
@@ -98,7 +98,7 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 
-			Jars                        = jars.ToArray ();
+			Jars                        = jars.Values.ToArray ();
 			ResolvedResourceDirectories = resolvedResourceDirectories.ToArray ();
 			ResolvedAssetDirectories    = resolvedAssetDirectories.ToArray ();
 			ResolvedEnvironmentFiles    = resolvedEnvironmentFiles.ToArray ();
@@ -112,7 +112,7 @@ namespace Xamarin.Android.Tasks
 			}
 
 			foreach (var directory in ResolvedAssetDirectories) {
-				MonoAndroidHelper.SetDirectoryWriteable (directory);
+				MonoAndroidHelper.SetDirectoryWriteable (directory.ItemSpec);
 			}
 
 			if (!string.IsNullOrEmpty (CacheFile)) {
@@ -122,21 +122,14 @@ namespace Xamarin.Android.Tasks
 						new XElement ("Jars",
 							Jars.Select(e => new XElement ("Jar", e))),
 						new XElement ("ResolvedResourceDirectories",
-							ResolvedResourceDirectories.Select(dir => {
-								var e = new XElement ("ResolvedResourceDirectory", dir.ItemSpec);
-								foreach (var name in knownMetadata) {
-									var value = dir.GetMetadata (name);
-									if (!string.IsNullOrEmpty (value))
-										e.SetAttributeValue (name, value);
-								}
-								return e;
-							})),
+							XDocumentExtensions.ToXElements (ResolvedResourceDirectories, "ResolvedResourceDirectory", knownMetadata)
+							),
 						new XElement ("ResolvedAssetDirectories", 
-							ResolvedAssetDirectories.Select(e => new XElement ("ResolvedAssetDirectory", e))),
-						new XElement ("ResolvedEnvironmentFiles", 
-							ResolvedEnvironmentFiles.Select(e => new XElement ("ResolvedEnvironmentFile", e))),
+							XDocumentExtensions.ToXElements (ResolvedAssetDirectories, "ResolvedAssetDirectory", knownMetadata)),
+						new XElement ("ResolvedEnvironmentFiles",
+							XDocumentExtensions.ToXElements (ResolvedEnvironmentFiles, "ResolvedEnvironmentFile", knownMetadata)),
 						new XElement ("ResolvedResourceDirectoryStamps",
-							ResolvedResourceDirectoryStamps.Select(e => new XElement ("ResolvedResourceDirectoryStamp", e)))
+							XDocumentExtensions.ToXElements (ResolvedResourceDirectoryStamps, "ResolvedResourceDirectoryStamp", knownMetadata))
 					));
 				document.SaveIfChanged (CacheFile);
 			}
@@ -173,10 +166,10 @@ namespace Xamarin.Android.Tasks
 		// Extracts library project contents under e.g. obj/Debug/[lp/*.jar | res/*/*]
 		void Extract (
 				DirectoryAssemblyResolver res,
-				ICollection<string> jars,
+				IDictionary<string, ITaskItem> jars,
 				ICollection<ITaskItem> resolvedResourceDirectories,
-				ICollection<string> resolvedAssetDirectories,
-				ICollection<string> resolvedEnvironments)
+				ICollection<ITaskItem> resolvedAssetDirectories,
+				ICollection<ITaskItem> resolvedEnvironments)
 		{
 			// lets "upgrade" the old directory.
 			string oldPath = Path.GetFullPath (Path.Combine (OutputImportDirectory, "..", "__library_projects__"));
@@ -231,9 +224,13 @@ namespace Xamarin.Android.Tasks
 						resolvedResourceDirectories.Add (taskItem);
 					}
 					if (Directory.Exists (assetsDir))
-						resolvedAssetDirectories.Add (Path.GetFullPath (assetsDir));
+						resolvedAssetDirectories.Add (new TaskItem (Path.GetFullPath (assetsDir), new Dictionary<string, string> {
+							{ OriginalFile, assemblyPath }
+						}));
 					foreach (var env in Directory.EnumerateFiles (outDirForDll, "__AndroidEnvironment__*", SearchOption.TopDirectoryOnly)) {
-						resolvedEnvironments.Add (env);
+						resolvedEnvironments.Add (new TaskItem (env, new Dictionary<string, string> {
+							{ OriginalFile, assemblyPath }
+						}));
 					}
 					continue;
 				}
@@ -251,7 +248,9 @@ namespace Xamarin.Android.Tasks
 						using (var stream = envtxt.GetResourceStream ()) {
 							updated |= MonoAndroidHelper.CopyIfStreamChanged (stream, outFile);
 						}
-						resolvedEnvironments.Add (Path.GetFullPath (outFile));
+						resolvedEnvironments.Add (new TaskItem (Path.GetFullPath (outFile), new Dictionary<string, string> {
+							{ OriginalFile, assemblyPath }
+						}));
 					}
 
 					// embedded jars (EmbeddedJar, EmbeddedReferenceJar)
@@ -260,7 +259,7 @@ namespace Xamarin.Android.Tasks
 						.Select (r => (EmbeddedResource) r);
 					foreach (var resjar in resjars) {
 						using (var stream = resjar.GetResourceStream ()) {
-							AddJar (jars, importsDir, resjar.Name);
+							AddJar (jars, importsDir, resjar.Name, assemblyPath);
 							updated |= MonoAndroidHelper.CopyIfStreamChanged (stream, Path.Combine (importsDir, resjar.Name));
 						}
 					}
@@ -302,11 +301,11 @@ namespace Xamarin.Android.Tasks
 										.Replace ("library_project_imports\\","")
 										.Replace ("library_project_imports/", "");
 									if (path.EndsWith (".jar", StringComparison.OrdinalIgnoreCase)) {
-										AddJar (jars, importsDir, path);
+										AddJar (jars, importsDir, path, assemblyPath);
 									}
 									return path;
 								}, deleteCallback: (fileToDelete) => {
-									return !jars.Contains (fileToDelete);
+									return !jars.ContainsKey (fileToDelete);
 								});
 							} catch (PathTooLongException ex) {
 								Log.LogCodedError ("XA4303", $"Error extracting resources from \"{assemblyPath}\": {ex}");
@@ -329,7 +328,9 @@ namespace Xamarin.Android.Tasks
 							resolvedResourceDirectories.Add (taskItem);
 						}
 						if (Directory.Exists (assetsDir))
-							resolvedAssetDirectories.Add (Path.GetFullPath (assetsDir));
+							resolvedAssetDirectories.Add (new TaskItem (Path.GetFullPath (assetsDir), new Dictionary<string, string> {
+								{ OriginalFile, assemblyPath }
+							}));
 					}
 				}
 
@@ -337,11 +338,11 @@ namespace Xamarin.Android.Tasks
 					// Delete unknown files in the top directory of importsDir
 					foreach (var file in Directory.EnumerateFiles (importsDir, "*")) {
 						var fullPath = Path.GetFullPath (file);
-						if (file.StartsWith ("__AndroidEnvironment__", StringComparison.OrdinalIgnoreCase) && !resolvedEnvironments.Contains (fullPath)) {
+						if (file.StartsWith ("__AndroidEnvironment__", StringComparison.OrdinalIgnoreCase) && !resolvedEnvironments.Any (x => x.ItemSpec == fullPath)) {
 							Log.LogDebugMessage ($"Deleting unknown AndroidEnvironment file: {Path.GetFileName (file)}");
 							File.Delete (fullPath);
 							updated = true;
-						} else if (file.EndsWith (".jar", StringComparison.OrdinalIgnoreCase) && !jars.Contains (fullPath)) {
+						} else if (file.EndsWith (".jar", StringComparison.OrdinalIgnoreCase) && !jars.ContainsKey (fullPath)) {
 							Log.LogDebugMessage ($"Deleting unknown jar: {Path.GetFileName (file)}");
 							File.Delete (fullPath);
 							updated = true;
@@ -370,6 +371,7 @@ namespace Xamarin.Android.Tasks
 				string aarHash = MonoAndroidHelper.HashFile (aarFile.ItemSpec);
 				string stamp = Path.Combine (outdir, Path.GetFileNameWithoutExtension (aarFile.ItemSpec) + ".stamp");
 				string stampHash = File.Exists (stamp) ? File.ReadAllText (stamp) : null;
+				var aarFullPath = Path.GetFullPath (aarFile.ItemSpec);
 				if (aarHash == stampHash) {
 					Log.LogDebugMessage ("Skipped {0}: extracted files are up to date", aarFile.ItemSpec);
 					if (Directory.Exists (importsDir)) {
@@ -383,7 +385,9 @@ namespace Xamarin.Android.Tasks
 							{ SkipAndroidResourceProcessing, "True" },
 						}));
 					if (Directory.Exists (assetsDir))
-						resolvedAssetDirectories.Add (Path.GetFullPath (assetsDir));
+						resolvedAssetDirectories.Add (new TaskItem  (Path.GetFullPath (assetsDir), new Dictionary<string, string> {
+							{ OriginalFile, aarFullPath },
+						}));
 					continue;
 				}
 
@@ -391,6 +395,7 @@ namespace Xamarin.Android.Tasks
 
 				// temporarily extracted directory will look like:
 				// _lp_/[aarFile]
+				
 				using (var zip = MonoAndroidHelper.ReadZipFile (aarFile.ItemSpec)) {
 					try {
 						updated |= Files.ExtractAll (zip, importsDir, modifyCallback: (entryFullName) => {
@@ -399,15 +404,15 @@ namespace Xamarin.Android.Tasks
 							if (entryFileName.StartsWith ("internal_impl", StringComparison.InvariantCulture)) {
 								var hash = Files.HashString (entryFileName);
 								var jar = Path.Combine (entryPath, $"internal_impl-{hash}.jar");
-								AddJar (jars, importsDir, jar);
+								AddJar (jars, importsDir, jar, aarFullPath);
 								return jar;
 							}
 							if (entryFullName.EndsWith (".jar", StringComparison.OrdinalIgnoreCase)) {
-								AddJar (jars, importsDir, entryFullName);
+								AddJar (jars, importsDir, entryFullName, aarFullPath);
 							}
 							return entryFullName;
 						}, deleteCallback: (fileToDelete) => {
-							return !jars.Contains (fileToDelete);
+							return !jars.ContainsKey (fileToDelete);
 						});
 
 						if (Directory.Exists (importsDir) && aarHash != stampHash) {
@@ -421,24 +426,29 @@ namespace Xamarin.Android.Tasks
 				}
 				if (Directory.Exists (resDir))
 					resolvedResourceDirectories.Add (new TaskItem (Path.GetFullPath (resDir), new Dictionary<string, string> {
-						{ OriginalFile, Path.GetFullPath (aarFile.ItemSpec) },
+						{ OriginalFile, aarFullPath },
 						{ SkipAndroidResourceProcessing, "True" },
 					}));
 				if (Directory.Exists (assetsDir))
-					resolvedAssetDirectories.Add (Path.GetFullPath (assetsDir));
+					resolvedAssetDirectories.Add (new TaskItem (Path.GetFullPath (assetsDir), new Dictionary<string, string> {
+						{ OriginalFile, aarFullPath },
+					}));
 			}
 		}
 
-		static void AddJar (ICollection<string> jars, string destination, string path)
+		static void AddJar (IDictionary<string, ITaskItem> jars, string destination, string path, string originalFile = null)
 		{
 			var fullPath = Path.GetFullPath (Path.Combine (destination, path));
-			AddJar (jars, fullPath);
+			AddJar (jars, fullPath, originalFile);
 		}
 
-		static void AddJar (ICollection<string> jars, string fullPath)
+		static void AddJar (IDictionary<string, ITaskItem> jars, string fullPath, string originalFile = null)
 		{
-			if (!jars.Contains (fullPath))
-				jars.Add (fullPath);
+			if (!jars.ContainsKey (fullPath)) {
+				jars.Add (fullPath, new TaskItem (fullPath, new Dictionary<string, string> {
+					{  OriginalFile, originalFile },
+				}));
+			}
 		}
 
 		void WriteAllText (string path, string contents, bool preserveTimestamp)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/XDocumentExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/XDocumentExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.XPath;
@@ -27,6 +28,19 @@ namespace Xamarin.Android.Tasks
 				taskItem.SetMetadata (attribute.Name.LocalName, attribute.Value);
 			}
 			return taskItem;
+		}
+
+		public static IEnumerable<XElement> ToXElements (ICollection<ITaskItem> items, string itemName, string[] knownMetadata)
+		{
+			foreach (var item in items) {
+				var e = new XElement (itemName, item.ItemSpec);
+				foreach (var name in knownMetadata) {
+					var value = item.GetMetadata (name);
+					if (!string.IsNullOrEmpty (value))
+						e.SetAttributeValue (name, value);
+				}
+				yield return e;
+			}
 		}
 
 		public static string[] GetPaths (this XDocument doc, params string[] paths)


### PR DESCRIPTION
One of the hard things to do when diagnosing issues
is figuring out where a certain file came from.
Because of the path and command line limits on
Windows we have to use shortened paths by default.
So we have paths such as

	obj/Debug/lp/32/res
	obj/Debug/lp/42/classes.jar
	obj/Debug/lp/55/assets

While this is great for path lengths, it does not
tell use which nuget or Library project those
items came from. There is a map file which does
hold the mapping information, however it is not
a straight forward process to look at that file and
then work out the path to the assembly or `.aar`.

So what this PR does is add a new piece of metadata
to each item specifying the `OriginalFile` which
the item came from. This will either be a full path
to an Assembly, for items which are extracted from
an EmbeddedResource. Or a full path to an `.aar` file,
which was downloaded with a nuget.

With this information diagnosing issues might get a
bit easier.