### PR TITLE
[tests/ci] Add BCL Test job to Azure pipelines

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -19,7 +19,7 @@ resources:
 variables:
   BundleArtifactName: bundle
   InstallerArtifactName: installers
-  NUnitTestAssembliesArtifactName: test-assemblies
+  TestAssembliesArtifactName: test-assemblies
   NUnitConsoleVersion: 3.9.0
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
@@ -127,10 +127,15 @@ stages:
     - script: make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1 PREPARE_ARGS="--bundle-path=$(System.DefaultWorkingDirectory)"
       displayName: make jenkins
 
+    - script: |
+        cp -r bin/$(XA.Build.Configuration)/bcl-tests bin/Test$(XA.Build.Configuration)/bcl-tests
+        cp bin/Build$(XA.Build.Configuration)/ProfileAssemblies.projitems bin/Test$(XA.Build.Configuration)/bcl-tests/
+      displayName: copy bcl-tests assemblies
+
     - task: PublishPipelineArtifact@0
       displayName: upload test assemblies
       inputs:
-        artifactName: $(NUnitTestAssembliesArtifactName)
+        artifactName: $(TestAssembliesArtifactName)
         targetPath: bin/Test$(XA.Build.Configuration)
 
     - script: make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
@@ -477,6 +482,66 @@ stages:
         targetPath: $(Build.ArtifactStagingDirectory)
       condition: always()
 
+  # Check - "Xamarin.Android (Test BCL With Emulator)"
+  - job: mac_bcl_tests
+    displayName: BCL With Emulator
+    pool: $(XA.Build.Mac.Pool)
+    timeoutInMinutes: 180
+    steps:
+    - template: yaml-templates/mac/setup-test-environment.yaml
+
+    - task: DownloadPipelineArtifact@1
+      inputs:
+        artifactName: $(TestAssembliesArtifactName)
+        downloadPath: $(System.DefaultWorkingDirectory)/bin/$(XA.Build.Configuration)
+
+    - task: MSBuild@1
+      displayName: build remap-assembly-ref.csproj
+      inputs:
+        solution: build-tools/remap-assembly-ref/remap-assembly-ref.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/remap-assembly-ref.binlog
+
+    - template: yaml-templates/apk-instrumentation.yaml
+      parameters:
+        configuration: $(XA.Build.Configuration)
+        testName: Xamarin.Android.Bcl-Tests
+        project: tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj
+        testResultsFiles: TestResult-Xamarin.Android.Bcl_Tests.nunit-$(XA.Build.Configuration).xml
+
+    - task: PublishTestResults@2
+      displayName: publish Xamarin.Android.Bcl-Tests-XUnit results
+      inputs:
+        testResultsFormat: NUnit
+        testResultsFiles: TestResult-Xamarin.Android.Bcl_Tests.xunit-$(XA.Build.Configuration).xml
+        testRunTitle: Xamarin.Android.Bcl-Tests-NUnit
+      condition: succeededOrFailed()
+
+    - task: MSBuild@1
+      displayName: shut down emulator
+      inputs:
+        solution: tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: >
+          /t:AcquireAndroidTarget,ReleaseAndroidTarget
+          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/shutdown-emulator.binlog
+      condition: always()
+
+    - task: MSBuild@1
+      displayName: package results
+      inputs:
+        solution: build-tools/xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: /t:Build,ZipBuildStatus,ZipTestResults /p:BuildStatusZipOutputPath=$(Build.ArtifactStagingDirectory) /p:TestResultZipOutputPath=$(Build.ArtifactStagingDirectory)
+      condition: always()
+
+    - task: PublishPipelineArtifact@0
+      displayName: upload artifacts
+      inputs:
+        artifactName: mac-bcl-test-testresults
+        targetPath: $(Build.ArtifactStagingDirectory)
+      condition: always()
+
   # Check - "Xamarin.Android (Test MSBuild Mac)"
   - job: mac_msbuild_tests
     displayName: MSBuild Mac
@@ -490,7 +555,7 @@ stages:
 
     - task: DownloadPipelineArtifact@1
       inputs:
