### PR TITLE
[tests] include all of bin/Test$(Configuration)/temp in xa-tests-results.zip

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/result-packaging.targets
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/result-packaging.targets
@@ -25,9 +25,9 @@
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\TestResult-*.xml" />
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\compatibility\*" />
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\logcat*" />
-    <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\**\*.binlog" />
-    <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\**\*.log" />
-    <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\**\screenshot.png" />
+    <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\temp\**\*">
+      <SubDirectory>temp\</SubDirectory>
+    </_TestResultFiles>
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\TestOutput-*.txt" />
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\Timing_*" />
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)*.csv" />
@@ -71,7 +71,7 @@
     <Copy
         UseHardlinksIfPossible="True"
         SourceFiles="@(_TestResultFiles)"
-        DestinationFiles="@(_TestResultFiles->'$(TestResultZipOutputPath)\$(TestResultZipName)\%(RecursiveDir)%(Filename)%(Extension)')"
+        DestinationFiles="@(_TestResultFiles->'$(TestResultZipOutputPath)\$(TestResultZipName)\%(SubDirectory)%(RecursiveDir)%(Filename)%(Extension)')"
     />
     <ItemGroup>
       <_TestResultFilesToZip Include="$(TestResultZipOutputPath)\$(TestResultZipName)\**\*" />

--- a/tests/CodeBehind/UnitTests/BuildTests.cs
+++ b/tests/CodeBehind/UnitTests/BuildTests.cs
@@ -151,7 +151,7 @@ namespace CodeBehindUnitTests
 		{
 			TestProjectRootDirectory = Path.GetFullPath (Path.Combine (XABuildPaths.TopDirectory, "tests", "CodeBehind", "BuildTests"));
 			CommonSampleLibraryRootDirectory = Path.GetFullPath (Path.Combine (XABuildPaths.TopDirectory, "tests", "CodeBehind", CommonSampleLibraryName));
-			TestOutputDir = Path.Combine (XABuildPaths.TestOutputDirectory, "CodeBehind");
+			TestOutputDir = Path.Combine (XABuildPaths.TestOutputDirectory, "temp", "CodeBehind");
 
 			generated_sources = new List <SourceFile> {
 				new SourceFile ("Binding.Main.g.cs") {
@@ -627,7 +627,7 @@ namespace CodeBehindUnitTests
 
 		string PrepareProject (string testName)
 		{
-			string tempRoot = Path.Combine (TestOutputDir, $"{testName}.build", XABuildPaths.Configuration);
+			string tempRoot = Path.Combine (TestOutputDir, testName, XABuildPaths.Configuration);
 			string temporaryProjectPath = Path.Combine (tempRoot, "project");
 
 			var ignore = new HashSet <string> {

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-Tests/Xamarin.Android.MakeBundle-Tests.csproj
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-Tests/Xamarin.Android.MakeBundle-Tests.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(UnitTestsMode)' == 'true' ">
-    <RelativeRootPath>..\..\..\..\..\..</RelativeRootPath>
+    <RelativeRootPath>..\..\..\..\..\..\..</RelativeRootPath>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(UnitTestsMode)' != 'true' ">

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/BuildTests.cs
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/BuildTests.cs
@@ -64,7 +64,7 @@ namespace Xamarin.Android.MakeBundle.UnitTests
 		static BuildTests_EmbeddedDSOBuildTests ()
 		{
 			TestProjectRootDirectory = Path.GetFullPath (Path.Combine (XABuildPaths.TopDirectory, "tests", "CodeGen-MkBundle", "Xamarin.Android.MakeBundle-Tests"));
-			TestOutputDir = Path.Combine (XABuildPaths.TestOutputDirectory, "CodeGen-MkBundle");
+			TestOutputDir = Path.Combine (XABuildPaths.TestOutputDirectory, "temp", "CodeGen-MkBundle");
 		}
 
 		[OneTimeSetUp]

--- a/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/BuildTests.cs
+++ b/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/BuildTests.cs
@@ -56,7 +56,7 @@ namespace EmbeddedDSOUnitTests
 		static BuildTests_EmbeddedDSOBuildTests ()
 		{
 			TestProjectRootDirectory = Path.GetFullPath (Path.Combine (XABuildPaths.TopDirectory, "tests", "EmbeddedDSOs", "EmbeddedDSO"));
-			TestOutputDir = Path.Combine (XABuildPaths.TestOutputDirectory, "EmbeddedDSO");
+			TestOutputDir = Path.Combine (XABuildPaths.TestOutputDirectory, "temp", "EmbeddedDSO");
 
 			produced_binaries = new List <string> {
 				$"{ProjectAssemblyName}.dll",

--- a/tests/EmbeddedDSOs/EmbeddedDSO/EmbeddedDSO.csproj
+++ b/tests/EmbeddedDSOs/EmbeddedDSO/EmbeddedDSO.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(UnitTestsMode)' == 'true' ">
-    <RelativeRootPath>..\..\..\..\..\..</RelativeRootPath>
+    <RelativeRootPath>..\..\..\..\..\..\..</RelativeRootPath>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(UnitTestsMode)' != 'true' ">


### PR DESCRIPTION
There have been some cases where we wanted to get the entire project
directory from the CI system after a test run has completed.

We can zip up all of:

    bin\Test$(Configuration)\temp\**\*

However, there are a few MSBuild-related tests that don't drop their
files in this directory:

* `CodeBehind`
* `CodeGen-MkBundle`
* `EmbeddedDSOs`

I changed these tests to output to `temp`. This should be OK even if
there is a naming collision, since they don't run at the same time as
the other MSBuild tests.