### PR TITLE
[ci] Do not hard code agent user name

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -93,11 +93,12 @@ stages:
       clean: all
     variables:
     - group: Xamarin Notarization
-    - name: JAVA_HOME
-      value: '/Users/vsts/Library/Android/jdk/'
     steps:
     - checkout: self
       submodules: recursive
+
+    - script: echo "##vso[task.setvariable variable=JAVA_HOME]$HOME/Library/Android/jdk"
+      displayName: set JAVA_HOME
 
     - task: UseDotNet@2
       displayName: install .NET Core 2.1.701


### PR DESCRIPTION
Context: https://build.azdo.io/3140335

Fix the hard coded user path by setting JAVA_HOME in a script that uses
a [VSO logging command][0]. This works around the inability to use system
variable values when setting other variables from YAML. This ensures that
the [JDK path used to provision][1] and build against stay in sync.

[0]: https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands
[1]: https://github.com/xamarin/xamarin-android/blob/73547b144c4022713dc6d50907bc4184a003acad/Configuration.props#L63