### PR TITLE
[Xamarin.Android.Build.Tasks] designer targets missing @(AndroidJavaLibrary)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
@@ -38,6 +38,9 @@ Copyright (C) 2016 Xamarin. All rights reserved.
     <ExtraJarLocation Include="@(_LibraryJars)">
       <Source>LibraryImport</Source>
     </ExtraJarLocation>
+    <ExtraJarLocation Include="@(AndroidJavaLibrary->'%(FullPath)')">
+      <Source>AndroidJavaLibrary</Source>
+    </ExtraJarLocation>
     <ExtraResourceLocation Include="@(_AdditionalAndroidResourcePaths->'%(Identity)\res')">
       <Source>AssemblyCache</Source>
     </ExtraResourceLocation>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/3418

In the case of AndroidX, the Android designer was not getting returned
certain `.jar` files from the `GetExtraLibraryLocationsForDesigner`
MSBuild target.

This target has an output item group of `ExtraJarLocation`, such as:

    <ExtraJarLocation Include="@(_AdditionalJavaLibraryReferences)">
      <Source>AssemblyCache</Source>
    </ExtraJarLocation>
    <ExtraJarLocation Include="@(_LibraryJars)">
      <Source>LibraryImport</Source>
    </ExtraJarLocation>

It turns out that any instances of `@(AndroidJavaLibrary)` were not
accounted for.

`<ReadLibraryProjectImportsCache/>` only returns jar files that were
extracted in `_ResolveLibraryProjectImports`, such as:

* `.jar` files from `__AndroidLibraryProjects__.zip`
* `.jar` files that are `EmbeddedResource`
* `.aar` files`

We need to return, `@(AndroidJavaLibrary)` in `ExtraJarLocation` as
well, but it *must* also be a full path. The designer's working
directory is *not* MSBuild's working directory.

Looking up what the value of `%(ExtraJarLocation.Source)` should be,
it is not actually used, but we should set it to something for
debugging purposes.

I also beefed up the test case a bit:

* Added a jar file & aar file
* Actually parse the XML for `libraryprojectimports.cache` and assert
  against the jar file count
* Look for the missing `@(AndroidJavaLibrary)` in the build output