### PR TITLE
[Xamarin.Android.Build.Tasks] fixes for case-insensitive FS

### DIFF
--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/SystemUnzip.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/SystemUnzip.cs
@@ -166,7 +166,6 @@ namespace Xamarin.Android.BuildTools.PrepTasks {
 					var destFileInfo = new FileInfo (dest);
 					if (!destFileInfo.Attributes.HasFlag (FileAttributes.ReparsePoint)) {
 						File.SetLastWriteTimeUtc (dest, DateTime.UtcNow);
-						File.SetLastAccessTimeUtc (dest, DateTime.UtcNow);
 					}
 				}
 			}

--- a/build-tools/xaprepare/xaprepare/Application/Utilities.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Utilities.cs
@@ -582,7 +582,6 @@ namespace Xamarin.Android.Prepare
 					var destFileInfo = new FileInfo (filePath);
 					if (!destFileInfo.Attributes.HasFlag (FileAttributes.ReparsePoint)) {
 						File.SetLastWriteTimeUtc (filePath, stamp);
-						File.SetLastAccessTimeUtc (filePath, stamp);
 					}
 					break;
 				} catch (Exception e) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
@@ -71,7 +71,7 @@ namespace Xamarin.Android.Tasks {
 							var lastModified = File.GetLastWriteTimeUtc (file);
 							if (document.SaveIfChanged (file)) {
 								Log.LogDebugMessage ($"Fixed up Custom Views in {file}");
-								MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (file, lastModified, Log);
+								File.SetLastWriteTimeUtc (file, lastModified);
 							}
 						}
 						processed.Add (file);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
@@ -58,7 +58,7 @@ namespace Xamarin.Android.Tasks
 						continue;
 					MonoAndroidHelper.CopyIfChanged (dest, item.ItemSpec);
 					// reset the Dates so MSBuild/xbuild doesn't think they changed.
-					MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (item.ItemSpec, srcmodifiedDate, Log);
+					File.SetLastWriteTimeUtc (item.ItemSpec, srcmodifiedDate);
 				}
 			}
 			finally {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MergeResources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MergeResources.cs
@@ -76,7 +76,7 @@ namespace Xamarin.Android.Tasks
 					MonoAndroidHelper.CopyIfChanged (src, destPath);
 			}
 			MonoAndroidHelper.SetWriteable (destPath);
-			MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (destPath, cachedDate, Log);
+			File.SetLastWriteTimeUtc (destPath, cachedDate);
 		}
 	}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -441,7 +441,7 @@ namespace Xamarin.Android.Tasks
 			if (preserveTimestamp && File.Exists (path)) {
 				var timestamp = File.GetLastWriteTimeUtc (path);
 				File.WriteAllText (path, contents);
-				MonoAndroidHelper.SetLastAccessAndWriteTimeUtc (path, timestamp, Log);
+				File.SetLastWriteTimeUtc (path, timestamp);
 			} else {
 				File.WriteAllText (path, contents);
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -439,7 +439,6 @@ namespace UnamedProject
 				//Invalidate build.props with newer timestamp, you could also modify anything in @(_PropertyCacheItems)
 				var props = b.Output.GetIntermediaryPath("build.props");
 				File.SetLastWriteTimeUtc(props, DateTime.UtcNow);
-				File.SetLastAccessTimeUtc(props, DateTime.UtcNow);
 				Assert.IsTrue (b.Build (proj), "second build should have succeeded.");
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -48,7 +48,6 @@ namespace Xamarin.Android.Build.Tests
 				foreach (var file in filesToTouch) {
 					FileAssert.Exists (file);
 					File.SetLastWriteTimeUtc (file, DateTime.UtcNow);
-					File.SetLastAccessTimeUtc (file, DateTime.UtcNow);
 				}
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "Second should have succeeded");
 
