### PR TITLE
[build] Create symlink to MSBuild's `Current` "version" directory

### DIFF
--- a/tools/xabuild/XABuildPaths.cs
+++ b/tools/xabuild/XABuildPaths.cs
@@ -167,9 +167,8 @@ namespace Xamarin.Android.Build
 					if (!Directory.Exists (xbuildDir))
 						continue;
 					systemTargetDirs.Add (xbuildDir);
-					foundSomeXbuldDirs = true;
 				}
-				if (!systemTargetDirs.Count == 0)
+				if (systemTargetDirs.Count == 0)
 					throw new InvalidOperationException ("Unable to locate xbuild directory");
 				systemTargetDirs.Add (Path.Combine (mono, "xbuild", "Microsoft"));
 				SystemTargetsDirectories = systemTargetDirs.ToArray ();

--- a/tools/xabuild/XABuildPaths.cs
+++ b/tools/xabuild/XABuildPaths.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -141,16 +142,37 @@ namespace Xamarin.Android.Build
 				NuGetTargets             = Path.Combine (nuget, "Microsoft.NuGet.targets");
 				NuGetRestoreTargets      = Path.Combine (VsInstallRoot, "Common7", "IDE", "CommonExtensions", "Microsoft", "NuGet", "NuGet.targets");
 			} else {
-				const string vsVersion   = "15.0";
+				string[] vsVersions       = new [] {"Current", "15.0"};
 				string mono              = IsMacOS ? "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono" : "/usr/lib/mono";
 				string monoExternal      = IsMacOS ? "/Library/Frameworks/Mono.framework/External/" : "/usr/lib/mono";
 				MSBuildPath              = Path.Combine (mono, "msbuild");
-				MSBuildBin               = Path.Combine (MSBuildPath, vsVersion, "bin");
+
+				MSBuildBin = null;
+				foreach (string vsVersion in vsVersions) {
+					MSBuildBin = Path.Combine (MSBuildPath, vsVersion, "bin");
+					if (Directory.Exists (MSBuildBin))
+						break;
+				}
+				if (string.IsNullOrEmpty (MSBuildBin))
+					throw new InvalidOperationException ("Unable to locate MSBuild binaries directory");
+
 				MSBuildConfig            = Path.Combine (MSBuildBin, "MSBuild.dll.config");
 				DotNetSdkPath            = FindLatestDotNetSdk ("/usr/local/share/dotnet/sdk");
 				MSBuildSdksPath          = DotNetSdkPath ?? Path.Combine (MSBuildBin, "Sdks");
 				SystemFrameworks         = Path.Combine (mono, "xbuild-frameworks");
-				SystemTargetsDirectories = new [] { Path.Combine (mono, "xbuild", vsVersion), Path.Combine (mono, "xbuild", "Microsoft") };
+
+				var systemTargetDirs = new List <string> ();
+				foreach (string vsVersion in vsVersions) {
+					string xbuildDir = Path.Combine (mono, "xbuild", vsVersion);
+					if (!Directory.Exists (xbuildDir))
+						continue;
+					systemTargetDirs.Add (xbuildDir);
+					foundSomeXbuldDirs = true;
+				}
+				if (!systemTargetDirs.Count == 0)
+					throw new InvalidOperationException ("Unable to locate xbuild directory");
+				systemTargetDirs.Add (Path.Combine (mono, "xbuild", "Microsoft"));
+				SystemTargetsDirectories = systemTargetDirs.ToArray ();
 				SearchPathsOS            = IsMacOS ? "osx" : "unix";
 
 				string nuget = Path.Combine (mono, "xbuild", "Microsoft", "NuGet");


### PR DESCRIPTION
Newer MSBuild versions are moving to use the `Current` directory instaed of a
versioned one (e.g. `14.0`, `15.0`) to keep its binaries, targets etc. Without
pointing to that directory in a symlink from
`bin/$(Configuration)/lib/xamarin.android/xbuild` the build will fail on Unix
with an error similar to:

  bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/Xamarin.Android.Aapt2.targets(31,3): error MSB3191: Unable to create directory "/Debug/". Access to the path '/Debug/' is denied.

Adjust XABuildPaths.cs to first look for the `Current` directory and only then
for the old `15.0` one.