### PR TITLE
Bump java-interop for fixed cecil build

### DIFF
--- a/build-tools/scripts/Configuration.Java.Interop.Override.props
+++ b/build-tools/scripts/Configuration.Java.Interop.Override.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <CecilRestoreConfiguration>net_4_0_Debug</CecilRestoreConfiguration>
     <CecilSourceDirectory>$(MSBuildThisFileDirectory)..\..\external\mono\external\cecil</CecilSourceDirectory>
     <UtilityOutputFullPath>$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\</UtilityOutputFullPath>
     <XamarinAndroidToolsDirectory>$(MSBuildThisFileDirectory)..\..\external\xamarin-android-tools</XamarinAndroidToolsDirectory>

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -36,8 +36,8 @@ if(NOT ANDROID)
   endforeach()
   set(MONODROID_SOURCES
     ${MONODROID_SOURCES}
-    ${JAVA_INTEROP_SRC_PATH}/java-interop-gc-bridge-mono.c
-    ${JAVA_INTEROP_SRC_PATH}/java-interop-jvm.c
+    ${JAVA_INTEROP_SRC_PATH}/java-interop-gc-bridge-mono.cc
+    ${JAVA_INTEROP_SRC_PATH}/java-interop-jvm.cc
     )
 endif()
 
@@ -207,9 +207,9 @@ set(MONODROID_SOURCES
   ${SOURCES_DIR}/util.cc
   ${SOURCES_DIR}/zip/ioapi.c
   ${SOURCES_DIR}/zip/unzip.c
-  ${JAVA_INTEROP_SRC_PATH}/java-interop.c
-  ${JAVA_INTEROP_SRC_PATH}/java-interop-mono.c
-  ${JAVA_INTEROP_SRC_PATH}/java-interop-util.c
+  ${JAVA_INTEROP_SRC_PATH}/java-interop.cc
+  ${JAVA_INTEROP_SRC_PATH}/java-interop-mono.cc
+  ${JAVA_INTEROP_SRC_PATH}/java-interop-util.cc
   )
 
 if(UNIX)

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -165,7 +165,7 @@ endif()
 
 add_definitions("-DHAVE_CONFIG_H")
 add_definitions("-D_REENTRANT")
-add_definitions("-DDYLIB_MONO")
+add_definitions("-DXAMARIN_ANDROID_DYLIB_MONO")
 add_definitions("-DJI_DLL_EXPORT")
 add_definitions("-DMONO_DLL_EXPORT")
 add_definitions("-DSGEN_BRIDGE_VERSION=${SGEN_BRIDGE_VERSION}")
@@ -200,7 +200,7 @@ set(MONODROID_SOURCES
   ${SOURCES_DIR}/embedded-assemblies.cc
   ${SOURCES_DIR}/globals.cc
   ${SOURCES_DIR}/jni.c
-  ${SOURCES_DIR}/logger.c
+  ${SOURCES_DIR}/logger.cc
   ${SOURCES_DIR}/monodroid-glue.cc
   ${SOURCES_DIR}/osbridge.cc
   ${SOURCES_DIR}/timezones.cc

--- a/src/monodroid/jni/debug.cc
+++ b/src/monodroid/jni/debug.cc
@@ -26,9 +26,7 @@
 #include <android/log.h>
 #endif
 
-extern "C" {
 #include "java-interop-util.h"
-}
 
 #include "monodroid.h"
 #include "debug.h"

--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -9,9 +9,7 @@
 #include <libgen.h>
 #include <errno.h>
 
-extern "C" {
 #include "java-interop-util.h"
-}
 
 #include "monodroid.h"
 #include "dylib-mono.h"

--- a/src/monodroid/jni/logger.cc
+++ b/src/monodroid/jni/logger.cc
@@ -21,6 +21,8 @@
 	__android_log_vprint ((_level_), CATEGORY_NAME((_category_)), (_format_), (_args_)); \
 	va_end ((_args_));
 
+using namespace xamarin::android;
+
 // Must match the same ordering as LogCategories
 static const char* log_names[] = {
 	"*none*",
@@ -127,7 +129,7 @@ init_logging_categories ()
 	log_categories = LOG_DEFAULT;
 #endif
 	log_timing_categories = LOG_TIMING_DEFAULT;
-	if (monodroid_get_namespaced_system_property (DEBUG_MONO_LOG_PROPERTY, &value) == 0)
+	if (monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_LOG_PROPERTY, &value) == 0)
 		return;
 
 	args = monodroid_strsplit (value, ",", -1);

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -49,10 +49,8 @@
 #include <dirent.h>
 #include <pthread.h>
 
-extern "C" {
 #include "java-interop-util.h"
 #include "logger.h"
-}
 
 #include "monodroid.h"
 #include "dylib-mono.h"

--- a/src/monodroid/jni/new_delete.cc
+++ b/src/monodroid/jni/new_delete.cc
@@ -1,9 +1,7 @@
 #include <stdlib.h>
 #include <new>
 
-extern "C" {
 #include "java-interop-util.h"
-}
 
 static void*
 do_alloc (size_t size)

--- a/src/monodroid/jni/timezones.cc
+++ b/src/monodroid/jni/timezones.cc
@@ -2,9 +2,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-extern "C" {
 #include "java-interop-util.h"
-}
 
 #include "mono_android_Runtime.h"
 #include "monodroid.h"

--- a/src/monodroid/jni/util.cc
+++ b/src/monodroid/jni/util.cc
@@ -17,9 +17,7 @@
 #include <direct.h>
 #endif
 
-extern "C" {
 #include "java-interop-util.h"
-}
 
 #include "monodroid.h"
 #include "util.h"

--- a/src/monodroid/jni/util.h
+++ b/src/monodroid/jni/util.h
@@ -50,16 +50,8 @@ typedef struct stat monodroid_stat_t;
 typedef struct dirent monodroid_dirent_t;
 #endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif // __cplusplus
-
 #include "java-interop-util.h"
 #include "logger.h"
-
-#ifdef __cplusplus
-}
-#endif // __cplusplus
 
 #define DEFAULT_DIRECTORY_MODE S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH
 #define XA_UNLIKELY(expr) (__builtin_expect ((expr) != 0, 0))

--- a/src/monodroid/jni/xamarin_getifaddrs.cc
+++ b/src/monodroid/jni/xamarin_getifaddrs.cc
@@ -22,9 +22,7 @@
 #include <android/log.h>
 #endif
 
-extern "C" {
 #include "logger.h"
-}
 
 #include "globals.h"
 #include "xamarin_getifaddrs.h"


### PR DESCRIPTION
Changes:

    [Java.Interop] JniMethodInfo.ToString() shouldn't throw (#425)
    [java-interop] Migrate to C++ (#427)
    Fix build with newer cecil (from overriden source path) (#428)