### PR TITLE
[tests] add checks if long paths supported

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -226,9 +226,7 @@ stages:
   jobs:
   - job: win_build_test
     displayName: Build and Test
-    pool: 
-      name: $(XA.Build.Win.Pool)
-      demands: Agent.Name -equals DDMBLDW137
+    pool: $(XA.Build.Win.Pool)
     timeoutInMinutes: 360
     cancelTimeoutInMinutes: 5
     workspace:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -226,7 +226,9 @@ stages:
   jobs:
   - job: win_build_test
     displayName: Build and Test
-    pool: $(XA.Build.Win.Pool)
+    pool: 
+      name: $(XA.Build.Win.Pool)
+      demands: Agent.Name -equals DDMBLDW137
     timeoutInMinutes: 360
     cancelTimeoutInMinutes: 5
     workspace:

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MaxPathTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MaxPathTests.cs
@@ -15,8 +15,8 @@ namespace Xamarin.Android.Build.Tests
 		[SetUp]
 		public void Setup ()
 		{
-			if (!IsWindows) {
-				Assert.Ignore ("MAX_PATH only applies on Windows");
+			if (LongPathsSupported) {
+				Assert.Ignore ("This environment supports long paths");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/RemoveDirTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/RemoveDirTests.cs
@@ -76,10 +76,10 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void LongPath ()
 		{
-			if (!IsWindows) {
-				Assert.Ignore ("MAX_PATH only applies on Windows");
+			if (LongPathsSupported) {
+				Assert.Ignore ("This environment supports long paths");
 			}
-			var file = NewFile (fileName: "foo".PadRight (250, 'N'));
+			var file = NewFile (fileName: "foo".PadRight (MaxFileName, 'N'));
 			var task = CreateTask ();
 			Assert.IsTrue (task.Execute (), "task.Execute() should have succeeded.");
 			Assert.AreEqual (1, task.RemovedDirectories.Length, "Changes should have been made.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -164,6 +164,32 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
+		/// <summary>
+		/// Windows can only create a file of 255 characters: This type of path is composed of components separated by backslashes, each up to the value returned in the lpMaximumComponentLength parameter of the GetVolumeInformation function (this value is commonly 255 characters).
+		/// See: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#maximum-path-length-limitation
+		/// </summary>
+		public const int MaxFileName = 255;
+
+		static Lazy<bool> longPaths = new Lazy<bool> (() => {
+			if (!TestEnvironment.IsWindows) {
+				return true;
+			}
+			var path = Path.Combine (Path.GetTempPath (), "foo".PadRight (MaxFileName, 'N'));
+			try {
+				File.WriteAllText (path, "");
+				return true;
+			} catch {
+				return false;
+			} finally {
+				// If the file exists, we should be able to delete it
+				if (File.Exists (path)) {
+					File.Delete (path);
+				}
+			}
+		});
+
+		public static bool LongPathsSupported => longPaths.Value;
+
 		protected static void WaitFor(int milliseconds)
 		{
 			var pause = new ManualResetEvent(false);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/FilesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/FilesTests.cs
@@ -85,7 +85,7 @@ namespace Xamarin.Android.Build.Tests
 		public void CopyIfChanged_LongPath ()
 		{
 			var src = NewFile (contents: "foo");
-			var dest = NewFile (contents: "bar", fileName: "bar".PadRight (250, 'N'));
+			var dest = NewFile (contents: "bar", fileName: "bar".PadRight (MaxFileName, 'N'));
 			dest = Files.ToLongPath (dest);
 			Assert.IsTrue (Files.CopyIfChanged (src, dest), "Changes should have occurred");
 			FileAssert.AreEqual (src, dest);
@@ -142,7 +142,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void CopyIfStringChanged_LongPath ()
 		{
-			var dest = NewFile (fileName: "bar".PadRight (250, 'N'));
+			var dest = NewFile (fileName: "bar".PadRight (MaxFileName, 'N'));
 			dest = Files.ToLongPath (dest);
 			Assert.IsTrue (Files.CopyIfStringChanged ("foo", dest), "Changes should have occurred");
 			FileAssert.Exists (dest);
@@ -192,7 +192,7 @@ namespace Xamarin.Android.Build.Tests
 		public void CopyIfStreamChanged_LongPath ()
 		{
 			using (var src = NewStream ("foo")) {
-				var dest = NewFile (fileName: "bar".PadRight (250, 'N'));
+				var dest = NewFile (fileName: "bar".PadRight (MaxFileName, 'N'));
 				dest = Files.ToLongPath (dest);
 				Assert.IsTrue (Files.CopyIfStreamChanged (src, dest), "Changes should have occurred");
 				FileAssert.Exists (dest);


### PR DESCRIPTION
Context: http://build.azdo.io/2971289

Our `MaxPathTests` seem to be failing on a specific build machine:
`DDMBLDW137`. I suspect this machine has long paths enabled.

I added a check that attempts to write a long path, and if it succeeds
we can `Assert.Ignore` these tests appropriately.