### PR TITLE
[Mono.Android] Add MetaKeyStates.None. [#3180]

### DIFF
--- a/src/Mono.Android/map.csv
+++ b/src/Mono.Android/map.csv
@@ -2293,6 +2293,7 @@
 15,Android.Views.MetaKeyStates,MetaMask,android/view/KeyEvent.META_META_MASK,458752
 15,Android.Views.MetaKeyStates,MetaOn,android/view/KeyEvent.META_META_ON,65536
 15,Android.Views.MetaKeyStates,MetaRightOn,android/view/KeyEvent.META_META_RIGHT_ON,262144
+0,Android.Views.MetaKeyStates,None,,0
 15,Android.Views.MetaKeyStates,NumLockOn,android/view/KeyEvent.META_NUM_LOCK_ON,2097152
 15,Android.Views.MetaKeyStates,ScrollLockOn,android/view/KeyEvent.META_SCROLL_LOCK_ON,4194304
 10,Android.Views.MetaKeyStates,ShiftLeftOn,android/view/KeyEvent.META_SHIFT_LEFT_ON,64


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/3180.

Diff against `Mono.Android.dll`:

```
diff --git a/mono.android-android-28/mcw/Android.Views.MetaKeyStates.cs b/mono.android-android-28/mcw/Android.Views.MetaKeyStates.cs
index ee50c45..df2bfa9 100644
--- a/mono.android-android-28/mcw/Android.Views.MetaKeyStates.cs
+++ b/mono.android-android-28/mcw/Android.Views.MetaKeyStates.cs
@@ -28,6 +28,8 @@ namespace Android.Views {
     MetaOn = 65536,
     [global::Android.Runtime.IntDefinition (null, JniField = "android/view/KeyEvent.META_META_RIGHT_ON")]
     MetaRightOn = 262144,
+    [global::Android.Runtime.IntDefinition (null, JniField = "")]
+    None = 0,
     [global::Android.Runtime.IntDefinition (null, JniField = "android/view/KeyEvent.META_NUM_LOCK_ON")]
     NumLockOn = 2097152,
     [global::Android.Runtime.IntDefinition (null, JniField = "android/view/KeyEvent.META_SCROLL_LOCK_ON")]
```