### PR TITLE
[create-pkg] Restore partial Side by Side support

### DIFF
--- a/build-tools/create-pkg/create-pkg.targets
+++ b/build-tools/create-pkg/create-pkg.targets
@@ -59,27 +59,38 @@
     <Exec WorkingDirectory="$(MSBuildTargetsDir)\lib"
         Command="ln -fs host-$(HostOS) host"
     />
+    <!-- Side by Side Compatibility Links -->
+    <Exec WorkingDirectory="$(PayloadDir)\Library\Frameworks\Xamarin.Android.framework"
+        Command="ln -fs Versions/Current/lib Libraries"
+    />
+    <Exec WorkingDirectory="$(PayloadDir)\Library\Frameworks\Xamarin.Android.framework\Versions\$(XAVersion)\lib"
+        Command="ln -fs xamarin.android/xbuild xbuild"
+    />
+    <Exec WorkingDirectory="$(PayloadDir)\Library\Frameworks\Xamarin.Android.framework\Versions\$(XAVersion)\lib"
+        Command="ln -fs xamarin.android/xbuild-frameworks xbuild-frameworks"
+    />
+    <!-- /Library/Frameworks/Mono.Framework/External Links -->
     <MakeDir Directories="$(MonoFrameworkExternalDir)\xbuild" />
     <Exec WorkingDirectory="$(MonoFrameworkExternalDir)\xbuild"
-        Command="ln -fs &quot;../../../Xamarin.Android.framework/Versions/$(XAVersion)/lib/xamarin.android/xbuild/Novell&quot; ."
+        Command="ln -fs &quot;../../../Xamarin.Android.framework/Libraries/xbuild/Novell&quot; ."
     />
     <MakeDir Directories="$(MonoFrameworkExternalDir)\xbuild\Xamarin" />
     <Exec WorkingDirectory="$(MonoFrameworkExternalDir)\xbuild\Xamarin"
-        Command="ln -fs &quot;../../../../Xamarin.Android.framework/Versions/$(XAVersion)/lib/xamarin.android/xbuild/Xamarin/Android&quot; ."
+        Command="ln -fs &quot;../../../../Xamarin.Android.framework/Libraries/xbuild/Xamarin/Android&quot; ."
     />
     <MakeDir Directories="$(MonoFrameworkExternalDir)\xbuild-frameworks" />
     <Exec WorkingDirectory="$(MonoFrameworkExternalDir)\xbuild-frameworks"
-        Command="ln -fs &quot;../../../Xamarin.Android.framework/Versions/$(XAVersion)/lib/xamarin.android/xbuild-frameworks/MonoAndroid&quot; ."
+        Command="ln -fs &quot;../../../Xamarin.Android.framework/Libraries/xbuild-frameworks/MonoAndroid&quot; ."
     />
     <MakeDir Directories="$(MonoFrameworkExternalDir)\monodoc" />
     <Exec WorkingDirectory="$(MonoFrameworkExternalDir)\monodoc"
-        Command="ln -fs &quot;../../../Xamarin.Android.framework/Versions/$(XAVersion)/lib/monodoc/MonoAndroid-docs.source&quot; ."
+        Command="ln -fs &quot;../../../Xamarin.Android.framework/Libraries/monodoc/MonoAndroid-docs.source&quot; ."
     />
     <Exec WorkingDirectory="$(MonoFrameworkExternalDir)\monodoc"
-        Command="ln -fs &quot;../../../Xamarin.Android.framework/Versions/$(XAVersion)/lib/monodoc/MonoAndroid-lib.tree&quot; ."
+        Command="ln -fs &quot;../../../Xamarin.Android.framework/Libraries/monodoc/MonoAndroid-lib.tree&quot; ."
     />
     <Exec WorkingDirectory="$(MonoFrameworkExternalDir)\monodoc"
-        Command="ln -fs &quot;../../../Xamarin.Android.framework/Versions/$(XAVersion)/lib/monodoc/MonoAndroid-lib.zip&quot; ."
+        Command="ln -fs &quot;../../../Xamarin.Android.framework/Libraries/monodoc/MonoAndroid-lib.zip&quot; ."
     />
   </Target>
   <Target Name="_FinalizePayload"


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3457
Context: https://github.com/xamarin/xamarin-android/commit/e83ba0ddc159d15abcfac1a5a4bce5a53e165d3f

During the installer rework in e83ba0d, some symlinks which we thought
were no longer needed were removed. It turns out AppCenter (and perhaps
others) were relying on these symlinks in order to facilitate swapping
between multiple versions of Xamarin.Android installed side by side.
These changes bring back 'unofficial' support for this Side by Side
installation scenario by restoring legacy symlink behavior.