### PR TITLE
Bump to mono/mono@1ce13bb

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -20,6 +20,10 @@
     <UseCommercialInstallerName Condition="'$(UseCommercialInstallerName)' == ''">False</UseCommercialInstallerName>
   </PropertyGroup>
   <ItemGroup>
+    <_DesignerFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\bcl\**\*" />
+    <_DesignerFilesWin Include="$(MSBuildSrcDir)\bcl\**\* "/>
+  </ItemGroup>
+  <ItemGroup>
     <_FrameworkFiles Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\AndroidApiInfo.xml" />
     <_FrameworkFiles Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\mono.android.dex" />
     <_FrameworkFiles Include="$(FrameworkSrcDir)\$(FirstInstallerFrameworkVersion)\Mono.Android.dll" />
@@ -266,11 +270,17 @@
       <MSBuildItemsWin Include="@(_MSBuildLibHostFilesWin)">
         <RelativePath>%(Filename)%(Extension)</RelativePath>
       </MSBuildItemsWin>
+      <MSBuildItemsWin Include="@(_DesignerFilesWin)">
+        <RelativePath>bcl\%(RecursiveDir)\%(Filename)%(Extension)</RelativePath>
+      </MSBuildItemsWin>
       <MSBuildItemsUnix Include="@(_MSBuildFiles);@(_MSBuildFilesUnix)">
         <RelativePath>$([MSBuild]::MakeRelative($(MSBuildSrcDir), %(FullPath)))</RelativePath>
       </MSBuildItemsUnix>
       <MSBuildItemsUnix Include="@(_MSBuildTargetsSrcFiles)">
         <RelativePath>$([MSBuild]::MakeRelative($(MSBuildTargetsSrcDir), %(FullPath)))</RelativePath>
+      </MSBuildItemsUnix>
+      <MSBuildItemsUnix Include="@(_DesignerFilesUnix)">
+        <RelativePath>$(HostOS)\bcl\%(RecursiveDir)\%(Filename)%(Extension)</RelativePath>
       </MSBuildItemsUnix>
     </ItemGroup>
   </Target>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2109,7 +2109,7 @@ because xbuild doesn't support framework reference assemblies.
     <_AssembliesToProcess Include="@(ResolvedAssemblies)" Condition=" '%(Filename)' != '' And '@(_JniFrameworkAssembly)' != '' " />
   </ItemGroup>
   <Exec
-       Command="MONO_CONFIG=&quot;$(MonoAndroidBinDirectory)mono.config&quot; MONO_PATH=&quot;$(_XATargetFrameworkDirectories):$(MonoAndroidLinkerInputDir)&quot; &quot;$(MonoAndroidBinDirectory)mono&quot; --debug &quot;$(MonoAndroidToolsDirectory)\jnimarshalmethod-gen.exe&quot; --jvm=&quot;$(JdkJvmPath)&quot; $(AndroidGenerateJniMarshalMethodsAdditionalArguments) @(_AssembliesToProcess->'&quot;$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)&quot;', ' ')"
+       Command="MONO_CONFIG=&quot;$(MonoAndroidBinDirectory)mono.config&quot; MONO_PATH=&quot;$(MonoAndroidBinDirectory)\bcl&quot;:&quot;$(MonoAndroidBinDirectory)\bcl\Facades&quot;:&quot;$(_XATargetFrameworkDirectories):$(MonoAndroidLinkerInputDir)&quot; &quot;$(MonoAndroidBinDirectory)mono&quot; --debug &quot;$(MonoAndroidToolsDirectory)\jnimarshalmethod-gen.exe&quot; --jvm=&quot;$(JdkJvmPath)&quot; $(AndroidGenerateJniMarshalMethodsAdditionalArguments) @(_AssembliesToProcess->'&quot;$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)&quot;', ' ')"
   />
   <Touch Files="$(_AndroidJniMarshalMethodsFlag)" AlwaysCreate="True" />
 </Target>

--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -681,10 +681,10 @@
       <BundleItem Include="$(_MSBuildDir)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName).d%(_MonoCrossRuntime.ExeSuffix)" Condition=" '@(_MonoCrossRuntime)' != '' " />
       <BundleItem Include="$(_MSBuildDir)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)" Condition=" '@(_MonoCrossRuntime)' != '' " />
       <BundleItem Include="@(_BclTestOutput)" />
