### PR TITLE
[Xamarin.Android.Build.Tasks] fix for shared runtime

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Resources/MonoRuntimeProvider.Shared.20.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/MonoRuntimeProvider.Shared.20.java
@@ -35,6 +35,7 @@ public class MonoRuntimeProvider
 		try {
 			android.content.pm.ApplicationInfo runtimeInfo = packageManager.getApplicationInfo ("Mono.Android.DebugRuntime", 0);
 			apks.add (0, runtimeInfo.sourceDir);
+			applicationInfo = runtimeInfo;
 		} catch (android.content.pm.PackageManager.NameNotFoundException e) {
 			throw new RuntimeException ("Unable to find application Mono.Android.DebugRuntime!", e);
 		}

--- a/src/Xamarin.Android.Build.Tasks/Resources/MonoRuntimeProvider.Shared.java
+++ b/src/Xamarin.Android.Build.Tasks/Resources/MonoRuntimeProvider.Shared.java
@@ -41,6 +41,7 @@ public class MonoRuntimeProvider
 		try {
 			android.content.pm.ApplicationInfo runtimeInfo = packageManager.getApplicationInfo ("Mono.Android.DebugRuntime", 0);
 			apks.add (0, runtimeInfo.sourceDir);
+			applicationInfo = runtimeInfo;
 		} catch (android.content.pm.PackageManager.NameNotFoundException e) {
 			throw new RuntimeException ("Unable to find application Mono.Android.DebugRuntime!", e);
 		}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/4f088670f2418d6291bd6d4b41fea0dd722081fb

Since 4f08867, I noticed a problem with apps crashing on startup with
Fast Deployment:

    monodroid: Creating public update directory: `/data/user/0/com.xamarin.android.helloworld/files/.__override__`
    monodroid: Using override path: /data/user/0/com.xamarin.android.helloworld/files/.__override__
    monodroid: Using override path: /storage/emulated/0/Android/data/com.xamarin.android.helloworld/files/.__override__
    monodroid: Using runtime path: /data/app/com.xamarin.android.helloworld-qnOclHxAJS4ueK0I4iLQCQ==/lib/x86
    monodroid: checking directory: `/data/user/0/com.xamarin.android.helloworld/files/.__override__/lib`
    monodroid: directory does not exist: `/data/user/0/com.xamarin.android.helloworld/files/.__override__/lib`
    monodroid: checking directory: `/storage/emulated/0/Android/data/com.xamarin.android.helloworld/files/.__override__/lib`
    monodroid: directory does not exist: `/storage/emulated/0/Android/data/com.xamarin.android.helloworld/files/.__override__/lib`
    monodroid: checking directory: `/storage/emulated/0/../legacy/Android/data/com.xamarin.android.helloworld/files/.__override__/lib`
    monodroid: directory does not exist: `/storage/emulated/0/../legacy/Android/data/com.xamarin.android.helloworld/files/.__override__/lib`
    monodroid: Trying to load sgen from: /data/app/com.xamarin.android.helloworld-qnOclHxAJS4ueK0I4iLQCQ==/lib/x86/libmonosgen-32bit-2.0.so
    monodroid: Trying to load sgen from: /system/lib/libmonosgen-2.0.so
    monodroid: Cannot find 'libmonosgen-2.0.so'. Looked in the following locations:
    monodroid:   /data/app/Mono.Android.DebugRuntime-GmlRe39q2aJXG6u5dtT6aA==/base.apk!/lib/x86
    monodroid:   /data/app/Mono.Android.Platform.ApiLevel_28-mKuuMvyx_JA4nAXc9BeUtA==/base.apk!/lib/x86
    monodroid:   /data/app/com.xamarin.android.helloworld-qnOclHxAJS4ueK0I4iLQCQ==/base.apk!/lib/x86
    monodroid:   /data/app/com.xamarin.android.helloworld-qnOclHxAJS4ueK0I4iLQCQ==/split_config.x86.apk!/lib/x86
    monodroid:   /data/app/com.xamarin.android.helloworld-qnOclHxAJS4ueK0I4iLQCQ==/split_config.xxxhdpi.apk!/lib/x86`

This was an example using an Android App Bundle, but I saw the same
problem with regular apps using a `.apk` file.

Then I noticed I changed something by mistake, the old code was:

    android.content.pm.ApplicationInfo runtimeInfo = context.getPackageManager ().getApplicationInfo ("Mono.Android.DebugRuntime", 0);
    mono.MonoPackageManager.LoadApplication (context, runtimeInfo,
        apiInfo != null
        ? new String[]{runtimeInfo.sourceDir, apiInfo.sourceDir, context.getApplicationInfo ().sourceDir}
        : new String[]{runtimeInfo.sourceDir, context.getApplicationInfo ().sourceDir});

`MonoPackageManager.LoadApplication` needs the `ApplicationInfo` from
the shared runtime APK, *not* the current app.

After fixing this, things worked for both Android App Bundles and
regular apps.