### PR TITLE
Add notarization to the Xamarin Android pipeline (#3536)

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -92,7 +92,9 @@ stages:
     workspace:
       clean: all
     variables:
-      JAVA_HOME: /Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home/
+    - group: Xamarin Notarization
+    - name: JAVA_HOME
+      value: '/Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home/'
     steps:
     - checkout: self
       submodules: recursive
@@ -170,6 +172,14 @@ stages:
     - template: productsign-pkg.yml@yaml
       parameters:
         UnsignedPkgPath: $(XA.Unsigned.Pkg)
+    
+    - script: |
+        cd $(Build.SourcesDirectory)/..
+        git clone -b $(ReleaseScriptsBranch) https://$(GitHub.Token):x-oauth-basic@github.com/xamarin/release-scripts
+        cd release-scripts
+        ruby notarize.rb $(XA.Unsigned.Pkg) $(XamarinIdentifier) $(XamarinUserId) $(XamarinPassword) $(TeamID)
+      displayName: Notarize PKG
+      condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
 
     - task: PublishPipelineArtifact@0
       displayName: upload installers


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/cca5b65c338c8685e0c52070f2cf5f89e337515a
Context: https://developer.apple.com/documentation/security/notarizing_your_app_before_distribution/customizing_the_notarization_workflow#3087734

Starting in macOS Catalina, our `.pkg` files will need to Notarized
to ensure that a Gatekeeper dialog is not displayed by the installer.

Our `.pkg` files are able to be Notarized as of commit cca5b65, so we
can now add a step for Notarization and Stapling to our non PR builds.