### PR TITLE
[Xamarin.Android.Build.Tasks] do not use %(HintPath)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
@@ -113,7 +113,7 @@ namespace Xamarin.Android.Tasks
 						var assemblyPath = assembly.ItemSpec;
 						var fileName = Path.GetFileName (assemblyPath);
 						if (MonoAndroidHelper.IsFrameworkAssembly (fileName) &&
-							!MonoAndroidHelper.FrameworkEmbeddedJarLookupTargets.Contains (fileName)) {
+								!MonoAndroidHelper.FrameworkEmbeddedJarLookupTargets.Contains (fileName)) {
 							Log.LogDebugMessage ($"Skipping framework assembly '{fileName}'.");
 							continue;
 						}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using Monodroid;
+using Mono.Cecil;
 
 using Java.Interop.Tools.Cecil;
 
@@ -105,30 +105,25 @@ namespace Xamarin.Android.Tasks
 				Namespace = string.Empty;
 
 			// Create static resource overwrite methods for each Resource class in libraries.
-			var assemblyNames = new List<string> ();
-			if (IsApplication && References != null && References.Any ()) {
+			if (IsApplication && References != null && References.Length > 0) {
 				// FIXME: should this be unified to some better code with ResolveLibraryProjectImports?
+				var assemblies = new List<AssemblyDefinition> (References.Length);
 				using (var resolver = new DirectoryAssemblyResolver (this.CreateTaskLogger (), loadDebugSymbols: false)) {
-					foreach (var assemblyName in References) {
-						var suffix = assemblyName.ItemSpec.EndsWith (".dll") ? String.Empty : ".dll";
-						string hintPath = assemblyName.GetMetadata ("HintPath").Replace (Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
-						string fileName = assemblyName.ItemSpec + suffix;
-						string fullPath = Path.GetFullPath (assemblyName.ItemSpec);
-						// Skip non existing files in DesignTimeBuild
-						if (!File.Exists (fullPath) && DesignTimeBuild) {
-							Log.LogDebugMessage ("Skipping non existant dependancy '{0}' due to design time build.", fullPath);
+					foreach (var assembly in References) {
+						var assemblyPath = assembly.ItemSpec;
+						var fileName = Path.GetFileName (assemblyPath);
+						if (MonoAndroidHelper.IsFrameworkAssembly (fileName) &&
+							!MonoAndroidHelper.FrameworkEmbeddedJarLookupTargets.Contains (fileName)) {
+							Log.LogDebugMessage ($"Skipping framework assembly '{fileName}'.");
 							continue;
 						}
-						resolver.Load (fullPath);
-						if (!String.IsNullOrEmpty (hintPath) && !File.Exists (hintPath)) // ignore invalid HintPath
-							hintPath = null;
-						string assemblyPath = String.IsNullOrEmpty (hintPath) ? fileName : hintPath;
-						if (MonoAndroidHelper.IsFrameworkAssembly (fileName) && !MonoAndroidHelper.FrameworkEmbeddedJarLookupTargets.Contains (Path.GetFileName (fileName)))
+						if (DesignTimeBuild && !File.Exists (assemblyPath)) {
+							Log.LogDebugMessage ($"Skipping non-existent dependency '{assemblyPath}' during a design-time build.");
 							continue;
+						}
+						assemblies.Add (resolver.Load (assemblyPath));
 						Log.LogDebugMessage ("Scan assembly {0} for resource generator", fileName);
-						assemblyNames.Add (assemblyPath);
 					}
-					var assemblies = assemblyNames.Select (assembly => resolver.GetAssembly (assembly));
 					new ResourceDesignerImportGenerator (Namespace, resources, Log)
 						.CreateImportMethods (assemblies);
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -149,23 +149,6 @@ namespace Xamarin.Android.Tasks
 			return !Log.HasLoggedErrors;
 		}
 
-		static string GetTargetAssembly (ITaskItem assemblyName)
-		{
-			var suffix = assemblyName.ItemSpec.EndsWith (".dll") ? String.Empty : ".dll";
-			string hintPath = assemblyName.GetMetadata ("HintPath").Replace (Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
-			string fileName = assemblyName.ItemSpec + suffix;
-			if (!String.IsNullOrEmpty (hintPath) && !File.Exists (hintPath))
-				hintPath = null;
-			string assemblyPath = String.IsNullOrEmpty (hintPath) ? fileName : hintPath;
-			string fileNameOnly = Path.GetFileName (fileName);
-			if (MonoAndroidHelper.IsFrameworkAssembly (fileName) &&
-					!MonoAndroidHelper.FrameworkEmbeddedJarLookupTargets.Contains (fileNameOnly) &&
-					!MonoAndroidHelper.FrameworkEmbeddedNativeLibraryAssemblies.Contains (fileNameOnly)) {
-				return null;
-			}
-			return Path.GetFullPath (assemblyPath);
-		}
-
 		// Extracts library project contents under e.g. obj/Debug/[__library_projects__/*.jar | res/*/*]
 		// Extracts library project contents under e.g. obj/Debug/[lp/*.jar | res/*/*]
 		void Extract (
@@ -189,9 +172,15 @@ namespace Xamarin.Android.Tasks
 
 			// FIXME: reorder references by import priority (not sure how to do that yet)
 			foreach (var assemblyPath in Assemblies
-					.Select (a => GetTargetAssembly (a))
-					.Where (a => a != null)
+					.Select (a => a.ItemSpec)
 					.Distinct ()) {
+				var fileName = Path.GetFileName (assemblyPath);
+				if (MonoAndroidHelper.IsFrameworkAssembly (fileName) &&
+					!MonoAndroidHelper.FrameworkEmbeddedJarLookupTargets.Contains (fileName) &&
+					!MonoAndroidHelper.FrameworkEmbeddedNativeLibraryAssemblies.Contains (fileName)) {
+					Log.LogDebugMessage ($"Skipping framework assembly '{fileName}'.");
+					continue;
+				}
 				if (DesignTimeBuild && !File.Exists (assemblyPath)) {
 					Log.LogDebugMessage ($"Skipping non-existent dependency '{assemblyPath}' during a design-time build.");
 					continue;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -176,8 +176,8 @@ namespace Xamarin.Android.Tasks
 					.Distinct ()) {
 				var fileName = Path.GetFileName (assemblyPath);
 				if (MonoAndroidHelper.IsFrameworkAssembly (fileName) &&
-					!MonoAndroidHelper.FrameworkEmbeddedJarLookupTargets.Contains (fileName) &&
-					!MonoAndroidHelper.FrameworkEmbeddedNativeLibraryAssemblies.Contains (fileName)) {
+						!MonoAndroidHelper.FrameworkEmbeddedJarLookupTargets.Contains (fileName) &&
+						!MonoAndroidHelper.FrameworkEmbeddedNativeLibraryAssemblies.Contains (fileName)) {
 					Log.LogDebugMessage ($"Skipping framework assembly '{fileName}'.");
 					continue;
 				}


### PR DESCRIPTION
We noticed some odd behavior from MSBuild such as:

    ReferenceDependencyPaths
        C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\Facades\netstandard.dll
            HintPath = ..\..\..\packages\Newtonsoft.Json.11.0.2\lib\netstandard2.0\Newtonsoft.Json.dll
        C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\System.Runtime.Serialization.dll
            HintPath = ..\..\..\packages\Xamarin.Forms.3.1.0.583944\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll

`%(HintPath)` is leftover metadata from the `@(ReferencePath)` item
group, so it points to the original assembly???

We currently use `%(HintPath)` in two places, but it seems like we
don't need to use it at all? `@(ReferencePath)` and
`@(ReferenceDependencyPaths)` will both have the full path to all of
the assemblies in `ITaskItem.ItemSpec`.

I was able to simplify two of our tasks and just use `ItemSpec`:

* `<ResolveLibraryProjectImports/>`
* `<GenerateResourceDesigner/>`

I also did some general refactoring in `<GenerateResourceDesigner/>`:

* Reorganized the top-level `foreach` loop, to more closely match what
  we were already doing in `<ResolveLibraryProjectImports/>`.
* Cleaned up some general LINQ usage.
* A `List<string>` of assembly names could just be a
  `List<AssemblyDefinition>`, to avoid some LINQ.
* Fixed spelling/used string interpolation in log messages.

## Results ##

I think I'm seeing a ~50ms improvement in
`<GenerateResourceDesigner/>` for an initial build:

    Before:
    205 ms  GenerateResourceDesigner                   1 calls
    After:
    152 ms  GenerateResourceDesigner                   1 calls

## Future Work ##

* It might be worth porting `<GenerateResourceDesigner/>` to use
  System.Reflection.Metadata instead of Mono.Cecil at some point.