### PR TITLE
Bump to xamarin/monodroid/d16-3@52c7914

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:d16-3@7550edd7d8e86e8042ffec6e21d6f249fa50d49f
+xamarin/monodroid:d16-3@52c7914d440e1bd57b28ae91a5bb7ac99c163659


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/commit/52c7914d440e1bd57b28ae91a5bb7ac99c163659

We need the monodroid-side changes for `@(_BuildTargetAbis)`.