### PR TITLE
[tests] Consistently run `run-api-compatibility-tests`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,8 +217,10 @@ prepare-external-git-dependencies:
 run-all-tests:
 	@echo "PRINTING MONO VERSION"
 	mono --version
-	$(call MSBUILD_BINLOG,run-all-tests,,Test) $(TEST_TARGETS) /t:RunAllTests
-	$(MAKE) run-api-compatibility-tests
+	_r=0 ; \
+	$(call MSBUILD_BINLOG,run-all-tests,,Test) $(TEST_TARGETS) /t:RunAllTests || _r=$$? ; \
+	$(MAKE) run-api-compatibility-tests || _r=$$?; \
+	exit $$_r
 
 clean:
 	$(call MSBUILD_BINLOG,clean) /t:Clean Xamarin.Android.sln


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/491
Context: https://github.com/xamarin/xamarin-android/pull/3032#issuecomment-487174225

A "funny" thing has happened with the mono/2019-02 bump: it has
apparently [broken API compatibility][0], which was not detected or
reported in the last [mono/2019-02 PR build][1].

What went wrong is that the `make run-all-tests` step was failing,
reporting an error, but because of how `make run-all-tests` was
structured, when the `RunAllTests` MSBuild target failed,
*no further tests were run*.

Further tests such as the API compatibility tests!

Fix the `make run-all-tests` target so that even if the `RunAllTests`
MSBuild target fails, we *continue executing tests* so that the
`make run-api-compatibility-tests` target is consistently executed.

The exit value of `make run-all-tests` is the exit value of the
*last failed test*.

[0]: https://github.com/xamarin/xamarin-android/pull/3032#issuecomment-487174225
[1]: https://jenkins.mono-project.com/job/xamarin-android-pr-pipeline-release/684/