### PR TITLE
[Xamarin.Android.Build.Tasks] improve incremental builds + designer

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
@@ -135,8 +135,8 @@ Copyright (C) 2016 Xamarin. All rights reserved.
 
 <Target Name="SetupDependenciesForDesigner"
     DependsOnTargets="UpdateAndroidResources;_AdjustJavacVersionArguments;_GeneratePackageManagerJavaForDesigner;_GetMonoPlatformJarPath;_DetermineJavaLibrariesToCompile"
-    Inputs="$(IntermediateOutputPath)android\src\mono\MonoPackageManager.java;$(_AndroidTypeMappingJavaToManaged);$(_AndroidTypeMappingManagedToJava)"
-    Outputs="$(IntermediateOutputPath)android\bin\classes\mono\MonoPackageManager.class">
+    Inputs="$(MSBuildAllProjects);$(MonoPlatformJarPath);@(_JavaStubFiles);@(AndroidJavaSource)"
+    Outputs="$(_AndroidStampDirectory)SetupDependenciesForDesigner.stamp">
   <Javac
       JavaPlatformJarPath="$(JavaPlatformJarPath)"
       ClassesOutputDirectory="$(IntermediateOutputPath)android\bin\classes"
@@ -149,6 +149,7 @@ Copyright (C) 2016 Xamarin. All rights reserved.
       JavacTargetVersion="$(JavacTargetVersion)"
       JavacSourceVersion="$(JavacSourceVersion)"
   />
+  <Touch Files="$(_AndroidStampDirectory)SetupDependenciesForDesigner.stamp" AlwaysCreate="true" />
 </Target>
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
@@ -16,6 +16,8 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string ClassesOutputDirectory { get; set; }
 
+		public string ClassesZip { get; set; }
+
 		public string JavaPlatformJarPath { get; set; }
 
 		public string JavacTargetVersion { get; set; }
@@ -31,8 +33,11 @@ namespace Xamarin.Android.Tasks
 			if (!result)
 				return result;
 			// compress all the class files
-			using (var zip = new ZipArchiveEx (Path.Combine (ClassesOutputDirectory, "..", "classes.zip"), FileMode.OpenOrCreate))
-				zip.AddDirectory (ClassesOutputDirectory, "", CompressionMethod.Store);
+			if (!string.IsNullOrEmpty (ClassesZip)) {
+				using (var zip = new ZipArchiveEx (ClassesZip, FileMode.OpenOrCreate)) {
+					zip.AddDirectory (ClassesOutputDirectory, "", CompressionMethod.Store);
+				}
+			}
 			return result;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -169,22 +169,26 @@ namespace Xamarin.ProjectTools
 			return new BuildOutput (this) { Builder = builder };
 		}
 
