### PR TITLE
[build] Always build result package dependencies

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -131,7 +131,7 @@ stages:
       inputs:
         solution: build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
         configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:ZipBuildStatus /p:BuildStatusZipOutputPath=$(Build.ArtifactStagingDirectory)
+        msbuildArguments: /t:Build,ZipBuildStatus /p:BuildStatusZipOutputPath=$(Build.ArtifactStagingDirectory)
       condition: always()
 
     - task: PublishPipelineArtifact@0
@@ -223,7 +223,7 @@ stages:
       inputs:
         solution: build-tools\Xamarin.Android.Tools.BootstrapTasks\Xamarin.Android.Tools.BootstrapTasks.csproj
         configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:ZipBuildStatus;ZipTestResults /p:BuildStatusZipOutputPath=$(Build.ArtifactStagingDirectory) /p:TestResultZipOutputPath=$(Build.ArtifactStagingDirectory)
+        msbuildArguments: /t:Build,ZipBuildStatus,ZipTestResults /p:BuildStatusZipOutputPath=$(Build.ArtifactStagingDirectory) /p:TestResultZipOutputPath=$(Build.ArtifactStagingDirectory)
       condition: always()
 
     - task: PublishPipelineArtifact@0
@@ -426,7 +426,7 @@ stages:
       inputs:
         solution: build-tools/xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
         configuration: $(ApkTestConfiguration)
-        msbuildArguments: /t:ZipBuildStatus;ZipTestResults /p:BuildStatusZipOutputPath=$(Build.ArtifactStagingDirectory) /p:TestResultZipOutputPath=$(Build.ArtifactStagingDirectory)
+        msbuildArguments: /t:Build,ZipBuildStatus,ZipTestResults /p:BuildStatusZipOutputPath=$(Build.ArtifactStagingDirectory) /p:TestResultZipOutputPath=$(Build.ArtifactStagingDirectory)
       condition: always()
 
     - task: PublishPipelineArtifact@0

--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -4,10 +4,8 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <_TopDir>$(MSBuildThisFileDirectory)..\..</_TopDir>
     <_XAPrepareExe>$(MSBuildThisFileDirectory)..\xaprepare\xaprepare\bin\$(Configuration)\xaprepare.exe</_XAPrepareExe>
-    <_XAPrepareStandardArgs>--no-emoji --run-mode=CI -a</_XAPrepareStandardArgs>
+    <_XAPrepareStandardArgs Condition=" '$(RunningOnCI)' == 'true' ">--no-emoji --run-mode=CI -a -v:d</_XAPrepareStandardArgs>
     <_XAPrepareStandardArgs Condition=" '$(XA_FORCE_COMPONENT_REFRESH)' == 'true' ">$(_XAPrepareStandardArgs) -refresh</_XAPrepareStandardArgs>
-    <!-- Enable diagnostic output when executing from the Xamarin.Android Azure Pipeline -->
-    <_XAPrepareStandardArgs Condition=" '$(RunningOnCI)' == 'true' ">$(_XAPrepareStandardArgs) -v:d</_XAPrepareStandardArgs>
     <_XAPrepareBundleArgs Condition=" '$(BundleRootPath)' != '' ">--bundle-path=&quot;$(BundleRootPath)&quot;</_XAPrepareBundleArgs>
   </PropertyGroup>
   <Import Project="$(_TopDir)\Configuration.props" />

--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -6,8 +6,8 @@
     <_XAPrepareExe>$(MSBuildThisFileDirectory)..\xaprepare\xaprepare\bin\$(Configuration)\xaprepare.exe</_XAPrepareExe>
     <_XAPrepareStandardArgs>--no-emoji --run-mode=CI -a</_XAPrepareStandardArgs>
     <_XAPrepareStandardArgs Condition=" '$(XA_FORCE_COMPONENT_REFRESH)' == 'true' ">$(_XAPrepareStandardArgs) -refresh</_XAPrepareStandardArgs>
-    <!--Enable diagnostic output when executing from Azure Pipelines-->
-    <_XAPrepareStandardArgs Condition=" '$(SYSTEM_DEFAULTWORKINGDIRECTORY)' != '' ">$(_XAPrepareStandardArgs) -v:d</_XAPrepareStandardArgs>
+    <!-- Enable diagnostic output when executing from the Xamarin.Android Azure Pipeline -->
+    <_XAPrepareStandardArgs Condition=" '$(RunningOnCI)' == 'true' ">$(_XAPrepareStandardArgs) -v:d</_XAPrepareStandardArgs>
     <_XAPrepareBundleArgs Condition=" '$(BundleRootPath)' != '' ">--bundle-path=&quot;$(BundleRootPath)&quot;</_XAPrepareBundleArgs>
   </PropertyGroup>
   <Import Project="$(_TopDir)\Configuration.props" />

--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -5,7 +5,9 @@
     <_TopDir>$(MSBuildThisFileDirectory)..\..</_TopDir>
     <_XAPrepareExe>$(MSBuildThisFileDirectory)..\xaprepare\xaprepare\bin\$(Configuration)\xaprepare.exe</_XAPrepareExe>
     <_XAPrepareStandardArgs>--no-emoji --run-mode=CI -a</_XAPrepareStandardArgs>
-    <_XAPrepareStandardArgs Condition= " '$(XA_FORCE_COMPONENT_REFRESH)' == 'true' ">$(_XAPrepareStandardArgs) -refresh</_XAPrepareStandardArgs>
+    <_XAPrepareStandardArgs Condition=" '$(XA_FORCE_COMPONENT_REFRESH)' == 'true' ">$(_XAPrepareStandardArgs) -refresh</_XAPrepareStandardArgs>
+    <!--Enable diagnostic output when executing from Azure Pipelines-->
+    <_XAPrepareStandardArgs Condition=" '$(SYSTEM_DEFAULTWORKINGDIRECTORY)' != '' ">$(_XAPrepareStandardArgs) -v:d</_XAPrepareStandardArgs>
     <_XAPrepareBundleArgs Condition=" '$(BundleRootPath)' != '' ">--bundle-path=&quot;$(BundleRootPath)&quot;</_XAPrepareBundleArgs>
   </PropertyGroup>
   <Import Project="$(_TopDir)\Configuration.props" />


### PR DESCRIPTION
Sometimes 'xaprepare.exe' will fail before all of the build status
packaging dependencies are built. We can fix some of these cases by
ensuring that we always call the build target before calling any status
packaging targets.