### PR TITLE
[aot] Make it possible to use AOT compiler without NDK

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -151,14 +151,22 @@
       <_ToolchainPrefix Include="x86_64">
         <ToolPrefix>x86_64-linux-android</ToolPrefix>
       </_ToolchainPrefix>
+      <_ToolName Include="as"/>
+      <_ToolName Include="ld"/>
+      <_ToolName Include="strip"/>
     </ItemGroup>
+
+    <CreateItem
+	Include="@(_ToolchainPrefix)" AdditionalMetadata="Tool=%(_ToolName.Identity)">
+      <Output TaskParameter="Include" ItemName="_ToolchainTool" />
+    </CreateItem>
 
     <Which
         HostOS="$(HostOS)"
         HostOSName="$(HostOsName)"
-        Program="$(AndroidNdkFullPath)/toolchains/%(_ToolchainPrefix.Identity)-4.9/prebuilt/$(_PrebuiltToolchainDir)/bin/%(_ToolchainPrefix.ToolPrefix)-as"
+        Program="$(AndroidNdkFullPath)/toolchains/%(_ToolchainTool.Identity)-4.9/prebuilt/$(_PrebuiltToolchainDir)/bin/%(ToolPrefix)-%(Tool)"
         Required="True">
-      <Output TaskParameter="Location" PropertyName="_NDKToolLocation%(_ToolchainPrefix.Identity)" />
+      <Output TaskParameter="Location" PropertyName="_NDKToolLocation%(_ToolchainTool.Identity)-%(Tool)" />
     </Which>
 
     <PropertyGroup>
@@ -167,9 +175,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <_NDKToolSource Include="$(_NDKToolLocation%(_ToolchainPrefix.Identity))" />
-      <_NDKToolDestination Condition=" '$(HostOS)' != 'Windows' " Include="$(_NDKToolDestinationBase)\$(HostOS)\$([System.IO.Path]::GetFileName ('$(_NDKToolLocation%(_ToolchainPrefix.Identity))'))" />
-      <_NDKToolDestination Condition=" '$(HostOS)' == 'Windows' " Include="$(_NDKToolDestinationBase)\$([System.IO.Path]::GetFileName ('$(_NDKToolLocation%(_ToolchainPrefix.Identity))'))" />
+      <_NDKToolSource Include="$(_NDKToolLocation%(_ToolchainTool.Identity)-%(_ToolchainTool.Tool))" />
+      <_NDKToolDestination Condition=" '$(HostOS)' != 'Windows' " Include="$(_NDKToolDestinationBase)\$(HostOS)\$([System.IO.Path]::GetFileName ('$(_NDKToolLocation%(_ToolchainTool.Identity)-%(_ToolchainTool.Tool))'))" />
+      <_NDKToolDestination Condition=" '$(HostOS)' == 'Windows' " Include="$(_NDKToolDestinationBase)\$([System.IO.Path]::GetFileName ('$(_NDKToolLocation%(_ToolchainTool.Identity)-%(_ToolchainTool.Tool))'))" />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -3005,6 +3005,7 @@ because xbuild doesn't support framework reference assemblies.
 	Condition="'$(AotAssemblies)' == 'True'"
 	AndroidAotMode="$(AndroidAotMode)"
 	AndroidNdkDirectory="$(_AndroidNdkDirectory)"
+	ToolsDirectory="$(MonoAndroidBinDirectory)"
 	AndroidApiLevel="$(_AndroidApiLevel)"
 	ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
 	SupportedAbis="@(_BuildTargetAbis)"


### PR DESCRIPTION
We will redistribute `as`, `ld` and `strip` tools and point AOT compiler to
these.

For AOT/llvm we still depend on NDK.