### PR TITLE
[Xamarin.Android.Build.Tasks] Ensure our tasks never leak an unhandled exception, which causes an MSB4018.

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@d868ae50822a3c940cae7c68993e06390a8d8e0a
+xamarin/monodroid:master@623845d44abe5eb7a76d9a63d48b30a27ac1bac2
 mono/mono:2019-08@29b1ac19c961b959a09097dbc0fe4cd567cc5298

--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:msbuild-codes@9e4d1fad3b25ef39c15e1ce324e28b050c8e5e8f
+xamarin/monodroid:master@d868ae50822a3c940cae7c68993e06390a8d8e0a
 mono/mono:2019-08@29b1ac19c961b959a09097dbc0fe4cd567cc5298

--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@3ed4b1921a43a6bf5718e82c923040e2512dd8cf
+xamarin/monodroid:msbuild-codes@9e4d1fad3b25ef39c15e1ce324e28b050c8e5e8f
 mono/mono:2019-08@29b1ac19c961b959a09097dbc0fe4cd567cc5298

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -103,7 +103,150 @@ ms.date: 08/23/2019
 
 ## XA6xxx: Internal tools
 
-## XA7xxx:	Reserved
+## XA7xxx: Unhandled MSBuild Exceptions
+
+Exceptions that have not been gracefully handled yet.  Ideally these will be fixed or replaced with better errors in the future.
+
+These take the form of `XACCC7NNN`, where `CCC` is a 3 character code denoting the MSBuild Task that is throwing the exception,
+and `NNN` is a 3 digit number indicating the type of the unhandled `Exception`.
+
+**Tasks:**
+* `A2C` - `Aapt2Compile`
+* `A2L` - `Aapt2Link`
+* `AAS` - `AndroidApkSigner`
+* `ACD` - `AndroidCreateDebugKey`
+* `ACM` - `AppendCustomMetadataToItemGroup`
+* `ADB` - `Adb`
+* `AJV` - `AdjustJavacVersionArguments`
+* `AOT` - `Aot`
+* `APT` - `Aapt`
+* `ASP` - `AndroidSignPackage`
+* `AZA` - `AndroidZipAlign`
+* `BAB` - `BuildAppBundle`
+* `BAS` - `BuildApkSet`
+* `BBA` - `BuildBaseAppBundle`
+* `BGN` - `BindingsGenerator`
+* `BLD` - `BuildApk`
+* `CAL` - `CreateAdditionalLibraryResourceCache`
+* `CAR` - `CalculateAdditionalResourceCacheDirectories`
+* `CCR` - `CopyAndConvertResources`
+* `CCV` - `ConvertCustomView`
+* `CDF` - `ConvertDebuggingFiles`
+* `CDJ` - `CheckDuplicateJavaLibraries`
+* `CFI` - `CheckForInvalidResourceFileNames`
+* `CFR` - `CheckForRemovedItems`
+* `CGJ` - `CopyGeneratedJavaResourceClasses`
+* `CGS` - `CheckGoogleSdkRequirements`
+* `CIC` - `CopyIfChanged`
+* `CIL` - `CilStrip`
+* `CLA` - `CollectLibraryAssets`
+* `CLC` - `CalculateLayoutCodeBehind`
+* `CLP` - `ClassParse`
+* `CLR` - `CreateLibraryResourceArchive`
+* `CMD` - `CreateMultiDexMainDexClassList`
+* `CML` - `CreateManagedLibraryResourceArchive`
+* `CMM` - `CreateMsymManifest`
+* `CNA` - `CompileNativeAssembly`
+* `CNE` - `CollectNonEmptyDirectories`
+* `CNL` - `CreateNativeLibraryArchive`
+* `CPD` - `CalculateProjectDependencies`
+* `CPF` - `CollectPdbFiles`
+* `CPI` - `CheckProjectItems`
+* `CPR` - `CopyResource`
+* `CPT` - `ComputeHash`
+* `CRC` - `ConvertResourcesCases`
+* `CRM` - `CreateResgenManifest`
+* `CRN` - `Crunch`
+* `CRP` - `AndroidComputeResPaths`
+* `CTD` - `CreateTemporaryDirectory`
+* `CTX` - `CompileToDalvik`
+* `DES` - `Desugar`
+* `DJL` - `DetermineJavaLibrariesToCompile`
+* `DX8` - `D8`
+* `FLB` - `FindLayoutsToBind`
+* `FLT` - `FilterAssemblies`
+* `GAD` - `GetAndroidDefineConstants`
+* `GAP` - `GetAndroidPackageName`
+* `GAR` - `GetAdditionalResourcesFromAssemblies`
+* `GAS` - `GetAppSettingsDirectory`
+* `GCB` - `GenerateCodeBehindForLayout`
+* `GCJ` - `GetConvertedJavaLibraries`
+* `GEP` - `GetExtraPackages`
+* `GFT` - `GetFilesThatExist`
+* `GIL` - `GetImportedLibraries`
+* `GJP` - `GetJavaPlatformJar`
+* `GJS` - `GenerateJavaStubs`
+* `GLB` - `GenerateLayoutBindings`
+* `GLR` - `GenerateLibraryResources`
+* `GMA` - `GenerateManagedAidlProxies`
+* `GMJ` - `GetMonoPlatformJar`
+* `GPM` - `GeneratePackageManagerJava`
+* `GRD` - `GenerateResourceDesigner`
+* `IAS` - `InstallApkSet`
+* `IJD` - `ImportJavaDoc`
+* `JDC` - `JavaDoc`
+* `JVC` - `Javac`
+* `JTX` - `JarToXml`
+* `KEY` - `KeyTool`
+* `LAS` - `LinkApplicationSharedLibraries`
+* `LEF` - `LogErrorsForFiles`
+* `LNK` - `LinkAssemblies`
+* `LNS` - `LinkAssembliesNoShrink`
+* `LNT` - `Lint`
+* `LWF` - `LogWarningsForFiles`
+* `MBN` - `MakeBundleNativeCodeExternal`
+* `MDC` - `MDoc`
+* `MER` - `MergeResources`
+* `PAI` - `PrepareAbiItems`
+* `PAW` - `ParseAndroidWearProjectAndManifest`
+* `PRO` - `Proguard`
+* `PWA` - `PrepareWearApplicationFiles`
+* `R8D` - `R8`
+* `RAM` - `ReadAndroidManifest`
+* `RAR` - `ReadAdditionalResourcesFromAssemblyCache`
+* `RAT` - `ResolveAndroidTooling`
+* `RDF` - `RemoveDirFixed`
+* `RIL` - `ReadImportedLibrariesCache`
+* `RJJ` - `ResolveJdkJvmPath`
+* `RLC` - `ReadLibraryProjectImportsCache`
+* `RLP` - `ResolveLibraryProjectImports`
+* `RRA` - `RemoveRegisterAttribute`
+* `RSA` - `ResolveAssemblies`
+* `RSD` - `ResolveSdks`
+* `RUF` - `RemoveUnknownFiles`
+* `SPL` - `SplitProperty`
+* `SVM` - `SetVsMonoAndroidRegistryKey`
+* `UNZ` - `Unzip`
+* `VJV` - `ValidateJavaVersion`
+* `WLF` - `WriteLockFile`
+
+**Exceptions:**
+
+* `7000` - Other Exception
+* `7001` - `NullReferenceException`
+* `7002` - `ArgumentOutOfRangeException`
+* `7003` - `ArgumentNullException`
+* `7004` - `ArgumentException`
+* `7005` - `FormatException`
+* `7006` - `IndexOutOfRangeException`
+* `7007` - `InvalidCastException`
+* `7008` - `ObjectDisposedException`
+* `7009` - `InvalidOperationException`
+* `7010` - `InvalidProgramException`
+* `7011` - `KeyNotFoundException`
+* `7012` - `TaskCanceledException`
+* `7013` - `OperationCanceledException`
+* `7014` - `OutOfMemoryException`
+* `7015` - `NotSupportedException`
+* `7016` - `StackOverflowException`
+* `7017` - `TimeoutException`
+* `7018` - `TypeInitializationException`
+* `7019` - `UnauthorizedAccessException`
+* `7020` - `ApplicationException`
+* `7021` - `KeyNotFoundException`
+* `7022` - `PathTooLongException`
+* `7023` - `DirectoryNotFoundException`
+* `7024` - `IOException`
 
 ## XA8xxx:	Reserved
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -17,8 +17,10 @@ using Xamarin.Build;
 
 namespace Xamarin.Android.Tasks
 {
-	public class Aapt : AsyncTask
+	public class Aapt : AndroidAsyncTask
 	{
+		public override string TaskPrefix => "APT";
+
 		public ITaskItem[] AdditionalAndroidResourcePaths { get; set; }
 
 		public string AndroidComponentResgenFlagFile { get; set; }
@@ -212,7 +214,7 @@ namespace Xamarin.Android.Tasks
 			return;
 		}
 
-		public override bool Execute () 
+		public override bool RunTask () 
 		{
 			resourceDirectory = ResourceDirectory.TrimEnd ('\\');
 			if (!Path.IsPathRooted (resourceDirectory))
@@ -223,7 +225,7 @@ namespace Xamarin.Android.Tasks
 
 				task.ContinueWith (Complete);
 
-				base.Execute ();
+				base.RunTask ();
 			} finally {
 				Reacquire ();
 			}
@@ -400,7 +402,7 @@ namespace Xamarin.Android.Tasks
 			if (string.IsNullOrEmpty (singleLine)) 
 				return;
 
-			var match = AndroidToolTask.AndroidErrorRegex.Match (singleLine.Trim ());
+			var match = AndroidRunToolTask.AndroidErrorRegex.Match (singleLine.Trim ());
 
 			if (match.Success) {
 				var file = match.Groups["file"].Value;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -18,7 +18,7 @@ using Xamarin.Build;
 
 namespace Xamarin.Android.Tasks {
 	
-	public class Aapt2 : AsyncTask {
+	public abstract class Aapt2 : AndroidAsyncTask {
 
 		protected Dictionary<string, string> resource_name_case_map;
 
@@ -97,7 +97,7 @@ namespace Xamarin.Android.Tasks {
 
 		bool IsAapt2Warning (string singleLine)
 		{
-			var match = AndroidToolTask.AndroidErrorRegex.Match (singleLine.Trim ());
+			var match = AndroidRunToolTask.AndroidErrorRegex.Match (singleLine.Trim ());
 			if (match.Success) {
 				var file = match.Groups ["file"].Value;
 				var level = match.Groups ["level"].Value.ToLowerInvariant ();
@@ -117,7 +117,7 @@ namespace Xamarin.Android.Tasks {
 			if (string.IsNullOrEmpty (singleLine))
 				return true;
 
-			var match = AndroidToolTask.AndroidErrorRegex.Match (singleLine.Trim ());
+			var match = AndroidRunToolTask.AndroidErrorRegex.Match (singleLine.Trim ());
 
 			if (match.Success) {
 				var file = match.Groups ["file"].Value;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
@@ -16,6 +16,7 @@ using Xamarin.Android.Tools;
 namespace Xamarin.Android.Tasks {
 	
 	public class Aapt2Compile : Aapt2 {
+		public override string TaskPrefix => "A2C";
 
 		List<ITaskItem> archives = new List<ITaskItem> ();
 
@@ -28,7 +29,7 @@ namespace Xamarin.Android.Tasks {
 		[Output]
 		public ITaskItem [] CompiledResourceFlatArchives => archives.ToArray ();
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			Yield ();
 			try {
@@ -36,7 +37,7 @@ namespace Xamarin.Android.Tasks {
 
 				task.ContinueWith (Complete);
 
-				base.Execute ();
+				base.RunTask ();
 			} finally {
 				Reacquire ();
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -17,6 +17,8 @@ namespace Xamarin.Android.Tasks {
 	
 	//aapt2 link -o resources.apk.bk --manifest Foo.xml --java . --custom-package com.infinitespace_studios.blankforms -R foo2 -v --auto-add-overlay
 	public class Aapt2Link : Aapt2 {
+		public override string TaskPrefix => "A2L";
+
 		[Required]
 		public ITaskItem [] ManifestFiles { get; set; }
 
@@ -75,7 +77,7 @@ namespace Xamarin.Android.Tasks {
 		AssemblyIdentityMap assemblyMap = new AssemblyIdentityMap ();
 		List<string> tempFiles = new List<string> ();
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			Yield ();
 			try {
@@ -83,7 +85,7 @@ namespace Xamarin.Android.Tasks {
 
 				task.ContinueWith (Complete);
 
-				base.Execute ();
+				base.RunTask ();
 			} finally {
 				Reacquire ();
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AdjustJavacVersionArguments.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AdjustJavacVersionArguments.cs
@@ -7,8 +7,10 @@ using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
-	public class AdjustJavacVersionArguments : Task
+	public class AdjustJavacVersionArguments : AndroidTask
 	{
+		public override string TaskPrefix => "AJV";
+
 		[Required]
 		public string JdkVersion { get; set; }
 
@@ -27,7 +29,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public string SourceVersion { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (JdkVersion.StartsWith ("9", StringComparison.OrdinalIgnoreCase)) {
 				TargetVersion = SourceVersion = DefaultJdkVersion;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidApkSigner.cs
@@ -8,6 +8,8 @@ namespace Xamarin.Android.Tasks
 {
 	public class AndroidApkSigner : JavaToolTask
 	{
+		public override string TaskPrefix => "AAS";
+
 		[Required]
 		public string ApkSignerJar { get; set; }
 
@@ -49,14 +51,14 @@ namespace Xamarin.Android.Tasks
 
 		public string AdditionalArguments { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (!File.Exists (GenerateFullPathToTool ())) {
 				Log.LogError ($"'{GenerateFullPathToTool ()}' does not exist. You need to install android-sdk build-tools 26.0.1 or above.");
 				return false;
 			}
 
-			return base.Execute ();
+			return base.RunTask ();
 		}
 
 		void AddStorePass (CommandLineBuilder cmd, string cmdLineSwitch, string value)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidCreateDebugKey.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidCreateDebugKey.cs
@@ -7,6 +7,8 @@ namespace Xamarin.Android.Tasks
 {
 	public class AndroidCreateDebugKey : KeyTool
 	{
+		public override string TaskPrefix => "ACD";
+
 		public int Validity { get; set; }
 
 		public string KeyAlgorithm { get; set; }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
@@ -5,8 +5,10 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks
 {
-	public class AndroidSignPackage : AndroidToolTask
+	public class AndroidSignPackage : AndroidRunToolTask
 	{
+		public override string TaskPrefix => "ASP";
+
 		bool hasWarnings;
 
 		[Required]

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidTask.cs
@@ -1,0 +1,61 @@
+using System;
+using Microsoft.Build.Utilities;
+using Xamarin.Build;
+
+namespace Xamarin.Android.Tasks
+{
+	// We use this task to ensure that no unhandled exceptions
+	// escape our tasks which would cause an MSB4018
+	public abstract class AndroidTask : Task
+	{
+		public abstract string TaskPrefix { get; }
+
+		public override bool Execute ()
+		{
+			try {
+				return RunTask ();
+			} catch (Exception ex) {
+				Log.LogUnhandledException (TaskPrefix, ex);
+				return false;
+			}
+		}
+
+		public abstract bool RunTask ();
+	}
+
+	public abstract class AndroidAsyncTask : AsyncTask
+	{
+		public abstract string TaskPrefix { get; }
+
+		public override bool Execute ()
+		{
+			try {
+				return RunTask ();
+			} catch (Exception ex) {
+				Log.LogUnhandledException (TaskPrefix, ex);
+				return false;
+			}
+		}
+
+		public virtual bool RunTask () => base.Execute ();
+	}
+
+	public abstract class AndroidToolTask : ToolTask
+	{
+		public abstract string TaskPrefix { get; }
+
+		public override bool Execute ()
+		{
+			try {
+				return RunTask ();
+			} catch (Exception ex) {
+				Log.LogUnhandledException (TaskPrefix, ex);
+				return false;
+			}
+		}
+
+		// Most ToolTask's do not override Execute and
+		// just expect the base to be called
+		public virtual bool RunTask () => base.Execute ();
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidToolTask.cs
@@ -6,7 +6,7 @@ using Microsoft.Build.Framework;
 
 namespace Xamarin.Android.Tasks
 {
-	public abstract class AndroidToolTask : ToolTask
+	public abstract class AndroidRunToolTask : AndroidToolTask
 	{
 		protected static bool IsWindows = Path.DirectorySeparatorChar == '\\';
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidUpdateResDir.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidUpdateResDir.cs
@@ -34,8 +34,10 @@ using System.Linq;
 
 namespace Xamarin.Android.Tasks
 {
-	public class AndroidComputeResPaths : Task
+	public class AndroidComputeResPaths : AndroidTask
 	{
+		public override string TaskPrefix => "CRP";
+
 		[Required]
 		public ITaskItem[] ResourceFiles { get; set; }
 		
@@ -57,7 +59,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public string ResourceNameCaseMap { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var intermediateFiles = new List<ITaskItem> ();
 			var resolvedFiles = new List<ITaskItem> ();
@@ -140,8 +142,10 @@ namespace Xamarin.Android.Tasks
 		}
 	}
 	
-	public class RemoveUnknownFiles : Task
+	public class RemoveUnknownFiles : AndroidTask
 	{
+		public override string TaskPrefix => "RUF";
+
 		static bool IsWindows = Path.DirectorySeparatorChar == '\\';
 
 		[Required]
@@ -158,7 +162,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem [] RemovedDirectories { get; set; }
 		
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var absDir = Path.GetFullPath (Directory);
 			

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidZipAlign.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidZipAlign.cs
@@ -9,8 +9,10 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks
 {
-	public class AndroidZipAlign : AndroidToolTask
+	public class AndroidZipAlign : AndroidRunToolTask
 	{
+		public override string TaskPrefix => "AZA";
+
 		public AndroidZipAlign ()
 		{
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -31,8 +31,10 @@ namespace Xamarin.Android.Tasks
 	}
 
 	// can't be a single ToolTask, because it has to run mkbundle many times for each arch.
-	public class Aot : AsyncTask
+	public class Aot : AndroidAsyncTask
 	{
+		public override string TaskPrefix => "AOT";
+
 		[Required]
 		public string AndroidAotMode { get; set; }
 
@@ -84,7 +86,7 @@ namespace Xamarin.Android.Tasks
 		{
 		}
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (EnableLLVM && !NdkUtil.Init (Log, AndroidNdkDirectory))
 				return false;
@@ -250,7 +252,7 @@ namespace Xamarin.Android.Tasks
 
 				task.ContinueWith (Complete);
 
-				base.Execute ();
+				base.RunTask ();
 
 				if (!task.Result)
 					return false;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AppendCustomMetadataToItemGroup.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AppendCustomMetadataToItemGroup.cs
@@ -6,7 +6,9 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks {
-	public class AppendCustomMetadataToItemGroup : Task {
+	public class AppendCustomMetadataToItemGroup : AndroidTask {
+		public override string TaskPrefix => "ACM";
+
 		[Required]
 		public ITaskItem[] Inputs { get; set; }
 
@@ -16,7 +18,7 @@ namespace Xamarin.Android.Tasks {
 		[Output]
 		public ITaskItem[] Output { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var output = new List<ITaskItem> ();
 			var metaData = new Dictionary<string, List<ITaskItem>> (StringComparer.InvariantCultureIgnoreCase);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -20,8 +20,10 @@ using Xamarin.Tools.Zip;
 
 namespace Xamarin.Android.Tasks
 {
-	public class BuildApk : Task
+	public class BuildApk : AndroidTask
 	{
+		public override string TaskPrefix => "BLD";
+
 		public string AndroidNdkDirectory { get; set; }
 
 		[Required]
@@ -201,7 +203,7 @@ namespace Xamarin.Android.Tasks
 			File.Delete (temp);
 		}
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			Aot.TryGetSequencePointsMode (AndroidSequencePointsMode, out sequencePointsMode);
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApkSet.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApkSet.cs
@@ -12,6 +12,8 @@ namespace Xamarin.Android.Tasks
 	/// </summary>
 	public class BuildApkSet : BundleTool
 	{
+		public override string TaskPrefix => "BAS";
+
 		[Required]
 		public string AppBundle { get; set; }
 
@@ -47,13 +49,13 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string StorePass { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			//NOTE: bundletool will not overwrite
 			if (File.Exists (Output))
 				File.Delete (Output);
 
-			base.Execute ();
+			base.RunTask ();
 
 			return !Log.HasLoggedErrors;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
@@ -14,6 +14,8 @@ namespace Xamarin.Android.Tasks
 	/// </summary>
 	public class BuildAppBundle : BundleTool
 	{
+		public override string TaskPrefix => "BAB";
+
 		static readonly string [] UncompressedByDefault = new [] {
 			// Xamarin.Android specific files
 			"typemap.mj",
@@ -64,7 +66,7 @@ namespace Xamarin.Android.Tasks
 
 		string temp;
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			temp = Path.GetTempFileName ();
 			try {
@@ -88,7 +90,7 @@ namespace Xamarin.Android.Tasks
 				if (File.Exists (Output))
 					File.Delete (Output);
 
-				base.Execute ();
+				base.RunTask ();
 			} finally {
 				File.Delete (temp);
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildBaseAppBundle.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildBaseAppBundle.cs
@@ -8,6 +8,8 @@ namespace Xamarin.Android.Tasks
 {
 	public class BuildBaseAppBundle : BuildApk
 	{
+		public override string TaskPrefix => "BBA";
+
 		/// <summary>
 		/// Files that need to land in the final APK need to go in `root/`
 		/// </summary>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateAdditionalResourceCacheDirectories.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateAdditionalResourceCacheDirectories.cs
@@ -10,8 +10,10 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CalculateAdditionalResourceCacheDirectories : Task
+	public class CalculateAdditionalResourceCacheDirectories : AndroidTask
 	{
+		public override string TaskPrefix => "CAR";
+
 		[Required]
 		public string[] AdditionalAndroidResourcePaths { get; set; }
 
@@ -21,7 +23,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem[] AdditionalResourceCachePaths { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (!AdditionalAndroidResourcePaths.Any ())
 				return true;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
@@ -15,8 +15,10 @@ using Xamarin.Build;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CalculateLayoutCodeBehind : AsyncTask
+	public class CalculateLayoutCodeBehind : AndroidAsyncTask
 	{
+		public override string TaskPrefix => "CLC";
+
 		sealed class LayoutInclude
 		{
 			public string Id;
@@ -111,7 +113,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem [] LayoutPartialClassFiles { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			widgetWithId = XPathExpression.Compile ("//*[@android:id and string-length(@android:id) != 0] | //include[not(@android:id)]");
 
@@ -143,7 +145,7 @@ namespace Xamarin.Android.Tasks
 					() => this.ParallelForEach (layoutsByName, kvp => ParseAndLoadGroup (layoutsByName, kvp.Key, kvp.Value.InputItems, ref kvp.Value.LayoutBindingItems, ref kvp.Value.LayoutPartialClassItems))
 				).ContinueWith (t => Complete ());
 
-				base.Execute ();
+				base.RunTask ();
 
 				foreach (var kvp in layoutsByName) {
 					LayoutGroup group = kvp.Value;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateProjectDependencies.cs
@@ -7,8 +7,10 @@ using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CalculateProjectDependencies : Task
+	public class CalculateProjectDependencies : AndroidTask
 	{
+		public override string TaskPrefix => "CPD";
+
 		const int DefaultMinSDKVersion = 11;
 
 		[Required]
@@ -41,7 +43,7 @@ namespace Xamarin.Android.Tasks
 			});
 		}
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var dependencies = new List<ITaskItem> ();
 			var targetApiLevel = MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (TargetFrameworkVersion);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckDuplicateJavaLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckDuplicateJavaLibraries.cs
@@ -6,13 +6,15 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CheckDuplicateJavaLibraries : Task
+	public class CheckDuplicateJavaLibraries : AndroidTask
 	{
-		public ITaskItem[] JavaSourceFiles { get; set; }
+		public override string TaskPrefix => "CDJ";
+
+		public ITaskItem [] JavaSourceFiles { get; set; }
 		public ITaskItem[] JavaLibraries { get; set; }		
 		public ITaskItem[] LibraryProjectJars { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var jarFiles = (JavaSourceFiles != null) ? JavaSourceFiles.Where (f => f.ItemSpec.EndsWith (".jar")) : null;
 			if (jarFiles != null && JavaLibraries != null)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckForInvalidResourceFileNames.cs
@@ -12,14 +12,16 @@ using System.Collections.Generic;
 using Xamarin.Android.Tasks;
 
 namespace Xamarin.Android.Tasks {
-	public class CheckForInvalidResourceFileNames : Task {
+	public class CheckForInvalidResourceFileNames : AndroidTask {
+		public override string TaskPrefix => "CFI";
+
 		[Required]
 		public ITaskItem[] Resources { get; set; }
 
 		Regex fileNameCheck = new Regex ("[^a-zA-Z0-9_.]+", RegexOptions.Compiled);
 		Regex fileNameWithHyphenCheck = new Regex ("[^a-zA-Z0-9_.-]+", RegexOptions.Compiled);
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			foreach (var resource in Resources) {
 				var resourceFile = resource.GetMetadata ("LogicalName").Replace ('\\', Path.DirectorySeparatorChar);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckForRemovedItems.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckForRemovedItems.cs
@@ -7,8 +7,10 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CheckForRemovedItems : Task 
+	public class CheckForRemovedItems : AndroidTask 
 	{
+		public override string TaskPrefix => "CFR";
+
 		[Required]
 		public ITaskItem[] Files { get; set; }
 
@@ -18,7 +20,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem RemovedFilesFlag { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var absDir = Path.GetFullPath (Directory);
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckGoogleSdkRequirements.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckGoogleSdkRequirements.cs
@@ -10,15 +10,17 @@ using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CheckGoogleSdkRequirements : Task 
+	public class CheckGoogleSdkRequirements : AndroidTask 
 	{
+		public override string TaskPrefix => "CGS";
+
 		[Required]
 		public string TargetFrameworkVersion { get; set; }
 
 		[Required]
 		public string ManifestFile { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			ManifestDocument manifest = new ManifestDocument (ManifestFile, this.Log);
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckProjectItems.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckProjectItems.cs
@@ -7,15 +7,17 @@ using System.IO;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CheckProjectItems : Task
+	public class CheckProjectItems : AndroidTask
 	{
+		public override string TaskPrefix => "CPI";
+
 		public bool IsApplication { get; set; }
 		public ITaskItem [] EmbeddedNativeLibraries { get; set; }
 		public ITaskItem [] NativeLibraries { get; set; }
 		public ITaskItem [] JavaLibraries { get; set; }
 		public ITaskItem [] JavaSourceFiles { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (IsApplication && EmbeddedNativeLibraries != null && EmbeddedNativeLibraries.Length > 0) {
 				foreach (ITaskItem lib in EmbeddedNativeLibraries) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CilStrip.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CilStrip.cs
@@ -9,8 +9,10 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CilStrip : Task
+	public class CilStrip : AndroidTask
 	{
+		public override string TaskPrefix => "CIL";
+
 		[Required]
 		public string AndroidAotMode { get; set; }
 
@@ -27,7 +29,7 @@ namespace Xamarin.Android.Tasks
 		{
 		}
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			try {
 				return DoExecute ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ClassParse.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ClassParse.cs
@@ -13,8 +13,10 @@ using System.Diagnostics;
 
 namespace Xamarin.Android.Tasks
 {
-	public class ClassParse : Task
+	public class ClassParse : AndroidTask
 	{
+		public override string TaskPrefix => "CLP";
+
 		[Required]
 		public string OutputFile { get; set; }
 
@@ -23,7 +25,7 @@ namespace Xamarin.Android.Tasks
 
 		public ITaskItem [] DocumentationPaths { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			using (var output = new StreamWriter (OutputFile, append: false, 
 						encoding: new UTF8Encoding (encoderShouldEmitUTF8Identifier: false))) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CollectLibraryAssets.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CollectLibraryAssets.cs
@@ -5,12 +5,14 @@ using System.IO;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CollectLibraryAssets : Task
+	public class CollectLibraryAssets : AndroidTask
 	{
+		public override string TaskPrefix => "CLA";
+
 		public string AssetDirectory { get; set; }
 		public string [] AdditionalAssetDirectories { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (AdditionalAssetDirectories != null)
 				foreach (var dir in AdditionalAssetDirectories)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
@@ -7,7 +7,9 @@ using Microsoft.Build.Framework;
 
 namespace Xamarin.Android.Tasks {
 	
-	public class CollectNonEmptyDirectories : Task {
+	public class CollectNonEmptyDirectories : AndroidTask {
+		public override string TaskPrefix => "CNE";
+
 		List<ITaskItem> output = new List<ITaskItem> ();
 
 		[Required]
@@ -16,7 +18,7 @@ namespace Xamarin.Android.Tasks {
 		[Output]
 		public ITaskItem[] Output => output.ToArray ();
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			foreach (var directory in Directories) {
 				if (!Directory.Exists (directory.ItemSpec))

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CollectPdbFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CollectPdbFiles.cs
@@ -7,8 +7,10 @@ using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CollectPdbFiles : Task
+	public class CollectPdbFiles : AndroidTask
 	{
+		public override string TaskPrefix => "CPF";
+
 		[Required]
 		public ITaskItem[] ResolvedAssemblies { get; set; }
 
@@ -18,7 +20,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem[] PortablePdbFiles { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var pdbFiles = new List<ITaskItem> ();
 			var portablePdbFiles = new List<ITaskItem> ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
@@ -12,8 +12,10 @@ using Xamarin.Build;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CompileNativeAssembly : AsyncTask
+	public class CompileNativeAssembly : AndroidAsyncTask
 	{
+		public override string TaskPrefix => "CNA";
+
 		sealed class Config
 		{
 			public string AssemblerPath;
@@ -33,7 +35,7 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string AndroidBinUtilsDirectory { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			try {
 				return DoExecute ();
@@ -56,7 +58,7 @@ namespace Xamarin.Android.Tasks
 				var task = this.RunTask ( () => RunParallelAssembler ());
 				task.ContinueWith (Complete);
 
-				base.Execute ();
+				base.RunTask ();
 
 				if (!task.Result)
 					return false;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileToDalvik.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileToDalvik.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Android.Tasks
 {
 	public class CompileToDalvik : JavaToolTask
 	{
-		public override string TaskPrefix => "CTD";
+		public override string TaskPrefix => "CTX";
 
 		public ITaskItem [] AdditionalJavaLibraryReferences { get; set; }
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileToDalvik.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileToDalvik.cs
@@ -14,7 +14,9 @@ namespace Xamarin.Android.Tasks
 {
 	public class CompileToDalvik : JavaToolTask
 	{
-		public ITaskItem[] AdditionalJavaLibraryReferences { get; set; }
+		public override string TaskPrefix => "CTD";
+
+		public ITaskItem [] AdditionalJavaLibraryReferences { get; set; }
 
 		[Required]
 		public string ClassesOutputDirectory { get; set; }
@@ -48,7 +50,7 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (!Directory.Exists (ClassesOutputDirectory))
 				Directory.CreateDirectory (ClassesOutputDirectory);
@@ -56,7 +58,7 @@ namespace Xamarin.Android.Tasks
 			bool ret = false;
 			inputListFile = Path.GetTempFileName ();
 			try {
-				ret = base.Execute ();
+				ret = base.RunTask ();
 			} catch (FileNotFoundException ex) {
 				Log.LogCodedError ("XA1003", ex.ToString ());
 			} finally {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ComputeHash.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ComputeHash.cs
@@ -7,7 +7,8 @@ using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
 
 namespace Xamarin.Android.Tasks {
-	public class ComputeHash : Task {
+	public class ComputeHash : AndroidTask {
+		public override string TaskPrefix => "CPT";
 
 		List<ITaskItem> output = new List<ITaskItem> ();
 
@@ -19,7 +20,7 @@ namespace Xamarin.Android.Tasks {
 		[Output]
 		public ITaskItem [] Output { get => output.ToArray (); }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			using (var sha1 = SHA1.Create ()) {
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
@@ -11,7 +11,8 @@ using Microsoft.Build.Utilities;
 using Monodroid;
 
 namespace Xamarin.Android.Tasks {
-	public class ConvertCustomView : Task {
+	public class ConvertCustomView : AndroidTask {
+		public override string TaskPrefix => "CCV";
 
 		[Required]
 		public string CustomViewMapFile { get; set; }
@@ -26,7 +27,7 @@ namespace Xamarin.Android.Tasks {
 		[Output]
 		public ITaskItem [] Processed { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var resource_name_case_map = MonoAndroidHelper.LoadResourceCaseMap (ResourceNameCaseMap);
 			var acw_map = MonoAndroidHelper.LoadAcwMapFile (AcwMapFile);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertDebuggingFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertDebuggingFiles.cs
@@ -7,8 +7,10 @@ using Pdb2Mdb;
 
 namespace Xamarin.Android.Tasks
 {
-	public class ConvertDebuggingFiles : Task
+	public class ConvertDebuggingFiles : AndroidTask
 	{
+		public override string TaskPrefix => "CDF";
+
 		// The .pdb files we need to convert
 		[Required]
 		public ITaskItem[] Files { get; set; }
@@ -16,7 +18,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem[] ConvertedFiles { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var convertedFiles = new List<ITaskItem> ();
 			foreach (var file in Files) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertResourcesCases.cs
@@ -11,8 +11,10 @@ using Monodroid;
 
 namespace Xamarin.Android.Tasks
 {
-	public class ConvertResourcesCases : Task
+	public class ConvertResourcesCases : AndroidTask
 	{
+		public override string TaskPrefix => "CRC";
+
 		[Required]
 		public ITaskItem[] ResourceDirectories { get; set; }
 
@@ -31,7 +33,7 @@ namespace Xamarin.Android.Tasks
 		Dictionary<string,string> resource_name_case_map;
 		Dictionary<string, HashSet<string>> customViewMap;
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			resource_name_case_map = MonoAndroidHelper.LoadResourceCaseMap (ResourceNameCaseMap);
 			var acw_map = MonoAndroidHelper.LoadAcwMapFile (AcwMapFile);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyAndConvertResources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyAndConvertResources.cs
@@ -10,8 +10,10 @@ using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CopyAndConvertResources : Task
+	public class CopyAndConvertResources : AndroidTask
 	{
+		public override string TaskPrefix => "CCR";
+
 		[Required]
 		public ITaskItem[] SourceFiles { get; set; }
 
@@ -37,7 +39,7 @@ namespace Xamarin.Android.Tasks
 		private List<ITaskItem> modifiedFiles = new List<ITaskItem>();
 		Dictionary<string, HashSet<string>> customViewMap;
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (SourceFiles.Length != DestinationFiles.Length)
 				throw new ArgumentException ("source and destination count mismatch");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyGeneratedJavaResourceClasses.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyGeneratedJavaResourceClasses.cs
@@ -7,8 +7,10 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CopyGeneratedJavaResourceClasses : Task
+	public class CopyGeneratedJavaResourceClasses : AndroidTask
 	{
+		public override string TaskPrefix => "CGJ";
+
 		[Required]
 		public string SourceTopDirectory { get; set; }
 		public string DestinationTopDirectory { get; set; }
@@ -19,7 +21,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public string PrimaryJavaResgenFile { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var list = new List<string> ();
 			foreach (var pkg in GetPackages ()) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyIfChanged.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyIfChanged.cs
@@ -14,8 +14,10 @@ namespace Xamarin.Android.Tasks
 	// when it hasn't actually changed, the user will get a "Reload?"
 	// prompt in IDEs, so we only want to copy the file if there is
 	// an actual change.
-	public class CopyIfChanged : Task
+	public class CopyIfChanged : AndroidTask
 	{
+		public override string TaskPrefix => "CIC";
+
 		[Required]
 		public ITaskItem[] SourceFiles { get; set; }
 
@@ -27,7 +29,7 @@ namespace Xamarin.Android.Tasks
 
 		private List<ITaskItem> modifiedFiles = new List<ITaskItem>();
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (SourceFiles.Length != DestinationFiles.Length)
 				throw new ArgumentException ("source and destination count mismatch");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyResource.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyResource.cs
@@ -10,8 +10,10 @@ using Java.Interop.Tools.JavaCallableWrappers;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CopyResource : Task
+	public class CopyResource : AndroidTask
 	{
+		public override string TaskPrefix => "CPR";
+
 		[Required]
 		public string ResourceName { get; set; }
 
@@ -20,7 +22,7 @@ namespace Xamarin.Android.Tasks
 
 		static readonly Assembly ExecutingAssembly = Assembly.GetExecutingAssembly ();
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			using (var from = ExecutingAssembly.GetManifestResourceStream (ResourceName)) {
 				if (from == null) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateAdditionalLibraryResourceCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateAdditionalLibraryResourceCache.cs
@@ -10,8 +10,9 @@ using Microsoft.Build.Framework;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CreateAdditionalLibraryResourceCache : Task
+	public class CreateAdditionalLibraryResourceCache : AndroidTask
 	{
+		public override string TaskPrefix => "CAL";
 
 		[Required]
 		public ITaskItem[] AdditionalAndroidResourcePaths { get; set; }
@@ -23,7 +24,7 @@ namespace Xamarin.Android.Tasks
 		public ITaskItem[] CopiedResources { get; set; }
 
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var copiedResources = new List<ITaskItem> ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateLibraryResourceArchive.cs
@@ -14,8 +14,10 @@ using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CreateLibraryResourceArchive : Task
+	public class CreateLibraryResourceArchive : AndroidTask
 	{
+		public override string TaskPrefix => "CLR";
+
 		[Required]
 		public string OutputDirectory { get; set; }
 
@@ -35,7 +37,7 @@ namespace Xamarin.Android.Tasks
 		{
 		}
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (LibraryProjectPropertiesFiles.Length == 0 && LibraryProjectZipFiles.Length == 0)
 				return true;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateManagedLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateManagedLibraryResourceArchive.cs
@@ -11,8 +11,10 @@ namespace Xamarin.Android.Tasks
 	/// <summary>
 	/// Creates __AndroidLibraryProjects__.zip, $(AndroidApplication) should be False!
 	/// </summary>
-	public class CreateManagedLibraryResourceArchive : Task
+	public class CreateManagedLibraryResourceArchive : AndroidTask
 	{
+		public override string TaskPrefix => "CML";
+
 		[Required]
 		public string OutputDirectory { get; set; }
 
@@ -37,7 +39,7 @@ namespace Xamarin.Android.Tasks
 		{
 		}
 		
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var outDirInfo = new DirectoryInfo (OutputDirectory);
 			

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateMsymManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateMsymManifest.cs
@@ -6,8 +6,10 @@ using System.IO;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CreateMsymManifest : Task
+	public class CreateMsymManifest : AndroidTask
 	{
+		public override string TaskPrefix => "CMM";
+
 		[Required]
 		public string BuildId { get; set; }
 
@@ -17,7 +19,7 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string OutputDirectory { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			XDocument doc = new XDocument (
 				new XElement ("mono-debug", new XAttribute("version", "1"),

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
@@ -14,6 +14,8 @@ namespace Xamarin.Android.Tasks
 {
 	public class CreateMultiDexMainDexClassList : JavaToolTask
 	{
+		public override string TaskPrefix => "CMD";
+
 		[Required]
 		public string ClassesOutputDirectory { get; set; }
 
@@ -35,12 +37,12 @@ namespace Xamarin.Android.Tasks
 		string tempJar;
 		bool writeOutputToKeepFile = false;
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			tempJar = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName () + ".jar");
 			commandlineAction = GenerateProguardCommands;
 			// run proguard first
-			var retval = base.Execute ();
+			var retval = base.RunTask ();
 			if (!retval || Log.HasLoggedErrors)
 				return false;
 
@@ -50,7 +52,7 @@ namespace Xamarin.Android.Tasks
 			if (File.Exists (MultiDexMainDexListFile))
 				File.WriteAllText (MultiDexMainDexListFile, string.Empty);
 
-			var result = base.Execute () && !Log.HasLoggedErrors;
+			var result = base.RunTask () && !Log.HasLoggedErrors;
 
 			if (result && CustomMainDexListFiles?.Length > 0) {
 				var content = new List<string> ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateNativeLibraryArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateNativeLibraryArchive.cs
@@ -11,8 +11,10 @@ namespace Xamarin.Android.Tasks
 	/// <summary>
 	/// Creates __AndroidNativeLibraries__.zip, $(AndroidApplication) should be False!
 	/// </summary>
-	public class CreateNativeLibraryArchive : Task
+	public class CreateNativeLibraryArchive : AndroidTask
 	{
+		public override string TaskPrefix => "CNL";
+
 		[Required]
 		public string OutputDirectory { get; set; }
 
@@ -23,7 +25,7 @@ namespace Xamarin.Android.Tasks
 		{
 		}
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var outDirInfo = new DirectoryInfo (OutputDirectory);
 			

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateResgenManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateResgenManifest.cs
@@ -11,15 +11,17 @@ using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CreateResgenManifest : Task
+	public class CreateResgenManifest : AndroidTask
 	{
+		public override string TaskPrefix => "CRM";
+
 		[Required]
 		public string ManifestOutputFile { get; set; }
 
 		[Required]
 		public string PackageName { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			// <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 			//		   package="MonoAndroidApplication4.MonoAndroidApplication4" />

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateTemporaryDirectory.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateTemporaryDirectory.cs
@@ -7,12 +7,14 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks
 {
-	public class CreateTemporaryDirectory : Task
+	public class CreateTemporaryDirectory : AndroidTask
 	{
+		public override string TaskPrefix => "CTD";
+
 		[Output]
 		public string TemporaryDirectory { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			TemporaryDirectory = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
 			Directory.CreateDirectory (TemporaryDirectory);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
@@ -13,8 +13,10 @@ using Xamarin.Build;
 
 namespace Xamarin.Android.Tasks
 {
-	public class Crunch : AsyncTask
+	public class Crunch : AndroidAsyncTask
 	{
+		public override string TaskPrefix => "CRN";
+
 		// Aapt errors looks like this:
 		//   C:\Users\Jonathan\Documents\Visual Studio 2010\Projects\AndroidMSBuildTest\AndroidMSBuildTest\obj\Debug\res\layout\main.axml:7: error: No resource identifier found for attribute 'id2' in package 'android' (TaskId:22)
 		// Look for them and convert them to MSBuild compatible errors.
@@ -68,7 +70,7 @@ namespace Xamarin.Android.Tasks
 			return;
 		}
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			Yield ();
 			try {
@@ -76,7 +78,7 @@ namespace Xamarin.Android.Tasks
 
 				task.ContinueWith (Complete);
 
-				base.Execute ();
+				base.RunTask ();
 			} finally {
 				Reacquire ();
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/D8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/D8.cs
@@ -11,6 +11,8 @@ namespace Xamarin.Android.Tasks
 	/// </summary>
 	public class D8 : JavaToolTask
 	{
+		public override string TaskPrefix => "DX8";
+
 		[Required]
 		public string JarPath { get; set; }
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Desugar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Desugar.cs
@@ -14,6 +14,8 @@ namespace Xamarin.Android.Tasks
 
 	public class Desugar : JavaToolTask
 	{
+		public override string TaskPrefix => "DES";
+
 		[Required]
 		public string DesugarJarPath { get; set; }
 
@@ -34,12 +36,12 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public string [] OutputJars { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (!Directory.Exists (OutputDirectory))
 				Directory.CreateDirectory (OutputDirectory);
 
-			return base.Execute ();
+			return base.RunTask ();
 		}
 
 		protected override string GenerateCommandLineCommands ()

--- a/src/Xamarin.Android.Build.Tasks/Tasks/DetermineJavaLibrariesToCompile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/DetermineJavaLibrariesToCompile.cs
@@ -8,8 +8,10 @@ using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
-	public class DetermineJavaLibrariesToCompile : Task
+	public class DetermineJavaLibrariesToCompile : AndroidTask
 	{
+		public override string TaskPrefix => "DJL";
+
 		[Required]
 		public ITaskItem[] MonoPlatformJarPaths { get; set; }
 
@@ -33,7 +35,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem[] ReferenceJavaLibraries { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var jars = new List<ITaskItem> ();
 			if (!EnableInstantRun)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/FilterAssemblies.cs
@@ -15,8 +15,10 @@ namespace Xamarin.Android.Tasks
 	/// * An EmbeddedResource ending with *.jar
 	/// * An EmbeddedResource beginning with __Android
 	/// </summary>
-	public class FilterAssemblies : Task
+	public class FilterAssemblies : AndroidTask
 	{
+		public override string TaskPrefix => "FLT";
+
 		const string TargetFrameworkIdentifier = "MonoAndroid";
 		const string MonoAndroidReference = "Mono.Android";
 
@@ -27,7 +29,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem [] OutputAssemblies { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (InputAssemblies == null)
 				return true;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/FindLayoutsToBind.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/FindLayoutsToBind.cs
@@ -9,8 +9,10 @@ using Microsoft.Build.Framework;
 
 namespace Xamarin.Android.Tasks
 {
-	public class FindLayoutsToBind : Task
+	public class FindLayoutsToBind : AndroidTask
 	{
+		public override string TaskPrefix => "FLB";
+
 		static readonly string DirSeparator = Path.DirectorySeparatorChar == '\\' ? @"\\" : "/";
 		static readonly Regex layoutPathRegex = new Regex ($".*{DirSeparator}+layout(-?\\w+)*{DirSeparator}+.*\\.a?xml$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
@@ -26,7 +28,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem[] LayoutsToBind { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var layouts = new Dictionary <string, ITaskItem> (StringComparer.OrdinalIgnoreCase);
 			if (GenerateLayoutBindings) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -23,8 +23,10 @@ namespace Xamarin.Android.Tasks
 {
 	using PackageNamingPolicyEnum   = PackageNamingPolicy;
 
-	public class GenerateJavaStubs : Task
+	public class GenerateJavaStubs : AndroidTask
 	{
+		public override string TaskPrefix => "GJS";
+
 		[Required]
 		public ITaskItem[] ResolvedAssemblies { get; set; }
 
@@ -74,7 +76,7 @@ namespace Xamarin.Android.Tasks
 
 		internal const string AndroidSkipJavaStubGeneration = "AndroidSkipJavaStubGeneration";
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			try {
 				// We're going to do 3 steps here instead of separate tasks so

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutBindings.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutBindings.cs
@@ -17,8 +17,10 @@ namespace Xamarin.Android.Tasks
 {
 	// TODO: add doc comments to the generated properties
 	//
-	public partial class GenerateLayoutBindings : AsyncTask
+	public partial class GenerateLayoutBindings : AndroidAsyncTask
 	{
+		public override string TaskPrefix => "GLB";
+
 		sealed class PartialClass
 		{
 			public string Name;
@@ -77,7 +79,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem [] GeneratedFiles { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (String.IsNullOrWhiteSpace (OutputLanguage))
 				OutputLanguage = DefaultOutputGenerator.Name;
@@ -100,7 +102,7 @@ namespace Xamarin.Android.Tasks
 			if (Generate (generator)) {
 				Complete ();
 			} else {
-				base.Execute ();
+				base.RunTask ();
 			}
 
 			return !Log.HasLoggedErrors;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutCodeBehind.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutCodeBehind.cs
@@ -16,7 +16,8 @@ using System.Runtime.CompilerServices;
 
 namespace Xamarin.Android.Tasks {
 
-	public class GenerateCodeBehindForLayout : Task {
+	public class GenerateCodeBehindForLayout : AndroidTask {
+		public override string TaskPrefix => "GCB";
 
 		const string UserDataIsMainKey = "IsMain";
 		const string ChildClassParentFieldName = "__parent";
@@ -98,7 +99,7 @@ namespace Xamarin.Android.Tasks {
 		[Output]
 		public ITaskItem [] GeneratedFiles { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var generatedFiles = new List<ITaskItem> ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLibraryResources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLibraryResources.cs
@@ -12,8 +12,10 @@ namespace Xamarin.Android.Tasks
 	/// <summary>
 	/// We used to invoke aapt/aapt2 per library (many times!), this task does the work to generate R.java for libraries without calling aapt/aapt2.
 	/// </summary>
-	public class GenerateLibraryResources : AsyncTask
+	public class GenerateLibraryResources : AndroidAsyncTask
 	{
+		public override string TaskPrefix => "GLR";
+
 		/// <summary>
 		/// The main R.txt for the app
 		/// </summary>
@@ -36,13 +38,13 @@ namespace Xamarin.Android.Tasks
 		/// </summary>
 		public string [] ManifestFiles { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			Yield ();
 			try {
 				this.RunTask (DoExecute).ContinueWith (Complete);
 
-				base.Execute ();
+				base.RunTask ();
 			} finally {
 				Reacquire ();
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateManagedAidlProxies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateManagedAidlProxies.cs
@@ -13,8 +13,10 @@ using Xamarin.Android.Tools.Aidl;
 
 namespace Xamarin.Android.Tasks
 {
-	public class GenerateManagedAidlProxies : Task
+	public class GenerateManagedAidlProxies : AndroidTask
 	{
+		public override string TaskPrefix => "GMA";
+
 		[Required]
 		public ITaskItem[] References { get; set; }
 
@@ -32,7 +34,7 @@ namespace Xamarin.Android.Tasks
 		{
 		}
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (SourceAidlFiles.Length == 0) // nothing to do
 				return true;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -13,8 +13,10 @@ using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
-	public class GeneratePackageManagerJava : Task
+	public class GeneratePackageManagerJava : AndroidTask
 	{
+		public override string TaskPrefix => "GPM";
+
 		Guid buildId = Guid.NewGuid ();
 
 		[Required]
@@ -71,7 +73,7 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			BuildId = buildId.ToString ();
 			Log.LogDebugMessage ("  [Output] BuildId: {0}", BuildId);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
@@ -13,8 +13,10 @@ using Java.Interop.Tools.Cecil;
 
 namespace Xamarin.Android.Tasks
 {
-	public class GenerateResourceDesigner : Task
+	public class GenerateResourceDesigner : AndroidTask
 	{
+		public override string TaskPrefix => "GRD";
+
 		[Required]
 		public string NetResgenOutputFile { get; set; }
 
@@ -51,7 +53,7 @@ namespace Xamarin.Android.Tasks
 
 		private Dictionary<string, string> resource_fixup = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase);
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			// In Xamarin Studio, if the project name isn't a valid C# identifier
 			// then $(RootNamespace) is not set, and the generated Activity is

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Generator.cs
@@ -12,8 +12,10 @@ using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
-	public class BindingsGenerator : AndroidToolTask
+	public class BindingsGenerator : AndroidRunToolTask
 	{
+		public override string TaskPrefix => "BGN";
+
 		public bool OnlyRunXmlAdjuster { get; set; }
 
 		public string XmlAdjusterOutput { get; set; }
@@ -57,7 +59,7 @@ namespace Xamarin.Android.Tasks
 
 		private List<Tuple<string, string>> transform_files = new List<Tuple<string,string>> ();
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			Directory.CreateDirectory (OutputDirectory);
 
@@ -91,7 +93,7 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 
-			return base.Execute ();
+			return base.RunTask ();
 		}
 
 		protected override string GenerateCommandLineCommands ()

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
@@ -16,8 +16,10 @@ using Xamarin.Build;
 namespace Xamarin.Android.Tasks
 {
 
-	public class GetAdditionalResourcesFromAssemblies : AsyncTask
+	public class GetAdditionalResourcesFromAssemblies : AndroidAsyncTask
 	{
+		public override string TaskPrefix => "GAR";
+
 		/// <summary>
 		/// Environment variable named XAMARIN_CACHEPATH that can be set 
 		/// to override the default cache path.
@@ -372,7 +374,7 @@ namespace Xamarin.Android.Tasks
 			return contentDir;
 		}
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			Yield ();
 			try {
@@ -451,7 +453,7 @@ namespace Xamarin.Android.Tasks
 				}
 			}, CancellationToken).ContinueWith (Complete);
 
-			var result = base.Execute ();
+			var result = base.RunTask ();
 
 			if (!result || Log.HasLoggedErrors) {
 				if (File.Exists (cacheFileFullPath))

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidDefineConstants.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidDefineConstants.cs
@@ -9,8 +9,10 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks
 {
-	public class GetAndroidDefineConstants : Task
+	public class GetAndroidDefineConstants : AndroidTask
 	{
+		public override string TaskPrefix => "GAD";
+
 		[Required]
 		public int AndroidApiLevel { get; set; }
 
@@ -19,7 +21,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public  ITaskItem[]     AndroidDefineConstants      { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var constants = new List<ITaskItem> ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidPackageName.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidPackageName.cs
@@ -33,8 +33,10 @@ using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
-	public class GetAndroidPackageName : Task
+	public class GetAndroidPackageName : AndroidTask
 	{
+		public override string TaskPrefix => "GAP";
+
 		public string ManifestFile { get; set; }
 
 		[Required]
@@ -43,7 +45,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public string PackageName { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			// If we don't have a manifest, default to using the assembly name
 			// If the assembly doesn't have a period in it, duplicate it so it does

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAppSettingsDirectory.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAppSettingsDirectory.cs
@@ -8,12 +8,14 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks
 {
-	public class GetAppSettingsDirectory : Task
+	public class GetAppSettingsDirectory : AndroidTask
 	{
+		public override string TaskPrefix => "GAS";
+
 		[Output]
 		public string AppSettingsDirectory { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			// Windows: C:\Users\Jonathan\AppData\Local\Xamarin\Mono for Android
 			var appdata_local = Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetConvertedJavaLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetConvertedJavaLibraries.cs
@@ -9,8 +9,10 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks
 {
-	public class GetConvertedJavaLibraries : Task
+	public class GetConvertedJavaLibraries : AndroidTask
 	{
+		public override string TaskPrefix => "GCJ";
+
 		[Required]
 		public string Extension { get; set; }
 		public string OutputJackDirectory { get; set; }
@@ -18,7 +20,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public string [] ConvertedFilesToBeGenerated { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var md5 = MD5.Create ();
 			ConvertedFilesToBeGenerated =

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetExtraPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetExtraPackages.cs
@@ -8,8 +8,10 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks
 {
-	public class GetExtraPackages : Task
+	public class GetExtraPackages : AndroidTask
 	{
+		public override string TaskPrefix => "GEP";
+
 		[Required]
 		public string IntermediateOutputPath { get; set; }
 
@@ -19,7 +21,7 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string LibraryProjectImportsDirectoryName { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var extraPackages = new List<string> ();
 			var libProjects = Path.Combine (IntermediateOutputPath, "__library_projects__");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetFilesThatExist.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetFilesThatExist.cs
@@ -10,8 +10,10 @@ namespace Xamarin.Android.Tasks
 {
 	// We have a list of files, we want to get the
 	// ones that actually exist on disk.
-	public class GetFilesThatExist : Task
+	public class GetFilesThatExist : AndroidTask
 	{
+		public override string TaskPrefix => "GFT";
+
 		[Required]
 		public ITaskItem[] Files { get; set; }
 
@@ -20,7 +22,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem[] FilesThatExist { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			FilesThatExist = Files.Where (p => File.Exists (p.ItemSpec) &&
 					(!IgnoreFiles?.Contains (p, TaskItemComparer.DefaultComparer) ?? true)).ToArray ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetImportedLibraries.cs
@@ -8,8 +8,10 @@ using Microsoft.Build.Framework;
 
 namespace Xamarin.Android.Tasks
 {
-	public class GetImportedLibraries : Task
+	public class GetImportedLibraries : AndroidTask
 	{
+		public override string TaskPrefix => "GIL";
+
 		static readonly string [] IgnoredManifestDirectories = new [] {
 			"bin",
 			"manifest",
@@ -30,7 +32,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem [] ManifestDocuments { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (!Directory.Exists (TargetDirectory)) {
 				Log.LogDebugMessage ("Target directory was not found");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetJavaPlatformJar.cs
@@ -11,8 +11,10 @@ using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
-	public class GetJavaPlatformJar : Task
+	public class GetJavaPlatformJar : AndroidTask
 	{
+		public override string TaskPrefix => "GJP";
+
 		private XNamespace androidNs = "http://schemas.android.com/apk/res/android";
 
 		[Required]
@@ -26,7 +28,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public string TargetSdkVersion    { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var platform = AndroidSdkPlatform;
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetMonoPlatformJar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetMonoPlatformJar.cs
@@ -7,8 +7,10 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks
 {
-	public class GetMonoPlatformJar : Task
+	public class GetMonoPlatformJar : AndroidTask
 	{
+		public override string TaskPrefix => "GMJ";
+
 		[Required]
 		public string TargetFrameworkDirectory { get; set; }
 
@@ -18,7 +20,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public string MonoPlatformDexPath { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var directories = TargetFrameworkDirectory.Split (new char[] { ';', ','} ,StringSplitOptions.RemoveEmptyEntries);
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ImportJavaDoc.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ImportJavaDoc.cs
@@ -8,8 +8,10 @@ using Xamarin.Android.Tools.Aidl;
 
 namespace Xamarin.Android.Tasks
 {
-	public class ImportJavaDoc : ToolTask
+	public class ImportJavaDoc : AndroidToolTask
 	{
+		public override string TaskPrefix => "IJD";
+
 		public string [] JavaDocs { get; set; }
 		
 		public string [] References { get; set; }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/InstallApkSet.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/InstallApkSet.cs
@@ -12,6 +12,8 @@ namespace Xamarin.Android.Tasks
 	/// </summary>
 	public class InstallApkSet : BundleTool
 	{
+		public override string TaskPrefix => "IAS";
+
 		[Required]
 		public string ApkSet { get; set; }
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JarToXml.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JarToXml.cs
@@ -10,8 +10,10 @@ using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
-	public class JarToXml : ToolTask
+	public class JarToXml : AndroidToolTask
 	{
+		public override string TaskPrefix => "JTX";
+
 		[Required]
 		public string AndroidSdkDirectory { get; set; }
 		
@@ -43,7 +45,7 @@ namespace Xamarin.Android.Tasks
 
 		public string JavaMaximumHeapSize { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (SourceJars == null || SourceJars.Count () == 0) {
 				Log.LogError ("At least one Java library is required for binding, this must be either 'EmbeddedJar', 'InputJar' (for jar), 'LibraryProjectZip' (for aar or zip) or 'LibraryProjectProperties' (project.properties) build action.");
@@ -71,7 +73,7 @@ namespace Xamarin.Android.Tasks
 			// Ensure our output directory exists
 			Directory.CreateDirectory (Path.GetDirectoryName (OutputFile));
 
-			return base.Execute ();
+			return base.RunTask ();
 		}
 
 		protected override string GenerateCommandLineCommands ()

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaCompileToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaCompileToolTask.cs
@@ -37,11 +37,11 @@ namespace Xamarin.Android.Tasks
 
 		internal string TemporarySourceListFile;
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			GenerateResponseFile ();
 
-			var retval = base.Execute ();
+			var retval = base.RunTask ();
 
 			try {
 				File.Delete (TemporarySourceListFile);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaDoc.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaDoc.cs
@@ -13,6 +13,8 @@ namespace Xamarin.Android.Tasks
 
 	public class JavaDoc : JavaToolTask
 	{
+		public override string TaskPrefix => "JDC";
+
 		public string [] SourceDirectories { get; set; }
 
 		public string [] DestinationDirectories { get; set; }
@@ -27,7 +29,7 @@ namespace Xamarin.Android.Tasks
 			get { return OS.IsWindows ? "javadoc.exe" : "javadoc"; }
 		}
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			foreach (var dir in DestinationDirectories)
 				if (!Directory.Exists (dir))
@@ -37,7 +39,7 @@ namespace Xamarin.Android.Tasks
 			foreach (var pair in SourceDirectories.Zip (DestinationDirectories, (src, dst) => new { Source = src, Destination = dst })) {
 				context_src = pair.Source;
 				context_dst = pair.Destination;
-				base.Execute ();
+				base.RunTask ();
 			}
 			return true;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaToolTask.cs
@@ -11,7 +11,7 @@ using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
-	public abstract class JavaToolTask : ToolTask
+	public abstract class JavaToolTask : AndroidToolTask
 	{
 		/*
 		Example Javac output for errors. Regex Matches on the first line, we then need to 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Javac.cs
@@ -14,6 +14,8 @@ namespace Xamarin.Android.Tasks
 {
 	public class Javac : JavaCompileToolTask
 	{
+		public override string TaskPrefix => "JVC";
+
 		[Required]
 		public string ClassesOutputDirectory { get; set; }
 
@@ -26,11 +28,11 @@ namespace Xamarin.Android.Tasks
 
 		public override string DefaultErrorCode => "JAVAC0000";
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (!Directory.Exists (ClassesOutputDirectory))
 				Directory.CreateDirectory (ClassesOutputDirectory);
-			var result = base.Execute ();
+			var result = base.RunTask ();
 			if (!result)
 				return result;
 			// compress all the class files

--- a/src/Xamarin.Android.Build.Tasks/Tasks/KeyTool.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/KeyTool.cs
@@ -5,8 +5,10 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks
 {
-	public class KeyTool : AndroidToolTask
+	public class KeyTool : AndroidRunToolTask
 	{
+		public override string TaskPrefix => "KEY";
+
 		string previousLine;
 
 		[Required]
@@ -28,7 +30,7 @@ namespace Xamarin.Android.Tasks
 
 		protected override string DefaultErrorCode => "ANDKT0000";
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			Log.LogDebugMessage ("KeyTool : {0}", Command);
 			Log.LogDebugMessage ("          {0}",KeyStore);
@@ -38,7 +40,7 @@ namespace Xamarin.Android.Tasks
 			if (!Directory.Exists (store_dir))
 				Directory.CreateDirectory (store_dir);
 
-			return base.Execute ();
+			return base.RunTask ();
 		}
 
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkApplicationSharedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkApplicationSharedLibraries.cs
@@ -12,8 +12,10 @@ using Xamarin.Build;
 
 namespace Xamarin.Android.Tasks
 {
-	public class LinkApplicationSharedLibraries : AsyncTask
+	public class LinkApplicationSharedLibraries : AndroidAsyncTask
 	{
+		public override string TaskPrefix => "LAS";
+
 		sealed class Config
 		{
 			public string LinkerPath;
@@ -39,7 +41,7 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string AndroidBinUtilsDirectory { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			try {
 				return DoExecute ();
@@ -62,7 +64,7 @@ namespace Xamarin.Android.Tasks
 				var task = this.RunTask ( () => RunParallelLinker ());
 				task.ContinueWith (Complete);
 
-				base.Execute ();
+				base.RunTask ();
 
 				if (!task.Result)
 					return false;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
@@ -21,8 +21,10 @@ namespace Xamarin.Android.Tasks
 	/// <summary>
 	/// This task is for Release builds, LinkMode=None now uses LinkAssembliesNoShrink
 	/// </summary>
-	public class LinkAssemblies : Task, ML.ILogger
+	public class LinkAssemblies : AndroidTask, ML.ILogger
 	{
+		public override string TaskPrefix => "LNK";
+
 		[Required]
 		public string UseSharedRuntime { get; set; }
 
@@ -66,7 +68,7 @@ namespace Xamarin.Android.Tasks
 			return retainList;
 		}
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var rp = new ReaderParameters {
 				InMemory    = true,

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
@@ -11,8 +11,10 @@ namespace Xamarin.Android.Tasks
 	/// <summary>
 	/// This task is for Debug builds where LinkMode=None, LinkAssemblies is for Release builds
 	/// </summary>
-	public class LinkAssembliesNoShrink : Task
+	public class LinkAssembliesNoShrink : AndroidTask
 	{
+		public override string TaskPrefix => "LNS";
+
 		/// <summary>
 		/// These are used so we have the full list of SearchDirectories
 		/// </summary>
@@ -25,7 +27,7 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public ITaskItem [] DestinationFiles { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (SourceFiles.Length != DestinationFiles.Length)
 				throw new ArgumentException ("source and destination count mismatch");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
@@ -11,8 +11,10 @@ using System.Text;
 
 namespace Xamarin.Android.Tasks
 {
-	public class Lint : ToolTask
+	public class Lint : AndroidToolTask
 	{
+		public override string TaskPrefix => "LNT";
+
 		// we need to check for lint based errors and warnings
 		// Sample Manifest Warnings note the ^ and ~ differences.... 
 		//
@@ -186,7 +188,7 @@ namespace Xamarin.Android.Tasks
 
 		static readonly Regex lintVersionRegex = new Regex (@"version[\t\s]+(?<version>[\d\.]+)", RegexOptions.Compiled);
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (string.IsNullOrEmpty (ToolPath) || !File.Exists (GenerateFullPathToTool ())) {
 				Log.LogCodedError ("XA5205", $"Cannot find `{ToolName}` in the Android SDK. Please set its path via /p:LintToolPath.");
@@ -213,7 +215,7 @@ namespace Xamarin.Android.Tasks
 
 			resource_name_case_map = MonoAndroidHelper.LoadResourceCaseMap (ResourceNameCaseMap);
 
-			base.Execute ();
+			base.RunTask ();
 
 			return !Log.HasLoggedErrors;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LogErrorsForFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LogErrorsForFiles.cs
@@ -4,8 +4,10 @@ using Microsoft.Build.Framework;
 
 namespace Xamarin.Android.Tasks
 {
-	public class LogErrorsForFiles : Task
+	public class LogErrorsForFiles : AndroidTask
 	{
+		public override string TaskPrefix => "LEF";
+
 		[Required]
 		public ITaskItem[] Files { get; set; }
 
@@ -19,7 +21,7 @@ namespace Xamarin.Android.Tasks
 
 		public string HelpKeyword { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			foreach (var item in Files) {
 				Log.LogError (SubCategory, Code, HelpKeyword, item.ItemSpec

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LogWarningsForFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LogWarningsForFiles.cs
@@ -4,8 +4,10 @@ using Microsoft.Build.Framework;
 
 namespace Xamarin.Android.Tasks
 {
-	public class LogWarningsForFiles : Task
+	public class LogWarningsForFiles : AndroidTask
 	{
+		public override string TaskPrefix => "LWF";
+
 		[Required]
 		public ITaskItem[] Files { get; set; }
 
@@ -19,7 +21,7 @@ namespace Xamarin.Android.Tasks
 
 		public string HelpKeyword { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			foreach (var item in Files) {
 				Log.LogWarning (SubCategory, Code, HelpKeyword, item.ItemSpec

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MDoc.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MDoc.cs
@@ -8,8 +8,10 @@ using Xamarin.Android.Tools.Aidl;
 
 namespace Xamarin.Android.Tasks
 {
-	public class MDoc : ToolTask
+	public class MDoc : AndroidToolTask
 	{
+		public override string TaskPrefix => "MDC";
+
 		public string [] References { get; set; }
 		
 		[Required]

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
@@ -16,8 +16,10 @@ using Xamarin.Android.Tools;
 namespace Xamarin.Android.Tasks
 {
 	// can't be a single ToolTask, because it has to run mkbundle many times for each arch.
-	public class MakeBundleNativeCodeExternal : Task
+	public class MakeBundleNativeCodeExternal : AndroidTask
 	{
+		public override string TaskPrefix => "MBN";
+
 		const string BundleSharedLibraryName = "libmonodroid_bundle_app.so";
 
 		[Required]
@@ -52,7 +54,7 @@ namespace Xamarin.Android.Tasks
 		{
 		}
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (!NdkUtil.Init (Log, AndroidNdkDirectory))
 				return false;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MergeResources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MergeResources.cs
@@ -9,8 +9,10 @@ using System.Text.RegularExpressions;
 
 namespace Xamarin.Android.Tasks
 {
-	public class MergeResources : Task
+	public class MergeResources : AndroidTask
 	{
+		public override string TaskPrefix => "MER";
+
 		[Required]
 		public ITaskItem[] SourceFiles { get; set; }
 
@@ -25,7 +27,7 @@ namespace Xamarin.Android.Tasks
 
 		ResourceMerger merger = null;
 			
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			// ok copy all the files from Cache into dest path
 			// then copy over the App Resources

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ParseAndroidWearProjectAndManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ParseAndroidWearProjectAndManifest.cs
@@ -10,8 +10,10 @@ using Xamarin.Android.Tools.Aidl;
 
 namespace Xamarin.Android.Tasks
 {
-	public class ParseAndroidWearProjectAndManifest : Task
+	public class ParseAndroidWearProjectAndManifest : AndroidTask
 	{
+		public override string TaskPrefix => "PAW";
+
 		static readonly XNamespace msbuildNS = XNamespace.Get ("http://schemas.microsoft.com/developer/msbuild/2003");
 
 		public ITaskItem [] ProjectFiles { get; set; }
@@ -20,7 +22,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public string ApplicationPackageName { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (ProjectFiles.Length != 1)
 				Log.LogError ("More than one Android Wear project is specified as the paired project. It can be at most one.");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/PrepareAbiItems.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/PrepareAbiItems.cs
@@ -6,8 +6,10 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks
 {
-	public class PrepareAbiItems : Task
+	public class PrepareAbiItems : AndroidTask
 	{
+		public override string TaskPrefix => "PAI";
+
 		[Required]
 		public string [] BuildTargetAbis { get; set; }
 
@@ -17,7 +19,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem[] OutputItems { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var items = new List<ITaskItem> ();
 			foreach (string abi in BuildTargetAbis) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/PrepareWearApplicationFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/PrepareWearApplicationFiles.cs
@@ -7,8 +7,10 @@ using System.Collections.Generic;
 
 namespace Xamarin.Android.Tasks
 {
-	public class PrepareWearApplicationFiles : Task
+	public class PrepareWearApplicationFiles : AndroidTask
 	{
+		public override string TaskPrefix => "PWA";
+
 		static readonly XNamespace androidNs = XNamespace.Get ("http://schemas.android.com/apk/res/android");
 
 		[Required]
@@ -23,7 +25,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public string [] ModifiedFiles { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			string rawapk = "wearable_app.apk";
 			string intermediateApkPath = Path.Combine (IntermediateOutputPath, "res", "raw", rawapk);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
@@ -18,8 +18,10 @@ using Xamarin.Tools.Zip;
 namespace Xamarin.Android.Tasks
 {
 	// See AOSP/sdk/eclipse/plugins/com.android.ide.eclipse.adt/src/com/android/ide/eclipse/adt/internal/build/BuildHelper.java
-	public class Proguard : ToolTask
+	public class Proguard : AndroidToolTask
 	{
+		public override string TaskPrefix => "PRO";
+
 		public string ProguardJarPath { get; set; }
 
 		public string ProguardToolPath { get; set; }
@@ -73,11 +75,11 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			EnvironmentVariables = MonoAndroidHelper.GetProguardEnvironmentVaribles (ProguardHome);
 
-			return base.Execute ();
+			return base.RunTask ();
 		}
 
 		protected override string GenerateCommandLineCommands ()

--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -13,6 +13,8 @@ namespace Xamarin.Android.Tasks
 	/// </summary>
 	public class R8 : D8
 	{
+		public override string TaskPrefix => "R8S";
+
 		[Required]
 		public string AndroidSdkBuildToolsPath { get; set; }
 		[Required]
@@ -35,11 +37,11 @@ namespace Xamarin.Android.Tasks
 
 		string temp;
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			try {
 				temp = Path.GetTempFileName ();
-				return base.Execute ();
+				return base.RunTask ();
 			} finally {
 				if (!string.IsNullOrEmpty (temp))
 					File.Delete (temp);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadAdditionalResourcesFromAssemblyCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadAdditionalResourcesFromAssemblyCache.cs
@@ -8,7 +8,8 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks
 {
-	public class ReadAdditionalResourcesFromAssemblyCache : Task {
+	public class ReadAdditionalResourcesFromAssemblyCache : AndroidTask {
+		public override string TaskPrefix => "RAR";
 
 		[Required]
 		public string CacheFile { get; set;} 
@@ -32,7 +33,7 @@ namespace Xamarin.Android.Tasks
 			AdditionalNativeLibraryReferences = new string [0];
 		}
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (!File.Exists (CacheFile)) {
 				Log.LogDebugMessage ("{0} does not exist. No Additional Resources found", CacheFile);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadAndroidManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadAndroidManifest.cs
@@ -9,8 +9,10 @@ namespace Xamarin.Android.Tasks
 	/// <summary>
 	/// Since GenerateJavaStubs can get skipped on incremental builds, this task parses the merged AndroidManifest.xml for values needed later in the build.
 	/// </summary>
-	public class ReadAndroidManifest : Task
+	public class ReadAndroidManifest : AndroidTask
 	{
+		public override string TaskPrefix => "RAM";
+
 		[Required]
 		public string ManifestFile { get; set; }
 
@@ -29,7 +31,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem [] UsesLibraries { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var androidNs = AndroidAppManifest.AndroidXNamespace;
 			var manifest = AndroidAppManifest.Load (ManifestFile, MonoAndroidHelper.SupportedVersions);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadImportedLibrariesCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadImportedLibrariesCache.cs
@@ -32,8 +32,10 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks
 {
-	public class ReadImportedLibrariesCache : Task
+	public class ReadImportedLibrariesCache : AndroidTask
 	{
+		public override string TaskPrefix => "RIL";
+
 		[Required]
 		public string CacheFile { get; set;} 
 
@@ -46,7 +48,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem [] ManifestDocuments { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (!File.Exists (CacheFile)) {
 				Log.LogDebugMessage ("{0} does not exist. No Imported Libraries found", CacheFile);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadLibraryProjectImportsCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadLibraryProjectImportsCache.cs
@@ -32,8 +32,10 @@ using Microsoft.Build.Framework;
 
 namespace Xamarin.Android.Tasks
 {
-	public class ReadLibraryProjectImportsCache : Task
+	public class ReadLibraryProjectImportsCache : AndroidTask
 	{
+		public override string TaskPrefix => "RLC";
+
 		[Required]
 		public string CacheFile { get; set;} 
 
@@ -52,7 +54,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public ITaskItem [] ResolvedResourceDirectoryStamps { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			Log.LogDebugMessage ("Task ReadLibraryProjectImportsCache");
 			Log.LogDebugMessage ("  CacheFile: {0}", CacheFile);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
@@ -34,10 +34,11 @@ using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
-	public class RemoveDirFixed : Task
+	public class RemoveDirFixed : AndroidTask
 	{
+		public override string TaskPrefix => "RDF";
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var temporaryRemovedDirectories = new List<ITaskItem> (Directories.Length);
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveRegisterAttribute.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveRegisterAttribute.cs
@@ -10,14 +10,16 @@ using Mono.Cecil;
 
 namespace Xamarin.Android.Tasks
 {
-	public class RemoveRegisterAttribute : Task
+	public class RemoveRegisterAttribute : AndroidTask
 	{
+		public override string TaskPrefix => "RRA";
+
 		const string RegisterAttribute = "Android.Runtime.RegisterAttribute";
 
 		[Required]
 		public ITaskItem[] ShrunkFrameworkAssemblies { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			// Find Mono.Android.dll
 			var mono_android = ShrunkFrameworkAssemblies.First (f => Path.GetFileNameWithoutExtension (f.ItemSpec) == "Mono.Android").ItemSpec;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
@@ -15,8 +15,10 @@ namespace Xamarin.Android.Tasks
 	/// - Calculate ApiLevel and ApiLevelName
 	/// - Find the paths of various Android tooling that other tasks need to call
 	/// </summary>
-	public class ResolveAndroidTooling : Task
+	public class ResolveAndroidTooling : AndroidTask
 	{
+		public override string TaskPrefix => "RAT";
+
 		public string AndroidSdkPath { get; set; }
 
 		public string AndroidSdkBuildToolsVersion { get; set; }
@@ -78,7 +80,7 @@ namespace Xamarin.Android.Tasks
 		static readonly string Lint = IsWindows ? "lint.bat" : "lint";
 		static readonly string ApkSigner = "apksigner.jar";
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			string toolsZipAlignPath = Path.Combine (AndroidSdkPath, "tools", ZipAlign);
 			bool findZipAlign = (string.IsNullOrEmpty (ZipAlignPath) || !Directory.Exists (ZipAlignPath)) && !File.Exists (toolsZipAlignPath);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -17,8 +17,10 @@ using Xamarin.Build;
 
 namespace Xamarin.Android.Tasks
 {
-	public class ResolveAssemblies : AsyncTask
+	public class ResolveAssemblies : AndroidAsyncTask
 	{
+		public override string TaskPrefix => "RSA";
+
 		// The user's assemblies to package
 		[Required]
 		public ITaskItem[] Assemblies { get; set; }
@@ -55,7 +57,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public string[] ResolvedDoNotPackageAttributes { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			Yield ();
 			try {
@@ -64,7 +66,7 @@ namespace Xamarin.Android.Tasks
 						Execute (resolver);
 					}
 				}, CancellationToken).ContinueWith (Complete);
-				return base.Execute ();
+				return base.RunTask ();
 			} finally {
 				Reacquire ();
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveJdkJvmPath.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveJdkJvmPath.cs
@@ -10,14 +10,16 @@ namespace Xamarin.Android.Tasks
 	/// <summary>
 	/// This MSBuild task's job is to find $(JdkJvmPath) used by $(AndroidGenerateJniMarshalMethods)
 	/// </summary>
-	public class ResolveJdkJvmPath : Task
+	public class ResolveJdkJvmPath : AndroidTask
 	{
+		public override string TaskPrefix => "RJJ";
+
 		public string JavaSdkPath { get; set; }
 
 		[Output]
 		public string JdkJvmPath { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			try {
 				JdkJvmPath = GetJvmPath ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -14,8 +14,10 @@ using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
 {
-	public class ResolveLibraryProjectImports : Task
+	public class ResolveLibraryProjectImports : AndroidTask
 	{
+		public override string TaskPrefix => "RLP";
+
 		[Required]
 		public string ImportsDirectory { get; set; }
 
@@ -74,7 +76,7 @@ namespace Xamarin.Android.Tasks
 
 		// Extracts library project contents under e.g. obj/Debug/[__library_projects__/*.jar | res/*/*]
 		// Extracts library project contents under e.g. obj/Debug/[lp/*.jar | res/*/*]
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			var jars                          = new Dictionary<string, ITaskItem> ();
 			var resolvedResourceDirectories   = new List<ITaskItem> ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -37,9 +37,11 @@ namespace Xamarin.Android.Tasks
 	/// <summary>
 	/// ResolveSdks' job is to call RefreshAndroidSdk and setup static members of MonoAndroidHelper
 	/// </summary>
-	public class ResolveSdks : Task
+	public class ResolveSdks : AndroidTask
 	{
-		public string[] ReferenceAssemblyPaths { get; set; }
+		public override string TaskPrefix => "RSD";
+
+		public string [] ReferenceAssemblyPaths { get; set; }
 
 		[Output]
 		public string AndroidNdkPath { get; set; }
@@ -62,7 +64,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public string AndroidBinUtilsPath { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			// OS X:    $prefix/lib/xamarin.android/xbuild/Xamarin/Android
 			// Windows: %ProgramFiles(x86)%\MSBuild\Xamarin\Android

--- a/src/Xamarin.Android.Build.Tasks/Tasks/SetVsMonoAndroidRegistryKey.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/SetVsMonoAndroidRegistryKey.cs
@@ -4,8 +4,10 @@ using System;
 
 namespace Xamarin.Android.Tasks
 {
-	public class SetVsMonoAndroidRegistryKey : Task
+	public class SetVsMonoAndroidRegistryKey : AndroidTask
 	{
+		public override string TaskPrefix => "SVM";
+
 		[Required]
 		public string InstallationID { get; set; }
 
@@ -14,7 +16,7 @@ namespace Xamarin.Android.Tasks
 
 		const string EnvironmentVariable = "XAMARIN_ANDROID_REGKEY";
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			string value = $@"SOFTWARE\Xamarin\VisualStudio\{VisualStudioVersion}_{InstallationID}\Android";
 			Log.LogDebugMessage ($"Setting %{EnvironmentVariable}%=\"{value}\"");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/SplitProperty.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/SplitProperty.cs
@@ -9,8 +9,10 @@ namespace Xamarin.Android.Tasks
 	/// ; - MSBuild default
 	/// , - Historically supported by Xamarin.Android
 	/// </summary>
-	public class SplitProperty : Task
+	public class SplitProperty : AndroidTask
 	{
+		public override string TaskPrefix => "SPL";
+
 		static readonly char [] Delimiters = { ',', ';' };
 
 		public string Value { get; set; }
@@ -18,7 +20,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public string [] Output { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (Value != null) {
 				Output = Value.Split (Delimiters, StringSplitOptions.RemoveEmptyEntries);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Unzip.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Unzip.cs
@@ -7,12 +7,14 @@ using Xamarin.Tools.Zip;
 
 namespace Xamarin.Android.Tasks
 {
-	public class Unzip : Task
+	public class Unzip : AndroidTask
 	{
+		public override string TaskPrefix => "UNZ";
+
 		public ITaskItem [] Sources { get; set; }
 		public ITaskItem [] DestinationDirectories { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			foreach (var pair in Sources.Zip (DestinationDirectories, (s, d) => new { Source = s, Destination = d })) {
 				if (!Directory.Exists (pair.Destination.ItemSpec))

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ValidateJavaVersion.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ValidateJavaVersion.cs
@@ -11,8 +11,10 @@ namespace Xamarin.Android.Tasks
 	/// <summary>
 	/// ValidateJavaVersion's job is to shell out to java and javac to detect their version
 	/// </summary>
-	public class ValidateJavaVersion : Task
+	public class ValidateJavaVersion : AndroidTask
 	{
+		public override string TaskPrefix => "VJV";
+
 		public string TargetFrameworkVersion { get; set; }
 
 		public string AndroidSdkBuildToolsVersion { get; set; }
@@ -33,7 +35,7 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public string JdkVersion { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			if (!ValidateJava (TargetFrameworkVersion, AndroidSdkBuildToolsVersion))
 				return false;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/WriteLockFile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/WriteLockFile.cs
@@ -8,12 +8,14 @@ namespace Xamarin.Android.Tasks
 	/// <summary>
 	/// Generates a warning if LockFile exists, registers the file to be deleted at end of build
 	/// </summary>
-	public class WriteLockFile : Task
+	public class WriteLockFile : AndroidTask
 	{
+		public override string TaskPrefix => "WLF";
+
 		[Required]
 		public string LockFile { get; set; }
 
-		public override bool Execute ()
+		public override bool RunTask ()
 		{
 			try {
 				var path = Path.GetFullPath (LockFile);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/AndroidRegExTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/AndroidRegExTests.cs
@@ -153,7 +153,7 @@ namespace Xamarin.Android.Build.Tests
 		[TestCaseSource(typeof (AndroidRegExTestsCases))]
 		public void RegExTests(string message, bool expectedToMatch, string expectedFile, string expectedLine, string expectedLevel, string expextedMessage)
 		{
-			var regex = Xamarin.Android.Tasks.AndroidToolTask.AndroidErrorRegex;
+			var regex = Xamarin.Android.Tasks.AndroidRunToolTask.AndroidErrorRegex;
 			var result = regex.Match (message);
 			Assert.AreEqual (expectedToMatch,result.Success);
 			Assert.AreEqual (expectedFile, result.Groups["file"].Value);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/UnhandledExceptionLogger.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/UnhandledExceptionLogger.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Build.Utilities;
+
+namespace Xamarin.Android.Tasks
+{
+	static class UnhandledExceptionLogger
+	{
+		public static void LogUnhandledException (this TaskLoggingHelper log, string prefix, Exception ex)
+		{
+			prefix = "XA" + prefix;
+
+			// Some ordering is necessary here to ensure exceptions are before their base exceptions
+			if (ex is NullReferenceException)
+				log.LogCodedError (prefix + "7001", ex.ToString ());
+			else if (ex is ArgumentOutOfRangeException)	// ArgumentException
+				log.LogCodedError (prefix + "7002", ex.ToString ());
+			else if (ex is ArgumentNullException)           // ArgumentException
+				log.LogCodedError (prefix + "7003", ex.ToString ());
+			else if (ex is ArgumentException)
+				log.LogCodedError (prefix + "7004", ex.ToString ());
+			else if (ex is FormatException)
+				log.LogCodedError (prefix + "7005", ex.ToString ());
+			else if (ex is IndexOutOfRangeException)
+				log.LogCodedError (prefix + "7006", ex.ToString ());
+			else if (ex is InvalidCastException)
+				log.LogCodedError (prefix + "7007", ex.ToString ());
+			else if (ex is ObjectDisposedException)		// InvalidOperationException
+				log.LogCodedError (prefix + "7008", ex.ToString ());
+			else if (ex is InvalidOperationException)
+				log.LogCodedError (prefix + "7009", ex.ToString ());
+			else if (ex is InvalidProgramException)
+				log.LogCodedError (prefix + "7010", ex.ToString ());
+			else if (ex is KeyNotFoundException)
+				log.LogCodedError (prefix + "7011", ex.ToString ());
+			else if (ex is TaskCanceledException)           // OperationCanceledException
+				log.LogCodedError (prefix + "7012", ex.ToString ());
+			else if (ex is OperationCanceledException)
+				log.LogCodedError (prefix + "7013", ex.ToString ());
+			else if (ex is OutOfMemoryException)
+				log.LogCodedError (prefix + "7014", ex.ToString ());
+			else if (ex is NotSupportedException)
+				log.LogCodedError (prefix + "7015", ex.ToString ());
+			else if (ex is StackOverflowException)
+				log.LogCodedError (prefix + "7016", ex.ToString ());
+			else if (ex is TimeoutException)
+				log.LogCodedError (prefix + "7017", ex.ToString ());
+			else if (ex is TypeInitializationException)
+				log.LogCodedError (prefix + "7018", ex.ToString ());
+			else if (ex is UnauthorizedAccessException)
+				log.LogCodedError (prefix + "7019", ex.ToString ());
+			else if (ex is ApplicationException)
+				log.LogCodedError (prefix + "7020", ex.ToString ());
+			else if (ex is KeyNotFoundException)
+				log.LogCodedError (prefix + "7021", ex.ToString ());
+			else if (ex is PathTooLongException)            // IOException
+				log.LogCodedError (prefix + "7022", ex.ToString ());
+			else if (ex is DirectoryNotFoundException)      // IOException
+				log.LogCodedError (prefix + "7023", ex.ToString ());
+			else if (ex is IOException) 
+				log.LogCodedError (prefix + "7024", ex.ToString ());
+
+			log.LogCodedError (prefix + "7000", ex.ToString ());
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Tasks\Aapt2.cs" />
     <Compile Include="Tasks\Aapt2Compile.cs" />
     <Compile Include="Tasks\Aapt2Link.cs" />
+    <Compile Include="Tasks\AndroidTask.cs" />
     <Compile Include="Tasks\AndroidZipAlign.cs" />
     <Compile Include="Tasks\BuildApk.cs" />
     <Compile Include="Tasks\BuildBaseAppBundle.cs" />
@@ -221,6 +222,7 @@
     <Compile Include="Linker\MonoDroid.Tuner\RemoveAttributes.cs" />
     <Compile Include="Utilities\AsyncTaskExtensions.cs" />
     <Compile Include="Utilities\MSBuildExtensions.cs" />
+    <Compile Include="Utilities\UnhandledExceptionLogger.cs" />
     <Compile Include="Utilities\ZipArchiveEx.cs" />
     <Compile Include="Mono.Android\ServiceAttribute.Partial.cs" />
     <Compile Include="$(LinkerSourceFullPath)\tuner\Mono.Tuner\AdjustVisibility.cs">


### PR DESCRIPTION
Errors and warning codes for errors and warnings reported within Visual Studio from developers participating in the Visual Studio Customer Experience Improvement Program are reported "telemetry" events, but only the error and warning codes are reported. The warning and error message contents are not sent.

Unfortunately all unhandled exceptions not caught by our MSBuild tasks are reported as `MSB4018`, which reduces the utility of telemetry, making it more difficult to better understand where our build system could be improved.

This PR creates new base tasks for us to inherit: `AndroidTask`, `AndroidAsyncTask`, and `AndroidToolTask`.  These tasks add catch-all exception handlers that capture and log unhandled exceptions instead of allowing them to leak out to MSBuild.

### Implementation

Each error begins with `XA` to denote it is from Xamarin Android so our codes do not collide with other components.

This is followed by a 3 character prefix given to each Task so we can see which Task is causing the error.  For example, the AOT task's prefix is `AOT` and the Linker is `LNK`.

Next is a `7` to denote these are unhandled exceptions.

Finally, common Exception types are encoded as integers to denote the type of Exception being thrown.  For example, `NullReferenceException` is `001`. (`000` denotes an Exception type we aren't specifically looking for.)

The exception table is here:
https://github.com/xamarin/xamarin-android/blob/b4e3c009a2f46ff38b4fba435efbd3fcbf60466b/src/Xamarin.Android.Build.Tasks/Utilities/UnhandledExceptionLogger.cs

Putting it all together:
* A `NullReferenceException` in `LinkAssemblies` would be `XALNK7001`
* A `StackOverflowException` in `AOT` would be `XAAOT7016`
