### PR TITLE
[Xamarin.Android.Build.Tasks] fix Inputs for aapt2

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
@@ -126,8 +126,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </Target>
 
 <Target Name="_CompileResources"
-    Condition=" '$(_AndroidUseAapt2)' == 'True' "
-    Inputs="@(AndroidResource)"
+    Condition=" '$(_AndroidUseAapt2)' == 'True' And '@(AndroidResource)' != '' "
+    Inputs="$(MSBuildAllProjects);$(_AndroidBuildPropertiesCache);@(AndroidResource)"
     Outputs="$(_AndroidLibraryFlatArchivesDirectory)\_CompileResources.stamp"
     DependsOnTargets="$(_BeforeCompileResources);_ConvertResourcesCases"
   >

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -681,5 +681,28 @@ namespace Lib2
 			Assert.IsTrue (task.Execute (), $"{nameof (ReadLibraryProjectImportsCache)} should have succeeded.");
 			return task;
 		}
+
+		[Test]
+		public void InvalidAndroidResource ([Values (true, false)] bool useAapt2)
+		{
+			var invalidXml = new AndroidItem.AndroidResource (@"Resources\values\ids.xml") {
+				TextContent = () => "<?xml version=\"1.0\" encoding=\"utf-8\" ?><resources><item/></resources>"
+			};
+
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				b.ThrowOnBuildFailure = false;
+
+				proj.OtherBuildItems.Add (invalidXml);
+				Assert.IsFalse (b.Build (proj), "Build should *not* have succeeded.");
+
+				proj.OtherBuildItems.Remove (invalidXml);
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+
+				proj.OtherBuildItems.Add (invalidXml);
+				Assert.IsFalse (b.Build (proj), "Build should *not* have succeeded.");
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3336

@brendanzagaeski found a really weird bug:

1. Build a project with aapt2 with an invalid XML file.
2. Remove the file from the project, build again.
3. Add the file back, build a third time.

On step 3 & beyond, no build error is given--meaning *something* must
be out of date.

I was able to reproduce the problem in a test, and saw it only occurs
with aapt2.

The `_CompileResources` MSBuild target was skipped:

    Skipping target "_CompileResources" because all output files are up-to-date with respect to the input files.
    Input files: Resources\values\ids.xml;Resources\drawable-hdpi\Icon.png;Resources\drawable-mdpi\Icon.png;Resources\drawable-xhdpi\Icon.png;Resources\drawable-xxhdpi\Icon.png;Resources\drawable-xxxhdpi\Icon.png;Resources\layout\Main.axml;Resources\values\Strings.xml
    Output files: obj\Debug\flata\\_CompileResources.stamp

But `_UpdateAndroidResgen` was *not* skipped:

    Building target "_UpdateAndroidResgen" completely.
    Input file "C:\src\xamarin-android\bin\TestDebug\temp\InvalidAndroidResourceTrue\obj\Debug\res\values\ids.xml" is newer than output file "obj\Debug\R.cs.flag".

Reviewing the `Inputs` of `_CompileResources`, it seems like we need
to include the following files to better match `_UpdateAndroidResgen`:

* `$(MSBuildAllProjects)` - so if the `.csproj` changes.
* `$(_AndroidBuildPropertiesCache)` - so if any of the important
  Xamarin.Android MSBuild properties change.

After adding these `Inputs`, I also had to add a `Condition` to skip
the `_CompileResources` target entirely if `@(AndroidResource)` was
blank. Otherwise projects like `Xamarin.Android.NUnitLite` did not
build. This was skipping before because the `Inputs` were empty.