### PR TITLE
[Xamarin.Android.Build.Tasks] remove Distinct() from <ResolveLibraryProjectImports/>

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -135,6 +135,29 @@ class MemTest {
 		}
 
 		[Test]
+		public void DuplicateReferences ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.MainActivity = proj.DefaultMainActivity.Replace ("public class MainActivity : Activity", "public class MainActivity : Android.Support.V7.App.AppCompatActivity");
+			var package = KnownPackages.SupportV7AppCompat_27_0_2_1;
+			var fullPath = Path.GetFullPath (Path.Combine (Root, "temp", "packages", $"{package.Id}.{package.Version}", "lib", package.TargetFramework, $"{package.Id}.dll"));
+			proj.PackageReferences.Add (package);
+			proj.Packages.Add (package);
+			proj.References.Add (new BuildItem.Reference (package.Id) {
+				MetadataValues = "HintPath=" + fullPath,
+			});
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "first build should have succeeded.");
+
+				// Remove NuGet packages, but leave References
+				proj.PackageReferences.Clear ();
+				proj.Packages.Clear ();
+
+				Assert.IsTrue (b.Build (proj), "second build should have succeeded.");
+			}
+		}
+
+		[Test]
 		public void BuildXamarinFormsMapsApplication ()
 		{
 			var proj = new XamarinFormsMapsApplicationProject ();


### PR DESCRIPTION
The `<ResolveLibraryProjectImports/>` task has some logic that needs
to look at the item metadata of each `@(Reference)`:

* `%(AndroidSkipResourceExtraction)` to skip unzipping anything
* `%(AndroidSkipResourceProcessing)` to skip `<ConvertResourcesCases/>`

To make matters weird, we had some LINQ:

    foreach (var assemblyPath in Assemblies
            .Select (a => a.ItemSpec)
            .Distinct ()) {

And we would basically lose the metadata information...

To handle this problem, we had two `HashSet`'s we used to lookup the
values:

    assembliesToSkipCaseFixup = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
    assembliestoSkipExtraction = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
    bool metaDataValue;
    foreach (var asm in Assemblies) {
        if (bool.TryParse (asm.GetMetadata (AndroidSkipResourceProcessing), out metaDataValue) && metaDataValue)
            assembliesToSkipCaseFixup.Add (asm.ItemSpec);
        if (bool.TryParse (asm.GetMetadata (GetAdditionalResourcesFromAssemblies.AndroidSkipResourceExtraction), out metaDataValue) && metaDataValue)
            assembliestoSkipExtraction.Add (asm.ItemSpec);
    }

I added a test to see what happens when we use multiple `@(Reference)`
such as:

* `<PackageReference/>`
* `packages.config` and a regular `<Reference/>`
* `<Reference/>` with a full path

It turns out there are MSBuild targets that disambiguate duplicate
assembly references:

https://github.com/NuGet/NuGet.BuildTasks/blob/640c8e13a9b7ab6e86264a296638fbf3cc016ad1/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets#L186-L207

The `ResolveNuGetPackageAssets` does a `Remove` against duplicate
`@(Reference)`, even if there are no NuGet packages present in the
project.

It seems safe for us to just drop the `Distinct()` and the
`HashSet`'s. The code is a bit simpler after doing this.

I'm also seeing a small ~25ms performance improvement with this change.