-      <BundleItem Include="@(MonoFacadeAssembly->'$(_MonoArchiveBclDir)\Facades\%(Identity)')" />
-      <BundleItem Include="@(MonoProfileAssembly->'$(_MonoArchiveBclDir)\%(Identity)')" />
-      <BundleItem Include="@(MonoFacadeAssembly->'$(_WindowsMonoArchiveBclDir)\Facades\%(Identity)')" />
-      <BundleItem Include="@(MonoProfileAssembly->'$(_WindowsMonoArchiveBclDir)\%(Identity)')" />
+      <BundleItem Include="@(MonoFacadeAssembly->'$(_MSBuildDir)\$(HostOS)\bcl\Facades\%(Identity)')" />
+      <BundleItem Include="@(MonoProfileAssembly->'$(_MSBuildDir)\$(HostOS)\bcl\%(Identity)')" />
+      <BundleItem Include="@(MonoFacadeAssembly->'$(_MSBuildDir)\bcl\Facades\%(Identity)')" />
+      <BundleItem Include="@(MonoProfileAssembly->'$(_MSBuildDir)\bcl\%(Identity)')" />
     </ItemGroup>
   </Target>
 

--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -168,7 +168,11 @@
       <Output TaskParameter="CommitHash"   PropertyName="_MonoGitCommitHash" />
     </GitCommitHash>
     <PropertyGroup>
+      <_MonoArchiveUriBase>https://xamjenkinsartifact.azureedge.net/mono-sdks</_MonoArchiveUriBase>
       <_MonoArchiveName>android-$(_MonoSdksConfiguration)-$(HostOS)-$(_MonoGitCommitHash)</_MonoArchiveName>
+      <_WindowsMonoArchiveName>android-release-Windows-$(_MonoGitCommitHash)</_WindowsMonoArchiveName>
+      <_MonoArchiveBclDir>$(_MSBuildDir)\$(HostOS)\bcl</_MonoArchiveBclDir>
+      <_WindowsMonoArchiveBclDir>$(_MSBuildDir)\bcl</_WindowsMonoArchiveBclDir>
     </PropertyGroup>
   </Target>
 
@@ -302,18 +306,21 @@
 
   <Target Name="_DownloadArchive"
       DependsOnTargets="_GetMonoGitCommitHash"
-      Condition=" !Exists('$(MonoSourceFullPath)\sdks\out\.stamp-$(_MonoArchiveName)-build') And !Exists('$(MonoSourceFullPath)\sdks\out\.stamp-$(_MonoArchiveName)-download') " >
+      Condition=" !Exists('$(MonoSourceFullPath)\sdks\out\.stamp-$(_MonoArchiveName)-build') And !Exists('$(MonoSourceFullPath)\sdks\out\.stamp-$(_MonoArchiveName)-download') And !Exists('$(MonoSourceFullPath)\sdks\out\.stamp-$(_WindowsMonoArchiveName)-download') " >
     <MakeDir
         Directories="$(MonoSourceFullPath)\sdks\out"
     />
     <DownloadUri
-        SourceUris="https://xamjenkinsartifact.azureedge.net/mono-sdks/$(_MonoArchiveName).zip"
+        SourceUris="$(_MonoArchiveUriBase)/$(_MonoArchiveName).zip"
         DestinationFiles="$(AndroidToolchainCacheDirectory)\$(_MonoArchiveName).zip"
         ContinueOnError="True"
     />
     <PropertyGroup>
       <_UnzipTempPath>$(MonoSourceFullPath)\sdks\.out.$([System.IO.Path]::GetRandomFileName())</_UnzipTempPath>
+      <_HostBclFilesDir>$(MonoSourceFullPath)\sdks\out\android-bcl\monodroid</_HostBclFilesDir>
+      <_WindowsBclFilesDir>$(_WindowsMonoArchiveBclDir)\android-bcl\monodroid</_WindowsBclFilesDir>
     </PropertyGroup>
+
     <SystemUnzip
         HostOS="$(HostOS)"
         SourceFiles="$(AndroidToolchainCacheDirectory)\$(_MonoArchiveName).zip"
@@ -323,6 +330,7 @@
     <RemoveDir
         Directories="$(_UnzipTempPath)"
     />
+
     <ItemGroup>
       <_ExtractedSdkFiles Include="$(MonoSourceFullPath)\sdks\out\**\*" />
     </ItemGroup>
@@ -337,6 +345,63 @@
         Files="$(MonoSourceFullPath)\sdks\out\.stamp-$(_MonoArchiveName)-download"
         AlwaysCreate="True"
     />
