### PR TITLE
[Xamarin.Android.Build.Tasks] Revert special handling of keywords in Android resource names

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileWithLibraryReferenceExpected.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileWithLibraryReferenceExpected.cs
@@ -24,6 +24,20 @@ namespace Foo.Foo
 			global::Android.Runtime.ResourceIdManager.UpdateIdValues();
 		}
 		
+		public static void UpdateIdValues()
+		{
+			global::Library.Resource.Animator.slide_in_bottom = global::Foo.Foo.Resource.Animator.slide_in_bottom;
+			global::Library.Resource.Array.widths_array = global::Foo.Foo.Resource.Array.widths_array;
+			global::Library.Resource.Dimension.main_text_item_size = global::Foo.Foo.Resource.Dimension.main_text_item_size;
+			global::Library.Resource.Drawable.ic_menu_preferences = global::Foo.Foo.Resource.Drawable.ic_menu_preferences;
+			global::Library.Resource.Font.arial = global::Foo.Foo.Resource.Font.arial;
+			global::Library.Resource.Id.menu_settings = global::Foo.Foo.Resource.Id.menu_settings;
+			global::Library.Resource.Mipmap.icon = global::Foo.Foo.Resource.Mipmap.icon;
+			global::Library.Resource.String.@fixed = global::Foo.Foo.Resource.String.@fixed;
+			global::Library.Resource.String.foo = global::Foo.Foo.Resource.String.foo;
+			global::Library.Resource.String.menu_settings = global::Foo.Foo.Resource.String.menu_settings;
+		}
+		
 		public partial class Animator
 		{
 			

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
@@ -23,7 +23,6 @@ namespace Xamarin.Android.Build.Tests {
     <item quantity=""one""> One location reported</item>
     <item quantity=""other"">%d locations reported</item>
   </plurals>
-  <string name=""menu_settings"">Android Beam settings</string>
 </resources>
 ";
 
@@ -37,6 +36,8 @@ namespace Xamarin.Android.Build.Tests {
     <item>Thickish</item>
     <item>Thick</item>
   </string-array>
+  <string name=""menu_settings"">Android Beam settings</string>
+  <string name=""fixed""></string>
 </resources>
 ";
 		const string Menu = @"<menu xmlns:android=""http://schemas.android.com/apk/res/android"">
@@ -136,9 +137,10 @@ int mipmap icon 0x7f0a0000
 int plurals num_locations_reported 0x7f0b0000
 int raw foo 0x7f0c0000
 int string app_name 0x7f0d0000
-int string foo 0x7f0d0001
-int string hello 0x7f0d0002
-int string menu_settings 0x7f0d0003
+int string fixed 0x7f0d0001
+int string foo 0x7f0d0002
+int string hello 0x7f0d0003
+int string menu_settings 0x7f0d0004
 int[] styleable CustomFonts { 0x010100d2, 0x7f030000 }
 int styleable CustomFonts_android_scrollX 0
 int styleable CustomFonts_customFont 1
@@ -198,6 +200,35 @@ int transition transition 0x7f0f0000
 			File.WriteAllText (Path.Combine (Root, path, "lp", "__res_name_case_map.txt"), "menu/Options.xml;menu/options.xml");
 		}
 
+		void BuildLibraryWithResources (string path)
+		{
+			var library = new XamarinAndroidLibraryProject () {
+				ProjectName = "Library",
+			};
+
+			var libraryStrings = library.AndroidResources.FirstOrDefault (r => r.Include () == @"Resources\values\Strings.xml");
+
+			library.AndroidResources.Clear ();
+			library.AndroidResources.Add (libraryStrings);
+			library.AndroidResources.Add (new AndroidItem.AndroidResource (Path.Combine ("Resources", "animator", "slide_in_bottom.xml")) { TextContent = () => Animator });
+			library.AndroidResources.Add (new AndroidItem.AndroidResource (Path.Combine ("Resources", "font", "arial.ttf")) { TextContent = () => "" });
+			library.AndroidResources.Add (new AndroidItem.AndroidResource (Path.Combine ("Resources", "values", "strings2.xml")) { TextContent = () => StringsXml2 });
+			library.AndroidResources.Add (new AndroidItem.AndroidResource (Path.Combine ("Resources", "values", "dimen.xml")) { TextContent = () => Dimen });
+
+			using (var stream = typeof (XamarinAndroidCommonProject).Assembly.GetManifestResourceStream ("Xamarin.ProjectTools.Resources.Base.Icon.png")) {
+				var icon_binary_mdpi = new byte [stream.Length];
+				stream.Read (icon_binary_mdpi, 0, (int)stream.Length);
+				library.AndroidResources.Add (new AndroidItem.AndroidResource (Path.Combine ("Resources", "drawable", "ic_menu_preferences.png")) { BinaryContent = () => icon_binary_mdpi });
+				library.AndroidResources.Add (new AndroidItem.AndroidResource (Path.Combine ("Resources", "mipmap-hdpi", "icon.png")) { BinaryContent = () => icon_binary_mdpi });
+			}
+
+			library.AndroidResources.Add (new AndroidItem.AndroidResource (Path.Combine ("Resources", "menu", "options.xml")) { TextContent = () => Menu });
+
+			using (ProjectBuilder builder = CreateDllBuilder (Path.Combine (Root, path))) {
+				Assert.IsTrue (builder.Build (library), "Build should have succeeded");
+			}
+		}
+
 		[Test]
 		public void GenerateDesignerFileWithÜmläüts ()
 		{
@@ -232,7 +263,7 @@ int transition transition 0x7f0f0000
 		}
 
 		[Test]
-		public void GenerateDesignerFileFromRtxt ()
+		public void GenerateDesignerFileFromRtxt ([Values (false, true)] bool withLibraryReference)
 		{
 			var path = Path.Combine ("temp", TestName + " Some Space");
 			CreateResourceDirectory (path);
@@ -257,9 +288,16 @@ int transition transition 0x7f0f0000
 			};
 			task.IsApplication = true;
 			task.JavaPlatformJarPath = Path.Combine (AndroidSdkDirectory, "platforms", "android-27", "android.jar");
+			if (withLibraryReference) {
+				var libraryPath = Path.Combine (path, "Library");
+				BuildLibraryWithResources (libraryPath);
+				task.References = new TaskItem [] {
+					new TaskItem (Path.Combine (Root, libraryPath, "bin", "Debug", "Library.dll"))
+				};
+			}
 			Assert.IsTrue (task.Execute (), "Task should have executed successfully.");
 			Assert.IsTrue (File.Exists (task.NetResgenOutputFile), $"{task.NetResgenOutputFile} should have been created.");
-			var expected = Path.Combine (Root, "Expected", "GenerateDesignerFileExpected.cs");
+			var expected = Path.Combine (Root, "Expected", withLibraryReference ? "GenerateDesignerFileWithLibraryReferenceExpected.cs" : "GenerateDesignerFileExpected.cs");
 			Assert.IsTrue (FileCompare (task.NetResgenOutputFile, expected),
 				 $"{task.NetResgenOutputFile} and {expected} do not match.");
 			Directory.Delete (Path.Combine (Root, path), recursive: true);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -114,6 +114,9 @@
     <Content Include="Expected\GenerateDesignerFileExpected.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Expected\GenerateDesignerFileWithLibraryReferenceExpected.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidLibraryProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidLibraryProject.cs
@@ -19,6 +19,7 @@ namespace Xamarin.ProjectTools
 			: base (debugConfigurationName, releaseConfigurationName)
 		{
 			SetProperty ("AndroidApplication", "False");
+			SetProperty ("AndroidResgenFile", Path.Combine ("Resources", "Resource.designer.cs"));
 
 			AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values\\Strings.xml") { TextContent = () => StringsXml.Replace ("${PROJECT_NAME}", ProjectName) });
 			StringsXml = default_strings_xml;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ResourceIdentifier.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ResourceIdentifier.cs
@@ -29,26 +29,6 @@ namespace Xamarin.Android.Tasks
 
 		private const string Identifier = IdentifierStartCharacter + "(" + IdentifierPartCharacter + ")";
 
-		//https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#keywords
-		private static readonly HashSet<string> _keywords = new HashSet<string> () {
-			  "abstract" , "as"       , "base"       , "bool"      , "break"
-			, "byte"     , "case"     , "catch"      , "char"      , "checked"
-			, "class"    , "const"    , "continue"   , "decimal"   , "default"
-			, "delegate" , "do"       , "double"     , "else"      , "enum"
-			, "event"    , "explicit" , "extern"     , "false"     , "finally"
-			, "fixed"    , "float"    , "for"        , "foreach"   , "goto"
-			, "if"       , "implicit" , "in"         , "int"       , "interface"
-			, "internal" , "is"       , "lock"       , "long"      , "namespace"
-			, "new"      , "null"     , "object"     , "operator"  , "out"
-			, "override" , "params"   , "private"    , "protected" , "public"
-			, "readonly" , "ref"      , "return"     , "sbyte"     , "sealed"
-			, "short"    , "sizeof"   , "stackalloc" , "static"    , "string"
-			, "struct"   , "switch"   , "this"       , "throw"     , "true"
-			, "try"      , "typeof"   , "uint"       , "ulong"     , "unchecked"
-			, "unsafe"   , "ushort"   , "using"      , "virtual"   , "void"
-			, "volatile" , "while",
-		};
-
 		// We use [^ ...] to detect any character that is NOT a match.
 		static Regex validIdentifier = new Regex ($"[^{Identifier}]", RegexOptions.Compiled);
 
@@ -60,8 +40,6 @@ namespace Xamarin.Android.Tasks
 
 			string result = validIdentifier.Replace (normalizedIdentifier, "_");
 
-			if (_keywords.Contains (result, StringComparer.Ordinal))
-				return $"@{result}";
 			return result;
 		}
 	}


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3250

Partially reverts [af61ecda][0].

It turns out that the System.CodeDom APIs take care of adding `@` as
needed on keywords when outputting C# source code.  Behind the scenes at
run time, the name of the field doesn't actually have the `@` prefix
(e.g., `nameof (@fixed)` returns `"fixed"`).  So the code in af61ecda
that added an `@` prefix unintentionally led to incorrect `false` return
values from `resourceFields.Contains()` in
`ResourceDesignerImportGenerator.CreateImportFor()`.

Revert the part of af61ecda that was adding an `@` prefix.  This goes
back to letting System.CodeDom take care of adding the `@` as needed and
restores the previous correct behavior of `resourceFields.Contains()`.

Before this change, the new updated `GenerateDesignerFileFromRtxt` test
failed because the generated `UpdateIdValues()` method in the output
`Resource.designer.cs` file did not include a line for the `fixed`
library project resource.  After this change, the test passes.

In a real app, this problem would mean that the original temporary
resource ID generated in the context of the library project would be
left assigned to the C# name of the resource, so a line similar to the
following would fail:

    Resources.GetString (Library.Resource.String.@fixed);

The exception would be similar to:

    Android.Content.Res.Resources+NotFoundException: String resource ID #0x7f0a0028

Corresponding test updates
==========================

Add a new `GenerateDesignerFileFromRtxt` test case with a library
reference to cover this scenario.

The code path in the `<GenerateResourceDesigner/>` task that uses the
`ResourceDesignerImportGenerator` class only runs if the `@(References)`
item list includes an assembly that is not a framework assembly.

Enable testing of that code path by expanding the
`GenerateDesignerFileFromRtxt` test to include both a version that runs
without a library reference (as before) and a new version that runs
*with* a library reference.

Modify the `XamarinAndroidLibraryProject` class to set the
`$(AndroidResgenFile)` property to the current default value used in the
library project template in Visual Studio.  This property is required to
get the expected behavior from the new test.  Without this change, the
library project would build skip processing the resources (because the
`$(_AndroidResourceDesignerFile)` property would be blank).  There is a
chance that changing this property in the `XamarinAndroidLibraryProject`
class itself might break other tests.  Depending on what happens with
the other tests, it might be better to set this property on just the one
*instance* of `XamarinAndroidLibraryProject` in the new test.

Move the `menu_settings` string from the app project resources into the
library project resources so that the new library project assembly will
build successfully.  I believe this also more closely matches how a real
project would look because the library project's `menu` resource
references that string, so the string needs to be available to the
library project and not just the app project.

Add a string to the library project resources that uses a C# keyword
(`fixed`) as its name to test that using C# keywords as resource names
is handled correctly.

[0]: https://github.com/xamarin/xamarin-android/commit/af61ecda302d69dd714f3a363829c3a9e593f5ab