### PR TITLE
[ci] Add API Compatibility job to Azure Pipelines

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -341,6 +341,12 @@ stages:
         FRAMEWORK_DIR=/Library/Frameworks/Xamarin.Android.framework/Versions/Current/lib/xamarin.android/xbuild-frameworks/MonoAndroid
       displayName: make run-api-compatibility-tests
 
+    - powershell: |
+        $breakageReports = Get-ChildItem $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/compatibility -Filter *.html
+        foreach ($report in $breakageReports) {
+            Write-Host "##vso[task.uploadsummary]$(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)/compatibility/$report"
+        }
+
   # Check - "Xamarin.Android (Test APK Instrumentation)"
   - job: mac_apk_tests
     displayName: APK Instrumentation

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -317,6 +317,30 @@ stages:
   displayName: Test
   dependsOn: mac_build
   jobs:
+  # Check - "Xamarin.Android (Test API Compatibility)"
+  - job: mac_api_compat
+    displayName: API Compatibility
+    pool: $(XA.Build.Mac.Pool)
+    timeoutInMinutes: 60
+    cancelTimeoutInMinutes: 5
+    workspace:
+      clean: all
+    steps:
+    - checkout: self
+      submodules: recursive
+
+    - template: yaml-templates/run-installer.yaml
+
+    - script: |
+        make prepare-update-mono PREPARE_CI=1 V=1 PREPARE_AUTOPROVISION=1 CONFIGURATION=$(XA.Build.Configuration)
+        make prepare PREPARE_CI=1 PREPARE_AUTOPROVISION=1 V=1 CONFIGURATION=$(XA.Build.Configuration)
+      displayName: make prepare
+
+    - script: >
+        make run-api-compatibility-tests V=1 CONFIGURATION=$(XA.Build.Configuration)
+        FRAMEWORK_DIR=/Library/Frameworks/Xamarin.Android.framework/Versions/Current/lib/xamarin.android/xbuild-frameworks/MonoAndroid
+      displayName: make run-api-compatibility-tests
+
   # Check - "Xamarin.Android (Test APK Instrumentation)"
   - job: mac_apk_tests
     displayName: APK Instrumentation


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/3607

Adds a new job to the Azure Pipelines 'Test' stage which downloads,
installs, and runs API compatibility checks against the .pkg installer
produced by the macOS build job.