### PR TITLE
Revert "[mono-runtimes] Use pdb2mdb from archive (#3147)"

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -85,7 +85,6 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\mkbundle-api.h" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\mono-symbolicate.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.CSharp.dll" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.CompilerServices.SymbolWriter.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Options.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Terminal.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\monodoc.dll" />

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -90,7 +90,6 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Terminal.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\monodoc.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\MULTIDEX_JAR_LICENSE" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\pdb2mdb.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\proguard\lib\proguard.jar"/>
     <_MSBuildFiles Include="$(MSBuildSrcDir)\proguard\license.html" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\startup.aotprofile" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -106,9 +106,6 @@
     <Reference Include="Xamarin.Build.AsyncTask">
       <HintPath>..\..\packages\Xamarin.Build.AsyncTask.0.3.4\lib\netstandard2.0\Xamarin.Build.AsyncTask.dll</HintPath>
     </Reference>
-    <Reference Include="pdb2mdb.exe">
-      <HintPath>..\..\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\pdb2mdb.exe</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(IntermediateOutputPath)Profile.g.cs" />
@@ -274,6 +271,84 @@
     <Compile Include="Tasks\CalculateProjectDependencies.cs" />
     <Compile Include="Tasks\ConvertCustomView.cs" />
     <Compile Include="Tasks\ComputeHash.cs" />
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\BitAccess.cs">
+      <Link>pdb2mdb\BitAccess.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\BitSet.cs">
+      <Link>pdb2mdb\BitSet.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\CvInfo.cs">
+      <Link>pdb2mdb\CvInfo.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\DataStream.cs">
+      <Link>pdb2mdb\DataStream.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\DbiDbgHdr.cs">
+      <Link>pdb2mdb\DbiDbgHdr.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\DbiHeader.cs">
+      <Link>pdb2mdb\DbiHeader.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\DbiModuleInfo.cs">
+      <Link>pdb2mdb\DbiModuleInfo.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\DbiSecCon.cs">
+      <Link>pdb2mdb\DbiSecCon.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\Driver.cs">
+      <Link>pdb2mdb\Driver.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\IntHashTable.cs">
+      <Link>pdb2mdb\IntHashTable.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\Interfaces.cs">
+      <Link>pdb2mdb\Interfaces.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\MsfDirectory.cs">
+      <Link>pdb2mdb\MsfDirectory.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\PdbConstant.cs">
+      <Link>pdb2mdb\PdbConstant.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\PdbDebugException.cs">
+      <Link>pdb2mdb\PdbDebugException.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\PdbException.cs">
+      <Link>pdb2mdb\PdbException.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\PdbFile.cs">
+      <Link>pdb2mdb\PdbFile.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\PdbFileHeader.cs">
+      <Link>pdb2mdb\PdbFileHeader.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\PdbFunction.cs">
+      <Link>pdb2mdb\PdbFunction.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\PdbLine.cs">
+      <Link>pdb2mdb\PdbLine.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\PdbLines.cs">
+      <Link>pdb2mdb\PdbLines.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\PdbReader.cs">
+      <Link>pdb2mdb\PdbReader.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\PdbScope.cs">
+      <Link>pdb2mdb\PdbScope.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\PdbSlot.cs">
+      <Link>pdb2mdb\PdbSlot.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\PdbSource.cs">
+      <Link>pdb2mdb\PdbSource.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\PdbWriter.cs">
+      <Link>pdb2mdb\PdbWriter.cs</Link>
+    </Compile>
+    <Compile Include="$(MonoSourceFullPath)\mcs\tools\pdb2mdb\SourceLocationProvider.cs">
+      <Link>pdb2mdb\SourceLocationProvider.cs</Link>
+    </Compile>
     <Compile Include="Tasks\Lint.cs" />
     <Compile Include="Tasks\ReadLibraryProjectImportsCache.cs" />
     <Compile Include="Tasks\ReadImportedLibrariesCache.cs" />

--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -109,7 +109,6 @@
     <_MonoUtility  Include="mono-symbolicate.exe" />
     <_MonoUtility  Include="mono-api-html.exe" />
     <_MonoUtility  Include="mono-api-info.exe" />
-    <_MonoUtility  Include="Mono.CompilerServices.SymbolWriter.dll" />
   </ItemGroup>
   <ItemGroup>
     <_MonoUtilitySource Include="@(_MonoUtility->'$(_MonoProfileToolsDir)\%(Identity)')" />

--- a/src/mono-runtimes/mono-runtimes.targets
+++ b/src/mono-runtimes/mono-runtimes.targets
@@ -110,7 +110,6 @@
     <_MonoUtility  Include="mono-api-html.exe" />
     <_MonoUtility  Include="mono-api-info.exe" />
     <_MonoUtility  Include="Mono.CompilerServices.SymbolWriter.dll" />
-    <_MonoUtility  Include="pdb2mdb.exe" />
   </ItemGroup>
   <ItemGroup>
     <_MonoUtilitySource Include="@(_MonoUtility->'$(_MonoProfileToolsDir)\%(Identity)')" />


