### PR TITLE
[Xamarin.Android.Build.Tasks] ndk binutils in subdirectory

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -136,18 +136,19 @@
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\proguard\bin\proguard.bat" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\aapt2.exe" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\libwinpthread-1.dll" />
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\aarch64-linux-android-as.exe" Condition=" '$(HostOS)' != 'Windows' "/>
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\aarch64-linux-android-ld.exe" Condition=" '$(HostOS)' != 'Windows' "/>
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\aarch64-linux-android-strip.exe" Condition=" '$(HostOS)' != 'Windows' "/>
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\arm-linux-androideabi-as.exe" Condition=" '$(HostOS)' != 'Windows' "/>
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\arm-linux-androideabi-ld.exe" Condition=" '$(HostOS)' != 'Windows' "/>
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\arm-linux-androideabi-strip.exe" Condition=" '$(HostOS)' != 'Windows' "/>
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\i686-linux-android-as.exe" Condition=" '$(HostOS)' != 'Windows' "/>
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\i686-linux-android-ld.exe" Condition=" '$(HostOS)' != 'Windows' "/>
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\i686-linux-android-strip.exe" Condition=" '$(HostOS)' != 'Windows' "/>
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\x86_64-linux-android-as.exe" Condition=" '$(HostOS)' != 'Windows' "/>
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\x86_64-linux-android-ld.exe" Condition=" '$(HostOS)' != 'Windows' "/>
-    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\x86_64-linux-android-strip.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\aarch64-linux-android-as.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\aarch64-linux-android-ld.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\aarch64-linux-android-strip.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\arm-linux-androideabi-as.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\arm-linux-androideabi-ld.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\arm-linux-androideabi-strip.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\i686-linux-android-as.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\i686-linux-android-ld.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\i686-linux-android-strip.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\x86_64-linux-android-as.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\x86_64-linux-android-ld.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\x86_64-linux-android-strip.exe" Condition=" '$(HostOS)' != 'Windows' "/>
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\ndk\libwinpthread-1.dll" Condition=" '$(HostOS)' != 'Windows' " />
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libmono-android.debug.dll"   Condition=" '$(HostOS)' != 'Windows' " />
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libmono-android.release.dll" Condition=" '$(HostOS)' != 'Windows' " />
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libMonoPosixHelper.dll" />
@@ -155,18 +156,18 @@
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libxamarin-app.dll" Condition=" '$(HostOS)' != 'Windows' " />
   </ItemGroup>
   <ItemGroup>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\aarch64-linux-android-as" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\aarch64-linux-android-ld" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\aarch64-linux-android-strip" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\arm-linux-androideabi-as" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\arm-linux-androideabi-ld" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\arm-linux-androideabi-strip" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\i686-linux-android-as" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\i686-linux-android-ld" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\i686-linux-android-strip" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\x86_64-linux-android-as" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\x86_64-linux-android-ld" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\x86_64-linux-android-strip" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\aarch64-linux-android-as" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\aarch64-linux-android-ld" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\aarch64-linux-android-strip" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\arm-linux-androideabi-as" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\arm-linux-androideabi-ld" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\arm-linux-androideabi-strip" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\i686-linux-android-as" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\i686-linux-android-ld" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\i686-linux-android-strip" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-as" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-ld" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-strip" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\illinkanalyzer" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\jit-times" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\mono" />

--- a/build-tools/xaprepare/xaprepare/Steps/Step_Get_Windows_Binutils.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_Get_Windows_Binutils.Unix.cs
@@ -90,9 +90,10 @@ namespace Xamarin.Android.Prepare
 				$"android-ndk-r{ndkVersion}/toolchains/llvm/prebuilt/windows-x86_64/bin/aarch64-linux-android-as.exe",
 				$"android-ndk-r{ndkVersion}/toolchains/llvm/prebuilt/windows-x86_64/bin/aarch64-linux-android-ld.exe",
 				$"android-ndk-r{ndkVersion}/toolchains/llvm/prebuilt/windows-x86_64/bin/aarch64-linux-android-strip.exe",
+				$"android-ndk-r{ndkVersion}/toolchains/llvm/prebuilt/windows-x86_64/bin/libwinpthread-1.dll",
 			};
 
