### PR TITLE
[Xamarin.Android.Build.Tasks] AutoSDK doesn't install Tools or Build Tools

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3279,6 +3279,8 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 			var androidSdkPath = Path.Combine (path, "android-sdk");
 			if (createSdkDirectory)
 				Directory.CreateDirectory (androidSdkPath);
+			else if (Directory.Exists (androidSdkPath))
+				Directory.Delete (androidSdkPath, recursive: true);
 			var referencesPath = CreateFauxReferencesDirectory (Path.Combine (path, "xbuild-frameworks"), apis);
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3271,13 +3271,14 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		}
 
 		[Test]
-		public void GetDependencyWhenSDKIsMissingTest ()
+		public void GetDependencyWhenSDKIsMissingTest ([Values (true, false)] bool createSdkDirectory)
 		{
 			var apis = new ApiInfo [] {
 			};
 			var path = Path.Combine ("temp", TestName);
 			var androidSdkPath = Path.Combine (path, "android-sdk");
-			Directory.CreateDirectory (androidSdkPath);
+			if (createSdkDirectory)
+				Directory.CreateDirectory (androidSdkPath);
 			var referencesPath = CreateFauxReferencesDirectory (Path.Combine (path, "xbuild-frameworks"), apis);
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3242,6 +3242,35 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		}
 
 		[Test]
