### PR TITLE
[Xamarin.Android.Build.Tests] Fix Lint Warnings

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1545,6 +1545,8 @@ namespace App1
 		{
 			FixLintOnWindows ();
 
+			string disabledIssues = "StaticFieldLeak,ObsoleteSdkInt,AllowBackup";
+
 			var proj = new XamarinAndroidApplicationProject () {
 				PackageReferences = {
 					KnownPackages.AndroidSupportV4_27_0_2_1,
@@ -1553,7 +1555,7 @@ namespace App1
 			};
 			proj.UseLatestPlatformSdk = false;
 			proj.SetProperty ("AndroidLintEnabled", true.ToString ());
-			proj.SetProperty ("AndroidLintDisabledIssues", "StaticFieldLeak,ObsoleteSdkInt,AllowBackup");
+			proj.SetProperty ("AndroidLintDisabledIssues", disabledIssues);
 			proj.SetProperty ("AndroidLintEnabledIssues", "");
 			proj.SetProperty ("AndroidLintCheckIssues", "");
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("public class MainActivity : Activity", @"
@@ -1581,8 +1583,12 @@ namespace App1
 				}
 			});
 			using (var b = CreateApkBuilder ("temp/CheckLintErrorsAndWarnings", cleanupOnDispose: false)) {
+				int maxApiLevel = b.GetMaxInstalledPlatform ();
 				string apiLevel;
 				proj.TargetFrameworkVersion = b.LatestTargetFrameworkVersion (out apiLevel);
+				if (int.TryParse (apiLevel, out int a) && a < maxApiLevel)
+					disabledIssues += ",OldTargetApi";
+				proj.SetProperty ("AndroidLintDisabledIssues", disabledIssues);
 				proj.AndroidManifest = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <manifest xmlns:android=""http://schemas.android.com/apk/res/android"" android:versionCode=""1"" android:versionName=""1.0"" package=""UnamedProject.UnamedProject"">
 	<uses-sdk android:minSdkVersion=""24"" android:targetSdkVersion=""{APILEVEL}"" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -235,6 +235,24 @@ namespace Xamarin.ProjectTools
 			}
 		}
 
+		public int GetMaxInstalledPlatform ()
+		{
+			using (var builder = new Builder ()) {
+				builder.ResolveSdks ();
+				int result = 0;
+				foreach (var dir in Directory.EnumerateDirectories (Path.Combine (builder.AndroidSdkDirectory, "platforms"))) {
+					int version;
+					string v = Path.GetFileName (dir).Replace ("android-", "");
+					if (!int.TryParse (v, out version))
+						continue;
+					if (version < result)
+						continue;
+					result = version;
+				}
+				return result;
+			}
+		}
+
 		static string GetApiLevelFromInfoPath (string androidApiInfo)
 		{
 			if (!File.Exists (androidApiInfo))


### PR DESCRIPTION
We can get into a situation where we dont
support a new api level, BUT our tooling
installed it in the `platforms` folder of
the SDK.

This means we get the following warning

	warning XA0102:  Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the android.os.Build.VERSION_CODES javadoc for details. [OldTargetApi]

What we need to do in the test is ignore this
warning, IF we are in that particular situation.