### PR TITLE
[xaprepare] Add `xaprepare.exe --ignore-min-mono-version=true`

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/Context.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Context.cs
@@ -144,6 +144,11 @@ namespace Xamarin.Android.Prepare
 		public bool IgnoreMaxMonoVersion               { get; set; } = true;
 
 		/// <summary>
+		///   Do not terminate session when Mono is older than specified in the dependencies
+		/// </summary>
+		public bool IgnoreMinMonoVersion               { get; set; } = false;
+
+		/// <summary>
 		///   Current session execution mode. See <see cref="t:ExecutionMode" />
 		/// </summary>
 		public ExecutionMode ExecutionMode             { get; set; } = Configurables.Defaults.ExecutionMode;

--- a/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
+++ b/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Android.Prepare
 		public const string EmulatorVersion                     = "EmulatorVersion";
 		public const string EmulatorPkgRevision                 = "EmulatorPkgRevision";
 		public const string IgnoreMaxMonoVersion                = "IgnoreMaxMonoVersion";
+		public const string IgnoreMinMonoVersion                = "IgnoreMinMonoVersion";
 		public const string JavaInteropFullPath                 = "JavaInteropFullPath";
 		public const string JavaSdkDirectory                    = "JavaSdkDirectory";
 		public const string LibZipSourceFullPath                = "LibZipSourceFullPath";

--- a/build-tools/xaprepare/xaprepare/Application/MonoPkgProgram.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/Application/MonoPkgProgram.MacOS.cs
@@ -34,6 +34,7 @@ namespace Xamarin.Android.Prepare
 		protected override bool CheckWhetherInstalled ()
 		{
 			IgnoreMaximumVersion = Context.Instance.IgnoreMaxMonoVersion;
+			IgnoreMinimumVersion = Context.Instance.IgnoreMinMonoVersion;
 			return base.CheckWhetherInstalled ();
 		}
 

--- a/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
+++ b/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
@@ -23,6 +23,7 @@ namespace Xamarin.Android.Prepare
 			properties.Add (KnownProperties.EmulatorVersion,                     StripQuotes ("@EmulatorVersion@"));
 			properties.Add (KnownProperties.EmulatorPkgRevision,                 StripQuotes ("@EmulatorPkgRevision@"));
 			properties.Add (KnownProperties.IgnoreMaxMonoVersion,                StripQuotes ("@IgnoreMaxMonoVersion@"));
+			properties.Add (KnownProperties.IgnoreMinMonoVersion,                StripQuotes ("@IgnoreMinMonoVersion@"));
 			properties.Add (KnownProperties.JavaInteropFullPath,                 StripQuotes (@"@JavaInteropFullPath@"));
 			properties.Add (KnownProperties.JavaSdkDirectory,                    StripQuotes (@"@JavaSdkDirectory@"));
 			properties.Add (KnownProperties.LibZipSourceFullPath,                StripQuotes (@"@LibZipSourceFullPath@"));

--- a/build-tools/xaprepare/xaprepare/Main.cs
+++ b/build-tools/xaprepare/xaprepare/Main.cs
@@ -28,6 +28,7 @@ namespace Xamarin.Android.Prepare
 			public bool AutoProvision          { get; set; }
 			public bool AutoProvisionUsesSudo  { get; set; }
 			public bool IgnoreMaxMonoVersion   { get; set; }
+			public bool IgnoreMinMonoVersion   { get; set; }
 			public bool EnableAll              { get; set; }
 			public string XABundlePath         { get; set; }
 			public string XABundleCopyDir      { get; set; }
@@ -106,6 +107,7 @@ namespace Xamarin.Android.Prepare
 				{"auto-provision=", $"Automatically install software required by Xamarin.Android", v => parsedOptions.AutoProvision = ParseBoolean (v)},
 				{"auto-provision-uses-sudo=", $"Allow use of sudo(1) when provisioning", v => parsedOptions.AutoProvisionUsesSudo = ParseBoolean (v)},
 				{"ignore-max-mono-version=", $"Ignore the maximum supported Mono version restriction", v => parsedOptions.IgnoreMaxMonoVersion = ParseBoolean (v)},
+				{"ignore-min-mono-version=", $"Ignore the minimum supported Mono version restriction", v => parsedOptions.IgnoreMinMonoVersion = ParseBoolean (v)},
 				"",
 				{"h|help", "Show this help message", v => parsedOptions.ShowHelp = true },
 			};
@@ -137,6 +139,7 @@ namespace Xamarin.Android.Prepare
 			Context.Instance.AutoProvision         = parsedOptions.AutoProvision;
 			Context.Instance.AutoProvisionUsesSudo = parsedOptions.AutoProvisionUsesSudo;
 			Context.Instance.IgnoreMaxMonoVersion  = parsedOptions.IgnoreMaxMonoVersion;
+			Context.Instance.IgnoreMinMonoVersion  = parsedOptions.IgnoreMinMonoVersion;
 			Context.Instance.EnableAllTargets      = parsedOptions.EnableAll;
 			Context.Instance.ComponentsToRefresh   = parsedOptions.RefreshList;
 


### PR DESCRIPTION
The xamarin-android build prefers that the system mono be the same
version as the bundled mono.  As `.external` is currently referencing
the mono/2019-06 branch, this suggests use of system mono 6.4.0.

Meanwhile, the current *stable* version of Xamarin.Android --
Xamarin.Android 9.4.0 (d16-2) at the time of this writing -- is using
mono/2019-02 (mono 6.0.0).

Consequently, if a stable version of mono is installed, the
xamarin-android repo cannot be built unless system mono is updated:

	$ make prepare
	...
	Checking Mono                                        [WRONG VERSION 6.0.0.311]
	  Error: Some programs are missing or have invalid versions, but automatic provisioning is disabled
	  Error: Failed to initialize OS support
	make: *** [prepare] Error 1

Add an `xaprepare.exe --ignore-min-mono-version=BOOL` option so that
the minimum mono version check can be skipped.  This will allow
`make prepare` to succeed when stable mono is present:

	$ make prepare PREPARE_ARGS="--ignore-min-mono-version=true"
	# succeeds; no errors