### PR TITLE
[Xamarin.Android.Build.Tasks] XA5302 warning for parallel builds

### DIFF
--- a/Documentation/guides/messages/xa5302.md
+++ b/Documentation/guides/messages/xa5302.md
@@ -1,0 +1,25 @@
+---
+title: Xamarin.Android warning XA5302
+description: XA5302 warning code
+ms.date: 08/14/2019
+---
+# Xamarin.Android warning XA5302
+
+## Issue
+
+The XA5302 warning is generated if we detect MSBuild building the
+project multiple times in parallel.
+
+You should not encounter this under normal circumstances in IDEs or at
+the command-line.
+
+## Solution
+
+You could also encounter this warning if MSBuild crashes, suffer power
+loss, etc. You can safely delete the file mentioned in the warning
+message as a last resort.
+
+Consider submitting a [bug][bug] if you are getting this failure under
+normal circumstances.
+
+[bug]: https://github.com/xamarin/xamarin-android/wiki/Submitting-Bugs,-Feature-Requests,-and-Pull-Requests

--- a/src/Xamarin.Android.Build.Tasks/Tasks/WriteLockFile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/WriteLockFile.cs
@@ -1,0 +1,63 @@
+using System;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// Generates a warning if LockFile exists, registers the file to be deleted at end of build
+	/// </summary>
+	public class WriteLockFile : Task
+	{
+		[Required]
+		public string LockFile { get; set; }
+
+		public override bool Execute ()
+		{
+			try {
+				var path = Path.GetFullPath (LockFile);
+				var key = new Tuple<string, string> (nameof (WriteLockFile), path); // Use the full path as part of the key
+
+				// Check if already registered, for sanity
+				var existing = BuildEngine4.GetRegisteredTaskObject (key, RegisteredTaskObjectLifetime.Build) as DeleteFileAfterBuild;
+				if (existing == null) {
+					if (File.Exists (path)) {
+						Log.LogCodedWarning ("XA5302", "Two processes may be building this project at once. Lock file exists at path: {0}", path);
+					} else {
+						Directory.CreateDirectory (Path.GetDirectoryName (path));
+						File.WriteAllText (path, "");
+					}
+
+					BuildEngine4.RegisterTaskObject (key, new DeleteFileAfterBuild (path), RegisteredTaskObjectLifetime.Build, allowEarlyCollection: false);
+				} else {
+					Log.LogDebugMessage ("Lock file was created earlier in the build.");
+				}
+			} catch (Exception ex) {
+				Log.LogDebugMessage ($"Exception in {nameof (WriteLockFile)}: {ex}");
+			}
+
+			// We want to always continue
+			return true;
+		}
+
+		/// <summary>
+		/// When using RegisterTaskObject and RegisteredTaskObjectLifetime.Build, MSBuild calls Dispose() at the end of the Build -- regardless of cancellation or failure
+		/// </summary>
+		class DeleteFileAfterBuild : IDisposable
+		{
+			readonly string path;
+
+			public DeleteFileAfterBuild (string path) => this.path = path;
+
+			public void Dispose ()
+			{
+				try {
+					File.Delete (path);
+				} catch {
+					// We don't want anything to throw here, but it is too late to log the error
+				}
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -51,6 +51,8 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, " 0 Warning(s)") || StringAssertEx.ContainsText (b.LastBuildOutput, " 1 Warning(s)"), "Should have no more than 1 MSBuild warnings.");
 				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "Warning: end of file not at end of a line"),
 					"Should not get a warning from the <CompileNativeAssembly/> task.");
+				var lockFile = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, ".__lock");
+				FileAssert.DoesNotExist (lockFile);
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -187,6 +187,7 @@
     <Compile Include="Tasks\ValidateJavaVersion.cs" />
     <Compile Include="Mono.Android\IntentFilterAttribute.Partial.cs" />
     <Compile Include="Mono.Android\GrantUriPermissionAttribute.Partial.cs" />
+    <Compile Include="Tasks\WriteLockFile.cs" />
     <Compile Include="Utilities\DummyCustomAttributeProvider.cs" />
     <Compile Include="Utilities\InvalidActivityNameException.cs" />
     <Compile Include="Utilities\JavaResourceParser.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -401,7 +401,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.SkipCases.projitems" />
 
 <Target Name="_WriteLockFile">
-    <WriteLockFile LockFile="$(IntermediateOutputPath).__lock" />
+  <WriteLockFile LockFile="$(IntermediateOutputPath).__lock" />
 </Target>
 
 <Target Name="_SeparateAppExtensionReferences">

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -15,7 +15,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 ***********************************************************************************************
 -->
 
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" InitialTargets="_WriteLockFile">
 <UsingTask TaskName="Xamarin.Android.Tasks.RemoveUnknownFiles" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.AdjustJavacVersionArguments" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.AndroidComputeResPaths" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -114,6 +114,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.CompileNativeAssembly" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.LinkApplicationSharedLibraries" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.PrepareAbiItems" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.WriteLockFile" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 
 <!--
 *******************************************
@@ -398,6 +399,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.D8.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Aapt2.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.SkipCases.projitems" />
+
+<Target Name="_WriteLockFile">
+    <WriteLockFile LockFile="$(IntermediateOutputPath).__lock" />
+</Target>
 
 <Target Name="_SeparateAppExtensionReferences">
 	<CreateItem Include="@(ProjectReference)" PreserveExistingMetadata="true" Condition="'%(Identity)' != '' AND '%(ProjectReference.IsAppExtension)' == 'true'">


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/3494#issuecomment-521256360

In the past, we have seen some cases where the IDE can run MSBuild on
the same project in parallel. This causes inexplicable failures
throughout Xamarin.Android's MSBuild targets.

If we generate a build warning indicating this is happening, we can
have insight release over release if this happens in the wild. We will
also have a visible warning recorded in customer build logs.

Basically, we should:

* Write a zero-byte "lock file" at the beginning of a build
    * Warn if this file already exists
* Delete the file at the end of the current build
    * Even if the build failed, was cancelled, etc.

This is simple and should work cross-platform, where a named `Mutex`
would only work on Windows.

To achieve this we can perform some MSBuild wizardry:

* Register a new MSBuild target with `InitialTargets`. This target
  will run before *anything* no matter what the top-level target was.
* Pass an `IDisposable` to `RegisterTaskObject` with a lifetime of the
  current build. MSBuild will `Dispose` it automatically at the end of
  the build.

I added an assertion in one test to make sure the lock file does not
exist after a build. I did some manually testing also, and things seem
to be working as expected.