### PR TITLE
[ci] Move Windows build and test to VS2019

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -21,7 +21,9 @@ variables:
   InstallerArtifactName: installers
   TestAssembliesArtifactName: test-assemblies
   NUnitConsoleVersion: 3.9.0
+  DotNetCoreVersion: 2.1.701
   HostedWinVS2019: Hosted Windows 2019 with VS2019
+  VSEngWinVS2019: VSEng-MicroBuildVS2019
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
 stages:
@@ -54,9 +56,9 @@ stages:
       submodules: recursive
 
     - task: UseDotNet@2
-      displayName: install .NET Core 2.1.701
+      displayName: install .NET Core $(DotNetCoreVersion)
       inputs:
-        version: 2.1.701
+        version: $(DotNetCoreVersion)
 
       # Update Mono in a separate step since xaprepare uses it as well and it will crash when Mono it runs with is updated
       # The 'prepare' step creates the bundle
@@ -103,9 +105,9 @@ stages:
       submodules: recursive
 
     - task: UseDotNet@2
-      displayName: install .NET Core 2.1.701
+      displayName: install .NET Core $(DotNetCoreVersion)
       inputs:
-        version: 2.1.701
+        version: $(DotNetCoreVersion)
 
     - task: DownloadPipelineArtifact@1
       inputs:
@@ -198,7 +200,7 @@ stages:
   - job: queue_vsix_signing
     displayName: Queue Vsix Signing
     dependsOn: mac_build_create_installers
-    pool: $(XA.Build.Win.Pool)
+    pool: $(VSEngWinVS2019)
     condition: and(eq(dependencies.mac_build_create_installers.result, 'Succeeded'), eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
     timeoutInMinutes: 45
     cancelTimeoutInMinutes: 1
@@ -226,7 +228,7 @@ stages:
   jobs:
   - job: win_build_test
     displayName: Build and Test
-    pool: $(XA.Build.Win.Pool)
+    pool: $(VSEngWinVS2019)
     timeoutInMinutes: 360
     cancelTimeoutInMinutes: 5
     workspace:
@@ -239,6 +241,11 @@ stages:
     steps:
     - checkout: self
       submodules: recursive
+
+    - task: UseDotNet@2
+      displayName: install .NET Core $(DotNetCoreVersion)
+      inputs:
+        version: $(DotNetCoreVersion)
 
     - task: DownloadPipelineArtifact@1
       inputs:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -207,6 +207,8 @@ stages:
     workspace:
       clean: all
     steps:
+    - task: xamops.azdevex.lingering-process-task.lingering-process-task@1
+
     - task: JenkinsQueueJob@2
       displayName: xamarin vsix codesign - run jenkins job
       inputs:
@@ -237,10 +239,11 @@ stages:
       AndroidTargetAbiArgs: >-
         /p:AndroidSupportedTargetJitAbis=armeabi-v7a:arm64-v8a:x86:x86_64
         /p:AndroidSupportedTargetAotAbis=armeabi-v7a:arm64:x86:x86_64:win-armeabi-v7a:win-arm64:win-x86:win-x86_64
-      JAVA_HOME: '%HOMEDRIVE%%HOMEPATH%\android-toolchain\jdk'
     steps:
     - checkout: self
       submodules: recursive
+
+    - task: xamops.azdevex.lingering-process-task.lingering-process-task@1
 
     - task: UseDotNet@2
       displayName: install .NET Core $(DotNetCoreVersion)

--- a/build-tools/automation/yaml-templates/mac/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/mac/setup-test-environment.yaml
@@ -18,9 +18,9 @@ steps:
   displayName: install xaprepare dependencies
 
 - task: UseDotNet@2
-  displayName: install .NET Core 2.1.701
+  displayName: install .NET Core $(DotNetCoreVersion)
   inputs:
-    version: 2.1.701
+    version: $(DotNetCoreVersion)
 
 # Restore solutions for Xamarin.Android.Tools.sln, Xamarin.Android.sln, and Xamarin.Android-Tests.sln
 - task: NuGetCommand@2

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -609,8 +609,6 @@ namespace App1
 			};
 			var path = Path.Combine ("temp", TestContext.CurrentContext.Test.Name);
 			using (var builder = CreateDllBuilder (Path.Combine (path, netStandardProject.ProjectName), cleanupOnDispose: false)) {
-				if (!Directory.Exists (builder.MicrosoftNetSdkDirectory))
-					Assert.Fail ($"Microsoft.NET.Sdk not found: {builder.MicrosoftNetSdkDirectory}");
 				using (var ab = CreateApkBuilder (Path.Combine (path, app.ProjectName), cleanupOnDispose: false)) {
 					builder.RequiresMSBuild =
 						ab.RequiresMSBuild = true;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -17,7 +17,6 @@ namespace Xamarin.ProjectTools
 	{
 		const string SigSegvError = "Got a SIGSEGV while executing native code";
 		const string ConsoleLoggerError = "[ERROR] FATAL UNHANDLED EXCEPTION: System.ArgumentException: is negative";
-		static string frameworkSDKRoot = null;
 
 		string root;
 		string buildLogFullPath;
@@ -114,31 +113,6 @@ namespace Xamarin.ProjectTools
 					var x86 = Environment.GetFolderPath (Environment.SpecialFolder.ProgramFilesX86);
 					return Path.Combine (x86, "MSBuild", "Xamarin", "Android");
 				}
-			}
-		}
-
-		public string MicrosoftNetSdkDirectory {
-			get {
-				string dotnetSearchPath = IsUnix ? frameworkSDKRoot
-						:  Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.ProgramFiles), "dotnet", "sdk");
-
-				string path = FindLatestDotNetSdk (dotnetSearchPath);
-				if (!string.IsNullOrEmpty (path))
-					return path;
-
-				if (!IsUnix) {
-					var visualStudioDirectory = TestEnvironment.GetVisualStudioDirectory ();
-					if (!string.IsNullOrEmpty (visualStudioDirectory)) {
-						path = Path.Combine (visualStudioDirectory, "MSBuild", "Sdks", "Microsoft.NET.Sdk");
-						if (File.Exists (Path.Combine (path, "Sdk", "Sdk.props")))
-							return path;
-					}
-					var x86 = Environment.GetFolderPath (Environment.SpecialFolder.ProgramFilesX86);
-					path = Path.Combine (x86, "MSBuild", "Sdks", "Microsoft.NET.Sdk");
-					if (File.Exists (Path.Combine (path, "Sdk", "Sdk.props")))
-						return path;
-				}
-				return string.Empty;
 			}
 		}
 
