### PR TITLE
[xa-prep-tasks] <Which/> can try lowercase extensions

### DIFF
--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/Which.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/Which.cs
@@ -30,9 +30,11 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 		{
 			var pathExt     = Environment.GetEnvironmentVariable ("PATHEXT");
 			var pathExts    = pathExt?.Split (new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
-			FileExtensions  = new string [(pathExts?.Length ?? 0) + 1];
-			if (pathExts != null) {
-				Array.Copy (pathExts, 0, FileExtensions, 0, pathExts.Length);
+			int length      = pathExts?.Length ?? 0;
+			FileExtensions  = new string [length * 2 + 1];
+			for (int i = 0, j = 0; i < length; i++, j += 2) {
+				FileExtensions [j] = pathExts [i].ToLowerInvariant ();
+				FileExtensions [j + 1] = pathExts [i];
 			}
 			FileExtensions [FileExtensions.Length - 1] = null;
 		}


### PR DESCRIPTION
On Windows, I noticed our build generates some odd file extensions:

    > ls .\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\ | Select-String EXE
    -a----        5/23/2019   2:17 PM        1422848 aarch64-linux-android-as.EXE
    -a----        5/23/2019   2:17 PM        1354752 arm-linux-androideabi-as.EXE
    -a----        5/23/2019   2:16 PM        1793024 i686-linux-android-as.EXE
    -a----        5/23/2019   2:17 PM        1792000 x86_64-linux-android-as.EXE

Going through our build that produces these files:

    <Which
        HostOS="$(HostOS)"
        HostOSName="$(HostOsName)"
        Program="$(AndroidNdkFullPath)/toolchains/%(_ToolchainPrefix.Identity)-4.9/prebuilt/$(_PrebuiltToolchainDir)/bin/%(_ToolchainPrefix.ToolPrefix)-as"
        Required="True">
      <Output TaskParameter="Location" PropertyName="_NDKToolLocation%(_ToolchainPrefix.Identity)" />
    </Which>

It looks like `EXE` in uppercase is the result of the `<Which/>`
MSBuild task using `%PATHEXT%`. The environment variable generally has
everything in uppercase, while actual extensions are lowercase:

    > $env:PATHEXT
    .COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.CPL

I refactored `<Which/>` to check for a lowercase version of each value
in `%PATHEXT%` to use if the file exists. It still attempts to use the
value *as-is* if that fails.

Since `<Which/>` is only run during our build (and on Windows), the
extra `File.Exists()` check should not be a performance concern.

I will also enjoy not seeing `EXE` throughout our build! :)