### PR TITLE
[Xamarin.Android.Build.Tasks] use typemaps when EmbedAssembliesIntoApk=False

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@6f77f153e386c22efb3b508b270e5cdc3dfced61
+xamarin/monodroid:master@ab054acc3fef6ae979c8dd447fb9723eee83c9de
 mono/mono:2019-08@df5e13f95df7a2d11d86904e74b1bd8950c9d43b

--- a/src/Xamarin.Android.Build.Tasks/Utilities/NativeAssemblyDataStream.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/NativeAssemblyDataStream.cs
@@ -81,6 +81,14 @@ namespace Xamarin.Android.Tasks
 			Flush ();
 		}
 
+		public void EmptyFile ()
+		{
+			MapVersion = 1;
+			MapEntryCount = 0;
+			MapEntryLength = 0;
+			MapValueOffset = 0;
+		}
+
 		public override void Flush ()
 		{
 			outputWriter.Flush ();

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingNativeAssemblyGenerator.cs
@@ -27,6 +27,8 @@ namespace Xamarin.Android.Tasks
 			this.mappingFieldName = mappingFieldName;
 		}
 
+		public bool EmbedAssemblies { get; set; }
+
 		protected override void WriteFileHeader (StreamWriter output, string outputFileName)
 		{
 			// The hash is written to make sure the assembly file which includes the data one is
@@ -43,7 +45,9 @@ namespace Xamarin.Android.Tasks
 			WriteMappingHeader (output, dataStream, mappingFieldName);
 			WriteCommentLine (output, "Mapping data");
 			WriteSymbol (output, mappingFieldName, dataSize, isGlobal: true, isObject: true, alwaysWriteSize: true);
-			output.WriteLine ($"{Indent}.include{Indent}\"{dataFileName}\"");
+			if (EmbedAssemblies) {
+				output.WriteLine ($"{Indent}.include{Indent}\"{dataFileName}\"");
+			}
 		}
 
 		void WriteMappingHeader (StreamWriter output, NativeAssemblyDataStream dataStream, string mappingFieldName)


### PR DESCRIPTION
This is a first step to use the `typemap.mj` and `typemap.jm` files
for Fast Deployment. We will eventually generate these files on a
per-assembly basis, but can get some small perf improvements for
`Debug` builds:

* When `$(EmbedAssembliesIntoApk)` is `True` use the native assembly
  in `typemap.*.inc` and the current behavior.
* When `$(EmbedAssembliesIntoApk)` is `False` don't generate any
  `typemap.*.inc` files at all, but still use the native assembly for
  environment variables.
* We have to still generate `typemap.*.s` files with empty values.

## typemap.*.s changes ##

Before:
```as
  jm_typemap_header:
    /* version */
    .long	1
    /* entry-count */
    .long	1324
    /* entry-length */
    .long	262
    /* value-offset */
    .long	117
    .size	jm_typemap_header, 16

    /* Mapping data */
    .type	jm_typemap, %object
    .global	jm_typemap
  jm_typemap:
    .size	jm_typemap, 346889
    .include	"typemap.jm.inc"
```
After:
```as
  jm_typemap_header:
    /* version */
    .long	1
    /* entry-count */
    .long	0
    /* entry-length */
    .long	0
    /* value-offset */
    .long	0
    .size	jm_typemap_header, 16

    /* Mapping data */
    .type	jm_typemap, %object
    .global	jm_typemap
  jm_typemap:
    .size	jm_typemap, 0
```
The result is I don't get a crash at runtime and the `typemap.mj` and
`typemap.jm` files are used.

## Results ##

I timed the Xamarin.Forms integration project in this repo.

An initial build:

    Before:
    2860 ms  GenerateJavaStubs                          1 calls
      84 ms  CompileNativeAssembly                      1 calls
    After:
    2595 ms  GenerateJavaStubs                          1 calls
      46 ms  CompileNativeAssembly                      1 calls

On an incremental build where `MainActivity.cs` was changed:

    Before:
     543 ms  GenerateJavaStubs                          1 calls
    After:
     323 ms  GenerateJavaStubs                          1 calls

`CompileNativeAssembly` is skipped for `MainActivity.cs` changes.

When comparing startup performance:

    Before:
    ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +1s302ms
    After:
    ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +1s341ms

As expected, startup is ~50ms worse.

I would say this change saves ~250ms on the full dev-loop in cases
where `<GenerateJavaStubs/>` needs to run.