### PR TITLE
[build] fixed a pile of warnings

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
@@ -42,7 +42,6 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 		int                     currentState = -1;
 		string                  targetTestResultsPath;
-		TextWriter              logcatWriter;
 
 		bool                    adbRestarted;
 

--- a/build-tools/create-bundle/create-bundle.csproj
+++ b/build-tools/create-bundle/create-bundle.csproj
@@ -48,17 +48,5 @@
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\System.Drawing.Primitives\System.Drawing.Primitives.csproj">
-      <Project>{C9FF2E4D-D927-479E-838B-647C16763F64}</Project>
-      <Name>System.Drawing.Primitives</Name>
-      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\netstandard\netstandard.csproj">
-      <Project>{93614CB8-4564-43B9-93B0-4AF4B3B16AAE}</Project>
-      <Name>netstandard</Name>
-      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/build-tools/create-pkg/create-pkg.csproj
+++ b/build-tools/create-pkg/create-pkg.csproj
@@ -9,7 +9,6 @@
     <AssemblyName>create-pkg</AssemblyName>
     <OutputPath>..\..\bin\Build$(Configuration)</OutputPath>
   </PropertyGroup>
-  <Import Project="create-pkg.targets" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -19,6 +18,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <ErrorReport>prompt</ErrorReport>
@@ -29,4 +29,5 @@
     <None Include="distribution.xml.in" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="create-pkg.targets" />
 </Project>

--- a/build-tools/create-pkg/create-pkg.targets
+++ b/build-tools/create-pkg/create-pkg.targets
@@ -16,6 +16,7 @@
     <PkgScriptsDir>$(MSBuildThisFileDirectory)scripts</PkgScriptsDir>
     <UpdateInfoGuid>d1ec039f-f3db-468b-a508-896d7c382999</UpdateInfoGuid>
   </PropertyGroup>
+  <Target Name="Build" />
   <Target Name="_CopyFilesToPayloadDir"
       DependsOnTargets="ConstructInstallerItems;GetXAVersion" >
     <PropertyGroup>

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\Configuration.props" />
   <Import Project="..\scripts\XAVersionInfo.targets" />
   <Import Project="..\..\src\mono-runtimes\ProfileAssemblies.projitems" />
   <Import Project="..\..\src\Mono.Android\Mono.Android.projitems" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -745,6 +745,7 @@
     <ProjectReference Include="..\..\build-tools\fetch-windows-assemblers\fetch-windows-assemblers.csproj">
       <Project>{09518DF2-C7B1-4CDB-849A-9F91F4BEA925}</Project>
       <Name>fetch-windows-assemblers</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
   <Import Project="ILRepack.targets" />

