### PR TITLE
Update LibZipSharp submodule to point to Xamarin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,7 +16,7 @@
     branch = rel-1-5-1
 [submodule "external/LibZipSharp"]
     path = external/LibZipSharp
-    url = https://github.com/grendello/LibZipSharp.git
+    url = https://github.com/xamarin/LibZipSharp.git
     branch = master
 [submodule "external/mman-win32"]
     path = external/mman-win32


### PR DESCRIPTION
`LibZipSharp` repository was moved from its previous location to
`xamarin/LibZipSharp`, update the submodule to point to the new location.