### PR TITLE
[build] Clean Azure Pipeline workspaces

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1,5 +1,7 @@
 # Xamarin.Android Pipeline
 
+name: $(Build.SourceBranch)-$(Build.SourceVersion)-$(Rev:r)
+
 trigger:
   - master
   - d16-*
@@ -24,10 +26,10 @@ stages:
     pool: $(XA.Build.Mac.Pool)
     timeoutInMinutes: 60
     cancelTimeoutInMinutes: 5
+    workspace:
+      clean: all
     steps:
-
     - checkout: self
-      clean: true
       submodules: recursive
 
       # Update Mono in a separate step since xaprepare uses it as well and it will crash when Mono it runs with is updated
@@ -74,11 +76,12 @@ stages:
     pool: $(XA.Build.Mac.Pool)
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
+    workspace:
+      clean: all
     variables:
       JAVA_HOME: /Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home/
     steps:
     - checkout: self
-      clean: true
       submodules: recursive
 
     - task: DownloadPipelineArtifact@1
@@ -147,11 +150,12 @@ stages:
     pool: $(XA.Build.Win.Pool)
     timeoutInMinutes: 360
     cancelTimeoutInMinutes: 5
+    workspace:
+      clean: all
     variables:
       JAVA_HOME: '%HOMEDRIVE%%HOMEPATH%\android-toolchain\jdk'
     steps:
     - checkout: self
-      clean: true
       submodules: recursive
 
     - task: DownloadPipelineArtifact@1


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/3205
Context: https://github.com/microsoft/azure-pipelines-agent/issues/2301

We've been occasionally encountering a Windows build failure that we
believe to be caused by having an unclean checkout on certain machines.
Previously, we had attempted to recursively clean our source checkout
through the Azure Pipeline checkout task options. However upon further
investigation, it appears that a 'git clean -ffdx' only occurs at the
root level of our repository, and the root level of every submodule. The
clean parameter associated with the checkout task does not recurse into
submodules of submodules. To address this, we'll attempt to clean out
our workspace entirely before each build. This may add a bit of time to
our checkout step, but it should ensure that we are always starting from
a completely clean state.

A 'name' parameter has also been added to the pipeline to improve the
build number naming schema from something date based (e.g. '20190613.14'),
to something to branch and hash based (e.g.
'refs_heads_master-c4c8ce4755f8dd25bc5f4e2c2f7e686fbedf2cd1-1' or
'refs_pull_7_merge-eed46ff9c22217a959c60574bab473afc2d8557d-1').