### PR TITLE
Bump to mono/mono/2019-08@bfbf823c

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:master@623845d44abe5eb7a76d9a63d48b30a27ac1bac2
-mono/mono:2019-08@7ec17ba1be9bd08d9d991d10414df2b78710bc18
+mono/mono:2019-08@bfbf823ca1129dbfd1ba5b7c066676bf185ed922


### PR DESCRIPTION
Changes: https://github.com/mono/mono/compare/7ec17ba1be9bd08d9d991d10414df2b78710bc18...bfbf823ca1129dbfd1ba5b7c066676bf185ed922

Context: https://github.com/mono/mono/issues/16709
Context: https://github.com/xamarin/xamarin-macios/issues/7005

Disables `ppdb` data decompression.
Add missing membars when initializing rgctx entries
Remove the mac32 build
Adds .NET 4.8 reference assemblies