### PR TITLE
Add a solution file for remap-assembly-ref

### DIFF
--- a/build-tools/remap-assembly-ref/remap-assembly-ref.sln
+++ b/build-tools/remap-assembly-ref/remap-assembly-ref.sln
@@ -1,0 +1,28 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "remap-assembly-ref", "remap-assembly-ref.csproj", "{C876DA71-8573-4CEF-9149-716D72455ED4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Android.Cecil", "..\..\external\Java.Interop\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.csproj", "{15945D4B-FF56-4BCC-B598-2718D199DD08}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+		Gendarme|Any CPU = Gendarme|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C876DA71-8573-4CEF-9149-716D72455ED4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C876DA71-8573-4CEF-9149-716D72455ED4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C876DA71-8573-4CEF-9149-716D72455ED4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C876DA71-8573-4CEF-9149-716D72455ED4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C876DA71-8573-4CEF-9149-716D72455ED4}.Gendarme|Any CPU.ActiveCfg = Debug|Any CPU
+		{C876DA71-8573-4CEF-9149-716D72455ED4}.Gendarme|Any CPU.Build.0 = Debug|Any CPU
+		{15945D4B-FF56-4BCC-B598-2718D199DD08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{15945D4B-FF56-4BCC-B598-2718D199DD08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{15945D4B-FF56-4BCC-B598-2718D199DD08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{15945D4B-FF56-4BCC-B598-2718D199DD08}.Release|Any CPU.Build.0 = Release|Any CPU
+		{15945D4B-FF56-4BCC-B598-2718D199DD08}.Gendarme|Any CPU.ActiveCfg = Gendarme|Any CPU
+		{15945D4B-FF56-4BCC-B598-2718D199DD08}.Gendarme|Any CPU.Build.0 = Gendarme|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/build-tools/xaprepare/xaprepare/Steps/Step_PrepareLocal.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_PrepareLocal.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Android.Prepare
 			var msbuild = new MSBuildRunner (context);
 
 			// This needs to be built *after* we copy Java.Interop props or we'll get the wrong Mono.Cecil assembly.
-			string remapAsmRefPath = Path.Combine (Configurables.Paths.BuildToolsDir, "remap-assembly-ref", "remap-assembly-ref.csproj");
+			string remapAsmRefPath = Path.Combine (Configurables.Paths.BuildToolsDir, "remap-assembly-ref", "remap-assembly-ref.sln");
 			bool result = await msbuild.Run (
 				projectPath: remapAsmRefPath,
 				logTag: "remap-assembly-ref",


### PR DESCRIPTION
We've seen the following build error when `remap-assembly-ref` is built
from within `xaprepare` by passing its project file to msbuild:

    (ValidateSolutionConfiguration target) ->
    /Users/vsts/agent/2.153.2/work/1/s/external/mono/external/cecil/Mono.Cecil.sln.metaproj :
     error MSB4126: The specified solution configuration "net_4_0_Debug|Any CPU" is invalid.
     Please specify a valid solution configuration using the Configuration and Platform properties
     (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those
     properties blank to use the default solution configuration.
     [/Users/vsts/agent/2.153.2/work/1/s/external/mono/external/cecil/Mono.Cecil.sln]

The reason is that the `$(Configuration)` property, even though set on the msbuild
command line, is reset somewhere in one of the Cecil projects to the value shown in
the above error message. This happens because properties set on command line when
building a `.csproj`, instead of an `.sln`, are **not** made read-only. Thus, using
a solution file should fix the problem and this is what this commit is adding.