### PR TITLE
[build] Add code-signing required for Notarization

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -133,6 +133,13 @@ stages:
         artifactName: $(NUnitTestAssembliesArtifactName)
         targetPath: bin/Test$(XA.Build.Configuration)
 
+    - template: install-certificates.yml@yaml
+      parameters:
+        DeveloperIdApplication: $(developer-id-application)
+        DeveloperIdInstaller: $(developer-id-installer)
+        IphoneDeveloper: $(iphone-developer)
+        MacDeveloper: $(mac-developer)
+
     - script: make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
       displayName: make create-installers
 

--- a/build-tools/create-pkg/create-pkg.targets
+++ b/build-tools/create-pkg/create-pkg.targets
@@ -32,8 +32,12 @@
     />
     <Copy
         SourceFiles="@(MSBuildItemsUnix)"
-        DestinationFiles="@(MSBuildItemsUnix->'$(MSBuildTargetsDir)\%(RelativePath)')"
-    />
+        DestinationFiles="@(MSBuildItemsUnix->'$(MSBuildTargetsDir)\%(RelativePath)')" >
+      <Output
+          TaskParameter="CopiedFiles"
+          ItemName="CopiedMSBuildItemsUnix"
+      />
+    </Copy>
     <Copy
         SourceFiles="@(XATargetsSrcFiles)"
         DestinationFolder="$(XAFrameworkDir)\lib\xamarin.android\xbuild\Xamarin"
@@ -82,8 +86,35 @@
         Command="ln -fs &quot;../../../Xamarin.Android.framework/Versions/$(XAVersion)/lib/monodoc/MonoAndroid-lib.zip&quot; ."
     />
   </Target>
+  <Target Name="_PrepareForNotarization"
+      Condition=" '$(HostOS)' == 'Darwin' And '$(RunningOnCI)' == 'true' "
+      DependsOnTargets="_CreateSymbolicLinks" >
+    <ItemGroup>
+      <CodesignArgs Include="-s &quot;Developer ID Application: Xamarin Inc&quot;" />
+      <CodesignArgs Include="-f --timestamp"/>
+    </ItemGroup>
+    <Exec Command="dd if=&quot;%(CopiedMSBuildItemsUnix.Identity)&quot; of=&quot;%(CopiedMSBuildItemsUnix.Identity).swab&quot; conv=swab"
+        Condition=" '%(CopiedMSBuildItemsUnix.SwabFile)' == 'True' " />
+    <Exec Command="rm &quot;%(CopiedMSBuildItemsUnix.Identity)&quot;"
+        Condition=" '%(CopiedMSBuildItemsUnix.SwabFile)' == 'True' " />
+    <Exec Command="codesign @(CodesignArgs, ' ') &quot;%(CopiedMSBuildItemsUnix.Identity)&quot;"
+        Condition=" '%(CopiedMSBuildItemsUnix.CodeSign)' == 'True' And '%(CopiedMSBuildItemsUnix.HardenRuntime)' != 'True' " />
+    <Exec Command="codesign @(CodesignArgs, ' ') -o runtime --entitlements &quot;%(CopiedMSBuildItemsUnix.EntitlementsPath)&quot; &quot;%(CopiedMSBuildItemsUnix.Identity)&quot;"
+        Condition=" '%(CopiedMSBuildItemsUnix.CodeSign)' == 'True' And '%(CopiedMSBuildItemsUnix.HardenRuntime)' == 'True' " />
+    <!-- Unpack, sign, and repack bundletool-->
+    <PropertyGroup>
+      <_BundleToolJarLocation>$([System.IO.Path]::GetFullPath('$(MSBuildTargetsDir)\bundletool.jar'))</_BundleToolJarLocation>
+      <_BundleToolExtractLocation>$(MSBuildSrcDir)\sign-bundletool</_BundleToolExtractLocation>
+    </PropertyGroup>
+    <RemoveDir Directories="$(_BundleToolExtractLocation)" />
+    <MakeDir Directories="$(_BundleToolExtractLocation)" />
+    <Exec WorkingDirectory="$(_BundleToolExtractLocation)" Command="jar -xvf &quot;$(_BundleToolJarLocation)&quot;" />
+    <Delete Files="$(_BundleToolJarLocation)" />
+    <Exec Command="codesign @(CodesignArgs, ' ') -o runtime --entitlements &quot;$(DefaultRuntimeEntitlementsPath)&quot; &quot;$(_BundleToolExtractLocation)\macos\aapt2&quot;" />
+    <Exec WorkingDirectory="$(_BundleToolExtractLocation)" Command="jar -cvf &quot;$(_BundleToolJarLocation)&quot; ." />
+  </Target>
   <Target Name="_FinalizePayload"
