### PR TITLE
[tests/MSbuildDeviceIntegration] Improve TimeZone Tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -200,7 +200,8 @@ namespace Xamarin.Android.Build.Tests
 		{
 			string ext = Environment.OSVersion.Platform != PlatformID.Unix ? ".exe" : "";
 			string adb = Path.Combine (AndroidSdkPath, "platform-tools", "adb" + ext);
-			return RunProcess (adb, command);
+			string adbTarget = Environment.GetEnvironmentVariable ("ADB_TARGET");
+			return RunProcess (adb, $"{adbTarget} {command}");
 		}
 
 		protected static string RunProcess (string exe, string args)


### PR DESCRIPTION
Currently the TimeZone unit tests do NOT restore
the device TimeZone back to its initial state.
This could effect other tests if they are expected
to run in a particular TimeZone. So we should restore
the state as much as possible.

Also the TimeZone tests REQUIRE the use of

	adb shell su root xxxx

in order to set the TimeZone. This will not work on
any device which has not been rooted. Fortunately we
can check the `ro.debuggable` to see if the device
can run the above command. If it cannot then we should
ignore the test with a suitable message.

Also fixes an issue where if you use the `ADB_TARGET` environment
variable it was ignored when running `RunAdbCommand`.