### PR TITLE
[ci] Add Code Analysis Job to azure-pipelines.yaml

### DIFF
--- a/build-tools/automation/CredScanSuppressions.json
+++ b/build-tools/automation/CredScanSuppressions.json
@@ -1,0 +1,9 @@
+{
+    "tool": "Credential Scanner",
+    "suppressions": [
+        {
+            "file": "\\src\\Xamarin.Android.Build.Tasks\\Tests\\Xamarin.ProjectTools\\Resources\\Base\\test.keystore",
+            "_justification": "Dummy keystore file used for testing."
+        }
+    ]
+}

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -12,7 +12,7 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/master
+    ref: refs/heads/pjcollins_static-analysis
     endpoint: xamarin
 
 # Global variables
@@ -21,13 +21,25 @@ variables:
   InstallerArtifactName: installers
   NUnitTestAssembliesArtifactName: test-assemblies
   NUnitConsoleVersion: 3.9.0
+  HostedWinVS2019: Hosted Windows 2019 with VS2019
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
-# Check - "Xamarin.Android (Prepare bundle)"
 stages:
 - stage: prepare
   displayName: Prepare
   jobs:
+  # Check - "Xamarin.Android (Prepare Run Code Analysis)"
+  - job: run_code_analysis
+    displayName: Run Code Analysis
+    pool: $(HostedWinVS2019)
+    timeoutInMinutes: 60
+    cancelTimeoutInMinutes: 5
+    steps:
+    - checkout: self
+      submodules: recursive
+    - template: security\xa-static-analysis.yml@yaml
+
+  # Check - "Xamarin.Android (Prepare bundle)"
   - job: create_bundle
     displayName: Bundle
     pool: $(XA.Build.Mac.Pool)
@@ -724,8 +736,7 @@ stages:
   # Check - "Xamarin.Android (Test Designer Windows)"
   - job: designer_integration_win
     displayName: Designer Windows
-    pool:
-      name: Hosted Windows 2019 with VS2019
+    pool: $(HostedWinVS2019)
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
     workspace:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -37,7 +37,7 @@ stages:
     steps:
     - checkout: self
       submodules: recursive
-    - template: security\xa-static-analysis.yml@yaml
+    - template: security\xa-static-analysis\v1.yml@yaml
       parameters:
         credScanSuppressionsFile: $(System.DefaultWorkingDirectory)\build-tools\automation\CredScanSuppressions.json
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -38,6 +38,8 @@ stages:
     - checkout: self
       submodules: recursive
     - template: security\xa-static-analysis.yml@yaml
+      parameters:
+        credScanSuppressionsFile: $(System.DefaultWorkingDirectory)\build-tools\automation\CredScanSuppressions.json
 
   # Check - "Xamarin.Android (Prepare bundle)"
   - job: create_bundle

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -12,7 +12,7 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/pjcollins_static-analysis
+    ref: refs/heads/master
     endpoint: xamarin
 
 # Global variables


### PR DESCRIPTION
Context: https://secdevtools.azurewebsites.net/
Context: https://github.com/xamarin/yaml-templates/pull/23

Adds a job which will run static analysis tools and report any issues or
warnings found as a build artifact titled 'CodeAnalysisLogs'. Currently
only the 'CredScan' tool is supported.