### PR TITLE
[profiled aot] Added 2 new properties for our targets

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -692,7 +692,7 @@ when packaging Release applications.
 -   **AndroidUseDefaultAotProfile** &ndash; A bool property which allows
     the developer to suppress usage of the default AOT profiles.
 
-    Added in Xamarin.Android 10.0.
+    Added in Xamarin.Android 10.1.
 
 -   **AndroidUseLegacyVersionCode** &ndash; A boolean property will allows
     the developer to revert the versionCode calculation back to its old pre

--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -219,6 +219,12 @@ used by the `Install` and `SignAndroidPackage` targets.
 The [Signing Properties](#Signing_Properties) are also relevant
 when packaging Release applications.
 
+-   **AndroidAotProfiles** &ndash; A string property which allows the
+    developer to add AOT profiles from the command line. It is
+    semicolon or comma separated list of absolute paths.
+
+    Added in Xamarin.Android 10.1.
+
 -   **AndroidApkDigestAlgorithm** &ndash; A string value which specifies
     the digest algorithm to use with `jarsigner -digestalg`.
 
@@ -342,9 +348,6 @@ when packaging Release applications.
     The profiles are listed in `AndroidAotProfile` item group. This
     ItemGroup contains default profile(s). It can be overriden by
     removing the existing one(s) and adding your own AOT profiles.
-
-    The profiles can also be added with `AndroidAotProfiles` property,
-    which should contain colon separated list of absolute paths.
 
     Support for this property was added in Xamarin.Android 9.4.
 

--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -343,6 +343,9 @@ when packaging Release applications.
     ItemGroup contains default profile(s). It can be overriden by
     removing the existing one(s) and adding your own AOT profiles.
 
+    The profiles can also be added with `AndroidAotProfiles` property,
+    which should contain colon separated list of absolute paths.
+
     Support for this property was added in Xamarin.Android 9.4.
 
     This property is `False` by default.
@@ -685,6 +688,11 @@ when packaging Release applications.
     use the to the `apksigner` tool rather than the `jarsigner`.
 
     Added in Xamarin.Android 8.2.
+
+-   **AndroidUseDefaultAotProfile** &ndash; A bool property which allows
+    the developer to suppress usage of the default AOT profiles.
+
+    Added in Xamarin.Android 10.0.
 
 -   **AndroidUseLegacyVersionCode** &ndash; A boolean property will allows
     the developer to revert the versionCode calculation back to its old pre

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Android.Build.Tests
 			};
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				StringAssertEx.ContainsRegex (@"\[aot-compiler stdout\] Using profile data file.*xbuild.Xamarin.Android.startup\.aotprofile", b.LastBuildOutput, "Should use default AOT profile");
+				StringAssertEx.ContainsRegex (@"\[aot-compiler stdout\] Using profile data file.*build.Xamarin.Android.startup\.aotprofile", b.LastBuildOutput, "Should use default AOT profile", RegexOptions.IgnoreCase);
 			}
 		}
 
@@ -60,7 +60,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetProperty (proj.ActiveConfigurationProperties, "AndroidUseDefaultAotProfile", "false");
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				StringAssertEx.DoesNotContainRegex (@"\[aot-compiler stdout\] Using profile data file.*xbuild.Xamarin.Android.startup.*\.aotprofile", b.LastBuildOutput, "Should not use default AOT profile");
+				StringAssertEx.DoesNotContainRegex (@"\[aot-compiler stdout\] Using profile data file.*build.Xamarin.Android.startup.*\.aotprofile", b.LastBuildOutput, "Should not use default AOT profile", RegexOptions.IgnoreCase);
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = true,
 				AndroidEnableProfiledAot = true,
 			};
-			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationReleaseProfiledAot")) {
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				StringAssertEx.ContainsRegex (@"\[aot-compiler stdout\] Using profile data file.*lib/xamarin.android/xbuild/Xamarin/Android/startup\.aotprofile", b.LastBuildOutput, "Should use default AOT profile");
 			}
