### PR TITLE
[XA.Build.Tasks] Add AndroidBinUtilsDirectory prop

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -257,6 +257,16 @@ when packaging Release applications.
 
     Added in Xamarin.Android 6.1.
 
+-   **AndroidBinUtilsPath** &ndash; A path to a directory containing
+    the Android [binutils][binutils] such as `ld`, the native linker,
+    and `as`, the native assembler. These binaries a subset of the
+    Android NDK, and are bundled with the Xamarin.Android
+    installation. `$(MonoAndroidBinDirectory)\ndk\` by default.
+
+    Added in Xamarin.Android 10.0.
+
+[binutils]: https://android.googlesource.com/toolchain/binutils/
+
 -   **AndroidBuildApplicationPackage** &ndash; A boolean value that
     indicates whether to create and sign the package (.apk). Setting
     this value to `True` is equivalent to using the

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -70,7 +70,8 @@ namespace Xamarin.Android.Tasks
 
 		public ITaskItem [] Profiles { get; set; }
 
-		public string ToolsDirectory { get; set; }
+		[Required]
+		public string AndroidBinUtilsDirectory { get; set; }
 
 		[Output]
 		public string[] NativeLibrariesReferences { get; set; }
@@ -364,7 +365,7 @@ namespace Xamarin.Android.Tasks
 				int level = 0;
 				string toolPrefix = EnableLLVM
 					? NdkUtil.GetNdkToolPrefix (AndroidNdkDirectory, arch, level = GetNdkApiLevel (AndroidNdkDirectory, AndroidApiLevel, arch))
-					: Path.Combine (ToolsDirectory, "ndk", $"{NdkUtil.GetArchDirName (arch)}-");
+					: Path.Combine (AndroidBinUtilsDirectory, $"{NdkUtil.GetArchDirName (arch)}-");
 				var toolchainPath = toolPrefix.Substring(0, toolPrefix.LastIndexOf(Path.DirectorySeparatorChar));
 				var ldFlags = string.Empty;
 				if (EnableLLVM) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
@@ -30,6 +30,9 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string WorkingDirectory { get; set; }
 
+		[Required]
+		public string AndroidBinUtilsDirectory { get; set; }
+
 		public override bool Execute ()
 		{
 			try {
@@ -134,7 +137,6 @@ namespace Xamarin.Android.Tasks
 
 		IEnumerable<Config> GetAssemblerConfigs ()
 		{
-			string sdkBinDirectory = Path.Combine (MonoAndroidHelper.GetOSBinPath (), "ndk");
 			foreach (ITaskItem item in Sources) {
 				string abi = item.GetMetadata ("abi")?.ToLowerInvariant ();
 				string prefix = String.Empty;
@@ -142,24 +144,24 @@ namespace Xamarin.Android.Tasks
 
 				switch (abi) {
 					case "armeabi-v7a":
-						prefix = Path.Combine (sdkBinDirectory, "arm-linux-androideabi");
+						prefix = Path.Combine (AndroidBinUtilsDirectory, "arm-linux-androideabi");
 						arch = AndroidTargetArch.Arm;
 						break;
 
 					case "arm64":
 					case "arm64-v8a":
 					case "aarch64":
-						prefix = Path.Combine (sdkBinDirectory, "aarch64-linux-android");
+						prefix = Path.Combine (AndroidBinUtilsDirectory, "aarch64-linux-android");
 						arch = AndroidTargetArch.Arm64;
 						break;
 
 					case "x86":
-						prefix = Path.Combine (sdkBinDirectory, "i686-linux-android");
+						prefix = Path.Combine (AndroidBinUtilsDirectory, "i686-linux-android");
 						arch = AndroidTargetArch.X86;
 						break;
 
 					case "x86_64":
-						prefix = Path.Combine (sdkBinDirectory, "x86_64-linux-android");
+						prefix = Path.Combine (AndroidBinUtilsDirectory, "x86_64-linux-android");
 						arch = AndroidTargetArch.X86_64;
 						break;
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkApplicationSharedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkApplicationSharedLibraries.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Android.Tasks
 		public bool DebugBuild { get; set; }
 
 		[Required]
-		public string AndroidSdkBuildToolsPath { get; set; }
+		public string AndroidBinUtilsDirectory { get; set; }
 
 		public override bool Execute ()
 		{
@@ -210,9 +210,9 @@ namespace Xamarin.Android.Tasks
 					linkerArgs.Add (QuoteFileName (file));
 				}
 
-				string ld = MonoAndroidHelper.GetExecutablePath (AndroidSdkBuildToolsPath, $"{NdkUtil.GetNdkToolchainPrefix (arch, false)}ld");
+				string ld = MonoAndroidHelper.GetExecutablePath (AndroidBinUtilsDirectory, $"{NdkUtil.GetNdkToolchainPrefix (arch, false)}ld");
 				yield return new Config {
-					LinkerPath = Path.Combine (AndroidSdkBuildToolsPath, ld),
+					LinkerPath = Path.Combine (AndroidBinUtilsDirectory, ld),
 					LinkerOptions = String.Join (" ", linkerArgs),
 					OutputSharedLibrary = inputs.OutputSharedLibrary,
 				};

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -59,6 +59,9 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public string MonoAndroidLibPath { get; set; }
 
+		[Output]
+		public string AndroidBinUtilsPath { get; set; }
+
 		public override bool Execute ()
 		{
 			// OS X:    $prefix/lib/xamarin.android/xbuild/Xamarin/Android
@@ -68,6 +71,7 @@ namespace Xamarin.Android.Tasks
 			}
 			MonoAndroidBinPath  = MonoAndroidHelper.GetOSBinPath () + Path.DirectorySeparatorChar;
 			MonoAndroidLibPath  = MonoAndroidHelper.GetOSLibPath () + Path.DirectorySeparatorChar;
+			AndroidBinUtilsPath = MonoAndroidBinPath + "ndk" + Path.DirectorySeparatorChar;
 
 			MonoAndroidHelper.RefreshSupportedVersions (ReferenceAssemblyPaths);
 
@@ -105,6 +109,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugMessage ($"  {nameof (JavaSdkPath)}: {JavaSdkPath}");
 			Log.LogDebugMessage ($"  {nameof (MonoAndroidBinPath)}: {MonoAndroidBinPath}");
 			Log.LogDebugMessage ($"  {nameof (MonoAndroidToolsPath)}: {MonoAndroidToolsPath}");
+			Log.LogDebugMessage ($"  {nameof (AndroidBinUtilsPath)}: {AndroidBinUtilsPath}");
 
 			//note: this task does not error out if it doesn't find all things. that's the job of the targets
 			return !Log.HasLoggedErrors;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -814,6 +814,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		<Output TaskParameter="MonoAndroidToolsPath"      PropertyName="MonoAndroidToolsDirectory" />
 		<Output TaskParameter="MonoAndroidBinPath"        PropertyName="MonoAndroidBinDirectory" />
 		<Output TaskParameter="MonoAndroidLibPath"        PropertyName="MonoAndroidLibDirectory" />
+		<Output TaskParameter="AndroidBinUtilsPath"       PropertyName="AndroidBinUtilsDirectory" Condition=" '$(AndroidBinUtilsDirectory)' == '' " />
 	</ResolveSdks>
 	<ResolveJdkJvmPath
 			JavaSdkPath="$(_JavaSdkDirectory)"
@@ -2828,6 +2829,7 @@ because xbuild doesn't support framework reference assemblies.
       Sources="@(_TypeMapAssemblySource);@(_EnvironmentAssemblySource)"
       DebugBuild="$(AndroidIncludeDebugSymbols)"
       WorkingDirectory="$(_NativeAssemblySourceDir)"
+      AndroidBinUtilsDirectory="$(AndroidBinUtilsDirectory)"
   />
   <ItemGroup>
     <FileWrites Include="@(_NativeAssemblyTarget)" />
@@ -2850,7 +2852,7 @@ because xbuild doesn't support framework reference assemblies.
       ObjectFiles="@(_NativeAssemblyTarget)"
       ApplicationSharedLibraries="@(_ApplicationSharedLibrary)"
       DebugBuild="$(AndroidIncludeDebugSymbols)"
-      AndroidSdkBuildToolsPath="$(AndroidSdkBuildToolsPath)"
+      AndroidBinUtilsDirectory="$(AndroidBinUtilsDirectory)"
   />
   <ItemGroup>
     <FileWrites Include="@(_ApplicationSharedLibrary)" />
@@ -2931,7 +2933,7 @@ because xbuild doesn't support framework reference assemblies.
 	Condition="'$(AotAssemblies)' == 'True'"
 	AndroidAotMode="$(AndroidAotMode)"
 	AndroidNdkDirectory="$(_AndroidNdkDirectory)"
-	ToolsDirectory="$(MonoAndroidBinDirectory)"
+	AndroidBinUtilsDirectory="$(AndroidBinUtilsDirectory)"
 	AndroidApiLevel="$(_AndroidApiLevel)"
 	ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
 	SupportedAbis="@(_BuildTargetAbis)"


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3564

Adds an overridable `$(AndroidBinUtilsDirectory)` property which is used
to specify the directory that contains `as`, `ld`, and `strip` tools.
The default value for this property is the installation path of our
distribution of these tools, `$(MonoAndroidBinDirectory)\ndk\`.

Fixes #3564 by ensuring that we use the 64bit version of `ld` that we're
distributing, rather than the 32bit version found in the Android SDK.

Bad:

    Task Parameter:AndroidSdkBuildToolsPath=/Users/user/Library/Developer/Xamarin/android-sdk-macosx/build-tools/28.0.3/
      [Native Linker] /Users/user/Library/Developer/Xamarin/android-sdk-macosx/build-tools/28.0.3/aarch64-linux-android-ld --unresolved-symbols=ignore-in-shared-libs --export-dynamic -soname libxamarin-app.so -z relro -z noexecstack --enable-new-dtags --eh-frame-hdr -shared --build-id --warn-shared-textrel --fatal-warnings -o obj/Release/app_shared_libraries/arm64-v8a/libxamarin-app.so --fix-cortex-a53-843419 -m aarch64linux obj/Release/android/typemap.jm.arm64-v8a.o obj/Release/android/typemap.mj.arm64-v8a.o obj/Release/android/environment.arm64-v8a.o
      [Native Linker] /Users/user/Library/Developer/Xamarin/android-sdk-macosx/build-tools/28.0.3/arm-linux-androideabi-ld --unresolved-symbols=ignore-in-shared-libs --export-dynamic -soname libxamarin-app.so -z relro -z noexecstack --enable-new-dtags --eh-frame-hdr -shared --build-id --warn-shared-textrel --fatal-warnings -o obj/Release/app_shared_libraries/armeabi-v7a/libxamarin-app.so -X -m armelf_linux_eabi obj/Release/android/typemap.jm.armeabi-v7a.o obj/Release/android/typemap.mj.armeabi-v7a.o obj/Release/android/environment.armeabi-v7a.o
    /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Android/Xamarin.Android.Common.targets(2869,3): error XA3001: Could not link native shared library: libxamarin-app.so [/Users/user/Library/Caches/xqatmp/e0dd2595/Android/WorkingWithStyles.Android.csproj]
    Done executing task "LinkApplicationSharedLibraries" -- FAILED.

Good:

    Task "LinkApplicationSharedLibraries"
      [Native Linker] /Library/Frameworks/Xamarin.Android.framework/Libraries/xbuild/Xamarin/Android/Darwin/ndk/aarch64-linux-android-ld --unresolved-symbols=ignore-in-shared-libs --export-dynamic -soname libxamarin-app.so -z relro -z noexecstack --enable-new-dtags --eh-frame-hdr -shared --build-id --warn-shared-textrel --fatal-warnings -o obj/Release/app_shared_libraries/arm64-v8a/libxamarin-app.so --fix-cortex-a53-843419 -m aarch64linux obj/Release/android/typemap.jm.arm64-v8a.o obj/Release/android/typemap.mj.arm64-v8a.o obj/Release/android/environment.arm64-v8a.o
      [Native Linker] /Library/Frameworks/Xamarin.Android.framework/Libraries/xbuild/Xamarin/Android/Darwin/ndk/arm-linux-androideabi-ld --unresolved-symbols=ignore-in-shared-libs --export-dynamic -soname libxamarin-app.so -z relro -z noexecstack --enable-new-dtags --eh-frame-hdr -shared --build-id --warn-shared-textrel --fatal-warnings -o obj/Release/app_shared_libraries/armeabi-v7a/libxamarin-app.so -X -m armelf_linux_eabi obj/Release/android/typemap.jm.armeabi-v7a.o obj/Release/android/typemap.mj.armeabi-v7a.o obj/Release/android/environment.armeabi-v7a.o
    Done executing task "LinkApplicationSharedLibraries".
