### PR TITLE
Changing metadata to not remove AudioRecord interfaces

### DIFF
--- a/src/Mono.Android/Android.Media/AudioRecord.cs
+++ b/src/Mono.Android/Android.Media/AudioRecord.cs
@@ -1,0 +1,26 @@
+using System;
+using Android.Runtime;
+
+namespace Android.Media
+{
+
+	public partial class AudioRecord
+	{
+
+#if ANDROID_29
+		[Obsolete ("Please do not use Android.Media.AudioRecord.RoutingChangedEventArgs since it was wrongly generated and it is not used internally.", error: true)]
+		public partial class RoutingChangedEventArgs : global::System.EventArgs {
+
+			public RoutingChangedEventArgs (Android.Media.AudioRecord audioRecord)
+			{
+				this.audioRecord = audioRecord;
+			}
+
+			Android.Media.AudioRecord audioRecord;
+			public Android.Media.AudioRecord AudioRecord {
+				get { return audioRecord; }
+			}
+		}
+#endif  // ANDROID_29
+	}
+}

--- a/src/Mono.Android/Android.Media/AudioTrack.cs
+++ b/src/Mono.Android/Android.Media/AudioTrack.cs
@@ -16,6 +16,22 @@ namespace Android.Media
 		{
 		}
 #endif
+
+#if ANDROID_29
+		[Obsolete ("Please do not use Android.Media.AudioTrack.RoutingChangedEventArgs since it was wrongly generated and it is not used internally.", error: true)]
+		public partial class RoutingChangedEventArgs : global::System.EventArgs {
+
+			public RoutingChangedEventArgs (Android.Media.AudioTrack audioTrack)
+			{
+				this.audioTrack = audioTrack;
+			}
+
+			Android.Media.AudioTrack audioTrack;
+			public Android.Media.AudioTrack AudioTrack {
+				get { return audioTrack; }
+			}
+		}
+#endif  // ANDROID_29
 	}
 }
 

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -174,6 +174,7 @@
     <Compile Include="Android.InputMethodServices\KeyboardView.cs" />
     <Compile Include="Android.Locations\LocationManager.cs" />
     <Compile Include="Android.Media\AudioManager.cs" />
+    <Compile Include="Android.Media\AudioRecord.cs" />
     <Compile Include="Android.Media\AudioTrack.cs" />
     <Compile Include="Android.Media\MediaMetadataRetriever.cs" />
     <Compile Include="Android.Media\MediaPlayer.cs" />

--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -1264,7 +1264,7 @@
   <!-- android.media.AudioRouting.OnRoutingChangedListener is a new
   interface that is added to AudioRecord and AudioTrack *as a base
   interface*. It is a breaking change if it were in C#, but surprisingly
-  not in Java because the method is *implemented* in thosee derived
+  not in Java because the method is *implemented* in those derived
   interfaces as a default method(!)
 
   Problems are:
@@ -1285,21 +1285,28 @@
   types and methods so far. Offering awkward API that forces manual
   fixup to rename every descendants is no-go.
 
+  *** The description above will cover scenarios from api 24 until api 28.
+  *** On api 29, we re-evaluate the scenario and we discovered that the fix is not the correct fix and is not working as expected
+  *** We should/will not remove AudioRouting anymore so developers can take advantage and use this interface and have access to the non obsolete method.
+  *** To avoid api breakage we will manually add RoutingChangedEventArgs to AudoTrack and AudoRecord classes.
+
   -->
 
-  <remove-node path="/api/package[@name='android.media']/interface[@name='AudioRouting']" />
-  <remove-node path="/api/package[@name='android.media']/class[@name='AudioRecord']/implements[@name='android.media.AudioRouting']" />
-  <remove-node path="/api/package[@name='android.media']/class[@name='AudioTrack']/implements[@name='android.media.AudioRouting']" />
+  <remove-node path="/api/package[@name='android.media']/interface[@name='AudioRouting']" api-since="24" api-until="28"/>
+  <remove-node path="/api/package[@name='android.media']/class[@name='AudioRecord']/implements[@name='android.media.AudioRouting']" api-since="24" api-until="28" />
+  <remove-node path="/api/package[@name='android.media']/class[@name='AudioTrack']/implements[@name='android.media.AudioRouting']" api-since="24" api-until="28" />
 
