### PR TITLE
[tests] Use d16-4 designer source on d16-4

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -754,7 +754,7 @@ stages:
       EnableRegressionTest: true
     steps:
     - script: |
-        git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git
+        git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git --branch d16-4
         cd designer
         git submodule update -q --init --recursive
       displayName: Clone and update designer
@@ -790,7 +790,7 @@ stages:
       VisualStudioInstallationPath: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
     steps:
     - script: |
-        git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git
+        git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git --branch d16-4
         cd designer
         git submodule update -q --init --recursive
       displayName: Clone and update designer


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3177751
Context: https://github.com/xamarin/designer/pull/2269

Custom control designer tests have recently started failing against
xamarin-android/d16-4 due to changes in designer/master. We should ensure
that our release branches are tracking the correct test sources, as
breaking changes can be expected when testing older release branches
against ongoing changes in master.