### PR TITLE
[Xamarin.Android.Build.Tasks] _LinkAssemblies ordering for code analysis

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -167,6 +167,19 @@ class MemTest {
 		}
 
 		[Test]
+		public void CodeAnalysis ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true
+			};
+			proj.SetProperty ("RunCodeAnalysis", "True");
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				b.Target = "Build";
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
+		[Test]
 		[NonParallelizable]
 		public void SkipConvertResourcesCases ([Values (false, true)] bool useAapt2)
 		{

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2264,7 +2264,6 @@ because xbuild doesn't support framework reference assemblies.
   <_GenerateJavaStubsDependsOnTargets>
     _SetLatestTargetFrameworkVersion;
     _PrepareNativeAssemblySources;
-    _LinkAssemblies;
     _PrepareAssemblies;
     $(_AfterPrepareAssemblies);
   </_GenerateJavaStubsDependsOnTargets>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3322

Enabling code analysis via `<RunCodeAnalysis>true</RunCodeAnalysis>`
results in a build error for `Release` configurations:

    error MSB4018: The "LinkAssemblies" task failed unexpectedly.
    error MSB4018: System.IO.FileNotFoundException: Could not load assembly 'DroidButton, Version=0.0.0.0, Culture=neutral, PublicKeyToken='. Perhaps it doesn't exist in the Mono for Android profile?
    error MSB4018: File name: 'DroidButton.dll'
    error MSB4018:   at Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.Resolve (Mono.Cecil.AssemblyNameReference reference, Mono.Cecil.ReaderParameters parameters) [0x00125] in <bf8d1485bd8b4cc8b07ee73dc73c2c6c>:0
    error MSB4018:   at Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.Resolve (System.String fullName, Mono.Cecil.ReaderParameters parameters) [0x00007] in <bf8d1485bd8b4cc8b07ee73dc73c2c6c>:0
    error MSB4018:   at Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.Resolve (System.String fullName) [0x00000] in <bf8d1485bd8b4cc8b07ee73dc73c2c6c>:0
    error MSB4018:   at Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.GetAssembly (System.String fileName) [0x00007] in <bf8d1485bd8b4cc8b07ee73dc73c2c6c>:0
    error MSB4018:   at Xamarin.Android.Tasks.LinkAssemblies.Execute (Java.Interop.Tools.Cecil.DirectoryAssemblyResolver res) [0x0004d] in <d8e2132c4a15403dbf186d3f29b4d4ff>:0
    error MSB4018:   at Xamarin.Android.Tasks.LinkAssemblies.Execute () [0x0001b] in <d8e2132c4a15403dbf186d3f29b4d4ff>:0
    error MSB4018:   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute () [0x00029] in <9793e3774951417ca4f48a7c60193b35>:0
    error MSB4018:   at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask (Microsoft.Build.BackEnd.ITaskExecutionHost taskExecutionHost, Microsoft.Build.BackEnd.Logging.TaskLoggingContext taskLoggingContext, Microsoft.Build.BackEnd.TaskHost taskHost, Microsoft.Build.BackEnd.ItemBucket bucket, Microsoft.Build.BackEnd.TaskExecutionMode howToExecuteTask) [0x002a9] in <9793e3774951417ca4f48a7c60193b35>:0

The `<LinkAssemblies/>` failure is due to the `linksrc` directory
being completely empty? It appears that `_PrepareAssemblies` and
`_CopyIntermediateAssemblies` was not run at all?

Looking at the value of `$(_GenerateJavaStubsDependsOnTargets)` the
ordering did not make sense:

    <_GenerateJavaStubsDependsOnTargets>
      _SetLatestTargetFrameworkVersion;
      _PrepareNativeAssemblySources;
      _LinkAssemblies;
      _PrepareAssemblies;
      $(_AfterPrepareAssemblies);
    </_GenerateJavaStubsDependsOnTargets>

`_LinkAssemblies` should not run *before* `_PrepareAssemblies`, since
`_PrepareAssemblies` lists other targets such as
`_CopyIntermediateAssemblies` that should run first. In a38cf5bb, we
added extension points for AndroidX, but I think this value was listed
by mistake. We should be able to just remove `_LinkAssemblies` here.

I am not sure how things were working with how this is... There must be
a subtle MSBuild ordering bug where `_LinkAssemblies` is running out
of order, but only when code analysis is used.