### PR TITLE
More C++ warnings cleanup + C++17 changes

### DIFF
--- a/src/monodroid/jni/basic-android-system.cc
+++ b/src/monodroid/jni/basic-android-system.cc
@@ -11,8 +11,6 @@ const char **BasicAndroidSystem::app_lib_directories;
 size_t BasicAndroidSystem::app_lib_directories_size = 0;
 #if WINDOWS
 static const char *SYSTEM_LIB_PATH;
-#else
-constexpr char BasicAndroidSystem::SYSTEM_LIB_PATH[];
 #endif
 
 // Values correspond to the CPU_KIND_* macros

--- a/src/monodroid/jni/debug-app-helper.cc
+++ b/src/monodroid/jni/debug-app-helper.cc
@@ -29,7 +29,6 @@ void log_fatal (LogCategories category, const char *format, ...);
 
 static void copy_file_to_internal_location (char *to_dir, char *from_dir, char *file);
 static void copy_native_libraries_to_internal_location ();
-static bool try_load_libmonosgen (const char *dir, char*& libmonoso);
 static char* get_libmonosgen_path ();
 
 bool maybe_load_library (const char *path);
@@ -94,22 +93,6 @@ Java_mono_android_DebugRuntime_init (JNIEnv *env, jclass klass, jobjectArray run
 		log_fatal (LOG_DEFAULT, "Failed to dlopen Mono runtime from %s: %s", monosgen_path, dlerror ());
 		exit (FATAL_EXIT_CANNOT_FIND_LIBMONOSGEN);
 	}
-}
-
-bool
-maybe_load_library (const char *path)
-{
-	struct stat sbuf;
-
-	if (stat (path, &sbuf) != 0)
-		return false;
-
-	if (dlopen (path, RTLD_LAZY | RTLD_GLOBAL | RTLD_NODELETE) != nullptr) {
-		log_info (LOG_DEFAULT, "Mono runtime loaded from %s", path);
-		return true;
-	}
-
-	return false;
 }
 
 #ifdef ANDROID

--- a/src/monodroid/jni/debug.hh
+++ b/src/monodroid/jni/debug.hh
@@ -6,7 +6,7 @@
 #include <pthread.h>
 
 #ifdef __cplusplus
-namespace xamarin { namespace android
+namespace xamarin::android
 {
 	class Debug
 	{
@@ -52,7 +52,7 @@ namespace xamarin { namespace android
 
 #endif
 	};
-} }
+}
 #else // __cplusplus
 const char *__get_debug_mono_log_property (void);
 

--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -52,11 +52,6 @@ const char *EmbeddedAssemblies::suffixes[] = {
 	".exe",
 };
 
