### PR TITLE
[ci] Add integrated regression test jobs

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -528,34 +528,17 @@ stages:
         artifactName: $(TestAssembliesArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
-    - script: >
-        mono packages/NUnit.ConsoleRunner.$(NUnitConsoleVersion)/tools/nunit3-console.exe
-        $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.dll
-        --result TestResult-MSBuildTests-$(XA.Build.Configuration).xml
-      displayName: run Xamarin.Android.Build.Tests
+    - template: yaml-templates/run-nunit-tests.yaml
+      parameters:
+        testRunTitle: Xamarin.Android.Build.Tests - Mac
+        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.dll
+        testResultsFile: TestResult-MSBuildTests-$(XA.Build.Configuration).xml
 
-    - task: PublishTestResults@2
-      displayName: publish test results
-      inputs:
-        testResultsFormat: NUnit
-        testResultsFiles: TestResult-MSBuildTests-$(XA.Build.Configuration).xml
-        testRunTitle: MSBuildTestsMac
-      condition: succeededOrFailed()
-
-    - script: >
-        mono packages/NUnit.ConsoleRunner.$(NUnitConsoleVersion)/tools/nunit3-console.exe
-        $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.Commercial.dll
-        --result TestResult-MSBuildTestsCommercial-$(XA.Build.Configuration).xml
-      displayName: run Xamarin.Android.Build.Tests.Commercial
-      condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
-
-    - task: PublishTestResults@2
-      displayName: publish test results
-      inputs:
-        testResultsFormat: NUnit
-        testResultsFiles: TestResult-MSBuildTestsCommercial-$(XA.Build.Configuration).xml
-        testRunTitle: MSBuildTestsMac
-      condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
+    - template: yaml-templates/run-nunit-tests.yaml
+      parameters:
+        testRunTitle: Xamarin.Android.Build.Tests.Commercial - Mac
+        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.Commercial.dll
+        testResultsFile: TestResult-MSBuildTestsCommercial-$(XA.Build.Configuration).xml
 
     - template: yaml-templates/upload-results.yaml
       parameters:
@@ -585,36 +568,19 @@ stages:
         msbuildArguments: >
           /t:AcquireAndroidTarget /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/start-emulator.binlog
 
-    - script: >
-        mono packages/NUnit.ConsoleRunner.$(NUnitConsoleVersion)/tools/nunit3-console.exe
-        $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.dll
-        --where "cat == UsesDevice"
-        --result TestResult-MSBuildDeviceTests-$(XA.Build.Configuration).xml
-      displayName: run on-device Xamarin.Android.Build.Tests
+    - template: yaml-templates/run-nunit-tests.yaml
+      parameters:
+        testRunTitle: Xamarin.Android.Build.Tests On Device - Mac
+        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.dll
+        nunitConsoleExtraArgs: --where "cat == UsesDevice"
+        testResultsFile: TestResult-MSBuildDeviceTests-$(XA.Build.Configuration).xml
 
-    - task: PublishTestResults@2
-      displayName: publish test results
-      inputs:
-        testResultsFormat: NUnit
-        testResultsFiles: TestResult-MSBuildDeviceTests-$(XA.Build.Configuration).xml
-        testRunTitle: MSBuildDeviceTestsMac
-      condition: always()
-
-    - script: >
-        mono packages/NUnit.ConsoleRunner.$(NUnitConsoleVersion)/tools/nunit3-console.exe
-        $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll
-        --where "test != Xamarin.Android.Build.Tests.DeploymentTest.CheckTimeZoneInfoIsCorrect"
-        --result TestResult-MSBuildDeviceIntegration-$(XA.Build.Configuration).xml
-      displayName: run on-device MSBuildDeviceIntegration tests
-      condition: succeededOrFailed()
-
-    - task: PublishTestResults@2
-      displayName: publish test results
-      inputs:
-        testResultsFormat: NUnit
-        testResultsFiles: TestResult-MSBuildDeviceIntegration-$(XA.Build.Configuration).xml
-        testRunTitle: MSBuildDeviceIntegration
-      condition: always()
+    - template: yaml-templates/run-nunit-tests.yaml
+      parameters:
+        testRunTitle: MSBuildDeviceIntegration On Device - Mac
+        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll
+        nunitConsoleExtraArgs: --where "test != Xamarin.Android.Build.Tests.DeploymentTest.CheckTimeZoneInfoIsCorrect"
+        testResultsFile: TestResult-MSBuildDeviceIntegration-$(XA.Build.Configuration).xml
 
     - task: MSBuild@1
       displayName: shut down emulator
@@ -654,20 +620,12 @@ stages:
         msbuildArguments: >
           /t:AcquireAndroidTarget /bl:$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/start-emulator.binlog
 
-    - script: >
-        mono packages/NUnit.ConsoleRunner.$(NUnitConsoleVersion)/tools/nunit3-console.exe
-        $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll
-        --where "test == Xamarin.Android.Build.Tests.DeploymentTest.CheckTimeZoneInfoIsCorrect"
-        --result TestResult-TimeZoneInfoTests-$(XA.Build.Configuration).xml
-      displayName: run TimeZoneInfo tests
-
-    - task: PublishTestResults@2
-      displayName: publish test results
-      inputs:
-        testResultsFormat: NUnit
-        testResultsFiles: TestResult-TimeZoneInfoTests-$(XA.Build.Configuration).xml
-        testRunTitle: TimeZoneInfoTestsMac
-      condition: always()
+    - template: yaml-templates/run-nunit-tests.yaml
+      parameters:
+        testRunTitle: TimeZoneInfoTests On Device - Mac
+        testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll
+        nunitConsoleExtraArgs: --where "test == Xamarin.Android.Build.Tests.DeploymentTest.CheckTimeZoneInfoIsCorrect"
+        testResultsFile: TestResult-TimeZoneInfoTests-$(XA.Build.Configuration).xml
 
     - task: MSBuild@1
       displayName: shut down emulator
@@ -754,3 +712,37 @@ stages:
     - template: designer\android-designer-tests.yaml@yaml
       parameters:
         designerSourcePath: $(System.DefaultWorkingDirectory)\designer
+
+  # Check - "Xamarin.Android (Test Integrated Regression Mac)"
+  - job: integrated_regression_mac
+    displayName: Integrated Regression Mac
+    pool:
+      name: VSEng-Xamarin-Mac-Devices
+      demands:
+      - android
+    timeoutInMinutes: 240
+    cancelTimeoutInMinutes: 5
+    workspace:
+      clean: all
+    steps:
+    - template: yaml-templates/run-integrated-regression-tests.yaml
+
+  # Check - "Xamarin.Android (Test Integrated Regression Windows)"
+  - job: integrated_regression_Win
+    displayName: Integrated Regression Windows
+    pool:
+      name: VSEng-Xamarin-Win-XMA
+      demands:
+      - android
+    timeoutInMinutes: 240
+    cancelTimeoutInMinutes: 5
+    workspace:
+      clean: all
+    variables:
+      XQA_VISUALSTUDIO_LOCATION: '%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise'
+    steps:
+    - template: remove-visualstudio.yml@yaml
+
+    - template: yaml-templates\run-integrated-regression-tests.yaml
+
+    - template: remove-visualstudio.yml@yaml

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -305,7 +305,7 @@ stages:
 
 - stage: test
   displayName: Test
-  dependsOn: []
+  dependsOn: mac_build
   jobs:
   # Check - "Xamarin.Android (Test APK Instrumentation)"
   - job: mac_apk_tests
@@ -722,6 +722,7 @@ stages:
       - android
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
+    condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
     workspace:
       clean: all
     steps:
@@ -736,6 +737,7 @@ stages:
       - android
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
+    condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
     workspace:
       clean: all
     variables:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -702,8 +702,6 @@ stages:
         provisioning_extra_args: -vv
 
     - template: yaml-templates\run-installer.yaml
-      parameters:
-        itemPattern: "*.vsix"
 
     - template: designer\android-designer-build-win.yaml@yaml
       parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -722,7 +722,7 @@ stages:
       - android
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
-    condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
+    condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
     workspace:
       clean: all
     steps:
@@ -737,7 +737,7 @@ stages:
       - android
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
-    condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
+    condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
     workspace:
       clean: all
     variables:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -305,7 +305,7 @@ stages:
 
 - stage: test
   displayName: Test
-  dependsOn: mac_build
+  dependsOn: []
   jobs:
   # Check - "Xamarin.Android (Test APK Instrumentation)"
   - job: mac_apk_tests

--- a/build-tools/automation/yaml-templates/mac/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/mac/setup-test-environment.yaml
@@ -34,4 +34,3 @@ steps:
     solution: build-tools/xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
     configuration: ${{ parameters.configuration }}
     msbuildArguments: /bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/BootstrapTasks.binlog
-

--- a/build-tools/automation/yaml-templates/run-installer.yaml
+++ b/build-tools/automation/yaml-templates/run-installer.yaml
@@ -1,16 +1,16 @@
-parameters:
-  itemPattern: "*.pkg"
-
 steps:
-- task: DownloadPipelineArtifact@1
+- task: DownloadPipelineArtifact@2
   inputs:
     artifactName: $(InstallerArtifactName)
-    itemPattern: ${{ parameters.itemPattern }}
     downloadPath: $(System.DefaultWorkingDirectory)
 
 - powershell: |
+    $itemPattern = "*.vsix"
+    if ([Environment]::OSVersion.Platform -eq "Unix") {
+        $itemPattern = "*.pkg"
+    }
     $searchDir = [System.IO.Path]::Combine("$(System.DefaultWorkingDirectory)", "*")
-    $installer = Get-ChildItem -Path "$searchDir" -Include "${{ parameters.itemPattern }}" -File
+    $installer = Get-ChildItem -Path "$searchDir" -Include "$itemPattern" -File
     if (![System.IO.File]::Exists($installer)) {
         throw [System.IO.FileNotFoundException] "Installer not found in $artifactDirectory."
     }

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -34,22 +34,7 @@ steps:
   displayName: install mono
   condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
 
-#- template: run-installer.yaml
-- task: xamops.azdevex.provisionator-task.provisionator@2
-  displayName: TEST - Provision XA Master Mac
-  inputs:
-    github_token: $(GitHub.Token)
-    provisioning_script: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/3036028/master/c08c77197eea74355ee834a3d93b86dd140dd163/xamarin.android-10.0.99.108.pkg
-    provisioning_extra_args: -vv
-  condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
-
-- task: xamops.azdevex.provisionator-task.provisionator@2
-  displayName: TEST - Provision XA Master Win
-  inputs:
-    github_token: $(GitHub.Token)
-    provisioning_script: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/3036028/master/c08c77197eea74355ee834a3d93b86dd140dd163/signed/Xamarin.Android.Sdk-10.0.99.108.vsix
-    provisioning_extra_args: -vv
-  condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
+- template: run-installer.yaml
 
 - powershell: |   
     if ([Environment]::OSVersion.Platform -eq "Unix") {

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -1,11 +1,7 @@
-parameters:
-  xqaConfiguration: Debug
-
 steps:
 - task: xamops.azdevex.lingering-process-task.lingering-process-task@1
 
 - script: |
-    git clone -q https://github.com/xamarin/xamarin-android.git
     git clone -q https://github.com/xamarin/monodroid-samples.git
     git clone -q https://github.com/xamarin/xamarin-forms-samples.git
     git clone -q https://$(GitHub.Token)@github.com/xamarin/QualityAssurance.git
@@ -13,33 +9,30 @@ steps:
     git checkout xa-smoke-test-prs
   displayName: clone test dependencies
 
+- task: DownloadBuildArtifacts@0
+  inputs:
+    buildType: specific
+    project: 0bdbc590-a062-4c3f-b0f6-9383f67865ee
+    pipeline: 'XQA.sln'
+    buildVersionToDownload: latestFromBranch
+    branchName: refs/heads/xa-smoke-test-prs
+    downloadType: specific
+    itemPattern: |
+      XQA.Android/**
+      provisionator/**
+      NUnit.ConsoleRunner/**
+    downloadPath: $(System.DefaultWorkingDirectory)
+
 - task: xamops.azdevex.provisionator-task.provisionator@2
   displayName: Provision Android Dependencies
   inputs:
     github_token: $(GitHub.Token)
-    provisioning_script: $(System.DefaultWorkingDirectory)/QualityAssurance/Scripts/Provisionator/xamarin-android.csx
-    provisioning_extra_args: -vv DEVDIV_PACKAGES_TOKEN=$(VSTS.PackageAndCIBuilds.A)
+    provisioning_script: $(System.DefaultWorkingDirectory)/provisionator/xamarin-android.csx
+    provisioning_extra_args: -vv
 
 - script: make prepare-update-mono V=1 PREPARE_CI=1 PREPARE_AUTOPROVISION=1
   displayName: install mono
   condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
-
-- task: NuGetCommand@2
-  displayName: nuget restore Xamarin.Android.sln
-  inputs:
-    restoreSolution: Xamarin.Android.sln
-
-# Workaround Azure Pipeline NuGet credential provider issue
-- task: NuGetAuthenticate@0
-- task: NuGetToolInstaller@1
-- script: nuget restore $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.sln -NonInteractive
-  displayName: nuget restore XQA.sln
-
-- task: MSBuild@1
-  displayName: msbuild XQA.sln
-  inputs:
-    solution: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.sln
-    configuration: ${{ parameters.xqaConfiguration }}
 
 #- template: run-installer.yaml
 - task: xamops.azdevex.provisionator-task.provisionator@2
@@ -60,9 +53,9 @@ steps:
 
 - powershell: |   
     if ([Environment]::OSVersion.Platform -eq "Unix") {
-       mono $(System.DefaultWorkingDirectory)/packages/NUnit.ConsoleRunner.$(NUnitConsoleVersion)/tools/nunit3-console.exe $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll --where "cat == XAUnitTestSetup || cat == XATestPrep || cat == EnvironmentInfo"
+       mono $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll --where "cat == XAUnitTestSetup || cat == XATestPrep || cat == EnvironmentInfo"
     } else {
-       $(System.DefaultWorkingDirectory)\packages\NUnit.ConsoleRunner.$(NUnitConsoleVersion)\tools\nunit3-console.exe $(System.DefaultWorkingDirectory)\QualityAssurance\Automation\XQA\XQA.Android\bin\${{ parameters.xqaConfiguration }}\XQA.Android.dll --where "cat == XAUnitTestSetup || cat == XATestPrep || cat == EnvironmentInfo"
+       $(System.DefaultWorkingDirectory)\NUnit.ConsoleRunner\tools\nunit3-console.exe $(System.DefaultWorkingDirectory)\XQA.Android\XQA.Android.dll --where "cat == XAUnitTestSetup || cat == XATestPrep || cat == EnvironmentInfo"
     }
   displayName: Test Environment Setup
   condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
@@ -71,129 +64,150 @@ steps:
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Mono.Android-Tests Debug on Device
     nunitConsoleExtraArgs: --where "cat == RuntimeTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Hello Tests on Device
     nunitConsoleExtraArgs: --where "cat == Hello"
     condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Smoke Tests on Device
     nunitConsoleExtraArgs: --where "cat == RegressionDeviceTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Smoke Tests
     nunitConsoleExtraArgs: --where "cat == RegressionTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Installer Tests
     nunitConsoleExtraArgs: --where "cat == InstallationTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Fast Deploy Tests
     nunitConsoleExtraArgs: --where "cat == FastDevTests"
     condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Debug Tests
     nunitConsoleExtraArgs: --where "cat == DebuggerTests"
     condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Incremental Build Tests
     nunitConsoleExtraArgs: --where "cat == BuildPerformance"
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: AOT Tests
     nunitConsoleExtraArgs: --where "cat == AotSupport"
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Linker Tests
     nunitConsoleExtraArgs: --where "cat == LinkerTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Wearable Tests
     nunitConsoleExtraArgs: --where "cat == Wearable"
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Proguard Tests
     nunitConsoleExtraArgs: --where "cat == Proguard"
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Multidex Tests
     nunitConsoleExtraArgs: --where "cat == Multidex"
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: ExplicitCrunch Tests
     nunitConsoleExtraArgs: --where "cat == ExplicitCrunch"
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: TargetFrameworkVersion Tests
     nunitConsoleExtraArgs: --where "cat == TargetFrameworkTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Resource Cache Tests
     nunitConsoleExtraArgs: --where "cat == ResourceCacheTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Property Cache Tests
     nunitConsoleExtraArgs: --where "cat == PropertyCacheTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Code Analysis Tests
     nunitConsoleExtraArgs: --where "cat == CodeAnalysisTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Networking Options Tests
     nunitConsoleExtraArgs: --where "cat == HttpClientAndTlsProviderPackageTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: AndroidApiInfo Tests
     nunitConsoleExtraArgs: --where "cat == AndroidApiInfoTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Test Environment Cleanup
     nunitConsoleExtraArgs: --where "cat == XATestCleanUp"

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -5,8 +5,6 @@ steps:
     git clone -q https://github.com/xamarin/monodroid-samples.git
     git clone -q https://github.com/xamarin/xamarin-forms-samples.git
     git clone -q https://$(GitHub.Token)@github.com/xamarin/QualityAssurance.git
-    cd QualityAssurance
-    git checkout xa-smoke-test-prs
   displayName: clone test dependencies
 
 - task: DownloadBuildArtifacts@0
@@ -15,7 +13,7 @@ steps:
     project: 0bdbc590-a062-4c3f-b0f6-9383f67865ee
     pipeline: 'XQA.sln'
     buildVersionToDownload: latestFromBranch
-    branchName: refs/heads/xa-smoke-test-prs
+    branchName: refs/heads/master
     downloadType: specific
     itemPattern: |
       XQA.Android/**

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -1,0 +1,198 @@
+steps:
+- task: xamops.azdevex.lingering-process-task.lingering-process-task@1
+
+- script: |
+    git clone -q https://github.com/xamarin/xamarin-android.git
+    git clone -q https://github.com/xamarin/monodroid-samples.git
+    git clone -q https://github.com/xamarin/xamarin-forms-samples.git
+  displayName: clone test dependencies
+
+- script: |
+    git clone -q https://$(GitHub.Token)@github.com/xamarin/QualityAssurance.git
+    cd QualityAssurance
+    git checkout xa-smoke-test-prs
+  displayName: clone QualityAssurance
+
+- task: DownloadBuildArtifacts@0
+  inputs:
+    buildType: specific
+    project: '0bdbc590-a062-4c3f-b0f6-9383f67865ee'
+    pipeline: 7013
+    buildVersionToDownload: latestFromBranch
+    branchName: 'refs/heads/xa-smoke-test-prs'
+    downloadType: specific
+    itemPattern: |
+      XQA.Android/**
+      provisionator/**
+      NUnit.ConsoleRunner/**
+    downloadPath: $(System.DefaultWorkingDirectory)
+
+- task: xamops.azdevex.provisionator-task.provisionator@2
+  displayName: Provision Android Dependencies
+  inputs:
+    github_token: $(GitHub.Token)
+    provisioning_script: $(System.DefaultWorkingDirectory)/provisionator/xamarin-android.csx
+    provisioning_extra_args: -vv
+
+- template: run-installer.yaml
+
+- powershell: |   
+    if ([Environment]::OSVersion.Platform -eq "Unix") {
+       mono $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll --where "cat == XAUnitTestSetup || cat == XATestPrep || cat == EnvironmentInfo"
+    } else {
+       $(System.DefaultWorkingDirectory)\NUnit.ConsoleRunner\tools\nunit3-console.exe $(System.DefaultWorkingDirectory)\XQA.Android\XQA.Android.dll --where "cat == XAUnitTestSetup || cat == XATestPrep || cat == EnvironmentInfo"
+    }
+  displayName: Test Environment Setup
+  condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
+  env:
+    GH_AUTH_SECRET: $(Github.Token)
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Mono.Android-Tests Debug on Device
+    nunitConsoleExtraArgs: --where "cat == RuntimeTests"
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Hello Tests on Device
+    nunitConsoleExtraArgs: --where "cat == Hello"
+    condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Smoke Tests on Device
+    nunitConsoleExtraArgs: --where "cat == RegressionDeviceTests"
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Smoke Tests
+    nunitConsoleExtraArgs: --where "cat == RegressionTests"
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Installer Tests
+    nunitConsoleExtraArgs: --where "cat == InstallationTests"
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Fast Deploy Tests
+    nunitConsoleExtraArgs: --where "cat == FastDevTests"
+    condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Debug Tests
+    nunitConsoleExtraArgs: --where "cat == DebuggerTests"
+    condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Incremental Build Tests
+    nunitConsoleExtraArgs: --where "cat == BuildPerformance"
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: AOT Tests
+    nunitConsoleExtraArgs: --where "cat == AotSupport"
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Linker Tests
+    nunitConsoleExtraArgs: --where "cat == LinkerTests"
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Wearable Tests
+    nunitConsoleExtraArgs: --where "cat == Wearable"
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Proguard Tests
+    nunitConsoleExtraArgs: --where "cat == Proguard"
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Multidex Tests
+    nunitConsoleExtraArgs: --where "cat == Multidex"
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: ExplicitCrunch Tests
+    nunitConsoleExtraArgs: --where "cat == ExplicitCrunch"
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: TargetFrameworkVersion Tests
+    nunitConsoleExtraArgs: --where "cat == TargetFrameworkTests"
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Resource Cache Tests
+    nunitConsoleExtraArgs: --where "cat == ResourceCacheTests"
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Property Cache Tests
+    nunitConsoleExtraArgs: --where "cat == PropertyCacheTests"
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Code Analysis Tests
+    nunitConsoleExtraArgs: --where "cat == CodeAnalysisTests"
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Networking Options Tests
+    nunitConsoleExtraArgs: --where "cat == HttpClientAndTlsProviderPackageTests"
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: AndroidApiInfo Tests
+    nunitConsoleExtraArgs: --where "cat == AndroidApiInfoTests"
+
+- template: run-nunit-tests.yaml
+  parameters:
+    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testRunTitle: Test Environment Cleanup
+    nunitConsoleExtraArgs: --where "cat == XATestCleanUp"

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -1,3 +1,6 @@
+parameters:
+  xqaConfiguration: Debug
+
 steps:
 - task: xamops.azdevex.lingering-process-task.lingering-process-task@1
 
@@ -5,42 +8,61 @@ steps:
     git clone -q https://github.com/xamarin/xamarin-android.git
     git clone -q https://github.com/xamarin/monodroid-samples.git
     git clone -q https://github.com/xamarin/xamarin-forms-samples.git
-  displayName: clone test dependencies
-
-- script: |
     git clone -q https://$(GitHub.Token)@github.com/xamarin/QualityAssurance.git
     cd QualityAssurance
     git checkout xa-smoke-test-prs
-  displayName: clone QualityAssurance
-
-- task: DownloadBuildArtifacts@0
-  inputs:
-    buildType: specific
-    project: '0bdbc590-a062-4c3f-b0f6-9383f67865ee'
-    pipeline: 7013
-    buildVersionToDownload: latestFromBranch
-    branchName: 'refs/heads/xa-smoke-test-prs'
-    downloadType: specific
-    itemPattern: |
-      XQA.Android/**
-      provisionator/**
-      NUnit.ConsoleRunner/**
-    downloadPath: $(System.DefaultWorkingDirectory)
+  displayName: clone test dependencies
 
 - task: xamops.azdevex.provisionator-task.provisionator@2
   displayName: Provision Android Dependencies
   inputs:
     github_token: $(GitHub.Token)
-    provisioning_script: $(System.DefaultWorkingDirectory)/provisionator/xamarin-android.csx
-    provisioning_extra_args: -vv
+    provisioning_script: $(System.DefaultWorkingDirectory)/QualityAssurance/Scripts/Provisionator/xamarin-android.csx
+    provisioning_extra_args: -vv DEVDIV_PACKAGES_TOKEN=$(VSTS.PackageAndCIBuilds.A)
 
-- template: run-installer.yaml
+- script: make prepare-update-mono V=1 PREPARE_CI=1 PREPARE_AUTOPROVISION=1
+  displayName: install mono
+  condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
+
+- task: NuGetCommand@2
+  displayName: nuget restore Xamarin.Android.sln
+  inputs:
+    restoreSolution: Xamarin.Android.sln
+
+# Workaround Azure Pipeline NuGet credential provider issue
+- task: NuGetAuthenticate@0
+- task: NuGetToolInstaller@1
+- script: nuget restore $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.sln -NonInteractive
+  displayName: nuget restore XQA.sln
+
+- task: MSBuild@1
+  displayName: msbuild XQA.sln
+  inputs:
+    solution: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.sln
+    configuration: ${{ parameters.xqaConfiguration }}
+
+#- template: run-installer.yaml
+- task: xamops.azdevex.provisionator-task.provisionator@2
+  displayName: TEST - Provision XA Master Mac
+  inputs:
+    github_token: $(GitHub.Token)
+    provisioning_script: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/3036028/master/c08c77197eea74355ee834a3d93b86dd140dd163/xamarin.android-10.0.99.108.pkg
+    provisioning_extra_args: -vv
+  condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
+
+- task: xamops.azdevex.provisionator-task.provisionator@2
+  displayName: TEST - Provision XA Master Win
+  inputs:
+    github_token: $(GitHub.Token)
+    provisioning_script: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/3036028/master/c08c77197eea74355ee834a3d93b86dd140dd163/signed/Xamarin.Android.Sdk-10.0.99.108.vsix
+    provisioning_extra_args: -vv
+  condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 
 - powershell: |   
     if ([Environment]::OSVersion.Platform -eq "Unix") {
-       mono $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll --where "cat == XAUnitTestSetup || cat == XATestPrep || cat == EnvironmentInfo"
+       mono $(System.DefaultWorkingDirectory)/packages/NUnit.ConsoleRunner.$(NUnitConsoleVersion)/tools/nunit3-console.exe $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll --where "cat == XAUnitTestSetup || cat == XATestPrep || cat == EnvironmentInfo"
     } else {
-       $(System.DefaultWorkingDirectory)\NUnit.ConsoleRunner\tools\nunit3-console.exe $(System.DefaultWorkingDirectory)\XQA.Android\XQA.Android.dll --where "cat == XAUnitTestSetup || cat == XATestPrep || cat == EnvironmentInfo"
+       $(System.DefaultWorkingDirectory)\packages\NUnit.ConsoleRunner.$(NUnitConsoleVersion)\tools\nunit3-console.exe $(System.DefaultWorkingDirectory)\QualityAssurance\Automation\XQA\XQA.Android\bin\${{ parameters.xqaConfiguration }}\XQA.Android.dll --where "cat == XAUnitTestSetup || cat == XATestPrep || cat == EnvironmentInfo"
     }
   displayName: Test Environment Setup
   condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
@@ -49,150 +71,129 @@ steps:
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: Mono.Android-Tests Debug on Device
     nunitConsoleExtraArgs: --where "cat == RuntimeTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: Hello Tests on Device
     nunitConsoleExtraArgs: --where "cat == Hello"
     condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: Smoke Tests on Device
     nunitConsoleExtraArgs: --where "cat == RegressionDeviceTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: Smoke Tests
     nunitConsoleExtraArgs: --where "cat == RegressionTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: Installer Tests
     nunitConsoleExtraArgs: --where "cat == InstallationTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: Fast Deploy Tests
     nunitConsoleExtraArgs: --where "cat == FastDevTests"
     condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: Debug Tests
     nunitConsoleExtraArgs: --where "cat == DebuggerTests"
     condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: Incremental Build Tests
     nunitConsoleExtraArgs: --where "cat == BuildPerformance"
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: AOT Tests
     nunitConsoleExtraArgs: --where "cat == AotSupport"
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: Linker Tests
     nunitConsoleExtraArgs: --where "cat == LinkerTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: Wearable Tests
     nunitConsoleExtraArgs: --where "cat == Wearable"
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: Proguard Tests
     nunitConsoleExtraArgs: --where "cat == Proguard"
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: Multidex Tests
     nunitConsoleExtraArgs: --where "cat == Multidex"
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: ExplicitCrunch Tests
     nunitConsoleExtraArgs: --where "cat == ExplicitCrunch"
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: TargetFrameworkVersion Tests
     nunitConsoleExtraArgs: --where "cat == TargetFrameworkTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: Resource Cache Tests
     nunitConsoleExtraArgs: --where "cat == ResourceCacheTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: Property Cache Tests
     nunitConsoleExtraArgs: --where "cat == PropertyCacheTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: Code Analysis Tests
     nunitConsoleExtraArgs: --where "cat == CodeAnalysisTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: Networking Options Tests
     nunitConsoleExtraArgs: --where "cat == HttpClientAndTlsProviderPackageTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: AndroidApiInfo Tests
     nunitConsoleExtraArgs: --where "cat == AndroidApiInfoTests"
 
 - template: run-nunit-tests.yaml
   parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+    testAssembly: $(System.DefaultWorkingDirectory)/QualityAssurance/Automation/XQA/XQA.Android/bin/${{ parameters.xqaConfiguration }}/XQA.Android.dll
     testRunTitle: Test Environment Cleanup
     nunitConsoleExtraArgs: --where "cat == XATestCleanUp"

--- a/build-tools/automation/yaml-templates/run-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-nunit-tests.yaml
@@ -1,0 +1,25 @@
+parameters:
+  nunitConsole: packages/NUnit.ConsoleRunner.$(NUnitConsoleVersion)/tools/nunit3-console.exe
+  testRunTitle: Xamarin Android Tests
+  testAssembly: []
+  testResultsFile: TestResult.xml
+  testResultsFormat: NUnit
+  nunitConsoleExtraArgs: ''
+  condition: succeededOrFailed()
+
+steps:
+- powershell: |
+    if ([Environment]::OSVersion.Platform -eq "Unix") {
+        mono ${{ parameters.nunitConsole }} ${{ parameters.testAssembly }} ${{ parameters.whereClause }} --result ${{ parameters.testResultsFile }} ${{ parameters.nunitConsoleExtraArgs }}
+    } else {
+        ${{ parameters.nunitConsole }} ${{ parameters.testAssembly }} ${{ parameters.whereClause }} --result ${{ parameters.testResultsFile }}  ${{ parameters.nunitConsoleExtraArgs }}
+    }
+  displayName: run ${{ parameters.testRunTitle }}
+  condition: ${{ parameters.condition }}
+
+- task: PublishTestResults@2
+  inputs:
+    testResultsFormat: ${{ parameters.testResultsFormat }}
+    testResultsFiles: ${{ parameters.testResultsFile }}
+    testRunTitle: ${{ parameters.testRunTitle }}
+  condition: ${{ parameters.condition }}


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_release?_a=releases&view=mine&definitionId=476

Adds two new "integrated regression test" jobs to Azure Pipelines to run
additional external tests which were previously only ran and reviewed in
an ad-hoc manner.

Permission issues with PR builds from forks are currently preventing us
from running these jobs against such builds, so we'll only run against
manually triggered or regular CI builds instead.
