### PR TITLE
[build] Migrate assemble-docs target from monodroid

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
+[submodule "external/android-api-docs"]
+    path = external/android-api-docs
+    url = https://github.com/xamarin/android-api-docs
+    branch = master
 [submodule "external/debugger-libs"]
     path = external/debugger-libs
     url = git://github.com/mono/debugger-libs

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -6,7 +6,11 @@
   <UsingTask AssemblyFile="..\..\bin\Build$(Configuration)\xa-prep-tasks.dll" TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" />
   <PropertyGroup>
     <RootBuildDir>$(XamarinAndroidSourcePath)\bin\$(Configuration)\</RootBuildDir>
-    <FrameworkSrcDir>$(RootBuildDir)\lib\xamarin.android\xbuild-frameworks\MonoAndroid</FrameworkSrcDir>
+    <FrameworkSrcDir>$(RootBuildDir)lib\xamarin.android\xbuild-frameworks\MonoAndroid\</FrameworkSrcDir>
+    <AndroidApiDocsPath Condition=" '$(AndroidApiDocsPath)' == '' ">$(XamarinAndroidSourcePath)external\android-api-docs\</AndroidApiDocsPath>
+    <_AndroidApiDocsPath>$([MSBuild]::EnsureTrailingSlash($(AndroidApiDocsPath)))</_AndroidApiDocsPath>
+    <_LatestStableFrameworkDir>$(FrameworkSrcDir)$(AndroidLatestStableFrameworkVersion)\</_LatestStableFrameworkDir>
+    <_MonoDocOutputPath>$(RootBuildDir)lib\monodoc\</_MonoDocOutputPath>
     <MSBuildSrcDir>$(RootBuildDir)\lib\xamarin.android\xbuild\Xamarin\Android</MSBuildSrcDir>
     <MSBuildTargetsSrcDir>$(XamarinAndroidSourcePath)\src\Xamarin.Android.Build.Tasks\MSBuild\Xamarin\Android</MSBuildTargetsSrcDir>
     <DefaultRuntimeEntitlementsPath>$(MSBuildThisFileDirectory)\..\create-pkg\runtime-entitlements.plist</DefaultRuntimeEntitlementsPath>
@@ -20,6 +24,60 @@
     <UseCommercialInstallerName Condition="'$(UseCommercialInstallerName)' == ''">False</UseCommercialInstallerName>
     <_HasCommercialFiles Condition="Exists('$(MSBuildSrcDir)\Mono.Android.DebugRuntime-debug.apk')">True</_HasCommercialFiles>
   </PropertyGroup>
