### PR TITLE
[Mono.Android] set JAVA_HOME when running dx

### DIFF
--- a/build-tools/scripts/JavaCallableWrappers.targets
+++ b/build-tools/scripts/JavaCallableWrappers.targets
@@ -49,6 +49,7 @@
       Outputs="$(OutputPath)mono.android.dex">
     <Exec
         Command="&quot;$(AndroidSdkDirectory)\build-tools\$(XABuildToolsFolder)\dx&quot; --dex --no-strict --output=&quot;$(OutputPath)mono.android.dex&quot; &quot;$(OutputPath)mono.android.jar&quot;"
+        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory)"
     />
   </Target>
 </Project>


### PR DESCRIPTION
Continuing to build  on a fresh Windows machine after b98175c1, I hit
a new issue:

    build-tools\scripts\JavaCallableWrappers.targets(50,5): error MSB3073:
      The command ""C:\Users\myuser\android-toolchain\sdk\build-tools\29.0.0\dx" --dex --no-strict --output="C:\src\xamarin-android\bin\Debug\lib\xamarin.android\xbuild-frameworks\MonoAndroid\v9.0\mono.android.dex" "C:\src\xamarin-android\bin\Debug\lib\xamarin.android\xbuild-frameworks\MonoAndroid\v9.0\mono.android.jar"" exited with code -1.
    EXEC No suitable Java found. In order to properly use the Android Developer
    Tools, you need a suitable version of Java JDK installed on your system.
    We recommend that you install the JDK version of JavaSE, available here:
      http://www.oracle.com/technetwork/java/javase/downloads
    If you already have Java installed, you can define the JAVA_HOME environment
    variable in Control Panel / System / Avanced System Settings to point to the
    JDK folder.
    You can find the complete Android SDK requirements here:
      http://developer.android.com/sdk/requirements.html

This machine does not have any Oracle JDKs installed, so it is only
using the Coretto JDK installed in:

    %userprofile%\android-toolchain\jdk

For this to work properly, we need to set `JAVA_HOME` during this
`<Exec/>` call.

After doing this, everything works properly.