### PR TITLE
[Xamarin.Android.Build.Tasks] warn XA0119 for non-ideal configurations

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -62,6 +62,7 @@ ms.date: 08/23/2019
 + [XA0116](xa0116.md): Unable to find `EmbeddedResource` of name `{ResourceName}`.
 + [XA0117](xa0117.md): The TargetFrameworkVersion {TargetFrameworkVersion} is deprecated. Please update it to be v4.4 or higher.
 + [XA0118](xa0118.md): Could not parse '{TargetMoniker}'
++ [XA0119](xa0119.md): A non-ideal configuration was found in the project.
 
 ## XA1xxx: Project related
 

--- a/Documentation/guides/messages/xa0119.md
+++ b/Documentation/guides/messages/xa0119.md
@@ -1,0 +1,44 @@
+---
+title: Xamarin.Android warning XA0119
+description: XA0110 warning code
+ms.date: 09/13/2019
+---
+# Xamarin.Android warning XA0119
+
+## Issue
+
+This warning indicate a non-ideal configuration in your
+Xamarin.Android project.
+
+## Solution
+
+Remove the following options from `Debug` configurations:
+
+* Linker
+  * `<AndroidLinkMode>SdkOnly</AndroidLinkMode>`
+  * `<AndroidLinkMode>Full</AndroidLinkMode>`
+* AOT
+  * `<AotAssemblies>True</AotAssemblies>`
+* Code Shrinker
+  * `<AndroidEnableProguard>True</AndroidEnableProguard>`
+  * `<EnableProguard>True</EnableProguard>`
+  * `<AndroidLinkTool>proguard</AndroidLinkTool>`
+  * `<AndroidLinkTool>r8</AndroidLinkTool>`
+* App Bundles
+  * `<AndroidPackageFormat>aab</AndroidPackageFormat>`
+
+*DO* use the following options for `Debug` configurations:
+
+* `<AndroidLinkMode>None</AndroidLinkMode>`
+* `<EmbedAssembliesIntoApk>False</EmbedAssembliesIntoApk>`
+* `<AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>`
+
+*DO* use the following options for `Release` configurations:
+
+* `<EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>`
+* `<AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>`
+
+Consider submitting a [bug][bug] if you are getting one of these
+warnings under normal circumstances.
+
+[bug]: https://github.com/xamarin/xamarin-android/wiki/Submitting-Bugs,-Feature-Requests,-and-Pull-Requests

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3613,6 +3613,20 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 		}
 
 		[Test]
+		public void XA0119 ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty ("_XASupportsFastDev", "True");
+			proj.SetProperty (KnownProperties.AndroidUseSharedRuntime, "True");
+			proj.SetProperty (proj.DebugProperties, "AndroidLinkMode", "Full");
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				b.Target = "Build"; // SignAndroidPackage would fail for OSS builds
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "XA0119"), "Output should contain XA0119 warnings");
+			}
+		}
+
+		[Test]
 		public void FastDeploymentDoesNotAddContentProvider ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -584,6 +584,25 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
  </CreateItem>
 </Target>
 
+<Target Name="_CheckNonIdealConfigurations">
+  <Warning Code="XA0119"
+      Text="Using Fast Deployment and AOT at the same time is not recommended. Use Fast Deployment for Debug configurations and AOT for Release configurations."
+      Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(AotAssemblies)' == 'True' "
+  />
+  <Warning Code="XA0119"
+      Text="Using Fast Deployment and the Linker at the same time is not recommended. Use Fast Deployment for Debug configurations and the Linker for Release configurations."
+      Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(AndroidLinkMode)' != 'None' "
+  />
+  <Warning Code="XA0119"
+      Text="Using Fast Deployment and a Code Shrinker at the same time is not recommended. Use Fast Deployment for Debug configurations and a Code Shrinker for Release configurations."
+      Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(AndroidLinkTool)' != '' "
+  />
+  <Warning Code="XA0119"
+      Text="Using Fast Deployment and Android App Bundles at the same time is not recommended. Use Fast Deployment for Debug configurations and Android App Bundles for Release configurations."
+      Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(AndroidPackageFormat)' == 'aab' "
+  />
+</Target>
+
 <Target Name="_CheckGoogleSdkRequirements"
     Condition="Exists('$(IntermediateOutputPath)android\AndroidManifest.xml') And '$(AndroidEnableGooglePlayStoreChecks)' == 'true' ">
   <CheckGoogleSdkRequirements
@@ -608,6 +627,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <PropertyGroup Condition="'$(AndroidApplication)' != '' And $(AndroidApplication)">
   <BuildDependsOn>
     _ValidateLinkMode;
+    _CheckNonIdealConfigurations;
     _SetupDesignTimeBuildForBuild;
     _CleanIntermediateIfNuGetsChange;
     _CreatePropertiesCache;
@@ -626,6 +646,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <PropertyGroup Condition="'$(AndroidApplication)' == '' Or !($(AndroidApplication))">
   <BuildDependsOn>
     _ValidateLinkMode;
+    _CheckNonIdealConfigurations;
      _SetupDesignTimeBuildForBuild;
     _CleanIntermediateIfNuGetsChange;
      _CreatePropertiesCache;


### PR DESCRIPTION
I have found developers using combinations of settings in `Debug` mode
that hurts their build times:

* Linker
* AOT
* ProGuard/R8

Additionally, using Android App Bundles is not a good idea for `Debug`
builds. Although, I have not seen that in the wild yet.

We can give a build warning if one of this configurations is found.

`XA0119` will recommend changing the project configuration and
hopefully guide develoeprs to change their settings.