### PR TITLE
Add APK test job to azure-pipelines.yaml

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/Adb.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/Adb.cs
@@ -43,6 +43,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		public                  bool            IgnoreExitCode        { get; set; }
 		public                  int             Timeout               { get; set; } = -1;
 		public                  string[]        EnvironmentVariables  { get; set; }
+		public                  bool            WriteOutputAsMessage  { get; set; } = false;
 
 		[Required]
 		public                  string          ToolPath              { get; set; }
@@ -147,7 +148,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			lock (linesLock) lines.Add (line);
 
 			if (!info.SuppressMSbuildLog) {
-				if (isStdout)
+				if (isStdout || WriteOutputAsMessage)
 					Log.LogMessage (MessageImportance.Low, line);
 				else
 					Log.LogWarning (line);

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
@@ -74,6 +74,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		{
 			var destFilename = Path.GetFileNameWithoutExtension (source) +
 				(string.IsNullOrWhiteSpace (Configuration) ? "" : "-" + Configuration) +
+				(string.IsNullOrWhiteSpace (TestsFlavor) ? "" : TestsFlavor) +
 				Path.GetExtension (source);
 			var dest = Path.Combine (DestinationFolder, destFilename);
 			return dest;

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		const                   string              TestResultsPathResult       = "INSTRUMENTATION_RESULT: nunit2-results-path=";
 		internal const          string              AdbRestartText              = "daemon not running; starting now at tcp:";
 		internal const          string              AdbCrashErrorText           = "The adb might have crashed and was restarted. ";
-		const                   string              ExitCodeName                = "INSTRUMENTATION_CODE: ";
+		const                   string              InstrumentationExitCodeName = "INSTRUMENTATION_CODE: ";
 		const                   int                 StateRunInstrumentation     = 0;
 		const                   int                 StateGetLogcat              = 1;
 		const                   int                 StateClearLogcat            = 2;
@@ -42,7 +42,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		public                  string              LogLevel                    { get; set; }
 
 		int                     currentState = -1;
-		int                     exitCode = 99;
+		int                     instrumentationExitCode = 99;
 		string                  targetTestResultsPath;
 
 		bool                    adbRestarted;
@@ -70,7 +70,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				return false;
 			}
 
-			if (exitCode != -1) {
+			if (instrumentationExitCode != -1) {
 				FailedToRun = Component;
 				Log.LogError (
 					$"Instrumentation for component `{Component}` did not exit successfully. " +
@@ -145,14 +145,14 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				return;
 
 			int testResultIndex = line.IndexOf (TestResultsPathResult, StringComparison.OrdinalIgnoreCase);
-			int exitCodeIndex = line.IndexOf (ExitCodeName, StringComparison.OrdinalIgnoreCase);
+			int exitCodeIndex = line.IndexOf (InstrumentationExitCodeName, StringComparison.OrdinalIgnoreCase);
 
 			if (testResultIndex < 0 && exitCodeIndex < 0)
 				return;
 			else if (testResultIndex >= 0)
 				targetTestResultsPath = line.Substring (testResultIndex + TestResultsPathResult.Length).Trim ();
 			else if (exitCodeIndex >= 0)
-				exitCode = int.Parse (line.Substring (exitCodeIndex + ExitCodeName.Length).Trim ());
+				instrumentationExitCode = int.Parse (line.Substring (exitCodeIndex + InstrumentationExitCodeName.Length).Trim ());
 		}
 	}
 }

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		const                   string              TestResultsPathResult       = "INSTRUMENTATION_RESULT: nunit2-results-path=";
 		internal const          string              AdbRestartText              = "daemon not running; starting now at tcp:";
 		internal const          string              AdbCrashErrorText           = "The adb might have crashed and was restarted. ";
+		const                   string              ExitCodeName                = "INSTRUMENTATION_CODE: ";
 		const                   int                 StateRunInstrumentation     = 0;
 		const                   int                 StateGetLogcat              = 1;
 		const                   int                 StateClearLogcat            = 2;
@@ -41,6 +42,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		public                  string              LogLevel                    { get; set; }
 
 		int                     currentState = -1;
+		int                     exitCode = 99;
 		string                  targetTestResultsPath;
 
 		bool                    adbRestarted;
@@ -65,6 +67,14 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				Log.LogError (
 						$"{adbText}Could not find NUnit2 results file after running component `{Component}`: " +
 						"no `nunit2-results-path` bundle value found in command output!");
+				return false;
+			}
+
+			if (exitCode != -1) {
+				FailedToRun = Component;
+				Log.LogError (
+					$"Instrumentation for component `{Component}` did not exit successfully. " +
+					"Process crashed or test failures occurred!");
 				return false;
 			}
 
@@ -134,11 +144,15 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			if (currentState != StateRunInstrumentation || String.IsNullOrEmpty (line))
 				return;
 
-			int i = line.IndexOf (TestResultsPathResult, StringComparison.OrdinalIgnoreCase);
-			if (i < 0)
-				return;
+			int testResultIndex = line.IndexOf (TestResultsPathResult, StringComparison.OrdinalIgnoreCase);
+			int exitCodeIndex = line.IndexOf (ExitCodeName, StringComparison.OrdinalIgnoreCase);
 
