### PR TITLE
[tests] Split APK tests into parallel and non-parallel runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,8 +243,8 @@ APK_TESTS_PROP = /p:ApkTests='"$(PACKAGES)"'
 endif
 
 run-apk-tests:
-	$(call MSBUILD_BINLOG,run-apk-tests,,Test) $(TEST_TARGETS) /t:RunApkTests $(APK_TESTS_PROP)
 	$(call MSBUILD_BINLOG,run-apk-tests,,Test) $(TEST_TARGETS) /t:RunApkTests /p:RunApkTestsTarget=RunPerformanceApkTests $(APK_TESTS_PROP)
+	$(call MSBUILD_BINLOG,run-apk-tests,,Test) $(TEST_TARGETS) /t:RunApkTests $(APK_TESTS_PROP)
 
 run-performance-tests:
 	$(call MSBUILD_BINLOG,run-performance-tests,,Test) $(TEST_TARGETS) /t:RunPerformanceTests

--- a/Makefile
+++ b/Makefile
@@ -244,6 +244,7 @@ endif
 
 run-apk-tests:
 	$(call MSBUILD_BINLOG,run-apk-tests,,Test) $(TEST_TARGETS) /t:RunApkTests $(APK_TESTS_PROP)
+	$(call MSBUILD_BINLOG,run-apk-tests,,Test) $(TEST_TARGETS) /t:RunApkTests /p:RunApkTestsTarget=RunPerformanceApkTests $(APK_TESTS_PROP)
 
 run-performance-tests:
 	$(call MSBUILD_BINLOG,run-performance-tests,,Test) $(TEST_TARGETS) /t:RunPerformanceTests

--- a/Makefile
+++ b/Makefile
@@ -243,8 +243,10 @@ APK_TESTS_PROP = /p:ApkTests='"$(PACKAGES)"'
 endif
 
 run-apk-tests:
-	$(call MSBUILD_BINLOG,run-apk-tests,,Test) $(TEST_TARGETS) /t:RunApkTests /p:RunApkTestsTarget=RunPerformanceApkTests $(APK_TESTS_PROP)
-	$(call MSBUILD_BINLOG,run-apk-tests,,Test) $(TEST_TARGETS) /t:RunApkTests $(APK_TESTS_PROP)
+	_r=0 ; \
+	$(call MSBUILD_BINLOG,run-apk-tests,,Test) $(TEST_TARGETS) /t:RunApkTests /p:RunApkTestsTarget=RunPerformanceApkTests $(APK_TESTS_PROP) || _r=$$? ; \
+	$(call MSBUILD_BINLOG,run-apk-tests,,Test) $(TEST_TARGETS) /t:RunApkTests $(APK_TESTS_PROP) || _r = $$? ; \
+	exit $$_r
 
 run-performance-tests:
 	$(call MSBUILD_BINLOG,run-performance-tests,,Test) $(TEST_TARGETS) /t:RunPerformanceTests

--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -200,6 +200,13 @@
     </_RunTestTarget>
   </ItemGroup>
   <Target Name="RunAllTests">
+    <MSBuild
+         ContinueOnError="ErrorAndContinue"
+         Projects="$(MSBuildThisFileDirectory)RunTests.targets"
+         RunEachTargetSeparately="True"
+         Targets="@(_RunTestTarget)"
+         Properties="%(_RunTestTarget.Properties)"
+     />
     <RunParallelTargets
         ContinueOnError="ErrorAndContinue"
         Configuration="$(Configuration)"
@@ -208,12 +215,5 @@
         ProjectFile="$(MSBuildThisFileDirectory)RunTests.targets"
         Targets="@(_RunParallelTestTarget)"
     />
-    <MSBuild
-         ContinueOnError="ErrorAndContinue"
-         Projects="$(MSBuildThisFileDirectory)RunTests.targets"
-         RunEachTargetSeparately="True"
-         Targets="@(_RunTestTarget)"
-         Properties="%(_RunTestTarget.Properties)"
-     />
    </Target>
 </Project>

--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -112,6 +112,7 @@
     <MSBuild
         ContinueOnError="ErrorAndContinue"
         Projects="$(_TopDir)\tests\RunApkTests.targets"
