### PR TITLE
[test] Use VS 2019 for Windows Designer tests

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -537,8 +537,7 @@ stages:
   - job: designer_integration_win
     displayName: Designer Windows
     pool:
-      name: VSEng-Xamarin-QA
-      demands: XQA.XA.Deviceless.Win
+      name: Hosted Windows 2019 with VS2019
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
     workspace:
@@ -546,9 +545,7 @@ stages:
     variables:
       EnableRegressionTest: true
       RegressionTestSuiteOutputDir: C:\Git\ADesRegTestSuite
-      XQA_VISUALSTUDIO_LOCATION: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise
-      VCINSTALLDIR: $(XQA_VISUALSTUDIO_LOCATION)\VC\
-      VisualStudioVersion: 15.0
+      VisualStudioInstallationPath: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
     steps:
     - script: |
         git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git
@@ -561,7 +558,7 @@ stages:
       inputs:
         github_token: $(GitHub.Token)
         provisioning_script: $(System.DefaultWorkingDirectory)\designer\bot-provisioning\dependencies.csx
-        provisioning_extra_args: '-remove "Visual Studio extension Xamarin.Android.Sdk" -vv'
+        provisioning_extra_args: -vv
 
     - task: DownloadPipelineArtifact@1
       inputs:


### PR DESCRIPTION
Migrates this test stage off of on-prem hardware to the hosted VS 2019
Windows machines. The issues which previously required us to temporarily
use on-prem hardware should now be resolved.