### PR TITLE
[tests/ci] Add MSBuild test jobs to Azure Pipelines

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:pjcollins_update-xabuildpaths@6e18a6566500215c10523b66e5a19d809192ea0d
+xamarin/monodroid:pjcollins_update-xabuildpaths@ae0cabe58a461f31b272b5c136f01ae8a872213c
 mono/mono:2019-06@761220d914e28b3ebd67e5642cf8c200110f62ec

--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:pjcollins_update-xabuildpaths@f225fadb81c781167f44d17d1b4160117ef16e2a
+xamarin/monodroid:pjcollins_update-xabuildpaths@6e18a6566500215c10523b66e5a19d809192ea0d
 mono/mono:2019-06@761220d914e28b3ebd67e5642cf8c200110f62ec

--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:pjcollins_update-xabuildpaths@9cfa66b7ab54c0980d1a5ee991b81b4632242087
+xamarin/monodroid:master@63bbeb076d809c74811a8001d38bf2e9e8672627
 mono/mono:2019-06@761220d914e28b3ebd67e5642cf8c200110f62ec

--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@237e0bd9f105b9842778ef82161a20c6d4497a40
+xamarin/monodroid:pjcollins_update-xabuildpaths@f225fadb81c781167f44d17d1b4160117ef16e2a
 mono/mono:2019-06@761220d914e28b3ebd67e5642cf8c200110f62ec

--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:pjcollins_update-xabuildpaths@ae0cabe58a461f31b272b5c136f01ae8a872213c
+xamarin/monodroid:pjcollins_update-xabuildpaths@9cfa66b7ab54c0980d1a5ee991b81b4632242087
 mono/mono:2019-06@761220d914e28b3ebd67e5642cf8c200110f62ec

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -19,6 +19,7 @@ resources:
 variables:
   BundleArtifactName: bundle
   InstallerArtifactName: installers
+  NUnitTestAssembliesArtifactName: test-assemblies
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
 # Check - "Xamarin.Android (Prepare bundle)"
@@ -114,6 +115,12 @@ stages:
 
     - script: make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1 PREPARE_ARGS="--bundle-path=$(System.DefaultWorkingDirectory)"
       displayName: make jenkins
+
+    - task: PublishPipelineArtifact@0
+      displayName: upload test assemblies
+      inputs:
+        artifactName: $(NUnitTestAssembliesArtifactName)
+        targetPath: bin/Test$(XA.Build.Configuration)
 
     - script: make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
       displayName: make create-installers
@@ -304,43 +311,9 @@ stages:
     variables:
       ApkTestConfiguration: Release
     steps:
-    - task: DownloadPipelineArtifact@1
-      inputs:
-        artifactName: $(InstallerArtifactName)
-        itemPattern: "*.pkg"
-        downloadPath: $(System.DefaultWorkingDirectory)
-
-    - template: yaml-templates/run-installer.yaml
-
-    - task: MSBuild@1
-      displayName: build xaprepare
-      inputs:
-        solution: build-tools/xaprepare/xaprepare.sln
+    - template: yaml-templates/mac/setup-test-environment.yaml
+      parameters:
         configuration: $(ApkTestConfiguration)
-        msbuildArguments: /t:Restore,Build
-
-    - script: |
-        mono build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=UpdateMono --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
-        mono build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
-        mono build-tools/xaprepare/xaprepare/bin/$(ApkTestConfiguration)/xaprepare.exe --s=AndroidToolchain --no-emoji --run-mode=CI
-      displayName: provision dependencies
-
-    - task: NuGetCommand@2
-      displayName: nuget restore Xamarin.Android.Tools.sln
-      inputs:
-        restoreSolution: external/xamarin-android-tools/Xamarin.Android.Tools.sln
-
-    - task: MSBuild@1
-      displayName: build Xamarin.Android.Tools.BootstrapTasks.csproj
-      inputs:
-        solution: build-tools/xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
-        configuration: $(ApkTestConfiguration)
-        msbuildArguments: /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/BootstrapTasks.binlog
-
-    - task: NuGetCommand@2
-      displayName: nuget restore Xamarin.Android-Tests.sln
-      inputs:
-        restoreSolution: Xamarin.Android-Tests.sln
 
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
@@ -490,6 +463,115 @@ stages:
       displayName: upload artifacts
       inputs:
         artifactName: mac-apk-test-results
+        targetPath: $(Build.ArtifactStagingDirectory)
+      condition: always()
+
+  # Check - "Xamarin.Android (Test MSBuild Mac)"
+  - job: mac_msbuild_tests
+    displayName: MSBuild Mac
+    pool: $(XA.Build.Mac.Pool)
+    timeoutInMinutes: 180
+    cancelTimeoutInMinutes: 5
+    workspace:
+      clean: all
+    steps:
+    - template: yaml-templates/mac/setup-test-environment.yaml
+
+    - task: DownloadPipelineArtifact@1
+      inputs:
+        artifactName: $(NUnitTestAssembliesArtifactName)
+        downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
+
+    - script: >
+        mono packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe
+        $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.dll
+        $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.Commercial.dll
+        --result TestResult-BuildTests-$(XA.Build.Configuration).xml
+      displayName: run Xamarin.Android.Build.Tests
+
+    - task: PublishTestResults@2
+      displayName: publish test results
+      inputs:
+        testResultsFormat: NUnit
+        testResultsFiles: TestResult-BuildTests-$(XA.Build.Configuration).xml
+        testRunTitle: BuildTestsMac
+      condition: succeededOrFailed()
+
+    - task: MSBuild@1
+      displayName: package results
+      inputs:
+        solution: build-tools/xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: /t:Build,ZipBuildStatus,ZipTestResults /p:BuildStatusZipOutputPath=$(Build.ArtifactStagingDirectory) /p:TestResultZipOutputPath=$(Build.ArtifactStagingDirectory)
+      condition: always()
+
+    - task: PublishPipelineArtifact@0
+      displayName: upload artifacts
+      inputs:
+        artifactName: mac-buildtask-testresults
+        targetPath: $(Build.ArtifactStagingDirectory)
+      condition: always()
+
+ # Check - "Xamarin.Android (Test MSBuild Devices Mac)"
+  - job: mac_msbuilddevice_tests
+    displayName: MSBuild Devices Mac
+    pool: $(XA.Build.Mac.Pool)
+    timeoutInMinutes: 180
+    cancelTimeoutInMinutes: 5
+    workspace:
+      clean: all
+    steps:
+    - template: yaml-templates/mac/setup-test-environment.yaml
+
+    - task: DownloadPipelineArtifact@1
+      inputs:
+        artifactName: $(NUnitTestAssembliesArtifactName)
+        downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
+
+    - task: MSBuild@1
+      displayName: start emulator
+      inputs:
+        solution: src/Mono.Android/Test/Mono.Android-Tests.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: >
+          /t:AcquireAndroidTarget /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/start-emulator.binlog
+
+    - script: >
+        mono packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe
+        $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll
+        --result TestResult-DeviceBuildTests-$(XA.Build.Configuration).xml
+      displayName: run on-device Xamarin.Android.Build.Tests
+
+    - task: PublishTestResults@2
+      displayName: publish test results
+      inputs:
+        testResultsFormat: NUnit
+        testResultsFiles: TestResult-DeviceBuildTests-$(XA.Build.Configuration).xml
+        testRunTitle: DeviceBuildTestsMac
+      condition: succeededOrFailed()
+
+    - task: MSBuild@1
+      displayName: shut down emulator
+      inputs:
+        solution: src/Mono.Android/Test/Mono.Android-Tests.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: >
+          /t:AcquireAndroidTarget,ReleaseAndroidTarget
+          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog
+      condition: always()
+
+    - task: MSBuild@1
+      displayName: package results
+      inputs:
+        solution: build-tools/xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: /t:Build,ZipBuildStatus,ZipTestResults /p:BuildStatusZipOutputPath=$(Build.ArtifactStagingDirectory) /p:TestResultZipOutputPath=$(Build.ArtifactStagingDirectory)
+      condition: always()
+
+    - task: PublishPipelineArtifact@0
+      displayName: upload artifacts
+      inputs:
+        artifactName: mac-devicebuildtask-testresults
         targetPath: $(Build.ArtifactStagingDirectory)
       condition: always()
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -486,16 +486,16 @@ stages:
         mono packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe
         $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.dll
         $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.Commercial.dll
-        --result TestResult-BuildTests-$(XA.Build.Configuration).xml
+        --result TestResult-MSBuildTests-$(XA.Build.Configuration).xml
       displayName: run Xamarin.Android.Build.Tests
 
     - task: PublishTestResults@2
       displayName: publish test results
       inputs:
         testResultsFormat: NUnit
-        testResultsFiles: TestResult-BuildTests-$(XA.Build.Configuration).xml
-        testRunTitle: BuildTestsMac
-      condition: succeededOrFailed()
+        testResultsFiles: TestResult-MSBuildTests-$(XA.Build.Configuration).xml
+        testRunTitle: MSBuildTestsMac
+      condition: always()
 
     - task: MSBuild@1
       displayName: package results
