### PR TITLE
[Xamarin.Android.Build.Tasks] Add Run target

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -100,6 +100,10 @@ The following build targets are defined for Xamarin.Android projects:
     (`.apk`). Use with `/p:Configuration=Release` to generate
     self-contained "Release" packages.
 
+-   **StartAndroidActivity** &ndash; Starts *launch* activity on the
+    device or the running emulator. The launch activity can be
+    overriden by `AndroidLaunchActivity` property.
+
 -   **UpdateAndroidResources** &ndash; Updates the
     `Resource.designer.cs` file. This target is usually called by the
     IDE when new resources are added to the project.

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -191,6 +191,7 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Aapt.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Aapt2.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Analysis.targets" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Application.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Bindings.targets" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Build.Tasks.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Android.Build.Tasks.pdb" />
@@ -225,7 +226,6 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Build.AsyncTask.pdb" />
   </ItemGroup>
   <ItemGroup>
-    <_MSBuildTargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\Xamarin.Android.Application.targets" />
     <_MSBuildTargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\Xamarin.Android.Bindings.After.targets" />
     <_MSBuildTargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\Xamarin.Android.Bindings.Before.targets" />
     <_MSBuildTargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\Xamarin.Android.Common\ImportAfter\Microsoft.Cpp.Android.targets" />

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -225,6 +225,7 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Xamarin.Build.AsyncTask.pdb" />
   </ItemGroup>
   <ItemGroup>
+    <_MSBuildTargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\Xamarin.Android.Application.targets" />
     <_MSBuildTargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\Xamarin.Android.Bindings.After.targets" />
     <_MSBuildTargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\Xamarin.Android.Bindings.Before.targets" />
     <_MSBuildTargetsSrcFiles Include="$(MSBuildTargetsSrcDir)\Xamarin.Android.Common\ImportAfter\Microsoft.Cpp.Android.targets" />

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidActivityName.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAndroidActivityName.cs
@@ -1,0 +1,25 @@
+using Microsoft.Build.Framework;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks
+{
+	public class GetAndroidActivityName : AndroidTask
+	{
+		public override string TaskPrefix => "GAAN";
+
+		[Required]
+		public string ManifestFile { get; set; }
+
+		[Output]
+		public string ActivityName { get; set; }
+
+		public override bool RunTask ()
+		{
+			var manifest = AndroidAppManifest.Load (ManifestFile, MonoAndroidHelper.SupportedVersions);
+
+			ActivityName = manifest.GetLaunchableUserActivityName ();
+
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Application.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Application.targets
@@ -12,17 +12,18 @@ Copyright (C) 2019 Microsoft Corporation. All rights reserved.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="Xamarin.Android.Tasks.GetAndroidActivityName" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
-  <Target Name="Run"
+  <Target Name="StartAndroidActivity"
       DependsOnTargets="_ResolveMonoAndroidSdks">
     <GetAndroidActivityName
+        Condition=" '$(AndroidLaunchActivity)' == '' "
         ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml">
-      <Output TaskParameter="ActivityName" PropertyName="_AndroidActivityName" />
+      <Output TaskParameter="ActivityName" PropertyName="AndroidLaunchActivity" />
     </GetAndroidActivityName>
     <GetAndroidPackageName
         ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
         AssemblyName="$(AssemblyName)">
       <Output TaskParameter="PackageName" PropertyName="_AndroidPackage" />
     </GetAndroidPackageName>
-    <Exec Command="&quot;$(AdbToolPath)adb&quot; $(AdbTarget) shell am start -n &quot;$(_AndroidPackage)/$(_AndroidActivityName)&quot;" />
+    <Exec Command="&quot;$(AdbToolPath)adb&quot; $(AdbTarget) shell am start -n &quot;$(_AndroidPackage)/$(AndroidLaunchActivity)&quot;" />
   </Target>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Application.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Application.targets
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+***********************************************************************************************
+Xamarin.Android.Application.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+  created a backup copy.  Incorrect changes to this file will make it
+  impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (C) 2019 Microsoft Corporation. All rights reserved.
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask TaskName="Xamarin.Android.Tasks.GetAndroidActivityName" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+  <Target Name="Run"
+      DependsOnTargets="_ResolveMonoAndroidSdks">
+    <GetAndroidActivityName
+        ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml">
+      <Output TaskParameter="ActivityName" PropertyName="_AndroidActivityName" />
+    </GetAndroidActivityName>
+    <GetAndroidPackageName
+        ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
+        AssemblyName="$(AssemblyName)">
+      <Output TaskParameter="PackageName" PropertyName="_AndroidPackage" />
+    </GetAndroidPackageName>
+    <Exec Command="&quot;$(AdbToolPath)adb&quot; $(AdbTarget) shell am start -n &quot;$(_AndroidPackage)/$(_AndroidActivityName)&quot;" />
+  </Target>
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -590,6 +590,7 @@
     <Compile Include="Tasks\AppendCustomMetadataToItemGroup.cs" />
     <Compile Include="Utilities\OutputLine.cs" />
     <Compile Include="Utilities\ResourceIdentifier.cs" />
+    <Compile Include="Tasks\GetAndroidActivityName.cs" />
   </ItemGroup>
   <ItemGroup>
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.LaunchMode.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -85,6 +85,9 @@
     <None Include="Xamarin.Android.Analysis.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Xamarin.Android.Application.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Xamarin.Android.Bindings.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -3490,6 +3490,8 @@ because xbuild doesn't support framework reference assemblies.
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Common.Debugging.targets"
         Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Android.Common.Debugging.targets')"/>
 
+<Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Application.targets"
+        Condition=" '$(AndroidApplication)' == 'True' "/>
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.PCLSupport.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Designer.targets" />
 


### PR DESCRIPTION
Add new `Run` target to start the app activity on the device/emulator

Add new `GetAndroidActivityName` task to retrieve the activity name
from the manifest file

Add new `Xamarin.Android.Application.targets` file for application
specific targets and import it conditionaly into the
`Xamarin.Android.Common.targets`.