### PR TITLE
[Xamarin.Android.Build.Tasks] Add some new AAPT2 coded errors

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -476,6 +476,8 @@ namespace Xamarin.Android.Tasks {
 			Tuple.Create ("APT2259", "is incompatible with attribute"),
 			Tuple.Create ("APT2260", "not found"),
 			Tuple.Create ("APT2261", "file failed to compile"),
+			Tuple.Create ("APT2262", "unexpected element <activity> found in <manifest>"),
+			Tuple.Create ("APT2263", "found in <manifest>"),  // unexpected element <xxxxx> found in <manifest>
 		};
 	}
 }


### PR DESCRIPTION
We were not catching the message `unexpected element <activity> found in <manifest>` that users are reporting after switching to `aapt2`.  Add that as well as a fallback for any other unexpected element messages.