### PR TITLE
[Xamarin.Android.Build.Tasks] <FilterAssemblies/> should look for .jar files

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs
@@ -88,7 +88,7 @@ namespace Xamarin.Android.Tasks
 				var resource = reader.GetManifestResource (handle);
 				var name = reader.GetString (resource.Name);
 				if (name.EndsWith (".jar", StringComparison.OrdinalIgnoreCase) ||
-					name.StartsWith ("__Android", StringComparison.OrdinalIgnoreCase)) {
+						name.StartsWith ("__Android", StringComparison.OrdinalIgnoreCase)) {
 					return true;
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3889,6 +3889,30 @@ public class ApplicationRegistration { }");
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}
 		}
+
+		[Test]
+		public void WorkManager ()
+		{
+			var proj = new XamarinFormsAndroidApplicationProject ();
+			proj.Sources.Add (new BuildItem.Source ("MyWorker.cs") {
+				TextContent = () =>
+@"using System;
+using Android.Content;
+using AndroidX.Work;
+
+public class MyWorker : Worker
+{
+	public MyWorker (Context c, WorkerParameters p) : base (c, p) { }
+
+	public override Result DoWork () => Result.InvokeSuccess ();
+}
+"
+			});
+			proj.PackageReferences.Add (KnownPackages.Android_Arch_Work_Runtime);
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/FilterAssembliesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/FilterAssembliesTests.cs
@@ -65,8 +65,6 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var task = new FilterAssemblies {
 				BuildEngine = new MockBuildEngine (TestContext.Out),
-				TargetFrameworkIdentifier = "MonoAndroid",
-				FallbackReference = "Mono.Android",
 				InputAssemblies = assemblies.Select (a => new TaskItem (a)).ToArray (),
 			};
 			Assert.IsTrue (task.Execute (), "task.Execute() should have succeeded.");
@@ -96,6 +94,17 @@ namespace Xamarin.Android.Build.Tests
 				"Xamarin.Forms.Platform.Android.dll",
 				"Xamarin.Forms.Platform.dll",
 			};
+			CollectionAssert.AreEqual (expected, actual);
+		}
+
+		[Test]
+		public async Task GuavaListenableFuture ()
+		{
+			var assemblies = await GetAssembliesFromNuGet (
+				"https://www.nuget.org/api/v2/package/Xamarin.Google.Guava.ListenableFuture/1.0.0",
+				"lib/MonoAndroid50/");
+			var actual = Run (assemblies);
+			var expected = new [] { "Xamarin.Google.Guava.ListenableFuture.dll" };
 			CollectionAssert.AreEqual (expected, actual);
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -625,6 +625,16 @@ namespace Xamarin.ProjectTools
 				}
 			}
 		};
+		public static Package Android_Arch_Work_Runtime = new Package {
+			Id = "Xamarin.Android.Arch.Work.Runtime",
+			Version = "1.0.0",
+			TargetFramework = "MonoAndroid90",
+			References = {
+				new BuildItem.Reference("Xamarin.Android.Arch.Work.Runtime") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Arch.Work.Runtime.1.0.0\\lib\\MonoAndroid90\\Xamarin.Android.Arch.Work.Runtime.dll"
+				}
+			}
+		};
 		public static Package Xamarin_Android_Crashlytics_2_9_4 = new Package {
 			Id = "Xamarin.Android.Crashlytics",
 			Version = "2.9.4",

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -519,8 +519,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   </ItemGroup>
   <FilterAssemblies
       DesignTimeBuild="$(DesignTimeBuild)"
-      TargetFrameworkIdentifier="MonoAndroid"
-      FallbackReference="Mono.Android"
       InputAssemblies="@(_ReferencePath);@(_ReferenceDependencyPaths)">
     <Output TaskParameter="OutputAssemblies" ItemName="_MonoAndroidReferencePath" />
   </FilterAssemblies>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3343
Context: https://github.com/xamarin/XamarinComponents/blob/54646f5c0bef9c618c700628bd1167768d7c9b4f/Android/Guava/source/Guava.ListenableFuture/Guava.ListenableFuture.csproj

We introduced a performance improvement in 5ec3e3ab that "classifies"
assemblies as Xamarin.Android assemblies or not. This allows us to
skip processing of NetStandard/BCL assemblies throughout the build.

Unfortunately, this Guava.ListenableFuture assembly is odd:

* No `[assembly: TargetFramework]` attribute at all
* No reference to `Mono.Android.dll`

The only "marker" is that it has a `.jar` file as an
`EmbeddedResource`, which is put there by `<EmbeddedJar/>`. Its
weirdness is related to it not having any C# code, and using SDK-style
projects.

The fix here is to update `<FilterAssemblies/>` to look for:

* `[assembly: TargetFramework("MonoAndroid,Version=v9.0")]`
* `Mono.Android.dll` reference
* `EmbeddedResource` ending with `*.jar`
* `EmbeddedResource` beginning with `__Android`

I also reworked this task so that the logic is hardcoded. It does not
seem useful to pass in input parameters from MSBuild targets anymore.