### PR TITLE
[Xamarin.Android.Build.Tasks] fully incremental linker for Debug builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
@@ -1,0 +1,98 @@
+using Java.Interop.Tools.Cecil;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using System;
+using System.IO;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// This task is for Debug builds where LinkMode=None, LinkAssemblies is for Release builds
+	/// </summary>
+	public class LinkAssembliesNoShrink : Task
+	{
+		/// <summary>
+		/// These are used so we have the full list of SearchDirectories
+		/// </summary>
+		[Required]
+		public ITaskItem [] ResolvedAssemblies { get; set; }
+
+		[Required]
+		public ITaskItem [] SourceFiles { get; set; }
+
+		[Required]
+		public ITaskItem [] DestinationFiles { get; set; }
+
+		public override bool Execute ()
+		{
+			if (SourceFiles.Length != DestinationFiles.Length)
+				throw new ArgumentException ("source and destination count mismatch");
+
+			var readerParameters = new ReaderParameters {
+				ReadSymbols = true,
+			};
+			var writerParameters = new WriterParameters {
+				DeterministicMvid = true,
+			};
+
+			using (var resolver = new DirectoryAssemblyResolver (this.CreateTaskLogger (), loadDebugSymbols: true, loadReaderParameters: readerParameters)) {
+				// Add SearchDirectories with ResolvedAssemblies
+				foreach (var assembly in ResolvedAssemblies) {
+					var path = Path.GetFullPath (Path.GetDirectoryName (assembly.ItemSpec));
+					if (!resolver.SearchDirectories.Contains (path))
+						resolver.SearchDirectories.Add (path);
+				}
+
+				// Run the FixAbstractMethodsStep
+				var step = new FixAbstractMethodsStep (resolver, Log);
+				for (int i = 0; i < SourceFiles.Length; i++) {
+					var source = SourceFiles [i];
+					var destination = DestinationFiles [i];
+
+					// Only run the step on "MonoAndroid" assemblies
+					if (MonoAndroidHelper.IsMonoAndroidAssembly (source) && !MonoAndroidHelper.IsSharedRuntimeAssembly (source.ItemSpec)) {
+						var assemblyDefinition = resolver.GetAssembly (source.ItemSpec);
+						if (step.FixAbstractMethods (assemblyDefinition)) {
+							Log.LogDebugMessage ($"Saving modified assembly: {destination.ItemSpec}");
+							writerParameters.WriteSymbols = assemblyDefinition.MainModule.HasSymbols;
+							assemblyDefinition.Write (destination.ItemSpec, writerParameters);
+							continue;
+						}
+					}
+
+					if (MonoAndroidHelper.CopyAssemblyAndSymbols (source.ItemSpec, destination.ItemSpec)) {
+						Log.LogDebugMessage ($"Copied: {destination.ItemSpec}");
+					} else {
+						Log.LogDebugMessage ($"Skipped unchanged file: {destination.ItemSpec}");
+					}
+				}
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+
+		class FixAbstractMethodsStep : MonoDroid.Tuner.FixAbstractMethodsStep
+		{
+			readonly DirectoryAssemblyResolver resolver;
+			readonly TaskLoggingHelper logger;
+
+			public FixAbstractMethodsStep (DirectoryAssemblyResolver resolver, TaskLoggingHelper logger)
+			{
+				this.resolver = resolver;
+				this.logger = logger;
+			}
+
+			protected override AssemblyDefinition GetMonoAndroidAssembly ()
+			{
+				return resolver.GetAssembly ("Mono.Android.dll");
+			}
+
+			public override void LogMessage (string message, params object [] values)
+			{
+				logger.LogDebugMessage (message, values);
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1247,14 +1247,10 @@ namespace App1
 					var intermediate = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath);
 					var outputPath = Path.Combine (Root, b.ProjectDirectory, proj.OutputPath);
 					var assetsPdb = Path.Combine (intermediate, "android", "assets", "Library1.pdb");
-					var linkDst = Path.Combine (intermediate, "linkdst", "Library1.pdb");
 					var binSrc = Path.Combine (outputPath, "Library1.pdb");
 					Assert.IsTrue (
 						File.Exists (assetsPdb),
 						"Library1.pdb must be copied to Intermediate directory");
-					Assert.IsFalse (
-						File.Exists (linkDst),
-						"Library1.pdb should not be copied to linkdst directory because it has no Abstrsact methods to fix up.");
 					Assert.IsTrue (
 						File.Exists (binSrc),
 						"Library1.pdb must be copied to bin directory");
@@ -1265,18 +1261,15 @@ namespace App1
 						var filedata = File.ReadAllBytes (binSrc);
 						Assert.AreEqual (filedata.Length, data.Length, "Library1.pdb in the apk should match {0}", binSrc);
 					}
-					linkDst = Path.Combine (intermediate, "linkdst", "App1.pdb");
+					var androidAssets = Path.Combine (intermediate, "android", "assets", "App1.pdb");
 					binSrc = Path.Combine (outputPath, "App1.pdb");
-					Assert.IsTrue (
-						File.Exists (linkDst),
-						"App1.pdb should be copied to linkdst directory because it has Abstrsact methods to fix up.");
 					Assert.IsTrue (
 						File.Exists (binSrc),
 						"App1.pdb must be copied to bin directory");
-					FileAssert.AreEqual (binSrc, linkDst, "{0} and {1} should not differ.", binSrc, linkDst);
-					linkDst = Path.Combine (intermediate, "linkdst", "App1.dll");
+					FileAssert.AreEqual (binSrc, androidAssets, "{0} and {1} should not differ.", binSrc, androidAssets);
+					androidAssets = Path.Combine (intermediate, "android", "assets", "App1.dll");
 					binSrc = Path.Combine (outputPath, "App1.dll");
-					FileAssert.AreEqual (binSrc, linkDst, "{0} and {1} should match.", binSrc, linkDst);
+					FileAssert.AreEqual (binSrc, androidAssets, "{0} and {1} should match.", binSrc, androidAssets);
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -508,6 +508,13 @@ namespace Lib2
 					Assert.IsTrue (appBuilder.Output.IsTargetSkipped (target), $"`{target}` should be skipped!");
 				}
 
+				var targetsShouldPartiallyRun = new [] {
+					"_LinkAssembliesNoShrink",
+				};
+				foreach (var target in targetsShouldPartiallyRun) {
+					Assert.IsTrue (appBuilder.Output.IsTargetPartiallyBuilt (target), $"`{target}` should *partially* run!");
+				}
+
 				var targetsShouldRun = new [] {
 					"_BuildApkEmbed",
 					"_CopyPackage",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
@@ -61,6 +61,19 @@ namespace Xamarin.ProjectTools
 			return false;
 		}
 
+		/// <summary>
+		/// Looks for: Building target "Foo" partially, because some output files are out of date with respect to their input files.
+		/// </summary>
+		public bool IsTargetPartiallyBuilt (string target)
+		{
+			foreach (var line in Builder.LastBuildOutput) {
+				if (line.Contains ($"Building target \"{target}\" partially")) {
+					return true;
+				}
+			}
+			return false;
+		}
+
 		public bool IsApkInstalled {
 			get {
 				foreach (var line in Builder.LastBuildOutput) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -288,6 +288,16 @@ namespace Xamarin.Android.Tasks
 		}
 #endif
 
+		public static bool IsMonoAndroidAssembly (ITaskItem assembly)
+		{
+			var tfi = assembly.GetMetadata ("TargetFrameworkIdentifier");
+			if (string.Compare (tfi, "MonoAndroid", StringComparison.OrdinalIgnoreCase) == 0)
+				return true;
+
+			var hasReference = assembly.GetMetadata ("HasMonoAndroidReference");
+			return bool.TryParse (hasReference, out bool value) && value;
+		}
+
 		public static bool IsFrameworkAssembly (string assembly)
 		{
 			return IsFrameworkAssembly (assembly, false);
@@ -295,11 +305,9 @@ namespace Xamarin.Android.Tasks
 
 		public static bool IsFrameworkAssembly (string assembly, bool checkSdkPath)
 		{
-			var assemblyName = Path.GetFileName (assembly);
-
-			if (Profile.SharedRuntimeAssemblies.Contains (assemblyName, StringComparer.InvariantCultureIgnoreCase)) {
+			if (IsSharedRuntimeAssembly (assembly)) {
 #if MSBUILD
-				bool treatAsUser = Array.BinarySearch (FrameworkAssembliesToTreatAsUserAssemblies, assemblyName, StringComparer.OrdinalIgnoreCase) >= 0;
+				bool treatAsUser = Array.BinarySearch (FrameworkAssembliesToTreatAsUserAssemblies, Path.GetFileName (assembly), StringComparer.OrdinalIgnoreCase) >= 0;
 				// Framework assemblies don't come from outside the SDK Path;
 				// user assemblies do
 				if (checkSdkPath && treatAsUser && TargetFrameworkDirectories != null) {
@@ -309,6 +317,11 @@ namespace Xamarin.Android.Tasks
 				return true;
 			}
 			return TargetFrameworkDirectories == null || !checkSdkPath ? false : ExistsInFrameworkPath (assembly);
+		}
+
+		public static bool IsSharedRuntimeAssembly (string assembly)
+		{
+			return Array.BinarySearch (Profile.SharedRuntimeAssemblies, Path.GetFileName (assembly), StringComparer.OrdinalIgnoreCase) >= 0;
 		}
 
 		public static bool IsReferenceAssembly (string assembly)
@@ -374,6 +387,22 @@ namespace Xamarin.Android.Tasks
 			foreach (var file in Directory.EnumerateFiles (directory, "*", SearchOption.AllDirectories)) {
 				SetWriteable (Path.GetFullPath (file));
 			}
+		}
+
+		public static bool CopyAssemblyAndSymbols (string source, string destination)
+		{
+			bool changed = CopyIfChanged (source, destination);
+			var mdb = source + ".mdb";
+			if (File.Exists (mdb)) {
+				var mdbDestination = destination + ".mdb";
+				CopyIfChanged (mdb, mdbDestination);
+			}
+			var pdb = Path.ChangeExtension (source, "pdb");
+			if (File.Exists (pdb) && Files.IsPortablePdb (pdb)) {
+				var pdbDestination = Path.ChangeExtension (destination, "pdb");
+				CopyIfChanged (pdb, pdbDestination);
+			}
+			return changed;
 		}
 
 		public static bool CopyIfChanged (string source, string destination)

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -159,6 +159,7 @@
     <Compile Include="Tasks\JarToXml.cs" />
     <Compile Include="Tasks\GetJavaPlatformJar.cs" />
     <Compile Include="Tasks\GetFilesThatExist.cs" />
+    <Compile Include="Tasks\LinkAssembliesNoShrink.cs" />
     <Compile Include="Tasks\ReadAndroidManifest.cs" />
     <Compile Include="Tasks\RemoveRegisterAttribute.cs" />
     <Compile Include="Tasks\GetMonoPlatformJar.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -85,6 +85,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.R8" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.KeyTool" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.LinkAssemblies" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.LinkAssembliesNoShrink" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.Lint" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.LogErrorsForFiles" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.LogWarningsForFiles" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -1195,7 +1196,6 @@ because xbuild doesn't support framework reference assemblies.
 	<MonoAndroidIntermediateAssetsDir>$(IntermediateOutputPath)android\assets\</MonoAndroidIntermediateAssetsDir>
 	<MonoAndroidIntermediateAssemblyDir>$(IntermediateOutputPath)android\assets\</MonoAndroidIntermediateAssemblyDir>
 	<_JniMarshalMethodsOutputDir>$(IntermediateOutputPath)jnisrc\</_JniMarshalMethodsOutputDir>
-	<MonoAndroidIntermediateAssemblyTempDir>$(IntermediateOutputPath)linkdst\</MonoAndroidIntermediateAssemblyTempDir>
 	<MonoAndroidResourcePrefix Condition="'$(MonoAndroidResourcePrefix)' == ''">Resources</MonoAndroidResourcePrefix>
 	<MonoAndroidIntermediate>$(IntermediateOutputPath)</MonoAndroidIntermediate>
 	<MonoAndroidCodeBehindDir>$(MonoAndroidIntermediate)generated</MonoAndroidCodeBehindDir>
@@ -2025,29 +2025,26 @@ because xbuild doesn't support framework reference assemblies.
   </ItemGroup>
 </Target>
 
+<Target Name="_LinkAssembliesNoShrinkInputs">
+  <ItemGroup>
+    <!-- We need this in its own item group so it isn't lost during a partial build -->
+    <_AllResolvedAssemblies Include="@(ResolvedAssemblies)" />
+  </ItemGroup>
+</Target>
+
 <Target Name="_LinkAssembliesNoShrink"
-  Condition="'$(AndroidLinkMode)' == 'None'"
-  Inputs="@(ResolvedUserAssemblies);$(_AndroidBuildPropertiesCache)"
-  Outputs="$(_AndroidLinkFlag)">
-
-    <LinkAssemblies
-      UseSharedRuntime="$(AndroidUseSharedRuntime)"
-      MainAssembly="$(MonoAndroidIntermediateAssemblyDir)$(TargetFileName)"
-      OutputDirectory="$(MonoAndroidIntermediateAssemblyTempDir)"
-      OptionalDestinationDirectory="$(MonoAndroidIntermediateAssemblyDir)"
-      I18nAssemblies="$(MandroidI18n)"
-      LinkMode="$(AndroidLinkMode)"
-      LinkDescriptions="@(LinkDescription)"
-      DumpDependencies="$(LinkerDumpDependencies)"
-      LinkOnlyNewerThan="$(_AndroidLinkFlag)"
-      ResolvedAssemblies="@(ResolvedAssemblies)" />
-
-    <!-- We have to use a flag instead of normal outputs because linking can delete unused assemblies -->
-    <Touch Files="$(_AndroidLinkFlag)" AlwaysCreate="true" />
-    <ItemGroup>
-      <FileWrites Include="$(_AndroidLinkFlag)" />
-      <FileWrites Include="$(MonoAndroidIntermediateAssemblyDir)*" />
-    </ItemGroup>
+    DependsOnTargets="_LinkAssembliesNoShrinkInputs"
+    Condition="'$(AndroidLinkMode)' == 'None'"
+    Inputs="@(ResolvedAssemblies);$(_AndroidBuildPropertiesCache)"
+    Outputs="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')">
+  <LinkAssembliesNoShrink
+      ResolvedAssemblies="@(_AllResolvedAssemblies)"
+      SourceFiles="@(ResolvedAssemblies)"
+      DestinationFiles="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')"
+  />
+  <ItemGroup>
+    <FileWrites Include="$(MonoAndroidIntermediateAssemblyDir)*" />
+  </ItemGroup>
 </Target>
 	
 <Target Name="_LinkAssembliesShrink"
@@ -3359,7 +3356,6 @@ because xbuild doesn't support framework reference assemblies.
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)android" Condition="Exists ('$(MonoAndroidIntermediate)android')" />
 	<!-- FIXME: remove this extraneous rmdir after a few release cycles since we release the one we killed it. -->
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)assemblies" Condition="Exists ('$(MonoAndroidIntermediate)assemblies')" />
-	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)linkdst" Condition="Exists ('$(MonoAndroidIntermediate)linkdst')" />
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)res" Condition="Exists ('$(MonoAndroidIntermediate)res')" />
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)aidl" Condition="Exists ('$(MonoAndroidIntermediate)aidl')" />
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediate)bundles" Condition="Exists ('$(MonoAndroidIntermediate)bundles')" />


