### PR TITLE
[build] Simplify Azure Pipeline build names

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1,6 +1,6 @@
 # Xamarin.Android Pipeline
 
-name: $(Build.SourceBranch)-$(Build.SourceVersion)-$(Rev:r)
+name: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
 
 trigger:
   - master


### PR DESCRIPTION
We use the `name` property to set our build "number" value in azure
pipelines. This is currently a bit noisy, so I've trimmed it to use the
short branch name variable. We'll lose PR number in the build number
for PR builds as a result, but it's still easily identifiable in the UI.

old: refs_heads_master-b9c3d9a98f20ac34f49c23effc542f0ab8473bd6-1
new: master-b9c3d9a98f20ac34f49c23effc542f0ab8473bd6-1

old: refs_pull_3279_merge-d83366ad6c9ae17a4f4d5c250f1fd81b455ac436-2
new: merge-d83366ad6c9ae17a4f4d5c250f1fd81b455ac436-2