### PR TITLE
[tests] fix for ExistingProject

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ExistingProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ExistingProject.cs
@@ -9,6 +9,8 @@ namespace Xamarin.ProjectTools
 	{
 		public override string ProjectTypeGuid => string.Empty;
 
+		public override bool ShouldPopulate => false;
+
 		public override List<ProjectResource> Save (bool saveProject = true) => new List<ProjectResource> ();
 
 		public override void UpdateProjectFiles (string directory, IEnumerable<ProjectResource> projectFiles, bool doNotCleanup = false) { }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -45,13 +45,16 @@ namespace Xamarin.ProjectTools
 			var files = project.Save (saveProject);
 
 			if (!built_before) {
-				if (Directory.Exists (ProjectDirectory)) {
-					FileSystemUtils.SetDirectoryWriteable (ProjectDirectory);
-					Directory.Delete (ProjectDirectory, true);
+				if (project.ShouldPopulate) {
+					if (Directory.Exists (ProjectDirectory)) {
+						FileSystemUtils.SetDirectoryWriteable (ProjectDirectory);
+						Directory.Delete (ProjectDirectory, true);
+					}
+					if (Directory.Exists (PackagesDirectory)) {
+						Directory.Delete (PackagesDirectory, true);
+					}
+					project.Populate (ProjectDirectory, files);
 				}
-				if (Directory.Exists (PackagesDirectory))
-					Directory.Delete (PackagesDirectory, true);
-				project.Populate (ProjectDirectory, files);
 
 				// Copy our solution's NuGet.config
 				var nuget_config = Path.Combine (XABuildPaths.TopDirectory, "NuGet.config");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -32,6 +32,10 @@ namespace Xamarin.ProjectTools
 		public IList<BuildItem> References { get; private set; }
 		public IList<Package> PackageReferences { get; private set; }
 		public virtual bool ShouldRestorePackageReferences => PackageReferences?.Count > 0;
+		/// <summary>
+		/// If true, the ProjectDirectory will be deleted and populated on the first build
+		/// </summary>
+		public virtual bool ShouldPopulate => true;
 		public IList<Import> Imports { get; private set; }
 		PropertyGroup common, debug, release;
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/c00095b6e560077bfb94185b6e0b9a36996d3b8b
Context: https://github.com/xamarin/monodroid/pull/1007

We have been getting the following error on monodroid builds:

    /Users/builder/jenkins/workspace/monodroid-pr/monodroid/external/xamarin-android/bin/Release/bin/xabuild /Users/builder/jenkins/workspace/monodroid-pr/monodroid/external/xamarin-android/bin/TestRelease/temp/HelloFormsFalse/HelloForms.sln /t:Restore /noconsolelogger "/flp1:LogFile=/Users/builder/jenkins/workspace/monodroid-pr/monodroid/external/xamarin-android/bin/TestRelease/temp/HelloFormsFalse/build.log;Encoding=UTF-8;Verbosity=diagnostic" @"/Users/builder/jenkins/workspace/monodroid-pr/monodroid/external/xamarin-android/bin/TestRelease/temp/HelloFormsFalse/project.rsp"
    Microsoft (R) Build Engine version 16.0.42-preview+g804bde742b for Mono
    Copyright (C) Microsoft Corporation. All rights reserved.

    MSBUILD : error MSB1009: Project file does not exist.
    Switch: /Users/builder/jenkins/workspace/monodroid-pr/monodroid/external/xamarin-android/bin/TestRelease/temp/HelloFormsFalse/HelloForms.sln

In c00095b, the tests were passing on xamarin-android builds, but they
fail when running in monodroid builds? This appears to be due to
differences in test ordering.

There was a code path where `ProjectBuilder` was deleting its
`ProjectDirectory` and calling `Populate()` on the project.

For an `ExistingProject` in `DeleteBinObjTest`, this would nuke the
directory we just extracted from a zip file--causing MSBuild to fail.

The fix is to add a new `ShouldPopulate` flag we can set to `false` to
skip the directory deletion.