### PR TITLE
[tests] only one test can NuGet.exe at once

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -313,6 +313,8 @@ namespace Xamarin.ProjectTools
 
 		}
 
+		static readonly object lockObject = new object ();
+
 		public virtual void NuGetRestore (string directory, string packagesDirectory = null)
 		{
 			if (!Packages.Any ())
@@ -328,18 +330,19 @@ namespace Xamarin.ProjectTools
 				RedirectStandardError = true,
 				RedirectStandardOutput = true,
 			};
-			//TODO: possibly remove this later?
-			psi.EnvironmentVariables.Add ("MONO_LOG_LEVEL", "debug");
-			Console.WriteLine ($"{psi.FileName} {psi.Arguments}");
-			using (var process = new Process {
-				StartInfo = psi,
-			}) {
-				process.OutputDataReceived += (sender, e) => Console.WriteLine (e.Data);
-				process.ErrorDataReceived += (sender, e) => Console.Error.WriteLine (e.Data);
-				process.Start ();
-				process.BeginOutputReadLine ();
-				process.BeginErrorReadLine ();
-				process.WaitForExit ();
+
+			lock (lockObject) {
+				Console.WriteLine ($"{psi.FileName} {psi.Arguments}");
+
+				using (var process = new Process ()) {
+					process.StartInfo = psi;
+					process.OutputDataReceived += (sender, e) => Console.WriteLine (e.Data);
+					process.ErrorDataReceived += (sender, e) => Console.Error.WriteLine (e.Data);
+					process.Start ();
+					process.BeginOutputReadLine ();
+					process.BeginErrorReadLine ();
+					process.WaitForExit ();
+				}
 			}
 		}
 


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/job/xamarin-android-pr-pipeline-release/1799/

A few MSBuild tests have randomly been failing:

* `BuildBasicApplicationAppCompat`
* `BuildWithResolveAssembliesFailure`

These tests all specifically use `package.config`, which we must call
`NuGet.exe` directly to restore them.

Let's see if only allowing one test to run `NuGet.exe` helps the
problem at all.