### PR TITLE
[Xamarin.Android.Build.Tasks] fix a case where armeabi is picked up

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3996,5 +3996,19 @@ namespace UnnamedProject
 				StringAssert.Contains ("android:networkSecurityConfig=\"@xml/network_security_config\"", contents);
 			}
 		}
+
+		[Test]
+		public void AbiNameInIntermediateOutputPath ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.PackageReferences.Add (KnownPackages.Akavache);
+			proj.OutputPath = Path.Combine ("bin", "x86", "Debug");
+			proj.IntermediateOutputPath = Path.Combine ("obj", "x86", "Debug");
+			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_ONCREATE}", "var task = Akavache.BlobCache.LocalMachine.GetAllKeys();");
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, Path.Combine ("armeabi", "libe_sqlite3.so")), "Build should not use `armeabi`.");
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -760,6 +760,11 @@ namespace Xamarin.ProjectTools
 				}
 			},
 		};
+		public static Package Akavache = new Package {
+			Id = "akavache",
+			Version = "6.0.30",
+			TargetFramework = "netstandard2.0",
+		};
 	}
 }
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -256,9 +256,12 @@ namespace Xamarin.Android.Tasks
 
 		public static string GetNativeLibraryAbi (string lib)
 		{
-			var dirs = lib.ToLowerInvariant ().Split ('/', '\\');
-
-			return ValidAbis.Where (p => dirs.Contains (p)).FirstOrDefault ();
+			// The topmost directory the .so file is contained within
+			var dir = Path.GetFileName (Path.GetDirectoryName (lib)).ToLowerInvariant ();
+			if (ValidAbis.Contains (dir)) {
+				return dir;
+			}
+			return null;
 		}
 
 		public static string GetNativeLibraryAbi (ITaskItem lib)


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3373

A certain situation was causing `armeabi` to be treated as a valid ABI
for native libraries:

* Using a NuGet package that includes an `armeabi` .so file.
* Some directory has a name of a *valid* abi, such as
  `$(IntermediateOutputPath)` set to `obj\Debug\x86`.

`MonoAndroidHelper.GetNativeLibraryAbi` was looking at all directory
names -- and so if `x86` was in the path at all, `armeabi/libfoo.so`
will be used throughout the build.

I reworked `GetNativeLibraryAbi` so that it only looks at the topmost
directory that contains the `.so` file. I also added a test for this
scenario.