### PR TITLE
[Xamarin.Android.Build.Tasks] App Bundles & Google Play

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -185,10 +185,17 @@ when packaging Release applications.
 
     Added in Xamarin.Android 8.2.
 
+-   **AndroidApkDigestAlgorithm** &ndash; A string value which specifies
+    the digest algorithm to use with `jarsigner -digestalg`.
+
+    The default value is `SHA1` for APKs and `SHA-256` for App Bundles.
+
+    Added in Xamarin.Android 9.4.
+
 -   **AndroidApkSigningAlgorithm** &ndash; A string value which specifies
     the signing algorithm to use with `jarsigner -sigalg`.
 
-    The default value is `md5withRSA`.
+    The default value is `md5withRSA` for APKs and `SHA256withRSA` for App Bundles.
 
     Added in Xamarin.Android 8.2.
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
@@ -32,7 +32,17 @@ namespace Xamarin.Android.Tasks
 
 		public string TimestampAuthorityCertificateAlias { get; set; }
 
+		/// <summary>
+		/// -sigalg switch, should be md5withRSA for APKs or SHA256withRSA for App Bundles
+		/// </summary>
+		[Required]
 		public string SigningAlgorithm { get; set; }
+
+		/// <summary>
+		/// -digestalg switch, should be SHA1 for APKs or SHA-256 for App Bundles
+		/// </summary>
+		[Required]
+		public string DigestAlgorithm { get; set; }
 
 		public string FileSuffix { get; set; }
 
@@ -49,8 +59,8 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitchIfNotNull ("-keystore ", KeyStore);
 			cmd.AppendSwitchIfNotNull ("-storepass ", StorePass);
 			cmd.AppendSwitchIfNotNull ("-keypass ", KeyPass);
-			cmd.AppendSwitchIfNotNull ("-digestalg ", "SHA1");
-			cmd.AppendSwitchIfNotNull ("-sigalg ", string.IsNullOrWhiteSpace (SigningAlgorithm) ? "md5withRSA" : SigningAlgorithm);
+			cmd.AppendSwitchIfNotNull ("-digestalg ", DigestAlgorithm);
+			cmd.AppendSwitchIfNotNull ("-sigalg ", SigningAlgorithm);
 			cmd.AppendSwitchIfNotNull ("-signedjar ", Path.Combine (SignedApkDirectory, $"{fileName}{FileSuffix}{extension}" ));
 
 			cmd.AppendFileNameIfNotNull (UnsignedApk);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -307,6 +307,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidUseAapt2            Condition=" '$(AndroidPackageFormat)' == 'aab' ">True</AndroidUseAapt2>
 	<AndroidUseApkSigner        Condition=" '$(AndroidPackageFormat)' == 'aab' ">False</AndroidUseApkSigner>
 	<AndroidCreatePackagePerAbi Condition=" '$(AndroidCreatePackagePerAbi)' == 'aab' ">False</AndroidCreatePackagePerAbi>
+	<AndroidApkSigningAlgorithm Condition=" '$(AndroidApkSigningAlgorithm)' == '' And '$(AndroidPackageFormat)' != 'aab' ">md5withRSA</AndroidApkSigningAlgorithm>
+	<AndroidApkSigningAlgorithm Condition=" '$(AndroidApkSigningAlgorithm)' == '' And '$(AndroidPackageFormat)' == 'aab' ">SHA256withRSA</AndroidApkSigningAlgorithm>
+	<AndroidApkDigestAlgorithm  Condition=" '$(AndroidApkDigestAlgorithm)' == '' And '$(AndroidPackageFormat)' != 'aab' ">SHA1</AndroidApkDigestAlgorithm>
+	<AndroidApkDigestAlgorithm  Condition=" '$(AndroidApkDigestAlgorithm)' == '' And '$(AndroidPackageFormat)' == 'aab' ">SHA-256</AndroidApkDigestAlgorithm>
 
 	<!-- Default Java heap size to 1GB (-Xmx1G) if not specified-->
 	<JavaMaximumHeapSize Condition=" '$(JavaMaximumHeapSize)' == '' ">1G</JavaMaximumHeapSize>
@@ -3308,6 +3312,7 @@ because xbuild doesn't support framework reference assemblies.
 		TimestampAuthorityUrl="$(JarsignerTimestampAuthorityUrl)"
 		TimestampAuthorityCertificateAlias="$(JarsignerTimestampAuthorityCertificateAlias)"
 		SigningAlgorithm="$(AndroidApkSigningAlgorithm)"
+		DigestAlgorithm="$(AndroidApkDigestAlgorithm)"
 	/>
 	<ItemGroup>
 		<ApkAbiFilesSigned Include="$(ApkFileSigned)" Condition="'$(AndroidUseApkSigner)' == 'true'" />


### PR DESCRIPTION
@redth and I recently went through the process of submitting a
Xamarin.Android App Bundle to Google Play. He had an existing app,
while I tested the SmartHotel360 app.

Unfortunately, Google Play did not accept the bundle at first:

    "The Android App Bundle was not signed."

But it *was* signed?

Looking at the build log, the build was running:

    jarsigner.exe
        -keystore foo.keystore
        -storepass foo
        -keypass foo
        -digestalg SHA1
        -sigalg md5withRSA
        -signedjar bin\Release\com.foo.smarthotel-Signed.aab
        obj\Release\90\android\bin\com.foo.smarthotel.aab

For Android App Bundles, Google Play seems to no longer allow md5 or
SHA1 in favor of SHA-256.

For App Bundles to be accepted by Google Play, we had to run
`jarsigner` manually with:

    jarsigner.exe
        -keystore foo.keystore
        -storepass foo
        -keypass foo
        -digestalg SHA-256
        -sigalg SHA256withRSA
        -signedjar bin\Release\com.foo.smarthotel-Signed.aab
        obj\Release\90\android\bin\com.foo.smarthotel.aab

To fix our MSBuild targets:

* `$(AndroidApkSigningAlgorithm)` now has default values to support
  both `.apk` and `.aab` files
* A new `$(AndroidApkDigestAlgorithm)` property was added with
  respective default values

This will give developers flexibility if these values need to be
changed from a `.csproj` in the future.

After this change, I was able to produce an App Bundle Google Play
will accept with:

    msbuild foo.android.csproj /t:SignAndroidPackage /p:Configuration=Release /p:AndroidPackageFormat=aab

I also had the following properties configured in the `.csproj`:

    <AndroidKeyStore>True</AndroidKeyStore>
    <AndroidSigningKeyStore>foo.keystore</AndroidSigningKeyStore>
    <AndroidSigningStorePass>foo</AndroidSigningStorePass>
    <AndroidSigningKeyAlias>foo</AndroidSigningKeyAlias>
    <AndroidSigningKeyPass>foo</AndroidSigningKeyPass>

`foo.keystore` I created by using the command from this doc:

https://docs.microsoft.com/en-us/xamarin/android/deploy-test/signing/manually-signing-the-apk

## Results ##

@redth's app had some good size improvements:

* APK: 39.4MB
* Android App Bundle: 23.3MB to 25.4MB

~35% savings!