--- a/src/Xamarin.Android.Tools.JavadocImporter/DocumentElement.cs
+++ b/src/Xamarin.Android.Tools.JavadocImporter/DocumentElement.cs
@@ -94,8 +94,6 @@ namespace Xamarin.Android.Tools.JavaDocToMdoc
 		{
 			XElement jd = Element;
 
-			RegisterAttribute mregister;
-			string anchor;
 			var section = GetSection (member, tregister);
 			if (section == null)
 				return;
@@ -104,7 +102,6 @@ namespace Xamarin.Android.Tools.JavaDocToMdoc
 			IEnumerable<XElement> destinations = GetMdocMembers (mdoc, member, section.RegisterAttribute, out property);
 			MemberInfo secondPropertyMember = null;
 			DocumentSection secondSection = null;
-			RegisterAttribute secondmregister;
 			string prefix = null, secondPrefix = null;
 			if (property != null) {
 				MethodInfo mi = member as MethodInfo;

--- a/src/bundletool/bundletool.targets
+++ b/src/bundletool/bundletool.targets
@@ -1,5 +1,4 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\Configuration.props" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.DownloadUri" />
   <PropertyGroup>
     <BuildDependsOn>

--- a/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
+++ b/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
@@ -35,10 +35,7 @@
       <HintPath>..\..\packages\NodaTime.2.4.5\lib\net45\NodaTime.dll</HintPath>
     </Reference>
   </ItemGroup>
-    <ItemGroup>
-    <Compile Include="..\..\bin\Test$(CONFIGURATION)\XABuildPaths.cs">
-      <Link>XABuildPaths.cs</Link>
-    </Compile>
+  <ItemGroup>
     <Compile Include="..\..\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.Android.Build.Tests\Utilities\DeviceTest.cs">
       <Link>Utilities\DeviceTest.cs</Link>
     </Compile>


### PR DESCRIPTION
Removed an extra `<Import/>`:

    src\bundletool\bundletool.targets(2,3): warning MSB4011:
    "Configuration.props" cannot be imported again. It was already imported at "src\bundletool\bundletool.csproj (11,3)".
    This is  most likely a build authoring error. This subsequent import will be ignored.

Removed an unused field `TextWriter logcatWriter;`:

    "build-tools\Xamarin.Android.Tools.BootstrapTasks\Xamarin.Android.Tools.BootstrapTasks.csproj" (default target) (5:2) ->
    (CoreCompile target) ->
      Xamarin.Android.Tools.BootstrapTasks\RunInstrumentationTests.cs(45,27): warning CS0169: The field 'RunInstrumentationTests.logcatWriter' is never used

Use `<ReferenceOutputAssembly>False</ReferenceOutputAssembly>`:

    "src\Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj" (default target) (28) ->
    (ResolveAssemblyReferences target) ->
      C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2106,5): warning MSB3270:
      There was a mismatch between the processor architecture of the project being built "MSIL" and the processor architecture of the reference "bin\BuildDebug\fetch-windows-assemblers.exe", "x86". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configura tion Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.

`Xamarin.Android.Build.Tasks.csproj` doesn't need to reference the C#
code in this project.

Removed some `<ProjectReference/>` that did not exist:

    "build-tools\create-bundle\create-bundle.csproj" (default target) (54) ->
    (ResolveProjectReferences target) ->
      C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(1875,5): warning :
      The referenced project '..\..\src\System.Drawing.Primitives\System.Drawing.Primitives.csproj' does not exist.
    "build-tools\create-bundle\create-bundle.csproj" (default target) (54) ->
      C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(1875,5): warning :
      The referenced project '..\..\src\netstandard\netstandard.csproj' does not exist.

Removed a duplicate `<Import/>`:

    build-tools\installers\create-installers.targets(3,3): warning MSB4011:
    "Configuration.props" cannot be imported again.
    It was already imported at "build-tools\create-vsix\create-vsi x.csproj (27,3)". This is most likely a build authoring error. This subsequent import will be ignored.

Removed a unneeded `<Compile/>` to `XABuildPaths.cs`:

    "Xamarin.Android.sln" (default target) (1) ->
    "tests\MSBuildDeviceIntegration\MSBuildDeviceIntegration.csproj" (default target) (66) ->
    src\Xamarin.Android.Build.Tasks\Tests\Xamarin.Android.Build.Tests\Utilities\DeviceTest.cs(16,44):
      warning CS0436: The type 'Paths' in 'tests\MSBuildDeviceIntegration\..\..\bin\TestDebug\XABuildPaths.cs' conflicts with the imported type 'Paths' in 'Xamarin.ProjectTools, Version=1.0.7090.19836, Culture=neutral, PublicKeyToken=null'.
      Using the type defined in 'tests\MSBuildDeviceIntegration\..\..\bin\TestDebug\XABuildPaths.cs'.

Create an empty `Build` target:

    "build-tools\create-pkg\create-pkg.csproj" (default target) (61) ->
      CSC : warning CS2008: No source files specified.

Unused local variables:

    "src\Xamarin.Android.Tools.JavadocImporter\Xamarin.Android.Tools.JavadocImporter.csproj" (default target) (51) ->
    DocumentElement.cs(97,22): warning CS0168: The variable 'mregister' is declared but never used
    DocumentElement.cs(98,11): warning CS0168: The variable 'anchor' is declared but never used
    DocumentElement.cs(107,22): warning CS0168: The variable 'secondmregister' is declared but never used