### PR TITLE
[MSBuildDeviceIntegration] Add null checks to [Teardown]

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -57,10 +57,10 @@ namespace Xamarin.Android.Build.Tests
 		[OneTimeTearDown]
 		public void AfterDeploymentTests ()
 		{
-			if (HasDevices)
+			if (HasDevices && proj != null)
 				RunAdbCommand ($"uninstall {proj.PackageName}");
 
-			if (TestContext.CurrentContext.Result.FailCount == 0 && Directory.Exists (builder.ProjectDirectory))
+			if (TestContext.CurrentContext.Result.FailCount == 0 && builder != null && Directory.Exists (builder.ProjectDirectory))
 			    Directory.Delete (builder.ProjectDirectory, recursive: true);
 		}
 


### PR DESCRIPTION
The `DeploymentTest` unit tests build the test application
during `[Setup]` of the unit test class. As a result if
we do not have any Devices attached we never create the
`proj` or `builder` classes.

So what happens is we get a test failure due to a Null
Reference exception when the test shuts down.
We should handle that senario and make sure we do not
throw errors when we shut down the unit tests.