### PR TITLE
[Xamarin.Android.Build.Tasks] fix resx files for aabs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Android.Tasks
 				var uncompressed = new List<string> {
 					"typemap.mj",
 					"typemap.jm",
-					"assemblies/*",
+					"assemblies/**",
 				};
 				if (!string.IsNullOrEmpty (UncompressedFileExtensions)) {
 					//NOTE: these are file extensions, that need converted to glob syntax

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BundleToolTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BundleToolTests.cs
@@ -232,10 +232,10 @@ namespace Xamarin.Android.Build.Tests
 
 			var aab = Path.Combine (intermediate, "android", "bin", "UnnamedProject.UnnamedProject.apks");
 			FileAssert.Exists (aab);
-			// Expecting: splits/base-arm64_v8a.apk, splits/base-en.apk, splits/base-es.apk, splits/base-master.apk, splits/base-xxxhdpi.apk
+			// Expecting: splits/base-arm64_v8a.apk, splits/base-en.apk, splits/base-master.apk, splits/base-xxxhdpi.apk
 			// This are split up based on: abi, language, base, and dpi
 			var contents = ListArchiveContents (aab).Where (a => a.EndsWith (".apk", StringComparison.OrdinalIgnoreCase)).ToArray ();
-			Assert.AreEqual (5, contents.Length, "Expecting five APKs!");
+			Assert.AreEqual (4, contents.Length, "Expecting four APKs!");
 
 			using (var stream = new MemoryStream ())
 			using (var apkSet = ZipArchive.Open (aab, FileMode.Open)) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BundleToolTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BundleToolTests.cs
@@ -11,44 +11,89 @@ namespace Xamarin.Android.Build.Tests
 	[TestFixture]
 	public class BundleToolTests : BaseTest
 	{
-		XamarinAndroidApplicationProject project;
-		ProjectBuilder builder;
+		XamarinAndroidLibraryProject lib;
+		XamarinAndroidApplicationProject app;
+		ProjectBuilder libBuilder, appBuilder;
 		string intermediate;
 		string bin;
+
+		const string Resx = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<root>
+	<resheader name=""resmimetype"">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name=""version"">
+		<value>2.0</value>
+	</resheader>
+	<resheader name=""reader"">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name=""writer"">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<!--contents-->
+</root>";
 
 		[OneTimeSetUp]
 		public void OneTimeSetUp ()
 		{
-			project = new XamarinFormsMapsApplicationProject {
+			var path = Path.Combine ("temp", TestName);
+			lib = new XamarinAndroidLibraryProject {
+				ProjectName = "Localization",
+				IsRelease = true,
+				OtherBuildItems = {
+					new BuildItem ("EmbeddedResource", "Foo.resx") {
+						TextContent = () => ResxWithContents ("<data name=\"CancelButton\"><value>Cancel</value></data>")
+					},
+					new BuildItem ("EmbeddedResource", "Foo.es.resx") {
+						TextContent = () => ResxWithContents ("<data name=\"CancelButton\"><value>Cancelar</value></data>")
+					}
+				}
+			};
+
+			app = new XamarinFormsMapsApplicationProject {
 				IsRelease = true,
 			};
+			app.References.Add (new BuildItem.ProjectReference ($"..\\{lib.ProjectName}\\{lib.ProjectName}.csproj", lib.ProjectName, lib.ProjectGuid));
+
 			//NOTE: this is here to enable adb shell run-as
-			project.AndroidManifest = project.AndroidManifest.Replace ("<application ", "<application android:debuggable=\"true\" ");
-			project.SetProperty (project.ReleaseProperties, "AndroidPackageFormat", "aab");
+			app.AndroidManifest = app.AndroidManifest.Replace ("<application ", "<application android:debuggable=\"true\" ");
+			app.SetProperty (app.ReleaseProperties, "AndroidPackageFormat", "aab");
 			var abis = new string [] { "armeabi-v7a", "arm64-v8a", "x86" };
-			project.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
+			app.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
 
-			builder = CreateApkBuilder (Path.Combine ("temp", TestName), cleanupOnDispose: true);
-			Assert.IsTrue (builder.Build (project), "Build should have succeeded.");
+			libBuilder = CreateDllBuilder (Path.Combine (path, lib.ProjectName), cleanupOnDispose: true);
+			Assert.IsTrue (libBuilder.Build (lib), "Library build should have succeeded.");
+			appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName), cleanupOnDispose: true);
+			Assert.IsTrue (appBuilder.Build (app), "App build should have succeeded.");
 
-			var projectDir = Path.Combine (Root, builder.ProjectDirectory);
-			intermediate = Path.Combine (projectDir, project.IntermediateOutputPath);
-			bin = Path.Combine (projectDir, project.OutputPath);
+			var projectDir = Path.Combine (Root, appBuilder.ProjectDirectory);
+			intermediate = Path.Combine (projectDir, app.IntermediateOutputPath);
+			bin = Path.Combine (projectDir, app.OutputPath);
+		}
+
+		string ResxWithContents (string contents)
+		{
+			return Resx.Replace ("<!--contents-->", contents);
 		}
 
 		[TearDown]
 		public void TearDown ()
 		{
 			var status = TestContext.CurrentContext.Result.Outcome.Status;
-			if (status == NUnit.Framework.Interfaces.TestStatus.Failed && builder != null) {
-				builder.CleanupOnDispose = false;
+			if (status == NUnit.Framework.Interfaces.TestStatus.Failed) {
+				if (libBuilder != null)
+					libBuilder.CleanupOnDispose = false;
+				if (appBuilder != null)
+					appBuilder.CleanupOnDispose = false;
 			}
 		}
 
 		[OneTimeTearDown]
 		public void OneTimeTearDown ()
 		{
-			builder?.Dispose ();
+			libBuilder?.Dispose ();
+			appBuilder?.Dispose ();
 		}
 
 		string [] ListArchiveContents (string archive)
@@ -99,6 +144,8 @@ namespace Xamarin.Android.Build.Tests
 				"root/assemblies/System.Core.dll",
 				"root/assemblies/System.dll",
 				"root/assemblies/System.Runtime.Serialization.dll",
+				"root/assemblies/Localization.dll",
+				"root/assemblies/es/Localization.resources.dll",
 				"root/assemblies/UnnamedProject.dll",
 				"root/NOTICE",
 				//These are random files from Google Play Services .jar/.aar files
@@ -150,6 +197,8 @@ namespace Xamarin.Android.Build.Tests
 				"base/root/assemblies/System.Core.dll",
 				"base/root/assemblies/System.dll",
 				"base/root/assemblies/System.Runtime.Serialization.dll",
+				"base/root/assemblies/Localization.dll",
+				"base/root/assemblies/es/Localization.resources.dll",
 				"base/root/assemblies/UnnamedProject.dll",
 				"base/root/NOTICE",
 				"BundleConfig.pb",
@@ -179,14 +228,28 @@ namespace Xamarin.Android.Build.Tests
 			if (!HasDevices)
 				Assert.Ignore ("Skipping Installation. No devices available.");
 
-			Assert.IsTrue (builder.RunTarget (project, "Install"), "App should have installed.");
+			Assert.IsTrue (appBuilder.RunTarget (app, "Install"), "App should have installed.");
 
 			var aab = Path.Combine (intermediate, "android", "bin", "UnnamedProject.UnnamedProject.apks");
 			FileAssert.Exists (aab);
-			// Expecting: splits/base-arm64_v8a.apk, splits/base-en.apk, splits/base-master.apk, splits/base-xxxhdpi.apk
+			// Expecting: splits/base-arm64_v8a.apk, splits/base-en.apk, splits/base-es.apk, splits/base-master.apk, splits/base-xxxhdpi.apk
 			// This are split up based on: abi, language, base, and dpi
 			var contents = ListArchiveContents (aab).Where (a => a.EndsWith (".apk", StringComparison.OrdinalIgnoreCase)).ToArray ();
-			Assert.AreEqual (4, contents.Length, "Expecting four APKs!");
+			Assert.AreEqual (5, contents.Length, "Expecting five APKs!");
+
+			using (var stream = new MemoryStream ())
+			using (var apkSet = ZipArchive.Open (aab, FileMode.Open)) {
+				// We have a zip inside a zip
+				var baseMaster = apkSet.ReadEntry ("splits/base-master.apk");
+				baseMaster.Extract (stream);
+
+				stream.Position = 0;
+				using (var baseApk = ZipArchive.Open (stream)) {
+					foreach (var dll in baseApk.Where (e => e.FullName.EndsWith (".dll", StringComparison.OrdinalIgnoreCase))) {
+						Assert.AreEqual (CompressionMethod.Store, dll.CompressionMethod, $"{dll.FullName} should be uncompressed!");
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3596
Context: https://github.com/google/bundletool/blob/2e9ac4e628a690c0fce402548fe90c747c86533c/src/main/proto/config.proto#L22-L25

We got report of `.resx` files not working with Android App Bundles.

Sure enough, when I tried the sample:

https://docs.microsoft.com/en-us/samples/xamarin/xamarin-forms-samples/usingresxlocalization/

I was not seeing Spanish localization when running the app...

So I pulled the app bundle from the device:

    >  adb shell pm list packages -f | Select-String UsingResxLocalization.Android
    package:/data/app/UsingResxLocalization.Android-VGGyQ6woBTkNUy4HJ8WqmQ==/base.apk=UsingResxLocalization.Android
    > adb pull /data/app/UsingResxLocalization.Android-VGGyQ6woBTkNUy4HJ8WqmQ==/base.apk
    /data/app/UsingResxLocalization.Android-VGGyQ6woBTkNUy4HJ8WqmQ==/base.apk: 1 file pulled. 35.1 MB/s (12330445 bytes in 0.335s)

And then discovered that all of the localization assemblies were
compressed!

    > 7z l base.apk
    ...
    Size  Compressed    Name
    ----- ------------  ------------
    14848        14848  assemblies\UsingResxLocalization.dll
     3584         1279  assemblies\de-CH\UsingResxLocalization.resources.dll
     3584         1275  assemblies\de\UsingResxLocalization.resources.dll
     3584         1306  assemblies\es\UsingResxLocalization.resources.dll
     3584         1273  assemblies\fr\UsingResxLocalization.resources.dll
     3584         1286  assemblies\id\UsingResxLocalization.resources.dll
     3584         1348  assemblies\ja\UsingResxLocalization.resources.dll
     3584         1280  assemblies\ms\UsingResxLocalization.resources.dll
     3584         1302  assemblies\pt-BR\UsingResxLocalization.resources.dll
     3584         1301  assemblies\pt\UsingResxLocalization.resources.dll
     3584         1288  assemblies\zh-Hans\UsingResxLocalization.resources.dll
     3584         1288  assemblies\zh-Hant\UsingResxLocalization.resources.dll

Looking the file structure of the `base.apk`, we had an incorrect
wildcard for `BundleConfig.json`:

    assemblies/*

It needs to be `assemblies/**`, so sub-directories will work.

I added a project with `.resx` files to `BundleToolTests` and some
assertions to ensure all .NET assemblies remain uncompressed in
Android App Bundles.