### PR TITLE
Disable archive verification in xaprepare

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/Utilities.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Utilities.cs
@@ -167,20 +167,6 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		public static async Task<bool> VerifyArchive (string fullArchivePath)
-		{
-			if (String.IsNullOrEmpty (fullArchivePath))
-				throw new ArgumentNullException ("must not be null or empty", nameof (fullArchivePath));
-
-			if (!FileExists (fullArchivePath))
-				return false;
-
-			string sevenZip = Context.Instance.Tools.SevenZipPath;
-			Log.DebugLine ($"Verifying archive {fullArchivePath}");
-			var runner = new SevenZipRunner (Context.Instance);
-			return await runner.VerifyArchive (fullArchivePath);
-		}
-
 		public static async Task<bool> Unpack (string fullArchivePath, string destinationDirectory, bool cleanDestinatioBeforeUnpacking = false)
 		{
 			if (String.IsNullOrEmpty (fullArchivePath))

--- a/build-tools/xaprepare/xaprepare/Steps/Step_Android_SDK_NDK.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_Android_SDK_NDK.cs
@@ -134,12 +134,8 @@ namespace Xamarin.Android.Prepare
 			Log.StatusLine ($"  {context.Characters.Bullet} Installing ", pkg.Component.Name, tailColor: ConsoleColor.White);
 
 			if (File.Exists (pkg.LocalPackagePath)) {
-				bool valid = Utilities.VerifyArchive (pkg.LocalPackagePath).GetAwaiter ().GetResult ();
-				if (!valid || (RefreshSdk && !IsNdk (pkg.Component)) || (RefreshNdk && IsNdk (pkg.Component))) {
-					if (valid)
-						LogStatus ("Reinstall requested, deleting cache", 4, ConsoleColor.Magenta);
-					else
-						LogStatus ("Downloaded package is invalid, re-download required. Deleting cache.", 4, ConsoleColor.Magenta);
+				if ((RefreshSdk && !IsNdk (pkg.Component)) || (RefreshNdk && IsNdk (pkg.Component))) {
+					LogStatus ("Reinstall requested, deleting cache", 4, ConsoleColor.Magenta);
 					Utilities.DeleteFile (pkg.LocalPackagePath);
 					toDownload.Add (pkg);
 				} else {

--- a/build-tools/xaprepare/xaprepare/Steps/Step_DownloadMonoArchive.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_DownloadMonoArchive.cs
@@ -71,8 +71,8 @@ namespace Xamarin.Android.Prepare
 
 		async Task<bool> DownloadAndUpackIfNeeded (Context context, string name, string localPath, string archiveFileName, string destinationDirectory)
 		{
-			if (await Utilities.VerifyArchive (localPath)) {
-				Log.StatusLine ($"{name} archive already downloaded and valid");
+			if (File.Exists (localPath)) {
+				Log.StatusLine ($"{name} archive already downloaded");
 			} else {
 				Utilities.DeleteFileSilent (localPath);
 

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallCorrettoOpenJDK.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallCorrettoOpenJDK.cs
@@ -69,11 +69,8 @@ namespace Xamarin.Android.Prepare
 		async Task<bool> DownloadCorretto (Context context, string localPackagePath, Uri url)
 		{
 			if (File.Exists (localPackagePath)) {
-				if (await Utilities.VerifyArchive (localPackagePath)) {
-					Log.StatusLine ("Corretto archive already downloaded and valid");
-					return true;
-				}
-				Utilities.DeleteFileSilent (localPackagePath);
+				Log.StatusLine ("Corretto archive already downloaded");
+				return true;
 			}
 
 			Log.StatusLine ("Downloading Corretto from ", url.ToString (), tailColor: ConsoleColor.White);

--- a/build-tools/xaprepare/xaprepare/Steps/Step_PrepareBundle.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_PrepareBundle.cs
@@ -31,8 +31,8 @@ namespace Xamarin.Android.Prepare
 			string localPackagePath = Configurables.Paths.BundleArchivePath;
 			Log.DebugLine ($"Local bundle path: {localPackagePath}");
 
-			if (await Utilities.VerifyArchive (localPackagePath)) {
-				Log.StatusLine ("Xamarin.Android Bundle archive already downloaded and valid");
+			if (File.Exists (localPackagePath)) {
+				Log.StatusLine ("Xamarin.Android Bundle archive already downloaded");
 			} else {
 				if (!String.IsNullOrEmpty (context.XABundlePath)) {
 					// User indicated they wanted to use a specific bundle that's supposed to be on disk. It's not (or

--- a/build-tools/xaprepare/xaprepare/ToolRunners/SevenZipRunner.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/SevenZipRunner.cs
@@ -48,30 +48,6 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		public async Task<bool> VerifyArchive (string archivePath)
-		{
-			if (String.IsNullOrEmpty (archivePath))
-				throw new ArgumentException ("must not be null or empty", nameof (archivePath));
-
-			ProcessRunner runner = CreateProcessRunner ("t");
-			AddStandardArguments (runner);
-			runner.AddQuotedArgument (archivePath);
-
-			try {
-				Log.StatusLine ($"Archive path: {archivePath}");
-				return await RunTool (
-					() => {
-						using (TextWriter outputSink = SetupOutputSink (runner, $"7zip-verify-archive.{Path.GetFileName (archivePath)}", "verifying archive integrity")) {
-							StartTwiddler ();
-							return runner.Run ();
-						}
-					}
-				);
-			} finally {
-				StopTwiddler ();
-			}
-		}
-
 		public async Task<bool> SevenZip (string outputArchivePath, string workingDirectory, List<string> inputFiles)
 		{
 			return await DoZip (outputArchivePath, workingDirectory, inputFiles, "7z", 9);


### PR DESCRIPTION
In order to make builds faster, we're going to remove downloaded archive
verification step. The way the verification works is basically unpack the
archive without writing its contents to disk, merely calculating the checksum.
In effect, the time it takes to verify is just slightly less than it takes to
actually unpack the archive. Removing the verification step appears to give us
~6 minutes back on Azure builds for the **prepare** target and just above 1 minute 
for the **prepare -> bundle** stage.