### PR TITLE
Bump to bundletool 0.10.2

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -101,7 +101,7 @@
     <XAPlatformToolsVersion>29.0.1</XAPlatformToolsVersion>
     <XAIntegratedTests Condition="'$(XAIntegratedTests)' == ''">False</XAIntegratedTests>
     <XAIncludeProprietaryBits Condition="'$(XAIncludeProprietaryBits)' == ''">False</XAIncludeProprietaryBits>
-    <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">0.10.0</XABundleToolVersion>
+    <XABundleToolVersion Condition="'$(XABundleToolVersion)' == ''">0.10.2</XABundleToolVersion>
     <PathSeparator>$([System.IO.Path]::PathSeparator)</PathSeparator>
     <_TestsAotName Condition=" '$(AotAssemblies)' == 'true' ">-Aot</_TestsAotName>
     <_TestsProfiledAotName Condition=" '$(AndroidEnableProfiledAot)' == 'true' ">-Profiled</_TestsProfiledAotName>

--- a/src/bundletool/bundletool.targets
+++ b/src/bundletool/bundletool.targets
@@ -18,11 +18,12 @@
   <Target Name="_DownloadBundleTool">
     <DownloadUri
         SourceUris="https://github.com/google/bundletool/releases/download/$(XABundleToolVersion)/bundletool-all-$(XABundleToolVersion).jar"
-        DestinationFiles="$(AndroidToolchainCacheDirectory)\bundletool.jar"
+        DestinationFiles="$(AndroidToolchainCacheDirectory)\bundletool-all-$(XABundleToolVersion).jar"
     />
     <Copy
-        SourceFiles="$(AndroidToolchainCacheDirectory)\bundletool.jar"
-        DestinationFolder="$(_Destination)"
+        SourceFiles="$(AndroidToolchainCacheDirectory)\bundletool-all-$(XABundleToolVersion).jar"
+        DestinationFiles="$(_Destination)bundletool.jar"
+        SkipUnchangedFiles="True"
     />
   </Target>
 


### PR DESCRIPTION
Context: https://github.com/google/bundletool/releases/tag/0.10.2
Changes: https://github.com/google/bundletool/compare/0.10.0...0.10.2

Bumping `bundletool` as I see some fixes that look important.

I then needed to fix the scenario where the `<DownloadUri/>` task was
skipping the download completely. By keeping the version in the
filename, it will force a download if `$(XABundleToolVersion)`
changes.

I also added `SkipUnchangedFiles=True` to speed up incremental builds
of `Xamarin.Android.sln`.