### PR TITLE
[Xamarin.Android.Build.Tasks] fix arbitrary files in App Bundles

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -174,10 +174,11 @@ namespace Xamarin.Android.Tasks
 								jarItem.Extract (d);
 								data = d.ToArray ();
 							}
-							if (apk.Archive.Any (e => e.FullName == jarItem.FullName))
+							var path = RootPath + jarItem.FullName;
+							if (apk.Archive.Any (e => e.FullName == path))
 								Log.LogMessage ("Warning: failed to add jar entry {0} from {1}: the same file already exists in the apk", jarItem.FullName, Path.GetFileName (jarFile));
 							else
-								apk.Archive.AddEntry (data, jarItem.FullName);
+								apk.Archive.AddEntry (data, path);
 						}
 					}
 					count++;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BundleToolTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BundleToolTests.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Android.Build.Tests
 		[OneTimeSetUp]
 		public void OneTimeSetUp ()
 		{
-			project = new XamarinAndroidApplicationProject {
+			project = new XamarinFormsMapsApplicationProject {
 				IsRelease = true,
 			};
 			//NOTE: this is here to enable adb shell run-as
@@ -57,7 +57,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var baseZip = Path.Combine (intermediate, "android", "bin", "base.zip");
 			var contents = ListArchiveContents (baseZip);
-			CollectionAssert.AreEqual (contents, new [] {
+			var expectedFiles = new [] {
 				"dex/classes.dex",
 				"lib/arm64-v8a/libmono-btls-shared.so",
 				"lib/arm64-v8a/libmonodroid.so",
@@ -84,8 +84,16 @@ namespace Xamarin.Android.Build.Tests
 				"root/assemblies/UnnamedProject.dll",
 				"root/NOTICE",
 				"root/typemap.jm",
-				"root/typemap.mj"
-			});
+				"root/typemap.mj",
+				//These are random files from Google Play Services .jar/.aar files
+				"root/build-data.properties",
+				"root/com/google/api/client/repackaged/org/apache/commons/codec/language/dmrules.txt",
+				"root/error_prone/Annotations.gwt.xml",
+				"root/protobuf.meta",
+			};
+			foreach (var expected in expectedFiles) {
+				CollectionAssert.Contains (contents, expected, $"`{baseZip}` did not contain `{expected}`");
+			}
 		}
 
 		[Test]
@@ -94,7 +102,7 @@ namespace Xamarin.Android.Build.Tests
 			var aab = Path.Combine (intermediate, "android", "bin", "UnnamedProject.UnnamedProject.aab");
 			FileAssert.Exists (aab);
 			var contents = ListArchiveContents (aab);
-			CollectionAssert.AreEqual (contents, new [] {
+			var expectedFiles = new [] {
 				"base/dex/classes.dex",
 				"base/lib/arm64-v8a/libmono-btls-shared.so",
 				"base/lib/arm64-v8a/libmonodroid.so",
@@ -123,8 +131,16 @@ namespace Xamarin.Android.Build.Tests
 				"base/root/NOTICE",
 				"base/root/typemap.jm",
 				"base/root/typemap.mj",
-				"BundleConfig.pb"
-			});
+				"BundleConfig.pb",
+				//These are random files from Google Play Services .jar/.aar files
+				"base/root/build-data.properties",
+				"base/root/com/google/api/client/repackaged/org/apache/commons/codec/language/dmrules.txt",
+				"base/root/error_prone/Annotations.gwt.xml",
+				"base/root/protobuf.meta",
+			};
+			foreach (var expected in expectedFiles) {
+				CollectionAssert.Contains (contents, expected, $"`{aab}` did not contain `{expected}`");
+			}
 		}
 
 		[Test]
@@ -146,9 +162,10 @@ namespace Xamarin.Android.Build.Tests
 
 			var aab = Path.Combine (intermediate, "android", "bin", "UnnamedProject.UnnamedProject.apks");
 			FileAssert.Exists (aab);
-			// Expecting: splits/base-arm64_v8a.apk, splits/base-master.apk, splits/base-xxxhdpi.apk
+			// Expecting: splits/base-arm64_v8a.apk, splits/base-en.apk, splits/base-master.apk, splits/base-xxxhdpi.apk
+			// This are split up based on: abi, language, base, and dpi
 			var contents = ListArchiveContents (aab).Where (a => a.EndsWith (".apk", StringComparison.OrdinalIgnoreCase)).ToArray ();
-			Assert.AreEqual (3, contents.Length, "Expecting three APKs!");
+			Assert.AreEqual (4, contents.Length, "Expecting four APKs!");
 		}
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2969

If you tried to use our new Android App Bundle feature with an app
using Google Play Services, you would get an error such as:

    [BT Module files can be only in pre-defined directories, but found 'protobuf.meta'.

Looking at `obj\Release\android\bin\base.zip`, it indeed had a file
named `protobuf.meta` in the root of the zip file.

In 4f08867, I missed a case where `<BuildApk/>` puts arbitrary files
from `.jar` files into `.apk` or `.aab` archives. For this to work
with app bundles, files like this need to go into a `/root/`
directory. I have a `RootPath` property to handle this, which I forgot
to use in this case.

## Tests ##

I updated `BundleToolTests` so that we use a
`XamarinFormsMapsApplicationProject` that contains Google Play
Services.

This gave us a couple benefits:

* We now have test coverage of these arbitrary files.
* We now have a new "split" based on language: base-en.apk

I also updated the tests so that *new* files won't cause the tests to
fail.

## Future changes ##

After seeing this code in `<BuildApk/>`, I want to improve it. It uses
`byte[]` + LINQ, I think there are some perf improvements to be done
here.