### PR TITLE
[Xamarin.Android.Build.Tasks] improve MAX_PATH errors

### DIFF
--- a/Documentation/guides/messages/xa5301.md
+++ b/Documentation/guides/messages/xa5301.md
@@ -1,0 +1,35 @@
+---
+title: Xamarin.Android error XA5301
+description: XA5301 error code
+ms.date: 08/13/2019
+---
+# Xamarin.Android error XA5301
+
+## Issue
+
+The XA5301 error is generated from a Windows [MAX_PATH][MAX_PATH]
+failure: a file path over 260 characters was encountered somewhere
+throughout the build.
+
+Consider submitting a [bug][bug] if you are getting this failure under
+normal circumstances.
+
+## Solution
+
+Rename your project to have a shorter name, or move the entire
+solution to a shorter path.
+
+For example:
+
+    C:\Users\MyReallyLongUsername\Desktop\Code\MyReallyLongSolutionName
+
+May fit under the [MAX_PATH][MAX_PATH] limit if it was instead:
+
+    C:\Code\MyReallyLongSolutionName
+
+Alternatively in recent versions of Windows 10, you can opt into long
+paths via a [Local Group Policy][long_path] system-wide.
+
+[bug]: https://github.com/xamarin/xamarin-android/wiki/Submitting-Bugs,-Feature-Requests,-and-Pull-Requests
+[MAX_PATH]: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#maximum-path-length-limitation
+[long_path]: https://blogs.msdn.microsoft.com/jeremykuhne/2016/07/30/net-4-6-2-and-long-paths-on-windows-10/

--- a/src/Xamarin.Android.Build.Tasks/Generator/Generator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Generator/Generator.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Text;
+using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
@@ -52,6 +53,13 @@ namespace Xamarin.Android.Tasks
 								message: xae.MessageWithoutCode,
 								messageArgs: new object [0]
 						);
