### PR TITLE
[tests] MSBuild performance regression tests

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -605,7 +605,7 @@ stages:
   - job: mac_msbuilddevice_tests
     displayName: MSBuild With Emulator - macOS
     pool: $(HostedMac)
-    timeoutInMinutes: 240
+    timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
     workspace:
       clean: all

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -605,7 +605,7 @@ stages:
   - job: mac_msbuilddevice_tests
     displayName: MSBuild With Emulator - macOS
     pool: $(HostedMac)
-    timeoutInMinutes: 120
+    timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
     workspace:
       clean: all

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -10,20 +10,23 @@ namespace Xamarin.Android.Build.Tests
 	[TestFixture, NonParallelizable]
 	public class PerformanceTest : DeviceTest
 	{
-		readonly Dictionary<string, int> csv_values = new Dictionary<string, int> ();
+		static readonly Dictionary<string, int> csv_values = new Dictionary<string, int> ();
 
-		[SetUp]
-		public void Setup ()
+		[OneTimeSetUp]
+		public static void Setup ()
 		{
 			var csv = Path.Combine (XABuildPaths.TopDirectory, "tests", "msbuild-times-reference", "MSBuildDeviceIntegration.csv");
 			using (var reader = File.OpenText (csv)) {
-				var keys = reader.ReadLine ().Split (',');
-				var values = reader.ReadLine ().Split (',');
-				Assert.AreEqual (keys.Length, values.Length, $"{csv} is not a valid CSV file.");
-				for (int i = 0; i < values.Length; i++) {
-					string text = values [i];
+				while (!reader.EndOfStream) {
+					var line = reader.ReadLine ();
+					if (line.StartsWith ("#") || string.IsNullOrWhiteSpace (line)) {
+						continue;
+					}
+					var split = line.Split (',');
+					Assert.AreEqual (2, split.Length, $"{csv} should have two entries per line.");
+					string text = split [1];
 					if (int.TryParse (text, out int value)) {
-						csv_values [keys [i]] = value;
+						csv_values [split [0]] = value;
 					} else {
 						Assert.Fail ($"'{text}' is not a valid integer!");
 					}

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -21,8 +21,12 @@ namespace Xamarin.Android.Build.Tests
 				var values = reader.ReadLine ().Split (',');
 				Assert.AreEqual (keys.Length, values.Length, $"{csv} is not a valid CSV file.");
 				for (int i = 0; i < values.Length; i++) {
-					int.TryParse (values [i], out int value);
-					csv_values [keys [i]] = value;
+					string text = values [i];
+					if (int.TryParse (text, out int value)) {
+						csv_values [keys [i]] = value;
+					} else {
+						Assert.Fail ($"'{text}' is not a valid integer!");
+					}
 				}
 			}
 		}
@@ -55,7 +59,6 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[Repeat (10)] //TODO: remove this
 		public void Build_No_Changes ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -78,7 +81,6 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[Repeat (10)] //TODO: remove this
 		public void Build_CSharp_Change ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -95,7 +97,6 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[Repeat (10)] //TODO: remove this
 		public void Build_AndroidResource_Change ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -111,7 +112,6 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[Repeat (10)] //TODO: remove this
 		public void Build_Designer_Change ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -132,7 +132,6 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[Repeat (10)] //TODO: remove this
 		public void Build_JLO_Change ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -149,7 +148,6 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[Repeat (10)] //TODO: remove this
 		public void Build_CSProj_Change ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -182,7 +180,6 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[TestCaseSource (nameof (XAML_Change))]
-		[Repeat (10)] //TODO: remove this
 		public void Build_XAML_Change (bool produceReferenceAssembly, bool install)
 		{
 			if (install) {
@@ -260,7 +257,6 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[Repeat (10)] //TODO: remove this
 		public void Install_CSharp_Change ()
 		{
 			DeviceRequired ();

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -55,6 +55,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Repeat (10)] //TODO: remove this
 		public void Build_No_Changes ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -77,6 +78,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Repeat (10)] //TODO: remove this
 		public void Build_CSharp_Change ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -93,6 +95,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Repeat (10)] //TODO: remove this
 		public void Build_AndroidResource_Change ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -108,6 +111,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Repeat (10)] //TODO: remove this
 		public void Build_Designer_Change ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -128,6 +132,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Repeat (10)] //TODO: remove this
 		public void Build_JLO_Change ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -144,6 +149,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Repeat (10)] //TODO: remove this
 		public void Build_CSProj_Change ()
 		{
 			var proj = new XamarinAndroidApplicationProject ();
@@ -176,6 +182,7 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[TestCaseSource (nameof (XAML_Change))]
+		[Repeat (10)] //TODO: remove this
 		public void Build_XAML_Change (bool produceReferenceAssembly, bool install)
 		{
 			if (install) {
@@ -253,6 +260,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Repeat (10)] //TODO: remove this
 		public void Install_CSharp_Change ()
 		{
 			DeviceRequired ();

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -17,6 +17,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var csv = Path.Combine (XABuildPaths.TopDirectory, "tests", "msbuild-times-reference", "MSBuildDeviceIntegration.csv");
 			using (var reader = File.OpenText (csv)) {
+				bool foundHeader = false;
 				while (!reader.EndOfStream) {
 					var line = reader.ReadLine ();
 					if (line.StartsWith ("#") || string.IsNullOrWhiteSpace (line)) {
@@ -24,6 +25,11 @@ namespace Xamarin.Android.Build.Tests
 					}
 					var split = line.Split (',');
 					Assert.AreEqual (2, split.Length, $"{csv} should have two entries per line.");
+					if (!foundHeader) {
+						// Ignore the first-line header
+						foundHeader = true;
+						continue;
+					}
 					string text = split [1];
 					if (int.TryParse (text, out int value)) {
 						csv_values [split [0]] = value;

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using NUnit.Framework;
+using Xamarin.ProjectTools;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture, NonParallelizable]
+	public class PerformanceTest : DeviceTest
+	{
+		readonly Dictionary<string, int> csv_values = new Dictionary<string, int> ();
+
+		[SetUp]
+		public void Setup ()
+		{
+			var csv = Path.Combine (XABuildPaths.TopDirectory, "tests", "msbuild-times-reference", "MSBuildDeviceIntegration.csv");
+			using (var reader = File.OpenText (csv)) {
+				var keys = reader.ReadLine ().Split (',');
+				var values = reader.ReadLine ().Split (',');
+				Assert.AreEqual (keys.Length, values.Length, $"{csv} is not a valid CSV file.");
+				for (int i = 0; i < values.Length; i++) {
+					int.TryParse (values [i], out int value);
+					csv_values [keys [i]] = value;
+				}
+			}
+		}
+
+		void DeviceRequired ()
+		{
+			if (!HasDevices) {
+				Assert.Ignore ("Test requires a device attached.");
+			}
+		}
+
+		void CommercialRequired ()
+		{
+			if (!CommercialBuildAvailable) {
+				Assert.Ignore ("Test requires a commercial build.");
+			}
+		}
+
+		void Profile (ProjectBuilder builder, Action<ProjectBuilder> action, [CallerMemberName] string caller = null)
+		{
+			if (!csv_values.TryGetValue (caller, out int expected)) {
+				Assert.Fail ($"No timeout value found for a key of {caller}");
+			}
+
+			action (builder);
+			var actual = builder.LastBuildTime.TotalMilliseconds;
+			if (actual > expected) {
+				Assert.Fail ($"Exceeded expected time of {expected}ms, actual {actual}ms");
+			}
+		}
+
+		[Test]
+		public void Build_No_Changes ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.MainActivity = proj.DefaultMainActivity;
+			using (var builder = CreateApkBuilder ()) {
+				builder.Target = "Build";
+				builder.Build (proj);
+
+				// Profile no changes
+				Profile (builder, b => b.Build (proj));
+
+				// Change C# and build
+				proj.MainActivity += $"{Environment.NewLine}//comment";
+				proj.Touch ("MainActivity.cs");
+				builder.Build (proj);
+
+				// Profile no changes
+				Profile (builder, b => b.Build (proj));
+			}
+		}
+
+		[Test]
+		public void Build_CSharp_Change ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.MainActivity = proj.DefaultMainActivity;
+			using (var builder = CreateApkBuilder ()) {
+				builder.Target = "Build";
+				builder.Build (proj);
+
+				// Profile C# change
+				proj.MainActivity += $"{Environment.NewLine}//comment";
+				proj.Touch ("MainActivity.cs");
+				Profile (builder, b => b.Build (proj));
+			}
+		}
+
+		[Test]
+		public void Build_AndroidResource_Change ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			using (var builder = CreateApkBuilder ()) {
+				builder.Target = "Build";
+				builder.Build (proj);
+
+				// Profile AndroidResource change
+				proj.LayoutMain += $"{Environment.NewLine}<!--comment-->";
+				proj.Touch ("Resources\\layout\\Main.axml");
+				Profile (builder, b => b.Build (proj));
+			}
+		}
+
+		[Test]
+		public void Build_Designer_Change ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.MainActivity = proj.DefaultMainActivity;
+			using (var builder = CreateApkBuilder ()) {
+				builder.Target = "Build";
+				builder.Build (proj);
+
+				// Change AndroidResource & run SetupDependenciesForDesigner
+				proj.LayoutMain += $"{Environment.NewLine}<!--comment-->";
+				proj.Touch ("Resources\\layout\\Main.axml");
+				var parameters = new [] { "DesignTimeBuild=True", "AndroidUseManagedDesignTimeResourceGenerator=False" };
+				builder.RunTarget (proj, "SetupDependenciesForDesigner", parameters: parameters);
+
+				// Profile AndroidResource change
+				Profile (builder, b => b.Build (proj));
+			}
+		}
+
+		[Test]
+		public void Build_JLO_Change ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.MainActivity = proj.DefaultMainActivity;
+			using (var builder = CreateApkBuilder ()) {
+				builder.Target = "Build";
+				builder.Build (proj);
+
+				// Profile Java.Lang.Object rename
+				proj.MainActivity = proj.MainActivity.Replace ("MainActivity", "MainActivity2");
+				proj.Touch ("MainActivity.cs");
+				Profile (builder, b => b.Build (proj));
+			}
+		}
+
+		[Test]
+		public void Build_CSProj_Change ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			using (var builder = CreateApkBuilder ()) {
+				builder.Target = "Build";
+				builder.Build (proj);
+
+				// Profile .csproj change
+				proj.Sources.Add (new BuildItem ("None", "Foo.txt") {
+					TextContent = () => "Bar",
+				});
+				Profile (builder, b => b.Build (proj));
+			}
+		}
+
+		static object [] XAML_Change = new object [] {
+			new object [] {
+				/* produceReferenceAssembly */ false,
+				/* install */                  false,
+			},
+			new object [] {
+				/* produceReferenceAssembly */ true,
+				/* install */                  false,
+			},
+			new object [] {
+				/* produceReferenceAssembly */ true,
+				/* install */                  true,
+			},
+		};
+
+		[Test]
+		[TestCaseSource (nameof (XAML_Change))]
+		public void Build_XAML_Change (bool produceReferenceAssembly, bool install)
+		{
+			if (install) {
+				DeviceRequired ();
+				CommercialRequired (); // This test will fail without Fast Deployment
+			}
+
+			var path = Path.Combine ("temp", TestName);
+			var xaml =
+@"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""
+             xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
+             x:Class=""MyLibrary.MyPage"">
+</ContentPage>";
+			var caller = nameof (Build_XAML_Change);
+			if (install) {
+				caller = caller.Replace ("Build", "Install");
+			} else if (produceReferenceAssembly) {
+				caller += "_RefAssembly";
+			}
+			var app = new XamarinFormsAndroidApplicationProject {
+				ProjectName = "MyApp",
+				Sources = {
+					new BuildItem.Source ("Foo.cs") {
+						TextContent = () => "public class Foo : Bar { }"
+					},
+				}
+			};
+			//NOTE: this will skip a 382ms <VerifyVersionsTask/> from the support library
+			app.SetProperty ("XamarinAndroidSupportSkipVerifyVersions", "True");
+
+			int count = 0;
+			var lib = new DotNetStandard {
+				ProjectName = "MyLibrary",
+				Sdk = "Microsoft.NET.Sdk",
+				TargetFramework = "netstandard2.0",
+				Sources = {
+					new BuildItem.Source ("Bar.cs") {
+						TextContent = () => "public class Bar { public Bar () { System.Console.WriteLine (" + count++ + "); } }"
+					},
+					new BuildItem ("EmbeddedResource", "MyPage.xaml") {
+						TextContent = () => xaml,
+					}
+				},
+				PackageReferences = {
+					KnownPackages.XamarinForms_4_0_0_425677
+				}
+			};
+			lib.SetProperty ("ProduceReferenceAssembly", produceReferenceAssembly.ToString ());
+			app.References.Add (new BuildItem.ProjectReference ($"..\\{lib.ProjectName}\\{lib.ProjectName}.csproj", lib.ProjectName, lib.ProjectGuid));
+
+			using (var libBuilder = CreateDllBuilder (Path.Combine (path, lib.ProjectName)))
+			using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
+				libBuilder.Build (lib);
+				appBuilder.Target = "Build";
+				if (install) {
+					appBuilder.Install (app);
+				} else {
+					appBuilder.Build (app);
+				}
+
+				libBuilder.AutomaticNuGetRestore =
+					appBuilder.AutomaticNuGetRestore = false;
+
+				// Profile XAML change
+				xaml += $"{Environment.NewLine}<!--comment-->";
+				lib.Touch ("MyPage.xaml");
+				libBuilder.Build (lib, doNotCleanupOnUpdate: true);
+				if (install) {
+					Profile (appBuilder, b => b.Install (app, doNotCleanupOnUpdate: true), caller);
+				} else {
+					Profile (appBuilder, b => b.Build (app, doNotCleanupOnUpdate: true), caller);
+				}
+			}
+		}
+
+		[Test]
+		public void Install_CSharp_Change ()
+		{
+			DeviceRequired ();
+			CommercialRequired (); // This test will fail without Fast Deployment
+
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.MainActivity = proj.DefaultMainActivity;
+			using (var builder = CreateApkBuilder ()) {
+				builder.Install (proj);
+
+				// Profile C# change
+				proj.MainActivity += $"{Environment.NewLine}//comment";
+				proj.Touch ("MainActivity.cs");
+				Profile (builder, b => b.Install (proj));
+			}
+		}
+	}
+}

