### PR TITLE
[aprofutil] Add the aprofutil to the installation

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -98,6 +98,7 @@
   </ItemGroup>
   <ItemGroup>
     <_MSBuildFiles Include="$(MSBuildSrcDir)\android-support-multidex.jar" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\aprofutil.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\cil-strip.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\class-parse.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\desugar_deploy.jar" />
@@ -135,6 +136,7 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\libZipSharp.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\libZipSharp.dll.config" Condition=" '$(HostOS)' != 'Windows' " />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Posix.NETStandard.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Profiler.Log.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\logcat-parse.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\mdoc.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\mkbundle.exe" />
@@ -245,6 +247,7 @@
     <_MSBuildFilesUnixSwab Include="$(MSBuildSrcDir)\$(HostOS)\ndk\x86_64-linux-android-strip" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\illinkanalyzer" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\jit-times" />
+    <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\aprofutil" />
     <_MSBuildFilesUnixSignAndHarden Include="$(MSBuildSrcDir)\$(HostOS)\mono" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\mono.config" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\$(HostOS)\mono-symbolicate" />

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Runtimes.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Runtimes.cs
@@ -381,6 +381,8 @@ namespace Xamarin.Android.Prepare
 			new MonoUtilityFile ("pdb2mdb.exe",                            remap: true),
 			new MonoUtilityFile ("ICSharpCode.SharpZipLib.dll",            remap: false),
 			new MonoUtilityFile ("Mono.CompilerServices.SymbolWriter.dll", remap: false),
+			new MonoUtilityFile ("aprofutil.exe",                          remap: false),
+			new MonoUtilityFile ("Mono.Profiler.Log.dll",                  remap: false),
 		};
 
 		/// <summary>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -269,6 +269,7 @@
     <_MonoScript Include="mono-symbolicate" />
     <_MonoScript Include="illinkanalyzer" />
     <_MonoScript Include="jit-times" />
+    <_MonoScript Include="aprofutil" />
     <_MonoScriptSource Include="@(_MonoScript->'$(_MonoScriptSourceDirectory)\%(Identity)')" />
     <_MonoScriptSource Include="mono.config" />
     <_MonoScriptDestination Include="@(_MonoScript->'$(_MonoScriptDestinationDirectory)\%(Identity)')" />

--- a/tools/scripts/aprofutil
+++ b/tools/scripts/aprofutil
@@ -1,0 +1,6 @@
+#!/bin/sh
+BINDIR=`dirname "$0"`
+MANDROID_DIR="$BINDIR/.."
+
+unset MONO_PATH
+exec mono $MONO_OPTIONS "$MANDROID_DIR/aprofutil.exe" "$@"


### PR DESCRIPTION
Let the xaprep know about the `aprofutil` and `Mono.Profiler.Log`
assembly.

Add documentation about *Profiling the AOT*.

Add script to call the aprofutil on MacOS.