### PR TITLE
[Xamarin.Android.Build.Tasks] <CopyIfChanged/> should check size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ apk-sizes-*.txt
 *.binlog
 src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props
 *~
+external/mono/
 external/monodroid/

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,5 @@ apk-sizes-*.txt
 *.binlog
 src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props
 *~
-external/mono/
 external/monodroid/
+external/mono/

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
@@ -107,7 +107,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 <Target Name="_ConvertResourcesCases"
     Condition=" '$(_AndroidUseAapt2)' == 'True' "
-    Inputs="@(AndroidResource)"
+    Inputs="$(MSBuildAllProjects);$(_AndroidBuildPropertiesCache);@(AndroidResource)"
     Outputs="$(_AndroidStampDirectory)_ConvertResourcesCases.stamp"
     DependsOnTargets="$(_BeforeConvertResourcesCases)"
   >

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -403,7 +403,7 @@ namespace UnamedProject
 		}
 
 		[Test]
-		public void BuildPropsBreaksConvertResourcesCases ()
+		public void BuildPropsBreaksConvertResourcesCases ([Values (true, false)] bool useAapt2)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 				AndroidResources = {
@@ -417,6 +417,7 @@ namespace UnamedProject
 					}
 				}
 			};
+			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "first build should have succeeded.");
 				//Invalidate build.props with newer timestamp, you could also modify anything in @(_PropertyCacheItems)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CopyIfChangedTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CopyIfChangedTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using Microsoft.Build.Framework;
