### PR TITLE
[Xamarin.Android.Build.Tasks] properly support abi delimiters

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -64,7 +64,7 @@ namespace Xamarin.Android.Tasks
 
 		public bool AndroidUseLatestPlatformSdk { get; set; }
 
-		public string SupportedAbis { get; set; }
+		public string [] SupportedAbis { get; set; }
 
 		public bool CreatePackagePerAbi { get; set; }
 
@@ -196,8 +196,8 @@ namespace Xamarin.Android.Tasks
 			}
 
 			var defaultAbi = new string [] { null };
-			var abis = SupportedAbis?.Split (new char [] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
-			foreach (var abi in (CreatePackagePerAbi && abis?.Length > 1) ? defaultAbi.Concat (abis) : defaultAbi) {
+			var abis = CreatePackagePerAbi && SupportedAbis?.Length > 1 ? defaultAbi.Concat (SupportedAbis) : defaultAbi;
+			foreach (var abi in abis) {
 				var currentResourceOutputFile = abi != null ? string.Format ("{0}-{1}", ResourceOutputFile, abi) : ResourceOutputFile;
 				if (!string.IsNullOrEmpty (currentResourceOutputFile) && !Path.IsPathRooted (currentResourceOutputFile))
 					currentResourceOutputFile = Path.Combine (WorkingDirectory, currentResourceOutputFile);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Android.Tasks {
 
 		public bool CreatePackagePerAbi { get; set; }
 
-		public string SupportedAbis { get; set; }
+		public string [] SupportedAbis { get; set; }
 
 		public string OutputFile { get; set; }
 
@@ -261,9 +261,9 @@ namespace Xamarin.Android.Tasks {
 			}
 
 			var defaultAbi = new string [] { null };
-			var abis = SupportedAbis?.Split (new char [] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
+			var abis = CreatePackagePerAbi && SupportedAbis?.Length > 1 ? defaultAbi.Concat (SupportedAbis) : defaultAbi;
 			var outputFile = string.IsNullOrEmpty (OutputFile) ? GetTempFile () : OutputFile;
-			foreach (var abi in (CreatePackagePerAbi && abis?.Length > 1) ? defaultAbi.Concat (abis) : defaultAbi) {
+			foreach (var abi in abis) {
 				var currentResourceOutputFile = abi != null ? string.Format ("{0}-{1}", outputFile, abi) : outputFile;
 				if (!string.IsNullOrEmpty (currentResourceOutputFile) && !Path.IsPathRooted (currentResourceOutputFile))
 					currentResourceOutputFile = Path.Combine (WorkingDirectory, currentResourceOutputFile);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -49,7 +49,7 @@ namespace Xamarin.Android.Tasks
 
 		// Which ABIs to include native libs for
 		[Required]
-		public string SupportedAbis { get; set; }
+		public string [] SupportedAbis { get; set; }
 
 		[Required]
 		public string AotOutputDirectory { get; set; }
@@ -237,20 +237,8 @@ namespace Xamarin.Android.Tasks
 			return level;
 		}
 
-		bool DoExecute () {
-			LogDebugMessage ("Aot:", AndroidAotMode);
-			LogDebugMessage ("  AndroidApiLevel: {0}", AndroidApiLevel);
-			LogDebugMessage ("  AndroidAotMode: {0}", AndroidAotMode);
-			LogDebugMessage ("  AndroidSequencePointsMode: {0}", AndroidSequencePointsMode);
-			LogDebugMessage ("  AndroidNdkDirectory: {0}", AndroidNdkDirectory);
-			LogDebugMessage ("  AotOutputDirectory: {0}", AotOutputDirectory);
-			LogDebugMessage ("  EnableLLVM: {0}", EnableLLVM);
-			LogDebugMessage ("  IntermediateAssemblyDir: {0}", IntermediateAssemblyDir);
-			LogDebugMessage ("  LinkMode: {0}", LinkMode);
-			LogDebugMessage ("  SupportedAbis: {0}", SupportedAbis);
-			LogDebugTaskItems ("  ResolvedAssemblies:", ResolvedAssemblies);
-			LogDebugTaskItems ("  AdditionalNativeLibraryReferences:", AdditionalNativeLibraryReferences);
-
+		bool DoExecute ()
+		{
 			bool hasValidAotMode = GetAndroidAotMode (AndroidAotMode, out AotMode);
 			if (!hasValidAotMode) {
 				LogCodedError ("XA3001", "Invalid AOT mode: {0}", AndroidAotMode);
@@ -316,8 +304,7 @@ namespace Xamarin.Android.Tasks
 				Directory.CreateDirectory (AotOutputDirectory);
 
 			var sdkBinDirectory = MonoAndroidHelper.GetOSBinPath ();
-			var abis = SupportedAbis.Split (new char[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
-			foreach (var abi in abis) {
+			foreach (var abi in SupportedAbis) {
 				string aotCompiler = "";
 				string outdir = "";
 				string mtriple = "";

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Android.Tasks
 		public ITaskItem [] FrameworkDirectories { get; set; }
 
 		[Required]
-		public string SupportedAbis { get; set; }
+		public string [] SupportedAbis { get; set; }
 
 		public string ManifestTemplate { get; set; }
 		public string[] MergedManifestDocuments { get; set; }
@@ -340,7 +340,7 @@ namespace Xamarin.Android.Tasks
 				string dataFileName = Path.GetFileName (dataFilePath);
 				NativeAssemblerTargetProvider asmTargetProvider;
 				var utf8Encoding = new UTF8Encoding (false);
-				foreach (string abi in SupportedAbis.Split (new char[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)) {
+				foreach (string abi in SupportedAbis) {
 					ms.SetLength (0);
 					switch (abi.Trim ()) {
 						case "armeabi-v7a":

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Android.Tasks
 		public bool IsBundledApplication { get; set; }
 
 		[Required]
-		public string SupportedAbis { get; set; }
+		public string [] SupportedAbis { get; set; }
 
 		[Required]
 		public string AndroidPackageName { get; set; }
@@ -231,7 +231,7 @@ namespace Xamarin.Android.Tasks
 
 			using (var ms = new MemoryStream ()) {
 				var utf8Encoding = new UTF8Encoding (false);
-				foreach (string abi in SupportedAbis.Split (new char[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)) {
+				foreach (string abi in SupportedAbis) {
 					ms.SetLength (0);
 					NativeAssemblerTargetProvider asmTargetProvider;
 					string asmFileName = Path.Combine (EnvironmentOutputDirectory, $"environment.{abi.ToLowerInvariant ()}.s");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
@@ -27,7 +27,8 @@ namespace Xamarin.Android.Tasks
 		public ITaskItem[] Assemblies { get; set; }
 		
 		// Which ABIs to include native libs for
-		public string SupportedAbis { get; set; }
+		[Required]
+		public string [] SupportedAbis { get; set; }
 		
 		[Required]
 		public string TempOutputPath { get; set; }
@@ -53,10 +54,6 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			Log.LogDebugMessage ("Assemblies: {0}", Assemblies.Length);
-			Log.LogDebugMessage ("SupportedAbis: {0}", SupportedAbis);
-			Log.LogDebugMessage ("AutoDeps: {0}", AutoDeps);
-
 			if (!NdkUtil.Init (Log, AndroidNdkDirectory))
 				return false;
 
@@ -74,14 +71,13 @@ namespace Xamarin.Android.Tasks
 
 		bool DoExecute ()
 		{
-			var abis = SupportedAbis.Split (new char[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
 			var results = new List<ITaskItem> ();
 			string bundlepath = Path.Combine (TempOutputPath, "bundles");
 			if (!Directory.Exists (bundlepath))
 				Directory.CreateDirectory (bundlepath);
 			else
 				Directory.Delete (bundlepath, true);
-			foreach (var abi in abis) {
+			foreach (var abi in SupportedAbis) {
 				AndroidTargetArch arch = AndroidTargetArch.Other;
 				switch (abi) {
 				case "arm64":

--- a/src/Xamarin.Android.Build.Tasks/Tasks/PrepareAbiItems.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/PrepareAbiItems.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Android.Tasks
 	public class PrepareAbiItems : Task
 	{
 		[Required]
-		public string BuildTargetAbis { get; set; }
+		public string [] BuildTargetAbis { get; set; }
 
 		[Required]
 		public string ItemNamePattern { get; set; }
@@ -19,9 +19,8 @@ namespace Xamarin.Android.Tasks
 
 		public override bool Execute ()
 		{
-			string[] abis = BuildTargetAbis.Split (new [] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries);
 			var items = new List<ITaskItem> ();
-			foreach (string abi in abis) {
+			foreach (string abi in BuildTargetAbis) {
 				var item = new TaskItem (ItemNamePattern.Replace ("@abi@", abi));
 				item.SetMetadata ("abi", abi);
 				items.Add (item);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/SplitProperty.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/SplitProperty.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// This task splits a property into an item group, considering the following delimiters:
+	/// ; - MSBuild default
+	/// , - Historically supported by Xamarin.Android
+	/// </summary>
+	public class SplitProperty : Task
+	{
+		static readonly char [] Delimiters = { ',', ';' };
+
+		public string Value { get; set; }
+
+		[Output]
+		public string [] Output { get; set; }
+
+		public override bool Execute ()
+		{
+			if (Value != null) {
+				Output = Value.Split (Delimiters, StringSplitOptions.RemoveEmptyEntries);
+			}
+			return true;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3856,6 +3856,16 @@ public class ApplicationRegistration { }");
 				Assert.AreNotEqual ("", contents);
 			}
 		}
+
+		[Test]
+		public void AbiDelimiters ([Values ("armeabi-v7a%3bx86", "armeabi-v7a,x86")] string abis)
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty (KnownProperties.AndroidSupportedAbis, abis);
+			using (var b = CreateApkBuilder (Path.Combine ("temp", $"{nameof (AbiDelimiters)}_{abis.GetHashCode ()}"))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MakeBundleNativeCodeExternalTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MakeBundleNativeCodeExternalTests.cs
@@ -35,7 +35,7 @@ namespace Xamarin.Android.Build.Tests {
 				BuildEngine = engine,
 				AndroidNdkDirectory = androidNdkDirectory,
 				Assemblies = new ITaskItem [0],
-				SupportedAbis = "armeabi-v7a",
+				SupportedAbis = new [] { "armeabi-v7a" },
 				TempOutputPath = path,
 				ToolPath = "",
 				BundleApiPath = ""
@@ -54,7 +54,7 @@ namespace Xamarin.Android.Build.Tests {
 				AndroidAotMode = "normal",
 				AndroidApiLevel = "28",
 				ResolvedAssemblies = new ITaskItem [0],
-				SupportedAbis = "armeabi-v7a",
+				SupportedAbis = new [] { "armeabi-v7a" },
 				AotOutputDirectory = path,
 				IntermediateAssemblyDir = path
 			};

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -171,6 +171,7 @@
     <Compile Include="Mono.Android\ContentProviderAttribute.Partial.cs" />
     <Compile Include="Mono.Android\LayoutAttribute.Partial.cs" />
     <Compile Include="Tasks\SetVsMonoAndroidRegistryKey.cs" />
+    <Compile Include="Tasks\SplitProperty.cs" />
     <Compile Include="Tasks\ValidateJavaVersion.cs" />
     <Compile Include="Mono.Android\IntentFilterAttribute.Partial.cs" />
     <Compile Include="Mono.Android\GrantUriPermissionAttribute.Partial.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -102,6 +102,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.ReadJavaStubsCache" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ReadLibraryProjectImportsCache" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ScanAssemblies" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.SplitProperty" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CheckProjectItems" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CheckDuplicateJavaLibraries" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CollectLibraryAssets" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -614,7 +615,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     _CheckProjectItems;
     _CheckForContent;
     _CheckTargetFramework;
-    _CheckSupportedAbis;
     _RemoveLegacyDesigner;
     _ValidateAndroidPackageProperties;
     $(BuildDependsOn);
@@ -1131,16 +1131,6 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_CheckTargetFramework">
 	<Warning Code="XA0109" Text="Unsupported or invalid %24(TargetFrameworkVersion) value of 'v4.5'. Please update your Project Options." Condition=" '$(TargetFrameworkVersion)' == 'v4.5' "/> 
-</Target>
-
-<Target Name="_CheckSupportedAbis">
-	<PropertyGroup>
-		<_RequestedAbis>;$(AndroidSupportedAbis.Replace(',', ';'));</_RequestedAbis>
-	</PropertyGroup>
-	<Error Code="XA0115"
-			Condition="$(_RequestedAbis.Contains(';armeabi;'))"
-			Text="Invalid value 'armeabi' in %24(AndroidSupportedAbis). This ABI is no longer supported. Please update your project properties to remove the old value. If the properties page does not show an 'armeabi' checkbox, un-check and re-check one of the other ABIs and save the changes."
-	/>
 </Target>
 
 <Target Name="_CheckForContent">
@@ -1692,7 +1682,7 @@ because xbuild doesn't support framework reference assemblies.
 		AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
 		YieldDuringToolExecution="$(YieldDuringToolExecution)"
 		ExplicitCrunch="$(AndroidExplicitCrunch)"
-		SupportedAbis="$(_BuildTargetAbis)"
+		SupportedAbis="@(_BuildTargetAbis)"
 		ResourceSymbolsTextFileDirectory="$(IntermediateOutputPath)"
 		ContinueOnError="$(DesignTimeBuild)"
 	/>
@@ -2255,13 +2245,13 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_PrepareNativeAssemblySources">
   <PrepareAbiItems
-    BuildTargetAbis="$(_BuildTargetAbis)"
+    BuildTargetAbis="@(_BuildTargetAbis)"
     ItemNamePattern="$(_NativeAssemblySourceDir)typemap.jm.@abi@.s">
       <Output TaskParameter="OutputItems" ItemName="_TypeMapAssemblySource" />
   </PrepareAbiItems>
 
   <PrepareAbiItems
-    BuildTargetAbis="$(_BuildTargetAbis)"
+    BuildTargetAbis="@(_BuildTargetAbis)"
     ItemNamePattern="$(_NativeAssemblySourceDir)typemap.mj.@abi@.s" >
       <Output TaskParameter="OutputItems" ItemName="_TypeMapAssemblySource" />
   </PrepareAbiItems>
@@ -2305,7 +2295,7 @@ because xbuild doesn't support framework reference assemblies.
 	ApplicationJavaClass="$(AndroidApplicationJavaClass)"
 	FrameworkDirectories="$(_XATargetFrameworkDirectories);$(_XATargetFrameworkDirectories)Facades"
 	AcwMapFile="$(_AcwMapFile)"
-	SupportedAbis="$(_BuildTargetAbis)">
+	SupportedAbis="@(_BuildTargetAbis)">
   </GenerateJavaStubs>
 
   <ItemGroup>
@@ -2399,7 +2389,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_PrepareEnvironmentAssemblySources">
   <PrepareAbiItems
-    BuildTargetAbis="$(_BuildTargetAbis)"
+    BuildTargetAbis="@(_BuildTargetAbis)"
     ItemNamePattern="$(_NativeAssemblySourceDir)environment.@abi@.s">
       <Output TaskParameter="OutputItems" ItemName="_EnvironmentAssemblySource" />
   </PrepareAbiItems>
@@ -2443,7 +2433,7 @@ because xbuild doesn't support framework reference assemblies.
     AndroidSequencePointsMode="$(_SequencePointsMode)"
     EnableSGenConcurrent="$(AndroidEnableSGenConcurrent)"
     IsBundledApplication="$(BundleAssemblies)"
-    SupportedAbis="$(_BuildTargetAbis)"
+    SupportedAbis="@(_BuildTargetAbis)"
     AndroidPackageName="$(_AndroidPackage)"
     EnablePreloadAssembliesDefault="$(_AndroidEnablePreloadAssembliesDefault)"
   >
@@ -2528,7 +2518,7 @@ because xbuild doesn't support framework reference assemblies.
     AndroidUseLatestPlatformSdk="$(AndroidUseLatestPlatformSdk)"
 	ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
     AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
-    SupportedAbis="$(_BuildTargetAbis)"
+    SupportedAbis="@(_BuildTargetAbis)"
     CreatePackagePerAbi="$(AndroidCreatePackagePerAbi)"
     YieldDuringToolExecution="$(YieldDuringToolExecution)"
     ExplicitCrunch="$(AndroidExplicitCrunch)"
@@ -2558,7 +2548,7 @@ because xbuild doesn't support framework reference assemblies.
     JavaPlatformJarPath="$(JavaPlatformJarPath)"
     VersionCodePattern="$(AndroidVersionCodePattern)"
     VersionCodeProperties="$(AndroidVersionCodeProperties)"
-    SupportedAbis="$(_BuildTargetAbis)"
+    SupportedAbis="@(_BuildTargetAbis)"
     CreatePackagePerAbi="$(AndroidCreatePackagePerAbi)"
     AssetsDirectory="$(MonoAndroidAssetsDirIntermediate)"
     AndroidSdkPlatform="$(_AndroidApiLevel)"
@@ -2921,12 +2911,8 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_PrepareApplicationSharedLibraryItems">
   <ItemGroup>
-    <_XARuntimeArchitecture Include="$(_BuildTargetAbis)"/>
-  </ItemGroup>
-
-  <ItemGroup>
-    <_ApplicationSharedLibrary Include="$(_AndroidApplicationSharedLibraryPath)%(_XARuntimeArchitecture.Identity)\libxamarin-app.so">
-      <abi>%(_XARuntimeArchitecture.Identity)</abi>
+    <_ApplicationSharedLibrary Include="$(_AndroidApplicationSharedLibraryPath)%(_BuildTargetAbis.Identity)\libxamarin-app.so">
+      <abi>%(_BuildTargetAbis.Identity)</abi>
     </_ApplicationSharedLibrary>
   </ItemGroup>
 </Target>
@@ -3020,7 +3006,7 @@ because xbuild doesn't support framework reference assemblies.
 	AndroidNdkDirectory="$(_AndroidNdkDirectory)"
 	AndroidApiLevel="$(_AndroidApiLevel)"
 	ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
-	SupportedAbis="$(_BuildTargetAbis)"
+	SupportedAbis="@(_BuildTargetAbis)"
 	AndroidSequencePointsMode="$(_SequencePointsMode)"
 	AotAdditionalArguments="$(AndroidAotAdditionalArguments)"
 	ResolvedAssemblies="@(_ResolvedUserAssemblies);@(_ShrunkFrameworkAssemblies)"
@@ -3049,7 +3035,7 @@ because xbuild doesn't support framework reference assemblies.
 		AndroidNdkDirectory="$(_AndroidNdkDirectory)"
 		Assemblies="@(_ResolvedUserAssemblies);@(_AndroidResolvedSatellitePaths);@(_ShrunkFrameworkAssemblies)"
 		IncludePath="$(MonoAndroidIncludeDirectory)"
-		SupportedAbis="$(_BuildTargetAbis)"
+		SupportedAbis="@(_BuildTargetAbis)"
 		TempOutputPath="$(IntermediateOutputPath)"
 		ToolPath="$(_MonoAndroidToolsDirectory)"
 		BundleApiPath="$(MSBuildThisFileDirectory)\mkbundle-api.h">
@@ -3071,7 +3057,7 @@ because xbuild doesn't support framework reference assemblies.
     AdditionalNativeLibraryReferences="@(_AdditionalNativeLibraryReferences)"
     EmbeddedNativeLibraryAssemblies="$(OutDir)$(TargetFileName);@(_ReferencePath);@(_ReferenceDependencyPaths)"
     DalvikClasses="@(_DexFile)"
-    SupportedAbis="$(_BuildTargetAbis)"
+    SupportedAbis="@(_BuildTargetAbis)"
     CreatePackagePerAbi="$(AndroidCreatePackagePerAbi)"
     UseSharedRuntime="$(AndroidUseSharedRuntime)"
     Debug="$(AndroidIncludeDebugSymbols)"
@@ -3100,7 +3086,7 @@ because xbuild doesn't support framework reference assemblies.
       AdditionalNativeLibraryReferences="@(_AdditionalNativeLibraryReferences)"
       EmbeddedNativeLibraryAssemblies="$(OutDir)$(TargetFileName);@(ReferencePath);@(ReferenceDependencyPaths)"
       DalvikClasses="@(_DexFile)"
-      SupportedAbis="$(_BuildTargetAbis)"
+      SupportedAbis="@(_BuildTargetAbis)"
       CreatePackagePerAbi="False"
       UseSharedRuntime="$(AndroidUseSharedRuntime)"
       Debug="$(AndroidIncludeDebugSymbols)"
@@ -3139,10 +3125,13 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_DefineBuildTargetAbis" DependsOnTargets="$(_BeforeDefineBuildTargetAbis)">
-	<CreateProperty Value="$(AndroidSupportedAbis)" Condition="'$(_BuildTargetAbis)' == ''">
-		<Output TaskParameter="Value" PropertyName="_BuildTargetAbis"/>
-	</CreateProperty>
-	<Message Text="Build target ABI: $(_BuildTargetAbis)" />
+  <SplitProperty Value="$(AndroidSupportedAbis)">
+    <Output TaskParameter="Output" ItemName="_BuildTargetAbis"/>
+  </SplitProperty>
+  <Error Code="XA0115"
+      Condition=" '%(_BuildTargetAbis.Identity)' == 'armeabi' "
+      Text="Invalid value 'armeabi' in %24(AndroidSupportedAbis). This ABI is no longer supported. Please update your project properties to remove the old value. If the properties page does not show an 'armeabi' checkbox, un-check and re-check one of the other ABIs and save the changes."
+  />
 </Target>
 
 <PropertyGroup>
@@ -3169,8 +3158,7 @@ because xbuild doesn't support framework reference assemblies.
   />
 
   <ItemGroup>
-    <_BuiltAbis Include="$(_BuildTargetAbis)" />
-    <_SymbolicateFiles Include="$(_AndroidAotBinDirectory)\%(_BuiltAbis.Identity)\**\*.msym" />
+    <_SymbolicateFiles Include="$(_AndroidAotBinDirectory)\%(_BuildTargetAbis.Identity)\**\*.msym" />
   </ItemGroup>
 
   <Copy Condition=" '$(MonoSymbolArchive)' == 'True' And '%(_SymbolicateFiles.Filename)' != '' "


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3175

In 6ce33aa5, we broke support for `,` and `%3b` as delimiters for
`$(AndroidSupportedAbis)`. We did not have a test checking for these
cases.

Reviewing the code, we had repetition like this throughout our
codebase:

    var abis = SupportedAbis.Split (new char[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);

Instead what we should do, is provide a single task that converts the
abis to an MSBuild item group to be used throughout:

    <SplitProperty Value="$(AndroidSupportedAbis)">
      <Output TaskParameter="Output" ItemName="_BuildTargetAbis"/>
    </SplitProperty>

Then we can consume the `@(_BuildTargetAbis)` item group in a simpler
way from inside MSBuild tasks:

    [Required]
    public string [] SupportedAbis { get; set; }

MSBuild can handle translating an item group to a `string[]`. We
should use that!

Other changes:

* Removed some extra log messages in `<Aot/>` and
  `<MakeBundleNativeCodeExternal/>`
* Moved the error checking for `XA0115` in `_CheckSupportedAbis` to
  happen right after `@(_BuildTargetAbis)` is created.
* Added tests for `,` and `%3b`

Future work:

I'll do similar cleanup for `$(AndroidStoreUncompressedFileExtensions)`
in another PR.