-      DependsOnTargets="_CreateSymbolicLinks">
+      DependsOnTargets="_CreateSymbolicLinks;_PrepareForNotarization">
     <ReplaceFileContents
         SourceFile="distribution.xml.in"
         DestinationFile="$(PkgDistributionDestination)"

--- a/build-tools/create-pkg/create-pkg.targets
+++ b/build-tools/create-pkg/create-pkg.targets
@@ -15,6 +15,7 @@
     <PkgLicenseDestinationEn>$(PkgResourcesPath)\en.lproj</PkgLicenseDestinationEn>
     <PkgScriptsDir>$(MSBuildThisFileDirectory)scripts</PkgScriptsDir>
     <UpdateInfoGuid>d1ec039f-f3db-468b-a508-896d7c382999</UpdateInfoGuid>
+    <CodesignArgs>-s &quot;Developer ID Application: Xamarin Inc&quot; -f --timestamp</CodesignArgs>
   </PropertyGroup>
   <Target Name="Build" />
   <Target Name="_CopyFilesToPayloadDir"
@@ -89,17 +90,12 @@
   <Target Name="_PrepareForNotarization"
       Condition=" '$(HostOS)' == 'Darwin' And '$(RunningOnCI)' == 'true' "
       DependsOnTargets="_CreateSymbolicLinks" >
-    <ItemGroup>
-      <CodesignArgs Include="-s &quot;Developer ID Application: Xamarin Inc&quot;" />
-      <CodesignArgs Include="-f --timestamp"/>
-    </ItemGroup>
     <Exec Command="dd if=&quot;%(CopiedMSBuildItemsUnix.Identity)&quot; of=&quot;%(CopiedMSBuildItemsUnix.Identity).swab&quot; conv=swab"
         Condition=" '%(CopiedMSBuildItemsUnix.SwabFile)' == 'True' " />
-    <Exec Command="rm &quot;%(CopiedMSBuildItemsUnix.Identity)&quot;"
-        Condition=" '%(CopiedMSBuildItemsUnix.SwabFile)' == 'True' " />
-    <Exec Command="codesign @(CodesignArgs, ' ') &quot;%(CopiedMSBuildItemsUnix.Identity)&quot;"
+    <Delete Files="%(CopiedMSBuildItemsUnix.Identity)" Condition=" '%(CopiedMSBuildItemsUnix.SwabFile)' == 'True' " />
+    <Exec Command="codesign $(CodesignArgs) &quot;%(CopiedMSBuildItemsUnix.Identity)&quot;"
         Condition=" '%(CopiedMSBuildItemsUnix.CodeSign)' == 'True' And '%(CopiedMSBuildItemsUnix.HardenRuntime)' != 'True' " />
-    <Exec Command="codesign @(CodesignArgs, ' ') -o runtime --entitlements &quot;%(CopiedMSBuildItemsUnix.EntitlementsPath)&quot; &quot;%(CopiedMSBuildItemsUnix.Identity)&quot;"
+    <Exec Command="codesign $(CodesignArgs) -o runtime --entitlements &quot;%(CopiedMSBuildItemsUnix.EntitlementsPath)&quot; &quot;%(CopiedMSBuildItemsUnix.Identity)&quot;"
         Condition=" '%(CopiedMSBuildItemsUnix.CodeSign)' == 'True' And '%(CopiedMSBuildItemsUnix.HardenRuntime)' == 'True' " />
     <!-- Unpack, sign, and repack bundletool-->
     <PropertyGroup>
@@ -110,7 +106,7 @@
     <MakeDir Directories="$(_BundleToolExtractLocation)" />
     <Exec WorkingDirectory="$(_BundleToolExtractLocation)" Command="jar -xvf &quot;$(_BundleToolJarLocation)&quot;" />
     <Delete Files="$(_BundleToolJarLocation)" />
-    <Exec Command="codesign @(CodesignArgs, ' ') -o runtime --entitlements &quot;$(DefaultRuntimeEntitlementsPath)&quot; &quot;$(_BundleToolExtractLocation)\macos\aapt2&quot;" />
+    <Exec Command="codesign $(CodesignArgs) -o runtime --entitlements &quot;$(DefaultRuntimeEntitlementsPath)&quot; &quot;$(_BundleToolExtractLocation)\macos\aapt2&quot;" />
     <Exec WorkingDirectory="$(_BundleToolExtractLocation)" Command="jar -cvmf META-INF/MANIFEST.MF &quot;$(_BundleToolJarLocation)&quot; ." />
   </Target>
   <Target Name="_FinalizePayload"

