### PR TITLE
[tests] Fix Build error when running 'RunNUnitDeviceTests'

### DIFF
--- a/tests/RunApkTests.targets
+++ b/tests/RunApkTests.targets
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Project DefaultTargets="RunApkTests" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.SetEnvironmentVariable" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <OutputPath>$(MSBuildThisFileDirectory)..\bin\Test$(Configuration)\</OutputPath>


### PR DESCRIPTION
When running `RunNUnitDeviceTests` manually you get
and error such as

	error MSB4036: The "SetEnvironmentVariable" task was not found.

This is because we are missing the `UsingTask` to bring
in this custom task. This is an issue only when running
`RunNUnitDeviceTests` manually. It does not happen when
running as part of `make run-apk-tests`.