### PR TITLE
[Xamarin.Android.Build.Tasks] remove the linksrc directory

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
@@ -62,7 +62,7 @@ namespace MonoDroid.Tuner
 
 			if (options.LinkNone) {
 				pipeline.AppendStep (new FixAbstractMethodsStep ());
-				pipeline.AppendStep (new OutputStep ());
+				pipeline.AppendStep (new OutputStepWithTimestamps ());
 				return pipeline;
 			}
 
@@ -117,7 +117,7 @@ namespace MonoDroid.Tuner
 			pipeline.AppendStep (new StripEmbeddedLibraries ());
 			// end monodroid specific
 			pipeline.AppendStep (new RegenerateGuidStep ());
-			pipeline.AppendStep (new OutputStep ());
+			pipeline.AppendStep (new OutputStepWithTimestamps ());
 
 			return pipeline;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/OutputStepWithTimestamps.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/OutputStepWithTimestamps.cs
@@ -1,0 +1,50 @@
+using System.IO;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Mono.Linker.Steps;
+using Xamarin.Android.Tools;
+
+namespace MonoDroid.Tuner
+{
+	/// <summary>
+	/// A subclass of OutputStep that overrides CopyAssembly and timestamps files properly with Files.CopyIfChanged
+	/// * original source from: https://github.com/mono/linker/blob/aa65acca5e41fbc1f8f597799381b853049704ff/src/linker/Linker.Steps/OutputStep.cs#L198-L231
+	/// </summary>
+	class OutputStepWithTimestamps : OutputStep
+	{
+		static FileInfo GetOriginalAssemblyFileInfo (AssemblyDefinition assembly)
+		{
+			return new FileInfo (assembly.MainModule.FileName);
+		}
+
+		protected override void CopyAssembly (AssemblyDefinition assembly, string directory)
+		{
+			// Special case.  When an assembly has embedded pdbs, link symbols is not enabled, and the assembly's action is copy,
+			// we want to match the behavior of assemblies with the other symbol types and end up with an assembly that does not have symbols.
+			// In order to do that, we can't simply copy files.  We need to write the assembly without symbols
+			if (assembly.MainModule.HasSymbols && !Context.LinkSymbols && assembly.MainModule.SymbolReader is EmbeddedPortablePdbReader) {
+				WriteAssembly (assembly, directory, new WriterParameters ());
+				return;
+			}
+
+			FileInfo fi = GetOriginalAssemblyFileInfo (assembly);
+			string target = Path.GetFullPath (Path.Combine (directory, fi.Name));
+			string source = fi.FullName;
+			if (source == target)
+				return;
+
+			Files.CopyIfChanged (source, target);
+
+			if (!Context.LinkSymbols)
+				return;
+
+			var mdb = source + ".mdb";
+			if (File.Exists (mdb))
+				Files.CopyIfChanged (mdb, target + ".mdb");
+
+			var pdb = Path.ChangeExtension (source, "pdb");
+			if (File.Exists (pdb))
+				Files.CopyIfChanged (pdb, Path.ChangeExtension (target, "pdb"));
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -504,11 +504,9 @@ namespace UnamedProject
 				// Xamarin.Android unless fastdev is enabled.
 				foreach (var file in new [] { "typemap.mj", "typemap.jm" }) {
 					var info = new FileInfo (Path.Combine (intermediate, "android", file));
-					if (!info.Exists) {
-						Assert.Ignore ($"{info.Name} does not exist, timestamp check skipped");
-						continue;
+					if (info.Exists) {
+						Assert.IsTrue (info.LastWriteTimeUtc > start, $"`{file}` is older than `{start}`, with a timestamp of `{info.LastWriteTimeUtc}`!");
 					}
-					Assert.IsTrue (info.LastWriteTimeUtc > start, $"`{file}` is older than `{start}`, with a timestamp of `{info.LastWriteTimeUtc}`!");
 				}
 
 				//One last build with no changes
@@ -1188,12 +1186,6 @@ namespace UnnamedProject {
 					"UnnamedProject.dll.mdb must be copied to the Intermediate directory");
 				Assert.IsTrue (b.Build (proj), "second build failed");
 				Assert.IsTrue (
-					b.Output.IsTargetSkipped ("_CopyMdbFiles"),
-					"the _CopyMdbFiles target should be skipped");
-				Assert.IsTrue (
-					b.Output.IsTargetSkipped ("_CopyPdbFiles"),
-					"the _CopyPdbFiles target should be skipped");
-				Assert.IsTrue (
 					File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android/assets/UnnamedProject.dll.mdb")) ||
 					File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android/assets/UnnamedProject.pdb")),
 					"UnnamedProject.dll.mdb must be copied to the Intermediate directory");
@@ -1252,9 +1244,11 @@ namespace App1
 				Assert.IsTrue (libb.Build (lib), "Library1 Build should have succeeded.");
 				using (var b = CreateApkBuilder (Path.Combine (path, "App1"))) {
 					Assert.IsTrue (b.Build (proj), "App1 Build should have succeeded.");
-					var assetsPdb = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "assets", "Library1.pdb");
-					var linkDst = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "linkdst", "Library1.pdb");
-					var linkSrc = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "linksrc", "Library1.pdb");
+					var intermediate = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath);
+					var outputPath = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath);
+					var assetsPdb = Path.Combine (intermediate, "android", "assets", "Library1.pdb");
+					var linkDst = Path.Combine (intermediate, "linkdst", "Library1.pdb");
+					var binSrc = Path.Combine (outputPath, "Library1.pdb");
 					Assert.IsTrue (
 						File.Exists (assetsPdb),
 						"Library1.pdb must be copied to Intermediate directory");
