### PR TITLE
[xaprepare] Detect `ant` installation directory

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -77,8 +77,8 @@
     <GradleHome Condition=" '$(GradleHome)' == '' ">$(MSBuildThisFileDirectory)build-tools\gradle</GradleHome>
     <GradleWPath Condition=" '$(GradleWPath)' == '' ">$(GradleHome)\gradlew</GradleWPath>
     <GradleArgs Condition=" '$(GradleArgs)' == '' ">--stacktrace --no-daemon</GradleArgs>
-    <AntDirectory>$(AndroidToolchainDirectory)\ant</AntDirectory>
-    <AntToolPath>$(AntDirectory)\bin</AntToolPath>
+    <AntDirectory Condition=" '$(AntDirectory)' == '' ">$(AndroidToolchainDirectory)\ant</AntDirectory>
+    <AntToolPath Condition=" '$(AntToolPath)' == '' ">$(AntDirectory)\bin</AntToolPath>
     <AndroidSupportedHostJitAbis Condition=" '$(AndroidSupportedHostJitAbis)' == '' ">$(HostOS)</AndroidSupportedHostJitAbis>
     <AndroidSupportedTargetJitAbis Condition=" '$(AndroidSupportedTargetJitAbis)' == '' ">armeabi-v7a:arm64-v8a:x86</AndroidSupportedTargetJitAbis>
     <JavaInteropSourceDirectory Condition=" '$(JavaInteropSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\Java.Interop</JavaInteropSourceDirectory>

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/Linux.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/Linux.cs
@@ -64,6 +64,15 @@ and re-enable it after building with the following command:
 			Log.WarningLine (BinfmtBaseWarning, ConsoleColor.White, showSeverity: false);
 		}
 
+		protected override bool InitOS ()
+		{
+			if (!base.InitOS ())
+				return false;
+
+			AntDirectory = "/usr";
+			return true;
+		}
+
 		public static Linux DetectAndCreate (Context context)
 		{
 			string name;

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/MacOS.cs
@@ -88,10 +88,11 @@ After all the issues are fixed, please re-run the bootstrapper.
 			// `HostHomebrewPrefix` property which is defined in `Configuration.OperatingSystem.props` but we're here to
 			// *generate* the latter file, so when the bootstrapper is built `HostHomebrewPrefix` is empty and we can't
 			// access mingw utilities. So, we need to cheat here.
-			string brewPrefix = Context.Instance.Properties.GetValue (KnownProperties.AndroidMxeFullPath);
-			if (String.IsNullOrEmpty (brewPrefix))
+			string mxePath = Context.Instance.Properties.GetValue (KnownProperties.AndroidMxeFullPath);
+			if (String.IsNullOrEmpty (mxePath))
 				Context.Instance.Properties.Set (KnownProperties.AndroidMxeFullPath, HomebrewPrefix);
 
+			AntDirectory = HomebrewPrefix;
 			return true;
 		}
 

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/OS.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/OS.cs
@@ -42,6 +42,11 @@ namespace Xamarin.Android.Prepare
 		public Dictionary<string, string> EnvironmentVariables { get; }
 
 		/// <summary>
+		///   Path to the directory under which <c>bin/ant</c> is installed.
+		/// </summary>
+		public string AntDirectory   { get; set; }
+
+		/// <summary>
 		///   Path to <c>javac</c> (full or relative)
 		/// </summary>
 		public string JavaCPath      { get; set; } = "javac";

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/Windows.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/Windows.cs
@@ -88,7 +88,6 @@ namespace Xamarin.Android.Prepare
 		protected override bool InitOS ()
 		{
 			Log.Todo ("gather dependencies here");
-			Log.Todo ("Implement JdkInfo");
 
 			JavaHome = Context.Instance.Properties.GetValue ("JavaSdkDirectory")?.Trim ();
 			if (String.IsNullOrEmpty (JavaHome))
@@ -101,6 +100,8 @@ namespace Xamarin.Android.Prepare
 			// This is required by Android SDK which uses a utility to locate Java on Windows
 			// ($SDK_ROOT/tools/lib/find_java.bat) and that utility, in turn, looks at JAVA_HOME
 			EnvironmentVariables ["JAVA_HOME"] = JavaHome;
+			AntDirectory = Configurables.Paths.AntInstallDir;
+
 			return true;
 		}
 

--- a/build-tools/xaprepare/xaprepare/Resources/Configuration.OperatingSystem.props.in
+++ b/build-tools/xaprepare/xaprepare/Resources/Configuration.OperatingSystem.props.in
@@ -20,5 +20,6 @@
         <JarPath Condition=" '$(JarPath)' == '' ">@jar@</JarPath>
         <JavaPath Condition=" '$(JavaPath)' == '' ">@java@</JavaPath>
         <HostHomebrewPrefix Condition=" '$(HostHomebrewPrefix)' == '' ">@HOST_HOMEBREW_PREFIX@</HostHomebrewPrefix>
+        <AntDirectory Condition=" '$(AntDirectory)' == '' ">@ANT_DIRECTORY@</AntDirectory>
     </PropertyGroup>
 </Project>

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
@@ -94,6 +94,7 @@ namespace Xamarin.Android.Prepare
 				{ "@javac@",                context.OS.JavaCPath },
 				{ "@java@",                 context.OS.JavaPath },
 				{ "@jar@",                  context.OS.JarPath },
+				{ "@ANT_DIRECTORY@",        context.OS.AntDirectory },
 			};
 
 			return new GeneratedPlaceholdersFile (


### PR DESCRIPTION
`ant` is installed using the package managers on `macOS` and `Linux` and by
downloading its zip distribution archive on Windows. All of those systems
install the utility in a different location (`macOS` in homebrew prefix -
usually `/usr/local`, Linux in `/usr` and Windows in `~/android-toolchain/ant`)
and so it is necessary to point our MSBuild tasks to the correct location.

Make the `AntDirectory` MSBuild property overridable and assign it the default,
detected, location in `Configuration.OperatingSystem.props`