### PR TITLE
[logcat timing] Make it possible to use local logcat file as input

### DIFF
--- a/build-tools/timing/timing.targets
+++ b/build-tools/timing/timing.targets
@@ -7,9 +7,18 @@
   <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.GitCommitHash" />
   <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.ProcessMSBuildTiming" />
   <Target Name="LogcatTiming">
-    <Exec Command="&quot;$(AdbToolPath)\$(AdbToolExe)&quot; $(_AdbTarget) $(AdbOptions) logcat -v threadtime -d > tmp-logcat-timing.log" />
+    <PropertyGroup>
+      <_DefaultLogcatInputFilename>tmp-logcat-timing.log</_DefaultLogcatInputFilename>
+    </PropertyGroup>
+    <Exec
+        Condition=" '$(LogcatInputFilename)' == '' "
+        Command="&quot;$(AdbToolPath)\$(AdbToolExe)&quot; $(_AdbTarget) $(AdbOptions) logcat -v threadtime -d > $(_DefaultLogcatInputFilename)"
+    />
+    <PropertyGroup Condition=" '$(LogcatInputFilename)' == '' ">
+      <LogcatInputFilename>$(_DefaultLogcatInputFilename)</LogcatInputFilename>
+    </PropertyGroup>
     <ProcessLogcatTiming
-        InputFilename="tmp-logcat-timing.log"
+        InputFilename="$(LogcatInputFilename)"
         ApplicationPackageName="$(Package)"
         PID="$(PID)"
         ResultsFilename="tmp-timing-results.csv"

--- a/build-tools/timing/timing.targets
+++ b/build-tools/timing/timing.targets
@@ -28,8 +28,9 @@
         AddResults="true"
         Activity="$(Activity)" />
     <Delete
-	Condition=" $(_TmpLogcatFileCreated) == 'True' "
-	Files="$(_TmpLogcatInputFilename)" />
+        Condition=" '$(_TmpLogcatFileCreated)' == 'True' "
+        Files="$(_TmpLogcatInputFilename)"
+    />
   </Target>
   <PropertyGroup>
     <_MSBuildTimingDependsOn>

--- a/build-tools/timing/timing.targets
+++ b/build-tools/timing/timing.targets
@@ -8,23 +8,28 @@
   <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.ProcessMSBuildTiming" />
   <Target Name="LogcatTiming">
     <PropertyGroup>
-      <_DefaultLogcatInputFilename>tmp-logcat-timing.log</_DefaultLogcatInputFilename>
+      <_TmpLogcatInputFilename>logcat-$([System.IO.Path]::GetRandomFileName()).txt</_TmpLogcatInputFilename>
     </PropertyGroup>
+    <Error Condition=" '$(LogcatInputFilename)' == '' And Exists($(_TmpLogcatInputFilename))" Text="Unable to create temporary file $(_TmpLogcatInputFilenam) as it already exists." />
     <Exec
         Condition=" '$(LogcatInputFilename)' == '' "
-        Command="&quot;$(AdbToolPath)\$(AdbToolExe)&quot; $(_AdbTarget) $(AdbOptions) logcat -v threadtime -d > $(_DefaultLogcatInputFilename)"
+        Command="&quot;$(AdbToolPath)\$(AdbToolExe)&quot; $(_AdbTarget) $(AdbOptions) logcat -v threadtime -d > $(_TmpLogcatInputFilename)"
     />
     <PropertyGroup Condition=" '$(LogcatInputFilename)' == '' ">
-      <LogcatInputFilename>$(_DefaultLogcatInputFilename)</LogcatInputFilename>
+      <LogcatInputFilename>$(_TmpLogcatInputFilename)</LogcatInputFilename>
+      <_TmpLogcatFileCreated>True</_TmpLogcatFileCreated>
     </PropertyGroup>
     <ProcessLogcatTiming
         InputFilename="$(LogcatInputFilename)"
         ApplicationPackageName="$(Package)"
         PID="$(PID)"
-        ResultsFilename="tmp-timing-results.csv"
+        ResultsFilename="$(LogcatInputFilename)-results.csv"
         DefinitionsFilename="..\scripts\TimingDefinitions.txt"
         AddResults="true"
         Activity="$(Activity)" />
+    <Delete
+	Condition=" $(_TmpLogcatFileCreated) == 'True' "
+	Files="$(_TmpLogcatInputFilename)" />
   </Target>
   <PropertyGroup>
     <_MSBuildTimingDependsOn>


### PR DESCRIPTION
This is helpful when analyzing logcats from CI or debugging the code
that processes the logcat timing.