### PR TITLE
[mono-runtimes] Use mono-api-html/info from bundle

### DIFF
--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -107,6 +107,8 @@
     <_MonoUtility  Include="illinkanalyzer.exe" />
     <_MonoUtility  Include="mono-symbolicate.exe" />
     <_MonoUtility  Include="mkbundle.exe" />
+    <_MonoUtility  Include="mono-api-html.exe" />
+    <_MonoUtility  Include="mono-api-info.exe" />
   </ItemGroup>
   <ItemGroup>
     <_MonoUtilitySource Include="@(_MonoUtility->'$(_MonoProfileToolsDir)\%(Identity)')" />

--- a/tests/api-compatibility/api-compatibility.mk
+++ b/tests/api-compatibility/api-compatibility.mk
@@ -5,9 +5,9 @@ RUNTIME           = mono --debug
 
 MONO_PATH         = $(call GetPath,MonoSource)
 MONO_API_HTML_DIR = $(MONO_PATH)/mcs/tools/mono-api-html
-MONO_API_HTML     = bin/Build$(CONFIGURATION)/mono-api-html.exe
+MONO_API_HTML     = bin/$(CONFIGURATION)/lib/xamarin.android/xbuild/Xamarin/Android/mono-api-html.exe
 MONO_API_INFO_DIR = $(MONO_PATH)/mcs/tools/corcompare
-MONO_API_INFO     = bin/Build$(CONFIGURATION)/mono-api-info.exe
+MONO_API_INFO     = bin/$(CONFIGURATION)/lib/xamarin.android/xbuild/Xamarin/Android/mono-api-info.exe
 MONO_OPTIONS_SRC  = $(MONO_PATH)/mcs/class/Mono.Options/Mono.Options/Options.cs
 FRAMEWORK_DIR     = bin/$(CONFIGURATION)/lib/xamarin.android/xbuild-frameworks/MonoAndroid
 
@@ -20,15 +20,3 @@ run-api-compatibility-tests: $(MONO_API_HTML) $(MONO_API_INFO)
 		MONO_API_INFO="$(RUNTIME) $(abspath $(MONO_API_INFO))" \
 		HTML_OUTPUT_DIR="$(abspath bin/Test$(CONFIGURATION)/compatibility)" \
 		XA_FRAMEWORK_DIR="$(abspath $(FRAMEWORK_DIR))"
-
-$(MONO_API_HTML): $(wildcard $(MONO_API_HTML_DIR)/*.cs) $(MONO_OPTIONS_SRC)
-	$(CSC) -out:$@ $(wildcard $(MONO_API_HTML_DIR)/*.cs) \
-		$(MONO_OPTIONS_SRC) \
-		-r:System.Xml.dll -r:System.Xml.Linq.dll
-
-MONO_API_INFO_REFS  = \
-  bin/$(CONFIGURATION)/lib/xamarin.android/xbuild/Xamarin/Android/Xamarin.Android.Cecil.dll
-
-$(MONO_API_INFO): $(wildcard $(MONO_API_INFO_DIR)/*.cs) $(MONO_OPTIONS_SRC)
-	$(CSC) -out:$@ $^ \
-		$(MONO_API_INFO_REFS:%=-r:%)


### PR DESCRIPTION
@jonpryor I also have another patch that keeps those binaries at `bin/Build$(CONFIGURATION)/` , but has a new target since it can't re-use `MonoUtility`. I hope this is okay as it is simpler.