+					} catch (DirectoryNotFoundException ex) {
+						ok = false;
+						if (OS.IsWindows) {
+							Diagnostic.Error (5301, "Failed to create JavaTypeInfo for class: {0} due to MAX_PATH: {1}", t.FullName, ex);
+						} else {
+							Diagnostic.Error (4209, "Failed to create JavaTypeInfo for class: {0} due to {1}", t.FullName, ex);
+						}
 					} catch (Exception ex) {
 						ok = false;
 						Diagnostic.Error (4209, "Failed to create JavaTypeInfo for class: {0} due to {1}", t.FullName, ex);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MaxPathTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MaxPathTests.cs
@@ -1,0 +1,83 @@
+using System.IO;
+using NUnit.Framework;
+using Xamarin.Android.Tools;
+using Xamarin.ProjectTools;
+
+namespace Xamarin.Android.Build.Tests
+{
+	/// <summary>
+	/// A set of tests checking MAX_PATH
+	/// </summary>
+	[TestFixture]
+	[Parallelizable (ParallelScope.Children)]
+	public class MaxPathTests : BaseTest
+	{
+		[SetUp]
+		public void Setup ()
+		{
+			if (!IsWindows) {
+				Assert.Ignore ("MAX_PATH only applies on Windows");
+			}
+		}
+
+		static object [] EdgeCases => new object [] {
+			new object[] {
+				/* limit */         145,
+				/* xamarinForms */  true,
+			},
+			new object[] {
+				/* limit */         77,
+				/* xamarinForms */  false,
+			},
+		};
+
+		/// <summary>
+		/// Full path length of .\bin\TestDebug\temp\
+		/// </summary>
+		int BaseLength => Path.Combine (Root, "temp").Length + 1;
+
+		[Test]
+		[TestCaseSource (nameof (EdgeCases))]
+		public void Edge (int limit, bool xamarinForms)
+		{
+			var testName = $"{nameof (Edge)}{xamarinForms}"
+				.PadRight (Files.MaxPath - BaseLength - limit, 'N');
+			var proj = xamarinForms ?
+				new XamarinFormsAndroidApplicationProject () :
+				new XamarinAndroidApplicationProject ();
+			using (var b = CreateApkBuilder (Path.Combine ("temp", testName))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
+			}
+		}
+
+		static object [] OverTheEdgeCases => new object [] {
+			new object[] {
+				/* limit */         144,
+				/* xamarinForms */  true,
+			},
+			new object[] {
+				/* limit */         76,
+				/* xamarinForms */  false,
+			},
+		};
+
+		[Test]
+		[TestCaseSource (nameof (OverTheEdgeCases))]
+		public void OverTheEdge (int limit, bool xamarinForms)
+		{
+			var testName = $"{nameof (Edge)}{xamarinForms}"
+				.PadRight (Files.MaxPath - BaseLength - limit, 'N');
+			var proj = xamarinForms ?
+				new XamarinFormsAndroidApplicationProject () :
+				new XamarinAndroidApplicationProject ();
+			using (var b = CreateApkBuilder (Path.Combine ("temp", testName))) {
+				b.ThrowOnBuildFailure = false;
+				Assert.IsFalse (b.Build (proj), "Build should have failed.");
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "XA5301"), "Should get MAX_PATH warning");
+				b.ThrowOnBuildFailure = true;
+				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MaxPathTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MaxPathTests.cs
@@ -48,6 +48,7 @@ namespace Xamarin.Android.Build.Tests
 			using (var b = CreateApkBuilder (Path.Combine ("temp", testName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, $"Trying long path: {Files.LongPathPrefix}"), "A long path should be encountered.");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/RemoveDirTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/RemoveDirTests.cs
@@ -1,0 +1,84 @@
+using System.IO;
+using Microsoft.Build.Utilities;
+using NUnit.Framework;
+using Xamarin.Android.Tasks;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	public class RemoveDirTests : BaseTest
+	{
+		string tempDirectory;
+
+		[SetUp]
+		public void Setup ()
+		{
+			tempDirectory = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
+			Directory.CreateDirectory (tempDirectory);
+		}
+
+		string NewFile (string fileName = "")
+		{
+			if (string.IsNullOrEmpty (fileName)) {
+				fileName = Path.GetRandomFileName ();
+			}
+			var path = Path.Combine (tempDirectory, fileName);
+			if (IsWindows && path.Length >= Files.MaxPath) {
+				File.WriteAllText (Files.ToLongPath (path), contents: "");
+			} else {
+				File.WriteAllText (path, contents: "");
+			}
+			return path;
+		}
+
+		RemoveDirFixed CreateTask () => new RemoveDirFixed {
+			BuildEngine = new MockBuildEngine (TestContext.Out),
+			Directories = new [] { new TaskItem (tempDirectory) },
+		};
+
+		[Test]
+		public void NormalDelete ()
+		{
+			NewFile ();
+			var task = CreateTask ();
+			Assert.IsTrue (task.Execute (), "task.Execute() should have succeeded.");
+			Assert.AreEqual (1, task.RemovedDirectories.Length, "Changes should have been made.");
+			DirectoryAssert.DoesNotExist (tempDirectory);
+		}
+
+		[Test]
+		public void NoExist ()
+		{
+			Directory.Delete (tempDirectory);
+			var task = CreateTask ();
+			Assert.IsTrue (task.Execute (), "task.Execute() should have succeeded.");
+			Assert.AreEqual (0, task.RemovedDirectories.Length, "No changes should have been made.");
+			DirectoryAssert.DoesNotExist (tempDirectory);
+		}
+
+		[Test]
+		public void ReadonlyFile ()
+		{
+			var file = NewFile ();
+			File.SetAttributes (file, FileAttributes.ReadOnly);
+			var task = CreateTask ();
+			Assert.IsTrue (task.Execute (), "task.Execute() should have succeeded.");
+			Assert.AreEqual (1, task.RemovedDirectories.Length, "Changes should have been made.");
+			DirectoryAssert.DoesNotExist (tempDirectory);
+		}
+
+		[Test]
+		public void LongPath ()
+		{
+			if (!IsWindows) {
+				Assert.Ignore ("MAX_PATH only applies on Windows");
+			}
+			var file = NewFile (fileName: "foo".PadRight (250, 'N'));
+			var task = CreateTask ();
+			Assert.IsTrue (task.Execute (), "task.Execute() should have succeeded.");
+			Assert.AreEqual (1, task.RemovedDirectories.Length, "Changes should have been made.");
+			DirectoryAssert.DoesNotExist (tempDirectory);
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/RemoveDirTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/RemoveDirTests.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NUnit.Framework;
 using Xamarin.Android.Tasks;
@@ -9,11 +12,13 @@ namespace Xamarin.Android.Build.Tests
 	[TestFixture]
 	public class RemoveDirTests : BaseTest
 	{
+		List<BuildMessageEventArgs> messages;
 		string tempDirectory;
 
 		[SetUp]
 		public void Setup ()
 		{
+			messages = new List<BuildMessageEventArgs> ();
 			tempDirectory = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
 			Directory.CreateDirectory (tempDirectory);
 		}
@@ -33,7 +38,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		RemoveDirFixed CreateTask () => new RemoveDirFixed {
-			BuildEngine = new MockBuildEngine (TestContext.Out),
+			BuildEngine = new MockBuildEngine (TestContext.Out, messages: messages),
 			Directories = new [] { new TaskItem (tempDirectory) },
 		};
 
@@ -79,6 +84,7 @@ namespace Xamarin.Android.Build.Tests
 			Assert.IsTrue (task.Execute (), "task.Execute() should have succeeded.");
 			Assert.AreEqual (1, task.RemovedDirectories.Length, "Changes should have been made.");
 			DirectoryAssert.DoesNotExist (tempDirectory);
+			Assert.IsTrue (StringAssertEx.ContainsText (messages.Select (m => m.Message), $"Trying long path: {Files.LongPathPrefix}"), "A long path should be encountered.");
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
@@ -21,6 +21,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)IncrementalBuildTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ManifestTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ManifestTest.TestCaseSource.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)MaxPathTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PackagingTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SupportV7RecyclerViewTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\BaseTest.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Tasks\AndroidRegExTests.cs" />
     <Compile Include="Tasks\CopyIfChangedTests.cs" />
     <Compile Include="Tasks\GetDependenciesTests.cs" />
+    <Compile Include="Tasks\RemoveDirTests.cs" />
     <Compile Include="Tasks\ResolveMonoAndroidSdksTests.cs" />
     <Compile Include="Tasks\LinkerTests.cs" />
     <Compile Include="Tasks\ResolveSdksTaskTests.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -15,6 +15,30 @@ namespace Xamarin.Android.Tools {
 
 	static class Files {
 
+		/// <summary>
+		/// Windows has a MAX_PATH limit of 260 characters
+		/// See: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#maximum-path-length-limitation
+		/// </summary>
+		public const int MaxPath = 260;
+
+		/// <summary>
+		/// On Windows, we can opt into a long path with this prefix
+		/// </summary>
+		public const string LongPathPrefix = @"\\?\";
+
+		/// <summary>
+		/// Converts a full path to a \\?\ prefixed path that works on all Windows machines when over 260 characters
+		/// NOTE: requires a *full path*, use sparingly
+		/// </summary>
+		public static string ToLongPath (string fullPath)
+		{
+			// On non-Windows platforms, return the path unchanged
+			if (Path.DirectorySeparatorChar != '\\') {
+				return fullPath;
+			}
+			return LongPathPrefix + fullPath;
+		}
+
 		public static bool Archive (string target, Action<string> archiver)
 		{
 			string newTarget = target + ".new";

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2571,7 +2571,7 @@ because xbuild doesn't support framework reference assemblies.
   Outputs="$(IntermediateOutputPath)_javac.stamp">
 
   <!-- remove existing <Javac /> outputs, since *.class files and classes.zip could contain old files -->
-  <RemoveDir Directories="$(IntermediateOutputPath)android\bin\classes" />
+  <RemoveDirFixed Directories="$(IntermediateOutputPath)android\bin\classes" />
   <Delete Files="$(IntermediateOutputPath)android\bin\classes.zip" />
 
   <!-- Compile java code -->


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2848
Context: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#maximum-path-length-limitation
Context: https://blogs.msdn.microsoft.com/jeremykuhne/2016/07/30/net-4-6-2-and-long-paths-on-windows-10/

A #deletebinobj problem has surfaced related to `MAX_PATH`. We have a
discrepancy of path length between:

* `obj\Debug\android\src` - where we generate `.java` source code
* `obj\Debug\android\bin\classes` - `javac` compiles `.class` files

If you have a project on the edge, where `android\src` does *not* have
a long path, but `android\bin\classes` *does*, we get the issue here:

    error MSB3231: Unable to remove directory "obj\Debug\90\android\bin\classes".
        Could not find a part of the path 'AccessibilityManagerCompat_AccessibilityStateChangeListenerImplementor.class'.

`javac` was able to create this file that is over `MAX_PATH`, and
unfortunately, .NET is throwing a `DirectoryNotFoundException` here...

An example:

    var dir = @"C:\src\xamarin-android\bin\TestDebug\temp\OnTheEdgeNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\obj\Debug\android\bin\classes";
    Directory.Delete(dir, recursive: true);

This code throws this when there is a file inside the directory over
`MAX_PATH`:

    System.IO.DirectoryNotFoundException: 'Could not find a part of the path 'AccessibilityManagerCompat_AccessibilityStateChangeListenerImplementor.class'.'

A solution, is to prefix `\\?\` in the `Directory.Delete` call as long
as you are already using a full path:

    Directory.Delete(@"\\?\" + dir, recursive: true);

As long as you are running on .NET 4.6.2 or higher, .NET will pass the
path directly to the Windows APIs without modification. This works
even without the `Local Group Policy` setting to enable long paths.

However, we should use `\\?\` sparingly:

* Not all `System.IO` and .NET APIs support `\\?\`-prefixed paths
* You have to already know that the path you are using is a full path
  -- `Path.GetFullPath()` will not expand a long path!

So I think we can safely prefix `\\?\` in some cases, such as:

* We hit a `DirectoryNotFoundException` or `PathTooLongException`
* On Windows, we can safely "try again" with `\\?\`

We can use this in `<RemoveDirFixed/>`, and it is able to delete
directories containing long paths.

## Other changes ##

* I refactored `<RemoveDirFixed/>` a bit, to make things cleaner.
* I added a `XA5301` error code for `MAX_PATH` issues.
* I added several new tests around `MAX_PATH`.