### PR TITLE
[Xamarin.Android.Build.Tasks] Invalid Resources generated for DesignTime

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
@@ -27,8 +27,8 @@ namespace Foo.Foo
 		public partial class Animator
 		{
 			
-			// aapt resource value: 0x7F070002
-			public const int slide_in_bottom = 2131165186;
+			// aapt resource value: 0x7F010000
+			public const int slide_in_bottom = 2130771968;
 			
 			static Animator()
 			{
@@ -43,8 +43,8 @@ namespace Foo.Foo
 		public partial class Array
 		{
 			
-			// aapt resource value: 0x7F130002
-			public const int widths_array = 2131951618;
+			// aapt resource value: 0x7F020000
+			public const int widths_array = 2130837504;
 			
 			static Array()
 			{
@@ -72,8 +72,8 @@ namespace Foo.Foo
 		public partial class Dimension
 		{
 			
-			// aapt resource value: 0x7F120002
-			public const int main_text_item_size = 2131886082;
+			// aapt resource value: 0x7F030000
+			public const int main_text_item_size = 2130903040;
 			
 			static Dimension()
 			{
@@ -88,8 +88,8 @@ namespace Foo.Foo
 		public partial class Drawable
 		{
 			
-			// aapt resource value: 0x7F080002
-			public const int ic_menu_preferences = 2131230722;
+			// aapt resource value: 0x7F040000
+			public const int ic_menu_preferences = 2130968576;
 			
 			static Drawable()
 			{
@@ -104,8 +104,8 @@ namespace Foo.Foo
 		public partial class Font
 		{
 			
-			// aapt resource value: 0x7F090002
-			public const int arial = 2131296258;
+			// aapt resource value: 0x7F050000
+			public const int arial = 2131034112;
 			
 			static Font()
 			{
@@ -120,14 +120,20 @@ namespace Foo.Foo
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7F010004
-			public const int menu_settings = 2130771972;
+			// aapt resource value: 0x7F060000
+			public const int Føø_Bar = 2131099648;
 			
-			// aapt resource value: 0x7F010002
-			public const int seekBar = 2130771970;
+			// aapt resource value: 0x7F060001
+			public const int menu_settings = 2131099649;
 			
-			// aapt resource value: 0x7F010003
-			public const int seekbar = 2130771971;
+			// aapt resource value: 0x7F060002
+			public const int seekBar = 2131099650;
+			
+			// aapt resource value: 0x7F060003
+			public const int seekbar = 2131099651;
+			
+			// aapt resource value: 0x7F060004
+			public const int textview_withperiod = 2131099652;
 			
 			static Id()
 			{
@@ -142,8 +148,8 @@ namespace Foo.Foo
 		public partial class Layout
 		{
 			
-			// aapt resource value: 0x7F020002
-			public const int main = 2130837506;
+			// aapt resource value: 0x7F070000
+			public const int main = 2131165184;
 			
 			static Layout()
 			{
@@ -158,8 +164,8 @@ namespace Foo.Foo
 		public partial class Menu
 		{
 			
-			// aapt resource value: 0x7F100002
-			public const int Options = 2131755010;
+			// aapt resource value: 0x7F080000
+			public const int Options = 2131230720;
 			
 			static Menu()
 			{
@@ -174,8 +180,8 @@ namespace Foo.Foo
 		public partial class Mipmap
 		{
 			
-			// aapt resource value: 0x7F110002
-			public const int icon = 2131820546;
+			// aapt resource value: 0x7F090000
+			public const int icon = 2131296256;
 			
 			static Mipmap()
 			{
@@ -190,8 +196,8 @@ namespace Foo.Foo
 		public partial class Raw
 		{
 			
-			// aapt resource value: 0x7F030002
-			public const int foo = 2130903042;
+			// aapt resource value: 0x7F0B0000
+			public const int foo = 2131427328;
 			
 			static Raw()
 			{
@@ -206,8 +212,8 @@ namespace Foo.Foo
 		public partial class Plurals
 		{
 			
-			// aapt resource value: 0x7F060002
-			public const int num_locations_reported = 2131099650;
+			// aapt resource value: 0x7F0A0000
+			public const int num_locations_reported = 2131361792;
 			
 			static Plurals()
 			{
@@ -222,17 +228,17 @@ namespace Foo.Foo
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7F050003
-			public const int app_name = 2131034115;
+			// aapt resource value: 0x7F0C0000
+			public const int app_name = 2131492864;
 			
-			// aapt resource value: 0x7F050005
-			public const int foo = 2131034117;
+			// aapt resource value: 0x7F0C0001
+			public const int foo = 2131492865;
 			
-			// aapt resource value: 0x7F050002
-			public const int hello = 2131034114;
+			// aapt resource value: 0x7F0C0002
+			public const int hello = 2131492866;
 			
-			// aapt resource value: 0x7F050004
-			public const int menu_settings = 2131034116;
+			// aapt resource value: 0x7F0C0003
+			public const int menu_settings = 2131492867;
 			
 			static String()
 			{
@@ -247,8 +253,8 @@ namespace Foo.Foo
 		public partial class Transition
 		{
 			
-			// aapt resource value: 0x7F040002
-			public const int transition = 2130968578;
+			// aapt resource value: 0x7F0D0000
+			public const int transition = 2131558400;
 			
 			static Transition()
 			{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
@@ -70,18 +70,60 @@ namespace Xamarin.Android.Build.Tests {
 <LinearLayout xmlns:android=""http://schemas.android.com/apk/res/android"">
 	<TextView android:id=""@+id/seekBar"" />
 	<TextView android:id=""@+id/seekbar"" />
+	<TextView android:id=""@+id/textview.withperiod"" />
+	<TextView android:id=""@+id/Føø-Bar"" />
 </LinearLayout>
 ";
 
-		[Test]
-		public void GenerateDesignerFileWithÜmläüts ()
+		const string AndroidManifest = @"<?xml version='1.0'?>
+<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" package=""MonoAndroidApplication4.MonoAndroidApplication4"" />";
+
+		/// <summary>
+		/// When you add new resources to the code blocks above, the following
+		/// Rtxt string needs to be updated with the correct values.
+		/// You can do this manually OR use aapt2
+		///
+		/// Run the GenerateDesignerFileFromRtxt test and let it fail.
+		/// You can then go to the appropriate resource directory
+		/// and run the following commands.
+		/// 
+		/// aapt2 compile -o compile.flata --dir res/
+		/// aapt2 compile -o lp.flata --dir lp/res/
+		/// aapt2 link -o foo.apk --manifest AndroidManifest.xml -R lp.flata -R compile.flata --auto-add-overlay --output-text-symbols R.txt -I ~/android-toolchain-xa/sdk/platforms/android-Q/android.jar
+		///
+		/// Then copy the values from the R.txt file and place them below.
+		/// </summary>
+		const string Rtxt = @"int animator slide_in_bottom 0x7f010000
+int array widths_array 0x7f020000
+int dimen main_text_item_size 0x7f030000
+int drawable ic_menu_preferences 0x7f040000
+int font arial 0x7f050000
+int id Føø_Bar 0x7f060000
+int id menu_settings 0x7f060001
+int id seekBar 0x7f060002
+int id seekbar 0x7f060003
+int id textview_withperiod 0x7f060004
+int layout main 0x7f070000
+int menu Options 0x7f080000
+int mipmap icon 0x7f090000
+int plurals num_locations_reported 0x7f0a0000
+int raw foo 0x7f0b0000
+int string app_name 0x7f0c0000
+int string foo 0x7f0c0001
+int string hello 0x7f0c0002
+int string menu_settings 0x7f0c0003
+int transition transition 0x7f0d0000
+";
+
+		public void CreateResourceDirectory (string path)
 		{
-			var path = Path.Combine ("temp", TestName + " Some Space");
 			Directory.CreateDirectory (Path.Combine (Root, path, "res", "values"));
 			Directory.CreateDirectory (Path.Combine (Root, path, "res", "transition"));
 
 			Directory.CreateDirectory (Path.Combine (Root, path, "res", "raw"));
 			Directory.CreateDirectory (Path.Combine (Root, path, "res", "layout"));
+
+			File.WriteAllText (Path.Combine (Root, path, "AndroidManifest.xml"), AndroidManifest);
 
 			File.WriteAllText (Path.Combine (Root, path, "res", "values", "strings.xml"), StringsXml);
 			File.WriteAllText (Path.Combine (Root, path, "res", "transition", "transition.xml"), Transition);
@@ -105,6 +147,14 @@ namespace Xamarin.Android.Build.Tests {
 				File.WriteAllBytes (Path.Combine (Root, path, "lp", "res", "mipmap-hdpi", "icon.png"), icon_binary_mdpi);
 			}
 			File.WriteAllText (Path.Combine (Root, path, "lp", "res", "menu", "Options.xml"), Menu);
+		}
+
+
+		[Test]
+		public void GenerateDesignerFileWithÜmläüts ()
+		{
+			var path = Path.Combine ("temp", TestName + " Some Space");
+			CreateResourceDirectory (path);
 			IBuildEngine engine = new MockBuildEngine (TestContext.Out);
 			var task = new GenerateResourceDesigner {
 				BuildEngine = engine
@@ -129,6 +179,39 @@ namespace Xamarin.Android.Build.Tests {
 			var expected = Path.Combine (Root, "Expected", "GenerateDesignerFileExpected.cs");
 			Assert.IsTrue (FileCompare (task.NetResgenOutputFile, expected), 
 			 	$"{task.NetResgenOutputFile} and {expected} do not match.");
+			Directory.Delete (Path.Combine (Root, path), recursive: true);
+		}
+
+		[Test]
+		public void GenerateDesignerFileFromRtxt ()
+		{
+			var path = Path.Combine ("temp", TestName + " Some Space");
+			CreateResourceDirectory (path);
+			File.WriteAllText (Path.Combine (Root, path, "R.txt"), Rtxt);
+			IBuildEngine engine = new MockBuildEngine (TestContext.Out);
+			var task = new GenerateResourceDesigner {
+				BuildEngine = engine
+			};
+			task.UseManagedResourceGenerator = true;
+			task.DesignTimeBuild = true;
+			task.Namespace = "Foo.Foo";
+			task.NetResgenOutputFile = Path.Combine (Root, path, "Resource.designer.cs");
+			task.ProjectDir = Path.Combine (Root, path);
+			task.ResourceDirectory = Path.Combine (Root, path, "res") + Path.DirectorySeparatorChar;
+			task.Resources = new TaskItem [] {
+				new TaskItem (Path.Combine (Root, path, "res", "values", "strings.xml"), new Dictionary<string, string> () {
+					{ "LogicalName", "values\\strings.xml" },
+				}),
+			};
+			task.AdditionalResourceDirectories = new TaskItem [] {
+				new TaskItem (Path.Combine (Root, path, "lp", "res")),
+			};
+			task.IsApplication = true;
+			Assert.IsTrue (task.Execute (), "Task should have executed successfully.");
+			Assert.IsTrue (File.Exists (task.NetResgenOutputFile), $"{task.NetResgenOutputFile} should have been created.");
+			var expected = Path.Combine (Root, "Expected", "GenerateDesignerFileExpected.cs");
+			Assert.IsTrue (FileCompare (task.NetResgenOutputFile, expected),
+				 $"{task.NetResgenOutputFile} and {expected} do not match.");
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ResourceIdentifier.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ResourceIdentifier.cs
@@ -1,0 +1,68 @@
+using System;
+using System.CodeDom;
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Tasks
+{
+	public class ResourceIdentifier {
+
+		//https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#identifiers
+		private const string FormattingCharacter = @"\p{Cf}";
+		private const string ConnectingCharacter = @"\p{Pc}";
+		private const string DecimalDigitCharacter = @"\p{Nd}";
+		private const string CombiningCharacter = @"\p{Mn}\p{Mc}";
+		private const string LetterCharacter = @"\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}";
+
+		private const string IdentifierPartCharacter = LetterCharacter +
+			DecimalDigitCharacter +
+			ConnectingCharacter +
+			CombiningCharacter +
+			FormattingCharacter;
+
+		private const string IdentifierStartCharacter = "(" + LetterCharacter + "_)";
+
+		private const string Identifier = IdentifierStartCharacter + "(" + IdentifierPartCharacter + ")";
+
+		//https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#keywords
+		private static readonly HashSet<string> _keywords = new HashSet<string> () {
+			  "abstract" , "as"       , "base"       , "bool"      , "break"
+			, "byte"     , "case"     , "catch"      , "char"      , "checked"
+			, "class"    , "const"    , "continue"   , "decimal"   , "default"
+			, "delegate" , "do"       , "double"     , "else"      , "enum"
+			, "event"    , "explicit" , "extern"     , "false"     , "finally"
+			, "fixed"    , "float"    , "for"        , "foreach"   , "goto"
+			, "if"       , "implicit" , "in"         , "int"       , "interface"
+			, "internal" , "is"       , "lock"       , "long"      , "namespace"
+			, "new"      , "null"     , "object"     , "operator"  , "out"
+			, "override" , "params"   , "private"    , "protected" , "public"
+			, "readonly" , "ref"      , "return"     , "sbyte"     , "sealed"
+			, "short"    , "sizeof"   , "stackalloc" , "static"    , "string"
+			, "struct"   , "switch"   , "this"       , "throw"     , "true"
+			, "try"      , "typeof"   , "uint"       , "ulong"     , "unchecked"
+			, "unsafe"   , "ushort"   , "using"      , "virtual"   , "void"
+			, "volatile" , "while",
+		};
+
+		// We use [^ ...] to detect any character that is NOT a match.
+		static Regex validIdentifier = new Regex ($"[^{Identifier}]", RegexOptions.Compiled);
+
+		public static string CreateValidIdentifier (string identifier)
+		{
+			if (String.IsNullOrWhiteSpace (identifier)) return string.Empty;
+
+			var normalizedIdentifier = identifier.Normalize ();
+
+			string result = validIdentifier.Replace (normalizedIdentifier, "_");
+
+			if (_keywords.Contains (result, StringComparer.Ordinal))
+				return $"@{result}";
+			return result;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ResourceParser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.CodeDom;
+using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -43,12 +44,12 @@ namespace Xamarin.Android.Tasks
 
 			if (map.TryGetValue (key, out mappedValue)) {
 				Log.LogDebugMessage ("  - Remapping resource: {0}.{1} -> {2}", type, name, mappedValue);
-				return mappedValue.Substring (mappedValue.LastIndexOf (Path.DirectorySeparatorChar) + 1);
+				return ResourceIdentifier.CreateValidIdentifier (mappedValue.Substring (mappedValue.LastIndexOf (Path.DirectorySeparatorChar) + 1));
 			}
 
 			Log.LogDebugMessage ("  - Not remapping resource: {0}.{1}", type, name);
 
-			return name;
+			return ResourceIdentifier.CreateValidIdentifier (name);
 		}
 
 	}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -643,6 +643,7 @@
     <Compile Include="Linker\MonoDroid.Tuner\AndroidLinkContext.cs" />
     <Compile Include="Tasks\AppendCustomMetadataToItemGroup.cs" />
     <Compile Include="Utilities\OutputLine.cs" />
+    <Compile Include="Utilities\ResourceIdentifier.cs" />
   </ItemGroup>
   <ItemGroup>
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.LaunchMode.cs" />


### PR DESCRIPTION
Fixes #3007

Xamarin.Forms introduced some new `android:id` values in the
`Xamarin.Forms.Platform.Android` assembly [1]. These include
a period `.` in the identifier, such as

	android:id="@+id/bottomtab.tabbar"
	android:id="@+id/toolbar.one"

When processing these with `aapt` or `aapt2` these identifiers
are "fixed up" to be valid java identifiers. The same is
NOT true for the `ManagedResourceParser`. As a result
the very first design time build will fail with the following
error.

	obj\Debug\81\designtime\Resource.designer.cs(5048,21,5048,30): error CS0145: A const field requires a value to be provided
	obj\Debug\81\designtime\Resource.designer.cs(5048,30,5048,31): error CS1003: Syntax error, ','
	obj\Debug\81\designtime\Resource.designer.cs(5048,31,5048,38): error CS1002: ; expected

This is because it is generating the following code in the
`Resource.designer.cs`

	public const int toolbar.one = 2131230899;

which is NOT a valid C# identifier.

This commit adds a new `ResourceIdentifier` class which
is responsible for making sure the identifier we generate
is a valid C# identifier. This logic is based on the
C# language specifications [1]. It also does keyword
detection and prepends an `@` if required. Just in case
a user calls an item `base` or `class` or any other
C# keyword.

[1] https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.Platform.Android/Resources/Layout/BottomTabLayout.axml#L13.
[2] https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#identifiers
[3] https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#keywords