### PR TITLE
[Xamarin.Android.Build.Tasks] fix for empty $(AndroidNdkDirectory)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
@@ -38,7 +38,6 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string AndroidSdkDirectory { get; set; }
 
-		[Required]
 		public string AndroidNdkDirectory { get; set; }
 
 		[Required]
@@ -71,8 +70,14 @@ namespace Xamarin.Android.Tasks
 			MatchEvaluator replaceEnvVar = (Match m) => {
 				var e = m.Groups [2].Value;
 				switch (e) {
-				case "ANDROID_SDK_PATH": return AndroidSdkDirectory.TrimEnd (Path.DirectorySeparatorChar);
-				case "ANDROID_NDK_PATH": return AndroidNdkDirectory.TrimEnd (Path.DirectorySeparatorChar);
+				case "ANDROID_SDK_PATH":
+					return AndroidSdkDirectory.TrimEnd (Path.DirectorySeparatorChar);
+				case "ANDROID_NDK_PATH":
+					//NOTE: AndroidNdkDirectory is not [Required]
+					if (string.IsNullOrEmpty (AndroidNdkDirectory)) {
+						goto default;
+					}
+					return AndroidNdkDirectory.TrimEnd (Path.DirectorySeparatorChar);
 				default:
 					var v = Environment.GetEnvironmentVariable (e);
 					if (!string.IsNullOrEmpty (v))

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ResolveMonoAndroidSdksTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ResolveMonoAndroidSdksTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using Xamarin.ProjectTools;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	public class ResolveMonoAndroidSdksTests : BaseTest
+	{
+		static readonly string [] parameters = new [] { "_ResolveMonoAndroidSdksDependsOn=" };
+		static readonly string [] messages = new [] {
+			"MonoAndroid Tools",
+			"Java SDK",
+			"Android SDK",
+			"Android NDK",
+			"Android Platform API level",
+		};
+
+		static Dictionary<string, string> ValuesFromLog (ProjectBuilder b)
+		{
+			var values = new Dictionary<string, string> ();
+			foreach (var line in b.LastBuildOutput) {
+				foreach (var key in messages) {
+					int index = line.IndexOf (key + ":", StringComparison.OrdinalIgnoreCase);
+					if (index != -1) {
+						index += key.Length + 1;
+						var value = line.Substring (index, line.Length - index).Trim ();
+						// The log line might also include a message such as: (TaskId:7)
+						index = value.IndexOf ("(", StringComparison.OrdinalIgnoreCase);
+						if (index != -1) {
+							value = value.Substring (0, index).Trim ();
+						}
+						values [key] = value;
+					}
+				}
+			}
+			return values;
+		}
+
+		[Test]
+		public void NormalInputs ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty ("MonoAndroidToolsDirectory", "xat");
+			proj.SetProperty ("_JavaSdkDirectory", "jdk");
+			proj.SetProperty ("_AndroidSdkDirectory", "sdk");
+			proj.SetProperty ("_AndroidNdkDirectory", "ndk");
+			proj.SetProperty ("_AndroidApiLevel", "29");
+
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				b.Target = "_ResolveMonoAndroidSdks";
+				Assert.IsTrue (b.Build (proj, parameters: parameters), "Build should have succeeded.");
+
+				var values = ValuesFromLog (b);
+				Assert.AreEqual ("xat\\", values ["MonoAndroid Tools"]);
+				Assert.AreEqual ("jdk\\", values ["Java SDK"]);
+				Assert.AreEqual ("sdk\\", values ["Android SDK"]);
+				Assert.AreEqual ("ndk\\", values ["Android NDK"]);
+				Assert.AreEqual ("29",    values ["Android Platform API level"]);
+			}
+		}
+
+		[Test]
+		public void MissingAndroidNDK ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty ("MonoAndroidToolsDirectory", "xat");
+			proj.SetProperty ("_JavaSdkDirectory", "jdk");
+			proj.SetProperty ("_AndroidSdkDirectory", "sdk");
+			proj.SetProperty ("_AndroidNdkDirectory", "");
+			proj.SetProperty ("_AndroidApiLevel", "29");
+
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				b.Target = "_ResolveMonoAndroidSdks";
+				Assert.IsTrue (b.Build (proj, parameters: parameters), "Build should have succeeded.");
+
+				var values = ValuesFromLog (b);
+				Assert.AreEqual ("xat\\", values ["MonoAndroid Tools"]);
+				Assert.AreEqual ("jdk\\", values ["Java SDK"]);
+				Assert.AreEqual ("sdk\\", values ["Android SDK"]);
+				Assert.AreEqual ("",      values ["Android NDK"]);
+				Assert.AreEqual ("29",    values ["Android Platform API level"]);
+			}
+		}
+
+		[Test]
+		public void HasTrailingSlash ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty ("MonoAndroidToolsDirectory", "xat\\");
+			proj.SetProperty ("_JavaSdkDirectory", "jdk\\");
+			proj.SetProperty ("_AndroidSdkDirectory", "sdk\\");
+			proj.SetProperty ("_AndroidNdkDirectory", "ndk\\");
+			proj.SetProperty ("_AndroidApiLevel", "29");
+
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				b.Target = "_ResolveMonoAndroidSdks";
+				Assert.IsTrue (b.Build (proj, parameters: parameters), "Build should have succeeded.");
+
+				var values = ValuesFromLog (b);
+				Assert.AreEqual ("xat\\", values ["MonoAndroid Tools"]);
+				Assert.AreEqual ("jdk\\", values ["Java SDK"]);
+				Assert.AreEqual ("sdk\\", values ["Android SDK"]);
+				Assert.AreEqual ("ndk\\", values ["Android NDK"]);
+				Assert.AreEqual ("29",    values ["Android Platform API level"]);
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ResolveMonoAndroidSdksTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ResolveMonoAndroidSdksTests.cs
@@ -54,10 +54,10 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (b.Build (proj, parameters: parameters), "Build should have succeeded.");
 
 				var values = ValuesFromLog (b);
