### PR TITLE
[build] Pass variables to monodroid and improve toolchain caching

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:master@bc0323dba033d04aa5128c43b015e8c319337127
+xamarin/monodroid:pjcollins_inversion-set-sdk@aba2c7a04511d650a9e926ba57e97d06e7c8e3f6

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:pjcollins_inversion-set-sdk@aba2c7a04511d650a9e926ba57e97d06e7c8e3f6
+xamarin/monodroid:master@237e0bd9f105b9842778ef82161a20c6d4497a40

--- a/Configuration.props
+++ b/Configuration.props
@@ -64,6 +64,7 @@
     <HOME Condition=" '$(HOME)' == '' ">$(USERPROFILE)</HOME>
     <AndroidPreviousFrameworkVersion Condition=" '$(AndroidPreviousFrameworkVersion)' == '' ">v1.0</AndroidPreviousFrameworkVersion>
     <AndroidToolchainCacheDirectory Condition=" '$(AndroidToolchainCacheDirectory)' == '' ">$(HOME)\android-archives</AndroidToolchainCacheDirectory>
+    <AndroidToolchainDirectory Condition=" '$(AndroidToolchainDirectory)' == '' And '$(RunningOnCI)' == 'true' And '$(HostOS)' == 'Darwin' ">$(HOME)\Library\Android</AndroidToolchainDirectory>
     <AndroidToolchainDirectory Condition=" '$(AndroidToolchainDirectory)' == '' ">$(HOME)\android-toolchain</AndroidToolchainDirectory>
     <AndroidMxeInstallPrefix Condition=" '$(HostOS)' == 'Linux' ">\usr</AndroidMxeInstallPrefix>
     <AndroidMxeInstallPrefix Condition=" '$(HostOS)' == 'Darwin' ">$(HostHomebrewPrefix)</AndroidMxeInstallPrefix>

--- a/Makefile
+++ b/Makefile
@@ -125,12 +125,6 @@ uninstall::
 	rm -rf "$(prefix)/lib/mono/xbuild/Xamarin/Android"
 	rm -rf "$(prefix)/lib/mono/xbuild-frameworks/MonoAndroid"
 
-include build-tools/scripts/BuildEverything.mk
-
-# Must be after BuildEverything.mk - it uses variables defined there
-include build-tools/scripts/Packaging.mk
-include tests/api-compatibility/api-compatibility.mk
-
 topdir  := $(shell pwd)
 
 # Used by External XA Build
@@ -138,6 +132,12 @@ EXTERNAL_XA_PATH=$(topdir)
 EXTERNAL_GIT_PATH=$(topdir)/external
 
 -include $(EXTERNAL_GIT_PATH)/monodroid/xa-integration.mk
+
+include build-tools/scripts/BuildEverything.mk
+
+# Must be after BuildEverything.mk - it uses variables defined there
+include build-tools/scripts/Packaging.mk
+include tests/api-compatibility/api-compatibility.mk
 
 run-all-tests:
 	@echo "PRINTING MONO VERSION"
@@ -193,7 +193,7 @@ prepare-build: prepare-build-init
 	msbuild $(PREPARE_MSBUILD_FLAGS) $(PREPARE_SOLUTION)
 
 .PHONY: prepare
-prepare:: prepare-build
+prepare: prepare-build
 	mono --debug $(PREPARE_EXE) $(_PREPARE_ARGS)
 
 .PHONY: prepare-help

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -19,7 +19,6 @@ resources:
 variables:
   BundleArtifactName: bundle
   InstallerArtifactName: installers
-  MacAndroidToolchainMSBuildArgs: /p:AndroidToolchainDirectory=/Users/vsts/Library/Android
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
 # Check - "Xamarin.Android (Prepare bundle)"
@@ -42,7 +41,7 @@ stages:
       # The 'prepare' step creates the bundle
     - script: |
         make prepare-update-mono PREPARE_CI=1 V=1 PREPARE_AUTOPROVISION=1 CONFIGURATION=$(XA.Build.Configuration)
-        make prepare PREPARE_CI=1 PREPARE_AUTOPROVISION=1 PREPARE_ARGS="--copy-bundle-to=bin/$(XA.Build.Configuration)" V=1 CONFIGURATION=$(XA.Build.Configuration) MSBUILD_ARGS="$(MacAndroidToolchainMSBuildArgs)"
+        make prepare PREPARE_CI=1 PREPARE_AUTOPROVISION=1 PREPARE_ARGS="--copy-bundle-to=bin/$(XA.Build.Configuration)" V=1 CONFIGURATION=$(XA.Build.Configuration)
       displayName: create bundle
 
     - task: CopyFiles@2
@@ -113,7 +112,7 @@ stages:
         provisioning_script: $(System.DefaultWorkingDirectory)/external/monodroid/build-tools/provisionator/profile.csx
         provisioning_extra_args: -vv
 