-constexpr char EmbeddedAssemblies::assemblies_prefix[];
-#if defined (DEBUG) || !defined (ANDROID)
-constexpr char EmbeddedAssemblies::override_typemap_entry_name[];
-#endif
-
 void EmbeddedAssemblies::set_assemblies_prefix (const char *prefix)
 {
 	if (assemblies_prefix_override != nullptr)

--- a/src/monodroid/jni/embedded-assemblies.hh
+++ b/src/monodroid/jni/embedded-assemblies.hh
@@ -10,7 +10,7 @@
 
 struct TypeMapHeader;
 
-namespace xamarin { namespace android { namespace internal {
+namespace xamarin::android::internal {
 #if defined (DEBUG) || !defined (ANDROID)
 	struct TypeMappingInfo;
 #endif
@@ -95,7 +95,7 @@ namespace xamarin { namespace android { namespace internal {
 #endif // DEBUG || !ANDROID
 		const char            *assemblies_prefix_override = nullptr;
 	};
-}}}
+}
 
 MONO_API int monodroid_embedded_assemblies_set_assemblies_prefix (const char *prefix);
 #endif /* INC_MONODROID_EMBEDDED_ASSEMBLIES_H */

--- a/src/monodroid/jni/jni-wrappers.hh
+++ b/src/monodroid/jni/jni-wrappers.hh
@@ -8,7 +8,7 @@
 
 #ifdef __cplusplus
 
-namespace xamarin { namespace android
+namespace xamarin::android
 {
 	class jstring_array_wrapper;
 
@@ -173,7 +173,7 @@ namespace xamarin { namespace android
 		jstring_wrapper  static_wrappers[5];
 		jstring_wrapper  invalid_wrapper;
 	};
-}}
+}
 
 #endif // __cplusplus
 #endif // __JNI_WRAPPERS_H

--- a/src/monodroid/jni/logger.cc
+++ b/src/monodroid/jni/logger.cc
@@ -17,6 +17,7 @@
 #include "util.hh"
 #include "globals.hh"
 
+#undef DO_LOG
 #define DO_LOG(_level_,_category_,_format_,_args_)						                        \
 	va_start ((_args_), (_format_));									                        \
 	__android_log_vprint ((_level_), CATEGORY_NAME((_category_)), (_format_), (_args_)); \

--- a/src/monodroid/jni/monodroid-glue-internal.hh
+++ b/src/monodroid/jni/monodroid-glue-internal.hh
@@ -6,7 +6,7 @@
 #include "android-system.hh"
 #include "osbridge.hh"
 
-namespace xamarin { namespace android { namespace internal
+namespace xamarin::android::internal
 {
 	extern char *primary_override_dir;
 	extern char *external_override_dir;
@@ -16,5 +16,5 @@ namespace xamarin { namespace android { namespace internal
 	class MonodroidRuntime
 	{
 	};
-} } }
+}
 #endif

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -997,28 +997,30 @@ create_domain (JNIEnv *env, jclass runtimeClass, jstring_array_wrapper &runtimeA
 		free (domain_name);
 	}
 
-	if (is_running_on_desktop && is_root_domain) {
-		// Check that our corlib is coherent with the version of Mono we loaded otherwise
-		// tell the IDE that the project likely need to be recompiled.
-		char* corlib_error_message = const_cast<char*>(mono_check_corlib_version ());
-		if (corlib_error_message == nullptr) {
-			if (!androidSystem.monodroid_get_system_property ("xamarin.studio.fakefaultycorliberrormessage", &corlib_error_message)) {
-				free (corlib_error_message);
-				corlib_error_message = nullptr;
+	if constexpr (is_running_on_desktop) {
+		if (is_root_domain) {
+			// Check that our corlib is coherent with the version of Mono we loaded otherwise
+			// tell the IDE that the project likely need to be recompiled.
+			char* corlib_error_message = const_cast<char*>(mono_check_corlib_version ());
+			if (corlib_error_message == nullptr) {
+				if (!androidSystem.monodroid_get_system_property ("xamarin.studio.fakefaultycorliberrormessage", &corlib_error_message)) {
+					free (corlib_error_message);
+					corlib_error_message = nullptr;
+				}
 			}
-		}
-		if (corlib_error_message != nullptr) {
-			jclass ex_klass = env->FindClass ("mono/android/MonoRuntimeException");
-			env->ThrowNew (ex_klass, corlib_error_message);
-			free (corlib_error_message);
-			return nullptr;
-		}
+			if (corlib_error_message != nullptr) {
+				jclass ex_klass = env->FindClass ("mono/android/MonoRuntimeException");
+				env->ThrowNew (ex_klass, corlib_error_message);
+				free (corlib_error_message);
+				return nullptr;
+			}
 
-		// Load a basic environment for the RootDomain if run on desktop so that we can unload
-		// and reload most assemblies including Mono.Android itself
-		MonoAssemblyName *aname = mono_assembly_name_new ("System");
-		mono_assembly_load_full (aname, nullptr, nullptr, 0);
-		mono_assembly_name_free (aname);
+			// Load a basic environment for the RootDomain if run on desktop so that we can unload
+			// and reload most assemblies including Mono.Android itself
+			MonoAssemblyName *aname = mono_assembly_name_new ("System");
+			mono_assembly_load_full (aname, nullptr, nullptr, 0);
+			mono_assembly_name_free (aname);
+		}
 	}
 
 	return domain;
@@ -1865,8 +1867,11 @@ create_and_initialize_domain (JNIEnv* env, jclass runtimeClass, jstring_array_wr
 	MonoDomain* domain = create_domain (env, runtimeClass, runtimeApks, loader, is_root_domain);
 
 	// When running on desktop, the root domain is only a dummy so don't initialize it
-	if (is_running_on_desktop && is_root_domain)
-		return domain;
+	if constexpr (is_running_on_desktop) {
+		if (is_root_domain) {
+			return domain;
+		}
+	}
 
 	if (androidSystem.is_assembly_preload_enabled ())
 		load_assemblies (domain, env, assemblies);
@@ -2050,7 +2055,7 @@ Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang,
 	delete[] runtime_args;
 
 	// Install our dummy exception handler on Desktop
-	if (is_running_on_desktop) {
+	if constexpr (is_running_on_desktop) {
 		mono_add_internal_call ("System.Diagnostics.Debugger::Mono_UnhandledException_internal(System.Exception)",
 		                                 reinterpret_cast<const void*> (monodroid_Mono_UnhandledException_internal));
 	}
@@ -2226,8 +2231,6 @@ extern "C" int monodroid_dylib_mono_init (void *mono_imports, const char *libmon
 {
 	if (mono_imports == nullptr)
 		return FALSE;
-
-	void *libmono_handle = libmono_path ? androidSystem.load_dso_from_any_directories(libmono_path, RTLD_LAZY | RTLD_GLOBAL) : dlopen (libmono_path, RTLD_LAZY | RTLD_GLOBAL);;
 	return TRUE;
 }
 

--- a/src/monodroid/jni/osbridge.hh
+++ b/src/monodroid/jni/osbridge.hh
@@ -5,7 +5,7 @@
 #include <jni.h>
 #include <mono/metadata/sgen-bridge.h>
 
-namespace xamarin { namespace android { namespace internal
+namespace xamarin::android::internal
 {
 	class OSBridge
 	{
@@ -171,5 +171,5 @@ namespace xamarin { namespace android { namespace internal
 		jmethodID ArrayList_add;
 		jmethodID GCUserPeer_ctor;
 	};
-}}}
+}
 #endif // !__OS_BRIDGE_H

--- a/src/monodroid/jni/util.cc
+++ b/src/monodroid/jni/util.cc
@@ -213,7 +213,7 @@ Util::monodroid_get_namespaced_system_property (const char *name, char **value)
 	if (value)
 		*value = nullptr;
 
-	if (strlen (package_property_suffix) > 0) {
+	if (package_property_suffix[0] != '\0') {
 		log_info (LOG_DEFAULT, "Trying to get property %s.%s", name, package_property_suffix);
 		char *propname;
 #if WINDOWS
@@ -229,11 +229,11 @@ Util::monodroid_get_namespaced_system_property (const char *name, char **value)
 #endif
 	}
 
-	if (result <= 0 || !local_value)
+	if (result <= 0 || local_value == nullptr)
 		result = androidSystem.monodroid_get_system_property (name, &local_value);
 
 	if (result > 0) {
-		if (strlen (local_value) == 0) {
+		if (local_value != nullptr && local_value[0] == '\0') {
 			delete[] local_value;
 			return 0;
 		}

--- a/src/monodroid/jni/util.hh
+++ b/src/monodroid/jni/util.hh
@@ -60,7 +60,7 @@ extern "C" {
 #ifdef __cplusplus
 }
 
-namespace xamarin { namespace android
+namespace xamarin::android
 {
 	struct timing_point
 	{
@@ -139,6 +139,6 @@ namespace xamarin { namespace android
 	private:
 		char package_property_suffix[9];
 	};
-} }
+}
 #endif // __cplusplus
 #endif /* __MONODROID_UTIL_H__ */


### PR DESCRIPTION
A small cleanup which deals with a handful of remaining warnings after enable
more extensive diagnostics in our compilers.

Deal with `read(2)` definition differences between Android+Unix compilers and
MinGW (on *nix the third argument, `count`, is defined to be of type `size_t`
while on MinGW it's `unsigned int` which caused an integer conversion warning
when building for Windows)

Take advantage of the C++17 `if constexpr ()` construct (works similar to the
preprocessor `#if{n}def` but is part of the language standard and is type-safe)
as well as the more compact (and less of an eyesore) namespace declaration,
instead of:

```cpp
namespace xamarin { namespace android { namespace internal
```
we can now use

```cpp
namespace xamarin::android::internal
```

C++17 allows one to declare and define certain static `constexpr` members
directly in the header file, without the need to add the definition of such
member in a source file somewhere. Take advantage of that.