### PR TITLE
[mono-runtimes] Fix _BuildUnlessCached

### DIFF
--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -657,6 +657,13 @@
 
   <Target Name="GetMonoBundleItems"
       DependsOnTargets="_GetRuntimesOutputItems;_GetLlvmOutputItems">
+    <PropertyGroup>
+      <_BundleHostOS Condition=" '$(HostOS)' == 'Windows' ">Darwin</_BundleHostOS>
+      <_BundleHostOS Condition=" '$(_BundleHostOS)' == '' ">$(HostOS)</_BundleHostOS>
+    </PropertyGroup>
+    <ItemGroup>
+      <_WinExcludeAssembly Include="Mono.Btls.Interface.dll" />
+    </ItemGroup>
     <ItemGroup>
       <BundleItem Include="@(_BclInstalledItem)" />
       <BundleItem Include="@(_MonoDocInstalledItems)" />
@@ -681,10 +688,13 @@
       <BundleItem Include="$(_MSBuildDir)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName).d%(_MonoCrossRuntime.ExeSuffix)" Condition=" '@(_MonoCrossRuntime)' != '' " />
       <BundleItem Include="$(_MSBuildDir)\%(_MonoCrossRuntime.InstallPath)%(_MonoCrossRuntime.CrossMonoName)%(_MonoCrossRuntime.ExeSuffix)" Condition=" '@(_MonoCrossRuntime)' != '' " />
       <BundleItem Include="@(_BclTestOutput)" />
-      <BundleItem Include="@(MonoFacadeAssembly->'$(_MSBuildDir)\$(HostOS)\bcl\Facades\%(Identity)')" />
-      <BundleItem Include="@(MonoProfileAssembly->'$(_MSBuildDir)\$(HostOS)\bcl\%(Identity)')" />
+      <BundleItem Include="@(MonoFacadeAssembly->'$(_MSBuildDir)\$(_BundleHostOS)\bcl\Facades\%(Identity)')" />
+      <BundleItem Include="@(MonoProfileAssembly->'$(_MSBuildDir)\$(_BundleHostOS)\bcl\%(Identity)')" />
       <BundleItem Include="@(MonoFacadeAssembly->'$(_MSBuildDir)\bcl\Facades\%(Identity)')" />
-      <BundleItem Include="@(MonoProfileAssembly->'$(_MSBuildDir)\bcl\%(Identity)')" />
+      <BundleItem
+          Include="@(MonoProfileAssembly->'$(_MSBuildDir)\bcl\%(Identity)')"
+          Exclude="@(_WinExcludeAssembly->'$(_MSBuildDir)\bcl\%(Identity)')"
+      />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/528/
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/528/Azure/processDownloadRequest/xamarin-android/xamarin-android/xa-build-status-v9.4.99.31_Darwin-x86_64_master_8b24a5ee-Release.zip

Commit d5e002e1 inadvertently broke the `_BuildUnlessCached` target.
The result is longer build times, as every time `src/mono-runtimes` is
is built because of a `@(ProjectReference)`, it rebuilds:

	Target "_BuildUnlessCached: (TargetId:1281)" in file "…/xamarin-android/src/mono-runtimes/mono-runtimes.targets" from project "…/xamarin-android/src/mono-runtimes/mono-runtimes.csproj" (target "Build" depends on it):
	Building target "_BuildUnlessCached" completely.
	Output file "…/xamarin-android/bin/Release/lib/xamarin.android/xbuild/Xamarin/Android/bcl/Mono.Btls.Interface.dll" does not exist.
	...
	  unzip "/Users/builder/android-archives/android-release-Darwin-1ce13bb09d464e7ffefbd0072b2d95669d080732.zip" -d "…/xamarin-android/external/mono/sdks/.out.fbzmisgj.p05/db3l09xi.jav" (TaskId:811)

The result is an annoying increase in build times.

The cause of the breakage is twofold:

 1. `@(MonoProfileAssembly)` includes `Mono.Btls.Interface.dll`, and
 2. The `android-release-Windows-*.zip` mono archive doesn't contain
    `Mono.Btls.Interface.dll`.

Apparently `Mono.Btls.Interface.dll` isn't a Mono assembly on Windows.

Fix the `_BuildUnlessCached` behavior by removing
`Mono.Btls.Interface.dll` from the expected Windows BCL files.