### PR TITLE
[tests] Dont run the NunitDeviceTests all the time.

### DIFF
--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -168,6 +168,13 @@
   <Target Name="RunPerformanceTests">
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\timing\timing.csproj" Targets="MSBuildTiming" />
   </Target>
+  <Target Name="RunNUnitDeviceTests">
+    <MSBuild
+        ContinueOnError="ErrorAndContinue"
+        Projects="$(_TopDir)\tests\RunApkTests.targets"
+        Targets="RunNUnitDeviceTests"
+    />
+  </Target>
   <ItemGroup>
     <_RunParallelTestTarget Include="RunNUnitTests" />
     <_RunParallelTestTarget Include="RunApkTests" />
@@ -175,6 +182,7 @@
   <ItemGroup>
     <_RunTestTarget Include="RunJavaInteropTests" />
     <_RunTestTarget Include="RunPerformanceTests" />
+    <_RunTestTarget Include="RunNUnitDeviceTests" />
   </ItemGroup>
   <Target Name="RunAllTests">
     <RunParallelTargets

--- a/tests/RunApkTests.targets
+++ b/tests/RunApkTests.targets
@@ -36,7 +36,19 @@
     <_DeviceTestAssembly Include="$(_TopDir)\bin\Test$(Configuration)\MSBuildDeviceIntegration\MSBuildDeviceIntegration.dll" />
   </ItemGroup>
 
-  <Target Name="RunNUnitDeviceTests">
+  <PropertyGroup>
+    <RunNUnitDeviceTestsDependsOn>
+      AcquireAndroidTarget;
+      RunMSBuildDeviceIntegration;
+      ReleaseAndroidTarget;
+      RenameApkTestCases;
+      ReportComponentFailures;
+    </RunNUnitDeviceTestsDependsOn>
+  </PropertyGroup>
+
+  <Target Name="RunNUnitDeviceTests" DependsOnTargets="$(RunNUnitDeviceTestsDependsOn)"/>
+
+  <Target Name="RunMSBuildDeviceIntegration">
     <SetEnvironmentVariable Name="USE_MSBUILD" Value="0" Condition=" '$(USE_MSBUILD)' == '' " />
     <ItemGroup>
       <NUnitTarget Include="@(_DeviceTestAssembly)">
@@ -70,7 +82,6 @@
     <RunApkTestsDependsOn>
       FilterApkTests;
       AcquireAndroidTarget;
-      RunNUnitDeviceTests;
       UndeployTestApks;
       DeployTestApks;
       DeployTestAabs;


### PR DESCRIPTION
We currently invoke `RunApkTests` 3 times with
different parameters. As a result that also
runs the `NUnitDeviceTests` 3 times!!

This commit reworks the RunTest.targets and
the RunApkTests.targets so they only run
once.