--- a/build-tools/create-pkg/create-pkg.targets
+++ b/build-tools/create-pkg/create-pkg.targets
@@ -111,7 +111,7 @@
     <Exec WorkingDirectory="$(_BundleToolExtractLocation)" Command="jar -xvf &quot;$(_BundleToolJarLocation)&quot;" />
     <Delete Files="$(_BundleToolJarLocation)" />
     <Exec Command="codesign @(CodesignArgs, ' ') -o runtime --entitlements &quot;$(DefaultRuntimeEntitlementsPath)&quot; &quot;$(_BundleToolExtractLocation)\macos\aapt2&quot;" />
-    <Exec WorkingDirectory="$(_BundleToolExtractLocation)" Command="jar -cvf &quot;$(_BundleToolJarLocation)&quot; ." />
+    <Exec WorkingDirectory="$(_BundleToolExtractLocation)" Command="jar -cvmf META-INF/MANIFEST.MF &quot;$(_BundleToolJarLocation)&quot; ." />
   </Target>
   <Target Name="_FinalizePayload"
       DependsOnTargets="_CreateSymbolicLinks;_PrepareForNotarization">

--- a/build-tools/create-pkg/runtime-entitlements.plist
+++ b/build-tools/create-pkg/runtime-entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.security.cs.allow-jit</key>
+        <true/>
+        <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+        <true/>
+        <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+        <true/>
+        <key>com.apple.security.cs.disable-library-validation</key>
+        <true/>
+    </dict>
+</plist>

--- a/build-tools/create-pkg/scripts/postinstall
+++ b/build-tools/create-pkg/scripts/postinstall
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+NDK_TOOL_ROOT=/Library/Frameworks/Xamarin.Android.framework/Versions/Current/lib/xamarin.android/xbuild/Xamarin/Android/Darwin/ndk
+files=$(find $NDK_TOOL_ROOT -name "*.swab")
+for file in $files; do
+	unswabbed=$(basename $file .swab)
+	dd if=$file of=$NDK_TOOL_ROOT/$unswabbed conv=swab
+	chmod +x $NDK_TOOL_ROOT/$unswabbed
+	rm $file
+done

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -9,6 +9,7 @@
     <FrameworkSrcDir>$(RootBuildDir)\lib\xamarin.android\xbuild-frameworks\MonoAndroid</FrameworkSrcDir>
     <MSBuildSrcDir>$(RootBuildDir)\lib\xamarin.android\xbuild\Xamarin\Android</MSBuildSrcDir>
     <MSBuildTargetsSrcDir>$(XamarinAndroidSourcePath)\src\Xamarin.Android.Build.Tasks\MSBuild\Xamarin\Android</MSBuildTargetsSrcDir>
+    <DefaultRuntimeEntitlementsPath>$(MSBuildThisFileDirectory)\..\create-pkg\runtime-entitlements.plist</DefaultRuntimeEntitlementsPath>
     <FirstInstallerFrameworkVersion Condition="Exists('$(FrameworkSrcDir)\$(AndroidFirstFrameworkVersion)')">$(AndroidFirstFrameworkVersion)</FirstInstallerFrameworkVersion>
     <FirstInstallerFrameworkVersion Condition="'$(FirstInstallerFrameworkVersion)' == ''">$(AndroidLatestStableFrameworkVersion)</FirstInstallerFrameworkVersion>
     <BclFrameworkVersion>v1.0</BclFrameworkVersion>
@@ -155,34 +156,90 @@
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libmonosgen-2.0.dll" />
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libxamarin-app.dll" Condition=" '$(HostOS)' != 'Windows' " />
   </ItemGroup>
+  <ItemDefinitionGroup>
+    <_MSBuildFilesUnix>
+      <CodeSign>False</CodeSign>
+      <HardenRuntime>False</HardenRuntime>
+      <EntitlementsPath>$(DefaultRuntimeEntitlementsPath)</EntitlementsPath>
+      <SwabFile>False</SwabFile>
+    </_MSBuildFilesUnix>
+  </ItemDefinitionGroup>
   <ItemGroup>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\aarch64-linux-android-as" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\aarch64-linux-android-ld" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\aarch64-linux-android-strip" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\arm-linux-androideabi-as" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\arm-linux-androideabi-ld" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\arm-linux-androideabi-strip" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\i686-linux-android-as" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\i686-linux-android-ld" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\i686-linux-android-strip" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-as" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-ld" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-strip" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\aarch64-linux-android-as" >
