### PR TITLE
[tests] SetLastWriteTimeUtc in InvalidAndroidResource test

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Framework;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -693,16 +693,27 @@ namespace Lib2
 			var proj = new XamarinAndroidApplicationProject ();
 			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				var projectFile = Path.Combine (Root, b.ProjectDirectory, proj.ProjectFilePath);
 				b.ThrowOnBuildFailure = false;
 				proj.OtherBuildItems.Add (invalidXml);
 				Assert.IsFalse (b.Build (proj), "Build should *not* have succeeded.");
 
 				b.ThrowOnBuildFailure = true;
 				proj.OtherBuildItems.Remove (invalidXml);
+
+				//HACK: for random test failure
+				b.Save (proj, doNotCleanupOnUpdate: true);
+				File.SetLastWriteTimeUtc (projectFile, DateTime.UtcNow.AddMinutes (1));
+
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 
 				b.ThrowOnBuildFailure = false;
 				proj.OtherBuildItems.Add (invalidXml);
+
+				//HACK: for random test failure
+				b.Save (proj, doNotCleanupOnUpdate: true);
+				File.SetLastWriteTimeUtc (projectFile, DateTime.UtcNow.AddMinutes (1));
+
 				Assert.IsFalse (b.Build (proj), "Build should *not* have succeeded.");
 			}
 		}


### PR DESCRIPTION
Context: http://build.azdo.io/2915638

The `IncrementalBuildTest.InvalidAndroidResource` test has been
failing randomly with:

    Resources/values/ids.xml(2): error APT0000: <item> must have a 'type' attribute.
    Resources/values/ids.xml : error APT0000: file failed to compile.

This test has a few steps:

1. Build a project with the above error -- ignore the error
2. Remove the offending file, build again
3. Add the offending file back -- ignore the error

It looks like on step No. 2 that the `.csproj` file for some reason is
not having a timestamp that would trigger this target:

    Target Name=_GenerateAndroidResourceDir Project=UnnamedProject.csproj
    Skipping target "_GenerateAndroidResourceDir" because all output files are up-to-date with respect to the input files.

Normally, this target runs during this test, due to the `.csproj` file
having a newer timestamp, and this MSBuild task will delete the
`ids.xml` file:

    <RemoveUnknownFiles Files="@(_AndroidResourceDest)" Directory="$(MonoAndroidResDirIntermediate)" RemoveDirectories="true">
      <Output ItemName="_AndroidResourceDestRemovedFiles" TaskParameter="RemovedFiles" />
    </RemoveUnknownFiles>

This test failure is only happening randomly on macOS, which seems
like it is a bug with `Xamarin.ProjectTools` running on Mono. For now,
we can use this workaround to get our test run green again...