### PR TITLE
[xaprepare] Fix bundle name generation for PRs

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/Context.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Context.cs
@@ -329,6 +329,15 @@ namespace Xamarin.Android.Prepare
 		/// </summary>
 		public RefreshableComponent ComponentsToRefresh { get; set; }
 
+
+		public bool BuildingAZPPullRequest {
+			get {
+				string buildReason = Environment.GetEnvironmentVariable ("BUILD_REASON");
+				return !String.IsNullOrEmpty (buildReason) && buildReason == "PullRequest";
+
+			}
+		}
+
 		static Context ()
 		{
 			Instance = new Context ();

--- a/build-tools/xaprepare/xaprepare/Application/Context.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Context.cs
@@ -329,12 +329,14 @@ namespace Xamarin.Android.Prepare
 		/// </summary>
 		public RefreshableComponent ComponentsToRefresh { get; set; }
 
-
-		public bool BuildingAZPPullRequest {
+		/// <summary>
+		///   True if the Azure Pipelines build was automatically triggered from a pull request.
+		///   Manually triggered pull request builds will have a 'Manual' build reason, and return false.
+		/// </summary>
+		public bool BuildingAzurePullRequest {
 			get {
 				string buildReason = Environment.GetEnvironmentVariable ("BUILD_REASON");
 				return !String.IsNullOrEmpty (buildReason) && buildReason == "PullRequest";
-
 			}
 		}
 
@@ -751,6 +753,9 @@ namespace Xamarin.Android.Prepare
 			Banner ("Updating Git submodules");
 
 			var git = new GitRunner (this);
+			if (!await git.CheckoutPullRequestSourceHead ())
+				Log.WarningLine ("Failed to update revision to HEAD of pull request source.");
+
 			if (!await git.SubmoduleUpdate ())
 				Log.WarningLine ("Failed to update Git submodules");
 


### PR DESCRIPTION
Context: https://github.com/microsoft/azure-pipelines-agent/issues/2330

We've been running into an issue on Azure Pipelines where the bundle
created in our 'Prepare' stage has a different name than the one that is
calculated later during build stages. This is because we're building a
merge commit on Azure pipelines, and if the target branch of the PR
changes in between stages, the merge commit that is checked out will
vary. We'll attempt to work around this (hopefully temporarily) by using
the HEAD of the source branch of a PR to calculate the bundle hashes,
rather than the HEAD of the source that is checked out at any given time.