### PR TITLE
Bump to xamarin/monodroid/d16-4@6f1e0752

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:d16-4@60d4bd47cd90744535d7040a4726241a6b04a467
+xamarin/monodroid:d16-4@6f1e0752acdd8ffd250793b84a9c8bc99fa642c8
 mono/mono:2019-06@2c3aeaf3780de7392a0d3cbe4dcf86846eb4dffa


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/60d4bd47cd90744535d7040a4726241a6b04a467...6f1e0752acdd8ffd250793b84a9c8bc99fa642c8

	$ git diff --shortstat 60d4bd47..6f1e0752
	 3 files changed, 9 insertions(+), 2 deletions(-)

Changes: https://github.com/xamarin/androidtools/compare/8bda6e8184999c85100f710b37452c45f925d6d7...47d0bcb5df91b8f29c1ff36675b481e1b543f1de

Fixes the random XA5300 error seen on our CI builds!