@@ -508,15 +508,15 @@ stages:
     - task: PublishPipelineArtifact@0
       displayName: upload artifacts
       inputs:
-        artifactName: mac-buildtask-testresults
+        artifactName: mac-msbuild-testresults
         targetPath: $(Build.ArtifactStagingDirectory)
       condition: always()
 
- # Check - "Xamarin.Android (Test MSBuild Devices Mac)"
+ # Check - "Xamarin.Android (Test MSBuild With Emulator Mac)"
   - job: mac_msbuilddevice_tests
-    displayName: MSBuild Devices Mac
+    displayName: MSBuild With Emulator Mac
     pool: $(XA.Build.Mac.Pool)
-    timeoutInMinutes: 180
+    timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
     workspace:
       clean: all
@@ -539,16 +539,17 @@ stages:
     - script: >
         mono packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe
         $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll
-        --result TestResult-DeviceBuildTests-$(XA.Build.Configuration).xml
+        --where "test != Xamarin.Android.Build.Tests.DeploymentTest.CheckTimeZoneInfoIsCorrect"
+        --result TestResult-MSBuildDeviceTests-$(XA.Build.Configuration).xml
       displayName: run on-device Xamarin.Android.Build.Tests
 
     - task: PublishTestResults@2
       displayName: publish test results
       inputs:
         testResultsFormat: NUnit
-        testResultsFiles: TestResult-DeviceBuildTests-$(XA.Build.Configuration).xml
-        testRunTitle: DeviceBuildTestsMac
-      condition: succeededOrFailed()
+        testResultsFiles: TestResult-MSBuildDeviceTests-$(XA.Build.Configuration).xml
+        testRunTitle: MSBuildDeviceTestsMac
+      condition: always()
 
     - task: MSBuild@1
       displayName: shut down emulator
@@ -571,7 +572,71 @@ stages:
     - task: PublishPipelineArtifact@0
       displayName: upload artifacts
       inputs:
-        artifactName: mac-devicebuildtask-testresults
+        artifactName: mac-msbuild-device-testresults
+        targetPath: $(Build.ArtifactStagingDirectory)
+      condition: always()
+
+# Check - "Xamarin.Android (Test TimeZoneInfo With Emulator Mac)"
+  - job: mac_msbuilddevice_tests
+    displayName: TimeZoneInfo With Emulator Mac
+    pool: $(XA.Build.Mac.Pool)
+    timeoutInMinutes: 240
+    cancelTimeoutInMinutes: 5
+    workspace:
+      clean: all
+    steps:
+    - template: yaml-templates/mac/setup-test-environment.yaml
+
+    - task: DownloadPipelineArtifact@1
+      inputs:
+        artifactName: $(NUnitTestAssembliesArtifactName)
+        downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
+
+    - task: MSBuild@1
+      displayName: start emulator
+      inputs:
+        solution: src/Mono.Android/Test/Mono.Android-Tests.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: >
+          /t:AcquireAndroidTarget /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/start-emulator.binlog
+
+    - script: >
+        mono packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe
+        $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll
+        --where "test == Xamarin.Android.Build.Tests.DeploymentTest.CheckTimeZoneInfoIsCorrect"
+        --result TestResult-TimeZoneInfoTests-$(XA.Build.Configuration).xml
+      displayName: run on-device Xamarin.Android.Build.Tests
+
+    - task: PublishTestResults@2
+      displayName: publish test results
+      inputs:
+        testResultsFormat: NUnit
+        testResultsFiles: TestResult-TimeZoneInfoTests-$(XA.Build.Configuration).xml
+        testRunTitle: TimeZoneInfoTestsMac
+      condition: always()
+
+    - task: MSBuild@1
+      displayName: shut down emulator
+      inputs:
+        solution: src/Mono.Android/Test/Mono.Android-Tests.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: >
+          /t:AcquireAndroidTarget,ReleaseAndroidTarget
+          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog
+      condition: always()
+
+    - task: MSBuild@1
+      displayName: package results
+      inputs:
+        solution: build-tools/xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: /t:Build,ZipBuildStatus,ZipTestResults /p:BuildStatusZipOutputPath=$(Build.ArtifactStagingDirectory) /p:TestResultZipOutputPath=$(Build.ArtifactStagingDirectory)
+      condition: always()
+
+    - task: PublishPipelineArtifact@0
+      displayName: upload artifacts
+      inputs:
+        artifactName: mac-timezoneinfo-testresults
         targetPath: $(Build.ArtifactStagingDirectory)
       condition: always()
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -577,7 +577,7 @@ stages:
       condition: always()
 
 # Check - "Xamarin.Android (Test TimeZoneInfo With Emulator Mac)"
-  - job: mac_msbuilddevice_tests
+  - job: mac_timezonedevice_tests
     displayName: TimeZoneInfo With Emulator Mac
     pool: $(XA.Build.Mac.Pool)
     timeoutInMinutes: 240

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -496,7 +496,6 @@ stages:
     - script: >
         mono packages/NUnit.ConsoleRunner.$(NUnitConsoleVersion)/tools/nunit3-console.exe
         $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.dll
-        $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.Commercial.dll
         --result TestResult-MSBuildTests-$(XA.Build.Configuration).xml
       displayName: run Xamarin.Android.Build.Tests
 
@@ -506,7 +505,22 @@ stages:
         testResultsFormat: NUnit
         testResultsFiles: TestResult-MSBuildTests-$(XA.Build.Configuration).xml
         testRunTitle: MSBuildTestsMac
-      condition: always()
+      condition: succeededOrFailed()
+
+    - script: >
+        mono packages/NUnit.ConsoleRunner.$(NUnitConsoleVersion)/tools/nunit3-console.exe
+        $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.Commercial.dll
+        --result TestResult-MSBuildTestsCommercial-$(XA.Build.Configuration).xml
+      displayName: run Xamarin.Android.Build.Tests.Commercial
+      condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
+
+    - task: PublishTestResults@2
+      displayName: publish test results
+      inputs:
+        testResultsFormat: NUnit
+        testResultsFiles: TestResult-MSBuildTestsCommercial-$(XA.Build.Configuration).xml
+        testRunTitle: MSBuildTestsMac
+      condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
 
     - task: MSBuild@1
       displayName: package results

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -38,6 +38,11 @@ stages:
     - checkout: self
       submodules: recursive
 
+    - task: UseDotNet@2
+      displayName: install .NET Core 2.1.701
+      inputs:
+        version: 2.1.701
+
       # Update Mono in a separate step since xaprepare uses it as well and it will crash when Mono it runs with is updated
       # The 'prepare' step creates the bundle
     - script: |
@@ -90,6 +95,11 @@ stages:
     steps:
     - checkout: self
       submodules: recursive
+
+    - task: UseDotNet@2
+      displayName: install .NET Core 2.1.701
+      inputs:
+        version: 2.1.701
 
     - task: DownloadPipelineArtifact@1
       inputs:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -538,8 +538,8 @@ stages:
 
     - script: >
         mono packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe
-        $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll
-        --where "test != Xamarin.Android.Build.Tests.DeploymentTest.CheckTimeZoneInfoIsCorrect"
+        $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.dll
+        --where "cat == UsesDevice"
         --result TestResult-MSBuildDeviceTests-$(XA.Build.Configuration).xml
       displayName: run on-device Xamarin.Android.Build.Tests
 
@@ -549,6 +549,22 @@ stages:
         testResultsFormat: NUnit
         testResultsFiles: TestResult-MSBuildDeviceTests-$(XA.Build.Configuration).xml
         testRunTitle: MSBuildDeviceTestsMac
+      condition: always()
+
+    - script: >
+        mono packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe
+        $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll
+        --where "test != Xamarin.Android.Build.Tests.DeploymentTest.CheckTimeZoneInfoIsCorrect"
+        --result TestResult-MSBuildDeviceIntegration-$(XA.Build.Configuration).xml
+      displayName: run on-device MSBuildDeviceIntegration tests
+      condition: succeededOrFailed()
+
+    - task: PublishTestResults@2
+      displayName: publish test results
+      inputs:
+        testResultsFormat: NUnit
+        testResultsFiles: TestResult-MSBuildDeviceIntegration-$(XA.Build.Configuration).xml
+        testRunTitle: MSBuildDeviceIntegration
       condition: always()
 
     - task: MSBuild@1
@@ -605,7 +621,7 @@ stages:
         $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll
         --where "test == Xamarin.Android.Build.Tests.DeploymentTest.CheckTimeZoneInfoIsCorrect"
         --result TestResult-TimeZoneInfoTests-$(XA.Build.Configuration).xml
-      displayName: run on-device Xamarin.Android.Build.Tests
+      displayName: run TimeZoneInfo tests
 
     - task: PublishTestResults@2
       displayName: publish test results

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -20,6 +20,7 @@ variables:
   BundleArtifactName: bundle
   InstallerArtifactName: installers
   NUnitTestAssembliesArtifactName: test-assemblies
+  NUnitConsoleVersion: 3.9.0
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
 # Check - "Xamarin.Android (Prepare bundle)"
