### PR TITLE
[Xamarin.Android.Build.Tasks] use System.Reflection.Metadata for ResolveLibraryProjectImports

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -7,8 +7,8 @@ using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
 using Xamarin.Tools.Zip;
 using Xamarin.Android.Tools;
-using System.Reflection.PortableExecutable;
 using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 
 namespace Xamarin.Android.Tasks
 {
@@ -217,9 +217,7 @@ namespace Xamarin.Android.Tasks
 				Log.LogDebugMessage ($"Refreshing {assemblyFileName}.dll");
 
 				using (var pe = new PEReader (File.OpenRead (assemblyPath))) {
-
 					var reader = pe.GetMetadataReader ();
-
 					foreach (var handle in reader.ManifestResources) {
 						var resource = reader.GetManifestResource (handle);
 						string name = reader.GetString (resource.Name);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MetadataExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MetadataExtensions.cs
@@ -1,5 +1,8 @@
-﻿using System;
+using System;
+using System.Diagnostics;
+using System.IO;
 using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 
 namespace Xamarin.Android.Tasks
 {
@@ -48,6 +51,49 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 			return null;
+		}
+
+
+		/// <summary>
+		/// Get the bytes in an embedded resource as a Stream.
+		/// WARNING: It is incorrect to read from this stream after the PEReader has been disposed.
+		/// 
+		/// See:
+		///		https://github.com/dotnet/corefx/issues/23372
+		///		https://gist.github.com/nguerrera/6864d2a907cb07d869be5a2afed8d764
+		/// </summary>
+		public static unsafe Stream GetEmbeddedResourceStream (this PEReader peReader, ManifestResource resource)
+		{
+			checked // arithmetic overflow here could cause AV
+			{
+				// Locate start and end of PE image in unmanaged memory.
+				var block = peReader.GetEntireImage ();
+				Debug.Assert (block.Pointer != null && block.Length > 0);
+
+				byte* peImageStart = block.Pointer;
+				byte* peImageEnd = peImageStart + block.Length;
+
+				// Locate offset to resources within PE image.
+				int offsetToResources;
+				if (!peReader.PEHeaders.TryGetDirectoryOffset (peReader.PEHeaders.CorHeader.ResourcesDirectory, out offsetToResources)) {
+					throw new BadImageFormatException ("Failed to get offset to resources in PE file.");
+				}
+				Debug.Assert (offsetToResources > 0);
+				byte* resourceStart = peImageStart + offsetToResources + resource.Offset;
+
+				// Get the length of the the resource from the first 4 bytes.
+				if (resourceStart >= peImageEnd - sizeof (int)) {
+					throw new BadImageFormatException ("resource offset out of bounds.");
+				}
+
+				int resourceLength = new BlobReader (resourceStart, sizeof (int)).ReadInt32 ();
+				resourceStart += sizeof (int);
+				if (resourceLength < 0 || resourceStart >= peImageEnd - resourceLength) {
+					throw new BadImageFormatException ("resource offset or length out of bounds.");
+				}
+
+				return new UnmanagedMemoryStream (resourceStart, resourceLength);
+			}
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -12,6 +12,7 @@
     <FileAlignment>512</FileAlignment>
     <SchemaVersion>2.0</SchemaVersion>
     <LibZipSharpBundleAllNativeLibraries>true</LibZipSharpBundleAllNativeLibraries>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <Import Project="..\..\build-tools\scripts\MSBuildReferences.projitems" />


### PR DESCRIPTION
I wrote the code for this a long time ago, but never opened a PR
because when timing the difference, I was seeing *no* improvement.

I even wrote a benchmark, that did clearly show an improvement:

https://github.com/jonathanpeppers/Benchmarks/blob/38ffb60421604b15eef38170ad9b12a2049ac3f1/Benchmarks/Cecil.cs

         Method |      Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
    ----------- |----------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
            SRM |  8.669 ms | 0.0385 ms | 0.0322 ms |   1000.0000 |    671.8750 |    656.2500 |             5.51 MB |
     Mono.Cecil | 24.006 ms | 0.1879 ms | 0.1758 ms |   1906.2500 |   1718.7500 |    781.2500 |            39.95 MB |

Then last week I saw this line in the diff:

    var assemblyLastWrite = new FileInfo (assemblyPath).LastWriteTimeUtc;

Doh! This was leftover from something else, I'm not sure!

After removing that, this *does* in fact help performance:

    Before:
    4814 ms  ResolveLibraryProjectImports               1 calls
    After:
    4502 ms  ResolveLibraryProjectImports               1 calls

This was the Xamarin.Forms project in this repo. I think this will
help by around 300ms any time the `<ResolveLibraryProjectImports/>`
MSBuild task needs to run.

This seems like an easy-win. The only drawback is the addition of:

    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

The `unsafe` keyword is needed for accessing `EmbeddedResource` with
System.Reflection.Metadata.