### PR TITLE
[Xamarin.Android.Build.Tasks] Add some extension points for the Components Team

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -104,6 +104,41 @@ The following build targets are defined for Xamarin.Android projects:
     `Resource.designer.cs` file. This target is usually called by the
     IDE when new resources are added to the project.
 
+<a name="Build_Extension_Points" />
+
+## Build Extension Points
+
+The Xamarin.Android build system exposes a few public extension points
+for those users wanting to hook into our build process. To use these 
+extension points you will need to define your own target inside a 
+`PropertyGroup`, for example
+
+   ```
+   <PropertyGroup>
+      <AfterGenerateAndroidManifest>
+         $(AfterGenerateAndroidManifest);
+         YourTarget;
+      </AfterGenerateAndroidManifest>
+   </PropertyGroup>
+   ```
+
+A word of caution about extending the build process. If not 
+written correctly build extensions can effect your build
+performance, especially if they run on every build. It is 
+highly recommended that you read the MSBuild [documentation](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild)
+before implementing such extensions.
+
+-   **AfterGenerateAndroidManifest** &ndash; This target will run 
+    directly after the internal `_GenerateJavaStubs` target. This
+    is where the `AndroidManifest.xml` file is generated in the 
+    `$(IntermediateOutputPath)`. So you you want to make any 
+    modifications to the generated `AndroidManifest.xml` file
+    you can do this using this extension point.
+
+-   **BeforeGenerateAndroidManifest** &ndash; This target will
+    run directly before `_GenerateJavaStubs`.
+
+<a name="Build_Properties" />
 
 ## Build Properties
 

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
@@ -60,19 +60,13 @@ Copyright (C) 2016 Xamarin. All rights reserved.
   <ItemGroup>
     <_ResolvedAssemblies
         Include="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')"
-        KeepDuplicates="false"
-        KeepMetadata="AndroidSkipJavaStubGeneration;TargetFrameworkIdentifier;HasMonoAndroidReference"
     />
     <_ResolvedUserAssemblies
         Include="@(ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')"
-        KeepDuplicates="false"
-        KeepMetadata="AndroidSkipJavaStubGeneration;TargetFrameworkIdentifier;HasMonoAndroidReference"
     />
     <_ResolvedUserMonoAndroidAssembliesForDesigner
         Include="@(ResolvedUserAssemblies)"
         Condition="'%(ResolvedUserAssemblies.TargetFrameworkIdentifier)' == 'MonoAndroid' Or '%(ResolvedUserAssemblies.HasMonoAndroidReference)' == 'True'"
-        KeepDuplicates="false"
-        KeepMetadata="AndroidSkipJavaStubGeneration;TargetFrameworkIdentifier;HasMonoAndroidReference"
     />
   </ItemGroup>
 </Target>

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
@@ -47,17 +47,43 @@ Copyright (C) 2016 Xamarin. All rights reserved.
   </ItemGroup>
 </Target>
 
-<Target Name="_GeneratePackageManagerJavaForDesigner"
-    DependsOnTargets="_AddStaticResources;_ResolveAssemblies"
-    Inputs="$(_ResolvedUserAssembliesHashFile);@(ResolvedAssemblies);@(ResolvedUserAssemblies);$(_AndroidManifestAbs);"
-    Outputs="$(IntermediateOutputPath)android\src\mono\MonoPackageManager.java;$(_AndroidTypeMappingJavaToManaged);$(_AndroidTypeMappingManagedToJava)">
+<Target Name="_CopyAssembliesForDesigner"
+    Inputs="@(ResolvedAssemblies)"
+    Outputs="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')">
   <Copy
       SourceFiles="@(ResolvedAssemblies)"
       DestinationFiles="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')"
   />
