### PR TITLE
[monodroid] Use __sync_sub_and_fetch for -g-

### DIFF
--- a/src/monodroid/jni/osbridge.cc
+++ b/src/monodroid/jni/osbridge.cc
@@ -181,7 +181,7 @@ OSBridge::_monodroid_gref_inc ()
 int
 OSBridge::_monodroid_gref_dec ()
 {
-	return __sync_fetch_and_sub (&gc_gref_count, 1);
+	return __sync_sub_and_fetch (&gc_gref_count, 1);
 }
 
 char*


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/3706

After enabling GREF logging to investigate a potential leak, my brain
got very confused while reading the GREF counts:

	+g+ grefc 1 gwrefc 0 obj-handle 0x2586/G -> new-handle 0x25b6/G from thread '(null)'(1)
	+g+ grefc 2 gwrefc 0 obj-handle 0x199/L -> new-handle 0x25c6/G from thread '(null)'(1)
	-g- grefc 2 gwrefc 0 handle 0x25c6/G from thread '(null)'(1)
	+g+ grefc 2 gwrefc 0 obj-handle 0x191/L -> new-handle 0x25ca/G from thread '(null)'(1)

In particular, note lines 2-3, in which `+g+`, `-g-`, and `+g+` all
show the same GREF count: 2.

Say what?  How can we start at 2, see `-g-`, and still be at 2?

`logcat-parse` also doesn't like this state of affairs:

	$ mono /Library/Frameworks/Xamarin.Android.framework/Versions/Current//lib/xamarin.android/xbuild/Xamarin/Android/logcat-parse.exe
	...
	csharp> var grefs = Grefs.Parse ("grefs.txt", null, GrefParseOptions.CheckCounts | GrefParseOptions.WarnOnCountMismatch);
	Warning:  grefc mismatch at line 20: expected     1, actual     2; line: -g- grefc 2 gwrefc 0 handle 0x25c6/G from thread '(null)'(1)
	...

The cause of the "too high" GREF count is because
`OSBridge::_monodroid_gref_dec()` uses `__sync_fetch_and_sub()` to
decrement `gc_gref_count`, meaning that the value returned is the
value *before* the subtraction, not the value after the subtract.

To get the value after the subtract, [`__sync_sub_and_fetch()`][0]
must be used.

Update `OSBridge::_monodroid_gref_dec()` to use
`__sync_sub_and_fetch()` so that the values make sense.

[0]: https://gcc.gnu.org/onlinedocs/gcc-4.1.0/gcc/Atomic-Builtins.html