### PR TITLE
[xaprepare] Use NuGet binary we download

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/ProcessRunner.cs
+++ b/build-tools/xaprepare/xaprepare/Application/ProcessRunner.cs
@@ -87,6 +87,22 @@ namespace Xamarin.Android.Prepare
 				throw new ArgumentException ("must not be null or empty", nameof (command));
 
 			this.command = command;
+			AddArgumentsInternal (ignoreEmptyArguments, arguments);
+		}
+
+		public ProcessRunner AddArguments (params string[] arguments)
+		{
+			return AddArguments (true, arguments);
+		}
+
+		public ProcessRunner AddArguments (bool ignoreEmptyArguments, params string[] arguments)
+		{
+			AddArgumentsInternal (ignoreEmptyArguments, arguments);
+			return this;
+		}
+
+		void AddArgumentsInternal (bool ignoreEmptyArguments, params string[] arguments)
+		{
 			if (arguments == null)
 				return;
 

--- a/build-tools/xaprepare/xaprepare/ToolRunners/NuGetRunner.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/NuGetRunner.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Android.Prepare
 		protected override string ToolName                  => "NuGet";
 
 		public NuGetRunner (Context context, Log log = null, string nugetPath = null)
-			: base (context, log, nugetPath)
+			: base (context, log, nugetPath ?? Configurables.Paths.LocalNugetPath)
 		{}
 
 		public async Task<bool> Restore (string solutionFilePath)

--- a/build-tools/xaprepare/xaprepare/ToolRunners/ToolRunner.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/ToolRunner.cs
@@ -87,7 +87,7 @@ namespace Xamarin.Android.Prepare
 			if (managedRunner != null)
 				managedRunner = Context.OS.Which (managedRunner);
 
-			var runner = new ProcessRunner (managedRunner ?? FullToolPath, initialParams) {
+			var runner = new ProcessRunner (managedRunner ?? FullToolPath) {
 				ProcessTimeout = ProcessTimeout,
 				EchoCmdAndArguments = EchoCmdAndArguments,
 				EchoStandardError = EchoStandardError,
@@ -103,6 +103,7 @@ namespace Xamarin.Android.Prepare
 			if (managedRunner != null)
 				runner.AddQuotedArgument (FullToolPath);
 
+			runner.AddArguments (initialParams);
 			return runner;
 		}
 


### PR DESCRIPTION
`NuGetRunner` doesn't properly specify full path to the nuget binary we download
as part of the prepare run and, thus, it depends on any random version of the
utility in the user's `$PATH` (if at all) which may lead to random errors
depending on the nuget version. Fix the issue by passing the full path to the
downloaded binary.

Additionally, fix `ToolRunner` to properly add arguments when managed
runtime (`mono`) is used on Unix. Until now any initial arguments were passed
to **mono** in such case, instead of to the managed executable. Doh.