### PR TITLE
[build] Check build dir for results before copy

### DIFF
--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -240,6 +240,7 @@ timestamps {
                 sh "make package-build-status CONFIGURATION=${env.BuildFlavor} V=1"
 
                 if (isCommercial) {
+                    sh "ls -l ${XADir}/bin/Build${env.BuildFlavor}"
                     sh "cp ${XADir}/bin/Build${env.BuildFlavor}/xa-build-status-*.zip ${packagePath}"
                 }
             } catch (error) {


### PR DESCRIPTION
We're encountering a failure when attemping to copy the 'xa-build-status'
zip to it's publish destination. For debugging purposes, we'll check the
content of this folder before attempting to copy anything.