### PR TITLE
[docs] Correct a typo in XA0115 documentation page

### DIFF
--- a/Documentation/guides/messages/xa0115.md
+++ b/Documentation/guides/messages/xa0115.md
@@ -22,7 +22,7 @@ pages on Windows or macOS.
 
  1. Select the project in the **Solution Explorer** and click the **Properties**
     icon, or right-click the project and select **Properties**.
- 2. In the side pane, choose **Advanced Options**.
+ 2. In the side pane, choose **Android Options**.
  3. Select the **Advanced** button.
  4. The **Supported architectures** list no longer includes an **armeabi**
     checkbox, so to remove the old armeabi setting, un-check and re-check one of


### PR DESCRIPTION
Of course, it took until after <https://github.com/xamarin/xamarin-android/pull/2967> was merged for me to be able to see that I had left a typo in the page.