### PR TITLE
[Tuner] Don't generate AbstractMethodErrors for default interface methods

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Mono.Cecil;
 
@@ -163,7 +164,7 @@ namespace MonoDroid.Tuner
 				if (ifaceDef.HasGenericParameters)
 					continue;
 
-				foreach (var iMethod in ifaceDef.Methods) {
+				foreach (var iMethod in ifaceDef.Methods.Where (m => m.IsAbstract)) {
 					bool exists = false;
 
 					foreach (var tMethod in typeMethods) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Linq;
+using Mono.Cecil;
+using Mono.Linker;
+using MonoDroid.Tuner;
+using NUnit.Framework;
+
+namespace Xamarin.Android.Build.Tests
+{
+	public class LinkerTests : BaseTest
+	{
+		[Test]
+		public void FixAbstractMethodsStep_SkipDimMembers ()
+		{
+			var step = new FixAbstractMethodsStep ();
+			var pipeline = new Pipeline ();
+			var context = new LinkContext (pipeline);
+
+			var android = CreateFauxMonoAndroidAssembly ();
+			var jlo = android.MainModule.GetType ("Java.Lang.Object");
+
+			context.Resolver.CacheAssembly (android);
+
+			var assm = AssemblyDefinition.CreateAssembly (new AssemblyNameDefinition ("DimTest", new Version ()), "DimTest", ModuleKind.Dll);
+			var void_type = assm.MainModule.ImportReference (typeof (void));
+
+			// Create interface
+			var iface = new TypeDefinition ("MyNamespace", "IMyInterface", TypeAttributes.Interface);
+
+			var abstract_method = new MethodDefinition ("MyAbstractMethod", MethodAttributes.Abstract, void_type);
+			var default_method = new MethodDefinition ("MyDefaultMethod", MethodAttributes.Public, void_type);
+
+			iface.Methods.Add (abstract_method);
+			iface.Methods.Add (default_method);
+
+			assm.MainModule.Types.Add (iface);
+
+			// Create implementing class
+			var impl = new TypeDefinition ("MyNamespace", "MyClass", TypeAttributes.Public, jlo);
+			impl.Interfaces.Add (new InterfaceImplementation (iface));
+
+			assm.MainModule.Types.Add (impl);
+
+			context.Resolver.CacheAssembly (assm);
+
+			step.Process (context);
+
+			// We should have generated an override for MyAbstractMethod
+			Assert.IsTrue (impl.Methods.Any (m => m.Name == "MyAbstractMethod"));
+
+			// We should not have generated an override for MyDefaultMethod
+			Assert.IsFalse (impl.Methods.Any (m => m.Name == "MyDefaultMethod"));
+		}
+
+		static AssemblyDefinition CreateFauxMonoAndroidAssembly ()
+		{
+			var assm = AssemblyDefinition.CreateAssembly (new AssemblyNameDefinition ("Mono.Android", new Version ()), "DimTest", ModuleKind.Dll);
+			var void_type = assm.MainModule.ImportReference (typeof (void));
+
+			// Create fake JLO type
+			var jlo = new TypeDefinition ("Java.Lang", "Object", TypeAttributes.Public);
+			assm.MainModule.Types.Add (jlo);
+
+			// Create fake Java.Lang.AbstractMethodError type
+			var ame = new TypeDefinition ("Java.Lang", "AbstractMethodError", TypeAttributes.Public);
+			ame.Methods.Add (new MethodDefinition (".ctor", MethodAttributes.Public, void_type));
+			assm.MainModule.Types.Add (ame);
+
+			return assm;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Tasks\CopyIfChangedTests.cs" />
     <Compile Include="Tasks\GetDependenciesTests.cs" />
     <Compile Include="Tasks\ResolveMonoAndroidSdksTests.cs" />
+    <Compile Include="Tasks\LinkerTests.cs" />
     <Compile Include="Tasks\ResolveSdksTaskTests.cs" />
     <Compile Include="Tasks\AndroidResourceTests.cs" />
     <Compile Include="Tasks\ManagedResourceParserTests.cs" />


### PR DESCRIPTION
Taken from #1939.

Today when we are compiling a class deriving from `Java.Lang.Object` that implements an interface and we see a method that exists on the interface that isn't implemented on the class we inject an override method that throws an `AbstractMethodError` exception.

With Default Interface Members, we need to ignore members that are implemented on the interface and not generate an override.  This is done by restricting our generation to `abstract` methods.

Original context here: https://github.com/xamarin/xamarin-android/commit/f96fcf93e157472072576bcc0a8698302899e8cf