### PR TITLE
[linker] Make sure we mark *Invoker types

### DIFF
--- a/src/Mono.Android/Test/Resources/layout/Main.axml
+++ b/src/Mono.Android/Test/Resources/layout/Main.axml
@@ -17,6 +17,12 @@
       android:layout_height="wrap_content"
       android:editable="false"
   />
+  <EditText
+      android:id="@+id/edit_text"
+      android:layout_weight="1"
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+  />
   <ScrollView
       android:id="@+id/my_scroll_view"
       android:layout_width="fill_parent"

--- a/src/Mono.Android/Test/Xamarin.Android.RuntimeTests/MainActivity.cs
+++ b/src/Mono.Android/Test/Xamarin.Android.RuntimeTests/MainActivity.cs
@@ -34,6 +34,9 @@ namespace Xamarin.Android.RuntimeTests
 				// ignore
 			};
 
+			// test https://github.com/xamarin/xamarin-android/issues/3263
+			edit_text.TextChanged += delegate { };
+
 			csharp_simple_fragment.AllowEnterTransitionOverlap = true;
 			csharp_partial_assembly.AllowEnterTransitionOverlap = true;
 			csharp_full_assembly.AllowEnterTransitionOverlap = true;

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MarkJavaObjects.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MarkJavaObjects.cs
@@ -192,6 +192,8 @@ namespace MonoDroid.Tuner {
 			if (invoker == null)
 				return;
 
+			Annotations.Mark (invoker);
+
 			PreserveIntPtrConstructor (invoker);
 			PreserveInterfaceMethods (type, invoker);
 		}

--- a/tests/Runtime-MultiDex/Resources/layout/Main.axml
+++ b/tests/Runtime-MultiDex/Resources/layout/Main.axml
@@ -17,6 +17,12 @@
       android:layout_height="wrap_content"
       android:editable="false"
   />
+  <EditText
+      android:id="@+id/edit_text"
+      android:layout_weight="1"
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+  />
   <ScrollView
       android:id="@+id/my_scroll_view"
       android:layout_width="fill_parent"


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/3263

Looks like
https://github.com/xamarin/xamarin-android/commit/5b945abb2e1f0fe1a9ab6589993c970869c4a752
introduced a new regression, where in some cases we were not marking
the *Invoker type anymore, as [this line](https://github.com/xamarin/xamarin-android/commit/5b945abb2e1f0fe1a9ab6589993c970869c4a752#diff-144727b152107ec306fbe284bd5902e3L60)
is gone.

This is fixed by marking the *Invoker types in MarkJavaObjects step.