### PR TITLE
[Xamarin.Android.Build.Tasks] Improve AAPT2 error granularity

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -131,7 +131,7 @@ namespace Xamarin.Android.Tasks {
 				// W/ResourceType(23681): For resource 0x0101053d, entry index(1341) is beyond type entryCount(733)
 				// W/ResourceType( 3681): For resource 0x0101053d, entry index(1341) is beyond type entryCount(733)
 				if (file.StartsWith ("W/", StringComparison.OrdinalIgnoreCase)) {
-					LogCodedWarning ("APT0000", singleLine);
+					LogCodedWarning (GetErrorCode (singleLine), singleLine);
 					return true;
 				}
 				if (message.StartsWith ("unknown option", StringComparison.OrdinalIgnoreCase)) {
@@ -148,7 +148,7 @@ namespace Xamarin.Android.Tasks {
 					return true;
 				}
 				if (message.Contains ("warn:")) {
-					LogCodedWarning ("APT0000", singleLine);
+					LogCodedWarning (GetErrorCode (singleLine), singleLine);
 					return true;
 				}
 				if (level.Contains ("note")) {
@@ -156,7 +156,7 @@ namespace Xamarin.Android.Tasks {
 					return true;
 				}
 				if (level.Contains ("warning")) {
-					LogCodedWarning ("APT0000", singleLine);
+					LogCodedWarning (GetErrorCode (singleLine), singleLine);
 					return true;
 				}
 
@@ -180,15 +180,16 @@ namespace Xamarin.Android.Tasks {
 					message = message.Substring ("error: ".Length);
 
 				if (level.Contains ("error") || (line != 0 && !string.IsNullOrEmpty (file))) {
-					LogCodedError ("APT0000", message, file, line);
+					LogCodedError (GetErrorCode (message), message, file, line);
 					return true;
 				}
 			}
 
 			if (!apptResult) {
-				LogCodedError ("APT0000", string.Format ("{0} \"{1}\".", singleLine.Trim (), singleLine.Substring (singleLine.LastIndexOfAny (new char [] { '\\', '/' }) + 1)), ToolName);
+				var message = string.Format ("{0} \"{1}\".", singleLine.Trim (), singleLine.Substring (singleLine.LastIndexOfAny (new char [] { '\\', '/' }) + 1));
+				LogCodedError (GetErrorCode (message), message, ToolName);
 			} else {
-				LogCodedWarning ("APT0000", singleLine);
+				LogCodedWarning (GetErrorCode (singleLine), singleLine);
 			}
 			return true;
 		}
@@ -197,5 +198,278 @@ namespace Xamarin.Android.Tasks {
 		{
 			resource_name_case_map = MonoAndroidHelper.LoadResourceCaseMap (ResourceNameCaseMap);
 		}
+
+		static string GetErrorCode (string message)
+		{
+			foreach (var tuple in error_codes)
+				if (message.IndexOf (tuple.Item2, StringComparison.OrdinalIgnoreCase) >= 0)
+					return tuple.Item1;
+
+			return "APT2000";
+		}
+
+		static readonly List<Tuple<string, string>> error_codes = new List<Tuple<string, string>> () {
+			Tuple.Create ("APT2001", "already defined a <flag>"),
+			Tuple.Create ("APT2002", "already defined an <enum>"),
+			Tuple.Create ("APT2003", "can't map package ID"),
+			Tuple.Create ("APT2004", "android:name in <uses-feature> must not be empty"),
+			Tuple.Create ("APT2005", "android-sdk is missing minSdkVersion attribute"),
+			Tuple.Create ("APT2006", "Artifact does not have a name and no global name template defined"),
+			Tuple.Create ("APT2007", "Asked to print artifacts without providing a configurations"),
+			Tuple.Create ("APT2008", "tag must be a valid Java class name"),
+			Tuple.Create ("APT2009", "tag must be a valid Java package name"),
+			Tuple.Create ("APT2010", "tag must not be empty"),
+			Tuple.Create ("APT2011", "attribute coreApp must be a boolean"),
+			Tuple.Create ("APT2012", "attribute 'featureSplit' used in <manifest> but 'android:isFeatureSplit"),
+			Tuple.Create ("APT2013", "attribute 'package' in <manifest> tag is not a valid Android package name"),
+			Tuple.Create ("APT2014", "attribute 'package' in <manifest> tag must not be a reference"),
+			Tuple.Create ("APT2015", "attribute 'split' in <manifest> tag is not a"),
+			Tuple.Create ("APT2016", "<attr> tag must have a 'name' attribute"),
+			Tuple.Create ("APT2017", "<bag> must have a 'type' attribute"),
+			Tuple.Create ("APT2018", "can not define a <flag>"),
+			Tuple.Create ("APT2019", "can not define an <enum>"),
+			Tuple.Create ("APT2020", "cannot define both android:name and android:glEsVersion"),
+			Tuple.Create ("APT2021", "cannot merge entry"),
+			Tuple.Create ("APT2022", "cannot merge type"),
+			Tuple.Create ("APT2023", "can't assign ID"),
+			Tuple.Create ("APT2024", "can't extract text into its own resource"),
+			Tuple.Create ("APT2025", "can't include static library when not building a static lib"),
+			Tuple.Create ("APT2026", "can't specify --package-id when not building a regular app"),
+			Tuple.Create ("APT2027", "target split ambiguous"),
+			Tuple.Create ("APT2028", "corrupt resources.arsc"),
+			Tuple.Create ("APT2029", "corrupt resource table"),
+			Tuple.Create ("APT2030", "corrupt ResTable_header chunk"),
+			Tuple.Create ("APT2031", "corrupt ResTable_package chunk"),
+			Tuple.Create ("APT2032", "corrupt ResTable_package"),
+			Tuple.Create ("APT2033", "corrupt ResTable_type chunk"),
+			Tuple.Create ("APT2034", "corrupt ResTable_typeSpec chunk"),
+			Tuple.Create ("APT2035", "Could not determine split APK artifact name"),
+			Tuple.Create ("APT2036", "Could not find the root element in the XML document"),
+			Tuple.Create ("APT2037", "could not identify format of APK"),
+			Tuple.Create ("APT2038", "Could not lookup required ABIs"),
+			Tuple.Create ("APT2039", "Could not lookup required Android SDK version"),
+			Tuple.Create ("APT2040", "Could not lookup required device features"),
+			Tuple.Create ("APT2041", "Could not lookup required locales"),
+			Tuple.Create ("APT2042", "Could not lookup required OpenGL texture formats"),
+			Tuple.Create ("APT2043", "Could not lookup required screen densities"),
+			Tuple.Create ("APT2044", "Could not parse ABI value"),
+			Tuple.Create ("APT2045", "could not parse array item"),
+			Tuple.Create ("APT2046", "Could not parse config descriptor for empty screen-density-group"),
+			Tuple.Create ("APT2047", "Could not parse config descriptor for screen-density"),
+			Tuple.Create ("APT2048", "Could not parse config file"),
+			Tuple.Create ("APT2049", "could not parse style item"),
+			Tuple.Create ("APT2050", "Could not process XML document"),
+			Tuple.Create ("APT2051", "could not update AndroidManifest.xml for output artifact"),
+			Tuple.Create ("APT2052", "could not validate post processing configuration"),
+			Tuple.Create ("APT2053", "for external package"),
+			Tuple.Create ("APT2054", "duplicate overlayable declaration for resource"),
+			Tuple.Create ("APT2055", "duplicate quantity"),
+			Tuple.Create ("APT2056", "duplicate symbol"),
+			Tuple.Create ("APT2057", "duplicate value for resource"),
+			Tuple.Create ("APT2058", "empty symbol"),
+			Tuple.Create ("APT2059", "failed assigning IDs"),
+			Tuple.Create ("APT2060", "failed deduping resources"),
+			Tuple.Create ("APT2061", "failed linking file resources"),
+			Tuple.Create ("APT2062", "failed linking references"),
+			Tuple.Create ("APT2063", "failed moving private attributes"),
+			Tuple.Create ("APT2064", "failed opening zip"),
+			Tuple.Create ("APT2065", "failed parsing input"),
+			Tuple.Create ("APT2066", "failed parsing overlays"),
+			Tuple.Create ("APT2067", "failed processing manifest"),
+			Tuple.Create ("APT2068", "failed reading png"),
+			Tuple.Create ("APT2069", "failed reading stable ID file"),
+			Tuple.Create ("APT2070", "failed removing resources with no defaults"),
+			Tuple.Create ("APT2071", "failed stripping products"),
+			Tuple.Create ("APT2072", "failed to allocate info ptr"),
+			Tuple.Create ("APT2073", "failed to allocate read ptr"),
+			Tuple.Create ("APT2074", "failed to allocate write info ptr"),
+			Tuple.Create ("APT2075", "failed to allocate write ptr"),
+			Tuple.Create ("APT2076", "failed to copy file"),
+			Tuple.Create ("APT2077", "failed to create archive"),
+			Tuple.Create ("APT2078", "failed to create directory"),
+			Tuple.Create ("APT2079", "failed to create libpng read png_info"),
+			Tuple.Create ("APT2080", "failed to create libpng read png_struct"),
+			Tuple.Create ("APT2081", "failed to create libpng write png_info"),
+			Tuple.Create ("APT2082", "failed to create libpng write png_struct"),
+			Tuple.Create ("APT2083", "failed to create Split AndroidManifest.xml"),
+			Tuple.Create ("APT2084", "failed to deserialize proto XML"),
+			Tuple.Create ("APT2085", "failed to deserialize proto"),
+			Tuple.Create ("APT2086", "failed to deserialize resource table"),
+			Tuple.Create ("APT2087", "failed to extract data from AndroidManifest.xml"),
+			Tuple.Create ("APT2088", "failed to find"),
+			Tuple.Create ("APT2089", "failed to finish entry"),
+			Tuple.Create ("APT2090", "failed to finish writing data"),
+			Tuple.Create ("APT2091", "failed to flatten resource table"),
+			Tuple.Create ("APT2092", "failed to load APK"),
+			Tuple.Create ("APT2093", "failed to load include path"),
+			Tuple.Create ("APT2094", "failed to merge resource table"),
+			Tuple.Create ("APT2095", "failed to mmap file"),
+			Tuple.Create ("APT2096", "failed to open APK"),
+			Tuple.Create ("APT2097", "failed to open directory"),
+			Tuple.Create ("APT2098", "failed to open file"),
+			Tuple.Create ("APT2099", "failed to open resources.arsc"),
+			Tuple.Create ("APT2100", "failed to open resources.pb"),
+			Tuple.Create ("APT2101", "failed to open"),
+			Tuple.Create ("APT2102", "failed to parse binary XML"),
+			Tuple.Create ("APT2103", "failed to parse binary"),
+			Tuple.Create ("APT2104", "failed to parse file as binary XML"),
+			Tuple.Create ("APT2105", "failed to parse file as proto XML"),
+			Tuple.Create ("APT2106", "failed to parse proto XML"),
+			Tuple.Create ("APT2107", "failed to parse table"),
+			Tuple.Create ("APT2108", "Failed to parse the output artifact list"),
+			Tuple.Create ("APT2109", "failed to parse value for resource"),
+			Tuple.Create ("APT2110", "failed to parse whitelist from config file"),
+			Tuple.Create ("APT2111", "failed to read compiled header"),
+			Tuple.Create ("APT2112", "failed to read proto"),
+			Tuple.Create ("APT2113", "failed to read"),
+			Tuple.Create ("APT2114", "Failed to rewrite"),
+			Tuple.Create ("APT2115", "failed to serialize AndroidManifest.xml"),
+			Tuple.Create ("APT2116", "failed to serialize file"),
+			Tuple.Create ("APT2117", "failed to serialize the resource table"),
+			Tuple.Create ("APT2118", "failed to serialize to binary XML"),
+			Tuple.Create ("APT2119", "failed to serialize to proto XML"),
+			Tuple.Create ("APT2120", "Failed to strip versioned resources"),
+			Tuple.Create ("APT2121", "failed to write entry data"),
+			Tuple.Create ("APT2122", "failed to write png"),
+			Tuple.Create ("APT2123", "failed to write resource table"),
+			Tuple.Create ("APT2124", "failed to write"),
+			Tuple.Create ("APT2125", "failed versioning styles"),
+			Tuple.Create ("APT2126", "file not found"),
+			Tuple.Create ("APT2127", "files given but --dir specified"),
+			Tuple.Create ("APT2128", "file signature does not match PNG signature"),
+			Tuple.Create ("APT2129", "flattening failed"),
+			Tuple.Create ("APT2130", "for configuration"),
+			Tuple.Create ("APT2131", "'id' is ignored within <public-group>"),
+			Tuple.Create ("APT2132", "illegal nested XLIFF 'g' tag"),
+			Tuple.Create ("APT2133", "incompatible package"),
+			Tuple.Create ("APT2134", "in <item> within an <overlayable>"),
+			Tuple.Create ("APT2135", "inline XML resources must have a single root"),
+			Tuple.Create ("APT2136", "inner element must either be a resource reference or empty"),
+			Tuple.Create ("APT2137", "in <public>"),
+			Tuple.Create ("APT2138", "invalid android:minSdkVersion"),
+			Tuple.Create ("APT2139", "invalid android:revisionCode"),
+			Tuple.Create ("APT2140", "invalid android:versionCode"),
+			Tuple.Create ("APT2141", "Invalid attribute:"),
+			Tuple.Create ("APT2142", "invalid config"),
+			Tuple.Create ("APT2143", "invalid density"),
+			Tuple.Create ("APT2144", "invalid file path"),
+			Tuple.Create ("APT2145", "invalid Java identifier"),
+			Tuple.Create ("APT2146", "invalid 'max' value"),
+			Tuple.Create ("APT2147", "invalid 'min' value"),
+			Tuple.Create ("APT2148", "invalid namespace prefix"),
+			Tuple.Create ("APT2149", "invalid package name"),
+			Tuple.Create ("APT2150", "invalid preferred density"),
+			Tuple.Create ("APT2151", "invalid resource ID"),
+			Tuple.Create ("APT2152", "invalid resource name"),
+			Tuple.Create ("APT2153", "invalid resources.pb"),
+			Tuple.Create ("APT2154", "invalid split name"),
+			Tuple.Create ("APT2155", "invalid split parameter"),
+			Tuple.Create ("APT2156", "invalid static library"),
+			Tuple.Create ("APT2157", "invalid type name"),
+			Tuple.Create ("APT2158", "Invalid value for flag --output-format"),
+			Tuple.Create ("APT2159", "invalid value for 'formatted'. Must be a boolean"),
+			Tuple.Create ("APT2160", "invalid value for 'translatable'. Must be a boolean"),
+			Tuple.Create ("APT2161", "invalid value for type"),
+			Tuple.Create ("APT2162", "invalid XML attribute"),
+			Tuple.Create ("APT2163", "is an invalid format"),
+			Tuple.Create ("APT2164", "is not a valid integer"),
+			Tuple.Create ("APT2165", "<item> in <plural> has invalid value"),
+			Tuple.Create ("APT2166", "<item> in <plurals> requires attribute"),
+			Tuple.Create ("APT2167", "<item> must have a 'name' attribute"),
+			Tuple.Create ("APT2168", "<item> must have a 'type' attribute"),
+			Tuple.Create ("APT2169", "<item> within an <overlayable> tag must have a 'name' attribute"),
+			Tuple.Create ("APT2170", "<item> within an <overlayable> tag must have a 'type' attribute"),
+			Tuple.Create ("APT2171", "<manifest> must have a 'package' attribute"),
+			Tuple.Create ("APT2172", "manifest must have a versionCode attribute"),
+			Tuple.Create ("APT2173", "<manifest> tag is missing 'package' attribute"),
+			Tuple.Create ("APT2174", "'min' and 'max' can only be used when format='integer'"),
+			Tuple.Create ("APT2175", "missing '='"),
+			Tuple.Create ("APT2176", "missing key string pool"),
+			Tuple.Create ("APT2177", "missing minSdkVersion from <uses-sdk>"),
+			Tuple.Create ("APT2178", "missing 'name' attribute"),
+			Tuple.Create ("APT2179", "Missing placeholder for artifact"),
+			Tuple.Create ("APT2180", "missing type string pool"),
+			Tuple.Create ("APT2181", "missing <uses-sdk> from <manifest>"),
+			Tuple.Create ("APT2182", "multiple default products defined for resource"),
+			Tuple.Create ("APT2183", "must be an integer"),
+			Tuple.Create ("APT2184", "have overlapping version-code-order attributes"),
+			Tuple.Create ("APT2185", "No AndroidManifest."),
+			Tuple.Create ("APT2186", "no attribute 'name' found for tag <"),
+			Tuple.Create ("APT2187", "no attribute 'value' found for tag"),
+			Tuple.Create ("APT2188", "no default product defined for resource"),
+			Tuple.Create ("APT2189", "no definition for declared symbol"),
+			Tuple.Create ("APT2190", "no file associated with"),
+			Tuple.Create ("APT2191", "No label found for element "),
+			Tuple.Create ("APT2192", "no <manifest> root tag defined"),
+			Tuple.Create ("APT2193", "No package name."),
+			Tuple.Create ("APT2194", "no package with ID 0x7f found in static library"),
+			Tuple.Create ("APT2195", "no root tag defined"),
+			Tuple.Create ("APT2196", "no root XML tag found"),
+			Tuple.Create ("APT2197", "no suitable parent for inheriting attribute"),
+			Tuple.Create ("APT2198", "not a valid png file"),
+			Tuple.Create ("APT2199", "not a valid png file"),
+			Tuple.Create ("APT2200", "not a valid string"),
+			Tuple.Create ("APT2201", "not enough data for PNG signature"),
+			Tuple.Create ("APT2202", "No version-code-order found for element"),
+			Tuple.Create ("APT2203", "only one of --shared-lib, --static-lib, or --proto_format can be defined"),
+			Tuple.Create ("APT2204", "Output directory is required when using a configuration file"),
+			Tuple.Create ("APT2205", "<overlayable> has invalid policy"),
+			Tuple.Create ("APT2206", "package 'android' can only be built as a regular app"),
+			Tuple.Create ("APT2207", "package ID is too big"),
+			Tuple.Create ("APT2208", "is too long"),
+			Tuple.Create ("APT2209", "Placeholder present but no value for artifact"),
+			Tuple.Create ("APT2210", "Placeholder present multiple times"),
+			Tuple.Create ("APT2211", "plain text not allowed here"),
+			Tuple.Create ("APT2212", "PNG image dimensions are too large"),
+			Tuple.Create ("APT2213", "previous declaration here"),
+			Tuple.Create ("APT2214", "<public-group> must have a 'first-id' attribute"),
+			Tuple.Create ("APT2215", "<public-group> must have a 'type' attribute"),
+			Tuple.Create ("APT2216", "<public> must have a 'name' attribute"),
+			Tuple.Create ("APT2217", "<public> must have a 'type' attribute"),
+			Tuple.Create ("APT2218", "resource file cannot be a directory"),
+			Tuple.Create ("APT2219", "name cannot contain '.' other than for"),
+			Tuple.Create ("APT2220", "has invalid entry name"),
+			Tuple.Create ("APT2221", "has same ID"),
+			Tuple.Create ("APT2222", "resource previously defined here"),
+			Tuple.Create ("APT2223", "does not override an existing resource"),
+			Tuple.Create ("APT2224", "has a conflicting value for"),
+			Tuple.Create ("APT2225", "was filtered out but no product variant remains"),
+			Tuple.Create ("APT2226", "ResTable_type has invalid id"),
+			Tuple.Create ("APT2227", "ResTable_typeSpec has invalid id"),
+			Tuple.Create ("APT2228", "ResTable_typeSpec has too many entries"),
+			Tuple.Create ("APT2229", "ResTable_typeSpec too small to hold entries"),
+			Tuple.Create ("APT2230", "root element must be <resources>"),
+			Tuple.Create ("APT2231", "root tag must be <manifest>"),
+			Tuple.Create ("APT2232", "selection of product"),
+			Tuple.Create ("APT2233", "is already taken by resource"),
+			Tuple.Create ("APT2234", "static library has no package"),
+			Tuple.Create ("APT2235", "invalid package ID 0x%02x"),
+			Tuple.Create ("APT2236", "unknown chunk of type 0x%02x"),
+			Tuple.Create ("APT2237", "string too large to encode using UTF-16"),
+			Tuple.Create ("APT2238", "string too large to encode using UTF-8"),
+			Tuple.Create ("APT2239", "The configuration and command line to filter artifacts do not match"),
+			Tuple.Create ("APT2240", "but resource already has ID"),
+			Tuple.Create ("APT2241", "but package"),
+			Tuple.Create ("APT2242", "but type"),
+			Tuple.Create ("APT2243", "'type' is ignored within <public-group>"),
+			Tuple.Create ("APT2244", "file passed as argument. Must be"),
+			Tuple.Create ("APT2245", "Unexpected element in ABI group"),
+			Tuple.Create ("APT2246", "Unexpected element in gl-texture element"),
+			Tuple.Create ("APT2247", "Unexpected element in GL texture group"),
+			Tuple.Create ("APT2248", "Unexpected root_element in device feature group"),
+			Tuple.Create ("APT2249", "Unexpected root_element in screen density group"),
+			Tuple.Create ("APT2250", "unknown command"),
+			Tuple.Create ("APT2251", "Unknown namespace found on root element"),
+			Tuple.Create ("APT2252", "unknown tag"),
+			Tuple.Create ("APT2253", "<uses-feature> must have either android:name or android:glEsVersion attribute"),
+			Tuple.Create ("APT2254", "xml parser error"),
+			Tuple.Create ("APT2255", "versionCode is invalid"),
+			Tuple.Create ("APT2256", "missing:"),
+			Tuple.Create ("APT2257", "in <public-group>"),
+			Tuple.Create ("APT2258", "invalid"),
+			Tuple.Create ("APT2259", "is incompatible with attribute"),
+			Tuple.Create ("APT2260", "not found"),
+			Tuple.Create ("APT2261", "file failed to compile"),
+		};
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
@@ -30,12 +30,12 @@ namespace Xamarin.Android.Tasks {
 				if (directory.StartsWith ("values", StringComparison.OrdinalIgnoreCase)) {
 					var match = fileNameWithHyphenCheck.Match (fileName);
 					if (match.Success) {
-						Log.LogCodedError ("APT0000", resource.ItemSpec, 0, $"Invalid file name: It must contain only {fileNameWithHyphenCheck}.");
+						Log.LogCodedError ("APT0002", resource.ItemSpec, 0, $"Invalid file name: It must contain only {fileNameWithHyphenCheck}.");
 					}
 				} else {
 					var match = fileNameCheck.Match (fileName);
 					if (match.Success) {
-						Log.LogCodedError ("APT0000", resource.ItemSpec, 0, $"Invalid file name: It must contain only {fileNameCheck}.");
+						Log.LogCodedError ("APT0003", resource.ItemSpec, 0, $"Invalid file name: It must contain only {fileNameCheck}.");
 					}
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -195,7 +195,7 @@ using System.Runtime.CompilerServices;
 			using (var b = CreateApkBuilder ($"temp/{TestName}")) {
 				b.ThrowOnBuildFailure = false;
 				Assert.IsFalse (b.Build (proj), "Build should have failed.");
-				StringAssertEx.Contains (useAapt2 ? "APT0000" : "APT1144", b.LastBuildOutput, "An error message with a blank \"level\", should be reported as an error!");
+				StringAssertEx.Contains (useAapt2 ? "APT0003" : "APT1144", b.LastBuildOutput, "An error message with a blank \"level\", should be reported as an error!");
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
 			}
 		}
@@ -677,7 +677,7 @@ namespace UnnamedProject
 				b.Verbosity = LoggerVerbosity.Diagnostic;
 				b.ThrowOnBuildFailure = false;
 				Assert.IsFalse (b.Build (proj), "Build should have failed");
-				StringAssertEx.Contains ("APT0000: ", b.LastBuildOutput);
+				StringAssertEx.Contains ("APT2260: ", b.LastBuildOutput);
 				StringAssertEx.Contains ("2 Error(s)", b.LastBuildOutput);
 			}
 		}
@@ -696,7 +696,7 @@ namespace UnnamedProject
 				b.Verbosity = LoggerVerbosity.Diagnostic;
 				b.ThrowOnBuildFailure = false;
 				Assert.IsFalse (b.Build (proj), "Build should have failed");
-				StringAssertEx.Contains ("APT0000: ", b.LastBuildOutput);
+				StringAssertEx.Contains ("APT2144: ", b.LastBuildOutput);
 				StringAssertEx.Contains ("1 Error(s)", b.LastBuildOutput);
 			}
 		}
