### PR TITLE
Update Linux.DebianCommon.cs to look for libncurses5-dev 

### DIFF
--- a/build-tools/automation/build.linux.groovy
+++ b/build-tools/automation/build.linux.groovy
@@ -28,7 +28,7 @@ def chRootPackages = '''
     lib32z1
     libc++-dev
     libgdk-pixbuf2.0-dev
-    libncurses-dev
+    libncurses5-dev
     libsqlite3-dev
     libtinfo-dev:i386
     libtool

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.DebianCommon.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.DebianCommon.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Android.Prepare
 			new DebianLinuxProgram ("g++-mingw-w64"),
 			new DebianLinuxProgram ("gcc-mingw-w64"),
 			new DebianLinuxProgram ("git"),
-			new DebianLinuxProgram ("libncurses-dev"),
+			new DebianLinuxProgram ("libncurses5-dev"),
 			new DebianLinuxProgram ("libtool"),
 			new DebianLinuxProgram ("libz-mingw-w64-dev"),
 			new DebianLinuxProgram ("libzip-dev"),


### PR DESCRIPTION
On ubuntu 18.04 (LTS) we are unable to install/find libncurses-dev, instead it uses libncurses5-dev