### PR TITLE
Update NDK to r20

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,7 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "19c";
+		public const string AndroidNdkVersion = "20";
+		public const string AndroidNdkPkgRevision = "20.0.5594570";
 
 		public static readonly List<AndroidPlatform> AllPlatforms = new List<AndroidPlatform> {
 			new AndroidPlatform (apiLevel: 1,  platformID: "1"),

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -13,6 +13,7 @@ namespace Xamarin.Android.Prepare
 		public AndroidToolchain ()
 		{
 			string AndroidNdkVersion       = BuildAndroidPlatforms.AndroidNdkVersion;
+			string AndroidPkgRevision      = BuildAndroidPlatforms.AndroidNdkPkgRevision;
 			string AndroidNdkDirectory     = GetRequiredProperty (KnownProperties.AndroidNdkDirectory);
 			string AndroidCmakeVersion     = GetRequiredProperty (KnownProperties.AndroidCmakeVersion);
 			string AndroidCmakeVersionPath = GetRequiredProperty (KnownProperties.AndroidCmakeVersionPath);
@@ -43,7 +44,7 @@ namespace Xamarin.Android.Prepare
 				new AndroidToolchainComponent ("docs-24_r01",                                       destDir: "docs", pkgRevision: "1"),
 				new AndroidToolchainComponent ("android_m2repository_r47",                          destDir: Path.Combine ("extras", "android", "m2repository"), pkgRevision: "47.0.0"),
 				new AndroidToolchainComponent ("x86-28_r04",                                        destDir: Path.Combine ("system-images", "android-28", "default", "x86"), relativeUrl: new Uri ("sys-img/android/", UriKind.Relative), pkgRevision: "4"),
-				new AndroidToolchainComponent ($"android-ndk-r{AndroidNdkVersion}-{osTag}-x86_64",  destDir: AndroidNdkDirectory, pkgRevision: "19.2.5345600"),
+				new AndroidToolchainComponent ($"android-ndk-r{AndroidNdkVersion}-{osTag}-x86_64",  destDir: AndroidNdkDirectory, pkgRevision: AndroidPkgRevision),
 				new AndroidToolchainComponent ($"build-tools_r{XABuildToolsVersion}-{altOsTag}",    destDir: Path.Combine ("build-tools", XABuildToolsFolder), isMultiVersion: true),
 				new AndroidToolchainComponent ($"platform-tools_r{XAPlatformToolsVersion}-{osTag}", destDir: "platform-tools", pkgRevision: XAPlatformToolsVersion),
 				new AndroidToolchainComponent ($"sdk-tools-{osTag}-4333796",                        destDir: "tools", pkgRevision: "26.1.1"),


### PR DESCRIPTION
Context: https://github.com/android-ndk/ndk/wiki/Changelog-r20
Context: https://android-developers.googleblog.com/2017/12/improving-app-security-and-performance.html

Google released NDK r20 recently with the following changes:

  - Updated Clang to r346389c.
  - Updated libc++ to r350972.
  - Add Android Q Beta 1 APIs:
    - MIDI (<amidi/AMidi.h>).
    - Binder.
    - Extensions to several APIs from previous releases

Also, this release brings [LLD][0], the new (fast!) linker from the LLVM project
which will become the default and only linker in the NDK in the future, so soon
we will need to start testing our software with it.

[0]: https://lld.llvm.org/