### PR TITLE
A handful of timing changes

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -61,10 +61,10 @@ namespace Android.Runtime {
 		extern static void monodroid_log (LogLevel level, LogCategories category, string message);
 
 		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
-		extern static IntPtr monodroid_timing_start (string message);
+		internal extern static IntPtr monodroid_timing_start (string message);
 
 		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
-		extern static void monodroid_timing_stop (IntPtr sequence, string message);
+		internal extern static void monodroid_timing_stop (IntPtr sequence, string message);
 
 		[DllImport ("__Internal", CallingConvention = CallingConvention.Cdecl)]
 		internal extern static void monodroid_free (IntPtr ptr);

--- a/src/Mono.Android/Android.Runtime/TimingLogger.cs
+++ b/src/Mono.Android/Android.Runtime/TimingLogger.cs
@@ -1,0 +1,98 @@
+using System;
+
+namespace Android.Runtime
+{
+	/// <summary>
+	///   A class which uses the native Xamarin.Android runtime to accurately measure (to the nanosecond level) time
+	///   spent executing a portion of code bracketed with calls to <see cref="Start"/> (or the constructor, by
+	///   default) and <see cref="Stop"/>.
+	///   Timing messages are logged with the <c>Info</c> priority and the <c>monodroid-timing</c> tag in the
+	///   device's logcat buffer.
+	/// </summary>
+	public class TimingLogger : IDisposable
+	{
+		bool disposed = false;
+		IntPtr sequence;
+		string initStartMessage;
+
+		/// <summary>
+		///   Construct a TimeLogger instance and start measuring time immediately, if the <paramref
+		///   name="startImmediately"/> parameter is left out or set to <c>true</c>. If the <paramref
+		///   name="startMessage"/> is not <c>null</c> then the message is logged at the start.
+		/// </summary>
+		public TimingLogger (string startMessage = null, bool startImmediately = true)
+		{
+			if (startImmediately)
+				Start (startMessage);
+			else {
+				initStartMessage = startMessage;
+				sequence = IntPtr.Zero;
+			}
+		}
+
+		~TimingLogger ()
+		{
+			Dispose (false);
+		}
+
+		/// <summary>
+		///   Start measuring time. If <paramref name="startMessage"/> is provided (or if the constructor was
+		///   passed a message to use when starting) it will be output to the log, otherwise the measurement
+		///   start is silent. The method does anything only if no measurement is active.
+		/// </summary>
+		public void Start (string startMessage = null)
+		{
+			if (sequence != IntPtr.Zero)
+				return;
+
+			sequence = JNIEnv.monodroid_timing_start (startMessage ?? initStartMessage);
+		}
+
+		/// <summary>
+		///   Stop measuring time and log message specified in the <paramref name="stopMessage"/> parameter. If
+		///   message is not specified, the Xamarin.Android runtime will use the default message, <c>"Managed
+		///   Timing"</c>. Time is reported in the following format:
+		///
+		/// <para>
+		///   <c>stopMessage; elapsed: %lis:%lu::%lu</c>
+		/// </para>
+		/// <para>
+		///   The <c>elapsed</c> fields are defined as follows: <c>seconds:milliseconds::nanoseconds</c>
+		/// </para>
+		/// </summary>
+		public void Stop (string stopMessage)
+		{
+			if (sequence == IntPtr.Zero)
+				return;
+
+			JNIEnv.monodroid_timing_stop (sequence, stopMessage);
+			sequence = IntPtr.Zero;
+		}
+
+		/// <summary>
+		///   Dispose of the current instance. <see cref="Dispose"/> for more information.
+		/// </summary>
+		public void Dispose()
+		{
+			Dispose (true);
+			GC.SuppressFinalize (this);
+		}
+
+		/// <summary>
+		///   Dispose of the current instance, stopping timing if necessary. Note that if timing is stopped
+		///   here, the log will contain the default message (<see cref="Stop"/>)
+		/// </summary>
+		protected virtual void Dispose (bool disposing)
+		{
+			if (!disposed) {
+				if (sequence != IntPtr.Zero) {
+					JNIEnv.monodroid_timing_stop (sequence, null);
+					sequence = IntPtr.Zero;
+				}
+
+				disposed = true;
+
+			}
+		}
+	}
+}

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -230,6 +230,7 @@
     <Compile Include="Android.Runtime\ResourceDesignerAttribute.cs" />
     <Compile Include="Android.Runtime\ResourceIdManager.cs" />
     <Compile Include="Android.Runtime\StringDefAttribute.cs" />
+    <Compile Include="Android.Runtime\TimingLogger.cs" />
     <Compile Include="Android.Runtime\TypeManager.cs" />
     <Compile Include="Android.Runtime\UncaughtExceptionHandler.cs" />
     <Compile Include="Android.Runtime\XAPeerMembers.cs" />

--- a/src/monodroid/jni/android-system.cc
+++ b/src/monodroid/jni/android-system.cc
@@ -343,7 +343,7 @@ AndroidSystem::create_update_dir (char *override_dir)
 	 * However, if any logging is enabled (which should _not_ happen with
 	 * pre-loaded apps!), we need the .__override__ directory...
 	 */
-	if (log_categories == 0 && utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_PROFILE_PROPERTY, nullptr) == 0) {
+	if (log_categories == 0 && monodroid_get_system_property (Debug::DEBUG_MONO_PROFILE_PROPERTY, nullptr) == 0) {
 		return;
 	}
 #endif
@@ -509,7 +509,7 @@ AndroidSystem::get_max_gref_count_from_system (void)
 	}
 
 	char *override;
