### PR TITLE
[build] Fix PR installer creation, and 'make jenkins'

### DIFF
--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -188,9 +188,10 @@ timestamps {
 
         utils.stageWithTimeout('create installers', 30, 'MINUTES', XADir, true) {    // Typically takes less than 5 minutes
             if (isPr) {
-                // Exclude mono components if they aren't being built.
+                // Override _MSBUILD_ARGS to ensure we only package the `AndroidSupportedTargetJitAbis` which are built.
+                // Also ensure that we don't require mono bundle components in the installer if this is not a full mono integration build.
                 def msbuildInstallerArgs = hasPrLabelFullMonoIntegrationBuild ? '' : '/p:IncludeMonoBundleComponents=False'
-                sh "make create-installers CONFIGURATION=${env.BuildFlavor} V=1 MSBUILD_ARGS='${msbuildInstallerArgs}'"
+                sh "make create-installers CONFIGURATION=${env.BuildFlavor} V=1 _MSBUILD_ARGS='${msbuildInstallerArgs}'"
             } else {
                 sh "make create-installers CONFIGURATION=${env.BuildFlavor} V=1"
             }

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -10,7 +10,8 @@
 # The other targets depended upon by leeroy also require rules.mk to be present and thus they
 # are invoked in the same way framework-assemblies is
 #
-jenkins:: prepare
+jenkins::
+	$(MAKE) PREPARE_CI=1 prepare
 	$(MAKE) leeroy $(ZIP_OUTPUT)
 
 leeroy: leeroy-all framework-assemblies opentk-jcw


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/a61fd98c3e1fb707329a83243d7088e7bf9ec955
Reverts: https://github.com/xamarin/xamarin-android/commit/1e4d167ac45002adaf0711db99b9e68acaf087a6

Fixes the PR build installer creation breakage[0] caused by 1e4d167 by
reverting it. Also fixes local `make jenkins` build failures, as the
recent changes in a61fd98c overlooked local build behavior. A 'full'
build was only being configured correctly when running from CI, and this
has been fixed by ensuring the `PREPARE_CI` make variable is set when
running `make jenkins` locally.

[0]

    11:03:56  "/Users/builder/jenkins/workspace/xamarin-android-pr-pipeline-release/xamarin-android/build-tools/create-pkg/create-pkg.csproj" (CreatePkg target) (1) ->
    11:03:56  (_CopyFilesToPayloadDir target) ->
    11:03:56    /Users/builder/jenkins/workspace/xamarin-android-pr-pipeline-release/xamarin-android/build-tools/create-pkg/create-pkg.targets(33,5): error MSB3030: Could not copy the file "/Users/builder/jenkins/workspace/xamarin-android-pr-pipeline-release/xamarin-android/bin/Release/lib/xamarin.android/xbuild/Xamarin/Android/lib/x86_64/libmono-android.debug.so" because it was not found. [/Users/builder/jenkins/workspace/xamarin-android-pr-pipeline-release/xamarin-android/build-tools/create-pkg/create-pkg.csproj]
    11:03:56    /Users/builder/jenkins/workspace/xamarin-android-pr-pipeline-release/xamarin-android/build-tools/create-pkg/create-pkg.targets(33,5): error MSB3030: Could not copy the file "/Users/builder/jenkins/workspace/xamarin-android-pr-pipeline-release/xamarin-android/bin/Release/lib/xamarin.android/xbuild/Xamarin/Android/lib/x86_64/libmono-android.release.so" because it was not found. [/Users/builder/jenkins/workspace/xamarin-android-pr-pipeline-release/xamarin-android/build-tools/create-pkg/create-pkg.csproj]
    11:03:56    /Users/builder/jenkins/workspace/xamarin-android-pr-pipeline-release/xamarin-android/build-tools/create-pkg/create-pkg.targets(33,5): error MSB3030: Could not copy the file "/Users/builder/jenkins/workspace/xamarin-android-pr-pipeline-release/xamarin-android/bin/Release/lib/xamarin.android/xbuild/Xamarin/Android/lib/x86_64/libsqlite3_xamarin.so" because it was not found. [/Users/builder/jenkins/workspace/xamarin-android-pr-pipeline-release/xamarin-android/build-tools/create-pkg/create-pkg.csproj]
    11:03:56
    11:03:56      0 Warning(s)
    11:03:56      3 Error(s)
    11:03:56
    11:03:56  Time Elapsed 00:00:03.98