### PR TITLE
Fix: ServiceAttribute is missing foregroundServiceType

### DIFF
--- a/build-tools/manifest-attribute-codegen/manifest-definition.xml
+++ b/build-tools/manifest-attribute-codegen/manifest-definition.xml
@@ -211,6 +211,7 @@
         <a name='roundIcon' api-level='25' />
         <a name='visibleToInstantApps' api-level='26' />
         <a name='splitName' api-level='26' />
+        <a name='foregroundServiceType' api-level='29' />
     </e>
     <e name='receiver'>
         <parent>application</parent>

--- a/src/Xamarin.Android.Build.Tasks/Mono.Android/ServiceAttribute.Partial.cs
+++ b/src/Xamarin.Android.Build.Tasks/Mono.Android/ServiceAttribute.Partial.cs
@@ -8,12 +8,15 @@ using Java.Interop.Tools.Cecil;
 
 using Xamarin.Android.Manifest;
 
+using Android.Content.PM;
+
 namespace Android.App {
 
 	partial class ServiceAttribute {
 
 		bool  _IsolatedProcess;
 		string _RoundIcon;
+		ForegroundService _ForegroundServiceType;
 
 		static ManifestDocumentElement<ServiceAttribute> mapping = new ManifestDocumentElement<ServiceAttribute> ("service") {
 			{
@@ -31,6 +34,11 @@ namespace Android.App {
 			  "exported",
 			  self          => self.Exported,
 			  (self, value) => self.Exported  = (bool) value
+			}, {
+			  "ForegroundServiceType",
+			  "foregroundServiceType",
+			  self          => self._ForegroundServiceType,
+			  (self, value) => self._ForegroundServiceType  = (ForegroundService) value
 			}, {
 			  "Icon",
 			  "icon",

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
@@ -185,6 +185,7 @@ namespace Xamarin.Android.Manifest {
 			{ typeof (ActivityPersistableMode),     (value, p, r, v) => ToString ((ActivityPersistableMode) value) },
 			{ typeof (ConfigChanges),       (value, p, r, v) => ToString ((ConfigChanges) value) },
 			{ typeof (DocumentLaunchMode),  (value, p, r, v) => ToString ((DocumentLaunchMode) value) },
+			{ typeof (ForegroundService),   (value, p, r, v) => ToString ((ForegroundService) value) },
 			{ typeof (LaunchMode),          (value, p, r, v) => ToString ((LaunchMode) value) },
 			{ typeof (Protection),          (value, p, r, v) => ToString ((Protection) value) },
 			{ typeof (ScreenOrientation),   (value, p, r, v) => ToString ((ScreenOrientation) value, v) },
@@ -192,7 +193,6 @@ namespace Xamarin.Android.Manifest {
 			{ typeof (UiOptions),           (value, p, r, v) => ToString ((UiOptions) value) },
 			{ typeof (Type),                (value, p, r, v) => ToString (value.ToString (), p, r) },
 			{ typeof (WindowRotationAnimation),     (value, p, r, v) => ToString ((WindowRotationAnimation) value) },
-			{ typeof (ForegroundService),     (value, p, r, v) => ToString ((ForegroundService) value) },
 		};
 
 		static string ToString (bool value)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocumentElement.cs
@@ -192,6 +192,7 @@ namespace Xamarin.Android.Manifest {
 			{ typeof (UiOptions),           (value, p, r, v) => ToString ((UiOptions) value) },
 			{ typeof (Type),                (value, p, r, v) => ToString (value.ToString (), p, r) },
 			{ typeof (WindowRotationAnimation),     (value, p, r, v) => ToString ((WindowRotationAnimation) value) },
+			{ typeof (ForegroundService),     (value, p, r, v) => ToString ((ForegroundService) value) },
 		};
 
 		static string ToString (bool value)
@@ -365,6 +366,19 @@ namespace Xamarin.Android.Manifest {
 			return ToString (typeDef);
 		}
 
+		static string ToString (ForegroundService value)
+		{
+			switch (value) {
+				case ForegroundService.TypeConnectedDevice:	return "connectedDevice";
+				case ForegroundService.TypeDataSync:		return "dataSync";
+				case ForegroundService.TypeLocation:		return "location";
+				case ForegroundService.TypeMediaPlayback:	return "mediaPlayback";
+				case ForegroundService.TypeMediaProjection:	return "mediaProjection";
+				case ForegroundService.TypePhoneCall:		return "phoneCall";
+				default:
+					throw new ArgumentException ($"Unsupported ForegroundServiceType value '{value}'.", nameof (value));
+			}
+		}
 		IEnumerator<string> IEnumerable<string>.GetEnumerator ()
 		{
 			return Mappings.Keys.GetEnumerator ();

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -595,6 +595,7 @@
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.LaunchMode.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.ScreenOrientation.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.ConfigChanges.cs" />
+    <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.ForegroundService.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.UiOptions.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Views.SoftInput.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.Protection.cs" />

--- a/src/Xamarin.Android.NamingCustomAttributes/Android.App/ServiceAttribute.cs
+++ b/src/Xamarin.Android.NamingCustomAttributes/Android.App/ServiceAttribute.cs
@@ -7,8 +7,8 @@ using Android.Views;
 namespace Android.App {
 
 	[Serializable]
-	[AttributeUsage (AttributeTargets.Class, 
-			AllowMultiple=false, 
+	[AttributeUsage (AttributeTargets.Class,
+			AllowMultiple=false,
 			Inherited=false)]
 	public sealed partial class ServiceAttribute : Attribute, Java.Interop.IJniNameProviderAttribute {
 
@@ -23,6 +23,9 @@ namespace Android.App {
 #endif
 		public bool                   Enabled                 {get; set;}
 		public bool                   Exported                {get; set;}
+#if ANDROID_29
+		public ForegroundService      ForegroundServiceType   {get; set;}
+#endif
 		[Category ("@drawable;@mipmap")]
 		public string                 Icon                    {get; set;}
 #if ANDROID_16


### PR DESCRIPTION
Our tools currently do not automatically add new manifest properties.
Manually adding ForegroundServiceType property to ServiceAttribute class

Tracking issue: https://github.com/xamarin/xamarin-android/issues/3712