### PR TITLE
[MSBuildDeviceIntegration] Harden checks for the debugger.

### DIFF
--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -845,7 +845,8 @@ mono_runtime_init (char *runtime_args)
 		debug_arg = utils.monodroid_strdup_printf ("--debugger-agent=transport=dt_socket,loglevel=%d,address=%s:%d,%sembedding=1", options.loglevel, options.host, options.sdb_port,
 				options.server ? "server=y," : "");
 		debug_options[0] = debug_arg;
-
+		// this text is used in unit tests to check the debugger started
+		// do not change it without updating the test.
 		log_warn (LOG_DEBUGGER, "Trying to initialize the debugger with options: %s", debug_arg);
 
 		if (options.out_port > 0) {
@@ -1737,7 +1738,8 @@ start_debugging (void)
 
 	debug_arg = utils.monodroid_strdup_printf ("--debugger-agent=transport=socket-fd,address=%d,embedding=1", sdb_fd);
 	debug_options[0] = debug_arg;
-
+	// this text is used in unit tests to check the debugger started
+	// do not change it without updating the test.
 	log_warn (LOG_DEBUGGER, "Trying to initialize the debugger with options: %s", debug_arg);
 
 	if (enable_soft_breakpoints ()) {

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -340,18 +340,21 @@ namespace ${ROOT_NAMESPACE} {
 				// we need to wait here for a while to allow the breakpoints to hit
 				// but we need to timeout
 				TimeSpan timeout = TimeSpan.FromSeconds (60);
+				int expected = 3;
 				while (session.IsConnected && breakcountHitCount < 3 && timeout >= TimeSpan.Zero) {
 					Thread.Sleep (10);
 					timeout = timeout.Subtract (TimeSpan.FromMilliseconds (10));
 				}
 				WaitFor (2000);
+				Assert.AreEqual (expected, breakcountHitCount, $"Should have hit {expected} breakpoints. Only hit {breakcountHitCount}");
+				breakcountHitCount = 0;
 				ClearAdbLogcat ();
 				ClickButton (proj.PackageName, "myXFButton", "CLICK ME");
-				while (session.IsConnected && breakcountHitCount < 4 && timeout >= TimeSpan.Zero) {
+				while (session.IsConnected && breakcountHitCount < 1 && timeout >= TimeSpan.Zero) {
 					Thread.Sleep (10);
 					timeout = timeout.Subtract (TimeSpan.FromMilliseconds (10));
 				}
-				int expected = 4;
+				expected = 1;
 				Assert.AreEqual (expected, breakcountHitCount, $"Should have hit {expected} breakpoints. Only hit {breakcountHitCount}");
 				Assert.True (b.Uninstall (proj), "Project should have uninstalled.");
 				session.Exit ();


### PR DESCRIPTION
We hit a problem where the text for the log message
for the debugger was changed. It went from

	monodroid-debug: Trying to initialize the debugger with options:

to

	monodroid-debug: mono_runtime_init: Trying to initialize the debugger with options:

Which stopped our unit test matching the line.
So lets make this use just the text

	Trying to initialize the debugger with options:

and make sure we comment the line to if it changes people
also go an update the unit test.