### PR TITLE
[Xamarin.Android.Build.Tasks] Thrown an exception while enabling "AndroidUseAapt2" in application.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -464,6 +464,17 @@ namespace UnnamedProject
 					"Warning while processing resources should not have been raised.");
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "Build should have succeeded.");
 				Assert.IsTrue (b.Output.IsTargetSkipped ("_GenerateJavaStubs"), "Target _GenerateJavaStubs should have been skipped");
+
+				lib.Touch ("CustomTextView.cs");
+
+				Assert.IsTrue (libb.Build (lib, doNotCleanupOnUpdate: true, saveProject: false), "second library build should have succeeded.");
+				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "second app build should have succeeded.");
+
+				using (var zip = ZipHelper.OpenZip (packaged_resources)) {
+					CheckCustomView (zip, intermediate, "lp", "0", "jl", "res", "layout", "custom_text_lib.xml");
+					CheckCustomView (zip, intermediate, "res", "layout", "custom_text_app.xml");
+				}
+
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 ***********************************************************************************************
 Xamarin.Android.Common.targets
 
@@ -2317,7 +2317,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_ConvertCustomView"
     Condition="Exists('$(_CustomViewMapFile)')"
-    Inputs="$(_CustomViewMapFile);$(_AcwMapFile)"
+    Inputs="$(_CustomViewMapFile);$(_AcwMapFile);@(_AndroidResourceDest);@(_LibraryResourceDirectoryStamps)"
     Outputs="$(_AndroidStampDirectory)_ConvertCustomView.stamp">
   <ConvertCustomView
       CustomViewMapFile="$(_CustomViewMapFile)"


### PR DESCRIPTION
Fixes #3123

Commit 373c6ed0 added a new `_ConvertCustomView` target to
handle the conversion of custom view to the md5 hash versions.
While it worked *most* of the time, there was a very specific
area where it was not fixing up the custom views.

This problem only occurs when a library project code is updated.
When happens next is when the main app builds the library
resources are then re-extracted to the
`$(IntermediateOutputPath)lp\XX\ji\res` directory. The
`ConvertResorucesCases` task is then run to fixup those `res`
files with the correct casing. After than `GenerateJavaStubs`
is then also run, this is because the library project was
updated.

However at this point the wheels fall of the wagon because
`_ConvertCustomViews` does NOT run. this is because it
is only using the following inputs.

	`$(_CustomViewMapFile);$(_AcwMapFile)`

Neither of these files are updated in this instance. The
acwmap file will only be updated if a class or namespace
are changed. If code within a class is changed nothing the
the acwmap will need to be updated, so we don't update the
file.

The `$(_CustomViewMapFile)` also does not be updated unless
resources are added or removed. So that doesn't change either.
The result is the target is skipped, and we end up with a
custom view which does NOT have the correct md5 hash. This
results in the following error at runtime.

	Android.Views.InflateException: Binary XML file line #1: Binary XML file line #1: Error inflating class InflatedLibrary.CodeBehindClass occurred

The fix in this case is to update the Inputs of the `_ConvertCustomView`
target to have the following

	`$(_CustomViewMapFile);$(_AcwMapFile);@(_AndroidResourceDest);@(_LibraryResourceDirectoryStamps)`

By including these two extra items we can make sure the target
runs if either an app resource is updated or if a library
project is updated.

A unit test has been updated to test for this particular issue.