+        Targets="$(RunApkTestsTarget)"
     />
     <PropertyGroup>
       <_HostOS>$(HostOS)</_HostOS>
@@ -133,6 +134,7 @@
     <MSBuild 
         ContinueOnError="ErrorAndContinue"
         Projects="$(_TopDir)\tests\RunApkTests.targets"
+        Targets="$(RunApkTestsTarget)"
         Condition=" '$(_CrossCompilerAvailable)' == 'True' "
         Properties="AotAssemblies=True"
     />
@@ -148,6 +150,7 @@
     <MSBuild
         ContinueOnError="ErrorAndContinue"
         Projects="$(_TopDir)\tests\RunApkTests.targets"
+        Targets="$(RunApkTestsTarget)"
         Condition=" '$(_CrossCompilerAvailable)' == 'True' "
         Properties="AndroidEnableProfiledAot=True;AotAssemblies=True"
     />
@@ -163,6 +166,7 @@
     <MSBuild
         ContinueOnError="ErrorAndContinue"
         Projects="$(_TopDir)\tests\RunApkTests.targets"
+        Targets="$(RunApkTestsTarget)"
         Condition=" '$(_CrossCompilerAvailable)' == 'True' "
         Properties="BundleAssemblies=True"
     />
@@ -182,9 +186,18 @@
     <_RunParallelTestTarget Include="RunApkTests" />
   </ItemGroup>
   <ItemGroup>
-    <_RunTestTarget Include="RunJavaInteropTests" />
-    <_RunTestTarget Include="RunPerformanceTests" />
-    <_RunTestTarget Include="RunNUnitDeviceTests" />
+    <_RunTestTarget Include="RunJavaInteropTests">
+      <Properties></Properties>
+    </_RunTestTarget>
+    <_RunTestTarget Include="RunPerformanceTests">
+      <Properties></Properties>
+    </_RunTestTarget>
+    <_RunTestTarget Include="RunApkTests">
+      <Properties>RunApkTestsTarget=RunPerformanceApkTests</Properties>
+    </_RunTestTarget>
+    <_RunTestTarget Include="RunNUnitDeviceTests">
+      <Properties></Properties>
+    </_RunTestTarget>
   </ItemGroup>
   <Target Name="RunAllTests">
     <RunParallelTargets
@@ -200,6 +213,7 @@
          Projects="$(MSBuildThisFileDirectory)RunTests.targets"
          RunEachTargetSeparately="True"
          Targets="@(_RunTestTarget)"
+         Properties="%(Properties)"
      />
    </Target>
 </Project>

--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -213,7 +213,7 @@
          Projects="$(MSBuildThisFileDirectory)RunTests.targets"
          RunEachTargetSeparately="True"
          Targets="@(_RunTestTarget)"
-         Properties="%(Properties)"
+         Properties="%(_RunTestTarget.Properties)"
      />
    </Target>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2262,10 +2262,6 @@ because xbuild doesn't support framework reference assemblies.
     ItemNamePattern="$(_NativeAssemblySourceDir)typemap.mj.@abi@.s" >
       <Output TaskParameter="OutputItems" ItemName="_TypeMapAssemblySource" />
   </PrepareAbiItems>
-
-  <ItemGroup>
-    <FileWrites Include="@(_TypeMapAssemblySource)" />
-  </ItemGroup>
 </Target>
 
 <Target Name="_GenerateJavaStubs"
@@ -2298,6 +2294,10 @@ because xbuild doesn't support framework reference assemblies.
 	AcwMapFile="$(_AcwMapFile)"
 	SupportedAbis="$(_BuildTargetAbis)">
   </GenerateJavaStubs>
+
+  <ItemGroup>
+    <FileWrites Include="@(_TypeMapAssemblySource)" />
+  </ItemGroup>
 
   <ConvertCustomView
 	Condition="Exists('$(_CustomViewMapFile)')"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2402,7 +2402,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_GeneratePackageManagerJava"
   DependsOnTargets="$(_GeneratePackageManagerJavaDependsOn)"
   Inputs="$(MSBuildAllProjects);$(_ResolvedUserAssembliesHashFile);$(MSBuildProjectFile);$(_AndroidBuildPropertiesCache)"
