### PR TITLE
[build] Add signing to azure-pipelines.yaml

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -18,9 +18,10 @@ resources:
 # Global variables
 variables:
   BundleArtifactName: bundle
-  InstallerArtifactName: unsigned-installers
+  InstallerArtifactName: installers
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
+# Check - "Xamarin.Android (Prepare bundle)"
 stages:
 - stage: prepare
   displayName: Prepare
@@ -75,7 +76,8 @@ stages:
   displayName: Mac
   dependsOn: prepare
   jobs:
-  - job: mac_build
+  # Check - "Xamarin.Android (Mac Build)"
+  - job: mac_build_create_installers
     displayName: Build
     pool: $(XA.Build.Mac.Pool)
     timeoutInMinutes: 240
@@ -117,16 +119,40 @@ stages:
       displayName: make create-installers
 
     - script: |
-        mkdir -p bin/Build$(XA.Build.Configuration)/unsigned-installers
-        cp bin/Build$(XA.Build.Configuration)/*.vsix bin/Build$(XA.Build.Configuration)/unsigned-installers
-        cp bin/Build$(XA.Build.Configuration)/*.pkg bin/Build$(XA.Build.Configuration)/unsigned-installers
+        mkdir -p bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
+        cp bin/Build$(XA.Build.Configuration)/*.vsix bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
+        cp bin/Build$(XA.Build.Configuration)/*.pkg bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
       displayName: copy unsigned installers
 
+    - script: |
+        VERSION=`LANG=C; export LANG && git log --no-color --first-parent -n1 --pretty=format:%ct`
+        echo "d1ec039f-f3db-468b-a508-896d7c382999 $VERSION" > bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)/updateinfo
+      displayName: create updateinfo file
+
+    - powershell: |
+        $pkg = Get-ChildItem -Path "bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)/*" -Include *.pkg -File
+        if (![System.IO.File]::Exists($pkg)) {
+            throw [System.IO.FileNotFoundException] "Pkg File not found in bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)"
+        }
+        Write-Host "##vso[task.setvariable variable=XA.Unsigned.Pkg]$pkg"
+      displayName: set variable to pkg path
+
+    - template: productsign-pkg.yml@yaml
+      parameters:
+        UnsignedPkgPath: $(XA.Unsigned.Pkg)
+
     - task: PublishPipelineArtifact@0
-      displayName: upload unsigned installers
+      displayName: upload installers
       inputs:
         artifactName: $(InstallerArtifactName)
-        targetPath: bin/Build$(XA.Build.Configuration)/unsigned-installers
+        targetPath: bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
+
+    - template: upload-to-storage.yml@yaml
+      parameters:
+        BuildPackages: bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
+        AzureContainerName: $(Azure.Container.Name)
+        AzureUploadLocation: $(Build.DefinitionName)/$(Build.BuildId)/$(Build.SourceBranchName)/$(Build.SourceVersion)
+        condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
 
     - task: MSBuild@1
       displayName: package build results
@@ -143,7 +169,32 @@ stages:
         targetPath: $(Build.ArtifactStagingDirectory)
       condition: always()
 
+  # Check - "Xamarin.Android (Mac Queue Vsix Signing)"
+  # Actually runs on a Windows host, but the work is done in a Jenkins job. Does not run on PR builds.
+  - job: queue_vsix_signing
+    displayName: Queue Vsix Signing
+    dependsOn: mac_build_create_installers
+    pool: $(XA.Build.Win.Pool)
+    condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
+    timeoutInMinutes: 30
+    cancelTimeoutInMinutes: 1
+    workspace:
+      clean: all
+    steps:
+    - task: JenkinsQueueJob@2
+      displayName: xamarin vsix codesign - run jenkins job
+      inputs:
+        serverEndpoint: $(Signing.Endpoint)
+        jobName: $(Signing.Job)
+        isParameterizedJob: true
+        jobParameters: |
+          REPO=$(Build.Repository.Name)
+          COMMIT=$(Build.SourceVersion)
+          SIGN_TYPE=Real
+          GITHUB_CONTEXT=$(GitHub.Artifacts.Context)
+
 # This stage ensures Windows specific build steps continue to work, and runs unit tests.
+# Check - "Xamarin.Android (Windows Build and Test)"
 - stage: win_build_test
   displayName: Windows
   dependsOn: prepare
@@ -242,7 +293,7 @@ stages:
   displayName: Test
   dependsOn: mac_build
   jobs:
-  # Test APK Instrumentation
+  # Check - "Xamarin.Android (Test APK Instrumentation)"
   - job: mac_apk_tests
     displayName: APK Instrumentation
     pool: $(XA.Build.Mac.Pool)
@@ -442,7 +493,7 @@ stages:
         targetPath: $(Build.ArtifactStagingDirectory)
       condition: always()
 
-  # Test Designer Mac  
+  # Check - "Xamarin.Android (Test Designer Mac)"
   - job: designer_integration_mac
     displayName: Designer Mac
     pool: $(XA.Build.Mac.Pool)
@@ -482,7 +533,7 @@ stages:
       parameters:
         designerSourcePath: $(System.DefaultWorkingDirectory)/designer
 
-  # Test Designer Windows
+  # Check - "Xamarin.Android (Test Designer Windows)"
   - job: designer_integration_win
     displayName: Designer Windows
     pool:


### PR DESCRIPTION
Context: https://github.com/xamarin/yaml-templates/pull/11
Context: https://github.com/xamarin/xamarin-android/blob/afb351205999c3c7ea9754c57f9c6467688e881b/build-tools/automation/build.groovy#L209
Context: https://github.com/xamarin/xamarin-android/blob/afb351205999c3c7ea9754c57f9c6467688e881b/build-tools/automation/build.groovy#L287

Imports existing installer signing logic from build.groovy so that we
can conditionally sign .pkg and .vsix installers for public releases.