### PR TITLE
[xaprepare] Always accept Android SDK licenses

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_Android_SDK_NDK.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_Android_SDK_NDK.cs
@@ -43,8 +43,13 @@ namespace Xamarin.Android.Prepare
 			var toInstall = new List <AndroidPackage> ();
 
 			toolchain.Components.ForEach (c => Check (context, packageCacheDir, sdkRoot, c, toInstall, 4));
-			if (toInstall.Count == 0)
+			if (toInstall.Count == 0) {
+				if (!AcceptLicenses (context, sdkRoot)) {
+					Log.ErrorLine ("Failed to accept Android SDK licenses");
+					return false;
+				}
 				return GatherNDKInfo (context, ndkRoot);
+			}
 
 			Log.MessageLine ();
 			toInstall.ForEach (p => Log.DebugLine ($"Missing Android component: {p.Component.Name}"));


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2794198
Context: https://github.com/xamarin/xamarin-android/commit/75e053e5eff431093c7e00d94962fcd13683be5c

I've seen a rare failure[0] in our Windows Azure Devops builds which
looks like it could have been introduced when we bumped the version of
build-tools that we provision from 28.0.3 to 29.0.0.

Rather than bumping the buildToolsVersion in the CodeGen-Binding suite,
we should be able to fix this by updating `xaprepare` to always execute
the Android SDK license acceptance step. This step would previously be
skipped if all SDK items were provisioned. Since it executes quickly, we
might as well run it everytime in case we somehow fall out of sync or
license files are otherwise deleted. This should allow gradle invocations
to automatically install the version of build-tools it requires.

[0]

    BuildJavaLibs:
       "E:\A\_work\2075\s\build-tools\gradle\gradlew" assembleDebug --stacktrace --no-daemon
      To honour the JVM settings for this build a new JVM will be forked. Please consider using the daemon: https://docs.gradle.org/5.1/userguide/gradle_daemon.html.
      Daemon will be stopped at the end of the build stopping after processing

      > Configure project :library
      File C:\Users\dlab14\.android\repositories.cfg could not be loaded.
      Checking the license for package Android SDK Build-Tools 28.0.3 in C:\Users\dlab14\android-toolchain\sdk\licenses
    EXEC : warning : License for package Android SDK Build-Tools 28.0.3 not accepted. [E:\A\_work\2075\s\tests\CodeGen-Binding\Xamarin.Android.LibraryProjectZip-LibBinding\Xamarin.Android.LibraryProjectZip-LibBinding.csproj]

      FAILURE: Build failed with an exception.

      * What went wrong:
      A problem occurred configuring project ':library'.
      > Failed to install the following Android SDK packages as some licences have not been accepted.
           build-tools;28.0.3 Android SDK Build-Tools 28.0.3
