### PR TITLE
[mono-runtimes] exclude a missing pdb file

### DIFF
--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -66,6 +66,7 @@
   <Import Project="ProfileAssemblies.projitems" />
   <ItemGroup>
     <_BclAssembly Include="@(MonoProfileAssembly)" />
+    <_BclExcludeDebugSymbols  Include="System.Reflection.TestModule.dll" />
     <_BclExcludeDebugSymbols  Include="System.Runtime.CompilerServices.Unsafe.dll" />
     <_BclExcludeDebugSymbols  Include="System.Windows.dll" />
     <_BclExcludeDebugSymbols  Include="System.Xml.Serialization.dll" />
@@ -73,7 +74,7 @@
     <_BclTestAssemblyDestination  Include="@(MonoTestSatelliteAssembly->'$(XAInstallPrefix)\..\..\bcl-tests\%(Identity)')" />
     <_BclTestAssemblyDestination
         Include="@(MonoTestAssembly->'$(XAInstallPrefix)\..\..\bcl-tests\%(Filename).pdb')"
-        Exclude="$(XAInstallPrefix)\..\..\bcl-tests\System.Runtime.CompilerServices.Unsafe.pdb"
+        Exclude="@(_BclExcludeDebugSymbols->'$(XAInstallPrefix)\..\..\bcl-tests\%(Filename).pdb')"
     />
     <_BclTestAssemblyDestination  Include="@(MonoTestRunner->'$(XAInstallPrefix)\..\..\bcl-tests\%(Identity)')" />
     <_BclTestAssemblyDestination  Include="@(MonoTestRunner->'$(XAInstallPrefix)\..\..\bcl-tests\%(Filename).pdb')" />


### PR DESCRIPTION
After 89be639 was merged, I was still hitting the original problem of
not being able to build on Windows. This time a different file was the
cuplrit:

    Building target "_BuildUnlessCached" completely.
    Output file "C:\src\xamarin-android\bin\Debug\lib\xamarin.android\\..\..\bcl-tests\System.Reflection.TestModule.pdb" does not exist.

This file did not exist in Xamarin.Android's bundle or the mono
archive, so we need to exclude it from `Outputs` of
`_BuildUnlessCached`.

To fix this, I added the file to `@(_BclExcludeDebugSymbols)` and
reworked line 77 to use this item group.

I then used a "weird trick" to hardcode the latest `(_VersionHash)`,
so the Xamarin.Android bundle wasn't invalidated for me locally:

    diff --git a/build-tools/create-bundle/bundle-path.targets b/build-tools/create-bundle/bundle-path.targets
    index c99eeab8..9269a6b3 100644
    --- a/build-tools/create-bundle/bundle-path.targets
    +++ b/build-tools/create-bundle/bundle-path.targets
    @@ -38,7 +38,7 @@
    -      <XABundleFileName Condition=" '$(HostOS)' == 'Windows' AND '$(XABundleFileName)' == '' ">bundle-$(XABundleVersion)-h$(_VersionHash)-$(Configuration)-Darwin-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>
    +      <XABundleFileName Condition=" '$(HostOS)' == 'Windows' AND '$(XABundleFileName)' == '' ">bundle-$(XABundleVersion)-h62993a79-$(Configuration)-Darwin-libzip=$(_LibZipHash),llvm=$(_LlvmHash),mono=$(_MonoHash).zip</XABundleFileName>

I was able to build on Windows again after this change:

    Skipping target "_BuildUnlessCached" because all output files are up-to-date with respect to the input files.