### PR TITLE
[monodroid] Allow loading assemblies from memory

### DIFF
--- a/build-tools/cmake/xa_macros.cmake
+++ b/build-tools/cmake/xa_macros.cmake
@@ -51,7 +51,10 @@ macro(xa_common_prepare)
     fPIC
     )
 
-  if(NOT MINGW AND NOT WIN32)
+  # Using flto seems to breaks LLDB debugging as debug symbols are not properly included
+  # thus disable on desktop builds where we care less about its benefits and would rather
+  # keep debuggability
+  if(NOT MINGW AND NOT WIN32 AND NOT APPLE)
     # -flto leaves a lot of temporary files with mingw builds, turn the optimization off as we don't really need it there
     set(XA_COMPILER_FLAGS ${XA_COMPILER_FLAGS} flto)
   endif()

--- a/src/java-runtime/java/mono/android/Runtime.java
+++ b/src/java-runtime/java/mono/android/Runtime.java
@@ -16,6 +16,7 @@ public class Runtime {
 	public static native void register (String managedType, java.lang.Class nativeClass, String methods);
 	public static native void notifyTimeZoneChanged ();
 	public static native int createNewContext (String[] runtimeApks, String[] assemblies, ClassLoader loader);
+	public static native int createNewContextWithData (String[] runtimeApks, String[] assemblies, byte[][] assembliesBytes, ClassLoader loader, boolean forcePreloadAssemblies);
 	public static native void switchToContext (int contextID);
 	public static native void destroyContexts (int[] contextIDs);
 	public static native void propagateUncaughtException (Thread javaThread, Throwable javaException);

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -22,6 +22,7 @@ include("../../build-tools/cmake/xa_macros.cmake")
 
 set(JAVA_INTEROP_SRC_PATH "../../external/Java.Interop/src/java-interop")
 string(REPLACE "\\" "/" TOP_DIR ${CMAKE_SOURCE_DIR})
+set(SOURCES_DIR ${TOP_DIR}/jni)
 
 if(NOT DEFINED MONO_PATH)
   message(FATAL_ERROR "Please set the MONO_PATH variable on command line (-DMONO_PATH=PATH)")
@@ -59,6 +60,7 @@ if(NOT ANDROID)
   endforeach()
   set(MONODROID_SOURCES
     ${MONODROID_SOURCES}
+    ${SOURCES_DIR}/inmemory-assemblies.cc
     ${JAVA_INTEROP_SRC_PATH}/java-interop-gc-bridge-mono.cc
     ${JAVA_INTEROP_SRC_PATH}/java-interop-jvm.cc
     )
@@ -227,7 +229,6 @@ check_include_files("linux/if_arp.h" HAVE_LINUX_IF_ARP_H)
 configure_file(jni/host-config.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/host-config.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include/ ${CMAKE_SOURCE_DIR}/include)
 
-set(SOURCES_DIR ${TOP_DIR}/jni)
 set(MONODROID_SOURCES
   ${MONODROID_SOURCES}
   ${SOURCES_DIR}/new_delete.cc

--- a/src/monodroid/jni/globals.cc
+++ b/src/monodroid/jni/globals.cc
@@ -7,6 +7,9 @@ Util utils;
 AndroidSystem androidSystem;
 OSBridge osBridge;
 EmbeddedAssemblies embeddedAssemblies;
+#ifndef ANDROID
+InMemoryAssemblies inMemoryAssemblies;
+#endif
 
 #ifdef DEBUG
 Debug debug;

--- a/src/monodroid/jni/globals.hh
+++ b/src/monodroid/jni/globals.hh
@@ -5,6 +5,7 @@
 #include "util.hh"
 #include "debug.hh"
 #include "embedded-assemblies.hh"
+#include "inmemory-assemblies.hh"
 #include "monodroid-glue-internal.hh"
 #include "cppcompat.hh"
 
@@ -12,6 +13,9 @@ extern xamarin::android::Util utils;
 extern xamarin::android::internal::AndroidSystem androidSystem;
 extern xamarin::android::internal::OSBridge osBridge;
 extern xamarin::android::internal::EmbeddedAssemblies embeddedAssemblies;
+#ifndef ANDROID
+extern xamarin::android::internal::InMemoryAssemblies inMemoryAssemblies;
+#endif
 
 #ifdef DEBUG
 extern xamarin::android::Debug debug;

--- a/src/monodroid/jni/inmemory-assemblies.cc
+++ b/src/monodroid/jni/inmemory-assemblies.cc
@@ -1,0 +1,162 @@
+#include "inmemory-assemblies.hh"
+#include "globals.hh"
+
+#include <mono/metadata/appdomain.h>
+#include <mono/metadata/assembly.h>
+#include <mono/metadata/reflection.h>
+
+extern "C" {
+#include "java-interop-util.h"
+}
+
+namespace xamarin::android::internal {
+
+void
+InMemoryAssemblies::add_or_update_from_java (MonoDomain *domain, JNIEnv *env, jstring_array_wrapper &assemblies, jobjectArray assembliesBytes)
+{
+	assert (assembliesBytes != nullptr);
+	InMemoryAssemblyEntry *new_entry = new InMemoryAssemblyEntry (domain, env, assemblies, assembliesBytes);
+	add_or_replace_entry (new_entry);
+}
+
+MonoAssembly*
+InMemoryAssemblies::load_assembly_from_memory (MonoDomain *domain, MonoAssemblyName *name)
+{
+	int domain_id = mono_domain_get_id (domain);
+	InMemoryAssemblyEntry *entry = find_entry (domain_id);
+	if (entry == nullptr)
+		return nullptr;
+
+	const char *asm_name = mono_assembly_name_get_name (name);
+	unsigned int asm_count = entry->assemblies_count;
+
+	for (unsigned int i = 0; i < asm_count; i++) {
+		const char *entry_name = entry->names[i];
+		const char *entry_bytes = entry->assemblies_bytes[i];
+		const unsigned int entry_bytes_len = entry->assemblies_bytes_len[i];
+
+		if (strcmp (asm_name, entry_name) != 0)
+			continue;
+
+		// There is unfortunately no public unmanaged API to do proper in-memory
+		// loading (it would require access to the MonoAssemblyLoadRequest API)
+		MonoClass *assembly_klass = utils.monodroid_get_class_from_name (domain, "mscorlib", "System.Reflection", "Assembly");
+		MonoClass *byte_klass = mono_get_byte_class ();
+		// Use the variant with 3 parameters so that we always get the first argument being a byte[]
+		// (the two last don't matter since we pass null anyway)
+		MonoMethod *assembly_load_method = mono_class_get_method_from_name (assembly_klass, "Load", 3);
+		MonoArray *byteArray = mono_array_new (domain, byte_klass, entry_bytes_len);
+		mono_value_copy_array (byteArray, 0, const_cast<char*> (entry_bytes), static_cast<int> (entry_bytes_len));
+
+		void *args[3];
+		args[0] = byteArray;
+		args[1] = nullptr;
+		args[2] = nullptr;
+		MonoReflectionAssembly *res = (MonoReflectionAssembly *)utils.monodroid_runtime_invoke (domain, assembly_load_method, nullptr, args, nullptr);
+		MonoAssembly *mono_assembly = mono_reflection_assembly_get_assembly (res);
+
+		return mono_assembly;
+	}
+
+	return nullptr;
+}
+
+void
+InMemoryAssemblies::clear_for_domain (MonoDomain *domain)
+{
+	int domain_id = mono_domain_get_id (domain);
+	InMemoryAssemblyEntry *entry = remove_entry (domain_id);
+	delete entry;
+}
+
+InMemoryAssemblies::InMemoryAssemblyEntry*
+InMemoryAssemblies::find_entry (int domain_id)
+{
+	for (unsigned int i = 0; i < length; i++) {
+		auto entry = entries[i];
+		if (entry->domain_id == domain_id)
+			return entry;
+	}
+	return nullptr;
+}
+
+void
+InMemoryAssemblies::add_or_replace_entry (InMemoryAssemblies::InMemoryAssemblyEntry *new_entry)
+{
+	for (unsigned int i = 0; i < length; i++) {
+		auto entry = entries[i];
+		if (entry->domain_id == new_entry->domain_id) {
+			entries[i] = new_entry;
+			delete entry;
+			return;
+		}
+	}
+	add_entry (new_entry);
+}
+
+void
+InMemoryAssemblies::add_entry (InMemoryAssemblies::InMemoryAssemblyEntry *entry)
+{
+	if (length >= capacity) {
+		capacity = MULTIPLY_WITH_OVERFLOW_CHECK(unsigned int, capacity, 2);
+		InMemoryAssemblyEntry **new_entries = new InMemoryAssemblyEntry*[capacity];
+		memcpy (new_entries, entries, MULTIPLY_WITH_OVERFLOW_CHECK(size_t, sizeof(void*), length));
+		InMemoryAssemblyEntry **old_entries = entries;
+		entries = new_entries;
+		delete[] old_entries;
+	}
+	entries[length++] = entry;
+}
+
+InMemoryAssemblies::InMemoryAssemblyEntry*
+InMemoryAssemblies::remove_entry (int domain_id)
+{
+	for (unsigned int i = 0; i < length; i++) {
+		InMemoryAssemblyEntry *entry = entries[i];
+		if (entry->domain_id == domain_id) {
+			for (unsigned int j = i; j < length - 1; j++)
+				entries[j] = entries[j + 1];
+			length--;
+			entries[length] = nullptr;
+			return entry;
+		}
+	}
+	return nullptr;
+}
+
+InMemoryAssemblies::InMemoryAssemblyEntry::InMemoryAssemblyEntry (MonoDomain *domain, JNIEnv *env, jstring_array_wrapper &assemblies, jobjectArray assembliesBytes)
+{
+	this->domain_id = mono_domain_get_id (domain);
+	this->assemblies_count = static_cast<unsigned int> (env->GetArrayLength (assembliesBytes));
+	this->names = new char*[assemblies_count];
+	this->assemblies_bytes = new char*[assemblies_count];
+	this->assemblies_bytes_len = new unsigned int[assemblies_count];
+
+	for (unsigned int index = 0; index < assemblies_count; index++) {
+		jboolean is_copy;
+		jbyteArray assembly_byte_array = reinterpret_cast <jbyteArray> (env->GetObjectArrayElement (assembliesBytes, static_cast<jsize> (index)));
+		unsigned int bytes_len = static_cast<unsigned int> (env->GetArrayLength (assembly_byte_array));
+		jbyte *bytes = env->GetByteArrayElements (assembly_byte_array, &is_copy);
+		jstring_wrapper &assembly = assemblies [index];
+
+		names[index] = utils.strdup_new (assembly.get_cstr ());
+		assemblies_bytes_len[index] = bytes_len;
+		assemblies_bytes[index] = new char[bytes_len];
+		memcpy (assemblies_bytes[index], bytes, bytes_len);
+
+		env->ReleaseByteArrayElements (assembly_byte_array, bytes, JNI_ABORT);
+	}
+}
+
+InMemoryAssemblies::InMemoryAssemblyEntry::~InMemoryAssemblyEntry ()
+{
+	for (unsigned int i = 0; i < assemblies_count; ++i) {
+		delete[] names [i];
+		delete[] assemblies_bytes [i];
+	}
+	delete[] names;
+	delete[] assemblies_bytes;
+	delete[] assemblies_bytes_len;
+}
+
+}

--- a/src/monodroid/jni/inmemory-assemblies.hh
+++ b/src/monodroid/jni/inmemory-assemblies.hh
@@ -1,0 +1,51 @@
+#ifndef INC_MONODROID_INMEMORY_ASSEMBLIES_H
+#define INC_MONODROID_INMEMORY_ASSEMBLIES_H
+
+#include "jni-wrappers.hh"
+#include <string.h>
+#include <mono/metadata/appdomain.h>
+#include <mono/metadata/assembly.h>
+
+#define DEFAULT_CAPACITY 8
+
+namespace xamarin::android::internal {
+	class InMemoryAssemblies
+	{
+		private:
+			struct InMemoryAssemblyEntry
+			{
+				int domain_id;
+				unsigned int assemblies_count;
+				char **names;
+				char **assemblies_bytes;
+				unsigned int *assemblies_bytes_len;
+
+				InMemoryAssemblyEntry (MonoDomain *domain, JNIEnv *env, jstring_array_wrapper &assemblies, jobjectArray assembliesBytes);
+				~InMemoryAssemblyEntry ();
+			};
+
+		public:
+			InMemoryAssemblies ()
+			{
+				capacity = DEFAULT_CAPACITY;
+				entries = new InMemoryAssemblyEntry*[DEFAULT_CAPACITY];
+			}
+
+			bool has_assemblies () const { return length > 0; }
+			MonoAssembly* load_assembly_from_memory (MonoDomain *domain, MonoAssemblyName *name);
+			void add_or_update_from_java (MonoDomain *domain, JNIEnv *env, jstring_array_wrapper &assemblies, jobjectArray assembliesBytes);
+			void clear_for_domain (MonoDomain *domain);
+
+		private:
+			InMemoryAssemblyEntry **entries;
+			unsigned int capacity;
+			unsigned int length;
+
+			InMemoryAssemblyEntry* find_entry (int domain_id);
+			void add_or_replace_entry (InMemoryAssemblyEntry *new_entry);
+			void add_entry (InMemoryAssemblyEntry *entry);
+			InMemoryAssemblyEntry* remove_entry (int domain_id);
+	};
+}
+
+#endif

--- a/src/monodroid/jni/mono_android_Runtime.h
+++ b/src/monodroid/jni/mono_android_Runtime.h
@@ -10,7 +10,7 @@ extern "C" {
 /*
  * Class:     mono_android_Runtime
  * Method:    init
- * Signature: (Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/ClassLoader;[Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;I;Ljava/lang/String)V
+ * Signature: (Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/ClassLoader;[Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;I[Ljava/lang/String;)V
  */
 JNIEXPORT void JNICALL Java_mono_android_Runtime_init
   (JNIEnv *, jclass, jstring, jobjectArray, jstring, jobjectArray, jobject, jobjectArray, jobjectArray, jstring, jint, jobjectArray);
@@ -46,6 +46,14 @@ JNIEXPORT void JNICALL Java_mono_android_Runtime_notifyTimeZoneChanged
  */
 JNIEXPORT jint JNICALL Java_mono_android_Runtime_createNewContext
   (JNIEnv *, jclass, jobjectArray, jobjectArray, jobject);
+
+/*
+ * Class:     mono_android_Runtime
+ * Method:    createNewContextWithData
+ * Signature: ([Ljava/lang/String;[Ljava/lang/String;[[BLjava/lang/ClassLoader;Z)I
+ */
+JNIEXPORT jint JNICALL Java_mono_android_Runtime_createNewContextWithData
+  (JNIEnv *, jclass, jobjectArray, jobjectArray, jobjectArray, jobject, jboolean);
 
 /*
  * Class:     mono_android_Runtime

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -2097,7 +2097,13 @@ JNICALL Java_mono_android_Runtime_register (JNIEnv *env, jclass klass, jstring m
 	mono_jit_thread_attach (domain);
 	// Refresh current domain as it might have been modified by the above call
 	domain = mono_domain_get ();
-	utils.monodroid_runtime_invoke (domain, registerType, nullptr, args, nullptr);
+
+	MonoMethod *register_jni_natives = registerType;
+	if (is_running_on_desktop) {
+		MonoClass *runtime = utils.monodroid_get_class_from_name (domain, "Mono.Android", "Android.Runtime", "JNIEnv");
+		register_jni_natives = mono_class_get_method_from_name (runtime, "RegisterJniNatives", 5);
+	}
+	utils.monodroid_runtime_invoke (domain, register_jni_natives, nullptr, args, nullptr);
 
 	env->ReleaseStringChars (methods, methods_ptr);
 	env->ReleaseStringChars (managedType, managedType_ptr);


### PR DESCRIPTION
This PR adds the necessary code and entry-point to be able to supply assembly data directly from memory.

The motivation is to allow the designer more flexibility in how it acquire those assemblies to begin with and avoid a complicated dance of file paths juggling and file copying that are detrimental to performance on Windows and cause file locking problems.

This is achieved by introducing a new class `InMemoryAssemblies` that, much like `EmbeddedAssemblies`, can be queried when a new .dll needs to be loaded to fetch it from a store that's keyed per-assembly name and per-appdomain. If not found in this new store it falls back to the existing logic that can load assemblies directly from disk.

Since we only care about this capability on desktop, the support is only compiled for host platforms (both Mac and Windows).