### PR TITLE
[Xamarin.Android.Build.Tasks] Clean did not delete App Bundles

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -524,12 +524,13 @@ namespace UnamedProject
 		}
 
 		[Test]
-		public void BuildApplicationAndClean ([Values (false, true)] bool isRelease)
+		public void BuildApplicationAndClean ([Values (false, true)] bool isRelease, [Values ("apk", "aab")] string packageFormat)
 		{
 			var proj = new XamarinFormsAndroidApplicationProject {
 				IsRelease = isRelease,
 			};
-			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
+			proj.SetProperty ("AndroidPackageFormat", packageFormat);
+			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
 
@@ -540,8 +541,7 @@ namespace UnamedProject
 				var files = Directory.GetFiles (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath), "*", SearchOption.AllDirectories)
 					.Where (x => !ignoreFiles.Any (i => !Path.GetFileName (x).Contains (i)));
 				Assert.AreEqual (0, files.Count (), "{0} should be Empty. Found {1}", proj.IntermediateOutputPath, string.Join (Environment.NewLine, files));
-				files = Directory.GetFiles (Path.Combine (Root, b.ProjectDirectory, proj.OutputPath), "*", SearchOption.AllDirectories)
-					.Where (x => !ignoreFiles.Any (i => !Path.GetFileName (x).Contains (i)));
+				files = Directory.GetFiles (Path.Combine (Root, b.ProjectDirectory, proj.OutputPath), "*", SearchOption.AllDirectories);
 				Assert.AreEqual (0, files.Count (), "{0} should be Empty. Found {1}", proj.OutputPath, string.Join (Environment.NewLine, files));
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -3300,6 +3300,18 @@ because xbuild doesn't support framework reference assemblies.
 	<CreateItem Include="$(ApkFileIntermediate)">
 		<Output TaskParameter="Include" ItemName="FileWrites"/>
 	</CreateItem>
+	<CreateItem Include="$(_AabFileSigned)">
+		<Output TaskParameter="Include" ItemName="FileWrites"/>
+	</CreateItem>
+	<CreateItem Include="$(_BaseZipIntermediate)">
+		<Output TaskParameter="Include" ItemName="FileWrites"/>
+	</CreateItem>
+	<CreateItem Include="$(_AppBundleIntermediate)">
+		<Output TaskParameter="Include" ItemName="FileWrites"/>
+	</CreateItem>
+	<CreateItem Include="$(_ApkSetIntermediate)">
+		<Output TaskParameter="Include" ItemName="FileWrites"/>
+	</CreateItem>
 	<!-- FIXME: check files exists -->
 	<CreateItem Include="@(_AndroidResourceDest)">
 		<Output TaskParameter="Include" ItemName="FileWrites"/>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3635

Running a `Clean`, would leave the app bundle in the `bin` directory:

    > msbuild Foo.Android.csproj /p:Configuration=Release /p:AndroidPackageFormat=aab /t:SignAndroidPackage
    > msbuild Foo.Android.csproj /p:Configuration=Release /p:AndroidPackageFormat=aab /t:Clean
    > ls -n bin\Release
    com.mycompany.foo-Signed.aab

The `_CollectMonoAndroidOutputs` MSBuild target has a series of
`<CreateItem/>` calls that add apk-related files to `@(FileWrites)`.

We need to do the same for all app-bundle-related files.