### PR TITLE
[Xamarin.Android.Build.Tasks] fix for abi delimiters

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3853,6 +3853,16 @@ public class ApplicationRegistration { }");
 				Assert.AreNotEqual ("", contents);
 			}
 		}
+
+		[Test]
+		public void AbiDelimiters ([Values ("armeabi-v7a%3bx86", "armeabi-v7a,x86")] string abis)
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty (KnownProperties.AndroidSupportedAbis, abis);
+			using (var b = CreateApkBuilder (Path.Combine ("temp", $"{nameof (AbiDelimiters)}_{abis.GetHashCode ()}"))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2916,7 +2916,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_PrepareApplicationSharedLibraryItems">
   <ItemGroup>
-    <_XARuntimeArchitecture Include="$(_BuildTargetAbis)"/>
+    <_XARuntimeArchitecture Include="$([MSBuild]::Unescape($(_BuildTargetAbis.Replace(',', ';'))))"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/901dba8cf03e65789f160927e8576c77924b13ff
Context: https://github.com/xamarin/xamarin-android/commit/decfbccf3e99449c9a8d6afef113c9339f1bc85b

In decfbcc, we broke support for `,` and `%3b` as delimiters for
`$(AndroidSupportedAbis)`. We did not have a test checking for these
cases.

I fixed this in 901dba8c, but the diff was too large to be deemed
"safe" for 16.2 at this point in time.

A one-line patch to fix the issue is this MSBuild incantation:

    <_XARuntimeArchitecture Include="$([MSBuild]::Unescape($(_BuildTargetAbis.Replace(',', ';'))))"/>

We replace the `,` with `;` -- which gets escaped to `%3b`. The
`[MSBuild]::Unescape` call converts `%3b` back to `;`.

This also supports `%3b`.