### PR TITLE
Try to detect the `gettid` function on Linux hosts

### DIFF
--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -140,6 +140,12 @@ if(ENABLE_NDK)
 
   link_directories("${XA_LIB_TOP_DIR}/${ANDROID_ABI}")
 else()
+  set(CMAKE_REQUIRED_DEFINITIONS "-D__USE_GNU")
+  check_cxx_symbol_exists(gettid unistd.h HAVE_GETTID_IN_UNISTD_H)
+  if(HAVE_GETTID_IN_UNISTD_H)
+	add_definitions("-DHAVE_GETTID_IN_UNISTD_H")
+  endif()
+
   # MinGW needs it for {v,a}sprintf
   add_definitions("-D_GNU_SOURCE")
   if(APPLE)

--- a/src/monodroid/jni/osbridge.cc
+++ b/src/monodroid/jni/osbridge.cc
@@ -6,6 +6,14 @@
 #include <sys/syscall.h>
 #endif
 
+#if defined (HAVE_GETTID_IN_UNISTD_H)
+#if !defined __USE_GNU
+#define __USE_GNU
+#endif // !def __USE_GNU
+#endif // def HAVE_GETTID_IN_UNISTD_H
+
+#include <unistd.h>
+
 #include <mono/metadata/class.h>
 #include <mono/metadata/object.h>
 #include <mono/metadata/threads.h>
@@ -69,12 +77,12 @@ gc_cross_references_cb (int num_sccs, MonoGCBridgeSCC **sccs, int num_xrefs, Mon
 }
 
 #ifdef WINDOWS
-typedef int tid_type;
+using tid_type = int;
 #else
-typedef pid_t tid_type;
+using tid_type = pid_t;
 #endif
 // glibc does *not* have a wrapper for the gettid syscall, Android NDK has it
-#if !defined (ANDROID)
+#if !defined (ANDROID) && !defined (HAVE_GETTID_IN_UNISTD_H)
 static tid_type gettid ()
 {
 #ifdef WINDOWS


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3802

Most Linux distributions don't have a wrapper for the `gettid` syscall in the
standard C library. It appears that distributions with newer glibc define it in
`unistd_ext.h` header included by `unistd.h`. Add a symbol check to avoid build
errors on those distributions which do define `gettid` in the system headers.