### PR TITLE
[mono-runtimes] include Mono.CompilerServices.SymbolWriter

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -90,6 +90,7 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\monodoc.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\MULTIDEX_JAR_LICENSE" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\pdb2mdb.exe" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.CompilerServices.SymbolWriter.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\proguard\lib\proguard.jar"/>
     <_MSBuildFiles Include="$(MSBuildSrcDir)\proguard\license.html" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\startup.aotprofile" />

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -85,12 +85,12 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\mkbundle-api.h" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\mono-symbolicate.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.CSharp.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.CompilerServices.SymbolWriter.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Options.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Terminal.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\monodoc.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\MULTIDEX_JAR_LICENSE" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\pdb2mdb.exe" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.CompilerServices.SymbolWriter.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\proguard\lib\proguard.jar"/>
     <_MSBuildFiles Include="$(MSBuildSrcDir)\proguard\license.html" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\startup.aotprofile" />

--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -109,8 +109,8 @@
     <_MonoUtility  Include="mono-symbolicate.exe" />
     <_MonoUtility  Include="mono-api-html.exe" />
     <_MonoUtility  Include="mono-api-info.exe" />
-    <_MonoUtility  Include="pdb2mdb.exe" />
     <_MonoUtility  Include="Mono.CompilerServices.SymbolWriter.dll" />
+    <_MonoUtility  Include="pdb2mdb.exe" />
   </ItemGroup>
   <ItemGroup>
     <_MonoUtilitySource Include="@(_MonoUtility->'$(_MonoProfileToolsDir)\%(Identity)')" />

--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -110,6 +110,7 @@
     <_MonoUtility  Include="mono-api-html.exe" />
     <_MonoUtility  Include="mono-api-info.exe" />
     <_MonoUtility  Include="pdb2mdb.exe" />
+    <_MonoUtility  Include="Mono.CompilerServices.SymbolWriter.dll" />
   </ItemGroup>
   <ItemGroup>
     <_MonoUtilitySource Include="@(_MonoUtility->'$(_MonoProfileToolsDir)\%(Identity)')" />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/055dabe34e1897305be178a260faee3815e3e908
Context: http://build.devdiv.io/2725037

Windows builds seem to be failing with:

    "tests\Runtime-MultiDex\Mono.Android-TestsMultiDex.csproj" (default target) (38) ->
    (_ConvertPdbFiles target) ->
      Xamarin.Android.Common.targets(2060,2): warning : Could not load file or assembly 'Mono.CompilerServices.SymbolWriter, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756' or one of its dependencies. The system cannot find the file specified. [E:\A\_work\2218\s\tests\Runtime-MultiDex\Mono.Android-TestsMultiDex.csproj]
      Xamarin.Android.Common.targets(2060,2): warning :    at Pdb2Mdb.Converter.Convert(String filename) [E:\A\_work\2218\s\tests\Runtime-MultiDex\Mono.Android-TestsMultiDex.csproj]
      Xamarin.Android.Common.targets(2060,2): warning :    at Xamarin.Android.Tasks.ConvertDebuggingFiles.Execute() [E:\A\_work\2218\s\tests\Runtime-MultiDex\Mono.Android-TestsMultiDex.csproj]

I see this file in the mono archive, so it looks like we missed this
assembly in 055dabe.