### PR TITLE
[C++ification] Convert monodroid-glue to a class

### DIFF
--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -236,9 +236,11 @@ set(MONODROID_SOURCES
   ${SOURCES_DIR}/basic-android-system.cc
   ${SOURCES_DIR}/basic-utilities.cc
   ${SOURCES_DIR}/cpu-arch-detect.cc
+  ${SOURCES_DIR}/debug.cc
   ${SOURCES_DIR}/debug-constants.cc
   ${SOURCES_DIR}/embedded-assemblies.cc
   ${SOURCES_DIR}/embedded-assemblies-zip.cc
+  ${SOURCES_DIR}/external-api.cc
   ${SOURCES_DIR}/globals.cc
   ${SOURCES_DIR}/jni.c
   ${SOURCES_DIR}/logger.cc
@@ -255,7 +257,6 @@ set(MONODROID_SOURCES
 if(UNIX)
   set(MONODROID_SOURCES
     ${MONODROID_SOURCES}
-    ${SOURCES_DIR}/debug.cc
     ${SOURCES_DIR}/monodroid-networkinfo.cc
     ${SOURCES_DIR}/xamarin_getifaddrs.cc
     )

--- a/src/monodroid/jni/debug.cc
+++ b/src/monodroid/jni/debug.cc
@@ -96,11 +96,12 @@ Debug::monodroid_profiler_load (const char *libmono_path, const char *desc, cons
 	if (found && logfile != nullptr)
 		utils.set_world_accessable (logfile);
 
-	if (!found)
+	if (!found) {
 		log_warn (LOG_DEFAULT,
 				"The '%s' profiler wasn't found in the main executable nor could it be loaded from '%s'.",
 				mname,
-		        libname.get ());
+				libname.get ());
+	}
 
 	delete[] mname;
 }

--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -21,10 +21,11 @@
 #include "util.hh"
 #include "embedded-assemblies.hh"
 #include "globals.hh"
-#include "monodroid-glue.h"
+#include "monodroid-glue.hh"
 #include "xamarin-app.h"
+#include "cpp-util.hh"
 
-namespace xamarin { namespace android { namespace internal {
+namespace xamarin::android::internal {
 #if defined (DEBUG) || !defined (ANDROID)
 	struct TypeMappingInfo {
 		char                     *source_apk;
@@ -36,7 +37,7 @@ namespace xamarin { namespace android { namespace internal {
 		TypeMappingInfo          *next;
 	};
 #endif // DEBUG || !ANDROID
-}}}
+}
 
 using namespace xamarin::android;
 using namespace xamarin::android::internal;
@@ -139,7 +140,7 @@ EmbeddedAssemblies::find_entry_in_type_map (const char *name, uint8_t map[], Typ
 	return e + header.value_offset;
 }
 
-inline const char*
+const char*
 EmbeddedAssemblies::typemap_java_to_managed (const char *java)
 {
 #if defined (DEBUG) || !defined (ANDROID)
@@ -154,7 +155,7 @@ EmbeddedAssemblies::typemap_java_to_managed (const char *java)
 	return find_entry_in_type_map (java, jm_typemap, jm_typemap_header);
 }
 
-inline const char*
+const char*
 EmbeddedAssemblies::typemap_managed_to_java (const char *managed)
 {
 #if defined (DEBUG) || !defined (ANDROID)
@@ -167,18 +168,6 @@ EmbeddedAssemblies::typemap_managed_to_java (const char *managed)
 	}
 #endif
 	return find_entry_in_type_map (managed, mj_typemap, mj_typemap_header);
-}
-
-MONO_API const char *
-monodroid_typemap_java_to_managed (const char *java)
-{
-	return embeddedAssemblies.typemap_java_to_managed (java);
-}
-
-MONO_API const char *
-monodroid_typemap_managed_to_java (const char *managed)
-{
-	return embeddedAssemblies.typemap_managed_to_java (managed);
 }
 
 #if defined (DEBUG) || !defined (ANDROID)
@@ -274,8 +263,8 @@ EmbeddedAssemblies::md_mmap_apk_file (int fd, uint32_t offset, uint32_t size, co
 	file_info.size  = size;
 
 	log_info (LOG_ASSEMBLY, "                       mmap_start: %08p  mmap_end: %08p  mmap_len: % 12u  file_start: %08p  file_end: %08p  file_len: % 12u      apk: %s  file: %s",
-			mmap_info.area, reinterpret_cast<int*> (mmap_info.area) + mmap_info.size, (unsigned int) mmap_info.size,
-			file_info.area, reinterpret_cast<int*> (file_info.area) + file_info.size, (unsigned int) file_info.size, apk, filename);
+	          mmap_info.area, reinterpret_cast<int*> (mmap_info.area) + mmap_info.size, (unsigned int) mmap_info.size,
+	          file_info.area, reinterpret_cast<int*> (file_info.area) + file_info.size, (unsigned int) file_info.size, apk, filename);
 
 	return file_info;
 }
@@ -379,10 +368,4 @@ EmbeddedAssemblies::register_from (const char *apk_file, monodroid_should_regist
 	}
 
 	return bundled_assemblies_count;
-}
-
-MONO_API int monodroid_embedded_assemblies_set_assemblies_prefix (const char *prefix)
-{
-	embeddedAssemblies.set_assemblies_prefix (prefix);
-	return 0;
 }

--- a/src/monodroid/jni/embedded-assemblies.hh
+++ b/src/monodroid/jni/embedded-assemblies.hh
@@ -98,7 +98,7 @@ namespace xamarin::android::internal {
 
 	private:
 		bool                   register_debug_symbols;
-		MonoBundledAssembly  **bundled_assemblies;
+		MonoBundledAssembly  **bundled_assemblies = nullptr;
 		size_t                 bundled_assemblies_count;
 #if defined (DEBUG) || !defined (ANDROID)
 		TypeMappingInfo       *java_to_managed_maps;

--- a/src/monodroid/jni/external-api.cc
+++ b/src/monodroid/jni/external-api.cc
@@ -1,0 +1,203 @@
+#ifdef WINDOWS
+#include <windef.h>
+#include <winbase.h>
+#include <shlobj.h>
+#include <objbase.h>
+#include <knownfolders.h>
+#include <shlwapi.h>
+#endif
+
+#include "globals.hh"
+
+using namespace xamarin::android::internal;
+
+/* Invoked by System.Core.dll!System.IO.MemoryMappedFiles.MemoryMapImpl.getpagesize */
+MONO_API int
+monodroid_getpagesize (void)
+{
+#ifndef WINDOWS
+	return getpagesize ();
+#else
+	SYSTEM_INFO info;
+	GetSystemInfo (&info);
+	return info.dwPageSize;
+#endif
+}
+
+/* Invoked by:
+   - System.Core.dll!System.TimeZoneInfo.Android.GetDefaultTimeZoneName
+   - Mono.Android.dll!Android.Runtime.AndroidEnvironment.GetDefaultTimeZone
+*/
+
+MONO_API void
+monodroid_free (void *ptr)
+{
+	free (ptr);
+}
+
+MONO_API int
+monodroid_get_system_property (const char *name, char **value)
+{
+	return androidSystem.monodroid_get_system_property (name, value);
+}
+
+MONO_API int
+_monodroid_max_gref_get (void)
+{
+	return static_cast<int>(androidSystem.get_max_gref_count ());
+}
+
+MONO_API int
+_monodroid_gref_get (void)
+{
+	return osBridge.get_gc_gref_count ();
+}
+
+MONO_API void
+_monodroid_gref_log (const char *message)
+{
+	osBridge._monodroid_gref_log (message);
+}
+
+MONO_API int
+_monodroid_gref_log_new (jobject curHandle, char curType, jobject newHandle, char newType, const char *threadName, int threadId, const char *from, int from_writable)
+{
+	return osBridge._monodroid_gref_log_new (curHandle, curType, newHandle, newType, threadName, threadId, from, from_writable);
+}
+
+MONO_API void
+_monodroid_gref_log_delete (jobject handle, char type, const char *threadName, int threadId, const char *from, int from_writable)
+{
+	osBridge._monodroid_gref_log_delete (handle, type, threadName, threadId, from, from_writable);
+}
+
+MONO_API void
+_monodroid_weak_gref_new (jobject curHandle, char curType, jobject newHandle, char newType, const char *threadName, int threadId, const char *from, int from_writable)
+{
+	osBridge._monodroid_weak_gref_new (curHandle, curType, newHandle, newType, threadName, threadId, from, from_writable);
+}
+
+MONO_API void
+_monodroid_weak_gref_delete (jobject handle, char type, const char *threadName, int threadId, const char *from, int from_writable)
+{
+	osBridge._monodroid_weak_gref_delete (handle, type, threadName, threadId, from, from_writable);
+}
+
+MONO_API void
+_monodroid_lref_log_new (int lrefc, jobject handle, char type, const char *threadName, int threadId, const char *from, int from_writable)
+{
+	osBridge._monodroid_lref_log_new (lrefc, handle, type, threadName, threadId, from, from_writable);
+}
+
+MONO_API void
+_monodroid_lref_log_delete (int lrefc, jobject handle, char type, const char *threadName, int threadId, const char *from, int from_writable)
+{
+	osBridge._monodroid_lref_log_delete (lrefc, handle, type, threadName, threadId, from, from_writable);
+}
+
+MONO_API void
+_monodroid_gc_wait_for_bridge_processing (void)
+{
+	mono_gc_wait_for_bridge_processing ();
+}
+
+/* !DO NOT REMOVE! Used by Mono BCL */
+MONO_API int
+_monodroid_get_android_api_level (void)
+{
+	return monodroidRuntime.get_android_api_level ();
+}
+
+/* Can be called by a native debugger to break the wait on startup */
+MONO_API void
+monodroid_clear_gdb_wait (void)
+{
+	monodroidRuntime.set_monodroid_gdb_wait (false);
+}
+
+MONO_API void*
+_monodroid_get_identity_hash_code (JNIEnv *env, void *v)
+{
+	intptr_t rv = env->CallStaticIntMethod (monodroidRuntime.get_java_class_System (), monodroidRuntime.get_java_class_method_System_identityHashCode (), v);
+	return (void*) rv;
+}
+
+MONO_API void*
+_monodroid_timezone_get_default_id (void)
+{
+	JNIEnv *env          = osBridge.ensure_jnienv ();
+	jmethodID getDefault = env->GetStaticMethodID (monodroidRuntime.get_java_class_TimeZone (), "getDefault", "()Ljava/util/TimeZone;");
+	jmethodID getID      = env->GetMethodID (monodroidRuntime.get_java_class_TimeZone (), "getID",      "()Ljava/lang/String;");
+	jobject d            = env->CallStaticObjectMethod (monodroidRuntime.get_java_class_TimeZone (), getDefault);
+	jstring id           = reinterpret_cast<jstring> (env->CallObjectMethod (d, getID));
+	const char *mutf8    = env->GetStringUTFChars (id, nullptr);
+	char *def_id         = strdup (mutf8);
+
+	env->ReleaseStringUTFChars (id, mutf8);
+	env->DeleteLocalRef (id);
+	env->DeleteLocalRef (d);
+
+	return def_id;
+}
+
+MONO_API void
+_monodroid_counters_dump (const char *format, ...)
+{
+	va_list args;
+	va_start (args, format);
+	monodroidRuntime.dump_counters_v (format, args);
+	va_end (args);
+}
+
+/* !DO NOT REMOVE! Used by libgdiplus.so */
+MONO_API int
+_monodroid_get_display_dpi (float *x_dpi, float *y_dpi)
+{
+	return monodroidRuntime.get_display_dpi (x_dpi, y_dpi);
+}
+
+MONO_API const char *
+monodroid_typemap_java_to_managed (const char *java)
+{
+	return embeddedAssemblies.typemap_java_to_managed (java);
+}
+
+MONO_API const char *
+monodroid_typemap_managed_to_java (const char *managed)
+{
+	return embeddedAssemblies.typemap_managed_to_java (managed);
+}
+
+MONO_API int monodroid_embedded_assemblies_set_assemblies_prefix (const char *prefix)
+{
+	embeddedAssemblies.set_assemblies_prefix (prefix);
+	return 0;
+}
+
+extern "C" void* monodroid_dylib_mono_new (const char *libmono_path)
+{
+	return nullptr;
+}
+
+extern "C" void monodroid_dylib_mono_free (void *mono_imports)
+{
+	// no-op
+}
+
+/*
+  this function is used from JavaInterop and should be treated as public API
+  https://github.com/xamarin/java.interop/blob/master/src/java-interop/java-interop-gc-bridge-mono.c#L266
+
+  it should also accept libmono_path = nullptr parameter
+*/
+extern "C" int monodroid_dylib_mono_init (void *mono_imports, const char *libmono_path)
+{
+	if (mono_imports == nullptr)
+		return FALSE;
+	return TRUE;
+}
+
+extern "C" void*  monodroid_get_dylib (void)
+{
+	return nullptr;
+}

--- a/src/monodroid/jni/globals.cc
+++ b/src/monodroid/jni/globals.cc
@@ -7,10 +7,8 @@ Util utils;
 AndroidSystem androidSystem;
 OSBridge osBridge;
 EmbeddedAssemblies embeddedAssemblies;
+MonodroidRuntime monodroidRuntime;
 #ifndef ANDROID
 InMemoryAssemblies inMemoryAssemblies;
 #endif
-
-#ifdef DEBUG
 Debug debug;
-#endif

--- a/src/monodroid/jni/globals.hh
+++ b/src/monodroid/jni/globals.hh
@@ -9,16 +9,14 @@
 #include "monodroid-glue-internal.hh"
 #include "cppcompat.hh"
 
+extern xamarin::android::Debug debug;
 extern xamarin::android::Util utils;
 extern xamarin::android::internal::AndroidSystem androidSystem;
 extern xamarin::android::internal::OSBridge osBridge;
 extern xamarin::android::internal::EmbeddedAssemblies embeddedAssemblies;
+extern xamarin::android::internal::MonodroidRuntime monodroidRuntime;
 #ifndef ANDROID
 extern xamarin::android::internal::InMemoryAssemblies inMemoryAssemblies;
-#endif
-
-#ifdef DEBUG
-extern xamarin::android::Debug debug;
 #endif
 
 #endif // !__GLOBALS_H

--- a/src/monodroid/jni/logger.cc
+++ b/src/monodroid/jni/logger.cc
@@ -12,7 +12,7 @@
 #include "logger.hh"
 
 #include "monodroid.h"
-#include "monodroid-glue.h"
+#include "monodroid-glue.hh"
 #include "debug.hh"
 #include "util.hh"
 #include "globals.hh"

--- a/src/monodroid/jni/mkbundle-api.h
+++ b/src/monodroid/jni/mkbundle-api.h
@@ -19,6 +19,9 @@ typedef struct BundleMonoAPI
 #include <stdarg.h>
 #include <android/log.h>
 
+#ifdef __cplusplus
+[[maybe_unused]]
+#endif
 static void
 mkbundle_log_error (const char *format, ...)
 {

--- a/src/monodroid/jni/monodroid-glue-internal.hh
+++ b/src/monodroid/jni/monodroid-glue-internal.hh
@@ -6,15 +6,203 @@
 #include "android-system.hh"
 #include "osbridge.hh"
 
+#include <mono/utils/mono-counters.h>
+#include <mono/metadata/profiler.h>
+
 namespace xamarin::android::internal
 {
-	extern char *primary_override_dir;
-	extern char *external_override_dir;
-	extern char *external_legacy_override_dir;
-	extern char *runtime_libdir;
-
 	class MonodroidRuntime
 	{
+#if defined (DEBUG) && !defined (WINDOWS)
+		typedef struct {
+			int debug;
+			int loglevel;
+			int64_t timeout_time;
+			char *host;
+			uint16_t sdb_port, out_port;
+			mono_bool server;
+		} RuntimeOptions;
+#endif
+
+		struct JnienvInitializeArgs {
+			JavaVM         *javaVm;
+			JNIEnv         *env;
+			jobject         grefLoader;
+			jmethodID       Loader_loadClass;
+			jclass          grefClass;
+			jmethodID       Class_forName;
+			unsigned int    logCategories;
+			jmethodID       Class_getName;
+			int             version;
+			int             androidSdkVersion;
+			int             localRefsAreIndirect;
+			int             grefGcThreshold;
+			jobject         grefIGCUserPeer;
+			int             isRunningOnDesktop;
+		};
+
+	private:
+		static constexpr float DEFAULT_X_DPI = 120.0f;
+		static constexpr float DEFAULT_Y_DPI = 120.0f;
+		static constexpr bool is_running_on_desktop =
+#if ANDROID
+		false;
+#else
+		true;
+#endif
+
+	public:
+		static constexpr int XA_LOG_COUNTERS = MONO_COUNTER_JIT | MONO_COUNTER_METADATA | MONO_COUNTER_GC | MONO_COUNTER_GENERICS;
+
+	public:
+		void Java_mono_android_Runtime_register (JNIEnv *env, jclass klass, jstring managedType, jclass nativeClass, jstring methods);
+		void Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApksJava,
+		                                             jstring runtimeNativeLibDir, jobjectArray appDirs, jobject loader,
+		                                             jobjectArray externalStorageDirs, jobjectArray assembliesJava,
+		                                             jint apiLevel, jboolean embeddedDSOsEnabled);
+		jint Java_mono_android_Runtime_createNewContextWithData (JNIEnv *env, jclass klass, jobjectArray runtimeApksJava, jobjectArray assembliesJava,
+		                                                         jobjectArray assembliesBytes, jobject loader, jboolean force_preload_assemblies);
+		void Java_mono_android_Runtime_switchToContext (JNIEnv *env, jclass klass, jint contextID);
+		void Java_mono_android_Runtime_destroyContexts (JNIEnv *env, jclass klass, jintArray array);
+		jint Java_JNI_OnLoad (JavaVM *vm, void *reserved);
+
+		int get_android_api_level () const
+		{
+			return android_api_level;
+		}
+
+		jclass get_java_class_System () const
+		{
+			return java_System;
+		}
+
+		jmethodID get_java_class_method_System_identityHashCode () const
+		{
+			return java_System_identityHashCode;
+		}
+
+		jclass get_java_class_TimeZone () const
+		{
+			return java_TimeZone;
+		}
+
+		void set_monodroid_gdb_wait (bool yes_no)
+		{
+			monodroid_gdb_wait = yes_no;
+		}
+
+		FILE *get_counters () const
+		{
+			return counters;
+		}
+
+		int get_display_dpi (float *x_dpi, float *y_dpi);
+		void propagate_uncaught_exception (MonoDomain *domain, JNIEnv *env, jobject javaThread, jthrowable javaException);
+
+		// The reason we don't use the C++ overload feature here is that there appears to be an issue in clang++ that
+		// comes with the Android NDK. The issue is that for calls like:
+		//
+		//   char *s = "something";
+		//   dump_counters ("My string: %s", s);
+		//
+		// the compiler will resolve the overload taking `va_list` instead of the one with the ellipsis, thus causing
+		// `vfprintf` to segfault while trying to perform a `strlen` on `args`.
+		//
+		// The issue appears to stem from the fact that `va_list` in the NDK is a typedef to `__builtin_va_list` which
+		// in turn is internally defined by clang to be `char*`
+		//
+		// Desktop builds (using both clang++ and g++) do NOT appear to have this issue, so it might be a problem in the
+		// NDK. More investigation would be required, but for now lets work around the issue by not overloading the 
+		// function
+		void dump_counters (const char *format, ...);
+		void dump_counters_v (const char *format, va_list args);
+
+	private:
+		int convert_dl_flags (int flags);
+		static void* monodroid_dlopen (const char *name, int flags, char **err, void *user_data);
+		static void* monodroid_dlsym (void *handle, const char *name, char **err, void *user_data);
+		static void* monodroid_dlopen_log_and_return (void *handle, char **err, const char *full_name, bool free_memory);
+		int LocalRefsAreIndirect (JNIEnv *env, jclass runtimeClass, int version);
+		void create_xdg_directory (jstring_wrapper& home, const char *relativePath, const char *environmentVariableName);
+		void create_xdg_directories_and_environment (JNIEnv *env, jstring_wrapper &homeDir);
+		void disable_external_signal_handlers ();
+		void lookup_bridge_info (MonoDomain *domain, MonoImage *image, const OSBridge::MonoJavaGCBridgeType *type, OSBridge::MonoJavaGCBridgeInfo *info);
+		void load_assembly (MonoDomain *domain, JNIEnv *env, jstring_wrapper &assembly);
+		void load_assemblies (MonoDomain *domain, JNIEnv *env, jstring_array_wrapper &assemblies);
+		void set_debug_options ();
+		void parse_gdb_options ();
+		void mono_runtime_init (char *runtime_args);
+		void setup_bundled_app (const char *dso_name);
+		void init_android_runtime (MonoDomain *domain, JNIEnv *env, jclass runtimeClass, jobject loader);
+		void set_environment_variable_for_directory (JNIEnv *env, const char *name, jstring_wrapper &value, bool createDirectory, mode_t mode);
+
+		void set_environment_variable_for_directory (JNIEnv *env, const char *name, jstring_wrapper &value)
+		{
+			set_environment_variable_for_directory (env, name, value, true, DEFAULT_DIRECTORY_MODE);
+		}
+
+		void set_environment_variable (JNIEnv *env, const char *name, jstring_wrapper &value)
+		{
+			set_environment_variable_for_directory (env, name, value, false, 0);
+		}
+
+		MonoClass* get_android_runtime_class (MonoDomain *domain);
+		void shutdown_android_runtime (MonoDomain *domain);
+		MonoDomain*	create_domain (JNIEnv *env, jclass runtimeClass, jstring_array_wrapper &runtimeApks, jobject loader, bool is_root_domain);
+		MonoDomain* create_and_initialize_domain (JNIEnv* env, jclass runtimeClass, jstring_array_wrapper &runtimeApks,
+		                                          jstring_array_wrapper &assemblies, jobjectArray assembliesBytes,
+		                                          jobject loader, bool is_root_domain, bool force_preload_assemblies);
+
+		void gather_bundled_assemblies (JNIEnv *env, jstring_array_wrapper &runtimeApks,
+		                                bool register_debug_symbols, size_t *out_user_assemblies_count);
+		static bool should_register_file (const char *filename);
+		void set_trace_options ();
+		void set_profile_options (JNIEnv *env);
+
+		void log_jit_event (MonoMethod *method, const char *event_name);
+		static void jit_begin (MonoProfiler *prof, MonoMethod *method);
+		static void jit_failed (MonoProfiler *prof, MonoMethod *method);
+		static void jit_done (MonoProfiler *prof, MonoMethod *method, MonoJitInfo* jinfo);
+		static void thread_start (MonoProfiler *prof, uintptr_t tid);
+		static void thread_end (MonoProfiler *prof, uintptr_t tid);
+
+#if defined (DEBUG)
+		void set_debug_env_vars (void);
+
+#if !defined (WINDOWS)
+		int parse_runtime_args (char *runtime_args, RuntimeOptions *options);
+		int monodroid_debug_connect (int sock, struct sockaddr_in addr);
+		int monodroid_debug_accept (int sock, struct sockaddr_in addr);
+#endif // !WINDOWS
+#endif // DEBUG
+
+#if !defined (RELEASE)
+		static MonoAssembly* open_from_update_dir (MonoAssemblyName *aname, char **assemblies_path, void *user_data);
+#endif
+	private:
+		MonoMethod         *registerType          = nullptr;
+		MonoMethod         *runtime_GetDisplayDPI = nullptr;
+		int                 android_api_level     = 0;
+		volatile bool       monodroid_gdb_wait    = true;
+		jclass              java_System;
+		jmethodID           java_System_identityHashCode;
+		jclass              java_TimeZone;
+		timing_period       jit_time;
+		FILE               *jit_log;
+		MonoProfilerHandle  profiler_handle;
+		FILE               *counters;
+		/*
+		 * If set, monodroid will spin in a loop until the debugger breaks the wait by
+		 * clearing monodroid_gdb_wait.
+		 */
+		bool                wait_for_gdb;
+
+		/* The context (mapping to a Mono AppDomain) that is currently selected as the
+		 * active context from the point of view of Java. We cannot rely on the value
+		 * of `mono_domain_get` for this as it's stored per-thread and we want to be
+		 * able to switch our different contexts from different threads.
+		 */
+		int                 current_context_id = -1;
 	};
 }
 #endif

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -24,8 +24,6 @@
 #include <mono/metadata/debug-helpers.h>
 #include <mono/metadata/mono-config.h>
 #include <mono/metadata/mono-debug.h>
-#include <mono/metadata/profiler.h>
-#include <mono/utils/mono-counters.h>
 #include <mono/utils/mono-dl-fallback.h>
 
 #include "mono_android_Runtime.h"
@@ -66,7 +64,7 @@
 #include "util.hh"
 #include "debug.hh"
 #include "embedded-assemblies.hh"
-#include "monodroid-glue.h"
+#include "monodroid-glue.hh"
 #include "mkbundle-api.h"
 #include "monodroid-glue-internal.hh"
 #include "globals.hh"
@@ -76,7 +74,7 @@
 #include "xamarin_getifaddrs.h"
 #endif
 
-#define XA_LOG_COUNTERS (MONO_COUNTER_JIT | MONO_COUNTER_METADATA | MONO_COUNTER_GC | MONO_COUNTER_GENERICS)
+#include "cpp-util.hh"
 
 using namespace xamarin::android;
 using namespace xamarin::android::internal;
@@ -85,81 +83,13 @@ using namespace xamarin::android::internal;
 // implementation details as it would prevent mkbundle from working
 #include "mkbundle-api.h"
 
-// TODO: all of these must be moved to some class
-static pthread_mutex_t process_cmd_mutex = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t process_cmd_cond = PTHREAD_COND_INITIALIZER;
-static int debugging_configured;
-static int sdb_fd;
-static int profiler_configured;
-static int profiler_fd;
-static char *profiler_description;
-#if DEBUG && !defined (WINDOWS)
-static int config_timedout;
-static struct timeval wait_tv;
-static struct timespec wait_ts;
-#endif  // def DEBUG
-static MonoMethod* registerType;
-/*
- * If set, monodroid will spin in a loop until the debugger breaks the wait by
- * clearing monodroid_gdb_wait.
- */
-static int wait_for_gdb;
-static volatile int monodroid_gdb_wait = TRUE;
-static int android_api_level = 0;
-
-static timing_period jit_time;
-
 #include "config.include"
 #include "machine.config.include"
-
-/* Can be called by a native debugger to break the wait on startup */
-MONO_API void
-monodroid_clear_gdb_wait (void)
-{
-	monodroid_gdb_wait = FALSE;
-}
 
 #ifdef WINDOWS
 static const char* get_xamarin_android_msbuild_path (void);
 const char *BasicAndroidSystem::SYSTEM_LIB_PATH = get_xamarin_android_msbuild_path();
 #endif
-
-/* !DO NOT REMOVE! Used by Mono BCL */
-MONO_API int
-_monodroid_get_android_api_level (void)
-{
-	return android_api_level;
-}
-
-/* Invoked by System.Core.dll!System.IO.MemoryMappedFiles.MemoryMapImpl.getpagesize */
-MONO_API int
-monodroid_getpagesize (void)
-{
-#ifndef WINDOWS
-	return getpagesize ();
-#else
-	SYSTEM_INFO info;
-	GetSystemInfo (&info);
-	return info.dwPageSize;
-#endif
-}
-
-/* Invoked by:
-    - System.Core.dll!System.TimeZoneInfo.Android.GetDefaultTimeZoneName
-    - Mono.Android.dll!Android.Runtime.AndroidEnvironment.GetDefaultTimeZone
-*/
-
-MONO_API void
-monodroid_free (void *ptr)
-{
-	free (ptr);
-}
-
-MONO_API int
-monodroid_get_system_property (const char *name, char **value)
-{
-	return androidSystem.monodroid_get_system_property (name, value);
-}
 
 /* Set of Windows-specific utility/reimplementation of Unix functions */
 #ifdef WINDOWS
@@ -206,10 +136,8 @@ mono_mkbundle_init_ptr mono_mkbundle_init;
 typedef void (*mono_mkbundle_initialize_mono_api_ptr) (const BundleMonoAPI *info);
 mono_mkbundle_initialize_mono_api_ptr mono_mkbundle_initialize_mono_api;
 
-// This function could be improved if we somehow marked an apk containing just the bundled app as
-// such - perhaps another __XA* environment variable? Would certainly make code faster.
-static void
-setup_bundled_app (const char *dso_name)
+void
+MonodroidRuntime::setup_bundled_app (const char *dso_name)
 {
 	if (!application_config.is_a_bundled_app)
 		return;
@@ -228,7 +156,7 @@ setup_bundled_app (const char *dso_name)
 		if (bundle_path == nullptr)
 			return;
 		log_info (LOG_BUNDLE, "Attempting to load bundled app from %s", bundle_path);
-		libapp = androidSystem.load_dso (bundle_path, dlopen_flags, TRUE);
+		libapp = androidSystem.load_dso (bundle_path, dlopen_flags, true);
 		if (needs_free)
 			delete[] bundle_path;
 	}
@@ -254,97 +182,15 @@ setup_bundled_app (const char *dso_name)
 	log_info (LOG_BUNDLE, "Bundled app loaded: %s", dso_name);
 }
 
-typedef struct {
-	void *dummy;
-} MonoDroidProfiler;
-
-static MonoProfilerHandle profiler_handle;
-
-static jclass     TimeZone_class;
-
-static constexpr bool is_running_on_desktop =
-#if ANDROID
-	false;
-#else
-	true;
-#endif
-
-MONO_API int
-_monodroid_max_gref_get (void)
-{
-	return static_cast<int>(androidSystem.get_max_gref_count ());
-}
-
-MONO_API int
-_monodroid_gref_get (void)
-{
-	return osBridge.get_gc_gref_count ();
-}
-
-MONO_API void
-_monodroid_gref_log (const char *message)
-{
-	osBridge._monodroid_gref_log (message);
-}
-
-MONO_API int
-_monodroid_gref_log_new (jobject curHandle, char curType, jobject newHandle, char newType, const char *threadName, int threadId, const char *from, int from_writable)
-{
-	return osBridge._monodroid_gref_log_new (curHandle, curType, newHandle, newType, threadName, threadId, from, from_writable);
-}
-
-MONO_API void
-_monodroid_gref_log_delete (jobject handle, char type, const char *threadName, int threadId, const char *from, int from_writable)
-{
-	osBridge._monodroid_gref_log_delete (handle, type, threadName, threadId, from, from_writable);
-}
-
-MONO_API void
-_monodroid_weak_gref_new (jobject curHandle, char curType, jobject newHandle, char newType, const char *threadName, int threadId, const char *from, int from_writable)
-{
-	osBridge._monodroid_weak_gref_new (curHandle, curType, newHandle, newType, threadName, threadId, from, from_writable);
-}
-
-MONO_API void
-_monodroid_weak_gref_delete (jobject handle, char type, const char *threadName, int threadId, const char *from, int from_writable)
-{
-	osBridge._monodroid_weak_gref_delete (handle, type, threadName, threadId, from, from_writable);
-}
-
-MONO_API void
-_monodroid_lref_log_new (int lrefc, jobject handle, char type, const char *threadName, int threadId, const char *from, int from_writable)
-{
-	osBridge._monodroid_lref_log_new (lrefc, handle, type, threadName, threadId, from, from_writable);
-}
-
-MONO_API void
-_monodroid_lref_log_delete (int lrefc, jobject handle, char type, const char *threadName, int threadId, const char *from, int from_writable)
-{
-	osBridge._monodroid_lref_log_delete (lrefc, handle, type, threadName, threadId, from, from_writable);
-}
-
-JNIEnv*
-get_jnienv (void)
-{
-	return osBridge.ensure_jnienv ();
-}
-
-/* The context (mapping to a Mono AppDomain) that is currently selected as the
- * active context from the point of view of Java. We cannot rely on the value
- * of `mono_domain_get` for this as it's stored per-thread and we want to be
- * able to switch our different contexts from different threads.
- */
-static int current_context_id = -1;
-
-static void
-thread_start (MonoProfiler *prof, uintptr_t tid)
+void
+MonodroidRuntime::thread_start (MonoProfiler *prof, uintptr_t tid)
 {
 	JNIEnv* env;
 	int r;
 #ifdef PLATFORM_ANDROID
 	r = osBridge.get_jvm ()->AttachCurrentThread (&env, nullptr);
 #else   // ndef PLATFORM_ANDROID
-	r = osBridge.get_jvm ()->AttachCurrentThread ((void**) &env, nullptr);
+	r = osBridge.get_jvm ()->AttachCurrentThread (reinterpret_cast<void**>(&env), nullptr);
 #endif  // ndef PLATFORM_ANDROID
 	if (r != JNI_OK) {
 #if DEBUG
@@ -354,8 +200,8 @@ thread_start (MonoProfiler *prof, uintptr_t tid)
 	}
 }
 
-static void
-thread_end (MonoProfiler *prof, uintptr_t tid)
+void
+MonodroidRuntime::thread_end (MonoProfiler *prof, uintptr_t tid)
 {
 	int r;
 	r = osBridge.get_jvm ()->DetachCurrentThread ();
@@ -368,14 +214,12 @@ thread_end (MonoProfiler *prof, uintptr_t tid)
 	}
 }
 
