### PR TITLE
[aot] Make it possible to use AOT compiler without NDK

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -728,6 +728,8 @@ when packaging Release applications.
     or not LLVM will be used when Ahead-of-Time compiling assemblies
     into native code.
 
+    Enabling this propery requires Android NDK to be installed.
+
     Support for this property was added in Xamarin.Android 5.1.
 
     This property is `False` by default.

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -137,9 +137,17 @@
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\aapt2.exe" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\libwinpthread-1.dll" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\aarch64-linux-android-as.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\aarch64-linux-android-ld.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\aarch64-linux-android-strip.exe" Condition=" '$(HostOS)' != 'Windows' "/>
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\arm-linux-androideabi-as.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\arm-linux-androideabi-ld.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\arm-linux-androideabi-strip.exe" Condition=" '$(HostOS)' != 'Windows' "/>
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\i686-linux-android-as.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\i686-linux-android-ld.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\i686-linux-android-strip.exe" Condition=" '$(HostOS)' != 'Windows' "/>
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\x86_64-linux-android-as.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\x86_64-linux-android-ld.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\x86_64-linux-android-strip.exe" Condition=" '$(HostOS)' != 'Windows' "/>
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libmono-android.debug.dll"   Condition=" '$(HostOS)' != 'Windows' " />
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libmono-android.release.dll" Condition=" '$(HostOS)' != 'Windows' " />
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libMonoPosixHelper.dll" />
@@ -148,9 +156,17 @@
   </ItemGroup>
   <ItemGroup>
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\aarch64-linux-android-as" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\aarch64-linux-android-ld" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\aarch64-linux-android-strip" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\arm-linux-androideabi-as" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\arm-linux-androideabi-ld" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\arm-linux-androideabi-strip" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\i686-linux-android-as" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\i686-linux-android-ld" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\i686-linux-android-strip" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\x86_64-linux-android-as" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\x86_64-linux-android-ld" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\x86_64-linux-android-strip" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\illinkanalyzer" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\jit-times" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\mono" />

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Standard.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Standard.Unix.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Android.Prepare
 				// (because they're not useful for every day work with XA) so they must be downloaded after the bundle
 				// is unpacked.
 				Log.DebugLine ("Adding Windows GAS download step (AFTER bundle)");
-				Steps.Add (new Step_Get_Windows_GAS ());
+				Steps.Add (new Step_Get_Windows_Binutils ());
 				return;
 			}
 

--- a/build-tools/xaprepare/xaprepare/Steps/Step_Get_Windows_Binutils.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_Get_Windows_Binutils.Unix.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Xamarin.Android.Prepare
 {
-	class Step_Get_Windows_GAS : Step
+	class Step_Get_Windows_Binutils : Step
 	{
 		const int EndFileChunkSize   = 65535 + 22; // Maximum comment size + EOCD size
 		const uint EOCDSignature     = 0x06054b50;
@@ -69,7 +69,7 @@ namespace Xamarin.Android.Prepare
 			public byte[] ExtraField;
 		};
 
-		public Step_Get_Windows_GAS ()
+		public Step_Get_Windows_Binutils ()
 			: base ("Downloading NDK tools for Windows")
 		{}
 
@@ -79,9 +79,17 @@ namespace Xamarin.Android.Prepare
 
 			var neededFiles = new HashSet<string> (StringComparer.OrdinalIgnoreCase) {
 				$"android-ndk-r{ndkVersion}/toolchains/llvm/prebuilt/windows-x86_64/bin/i686-linux-android-as.exe",
+				$"android-ndk-r{ndkVersion}/toolchains/llvm/prebuilt/windows-x86_64/bin/i686-linux-android-ld.exe",
+				$"android-ndk-r{ndkVersion}/toolchains/llvm/prebuilt/windows-x86_64/bin/i686-linux-android-strip.exe",
 				$"android-ndk-r{ndkVersion}/toolchains/llvm/prebuilt/windows-x86_64/bin/arm-linux-androideabi-as.exe",
+				$"android-ndk-r{ndkVersion}/toolchains/llvm/prebuilt/windows-x86_64/bin/arm-linux-androideabi-ld.exe",
+				$"android-ndk-r{ndkVersion}/toolchains/llvm/prebuilt/windows-x86_64/bin/arm-linux-androideabi-strip.exe",
 				$"android-ndk-r{ndkVersion}/toolchains/llvm/prebuilt/windows-x86_64/bin/x86_64-linux-android-as.exe",
+				$"android-ndk-r{ndkVersion}/toolchains/llvm/prebuilt/windows-x86_64/bin/x86_64-linux-android-ld.exe",
+				$"android-ndk-r{ndkVersion}/toolchains/llvm/prebuilt/windows-x86_64/bin/x86_64-linux-android-strip.exe",
 				$"android-ndk-r{ndkVersion}/toolchains/llvm/prebuilt/windows-x86_64/bin/aarch64-linux-android-as.exe",
+				$"android-ndk-r{ndkVersion}/toolchains/llvm/prebuilt/windows-x86_64/bin/aarch64-linux-android-ld.exe",
+				$"android-ndk-r{ndkVersion}/toolchains/llvm/prebuilt/windows-x86_64/bin/aarch64-linux-android-strip.exe",
 			};
 
 			string destinationDirectory = Path.Combine (Configurables.Paths.InstallMSBuildDir);

--- a/build-tools/xaprepare/xaprepare/Steps/Step_PrepareBundle.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_PrepareBundle.Unix.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Android.Prepare
 			// We need it here (even though Scenario_Standard runs the step, because if we failed to download the
 			// bundle, the Step_BuildMonoRuntimes above will clean the destination directory and the Windows GAS
 			// executables with it.
-			AddFailureStep (new Step_Get_Windows_GAS ());
+			AddFailureStep (new Step_Get_Windows_Binutils ());
 			AddFailureStep (new Step_CreateBundle ());
 		}
 

--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -193,7 +193,7 @@
     <Compile Include="Steps\Step_BuildLibZipForWindows.Unix.cs" />
     <Compile Include="Steps\Step_CreateBundle.Unix.cs" />
     <Compile Include="Steps\Step_GenerateFiles.Unix.cs" />
-    <Compile Include="Steps\Step_Get_Windows_GAS.Unix.cs" />
+    <Compile Include="Steps\Step_Get_Windows_Binutils.Unix.cs" />
     <Compile Include="Steps\Step_PrepareBundle.Unix.cs" />
     <Compile Include="Steps\Step_PrepareExternal.Unix.cs" />
     <Compile Include="Steps\Step_PrepareImageDependencies.Unix.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MakeBundleNativeCodeExternalTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MakeBundleNativeCodeExternalTests.cs
@@ -53,6 +53,7 @@ namespace Xamarin.Android.Build.Tests {
 				AndroidNdkDirectory = androidNdkDirectory,
 				AndroidAotMode = "normal",
 				AndroidApiLevel = "28",
+				EnableLLVM = true,
 				ResolvedAssemblies = new ITaskItem [0],
 				SupportedAbis = new [] { "armeabi-v7a" },
 				AotOutputDirectory = path,

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -157,7 +157,7 @@
     </ItemGroup>
 
     <CreateItem
-	Include="@(_ToolchainPrefix)" AdditionalMetadata="Tool=%(_ToolName.Identity)">
+        Include="@(_ToolchainPrefix)" AdditionalMetadata="Tool=%(_ToolName.Identity)">
       <Output TaskParameter="Include" ItemName="_ToolchainTool" />
     </CreateItem>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -151,14 +151,22 @@
       <_ToolchainPrefix Include="x86_64">
         <ToolPrefix>x86_64-linux-android</ToolPrefix>
       </_ToolchainPrefix>
+      <_ToolName Include="as"/>
+      <_ToolName Include="ld"/>
+      <_ToolName Include="strip"/>
     </ItemGroup>
+
+    <CreateItem
+	Include="@(_ToolchainPrefix)" AdditionalMetadata="Tool=%(_ToolName.Identity)">
+      <Output TaskParameter="Include" ItemName="_ToolchainTool" />
+    </CreateItem>
 
     <Which
         HostOS="$(HostOS)"
         HostOSName="$(HostOsName)"
-        Program="$(AndroidNdkFullPath)/toolchains/%(_ToolchainPrefix.Identity)-4.9/prebuilt/$(_PrebuiltToolchainDir)/bin/%(_ToolchainPrefix.ToolPrefix)-as"
+        Program="$(AndroidNdkFullPath)/toolchains/%(_ToolchainTool.Identity)-4.9/prebuilt/$(_PrebuiltToolchainDir)/bin/%(ToolPrefix)-%(Tool)"
         Required="True">
-      <Output TaskParameter="Location" PropertyName="_NDKToolLocation%(_ToolchainPrefix.Identity)" />
+      <Output TaskParameter="Location" PropertyName="_NDKToolLocation%(_ToolchainTool.Identity)-%(Tool)" />
     </Which>
 
     <PropertyGroup>
@@ -167,9 +175,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <_NDKToolSource Include="$(_NDKToolLocation%(_ToolchainPrefix.Identity))" />
-      <_NDKToolDestination Condition=" '$(HostOS)' != 'Windows' " Include="$(_NDKToolDestinationBase)\$(HostOS)\$([System.IO.Path]::GetFileName ('$(_NDKToolLocation%(_ToolchainPrefix.Identity))'))" />
-      <_NDKToolDestination Condition=" '$(HostOS)' == 'Windows' " Include="$(_NDKToolDestinationBase)\$([System.IO.Path]::GetFileName ('$(_NDKToolLocation%(_ToolchainPrefix.Identity))'))" />
+      <_NDKToolSource Include="$(_NDKToolLocation%(_ToolchainTool.Identity)-%(_ToolchainTool.Tool))" />
+      <_NDKToolDestination Condition=" '$(HostOS)' != 'Windows' " Include="$(_NDKToolDestinationBase)\$(HostOS)\$([System.IO.Path]::GetFileName ('$(_NDKToolLocation%(_ToolchainTool.Identity)-%(_ToolchainTool.Tool))'))" />
+      <_NDKToolDestination Condition=" '$(HostOS)' == 'Windows' " Include="$(_NDKToolDestinationBase)\$([System.IO.Path]::GetFileName ('$(_NDKToolLocation%(_ToolchainTool.Identity)-%(_ToolchainTool.Tool))'))" />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -164,7 +164,7 @@
     <Which
         HostOS="$(HostOS)"
         HostOSName="$(HostOsName)"
-        Program="$(AndroidNdkFullPath)/toolchains/%(_ToolchainTool.Identity)-4.9/prebuilt/$(_PrebuiltToolchainDir)/bin/%(ToolPrefix)-%(Tool)"
+        Program="$(AndroidNdkFullPath)\toolchains\%(_ToolchainTool.Identity)-4.9\prebuilt\$(_PrebuiltToolchainDir)\bin\%(ToolPrefix)-%(Tool)"
         Required="True">
       <Output TaskParameter="Location" PropertyName="_NDKToolLocation%(_ToolchainTool.Identity)-%(Tool)" />
     </Which>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -3009,6 +3009,7 @@ because xbuild doesn't support framework reference assemblies.
 	Condition="'$(AotAssemblies)' == 'True'"
 	AndroidAotMode="$(AndroidAotMode)"
 	AndroidNdkDirectory="$(_AndroidNdkDirectory)"
+	ToolsDirectory="$(MonoAndroidBinDirectory)"
 	AndroidApiLevel="$(_AndroidApiLevel)"
 	ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
 	SupportedAbis="@(_BuildTargetAbis)"


### PR DESCRIPTION
Implements https://github.com/xamarin/xamarin-android/issues/3299

We will redistribute `as`, `ld` and `strip` tools and point AOT compiler to
these.

For AOT/llvm we still depend on NDK.