### PR TITLE
[tests] Fix the MSBuild device tests

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
@@ -41,6 +41,8 @@ namespace Xamarin.Android.Build.Tests
 					string className = "Lcom/xamarin/forms/platform/android/FormsViewGroup;";
 					Assert.IsFalse (DexUtils.ContainsClass (className, dexFile, b.AndroidSdkDirectory), $"`{dexFile}` should *not* include `{className}`!");
 					className = "Lmono/MonoRuntimeProvider;";
+					Assert.IsFalse (DexUtils.ContainsClass (className, dexFile, b.AndroidSdkDirectory), $"`{dexFile}` should include `{className}`!");
+					className = "Lmono/MonoPackageManager;";
 					Assert.IsTrue (DexUtils.ContainsClass (className, dexFile, b.AndroidSdkDirectory), $"`{dexFile}` should include `{className}`!");
 				} finally {
 					File.Delete (dexFile);

--- a/tests/RunApkTests.targets
+++ b/tests/RunApkTests.targets
@@ -48,7 +48,6 @@
   <Target Name="RunNUnitDeviceTests" DependsOnTargets="$(RunNUnitDeviceTestsDependsOn)"/>
 
   <Target Name="RunMSBuildDeviceIntegration">
-    <SetEnvironmentVariable Name="USE_MSBUILD" Value="0" Condition=" '$(USE_MSBUILD)' == '' " />
     <ItemGroup>
       <NUnitTarget Include="@(_DeviceTestAssembly)">
         <TestFilename>%(_DeviceTestAssembly.Filename)</TestFilename>


### PR DESCRIPTION
There were a couple of problems with the
device tests. Firstly we were exporting
the `USE_MSBUILD` property this was causing
the old `__NonExistentFile__` file build
issue which causes `CoreCompile` to always
run.

The second was we were looking for `MonoRuntimeProvider`
in the `classes.dex` file in the apk. However with the
new enhanced fast deployment we no longer include that
file. So we need to check it does NOT exist, bit
check that `MonoPackageManager` is included instead.