### PR TITLE
Windows build fixes

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/Context.Linux.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Context.Linux.cs
@@ -2,6 +2,8 @@ namespace Xamarin.Android.Prepare
 {
 	partial class Context
 	{
+		static bool isWindows = false;
+
 		void InitOS ()
 		{
 			OS = Linux.DetectAndCreate (this);

--- a/build-tools/xaprepare/xaprepare/Application/Context.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Context.MacOS.cs
@@ -2,6 +2,8 @@ namespace Xamarin.Android.Prepare
 {
 	partial class Context
 	{
+		static bool isWindows = false;
+
 		void InitOS ()
 		{
 			OS = new MacOS (this);

--- a/build-tools/xaprepare/xaprepare/Application/Context.Windows.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Context.Windows.cs
@@ -2,6 +2,8 @@ namespace Xamarin.Android.Prepare
 {
 	partial class Context
 	{
+		static bool isWindows = true;
+
 		void InitOS ()
 		{
 			OS = new Windows (Context.Instance);

--- a/build-tools/xaprepare/xaprepare/Application/Context.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Context.cs
@@ -49,6 +49,14 @@ namespace Xamarin.Android.Prepare
 		public static Context Instance                 { get; }
 
 		/// <summary>
+		///   This should not really be here, but due to the fact that Windows is still special-cased (until we
+		///   can drop using the bundle and build everything on Windows) we need to check "dynamically" if we're
+		///   running on Windows in some cases. This will be set to <c>true</c> only when xaprepare is built on
+		///   Windows.
+		/// </summary>
+		public static bool IsWindows                   => isWindows;
+
+		/// <summary>
 		///   Information about the operating system we're currently running on. See <see cref="OS" />
 		/// </summary>
 		public OS OS                                   { get; private set; }

--- a/build-tools/xaprepare/xaprepare/Application/MonoCrossRuntime.Windows.cs
+++ b/build-tools/xaprepare/xaprepare/Application/MonoCrossRuntime.Windows.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+
+namespace Xamarin.Android.Prepare
+{
+	partial class MonoCrossRuntime : MonoRuntime
+	{
+		partial void InitOS (Context context)
+		{
+			// On Windows we should not check cross runtimes because we don't build them - thus they must be
+			// removed from the set of runtime files/bundle items or otherwise we'll get false negatives
+			// similar to:
+			//
+			//   bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\Windows\cross-arm missing, skipping the rest of bundle item file scan
+			//      Some bundle files are missing, download/rebuild/reinstall forced
+			//
+			if (!context.IsWindowsCrossAotAbi (Name))
+				SupportedOnHostOS = false;
+		}
+	}
+}

--- a/build-tools/xaprepare/xaprepare/Application/MonoCrossRuntime.cs
+++ b/build-tools/xaprepare/xaprepare/Application/MonoCrossRuntime.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Xamarin.Android.Prepare
 {
-	class MonoCrossRuntime : MonoRuntime
+	partial class MonoCrossRuntime : MonoRuntime
 	{
 		public override string Flavor => "cross compilation";
 
@@ -32,6 +32,10 @@ namespace Xamarin.Android.Prepare
 
 			CrossMonoName = Configurables.Defaults.CrossRuntimeNames [Name];
 			ExePrefix = Configurables.Defaults.CrossRuntimeExePrefixes [Name];
+
+			InitOS (context);
 		}
+
+		partial void InitOS (Context context);
 	}
 }

--- a/build-tools/xaprepare/xaprepare/Application/Runtime.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Runtime.cs
@@ -6,8 +6,13 @@ namespace Xamarin.Android.Prepare
 	{
 		Func<Context, bool> enabledCheck;
 
+		/// <summary>
+		///   Set to <c>true</c> if the current runtime is supported on the host OS.
+		/// </summary>
+		protected bool SupportedOnHostOS { get; set; } = true;
+
 		protected Context Context => Context.Instance;
-		public bool Enabled       => enabledCheck (Context);
+		public bool Enabled       => SupportedOnHostOS && enabledCheck (Context);
 		public string ExeSuffix   { get; protected set; }
 
 		/// <summary>

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Runtimes.Windows.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Runtimes.Windows.cs
@@ -7,14 +7,8 @@ namespace Xamarin.Android.Prepare
 {
 	partial class Runtimes
 	{
-		partial void AddUnixBundleItems (List<BundleItem> bundleItems)
-		{
-			bundleItems.AddRange (UnixBundleItems);
-		}
-
 		partial void PopulateDesignerBclFiles (List<BclFile> designerHostBclFilesToInstall, List<BclFile> designerWindowsBclFilesToInstall)
 		{
-			designerHostBclFilesToInstall.AddRange (BclToDesigner (BclFileTarget.DesignerHost));
 			designerWindowsBclFilesToInstall.AddRange (BclToDesigner (BclFileTarget.DesignerWindows));
 		}
 	}

--- a/build-tools/xaprepare/xaprepare/Steps/Step_BuildMonoRuntimes.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_BuildMonoRuntimes.Unix.cs
@@ -188,7 +188,7 @@ namespace Xamarin.Android.Prepare
 				return false;
 			}
 
-			Log.DebugLine ("Moving unpacked Mono archive from {tempDir} to {destinationDirectory}");
+			Log.DebugLine ($"Moving unpacked Mono archive from {tempDir} to {destinationDirectory}");
 			try {
 				Utilities.MoveDirectoryContentsRecursively (tempDir, destinationDirectory, resetFileTimestamp: true);
 			} finally {

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallAnt.Windows.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallAnt.Windows.cs
@@ -52,7 +52,7 @@ namespace Xamarin.Android.Prepare
 					return false;
 				}
 
-				Log.DebugLine ("Moving unpacked Ant from {tempDir} to {Configurables.Paths.AntInstallDir}");
+				Log.DebugLine ($"Moving unpacked Ant from {tempDir} to {Configurables.Paths.AntInstallDir}");
 
 				// There should be just a single subdirectory
 				List<string> subdirs = Directory.EnumerateDirectories (tempDir).ToList ();

--- a/build-tools/xaprepare/xaprepare/Steps/Step_PrepareBundle.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_PrepareBundle.cs
@@ -84,8 +84,8 @@ namespace Xamarin.Android.Prepare
 					return false;
 				}
 
-				Log.DebugLine ("Moving unpacked bundle from {tempDir} to {Configurables.Paths.Bundle_InstallDir}");
-				Utilities.MoveDirectoryContentsRecursively (tempDir, Configurables.Paths.BundleInstallDir, resetFileTimestamp: true);
+				Log.DebugLine ($"Moving unpacked bundle from {tempDir} to {Configurables.Paths.BundleInstallDir}");
+				Utilities.MoveDirectoryContentsRecursively (tempDir, Configurables.Paths.BundleInstallDir, resetFileTimestamp: true, ignoreDeletionErrors: true);
 			} finally {
 				Utilities.DeleteDirectorySilent (tempDir);
 			}

--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -249,6 +249,8 @@
     <Compile Include="Application\DetermineWindowsVersion.Windows.cs" />
     <Compile Include="Application\LlvmRuntime.Windows.cs" />
     <Compile Include="Application\Log.Windows.cs" />
+    <Compile Include="Application\MonoCrossRuntime.Windows.cs" />
+    <Compile Include="ConfigAndData\Runtimes.Windows.cs" />
     <Compile Include="Application\Utilities.Windows.cs" />
     <Compile Include="ConfigAndData\Configurables.Windows.cs" />
     <Compile Include="ConfigAndData\Dependencies\AndroidToolchain.Windows.cs" />


### PR DESCRIPTION
Don't include designer certain files in BuildItems on Windows

Windows, as a host OS, does NOT currently install any BCL files - it takes
everything from the bundle produced on macOS. However, the code to populate
designer BCL file sets also ran on Windows thus producing this, false negative,
error:

     bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\Windows\bcl\I18N.dll missing, skipping the rest of bundle item file scan
     Some bundle files are missing, download/rebuild/reinstall forced

     Step Xamarin.Android.Prepare.Step_PrepareBundle failed
      System.InvalidOperationException: Step Xamarin.Android.Prepare.Step_PrepareBundle failed

Fix the issue by not populating the designer BCL files on Windows.

Another issue is Windows trying to include **host** versions of the
cross-compilers in the bundle items, thus resulting in this error:

     bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\Windows\cross-arm missing, skipping the rest of bundle item file scan
      Some bundle files are missing, download/rebuild/reinstall forced

Fix the issue by ignoring all the cross-compilers on Windows.

Reset file attributes if they prevent deletion of a temporary dir

The problem, so far, occurred only on Windows, but it may happen on other
systems as well. Whenever a file is marked read-only the `Directory.Delete`
method will throw a "permission denied" exception, refusing to delete the file.
This happens, for instance, with our current bundle in which the
`libzip.5.0.dylib` file is marked read-only after 7z writes it to the system (in
my case the macOSX permissions for the file were `444` octal, so it is, indeed,
read-only).

In order to work around this we catch the `UnauthorizedAccessException` and
attempt to recursively reset permissions of all files found in the directory
being moved to `FileAttributes.Normal`.

Additionally, `MoveDirectoryContentsRecursively` now has a way to ignore all
directory deletion errors. By default the errors aren't ignored with the
exception of the Xamarin.Android bundle unpacking.