### PR TITLE
[build/test] Include installer signing and other fixes from master

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:d16-3@52c7914d440e1bd57b28ae91a5bb7ac99c163659
+xamarin/monodroid:d16-3@cccf420083cadeae8bcd8be68eea65db1b707274

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1,6 +1,6 @@
 # Xamarin.Android Pipeline
 
-name: $(Build.SourceBranch)-$(Build.SourceVersion)-$(Rev:r)
+name: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
 
 trigger:
   - master

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -19,17 +19,11 @@ resources:
 variables:
   BundleArtifactName: bundle
   InstallerArtifactName: unsigned-installers
-  AutoProvisionArgs: /p:AutoProvision=True /p:AutoProvisionUsesSudo=True /p:IgnoreMaxMonoVersion=False
-  AndroidTargetAbiArgs: >-
-    /p:AndroidSupportedTargetJitAbis=armeabi-v7a:arm64-v8a:x86:x86_64
-    /p:AndroidSupportedTargetAotAbis=armeabi-v7a:arm64:x86:x86_64:win-armeabi-v7a:win-arm64:win-x86:win-x86_64
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
 stages:
 - stage: prepare
   displayName: Prepare
-  variables:
-    MSBuildAbiArgs: $(AndroidTargetAbiArgs) /p:AndroidSupportedHostJitAbis=Darwin:mxe-Win32:mxe-Win64
   jobs:
   - job: create_bundle
     displayName: Bundle
@@ -45,8 +39,8 @@ stages:
       # Update Mono in a separate step since xaprepare uses it as well and it will crash when Mono it runs with is updated
       # The 'prepare' step creates the bundle
     - script: |
-        make prepare-update-mono PREPARE_CI=1 V=1 CONFIGURATION=$(XA.Build.Configuration) MSBUILD_ARGS="$(AutoProvisionArgs) $(MSBuildAbiArgs)"
-        make prepare PREPARE_CI=1 PREPARE_ARGS="--copy-bundle-to=bin/$(XA.Build.Configuration)" V=1 CONFIGURATION=$(XA.Build.Configuration) MSBUILD_ARGS="$(AutoProvisionArgs) $(MSBuildAbiArgs)"
+        make prepare-update-mono PREPARE_CI=1 V=1 PREPARE_AUTOPROVISION=1 CONFIGURATION=$(XA.Build.Configuration)
+        make prepare PREPARE_CI=1 PREPARE_AUTOPROVISION=1 PREPARE_ARGS="--copy-bundle-to=bin/$(XA.Build.Configuration)" V=1 CONFIGURATION=$(XA.Build.Configuration)
       displayName: create bundle
 
     - task: CopyFiles@2
@@ -99,8 +93,11 @@ stages:
         artifactName: $(BundleArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)
 
+    - script: make prepare-update-mono V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1 PREPARE_ARGS="--bundle-path=$(System.DefaultWorkingDirectory)"
+      displayName: make prepare-update-mono
+
     - script: make prepare-external-git-dependencies PREPARE_CI=1 CONFIGURATION=$(XA.Build.Configuration)
-      displayName: make prepare-commercial
+      displayName: make prepare-external-git-dependencies
       condition: eq(variables['XA.Commercial.Build'], 'true')
       env:
         GH_AUTH_SECRET: $(Github.Token)
@@ -113,11 +110,7 @@ stages:
         provisioning_script: $(System.DefaultWorkingDirectory)/external/monodroid/build-tools/provisionator/profile.csx
         provisioning_extra_args: -vv
 
-    - script: make prepare-update-mono V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_ARGS="--bundle-path=$(System.DefaultWorkingDirectory)" MSBUILD_ARGS="$(AutoProvisionArgs) /p:BundleRootPath=$(System.DefaultWorkingDirectory)"
-      displayName: make prepare-update-mono
-
-      # No need to add `prepare` to the command line, the `jenkins` rule depends on `prepare-jenkins` which will run the bootstrapper
-    - script: make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_ARGS="--bundle-path=$(System.DefaultWorkingDirectory)" MSBUILD_ARGS="$(AutoProvisionArgs) /p:BundleRootPath=$(System.DefaultWorkingDirectory)"
+    - script: make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1 PREPARE_ARGS="--bundle-path=$(System.DefaultWorkingDirectory)"
       displayName: make jenkins
 
     - script: make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
@@ -163,6 +156,9 @@ stages:
     workspace:
       clean: all
     variables:
+      AndroidTargetAbiArgs: >-
+        /p:AndroidSupportedTargetJitAbis=armeabi-v7a:arm64-v8a:x86:x86_64
+        /p:AndroidSupportedTargetAotAbis=armeabi-v7a:arm64:x86:x86_64:win-armeabi-v7a:win-arm64:win-x86:win-x86_64
       JAVA_HOME: '%HOMEDRIVE%%HOMEPATH%\android-toolchain\jdk'
     steps:
     - checkout: self
@@ -178,14 +174,14 @@ stages:
       inputs:
         solution: Xamarin.Android.sln
         configuration: $(XA.Build.Configuration)
-        msbuildArguments: $(AutoProvisionArgs) $(AndroidTargetAbiArgs) /t:Prepare /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\msbuild-prepare.binlog /p:BundleRootPath=$(System.DefaultWorkingDirectory)
+        msbuildArguments: /t:Prepare /p:AutoProvision=true $(AndroidTargetAbiArgs) /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\msbuild-prepare.binlog /p:BundleRootPath=$(System.DefaultWorkingDirectory)
 
     - task: MSBuild@1
       displayName: msbuild Xamarin.Android /t:Build
       inputs:
         solution: Xamarin.Android.sln
         configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:Build /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\msbuild-build.binlog /p:BundleRootPath=$(System.DefaultWorkingDirectory) $(AndroidTargetAbiArgs)
+        msbuildArguments: /t:Build $(AndroidTargetAbiArgs) /bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\msbuild-build.binlog /p:BundleRootPath=$(System.DefaultWorkingDirectory)
 
     - task: MSBuild@1
       displayName: msbuild create-vsix

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -18,9 +18,10 @@ resources:
 # Global variables
 variables:
   BundleArtifactName: bundle
-  InstallerArtifactName: unsigned-installers
+  InstallerArtifactName: installers
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
+# Check - "Xamarin.Android (Prepare bundle)"
 stages:
 - stage: prepare
   displayName: Prepare
@@ -75,7 +76,8 @@ stages:
   displayName: Mac
   dependsOn: prepare
   jobs:
-  - job: mac_build
+  # Check - "Xamarin.Android (Mac Build)"
+  - job: mac_build_create_installers
     displayName: Build
     pool: $(XA.Build.Mac.Pool)
     timeoutInMinutes: 240
@@ -117,16 +119,40 @@ stages:
       displayName: make create-installers
 
     - script: |
