### PR TITLE
[tests] Collect separate logcat files for xunit and nunit BCL tests

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
@@ -20,6 +20,8 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		public                  bool                DeleteSourceFiles           { get; set; }
 		public                  string              Configuration               { get; set; }
 		public                  string              TestsFlavor                 { get; set; }
+		public                  string              LogcatFilenameDistincion    { get; set; }
+
 		[Required]
 		public                  string              SourceFile                  { get; set; }
 		[Required]
@@ -44,7 +46,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			catch (Exception e) {
 				Log.LogWarning ($"Unable to process `{SourceFile}`.  Is it empty?  (Did a unit test runner SIGSEGV?)");
 				Log.LogWarningFromException (e);
-				CreateErrorResultsFile (SourceFile, dest, Configuration, TestsFlavor, e, m => {
+				CreateErrorResultsFile (SourceFile, dest, Configuration, TestsFlavor, LogcatFilenameDistincion, e, m => {
 						Log.LogMessage (MessageImportance.Low, m);
 				});
 			}
@@ -106,9 +108,9 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 	partial class RenameTestCases {
 
-		static void CreateErrorResultsFile (string sourceFile, string destFile, string config, string flavor, Exception e, Action<string> logDebugMessage)
+		static void CreateErrorResultsFile (string sourceFile, string destFile, string config, string flavor, string distinction, Exception e, Action<string> logDebugMessage)
 		{
-			GetTestCaseInfo (sourceFile, Path.GetDirectoryName (destFile), config, flavor, logDebugMessage, out var testSuiteName, out var testCaseName, out var logcatPath);
+			GetTestCaseInfo (sourceFile, Path.GetDirectoryName (destFile), config, flavor, distinction, logDebugMessage, out var testSuiteName, out var testCaseName, out var logcatPath);
 			var contents  = new StringBuilder ();
 			if (File.Exists (sourceFile)) {
 				contents.Append (File.ReadAllText (sourceFile));
@@ -162,14 +164,14 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		//   /Users/builder/jenkins/workspace/xamarin-android-pr-builder-release/xamarin-android/bin/TestRelease/logcat-Release-Mono.Android_Tests.txt
 		//
 		// We need to extract the "base" test name from `SourceFile`, and use that to construct `logcatPath`
-		static void GetTestCaseInfo (string sourceFile, string destinationFolder, string config, string flavor, Action<string> logDebugMessage, out string testSuiteName, out string testCaseName, out string logcatPath)
+		static void GetTestCaseInfo (string sourceFile, string destinationFolder, string config, string flavor, string distinction, Action<string> logDebugMessage, out string testSuiteName, out string testCaseName, out string logcatPath)
 		{
 			var name        = Path.GetFileNameWithoutExtension (sourceFile);
 			if (name.StartsWith ("TestResult-"))
 				name    = name.Substring ("TestResult-".Length);
 			testSuiteName   = name;
 			testCaseName    = $"Possible Crash / {config}";
-			logcatPath      = Path.Combine (destinationFolder, "bin", $"Test{config}", $"logcat-{config}{flavor}-{name}.txt");
+			logcatPath      = Path.Combine (destinationFolder, "bin", $"Test{config}", $"logcat-{config}{flavor}-{name}{distinction}.txt");
 			logDebugMessage ($"Looking for `adb logcat` output in the file: {logcatPath}");
 			if (!File.Exists (logcatPath)) {
 				logDebugMessage ($"Could not find file `{logcatPath}`.  Will not be including `adb logcat` output.");
@@ -197,7 +199,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			string destFile       = args [0];
 			string sourceFile     = args.Length > 1 ? args [1] : "source.xml";
 			string config         = args.Length > 2 ? args [2] : "Debug";
-			CreateErrorResultsFile (sourceFile, destFile, config, "", new Exception ("Wee!!!"), Console.WriteLine);
+			CreateErrorResultsFile (sourceFile, destFile, config, "", "", new Exception ("Wee!!!"), Console.WriteLine);
 		}
 	}
 #endif  // APP

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -232,7 +232,7 @@
         PackageName="%(TestApkInstrumentation.Package)"
         Component="%(TestApkInstrumentation.Package)/%(TestApkInstrumentation.Identity)"
         NUnit2TestResultsFile="%(TestApkInstrumentation.ResultsPath)"
-        LogcatFilename="$(_LogcatFilenameBase)-%(TestApkInstrumentation.Package).txt"
+        LogcatFilename="$(_LogcatFilenameBase)-%(TestApkInstrumentation.Package)%(TestApkInstrumentation.LogcatFilenameDistincion).txt"
         InstrumentationArguments="$(_IncludeCategories);$(_ExcludeCategories)"
         TestFixture="$(TestFixture)"
         ToolExe="$(AdbToolExe)"
@@ -305,6 +305,7 @@
         DestinationFolder="$(MSBuildThisFileDirectory)..\.."
         SourceFile="%(TestApkInstrumentation.ResultsPath)"
         TestsFlavor="$(TestsFlavor)"
+        LogcatFilenameDistincion="%(TestApkInstrumentation.LogcatFilenameDistincion)"
     />
   </Target>
   <Target Name="RecordApkSizes"

--- a/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.projitems
+++ b/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.projitems
@@ -8,8 +8,6 @@
     <TestApk Include="$(OutputPath)Xamarin.Android.Bcl_Tests-Signed.apk">
       <Package>Xamarin.Android.Bcl_Tests</Package>
       <InstrumentationType>xamarin.android.bcltests.TestInstrumentation</InstrumentationType>
-      <TimingDefinitionsFilename>$(MSBuildThisFileDirectory)..\..\..\build-tools\scripts\TimingDefinitions.txt</TimingDefinitionsFilename>
-      <TimingResultsFilename>$(MSBuildThisFileDirectory)..\..\..\TestResult-Xamarin.Android.Bcl_Tests-times.csv</TimingResultsFilename>
     </TestApk>
   </ItemGroup>
 
@@ -17,11 +15,13 @@
     <TestApkInstrumentation Include="xamarin.android.bcltests.XUnitInstrumentation">
       <Package>Xamarin.Android.Bcl_Tests</Package>
       <ResultsPath>$(OutputPath)TestResult-Xamarin.Android.Bcl_Tests.xunit.xml</ResultsPath>
+      <LogcatFilenameDistincion>.xunit</LogcatFilenameDistincion>
     </TestApkInstrumentation>
 
     <TestApkInstrumentation Include="xamarin.android.bcltests.NUnitInstrumentation">
       <Package>Xamarin.Android.Bcl_Tests</Package>
       <ResultsPath>$(OutputPath)TestResult-Xamarin.Android.Bcl_Tests.nunit.xml</ResultsPath>
+      <LogcatFilenameDistincion>.nunit</LogcatFilenameDistincion>
     </TestApkInstrumentation>
 
     <TestApkPermission Include="READ_PHONE_STATE">


### PR DESCRIPTION
Until now, the logcat filenames were created per TestApk item. BCL
tests share the TestApk item and are differentiated by
TestApkInstrumentation item.

We would like to have logcat files for both.

Also do not process timing for these as it would complicate the
processing (we iterate over _AllArchives and not
TestApkInstrumentation item group). We don't use the BCL timing for
plots, so we will not miss these.

Hopefully this change will help diagnose the BCL tests on Jenkins,
which might be crashing currently and we didn't have the logcat output
in the test results archive.

It might be just another adb crash, but having the logcat output might
shed some light.

    [2019-05-05T16:46:27.721Z]   [TESTLOG] Test ResolveSdkTiming Complete
    [2019-05-05T16:46:27.721Z]   [TESTLOG] Test ResolveSdkTiming Outcome=Passed
    [2019-05-05T16:46:27.721Z] emulator: onGuestSendCommand: [0x7ff52c47aad0] Adb connected, start proxing data
    [2019-05-05T16:46:27.721Z] VERBOSE: AdbHostServer.cpp:49: Send [0012host:emulator:5571] to adb daemon.
    [2019-05-05T16:46:29.887Z] /Users/builder/jenkins/workspace/xamarin-android/xamarin-android/build-tools/scripts/TestApks.targets(226,5): warning : * daemon started successfully [/Users/builder/jenkins/wo
    rkspace/xamarin-android/xamarin-android/tests/RunApkTests.targets]
    [2019-05-05T16:46:30.975Z]   Executing: /Users/builder/android-toolchain/sdk/platform-tools/adb   logcat -c
    [2019-05-05T16:46:30.975Z] /Users/builder/jenkins/workspace/xamarin-android/xamarin-android/build-tools/scripts/TestApks.targets(226,5): error : The adb might have crashed and was restarted. Could not find NUnit2 results file after running component `Xamarin.Android.Bcl_Tests/xamarin.android.bcltests.XUnitInstrumentation`: no `nunit2-results-path` bundle value found in command output! [/Users/builder/jenkins/workspace/xamarin-android/xamarin-android/tests/RunApkTests.targets]