### PR TITLE
[tests] Add XF test to _ApkTestProjectBundle

### DIFF
--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -31,6 +31,7 @@
     <_ApkTestProjectAot Include="$(_TopDir)\src\Mono.Android\Test\Mono.Android-Tests.csproj" />
     <_ApkTestProjectAot Include="$(_TopDir)\tests\Xamarin.Forms-Performance-Integration\Droid\Xamarin.Forms.Performance.Integration.Droid.csproj" />
     <_ApkTestProjectBundle Include="$(_TopDir)\src\Mono.Android\Test\Mono.Android-Tests.csproj" />
+    <_ApkTestProjectBundle Include="$(_TopDir)\tests\Xamarin.Forms-Performance-Integration\Droid\Xamarin.Forms.Performance.Integration.Droid.csproj" />
   </ItemGroup>
   <Target Name="ListNUnitTests">
     <Exec


### PR DESCRIPTION
When fixing the AOT measurements
(https://github.com/xamarin/xamarin-android/pull/3017), I didn't
notice we have similar issue with the Bundle flavor.

We can either not run XF in Bundle flavor or rebuild it before
run. The XF apps are very common, so I think it makes sense to keep running
the test and thus we need to add it to the `_ApkTestProjectBundle` item
group so that it is rebuild before running.