### PR TITLE
[tests/MSBuildDeviceIntegation] Fix TestAndroidStoreKey to check for Device.

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -364,6 +364,10 @@ namespace Xamarin.Android.Build.Tests
 		[TestCaseSource (nameof (AndroidStoreKeyTests))]
 		public void TestAndroidStoreKey (bool useApkSigner, bool isRelease, string packageFormat, string androidKeyStore, string password, string expected, bool shouldInstall)
 		{
+			if (!HasDevices) {
+				Assert.Ignore ("Test Skipped no devices or emulators found.");
+			}
+
 			string path = Path.Combine ("temp", TestName.Replace (expected, expected.Replace ("-", "_")));
 			string storepassfile = Path.Combine (Root, path, "storepass.txt");
 			string keypassfile = Path.Combine (Root, path, "keypass.txt");


### PR DESCRIPTION
Commit 5745b601 added a new unit test `TestAndroidStoreKey`.
However this test needs to have a device present in order
to run correctly. The test did not include the standard
`HasDevices` check at the start of the test. As a result
the test will fail if we don't have a device. We should
Ignore this test if we do not have a device like we do
on other tests in this project.