### PR TITLE
[Xamarin.Android.Build.Tasks] downgrade XA0106 to a message

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -38,11 +38,12 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void BuildHasNoWarnings ([Values (true, false)] bool isRelease)
+		public void BuildHasNoWarnings ([Values (true, false)] bool isRelease, [Values (true, false)] bool xamarinForms)
 		{
-			var proj = new XamarinFormsAndroidApplicationProject {
-				IsRelease = isRelease,
-			};
+			var proj = xamarinForms ?
+				new XamarinFormsAndroidApplicationProject () :
+				new XamarinAndroidApplicationProject ();
+			proj.IsRelease = isRelease;
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "0 Warning(s)"), "Should have zero MSBuild warnings.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -40,7 +40,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void BuildHasNoWarnings ([Values (true, false)] bool isRelease)
 		{
-			var proj = new XamarinAndroidApplicationProject {
+			var proj = new XamarinFormsAndroidApplicationProject {
 				IsRelease = isRelease,
 			};
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ResourceDesignerImportGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ResourceDesignerImportGenerator.cs
@@ -66,23 +66,15 @@ namespace Xamarin.Android.Tasks
 				var srcClassRef = new CodeTypeReferenceExpression (
 					new CodeTypeReference (primary_name + (isNestedSrc ? '.' : '_') + type.Name, CodeTypeReferenceOptions.GlobalReference));
 				// destination language may not support nested types, but they should take care of such types by themselves.
+				var typeFullName = type.FullName.Replace ('/', '.');
 				var dstClassRef = new CodeTypeReferenceExpression (
-					new CodeTypeReference (type.FullName.Replace ('/', '.'), CodeTypeReferenceOptions.GlobalReference));
+					new CodeTypeReference (typeFullName, CodeTypeReferenceOptions.GlobalReference));
 				foreach (var field in type.Fields) {
 					var dstField = new CodeFieldReferenceExpression (dstClassRef, field.Name);
 					var srcField = new CodeFieldReferenceExpression (srcClassRef, field.Name);
 					var fieldName = CreateIdentifier (type.Name, field.Name);
 					if (!resourceFields.Contains (fieldName)) {
-						Log.LogWarning (subcategory: null,
-							warningCode: "XA0106",
-							helpKeyword: null,
-							file: null,
-							lineNumber: 0,
-							columnNumber: 0,
-							endLineNumber: 0,
-							endColumnNumber: 0,
-							message: $"Skipping {fieldName}. Please check that your Nuget Package versions are compatible."
-						);
+						Log.LogDebugMessage ($"Value not found for {typeFullName}.{field.Name}, skipping...");
 						continue;
 					}
 					// This simply assigns field regardless of whether it is int or int[].


### PR DESCRIPTION
Fixes: http://feedback.devdiv.io/606610
Fixes: https://github.com/xamarin/xamarin-android/issues/1988

The latest version of Xamarin.Forms causes warnings such as:

    warning XA0106: Skipping UnnamedProject.Resource.Drawable.avd_hide_password_1. Please check that your Nuget Package versions are compatible.
    warning XA0106: Skipping UnnamedProject.Resource.Drawable.avd_hide_password_2. Please check that your Nuget Package versions are compatible.
    warning XA0106: Skipping UnnamedProject.Resource.Drawable.avd_hide_password_3. Please check that your Nuget Package versions are compatible.
    warning XA0106: Skipping UnnamedProject.Resource.Drawable.avd_show_password_1. Please check that your Nuget Package versions are compatible.
    warning XA0106: Skipping UnnamedProject.Resource.Drawable.avd_show_password_2. Please check that your Nuget Package versions are compatible.
    warning XA0106: Skipping UnnamedProject.Resource.Drawable.avd_show_password_3. Please check that your Nuget Package versions are compatible.
    warning XA0106: Skipping UnnamedProject.Resource.Id.fixed. Please check that your Nuget Package versions are compatible.

I was able to reproduce this, just by changing a test we have to use
`XamarinFormsAndroidApplicationProject`.

It appears that the Xamarin.Forms NuGet package is shipping fields
that aapt/aapt2 aren't finding:

    # Found
    public static int avd_hide_password;
    # Not found
    public static int avd_hide_password_1;
    public static int avd_hide_password_2;
    public static int avd_hide_password_3;
    # Found
    public static int avd_show_password;
    # Not Found
    public static int avd_show_password_1;
    public static int avd_show_password_2;
    public static int avd_show_password_3;

Xamarin.Forms doesn't actually *use* these fields, but something has
changed between the version of either Xamarin.Android or the Android
SDK where Xamarin.Forms was built -- and how projects are built *now*.

In either case `XA0106` is completely unactionable, we should
downgrade it to a message and give a little more information while
we're at it.

This downgrades the warnings to:

    Value not found for Xamarin.Forms.Platform.Android.Resource.Drawable.avd_hide_password_1, skipping...
    Value not found for Xamarin.Forms.Platform.Android.Resource.Drawable.avd_hide_password_2, skipping...
    Value not found for Xamarin.Forms.Platform.Android.Resource.Drawable.avd_hide_password_3, skipping...
    Value not found for Xamarin.Forms.Platform.Android.Resource.Drawable.avd_show_password_1, skipping...
    Value not found for Xamarin.Forms.Platform.Android.Resource.Drawable.avd_show_password_2, skipping...
    Value not found for Xamarin.Forms.Platform.Android.Resource.Drawable.avd_show_password_3, skipping...

I think it makes more sense to give the full name of the field, so it
indicates the assembly it came from.