### PR TITLE
[installer] Remove symlinks created in /Developer

### DIFF
--- a/build-tools/create-pkg/create-pkg.targets
+++ b/build-tools/create-pkg/create-pkg.targets
@@ -56,11 +56,6 @@
     <Exec WorkingDirectory="$(PayloadDir)\Library\Frameworks\Xamarin.Android.framework\Versions"
         Command="ln -fs $(XAVersion) Current"
     />
-    <!-- Required for VS Mac Updater -->
-    <MakeDir Directories="$(PayloadDir)\Developer" />
-    <Exec WorkingDirectory="$(PayloadDir)\Developer"
-        Command="ln -fs &quot;../Library/Frameworks/Xamarin.Android.framework/Versions/Current&quot; MonoAndroid"
-    />
     <Exec WorkingDirectory="$(MSBuildTargetsDir)\lib"
         Command="ln -fs host-$(HostOS) host"
     />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-macios/issues/6504
Context: https://github.com/xamarin/vsmac-xamarin-extensions/pull/245

This should allow our .pkg installer to execute on macOS Catalina.
