### PR TITLE
[Xamarin.Android.BuildTasks] fix for _LinkAssembliesNoShrink

### DIFF
--- a/Documentation/guides/MSBuildBestPractices.md
+++ b/Documentation/guides/MSBuildBestPractices.md
@@ -251,6 +251,11 @@ will re-run the target completely. `$(MSBuildAllProjects)` is a list
 of every MSBuild file imported during a build, MSBuild automatically
 evaluates `$(MSBuildAllProjects)` since [MSBuild 16.0][allprojects].
 
+One pitfall, is this `_GenerateDocumentation` example *must* touch the
+timestamps on all files in `Outputs` -- regardless if they were
+actually changed. Otherwise, your target can get into a state where it
+will never be skipped again.
+
 Read more about building *partially* on the [official MSBuild
 docs][msbuild-partial].
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
@@ -66,6 +66,9 @@ namespace Xamarin.Android.Tasks
 						Log.LogDebugMessage ($"Copied: {destination.ItemSpec}");
 					} else {
 						Log.LogDebugMessage ($"Skipped unchanged file: {destination.ItemSpec}");
+
+						// NOTE: We still need to update the timestamp on this file, or this target would run again
+						File.SetLastWriteTimeUtc (destination.ItemSpec, DateTime.UtcNow);
 					}
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -527,6 +527,25 @@ namespace Lib2
 		}
 
 		[Test]
+		public void LinkAssembliesNoShrink ()
+		{
+			var proj = new XamarinFormsAndroidApplicationProject ();
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "build should have succeeded.");
+
+				// Touch an assembly to a timestamp older than build.props
+				var formsViewGroup = b.Output.GetIntermediaryPath (Path.Combine ("android", "assets", "FormsViewGroup.dll"));
+				File.SetLastWriteTimeUtc (formsViewGroup, new DateTime (1970, 1, 1));
+				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "build should have succeeded.");
+				Assert.IsFalse (b.Output.IsTargetSkipped ("_LinkAssembliesNoShrink"), "_LinkAssembliesNoShrink should *not* be skipped.");
+
+				// No changes
+				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "build should have succeeded.");
+				Assert.IsTrue (b.Output.IsTargetSkipped ("_LinkAssembliesNoShrink"), "_LinkAssembliesNoShrink should be skipped.");
+			}
+		}
+
+		[Test]
 		[NonParallelizable] // /restore can fail on Mac in parallel
 		public void ConvertCustomView ([Values (true, false)] bool useAapt2)
 		{


### PR DESCRIPTION
In 5320c25a, I implemented a way for `_LinkAssembliesNoShrink` to
build partially.

However, I found a bug when testing out the new feature on a project
with existing `bin` and `obj` directories:

* `build.props` was updated because `$(XamarinAndroidVersion)` changed
* `_LinkAssembliesNoShrink` ran, but many of the files were not
  actually copied, such as `FormsViewGroup.dll` from the Xamarin.Forms
  NuGet package.
* Any subsequent build would always run `_LinkAssembliesNoShrink`
  fully! Because `FormsViewGroup.dll` would eternally have an older
  timestamp than `build.props`.

I was able to reproduce the problem with a new test.

The fix is to set the timestamp on copied assemblies, even if they
weren't actually copied. This way the `Inputs` and `Outputs` of
`_LinkAssembliesNoShrink` will always be correct.

Building partially is a tricky operation... If applied in the future
to other targets, we'll have to specifically test scenarios like this!