### PR TITLE
[Xamarin.Android.Build.Task] Handle res-auto headerLayout

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/AndroidResourceTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/AndroidResourceTests.cs
@@ -14,6 +14,37 @@ namespace Xamarin.Android.Build.Tests {
 	[Parallelizable (ParallelScope.Self)]
 	public class AndroidResourceTests : BaseTest {
 		[Test]
+		public void HeaderLayout ()
+		{
+			var path = Path.Combine (Root, "temp", TestName);
+			Directory.CreateDirectory (path);
+			var layoutDir = Path.Combine (path, "res", "layout");
+			var menuDir = Path.Combine (path, "res", "menu");
+			Directory.CreateDirectory (layoutDir);
+			Directory.CreateDirectory (menuDir);
+			var main = Path.Combine (layoutDir, "main.xml");
+			File.WriteAllText (main, @"<?xml version=""1.0"" encoding=""utf-8""?>
+<LinearLayout xmlns:android=""http://schemas.android.com/apk/res/android""
+	xmlns:app=""http://schemas.android.com/apk/res-auto""
+	android:orientation = ""horizontal""
+	android:layout_width = ""match_parent""
+	android:layout_height = ""match_parent""
+	app:headerLayout=""@layout/headerLayout""
+	>
+</LinearLayout>");
+
+			var headerLayout = Path.Combine (layoutDir, "headerlayout.xml");
+			File.WriteAllText (headerLayout, @"<?xml version=""1.0"" encoding=""utf-8""?>
+<LinearLayout>
+</LinearLayout>
+");
+			Monodroid.AndroidResource.UpdateXmlResource (Path.Combine (path, "res"), main, new Dictionary<string, string> (), null);
+			var mainText = File.ReadAllText (main);
+			Assert.True (mainText.Contains ("@layout/headerlayout"), "'@layout/headerLayout' was not converted to '@layout/headerlayout'");
+			Directory.Delete (path, recursive: true);
+		}
+
+		[Test]
 		public void MenuActionLayout ()
 		{
 			var path = Path.Combine (Root, "temp", "MenuActionLayout");

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
@@ -201,10 +201,7 @@ namespace Monodroid {
 		{
 			if (attr.Name.Namespace != res_auto)
 				return false;
-			switch (attr.Name.LocalName) {
-			case "rectLayout":
-			case "roundLayout":
-			case "actionLayout":
+			if (attr.Name.LocalName.EndsWith ("Layout", StringComparison.Ordinal)) {
 				attr.Value = attr.Value.ToLowerInvariant ();
 				return true;
 			}


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/969915

Certain android resource items can make use of the following
namespace

	xmlns:app=""http://schemas.android.com/apk/res-auto""

this provides additional extension attributes which need
to be fixed up. Some examples are `actionLayout`, `rectLayout`
and `roundLayout`. The values for these attributes should
be lowercased as they refer to a `@layout` item.

It seems however that this list is always expanding. A new
item `headerLayout` seems to have appeared. Rather than handcoding
each of these items, the code here changes to check for `Layout`
in the attrbiute and will then lowercase the value. This should
protect us from future "additions", and help our customers since
they won't have to work around casing problems for attributes we
do not support.