### PR TITLE
[Xamarin.Android.Build.Tasks] Handle duplicate Resources for Resource.Designer.cs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
@@ -62,6 +62,12 @@ namespace Foo.Foo
 			// aapt resource value: 0x7F030000
 			public const int customFont = 2130903040;
 			
+			// aapt resource value: 0x7F030001
+			public const int entries = 2130903041;
+			
+			// aapt resource value: 0x7F030002
+			public const int entryValues = 2130903042;
+			
 			static Attribute()
 			{
 				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
@@ -266,6 +272,25 @@ namespace Foo.Foo
 			
 			// aapt resource value: 0x1
 			public const int CustomFonts_customFont = 1;
+			
+			// aapt resource value: { 0x10100B2,0x10101F8,0x7F030001,0x7F030002 }
+			public static int[] MultiSelectListPreference = new int[] {
+					16842930,
+					16843256,
+					2130903041,
+					2130903042};
+			
+			// aapt resource value: 0x0
+			public const int MultiSelectListPreference_android_entries = 0;
+			
+			// aapt resource value: 0x1
+			public const int MultiSelectListPreference_android_entryValues = 1;
+			
+			// aapt resource value: 0x2
+			public const int MultiSelectListPreference_entries = 2;
+			
+			// aapt resource value: 0x3
+			public const int MultiSelectListPreference_entryValues = 3;
 			
 			static Styleable()
 			{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
@@ -66,6 +66,22 @@ namespace Xamarin.Android.Build.Tests {
     <attr name=""android:scrollX"" />
     <attr name=""customFont"" />
   </declare-styleable>
+  <declare-styleable name=""MultiSelectListPreference"">
+    <attr name=""entries""/>
+    <attr name=""android:entries""/>
+    <attr name=""entryValues""/>
+    <attr name=""android:entryValues""/>
+  </declare-styleable>
+</resources>";
+
+		const string Styleablev21 = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<resources>
+  <declare-styleable name=""MultiSelectListPreference"">
+    <attr name=""entries""/>
+    <attr name=""android:entries""/>
+    <attr name=""entryValues""/>
+    <attr name=""android:entryValues""/>
+  </declare-styleable>
 </resources>";
 
 		const string Transition = @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -104,6 +120,8 @@ namespace Xamarin.Android.Build.Tests {
 		const string Rtxt = @"int animator slide_in_bottom 0x7f010000
 int array widths_array 0x7f020000
 int attr customFont 0x7f030000
+int attr entries 0x7f030001
+int attr entryValues 0x7f030002
 int dimen main_text_item_size 0x7f040000
 int drawable ic_menu_preferences 0x7f050000
 int font arial 0x7f060000
@@ -121,9 +139,14 @@ int string app_name 0x7f0d0000
 int string foo 0x7f0d0001
 int string hello 0x7f0d0002
 int string menu_settings 0x7f0d0003
-int[] styleable CustomFonts { 0x010100d2,0x7f030000 }
+int[] styleable CustomFonts { 0x010100d2, 0x7f030000 }
 int styleable CustomFonts_android_scrollX 0
 int styleable CustomFonts_customFont 1
+int[] styleable MultiSelectListPreference { 0x010100b2, 0x010101f8, 0x7f030001, 0x7f030002 }
+int styleable MultiSelectListPreference_android_entries 0
+int styleable MultiSelectListPreference_android_entryValues 1
+int styleable MultiSelectListPreference_entries 2
+int styleable MultiSelectListPreference_entryValues 3
 int transition transition 0x7f0f0000
 ";
 		[OneTimeSetUp]
@@ -140,6 +163,7 @@ int transition transition 0x7f0f0000
 		public void CreateResourceDirectory (string path)
 		{
 			Directory.CreateDirectory (Path.Combine (Root, path, "res", "values"));
+			Directory.CreateDirectory (Path.Combine (Root, path, "res", "values-v21"));
 			Directory.CreateDirectory (Path.Combine (Root, path, "res", "transition"));
 
 			Directory.CreateDirectory (Path.Combine (Root, path, "res", "raw"));
@@ -149,6 +173,7 @@ int transition transition 0x7f0f0000
 
 			File.WriteAllText (Path.Combine (Root, path, "res", "values", "strings.xml"), StringsXml);
 			File.WriteAllText (Path.Combine (Root, path, "res", "values", "attrs.xml"), Styleable);
+			File.WriteAllText (Path.Combine (Root, path, "res", "values-v21", "attrs.xml"), Styleablev21);
 			File.WriteAllText (Path.Combine (Root, path, "res", "transition", "transition.xml"), Transition);
 			File.WriteAllText (Path.Combine (Root, path, "res", "raw", "foo.txt"), "Foo");
 			File.WriteAllText (Path.Combine (Root, path, "res", "layout", "main.xml"), Main);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -454,6 +454,7 @@ namespace Xamarin.Android.Tasks
 
 		void CreateResourceField (string root, string fieldName, XmlReader element = null)
 		{
+			Log.LogMessage (Microsoft.Build.Framework.MessageImportance.High, $"DEBUG!!! {root} {fieldName}");
 			var i = root.IndexOf ('-');
 			var item = i < 0 ? root : root.Substring (0, i);
 			item = resourceNamesToUseDirectly.Contains (root) ? root : item;
@@ -542,6 +543,7 @@ namespace Xamarin.Android.Tasks
 			string topName = null;
 			int fieldCount = 0;
 			List<CodeMemberField> fields = new List<CodeMemberField> ();
+			List<string> attribs = new List<string> ();
 			while (reader.Read ()) {
 				if (reader.NodeType == XmlNodeType.Whitespace || reader.NodeType == XmlNodeType.Comment)
 					continue;
@@ -564,27 +566,34 @@ namespace Xamarin.Android.Tasks
 				}
 				reader.MoveToElement ();
 				if (reader.LocalName == "attr") {
-					CreateIntField (styleable, $"{topName}_{name}", fieldCount);
-					if (!name.StartsWith ("android:", StringComparison.OrdinalIgnoreCase))
-						fields.Add (CreateIntField (attrib, name));
-					else {
-						// this is an android:xxx resource, we should not calcuate the id
-						// we should get it from "somewhere" maybe the pubic.xml
-						var f = new CodeMemberField (typeof(int), name);
-						f.InitExpression = new CodePrimitiveExpression (0);
-						fields.Add (f);
-					}
-					fieldCount++;
+					attribs.Add (name);
 				} else {
 					if (name != null)
 						CreateIntField (ids, $"{name}");
 				}
 			}
-			CodeMemberField field = CreateIntArrayField (styleable, topName, fieldCount);
-			CodeArrayCreateExpression c = field.InitExpression as CodeArrayCreateExpression;
-			if (c == null)
-				return;
-			arrayMapping.Add (field, fields.ToArray ());
+			CodeMemberField field = CreateIntArrayField (styleable, topName, attribs.Count);
+			if (!arrayMapping.ContainsKey (field)) {
+				attribs.Sort (StringComparer.OrdinalIgnoreCase);
+				for (int i = 0; i < attribs.Count; i++) {
+					string name = attribs [i];
+					if (!name.StartsWith ("android:", StringComparison.OrdinalIgnoreCase))
+						fields.Add (CreateIntField (attrib, name));
+					else {
+						// this is an android:xxx resource, we should not calcuate the id
+						// we should get it from "somewhere" maybe the pubic.xml
+						var f = new CodeMemberField (typeof (int), name);
+						f.InitExpression = new CodePrimitiveExpression (0);
+						fields.Add (f);
+					}
+					CreateIntField (styleable, $"{topName}_{name}", i);
+				}
+				CodeArrayCreateExpression c = field.InitExpression as CodeArrayCreateExpression;
+				if (c == null)
+					return;
+				
+				arrayMapping.Add (field, fields.ToArray ());
+			}
 		}
 
 		void ProcessXmlFile (string file)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -454,7 +454,6 @@ namespace Xamarin.Android.Tasks
 
 		void CreateResourceField (string root, string fieldName, XmlReader element = null)
 		{
-			Log.LogMessage (Microsoft.Build.Framework.MessageImportance.High, $"DEBUG!!! {root} {fieldName}");
 			var i = root.IndexOf ('-');
 			var item = i < 0 ? root : root.Substring (0, i);
 			item = resourceNamesToUseDirectly.Contains (root) ? root : item;


### PR DESCRIPTION
You can have versioned resources in android. As a
result you can have duplicate resource entries.
In the case of styleable items we were trying to
use a dictionary to keep track of the items which
we need to generate id's for. However because we
where comming across duplicate resource entires
we were crashing with a

	System.ArgumentException: An item with the same key has already been added.

This was because we had already created that `CodeMemberField`
and added it to the dictionary. What we need to do is skip over
items which have already been added.

Another problem with this was the order in which we
generated the styleable items. Adding the new `MultiSelectListPreference`
item caused the `ManagedResourceParser` to produce
different results. It turns out that android does some
sorting on the values and fields it produces for
the `Styleable` items.

Given the following xml declaration

	  <declare-styleable name="MultiSelectListPreference">
		<attr name="entries"/>
		<attr name="android:entries"/>
		<attr name="entryValues"/>
		<attr name="android:entryValues"/>
	</declare-styleable>

the following is produced in the `R.txt` file.

	int[] styleable MultiSelectListPreference { 0x010100b2, 0x010101f8, 0x7f030001, 0x7f030002 }
	int styleable MultiSelectListPreference_android_entries 0
	int styleable MultiSelectListPreference_android_entryValues 1
	int styleable MultiSelectListPreference_entries 2
	int styleable MultiSelectListPreference_entryValues 3

Note that the items are ordered alphabetically and NOT by the
order in which they appear in the xml. This needs to be done
BEFORE we actaully generate or lookup the actual id values
for these items. This is so they have the correct `index` into
the `MultiSelectListPreference` array. This commit also
fixes up this issue.

Unit test has been modified to take into account these new
senarios.