### PR TITLE
Import Configuration.props in Mono.Android-Test.Library

### DIFF
--- a/src/Mono.Android/Test/Mono.Android-Test.Library/Mono.Android-Test.Library.csproj
+++ b/src/Mono.Android/Test/Mono.Android-Test.Library/Mono.Android-Test.Library.csproj
@@ -17,6 +17,7 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
   </PropertyGroup>
+  <Import Project="..\..\..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2819142
Context: https://github.com/xamarin/xamarin-android/commit/e9561076a8e8761002931b886991eb1616561864

When this additional test library was added in e956107 it did not import
our Configuration.props file which contains default paths to the Android
tooling that we provision. This recently caused a breakage when bumping
the TargetFrameworkVersion of this project to v10.0 and building against
a system install of XA, as the Android SDK path which was automatically
resolved did not contain an android-29/android.jar. Importing the
Configuration.props file should fix this build failure.