### PR TITLE
[xaprepare] Java.Interop should use Corretto

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_PrepareExternal.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_PrepareExternal.Unix.cs
@@ -32,6 +32,7 @@ namespace Xamarin.Android.Prepare
 				arguments: new List <string> {
 					"prepare",
 					$"CONFIGURATION={context.Configuration}",
+					$"JAVA_HOME={context.OS.JavaHome}",
 					$"JI_MAX_JDK={Configurables.Defaults.MaxJDKVersion}",
 				}
 			);


### PR DESCRIPTION
A co-worker who only had AdoptOpenJDK 13 installed was not able to run
`make prepare`:

	Project "…/xamarin-android/external/Java.Interop/build-tools/scripts/jdk.targets" on node 1 (GetPreferredJdkRoot target(s)).
	…/xamarin-android/external/Java.Interop/build-tools/scripts/jdk.targets(5,5): warning : Not a valid JDK directory: `/Library/Java/JavaVirtualMachines/adoptopenjdk-13.jdk/Contents/Home`; via locator: `/usr/libexec/java_home -X`
	…/git/xamarin-android/external/Java.Interop/build-tools/scripts/jdk.targets(5,5): error : Could not determine JAVA_HOME location. Please set JdksRoot or export the JAVA_HOME environment variable.
	Done Building Project "…/xamarin-android/external/Java.Interop/build-tools/scripts/jdk.targets" (GetPreferredJdkRoot target(s)) -- FAILED.

	Build FAILED.

`make prepare` failed because we require JDK 8, as the Android SDK
tooling doesn't work with JDK 9 and later.

What's "odd" about this is that ever since commit 9302d514 -- the
introduction of `xaprepare` -- Amazon Corretto JDK 8 has been
installed into `$(JavaSdkDirectory)`, which defaults to
`$HOME/android-archives/jdk`.

We thus *have* a valid JDK already installed; why aren't we using it?

Update `Step_PrepareExternal.Unix.cs` so that when we run
Java.Interop's `make prepare`, we override `$JAVA_HOME` to refer to
the Amazon Corretto JDK installation directory.  This way,
Java.Interop uses the same JDK as the rest of xamarin-android, which
in turn means that if the "wrong" or *no* System JDK is present,
Java.Interop can still be prepared and built.