### PR TITLE
[XA.Build.Tasks] Fix file hashing using statement

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAdditionalResourcesFromAssemblies.cs
@@ -213,20 +213,21 @@ namespace Xamarin.Android.Tasks
 			}
 
 			var hashFile = file + ".sha1";
-			using (hashAlgorithm)
-			if (File.Exists (hashFile) && string.Compare (File.ReadAllText (hashFile), sha1, StringComparison.InvariantCultureIgnoreCase) == 0)
-				return true;
+			using (hashAlgorithm) {
+				if (File.Exists (hashFile) && string.Compare (File.ReadAllText (hashFile), sha1, StringComparison.InvariantCultureIgnoreCase) == 0)
+					return true;
 
-			var hash = Files.HashFile (file, hashAlgorithm);
-			LogDebugMessage ("File : {0}", file);
-			LogDebugMessage ("SHA1 : {0}", hash);
-			LogDebugMessage ("Expected SHA1 : {0}", sha1);
+				var hash = Files.HashFile (file, hashAlgorithm);
+				LogDebugMessage ("File : {0}", file);
+				LogDebugMessage ("SHA1 : {0}", hash);
+				LogDebugMessage ("Expected SHA1 : {0}", sha1);
 
-			var isValid = string.Compare (hash, sha1, StringComparison.InvariantCultureIgnoreCase) == 0;
-			if (isValid)
-				File.WriteAllText (hashFile, hash);
+				var isValid = string.Compare (hash, sha1, StringComparison.InvariantCultureIgnoreCase) == 0;
+				if (isValid)
+					File.WriteAllText (hashFile, hash);
 
-			return isValid;
+				return isValid;
+			}
 		}
 
 		void DoDownload (long totalBytes, long offset, Stream responseStream, Stream outputStream, Action<long, long, int> progressCallback = null)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GetAdditionalResourcesFromAssembliesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GetAdditionalResourcesFromAssembliesTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using Xamarin.ProjectTools;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	public class GetAdditionalResourcesFromAssembliesTests : BaseTest
+	{
+
+		[Test]
+		public void IsValidDownloadTest ()
+		{
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = true,
+				PackageReferences = {
+					KnownPackages.SupportCompat_24_2_1,
+				},
+				TargetFrameworkVersion = "v7.0",
+			};
+			using (var b = CreateApkBuilder (Path.Combine("temp", "IsValidDownloadTest"))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -95,6 +95,7 @@
   <ItemGroup>
     <Compile Include="Tasks\AndroidRegExTests.cs" />
     <Compile Include="Tasks\CopyIfChangedTests.cs" />
+    <Compile Include="Tasks\GetAdditionalResourcesFromAssembliesTests.cs" />
     <Compile Include="Tasks\GetDependenciesTests.cs" />
     <Compile Include="Tasks\RemoveDirTests.cs" />
     <Compile Include="Tasks\ResolveMonoAndroidSdksTests.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -212,6 +212,15 @@ namespace Xamarin.ProjectTools
 					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.v7.AppCompat.25.4.0.1\\lib\\MonoAndroid70\\Xamarin.Android.Support.v7.AppCompat.dll" }
 			}
 		};
