### PR TITLE
[build] support .7z extension for xa bundle

### DIFF
--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -173,7 +173,7 @@ timestamps {
             sh "make prepare ${buildTarget} CONFIGURATION=${env.BuildFlavor} V=1 PREPARE_CI=1 MSBUILD_ARGS='$EXTRA_MSBUILD_ARGS'"
 
             if (isCommercial) {
-                sh "cp bin/${env.BuildFlavor}/bundle-*.zip ${packagePath}"
+                sh "cp bin/${env.BuildFlavor}/bundle-* ${packagePath}"
 
                 sh '''
                     VERSION=`LANG=C; export LANG && git log --no-color --first-parent -n1 --pretty=format:%ct`
@@ -255,9 +255,9 @@ timestamps {
 
             if (!isPr) {
                 if (isCommercial) {
-                    publishBuildFilePaths = "${publishBuildFilePaths},bundle-*.zip"
+                    publishBuildFilePaths = "${publishBuildFilePaths},bundle-*"
                 } else {
-                    publishBuildFilePaths = "${publishBuildFilePaths},${XADir}/bin/${env.BuildFlavor}/bundle-*.zip"
+                    publishBuildFilePaths = "${publishBuildFilePaths},${XADir}/bin/${env.BuildFlavor}/bundle-*"
                 }
             }
 


### PR DESCRIPTION
Context: https://jenkins.internalx.com/view/Xamarin.Android/job/xamarin-android-commercial/127/execution/node/153/log/

On latest master, the new `.7z` bundle is giving a 404:

    Bundle URL: https://xamjenkinsartifact.azureedge.net/mono-jenkins/xamarin-android-debug/xamarin-android/bin/Debug/bundle-v21-h9f52cd0-Debug-Darwin-libzip=b95cf3f,mono=c6edaa6.7z
    Step Xamarin.Android.Prepare.Step_PrepareBundle failed

When I look at the build log from Jenkins:

    11:47:21  + cp 'bin/Release/bundle-*.zip' /Users/builder/jenkins/workspace/xamarin-android-commercial/package
    11:47:21  cp: bin/Release/bundle-*.zip: No such file or directory
    11:47:22  sh: line 1: 29879 Terminated: 15          sleep 3

It looks like we are still expecting `.zip` here.

I changed our groovy script to use `-*`, so that both extensions will
work as needed.