### PR TITLE
[r8] fix Main-Class setting in manifest

### DIFF
--- a/src/r8/build.gradle
+++ b/src/r8/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 jar {
     duplicatesStrategy = 'exclude'
     manifest {
-        attributes 'Main-Class': 'com.android.tools.r8.SwissArmyKnife'
+        attributes 'Main-Class': 'com.android.tools.r8.R8'
     }
     from {
         configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }


### PR DESCRIPTION
If you run:

    > java -jar .\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\r8.jar
    Error: Could not find or load main class com.android.tools.r8.SwissArmyKnife

Whoops! In a85dd5b5 I bumped r8 to 1.5.68, which no longer contains
`SwissArmyKnife` anymore, but forgot to fix this setting.

This is not a problem for Xamarin.Android because it invokes this
command instead:

    > java -classpath .\bin\Debug\lib\xamarin.android\xbuild\Xamarin\Android\r8.jar com.android.tools.r8.R8

But it would be good to fix this anyway.