### PR TITLE
[java-runtimes] Set `%JAVA_HOME%`

### DIFF
--- a/src/java-runtime/java-runtime.targets
+++ b/src/java-runtime/java-runtime.targets
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
 <ItemGroup>
   <_RuntimeOutput Include="$(OutputPath)java_runtime.jar">
     <OutputJar>$(OutputPath)java_runtime.jar</OutputJar>
@@ -52,11 +53,15 @@
   />
 </Target>
 <Target Name="_GenerateRuntimeDex16"
-      AfterTargets="Build"
-      Inputs="@(_RuntimeOutput->'%(Identity)')"
-      Outputs="@(_RuntimeOutput->'%(OutputDex)')">
+    AfterTargets="Build"
+    Inputs="@(_RuntimeOutput->'%(Identity)')"
+    Outputs="@(_RuntimeOutput->'%(OutputDex)')">
+  <PropertyGroup>
+    <_JavaHome Condition=" '$(JAVA_HOME)' == '' And '$(JavaSdkDirectory)' != '' ">JAVA_HOME=$(JavaSdkDirectory)</_JavaHome>
+  </PropertyGroup>
   <Exec
       Command="&quot;$(AndroidSdkDirectory)\build-tools\$(XABuildToolsFolder)\dx&quot; --dex --no-strict --output=&quot;%(_RuntimeOutput.OutputDex)&quot; &quot;%(_RuntimeOutput.OutputJar)&quot;"
+      EnvironmentVariables="$(_JavaHome)"
   />
 </Target>
 </Project>


### PR DESCRIPTION
For some unknown reason, the JDK environment on @jonpryor's Windows
machine is "wonky," in that the `src\java-runtimes` directory fails
to build because the Android SDK `dx` command fails to execute
because `dx` cannot find Java:

	> cd src\java-runtimes
	> msbuild
	...
	ERROR: No suitable Java found. In order to properly use the Android Developer
	Tools, you need a suitable version of Java JDK installed on your system.
	We recommend that you install the JDK version of JavaSE, available here:
	  http://www.oracle.com/technetwork/java/javase/downloads

	If you already have Java installed, you can define the JAVA_HOME environment
	variable in Control Panel / System / Avanced System Settings to point to the
	JDK folder.

	You can find the complete Android SDK requirements here:
	  http://developer.android.com/sdk/requirements.html

This happens when:

 1. `%JAVA_HOME%` refers to a non-existent directory.
    (*How* @jonpryor got an invalid directory in there...)  *or*

 2. `%JAVA_HOME%` is empty and `$(JavaSdkDirectory)` refers to a
    *valid* directory.

(Again, why this happens to @jonpryor but not others on the team has
not yet been determined.)

Fix this by explicitly providing `%JAVA_HOME%` within the `<Exec/>`
task which executes `dx`, so that `java` can be found.