### PR TITLE
[Xamarin.Android.Build.Tasks] Validate the `android:versionCode`

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -19,7 +19,9 @@
 
 + [XA0000](xa0000.md): Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion).
 + [XA0001](xa0001.md): Invalid or unsupported `$(TargetFrameworkVersion)` value.
-+ [XA0118](xa0002.md): Could not find mono.android.jar
++ [XA0002](xa0002.md): Could not find mono.android.jar
++ [XA0003](xa0003.md): Invalid `android:versionCode` value. It must be an integer value.
++ [XA0004](xa0004.md): VersionCode {code} is outside 0, {maxVersionCode} interval.
 
 + [XA0030](xa0030.md): Building with JDK Version `{versionNumber}` is not supported.
 + [XA0031](xa0031.md): Java SDK {requiredJavaForFrameworkVersion} or above is required when targeting FrameworkVersion {targetFrameworkVersion}.

--- a/Documentation/guides/messages/xa0003.md
+++ b/Documentation/guides/messages/xa0003.md
@@ -1,0 +1,21 @@
+---
+title: Xamarin.Android error XA0003
+description: XA0003 error code
+ms.date: 07/13/2019
+---
+# Xamarin.Android error XA0003
+
+## Issue
+
+This error means the value for `android:versionCode` in the 
+`AndroidManifest.xml` file is not an integer value. 
+
+Google requires that the value be an integer within the 
+range of 0 to 2100000000. 
+See [https://developer.android.com/studio/publish/versioning](https://developer.android.com/studio/publish/versioning)
+for more details.
+
+## Solution
+
+Correct the `android:versionCode` in the `AndroidManifest.xml` to 
+be an integer in the range of 0 to 2100000000.

--- a/Documentation/guides/messages/xa0004.md
+++ b/Documentation/guides/messages/xa0004.md
@@ -1,0 +1,22 @@
+---
+title: Xamarin.Android error XA0004
+description: XA0004 error code
+ms.date: 07/13/2019
+---
+# Xamarin.Android error XA0004
+
+## Issue
+
+This error means the value for `android:versionCode` in the 
+`AndroidManifest.xml` file is and integer but is not 
+within the value range of 0 to 2100000000.
+
+Google requires that the value be an integer within the 
+range of 0 to 2100000000. 
+See [https://developer.android.com/studio/publish/versioning](https://developer.android.com/studio/publish/versioning)
+for more details.
+
+## Solution
+
+Correct the `android:versionCode` in the `AndroidManifest.xml` to 
+be an integer in the range of 0 to 2100000000.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -121,13 +121,20 @@ namespace Xamarin.Android.Tasks {
 			string manifestFile = Path.Combine (manifestDir, Path.GetFileName (ManifestFile));
 			ManifestDocument manifest = new ManifestDocument (ManifestFile, this.Log);
 			manifest.SdkVersion = AndroidSdkPlatform;
-			if (currentAbi != null) {
-				if (!string.IsNullOrEmpty (VersionCodePattern))
+			if (!string.IsNullOrEmpty (VersionCodePattern)) {
+				try {
 					manifest.CalculateVersionCode (currentAbi, VersionCodePattern, VersionCodeProperties);
-				else
-					manifest.SetAbi (currentAbi);
-			} else if (!string.IsNullOrEmpty (VersionCodePattern)) {
-				manifest.CalculateVersionCode (null, VersionCodePattern, VersionCodeProperties);
+				} catch (ArgumentOutOfRangeException ex) {
+					Log.LogCodedError ("XA0003", ManifestFile, 0, ex.Message);
+					return string.Empty;
+				}
+			}
+			if (currentAbi != null && string.IsNullOrEmpty (VersionCodePattern)) {
+				manifest.SetAbi (currentAbi);
+			}
+			if (!manifest.ValidateVersionCode (out string error, out string errorCode)) {
+				Log.LogCodedError (errorCode, ManifestFile, 0, error);
+				return string.Empty;
 			}
 			manifest.ApplicationName = ApplicationName;
 			manifest.Save (manifestFile);
@@ -271,7 +278,8 @@ namespace Xamarin.Android.Tasks {
 				var currentResourceOutputFile = abi != null ? string.Format ("{0}-{1}", outputFile, abi) : outputFile;
 				if (!string.IsNullOrEmpty (currentResourceOutputFile) && !Path.IsPathRooted (currentResourceOutputFile))
 					currentResourceOutputFile = Path.Combine (WorkingDirectory, currentResourceOutputFile);
-				if (!ExecuteForAbi (GenerateCommandLineCommands (manifest, abi, currentResourceOutputFile), currentResourceOutputFile)) {
+				string cmd = GenerateCommandLineCommands (manifest, abi, currentResourceOutputFile);
+				if (string.IsNullOrWhiteSpace (cmd) || !ExecuteForAbi (cmd, currentResourceOutputFile)) {
 					Cancel ();
 				}
 			}


### PR DESCRIPTION
Fixes #2023

The `versionCode` in the android manifest should be
an `int` value. It should fall within the range of
`0` to `2100000000`.

This commit adds some checks which will emit MSBuild errors
if we encounter an invalid `versionCode`. It also
adds some unit tests to test for decimal values and
the boundary conditions.