### PR TITLE
[build] Don't publish bundle on internal Jenkins

### DIFF
--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -173,8 +173,6 @@ timestamps {
             sh "make prepare ${buildTarget} CONFIGURATION=${env.BuildFlavor} V=1 PREPARE_CI=1 MSBUILD_ARGS='$EXTRA_MSBUILD_ARGS'"
 
             if (isCommercial) {
-                sh "cp bin/${env.BuildFlavor}/bundle-* ${packagePath}"
-
                 sh '''
                     VERSION=`LANG=C; export LANG && git log --no-color --first-parent -n1 --pretty=format:%ct`
                     echo "d1ec039f-f3db-468b-a508-896d7c382999 $VERSION" > ../package/updateinfo
@@ -255,7 +253,7 @@ timestamps {
 
             if (!isPr) {
                 if (isCommercial) {
-                    publishBuildFilePaths = "${publishBuildFilePaths},bundle-*"
+                    publishBuildFilePaths = "${publishBuildFilePaths}"
                 } else {
                     publishBuildFilePaths = "${publishBuildFilePaths},${XADir}/bin/${env.BuildFlavor}/bundle-*"
                 }

--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -252,9 +252,7 @@ timestamps {
             }
 
             if (!isPr) {
-                if (isCommercial) {
-                    publishBuildFilePaths = "${publishBuildFilePaths}"
-                } else {
+                if (!isCommercial) {
                     publishBuildFilePaths = "${publishBuildFilePaths},${XADir}/bin/${env.BuildFlavor}/bundle-*"
                 }
             }


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/6f238a2b98a4e03b9f8f7a9b84e865c1b515d036

Commit 6f238a2b fixed the xaprepare bootstrapping logic to be able to
download and consume a bundle which was previously built and published
to azure storage. It also exposed a "bug" in xaprepare: when a prebuilt
bundle was downloaded and used, it would no longer also be copied to the
output directory where it would have otherwise been built. Azure Pipeline
and internal Jenkins builds which use a prebuilt bundle broke as a result,
as they attempt to upload a bundle from bin/$Configuration. The Azure
Pipeline breakage was fixed in commit 6f238a2b because subsequent jobs
rely on the bundle being uploaded again. There are no downstream
consumers of the bundle uploaded by internal Jenkins, so there is no need
to continue to upload it.