+      <SwabFile>True</SwabFile>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\aarch64-linux-android-ld" >
+      <SwabFile>True</SwabFile>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\aarch64-linux-android-strip" >
+      <SwabFile>True</SwabFile>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\arm-linux-androideabi-as" >
+      <SwabFile>True</SwabFile>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\arm-linux-androideabi-ld" >
+      <SwabFile>True</SwabFile>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\arm-linux-androideabi-strip" >
+      <SwabFile>True</SwabFile>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\i686-linux-android-as" >
+      <SwabFile>True</SwabFile>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\i686-linux-android-ld" >
+      <SwabFile>True</SwabFile>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\i686-linux-android-strip" >
+      <SwabFile>True</SwabFile>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-as" >
+      <SwabFile>True</SwabFile>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-ld" >
+      <SwabFile>True</SwabFile>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-strip" >
+      <SwabFile>True</SwabFile>
+    </_MSBuildFilesUnix>
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\illinkanalyzer" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\jit-times" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\mono" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\mono" >
+      <CodeSign>True</CodeSign>
+      <HardenRuntime>True</HardenRuntime>
+    </_MSBuildFilesUnix>
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\mono.config" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\mono-symbolicate" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\aapt2" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-android.debug.$(LibExtension)" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-android.release.$(LibExtension)" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-native.$(LibExtension)" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-profiler-aot.$(LibExtension)" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-profiler-log.$(LibExtension)" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libMonoPosixHelper.$(LibExtension)" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmonosgen-2.0.$(LibExtension)" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libxamarin-app.$(LibExtension)" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\libzip.5.0.$(LibExtension)" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\aapt2" >
+      <CodeSign>True</CodeSign>
+      <HardenRuntime>True</HardenRuntime>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-android.debug.$(LibExtension)" >
+      <CodeSign>True</CodeSign>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-android.release.$(LibExtension)" >
+      <CodeSign>True</CodeSign>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-native.$(LibExtension)" >
+      <CodeSign>True</CodeSign>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-profiler-aot.$(LibExtension)" >
+      <CodeSign>True</CodeSign>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-profiler-log.$(LibExtension)" >
+      <CodeSign>True</CodeSign>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libMonoPosixHelper.$(LibExtension)" >
+      <CodeSign>True</CodeSign>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmonosgen-2.0.$(LibExtension)" >
+      <CodeSign>True</CodeSign>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libxamarin-app.$(LibExtension)" >
+      <CodeSign>True</CodeSign>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\libzip.5.0.$(LibExtension)" >
+      <CodeSign>True</CodeSign>
+    </_MSBuildFilesUnix>
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\proguard\bin\proguard.sh" />
   </ItemGroup>
   <!-- Allow us to exclude mono bundle files for PR builds -->
@@ -193,12 +250,30 @@
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\cross-x86_64.exe" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\llc.exe" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\opt.exe" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\cross-arm" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\cross-arm64" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\cross-x86" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\cross-x86_64" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\llc" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\opt" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\cross-arm" >
+      <CodeSign>True</CodeSign>
+      <HardenRuntime>True</HardenRuntime>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\cross-arm64" >
+      <CodeSign>True</CodeSign>
+      <HardenRuntime>True</HardenRuntime>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\cross-x86" >
+      <CodeSign>True</CodeSign>
+      <HardenRuntime>True</HardenRuntime>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\cross-x86_64" >
+      <CodeSign>True</CodeSign>
+      <HardenRuntime>True</HardenRuntime>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\llc" >
+      <CodeSign>True</CodeSign>
+      <HardenRuntime>True</HardenRuntime>
+    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\opt" >
+      <CodeSign>True</CodeSign>
+      <HardenRuntime>True</HardenRuntime>
+    </_MSBuildFilesUnix>
   </ItemGroup>
   <ItemGroup>
     <XATargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\..\Xamarin.Android.Sdk.props" />

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -157,89 +157,46 @@
     <_MSBuildLibHostFilesWin Include="$(MSBuildSrcDir)\lib\host-mxe-Win64\libxamarin-app.dll" Condition=" '$(HostOS)' != 'Windows' " />
   </ItemGroup>
   <ItemDefinitionGroup>
