### PR TITLE
[WIP] Emit a stableIds file from the ManagedResourceParser.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -73,6 +73,10 @@ namespace Xamarin.Android.Tasks {
 		public bool NonConstantId { get; set; }
 
 		public bool ProtobufFormat { get; set; }
+		
+		public string EmitIdsFile { get; set; }
+
+		public string StableIdsFile { get; set; }
 
 		AssemblyIdentityMap assemblyMap = new AssemblyIdentityMap ();
 		List<string> tempFiles = new List<string> ();
@@ -201,6 +205,10 @@ namespace Xamarin.Android.Tasks {
 				if (!string.IsNullOrWhiteSpace (assetDir) && Directory.Exists (assetDir))
 					cmd.AppendSwitchIfNotNull ("-A ", assetDir);
 			}
+			if (!string.IsNullOrEmpty (StableIdsFile) && File.Exists (StableIdsFile)) {
+				cmd.AppendSwitchIfNotNull ("--stable-ids ", StableIdsFile);
+			}
+			cmd.AppendSwitchIfNotNull ("--emit-ids ", EmitIdsFile);
 			cmd.AppendSwitchIfNotNull ("-o ", currentResourceOutputFile);
 			return cmd.ToString ();
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
@@ -51,6 +51,10 @@ namespace Xamarin.Android.Tasks
 
 		public string ResourceFlagFile { get; set; }
 
+		public string StableIdsFile { get; set; }
+
+		public string ApplicationName { get; set; }
+
 		private Dictionary<string, string> resource_fixup = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase);
 
 		public override bool RunTask ()
