### PR TITLE
Always check if we have every bundle item installed

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -342,8 +342,8 @@ namespace Xamarin.Android.Prepare
 			//   * The "file" part must always be a valid glob pattern
 			//
 			public static readonly List<string> BundleVersionHashFiles = new List<string> {
-				Path.Combine (BuildToolsScriptsDir, "BuildEverything.mk"),
 				Path.Combine (BuildPaths.XAPrepareSourceDir, "ConfigAndData", "BuildAndroidPlatforms.cs"),
+				Path.Combine (BuildPaths.XAPrepareSourceDir, "ConfigAndData", "Runtimes.cs"),
 			};
 
 			public static string AndroidToolchainBinDirectory => EnsureAndroidToolchainBinDirectories ();

--- a/build-tools/xaprepare/xaprepare/Steps/MonoRuntimesHelpers.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/MonoRuntimesHelpers.cs
@@ -180,5 +180,35 @@ namespace Xamarin.Android.Prepare
 				return Path.GetFullPath (path);
 			}
 		}
+
+		public static string GetRootDir (Runtime runtime)
+		{
+			if (runtime == null)
+				throw new ArgumentNullException (nameof (runtime));
+
+			return Path.Combine (Configurables.Paths.MonoSDKSRelativeOutputDir, $"android-{runtime.PrefixedName}-{Configurables.Defaults.MonoSdksConfiguration}");
+		}
+
+		public static bool AllBundleItemsPresent (Runtimes runtimes)
+		{
+			if (runtimes == null)
+				throw new ArgumentNullException (nameof (runtimes));
+
+			bool runtimesFoundAndComplete = true;
+			foreach (BundleItem item in runtimes.BundleItems) {
+				if (item == null)
+					continue;
+
+				// BundleItem.SourcePath is the path *after* the file is installed into our tree
+				if (File.Exists (item.SourcePath))
+					continue;
+
+				runtimesFoundAndComplete = false;
+				Log.Instance.DebugLine ($"{item.SourcePath} missing, skipping the rest of bundle item file scan");
+				break;
+			}
+
+			return runtimesFoundAndComplete;
+		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/Steps/Step_BuildMonoRuntimes.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_BuildMonoRuntimes.Unix.cs
@@ -40,7 +40,8 @@ namespace Xamarin.Android.Prepare
 					Log.ErrorLine ("Mono runtime build failed");
 					return false;
 				}
-			}
+			} else
+				SaveAbiChoice (context);
 
 			CleanupBeforeInstall ();
 			Log.StatusLine ();
@@ -119,22 +120,7 @@ namespace Xamarin.Android.Prepare
 
 			Log.StatusLine ("Checking if all runtime files are present");
 			allRuntimes = new Runtimes ();
-			bool runtimesFoundAndComplete = true;
-			foreach (BundleItem item in allRuntimes.BundleItems) {
-				if (item == null)
-					continue;
-
-				// BundleItem.SourcePath is the path *after* the file is installed into our tree
-				if (File.Exists (item.SourcePath))
-					continue;
-
-				runtimesFoundAndComplete = false;
-				Log.DebugLine ($"{item.SourcePath} missing, skipping the rest of file scan");
-				Log.StatusLine ($"  {context.Characters.Bullet} some Mono Runtime files are missing, download/rebuild forced");
-				break;
-			}
-
-			if (runtimesFoundAndComplete) {
+			if (MonoRuntimesHelpers.AllBundleItemsPresent (allRuntimes)) {
 				// User might have changed the set of ABIs to build, we need to check and rebuild if necessary
 				if (!AbiChoiceChanged (context)) {
 					Log.StatusLine ("Mono runtimes already present and complete. No need to download or build.");
@@ -143,6 +129,7 @@ namespace Xamarin.Android.Prepare
 
 				Log.StatusLine ("Mono already present, but the choice of ABIs changed since previous build, runtime refresh is necessary");
 			}
+			Log.Instance.StatusLine ($"  {Context.Instance.Characters.Bullet} some files are missing, download/rebuild/reinstall forced");
 
 			bool result = await DownloadAndUpackIfNeeded (
 				context,
@@ -337,8 +324,6 @@ namespace Xamarin.Android.Prepare
 
 			StatusStep (context, "Installing Designer Windows BCL assemblies");
 			InstallBCLFiles (allRuntimes.DesignerWindowsBclFilesToInstall);
-
-			Utilities.DeleteDirectorySilent (Configurables.Paths.BCLWindowsOutputDir);
 
 			return GenerateFrameworkList (
 				context,

--- a/build-tools/xaprepare/xaprepare/Steps/Step_PrepareBundle.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_PrepareBundle.cs
@@ -91,13 +91,13 @@ namespace Xamarin.Android.Prepare
 			}
 
 			if (String.IsNullOrEmpty (context.XABundleCopyDir))
-				return true;
+				return HaveEverything ();
 
 			string destPackagePath = Path.Combine (context.XABundleCopyDir, Path.GetFileName (localPackagePath));
 			Log.DebugLine ($"Copy of the XA bundle was requested to be created at {destPackagePath}");
 			if (Utilities.FileExists (destPackagePath)) {
 				Log.DebugLine ("Bundle copy already exists");
-				return true;
+				return HaveEverything ();
 			}
 
 			// Utilities.FileExists above will return `false` for a dangling symlink at `destPackagePath`, doesn't hurt
@@ -105,7 +105,15 @@ namespace Xamarin.Android.Prepare
 			Utilities.DeleteFileSilent (destPackagePath);
 			Utilities.CopyFile (localPackagePath, destPackagePath);
 
-			return true;
+			return HaveEverything ();
+
+			bool HaveEverything ()
+			{
+				bool ret = MonoRuntimesHelpers.AllBundleItemsPresent (new Runtimes ());
+				if (!ret)
+					Log.Instance.StatusLine ($"Some bundle files are missing, download/rebuild/reinstall forced");
+				return ret;
+			}
 		}
 	}
 }


### PR DESCRIPTION
It may happen that some files which are supposed to be in the bundle are
missing. In such case we need to re-download or re-install the bundle to fix the
issue. This commit makes sure it happens.

Additionally, since all the bundle items are specified in `Runtimes.cs`, the
file must be used when calculating the bundle "version" hash or we might face
the issue when the list of expected bundle items (in `Runtimes.cs`) doesn't
agree with what's in the currently selected bundle - because the hash didn't
change even though we added/removed bundle items in `Runtimes.cs`