### PR TITLE
[tests/ci] Fix Azure Pipeline hosted detection

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
@@ -56,9 +56,9 @@ namespace Xamarin.ProjectTools
 		public static bool IsRunningOnHostedAzureAgent {
 			get {
 				string agentNameValue = Environment.GetEnvironmentVariable ("AGENT_NAME");
-				bool hasHostedAgentName = !string.IsNullOrEmpty (agentNameValue) && agentNameValue.ToUpper ().Contains ("AZURE PIPELINES");
+				bool hasHostedAgentName = !string.IsNullOrEmpty (agentNameValue) && agentNameValue.ToUpperInvariant ().Contains ("AZURE PIPELINES");
 				string serverTypeValue = Environment.GetEnvironmentVariable ("SYSTEM_SERVERTYPE");
-				bool isHostedServerType = !string.IsNullOrEmpty (serverTypeValue) && serverTypeValue.ToUpper ().Contains ("HOSTED");
+				bool isHostedServerType = !string.IsNullOrEmpty (serverTypeValue) && serverTypeValue.ToUpperInvariant ().Contains ("HOSTED");
 				return hasHostedAgentName || isHostedServerType;
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
@@ -56,7 +56,10 @@ namespace Xamarin.ProjectTools
 		public static bool IsRunningOnHostedAzureAgent {
 			get {
 				string agentNameValue = Environment.GetEnvironmentVariable ("AGENT_NAME");
-				return !string.IsNullOrEmpty(agentNameValue) && agentNameValue.ToUpper ().Contains ("HOSTED");
+				bool hasHostedAgentName = !string.IsNullOrEmpty (agentNameValue) && agentNameValue.ToUpper ().Contains ("AZURE PIPELINES");
+				string serverTypeValue = Environment.GetEnvironmentVariable ("SYSTEM_SERVERTYPE");
+				bool isHostedServerType = !string.IsNullOrEmpty (serverTypeValue) && serverTypeValue.ToUpper ().Contains ("HOSTED");
+				return hasHostedAgentName || isHostedServerType;
 			}
 		}
 


### PR DESCRIPTION
The hosted pools we're using on Azure Pipelines no longer appear to have
'hosted' in the name. Updates the running on hosted check to look for
the new hosted pool agent naming schema, and adds a new variable check
to help make this more robust. Predefined Azure Pipeline variables can be
found here: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables