### PR TITLE
 [Xamarin.Android.Build.Tasks] #deletebinobj "regression protection"

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DeleteBinObjTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DeleteBinObjTest.cs
@@ -1,0 +1,58 @@
+using NUnit.Framework;
+using System.IO;
+using Xamarin.ProjectTools;
+using Xamarin.Tools.Zip;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	[Parallelizable (ParallelScope.Children)]
+	public class DeleteBinObjTest : BaseTest
+	{
+		const string BaseUrl = "https://xamjenkinsartifact.azureedge.net/mono-jenkins/xamarin-android-test/";
+		readonly DownloadedCache Cache = new DownloadedCache ();
+
+		string HostOS => IsWindows ? "Windows" : "Darwin";
+
+		void RunTest (string name, string sln, string csproj, string version, string revision, bool isRelease)
+		{
+			var configuration = isRelease ? "Release" : "Debug";
+			var zipPath = Cache.GetAsFile ($"{BaseUrl}{name}-{version}-{HostOS}-{revision}.zip");
+			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestName)))
+			using (var zip = ZipArchive.Open (zipPath, FileMode.Open)) {
+				builder.AutomaticNuGetRestore = false;
+
+				var projectDir = Path.Combine (Root, builder.ProjectDirectory);
+				if (Directory.Exists (projectDir))
+					Directory.Delete (projectDir, recursive: true);
+				zip.ExtractAll (projectDir);
+
+				var solution = new ExistingProject {
+					IsRelease = isRelease,
+					ProjectFilePath = Path.Combine (projectDir, sln),
+				};
+				// RestoreNoCache will bypass a global cache on CI machines
+				Assert.IsTrue (builder.Restore (solution, doNotCleanupOnUpdate: true, parameters: new [] { "RestoreNoCache=True" }), "Restore should have succeeded.");
+
+				var project = new ExistingProject {
+					IsRelease = isRelease,
+					ProjectFilePath = Path.Combine (projectDir, csproj),
+				};
+				var parameters = new [] { "Configuration=" + configuration };
+				if (HasDevices) {
+					Assert.IsTrue (builder.Install (project, doNotCleanupOnUpdate: true, parameters: parameters, saveProject: false),
+						"Install should have succeeded.");
+				} else {
+					Assert.IsTrue (builder.Build (project, doNotCleanupOnUpdate: true, parameters: parameters, saveProject: false),
+						"Build should have succeeded.");
+				}
+			}
+		}
+
+		[Test]
+		public void HelloForms ([Values (false, true)] bool isRelease)
+		{
+			RunTest (nameof (HelloForms), "HelloForms.sln", Path.Combine ("HelloForms.Android", "HelloForms.Android.csproj"), "15.9", "ecb13a9", isRelease);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
@@ -15,6 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)BuildAssetsTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BuildTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BuildTest.TestCaseSource.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DeleteBinObjTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DesignerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DeferredBuildTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IncrementalBuildTest.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ExistingProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ExistingProject.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace Xamarin.ProjectTools
+{
+	/// <summary>
+	/// A project class for use when a project already exists on disk
+	/// </summary>
+	public class ExistingProject : XamarinProject
+	{
+		public override string ProjectTypeGuid => string.Empty;
+
+		public override List<ProjectResource> Save (bool saveProject = true) => new List<ProjectResource> ();
+
+		public override void UpdateProjectFiles (string directory, IEnumerable<ProjectResource> projectFiles, bool doNotCleanup = false) { }
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -1,4 +1,4 @@
-﻿﻿using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -82,10 +82,10 @@ namespace Xamarin.ProjectTools
 			return result;
 		}
 
-		public bool Install (XamarinProject project, bool doNotCleanupOnUpdate = false, bool saveProject = true)
+		public bool Install (XamarinProject project, bool doNotCleanupOnUpdate = false, string [] parameters = null, bool saveProject = true)
 		{
 			//NOTE: since $(BuildingInsideVisualStudio) is set, Build will not happen by default
-			return RunTarget (project, "Build,Install", doNotCleanupOnUpdate, saveProject: saveProject);
+			return RunTarget (project, "Build,Install", doNotCleanupOnUpdate, parameters, saveProject: saveProject);
 		}
 
 		public bool Uninstall (XamarinProject project, bool doNotCleanupOnUpdate = false, bool saveProject = true)
@@ -93,9 +93,9 @@ namespace Xamarin.ProjectTools
 			return RunTarget (project, "Uninstall", doNotCleanupOnUpdate);
 		}
 
-		public bool Restore (XamarinProject project, bool doNotCleanupOnUpdate = false)
+		public bool Restore (XamarinProject project, bool doNotCleanupOnUpdate = false, string [] parameters = null)
 		{
-			return RunTarget (project, "Restore", doNotCleanupOnUpdate);
+			return RunTarget (project, "Restore", doNotCleanupOnUpdate, parameters);
 		}
 
 		public bool Clean (XamarinProject project, bool doNotCleanupOnUpdate = false)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -226,7 +226,7 @@ namespace Xamarin.ProjectTools
 			UpdateProjectFiles (directory, projectFiles);
 		}
 
-		public void UpdateProjectFiles (string directory, IEnumerable<ProjectResource> projectFiles, bool doNotCleanup = false)
+		public virtual void UpdateProjectFiles (string directory, IEnumerable<ProjectResource> projectFiles, bool doNotCleanup = false)
 		{
 			directory = Path.Combine (Root, directory.Replace ('\\', '/').Replace ('/', Path.DirectorySeparatorChar));
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -37,6 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Android\XamarinFormsMapsApplicationProject.cs" />
+    <Compile Include="Common\ExistingProject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Common\BuildActions.cs" />
     <Compile Include="Common\BuildItem.cs" />


### PR DESCRIPTION
I setup a new #deletebinobj "regression protection" test:

* Created the Master/Detail Xamarin.Forms template from Visual Studio
  2017 15.9
* Built it with 15.9, `Debug` and `Release`
* Zipped it up, and uploaded to Azure

I created 2 zips: Windows & Darwin. I also added a "revision" in the
URL, for changing the zip over time. It will get cached on a CDN, so
the URL needs to change sometimes.

Next I created an `ExistingProject` type in `Xamarin.ProjectTools`, so
I could unzip these files and build them.

To fix other weirdness with NuGet when passing `bin` and `obj` from
one machine to another, I had to:

* Explicitly run `Restore`
* Set `RestoreNoCache=True`, or Mac would fail to `Restore`

I plan to make further changes to `DeleteBinObjTest.cs` in other PRs.
It should start apps and connect the debugger like we are doing in
other tests.