@@ -1262,29 +1256,27 @@ namespace App1
 						File.Exists (linkDst),
 						"Library1.pdb should not be copied to linkdst directory because it has no Abstrsact methods to fix up.");
 					Assert.IsTrue (
-						File.Exists (linkSrc),
-						"Library1.pdb must be copied to linksrc directory");
-					var outputPath = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath);
+						File.Exists (binSrc),
+						"Library1.pdb must be copied to bin directory");
 					using (var apk = ZipHelper.OpenZip (Path.Combine (outputPath, proj.PackageName + "-Signed.apk"))) {
 						var data = ZipHelper.ReadFileFromZip (apk, "assemblies/Library1.pdb");
 						if (data == null)
 							data = File.ReadAllBytes (assetsPdb);
-						var filedata = File.ReadAllBytes (linkSrc);
-						Assert.AreEqual (filedata.Length, data.Length, "Library1.pdb in the apk should match {0}", linkSrc);
+						var filedata = File.ReadAllBytes (binSrc);
+						Assert.AreEqual (filedata.Length, data.Length, "Library1.pdb in the apk should match {0}", binSrc);
 					}
-					linkDst = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "linkdst", "App1.pdb");
-					linkSrc = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "linksrc", "App1.pdb");
+					linkDst = Path.Combine (intermediate, "linkdst", "App1.pdb");
+					binSrc = Path.Combine (outputPath, "App1.pdb");
 					Assert.IsTrue (
 						File.Exists (linkDst),
 						"App1.pdb should be copied to linkdst directory because it has Abstrsact methods to fix up.");
 					Assert.IsTrue (
-						File.Exists (linkSrc),
-						"App1.pdb must be copied to linksrc directory");
-					FileAssert.AreEqual (linkSrc, linkDst, "{0} and {1} should not differ.", linkSrc, linkDst);
-					linkDst = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "linkdst", "App1.dll");
-					linkSrc = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "linksrc", "App1.dll");
-					FileAssert.AreEqual (linkSrc, linkDst, "{0} and {1} should match.", linkSrc, linkDst);
-
+						File.Exists (binSrc),
+						"App1.pdb must be copied to bin directory");
+					FileAssert.AreEqual (binSrc, linkDst, "{0} and {1} should not differ.", binSrc, linkDst);
+					linkDst = Path.Combine (intermediate, "linkdst", "App1.dll");
+					binSrc = Path.Combine (outputPath, "App1.dll");
+					FileAssert.AreEqual (binSrc, linkDst, "{0} and {1} should match.", binSrc, linkDst);
 				}
 			}
 		}
