### PR TITLE
[Xamarin.Android.Build.Tasks] set $(MaxSupportedLangVersion) for C# 8

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -780,6 +780,31 @@ namespace UnamedProject
 		}
 
 		[Test]
+		public void CSharp8Features ([Values (true, false)] bool bindingProject)
+		{
+			XamarinAndroidProject proj;
+			if (bindingProject) {
+				proj = new XamarinAndroidBindingProject {
+					AndroidClassParser = "class-parse",
+					Jars = {
+						new AndroidItem.EmbeddedJar ("Jars\\svg-android.jar") {
+							WebContentFileNameFromAzure = "javaBindingIssue.jar"
+						}
+					}
+				};
+			} else {
+				proj = new XamarinAndroidApplicationProject ();
+			}
+
+			proj.Sources.Add (new BuildItem.Source ("Foo.cs") {
+				TextContent = () => "class A { void B () { using var s = new System.IO.MemoryStream (); } }",
+			});
+			using (var b = bindingProject ? CreateDllBuilder () : CreateApkBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			}
+		}
+
+		[Test]
 		public void BuildMkBundleApplicationRelease ()
 		{
 			var proj = new XamarinAndroidApplicationProject () { IsRelease = true, BundleAssemblies = true };

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -63,6 +63,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
     <MonoAndroidVersion>v5.0</MonoAndroidVersion>
     <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == '' And '$(AndroidUseLatestPlatformSdk)' == 'False'">v4.4</TargetFrameworkVersion>
+    <MaxSupportedLangVersion Condition=" '$(MaxSupportedLangVersion)' == '' ">8.0</MaxSupportedLangVersion>
     <UseShortFileNames Condition="'$(UseShortFileNames)' == ''">True</UseShortFileNames>
     <UseShortGeneratorFileNames Condition="'$(UseShortGeneratorFileNames)' == ''">False</UseShortGeneratorFileNames>
     <AndroidClassParser Condition=" '$(AndroidClassParser)' == '' ">jar2xml</AndroidClassParser>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.CSharp.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.CSharp.targets
@@ -28,6 +28,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     <PropertyGroup>
         <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
         <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v4.4</TargetFrameworkVersion>
+        <MaxSupportedLangVersion Condition=" '$(MaxSupportedLangVersion)' == '' ">8.0</MaxSupportedLangVersion>
         <AndroidLinkMode Condition="'$(AndroidLinkMode)' == ''">SdkOnly</AndroidLinkMode>
         <!-- The .NET SGEN tool cannot process Xamarin.Android assemblies because
              our mscorlib.dll isn't properly signed, as far as its concerned.


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3807
Context: https://github.com/dotnet/roslyn/blob/d28899e051db225e4c1126c61c5bda2dba2a32b1/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets#L6-L10
Context: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version

Reviewing the MSBuild targets from Roslyn:

    <PropertyGroup Condition="('$(TargetFrameworkIdentifier)' != '.NETCoreApp' OR '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0') AND
                            ('$(TargetFrameworkIdentifier)' != '.NETStandard' OR '$(_TargetFrameworkVersionWithoutV)' &lt; '2.1')">
      <MaxSupportedLangVersion Condition="'$(MaxSupportedLangVersion)' == ''">7.3</MaxSupportedLangVersion>
      <LangVersion Condition="'$(LangVersion)' == ''">$(MaxSupportedLangVersion)</LangVersion>
    </PropertyGroup>

Since Xamarin.Android projects aren't `.NETCoreApp` or `.NETStandard`,
we have to set `$(MaxSupportedLangVersion)` to opt into the new
language features.

We have to set this before this import:

    <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

So I have to set this property in both `Xamarin.Android.CSharp.targets`
and `Xamarin.Android.Bindings.targets`.

I added a test for both project types.