-  <remove-node path="/api/package[@name='android.media']/interface[@name='AudioRouting.OnRoutingChangedListener']" />
+  <remove-node path="/api/package[@name='android.media']/interface[@name='AudioRouting.OnRoutingChangedListener']" api-since="24" api-until="28" />
 
-  <remove-node path="/api/package[@name='android.media']/interface[@name='AudioRecord.OnRoutingChangedListener']/implements[@name='android.media.AudioRouting.OnRoutingChangedListener']" />
-  <remove-node path="/api/package[@name='android.media']/interface[@name='AudioRecord.OnRoutingChangedListener']/method[@name='onRoutingChanged' and parameter[1]/@type='android.media.AudioRouting']" />
-  <remove-node path="/api/package[@name='android.media']/interface[@name='AudioTrack.OnRoutingChangedListener']/implements[@name='android.media.AudioRouting.OnRoutingChangedListener']" />
-  <remove-node path="/api/package[@name='android.media']/interface[@name='AudioTrack.OnRoutingChangedListener']/method[@name='onRoutingChanged' and parameter[1]/@type='android.media.AudioRouting']" />
+  <remove-node path="/api/package[@name='android.media']/interface[@name='AudioRecord.OnRoutingChangedListener']/implements[@name='android.media.AudioRouting.OnRoutingChangedListener']" api-since="24" api-until="28" />
+  <remove-node path="/api/package[@name='android.media']/interface[@name='AudioRecord.OnRoutingChangedListener']/method[@name='onRoutingChanged' and parameter[1]/@type='android.media.AudioRouting']" api-since="24" api-until="28" />
+  <remove-node path="/api/package[@name='android.media']/interface[@name='AudioTrack.OnRoutingChangedListener']/implements[@name='android.media.AudioRouting.OnRoutingChangedListener']" api-since="24" api-until="28" />
+  <remove-node path="/api/package[@name='android.media']/interface[@name='AudioTrack.OnRoutingChangedListener']/method[@name='onRoutingChanged' and parameter[1]/@type='android.media.AudioRouting']" api-since="24" api-until="28" />
 
-  <remove-node path="/api/package[@name='android.media']/class[@name='AudioRecord']/method[@name='addOnRoutingChangedListener' and parameter[1]/@type='android.media.AudioRouting.OnRoutingChangedListener']" />
-  <remove-node path="/api/package[@name='android.media']/class[@name='AudioTrack']/method[@name='addOnRoutingChangedListener' and parameter[1]/@type='android.media.AudioRouting.OnRoutingChangedListener']" />
+  <remove-node path="/api/package[@name='android.media']/class[@name='AudioRecord']/method[@name='addOnRoutingChangedListener' and parameter[1]/@type='android.media.AudioRouting.OnRoutingChangedListener']" api-since="24" api-until="28" />
+  <remove-node path="/api/package[@name='android.media']/class[@name='AudioTrack']/method[@name='addOnRoutingChangedListener' and parameter[1]/@type='android.media.AudioRouting.OnRoutingChangedListener']" api-since="24" api-until="28" />
+
+  <!-- end of AudioRouting fix -->
 
   <!-- field name conflict -->
   <attr path="/api/package[@name='android.provider']/class[@name='ContactsContract.CommonDataKinds.Organization']/field[@name='PHONETIC_NAME_STYLE']" name="managedName">PhoneticNameStyleField</attr>


### PR DESCRIPTION
Starting on Api 29, Changing metadata to not remove AudioRecord interfaces anymore
Adding RoutingChangedEventArgs class back to AudioRecord and AudioTrack via partial class

Issue: https://github.com/xamarin/xamarin-android/issues/3313