### PR TITLE
Update to SQLite 3.28.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,7 +45,7 @@
 [submodule "external/sqlite"]
     path = external/sqlite
     url = https://github.com/xamarin/sqlite.git
-    branch = 3.27.1
+    branch = 3.28.0
 [submodule "external/xamarin-android-api-compatibility"]
     path = external/xamarin-android-api-compatibility
     url = https://github.com/xamarin/xamarin-android-api-compatibility.git


### PR DESCRIPTION
Context: https://sqlite.org/releaselog/3_27_2.html
Context: https://sqlite.org/releaselog/3_28_0.html
    
Security updates:    
  - [CVE-2019-9936][0]: fix a buffer overread that could occur when running fts5
    prefix queries inside a transaction
  - [CVE-2019-9937][1]: fix an fts5 problem with interleaving reads and writes
    in a single transaction
  - [CVE-2019-8457][2]: heap out-of-bound read

[0]: https://www.cvedetails.com/cve/CVE-2019-9936/
[1]: https://www.cvedetails.com/cve/CVE-2019-9937/
[2]: https://www.cvedetails.com/cve/CVE-2019-8457/