### PR TITLE
Bump to grendello/LibZipSharp/master@71f4a94

### DIFF
--- a/build-tools/scripts/RunTests.targets
+++ b/build-tools/scripts/RunTests.targets
@@ -17,8 +17,8 @@
   <ItemGroup>
     <_TestAssembly Include="$(_TopDir)\bin\Test$(Configuration)\Xamarin.Android.Build.Tests.dll" />
     <_TestAssembly Include="$(_TopDir)\bin\Test$(Configuration)\CodeBehind\CodeBehindUnitTests.dll" />
-    <_TestAssembly Include="$(_TopDir)\bin\Test$(Configuration)\EmbeddedDSO\EmbeddedDSOUnitTests.dll" />
-    <_TestAssembly Include="$(_TopDir)\bin\Test$(Configuration)\Xamarin.Android.MakeBundle-UnitTests\Xamarin.Android.MakeBundle-UnitTests.dll" />
+    <_TestAssembly Include="$(_TopDir)\bin\Test$(Configuration)\EmbeddedDSOUnitTests.dll" />
+    <_TestAssembly Include="$(_TopDir)\bin\Test$(Configuration)\Xamarin.Android.MakeBundle-UnitTests.dll" />
     <_ApkTestProject Include="$(_TopDir)\src\Mono.Android\Test\Mono.Android-Tests.csproj" />
     <_ApkTestProject Include="$(_TopDir)\tests\CodeGen-Binding\Xamarin.Android.JcwGen-Tests\Xamarin.Android.JcwGen-Tests.csproj" />
     <_ApkTestProject Include="$(_TopDir)\tests\CodeGen-MkBundle\Xamarin.Android.MakeBundle-Tests\Xamarin.Android.MakeBundle-Tests.csproj" />

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Standard.Windows.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Standard.Windows.cs
@@ -6,10 +6,11 @@ namespace Xamarin.Android.Prepare
 	{
 		partial void AddRequiredOSSpecificSteps (bool beforeBundle)
 		{
-			if (!beforeBundle)
-				return;
-
-			Steps.Add (new Step_InstallAnt ());
+			if (beforeBundle) {
+				Steps.Add (new Step_InstallAnt ());
+			} else {
+				Steps.Add (new Step_CopyLibZip ());
+			}
 		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/Steps/Step_CopyLibZip.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_CopyLibZip.cs
@@ -1,0 +1,26 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+
+namespace Xamarin.Android.Prepare
+{
+	class Step_CopyLibZip : Step
+	{
+		const string LibZip = "libzip.dll";
+
+		public Step_CopyLibZip () : base ($"Copying {LibZip}") { }
+
+		protected override Task<bool> Execute (Context context)
+		{
+			Copy ();
+			Copy ("x64");
+			return Task.FromResult (true);
+		}
+
+		void Copy (string dir = "")
+		{
+			var src = Path.Combine (Configurables.Paths.InstallMSBuildDir, dir, LibZip);
+			var dest = Path.Combine (Configurables.Paths.BuildBinDir, dir, LibZip);
+			Utilities.CopyFile (src, dest, overwriteDestinationFile: true);
+		}
+	}
+}

--- a/build-tools/xaprepare/xaprepare/Steps/Step_CopyLibZip.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_CopyLibZip.cs
@@ -19,8 +19,10 @@ namespace Xamarin.Android.Prepare
 		void Copy (string dir = "")
 		{
 			var src = Path.Combine (Configurables.Paths.InstallMSBuildDir, dir, LibZip);
-			var dest = Path.Combine (Configurables.Paths.BuildBinDir, dir, LibZip);
-			Utilities.CopyFile (src, dest, overwriteDestinationFile: true);
+			var buildBin = Path.Combine (Configurables.Paths.BuildBinDir, dir, LibZip);
+			Utilities.CopyFile (src, buildBin, overwriteDestinationFile: true);
+			var testBin = Path.Combine (Configurables.Paths.TestBinDir, dir, LibZip);
+			Utilities.CopyFile (src, testBin, overwriteDestinationFile: true);
 		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Scenarios\Scenario_Standard.cs" />
     <Compile Include="Steps\Step_Android_SDK_NDK.cs" />
     <Compile Include="Steps\Step_BuildMingwDependencies.cs" />
+    <Compile Include="Steps\Step_CopyLibZip.cs" />
     <Compile Include="Steps\Step_DownloadNuGet.cs" />
     <Compile Include="Steps\Step_GenerateFiles.cs" />
     <Compile Include="Steps\Step_InstallCorrettoOpenJDK.cs" />

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Xamarin.Android.MakeBundle-UnitTests.csproj
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Xamarin.Android.MakeBundle-UnitTests.csproj
@@ -12,14 +12,14 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\bin\TestDebug\Xamarin.Android.MakeBundle-UnitTests</OutputPath>
+    <OutputPath>..\..\..\bin\TestDebug</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
-    <OutputPath>..\..\..\bin\TestRelease\Xamarin.Android.MakeBundle-UnitTests</OutputPath>
+    <OutputPath>..\..\..\bin\TestRelease</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/EmbeddedDSO-UnitTests.csproj
+++ b/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/EmbeddedDSO-UnitTests.csproj
@@ -16,14 +16,14 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\bin\TestDebug\EmbeddedDSO</OutputPath>
+    <OutputPath>..\..\..\bin\TestDebug</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
-    <OutputPath>..\..\..\bin\TestRelease\EmbeddedDSO</OutputPath>
+    <OutputPath>..\..\..\bin\TestRelease</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>


### PR DESCRIPTION
Changes: https://github.com/grendello/LibZipSharp/compare/da94d3d...71f4a94

I hit an error during a local build on Windows:

    "src\aapt2\aapt2.csproj" (default target) (26:2) ->
    (_DownloadAapt2 target) ->
      src\aapt2\aapt2.targets(49,5): error MSB4018: The "UnzipDirectoryChildren" task failed unexpectedly.
      src\aapt2\aapt2.targets(49,5): error MSB4018: System.AggregateException: One or more errors occurred.
      ---> System.DllNotFoundException: Unable to load DLL 'libzip.dll': The specified module could not be found. (Exception from HRESULT: 0x8007007E)

The culprit appeared to be `bin\BuildDebug\libzip.dll` having a
dependency on `zlib.dll`. But we don't even ship `zlib.dll`?

Further investigation, we found `libZipSharp` was using some outdated
NuGet packages for these native libraries on Windows.

In removing the NuGet packages for `libzip.dll` and `zlib.dll` on
Windows, we need to copy the native libraries to `bin\BuildDebug`
during the bootstrap process. I added a new step in `xaprepare` for
this.