-	if (utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_MAX_GREFC, &override) > 0) {
+	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_MAX_GREFC, &override) > 0) {
 		char *e;
 		max       = strtol (override, &e, 10);
 		switch (*e) {

--- a/src/monodroid/jni/debug.cc
+++ b/src/monodroid/jni/debug.cc
@@ -211,7 +211,7 @@ void
 Debug::start_debugging_and_profiling ()
 {
 	char *connect_args;
-	utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_CONNECT_PROPERTY, &connect_args);
+	androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_CONNECT_PROPERTY, &connect_args);
 
 	if (connect_args != nullptr) {
 		int res = start_connection (connect_args);
@@ -579,7 +579,7 @@ Debug::enable_soft_breakpoints (void)
 
 	char *value;
 	/* Soft breakpoints are enabled by default */
-	if (utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_SOFT_BREAKPOINTS, &value) <= 0) {
+	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_SOFT_BREAKPOINTS, &value) <= 0) {
 		log_info (LOG_DEBUGGER, "soft breakpoints enabled by default (%s property not defined)", Debug::DEBUG_MONO_SOFT_BREAKPOINTS);
 		return 1;
 	}

--- a/src/monodroid/jni/external-api.cc
+++ b/src/monodroid/jni/external-api.cc
@@ -243,7 +243,7 @@ monodroid_store_package_name (const char *name)
 MONO_API int
 monodroid_get_namespaced_system_property (const char *name, char **value)
 {
-	return static_cast<int>(utils.monodroid_get_namespaced_system_property (name, value));
+	return static_cast<int>(androidSystem.monodroid_get_system_property (name, value));
 }
 
 MONO_API FILE*

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -465,7 +465,7 @@ MonodroidRuntime::parse_gdb_options ()
 {
 	char *val;
 
-	if (!(utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_GDB_PROPERTY, &val) > 0))
+	if (!(androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_GDB_PROPERTY, &val) > 0))
 		return;
 
 	if (strstr (val, "wait:") == val) {
@@ -599,7 +599,7 @@ MonodroidRuntime::parse_runtime_args (char *runtime_args, RuntimeOptions *option
 inline void
 MonodroidRuntime::set_debug_options (void)
 {
-	if (utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_DEBUG_PROPERTY, nullptr) == 0)
+	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_DEBUG_PROPERTY, nullptr) == 0)
 		return;
 
 	embeddedAssemblies.set_register_debug_symbols (true);
@@ -728,7 +728,7 @@ MonodroidRuntime::mono_runtime_init (char *runtime_args)
 
 	char *prop_val;
 	/* Additional runtime arguments passed to mono_jit_parse_options () */
