### PR TITLE
[Xamarin.Android.Build.Tasks] Debug Shared Runtime deployment attempts are crashing on startup

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -308,10 +308,8 @@ namespace Xamarin.Android.Tasks
 		void WriteTypeMappings (List<TypeDefinition> types)
 		{
 			void logger (TraceLevel level, string value) => Log.LogDebugMessage (value);
-			TypeNameMapGenerator createTypeMapGenerator () => UseSharedRuntime ?
-				new TypeNameMapGenerator (types, logger) :
-				new TypeNameMapGenerator (ResolvedAssemblies.Select (p => p.ItemSpec), logger);
-			using (var gen = createTypeMapGenerator ()) {
+			TypeNameMapGenerator generator = new TypeNameMapGenerator (ResolvedAssemblies.Select (p => p.ItemSpec), logger);
+			using (var gen = generator) {
 				using (var ms = new MemoryStream ()) {
 					UpdateWhenChanged (Path.Combine (OutputDirectory, "typemap.jm"), "jm", ms, gen.WriteJavaToManaged);
 					UpdateWhenChanged (Path.Combine (OutputDirectory, "typemap.mj"), "mj", ms, gen.WriteManagedToJava);


### PR DESCRIPTION
Fixes #3081

When running an app using the shared runtime we get
the following

	Unhandled Exception : System.ArgumentException: Handle must be valid.

This was tracked down to the information in the `typemap.mj.inc`
file. Here are the file sizes for that file, one with the shared
runtime enabled, one without

	ls -la typemap.mj.inc    <- shared runtime
	-rw-r--r--  1 d  staff  462  9 May 09:42 typemap.mj.inc
	ls -la obj/Debug/android/typemap.mj.inc   <- not shared runtime
	-rw-r--r--  1 d  staff  8982060  9 May 09:43 obj/Debug/android/typemap.mj.inc

As you can see, the shared runtime file is missing a huge
amount of data. In the past when we generated the old typemap
files we only needed to generate the mapping for the types
in the user assemblies. This is because when using the
shared runtime,it already included the mappings. However
in the new system these are now compiled into the `libxamarin-app.so`
native library. This means that even when using the shared
runtime we should be generating ALL the mappings in that
library.

This commit removes the bit of code in `GenerateJavaStubs` which
limits the types being exported when using the shared runtime.