### PR TITLE
Bump to mono/mono/2019-98@baa12e5d

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:master@dceaee4ed2a49a81c86bc52b47f07faaf7e4fc13
-mono/mono:2019-08@df5e13f95df7a2d11d86904e74b1bd8950c9d43b
+mono/mono:2019-08@baa12e5d2405fc81195817638983ba7d6d8330f2


### PR DESCRIPTION
Changes: https://github.com/mono/mono/compare/df5e13f95df7a2d11d86904e74b1bd8950c9d43b...baa12e5d2405fc81195817638983ba7d6d8330f2

  * mono/mono@baa12e5d: [profiler] Fix coverage profiler on macos (#17422)
  * mono/mono@ef75d4be: [2019-08] BeginConnect complete to early when not using callback. (#17416)
  * mono/mono@01dbbb74: [2019-08] Enable GSS on Linux (#17410)
  * mono/mono@51a3dc37: Fix SafeHandle marshalling in ref/in/out parameters (#17330)
  * mono/mono@3eb5f34f: [GTK] Bump bockbuild for GtkViewport autoscrolling patch. (#17321)
  * mono/mono@b601371d: Update MERP event type to MonoAppCrash
  * mono/mono@6184ff00: [2019-08][ci] Use Xcode11.1 and 11.2beta2 for XI/XM Mono SDK builds (#17324)
  * mono/mono@8969f2cc: [2019-08] [merp] Include any managed methods in the 'unmanaged_frames portion (#17316)
  * mono/mono@30094401: [2019-08][merp] Don't install SIGTERM handler in EnableMicrosoftTelemetry (#17308)