### PR TITLE
[Xamarin.Android.Build.Tasks] fix false warning from r8

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -52,7 +52,9 @@ namespace Xamarin.Android.Tasks
 
 			if (EnableMultiDex) {
 				if (MinSdkVersion >= 21) {
-					Log.LogCodedWarning ("XA4306", "R8 does not support `MultiDexMainDexList` files when android:minSdkVersion >= 21");
+					if (CustomMainDexListFiles?.Length > 0) {
+						Log.LogCodedWarning ("XA4306", "R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion >= 21");
+					}
 				} else if (string.IsNullOrEmpty (MultiDexMainDexListFile)) {
 					Log.LogCodedWarning ("XA4305", $"MultiDex is enabled, but '{nameof (MultiDexMainDexListFile)}' was not specified.");
 				} else {


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3370
Context: https://github.com/xamarin/xamarin-android/pull/3121

In 34ee4735, I introduced an incorrect warning if:

* `android:minSdkVersion` >= 21
* `$(AndroidEnableMultiDex)` is `True`
* `$(AndroidDexTool)` is `d8`

We need to check if any `@(MultiDexMainDexList)` files were present
before issuing the warning. r8 no longer supports custom
`multidex.keep` files in some cases, so this is what the `<R8/>`
MSBuild task is actually meant to warn about.

I also improved the warning message a bit.