### PR TITLE
[monodroid] support typemaps from shared runtime again

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -308,8 +308,10 @@ namespace Xamarin.Android.Tasks
 		void WriteTypeMappings (List<TypeDefinition> types)
 		{
 			void logger (TraceLevel level, string value) => Log.LogDebugMessage (value);
-			TypeNameMapGenerator generator = new TypeNameMapGenerator (ResolvedAssemblies.Select (p => p.ItemSpec), logger);
-			using (var gen = generator) {
+			TypeNameMapGenerator createTypeMapGenerator () => UseSharedRuntime ?
+				new TypeNameMapGenerator (types, logger) :
+				new TypeNameMapGenerator (ResolvedAssemblies.Select (p => p.ItemSpec), logger);
+			using (var gen = createTypeMapGenerator ()) {
 				using (var ms = new MemoryStream ()) {
 					UpdateWhenChanged (Path.Combine (OutputDirectory, "typemap.jm"), "jm", ms, gen.WriteJavaToManaged);
 					UpdateWhenChanged (Path.Combine (OutputDirectory, "typemap.mj"), "mj", ms, gen.WriteManagedToJava);

--- a/src/monodroid/jni/embedded-assemblies.h
+++ b/src/monodroid/jni/embedded-assemblies.h
@@ -10,18 +10,14 @@
 struct TypeMapHeader;
 
 namespace xamarin { namespace android { namespace internal {
-#if defined (DEBUG) || !defined (ANDROID)
 	struct TypeMappingInfo;
-#endif
 	struct md_mmap_info;
 
 	class EmbeddedAssemblies
 	{
 	private:
 		static constexpr char assemblies_prefix[] = "assemblies/";
-#if defined (DEBUG) || !defined (ANDROID)
 		static constexpr char override_typemap_entry_name[] = ".__override__";
-#endif
 		static const char *suffixes[];
 
 	public:
@@ -29,9 +25,7 @@ namespace xamarin { namespace android { namespace internal {
 		using monodroid_should_register = bool (*)(const char *filename);
 
 	public:
-#if defined (DEBUG) || !defined (ANDROID)
 		void try_load_typemaps_from_directory (const char *path);
-#endif
 		void install_preload_hooks ();
 		const char* typemap_java_to_managed (const char *java);
 		const char* typemap_managed_to_java (const char *managed);
@@ -61,9 +55,7 @@ namespace xamarin { namespace android { namespace internal {
 		bool gather_bundled_assemblies_from_apk (const char* apk, monodroid_should_register should_register);
 		MonoAssembly* open_from_bundles (MonoAssemblyName* aname, bool ref_only);
 		void extract_int (const char **header, const char *source_apk, const char *source_entry, const char *key_name, int *value);
-#if defined (DEBUG) || !defined (ANDROID)
 		bool add_type_mapping (TypeMappingInfo **info, const char *source_apk, const char *source_entry, const char *addr);
-#endif // DEBUG || !ANDROID
 		bool register_debug_symbols_for_assembly (const char *entry_name, MonoBundledAssembly *assembly, const mono_byte *debug_contents, int debug_size);
 
 		static md_mmap_info md_mmap_apk_file (int fd, uLong offset, uLong size, const char* filename, const char* apk);
@@ -88,10 +80,8 @@ namespace xamarin { namespace android { namespace internal {
 		bool                   register_debug_symbols;
 		MonoBundledAssembly  **bundled_assemblies;
 		size_t                 bundled_assemblies_count;
-#if defined (DEBUG) || !defined (ANDROID)
 		TypeMappingInfo       *java_to_managed_maps;
 		TypeMappingInfo       *managed_to_java_maps;
-#endif // DEBUG || !ANDROID
 		const char            *assemblies_prefix_override = nullptr;
 	};
 }}}

--- a/src/monodroid/jni/embedded-assemblies.h
+++ b/src/monodroid/jni/embedded-assemblies.h
@@ -10,14 +10,18 @@
 struct TypeMapHeader;
 
 namespace xamarin { namespace android { namespace internal {
+#if defined (DEBUG) || !defined (ANDROID)
 	struct TypeMappingInfo;
+#endif
 	struct md_mmap_info;
 
 	class EmbeddedAssemblies
 	{
 	private:
 		static constexpr char assemblies_prefix[] = "assemblies/";
+#if defined (DEBUG) || !defined (ANDROID)
 		static constexpr char override_typemap_entry_name[] = ".__override__";
+#endif
 		static const char *suffixes[];
 
 	public:
@@ -25,7 +29,9 @@ namespace xamarin { namespace android { namespace internal {
 		using monodroid_should_register = bool (*)(const char *filename);
 
 	public:
+#if defined (DEBUG) || !defined (ANDROID)
 		void try_load_typemaps_from_directory (const char *path);
+#endif
 		void install_preload_hooks ();
 		const char* typemap_java_to_managed (const char *java);
 		const char* typemap_managed_to_java (const char *managed);
@@ -55,7 +61,9 @@ namespace xamarin { namespace android { namespace internal {
 		bool gather_bundled_assemblies_from_apk (const char* apk, monodroid_should_register should_register);
 		MonoAssembly* open_from_bundles (MonoAssemblyName* aname, bool ref_only);
 		void extract_int (const char **header, const char *source_apk, const char *source_entry, const char *key_name, int *value);
+#if defined (DEBUG) || !defined (ANDROID)
 		bool add_type_mapping (TypeMappingInfo **info, const char *source_apk, const char *source_entry, const char *addr);
+#endif // DEBUG || !ANDROID
 		bool register_debug_symbols_for_assembly (const char *entry_name, MonoBundledAssembly *assembly, const mono_byte *debug_contents, int debug_size);
 
 		static md_mmap_info md_mmap_apk_file (int fd, uLong offset, uLong size, const char* filename, const char* apk);
@@ -80,8 +88,10 @@ namespace xamarin { namespace android { namespace internal {
 		bool                   register_debug_symbols;
 		MonoBundledAssembly  **bundled_assemblies;
 		size_t                 bundled_assemblies_count;
+#if defined (DEBUG) || !defined (ANDROID)
 		TypeMappingInfo       *java_to_managed_maps;
 		TypeMappingInfo       *managed_to_java_maps;
+#endif // DEBUG || !ANDROID
 		const char            *assemblies_prefix_override = nullptr;
 	};
 }}}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/7ac95e733c6065dae0c65cad217ab8214fd72247
Context: https://github.com/xamarin/xamarin-android/commit/decfbccf#diff-fcb50a6533eb26323059bc5c8bda1dd7L384

This reverts 7ac95e7 and reverts a small portion of decfbcc.

Unfortunately with 16.2/master we have a ~2.75 second regression with
incremental build performance.

An example using a "Hello World" Xamarin.Forms app, which came from
the File->New Project template in Visual Studio 2019 16.0:

    9.2.3-0
       829 ms  GenerateJavaStubs                          1 calls
    9.4.0-17
      3703 ms  GenerateJavaStubs                          1 calls

This was `Debug` / fast dev build after a XAML change.

The slowdown is due to changes in 7ac95e7, which fixed a crash on
startup when the Mono shared runtime is used.

This constructor used in `<GenerateJavaStubs/>`:

    new TypeNameMapGenerator (ResolvedAssemblies.Select (p => p.ItemSpec), logger)

Will iterate over all the types in the assemblies again, and not make
use of the local `types` list already present.

We removed support in decfbcc for loading typemap files from the Mono
shared runtime. For getting something we can easily cherry-pick for
16.2, I think we can just put this support back in--and completely
revert 7ac95e7.

Down the road we can do something more involved to put back the
changes from decfbcc.