### PR TITLE
Increase AndroidClientHandler timeouts

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -172,11 +172,12 @@ namespace Xamarin.Android.Net
 		/// cref="t:System.TimeSpan.Zero"/>
 		/// </para>
 		/// <para>
-		/// The default value is <c>100</c> seconds, the same as the documented value of <see
-		/// cref="t:System.Net.Http.HttpClient.Timeout"/>
+		/// The default value is <c>24</c> hours, much higher than the documented value of <see
+		/// cref="t:System.Net.Http.HttpClient.Timeout"/> and the same as the value of iOS-specific
+		/// NSUrlSessionHandler.
 		/// </para>
 		/// </summary>
-		public TimeSpan ReadTimeout { get; set; } = TimeSpan.FromSeconds (100);
+		public TimeSpan ReadTimeout { get; set; } = TimeSpan.FromHours (24);
 
 		/// <summary>
 		/// <para>
@@ -192,7 +193,7 @@ namespace Xamarin.Android.Net
 		/// The default value is <c>120</c> seconds.
 		/// </para>
 		/// </summary>
-		public TimeSpan ConnectTimeout { get; set; } = TimeSpan.FromSeconds (120);
+		public TimeSpan ConnectTimeout { get; set; } = TimeSpan.FromHours (24);
 
 		protected override void Dispose (bool disposing)
 		{


### PR DESCRIPTION
`AndroidClientHandler` has no way of accessing the `HttpClient.Timeout` property
in order to set the timeout value of *two* native http client
properties (connect and read timeouts) and so it uses two custom properties to
provide these values. So far, the values were set to 100s for the read timeout
and 120s for the connect timeout, which seemed to be a reasonable value for
their purposes. However, if a developer sets `HttpClient.Timeout` to a
value *larger* than our defaults, `AndroidClientHandler` values "win" and the
connection/read time out earlier. The workaround is to set "our" timeouts along
with the `HttpClient` one, but if the developer cannot do it, for any kind of
reasons (i.e. to avoid platform-specific code) then they are faced with an
annoying situation.

The real fix would be to improve `HttpClient` API so that its associated client
handler can access `HttpClient` properties, but since it's not a quick fix we
can implement now, this commit bumps the default timeout values to
the (unreasonable) value of 24h to make sure we use values higher than the most
likely figures assigned to `HttpClient.Timeout` and to match Xamarin.iOS
NSUrlSessionHandler defaults.