### PR TITLE
[docs] Correct NoWarn property to MSBuildWarningsAsMessages

### DIFF
--- a/Documentation/guides/messages/xa0113.md
+++ b/Documentation/guides/messages/xa0113.md
@@ -16,8 +16,8 @@ If you are seeing this warning, you should update the
 `$(TargetFrameworkVersion)` of your projects to be v8.0 or above.
 
 If you are not targeting the Google Play store and wish to hide these
-warnings, you can make use of the `/warnasmessage:XA0113` command line switch.
-Alternatively, add
+warnings, you can make use of the `/warnasmessage:XA0113` command line
+switch.  Alternatively, add
 
 ```xml
 <PropertyGroup>

--- a/Documentation/guides/messages/xa0113.md
+++ b/Documentation/guides/messages/xa0113.md
@@ -16,11 +16,13 @@ If you are seeing this warning, you should update the
 `$(TargetFrameworkVersion)` of your projects to be v8.0 or above.
 
 If you are not targeting the Google Play store and wish to hide these
-warnings, you can make use of the `/nowarn:XA0113` command line switch.
+warnings, you can make use of the `/warnasmessage:XA0113` command line switch.
 Alternatively, add
 
 ```xml
-<NoWarn>XA0113</NoWarn>
+<PropertyGroup>
+    <MSBuildWarningsAsMessages>XA0113</MSBuildWarningsAsMessages>
+</PropertyGroup>
 ```
 
 to your *.csproj* file.

--- a/Documentation/guides/messages/xa0114.md
+++ b/Documentation/guides/messages/xa0114.md
@@ -16,8 +16,8 @@ If you are seeing this warning, you should update the
 `$(TargetFrameworkVersion)` of your projects to be v8.0 or above.
 
 If you are not targeting the Google Play store and wish to hide these
-warnings, you can make use of the `/warnasmessage:XA0114` command line switch.
-Alternatively, add
+warnings, you can make use of the `/warnasmessage:XA0114` command line
+switch.  Alternatively, add
 
 ```xml
 <PropertyGroup>

--- a/Documentation/guides/messages/xa0114.md
+++ b/Documentation/guides/messages/xa0114.md
@@ -16,11 +16,13 @@ If you are seeing this warning, you should update the
 `$(TargetFrameworkVersion)` of your projects to be v8.0 or above.
 
 If you are not targeting the Google Play store and wish to hide these
-warnings, you can make use of the `/nowarn:XA0114` command line switch.
+warnings, you can make use of the `/warnasmessage:XA0114` command line switch.
 Alternatively, add
 
 ```xml
-<NoWarn>XA0114</NoWarn>
+<PropertyGroup>
+    <MSBuildWarningsAsMessages>XA0114</MSBuildWarningsAsMessages>
+</PropertyGroup>
 ```
 
 to your *.csproj* file.

--- a/Documentation/guides/messages/xa4214.md
+++ b/Documentation/guides/messages/xa4214.md
@@ -34,11 +34,11 @@ example is the `class` attribute on `fragment` elements.
 
 If you choose to use `[Register]` attributes or assembly-qualified names rather
 than renaming the managed types, then you can hide the warnings either by adding
-the `/nowarn:XA4214` switch to the MSBuild command line or by adding `XA4214` to
-the `$(NoWarn)` property in your .csproj file:
+the `/warnasmessage:XA4214` switch to the MSBuild command line or by adding `XA4214` to
+the `$(MSBuildWarningsAsMessages)` property in your .csproj file:
 
 ```xml
 <PropertyGroup>
-    <NoWarn>$(NoWarn);XA4214</NoWarn>
+    <MSBuildWarningsAsMessages>XA4214</MSBuildWarningsAsMessages>
 </PropertyGroup>
 ```

--- a/Documentation/guides/messages/xa4214.md
+++ b/Documentation/guides/messages/xa4214.md
@@ -34,8 +34,8 @@ example is the `class` attribute on `fragment` elements.
 
 If you choose to use `[Register]` attributes or assembly-qualified names rather
 than renaming the managed types, then you can hide the warnings either by adding
-the `/warnasmessage:XA4214` switch to the MSBuild command line or by adding `XA4214` to
-the `$(MSBuildWarningsAsMessages)` property in your .csproj file:
+the `/warnasmessage:XA4214` switch to the MSBuild command line or by adding
+`XA4214` to the `$(MSBuildWarningsAsMessages)` property in your .csproj file:
 
 ```xml
 <PropertyGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/1988

Also replace the `/nowarn` command line switch with its alias
`/warnasmessage` to help emphasize the distinction between this command
line switch and the *unrelated* `$(NoWarn)` MSBuild property.

I have verified that both the `/warnasmessage` command line switch and
the `$(MSBuildWarningsAsMessages)` MSBuild property successfully
suppress `XAnnnn` warnings such as `XA4214`.

The reason behind these changes is that I learned that the `/nowarn`
command line switch for MSBuild does *not* correspond to the `$(NoWarn)`
MSBuild property.  In fact, the `$(NoWarn)` property is not used at all
by the MSBuild logger itself.  It is instead passed into the [`<Csc/>`
task in C# projects][0], the [`<Vbc/>` task in Visual Basic
projects][1], and the [`MSBuildRestoreUtility` class][2] and
[`<PackTask/>` task][3] in the NuGet package manager, allowing those
tools to suppress the warnings internally, before MSBuild sees them.

In the past, MSBuild did not provide a mechanism to suppress warnings
via the MSBuild logger itself, so Xamarin.Android would have had to
provide its own mechanism to suppress warnings internally.  But as of [a
few years ago][4], MSBuild now includes a `/nowarn` (aka
`/warnasmessage`) command line switch to control how the MSBuild logger
itself suppresses warnings.  The complication is that the meaning of the
`$(NoWarn)` property was already well established by then, so instead of
changing the semantics of that existing property, the team [added a
separate `$(MSBuildWarningsAsMessages)` property][5] to go along with
the new command line switch.

Another little complication is that the [MSBuild command-line
reference][6] does not yet mention the `/nowarn` or `/warnasmessage`
switch, and the [common MSBuild project properties documentation][7]
does not yet mention the `$(MSBuildWarningsAsMessages)` property.  The
Visual Studio property pages UI doesn't currently include this property
either.  (The [**Build > Errors and warnings > Suppress warnings**][8]
Visual Studio property pages setting corresponds to older the
`$(NoWarn)` property instead.)

[0]: https://github.com/microsoft/msbuild/blob/v16.0.461.62831/src/Tasks/Microsoft.CSharp.CurrentVersion.targets#L259
[1]: https://github.com/microsoft/msbuild/blob/v16.0.461.62831/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets#L247
[2]: https://github.com/NuGet/NuGet.Client/blob/5.2.0.6045/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs#L606
[3]: https://github.com/NuGet/NuGet.Client/blob/5.2.0.6045/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets#L246
[4]: https://github.com/microsoft/msbuild/commit/4287837b1b447905625593a926d60ab5e756e71d
[5]: https://github.com/microsoft/msbuild/commit/01f99150e087634fd563af6fe557e0e8421ed6a5
[6]: https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2019
[7]: https://docs.microsoft.com/visualstudio/msbuild/common-msbuild-project-properties?view=vs-2019
[8]: https://docs.microsoft.com/en-us/visualstudio/ide/how-to-suppress-compiler-warnings?view=vs-2019#suppress-specific-warnings-for-visual-c-or-f