### PR TITLE
[tests] Detect adb crash during instrumentation

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
@@ -113,6 +113,8 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			if (File.Exists (sourceFile)) {
 				contents.Append (File.ReadAllText (sourceFile));
 			}
+
+			bool adbCrashed = false;
 			if (logcatPath != null) {
 				if (contents.Length > 0) {
 					contents.AppendLine ();
@@ -140,9 +142,12 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				if (inBinRun) {
 					contents.Append ("]");
 				}
+
+				adbCrashed |= logcat.IndexOf (RunInstrumentationTests.AdbRestartText, StringComparison.Ordinal) >= 0;
 			}
 
-			var message = $"Error processing `{sourceFile}`.  " +
+			var adbText = adbCrashed ? RunInstrumentationTests.AdbCrashErrorText : "";
+			var message = $"{adbText}Error processing `{sourceFile}`.  " +
 				$"Check the build log for execution errors.{Environment.NewLine}" +
 				$"File contents:{Environment.NewLine}";
 


### PR DESCRIPTION
adb sometimes crashes during test instrumentation. When it happens,
one needs to download the binlogs to confirm it.

With this change is should be reported in the test results and also
mentioned in the log.

The adb crash in binlogs looks like:

    Executing: /Users/builder/android-toolchain/sdk/platform-tools/adb -s emulator-5570  shell am instrument  -e "loglevel Verbose" -w "Mono.Android_TestsMultiDex/xamarin.android.runtimetests.TestInstrumentation" (TaskId:274)
    Executing: /Users/builder/android-toolchain/sdk/platform-tools/adb -s emulator-5570  logcat -v threadtime -d (TaskId:274)
    appending stdout to file: /Users/builder/jenkins/workspace/xamarin-android/xamarin-android/build-tools/scripts/../../bin/TestRelease/logcat-Release-Bundle-Mono.Android_TestsMultiDex.txt (TaskId:274)
    /Users/builder/jenkins/workspace/xamarin-android/xamarin-android/build-tools/scripts/TestApks.targets(226,5): warning : * daemon not running; starting now at tcp:5037 [/Users/builder/jenkins/workspace/xamarin-android/xamarin-android/tests/RunApkTests.targets]
    /Users/builder/jenkins/workspace/xamarin-android/xamarin-android/build-tools/scripts/TestApks.targets(226,5): warning : * daemon started successfully [/Users/builder/jenkins/workspace/xamarin-android/xamarin-android/tests/RunApkTests.targets]