### PR TITLE
[tests] Revert part of 63bef5811

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RenameTestCases.cs
@@ -20,8 +20,6 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		public                  bool                DeleteSourceFiles           { get; set; }
 		public                  string              Configuration               { get; set; }
 		public                  string              TestsFlavor                 { get; set; }
-		public                  string              LogcatFilenameDistincion    { get; set; }
-
 		[Required]
 		public                  string              SourceFile                  { get; set; }
 		[Required]
@@ -46,7 +44,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			catch (Exception e) {
 				Log.LogWarning ($"Unable to process `{SourceFile}`.  Is it empty?  (Did a unit test runner SIGSEGV?)");
 				Log.LogWarningFromException (e);
-				CreateErrorResultsFile (SourceFile, dest, Configuration, TestsFlavor, LogcatFilenameDistincion, e, m => {
+				CreateErrorResultsFile (SourceFile, dest, Configuration, TestsFlavor, e, m => {
 						Log.LogMessage (MessageImportance.Low, m);
 				});
 			}
@@ -108,9 +106,9 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 	partial class RenameTestCases {
 
-		static void CreateErrorResultsFile (string sourceFile, string destFile, string config, string flavor, string distinction, Exception e, Action<string> logDebugMessage)
+		static void CreateErrorResultsFile (string sourceFile, string destFile, string config, string flavor, Exception e, Action<string> logDebugMessage)
 		{
-			GetTestCaseInfo (sourceFile, Path.GetDirectoryName (destFile), config, flavor, distinction, logDebugMessage, out var testSuiteName, out var testCaseName, out var logcatPath);
+			GetTestCaseInfo (sourceFile, Path.GetDirectoryName (destFile), config, flavor, logDebugMessage, out var testSuiteName, out var testCaseName, out var logcatPath);
 			var contents  = new StringBuilder ();
 			if (File.Exists (sourceFile)) {
 				contents.Append (File.ReadAllText (sourceFile));
@@ -164,14 +162,14 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		//   /Users/builder/jenkins/workspace/xamarin-android-pr-builder-release/xamarin-android/bin/TestRelease/logcat-Release-Mono.Android_Tests.txt
 		//
 		// We need to extract the "base" test name from `SourceFile`, and use that to construct `logcatPath`
-		static void GetTestCaseInfo (string sourceFile, string destinationFolder, string config, string flavor, string distinction, Action<string> logDebugMessage, out string testSuiteName, out string testCaseName, out string logcatPath)
+		static void GetTestCaseInfo (string sourceFile, string destinationFolder, string config, string flavor, Action<string> logDebugMessage, out string testSuiteName, out string testCaseName, out string logcatPath)
 		{
 			var name        = Path.GetFileNameWithoutExtension (sourceFile);
 			if (name.StartsWith ("TestResult-"))
 				name    = name.Substring ("TestResult-".Length);
 			testSuiteName   = name;
 			testCaseName    = $"Possible Crash / {config}";
-			logcatPath      = Path.Combine (destinationFolder, "bin", $"Test{config}", $"logcat-{config}{flavor}-{name}{distinction}.txt");
+			logcatPath      = Path.Combine (destinationFolder, "bin", $"Test{config}", $"logcat-{config}{flavor}-{name}.txt");
 			logDebugMessage ($"Looking for `adb logcat` output in the file: {logcatPath}");
 			if (!File.Exists (logcatPath)) {
 				logDebugMessage ($"Could not find file `{logcatPath}`.  Will not be including `adb logcat` output.");
@@ -199,7 +197,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 			string destFile       = args [0];
 			string sourceFile     = args.Length > 1 ? args [1] : "source.xml";
 			string config         = args.Length > 2 ? args [2] : "Debug";
-			CreateErrorResultsFile (sourceFile, destFile, config, "", "", new Exception ("Wee!!!"), Console.WriteLine);
+			CreateErrorResultsFile (sourceFile, destFile, config, "", new Exception ("Wee!!!"), Console.WriteLine);
 		}
 	}
 #endif  // APP

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -305,7 +305,6 @@
         DestinationFolder="$(MSBuildThisFileDirectory)..\.."
         SourceFile="%(TestApkInstrumentation.ResultsPath)"
         TestsFlavor="$(TestsFlavor)"
-        LogcatFilenameDistincion="%(TestApkInstrumentation.LogcatFilenameDistincion)"
     />
   </Target>
   <Target Name="RecordApkSizes"


### PR DESCRIPTION
In recent builds we don't get the logcat output in the error results
test file as we want. It happens because we have the `logcatPath`
wrong.

Like here: https://jenkins.mono-project.com/job/xamarin-android-pr-pipeline-release/1124/testReport/junit/Xamarin.Android.Bcl_Tests/xunit/Possible_Crash___Release/

Checking the build logs, I found:

    Looking for `adb logcat` output in the file: /Users/builder/jenkins/workspace/xamarin-android-pr-pipeline-release/xamarin-android/build-tools/scripts/../../bin/TestRelease/logcat-Release-Xamarin.Android.Bcl_Tests.xunit.xunit.txt (TaskId:65)
    Could not find file `/Users/builder/jenkins/workspace/xamarin-android-pr-pipeline-release/xamarin-android/build-tools/scripts/../../bin/TestRelease/logcat-Release-Xamarin.Android.Bcl_Tests.xunit.xunit.txt`.  Will not be including `adb logcat` output. (TaskId:65)

Turned out we don't need the distinction string in `RenameTestCases`
task as it is already part of the test name.

It would help notice crashes like https://github.com/xamarin/xamarin-android/issues/3075 quickly.