### PR TITLE
[linker] Update PreserveHttpAndroidClientHandler substep

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/PreserveHttpAndroidClientHandler.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/PreserveHttpAndroidClientHandler.cs
@@ -19,7 +19,7 @@ namespace MonoDroid.Tuner
 
 		public override void ProcessMethod (MethodDefinition method)
 		{
-			if (method.Name == "GetDefaultHandler" && method.DeclaringType.FullName == "System.Net.Http.HttpClient")
+			if (method.Name == "CreateDefaultHandler" && method.DeclaringType.FullName == "System.Net.Http.HttpClient")
 				Mark ();
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3626

https://github.com/mono/mono/commit/6034bc00c432356a31208136b871ed152eb3f8d3
https://github.com/mono/mono/commit/2d6f02a83c5715b41364fe450f3bf4391c64c37b
introduced new `HttpClient.CreateDefaultHandler()` method, which
replaces the `HttpClient.GetDefaultHandler()` method.

Our XA linker logic was detecting `AndroidClientHandler` usage by
checking the `GetDefaultHandler` method and so it doesn't work
anymore.

Added a new test to avoid similar regression in the future.