### PR TITLE
[monodroid] Change the libmono-native dllmap target on osx

### DIFF
--- a/src/monodroid/config.xml
+++ b/src/monodroid/config.xml
@@ -10,7 +10,7 @@
 	<dllmap wordsize="64" dll="libintl" target="/system/lib64/libc.so" />
 	<dllmap dll="MonoPosixHelper" target="libMonoPosixHelper.so" />
 	<dllmap dll="System.Native">
-		<dllentry os="osx" dll="libmono-native.dylib" />
+		<dllentry os="osx" dll="__Internal" />
 		<dllentry os="linux" dll="libmono-native.so" />
 	</dllmap>
 	<dllmap wordsize="32" dll="i:msvcrt" target="/system/lib/libc.so" />

--- a/src/monodroid/config.xml
+++ b/src/monodroid/config.xml
@@ -9,7 +9,10 @@
 	<dllmap wordsize="32" dll="libintl" target="/system/lib/libc.so" />
 	<dllmap wordsize="64" dll="libintl" target="/system/lib64/libc.so" />
 	<dllmap dll="MonoPosixHelper" target="libMonoPosixHelper.so" />
-	<dllmap dll="System.Native" target="libmono-native.so" />
+	<dllmap dll="System.Native">
+		<dllentry os="osx" dll="libmono-native.dylib" />
+		<dllentry os="linux" dll="libmono-native.so" />
+	</dllmap>
 	<dllmap wordsize="32" dll="i:msvcrt" target="/system/lib/libc.so" />
 	<dllmap wordsize="64" dll="i:msvcrt" target="/system/lib64/libc.so" />
 	<dllmap wordsize="32" dll="i:msvcrt.dll" target="/system/lib/libc.so" />


### PR DESCRIPTION
One of the designer unit tests is failing on Mac with:

    [2019-04-25 21:52:55.8] INFO: : Unhandled Exception:
    [2019-04-25 21:52:55.8] INFO: : System.TypeInitializationException: The type initializer for 'System.Console' threw an exception. ---> System.DllNotFoundException: libmono-native.so
    [2019-04-25 21:52:55.8] INFO: :   at (wrapper managed-to-native) Interop+Sys.Stat(byte&,Interop/Sys/FileStatus&)
    [2019-04-25 21:52:55.8] INFO: :   at Interop+Sys.Stat (System.ReadOnlySpan`1[T] path, Interop+Sys+FileStatus& output) [0x00028] in <ca2a591e441f458bb6bef167b4521022>:0
    [2019-04-25 21:52:55.8] INFO: :   at System.IO.FileSystem.FileExists (System.ReadOnlySpan`1[T] fullPath, System.Int32 fileType, Interop+ErrorInfo& errorInfo) [0x00007] in <ca2a591e441f458bb6bef167b4521022>:0
    [2019-04-25 21:52:55.8] INFO: :   at System.IO.FileSystem.FileExists (System.ReadOnlySpan`1[T] fullPath) [0x00006] in <ca2a591e441f458bb6bef167b4521022>:0
    [2019-04-25 21:52:55.8] INFO: :   at System.IO.File.Exists (System.String path) [0x00043] in <ca2a591e441f458bb6bef167b4521022>:0
    [2019-04-25 21:52:55.8] INFO: :   at System.IO.LogcatTextWriter.IsRunningOnAndroid () [0x00000] in <ca2a591e441f458bb6bef167b4521022>:0
    [2019-04-25 21:52:55.8] INFO: :   at System.Console.SetupStreams (System.Text.Encoding inputEncoding, System.Text.Encoding outputEncoding) [0x00050] in <ca2a591e441f458bb6bef167b4521022>:0
    [2019-04-25 21:52:55.8] INFO: :   at System.Console..cctor () [0x0004f] in <ca2a591e441f458bb6bef167b4521022>:0

First, the `.so` extension is wrong. Also the designer puts the assemblies in temporary location, without the shared libraries, so the share `libmono-native` library is not found. Designer preloads the runtime shared libraries instead.

So we set the dllmap target on Mac to `__Internal` and the designer will preload the `libmono-native`.