### PR TITLE
[Xamarin.Android.Build.Tasks] Dont create debug.keystore if we don't need to.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -3116,7 +3116,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_CreateAndroidDebugSigningKey"
-		Condition="!Exists ('$(_ApkDebugKeyStore)')"
+		Condition="!Exists ('$(_ApkDebugKeyStore)') And '$(AndroidKeyStore)' != 'True' "
 		DependsOnTargets="$(_OnResolveMonoAndroidSdks)"
 	>
 	<AndroidCreateDebugKey


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/3547

When building in release mode if the user has `AndroidKeyStore` set
we should not try to create the debug.keystore. This is causing
problems on CI systems since sometimes the CI job is running
as a `system` account. Mostly around writting to the system
profile directory `C:\Windows\system32\config\systemprofile\AppData`.