### PR TITLE
[RuntimeService] Include .pdb files in the Shared Runtime

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@623845d44abe5eb7a76d9a63d48b30a27ac1bac2
+xamarin/monodroid:master@3234426db1bec31d46ecbe8b588a7199511ca3e2
 mono/mono:2019-08@d8441deead62b3af591c6daefb5013b09ef1ab8b


### PR DESCRIPTION
Some time around mono 4.9 (0ddcf96), the C# compiler started
emitting Portable PDB (`.pdb`) files instead of `*.mdb` files.
However, the shared runtime was not updated to include `.pdb` files.
It was still only including `*.mdb` files.
    
Consequently, the shared runtime hasn't included debug symbols in *ages*.
    
Update the `tools/RuntimeService` so that `.pdb` files are included
in the shared runtime, so that stack traces when `debug.mono.debug`=1
are more useful.