### PR TITLE
[Jenkins] remove some duplicate test phases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,14 +171,14 @@ endif
 
 run-apk-tests:
 	_r=0 ; \
-	$(call MSBUILD_BINLOG,run-apk-tests,,Test) $(TEST_TARGETS) /t:RunApkTests /p:RunApkTestsTarget=RunPerformanceApkTests $(APK_TESTS_PROP) || _r=$$? ; \
-	$(call MSBUILD_BINLOG,run-apk-tests,,Test) $(TEST_TARGETS) /t:RunApkTests $(APK_TESTS_PROP) || _r = $$? ; \
+	$(call MSBUILD_BINLOG,run-apk-tests,,Test) $(TEST_TARGETS) /t:RunApkTests /p:RunApkTestsTarget=RunPerformanceApkTests $(APK_TESTS_PROP) || _r=1 ; \
+	$(call MSBUILD_BINLOG,run-apk-tests,,Test) $(TEST_TARGETS) /t:RunApkTests $(APK_TESTS_PROP) || _r=1 ; \
 	exit $$_r
 
 run-performance-tests:
 	_r=0 ; \
-	$(call MSBUILD_BINLOG,run-apk-tests,,Test) $(TEST_TARGETS) /t:RunApkTests /p:RunApkTestsTarget=RunPerformanceApkTests $(APK_TESTS_PROP) || _r=$$? ; \
-	$(call MSBUILD_BINLOG,run-performance-tests,,Test) $(TEST_TARGETS) /t:RunPerformanceTests || _r = $$? ; \
+	$(call MSBUILD_BINLOG,run-apk-tests,,Test) $(TEST_TARGETS) /t:RunApkTests /p:RunApkTestsTarget=RunPerformanceApkTests $(APK_TESTS_PROP) || _r=1 ; \
+	$(call MSBUILD_BINLOG,run-performance-tests,,Test) $(TEST_TARGETS) /t:RunPerformanceTests || _r=1 ; \
 	exit $$_r
 
 list-nunit-tests:

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,10 @@ run-apk-tests:
 	exit $$_r
 
 run-performance-tests:
-	$(call MSBUILD_BINLOG,run-performance-tests,,Test) $(TEST_TARGETS) /t:RunPerformanceTests
+	_r=0 ; \
+	$(call MSBUILD_BINLOG,run-apk-tests,,Test) $(TEST_TARGETS) /t:RunApkTests /p:RunApkTestsTarget=RunPerformanceApkTests $(APK_TESTS_PROP) || _r=$$? ; \
+	$(call MSBUILD_BINLOG,run-performance-tests,,Test) $(TEST_TARGETS) /t:RunPerformanceTests || _r = $$? ; \
+	exit $$_r
 
 list-nunit-tests:
 	$(MSBUILD) $(MSBUILD_FLAGS) $(TEST_TARGETS) /t:ListNUnitTests

--- a/build-tools/automation/build.groovy
+++ b/build-tools/automation/build.groovy
@@ -291,25 +291,17 @@ timestamps {
             }
         }
 
-        utils.stageWithTimeout('run all tests', 360, 'MINUTES', XADir, false) {   // Typically takes 6hr
+        utils.stageWithTimeout('run performance tests', 60, 'MINUTES', XADir, false) {
             if (skipTest) {
-                echo "Skipping 'run all tests' stage. Clear the SkipTest variable setting to build and run tests"
+                echo "Skipping 'run performance tests' stage. Clear the SkipTest variable setting to build and run tests"
                 return
             }
 
-            echo "running tests"
+            echo "running performance tests"
 
-            def skipNunitTests = false
-
-            if (isPr) {
-                def hasPrLabelRunTestsRelease = utils.hasPrLabel(gitRepo, env.ghprbPullId, 'run-tests-release')
-                skipNunitTests = hasPrLabelFullMonoIntegrationBuild || hasPrLabelRunTestsRelease
-                echo "Run all tests: Labels on the PR: 'full-mono-integration-build' (${hasPrLabelFullMonoIntegrationBuild}) and/or 'run-tests-release' (${hasPrLabelRunTestsRelease})"
-            }
-
-            commandStatus = sh (script: "make run-all-tests CONFIGURATION=${env.BuildFlavor} V=1" + (skipNunitTests ? " SKIP_NUNIT_TESTS=1" : ""), returnStatus: true)
+            commandStatus = sh (script: "make run-performance-tests CONFIGURATION=${env.BuildFlavor} V=1", returnStatus: true)
             if (commandStatus != 0) {
-                error "run-all-tests FAILED, status: ${commandStatus}"     // Ensure stage is labeled as 'failed' and red failure indicator is displayed in Jenkins pipeline steps view
+                error "run-performance-tests FAILED, status: ${commandStatus}"     // Ensure stage is labeled as 'failed' and red failure indicator is displayed in Jenkins pipeline steps view
             }
         }
 

--- a/tests/RunApkTests.targets
+++ b/tests/RunApkTests.targets
@@ -105,7 +105,7 @@
   </Target>
 
   <ItemGroup>
-    <_ApkPerfTests Include="Xamarin.Android.Locale_Tests;Xamarin.Forms_Performance_Integration">
+    <_ApkPerfTests Include="Mono.Android_Tests;Xamarin.Android.Locale_Tests;Xamarin.Forms_Performance_Integration">
       <Package>%(Identity)</Package>
     </_ApkPerfTests>
   </ItemGroup>


### PR DESCRIPTION
As we slowly migrate to Azure DevOps, there are some duplicate phases
we are running on Jenkins that mostly produce noise, such as:

* MSBuild Tests - we commonly get failures related to NuGet
* BCL Tests - enough said...
* Networking-related issues on APK-based tests

For now we could replace the call:

    make run-all-tests

To run a subset:

    make run-performance-tests

This will keep the existing plots we have working. OSS contributors
will still have access to builds, etc.