### PR TITLE
[Xamarin.Android.Build.Tasks] proguard/r8 + multidex missing rule

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Resources/proguard_xamarin.cfg
+++ b/src/Xamarin.Android.Build.Tasks/Resources/proguard_xamarin.cfg
@@ -2,6 +2,7 @@
 
 -dontobfuscate
 
+-keep class android.support.multidex.MultiDexApplication { <init>(); }
 -keep class mono.MonoRuntimeProvider { *; <init>(...); }
 -keep class mono.MonoPackageManager { *; <init>(...); }
 -keep class mono.MonoPackageManager_Resources { *; <init>(...); }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1017,6 +1017,24 @@ namespace UnnamedProject {
 		}
 
 		[Test]
+		public void MultiDexAndCodeShrinker ([Values ("proguard", "r8")] string linkTool)
+		{
+			var proj = CreateMultiDexRequiredApplication ();
+			proj.SetProperty ("AndroidEnableMultiDex", "True");
+			proj.EnableProguard =
+				proj.IsRelease = true;
+			proj.LinkTool = linkTool;
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+
+				var className = "Landroid/support/multidex/MultiDexApplication;";
+				var dexFile = b.Output.GetIntermediaryPath (Path.Combine ("android", "bin", "classes.dex"));
+				FileAssert.Exists (dexFile);
+				Assert.IsTrue (DexUtils.ContainsClassWithMethod (className, "<init>", "()V", dexFile, b.AndroidSdkDirectory), $"`{dexFile}` should include `{className}`!");
+			}
+		}
+
+		[Test]
 		public void BasicApplicationRepetitiveBuild ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();


### PR DESCRIPTION
I recently was doing some testing, and was using the Xamarin.Forms
Shell template from Visual Studio 2019. I also added
Xamarin.Forms.Maps and enabled multi-dex + r8.

Unfortunately, the app crashed on start with:

    java.lang.ClassNotFoundException: Didn't find class "android.support.multidex.MultiDexApplication"

Using `dexdump`, the class was indeed missing from `classes.dex`.

It feels like this should "just work"?

From some conversation on Slack, @JonDouglas tried in Android Studio;
it was adding this proguard rule automatically:

    -keep class android.support.multidex.MultiDexApplication { <init>(); }

I think we can just add this rule to `proguard_xamarin.cfg` *always*
to fix this problem. I tested non-multidex apps, and no new warnings
are popping up or anything. Xamarin.Android apps with proguard/r8 +
multidex were working by default after I made this change.

I added a test that verifies this problem is fixed.