@@ -96,7 +100,13 @@ namespace Xamarin.Android.Tasks
 			// Parse out the resources from the R.java file
 			CodeTypeDeclaration resources;
 			if (UseManagedResourceGenerator) {
-				var parser = new ManagedResourceParser () { Log = Log, JavaPlatformDirectory = javaPlatformDirectory, ResourceFlagFile = ResourceFlagFile };
+				var parser = new ManagedResourceParser () {
+					Log = Log,
+					JavaPlatformDirectory = javaPlatformDirectory,
+					ResourceFlagFile = ResourceFlagFile,
+					StableIdsFile = StableIdsFile,
+					ApplicationName = ApplicationName,
+				};
 				resources = parser.Parse (ResourceDirectory, AdditionalResourceDirectories?.Select (x => x.ItemSpec), IsApplication, resource_fixup);
 			} else {
 				var parser = new JavaResourceParser () { Log = Log };

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetExtraPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetExtraPackages.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Android.Tasks
 		public override string TaskPrefix => "GEP";
 
 		[Required]
-		public string IntermediateOutputPath { get; set; }
+		public string LibraryProjectIntermediatePath { get; set; }
 
 		[Output]
 		public string ExtraPackages { get; set; }
@@ -24,9 +24,8 @@ namespace Xamarin.Android.Tasks
 		public override bool RunTask ()
 		{
 			var extraPackages = new List<string> ();
-			var libProjects = Path.Combine (IntermediateOutputPath, "__library_projects__");
-			if (Directory.Exists (libProjects)) {
-				foreach (var assemblyDir in Directory.GetDirectories (libProjects)) {
+			if (Directory.Exists (LibraryProjectIntermediatePath)) {
+				foreach (var assemblyDir in Directory.GetDirectories (LibraryProjectIntermediatePath)) {
 					foreach (var importBaseDir in new string [] { LibraryProjectImportsDirectoryName, "library_project_imports", }) {
 						string importsDir = Path.Combine (assemblyDir, importBaseDir);
 						string libpkg = GetPackageNameForLibrary (importsDir, Path.GetDirectoryName (assemblyDir));

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
@@ -721,5 +721,35 @@ int styleable ElevenAttributes_attr10 10";
 				 $"{task.NetResgenOutputFile} and {expected} do not match.");
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
+		
+		public void DebugGenerator ()
+		{
+			string path = "/Users/dean/Documents/Sandbox/Xamarin/xaspeed/tests/Xamarin.Forms-Performance-Integration/Droid";
+			IBuildEngine engine = new MockBuildEngine (TestContext.Out);
+			var task = new GenerateResourceDesigner {
+				BuildEngine = engine
+			};
+			task.UseManagedResourceGenerator = true;
+			task.DesignTimeBuild = true;
+			task.Namespace = "Xamarin.Forms.Performance.Integration.Droid";
+			task.NetResgenOutputFile = Path.Combine (path, "Resource.designer.cs");
+			task.ProjectDir = Path.Combine (path);
+			task.ResourceDirectory = Path.Combine (path, "obj", "Debug", "res") + Path.DirectorySeparatorChar;
+			var files = Directory.EnumerateFiles (task.ResourceDirectory, "*.*", SearchOption.AllDirectories);
+			List<TaskItem> items = new List<TaskItem> ();
+			foreach (var f in files) {
+				items.Add (new TaskItem (f, new Dictionary<string, string> {
+					{ "LogicalName", f.Replace (task.ResourceDirectory, string.Empty) }
+				}));
+			}
+			task.Resources = items.ToArray ();
+			task.AdditionalResourceDirectories = new TaskItem [] {
+				new TaskItem (Path.Combine (path, "obj", "Debug", "lp", "res")),
+			};
+			task.IsApplication = true;
+			task.StableIdsFile = Path.Combine (path, "stableid-test.txt");
+			task.ApplicationName = "Xamarin.Forms_Performance_Integration";
+			task.Execute ();
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1331,6 +1331,8 @@ because xbuild doesn't support framework reference assemblies.
 		DesignTimeBuild="$(DesignTimeBuild)"
 		JavaPlatformJarPath="$(JavaPlatformJarPath)"
 		ResourceFlagFile="$(_AndroidResFlagFile)"
+		StableIdsFile="$(IntermediateOutputPath)stableids.txt"
+		ApplicationName="$(_AndroidPackage)"
 		Condition="Exists ('$(MonoAndroidResourcePrefix)')"
 	/>
 	<ItemGroup>
@@ -1338,6 +1340,7 @@ because xbuild doesn't support framework reference assemblies.
 		<CorrectCasedItem Include="%(Compile.Identity)" Condition="'%(Compile.Identity)' == 'Resources\Resource.designer.cs'"/>
 		<Compile Remove="@(CorrectCasedItem)" Condition=" '$(ManagedDesignTimeBuild)' == 'True' And '%(CorrectCasedItem.Identity)' != '' "/>
 		<Compile Include="$(_AndroidManagedResourceDesignerFile)" Condition=" '$(ManagedDesignTimeBuild)' == 'True' And Exists ('$(_AndroidManagedResourceDesignerFile)')" />
+		<FileWrites Include="$(IntermediateOutputPath)stableids.txt" />
 	</ItemGroup>
 </Target>
 	
@@ -1692,8 +1695,21 @@ because xbuild doesn't support framework reference assemblies.
 		IsApplication="$(AndroidApplication)"
 		References="@(_ReferencePath)"
 		UseManagedResourceGenerator="$(_UseManagedResourceGenerator)"
+		StableIdsFile="$(IntermediateOutputPath)stableids.txt"
+		ApplicationName="$(_AndroidPackage)"
 		DesignTimeBuild="$(DesignTimeBuild)"
 		JavaPlatformJarPath="$(JavaPlatformJarPath)"
+	/>
+		
+	<ItemGroup>
+		<FileWrites Include="$(IntermediateOutputPath)stableids.txt" />	
+	</ItemGroup>
+
+	<!-- Only copy if the file contents changed, so users only get Reload? dialog for real changes -->
+	<CopyIfChanged
+		SourceFiles="$(ResgenTemporaryDirectory)\$(AndroidResgenFilename)"
+		DestinationFiles="$(_AndroidResourceDesignerFile)"
+		Condition="'$(_AndroidResourceDesignerFile)' != '' And Exists ('$(ResgenTemporaryDirectory)\$(AndroidResgenFilename)')"
 	/>
 
 	<!-- Delete our temporary directory -->
@@ -2381,6 +2397,7 @@ because xbuild doesn't support framework reference assemblies.
   <ItemGroup>
     <FileWrites Include="$(_PackagedResources)" />
     <FileWrites Include="$(_GeneratedPrimaryJavaResgenFile)" />
+    <FileWrites Include="$(IntermediateOutputPath)emit.txt" />
   </ItemGroup>
 </Target>
 
@@ -3291,6 +3308,8 @@ because xbuild doesn't support framework reference assemblies.
 	<Delete Files="$(_AndroidMainDexListFile)" />
 	<Delete Files="$(_AndroidBuildIdFile)" />
 	<Delete Files="$(_ResolvedUserAssembliesHashFile)" />
+	<Delete Files="$(IntermediateOutputPath)stableids.txt" />
+	<Delete Files="$(IntermediateOutputPath)emit.txt" />
 </Target>
 
 <Target Name="_CollectMonoAndroidOutputs" DependsOnTargets="_ValidateAndroidPackageProperties">


### PR DESCRIPTION
So the idea here is this. We get the ManagedResourceParser to emit a `stableids.txt` file which `aapt2` will then use to generate its own resource ids. 

Benefit. We can then just use the ManagedResourceParser to generate the `Resource.designer.cs` file for both DTB and the main build. This is because we know the correct id's will be used. 

- [ ] Get the ManagedParser to emit the file
- [ ] Add Unit tests to make sure we generate the correct id's 
- [ ] Add Unit tests to include more complex resources
- [ ] Add Tests to see what happens for `android:xxx` style resources in `declare-styleable` items.