-    - script: make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1 PREPARE_ARGS="--bundle-path=$(System.DefaultWorkingDirectory)" MSBUILD_ARGS="$(MacAndroidToolchainMSBuildArgs)"
+    - script: make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1 PREPARE_ARGS="--bundle-path=$(System.DefaultWorkingDirectory)"
       displayName: make jenkins
 
     - script: make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
@@ -323,7 +322,7 @@ stages:
     - script: |
         mono build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=UpdateMono --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
         mono build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
-        mono build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=AndroidToolchain --no-emoji --run-mode=CI $(MacAndroidToolchainMSBuildArgs)
+        mono build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=AndroidToolchain --no-emoji --run-mode=CI
       displayName: provision dependencies
 
     - task: NuGetCommand@2

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -19,6 +19,7 @@ resources:
 variables:
   BundleArtifactName: bundle
   InstallerArtifactName: installers
+  MacAndroidToolchainMSBuildArgs: /p:AndroidToolchainDirectory=/Users/vsts/Library/Android
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
 # Check - "Xamarin.Android (Prepare bundle)"
@@ -41,7 +42,7 @@ stages:
       # The 'prepare' step creates the bundle
     - script: |
         make prepare-update-mono PREPARE_CI=1 V=1 PREPARE_AUTOPROVISION=1 CONFIGURATION=$(XA.Build.Configuration)
-        make prepare PREPARE_CI=1 PREPARE_AUTOPROVISION=1 PREPARE_ARGS="--copy-bundle-to=bin/$(XA.Build.Configuration)" V=1 CONFIGURATION=$(XA.Build.Configuration)
+        make prepare PREPARE_CI=1 PREPARE_AUTOPROVISION=1 PREPARE_ARGS="--copy-bundle-to=bin/$(XA.Build.Configuration)" V=1 CONFIGURATION=$(XA.Build.Configuration) MSBUILD_ARGS="$(MacAndroidToolchainMSBuildArgs)"
       displayName: create bundle
 
     - task: CopyFiles@2
@@ -112,7 +113,7 @@ stages:
         provisioning_script: $(System.DefaultWorkingDirectory)/external/monodroid/build-tools/provisionator/profile.csx
         provisioning_extra_args: -vv
 
-    - script: make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1 PREPARE_ARGS="--bundle-path=$(System.DefaultWorkingDirectory)"
+    - script: make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1 PREPARE_ARGS="--bundle-path=$(System.DefaultWorkingDirectory)" MSBUILD_ARGS="$(MacAndroidToolchainMSBuildArgs)"
       displayName: make jenkins
 
     - script: make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
@@ -322,7 +323,7 @@ stages:
     - script: |
         mono build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=UpdateMono --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
         mono build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
-        mono build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=AndroidToolchain --no-emoji --run-mode=CI
+        mono build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=AndroidToolchain --no-emoji --run-mode=CI $(MacAndroidToolchainMSBuildArgs)
       displayName: provision dependencies
 
     - task: NuGetCommand@2

--- a/build-tools/scripts/BuildEverything.mk
+++ b/build-tools/scripts/BuildEverything.mk
@@ -10,9 +10,12 @@
 # The other targets depended upon by leeroy also require rules.mk to be present and thus they
 # are invoked in the same way framework-assemblies is
 #
-jenkins::
+jenkins:
 	$(MAKE) PREPARE_CI=1 prepare
 	$(MAKE) leeroy $(ZIP_OUTPUT)
+ifeq ($(XA_INVERTED_COMMERCIAL_BUILD),true)
+	$(MAKE) commercial
+endif
 
 leeroy: leeroy-all framework-assemblies opentk-jcw
 

--- a/build-tools/xaprepare/xaprepare/Application/GeneratedMakeRulesFile.cs
+++ b/build-tools/xaprepare/xaprepare/Application/GeneratedMakeRulesFile.cs
@@ -97,6 +97,7 @@ namespace Xamarin.Android.Prepare
 			WriteVariable ("ALL_JIT_ABIS",      ToValue (AbiNames.AllJitAbis));
 			WriteVariable ("ALL_HOST_ABIS",     ToValue (AbiNames.AllHostAbis));
 			WriteVariable ("ALL_AOT_ABIS",      ToValue (AbiNames.AllAotAbis));
+			WriteVariable ("ANDROID_TOOLCHAIN_DIR", context.Properties.GetRequiredValue (KnownProperties.AndroidToolchainDirectory));
 			if (context.MonoOptions != null && context.MonoOptions.Count > 0) {
 				WriteVariable ("MONO_OPTIONS", ToValue (context.MonoOptions));
 				sw.WriteLine ("export MONO_OPTIONS");


### PR DESCRIPTION
Context: https://github.com/xamarin/monodroid/pull/1010

Partially reworks the inverted build so that variables imported from
'rules.mk' can be accessed externally. 

Improves commercial build support for new Android API levels.

Improves provisioning performance when building and testing on the
Azure Pipeline macOS hosted agent pools. We'll now use the Android
SDK components which are pre-installed on those machines, as most of
what we need is already present and this location should be less prone
to being cleaned up.