-				Assert.AreEqual ("xat\\", values ["MonoAndroid Tools"]);
-				Assert.AreEqual ("jdk\\", values ["Java SDK"]);
-				Assert.AreEqual ("sdk\\", values ["Android SDK"]);
-				Assert.AreEqual ("ndk\\", values ["Android NDK"]);
+				Assert.AreEqual ($"xat{Path.DirectorySeparatorChar}", values ["MonoAndroid Tools"]);
+				Assert.AreEqual ($"jdk{Path.DirectorySeparatorChar}", values ["Java SDK"]);
+				Assert.AreEqual ($"sdk{Path.DirectorySeparatorChar}", values ["Android SDK"]);
+				Assert.AreEqual ($"ndk{Path.DirectorySeparatorChar}", values ["Android NDK"]);
 				Assert.AreEqual ("29",    values ["Android Platform API level"]);
 			}
 		}
@@ -77,9 +77,9 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (b.Build (proj, parameters: parameters), "Build should have succeeded.");
 
 				var values = ValuesFromLog (b);
-				Assert.AreEqual ("xat\\", values ["MonoAndroid Tools"]);
-				Assert.AreEqual ("jdk\\", values ["Java SDK"]);
-				Assert.AreEqual ("sdk\\", values ["Android SDK"]);
+				Assert.AreEqual ($"xat{Path.DirectorySeparatorChar}", values ["MonoAndroid Tools"]);
+				Assert.AreEqual ($"jdk{Path.DirectorySeparatorChar}", values ["Java SDK"]);
+				Assert.AreEqual ($"sdk{Path.DirectorySeparatorChar}", values ["Android SDK"]);
 				Assert.AreEqual ("",      values ["Android NDK"]);
 				Assert.AreEqual ("29",    values ["Android Platform API level"]);
 			}
@@ -89,10 +89,10 @@ namespace Xamarin.Android.Build.Tests
 		public void HasTrailingSlash ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
-			proj.SetProperty ("MonoAndroidToolsDirectory", "xat\\");
-			proj.SetProperty ("_JavaSdkDirectory", "jdk\\");
-			proj.SetProperty ("_AndroidSdkDirectory", "sdk\\");
-			proj.SetProperty ("_AndroidNdkDirectory", "ndk\\");
+			proj.SetProperty ("MonoAndroidToolsDirectory", $"xat{Path.DirectorySeparatorChar}");
+			proj.SetProperty ("_JavaSdkDirectory", $"jdk{Path.DirectorySeparatorChar}");
+			proj.SetProperty ("_AndroidSdkDirectory", $"sdk{Path.DirectorySeparatorChar}");
+			proj.SetProperty ("_AndroidNdkDirectory", $"ndk{Path.DirectorySeparatorChar}");
 			proj.SetProperty ("_AndroidApiLevel", "29");
 
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
@@ -100,10 +100,10 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (b.Build (proj, parameters: parameters), "Build should have succeeded.");
 
 				var values = ValuesFromLog (b);