-  Outputs="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp;@(_EnvironmentAssemblySource)">
+  Outputs="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp">
   <!-- Create java needed for Mono runtime -->
   <GeneratePackageManagerJava
     ResolvedAssemblies="@(_ResolvedAssemblies)"
@@ -2437,6 +2437,7 @@ because xbuild doesn't support framework reference assemblies.
   />
   <ItemGroup>
     <FileWrites Include="$(_AndroidBuildIdFile)" />
+    <FileWrites Include="$(_EnvironmentAssemblySource)" />
   </ItemGroup>
 </Target>
 
@@ -2895,6 +2896,9 @@ because xbuild doesn't support framework reference assemblies.
       DebugBuild="$(AndroidIncludeDebugSymbols)"
       WorkingDirectory="$(_NativeAssemblySourceDir)"
   />
+  <ItemGroup>
+    <FileWrites Include="@(_NativeAssemblyTarget)" />
+  </ItemGroup>
 </Target>
 
 <Target Name="_PrepareApplicationSharedLibraryItems">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2262,6 +2262,10 @@ because xbuild doesn't support framework reference assemblies.
     ItemNamePattern="$(_NativeAssemblySourceDir)typemap.mj.@abi@.s" >
       <Output TaskParameter="OutputItems" ItemName="_TypeMapAssemblySource" />
   </PrepareAbiItems>
+
+  <ItemGroup>
+    <FileWrites Include="@(_TypeMapAssemblySource)" />
+  </ItemGroup>
 </Target>
 
 <Target Name="_GenerateJavaStubs"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2266,7 +2266,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_GenerateJavaStubs"
   DependsOnTargets="_SetLatestTargetFrameworkVersion;_PrepareAssemblies;$(_AfterPrepareAssemblies);_PrepareNativeAssemblySources"
   Inputs="$(MSBuildAllProjects);@(_ResolvedUserMonoAndroidAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(_AndroidResourceDest)"
-  Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp;@(_TypeMapAssemblySource)">
+  Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
   <GenerateJavaStubs
     ResolvedAssemblies="@(_ResolvedAssemblies)"
     ResolvedUserAssemblies="@(_ResolvedUserMonoAndroidAssemblies)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2266,7 +2266,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_GenerateJavaStubs"
   DependsOnTargets="_SetLatestTargetFrameworkVersion;_PrepareAssemblies;$(_AfterPrepareAssemblies);_PrepareNativeAssemblySources"
   Inputs="$(MSBuildAllProjects);@(_ResolvedUserMonoAndroidAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(_AndroidResourceDest)"
-  Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
+  Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp;@(_TypeMapAssemblySource)">
   <GenerateJavaStubs
     ResolvedAssemblies="@(_ResolvedAssemblies)"
     ResolvedUserAssemblies="@(_ResolvedUserMonoAndroidAssemblies)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1267,6 +1267,7 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="BundleAssemblies=$(BundleAssemblies)" />
 		<_PropertyCacheItems Include="AotAssemblies=$(AotAssemblies)" />
 		<_PropertyCacheItems Include="AndroidAotMode=$(AndroidAotMode)" />
+		<_PropertyCacheItems Include="AndroidEnableProfiledAot=$(AndroidEnableProfiledAot)" />
 		<_PropertyCacheItems Include="ExplicitCrunch=$(AndroidExplicitCrunch)" />
 		<_PropertyCacheItems Include="AndroidDexTool=$(AndroidDexTool)" />
 		<_PropertyCacheItems Include="AndroidLinkTool=$(AndroidLinkTool)" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2267,7 +2267,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_GenerateJavaStubs"
   DependsOnTargets="_SetLatestTargetFrameworkVersion;_PrepareAssemblies;$(_AfterPrepareAssemblies);_PrepareNativeAssemblySources"
   Inputs="$(MSBuildAllProjects);@(_ResolvedUserMonoAndroidAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(_AndroidResourceDest)"
