### PR TITLE
[Xamarin.Android.Build.Tasks] Add EnvVar and File support for Signing APKs

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -1073,6 +1073,15 @@ server, the following MSBuild properties can be used:
     the value entered when `keytool` asks **Enter key password for
     $(AndroidSigningKeyAlias)**.
 
+    You can use the raw password here, however if you want to hide your password in logs
+    you can use a prefix of env: or file: to point it to an Environment variable or 
+    a file. For example
+
+    ```
+        env:<PasswordEnvironentVariable>
+        file:<PasswordFile> 
+    ```
+
 -   **AndroidSigningKeyStore** &ndash; Specifies the filename of the
     keystore file created by `keytool`. This corresponds to the value
     provided to the **keytool -keystore** option.
@@ -1081,6 +1090,15 @@ server, the following MSBuild properties can be used:
     `$(AndroidSigningKeyStore)`. This is the value provided to
     `keytool` when creating the keystore file and asked **Enter
     keystore password:**.
+
+    You can use the raw password here, however if you want to hide your password in logs
+    you can use a prefix of env: or file: to point it to an Environment variable or 
+    a file. For example
+
+    ```
+        env:<PasswordEnvironentVariable>
+        file:<PasswordFile> 
+    ```
 
 For example, consider the following `keytool` invocation:
 
@@ -1108,6 +1126,26 @@ To use the keystore generated above, use the property group:
     <AndroidSigningStorePass>keystore.filename password</AndroidSigningStorePass>
     <AndroidSigningKeyAlias>keystore.alias</AndroidSigningKeyAlias>
     <AndroidSigningKeyPass>keystore.alias password</AndroidSigningKeyPass>
