### PR TITLE
Don't include designer BCL files in BuildItems on Windows

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/MonoCrossRuntime.Windows.cs
+++ b/build-tools/xaprepare/xaprepare/Application/MonoCrossRuntime.Windows.cs
@@ -1,0 +1,20 @@
+using System;
+using System.IO;
+
+namespace Xamarin.Android.Prepare
+{
+	partial class MonoCrossRuntime : MonoRuntime
+	{
+		partial void InitOS ()
+		{
+			// On Windows we should not check cross runtimes because we don't build them - thus they must be
+			// removed from the set of runtime files/bundle items or otherwise we'll get false negatives
+			// similar to:
+			//
+			//   bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\Windows\cross-arm missing, skipping the rest of bundle item file scan
+			//      Some bundle files are missing, download/rebuild/reinstall forced
+			//
+			SupportedOnHostOS = false;
+		}
+	}
+}

--- a/build-tools/xaprepare/xaprepare/Application/MonoCrossRuntime.cs
+++ b/build-tools/xaprepare/xaprepare/Application/MonoCrossRuntime.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Xamarin.Android.Prepare
 {
-	class MonoCrossRuntime : MonoRuntime
+	partial class MonoCrossRuntime : MonoRuntime
 	{
 		public override string Flavor => "cross compilation";
 
@@ -13,6 +13,8 @@ namespace Xamarin.Android.Prepare
 
 		public override void Init (Context context)
 		{
+			InitOS ();
+
 			if (context.IsHostCrossAotAbi (Name)) {
 				InstallPath = context.OS.Type; // Linux | Darwin | Windows
 				Strip = "strip";
@@ -33,5 +35,7 @@ namespace Xamarin.Android.Prepare
 			CrossMonoName = Configurables.Defaults.CrossRuntimeNames [Name];
 			ExePrefix = Configurables.Defaults.CrossRuntimeExePrefixes [Name];
 		}
+
+		partial void InitOS ();
 	}
 }

--- a/build-tools/xaprepare/xaprepare/Application/Runtime.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Runtime.cs
@@ -6,8 +6,13 @@ namespace Xamarin.Android.Prepare
 	{
 		Func<Context, bool> enabledCheck;
 
+		/// <summary>
+		///   Set to <c>true</c> if the current runtime is supported on the host OS.
+		/// </summary>
+		protected bool SupportedOnHostOS { get; set; } = true;
+
 		protected Context Context => Context.Instance;
-		public bool Enabled       => enabledCheck (Context);
+		public bool Enabled       => SupportedOnHostOS && enabledCheck (Context);
 		public string ExeSuffix   { get; protected set; }
 
 		/// <summary>

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Runtimes.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Runtimes.Unix.cs
@@ -11,5 +11,29 @@ namespace Xamarin.Android.Prepare
 		{
 			bundleItems.AddRange (UnixBundleItems);
 		}
+
+		partial void PopulateDesignerBclFiles (List<BclFile> designerHostBclFilesToInstall, List<BclFile> designerWindowsBclFilesToInstall)
+		{
+			designerHostBclFilesToInstall.AddRange (BclToDesigner (BclFileTarget.DesignerHost));
+			designerWindowsBclFilesToInstall.AddRange (BclToDesigner (BclFileTarget.DesignerWindows));
+
+			List<BclFile> BclToDesigner (BclFileTarget ignoreForTarget)
+			{
+				return BclFilesToInstall.Where (bf => ShouldInclude (bf, ignoreForTarget)).Select (bf => new BclFile (bf.Name, bf.Type, excludeDebugSymbols: true, version: bf.Version, target: ignoreForTarget)).ToList ();
+			}
+
+			bool ShouldInclude (BclFile bf, BclFileTarget ignoreForTarget)
+			{
+				if (DesignerIgnoreFiles == null || !DesignerIgnoreFiles.TryGetValue (bf.Name, out (BclFileType Type, BclFileTarget Target) bft)) {
+					return true;
+				}
+
+				if (bf.Type != bft.Type || bft.Target != ignoreForTarget)
+					return true;
+
+				Log.Instance.DebugLine ($"BCL file {bf.Name} will NOT be included in the installed Designer BCL files ({ignoreForTarget})");
+				return false;
+			}
+		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Runtimes.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Runtimes.cs
@@ -842,27 +842,13 @@ namespace Xamarin.Android.Prepare
 				runtime.Init (c);
 			}
 
-			DesignerHostBclFilesToInstall = BclToDesigner (BclFileTarget.DesignerHost);
-			DesignerWindowsBclFilesToInstall = BclToDesigner (BclFileTarget.DesignerWindows);
+			DesignerHostBclFilesToInstall = new List<BclFile> ();
+			DesignerWindowsBclFilesToInstall = new List<BclFile> ();
 
-			List<BclFile> BclToDesigner (BclFileTarget ignoreForTarget)
-			{
-				return BclFilesToInstall.Where (bf => ShouldInclude (bf, ignoreForTarget)).Select (bf => new BclFile (bf.Name, bf.Type, excludeDebugSymbols: true, version: bf.Version, target: ignoreForTarget)).ToList ();
-			}
-
-			bool ShouldInclude (BclFile bf, BclFileTarget ignoreForTarget)
-			{
-				if (DesignerIgnoreFiles == null || !DesignerIgnoreFiles.TryGetValue (bf.Name, out (BclFileType Type, BclFileTarget Target) bft)) {
-					return true;
-				}
-
-				if (bf.Type != bft.Type || bft.Target != ignoreForTarget)
-					return true;
-
-				Log.Instance.DebugLine ($"BCL file {bf.Name} will NOT be included in the installed Designer BCL files ({ignoreForTarget})");
-				return false;
-			}
+			PopulateDesignerBclFiles (DesignerHostBclFilesToInstall, DesignerWindowsBclFilesToInstall);
 		}
+
+		partial void PopulateDesignerBclFiles (List<BclFile> designerHostBclFilesToInstall, List<BclFile> designerWindowsBclFilesToInstall);
 
 		List<BundleItem> bundleItems;
 	}

