### PR TITLE
[Xamarin.Android.Build.Tasks] async helpers in AndroidAsyncTask

### DIFF
--- a/Documentation/guides/MSBuildBestPractices.md
+++ b/Documentation/guides/MSBuildBestPractices.md
@@ -459,6 +459,9 @@ would `Task.Execute()`:
 ```csharp
 public class MyTask : AndroidTask
 {
+    // Prefix for XAMYT0000 error codes: choose unique chars
+    public override string TaskPrefix => "MYT";
+
     public override bool RunTask ()
     {
         // Implementation

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -214,32 +214,17 @@ namespace Xamarin.Android.Tasks
 			return;
 		}
 
-		public override bool RunTask () 
+		public override System.Threading.Tasks.Task RunTaskAsync ()
 		{
 			resourceDirectory = ResourceDirectory.TrimEnd ('\\');
 			if (!Path.IsPathRooted (resourceDirectory))
 				resourceDirectory = Path.Combine (WorkingDirectory, resourceDirectory);
-			Yield ();
-			try {
-				var task = this.RunTask (DoExecute);
 
-				task.ContinueWith (Complete);
-
-				base.RunTask ();
-			} finally {
-				Reacquire ();
-			}
-
-			return !Log.HasLoggedErrors;
-		}
-
-		void DoExecute ()
-		{
 			resource_name_case_map = MonoAndroidHelper.LoadResourceCaseMap (ResourceNameCaseMap);
 
 			assemblyMap.Load (Path.Combine (WorkingDirectory, AssemblyIdentityMapFile));
 
-			this.ParallelForEach (ManifestFiles, ProcessManifest);
+			return this.WhenAll (ManifestFiles, ProcessManifest);
 		}
 
 		protected string GenerateCommandLineCommands (string ManifestFile, string currentAbi, string currentResourceOutputFile)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Compile.cs
@@ -29,27 +29,11 @@ namespace Xamarin.Android.Tasks {
 		[Output]
 		public ITaskItem [] CompiledResourceFlatArchives => archives.ToArray ();
 
-		public override bool RunTask ()
-		{
-			Yield ();
-			try {
-				var task = this.RunTask (DoExecute);
-
-				task.ContinueWith (Complete);
-
-				base.RunTask ();
-			} finally {
-				Reacquire ();
-			}
-
-			return !Log.HasLoggedErrors;
-		}
-
-		void DoExecute ()
+		public override System.Threading.Tasks.Task RunTaskAsync ()
 		{
 			LoadResourceCaseMap ();
 
-			this.ParallelForEachWithLock (ResourceDirectories, ProcessDirectory);
+			return this.WhenAllWithLock (ResourceDirectories, ProcessDirectory);
 		}
 
 		void ProcessDirectory (ITaskItem resourceDirectory, object lockObject)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -77,30 +77,14 @@ namespace Xamarin.Android.Tasks {
 		AssemblyIdentityMap assemblyMap = new AssemblyIdentityMap ();
 		List<string> tempFiles = new List<string> ();
 
-		public override bool RunTask ()
-		{
-			Yield ();
-			try {
-				var task = this.RunTask (DoExecute);
-
-				task.ContinueWith (Complete);
-
-				base.RunTask ();
-			} finally {
-				Reacquire ();
-			}
-
-			return !Log.HasLoggedErrors;
-		}
-
-		void DoExecute ()
+		public async override System.Threading.Tasks.Task RunTaskAsync ()
 		{
 			try {
 				LoadResourceCaseMap ();
 
 				assemblyMap.Load (Path.Combine (WorkingDirectory, AssemblyIdentityMapFile));
 
-				this.ParallelForEach (ManifestFiles, ProcessManifest);
+				await this.WhenAll (ManifestFiles, ProcessManifest);
 			} finally {
 				lock (tempFiles) {
 					foreach (var temp in tempFiles) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
@@ -35,60 +35,12 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public string AndroidBinUtilsDirectory { get; set; }
 
-		public override bool RunTask ()
+		public override System.Threading.Tasks.Task RunTaskAsync ()
 		{
-			try {
-				return DoExecute ();
-			} catch (Exception e) {
-				// We don't want to present a wall of text to the end user...
-				Log.LogCodedError ("XA3001", $"Unable to generate `libxamarin-app.so`: {e.Message}");
-
-				// ...but having the full stack trace available is important for us, so log it here
-				// int the way that will make it included in XA builds on bots or in verbose end user
-				// builds but not otherwise.
-				LogDebugMessage ($"Full exception: {e}");
-				return false;
-			}
+			return this.WhenAll (GetAssemblerConfigs (), RunAssembler);
 		}
 
-		bool DoExecute ()
-		{
-			Yield ();
-			try {
-				var task = this.RunTask ( () => RunParallelAssembler ());
-				task.ContinueWith (Complete);
-
-				base.RunTask ();
-
-				if (!task.Result)
-					return false;
-			} finally {
-				Reacquire ();
-			}
-
-			return !Log.HasLoggedErrors;
-		}
-
-		bool RunParallelAssembler ()
-		{
-			try {
-				this.ParallelForEach (GetAssemblerConfigs (),
-					config => {
-						if (!RunAssembler (config)) {
-							LogCodedError ("XA3001", $"Could not compile native assembly file: {Path.GetFileName (config.InputSource)}");
-							Cancel ();
-							return;
-						}
-					}
-				);
-			} catch (OperationCanceledException) {
-				return false;
-			}
-
-			return true;
-		}
-
-		bool RunAssembler (Config config)
+		void RunAssembler (Config config)
 		{
 			var stdout_completed = new ManualResetEvent (false);
 			var stderr_completed = new ManualResetEvent (false);
@@ -133,7 +85,10 @@ namespace Xamarin.Android.Tasks
 				if (psi.RedirectStandardOutput)
 					stdout_completed.WaitOne (TimeSpan.FromSeconds (30));
 
-				return proc.ExitCode == 0;
+				if (proc.ExitCode != 0) {
+					LogCodedError ("XA3001", $"Could not compile native assembly file: {Path.GetFileName (config.InputSource)}");
+					Cancel ();
+				}
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Crunch.cs
@@ -70,37 +70,17 @@ namespace Xamarin.Android.Tasks
 			return;
 		}
 
-		public override bool RunTask ()
-		{
-			Yield ();
-			try {
-				var task = this.RunTask (DoExecute);
-
-				task.ContinueWith (Complete);
-
-				base.RunTask ();
-			} finally {
-				Reacquire ();
-			}
-
-			return !Log.HasLoggedErrors;
-		}
-
-		void DoExecute ()
+		public async override System.Threading.Tasks.Task RunTaskAsync ()
 		{
 			// copy the changed files over to a temp location for processing
 			var imageFiles = SourceFiles.Where (x => string.Equals (Path.GetExtension (x.ItemSpec),".png", StringComparison.OrdinalIgnoreCase));
-
 			if (!imageFiles.Any ())
 				return;
 
 			var imageGroups = imageFiles.GroupBy (x => Path.GetDirectoryName (Path.GetFullPath (x.ItemSpec)));
 
-			this.ParallelForEach (imageGroups, DoExecute);
-
-			return;
+			await this.WhenAll (imageGroups, DoExecute);
 		}
-
 
 		protected string GenerateFullPathToTool ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLibraryResources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLibraryResources.cs
@@ -38,25 +38,11 @@ namespace Xamarin.Android.Tasks
 		/// </summary>
 		public string [] ManifestFiles { get; set; }
 
-		public override bool RunTask ()
-		{
-			Yield ();
-			try {
-				this.RunTask (DoExecute).ContinueWith (Complete);
-
-				base.RunTask ();
-			} finally {
-				Reacquire ();
-			}
-
-			return !Log.HasLoggedErrors;
-		}
-
 		string main_r_txt;
 		string output_directory;
 		Dictionary<string, string> r_txt_mapping;
 
-		void DoExecute ()
+		public async override System.Threading.Tasks.Task RunTaskAsync ()
 		{
 			if (LibraryTextFiles == null || LibraryTextFiles.Length == 0)
 				return;
@@ -75,7 +61,7 @@ namespace Xamarin.Android.Tasks
 			output_directory = Path.GetFullPath (OutputDirectory);
 
 			var libraries = LibraryTextFiles.Zip (ManifestFiles, (textFile, manifestFile) => new Library (textFile, manifestFile));
-			this.ParallelForEach (libraries, GenerateJava);
+			await this.WhenAll (libraries, GenerateJava);
 		}
 
 		/// <summary>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -57,19 +57,12 @@ namespace Xamarin.Android.Tasks
 		[Output]
 		public string[] ResolvedDoNotPackageAttributes { get; set; }
 
-		public override bool RunTask ()
+		public override System.Threading.Tasks.Task RunTaskAsync ()
 		{
-			Yield ();
-			try {
-				System.Threading.Tasks.Task.Run (() => {
-					using (var resolver = new MetadataResolver ()) {
-						Execute (resolver);
-					}
-				}, CancellationToken).ContinueWith (Complete);
-				return base.RunTask ();
-			} finally {
-				Reacquire ();
+			using (var resolver = new MetadataResolver ()) {
+				Execute (resolver);
 			}
+			return Done;
 		}
 
 		void Execute (MetadataResolver resolver)
@@ -131,7 +124,7 @@ namespace Xamarin.Android.Tasks
 			var mainapiLevel = MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (TargetFrameworkVersion);
 			foreach (var item in api_levels.Where (x => mainapiLevel < x.Value)) {
 				var itemOSVersion = MonoAndroidHelper.SupportedVersions.GetFrameworkVersionFromApiLevel (item.Value);
-				Log.LogCodedWarning ("XA0105", ProjectFile, 0,
+				LogCodedWarning ("XA0105", ProjectFile, 0,
 					"The $(TargetFrameworkVersion) for {0} ({1}) is greater than the $(TargetFrameworkVersion) for your project ({2}). " +
 					"You need to increase the $(TargetFrameworkVersion) for your project.", Path.GetFileName (item.Key), itemOSVersion, TargetFrameworkVersion);
 			}
@@ -310,7 +303,7 @@ namespace Xamarin.Android.Tasks
 												var apiLevel = MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (version);
 												if (apiLevel != null) {
 													var assemblyName = reader.GetString (assembly.Name);
-													Log.LogDebugMessage ("{0}={1}", assemblyName, apiLevel);
+													LogDebugMessage ("{0}={1}", assemblyName, apiLevel);
 													api_levels [assemblyName] = apiLevel.Value;
 												}
 											}


### PR DESCRIPTION
Right now there is a lot of boilerplate when using `AsyncTask`:

    public override bool RunTask ()
    {
        Yield ();
        try {
            var task = this.RunTask (DoExecute);

            task.ContinueWith (Complete);

            base.RunTask ();
        } finally {
            Reacquire ();
        }

        return !Log.HasLoggedErrors;
    }

We don't want to remember all that... or have to consistently get it
right.

Then if you want to use `Parallel.ForEach` it gets even more complex:

    this.RunTask (
        () => this.ParallelForEach (SomeArray, DoExecute)
    ).ContinueWith (Complete);

In d4c8f077, we created a base `AndroidAsyncTask` for error handling.
Let's put this weird `Yield-try-finally-Reacquire` logic in there,
too!

So instead, you would override:

    public override System.Threading.Tasks.Task RunTaskAsync ()

This method is:

* Already on a background thread.
* You can use `async` / `await` nicely.

I also added helper methods, so that instead of:

    this.ParallelForEach (ManifestFiles, ProcessManifest);

You can instead do:

    await this.WhenAll (ManifestFiles, ProcessManifest);

This plays well with `async` / `await`.

In refactoring this, I found some places where `<ResolveAssemblies/>`
was accessing `Log.Log*` on a background thread... I fixed that.