-	if (utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_RUNTIME_ARGS_PROPERTY, &prop_val) > 0) {
+	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_RUNTIME_ARGS_PROPERTY, &prop_val) > 0) {
 		char **ptr;
 
 		log_warn (LOG_DEBUGGER, "passing '%s' as extra arguments to the runtime.\n", prop_val);
@@ -1022,7 +1022,7 @@ MonodroidRuntime::propagate_uncaught_exception (MonoDomain *domain, JNIEnv *env,
 static void
 setup_gc_logging (void)
 {
-	gc_spew_enabled = utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_GC_PROPERTY, nullptr) > 0;
+	gc_spew_enabled = androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_GC_PROPERTY, nullptr) > 0;
 	if (gc_spew_enabled) {
 		log_categories |= LOG_GC;
 	}
@@ -1147,7 +1147,7 @@ MonodroidRuntime::set_debug_env_vars (void)
 {
 	char *value;
 
-	if (utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_ENV_PROPERTY, &value) == 0)
+	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_ENV_PROPERTY, &value) == 0)
 		return;
 
 	char **args = utils.monodroid_strsplit (value, "|", 0);
@@ -1175,7 +1175,7 @@ MonodroidRuntime::set_trace_options (void)
 {
 	char *value;
 
-	if (utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_TRACE_PROPERTY, &value) == 0)
+	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_TRACE_PROPERTY, &value) == 0)
 		return;
 
 	mono_jit_set_trace_options (value);
@@ -1192,7 +1192,7 @@ MonodroidRuntime::set_profile_options (JNIEnv *env)
 	constexpr const size_t output_arg_len = sizeof(output_arg) - 1;
 
 	char *value;
-	if (utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_PROFILE_PROPERTY, &value) == 0)
+	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_PROFILE_PROPERTY, &value) == 0)
 		return;
 
 	char *output = nullptr;
@@ -1496,7 +1496,8 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 	}
 
 	char *runtime_args = nullptr;
-	utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_EXTRA_PROPERTY, &runtime_args);
+	androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_EXTRA_PROPERTY, &runtime_args);
+
 #if TRACE
 	__android_log_print (ANDROID_LOG_INFO, "*jonp*", "debug.mono.extra=%s", runtime_args);
 #endif
@@ -1537,7 +1538,6 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 void
 MonodroidRuntime::dump_counters (const char *format, ...)
 {
-	log_warn (LOG_DEFAULT, "%s called (counters == %p)", __PRETTY_FUNCTION__, counters);
 	if (counters == nullptr)
 		return;
 

--- a/src/monodroid/jni/osbridge.cc
+++ b/src/monodroid/jni/osbridge.cc
@@ -966,7 +966,7 @@ OSBridge::platform_supports_weak_refs (void)
 		free (value);
 	}
 
-	if (utils.monodroid_get_namespaced_system_property (Debug::DEBUG_MONO_WREF_PROPERTY, &value) > 0) {
+	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_WREF_PROPERTY, &value) > 0) {
 		int use_weak_refs = 0;
 		if (!strcmp ("jni", value))
 			use_weak_refs = 1;
@@ -990,14 +990,14 @@ OSBridge::platform_supports_weak_refs (void)
 			return use_weak_refs;
 	}
 
