### PR TITLE
[ci] Fix vsix sign job and other conditions

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -117,7 +117,7 @@ stages:
 
     - script: make prepare-external-git-dependencies PREPARE_CI=1 CONFIGURATION=$(XA.Build.Configuration)
       displayName: make prepare-external-git-dependencies
-      condition: eq(variables['XA.Commercial.Build'], 'true')
+      condition: eq(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
       env:
         GH_AUTH_SECRET: $(Github.Token)
 
@@ -174,7 +174,7 @@ stages:
         cd release-scripts
         ruby notarize.rb $(XA.Unsigned.Pkg) $(XamarinIdentifier) $(XamarinUserId) $(XamarinPassword) $(TeamID)
       displayName: Notarize PKG
-      condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
+      condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
 
     - task: PublishPipelineArtifact@0
       displayName: upload installers
@@ -187,7 +187,7 @@ stages:
         BuildPackages: bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
         AzureContainerName: $(Azure.Container.Name)
         AzureUploadLocation: $(Build.DefinitionName)/$(Build.BuildId)/$(Build.SourceBranchName)/$(Build.SourceVersion)
-        condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
+        condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
 
     - template: yaml-templates/upload-results.yaml
       parameters:
@@ -199,7 +199,7 @@ stages:
     displayName: Queue Vsix Signing
     dependsOn: mac_build_create_installers
     pool: $(XA.Build.Win.Pool)
-    condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
+    condition: and(eq(dependencies.mac_build_create_installers.result, 'Succeeded'), eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
     timeoutInMinutes: 45
     cancelTimeoutInMinutes: 1
     workspace:


### PR DESCRIPTION
Context: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops#dependencies

We shouldn't run the vsix sign job if any failures occurred in the build
before it. We also shouldn't run notarization and upload to storage steps
if any failures occur in our build.