### PR TITLE
[tests] DeviceTest captures & records screenshots

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/result-packaging.targets
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/result-packaging.targets
@@ -27,6 +27,7 @@
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\logcat*" />
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\**\*.binlog" />
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\**\*.log" />
+    <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\**\screenshot.png" />
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\TestOutput-*.txt" />
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\Timing_*" />
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)*.csv" />


### PR DESCRIPTION
Context: https://dev.azure.com/DevDiv/DevDiv/_build/results?buildId=3075928&view=ms.vss-test-web.test-result-details

I was originally using this in #3649, but it seemed better to do this
in a separate PR.

If a `DeviceTest` fails, it can take a screenshot, add an attachment
to the failed test, and archive it as an artifact. This will help
troubleshoot if things like a button press fails, and if we add more
tests like this down the road.