### PR TITLE
[tests] Bump NUnit BCL Test timeout to 1 hour

### DIFF
--- a/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.projitems
+++ b/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.projitems
@@ -23,6 +23,7 @@
       <Package>Xamarin.Android.Bcl_Tests</Package>
       <ResultsPath>$(OutputPath)TestResult-Xamarin.Android.Bcl_Tests.nunit.xml</ResultsPath>
       <LogcatFilenameDistincion>.nunit</LogcatFilenameDistincion>
+      <TimeoutInMS>3600000</TimeoutInMS>
     </TestApkInstrumentation>
 
     <TestApkPermission Include="READ_PHONE_STATE">


### PR DESCRIPTION
Restores the instrumentation timeout for the NUnit set of BCL tests to
60 minutes, which was the previous timeout value prior to commit 3d9b154.