+  <ItemGroup>
+    <_MsxDocAssembly Include="Mono.Android">
+      <SourceFolder>$(_AndroidApiDocsPath)docs\%(Identity)\en\</SourceFolder>
+    </_MsxDocAssembly>
+    <_MonoDocAssembly Include="@(_MsxDocAssembly);OpenTK-1.0;Xamarin.Android.NUnitLite">
+      <SourceFolder>$(_AndroidApiDocsPath)docs\%(Identity)\en\</SourceFolder>
+    </_MonoDocAssembly>
+  </ItemGroup>
+  <Target Name="_FindFrameworkDirs">
+    <ItemGroup>
+      <_FrameworkDirs Include="@(AndroidApiInfo->'$(FrameworkSrcDir)%(Identity)\')" />
+      <_FrameworkDirsThatExist Condition="Exists('%(Identity)')" Include="@(_FrameworkDirs)" />
+      <_EarlierFrameworkDir Include="@(_FrameworkDirsThatExist)" Exclude="$(_LatestStableFrameworkDir)" />
+    </ItemGroup>
+  </Target>
+  <Target Name="_FindDocSourceFiles">
+    <ItemGroup>
+      <_MsxDocSourceFile Include="%(_MsxDocAssembly.SourceFolder)**" />
+      <_MonoDocSourceFile Include="%(_MonoDocAssembly.SourceFolder)**" />
+    </ItemGroup>
+  </Target>
+  <Target Name="_GenerateMsxDocXmls"
+      DependsOnTargets="_FindFrameworkDirs;_FindDocSourceFiles"
+      Inputs="@(_MsxDocSourceFile)"
+      Outputs="@(_MsxDocAssembly->'$(_LatestStableFrameworkDir)%(Identity).xml')">
+    <Exec Command="mdoc --debug export-msxdoc -o &quot;$(_LatestStableFrameworkDir)%(_MsxDocAssembly.Identity).xml&quot; &quot;%(_MsxDocAssembly.SourceFolder)&quot;" />
+  </Target>
+  <Target Name="_GenerateMsxDocXmlRedirects"
+      DependsOnTargets="_FindFrameworkDirs"
+      Inputs="$(XamarinAndroidSourcePath)build-tools\scripts\redirect-Mono.Android.xml.in"
+      Outputs="@(_EarlierFrameworkDir->'%(Identity)Mono.Android.xml')">
+    <ReplaceFileContents
+        SourceFile="$(XamarinAndroidSourcePath)build-tools\scripts\redirect-Mono.Android.xml.in"
+        DestinationFile="%(_EarlierFrameworkDir.Identity)Mono.Android.xml"
+        Replacements="@LAST_FRAMEWORK_VERSION@=$(AndroidLatestStableFrameworkVersion)" />
+  </Target>
+  <Target Name="_GenerateMonoAndroidLibArchive"
+      DependsOnTargets="_FindDocSourceFiles"
+      Inputs="@(_MonoDocSourceFile)"
+      Outputs="$(_MonoDocOutputPath)MonoAndroid-lib.zip;$(_MonoDocOutputPath)MonoAndroid-lib.tree">
+    <MakeDir Directories="$(_MonoDocOutputPath)" />
+    <Exec Command="mdoc --debug assemble -o &quot;$(_MonoDocOutputPath)MonoAndroid-lib&quot; @(_MonoDocAssembly->'&quot;%(SourceFolder)&quot;', ' ')" />
+  </Target>
+  <Target Name="_CopyMonoAndroidDocsSource"
+      Inputs="$(_AndroidApiDocsPath)MonoAndroid-docs.source"
+      Outputs="$(_MonodocOutputPath)MonoAndroid-docs.source">
+    <Copy
+        SourceFiles="$(_AndroidApiDocsPath)MonoAndroid-docs.source"
+        DestinationFolder="$(_MonoDocOutputPath)" />
+  </Target>
+  <Target
+      Name="AssembleApiDocs"
+      DependsOnTargets="_GenerateMsxDocXmls;_GenerateMsxDocXmlRedirects;_GenerateMonoAndroidLibArchive;_CopyMonoAndroidDocsSource"
+      Condition=" '$(HostOS)' != 'Windows' " />
   <ItemGroup>
     <_DesignerFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\bcl\**\*" />
     <_DesignerFilesWin Include="$(MSBuildSrcDir)\bcl\**\* "/>
@@ -260,9 +318,9 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Installer.Common.targets" />
     <LegacyTargetsFiles Include="$(RootBuildDir)\lib\xamarin.android\xbuild\Novell\Xamarin.Android.Bindings.targets" />
     <LegacyTargetsFiles Include="$(RootBuildDir)\lib\xamarin.android\xbuild\Novell\Xamarin.Android.VisualBasic.targets" />
-    <MonoDocFiles Include="$(RootBuildDir)\lib\monodoc\MonoAndroid-docs.source" />
-    <MonoDocFiles Include="$(RootBuildDir)\lib\monodoc\MonoAndroid-lib.tree" />
-    <MonoDocFiles Include="$(RootBuildDir)\lib\monodoc\MonoAndroid-lib.zip" />
+    <MonoDocFiles Include="$(_MonoDocOutputPath)MonoAndroid-docs.source" />
+    <MonoDocFiles Include="$(_MonoDocOutputPath)MonoAndroid-lib.tree" />
+    <MonoDocFiles Include="$(_MonoDocOutputPath)MonoAndroid-lib.zip" />
     <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Mono.CompilerServices.SymbolWriter.xml" />
     <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Mono.Data.Sqlite.xml" />
     <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Mono.Data.Tds.xml" />
@@ -286,10 +344,9 @@
     <_FrameworkFilesWin Include="$(FrameworkSrcDir)\$(BclFrameworkVersion)\Xamarin.Android.NUnitLite.xml" />
   </ItemGroup>
   <Target Name="ConstructInstallerItems"
