### PR TITLE
[Xamarin.Android.Build.Tasks] tests for MSBuild.Sdk.Extras

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.DefaultOutputPaths.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.DefaultOutputPaths.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup Condition="'$(BaseIntermediateOutputPath)' == ''">
-		<BaseIntermediateOutputPath>obj</BaseIntermediateOutputPath>
+		<BaseIntermediateOutputPath>obj\</BaseIntermediateOutputPath>
 	</PropertyGroup>
 	<PropertyGroup>
 		<BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>
@@ -11,18 +11,15 @@
 	<PropertyGroup Condition="'$(AndroidUseLatestPlatformSdk)' != 'true'">
 		<!-- Only change IntermediateOutputPath on Windows by default to avoid backward compatibility issues -->
 		<AppendTargetFrameworkToIntermediateOutputPath Condition=" '$(AppendTargetFrameworkToIntermediateOutputPath)' == '' And '$(OS)' == 'Windows_NT' ">True</AppendTargetFrameworkToIntermediateOutputPath>
-		<AppendTargetFrameworkToIntermediateOutputPath Condition=" '$(AppendTargetFrameworkToIntermediateOutputPath)' == '' And '$(OS)' != 'Windows_NT' ">False</AppendTargetFrameworkToIntermediateOutputPath>
 		<AppendTargetFrameworkToIntermediateOutputPath Condition="'$(AppendTargetFrameworkToIntermediateOutputPath)' == ''">False</AppendTargetFrameworkToIntermediateOutputPath>
 		<!-- We don't change the OutputPath by default to avoid backward compatibility issues -->
 		<AppendTargetFrameworkToOutputPath Condition="'$(AppendTargetFrameworkToOutputPath)' == ''">false</AppendTargetFrameworkToOutputPath>
 		<TargetFrameworkToOutputPath>$(TargetFrameworkVersion.TrimStart('v').Replace('.', ''))</TargetFrameworkToOutputPath>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(AppendTargetFrameworkToIntermediateOutputPath)' == 'true'">
-		<IntermediateOutputPath Condition="'$(IntermediateOutputPath)' != '' and !HasTrailingSlash('$(IntermediateOutputPath)')">$(IntermediateOutputPath)\</IntermediateOutputPath>
-		<IntermediateOutputPath>$(IntermediateOutputPath)$(TargetFrameworkToOutputPath)</IntermediateOutputPath>
+	<PropertyGroup Condition=" '$(AppendTargetFrameworkToIntermediateOutputPath)' == 'True' And '$(UsingMicrosoftNETSdk)' != 'True' ">
+		<IntermediateOutputPath>$([MSBuild]::EnsureTrailingSlash($(IntermediateOutputPath)))$(TargetFrameworkToOutputPath)</IntermediateOutputPath>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(AppendTargetFrameworkToOutputPath)' == 'true'">
-		<OutputPath Condition="'$(OutputPath)' != '' and !HasTrailingSlash('$(OutputPath)')">$(OutputPath)\</OutputPath>
-		<OutputPath>$(OutputPath)$(TargetFrameworkToOutputPath)</OutputPath>
+	<PropertyGroup Condition=" '$(AppendTargetFrameworkToOutputPath)' == 'True' And '$(UsingMicrosoftNETSdk)' != 'True' ">
+		<OutputPath>$([MSBuild]::EnsureTrailingSlash($(OutputPath)))$(TargetFrameworkToOutputPath)</OutputPath>
 	</PropertyGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MSBuildSdkExtrasTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MSBuildSdkExtrasTests.cs