-			targetTestResultsPath = line.Substring (i + TestResultsPathResult.Length).Trim ();
+			if (testResultIndex < 0 && exitCodeIndex < 0)
+				return;
+			else if (testResultIndex >= 0)
+				targetTestResultsPath = line.Substring (testResultIndex + TestResultsPathResult.Length).Trim ();
+			else if (exitCodeIndex >= 0)
+				exitCode = int.Parse (line.Substring (exitCodeIndex + ExitCodeName.Length).Trim ());
 		}
 	}
 }

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/result-packaging.targets
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/result-packaging.targets
@@ -6,8 +6,7 @@
     <_BuildStatusFiles Include="$(XamarinAndroidSourcePath)Configuration.OperatingSystem.props" Condition="Exists('$(XamarinAndroidSourcePath)Configuration.OperatingSystem.props')" />
     <_BuildStatusFiles Include="$(XamarinAndroidSourcePath)Configuration.Override.props" Condition="Exists('$(XamarinAndroidSourcePath)Configuration.Override.props')" />
     <_BuildStatusFiles Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\XABuildConfig.cs" Condition="Exists('$(XamarinAndroidSourcePath)bin\Build$(Configuration)\XABuildConfig.cs')" />
-    <_BuildStatusFiles Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\msbuild*.binlog" />
-    <_BuildStatusFiles Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\bootstrap*.binlog" />
+    <_BuildStatusFiles Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\*.binlog" />
     <_BuildStatusFiles Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\prepare*.log" />
     <_BuildStatusFiles Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\*.mk" />
     <_BuildStatusFiles Include="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\*.projitems" />
@@ -27,7 +26,7 @@
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\*.log" />
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\compatibility\*" />
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\logcat*" />
-    <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\msbuild*.binlog*" />
+    <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\*.binlog" />
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\temp\**\*.binlog" />
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\temp\**\*.log" />
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\EmbeddedDSO\EmbeddedDSO.build\**\*" />

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -216,7 +216,6 @@ stages:
         testResultsFormat: NUnit
         testResultsFiles: TestResult-*.xml
         testRunTitle: xamarin-android
-        failTaskOnFailedTests: true
       condition: succeededOrFailed()
 
     - task: MSBuild@1
@@ -243,6 +242,8 @@ stages:
     pool: $(XA.Build.Mac.Pool)
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
+    workspace:
+      clean: all
     variables:
       ApkTestConfiguration: Release
     steps:
@@ -254,11 +255,18 @@ stages:
 
     - template: yaml-templates/run-installer.yaml
 
-    # HACK - Provision Emulator
+    - task: MSBuild@1
+      displayName: build xaprepare
+      inputs:
+        solution: build-tools/xaprepare/xaprepare.sln
+        configuration: $(ApkTestConfiguration)
+        msbuildArguments: /t:Restore,Build
+
     - script: |
-        make prepare CONFIGURATION=$(ApkTestConfiguration) V=1 MSBUILD=msbuild MSBUILD_ARGS="$(AutoProvisionArgs)"
-        git clean -xfd
-      displayName: (hack) make prepare - provision emulator
+        mono build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=UpdateMono --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
+        mono build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
+        mono build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=AndroidToolchain --no-emoji --run-mode=CI
+      displayName: provision dependencies
 
     - task: NuGetCommand@2
       displayName: nuget restore Xamarin.Android.Tools.sln
@@ -416,7 +424,14 @@ stages:
     - task: MSBuild@1
       displayName: package results
       inputs:
-        solution: build-tools\Xamarin.Android.Tools.BootstrapTasks\Xamarin.Android.Tools.BootstrapTasks.csproj
+        solution: build-tools/xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
         configuration: $(ApkTestConfiguration)
-        msbuildArguments: /t:ZipTestResults /p:TestResultZipOutputPath=$(Build.ArtifactStagingDirectory)
+        msbuildArguments: /t:ZipBuildStatus;ZipTestResults /p:BuildStatusZipOutputPath=$(Build.ArtifactStagingDirectory) /p:TestResultZipOutputPath=$(Build.ArtifactStagingDirectory)
+      condition: always()
+
+    - task: PublishPipelineArtifact@0
+      displayName: upload artifacts
+      inputs:
+        artifactName: mac-apk-test-results
+        targetPath: $(Build.ArtifactStagingDirectory)
       condition: always()

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -9,6 +9,7 @@ trigger:
 # Global variables
 variables:
   BundleArtifactName: bundle
+  InstallerArtifactName: unsigned-installers
   AutoProvisionArgs: /p:AutoProvision=True /p:AutoProvisionUsesSudo=True /p:IgnoreMaxMonoVersion=False
   AndroidTargetAbiArgs: >-
     /p:AndroidSupportedTargetJitAbis=armeabi-v7a:arm64-v8a:x86:x86_64
@@ -122,7 +123,7 @@ stages:
     - task: PublishPipelineArtifact@0
       displayName: upload unsigned installers
       inputs:
-        artifactName: unsigned
+        artifactName: $(InstallerArtifactName)
         targetPath: bin/Build$(XA.Build.Configuration)/unsigned-installers
 
     - task: MSBuild@1
@@ -231,4 +232,191 @@ stages:
       inputs:
         artifactName: win-build-test-results
         targetPath: $(Build.ArtifactStagingDirectory)