@@ -493,7 +494,7 @@ stages:
         downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
     - script: >
-        mono packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe
+        mono packages/NUnit.ConsoleRunner.$(NUnitConsoleVersion)/tools/nunit3-console.exe
         $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.dll
         $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.Commercial.dll
         --result TestResult-MSBuildTests-$(XA.Build.Configuration).xml
@@ -547,7 +548,7 @@ stages:
           /t:AcquireAndroidTarget /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/start-emulator.binlog
 
     - script: >
-        mono packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe
+        mono packages/NUnit.ConsoleRunner.$(NUnitConsoleVersion)/tools/nunit3-console.exe
         $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.dll
         --where "cat == UsesDevice"
         --result TestResult-MSBuildDeviceTests-$(XA.Build.Configuration).xml
@@ -562,7 +563,7 @@ stages:
       condition: always()
 
     - script: >
-        mono packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe
+        mono packages/NUnit.ConsoleRunner.$(NUnitConsoleVersion)/tools/nunit3-console.exe
         $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll
         --where "test != Xamarin.Android.Build.Tests.DeploymentTest.CheckTimeZoneInfoIsCorrect"
         --result TestResult-MSBuildDeviceIntegration-$(XA.Build.Configuration).xml
@@ -627,7 +628,7 @@ stages:
           /t:AcquireAndroidTarget /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/start-emulator.binlog
 
     - script: >
-        mono packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe
+        mono packages/NUnit.ConsoleRunner.$(NUnitConsoleVersion)/tools/nunit3-console.exe
         $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll
         --where "test == Xamarin.Android.Build.Tests.DeploymentTest.CheckTimeZoneInfoIsCorrect"
         --result TestResult-TimeZoneInfoTests-$(XA.Build.Configuration).xml

--- a/build-tools/automation/yaml-templates/mac/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/mac/setup-test-environment.yaml
@@ -21,7 +21,12 @@ steps:
     mono build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=UpdateMono --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
     mono build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
     mono build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=AndroidToolchain --no-emoji --run-mode=CI
-  displayName: provision dependencies
+  displayName: install xaprepare dependencies
+
+- task: UseDotNet@2
+  displayName: install .NET Core 2.1.701
+  inputs:
+    version: 2.1.701
 
 # Restore solutions for Xamarin.Android.Tools.sln, Xamarin.Android.sln, and Xamarin.Android-Tests.sln
 - task: NuGetCommand@2

--- a/build-tools/automation/yaml-templates/mac/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/mac/setup-test-environment.yaml
@@ -1,0 +1,38 @@
+parameters:
+  configuration: $(XA.Build.Configuration)
+
+steps:
+- task: DownloadPipelineArtifact@1
+  inputs:
+    artifactName: $(InstallerArtifactName)
+    itemPattern: "*.pkg"
+    downloadPath: $(System.DefaultWorkingDirectory)
+
+- template: ../run-installer.yaml
+
+- task: MSBuild@1
+  displayName: build xaprepare
+  inputs:
+    solution: build-tools/xaprepare/xaprepare.sln
+    configuration: ${{ parameters.configuration }}
+    msbuildArguments: /t:Restore,Build
+
+- script: |
+    mono build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=UpdateMono --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
+    mono build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
+    mono build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=AndroidToolchain --no-emoji --run-mode=CI
+  displayName: provision dependencies
+
+# Restore solutions for Xamarin.Android.Tools.sln, Xamarin.Android.sln, and Xamarin.Android-Tests.sln
+- task: NuGetCommand@2
+  displayName: nuget restore Xamarin.Android solutions
+  inputs:
+    restoreSolution: '**/Xamarin.Android*.sln'
+
+- task: MSBuild@1
+  displayName: build Xamarin.Android.Tools.BootstrapTasks.csproj
+  inputs:
+    solution: build-tools/xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+    configuration: ${{ parameters.configuration }}
+    msbuildArguments: /bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/BootstrapTasks.binlog
+

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.MacOS.cs
@@ -7,10 +7,7 @@ namespace Xamarin.Android.Prepare
 		partial class Urls
 		{
 			public static readonly Uri Corretto = new Uri ("https://d3pxv6yz143wms.cloudfront.net/8.212.04.2/amazon-corretto-8.212.04.2-macosx-x64.tar.gz");
-
-			// 6.0: https://download.mono-project.com/archive/6.0.0/macos-10-universal/MonoFramework-MDK-6.0.0.241.macos10.xamarin.universal.pkg
-			//      Currently breaks the build, thus we use the latest stable below
-			public static readonly Uri MonoPackage = new Uri ("https://download.mono-project.com/archive/5.20.1/macos-10-universal/MonoFramework-MDK-5.20.1.19.macos10.xamarin.universal.pkg");
+			public static readonly Uri MonoPackage = new Uri ("https://download.mono-project.com/archive/6.0.0/macos-10-universal/MonoFramework-MDK-6.0.0.313.macos10.xamarin.universal.pkg");
 		}
 
 		partial class Defaults

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
@@ -34,8 +34,8 @@ namespace Xamarin.Android.Prepare
 
 			// If you change the minimum Mono version here, please change the URL as well
 			new MonoPkgProgram ("Mono", "com.xamarin.mono-MDK.pkg", Configurables.Urls.MonoPackage) {
-				MinimumVersion = "5.20.1.19",
-				MaximumVersion = "5.99.0.0",
+				MinimumVersion = "6.0.0.313",
+				MaximumVersion = "6.99.0.0",
 			},
 		};
 

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
@@ -52,7 +52,6 @@ namespace Xamarin.Android.Prepare
 					return new List <GeneratedFile> {
 						Get_Configuration_OperatingSystem_props (context),
 						Get_Ndk_projitems (context),
-						Get_XABuildPaths_cs (context),
 						Get_XABuildConfig_cs (context),
 						Get_mingw_32_cmake (context),
 						Get_mingw_64_cmake (context),
@@ -113,22 +112,6 @@ namespace Xamarin.Android.Prepare
 				replacements,
 				Path.Combine (Configurables.Paths.BootstrapResourcesDir, $"{OutputFileName}.in"),
 				Path.Combine (BuildPaths.XamarinAndroidSourceRoot, OutputFileName)
-			);
-		}
-
-		GeneratedFile Get_XABuildPaths_cs (Context context)
-		{
-			const string OutputFileName = "XABuildPaths.cs";
-
-			var replacements = new Dictionary<string, string> (StringComparer.Ordinal) {
-				{ "@CONFIGURATION@", context.Configuration },
-				{ "@TOP_DIRECTORY@", BuildPaths.XamarinAndroidSourceRoot },
-			};
-
-			return new GeneratedPlaceholdersFile (
-				replacements,
-				Path.Combine (Configurables.Paths.BuildToolsScriptsDir, $"{OutputFileName}.in"),
-				Path.Combine (Configurables.Paths.TestBinDir, OutputFileName)
 			);
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xamarin.ProjectTools;
 using NUnit.Framework;
 using System.Linq;
@@ -10,6 +10,7 @@ using Microsoft.Build.Framework;
 using System.Xml.Linq;
 using System.Security.Cryptography;
 using System.Text.RegularExpressions;
+using Xamarin.ProjectTools;
 
 namespace Xamarin.Android.Build.Tests
 {
@@ -1151,7 +1152,7 @@ namespace Lib1 {
 		[NonParallelizable]
 		public void BuildAppWithManagedResourceParserAndLibraries ()
 		{
-			int maxBuildTimeMs = 10000;
+			int maxBuildTimeMs = TestEnvironment.IsRunningOnHostedAzureAgent ? 15000 : 10000;
 			var path = Path.Combine ("temp", "BuildAppWithMRPAL");
 			var theme = new AndroidItem.AndroidResource ("Resources\\values\\Theme.xml") {
 				TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -520,7 +520,8 @@ namespace UnnamedProject
 		};
 
 		[Test]
-		[TestCaseSource(nameof (ReleaseLanguage))]
+		[Parallelizable (ParallelScope.Self)]
+		[TestCaseSource (nameof (ReleaseLanguage))]
 		public void CheckResourceDesignerIsCreated (bool isRelease, ProjectLanguage language)
 		{
 			//Due to the MSBuild project automatically sorting <ItemGroup />, we can't possibly get the F# projects to build here on Windows
@@ -1514,6 +1515,7 @@ namespace UnnamedProject
 		}
 
 		[Test]
+		[Parallelizable (ParallelScope.Self)]
 		public void CheckNoVersionVectors ([Values (true, false)] bool useAapt2)
 		{
 			var proj = new XamarinFormsAndroidApplicationProject ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -75,12 +75,16 @@ namespace Xamarin.Android.Build.Tests
 			using (var b = CreateDllBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded");
-				var fileCount = Directory.GetFiles (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath), "*", SearchOption.AllDirectories)
-					.Where (x => !Path.GetFileName (x).StartsWith ("TemporaryGeneratedFile")).Count ();
+				var ignoreFiles = new string [] {
+					"TemporaryGeneratedFile",
+					"FileListAbsolute.txt",
+				};
+				var files = Directory.GetFiles (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath), "*", SearchOption.AllDirectories)
+					.Where (x => !ignoreFiles.Any (i => !Path.GetFileName (x).Contains (i)));
 				Assert.AreEqual (0, Directory.GetDirectories (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath), "*", SearchOption.AllDirectories).Length,
 					"All directories in {0} should have been removed", proj.IntermediateOutputPath);
-				Assert.AreEqual (0, fileCount,
-					"All files in {0} should have been removed", proj.IntermediateOutputPath);
+				Assert.AreEqual (0, files.Count (), "{0} should be empty. Found {1}",
+					proj.IntermediateOutputPath, string.Join (Environment.NewLine, files));
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -115,6 +115,7 @@ class MemTest {
 		}
 
 		[Test]
+		[NonParallelizable]
 		public void BuildBasicApplicationAppCompat ([Values (true, false)] bool usePackageReference)
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -2562,6 +2563,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		}
 
 		[Test]
+		[NonParallelizable]
 		public void BuildWithResolveAssembliesFailure ([Values (true, false)] bool usePackageReference)
 		{
 			var path = Path.Combine ("temp", TestContext.CurrentContext.Test.Name);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2082,7 +2082,7 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 				AndroidClassParser = "class-parse",
 			};
 			using (var bbuilder = CreateDllBuilder (Path.Combine (path, "BuildWithExternalJavaLibraryBinding"))) {
-				string multidex_path = bbuilder.RunningMSBuild ? TestEnvironment.MonoAndroidToolsDirectory : @"$(MonoDroidInstallDirectory)\lib\xamarin.android\xbuild\Xamarin\Android";
+				string multidex_path = TestEnvironment.IsRunningOnCI ? TestEnvironment.MonoAndroidToolsDirectory : @"$(MonoDroidInstallDirectory)\lib\xamarin.android\xbuild\Xamarin\Android";
 				string multidex_jar = $@"{multidex_path}\android-support-multidex.jar";
 				binding.Jars.Add (new AndroidItem.InputJar (() => multidex_jar));
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -856,7 +856,7 @@ namespace UnamedProject
 					"Landroid/runtime/UncaughtExceptionHandler;",
 				};
 				foreach (var className in classes) {
-					Assert.IsTrue (DexUtils.ContainsClassWithMethod (className, "<init>", "()V", dexFile, b.AndroidSdkDirectory), $"`{dexFile}` should include `{className}`!");
+					Assert.IsTrue (DexUtils.ContainsClassWithMethod (className, "<init>", "()V", dexFile, AndroidSdkPath), $"`{dexFile}` should include `{className}`!");
 				}
 			}
 		}
@@ -1072,7 +1072,7 @@ namespace UnnamedProject {
 				var className = "Landroid/support/multidex/MultiDexApplication;";
 				var dexFile = b.Output.GetIntermediaryPath (Path.Combine ("android", "bin", "classes.dex"));
 				FileAssert.Exists (dexFile);
-				Assert.IsTrue (DexUtils.ContainsClassWithMethod (className, "<init>", "()V", dexFile, b.AndroidSdkDirectory), $"`{dexFile}` should include `{className}`!");
+				Assert.IsTrue (DexUtils.ContainsClassWithMethod (className, "<init>", "()V", dexFile, AndroidSdkPath), $"`{dexFile}` should include `{className}`!");
 			}
 		}
 
@@ -1534,8 +1534,8 @@ namespace App1
 		void FixLintOnWindows ()
 		{
 			if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
-				var userProfile = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
-				var androidSdkTools = Path.Combine (userProfile, "android-toolchain", "sdk", "tools");
+				var androidSdk = AndroidSdkResolver.GetAndroidSdkPath ();
+				var androidSdkTools = Path.Combine (androidSdk, "tools");
 				if (Directory.Exists (androidSdkTools)) {
 					Environment.SetEnvironmentVariable ("JAVA_OPTS", $"\"-Dcom.android.tools.lint.bindir={androidSdkTools}\"", EnvironmentVariableTarget.Process);
 				}
@@ -2077,8 +2077,8 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 				AndroidClassParser = "class-parse",
 			};
 			using (var bbuilder = CreateDllBuilder (Path.Combine (path, "BuildWithExternalJavaLibraryBinding"))) {
-				string multidex_path = bbuilder.RunningMSBuild ? @"$(MSBuildExtensionsPath)" : @"$(MonoDroidInstallDirectory)\lib\xamarin.android\xbuild";
-				string multidex_jar = $@"{multidex_path}\Xamarin\Android\android-support-multidex.jar";
+				string multidex_path = bbuilder.RunningMSBuild ? TestEnvironment.MonoAndroidToolsDirectory : @"$(MonoDroidInstallDirectory)\lib\xamarin.android\xbuild\Xamarin\Android";
+				string multidex_jar = $@"{multidex_path}\android-support-multidex.jar";
 				binding.Jars.Add (new AndroidItem.InputJar (() => multidex_jar));
 
 				Assert.IsTrue (bbuilder.Build (binding));
@@ -2504,7 +2504,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				var className = "Lmono/MonoRuntimeProvider;";
 				var dexFile = b.Output.GetIntermediaryPath (Path.Combine ("android", "bin", "classes.dex"));
 				FileAssert.Exists (dexFile);
-				Assert.IsTrue (DexUtils.ContainsClass (className, dexFile, b.AndroidSdkDirectory), $"`{dexFile}` should include `{className}`!");
+				Assert.IsTrue (DexUtils.ContainsClass (className, dexFile, AndroidSdkPath), $"`{dexFile}` should include `{className}`!");
 			}
 		}
 
@@ -3487,7 +3487,7 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 				var className = "Lmono/MonoRuntimeProvider;";
 				var dexFile = builder.Output.GetIntermediaryPath (Path.Combine ("android", "bin", "classes.dex"));
 				FileAssert.Exists (dexFile);
-				Assert.IsTrue (DexUtils.ContainsClass (className, dexFile, builder.AndroidSdkDirectory), $"`{dexFile}` should include `{className}`!");
+				Assert.IsTrue (DexUtils.ContainsClass (className, dexFile, AndroidSdkPath), $"`{dexFile}` should include `{className}`!");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -518,11 +518,16 @@ namespace UnamedProject
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
+
+				var ignoreFiles = new string [] {
+					"TemporaryGeneratedFile",
+					"FileListAbsolute.txt",
+				};
 				var files = Directory.GetFiles (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath), "*", SearchOption.AllDirectories)
-					.Where (x => !Path.GetFileName (x).StartsWith ("TemporaryGeneratedFile"));
+					.Where (x => !ignoreFiles.Any (i => !Path.GetFileName (x).Contains (i)));
 				Assert.AreEqual (0, files.Count (), "{0} should be Empty. Found {1}", proj.IntermediateOutputPath, string.Join (Environment.NewLine, files));
 				files = Directory.GetFiles (Path.Combine (Root, b.ProjectDirectory, proj.OutputPath), "*", SearchOption.AllDirectories)
-					.Where (x => !Path.GetFileName (x).StartsWith ("TemporaryGeneratedFile"));
+					.Where (x => !ignoreFiles.Any (i => !Path.GetFileName (x).Contains (i)));
 				Assert.AreEqual (0, files.Count (), "{0} should be Empty. Found {1}", proj.OutputPath, string.Join (Environment.NewLine, files));
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DeleteBinObjTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DeleteBinObjTest.cs
@@ -6,7 +6,7 @@ using Xamarin.Tools.Zip;
 namespace Xamarin.Android.Build.Tests
 {
 	[TestFixture]
-	[Parallelizable (ParallelScope.Children)]
+	[Parallelizable (ParallelScope.Fixtures)]
 	public class DeleteBinObjTest : BaseTest
 	{
 		const string BaseUrl = "https://xamjenkinsartifact.azureedge.net/mono-jenkins/xamarin-android-test/";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DeleteBinObjTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DeleteBinObjTest.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
-		[Test]
+		[Test, Category ("UsesDevice")]
 		public void HelloForms ([Values (false, true)] bool isRelease)
 		{
 			RunTest (nameof (HelloForms), "HelloForms.sln", Path.Combine ("HelloForms.Android", "HelloForms.Android.csproj"), "15.9", "ecb13a9", isRelease);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -682,7 +682,8 @@ namespace Lib2
 			return task;
 		}
 
-		[Test, Parallelizable (ParallelScope.Self)]
+		[Test]
+		[NonParallelizable]
 		public void InvalidAndroidResource ([Values (true, false)] bool useAapt2)
 		{
 			var invalidXml = new AndroidItem.AndroidResource (@"Resources\values\ids.xml") {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -682,7 +682,7 @@ namespace Lib2
 			return task;
 		}
 
-		[Test]
+		[Test, Parallelizable (ParallelScope.Self)]
 		public void InvalidAndroidResource ([Values (true, false)] bool useAapt2)
 		{
 			var invalidXml = new AndroidItem.AndroidResource (@"Resources\values\ids.xml") {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -169,6 +169,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Parallelizable (ParallelScope.Self)]
 		public void CheckIncludedNativeLibraries ([Values (true, false)] bool compressNativeLibraries)
 		{
 			var proj = new XamarinAndroidApplicationProject () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BundleToolTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BundleToolTests.cs
@@ -173,7 +173,7 @@ namespace Xamarin.Android.Build.Tests
 			Assert.IsTrue (StringAssertEx.ContainsText (contents, "META-INF/MANIFEST.MF"), $"{aab} is not signed!");
 		}
 
-		[Test]
+		[Test, Category ("UsesDevice")]
 		public void ApkSet ()
 		{
 			if (!HasDevices)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using Xamarin.ProjectTools;
@@ -151,16 +151,8 @@ int styleable MultiSelectListPreference_entries 2
 int styleable MultiSelectListPreference_entryValues 3
 int transition transition 0x7f0f0000
 ";
-		[OneTimeSetUp]
-		public void Setup ()
-		{
-			using (var builder = new Builder ()) {
-				builder.ResolveSdks ();
-				AndroidSdkDirectory = builder.AndroidSdkDirectory;
-			}
-		}
 
-		public string AndroidSdkDirectory { get; set; }
+		public string AndroidSdkDirectory { get; set; } = AndroidSdkResolver.GetAndroidSdkPath ();
 
 		public void CreateResourceDirectory (string path)
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/NdkUtilTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/NdkUtilTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NUnit.Framework;
 using System;
@@ -30,9 +30,8 @@ namespace Xamarin.Android.Build.Tests.Tasks {
 		{
 			var log = new TaskLoggingHelper (engine, TestName);
 			using (var builder = new Builder ()) {
-				builder.ResolveSdks ();
-				var ndkDir = builder.AndroidNdkDirectory;
-				var sdkDir = builder.AndroidSdkDirectory;
+				var ndkDir = AndroidNdkPath;
+				var sdkDir = AndroidSdkPath;
 				MonoAndroidHelper.AndroidSdk = new AndroidSdkInfo ((arg1, arg2) => { }, sdkDir, ndkDir);
 				NdkUtil.Init (log, ndkDir);
 				var platforms = NdkUtil.GetSupportedPlatforms (ndkDir);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -1,4 +1,4 @@
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Collections;
 using System.Collections.Concurrent;
@@ -437,7 +437,7 @@ namespace Xamarin.Android.Build.Tests
 				FileSystemUtils.SetDirectoryWriteable (output);
 				Directory.Delete (output, recursive: true);
 			} else {
-				foreach (var file in Directory.GetFiles (Path.Combine (output), "build.log", SearchOption.AllDirectories)) {
+				foreach (var file in Directory.GetFiles (Path.Combine (output), "*.log", SearchOption.AllDirectories)) {
 					TestContext.AddTestAttachment (file, Path.GetFileName (output));
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using System;
 using System.Collections;
 using System.Collections.Concurrent;
@@ -15,7 +15,6 @@ using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using Xamarin.ProjectTools;
-using XABuildPaths = Xamarin.Android.Build.Paths;
 
 namespace Xamarin.Android.Build.Tests
 {
@@ -45,30 +44,12 @@ namespace Xamarin.Android.Build.Tests
 				private set;
 			}
 
-			public static bool IsMacOS {
-				get;
-				private set;
-			}
-
-			public static bool IsLinux {
-				get;
-				private set;
-			}
-
-			public static bool IsWindows {
-				get;
-				private set;
-			}
-
 			static SetUp ()
 			{
 				using (var builder = new Builder ()) {
 					CommercialBuildAvailable = File.Exists (Path.Combine (builder.AndroidMSBuildDirectory, "Xamarin.Android.Common.Debugging.targets"));
 					AndroidMSBuildDirectory = builder.AndroidMSBuildDirectory;
 				}
-				IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
-				IsMacOS = !IsWindows && IsDarwin ();
-				IsLinux = !IsWindows && !IsMacOS;
 			}
 
 			[OneTimeSetUp]
@@ -119,36 +100,17 @@ namespace Xamarin.Android.Build.Tests
 					p.Kill ();
 			}
 
-			[DllImport ("libc")]
-			static extern int uname (IntPtr buf);
-
-			static bool IsDarwin ()
-			{
-				IntPtr buf = IntPtr.Zero;
-				try {
-					buf = Marshal.AllocHGlobal (8192);
-					if (uname (buf) == 0) {
-						string os = Marshal.PtrToStringAnsi (buf);
-						return os == "Darwin";
-					}
-				} catch {
-				} finally {
-					if (buf != IntPtr.Zero)
-						Marshal.FreeHGlobal (buf);
-				}
-				return false;
-			}
 		}
 
 		protected bool HasDevices => SetUp.HasDevices;
 
 		protected string DeviceAbi => SetUp.DeviceAbi;
 
-		protected bool IsWindows => SetUp.IsWindows;
+		protected bool IsWindows => TestEnvironment.IsWindows;
 
-		protected bool IsMacOS => SetUp.IsMacOS;
+		protected bool IsMacOS => TestEnvironment.IsMacOS;
 
-		protected bool IsLinux => SetUp.IsLinux;
+		protected bool IsLinux => TestEnvironment.IsLinux;
 
 		public string CacheRootPath {
 			get {
@@ -192,21 +154,13 @@ namespace Xamarin.Android.Build.Tests
 
 		public static string AndroidSdkPath {
 			get {
-				var home = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
-				var sdkPath = Environment.GetEnvironmentVariable ("ANDROID_SDK_PATH");
-				if (string.IsNullOrEmpty (sdkPath))
-					sdkPath = Path.Combine (home, "android-toolchain", "sdk");
-				return sdkPath;
+				return AndroidSdkResolver.GetAndroidSdkPath ();
 			}
 		}
 
 		public static string AndroidNdkPath {
 			get {
-				var home = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
-				var sdkPath = Environment.GetEnvironmentVariable ("ANDROID_NDK_PATH");
-				if (string.IsNullOrEmpty (sdkPath))
-					sdkPath = Path.Combine (home, "android-toolchain", "ndk");
-				return sdkPath;
+				return AndroidSdkResolver.GetAndroidNdkPath ();
 			}
 		}
 
@@ -484,18 +438,7 @@ namespace Xamarin.Android.Build.Tests
 				Directory.Delete (output, recursive: true);
 			} else {
 				foreach (var file in Directory.GetFiles (Path.Combine (output), "build.log", SearchOption.AllDirectories)) {
-					TestContext.Out.WriteLine ("*************************************************************************");
-					TestContext.Out.WriteLine (file);
-					TestContext.Out.WriteLine ();
-					using (StreamReader reader = new StreamReader (file)) {
-						string line;
-						while ((line = reader.ReadLine ()) != null) {
-							TestContext.Out.WriteLine (line);
-							TestContext.Out.Flush ();
-						}
-					}
-					TestContext.Out.WriteLine ("*************************************************************************");
-					TestContext.Out.Flush ();
+					TestContext.AddTestAttachment (file, Path.GetFileName (output));
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BuildHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BuildHelper.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Android.Build.Tests
 				CleanupAfterSuccessfulBuild = cleanupAfterSuccessfulBuild,
 				CleanupOnDispose = cleanupOnDispose,
 				Verbosity = LoggerVerbosity.Diagnostic,
-				Root = Xamarin.Android.Build.Paths.TestOutputDirectory,
+				Root = XABuildPaths.TestOutputDirectory,
 			};
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -13,7 +13,6 @@ using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using Xamarin.ProjectTools;
-using XABuildPaths = Xamarin.Android.Build.Paths;
 
 namespace Xamarin.Android.Build.Tests
 {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+
+namespace Xamarin.ProjectTools
+{
+	public static class AndroidSdkResolver
+	{
+		static string HomeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+		static string DefaultToolchainPath = Path.Combine (HomeDirectory, "android-toolchain");
+		static string AzureToolchainPathMacOS = Path.Combine (HomeDirectory, "Library", "Android");
+		static string ToolchainPath = (TestEnvironment.IsMacOS && TestEnvironment.IsRunningOnCI) ? AzureToolchainPathMacOS : DefaultToolchainPath;
+
+		static string GetPathFromRegistry (string valueName)
+		{
+			if (TestEnvironment.IsWindows) {
+				return (string) Microsoft.Win32.Registry.GetValue ("HKEY_CURRENT_USER\\SOFTWARE\\Novell\\Mono for Android", valueName, null);
+			}
+			return null;
+		}
+
+		public static string GetAndroidSdkPath ()
+		{
+			var sdkPath = Environment.GetEnvironmentVariable ("ANDROID_SDK_PATH");
+			if (String.IsNullOrEmpty (sdkPath))
+				sdkPath = GetPathFromRegistry ("AndroidSdkDirectory");
+			if (String.IsNullOrEmpty (sdkPath))
+				sdkPath = Path.GetFullPath (Path.Combine (ToolchainPath, "sdk"));
+
+			return sdkPath;
+
+		}
+
+		public static string GetAndroidNdkPath ()
+		{
+			var ndkPath = Environment.GetEnvironmentVariable ("ANDROID_NDK_PATH");
+			if (String.IsNullOrEmpty (ndkPath))
+				ndkPath = GetPathFromRegistry ("AndroidNdkDirectory");
+			if (String.IsNullOrEmpty (ndkPath))
+				ndkPath = Path.GetFullPath (Path.Combine (ToolchainPath, "ndk"));
+
+			return ndkPath;
+		}
+
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/JarContentBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/JarContentBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -16,14 +16,6 @@ namespace Xamarin.ProjectTools
 		public string JavaSourceFileName { get; set; }
 		public string JavaSourceText { get; set; }
 
-		string GetPathFromRegistry (string valueName)
-		{
-			if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
-				return (string)Microsoft.Win32.Registry.GetValue ("HKEY_CURRENT_USER\\SOFTWARE\\Novell\\Mono for Android", valueName, null);
-			}
-			return null;
-		}
-
 		public JarContentBuilder ()
 		{
 			Action<TraceLevel, string> logger = (level, value) => {
@@ -36,18 +28,8 @@ namespace Xamarin.ProjectTools
 				}
 			};
 
-			var homeDirectory = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
-			var androidSdkToolPath = Path.Combine (homeDirectory, "android-toolchain");
-			var sdkPath = Environment.GetEnvironmentVariable ("ANDROID_SDK_PATH");
-			if (String.IsNullOrEmpty (sdkPath))
-				sdkPath = GetPathFromRegistry ("AndroidSdkDirectory");
-			if (String.IsNullOrEmpty (sdkPath))
-				sdkPath = Path.GetFullPath (Path.Combine (androidSdkToolPath, "sdk"));
-			var ndkPath = Environment.GetEnvironmentVariable ("ANDROID_NDK_PATH");
-			if (String.IsNullOrEmpty (ndkPath))
-				ndkPath = GetPathFromRegistry ("AndroidNdkDirectory");
-			if (String.IsNullOrEmpty (ndkPath))
-				ndkPath = Path.GetFullPath (Path.Combine (androidSdkToolPath, "ndk"));
+			var sdkPath = AndroidSdkResolver.GetAndroidSdkPath ();
+			var ndkPath = AndroidSdkResolver.GetAndroidNdkPath ();
 			var androidSdk = new AndroidSdkInfo (logger, androidSdkPath: sdkPath, androidNdkPath: ndkPath);
 			JavacFullPath = Path.Combine (androidSdk.JavaSdkPath, "bin", "javac");
 			JarFullPath = Path.Combine (androidSdk.JavaSdkPath, "bin", "jar");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.IO;
 using System.Diagnostics;
@@ -10,8 +10,6 @@ using System.Threading;
 using System.Xml.XPath;
 using System.Xml.Linq;
 using Xamarin.Android.Tools.VSWhere;
-
-using XABuildPaths = Xamarin.Android.Build.Paths;
 
 namespace Xamarin.ProjectTools
 {
@@ -237,20 +235,18 @@ namespace Xamarin.ProjectTools
 
 		public int GetMaxInstalledPlatform ()
 		{
-			using (var builder = new Builder ()) {
-				builder.ResolveSdks ();
-				int result = 0;
-				foreach (var dir in Directory.EnumerateDirectories (Path.Combine (builder.AndroidSdkDirectory, "platforms"))) {
-					int version;
-					string v = Path.GetFileName (dir).Replace ("android-", "");
-					if (!int.TryParse (v, out version))
-						continue;
-					if (version < result)
-						continue;
-					result = version;
-				}
-				return result;
+			string sdkPath = AndroidSdkResolver.GetAndroidSdkPath ();
+			int result = 0;
+			foreach (var dir in Directory.EnumerateDirectories (Path.Combine (sdkPath, "platforms"))) {
+				int version;
+				string v = Path.GetFileName (dir).Replace ("android-", "");
+				if (!int.TryParse (v, out version))
+					continue;
+				if (version < result)
+					continue;
+				result = version;
 			}
+			return result;
 		}
 
 		static string GetApiLevelFromInfoPath (string androidApiInfo)
@@ -318,49 +314,8 @@ namespace Xamarin.ProjectTools
 			GC.SuppressFinalize (this);
 		}
 
-		public string AndroidSdkDirectory { get; private set; }
-
-		public string AndroidNdkDirectory { get; private set; }
-
-		/// <summary>
-		/// Locates and sets AndroidSdkDirectory and AndroidNdkDirectory
-		/// </summary>
-		public void ResolveSdks ()
-		{
-			var homeDirectory = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
-			var androidSdkToolPath = Path.Combine (homeDirectory, "android-toolchain");
-			if (string.IsNullOrEmpty (AndroidSdkDirectory)) {
-				var sdkPath = Environment.GetEnvironmentVariable ("ANDROID_SDK_PATH");
-				if (String.IsNullOrEmpty (sdkPath))
-					sdkPath = GetPathFromRegistry ("AndroidSdkDirectory");
-				if (String.IsNullOrEmpty (sdkPath))
-					sdkPath = Path.GetFullPath (Path.Combine (androidSdkToolPath, "sdk"));
-				if (Directory.Exists (sdkPath)) {
-					AndroidSdkDirectory = sdkPath;
-				}
-			}
-			if (string.IsNullOrEmpty (AndroidNdkDirectory)) {
-				var ndkPath = Environment.GetEnvironmentVariable ("ANDROID_NDK_PATH");
-				if (String.IsNullOrEmpty (ndkPath))
-					ndkPath = GetPathFromRegistry ("AndroidNdkDirectory");
-				if (String.IsNullOrEmpty (ndkPath))
-					ndkPath = Path.GetFullPath (Path.Combine (androidSdkToolPath, "ndk"));
-				if (Directory.Exists (ndkPath)) {
-					AndroidNdkDirectory = ndkPath;
-				}
-			}
-		}
-
 		protected virtual void Dispose (bool disposing)
 		{
-		}
-
-		string GetPathFromRegistry (string valueName)
-		{
-			if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
-				return (string)Microsoft.Win32.Registry.GetValue ("HKEY_CURRENT_USER\\SOFTWARE\\Novell\\Mono for Android", valueName, null);
-			}
-			return null;
 		}
 
 		Regex timeElapsedRegEx = new Regex (
@@ -382,8 +337,6 @@ namespace Xamarin.ProjectTools
 				: string.Format ("/noconsolelogger \"/flp1:LogFile={0};Encoding=UTF-8;Verbosity={1}\"",
 					buildLogFullPath, Verbosity.ToString ().ToLower ());
 
-			ResolveSdks ();
-
 			var start = DateTime.UtcNow;
 			var args  = new StringBuilder ();
 			var psi   = new ProcessStartInfo (XABuildExe);
@@ -399,11 +352,13 @@ namespace Xamarin.ProjectTools
 				if (BuildingInsideVisualStudio && RunningMSBuild) {
 					sw.WriteLine (" /p:BuildingOutOfProcess=true");
 				}
-				if (!string.IsNullOrEmpty (AndroidSdkDirectory)) {
-					sw.WriteLine (" /p:AndroidSdkDirectory=\"{0}\" ", AndroidSdkDirectory);
+				string sdkPath = AndroidSdkResolver.GetAndroidSdkPath ();
+				if (Directory.Exists (sdkPath)) {
+					sw.WriteLine (" /p:AndroidSdkDirectory=\"{0}\" ", sdkPath);
 				}
-				if (!string.IsNullOrEmpty (AndroidNdkDirectory)) {
-					sw.WriteLine (" /p:AndroidNdkDirectory=\"{0}\" ", AndroidNdkDirectory);
+				string ndkPath = AndroidSdkResolver.GetAndroidNdkPath ();
+				if (Directory.Exists (ndkPath)) {
+					sw.WriteLine (" /p:AndroidNdkDirectory=\"{0}\" ", ndkPath);
 				}
 				if (parameters != null) {
 					foreach (var param in parameters) {
@@ -525,12 +480,8 @@ namespace Xamarin.ProjectTools
 			}
 			if (!result && ThrowOnBuildFailure) {
 				string message = "Build failure: " + Path.GetFileName (projectOrSolution) + (BuildLogFile != null && File.Exists (buildLogFullPath) ? "Build log recorded at " + buildLogFullPath : null);
-				//NOTE: enormous logs will lock up IDE's UI
-				if (IsRunningInIDE) {
-					throw new FailedBuildException (message);
-				} else {
-					throw new FailedBuildException (message, null, File.ReadAllText (buildLogFullPath));
-				}
+				//NOTE: enormous logs will lock up IDE's UI. Build result files should be appended to the TestResult on failure.
+				throw new FailedBuildException (message);
 			}
 
 			return result;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -47,18 +47,6 @@ namespace Xamarin.ProjectTools
 		/// </summary>
 		public bool AutomaticNuGetRestore { get; set; } = true;
 
-		static string visualStudioDirectory;
-
-		string GetVisualStudioDirectory ()
-		{
-			//We should cache and reuse this value, so we don't run vswhere.exe so much
-			if (!string.IsNullOrEmpty (visualStudioDirectory))
-				return visualStudioDirectory;
-
-			var instance = MSBuildLocator.QueryLatest ();
-			return visualStudioDirectory = instance.VisualStudioRootPath;
-		}
-
 		public string XABuildExe {
 			get {
 				RunningMSBuild = true;
@@ -119,7 +107,7 @@ namespace Xamarin.ProjectTools
 					if (Directory.Exists (Path.Combine (outdir, "lib")) && File.Exists (Path.Combine (outdir, libmonodroidPath)))
 						return Path.Combine (outdir, "lib", "xamarin.android");
 
-					var visualStudioDirectory = GetVisualStudioDirectory ();
+					var visualStudioDirectory = TestEnvironment.GetVisualStudioDirectory ();
 					if (!string.IsNullOrEmpty (visualStudioDirectory))
 						return Path.Combine (visualStudioDirectory, "MSBuild", "Xamarin", "Android");
 
@@ -139,7 +127,7 @@ namespace Xamarin.ProjectTools
 	
 					return string.Empty;
 				}
-				var visualStudioDirectory = GetVisualStudioDirectory ();
+				var visualStudioDirectory = TestEnvironment.GetVisualStudioDirectory ();
 				if (!string.IsNullOrEmpty (visualStudioDirectory)) {
 					path = Path.Combine (visualStudioDirectory, "MSBuild", "Sdks", "Microsoft.NET.Sdk");
 					if (File.Exists (Path.Combine (path, "Sdk", "Sdk.props")))
@@ -437,7 +425,7 @@ namespace Xamarin.ProjectTools
 					p.Start ();
 					p.BeginOutputReadLine ();
 					p.BeginErrorReadLine ();
-					ranToCompletion = p.WaitForExit ((int)new TimeSpan (0, 10, 0).TotalMilliseconds);
+					ranToCompletion = p.WaitForExit ((int)new TimeSpan (0, 15, 0).TotalMilliseconds);
 					if (psi.RedirectStandardOutput)
 						stdout.WaitOne ();
 					if (psi.RedirectStandardError)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -5,8 +5,6 @@ using System.Linq;
 using System.Diagnostics;
 using Microsoft.Build.Framework;
 
-using XABuildPaths = Xamarin.Android.Build.Paths;
-
 namespace Xamarin.ProjectTools
 {
 	public class ProjectBuilder : Builder

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
@@ -1,5 +1,7 @@
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
+using Xamarin.Android.Tools.VSWhere;
 
 namespace Xamarin.ProjectTools
 {
@@ -51,12 +53,40 @@ namespace Xamarin.ProjectTools
 			}
 		}
 
-		public static string MonoAndroidToolsDirectory {
+		public static readonly string MacOSInstallationRoot = "/Library/Frameworks/Xamarin.Android.framework/Versions/Current";
+
+		static string visualStudioDirectory;
+		public static string GetVisualStudioDirectory ()
+		{
+			//We should cache and reuse this value, so we don't run vswhere.exe so much
+			if (!string.IsNullOrEmpty (visualStudioDirectory))
+				return visualStudioDirectory;
+
+			var instance = MSBuildLocator.QueryLatest ();
+			return visualStudioDirectory = instance.VisualStudioRootPath;
+		}
+
+		public static string MonoAndroidFrameworkDirectory {
 			get {
-				return IsWindows ? @"$(MSBuildExtensionsPath)\Xamarin\Android" : "/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Android";
+				if (IsWindows) {
+					string visualStudioDirectory = GetVisualStudioDirectory ();
+					return Path.Combine (visualStudioDirectory, "Common7", "IDE", "ReferenceAssemblies", "Microsoft", "Framework", "MonoAndroid");
+				} else {
+					return Path.Combine (MacOSInstallationRoot, "lib", "xamarin.android", "xbuild-frameworks", "MonoAndroid");
+				}
 			}
 		}
 
+		public static string MonoAndroidToolsDirectory {
+			get {
+				if (IsWindows) {
+					string visualStudioDirectory = GetVisualStudioDirectory ();
+					return Path.Combine (visualStudioDirectory, "MSBuild", "Xamarin", "Android");
+				} else {
+					return Path.Combine (MacOSInstallationRoot, "lib", "xamarin.android", "xbuild", "Xamarin", "Android");
+				}
+			}
+		}
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Xamarin.ProjectTools
+{
+	public static class TestEnvironment
+	{
+		[DllImport ("libc")]
+		static extern int uname (IntPtr buf);
+
+		static bool IsDarwin ()
+		{
+			IntPtr buf = IntPtr.Zero;
+			try {
+				buf = Marshal.AllocHGlobal (8192);
+				if (uname (buf) == 0) {
+					string os = Marshal.PtrToStringAnsi (buf);
+					return os == "Darwin";
+				}
+			} catch {
+			} finally {
+				if (buf != IntPtr.Zero)
+					Marshal.FreeHGlobal (buf);
+			}
+			return false;
+		}
+
+		public static bool IsWindows {
+			get {
+				return Environment.OSVersion.Platform == PlatformID.Win32NT;
+			}
+		}
+
+		public static bool IsMacOS {
+			get {
+				return IsDarwin ();
+			}
+		}
+
+		public static bool IsLinux {
+			get {
+				return !IsWindows && !IsMacOS;
+			}
+		}
+
+		public static bool IsRunningOnCI {
+			get {
+				string runningOnCiValue = Environment.GetEnvironmentVariable ("RUNNINGONCI");
+				bool.TryParse (runningOnCiValue, out bool isRunningOnCi);
+				return isRunningOnCi;
+			}
+		}
+
+		public static string MonoAndroidToolsDirectory {
+			get {
+				return IsWindows ? @"$(MSBuildExtensionsPath)\Xamarin\Android" : "/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Android";
+			}
+		}
+
+	}
+}
+

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
@@ -53,6 +53,13 @@ namespace Xamarin.ProjectTools
 			}
 		}
 
+		public static bool IsRunningOnHostedAzureAgent {
+			get {
+				string agentNameValue = Environment.GetEnvironmentVariable ("AGENT_NAME");
+				return !string.IsNullOrEmpty(agentNameValue) && agentNameValue.ToUpper ().Contains ("HOSTED");
+			}
+		}
+
 		public static readonly string MacOSInstallationRoot = "/Library/Frameworks/Xamarin.Android.framework/Versions/Current";
 
 		static string visualStudioDirectory;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -7,8 +7,6 @@ using Microsoft.Build.Construction;
 using System.Diagnostics;
 using System.Text;
 
-using XABuildPaths = Xamarin.Android.Build.Paths;
-
 namespace Xamarin.ProjectTools
 {
 	public abstract class XamarinProject 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/XABuildPaths.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/XABuildPaths.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+
+namespace Xamarin.ProjectTools
+{
+	public class XABuildPaths
+	{
+		#if DEBUG
+		public static string Configuration = Environment.GetEnvironmentVariable ("CONFIGURATION") ?? "Debug";
+		#else
+		public static string Configuration = Environment.GetEnvironmentVariable ("CONFIGURATION") ?? "Release";
+		#endif
+
+		public static string TopDirectory = GetTopDirRecursive (Path.GetFullPath (
+			Path.GetDirectoryName (new Uri (typeof (XamarinProject).Assembly.CodeBase).LocalPath)));
+
+		public static readonly string PrefixDirectory = Path.Combine (TopDirectory, "bin", Configuration);
+		public static readonly string BinDirectory = Path.Combine (PrefixDirectory, "bin");
+		public static readonly string XABuildScript = Path.Combine (BinDirectory, "xabuild");
+		public static readonly string XABuildExe = Path.Combine (BinDirectory, "xabuild.exe");
+		public static readonly string TestOutputDirectory = Path.Combine (TopDirectory, "bin", "TestRelease");
+
+		static string GetTopDirRecursive (string searchDirectory, int maxSearchDepth = 5)
+		{
+			if (File.Exists (Path.Combine (searchDirectory, "Configuration.props")))
+				return searchDirectory;
+
+			if (maxSearchDepth <= 0)
+				throw new DirectoryNotFoundException ("Unable to locate root xamarin-android directory!");
+
+			return GetTopDirRecursive (Directory.GetParent (searchDirectory).FullName, --maxSearchDepth);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -36,8 +36,10 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Android\AndroidSdkResolver.cs" />
     <Compile Include="Android\XamarinFormsMapsApplicationProject.cs" />
     <Compile Include="Common\ExistingProject.cs" />
+    <Compile Include="Common\TestEnvironment.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Common\BuildActions.cs" />
     <Compile Include="Common\BuildItem.cs" />
@@ -79,9 +81,7 @@
     <Compile Include="Common\ContentBuilder.cs" />
     <Compile Include="Common\DotNetStandard.cs" />
     <Compile Include="Common\DotNetXamarinProject.cs" />
-    <Compile Include="..\..\..\..\bin\Test$(CONFIGURATION)\XABuildPaths.cs">
-      <Link>XABuildPaths.cs</Link>
-    </Compile>
+    <Compile Include="XABuildPaths.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\Wear\LayoutMain.axml">

--- a/tests/CodeBehind/UnitTests/BuildTests.cs
+++ b/tests/CodeBehind/UnitTests/BuildTests.cs
@@ -10,8 +10,6 @@ using NUnit.Framework;
 
 using Xamarin.ProjectTools;
 
-using XABuildPaths = global::Xamarin.Android.Build.Paths;
-
 namespace CodeBehindUnitTests
 {
 	sealed class LocalBuilder : Builder

--- a/tests/CodeBehind/UnitTests/CodeBehindUnitTests.csproj
+++ b/tests/CodeBehind/UnitTests/CodeBehindUnitTests.csproj
@@ -32,9 +32,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BuildTests.cs" />
-    <Compile Include="..\..\..\bin\Test$(CONFIGURATION)/XABuildPaths.cs">
-       <Link>XABuildPaths.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/BuildTests.cs
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/BuildTests.cs
@@ -14,8 +14,6 @@ using NUnit.Framework;
 using Xamarin.ProjectTools;
 using Xamarin.Tools.Zip;
 
-using XABuildPaths = global::Xamarin.Android.Build.Paths;
-
 namespace Xamarin.Android.MakeBundle.UnitTests
 {
 	sealed class LocalBuilder : Builder

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Xamarin.Android.MakeBundle-UnitTests.csproj
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Xamarin.Android.MakeBundle-UnitTests.csproj
@@ -38,9 +38,6 @@
   <ItemGroup>
     <Compile Include="BuildTests.cs" />
     <Compile Include="$(IntermediateOutputPath)Config.cs" />
-    <Compile Include="..\..\..\bin\Test$(CONFIGURATION)/XABuildPaths.cs">
-       <Link>XABuildPaths.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/BuildTests.cs
+++ b/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/BuildTests.cs
@@ -15,8 +15,6 @@ using Xamarin.Android.Build.Tests;
 using Xamarin.ProjectTools;
 using Xamarin.Tools.Zip;
 
-using XABuildPaths = global::Xamarin.Android.Build.Paths;
-
 namespace EmbeddedDSOUnitTests
 {
 	sealed class LocalBuilder : ProjectBuilder
@@ -82,7 +80,7 @@ namespace EmbeddedDSOUnitTests
 
 			Assert.That (success, Is.True, "Should have been built");
 
-			androidSdkDir = builder.AndroidSdkDirectory;
+			androidSdkDir = AndroidSdkResolver.GetAndroidSdkPath ();
 		}
 
 		[Test]

--- a/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/EmbeddedDSO-UnitTests.csproj
+++ b/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/EmbeddedDSO-UnitTests.csproj
@@ -46,9 +46,6 @@
   <ItemGroup>
     <Compile Include="BuildTests.cs" />
     <Compile Include="$(IntermediateOutputPath)Config.cs" />
-    <Compile Include="..\..\..\bin\Test$(CONFIGURATION)/XABuildPaths.cs">
-       <Link>XABuildPaths.cs</Link>
-    </Compile>
     <Compile Include="..\..\..\bin\Build$(CONFIGURATION)/XABuildConfig.cs">
        <Link>XABuildConfig.cs</Link>
     </Compile>

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -53,8 +53,11 @@ namespace Xamarin.Android.Build.Tests
 					Assert.True (b.RunTarget (proj, "_Run"), "Project should have run.");
 				else
 					AdbStartActivity ($"{proj.PackageName}/md52d9cf6333b8e95e8683a477bc589eda5.MainActivity");
-				Assert.True (WaitForActivityToStart (proj.PackageName, "MainActivity", output: out string output, timeout: 10),
-					"Activity should have started.");
+
+				string logcatPath = Path.Combine (XABuildPaths.TestOutputDirectory, b.ProjectDirectory, "logcat.log");
+				bool didActivityStart = WaitForActivityToStart (proj.PackageName, "MainActivity", output: out string logcatOutput, timeout: 30);
+				File.WriteAllText (logcatPath, logcatOutput);
+				Assert.True (didActivityStart, "Activity should have started.");
 				Assert.True (b.Uninstall (proj), "Project should have uninstalled.");
 			}
 		}
@@ -166,7 +169,10 @@ namespace Xamarin.Android.Build.Tests
 					"AndroidAttachDebugger=True",
 				}), "Project should have run.");
 				
-				Assert.IsTrue (WaitForDebuggerToStart (output: out string logcat), "Activity should have started");
+				string logcatPath = Path.Combine (XABuildPaths.TestOutputDirectory, b.ProjectDirectory, "logcat.log");
+				bool didDebuggerStart = WaitForDebuggerToStart (output: out string logcatOutput);
+				File.WriteAllText (logcatPath, logcatOutput);
+				Assert.IsTrue (didDebuggerStart, "Activity should have started");
 				// we need to give a bit of time for the debug server to start up.
 				WaitFor (2000);
 				session.LogWriter += (isStderr, text) => { Console.WriteLine (text); };

--- a/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
@@ -39,11 +39,11 @@ namespace Xamarin.Android.Build.Tests
 				File.WriteAllBytes (dexFile, apk.GetRaw (ApkContents.ClassesDex));
 				try {
 					string className = "Lcom/xamarin/forms/platform/android/FormsViewGroup;";
-					Assert.IsFalse (DexUtils.ContainsClass (className, dexFile, b.AndroidSdkDirectory), $"`{dexFile}` should *not* include `{className}`!");
+					Assert.IsFalse (DexUtils.ContainsClass (className, dexFile, AndroidSdkPath), $"`{dexFile}` should *not* include `{className}`!");
 					className = "Lmono/MonoRuntimeProvider;";
-					Assert.IsFalse (DexUtils.ContainsClass (className, dexFile, b.AndroidSdkDirectory), $"`{dexFile}` should include `{className}`!");
+					Assert.IsFalse (DexUtils.ContainsClass (className, dexFile, AndroidSdkPath), $"`{dexFile}` should include `{className}`!");
 					className = "Lmono/MonoPackageManager;";
-					Assert.IsTrue (DexUtils.ContainsClass (className, dexFile, b.AndroidSdkDirectory), $"`{dexFile}` should include `{className}`!");
+					Assert.IsTrue (DexUtils.ContainsClass (className, dexFile, AndroidSdkPath), $"`{dexFile}` should include `{className}`!");
 				} finally {
 					File.Delete (dexFile);
 				}

--- a/tools/msbuild-fuzzer/Program.cs
+++ b/tools/msbuild-fuzzer/Program.cs
@@ -25,7 +25,7 @@ namespace MSBuild.Fuzzer
 				AutomaticNuGetRestore = false,
 				CleanupAfterSuccessfulBuild = false,
 				CleanupOnDispose = true,
-				Root = Xamarin.Android.Build.Paths.TestOutputDirectory,
+				Root = XABuildPaths.TestOutputDirectory,
 			}) {
 				directory = Path.GetFullPath (Path.Combine (builder.Root, builder.ProjectDirectory));
 				if (Directory.Exists (directory))


### PR DESCRIPTION
Adds new `mac_msbuild_tests`,  `mac_msbuilddevice_tests`, and 
`mac_timezonedevice_tests` jobs to azure-pipelines.yaml to run the
msbuild tests against our installers.

Other changes and fixes:

  * Removes the dependency on the generated XABuildPaths.cs file so that
    test assemblies can be built and executed on different environments.

  * Standardizes Android SDK and NDK path and OS information lookup to
    reduce some code duplication and better allow for toolchain path
    overriding.

  * Updates Mono to 6.0.0.313 and .NET Core to 2.1.701 for our macOS
    building and test stages.

  * Introduces a new `UsesDevice` test category to allow us to filter
    execution of tests which will be skipped or behave differently when
    a device or emulator is attached.

  * Updates clean tests to ignore the `FileListAbsolute.txt` file now used
    by the clean target on macOS.

  * Updates the ParallelScope attribute for some multi source tests to
    avoid NuGet restore related issues occurring on macOS. This should
    ensure that dynamically generated test case instances don't run in
    parallel with eachother, but still allows for parallel execution
    against other tests or fixtures. I believe that this is not occurring
    on Jenkins because our test NuGet dependencies have been cached for
    quite some time. On Azure Pipelines, we're more often dealing with
    clean machines, and parallel attempts to restore/install into global
    cache paths were occasionally failing as shown below:

        NuGet.targets(121,5): error : Could not find file "/Users/vsts/.local/share/NuGet/v3-cache/1ca707a4d90792ce8e42453d4e350886a0fdaa4d$ps:_api.nuget.org_v3_index.json/nupkg_sqlitepclraw.core.1.1.8.dat"
        NuGet.targets(121,5): error : The file '/Users/vsts/.nuget/packages/xamarin.android.support.compat/28.0.0.1/.nupkg.metadata' already exists.
        NuGet.targets(121,5): error : Could not find file "/Users/vsts/.nuget/packages/xamarin.forms/3.4.0.1008975/2omeck77.h7w"

  * Attaches relevant build log file paths to the test result xml rather
    than dumping the full log to the test output. It's a bit painful to
    scroll through diagnostic build output to see which tests failed.
    Build logs can now be viewed directly in the 'attachments' tab of
    each test failure in Azure Pipelines:

![image](https://user-images.githubusercontent.com/2000163/61400968-72c09180-a89f-11e9-824e-10e2bcf1543e.png)
