### PR TITLE
Reset file attributes if they prevent deletion of a temporary dir

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_PrepareBundle.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_PrepareBundle.cs
@@ -85,7 +85,7 @@ namespace Xamarin.Android.Prepare
 				}
 
 				Log.DebugLine ("Moving unpacked bundle from {tempDir} to {Configurables.Paths.Bundle_InstallDir}");
-				Utilities.MoveDirectoryContentsRecursively (tempDir, Configurables.Paths.BundleInstallDir, resetFileTimestamp: true);
+				Utilities.MoveDirectoryContentsRecursively (tempDir, Configurables.Paths.BundleInstallDir, resetFileTimestamp: true, ignoreDeletionErrors: true);
 			} finally {
 				Utilities.DeleteDirectorySilent (tempDir);
 			}


### PR DESCRIPTION
The problem, so far, occurred only on Windows, but it may happen on other
systems as well. Whenever a file is marked read-only the `Directory.Delete`
method will throw a "permission denied" exception, refusing to delete the file.
This happens, for instance, with our current bundle in which the
`libzip.5.0.dylib` file is marked read-only after 7z writes it to the system (in
my case the macOSX permissions for the file were `444` octal, so it is, indeed,
read-only).

In order to work around this we catch the `UnauthorizedAccessException` and
attempt to recursively reset permissions of all files found in the directory
being moved to `FileAttributes.Normal`.

Additionally, `MoveDirectoryContentsRecursively` now has a way to ignore all
directory deletion errors. By default the errors aren't ignored with the
exception of the Xamarin.Android bundle unpacking.