### PR TITLE
[ci] Remove monodroid provisionator script

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -94,7 +94,7 @@ stages:
     variables:
     - group: Xamarin Notarization
     - name: JAVA_HOME
-      value: '/Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home/'
+      value: '/Users/vsts/Library/Android/jdk/'
     steps:
     - checkout: self
       submodules: recursive
@@ -117,14 +117,6 @@ stages:
       condition: eq(variables['XA.Commercial.Build'], 'true')
       env:
         GH_AUTH_SECRET: $(Github.Token)
-
-    - task: provisionator@2
-      condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
-      inputs:
-        provisionator_uri: $(provisionator-uri)
-        github_token: $(GitHub.Token)
-        provisioning_script: $(System.DefaultWorkingDirectory)/external/monodroid/build-tools/provisionator/profile.csx
-        provisioning_extra_args: -vv
 
     - script: make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1 PREPARE_ARGS="--bundle-path=$(System.DefaultWorkingDirectory)"
       displayName: make jenkins

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/OS.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/OS.cs
@@ -49,21 +49,21 @@ namespace Xamarin.Android.Prepare
 		/// <summary>
 		///   Path to <c>javac</c> (full or relative)
 		/// </summary>
-		public string JavaCPath      { get; set; } = "javac";
+		public string JavaCPath      { get; set; }
 
 		/// <summary>
 		///   Path to <c>jar</c> (full or relative)
 		/// </summary>
-		public string JarPath        { get; set; } = "jar";
+		public string JarPath        { get; set; }
 
 		/// <summary>
 		///   Path to <c>java</c> (full or relative)
 		/// </summary>
-		public string JavaPath       { get; set; } = "java";
+		public string JavaPath       { get; set; }
 
 		/// <summary>
-		///   Full path to Java home, defaults to contents of the <c>JAVA_HOME</c> environment variable or an empty
-		///   string if the variable isn't present.
+		///   Full path to Java home, set via the <c>$(JavaSdkDirectory)</c> MSBuild property or defaults to
+		///   <c>$(AndroidToolchainDirectory)/jdk</c>.
 		/// </summary>
 		public string JavaHome       { get; set; }
 
@@ -184,7 +184,21 @@ namespace Xamarin.Android.Prepare
 		///   Initialize base OS support properties, variables etc. Implementation should perform as little detection of
 		///   programs etc as possible
 		/// </summary>
-		protected abstract bool InitOS ();
+		protected virtual bool InitOS ()
+		{
+			JavaHome = Context.Instance.Properties.GetValue (KnownProperties.JavaSdkDirectory)?.Trim ();
+			if (String.IsNullOrEmpty (JavaHome)) {
+				var androidToolchainDirectory = Context.Instance.Properties.GetValue (KnownProperties.AndroidToolchainDirectory)?.Trim ();
+				JavaHome = Path.Combine (androidToolchainDirectory, "jdk");
+			}
+
+			string extension = IsWindows ? ".exe" : string.Empty;
+			JavaCPath = Path.Combine (JavaHome, "bin", $"javac{extension}");
+			JavaPath = Path.Combine (JavaHome, "bin", $"java{extension}");
+			JarPath = Path.Combine (JavaHome, "bin", $"jar{extension}");
+
+			return true;
+		}
 
 		/// <summary>
 		///   Initialize <see cref="Dependencies"/> for the host OS

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/Unix.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/Unix.cs
@@ -20,15 +20,6 @@ namespace Xamarin.Android.Prepare
 			Architecture = Utilities.GetStringFromStdout ("uname", "-m")?.Trim ();
 		}
 
-		protected override bool InitOS ()
-		{
-			JavaHome = Context.Instance.Properties.GetValue (KnownProperties.JavaSdkDirectory);
-			if (String.IsNullOrEmpty (JavaHome))
-				JavaHome = Environment.GetEnvironmentVariable ("JAVA_HOME") ?? String.Empty;
-
-			return true;
-		}
-
 		protected override void DetectCompilers ()
 		{
 			string ccVersion = Utilities.GetStringFromStdout (Configurables.Defaults.DefaultCompiler, "--version");

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/Windows.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/Windows.cs
@@ -87,15 +87,8 @@ namespace Xamarin.Android.Prepare
 
 		protected override bool InitOS ()
 		{
+			base.InitOS ();
 			Log.Todo ("gather dependencies here");
-
-			JavaHome = Context.Instance.Properties.GetValue ("JavaSdkDirectory")?.Trim ();
-			if (String.IsNullOrEmpty (JavaHome))
-				JavaHome  = Path.Combine (HomeDirectory, "android-toolchain", "jdk");
-
-			JavaCPath = Path.Combine (JavaHome, "bin", "javac.exe");
-			JavaPath  = Path.Combine (JavaHome, "bin", "java.exe");
-			JarPath   = Path.Combine (JavaHome, "bin", "jar.exe");
 
 			// This is required by Android SDK which uses a utility to locate Java on Windows
 			// ($SDK_ROOT/tools/lib/find_java.bat) and that utility, in turn, looks at JAVA_HOME

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
@@ -69,10 +69,6 @@ namespace Xamarin.Android.Prepare
 		{
 			const string OutputFileName = "Configuration.OperatingSystem.props";
 
-			string javaSdkDirectory = context.Properties.GetValue ("JavaSdkDirectory");
-			if (String.IsNullOrEmpty (javaSdkDirectory))
-				javaSdkDirectory = context.OS.JavaHome;
-
 			var replacements = new Dictionary<string, string> (StringComparer.Ordinal) {
 				{ "@OS_NAME@",              context.OS.Name ?? String.Empty },
 				{ "@HOST_OS_FLAVOR@",       context.OS.Flavor ?? String.Empty },
@@ -89,7 +85,7 @@ namespace Xamarin.Android.Prepare
 				{ "@HOST_CXX32@",           context.OS.CXX32 ?? String.Empty },
 				{ "@HOST_CXX64@",           context.OS.CXX64 ?? String.Empty },
 				{ "@HOST_HOMEBREW_PREFIX@", context.OS.HomebrewPrefix ?? String.Empty },
-				{ "@JavaSdkDirectory@",     javaSdkDirectory ?? String.Empty },
+				{ "@JavaSdkDirectory@",     context.OS.JavaHome },
 				{ "@javac@",                context.OS.JavaCPath },
 				{ "@java@",                 context.OS.JavaPath },
 				{ "@jar@",                  context.OS.JarPath },


### PR DESCRIPTION
We currently use the monodroid "provisionator" script to install the
JDK and select a specific version of Xcode.

However, we should no longer need to invoke the provisionator script,
as we're already installing the Corretto JDK and other dependencies
as part of `xaprepare`.  Furthermore, we should no longer have a
dependency on Xcode 9.2, so the default macOS compiler toolchain works.

As of commit 08e0ccb4 `$(AndroidToolchainDirectory)` is set to
`$(HOME)/Library/Android` when executing on macOS Azure Pipelines
hosts, and the JDK is installed into `$HOME/Library/Android/jdk`.

Export `$JAVA_HOME` on the macOS DevOps build so that it references
the JDK that `xaprepare` installs.

Additionally, instead of relying on `$JAVA_HOME` or ib JDK tools
existing in `$PATH` on macOS, use the value of `$(JavaSdkDirectory)`
to provide full paths to JDK tools.  If `$(JavaSdkDirectory)` is not
set, we set it to `$(AndroidToolchainDirectory)/jdk` which contains
the JDK we install.