+      condition: always()
+
+- stage: test
+  displayName: Test
+  dependsOn: mac_build
+  jobs:
+  - job: mac_apk_tests
+    displayName: APK Instrumentation
+    pool: $(XA.Build.Mac.Pool)
+    timeoutInMinutes: 240
+    cancelTimeoutInMinutes: 5
+    variables:
+      ApkTestConfiguration: Release
+    steps:
+    - task: DownloadPipelineArtifact@1
+      inputs:
+        artifactName: $(InstallerArtifactName)
+        itemPattern: "*.pkg"
+        downloadPath: $(System.DefaultWorkingDirectory)
+
+    - template: yaml-templates/run-installer.yaml
+
+    # HACK - Provision Emulator
+    - script: |
+        make prepare CONFIGURATION=$(ApkTestConfiguration) V=1 MSBUILD=msbuild MSBUILD_ARGS="$(AutoProvisionArgs)"
+        git clean -xfd
+      displayName: (hack) make prepare - provision emulator
+
+    - task: NuGetCommand@2
+      displayName: nuget restore Xamarin.Android.Tools.sln
+      inputs:
+        restoreSolution: external/xamarin-android-tools/Xamarin.Android.Tools.sln
+
+    - task: MSBuild@1
+      displayName: build Xamarin.Android.Tools.BootstrapTasks.csproj
+      inputs:
+        solution: build-tools/xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+        configuration: $(ApkTestConfiguration)
+        msbuildArguments: /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/BootstrapTasks.binlog
+
+    - task: NuGetCommand@2
+      displayName: nuget restore Xamarin.Android-Tests.sln
+      inputs:
+        restoreSolution: Xamarin.Android-Tests.sln
+
+    - template: yaml-templates/apk-instrumentation.yaml
+      parameters:
+        configuration: $(ApkTestConfiguration)
+        testName: Mono.Android_Tests
+        project: src/Mono.Android/Test/Mono.Android-Tests.csproj
+        testResultsFiles: TestResult-Mono.Android_Tests-$(ApkTestConfiguration).xml
+
+    - template: yaml-templates/apk-instrumentation.yaml
+      parameters:
+        configuration: $(ApkTestConfiguration)
+        testName: Mono.Android_Tests-Aot
+        project: src/Mono.Android/Test/Mono.Android-Tests.csproj
+        testResultsFiles: TestResult-Mono.Android_Tests-$(ApkTestConfiguration)-Aot.xml
+        extraBuildArgs: /p:AotAssemblies=True /p:EnableLlvm=True
+
+    - template: yaml-templates/apk-instrumentation.yaml
+      parameters:
+        configuration: $(ApkTestConfiguration)
+        testName: Mono.Android_Tests-Profiled
+        project: src/Mono.Android/Test/Mono.Android-Tests.csproj
+        testResultsFiles: TestResult-Mono.Android_Tests-$(ApkTestConfiguration)-Profiled.xml
+        extraBuildArgs: /p:AndroidEnableProfiledAot=true
+
+    - template: yaml-templates/apk-instrumentation.yaml
+      parameters:
+        configuration: $(ApkTestConfiguration)
+        testName: Mono.Android_Tests-Bundle
+        project: src/Mono.Android/Test/Mono.Android-Tests.csproj
+        testResultsFiles: TestResult-Mono.Android_Tests-$(ApkTestConfiguration)-Bundle.xml
+        extraBuildArgs: /p:BundleAssemblies=true
+
+    - template: yaml-templates/apk-instrumentation.yaml
+      parameters:
+        configuration: $(ApkTestConfiguration)
+        testName: Mono.Android_TestsAppBundle
+        project: tests/Runtime-AppBundle/Mono.Android-TestsAppBundle.csproj
+        testResultsFiles: TestResult-Mono.Android_TestsAppBundle-$(ApkTestConfiguration).xml
+        packageType: Aab
+
+    - template: yaml-templates/apk-instrumentation.yaml
+      parameters:
+        configuration: $(ApkTestConfiguration)
+        testName: Mono.Android_TestsMultiDex
+        project: tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.csproj
+        testResultsFiles: TestResult-Mono.Android_TestsMultiDex-$(ApkTestConfiguration).xml
+
+    - template: yaml-templates/apk-instrumentation.yaml
+      parameters:
+        configuration: $(ApkTestConfiguration)
+        testName: Xamarin.Android.JcwGen_Tests
+        project: tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.csproj
+        testResultsFiles: TestResult-Xamarin.Android.JcwGen_Tests-$(ApkTestConfiguration).xml
+
+    - template: yaml-templates/apk-instrumentation.yaml
+      parameters:
+        configuration: $(ApkTestConfiguration)
+        testName: Xamarin.Android.Locale_Tests
+        project: tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj
+        testResultsFiles: TestResult-Xamarin.Android.Locale_Tests-$(ApkTestConfiguration).xml
+
+    - template: yaml-templates/apk-instrumentation.yaml
+      parameters:
+        configuration: $(ApkTestConfiguration)
+        testName: Xamarin.Android.Locale_Tests-Aot
+        project: tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj
+        testResultsFiles: TestResult-Xamarin.Android.Locale_Tests-$(ApkTestConfiguration)-Aot.xml
+        extraBuildArgs: /p:AotAssemblies=True
+
+    - template: yaml-templates/apk-instrumentation.yaml
+      parameters:
+        configuration: $(ApkTestConfiguration)
+        testName: Xamarin.Android.Locale_Tests-Profiled
+        project: tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj
+        testResultsFiles: TestResult-Xamarin.Android.Locale_Tests-$(ApkTestConfiguration)-Profiled.xml
+        extraBuildArgs: /p:AndroidEnableProfiledAot=true
+
+    - template: yaml-templates/apk-instrumentation.yaml
+      parameters:
+        configuration: $(ApkTestConfiguration)
+        testName: Xamarin.Android.EmbeddedDSO_Test
+        project: tests/EmbeddedDSOs/EmbeddedDSO/EmbeddedDSO.csproj
+        testResultsFiles: TestResult-Xamarin.Android.EmbeddedDSO_Test.nunit-$(ApkTestConfiguration).xml
+
+    - task: MSBuild@1
+      displayName: run Xamarin.Forms-Performance-Integration
+      inputs:
+        solution: tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
+        configuration: $(ApkTestConfiguration)
+        msbuildArguments: >
+          /t:AcquireAndroidTarget,SignAndroidPackage,UndeployTestApks,DeployTestApks,RunTestApks,ReportComponentFailures
+          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/XamarinFormsPerf.binlog
+      condition: succeededOrFailed()
+
+    - task: MSBuild@1
+      displayName: run Xamarin.Forms-Performance-Integration-Aot
+      inputs:
+        solution: tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
+        configuration: $(ApkTestConfiguration)
+        msbuildArguments: >
+          /t:AcquireAndroidTarget,SignAndroidPackage,UndeployTestApks,DeployTestApks,RunTestApks,ReportComponentFailures
+          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/XamarinFormsPerf-Aot.binlog
+          /p:AotAssemblies=true
+      condition: succeededOrFailed()
+
+    - task: MSBuild@1
+      displayName: run Xamarin.Forms-Performance-Integration-Profiled
+      inputs:
+        solution: tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
+        configuration: $(ApkTestConfiguration)
+        msbuildArguments: >
+          /t:AcquireAndroidTarget,SignAndroidPackage,UndeployTestApks,DeployTestApks,RunTestApks,ReportComponentFailures
+          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/XamarinFormsPerf-Profiled.binlog
+          /p:AndroidEnableProfiledAot=true
+      condition: succeededOrFailed()
+
+    - task: MSBuild@1
+      displayName: run Xamarin.Forms-Performance-Integration-Bundle
+      inputs:
+        solution: tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
+        configuration: $(ApkTestConfiguration)
+        msbuildArguments: >
+          /t:AcquireAndroidTarget,SignAndroidPackage,UndeployTestApks,DeployTestApks,RunTestApks,ReportComponentFailures
+          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/XamarinFormsPerf-Bundle.binlog
+          /p:BundleAssemblies=true
+      condition: succeededOrFailed()
+
+    - task: MSBuild@1
+      displayName: shut down emulator
+      inputs:
+        solution: src/Mono.Android/Test/Mono.Android-Tests.csproj
+        configuration: $(ApkTestConfiguration)
+        msbuildArguments: >
+          /t:AcquireAndroidTarget,ReleaseAndroidTarget
+          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/shutdown-emulator.binlog
+      condition: always()
+
+    - task: MSBuild@1
+      displayName: package results
+      inputs:
+        solution: build-tools\Xamarin.Android.Tools.BootstrapTasks\Xamarin.Android.Tools.BootstrapTasks.csproj
+        configuration: $(ApkTestConfiguration)
+        msbuildArguments: /t:ZipTestResults /p:TestResultZipOutputPath=$(Build.ArtifactStagingDirectory)
       condition: always()

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -3,7 +3,7 @@ parameters:
   testName: []
   project: []
   testResultsFiles: []