@@ -270,31 +244,6 @@ namespace Xamarin.ProjectTools
 			BuildLogFile = "build.log";
 			Console.WriteLine ($"Using {XABuildExe}");
 			Console.WriteLine ($"Using {(RunningMSBuild ? "msbuild" : "xbuild")}");
-			if (IsUnix && string.IsNullOrEmpty (frameworkSDKRoot)) {
-				var psi = new ProcessStartInfo ("msbuild") {
-					RedirectStandardOutput = true,
-					UseShellExecute = false,
-					CreateNoWindow = true,
-					WindowStyle = ProcessWindowStyle.Hidden,
-					WorkingDirectory = Root,
-					Arguments = $" {Path.Combine (Root, "FrameworkPath.targets")} /v:minimal /nologo",
-				};
-				using (var process = Process.Start (psi)) {
-					process.WaitForExit ();
-					frameworkSDKRoot = process.StandardOutput.ReadToEnd ().Trim ();
-				}
-
-				//NOTE: some machines aren't returning /msbuild/ on the end
-				//      macOS should be /Library/Frameworks/Mono.framework/Versions/5.18.0/lib/mono/msbuild/
-				var dir = Path.GetFileName (frameworkSDKRoot.TrimEnd (Path.DirectorySeparatorChar));
-				if (dir != "msbuild") {
-					var path = Path.Combine (frameworkSDKRoot, "msbuild");
-					if (Directory.Exists (path))
-						frameworkSDKRoot = path;
-				}
-			}
-			if (!string.IsNullOrEmpty (frameworkSDKRoot))
-				Console.WriteLine ($"Using $(FrameworkSDKRoot): {frameworkSDKRoot}");
 		}
 
 		public void Dispose ()
