### PR TITLE
[ci] Add Windows MSBuild test job

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -197,7 +197,7 @@ stages:
       parameters:
         artifactName: mac-build-results
 
-  # Check - "Xamarin.Android (Mac Queue Vsix Signing)"
+  # Check - "Xamarin.Android (Build Queue Vsix Signing)"
   # Actually runs on a Windows host, but the work is done in a Jenkins job. Does not run on PR builds.
   - job: queue_vsix_signing
     displayName: Queue Vsix Signing
@@ -224,14 +224,10 @@ stages:
           GITHUB_CONTEXT=$(GitHub.Artifacts.Context)
           ENABLE_JAR_SIGNING=true
 
-# This stage ensures Windows specific build steps continue to work, and runs unit tests.
-# Check - "Xamarin.Android (Windows Build and Test)"
-- stage: win_build_test
-  displayName: Windows
-  dependsOn: prepare
-  jobs:
+  # This stage ensures Windows specific build steps continue to work, and runs a limited set of unit tests.
+  # Check - "Xamarin.Android (Build Windows)"
   - job: win_build_test
-    displayName: Build and Test
+    displayName: Windows
     pool: $(VSEngWinVS2019)
     timeoutInMinutes: 360
     cancelTimeoutInMinutes: 5
@@ -285,14 +281,6 @@ stages:
         arguments: Xamarin.Android-Tests.sln /p:Configuration=$(XA.Build.Configuration) /p:XAIntegratedTests=False /bl:$(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\msbuild-build-tests.binlog $(AndroidTargetAbiArgs)
 
     - task: MSBuild@1
-      displayName: nunit Xamarin.Android.Build.Tests
-      inputs:
-        solution: Xamarin.Android.sln
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: /t:RunNUnitTests /bl:$(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\msbuild-run-nunit-tests.binlog
-      timeoutInMinutes: 240
-
-    - task: MSBuild@1
       displayName: nunit Java.Interop Tests
       inputs:
         solution: Xamarin.Android.sln
@@ -314,6 +302,8 @@ stages:
     - template: yaml-templates\upload-results.yaml
       parameters:
         artifactName: win-build-test-results
+
+  # TODO Check - "Xamarin.Android (Build Linux)"
 
 - stage: test
   displayName: Test
@@ -360,7 +350,7 @@ stages:
     variables:
       ApkTestConfiguration: Release
     steps:
-    - template: yaml-templates/mac/setup-test-environment.yaml
+    - template: yaml-templates/setup-test-environment.yaml
       parameters:
         configuration: $(ApkTestConfiguration)
 
@@ -511,7 +501,7 @@ stages:
     pool: $(HostedMac)
     timeoutInMinutes: 180
     steps:
-    - template: yaml-templates/mac/setup-test-environment.yaml
+    - template: yaml-templates/setup-test-environment.yaml
 
     - task: DownloadPipelineArtifact@1
       inputs:
@@ -563,7 +553,7 @@ stages:
     workspace:
       clean: all
     steps:
-    - template: yaml-templates/mac/setup-test-environment.yaml
+    - template: yaml-templates/setup-test-environment.yaml
 
     - task: DownloadPipelineArtifact@1
       inputs:
@@ -586,7 +576,56 @@ stages:
       parameters:
         artifactName: mac-msbuild-test-results
 
- # Check - "Xamarin.Android (Test MSBuild With Emulator Mac)"
+  # Check - "Xamarin.Android (Test MSBuild Win)"
+  - job: win_msbuild_tests
+    displayName: MSBuild Win
+    pool: $(HostedWinVS2019)
+    timeoutInMinutes: 180
+    cancelTimeoutInMinutes: 5
+    workspace:
+      clean: all
+    steps:
+    - template: yaml-templates\setup-test-environment.yaml
+
+    - task: DownloadPipelineArtifact@1
+      inputs:
+        artifactName: $(TestAssembliesArtifactName)
+        downloadPath: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)
+
+    - script: >
+        packages/NUnit.ConsoleRunner.$(NUnitConsoleVersion)\tools\nunit3-console.exe
+        $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\Xamarin.Android.Build.Tests.dll
+        --result TestResult-WinMSBuildTests-$(XA.Build.Configuration).xml
+      displayName: run Xamarin.Android.Build.Tests
+
+    - task: PublishTestResults@2
+      displayName: publish test results
+      inputs:
+        testResultsFormat: NUnit
+        testResultsFiles: TestResult-WinMSBuildTests-$(XA.Build.Configuration).xml
+        testRunTitle: MSBuildTestsWin
+      condition: succeededOrFailed()
+
+    - script: >
+        packages\NUnit.ConsoleRunner.$(NUnitConsoleVersion)\tools\nunit3-console.exe
+        $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\Xamarin.Android.Build.Tests.Commercial.dll
+        --result TestResult-WinMSBuildTestsCommercial-$(XA.Build.Configuration).xml
+      displayName: run Xamarin.Android.Build.Tests.Commercial
+      condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
+
+    - task: PublishTestResults@2
+      displayName: publish test results
+      inputs:
+        testResultsFormat: NUnit
+        testResultsFiles: TestResult-WinMSBuildTestsCommercial-$(XA.Build.Configuration).xml
+        testRunTitle: MSBuildTestsMWin
+      condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
+
+    - template: yaml-templates\upload-results.yaml
+      parameters:
+        artifactName: win-msbuild-test-results
+
+  # Check - "Xamarin.Android (Test MSBuild With Emulator Mac)"
   - job: mac_msbuilddevice_tests
     displayName: MSBuild With Emulator Mac
     pool: $(HostedMac)
@@ -595,7 +634,7 @@ stages:
     workspace:
       clean: all
     steps:
-    - template: yaml-templates/mac/setup-test-environment.yaml
+    - template: yaml-templates/setup-test-environment.yaml
 
     - task: DownloadPipelineArtifact@1
       inputs:
@@ -638,7 +677,76 @@ stages:
       parameters:
         artifactName: mac-msbuild-device-test-results
 
-# Check - "Xamarin.Android (Test TimeZoneInfo With Emulator Mac)"
+  # Check - "Xamarin.Android (Test MSBuild With Emulator Win)"
+  - job: win_msbuilddevice_tests
+    displayName: MSBuild With Emulator Win
+    pool: $(HostedWinVS2019)
+    timeoutInMinutes: 150
+    cancelTimeoutInMinutes: 5
+    workspace:
+      clean: all
+    steps:
+    - template: yaml-templates\setup-test-environment.yaml
+
+    - task: DownloadPipelineArtifact@1
+      inputs:
+        artifactName: $(TestAssembliesArtifactName)
+        downloadPath: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)
+
+    - task: MSBuild@1
+      displayName: start emulator
+      inputs:
+        solution: src\Mono.Android\Test\Mono.Android-Tests.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: >
+          /t:AcquireAndroidTarget /bl:$(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\start-emulator.binlog
+
+    - script: >
+        packages\NUnit.ConsoleRunner.$(NUnitConsoleVersion)\tools\nunit3-console.exe
+        $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\Xamarin.Android.Build.Tests.dll
+        --where "cat == UsesDevice"
+        --result TestResult-WinMSBuildDeviceTests-$(XA.Build.Configuration).xml
+      displayName: run on-device Xamarin.Android.Build.Tests
+
+    - task: PublishTestResults@2
+      displayName: publish test results
+      inputs:
+        testResultsFormat: NUnit
+        testResultsFiles: TestResult-WinMSBuildDeviceTests-$(XA.Build.Configuration).xml
+        testRunTitle: MSBuildDeviceTestsWin
+      condition: always()
+
+    - script: >
+        packages\NUnit.ConsoleRunner.$(NUnitConsoleVersion)\tools\nunit3-console.exe
+        $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\MSBuildDeviceIntegration\MSBuildDeviceIntegration.dll
+        --where "test != Xamarin.Android.Build.Tests.DeploymentTest.CheckTimeZoneInfoIsCorrect"
+        --result TestResult-WinMSBuildDeviceIntegration-$(XA.Build.Configuration).xml
+      displayName: run on-device MSBuildDeviceIntegration tests
+      condition: succeededOrFailed()
+
+    - task: PublishTestResults@2
+      displayName: publish test results
+      inputs:
+        testResultsFormat: NUnit
+        testResultsFiles: TestResult-WinMSBuildDeviceIntegration-$(XA.Build.Configuration).xml
+        testRunTitle: MSBuildDeviceIntegration
+      condition: always()
+
+    - task: MSBuild@1
+      displayName: shut down emulator
+      inputs:
+        solution: src\Mono.Android\Test\Mono.Android-Tests.csproj
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: >
+          /t:AcquireAndroidTarget,ReleaseAndroidTarget
+          /bl:$(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\shutdown-emulator.binlog
+      condition: always()
+
+    - template: yaml-templates\upload-results.yaml
+      parameters:
+        artifactName: mac-msbuild-device-test-results
+
+  # Check - "Xamarin.Android (Test TimeZoneInfo With Emulator Mac)"
   - job: mac_timezonedevice_tests
     displayName: TimeZoneInfo With Emulator Mac
     pool: $(HostedMac)
@@ -647,7 +755,7 @@ stages:
     workspace:
       clean: all
     steps:
-    - template: yaml-templates/mac/setup-test-environment.yaml
+    - template: yaml-templates/setup-test-environment.yaml
 
     - task: DownloadPipelineArtifact@1
       inputs:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -572,15 +572,15 @@ stages:
 
     - template: yaml-templates/run-nunit-tests.yaml
       parameters:
-        testRunTitle: Xamarin.Android.Build.Tests - Mac
+        testRunTitle: Xamarin.Android.Build.Tests - macOS
         testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.dll
-        testResultsFile: TestResult-MSBuildTests-$(XA.Build.Configuration).xml
+        testResultsFile: TestResult-MSBuildTests-macOS-$(XA.Build.Configuration).xml
 
     - template: yaml-templates/run-nunit-tests.yaml
       parameters:
-        testRunTitle: Xamarin.Android.Build.Tests.Commercial - Mac
+        testRunTitle: Xamarin.Android.Build.Tests.Commercial - macOS
         testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.Commercial.dll
-        testResultsFile: TestResult-MSBuildTestsCommercial-$(XA.Build.Configuration).xml
+        testResultsFile: TestResult-MSBuildTestsCommercial-macOS-$(XA.Build.Configuration).xml
 
     - template: yaml-templates/upload-results.yaml
       parameters:
@@ -594,42 +594,29 @@ stages:
     cancelTimeoutInMinutes: 5
     workspace:
       clean: all
+    variables:
+      VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
     steps:
     - template: yaml-templates\setup-test-environment.yaml
+      parameters:
+        provisionExtraArgs: -vv PROVISIONATOR_VISUALSTUDIO_LOCATION=$(VSINSTALLDIR)
 
     - task: DownloadPipelineArtifact@1
       inputs:
         artifactName: $(TestAssembliesArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)
 
-    - script: >
-        packages/NUnit.ConsoleRunner.$(NUnitConsoleVersion)\tools\nunit3-console.exe
-        $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\Xamarin.Android.Build.Tests.dll
-        --result TestResult-WinMSBuildTests-$(XA.Build.Configuration).xml
-      displayName: run Xamarin.Android.Build.Tests
+    - template: yaml-templates\run-nunit-tests.yaml
+      parameters:
+        testRunTitle: Xamarin.Android.Build.Tests - Windows
+        testAssembly: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\Xamarin.Android.Build.Tests.dll
+        testResultsFile: TestResult-MSBuildTests-Windows-$(XA.Build.Configuration).xml
 
-    - task: PublishTestResults@2
-      displayName: publish test results
-      inputs:
-        testResultsFormat: NUnit
-        testResultsFiles: TestResult-WinMSBuildTests-$(XA.Build.Configuration).xml
-        testRunTitle: MSBuildTestsWin
-      condition: succeededOrFailed()
-
-    - script: >
-        packages\NUnit.ConsoleRunner.$(NUnitConsoleVersion)\tools\nunit3-console.exe
-        $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\Xamarin.Android.Build.Tests.Commercial.dll
-        --result TestResult-WinMSBuildTestsCommercial-$(XA.Build.Configuration).xml
-      displayName: run Xamarin.Android.Build.Tests.Commercial
-      condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
-
-    - task: PublishTestResults@2
-      displayName: publish test results
-      inputs:
-        testResultsFormat: NUnit
-        testResultsFiles: TestResult-WinMSBuildTestsCommercial-$(XA.Build.Configuration).xml
-        testRunTitle: MSBuildTestsMWin
-      condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
+    - template: yaml-templates\run-nunit-tests.yaml
+      parameters:
+        testRunTitle: Xamarin.Android.Build.Tests.Commercial - Windows
+        testAssembly: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\Xamarin.Android.Build.Tests.Commercial.dll
+        testResultsFile: TestResult-MSBuildTestsCommercial-Windows-$(XA.Build.Configuration).xml
 
     - template: yaml-templates\upload-results.yaml
       parameters:
@@ -661,14 +648,14 @@ stages:
 
     - template: yaml-templates/run-nunit-tests.yaml
       parameters:
-        testRunTitle: Xamarin.Android.Build.Tests On Device - Mac
+        testRunTitle: Xamarin.Android.Build.Tests On Device - macOS
         testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/Xamarin.Android.Build.Tests.dll
         nunitConsoleExtraArgs: --where "cat == UsesDevice"
         testResultsFile: TestResult-MSBuildDeviceTests-$(XA.Build.Configuration).xml
 
     - template: yaml-templates/run-nunit-tests.yaml
       parameters:
-        testRunTitle: MSBuildDeviceIntegration On Device - Mac
+        testRunTitle: MSBuildDeviceIntegration On Device - macOS
         testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll
         nunitConsoleExtraArgs: --where "test != Xamarin.Android.Build.Tests.DeploymentTest.CheckTimeZoneInfoIsCorrect"
         testResultsFile: TestResult-MSBuildDeviceIntegration-$(XA.Build.Configuration).xml
@@ -684,75 +671,6 @@ stages:
       condition: always()
 
     - template: yaml-templates/upload-results.yaml
-      parameters:
-        artifactName: mac-msbuild-device-test-results
-
-  # Check - "Xamarin.Android (Test MSBuild With Emulator - Windows)"
-  - job: win_msbuilddevice_tests
-    displayName: MSBuild With Emulator - Windows
-    pool: $(VSEngWinVS2019)
-    timeoutInMinutes: 150
-    cancelTimeoutInMinutes: 5
-    workspace:
-      clean: all
-    steps:
-    - template: yaml-templates\setup-test-environment.yaml
-
-    - task: DownloadPipelineArtifact@1
-      inputs:
-        artifactName: $(TestAssembliesArtifactName)
-        downloadPath: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)
-
-    - task: MSBuild@1
-      displayName: start emulator
-      inputs:
-        solution: src\Mono.Android\Test\Mono.Android-Tests.csproj
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: >
-          /t:AcquireAndroidTarget /bl:$(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\start-emulator.binlog
-
-    - script: >
-        packages\NUnit.ConsoleRunner.$(NUnitConsoleVersion)\tools\nunit3-console.exe
-        $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\Xamarin.Android.Build.Tests.dll
-        --where "cat == UsesDevice"
-        --result TestResult-WinMSBuildDeviceTests-$(XA.Build.Configuration).xml
-      displayName: run on-device Xamarin.Android.Build.Tests
-
-    - task: PublishTestResults@2
-      displayName: publish test results
-      inputs:
-        testResultsFormat: NUnit
-        testResultsFiles: TestResult-WinMSBuildDeviceTests-$(XA.Build.Configuration).xml
-        testRunTitle: MSBuildDeviceTestsWin
-      condition: always()
-
-    - script: >
-        packages\NUnit.ConsoleRunner.$(NUnitConsoleVersion)\tools\nunit3-console.exe
-        $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\MSBuildDeviceIntegration\MSBuildDeviceIntegration.dll
-        --where "test != Xamarin.Android.Build.Tests.DeploymentTest.CheckTimeZoneInfoIsCorrect"
-        --result TestResult-WinMSBuildDeviceIntegration-$(XA.Build.Configuration).xml
-      displayName: run on-device MSBuildDeviceIntegration tests
-      condition: succeededOrFailed()
-
-    - task: PublishTestResults@2
-      displayName: publish test results
-      inputs:
-        testResultsFormat: NUnit
-        testResultsFiles: TestResult-WinMSBuildDeviceIntegration-$(XA.Build.Configuration).xml
-        testRunTitle: MSBuildDeviceIntegration
-      condition: always()
-
-    - task: MSBuild@1
-      displayName: shut down emulator
-      inputs:
-        solution: src\Mono.Android\Test\Mono.Android-Tests.csproj
-        configuration: $(XA.Build.Configuration)
-        msbuildArguments: >
-          /t:AcquireAndroidTarget,ReleaseAndroidTarget
-          /bl:$(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\shutdown-emulator.binlog
-      condition: always()
-
-    - template: yaml-templates\upload-results.yaml
       parameters:
         artifactName: mac-msbuild-device-test-results
 
@@ -782,7 +700,7 @@ stages:
 
     - template: yaml-templates/run-nunit-tests.yaml
       parameters:
-        testRunTitle: TimeZoneInfoTests On Device - Mac
+        testRunTitle: TimeZoneInfoTests On Device - macOS
         testAssembly: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll
         nunitConsoleExtraArgs: --where "test == Xamarin.Android.Build.Tests.DeploymentTest.CheckTimeZoneInfoIsCorrect"
         testResultsFile: TestResult-TimeZoneInfoTests-$(XA.Build.Configuration).xml
@@ -871,9 +789,9 @@ stages:
       parameters:
         designerSourcePath: $(System.DefaultWorkingDirectory)\designer
 
-  # Check - "Xamarin.Android (Test Integrated Regression Mac)"
+  # Check - "Xamarin.Android (Test Integrated Regression - macOS)"
   - job: integrated_regression_mac
-    displayName: Integrated Regression Mac
+    displayName: Integrated Regression - macOS
     pool:
       name: VSEng-Xamarin-Mac-Devices
       demands:
@@ -886,9 +804,9 @@ stages:
     steps:
     - template: yaml-templates/run-integrated-regression-tests.yaml
 
-  # Check - "Xamarin.Android (Test Integrated Regression Windows)"
+  # Check - "Xamarin.Android (Test Integrated Regression - Windows)"
   - job: integrated_regression_Win
-    displayName: Integrated Regression Windows
+    displayName: Integrated Regression - Windows
     pool:
       name: VSEng-Xamarin-Win-XMA
       demands:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -315,8 +315,6 @@ stages:
       parameters:
         artifactName: win-build-test-results
 
-  # TODO Check - "Xamarin.Android (Build Linux)"
-
 - stage: test
   displayName: Test
   dependsOn: mac_build
@@ -591,7 +589,7 @@ stages:
   # Check - "Xamarin.Android (Test MSBuild - Windows)"
   - job: win_msbuild_tests
     displayName: MSBuild - Windows
-    pool: $(HostedWinVS2019)
+    pool: $(VSEngWinVS2019)
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
     workspace:
@@ -692,7 +690,7 @@ stages:
   # Check - "Xamarin.Android (Test MSBuild With Emulator - Windows)"
   - job: win_msbuilddevice_tests
     displayName: MSBuild With Emulator - Windows
-    pool: $(HostedWinVS2019)
+    pool: $(VSEngWinVS2019)
     timeoutInMinutes: 150
     cancelTimeoutInMinutes: 5
     workspace:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -599,7 +599,7 @@ stages:
     steps:
     - template: yaml-templates\setup-test-environment.yaml
       parameters:
-        provisionExtraArgs: -vv PROVISIONATOR_VISUALSTUDIO_LOCATION=$(VSINSTALLDIR)
+        provisionExtraArgs: -vv PROVISIONATOR_VISUALSTUDIO_LOCATION="$(VSINSTALLDIR)"
 
     - task: DownloadPipelineArtifact@1
       inputs:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -197,7 +197,7 @@ stages:
       parameters:
         artifactName: mac-build-results
 
-  # Check - "Xamarin.Android (Build Queue Vsix Signing)"
+  # Check - "Xamarin.Android (Mac Queue Vsix Signing)"
   # Actually runs on a Windows host, but the work is done in a Jenkins job. Does not run on PR builds.
   - job: queue_vsix_signing
     displayName: Queue Vsix Signing
@@ -224,10 +224,14 @@ stages:
           GITHUB_CONTEXT=$(GitHub.Artifacts.Context)
           ENABLE_JAR_SIGNING=true
 
-  # This stage ensures Windows specific build steps continue to work, and runs a limited set of unit tests.
-  # Check - "Xamarin.Android (Build Windows)"
+# This stage ensures Windows specific build steps continue to work, and runs unit tests.
+# Check - "Xamarin.Android (Windows Build and Test)"
+- stage: win_build_test
+  displayName: Windows
+  dependsOn: prepare
+  jobs:
   - job: win_build_test
-    displayName: Windows
+    displayName: Build and Test
     pool: $(VSEngWinVS2019)
     timeoutInMinutes: 360
     cancelTimeoutInMinutes: 5
@@ -281,6 +285,14 @@ stages:
         arguments: Xamarin.Android-Tests.sln /p:Configuration=$(XA.Build.Configuration) /p:XAIntegratedTests=False /bl:$(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\msbuild-build-tests.binlog $(AndroidTargetAbiArgs)
 
     - task: MSBuild@1
+      displayName: nunit Xamarin.Android.Build.Tests
+      inputs:
+        solution: Xamarin.Android.sln
+        configuration: $(XA.Build.Configuration)
+        msbuildArguments: /t:RunNUnitTests /bl:$(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\msbuild-run-nunit-tests.binlog
+      timeoutInMinutes: 240
+
+    - task: MSBuild@1
       displayName: nunit Java.Interop Tests
       inputs:
         solution: Xamarin.Android.sln
@@ -312,7 +324,7 @@ stages:
   # Check - "Xamarin.Android (Test API Compatibility)"
   - job: mac_api_compat
     displayName: API Compatibility
-    pool: $(XA.Build.Mac.Pool)
+    pool: $(HostedMacMojave)
     timeoutInMinutes: 60
     cancelTimeoutInMinutes: 5
     workspace:
@@ -339,9 +351,9 @@ stages:
             Write-Host "##vso[task.uploadsummary]$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/compatibility/$report"
         }
 
-  # Check - "Xamarin.Android (Test APK Instrumentation)"
+  # Check - "Xamarin.Android (Test APK Instrumentation - macOS)"
   - job: mac_apk_tests
-    displayName: APK Instrumentation
+    displayName: APK Instrumentation - macOS
     pool: $(HostedMac)
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
@@ -495,9 +507,9 @@ stages:
         configuration: $(ApkTestConfiguration)
         artifactName: mac-apk-test-results
 
-  # Check - "Xamarin.Android (Test BCL With Emulator)"
+  # Check - "Xamarin.Android (Test BCL With Emulator - macOS)"
   - job: mac_bcl_tests
-    displayName: BCL With Emulator
+    displayName: BCL With Emulator - macOS
     pool: $(HostedMac)
     timeoutInMinutes: 180
     steps:
@@ -544,9 +556,9 @@ stages:
       parameters:
         artifactName: mac-bcl-test-results
 
-  # Check - "Xamarin.Android (Test MSBuild Mac)"
+  # Check - "Xamarin.Android (Test MSBuild - macOS)"
   - job: mac_msbuild_tests
-    displayName: MSBuild Mac
+    displayName: MSBuild - macOS
     pool: $(HostedMacMojave)
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
@@ -576,9 +588,9 @@ stages:
       parameters:
         artifactName: mac-msbuild-test-results
 
-  # Check - "Xamarin.Android (Test MSBuild Win)"
+  # Check - "Xamarin.Android (Test MSBuild - Windows)"
   - job: win_msbuild_tests
-    displayName: MSBuild Win
+    displayName: MSBuild - Windows
     pool: $(HostedWinVS2019)
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
@@ -625,9 +637,9 @@ stages:
       parameters:
         artifactName: win-msbuild-test-results
 
-  # Check - "Xamarin.Android (Test MSBuild With Emulator Mac)"
+  # Check - "Xamarin.Android (Test MSBuild With Emulator - macOS)"
   - job: mac_msbuilddevice_tests
-    displayName: MSBuild With Emulator Mac
+    displayName: MSBuild With Emulator - macOS
     pool: $(HostedMac)
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
@@ -677,9 +689,9 @@ stages:
       parameters:
         artifactName: mac-msbuild-device-test-results
 
-  # Check - "Xamarin.Android (Test MSBuild With Emulator Win)"
+  # Check - "Xamarin.Android (Test MSBuild With Emulator - Windows)"
   - job: win_msbuilddevice_tests
-    displayName: MSBuild With Emulator Win
+    displayName: MSBuild With Emulator - Windows
     pool: $(HostedWinVS2019)
     timeoutInMinutes: 150
     cancelTimeoutInMinutes: 5
@@ -746,9 +758,9 @@ stages:
       parameters:
         artifactName: mac-msbuild-device-test-results
 
-  # Check - "Xamarin.Android (Test TimeZoneInfo With Emulator Mac)"
+  # Check - "Xamarin.Android (Test TimeZoneInfo With Emulator - macOS)"
   - job: mac_timezonedevice_tests
-    displayName: TimeZoneInfo With Emulator Mac
+    displayName: TimeZoneInfo With Emulator - macOS
     pool: $(HostedMac)
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
@@ -791,9 +803,9 @@ stages:
       parameters:
         artifactName: mac-timezoneinfo-test-results
 
-  # Check - "Xamarin.Android (Test Designer Mac)"
+  # Check - "Xamarin.Android (Test Designer - macOS)"
   - job: designer_integration_mac
-    displayName: Designer Mac
+    displayName: Designer - macOS
     pool: $(HostedMac)
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
@@ -827,7 +839,7 @@ stages:
 
   # Check - "Xamarin.Android (Test Designer Windows)"
   - job: designer_integration_win
-    displayName: Designer Windows
+    displayName: Designer - Windows
     pool: $(HostedWinVS2019)
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5

--- a/build-tools/automation/yaml-templates/run-installer.yaml
+++ b/build-tools/automation/yaml-templates/run-installer.yaml
@@ -1,3 +1,6 @@
+parameters:
+  provisionExtraArgs: -vv
+
 steps:
 - task: DownloadPipelineArtifact@2
   inputs:
@@ -22,4 +25,4 @@ steps:
     provisionator_uri: $(provisionator-uri)
     github_token: $(GitHub.Token)
     provisioning_script: $(XA.Provisionator.Args)
-    provisioning_extra_args: -vv
+    provisioning_extra_args: ${{ parameters.provisionExtraArgs }}

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -19,8 +19,8 @@ steps:
   condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
 
 - script: |
-    build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=Required --auto-provision=yes --no-emoji --run-mode=CI
-    build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=AndroidToolchain --no-emoji --run-mode=CI
+    $(System.DefaultWorkingDirectory)\build-tools\xaprepare\xaprepare\bin\${{ parameters.configuration }}\xaprepare.exe --s=Required --auto-provision=yes --no-emoji --run-mode=CI
+    $(System.DefaultWorkingDirectory)\build-tools\xaprepare\xaprepare\bin\${{ parameters.configuration }}\xaprepare.exe --s=AndroidToolchain --no-emoji --run-mode=CI
   displayName: install test dependencies
   condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -2,7 +2,7 @@ parameters:
   configuration: $(XA.Build.Configuration)
 
 steps:
-- template: ../run-installer.yaml
+- template: run-installer.yaml
 
 - task: MSBuild@1
   displayName: build xaprepare
@@ -15,7 +15,14 @@ steps:
     mono build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=UpdateMono --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
     mono build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=Required --auto-provision=yes --auto-provision-uses-sudo=yes --no-emoji --run-mode=CI
     mono build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=AndroidToolchain --no-emoji --run-mode=CI
-  displayName: install xaprepare dependencies
+  displayName: install test dependencies
+  condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
+
+- script: |
+    build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=Required --auto-provision=yes --no-emoji --run-mode=CI
+    build-tools/xaprepare/xaprepare/bin/${{ parameters.configuration }}/xaprepare.exe --s=AndroidToolchain --no-emoji --run-mode=CI
+  displayName: install test dependencies
+  condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 
 - task: UseDotNet@2
   displayName: install .NET Core $(DotNetCoreVersion)

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -1,8 +1,11 @@
 parameters:
   configuration: $(XA.Build.Configuration)
+  provisionExtraArgs: -vv
 
 steps:
 - template: run-installer.yaml
+  parameters:
+    provisionExtraArgs: ${{ parameters.provisionExtraArgs }}
 
 - task: MSBuild@1
   displayName: build xaprepare

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2374,7 +2374,7 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				builder.GetTargetFrameworkVersionRange (out var _, out string firstFrameworkVersion, out var _, out string lastFrameworkVersion);
 				proj.SetProperty ("TargetFrameworkVersion", firstFrameworkVersion);
-				if (!Directory.Exists (Path.Combine (builder.FrameworkLibDirectory, "xbuild-frameworks", "MonoAndroid", firstFrameworkVersion)))
+				if (!Directory.Exists (Path.Combine (builder.FrameworkLibDirectory, firstFrameworkVersion)))
 					Assert.Ignore ("This is a Pull Request Build. Ignoring test.");
 				Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
 				Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, $"Output Property: TargetFrameworkVersion={firstFrameworkVersion}"), $"TargetFrameworkVerson should be {firstFrameworkVersion}");
@@ -3174,7 +3174,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				UseLatestPlatformSdk = false,
 			};
 			using (var builder = CreateApkBuilder (Path.Combine (path, proj.ProjectName), false, false)) {
-				if (!Directory.Exists (Path.Combine (builder.FrameworkLibDirectory, "xbuild-frameworks", "MonoAndroid", targetFrameworkVersion)))
+				if (!Directory.Exists (Path.Combine (builder.FrameworkLibDirectory, targetFrameworkVersion)))
 					Assert.Ignore ("This is a Pull Request Build. Ignoring test.");
 				builder.ThrowOnBuildFailure = false;
 				builder.Target = "_SetLatestTargetFrameworkVersion";
@@ -3202,7 +3202,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				UseLatestPlatformSdk = false,
 			};
 			using (var builder = CreateApkBuilder (Path.Combine (path, proj.ProjectName), false, false)) {
-				if (!Directory.Exists (Path.Combine (builder.FrameworkLibDirectory, "xbuild-frameworks", "MonoAndroid", "v8.1")))
+				if (!Directory.Exists (Path.Combine (builder.FrameworkLibDirectory, "v8.1")))
 					Assert.Ignore ("This is a Pull Request Build. Ignoring test.");
 				builder.ThrowOnBuildFailure = false;
 				builder.Verbosity = LoggerVerbosity.Diagnostic;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -387,7 +387,9 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 				if (!b.TargetFrameworkExists (proj.TargetFrameworkVersion))
 					Assert.Ignore ($"Skipped as {proj.TargetFrameworkVersion} not available.");
 				Assert.IsTrue (b.Build (proj), "first build should have succeeded.");
-				var packagedResource = Path.Combine (b.Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "bin", "packaged_resources");
+				string intermediateDir = TestEnvironment.IsWindows
+					? Path.Combine (proj.IntermediateOutputPath, proj.TargetFrameworkAbbreviated) : proj.IntermediateOutputPath;
+				var packagedResource = Path.Combine (b.Root, b.ProjectDirectory, intermediateDir, "android", "bin", "packaged_resources");
 				FileAssert.Exists (packagedResource, $"{packagedResource} should have been created.");
 				var packagedResourcearm = packagedResource + "-armeabi-v7a";
 				FileAssert.Exists (packagedResourcearm, $"{packagedResourcearm} should have been created.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -72,6 +72,9 @@ namespace Xamarin.ProjectTools
 			}
 		}
 
+		/// <summary>
+		/// The top directory of a local build tree if it can be found, e.g. xamarin-android/bin/Debug.
+		/// </summary>
 		string BuildOutputDirectory {
 			get {
 				var outdir = Environment.GetEnvironmentVariable ("XA_BUILD_OUTPUT_PATH");
@@ -92,6 +95,12 @@ namespace Xamarin.ProjectTools
 			}
 		}
 
+		/// <summary>
+		/// The MonoAndroidTools directory within a local build tree, e.g. xamarin-android/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android.<br/>
+		/// If a local build tree can not be found, or if it is empty, this will return the system installation location instead:<br/>
+		///	Windows:  C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Xamarin\Android <br/>
+		///	macOS:    /Library/Frameworks/Xamarin.Android.framework/Versions/Current/lib/xamarin.android/xbuild/Xamarin/Android
+		/// </summary>
 		public string AndroidMSBuildDirectory {
 			get {
 				var msbuildDir = Path.Combine (BuildOutputDirectory, "lib", "xamarin.android", "xbuild", "Xamarin", "Android");
@@ -102,6 +111,13 @@ namespace Xamarin.ProjectTools
 			}
 		}
 
+		/// <summary>
+		/// The MonoAndroid framework (and other reference assemblies) directory within a local build tree. Contains v1.0, v9.0, etc,
+		/// e.g. xamarin-android/bin/Debug/lib/xamarin.android/xbuild-frameworks/MonoAndroid.<br/>
+		/// If a local build tree can not be found, or if it is empty, this will return the system installation location instead:<br/>
+		///	Windows:  C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid <br/>
+		///	macOS:    Library/Frameworks/Xamarin.Android.framework/Versions/Current/lib/xamarin.android/xbuild-frameworks/MonoAndroid
+		/// </summary>
 		public string FrameworkLibDirectory {
 			get {
 				var frameworkLibDir = Path.Combine (BuildOutputDirectory, "lib", "xamarin.android", "xbuild-frameworks", "MonoAndroid");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -68,7 +68,7 @@ namespace Xamarin.ProjectTools
 				xabuild = XABuildPaths.XABuildExe;
 				if (File.Exists (xabuild))
 					return xabuild;
-				return "msbuild";
+				return IsUnix ? "msbuild" : TestEnvironment.GetVisualStudioInstance ().MSBuildPath;
 			}
 		}
 
@@ -106,9 +106,9 @@ namespace Xamarin.ProjectTools
 					if (Directory.Exists (Path.Combine (outdir, "lib")) && File.Exists (Path.Combine (outdir, libmonodroidPath)))
 						return Path.Combine (outdir, "lib", "xamarin.android");
 
-					var visualStudioDirectory = TestEnvironment.GetVisualStudioDirectory ();
-					if (!string.IsNullOrEmpty (visualStudioDirectory))
-						return Path.Combine (visualStudioDirectory, "MSBuild", "Xamarin", "Android");
+					var vs = TestEnvironment.GetVisualStudioInstance ();
+					if (!string.IsNullOrEmpty (vs.VisualStudioRootPath))
+						return Path.Combine (vs.VisualStudioRootPath, "MSBuild", "Xamarin", "Android");
 
 					var x86 = Environment.GetFolderPath (Environment.SpecialFolder.ProgramFilesX86);
 					return Path.Combine (x86, "MSBuild", "Xamarin", "Android");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -158,12 +158,7 @@ namespace Xamarin.ProjectTools
 		public RuntimeInfo [] GetSupportedRuntimes ()
 		{
 			var runtimeInfo = new List<RuntimeInfo> ();
-			var outdir = FrameworkLibDirectory;
-			var path = Path.Combine (outdir, "xbuild", "Xamarin", "Android", "lib");
-			if (!Directory.Exists (path)) {
-				path = outdir;
-			}
-			foreach (var file in Directory.EnumerateFiles (path, "libmono-android.*.so", SearchOption.AllDirectories)) {
+			foreach (var file in Directory.EnumerateFiles (Path.Combine (AndroidMSBuildDirectory, "lib"), "libmono-android.*.so", SearchOption.AllDirectories)) {
 				string fullFilePath = Path.GetFullPath (file);
 				DirectoryInfo parentDir = Directory.GetParent (fullFilePath);
 				if (parentDir == null)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
@@ -65,22 +65,21 @@ namespace Xamarin.ProjectTools
 
 		public static readonly string MacOSInstallationRoot = "/Library/Frameworks/Xamarin.Android.framework/Versions/Current";
 
-		static string visualStudioDirectory;
-		public static string GetVisualStudioDirectory ()
+		static VisualStudioInstance visualStudioInstance;
+		public static VisualStudioInstance GetVisualStudioInstance ()
 		{
 			//We should cache and reuse this value, so we don't run vswhere.exe so much
-			if (!string.IsNullOrEmpty (visualStudioDirectory))
-				return visualStudioDirectory;
+			if (visualStudioInstance != null && !string.IsNullOrEmpty (visualStudioInstance.VisualStudioRootPath))
+				return visualStudioInstance;
 
-			var instance = MSBuildLocator.QueryLatest ();
-			return visualStudioDirectory = instance.VisualStudioRootPath;
+			return visualStudioInstance = MSBuildLocator.QueryLatest ();
 		}
 
 		public static string MonoAndroidFrameworkDirectory {
 			get {
 				if (IsWindows) {
-					string visualStudioDirectory = GetVisualStudioDirectory ();
-					return Path.Combine (visualStudioDirectory, "Common7", "IDE", "ReferenceAssemblies", "Microsoft", "Framework", "MonoAndroid");
+					VisualStudioInstance vs = GetVisualStudioInstance ();
+					return Path.Combine (vs.VisualStudioRootPath, "Common7", "IDE", "ReferenceAssemblies", "Microsoft", "Framework", "MonoAndroid");
 				} else {
 					return Path.Combine (MacOSInstallationRoot, "lib", "xamarin.android", "xbuild-frameworks", "MonoAndroid");
 				}
@@ -90,8 +89,8 @@ namespace Xamarin.ProjectTools
 		public static string MonoAndroidToolsDirectory {
 			get {
 				if (IsWindows) {
-					string visualStudioDirectory = GetVisualStudioDirectory ();
-					return Path.Combine (visualStudioDirectory, "MSBuild", "Xamarin", "Android");
+					VisualStudioInstance vs = GetVisualStudioInstance ();
+					return Path.Combine (vs.VisualStudioRootPath, "MSBuild", "Xamarin", "Android");
 				} else {
 					return Path.Combine (MacOSInstallationRoot, "lib", "xamarin.android", "xbuild", "Xamarin", "Android");
 				}


### PR DESCRIPTION
We'd like to run most if not all of our tests against a complete .vsix
or .pkg installer in order to better replicate our users development
environments. All of our 'Test' jobs on Azure Pipelines are currently
configured to test against our installers, however these jobs are only
running on macOS environments.

Adds one new jobs to run the msbuild tests which don't require an
emulator on a Windows test environment against our .vsix installer.