### PR TITLE
[tests] fix DebuggingTest hang on failure

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -179,14 +179,14 @@ namespace Xamarin.Android.Build.Tests
 				// we need to wait here for a while to allow the breakpoints to hit
 				// but we need to timeout
 				TimeSpan timeout = TimeSpan.FromSeconds (60);
-				while (session.IsConnected && breakcountHitCount < 3) {
+				while (session.IsConnected && breakcountHitCount < 3 && timeout >= TimeSpan.Zero) {
 					Thread.Sleep (10);
 					timeout = timeout.Subtract (TimeSpan.FromMilliseconds (10));
 				}
 				WaitFor (2000);
 				ClearAdbLogcat ();
 				ClickButton (proj.PackageName, "myXFButton", "CLICK ME");
-				while (session.IsConnected && breakcountHitCount < 4) {
+				while (session.IsConnected && breakcountHitCount < 4 && timeout >= TimeSpan.Zero) {
 					Thread.Sleep (10);
 					timeout = timeout.Subtract (TimeSpan.FromMilliseconds (10));
 				}


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3062430&view=logs&s=859b8d9a-8fd6-5a5c-6f5e-f84f1990894e&j=4348ab7c-72f0-52b0-44fd-6f17a16a558f

We had a test hang for the MSBuild device tests.

Reviewing the `while` loop in `ApplicationRunsWithDebuggerAndBreaks`:

    TimeSpan timeout = TimeSpan.FromSeconds (60);
    while (session.IsConnected && breakcountHitCount < 3) {
        Thread.Sleep (10);
        timeout = timeout.Subtract (TimeSpan.FromMilliseconds (10));
    }

This would be an infinite loop if the test failed. I think it was
intended to check:

    while (session.IsConnected && breakcountHitCount < 4 && timeout >= TimeSpan.Zero) {
        ...