### PR TITLE
Bump Mono to fix remapping assembly versions on run time

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:master@623845d44abe5eb7a76d9a63d48b30a27ac1bac2
-mono/mono:2019-08@c99adb97edc6a57d934105d5c13506518134b585
+mono/mono:2019-08@d8441deead62b3af591c6daefb5013b09ef1ab8b


### PR DESCRIPTION
Context: https://github.com/mono/mono/commit/7ae0f38fd7ee4409b3cc717e33315188b603bb31

Mono had a small regression where it started to ignore the runtime version
passed to it during initialization (`mobile` in our case) which resulted in the
runtime repeatedly remapping assemblies from the "mobile" version `2.0.5.0` to
the "default" version `4.0.0.0`. That, in turn, caused our assembly preload hook
to be repeatedly called in order to load the same assemblies over and over
again. Bump Mono to fix the issue.

Changes:

  * d8441deead6 [crashing] Remove Mono signal handlers when starting to handle a crash (#17078)
  * 7ae0f38fd7e [runtime] Respect runtime_version in mono_init_internal (#17086)
  * 61ca7fe3a46 [sdks] Bump min iOS version to 7.0. (#17070)