### PR TITLE
[r8] update to 1.4.93

### DIFF
--- a/Documentation/guides/messages/xa4306.md
+++ b/Documentation/guides/messages/xa4306.md
@@ -1,0 +1,26 @@
+---
+title: Xamarin.Android warning XA4306
+description: XA4306 warning code
+ms.date: 05/28/2019
+---
+# Xamarin.Android warning XA4306
+
+## Issue
+
+[d8/r8][r8_source] does not support using custom `multidex.keep` files
+if `minSdkVersion` >= 21, e.g. devices where native multidex is
+supported. In theses cases, d8/r8 calculates the contents of the main
+`classes.dex` without rules specified by developers.
+
+[This change][r8_commit] in d8/r8 appeared in version 1.4.93.
+
+## Solution
+
+Verify you are not declaring any `MultiDexMainDexList` build items.
+
+Consider submitting a [bug][bug] if your application does not function
+after removing any `MultiDexMainDexList` items.
+
+[r8_source]: https://r8.googlesource.com/
+[r8_commit]: https://r8.googlesource.com/r8/+/0e5c4339df0207a0e38f11438db84b29f328f777%5E%21/
+[bug]: https://github.com/xamarin/xamarin-android/wiki/Submitting-Bugs,-Feature-Requests,-and-Pull-Requests

--- a/src/Xamarin.Android.Build.Tasks/Tasks/D8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/D8.cs
@@ -45,6 +45,8 @@ namespace Xamarin.Android.Tasks
 
 		protected virtual string MainClass => "com.android.tools.r8.D8";
 
+		protected int MinSdkVersion { get; set; }
+
 		protected virtual CommandLineBuilder GetCommandLineBuilder ()
 		{
 			var cmd = new CommandLineBuilder ();
@@ -66,8 +68,10 @@ namespace Xamarin.Android.Tasks
 			//NOTE: if this is blank, we can omit --min-api in this call
 			if (!string.IsNullOrEmpty (AndroidManifestFile)) {
 				var doc = AndroidAppManifest.Load (AndroidManifestFile, MonoAndroidHelper.SupportedVersions);
-				int minApiVersion = doc.MinSdkVersion == null ? 4 : (int)doc.MinSdkVersion;
-				cmd.AppendSwitchIfNotNull ("--min-api ", minApiVersion.ToString ());
+				if (doc.MinSdkVersion.HasValue) {
+					MinSdkVersion = doc.MinSdkVersion.Value;
+					cmd.AppendSwitchIfNotNull ("--min-api ", MinSdkVersion.ToString ());
+				}
 			}
 
 			if (!EnableDesugar)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -51,7 +51,9 @@ namespace Xamarin.Android.Tasks
 			var cmd = base.GetCommandLineBuilder ();
 
 			if (EnableMultiDex) {
-				if (string.IsNullOrEmpty (MultiDexMainDexListFile)) {
+				if (MinSdkVersion >= 21) {
+					Log.LogCodedWarning ("XA4306", "R8 does not support `MultiDexMainDexList` files when android:minSdkVersion >= 21");
+				} else if (string.IsNullOrEmpty (MultiDexMainDexListFile)) {
 					Log.LogCodedWarning ("XA4305", $"MultiDex is enabled, but '{nameof (MultiDexMainDexListFile)}' was not specified.");
 				} else {
 					var content = new List<string> ();

--- a/src/r8/build.gradle
+++ b/src/r8/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
 }
 
-// See: https://r8.googlesource.com/r8/+/refs/tags/1.3.52/build.gradle#52
+// See: https://r8.googlesource.com/r8/+/refs/tags/1.4.93/build.gradle#52
 repositories {
     maven { url 'https://maven.google.com' }
     maven { url 'https://kotlin.bintray.com/kotlinx' }
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'com.android.tools', name: 'r8', version: '1.3.52'
+    compile group: 'com.android.tools', name: 'r8', version: '1.4.93'
 }
 
 jar {


### PR DESCRIPTION
Context: https://mvnrepository.com/artifact/com.android.tools/r8/1.4.93
Context: https://r8.googlesource.com/r8/+/refs/tags/1.4.93/

Updating to the latest R8, we hit a problem...

In R8 1.4.93, they appear to have removed support for custom
`multidex.keep` files when `minSdkVersion` >= 21. R8 decides on its
own if multidex is needed, and splits up dex files appropriately.

The new error message was added here:

https://r8.googlesource.com/r8/+/0e5c4339df0207a0e38f11438db84b29f328f777%5E%21/

Since `r8.jar` will now abort with an error if you specify
`multidex.keep` files and `minSdkVersion` >= 21. I feel all we can do
in this case is add a new warning if developers specify
`@(MultiDexMainDexList)` with R8--then allow R8 to calculate multidex
on its own.

We looked a bit, and did not find much usage of the
`@(MultiDexMainDexList)` item group:

https://github.com/search?q=MultiDexMainDexList&type=Code

The examples of `multidex.keep` files we found, looked like they
shouldn't be needed anyway.

I updated the `MultiDexCustomMainDexFileList` test to check dx/d8 and
API 19/21. R8 appears to create multiple dex files without any
multidex rules or `multidex.keep` files.