### PR TITLE
[Xamarin.Android.Build.Tasks] fix #deletebinobj bug with designer

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -109,15 +109,15 @@ namespace Xamarin.ProjectTools
 			return RunTarget (project, "UpdateAndroidResources", doNotCleanupOnUpdate, parameters, environmentVariables);
 		}
 
-		public bool DesignTimeBuild (XamarinProject project, bool doNotCleanupOnUpdate = false, string [] parameters = null)
+		public bool DesignTimeBuild (XamarinProject project, string target = "Compile", bool doNotCleanupOnUpdate = false, string [] parameters = null)
 		{
 			if (parameters == null) {
-				return RunTarget (project, "Compile", doNotCleanupOnUpdate, parameters: new string [] { "DesignTimeBuild=True" });
+				return RunTarget (project, target, doNotCleanupOnUpdate, parameters: new string [] { "DesignTimeBuild=True" });
 			} else {
 				var designTimeParameters = new string [parameters.Length + 1];
 				parameters.CopyTo (designTimeParameters, 0);
 				designTimeParameters [parameters.Length] = "DesignTimeBuild=True";
-				return RunTarget (project, "Compile", doNotCleanupOnUpdate, parameters: designTimeParameters);
+				return RunTarget (project, target, doNotCleanupOnUpdate, parameters: designTimeParameters);
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1376,6 +1376,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_ResolveLibraryProjectImports"
+		DependsOnTargets="$(CoreResolveReferencesDependsOn)"
 		Inputs="$(ProjectAssetsFile);$(MSBuildProjectFullPath);@(_MonoAndroidReferencePath);$(_AndroidBuildPropertiesCache)"
 		Outputs="$(_AndroidStampDirectory)_ResolveLibraryProjectImports.stamp">
 	<ResolveLibraryProjectImports


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3494

In VS 2019 16.2 on Windows, I was able to reproduce a #deletebinobj
bug:

1. Create a new Xamarin.Android app
2. Open a layout file
3. Quickly type one letter and hit Ctrl+B

For me it took a couple tries sometimes, but I could eventually get an
error such as:

    Aapt2Link
        Assembly = C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\MSBuild\Xamarin\Android\Xamarin.Android.Build.Tasks.dll
        ...
        Executing link --manifest C:\Users\jopepper\AppData\Local\Temp\aihofny3.f3q\manifest\AndroidManifest.xml --java C:\Users\jopepper\AppData\Local\Temp\aihofny3.f3q --custom-package com.companyname.app10 -R C:\Users\jopepper\source\repos\App10\App10\obj\Debug\90\flata\\compiled.flata --auto-add-overlay -I "C:\Program Files (x86)\Android\android-sdk\platforms\android-28\android.jar" --output-text-symbols obj\Debug\90\R.txt --no-version-vectors  -o C:\Users\jopepper\AppData\Local\Temp\aihofny3.f3q\resources.apk
        Errors
            C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\MSBuild\Xamarin\Android\Xamarin.Android.Common.targets(1661,2): error APT0000: resource style/Theme.AppCompat.Light.DarkActionBar (aka com.companyname.app10:style/Theme.AppCompat.Light.DarkActionBar) not found.
            Resources\values\styles.xml(2,0): error APT0000: style attribute 'attr/colorPrimary (aka com.companyname.app10:attr/colorPrimary)' not found.
            Resources\values\styles.xml(2,0): error APT0000: style attribute 'attr/colorPrimaryDark (aka com.companyname.app10:attr/colorPrimaryDark)' not found.
            Resources\values\styles.xml(2,0): error APT0000: style attribute 'attr/colorAccent (aka com.companyname.app10:attr/colorAccent)' not found.
            C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\MSBuild\Xamarin\Android\Xamarin.Android.Common.targets(1661,2): error APT0000: resource style/ThemeOverlay.AppCompat.Dark.ActionBar (aka com.companyname.app10:style/ThemeOverlay.AppCompat.Dark.ActionBar) not found.
            Resources\values\styles.xml(2,0): error APT0000: style attribute 'attr/windowActionBar (aka com.companyname.app10:attr/windowActionBar)' not found.
            Resources\values\styles.xml(2,0): error APT0000: style attribute 'attr/windowNoTitle (aka com.companyname.app10:attr/windowNoTitle)' not found.
            C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\MSBuild\Xamarin\Android\Xamarin.Android.Common.targets(1661,2): error APT0000: resource style/ThemeOverlay.AppCompat.Light (aka com.companyname.app10:style/ThemeOverlay.AppCompat.Light) not found.
            C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\MSBuild\Xamarin\Android\Xamarin.Android.Common.targets(1661,2): error APT0000: failed linking references.

When in this state, a `Rebuild` is required to get the project working
again.

The `<Aapt2Link/>` failure is actually caused by an incomplete list of
`ResolvedResourceDirectories`:

    Task ReadLibraryProjectImportsCache
      CacheFile: obj\Debug\90\libraryprojectimports.cache
      Jars:
      ResolvedAssetDirectories:
      ResolvedResourceDirectories:
      ResolvedEnvironmentFiles:
      ResolvedResourceDirectoryStamps:

How is `libraryprojectimports.cache` blank?

    <Paths><Jars /><ResolvedResourceDirectories /><ResolvedAssetDirectories /><ResolvedEnvironmentFiles /><ResolvedResourceDirectoryStamps /></Paths>

Looking at the build logs, several builds are triggered by the Ctrl+B:

* `GetAndroidDependencies` - the IDE's `Auto Install Android SDKs`
  feature
* `UpdateGeneratedFiles` - a design-time build of the XML file save
* `Build` - the actual build
* `GetExtraLibraryLocationsForDesigner` - the designer's target that
  runs after build

There were also a few more builds prior to this one, namely the
`SetupDependenciesForDesigner` target when I opened the layout in the
designer. Sometimes `UpdateGeneratedFiles` ran twice, and sometimes
not? It appears the times that it runs twice is when the problem
occurs? In some cases, I would even have to restart the IDE to see the
issue occur again... I could not see any builds running a the same
time either; each build ran sequentially.

When I opened the *first* `UpdateGeneratedFiles` log, the
`<ResolveLibraryProjectImports/>` task ran with no `Assemblies` as
input!

During a normal build the `_AddAndroidCustomMetaData` target runs
ahead of `_ResolveLibraryProjectImports`, but that isn't happening
here. This new target was added in 5f27d0c, and it appears things work
fine--except for a specific incremental design-time build.

`_ResolveLibraryProjectImports` needs to depend on
`$(CoreResolveReferencesDependsOn)`. After doing this, I can no longer
reproduce the problem in a test or manually testing in the IDE.