### PR TITLE
Fix debian build

### DIFF
--- a/build-tools/debian-metadata/rules
+++ b/build-tools/debian-metadata/rules
@@ -16,10 +16,12 @@ override_dh_shlibdeps:
 
 override_dh_install:
 	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/cross-*.exe*
+	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/*-as.exe*
 	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/llc.exe
 	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/opt.exe
 	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/aapt2.exe
 	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/libwinpthread-1.dll
+	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/libzip.dll
 
 	dh_install
 


### PR DESCRIPTION
Debian packaging process doesn't work well with native PE executables, trying to
process them with `ikdasm` in order to extract dependencies of the executable.
To make builds possible, remove all the Windows GNU Assemblier (`*-as.exe`)
executables, as well as any instances of `libzip.dll`, before packaging.