### PR TITLE
[Xamarin.Android.Build.Tasks] correct name for AAR stamp files

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -366,7 +366,7 @@ namespace Xamarin.Android.Tasks
 
 				bool updated = false;
 				string aarHash = MonoAndroidHelper.HashFile (aarFile.ItemSpec);
-				string stamp = Path.Combine (outdir, Path.GetFileNameWithoutExtension (aarFile.ItemSpec) + ".stamp");
+				string stamp = Path.Combine (outdir, aarIdentityName + ".stamp");
 				string stampHash = File.Exists (stamp) ? File.ReadAllText (stamp) : null;
 				var aarFullPath = Path.GetFullPath (aarFile.ItemSpec);
 				if (aarHash == stampHash) {


### PR DESCRIPTION
In testing our AndroidX migration, we found a situation where some of
Xamarin.Android's MSBuild targets would always run:

    Building target "_ConvertLibraryResourcesCases" completely.
    Input file "obj\Debug\90\lp\44.stamp" does not exist.
    ...
    Building target "_UpdateAndroidResgen" completely.
    Input file "obj\Debug\90\lp\44.stamp" does not exist.
    ...
    Building target "_CreateBaseApk" completely.
    Input file "obj\Debug\90\lp\44.stamp" does not exist.

This seemed to occur in the case of the AndroidX NuGet package using
an AAR file. Digging further, it seemed we were using the incorrect
path for the `N.stamp` file in the `<ResolveLibraryProjectImports/>`
MSBuild task. It was using `aarFile.ItemSpec` instead of
`aarIdentityName`, which would be the integer-based ID.

It seems this bug has been here (at least since 15.8), so perhaps it
has always been this way?

https://github.com/xamarin/xamarin-android/blob/8db794a1f80ebcf1ba6943d43cb1b19d78a0eabf/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs#L331-L333

In addition to this fix, I expanded
`IncrementalBuildTest.ResolveLibraryProjectImports`:

* Check both `$(AndroidUseAapt2)` True/False
* Check the counts on the `ResolvedResourceDirectoryStamps`
* Check the `ResolvedResourceDirectoryStamps` *exist*
* Make a 4th build with no changes to check that these expensive
  targets are skipped.