### PR TITLE
[Xamarin.Android.Build.Tasks] Catch Proguard config format errors. 

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -93,6 +93,7 @@ ms.date: 08/23/2019
 + [XA4304](xa4304.md): Proguard configuration file '{file}' was not found.
 + [XA4305](xa4305.md): MultiDex is enabled, but '{nameof (MultiDexMainDexListFile)}' was not specified.
 + [XA4306](xa4306.md): R8 does not support \`@(MultiDexMainDexList)\` files when android:minSdkVersion >= 21
++ [XA4307](xa4307.md): Invalid ProGuard configuration file.
 
 ## XA5xxx: GCC and toolchain
 

--- a/Documentation/guides/messages/xa4307.md
+++ b/Documentation/guides/messages/xa4307.md
@@ -1,0 +1,32 @@
+---
+title: Xamarin.Android error XA4307
+description: XA4307 error code
+ms.date: 10/03/2019
+---
+# Xamarin.Android error XA4307
+
+## Issue
+
+The `Proguard` MSBuild task encountered a ProGuard configuration file
+that it could not parse. These files are generally declared in your
+Xamarin.Android project with a build action of
+`ProguardConfiguration`. However, Xamarin.Android also generates
+ProGuard configuration files internally during the build process.
+
+To learn more about ProGuard and how it relates to Android
+development, see the [Android documentation][android] or the [ProGuard
+website][proguard].
+
+## Solution
+
+Verify you are not declaring a `ProguardConfiguration` build item that
+contains valid entries. This can also be caused by the config file 
+containing a Byte Order Mark (BOM) at the start of the file. If this 
+is the case remove the BOM or save the file using ASCII encoding.
+
+Consider submitting a [bug][bug] if you are getting this error under
+normal circumstances.
+
+[android]: https://developer.android.com/studio/build/shrink-code
+[proguard]: https://www.guardsquare.com/en/products/proguard/manual
+[bug]: https://github.com/xamarin/xamarin-android/wiki/Submitting-Bugs,-Feature-Requests,-and-Pull-Requests

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3461,6 +3461,34 @@ namespace UnnamedProject {
 		}
 
 		[Test]
+		public void ProguardBOMError ([Values ("dx")] string dexTool, [Values ("proguard")] string linkTool)
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				EnableDesugar = true, //It is certain this test would fail without desugar
+				DexTool = dexTool,
+				LinkTool = linkTool,
+			};
+			if (!string.IsNullOrEmpty (linkTool)) {
+				var rules = new List<string> {
+					"-dontwarn com.google.devtools.build.android.desugar.**",
+					"-dontwarn javax.annotation.**",
+					"-dontwarn org.codehaus.mojo.animal_sniffer.*",
+				};
+				var encoding = new UTF8Encoding (encoderShouldEmitUTF8Identifier: true);
+				proj.OtherBuildItems.Add (new BuildItem ("ProguardConfiguration", "proguard.cfg") {
+					TextContent = () => string.Join (Environment.NewLine, rules),
+					Encoding = encoding,
+				});
+			}
+			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				builder.ThrowOnBuildFailure = false;
+				Assert.IsFalse (builder.Build (proj), "Build should have failed.");
+				StringAssertEx.Contains ($"error XA4307", builder.LastBuildOutput, "Error should be XA4307");
+			}
+		}
+
+		[Test]
 		public void Desugar ([Values (true, false)] bool isRelease, [Values ("dx", "d8")] string dexTool, [Values ("", "proguard", "r8")] string linkTool)
 		{
 			var proj = new XamarinAndroidApplicationProject () {


### PR DESCRIPTION
Fixes #3571

Currently if `proguard` encounters a problem with the format
of a config file our users get this unhelpful message

	error MSB6006: "java.exe" exited with code 1.

They have to look though the logs to pick our the actual
error. Most of the reports we have seen are a result of the
file being saved with a Byte Order Mark (BOM). In this case
`proguard` throws a `proguard.ParseException`. This commit
catches this particular issue and makes sure the actual
error message is raised rather than the generic java one.

This also adds a unit test.