### PR TITLE
[Xamarin.Android.Build.Tasks] fix NRE in <ConvertCustomView/>

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
@@ -49,13 +49,13 @@ namespace Xamarin.Android.Tasks {
 						bool update = false;
 						foreach (var elem in AndroidResource.GetElements (e).Prepend (e)) {
 							update |= TryFixCustomView (elem, acw_map, (level, message) => {
-								ITaskItem resdir = ResourceDirectories?.FirstOrDefault (x => file.StartsWith (x.ItemSpec)) ?? null;
+								ITaskItem resdir = ResourceDirectories?.FirstOrDefault (x => file.StartsWith (x.ItemSpec, StringComparison.OrdinalIgnoreCase)) ?? null;
 								switch (level) {
 								case TraceLevel.Error:
-									Log.FixupResourceFilenameAndLogCodedError ("XA1002", message, file, resdir.ItemSpec, resource_name_case_map);
+									Log.FixupResourceFilenameAndLogCodedError ("XA1002", message, file, resdir?.ItemSpec, resource_name_case_map);
 									break;
 								case TraceLevel.Warning:
-									Log.FixupResourceFilenameAndLogCodedError ("XA1001", message, file, resdir.ItemSpec, resource_name_case_map);
+									Log.FixupResourceFilenameAndLogCodedError ("XA1001", message, file, resdir?.ItemSpec, resource_name_case_map);
 									break;
 								default:
 									Log.LogDebugMessage (message);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ConvertResourcesCasesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ConvertResourcesCasesTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using Xamarin.ProjectTools;
@@ -122,6 +122,10 @@ namespace Xamarin.Android.Build.Tests {
 				"classlibrary1.CustomView;md5d6f7135293df7527c983d45d07471c5e.CustomTextView",
 			});
 			Assert.IsTrue (task.Execute (), "Task should have executed successfully");
+			if (IsWindows) {
+				// Causes an NRE
+				resPath = resPath.ToUpperInvariant ();
+			}
 			var custom = new ConvertCustomView () {
 				BuildEngine = engine,
 				CustomViewMapFile = task.CustomViewMapFile,


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3477

An issue was reported of an error such as:

    /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Android/Xamarin.Android.Common.targets(2315,3): error MSB4018: The "ConvertCustomView" task failed unexpectedly.
    System.NullReferenceException: Object reference not set to an instance of an object
        at Xamarin.Android.Tasks.ConvertCustomView+<>c__DisplayClass20_1.<Execute>b__0 (System.Diagnostics.TraceLevel level, System.String message) [0x0005b] in <35be9ecd0f44486bbcde5cb44c4d94c6>:0
        at Xamarin.Android.Tasks.ConvertCustomView.TryFixCustomView (System.Xml.Linq.XElement elem, System.Collections.Generic.Dictionary`2[TKey,TValue] acwMap, System.Action`2[T1,T2] logMessage) [0x0006f] in <35be9ecd0f44486bbcde5cb44c4d94c6>:0
        at Xamarin.Android.Tasks.ConvertCustomView.Execute () [0x00110] in <35be9ecd0f44486bbcde5cb44c4d94c6>:0
        at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute () [0x00029] in <9793e3774951417ca4f48a7c60193b35>:0
        at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask (Microsoft.Build.BackEnd.ITaskExecutionHost taskExecutionHost, Microsoft.Build.BackEnd.Logging.TaskLoggingContext taskLoggingContext, Microsoft.Build.BackEnd.TaskHost taskHost, Microsoft.Build.BackEnd.ItemBucket bucket, Microsoft.Build.BackEnd.TaskExecutionMode howToExecuteTask) [0x002a9] in <9793e3774951417ca4f48a7c60193b35>:0

In the `<ConvertCustomView/>` MSBuild task, there is a code path in
which `resdir` can be `null` and we directly call `resdir.ItemSpec`.
It looks like we can just use `resdir?.ItemSpec`, and
`FixupResourceFilenameAndLogCodedError` safely handles `null` passed
in.

I was only able to reproduce the issue by uppercasing the directory
name -- I am not sure how this would happen in a real project.

In either case, I added the null check and used
`StringComparison.OrdinalIgnoreCase` where appropriate.