-				Assert.AreEqual ("xat\\", values ["MonoAndroid Tools"]);
-				Assert.AreEqual ("jdk\\", values ["Java SDK"]);
-				Assert.AreEqual ("sdk\\", values ["Android SDK"]);
-				Assert.AreEqual ("ndk\\", values ["Android NDK"]);
+				Assert.AreEqual ($"xat{Path.DirectorySeparatorChar}", values ["MonoAndroid Tools"]);
+				Assert.AreEqual ($"jdk{Path.DirectorySeparatorChar}", values ["Java SDK"]);
+				Assert.AreEqual ($"sdk{Path.DirectorySeparatorChar}", values ["Android SDK"]);
+				Assert.AreEqual ($"ndk{Path.DirectorySeparatorChar}", values ["Android NDK"]);
 				Assert.AreEqual ("29",    values ["Android Platform API level"]);
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Tasks\AndroidRegExTests.cs" />
     <Compile Include="Tasks\CopyIfChangedTests.cs" />
     <Compile Include="Tasks\GetDependenciesTests.cs" />
+    <Compile Include="Tasks\ResolveMonoAndroidSdksTests.cs" />
     <Compile Include="Tasks\ResolveSdksTaskTests.cs" />
     <Compile Include="Tasks\AndroidResourceTests.cs" />
     <Compile Include="Tasks\ManagedResourceParserTests.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -922,55 +922,17 @@ because xbuild doesn't support framework reference assemblies.
 	</GetAppSettingsDirectory>
 
 	<!-- ensure a version of paths with trailing slashes even if overridden by /p:foo=bar -->
-	<CreateProperty Value="$(AppSettingsDirectory)">
-		<Output TaskParameter="Value" PropertyName="_AppSettingsDirectory"/>
-	</CreateProperty>
-	<CreateProperty Value="$(_AppSettingsDirectory)\">
-		<Output TaskParameter="Value" PropertyName="_AppSettingsDirectory"
-			Condition="!HasTrailingSlash('$(_AppSettingsDirectory)')" />
-	</CreateProperty>
+	<PropertyGroup>
+		<_AppSettingsDirectory>$([MSBuild]::EnsureTrailingSlash($(AppSettingsDirectory)))</_AppSettingsDirectory>
+		<_ApkDebugKeyStore Condition=" '$(_ApkDebugKeyStore)' == '' ">$(_AppSettingsDirectory)debug.keystore</_ApkDebugKeyStore>
+		<_MonoAndroidToolsDirectory>$([MSBuild]::EnsureTrailingSlash($(MonoAndroidToolsDirectory)))</_MonoAndroidToolsDirectory>
+		<_AndroidNdkDirectory>$([MSBuild]::EnsureTrailingSlash($(_AndroidNdkDirectory)))</_AndroidNdkDirectory>
+		<_AndroidSdkDirectory>$([MSBuild]::EnsureTrailingSlash($(_AndroidSdkDirectory)))</_AndroidSdkDirectory>
+		<AndroidSdkBuildToolsPath>$([MSBuild]::EnsureTrailingSlash($(AndroidSdkBuildToolsPath)))</AndroidSdkBuildToolsPath>
+		<AndroidSdkBuildToolsBinPath>$([MSBuild]::EnsureTrailingSlash($(AndroidSdkBuildToolsBinPath)))</AndroidSdkBuildToolsBinPath>
+		<_JavaSdkDirectory>$([MSBuild]::EnsureTrailingSlash($(_JavaSdkDirectory)))</_JavaSdkDirectory>
+	</PropertyGroup>
 
