### PR TITLE
[tests] add [NonParallelizable] to ConvertCustomView

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -520,6 +520,7 @@ namespace Lib2
 		}
 
 		[Test]
+		[NonParallelizable] // /restore can fail on Mac in parallel
 		public void ConvertCustomView ([Values (true, false)] bool useAapt2)
 		{
 			var path = Path.Combine ("temp", TestName);


### PR DESCRIPTION
Context: http://build.azdo.io/2989026

We have seen test failures such as:

    Xamarin.Android.Build.Tests.IncrementalBuildTest.ConvertCustomView(True)
    Xamarin.Android.Build.Tests.IncrementalBuildTest.ConvertCustomView(False)

They both get a build error such as:

    /Library/Frameworks/Mono.framework/Versions/6.0.0/lib/mono/msbuild/Current/bin/NuGet.targets(121,5):
        error : The file '/Users/vsts/.nuget/packages/netstandard.library/2.0.3/.nupkg.metadata' already exists.

I think this a general bug when using `/t:Restore` or `/restore` with
an SDK-style project on Mac in parallel. I saw a similar issue when
writing the `MSBuildSdkExtrasTests`.

For now `[NonParallelizable]` should solve the issue.