-		string project_file_contents;
+		ProjectResource project;
 		string packages_config_contents;
 
 		public virtual List<ProjectResource> Save (bool saveProject = true)
 		{
 			var list = new List<ProjectResource> ();
 			if (saveProject) {
+				if (project == null) {
+					project = new ProjectResource {
+						Path = ProjectFilePath,
+						Encoding = System.Text.Encoding.UTF8,
+					};
+				}
+				// Clear the Timestamp if the project changed
 				var contents = SaveProject ();
-				var timestamp = contents != project_file_contents ? default (DateTimeOffset?) : 
-					ItemGroupList.SelectMany (ig => ig).Where (i => i.Timestamp != null).Select (i => (DateTimeOffset)i.Timestamp).Max ();
-				list.Add (new ProjectResource () {
-					Timestamp = timestamp,
-					Path = ProjectFilePath,
-					Content = project_file_contents = contents,
-					Encoding = System.Text.Encoding.UTF8,
-				});
+				if (contents != project.Content) {
+					project.Timestamp = null;
+					project.Content = contents;
+				}
+				list.Add (project);
 			}
 
 			if (Packages.Any ()) {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2552,6 +2552,7 @@ because xbuild doesn't support framework reference assemblies.
   <Javac
     JavaPlatformJarPath="$(JavaPlatformJarPath)"
     ClassesOutputDirectory="$(IntermediateOutputPath)android\bin\classes"
+    ClassesZip="$(IntermediateOutputPath)android\bin\classes.zip"
     TargetFrameworkDirectory="$(TargetFrameworkDirectory)"
     StubSourceDirectory="$(IntermediateOutputPath)android\src"
     JavaSourceFiles="@(AndroidJavaSource)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1382,7 +1382,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_ResolveLibraryProjectImports"
 		DependsOnTargets="$(CoreResolveReferencesDependsOn)"
-		Inputs="$(ProjectAssetsFile);$(MSBuildProjectFullPath);@(_MonoAndroidReferencePath);$(_AndroidBuildPropertiesCache)"
+		Inputs="$(ProjectAssetsFile);$(MSBuildProjectFullPath);@(_MonoAndroidReferencePath);@(AndroidAarLibrary);$(_AndroidBuildPropertiesCache)"
 		Outputs="$(_AndroidStampDirectory)_ResolveLibraryProjectImports.stamp">
 	<ResolveLibraryProjectImports
 		ContinueOnError="$(DesignTimeBuild)"


### PR DESCRIPTION
I was reviewing MSBuild logs inside the IDE when using the Android
designer and noticed something odd:

    Building target "_CompileToDalvikWithDx" completely.
    Input file "obj\Debug\android\bin\classes.zip" is newer than output file "obj\Debug\stamp\_CompileToDalvik.stamp".

It appears that editing an Android layout was causing
`_CompileToDalvikWithDx` to run again?

Then I looked at the build log from `SetupDependenciesForDesigner`:

    Building target "SetupDependenciesForDesigner" completely.
    Output file "obj\Debug\android\bin\classes\mono\MonoPackageManager.class" does not exist.

Ok, we no longer generate `MonoPackageManager.class`. It is included
as part of `java-runtime.jar`.

Looking closer, the `Inputs` and `Outputs` did not seem right for
`SetupDependenciesForDesigner`:

    Inputs="$(IntermediateOutputPath)android\src\mono\MonoPackageManager.java;$(_AndroidTypeMappingJavaToManaged);$(_AndroidTypeMappingManagedToJava)"
    Outputs="$(IntermediateOutputPath)android\bin\classes\mono\MonoPackageManager.class"

We no longer generate `$(_AndroidTypeMappingJavaToManaged)` or
`$(_AndroidTypeMappingManagedToJava)`, so we would also hit:

    Building target "SetupDependenciesForDesigner" completely.
    Input file "obj\Debug\android\typemap.jm" does not exist.

In the current state of affairs, `SetupDependenciesForDesigner` will
always run -- and trigger `_CompileToDalvikWithDx` on incremental
*regular* builds.

Two goals here would make things a lot better:

1. `SetupDependenciesForDesigner` should be skippable.
2. `SetupDependenciesForDesigner` should not trigger anything later if
   you do a regular build.

For no. 1 we can more appropriately write the `Inputs` and `Outputs` as:

    Inputs="$(MSBuildAllProjects);$(MonoPlatformJarPath);@(_JavaStubFiles);@(AndroidJavaSource)"
    Outputs="$(_AndroidStampDirectory)SetupDependenciesForDesigner.stamp"

This matches what we do for `_CompileJava`, and
`SetupDependenciesForDesigner` can manage its own stamp file.

For goal no. 2, however, we need an option for the `<Javac/>` MSBuild
task to *not* generate `classes.zip`. The designer does not use this
file, so we don't need to create it! We also don't want a regular
build later to see the timestamp on `classes.zip` change.

## Xamarin.ProjectTools ##

In trying to write some tests, I actually found a bug in
Xamarin.ProjectTools:

* Call `Touch()` on a file
* The timestamp on the `.csproj` is updated -- when it did not change

To account for this, I reworked the `XamarinProject` class to save a
copy of the `ProjectResource` instance between builds.

These changes allowed me to add the needed tests in `DesignerTests`.