@@ -58,7 +58,7 @@ namespace Xamarin.Android.Build.Tests
 				AndroidEnableProfiledAot = true,
 			};
 			proj.SetProperty (proj.ActiveConfigurationProperties, "AndroidUseDefaultAotProfile", "false");
-			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationReleaseProfiledAotWithoutDefaultProfile")) {
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				StringAssertEx.DoesNotContainRegex (@"\[aot-compiler stdout\] Using profile data file.*lib/xamarin.android/xbuild/Xamarin/Android/startup.*\.aotprofile", b.LastBuildOutput, "Should not use default AOT profile");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = true,
 				AndroidEnableProfiledAot = true,
 			};
-			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationRelease")) {
+			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationReleaseProfiledAot")) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				StringAssertEx.ContainsRegex (@"\[aot-compiler stdout\] Using profile data file.*lib/xamarin.android/xbuild/Xamarin/Android/startup\.aotprofile", b.LastBuildOutput, "Should use default AOT profile");
 			}
@@ -58,7 +58,7 @@ namespace Xamarin.Android.Build.Tests
 				AndroidEnableProfiledAot = true,
 			};
 			proj.SetProperty (proj.ActiveConfigurationProperties, "AndroidUseDefaultAotProfile", "false");
-			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationRelease")) {
+			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationReleaseProfiledAotWithoutDefaultProfile")) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				StringAssertEx.DoesNotContainRegex (@"\[aot-compiler stdout\] Using profile data file.*lib/xamarin.android/xbuild/Xamarin/Android/startup.*\.aotprofile", b.LastBuildOutput, "Should not use default AOT profile");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -37,6 +37,33 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
+		[Test]
+		public void BuildBasicApplicationReleaseProfiledAot ()
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				AndroidEnableProfiledAot = true,
+			};
+			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationRelease")) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				StringAssertEx.ContainsRegex (@"\[aot-compiler stdout\] Using profile data file.*lib/xamarin.android/xbuild/Xamarin/Android/startup\.aotprofile", b.LastBuildOutput, "Should use default AOT profile");
+			}
+		}
+
+		[Test]
+		public void BuildBasicApplicationReleaseProfiledAotWithoutDefaultProfile ()
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				AndroidEnableProfiledAot = true,
+			};
+			proj.SetProperty (proj.ActiveConfigurationProperties, "AndroidUseDefaultAotProfile", "false");
+			using (var b = CreateApkBuilder ("temp/BuildBasicApplicationRelease")) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				StringAssertEx.DoesNotContainRegex (@"\[aot-compiler stdout\] Using profile data file.*lib/xamarin.android/xbuild/Xamarin/Android/startup.*\.aotprofile", b.LastBuildOutput, "Should not use default AOT profile");
+			}
+		}
+
 		static readonly object [] BuildHasNoWarningsSource = new object [] {
 			new object [] {
 				/* isRelease */     false,
@@ -845,9 +872,7 @@ namespace UnamedProject
 					// LLVM passes a direct path to libc.so, and we need to use the libc.so
 					// which corresponds to the *minimum* SDK version specified in AndroidManifest.xml
 					// Since we overrode minSdkVersion=16, that means we should use libc.so from android-16.
-					var rightLibc   = new Regex (@"\s*\[aot-compiler stdout].*android-16.arch-.*.usr.lib.libc\.so", RegexOptions.Multiline);
-					var m           = rightLibc.Match (string.Join ("\n",b.LastBuildOutput));
-					Assert.IsTrue (m.Success, "AOT+LLVM should use libc.so from minSdkVersion!");
+					StringAssertEx.ContainsRegex (@"\s*\[aot-compiler stdout].*android-16.arch-.*.usr.lib.libc\.so", b.LastBuildOutput, "AOT+LLVM should use libc.so from minSdkVersion!");
 				}
 				foreach (var abi in supportedAbis.Split (new char [] { ';' })) {
 					var libapp = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Android.Build.Tests
 			};
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				StringAssertEx.ContainsRegex (@"\[aot-compiler stdout\] Using profile data file.*lib.xamarin.android.xbuild.Xamarin.Android.startup\.aotprofile", b.LastBuildOutput, "Should use default AOT profile");
+				StringAssertEx.ContainsRegex (@"\[aot-compiler stdout\] Using profile data file.*xbuild.Xamarin.Android.startup\.aotprofile", b.LastBuildOutput, "Should use default AOT profile");
 			}
 		}
 
