### PR TITLE
Bump to r8 1.5.68

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Android.Tasks
 		public string ProguardCommonXamarinConfiguration { get; set; }
 		public string ProguardConfigurationFiles { get; set; }
 
-		protected override string MainClass => "com.android.tools.r8.SwissArmyKnife";
+		protected override string MainClass => "com.android.tools.r8.R8";
 
 		string temp;
 

--- a/src/r8/build.gradle
+++ b/src/r8/build.gradle
@@ -2,15 +2,18 @@ plugins {
     id 'java'
 }
 
-// See: https://r8.googlesource.com/r8/+/refs/tags/1.4.93/build.gradle#52
+// See: https://r8.googlesource.com/r8/+/refs/tags/1.5.67/build.gradle#53
 repositories {
+    maven {
+       url 'http://storage.googleapis.com/r8-deps/maven_mirror/'
+    }
     maven { url 'https://maven.google.com' }
-    maven { url 'https://kotlin.bintray.com/kotlinx' }
     mavenCentral()
+    maven { url 'https://kotlin.bintray.com/kotlinx' }
 }
 
 dependencies {
-    compile group: 'com.android.tools', name: 'r8', version: '1.4.93'
+    compile group: 'com.android.tools', name: 'r8', version: '1.5.68'
 }
 
 jar {


### PR DESCRIPTION
Context: https://mvnrepository.com/artifact/com.android.tools/r8/1.5.68

I updated the list of maven repositories to match r8's source.

One weirdness to note, was there was a 1.5.68 tag missing, so I looked at 1.5.67 instead.