-        artifactName: $(NUnitTestAssembliesArtifactName)
+        artifactName: $(TestAssembliesArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
     - script: >
@@ -550,7 +615,7 @@ stages:
 
     - task: DownloadPipelineArtifact@1
       inputs:
-        artifactName: $(NUnitTestAssembliesArtifactName)
+        artifactName: $(TestAssembliesArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
     - task: MSBuild@1
@@ -630,7 +695,7 @@ stages:
 
     - task: DownloadPipelineArtifact@1
       inputs:
-        artifactName: $(NUnitTestAssembliesArtifactName)
+        artifactName: $(TestAssembliesArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
     - task: MSBuild@1

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -23,6 +23,12 @@
     <_AllArchives Include="@(TestAab)" />
   </ItemGroup>
 
+  <ItemDefinitionGroup>
+    <TestApkInstrumentation>
+      <TimeoutInMS>1800000</TimeoutInMS>
+    </TestApkInstrumentation>
+  </ItemDefinitionGroup>
+
   <Target Name="AcquireAndroidTarget">
     <Xamarin.Android.Tools.BootstrapTasks.CheckAdbTarget
         Condition=" '$(RequireNewEmulator)' != 'True' "
@@ -242,7 +248,7 @@
         TestFixture="$(TestFixture)"
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)"
-        Timeout="3600000">
+        Timeout="%(TestApkInstrumentation.TimeoutInMS)">
       <Output TaskParameter="FailedToRun" ItemName="_FailedComponent"/>
     </RunInstrumentationTests>
     <RunUITests

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Runtimes.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Runtimes.cs
@@ -352,6 +352,7 @@ namespace Xamarin.Android.Prepare
 
 			// This is referenced by monodroid_corlib_xunit-test.dll
 			new TestAssembly ("System.Runtime.CompilerServices.Unsafe.dll",                      TestAssemblyType.Reference, excludeDebugSymbols: true),
+			new TestAssembly ("Xunit.NetCore.Extensions.dll",				     TestAssemblyType.Satellite),
 
 			// Satellite assemblies
 			new TestAssembly (Path.Combine ("es-ES", "monodroid_corlib_test.resources.dll"),     TestAssemblyType.Satellite),

--- a/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.projitems
+++ b/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.projitems
@@ -16,6 +16,7 @@
       <Package>Xamarin.Android.Bcl_Tests</Package>
       <ResultsPath>$(OutputPath)TestResult-Xamarin.Android.Bcl_Tests.xunit.xml</ResultsPath>
       <LogcatFilenameDistincion>.xunit</LogcatFilenameDistincion>
+      <TimeoutInMS>4500000</TimeoutInMS>
     </TestApkInstrumentation>
 
     <TestApkInstrumentation Include="xamarin.android.bcltests.NUnitInstrumentation">

--- a/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets
+++ b/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.targets
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_ProfAssemProjItemsPath>..\..\..\bin\Build$(Configuration)\ProfileAssemblies.projitems</_ProfAssemProjItemsPath>
+    <_ProfAssemProjItemsPath Condition="!Exists('$(_ProfAssemProjItemsPath)')">..\..\..\bin\$(Configuration)\bcl-tests\ProfileAssemblies.projitems</_ProfAssemProjItemsPath>
+  </PropertyGroup>
   <Import Project="Xamarin.Android.Bcl-Tests.projitems" />
   <Import Project="..\..\..\build-tools\scripts\TestApks.targets" />
-  <Import Project="..\..\..\bin\Build$(Configuration)\ProfileAssemblies.projitems" />
+  <Import Project="$(_ProfAssemProjItemsPath)" />
   <Target Name="_AddTestAssemblies"
       DependsOnTargets="_RemapAssemblies"
       BeforeTargets="ResolveAssemblyReferences">

--- a/tests/TestRunner.Core/TestRunner.cs
+++ b/tests/TestRunner.Core/TestRunner.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Android.UnitTests
 		public string TestsRootDirectory { get; set; }
 		public Context Context { get; }
 		public List<TestFailureInfo> FailureInfos { get; } = new List<TestFailureInfo> ();
+		public string TestSuiteToRun { get; set; }
 
 		protected LogWriter Logger { get; }
 		protected abstract string ResultsFileName { get; set; }

--- a/tests/TestRunner.NUnit/NUnitTestInstrumentation.cs
+++ b/tests/TestRunner.NUnit/NUnitTestInstrumentation.cs
@@ -44,9 +44,8 @@ namespace Xamarin.Android.UnitTests.NUnit
 
 		IEnumerable<string> GetFilterValuesFromExtras (string key)
 		{
-			Dictionary<string, string> extras = GetStringExtrasFromBundle ();
-			if (extras.ContainsKey (key)) {
-				string filterValue = extras [key];
+			if (StringExtrasInBundle.ContainsKey (key)) {
+				string filterValue = StringExtrasInBundle [key];
 				if (!string.IsNullOrEmpty (filterValue))
 					return filterValue.Split (':');
 			}
@@ -66,13 +65,13 @@ namespace Xamarin.Android.UnitTests.NUnit
 			ChainCategoryFilter (IncludedCategories, false, ref filter);
 
 			Log.Info (LogTag, "Configuring test categories to include from extras:");
-			ChainCategoryFilter (GetFilterValuesFromExtras ("include"), false, ref filter);
+			ChainCategoryFilter (GetFilterValuesFromExtras (KnownArguments.Include), false, ref filter);
 
 			Log.Info (LogTag, "Configuring test categories to exclude:");
 			ChainCategoryFilter (ExcludedCategories, true, ref filter);
 
 			Log.Info(LogTag, "Configuring test categories to exclude from extras:");
-			ChainCategoryFilter (GetFilterValuesFromExtras ("exclude"), true, ref filter);
+			ChainCategoryFilter (GetFilterValuesFromExtras (KnownArguments.Exclude), true, ref filter);
 
 			Log.Info (LogTag, "Configuring tests to exclude (by name):");
 			ChainTestNameFilter (ExcludedTestNames?.ToArray (), ref filter);

--- a/tests/TestRunner.xUnit/XUnitTestInstrumentation.cs
+++ b/tests/TestRunner.xUnit/XUnitTestInstrumentation.cs
@@ -24,7 +24,9 @@ namespace Xamarin.Android.UnitTests.XUnit
 
 		protected override XUnitTestRunner CreateRunner (LogWriter logger, Bundle bundle)
 		{
-			return new XUnitTestRunner (Context, logger, bundle);
+			return new XUnitTestRunner (Context, logger, bundle) {
+				TestSuiteToRun = TestSuiteToRun,
+			};
 		}
 	}
 }


### PR DESCRIPTION
Adds a new job to build and run the BCL Test Suite on an emulator.

Conflicts:
	tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj