### PR TITLE
[bundletool] bump to 0.10.0

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -107,7 +107,7 @@
     <XAPlatformToolsVersion>29.0.1</XAPlatformToolsVersion>
     <XAIntegratedTests Condition="'$(XAIntegratedTests)' == ''">False</XAIntegratedTests>
     <XAIncludeProprietaryBits Condition="'$(XAIncludeProprietaryBits)' == ''">False</XAIncludeProprietaryBits>
-    <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">0.8.0</XABundleToolVersion>
+    <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">0.10.0</XABundleToolVersion>
     <PathSeparator>$([System.IO.Path]::PathSeparator)</PathSeparator>
     <_TestsAotName Condition=" '$(AotAssemblies)' == 'true' ">-Aot</_TestsAotName>
     <_TestsProfiledAotName Condition=" '$(AndroidEnableProfiledAot)' == 'true' ">-Profiled</_TestsProfiledAotName>
@@ -144,7 +144,7 @@
     <EmulatorToolExe Condition=" '$(EmulatorToolExe)' == '' ">emulator</EmulatorToolExe>
     <NdkBuildPath Condition=" '$(NdkBuildPath)' == '' And '$(HostOS)' != 'Windows' ">$(AndroidNdkDirectory)\ndk-build</NdkBuildPath>
     <NdkBuildPath Condition=" '$(NdkBuildPath)' == '' And '$(HostOS)' == 'Windows' ">$(AndroidNdkDirectory)\ndk-build.cmd</NdkBuildPath>
-    <BundleToolJarPath Condition=" '$(BundleToolJarPath)' == '' ">$(XAInstallPrefix)xbuild\Xamarin\Android\bundletool-all-$(XABundleToolVersion).jar</BundleToolJarPath>
+    <BundleToolJarPath Condition=" '$(BundleToolJarPath)' == '' ">$(XAInstallPrefix)xbuild\Xamarin\Android\bundletool.jar</BundleToolJarPath>
   </PropertyGroup>
   <!--
     "Fixup" $(AndroidSupportedHostJitAbis) so that Condition attributes elsewhere

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -91,7 +91,7 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\startup.aotprofile" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\startup-xf.aotprofile" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\r8.jar" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\bundletool-all-$(XABundleToolVersion).jar" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\bundletool.jar" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\java_runtime.jar" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\java_runtime_fastdev.jar" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\java_runtime.dex" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1039,7 +1039,7 @@ because xbuild doesn't support framework reference assemblies.
 		/>
 	</CreateProperty>
 
-	<CreateProperty Value="$(MonoAndroidToolsDirectory)\bundletool-all-$(BundleToolVersion).jar">
+	<CreateProperty Value="$(MonoAndroidToolsDirectory)\bundletool.jar">
 		<Output TaskParameter="Value" PropertyName="AndroidBundleToolJarPath"
 				Condition="'$(AndroidBundleToolJarPath)' == ''"
 		/>

--- a/src/bundletool/bundletool.targets
+++ b/src/bundletool/bundletool.targets
@@ -18,10 +18,10 @@
   <Target Name="_DownloadBundleTool">
     <DownloadUri
         SourceUris="https://github.com/google/bundletool/releases/download/$(XABundleToolVersion)/bundletool-all-$(XABundleToolVersion).jar"
-        DestinationFiles="$(AndroidToolchainCacheDirectory)\bundletool-all-$(XABundleToolVersion).jar"
+        DestinationFiles="$(AndroidToolchainCacheDirectory)\bundletool.jar"
     />
     <Copy
-        SourceFiles="$(AndroidToolchainCacheDirectory)\bundletool-all-$(XABundleToolVersion).jar"
+        SourceFiles="$(AndroidToolchainCacheDirectory)\bundletool.jar"
         DestinationFolder="$(_Destination)"
     />
   </Target>


### PR DESCRIPTION
Context: https://github.com/google/bundletool/releases/tag/0.10.0
Context: https://mvnrepository.com/artifact/com.android.tools.build/bundletool

`bundletool` has had a few releases lately, we should update the
version we are shipping with Xamarin.Android.

I also noticed we were shipping:

    bundletool-all-0.8.0-jar

I think we could just use `bundletool.jar`. It would be useful to have
a static filename as versions change release to release. This matches
up with other things we ship, such as `r8.jar`.

You can query the version of `bundletool` with:

    $ java -jar bundletool.jar version
    0.10.0

So we don't need to encode the version in the filename.