### PR TITLE
Bump external monodroid reference

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:master@ed4351857d84b3f797a830883517168104826518
+xamarin/monodroid:non-experimental-vsix@0b38831769817f0e8d43eafefa547e3f98ba9ad3

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:non-experimental-vsix@0b38831769817f0e8d43eafefa547e3f98ba9ad3
+xamarin/monodroid:master@473ef2dfeba46709bd26fae21d13c5c1ba541659


### PR DESCRIPTION
Provides a fix for commercial .vsix installers being flagged as experimental.