### PR TITLE
[tests] Add XF test to _ApkTestProjectAot

### DIFF
--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -29,6 +29,7 @@
     <_ApkTestProject Include="$(_TopDir)\tests\Runtime-AppBundle\Mono.Android-TestsAppBundle.csproj" />
     <_ApkTestProject Include="$(_TopDir)\tests\Runtime-MultiDex\Mono.Android-TestsMultiDex.csproj" />
     <_ApkTestProjectAot Include="$(_TopDir)\src\Mono.Android\Test\Mono.Android-Tests.csproj" />
+    <_ApkTestProjectAot Include="$(_TopDir)\tests\Xamarin.Forms-Performance-Integration\Droid\Xamarin.Forms.Performance.Integration.Droid.csproj" />
     <_ApkTestProjectBundle Include="$(_TopDir)\src\Mono.Android\Test\Mono.Android-Tests.csproj" />
   </ItemGroup>
   <Target Name="ListNUnitTests">


### PR DESCRIPTION
So that it is rebuilt, before running it, with AOT enabled. That
explains the unexpected test times measurements, where there wasn't
much difference between AOT and non-AOT measurements.

Example unexpected measurements (the lines are split for better
readability):

    last-Release,JNI.init-Release,init-Release,OnCreateBegin-Release,OnCreateEnd-Release,OnStartBegin-Release,OnStartEnd-Release,OnResumeBegin-Release,OnResumeEnd-Release,ActivityDisplayed-Release
    last-Release-Aot,JNI.init-Release-Aot,init-Release-Aot,OnCreateBegin-Release-Aot,OnCreateEnd-Release-Aot,OnStartBegin-Release-Aot,OnStartEnd-Release-Aot,OnResumeBegin-Release-Aot,OnResumeEnd-Release-Aot,ActivityDisplayed-Release-Aot
    last-Release-Profiled-Aot,JNI.init-Release-Profiled-Aot,init-Release-Profiled-Aot,OnCreateBegin-Release-Profiled-Aot,OnCreateEnd-Release-Profiled-Aot,OnStartBegin-Release-Profiled-Aot,OnStartEnd-Release-Profiled-Aot,OnResumeBegin-Release-Profiled-Aot,OnResumeEnd-Release-Profiled-Aot,ActivityDisplayed-Release-Profiled-Aot
    last-Release-Bundle,JNI.init-Release-Bundle,init-Release-Bundle,OnCreateBegin-Release-Bundle,OnCreateEnd-Release-Bundle,OnStartBegin-Release-Bundle,OnStartEnd-Release-Bundle,OnResumeBegin-Release-Bundle,OnResumeEnd-Release-Bundle,ActivityDisplayed-Release-Bundle
    738,195,195,238,459,461,461,461,462,800
    727,198,198,239,462,464,464,464,465,786
    829,258,258,307,540,542,542,543,544,888
    717,198,198,240,465,467,467,468,468,773