### PR TITLE
[Xamarin.Android.Build.Tasks] fix for ManagedResourceParser

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2150,7 +2150,8 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
 			proj.SetProperty ("TargetFrameworkVersion", "v5.0");
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestName))) {
-				Assert.IsTrue (builder.Build (proj), "Build should have succeeded");
+				Assert.IsTrue (builder.DesignTimeBuild (proj), "design-time build should have succeeded");
+				Assert.IsTrue (builder.Build (proj), "build should have succeeded");
 				var targetAar = Path.Combine (CachePath, "Xamarin.Android.Support.v7.AppCompat", "23.1.1.0",
 					"content", "m2repository", "com", "android", "support", "appcompat-v7", "23.1.1", "appcompat-v7-23.1.1.aar");
 				if (File.Exists (targetAar)) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -75,10 +75,12 @@ namespace Xamarin.Android.Tasks
 						rTxt = Path.Combine (dir, "..", "R.txt");
 						if (File.Exists (rTxt)) {
 							ProcessRtxtFile (rTxt);
-						} else {
+						} else if (Directory.Exists (dir)) {
 							foreach (var file in Directory.EnumerateFiles (dir, "*.*", SearchOption.AllDirectories)) {
 								ProcessResourceFile (file);
 							}
+						} else {
+							Log.LogDebugMessage ($"Skipping non-existent directory: {dir}");
 						}
 					}
 				}


### PR DESCRIPTION
Context: http://build.devdiv.io/2593085
Context: https://github.com/xamarin/xamarin-android/commit/c9c1f8ad1922fc7aad517689f5dff3d1214a0ea5

The Android designer's integration tests found another problem:

    Xamarin.Android.Common.targets(1326,2): warning MSB4018: The "GenerateResourceDesigner" task failed unexpectedly.
    System.IO.DirectoryNotFoundException: Could not find a part of the path 'C:\Users\myuser\AppData\Local\Xamarin\Xamarin.Android.Support.CustomTabs\23.1.1.0\embedded\res'.
        at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
        at System.IO.FileSystemEnumerableIterator`1.CommonInit()
        at System.IO.FileSystemEnumerableIterator`1..ctor(String path, String originalUserPath, String searchPattern, SearchOption searchOption, SearchResultHandler`1 resultHandler, Boolean checkHost)
        at System.IO.Directory.EnumerateFiles(String path, String searchPattern, SearchOption searchOption)
        at Xamarin.Android.Tasks.ManagedResourceParser.Parse(String resourceDirectory, IEnumerable`1 additionalResourceDirectories, Boolean isApp, Dictionary`2 resourceMap)
        at Xamarin.Android.Tasks.GenerateResourceDesigner.Execute()
        at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
        at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext() [C:\src\xamarin-android\bin\TestDebug\temp\ResourceExtractionFalse\UnnamedProject.csproj]

This is very closely related to what I fixed in c9c1f8a.

I could reproduce the problem by just doing a design-time build with a
project using the `Xamarin.Android.Support.CustomTabs` 23.x NuGet
package.

Looking at the code in `ManagedResourceParser`, it just seems like it
has always been this way? (circa Sept 2017) I am not sure what has
changed, that is causing these to pop up.