-FILE *jit_log;
-
-static void
-log_jit_event (MonoMethod *method, const char *event_name)
+inline void
+MonodroidRuntime::log_jit_event (MonoMethod *method, const char *event_name)
 {
 	jit_time.mark_end ();
 
-	if (!jit_log)
+	if (jit_log == nullptr)
 		return;
 
 	char* name = mono_method_full_name (method, 1);
@@ -386,30 +230,29 @@ log_jit_event (MonoMethod *method, const char *event_name)
 	free (name);
 }
 
-static void
-jit_begin (MonoProfiler *prof, MonoMethod *method)
+void
+MonodroidRuntime::jit_begin (MonoProfiler *prof, MonoMethod *method)
 {
-	log_jit_event (method, "begin");
+	monodroidRuntime.log_jit_event (method, "begin");
 }
 
-static void
-jit_failed (MonoProfiler *prof, MonoMethod *method)
+void
+MonodroidRuntime::jit_failed (MonoProfiler *prof, MonoMethod *method)
 {
-	log_jit_event (method, "failed");
+	monodroidRuntime.log_jit_event (method, "failed");
 }
 
-static void
-jit_done (MonoProfiler *prof, MonoMethod *method, MonoJitInfo* jinfo)
+void
+MonodroidRuntime::jit_done (MonoProfiler *prof, MonoMethod *method, MonoJitInfo* jinfo)
 {
-	log_jit_event (method, "done");
+	monodroidRuntime.log_jit_event (method, "done");
 }
 
 #ifndef RELEASE
 MonoAssembly*