-  extraBuildArgs: []
+  extraBuildArgs: ""
   testResultsFormat: NUnit
   packageType: Apk
 
@@ -15,7 +15,7 @@ steps:
     configuration: ${{ parameters.configuration }}
     msbuildArguments: >
       /t:AcquireAndroidTarget,SignAndroidPackage,UndeployTestApks,DeployTest${{ parameters.packageType }}s,RunTestApks,RenameApkTestCases,ReportComponentFailures
-      /bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}run${{ parameters.testName }}.binlog
+      /bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/run${{ parameters.testName }}.binlog
       ${{ parameters.extraBuildArgs }}
   condition: succeededOrFailed()
 
@@ -24,6 +24,5 @@ steps:
   inputs:
     testResultsFormat: ${{ parameters.testResultsFormat }}
     testResultsFiles: ${{ parameters.testResultsFiles }}
-    failTaskOnFailedTests: true
     testRunTitle: ${{ parameters.testName }}
   condition: succeededOrFailed()

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -1,0 +1,29 @@
+parameters:
+  configuration: []
+  testName: []
+  project: []
+  testResultsFiles: []
+  extraBuildArgs: []
+  testResultsFormat: NUnit
+  packageType: Apk
+
+steps:
+- task: MSBuild@1
+  displayName: run ${{ parameters.testName }}
+  inputs:
+    solution: ${{ parameters.project }}
+    configuration: ${{ parameters.configuration }}
+    msbuildArguments: >
+      /t:AcquireAndroidTarget,SignAndroidPackage,UndeployTestApks,DeployTest${{ parameters.packageType }}s,RunTestApks,RenameApkTestCases,ReportComponentFailures
+      /bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}run${{ parameters.testName }}.binlog
+      ${{ parameters.extraBuildArgs }}
+  condition: succeededOrFailed()
+
+- task: PublishTestResults@2
+  displayName: publish ${{ parameters.testName }} results
+  inputs:
+    testResultsFormat: ${{ parameters.testResultsFormat }}
+    testResultsFiles: ${{ parameters.testResultsFiles }}
+    failTaskOnFailedTests: true
+    testRunTitle: ${{ parameters.testName }}
+  condition: succeededOrFailed()

--- a/build-tools/automation/yaml-templates/run-installer.yaml
+++ b/build-tools/automation/yaml-templates/run-installer.yaml
@@ -1,0 +1,22 @@
+parameters:
+  artifactDirectory: $(System.DefaultWorkingDirectory)
+
+steps:
+- powershell: |
+    if ([Environment]::OSVersion.Platform -eq "Unix") {
+        $installer = Get-ChildItem -Path "${{ parameters.artifactDirectory }}/*" -Include *.pkg -File
+    } else {
+        $installer = Get-ChildItem -Path "${{ parameters.artifactDirectory }}\*" -Include *.vsix -File
+    }
+    if (![System.IO.File]::Exists($installer)) {
+        throw [System.IO.FileNotFoundException] "Installer not found in $artifactDirectory."
+    }
+    Write-Host "##vso[task.setvariable variable=XA.Provisionator.Args]$installer"
+  displayName: find installer and set provisionator variable
+
+- task: provisionator@2
+  inputs:
+    provisionator_uri: $(provisionator-uri)
+    github_token: $(GitHub.Token)
+    provisioning_script: $(XA.Provisionator.Args)
+    provisioning_extra_args: -vv

--- a/build-tools/scripts/Jar.targets
+++ b/build-tools/scripts/Jar.targets
@@ -7,10 +7,8 @@
       <_JavacSourceVersion Condition=" '$(_JavacSourceVersion)' == '' ">1.5</_JavacSourceVersion>
       <_JavacTargetVersion Condition="$(_JdkVersion.StartsWith ('9'))">1.8</_JavacTargetVersion>
       <_JavacTargetVersion Condition=" '$(_JavacTargetVersion)' == '' ">1.6</_JavacTargetVersion>
-      <JarPath Condition=" '$(JarPath)' == '' And !$([MSBuild]::IsOsPlatform(Windows)) ">$(JavaSdkDirectory)\bin\jar</JarPath>
-      <JarPath Condition=" '$(JarPath)' == '' And $([MSBuild]::IsOsPlatform(Windows)) ">$(JavaSdkDirectory)\bin\jar.exe</JarPath>
-      <JavaCPath Condition=" '$(JavaCPath)' == '' And !$([MSBuild]::IsOsPlatform(Windows)) ">$(JavaSdkDirectory)\bin\javac</JavaCPath>
-      <JavaCPath Condition=" '$(JavaCPath)' == '' And $([MSBuild]::IsOsPlatform(Windows)) ">$(JavaSdkDirectory)\bin\javac.exe</JavaCPath>
+      <JarPath Condition=" '$(JarPath)' == '' ">$(JavaSdkDirectory)\bin\jar</JarPath>
+      <JavaCPath Condition=" '$(JavaCPath)' == '' ">$(JavaSdkDirectory)\bin\javac</JavaCPath>
     </PropertyGroup>
   </Target>
   <Target Name="BuildTestJarFile"

--- a/build-tools/scripts/Jar.targets
+++ b/build-tools/scripts/Jar.targets
@@ -7,6 +7,10 @@
       <_JavacSourceVersion Condition=" '$(_JavacSourceVersion)' == '' ">1.5</_JavacSourceVersion>
       <_JavacTargetVersion Condition="$(_JdkVersion.StartsWith ('9'))">1.8</_JavacTargetVersion>
       <_JavacTargetVersion Condition=" '$(_JavacTargetVersion)' == '' ">1.6</_JavacTargetVersion>
+      <JarPath Condition=" '$(JarPath)' == '' And !$([MSBuild]::IsOsPlatform(Windows)) ">$(JavaSdkDirectory)\bin\jar</JarPath>
+      <JarPath Condition=" '$(JarPath)' == '' And $([MSBuild]::IsOsPlatform(Windows)) ">$(JavaSdkDirectory)\bin\jar.exe</JarPath>
+      <JavaCPath Condition=" '$(JavaCPath)' == '' And !$([MSBuild]::IsOsPlatform(Windows)) ">$(JavaSdkDirectory)\bin\javac</JavaCPath>
+      <JavaCPath Condition=" '$(JavaCPath)' == '' And $([MSBuild]::IsOsPlatform(Windows)) ">$(JavaSdkDirectory)\bin\javac.exe</JavaCPath>
     </PropertyGroup>
   </Target>
   <Target Name="BuildTestJarFile"

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -169,16 +169,18 @@
   <Target Name="DeployTestAabs"
       Condition=" '@(TestAab)' != '' ">
     <PropertyGroup>
-      <_KeyStore>..\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Resources\Base\test.keystore</_KeyStore>
+      <_KeyStore>$(XamarinAndroidSourcePath)\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Resources\Base\test.keystore</_KeyStore>
       <_KeyAlias>mykey</_KeyAlias>
       <_KeyPass>android</_KeyPass>
       <_StorePass>android</_StorePass>
+      <JavaPath Condition=" '$(JavaPath)' == '' And !$([MSBuild]::IsOsPlatform(Windows)) ">$(JavaSdkDirectory)\bin\java</JavaPath>
+      <JavaPath Condition=" '$(JavaPath)' == '' And $([MSBuild]::IsOsPlatform(Windows)) ">$(JavaSdkDirectory)\bin\java.exe</JavaPath>
     </PropertyGroup>
     <Xamarin.Android.Tools.BootstrapTasks.BundleTool
         Arguments="build-apks --connected-device --overwrite --mode default --bundle &quot;%(TestAab.Identity)&quot; --output &quot;%(TestAab.Identity).apks&quot;"
         ContinueOnError="ErrorAndContinue"
         JavaPath="$(JavaPath)"
-        JarPath="$(BundleToolJarPath)"
+        JarPath="$(AndroidBundleToolJarPath)"
         AdbToolExe="$(AdbToolExe)"
         AdbToolPath="$(AdbToolPath)"
         KeyStore="$([System.IO.Path]::GetFullPath ('$(_KeyStore)'))"
