### PR TITLE
[tests] Don't rename test cases from RunNUnitDeviceTests

### DIFF
--- a/tests/RunApkTests.targets
+++ b/tests/RunApkTests.targets
@@ -41,8 +41,6 @@
       AcquireAndroidTarget;
       RunMSBuildDeviceIntegration;
       ReleaseAndroidTarget;
-      RenameApkTestCases;
-      ReportComponentFailures;
     </RunNUnitDeviceTestsDependsOn>
   </PropertyGroup>
 


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/470/testReport/

A "funny" thing happened with the Jenkins build for commit decfbccf:
~all of the on-device `.apk` tests failed, which is *not* something
which happened for PR #2718, e.g. the [last PR build][0] only had a
failure in `CheckTimeZoneInfoIsCorrect("Pacific/Pitcairn")`, because
the emulator exited (crashed?), which we deemed as unrelated.

146,363 tests ran in that PR build.

Compare to the master build, which had 3,884 tests (!).

Thus, a question: *what happened*?!

Some further investigation showed that things were even *more*
confusing: the `msbuild-20190417T122656-Target-RunApkTests.binlog`
file showed that the test results were successfully grabbed!

	Task "RunInstrumentationTests"
	  ...
	  Executing: /Users/builder/android-toolchain/sdk/platform-tools/adb -s emulator-5570  shell am instrument  -e "loglevel Verbose" -w "Xamarin.Android.JcwGen_Tests/xamarin.android.jcwgentests.TestInstrumentation"
	  ...
	  INSTRUMENTATION_CODE: -1
	  ...
	  Executing: /Users/builder/android-toolchain/sdk/platform-tools/adb -s emulator-5570  pull "/storage/emulated/0/Android/data/Xamarin.Android.JcwGen_Tests/files/Documents/TestResults.xml" "…/TestRelease/TestResult-Xamarin.Android.JcwGen_Tests.xml
	  /storage/emulated/0/Android/data/Xamarin.Android.JcwGen_Tests/files/Documents/TestResults.xml: 1 file pulled. 2.4 MB/s (5161 bytes in 0.002s)

Yet this same test was reported as [failing][1]!

What went wrong?

For a *hint*, when `<RenameTestCases/>` generates a "stub" error NUnit
XML file, it *also* reports a warning into the build log:

	Unable to process `{SourceFile}`.  Is it empty?  (Did a unit test runner SIGSEGV?)

This warning message *was not present* within
`msbuild-20190417T122656-Target-RunApkTests.binlog`.

It *was* present within
`msbuild-20190417T122655-run-all-tests.binlog`!

	build-tools/scripts/TestApks.targets(301,5): warning : Unable to process `…/TestResult-Mono.Android_Tests.xml`.  Is it empty?  (Did a unit test runner SIGSEGV?)
	build-tools/scripts/TestApks.targets(301,5): warning : Unable to process `…/TestResult-Xamarin.Android.Bcl_Tests.xunit.xml`.  Is it empty?  (Did a unit test runner SIGSEGV?)
	build-tools/scripts/TestApks.targets(301,5): warning : Unable to process `…/TestResult-Xamarin.Android.Bcl_Tests.nunit.xml`.  Is it empty?  (Did a unit test runner SIGSEGV?)
	build-tools/scripts/TestApks.targets(301,5): warning : Unable to process `…/TestResult-Xamarin.Android.JcwGen_Tests.xml`.  Is it empty?  (Did a unit test runner SIGSEGV?)
	build-tools/scripts/TestApks.targets(301,5): warning : Unable to process `…/TestResult-Xamarin.Android.EmbeddedDSO_Test.nunit.xml`.  Is it empty?  (Did a unit test runner SIGSEGV?)
	build-tools/scripts/TestApks.targets(301,5): warning : Unable to process `…/TestResult-Xamarin.Android.Locale_Tests.xml`.  Is it empty?  (Did a unit test runner SIGSEGV?)
	build-tools/scripts/TestApks.targets(301,5): warning : Unable to process `…/TestResult-Mono.Android_TestsAppBundle.xml`.  Is it empty?  (Did a unit test runner SIGSEGV?)
	build-tools/scripts/TestApks.targets(301,5): warning : Unable to process `…/TestResult-Mono.Android_TestsMultiDex.xml`.  Is it empty?  (Did a unit test runner SIGSEGV?)
	build-tools/scripts/TestApks.targets(301,5): warning : Unable to process `…/TestResult-Mono.Android_Tests.xml`.  Is it empty?  (Did a unit test runner SIGSEGV?)
	build-tools/scripts/TestApks.targets(301,5): warning : Unable to process `…/TestResult-Xamarin.Android.Bcl_Tests.xunit.xml`.  Is it empty?  (Did a unit test runner SIGSEGV?)
	build-tools/scripts/TestApks.targets(301,5): warning : Unable to process `…/TestResult-Xamarin.Android.Bcl_Tests.nunit.xml`.  Is it empty?  (Did a unit test runner SIGSEGV?)
	build-tools/scripts/TestApks.targets(301,5): warning : Unable to process `…/TestResult-Xamarin.Android.JcwGen_Tests.xml`.  Is it empty?  (Did a unit test runner SIGSEGV?)
	build-tools/scripts/TestApks.targets(301,5): warning : Unable to process `…/TestResult-Xamarin.Android.EmbeddedDSO_Test.nunit.xml`.  Is it empty?  (Did a unit test runner SIGSEGV?)
	build-tools/scripts/TestApks.targets(301,5): warning : Unable to process `…/TestResult-Xamarin.Android.Locale_Tests.xml`.  Is it empty?  (Did a unit test runner SIGSEGV?)
	build-tools/scripts/TestApks.targets(301,5): warning : Unable to process `…/TestResult-Mono.Android_TestsAppBundle.xml`.  Is it empty?  (Did a unit test runner SIGSEGV?)
	build-tools/scripts/TestApks.targets(301,5): warning : Unable to process `…/TestResult-Mono.Android_TestsMultiDex.xml`.  Is it empty?  (Did a unit test runner SIGSEGV?)

What appears to have happened is commit 84c97da1:
`$(RunNUnitDeviceTestsDependsOn)` included `RenameApkTestCases`, which
calls `<RenameTestCases/>` for *all known `.apk` tests*, but the
`RunMSBuildDeviceIntegration` target doesn't create any of the NUnit
XML files which the `RenameApkTestCases` target expected to process.

The result is that when `make run-all-tests`/the `RunAllTests` target
was run, the `RunApkTests` target would be run, *and pass*, then
(later) the `RunNUnitDeviceTests` target would run, which would call
the `RenameApkTestCases` target, which would promptly FAIL THE WORLD
(see above) because none of the expected files existed.

Nor *should* those files exist from a `RunNUnitDeviceTests` run!

The fix?  Update `$(RunNUnitDeviceTestsDependsOn)` so that the
`RenameApkTestCases` and `ReportComponentFailures` targets aren't
executed.  This should allow things to build "normally".

Bonus question: why didn't PR #2987 fail for this reason?  ¯\_(ツ)_/¯

[0]: https://jenkins.mono-project.com/job/xamarin-android-pr-pipeline-release/618/testReport/
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/470/testReport/Xamarin.Android/JcwGen_Tests/Possible_Crash___Release/