+		public void GetDependencyTest ()
+		{
+			var apis = new ApiInfo [] {
+			};
+			var path = Path.Combine ("temp", TestName);
+			var androidSdkPath = CreateFauxAndroidSdkDirectory (Path.Combine (path, "android-sdk"),
+					null, apis);
+			var referencesPath = CreateFauxReferencesDirectory (Path.Combine (path, "xbuild-frameworks"), apis);
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				TargetFrameworkVersion = "v8.0",
+				UseLatestPlatformSdk = false,
+			};
+			var parameters = new string [] {
+				$"TargetFrameworkRootPath={referencesPath}",
+				$"AndroidSdkDirectory={androidSdkPath}",
+			};
+			var envVar = new Dictionary<string, string>  {
+				{ "XBUILD_FRAMEWORK_FOLDERS_PATH", referencesPath },
+			};
+			using (var builder = CreateApkBuilder (Path.Combine (path, proj.ProjectName), cleanupAfterSuccessfulBuild: false, cleanupOnDispose: false)) {
+				builder.ThrowOnBuildFailure = false;
+				builder.Target = "GetAndroidDependencies";
+				Assert.True (builder.Build (proj, parameters: parameters, environmentVariables: envVar),
+					string.Format ("First Build should have succeeded"));
+			}
+		}
+
+		[Test]
 		public void ValidateUseLatestAndroid ()
 		{
 			var apis = new ApiInfo [] {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -3242,7 +3242,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		}
 
 		[Test]
-		public void GetDependencyTest ()
+		public void GetDependencyWhenBuildToolsAreMissingTest ()
 		{
 			var apis = new ApiInfo [] {
 			};
@@ -3259,14 +3259,44 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 				$"TargetFrameworkRootPath={referencesPath}",
 				$"AndroidSdkDirectory={androidSdkPath}",
 			};
-			var envVar = new Dictionary<string, string>  {
-				{ "XBUILD_FRAMEWORK_FOLDERS_PATH", referencesPath },
-			};
 			using (var builder = CreateApkBuilder (Path.Combine (path, proj.ProjectName), cleanupAfterSuccessfulBuild: false, cleanupOnDispose: false)) {
 				builder.ThrowOnBuildFailure = false;
 				builder.Target = "GetAndroidDependencies";
-				Assert.True (builder.Build (proj, parameters: parameters, environmentVariables: envVar),
+				Assert.True (builder.Build (proj, parameters: parameters),
 					string.Format ("First Build should have succeeded"));
+				StringAssertEx.Contains ("platforms/android-26", builder.LastBuildOutput, "platforms/android-26 should be a dependency.");
+				StringAssertEx.Contains ("build-tools/28.0.3", builder.LastBuildOutput, "build-tools/28.0.3 should be a dependency.");
+				StringAssertEx.Contains ("platform-tools", builder.LastBuildOutput, "platform-tools should be a dependency.");
+			}
+		}
+
+		[Test]
+		public void GetDependencyWhenSDKIsMissingTest ()
+		{
+			var apis = new ApiInfo [] {
+			};
+			var path = Path.Combine ("temp", TestName);
+			var androidSdkPath = Path.Combine (path, "android-sdk");
+			Directory.CreateDirectory (androidSdkPath);
+			var referencesPath = CreateFauxReferencesDirectory (Path.Combine (path, "xbuild-frameworks"), apis);
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				TargetFrameworkVersion = "v8.0",
+				UseLatestPlatformSdk = false,
+			};
+			var parameters = new string [] {
+				$"TargetFrameworkRootPath={referencesPath}",
+				$"AndroidSdkDirectory={androidSdkPath}",
+			};
+
+			using (var builder = CreateApkBuilder (Path.Combine (path, proj.ProjectName), cleanupAfterSuccessfulBuild: false, cleanupOnDispose: false)) {
+				builder.ThrowOnBuildFailure = false;
+				builder.Target = "GetAndroidDependencies";
+				Assert.True (builder.Build (proj, parameters: parameters),
+					string.Format ("First Build should have succeeded"));
+				StringAssertEx.Contains ("platforms/android-26", builder.LastBuildOutput, "platforms/android-26 should be a dependency.");
+				StringAssertEx.Contains ("build-tools/28.0.3", builder.LastBuildOutput, "build-tools/28.0.3 should be a dependency.");
+				StringAssertEx.Contains ("platform-tools", builder.LastBuildOutput, "platform-tools should be a dependency.");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -250,7 +250,7 @@ namespace Xamarin.Android.Build.Tests
 			var androidSdkBinPath = Path.Combine (androidSdkToolsPath, "bin");
 			var androidSdkPlatformToolsPath = Path.Combine (androidSdkDirectory, "platform-tools");
 			var androidSdkPlatformsPath = Path.Combine (androidSdkDirectory, "platforms");
-			var androidSdkBuildToolsPath = Path.Combine (androidSdkDirectory, "build-tools", buildToolsVersion);
+			var androidSdkBuildToolsPath = Path.Combine (androidSdkDirectory, "build-tools", buildToolsVersion ?? string.Empty);
 			Directory.CreateDirectory (androidSdkDirectory);
 			Directory.CreateDirectory (androidSdkToolsPath);
 			Directory.CreateDirectory (androidSdkBinPath);
@@ -259,8 +259,10 @@ namespace Xamarin.Android.Build.Tests
 			Directory.CreateDirectory (androidSdkBuildToolsPath);
 
 			File.WriteAllText (Path.Combine (androidSdkPlatformToolsPath, IsWindows ? "adb.exe" : "adb"), "");
-			File.WriteAllText (Path.Combine (androidSdkBuildToolsPath, IsWindows ? "zipalign.exe" : "zipalign"), "");
-			File.WriteAllText (Path.Combine (androidSdkBuildToolsPath, IsWindows ? "aapt.exe" : "aapt"), "");
+			if (!string.IsNullOrEmpty (buildToolsVersion)) {
+				File.WriteAllText (Path.Combine (androidSdkBuildToolsPath, IsWindows ? "zipalign.exe" : "zipalign"), "");
+				File.WriteAllText (Path.Combine (androidSdkBuildToolsPath, IsWindows ? "aapt.exe" : "aapt"), "");
+			}
 			File.WriteAllText (Path.Combine (androidSdkToolsPath, IsWindows ? "lint.bat" : "lint"), "");
 
 			List<ApiInfo> defaults = new List<ApiInfo> ();

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -834,9 +834,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </Target>
 
 <Target Name="_ResolveSdks" DependsOnTargets="_GetReferenceAssemblyPaths">
-  <PropertyGroup>
-      <_AndroidAllowMissingSdkTooling Condition=" '$(_AndroidAllowMissingSdkTooling)' == '' ">False</_AndroidAllowMissingSdkTooling>
-  </PropertyGroup>
+	<PropertyGroup>
+			<_AndroidAllowMissingSdkTooling Condition=" '$(_AndroidAllowMissingSdkTooling)' == '' ">False</_AndroidAllowMissingSdkTooling>
+	</PropertyGroup>
 	<ResolveSdks
 			AndroidSdkPath="$(AndroidSdkDirectory)"
 			AndroidNdkPath="$(AndroidNdkDirectory)"
@@ -883,7 +883,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 			SequencePointsMode="$(_AndroidSequencePointsMode)"
 			ProjectFilePath="$(MSBuildProjectFullPath)"			
 			LintToolPath="$(LintToolPath)"
-      ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
+			ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
 			ZipAlignPath="$(ZipAlignToolPath)">
 		<Output TaskParameter="TargetFrameworkVersion"      PropertyName="TargetFrameworkVersion" />
 		<Output TaskParameter="AndroidApiLevel"             PropertyName="_AndroidApiLevel"            Condition="'$(_AndroidApiLevel)' == ''" />
@@ -3445,7 +3445,7 @@ because xbuild doesn't support framework reference assemblies.
 <!-- SDK Management Targets -->
 <Target Name="_BeforeGetAndroidDependencies">
     <PropertyGroup>
-      <_AndroidAllowMissingSdkTooling>True</_AndroidAllowMissingSdkTooling>
+        <_AndroidAllowMissingSdkTooling>True</_AndroidAllowMissingSdkTooling>
     </PropertyGroup>
 </Target> 
  

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -834,6 +834,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </Target>
 
 <Target Name="_ResolveSdks" DependsOnTargets="_GetReferenceAssemblyPaths">
+  <PropertyGroup>
+      <_AndroidAllowMissingSdkTooling Condition=" '$(_AndroidAllowMissingSdkTooling)' == '' ">False</_AndroidAllowMissingSdkTooling>
+  </PropertyGroup>
 	<ResolveSdks
 			AndroidSdkPath="$(AndroidSdkDirectory)"
 			AndroidNdkPath="$(AndroidNdkDirectory)"
@@ -880,6 +883,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 			SequencePointsMode="$(_AndroidSequencePointsMode)"
 			ProjectFilePath="$(MSBuildProjectFullPath)"			
 			LintToolPath="$(LintToolPath)"
+      ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
 			ZipAlignPath="$(ZipAlignToolPath)">
 		<Output TaskParameter="TargetFrameworkVersion"      PropertyName="TargetFrameworkVersion" />
 		<Output TaskParameter="AndroidApiLevel"             PropertyName="_AndroidApiLevel"            Condition="'$(_AndroidApiLevel)' == ''" />
@@ -3439,7 +3443,13 @@ because xbuild doesn't support framework reference assemblies.
 
 
 <!-- SDK Management Targets -->
-<Target Name="GetAndroidDependencies" DependsOnTargets="_SetLatestTargetFrameworkVersion;$(GetAndroidDependenciesDependsOn)" Returns="@(AndroidDependency)">
+<Target Name="_BeforeGetAndroidDependencies">
+    <PropertyGroup>
+      <_AndroidAllowMissingSdkTooling>True</_AndroidAllowMissingSdkTooling>
+    </PropertyGroup>
+</Target> 
+ 
+<Target Name="GetAndroidDependencies" DependsOnTargets="_BeforeGetAndroidDependencies;_SetLatestTargetFrameworkVersion;$(GetAndroidDependenciesDependsOn)" Returns="@(AndroidDependency)">
   <PropertyGroup>
     <_ProjectAndroidManifest>$(ProjectDir)$(AndroidManifest)</_ProjectAndroidManifest>
     <_NdkRequired Condition="'$(BundleAssemblies)' == 'True' Or '$(AotAssemblies)' == 'True'">true</_NdkRequired>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -835,7 +835,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 <Target Name="_ResolveSdks" DependsOnTargets="_GetReferenceAssemblyPaths">
 	<PropertyGroup>
-			<_AndroidAllowMissingSdkTooling Condition=" '$(_AndroidAllowMissingSdkTooling)' == '' ">False</_AndroidAllowMissingSdkTooling>
+    <_AndroidAllowMissingSdkTooling Condition=" '$(_AndroidAllowMissingSdkTooling)' == '' ">False</_AndroidAllowMissingSdkTooling>
 	</PropertyGroup>
 	<ResolveSdks
 			AndroidSdkPath="$(AndroidSdkDirectory)"
@@ -871,6 +871,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		<Output TaskParameter="MinimumRequiredJdkVersion" PropertyName="_DefaultJdkVersion" />
 	</ValidateJavaVersion>
 	<ResolveAndroidTooling
+			ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
 			TargetFrameworkVersion="$(TargetFrameworkVersion)"
 			AndroidApiLevel="$(AndroidApiLevel)"
 			AndroidApplication="$(AndroidApplication)"
@@ -883,7 +884,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 			SequencePointsMode="$(_AndroidSequencePointsMode)"
 			ProjectFilePath="$(MSBuildProjectFullPath)"			
 			LintToolPath="$(LintToolPath)"
-			ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
 			ZipAlignPath="$(ZipAlignToolPath)">
 		<Output TaskParameter="TargetFrameworkVersion"      PropertyName="TargetFrameworkVersion" />
 		<Output TaskParameter="AndroidApiLevel"             PropertyName="_AndroidApiLevel"            Condition="'$(_AndroidApiLevel)' == ''" />
@@ -3444,9 +3444,9 @@ because xbuild doesn't support framework reference assemblies.
 
 <!-- SDK Management Targets -->
 <Target Name="_BeforeGetAndroidDependencies">
-    <PropertyGroup>
-        <_AndroidAllowMissingSdkTooling>True</_AndroidAllowMissingSdkTooling>
-    </PropertyGroup>
+  <PropertyGroup>
+    <_AndroidAllowMissingSdkTooling>True</_AndroidAllowMissingSdkTooling>
+  </PropertyGroup>
 </Target> 
  
 <Target Name="GetAndroidDependencies" DependsOnTargets="_BeforeGetAndroidDependencies;_SetLatestTargetFrameworkVersion;$(GetAndroidDependenciesDependsOn)" Returns="@(AndroidDependency)">


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/994496

When we call `GetAndroidDependencies` we expect to get
a list of TaskItems back describing the tooling the
project needs.

However if certain parts of the Android SDK have NOT
been installed we get errors such as

	XA5205: Cannot find aapt.exe. Please install the Android SDK Build-tools package with the C:\Program Files (x86)\Android\android-sdk\tools\android.bat program.

This is because `ResolveAndroidTooling` throws an error. This
is expected behaviour when building an app. However when calling
`GetAndroidDependencies` we dont want it to throw. So lets
add a property which will control the `ContinueOnError` property
of the task. Doing a normal build the error will be reported.
However when calling via the `GetAndroidDependencies` target,
the error will be converted into a warning so that the later
tasks can still complete.