@@ -60,7 +60,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetProperty (proj.ActiveConfigurationProperties, "AndroidUseDefaultAotProfile", "false");
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				StringAssertEx.DoesNotContainRegex (@"\[aot-compiler stdout\] Using profile data file.*lib.xamarin.android.xbuild.Xamarin.Android.startup.*\.aotprofile", b.LastBuildOutput, "Should not use default AOT profile");
+				StringAssertEx.DoesNotContainRegex (@"\[aot-compiler stdout\] Using profile data file.*xbuild.Xamarin.Android.startup.*\.aotprofile", b.LastBuildOutput, "Should not use default AOT profile");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Android.Build.Tests
 			};
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				StringAssertEx.ContainsRegex (@"\[aot-compiler stdout\] Using profile data file.*lib/xamarin.android/xbuild/Xamarin/Android/startup\.aotprofile", b.LastBuildOutput, "Should use default AOT profile");
+				StringAssertEx.ContainsRegex (@"\[aot-compiler stdout\] Using profile data file.*lib.xamarin.android.xbuild.Xamarin.Android.startup\.aotprofile", b.LastBuildOutput, "Should use default AOT profile");
 			}
 		}
 
@@ -60,7 +60,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetProperty (proj.ActiveConfigurationProperties, "AndroidUseDefaultAotProfile", "false");
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				StringAssertEx.DoesNotContainRegex (@"\[aot-compiler stdout\] Using profile data file.*lib/xamarin.android/xbuild/Xamarin/Android/startup.*\.aotprofile", b.LastBuildOutput, "Should not use default AOT profile");
+				StringAssertEx.DoesNotContainRegex (@"\[aot-compiler stdout\] Using profile data file.*lib.xamarin.android.xbuild.Xamarin.Android.startup.*\.aotprofile", b.LastBuildOutput, "Should not use default AOT profile");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BuildHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BuildHelper.cs
@@ -53,21 +53,21 @@ namespace Xamarin.Android.Build.Tests
 			Assert.Fail (message ?? $"String did not contain '{text}'!");
 		}
 
-		public static bool ContainsRegex (string pattern, IEnumerable<string> collection)
+		public static bool ContainsRegex (string pattern, IEnumerable<string> collection, RegexOptions additionalOptions = 0)
 		{
-			var regex = new Regex (pattern, RegexOptions.Multiline);
+			var regex = new Regex (pattern, RegexOptions.Multiline | additionalOptions);
 
 			return regex.Match (string.Join ("\n", collection)).Success;
 		}
 
-		public static void ContainsRegex (string pattern, IEnumerable<string> collection, string message = null)
+		public static void ContainsRegex (string pattern, IEnumerable<string> collection, string message = null, RegexOptions additionalOptions = 0)
 		{
-			Assert.IsTrue (ContainsRegex (pattern, collection), message);
+			Assert.IsTrue (ContainsRegex (pattern, collection, additionalOptions), message);
 		}
 
-		public static void DoesNotContainRegex (string pattern, IEnumerable<string> collection, string message = null)
+		public static void DoesNotContainRegex (string pattern, IEnumerable<string> collection, string message = null, RegexOptions additionalOptions = 0)
 		{
-			Assert.IsFalse (ContainsRegex (pattern, collection), message);
+			Assert.IsFalse (ContainsRegex (pattern, collection, additionalOptions), message);
 		}
 
 		public static bool ContainsText (this IEnumerable<string> collection, string expected) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BuildHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BuildHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
 using Xamarin.ProjectTools;
 using NUnit.Framework;
@@ -50,6 +51,23 @@ namespace Xamarin.Android.Build.Tests
 				}
 			}
 			Assert.Fail (message ?? $"String did not contain '{text}'!");
