### PR TITLE
[docs] Add OSS Xamarin.Android master download location

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,12 @@ Xamarin.Android provides open-source bindings of the Android SDK for use with
 | **Commercial Xamarin.Android 8.3 (d15-7)** for macOS &amp; Windows+Visual Studio 2017       | [![Commercial Xamarin.Android 8.3, macOS+VS2017][commercial-d15-7-macOS-x86_64-icon]][commercial-d15-7-macOS-x86_64-status] |
 | **Commercial Xamarin.Android 9.0 (d15-8)** for macOS &amp; Windows+Visual Studio 2017       | [![Commercial Xamarin.Android 9.0, macOS+VS2017][commercial-d15-8-macOS-x86_64-icon]][commercial-d15-8-macOS-x86_64-status] |
 | **Commercial Xamarin.Android 9.1 (d15-9)** for macOS &amp; Windows+Visual Studio 2017       | [![Commercial Xamarin.Android 9.1, macOS+VS2017][commercial-d15-9-macOS-x86_64-icon]][commercial-d15-9-macOS-x86_64-status] |
-| **Commercial Xamarin.Android 9.2 (d16-0)** for Windows+Visual Studio 2019       | [Download][commercial-d16-0-Windows-x86_64] |
-| **Commercial Xamarin.Android 9.2 (d16-0)** for macOS                            | [Download][commercial-d16-0-macOS-x86_64]   |
+| **Commercial Xamarin.Android 9.2 (d16-0)** for Windows+Visual Studio 2019                   | [Download][commercial-d16-0-Windows-x86_64] |
+| **Commercial Xamarin.Android 9.2 (d16-0)** for macOS                                        | [Download][commercial-d16-0-macOS-x86_64]   |
+| **Commercial Xamarin.Android 9.3 (d16-1)** for Windows+Visual Studio 2019                   | [Download][commercial-d16-1-Windows-x86_64] |
+| **Commercial Xamarin.Android 9.3 (d16-1)** for macOS                                        | [Download][commercial-d16-1-macOS-x86_64]   |
+| **Commercial Xamarin.Android 9.4 (d16-2) Preview** for Windows+Visual Studio 2019 Preview   | [Download][commercial-d16-2-Windows-x86_64] |
+| **Commercial Xamarin.Android 9.4 (d16-2) Preview** for macOS                                | [Download][commercial-d16-2-macOS-x86_64]   |
 | **OSS Xamarin.Android 9.4.99 (master)** for macOS &amp; Windows+Visual Studio 2019\*        | [![Open Source Xamarin.Android 9.4.99, macOS+VS2019][oss-master-macOS-x86_64-icon]][oss-master-macOS-x86_64-artifacts] |
 
 *\* Please note that the OSS installer packages are not digitally signed.*
@@ -51,6 +55,10 @@ Xamarin.Android provides open-source bindings of the Android SDK for use with
 [commercial-d15-9-macOS-x86_64-status]:   https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-builds-d15-9/
 [commercial-d16-0-Windows-x86_64]:        https://download.visualstudio.microsoft.com/download/pr/b153d2f1-f6ce-4fdf-b38d-5e228ae08bd6/d308fbee786cfb26a2fd783f183f4e7e/xamarin.android.sdk.9.2.3.0.vsix
 [commercial-d16-0-macOS-x86_64]:          https://download.visualstudio.microsoft.com/download/pr/70ad99db-5313-4c32-9b0e-9c5b37a995c9/e505e4500a1a89d947906fecad034031/xamarin.android-9.2.3-0.pkg