-open_from_update_dir (MonoAssemblyName *aname, char **assemblies_path, void *user_data)
+MonodroidRuntime::open_from_update_dir (MonoAssemblyName *aname, char **assemblies_path, void *user_data)
 {
 	MonoAssembly *result = nullptr;
-	int found = 0;
 
 #ifndef ANDROID
 	// First check if there are any in-memory assemblies
@@ -425,45 +268,55 @@ open_from_update_dir (MonoAssemblyName *aname, char **assemblies_path, void *use
 		log_debug (LOG_ASSEMBLY, "No in-memory assemblies detected", mono_assembly_name_get_name (aname));
 	}
 #endif
+	const char *override_dir;
+	bool found = false;
 
-	const char *culture = reinterpret_cast<const char*> (mono_assembly_name_get_culture (aname));
-	const char *name    = reinterpret_cast<const char*> (mono_assembly_name_get_name (aname));
-	char *pname;
-
-	for (uint32_t oi = 0; oi < AndroidSystem::MAX_OVERRIDES; ++oi)
-		if (androidSystem.get_override_dir (oi) != nullptr && utils.directory_exists (androidSystem.get_override_dir (oi)))
-			found = 1;
+	for (uint32_t oi = 0; oi < AndroidSystem::MAX_OVERRIDES; ++oi) {
+		override_dir = androidSystem.get_override_dir (oi);
+		if (override_dir != nullptr && utils.directory_exists (override_dir)) {
+			found = true;
+			break;
+		}
+	}
 	if (!found)
 		return nullptr;
 
-	if (culture != nullptr && strlen (culture) > 0)
-		pname = utils.path_combine (culture, name);
-	else
-		pname = utils.strdup_new (name);
+	const char *culture = reinterpret_cast<const char*> (mono_assembly_name_get_culture (aname));
+	const char *name    = reinterpret_cast<const char*> (mono_assembly_name_get_name (aname));
+	char *pname_raw_ptr;
 
-	static const char *formats[] = {
+	if (culture != nullptr && *culture != '\0')
+		pname_raw_ptr = utils.path_combine (culture, name);
+	else
+		pname_raw_ptr = utils.strdup_new (name);
+
+	simple_pointer_guard<char[]> pname (pname_raw_ptr);
+
+	constexpr const char *formats[] = {
 		"%s" MONODROID_PATH_SEPARATOR "%s",
 		"%s" MONODROID_PATH_SEPARATOR "%s.dll",
 		"%s" MONODROID_PATH_SEPARATOR "%s.exe",
 	};
+	constexpr size_t nformats = sizeof (formats)/sizeof (formats [0]);
 
-	for (size_t fi = 0; fi < sizeof (formats)/sizeof (formats [0]) && result == nullptr; ++fi) {
+	for (size_t fi = 0; fi < nformats && result == nullptr; ++fi) {
 		for (uint32_t oi = 0; oi < AndroidSystem::MAX_OVERRIDES; ++oi) {
-			char *fullpath;
-			if (androidSystem.get_override_dir (oi) == nullptr || !utils.directory_exists (androidSystem.get_override_dir (oi)))
+			override_dir = androidSystem.get_override_dir (oi);
+			if (override_dir == nullptr || !utils.directory_exists (override_dir))
 				continue;
-			fullpath = utils.monodroid_strdup_printf (formats [fi], androidSystem.get_override_dir (oi), pname);
-			log_info (LOG_ASSEMBLY, "open_from_update_dir: trying to open assembly: %s\n", fullpath);
+
+			simple_pointer_guard<char, false> fullpath (utils.monodroid_strdup_printf (formats [fi], override_dir, pname.get ()));
+
+			log_info (LOG_ASSEMBLY, "open_from_update_dir: trying to open assembly: %s\n", static_cast<const char*>(fullpath));
 			if (utils.file_exists (fullpath))
 				result = mono_assembly_open_full (fullpath, nullptr, 0);
-			free (fullpath);
 			if (result) {
 				// TODO: register .mdb, .pdb file
 				break;
 			}
 		}
 	}
-	delete[] pname;
+
 	if (result && utils.should_log (LOG_ASSEMBLY)) {
 		log_info_nocheck (LOG_ASSEMBLY, "open_from_update_dir: loaded assembly: %p\n", result);
 	}
@@ -472,7 +325,7 @@ open_from_update_dir (MonoAssemblyName *aname, char **assemblies_path, void *use
 #endif
 
 bool
-should_register_file (const char *filename)
+MonodroidRuntime::should_register_file (const char *filename)
 {
 #ifndef RELEASE
 	for (size_t i = 0; i < AndroidSystem::MAX_OVERRIDES; ++i) {
@@ -480,9 +333,8 @@ should_register_file (const char *filename)
 		if (odir == nullptr)
 			continue;
 
-		char *p       = utils.path_combine (odir, filename);
+		simple_pointer_guard<char[]> p (utils.path_combine (odir, filename));
 		bool  exists  = utils.file_exists (p);
-		delete[] p;
 
 		if (exists) {
 			log_info (LOG_ASSEMBLY, "should not register '%s' as it exists in the override directory '%s'", filename, odir);
@@ -493,8 +345,8 @@ should_register_file (const char *filename)
 	return true;
 }
 
-static void
-gather_bundled_assemblies (JNIEnv *env, jstring_array_wrapper &runtimeApks, bool register_debug_symbols, size_t *out_user_assemblies_count)
+inline void
+MonodroidRuntime::gather_bundled_assemblies (JNIEnv *env, jstring_array_wrapper &runtimeApks, bool register_debug_symbols, size_t *out_user_assemblies_count)
 {
 #if defined(DEBUG) || !defined (ANDROID)
 	for (size_t i = 0; i < AndroidSystem::MAX_OVERRIDES; ++i) {
@@ -506,12 +358,12 @@ gather_bundled_assemblies (JNIEnv *env, jstring_array_wrapper &runtimeApks, bool
 	}
 #endif
 
+	int64_t apk_count = static_cast<int64_t>(runtimeApks.get_length ());
 	size_t prev_num_assemblies = 0;
-	for (int64_t i = static_cast<int64_t>(runtimeApks.get_length () - 1); i >= 0; --i) {
-		size_t           cur_num_assemblies;
+	for (int64_t i = apk_count - 1; i >= 0; --i) {
 		jstring_wrapper &apk_file = runtimeApks [static_cast<size_t>(i)];
 
-		cur_num_assemblies  = embeddedAssemblies.register_from<should_register_file> (apk_file.get_cstr ());
+		size_t cur_num_assemblies  = embeddedAssemblies.register_from<should_register_file> (apk_file.get_cstr ());
 
 		if (strstr (apk_file.get_cstr (), "/Mono.Android.DebugRuntime") == nullptr &&
 		    strstr (apk_file.get_cstr (), "/Mono.Android.Platform.ApiLevel_") == nullptr)
@@ -521,25 +373,24 @@ gather_bundled_assemblies (JNIEnv *env, jstring_array_wrapper &runtimeApks, bool
 }
 
 #if defined (DEBUG) && !defined (WINDOWS)
-int monodroid_debug_connect (int sock, struct sockaddr_in addr) {
-	long flags = 0;
-	int res = 0;
-	fd_set fds;
-	struct timeval tv;
-	socklen_t len;
-	int val = 0;
-
-	flags = fcntl (sock, F_GETFL, nullptr);
+int
+MonodroidRuntime::monodroid_debug_connect (int sock, struct sockaddr_in addr)
+{
+	long flags = fcntl (sock, F_GETFL, nullptr);
 	flags |= O_NONBLOCK;
 	fcntl (sock, F_SETFL, flags);
 
-	res = connect (sock, (struct sockaddr *) &addr, sizeof (addr));
+	int res = connect (sock, (struct sockaddr *) &addr, sizeof (addr));
 
 	if (res < 0) {
 		if (errno == EINPROGRESS) {
-			while (1) {
+			while (true) {
+				timeval tv;
+
 				tv.tv_sec = 2;
 				tv.tv_usec = 0;
+
+				fd_set fds;
 				FD_ZERO (&fds);
 				FD_SET (sock, &fds);
 
@@ -547,8 +398,8 @@ int monodroid_debug_connect (int sock, struct sockaddr_in addr) {
 
 				if (res <= 0 && errno != EINTR) return -5;
 
-				len = sizeof (int);
-
+				socklen_t len = sizeof (int);
+				int val = 0;
 				if (getsockopt (sock, SOL_SOCKET, SO_ERROR, &val, &len) < 0) return -3;
 
 				if (val) return -4;
@@ -568,13 +419,9 @@ int monodroid_debug_connect (int sock, struct sockaddr_in addr) {
 }
 
 int
-monodroid_debug_accept (int sock, struct sockaddr_in addr)
+MonodroidRuntime::monodroid_debug_accept (int sock, struct sockaddr_in addr)
 {
-	char handshake_msg [128];
-	ssize_t res;
-	int accepted;
-
-	res = bind (sock, (struct sockaddr *) &addr, sizeof (addr));
+	ssize_t res = bind (sock, (struct sockaddr *) &addr, sizeof (addr));
 	if (res < 0)
 		return -1;
 
@@ -582,13 +429,15 @@ monodroid_debug_accept (int sock, struct sockaddr_in addr)
 	if (res < 0)
 		return -2;
 
-	accepted = accept (sock, nullptr, nullptr);
+	int accepted = accept (sock, nullptr, nullptr);
 	if (accepted < 0)
 		return -3;
 
-	sprintf (handshake_msg, "MonoDroid-Handshake\n");
+	constexpr const char handshake_msg [] = "MonoDroid-Handshake\n";
+	constexpr size_t handshake_length = sizeof (handshake_msg) - 1;
+
 	do {
-		res = send (accepted, handshake_msg, strlen (handshake_msg), 0);
+		res = send (accepted, handshake_msg, handshake_length, 0);
 	} while (res == -1 && errno == EINTR);
 	if (res < 0)
 		return -4;
@@ -597,8 +446,8 @@ monodroid_debug_accept (int sock, struct sockaddr_in addr)
 }
 #endif
 
-JNIEXPORT jint JNICALL
-JNI_OnLoad (JavaVM *vm, void *reserved)
+inline jint
+MonodroidRuntime::Java_JNI_OnLoad (JavaVM *vm, void *reserved)
 {
 	JNIEnv *env;
 
@@ -610,8 +459,8 @@ JNI_OnLoad (JavaVM *vm, void *reserved)
 	return JNI_VERSION_1_6;
 }
 
-static void
-parse_gdb_options (void)
+void
+MonodroidRuntime::parse_gdb_options ()
 {
 	char *val;
 
@@ -626,16 +475,15 @@ parse_gdb_options (void)
 		 * The debugger can break the wait by setting 'monodroid_gdb_wait' to 0.
 		 * If the current time is later than <timestamp> + 10s, the property is ignored.
 		 */
-		long long v;
-		int do_wait = TRUE;
+		bool do_wait = true;
 
-		v = atoll (val + strlen ("wait:"));
+		long long v = atoll (val + strlen ("wait:"));
 		if (v > 100000) {
 			time_t secs = time (nullptr);
 
 			if (v + 10 < secs) {
 				log_warn (LOG_DEFAULT, "Found stale %s property with value '%s', not waiting.", Debug::DEBUG_MONO_GDB_PROPERTY, val);
-				do_wait = FALSE;
+				do_wait = false;
 			}
 		}
 
@@ -646,21 +494,12 @@ parse_gdb_options (void)
 }
 
 #if defined (DEBUG) && !defined (WINDOWS)
-typedef struct {
-	int debug;
-	int loglevel;
-	int64_t timeout_time;
-	char *host;
-	uint16_t sdb_port, out_port;
-	mono_bool server;
-} RuntimeOptions;
-
-static int
-parse_runtime_args (char *runtime_args, RuntimeOptions *options)
+int
+MonodroidRuntime::parse_runtime_args (char *runtime_args, RuntimeOptions *options)
 {
 	char **args, **ptr;
 
-	if (!runtime_args)
+	if (runtime_args == nullptr)
 		return 1;
 
 	options->timeout_time = 0;
@@ -756,8 +595,8 @@ parse_runtime_args (char *runtime_args, RuntimeOptions *options)
 }
 #endif  // def DEBUG && !WINDOWS
 
-static void
-set_debug_options (void)
+inline void
+MonodroidRuntime::set_debug_options (void)
 {
 	if (utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_DEBUG_PROPERTY, nullptr) == 0)
 		return;
@@ -766,65 +605,9 @@ set_debug_options (void)
 	mono_debug_init (MONO_DEBUG_FORMAT_MONO);
 }
 
-#ifdef ANDROID
-#ifdef DEBUG
-static const char *soft_breakpoint_kernel_list[] = {
-	"2.6.32.21-g1e30168", nullptr
-};
-
-static int
-enable_soft_breakpoints (void)
+void
+MonodroidRuntime::mono_runtime_init (char *runtime_args)
 {
-	struct utsname name;
-
-	/* This check is to make debugging work on some old Samsung device which had
-	 * a patched kernel that would abort the application after several segfaults
-	 * (with the SIGSEGV being used for single-stepping in Mono)
-	*/
-	uname (&name);
-	for (const char** ptr = soft_breakpoint_kernel_list; *ptr; ptr++) {
-		if (!strcmp (name.release, *ptr)) {
-			log_info (LOG_DEBUGGER, "soft breakpoints enabled due to kernel version match (%s)", name.release);
-			return 1;
-		}
-	}
-
-	char *value;
-	/* Soft breakpoints are enabled by default */
-	if (utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_SOFT_BREAKPOINTS, &value) <= 0) {
-		log_info (LOG_DEBUGGER, "soft breakpoints enabled by default (%s property not defined)", Debug::DEBUG_MONO_SOFT_BREAKPOINTS);
-		return 1;
-	}
-
-	int ret;
-	if (strcmp ("0", value) == 0) {
-		ret = 0;
-		log_info (LOG_DEBUGGER, "soft breakpoints disabled (%s property set to %s)", Debug::DEBUG_MONO_SOFT_BREAKPOINTS, value);
-	} else {
-		ret = 1;
-		log_info (LOG_DEBUGGER, "soft breakpoints enabled (%s property set to %s)", Debug::DEBUG_MONO_SOFT_BREAKPOINTS, value);
-	}
-	delete[] value;
-	return ret;
-}
-#endif /* DEBUG */
-#else  /* !defined (ANDROID) */
-#if defined (DEBUG) && !defined (WINDOWS)
-#ifndef enable_soft_breakpoints
-static int
-enable_soft_breakpoints (void)
-{
-	return 0;
-}
-#endif /* DEBUG */
-#endif // enable_soft_breakpoints
-#endif /* defined (ANDROID) */
-
-static void
-mono_runtime_init (char *runtime_args)
-{
-	char *prop_val;
-
 #if defined (DEBUG) && !defined (WINDOWS)
 	RuntimeOptions options;
 	int64_t cur_time;
@@ -837,34 +620,39 @@ mono_runtime_init (char *runtime_args)
 	} else if (options.debug && cur_time > options.timeout_time) {
 		log_warn (LOG_DEBUGGER, "Not starting the debugger as the timeout value has been reached; current-time: %lli  timeout: %lli", cur_time, options.timeout_time);
 	} else if (options.debug && cur_time <= options.timeout_time) {
-		char *debug_arg;
-		char *debug_options [2];
-
 		embeddedAssemblies.set_register_debug_symbols (true);
 
-		debug_arg = utils.monodroid_strdup_printf ("--debugger-agent=transport=dt_socket,loglevel=%d,address=%s:%d,%sembedding=1", options.loglevel, options.host, options.sdb_port,
-				options.server ? "server=y," : "");
-		debug_options[0] = debug_arg;
+		char *debug_arg = utils.monodroid_strdup_printf (
+			"--debugger-agent=transport=dt_socket,loglevel=%d,address=%s:%d,%sembedding=1",
+			options.loglevel,
+			options.host,
+			options.sdb_port,
+			options.server ? "server=y," : ""
+		);
+
+		char *debug_options [2] = {
+			debug_arg,
+			nullptr
+		};
+
 		// this text is used in unit tests to check the debugger started
 		// do not change it without updating the test.
 		log_warn (LOG_DEBUGGER, "Trying to initialize the debugger with options: %s", debug_arg);
 
 		if (options.out_port > 0) {
-			struct sockaddr_in addr;
-			int sock;
-			int r;
-
-			sock = socket (PF_INET, SOCK_STREAM, IPPROTO_TCP);
+			int sock = socket (PF_INET, SOCK_STREAM, IPPROTO_TCP);
 			if (sock < 0) {
 				log_fatal (LOG_DEBUGGER, "Could not construct a socket for stdout and stderr; does your app have the android.permission.INTERNET permission? %s", strerror (errno));
 				exit (FATAL_EXIT_DEBUGGER_CONNECT);
 			}
 
-			memset(&addr, 0, sizeof (addr));
+			sockaddr_in addr;
+			memset (&addr, 0, sizeof (addr));
 
 			addr.sin_family = AF_INET;
 			addr.sin_port = htons (options.out_port);
 
+			int r;
 			if ((r = inet_pton (AF_INET, options.host, &addr.sin_addr)) != 1) {
 				log_error (LOG_DEBUGGER, "Could not setup a socket for stdout and stderr: %s",
 						r == -1 ? strerror (errno) : "address not parseable in the specified address family");
@@ -894,7 +682,7 @@ mono_runtime_init (char *runtime_args)
 			}
 		}
 
-		if (enable_soft_breakpoints ()) {
+		if (debug.enable_soft_breakpoints ()) {
 			constexpr char soft_breakpoints[] = "--soft-breakpoints";
 			debug_options[1] = const_cast<char*> (soft_breakpoints);
 			mono_jit_parse_options (2, debug_options);
@@ -912,10 +700,9 @@ mono_runtime_init (char *runtime_args)
 
 	bool log_methods = utils.should_log (LOG_TIMING) && !(log_timing_categories & LOG_TIMING_BARE);
 	if (XA_UNLIKELY (log_methods)) {
-		char *jit_log_path = utils.path_combine (androidSystem.get_override_dir (0), "methods.txt");
+		simple_pointer_guard<char[]> jit_log_path = utils.path_combine (androidSystem.get_override_dir (0), "methods.txt");
 		jit_log = utils.monodroid_fopen (jit_log_path, "a");
 		utils.set_world_accessable (jit_log_path);
-		delete[] jit_log_path;
 	}
 
 	profiler_handle = mono_profiler_create (nullptr);
@@ -938,15 +725,15 @@ mono_runtime_init (char *runtime_args)
 		}
 	}
 
+	char *prop_val;
 	/* Additional runtime arguments passed to mono_jit_parse_options () */
 	if (utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_RUNTIME_ARGS_PROPERTY, &prop_val) > 0) {
-		char **args, **ptr;
-		int argc;
+		char **ptr;
 
 		log_warn (LOG_DEBUGGER, "passing '%s' as extra arguments to the runtime.\n", prop_val);
 
-		args = utils.monodroid_strsplit (prop_val, " ", 0);
-		argc = 0;
+		char **args = utils.monodroid_strsplit (prop_val, " ", 0);
+		int argc = 0;
 		delete[] prop_val;
 
 		for (ptr = args; *ptr; ptr++)
@@ -988,10 +775,9 @@ mono_runtime_init (char *runtime_args)
 #endif
 }
 
-static MonoDomain*
-create_domain (JNIEnv *env, jclass runtimeClass, jstring_array_wrapper &runtimeApks, jobject loader, bool is_root_domain)
+MonoDomain*
+MonodroidRuntime::create_domain (JNIEnv *env, jclass runtimeClass, jstring_array_wrapper &runtimeApks, jobject loader, bool is_root_domain)
 {
-	MonoDomain *domain;
 	size_t user_assemblies_count   = 0;;
 
 	gather_bundled_assemblies (env, runtimeApks, embeddedAssemblies.get_register_debug_symbols (), &user_assemblies_count);
@@ -1003,30 +789,30 @@ create_domain (JNIEnv *env, jclass runtimeClass, jstring_array_wrapper &runtimeA
 		exit (FATAL_EXIT_NO_ASSEMBLIES);
 	}
 
+	MonoDomain *domain;
 	if (is_root_domain) {
 		domain = mono_jit_init_version (const_cast<char*> ("RootDomain"), const_cast<char*> ("mobile"));
 	} else {
 		MonoDomain* root_domain = mono_get_root_domain ();
-		char *domain_name = utils.monodroid_strdup_printf ("MonoAndroidDomain%d", android_api_level);
+		simple_pointer_guard<char[], false> domain_name = utils.monodroid_strdup_printf ("MonoAndroidDomain%d", android_api_level);
 		domain = utils.monodroid_create_appdomain (root_domain, domain_name, /*shadow_copy:*/ 1, /*shadow_directory:*/ androidSystem.get_override_dir (0));
-		free (domain_name);
 	}
 
 	if constexpr (is_running_on_desktop) {
 		if (is_root_domain) {
 			// Check that our corlib is coherent with the version of Mono we loaded otherwise
 			// tell the IDE that the project likely need to be recompiled.
-			char* corlib_error_message = const_cast<char*>(mono_check_corlib_version ());
+			simple_pointer_guard<char, false> corlib_error_message_guard = const_cast<char*>(mono_check_corlib_version ());
+			char *corlib_error_message = corlib_error_message_guard.get ();
+
 			if (corlib_error_message == nullptr) {
 				if (!androidSystem.monodroid_get_system_property ("xamarin.studio.fakefaultycorliberrormessage", &corlib_error_message)) {
-					free (corlib_error_message);
 					corlib_error_message = nullptr;
 				}
 			}
 			if (corlib_error_message != nullptr) {
 				jclass ex_klass = env->FindClass ("mono/android/MonoRuntimeException");
 				env->ThrowNew (ex_klass, corlib_error_message);
-				free (corlib_error_message);
 				return nullptr;
 			}
 
@@ -1041,81 +827,24 @@ create_domain (JNIEnv *env, jclass runtimeClass, jstring_array_wrapper &runtimeA
 	return domain;
 }
 
-static jclass System;
-static jmethodID System_identityHashCode;
-
-static int
-LocalRefsAreIndirect (JNIEnv *env, jclass runtimeClass, int version)
+inline int
+MonodroidRuntime::LocalRefsAreIndirect (JNIEnv *env, jclass runtimeClass, int version)
 {
-	if (version < 14)
+	if (version < 14) {
+		java_System = nullptr;
+		java_System_identityHashCode = 0;
 		return 0;
+	}
 
-	System = utils.get_class_from_runtime_field(env, runtimeClass, "java_lang_System", true);
-	System_identityHashCode = env->GetStaticMethodID (System, "identityHashCode", "(Ljava/lang/Object;)I");
+	java_System = utils.get_class_from_runtime_field(env, runtimeClass, "java_lang_System", true);
+	java_System_identityHashCode = env->GetStaticMethodID (java_System, "identityHashCode", "(Ljava/lang/Object;)I");
 
 	return 1;
 }
 
-MONO_API void*
-_monodroid_get_identity_hash_code (JNIEnv *env, void *v)
+int
+MonodroidRuntime::get_display_dpi (float *x_dpi, float *y_dpi)
 {
-	intptr_t rv = env->CallStaticIntMethod (System, System_identityHashCode, v);
-	return (void*) rv;
-}
-
-MONO_API void*
-_monodroid_timezone_get_default_id (void)
-{
-	JNIEnv *env          = osBridge.ensure_jnienv ();
-	jmethodID getDefault = env->GetStaticMethodID (TimeZone_class, "getDefault", "()Ljava/util/TimeZone;");
-	jmethodID getID      = env->GetMethodID (TimeZone_class, "getID",      "()Ljava/lang/String;");
-	jobject d            = env->CallStaticObjectMethod (TimeZone_class, getDefault);
-	jstring id           = reinterpret_cast<jstring> (env->CallObjectMethod (d, getID));
-	const char *mutf8    = env->GetStringUTFChars (id, nullptr);
-	char *def_id         = strdup (mutf8);
-
-	env->ReleaseStringUTFChars (id, mutf8);
-	env->DeleteLocalRef (id);
-	env->DeleteLocalRef (d);
-
-	return def_id;
-}
-
-MONO_API void
-_monodroid_gc_wait_for_bridge_processing (void)
-{
-	mono_gc_wait_for_bridge_processing ();
-}
-
-struct JnienvInitializeArgs {
-	JavaVM         *javaVm;
-	JNIEnv         *env;
-	jobject         grefLoader;
-	jmethodID       Loader_loadClass;
-	jclass          grefClass;
-	jmethodID       Class_forName;
-	unsigned int    logCategories;
-	jmethodID       Class_getName;
-	int             version;
-	int             androidSdkVersion;
-	int             localRefsAreIndirect;
-	int             grefGcThreshold;
-	jobject         grefIGCUserPeer;
-	int             isRunningOnDesktop;
-};
-
-#define DEFAULT_X_DPI 120.0f
-#define DEFAULT_Y_DPI 120.0f
-
-static MonoMethod *runtime_GetDisplayDPI;
-
-/* !DO NOT REMOVE! Used by libgdiplus.so */
-MONO_API int
-_monodroid_get_display_dpi (float *x_dpi, float *y_dpi)
-{
-	void *args[2];
-	MonoObject *exc = nullptr;
-
 	if (!x_dpi) {
 		log_error (LOG_DEFAULT, "Internal error: x_dpi parameter missing in get_display_dpi");
 		return -1;
@@ -1127,7 +856,7 @@ _monodroid_get_display_dpi (float *x_dpi, float *y_dpi)
 	}
 
 	MonoDomain *domain = nullptr;
-	if (!runtime_GetDisplayDPI) {
+	if (runtime_GetDisplayDPI == nullptr) {
 		domain = mono_get_root_domain ();
 		MonoAssembly *assm = utils.monodroid_load_assembly (domain, "Mono.Android");;
 
@@ -1149,10 +878,14 @@ _monodroid_get_display_dpi (float *x_dpi, float *y_dpi)
 		return 0;
 	}
 
-	args [0] = x_dpi;
-	args [1] = y_dpi;
+	void* args [] = {
+		x_dpi,
+		y_dpi,
+	};
+
+	MonoObject *exc = nullptr;
 	utils.monodroid_runtime_invoke (domain != nullptr ? domain : mono_get_root_domain (), runtime_GetDisplayDPI, nullptr, args, &exc);
-	if (exc) {
+	if (exc != nullptr) {
 		*x_dpi = DEFAULT_X_DPI;
 		*y_dpi = DEFAULT_Y_DPI;
 	}
@@ -1160,8 +893,8 @@ _monodroid_get_display_dpi (float *x_dpi, float *y_dpi)
 	return 0;
 }
 
-static void
-lookup_bridge_info (MonoDomain *domain, MonoImage *image, const OSBridge::MonoJavaGCBridgeType *type, OSBridge::MonoJavaGCBridgeInfo *info)
+inline void
+MonodroidRuntime::lookup_bridge_info (MonoDomain *domain, MonoImage *image, const OSBridge::MonoJavaGCBridgeType *type, OSBridge::MonoJavaGCBridgeInfo *info)
 {
 	info->klass             = utils.monodroid_get_class_from_image (domain, image, type->_namespace, type->_typename);
 	info->handle            = mono_class_get_field_from_name (info->klass, const_cast<char*> ("handle"));
@@ -1170,75 +903,64 @@ lookup_bridge_info (MonoDomain *domain, MonoImage *image, const OSBridge::MonoJa
 	info->weak_handle       = mono_class_get_field_from_name (info->klass, const_cast<char*> ("weak_handle"));
 }
 
-static void
-init_android_runtime (MonoDomain *domain, JNIEnv *env, jclass runtimeClass, jobject loader)
+void
+MonodroidRuntime::init_android_runtime (MonoDomain *domain, JNIEnv *env, jclass runtimeClass, jobject loader)
 {
-	MonoAssembly *assm;
-	MonoClass *runtime;
-	MonoImage *image;
-	MonoMethod *method;
-	jclass lrefLoaderClass;
-
-	struct JnienvInitializeArgs init    = {};
-	void *args [1];
-	args [0] = &init;
-
-	init.javaVm                 = osBridge.get_jvm ();
-	init.env                    = env;
-	init.logCategories          = log_categories;
-	init.version                = env->GetVersion ();
-	init.androidSdkVersion      = android_api_level;
-	init.localRefsAreIndirect   = LocalRefsAreIndirect (env, runtimeClass, init.androidSdkVersion);
-	init.isRunningOnDesktop     = is_running_on_desktop;
-
-	// GC threshold is 90% of the max GREF count
-	init.grefGcThreshold        = static_cast<int>(androidSystem.get_gref_gc_threshold ());
-
-	log_warn (LOG_GC, "GREF GC Threshold: %i", init.grefGcThreshold);
-
-	init.grefClass = utils.get_class_from_runtime_field (env, runtimeClass, "java_lang_Class", true);
-	init.Class_getName  = env->GetMethodID (init.grefClass, "getName", "()Ljava/lang/String;");
-	init.Class_forName = env->GetStaticMethodID (init.grefClass, "forName", "(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;");
-
-	assm  = utils.monodroid_load_assembly (domain, "Mono.Android");
-	image = mono_assembly_get_image  (assm);
+	MonoAssembly *assm = utils.monodroid_load_assembly (domain, "Mono.Android");
+	MonoImage *image   = mono_assembly_get_image (assm);
 
 	for (uint32_t i = 0; i < OSBridge::NUM_GC_BRIDGE_TYPES; ++i) {
 		lookup_bridge_info (domain, image, &osBridge.get_java_gc_bridge_type (i), &osBridge.get_java_gc_bridge_info (i));
 	}
 
 	// TODO: try looking up the method by its token
-	runtime                             = utils.monodroid_get_class_from_image (domain, image, "Android.Runtime", "JNIEnv");
-	method                              = mono_class_get_method_from_name (runtime, "Initialize", 1);
+	MonoClass *runtime = utils.monodroid_get_class_from_image (domain, image, "Android.Runtime", "JNIEnv");
+	MonoMethod *method = mono_class_get_method_from_name (runtime, "Initialize", 1);
 
-	if (method == 0) {
+	if (method == nullptr) {
 		log_fatal (LOG_DEFAULT, "INTERNAL ERROR: Unable to find Android.Runtime.JNIEnv.Initialize!");
 		exit (FATAL_EXIT_MISSING_INIT);
 	}
 	/* If running on desktop, we may be swapping in a new Mono.Android image when calling this
 	 * so always make sure we have the freshest handle to the method.
 	 */
-	if (registerType == 0 || is_running_on_desktop) {
+	if (registerType == nullptr || is_running_on_desktop) {
 		registerType = mono_class_get_method_from_name (runtime, "RegisterJniNatives", 5);
 	}
-	if (registerType == 0) {
+	if (registerType == nullptr) {
 		log_fatal (LOG_DEFAULT, "INTERNAL ERROR: Unable to find Android.Runtime.JNIEnv.RegisterJniNatives!");
 		exit (FATAL_EXIT_CANNOT_FIND_JNIENV);
 	}
 	MonoClass *android_runtime_jnienv = runtime;
 	MonoClassField *bridge_processing_field = mono_class_get_field_from_name (runtime, const_cast<char*> ("BridgeProcessing"));
-	if (!android_runtime_jnienv || !bridge_processing_field) {
+	if (android_runtime_jnienv ==nullptr || bridge_processing_field == nullptr) {
 		log_fatal (LOG_DEFAULT, "INTERNAL_ERROR: Unable to find Android.Runtime.JNIEnv.BridgeProcessing");
 		exit (FATAL_EXIT_CANNOT_FIND_JNIENV);
 	}
 
-	lrefLoaderClass = env->GetObjectClass (loader);
-	init.Loader_loadClass = env->GetMethodID (lrefLoaderClass, "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;");
+	jclass lrefLoaderClass = env->GetObjectClass (loader);
+
+	JnienvInitializeArgs init;
+	init.javaVm               = osBridge.get_jvm ();
+	init.env                  = env;
+	init.logCategories        = log_categories;
+	init.version              = env->GetVersion ();
+	init.androidSdkVersion    = android_api_level;
+	init.localRefsAreIndirect = LocalRefsAreIndirect (env, runtimeClass, init.androidSdkVersion);
+	init.isRunningOnDesktop   = is_running_on_desktop;
+
+	// GC threshold is 90% of the max GREF count
+	init.grefGcThreshold      = static_cast<int>(androidSystem.get_gref_gc_threshold ());
+	init.grefClass            = utils.get_class_from_runtime_field (env, runtimeClass, "java_lang_Class", true);
+	init.Class_getName        = env->GetMethodID (init.grefClass, "getName", "()Ljava/lang/String;");
+	init.Class_forName        = env->GetStaticMethodID (init.grefClass, "forName", "(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;");
+	init.Loader_loadClass     = env->GetMethodID (lrefLoaderClass, "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;");
+	init.grefLoader           = env->NewGlobalRef (loader);
+	init.grefIGCUserPeer      = utils.get_class_from_runtime_field (env, runtimeClass, "mono_android_IGCUserPeer", true);
+
 	env->DeleteLocalRef (lrefLoaderClass);
 
-	init.grefLoader = env->NewGlobalRef (loader);
-
-	init.grefIGCUserPeer  = utils.get_class_from_runtime_field(env, runtimeClass, "mono_android_IGCUserPeer", true);
+	log_warn (LOG_GC, "GREF GC Threshold: %i", init.grefGcThreshold);
 
 	osBridge.initialize_on_runtime_init (env, runtimeClass);
 
@@ -1248,6 +970,9 @@ init_android_runtime (MonoDomain *domain, JNIEnv *env, jclass runtimeClass, jobj
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
 		partial_time.mark_start ();
 
+	void *args [] = {
+		&init,
+	};
 	utils.monodroid_runtime_invoke (domain, method, nullptr, args, nullptr);
 
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
@@ -1258,8 +983,8 @@ init_android_runtime (MonoDomain *domain, JNIEnv *env, jclass runtimeClass, jobj
 	}
 }
 
-static MonoClass*
-get_android_runtime_class (MonoDomain *domain)
+inline MonoClass*
+MonodroidRuntime::get_android_runtime_class (MonoDomain *domain)
 {
 	MonoAssembly *assm = utils.monodroid_load_assembly (domain, "Mono.Android");
 	MonoImage *image   = mono_assembly_get_image (assm);
@@ -1268,8 +993,8 @@ get_android_runtime_class (MonoDomain *domain)
 	return runtime;
 }
 
-static void
-shutdown_android_runtime (MonoDomain *domain)
+inline void
+MonodroidRuntime::shutdown_android_runtime (MonoDomain *domain)
 {
 	MonoClass *runtime = get_android_runtime_class (domain);
 	MonoMethod *method = mono_class_get_method_from_name (runtime, "Exit", 0);
@@ -1277,16 +1002,17 @@ shutdown_android_runtime (MonoDomain *domain)
 	utils.monodroid_runtime_invoke (domain, method, nullptr, nullptr, nullptr);
 }
 
-static void
-propagate_uncaught_exception (MonoDomain *domain, JNIEnv *env, jobject javaThread, jthrowable javaException)
+inline void
+MonodroidRuntime::propagate_uncaught_exception (MonoDomain *domain, JNIEnv *env, jobject javaThread, jthrowable javaException)
 {
-	void *args[3];
 	MonoClass *runtime = get_android_runtime_class (domain);
 	MonoMethod *method = mono_class_get_method_from_name (runtime, "PropagateUncaughtException", 3);
 
-	args[0] = &env;
-	args[1] = &javaThread;
-	args[2] = &javaException;
+	void* args[] = {
+		&env,
+		&javaThread,
+		&javaException,
+	};
 	utils.monodroid_runtime_invoke (domain, method, nullptr, args, nullptr);
 }
 
@@ -1301,8 +1027,8 @@ setup_gc_logging (void)
 }
 #endif
 
-static int
-convert_dl_flags (int flags)
+inline int
+MonodroidRuntime::convert_dl_flags (int flags)
 {
 	int lflags = flags & static_cast<int> (MONO_DL_LOCAL) ? 0: RTLD_GLOBAL;
 
@@ -1313,14 +1039,25 @@ convert_dl_flags (int flags)
 	return lflags;
 }
 
-static void*
-monodroid_dlopen (const char *name, int flags, char **err, void *user_data)
+inline void*
+MonodroidRuntime::monodroid_dlopen_log_and_return (void *handle, char **err, const char *full_name, bool free_memory)
 {
-	int dl_flags = convert_dl_flags (flags);
-	void *h = nullptr;
-	char *full_name = nullptr;
-	char *basename = nullptr;
-	mono_bool libmonodroid_fallback = FALSE;
+	if (handle == nullptr && err != nullptr) {
+		*err = utils.monodroid_strdup_printf ("Could not load library: Library '%s' not found.", full_name);
+	}
+
+	if (free_memory) {
+		delete[] full_name;
+	}
+
+	return handle;
+}
+
+void*
+MonodroidRuntime::monodroid_dlopen (const char *name, int flags, char **err, void *user_data)
+{
+	int dl_flags = monodroidRuntime.convert_dl_flags (flags);
+	bool libmonodroid_fallback = false;
 
 	/* name is nullptr when we're P/Invoking __Internal, so remap to libmonodroid */
 	if (name == nullptr) {
@@ -1328,53 +1065,38 @@ monodroid_dlopen (const char *name, int flags, char **err, void *user_data)
 		libmonodroid_fallback = TRUE;
 	}
 
-	h = androidSystem.load_dso_from_any_directories (name, dl_flags);
+	void *h = androidSystem.load_dso_from_any_directories (name, dl_flags);
 	if (h != nullptr) {
-		goto done_and_out;
+		return monodroid_dlopen_log_and_return (h, err, name, false);
 	}
 
 	if (libmonodroid_fallback) {
-		full_name = utils.path_combine (AndroidSystem::SYSTEM_LIB_PATH, "libmonodroid.so");
-		h = androidSystem.load_dso (full_name, dl_flags, FALSE);
-		goto done_and_out;
+		char *full_name = utils.path_combine (AndroidSystem::SYSTEM_LIB_PATH, "libmonodroid.so");
+		h = androidSystem.load_dso (full_name, dl_flags, false);
+		return monodroid_dlopen_log_and_return (h, err, full_name, true);
 	}
 
-	if (!strstr (name, ".dll.so") && !strstr (name, ".exe.so")) {
-		goto done_and_out;
+	if (!utils.ends_with (name, ".dll.so") && !utils.ends_with (name, ".exe.so")) {
+		return monodroid_dlopen_log_and_return (h, err, name, false);
 	}
 
-	basename = const_cast<char*> (strrchr (name, '/'));
-	if (basename != nullptr)
-		basename++;
+	char *basename_part = const_cast<char*> (strrchr (name, '/'));
+	if (basename_part != nullptr)
+		basename_part++;
 	else
-		basename = (char*)name;
+		basename_part = (char*)name;
 
-#if WINDOWS
-	basename = utils.monodroid_strdup_printf ("libaot-%s", basename);
-#else
-	basename = utils.string_concat ("libaot-", basename);
-#endif
+	simple_pointer_guard<char[]> basename = utils.string_concat ("libaot-", basename_part);
 	h = androidSystem.load_dso_from_any_directories (basename, dl_flags);
 
 	if (h != nullptr && XA_UNLIKELY (utils.should_log (LOG_ASSEMBLY)))
-		log_info_nocheck (LOG_ASSEMBLY, "Loaded AOT image '%s'", basename);
-
-  done_and_out:
-	if (!h && err) {
-		*err = utils.monodroid_strdup_printf ("Could not load library: Library '%s' not found.", full_name);
-	}
-#if WINDOWS
-	free (basename);
-#else
-	delete[] basename;
-#endif
-	delete[] full_name;
+		log_info_nocheck (LOG_ASSEMBLY, "Loaded AOT image '%s'", static_cast<const char*>(basename));
 
 	return h;
 }
 
-static void*
-monodroid_dlsym (void *handle, const char *name, char **err, void *user_data)
+void*
+MonodroidRuntime::monodroid_dlsym (void *handle, const char *name, char **err, void *user_data)
 {
 	void *s;
 
@@ -1387,8 +1109,8 @@ monodroid_dlsym (void *handle, const char *name, char **err, void *user_data)
 	return s;
 }
 
-static void
-set_environment_variable_for_directory (JNIEnv *env, const char *name, jstring_wrapper &value, bool createDirectory, mode_t mode )
+inline void
+MonodroidRuntime::set_environment_variable_for_directory (JNIEnv *env, const char *name, jstring_wrapper &value, bool createDirectory, mode_t mode)
 {
 	if (createDirectory) {
 		int rv = utils.create_directory (value.get_cstr (), mode);
@@ -1398,41 +1120,28 @@ set_environment_variable_for_directory (JNIEnv *env, const char *name, jstring_w
 	setenv (name, value.get_cstr (), 1);
 }
 
-static void
-set_environment_variable_for_directory (JNIEnv *env, const char *name, jstring_wrapper &value)
+inline void
+MonodroidRuntime::create_xdg_directory (jstring_wrapper& home, const char *relativePath, const char *environmentVariableName)
 {
-	set_environment_variable_for_directory (env, name, value, true, DEFAULT_DIRECTORY_MODE);
-}
-
-static void
-set_environment_variable (JNIEnv *env, const char *name, jstring_wrapper &value)
-{
-	set_environment_variable_for_directory (env, name, value, false, 0);
-}
-
-static void
-create_xdg_directory (jstring_wrapper& home, const char *relativePath, const char *environmentVariableName)
-{
-	char *dir = utils.path_combine (home.get_cstr (), relativePath);
-	log_info (LOG_DEFAULT, "Creating XDG directory: %s", dir);
+	simple_pointer_guard<char> dir = utils.path_combine (home.get_cstr (), relativePath);
+	log_info (LOG_DEFAULT, "Creating XDG directory: %s", static_cast<char*>(dir));
 	int rv = utils.create_directory (dir, DEFAULT_DIRECTORY_MODE);
 	if (rv < 0 && errno != EEXIST)
-		log_warn (LOG_DEFAULT, "Failed to create XDG directory %s. %s", dir, strerror (errno));
+		log_warn (LOG_DEFAULT, "Failed to create XDG directory %s. %s", static_cast<char*>(dir), strerror (errno));
 	if (environmentVariableName)
 		setenv (environmentVariableName, dir, 1);
-	delete[] dir;
 }
 
-static void
-create_xdg_directories_and_environment (JNIEnv *env, jstring_wrapper &homeDir)
+inline void
+MonodroidRuntime::create_xdg_directories_and_environment (JNIEnv *env, jstring_wrapper &homeDir)
 {
 	create_xdg_directory (homeDir, ".local/share", "XDG_DATA_HOME");
 	create_xdg_directory (homeDir, ".config", "XDG_CONFIG_HOME");
 }
 
 #if DEBUG
-static void
-set_debug_env_vars (void)
+void
+MonodroidRuntime::set_debug_env_vars (void)
 {
 	char *value;
 
@@ -1459,8 +1168,8 @@ set_debug_env_vars (void)
 }
 #endif /* DEBUG */
 
-static void
-set_trace_options (void)
+inline void
+MonodroidRuntime::set_trace_options (void)
 {
 	char *value;
 
@@ -1471,159 +1180,72 @@ set_trace_options (void)
 	delete[] value;
 }
 
-/* Profiler support cribbed from mono/metadata/profiler.c */
-
-typedef void (*ProfilerInitializer) (const char*);
-static constexpr char INITIALIZER_NAME[] = "mono_profiler_init";
-
-static mono_bool
-load_profiler (void *handle, const char *desc, const char *symbol)
+inline void
+MonodroidRuntime::set_profile_options (JNIEnv *env)
 {
-	ProfilerInitializer func = reinterpret_cast<ProfilerInitializer> (dlsym (handle, symbol));
-	log_warn (LOG_DEFAULT, "Looking for profiler init symbol '%s'? %p", symbol, func);
+	constexpr const char mlpd_ext[] = "mlpd";
+	constexpr const char aot_ext[] = "aotprofile";
 
-	if (func) {
-		func (desc);
-		return 1;
-	}
-	return 0;
-}
+	constexpr const char output_arg[] = "output=";
+	constexpr const size_t output_arg_len = sizeof(output_arg) - 1;
 
-static mono_bool
-load_profiler_from_handle (void *dso_handle, const char *desc, const char *name)
-{
-	if (!dso_handle)
-		return FALSE;
-
-	char *symbol;
-#if WINDOWS
-	symbol = utils.monodroid_strdup_printf ("%s_%s", INITIALIZER_NAME, name);
-#else
-	symbol = utils.string_concat (INITIALIZER_NAME, "_", name);
-#endif
-	mono_bool result = load_profiler (dso_handle, desc, symbol);
-#if WINDOWS
-	free (symbol);
-#else
-	delete[] symbol;
-#endif
-	if (result)
-		return TRUE;
-	dlclose (dso_handle);
-	return FALSE;
-}
-
-static void
-monodroid_profiler_load (const char *libmono_path, const char *desc, const char *logfile)
-{
-	const char* col = strchr (desc, ':');
-	char *mname;
-
-	if (col != nullptr) {
-		size_t name_len = static_cast<size_t>(col - desc);
-		size_t alloc_size = ADD_WITH_OVERFLOW_CHECK (size_t, name_len, 1);
-		mname = new char [alloc_size];
-		strncpy (mname, desc, name_len);
-		mname [name_len] = 0;
-	} else {
-		mname = utils.strdup_new (desc);
-	}
-
-	int dlopen_flags = RTLD_LAZY;
-	char *libname;
-#if WINDOWS
-	libname = utils.monodroid_strdup_printf ("libmono-profiler-%s.so", mname);
-#else
-	libname = utils.string_concat ("libmono-profiler-", mname, ".so");
-#endif
-	mono_bool found = 0;
-	void *handle = androidSystem.load_dso_from_any_directories (libname, dlopen_flags);
-	found = load_profiler_from_handle (handle, desc, mname);
-
-	if (!found && libmono_path != nullptr) {
-		char *full_path = utils.path_combine (libmono_path, libname);
-		handle = androidSystem.load_dso (full_path, dlopen_flags, FALSE);
-		delete[] full_path;
-		found = load_profiler_from_handle (handle, desc, mname);
-	}
-
-	if (found && logfile != nullptr)
-		utils.set_world_accessable (logfile);
-
-	if (!found)
-		log_warn (LOG_DEFAULT,
-				"The '%s' profiler wasn't found in the main executable nor could it be loaded from '%s'.",
-				mname,
-				libname);
-
-	delete[] mname;
-	delete[] libname;
-}
-
-static void
-set_profile_options (JNIEnv *env)
-{
 	char *value;
 	if (utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_PROFILE_PROPERTY, &value) == 0)
 		return;
 
 	char *output = nullptr;
-	char **args = utils.monodroid_strsplit (value, ",", 0);
-	for (char **ptr = args; ptr && *ptr; ptr++) {
-		const char *arg = *ptr;
-		if (!strncmp (arg, "output=", sizeof ("output=")-1)) {
-			const char *p = arg + (sizeof ("output=")-1);
-			if (strlen (p)) {
-				output = utils.strdup_new (p);
-				break;
-			}
+	char *delimiter = strchr (value, ',');
+	while (delimiter != nullptr) {
+		char *arg = delimiter + 1;
+		if (*arg == '\0') {
+			break;
 		}
+
+		if (strncmp (arg, output_arg, output_arg_len) != 0) {
+			delimiter = strchr (arg, ',');
+			continue;
+		}
+
+		arg += output_arg_len;
+		if (*arg == '\0') {
+			break; // empty...
+		}
+
+		delimiter = strchr (arg, ',');
+		if (delimiter == nullptr) {
+			output = utils.strdup_new (arg);
+		} else {
+			output = utils.strdup_new (arg, static_cast<size_t>(delimiter - arg));
+		}
+		break;
 	}
-	utils.monodroid_strfreev (args);
 
-	if (!output) {
+	if (output == nullptr) {
 		const char* col = strchr (value, ':');
-		char *ovalue;
 		char *extension;
+		bool  extension_needs_free = false;
 
-		if ((col != nullptr && !strncmp (value, "log:", 4)) || !strcmp (value, "log"))
-			extension = utils.strdup_new ("mlpd");
+		if ((col != nullptr && strncmp (value, "log:", 4) == 0) || strcmp (value, "log") == 0)
+			extension = const_cast<char*>(mlpd_ext);
 		else if ((col != nullptr && !strncmp (value, "aot:", 4)) || !strcmp (value, "aot"))
-			extension = utils.strdup_new ("aotprofile");
+			extension = const_cast<char*>(aot_ext);
+		else if ((col != nullptr && strncmp (value, "default:", 8) == 0) || strcmp (value, "default") == 0)
+			extension = const_cast<char*>(mlpd_ext);
 		else {
 			size_t len = col != nullptr ? static_cast<size_t>(col - value) : strlen (value);
 			size_t alloc_size = ADD_WITH_OVERFLOW_CHECK (size_t, len, 1);
 			extension = new char [alloc_size];
 			strncpy (extension, value, len);
 			extension [len] = '\0';
+			extension_needs_free = true;
 		}
 
-		char *filename;
-#if WINDOWS
-		filename = utils.monodroid_strdup_printf ("profile.%s", extension);
-#else
-		filename = utils.string_concat ("profile.", extension);
-#endif
+		output = utils.string_concat (androidSystem.get_override_dir (0), MONODROID_PATH_SEPARATOR, "profile.", extension);
+		char *ovalue = utils.string_concat (value, col == nullptr ? ":" : ",", output_arg, output);
 
-		output = utils.path_combine (androidSystem.get_override_dir (0), filename);
-#if WINDOWS
-		ovalue = utils.monodroid_strdup_printf ("%s%soutput=%s",
-				value,
-				col == nullptr ? ":" : ",",
-				output);
-#else
-		ovalue = utils.string_concat (value,
-		                              col == nullptr ? ":" : ",",
-		                              "output=",
-		                              output);
-#endif
+		if (extension_needs_free)
+			delete[] extension;
 		delete[] value;
-		delete[] extension;
-#if WINDOWS
-		free (filename);
-#else
-		delete[] filename;
-#endif
 		value = ovalue;
 	}
 
@@ -1634,144 +1256,11 @@ set_profile_options (JNIEnv *env)
 	unlink (output);
 
 	log_warn (LOG_DEFAULT, "Initializing profiler with options: %s", value);
-	monodroid_profiler_load (androidSystem.get_runtime_libdir (), value, output);
+	debug.monodroid_profiler_load (androidSystem.get_runtime_libdir (), value, output);
 
 	delete[] value;
 	delete[] output;
 }
-
-static FILE* counters;
-
-/*
- * process_cmd:
- *
- *   Process a command received from XS through a socket connection.
- * This is called on a separate thread.
- * Return TRUE, if a new connection need to be opened.
- */
-int
-process_cmd (int fd, char *cmd)
-{
-	if (!strcmp (cmd, "connect output")) {
-		dup2 (fd, 1);
-		dup2 (fd, 2);
-		return TRUE;
-	} else if (!strcmp (cmd, "connect stdout")) {
-		dup2 (fd, 1);
-		return TRUE;
-	} else if (!strcmp (cmd, "connect stderr")) {
-		dup2 (fd, 2);
-		return TRUE;
-	} else if (!strcmp (cmd, "discard")) {
-		return TRUE;
-	} else if (!strcmp (cmd, "ping")) {
-		if (!utils.send_uninterrupted (fd, const_cast<void*> (reinterpret_cast<const void*> ("pong")), 5))
-			log_error (LOG_DEFAULT, "Got keepalive request from XS, but could not send response back (%s)\n", strerror (errno));
-	} else if (!strcmp (cmd, "exit process")) {
-		log_info (LOG_DEFAULT, "XS requested an exit, will exit immediately.\n");
-		fflush (stdout);
-		fflush (stderr);
-		exit (0);
-	} else if (!strncmp (cmd, "start debugger: ", 16)) {
-		const char *debugger = cmd + 16;
-		int use_fd = FALSE;
-		if (!strcmp (debugger, "no")) {
-			/* disabled */
-		} else if (!strcmp (debugger, "sdb")) {
-			sdb_fd = fd;
-			use_fd = TRUE;
-		}
-		/* Notify the main thread (start_debugging ()) */
-		debugging_configured = TRUE;
-		pthread_mutex_lock (&process_cmd_mutex);
-		pthread_cond_signal (&process_cmd_cond);
-		pthread_mutex_unlock (&process_cmd_mutex);
-		if (use_fd)
-			return TRUE;
-	} else if (!strncmp (cmd, "start profiler: ", 16)) {
-		const char *prof = cmd + 16;
-		int use_fd = FALSE;
-
-		if (!strcmp (prof, "no")) {
-			/* disabled */
-		} else if (!strncmp (prof, "log:", 4)) {
-			use_fd = TRUE;
-			profiler_fd = fd;
-			profiler_description = utils.monodroid_strdup_printf ("%s,output=#%i", prof, profiler_fd);
-		} else {
-			log_error (LOG_DEFAULT, "Unknown profiler: '%s'", prof);
-		}
-		/* Notify the main thread (start_profiling ()) */
-		profiler_configured = TRUE;
-		pthread_mutex_lock (&process_cmd_mutex);
-		pthread_cond_signal (&process_cmd_cond);
-		pthread_mutex_unlock (&process_cmd_mutex);
-		if (use_fd)
-			return TRUE;
-	} else {
-		log_error (LOG_DEFAULT, "Unsupported command: '%s'", cmd);
-	}
-
-	return FALSE;
-}
-
-#if defined (DEBUG) && !defined (WINDOWS)
-
-static void
-start_debugging (void)
-{
-	char *debug_arg;
-	char *debug_options [2];
-
-	// wait for debugger configuration to finish
-	pthread_mutex_lock (&process_cmd_mutex);
-	while (!debugging_configured && !config_timedout) {
-		if (pthread_cond_timedwait (&process_cmd_cond, &process_cmd_mutex, &wait_ts) == ETIMEDOUT)
-			config_timedout = TRUE;
-	}
-	pthread_mutex_unlock (&process_cmd_mutex);
-
-	if (!sdb_fd)
-		return;
-
-	embeddedAssemblies.set_register_debug_symbols (true);
-
-	debug_arg = utils.monodroid_strdup_printf ("--debugger-agent=transport=socket-fd,address=%d,embedding=1", sdb_fd);
-	debug_options[0] = debug_arg;
-	// this text is used in unit tests to check the debugger started
-	// do not change it without updating the test.
-	log_warn (LOG_DEBUGGER, "Trying to initialize the debugger with options: %s", debug_arg);
-
-	if (enable_soft_breakpoints ()) {
-		constexpr char soft_breakpoints[] = "--soft-breakpoints";
-		debug_options[1] = const_cast<char*> (soft_breakpoints);
-		mono_jit_parse_options (2, debug_options);
-	} else {
-		mono_jit_parse_options (1, debug_options);
-	}
-
-	mono_debug_init (MONO_DEBUG_FORMAT_MONO);
-}
-
-static void
-start_profiling (void)
-{
-	// wait for profiler configuration to finish
-	pthread_mutex_lock (&process_cmd_mutex);
-	while (!profiler_configured && !config_timedout) {
-		if (pthread_cond_timedwait (&process_cmd_cond, &process_cmd_mutex, &wait_ts) == ETIMEDOUT)
-			config_timedout = TRUE;
-	}
-	pthread_mutex_unlock (&process_cmd_mutex);
-
-	if (!profiler_description)
-		return;
-
-	log_info (LOG_DEFAULT, "Loading profiler: '%s'", profiler_description);
-	monodroid_profiler_load (androidSystem.get_runtime_libdir (), profiler_description, nullptr);
-}
-
-#endif  // def DEBUG && !WINDOWS
 
 /*
 Disable LLVM signal handlers.
@@ -1784,8 +1273,8 @@ a nice and smart library installs a ton of signal handlers and don't chain at al
 This is a hack to set llvm::DisablePrettyStackTrace to true and avoid this source of signal handlers.
 
 */
-static void
-disable_external_signal_handlers (void)
+void
+MonodroidRuntime::disable_external_signal_handlers (void)
 {
 	if (!androidSystem.is_mono_llvm_enabled ())
 		return;
@@ -1801,26 +1290,8 @@ disable_external_signal_handlers (void)
 	}
 }
 
-MONO_API void
-_monodroid_counters_dump (const char *format, ...)
-{
-	if (counters == nullptr)
-		return;
-
-	va_list args;
-	fprintf (counters, "\n");
-
-	va_start (args, format);
-	vfprintf (counters, format, args);
-	va_end (args);
-
-	fprintf (counters, "\n");
-
-	mono_counters_dump (static_cast<int>(XA_LOG_COUNTERS), counters);
-}
-
-static void
-load_assembly (MonoDomain *domain, JNIEnv *env, jstring_wrapper &assembly)
+inline void
+MonodroidRuntime::load_assembly (MonoDomain *domain, JNIEnv *env, jstring_wrapper &assembly)
 {
 	timing_period total_time;
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
@@ -1855,8 +1326,8 @@ load_assembly (MonoDomain *domain, JNIEnv *env, jstring_wrapper &assembly)
 	}
 }
 
-static void
-load_assemblies (MonoDomain *domain, JNIEnv *env, jstring_array_wrapper &assemblies)
+inline void
+MonodroidRuntime::load_assemblies (MonoDomain *domain, JNIEnv *env, jstring_array_wrapper &assemblies)
 {
 	timing_period total_time;
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
@@ -1876,14 +1347,16 @@ load_assemblies (MonoDomain *domain, JNIEnv *env, jstring_array_wrapper &assembl
 	}
 }
 
-static void
+[[maybe_unused]] static void
 monodroid_Mono_UnhandledException_internal (MonoException *ex)
 {
 	// Do nothing with it here, we let the exception naturally propagate on the managed side
 }
 
-static MonoDomain*
-create_and_initialize_domain (JNIEnv* env, jclass runtimeClass, jstring_array_wrapper &runtimeApks, jstring_array_wrapper &assemblies, jobjectArray assembliesBytes, jobject loader, bool is_root_domain, bool force_preload_assemblies)
+MonoDomain*
+MonodroidRuntime::create_and_initialize_domain (JNIEnv* env, jclass runtimeClass, jstring_array_wrapper &runtimeApks,
+                                                jstring_array_wrapper &assemblies, jobjectArray assembliesBytes,
+                                                jobject loader, bool is_root_domain, bool force_preload_assemblies)
 {
 	MonoDomain* domain = create_domain (env, runtimeClass, runtimeApks, loader, is_root_domain);
 
@@ -1907,24 +1380,11 @@ create_and_initialize_domain (JNIEnv* env, jclass runtimeClass, jstring_array_wr
 	return domain;
 }
 
-/* !DO NOT REMOVE! Used by the Android Designer */
-JNIEXPORT void JNICALL
-Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApksJava,
-                                jstring runtimeNativeLibDir, jobjectArray appDirs, jobject loader,
-                                jobjectArray externalStorageDirs, jobjectArray assembliesJava, jstring packageName,
-                                jint apiLevel, jobjectArray environmentVariables)
-{
-	Java_mono_android_Runtime_initInternal (
-		env, klass, lang, runtimeApksJava, runtimeNativeLibDir,
-		appDirs, loader, externalStorageDirs, assembliesJava, apiLevel,
-		/* embeddedDSOsEnabled */ JNI_FALSE);
-}
-
-JNIEXPORT void JNICALL
-Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApksJava,
-                                jstring runtimeNativeLibDir, jobjectArray appDirs, jobject loader,
-                                jobjectArray externalStorageDirs, jobjectArray assembliesJava,
-                                jint apiLevel, jboolean embeddedDSOsEnabled)
+inline void
+MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApksJava,
+                                                          jstring runtimeNativeLibDir, jobjectArray appDirs, jobject loader,
+                                                          jobjectArray externalStorageDirs, jobjectArray assembliesJava,
+                                                          jint apiLevel, jboolean embeddedDSOsEnabled)
 {
 	init_logging_categories ();
 
@@ -1936,7 +1396,7 @@ Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang,
 	android_api_level = apiLevel;
 	androidSystem.set_embedded_dso_mode_enabled ((bool) embeddedDSOsEnabled);
 
-	TimeZone_class = utils.get_class_from_runtime_field (env, klass, "java_util_TimeZone", true);
+	java_TimeZone = utils.get_class_from_runtime_field (env, klass, "java_util_TimeZone", true);
 
 	utils.monodroid_store_package_name (application_config.android_package_name);
 
@@ -1992,11 +1452,10 @@ Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang,
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)) && !(log_timing_categories & LOG_TIMING_BARE)) {
 		mono_counters_enable (static_cast<int>(XA_LOG_COUNTERS));
 
-		char *counters_path = utils.path_combine (androidSystem.get_override_dir (0), "counters.txt");
-		log_info_nocheck (LOG_TIMING, "counters path: %s", counters_path);
+		simple_pointer_guard<char[]> counters_path (utils.path_combine (androidSystem.get_override_dir (0), "counters.txt"));
+		log_info_nocheck (LOG_TIMING, "counters path: %s", counters_path.get ());
 		counters = utils.monodroid_fopen (counters_path, "a");
 		utils.set_world_accessable (counters_path);
-		delete[] counters_path;
 	}
 
 	mono_dl_fallback_register (monodroid_dlopen, monodroid_dlsym, nullptr, nullptr);
@@ -2006,26 +1465,7 @@ Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang,
 	set_trace_options ();
 
 #if defined (DEBUG) && !defined (WINDOWS)
-	char *connect_args;
-	utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_CONNECT_PROPERTY, &connect_args);
-
-	if (connect_args != nullptr) {
-		int res = debug.start_connection (connect_args);
-		if (res != 2) {
-			if (res) {
-				log_fatal (LOG_DEBUGGER, "Could not start a connection to the debugger with connection args '%s'.", connect_args);
-				exit (FATAL_EXIT_DEBUGGER_CONNECT);
-			}
-
-			/* Wait for XS to configure debugging/profiling */
-			gettimeofday(&wait_tv, nullptr);
-			wait_ts.tv_sec = wait_tv.tv_sec + 2;
-			wait_ts.tv_nsec = wait_tv.tv_usec * 1000;
-			start_debugging ();
-			start_profiling ();
-		}
-		delete[] connect_args;
-	}
+	debug.start_debugging_and_profiling ();
 #endif
 
 	mono_config_parse_memory (reinterpret_cast<const char*> (monodroid_config));
@@ -2090,35 +1530,109 @@ Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang,
 
 		timing_diff diff (total_time);
 		log_info_nocheck (LOG_TIMING, "Runtime.init: end, total time; elapsed: %lis:%lu::%lu", diff.sec, diff.ms, diff.ns);
-		_monodroid_counters_dump ("## Runtime.init: end");
+		dump_counters ("## Runtime.init: end");
 	}
 }
 
-JNIEXPORT void
-JNICALL Java_mono_android_Runtime_register (JNIEnv *env, jclass klass, jstring managedType, jclass nativeClass, jstring methods)
+void
+MonodroidRuntime::dump_counters (const char *format, ...)
 {
-	int managedType_len, methods_len;
-	const jchar *managedType_ptr, *methods_ptr;
-	void *args [5];
-	const char *mt_ptr;
-	MonoDomain *domain = mono_domain_get ();
+	log_warn (LOG_DEFAULT, "%s called (counters == %p)", __PRETTY_FUNCTION__, counters);
+	if (counters == nullptr)
+		return;
+
+	va_list args;
+	va_start (args, format);
+	dump_counters_v (format, args);
+	va_end (args);
+}
+
+void
+MonodroidRuntime::dump_counters_v (const char *format, va_list args)
+{
+	log_warn (LOG_DEFAULT, "%s called (counters == %p)", __PRETTY_FUNCTION__, counters);
+	if (counters == nullptr)
+		return;
+
+	fprintf (counters, "\n");
+	vfprintf (counters, format, args);
+	fprintf (counters, "\n");
+
+	mono_counters_dump (static_cast<int>(MonodroidRuntime::XA_LOG_COUNTERS), counters);
+}
+
+JNIEXPORT jint JNICALL
+JNI_OnLoad (JavaVM *vm, void *reserved)
+{
+	return monodroidRuntime.Java_JNI_OnLoad (vm, reserved);
+}
+
+/* !DO NOT REMOVE! Used by the Android Designer */
+JNIEXPORT void JNICALL
+Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApksJava,
+                                jstring runtimeNativeLibDir, jobjectArray appDirs, jobject loader,
+                                jobjectArray externalStorageDirs, jobjectArray assembliesJava, jstring packageName,
+                                jint apiLevel, jobjectArray environmentVariables)
+{
+	monodroidRuntime.Java_mono_android_Runtime_initInternal (
+		env,
+		klass,
+		lang,
+		runtimeApksJava,
+		runtimeNativeLibDir,
+		appDirs,
+		loader,
+		externalStorageDirs,
+		assembliesJava,
+		apiLevel,
+		/* embeddedDSOsEnabled */ JNI_FALSE
+	);
+}
+
+JNIEXPORT void JNICALL
+Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApksJava,
+                                jstring runtimeNativeLibDir, jobjectArray appDirs, jobject loader,
+                                jobjectArray externalStorageDirs, jobjectArray assembliesJava,
+                                jint apiLevel, jboolean embeddedDSOsEnabled)
+{
+	monodroidRuntime.Java_mono_android_Runtime_initInternal (
+		env,
+		klass,
+		lang,
+		runtimeApksJava,
+		runtimeNativeLibDir,
+		appDirs,
+		loader,
+		externalStorageDirs,
+		assembliesJava,
+		apiLevel,
+		embeddedDSOsEnabled
+	);
+}
+
+inline void
+MonodroidRuntime::Java_mono_android_Runtime_register (JNIEnv *env, jclass klass, jstring managedType, jclass nativeClass, jstring methods)
+{
 	timing_period total_time;
 
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
 		total_time.mark_start ();
 
-	managedType_len = env->GetStringLength (managedType);
-	managedType_ptr = env->GetStringChars (managedType, nullptr);
+	int managedType_len = env->GetStringLength (managedType);
+	const jchar *managedType_ptr = env->GetStringChars (managedType, nullptr);
 
-	methods_len = env->GetStringLength (methods);
-	methods_ptr = env->GetStringChars (methods, nullptr);
+	int methods_len = env->GetStringLength (methods);
+	const jchar *methods_ptr = env->GetStringChars (methods, nullptr);
 
-	args [0] = &managedType_ptr,
-	args [1] = &managedType_len;
-	args [2] = &nativeClass;
-	args [3] = &methods_ptr;
-	args [4] = &methods_len;
+	void *args[] = {
+		&managedType_ptr,
+		&managedType_len,
+		&nativeClass,
+		&methods_ptr,
+		&methods_len,
+	};
 
+	MonoDomain *domain = mono_domain_get ();
 	mono_jit_thread_attach (domain);
 	// Refresh current domain as it might have been modified by the above call
 	domain = mono_domain_get ();
@@ -2138,14 +1652,21 @@ JNICALL Java_mono_android_Runtime_register (JNIEnv *env, jclass klass, jstring m
 
 		timing_diff diff (total_time);
 
-		mt_ptr = env->GetStringUTFChars (managedType, nullptr);
+		const char *mt_ptr = env->GetStringUTFChars (managedType, nullptr);
 		char *type = utils.strdup_new (mt_ptr);
 		env->ReleaseStringUTFChars (managedType, mt_ptr);
 
 		log_info_nocheck (LOG_TIMING, "Runtime.register: end time; elapsed: %lis:%lu::%lu", diff.sec, diff.ms, diff.ns);
-		_monodroid_counters_dump ("## Runtime.register: type=%s\n", type);
+		log_warn (LOG_DEFAULT, "type == %s", type == nullptr ? "<null>" : type);
+		dump_counters ("## Runtime.register: type=%s\n", type);
 		delete[] type;
 	}
+}
+
+JNIEXPORT void
+JNICALL Java_mono_android_Runtime_register (JNIEnv *env, jclass klass, jstring managedType, jclass nativeClass, jstring methods)
+{
+	monodroidRuntime.Java_mono_android_Runtime_register (env, klass, managedType, nativeClass, methods);
 }
 
 // DO NOT USE ON NORMAL X.A
@@ -2162,8 +1683,9 @@ reinitialize_android_runtime_type_manager (JNIEnv *env)
 	env->DeleteLocalRef (typeManager);
 }
 
-JNIEXPORT jint
-JNICALL Java_mono_android_Runtime_createNewContextWithData (JNIEnv *env, jclass klass, jobjectArray runtimeApksJava, jobjectArray assembliesJava, jobjectArray assembliesBytes, jobject loader, jboolean force_preload_assemblies)
+inline jint
+MonodroidRuntime::Java_mono_android_Runtime_createNewContextWithData (JNIEnv *env, jclass klass, jobjectArray runtimeApksJava, jobjectArray assembliesJava,
+                                                                      jobjectArray assembliesBytes, jobject loader, jboolean force_preload_assemblies)
 {
 	log_info (LOG_DEFAULT, "CREATING NEW CONTEXT");
 	reinitialize_android_runtime_type_manager (env);
@@ -2180,15 +1702,8 @@ JNICALL Java_mono_android_Runtime_createNewContextWithData (JNIEnv *env, jclass 
 	return domain_id;
 }
 
-/* !DO NOT REMOVE! Used by older versions of the Android Designer (pre-16.4) */
-JNIEXPORT jint
-JNICALL Java_mono_android_Runtime_createNewContext (JNIEnv *env, jclass klass, jobjectArray runtimeApksJava, jobjectArray assembliesJava, jobject loader)
-{
-	return Java_mono_android_Runtime_createNewContextWithData (env, klass, runtimeApksJava, assembliesJava, nullptr, loader, false);
-}
-
-JNIEXPORT void
-JNICALL Java_mono_android_Runtime_switchToContext (JNIEnv *env, jclass klass, jint contextID)
+inline void
+MonodroidRuntime::Java_mono_android_Runtime_switchToContext (JNIEnv *env, jclass klass, jint contextID)
 {
 	log_info (LOG_DEFAULT, "SWITCHING CONTEXT");
 	MonoDomain *domain = mono_domain_get_by_id ((int)contextID);
@@ -2200,8 +1715,8 @@ JNICALL Java_mono_android_Runtime_switchToContext (JNIEnv *env, jclass klass, ji
 	current_context_id = (int)contextID;
 }
 
-JNIEXPORT void
-JNICALL Java_mono_android_Runtime_destroyContexts (JNIEnv *env, jclass klass, jintArray array)
+inline void
+MonodroidRuntime::Java_mono_android_Runtime_destroyContexts (JNIEnv *env, jclass klass, jintArray array)
 {
 	MonoDomain *root_domain = mono_get_root_domain ();
 	mono_jit_thread_attach (root_domain);
@@ -2212,8 +1727,7 @@ JNICALL Java_mono_android_Runtime_destroyContexts (JNIEnv *env, jclass klass, ji
 
 	log_info (LOG_DEFAULT, "Cleaning %d domains", count);
 
-	int i;
-	for (i = 0; i < count; i++) {
+	for (jsize i = 0; i < count; i++) {
 		int domain_id = contextIDs[i];
 		MonoDomain *domain = mono_domain_get_by_id (domain_id);
 
@@ -2228,7 +1742,7 @@ JNICALL Java_mono_android_Runtime_destroyContexts (JNIEnv *env, jclass klass, ji
 	}
 	osBridge.on_destroy_contexts ();
 
-	for (i = 0; i < count; i++) {
+	for (jsize i = 0; i < count; i++) {
 		int domain_id = contextIDs[i];
 		MonoDomain *domain = mono_domain_get_by_id (domain_id);
 
@@ -2245,37 +1759,56 @@ JNICALL Java_mono_android_Runtime_destroyContexts (JNIEnv *env, jclass klass, ji
 	log_info (LOG_DEFAULT, "All domain cleaned up");
 }
 
+JNIEnv*
+get_jnienv (void)
+{
+	return osBridge.ensure_jnienv ();
+}
+
+JNIEXPORT jint
+JNICALL Java_mono_android_Runtime_createNewContextWithData (JNIEnv *env, jclass klass, jobjectArray runtimeApksJava, jobjectArray assembliesJava, jobjectArray assembliesBytes, jobject loader, jboolean force_preload_assemblies)
+{
+	return monodroidRuntime.Java_mono_android_Runtime_createNewContextWithData (
+		env,
+		klass,
+		runtimeApksJava,
+		assembliesJava,
+		assembliesBytes,
+		loader,
+		force_preload_assemblies
+	);
+}
+
+/* !DO NOT REMOVE! Used by older versions of the Android Designer (pre-16.4) */
+JNIEXPORT jint
+JNICALL Java_mono_android_Runtime_createNewContext (JNIEnv *env, jclass klass, jobjectArray runtimeApksJava, jobjectArray assembliesJava, jobject loader)
+{
+	return monodroidRuntime.Java_mono_android_Runtime_createNewContextWithData (
+		env,
+		klass,
+		runtimeApksJava,
+		assembliesJava,
+		nullptr, // assembliesBytes
+		loader,
+		false    // force_preload_assemblies
+	);
+}
+
+JNIEXPORT void
+JNICALL Java_mono_android_Runtime_switchToContext (JNIEnv *env, jclass klass, jint contextID)
+{
+	monodroidRuntime.Java_mono_android_Runtime_switchToContext (env, klass, contextID);
+}
+
+JNIEXPORT void
+JNICALL Java_mono_android_Runtime_destroyContexts (JNIEnv *env, jclass klass, jintArray array)
+{
+	monodroidRuntime.Java_mono_android_Runtime_destroyContexts (env, klass, array);
+}
+
 JNIEXPORT void
 JNICALL Java_mono_android_Runtime_propagateUncaughtException (JNIEnv *env, jclass klass, jobject javaThread, jthrowable javaException)
 {
 	MonoDomain *domain = mono_domain_get ();
-	propagate_uncaught_exception (domain, env, javaThread, javaException);
-}
-
-extern "C" void* monodroid_dylib_mono_new (const char *libmono_path)
-{
-	return nullptr;
-}
-
-extern "C" void monodroid_dylib_mono_free (void *mono_imports)
-{
-	// no-op
-}
-
-/*
-  this function is used from JavaInterop and should be treated as public API
-  https://github.com/xamarin/java.interop/blob/master/src/java-interop/java-interop-gc-bridge-mono.c#L266
-
-  it should also accept libmono_path = nullptr parameter
-*/
-extern "C" int monodroid_dylib_mono_init (void *mono_imports, const char *libmono_path)
-{
-	if (mono_imports == nullptr)
-		return FALSE;
-	return TRUE;
-}
-
-extern "C" void*  monodroid_get_dylib (void)
-{
-	return nullptr;
+	monodroidRuntime.propagate_uncaught_exception (domain, env, javaThread, javaException);
 }

--- a/src/monodroid/jni/monodroid-glue.hh
+++ b/src/monodroid/jni/monodroid-glue.hh
@@ -21,5 +21,4 @@ JNIEnv* get_jnienv (void);
 
 extern  FILE  *gref_log;
 extern  FILE  *lref_log;
-
 #endif /* __MONODROID_GLUE_H */

--- a/src/monodroid/jni/monodroid-networkinfo.cc
+++ b/src/monodroid/jni/monodroid-networkinfo.cc
@@ -30,7 +30,7 @@
 #include <string.h>
 
 #include "monodroid.h"
-#include "monodroid-glue.h"
+#include "monodroid-glue.hh"
 
 #include "util.hh"
 #include "globals.hh"

--- a/src/monodroid/jni/timezones.cc
+++ b/src/monodroid/jni/timezones.cc
@@ -15,7 +15,7 @@
 #include "debug.hh"
 #include "embedded-assemblies.hh"
 #include "util.hh"
-#include "monodroid-glue.h"
+#include "monodroid-glue.hh"
 #include "globals.hh"
 
 using namespace xamarin::android;

--- a/src/monodroid/jni/util.hh
+++ b/src/monodroid/jni/util.hh
@@ -127,15 +127,12 @@ namespace xamarin::android
 		//char *monodroid_strdup_printf (const char *format, va_list vargs);
 		void  monodroid_property_set (MonoDomain *domain, MonoProperty *property, void *obj, void **params, MonoObject **exc);
 
-#if WINDOWS
-		void package_hash_to_hex (uint32_t hash);
-#else
 		template<typename IdxType>
 		void package_hash_to_hex (IdxType idx);
 
 		template<typename IdxType = size_t, typename ...Indices>
 		void package_hash_to_hex (uint32_t hash, IdxType idx, Indices... indices);
-#endif
+
 	private:
 		char package_property_suffix[9];
 	};

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -327,7 +327,7 @@ namespace ${ROOT_NAMESPACE} {
 					$"AndroidSdbHostPort={port}",
 					"AndroidAttachDebugger=True",
 				}), "Project should have run.");
-				
+
 				Assert.IsTrue (WaitForDebuggerToStart (Path.Combine (Root, b.ProjectDirectory, "logcat.log")), "Activity should have started");
 				// we need to give a bit of time for the debug server to start up.
 				WaitFor (2000);

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -87,7 +87,7 @@ namespace Xamarin.Android.Build.Tests
 				"Asia/Qostanay",
 				"US/Pacific-New"
 			};
-			
+
 			foreach (var tz in NodaTime.DateTimeZoneProviders.Tzdb.Ids) {
 				if (ignore.Contains (tz))
 					continue;


### PR DESCRIPTION
monodroid-glue is one of the last pieces of our native code that, so far, hasn't
been converted to "proper" C++ by putting the data and functions in a class,
while migrating some of them to more appropriate classes.

This commit implements just that:

  * move all the data members to a new `MonodroidRuntime` class
  * move a number of profiler and debugging functions to the `Debug` class
  * move most `MONO_API` functions to a separate file

Additionally, bits and pieces of code are modified to make them more C++ than
C (including some Windows-specific code to work around the ancient mingw version
we used at some point).

The simple pointer guard class is extended to work with C-allocated
pointers (the class still needs some work to make it more generally useful, but
that's beyond the scope of this commit).