### PR TITLE
[Xamarin.Android.Build.Tasks] MSBuild target does not properly build incrementally

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1131,8 +1131,13 @@ namespace Lib1 {
 				StringAssert.Contains ("myButton", designerContents, $"{designerFile} should contain Resources.Id.myButton");
 				StringAssert.Contains ("Icon", designerContents, $"{designerFile} should contain Resources.Drawable.Icon");
 				StringAssert.Contains ("Main", designerContents, $"{designerFile} should contain Resources.Layout.Main");
-				Assert.IsTrue (appBuilder.Build (appProj),
+				appBuilder.BuildLogFile = "build.log";
+				Assert.IsTrue (appBuilder.Build (appProj, doNotCleanupOnUpdate: true),
 					"Normal Application Build should have succeeded.");
+				Assert.IsTrue (appProj.CreateBuildOutput (appBuilder).IsTargetSkipped ("_ManagedUpdateAndroidResgen"),
+					"Target '_ManagedUpdateAndroidResgen' should not have run.");
+				appBuilder.BuildLogFile = "designtimebuild.log";
+				Assert.IsTrue (appBuilder.DesignTimeBuild (appProj, doNotCleanupOnUpdate: true), "DesignTime Application Build should have succeeded.");
 				Assert.IsTrue (appProj.CreateBuildOutput (appBuilder).IsTargetSkipped ("_ManagedUpdateAndroidResgen"),
 					"Target '_ManagedUpdateAndroidResgen' should not have run.");
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1227,23 +1227,28 @@ because xbuild doesn't support framework reference assemblies.
 	</ItemGroup>
 </Target>
 
-<PropertyGroup>
-	<_ManagedUpdateAndroidResgenInputs>
-		$(MSBuildAllProjects);
-		@(AndroidResource);
-		@(AndroidBoundLayout);
-		@(_MonoAndroidReferencePath);
-		@(_LibraryResourceDirectoryStamps);
-		$(_AndroidBuildPropertiesCache);
-		$(ProjectAssetsFile);
-	</_ManagedUpdateAndroidResgenInputs>
-</PropertyGroup>
+<Target Name="_BeforeManagedUpdateAndroidResgen">
+  <PropertyGroup>
+    <_ManagedUpdateAndroidResgenInputs>
+      $(MSBuildAllProjects);
+      @(AndroidResource);
+      @(AndroidBoundLayout);
+      @(_MonoAndroidReferencePath);
+      @(_LibraryResourceDirectoryStamps);
+      $(_AndroidBuildPropertiesCache);
+      $(ProjectAssetsFile);
+      $(_AndroidResourcePathsDesignTimeCache);
+      $(_AndroidLibraryProjectImportsDesignTimeCache);
+      $(_AndroidLibraryImportsDesignTimeCache);
+    </_ManagedUpdateAndroidResgenInputs>
+  </PropertyGroup>
+</Target>
 
 <!-- Managed DesignTime Resource Generation -->
 <Target Name="_ManagedUpdateAndroidResgen" Condition=" '$(ManagedDesignTimeBuild)' == 'True' "
-		Inputs="$(_ManagedUpdateAndroidResgenInputs);$(_AndroidLibraryProjectImportsCache);$(_AndroidLibraryImportsCache);"
+		Inputs="$(_ManagedUpdateAndroidResgenInputs)"
 		Outputs="$(_AndroidManagedResourceDesignerFile)"
-		DependsOnTargets="_CreatePropertiesCache;_ExtractLibraryProjectImports;_ValidateAndroidPackageProperties">
+		DependsOnTargets="_CreatePropertiesCache;_ExtractLibraryProjectImports;_ValidateAndroidPackageProperties;_BeforeManagedUpdateAndroidResgen">
 	<MakeDir Directories="$(_AndroidIntermediateDesignTimeBuildDirectory)" />
 	<!-- Parse primary R.java and create Resources.Designer.cs -->
 	<GenerateResourceDesigner

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1237,11 +1237,13 @@ because xbuild doesn't support framework reference assemblies.
       @(_LibraryResourceDirectoryStamps);
       $(_AndroidBuildPropertiesCache);
       $(ProjectAssetsFile);
-      $(_AndroidResourcePathsDesignTimeCache);
-      $(_AndroidLibraryProjectImportsDesignTimeCache);
-      $(_AndroidLibraryImportsDesignTimeCache);
     </_ManagedUpdateAndroidResgenInputs>
   </PropertyGroup>
+  <PropertyGroup>
+    <_ManagedUpdateAndroidResgenInputs Condition="Exists ('$(_AndroidResourcePathsDesignTimeCache)')">$(_ManagedUpdateAndroidResgenInputs);$(_AndroidResourcePathsDesignTimeCache);</_ManagedUpdateAndroidResgenInputs>
+    <_ManagedUpdateAndroidResgenInputs Condition="Exists ('$(_AndroidLibraryImportsDesignTimeCache)')">$(_ManagedUpdateAndroidResgenInputs);$(_AndroidLibraryImportsDesignTimeCache);</_ManagedUpdateAndroidResgenInputs>
+    <_ManagedUpdateAndroidResgenInputs Condition="Exists ('$(_AndroidLibraryProjectImportsDesignTimeCache)')">$(_ManagedUpdateAndroidResgenInputs);$(_AndroidLibraryProjectImportsDesignTimeCache);</_ManagedUpdateAndroidResgenInputs>
+  <PropertyGroup>
 </Target>
 
 <!-- Managed DesignTime Resource Generation -->

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1243,7 +1243,7 @@ because xbuild doesn't support framework reference assemblies.
     <_ManagedUpdateAndroidResgenInputs Condition="Exists ('$(_AndroidResourcePathsDesignTimeCache)')">$(_ManagedUpdateAndroidResgenInputs);$(_AndroidResourcePathsDesignTimeCache);</_ManagedUpdateAndroidResgenInputs>
     <_ManagedUpdateAndroidResgenInputs Condition="Exists ('$(_AndroidLibraryImportsDesignTimeCache)')">$(_ManagedUpdateAndroidResgenInputs);$(_AndroidLibraryImportsDesignTimeCache);</_ManagedUpdateAndroidResgenInputs>
     <_ManagedUpdateAndroidResgenInputs Condition="Exists ('$(_AndroidLibraryProjectImportsDesignTimeCache)')">$(_ManagedUpdateAndroidResgenInputs);$(_AndroidLibraryProjectImportsDesignTimeCache);</_ManagedUpdateAndroidResgenInputs>
-  <PropertyGroup>
+  </PropertyGroup>
 </Target>
 
 <!-- Managed DesignTime Resource Generation -->


### PR DESCRIPTION
Fixes #2413

We should calculate the values for `_ManagedUpdateAndroidResgenInputs`
in a target rather than at evaluation time. This is so
we can pick up the correct `_AndroidBuildPropertiesCache`.