+		}
+
+		public static bool ContainsRegex (string pattern, IEnumerable<string> collection)
+		{
+			var regex = new Regex (pattern, RegexOptions.Multiline);
+
+			return regex.Match (string.Join ("\n", collection)).Success;
+		}
+
+		public static void ContainsRegex (string pattern, IEnumerable<string> collection, string message = null)
+		{
+			Assert.IsTrue (ContainsRegex (pattern, collection), message);
+		}
+
+		public static void DoesNotContainRegex (string pattern, IEnumerable<string> collection, string message = null)
+		{
+			Assert.IsFalse (ContainsRegex (pattern, collection), message);
 		}
 
 		public static bool ContainsText (this IEnumerable<string> collection, string expected) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
@@ -23,6 +23,7 @@ namespace Xamarin.ProjectTools
 		public const string AndroidLinkTool = "AndroidLinkTool";
 		public const string UseJackAndJill = "UseJackAndJill";
 		public const string AotAssemblies = "AotAssemblies";
+		public const string AndroidEnableProfiledAot = "AndroidEnableProfiledAot";
 
 		public const string AndroidExplicitCrunch = "AndroidExplicitCrunch";
 		public const string OutputPath = "OutputPath";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -76,6 +76,11 @@ namespace Xamarin.ProjectTools
 			set { SetProperty (KnownProperties.AotAssemblies, value.ToString ()); }
 		}
 
+		public bool AndroidEnableProfiledAot {
+			get { return string.Equals (GetProperty (KnownProperties.AndroidEnableProfiledAot), "True", StringComparison.OrdinalIgnoreCase); }
+			set { SetProperty (KnownProperties.AndroidEnableProfiledAot, value.ToString ()); }
+		}
+
 		public bool EnableProguard {
 			get { return string.Equals (GetProperty (KnownProperties.EnableProguard), "True", StringComparison.OrdinalIgnoreCase); }
 			set { SetProperty (KnownProperties.EnableProguard, value.ToString ()); }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2829,11 +2829,12 @@ because xbuild doesn't support framework reference assemblies.
     <_StartupAotProfile Condition="'%(ResolvedAssemblies.Filename)' == 'Xamarin.Forms.Platform.Android'">startup-xf.aotprofile</_StartupAotProfile>
     <_StartupAotProfile Condition="'$(_StartupAotProfile)' == ''">startup.aotprofile</_StartupAotProfile>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(AndroidUseDefaultAotProfile)' != 'False'">
     <AndroidAotProfile Include="$(MSBuildThisFileDirectory)$(_StartupAotProfile)" />
   </ItemGroup>
   <ItemGroup Condition="'$(AndroidEnableProfiledAot)' == 'True'">
     <_AotProfiles Include="@(AndroidAotProfile)" />
+    <_AotProfiles Include="$(AndroidAotProfiles.Split(':'))" />
   </ItemGroup>
   <Aot
 	Condition="'$(AotAssemblies)' == 'True'"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2832,9 +2832,11 @@ because xbuild doesn't support framework reference assemblies.
   <ItemGroup Condition="'$(AndroidUseDefaultAotProfile)' != 'False'">
     <AndroidAotProfile Include="$(MSBuildThisFileDirectory)$(_StartupAotProfile)" />
   </ItemGroup>
+  <SplitProperty Value="$(AndroidAotProfiles)" Condition="'$(AndroidAotProfiles)' != ''">
+    <Output TaskParameter="Output" ItemName="_AotProfiles" />
+  </SplitProperty>
   <ItemGroup Condition="'$(AndroidEnableProfiledAot)' == 'True'">
     <_AotProfiles Include="@(AndroidAotProfile)" />
-    <_AotProfiles Include="$(AndroidAotProfiles.Split(':'))" />
   </ItemGroup>
   <Aot
 	Condition="'$(AotAssemblies)' == 'True'"


### PR DESCRIPTION
Add `AndroidUseDefaultAotProfile`. It can be used to suppress usage of
the default AOT profiles.

Add `AndroidAotProfiles` property to specify AOT profiles from command
line.