### PR TITLE
[Xamarin.Android.Build.Tasks] aapt2 failure causes targets to skip

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -210,24 +210,30 @@ namespace Xamarin.Android.Tasks {
 		bool ExecuteForAbi (string cmd, string currentResourceOutputFile)
 		{
 			var output = new List<OutputLine> ();
-			var ret = RunAapt (cmd, output);
+			var aaptResult = RunAapt (cmd, output);
 			var success = !string.IsNullOrEmpty (currentResourceOutputFile)
 				? File.Exists (Path.Combine (currentResourceOutputFile + ".bk"))
-				: ret;
+				: aaptResult;
 			foreach (var line in output) {
 				if (!LogAapt2EventsFromOutput (line.Line, MessageImportance.Normal, success))
 					break;
 			}
-			if (ret && !string.IsNullOrEmpty (currentResourceOutputFile)) {
+			if (!string.IsNullOrEmpty (currentResourceOutputFile)) {
 				var tmpfile = currentResourceOutputFile + ".bk";
 				// aapt2 might not produce an archive and we must provide
 				// and -o foo even if we don't want one.
 				if (File.Exists (tmpfile)) {
-					MonoAndroidHelper.CopyIfZipChanged (tmpfile, currentResourceOutputFile);
+					if (aaptResult) {
+						MonoAndroidHelper.CopyIfZipChanged (tmpfile, currentResourceOutputFile);
+					}
 					File.Delete (tmpfile);
 				}
+				// Delete the archive on failure
+				if (!aaptResult && File.Exists (currentResourceOutputFile)) {
+					File.Delete (currentResourceOutputFile);
+				}
 			}
-			return ret;
+			return aaptResult;
 		}
 
 		bool ManifestIsUpToDate (string manifestFile)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -1021,5 +1021,23 @@ namespace Lib2
 				Assert.IsTrue (appBuilder.Build (app), "app build should have succeeded.");
 			}
 		}
+
+		[Test]
+		public void AaptError ([Values (true, false)] bool useAapt2)
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				Sources = {
+					new BuildItem.Source ("TestActivity.cs") {
+						TextContent = () => @"using Android.App; [Activity(Theme = ""@style/DoesNotExist"")] class TestActivity : Activity { }"
+					}
+				}
+			};
+			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
+			using (var builder = CreateApkBuilder ()) {
+				builder.ThrowOnBuildFailure = false;
+				Assert.IsFalse (builder.Build (proj), "Build should *not* have succeeded on the first build.");
+				Assert.IsFalse (builder.Build (proj), "Build should *not* have succeeded on the second build.");
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3779

Using @brendanzagaeski's repro, I saw a possible #deletebinobj issue
when using aapt2:

* Build with a resource error, get an `APT2XXX` error code.
* Future builds give no error???

Once in this state, you could be using a malformed APK until you
modify a `@(AndroidResource)` -- or fix the problem?

The cause appears to be that `aapt2` is actually generating output in
`obj\Debug\bin\android\packaged_resources` even though it emits an
error?

I think we should:

* Do *not* copy `packaged_resources.bk` if `aapt2` failed.
* Delete `packaged_resources` on `aapt2` failures.