### PR TITLE
[Xamarin.Android.Build.Tasks] aapt2 failure causes targets to skip

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -972,5 +972,23 @@ namespace Lib2
 				Assert.IsTrue (DexUtils.ContainsClass (className, dexFile, AndroidSdkPath), $"`{dexFile}` should include `{className}`!");
 			}
 		}
+
+		[Test]
+		public void AaptError ([Values (true, false)] bool useAapt2)
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				Sources = {
+					new BuildItem.Source ("TestActivity.cs") {
+						TextContent = () => @"using Android.App; [Activity(Theme = ""@style/DoesNotExist"")] class TestActivity : Activity { }"
+					}
+				}
+			};
+			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
+			using (var builder = CreateApkBuilder ()) {
+				builder.ThrowOnBuildFailure = false;
+				Assert.IsFalse (builder.Build (proj), "Build should *not* have succeeded on the first build.");
+				Assert.IsFalse (builder.Build (proj), "Build should *not* have succeeded on the second build.");
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3779

Using @brendanzagaeski's repro, I saw a possible #deletebinobj issue
when using aapt2:

* Build with a resource error, get an `APT2XXX` error code.
* Future builds give no error???

Once in this state, you could be using a malformed APK until you
modify a `@(AndroidResource)` -- or fix the problem?

The cause appears to be that `aapt2` is actually generating output in
`obj\Debug\bin\android\packaged_resources` even though it emits an
error?

I think we should:

* Do *not* copy `packaged_resources.bk` if `aapt2` failed.
* Delete `packaged_resources` on `aapt2` failures.