+using Xamarin.Android.Tasks;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	public class CopyIfChangedTests
+	{
+		string tempDirectory;
+
+		[SetUp]
+		public void Setup ()
+		{
+			tempDirectory = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
+			Directory.CreateDirectory (tempDirectory);
+		}
+
+		[TearDown]
+		public void TearDown ()
+		{
+			Directory.Delete (tempDirectory, recursive: true);
+		}
+
+		string NewFile (string contents = null)
+		{
+			var path = Path.Combine (tempDirectory, Path.GetRandomFileName ());
+			if (!string.IsNullOrEmpty (contents)) {
+				File.WriteAllText (path, contents);
+			}
+			return path;
+		}
+
+		ITaskItem [] ToArray (string path)
+		{
+			return new [] { new TaskItem (path) };
+		}
+
+		[Test]
+		public void DestinationNoExist ()
+		{
+			var src = NewFile ("foo");
+			var dest = NewFile ();
+
+			var task = new CopyIfChanged {
+				BuildEngine = new MockBuildEngine (TestContext.Out),
+				SourceFiles = ToArray (src),
+				DestinationFiles = ToArray (dest),
+			};
+			Assert.IsTrue (task.Execute (), "task.Execute() should have succeeded.");
+			Assert.AreEqual (1, task.ModifiedFiles.Length, "Changes should have been made.");
+		}
+
+		[Test]
+		public void NoChange ()
+		{
+			var src = NewFile ("foo");
+			var dest = NewFile ("foo");
+			var now = DateTime.UtcNow;
+			File.SetLastWriteTimeUtc (src, now);
+			File.SetLastWriteTimeUtc (dest, now);
+
+			var task = new CopyIfChanged {
+				BuildEngine = new MockBuildEngine (TestContext.Out),
+				SourceFiles = ToArray (src),
+				DestinationFiles = ToArray (dest),
+			};
+			Assert.IsTrue (task.Execute (), "task.Execute() should have succeeded.");
+			Assert.AreEqual (0, task.ModifiedFiles.Length, "No changes should have been made.");
+		}
+
+		[Test]
+		public void DestinationOlder ()
+		{
+			var src = NewFile ("foo");
+			var dest = NewFile ("bar");
+			var now = DateTime.UtcNow;
+			File.SetLastWriteTimeUtc (src, now);
+			File.SetLastWriteTimeUtc (dest, now.AddSeconds (-1)); // destination is older
+
+			var task = new CopyIfChanged {
+				BuildEngine = new MockBuildEngine (TestContext.Out),
+				SourceFiles = ToArray (src),
+				DestinationFiles = ToArray (dest),
+			};
+			Assert.IsTrue (task.Execute (), "task.Execute() should have succeeded.");
+			Assert.AreEqual (1, task.ModifiedFiles.Length, "Changes should have been made.");
+		}
+
+		[Test]
+		public void SourceOlder ()
+		{
+			var src = NewFile ("foo");
+			var dest = NewFile ("foo");
+			var now = DateTime.UtcNow;
+			File.SetLastWriteTimeUtc (src, now.AddSeconds (-1)); // source is older
+			File.SetLastWriteTimeUtc (dest, now);
+
+			var task = new CopyIfChanged {
+				BuildEngine = new MockBuildEngine (TestContext.Out),
+				SourceFiles = ToArray (src),
+				DestinationFiles = ToArray (dest),
+			};
+			Assert.IsTrue (task.Execute (), "task.Execute() should have succeeded.");
+			Assert.AreEqual (0, task.ModifiedFiles.Length, "No changes should have been made.");
+		}
+
+		[Test]
+		public void SourceOlderDifferentLength ()
+		{
+			var src = NewFile ("foo");
+			var dest = NewFile ("foofoo");
+			var now = DateTime.UtcNow;
+			File.SetLastWriteTimeUtc (src, now.AddSeconds (-1)); // source is older
+			File.SetLastWriteTimeUtc (dest, now);
+
+			var task = new CopyIfChanged {
+				BuildEngine = new MockBuildEngine (TestContext.Out),
+				SourceFiles = ToArray (src),
+				DestinationFiles = ToArray (dest),
+			};
+			Assert.IsTrue (task.Execute (), "task.Execute() should have succeeded.");
+			Assert.AreEqual (1, task.ModifiedFiles.Length, "Changes should have been made.");
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -91,6 +91,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Tasks\AndroidRegExTests.cs" />
+    <Compile Include="Tasks\CopyIfChangedTests.cs" />
     <Compile Include="Tasks\GetDependenciesTests.cs" />
     <Compile Include="Tasks\ResolveSdksTaskTests.cs" />
     <Compile Include="Tasks\AndroidResourceTests.cs" />


### PR DESCRIPTION
[Xamarin.Android.Build.Tasks] <CopyIfChanged/> should check size

Fixes: https://github.com/xamarin/xamarin-android/issues/2584

Building a project with two different `$(TargetFrameworkVersion)`:

    msbuild /p:Configuration=Release /p:TargetFrameworkVersion=v4.4
    msbuild /t:Configuration=Release /p:TargetFrameworkVersion=v9.0

Results in a build error:

    error MSB4018: The "LinkAssemblies" task failed unexpectedly.
    Mono.Linker.MarkException: Error processing method: 'System.Void BatchStepSensor.BatchStepSensorFragment::OnSaveInstanceState(Android.OS.Bundle)' in assembly: 'BatchStepSensor.dll' ---> Mono.Cecil.ResolutionException: Failed to resolve System.Void Android.OS.BaseBundle::PutInt(System.String,System.Int32)
        at Mono.Linker.Steps.MarkStep.HandleUnresolvedMethod(MethodReference reference)
        at Mono.Linker.Steps.MarkStep.MarkMethod(MethodReference reference)
        at Mono.Linker.Steps.MarkStep.MarkInstruction(Instruction instruction)
        at Mono.Linker.Steps.MarkStep.MarkMethodBody(MethodBody body)
        at Mono.Linker.Steps.MarkStep.ProcessMethod(MethodDefinition method)
        at Mono.Linker.Steps.MarkStep.ProcessQueue()
        --- End of inner exception stack trace ---
        at Mono.Linker.Steps.MarkStep.ProcessQueue()
        at Mono.Linker.Steps.MarkStep.ProcessPrimaryQueue()
        at Mono.Linker.Steps.MarkStep.Process()
        at MonoDroid.Tuner.MonoDroidMarkStep.Process(LinkContext context)
        at Mono.Linker.Pipeline.ProcessStep(LinkContext context, IStep step)
        at Mono.Linker.Pipeline.Process(LinkContext context)
        at MonoDroid.Tuner.Linker.Process(LinkerOptions options, ILogger logger, LinkContext& context)
        at Xamarin.Android.Tasks.LinkAssemblies.Execute(DirectoryAssemblyResolver res)
        at Xamarin.Android.Tasks.LinkAssemblies.Execute()
        at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
        at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext()

Which is due to an outdated `Mono.Android.dll` in the `obj` directory:

    Target Name=_CopyIntermediateAssemblies
        CopyIfChanged
        ...
        Skipping C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v9.0\Mono.Android.dll its up to date
        ...
        ModifiedFiles:
            obj\Release\linksrc\BatchStepSensor.dll

Reviewing the `<CopyIfChanged/>` MSBuild task, there is a code path
where the copy is skipped if the source file is newer than the
destination.

In the case of modifying `$(TargetFrameworkVersion)` on an incremental
build, a *different* `Mono.Android.dll` would have an older timestamp.
The copy would be skipped.

A fix here is to *also* check the size of the source and destination
files, and only allow the copy to be skipped if the sizes match.

## _ConvertResourcesCases ##

These changes surfaced a bug in the `_ConvertResourcesCases` target,
if `build.props` changes then:

* The `_CompileResources` target runs
* `_ConvertResourcesCases` is skipped...

And you get a build error such as:

    Resources\layout\test.axml(3): error APT0000: resource drawable/IMALLCAPS (aka UnnamedProject.UnnamedProject:drawable/IMALLCAPS) not found.

The solution here is to make the `Inputs` of `_CompileResources` and
`_ConvertResourcesCases` the same. I also adjusted a test to check
both aapt and aapt2.