### PR TITLE
[Xamarin.Android.Build.Tasks] deprecate <GetAdditionalResourcesFromAssemblies/>

### DIFF
--- a/Documentation/guides/messages/xa0121.md
+++ b/Documentation/guides/messages/xa0121.md
@@ -1,0 +1,34 @@
+---
+title: Xamarin.Android warning XA0121
+description: XA0121 warning code
+ms.date: 09/19/2019
+---
+# Xamarin.Android warning XA0121
+
+## Issue
+
+The behavior implemented in the
+`<GetAdditionalResourcesFromAssemblies/>` MSBuild task is now
+deprecated.
+
+This MSBuild task is a precursor to [Xamarin.Build.Download][xbd] that
+enables downloading of Android packages from the internet.
+
+Libraries using any of the following custom assembly-level attributes
+will encounter this warning:
+
+* `IncludeAndroidResourcesFromAttribute`
+* `NativeLibraryReferenceAttribute`
+* `JavaLibraryReferenceAttribute`
+
+## Solution
+
+The [Xamarin Support Libraries][supportlibs], can be simply updated to
+a newer version on NuGet.
+
+Library authors will need to remove usage of these deprecated
+attributes. Their functionality will be removed in a future version of
+Xamarin.Android.
+
+[xbd]: https://www.nuget.org/packages/Xamarin.Build.Download
+[supportlibs]: https://github.com/xamarin/AndroidSupportComponents

--- a/src/Mono.Android/Android/IncludeAndroidResourcesFromAttribute.cs
+++ b/src/Mono.Android/Android/IncludeAndroidResourcesFromAttribute.cs
@@ -3,6 +3,7 @@ using System;
 namespace Android {
 
 	[AttributeUsage (AttributeTargets.Assembly, AllowMultiple = true)]
+	[Obsolete ("This attribute is deprecated and will be removed in a future release.")]
 	public class IncludeAndroidResourcesFromAttribute : ReferenceFilesAttribute
 	{
 		public IncludeAndroidResourcesFromAttribute (string path)

--- a/src/Mono.Android/Android/NativeLibraryReferenceAttribute.cs
+++ b/src/Mono.Android/Android/NativeLibraryReferenceAttribute.cs
@@ -3,6 +3,7 @@ using System;
 namespace Android {
 
 	[AttributeUsage (AttributeTargets.Assembly, AllowMultiple = true)]
+	[Obsolete ("This attribute is deprecated and will be removed in a future release.")]
 	sealed public class NativeLibraryReferenceAttribute : ReferenceFilesAttribute
 	{
 		public NativeLibraryReferenceAttribute (string filename)

--- a/src/Mono.Android/Android/ReferenceFilesAttribute.cs
+++ b/src/Mono.Android/Android/ReferenceFilesAttribute.cs
@@ -1,7 +1,7 @@
 using System;
 
 namespace Android {
-
+	[Obsolete ("This attribute is deprecated and will be removed in a future release.")]
 	public abstract class ReferenceFilesAttribute : Attribute
 	{
 		internal ReferenceFilesAttribute () {}

--- a/src/Mono.Android/Java.Interop/JavaLibraryReferenceAttribute.cs
+++ b/src/Mono.Android/Java.Interop/JavaLibraryReferenceAttribute.cs
@@ -3,6 +3,7 @@ using System;
 namespace Java.Interop {
 
 	[AttributeUsage (AttributeTargets.Assembly, AllowMultiple = true)]
+	[Obsolete ("This attribute is deprecated and will be removed in a future release.")]
 	public class JavaLibraryReferenceAttribute : Android.ReferenceFilesAttribute
 	{
 		public JavaLibraryReferenceAttribute (string filename)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
@@ -113,6 +113,9 @@ namespace Xamarin.Android.Tasks
 		void AddAttributeValue (ICollection<string> items, CustomAttributeValue<object> attributeValue, string errorCode, string errorFmt,
 			bool isDirectory, string fullPath, string attributeFullName)
 		{
+			LogCodedWarning ("XA0121",
+				$"Assembly '{Path.GetFileName (fullPath)}' is using a deprecated attribute '[assembly: {attributeFullName}]'. Use a newer version of this NuGet package or notify the library author.");
+
 			if (attributeValue.NamedArguments.Length == 0 || attributeValue.FixedArguments.Length != 1) {
 				LogCodedWarning (errorCode, "Attribute {0} doesn't have expected one constructor agrument", attributeFullName);
 				return;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2296,6 +2296,7 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (builder.DesignTimeBuild (proj), "design-time build should have succeeded");
 				Assert.IsTrue (builder.Build (proj), "build should have succeeded");
+				Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, "XA0121"), "Output should contain XA0121 warnings");
 				var targetAar = Path.Combine (CachePath, "Xamarin.Android.Support.v7.AppCompat", "23.1.1.0",
 					"content", "m2repository", "com", "android", "support", "appcompat-v7", "23.1.1", "appcompat-v7-23.1.1.aar");
 				if (File.Exists (targetAar)) {


### PR DESCRIPTION
The `<GetAdditionalResourcesFromAssemblies/>` MSBuild task is the
precursor to Xamarin.Build.Download. It is only used by very old
versions of the Xamarin support library components.

We want to deprecate its behavior in an effort to remove complexity
and improve build performance. We have to scan each assembly for these
assembly-level attributes.

I added a new `XA0121` warning if a library is encountered during a
build that uses these attributes:

* `IncludeAndroidResourcesFromAttribute`
* `NativeLibraryReferenceAttribute`
* `JavaLibraryReferenceAttribute`

I added `[Obsolete]` on these as well.