### PR TITLE
[linker] Simplify java ifaces detection

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Extensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Extensions.cs
@@ -16,6 +16,7 @@ namespace MonoDroid.Tuner {
 
 		const string JavaObject = "Java.Lang.Object";
 		const string IJavaObject = "Android.Runtime.IJavaObject";
+		const string IJavaPeerable = "Java.Interop.IJavaPeerable";
 		const string JavaThrowable = "Java.Lang.Throwable";
 
 		public static bool IsJavaObject (this TypeDefinition type)
@@ -31,6 +32,11 @@ namespace MonoDroid.Tuner {
 		public static bool ImplementsIJavaObject (this TypeDefinition type)
 		{
 			return type.Implements (IJavaObject);
+		}
+
+		public static bool ImplementsIJavaPeerable (this TypeDefinition type)
+		{
+			return type.Implements (IJavaPeerable);
 		}
 
 		public static object GetSettableValue (this CustomAttributeArgument arg)
@@ -136,25 +142,6 @@ namespace MonoDroid.Tuner {
 			}
 
 			return false;
-		}
-
-		public static bool TryGetRegisterAdapter (this TypeDefinition td, out string adapter)
-		{
-		       CustomAttribute register;
-		       adapter = null;
-
-		       if (!TryGetRegisterAttribute (td, out register))
-			       return false;
-
-		       if (register.ConstructorArguments.Count != 3)
-			       return false;
-
-		       adapter = (string) register.ConstructorArguments [2].Value;
-
-		       if (string.IsNullOrEmpty (adapter))
-			       return false;
-
-		       return true;
 		}
 
 		public static bool TryGetRegisterMember (this MethodDefinition md, out string method)

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MonoDroidMarkStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MonoDroidMarkStep.cs
@@ -441,7 +441,7 @@ namespace MonoDroid.Tuner
 			if (base.ShouldMarkInterfaceImplementation (type, iface, resolvedInterfaceType))
 				return true;
 
-			return resolvedInterfaceType.TryGetRegisterAdapter (out _);
+			return resolvedInterfaceType.ImplementsIJavaObject () || resolvedInterfaceType.ImplementsIJavaPeerable ();
 		}
 
 		protected override void DoAdditionalTypeProcessing (TypeDefinition type)


### PR DESCRIPTION
Check whether the interface type is based on `IJavaObject` or
`IJavaPeerable` when deciding if the iface should be marked without
further linker analysis.

@jonp suggested that idea during review of
https://github.com/xamarin/xamarin-android/pull/3525

I have tried the change with Topeka sample to make sure we don't break
the java ifaces linking again. The size stays the same. The set of
interfaces for which we return *true* in
`ShouldMarkInterfaceImplementation` is the same with the exception of
`IJavaObject` and `IJavaPeerable`. These would be preserved anyway.