### PR TITLE
[Xamarin.Android.Build.Tasks] JAVAC0000 error code

### DIFF
--- a/Documentation/guides/messages/javac0000.md
+++ b/Documentation/guides/messages/javac0000.md
@@ -1,0 +1,33 @@
+---
+title: Xamarin.Android error JAVAC0000
+description: JAVAC0000 error code
+ms.date: 08/05/2019
+---
+# Xamarin.Android error JAVAC0000
+
+## Example messages
+
+```
+error JAVAC0000: Foo.java(1,8): javac error: class, interface, or enum expected
+```
+
+```
+error JAVAC0000: Foo.java(1,41): javac error: ';' expected
+```
+
+## Issue
+
+During a normal Xamarin.Android build, Java source code is generated
+and compiled. This message indicates that [`javac`][javac], the Java
+programming language compiler, failed to compile Java source code.
+
+## Solution
+
+If you have Java source code in your project with a build action of
+`AndroidJavaSource`, verify your Java syntax is correct.
+
+Consider submitting a [bug][bug] if you are getting this error under
+normal circumstances.
+
+[javac]: https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javac.html
+[bug]: https://github.com/xamarin/xamarin-android/wiki/Submitting-Bugs,-Feature-Requests,-and-Pull-Requests

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaToolTask.cs
@@ -78,6 +78,8 @@ namespace Xamarin.Android.Tasks
 
 		public string JavaMaximumHeapSize { get; set; }
 
+		public virtual string DefaultErrorCode => null;
+
 		protected override string ToolName {
 			get { return OS.IsWindows ? "java.exe" : "java"; }
 		}
@@ -91,7 +93,7 @@ namespace Xamarin.Android.Tasks
 						break;
 				}
 				if (foundError && errorText.Length > 0) {
-					Log.LogError (ToolName, null, null, file, line - 1, column + 1, 0, 0, errorText.ToString ());
+					Log.LogError (ToolName, DefaultErrorCode, null, file, line - 1, column + 1, 0, 0, errorText.ToString ());
 				}
 				return !Log.HasLoggedErrors;
 			}
@@ -111,7 +113,7 @@ namespace Xamarin.Android.Tasks
 						ToolName, GenerateCommandLineCommands ());
 					break;
 				default:
-					Log.LogError ("{0} : {1}", exception, error);
+					Log.LogCodedError (DefaultErrorCode, "{0} : {1}", exception, error);
 					break;
 			}
 		}
@@ -123,7 +125,7 @@ namespace Xamarin.Android.Tasks
 
 			if (match.Success) {
 				if (!string.IsNullOrEmpty (file)) {
-					Log.LogError (ToolName, null, null, file, line - 1, column + 1, 0, 0, errorText.ToString ());
+					Log.LogError (ToolName, DefaultErrorCode, null, file, line - 1, column + 1, 0, 0, errorText.ToString ());
 					errorText.Clear ();
 				}
 				file = match.Groups ["file"].Value;
@@ -149,7 +151,7 @@ namespace Xamarin.Android.Tasks
 
 				if (singleLine.StartsWith ("Note:") || singleLine.Trim ().EndsWith ("errors")) {
 					// See if we have one last error to print out
-					Log.LogError (null, null, null, file, line - 1, column + 1, 0, 0, errorText.ToString ());
+					Log.LogError (ToolName, DefaultErrorCode, null, file, line - 1, column + 1, 0, 0, errorText.ToString ());
 					errorText.Clear ();
 					foundError = false;
 					return true;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
@@ -21,6 +21,8 @@ namespace Xamarin.Android.Tasks
 		public string JavacTargetVersion { get; set; }
 		public string JavacSourceVersion { get; set; }
 
+		public override string DefaultErrorCode => "JAVAC0000";
+
 		public override bool Execute ()
 		{
 			if (!Directory.Exists (ClassesOutputDirectory))

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1448,14 +1448,11 @@ namespace App1
 			using (var b = CreateApkBuilder ("temp/CheckJavaError")) {
 				b.ThrowOnBuildFailure = false;
 				Assert.IsFalse (b.Build (proj), "Build should have failed.");
-				if (b.IsUnix) {
-					var text = "TestMe.java(1,8):  javacerror :  error: class, interface, or enum expected";
-					if (b.RunningMSBuild)
-						text = "TestMe.java(1,8): javac error :  error: class, interface, or enum expected";
-					StringAssertEx.Contains (text, b.LastBuildOutput);
-				} else
-					StringAssertEx.Contains ("TestMe.java(1,8): javac.exe error :  error: class, interface, or enum expected", b.LastBuildOutput);
-				StringAssertEx.Contains ("TestMe2.java(1,41): error :  error: ';' expected", b.LastBuildOutput);
+				var ext = b.IsUnix ? "" : ".exe";
+				var text = $"TestMe.java(1,8): javac{ext} error JAVAC0000:  error: class, interface, or enum expected";
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, text), "TestMe.java(1,8) expected");
+				text = $"TestMe2.java(1,41): javac{ext} error JAVAC0000:  error: ';' expected";
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, text), "TestMe2.java(1,41) expected");
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
 			}
 		}


### PR DESCRIPTION
For tracking "deletebinobj" progress, we wanted to make sure we have
proper error codes for any failure that would be symptomatic of a
"deletebinobj" problem.

`javac` failing is one place that developers can't easily cause a
build failure without using `AndroidJavaSource`. If we get a
`JAVAC0000`, likely something went wrong with the Xamarin.Android
build system.

I also fixed up the test that was checking these error messages: it
was using `StringAssertEx.Contains` that calls `Assert.Pass`: some of
the assertions at the end of the test were skipped.