--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -1,0 +1,2 @@
+Build_No_Changes,Build_CSharp_Change,Build_AndroidResource_Change,Build_Designer_Change,Build_JLO_Change,Build_CSProj_Change,Build_XAML_Change,Build_XAML_Change_RefAssembly,Install_CSharp_Change,Install_XAML_Change
+3250,4000,4750,4250,9000,9500,9500,6250,6000,7500

--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -1,2 +1,13 @@
-Build_No_Changes,Build_CSharp_Change,Build_AndroidResource_Change,Build_Designer_Change,Build_JLO_Change,Build_CSProj_Change,Build_XAML_Change,Build_XAML_Change_RefAssembly,Install_CSharp_Change,Install_XAML_Change
-3250,4000,4750,4250,9000,9500,9500,6250,6000,7500
+# Comments and blank lines are ignored
+# First non-comment row is human description of columns
+# Test Name,Time in ms (int)
+Build_No_Changes,3250
+Build_CSharp_Change,4000
+Build_AndroidResource_Change,4750
+Build_Designer_Change,4250
+Build_JLO_Change,9000
+Build_CSProj_Change,9500
+Build_XAML_Change,9500
+Build_XAML_Change_RefAssembly,6250
+Install_CSharp_Change,6000
+Install_XAML_Change,7500

--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -1,6 +1,7 @@
 # Comments and blank lines are ignored
 # First non-comment row is human description of columns
-# Test Name,Time in ms (int)
+Test Name,Time in ms (int)
+# Data
 Build_No_Changes,3250
 Build_CSharp_Change,4000
 Build_AndroidResource_Change,4750


### PR DESCRIPTION
A new set of tests to catch regressions in build performance. They
would likely catch a bug where we accidentally caused MSBuild targets
to run when they shouldn't.

In a previous build, these tests passed while using `[Repeat(10)]`:

https://build.azdo.io/3193441

Hopefully, this means they will be stable (not flaky) going forward.

Cases we are now testing:

- Build with no changes
- Build with C# change
- Build with AndroidResource change
- Build with Android designer change (call designer's MSBuild targets)
- Build with XAML change & *no* reference assemblies
- Build with XAML change & reference assemblies
- Build with new `Java.Lang.Object`
- Build with `csproj` change
- Install with C# change
- Install with XAML change & reference assemblies

These run on on the MSBuild Device tests on Mac. I gave about 250ms of
leeway, but I was seeing 2 or 3 times better numbers locally.