### PR TITLE
[linker] Improve *Invoker types linking

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Extensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Extensions.cs
@@ -120,14 +120,14 @@ namespace MonoDroid.Tuner {
 			return true;
 		}
 
-		public static bool TryGetRegisterAttribute (this MethodDefinition method, out CustomAttribute register)
+		static bool TryGetRegisterAttribute (ICustomAttributeProvider provider, out CustomAttribute register)
 		{
 			register = null;
 
-			if (!method.HasCustomAttributes)
+			if (!provider.HasCustomAttributes)
 				return false;
 
-			foreach (CustomAttribute attribute in method.CustomAttributes) {
+			foreach (CustomAttribute attribute in provider.CustomAttributes) {
 				if (!IsRegisterAttribute (attribute))
 					continue;
 
@@ -136,6 +136,25 @@ namespace MonoDroid.Tuner {
 			}
 
 			return false;
+		}
+
+		public static bool TryGetRegisterAdapter (this TypeDefinition td, out string adapter)
+		{
+		       CustomAttribute register;
+		       adapter = null;
+
+		       if (!TryGetRegisterAttribute (td, out register))
+			       return false;
+
+		       if (register.ConstructorArguments.Count != 3)
+			       return false;
+
+		       adapter = (string) register.ConstructorArguments [2].Value;
+
+		       if (string.IsNullOrEmpty (adapter))
+			       return false;
+
+		       return true;
 		}
 
 		public static bool TryGetRegisterMember (this MethodDefinition md, out string method)
@@ -150,7 +169,7 @@ namespace MonoDroid.Tuner {
 			nativeMethod = null;
 			signature = null;
 
-			if (!md.TryGetRegisterAttribute (out register))
+			if (!TryGetRegisterAttribute (md, out register))
 				return false;
 
 			if (register.ConstructorArguments.Count != 3)

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MarkJavaObjects.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MarkJavaObjects.cs
@@ -192,8 +192,6 @@ namespace MonoDroid.Tuner {
 			if (invoker == null)
 				return;
 
-			Annotations.Mark (invoker);
-
 			PreserveIntPtrConstructor (invoker);
 			PreserveInterfaceMethods (type, invoker);
 		}

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MonoDroidMarkStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MonoDroidMarkStep.cs
@@ -436,6 +436,14 @@ namespace MonoDroid.Tuner
 			PreserveRegisteredMethod (method.DeclaringType, member);
 		}
 
+		protected override bool ShouldMarkInterfaceImplementation (TypeDefinition type, InterfaceImplementation iface, TypeDefinition resolvedInterfaceType)
+		{
+			if (base.ShouldMarkInterfaceImplementation (type, iface, resolvedInterfaceType))
+				return true;
+
+			return resolvedInterfaceType.TryGetRegisterAdapter (out _);
+		}
+
 		protected override void DoAdditionalTypeProcessing (TypeDefinition type)
 		{
 			// If we are preserving a Mono.Android interface,


### PR DESCRIPTION
Improves fix of https://github.com/xamarin/xamarin-android/issues/3263

The
https://github.com/xamarin/xamarin-android/commit/4d8c28f624b50a86b564b0bc6bdefb85ea822b69
fix increased the apk size more than needed. It marked all the
*Invoker types, beause MarkJavaObjects substep iterates over all
Java.Object derived types, before all the linking.

Turned out that the original regression came from the linker
itself. The new linker optimization was introduced in
https://github.com/mono/linker/commit/13ea1582e518f5f64cb93057aca962983e58e337
and so the ITextWatcher interface was not marked anymore.

Before the new optimization, the linker preserved these
ifaces (like `ITextWatcher`) when marking the types based on them
(like `AbsListView` or `ITextWatcherImplementor` in this case). That also
resulted in keeping the invoker interfaces in the assembly. The above
mentioned optimization changed that.

Now they were linked out, because the interfaces implementation
are only accessed (during app runtime) after the invoker type is loaded by
`Type.GetType(string,bool)` in the native members registration
process. The linker cannot know about that without XA help during the
linking. The result of `ITextWatcher` being linked away is that the
`ITeextWatcherInvoker` type was linked away too.

It is now fixed by overriding the `ShouldMarkInterfaceImplementation`
method in `MarkStep`, which returns true for registered interfaces.
These interfaces are special for XA in a way, that it can be,
 in some cases, reached only from java side and thus linker is unable
to track the interface usage. It is similar to how linker handles the COM
interfaces.

The crash in Topeka sample:

    I MonoDroid: System.TypeLoadException: Could not load type 'Android.Text.ITextWatcherInvoker' from assembly 'Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
    I MonoDroid:   at (wrapper managed-to-native) System.RuntimeTypeHandle.internal_from_name(string,System.Threading.StackCrawlMark&,System.Reflection.Assembly,bool,bool,bool)
    I MonoDroid:   at System.RuntimeTypeHandle.GetTypeByName (System.String typeName, System.Boolean throwOnError, System.Boolean ignoreCase, System.Boolean reflectionOnly, System.Threading.StackCrawlMark& stackMark, System.Boolean loadTypeFromPartialName) [0x0008d] in <ab232a84cff64754aaec9d455f50a794>:0
    I MonoDroid:   at System.RuntimeType.GetType (System.String typeName, System.Boolean throwOnError, System.Boolean ignoreCase, System.Boolean reflectionOnly, System.Threading.StackCrawlMark& stackMark) [0x0000e] in <ab232a84cff64754aaec9d455f50a794>:0
    I MonoDroid:   at System.Type.GetType (System.String typeName, System.Boolean throwOnError) [0x00002] in <ab232a84cff64754aaec9d455f50a794>:0
    I MonoDroid:   at Android.Runtime.AndroidTypeManager.RegisterNativeMembers (Java.Interop.JniType jniType, System.Type type, System.String methods) [0x00131] in <4bc2304bf5d8408baea9dd059d7ea365>:0
    I MonoDroid:   at Android.Runtime.JNIEnv.RegisterJniNatives (System.IntPtr typeName_ptr, System.Int32 typeName_len, System.IntPtr jniClass, System.IntPtr methods_ptr, System.Int32 methods_len) [0x00128] in <4bc2304bf5d8408baea9dd059d7ea365>:0
    I MonoDroid:   at (wrapper managed-to-native) Java.Interop.NativeMethods.java_interop_jnienv_call_static_object_method_a(intptr,intptr&,intptr,intptr,Java.Interop.JniArgumentValue*)
    I MonoDroid:   at Java.Interop.JniEnvironment+StaticMethods.CallStaticObjectMethod (Java.Interop.JniObjectReference type, Java.Interop.JniMethodInfo method, Java.Interop.JniArgumentValue* args) [0x00073] in <fbb1482d0c6b44009a68f9f7e8c6389a>:0
    I MonoDroid:   at Android.Runtime.JNIEnv.CallStaticObjectMethod (System.IntPtr jclass, System.IntPtr jmethod, Android.Runtime.JValue* parms) [0x0000f] in <4bc2304bf5d8408baea9dd059d7ea365>:0
    I MonoDroid:   at Android.Runtime.JNIEnv.CallStaticObjectMethod (System.IntPtr jclass, System.IntPtr jmethod, Android.Runtime.JValue[] parms) [0x0001a] in <4bc2304bf5d8408baea9dd059d7ea365>:0
    I MonoDroid:   at Android.Runtime.JNIEnv.FindClass (System.String classname) [0x0003f] in <4bc2304bf5d8408baea9dd059d7ea365>:0
    I MonoDroid:   at Android.Runtime.JNIEnv.AllocObject (System.String jniClassName) [0x00001] in <4bc2304bf5d8408baea9dd059d7ea365>:0
    I MonoDroid:   at Android.Runtime.JNIEnv.StartCreateInstance (System.String jniClassName, System.String jniCtorSignature, Android.Runtime.JValue* constructorParameters) [0x0000a] in <4bc2304bf5d8408baea9dd059d7ea365>:0
    I MonoDroid:   at Android.Runtime.JNIEnv.StartCreateInstance (System.String jniClassName, System.String jniCtorSignature, Android.Runtime.JValue[] constructorParameters) [0x00019] in <4bc2304bf5d8408baea9dd059d7ea365>:0
    I MonoDroid:   at Android.Text.TextWatcherImplementor..ctor (System.Object inst, System.EventHandler`1[TEventArgs] changed_handler, System.EventHandler`1[TEventArgs] before_handler, System.EventHandler`1[TEventArgs] after_handler) [0x00010] in <4bc2304bf5d8408baea9dd059d7ea365>:0
    I MonoDroid:   at Android.Widget.TextView.add_TextChanged (System.EventHandler`1[TEventArgs] value) [0x0001f] in <4bc2304bf5d8408baea9dd059d7ea365>:0
    I MonoDroid:   at Topeka.Fragments.SignInFragment.InitContentViews (Android.Views.View view) [0x00011] in <201b9318435b446d821a19dfd1fa7bfb>:0
    I MonoDroid:   at Topeka.Fragments.SignInFragment.OnViewCreated (Android.Views.View view, Android.OS.Bundle savedInstanceState) [0x0003e] in <201b9318435b446d821a19dfd1fa7bfb>:0
    I MonoDroid:   at Android.App.Fragment.n_OnViewCreated_Landroid_view_View_Landroid_os_Bundle_ (System.IntPtr jnienv, System.IntPtr native__this, System.IntPtr native_view, System.IntPtr native_savedInstanceState) [0x0001a] in <4bc2304bf5d8408baea9dd059d7ea365>:0
    I MonoDroid:   at (wrapper dynamic-method) Android.Runtime.DynamicMethodNameCounter.9(intptr,intptr,intptr,intptr)

The comparison of apk sizes with original and this fix (Topeka sample,
which was also used as repro):

| Version        | Size in bytes |
|----------------|--------------:|
| Before @4d8c28 |      21434941 |
| After  @4d8c28 |      28242405 |
| This fix       |      21638678 |

So the previous fix increased the apk size by around 6.5Mbytes, this
fix adds less than 199kbytes instead.