### PR TITLE
[Xamarin.Android.Build.Tasks] fix Android Wear incremental builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/WearTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/WearTests.cs
@@ -1,0 +1,59 @@
+using System.IO;
+using NUnit.Framework;
+using Xamarin.ProjectTools;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	[NonParallelizable] // <GetAdditionalResourcesFromAssemblies/> is failing in parallel builds
+	public class WearTests : BaseTest
+	{
+		[Test]
+		public void BasicProject ([Values (true, false)] bool isRelease)
+		{
+			var proj = new XamarinAndroidWearApplicationProject {
+				IsRelease = isRelease,
+			};
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
+		[Test]
+		public void BundledWearApp ()
+		{
+			var target = "_UpdateAndroidResgen";
+			var path = Path.Combine ("temp", TestName);
+			var app = new XamarinAndroidApplicationProject {
+				ProjectName = "MyApp",
+			};
+			var wear = new XamarinAndroidWearApplicationProject ();
+			app.References.Add (new BuildItem.ProjectReference ($"..\\{wear.ProjectName}\\{wear.ProjectName}.csproj", wear.ProjectName, wear.ProjectGuid) {
+				MetadataValues = "IsAppExtension=True"
+			});
+
+			using (var wearBuilder = CreateDllBuilder (Path.Combine (path, wear.ProjectName)))
+			using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
+				Assert.IsTrue (wearBuilder.Build (wear), "first wear build should have succeeded.");
+				Assert.IsTrue (appBuilder.Build (app), "first app build should have succeeded.");
+				// Build with no changes
+				Assert.IsTrue (wearBuilder.Build (wear, doNotCleanupOnUpdate: true), "second wear build should have succeeded.");
+				Assert.IsTrue (wearBuilder.Output.IsTargetSkipped (target), $"`{target}` in wear build should be skipped!");
+				Assert.IsTrue (appBuilder.Build (app, doNotCleanupOnUpdate: true), "second app build should have succeeded.");
+				Assert.IsTrue (appBuilder.LastBuildOutput.ContainsOccurances ($"Skipping target \"{target}\"", 2), $"`{target}` in app build should be skipped!");
+				// Check the APK for the special Android Wear files
+				var files = new [] {
+					"res/raw/wearable_app.apk",
+					"res/xml/wearable_app_desc.xml"
+				};
+				var apk = Path.Combine (Root, appBuilder.ProjectDirectory, app.OutputPath, $"{app.PackageName}.apk");
+				FileAssert.Exists (apk);
+				using (var zipFile = ZipHelper.OpenZip (apk)) {
+					foreach (var file in files) {
+						Assert.IsTrue (zipFile.ContainsEntry (file, caseSensitive: true), $"{file} should be in the apk!");
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/WearTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/WearTests.cs
@@ -32,6 +32,12 @@ namespace Xamarin.Android.Build.Tests
 				MetadataValues = "IsAppExtension=True"
 			});
 
+			// Set these to be the same values
+			app.SetProperty (app.DebugProperties, KnownProperties.AndroidUseSharedRuntime, "False");
+			app.SetProperty (app.DebugProperties, "EmbedAssembliesIntoApk", "True");
+			wear.SetProperty (wear.DebugProperties, KnownProperties.AndroidUseSharedRuntime, "False");
+			wear.SetProperty (wear.DebugProperties, "EmbedAssembliesIntoApk", "True");
+
 			using (var wearBuilder = CreateDllBuilder (Path.Combine (path, wear.ProjectName)))
 			using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
 				Assert.IsTrue (wearBuilder.Build (wear), "first wear build should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
@@ -31,5 +31,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\MockBuildEngine.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\MonoAndroidHelperTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\EnvironmentHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WearTests.cs" />
   </ItemGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -105,11 +105,11 @@ namespace Xamarin.ProjectTools
 		};
 		public static Package AndroidWear = new Package () {
 			Id = "Xamarin.Android.Wear",
-			Version = "1.0.0-preview7",
-			TargetFramework = "MonoAndroid4487",
+			Version = "1.0.0",
+			TargetFramework = "MonoAndroid44",
 			References = {
 				new BuildItem.Reference ("Xamarin.Android.Wearable") {
-					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Wear.1.0.0-preview7\\lib\\MonoAndroid10\\Xamarin.Android.Wearable.dll" }
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Wear.1.0.0\\lib\\MonoAndroid44\\Xamarin.Android.Wearable.dll" }
 				}
 		};
 		public static Package AndroidWear_2_2_0 = new Package () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidWearApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidWearApplicationProject.cs
@@ -28,8 +28,7 @@ namespace Xamarin.ProjectTools
 			: base (debugConfigurationName, releaseConfigurationName)
 		{
 			TargetFrameworkVersion = Versions.KitkatWatch;
-			UseLatestPlatformSdk = false;
-			PackageReferences.Add (KnownPackages.AndroidSupportV13Kitkat);
+			UseLatestPlatformSdk = true;
 			PackageReferences.Add (KnownPackages.AndroidWear);
 
 			MainActivity = default_main_activity;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetXamarinProject.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Xml.Linq;
 using Microsoft.Build.Construction;
 
@@ -113,30 +114,34 @@ namespace Xamarin.ProjectTools
 
 		public override string SaveProject ()
 		{
+			XNamespace ns = "http://schemas.microsoft.com/developer/msbuild/2003";
+			var encoding = Encoding.UTF8;
 			var root = Construct ();
-			var sw = new StringWriter ();
-			root.Save (sw);
-			var document = XDocument.Parse (sw.ToString ());
-			var pn = XName.Get ("Project", "http://schemas.microsoft.com/developer/msbuild/2003");
-			var p = document.Element (pn);
-			if (p != null) {
-				//NOTE: when running tests inside VS 2019 "Current" was set here
-				p.SetAttributeValue ("ToolsVersion", "15.0");
+			XDocument document;
+			using (var stream = new MemoryStream ())
+			using (var sw = new StreamWriter (stream, encoding, 8 * 1024, leaveOpen: true)) {
+				root.Save (sw);
+				stream.Position = 0;
+				document = XDocument.Load (stream);
+				document.Declaration.Encoding = encoding.HeaderName;
+				var pn = XName.Get ("Project", ns.NamespaceName);
+				var p = document.Element (pn);
+				if (p != null) {
+					//NOTE: when running tests inside VS 2019 "Current" was set here
+					p.SetAttributeValue ("ToolsVersion", "15.0");
 
-				var referenceGroup = p.Elements ().FirstOrDefault (x => x.Name.LocalName == "ItemGroup" &&  x.HasElements && x.Elements ().Any (e => e.Name.LocalName == "Reference"));
-				if (referenceGroup != null) {
-					foreach (var pr in PackageReferences) {
-						//NOTE: without the namespace it puts xmlns=""
-						XNamespace ns = "http://schemas.microsoft.com/developer/msbuild/2003";
-						var e = XElement.Parse ($"<PackageReference Include=\"{pr.Id}\" Version=\"{pr.Version}\"/>");
-						e.Name = ns + e.Name.LocalName;
-						referenceGroup.Add (e);
+					var referenceGroup = p.Elements ().FirstOrDefault (x => x.Name.LocalName == "ItemGroup" && x.HasElements && x.Elements ().Any (e => e.Name.LocalName == "Reference"));
+					if (referenceGroup != null) {
+						foreach (var pr in PackageReferences) {
+							//NOTE: without the namespace it puts xmlns=""
+							var e = XElement.Parse ($"<PackageReference Include=\"{pr.Id}\" Version=\"{pr.Version}\"/>");
+							e.Name = ns + e.Name.LocalName;
+							referenceGroup.Add (e);
+						}
 					}
-					sw = new StringWriter ();
-					document.Save (sw);
 				}
+				return document.ToString ();
 			}
-			return sw.ToString ();
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -452,15 +452,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		WearApplicationApkPath="$(BundledWearApplicationApkPath)">
 		<Output TaskParameter="WearableApplicationDescriptionFile" ItemName="_WearableApplicationDescriptionFile" />
 		<Output TaskParameter="BundledWearApplicationApkResourceFile" ItemName="_BundledWearApplicationApkResourceFile" />
+		<Output TaskParameter="ModifiedFiles" ItemName="_ModifiedResources" />
 	</PrepareWearApplicationFiles>
-	<CreateItem Include="@(_WearableApplicationDescriptionFile)"
-		Condition="'@(_WearableApplicationDescriptionFile)' != ''">
-		<Output TaskParameter="Include" ItemName="AndroidResource" />
-	</CreateItem>
-	<CreateItem Include="@(_BundledWearApplicationApkResourceFile)"
-		Condition="'@(_BundledWearApplicationApkResourceFile)' != ''">
-		<Output TaskParameter="Include" ItemName="AndroidResource" />
-	</CreateItem>
 	<!-- in case there is no actual wear apk to be bundled, we don't generate wear_app_desc.xml and we shouldn't modify AndroidManifest.xml as if it had the apk -->
 	<CreateProperty Value=""
 		Condition="'@(_WearableApplicationDescriptionFile)' == ''">
@@ -1372,6 +1365,10 @@ because xbuild doesn't support framework reference assemblies.
 	>
 		<Output ItemName="_ModifiedResources" TaskParameter="ModifiedFiles"/>
 	</CopyIfChanged>
+	<!--NOTE: these two item groups are generated for Wear apps-->
+	<ItemGroup>
+		<_AndroidResourceDest Include="@(_WearableApplicationDescriptionFile);@(_BundledWearApplicationApkResourceFile)" />
+	</ItemGroup>
 	<RemoveUnknownFiles Files="@(_AndroidResourceDest)" Directory="$(MonoAndroidResDirIntermediate)" RemoveDirectories="true">
 		<Output ItemName="_AndroidResourceDestRemovedFiles" TaskParameter="RemovedFiles" />
 	</RemoveUnknownFiles>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3562

Our QA tests caught a regression where building a Xamarin.Android app
that includes an embedded Android Wear app would always rebuild.

This brought up a few things:

1. We have a `XamarinAndroidWearApplicationProject` class, but no
   tests using it?
2. What does our MSBuild targets even do for Wear projects?

## Tests ##

In adding some tests, I had to fix a few other things:

* We should use the 1.0.0 Xamarin.Android.Wearable NuGet instead of
  `preview7`.
* `Xamarin.ProjectTools` was generating `csproj` files of an encoding
  that did not match:

```
   Xamarin.Android.Common.targets(423,2): error MSB4018: The "ParseAndroidWearProjectAndManifest" task failed unexpectedly.
        System.Xml.XmlException: There is no Unicode byte order mark. Cannot switch to Unicode.
        at System.Xml.XmlTextReaderImpl.Throw(Exception e)
        at System.Xml.XmlTextReaderImpl.ThrowWithoutLineInfo(String res)
        at System.Xml.XmlTextReaderImpl.CheckEncoding(String newEncodingName)
        at System.Xml.XmlTextReaderImpl.ParseXmlDeclaration(Boolean isTextDecl)
        at System.Xml.XmlTextReaderImpl.Read()
        at System.Xml.Linq.XDocument.Load(XmlReader reader, LoadOptions options)
        at System.Xml.Linq.XDocument.Load(String uri, LoadOptions options)
        at System.Xml.Linq.XDocument.Load(String uri)
        at Xamarin.Android.Tasks.ParseAndroidWearProjectAndManifest.Execute()
        at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
        at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext() 
```

The file was actually `utf-8` but we were generating:

    <?xml version="1.0" encoding="utf-16"?>

I reworked `Xamarin.ProjectTools` to fix this.

I was able to add a simple test that just build a wear project, and
then added a second test that reproduces the problem.

## The Problem ##

Generally embedded Android Wear solutions:

* A main app references the Wear project.
* The main app grabs a few files from the Wear project: the APK and an
  xml configuration file and copies them into `obj\Debug\res`.

What was even weirder, since we put them in `@(AndroidResource)` the
`_GenerateAndroidResourceDir` MSBuild target would attempt to copy
these files to themselves. The same files paths were in
`@(_AndroidResolvedResources)` and `@(_AndroidResourceDest)`...

    <CopyIfChanged
        SourceFiles="@(_AndroidResolvedResources)"
        DestinationFiles="@(_AndroidResourceDest)"

The problem was we basically were copying these files and never adding
them to `@(_ModifiedResources)`. This meant that
`$(_AndroidResFlagFile)` was not `<Touch/>`'d in some cases:

    <Touch
        Files="$(_AndroidResFlagFile)"
        AlwaysCreate="True"
        Condition=" !Exists ('$(_AndroidResFlagFile)') Or '@(_ModifiedResources)' != '' Or '@(_AndroidResourceDestRemovedFiles)' != '' "
    />

Two fixes seemed to solve the issue:

* The `<PrepareWearApplicationFiles/>` task needs to return a
  `ModifiedFiles` output we can add to `@(_ModifiedResources)`.
* We should define the Wear files in `@(_AndroidResourceDest)` after
  the `<CopyIfChanged/>` call such as:

    <_AndroidResourceDest Include="@(_WearableApplicationDescriptionFile);@(_BundledWearApplicationApkResourceFile)" />

This way they are never part of `@(AndroidResource)`, since they are
auto-generated.