### PR TITLE
[tests] Capture logcat output for all deploy tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -52,7 +52,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
-		protected static bool MonitorAdbLogcat (Func<string, bool> action, int timeout = 10)
+		protected static bool MonitorAdbLogcat (Func<string, bool> action, int timeout = 15)
 		{
 			string ext = Environment.OSVersion.Platform != PlatformID.Unix ? ".exe" : "";
 			string adb = Path.Combine (AndroidSdkPath, "platform-tools", "adb" + ext);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -52,7 +52,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
-		protected static bool MonitorAdbLogcat (Func<string, bool> action, int timeout = 15)
+		protected static bool MonitorAdbLogcat (Func<string, bool> action, string logcatFilePath, int timeout = 15)
 		{
 			string ext = Environment.OSVersion.Platform != PlatformID.Unix ? ".exe" : "";
 			string adb = Path.Combine (AndroidSdkPath, "platform-tools", "adb" + ext);
@@ -62,47 +62,46 @@ namespace Xamarin.Android.Build.Tests
 				CreateNoWindow = true,
 				WindowStyle = ProcessWindowStyle.Hidden,
 			};
+
+			bool didActionSucceed = false;
 			using (var proc = Process.Start (info)) {
-				var sw = new Stopwatch ();
-				try {
-					TimeSpan time = TimeSpan.FromSeconds (timeout);
-					while (time.TotalMilliseconds > 0) {
-						sw.Start ();
-						if (action (proc.StandardOutput.ReadLine ()))
-							return true;
-						time = time.Subtract (TimeSpan.FromMilliseconds (sw.ElapsedMilliseconds));
-						sw.Reset ();
+				var sb = new StringBuilder ();
+
+				proc.OutputDataReceived += (sender, e) => {
+					if (e.Data != null) {
+						sb.AppendLine (e.Data);
+						if (action (e.Data)) {
+							didActionSucceed = true;
+							proc.Kill ();
+						}
 					}
-				} finally {
-					sw.Stop ();
+				};
+
+				proc.BeginOutputReadLine ();
+				if (!proc.WaitForExit (timeout * 1000)) {
 					proc.Kill ();
-					proc.WaitForExit ();
 				}
-				return false;
+
+				File.WriteAllText (logcatFilePath, sb.ToString ());
+				return didActionSucceed;
 			}
 		}
 
-		protected static bool WaitForDebuggerToStart (out string output, int timeout = 60)
+		protected static bool WaitForDebuggerToStart (string logcatFilePath, int timeout = 60)
 		{
-			var sb = new StringBuilder ();
 			bool result = MonitorAdbLogcat ((line) => {
-				sb.AppendLine (line);
 				return line.IndexOf ("monodroid-debug: Trying to initialize the debugger with options", StringComparison.OrdinalIgnoreCase) > 0;
-			}, timeout: timeout);
-			output = sb.ToString ();
+			}, logcatFilePath, timeout);
 			return result;
 		}
 
-		protected static bool WaitForActivityToStart (string activityNamespace, string activityName, out string output, int timeout = 60)
+		protected static bool WaitForActivityToStart (string activityNamespace, string activityName, string logcatFilePath, int timeout = 60)
 		{
-			var sb = new StringBuilder ();
 			bool result = MonitorAdbLogcat ((line) => {
-				sb.AppendLine (line);
 				var idx1 = line.IndexOf ("ActivityManager: Displayed", StringComparison.OrdinalIgnoreCase);
 				var idx2 = idx1 > 0 ? 0 : line.IndexOf ("ActivityTaskManager: Displayed", StringComparison.OrdinalIgnoreCase);
 				return (idx1 > 0 || idx2 > 0) && line.Contains (activityNamespace) && line.Contains (activityName);
-			}, timeout: timeout);
-			output = sb.ToString ();
+			}, logcatFilePath, timeout);
 			return result;
 		}
 

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -54,10 +54,8 @@ namespace Xamarin.Android.Build.Tests
 				else
 					AdbStartActivity ($"{proj.PackageName}/md52d9cf6333b8e95e8683a477bc589eda5.MainActivity");
 
-				string logcatPath = Path.Combine (XABuildPaths.TestOutputDirectory, b.ProjectDirectory, "logcat.log");
-				bool didActivityStart = WaitForActivityToStart (proj.PackageName, "MainActivity", output: out string logcatOutput, timeout: 30);
-				File.WriteAllText (logcatPath, logcatOutput);
-				Assert.True (didActivityStart, "Activity should have started.");
+				Assert.True (WaitForActivityToStart (proj.PackageName, "MainActivity",
+					Path.Combine (Root, b.ProjectDirectory, "logcat.log"), 30), "Activity should have started.");
 				Assert.True (b.Uninstall (proj), "Project should have uninstalled.");
 			}
 		}
@@ -169,10 +167,7 @@ namespace Xamarin.Android.Build.Tests
 					"AndroidAttachDebugger=True",
 				}), "Project should have run.");
 				
-				string logcatPath = Path.Combine (XABuildPaths.TestOutputDirectory, b.ProjectDirectory, "logcat.log");
-				bool didDebuggerStart = WaitForDebuggerToStart (output: out string logcatOutput);
-				File.WriteAllText (logcatPath, logcatOutput);
-				Assert.IsTrue (didDebuggerStart, "Activity should have started");
+				Assert.IsTrue (WaitForDebuggerToStart (Path.Combine (Root, b.ProjectDirectory, "logcat.log")), "Activity should have started");
 				// we need to give a bit of time for the debug server to start up.
 				WaitFor (2000);
 				session.LogWriter += (isStderr, text) => { Console.WriteLine (text); };


### PR DESCRIPTION
Context: http://build.azdo.io/2917852

We have seen a couple of intermittent issues in some deployment tests on
Azure Pipelines. I suspect these are emulator performance related, but
such failures are difficult to diagnose without logcat output.

MSBuild tests which assert on logcat output have been updated to ensure
that they write the output to a file. This file will automatically be
appended to the test result xml on failure for all tests which inherit
from `BaseTest`.

I've also bumped the default logcat monitoring timeout to 15 seconds to
allow us to be more lenient around slower startup times for emulators
running on Azure hosted pools.