### PR TITLE
[tests] Import regression test for bug 29730

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/BugzillaTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/BugzillaTests.cs
@@ -18,10 +18,11 @@ namespace Xamarin.Android.Build.Tests
 		[TearDown]
 		public void Teardown ()
 		{
-			if (HasDevices)
+			if (HasDevices && proj != null)
 				RunAdbCommand ($"uninstall {proj.PackageName}");
 
-			if (TestContext.CurrentContext.Result.Outcome.Status == NUnit.Framework.Interfaces.TestStatus.Passed && Directory.Exists (builder.ProjectDirectory))
+			if (TestContext.CurrentContext.Result.Outcome.Status == NUnit.Framework.Interfaces.TestStatus.Passed
+				&& builder != null && Directory.Exists (builder.ProjectDirectory))
 				Directory.Delete (builder.ProjectDirectory, recursive: true);
 		}
 

--- a/tests/MSBuildDeviceIntegration/Tests/BugzillaTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/BugzillaTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Xamarin.ProjectTools;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[SingleThreaded]
+	public class BugzillaTests : DeviceTest
+	{
+		static ProjectBuilder builder;
+		static XamarinAndroidApplicationProject proj;
+
+		[OneTimeTearDown]
+		public void AfterDeploymentTests ()
+		{
+			if (HasDevices)
+				RunAdbCommand ($"uninstall {proj.PackageName}");
+
+			if (TestContext.CurrentContext.Result.FailCount == 0 && Directory.Exists (builder.ProjectDirectory))
+				Directory.Delete (builder.ProjectDirectory, recursive: true);
+		}
+
+		[Test]
+		public void GlobalLayoutEvent_ShouldRegisterAndFire_OnActivityLaunch ([Values (false, true)] bool isRelease)
+		{
+			if (!HasDevices)
+				Assert.Ignore ("Skipping Test. No devices available.");
+
+			string expectedLogcatOutput = "Bug 29730: GlobalLayout event handler called!";
+
+			proj = new XamarinAndroidApplicationProject () {
+				IsRelease = isRelease,
+			};
+			if (isRelease || !CommercialBuildAvailable) {
+				proj.SetProperty (KnownProperties.AndroidSupportedAbis, "armeabi-v7a;arm64-v8a;x86");
+			}
+			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_ONCREATE}",
+$@"button.ViewTreeObserver.GlobalLayout += Button_ViewTreeObserver_GlobalLayout;
+		}}
+		void Button_ViewTreeObserver_GlobalLayout (object sender, EventArgs e)
+		{{
+			Android.Util.Log.Debug (""BugzillaTests"", ""{expectedLogcatOutput}"");
+");
+			builder = CreateApkBuilder (Path.Combine ("temp", "Bug29730"));
+			Assert.IsTrue (builder.Install (proj), "Install should have succeeded.");
+			ClearAdbLogcat ();
+			AdbStartActivity ($"{proj.PackageName}/{proj.JavaPackageName}.MainActivity");
+			Assert.IsTrue (MonitorAdbLogcat ((line) => {
+				return line.Contains (expectedLogcatOutput);
+			}, Path.Combine (Root, builder.ProjectDirectory, "startup-logcat.log"), 45), $"Output did not contain {expectedLogcatOutput}!");
+		}
+
+	}
+}


### PR DESCRIPTION
Context: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=3107238&view=ms.vss-test-web.test-result-details
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=29730

This test has been failing with some frequency since it was imported in
the new Integrated Regression test Azure Pipeline jobs. After some
investigation, it appears that the failure is due to test environment
limitations. Some of the Android devices attached to the machine pools
being used for this test job have a lock screen enabled, and in some
cases this is preventing `ViewTreeObserver` events from executing.

Fixes the intermittent failure by moving this test into the
`MSBuildDeviceIntegration` suite which runs on an x86 emulator in CI.
This emulator is never locked and should always display activites for
applications we're installing and launching.