### PR TITLE
[build] use Prepare target for AzDO

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -160,14 +160,11 @@ stages:
         downloadPath: $(System.DefaultWorkingDirectory)
 
     - task: MSBuild@1
-      displayName: build xaprepare
+      displayName: msbuild Xamarin.Android /t:Prepare
       inputs:
-        solution: build-tools\xaprepare\xaprepare.sln
+        solution: Xamarin.Android.sln
         configuration: $(XA.Build.Configuration)
-        msbuildArguments: $(AutoProvisionArgs) $(AndroidTargetAbiArgs) /t:"Restore;Build"
-
-    - script: build-tools\xaprepare\xaprepare\bin\$(XA.Build.Configuration)\xaprepare.exe -v:d --no-emoji --run-mode=CI -a --bundle-path="$(System.DefaultWorkingDirectory)"
-      displayName: run xaprepare
+        msbuildArguments: $(AutoProvisionArgs) $(AndroidTargetAbiArgs) /t:Prepare /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\msbuild-prepare.binlog /p:BundleRootPath=$(System.DefaultWorkingDirectory)
 
     - task: MSBuild@1
       displayName: msbuild Xamarin.Android /t:Build

--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -4,7 +4,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <_TopDir>$(MSBuildThisFileDirectory)..\..</_TopDir>
     <_XAPrepareExe>$(MSBuildThisFileDirectory)..\xaprepare\xaprepare\bin\$(Configuration)\xaprepare.exe</_XAPrepareExe>
-    <_XAPrepareStandardArgs>--no-emoji --run-mode=CI</_XAPrepareStandardArgs>
+    <_XAPrepareStandardArgs>--no-emoji --run-mode=CI -a</_XAPrepareStandardArgs>
+    <_XAPrepareBundleArgs Condition=" '$(BundleRootPath)' != '' ">--bundle-path=&quot;$(BundleRootPath)&quot;</_XAPrepareBundleArgs>
   </PropertyGroup>
   <Import Project="$(_TopDir)\Configuration.props" />
   <Target Name="_BuildXAPrepare">
@@ -21,6 +22,6 @@
         Text="The specified `%24(AndroidToolchainDirectory)` '$(AndroidToolchainDirectory)' contains a space. Android NDK commands do not support this. Please create a Configuration.Override.props file that sets the AndroidToolchainDirectory property to a different path."
         Condition="$(AndroidToolchainDirectory.Contains (' '))"
     />
-    <Exec Command="$(_XAPrepareExe) $(_XAPrepareStandardArgs)" WorkingDirectory="$(_TopDir)" />
+    <Exec Command="$(_XAPrepareExe) $(_XAPrepareStandardArgs) $(_XAPrepareBundleArgs)" WorkingDirectory="$(_TopDir)" />
   </Target>
 </Project>


### PR DESCRIPTION
Instead of running `xaprepare.exe` directly during our build, we
should instead use the `/t:Prepare` target.

This is what developers will use to build Xamarin.Android on Windows,
so this will help us ensure the `Prepare` target continues to work.