### PR TITLE
[Xamarin.Android.Build.Tasks] downgrade jarsigner warnings to messages

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidSignPackage.cs
@@ -118,11 +118,29 @@ namespace Xamarin.Android.Tasks
 				return;
 			}
 
-			if (hasWarnings)
+			if (hasWarnings && !IsWarningIgnored (singleLine))
 				Log.LogCodedWarning (DefaultErrorCode, GenerateFullPathToTool (), 0, singleLine);
 			else
 				Log.LogMessage (singleLine, importance);
 		}
+
+		static bool IsWarningIgnored (string singleLine)
+		{
+			foreach (var warning in IgnoredWarnings) {
+				if (singleLine.IndexOf (warning, StringComparison.OrdinalIgnoreCase) >= 0) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		/// <summary>
+		/// See: http://hg.openjdk.java.net/jdk8u/jdk8u-dev/jdk/file/0fc878b99541/src/share/classes/sun/security/tools/jarsigner/Resources.java
+		/// </summary>
+		static readonly string [] IgnoredWarnings = new [] {
+			"certificate is self-signed",
+			"No -tsa or -tsacert is provided",
+		};
 
 		protected override string ToolName
 		{


### PR DESCRIPTION
`jarsigner` always prints a message such as:

    Warning: The signer's certificate is self-signed.
    No -tsa or -tsacert is provided and this jar is not timestamped. Without a timestamp, users may not be able to validate this jar after the signer certificate's expiration date (2049-06-13) or after any future revocation date.

You will see this if `$(AndroidApkSigner)` is `False` or
`$(AndroidPackageFormat)` is `aab`.

This is basically just noise, `jarsigner` always complains when
signing APKs with a self-signed keystore file.

We should downgrade these specific `Warning:` messages from
`jarsigner` to just a regular MSBuild message.

I found the source code for `jarsigner` here:

* `Resources.java`: http://hg.openjdk.java.net/jdk8u/jdk8u-dev/jdk/file/0fc878b99541/src/share/classes/sun/security/tools/jarsigner/Resources.java
* `Main.java`: http://hg.openjdk.java.net/jdk8u/jdk8u-dev/jdk/file/0fc878b99541/src/share/classes/sun/security/tools/jarsigner/Main.java