@@ -498,29 +447,6 @@ namespace Xamarin.ProjectTools
 		string QuoteFileName (string fileName)
 		{
 			return fileName.Contains (" ") ? $"\"{fileName}\"" : fileName;
-		}
-
-		string FindLatestDotNetSdk (string dotNetPath)
-		{
-			if (Directory.Exists (dotNetPath)) {
-				Version latest = new Version (0,0);
-				string Sdk = null;
-				foreach (var dir in Directory.EnumerateDirectories (dotNetPath)) {
-					// Preview versions such as `3.0.100-preview9-013775` will be ignored.
-					Version.TryParse (Path.GetFileName (dir), out Version version);
-					var sdksDir = Path.Combine (dir, "Sdks");
-					if (!Directory.Exists (sdksDir))
-						sdksDir = Path.Combine (dir, "bin", "Sdks");
-					if (version != null && version > latest) {
-						if (Directory.Exists (sdksDir) && File.Exists (Path.Combine (sdksDir, "Microsoft.NET.Sdk", "Sdk", "Sdk.props"))) {
-							latest = version;
-							Sdk = Path.Combine (sdksDir, "Microsoft.NET.Sdk");
-						}
-					}
-				}
-				return Sdk;
-			}
-			return null;
 		}
 
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -120,7 +120,7 @@ namespace Xamarin.ProjectTools
 		public string MicrosoftNetSdkDirectory {
 			get {
 				string dotnetSearchPath = IsUnix ? frameworkSDKRoot
-						:  Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.ProgramFiles), "dotnet");
+						:  Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.ProgramFiles), "dotnet", "sdk");
 
 				string path = FindLatestDotNetSdk (dotnetSearchPath);
 				if (!string.IsNullOrEmpty (path))
@@ -506,7 +506,6 @@ namespace Xamarin.ProjectTools
 				Version latest = new Version (0,0);
 				string Sdk = null;
 				foreach (var dir in Directory.EnumerateDirectories (dotNetPath)) {
-					Console.WriteLine ($"Found potential .NET dir: {dir}");
 					// Preview versions such as `3.0.100-preview9-013775` will be ignored.
 					Version.TryParse (Path.GetFileName (dir), out Version version);
 					var sdksDir = Path.Combine (dir, "Sdks");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -506,6 +506,7 @@ namespace Xamarin.ProjectTools
 				Version latest = new Version (0,0);
 				string Sdk = null;
 				foreach (var dir in Directory.EnumerateDirectories (dotNetPath)) {
+					Console.WriteLine ($"Found potential .NET dir: {dir}");
 					// Preview versions such as `3.0.100-preview9-013775` will be ignored.
 					Version.TryParse (Path.GetFileName (dir), out Version version);
 					var sdksDir = Path.Combine (dir, "Sdks");

--- a/src/java-runtime/java-runtime.targets
+++ b/src/java-runtime/java-runtime.targets
@@ -56,12 +56,9 @@
     AfterTargets="Build"
     Inputs="@(_RuntimeOutput->'%(Identity)')"
     Outputs="@(_RuntimeOutput->'%(OutputDex)')">
-  <PropertyGroup>
-    <_JavaHome Condition=" '$(JAVA_HOME)' == '' And '$(JavaSdkDirectory)' != '' ">JAVA_HOME=$(JavaSdkDirectory)</_JavaHome>
-  </PropertyGroup>
   <Exec
       Command="&quot;$(AndroidSdkDirectory)\build-tools\$(XABuildToolsFolder)\dx&quot; --dex --no-strict --output=&quot;%(_RuntimeOutput.OutputDex)&quot; &quot;%(_RuntimeOutput.OutputJar)&quot;"
-      EnvironmentVariables="$(_JavaHome)"
+      EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory)"
   />
 </Target>
 </Project>


### PR DESCRIPTION
We've been encountering a handful of issues recently with the Windows
machine pool we're using for building and testing. There have been quite
a few failures caused by files being locked, or dependencies being out
of date or missing. Moving to the VSEng VS2019 Windows pool will
hopefully resolve some of these issues.

Unfortunately the size of our build dependencies presents an issue when
attempting to use the Microsoft hosted Windows VS2019 agents, as our Win
job ultimately runs out of space when executing on those VMS. Using the
VSEng VS2019 pool will allow us to migrate to VS2019 while avoiding disk
space limitations.

As of commit 8cdda11, `$(JavaSdkDirectory)` will have a default value
of the path to the Corretto JDK we install on both Windows and macOS.
We should try to use this JDK path for all Android/Java tool invocations
which require `$(JAVA_HOME)` to be set.

Also adds a [process monitor/killer][0] to our Windows build jobs to attempt
to better monitor, or hopefully prevent, cases of our source directory being
in use by an external process when a job starts.

[0]: https://github.com/xamarin/azdev-extension/tree/4444d45d51e15ad8c84f0b8ce72ee710a71352f9/lingering-process-task