--- a/build-tools/xaprepare/xaprepare/Steps/Step_PrepareBundle.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_PrepareBundle.cs
@@ -84,7 +84,7 @@ namespace Xamarin.Android.Prepare
 					return false;
 				}
 
-				Log.DebugLine ("Moving unpacked bundle from {tempDir} to {Configurables.Paths.Bundle_InstallDir}");
+				Log.DebugLine ($"Moving unpacked bundle from {tempDir} to {Configurables.Paths.BundleInstallDir}");
 				Utilities.MoveDirectoryContentsRecursively (tempDir, Configurables.Paths.BundleInstallDir, resetFileTimestamp: true);
 			} finally {
 				Utilities.DeleteDirectorySilent (tempDir);

--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -249,6 +249,7 @@
     <Compile Include="Application\DetermineWindowsVersion.Windows.cs" />
     <Compile Include="Application\LlvmRuntime.Windows.cs" />
     <Compile Include="Application\Log.Windows.cs" />
+    <Compile Include="Application\MonoCrossRuntime.Windows.cs" />
     <Compile Include="Application\Utilities.Windows.cs" />
     <Compile Include="ConfigAndData\Configurables.Windows.cs" />
     <Compile Include="ConfigAndData\Dependencies\AndroidToolchain.Windows.cs" />


### PR DESCRIPTION
Windows, as a host, does NOT currently install any BCL files - it takes
everything from the bundle produced on macOS. However, the code to populate
designer BCL file sets also ran on Windows thus producing this, false negative,
error:

   bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\Windows\bcl\I18N.dll missing, skipping the rest of bundle item file scan
   Some bundle files are missing, download/rebuild/reinstall forced

   Step Xamarin.Android.Prepare.Step_PrepareBundle failed
    System.InvalidOperationException: Step Xamarin.Android.Prepare.Step_PrepareBundle failed

Fix the issue by not populating the designer BCL files on Windows.