### PR TITLE
[Xamarin.ProjectTools] use Timestamp for <Import/>

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Import.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Import.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Xamarin.ProjectTools
 {
@@ -10,8 +10,11 @@ namespace Xamarin.ProjectTools
 		}
 
 		public Import (Func<string> project) {
-			Project = project; 
+			Project = project;
+			Timestamp = DateTimeOffset.UtcNow;
 		}
+
+		public DateTimeOffset? Timestamp { get; set; }
 
 		public Func<string> Project { get; set; }
 		public Func<string> TextContent { get; set; }


### PR DESCRIPTION
Context: http://build.azdo.io/2910500

The `CustomDesignerTargetSetupDependenciesForDesigner` test has been
failing randomly with:

    _UpdateAndroidResgen should have been skipped.
    Expected: True
    But was: False

When I look at the log, following the targets, the culprit seems to
be `_CompileResources`:

    Building target "_CompileResources" completely.
    Input file "/Users/vsts/agent/2.155.1/work/1/s/bin/TestRelease/temp/SetupDependenciesForDesigner/UnnamedProject/foo.targets" is newer than output file "obj/Debug/flata/_CompileResources.stamp".

This test uses a `foo.targets` to customize the MSBuild logic:

    Imports = {
        new Import ("foo.targets") {
            TextContent = ...
        },

When reviewing the source code in Xamarin.ProjectTools, it appears
that we were always saving any `<Import/>` elements -- because
`Import` has no `Timestamp` property. Adding a proper `Timestamp`
value that mirrors what `BuildItem` does appears to have fixed this
test. How was this working before?

I also updated the `Touch()` helper method so that it also can take
`<Import/>` items into account.