### PR TITLE
[Xamarin.Android.Build.Tasks] non-existent @(AndroidResource) files should error

### DIFF
--- a/Documentation/guides/messages/xa2001.md
+++ b/Documentation/guides/messages/xa2001.md
@@ -1,0 +1,20 @@
+---
+title: Xamarin.Android error XA2001
+description: XA2001 error code
+ms.date: 10/24/2019
+---
+# Xamarin.Android error XA2001
+
+An `<AndroidResource/>` item was specified in a project that does not
+exist.
+
+## Example messages
+
+```
+Source file '{filename}' could not be found.
+```
+
+## Solution
+
+Review your project's `.csproj` file and remove any
+`<AndroidResource/>` items that do not exist.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidUpdateResDir.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidUpdateResDir.cs
@@ -125,6 +125,10 @@ namespace Xamarin.Android.Tasks
 				if (String.Compare (intermediateDirFullPath, 0, dest, 0, intermediateDirFullPath.Length, StringComparison.OrdinalIgnoreCase) != 0) {
 					dest = Path.GetFullPath (Path.Combine (IntermediateDir, Path.GetFileName (baseFileName)));
 				}
+				if (!File.Exists (item.ItemSpec)) {
+					Log.LogCodedError ("XA2001", file: item.ItemSpec, lineNumber: 0, message: $"Source file '{item.ItemSpec}' could not be found.");
+					continue;
+				}
 				var newItem = new TaskItem (dest);
 				newItem.SetMetadata ("LogicalName", rel);
 				item.CopyMetadataTo (newItem);
@@ -138,7 +142,7 @@ namespace Xamarin.Android.Tasks
 			Log.LogDebugTaskItems ("  IntermediateFiles:", IntermediateFiles);
 			Log.LogDebugTaskItems ("  ResolvedResourceFiles:", ResolvedResourceFiles);
 			Log.LogDebugTaskItems ("  ResourceNameCaseMap:", ResourceNameCaseMap);
-			return true;
+			return !Log.HasLoggedErrors;
 		}
 	}
 	

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -550,6 +550,28 @@ namespace UnamedProject
 		}
 
 		[Test]
+		public void AndroidResourceNotExist ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				Imports = {
+					new Import (() => "foo.projitems") {
+						TextContent = () =>
+@"<Project>
+	<ItemGroup>
+		<AndroidResource Include=""Resources\layout\noexist.xml"" />
+	</ItemGroup>
+</Project>"
+					},
+				},
+			};
+			using (var b = CreateApkBuilder ()) {
+				b.ThrowOnBuildFailure = false;
+				Assert.IsFalse (b.Build (proj), "Build should have failed.");
+				Assert.IsTrue (b.LastBuildOutput.ContainsText ("XA2001"), "Should recieve XA2001 error.");
+			}
+		}
+
+		[Test]
 		public void TargetFrameworkMonikerAssemblyAttributesPath ()
 		{
 			const string filePattern = "MonoAndroid,Version=v*.AssemblyAttributes.cs";


### PR DESCRIPTION
I found a performance problem in a project containing:

    <AndroidResource Include="Resources\layout\noexist.xml" />

What happens in this case, is on every build you get:

    Building target "_CompileResources" completely.
    Input file "Resources\layout\noexist.xml" does not exist.
    Building target "_UpdateAndroidResgen" completely.
    Input file "Resources\layout\noexist.xml" does not exist.

Effectively, even builds with no changes will always run expensive
`aapt` calls...

But we should just emit an error here! That would match more in-line
with what the `<Csc/>` MSBuild task gives for missing C# files.

An example of a non-existent C# file:

    (CoreCompile target) ->
    CSC : error CS2001: Source file 'C:\src\xamarin-android\samples\HelloWorld\noexist.cs' could not be found.

Giving a similar `XA2001` error for `@(AndroidResource)` files will
solve the issue here.