### PR TITLE
Bump to mono/mono/2019-08@ef75d4be

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:d16-4@400af80a924649081ce4ea15dfffcbd5c924d857
-mono/mono:2019-08@01dbbb746f4174130ef1226e4a9683f2f9a70f9d
+mono/mono:2019-08@ef75d4bef7509b23103fffa2acca039e9acbb157


### PR DESCRIPTION
Changes: https://github.com/mono/mono/compare/01dbbb746f4174130ef1226e4a9683f2f9a70f9d...ef75d4bef7509b23103fffa2acca039e9acbb157

Fixes an issue within `Socket.BeginConnect()` returning too early when
the callback wasn't provided.