### PR TITLE
[Xamarin.Android.Build.Tasks] support Deterministic builds (#3554)

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -33,6 +33,7 @@
     <AndroidFrameworkVersion Condition=" '$(AndroidFrameworkVersion)' == '' And '$(_IsRunningNuGetRestore)' != 'True' ">$(AndroidLatestStableFrameworkVersion)</AndroidFrameworkVersion>
     <AndroidUseLatestPlatformSdk Condition=" '$(AndroidFrameworkVersion)' == '' And '$(_IsRunningNuGetRestore)' == 'True' ">True</AndroidUseLatestPlatformSdk>
     <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
+    <Deterministic Condition=" '$(Deterministic)' == '' ">True</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(HostOS)' == '' ">
     <HostOS Condition="$([MSBuild]::IsOSPlatform('windows'))">Windows</HostOS>

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Properties/AssemblyInfo.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Properties/AssemblyInfo.cs
@@ -12,12 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright ("Xamarin Inc.")]
 [assembly: AssemblyTrademark ("Xamarin")]
 [assembly: AssemblyCulture ("")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion ("1.0.*")]
+[assembly: AssemblyVersion ("1.0.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/build-tools/api-merge/Properties/AssemblyInfo.cs
+++ b/build-tools/api-merge/Properties/AssemblyInfo.cs
@@ -12,12 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright ("Xamarin Inc.")]
 [assembly: AssemblyTrademark ("Xamarin")]
 [assembly: AssemblyCulture ("")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion ("1.0.*")]
+[assembly: AssemblyVersion ("1.0.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/build-tools/api-xml-adjuster/Properties/AssemblyInfo.cs
+++ b/build-tools/api-xml-adjuster/Properties/AssemblyInfo.cs
@@ -12,12 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright ("jon")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion ("1.0.*")]
+[assembly: AssemblyVersion ("1.0.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/build-tools/jnienv-gen/Properties/AssemblyInfo.cs
+++ b/build-tools/jnienv-gen/Properties/AssemblyInfo.cs
@@ -12,12 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright ("Xamarin Inc.")]
 [assembly: AssemblyTrademark ("Xamarin")]
 [assembly: AssemblyCulture ("")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion ("1.0.*")]
+[assembly: AssemblyVersion ("1.0.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/build-tools/xa-prep-tasks/Properties/AssemblyInfo.cs
+++ b/build-tools/xa-prep-tasks/Properties/AssemblyInfo.cs
@@ -12,12 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright ("Microsoft Corporation")]
 [assembly: AssemblyTrademark ("Microsoft")]
 [assembly: AssemblyCulture ("")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion ("1.0.*")]
+[assembly: AssemblyVersion ("1.0.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/build-tools/xaprepare/xaprepare/Properties/AssemblyInfo.cs
+++ b/build-tools/xaprepare/xaprepare/Properties/AssemblyInfo.cs
@@ -12,12 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright ("${AuthorCopyright}")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion ("1.0.*")]
+[assembly: AssemblyVersion ("1.0.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/src/Mono.Android.Export/Properties/AssemblyInfo.cs
+++ b/src/Mono.Android.Export/Properties/AssemblyInfo.cs
@@ -12,12 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright ("Xamarin Inc.")]
 [assembly: AssemblyTrademark ("Xamarin")]
 [assembly: AssemblyCulture ("")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion ("1.0.*")]
+[assembly: AssemblyVersion ("1.0.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/Linker.cs
@@ -48,6 +48,7 @@ namespace MonoDroid.Tuner
 			context.CoreAction = AssemblyAction.Link;
 			context.UserAction = AssemblyAction.Link;
 			context.LinkSymbols = true;
+			context.DeterministicOutput = options.DeterministicOutput;
 			context.SymbolReaderProvider = new DefaultSymbolReaderProvider (true);
 			context.SymbolWriterProvider = new DefaultSymbolWriterProvider ();
 			context.OutputDirectory = options.OutputDirectory;

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/LinkerOptions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/LinkerOptions.cs
@@ -23,5 +23,6 @@ namespace MonoDroid.Tuner
 		public string HttpClientHandlerType { get; set; }
 		public string TlsProvider { get; set; }
 		public bool PreserveJniMarshalMethods { get; set; }
+		public bool DeterministicOutput { get; set; }
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
@@ -54,6 +54,8 @@ namespace Xamarin.Android.Tasks
 
 		public bool PreserveJniMarshalMethods { get; set; }
 
+		public bool Deterministic { get; set; }
+
 		IEnumerable<AssemblyDefinition> GetRetainAssemblies (DirectoryAssemblyResolver res)
 		{
 			List<AssemblyDefinition> retainList = null;
@@ -102,6 +104,7 @@ namespace Xamarin.Android.Tasks
 			options.HttpClientHandlerType = HttpClientHandlerType;
 			options.TlsProvider = TlsProvider;
 			options.PreserveJniMarshalMethods = PreserveJniMarshalMethods;
+			options.DeterministicOutput = Deterministic;
 			
 			var skiplist = new List<string> ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
@@ -2,7 +2,6 @@ using Java.Interop.Tools.Cecil;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Mono.Cecil;
-using Mono.Cecil.Cil;
 using System;
 using System.IO;
 
@@ -27,6 +26,8 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public ITaskItem [] DestinationFiles { get; set; }
 
+		public bool Deterministic { get; set; }
+
 		public override bool RunTask ()
 		{
 			if (SourceFiles.Length != DestinationFiles.Length)
@@ -36,7 +37,7 @@ namespace Xamarin.Android.Tasks
 				ReadSymbols = true,
 			};
 			var writerParameters = new WriterParameters {
-				DeterministicMvid = true,
+				DeterministicMvid = Deterministic,
 			};
 
 			using (var resolver = new DirectoryAssemblyResolver (this.CreateTaskLogger (), loadDebugSymbols: true, loadReaderParameters: readerParameters)) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveRegisterAttribute.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveRegisterAttribute.cs
@@ -19,16 +19,21 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public ITaskItem[] ShrunkFrameworkAssemblies { get; set; }
 
+		public bool Deterministic { get; set; }
+
 		public override bool RunTask ()
 		{
 			// Find Mono.Android.dll
 			var mono_android = ShrunkFrameworkAssemblies.First (f => Path.GetFileNameWithoutExtension (f.ItemSpec) == "Mono.Android").ItemSpec;
+			var writerParameters = new WriterParameters {
+				DeterministicMvid = Deterministic,
+			};
 			using (var assembly = AssemblyDefinition.ReadAssembly (mono_android, new ReaderParameters { ReadWrite = true })) {
 				// Strip out [Register] attributes
 				foreach (TypeDefinition type in assembly.MainModule.Types)
 					ProcessType (type);
 
-				assembly.Write ();
+				assembly.Write (writerParameters);
 			}
 			
 			return true;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1823,9 +1823,9 @@ namespace App1
 			else
 				proj.RemoveProperty (proj.ActiveConfigurationProperties, "Optimize");
 			if (embedassebmlies.HasValue)
-				proj.SetProperty (proj.ActiveConfigurationProperties, "EmbedAssembliesIntoApk", embedassebmlies.Value);
+				proj.SetProperty (proj.ActiveConfigurationProperties, KnownProperties.EmbedAssembliesIntoApk, embedassebmlies.Value);
 			else
-				proj.RemoveProperty (proj.ActiveConfigurationProperties, "EmbedAssembliesIntoApk");
+				proj.RemoveProperty (proj.ActiveConfigurationProperties, KnownProperties.EmbedAssembliesIntoApk);
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				var runtimeInfo = b.GetSupportedRuntimes ();
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
@@ -2845,10 +2845,11 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		[Test]
 		public void BuildBasicApplicationCheckPdb ()
 		{
-			var proj = new XamarinAndroidApplicationProject ();
+			var proj = new XamarinAndroidApplicationProject {
+				EmbedAssembliesIntoApk = true,
+				AndroidUseSharedRuntime = false,
+			};
 			proj.SetProperty (proj.ActiveConfigurationProperties, "DebugType", "portable");
-			proj.SetProperty ("EmbedAssembliesIntoApk", true.ToString ());
-			proj.SetProperty ("AndroidUseSharedRuntime", false.ToString ());
 			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationCheckPdb", false, false)) {
 				b.Verbosity = LoggerVerbosity.Diagnostic;
 				var reference = new BuildItem.Reference ("PdbTestLibrary.dll") {
@@ -3630,10 +3631,11 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 		[Test]
 		public void FastDeploymentDoesNotAddContentProvider ()
 		{
-			var proj = new XamarinAndroidApplicationProject ();
+			var proj = new XamarinAndroidApplicationProject {
+				AndroidUseSharedRuntime = true,
+				EmbedAssembliesIntoApk = false,
+			};
 			proj.SetProperty ("_XASupportsFastDev", "True");
-			proj.SetProperty (proj.DebugProperties, KnownProperties.AndroidUseSharedRuntime, "True");
-			proj.SetProperty (proj.DebugProperties, "EmbedAssembliesIntoApk", "False");
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				//NOTE: build will fail, due to $(_XASupportsFastDev)
 				b.ThrowOnBuildFailure = false;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -362,14 +362,18 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
-		protected ProjectBuilder CreateApkBuilder (string directory, bool cleanupAfterSuccessfulBuild = false, bool cleanupOnDispose = false)
+		protected ProjectBuilder CreateApkBuilder (string directory = null, bool cleanupAfterSuccessfulBuild = false, bool cleanupOnDispose = false)
 		{
+			if (string.IsNullOrEmpty (directory))
+				directory = Path.Combine ("temp", TestName);
 			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = Path.Combine (Root, directory);
 			return BuildHelper.CreateApkBuilder (directory, cleanupAfterSuccessfulBuild, cleanupOnDispose);
 		}
 
-		protected ProjectBuilder CreateDllBuilder (string directory, bool cleanupAfterSuccessfulBuild = false, bool cleanupOnDispose = false)
+		protected ProjectBuilder CreateDllBuilder (string directory = null, bool cleanupAfterSuccessfulBuild = false, bool cleanupOnDispose = false)
 		{
+			if (string.IsNullOrEmpty (directory))
+				directory = Path.Combine ("temp", TestName);
 			TestOutputDirectories [TestContext.CurrentContext.Test.ID] = Path.Combine (Root, directory);
 			return BuildHelper.CreateDllBuilder (directory, cleanupAfterSuccessfulBuild, cleanupOnDispose);
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/WearTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/WearTests.cs
@@ -26,17 +26,16 @@ namespace Xamarin.Android.Build.Tests
 			var path = Path.Combine ("temp", TestName);
 			var app = new XamarinAndroidApplicationProject {
 				ProjectName = "MyApp",
+				AndroidUseSharedRuntime = false,
+				EmbedAssembliesIntoApk = true,
 			};
-			var wear = new XamarinAndroidWearApplicationProject ();
+			var wear = new XamarinAndroidWearApplicationProject {
+				AndroidUseSharedRuntime = false,
+				EmbedAssembliesIntoApk = true,
+			};
 			app.References.Add (new BuildItem.ProjectReference ($"..\\{wear.ProjectName}\\{wear.ProjectName}.csproj", wear.ProjectName, wear.ProjectGuid) {
 				MetadataValues = "IsAppExtension=True"
 			});
-
-			// Set these to be the same values
-			app.SetProperty (app.DebugProperties, KnownProperties.AndroidUseSharedRuntime, "False");
-			app.SetProperty (app.DebugProperties, "EmbedAssembliesIntoApk", "True");
-			wear.SetProperty (wear.DebugProperties, KnownProperties.AndroidUseSharedRuntime, "False");
-			wear.SetProperty (wear.DebugProperties, "EmbedAssembliesIntoApk", "True");
 
 			using (var wearBuilder = CreateDllBuilder (Path.Combine (path, wear.ProjectName)))
 			using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
@@ -9,11 +9,13 @@ namespace Xamarin.ProjectTools
 
 		public const string AndroidLinkMode = "AndroidLinkMode";
 		public const string AndroidUseSharedRuntime = "AndroidUseSharedRuntime";
+		public const string EmbedAssembliesIntoApk = "EmbedAssembliesIntoApk";
 		public const string AndroidUseLatestPlatformSdk = "AndroidUseLatestPlatformSdk";
 		public const string AndroidCreatePackagePerAbi = "AndroidCreatePackagePerAbi";
 
 		public const string AndroidSupportedAbis = "AndroidSupportedAbis";
 
+		public const string Deterministic = "Deterministic";
 		public const string BundleAssemblies = "BundleAssemblies";
 		public const string EnableProguard = "EnableProguard";
 		public const string AndroidEnableDesugar = "AndroidEnableDesugar";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -43,8 +43,8 @@ namespace Xamarin.ProjectTools
 			SetProperty ("AndroidManifest", "Properties\\AndroidManifest.xml");
 			SetProperty (DebugProperties, "AndroidLinkMode", "None");
 			SetProperty (ReleaseProperties, "AndroidLinkMode", "SdkOnly");
-			SetProperty (DebugProperties, "EmbedAssembliesIntoApk", "False", "'$(EmbedAssembliesIntoApk)' == ''");
-			SetProperty (ReleaseProperties, "EmbedAssembliesIntoApk", "True", "'$(EmbedAssembliesIntoApk)' == ''");
+			SetProperty (DebugProperties, KnownProperties.EmbedAssembliesIntoApk, "False", "'$(EmbedAssembliesIntoApk)' == ''");
+			SetProperty (ReleaseProperties, KnownProperties.EmbedAssembliesIntoApk, "True", "'$(EmbedAssembliesIntoApk)' == ''");
 
 			AndroidManifest = default_android_manifest;
 			LayoutMain = default_layout_main;
@@ -83,6 +83,21 @@ namespace Xamarin.ProjectTools
 		public bool EnableDesugar {
 			get { return string.Equals (GetProperty (KnownProperties.AndroidEnableDesugar), "True", StringComparison.OrdinalIgnoreCase); }
 			set { SetProperty (KnownProperties.AndroidEnableDesugar, value.ToString ()); }
+		}
+
+		public bool Deterministic {
+			get { return string.Equals (GetProperty (KnownProperties.Deterministic), "True", StringComparison.OrdinalIgnoreCase); }
+			set { SetProperty (KnownProperties.Deterministic, value.ToString ()); }
+		}
+
+		public bool AndroidUseSharedRuntime {
+			get { return string.Equals (GetProperty (KnownProperties.AndroidUseSharedRuntime), "True", StringComparison.OrdinalIgnoreCase); }
+			set { SetProperty (KnownProperties.AndroidUseSharedRuntime, value.ToString ()); }
+		}
+
+		public bool EmbedAssembliesIntoApk {
+			get { return string.Equals (GetProperty (KnownProperties.EmbedAssembliesIntoApk), "True", StringComparison.OrdinalIgnoreCase); }
+			set { SetProperty (KnownProperties.EmbedAssembliesIntoApk, value.ToString ()); }
 		}
 
 		public string DexTool {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Properties/AssemblyInfo.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Properties/AssemblyInfo.cs
@@ -12,12 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright ("Copyright © Xamarin 2011-2016")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion ("1.0.*")]
+[assembly: AssemblyVersion ("1.0.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1997,6 +1997,7 @@ because xbuild doesn't support framework reference assemblies.
       ResolvedAssemblies="@(_AllResolvedAssemblies)"
       SourceFiles="@(ResolvedAssemblies)"
       DestinationFiles="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')"
+      Deterministic="$(Deterministic)"
   />
   <ItemGroup>
     <FileWrites Include="$(MonoAndroidIntermediateAssemblyDir)*" />
@@ -2040,6 +2041,7 @@ because xbuild doesn't support framework reference assemblies.
       ProguardConfiguration="$(_ProguardProjectConfiguration)"
       PreserveJniMarshalMethods="$(AndroidGenerateJniMarshalMethods)"
       EnableProguard="$(AndroidEnableProguard)"
+      Deterministic="$(Deterministic)"
       DumpDependencies="$(LinkerDumpDependencies)"
       ResolvedAssemblies="@(_AssembliesToLink)"
       HttpClientHandlerType="$(AndroidHttpClientHandlerType)"
@@ -2641,6 +2643,7 @@ because xbuild doesn't support framework reference assemblies.
   <!-- Shrink Mono.Android.dll by removing attribute only needed for GenerateJavaStubs -->
   <RemoveRegisterAttribute
     Condition="'$(AndroidLinkMode)' != 'None' AND '$(AndroidUseSharedRuntime)' != 'true'"
+    Deterministic="$(Deterministic)"
     ShrunkFrameworkAssemblies="@(_ShrunkFrameworkAssemblies)" />
 
   <MakeDir Directories="$(MonoAndroidIntermediateAssetsDir)shrunk" />

--- a/src/Xamarin.Android.NUnitLite/Properties/AssemblyInfo.cs
+++ b/src/Xamarin.Android.NUnitLite/Properties/AssemblyInfo.cs
@@ -12,12 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright ("jon")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion ("1.0.*")]
+[assembly: AssemblyVersion ("1.0.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/src/Xamarin.Android.Tools.JavadocImporter/Properties/AssemblyInfo.cs
+++ b/src/Xamarin.Android.Tools.JavadocImporter/Properties/AssemblyInfo.cs
@@ -12,12 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright ("")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion ("1.0.*")]
+[assembly: AssemblyVersion ("1.0.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Properties/AssemblyInfo.cs
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Properties/AssemblyInfo.cs
@@ -12,12 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright ("Microsoft")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion ("1.0.*")]
+[assembly: AssemblyVersion ("1.0.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/Properties/AssemblyInfo.cs
+++ b/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/Properties/AssemblyInfo.cs
@@ -12,12 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright ("Marek Habersack")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion ("1.0.*")]
+[assembly: AssemblyVersion ("1.0.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -110,12 +110,12 @@ namespace Xamarin.Android.Build.Tests
 			}
 			var proj = new XamarinFormsAndroidApplicationProject () {
 				IsRelease = false,
+				AndroidUseSharedRuntime = useSharedRuntime,
+				EmbedAssembliesIntoApk = embedAssemblies,
 				AndroidFastDeploymentType = fastDevType
 			};
 			var abis = new string [] { "armeabi-v7a", "x86" };
 			proj.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
-			proj.SetProperty (KnownProperties.AndroidUseSharedRuntime, useSharedRuntime.ToString ());
-			proj.SetProperty ("EmbedAssembliesIntoApk", embedAssemblies.ToString ());
 			proj.SetDefaultTargetDevice ();
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				string apiLevel;

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -231,9 +231,10 @@ namespace Xamarin.Android.Build.Tests
 
 			//Setup a situation where we get INSTALL_FAILED_NO_MATCHING_ABIS
 			var abi = "armeabi-v7a";
-			var proj = new XamarinAndroidApplicationProject ();
-			proj.SetProperty (proj.DebugProperties, "AndroidUseSharedRuntime", false);
-			proj.SetProperty (proj.DebugProperties, "EmbedAssembliesIntoApk", true);
+			var proj = new XamarinAndroidApplicationProject {
+				AndroidUseSharedRuntime = false,
+				EmbedAssembliesIntoApk = true,
+			};
 			proj.SetProperty (proj.DebugProperties, KnownProperties.AndroidSupportedAbis, abi);
 
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
@@ -256,9 +257,10 @@ namespace Xamarin.Android.Build.Tests
 				Assert.Ignore ("Test Skipped no devices or emulators found.");
 			}
 
-			var proj = new XamarinAndroidApplicationProject ();
-			proj.SetProperty (proj.DebugProperties, "AndroidUseSharedRuntime", true);
-			proj.SetProperty (proj.DebugProperties, "EmbedAssembliesIntoApk", false);
+			var proj = new XamarinAndroidApplicationProject {
+				AndroidUseSharedRuntime = true,
+				EmbedAssembliesIntoApk = false,
+			};
 
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				Assert.IsTrue (builder.Install (proj), "Install should have succeeded.");
@@ -278,8 +280,8 @@ namespace Xamarin.Android.Build.Tests
 				StringAssert.Contains ($"{proj.ProjectName}.dll", directorylist, $"{proj.ProjectName}.dll should exist in the .__override__ directory.");
 
 				//Now toggle FastDev to OFF
-				proj.SetProperty (proj.DebugProperties, "AndroidUseSharedRuntime", false);
-				proj.SetProperty (proj.DebugProperties, "EmbedAssembliesIntoApk", true);
+				proj.AndroidUseSharedRuntime = false;
+				proj.EmbedAssembliesIntoApk = true;
 				var abis = new string [] { "armeabi-v7a", "x86" };
 				proj.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
 

--- a/tools/javadoc2mdoc/Properties/AssemblyInfo.cs
+++ b/tools/javadoc2mdoc/Properties/AssemblyInfo.cs
@@ -12,12 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright ("")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion ("1.0.*")]
+[assembly: AssemblyVersion ("1.0.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/tools/jit-times/Properties/AssemblyInfo.cs
+++ b/tools/jit-times/Properties/AssemblyInfo.cs
@@ -11,12 +11,7 @@
 [assembly: AssemblyCopyright ("2019 Microsoft Corporation")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion ("1.0.*")]
+[assembly: AssemblyVersion ("1.0.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/tools/setup-windows/Properties/AssemblyInfo.cs
+++ b/tools/setup-windows/Properties/AssemblyInfo.cs
@@ -12,12 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright ("")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion ("1.0.*")]
+[assembly: AssemblyVersion ("1.0.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/tools/vswhere/Properties/AssemblyInfo.cs
+++ b/tools/vswhere/Properties/AssemblyInfo.cs
@@ -12,12 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright ("")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion ("1.0.*")]
+[assembly: AssemblyVersion ("1.0.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/tools/xabuild/Properties/AssemblyInfo.cs
+++ b/tools/xabuild/Properties/AssemblyInfo.cs
@@ -12,12 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright ("")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
-
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion ("1.0.*")]
+[assembly: AssemblyVersion ("1.0.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2957
Context: https://blog.paranoidcoding.com/2016/04/05/deterministic-builds-in-roslyn.html

Since Visual Studio 2019, [`$(Deterministic)`][0] is set in the .NET
framework class library project template:

	<PropertyGroup>
	  <Deterministic>True</Deterministic>
	  <!-- ... -->
	</PropertyGroup>

It is also the default for SDK-style projects.

What this setting does is enable a stable MVID for the produced .NET
assembly.  If you do `touch Foo.cs && msbuild`, the resulting
assembly will have its contents unchanged.  However, the timestamp of
the file *will* change.  There may be some narrow performance gains
we can get there.

The only drawback of `$(Determinitic)` is that the following will
produce a CS8357 build error:

	[assembly: AssemblyVersion ("1.0.*")]
	// error CS8357: The specified version string contains wildcards,
	//               which are not compatible with determinism.
	//               Either remove wildcards from the version string,
	//               or disable determinism for this compilation

Since `1.0.*` implies that the assembly changes on incremental
builds, `$(Deterministic)`=True cannot support it.  So we can't just
make it default without breaking someone.

~~ What should we do? ~~

We should start building Xamarin.Android using `$(Deterministic)`=True
and add a few tests for it.  We had some usage of
`[assembly:AssemblyVersion]` wildcards that seemed unnecessary.

When `$(Deterministic)`=True, any places using Mono.Cecil need to use
the appropriate `WriterParameters.DeterministicMvid` setting when
writing assemblies.  The linker has an equivalent
`LinkContext.DeterministicOutput` property.

After this change makes it in, we should consider putting
`<Deterministic>True</Deterministic>` in the Xamarin templates.
We would also need to remove some comments in `AssemblyInfo.cs` that
suggests to use `[assembly: AssemblyVersion ("1.0.*")]`.

~~ Other changes ~~

I added a few general fixes to `Xamarin.ProjectTools`:

  * Made properties so `AndroidUseSharedRuntime` and
    `EmbedAssembliesIntoApk` are strongly typed.
  * Added a `Deterministic` property
  * In `BaseTest`, `CreateApkBuilder()` and `CreateDllBuilder()` now
    have the `directory` parameter optional.

[0]: https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/command-line-compiler/deterministic