+      DependsOnTargets="_FindFrameworkDirs;AssembleApiDocs"
       Returns="@(FrameworkItemsWin);@(FrameworkItemsUnix);@(MSBuildItemsWin);@(MSBuildItemsUnix)">
     <ItemGroup>
-      <_FrameworkDirs Include="@(AndroidApiInfo->'$(FrameworkSrcDir)\%(Identity)')" />
-      <_FrameworkDirsThatExist Condition="Exists('%(Identity)')" Include="@(_FrameworkDirs)" />
       <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\AndroidApiInfo.xml')" />
       <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\mono.android.dex')" />
       <_FrameworkFiles Include="@(_FrameworkDirsThatExist->'%(Identity)\Mono.Android.dll')" />

--- a/build-tools/scripts/redirect-Mono.Android.xml.in
+++ b/build-tools/scripts/redirect-Mono.Android.xml.in
@@ -1,0 +1,1 @@
+<doc redirect="..\@LAST_FRAMEWORK_VERSION@\Mono.Android.xml" />


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3086

Now that the [Xamarin.Android API docs][0] have been open sourced,
migrate the `assemble-docs` target and its dependencies from the
`docs.make` file in monodroid to a set of MSBuild targets in
xamarin-android.

Move `@(_FrameworkDirs)` and `@(_FrameworkDirsThatExist)` into their own
helper target so that the new targets can use them.

Add a trailing slash on the value of `$(FrameworkSrcDir)` so that the
new targets can follow the convention that the value of a directory path
property always includes a trailing slash.

Add the new targets that replace the old `docs.make` targets.  These
targets run `mdoc` to generate "msxdoc" Microsoft XML Documentation
format files that are used in the `.vsix` installer for Windows as well
as a monodoc format `MonoAndroid-lib.zip` archive and an accompanying
`.tree` file that are used in the `.pkg` installer for macOS.

Bring in android-api-docs as a submodule, set at the same commit as the
corresponding submodule in monodroid.

There are a few intentional differences compared to the original
`docs.make` targets:

  * The Microsoft XML Documentation files are output to the directory of
    the latest *stable* framework version rather than the latest *known*
    framework version.  This is useful because it means the MSBuild
    targets don't need access to the `$(FRAMEWORKS)` `make` variable.

  * The OpenTK-1.0 docs are only generated for the `mdoc assemble` step
    and not for the `mdoc export-msxdoc` step.  The `export-msxdoc`
    output isn't needed at the moment because the `.vsix` installer
    instead uses the `.xml` file that's generated when
    `Mono.Android.csproj` builds `OpenTK-1.0.csproj` for
    `$(TargetFrameworkVersion)` `v4.4`.

  * The OpenTK docs are omitted in favor of the OpenTK-1.0 docs because
    OpenTK has been deprecated and removed from Xamarin.Android.

  * The `pimpup-docs` target is omitted.  I checked the build logs for a
    recent commercial build and saw that while the build does compile
    `doc-relcontent-merger.exe` and `recipe-relcontent-generator.exe`,
    it never runs either one.  Starting in [monodroid@c83b93e2][1], the
    `$(PIMP_STAMP)` target that used to run `doc-relcontent-merger.exe`
    was no longer needed and was disabled.

  * The `docs/netdocs.zip` and `docs/mono-libs.zip` targets are also
    intentionally omitted.  Although commercial builds do still run
    those targets, the outputs are not used for anything.  For example,
    they aren't included in the `.pkg` installer for macOS or the
    `.vsix` installer for Windows.

    Based on the contents of the `push-docs` target in `docs.make` and
    the fact that that target was last edited in 2012, I believe the
    `netdocs.zip` and `mono-libs.zip` archives were for an old online
    documentation system that was retired long ago.

I verified that the `Mono.Android.xml` Microsoft XML Documentation file
generated by these new targets was identical to the version generated by
the `docs.make` targets.  Similarly, I verified that the new monodoc
`MonoAndroid-lib.zip` archive generated by these targets contained the
same list of `xml.summary.*` files as the `.zip` archive generated by
the `docs.make` targets.

[0]: https://github.com/xamarin/android-api-docs
[1]: https://github.com/xamarin/monodroid/commit/c83b93e20b0e6f80af7f8e19a6f1dc73f187e4f0