@@ -1,0 +1,92 @@
+using System.IO;
+using System.Linq;
+using Mono.Cecil;
+using NUnit.Framework;
+using Xamarin.ProjectTools;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	[NonParallelizable] // On MacOS, parallel /restore causes issues
+	public class MSBuildSdkExtrasTests : BaseTest
+	{
+		[Test]
+		public void ClassLibrary ()
+		{
+			var proj = new MSBuildSdkExtrasProject ();
+			using (var b = CreateDllBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				var output = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, proj.ProjectName + ".dll");
+				FileAssert.Exists (output);
+				AssertContainsClass (output, "Class1", contains: true);
+			}
+		}
+
+		[Test]
+		public void ClassLibraryNoResources ()
+		{
+			var proj = new MSBuildSdkExtrasProject ();
+			proj.Sources.Remove (proj.Sources.First (s => s.BuildAction == "AndroidResource"));
+			using (var b = CreateDllBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				var output = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, proj.ProjectName + ".dll");
+				FileAssert.Exists (output);
+				AssertContainsClass (output, "Class1", contains: true);
+			}
+		}
+
+		[Test]
+		public void BindingProject ()
+		{
+			var proj = new MSBuildSdkExtrasProject {
+				IsBindingProject = true,
+			};
+			proj.OtherBuildItems.Add (new AndroidItem.EmbeddedJar ("Jars\\svg-android.jar") {
+				WebContent = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/svg-android/svg-android.jar"
+			});
+			using (var b = CreateDllBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				var output = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, proj.ProjectName + ".dll");
+				FileAssert.Exists (output);
+				AssertContainsClass (output, "Com.Larvalabs.Svgandroid.SVG", contains: true);
+			}
+		}
+
+		[Test]
+		public void MultiTargeting ()
+		{
+			var proj = new MSBuildSdkExtrasProject ();
+			proj.TargetFrameworks += ";netstandard2.0";
+			proj.Sources.Add (new BuildItem.Source ("MyView.cs") {
+				TextContent = () =>
+@"#if __ANDROID__
+class MyView : Android.Views.View
+{
+	public MyView (Android.Content.Context c) : base (c) { }
+}
+#endif",
+			});
+			using (var b = CreateDllBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				var output = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, proj.ProjectName + ".dll");
+				FileAssert.Exists (output);
+				AssertContainsClass (output, "MyView", contains: true);
+				output = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath, "..", "netstandard2.0", proj.ProjectName + ".dll");
+				FileAssert.Exists (output);
+				AssertContainsClass (output, "MyView", contains: false);
+			}
+		}
+
+		void AssertContainsClass (string assemblyFile, string className, bool contains)
+		{
+			using (var assembly = AssemblyDefinition.ReadAssembly(assemblyFile)) {
+				bool result = assembly.MainModule.Types.Select (t => t.FullName).Contains (className);
+				if (contains) {
+					Assert.IsTrue (result, $"{assemblyFile} should contain {className}!");
+				} else {
+					Assert.IsFalse (result, $"{assemblyFile} should *not* contain {className}!");
+				}
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
@@ -22,6 +22,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ManifestTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ManifestTest.TestCaseSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MaxPathTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)MSBuildSdkExtrasTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PackagingTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SupportV7RecyclerViewTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\BaseTest.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/MSBuildSdkExtrasProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/MSBuildSdkExtrasProject.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+
+namespace Xamarin.ProjectTools
+{
+	public class MSBuildSdkExtrasProject : DotNetStandard
+	{
+		public MSBuildSdkExtrasProject ()
+		{
+			Sdk = "MSBuild.Sdk.Extras/2.0.41";
+			Sources.Add (new BuildItem.Source ("Class1.cs") {
+				TextContent = () => "public class Class1 { }"
+			});
+			Sources.Add (new AndroidItem.AndroidResource ("Resources\\values\\Strings.xml") {
+				TextContent = () => StringsXml.Replace ("${PROJECT_NAME}", ProjectName)
+			});
+			StringsXml = XamarinAndroidLibraryProject.default_strings_xml;
+			TargetFrameworks = "MonoAndroid10.0";
+		}
+
+		public string StringsXml { get; set; }
+
+		/// <summary>
+		/// /t:Restore or /restore is always required
+		/// </summary>
+		public override bool ShouldRestorePackageReferences => true;
+
+		public string TargetFrameworks {
+			get => GetProperty (nameof (TargetFrameworks));
+			set => SetProperty (nameof (TargetFrameworks), value);
+		}
+
+		public bool IsBindingProject {
+			get => string.Equals (GetProperty (nameof (IsBindingProject)), "True", StringComparison.OrdinalIgnoreCase);
+			set => SetProperty (nameof (IsBindingProject), value.ToString ());
+		}
+
+		string Configuration => IsRelease ? "Release" : "Debug";
+
+		public string TargetFrameworkDirectory {
+			get {
+				int index = TargetFrameworks.IndexOf (";");
+				if (index != -1) {
+					return TargetFrameworks.Substring (0, TargetFrameworks.Length - index).ToLowerInvariant ();
+				}
+				return TargetFrameworks.ToLowerInvariant ();
+			}
+		}
+
+		public string OutputPath => Path.Combine ("bin", Configuration, TargetFrameworkDirectory);
+
+		public string IntermediateOutputPath => Path.Combine ("obj", Configuration, TargetFrameworkDirectory);
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidLibraryProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidLibraryProject.cs
@@ -9,7 +9,7 @@ namespace Xamarin.ProjectTools
 {
 	public class XamarinAndroidLibraryProject : XamarinAndroidCommonProject
 	{
-		const string default_strings_xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+		internal const string default_strings_xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <resources>
 	<string name=""library_name"">${PROJECT_NAME}</string>
 </resources>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetStandard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetStandard.cs
@@ -15,10 +15,12 @@ namespace Xamarin.ProjectTools
 
 		public DotNetStandard ()
 		{
+			ProjectName = "UnnamedProject";
 			Sources = new List<BuildItem> ();
 			OtherBuildItems = new List<BuildItem> ();
 			SetProperty (CommonProperties, "DebugType", "full");
 			ItemGroupList.Add (Sources);
+			ItemGroupList.Add (OtherBuildItems);
 			Language = XamarinAndroidProjectLanguage.CSharp;
 		}
 
@@ -51,32 +53,36 @@ namespace Xamarin.ProjectTools
 				}
 			}
 			sb.AppendLine ("\t</PropertyGroup>");
-			sb.AppendLine ("\t<ItemGroup>");
-			foreach (var pr in PackageReferences) {
-				sb.AppendLine ($"\t\t<PackageReference Include=\"{pr.Id}\" Version=\"{pr.Version}\"/>");
-			}
-			sb.AppendLine ("\t</ItemGroup>");
-			sb.AppendLine ("\t<ItemGroup>");
-			foreach (var bi in OtherBuildItems) {
-				sb.Append ($"\t\t<{bi.BuildAction} ");
-				if (bi.Include != null) sb.Append ($"Include=\"{bi.Include ()}\" ");
-				if (bi.Update != null) sb.Append ($"Update=\"{bi.Update ()}\" ");
-				if (bi.Remove != null) sb.Append ($"Remove=\"{bi.Remove ()}\" ");
-				if (bi.Generator != null) sb.Append ($"Generator=\"{bi.Generator ()}\" ");
-				if (bi.DependentUpon != null) sb.Append ($"DependentUpon=\"{bi.DependentUpon ()}\" ");
-				if (bi.Version != null) sb.Append ($"Version=\"{bi.Version ()}\" ");
-				if (bi.SubType != null) sb.Append ($"SubType=\"{bi.SubType ()}\" ");
-				if (bi.Metadata.Any ()) {
-					sb.AppendLine ($"\t\t/>");
-				} else {
-					sb.AppendLine ($">");
-					foreach (var kvp in bi.Metadata) {
-						sb.AppendLine ($"\t\t\t<{kvp.Key}>{kvp.Value}</{kvp.Key}>");
-					}
-					sb.AppendLine ($"\t\t</{bi.BuildAction}>");
+			if (PackageReferences.Count > 0) {
+				sb.AppendLine ("\t<ItemGroup>");
+				foreach (var pr in PackageReferences) {
+					sb.AppendLine ($"\t\t<PackageReference Include=\"{pr.Id}\" Version=\"{pr.Version}\"/>");
 				}
+				sb.AppendLine ("\t</ItemGroup>");
 			}
-			sb.AppendLine ("\t</ItemGroup>");
+			if (OtherBuildItems.Count > 0) {
+				sb.AppendLine ("\t<ItemGroup>");
+				foreach (var bi in OtherBuildItems) {
+					sb.Append ($"\t\t<{bi.BuildAction} ");
+					if (bi.Include != null) sb.Append ($"Include=\"{bi.Include ()}\" ");
+					if (bi.Update != null) sb.Append ($"Update=\"{bi.Update ()}\" ");
+					if (bi.Remove != null) sb.Append ($"Remove=\"{bi.Remove ()}\" ");
+					if (bi.Generator != null) sb.Append ($"Generator=\"{bi.Generator ()}\" ");
+					if (bi.DependentUpon != null) sb.Append ($"DependentUpon=\"{bi.DependentUpon ()}\" ");
+					if (bi.Version != null) sb.Append ($"Version=\"{bi.Version ()}\" ");
+					if (bi.SubType != null) sb.Append ($"SubType=\"{bi.SubType ()}\" ");
+					if (bi.Metadata.Any ()) {
+						sb.AppendLine ($"\t\t/>");
+					} else {
+						sb.AppendLine ($">");
+						foreach (var kvp in bi.Metadata) {
+							sb.AppendLine ($"\t\t\t<{kvp.Key}>{kvp.Value}</{kvp.Key}>");
+						}
+						sb.AppendLine ($"\t\t</{bi.BuildAction}>");
+					}
+				}
+				sb.AppendLine ("\t</ItemGroup>");
+			}
 			return $"<Project Sdk=\"{Sdk}\">\r\n{sb.ToString ()}\r\n</Project>";
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -207,7 +207,7 @@ namespace Xamarin.ProjectTools
 			foreach (var ig in ItemGroupList)
 				list.AddRange (ig.Select (s => new ProjectResource () {
 					Timestamp = s.Timestamp,
-					Path = s.Include (),
+					Path = s.Include?.Invoke (),
 					Content = s.TextContent == null ? null : s.TextContent (),
 					BinaryContent = s.BinaryContent == null ? null : s.BinaryContent (),
 					Encoding = s.Encoding,
@@ -257,6 +257,9 @@ namespace Xamarin.ProjectTools
 				throw new InvalidOperationException ("Path '" + directory + "' does not exist.");
 
 			foreach (var p in projectFiles) {
+				// Skip empty paths or wildcards
+				if (string.IsNullOrEmpty (p.Path) || p.Path.Contains ("*"))
+					continue;
 				var path = Path.Combine (directory, p.Path.Replace ('\\', '/').Replace ('/', Path.DirectorySeparatorChar));
 
 				if (p.Deleted) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Android\AndroidSdkResolver.cs" />
     <Compile Include="Android\XamarinFormsMapsApplicationProject.cs" />
     <Compile Include="Common\ExistingProject.cs" />
+    <Compile Include="Android\MSBuildSdkExtrasProject.cs" />
     <Compile Include="Common\TestEnvironment.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Common\BuildActions.cs" />

--- a/tools/xabuild/XABuildPaths.cs
+++ b/tools/xabuild/XABuildPaths.cs
@@ -49,9 +49,24 @@ namespace Xamarin.Android.Build
 		public string MSBuildBin { get; private set; }
 
 		/// <summary>
+		/// Temporary directory used for MSBUILD_EXE_PATH
+		/// </summary>
+		public string MSBuildTempPath { get; private set; }
+
+		/// <summary>
 		/// Temporary file used for MSBUILD_EXE_PATH
 		/// </summary>
 		public string MSBuildExeTempPath { get; private set; }
+
+		/// <summary>
+		/// Config file needed for Microsoft.Build.NuGetSdkResolver.dll to work
+		/// </summary>
+		public string SdkResolverConfigPath { get; private set; }
+
+		/// <summary>
+		/// Full path to the system Microsoft.Build.NuGetSdkResolver.dll
+		/// </summary>
+		public string NuGetSdkResolverPath { get; private set; }
 
 		/// <summary>
 		/// Path to MSBuild's App.config file
@@ -140,7 +155,9 @@ namespace Xamarin.Android.Build
 				}
 				NuGetProps               = Path.Combine (nuget, "Microsoft.NuGet.props");
 				NuGetTargets             = Path.Combine (nuget, "Microsoft.NuGet.targets");
-				NuGetRestoreTargets      = Path.Combine (VsInstallRoot, "Common7", "IDE", "CommonExtensions", "Microsoft", "NuGet", "NuGet.targets");
+				var nugetDirectory       = Path.Combine (VsInstallRoot, "Common7", "IDE", "CommonExtensions", "Microsoft", "NuGet");
+				NuGetRestoreTargets      = Path.Combine (nugetDirectory, "NuGet.targets");
+				NuGetSdkResolverPath     = Path.Combine (nugetDirectory, "Microsoft.Build.NuGetSdkResolver.dll");
 			} else {
 				string[] vsVersions       = new [] {"Current", "15.0"};
 				string mono              = IsMacOS ? "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono" : "/usr/lib/mono";
@@ -180,15 +197,19 @@ namespace Xamarin.Android.Build
 					NuGetProps   = Path.Combine (nuget, "Microsoft.NuGet.props");
 				}
 				NuGetRestoreTargets = Path.Combine (MSBuildBin, "NuGet.targets");
+				NuGetSdkResolverPath = Path.Combine (MSBuildBin, "Microsoft.Build.NuGetSdkResolver.dll");
 				if (!File.Exists (NuGetRestoreTargets) && !string.IsNullOrEmpty (DotNetSdkPath)) {
 					NuGetRestoreTargets = Path.Combine (DotNetSdkPath, "..", "NuGet.targets");
+					NuGetSdkResolverPath = Path.Combine (DotNetSdkPath, "..", "Microsoft.Build.NuGetSdkResolver.dll");
 				}
 			}
 
 			FrameworksDirectory       = Path.Combine (prefix, "xbuild-frameworks");
 			MSBuildExtensionsPath     = Path.Combine (prefix, "xbuild");
 			MonoAndroidToolsDirectory = Path.Combine (prefix, "xbuild", "Xamarin", "Android");
-			MSBuildExeTempPath        = Path.GetTempFileName ();
+			MSBuildTempPath           = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
+			MSBuildExeTempPath        = Path.Combine (MSBuildTempPath, Path.GetRandomFileName ());
+			SdkResolverConfigPath     = Path.Combine (MSBuildTempPath, "SdkResolvers", "Microsoft.Build.NuGetSdkResolver", "Microsoft.Build.NuGetSdkResolver.xml");
 			XABuildConfig             = MSBuildExeTempPath + ".config";
 
 			var roslyn = Path.Combine (MSBuildBin, "Roslyn");


### PR DESCRIPTION
Context: https://github.com/onovotny/MSBuildSdkExtras
Context: https://www.nuget.org/packages/MSBuild.Sdk.Extras/

Today, you can create an SDK-style project such as:

    <Project Sdk="Microsoft.NET.Sdk">
      <PropertyGroup>
        <TargetFramework>netstandard2.0</TargetFramework>
      </PropertyGroup>
    </Project>

If you want to "multi-target", you can take advantage of
MSBuild.Sdk.Extras, such as:

    <Project Sdk="MSBuild.Sdk.Extras/2.0.41">
      <PropertyGroup>
        <TargetFrameworks>netstandard2.0;MonoAndroid90</TargetFrameworks>
      </PropertyGroup>
    </Project>

This imports `Xamarin.Android.CSharp.targets` on top of the SDK-style
MSBuild targets. `MSBuild.Sdk.Extras` is a community-led project.

During a build both will be produced:

* `bin\Debug\netstandard2.0\foo.dll`
* `bin\Debug\monoandroid90\90\foo.dll` - *NOTE* this seems wrong

Unfortunately, our `$(OutputPath)` is not correct, this is problem
number one. We also have no tests verifying that MSBuild.Sdk.Extras
continues to work! Lastly, we are missing some support for the NuGet
"SDK Resolver" in `xabuild.exe`.

## xabuild ##

SDK-style projects have a concept of a "SDK resolver", which locates
the appropriate assemblies, MSBuild targets, etc.
`Microsoft.Build.NuGetSdkResolver.dll` enables SDKs to come from
NuGet, such as `MSBuild.Sdk.Extras`.

Using `xabuild.exe` as-is was producing errors such as:

    Project Name=UnnamedProject.csproj id:4 File=UnnamedProject.csproj
        Resolving SDK 'MSBuild.Sdk.Extras/2.0.41'...
        MSB4236: The SDK 'MSBuild.Sdk.Extras/2.0.41' specified could not be found.

For `Microsoft.Build.NuGetSdkResolver.dll` to be *found*:

* Relative to `%MSBUILD_EXE_PATH%`, a
  `SdkResolvers\Microsoft.Build.SdkResolver\Microsoft.Build.SdkResolver.xml`
  file must exist.
* `Microsoft.Build.SdkResolver.xml` contains a path to
  `Microsoft.Build.NuGetSdkResolver.dll`

An example of this XML file would be:

    <SdkResolver>
      <Path>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\Microsoft.Build.NuGetSdkResolver.dll</Path>
    </SdkResolver>

To get `xabuild.exe` working as needed, I had to:

* `%MSBUILD_EXE_PATH%` is created in a subdirectory of `%TEMP%`
* This subdirectory also contains
  `SdkResolvers\Microsoft.Build.SdkResolver\Microsoft.Build.SdkResolver.xml`
* `xabuild.exe` now generates the extra config file
* On exit, `xabuild.exe` deletes the entire temp directory

## Xamarin.Android.DefaultOutputPaths.targets ##

I fixed up the weirdness when MSBuild.Sdk.Extras is used:

* If `$(UsingMicrosoftNETSdk)` is `True`, we should not mess with
  `$(OutputPath)` or `$(IntermediateOutputPath)`.
* Proper paths are used already by default, such as:
  `obj\Debug\monoandroid90` and `bin\Debug\monoandroid90`

Other refactoring:

* `$(BaseIntermediateOutputPath)` should be `obj\` by default`
* I made use of `[MSBuild]::EnsureTrailingSlash`
* Removed a duplicate line setting
  `$(AppendTargetFrameworkToIntermediateOutputPath)`

## tests ##

In `Xamarin.ProjectTools`, I created a `MSBuildSdkExtrasProject` class
and added tests for a couple scenarios:

* A regular class library
* A class library with no `@(AndroidResource)`
* A multi-targeted library using `#if __ANDROID__`