### PR TITLE
[Xamarin.Android.Build.Tasks] don't copy to linksrc for Debug builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -364,6 +364,7 @@ namespace Lib2
 					}
 				}
 			};
+			proj.SetProperty (proj.ActiveConfigurationProperties, "AndroidLinkMode", "SdkOnly");
 			if (IsWindows) {
 				//NOTE: pdb2mdb will run on Windows on the current project's symbols if DebugType=Full
 				proj.SetProperty (proj.DebugProperties, "DebugType", "Full");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2059,8 +2059,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_CopyPdbFiles"
 		Condition=" '$(AndroidLinkMode)' != 'None' "
 		Inputs="@(_ResolvedPortablePdbFiles)"
-		Outputs="$(_AndroidStampDirectory)_CopyPdbFiles.stamp"
-		DependsOnTargets="_ConvertPdbFiles">
+		Outputs="$(_AndroidStampDirectory)_CopyPdbFiles.stamp">
 	<ItemGroup>
 		<_CopyPdbFilesLinkerFiles Include="@(_ResolvedPortablePdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')" />
 	</ItemGroup>
@@ -2179,6 +2178,7 @@ because xbuild doesn't support framework reference assemblies.
 		;_ResolveSatellitePaths
 		;_CreatePackageWorkspace
 		;_CopyIntermediateAssemblies
+		;_ConvertPdbFiles
 		;_CopyPdbFiles
 		;_CopyMdbFiles
 		;_LinkAssemblies
@@ -2409,7 +2409,7 @@ because xbuild doesn't support framework reference assemblies.
   <GeneratePackageManagerJava
     ResolvedAssemblies="@(_ResolvedAssemblies)"
     ResolvedUserAssemblies="@(_ResolvedUserAssemblies)"
-    MainAssembly="$(MonoAndroidLinkerInputDir)$(TargetFileName)"
+    MainAssembly="$(OutDir)$(TargetFileName)"
     OutputDirectory="$(IntermediateOutputPath)android\src\mono"
     EnvironmentOutputDirectory="$(IntermediateOutputPath)android"
     UseSharedRuntime="$(AndroidUseSharedRuntime)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1987,6 +1987,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_CopyIntermediateAssemblies"
+	Condition=" '$(AndroidLinkMode)' != 'None' "
 	Inputs="@(ResolvedAssemblies);@(_AndroidResolvedSatellitePaths)"
 	Outputs="$(_AndroidStampDirectory)_CopyIntermediateAssemblies.stamp"
 	DependsOnTargets="_ResolveAssemblies;_ResolveSatellitePaths;_CreatePackageWorkspace;_CopyConfigFiles">
@@ -2056,6 +2057,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_CopyPdbFiles"
+		Condition=" '$(AndroidLinkMode)' != 'None' "
 		Inputs="@(_ResolvedPortablePdbFiles)"
 		Outputs="$(_AndroidStampDirectory)_CopyPdbFiles.stamp"
 		DependsOnTargets="_ConvertPdbFiles">
@@ -2070,6 +2072,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_CopyMdbFiles"
+		Condition=" '$(AndroidLinkMode)' != 'None' "
 		Inputs="@(_ResolvedMdbFiles)"
 		Outputs="$(_AndroidStampDirectory)_CopyMdbFiles.stamp"
 		DependsOnTargets="_CollectMdbFiles">


### PR DESCRIPTION
While investigating performance of the `_LinkAssembliesNoShrink`
MSBuild target, I noticed it has the following behavior:

* Take all assemblies from `@(ResolvedAssemblies)`. These are their
  original locations from after `Build`. Some from `bin\Debug`, some
  from `$(UserProfile)\.nuget`, etc.
* Output assemblies directly to be packaged, in:
  `$(IntermediateOutputPath)android\assets`

After a build, however, there was a `linksrc` directory containing all
assemblies. For the Xamarin.Forms app in this repo, it was ~69.7MB and
had 77 files.

But this directory appears to be completely unused when
`$(AndroidLinkMode)` is `None`?

That means we could skip a few MSBuild targets in this case:

* `_CopyIntermediateAssemblies`
* `_CopyPdbFiles`
* `_CopyMdbFiles`

An initial build of the Xamarin.Forms project in this repo used to
take:

     16 ms  _CopyMdbFiles                              1 calls
     77 ms  _CopyPdbFiles                              1 calls
    202 ms  _CopyIntermediateAssemblies                1 calls

So this looks like it saves ~275ms on debug builds. I suspect the
savings would be even better on slower machines (or without SSDs).