### PR TITLE
[xaprepare] Bump OpenJDK Corretto version

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Linux.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Linux.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Android.Prepare
 	{
 		partial class Urls
 		{
-			public static readonly Uri Corretto = new Uri ("https://d3pxv6yz143wms.cloudfront.net/8.212.04.2/amazon-corretto-8.212.04.2-linux-x64.tar.gz");
+			public static readonly Uri Corretto = new Uri ($"{Corretto_BaseUri}{CorrettoUrlPathVersion}/amazon-corretto-{CorrettoDistVersion}-linux-x64.tar.gz");
 		}
 
 		partial class Defaults

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.MacOS.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Android.Prepare
 	{
 		partial class Urls
 		{
-			public static readonly Uri Corretto = new Uri ("https://d3pxv6yz143wms.cloudfront.net/8.212.04.2/amazon-corretto-8.212.04.2-macosx-x64.tar.gz");
+			public static readonly Uri Corretto = new Uri ($"{Corretto_BaseUri}{CorrettoUrlPathVersion}/amazon-corretto-{CorrettoDistVersion}-macosx-x64.tar.gz");
 			public static readonly Uri MonoPackage = new Uri ("https://download.mono-project.com/archive/6.0.0/macos-10-universal/MonoFramework-MDK-6.0.0.313.macos10.xamarin.universal.pkg");
 		}
 

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Unix.cs
@@ -1,12 +1,17 @@
+using System;
 using System.IO;
 
 namespace Xamarin.Android.Prepare
 {
 	partial class Configurables
 	{
+		const string CorrettoDistVersion = "8.222.10.1";
+		const string CorrettoUrlPathVersion = CorrettoDistVersion;
+
 		partial class Defaults
 		{
 			public const string DefaultCompiler = "cc";
+			public static readonly Version CorrettoVersion = Version.Parse (CorrettoDistVersion);
 		}
 
 		partial class Paths

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Windows.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Windows.cs
@@ -5,12 +5,15 @@ namespace Xamarin.Android.Prepare
 {
 	partial class Configurables
 	{
+		const string CorrettoDistVersion = "8.222.10.3";
+		const string CorrettoUrlPathVersion = "8.222.10.1";
+
 		partial class Urls
 		{
 			public static Uri Corretto => GetWindowsCorrettoUrl ();
 
-			public static readonly Uri Corretto64 = new Uri ("https://d3pxv6yz143wms.cloudfront.net/8.212.04.2/amazon-corretto-8.212.04.2-windows-x64-jdk.zip");
-			public static readonly Uri Corretto32 = new Uri ("https://d3pxv6yz143wms.cloudfront.net/8.212.04.2/amazon-corretto-8.212.04.2-windows-x86-jdk.zip");
+			public static readonly Uri Corretto64 = new Uri ($"{Corretto_BaseUri}{CorrettoUrlPathVersion}/amazon-corretto-{CorrettoDistVersion}-windows-x64-jdk.zip");
+			public static readonly Uri Corretto32 = new Uri ($"{Corretto_BaseUri}{CorrettoUrlPathVersion}/amazon-corretto-{CorrettoDistVersion}-windows-x86-jdk.zip");
 
 			/// <summary>
 			///   Base URL for the Ant tool download. Used in <see cref ="AndroidToolchain"/>
@@ -29,6 +32,7 @@ namespace Xamarin.Android.Prepare
 		partial class Defaults
 		{
 			public const string NativeLibraryExtension = ".dll";
+			public static readonly Version CorrettoVersion = Version.Parse (CorrettoDistVersion);
 		}
 
 		partial class Paths

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -19,6 +19,9 @@ namespace Xamarin.Android.Prepare
 
 		public static partial class Urls
 		{
+			// Keep the trailing slash here - OS-specific code assumes it's there.
+			public const string Corretto_BaseUri = "https://d3pxv6yz143wms.cloudfront.net/";
+
 			/// <summary>
 			///   Base URL for all Android SDK and NDK downloads. Used in <see cref="AndroidToolchain"/>
 			/// </summary>
@@ -110,7 +113,6 @@ namespace Xamarin.Android.Prepare
 			///   The maximum JDK version we support. Note: this will probably go away with Corretto
 			/// </summary>
 			public const int MaxJDKVersion = 8;
-			public static readonly Version CorrettoVersion = Version.Parse ("8.212.04.2");
 
 			/// <summary>
 			///   Prefix for all the log files created by the bootstrapper.


### PR DESCRIPTION
Context: https://docs.aws.amazon.com/corretto/latest/corretto-8-ug/change-log.html#changes-2019-07-16

New upstream release fixes a number of security issues:

  * [CVE-2019-7317](https://www.cvedetails.com/cve/CVE-2019-7317)
  * [CVE-2019-2842](https://www.cvedetails.com/cve/CVE-2019-2842)
  * [CVE-2019-2766](https://www.cvedetails.com/cve/CVE-2019-2766)
  * [CVE-2019-2816](https://www.cvedetails.com/cve/CVE-2019-2816)
  * [CVE-2019-2745](https://www.cvedetails.com/cve/CVE-2019-2745)
  * [CVE-2019-2786](https://www.cvedetails.com/cve/CVE-2019-2786)
  * [CVE-2019-2762](https://www.cvedetails.com/cve/CVE-2019-2762)
  * [CVE-2019-2769](https://www.cvedetails.com/cve/CVE-2019-2769)

Windows bumps to a different version of Corretto because of trivial and cosmetic
changes that were specific only to Windows OS.