-	if (utils.monodroid_get_namespaced_system_property ("persist.sys.dalvik.vm.lib", &value) > 0) {
+	if (androidSystem.monodroid_get_system_property ("persist.sys.dalvik.vm.lib", &value) > 0) {
 		int art = 0;
 		if (!strcmp ("libart.so", value))
 			art = 1;
 		free (value);
 		if (art) {
 			int use_java = 0;
-			if (utils.monodroid_get_namespaced_system_property ("ro.build.version.release", &value) > 0) {
+			if (androidSystem.monodroid_get_system_property ("ro.build.version.release", &value) > 0) {
 				// Android 4.x ART is busted; see https://code.google.com/p/android/issues/detail?id=63929
 				if (value [0] != 0 && value [0] == '4' && value [1] != 0 && value [1] == '.') {
 					use_java = 1;

--- a/src/monodroid/jni/util.cc
+++ b/src/monodroid/jni/util.cc
@@ -174,42 +174,6 @@ Util::monodroid_store_package_name (const char *name)
 	log_info (LOG_DEFAULT, "Generated hash 0x%s for package name %s", package_property_suffix, name);
 }
 
-size_t
-Util::monodroid_get_namespaced_system_property (const char *name, char **value)
-{
-	char *local_value = nullptr;
-	ssize_t result = 0;
-
-	if (value)
-		*value = nullptr;
-
-	if (package_property_suffix[0] != '\0') {
-		log_info (LOG_DEFAULT, "Trying to get property %s.%s", name, package_property_suffix);
-		simple_pointer_guard<char[]> propname (string_concat (name, ".", package_property_suffix));
-		result = androidSystem.monodroid_get_system_property (propname, &local_value);
-	}
-
-	if (result <= 0 || local_value == nullptr)
-		result = androidSystem.monodroid_get_system_property (name, &local_value);
-
-	if (result > 0) {
-		if (local_value != nullptr && local_value[0] == '\0') {
-			delete[] local_value;
-			return 0;
-		}
-
-		log_info (LOG_DEFAULT, "Property '%s' has value '%s'.", name, local_value);
-
-		if (value != nullptr)
-			*value = local_value;
-		else
-			delete[] local_value;
-		return static_cast<size_t>(result);
-	}
-
-	return androidSystem.monodroid_get_system_property_from_overrides (name, value);
-}
-
 MonoAssembly *
 Util::monodroid_load_assembly (MonoDomain *domain, const char *basename)
 {

--- a/src/monodroid/jni/util.hh
+++ b/src/monodroid/jni/util.hh
@@ -75,7 +75,6 @@ namespace xamarin::android
 
 	public:
 		void             monodroid_store_package_name (const char *name);
-		size_t           monodroid_get_namespaced_system_property (const char *name, char **value);
 		MonoAssembly    *monodroid_load_assembly (MonoDomain *domain, const char *basename);
 		MonoObject      *monodroid_runtime_invoke (MonoDomain *domain, MonoMethod *method, void *obj, void **params, MonoObject **exc);
 		MonoClass       *monodroid_get_class_from_name (MonoDomain *domain, const char* assembly, const char *_namespace, const char *type);

--- a/tests/Xamarin.Forms-Performance-Integration/Droid/MainActivity.cs
+++ b/tests/Xamarin.Forms-Performance-Integration/Droid/MainActivity.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using Android.App;
 using Android.Content;
@@ -19,8 +19,11 @@ namespace Xamarin.Forms.Performance.Integration.Droid
 
 		protected override void OnCreate (Bundle bundle)
 		{
-			if (firstOnCreate)
-				Console.WriteLine ("startup-timing: OnCreate reached");
+			TimingLogger timing = null;
+
+			if (firstOnCreate) {
+				timing = new TimingLogger ("startup-timing: OnCreate reached");
+			}
 
 			TabLayoutResource = Resource.Layout.Tabbar;
 			ToolbarResource = Resource.Layout.Toolbar;
@@ -32,7 +35,7 @@ namespace Xamarin.Forms.Performance.Integration.Droid
 			LoadApplication (new App ());
 
 			if (firstOnCreate) {
-				Console.WriteLine ("startup-timing: OnCreate end reached");
+				timing.Stop ("startup-timing: OnCreate end reached");
 				firstOnCreate = false;
 			}
 		}
@@ -44,26 +47,32 @@ namespace Xamarin.Forms.Performance.Integration.Droid
 
 		protected override void OnStart ()
 		{
-			if (firstOnStart)
-				Console.WriteLine ("startup-timing: OnStart reached");
+			TimingLogger timing = null;
+
+			if (firstOnStart) {
+				timing = new TimingLogger ("startup-timing: OnStart reached");
+			}
 
 			base.OnStart ();
 
 			if (firstOnStart) {
-				Console.WriteLine ("startup-timing: OnStart end reached");
+				timing.Stop ("startup-timing: OnStart end reached");
 				firstOnStart = false;
 			}
 		}
 
 		protected override void OnResume ()
 		{
-			if (firstOnResume)
-				Console.WriteLine ("startup-timing: OnResume reached");
+			TimingLogger timing = null;
+
+			if (firstOnResume) {
+				timing = new TimingLogger ("startup-timing: OnResume reached");
+			}
 
 			base.OnResume ();
 
 			if (firstOnResume) {
-				Console.WriteLine ("startup-timing: OnResume end reached");
+				timing.Stop ("startup-timing: OnResume end reached");
 				firstOnResume = false;
 			}
 		}


### PR DESCRIPTION
This commit introduces a new public class, `Android.Runtime.Timing` which can be
used by the managed code to efficiently and accurately (to the nanosecond level)
measure code performance. At the moment the class is used only by our
Xamarin.Forms integration test.

Additionally, this commit removes support for namespaced system properties (that
is properties suffixed by the package name) which were added for the benefit of
the IDEs but never seen any use. Namespaced properties require two system
property retrieval calls and so they cost extra time (not much, around 25k
nanoseconds but taken together they can contribute to >1ms of startup time with
no real purpose).