### PR TITLE
Bump to mono@7ec17ba1be9bd08d9d991d10414df2b78710bc18

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:master@623845d44abe5eb7a76d9a63d48b30a27ac1bac2
-mono/mono:2019-08@cecda47c489a990c1554bdef486fa54e97544eea
+mono/mono:2019-08@7ec17ba1be9bd08d9d991d10414df2b78710bc18


### PR DESCRIPTION
Changes: https://github.com/mono/mono/compare/cecda47c489a990c1554bdef486fa54e97544eea...7ec17ba1be9bd08d9d991d10414df2b78710bc18
Context: https://github.com/xamarin/xamarin-android/issues/3619

Fixes AOT on Windows and adds aprofutil tool to mono SDK (aka mono
android archive)

Other changes include memory leak fix and thread name related issue.