### PR TITLE
[aapt2] Bump Aapt2 to Version 3.5.0-5435860

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -102,6 +102,8 @@ namespace Xamarin.Android.Tasks {
 				var file = match.Groups ["file"].Value;
 				var level = match.Groups ["level"].Value.ToLowerInvariant ();
 				var message = match.Groups ["message"].Value;
+				if (singleLine.StartsWith ($"{ToolName} W", StringComparison.OrdinalIgnoreCase))
+					return true;
 				if (file.StartsWith ("W/", StringComparison.OrdinalIgnoreCase))
 					return true;
 				if (message.Contains ("warn:"))
@@ -139,6 +141,10 @@ namespace Xamarin.Android.Tasks {
 					LogCodedError ("APT0001", $"{message}. This is the result of using `aapt` command line arguments with `aapt2`. The arguments are not compatible.");
 					return false;
 				}
+				if (message.Contains ("in APK") && message.Contains ("is compressed.")) {
+					LogMessage (singleLine, messageImportance);
+					return true;
+				}
 				if (message.Contains ("fakeLogOpen")) {
 					LogMessage (singleLine, messageImportance);
 					return true;
@@ -155,7 +161,7 @@ namespace Xamarin.Android.Tasks {
 					LogMessage (message, messageImportance);
 					return true;
 				}
-				if (level.Contains ("warning")) {
+				if (level.Contains ("warning") || level.StartsWith ($"{ToolName} W", StringComparison.OrdinalIgnoreCase)) {
 					LogCodedWarning (GetErrorCode (singleLine), singleLine);
 					return true;
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidToolTask.cs
@@ -80,6 +80,8 @@ namespace Xamarin.Android.Tasks
 		//   Resources/values/theme.xml(2): error APT0000: Error retrieving parent for item: No resource found that matches the given name '@android:style/Theme.AppCompat'.
 		//   Resources/values/theme.xml:2: error APT0000: Error retrieving parent for item: No resource found that matches the given name '@android:style/Theme.AppCompat'.
 		//   res/drawable/foo-bar.jpg: Invalid file name: must contain only [a-z0-9_.]
+		// Warnings can be like this
+		//   aapt2 W 09-17 18:15:27 98796 12879433 ApkAssets.cpp:138] resources.arsc in APK 'android.jar' is compressed.
 		// Look for them and convert them to MSBuild compatible errors.
 		static Regex androidErrorRegex;
 		public static Regex AndroidErrorRegex {
@@ -99,9 +101,9 @@ namespace Xamarin.Android.Tasks
  \s*
  :
 )?
-( # optional warning|error:
+( # optional warning|error|aapt2\sW|aapt2.exe\sW:
  \s*
- (?<level>(warning|error)[^:]*)\s*
+ (?<level>(warning|error|aapt2\sW|aapt2.exe\sW)[^:]*)\s*
  :
 )?
 \s*

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/AndroidRegExTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/AndroidRegExTests.cs
@@ -146,6 +146,22 @@ namespace Xamarin.Android.Build.Tests
 					/*expectedLevel*/	"",
 					/*expectedMessage*/	"For resource 0x0101053d, entry index(1341) is beyond type entryCount(1155)"
 				};
+				yield return new object [] {
+					/*message*/		"aapt2 W 09-17 18:15:27 98796 12879433 ApkAssets.cpp:138] resources.arsc in APK 'android.jar' is compressed.",
+					/*expectedToMatch*/	true,
+					/*expectedFile*/	"",
+					/*expectedLine*/	"",
+					/*expectedLevel*/	"aapt2 W 09-17 18",
+					/*expectedMessage*/	"15:27 98796 12879433 ApkAssets.cpp:138] resources.arsc in APK 'android.jar' is compressed."
+				};
+				yield return new object [] {
+					/*message*/		"aapt2.exe W 09-17 18:15:27 98796 12879433 ApkAssets.cpp:138] resources.arsc in APK 'android.jar' is compressed.",
+					/*expectedToMatch*/	true,
+					/*expectedFile*/	"",
+					/*expectedLine*/	"",
+					/*expectedLevel*/	"aapt2.exe W 09-17 18",
+					/*expectedMessage*/	"15:27 98796 12879433 ApkAssets.cpp:138] resources.arsc in APK 'android.jar' is compressed."
+				};
 			}
 		}
 

--- a/src/aapt2/aapt2.targets
+++ b/src/aapt2/aapt2.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.DownloadUri" />
   <PropertyGroup>
-    <Aapt2Version>3.4.1-5326820</Aapt2Version>
+    <Aapt2Version>3.5.0-5435860</Aapt2Version>
     <BuildDependsOn>
       ResolveReferences;
       _DownloadAapt2;


### PR DESCRIPTION
Source https://mvnrepository.com/artifact/com.android.tools.build/aapt2/3.5.0-5435860

This PR updates the `aapt2` tool we ship to the latest stable version. It also adds some additional message processing. The line [1] is a warning, and it is being picked up as an error by out Task. This is because it is not following the same pattern as other warnings. 

```
// aapt2 W 09-17 18:15:27 98796 12879433 ApkAssets.cpp:138] resources.arsc in APK 'android.jar' is compressed.
```

So in this case we need to look for the `aapt2 W ` and tag such lines as warnings not errors.


[1] https://github.com/aosp-mirror/platform_frameworks_base/blob/master/libs/androidfw/ApkAssets.cpp#L137