### PR TITLE
[ci] Move Azure Pipeline mac jobs to Mojave

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -22,7 +22,8 @@ variables:
   TestAssembliesArtifactName: test-assemblies
   NUnitConsoleVersion: 3.9.0
   DotNetCoreVersion: 2.1.701
-  HostedInternalMojave: Hosted Mac Internal Mojave
+  HostedMacMojave: Hosted Mac Internal Mojave
+  HostedMac: Hosted Mac Internal
   HostedWinVS2019: Hosted Windows 2019 with VS2019
   VSEngWinVS2019: VSEng-MicroBuildVS2019
 
@@ -47,7 +48,7 @@ stages:
   # Check - "Xamarin.Android (Prepare bundle)"
   - job: create_bundle
     displayName: Bundle
-    pool: $(HostedInternalMojave)
+    pool: $(HostedMacMojave)
     timeoutInMinutes: 60
     cancelTimeoutInMinutes: 5
     workspace:
@@ -92,7 +93,7 @@ stages:
   # Check - "Xamarin.Android (Mac Build)"
   - job: mac_build_create_installers
     displayName: Build
-    pool: $(HostedInternalMojave)
+    pool: $(HostedMacMojave)
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
     workspace:
@@ -321,7 +322,7 @@ stages:
   # Check - "Xamarin.Android (Test APK Instrumentation)"
   - job: mac_apk_tests
     displayName: APK Instrumentation
-    pool: $(HostedInternalMojave)
+    pool: $(HostedMac)
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
     workspace:
@@ -477,7 +478,7 @@ stages:
   # Check - "Xamarin.Android (Test BCL With Emulator)"
   - job: mac_bcl_tests
     displayName: BCL With Emulator
-    pool: $(HostedInternalMojave)
+    pool: $(HostedMac)
     timeoutInMinutes: 180
     steps:
     - template: yaml-templates/mac/setup-test-environment.yaml
@@ -526,7 +527,7 @@ stages:
   # Check - "Xamarin.Android (Test MSBuild Mac)"
   - job: mac_msbuild_tests
     displayName: MSBuild Mac
-    pool: $(HostedInternalMojave)
+    pool: $(HostedMacMojave)
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
     workspace:
@@ -575,7 +576,7 @@ stages:
  # Check - "Xamarin.Android (Test MSBuild With Emulator Mac)"
   - job: mac_msbuilddevice_tests
     displayName: MSBuild With Emulator Mac
-    pool: $(HostedInternalMojave)
+    pool: $(HostedMac)
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
     workspace:
@@ -644,7 +645,7 @@ stages:
 # Check - "Xamarin.Android (Test TimeZoneInfo With Emulator Mac)"
   - job: mac_timezonedevice_tests
     displayName: TimeZoneInfo With Emulator Mac
-    pool: $(HostedInternalMojave)
+    pool: $(HostedMac)
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
     workspace:
@@ -697,7 +698,7 @@ stages:
   # Check - "Xamarin.Android (Test Designer Mac)"
   - job: designer_integration_mac
     displayName: Designer Mac
-    pool: $(HostedInternalMojave)
+    pool: $(HostedMac)
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
     workspace:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -22,6 +22,7 @@ variables:
   TestAssembliesArtifactName: test-assemblies
   NUnitConsoleVersion: 3.9.0
   DotNetCoreVersion: 2.1.701
+  HostedInternalMojave: Hosted Mac Internal Mojave
   HostedWinVS2019: Hosted Windows 2019 with VS2019
   VSEngWinVS2019: VSEng-MicroBuildVS2019
 
@@ -46,7 +47,7 @@ stages:
   # Check - "Xamarin.Android (Prepare bundle)"
   - job: create_bundle
     displayName: Bundle
-    pool: $(XA.Build.Mac.Pool)
+    pool: $(HostedInternalMojave)
     timeoutInMinutes: 60
     cancelTimeoutInMinutes: 5
     workspace:
@@ -91,7 +92,7 @@ stages:
   # Check - "Xamarin.Android (Mac Build)"
   - job: mac_build_create_installers
     displayName: Build
-    pool: $(XA.Build.Mac.Pool)
+    pool: $(HostedInternalMojave)
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
     workspace:
@@ -320,7 +321,7 @@ stages:
   # Check - "Xamarin.Android (Test APK Instrumentation)"
   - job: mac_apk_tests
     displayName: APK Instrumentation
-    pool: $(XA.Build.Mac.Pool)
+    pool: $(HostedInternalMojave)
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
     workspace:
@@ -476,7 +477,7 @@ stages:
   # Check - "Xamarin.Android (Test BCL With Emulator)"
   - job: mac_bcl_tests
     displayName: BCL With Emulator
-    pool: $(XA.Build.Mac.Pool)
+    pool: $(HostedInternalMojave)
     timeoutInMinutes: 180
     steps:
     - template: yaml-templates/mac/setup-test-environment.yaml
@@ -525,7 +526,7 @@ stages:
   # Check - "Xamarin.Android (Test MSBuild Mac)"
   - job: mac_msbuild_tests
     displayName: MSBuild Mac
-    pool: $(XA.Build.Mac.Pool)
+    pool: $(HostedInternalMojave)
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
     workspace:
@@ -574,7 +575,7 @@ stages:
  # Check - "Xamarin.Android (Test MSBuild With Emulator Mac)"
   - job: mac_msbuilddevice_tests
     displayName: MSBuild With Emulator Mac
-    pool: $(XA.Build.Mac.Pool)
+    pool: $(HostedInternalMojave)
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
     workspace:
@@ -643,7 +644,7 @@ stages:
 # Check - "Xamarin.Android (Test TimeZoneInfo With Emulator Mac)"
   - job: mac_timezonedevice_tests
     displayName: TimeZoneInfo With Emulator Mac
-    pool: $(XA.Build.Mac.Pool)
+    pool: $(HostedInternalMojave)
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
     workspace:
@@ -696,7 +697,7 @@ stages:
   # Check - "Xamarin.Android (Test Designer Mac)"
   - job: designer_integration_mac
     displayName: Designer Mac
-    pool: $(XA.Build.Mac.Pool)
+    pool: $(HostedInternalMojave)
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
     workspace:


### PR DESCRIPTION
Migrates our macOS build jobs to the macOS 10.14 Mojave pool which is
more performant for certain build types. Also moves all host name variables
into 'azure-pipelines.yaml' so it's easier to test and swap to different machine
pools. Looking at performance across a few jobs, the Mojave pool appears to
be better for all of our jobs which don't use an emulator. Unfortunately,
emulator performance appears to be worse on this pool however.

|        Job        | HighSierra | Mojave         |
|-----------------|------------|----------------|
| Prepare           | ~18m       | ~13m       |
| Build             | ~75m       | ~55m        |
| Test Apks         | ~48m       | ~50m           |
| Test BCL          | ~90m       | ~113m          |
| Test MSBuild      | ~128m      | ~118m          |
| Test MSBuild Emu  | ~53m       | timeout @ 120m |
| Test TimeZoneInfo | ~152m      | ~180m          |

These numbers should be taken with a bit of a grain of salt however, as we've
seen a pretty big difference in machine performance across the same pools.