@@ -1333,15 +1325,9 @@ namespace App1
 					File.Exists (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "assets", "NetStandard16.pdb")),
 					"NetStandard16.pdb must be copied to Intermediate directory");
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "second build failed");
-				Assert.IsTrue (
-					b.Output.IsTargetSkipped ("_CopyMdbFiles"),
-					"the _CopyMdbFiles target should be skipped");
 				var lastTime = File.GetLastWriteTimeUtc (pdbToMdbPath);
 				pdb.Timestamp = DateTimeOffset.UtcNow;
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "third build failed");
-				Assert.IsFalse (
-					b.Output.IsTargetSkipped ("_CopyMdbFiles"),
-					"the _CopyMdbFiles target should not be skipped");
 				Assert.Less (lastTime,
 					File.GetLastWriteTimeUtc (pdbToMdbPath),
 					"{0} should have been updated", pdbToMdbPath);
@@ -2855,16 +2841,10 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				}
 				b.BuildLogFile = "build1.log";
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "second build failed");
-				Assert.IsTrue (
-					b.Output.IsTargetSkipped ("_CopyMdbFiles"),
-					"the _CopyMdbFiles target should be skipped");
 				b.BuildLogFile = "build2.log";
 				var lastTime = File.GetLastWriteTimeUtc (pdbToMdbPath);
 				pdb.Timestamp = DateTimeOffset.UtcNow;
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "third build failed");
-				Assert.IsFalse (
-					b.Output.IsTargetSkipped ("_CopyMdbFiles"),
-					"the _CopyMdbFiles target should not be skipped");
 				Assert.Less (lastTime,
 					File.GetLastWriteTimeUtc (pdbToMdbPath),
 					"{0} should have been updated", pdbToMdbPath);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -345,13 +345,11 @@ namespace Lib2
 		public void AppProjectTargetsDoNotBreak ()
 		{
 			var targets = new List<string> {
-				"_CopyIntermediateAssemblies",
 				"_GeneratePackageManagerJava",
 				"_ResolveLibraryProjectImports",
 				"_BuildAdditionalResourcesCache",
 				"_CleanIntermediateIfNuGetsChange",
 				"_CopyConfigFiles",
-				"_CopyPdbFiles",
 			};
 			var proj = new XamarinFormsAndroidApplicationProject {
 				OtherBuildItems = {
@@ -366,7 +364,6 @@ namespace Lib2
 			if (IsWindows) {
 				//NOTE: pdb2mdb will run on Windows on the current project's symbols if DebugType=Full
 				proj.SetProperty (proj.DebugProperties, "DebugType", "Full");
-				targets.Add ("_CopyMdbFiles");
 				targets.Add ("_ConvertPdbFiles");
 			}
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -66,8 +66,7 @@ namespace Xamarin.Android.Build.Tests
 				var allFilesInArchive = Directory.GetFiles (archivePath, "*", SearchOption.AllDirectories);
 				string extension = "dll";
 				Assert.IsTrue (allFilesInArchive.Any (x => Path.GetFileName (x) == $"{proj.ProjectName}.{extension}"), $"{proj.ProjectName}.{extension} should exist in {archivePath}");
-				//NOTE: Windows is still generating mdb files here
-				extension = IsWindows ? "dll.mdb" : "pdb";
+				extension = "pdb";
 				Assert.IsTrue (allFilesInArchive.Any (x => Path.GetFileName (x) == $"{proj.ProjectName}.{extension}"), $"{proj.ProjectName}.{extension} should exist in {archivePath}");
 
 				string intermediateOutputDir = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Linker\MonoDroid.Tuner\Linker.cs" />
     <Compile Include="Linker\MonoDroid.Tuner\LinkerOptions.cs" />
     <Compile Include="Linker\MonoDroid.Tuner\MonoDroidMarkStep.cs" />
+    <Compile Include="Linker\MonoDroid.Tuner\OutputStepWithTimestamps.cs" />
     <Compile Include="Linker\MonoDroid.Tuner\PreserveHttpAndroidClientHandler.cs" />
     <Compile Include="Linker\MonoDroid.Tuner\StripEmbeddedLibraries.cs" />
     <Compile Include="Tasks\Aapt.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2056,7 +2056,7 @@ because xbuild doesn't support framework reference assemblies.
 
     <PropertyGroup>
       <_MainAssembly Condition=" '$(AndroidGenerateJniMarshalMethods)' != 'True' ">$(TargetPath)</_MainAssembly>
-      <_MainAssembly Condition=" '$(AndroidGenerateJniMarshalMethods)' == 'True' ">$(_JniMarshalMethodsInputDir)$(TargetFileName)</_MainAssembly>
+      <_MainAssembly Condition=" '$(AndroidGenerateJniMarshalMethods)' == 'True' ">$(_JniMarshalMethodsOutputDir)$(TargetFileName)</_MainAssembly>
     </PropertyGroup>
     <ItemGroup Condition=" '$(AndroidGenerateJniMarshalMethods)' != 'True' ">
       <_AssembliesToLink Include="@(ResolvedAssemblies)" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1192,8 +1192,8 @@ because xbuild doesn't support framework reference assemblies.
 <PropertyGroup>
 	<MonoAndroidResDirIntermediate>$(IntermediateOutputPath)res\</MonoAndroidResDirIntermediate>
 	<MonoAndroidIntermediateAssetsDir>$(IntermediateOutputPath)android\assets\</MonoAndroidIntermediateAssetsDir>
-	<MonoAndroidLinkerInputDir>$(IntermediateOutputPath)linksrc\</MonoAndroidLinkerInputDir>
 	<MonoAndroidIntermediateAssemblyDir>$(IntermediateOutputPath)android\assets\</MonoAndroidIntermediateAssemblyDir>
+	<_JniMarshalMethodsOutputDir>$(IntermediateOutputPath)jnisrc\</_JniMarshalMethodsOutputDir>
 	<MonoAndroidIntermediateAssemblyTempDir>$(IntermediateOutputPath)linkdst\</MonoAndroidIntermediateAssemblyTempDir>
 	<MonoAndroidResourcePrefix Condition="'$(MonoAndroidResourcePrefix)' == ''">Resources</MonoAndroidResourcePrefix>
 	<MonoAndroidIntermediate>$(IntermediateOutputPath)</MonoAndroidIntermediate>
@@ -1202,7 +1202,6 @@ because xbuild doesn't support framework reference assemblies.
 	<_AndroidAotBinDirectory>$(IntermediateOutputPath)aot</_AndroidAotBinDirectory>
 	<_AndroidResgenFlagFile>$(IntermediateOutputPath)R.cs.flag</_AndroidResgenFlagFile>
 	<_AndroidResFlagFile>$(IntermediateOutputPath)res.flag</_AndroidResFlagFile>
-	<_AndroidJniMarshalMethodsFlag>$(IntermediateOutputPath)jnimarshalmethods.flag</_AndroidJniMarshalMethodsFlag>
 	<_AndroidLinkFlag>$(IntermediateOutputPath)link.flag</_AndroidLinkFlag>
 	<_AndroidApkPerAbiFlagFile>$(IntermediateOutputPath)android\bin\apk_per_abi.flag</_AndroidApkPerAbiFlagFile>
 	<_AndroidDebugKeyStoreFlag>$(IntermediateOutputPath)android_debug_keystore.flag</_AndroidDebugKeyStoreFlag>
@@ -1249,6 +1248,7 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="AndroidUseLatestPlatformSdk=$(AndroidUseLatestPlatformSdk)" />
 		<_PropertyCacheItems Include="TargetFrameworkVersion=$(TargetFrameworkVersion)" />
 		<_PropertyCacheItems Include="AndroidCreatePackagePerAbi=$(AndroidCreatePackagePerAbi)" />
+		<_PropertyCacheItems Include="AndroidGenerateJniMarshalMethods=$(AndroidGenerateJniMarshalMethods)" />
 		<_PropertyCacheItems Include="OS=$(OS)" />
 		<_PropertyCacheItems Include="DesignTimeBuild=$(DesignTimeBuild)" />
 		<_PropertyCacheItems Include="AndroidIncludeDebugSymbols=$(AndroidIncludeDebugSymbols)" />
@@ -1947,25 +1947,6 @@ because xbuild doesn't support framework reference assemblies.
   </ItemGroup>
 </Target>
 
-<Target Name="_CopyIntermediateAssemblies"
-	Inputs="@(ResolvedAssemblies);@(_AndroidResolvedSatellitePaths)"
-	Outputs="$(_AndroidStampDirectory)_CopyIntermediateAssemblies.stamp"
-	DependsOnTargets="_ResolveAssemblies;_ResolveSatellitePaths;_CreatePackageWorkspace;_CopyConfigFiles">
-	<ItemGroup>
-		<_CIAResolvedAssembliesDestinationFiles     Include="@(ResolvedAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')" />
-		<_CIAResolvedSatellitePathsDestinationFiles Include="@(_AndroidResolvedSatellitePaths->'$(MonoAndroidLinkerInputDir)%(DestinationSubDirectory)%(Filename)%(Extension)')" />
-	</ItemGroup>
-	<!-- Make a copy of every assembly we need in assemblies -->
-	<CopyIfChanged SourceFiles="@(ResolvedAssemblies)"             DestinationFiles="@(_CIAResolvedAssembliesDestinationFiles)" />
-	<CopyIfChanged SourceFiles="@(_AndroidResolvedSatellitePaths)" DestinationFiles="@(_CIAResolvedSatellitePathsDestinationFiles)" />
-	<!-- Delete mdb files leftover from a previous build -->
-	<Delete Files="@(ResolvedAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension).mdb')" />
-	<Touch Files="$(_AndroidStampDirectory)_CopyIntermediateAssemblies.stamp" AlwaysCreate="True" />
-	<ItemGroup>
-		<FileWrites Include="@(_CIAResolvedAssembliesDestinationFiles);@(_CIAResolvedSatellitePathsDestinationFiles)" />
-	</ItemGroup>
-</Target>
-
 <Target Name="_CollectConfigFiles">
 	<GetFilesThatExist
 			Files="@(ResolvedAssemblies->'%(identity).config')">
@@ -2016,56 +1997,31 @@ because xbuild doesn't support framework reference assemblies.
 	</ItemGroup>
 </Target>
 
-<Target Name="_CopyPdbFiles"
-		Inputs="@(_ResolvedPortablePdbFiles)"
-		Outputs="$(_AndroidStampDirectory)_CopyPdbFiles.stamp"
-		DependsOnTargets="_ConvertPdbFiles">
-	<ItemGroup>
-		<_CopyPdbFilesLinkerFiles Include="@(_ResolvedPortablePdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')" />
-	</ItemGroup>
-	<CopyIfChanged SourceFiles="@(_ResolvedPortablePdbFiles)" DestinationFiles="@(_CopyPdbFilesLinkerFiles)" />
-	<Touch Files="$(_AndroidStampDirectory)_CopyPdbFiles.stamp" AlwaysCreate="True" />
-	<ItemGroup>
-		<FileWrites Include="@(_CopyPdbFilesLinkerFiles)" />
-	</ItemGroup>
-</Target>
-
-<Target Name="_CopyMdbFiles"
-		Inputs="@(_ResolvedMdbFiles)"
-		Outputs="$(_AndroidStampDirectory)_CopyMdbFiles.stamp"
-		DependsOnTargets="_CollectMdbFiles">
-	<ItemGroup>
-		<_CopyMdbFilesLinkerFiles Include="@(_ResolvedMdbFiles->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')" />
-	</ItemGroup>
-	<CopyIfChanged SourceFiles="@(_ResolvedMdbFiles)" DestinationFiles="@(_CopyMdbFilesLinkerFiles)" />
-	<Touch Files="$(_AndroidStampDirectory)_CopyMdbFiles.stamp" AlwaysCreate="True" />
-	<ItemGroup>
-		<FileWrites Include="@(_CopyMdbFilesLinkerFiles)" />
-	</ItemGroup>
-</Target>
-	
 <Target Name="_LinkAssemblies"
   DependsOnTargets="_ResolveAssemblies;_CreatePackageWorkspace;$(_BeforeLinkAssemblies);_GenerateJniMarshalMethods;_LinkAssembliesNoShrink;_LinkAssembliesShrink" />
 
 <Target Name="_GenerateJniMarshalMethods"
     Condition="'$(AndroidGenerateJniMarshalMethods)' == 'True' And '$(AndroidLinkMode)' != 'None' And '$(OS)' != 'Windows_NT'"
     DependsOnTargets="_GetReferenceAssemblyPaths;_SetLatestTargetFrameworkVersion"
-    Inputs="@(ResolvedUserAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
-    Outputs="$(_AndroidJniMarshalMethodsFlag)">
+    Inputs="$(_AndroidBuildPropertiesCache);@(ResolvedUserAssemblies)"
+    Outputs="$(_AndroidStampDirectory)_GenerateJniMarshalMethods.stamp">
   <ItemGroup>
     <_JniFrameworkAssembly Include="Mono.Android.dll" />
     <_JniFrameworkAssembly Include="OpenTK-1.0.dll" />
     <_JniFrameworkAssembly Include="OpenTK.dll" />
     <_JniFrameworkAssembly Include="Xamarin.Android.NUnitLite.dll" />
-  </ItemGroup>
-  <ItemGroup>
     <_AssembliesToProcess Include="@(ResolvedUserAssemblies)" />
-    <_AssembliesToProcess Include="@(ResolvedAssemblies)" Condition=" '%(Filename)' != '' And '@(_JniFrameworkAssembly)' != '' " />
+    <_AssembliesToProcess Include="@(ResolvedFrameworkAssemblies)" Condition=" '%(Filename)' == '@(_JniFrameworkAssembly->'%(Filename)')' " />
   </ItemGroup>
+  <RemoveDirFixed Directories="$(_JniMarshalMethodsOutputDir)" />
+  <MakeDir Directories="$(_JniMarshalMethodsOutputDir)" />
   <Exec
-       Command="DYLD_LIBRARY_PATH=&quot;$(MonoAndroidLibDirectory)&quot; MONO_CONFIG=&quot;$(MonoAndroidBinDirectory)mono.config&quot; MONO_PATH=&quot;$(MonoAndroidBinDirectory)\bcl&quot;:&quot;$(MonoAndroidBinDirectory)\bcl\Facades&quot;:&quot;$(_XATargetFrameworkDirectories):$(MonoAndroidLinkerInputDir)&quot; &quot;$(MonoAndroidBinDirectory)mono&quot; --debug &quot;$(MonoAndroidToolsDirectory)\jnimarshalmethod-gen.exe&quot; --jvm=&quot;$(JdkJvmPath)&quot; $(AndroidGenerateJniMarshalMethodsAdditionalArguments) @(_AssembliesToProcess->'&quot;$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)&quot;', ' ')"
+      Command="DYLD_LIBRARY_PATH=&quot;$(MonoAndroidLibDirectory)&quot; MONO_CONFIG=&quot;$(MonoAndroidBinDirectory)mono.config&quot; MONO_PATH=&quot;$(MonoAndroidBinDirectory)\bcl&quot;:&quot;$(MonoAndroidBinDirectory)\bcl\Facades&quot;:&quot;$(_XATargetFrameworkDirectories)&quot; &quot;$(MonoAndroidBinDirectory)mono&quot; --debug &quot;$(MonoAndroidToolsDirectory)\jnimarshalmethod-gen.exe&quot; --jvm=&quot;$(JdkJvmPath)&quot; @(ResolvedAssemblies->'--r=&quot;%(Identity)&quot;', ' ') --o=&quot;$(_JniMarshalMethodsOutputDir)&quot; $(AndroidGenerateJniMarshalMethodsAdditionalArguments) @(_AssembliesToProcess->'&quot;%(Identity)&quot;', ' ')"
   />
-  <Touch Files="$(_AndroidJniMarshalMethodsFlag)" AlwaysCreate="True" />
+  <Touch Files="$(_AndroidStampDirectory)_GenerateJniMarshalMethods.stamp" AlwaysCreate="True" />
+  <ItemGroup>
+    <FileWrites Include="$(_AssembliesToProcess)" />
+  </ItemGroup>
 </Target>
 
 <Target Name="_LinkAssembliesNoShrink"
@@ -2095,8 +2051,21 @@ because xbuild doesn't support framework reference assemblies.
 	
 <Target Name="_LinkAssembliesShrink"
   Condition="'$(AndroidLinkMode)' != 'None'"
-  Inputs="@(ResolvedUserAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)');$(_AndroidBuildPropertiesCache)"
+  Inputs="@(ResolvedUserAssemblies);$(_AndroidBuildPropertiesCache)"
   Outputs="$(_AndroidLinkFlag)">
+
+    <PropertyGroup>
+      <_MainAssembly Condition=" '$(AndroidGenerateJniMarshalMethods)' != 'True' ">$(TargetPath)</_MainAssembly>
+      <_MainAssembly Condition=" '$(AndroidGenerateJniMarshalMethods)' == 'True' ">$(_JniMarshalMethodsInputDir)$(TargetFileName)</_MainAssembly>
+    </PropertyGroup>
+    <ItemGroup Condition=" '$(AndroidGenerateJniMarshalMethods)' != 'True' ">
+      <_AssembliesToLink Include="@(ResolvedAssemblies)" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(AndroidGenerateJniMarshalMethods)' == 'True' ">
+      <_JniAssembliesToLink Include="@(ResolvedAssemblies->'$(_JniMarshalMethodsOutputDir)%(Filename)%(Extension)')" />
+      <_AssembliesToLink Condition="Exists(%(Identity))" Include="@(_JniAssembliesToLink)" />
+      <_AssembliesToLink Condition="!Exists(@(JniAssembliesToLink))" Include="@(ResolvedAssemblies)" />
+    </ItemGroup>
 
     <CreateProperty
     	Condition=" '$(AndroidLinkTool)' != '' "
@@ -2108,7 +2077,7 @@ because xbuild doesn't support framework reference assemblies.
 
     <LinkAssemblies
       UseSharedRuntime="$(AndroidUseSharedRuntime)"
-      MainAssembly="$(MonoAndroidLinkerInputDir)$(TargetFileName)"
+      MainAssembly="$(_MainAssembly)"
       OutputDirectory="$(MonoAndroidIntermediateAssetsDir)"
       I18nAssemblies="$(MandroidI18n)"
       LinkMode="$(AndroidLinkMode)"
@@ -2118,7 +2087,7 @@ because xbuild doesn't support framework reference assemblies.
       PreserveJniMarshalMethods="$(AndroidGenerateJniMarshalMethods)"
       EnableProguard="$(AndroidEnableProguard)"
       DumpDependencies="$(LinkerDumpDependencies)"
-      ResolvedAssemblies="@(ResolvedAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
+      ResolvedAssemblies="@(_AssembliesToLink)"
       HttpClientHandlerType="$(AndroidHttpClientHandlerType)"
       TlsProvider="$(AndroidTlsProvider)" />
 
@@ -2136,9 +2105,8 @@ because xbuild doesn't support framework reference assemblies.
 		;_CheckForObsoleteAssemblies
 		;_ResolveSatellitePaths
 		;_CreatePackageWorkspace
-		;_CopyIntermediateAssemblies
-		;_CopyPdbFiles
-		;_CopyMdbFiles
+		;_CopyConfigFiles
+		;_ConvertPdbFiles
 		;_LinkAssemblies
 	</_PrepareAssembliesDependsOnTargets>
 </PropertyGroup>
@@ -2368,7 +2336,7 @@ because xbuild doesn't support framework reference assemblies.
   <GeneratePackageManagerJava
     ResolvedAssemblies="@(_ResolvedAssemblies)"
     ResolvedUserAssemblies="@(_ResolvedUserAssemblies)"
-    MainAssembly="$(MonoAndroidLinkerInputDir)$(TargetFileName)"
+    MainAssembly="$(TargetPath)"
     OutputDirectory="$(IntermediateOutputPath)android\src\mono"
     EnvironmentOutputDirectory="$(IntermediateOutputPath)android"
     UseSharedRuntime="$(AndroidUseSharedRuntime)"
@@ -2887,9 +2855,11 @@ because xbuild doesn't support framework reference assemblies.
 		_SetLatestTargetFrameworkVersion;
 		_GetLibraryImports;
 		_RemoveRegisterAttribute;
-		_CopyIntermediateAssemblies;
-		_CopyPdbFiles;
-		_CopyMdbFiles;
+		_ResolveAssemblies;
+		_ResolveSatellitePaths;
+		_CreatePackageWorkspace;
+		_CopyConfigFiles;
+		_ConvertPdbFiles;
 		_LinkAssemblies;
 		_GenerateJavaStubs;
 		_ConvertCustomView;
@@ -3382,7 +3352,6 @@ because xbuild doesn't support framework reference assemblies.
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)android" Condition="Exists ('$(MonoAndroidIntermediate)android')" />
 	<!-- FIXME: remove this extraneous rmdir after a few release cycles since we release the one we killed it. -->
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)assemblies" Condition="Exists ('$(MonoAndroidIntermediate)assemblies')" />
-	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)linksrc" Condition="Exists ('$(MonoAndroidIntermediate)linksrc')" />
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)linkdst" Condition="Exists ('$(MonoAndroidIntermediate)linkdst')" />
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)res" Condition="Exists ('$(MonoAndroidIntermediate)res')" />
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)aidl" Condition="Exists ('$(MonoAndroidIntermediate)aidl')" />


