### PR TITLE
Added _AddAndroidDefines target dependency for _ManagedUpdateAndroidResgen

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DeferredBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DeferredBuildTest.cs
@@ -38,6 +38,8 @@ namespace Xamarin.Android.Build.Tests
 					// The DTB passes down these two properties
 					"SkipCompilerExecution=true",
 					"ProvideCommandLineArgs=true",
+					// AndroidNDKDirectory should be set by _AddAndroidDefines target
+					"AndroidNDKDirectory="
 				}), "background build should have succeeded.");
 
 				Assert.IsFalse (appBuilder.Output.IsTargetSkipped ("UpdateAndroidResources"), $"`UpdateAndroidResources` should *not* be skipped in the deferred build!");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1323,7 +1323,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_ManagedUpdateAndroidResgen" Condition=" '$(ManagedDesignTimeBuild)' == 'True' "
 		Inputs="$(_ManagedUpdateAndroidResgenInputs);$(_AndroidResourcePathsCache);$(_AndroidLibraryProjectImportsCache);$(_AndroidLibraryImportsCache);"
 		Outputs="$(_AndroidManagedResourceDesignerFile)"
-		DependsOnTargets="_CreatePropertiesCache;_ExtractLibraryProjectImports;_CreateAdditionalResourceCache;_ValidateAndroidPackageProperties">
+		DependsOnTargets="_CreatePropertiesCache;_ExtractLibraryProjectImports;_AddAndroidDefines;_CreateAdditionalResourceCache;_ValidateAndroidPackageProperties">
 	<MakeDir Directories="$(_AndroidIntermediateDesignTimeBuildDirectory)" />
 	<!-- Parse primary R.java and create Resources.Designer.cs -->
 	<GenerateResourceDesigner


### PR DESCRIPTION
When running deferred builds as following:

`/t:DeferredBuild /p:DeferredBuild=true /p:BuildingInsideVisualStudio=true`

`ManagedDesignTimeBuild` property will be set to `true` and `_ManagedUpdateAndroidResgen`
target will be invoked as part of the `UpdateAndroidResources` target.

At this time we need to make sure that `_AddAndroidDefines` target is executed before
creating the addtional resource cache in order to set the required `AndroidNDKDirectory`
property.