### PR TITLE
[Xamarin.Android.Build.Tasks] dispose GetManifestResourceStream

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -115,10 +115,10 @@ namespace Xamarin.Android.Tasks
 			ArchiveFileList files = new ArchiveFileList ();
 			if (apkInputPath != null)
 				File.Copy (apkInputPath, temp, overwrite: true);
+			using (var notice = Assembly.GetExecutingAssembly ().GetManifestResourceStream ("NOTICE.txt"))
 			using (var apk = new ZipArchiveEx (temp, apkInputPath != null ? FileMode.Open : FileMode.Create )) {
 				apk.FixupWindowsPathSeparators ((a, b) => Log.LogDebugMessage ($"Fixing up malformed entry `{a}` -> `{b}`"));
-				apk.Archive.AddEntry (RootPath + "NOTICE",
-						Assembly.GetExecutingAssembly ().GetManifestResourceStream ("NOTICE.txt"));
+				apk.Archive.AddEntry (RootPath + "NOTICE", notice);
 
 				// Add classes.dx
 				foreach (var dex in DalvikClasses) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
@@ -129,13 +129,6 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		public void Close ()
-		{
-			if (zip != null) {
-				zip.Close ();
-			}
-		}
-
 		public void Dispose ()
 		{
 			Dispose(true);


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/3695
Context: https://dev.azure.com/DevDiv/DevDiv/_build/results?buildId=3095849&view=ms.vss-test-web.test-result-details

We have been hitting a random MSBuild test failure on macOS:

    Unable to open 'obj/Debug/android/bin/UnnamedProject.UnnamedProject.apk' as zip archive

This appears to be coming from `zipalign` directly. In #3695 I was
able to get the APK file in question.

Using 7-zip on Windows, it reports the file is invalid:

    > 7z t "C:\Users\jopepper\Downloads\CheckResourceDesignerIsCreatedFalseCSharp\obj\Debug\android\bin\UnnamedProject.UnnamedProject.apk"                                                                                                                                                                                                                   7-Zip 19.00 (x64) : Copyright (c) 1999-2018 Igor Pavlov : 2019-02-21
    Scanning the drive for archives:
    1 file, 5578397 bytes (5448 KiB)
    Testing archive: C:\Users\jopepper\Downloads\CheckResourceDesignerIsCreatedFalseCSharp\obj\Debug\android\bin\UnnamedProject.UnnamedProject.apk
    --
    Path = C:\Users\jopepper\Downloads\CheckResourceDesignerIsCreatedFalseCSharp\obj\Debug\android\bin\UnnamedProject.UnnamedProject.apk
    Type = zip
    Physical Size = 5578397
    ERROR: Headers Error : NOTICE
    ERROR: Headers Error : classes.dex
    ERROR: Headers Error : lib\arm64-v8a\libmonodroid.so
    Sub items Errors: 3
    Archives with Errors: 1
    Sub items Errors: 3

Reviewing the code in `<BuildApk/>`, we aren't disposing what is
returned from:

    Assembly.GetExecutingAssembly ().GetManifestResourceStream ("NOTICE.txt")

An `UnmanagedMemoryStream` is returned here, so it is possible that
this could be the source of the issue? Disposing is good hygiene here
anyway. It is good to make this change even if it doesn't fix the
issue.

I also removed a completely unused `Close()` method in `ZipArchiveEx`.