### PR TITLE
[Xamarin.Android.Build.Tests] Done run BuildLibraryWhichUsesResources in parallel.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -133,6 +133,7 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[TestCaseSource (nameof (ClassParseOptions))]
+		[NonParallelizable]
 		public void BuildLibraryZipBindigLibraryWithAarOfJar (string classParser)
 		{
 			var proj = new XamarinAndroidBindingProject () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1768,6 +1768,7 @@ namespace App1
 		}
 
 		[Test]
+		[NonParallelizable]
 		/// <summary>
 		/// Reference https://bugzilla.xamarin.com/show_bug.cgi?id=29568
 		/// </summary>


### PR DESCRIPTION
We have a race condition. If the `BuildLibraryWhichUsesResources`
tests run at the same time it causes the following
type of errors.

	error APT2260: resource style/Platform.V11.AppCompat.Light (aka UnnamedProject.UnnamedProject:style/Platform.V11.AppCompat.Light) not found.
	error APT2062: failed linking references.

This seems to be because both tests try to extract files
into the same global cache directory. What ends up happening
is we end up with an empty directory and no files.
This is because of the `GetAdditionalResourcesFromAssemblies`
task, which we are deprecating anyway.

So lets not run these in parellel, so they do not trip over
each other.