### PR TITLE
[xaprepare] Make sure only the enabled components are included in the…

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_CreateBundle.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_CreateBundle.Unix.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Android.Prepare
 				throw new InvalidOperationException ($"Unsupported compression type: {cf.Description}");
 			}
 
-			List<string> items = allRuntimes.BundleItems.Select (
+			List<string> items = allRuntimes.BundleItems.Where (item => item.ShouldInclude == null || item.ShouldInclude (context)).Select (
 				item => {
 					string relPath = Utilities.GetRelativePath (binRoot, item.SourcePath);
 					Log.DebugLine ($"Bundle item: {item.SourcePath} (archive path: {relPath})");


### PR DESCRIPTION
… bundle

Bundle contents differs based on the selected targets, ABIs, architectures etc
and for that reason each `BundleItem` has the `ShouldInclude` functor to allow
the packaging code to determine whether to include the particular item or not.
The problem is, the functor was never used by the bundle creation step... ;/

This commit fixes the issue.