### PR TITLE
[Xamarin.Android.Build.Tasks] fix for aapt2 and $(AndroidResgenArgs)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1,4 +1,4 @@
-﻿﻿﻿using System;
+using System;
 using Xamarin.ProjectTools;
 using NUnit.Framework;
 using System.Linq;
@@ -1483,6 +1483,26 @@ namespace UnnamedProject
 			});
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "first build should have succeeded");
+			}
+		}
+
+		[Test]
+		public void CheckNoVersionVectors ([Values (true, false)] bool useAapt2)
+		{
+			var proj = new XamarinFormsAndroidApplicationProject ();
+			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+
+				string aaptCommand = useAapt2 ? "Executing link" : "Executing package";
+				foreach (var line in b.LastBuildOutput) {
+					if (line.Contains (aaptCommand)) {
+						StringAssert.Contains ("--no-version-vectors", line, "The Xamarin.Android.Support.Vector.Drawable NuGet should set `--no-version-vectors`!");
+						return;
+					}
+				}
+
+				Assert.Fail ($"aapt log message was not found: {aaptCommand}");
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Xamarin.ProjectTools;
 using NUnit.Framework;
 using System.Linq;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -891,7 +891,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	/>
 	<PropertyGroup>
 		<AndroidExplicitCrunch Condition=" '$(_AndroidUseAapt2)' == 'True' ">false</AndroidExplicitCrunch>
-		<AndroidAapt2LinkExtraArgs Condition=" '$(_AndroidUseAapt2)' == 'True' And $(AndroidResgenExtraArgs.Contains('--no-version-vectors')) And !($(AndroidAapt2LinkExtraArgs.Contains('--no-version-vectors'))) ">--no-version-vectors $(AndroidAapt2LinkExtraArgs) </AndroidAapt2LinkExtraArgs>
 	</PropertyGroup>
 </Target>
 
@@ -1630,6 +1629,10 @@ because xbuild doesn't support framework reference assemblies.
 	Inputs="$(_UpdateAndroidResgenInputs)"
 	Outputs="$(_AndroidResgenFlagFile)"
 	DependsOnTargets="$(_UpdateAndroidResgenDependsOnTargets);$(_AfterGenerateAndroidResourceDir);_CompileAndroidLibraryResources;_CompileResources">
+
+	<PropertyGroup>
+		<AndroidAapt2LinkExtraArgs Condition=" '$(_AndroidUseAapt2)' == 'True' And $(AndroidResgenExtraArgs.Contains('--no-version-vectors')) And !($(AndroidAapt2LinkExtraArgs.Contains('--no-version-vectors'))) ">--no-version-vectors $(AndroidAapt2LinkExtraArgs) </AndroidAapt2LinkExtraArgs>
+	</PropertyGroup>
 
 	<!-- Create a temporary directory to work in -->
 	<CreateTemporaryDirectory>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3314

Create a new Xamarin.Forms project using aapt2, you will encounter a
crash on startup for API 19 devices:

    android.content.res.Resources$NotFoundException: File res/drawable/abc_vector_test.xml from drawable resource ID #0x7f080058
    at android.content.res.Resources.loadDrawable(Resources.java:2096)
    at android.content.res.Resources.getDrawable(Resources.java:700)
    at android.support.v4.content.ContextCompat.getDrawable(ContextCompat.java:360)
    at android.support.v7.widget.AppCompatDrawableManager.getDrawable(AppCompatDrawableManager.java:198)
    at android.support.v7.widget.AppCompatDrawableManager.getDrawable(AppCompatDrawableManager.java:186)
    at android.support.v7.widget.AppCompatDrawableManager.checkVectorDrawableSetup(AppCompatDrawableManager.java:753)
    at android.support.v7.widget.AppCompatDrawableManager.getDrawable(AppCompatDrawableManager.java:191)
    at android.support.v7.widget.TintTypedArray.getDrawableIfKnown(TintTypedArray.java:85)
    at android.support.v7.app.AppCompatDelegateImplBase.(AppCompatDelegateImplBase.java:128)
    at android.support.v7.app.AppCompatDelegateImplV9.(AppCompatDelegateImplV9.java:149)
    at android.support.v7.app.AppCompatDelegateImplV11.(AppCompatDelegateImplV11.java:29)
    at android.support.v7.app.AppCompatDelegateImplV14.(AppCompatDelegateImplV14.java:54)
    at android.support.v7.app.AppCompatDelegate.create(AppCompatDelegate.java:202)
    at android.support.v7.app.AppCompatDelegate.create(AppCompatDelegate.java:183)
    at android.support.v7.app.AppCompatActivity.getDelegate(AppCompatActivity.java:519)
    at android.support.v7.app.AppCompatActivity.onCreate(AppCompatActivity.java:70)
    at com.taphome.offline.SplashActivity.n_onCreate(Native Method)
    at com.taphome.offline.SplashActivity.onCreate(SplashActivity.java:29)
    at android.app.Activity.performCreate(Activity.java:5231)
    at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1087)
    at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2148)
    at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2233)
    at android.app.ActivityThread.access$800(ActivityThread.java:135)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1196)
    at android.os.Handler.dispatchMessage(Handler.java:102)
    at android.os.Looper.loop(Looper.java:136)
    at android.app.ActivityThread.main(ActivityThread.java:5001)
    at java.lang.reflect.Method.invokeNative(Native Method)
    at java.lang.reflect.Method.invoke(Method.java:515)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:793)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:609)
    at dalvik.system.NativeStart.main(Native Method)
    Java.Lang.RuntimeException: File res/drawable/abc_vector_test.xml from drawable resource ID #0x7f080058 --->
    Org.XmlPull.V1.XmlPullParserException: Binary XML file line #15: invalid drawable tag vector

Reviewing the logs, there was a missing `--no-version-vectors` flag?

The Xamarin.Android.Support.Vector.Drawable NuGet was setting this
value:

    Target _XamarinAndroidSupportVectorDrawableArgs
        AndroidResgenExtraArgs = --no-version-vectors

Unfortunately the logic for passing this flag to aapt2 was happening
*too soon*, at this point `$(AndroidResgenExtraArgs)` is blank:

    <AndroidAapt2LinkExtraArgs Condition=" '$(_AndroidUseAapt2)' == 'True' And $(AndroidResgenExtraArgs.Contains('--no-version-vectors')) And !($(AndroidAapt2LinkExtraArgs.Contains('--no-version-vectors'))) ">--no-version-vectors $(AndroidAapt2LinkExtraArgs) </AndroidAapt2LinkExtraArgs>

The simple solution here is to move this property at the beginning of
`_UpdateAndroidResgen` and the problem is solved.

I added a test verifying that we are getting the
`--no-version-vectors` flag for both aapt and aapt2.