-  Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
+  Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp;@(_TypeMapAssemblySource)">
   <GenerateJavaStubs
     ResolvedAssemblies="@(_ResolvedAssemblies)"
     ResolvedUserAssemblies="@(_ResolvedUserMonoAndroidAssemblies)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2402,7 +2402,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_GeneratePackageManagerJava"
   DependsOnTargets="$(_GeneratePackageManagerJavaDependsOn)"
   Inputs="$(MSBuildAllProjects);$(_ResolvedUserAssembliesHashFile);$(MSBuildProjectFile);$(_AndroidBuildPropertiesCache)"
-  Outputs="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp">
+  Outputs="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp;@(_EnvironmentAssemblySource)">
   <!-- Create java needed for Mono runtime -->
   <GeneratePackageManagerJava
     ResolvedAssemblies="@(_ResolvedAssemblies)"
@@ -2437,7 +2437,6 @@ because xbuild doesn't support framework reference assemblies.
   />
   <ItemGroup>
     <FileWrites Include="$(_AndroidBuildIdFile)" />
-    <FileWrites Include="$(_EnvironmentAssemblySource)" />
   </ItemGroup>
 </Target>
 
@@ -2896,9 +2895,6 @@ because xbuild doesn't support framework reference assemblies.
       DebugBuild="$(AndroidIncludeDebugSymbols)"
       WorkingDirectory="$(_NativeAssemblySourceDir)"
   />
-  <ItemGroup>
-    <FileWrites Include="@(_NativeAssemblyTarget)" />
-  </ItemGroup>
 </Target>
 
 <Target Name="_PrepareApplicationSharedLibraryItems">

--- a/tests/RunApkTests.targets
+++ b/tests/RunApkTests.targets
@@ -104,7 +104,36 @@
     <Message Text="@(TestApk) " />
   </Target>
 
+  <ItemGroup>
+    <_ApkPerfTests Include="Xamarin.Android.Locale_Tests;Xamarin.Forms_Performance_Integration">
+      <Package>%(Identity)</Package>
+    </_ApkPerfTests>
+  </ItemGroup>
+
+  <Target Name="PrefilterPerformance">
+    <ItemGroup>
+      <_AllArchives Remove="@(_AllArchives)" Condition=" '%(Package)' != '' And '@(_ApkPerfTests)' == '' " />
+      <TestApk Remove="@(TestApk)" Condition=" '%(Package)' != '' And '@(_ApkPerfTests)' == '' " />
+      <TestApkInstrumentation Remove="@(TestApkInstrumentation)" Condition=" '%(Package)' != '' And '@(_ApkPerfTests)' == '' " />
+      <TestApkPermission Remove="@(TestApkPermission)" Condition=" '%(Package)' != '' And '@(_ApkPerfTests)' == '' " />
+    </ItemGroup>
+    <Message Text="Performance apk test: @(TestApk)" />
+  </Target>
+
+  <Target Name="PrefilterNonPerformance">
+    <ItemGroup>
+      <_AllArchives Remove="@(_AllArchives)" Condition=" '%(Package)' != '' And '@(_ApkPerfTests)' != '' " />
+      <TestApk Remove="@(TestApk)" Condition=" '%(Package)' != '' And '@(_ApkPerfTests)' != '' " />
+      <TestApkInstrumentation Remove="@(TestApkInstrumentation)" Condition=" '%(Package)' != '' And '@(_ApkPerfTests)' != '' " />
+      <TestApkPermission Remove="@(TestApkPermission)" Condition=" '%(Package)' != '' And '@(_ApkPerfTests)' != '' " />
+    </ItemGroup>
+    <Message Text="Non performance apk test: @(TestApk)" />
+  </Target>
+
   <Target Name="RunApkTests"
-      DependsOnTargets="$(RunApkTestsDependsOn)">
+      DependsOnTargets="PrefilterNonPerformance;$(RunApkTestsDependsOn)">
+  </Target>
+  <Target Name="RunPerformanceApkTests"
+      DependsOnTargets="PrefilterPerformance;$(RunApkTestsDependsOn)">
   </Target>
 </Project>


### PR DESCRIPTION
We want to run 2 apk tests, locale and XF, non-parallel. So that the
performance measurements for these tests make more sense and are
comparable between test flavors and also between builds.

The splitting is implemented by introducing new
`RunPerformanceApkTests` target and pre-filtering `TestApk`,
`TestApkInstrumentation` and `TestApkPermission` item groups for this
target and also for `RunApkTests` target.