### PR TITLE
Fix `File.Move` with dangling symlinks

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/Utilities.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Utilities.Unix.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 
 using Mono.Unix.Native;
 
@@ -8,17 +9,17 @@ namespace Xamarin.Android.Prepare
 {
 	static partial class Utilities
 	{
+		/// <summary>
+		///   Checks if the file exists as well as whether it's a symbolic link. If it is one, the method checks whether
+		///   the file pointed to exists and returns <c>false</c> if it's not there.
+		/// </summary>
 		public static bool FileExists (string path)
 		{
 			if (!File.Exists (path))
 				return false;
 
-			Stat sbuf;
-			int ret = Syscall.stat (path, out sbuf);
-			if (ret < 0) {
-				if (Stdlib.GetLastError () == Errno.ENOENT)
-					Log.Instance.WarningLine ($"File {path} is a dangling symlink. Treating as NOT existing.");
-
+			if (FileIsDanglingSymlink (path)) {
+				Log.Instance.WarningLine ($"File {path} is a dangling symlink. Treating as NOT existing.");
 				return false;
 			}
 
@@ -28,6 +29,63 @@ namespace Xamarin.Android.Prepare
 		public static IEnumerable<string> FindExecutable (string executable)
 		{
 			yield return executable;
+		}
+
+		/// <summary>
+		///   Moves file from <paramref name="sourcePath"/> to <paramref name="destinationPath"/> the same way <see
+		///   cref="System.IO.File.Move"/> does but it checks whether the file pointed to by <paramref
+		///   name="sourcePath"/> is a dangling symlink and, if yes, it does not call <see cref="System.IO.File.Move"/>
+		///   but instead uses <c>readlink(2)</c> and <c>symlink(2)</c> to recreate the symlink at the destination. This
+		///   is to work around a bug in Mono 6 series which will throw an exception when trying to move a dangling
+		///   symlink.
+		/// </summary>
+		public static void FileMove (string sourcePath, string destinationPath)
+		{
+			if (String.IsNullOrEmpty (sourcePath))
+				throw new ArgumentException ("must not be null or empty", nameof (sourcePath));
+			if (String.IsNullOrEmpty (destinationPath))
+				throw new ArgumentException ("must not be null or empty", nameof (destinationPath));
+
+			int ret = Syscall.lstat (sourcePath, out Stat sbuf);
+			if (ret != 0 || (ret == 0 && (sbuf.st_mode & FilePermissions.S_IFLNK) != FilePermissions.S_IFLNK)) {
+				// Not a symlink or an error, just call to the BCL and let it handle both situations
+				File.Move (sourcePath, destinationPath);
+				return;
+			}
+
+			// Source is a symlink
+			ret = Syscall.stat (sourcePath, out sbuf);
+			Log.DebugLine ($"stat on {sourcePath} returned {ret}. Errno: {Stdlib.GetLastError ()}");
+			if (FileIsDanglingSymlink (sourcePath)) {
+				// let BCL handle it
+				File.Move (sourcePath, destinationPath);
+				return;
+			}
+
+			Log.DebugLine ($"Moving a dangling symlink from {sourcePath} to {destinationPath}");
+			// We have a dangling symlink, we'll just recreate it at the destination and remove the source
+			var sb = new StringBuilder (checked((int)sbuf.st_size));
+			ret = Syscall.readlink (sourcePath, sb);
+			if (ret < 0)
+				throw new IOException ($"Failed to read a symbolic link '{sourcePath}'. {Stdlib.strerror (Stdlib.GetLastError ())}");
+
+			string sourceLinkContents = sb.ToString ();
+			Log.DebugLine ($"Source symlink {sourcePath} points to: {sourceLinkContents}");
+			ret = Syscall.symlink (sourceLinkContents, destinationPath);
+			if (ret < 0)
+				throw new IOException ($"Failed to create a symbolic link '{destinationPath}' -> '{sourceLinkContents}'. {Stdlib.strerror (Stdlib.GetLastError ())}");
+		}
+
+		static bool FileIsDanglingSymlink (string path)
+		{
+			int ret = Syscall.stat (path, out Stat sbuf);
+			Log.DebugLine ($"stat on {path} returned {ret}. Errno: {Stdlib.GetLastError ()}");
+			if (ret == 0 || (ret < 0 && Stdlib.GetLastError () != Errno.ENOENT)) {
+				// Either a valid symlink or an error other than ENOENT
+				return false;
+			}
+
+			return true;
 		}
 
 		// Adapted from CoreFX sources

--- a/build-tools/xaprepare/xaprepare/Application/Utilities.Windows.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Utilities.Windows.cs
@@ -12,6 +12,11 @@ namespace Xamarin.Android.Prepare
 
 		internal const char VolumeSeparatorChar = ':';
 
+		public static void FileMove (string sourcePath, string destinationPath)
+		{
+			File.Move (sourcePath, destinationPath);
+		}
+
 		public static bool FileExists (string filePath)
 		{
 			return File.Exists (filePath);

--- a/build-tools/xaprepare/xaprepare/Application/Utilities.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Utilities.cs
@@ -483,7 +483,7 @@ namespace Xamarin.Android.Prepare
 
 		public static void TouchFileWithRetry (string filePath, DateTime stamp)
 		{
-			if (!FileExists (filePath))
+			if (!File.Exists (filePath))
 				return;
 
 			Log.DebugLine ($"Resetting timestamp of {filePath}");
@@ -520,7 +520,7 @@ namespace Xamarin.Android.Prepare
 			Log.DebugLine ($"Moving '{source}' to '{destination}'");
 			for (int i = 0; i < IOExceptionRetries; i++) {
 				try {
-					File.Move (source, destination);
+					FileMove (source, destination);
 					break;
 				} catch (Exception e) {
 					ex = e;


### PR DESCRIPTION
Current versions of Mono 6 have a bug which makes them throw an `IOException`
whenever an attempt is made to move a file that is a dangling symlink, on Unix
operating systems:

    Mono archive already downloaded and valid
    Archive path: android-archives/android-debug-Darwin-ddef564e344e1e287d6e7755d633d54aa6344985.7z
    [7zip] extracting archive
    [7zip] log file: bin/BuildDebug/prepare-20190610T143559.7zip-extract.android-debug-Darwin-ddef564e344e1e287d6e7755d633d54aa6344985.7z.log
    Elapsed: 00:00:41.0868232

    Step Xamarin.Android.Prepare.Step_BuildMonoRuntimes failed: Could not find file 'external/mono/sdks/out.tmp/android-host-mxe-Win32-debug/bin/mono'.
    System.InvalidOperationException: Step Xamarin.Android.Prepare.Step_BuildMonoRuntimes failed: Could not find file 'external/mono/sdks/out.tmp/android-host-mxe-Win32-debug/bin/mono'. ---> System.IO.FileNotFoundException: Could not find file 'external/mono/sdks/out.tmp/android-host-mxe-Win32-debug/bin/mono'.
      at Xamarin.Android.Prepare.Utilities.MoveFileWithRetry (System.String source, System.String destination, System.Boolean resetFileTimestamp) [0x000c1] in build-tools/xaprepare/xaprepare/Application/Utilities.cs:538
      at Xamarin.Android.Prepare.Utilities.MoveDirectory (System.String sourceDir, System.String destinationDir, System.Boolean resetFileTimestamp) [0x000be] in build-tools/xaprepare/xaprepare/Application/Utilities.cs:475
      at Xamarin.Android.Prepare.Utilities.MoveDirectory (System.String sourceDir, System.String destinationDir, System.Boolean resetFileTimestamp) [0x00098] in build-tools/xaprepare/xaprepare/Application/Utilities.cs:468
      at Xamarin.Android.Prepare.Utilities.MoveDirectory (System.String sourceDir, System.String destinationDir, System.Boolean resetFileTimestamp) [0x00098] in build-tools/xaprepare/xaprepare/Application/Utilities.cs:468
      at Xamarin.Android.Prepare.Utilities.MoveDirectoryContentsRecursively (System.String sourceDir, System.String destinationDir, System.Boolean cleanDestinationDir, System.Boolean resetFileTimestamp) [0x000dc] in build-tools/xaprepare/xaprepare/Application/Utilities.cs:451

Since we cannot, at this time, fix the problem in the Mono BCL, we need to work
around it. Thus, this commit implements a way to check whether a file is a
dangling symlink before calling `File.Move`. If the file **is** a dangling
symlink, it is not copied using `link(2)` (the cause of the Mono bug) but,
rather, it is recreated at the destination location using the contents of the
source symlink acquired using `readlink(2)`.