### PR TITLE
[Xamarin.Android.Build.Tasks] .aab default uncompressed file extensions

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
@@ -14,6 +14,46 @@ namespace Xamarin.Android.Tasks
 	/// </summary>
 	public class BuildAppBundle : BundleTool
 	{
+		static readonly string [] UncompressedByDefault = new [] {
+			// Xamarin.Android specific files
+			"typemap.mj",
+			"typemap.jm",
+			"assemblies/**",
+			// Android specific files, listed here:
+			// https://github.com/google/bundletool/blob/5ac94cb61e949f135c50f6ce52bbb5f00e8e959f/src/main/java/com/android/tools/build/bundletool/io/ApkSerializerHelper.java#L111-L115
+			"**/*.3g2",
+			"**/*.3gp",
+			"**/*.3gpp",
+			"**/*.3gpp2",
+			"**/*.aac",
+			"**/*.amr",
+			"**/*.awb",
+			"**/*.gif",
+			"**/*.imy",
+			"**/*.jet",
+			"**/*.jpeg",
+			"**/*.jpg",
+			"**/*.m4a",
+			"**/*.m4v",
+			"**/*.mid",
+			"**/*.midi",
+			"**/*.mkv",
+			"**/*.mp2",
+			"**/*.mp3",
+			"**/*.mp4",
+			"**/*.mpeg",
+			"**/*.mpg",
+			"**/*.ogg",
+			"**/*.png",
+			"**/*.rtttl",
+			"**/*.smf",
+			"**/*.wav",
+			"**/*.webm",
+			"**/*.wma",
+			"**/*.wmv",
+			"**/*.xmf",
+		};
+
 		[Required]
 		public string BaseZip { get; set; }
 
@@ -28,11 +68,7 @@ namespace Xamarin.Android.Tasks
 		{
 			temp = Path.GetTempFileName ();
 			try {
-				var uncompressed = new List<string> {
-					"typemap.mj",
-					"typemap.jm",
-					"assemblies/**",
-				};
+				var uncompressed = new List<string> (UncompressedByDefault);
 				if (!string.IsNullOrEmpty (UncompressedFileExtensions)) {
 					//NOTE: these are file extensions, that need converted to glob syntax
 					var split = UncompressedFileExtensions.Split (new char [] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3598

By default, Android leaves "already compressed" files such as
`*.wav` uncompressed in APKs.

This behavior is implemented in `aapt` & `aapt2`:

* `aapt`: https://github.com/aosp-mirror/platform_frameworks_base/blob/036ea39d96babb6c8a20464319903aea130e1a5f/tools/aapt/Package.cpp#L30-L37
* `aapt2`: https://github.com/aosp-mirror/platform_frameworks_base/blob/e80b45506501815061b079dcb10bf87443bd385d/tools/aapt2/cmd/Link.cpp#L2339-L2343

`bundletool` has a similar list of file extensions:

https://github.com/google/bundletool/blob/5ac94cb61e949f135c50f6ce52bbb5f00e8e959f/src/main/java/com/android/tools/build/bundletool/io/ApkSerializerHelper.java#L111-L115

However, if you specify `BundleConfig.json` (the `--config` switch),
`bundletool` does not use the `NO_COMPRESSION_EXTENSIONS`
list at all:

https://github.com/google/bundletool/blob/5ac94cb61e949f135c50f6ce52bbb5f00e8e959f/src/main/java/com/android/tools/build/bundletool/io/ApkSerializerHelper.java#L323-L330

    For bundle versions starting by 0.7.3 the no-compression is fully
    configured through the bundle config file.

Since .NET assemblies need to be uncompressed, we now need to manage
our own list of file extensions... I grabbed the list from
`bundletool`, since it will only be used in the `<BuildAppBundle/>`
MSBuild task.

I added some tests around this scenario.