### PR TITLE
[Xamarin.Android.Build.Tasks] fix warnings from <CompileNativeAssembly/>

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
@@ -196,12 +196,12 @@ namespace Xamarin.Android.Tasks
 
 		void OnOutputData (string assemblerName, object sender, DataReceivedEventArgs e)
 		{
-			LogMessage ($"[{assemblerName} stdout] {e.Data}");
+			LogDebugMessage ($"[{assemblerName} stdout] {e.Data}");
 		}
 
 		void OnErrorData (string assemblerName, object sender, DataReceivedEventArgs e)
 		{
-			LogMessage ($"[{assemblerName} stderr] {e.Data}");
+			LogMessage ($"[{assemblerName} stderr] {e.Data}", MessageImportance.High);
 		}
 
 		static string QuoteFileName (string fileName)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -309,7 +309,7 @@ namespace Xamarin.Android.Tasks
 			string dataFilePath = $"{path}.inc";
 			using (var stream = new NativeAssemblyDataStream ()) {
 				generator (stream);
-				stream.Flush ();
+				stream.EndOfFile ();
 				MonoAndroidHelper.CopyIfStreamChanged (stream, dataFilePath);
 
 				var generatedFiles = new List <ITaskItem> ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -38,6 +38,20 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void BuildHasNoWarnings ([Values (true, false)] bool isRelease)
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = isRelease,
+			};
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "0 Warning(s)"), "Should have zero MSBuild warnings.");
+				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "Warning: end of file not at end of a line"),
+					"Should not get a warning from the <CompileNativeAssembly/> task.");
+			}
+		}
+
+		[Test]
 		public void BuildBasicApplicationWithNuGetPackageConflicts ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NativeAssemblyDataStream.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NativeAssemblyDataStream.cs
@@ -74,6 +74,12 @@ namespace Xamarin.Android.Tasks
 			outputStream = null;
 		}
 
+		public void EndOfFile ()
+		{
+			outputWriter.WriteLine ();
+			Flush ();
+		}
+
 		public override void Flush ()
 		{
 			outputWriter.Flush ();


### PR DESCRIPTION
Any Xamarin.Android app was generating build output such as:

    _CompileNativeAssemblySources:
      [aarch64-linux-android-as.EXE stderr] typemap.mj.inc: Assembler messages:
      [aarch64-linux-android-as.EXE stderr] typemap.mj.inc:60201: Warning: end of file not at end of a line; newline inserted
      [arm-linux-androideabi-as.EXE stderr] typemap.mj.inc: Assembler messages:
      [arm-linux-androideabi-as.EXE stderr] typemap.mj.inc:60201: Warning: end of file not at end of a line; newline inserted

The fix was we just needed to call `StreamWriter.WriteLine()` once at
the end of the file. I added an `NativeAssemblyDataStream.EndOfFile()`
method to call for this instead of `Flush()`.

I also updated log messages in `<CompileNativeAssembly/>` to be more
precise:

* stdout should probably use `LogDebugMessage` for
  `MessageImportance.Low`.
* stderr should probably use `MessageImportance.High`.

I added a test that checks for MSBuild warnings in general, and that
we aren't getting messages like these anymore.