### PR TITLE
[Xamarin.Andorid.Build.Tasks] Check if LogicalName is valid before check Resource File.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
@@ -22,8 +22,11 @@ namespace Xamarin.Android.Tasks {
 		public override bool Execute ()
 		{
 			foreach (var resource in Resources) {
-				var fileName = Path.GetFileName (resource.ItemSpec);
-				var directory = Path.GetFileName (Path.GetDirectoryName (resource.ItemSpec));
+				var resourceFile = resource.GetMetadata ("LogicalName");
+				if (string.IsNullOrEmpty (resourceFile))
+					resourceFile = resource.ItemSpec;
+				var fileName = Path.GetFileName (resourceFile);
+				var directory = Path.GetFileName (Path.GetDirectoryName (resourceFile));
 				if (directory.StartsWith ("values", StringComparison.OrdinalIgnoreCase)) {
 					var match = fileNameWithHyphenCheck.Match (fileName);
 					if (match.Success) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Android.Tasks {
 		public override bool Execute ()
 		{
 			foreach (var resource in Resources) {
-				var resourceFile = resource.GetMetadata ("LogicalName");
+				var resourceFile = resource.GetMetadata ("LogicalName").Replace ('\\', Path.DirectorySeparatorChar);
 				if (string.IsNullOrEmpty (resourceFile))
 					resourceFile = resource.ItemSpec;
 				var fileName = Path.GetFileName (resourceFile);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -724,6 +724,32 @@ namespace UnnamedProject
 		}
 
 		[Test]
+		public void CheckAaptErrorNotRaisedForInvalidFileNameWithValidLogicalName ([Values (false, true)] bool useAapt2)
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
+			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\drawable\\icon-2.png") {
+				Metadata = { { "LogicalName", "Resources\\drawable\\icon2.png" } },
+				BinaryContent = () => XamarinAndroidCommonProject.icon_binary_hdpi,
+			});
+			proj.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\values\\strings-2.xml") {
+				Metadata = { { "LogicalName", "Resources\\values\\strings2.xml" } },
+				TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
+<resources>
+	<string name=""hellome"">Hello World, Click Me!</string>
+</resources>",
+			});
+			var projectPath = string.Format ($"temp/{TestName}");
+			using (var b = CreateApkBuilder (Path.Combine (projectPath, "UnamedApp"), false, false)) {
+				b.Verbosity = LoggerVerbosity.Diagnostic;
+				b.ThrowOnBuildFailure = false;
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				StringAssertEx.DoesNotContain ("Invalid file name:", b.LastBuildOutput);
+				StringAssertEx.DoesNotContain ("1 Error(s)", b.LastBuildOutput);
+			}
+		}
+
+		[Test]
 		public void CheckAaptErrorRaisedForDuplicateResourceinApp ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();


### PR DESCRIPTION
Some of our customers are generating `Resource` files
which have invalid file names (as far as aapt/aapt2 is
concerned). They use the `LogicalName` meta data to
provide the "Real" name that the build process should
use.

However when using `aapt2` our `CheckForInvalidResourceFileNames`
task was NOT using the `LogicalName` metadata. It was
just using the filename. This breaks their projects with
an

	APT0000: Invalid file name: It must contain only [^a-zA-Z0-9_.-]+

or

	APT0000: Invalid file name: It must contain only [^a-zA-Z0-9_.]+

We should really support this scenario since we allow the
use of `LogicalName` for resource files anyway.

This commit fixes that issue and adds a unit test.