### PR TITLE
[build] Adjust dependencies for Ubuntu 19

### DIFF
--- a/build-tools/scripts/dependencies/debian-common.sh
+++ b/build-tools/scripts/dependencies/debian-common.sh
@@ -8,7 +8,7 @@ DEBIAN_COMMON_DEPS="autoconf
 	libtool
 	libncurses-dev
 	libz-mingw-w64-dev
-	libzip4
+	libzip-dev
 	linux-libc-dev
 	make
 	unzip

--- a/build-tools/scripts/dependencies/linux-prepare-Ubuntu.sh
+++ b/build-tools/scripts/dependencies/linux-prepare-Ubuntu.sh
@@ -1,12 +1,13 @@
 . "`dirname $0`"/debian-common.sh
 
-DISTRO_DEPS="$DEBIAN_COMMON_DEPS openjdk-8-jdk"
-
 MAJOR=$(echo $1 | cut -d '.' -f 1)
 MINOR=$(echo $1 | cut -d '.' -f 2)
 
 if [ $MAJOR -eq 17 -a $MINOR -eq 10 ] || [ $MAJOR -ge 18 ]; then
     NEED_LIBTOOL=yes
+    if [ $MAJOR -lt 19 ]; then
+        DISTRO_DEPS="$DEBIAN_COMMON_DEPS openjdk-8-jdk"
+    fi
 else
     NEED_LIBTOOL=no
 fi


### PR DESCRIPTION
Ubuntu 19 removed OpenJDK 8 and thus we can no longer depend on distro packages
to install it. OpenJDK 8 is a requirement for Android development but, alas,
there's no replacement in the Ubuntu 19 (or Debian 10+) repositories for this
version. At some point we will start provisioning our own version of OpenJDK 8
but, for now, user needs to install OpenJDK 8 on their own. A recommended
alternative is https://docs.aws.amazon.com/corretto/latest/corretto-8-ug/downloads-list.html

Remove dependency on openjdk-8-jdk and change `libzip4` dependency to
`libzip-dev` in order to install the latest version of libzip.