### PR TITLE
Bump to xamarin/monodroid/master@8cd2639e

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@623845d44abe5eb7a76d9a63d48b30a27ac1bac2
+xamarin/monodroid:master@8cd2639e7c396f4e5ee8816dccdb2db5fe523023
 mono/mono:2019-08@c99adb97edc6a57d934105d5c13506518134b585

--- a/Documentation/release-notes/master.md
+++ b/Documentation/release-notes/master.md
@@ -17,6 +17,16 @@ Description of new feature
 
   * Description of known issue in the new feature, if applicable
 
+### Build and deployment performance
+
+  * When **Use Fast Deployment** is enabled, cache some of the information
+    that is retrieved from the device during the first deployment so that it can
+    be reused on subsequent deployments of the same app until Visual Studio is
+    restarted.  This reduced the time for the `InstallPackageAssemblies` task
+    during the second deployment of Xamarin.Forms app where one line of a XAML
+    file was changed from about 500 milliseconds to about 375 milliseconds in a
+    test environment.
+
 ### Static/Default Interface Methods (Preview)
 
 With the new support for default interface methods in C# 8.0 we can now produce bindings that better match Java libraries 


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/623845d44abe5eb7a76d9a63d48b30a27ac1bac2...8cd2639e7c396f4e5ee8816dccdb2db5fe523023

	$ git diff --shortstat 623845d4..8cd2639e
	 13 files changed, 178 insertions(+), 38 deletions(-)

Bring in changes to the commercial `InstallPackageAssemblies` task to
cache the `AndroidDeploySession` in MSBuild's AppDomain for reuse across
repeated fast deployments.