### PR TITLE
[Aot task] add quotes around the lib paths

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -367,9 +367,9 @@ namespace Xamarin.Android.Tasks
 						}
 					}
 
-					libs.Add (Path.Combine (toolchainLibDir, "libgcc.a"));
-					libs.Add (Path.Combine (androidLibPath, "libc.so"));
-					libs.Add (Path.Combine (androidLibPath, "libm.so"));
+					libs.Add ($"\\\"{Path.Combine (toolchainLibDir, "libgcc.a")}\\\"");
+					libs.Add ($"\\\"{Path.Combine (androidLibPath, "libc.so")}\\\"");
+					libs.Add ($"\\\"{Path.Combine (androidLibPath, "libm.so")}\\\"");
 
 					ldFlags = string.Join(";", libs);
 				}
@@ -468,6 +468,9 @@ namespace Xamarin.Android.Tasks
 
 			LogDebugMessage ("[AOT] MONO_PATH=\"{0}\" MONO_ENV_OPTIONS=\"{1}\" {2} {3}",
 				psi.EnvironmentVariables ["MONO_PATH"], psi.EnvironmentVariables ["MONO_ENV_OPTIONS"], psi.FileName, psi.Arguments);
+
+			if (!string.IsNullOrEmpty (responseFile))
+				LogDebugMessage ("[AOT] response file {0}: {1}", responseFile, File.ReadAllText (responseFile));
 
 			using (var proc = new Process ()) {
 				proc.OutputDataReceived += (s, e) => {


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3651

Also print the response file content to the log for easier
troubleshooting of the AOT