### PR TITLE
[aapt2] Bump Aapt2 version to 3.4.1-5326820

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -159,7 +159,6 @@
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\mono.config" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\mono-symbolicate" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\aapt2" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\lib64\libc++.$(LibExtension)" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-android.debug.$(LibExtension)" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-android.release.$(LibExtension)" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-native.$(LibExtension)" />

--- a/src/aapt2/aapt2.targets
+++ b/src/aapt2/aapt2.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.DownloadUri" />
   <PropertyGroup>
-    <Aapt2Version>3.3.1-5013011</Aapt2Version>
+    <Aapt2Version>3.4.1-5326820</Aapt2Version>
     <BuildDependsOn>
       ResolveReferences;
       _DownloadAapt2;


### PR DESCRIPTION
In the current version of aapt2 we use we are seeing
the following error on Windows

	 error APT0000: failed parsing overlays.

Oddly it works on MacOS. Bumping to version
3.4.1-5326820 seems to fix the issue.