-    <_MSBuildFilesUnix>
-      <CodeSign>False</CodeSign>
-      <HardenRuntime>False</HardenRuntime>
+    <_MSBuildFilesUnixSign>
+      <CodeSign>True</CodeSign>
+    </_MSBuildFilesUnixSign>
+    <_MSBuildFilesUnixSignAndHarden>
+      <CodeSign>True</CodeSign>
+      <HardenRuntime>True</HardenRuntime>
       <EntitlementsPath>$(DefaultRuntimeEntitlementsPath)</EntitlementsPath>
-      <SwabFile>False</SwabFile>
-    </_MSBuildFilesUnix>
+    </_MSBuildFilesUnixSignAndHarden>
+    <_MSBuildFilesUnixSwab>
+      <SwabFile>True</SwabFile>
+    </_MSBuildFilesUnixSwab>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\aarch64-linux-android-as" >
-      <SwabFile>True</SwabFile>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\aarch64-linux-android-ld" >
-      <SwabFile>True</SwabFile>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\aarch64-linux-android-strip" >
-      <SwabFile>True</SwabFile>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\arm-linux-androideabi-as" >
-      <SwabFile>True</SwabFile>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\arm-linux-androideabi-ld" >
-      <SwabFile>True</SwabFile>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\arm-linux-androideabi-strip" >
-      <SwabFile>True</SwabFile>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\i686-linux-android-as" >
-      <SwabFile>True</SwabFile>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\i686-linux-android-ld" >
-      <SwabFile>True</SwabFile>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\i686-linux-android-strip" >
-      <SwabFile>True</SwabFile>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-as" >
-      <SwabFile>True</SwabFile>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-ld" >
-      <SwabFile>True</SwabFile>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-strip" >
-      <SwabFile>True</SwabFile>
-    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnixSwab Include="$(MSBuildSrcDir)\$(HostOS)\ndk\aarch64-linux-android-as" />
+    <_MSBuildFilesUnixSwab Include="$(MSBuildSrcDir)\$(HostOS)\ndk\aarch64-linux-android-ld" />
+    <_MSBuildFilesUnixSwab Include="$(MSBuildSrcDir)\$(HostOS)\ndk\aarch64-linux-android-strip" />
+    <_MSBuildFilesUnixSwab Include="$(MSBuildSrcDir)\$(HostOS)\ndk\arm-linux-androideabi-as" />
+    <_MSBuildFilesUnixSwab Include="$(MSBuildSrcDir)\$(HostOS)\ndk\arm-linux-androideabi-ld" />
+    <_MSBuildFilesUnixSwab Include="$(MSBuildSrcDir)\$(HostOS)\ndk\arm-linux-androideabi-strip" />
+    <_MSBuildFilesUnixSwab Include="$(MSBuildSrcDir)\$(HostOS)\ndk\i686-linux-android-as" />
+    <_MSBuildFilesUnixSwab Include="$(MSBuildSrcDir)\$(HostOS)\ndk\i686-linux-android-ld" />
+    <_MSBuildFilesUnixSwab Include="$(MSBuildSrcDir)\$(HostOS)\ndk\i686-linux-android-strip" />
+    <_MSBuildFilesUnixSwab Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-as" />
+    <_MSBuildFilesUnixSwab Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-ld" />
+    <_MSBuildFilesUnixSwab Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-strip" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\illinkanalyzer" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\jit-times" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\mono" >
-      <CodeSign>True</CodeSign>
-      <HardenRuntime>True</HardenRuntime>
-    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\mono" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\mono.config" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\mono-symbolicate" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\aapt2" >
-      <CodeSign>True</CodeSign>
-      <HardenRuntime>True</HardenRuntime>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-android.debug.$(LibExtension)" >
-      <CodeSign>True</CodeSign>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-android.release.$(LibExtension)" >
-      <CodeSign>True</CodeSign>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-native.$(LibExtension)" >
-      <CodeSign>True</CodeSign>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-profiler-aot.$(LibExtension)" >
-      <CodeSign>True</CodeSign>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-profiler-log.$(LibExtension)" >
-      <CodeSign>True</CodeSign>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libMonoPosixHelper.$(LibExtension)" >
-      <CodeSign>True</CodeSign>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmonosgen-2.0.$(LibExtension)" >
-      <CodeSign>True</CodeSign>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libxamarin-app.$(LibExtension)" >
-      <CodeSign>True</CodeSign>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\libzip.5.0.$(LibExtension)" >
-      <CodeSign>True</CodeSign>
-    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\aapt2" />
+    <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-android.debug.$(LibExtension)" />
+    <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-android.release.$(LibExtension)" />
+    <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-native.$(LibExtension)" />
+    <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-profiler-aot.$(LibExtension)" />
+    <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmono-profiler-log.$(LibExtension)" />
+    <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libMonoPosixHelper.$(LibExtension)" />
+    <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmonosgen-2.0.$(LibExtension)" />
+    <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libxamarin-app.$(LibExtension)" />
+    <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\libzip.5.0.$(LibExtension)" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\proguard\bin\proguard.sh" />
   </ItemGroup>
   <!-- Allow us to exclude mono bundle files for PR builds -->
