### PR TITLE
[r8] prevent duplicate files in the output jar

### DIFF
--- a/src/r8/build.gradle
+++ b/src/r8/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 }
 
 jar {
+    duplicatesStrategy = 'exclude'
     manifest {
         attributes 'Main-Class': 'com.android.tools.r8.SwissArmyKnife'
     }


### PR DESCRIPTION
Context: https://discuss.gradle.org/t/duplicated-classes-output-jar-with-gradle/17301/2
Context: https://docs.gradle.org/current/javadoc/org/gradle/api/file/DuplicatesStrategy.html

Some internal Microsoft tooling was giving us a failure about `r8.jar`:

    jarsigner: unable to sign jar: java.util.zip.ZipException: duplicate entry: module-info.class

Indeed there were duplicates:

    7z l .\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\r8.jar | Select-String module-info.class
    2018-08-05 07:07:30 .....          275          171  module-info.class
    2018-08-05 07:07:40 .....          269          166  module-info.class
    2018-08-05 07:07:24 .....          192          140  module-info.class
    2018-08-05 07:07:18 .....          192          143  module-info.class

It looks like all we need is a setting in our `build.gradle`:

    duplicatesStrategy = 'exclude'

This will use the `module-info.class` from `r8` itself and any
subsequent instances of its dependencies will be excluded.

After building `r8` again we are missing all the duplicates:

    7z l .\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\r8.jar | Select-String module-info.class
    2018-08-05 07:07:30 .....          275          171  module-info.class