### PR TITLE
[Xamarin.Android.Build.Tasks] fix for MonoPackageManager.java from 16.1

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1921,15 +1921,14 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_CleanupOldStaticResources"
-    Condition="Exists ('$(MonoAndroidIntermediate)android\src\mono\app\ApplicationRegistration.java')">
+    Condition=" Exists ('$(MonoAndroidIntermediate)android\src\mono\android\app\NotifyTimeZoneChanges.java') ">
   <ItemGroup>
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\MultiDexLoader.java" />
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\android\ResourcePatcher.java" />
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\MonoPackageManager.java" />
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\IncrementalClassLoader.java" />
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\Placeholder.java" />
-    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\app\ApplicationRegistration.java" />
-    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\app\NotifyTimeZoneChanges.java" />
+    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\android\app\NotifyTimeZoneChanges.java" />
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\MonkeyPatcher.java" />
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\android\incrementaldeployment\MultiDexLoader.class" />
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\android\ResourcePatcher.class" />
@@ -1937,9 +1936,10 @@ because xbuild doesn't support framework reference assemblies.
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\MonoPackageManager_Resources.class" />
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\android\incrementaldeployment\IncrementalClassLoader*.class" />
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\android\incrementaldeployment\Placeholder.class" />
-    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\android\app\ApplicationRegistration.class" />
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\android\app\NotifyTimeZoneChanges.class" />
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\android\MonkeyPatcher.class" />
+    <_OldStaticResources Include="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp" />
+    <_OldStaticResources Include="$(IntermediateOutputPath)_javac.stamp" />
   </ItemGroup>
   <Delete Files="@(_OldStaticResources)" />
 </Target>


### PR DESCRIPTION
Fixes: http://work.devdiv.io/899432

There is a #deletebinobj problem if you take an existing project built
with 16.1 and build with 16.2/master.

1. File > New > Android App in 16.1.
2. Build
3. Open in 16.2, build.

Get an error such as:

    obj\Debug\90\android\src\mono\MonoPackageManager_Resources.java(2,8):  error: duplicate class: mono.MonoPackageManager_Resources
    public class MonoPackageManager_Resources {

Reviewing `obj\Debug\90\android\src\mono`, there is a
`MonoPackageManager.java` and `MonoPackageManager_Resources.java` that
have a duplicate class.

In 5a9d1a6, we had already tried to fix this, but the
`_CleanupOldStaticResources` target was not running? It appears that
16.1 is not producing the `ApplicationRegistration.java` file it is
looking for.

The path we were using for a few files wasn't right:

    android\src\mono\app\ApplicationRegistration.java

Should actually be:

    android\src\mono\android\app\ApplicationRegistration.java

But then looking at `<GenerateJavaStubs/>`, we still produce this
file? I think we should instead use `NotifyTimeZoneChanges.java` for
this check. We don't need to delete, or look for
`ApplicationRegistration.java`.

Then I found another problem, in that `_GeneratePackageManagerJava`
and `_CompileJava` need to re-run. I added the stamp files for these
MSBuild targets to the `@(_OldStaticResources)` item group to fix
this.