### PR TITLE
[monodroid] Get rid of mono_profiler_install_thread

### DIFF
--- a/src/monodroid/jni/dylib-mono.cc
+++ b/src/monodroid/jni/dylib-mono.cc
@@ -124,7 +124,6 @@ bool DylibMono::init (void *libmono_handle)
 	LOAD_SYMBOL(mono_object_unbox)
 	LOAD_SYMBOL(mono_profiler_install)
 	LOAD_SYMBOL(mono_profiler_install_jit_end)
-	LOAD_SYMBOL(mono_profiler_install_thread)
 	LOAD_SYMBOL(mono_profiler_set_events)
 	LOAD_SYMBOL(mono_property_set_value)
 	LOAD_SYMBOL(mono_register_bundled_assemblies)
@@ -677,12 +676,20 @@ DylibMono::profiler_create ()
 }
 
 void
-DylibMono::profiler_install_thread (MonoProfilerHandle handle, MonoThreadStartedEventFunc start_ftn, MonoThreadStoppedEventFunc end_ftn)
+DylibMono::profiler_set_thread_started_callback (MonoProfilerHandle handle, MonoThreadStartedEventFunc start_ftn)
 {
-	if (mono_profiler_set_thread_started_callback == nullptr || mono_profiler_set_thread_stopped_callback == nullptr)
+	if (mono_profiler_set_thread_started_callback == nullptr)
 		return;
 
 	mono_profiler_set_thread_started_callback (handle, start_ftn);
+}
+
+void
+DylibMono::profiler_set_thread_stopped_callback (MonoProfilerHandle handle, MonoThreadStoppedEventFunc end_ftn)
+{
+	if (mono_profiler_set_thread_stopped_callback == nullptr)
+		return;
+
 	mono_profiler_set_thread_stopped_callback (handle, end_ftn);
 }
 

--- a/src/monodroid/jni/dylib-mono.h
+++ b/src/monodroid/jni/dylib-mono.h
@@ -659,10 +659,11 @@ public:
 	MonoObject* object_new (MonoDomain *domain, MonoClass *klass);
 	void* object_unbox (MonoObject *obj);
 	MonoProfilerHandle profiler_create ();
-	void profiler_install_thread (MonoProfilerHandle handle, MonoThreadStartedEventFunc start_ftn, MonoThreadStoppedEventFunc end_ftn);
 	void profiler_set_jit_begin_callback (MonoProfilerHandle handle, MonoJitBeginEventFunc begin_ftn);
 	void profiler_set_jit_done_callback (MonoProfilerHandle handle, MonoJitDoneEventFunc done_ftn);
 	void profiler_set_jit_failed_callback (MonoProfilerHandle handle, MonoJitFailedEventFunc failed_ftn);
+	void profiler_set_thread_started_callback (MonoProfilerHandle handle, MonoThreadStartedEventFunc start_ftn);
+	void profiler_set_thread_stopped_callback (MonoProfilerHandle handle, MonoThreadStoppedEventFunc end_ftn);
 	void property_set_value (MonoProperty *prop, void *obj, void **params, MonoObject **exc);
 	void register_bundled_assemblies (const MonoBundledAssembly **assemblies);
 	void register_config_for_assembly (const char* assembly_name, const char* config_xml);

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -894,7 +894,8 @@ mono_runtime_init (char *runtime_args)
 	}
 
 	profiler_handle = monoFunctions.profiler_create ();
-	monoFunctions.profiler_install_thread (profiler_handle, thread_start, thread_end);
+	monoFunctions.profiler_set_thread_started_callback (profiler_handle, thread_start);
+	monoFunctions.profiler_set_thread_stopped_callback (profiler_handle, thread_end);
 	if (XA_UNLIKELY (log_methods)) {
 		jit_time.mark_start ();
 		monoFunctions.profiler_set_jit_begin_callback (profiler_handle, jit_begin);


### PR DESCRIPTION
Do not load that symbol anymore. Also replace the
`DylibMono::profiler_install_thread` method with the callback methods
and use these directly.

Left the

    monodroid_mono_profiler_install_thread_fptr mono_profiler_install_thread;

in DylibMono struct to preserve the binary compatability (preserve
struct order). This will vanish once we get rid of the whole
DylibMono.