+[commercial-d16-1-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-release-windows
+[commercial-d16-1-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-release-macos
+[commercial-d16-2-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-preview-windows
+[commercial-d16-2-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-preview-macos
 [oss-master-macOS-x86_64-icon]:           https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/lastSuccessfulBuild/badge/icon
 [oss-master-macOS-x86_64-artifacts]:      https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/lastSuccessfulBuild/Azure
 

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ Xamarin.Android provides open-source bindings of the Android SDK for use with
 [commercial-d15-8-macOS-x86_64-status]:   https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-builds-d15-8/
 [commercial-d15-9-macOS-x86_64-icon]:     https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-builds-d15-9/badge/icon
 [commercial-d15-9-macOS-x86_64-status]:   https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-builds-d15-9/
-[commercial-d16-0-Windows-x86_64]:        https://download.visualstudio.microsoft.com/download/pr/b153d2f1-f6ce-4fdf-b38d-5e228ae08bd6/d308fbee786cfb26a2fd783f183f4e7e/xamarin.android.sdk.9.2.3.0.vsix
-[commercial-d16-0-macOS-x86_64]:          https://download.visualstudio.microsoft.com/download/pr/70ad99db-5313-4c32-9b0e-9c5b37a995c9/e505e4500a1a89d947906fecad034031/xamarin.android-9.2.3-0.pkg
-[commercial-d16-1-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-release-windows
-[commercial-d16-1-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-release-macos
-[commercial-d16-2-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-preview-windows
-[commercial-d16-2-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-preview-macos
+[commercial-d16-0-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-0-windows
+[commercial-d16-0-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-0-macos
+[commercial-d16-1-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-1-windows
+[commercial-d16-1-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-1-macos
+[commercial-d16-2-Windows-x86_64]:        https://aka.ms/xamarin-android-commercial-d16-2-windows
+[commercial-d16-2-macOS-x86_64]:          https://aka.ms/xamarin-android-commercial-d16-2-macos
 [oss-master-macOS-x86_64-icon]:           https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/lastSuccessfulBuild/badge/icon
 [oss-master-macOS-x86_64-artifacts]:      https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/lastSuccessfulBuild/Azure
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ Xamarin.Android provides open-source bindings of the Android SDK for use with
 
 | Platform        | Status |
 |-----------------|--------|
-| **Commercial Xamarin.Android 7.3 (d15-2)** for macOS                                        | [![Commercial Xamarin.Android 7.3, macOS][commercial-d15-2-macOS-x86_64-icon]][commercial-d15-2-macOS-x86_64-status] |
-| **Commercial Xamarin.Android 7.4 (d15-3)** for macOS                                        | [![Commercial Xamarin.Android 7.4, macOS][commercial-d15-3-macOS-x86_64-icon]][commercial-d15-3-macOS-x86_64-status] |
 | **Commercial Xamarin.Android 8.0 (d15-4)** for macOS &amp; Windows+Visual Studio 2017       | [![Commercial Xamarin.Android 8.0, macOS+VS2017][commercial-d15-4-macOS-x86_64-icon]][commercial-d15-4-macOS-x86_64-status] |
 | **Commercial Xamarin.Android 8.1 (d15-5)** for macOS &amp; Windows+Visual Studio 2017       | [![Commercial Xamarin.Android 8.1, macOS+VS2017][commercial-d15-5-macOS-x86_64-icon]][commercial-d15-5-macOS-x86_64-status] |
 | **Commercial Xamarin.Android 8.2 (d15-6)** for macOS &amp; Windows+Visual Studio 2017       | [![Commercial Xamarin.Android 8.2, macOS+VS2017][commercial-d15-6-macOS-x86_64-icon]][commercial-d15-6-macOS-x86_64-status] |
@@ -35,11 +33,10 @@ Xamarin.Android provides open-source bindings of the Android SDK for use with
 | **Commercial Xamarin.Android 9.1 (d15-9)** for macOS &amp; Windows+Visual Studio 2017       | [![Commercial Xamarin.Android 9.1, macOS+VS2017][commercial-d15-9-macOS-x86_64-icon]][commercial-d15-9-macOS-x86_64-status] |
 | **Commercial Xamarin.Android 9.2 (d16-0)** for Windows+Visual Studio 2019       | [Download][commercial-d16-0-Windows-x86_64] |
 | **Commercial Xamarin.Android 9.2 (d16-0)** for macOS                            | [Download][commercial-d16-0-macOS-x86_64]   |
+| **OSS Xamarin.Android 9.4.99 (master)** for macOS &amp; Windows+Visual Studio 2019\*        | [![Open Source Xamarin.Android 9.4.99, macOS+VS2019][oss-master-macOS-x86_64-icon]][oss-master-macOS-x86_64-artifacts] |
 
-[commercial-d15-2-macOS-x86_64-icon]:     https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-builds-d15-2/badge/icon
-[commercial-d15-2-macOS-x86_64-status]:   https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-builds-d15-2/
-[commercial-d15-3-macOS-x86_64-icon]:     https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-builds-d15-3/badge/icon
-[commercial-d15-3-macOS-x86_64-status]:   https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-builds-d15-3/
+*\* Please note that the OSS installer packages are not digitally signed.*
+
 [commercial-d15-4-macOS-x86_64-icon]:     https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-builds-d15-4/badge/icon
 [commercial-d15-4-macOS-x86_64-status]:   https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-builds-d15-4/
 [commercial-d15-5-macOS-x86_64-icon]:     https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-builds-d15-5/badge/icon
@@ -54,6 +51,8 @@ Xamarin.Android provides open-source bindings of the Android SDK for use with
 [commercial-d15-9-macOS-x86_64-status]:   https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-builds-d15-9/
 [commercial-d16-0-Windows-x86_64]:        https://download.visualstudio.microsoft.com/download/pr/b153d2f1-f6ce-4fdf-b38d-5e228ae08bd6/d308fbee786cfb26a2fd783f183f4e7e/xamarin.android.sdk.9.2.3.0.vsix
 [commercial-d16-0-macOS-x86_64]:          https://download.visualstudio.microsoft.com/download/pr/70ad99db-5313-4c32-9b0e-9c5b37a995c9/e505e4500a1a89d947906fecad034031/xamarin.android-9.2.3-0.pkg
+[oss-master-macOS-x86_64-icon]:           https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/lastSuccessfulBuild/badge/icon
+[oss-master-macOS-x86_64-artifacts]:      https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/lastSuccessfulBuild/Azure
 
 # Contributing
 


### PR DESCRIPTION
Also, remove the old Xamarin.Android 7.x download locations for
tidiness.