### PR TITLE
Don't use NDK linker to link libxamarin-app.so

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkApplicationSharedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkApplicationSharedLibraries.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Android.Tasks
 		public bool DebugBuild { get; set; }
 
 		[Required]
-		public string AndroidNdkDirectory { get; set; }
+		public string AndroidSdkBuildToolsPath { get; set; }
 
 		public override bool Execute ()
 		{
@@ -210,8 +210,9 @@ namespace Xamarin.Android.Tasks
 					linkerArgs.Add (QuoteFileName (file));
 				}
 
+				string ld = MonoAndroidHelper.GetExecutablePath (AndroidSdkBuildToolsPath, $"{NdkUtil.GetNdkToolchainPrefix (arch, false)}ld");
 				yield return new Config {
-					LinkerPath = NdkUtil.GetNdkTool (AndroidNdkDirectory, arch, "ld", XABuildConfig.ArchAPILevels [abi]),
+					LinkerPath = Path.Combine (AndroidSdkBuildToolsPath, ld),
 					LinkerOptions = String.Join (" ", linkerArgs),
 					OutputSharedLibrary = inputs.OutputSharedLibrary,
 				};

--- a/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
@@ -262,7 +262,7 @@ namespace Xamarin.Android.Tasks
 			return null;
 		}
 
-		static string GetNdkToolchainPrefix (AndroidTargetArch arch, bool forCompiler)
+		public static string GetNdkToolchainPrefix (AndroidTargetArch arch, bool forCompiler)
 		{
 			if (!UsingClangNDK)
 				return NdkUtilOld.GetNdkToolchainPrefix (arch);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2912,7 +2912,7 @@ because xbuild doesn't support framework reference assemblies.
       ObjectFiles="@(_NativeAssemblyTarget)"
       ApplicationSharedLibraries="@(_ApplicationSharedLibrary)"
       DebugBuild="$(AndroidIncludeDebugSymbols)"
-      AndroidNdkDirectory="$(_AndroidNdkDirectory)"
+      AndroidSdkBuildToolsPath="$(AndroidSdkBuildToolsPath)"
   />
   <ItemGroup>
     <FileWrites Include="@(_ApplicationSharedLibrary)" />


### PR DESCRIPTION
The code mistakenly used the `ld` linker from Android NDK while it should have
used one from the Android *SDK*'s build-tools.