@@ -768,7 +768,9 @@ namespace UnnamedProject
 				b.Verbosity = LoggerVerbosity.Diagnostic;
 				b.ThrowOnBuildFailure = false;
 				Assert.IsFalse (b.Build (proj), "Build should have failed");
-				StringAssertEx.Contains ("APT0000: ", b.LastBuildOutput);
+				StringAssertEx.Contains ("APT2057: ", b.LastBuildOutput);
+				StringAssertEx.Contains ("APT2222: ", b.LastBuildOutput);
+				StringAssertEx.Contains ("APT2261: ", b.LastBuildOutput);
 				StringAssertEx.Contains ("2 Error(s)", b.LastBuildOutput);
 			}
 		}
@@ -1309,7 +1311,7 @@ namespace Lib1 {
 			});
 			using (var builder = CreateApkBuilder (path, false, false)) {
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
-				StringAssertEx.Contains ($"warning APT1145: warning: string '{name}' has no default translation.", builder.LastBuildOutput, "Build output should contain an APT0000 warning about 'no default translation'");
+				StringAssertEx.Contains ($"warning APT1145: warning: string '{name}' has no default translation.", builder.LastBuildOutput, "Build output should contain an APT1145 warning about 'no default translation'");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -116,7 +116,7 @@ namespace Bug12935
 				proj.TargetFrameworkVersion = "v4.0.3";
 				proj.AndroidManifest = string.Format (TargetSdkManifest, "15");
 				Assert.IsFalse (builder.Build (proj), "Build for TargetFrameworkVersion 15 should have failed");
-				StringAssertEx.Contains (useAapt2 ? "APT0000: " : "APT1134: ", builder.LastBuildOutput);
+				StringAssertEx.Contains (useAapt2 ? "APT2259: " : "APT1134: ", builder.LastBuildOutput);
 				StringAssertEx.Contains ("1 Error(s)", builder.LastBuildOutput);
 			}
 		}


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/735263
Context: https://android.googlesource.com/platform/frameworks/base/+/563abce4ed0a0d9f08f8839a8f15b548b3dcd4d1/tools/aapt
Context: https://gist.github.com/grendello/72c1ce5f6e8cdd3aefd393b983576d9a

