### PR TITLE
[xaprepare] bump NuGet and system Mono

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.MacOS.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Android.Prepare
 		partial class Urls
 		{
 			public static readonly Uri Corretto = new Uri ("https://d3pxv6yz143wms.cloudfront.net/8.212.04.2/amazon-corretto-8.212.04.2-macosx-x64.tar.gz");
-			public static readonly Uri MonoPackage = new Uri ("https://download.mono-project.com/archive/6.0.0/macos-10-universal/MonoFramework-MDK-6.0.0.313.macos10.xamarin.universal.pkg");
+			public static readonly Uri MonoPackage = new Uri ("https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2019-06/121/761220d914e28b3ebd67e5642cf8c200110f62ec/MonoFramework-MDK-6.4.0.137.macos10.xamarin.universal.pkg");
 		}
 
 		partial class Defaults

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Android.Prepare
 			const string Bundle_AzureJobUri_Release = "xamarin-android";
 			static string Bundle_AzureJobUri => ctx.IsDebugBuild ? Bundle_AzureJobUri_Debug : Bundle_AzureJobUri_Release;
 
-			public static readonly Uri NugetUri = new Uri ("https://dist.nuget.org/win-x86-commandline/v4.9.4/nuget.exe");
+			public static readonly Uri NugetUri = new Uri ("https://dist.nuget.org/win-x86-commandline/v5.2.0/nuget.exe");
 
 			public static Uri MonoArchive_BaseUri = new Uri ("https://xamjenkinsartifact.azureedge.net/mono-sdks/");
 		}


### PR DESCRIPTION
Context: https://github.com/mono/mono/blob/63d98369c6ccd62d473b0530e3249baca0e26151/packaging/MacSDK/nuget.py#L7-L8

We've had a lot of failures around MSBuild tests using
`packages.config` on Jenkins. Things seem to work on Azure DevOps?

Let's see if bumping things helps:

* Install the same system Mono from mono/mono/2019-06@761220d9
* Use NuGet 5.2.0 to align with MSBuild and mono/mono/2019-06