### PR TITLE
[Xamarin.Android.Build.Tasks] Fix issues with re running CilStrip.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CilStrip.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CilStrip.cs
@@ -20,6 +20,9 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public ITaskItem[] ResolvedAssemblies { get; set; }
 
+		[Required]
+		public ITaskItem ApkOutputPath { get; set; }
+
 		public CilStrip ()
 		{
 		}
@@ -51,11 +54,22 @@ namespace Xamarin.Android.Tasks
 			if (!Directory.Exists (nonstripDir))
 				Directory.CreateDirectory (nonstripDir);
 
+			var timestampFileDate = File.GetLastWriteTimeUtc (ApkOutputPath.ItemSpec);
+
 			foreach (var assembly in ResolvedAssemblies) {
 				string assemblyPath = Path.GetFullPath (assembly.ItemSpec);
 				string nonstripPath = Path.Combine (nonstripDir, Path.GetFileName (assemblyPath));
 
-				File.Move (assemblyPath, nonstripPath);
+				Log.LogDebugMessage ($"Moving {assemblyPath} to {nonstripPath}");
+
+				var srcmodifiedDate = File.GetLastWriteTimeUtc (assemblyPath);
+				
+				if (srcmodifiedDate < timestampFileDate) {
+					Log.LogDebugMessage ($"Skipping strip of IL for {assembly.ItemSpec}. Assembly has already been stripped.");
+					continue;
+				}
+
+				File.Copy (assemblyPath, nonstripPath, overwrite: true);
 
 				if (!RunCilStrip (nonstripPath, assemblyPath)) {
 					Log.LogCodedError ("XA3001", "Could not strip IL of assembly: {0}", assembly.ItemSpec);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -803,5 +803,96 @@ namespace Lib2
 				FileAssert.Exists (path);
 			}
 		}
