### PR TITLE
[Xamarin.Android.Build.Tasks] Add _Run Target for OSS.

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -231,6 +231,9 @@
     <_MSBuildTargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\Xamarin.Android.Common.Before.targets" />
     <_MSBuildTargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\Xamarin.Android.DefaultOutputPaths.targets" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(_HasCommercialFiles)' != 'True' ">
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Common.Device.targets" />
+  </ItemGroup>
   <ItemGroup>
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\libzip.dll" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\lib64\libzip.dll" />

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Device.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Device.targets
@@ -1,0 +1,27 @@
+<!--
+***********************************************************************************************
+Xamarin.Android.Device.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+  created a backup copy.  Incorrect changes to this file will make it
+  impossible to load or build your projects from the command-line or the IDE.
+
+This file imports the version- and platform-specific targets for the project importing
+this file. This file also defines targets to produce an error if the specified targets
+file does not exist, but the project is built anyway (command-line or IDE build).
+
+Copyright (C) 2019  Microsoft Corporation. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="_Run" DependsOnTargets="AndroidPrepareForBuild">
+    <XmlPeek Namespaces="&lt;Namespace Prefix='android' Uri='http://schemas.android.com/apk/res/android' /&gt;"
+        XmlInputPath="$(IntermediateOutputPath)android\AndroidManifest.xml"
+        Condition=" '$(_LaunchAcivity)' == '' And Exists ('$(IntermediateOutputPath)android\AndroidManifest.xml') "
+        Query="/manifest/application/activity[./intent-filter/category/@android:name='android.intent.category.LAUNCHER']/@android:name">
+      <Output PropertyName="_LaunchAcivity" TaskParameter="Result" />
+    </XmlPeek>
+    <Exec Command="&quot;$(AdbToolPath)\adb&quot; $(AdbTarget) shell am start $(_AndroidPackage)/$(_LaunchAcivity)" />
+  </Target>
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -82,6 +82,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Xamarin.Android.Aapt2.targets</Link>
     </None>
+    <None Include="MSBuild\Xamarin\Android\Xamarin.Android.Device.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Xamarin.Android.Device.targets</Link>
+    </None>
     <None Include="Xamarin.Android.Analysis.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -3470,6 +3470,9 @@ because xbuild doesn't support framework reference assemblies.
   </CalculateProjectDependencies>
 </Target>
 
+<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Common.Device.targets"
+        Condition=" '$(AndroidApplication)' == 'True' And Exists('$(MSBuildThisFileDirectory)Xamarin.Android.Common.Device.targets')"/>
+
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Common.Debugging.targets"
         Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Android.Common.Debugging.targets')"/>
 


### PR DESCRIPTION
Add a helper target for users of the open source
version of Xamarin.Android. With this target users
will be able to start the android application
from msbuild.

	msbuild foo.csproj /t:_Run

By default the target will look up the application
to run from the `AndroidManifest.xml`. However if
you want to start a different app you can override
the `_LaunchAcivity` MSBuild property.

	msbuild foo.csproh /t:_Run /p:_LaunchAcivity=something.app