### PR TITLE
[C++ification] Continue converting code to "proper" C++

### DIFF
--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -275,6 +275,10 @@ if(NOT WIN32 AND NOT MINGW)
 	${SOURCES_DIR}/shared-constants.cc
 	)
   add_library(xamarin-debug-app-helper SHARED ${XAMARIN_DEBUG_APP_HELPER_SOURCES})
+  target_compile_definitions(
+	xamarin-debug-app-helper
+	PUBLIC -DDEBUG_APP_HELPER
+	)
 endif()
 
 set(SOURCES_FRAGMENT_FILE "sources.projitems")

--- a/src/monodroid/jni/android-system.hh
+++ b/src/monodroid/jni/android-system.hh
@@ -15,12 +15,12 @@
 
 #include <mono/jit/jit.h>
 
-namespace xamarin { namespace android {
+namespace xamarin::android {
 	class jstring_wrapper;
 	class jstring_array_wrapper;
-}}
+}
 
-namespace xamarin { namespace android { namespace internal
+namespace xamarin::android::internal
 {
 #if defined (DEBUG) || !defined (ANDROID)
 	struct BundledProperty;
@@ -45,13 +45,13 @@ namespace xamarin { namespace android { namespace internal
 		void  create_update_dir (char *override_dir);
 		int   monodroid_get_system_property (const char *name, char **value);
 		size_t monodroid_get_system_property_from_overrides (const char *name, char ** value);
-		size_t monodroid_read_file_into_memory (const char *path, char **value);
+		size_t monodroid_read_file_into_memory (const char *path, char *&value);
 		char* get_bundled_app (JNIEnv *env, jstring dir);
 		int   count_override_assemblies ();
 		long  get_gref_gc_threshold ();
 		void* load_dso (const char *path, int dl_flags, bool skip_exists_check);
 		void* load_dso_from_any_directories (const char *name, int dl_flags);
-		char* get_full_dso_path_on_disk (const char *dso_name, bool *needs_free);
+		char* get_full_dso_path_on_disk (const char *dso_name, bool &needs_free);
 		monodroid_dirent_t* readdir (monodroid_dir_t *dir);
 
 		long get_max_gref_count () const
@@ -106,11 +106,11 @@ namespace xamarin { namespace android { namespace internal
 #if defined (DEBUG) || !defined (ANDROID)
 		size_t  _monodroid_get_system_property_from_file (const char *path, char **value);
 #endif
-		char* get_full_dso_path (const char *base_dir, const char *dso_path, bool *needs_free);
+		char* get_full_dso_path (const char *base_dir, const char *dso_path, bool &needs_free);
 		void* load_dso_from_specified_dirs (const char **directories, size_t num_entries, const char *dso_name, int dl_flags);
 		void* load_dso_from_app_lib_dirs (const char *name, int dl_flags);
 		void* load_dso_from_override_dirs (const char *name, int dl_flags);
-		char* get_existing_dso_path_on_disk (const char *base_dir, const char *dso_name, bool *needs_free);
+		char* get_existing_dso_path_on_disk (const char *base_dir, const char *dso_name, bool &needs_free);
 
 #if defined (WINDOWS)
 		struct _wdirent* readdir_windows (_WDIR *dirp);
@@ -127,5 +127,5 @@ namespace xamarin { namespace android { namespace internal
 		MonoAotMode aotMode = MonoAotMode::MONO_AOT_MODE_NONE;
 		bool running_in_emulator = false;
 	};
-}}}
+}
 #endif // !__ANDROID_SYSTEM_H

--- a/src/monodroid/jni/basic-android-system.cc
+++ b/src/monodroid/jni/basic-android-system.cc
@@ -9,20 +9,6 @@ using namespace xamarin::android::internal;
 char* BasicAndroidSystem::override_dirs [MAX_OVERRIDES];
 const char **BasicAndroidSystem::app_lib_directories;
 size_t BasicAndroidSystem::app_lib_directories_size = 0;
-#if WINDOWS
-static const char *SYSTEM_LIB_PATH;
-#endif
-
-// Values correspond to the CPU_KIND_* macros
-const char* BasicAndroidSystem::android_abi_names[CPU_KIND_X86_64+1] = {
-	"unknown",
-	[CPU_KIND_ARM]      = "armeabi-v7a",
-	[CPU_KIND_ARM64]    = "arm64-v8a",
-	[CPU_KIND_MIPS]     = "mips",
-	[CPU_KIND_X86]      = "x86",
-	[CPU_KIND_X86_64]   = "x86_64",
-};
-#define ANDROID_ABI_NAMES_SIZE (sizeof(android_abi_names) / sizeof (android_abi_names[0]))
 
 void
 BasicAndroidSystem::setup_app_library_directories (JNIEnv *env, jstring_array_wrapper& runtimeApks, jstring_array_wrapper& appDirs, int androidApiLevel)
@@ -30,12 +16,12 @@ BasicAndroidSystem::setup_app_library_directories (JNIEnv *env, jstring_array_wr
 	if (androidApiLevel < 23 || !is_embedded_dso_mode_enabled ()) {
 		log_info (LOG_DEFAULT, "Setting up for DSO lookup in app data directories");
 		BasicAndroidSystem::app_lib_directories_size = 1;
-		BasicAndroidSystem::app_lib_directories = (const char**) xcalloc (BasicAndroidSystem::app_lib_directories_size, sizeof(char*));
-		BasicAndroidSystem::app_lib_directories [0] = strdup (appDirs[2].get_cstr ());
+		BasicAndroidSystem::app_lib_directories = reinterpret_cast<const char**>(new char[app_lib_directories_size]());
+		BasicAndroidSystem::app_lib_directories [0] = utils.strdup_new (appDirs[2].get_cstr ());
 	} else {
 		log_info (LOG_DEFAULT, "Setting up for DSO lookup directly in the APK");
 		BasicAndroidSystem::app_lib_directories_size = runtimeApks.get_length ();
-		BasicAndroidSystem::app_lib_directories = (const char**) xcalloc (BasicAndroidSystem::app_lib_directories_size, sizeof(char*));
+		BasicAndroidSystem::app_lib_directories = reinterpret_cast<const char**>(new char[app_lib_directories_size]());
 
 		unsigned short built_for_cpu = 0, running_on_cpu = 0;
 		unsigned char is64bit = 0;
@@ -60,7 +46,7 @@ BasicAndroidSystem::add_apk_libdir (const char *apk, size_t index, size_t apk_co
 {
 	assert (user_data != nullptr);
 	assert (index >= 0 && index < app_lib_directories_size);
-	app_lib_directories [index] = utils.monodroid_strdup_printf ("%s!/lib/%s", apk, (const char*)user_data);
+	app_lib_directories [index] = utils.string_concat (apk, "!/lib/", static_cast<const char*>(user_data));
 }
 
 void

--- a/src/monodroid/jni/basic-android-system.hh
+++ b/src/monodroid/jni/basic-android-system.hh
@@ -15,7 +15,16 @@ namespace xamarin::android::internal
 		using ForEachApkHandler = void (BasicAndroidSystem::*) (const char *apk, size_t index, size_t apk_count, void *user_data);
 
 	private:
-		static const char* android_abi_names[CPU_KIND_X86_64+1];
+		// Values correspond to the CPU_KIND_* macros
+		static constexpr const char* android_abi_names[CPU_KIND_X86_64+1] = {
+			"unknown",
+			[CPU_KIND_ARM]      = "armeabi-v7a",
+			[CPU_KIND_ARM64]    = "arm64-v8a",
+			[CPU_KIND_MIPS]     = "mips",
+			[CPU_KIND_X86]      = "x86",
+			[CPU_KIND_X86_64]   = "x86_64",
+		};
+		static constexpr size_t ANDROID_ABI_NAMES_SIZE = sizeof(android_abi_names) / sizeof (android_abi_names[0]);
 
 	public:
 #ifdef ANDROID64

--- a/src/monodroid/jni/basic-utilities.hh
+++ b/src/monodroid/jni/basic-utilities.hh
@@ -64,7 +64,6 @@ namespace xamarin::android
 		char           **monodroid_strsplit (const char *str, const char *delimiter, size_t max_tokens);
 		char            *monodroid_strdup_printf (const char *format, ...);
 		char            *monodroid_strdup_vprintf (const char *format, va_list vargs);
-		int              ends_with (const char *str, const char *end);
 		char*            path_combine(const char *path1, const char *path2);
 		void             create_public_directory (const char *dir);
 		int              create_directory (const char *pathname, mode_t mode);
@@ -73,6 +72,19 @@ namespace xamarin::android
 		bool             file_exists (const char *file);
 		bool             directory_exists (const char *directory);
 		bool             file_copy (const char *to, const char *from);
+
+		bool ends_with_slow (const char *str, const char *end)
+		{
+			char *p = const_cast<char*> (strstr (str, end));
+			return p != nullptr && p [strlen (end)] == '\0';
+		}
+
+		template<size_t N>
+		bool ends_with (const char *str, const char (&end)[N])
+		{
+			char *p = const_cast<char*> (strstr (str, end));
+			return p != nullptr && p [N - 1] == '\0';
+		}
 
 		void *xmalloc (size_t size)
 		{

--- a/src/monodroid/jni/debug-app-helper.cc
+++ b/src/monodroid/jni/debug-app-helper.cc
@@ -27,8 +27,10 @@ void log_warn (LogCategories category, const char *format, ...);
 void log_error (LogCategories category, const char *format, ...);
 void log_fatal (LogCategories category, const char *format, ...);
 
+#if !defined (RELEASE)
 static void copy_file_to_internal_location (char *to_dir, char *from_dir, char *file);
 static void copy_native_libraries_to_internal_location ();
+#endif
 static char* get_libmonosgen_path ();
 
 bool maybe_load_library (const char *path);
@@ -95,7 +97,7 @@ Java_mono_android_DebugRuntime_init (JNIEnv *env, jclass klass, jobjectArray run
 	}
 }
 
-#ifdef ANDROID
+#if defined (ANDROID) && !defined (RELEASE)
 static void
 copy_file_to_internal_location (char *to_dir, char *from_dir, char *file)
 {
@@ -130,7 +132,7 @@ copy_file_to_internal_location (char *to_dir, char *from_dir, char *file)
 	delete[] from_file;
 	delete[] to_file;
 }
-#else  /* !defined (ANDROID) */
+#elif !defined (RELEASE)  /* !defined (ANDROID) */
 static void
 copy_file_to_internal_location (char *to_dir, char *from_dir, char* file)
 {

--- a/src/monodroid/jni/debug.hh
+++ b/src/monodroid/jni/debug.hh
@@ -49,15 +49,15 @@ namespace xamarin::android
 
 #if !defined (WINDOWS) && defined (DEBUG)
 	public:
-		int          enable_soft_breakpoints ();
+		bool         enable_soft_breakpoints ();
 		void         start_debugging_and_profiling ();
 
 	private:
 		int          start_connection (char *options);
 		void         parse_options (char *options, ConnOptions *opts);
-		int          process_connection (int fd);
+		bool         process_connection (int fd);
 		int          handle_server_connection (void);
-		int          process_cmd (int fd, char *cmd);
+		bool         process_cmd (int fd, char *cmd);
 		void         start_debugging ();
 		void         start_profiling ();
 		friend void* conn_thread (void *arg);

--- a/src/monodroid/jni/embedded-assemblies.cc
+++ b/src/monodroid/jni/embedded-assemblies.cc
@@ -42,12 +42,6 @@ namespace xamarin::android::internal {
 using namespace xamarin::android;
 using namespace xamarin::android::internal;
 
-const char *EmbeddedAssemblies::suffixes[] = {
-	"",
-	".dll",
-	".exe",
-};
-
 void EmbeddedAssemblies::set_assemblies_prefix (const char *prefix)
 {
 	if (assemblies_prefix_override != nullptr)
@@ -77,7 +71,7 @@ EmbeddedAssemblies::open_from_bundles (MonoAssemblyName* aname, bool ref_only)
 	char *ename = name + strlen (name);
 
 	MonoAssembly *a = nullptr;
-	for (size_t si = 0; si < sizeof (suffixes)/sizeof (suffixes [0]) && a == nullptr; ++si) {
+	for (size_t si = 0; si < SUFFIXES_SIZE && a == nullptr; ++si) {
 		MonoBundledAssembly **p;
 
 		*ename = '\0';
@@ -334,7 +328,7 @@ EmbeddedAssemblies::try_load_typemaps_from_directory (const char *path)
 		char *file_path = utils.path_combine (dir_path, file_name);
 		if (utils.monodroid_dirent_hasextension (e, ".mj") || utils.monodroid_dirent_hasextension (e, ".jm")) {
 			char *val = nullptr;
-			size_t len = androidSystem.monodroid_read_file_into_memory (file_path, &val);
+			size_t len = androidSystem.monodroid_read_file_into_memory (file_path, val);
 			if (len > 0 && val != nullptr) {
 				if (utils.monodroid_dirent_hasextension (e, ".mj")) {
 					if (!add_type_mapping (&managed_to_java_maps, file_path, override_typemap_entry_name, ((const char*)val)))

--- a/src/monodroid/jni/embedded-assemblies.hh
+++ b/src/monodroid/jni/embedded-assemblies.hh
@@ -29,7 +29,12 @@ namespace xamarin::android::internal {
 #if defined (DEBUG) || !defined (ANDROID)
 		static constexpr char override_typemap_entry_name[] = ".__override__";
 #endif
-		static const char *suffixes[];
+		static constexpr const char *suffixes[] = {
+			"",
+			".dll",
+			".exe",
+		};
+		static constexpr size_t SUFFIXES_SIZE = sizeof(suffixes) / sizeof (suffixes[0]);
 
 	public:
 		/* filename is e.g. System.dll, System.dll.mdb, System.pdb */

--- a/src/monodroid/jni/external-api.cc
+++ b/src/monodroid/jni/external-api.cc
@@ -204,18 +204,96 @@ monodroid_timing_stop (managed_timing_sequence *sequence, const char *message)
 	timing->release_sequence (sequence);
 }
 
+MONO_API void
+monodroid_strfreev (char **str_array)
+{
+	utils.monodroid_strfreev (str_array);
+}
+
+MONO_API char**
+monodroid_strsplit (const char *str, const char *delimiter, size_t max_tokens)
+{
+	return utils.monodroid_strsplit (str, delimiter, max_tokens);
+}
+
+MONO_API char*
+monodroid_strdup_printf (const char *format, ...)
+{
+	va_list args;
+
+	va_start (args, format);
+	char *ret = utils.monodroid_strdup_vprintf (format, args);
+	va_end (args);
+
+	return ret;
+}
+
 MONO_API char*
 monodroid_TypeManager_get_java_class_name (jclass klass)
 {
 	return monodroidRuntime.get_java_class_name_for_TypeManager (klass);
 }
 
-extern "C" void* monodroid_dylib_mono_new (const char *libmono_path)
+MONO_API void
+monodroid_store_package_name (const char *name)
+{
+	utils.monodroid_store_package_name (name);
+}
+
+MONO_API int
+monodroid_get_namespaced_system_property (const char *name, char **value)
+{
+	return static_cast<int>(utils.monodroid_get_namespaced_system_property (name, value));
+}
+
+MONO_API FILE*
+monodroid_fopen (const char* filename, const char* mode)
+{
+	return utils.monodroid_fopen (filename, mode);
+}
+
+MONO_API int
+send_uninterrupted (int fd, void *buf, int len)
+{
+	if (len < 0)
+		len = 0;
+	return utils.send_uninterrupted (fd, buf, static_cast<size_t>(len));
+}
+
+MONO_API int
+recv_uninterrupted (int fd, void *buf, int len)
+{
+	if (len < 0)
+		len = 0;
+	return static_cast<int>(utils.recv_uninterrupted (fd, buf, static_cast<size_t>(len)));
+}
+
+MONO_API void
+set_world_accessable (const char *path)
+{
+	utils.set_world_accessable (path);
+}
+
+MONO_API void
+create_public_directory (const char *dir)
+{
+	utils.create_public_directory (dir);
+}
+
+MONO_API char*
+path_combine (const char *path1, const char *path2)
+{
+	return utils.path_combine (path1, path2);
+}
+
+MONO_API void*
+monodroid_dylib_mono_new (const char *libmono_path)
 {
 	return nullptr;
 }
 
-extern "C" void monodroid_dylib_mono_free (void *mono_imports)
+MONO_API void
+monodroid_dylib_mono_free (void *mono_imports)
 {
 	// no-op
 }
@@ -226,14 +304,16 @@ extern "C" void monodroid_dylib_mono_free (void *mono_imports)
 
   it should also accept libmono_path = nullptr parameter
 */
-extern "C" int monodroid_dylib_mono_init (void *mono_imports, const char *libmono_path)
+MONO_API int
+monodroid_dylib_mono_init (void *mono_imports, const char *libmono_path)
 {
 	if (mono_imports == nullptr)
 		return FALSE;
 	return TRUE;
 }
 
-extern "C" void*  monodroid_get_dylib (void)
+MONO_API void*
+monodroid_get_dylib (void)
 {
 	return nullptr;
 }

--- a/src/monodroid/jni/globals.hh
+++ b/src/monodroid/jni/globals.hh
@@ -2,8 +2,13 @@
 #ifndef __GLOBALS_H
 #define __GLOBALS_H
 
+#if !defined (DEBUG_APP_HELPER)
 #include "util.hh"
+#else
+#include "basic-utilities.hh"
+#endif
 #include "timing.hh"
+
 #include "debug.hh"
 #include "embedded-assemblies.hh"
 #include "inmemory-assemblies.hh"
@@ -11,7 +16,11 @@
 #include "cppcompat.hh"
 
 extern xamarin::android::Debug debug;
+#if !defined (DEBUG_APP_HELPER)
 extern xamarin::android::Util utils;
+#else
+extern xamarin::android::BasicUtilities utils;
+#endif
 extern xamarin::android::internal::AndroidSystem androidSystem;
 extern xamarin::android::internal::OSBridge osBridge;
 extern xamarin::android::internal::EmbeddedAssemblies embeddedAssemblies;

--- a/src/monodroid/jni/inmemory-assemblies.cc
+++ b/src/monodroid/jni/inmemory-assemblies.cc
@@ -9,7 +9,7 @@ extern "C" {
 #include "java-interop-util.h"
 }
 
-namespace xamarin::android::internal {
+using namespace xamarin::android::internal;
 
 void
 InMemoryAssemblies::add_or_update_from_java (MonoDomain *domain, JNIEnv *env, jstring_array_wrapper &assemblies, jobjectArray assembliesBytes)
@@ -157,6 +157,4 @@ InMemoryAssemblies::InMemoryAssemblyEntry::~InMemoryAssemblyEntry ()
 	delete[] names;
 	delete[] assemblies_bytes;
 	delete[] assemblies_bytes_len;
-}
-
 }

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -152,7 +152,7 @@ MonodroidRuntime::setup_bundled_app (const char *dso_name)
 	} else {
 		bool needs_free = false;
 		log_info (LOG_DEFAULT, "bundle app: normal mode");
-		char *bundle_path = androidSystem.get_full_dso_path_on_disk (dso_name, &needs_free);
+		char *bundle_path = androidSystem.get_full_dso_path_on_disk (dso_name, needs_free);
 		log_info (LOG_DEFAULT, "bundle_path == %s", bundle_path ? bundle_path : "<nullptr>");
 		if (bundle_path == nullptr)
 			return;
@@ -226,7 +226,7 @@ MonodroidRuntime::log_jit_event (MonoMethod *method, const char *event_name)
 	char* name = mono_method_full_name (method, 1);
 
 	timing_diff diff (jit_time);
-	fprintf (jit_log, "JIT method %6s: %s elapsed: %lis:%u::%u\n", event_name, name, diff.sec, diff.ms, diff.ns);
+	fprintf (jit_log, "JIT method %6s: %s elapsed: %lis:%u::%u\n", event_name, name, static_cast<long int>(diff.sec), diff.ms, diff.ns);
 
 	free (name);
 }

--- a/src/monodroid/jni/util.hh
+++ b/src/monodroid/jni/util.hh
@@ -64,6 +64,8 @@ namespace xamarin::android
 {
 	class Util : public BasicUtilities
 	{
+		static constexpr const char hex_chars [] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+
 #if defined (ANDROID) || defined (LINUX)
 		using timestruct = timespec;
 #else


### PR DESCRIPTION
Next commit in the series of making our native code use "proper" C++ constructs,
take advantage of the language's features etc. Changes:
    
  * Fix more compilation warnings arising from differences between platforms
  * Compare pointers against `nullptr` instead of the traditional `!p` C-style check
  * Use the `simple_pointer_guard` class in more places
  * Use references to pointers instead of pointers to pointers in a handful of
    places to decrease the number of null checks
  * Switch nested namespace declarations to C++17 style
  * Make `Util::ends_with` slightly faster when used with literal strings,
    taking advantage of C++ templates
  * Move variable declarations closer to places where they are actually used
  * Move a number of extern "C" functions to `external-api.cc`