### PR TITLE
[tests] improve InvalidAndroidResource failure

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -693,13 +693,14 @@ namespace Lib2
 			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				b.ThrowOnBuildFailure = false;
-
 				proj.OtherBuildItems.Add (invalidXml);
 				Assert.IsFalse (b.Build (proj), "Build should *not* have succeeded.");
 
+				b.ThrowOnBuildFailure = true;
 				proj.OtherBuildItems.Remove (invalidXml);
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 
+				b.ThrowOnBuildFailure = false;
 				proj.OtherBuildItems.Add (invalidXml);
 				Assert.IsFalse (b.Build (proj), "Build should *not* have succeeded.");
 			}


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/job/xamarin-android-pr-pipeline-release/1744/testReport/Xamarin.Android.Build.Tests.IncrementalBuildTest/InvalidAndroidResource/_True____Release/

`IncrementalBuildTest.InvalidAndroidResource` is sometimes failing on
Jenkins with:

    Build should have succeeded.
      Expected: True
      But was:  False

If we set `ThrowOnBuildFailure` back to `True` before this assertion,
we will get a proper build log in the error message.