### PR TITLE
Fix Xamarin.Android bundle URL

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -34,7 +34,7 @@ stages:
       # The 'prepare' step creates the bundle
     - script: |
         make prepare-update-mono PREPARE_CI=1 V=1 CONFIGURATION=$(XA.Build.Configuration) MSBUILD_ARGS="$(AutoProvisionArgs) $(MSBuildAbiArgs)"
-        make prepare PREPARE_CI=1 V=1 CONFIGURATION=$(XA.Build.Configuration) MSBUILD_ARGS="$(AutoProvisionArgs) $(MSBuildAbiArgs)"
+        make prepare PREPARE_CI=1 PREPARE_ARGS="--copy-bundle-to=bin/$(XA.Build.Configuration)" V=1 CONFIGURATION=$(XA.Build.Configuration) MSBUILD_ARGS="$(AutoProvisionArgs) $(MSBuildAbiArgs)"
       displayName: create bundle
 
     - task: CopyFiles@2

--- a/build-tools/xaprepare/xaprepare/Application/Context.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Context.cs
@@ -310,6 +310,12 @@ namespace Xamarin.Android.Prepare
 		/// </summary>
 		public string XABundlePath { get; set; }
 
+		/// <summary>
+		///   Full filesystem path to the directory where the downloaded bundle should be copied to. This is used by the
+		///   Azure CI bots.
+		/// </summary>
+		public string XABundleCopyDir { get; set; }
+
 		static Context ()
 		{
 			Instance = new Context ();

--- a/build-tools/xaprepare/xaprepare/Application/Utilities.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Utilities.cs
@@ -320,7 +320,7 @@ namespace Xamarin.Android.Prepare
 			else
 				targetFileName = destinationFileName;
 
-			if (!File.Exists (sourceFilePath))
+			if (!FileExists (sourceFilePath))
 				throw new InvalidOperationException ($"Location '{sourceFilePath}' does not point to a file");
 
 			CreateDirectory (destinationDirectory);

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Android.Prepare
 			/// <summary>
 			///   Base URL to download the XA binary bundle from
 			/// </summary>
-			public static Uri Bundle_XABundleDownloadPrefix => new Uri (Bundle_AzureBaseUri, $"{Bundle_AzureJobUri}/xamarin-android/bin/{Context.Instance.Configuration}");
+			public static Uri Bundle_XABundleDownloadPrefix => new Uri (Bundle_AzureBaseUri, $"{Bundle_AzureJobUri}/xamarin-android/bin/{Context.Instance.Configuration}/");
 			static readonly Uri Bundle_AzureBaseUri = new Uri ("https://xamjenkinsartifact.azureedge.net/mono-jenkins/");
 			const string Bundle_AzureJobUri_Debug = "xamarin-android-debug";
 			const string Bundle_AzureJobUri_Release = "xamarin-android";

--- a/build-tools/xaprepare/xaprepare/Main.cs
+++ b/build-tools/xaprepare/xaprepare/Main.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -30,6 +31,7 @@ namespace Xamarin.Android.Prepare
 			public bool RefreshPrograms        { get; set; }
 			public bool EnableAll              { get; set; }
 			public string XABundlePath         { get; set; }
+			public string XABundleCopyDir      { get; set; }
 		}
 
 		public static int Main (string[] args)
@@ -97,7 +99,8 @@ namespace Xamarin.Android.Prepare
 				{"cf=", $"{{NAME}} of the compression format to use for some archives (e.g. the XA bundle). One of: {GetCompressionFormatNames ()}; Default: {parsedOptions.CompressionFormat}", v => parsedOptions.CompressionFormat = v?.Trim ()},
 				{"c|configuration=", $"Build {{CONFIGURATION}}. Default: {Context.Instance.Configuration}", v => parsedOptions.Configuration = v?.Trim ()},
 				{"a|enable-all", "Enable preparation of all the supported targets, ABIs etc", v => parsedOptions.EnableAll = true},
-				{"b|bundle-path=", "Full path to the directory where Xamarin.Android bundle can be found (excluding the file name)", v => parsedOptions.XABundlePath = v?.Trim ()},
+				{"b|bundle-path=", "Full path to the {{DIRECTORY}} where Xamarin.Android bundle can be found (excluding the file name)", v => parsedOptions.XABundlePath = v?.Trim ()},
+				{"copy-bundle-to=", "Full path to the {{DIRECTORY}} where downloaded bundle should be copied (excluding the file name)", v => parsedOptions.XABundleCopyDir = v?.Trim ()},
 				"",
 				{"auto-provision=", $"Automatically install software required by Xamarin.Android", v => parsedOptions.AutoProvision = ParseBoolean (v)},
 				{"auto-provision-uses-sudo=", $"Allow use of sudo(1) when provisioning", v => parsedOptions.AutoProvisionUsesSudo = ParseBoolean (v)},
@@ -143,6 +146,13 @@ namespace Xamarin.Android.Prepare
 
 			if (!String.IsNullOrEmpty (parsedOptions.HashAlgorithm))
 				Context.Instance.HashAlgorithm = parsedOptions.HashAlgorithm;
+
+			if (!String.IsNullOrEmpty (parsedOptions.XABundleCopyDir)) {
+				if (Path.IsPathRooted (parsedOptions.XABundleCopyDir))
+					Context.Instance.XABundleCopyDir = parsedOptions.XABundleCopyDir;
+				else
+					Context.Instance.XABundleCopyDir = Path.Combine (BuildPaths.XamarinAndroidSourceRoot, parsedOptions.XABundleCopyDir);
+			}
 
 			SetCompressionFormat (parsedOptions.CompressionFormat);
 

--- a/build-tools/xaprepare/xaprepare/Steps/Step_PrepareBundle.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_PrepareBundle.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Android.Prepare
 				Log.InfoLine ($"Forced Mono runtimes rebuild requested but rebuilding on {context.OS.Type} is currently not supported.");
 			}
 
-			string localPackagePath = Path.Combine (Configurables.Paths.BundleArchivePath);
+			string localPackagePath = Configurables.Paths.BundleArchivePath;
 			if (await Utilities.VerifyArchive (localPackagePath)) {
 				Log.StatusLine ("Xamarin.Android Bundle archive already downloaded and valid");
 			} else {
@@ -86,6 +86,21 @@ namespace Xamarin.Android.Prepare
 			} finally {
 				Utilities.DeleteDirectorySilent (tempDir);
 			}
+
+			if (String.IsNullOrEmpty (context.XABundleCopyDir))
+				return true;
+
+			string destPackagePath = Path.Combine (context.XABundleCopyDir, Path.GetFileName (localPackagePath));
+			Log.DebugLine ($"Copy of the XA bundle was requested to be created at {destPackagePath}");
+			if (Utilities.FileExists (destPackagePath)) {
+				Log.DebugLine ("Bundle copy already exists");
+				return true;
+			}
+
+			// Utilities.FileExists above will return `false` for a dangling symlink at `destPackagePath`, doesn't hurt
+			// to remove it here just in case
+			Utilities.DeleteFileSilent (destPackagePath);
+			Utilities.CopyFile (localPackagePath, destPackagePath);
 
 			return true;
 		}


### PR DESCRIPTION
Without the trailing `/` in the base URL the last part (the configuration) of
the URL was dropped from the final URL thus pointing to a resource that doesn't
exist.