### PR TITLE
[tests] Introduce 'HybridAotNotWorking' category

### DIFF
--- a/src/Mono.Android/Test/System/AppDomainTest.cs
+++ b/src/Mono.Android/Test/System/AppDomainTest.cs
@@ -13,6 +13,7 @@ namespace SystemTests {
 	public class AppDomainTest {
 
 		[Test]
+		[Category ("HybridAotNotWorking")]
 		public void DateTime_Now_Works ()
 		{
 			new Boom().Bang();

--- a/src/Mono.Android/Test/System/AppDomainTest.cs
+++ b/src/Mono.Android/Test/System/AppDomainTest.cs
@@ -13,7 +13,7 @@ namespace SystemTests {
 	public class AppDomainTest {
 
 		[Test]
-		[Category ("HybridAotNotWorking")]
+		[Category ("HybridAotNotWorking")] // See https://github.com/xamarin/xamarin-android/issues/1536
 		public void DateTime_Now_Works ()
 		{
 			new Boom().Bang();


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/1536
Context: https://dev.azure.com/devdiv/DevDiv/_releaseProgress?_a=release-environment-extension&releaseId=484122&environmentId=2423388&extensionId=ms.vss-test-web.test-result-in-release-environment-editor-tab

Introduces a new test category which can be used to ignore unit tests
that aren't compatible with Hybrid AOT.