### PR TITLE
[Xamarin.Android.Build.Tasks] Dont use a temp location for AssemblyAttribute.cs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -22,6 +22,17 @@ namespace Xamarin.Android.Build.Tests
 		[TestCaseSource (nameof (ClassParseOptions))]
 		public void BuildBasicBindingLibrary (string classParser)
 		{
+			var targets = new List<string> {
+				"_ExtractJavaDocJars",
+				"ExportJarToXml",
+				"GenerateBindings",
+				"ResolveLibraryProjects",
+				"BuildDocumentation",
+				"_ResolveLibraryProjectImports",
+				"_BuildAdditionalResourcesCache",
+				"CoreCompile",
+			};
+
 			var proj = new XamarinAndroidBindingProject () {
 				IsRelease = true,
 			};
@@ -41,6 +52,11 @@ namespace Xamarin.Android.Build.Tests
 				};
 				foreach (var property in properties) {
 					Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, property + " = "), $"$({property}) should be set!");
+				}
+
+				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "second build should succeed");
+				foreach (var target in targets) {
+					Assert.IsTrue (b.Output.IsTargetSkipped (target), $"`{target}` should be skipped on second build!");
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -218,6 +218,16 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
           Condition="'$(TargetFrameworkProfile)' == ''"
       />
     </CreateProperty>
+    <CreateProperty Value="$(IntermediateOutputPath)$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)">
+      <Output TaskParameter="Value" PropertyName="TargetFrameworkMonikerAssemblyAttributesPath"
+       Condition="'$(TargetFrameworkMoniker)' != ''"
+    />
+    </CreateProperty>
+    <CreateItem Include="$(TargetFrameworkMonikerAssemblyAttributesPath)">
+      <Output TaskParameter="Include" ItemName="FileWrites"
+        Condition="'$(TargetFrameworkMonikerAssemblyAttributesPath)' != ''"
+    />
+    </CreateItem>
     <CreateItem Include="$(_JavaInteropReferences)">
       <Output TaskParameter="Include" ItemName="Reference" />
     </CreateItem>


### PR DESCRIPTION
Context #1240

As part of the build process MSBuild generates an
`AssemblyAttribute.cs` class, such as

	MonoAndroid,Version=v9.0.AssemblyAttributes.cs

This is the file which adds the `TargetFrameworkAttribute`
to the assembly. While investigating #1240 I noticed that
`_GenerateJavaStubs` was ALWAYS running, even on
incremental builds with no changes. Digging into the build
logs, `CoreCompile` was running because it thought one
of the binding project assemblies was newer..?

Digging in a bit more and I found this in the Binding Library
build output on the `CoreCompile` target.

	Input file "/var/folders/n_/vt_nzq1n04schx5yy2jgcgcw0000gn/T/MonoAndroid,Version=v9.0.AssemblyAttributes.cs" is newer than output file "obj/Release/Xamarin.Android.McwGen-Tests.pdb".

It turns out our binding targets were missing a few lines which
exist in the common targets. These line set the
`TargetFrameworkMonikerAssemblyAttributesPath` msbuild property
to be located in the `$(IntermediateOutputPath)`. If this
value is NOT set it turns out MSBuild defaults to dropping
this file into a temp directory. That means it can be cleaned
up at any point which will trigger a full build. :face_palm.

So lets use the same few lines from the common targets to
make sure we generate this file in our `$(IntermediateOutputPath)`.
This stopped `_GenerateJavaStubs` from running when there were
no changes (as expected).

I updated one of our binding tests to check to make sure certain
targets DO NOT run on an incremental build. Similar to what we
do with our application targets.