### PR TITLE
[Xamarin.Android.Build.Tasks] Apk per ABI fails with TargetFrameworkVersion v7.1 and lower when Aapt2 is enabled

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
@@ -66,12 +66,8 @@ namespace Xamarin.Android.Tasks {
 					archives.Add (new TaskItem (outputArchive));
 			}
 			foreach (var line in output) {
-				if (line.StdError) {
-					if (!LogAapt2EventsFromOutput (line.Line, MessageImportance.Normal, success))
-						break;
-				} else {
-					LogMessage (line.Line, MessageImportance.Normal);
-				}
+				if (!LogAapt2EventsFromOutput (line.Line, MessageImportance.Normal, success))
+					break;
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -222,12 +222,8 @@ namespace Xamarin.Android.Tasks {
 				? File.Exists (Path.Combine (currentResourceOutputFile + ".bk"))
 				: ret;
 			foreach (var line in output) {
-				if (line.StdError) {
-					if (!LogAapt2EventsFromOutput (line.Line, MessageImportance.Normal, success))
-						break;
-				} else {
-					LogMessage (line.Line, MessageImportance.Normal);
-				}
+				if (!LogAapt2EventsFromOutput (line.Line, MessageImportance.Normal, success))
+					break;
 			}
 			if (ret && !string.IsNullOrEmpty (currentResourceOutputFile)) {
 				var tmpfile = currentResourceOutputFile + ".bk";


### PR DESCRIPTION
Fixes #3083

`aapt2` can be inconsistent regarding its exit code and
writing errors to stderr. It turns out that there are
cases where only WARNINGS are written to stderr. In this
case the exit code is 0. However we can not rely on the
exit code only, since there have been cases where
the exit code is 0 but we have errors on stderr.

So what we need to do is parse the stderr output and look
for those `tags` which we know represent warnings. This is
so we can correctly classify those errors/warnings to make
sure we correctly report the issues.