### PR TITLE
[xaprepare] correct strong name for Xamarin.Android.Cecil.*

### DIFF
--- a/build-tools/conjure-xamarin-android-cecil/conjure-xamarin-android-cecil.cs
+++ b/build-tools/conjure-xamarin-android-cecil/conjure-xamarin-android-cecil.cs
@@ -10,7 +10,17 @@ public class ConjureXamarinAndroidCecil
 	const string BaseNameReplacement = "Xamarin.Android.Cecil";
 	const string CecilAssemblyName = BaseNameReplacement;
 	const string CecilMdbAssemblyName = BaseNameReplacement + ".Mdb";
-	const string PublicKey = "024004800094000620002400525341310400101079159977d2d03a8e6bea7a2e74e8d1afcc93e8851974952bb480a12c9134474d462447c37ee68c080536fcf3c3fbe2ff9c979ce998475e56e8ce82dd5bf35dc1e93bf2eeecf874b2477c5081dbea7447fddafa277b22de47d6ffea449674a4f9fccf84d1506989380284dbdd35f46cdff12a1bd78e4ef065d016df";
+	const string PublicKey =
+		"00240000048000009400000006020000" +
+		"00240000525341310004000001000100" +
+		"79159977D2D03A8E6BEA7A2E74E8D1AF" +
+		"CC93E8851974952BB480A12C9134474D" +
+		"04062447C37E0E68C080536FCF3C3FBE" +
+		"2FF9C979CE998475E506E8CE82DD5B0F" +
+		"350DC10E93BF2EEECF874B24770C5081" +
+		"DBEA7447FDDAFA277B22DE47D6FFEA44" +
+		"9674A4F9FCCF84D15069089380284DBD" +
+		"D35F46CDFF12A1BD78E4EF0065D016DF";
 
 	static readonly List<string> internalsVisibleTo = new List<string> {
 		$"Xamarin.Android.Cecil.Pdb, PublicKey={PublicKey}",

--- a/build-tools/conjure-xamarin-android-cecil/conjure-xamarin-android-cecil.cs
+++ b/build-tools/conjure-xamarin-android-cecil/conjure-xamarin-android-cecil.cs
@@ -10,10 +10,11 @@ public class ConjureXamarinAndroidCecil
 	const string BaseNameReplacement = "Xamarin.Android.Cecil";
 	const string CecilAssemblyName = BaseNameReplacement;
 	const string CecilMdbAssemblyName = BaseNameReplacement + ".Mdb";
+	const string PublicKey = "024004800094000620002400525341310400101079159977d2d03a8e6bea7a2e74e8d1afcc93e8851974952bb480a12c9134474d462447c37ee68c080536fcf3c3fbe2ff9c979ce998475e56e8ce82dd5bf35dc1e93bf2eeecf874b2477c5081dbea7447fddafa277b22de47d6ffea449674a4f9fccf84d1506989380284dbdd35f46cdff12a1bd78e4ef065d016df";
 
 	static readonly List<string> internalsVisibleTo = new List<string> {
-		"Xamarin.Android.Cecil.Pdb, PublicKey=0024000004800000940000000602000000240000525341310004000011000000438ac2a5acfbf16cbd2b2b47a62762f273df9cb2795ceccdf77d10bf508e69e7a362ea7a45455bbf3ac955e1f2e2814f144e5d817efc4c6502cc012df310783348304e3ae38573c6d658c234025821fda87a0be8a0d504df564e2c93b2b878925f42503e9d54dfef9f9586d9e6f38a305769587b1de01f6c0410328b2c9733db",
-		"Xamarin.Android.Cecil.Mdb, PublicKey=0024000004800000940000000602000000240000525341310004000011000000438ac2a5acfbf16cbd2b2b47a62762f273df9cb2795ceccdf77d10bf508e69e7a362ea7a45455bbf3ac955e1f2e2814f144e5d817efc4c6502cc012df310783348304e3ae38573c6d658c234025821fda87a0be8a0d504df564e2c93b2b878925f42503e9d54dfef9f9586d9e6f38a305769587b1de01f6c0410328b2c9733db"
+		$"Xamarin.Android.Cecil.Pdb, PublicKey={PublicKey}",
+		$"Xamarin.Android.Cecil.Mdb, PublicKey={PublicKey}"
 	};
 
 	public static int Main (string[] args)

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -125,7 +125,7 @@ namespace Xamarin.Android.Prepare
 			/// <summary>
 			///   Version of the XA binary bundle downloaded/created by this tool.
 			/// </summary>
-			public const string XABundleVersion = "v21";
+			public const string XABundleVersion = "v22";
 
 			/// <summary>
 			///   Length to truncate the git commit hash to.


### PR DESCRIPTION
Context: http://build.azdo.io/2882865
Context: https://github.com/jbevain/cecil/blob/ab5075b3a885ffd5bee5d347b79ce71aabeb32d1/Mono.Cecil.Cil/Symbols.cs#L957-L978

Two tests on Windows have been failing on master since 0c9f83b7:

    Xamarin.Android.Build.Tests.BuildTest.BuildHasNoWarnings
        Should have zero MSBuild warnings.
        Expected: True
        But was: False

The actual warning is:

    (_GenerateJavaStubs target) ->
    warning : Failed to read 'obj\Debug\android\assets\HelloWorld.dll' with debugging symbols. Retrying to load it without it. Error detail s are logged below. [C:\src\xamarin-android\samples\HelloWorld\HelloWorld.csproj]
    warning : Mono.Cecil.Cil.SymbolsNotFoundException: No symbol found for file: obj\Debug\android\assets\HelloWorld.dll [C:\src\xamarin-an droid\samples\HelloWorld\HelloWorld.csproj]
    warning :    at Mono.Cecil.Cil.DefaultSymbolReaderProvider.GetSymbolReader(ModuleDefinition module, String fileName) [C:\src\xamarin-andr oid\samples\HelloWorld\HelloWorld.csproj]
    warning :    at Mono.Cecil.ModuleReader.ReadSymbols(ModuleDefinition module, ReaderParameters parameters) [C:\src\xamarin-android\samples \HelloWorld\HelloWorld.csproj]
    warning :    at Mono.Cecil.ModuleReader.CreateModule(Image image, ReaderParameters parameters) [C:\src\xamarin-android\samples\HelloWorld \HelloWorld.csproj]
    warning :    at Mono.Cecil.ModuleDefinition.ReadModule(String fileName, ReaderParameters parameters) [C:\src\xamarin-android\samples\Hell oWorld\HelloWorld.csproj]
    warning :    at Mono.Cecil.AssemblyDefinition.ReadAssembly(String fileName, ReaderParameters parameters) [C:\src\xamarin-android\samples\ HelloWorld\HelloWorld.csproj]
    warning :    at Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.ReadAssembly(String file) in C:\src\xamarin-android\external\Java.Inte rop\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil\DirectoryAssemblyResolver.cs:line 163

This seems to be happening when the project is using `DebugType=Full`
and produces a `.dll.mdb` file for symbols.

Digging further, it appears that `Xamarin.Android.Cecil.dll` is unable
to create a `Mono.Cecil.Mdb.MdbReaderProvider` due to this exception:

    Attempt by method 'Mono.Cecil.Mdb.MdbReaderProvider.GetSymbolReader(Mono.Cecil.ModuleDefinition, System.String)' to access method 'Mono.Cecil.Mixin.CheckModule(Mono.Cecil.ModuleDefinition)' failed.

So then I checked what `InternalsVisibleTo` is set to:

    // ends with 33db
    [assembly: InternalsVisibleTo("Xamarin.Android.Cecil.Mdb, PublicKey=0024000004800000940000000602000000240000525341310004000011000000438ac2a5acfbf16cbd2b2b47a62762f273df9cb2795ceccdf77d10bf508e69e7a362ea7a45455bbf3ac955e1f2e2814f144e5d817efc4c6502cc012df310783348304e3ae38573c6d658c234025821fda87a0be8a0d504df564e2c93b2b878925f42503e9d54dfef9f9586d9e6f38a305769587b1de01f6c0410328b2c9733db")]

But when I look at the actual assembly:

    // Xamarin.Android.Cecil.Mdb, Version=0.11.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756
    // ends with 16df
    // Public key: 024004800094000620002400525341310400101079159977d2d03a8e6bea7a2e74e8d1afcc93e8851974952bb480a12c9134474d462447c37ee68c080536fcf3c3fbe2ff9c979ce998475e56e8ce82dd5bf35dc1e93bf2eeecf874b2477c5081dbea7447fddafa277b22de47d6ffea449674a4f9fccf84d1506989380284dbdd35f46cdff12a1bd78e4ef065d016df

I think that `conjure-xamarin-android-cecil` is just using the wrong
public key when writing `InternalsVisibleTo`. Things worked fine on
macOS, since Mono is not as strict with strong naming.