@@ -191,7 +193,7 @@
         Arguments="install-apks --modules _ALL_ --apks &quot;%(TestAab.Identity).apks&quot;"
         ContinueOnError="ErrorAndContinue"
         JavaPath="$(JavaPath)"
-        JarPath="$(BundleToolJarPath)"
+        JarPath="$(AndroidBundleToolJarPath)"
         AdbToolExe="$(AdbToolExe)"
         AdbToolPath="$(AdbToolPath)"
     />

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -63,6 +63,7 @@
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)"
         Timeout="120000"
+        WriteOutputAsMessage="True"
     />
     <Xamarin.Android.Tools.BootstrapTasks.Adb
         EnvironmentVariables="ADB_TRACE=all"
@@ -72,6 +73,7 @@
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)"
         Timeout="120000"
+        WriteOutputAsMessage="True"
     />
     <Xamarin.Android.Tools.BootstrapTasks.Adb
         Arguments="$(_AdbTarget) shell setprop debug.mono.log timing"

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -175,6 +175,8 @@
       <_KeyAlias>mykey</_KeyAlias>
       <_KeyPass>android</_KeyPass>
       <_StorePass>android</_StorePass>
+      <!-- Support for running against a system installation of XA. -->
+      <BundleToolJarPath Condition=" !Exists('$(BundleToolJarPath)') ">$(AndroidBundleToolJarPath)</BundleToolJarPath>
       <JavaPath Condition=" '$(JavaPath)' == '' And !$([MSBuild]::IsOsPlatform(Windows)) ">$(JavaSdkDirectory)\bin\java</JavaPath>
       <JavaPath Condition=" '$(JavaPath)' == '' And $([MSBuild]::IsOsPlatform(Windows)) ">$(JavaSdkDirectory)\bin\java.exe</JavaPath>
     </PropertyGroup>
@@ -182,7 +184,7 @@
         Arguments="build-apks --connected-device --overwrite --mode default --bundle &quot;%(TestAab.Identity)&quot; --output &quot;%(TestAab.Identity).apks&quot;"
         ContinueOnError="ErrorAndContinue"
         JavaPath="$(JavaPath)"
-        JarPath="$(AndroidBundleToolJarPath)"
+        JarPath="$(BundleToolJarPath)"
         AdbToolExe="$(AdbToolExe)"
         AdbToolPath="$(AdbToolPath)"
         KeyStore="$([System.IO.Path]::GetFullPath ('$(_KeyStore)'))"
@@ -195,7 +197,7 @@
         Arguments="install-apks --modules _ALL_ --apks &quot;%(TestAab.Identity).apks&quot;"
         ContinueOnError="ErrorAndContinue"
         JavaPath="$(JavaPath)"
-        JarPath="$(AndroidBundleToolJarPath)"
+        JarPath="$(BundleToolJarPath)"
         AdbToolExe="$(AdbToolExe)"
         AdbToolPath="$(AdbToolPath)"
     />

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -177,8 +177,7 @@
       <_StorePass>android</_StorePass>
       <!-- Support for running against a system installation of XA. -->
       <BundleToolJarPath Condition=" !Exists('$(BundleToolJarPath)') ">$(AndroidBundleToolJarPath)</BundleToolJarPath>
-      <JavaPath Condition=" '$(JavaPath)' == '' And !$([MSBuild]::IsOsPlatform(Windows)) ">$(JavaSdkDirectory)\bin\java</JavaPath>
-      <JavaPath Condition=" '$(JavaPath)' == '' And $([MSBuild]::IsOsPlatform(Windows)) ">$(JavaSdkDirectory)\bin\java.exe</JavaPath>
+      <JavaPath Condition=" '$(JavaPath)' == '' ">$(JavaSdkDirectory)\bin\java</JavaPath>
     </PropertyGroup>
     <Xamarin.Android.Tools.BootstrapTasks.BundleTool
         Arguments="build-apks --connected-device --overwrite --mode default --bundle &quot;%(TestAab.Identity)&quot; --output &quot;%(TestAab.Identity).apks&quot;"
@@ -303,7 +302,7 @@
     />
   </Target>
   <Target Name="RenameApkTestCases"
-      Condition=" '@(TestApk)' != '' ">
+      Condition=" '@(TestApk)' != '' Or '@(TestAab)' != '' ">
     <RenameTestCases
         Condition=" '%(TestApkInstrumentation.ResultsPath)' != '' "
         Configuration="$(Configuration)"

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ProcessLogcatTiming.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ProcessLogcatTiming.cs
@@ -51,6 +51,12 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 						timingRegex = new Regex ($@"^(?<timestamp>\d+-\d+\s+[\d:\.]+)\s+{PID}\s+(?<message>.*)$");
 						started = true;
 					} else {
+						if (line.Contains ($"Process {ApplicationPackageName} (pid {PID}) has died")) {
+							Log.LogError ("Application crash detected. Could not collect performance data.");
+							reader.Close ();
+							return false;
+						}
+
 						var match = timingRegex.Match (line);
 						if (!match.Success) {
 							if (!string.IsNullOrEmpty (Activity)) {
@@ -91,8 +97,11 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 					Log.LogMessage (MessageImportance.Normal, $"Last timing message: {(last - start).TotalMilliseconds}ms");
 
 					WriteResults ();
-				} else
-					Log.LogWarning ("Wasn't able to collect the performance data");
+				} else {
+					Log.LogError ("Application start wasn't detected. Could not collect performance data.");
+					reader.Close ();
+					return false;
+				}
 
 				reader.Close ();
 			}

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ProcessLogcatTiming.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/ProcessLogcatTiming.cs
@@ -53,7 +53,6 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 					} else {
 						if (line.Contains ($"Process {ApplicationPackageName} (pid {PID}) has died")) {
 							Log.LogError ("Application crash detected. Could not collect performance data.");
-							reader.Close ();
 							return false;
 						}
 
@@ -99,11 +98,8 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 					WriteResults ();
 				} else {
 					Log.LogError ("Application start wasn't detected. Could not collect performance data.");
-					reader.Close ();
 					return false;
 				}