### PR DESCRIPTION
I've removed various MSBuild targets that copy assemblies into the
`obj\Debug\linksrc` directory, and instead just use
`@(ResolvedUserAssemblies)` or `@(ResolvedAssemblies)` directly

Things seem to *work*, I can build and deploy `samples\HelloWorld` and
the Xamarin.Forms app in this repo. Let's see what breaks?

The size of `tests\Xamarin.Forms-Performance-Integration\Droid\obj\`
is improved dramatically:

    Before:
    184.27 MB
    After:
    111.74 MB

~73MB savings.

These MSBuild tasks were completely removed:

      3 ms  _CopyMdbFiles                              1 calls
     43 ms  _CopyPdbFiles                              1 calls
    127 ms  _CopyIntermediateAssemblies                1 calls

On a slower machine with Windows Defender enabled, these targets are
taking:

      6 ms  _CopyMdbFiles                              1 calls
     95 ms  _CopyPdbFiles                              1 calls
    269 ms  _CopyIntermediateAssemblies                1 calls

On the slower machine, the overall time was even more drastic:

    Before:
    Time Elapsed 00:00:33.41
    After:
    Time Elapsed 00:00:29.92

With Windows Defender processes using the CPU, the overall build time
is improved by ~3.5 seconds?

## Changes for jnimarshalmethod-gen ##

Because `jnimarshalmethod-gen` edits assemblies in `linksrc` in-place,
before the linker, I added an extra `jnisrc` directory to accommodate
for this. Then when `_LinkAssembliesShrink` runs, it operates on
assemblies in the `jnisrc` directory.

We can revisit this if `$(AndroidGenerateJniMarshalMethods)` ever
becomes default.