-	<CreateProperty Value="$(_AppSettingsDirectory)debug.keystore">
-		<Output TaskParameter="Value" PropertyName="_ApkDebugKeyStore"
-			Condition="'$(_ApkDebugKeyStore)' == ''"
-		/>
-	</CreateProperty>
-
-	<CreateProperty Value="$(MonoAndroidToolsDirectory)">
-		<Output TaskParameter="Value" PropertyName="_MonoAndroidToolsDirectory"/>
-	</CreateProperty>
-	<CreateProperty Value="$(_MonoAndroidToolsDirectory)\">
-		<Output TaskParameter="Value" PropertyName="_MonoAndroidToolsDirectory"
-			Condition="!HasTrailingSlash('$(_MonoAndroidToolsDirectory)')" />
-	</CreateProperty>
-
-	<CreateProperty Value="$(_AndroidNdkDirectory)\">
-		<Output TaskParameter="Value" PropertyName="_AndroidNdkDirectory"
-			Condition="!HasTrailingSlash('$(_AndroidNdkDirectory)')" />
-	</CreateProperty>
-
-	<CreateProperty Value="$(_AndroidSdkDirectory)\">
-		<Output TaskParameter="Value" PropertyName="_AndroidSdkDirectory"
-			Condition="!HasTrailingSlash('$(_AndroidSdkDirectory)')" />
-	</CreateProperty>
-
-	<CreateProperty Value="$(AndroidSdkBuildToolsPath)\">
-		<Output TaskParameter="Value" PropertyName="AndroidSdkBuildToolsPath"
-				Condition="!HasTrailingSlash('$(AndroidSdkBuildToolsPath)')"
-		/>
-	</CreateProperty>
-
-	<CreateProperty Value="$(AndroidSdkBuildToolsBinPath)\">
-		<Output TaskParameter="Value" PropertyName="AndroidSdkBuildToolsBinPath"
-				Condition="!HasTrailingSlash('$(AndroidSdkBuildToolsBinPath)')"
-		/>
-	</CreateProperty>
-
-	<CreateProperty Value="$(_JavaSdkDirectory)\">
-		<Output TaskParameter="Value" PropertyName="_JavaSdkDirectory"
-			Condition="!HasTrailingSlash('$(_JavaSdkDirectory)')" />
-	</CreateProperty>
-	
 	<Message Text="MonoAndroid Tools: $(_MonoAndroidToolsDirectory)"/>
 	<Message Text="Android Platform API level: $(_AndroidApiLevel)"/>
 	<Message Text="TargetFrameworkVersion: $(TargetFrameworkVersion)"/>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/3402

When reviewing #3402, we found two things that seem wrong™:

* A case where `AndroidNdkDirectory` in the
  `<GetAdditionalResourcesFromAssemblies/>` MSBuild task, was
  `[Required]`. How did that ever work?
* In cases where `$(AndroidNdkDirectory)` is blank, it appears to get
  set to `\`. Ok that's how it worked...

The first fix was to just remove `[Required]`, I did not find any
other places this was incorrect. I also had to adjust
`<GetAdditionalResourcesFromAssemblies/>` to account for the value
being blank.

Then I revisited the pattern we have in the `_ResolveMonoAndroidSdks`
MSBuild target:

    <CreateProperty Value="$(AppSettingsDirectory)">
        <Output TaskParameter="Value" PropertyName="_AppSettingsDirectory"/>
    </CreateProperty>
    <CreateProperty Value="$(_AppSettingsDirectory)\">
        <Output TaskParameter="Value" PropertyName="_AppSettingsDirectory"
            Condition="!HasTrailingSlash('$(_AppSettingsDirectory)')" />
    </CreateProperty>

That is a lot of logic, which actually doesn't work properly if the
incoming value is blank... The end result is `\`.

This would be more properly written as:

    <_AppSettingsDirectory>$([MSBuild]::EnsureTrailingSlash($(AppSettingsDirectory)))</_AppSettingsDirectory>

https://docs.microsoft.com/en-us/visualstudio/msbuild/property-functions?view=vs-2019#msbuild-property-functions

Using `$([MSBuild]::EnsureTrailingSlash())` does the following:

    If the given path doesn't have a trailing slash then add one. If the path is an empty string, does not modify it.

I have reworked the `_ResolveMonoAndroidSdks` target to use this
simpler pattern instead.

I also wrote a few tests around this target, which runs the
`_ResolveMonoAndroidSdks` target directly. Each test takes < 1 second
to complete, since it isn't actually doing a full build.