+		public static Package SupportCompat_24_2_1 = new Package {
+			Id = "Xamarin.Android.Support.Compat",
+			Version = "24.2.1",
+			TargetFramework = "MonoAndroid70",
+			References = {
+				new BuildItem.Reference ("Xamarin.Android.Support.Compat") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Android.Support.Compat.24.2.1\\lib\\MonoAndroid70\\Xamarin.Android.Support.Compat.dll" }
+			}
+		};
 		public static Package SupportCompat_25_4_0_1 = new Package {
 			Id = "Xamarin.Android.Support.Compat",
 			Version = "25.4.0.1",


### PR DESCRIPTION
Context: https://dev.azure.com/devdiv/DevDiv/_releaseProgress?releaseId=469145&_a=release-environment-extension&environmentId=2323128&extensionId=ms.vss-test-web.test-result-in-release-environment-editor-tab&runId=8876788&resultId=100476&paneView=debug
Context: https://github.com/xamarin/xamarin-android/commit/88a1d6cd88e68bda208a6eb05d99d802c7800d2e

Adds missing braces to a using statement to fix the following
`ObjectDisposedException`:

    C:\Program Files (x86)\Microsoft Visual Studio\2019\IntPreview\MSBuild\Xamarin\Android\Xamarin.Android.Common.targets(535,3): warning XA0121: Assembly 'Xamarin.Android.Support.Compat.dll' is using a deprecated attribute '[assembly: Java.Interop.JavaLibraryReferenceAttribute]'. Use a newer version of this NuGet package or notify the library author. [C:\agent\_work\r1\a\mc\N-02-KittenView\KittenView.Droid\KittenView.Droid.csproj]
      Making sure we have https://dl-ssl.google.com/android/repository/android_m2repository_r38.zip downloaded and extracted m2repository/com/android/support/support-compat/24.2.1/support-compat-24.2.1.aar from it... (TaskId:126)
    C:\Program Files (x86)\Microsoft Visual Studio\2019\IntPreview\MSBuild\Xamarin\Android\Xamarin.Android.Common.targets(535,3): error : Cannot access a disposed object. [C:\agent\_work\r1\a\mc\N-02-KittenView\KittenView.Droid\KittenView.Droid.csproj]
    C:\Program Files (x86)\Microsoft Visual Studio\2019\IntPreview\MSBuild\Xamarin\Android\Xamarin.Android.Common.targets(535,3): error :    at System.Security.Cryptography.HashAlgorithm.ComputeHash(Stream inputStream) [C:\agent\_work\r1\a\mc\N-02-KittenView\KittenView.Droid\KittenView.Droid.csproj]
    C:\Program Files (x86)\Microsoft Visual Studio\2019\IntPreview\MSBuild\Xamarin\Android\Xamarin.Android.Common.targets(535,3): error :    at Xamarin.Android.Tools.Files.HashFile(String filename, HashAlgorithm hashAlg) [C:\agent\_work\r1\a\mc\N-02-KittenView\KittenView.Droid\KittenView.Droid.csproj]
    C:\Program Files (x86)\Microsoft Visual Studio\2019\IntPreview\MSBuild\Xamarin\Android\Xamarin.Android.Common.targets(535,3): error :    at Xamarin.Android.Tasks.GetAdditionalResourcesFromAssemblies.IsValidDownload(String file, String sha1) [C:\agent\_work\r1\a\mc\N-02-KittenView\KittenView.Droid\KittenView.Droid.csproj]
    C:\Program Files (x86)\Microsoft Visual Studio\2019\IntPreview\MSBuild\Xamarin\Android\Xamarin.Android.Common.targets(535,3): error :    at Xamarin.Android.Tasks.GetAdditionalResourcesFromAssemblies.MakeSureLibraryIsInPlace(String destinationBase, String url, String version, String embeddedArchive, String sha1) [C:\agent\_work\r1\a\mc\N-02-KittenView\KittenView.Droid\KittenView.Droid.csproj]
    C:\Program Files (x86)\Microsoft Visual Studio\2019\IntPreview\MSBuild\Xamarin\Android\Xamarin.Android.Common.targets(535,3): error :    at Xamarin.Android.Tasks.GetAdditionalResourcesFromAssemblies.AddAttributeValue(ICollection`1 items, CustomAttributeValue`1 attributeValue, String errorCode, String errorFmt, Boolean isDirectory, String fullPath, String attributeFullName) [C:\agent\_work\r1\a\mc\N-02-KittenView\KittenView.Droid\KittenView.Droid.csproj]
    C:\Program Files (x86)\Microsoft Visual Studio\2019\IntPreview\MSBuild\Xamarin\Android\Xamarin.Android.Common.targets(535,3): error :    at Xamarin.Android.Tasks.GetAdditionalResourcesFromAssemblies.<RunTaskAsync>d__38.MoveNext() [C:\agent\_work\r1\a\mc\N-02-KittenView\KittenView.Droid\KittenView.Droid.csproj]
    Done executing task "GetAdditionalResourcesFromAssemblies" -- FAILED. (TaskId:126)