### PR TITLE
Bump mono to 2019-08@cecda47c489a990c1554bdef486fa54e97544eea

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:master@623845d44abe5eb7a76d9a63d48b30a27ac1bac2
-mono/mono:2019-08@29b1ac19c961b959a09097dbc0fe4cd567cc5298
+mono/mono:2019-08@cecda47c489a990c1554bdef486fa54e97544eea


### PR DESCRIPTION
To get `aprofutil` tool. Besides other changes it also contain fix for
AOT/arm32, where method_addresses are in data section to avoid .text
relocations.

Changes: https://github.com/mono/mono/compare/29b1ac19c961b959a09097dbc0fe4cd567cc5298...cecda47c489a990c1554bdef486fa54e97544eea