-
-				reader.Close ();
 			}
 
 			return true;

--- a/src/Mono.Android/Test/Mono.Android-Tests.targets
+++ b/src/Mono.Android/Test/Mono.Android-Tests.targets
@@ -17,7 +17,9 @@
     <Error Text="Could not locate Android NDK." Condition="!Exists ('$(NdkBuildPath)')" />
     <Exec Command="&quot;$(NdkBuildPath)&quot;" />
   </Target>
+  <!-- Not required for testing against a system installation -->
   <Target Name="EnsureJavaInteropDllConfigs"
+      Condition="Exists ('$(XAInstallPrefix)xbuild\Xamarin\Android\Java.Interop.dll.config')"
       BeforeTargets="_GenerateJniMarshalMethods"
       DependsOnTargets="_CreateJavaInteropDllConfigs">
   </Target>

--- a/src/Mono.Android/Test/Mono.Android-Tests.targets
+++ b/src/Mono.Android/Test/Mono.Android-Tests.targets
@@ -17,9 +17,9 @@
     <Error Text="Could not locate Android NDK." Condition="!Exists ('$(NdkBuildPath)')" />
     <Exec Command="&quot;$(NdkBuildPath)&quot;" />
   </Target>
-  <!-- Not required for testing against a system installation -->
+  <!-- Not required when testing against a system installation of XA. -->
   <Target Name="EnsureJavaInteropDllConfigs"
-      Condition="Exists ('$(XAInstallPrefix)xbuild\Xamarin\Android\Java.Interop.dll.config')"
+      Condition="Exists ('$(XAInstallPrefix)xbuild\Xamarin\Android\Java.Interop.dll')"
       BeforeTargets="_GenerateJniMarshalMethods"
       DependsOnTargets="_CreateJavaInteropDllConfigs">
   </Target>

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\build-tools\scripts\Jar.targets" />
-  <UsingTask AssemblyFile="..\..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
+  <Import Project="$(XamarinAndroidSourcePath)build-tools\scripts\Jar.targets" />
+  <UsingTask AssemblyFile="$(XamarinAndroidSourcePath)bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
   <Target Name="BuildNativeLibs"
       DependsOnTargets="AndroidPrepareForBuild;_GetJavacVersions"
       Inputs="jni\simple-lib.c;jni\Android.mk"

--- a/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
+++ b/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding/Xamarin.Android.LibraryProjectZip-LibBinding.targets
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\build-tools\scripts\Jar.targets" />
   <UsingTask AssemblyFile="..\..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
   <Target Name="BuildNativeLibs"
-      DependsOnTargets="AndroidPrepareForBuild"
+      DependsOnTargets="AndroidPrepareForBuild;_GetJavacVersions"
       Inputs="jni\simple-lib.c;jni\Android.mk"
       Outputs="@(AndroidNativeLibrary);$(OutputPath)\native-lib-1\NativeLib.zip">
     <Error
@@ -17,7 +18,7 @@
     />
   </Target>
   <Target Name="BuildNativeLibs2"
-      DependsOnTargets="AndroidPrepareForBuild"
+      DependsOnTargets="AndroidPrepareForBuild;_GetJavacVersions"
       Inputs="simple2\jni\simple2-lib.c;simple2\jni\Android.mk"
       Outputs="@(AndroidNativeLibrary);$(OutputPath)\native-lib-2\NativeLib2.zip">
     <Error

--- a/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.targets
+++ b/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.targets
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="Xamarin.Forms.Performance.Integration.Droid.projitems" />
-  <Import Project="..\..\..\build-tools\scripts\TestApks.targets" />
-  <Import Project="..\..\..\build-tools\scripts\JavaInteropDllConfigs.targets" />
+  <Import Project="$(XamarinAndroidSourcePath)build-tools\scripts\TestApks.targets" />
+  <Import Project="$(XamarinAndroidSourcePath)build-tools\scripts\JavaInteropDllConfigs.targets" />
   <Target Name="EnsureJavaInteropDllConfigs"
       Condition="Exists ('$(XAInstallPrefix)xbuild\Xamarin\Android\Java.Interop.dll')"
       BeforeTargets="_GenerateJniMarshalMethods"

--- a/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.targets
+++ b/tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.targets
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="Xamarin.Forms.Performance.Integration.Droid.projitems" />
+  <Import Project="..\..\..\build-tools\scripts\TestApks.targets" />
   <Import Project="..\..\..\build-tools\scripts\JavaInteropDllConfigs.targets" />
   <Target Name="EnsureJavaInteropDllConfigs"
+      Condition="Exists ('$(XAInstallPrefix)xbuild\Xamarin\Android\Java.Interop.dll')"
       BeforeTargets="_GenerateJniMarshalMethods"
       DependsOnTargets="_CreateJavaInteropDllConfigs">
   </Target>


