### PR TITLE
Bump to xamarin/monodroid/d16-2@1c7dc0b7

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:d16-2@48faeb611654670518b26ae279f9eb8509f685c3
+xamarin/monodroid:d16-2@1c7dc0b742b0dd49b93189730a14eb61dc1e89a5


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/48faeb611654670518b26ae279f9eb8509f685c3...1c7dc0b742b0dd49b93189730a14eb61dc1e89a5

Allow additional extension of build process `PropertyGroup` elements.