-        mkdir -p bin/Build$(XA.Build.Configuration)/unsigned-installers
-        cp bin/Build$(XA.Build.Configuration)/*.vsix bin/Build$(XA.Build.Configuration)/unsigned-installers
-        cp bin/Build$(XA.Build.Configuration)/*.pkg bin/Build$(XA.Build.Configuration)/unsigned-installers
+        mkdir -p bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
+        cp bin/Build$(XA.Build.Configuration)/*.vsix bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
+        cp bin/Build$(XA.Build.Configuration)/*.pkg bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
       displayName: copy unsigned installers
 
+    - script: |
+        VERSION=`LANG=C; export LANG && git log --no-color --first-parent -n1 --pretty=format:%ct`
+        echo "d1ec039f-f3db-468b-a508-896d7c382999 $VERSION" > bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)/updateinfo
+      displayName: create updateinfo file
+
+    - powershell: |
+        $pkg = Get-ChildItem -Path "bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)/*" -Include *.pkg -File
+        if (![System.IO.File]::Exists($pkg)) {
+            throw [System.IO.FileNotFoundException] "Pkg File not found in bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)"
+        }
+        Write-Host "##vso[task.setvariable variable=XA.Unsigned.Pkg]$pkg"
+      displayName: set variable to pkg path
+
+    - template: productsign-pkg.yml@yaml
+      parameters:
+        UnsignedPkgPath: $(XA.Unsigned.Pkg)
+
     - task: PublishPipelineArtifact@0
-      displayName: upload unsigned installers
+      displayName: upload installers
       inputs:
         artifactName: $(InstallerArtifactName)
-        targetPath: bin/Build$(XA.Build.Configuration)/unsigned-installers
+        targetPath: bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
+
+    - template: upload-to-storage.yml@yaml
+      parameters:
+        BuildPackages: bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
+        AzureContainerName: $(Azure.Container.Name)
+        AzureUploadLocation: $(Build.DefinitionName)/$(Build.BuildId)/$(Build.SourceBranchName)/$(Build.SourceVersion)
+        condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
 
     - task: MSBuild@1
       displayName: package build results
@@ -143,7 +169,32 @@ stages:
         targetPath: $(Build.ArtifactStagingDirectory)
       condition: always()
 
+  # Check - "Xamarin.Android (Mac Queue Vsix Signing)"
+  # Actually runs on a Windows host, but the work is done in a Jenkins job. Does not run on PR builds.
+  - job: queue_vsix_signing
+    displayName: Queue Vsix Signing
+    dependsOn: mac_build_create_installers
+    pool: $(XA.Build.Win.Pool)
+    condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
+    timeoutInMinutes: 30
+    cancelTimeoutInMinutes: 1
+    workspace:
+      clean: all
+    steps:
+    - task: JenkinsQueueJob@2
+      displayName: xamarin vsix codesign - run jenkins job
+      inputs:
+        serverEndpoint: $(Signing.Endpoint)
+        jobName: $(Signing.Job)
+        isParameterizedJob: true
+        jobParameters: |
+          REPO=$(Build.Repository.Name)
+          COMMIT=$(Build.SourceVersion)
+          SIGN_TYPE=Real
+          GITHUB_CONTEXT=$(GitHub.Artifacts.Context)
+
 # This stage ensures Windows specific build steps continue to work, and runs unit tests.
+# Check - "Xamarin.Android (Windows Build and Test)"
 - stage: win_build_test
   displayName: Windows
   dependsOn: prepare
@@ -242,7 +293,7 @@ stages:
   displayName: Test
   dependsOn: mac_build
   jobs:
-  # Test APK Instrumentation
+  # Check - "Xamarin.Android (Test APK Instrumentation)"
   - job: mac_apk_tests
     displayName: APK Instrumentation
     pool: $(XA.Build.Mac.Pool)
@@ -442,7 +493,7 @@ stages:
         targetPath: $(Build.ArtifactStagingDirectory)
       condition: always()
 
-  # Test Designer Mac  
+  # Check - "Xamarin.Android (Test Designer Mac)"
   - job: designer_integration_mac
     displayName: Designer Mac
     pool: $(XA.Build.Mac.Pool)
@@ -482,7 +533,7 @@ stages:
       parameters:
         designerSourcePath: $(System.DefaultWorkingDirectory)/designer
 
-  # Test Designer Windows
+  # Check - "Xamarin.Android (Test Designer Windows)"
   - job: designer_integration_win
     displayName: Designer Windows
     pool:

--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -21,6 +21,7 @@ def skipTest = false
 
 def hasPrLabelFullMonoIntegrationBuild = false
 
+def prepareFlags = 'PREPARE_CI=1'
 def buildTarget = 'jenkins'
 
 def utils = null
@@ -119,6 +120,7 @@ timestamps {
                     hasPrLabelFullMonoIntegrationBuild = true
                     buildTarget = 'jenkins'
                 } else {
+                    prepareFlags = 'PREPARE_CI_PR=1'
                     buildTarget = 'all'
                     // Also compile host libs for windows so that a complete VSIX can be created
                     if (isUnix()) {
@@ -149,7 +151,7 @@ timestamps {
 
         utils.stageWithTimeout('prepare deps', 30, 'MINUTES', XADir, true) {    // Typically takes less than 2 minutes, but can take longer if any prereqs need to be provisioned
             if (isCommercial) {
-                sh "make prepare-external-git-dependencies PREPARE_CI=1 V=1 "
+                sh "make prepare-external-git-dependencies ${prepareFlags} V=1 "
 
                 utils.stageWithTimeout('provisionator', 30, 'MINUTES', "${commercialPath}/build-tools/provisionator", true) {
                     sh('./provisionator.sh profile.csx -v')
@@ -172,9 +174,9 @@ timestamps {
             // The 'prepare*' targets must run separately to '${buildTarget}` as preparation generates the 'rules.mk' file conditionally included by
             // Makefile and it will **NOT** be included if we call e.g `make prepare jenkins` so the 'jenkns' target will **NOT** build all the supported
             // targets and architectures leading to test errors later on (e.g. in EmbeddedDSOs tests)
-            sh "make prepare-update-mono CONFIGURATION=${env.BuildFlavor} V=1 PREPARE_CI=1 MSBUILD_ARGS='$EXTRA_MSBUILD_ARGS'"
-            sh "make prepare CONFIGURATION=${env.BuildFlavor} V=1 PREPARE_CI=1 MSBUILD_ARGS='$EXTRA_MSBUILD_ARGS'"
-            sh "make ${buildTarget} CONFIGURATION=${env.BuildFlavor} V=1 MSBUILD_ARGS='$EXTRA_MSBUILD_ARGS'"
+            sh "make prepare-update-mono CONFIGURATION=${env.BuildFlavor} V=1 ${prepareFlags} MSBUILD_ARGS='$EXTRA_MSBUILD_ARGS'"
+            sh "make prepare CONFIGURATION=${env.BuildFlavor} V=1 ${prepareFlags} MSBUILD_ARGS='$EXTRA_MSBUILD_ARGS'"
+            sh "make ${buildTarget} CONFIGURATION=${env.BuildFlavor} V=1 ${prepareFlags} MSBUILD_ARGS='$EXTRA_MSBUILD_ARGS'"
 
             if (isCommercial) {
                 sh '''
@@ -186,10 +188,9 @@ timestamps {
 
         utils.stageWithTimeout('create installers', 30, 'MINUTES', XADir, true) {    // Typically takes less than 5 minutes
             if (isPr) {
-                // Override _MSBUILD_ARGS to ensure we only package the `AndroidSupportedTargetJitAbis` which are built.
-                // Also ensure that we don't require mono bundle components in the installer if this is not a full mono integration build.
+                // Exclude mono components if they aren't being built.
                 def msbuildInstallerArgs = hasPrLabelFullMonoIntegrationBuild ? '' : '/p:IncludeMonoBundleComponents=False'
-                sh "make create-installers CONFIGURATION=${env.BuildFlavor} V=1 _MSBUILD_ARGS='${msbuildInstallerArgs}'"
+                sh "make create-installers CONFIGURATION=${env.BuildFlavor} V=1 MSBUILD_ARGS='${msbuildInstallerArgs}'"
             } else {
                 sh "make create-installers CONFIGURATION=${env.BuildFlavor} V=1"
             }

--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -188,9 +188,10 @@ timestamps {
 
         utils.stageWithTimeout('create installers', 30, 'MINUTES', XADir, true) {    // Typically takes less than 5 minutes
             if (isPr) {
-                // Exclude mono components if they aren't being built.
+                // Override _MSBUILD_ARGS to ensure we only package the `AndroidSupportedTargetJitAbis` which are built.
+                // Also ensure that we don't require mono bundle components in the installer if this is not a full mono integration build.
                 def msbuildInstallerArgs = hasPrLabelFullMonoIntegrationBuild ? '' : '/p:IncludeMonoBundleComponents=False'
-                sh "make create-installers CONFIGURATION=${env.BuildFlavor} V=1 MSBUILD_ARGS='${msbuildInstallerArgs}'"
+                sh "make create-installers CONFIGURATION=${env.BuildFlavor} V=1 _MSBUILD_ARGS='${msbuildInstallerArgs}'"
             } else {
                 sh "make create-installers CONFIGURATION=${env.BuildFlavor} V=1"
             }

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -10,7 +10,8 @@
 # The other targets depended upon by leeroy also require rules.mk to be present and thus they
 # are invoked in the same way framework-assemblies is
 #
-jenkins:: prepare
+jenkins::
+	$(MAKE) PREPARE_CI=1 prepare
 	$(MAKE) leeroy $(ZIP_OUTPUT)
 
 leeroy: leeroy-all framework-assemblies opentk-jcw

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -10,7 +10,7 @@
 # The other targets depended upon by leeroy also require rules.mk to be present and thus they
 # are invoked in the same way framework-assemblies is
 #
-jenkins:: prepare-jenkins
+jenkins:: prepare
 	$(MAKE) leeroy $(ZIP_OUTPUT)
 
 leeroy: leeroy-all framework-assemblies opentk-jcw

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
@@ -15,9 +15,15 @@ namespace Xamarin.Android.Build.Tests {
 
 		string GetPathToAapt2 ()
 		{
-			var path = Path.Combine (AndroidSdkPath, "build-tools");
+
+			var exe = IsWindows ? "aapt2.exe" : "aapt2";
+			var path = Path.Combine (AndroidMSBuildDirectory, IsWindows ? "" : (IsMacOS ? "Darwin" : "Linux"));
+			if (File.Exists (Path.Combine (path, exe)))
+				return path;
+
+			path = Path.Combine (AndroidSdkPath, "build-tools");
 			foreach (var dir in Directory.GetDirectories (path, "*", SearchOption.TopDirectoryOnly).OrderByDescending (x => x)) {
-				var aapt2 = Path.Combine (dir, IsWindows ? "aapt2.exe" : "aapt");
+				var aapt2 = Path.Combine (dir, exe);
 				if (File.Exists (aapt2))
 					return dir;
 			}
@@ -175,8 +181,9 @@ namespace Xamarin.Android.Build.Tests {
 			} finally {
 				Directory.SetCurrentDirectory (current);
 			}
-			Assert.AreEqual (1, errors.Count, "One Error should have been raised.");
+			Assert.AreEqual (2, errors.Count, $"Two Error should have been raised. {string.Join (" ", errors.Select (e => e.Message))}");
 			Assert.AreEqual ($"Resources{directorySeperator}Values{directorySeperator}Strings.xml", errors[0].File, $"`values{directorySeperator}strings.xml` should have been replaced with `Resources{directorySeperator}Values{directorySeperator}Strings.xml`");
+			Assert.AreEqual ($"Resources{directorySeperator}Values{directorySeperator}Strings.xml", errors [1].File, $"`values{directorySeperator}strings.xml` should have been replaced with `Resources{directorySeperator}Values{directorySeperator}Strings.xml`");
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
 
@@ -223,7 +230,7 @@ namespace Xamarin.Android.Build.Tests {
 				ExtraArgs = "--no-crunch "
 			};
 			Assert.False (task.Execute (), "task should have failed.");
-			Assert.AreEqual (1, errors.Count, "One error should have been raised.");
+			Assert.AreEqual (1, errors.Count, $"One error should have been raised. {string.Join (" ", errors.Select (e => e.Message))}");
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
 	}

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -36,8 +36,9 @@ namespace Xamarin.Android.Build.Tests
 			builder = CreateApkBuilder (Path.Combine ("temp", "DeploymentTests"));
 			string apiLevel;
 			proj.TargetFrameworkVersion = builder.LatestTargetFrameworkVersion (out apiLevel);
+			proj.PackageName = "Xamarin.TimeZoneTest";
 			proj.AndroidManifest = $@"<?xml version=""1.0"" encoding=""utf-8""?>
-<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" android:versionCode=""1"" android:versionName=""1.0"" package=""UnnamedProject.UnnamedProject"">
+<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" android:versionCode=""1"" android:versionName=""1.0"" package=""Xamarin.TimeZoneTest"">
 	<uses-sdk android:minSdkVersion=""24"" android:targetSdkVersion=""{apiLevel}"" />
 	<application android:label=""${{PROJECT_NAME}}"">
 	</application >
@@ -99,7 +100,9 @@ namespace Xamarin.Android.Build.Tests
 			ClearAdbLogcat ();
 			AdbStartActivity ($"{proj.PackageName}/md52d9cf6333b8e95e8683a477bc589eda5.MainActivity");
 			Assert.IsTrue (WaitForActivityToStart (proj.PackageName, "MainActivity", output: out string logcat), "Activity should have started");
-			StringAssert.Contains ($"TimeZoneInfo={timeZone}", logcat, $"TimeZone should have been {timeZone}");
+			Assert.IsTrue (MonitorAdbLogcat ((l)=> {
+				return l.Contains ($"TimeZoneInfo={timeZone}");
+			}), $"TimeZone should have been {timeZone}");
 		}
 	}
 }


### PR DESCRIPTION
This should hopefully include everything we need to get both of
our CI systems back to "green", and allow us to ship Azure Pipeline
based builds for d16-3.

Context: https://jenkins.mono-project.com/job/xamarin-android-pr-pipeline-release/1481/

  * Bump to xamarin/monodroid@cccf420
    Changes: http://github.com/xamarin/monodroid/compare/52c7914...cccf420

  * Adds conditional .pkg and .vsix signing, blob storage uploading
    and GitHub artifact status reporting.

  * Includes some make and azure-pipelines.yaml based cleanup,
    which was done to resolve the EmbeddedDSOTest failures on
    Jenkins PR builds.

  * Fixes CheckTimeZoneInfoIsCorrect test failures.

  * Fixes Aapt2CompileFixesUpErrors test failure.
  