### PR TITLE
Fix mingw dependency version constraint

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Android.Prepare
 
 			new HomebrewProgram ("mingw-w64", new Uri ("https://raw.githubusercontent.com/Homebrew/homebrew-core/a6542037a48a55061a4c319e6bb174b3715f7cbe/Formula/mingw-w64.rb")) {
 				MinimumVersion = "6.0.0_1",
-				MaximumVersion = "6.0.0_1",
+				MaximumVersion = "6.0.0_2",
 				Pin = true,
 			},
 


### PR DESCRIPTION
When running `make prepare` with `AutoProvision` set to true, the script installs mingw 6.0.0_2. When it detects that mingw is not installed, it will install version 6.0.0_2 and continue. The next time, it will detect 6.0.0_2 and complain about the version, unable to proceed.