### PR TITLE
[Xamarin.Android.Build.Tasks] r8 should not optimize for multi-dex only

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -35,16 +35,16 @@ namespace Xamarin.Android.Tasks
 
 		protected override string MainClass => "com.android.tools.r8.R8";
 
-		string temp;
+		readonly List<string> tempFiles = new List<string> ();
 
 		public override bool RunTask ()
 		{
 			try {
-				temp = Path.GetTempFileName ();
 				return base.RunTask ();
 			} finally {
-				if (!string.IsNullOrEmpty (temp))
+				foreach (var temp in tempFiles) {
 					File.Delete (temp);
+				}
 			}
 		}
 
@@ -61,6 +61,8 @@ namespace Xamarin.Android.Tasks
 					Log.LogCodedWarning ("XA4305", $"MultiDex is enabled, but '{nameof (MultiDexMainDexListFile)}' was not specified.");
 				} else {
 					var content = new List<string> ();
+					var temp = Path.GetTempFileName ();
+					tempFiles.Add (temp);
 					if (CustomMainDexListFiles != null) {
 						foreach (var file in CustomMainDexListFiles) {
 							if (File.Exists (file.ItemSpec)) {
@@ -117,6 +119,15 @@ namespace Xamarin.Android.Tasks
 				//NOTE: we may be calling r8 *only* for multi-dex, and all shrinking is disabled
 				cmd.AppendSwitch ("--no-tree-shaking");
 				cmd.AppendSwitch ("--no-minification");
+				// Rules to turn off optimizations
+				var temp = Path.GetTempFileName ();
+				File.WriteAllLines (temp, new [] {
+					"-dontoptimize",
+					"-dontpreverify",
+					"-keepattributes **"
+				});
+				tempFiles.Add (temp);
+				cmd.AppendSwitchIfNotNull ("--pg-conf ", temp);
 			}
 
 			return cmd;


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3751

When enabling multi-dex, but *not* code shrinking, such as:

    <AndroidDexTool>d8</AndroidDexTool>
    <AndroidLinkTool></AndroidLinkTool>
    <AndroidEnableMultiDex>True</AndroidEnableMultiDex>

In this configuration, we run r8 instead of d8, because it fully
supports multi-dex. r8 automatically calculates what needs to go in
the main dex file, which d8 doesn't do.

We pass these flags to r8 in this mode:

    --no-tree-shaking --no-minification

However, I noticed a few problems in the dex file I analyzed with:

    dexdump -d obj\Debug\android\bin\classes.dex > classes.txt

* The dex code appears to be optimized. The code within methods is
  shortened/scrambled.
* Annotations are missing???

`dexdump` does not appear to list annotations, but I could see them
missing from viewing the `classes.dex` file in Android Studio and the
file size was smaller.

I discovered adding this to the r8 command solved the issue:

    --pg-conf "C:\Program Files (x86)\Android\android-sdk\tools\proguard\proguard-android.txt"

Debugging further, specifically these rules solve the issue:

    -dontoptimize
    -dontpreverify
    -keepattributes *Annotation*

The dropped annotations specifically broke #3751, but I suspect other
*weird* issues would occur from the optimized code? If no code
shrinker is used, we don't want to optimize anything!

I am unsure how to add a test here, as `dexdump` (or `DexUtils`)
doesn't give us a way see that the annotations got stripped or the dex
code is optimized? *Open to ideas*