@@ -250,30 +207,12 @@
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\cross-x86_64.exe" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\llc.exe" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\opt.exe" />
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\cross-arm" >
-      <CodeSign>True</CodeSign>
-      <HardenRuntime>True</HardenRuntime>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\cross-arm64" >
-      <CodeSign>True</CodeSign>
-      <HardenRuntime>True</HardenRuntime>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\cross-x86" >
-      <CodeSign>True</CodeSign>
-      <HardenRuntime>True</HardenRuntime>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\cross-x86_64" >
-      <CodeSign>True</CodeSign>
-      <HardenRuntime>True</HardenRuntime>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\llc" >
-      <CodeSign>True</CodeSign>
-      <HardenRuntime>True</HardenRuntime>
-    </_MSBuildFilesUnix>
-    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\opt" >
-      <CodeSign>True</CodeSign>
-      <HardenRuntime>True</HardenRuntime>
-    </_MSBuildFilesUnix>
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\cross-arm" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\cross-arm64" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\cross-x86" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\cross-x86_64" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\llc" />
+    <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\opt" />
   </ItemGroup>
   <ItemGroup>
     <XATargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\..\Xamarin.Android.Sdk.props" />
@@ -373,7 +312,7 @@
       <MSBuildItemsWin Include="@(_DesignerFilesWin)">
         <RelativePath>bcl\%(RecursiveDir)\%(Filename)%(Extension)</RelativePath>
       </MSBuildItemsWin>
-      <MSBuildItemsUnix Include="@(_MSBuildFiles);@(_MSBuildFilesUnix)">
+      <MSBuildItemsUnix Include="@(_MSBuildFiles);@(_MSBuildFilesUnix);@(_MSBuildFilesUnixSwab);@(_MSBuildFilesUnixSign);@(_MSBuildFilesUnixSignAndHarden)">
         <RelativePath>$([MSBuild]::MakeRelative($(MSBuildSrcDir), %(FullPath)))</RelativePath>
       </MSBuildItemsUnix>
       <MSBuildItemsUnix Include="@(_MSBuildTargetsSrcFiles)">


### PR DESCRIPTION
Context: https://developer.apple.com/documentation/security/notarizing_your_app_before_distribution
Context: https://github.com/android-ndk/ndk/issues/1060

Starting in macOS Catalina, our .pkg files will need to Notarized to
ensure that a Gatekeeper dialog is not displayed when we first attempt
to install them.

Notarization has the following requirements:

    * All executables being distributed must be code-signed.
    * A secure timestamp must be added to the code-signing signature.
    * All relevant executables must have the Hardened Runtime enabled.
    * All relevant executables must be built against macOS 10.9 or later.

To meet these requirements, code-signing and runtime Hardening have now
been enabled for all relevant installer files that we're building or
extracting from the mono archive. New metadata has been added to these
items to control the behavior of a new `codesign` invocation which runs
during .pkg creation on our Azure Pipelines macOS builds.

All files which require runtime hardening are using the same "hardened
runtime entitlements" file by default. This entitlements file was taken
directly from mono[0], and likely represents a broader set of permission
than is needed for most of our files. We should revisit this on a per
file basis in the future to further "harden" our executables.

The Android NDK tools that we are redistributing can not be be signed,
as they've been linked/built against macOS 10.8. We've worked around the
code-signing requirement (hopefully temporarily) for these files by
"scrambling" the file content before creating the .pkg, and then
"unscrambling" the file in a new `postinstall` script that is embedded
into our .pkg installer.

[0] https://github.com/mono/mono/blob/c62473114a9a994676383047104549604230c8e6/mono/mini/mac-entitlements.plist