### PR TITLE
[ci] Upload Notarized .pkg for validation

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -306,6 +306,9 @@ stages:
         ruby notarize.rb $(XA.Unsigned.Pkg) $(XamarinIdentifier) $(XamarinUserId) $(XamarinPassword) $(TeamID)
       displayName: Notarize PKG
 
+    - script: xcrun stapler validate $(XA.Unsigned.Pkg)
+      displayName: validate notarized pkg
+
     - template: upload-to-storage.yml@yaml
       parameters:
         BuildPackages: $(System.DefaultWorkingDirectory)/storage-artifacts

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -312,6 +312,15 @@ stages:
         AzureContainerName: $(Azure.Container.Name)
         AzureUploadLocation: $(Build.DefinitionName)/$(Build.BuildId)/$(Build.SourceBranchName)/$(Build.SourceVersion)
 
+    - script: cp $(System.DefaultWorkingDirectory)/storage-artifacts/*.pkg $(Build.ArtifactStagingDirectory)
+      displayName: copy notarized pkg
+
+    - task: PublishPipelineArtifact@0
+      displayName: upload notarized pkg
+      inputs:
+        artifactName: notarized-pkg
+        targetPath: $(Build.ArtifactStagingDirectory)
+
   # Check - "Xamarin.Android (Finalize Installers Queue Vsix Signing)"
   - job: queue_vsix_signing
     displayName: Queue Vsix Signing


### PR DESCRIPTION
Commit d202ef4 broke some [downstream validation][0] which ensured our .pkg
file was properly notarized. These changes temporarily reintroduce a
build artifact which contains our notarized .pkg, so that it can be used
by this validation release defintion. 

A script has also been added to run the `xcrun stapler validate` command
against our finished `.pkg` file to validate the "notarize and staple" step.
This command will exit with code 65 and cause the notarization job to fail
if a successful notarization ticket has not been stapled to the `.pkg` file.

[0]: https://dev.azure.com/devdiv/DevDiv/_release?_a=releases&view=mine&definitionId=1977