### PR TITLE
[tests] FileCompare -> AssertFileContentsMatch

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
@@ -348,8 +348,7 @@ int xml myxml 0x7f140000
 			Assert.IsTrue (task.Execute (), "Task should have executed successfully.");
 			Assert.IsTrue (File.Exists (task.NetResgenOutputFile), $"{task.NetResgenOutputFile} should have been created.");
 			var expected = Path.Combine (Root, "Expected", "GenerateDesignerFileExpected.cs");
-			Assert.IsTrue (FileCompare (task.NetResgenOutputFile, expected), 
-			 	$"{task.NetResgenOutputFile} and {expected} do not match.");
+			AssertFileContentsMatch (task.NetResgenOutputFile, expected);
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
 
@@ -389,8 +388,7 @@ int xml myxml 0x7f140000
 			Assert.IsTrue (task.Execute (), "Task should have executed successfully.");
 			Assert.IsTrue (File.Exists (task.NetResgenOutputFile), $"{task.NetResgenOutputFile} should have been created.");
 			var expected = Path.Combine (Root, "Expected", withLibraryReference ? "GenerateDesignerFileWithLibraryReferenceExpected.cs" : "GenerateDesignerFileExpected.cs");
-			Assert.IsTrue (FileCompare (task.NetResgenOutputFile, expected),
-				 $"{task.NetResgenOutputFile} and {expected} do not match.");
+			AssertFileContentsMatch (task.NetResgenOutputFile, expected);
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
 
@@ -426,8 +424,7 @@ int xml myxml 0x7f140000
 			Assert.IsTrue (task.Execute (), "Task should have executed successfully.");
 			Assert.IsTrue (File.Exists (task.NetResgenOutputFile), $"{task.NetResgenOutputFile} should have been created.");
 			var expected = Path.Combine (Root, "Expected", "GenerateDesignerFileExpected.cs");
-			Assert.IsTrue (FileCompare (task.NetResgenOutputFile, expected),
-				 $"{task.NetResgenOutputFile} and {expected} do not match.");
+			AssertFileContentsMatch (task.NetResgenOutputFile, expected);
 			// Update the id, and force the managed parser to re-parse the output
 			File.WriteAllText (Path.Combine (Root, path, "res", "layout", "main.xml"), Main.Replace ("@+id/textview.withperiod", "@+id/textview.withperiod2"));
 			File.SetLastWriteTimeUtc (task.ResourceFlagFile, DateTime.UtcNow);
@@ -436,8 +433,7 @@ int xml myxml 0x7f140000
 			var data = File.ReadAllText (expected);
 			var expectedWithNewId = Path.Combine (Root, path, "GenerateDesignerFileExpectedWithNewId.cs");
 			File.WriteAllText (expectedWithNewId, data.Replace ("withperiod", "withperiod2"));
-			Assert.IsTrue (FileCompare (task.NetResgenOutputFile, expectedWithNewId),
-				 $"{task.NetResgenOutputFile} and {expectedWithNewId} do not match.");
+			AssertFileContentsMatch (task.NetResgenOutputFile, expectedWithNewId);
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
 
@@ -520,8 +516,7 @@ int xml myxml 0x7f140000
 			Assert.IsTrue (task.Execute (), "Task should have executed successfully.");
 			string aapt2Designer = Path.Combine (Root, path, "Resource.designer.aapt2.cs");
 			string managedDesigner = Path.Combine (Root, path, "Resource.designer.managed.cs");
-			Assert.IsTrue (FileCompare (managedDesigner, aapt2Designer),
-				 $"{managedDesigner} and {aapt2Designer} do not match.");
+			AssertFileContentsMatch (managedDesigner, aapt2Designer);
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 
 		}
@@ -594,9 +589,7 @@ int xml myxml 0x7f140000
 			Assert.IsTrue (task.Execute (), "Task should have executed successfully.");
 
 			string managedDesignerRtxt = Path.Combine (Root, path, "Resource.designer.managedrtxt.cs");
-
-			Assert.IsTrue (FileCompare (managedDesignerRtxt, aaptDesigner),
-				 $"{managedDesignerRtxt} and {aaptDesigner} do not match.");
+			AssertFileContentsMatch (managedDesignerRtxt, aaptDesigner);
 
 			File.WriteAllText (task.ResourceFlagFile, string.Empty);
 			File.Delete (Path.Combine (Root, path, "R.txt.bak"));
@@ -717,8 +710,7 @@ int styleable ElevenAttributes_attr10 10";
 			Assert.IsTrue (task.Execute (), "Task should have executed successfully.");
 			Assert.IsTrue (File.Exists (task.NetResgenOutputFile), $"{task.NetResgenOutputFile} should have been created.");
 			var expected = Path.Combine (Root, "Expected", "GenerateDesignerFileWithElevenStyleableAttributesExpected.cs");
-			Assert.IsTrue (FileCompare (task.NetResgenOutputFile, expected),
-				 $"{task.NetResgenOutputFile} and {expected} do not match.");
+			AssertFileContentsMatch (task.NetResgenOutputFile, expected);
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -470,6 +470,11 @@ namespace Xamarin.Android.Tasks
 			return Files.HashStream (stream);
 		}
 
+		public static string HashBytes (byte[] bytes)
+		{
+			return Files.HashBytes (bytes);
+		}
+
 		public static bool HasFileChanged (string source, string destination)
 		{
 			return Files.HasFileChanged (source, destination);


### PR DESCRIPTION
We have a few tests that make use of `FileCompare`, which
unfortunately does not report what actually differed.

I think we should make this method `AssertFileContentsMatch` instead,
and add both files as test attachments in cases of failure. This way
we can inspect both files and see what went wrong. Our test code will
also be a little simpler.

Additionally, I found the actual difference in the two files is CRLF
vs LF. I accidentally lost the following line in 88a1d6cd:

https://github.com/xamarin/xamarin-android/commit/88a1d6cd88e68bda208a6eb05d99d802c7800d2e#diff-f2ab112c825cdebe3019eecdbed39cb5L397

I partially reverted 88a1d6cd to use the helper method
`ReadAllBytesIgnoringLineEndings`, but used CRC64 instead of MD5.