### PR DESCRIPTION
If I time an incremental build of a "Hello World" Xamarin.Forms app,
one of the last remaining areas to improve is:

    340 ms  LinkAssemblies                             1 calls

In this build, I made a one-line change in a XAML file in a
NetStandard project with the optimal settings such as
`$(ProduceReferenceAssembly)`.

On a slower PC I have with Windows defender enabled, this step can
take even longer:

    767 ms  LinkAssemblies                             1 calls

Part of the reason for the time taken is the linker needs to load
*every* assembly, even if not every assembly is actually changed or
saved.

A `Debug` build (or `$(AndroidLinkMode)` = `None`) only needs to run a
single linker step:

    var pipeline = new Pipeline ();
    if (options.LinkNone) {
        pipeline.AppendStep (new FixAbstractMethodsStep ());
        pipeline.AppendStep (new OutputStepWithTimestamps ());
        return pipeline;
    }

`FixAbstractMethodsStep` also only applies to "Xamarin.Android"
assemblies which would reference `Mono.Android.dll`. The
`OutputStepWithTimestamps` step is also responsible for getting all
assemblies to their final destination in
`$(IntermediateOutputPath)android\assets\`.

In an ideal world, in an incremental build:

* A `Foo.dll` NetStandard assembly changes
    * We know it is *not* a "Xamarin.Android" assembly
* The linker step loads 0 assemblies
    * We merely copy `Foo.dll` to `android\assets\`

We can achieve this with a new `<LinkAssembliesNoShrink/>` MSBuild
task that doesn't use the normal code path for the full linker. We can
split out `FixAbstractMethodsStep` so we can call it on a per-assembly
basis as needed.

## Partial Builds ##

To achieve our ideal scenario, we need to leverage a feature of
MSBuild that enables an MSBuild target to build *partially*:

    Building target "Foo" partially, because some output files are out of date with respect to their input files.

For example, we had a target such as:

    <Target Name="_GenerateDocumentation"
        Inputs="@(_JavaFiles)"
        Outputs="@(_JavaFiles->'$(DocsDirectory)%(Filename).md')">
      <GenerateDocumentation
          SourceFiles="@(_JavaFiles)"
          DestinationFiles="@(_JavaFiles->'$(DocsDirectory)%(Filename).md')"
      />
    </Target>

MSBuild can compare the `Inputs` and `Outputs` and only pass in the
`@(_JavaFiles)` that have changed to `<GenerateDocumentation/>`.

The trick, is that `<LinkAssembliesNoShrink/>` needs to process a
subset of the assemblies that changed, while still *knowing* the full
list of assemblies. An assembly could change that references another
assembly that Mono.Cecil needs to be able to load.

So we can record an `@(_AllResolvedAssemblies)` item group such as:

    <Target Name="_LinkAssembliesNoShrinkInputs">
      <ItemGroup>
        <_AllResolvedAssemblies Include="@(ResolvedAssemblies)" />
      </ItemGroup>
    </Target>

    <Target Name="_LinkAssembliesNoShrink"
        DependsOnTargets="_LinkAssembliesNoShrinkInputs"
        Inputs="@(ResolvedAssemblies);$(_AndroidBuildPropertiesCache)"
        Outputs="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')">
      <LinkAssembliesNoShrink
          ResolvedAssemblies="@(_AllResolvedAssemblies)"
          SourceFiles="@(ResolvedAssemblies)"
          DestinationFiles="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')"
      />
    ...
    </Target>

This way `SourceFiles` and `DestinationFiles` files have a subset of
assemblies, while `ResolvedAssemblies` can still have a known list of
all assemblies.

## Results ##

Incremental builds are improved dramatically for a one-line XAML
change:

    Before:
    340 ms  LinkAssemblies                             1 calls
    After:
      9 ms  LinkAssembliesNoShrink                     1 calls

The only I/O operation is a `MonoAndroidHelper.CopyIfChanged` on a
single assembly.

## Other Refactoring ##

Since `<LinkAssemblies/>` is no longer used for `Debug` builds, we can
remove a few options that are not currently used for `Release` builds:

* `OptionalDestinationDirectory`
* `LinkOnlyNewerThan`