### PR TITLE
[Xamarin.Android.Build.Tasks] use d8 by default

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -298,7 +298,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<AndroidEnableProguard Condition=" '$(AndroidEnableProguard)' == '' ">$(EnableProguard)</AndroidEnableProguard>
 	<AndroidEnableProguard Condition=" '$(AndroidLinkTool)' == 'proguard' ">True</AndroidEnableProguard>
 	<AndroidEnableMultiDex Condition=" '$(AndroidEnableMultiDex)' == '' ">False</AndroidEnableMultiDex>
-	<AndroidDexTool   Condition=" '$(AndroidDexTool)' == '' ">dx</AndroidDexTool>
+	<AndroidDexTool   Condition=" '$(AndroidDexTool)' == '' ">d8</AndroidDexTool>
 	<AndroidDexTool   Condition=" '$(AndroidLinkTool)' == 'r8' ">d8</AndroidDexTool>
 	<!-- NOTE: $(AndroidLinkTool) would be blank if code shrinking is not used at all -->
 	<AndroidLinkTool       Condition=" '$(AndroidLinkTool)' == '' And '$(AndroidEnableProguard)' == 'True' ">proguard</AndroidLinkTool>

--- a/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Properties/AndroidManifest.xml
+++ b/tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Xamarin.Android.JcwGen_Tests">
-	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="28" />
+	<uses-sdk android:minSdkVersion="24" />
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<application android:label="Xamarin.Android.JcwGen-Tests">


### PR DESCRIPTION
This is an effort to improve build performance going forward.

## Fix JcwGen DimTest ##

Context: https://dev.azure.com/DevDiv/DevDiv/_build/results?buildId=3087283&view=ms.vss-test-web.test-result-details

I was getting:

    Java.Lang.AbstractMethodError : abstract method "int com.xamarin.android.DefaultMethodsInterface.foo()"
      at Java.Interop.JniEnvironment+InstanceMethods.CallNonvirtualIntMethod (Java.Interop.JniObjectReference instance, Java.Interop.JniObjectReference type, Java.Interop.JniMethodInfo method, Java.Interop.JniArgumentValue* args) [0x0008e] in <eea339da6b5e4d4bb255bfef95601890>:0
      at Java.Interop.JniPeerMembers+JniInstanceMethods.InvokeVirtualInt32Method (System.String encodedMember, Java.Interop.IJavaPeerable self, Java.Interop.JniArgumentValue* parameters) [0x0005d] in <eea339da6b5e4d4bb255bfef95601890>:0
      at Com.Xamarin.Android.IDefaultMethodsInterface.Foo () [0x0000a] in <eea339da6b5e4d4bb255bfef95601890>:0
      at Xamarin.Android.JcwGenTests.DimTest.TestManagedEmptyDefaultInterfaceMethods () [0x00006] in <df90a46a8e0744d79a31b7791f258318>:0
      at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
      at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <37b7146e027b4a5dabb872e988c3971b>:0
      --- End of managed Java.Lang.AbstractMethodError stack trace ---
      java.lang.AbstractMethodError: abstract method "int com.xamarin.android.DefaultMethodsInterface.foo()"
      at md545536373befe5ba5b0be978b998d36b6.TestSuiteInstrumentation.n_onStart(Native Method)
      at md545536373befe5ba5b0be978b998d36b6.TestSuiteInstrumentation.onStart(TestSuiteInstrumentation.java:29)
      at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2189)

Reviewing the `classes.dex` file, it appears that d8/r8 was
desugaring the default interface methods away.

However, setting `android:minSdkVersion="24"` solves the problem?

I'm finding conflicting information on this:

    Android does not support all Java 8 language features. However, the
    following features are available when developing apps targeting
    Android 7.0 (API level 24):

    * Default and static interface methods

https://stackoverflow.com/a/46873490/132442

But comments and current documentation indicate that all API levels
should support DIM?

However, it looks like the behavior of d8/r8 is to desugar away DIM
unless at least `--min-api 24` is passed.

In order to test DIM, I think we should just change
`AndroidManifest.xml` in this project.