### PR TITLE
[build] Simplify CI make and xaprepare invocations

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -19,17 +19,11 @@ resources:
 variables:
   BundleArtifactName: bundle
   InstallerArtifactName: unsigned-installers
-  AutoProvisionArgs: /p:AutoProvision=True /p:AutoProvisionUsesSudo=True /p:IgnoreMaxMonoVersion=False
-  AndroidTargetAbiArgs: >-
-    /p:AndroidSupportedTargetJitAbis=armeabi-v7a:arm64-v8a:x86:x86_64
-    /p:AndroidSupportedTargetAotAbis=armeabi-v7a:arm64:x86:x86_64:win-armeabi-v7a:win-arm64:win-x86:win-x86_64
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
 stages:
 - stage: prepare
   displayName: Prepare
-  variables:
-    MSBuildAbiArgs: $(AndroidTargetAbiArgs) /p:AndroidSupportedHostJitAbis=Darwin:mxe-Win32:mxe-Win64
   jobs:
   - job: create_bundle
     displayName: Bundle
@@ -45,8 +39,8 @@ stages:
       # Update Mono in a separate step since xaprepare uses it as well and it will crash when Mono it runs with is updated
       # The 'prepare' step creates the bundle
     - script: |
-        make prepare-update-mono PREPARE_CI=1 V=1 CONFIGURATION=$(XA.Build.Configuration) MSBUILD_ARGS="$(AutoProvisionArgs) $(MSBuildAbiArgs)"
-        make prepare PREPARE_CI=1 PREPARE_ARGS="--copy-bundle-to=bin/$(XA.Build.Configuration)" V=1 CONFIGURATION=$(XA.Build.Configuration) MSBUILD_ARGS="$(AutoProvisionArgs) $(MSBuildAbiArgs)"
+        make prepare-update-mono PREPARE_CI=1 V=1 PREPARE_AUTOPROVISION=1 CONFIGURATION=$(XA.Build.Configuration)
+        make prepare PREPARE_CI=1 PREPARE_AUTOPROVISION=1 PREPARE_ARGS="--copy-bundle-to=bin/$(XA.Build.Configuration)" V=1 CONFIGURATION=$(XA.Build.Configuration)
       displayName: create bundle
 
     - task: CopyFiles@2
@@ -99,8 +93,11 @@ stages:
         artifactName: $(BundleArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)
 
+    - script: make prepare-update-mono V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1 PREPARE_ARGS="--bundle-path=$(System.DefaultWorkingDirectory)"
+      displayName: make prepare-update-mono
+
     - script: make prepare-external-git-dependencies PREPARE_CI=1 CONFIGURATION=$(XA.Build.Configuration)
-      displayName: make prepare-commercial
+      displayName: make prepare-external-git-dependencies
       condition: eq(variables['XA.Commercial.Build'], 'true')
       env:
         GH_AUTH_SECRET: $(Github.Token)
@@ -113,11 +110,7 @@ stages:
         provisioning_script: $(System.DefaultWorkingDirectory)/external/monodroid/build-tools/provisionator/profile.csx
         provisioning_extra_args: -vv
 
-    - script: make prepare-update-mono V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_ARGS="--bundle-path=$(System.DefaultWorkingDirectory)" MSBUILD_ARGS="$(AutoProvisionArgs) /p:BundleRootPath=$(System.DefaultWorkingDirectory)"
-      displayName: make prepare-update-mono
-
-      # No need to add `prepare` to the command line, the `jenkins` rule depends on `prepare-jenkins` which will run the bootstrapper
-    - script: make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_ARGS="--bundle-path=$(System.DefaultWorkingDirectory)" MSBUILD_ARGS="$(AutoProvisionArgs) /p:BundleRootPath=$(System.DefaultWorkingDirectory)"
+    - script: make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1 PREPARE_ARGS="--bundle-path=$(System.DefaultWorkingDirectory)"
       displayName: make jenkins
 
     - script: make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
@@ -163,6 +156,9 @@ stages:
     workspace:
       clean: all
     variables:
+      AndroidTargetAbiArgs: >-
+        /p:AndroidSupportedTargetJitAbis=armeabi-v7a:arm64-v8a:x86:x86_64
+        /p:AndroidSupportedTargetAotAbis=armeabi-v7a:arm64:x86:x86_64:win-armeabi-v7a:win-arm64:win-x86:win-x86_64
       JAVA_HOME: '%HOMEDRIVE%%HOMEPATH%\android-toolchain\jdk'
     steps:
     - checkout: self
@@ -178,14 +174,14 @@ stages:
       inputs:
         solution: Xamarin.Android.sln
         configuration: $(XA.Build.Configuration)
