### PR TITLE
[tests] Increase the emulator RAM size to 3GB

### DIFF
--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -42,7 +42,7 @@
         ImageName="$(_TestImageName)"
         ToolExe="$(AvdManagerToolExe)"
         ToolPath="$(AndroidToolsBinPath)"
-        RamSizeMB="2048"
+        RamSizeMB="3072"
         DataPartitionSizeMB="4096"
     />
     <StartAndroidEmulator


### PR DESCRIPTION
Recently some/many of the tests run out of memory on Jenkins. So lets
try to increase the emulator memory size to see whether it will help.

The emulator is created for every build on CI, like this:

    Using "CreateAndroidEmulator" task from assembly "/Users/builder/jenkins/workspace/xamarin-android/xamarin-android/build-tools/scripts/../../bin/BuildRelease/Xamarin.Android.Tools.BootstrapTasks.dll".
    Task "CreateAndroidEmulator" (TaskId:110)
      Task Parameter:AndroidAbi=x86 (TaskId:110)
      Task Parameter:AndroidSdkHome=/Users/builder/android-toolchain/sdk (TaskId:110)
      Task Parameter:SdkVersion=28 (TaskId:110)
      Task Parameter:ImageName=XamarinAndroidTestRunner (TaskId:110)
      Task Parameter:ToolExe=avdmanager (TaskId:110)
      Task Parameter:ToolPath=/Users/builder/android-toolchain/sdk/tools/bin (TaskId:110)
      Task Parameter:RamSizeMB=2048 (TaskId:110)
      Task Parameter:DataPartitionSizeMB=4096 (TaskId:110)
      Task CreateAndroidEmulator (TaskId:110)
        AndroidAbi: x86 (TaskId:110)
        AndroidSdkHome: /Users/builder/android-toolchain/sdk (TaskId:110)
        JavaSdkHome:  (TaskId:110)
        ImageName: XamarinAndroidTestRunner (TaskId:110)
        SdkVersion: 28 (TaskId:110)
        TargetId: system-images;android-28;default;x86 (TaskId:110)
        ToolExe: avdmanager (TaskId:110)
        ToolPath: /Users/builder/android-toolchain/sdk/tools/bin (TaskId:110)
      Tool /Users/builder/android-toolchain/sdk/tools/bin/avdmanager execution started with arguments: create avd --abi x86 -f -n XamarinAndroidTestRunner --package "system-images;android-28;default;x86" (TaskId:110)
      Environment variables being passed to the tool: (TaskId:110)
            ANDROID_SDK_HOME="/Users/builder/android-toolchain/sdk" (TaskId:110)
    Done executing task "CreateAndroidEmulator". (TaskId:110)

Example out of memory test run:

    I xUnit   : Test collection finished (TaskId:51)
    I xUnit   :    Time: 0 (TaskId:51)
    I xUnit   :    Total tests run: 0 (TaskId:51)
    I xUnit   :    Skipped tests: 0 (TaskId:51)
    I xUnit   :    Failed tests: 0 (TaskId:51)
    I xUnit   :    Test collection: Test collection for System.Numerics.Tests.op_orTest (TaskId:51)
    V xUnit   :    Associated test case: System.Numerics.Tests.op_orTest.RunOrTests (TaskId:51)
    E mono    :  (TaskId:51)
    E mono    : Unhandled Exception: (TaskId:51)
    E mono    : System.OutOfMemoryException: Insufficient memory to continue the execution of the program. (TaskId:51)
    E mono    :   at (wrapper alloc) System.Object.AllocVector(intptr,intptr) (TaskId:51)
    E mono    :   at System.Collections.Generic.List`1[T].set_Capacity (System.Int32 value) [0x00021] in <b4834163b7c34fdd9789780c9b58c810>:0  (TaskId:51)
    E mono    :   at System.Collections.Generic.List`1[T].EnsureCapacity (System.Int32 min) [0x00036] in <b4834163b7c34fdd9789780c9b58c810>:0  (TaskId:51)
    E mono    :   at System.Collections.Generic.List`1[T].AddEnumerable (System.Collections.Generic.IEnumerable`1[T] enumerable) [0x0002e] in <b4834163b7c34fdd9789780c9b58c810>:0  (TaskId:51)
    E mono    :   at System.Collections.Generic.List`1[T]..ctor (System.Collections.Generic.IEnumerable`1[T] collection) [0x00062] in <b4834163b7c34fdd9789780c9b58c810>:0  (TaskId:51)
    E mono    :   at System.Linq.Enumerable.ToList[TSource] (System.Collections.Generic.IEnumerable`1[T] source) [0x00018] in <f506283258c042f6b92c6d09a3e02728>:0  (TaskId:51)
    E mono    :   at Xunit.Sdk.TestAssemblyMessage..ctor (System.Collections.Generic.IEnumerable`1[T] testCases, Xunit.Abstractions.ITestAssembly testAssembly) [0x0000d] in <724f386d8f5b4395a7fa46c7a3a38a2a>:0  (TaskId:51)
    E mono    :   at Xunit.Sdk.TestAssemblyFinished..ctor (System.Collections.Generic.IEnumerable`1[T] testCases, Xunit.Abstractions.ITestAssembly testAssembly, System.Decimal executionTime, System.Int32 testsRun, System.Int32 testsFailed, System.Int32 testsSkipped) [0x00000] in <724f386d8f5b4395a7fa46c7a3a38a2a>:0  (TaskId:51)
    E mono    :   at Xunit.Sdk.TestAssemblyRunner`1[TTestCase].RunAsync () [0x00251] in <724f386d8f5b4395a7fa46c7a3a38a2a>:0  (TaskId:51)
    E mono    :   at Xunit.Sdk.XunitTestFrameworkExecutor.RunTestCases (System.Collections.Generic.IEnumerable`1[T] testCases, Xunit.Abstractions.IMessageSink executionMessageSink, Xunit.Abstractions.ITestFrameworkExecutionOptions executionOptions) [0x00094] in <724f386d8f5b4395a7fa46c7a3a38a2a>:0  (TaskId:51)
    E mono    :   at System.Runtime.CompilerServices.AsyncMethodBuilderCore+<>c.<ThrowAsync>b__7_1 (System.Object state) [0x00000] in <b4834163b7c34fdd9789780c9b58c810>:0  (TaskId:51)
    E mono    :   at System.Threading.QueueUserWorkItemCallback.WaitCallback_Context (System.Object state) [0x00007] in <b4834163b7c34fdd9789780c9b58c810>:0  (TaskId:51)
    E mono    :   at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00071] in <b4834163b7c34fdd9789780c9b58c810>:0  (TaskId:51)
    E mono    :   at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in <b4834163b7c34fdd9789780c9b58c810>:0  (TaskId:51)
    E mono    :   at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem () [0x00021] in <b4834163b7c34fdd9789780c9b58c810>:0  (TaskId:51)
    E mono    :   at System.Threading.ThreadPoolWorkQueue.Dispatch () [0x00074] in <b4834163b7c34fdd9789780c9b58c810>:0  (TaskId:51)
    E mono    :   at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback () [0x00000] in <b4834163b7c34fdd9789780c9b58c810>:0  (TaskId:51)