### PR TITLE
[MSBuildDeviceIntegration] Fix the Install/InstantRun tests.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -40,6 +40,13 @@ namespace Xamarin.Android.Build.Tests
 				private set;
 			}
 
+			static SetUp ()
+			{
+				using (var builder = new Builder ()) {
+					CommercialBuildAvailable = File.Exists (Path.Combine (builder.AndroidMSBuildDirectory, "Xamarin.Android.Common.Debugging.targets"));
+				}
+			}
+
 			[OneTimeSetUp]
 			public void BeforeAllTests ()
 			{
@@ -64,9 +71,6 @@ namespace Xamarin.Android.Build.Tests
 					}
 				} catch (Exception ex) {
 					Console.Error.WriteLine ("Failed to determine whether there is Android target emulator or not: " + ex);
-				}
-				using (var builder = new Builder ()) {
-					CommercialBuildAvailable = File.Exists (Path.Combine (builder.AndroidMSBuildDirectory, "Xamarin.Android.Common.Debugging.targets"));
 				}
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -84,7 +84,7 @@ namespace Xamarin.ProjectTools
 
 		public bool Install (XamarinProject project, bool doNotCleanupOnUpdate = false, bool saveProject = true)
 		{
-			return RunTarget (project, "Install", doNotCleanupOnUpdate, saveProject: saveProject);
+			return RunTarget (project, "Build,Install", doNotCleanupOnUpdate, saveProject: saveProject);
 		}
 
 		public bool Uninstall (XamarinProject project, bool doNotCleanupOnUpdate = false, bool saveProject = true)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -84,6 +84,7 @@ namespace Xamarin.ProjectTools
 
 		public bool Install (XamarinProject project, bool doNotCleanupOnUpdate = false, bool saveProject = true)
 		{
+			//NOTE: since $(BuildingInsideVisualStudio) is set, Build will not happen by default
 			return RunTarget (project, "Build,Install", doNotCleanupOnUpdate, saveProject: saveProject);
 		}
 


### PR DESCRIPTION
We made a change where `SignAndroidPackage` no longer
automatically calls `Build`. This was done to help
speed up the IDE and to save it having to call `Build`
all over again. There was an assumption in the `Install`
tests where we assumed `Build` was being called. As a
result a bunch of tests failed with our favourite
`LinkAssemblies` error.

	error MSB4018: System.IO.FileNotFoundException: Could not load assembly 'UnnamedProject, Version=0.0.0.0, Culture=neutral, PublicKeyToken='. Perhaps it doesn't exist in the Mono for Android profile?

So lets call `Build` before we do any of the Installation
tests.

Next up it seems that Nunit resolves all the test cases
BEFORE the `[OnTimeSetup]` runs. As a result the value
for `CommercialBuildAvailable` was always `false`.
So lets calculate that in a static constructor so that
it will have the correct value when nunit figures out
the test cases.