### PR TITLE
[tests] update to Xamarin.Forms 4.0.0

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2692,7 +2692,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 
 				proj.PackageReferences.Clear ();
 				//NOTE: we can get all the other dependencies transitively, yay!
-				proj.PackageReferences.Add (KnownPackages.XamarinForms_3_6_0_220655);
+				proj.PackageReferences.Add (KnownPackages.XamarinForms_4_0_0_425677);
 				b.Save (proj, doNotCleanupOnUpdate: true);
 				Assert.IsTrue (b.Build (proj), "second build should have succeeded.");
 				Assert.IsFalse (b.Output.IsTargetSkipped ("_CleanIntermediateIfNuGetsChange"), "`_CleanIntermediateIfNuGetsChange` should have run!");
@@ -2735,7 +2735,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 
 				proj.PackageReferences.Clear ();
 				//NOTE: we can get all the other dependencies transitively, yay!
-				proj.PackageReferences.Add (KnownPackages.XamarinForms_3_6_0_220655);
+				proj.PackageReferences.Add (KnownPackages.XamarinForms_4_0_0_425677);
 				Assert.IsTrue (b.Build (proj, saveProject: true, doNotCleanupOnUpdate: true), "second build should have succeeded.");
 				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "Refreshing Xamarin.Android.Support.v7.AppCompat.dll"), "`ResolveLibraryProjectImports` should not skip `Xamarin.Android.Support.v7.AppCompat.dll`!");
 				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "Deleting unknown jar: support-annotations.jar"), "`support-annotations.jar` should be deleted!");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -473,38 +473,38 @@ namespace Xamarin.ProjectTools
 				},
 			}
 		};
-		public static Package XamarinForms_3_6_0_220655 = new Package {
+		public static Package XamarinForms_4_0_0_425677 = new Package {
 			Id = "Xamarin.Forms",
-			Version = "3.6.0.220655",
+			Version = "4.0.0.425677",
 			TargetFramework = "MonoAndroid90",
 			References =  {
 				new BuildItem.Reference ("Xamarin.Forms.Platform.Android") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.6.0.220655\\lib\\MonoAndroid90\\Xamarin.Forms.Platform.Android.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.4.0.0.425677\\lib\\MonoAndroid90\\Xamarin.Forms.Platform.Android.dll"
 				},
 				new BuildItem.Reference ("FormsViewGroup") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.6.0.220655\\lib\\MonoAndroid90\\FormsViewGroup.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.4.0.0.425677\\lib\\MonoAndroid90\\FormsViewGroup.dll"
 				},
 				new BuildItem.Reference ("Xamarin.Forms.Core") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.6.0.220655\\lib\\MonoAndroid90\\Xamarin.Forms.Core.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.4.0.0.425677\\lib\\MonoAndroid90\\Xamarin.Forms.Core.dll"
 				},
 				new BuildItem.Reference ("Xamarin.Forms.Xaml") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.6.0.220655\\lib\\MonoAndroid90\\Xamarin.Forms.Xaml.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.4.0.0.425677\\lib\\MonoAndroid90\\Xamarin.Forms.Xaml.dll"
 				},
 				new BuildItem.Reference ("Xamarin.Forms.Platform") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.3.6.0.220655\\lib\\MonoAndroid90\\Xamarin.Forms.Platform.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.4.0.0.425677\\lib\\MonoAndroid90\\Xamarin.Forms.Platform.dll"
 				},
 			}
 		};
-		public static Package XamarinFormsMaps_3_6_0_220655 = new Package {
+		public static Package XamarinFormsMaps_4_0_0_425677 = new Package {
 			Id = "Xamarin.Forms.Maps",
-			Version = "3.6.0.220655",
+			Version = "4.0.0.425677",
 			TargetFramework = "MonoAndroid90",
 			References =  {
 				new BuildItem.Reference ("Xamarin.Forms.Maps.Android") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.Maps.3.6.0.220655\\lib\\MonoAndroid90\\Xamarin.Forms.Maps.Android.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.Maps.4.0.0.425677\\lib\\MonoAndroid90\\Xamarin.Forms.Maps.Android.dll"
 				},
 				new BuildItem.Reference ("Xamarin.Forms.Maps") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.Maps.3.6.0.220655\\lib\\MonoAndroid90\\Xamarin.Forms.Maps.dll"
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.Maps.4.0.0.425677\\lib\\MonoAndroid90\\Xamarin.Forms.Maps.dll"
 				},
 			}
 		};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsAndroidApplicationProject.cs
@@ -41,7 +41,7 @@ namespace Xamarin.ProjectTools
 			: base (debugConfigurationName, releaseConfigurationName)
 		{
 			//NOTE: we can get all the other dependencies transitively, yay!
-			PackageReferences.Add (KnownPackages.XamarinForms_3_6_0_220655);
+			PackageReferences.Add (KnownPackages.XamarinForms_4_0_0_425677);
 
 			AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values\\colors.xml") {
 				TextContent = () => colors_xml,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsMapsApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsMapsApplicationProject.cs
@@ -15,7 +15,7 @@ namespace Xamarin.ProjectTools
 
 		public XamarinFormsMapsApplicationProject ()
 		{
-			PackageReferences.Add (KnownPackages.XamarinFormsMaps_3_6_0_220655);
+			PackageReferences.Add (KnownPackages.XamarinFormsMaps_4_0_0_425677);
 			MainActivity = MainActivity.Replace ("//${AFTER_FORMS_INIT}", "Xamarin.FormsMaps.Init (this, savedInstanceState);");
 			//NOTE: API_KEY metadata just has to *exist*
 			AndroidManifest = AndroidManifest.Replace ("</application>", "<meta-data android:name=\"com.google.android.maps.v2.API_KEY\" android:value=\"\" /></application>");


### PR DESCRIPTION
Context: https://github.com/xamarin/Xamarin.Forms/issues/6250

Xamarin.Forms 4.0.0.425677 just went stable.

I've seen an issue with r8 that happens with XF 4.0 and *not* 3.6, so
I thought it would be worth upgrading our MSBuild tests to see if any
tests fail.