-			string destinationDirectory = Path.Combine (Configurables.Paths.InstallMSBuildDir);
+			string destinationDirectory = Path.Combine (Configurables.Paths.InstallMSBuildDir, "ndk");
 			int existingFiles = 0;
 			foreach (string f in neededFiles) {
 				string file = Path.Combine (destinationDirectory, Path.GetFileName (f));

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -364,7 +364,7 @@ namespace Xamarin.Android.Tasks
 				int level = 0;
 				string toolPrefix = EnableLLVM
 					? NdkUtil.GetNdkToolPrefix (AndroidNdkDirectory, arch, level = GetNdkApiLevel (AndroidNdkDirectory, AndroidApiLevel, arch))
-					: $"{ToolsDirectory}{NdkUtil.GetArchDirName (arch)}-";
+					: Path.Combine (ToolsDirectory, "ndk", $"{NdkUtil.GetArchDirName (arch)}-");
 				var toolchainPath = toolPrefix.Substring(0, toolPrefix.LastIndexOf(Path.DirectorySeparatorChar));
 				var ldFlags = string.Empty;
 				if (EnableLLVM) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
@@ -134,7 +134,7 @@ namespace Xamarin.Android.Tasks
 
 		IEnumerable<Config> GetAssemblerConfigs ()
 		{
-			string sdkBinDirectory = MonoAndroidHelper.GetOSBinPath ();
+			string sdkBinDirectory = Path.Combine (MonoAndroidHelper.GetOSBinPath (), "ndk");
 			foreach (ITaskItem item in Sources) {
 				string abi = item.GetMetadata ("abi")?.ToLowerInvariant ();
 				string prefix = String.Empty;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -171,13 +171,15 @@
 
     <PropertyGroup>
       <_NDKToolFileName>$([System.IO.Path]::GetFileName ('$(_NDKToolLocation)'))</_NDKToolFileName>
-      <_NDKToolDestinationBase>$(XAInstallPrefix)xbuild\Xamarin\Android</_NDKToolDestinationBase>
+      <_NDKToolDestinationBase Condition=" '$(HostOS)' != 'Windows' ">$(XAInstallPrefix)xbuild\Xamarin\Android\$(HostOS)\ndk\</_NDKToolDestinationBase>
+      <_NDKToolDestinationBase Condition=" '$(HostOS)' == 'Windows' ">$(XAInstallPrefix)xbuild\Xamarin\Android\ndk\</_NDKToolDestinationBase>
     </PropertyGroup>
 
     <ItemGroup>
       <_NDKToolSource Include="$(_NDKToolLocation%(_ToolchainTool.Identity)-%(_ToolchainTool.Tool))" />
-      <_NDKToolDestination Condition=" '$(HostOS)' != 'Windows' " Include="$(_NDKToolDestinationBase)\$(HostOS)\$([System.IO.Path]::GetFileName ('$(_NDKToolLocation%(_ToolchainTool.Identity)-%(_ToolchainTool.Tool))'))" />
-      <_NDKToolDestination Condition=" '$(HostOS)' == 'Windows' " Include="$(_NDKToolDestinationBase)\$([System.IO.Path]::GetFileName ('$(_NDKToolLocation%(_ToolchainTool.Identity)-%(_ToolchainTool.Tool))'))" />
+      <_NDKToolSource Condition=" '$(HostOS)' == 'Windows' " Include="$([System.IO.Path]::GetDirectoryName ('$(_NDKToolLocationaarch64-linux-android-as)'))\libwinpthread-1.dll" />
+      <_NDKToolDestination Include="$(_NDKToolDestinationBase)$([System.IO.Path]::GetFileName ('$(_NDKToolLocation%(_ToolchainTool.Identity)-%(_ToolchainTool.Tool))'))" />
+      <_NDKToolDestination Condition=" '$(HostOS)' == 'Windows' " Include="$(_NDKToolDestinationBase)libwinpthread-1.dll" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Context: http://build.azdo.io/2915201

Several of the AOT-related MSBuild tests are failing on Windows with:

    [aot-compiler stderr] AOT of image C:\src\xamarin-android\bin\TestDebug\temp\BuildAotApplication_armeabi-v7a_False_True\obj\Release\android\assets\UnnamedProject.dll failed.
    [aot-compiler stdout] Mono Ahead of Time compiler - compiling assembly C:\src\xamarin-android\bin\TestDebug\temp\BuildAotApplication_armeabi-v7a_False_True\obj\Release\android\assets\UnnamedProject.dll
    [aot-compiler stdout] AOTID 748C00A1-04B7-4B7C-9935-5C7AB69FC5C9
    [aot-compiler stdout] Compiled: 17/17
    [aot-compiler stdout] Executing the native assembler: "C:\src\XAMARI~1\bin\Debug\lib\XAMARI~1.AND\xbuild\Xamarin\Android\arm-linux-androideabi-as"   -mfpu=vfp3 -o C:\src\XAMARI~1\bin\TESTDE~1\temp\BU9159~1\obj\Release\aot\ARMEAB~1\UnnamedProject.dll\temp.s.o C:\src\XAMARI~1\bin\TESTDE~1\temp\BU9159~1\obj\Release\aot\ARMEAB~1\UnnamedProject.dll\temp.s
    [aot-compiler stdout] Executing the native linker: "C:\src\XAMARI~1\bin\Debug\lib\XAMARI~1.AND\xbuild\Xamarin\Android\arm-linux-androideabi-ld"  -shared -o C:\src\XAMARI~1\bin\TESTDE~1\temp\BU9159~1\obj\Release\aot\ARMEAB~1\libaot-UnnamedProject.dll.so.tmp  C:\src\XAMARI~1\bin\TESTDE~1\temp\BU9159~1\obj\Release\aot\ARMEAB~1\UnnamedProject.dll\temp.s.o
    error XA3001: Could not AOT the assembly: UnnamedProject.dll

We now ship `arm-linux-androideabi-ld.exe` and other executables from
the Android NDK. It appears the one we are shipping is missing a
dependency:

    arm-linux-androideabi-ld.exe
          kernel32.dll
          MSVCRT.dll
        ? libwinpthread-1.dll
          user32.dll

Looking in our build tree, we have this file as a dependency of
`aapt2.exe`. Unfortunately both `aapt2.exe` and its copy of
`libwinpthread-1.dll` are 32 bit...

I think the sanest course of action is to place all of the binaries
from the Android NDK into a `ndk` subdirectory. This way its copy of
`libwinpthread-1.dll` can be unique and not collide with `aapt2.exe`.

Changes needed for this:

* `xaprepare` needs to download `libwinpthread-1.dll` in
  `Step_Get_Windows_Binutils`
* `Xamarin.Android.Build.Tasks.targets` needs to copy
  `libwinpthread-1.dll` to the output directory on Windows.
* The installers need to use files from the `ndk` directory, and
  include `libwinpthread-1.dll` in the VSIX.
* `<Aot/>` and `<CompileNativeAssembly/>` need to use the `ndk`
  directory on all platforms.