-        msbuildArguments: $(AutoProvisionArgs) $(AndroidTargetAbiArgs) /t:Prepare /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\msbuild-prepare.binlog /p:BundleRootPath=$(System.DefaultWorkingDirectory)
+        msbuildArguments: /t:Prepare /p:AutoProvision=true $(AndroidTargetAbiArgs) /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\msbuild-prepare.binlog /p:BundleRootPath=$(System.DefaultWorkingDirectory)
 
     - task: MSBuild@1
       displayName: msbuild Xamarin.Android /t:Build
       inputs:
         solution: Xamarin.Android.sln
         configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:Build /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\msbuild-build.binlog /p:BundleRootPath=$(System.DefaultWorkingDirectory) $(AndroidTargetAbiArgs)
+        msbuildArguments: /t:Build $(AndroidTargetAbiArgs) /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\msbuild-build.binlog /p:BundleRootPath=$(System.DefaultWorkingDirectory)
 
     - task: MSBuild@1
       displayName: msbuild create-vsix

--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -188,10 +188,9 @@ timestamps {
 
         utils.stageWithTimeout('create installers', 30, 'MINUTES', XADir, true) {    // Typically takes less than 5 minutes
             if (isPr) {
-                // Override _MSBUILD_ARGS to ensure we only package the `AndroidSupportedTargetJitAbis` which are built.
-                // Also ensure that we don't require mono bundle components in the installer if this is not a full mono integration build.
+                // Exclude mono components if they aren't being built.
                 def msbuildInstallerArgs = hasPrLabelFullMonoIntegrationBuild ? '' : '/p:IncludeMonoBundleComponents=False'
-                sh "make create-installers CONFIGURATION=${env.BuildFlavor} V=1 _MSBUILD_ARGS='${msbuildInstallerArgs}'"
+                sh "make create-installers CONFIGURATION=${env.BuildFlavor} V=1 MSBUILD_ARGS='${msbuildInstallerArgs}'"
             } else {
                 sh "make create-installers CONFIGURATION=${env.BuildFlavor} V=1"
             }

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -10,7 +10,7 @@
 # The other targets depended upon by leeroy also require rules.mk to be present and thus they
 # are invoked in the same way framework-assemblies is
 #
-jenkins:: prepare-jenkins
+jenkins:: prepare
 	$(MAKE) leeroy $(ZIP_OUTPUT)
 
 leeroy: leeroy-all framework-assemblies opentk-jcw


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/job/xamarin-android-pr-pipeline-release/1448/#showFailuresLink
Context: https://github.com/xamarin/xamarin-android/commit/9302d514a1437e5d1977da06dfbbe4e7054f33d5
Context: https://github.com/xamarin/xamarin-android/commit/f9f5b6cd120484b13df74e94638e07411d8693fa

The primary intent of these changes is to fix the `EmbeddedDSOUnitTests`
failures we are encountering with Jenkins PR builds. However, this has
presented an opportunity to also clean up some xaprepare changes 
which are no longer needed.

We built a lot of hacks into our make file when initially working on the
xaprepare tool, as the windows and mac azure pipeline builds could not
be modified at the time. We now have these builds defined in yaml, and
as such we should be able to simplify the underlying make rules used by
all of our builds.

  * Removes `prepare-build-ci` which no longer appears to be relevant,
    as the extra args it specifies don't appear to be set before the
    tool is built.

  * Removes `prepare-jenkins` and `prepare-commercial`, as we can now
    rely on the `prepare` rule again. The behavior of `prepare` will
    change depending on the `_PREPARE_ARGS` varible, which is controlled
    by different flags passed by our CI systems, `azure-pipelines.yaml`,
    and `build.groovy`

  * Introduces a new `prepareFlags` variable to build.groovy which is
    used to control whether or not the "prepare all" (-a arg) should
    be passed to xaprepare. This should not be specified when building
    Jenkins PR builds, as they only build a subset of all supported ABIs
    and frameworks. This should address the EmbeddedDSO test failures we
    are encountering in Jenkins PR builds.

  * Removes the MSBuild Auto Provision and ABI related args from make
    invocations in azure-pipelines.yaml. Make variables will instead be
    used to control these options.

  * Removes the `prepare-update-mono` dependency from
    `prepare-external-git-dependencies` as we should be able to call
    this without needing to update mono.

  * Adds a `prepare` dependency back to `jenkins`, now that the
    `prepare-jenkins` step is no longer required.

  * Removes the `_MSBUILD_ARGS` override from installer creation in
    build.groovy. This was initially required because we did not import
    different `rules.make` based on how our build was configured and
    prepared. The `xaprepare` tool now better controls the ABIs we should be
    building and packaging for each build type, so this is no longer needed.
