### PR TITLE
[xdelta] Download and ship the xdelta3 tool.

### DIFF
--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -15,6 +15,7 @@ The attached notices are provided for information only.
 2. google/desugar (https://android.googlesource.com/platform/external/desugar/+/master/)
 3. nunit/nunitlite (https://github.com/nunit/nunitlite/)
 4. zLibDll/minizip (http://www.winimage.com/zLibDll/minizip.html)
+5. jmacd/xdelta (https://github.com/jmacd/xdelta/)
 
 %% bazelbuild/bazel NOTICES AND INFORMATION BEGIN HERE
 ======================================================
@@ -483,3 +484,185 @@ misrepresented as being the original software.
 =====================================================
 END OF zLibDll/minizip NOTICES AND INFORMATION
 
+%% jmacd/xdelta NOTICES AND INFORMATION BEGIN HERE
+====================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+====================================================
+END OF jmacd/xdelta NOTICES AND INFORMATION

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -119,6 +119,10 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Tools.JavaDocImporter.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.VisualBasic.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Build.AsyncTask.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Android\x86\xdelta3" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Android\x86_64\xdelta3" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Android\armeabi-v7a\xdelta3" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Android\arm64-v8a\xdelta3" />
   </ItemGroup>
   <ItemGroup>
     <_MSBuildTargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\Xamarin.Android.Bindings.After.targets" />
@@ -133,6 +137,7 @@
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\x64\libzip.dll" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\proguard\bin\proguard.bat" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\aapt2.exe" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\xdelta3.exe" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\libwinpthread-1.dll" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\aarch64-linux-android-as.exe" Condition=" '$(HostOS)' != 'Windows' "/>
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\arm-linux-androideabi-as.exe" Condition=" '$(HostOS)' != 'Windows' "/>
@@ -155,6 +160,7 @@
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\mono.config" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\mono-symbolicate" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\aapt2" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\xdelta3" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-android.debug.$(LibExtension)" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-android.release.$(LibExtension)" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-native.$(LibExtension)" />

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -36,6 +36,8 @@ namespace Xamarin.Android.Prepare
 			public static readonly Uri NugetUri = new Uri ("https://dist.nuget.org/win-x86-commandline/v4.9.4/nuget.exe");
 
 			public static Uri MonoArchive_BaseUri = new Uri ("https://xamjenkinsartifact.azureedge.net/mono-sdks/");
+
+			public static readonly Uri XDeltaUri = new Uri ("https://github.com/dellis1972/xdelta/releases/download/");
 		}
 
 		public static partial class Defaults

--- a/build-tools/xaprepare/xaprepare/Resources/Configuration.OperatingSystem.props.in
+++ b/build-tools/xaprepare/xaprepare/Resources/Configuration.OperatingSystem.props.in
@@ -21,5 +21,6 @@
         <JavaPath Condition=" '$(JavaPath)' == '' ">@java@</JavaPath>
         <HostHomebrewPrefix Condition=" '$(HostHomebrewPrefix)' == '' ">@HOST_HOMEBREW_PREFIX@</HostHomebrewPrefix>
         <AntDirectory Condition=" '$(AntDirectory)' == '' ">@ANT_DIRECTORY@</AntDirectory>
+        <SevenZip Condition=" '$(SevenZip)' == '' ">@SevenZip@</SevenZip>
     </PropertyGroup>
 </Project>

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Standard.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Standard.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Android.Prepare
 			Steps.Add (new Step_PrepareLocal ());
 			AddRequiredOSSpecificSteps (true);
 			Steps.Add (new Step_PrepareBundle ());
+			Steps.Add (new Step_DownloadXDelta ());
 			AddRequiredOSSpecificSteps (false);
 		}
 

--- a/build-tools/xaprepare/xaprepare/Steps/Step_DownloadXDelta.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_DownloadXDelta.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Xamarin.Android.Prepare
+{
+	class Step_DownloadXDelta : StepWithDownloadProgress
+	{
+		const string XDeltaTag = "v3.0.11-ci";
+		const string XDeltaVersion = "3.0";
+		static readonly Dictionary<string, string> platforms = new Dictionary<string, string> () {
+			{ "macos", "Darwin" },
+			{ "windows", "" },
+			{ "linux", "Linux" },
+			{ "android", "Android" },
+		};
+
+		public Step_DownloadXDelta () : base ($"Downloading xdelta") { }
+
+		protected async override Task<bool> Execute (Context context)
+		{
+			if (context == null)
+				throw new ArgumentNullException (nameof (context));
+
+			//https://github.com/dellis1972/xdelta/releases/download/$(XDeltaTag)/xdelta-$(XDeltaVersion)-$(_XDeltaDownload.Platform).7z
+			string packageCacheDir = context.Properties.GetRequiredValue (KnownProperties.AndroidToolchainCacheDirectory);
+			var sevenZip = new SevenZipRunner (context);
+
+			foreach (var platform in platforms) {
+				string archiveFileName = $"xdelta-{XDeltaVersion}-{platform.Key}.7z";
+				Uri xDeltaUri = new Uri (Configurables.Urls.XDeltaUri, $"{XDeltaTag}/{archiveFileName}");
+
+				string cacheFileName = Path.Combine (packageCacheDir, archiveFileName);
+
+				Utilities.CreateDirectory (Path.GetDirectoryName (cacheFileName));
+
+				if (!await DownloadXDeltaBundle (context, cacheFileName, xDeltaUri))
+					return false;
+
+				string extractToPath = Path.Combine (Configurables.Paths.InstallMSBuildDir, platform.Value);
+
+				Utilities.CreateDirectory (extractToPath);
+
+				if (! await sevenZip.Extract (cacheFileName, extractToPath))
+					return false;
+			}
+
+			return true;
+		}
+
+		async Task<bool> DownloadXDeltaBundle (Context context, string localPackagePath, Uri url)
+		{
+			if (File.Exists (localPackagePath)) {
+				if (await Utilities.VerifyArchive (localPackagePath)) {
+					Log.StatusLine ("xdelta archive already downloaded and valid");
+					return true;
+				}
+				Utilities.DeleteFileSilent (localPackagePath);
+			}
+
+			Log.StatusLine ("Downloading xdelta from ", url.ToString (), tailColor: ConsoleColor.White);
+
+			DownloadStatus downloadStatus = Utilities.SetupDownloadStatus (context, int.MaxValue, context.InteractiveSession);
+			Log.StatusLine ($"  {context.Characters.Link} {url}", ConsoleColor.White);
+			await Download (context, url, localPackagePath, "xdelta", Path.GetFileName (localPackagePath), downloadStatus);
+
+			if (!File.Exists (localPackagePath)) {
+				Log.ErrorLine ($"Download of xdelta from {url} failed.");
+				return false;
+			}
+
+			return true;
+		}
+	}
+}

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
@@ -95,6 +95,7 @@ namespace Xamarin.Android.Prepare
 				{ "@java@",                 context.OS.JavaPath },
 				{ "@jar@",                  context.OS.JarPath },
 				{ "@ANT_DIRECTORY@",        context.OS.AntDirectory },
+				{ "@SevenZip@",             context.Tools.SevenZipPath },
 			};
 
 			return new GeneratedPlaceholdersFile (

--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -179,6 +179,7 @@
     <Compile Include="ToolRunners\ToolRunner.cs" />
     <Compile Include="ToolRunners\ToolRunner.OutputSink.cs" />
     <Compile Include="Application\RefreshableComponent.cs" />
+    <Compile Include="Steps\Step_DownloadXDelta.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(OS)' == 'Unix' ">
     <Compile Include="Application\EssentialTools.Unix.cs" />


### PR DESCRIPTION
As part of our development of the fast deployment
system we need to have a way to do binary diffs.
The xdelta tool (http://xdelta.org) provides that
capability. This PR makes use of the binaries
produced from the following fork of xdelta

	https://github.com/dellis1972/xdelta

It downloads the binaries for MacOS, Linux and Windows.
It also downloads Android binaries for the following
architectures

	x86, x86_64, armeabi-v7a, arm64-v8a

This will allow us to produce a binary diff on the
host machine and apply it on the device.