### PR TITLE
Bump to mono/mono/2019-08@7ec17ba1

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:master@623845d44abe5eb7a76d9a63d48b30a27ac1bac2
-mono/mono:2019-08@cecda47c489a990c1554bdef486fa54e97544eea
+mono/mono:2019-08@7ec17ba1be9bd08d9d991d10414df2b78710bc18


### PR DESCRIPTION
Changes: https://github.com/mono/mono/compare/cecda47c489a990c1554bdef486fa54e97544eea...7ec17ba1be9bd08d9d991d10414df2b78710bc18

Fixes: https://github.com/xamarin/xamarin-android/issues/3619

Adds `aprofutil.exe` to the mono archive for Xamarin.Android use.

Fix leaks when handling a few metadata attributes.

Fix infrequent hangs in test-runner.

[threads] do not convert NULL thread name.