### PR TITLE
[tests] AndroidUpdateResourcesTest timing should exclude Restore

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1153,7 +1153,7 @@ namespace Lib1 {
 		[NonParallelizable]
 		public void BuildAppWithManagedResourceParserAndLibraries ()
 		{
-			int maxBuildTimeMs = TestEnvironment.IsRunningOnHostedAzureAgent ? 15000 : 10000;
+			int maxBuildTimeMs = 10000;
 			var path = Path.Combine ("temp", "BuildAppWithMRPAL");
 			var theme = new AndroidItem.AndroidResource ("Resources\\values\\Theme.xml") {
 				TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -1195,9 +1195,12 @@ namespace Lib1 {
 			};
 			appProj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", "True");
 			using (var libBuilder = CreateDllBuilder (Path.Combine (path, libProj.ProjectName), false, false)) {
-				libBuilder.Verbosity = LoggerVerbosity.Diagnostic;
+				libBuilder.AutomaticNuGetRestore = false;
+				Assert.IsTrue (libBuilder.RunTarget (libProj, "Restore"), "Library project should have restored.");
 				libBuilder.ThrowOnBuildFailure = false;
 				using (var appBuilder = CreateApkBuilder (Path.Combine (path, appProj.ProjectName), false, false)) {
+					appBuilder.AutomaticNuGetRestore = false;
+					Assert.IsTrue (appBuilder.RunTarget (appProj, "Restore"), "App project should have restored.");
 					appBuilder.ThrowOnBuildFailure = false;
 					Assert.IsTrue (libBuilder.DesignTimeBuild (libProj), "Library project should have built");
 					Assert.LessOrEqual (libBuilder.LastBuildTime.TotalMilliseconds, maxBuildTimeMs, $"DesignTime build should be less than {maxBuildTimeMs} milliseconds.");


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2942448&view=ms.vss-test-web.build-test-results-tab&runId=7928872&resultId=100035&paneView=debug

We have a specific test that times a design-time build and asserts
that it took less than a period of time.

It appears that in once instance the test taking too long, the
`Restore` target is what took a long time:

    10765 ms  Restore                                    1 calls

We should explicitly NuGet restore *first*, and not include that in
the timing.

I think this will also allow us to just check that things are under
10s and not check `IsRunningOnHostedAzureAgent`.