### PR TITLE
[build] Fix internal Jenkins build status reporting

### DIFF
--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -240,8 +240,7 @@ timestamps {
                 sh "make package-build-status CONFIGURATION=${env.BuildFlavor} V=1"
 
                 if (isCommercial) {
-                    sh "ls -l ${XADir}/bin/Build${env.BuildFlavor}"
-                    sh "cp ${XADir}/bin/Build${env.BuildFlavor}/xa-build-status-*.zip ${packagePath}"
+                    sh "cp bin/Build${env.BuildFlavor}/xa-build-status-*.zip ${packagePath}"
                 }
             } catch (error) {
                 echo "ERROR : NON-FATAL : processBuildStatus: Unexpected error: ${error}"


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/d9348ebfe58a41c8bb340a3984c62e1a4f90d9c3

We were encountering an issue when trying to upload our build results
file on internal Jenkins, which appears to have been caused by the fact
that we were appending an extra 'xamarin-android' to the result path we
were trying to copy from. Strangely, this upload failure seemed to only
happen intermittently, but I'm not sure how (if?) it ever worked.

The fix is to remove the extra 'xamarin-android' value from the expected
build result path, as we're already executing these commands from the
'xamarin-android' directory.