### PR TITLE
[Xamarin.Android.Build.Tasks] first styleable resource id is always incorrect

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
@@ -44,6 +44,9 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public bool DesignTimeBuild { get; set; }
 
+		[Required]
+		public string JavaPlatformJarPath { get; set; }
+
 		private Dictionary<string, string> resource_fixup = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase);
 
 		public override bool Execute ()
@@ -61,6 +64,8 @@ namespace Xamarin.Android.Tasks
 			// ResourceDirectory may be a relative path, and
 			// we need to compare it to absolute paths
 			ResourceDirectory = Path.GetFullPath (ResourceDirectory);
+
+			var javaPlatformDirectory = Path.GetDirectoryName (JavaPlatformJarPath);
 
 			// Create our capitalization maps so we can support mixed case resources
 			foreach (var item in Resources) {
@@ -87,7 +92,7 @@ namespace Xamarin.Android.Tasks
 			// Parse out the resources from the R.java file
 			CodeTypeDeclaration resources;
 			if (UseManagedResourceGenerator) {
-				var parser = new ManagedResourceParser () { Log = Log };
+				var parser = new ManagedResourceParser () { Log = Log, JavaPlatformDirectory = javaPlatformDirectory, };
 				resources = parser.Parse (ResourceDirectory, AdditionalResourceDirectories?.Select (x => x.ItemSpec), IsApplication, resource_fixup);
 			} else {
 				var parser = new JavaResourceParser () { Log = Log };

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
@@ -59,6 +59,9 @@ namespace Foo.Foo
 		public partial class Attribute
 		{
 			
+			// aapt resource value: 0x7F030000
+			public const int customFont = 2130903040;
+			
 			static Attribute()
 			{
 				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
@@ -72,8 +75,8 @@ namespace Foo.Foo
 		public partial class Dimension
 		{
 			
-			// aapt resource value: 0x7F030000
-			public const int main_text_item_size = 2130903040;
+			// aapt resource value: 0x7F040000
+			public const int main_text_item_size = 2130968576;
 			
 			static Dimension()
 			{
@@ -88,8 +91,8 @@ namespace Foo.Foo
 		public partial class Drawable
 		{
 			
-			// aapt resource value: 0x7F040000
-			public const int ic_menu_preferences = 2130968576;
+			// aapt resource value: 0x7F050000
+			public const int ic_menu_preferences = 2131034112;
 			
 			static Drawable()
 			{
@@ -104,8 +107,8 @@ namespace Foo.Foo
 		public partial class Font
 		{
 			
-			// aapt resource value: 0x7F050000
-			public const int arial = 2131034112;
+			// aapt resource value: 0x7F060000
+			public const int arial = 2131099648;
 			
 			static Font()
 			{
@@ -120,20 +123,20 @@ namespace Foo.Foo
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7F060000
-			public const int Føø_Bar = 2131099648;
+			// aapt resource value: 0x7F070000
+			public const int Føø_Bar = 2131165184;
 			
-			// aapt resource value: 0x7F060001
-			public const int menu_settings = 2131099649;
+			// aapt resource value: 0x7F070001
+			public const int menu_settings = 2131165185;
 			
-			// aapt resource value: 0x7F060002
-			public const int seekBar = 2131099650;
+			// aapt resource value: 0x7F070002
+			public const int seekBar = 2131165186;
 			
-			// aapt resource value: 0x7F060003
-			public const int seekbar = 2131099651;
+			// aapt resource value: 0x7F070003
+			public const int seekbar = 2131165187;
 			
-			// aapt resource value: 0x7F060004
-			public const int textview_withperiod = 2131099652;
+			// aapt resource value: 0x7F070004
+			public const int textview_withperiod = 2131165188;
 			
 			static Id()
 			{
@@ -148,8 +151,8 @@ namespace Foo.Foo
 		public partial class Layout
 		{
 			
-			// aapt resource value: 0x7F070000
-			public const int main = 2131165184;
+			// aapt resource value: 0x7F080000
+			public const int main = 2131230720;
 			
 			static Layout()
 			{
@@ -164,8 +167,8 @@ namespace Foo.Foo
 		public partial class Menu
 		{
 			
-			// aapt resource value: 0x7F080000
-			public const int Options = 2131230720;
+			// aapt resource value: 0x7F090000
+			public const int Options = 2131296256;
 			
 			static Menu()
 			{
@@ -180,8 +183,8 @@ namespace Foo.Foo
 		public partial class Mipmap
 		{
 			
-			// aapt resource value: 0x7F090000
-			public const int icon = 2131296256;
+			// aapt resource value: 0x7F0A0000
+			public const int icon = 2131361792;
 			
 			static Mipmap()
 			{
@@ -196,8 +199,8 @@ namespace Foo.Foo
 		public partial class Raw
 		{
 			
-			// aapt resource value: 0x7F0B0000
-			public const int foo = 2131427328;
+			// aapt resource value: 0x7F0C0000
+			public const int foo = 2131492864;
 			
 			static Raw()
 			{
@@ -212,8 +215,8 @@ namespace Foo.Foo
 		public partial class Plurals
 		{
 			
-			// aapt resource value: 0x7F0A0000
-			public const int num_locations_reported = 2131361792;
+			// aapt resource value: 0x7F0B0000
+			public const int num_locations_reported = 2131427328;
 			
 			static Plurals()
 			{
@@ -228,17 +231,17 @@ namespace Foo.Foo
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7F0C0000
-			public const int app_name = 2131492864;
+			// aapt resource value: 0x7F0D0000
+			public const int app_name = 2131558400;
 			
-			// aapt resource value: 0x7F0C0001
-			public const int foo = 2131492865;
+			// aapt resource value: 0x7F0D0001
+			public const int foo = 2131558401;
 			
-			// aapt resource value: 0x7F0C0002
-			public const int hello = 2131492866;
+			// aapt resource value: 0x7F0D0002
+			public const int hello = 2131558402;
 			
-			// aapt resource value: 0x7F0C0003
-			public const int menu_settings = 2131492867;
+			// aapt resource value: 0x7F0D0003
+			public const int menu_settings = 2131558403;
 			
 			static String()
 			{
@@ -250,11 +253,34 @@ namespace Foo.Foo
 			}
 		}
 		
+		public partial class Styleable
+		{
+			
+			public static int[] CustomFonts = new int[] {
+					16842962,
+					2130903040};
+			
+			// aapt resource value: 0x0
+			public const int CustomFonts_android_scrollX = 0;
+			
+			// aapt resource value: 0x1
+			public const int CustomFonts_customFont = 1;
+			
+			static Styleable()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Styleable()
+			{
+			}
+		}
+		
 		public partial class Transition
 		{
 			
-			// aapt resource value: 0x7F0D0000
-			public const int transition = 2131558400;
+			// aapt resource value: 0x7F0F0000
+			public const int transition = 2131689472;
 			
 			static Transition()
 			{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
@@ -256,6 +256,7 @@ namespace Foo.Foo
 		public partial class Styleable
 		{
 			
+			// aapt resource value: { 0x10100D2,0x7F030000 }
 			public static int[] CustomFonts = new int[] {
 					16842962,
 					2130903040};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
@@ -60,6 +60,14 @@ namespace Xamarin.Android.Build.Tests {
 	<dimen name=""main_text_item_size"">17dp</dimen>
 </resources>";
 
+		const string Styleable = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<resources>
+  <declare-styleable name=""CustomFonts"">
+    <attr name=""android:scrollX"" />
+    <attr name=""customFont"" />
+  </declare-styleable>
+</resources>";
+
 		const string Transition = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <changeBounds
   xmlns:android=""http://schemas.android.com/apk/res/android""
@@ -95,25 +103,39 @@ namespace Xamarin.Android.Build.Tests {
 		/// </summary>
 		const string Rtxt = @"int animator slide_in_bottom 0x7f010000
 int array widths_array 0x7f020000
-int dimen main_text_item_size 0x7f030000
-int drawable ic_menu_preferences 0x7f040000
-int font arial 0x7f050000
-int id Føø_Bar 0x7f060000
-int id menu_settings 0x7f060001
-int id seekBar 0x7f060002
-int id seekbar 0x7f060003
-int id textview_withperiod 0x7f060004
-int layout main 0x7f070000
-int menu Options 0x7f080000
-int mipmap icon 0x7f090000
-int plurals num_locations_reported 0x7f0a0000
-int raw foo 0x7f0b0000
-int string app_name 0x7f0c0000
-int string foo 0x7f0c0001
-int string hello 0x7f0c0002
-int string menu_settings 0x7f0c0003
-int transition transition 0x7f0d0000
+int attr customFont 0x7f030000
+int dimen main_text_item_size 0x7f040000
+int drawable ic_menu_preferences 0x7f050000
+int font arial 0x7f060000
+int id Føø_Bar 0x7f070000
+int id menu_settings 0x7f070001
+int id seekBar 0x7f070002
+int id seekbar 0x7f070003
+int id textview_withperiod 0x7f070004
+int layout main 0x7f080000
+int menu options 0x7f090000
+int mipmap icon 0x7f0a0000
+int plurals num_locations_reported 0x7f0b0000
+int raw foo 0x7f0c0000
+int string app_name 0x7f0d0000
+int string foo 0x7f0d0001
+int string hello 0x7f0d0002
+int string menu_settings 0x7f0d0003
+int[] styleable CustomFonts { 0x010100d2,0x7f030000 }
+int styleable CustomFonts_android_scrollX 0
+int styleable CustomFonts_customFont 1
+int transition transition 0x7f0f0000
 ";
+		[OneTimeSetUp]
+		public void Setup ()
+		{
+			using (var builder = new Builder ()) {
+				builder.ResolveSdks ();
+				AndroidSdkDirectory = builder.AndroidSdkDirectory;
+			}
+		}
+
+		public string AndroidSdkDirectory { get; set; }
 
 		public void CreateResourceDirectory (string path)
 		{
@@ -126,6 +148,7 @@ int transition transition 0x7f0d0000
 			File.WriteAllText (Path.Combine (Root, path, "AndroidManifest.xml"), AndroidManifest);
 
 			File.WriteAllText (Path.Combine (Root, path, "res", "values", "strings.xml"), StringsXml);
+			File.WriteAllText (Path.Combine (Root, path, "res", "values", "attrs.xml"), Styleable);
 			File.WriteAllText (Path.Combine (Root, path, "res", "transition", "transition.xml"), Transition);
 			File.WriteAllText (Path.Combine (Root, path, "res", "raw", "foo.txt"), "Foo");
 			File.WriteAllText (Path.Combine (Root, path, "res", "layout", "main.xml"), Main);
@@ -146,9 +169,9 @@ int transition transition 0x7f0d0000
 				File.WriteAllBytes (Path.Combine (Root, path, "lp", "res", "drawable", "ic_menu_preferences.png"), icon_binary_mdpi);
 				File.WriteAllBytes (Path.Combine (Root, path, "lp", "res", "mipmap-hdpi", "icon.png"), icon_binary_mdpi);
 			}
-			File.WriteAllText (Path.Combine (Root, path, "lp", "res", "menu", "Options.xml"), Menu);
+			File.WriteAllText (Path.Combine (Root, path, "lp", "res", "menu", "options.xml"), Menu);
+			File.WriteAllText (Path.Combine (Root, path, "lp", "__res_name_case_map.txt"), "menu/Options.xml;menu/options.xml");
 		}
-
 
 		[Test]
 		public void GenerateDesignerFileWithÜmläüts ()
@@ -174,6 +197,7 @@ int transition transition 0x7f0d0000
 				new TaskItem (Path.Combine (Root, path, "lp", "res")),
 			};
 			task.IsApplication = true;
+			task.JavaPlatformJarPath = Path.Combine (AndroidSdkDirectory, "platforms", "android-27", "android.jar");
 			Assert.IsTrue (task.Execute (), "Task should have executed successfully.");
 			Assert.IsTrue (File.Exists (task.NetResgenOutputFile), $"{task.NetResgenOutputFile} should have been created.");
 			var expected = Path.Combine (Root, "Expected", "GenerateDesignerFileExpected.cs");
@@ -207,6 +231,7 @@ int transition transition 0x7f0d0000
 				new TaskItem (Path.Combine (Root, path, "lp", "res")),
 			};
 			task.IsApplication = true;
+			task.JavaPlatformJarPath = Path.Combine (AndroidSdkDirectory, "platforms", "android-27", "android.jar");
 			Assert.IsTrue (task.Execute (), "Task should have executed successfully.");
 			Assert.IsTrue (File.Exists (task.NetResgenOutputFile), $"{task.NetResgenOutputFile} should have been created.");
 			var expected = Path.Combine (Root, "Expected", "GenerateDesignerFileExpected.cs");

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ResourceIdentifier.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ResourceIdentifier.cs
@@ -16,18 +16,18 @@ namespace Xamarin.Android.Tasks
 		private const string FormattingCharacter = @"\p{Cf}";
 		private const string ConnectingCharacter = @"\p{Pc}";
 		private const string DecimalDigitCharacter = @"\p{Nd}";
-		private const string CombiningCharacter = @"\p{Mn}\p{Mc}";
-		private const string LetterCharacter = @"\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}";
+		private const string CombiningCharacter = @"\p{Mn},\p{Mc}";
+		private const string LetterCharacter = @"\p{Lu},\p{Ll},\p{Lt},\p{Lm},\p{Lo},\p{Nl}";
 
-		private const string IdentifierPartCharacter = LetterCharacter +
-			DecimalDigitCharacter +
-			ConnectingCharacter +
-			CombiningCharacter +
+		private const string IdentifierPartCharacter = LetterCharacter + "," +
+			DecimalDigitCharacter + "," +
+			ConnectingCharacter + "," +
+			CombiningCharacter + "," +
 			FormattingCharacter;
 
-		private const string IdentifierStartCharacter = "(" + LetterCharacter + "_)";
+		private const string IdentifierStartCharacter = "(" + LetterCharacter + ",_)";
 
-		private const string Identifier = IdentifierStartCharacter + "(" + IdentifierPartCharacter + ")";
+		private const string Identifier = IdentifierStartCharacter + "((" + IdentifierPartCharacter + ")+)*";
 
 		//https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#keywords
 		private static readonly HashSet<string> _keywords = new HashSet<string> () {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ResourceIdentifier.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ResourceIdentifier.cs
@@ -16,18 +16,18 @@ namespace Xamarin.Android.Tasks
 		private const string FormattingCharacter = @"\p{Cf}";
 		private const string ConnectingCharacter = @"\p{Pc}";
 		private const string DecimalDigitCharacter = @"\p{Nd}";
-		private const string CombiningCharacter = @"\p{Mn},\p{Mc}";
-		private const string LetterCharacter = @"\p{Lu},\p{Ll},\p{Lt},\p{Lm},\p{Lo},\p{Nl}";
+		private const string CombiningCharacter = @"\p{Mn}\p{Mc}";
+		private const string LetterCharacter = @"\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}";
 
-		private const string IdentifierPartCharacter = LetterCharacter + "," +
-			DecimalDigitCharacter + "," +
-			ConnectingCharacter + "," +
-			CombiningCharacter + "," +
+		private const string IdentifierPartCharacter = LetterCharacter +
+			DecimalDigitCharacter +
+			ConnectingCharacter +
+			CombiningCharacter +
 			FormattingCharacter;
 
-		private const string IdentifierStartCharacter = "(" + LetterCharacter + ",_)";
+		private const string IdentifierStartCharacter = "(" + LetterCharacter + "_)";
 
-		private const string Identifier = IdentifierStartCharacter + "((" + IdentifierPartCharacter + ")+)*";
+		private const string Identifier = IdentifierStartCharacter + "(" + IdentifierPartCharacter + ")";
 
 		//https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#keywords
 		private static readonly HashSet<string> _keywords = new HashSet<string> () {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1330,7 +1330,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_ManagedUpdateAndroidResgen" Condition=" '$(ManagedDesignTimeBuild)' == 'True' "
 		Inputs="$(_ManagedUpdateAndroidResgenInputs);$(_AndroidResourcePathsCache);$(_AndroidLibraryProjectImportsCache);$(_AndroidLibraryImportsCache);"
 		Outputs="$(_AndroidManagedResourceDesignerFile)"
-		DependsOnTargets="_CreatePropertiesCache;_ExtractLibraryProjectImports;_CreateAdditionalResourceCache">
+		DependsOnTargets="_CreatePropertiesCache;_ExtractLibraryProjectImports;_CreateAdditionalResourceCache;_ValidateAndroidPackageProperties">
 	<MakeDir Directories="$(_AndroidIntermediateDesignTimeBuildDirectory)" />
 	<!-- Parse primary R.java and create Resources.Designer.cs -->
 	<GenerateResourceDesigner
@@ -1346,6 +1346,7 @@ because xbuild doesn't support framework reference assemblies.
 		References="@(_ReferencePath)"
 		UseManagedResourceGenerator="True"
 		DesignTimeBuild="$(DesignTimeBuild)"
+		JavaPlatformJarPath="$(JavaPlatformJarPath)"
 		Condition="Exists ('$(MonoAndroidResourcePrefix)')"
 	/>
 	<ItemGroup>
@@ -1762,6 +1763,7 @@ because xbuild doesn't support framework reference assemblies.
 		References="@(_ReferencePath)"
 		UseManagedResourceGenerator="$(_UseManagedResourceGenerator)"
 		DesignTimeBuild="$(DesignTimeBuild)"
+		JavaPlatformJarPath="$(JavaPlatformJarPath)"
 	/>
 
 	<!-- Only copy if the file contents changed, so users only get Reload? dialog for real changes -->


### PR DESCRIPTION
Fixes #3049

This commit also reworks the id generation of the
`ManagedResourceParser` to try replicate the
ids which `aapt2` produces. As a result if the managed
parser generates the code from the `R.txt` file or
directly from the resources, the resulting designer.cs
file will be identical most of the time. There does seem
to be an odd ordering issue where the R.txt file does
not seem to order the items by name as the Id's are 
sometimes switched. 