### PR TITLE
[Xamarin.Android.Build.Tasks] Restore ConvertResourcesCases skipping

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -216,7 +216,7 @@ namespace Xamarin.Android.Tasks
 						var taskItem = new TaskItem (Path.GetFullPath (resDir), new Dictionary<string, string> {
 							{ OriginalFile, assemblyPath },
 						});
-						if (assembliesToSkipCaseFixup.Contains (assemblyFileName))
+						if (assembliesToSkipCaseFixup.Contains (assemblyPath))
 							taskItem.SetMetadata (AndroidSkipResourceProcessing, "True");
 						resolvedResourceDirectories.Add (taskItem);
 					}
@@ -320,7 +320,7 @@ namespace Xamarin.Android.Tasks
 							var taskItem = new TaskItem (Path.GetFullPath (resDir), new Dictionary<string, string> {
 								{ OriginalFile, assemblyPath }
 							});
-							if (assembliesToSkipCaseFixup.Contains (assemblyFileName))
+							if (assembliesToSkipCaseFixup.Contains (assemblyPath))
 								taskItem.SetMetadata (AndroidSkipResourceProcessing, "True");
 							resolvedResourceDirectories.Add (taskItem);
 						}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -193,14 +193,13 @@ class MemTest {
 					"Xamarin.Android.Support.Design.dll",
 					"Xamarin.Android.Support.Media.Compat.dll",
 					"Xamarin.Android.Support.Transition.dll",
-					"Xamarin.Android.Support.v4.dll",
 					"Xamarin.Android.Support.v7.AppCompat.dll",
 					"Xamarin.Android.Support.v7.CardView.dll",
 					"Xamarin.Android.Support.v7.MediaRouter.dll",
 					"Xamarin.Android.Support.v7.RecyclerView.dll",
 					"material-menu-1.1.0.aar",
 				};
-				foreach (var file in skipped) {
+				foreach (var file in files) {
 					Assert.IsTrue (StringAssertEx.ContainsText (skipped, file), $"`{target}` should skip `{file}`.");
 				}
 			}


### PR DESCRIPTION
[02c07ed6][0] introduced a refinement on `<ConvertResourcesCases/>` to
allow it to skip certain "well-known" assemblies that don't need
processing.  It used an MSBuild item group to define the list of
well-known assemblies.  Each item in the group was a name of a
well-known assembly, without any file extension.

02c07ed6 also included an automated test that checked the build output
for each of the well-known assemblies that should be skipped when
building a test project.  But one of the variable names in the test code
was unintentionally switched around, so the test was actually skipping
over that check for the expected assemblies.

Later, [b255da27][1] adapted the assembly skipping mechanism slightly to
use custom metadata to define the list of well-known assemblies.  This
was a step toward toward using custom metadata as a more general
technique for various other scenarios too.

Just by chance, there was a tiny missing change in b255da27, which meant
that the assembly skipping behavior got unintentionally disabled.  The
trouble was that the original item group in 02c07ed6 had been using just
the name of the assembly with no file extension, while the new commit
used the full path to the assembly, including the file extension, and
there were a couple lines in `ResolveLibraryProjectImports.Extract()`
that were still searching through the list of "well-known" assemblies
using just the name rather than the full path.

Separately, starting in version 28.0.0, the Xamarin.Android.Support.v4
NuGet package started to include a `monoandroid90/` target framework
directory.  The `__AndroidLibraryProjects__.zip` embedded resource in
the `monoandroid90/Xamarin.Android.Support.v4.dll` assembly does *not*
include a `res/` directory, so when the `$(TargetFrameworkVersion)` is
`v9.0`, the Xamarin.Android.Support.v4 assembly is no longer passed to
`<ConvertResourcesCases/>` at all.  Accordingly, that assembly name can
now be removed from the list of expected skipped assemblies in the
`SkipConvertResourcesCases` test.

I ran the updated `SkipConvertResourcesCases` test locally, first
*without* the change in `<ResolveLibraryProjectImports/>` to confirm
that it failed, and then also *with* the change to verify that it
succeeded.

I also checked that these changes successfully restored the performance
gains from b255da27.

Results with `$(AndroidUseAapt2)` enabled:

	Before:
	3359 ms  ConvertResourcesCases                      2 calls
	2562 ms  ResolveLibraryProjectImports               1 calls

	After:
	  62 ms  ConvertResourcesCases                      2 calls
	2500 ms  ResolveLibraryProjectImports               1 calls

Results with `$(AndroidUseAapt2)` disabled:

	Before:
	3237 ms  ConvertResourcesCases                      1 calls
	3234 ms  ResolveLibraryProjectImports               1 calls

	After:
	  94 ms  ConvertResourcesCases                      1 calls
	2641 ms  ResolveLibraryProjectImports               1 calls

This was the Xamarin.Forms.Performance.Integration.Droid project in this
repo, using an initial clean build.

[0]: https://github.com/xamarin/xamarin-android/commit/02c07ed6d9e0a2559d9948750ea798ff56db28e4
[1]: https://github.com/xamarin/xamarin-android/commit/5f27d0cac299cf771cf4e815c4901c7ce768ad7c