### PR TITLE
[xaprepare] Use AndroidToolchainDirectory for default JavaHome

### DIFF
--- a/build-tools/xaprepare/xaprepare/OperatingSystems/Windows.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/Windows.cs
@@ -90,8 +90,10 @@ namespace Xamarin.Android.Prepare
 			Log.Todo ("gather dependencies here");
 
 			JavaHome = Context.Instance.Properties.GetValue ("JavaSdkDirectory")?.Trim ();
-			if (String.IsNullOrEmpty (JavaHome))
-				JavaHome  = Path.Combine (HomeDirectory, "android-toolchain", "jdk");
+			if (String.IsNullOrEmpty (JavaHome)) {
+				var androidToolchainDirectory = Context.Instance.Properties.GetValue ("AndroidToolchainDirectory")?.Trim ();
+				JavaHome  = Path.Combine (androidToolchainDirectory, "jdk");
+			}
 
 			JavaCPath = Path.Combine (JavaHome, "bin", "javac.exe");
 			JavaPath  = Path.Combine (JavaHome, "bin", "java.exe");


### PR DESCRIPTION
Before this change, setting a custom value for
`$(AndroidToolchainDirectory)` in a `Configuration.Override.props` file
without explicitly setting a corresponding value for
`$(JavaSdkDirectory)` would result in an error when running the
`Prepare` target on Windows:

      TODO: Modify ProcessRunner to allow standard input writing and switch to it here
            From: Xamarin.Android.Prepare.Step_Android_SDK_NDK.AcceptLicenses at C:\Source\xamarin-android\build-tools\xaprepare\xaprepare\Steps\Step_Android_SDK_NDK.cs(103,4)

    EXEC : error : JAVA_HOME is set to an invalid directory: C:\Users\Windows User\android-toolchain\jdk

This is somewhat unexpected because `xaprepare` does successfully
install the JDK into the `$(AndroidToolchainDirectory)\jdk` directory
before this step.

To make this scenario a little more user-friendly, adjust the default
`JavaHome` value to use a path relative to the
`$(AndroidToolchainDirectory)` instead of the user's home directory.
That way, there's no need to explicitly set the `$(JavaSdkDirectory)`
when using a custom `$(AndroidToolchainDirectory)`.