+    <MakeDir
+        Directories="$(_MonoArchiveBclDir)\Facades"
+    />
+    <ItemGroup>
+      <_ExtractedAndroidMainBclFiles Include="$(_HostBclFilesDir)\*" Exclude="$(_HostBclFilesDir)\*.pdb;$(_HostBclFilesDir)\*.unsafe.dll.tmp;$(_HostBclFilesDir)\Consts.cs" />
+      <_ExtractedAndroidFacadeBclFiles Include="$(_HostBclFilesDir)\Facades\*" Exclude="$(_HostBclFilesDir)\Facades\*.pdb;$(_HostBclFilesDir)\Facades\.stamp" />
+    </ItemGroup>
+    <Copy
+        SourceFiles="@(_ExtractedAndroidMainBclFiles)"
+        DestinationFiles="@(_ExtractedAndroidMainBclFiles->'$(_MonoArchiveBclDir)\%(Filename)%(Extension)')"
+    />
+    <Copy
+        SourceFiles="@(_ExtractedAndroidFacadeBclFiles)"
+        DestinationFiles="@(_ExtractedAndroidFacadeBclFiles->'$(_MonoArchiveBclDir)\Facades\%(Filename)%(Extension)')"
+    />
+
+    <MakeDir
+        Directories="$(_WindowsMonoArchiveBclDir)\Facades"
+    />
+    <DownloadUri
+        SourceUris="$(_MonoArchiveUriBase)/$(_WindowsMonoArchiveName).zip"
+        DestinationFiles="$(AndroidToolchainCacheDirectory)\$(_WindowsMonoArchiveName).zip"
+        ContinueOnError="True"
+    />
+    <PropertyGroup>
+      <_UnzipTempPath>$(_MSBuildDir)\.windows-bcl.$([System.IO.Path]::GetRandomFileName())</_UnzipTempPath>
+    </PropertyGroup>
+    <SystemUnzip
+        HostOS="$(HostOS)"
+        SourceFiles="$(AndroidToolchainCacheDirectory)\$(_WindowsMonoArchiveName).zip"
+        DestinationFolder="$(_WindowsMonoArchiveBclDir)"
+        TempUnzipDir="$(_UnzipTempPath)"
+    />
+    <RemoveDir
+        Directories="$(_UnzipTempPath)"
+    />
+    <ItemGroup>
+      <_ExtractedWindowsAndroidMainBclFiles Include="$(_WindowsBclFilesDir)\*" Exclude="$(_WindowsBclFilesDir)\*.pdb;$(_WindowsBclFilesDir)\*.unsafe.dll.tmp;$(_WindowsBclFilesDir)\Consts.cs" />
+      <_ExtractedWindowsAndroidFacadeBclFiles Include="$(_WindowsBclFilesDir)\Facades\*" Exclude="$(_WindowsBclFilesDir)\Facades\*.pdb;$(_WindowsBclFilesDir)\Facades\.stamp" />
+    </ItemGroup>
+    <Copy
+        SourceFiles="@(_ExtractedWindowsAndroidMainBclFiles)"
+        DestinationFiles="@(_ExtractedWindowsAndroidMainBclFiles->'$(_WindowsMonoArchiveBclDir)\%(Filename)%(Extension)')"
+    />
+    <Copy
+        SourceFiles="@(_ExtractedWindowsAndroidFacadeBclFiles)"
+        DestinationFiles="@(_ExtractedWindowsAndroidFacadeBclFiles->'$(_WindowsMonoArchiveBclDir)\Facades\%(Filename)%(Extension)')"
+    />
+    <RemoveDir
+        Directories="$(_WindowsMonoArchiveBclDir)\android-bcl"
+    />
+    <Touch
+        Condition=" Exists('$(AndroidToolchainCacheDirectory)\$(_WindowsMonoArchiveName).zip') "
+        Files="$(MonoSourceFullPath)\sdks\out\.stamp-$(_WindowsMonoArchiveName)-download"
+        AlwaysCreate="True"
+    />
+
   </Target>
 
   <Target Name="_Build"
@@ -616,6 +681,10 @@
       <BundleItem Include="$(_MSBuildDir)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName).d%(_MonoCrossRuntime.ExeSuffix)" Condition=" '@(_MonoCrossRuntime)' != '' " />
       <BundleItem Include="$(_MSBuildDir)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)" Condition=" '@(_MonoCrossRuntime)' != '' " />
       <BundleItem Include="@(_BclTestOutput)" />
+      <BundleItem Include="@(MonoFacadeAssembly->'$(_MonoArchiveBclDir)\Facades\%(Identity)')" />
+      <BundleItem Include="@(MonoProfileAssembly->'$(_MonoArchiveBclDir)\%(Identity)')" />
+      <BundleItem Include="@(MonoFacadeAssembly->'$(_WindowsMonoArchiveBclDir)\Facades\%(Identity)')" />
+      <BundleItem Include="@(MonoProfileAssembly->'$(_WindowsMonoArchiveBclDir)\%(Identity)')" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Add build-time support for *Windows* [mono archives][0].

Context: [xamarin-android/d16-2-with-mono-2018-10-via-6e8a50ea][1]
Context: https://github.com/mono/mono/pull/14307
Context: https://github.com/mono/mono/issues/14333

Fixes: https://github.com/mono/mono/issues/13150
Fixes: https://github.com/mono/mono/issues/14223
Fixes: https://github.com/mono/mono/issues/14247
Fixes: https://github.com/mono/mono/issues/14290