### PR DESCRIPTION
Adds a `Test` stage to azure-pipelines.yaml. At present, this stage only
contains one test job, which builds and runs the following emulator tests:

    Mono.Android_Tests
    Mono.Android-Tests (AOT + LLVM)
    Mono.Android-Tests (Profiled AOT)
    Mono.Android-Tests (Bundle)
    Mono.Android_TestsAppBundle
    Mono.Android_TestsMultiDex
    Xamarin.Android.JcwGen_Tests
    Xamarin.Android.Locale_Tests
    Xamarin.Android.Locale-Tests (AOT)
    Xamarin.Android.Locale-Tests (Profiled AOT)
    Xamarin.Android.EmbeddedDSO_Test
    Xamarin.Forms.Performance.Integration.Droid 
    Xamarin.Forms.Performance.Integration.Droid (AOT)
    Xamarin.Forms.Performance.Integration.Droid (Profiled AOT)
    Xamarin.Forms.Performance.Integration.Droid (Bundle)

Performance reporting has not been considered as part of this PR. Execution of the 
BCL Test suite will also need to be added to the `Test` stage in the future.

Other Fixes:

    * Support has been added for running APK tests against an XA installation

        We can now build and run Xamarin.Android.JcwGen_Tests, Mono.Android_Tests,
        and Xamarin.Forms.Performance.Integration.Droid tests against a system
        installation of Xamarin.Android.

    * Produce an error when any test failures occur during instrumentation

        The instrumentation exit code value of `-1` indicates success, and any
        other values returned here should be reported as errors. A non `-1` value
        indicates that crash or test failure occurred.

    * Produce an error if logcat timing data can't be parsed

        We'll now error out when parsing logcat for timing data if the running
        application died, or if we fail to detect application startup.

    * Don't always report logcat stderr as a warning

        Adb invocations are prone to returning non zero exit codes even when
        they are successful. This can make our msbuild output a bit noisy[0] when
        they are invoked using the Adb.cs task. The new optional parameter
        `WriteOutputAsMessage` can now be provided to the adb task, so that we
        don't always write messages coming from stderr as msbuild warnings. This
        is used in our targets which wait for emulator startup to make it easier
        to detect real failures in test instrumentation and emulator startup.

        [0]
            /Users/peter/source/pj/xamarin-android/build-tools/scripts/TestApks.targets(68,5): warning : adb D 04-29 15:10:48  3527 42649 adb_trace.cpp:192] Android Debug Bridge version 1.0.40 [/Users/peter/source/pj/xamarin-android/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj]
            /Users/peter/source/pj/xamarin-android/build-tools/scripts/TestApks.targets(68,5): warning : adb D 04-29 15:10:48  3527 42649 adb_trace.cpp:192] Version 28.0.2-5303910 [/Users/peter/source/pj/xamarin-android/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj]
            /Users/peter/source/pj/xamarin-android/build-tools/scripts/TestApks.targets(68,5): warning : adb D 04-29 15:10:48  3527 42649 adb_trace.cpp:192] Installed as /Users/peter/android-toolchain/sdk/platform-tools/adb [/Users/peter/source/pj/xamarin-android/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj]
            /Users/peter/source/pj/xamarin-android/build-tools/scripts/TestApks.targets(68,5): warning : adb D 04-29 15:10:48  3527 42649 adb_trace.cpp:192]  [/Users/peter/source/pj/xamarin-android/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj]
            /Users/peter/source/pj/xamarin-android/build-tools/scripts/TestApks.targets(68,5): warning : adb D 04-29 15:10:48  3527 42649 adb_client.cpp:287] adb_query: host-serial:emulator-5570:features [/Users/peter/source/pj/xamarin-android/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj]
            /Users/peter/source/pj/xamarin-android/build-tools/scripts/TestApks.targets(68,5): warning : adb D 04-29 15:10:48  3527 42649 adb_client.cpp:137] _adb_connect: host:version [/Users/peter/source/pj/xamarin-android/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj]
            /Users/peter/source/pj/xamarin-android/build-tools/scripts/TestApks.targets(68,5): warning : adb D 04-29 15:10:48  3527 42649 adb_io.cpp:107] writex: fd=3 len=16 30303063686f73743a76657273696f6e 000chost:version [/Users/peter/source/pj/xamarin-android/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj]
            /Users/peter/source/pj/xamarin-android/build-tools/scripts/TestApks.targets(68,5): warning : adb D 04-29 15:10:48  3527 42649 adb_io.cpp:81] readx: fd=3 wanted=4 [/Users/peter/source/pj/xamarin-android/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj]
            /Users/peter/source/pj/xamarin-android/build-tools/scripts/TestApks.targets(68,5): warning : adb D 04-29 15:10:48  3527 42649 adb_io.cpp:97] readx: fd=3 wanted=4 got=4 4f4b4159 OKAY [/Users/peter/source/pj/xamarin-android/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj]
            /Users/peter/source/pj/xamarin-android/build-tools/scripts/TestApks.targets(68,5): warning : adb D 04-29 15:10:48  3527 42649 adb_client.cpp:165] _adb_connect: return fd 3 [/Users/peter/source/pj/xamarin-android/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj]
            /Users/peter/source/pj/xamarin-android/build-tools/scripts/TestApks.targets(68,5): warning : adb D 04-29 15:10:48  3527 42649 adb_client.cpp:197] adb_connect: service host-serial:emulator-5570:features [/Users/peter/source/pj/xamarin-android/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj]
            /Users/peter/source/pj/xamarin-android/build-tools/scripts/TestApks.targets(68,5): warning : adb D 04-29 15:10:48  3527 42649 adb_io.cpp:81] readx: fd=3 wanted=4 [/Users/peter/source/pj/xamarin-android/tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj]