+</Target>
+
+<Target Name="_PrepareAssembliesForDesigner">
+  <ItemGroup>
+    <_ResolvedAssemblies
+        Include="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')"
+        KeepDuplicates="false"
+        KeepMetadata="AndroidSkipJavaStubGeneration;TargetFrameworkIdentifier;HasMonoAndroidReference"
+    />
+    <_ResolvedUserAssemblies
+        Include="@(ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')"
+        KeepDuplicates="false"
+        KeepMetadata="AndroidSkipJavaStubGeneration;TargetFrameworkIdentifier;HasMonoAndroidReference"
+    />
+    <_ResolvedUserMonoAndroidAssembliesForDesigner
+        Include="@(ResolvedUserAssemblies)"
+        Condition="'%(ResolvedUserAssemblies.TargetFrameworkIdentifier)' == 'MonoAndroid' Or '%(ResolvedUserAssemblies.HasMonoAndroidReference)' == 'True'"
+        KeepDuplicates="false"
+        KeepMetadata="AndroidSkipJavaStubGeneration;TargetFrameworkIdentifier;HasMonoAndroidReference"
+    />
+  </ItemGroup>
+</Target>
+
+<Target Name="_GeneratePackageManagerJavaForDesigner"
+    DependsOnTargets="_AddStaticResources;_ResolveAssemblies;_CopyAssembliesForDesigner;_PrepareAssembliesForDesigner;$(BeforeGenerateAndroidManifest)"
+    Inputs="$(_ResolvedUserAssembliesHashFile);@(ResolvedAssemblies);@(ResolvedUserAssemblies);$(_AndroidManifestAbs);"
+    Outputs="$(IntermediateOutputPath)android\src\mono\MonoPackageManager.java;$(_AndroidTypeMappingJavaToManaged);$(_AndroidTypeMappingManagedToJava)">
   <GenerateJavaStubs
-      ResolvedAssemblies="@(ResolvedAssemblies)"
-      ResolvedUserAssemblies="@(ResolvedUserAssemblies)"
+      ResolvedAssemblies="@(_ResolvedAssemblies)"
+      ResolvedUserAssemblies="@(_ResolvedUserMonoAndroidAssembliesForDesigner)"
       ManifestTemplate="$(_AndroidManifestAbs)"
       MergedManifestDocuments="@(ExtractedManifestDocuments)"
       Debug="$(AndroidIncludeDebugSymbols)"
@@ -86,8 +112,8 @@ Copyright (C) 2016 Xamarin. All rights reserved.
   />
   <!-- Create java needed for Mono runtime -->
   <GeneratePackageManagerJava
-      ResolvedAssemblies="@(ResolvedAssemblies)"
-      ResolvedUserAssemblies="@(ResolvedUserAssemblies)"
+      ResolvedAssemblies="@(_ResolvedAssemblies)"
+      ResolvedUserAssemblies="@(_ResolvedUserAssemblies)"
       MainAssembly="$(MonoAndroidLinkerInputDir)$(TargetFileName)"
       OutputDirectory="$(IntermediateOutputPath)android\src\mono"
       EnvironmentOutputDirectory="$(IntermediateOutputPath)android\src\mono\android\app"

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -126,6 +126,8 @@ namespace Xamarin.Android.Tasks
 					Log.LogDebugMessage ($"Skipping Java Stub Generation for {asm.ItemSpec}");
 					continue;
 				}
+				if (!assemblies.All (x => Path.GetFileName (x) != Path.GetFileName (asm.ItemSpec)))
+					continue;
 				Log.LogDebugMessage ($"Adding {asm.ItemSpec} to assemblies.");
 				assemblies.Add (asm.ItemSpec);
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DesignerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DesignerTests.cs
@@ -41,6 +41,22 @@ namespace Xamarin.Android.Build.Tests
 					KnownPackages.SupportV7AppCompat_25_4_0_1,
 				},
 				References = { new BuildItem ("ProjectReference", "..\\Library1\\Library1.csproj") },
