### PR TITLE
[Xamarin.Android.Build.Tasks] fix the NuGetizer 3000

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs
@@ -20,7 +20,6 @@ namespace Xamarin.Android.Tasks
 		const string TargetFrameworkIdentifier = "MonoAndroid";
 		const string MonoAndroidReference = "Mono.Android";
 
-		[Required]
 		public bool DesignTimeBuild { get; set; }
 
 		public ITaskItem [] InputAssemblies { get; set; }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3919,6 +3919,17 @@ public class MyWorker : Worker
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}
 		}
+
+		[Test]
+		public void NuGetizer3000 ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.PackageReferences.Add (KnownPackages.NuGet_Build_Packaging);
+			using (var b = CreateApkBuilder (Path.Combine ("temp", nameof (NuGetizer3000)))) {
+				b.Target = "GetPackageContents";
+				Assert.IsTrue (b.Build (proj), $"{b.Target} should have succeeded.");
+			}
+		}
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -659,6 +659,10 @@ namespace Xamarin.ProjectTools
 			Id = "Xamarin.Build.Download",
 			Version = "0.4.11",
 		};
+		public static Package NuGet_Build_Packaging = new Package {
+			Id = "NuGet.Build.Packaging",
+			Version = "0.2.2",
+		};
 		public static Package Xamarin_GooglePlayServices_Base = new Package {
 			Id = "Xamarin.GooglePlayServices.Base",
 	    		Version = "60.1142.1",


### PR DESCRIPTION
Fixes: http://work.azdo.io/917139
Context: https://github.com/NuGet/Home/wiki/NuGetizer-Core-Features

The NuGetizer 3000, was failing on Xamarin.Android 9.4 with:

    The "FilterAssemblies" task was not given a value for the required parameter "DesignTimeBuild".

This tool runs a `GetPackageContents` MSBuild target that is defined
here:

https://github.com/NuGet/NuGet.Build.Packaging/blob/dev/src/Build/NuGet.Build.Packaging.Tasks/NuGet.Build.Packaging.targets#L201

Since this isn't a `Build` or a `Compile`, neither of these targets
will run:

* `_SetupDesignTimeBuildForBuild`
* `_SetupDesignTimeBuildForCompile`

I don't think we can make the `_AddAndroidCustomMetaData` MSBuild
target (that runs `<FilterAssemblies/>`) depend on either of these.

The simple fix is to just remove `[Required]` from the
`DesignTimeBuild` property, as it will be fine for it to default to
`false`.

/cc @mrward @kzu 