### PR TITLE
[Xamarin.Android.Build.Tests] Run tests in the right directory.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/XABuildPaths.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/XABuildPaths.cs
@@ -18,7 +18,7 @@ namespace Xamarin.ProjectTools
 		public static readonly string BinDirectory = Path.Combine (PrefixDirectory, "bin");
 		public static readonly string XABuildScript = Path.Combine (BinDirectory, "xabuild");
 		public static readonly string XABuildExe = Path.Combine (BinDirectory, "xabuild.exe");
-		public static readonly string TestOutputDirectory = Path.Combine (TopDirectory, "bin", "TestRelease");
+		public static readonly string TestOutputDirectory = Path.Combine (TopDirectory, "bin", $"Test{Configuration}");
 
 		static string GetTopDirRecursive (string searchDirectory, int maxSearchDepth = 5)
 		{


### PR DESCRIPTION
We are currently always running the tests in the
`bin\TestRelease\temp` directory. However it seems our
build system is restoring Nuget packages into

`bin\Test$(Configuration)\temp\packages`

As a reuslt for certain tests the Hint paths are no
longer valid and that causes the test to fail.

This commit changes the path to make use of the
`$(Configuration)` so we end up using the correct
output path for the tests.