### PR TITLE
Do not pass Proxy.NoProxy so that the system proxy settings are respected

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -260,8 +260,13 @@ namespace Xamarin.Android.Net
 				URL java_url = new URL (EncodeUrl (redirectState.NewUrl));
 				URLConnection java_connection;
 				if (UseProxy)
-					java_connection = java_url.OpenConnection (await GetJavaProxy (redirectState.NewUrl, cancellationToken));
+				{
+					var javaProxy = await GetJavaProxy (redirectState.NewUrl, cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+					// When you use the parameter Java.Net.Proxy.NoProxy the system proxy is overriden. Leave the parameter out to respect the default settings.
+					java_connection = javaProxy == Java.Net.Proxy.NoProxy ? java_url.OpenConnection() : java_url.OpenConnection (javaProxy);
+				}
 				else
+					// In this case the consumer of this class has explicitly chosen to not use a proxy, so bypass the default proxy. The default value of UseProxy is true.
 					java_connection = java_url.OpenConnection (Java.Net.Proxy.NoProxy);
 
 				var httpsConnection = java_connection as HttpsURLConnection;

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -259,15 +259,14 @@ namespace Xamarin.Android.Net
 			while (true) {
 				URL java_url = new URL (EncodeUrl (redirectState.NewUrl));
 				URLConnection java_connection;
-				if (UseProxy)
-				{
-					var javaProxy = await GetJavaProxy (redirectState.NewUrl, cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+				if (UseProxy) {
+					var javaProxy = await GetJavaProxy (redirectState.NewUrl, cancellationToken).ConfigureAwait (continueOnCapturedContext: false);
 					// When you use the parameter Java.Net.Proxy.NoProxy the system proxy is overriden. Leave the parameter out to respect the default settings.
-					java_connection = javaProxy == Java.Net.Proxy.NoProxy ? java_url.OpenConnection() : java_url.OpenConnection (javaProxy);
-				}
-				else
+					java_connection = javaProxy == Java.Net.Proxy.NoProxy ? java_url.OpenConnection () : java_url.OpenConnection (javaProxy);
+				} else {
 					// In this case the consumer of this class has explicitly chosen to not use a proxy, so bypass the default proxy. The default value of UseProxy is true.
 					java_connection = java_url.OpenConnection (Java.Net.Proxy.NoProxy);
+				}
 
 				var httpsConnection = java_connection as HttpsURLConnection;
 				if (httpsConnection != null) {


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/3058

I added comments inline for clarification.
According to https://docs.oracle.com/javase/7/docs/api/java/net/URL.html#openConnection() passing Proxy.NoProxy tells the URL class to not use a proxy, regardless of system settings. Leaving the parameter out makes sure that system settings are used.