### PR TITLE
[Xamarin.Android.Build.Tasks] #deletebinobj going from 15.9 to master

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3715,16 +3715,24 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 					"_CompileJava",
 				};
 				Assert.IsTrue (b.Output.IsTargetSkipped (targets [0]), $"`{targets [0]}` should be skipped.");
-				var oldMonoPackageManager = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "src", "mono", "MonoPackageManager.java");
-				var notifyTimeZoneChanges = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "src", "mono", "android", "app", "NotifyTimeZoneChanges.java");
+				var intermediate = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath);
+				var oldMonoPackageManager = Path.Combine (intermediate, "android", "src", "mono", "MonoPackageManager.java");
+				var seppuku = Path.Combine (intermediate, "android", "src", "mono", "android", "Seppuku.java");
+				var notifyTimeZoneChanges = Path.Combine (intermediate, "android", "src", "mono", "android", "app", "NotifyTimeZoneChanges.java");
+				Directory.CreateDirectory (Path.GetDirectoryName (seppuku));
 				Directory.CreateDirectory (Path.GetDirectoryName (notifyTimeZoneChanges));
 				File.WriteAllText (oldMonoPackageManager, @"package mono;
 public class MonoPackageManager { }
 class MonoPackageManager_Resources { }");
+				File.WriteAllText (seppuku, @"package mono.android;
+public class Seppuku { }");
 				File.WriteAllText (notifyTimeZoneChanges, @"package mono.android.app;
 public class ApplicationRegistration { }");
-				var oldMonoPackageManagerClass = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "bin", "classes" , "mono", "MonoPackageManager.class");
+				var oldMonoPackageManagerClass = Path.Combine (intermediate, "android", "bin", "classes" , "mono", "MonoPackageManager.class");
+				var seppukuClass = Path.Combine (intermediate, "android", "bin", "classes", "mono", "android", "Seppuku.class");
+				Directory.CreateDirectory (Path.GetDirectoryName (seppukuClass));
 				File.WriteAllText (oldMonoPackageManagerClass, "");
+				File.WriteAllText (seppukuClass, "");
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				foreach (var target in targets) {
 					Assert.IsFalse (b.Output.IsTargetSkipped (target), $"`{target}` should *not* be skipped.");
@@ -3732,10 +3740,12 @@ public class ApplicationRegistration { }");
 				// Old files that should *not* exist
 				FileAssert.DoesNotExist (oldMonoPackageManager);
 				FileAssert.DoesNotExist (oldMonoPackageManagerClass);
+				FileAssert.DoesNotExist (seppuku);
+				FileAssert.DoesNotExist (seppukuClass);
 				FileAssert.DoesNotExist (notifyTimeZoneChanges);
 				// New files that should exist
-				var monoPackageManager_Resources = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "src", "mono", "MonoPackageManager_Resources.java");
-				var monoPackageManager_ResourcesClass = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "bin", "classes", "mono", "MonoPackageManager_Resources.class");
+				var monoPackageManager_Resources = Path.Combine (intermediate, "android", "src", "mono", "MonoPackageManager_Resources.java");
+				var monoPackageManager_ResourcesClass = Path.Combine (intermediate, "android", "bin", "classes", "mono", "MonoPackageManager_Resources.class");
 				FileAssert.Exists (monoPackageManager_Resources);
 				FileAssert.Exists (monoPackageManager_ResourcesClass);
 			}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1927,6 +1927,7 @@ because xbuild doesn't support framework reference assemblies.
   <ItemGroup>
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\MultiDexLoader.java" />
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\android\ResourcePatcher.java" />
+    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\android\Seppuku.java" />
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\MonoPackageManager.java" />
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\IncrementalClassLoader.java" />
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\Placeholder.java" />
@@ -1934,6 +1935,7 @@ because xbuild doesn't support framework reference assemblies.
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\src\mono\android\incrementaldeployment\MonkeyPatcher.java" />
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\android\incrementaldeployment\MultiDexLoader.class" />
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\android\ResourcePatcher.class" />
+    <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\android\Seppuku.class" />
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\MonoPackageManager.class" />
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\MonoPackageManager_Resources.class" />
     <_OldStaticResources Include="$(MonoAndroidIntermediate)android\bin\classes\mono\android\incrementaldeployment\IncrementalClassLoader*.class" />


### PR DESCRIPTION
I was actively looking for #deletebinobj bugs, and tried a scenario:

* Create the Master/Detail template from VS 2017 15.9
* Build with 2017 15.9
* Build with 2019 16.2/master

Unfortunately this found a bug:

    Task CompileToDalvik
    ...
    Xamarin.Android.Common.targets(2805,3): java.lang.IllegalArgumentException: already added :  Lmono/android/Seppuku;

`Seppuku.java` was another file we missed when creating the
`_CleanupOldStaticResources` target.

I plan to make a new type of test for this scenario, but for now I
updated the `RemoveOldMonoPackageManager` to reproduce this issue.

This fix we can hopefully backport to 16.2.