### PR TITLE
[xaprepare] install JDK before Android SDK/NDK

### DIFF
--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_AndroidToolchain.cs
@@ -11,8 +11,8 @@ namespace Xamarin.Android.Prepare
 
 		protected override void AddSteps (Context context)
 		{
-			Steps.Add (new Step_Android_SDK_NDK ());
 			Steps.Add (new Step_InstallCorrettoOpenJDK ());
+			Steps.Add (new Step_Android_SDK_NDK ());
 
 			// disable installation of missing programs...
 			context.SetCondition (KnownConditions.AllowProgramInstallation, false);

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Standard.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Standard.cs
@@ -14,9 +14,9 @@ namespace Xamarin.Android.Prepare
 		    if (context == null)
 			    throw new ArgumentNullException (nameof (context));
 
+		    Steps.Add (new Step_InstallCorrettoOpenJDK ());
 		    Steps.Add (new Step_Android_SDK_NDK ());
 		    Steps.Add (new Step_GenerateFiles (atBuildStart: true));
-		    Steps.Add (new Step_InstallCorrettoOpenJDK ());
 		    Steps.Add (new Step_PrepareProps ());
 		    Steps.Add (new Step_PrepareExternal ());
 		    Steps.Add (new Step_PrepareLocal ());


### PR DESCRIPTION
I tried building Xamarin.Android on a clean Windows machine:

    From: Xamarin.Android.Prepare.Step_Android_SDK_NDK.AcceptLicenses at C:\src\xamarin-android\build-tools\xaprepare\xaprepare\Steps\Step_Android_SDK_NDK.cs(98,4)
    EXEC JAVA_HOME is set to an invalid directory: C:\Users\jopepper\android-toolchain\jdk
    C:\src\xamarin-android\build-tools\scripts\PrepareWindows.targets(26,5): error MSB3073: The command "C:\src\xamarin-android\build-tools\scripts\..\xaprepare\xaprepare\bin\Debug\xaprepare.exe --no-emoji --run-mode=CI -a " exited with code -1.

Looking at my filesystem, the `jdk` directory did not exist.

It looks like we just need to reorder the steps so that the JDK is
installed before the Android SDK. I was able to fully run `xaprepare`
after that.

I guess things are working on other machines because they have a JDK
that was found automatically? I have no Oracle JDK on this machine.