### PR TITLE
[Xamarin.Android.Build.Tasks] fix cwd usage in <Aapt2Link/>

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -142,16 +142,24 @@ namespace Xamarin.Android.Tasks {
 				cmd.AppendSwitchIfNotNull ("--custom-package ", PackageName.ToLowerInvariant ());
 			
 			if (AdditionalResourceArchives != null) {
-				foreach (var dir in AdditionalResourceArchives) {
-					var flatArchive = dir.ItemSpec;
-					if (!File.Exists (flatArchive))
-						continue;
-					cmd.AppendSwitchIfNotNull ("-R ", flatArchive);
+				foreach (var item in AdditionalResourceArchives) {
+					var flata = Path.Combine (WorkingDirectory, item.ItemSpec);
+					if (File.Exists (flata)) {
+						cmd.AppendSwitchIfNotNull ("-R ", flata);
+					} else {
+						Log.LogDebugMessage ("Archive does not exist: " + flata);
+					}
 				}
 			}
 
-			if (CompiledResourceFlatArchive != null && File.Exists (CompiledResourceFlatArchive.ItemSpec))
-				cmd.AppendSwitchIfNotNull ("-R ", CompiledResourceFlatArchive.ItemSpec);
+			if (CompiledResourceFlatArchive != null) {
+				var flata = Path.Combine (WorkingDirectory, CompiledResourceFlatArchive.ItemSpec);
+				if (File.Exists (flata)) {
+					cmd.AppendSwitchIfNotNull ("-R ", flata);
+				} else {
+					Log.LogDebugMessage ("Archive does not exist: " + flata);
+				}
+			}
 			
 			cmd.AppendSwitch ("--auto-add-overlay");
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3237

We have been made aware of a random error when building Xamarin.Forms
from source:

    Errors
        AppCompat\NavigationPageRenderer.cs(461,34): error CS0117: 'Resource.Attribute' does not contain a definition for 'actionBarSize'
        Renderers\ShellItemRenderer.cs(60,45): error CS0117: 'Resource' does not contain a definition for 'Layout'
    ... plus more

I was able to reproduce this in the IDE, but also with:

    > git clean -dxf
    > msbuild Xamarin.Forms.sln /restore /m

I could resolve the issue by either:

* Change the setting in the IDE to use 1 MSBuild node
* Remove `/m`, which builds in parallel
* Add `/p:AndroidUseAapt2=False`

After debugging, the problem appeared to be this file was completely
blank:

    Xamarin.Forms.Platform.Android\obj\Debug\90\R.txt

Then when I reviewed the `aapt2 link` call:

    Executing link --manifest C:\Users\jopepper\AppData\Local\Temp\dief34vx.ctw\manifest\AndroidManifest.xml --java C:\Users\jopepper\AppData\Local\Temp\dief34vx.ctw --custom-package xamarin.forms.platform.android --auto-add-overlay -I "C:\Program Files (x86)\Android\android-sdk\platforms\android-28\android.jar" --output-text-symbols obj\Debug\90\R.txt -o C:\Users\jopepper\AppData\Local\Temp\dief34vx.ctw\resources.apk

There were no `-R` arguments? This meant that the `.flata` files did
not exist at all??? Yet they *did* exist, and I could see them
generated in the log prior to this call...

I added logging and tried it again:

    Aapt2Link
    ...
        Archive does not exist: obj\Debug\90\flata\43df68e0d20944e28151b722a21d9b9ef640254e.flata
        Archive does not exist: obj\Debug\90\flata\74a3f1c210308ec085909c723a8990aa914c1a71.flata
        Archive does not exist: obj\Debug\90\flata\4db0a001e031ddf3be314c5355f4fbbc0ce43f64.flata
        Archive does not exist: obj\Debug\90\flata\b12a43cde6840d15dadec10f8fb3ca5c547acc69.flata
        Archive does not exist: obj\Debug\90\flata\3b2cd76e696829add57b46e563c7a78bb42b7b11.flata
        Archive does not exist: obj\Debug\90\flata\ba386569fd62aa4d06aae04e8fc5ea2f4c505ecb.flata
        Archive does not exist: obj\Debug\90\flata\5ad21817f3b88df6b142d14cfcd0aa60312a41f2.flata
        Archive does not exist: obj\Debug\90\flata\86863b3e6cc326508270b8c30f738959fb241678.flata
        Archive does not exist: obj\Debug\90\flata\6a09985ebabd8c9070c92b8338f9c6f6198d0f0a.flata
        Archive does not exist: obj\Debug\90\flata\02d2c22bddc9d6810e8dc8cbdbe03619212dddc0.flata
        Archive does not exist: obj\Debug\90\flata\081a2e056100d972d2fc4067acb8a5034ac9ac9c.flata
        Archive does not exist: obj\Debug\90\flata\bd1122dc1010f54688ad4b996adc4af4b964358a.flata
        Archive does not exist: obj\Debug\90\flata\\compiled.flata
        Executing link --manifest C:\Users\jopepper\AppData\Local\Temp\cxwzxiiv.he2\manifest\AndroidManifest.xml --java C:\Users\jopepper\AppData\Local\Temp\cxwzxiiv.he2 --custom-package xamarin.forms.maps.android --auto-add-overlay -I "C:\Program Files (x86)\Android\android-sdk\platforms\android-28\android.jar" --output-text-symbols obj\Debug\90\R.txt -o C:\Users\jopepper\AppData\Local\Temp\cxwzxiiv.he2\resources.apk

That is when I realized all these were relative paths. We need to be
using `AsyncTask.WorkingDirectory` here. After fixing that the problem
went away. I kept the logging as well, since it should be helpful in
the future.

Unfortunately, I don't see how to add a test for this issue, since the
`/m` switch does not work with `xabuild.exe` on Windows. MSBuild's
out-of-process node logic gets a bit confused.

We should revisit later, and add new MSBuild tests using `/m` after we
get the tests running against the system install on Azure DevOps.