+				Imports = {
+				new Import ("foo.targets") {
+					TextContent = () => @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project ToolsVersion=""4.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+<PropertyGroup>
+	<BeforeGenerateAndroidManifest>
+		$(BeforeGenerateAndroidManifest);
+		_Foo;
+	</BeforeGenerateAndroidManifest>
+</PropertyGroup>
+<Target Name=""_Foo"">
+</Target>
+</Project>
+"
+					},
+				},
 			};
 			proj.Sources.Add (new BuildItem.Source ("CustomTextView.cs") {
 				TextContent = () => @"using Android.Widget;
@@ -82,6 +98,7 @@ namespace UnnamedProject
 				appb.Target = target;
 				Assert.IsTrue (appb.Build (proj, parameters: DesignerParameters), $"build should have succeeded for target `{target}`");
 				Assert.IsTrue (appb.Output.AreTargetsAllBuilt ("_UpdateAndroidResgen"), "_UpdateAndroidResgen should have run completely.");
+				Assert.IsTrue (appb.Output.AreTargetsAllBuilt ("_Foo"), "_Foo should have run completely");
 				var customViewPath = Path.Combine (Root, appb.ProjectDirectory, proj.IntermediateOutputPath, "res", "layout", "custom_text.xml");
 				Assert.IsTrue (File.Exists (customViewPath), $"custom_text.xml should exist at {customViewPath}");
 				var doc = XDocument.Load (customViewPath);
@@ -94,6 +111,7 @@ namespace UnnamedProject
 				appb.Target = "Build";
 				Assert.IsTrue (appb.Build (proj), "app build should have succeeded.");
 				Assert.IsTrue (appb.Output.AreTargetsAllBuilt ("_UpdateAndroidResgen"), "_UpdateAndroidResgen should have run completely.");
+				Assert.IsTrue (appb.Output.AreTargetsAllBuilt ("_Foo"), "_Foo should have run completely");
 				doc = XDocument.Load (customViewPath);
 				Assert.IsNull (doc.Element ("LinearLayout").Element ("UnnamedProject.CustomTextView"),
 					"UnnamedProject.CustomTextView should have been replaced with an $(MD5Hash).CustomTextView");
@@ -102,6 +120,7 @@ namespace UnnamedProject
 				appb.Target = target;
 				Assert.IsTrue (appb.Build (proj, parameters: DesignerParameters), $"build should have succeeded for target `{target}`");
 				Assert.IsTrue (appb.Output.AreTargetsAllSkipped ("_UpdateAndroidResgen"), "_UpdateAndroidResgen should have been skipped.");
+				Assert.IsTrue (appb.Output.AreTargetsAllBuilt ("_Foo"), "_Foo should have run completely");
 				doc = XDocument.Load (customViewPath);
 				Assert.IsNull (doc.Element ("LinearLayout").Element ("UnnamedProject.CustomTextView"),
 					"UnnamedProject.CustomTextView should have been replaced with an $(MD5Hash).CustomTextView");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2961,14 +2961,8 @@ because xbuild doesn't support framework reference assemblies.
 		_CopyMdbFiles;
 		_LinkAssemblies;
 		_GenerateJavaStubs;
-<<<<<<< HEAD
-<<<<<<< HEAD
 		_ConvertCustomView;
-=======
 		$(AfterGenerateAndroidManifest);
->>>>>>> [Xamarin.Android.Build.Tasks] Add some extension points for the Components Team
-=======
->>>>>>> Add Unit Test. Rework the targets a bit
 		_GenerateEnvironmentFiles;
 		_CompileJava;
 		_CompileDex;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1618,8 +1618,6 @@ because xbuild doesn't support framework reference assemblies.
 		_GenerateAndroidResourceDir;
 		_IncludeLayoutBindingSources;
 		_DefineBuildTargetAbis;
-		_CompileAndroidLibraryResources;
-		_CompileResources;
 	</_UpdateAndroidResgenDependsOnTargets>
 	<_UpdateAndroidResgenInputs>
 		$(MSBuildAllProjects);
@@ -1637,7 +1635,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_UpdateAndroidResgen"
 	Inputs="$(_UpdateAndroidResgenInputs)"
 	Outputs="$(_AndroidResgenFlagFile)"
-	DependsOnTargets="$(_UpdateAndroidResgenDependsOnTargets)">
+	DependsOnTargets="$(_UpdateAndroidResgenDependsOnTargets);$(_AfterGenerateAndroidResourceDir);_CompileAndroidLibraryResources;_CompileResources">
 
 	<!-- Create a temporary directory to work in -->
 	<CreateTemporaryDirectory>
@@ -2091,7 +2089,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 	
 <Target Name="_LinkAssemblies"
-  DependsOnTargets="_ResolveAssemblies;_CreatePackageWorkspace;_GenerateJniMarshalMethods;_LinkAssembliesNoShrink;_LinkAssembliesShrink" />
+  DependsOnTargets="_ResolveAssemblies;_CreatePackageWorkspace;$(_BeforeLinkAssemblies);_GenerateJniMarshalMethods;_LinkAssembliesNoShrink;_LinkAssembliesShrink" />
 
 <Target Name="_GenerateJniMarshalMethods"
     Condition="'$(AndroidGenerateJniMarshalMethods)' == 'True' And '$(AndroidLinkMode)' != 'None' And '$(OS)' != 'Windows_NT'"
@@ -2274,8 +2272,18 @@ because xbuild doesn't support framework reference assemblies.
   </PrepareAbiItems>
 </Target>
 
+<PropertyGroup>
+  <_GenerateJavaStubsDependsOnTargets>
+    _SetLatestTargetFrameworkVersion;
+    _PrepareNativeAssemblySources;
+    _LinkAssemblies;
+    _PrepareAssemblies;
+    $(_AfterPrepareAssemblies);
+  </_GenerateJavaStubsDependsOnTargets>
+</PropertyGroup>
+
 <Target Name="_GenerateJavaStubs"
-  DependsOnTargets="_SetLatestTargetFrameworkVersion;_PrepareAssemblies;$(_AfterPrepareAssemblies);_PrepareNativeAssemblySources"
+  DependsOnTargets="$(_GenerateJavaStubsDependsOnTargets);$(BeforeGenerateAndroidManifest)"
   Inputs="$(MSBuildAllProjects);@(_ResolvedUserMonoAndroidAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(_AndroidResourceDest)"
   Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp;@(_TypeMapAssemblySource)">
   <GenerateJavaStubs
@@ -2482,7 +2490,7 @@ because xbuild doesn't support framework reference assemblies.
 </PropertyGroup>
 
 <Target Name="_CreateBaseApk"
-  DependsOnTargets="$(_CreateBaseApkDependsOnTargets)"
+  DependsOnTargets="$(_CreateBaseApkDependsOnTargets);$(AfterGenerateAndroidManifest)"
   Inputs="$(_CreateBaseApkInputs)"
   Outputs="$(_PackagedResources)">
   <!-- Create a temporary directory to work in, or else R.java will always get updated -->
@@ -2821,7 +2829,7 @@ because xbuild doesn't support framework reference assemblies.
 </PropertyGroup>
 
 <Target Name="_CompileDex"
-		DependsOnTargets="$(_CompileDexDependsOn)">
+		DependsOnTargets="$(_BeforeCompileDex);$(_CompileDexDependsOn)">
 	<ItemGroup>
 		<_DexFile Include="$(IntermediateOutputPath)android\bin\dex\*.dex" />
 		<_DexFile Include="$(IntermediateOutputPath)android\bin\*.dex" />
@@ -2953,7 +2961,14 @@ because xbuild doesn't support framework reference assemblies.
 		_CopyMdbFiles;
 		_LinkAssemblies;
 		_GenerateJavaStubs;
+<<<<<<< HEAD
+<<<<<<< HEAD
 		_ConvertCustomView;
+=======
+		$(AfterGenerateAndroidManifest);
+>>>>>>> [Xamarin.Android.Build.Tasks] Add some extension points for the Components Team
+=======
+>>>>>>> Add Unit Test. Rework the targets a bit
 		_GenerateEnvironmentFiles;
 		_CompileJava;
 		_CompileDex;


### PR DESCRIPTION
As part of the AndroidX migration the Component team
need to hook into our build process. They have
currently been doing that via `BeforeTargets/AfterTargets`.
We have been trying to reduce our use of those methods
within the Xamarin.Android product since commit 3942496.

This PR adds a few internal extension points which can be used
by the components team. Namely

	$(_BeforeLinkAssemblies);
	$(_AfterGenerateAndroidResourceDir);
	$(_BeforeCompileDex);

These can be used by adding a new property group via

	<PropertyGroup>
		<_BeforeCompileDex>
			$(_BeforeCompileDex);
			_Foo;
		</_BeforeCompileDex>
	</PropertyGRoup>

We have also added a couple of public extension points

	$(BeforeGenerateAndroidManifest);
	$(AfterGenerateAndroidManifest);

The main purpose os these is two fold. First for the
component team, but second it should help our users
with making `AndroidManifest.xml` adjustments.

Currently `GenerateJavaStubs` is responsible for producing
the `AndroidManfiest.xml` the app uses. However if our
users want to adjust that file after generation to say
remove persmissions (see #1335) they do not have a good
extension point. These new extension points will run
before and after `GenerateJavaStubs` at the moment.

When we finally have the time to refactor `GenerateJavaStubs`
we can make sure these extension points are still called
at the right time.