### PR TITLE
[tests] fix for MonoAndroidHelperTests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/MonoAndroidHelperTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/MonoAndroidHelperTests.cs
@@ -98,6 +98,9 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void CopyIfStringChanged_Readonly ()
 		{
+			if (File.Exists (temp)) {
+				File.SetAttributes (temp, FileAttributes.Normal);
+			}
 			File.WriteAllText (temp, "");
 			File.SetAttributes (temp, FileAttributes.ReadOnly);
 
@@ -109,6 +112,9 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void CopyIfBytesChanged_Readonly ()
 		{
+			if (File.Exists (temp)) {
+				File.SetAttributes (temp, FileAttributes.Normal);
+			}
 			File.WriteAllText (temp, "");
 			File.SetAttributes (temp, FileAttributes.ReadOnly);
 
@@ -120,6 +126,9 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void CopyIfStreamChanged_Readonly ()
 		{
+			if (File.Exists (temp)) {
+				File.SetAttributes (temp, FileAttributes.Normal);
+			}
 			File.WriteAllText (temp, "");
 			File.SetAttributes (temp, FileAttributes.ReadOnly);
 


### PR DESCRIPTION
Context: https://dev.azure.com/DevDiv/DevDiv/_build/results?buildId=3077728&view=ms.vss-test-web.test-result-details

We had a random test failure, such as:

    Xamarin.Android.Build.Tests.MonoAndroidHelperTests.CopyIfBytesChanged_Readonly
    System.UnauthorizedAccessException : Access to the path 'C:\Users\dlab14\AppData\Local\Temp\CopyIfBytesChanged_Readonly' is denied.
    TearDown : System.UnauthorizedAccessException : Access to the path 'C:\Users\dlab14\AppData\Local\Temp\CopyIfBytesChanged_Readonly' is denied.
    Stack trace
        at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
        at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
        at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
        at System.IO.StreamWriter.CreateFile(String path, Boolean append, Boolean checkHost)
        at System.IO.StreamWriter..ctor(String path, Boolean append, Encoding encoding, Int32 bufferSize, Boolean checkHost)
        at System.IO.File.InternalWriteAllText(String path, String contents, Encoding encoding, Boolean checkHost)
        at Xamarin.Android.Build.Tests.MonoAndroidHelperTests.CopyIfBytesChanged_Readonly() in E:\A\_work\275\s\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.Android.Build.Tests\Utilities\MonoAndroidHelperTests.cs:line 113
        --TearDown
        at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
        at System.IO.File.InternalDelete(String path, Boolean checkHost)

These tests do something like:

    [Test]
    public void CopyIfStreamChanged_Readonly ()
    {
        File.WriteAllText (temp, "");
        File.SetAttributes (temp, FileAttributes.ReadOnly);
        // test that things work with a readonly file
    }

I could reproduce the issue by putting a breakpoint after the file is
readonly, then stopping the process. Any subsequent run would fail.

So a previous build must have run on this build machine, `DDMBLDW196`,
and left this file around?

I updated the tests to set `FileAttributes.Normal` if the file already
exists.