### PR TITLE
[Xamarin.Android.Build.Tasks] support Application.NetworkSecurityConfig

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/ApplicationAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/ApplicationAttribute.Partial.cs
@@ -164,8 +164,7 @@ namespace Android.App {
 			  "NetworkSecurityConfig",
 			  "networkSecurityConfig",
 			  self          => self._NetworkSecurityConfig,
-			  (self, value) => self._NetworkSecurityConfig = (string) value,
-			  typeof (Type)
+			  (self, value) => self._NetworkSecurityConfig = (string) value
 			}, {
 			  "Permission",
 			  "permission",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3932,5 +3932,48 @@ public class MyWorker : Worker
 				Assert.IsTrue (b.Build (proj), $"{b.Target} should have succeeded.");
 			}
 		}
+
+		[Test]
+		public void NetworkSecurityConfig ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.Sources.Add (new BuildItem ("Compile", "CustomApp.cs") { TextContent = () => @"
+using System;
+using Android.App;
+using Android.Runtime;
+
+namespace UnnamedProject
+{
+	[Application(Name = ""com.xamarin.android.CustomApp"", NetworkSecurityConfig = ""@xml/network_security_config"")]
+	public class CustomApp : Application
+	{
+		public CustomApp(IntPtr handle, JniHandleOwnership ownerShip) : base(handle, ownerShip) { }
+	}
+}" });
+			proj.AndroidResources.Add (new AndroidItem.AndroidResource (@"Resources\xml\network_security_config.xml") {
+				TextContent = () =>
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<network-security-config>
+    <domain-config>
+        <domain includeSubdomains=""true"">example.com</domain>
+        <trust-anchors>
+            <certificates src=""@raw/my_ca""/>
+        </trust-anchors>
+    </domain-config>
+</network-security-config>"
+			});
+			proj.AndroidResources.Add (new AndroidItem.AndroidResource (@"Resources\raw\my_ca") {
+				BinaryContent = () => new byte [0], // doesn't have to be real, just *exist*
+			});
+
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+
+				var manifest = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "AndroidManifest.xml");
+				FileAssert.Exists (manifest);
+				var contents = File.ReadAllText (manifest);
+				StringAssert.Contains ("android:networkSecurityConfig=\"@xml/network_security_config\"", contents);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3276
Context: https://developer.android.com/training/articles/security-config

A custom `Android.App.Application` subclass with the attribute:

    [Application(NetworkSecurityConfig = "@xml/network_security_config")]

Causes the `<GenerateJavaStubs/>` MSBuild task to throw:

    The "GenerateJavaStubs" task failed unexpectedly.
        System.ArgumentNullException: Value cannot be null.
        Parameter name: fullName
        at Mono.Cecil.AssemblyNameReference.Parse(String fullName)
        at Xamarin.Android.Manifest.ManifestDocumentElement.ResolveType(String type, ICustomAttributeProvider provider, IAssemblyResolver resolver)
        at Xamarin.Android.Manifest.ManifestDocumentElement1.<>c.<.cctor>b__25_12(Object value, ICustomAttributeProvider p, IAssemblyResolver r, Int32 v)
        at Xamarin.Android.Manifest.ManifestDocumentElement1.ToAttributeValue(String name, T value, ICustomAttributeProvider provider, IAssemblyResolver resolver, Int32 targetSdkVersion)
        at Xamarin.Android.Manifest.ManifestDocumentElement1.ToAttribute(String name, T value, String packageName, ICustomAttributeProvider provider, IAssemblyResolver resolver, Int32 targetSdkVersion)
        at Xamarin.Android.Manifest.ManifestDocumentElement1.<>c__DisplayClass8_0.b__1(String e)
        at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
        at System.Linq.Enumerable.WhereEnumerableIterator1.MoveNext()
        at System.Xml.Linq.XContainer.AddContentSkipNotify(Object content)
        at Xamarin.Android.Manifest.ManifestDocumentElement1.ToElement(T value, ICollection1 specified, String packageName, ICustomAttributeProvider provider, IAssemblyResolver resolver, Int32 targetSdkVersion)
        at Android.App.ApplicationAttribute.ToElement(IAssemblyResolver resolver, String packageName)
        at Xamarin.Android.Tasks.ManifestDocument.CreateApplicationElement(XElement manifest, String applicationClass, List1 subclasses, List1 selectedWhitelistAssemblies)
        at Xamarin.Android.Tasks.ManifestDocument.Merge(List1 subclasses, List1 selectedWhitelistAssemblies, String applicationClass, Boolean embed, String bundledWearApplicationName, IEnumerable1 mergedManifestDocuments)
        at Xamarin.Android.Tasks.GenerateJavaStubs.Run(DirectoryAssemblyResolver res)
        at Xamarin.Android.Tasks.GenerateJavaStubs.Execute()
        at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
        at Microsoft.Build.BackEnd.TaskBuilder.d__26.MoveNext()

When I attached a debugger on Windows, it appeared the following
method was treating the `string` value as a .NET type that can be
resolved:

    static string ToString (string value, ICustomAttributeProvider provider, IAssemblyResolver resolver)
    {
        var typeDef = ResolveType (value, provider, resolver);
        return ToString (typeDef);
    }

The `value` is `@xml/network_security_config`, which is not a
`System.Type` at all?

It looks like our mapping for `networkSecurityConfig` in
`ApplicationAttribute.Partial.cs` had marked this value as a
`System.Type` when it should be `string`.

After making this change, things seem to work fine. Viewing the APK in
Android Studio, the final/compiled `AndroidManifest.xml` looked
correct:

    <application
        android:label="UnnamedProject"
        android:icon="@ref/0x7f010000"
        android:name="com.xamarin.android.CustomApp"
        android:debuggable="true"
        android:allowBackup="true"
        android:networkSecurityConfig="@ref/0x7f060000">

I was able to install and run this APK on a device.