### PR TITLE
[jnimarshalmethod-gen] Include java-interop.jar in the installation

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -60,6 +60,7 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Runtime.Environment.dll.config" Condition=" '$(HostOS)' != 'Windows' " />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\jcw-gen.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\jit-times.exe" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\java-interop.jar" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\jnimarshalmethod-gen.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\LayoutBinding.cs" />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-android.debug.so')" />

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -49,6 +49,7 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\HtmlAgilityPack.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\illinkanalyzer.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Irony.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\java-interop.jar" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\javadoc-to-mdoc.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Interop.dll.config" />
@@ -60,7 +61,6 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Java.Runtime.Environment.dll.config" Condition=" '$(HostOS)' != 'Windows' " />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\jcw-gen.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\jit-times.exe" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\java-interop.jar" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\jnimarshalmethod-gen.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\LayoutBinding.cs" />
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libmono-android.debug.so')" />


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3234

We had trouble creating the required java types, because
`java-interop.jar` was missing.

Thus we endup with:

	Error: jnimarshalmethod-gen: Unable to create Java VM
	System.TypeInitializationException: The type initializer for 'Types' threw an exception. ---> System.NullReferenceException: Object reference not set to an instance of an object
	  at Java.Interop.JniEnvironment+Types.FindClass (System.String classname) [0x000b2] in <3d0cf794364146b58e1c173deac04834>:0
	  at Java.Interop.JniType..ctor (System.String classname) [0x00006] in <3d0cf794364146b58e1c173deac04834>:0
	  at Java.Interop.JniEnvironment+Types..cctor () [0x000d2] in <3d0cf794364146b58e1c173deac04834>:0
	   --- End of inner exception stack trace ---
	  at Java.Interop.JniType..ctor (System.String classname) [0x00006] in <3d0cf794364146b58e1c173deac04834>:0
	  at Java.Interop.JniRuntime..ctor (Java.Interop.JniRuntime+CreationOptions options) [0x001b4] in <3d0cf794364146b58e1c173deac04834>:0
	  at Java.Interop.JreRuntime..ctor (Java.Interop.JreRuntimeOptions builder) [0x00007] in <0837e9ee267c4328a98bfd16059a729d>:0
	  at Java.Interop.JreRuntimeOptions.CreateJreVM () [0x00000] in <0837e9ee267c4328a98bfd16059a729d>:0
	  at Xamarin.Android.Tools.JniMarshalMethodGenerator.App.CreateJavaVM (System.String jvmDllPath) [0x0000d] in <c1d2f255a4b541868afd675bdc42a188>:0