### PR TITLE
Adding HearingAids item to Android.Bluetooth.ProfileType enum

### DIFF
--- a/build-tools/enumification-helpers/enum-conversion-mappings.xml
+++ b/build-tools/enumification-helpers/enum-conversion-mappings.xml
@@ -113,7 +113,7 @@
   <map package="android.bluetooth" class="BluetoothHealth" fields="" prefix="CHANNEL_TYPE_" enum-name="HealthChannelType" />
   <map package="android.bluetooth" class="BluetoothHealth" fields="" prefix="STATE_" enum-name="HealthState" />
   <map package="android.bluetooth" class="BluetoothHealth" fields="SINK_ROLE SOURCE_ROLE" prefix="" enum-name="RoleType" />
-  <map package="android.bluetooth" class="BluetoothProfile" fields="A2DP GATT GATT_SERVER HEADSET HEALTH HID_DEVICE SAP" prefix="" enum-name="ProfileType" />
+  <map package="android.bluetooth" class="BluetoothProfile" fields="A2DP GATT GATT_SERVER HEADSET HEALTH HID_DEVICE SAP HEARING_AID" prefix="" enum-name="ProfileType" />
   <map package="android.bluetooth" class="BluetoothProfile" fields="" prefix="STATE_" enum-name="ProfileState" is-transient="false" />
   <map package="android.bluetooth.le" class="AdvertiseCallback" fields="" prefix="ADVERTISE_FAILED_" enum-name="AdvertiseFailure" is-transient="false" api-level="21" />
   <map package="android.bluetooth.le" class="AdvertiseSettings" fields="" prefix="ADVERTISE_MODE_" enum-name="AdvertiseMode" is-transient="false" api-level="21" />

--- a/src/Mono.Android/map.csv
+++ b/src/Mono.Android/map.csv
@@ -3859,6 +3859,7 @@
 15,Android.Bluetooth.ProfileType,Health,I:android/bluetooth/BluetoothProfile.HEALTH,3
 28,Android.Bluetooth.ProfileType,HidDevice,I:android/bluetooth/BluetoothProfile.HID_DEVICE,19
 23,Android.Bluetooth.ProfileType,Sap,I:android/bluetooth/BluetoothProfile.SAP,10
+29,Android.Bluetooth.ProfileType,HearingAid,I:android/bluetooth/BluetoothProfile.HEARING_AID,21
 15,Android.Content.TrimMemory,Background,I:android/content/ComponentCallbacks2.TRIM_MEMORY_BACKGROUND,40
 15,Android.Content.TrimMemory,Complete,I:android/content/ComponentCallbacks2.TRIM_MEMORY_COMPLETE,80
 15,Android.Content.TrimMemory,Moderate,I:android/content/ComponentCallbacks2.TRIM_MEMORY_MODERATE,60


### PR DESCRIPTION
HearingAids was not included on the list of options for Android.Bluetooth.ProfileType enum as reported by https://github.com/xamarin/xamarin-android/issues/3508
