### PR TITLE
[Xamarin.Android.Build.Tasks] support for META-INF/services inclusion in APKs

### DIFF
--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -11,10 +11,219 @@ bring it to our attention. Post an issue or email us:
 
 The attached notices are provided for information only.
 
-1. bazelbuild/bazel (https://github.com/bazelbuild/bazel/)
-2. force-net/crc32.net (https://github.com/xamarin/proguard/)
-3. google/desugar (https://android.googlesource.com/platform/external/desugar/+/master/)
-4. nunit/nunitlite (https://github.com/nunit/nunitlite/)
+1. android/platform/tools/base (https://android.googlesource.com/platform/tools/base/+/d41d662dbf89f9b60ca6256415a059c0107749b8/sdk-common/NOTICE)
+2. bazelbuild/bazel (https://github.com/bazelbuild/bazel/)
+3. force-net/crc32.net (https://github.com/force-net/Crc32.NET)
+4. google/desugar (https://android.googlesource.com/platform/external/desugar/+/master/)
+5. nunit/nunitlite (https://github.com/nunit/nunitlite/)
+
+%% android/platform/tools/base NOTICES AND INFORMATION BEGIN HERE
+=================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+=================================================================
+END OF android/platform/tools/base NOTICES AND INFORMATION
 
 %% bazelbuild/bazel NOTICES AND INFORMATION BEGIN HERE
 ======================================================

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/Xamarin.Android.Build.Tasks.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/Xamarin.Android.Build.Tasks.cs
@@ -4,6 +4,17 @@ using System.IO;
 
 namespace Xamarin.Android.Prepare
 {
+	[TPN]
+	class XamarinAndroidBuildTasks_AOSP : ThirdPartyNotice
+	{
+		static readonly Uri    url         = new Uri ("https://android.googlesource.com/platform/tools/base/+/d41d662dbf89f9b60ca6256415a059c0107749b8/sdk-common/NOTICE");
+
+		public override string LicenseText => null;
+		public override string LicenseFile => CommonLicenses.Apache20Path;
+		public override string Name        => "android/platform/tools/base";
+		public override Uri    SourceUrl   => url;
+	}
+
 	// The contents of the following files are originally from
 	// 	https://github.com/bazelbuild/bazel/tree/master/src/tools/android/java/com/google/devtools/build/android/incrementaldeployment
 	// 	* Xamarin.Android.Build.Tasks/Resources/IncrementalClassLoader.java

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/PackagingUtilsTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/PackagingUtilsTests.cs
@@ -1,0 +1,77 @@
+using NUnit.Framework;
+using Xamarin.Android.Tasks;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	public class PackagingUtilsTests
+	{
+		void AssertIsValid (string path)
+		{
+			Assert.IsTrue (PackagingUtils.CheckEntryForPackaging (path), $"{path} should be valid");
+		}
+
+		void AssertIsNotValid (string path)
+		{
+			Assert.IsFalse (PackagingUtils.CheckEntryForPackaging (path), $"{path} should *not* be valid");
+		}
+
+		[Test]
+		public void JarManifest ()
+		{
+			AssertIsNotValid ("META-INF/MANIFEST.MF");
+		}
+
+		[Test]
+		public void SvnDirectories ()
+		{
+			AssertIsNotValid (".svn/foo");
+			AssertIsNotValid (".svn\\foo");
+			AssertIsNotValid ("bar/.svn/foo");
+			AssertIsNotValid ("bar\\.svn\\foo");
+		}
+
+		[Test]
+		public void KotlinServices ()
+		{
+			AssertIsValid ("META-INF/services/kotlinx.coroutines.internal.MainDispatcherFactory");
+			AssertIsValid ("META-INF/services/kotlinx.coroutines.CoroutineExceptionHandler");
+		}
+
+		[Test]
+		public void JavaFiles ()
+		{
+			AssertIsNotValid ("foo.java");
+			AssertIsNotValid ("foo/bar.java");
+			AssertIsNotValid ("foo\\bar.java");
+			AssertIsNotValid ("foo.class");
+			AssertIsNotValid ("foo/bar.class");
+			AssertIsNotValid ("foo\\bar.class");
+			AssertIsNotValid ("foo.scala");
+			AssertIsNotValid ("foo/bar.scala");
+			AssertIsNotValid ("foo\\bar.scala");
+		}
+
+		[Test]
+		public void HiddenFiles ()
+		{
+			AssertIsNotValid (".foo");
+			AssertIsNotValid ("foo/.bar");
+			AssertIsNotValid ("foo\\.bar");
+			AssertIsNotValid ("foo~");
+			AssertIsNotValid ("foo/bar~");
+			AssertIsNotValid ("foo\\bar~");
+			AssertIsValid ("_foo"); //NOTE: this is allowed
+			AssertIsNotValid ("_foo/bar");
+		}
+
+		[Test]
+		public void Directories ()
+		{
+			AssertIsNotValid ("foo/");
+			AssertIsNotValid ("foo\\");
+			AssertIsNotValid ("META-INF/");
+			AssertIsNotValid ("META-INF\\");
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
@@ -31,6 +31,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\MockBuildEngine.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\MonoAndroidHelperTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\EnvironmentHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\PackagingUtilsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WearTests.cs" />
   </ItemGroup>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Utilities/PackagingUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/PackagingUtils.cs
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * Original source: https://android.googlesource.com/platform/tools/base/+/d41d662dbf89f9b60ca6256415a059c0107749b8/sdk-common/src/main/java/com/android/ide/common/packaging/PackagingUtils.java
+ */
+
+using System;
+using System.Linq;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// Utility class for packaging.
+	/// </summary>
+	internal class PackagingUtils
+	{
+		static readonly string [] InvalidEntryPaths = new []{
+			// http://hg.openjdk.java.net/jdk8u/jdk8u-dev/jdk/file/0fc878b99541/src/share/classes/java/util/jar/JarFile.java#l91
+			"META-INF/MANIFEST.MF",
+		};
+
+		static readonly Regex pathRegex = new Regex (@"\\|\/", RegexOptions.Compiled);
+
+		/// <summary>
+		/// Checks if a zip entry is valid for packaging into the .apk as standard Java resource.
+		/// </summary>
+		/// <param name="entryName">the name of the zip entry from Xamarin.Tools.Zip.ZipEntry.FullName.</param>
+		/// <returns>true if the entry is valid for packaging.</returns>
+		public static bool CheckEntryForPackaging (string entryName)
+		{
+			if (InvalidEntryPaths.Contains (entryName))
+				return false;
+
+			var segments = pathRegex.Split (entryName);
+			for (int i = 0; i < segments.Length - 1; i++) {
+				if (!CheckFolderForPackaging (segments [i])) {
+					return false;
+				}
+			}
+
+			var fileName = segments [segments.Length - 1];
+			if (string.IsNullOrEmpty (fileName))
+				return false;
+			return CheckFileForPackaging (fileName, Path.GetExtension (fileName));
+		}
+
+		/// <summary>
+		/// Checks whether a folder and its content is valid for packaging into the .apk as standard Java resource.
+		/// </summary>
+		/// <param name="folderName">the name of the folder.</param>
+		/// <returns>true if the folder is valid for packaging.</returns>
+		static bool CheckFolderForPackaging (string folderName)
+		{
+			return !EqualsIgnoreCase (folderName, "CVS") &&
+				!EqualsIgnoreCase (folderName, ".svn") &&
+				!EqualsIgnoreCase (folderName, "SCCS") &&
+				!folderName.StartsWith ("_");
+		}
+
+		/// <summary>
+		/// Checks a file to make sure it should be packaged as standard resources.
+		/// </summary>
+		/// <param name="fileName">the name of the file (including extension)</param>
+		/// <param name="extension">the extension of the file (including '.')</param>
+		/// <returns>true if the file should be packaged as standard java resources.</returns>
+		static bool CheckFileForPackaging (string fileName, string extension)
+		{
+			// ignore hidden files and backup files
+			return !(fileName [0] == '.' || fileName [fileName.Length - 1] == '~') &&
+				!EqualsIgnoreCase (".aidl", extension) &&        // Aidl files
+				!EqualsIgnoreCase (".rs", extension) &&          // RenderScript files
+				!EqualsIgnoreCase (".fs", extension) &&          // FilterScript files
+				!EqualsIgnoreCase (".rsh", extension) &&         // RenderScript header files
+				!EqualsIgnoreCase (".d", extension) &&           // Dependency files
+				!EqualsIgnoreCase (".java", extension) &&        // Java files
+				!EqualsIgnoreCase (".scala", extension) &&       // Scala files
+				!EqualsIgnoreCase (".class", extension) &&       // Java class files
+				!EqualsIgnoreCase (".scc", extension) &&         // VisualSourceSafe
+				!EqualsIgnoreCase (".swp", extension) &&         // vi swap file
+				!EqualsIgnoreCase ("thumbs.db", fileName) &&     // image index file
+				!EqualsIgnoreCase ("picasa.ini", fileName) &&    // image index file
+				!EqualsIgnoreCase ("about.html", fileName) &&    // Javadoc
+				!EqualsIgnoreCase ("package.html", fileName) &&  // Javadoc
+				!EqualsIgnoreCase ("overview.html", fileName);   // Javadoc
+		}
+
+		static bool EqualsIgnoreCase (string a, string b)
+		{
+			return string.Compare (a, b, StringComparison.OrdinalIgnoreCase) == 0;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -202,6 +202,7 @@
     <Compile Include="Utilities\JavaResourceParser.cs" />
     <Compile Include="Utilities\MetadataResolver.cs" />
     <Compile Include="Utilities\MetadataExtensions.cs" />
+    <Compile Include="Utilities\PackagingUtils.cs" />
     <Compile Include="Utilities\ResourceParser.cs" />
     <Compile Include="Utilities\ManagedResourceParser.cs" />
     <Compile Include="Utilities\ManifestDocumentElement.cs" />


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3348

Usage of a Kotlin library in a Xamarin.Android application could fail
with:

    [AndroidRuntime] FATAL EXCEPTION: main
    [AndroidRuntime] Process: com.sample.xamarinsampleapp, PID: 20262
    [AndroidRuntime] java.lang.IllegalStateException: Module with the Main dispatcher is missing. Add dependency providing the Main dispatcher, e.g. 'kotlinx-coroutines-android'

Reviewing the results of an APK from Android Studio, these files were
missing in the equivalent Xamarin.Android apk:

    META-INF/services/kotlinx.coroutines.internal.MainDispatcherFactory
    META-INF/services/kotlinx.coroutines.CoroutineExceptionHandler

I was able to piece together what the behavior is from Google's
Android Gradle plugin.

The top level gradle task:

https://android.googlesource.com/platform/tools/base/+/gradle_2.0.0/build-system/gradle-core/src/main/groovy/com/android/build/gradle/internal/tasks/ExtractJavaResourcesTask.java?autodive=0%2F%2F%2F%2F%2F%2F%2F%2F%2F#199

Ignores `java.util.jar.JarFile.MANIFEST_NAME`:

http://hg.openjdk.java.net/jdk8u/jdk8u-dev/jdk/file/0fc878b99541/src/share/classes/java/util/jar/JarFile.java#l91

Then makes use of `PackagingUtils.java` for the remaining checks:

https://android.googlesource.com/platform/tools/base/+/d41d662dbf89f9b60ca6256415a059c0107749b8/sdk-common/src/main/java/com/android/ide/common/packaging/PackagingUtils.java

I have ported the code to C#, so our behavior should be identical to
Android Studio now.

I added a few tests:

* MSBuild tests that use `kotlinx-coroutines-android-1.3.2.jar` in
  both APKs and app bundles.
* Unit tests checking the general `PackagingUtils.cs` class works.