### PR TITLE
[xaprepare] restore NuGets for remap-assembly-ref

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_PrepareLocal.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_PrepareLocal.cs
@@ -19,6 +19,9 @@ namespace Xamarin.Android.Prepare
 			bool result = await msbuild.Run (
 				projectPath: remapAsmRefPath,
 				logTag: "remap-assembly-ref",
+				arguments: new List<string> {
+					"/restore" // Restore, in addition to Build
+				},
 				binlogName: "build-remap-assembly-ref"
 			);
 
@@ -32,7 +35,7 @@ namespace Xamarin.Android.Prepare
 				projectPath: xfTestPath,
 				logTag: "xfperf",
 				arguments: new List <string> {
-					"/t:Restore"
+					"/t:Restore" // Just the Restore target
 				},
 				binlogName: "prepare-restore"
 			);


### PR DESCRIPTION
Context: http://build.devdiv.io/2754453

We've been seeing some random failures on Windows builds, such as:

    EXEC : error : Failed to build remap-assembly-ref

But I was not able to retrieve the build logs, since the "package
build results" step depends on `xaprepare` finishing successfully.

So I made a quick/dirty PR to grab the logs:

https://github.com/xamarin/xamarin-android/pull/3199

From here, I got a `msbuild-*-build-remap-assembly-ref.binlog` file
with the full error message:

    ResolveNuGetPackageAssets
        ...
        Errors
            C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\Microsoft\NuGet\15.0\Microsoft.NuGet.targets(186,5):
            Your project file doesn't list 'win' as a "RuntimeIdentifier". You should add 'win' to the "RuntimeIdentifiers" property in
            your project file and then re-run NuGet restore. [E:\A\_work\2095\s\external\mono\external\cecil\Mono.Cecil.csproj]

Googling this error message, most of the "fixes" appear to be deleting
`bin/obj` or running `msbuild /t:Restore`.

Looking at how we build `remap-assembly-ref.csproj`, we did not have
the `/restore` flag.

Let's add that and see what happens?