### PR TITLE
Fix weird `TargetsSkipped` test failure. 

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -60,8 +60,8 @@ namespace Xamarin.Android.Build.Tests
 			if (HasDevices && proj != null)
 				RunAdbCommand ($"uninstall {proj.PackageName}");
 
-			if (TestContext.CurrentContext.Result.FailCount == 0 && builder != null && Directory.Exists (builder.ProjectDirectory))
-			    Directory.Delete (builder.ProjectDirectory, recursive: true);
+			if (TestContext.CurrentContext.Result.FailCount == 0 && builder != null && Directory.Exists (Path.Combine (Root, builder.ProjectDirectory)))
+				Directory.Delete (Path.Combine (Root, builder.ProjectDirectory), recursive: true);
 		}
 
 

--- a/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
@@ -118,8 +118,6 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsFalse (b.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "5 second _UpdateAndroidResgen was skipped");
 				// CoreCompile should be built.
 				Assert.IsTrue (b.Output.IsTargetSkipped ("CoreCompile"), "5 CoreCompile was not skipped");
-				//bool e = !b.RunningMSBuild;
-				//Assert.AreEqual (e, b.Output.IsTargetSkipped ("CoreCompile"), $"5 CoreCompile was {(e ? " not " : "")} skipped");
 			} else {
 				Assert.IsTrue (b.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "5 second _UpdateAndroidResgen was not skipped");
 				// CoreCompile should not be built.

--- a/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
@@ -117,7 +117,9 @@ namespace Xamarin.Android.Build.Tests
 			if (useManagedResourceGenerator) {
 				Assert.IsFalse (b.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "5 second _UpdateAndroidResgen was skipped");
 				// CoreCompile should be built.
-				Assert.AreEqual (!b.RunningMSBuild, b.Output.IsTargetSkipped ("CoreCompile"), "5 CoreCompile was skipped");
+				Assert.IsTrue (b.Output.IsTargetSkipped ("CoreCompile"), "5 CoreCompile was not skipped");
+				//bool e = !b.RunningMSBuild;
+				//Assert.AreEqual (e, b.Output.IsTargetSkipped ("CoreCompile"), $"5 CoreCompile was {(e ? " not " : "")} skipped");
 			} else {
 				Assert.IsTrue (b.Output.IsTargetSkipped ("_UpdateAndroidResgen"), "5 second _UpdateAndroidResgen was not skipped");
 				// CoreCompile should not be built.


### PR DESCRIPTION
The `TargetsSkipped` had some code which was using the `b.RunningMSBuild` code. This is weird since we ALWAYS use MSBuild now. This test was also randomly failing because the target was being skipped when it was expected to run (according to the test). However this looks like a bug in the test itself which was trying to verify old behaviour which has since changed. 

So we need to update the test to verify the correct behaviour. In this case the `CoreCompile` target SHOULD be skipped. 

This PR is also addressing an issue where the deployment tests were leaving directories in place even though the test passed. This was due to the directory checks NOT including the required `Root` path information.