### PR TITLE
[Xamarin.Android.Build.Tasks] fix incremental builds w/ native assembler

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2209,7 +2209,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_GenerateJavaStubs"
   DependsOnTargets="$(_GenerateJavaStubsDependsOnTargets);$(BeforeGenerateAndroidManifest)"
   Inputs="$(MSBuildAllProjects);@(_ResolvedUserMonoAndroidAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(_AndroidResourceDest)"
-  Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp;@(_TypeMapAssemblySource)">
+  Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
   <GenerateJavaStubs
     ResolvedAssemblies="@(_ResolvedAssemblies)"
     ResolvedUserAssemblies="@(_ResolvedUserMonoAndroidAssemblies)"
@@ -2331,8 +2331,8 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_GeneratePackageManagerJava"
   DependsOnTargets="$(_GeneratePackageManagerJavaDependsOn)"
-  Inputs="$(MSBuildAllProjects);$(_ResolvedUserAssembliesHashFile);$(MSBuildProjectFile);$(_AndroidBuildPropertiesCache)"
-  Outputs="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp;@(_EnvironmentAssemblySource)">
+  Inputs="$(MSBuildAllProjects);$(_ResolvedUserAssembliesHashFile);$(MSBuildProjectFile);$(_AndroidBuildPropertiesCache);@(AndroidEnvironment);@(LibraryEnvironments)"
+  Outputs="$(_AndroidStampDirectory)_GeneratePackageManagerJava.stamp">
   <!-- Create java needed for Mono runtime -->
   <GeneratePackageManagerJava
     ResolvedAssemblies="@(_ResolvedAssemblies)"
@@ -2367,6 +2367,7 @@ because xbuild doesn't support framework reference assemblies.
   />
   <ItemGroup>
     <FileWrites Include="$(_AndroidBuildIdFile)" />
+    <FileWrites Include="@(_EnvironmentAssemblySource)" />
   </ItemGroup>
 </Target>
 
@@ -2593,6 +2594,7 @@ because xbuild doesn't support framework reference assemblies.
 <PropertyGroup>
 	<_CompileToDalvikDependsOnTargets>
 		_CompileJava;
+		_CreateApplicationSharedLibraries;
 		_GetMonoPlatformJarPath;
 		_GetAdditionalResourcesFromAssemblies;
 		_CreateAdditionalResourceCache;
@@ -2827,6 +2829,9 @@ because xbuild doesn't support framework reference assemblies.
       DebugBuild="$(AndroidIncludeDebugSymbols)"
       WorkingDirectory="$(_NativeAssemblySourceDir)"
   />
+  <ItemGroup>
+    <FileWrites Include="@(_NativeAssemblyTarget)" />
+  </ItemGroup>
 </Target>
 
 <Target Name="_PrepareApplicationSharedLibraryItems">
@@ -2868,13 +2873,13 @@ because xbuild doesn't support framework reference assemblies.
 		$(AfterGenerateAndroidManifest);
 		_GenerateEnvironmentFiles;
 		_CompileJava;
+		_CreateApplicationSharedLibraries;
 		_CompileDex;
 		$(_AfterCompileDex);
 		_CreateBaseApk;
 		_PrepareAssemblies;
 		_ResolveSatellitePaths;
 		_CheckApkPerAbiFlag;
-		_CreateApplicationSharedLibraries;
 		;_LintChecks
 		;_IncludeNativeSystemLibraries
 		;_CheckGoogleSdkRequirements


### PR DESCRIPTION
When testing performance, I found an issue with `_GenerateJavaStubs`:

1. Change `MainActivity.cs` in an Android app project and hit F5.
2. The `Build` runs `_GenerateJavaStubs`
3. The `Install` runs `_GenerateJavaStubs`
4. Any subsequent build (even with no changes) will run
   `_GenerateJavaStubs`...

The log reads:

    Building target "_GenerateJavaStubs" completely.
    Input file "obj\Debug\90\android\assets\App14.dll" is newer than output file "obj\Debug\90\android\typemap.jm.arm64-v8a.s".

In 74cf0ec9, we modified the `Outputs` to be:

    Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp;@(_TypeMapAssemblySource)"

This would be OK, except in some cases we don't update this file:

    MonoAndroidHelper.CopyIfStreamChanged (ms, asmFileName);

If `_GenerateJavaStubs` runs, but the typemap doesn't change, we will
be stuck in a spot where `_GenerateJavaStubs` will always run on
incremental builds.

`_GeneratePackageManagerJava` has the exact same problem as well.

## IncrementalClean ##

The real issue 74cf0ec9 was trying to solve was that some of these
`typemap.*.s` files were getting deleted during incremental builds.

A PR build was hitting:

    _CompileNativeAssemblySources:
        Assembler messages:
        can't open typemap.mj.armeabi-v7a.s for reading: No such file or directory

Due to:

    Skipping target "_GenerateJavaStubs" because all output files are up-to-date with respect to the input files.

We suspected `IncrementalClean` was deleting these files, but we
weren't able to find the right log file where that happened...

Going through things again, I figured out what was going on:

* `@(_EnvironmentAssemblySource)` and `@(_NativeAssemblyTarget)` were
  not added to `FileWrites`
* `_CreateApplicationSharedLibraries` was not running during `Build`
  but `SignAndroidPackage`. This means it was running *after*
  `IncrementalClean`. Any files it produced that were in `FileWrites`
  are ignored...
* We can run `_CreateApplicationSharedLibraries` right after
  `_CompileJava`. This has other benefits than correctness for
  `IncrementalClean`, such as when a build error occurs. The UX is a
  bit nicer in IDEs for errors from `Build` than `Install`.

After these changes I can remove the extra `Outputs` from
`_GenerateJavaStubs` and `_GeneratePackageManagerJava` and solely rely
on the stamp files as an output.

Moving `_CreateApplicationSharedLibraries` to `Build` should not
impact incremental build performance, as it should be target that is
skipped on almost all builds.

I also added a new test for these scenarios, verifying targets skip
and files are added to `FileWrites` appropriately.

Other fixes:

* `AndroidEnvironment` files were not an `Input` to
  `_GeneratePackageManagerJava`. So changing environment vars seems
  like it would always require a `Rebuild` to work...