### PR DESCRIPTION
This reverts commit 055dabe34e1897305be178a260faee3815e3e908.
Additional context: f62b794e3a3d8542d43729256b5853736ac0825c

This change produced a breakage when building Xamarin.Android-Tests.sln
on Windows. This breakage[0] was missed for two reasons.

1. We only recently introduced the ability to automatically test mono
       related changes on Windows in f9f5b6cd120484b13df74e94638e07411d8693fa.
2. This new Windows build encountered some issues related to submodule
       updating when it was first introduced, which was fixed by 2f163049936eb7f95bbbdff184a8e2d128010744.
```
[0] 2019-06-01T04:11:42.7706017Z "E:\A\_work\2165\s\Xamarin.Android-Tests.sln" (default target) (1) ->
    2019-06-01T04:11:42.7706304Z "E:\A\_work\2165\s\tests\Runtime-MultiDex\Mono.Android-TestsMultiDex.csproj" (default target) (38) ->
    2019-06-01T04:11:42.7706632Z (_ConvertPdbFiles target) ->
    2019-06-01T04:11:42.7707237Z   E:\A\_work\2165\s\bin\Release\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Common.targets(2060,2): warning : Could not load file or assembly 'Mono.CompilerServices.SymbolWriter, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756' or one of its dependencies. Strong name validation failed. (Exception from HRESULT: 0x8013141A) [E:\A\_work\2165\s\tests\Runtime-MultiDex\Mono.Android-TestsMultiDex.csproj]
    2019-06-01T04:11:42.7708120Z E:\A\_work\2165\s\bin\Release\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Common.targets(2060,2): warning :    at Pdb2Mdb.Converter.Convert(String filename) [E:\A\_work\2165\s\tests\Runtime-MultiDex\Mono.Android-TestsMultiDex.csproj]
    2019-06-01T04:11:42.7708892Z E:\A\_work\2165\s\bin\Release\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Common.targets(2060,2): warning :    at Xamarin.Android.Tasks.ConvertDebuggingFiles.Execute() [E:\A\_work\2165\s\tests\Runtime-MultiDex\Mono.Android-TestsMultiDex.csproj]
    2019-06-01T04:11:42.7709397Z
    2019-06-01T04:11:42.7709727Z
    2019-06-01T04:11:42.7710075Z "E:\A\_work\2165\s\Xamarin.Android-Tests.sln" (default target) (1) ->
    2019-06-01T04:11:42.7710498Z "E:\A\_work\2165\s\src\Mono.Android\Test\Mono.Android-Tests.csproj" (default target) (2) ->
    2019-06-01T04:11:42.7710951Z (_ConvertPdbFiles target) ->
    2019-06-01T04:11:42.7713919Z   E:\A\_work\2165\s\bin\Release\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Common.targets(2061,2): error MSB3375: The file "E:\A\_work\2165\s\src\Mono.Android\Test\Mono.Android-Test.Library\bin\Release\Mono.Android_Test.Library.dll.mdb" does not exist. [E:\A\_work\2165\s\src\Mono.Android\Test\Mono.Android-Tests.csproj]
    2019-06-01T04:11:42.7714524Z
    2019-06-01T04:11:42.7714927Z
    2019-06-01T04:11:42.7715395Z "E:\A\_work\2165\s\Xamarin.Android-Tests.sln" (default target) (1) ->
    2019-06-01T04:11:42.7717319Z "E:\A\_work\2165\s\tests\Xamarin.Forms-Performance-Integration\Droid\Xamarin.Forms.Performance.Integration.Droid.csproj" (default target) (28) ->
    2019-06-01T04:11:42.7718039Z   E:\A\_work\2165\s\bin\Release\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Common.targets(2061,2): error MSB3375: The file "E:\A\_work\2165\s\packages\Xam.Plugin.Connectivity.3.2.0\lib\MonoAndroid10\Plugin.Connectivity.dll.mdb" does not exist. [E:\A\_work\2165\s\tests\Xamarin.Forms-Performance-Integration\Droid\Xamarin.Forms.Performance.Integration.Droid.csproj]
    2019-06-01T04:11:42.7718610Z
    2019-06-01T04:11:42.7718810Z
    2019-06-01T04:11:42.7719008Z "E:\A\_work\2165\s\Xamarin.Android-Tests.sln" (default target) (1) ->
    2019-06-01T04:11:42.7719310Z "E:\A\_work\2165\s\tests\Runtime-MultiDex\Mono.Android-TestsMultiDex.csproj" (default target) (38) ->
    2019-06-01T04:11:42.7720116Z   E:\A\_work\2165\s\bin\Release\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Common.targets(2061,2): error MSB3375: The file "E:\A\_work\2165\s\src\Mono.Android\Test\Mono.Android-Test.Library\bin\Release\Mono.Android_Test.Library.dll.mdb" does not exist. [E:\A\_work\2165\s\tests\Runtime-MultiDex\Mono.Android-TestsMultiDex.csproj]
    2019-06-01T04:11:42.7720532Z
    2019-06-01T04:11:42.7720745Z     262 Warning(s)
    2019-06-01T04:11:42.7720960Z     3 Error(s)
```