The [Xamarin.Android Designer][2] is an interesting beast: it runs a
Xamarin.Android-like Java stack on desktop macOS and Windows.  A Java
process is created, and that Java process loads:

  * *Desktop* Mono via `libmonosgen-2.0.dylib` (macOS)` or
    `libmonosgen-2.0.dll` (Windows).`
  * The Xamarin.Android runtime via `libmono-android.debug.dylib`
    (macOS) or `libmono-android.debug.dll` (Windows)
  * Other Java code (to render items to the screen)
  * `Mono.Android.dll` and other user assemblies (to render items to
    the screen).

Being "interesting" means it introduces all kinds of "fun":
`libmono-android.debug.dll` needs to be built *for Windows* (which is
why there's `#if WINDOWS` within `src/monodroid`),
`libmonosgen-2.0.dll` needs to be built for Windows (not a huge
issue), and -- "equally" important but *more* important regarding the
next few paragraphs! -- `mscorlib.dll` needs to target Windows.

`mscorlib.dll` is where things get annoying.  Once Upon A Time™,
Mono's `mscorlib.dll` was platform agnostic: build it for one
platform, it would run everywhere, as it would internally perform
runtime OS-checks to behave appropriately on Unix/Windows/etc.

That hasn't been true for awhile, but the Xamarin.Android build and
install environment still assumes it to be true.  Consequently, a
"Unix" `mscorlib.dll` is used by the Designer on Windows.  This
[*apparently* (?)][3] hasn't blown up catastrophically before, but
with the mono/2019-02 migration (b8c30f9) we have now entered
"catastrophic" territory: [Designer integration tests on Windows][4]
may fail because `System.Native` cannot be found:

	System.TypeInitializationException: The type initializer for 'System.Console' threw an exception. ---> System.DllNotFoundException: System.Native

The fix?  We need a *Windows*-targeting build of `mscorlib.dll` and
other BCL assemblies, in this case one that *doesn't* use the
`System.Native` native library in P/Invokes.

Enter the [Multi-platform monodroid BCL builds mono epic][5]: instead
of mono building and providing a *single* "mono archive" which
contains files for *every* supported architecture (macOS, Windows,
Android), mono will instead provide [*multiple* mono archives][6],
each supporting a particular subset.  For example, the
[archives for mono/2019-02@0bd00ec][7] include:

  * `android-release-Windows-0bd00ec58809f2a6ec5feff587b1117255b080fd.zip`:
    `monodroid`-profile BCL assemblies built to run on Windows.

  * `android-release-Darwin-0bd00ec58809f2a6ec5feff587b1117255b080fd.zip`:
    `monodroid`-profile BCl assemblies built to run on macOS, *and*
    `libmonosgen-2.0.dylib` for macOS, *and* `libmonosgen-2.0.dll`
    for Win32 & Win64, *and*...everything else (for now).

Thus, the fix for Designer-on-Windows: Download *all* required mono
archives (both Darwin & Windows for now) -- not just the Darwin
archive -- and extract those archives where the xamarin-android build
requires them to be.

Host-specific BCL files are placed into the
`$(MonoAndroidBinDirectory)\bcl`, e.g. the macOS-targeting
`mscorlib.dll` will be installed into:

	…/lib/xamarin.android/xbuild/Xamarin/Android/Darwin/bcl/mscorlib.dll

While Windows (currently) omits the OS name, and will install into:

	…/Xamarin/Android/bcl/mscorlib.dll

TODO:

  * Many of the host-specific BCL assemblies are "identical enough"
    to the Android-targeting BCL assemblies, e.g. the only difference
    between `System.Net.dll` for Windows & Android is the MVID GUID.
    We could be smarter about which files we redistribute, which
    would shrink the installation size.

  * Stop special-casing Windows within `$(MonoAndroidBinDirectory)`.
    Windows-specific files such as `cross-arm.exe` should be
    installed into `…/Xamarin/Android/Windows/cross-arm.exe`, and
    use `…/Xamarin/Android/Windows/bcl/mscorlib.dll` for the
    Windows-targeting monodroid-profile `mscorlib.dll`.

[0]: https://github.com/xamarin/xamarin-android/projects/10
[1]: https://github.com/xamarin/xamarin-android/commit/1f003cc51e7a0880389f97d282c3a0d2f80bf6c2
[2]: https://docs.microsoft.com/en-us/xamarin/android/user-interface/android-designer/
[3]: https://developercommunity.visualstudio.com/content/problem/440975/xamarin-xaml-designer-still-fails.html
[4]: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2634805
[5]: https://github.com/mono/mono/issues/14333
[6]: https://jenkins.mono-project.com/view/All/job/archive-mono/
[7]: https://jenkins.mono-project.com/view/All/job/archive-mono/job/2019-02/232/Azure/
