### PR TITLE
[mono-runtimes] missing pdbs for bcl-tests

### DIFF
--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -296,9 +296,10 @@
       <_BclTestAssemblyReference Include="@(MonoTestAssembly)" Condition="'%(MonoTestAssembly.TestType)' == 'reference'" />
       <_BclTestAssembly  Include="@(MonoTestAssembly)" Condition="'%(MonoTestAssembly.TestType)' == '' Or '%(MonoTestAssembly.TestType)' == 'xunit' " />
       <_BclTestAssemblySource Include="@(_BclTestAssemblyReference->'$(_MonoProfileDir)\%(Identity)')" />
-      <_BclTestAssemblySource Include="@(_BclTestAssemblyReference->'$(_MonoProfileDir)\%(Filename).pdb')" Condition="Exists('@(_BclTestAssemblyReference->'$(_MonoProfileDir)\%(Filename).pdb')')" />
       <_BclTestAssemblySource Include="@(_BclTestAssembly->'$(_MonoProfileDir)\tests\%(Identity)')" />
-      <_BclTestAssemblySource Include="@(_BclTestAssembly->'$(_MonoProfileDir)\tests\%(Filename).pdb')" Condition="Exists('@(_BclTestAssembly->'$(_MonoProfileDir)\tests\%(Filename).pdb')')" />
+      <_BclTestAssemblySymbols Include="@(_BclTestAssemblyReference->'$(_MonoProfileDir)\%(Filename).pdb')" />
+      <_BclTestAssemblySymbols Include="@(_BclTestAssembly->'$(_MonoProfileDir)\tests\%(Filename).pdb')" />
+      <_BclTestAssemblySource Include="@(_BclTestAssemblySymbols)" Condition="Exists('%(Identity)')" />
       <_BclTestAssemblySource Include="@(MonoTestRunner->'$(_MonoProfileDir)\%(Identity)')" />
       <_BclTestAssemblySource Include="@(MonoTestRunner->'$(_MonoProfileDir)\%(Filename).pdb')" />
       <_BclTestSatelliteAssemblySource  Include="@(MonoTestSatelliteAssembly->'$(_MonoProfileDir)\tests\%(Identity)')" />


### PR DESCRIPTION
Context: http://build.devdiv.io/2621129

We have been seeing failures like this on Windows:

    src\mono-runtimes\mono-runtimes.targets(323,5): Error MSB4018: The "SystemUnzip" task failed unexpectedly.
    System.AggregateException: One or more errors occurred. --->
    System.IO.FileNotFoundException: Could not find file 'C:\Users\dlab14\android-archives\android-release-Windows-e66c76674243826a8d127f0261f0fb64f8d59757.zip'.

Which is odd, because we should not be downloading the mono archive on
Windows at all. When a bundle produced by xamarin-android builds
exists, this step should be skipped.

The culprit was:

    Building target "_BuildUnlessCached" completely.
    Output file "C:\src\xamarin-android\bin\Debug\lib\xamarin.android\\..\..\bcl-tests\BinarySerializationOverVersionsTest.pdb" does not exist.

`BinarySerializationOverVersionsTest.pdb` (or any pdb!) does not exist
in the xamarin-android bundle, but it exists in the mono archive.

After reviewing logs further, the `@(_BclTestAssemblySource)` item
group did not contain the missing pdb files.

Then I noticed two lines such as this:

    <_BclTestAssemblySource Include="@(_BclTestAssembly->'$(_MonoProfileDir)\tests\%(Filename).pdb')" Condition="Exists('@(_BclTestAssembly->'$(_MonoProfileDir)\tests\%(Filename).pdb')')" />

The `Exists` check is evaluating to `False`, which I think is due to
MSBuild expanding the transform.

I think it's *literally* checking a file named `foo.pdb;bar.pdb;`
exists... but every file path listed here, of course.

The fix is to use an intermediate item group
`@(_BclTestAssemblySymbols)`, and instead do:

    <_BclTestAssemblySource Include="@(_BclTestAssemblySymbols)" Condition="Exists('%(Identity)')" />

After this change, I am getting this when I build
`mono-runtimes.csproj`:

    Skipping target "_BuildUnlessCached" because all output files are up-to-date with respect to the input files.

I also have these files:

    $ ls bin/Debug/bcl-tests/ | grep pdb$
    BinarySerializationOverVersionsTest.pdb
    Microsoft.CSharp.pdb
    TestLoadAssembly.pdb
    monodroid_I18N.CJK_test.pdb
    ...

(plus many more)