### PR TITLE
[Xamarin.Android.Build.Tasks] more logging in <BuildApk/>

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -148,8 +148,7 @@ namespace Xamarin.Android.Tools {
 					File.WriteAllText (destination + ".hash", hash);
 #endif
 				return true;
-			}/* else
-				Console.WriteLine ("Skipping copying {0}, unchanged", Path.GetFileName (destination));*/
+			}
 
 			return false;
 		}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/blob/373c6ed08bef01274bd4abfe330d50327052e067/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs#L195
Context: https://github.com/xamarin/xamarin-android/blob/373c6ed08bef01274bd4abfe330d50327052e067/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs#L271

Testing locally, code changes were not making it onto my device...

Reviewing the build logs:

1. `_CopyPackage` was skipped
2. `CopyIfZipChanged` was returning `false`
3. The `CRC` values of each item in the APK was reporting `0`???

I decided to nuke my build tree with `git clean -dxf` and rebuild.
Then it worked fine... I must have had an outdated `libzip.dll` that
was broken?

This makes me nervous, but there is something to improve here.

There was not really sufficient logging for me to understand what
happened without making code changes to the MSBuild tasks. So I think
it is a good idea to log the result of `CopyIfZipChanged`, if we need
to review what is happening from customer build logs in the future.

I also removed a commented out `Console.WriteLine()`.