### PR TITLE
[build] Allow Windows to override `$(JavaSdkDirectory)`

### DIFF
--- a/Documentation/building/configuration.md
+++ b/Documentation/building/configuration.md
@@ -122,6 +122,13 @@ Overridable MSBuild properties include:
     build and reference projects from. By default, this is
     `external/Java.Interop` directory, maintained by `git submodule update`.
 
+  * `$(JavaSdkDirectory)`: The JDK directory.  `$(JavaSdkDirectory)\bin\java`,
+    `$(JavaSdkDirectory)\bin\javac`, and `$(JavaSdkDirectory)\bin\jar` must
+    exist.
+
+    If not specified, we'll attempt to use a default based on e.g. the
+    `JAVA_HOME` environment variable and other "known" directories.
+
   * `$(MakeConcurrency)`: **make**(1) parameters to use intended to influence
     the number of CPU cores used when **make**(1) executes. By default this uses
     `-jCOUNT`, where `COUNT` is obtained from `sysctl hw.ncpu`.

--- a/build-tools/scripts/Windows-Configuration.OperatingSystem.props.in
+++ b/build-tools/scripts/Windows-Configuration.OperatingSystem.props.in
@@ -9,9 +9,9 @@
     <HostTriplet64 Condition=" '$(HostTriplet64)' == '' ">x86_64-win32</HostTriplet64>
     <HostCpuCount Condition=" '$(HostCpuCount)' == '' ">$([System.Environment]::ProcessorCount)</HostCpuCount>
     <HostBits Condition=" '$(HostBits)' == '' ">64</HostBits>
-    <JavaSdkDirectory>@JAVA_HOME@</JavaSdkDirectory>
-    <JavaCPath>$(JavaSdkDirectory)\bin\javac.exe</JavaCPath>
-    <JarPath>$(JavaSdkDirectory)\bin\jar.exe</JarPath>
-    <JavaPath>$(JavaSdkDirectory)\bin\java.exe</JavaPath>
+    <JavaSdkDirectory Condition=" '$(JavaSdkDirectory)' == '' ">@JAVA_HOME@</JavaSdkDirectory>
+    <JavaCPath Condition=" '$(JavaCPath)' == '' ">$(JavaSdkDirectory)\bin\javac.exe</JavaCPath>
+    <JarPath Condition=" '$(JarPath)' == '' ">$(JavaSdkDirectory)\bin\jar.exe</JarPath>
+    <JavaPath Condition=" '$(JavaPath)' == '' ">$(JavaSdkDirectory)\bin\java.exe</JavaPath>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Allow `$(JavaSdkDirectory)` to be specified within
`Configuration.Override.props` to control the JDK location.