### PR TITLE
[tests] check d8 works with "Enhanced Fast Deployment"

### DIFF
--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -139,7 +139,7 @@ timestamps {
             }
         }
 
-        utils.stageWithTimeout('run all tests', 160, 'MINUTES', XADir, false) {   // Typically takes 1hr and 50 minutes (or 110 minutes)
+        utils.stageWithTimeout('run all tests', 240, 'MINUTES', XADir, false) {   // Typically takes 1hr and 50 minutes (or 110 minutes)
             echo "running tests"
 
             def skipNunitTests = false


### PR DESCRIPTION
There is a direct call to `<CompileToDalvik/>` when using
`AndroidFastDeploymentType` = `Assemblies:Dexes`.

We need to add a few tests here to verify that this code path still
works when using `$(AndroidDexTool)` = `d8`.

I also did some minor cleanup in these tests, such as:

* Instead of checking if the `classes.dex` < 30K, I actually checked
  for a class that should be missing and one that should exist.
* Use the `TestName` property.
* Use of `CreateApkBuilder (..., false, false)` can just omit the two
  `false, false` parameters, as that is the default now.

The actual changes for d8 + enhanced fastdev will be in monodroid.