+</PropertyGroup>
+```
+
+To use an environment variable to store your password you can do the following
+
+```xml
+<PropertyGroup>
+    <AndroidSigningStorePass>env:SomeEnvironmentVariableWithThePassword</AndroidSigningStorePass>
+    <AndroidSigningKeyPass>env:SomeEnvironmentVariableWithThePassword</AndroidSigningKeyPass>
+</PropertyGroup>
+```
+
+to use a file you can do the following
+
+To use an environment variable to store your password you can do the following
+
+```xml
+<PropertyGroup>
+    <AndroidSigningStorePass>file:SomeFileWithThePassword</AndroidSigningStorePass>
+    <AndroidSigningKeyPass>file:SomeFileWithThePassword</AndroidSigningKeyPass>
 </PropertyGroup>
 ```
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
@@ -23,9 +23,27 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string KeyAlias { get; set; }
 
+		/// <summary>
+		/// The Password for the Key.
+		/// You can use the raw password here, however if you want to hide your password in logs
+		/// you can use a preview of env: or file: to point it to an Environment variable or 
+		/// a file.
+		///
+		///   env:<PasswordEnvironentVariable>
+		///   file:<PasswordFile> 
+		/// </summary>
 		[Required]
 		public string KeyPass { get; set; }
 
+		/// <summary>
+		/// The Password for the Keystore.
+		/// You can use the raw password here, however if you want to hide your password in logs
+		/// you can use a preview of env: or file: to point it to an Environment variable or 
+		/// a file.
+		///
+		///   env:<PasswordEnvironentVariable>
+		///   file:<PasswordFile> 
+		/// </summary>
 		[Required]
 		public string StorePass { get; set; }
 
@@ -39,6 +57,18 @@ namespace Xamarin.Android.Tasks
 			}
 
 			return base.Execute ();
+		}
+
+		void AddStorePass (CommandLineBuilder cmd, string cmdLineSwitch, string value)
+		{
+			if (value.StartsWith ("env:", StringComparison.Ordinal)) {
+				cmd.AppendSwitchIfNotNull ($"{cmdLineSwitch} ", value);
+			}
+			else if (value.StartsWith ("file:", StringComparison.Ordinal)) {
+				cmd.AppendSwitchIfNotNull ($"{cmdLineSwitch} file:", value.Replace ("file:", string.Empty));
+			} else {
+				cmd.AppendSwitchIfNotNull ($"{cmdLineSwitch} pass:", value);
+			}
 		}
 
 		protected override string GenerateCommandLineCommands ()
@@ -59,9 +89,9 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitchIfNotNull ("-jar ", ApkSignerJar);
 			cmd.AppendSwitch ("sign");
 			cmd.AppendSwitchIfNotNull ("--ks ", KeyStore);
-			cmd.AppendSwitchIfNotNull ("--ks-pass pass:", StorePass);
+			AddStorePass (cmd, "--ks-pass", StorePass);
 			cmd.AppendSwitchIfNotNull ("--ks-key-alias ", KeyAlias);
-			cmd.AppendSwitchIfNotNull ("--key-pass pass:", KeyPass);
+			AddStorePass (cmd, "--key-pass", KeyPass);
 			cmd.AppendSwitchIfNotNull ("--min-sdk-version ", minSdk.ToString ());
 			cmd.AppendSwitchIfNotNull ("--max-sdk-version ", maxSdk.ToString ());
 		

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
@@ -22,9 +22,27 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string KeyAlias { get; set; }
 		
+		/// <summary>
+		/// The Password for the Key.
+		/// You can use the raw password here, however if you want to hide your password in logs
+		/// you can use a preview of env: or file: to point it to an Environment variable or 
+		/// a file.
+		///
+		///   env:<PasswordEnvironentVariable>
+		///   file:<PasswordFile> 
+		/// </summary>
 		[Required]
 		public string KeyPass { get; set; }
 		
+		/// <summary>
+		/// The Password for the Keystore.
+		/// You can use the raw password here, however if you want to hide your password in logs
+		/// you can use a preview of env: or file: to point it to an Environment variable or 
+		/// a file.
+		///
+		///   env:<PasswordEnvironentVariable>
+		///   file:<PasswordFile> 
+		/// </summary>
 		[Required]
 		public string StorePass { get; set; }
 
@@ -48,6 +66,19 @@ namespace Xamarin.Android.Tasks
 
 		protected override string DefaultErrorCode => "ANDJS0000";
 
+		void AddStorePass (CommandLineBuilder cmd, string cmdLineSwitch, string value)
+		{
+			string pass = value.Replace ("env:", string.Empty).Replace ("file:", string.Empty);
+			if (value.StartsWith ("env:", StringComparison.Ordinal)) {
+				cmd.AppendSwitchIfNotNull ($"{cmdLineSwitch}:env ", pass);
+			}
+			else if (value.StartsWith ("file:", StringComparison.Ordinal)) {
+				cmd.AppendSwitchIfNotNull ($"{cmdLineSwitch}:file ", pass);
+			} else {
+				cmd.AppendSwitchIfNotNull ($"{cmdLineSwitch} ", pass);
+			}
+		}
+
 		protected override string GenerateCommandLineCommands ()
 		{
 			var fileName = Path.GetFileNameWithoutExtension (UnsignedApk);
@@ -57,8 +88,8 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitchIfNotNull ("-tsa ", TimestampAuthorityUrl);
 			cmd.AppendSwitchIfNotNull ("-tsacert ", TimestampAuthorityCertificateAlias);
 			cmd.AppendSwitchIfNotNull ("-keystore ", KeyStore);
-			cmd.AppendSwitchIfNotNull ("-storepass ", StorePass);
-			cmd.AppendSwitchIfNotNull ("-keypass ", KeyPass);
+			AddStorePass (cmd, "-storepass", StorePass);
+			AddStorePass (cmd, "-keypass", KeyPass);
 			cmd.AppendSwitchIfNotNull ("-digestalg ", DigestAlgorithm);
 			cmd.AppendSwitchIfNotNull ("-sigalg ", SigningAlgorithm);
 			cmd.AppendSwitchIfNotNull ("-signedjar ", Path.Combine (SignedApkDirectory, $"{fileName}{FileSuffix}{extension}" ));


### PR DESCRIPTION
Fixes #3513

Both `jarsigner` and `apksigner` provide a way to use both
files and environment variables for the store and key passwords.

For `jarsigner` you have to suffix the parameter switch with either
`:env` or `:file` to use those options. For `apksigner` you have
to prefix the value with either `:env`, `:file` or `:pass`.

We currently only support raw passwords.

This commit adds support for using both `env:` and `file:` for
signing. When providing values for the MSBuild properties
such as `AndroidSigningStorePass` and `AndroidSigningKeyPass` all
they need to do is prefix the value with `env:` or `file:` to
use the alternative parameters.

	/p:AndroidSigningKeyPass=env:MyPasswordEnvVar
	/p:AndroidSigningKeyPass=file:PathToPasswordFile

This will stop passwords appearing in build logs etc.