### PR TITLE
Bump to xamarin/Java.Interop/master@2abfc1e0

### DIFF
--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -137,11 +137,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Debugging", "external\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Debugging.Soft", "external\debugger-libs\Mono.Debugging.Soft\Mono.Debugging.Soft.csproj", "{DE40756E-57F6-4AF2-B155-55E3A88CCED8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "jnienv-gen", "external\Java.Interop\build-tools\jnienv-gen\jnienv-gen.csproj", "{6410DA0F-5E14-4FC0-9AEE-F4C542C96C7A}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems*{3f1f2f50-af1a-4a5a-bedb-193372f068d7}*SharedItemsImports = 4
 		src\Xamarin.Android.Build.Tasks\Tests\Xamarin.Android.Build.Tests\Xamarin.Android.Build.Tests.Shared.projitems*{53e4abf0-1085-45f9-b964-dcae4b819998}*SharedItemsImports = 4
-		src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems*{66cf299a-ce95-4131-bcd8-db66e30c4bf7}*SharedItemsImports = 4
 		src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems*{74598f5c-b8cc-4ce6-8ee2-ab9ca1400076}*SharedItemsImports = 13
 		src\Xamarin.Android.Build.Tasks\Tests\Xamarin.Android.Build.Tests\Xamarin.Android.Build.Tests.Shared.projitems*{bd1d66bf-5ac7-4926-8ebe-b2198a112eb0}*SharedItemsImports = 13
 		external\Java.Interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems*{d1295a8f-4f42-461d-a046-564476c10002}*SharedItemsImports = 4
@@ -387,6 +388,10 @@ Global
 		{DE40756E-57F6-4AF2-B155-55E3A88CCED8}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{DE40756E-57F6-4AF2-B155-55E3A88CCED8}.Release|AnyCPU.ActiveCfg = Release|Any CPU
 		{DE40756E-57F6-4AF2-B155-55E3A88CCED8}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{6410DA0F-5E14-4FC0-9AEE-F4C542C96C7A}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{6410DA0F-5E14-4FC0-9AEE-F4C542C96C7A}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{6410DA0F-5E14-4FC0-9AEE-F4C542C96C7A}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{6410DA0F-5E14-4FC0-9AEE-F4C542C96C7A}.Release|AnyCPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -440,10 +445,10 @@ Global
 		{E34BCFA0-CAA4-412C-AA1C-75DB8D67D157} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{1E5501E8-49C1-4659-838D-CC9720C5208F} = {CAB438D8-B0F5-4AF0-BEBD-9E2ADBD7B483}
 		{1BAFA0CC-0377-46CE-AB7B-7BB2E7B62F63} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
-		{F3CFF31C-037B-450F-B22D-1D6E529B2DCC} = {864062D3-A415-4A6F-9324-5820237BA058}
-		{46529930-A5CC-4205-A50D-0AAAC639F082} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 		{0C31DE30-F9DF-4312-BFFE-DCAD558CCF08} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
 		{A0AEF446-3368-4591-9DE6-BC3B2B33337D} = {04E3E11E-B47D-4599-8AFC-50515A95E715}
+		{F3CFF31C-037B-450F-B22D-1D6E529B2DCC} = {864062D3-A415-4A6F-9324-5820237BA058}
+		{46529930-A5CC-4205-A50D-0AAAC639F082} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 		{DBDC804F-8406-4F5E-83C6-720CB0CB6C6F} = {864062D3-A415-4A6F-9324-5820237BA058}
 		{16DB2680-399B-4111-AA26-6CDBBFA334D8} = {CAB438D8-B0F5-4AF0-BEBD-9E2ADBD7B483}
 		{3B2A5653-EC97-4001-BB9B-D90F1AF2C371} = {05C3B1D6-A4CE-4534-A9E4-E9117591ADF7}
@@ -451,6 +456,7 @@ Global
 		{372E8E3E-29D5-4B4D-88A2-4711CD628C4E} = {05C3B1D6-A4CE-4534-A9E4-E9117591ADF7}
 		{90C99ADB-7D4B-4EB4-98C2-40BD1B14C7D2} = {05C3B1D6-A4CE-4534-A9E4-E9117591ADF7}
 		{DE40756E-57F6-4AF2-B155-55E3A88CCED8} = {05C3B1D6-A4CE-4534-A9E4-E9117591ADF7}
+		{6410DA0F-5E14-4FC0-9AEE-F4C542C96C7A} = {05C3B1D6-A4CE-4534-A9E4-E9117591ADF7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {53A1F287-EFB2-4D97-A4BB-4A5E145613F6}

--- a/build-tools/jnienv-gen/Generator.cs
+++ b/build-tools/jnienv-gen/Generator.cs
@@ -390,7 +390,7 @@ namespace Xamarin.Android.JniEnv
 				if (entry.Parameters [i].Type.ManagedType.StartsWith ("out "))
 					o.Write ("out ");
 				if (entry.Parameters [i].Type.ManagedType == "JValue*")
-					o.Write ("(JniArgumentValue*) " + Escape (entry.Parameters [i].Name));
+					o.Write ("(IntPtr) " + Escape (entry.Parameters [i].Name));
 				else if (IsObjectReferenceType (entry.Parameters [i].Type))
 					o.Write (string.Format ("new JniObjectReference ({0})", Escape (entry.Parameters [i].Name)));
 				else if (IsMemberID (entry.Parameters [i].Type)) {

--- a/build-tools/jnienv-gen/Generator.cs
+++ b/build-tools/jnienv-gen/Generator.cs
@@ -390,7 +390,7 @@ namespace Xamarin.Android.JniEnv
 				if (entry.Parameters [i].Type.ManagedType.StartsWith ("out "))
 					o.Write ("out ");
 				if (entry.Parameters [i].Type.ManagedType == "JValue*")
-					o.Write ("(IntPtr) " + Escape (entry.Parameters [i].Name));
+					o.Write ("(JniArgumentValue*) " + Escape (entry.Parameters [i].Name));
 				else if (IsObjectReferenceType (entry.Parameters [i].Type))
 					o.Write (string.Format ("new JniObjectReference ({0})", Escape (entry.Parameters [i].Name)));
 				else if (IsMemberID (entry.Parameters [i].Type)) {


### PR DESCRIPTION
Changes: https://github.com/xamarin/Java.Interop/compare/be581591d0a995c740600be3ceefd0c3351dd0dd...2abfc1e06a641a095acebe518f8f684efb36b3f1

Context: https://github.com/xamarin/java.interop/pull/459

Updates `generator` so that all bound Java interfaces also implement
`IJavaPeerable` in addition to `IJavaObject`, for eventual future
C#8 Default Interface Member support.

[generator] Remove extraneous slash when creating .projitems.

[generator] Always use XAPeerMembers for XAJavaInterop1

Drop dependency on DylibMono when building for Xamarin.Android

[jnienv-gen] fix p/invoke usage for .NET framework

Add `jnimarshalmethod-gen.exe -r ASSEMBLY` option.