+		
+#pragma warning disable 414
+		static object [] AotChecks () => new object [] {
+			new object[] {
+				/* supportedAbis */   "arm64-v8a",
+				/* androidAotMode */  "", // None, Normal, Hybrib, Full
+				/* aotAssemblies */   false,
+				/* expectedResult */  true,
+			},
+			new object[] {
+				/* supportedAbis */   "arm64-v8a",
+				/* androidAotMode */  "Normal", // None, Normal, Hybrid, Full
+				/* aotAssemblies */   true,
+				/* expectedResult */  true,
+			},
+			new object[] {
+				/* supportedAbis */   "arm64-v8a",
+				/* androidAotMode */  "Normal", // None, Normal, Hybrid, Full
+				/* aotAssemblies */   false,
+				/* expectedResult */  true,
+			},
+			new object[] {
+				/* supportedAbis */   "arm64-v8a",
+				/* androidAotMode */  "Full", // None, Normal, Hybrid, Full
+				/* aotAssemblies */   true,
+				/* expectedResult */  false,
+			},
+			new object[] {
+				/* supportedAbis */   "arm64-v8a",
+				/* androidAotMode */  "Full", // None, Normal, Hybrid, Full
+				/* aotAssemblies */   false,
+				/* expectedResult */  false,
+			},
+			new object[] {
+				/* supportedAbis */   "arm64-v8a",
+				/* androidAotMode */  "Hybrid", // None, Normal, Hybrid, Full
+				/* aotAssemblies */   true,
+				/* expectedResult */  true,
+			},
+			new object[] {
+				/* supportedAbis */   "arm64-v8a",
+				/* androidAotMode */  "Hybrid", // None, Normal, Hybrid, Full
+				/* aotAssemblies */   false,
+				/* expectedResult */  true,
+			},
+		};
+#pragma warning restore 414
+
+		[Test]
+		[TestCaseSource (nameof (AotChecks))]
+		public void BuildIncrementalAot (string supportedAbis, string androidAotMode, bool aotAssemblies, bool expectedResult)
+		{
+			var targets = new string [] {
+				"_RemoveRegisterAttribute",
+				"_BuildApkEmbed",
+			};
+			var path = Path.Combine ("temp", $"BuildAotApplication_{supportedAbis}_{androidAotMode}_{aotAssemblies}_{expectedResult}");
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				BundleAssemblies = false,
+				AotAssemblies = aotAssemblies,
+			};
+			if (!string.IsNullOrEmpty (androidAotMode))
+			    proj.SetProperty ("AndroidAotMode", androidAotMode);
+			using (var b = CreateApkBuilder (path)) {
+				if (!b.CrossCompilerAvailable (supportedAbis))
+					Assert.Ignore ($"Cross compiler for {supportedAbis} was not available");
+				if (!b.GetSupportedRuntimes ().Any (x => supportedAbis == x.Abi))
+					Assert.Ignore ($"Runtime for {supportedAbis} was not available.");
+				b.ThrowOnBuildFailure = false;
+				b.Verbosity = LoggerVerbosity.Diagnostic;
+				Assert.AreEqual (expectedResult, b.Build (proj), "Build should have {0}.", expectedResult ? "succeeded" : "failed");
+				if (!expectedResult)
+					return;
+				foreach (var target in targets) {
+					Assert.IsFalse (b.Output.IsTargetSkipped (target), $"`{target}` should *not* be skipped on first build!");
+				}
+				
+				Assert.IsTrue (b.Build (proj), "Second build should have succeeded.");
+				foreach (var target in targets) {
+					Assert.IsTrue (b.Output.IsTargetSkipped (target), $"`{target}` should be skipped on second build!");
+				}
+
+				proj.Touch ("MainActivity.cs");
+
+				Assert.IsTrue (b.Build (proj), "Third build should have succeeded.");
+				foreach (var target in targets) {
+					Assert.IsFalse (b.Output.IsTargetSkipped (target), $"`{target}` should *not* be skipped on third build!");
+				}
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -227,7 +227,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<!-- Ahead-of-time compilation properties -->
 	<AotAssemblies Condition=" '$(AndroidEnableProfiledAot)' == 'True' ">True</AotAssemblies>
 	<AndroidAotMode Condition=" '$(AndroidAotMode)' == '' And '$(AotAssemblies)' == 'True' ">Normal</AndroidAotMode>
-	<AotAssemblies Condition=" '$(AndroidAotMode)' != '' ">True</AotAssemblies>
+	<AotAssemblies Condition=" '$(AndroidAotMode)' != '' And '$(AndroidAotMode)' != 'None' ">True</AotAssemblies>
 	<AotAssemblies Condition=" '$(AotAssemblies)' == '' ">False</AotAssemblies>
 
 	<AndroidExplicitCrunch Condition=" '$(AndroidExplicitCrunch)' == '' ">False</AndroidExplicitCrunch>
@@ -545,11 +545,12 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   />
   <Touch
       Condition=" '$(DesignTimeBuild)' != 'True' "
-      Files="$(_AndroidStampDirectory)_BuildAdditionalResourcesCache.stamp"
+      Files="$(_AndroidStampDirectory)_BuildAdditionalResourcesCache.stamp;$(MonoAndroidIntermediateResourceCache).stamp"
       AlwaysCreate="True"
   />
   <ItemGroup>
     <FileWrites Include="$(_AndroidResourcePathsCache)" Condition=" Exists ('$(_AndroidResourcePathsCache)') " />
+    <FileWrites Include="$(MonoAndroidIntermediateResourceCache).stamp" Condition=" Exists ('$(MonoAndroidIntermediateResourceCache).stamp') " />
   </ItemGroup>
 </Target>
 
@@ -2603,7 +2604,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_RemoveRegisterAttribute"
   DependsOnTargets="_PrepareAssemblies"
-  Inputs="@(_ResolvedFrameworkAssemblies);$(_AndroidBuildPropertiesCache)"
+  Inputs="$(_AndroidLinkFlag)"
   Outputs="$(_RemoveRegisterFlag)"
   Condition="'$(AndroidLinkMode)' != 'None' AND '$(AndroidUseSharedRuntime)' != 'true'">
 
@@ -2815,6 +2816,7 @@ because xbuild doesn't support framework reference assemblies.
 	Condition=" '$(AndroidAotMode)' == 'Hybrid' And '$(AotAssemblies)' == 'True' "
 	AndroidAotMode="$(AndroidAotMode)"
 	ToolPath="$(_MonoAndroidToolsDirectory)"
+	ApkOutputPath="$(_BuildApkEmbedOutputs)"
 	ResolvedAssemblies="@(_ResolvedAssemblies)">
   </CilStrip> 
 


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/1240

The `CilStrp` task was not able to handle being called incrementally. When called a second time the resulting error would be raised.

```
error XA3001: System.IO.IOException: The file '/Users/dean/Projects/Foo5F/Foo/obj/Release/android/assets/non-stripped/Foo.dll' already exists. 
at System.IO.FileSystem.LinkOrCopyFile (System.String sourceFullPath, System.String destFullPath) [0x000b9] in <06589f46f7f64859943a6a461f88c56e>:0
at System.IO.FileSystem.MoveFile (System.String sourceFullPath, System.String destFullPath) [0x0003a] in <06589f46f7f64859943a6a461f88c56e>:0
at System.IO.File.Move (System.String sourceFileName, System.String destFileName) [0x00083] in <06589f46f7f64859943a6a461f88c56e>:0
at Xamarin.Android.Tasks.CilStrip.DoExecute () [0x000a8] in <fd1a3c6c66de470d989dd70ca1f91267>:0
at Xamarin.Android.Tasks.CilStrip.Execute () [0x00000] in <fd1a3c6c66de470d989dd70ca1f91267>:0
```


This commit make sure we do not try to strip an assembly if it has already been stripped. It also adds a new Unit Test to make sure the build system behaves as we expect.