### PR TITLE
[Xamarin.Android.Build.Test] Check _Upload is skipped.

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -36,10 +36,14 @@ namespace Xamarin.Android.Build.Tests
 				builder.Verbosity = LoggerVerbosity.Diagnostic;
 				Assert.IsTrue (builder.Build (proj));
 				Assert.IsTrue (builder.Install (proj));
+				Assert.IsTrue (builder.Output.AreTargetsAllBuilt ("_Upload"), "_Upload should have built completely.");
+				Assert.IsTrue (builder.Install (proj));
+				Assert.IsTrue (builder.Output.AreTargetsAllSkipped ("_Upload"), "_Upload should have been skipped.");
 				Assert.AreEqual ($"package:{proj.PackageName}", RunAdbCommand ($"shell pm list packages {proj.PackageName}").Trim (),
 					$"{proj.PackageName} is not installed on the device.");
 				Assert.AreEqual ("Success", RunAdbCommand ($"uninstall {proj.PackageName}").Trim (), $"{proj.PackageName} was not uninstalled.");
 				Assert.IsTrue (builder.Install (proj));
+				Assert.IsTrue (builder.Output.AreTargetsAllBuilt ("_Upload"), "_Upload should have built completely.");
 				Assert.AreEqual ($"package:{proj.PackageName}", RunAdbCommand ($"shell pm list packages {proj.PackageName}").Trim (),
 					$"{proj.PackageName} is not installed on the device.");
 			}


### PR DESCRIPTION
Context #3727

Somehow sometimes the code we have does NOT detect
that the user uninstalled the app. As a result the
`_Upload` target does not run. This commit just adds
some additional checks to the unit test to make sure we
skip that target when we should, and run it when we need to.

Hopefully this might help us detect if and when this problem 
happens on our build system.