### PR TITLE
[Xamarin.Android.Build.Tasks] Fix up DesignTime build Resource.Designer.cs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
@@ -47,6 +47,8 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string JavaPlatformJarPath { get; set; }
 
+		public string ResourceFlagFile { get; set; }
+
 		private Dictionary<string, string> resource_fixup = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase);
 
 		public override bool Execute ()
@@ -92,7 +94,7 @@ namespace Xamarin.Android.Tasks
 			// Parse out the resources from the R.java file
 			CodeTypeDeclaration resources;
 			if (UseManagedResourceGenerator) {
-				var parser = new ManagedResourceParser () { Log = Log, JavaPlatformDirectory = javaPlatformDirectory, };
+				var parser = new ManagedResourceParser () { Log = Log, JavaPlatformDirectory = javaPlatformDirectory, ResourceFlagFile = ResourceFlagFile };
 				resources = parser.Parse (ResourceDirectory, AdditionalResourceDirectories?.Select (x => x.ItemSpec), IsApplication, resource_fixup);
 			} else {
 				var parser = new JavaResourceParser () { Log = Log };

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -27,6 +27,8 @@ namespace Xamarin.Android.Tasks
 
 		public string JavaPlatformDirectory { get; set; }
 
+		public string ResourceFlagFile { get; set; }
+
 		void SortMembers (CodeTypeDeclaration decl)
 		{
 			CodeTypeMember [] members = new CodeTypeMember [decl.Members.Count];
@@ -98,10 +100,13 @@ namespace Xamarin.Android.Tasks
 				publicXml = XDocument.Load (publicXmlPath);
 			}
 
+			var resModifiedDate = !string.IsNullOrEmpty (ResourceFlagFile) && File.Exists (ResourceFlagFile)
+				? File.GetLastWriteTimeUtc (ResourceFlagFile)
+				: DateTime.MinValue;
 			// This top most R.txt will contain EVERYTHING we need. including library resources since it represents
 			// the final build.
 			var rTxt = Path.Combine(resourceDirectory, "..", "R.txt");
-			if (File.Exists (rTxt)) {
+			if (File.Exists (rTxt) && File.GetLastWriteTimeUtc (rTxt) > resModifiedDate) {
 				ProcessRtxtFile (rTxt);
 			} else {
 				foreach (var dir in Directory.EnumerateDirectories (resourceDirectory, "*", SearchOption.TopDirectoryOnly)) {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1342,6 +1342,7 @@ because xbuild doesn't support framework reference assemblies.
 		UseManagedResourceGenerator="True"
 		DesignTimeBuild="$(DesignTimeBuild)"
 		JavaPlatformJarPath="$(JavaPlatformJarPath)"
+		ResourceFlagFile="$(_AndroidResFlagFile)"
 		Condition="Exists ('$(MonoAndroidResourcePrefix)')"
 	/>
 	<ItemGroup>


### PR DESCRIPTION
One of the problems we have with the `ManagedResourceParser` is
that it uses the `R.txt` to generate the `Resource.Designer.cs`
file. The issue there is that if the user modifies a layout file
(say adds or changes and id) that will NOT be picked up until
the next build. This is because the `R.txt` file is generated
by `aapt/aapt2` and those tools are not called for DesignTime
Builds.

So what we need to do is pass in the `$(_AndroidResFlagFile)`
into the `GenerateResourceDesigner`. This will allow us to
do a last modified date time check against the `R.txt` file.
If the `$(_AndroidResFlagFile)` is newer then we should NOT
use the `R.txt` and parse the layout files to pick up changes.