### PR TITLE
[build] discrete step for xaprepare's logs

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -166,6 +166,13 @@ stages:
         configuration: $(XA.Build.Configuration)
         msbuildArguments: $(AutoProvisionArgs) $(AndroidTargetAbiArgs) /t:Prepare /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\msbuild-prepare.binlog /p:BundleRootPath=$(System.DefaultWorkingDirectory)
 
+    - task: PublishPipelineArtifact@0
+      displayName: upload xaprepare logs
+      inputs:
+        artifactName: win-xaprepare-results
+        targetPath: $(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\
+      condition: always()
+
     - task: MSBuild@1
       displayName: msbuild Xamarin.Android /t:Build
       inputs:


### PR DESCRIPTION
Context: http://build.devdiv.io/2753179

`xaprepare` is failing somewhat randomly on Windows with:

    EXEC : error : Failed to build remap-assembly-ref [E:\A\_work\2865\s\Xamarin.Android.sln]

Unfortunately, we don't have the logs, since this step relies on
`libzip`:

    - task: MSBuild@1
      displayName: package results
      inputs:
        solution: build-tools\Xamarin.Android.Tools.BootstrapTasks\Xamarin.Android.Tools.BootstrapTasks.csproj
        configuration: $(XA.Build.Configuration)
        msbuildArguments: /t:ZipBuildStatus;ZipTestResults /p:BuildStatusZipOutputPath=$(Build.ArtifactStagingDirectory) /p:TestResultZipOutputPath=$(Build.ArtifactStagingDirectory)
      condition: always()

I added an earlier step to just upload everything in `bin\BuildRelease`.

We may not want to merge this, but let's figure out what is wrong.