### PR TITLE
[tests] add an MSBuild test for AndroidX migration

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -508,6 +508,56 @@ namespace Xamarin.ProjectTools
 				},
 			}
 		};
+		public static Package AndroidXMigration = new Package {
+			Id = "Xamarin.AndroidX.Migration",
+			Version = "1.0.0-preview04",
+			TargetFramework = "MonoAndroid10",
+		};
+		public static Package AndroidXAppCompat = new Package {
+			Id = "Xamarin.AndroidX.AppCompat",
+			Version = "1.0.2-preview02",
+			TargetFramework = "MonoAndroid10",
+		};
+		public static Package AndroidXBrowser = new Package {
+			Id = "Xamarin.AndroidX.Browser",
+			Version = "1.0.0-preview02",
+			TargetFramework = "MonoAndroid90",
+			References =  {
+				new BuildItem.Reference ("Xamarin.AndroidX.Browser") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.AndroidX.Browser.1.0.0-preview02\\lib\\MonoAndroid90\\Xamarin.AndroidX.Browser.dll"
+				},
+			}
+		};
+		public static Package AndroidXMediaRouter = new Package {
+			Id = "Xamarin.AndroidX.MediaRouter",
+			Version = "1.0.0-preview02",
+			TargetFramework = "MonoAndroid90",
+			References =  {
+				new BuildItem.Reference ("Xamarin.AndroidX.MediaRouter") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.AndroidX.MediaRouter.1.0.0-preview02\\lib\\MonoAndroid90\\Xamarin.AndroidX.MediaRouter.dll"
+				},
+			}
+		};
+		public static Package AndroidXLegacySupportV4 = new Package {
+			Id = "Xamarin.AndroidX.Legacy.Support.V4",
+			Version = "1.0.0-preview02",
+			TargetFramework = "MonoAndroid90",
+			References =  {
+				new BuildItem.Reference ("Xamarin.AndroidX.Legacy.Support.V4") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.AndroidX.Legacy.Support.V4.1.0.0-preview02\\lib\\MonoAndroid90\\Xamarin.AndroidX.Legacy.Support.V4.dll"
+				},
+			}
+		};
+		public static Package XamarinGoogleAndroidMaterial = new Package {
+			Id = "Xamarin.Google.Android.Material",
+			Version = "1.0.0-preview02",
+			TargetFramework = "MonoAndroid90",
+			References =  {
+				new BuildItem.Reference ("Xamarin.Google.Android.Material") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Google.Android.Material.1.0.0-preview02\\lib\\MonoAndroid90\\Xamarin.Google.Android.Material.dll"
+				},
+			}
+		};
 		public static Package CocosSharp_PCL_Shared_1_5_0_0 = new Package {
 			Id = "CocosSharp.PCL.Shared", 
 			Version = "1.5.0.0",


### PR DESCRIPTION
Context: https://www.nuget.org/packages/Xamarin.AndroidX.Migration

Xamarin.AndroidX.Migration has a lot of integration into the
Xamarin.Android MSBuild targets. We should include a test for
AndroidX, so we have better coverage of our MSBuild extension points.

We don't want to break it!