### PR TITLE
Don't use RTLD_NODELETE flag with dlopen

### DIFF
--- a/src/monodroid/jni/debug-app-helper.cc
+++ b/src/monodroid/jni/debug-app-helper.cc
@@ -88,7 +88,7 @@ Java_mono_android_DebugRuntime_init (JNIEnv *env, jclass klass, jobjectArray run
 	}
 
 	char *monosgen_path = get_libmonosgen_path ();
-	void *monosgen = dlopen (monosgen_path, RTLD_LAZY | RTLD_GLOBAL | RTLD_NODELETE);
+	void *monosgen = dlopen (monosgen_path, RTLD_LAZY | RTLD_GLOBAL);
 	if (monosgen == nullptr) {
 		log_fatal (LOG_DEFAULT, "Failed to dlopen Mono runtime from %s: %s", monosgen_path, dlerror ());
 		exit (FATAL_EXIT_CANNOT_FIND_LIBMONOSGEN);


### PR DESCRIPTION
Fixes: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/989404
Context: https://developercommunity.visualstudio.com/content/problem/749635/xamarin-stop-on-load.html

Xamarin.Android runtime used the `RTLD_NODELETE` flag with `dlopen(3)` in order
to make subsequent opens of the same shared library slightly faster (the flag
causes `dlclose(3)` not to remove the mapped DSO from memory and not to
reinitialize its static variables etc on the subsequent call to `dlopen`). The
flag is defined in the NDK without any API level (platform) version restrictions
but, apparently, it fails to work on some API 22 Samsung devices with the
following error:

    F/debug-app-helper( 9171): Failed to dlopen Mono runtime from /data/data/com.companyname.xamarinlearning/files/.__override__/links/libmonosgen-2.0.so: dlopen failed: invalid flags to dlopen: 1003

Remove the flag in order to make our runtime work on the affected devices.