### PR TITLE
[Xamarin.Android.Build.Tests] Clean cache on CI

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -451,7 +451,7 @@ namespace Xamarin.Android.Build.Tests
 		public void FixtureSetup ()
 		{
 			// Clean the Resource Cache.
-			if (string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("BUILD_HOST")))
+			if (!TestEnvironment.IsRunningOnCI)
 				return;
 			if (Directory.Exists (CachePath)) {
 				foreach (var subDir in Directory.GetDirectories (CachePath, "*", SearchOption.TopDirectoryOnly)) {


### PR DESCRIPTION
We don't export the BUILD_HOST environment variable
anymore. As a result we don't clear out the global
Xamarin cache for extracted zip files.

So lets change this code to use the `TestEnvironment.IsRunningOnCI`
so we can correctly detect when we are running
on CI.