### PR TITLE
[Xamarin.Android.Build.Tasks] Produce a better ZipAlign Error.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidZipAlign.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidZipAlign.cs
@@ -1,21 +1,12 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-
 using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks
 {
 	public class AndroidZipAlign : AndroidRunToolTask
 	{
 		public override string TaskPrefix => "AZA";
-
-		public AndroidZipAlign ()
-		{
-		}
 
 		[Required]
 		public ITaskItem Source { get; set; }
@@ -36,7 +27,7 @@ namespace Xamarin.Android.Tasks
 		protected override string GenerateCommandLineCommands ()
 		{
 			string sourceFilename = Path.GetFileNameWithoutExtension (Source.ItemSpec);
-			if (sourceFilename.EndsWith (strSignedUnaligned))
+			if (sourceFilename.EndsWith (strSignedUnaligned, StringComparison.OrdinalIgnoreCase))
 				sourceFilename = sourceFilename.Remove (sourceFilename.Length - strSignedUnaligned.Length);
 			return string.Format ("-p {0} \"{1}\" \"{2}{3}{4}-Signed.apk\"",
 				Alignment, Source.ItemSpec, DestinationDirectory.ItemSpec, Path.DirectorySeparatorChar, sourceFilename);
@@ -50,6 +41,13 @@ namespace Xamarin.Android.Tasks
 		protected override string ToolName
 		{
 			get { return IsWindows ? "zipalign.exe" : "zipalign"; }
+		}
+
+		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
+		{
+			if (ExitCode != 0)
+				Log.LogCodedError (DefaultErrorCode, singleLine);
+			base.LogEventsFromTextOutput (singleLine, messageImportance);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ZipAlignTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ZipAlignTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NUnit.Framework;
+using Xamarin.Android.Tasks;
+
+namespace Xamarin.Android.Build.Tests.Tasks
+{
+	[TestFixture]
+	public class ZipAlignTests : BaseTest
+	{
+		string path;
+		List<BuildErrorEventArgs> errors;
+		List<BuildMessageEventArgs> messages;
+		MockBuildEngine engine;
+
+		[SetUp]
+		public void Setup ()
+		{
+			path = Path.Combine (Root, "temp", TestName);
+			engine = new MockBuildEngine (TestContext.Out,
+				errors: errors = new List<BuildErrorEventArgs> (),
+				messages: messages = new List<BuildMessageEventArgs> ());
+			Directory.CreateDirectory (path);
+		}
+
+		[TearDown]
+		public void TearDown ()
+		{
+			if (Directory.Exists (path))
+				Directory.Delete (path, recursive: true);
+		}
+
+		[Test]
+		public void CheckAZAErrorCodeIsRaised ()
+		{
+
+			var exe = IsWindows ? "zipalign.exe" : "zipalign";
+			var source = Path.Combine (path, "error.zip");
+			var zipAlign = new AndroidZipAlign () {
+				BuildEngine = engine,
+				Source = new TaskItem (source),
+				DestinationDirectory = new TaskItem (path),
+				ToolPath = GetPathToLatestBuildTools (exe)
+			};
+			File.WriteAllText (source, "Invalid Zip File");
+			Assert.False (zipAlign.Execute (), "Execute should *not* succeed!");
+			Assert.AreEqual (1, errors.Count, "1 error should have been raised.");
+			Assert.AreEqual ("ANDZA0000", errors [0].Code, $"Expected error code ANDZA0000 but got {errors [0].Code}");
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -418,15 +418,9 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
-		protected string GetPathToAapt2 ()
+		protected string GetPathToLatestBuildTools (string exe)
 		{
-
-			var exe = IsWindows ? "aapt2.exe" : "aapt2";
-			var path = Path.Combine (AndroidMSBuildDirectory, IsWindows ? "" : (IsMacOS ? "Darwin" : "Linux"));
-			if (File.Exists (Path.Combine (path, exe)))
-				return path;
-
-			path = Path.Combine (AndroidSdkPath, "build-tools");
+			var path = Path.Combine (AndroidSdkPath, "build-tools");
 			foreach (var dir in Directory.GetDirectories (path, "*", SearchOption.TopDirectoryOnly).OrderByDescending (x => new Version (Path.GetFileName (x)))) {
 				var aapt2 = Path.Combine (dir, exe);
 				if (File.Exists (aapt2))
@@ -435,18 +429,19 @@ namespace Xamarin.Android.Build.Tests
 			return Path.Combine (path, "25.0.2");
 		}
 
+		protected string GetPathToAapt2 ()
+		{
+			var exe = IsWindows ? "aapt2.exe" : "aapt2";
+			var path = Path.Combine (AndroidMSBuildDirectory, IsWindows ? "" : (IsMacOS ? "Darwin" : "Linux"));
+			if (File.Exists (Path.Combine (path, exe)))
+				return path;
+			return GetPathToLatestBuildTools (exe);
+		}
+
 		protected string GetPathToAapt ()
 		{
-
 			var exe = IsWindows ? "aapt.exe" : "aapt";
-
-			var path = Path.Combine (AndroidSdkPath, "build-tools");
-			foreach (var dir in Directory.GetDirectories (path, "*", SearchOption.TopDirectoryOnly).OrderByDescending (x => new Version (Path.GetFileName (x)))) {
-				var aapt2 = Path.Combine (dir, exe);
-				if (File.Exists (aapt2))
-					return dir;
-			}
-			return Path.Combine (path, "25.0.2");
+			return GetPathToLatestBuildTools (exe);
 		}
 
 		[OneTimeSetUp]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Tasks\NdkUtilTests.cs" />
     <Compile Include="Tasks\CheckGoogleSdkRequirementsTests.cs" />
     <Compile Include="Tasks\AndroidComputeResPathsTests.cs" />
+    <Compile Include="Tasks\ZipAlignTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Expected\GenerateDesignerFileExpected.cs">


### PR DESCRIPTION
The standard behaviour of the `ToolTask` is to write
any `stderr` output out as a message. It then logs
a generic "Tool existed with exitcode X" error. This
is not great as the end user then has to dig through
the logs to find the actual problem.

The `ToolTask` does have a property `LogStandardErrorAsError`
which defaults to `false`. When set to `true` any `stderr`
output will be logged as an error. However there is no way
in the `ToolTask` to provide an `ErrorCode` for those errors.
You just get a blank `ErrorCode`. So while that might seem
like a good solution, its not what we are after.

So in this case we want an `ANDZA0000` errode code. Looking
at the source code for `ToolTask` [1] the best way to do
this is to intercept the message logging in the
`LogEventsFromTextOutput`. Fortunately the `ExitCode` for the
app is set by the time we enter the `LogEventsFromTextOutput`
method. So we can just check the `ExitCode` and then log
any line we get as an Error with our customer `ErrorCode`.

[1] https://github.com/Microsoft/msbuild/blob/master/src/Utilities/ToolTask.cs#L1057