Errors and warning *codes* for errors and warnings reported
*within Visual Studio* from developers participating in the
[Visual Studio Customer Experience Improvement Program][0] are
reported "telemetry" events, but *only* the error and warning codes
are reported.  The warning and error message contents are not sent.

Unfortunately all `aapt2`-related errors are reported as APT0000,
which reduces the utility of telemetry, making it more difficult to
better understand where our build system could be improved.

@grendello created a `grep` pipeline for the `aapt2` sources to try to
extract plausible error messages that we can compare against.  

	rgrep -Pzoh '(?s)(->|\.)Error.*?;\n' * | \
	  tr -d '\n' | tr ';' '\n'| \
	  sed -e 's/^[ \t]*//g' -e 's/^.*Error([ \t]*DiagMessage[ \t]*(.*)[ \t]*<<//g' -e 's/^.*Error(.*)//g;' -e 's/^;$//g' | \
	  sort | uniq

Improve the `<Aapt2/>` task to check against this list of "known"
error strings and associate them with unique `APTxxxx` codes.
This will allow for more meaningful documentation to be written
in the future, and will allow our telemetry to be more meaningful
and permit improved focusing of future efforts.

[0]: https://docs.microsoft.com/en-us/visualstudio/ide/visual-studio-experience-improvement-program?view=vs-2019