@@ -389,7 +388,6 @@ namespace Lib2
 				foreach (var file in filesToTouch) {
 					FileAssert.Exists (file);
 					File.SetLastWriteTimeUtc (file, DateTime.UtcNow);
-					File.SetLastAccessTimeUtc (file, DateTime.UtcNow);
 				}
 
 				//NOTE: second build, targets will run because inputs changed
@@ -447,7 +445,6 @@ namespace Lib2
 				foreach (var file in filesToTouch) {
 					FileAssert.Exists (file);
 					File.SetLastWriteTimeUtc (file, DateTime.UtcNow);
-					File.SetLastAccessTimeUtc (file, DateTime.UtcNow);
 				}
 
 				//NOTE: second build, targets will run because inputs changed
@@ -715,6 +712,27 @@ namespace Lib2
 				File.SetLastWriteTimeUtc (projectFile, DateTime.UtcNow.AddMinutes (1));
 
 				Assert.IsFalse (b.Build (proj), "Build should *not* have succeeded.");
+			}
+		}
+
+		[Test]
+		public void CasingOnJavaLangObject ()
+		{
+			var className = "Foo";
+			var proj = new XamarinAndroidApplicationProject {
+				Sources = {
+					new BuildItem ("Compile", "Foo.cs") {
+						TextContent = () => {
+							return $"public class {className} : Java.Lang.Object {{ }}";
+						}
+					},
+				}
+			};
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "first build should have succeeded.");
+				className = "fOO";
+				proj.Touch ("Foo.cs");
+				Assert.IsTrue (b.Build (proj), "second build should have succeeded.");
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -62,14 +62,14 @@ namespace Xamarin.Android.Tools {
 					Directory.CreateDirectory (directory);
 
 				if (!Directory.Exists (source)) {
-					File.Copy (source, destination, true);
+					MonoAndroidHelper.SetWriteable (destination);
+					File.Delete (destination);
+					File.Copy (source, destination);
 					MonoAndroidHelper.SetWriteable (destination);
 					File.SetLastWriteTimeUtc (destination, DateTime.UtcNow);
-					File.SetLastAccessTimeUtc (destination, DateTime.UtcNow);
 					return true;
 				}
-			}/* else
-				Console.WriteLine ("Skipping copying {0}, unchanged", Path.GetFileName (destination));*/
+			}
 
 			return false;
 		}
@@ -89,6 +89,7 @@ namespace Xamarin.Android.Tools {
 					Directory.CreateDirectory (directory);
 
 				MonoAndroidHelper.SetWriteable (destination);
+				File.Delete (destination);
 				File.WriteAllBytes (destination, bytes);
 				return true;
 			}
