### PR TITLE
[Xamarin.Android.Build.Tests] Add some additional helper methods.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Xamarin.Tools.Zip;
 
 namespace Xamarin.ProjectTools
@@ -72,6 +73,24 @@ namespace Xamarin.ProjectTools
 				}
 			}
 			return false;
+		}
+
+		/// <summary>
+		/// Extracts the timing (in milliseconds) from the Performance Summary.
+		/// </summary>
+		/// <param name="targetOrTask">The Target or Task to get the timing for.</param>
+		/// <returns>The time it took as a TimeSpan. Or Zero if the data could not be found.</returns>
+		public TimeSpan GetTargetOrTaskTime (string targetOrTask)
+		{
+			var regex = new Regex (@"\s+(?<time>\d+)\s+(ms)\s+(" + targetOrTask + @")\s+(?<calls>\d+)\scalls", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+			foreach (var line in Builder.LastBuildOutput) {
+				var match = regex.Match (line);
+				if (match.Success) {
+					if (TimeSpan.TryParse ($"0:0:0.{match.Groups ["time"].Value}", out TimeSpan result))
+						return result;
+				}
+			}
+			return TimeSpan.Zero;
 		}
 
 		public bool IsApkInstalled {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
@@ -8,6 +8,8 @@ namespace Xamarin.ProjectTools
 {
 	public class BuildOutput
 	{
+		Regex regex = new Regex (@"\s+(?<time>\d+)\s+(ms)\s+(" + targetOrTask + @")\s+(?<calls>\d+)\scalls", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+
 		internal BuildOutput (XamarinProject project)
 		{
 			Project = project;
@@ -82,7 +84,6 @@ namespace Xamarin.ProjectTools
 		/// <returns>The time it took as a TimeSpan. Or Zero if the data could not be found.</returns>
 		public TimeSpan GetTargetOrTaskTime (string targetOrTask)
 		{
-			var regex = new Regex (@"\s+(?<time>\d+)\s+(ms)\s+(" + targetOrTask + @")\s+(?<calls>\d+)\scalls", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 			foreach (var line in Builder.LastBuildOutput) {
 				var match = regex.Match (line);
 				if (match.Success) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/BuildOutput.cs
@@ -8,8 +8,6 @@ namespace Xamarin.ProjectTools
 {
 	public class BuildOutput
 	{
-		Regex regex = new Regex (@"\s+(?<time>\d+)\s+(ms)\s+(" + targetOrTask + @")\s+(?<calls>\d+)\scalls", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
-
 		internal BuildOutput (XamarinProject project)
 		{
 			Project = project;
@@ -84,6 +82,8 @@ namespace Xamarin.ProjectTools
 		/// <returns>The time it took as a TimeSpan. Or Zero if the data could not be found.</returns>
 		public TimeSpan GetTargetOrTaskTime (string targetOrTask)
 		{
+			Regex regex = new Regex (@"\s+(?<time>\d+)\s+(ms)\s+(" + targetOrTask + @")\s+(?<calls>\d+)\scalls",
+				RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 			foreach (var line in Builder.LastBuildOutput) {
 				var match = regex.Match (line);
 				if (match.Success) {


### PR DESCRIPTION
This commit adds some helper methods which will pull
out Task and Target timings from the PerformanceSummary
of a build log.

It also picks up the data from `adb logcat` which tells
us how long it took for the app to start.

These methods will be used in future tests.