@@ -103,6 +104,7 @@ namespace Xamarin.Android.Tools {
 					Directory.CreateDirectory (directory);
 
 				MonoAndroidHelper.SetWriteable (destination);
+				File.Delete (destination);
 				using (var fileStream = File.Create (destination)) {
 					stream.Position = 0; //HasStreamChanged read to the end
 					stream.CopyTo (fileStream);
@@ -122,7 +124,6 @@ namespace Xamarin.Android.Tools {
 					source.CopyTo (f);
 				}
 				File.SetLastWriteTimeUtc (destination, DateTime.UtcNow);
-				File.SetLastAccessTimeUtc (destination, DateTime.UtcNow);
 #if TESTCACHE
 				if (hash != null)
 					File.WriteAllText (destination + ".hash", hash);
@@ -142,7 +143,6 @@ namespace Xamarin.Android.Tools {
 
 				File.Copy (source, destination, true);
 				File.SetLastWriteTimeUtc (destination, DateTime.UtcNow);
-				File.SetLastAccessTimeUtc (destination, DateTime.UtcNow);
 #if TESTCACHE
 				if (hash != null)
 					File.WriteAllText (destination + ".hash", hash);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -343,19 +343,6 @@ namespace Xamarin.Android.Tasks
 			return false;
 		}
 
-#if MSBUILD
-		public static void SetLastAccessAndWriteTimeUtc (string source, DateTime dateUtc, TaskLoggingHelper Log)
-		{
-			try {
-				File.SetLastWriteTimeUtc (source, dateUtc);
-				File.SetLastAccessTimeUtc (source, dateUtc);
-			} catch (Exception ex) {
-				Log.LogWarning ("There was a problem setting the Last Access/Write time on file {0}", source);
-				Log.LogWarningFromException (ex);
-			}
-		}
-#endif  // MSBUILD
-
 		public static void SetWriteable (string source)
 		{
 			if (!File.Exists (source))

--- a/tools/msbuild-fuzzer/Program.cs
+++ b/tools/msbuild-fuzzer/Program.cs
@@ -211,7 +211,6 @@ namespace MSBuild.Fuzzer
 						 select f).ToArray ();
 			var file = files [random.Next (0, files.Length)];
 			File.SetLastWriteTimeUtc (file, DateTime.UtcNow);
-			File.SetLastAccessTimeUtc (file, DateTime.UtcNow);
 			return true;
 		}
 


### PR DESCRIPTION
A simple C# code change could break our build:

    class Foo : Java.Lang.Object { }

Changed to:

    class fOO : Java.Lang.Object { }

`javac` will fail on Windows (and likely macOS if you have a case
insensitive file system) with:

    obj\Debug\android\src\md54a1bd985b0effc3cb8b7fa6ec8bb4028\Foo.java(4,8):  error: class fOO is public, should be declared in a file named fOO.java
    public class fOO

The only way to get the project working again is to do a `Clean` or
`Rebuild`.

This C# snippet illustrates the issue further:

    File.WriteAllText("Foo.txt", "Foo");
    File.WriteAllText("fOO.txt", "fOO");
    foreach (var file in Directory.GetFiles (".", "*.txt"))
    {
        Console.WriteLine(file + " -> " + File.ReadAllText (file));
    }

The output is:

    .\Foo.txt -> fOO

The only solution is to put a `File.Delete()` prior to the second file
write -- there is no other way to sanely correct the casing on a file!

I added a call to `File.Delete()` in any of the `Files.Copy*IfChanged`
methods, which appears to solve the problem. I wrote a small battery
of tests to be sure things are working. One thing to note is that
`File.Delete()` does not throw if the file does not exist, and so we
don't need a `File.Exists` check. There are tests covering this case
as well.

We have been trying to *reduce* disk I/O, and so this is going to be a
slight performance hit. My thought is we could remove any calls to
`File.SetLastAccessTimeUtc` as they seem duplicative of
`File.SetLastWriteTimeUtc`.

After the fixes and removal of `File.SetLastAccessTimeUtc`, the
performance seems to be roughly the same if we look at two MSBuild
tasks that use `Copy*IfChanged` a lot. Here is three runs of a "fresh"
build of the Xamarin.Forms project in this repo:

    Before:
     172 ms  CopyIfChanged                              5 calls
     151 ms  CopyIfChanged                              5 calls
     161 ms  CopyIfChanged                              5 calls
    4603 ms  GenerateJavaStubs                          1 calls
    4368 ms  GenerateJavaStubs                          1 calls
    4529 ms  GenerateJavaStubs                          1 calls

    After:
     157 ms  CopyIfChanged                              5 calls
     180 ms  CopyIfChanged                              5 calls
     150 ms  CopyIfChanged                              5 calls
    4241 ms  GenerateJavaStubs                          1 calls
    4496 ms  GenerateJavaStubs                          1 calls
    4319 ms  GenerateJavaStubs                          1 calls

Note that the `<CopyIfChanged/>` calls `Files.CopyIfChanged` for each
input file internally, and the task itself was called 5 times here.
`<GenerateJavaStubs/>` calls `CopyIfStringChanged` for each Java stub.

Other changes:

* I removed all usage of `File.SetLastAccessTimeUtc` -- they seemed to
  be duplicate everywhere.
* Fixed a bug I found, where if the destination file is readonly,
  `Files.CopyIfChanged` failed...
* Removed a comment in `Files.cs`