### PR TITLE
Bump to mono/mono/2019-08@8946e49a

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:d16-4@ed9e9e8ca05acc09e47aff89b1ff5fe0dd0cf231
-mono/mono:2019-08@ef75d4bef7509b23103fffa2acca039e9acbb157
+mono/mono:2019-08@8946e49a974ea8b75fe5b8b7e93ffd4571521a85


### PR DESCRIPTION
Changes: https://github.com/mono/mono/compare/baa12e5d2405fc81195817638983ba7d6d8330f2...8946e49a974ea8b75fe5b8b7e93ffd4571521a85

Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1005448
Context: https://github.com/mono/mono/issues/17084

  * mono/mono@8946e49a: (origin/2019-08) Added SR.missing from original backport
  * mono/mono@5c784c97: Bump to mono/corefx@fb41040
  * mono/mono@fdb70490: Revert "[2019-08] rollback msbuild/roslyn updates for a preview" (#17543)
  * mono/mono@92a17792: [2019-08] [debugger] Changing how debugger handles exception ... (#17524)
  * mono/mono@1b2e536b: [2019-08] rollback msbuild/roslyn updates for a preview
  * mono/mono@ec4ef9bc: Bump roslyn-binaries to get roslyn 3.4.0-beta3-19521-01
  * mono/mono@cc8deca9: Bump msbuild to pick up sdks+roslyn updates
  * mono/mono@335f0109: Bump msbuild to track mono-2019-08
  * mono/mono@90d6e496: Fix checks so stack overflows work again.
  * mono/mono@4b60e7f9: [jit] Avoid running mono_handle_native_crash () on the altstack, it can't produce a backtrace. AMD64 only for now.
  * mono/mono@989333d6: Bump Bockbuild to pick-up gtk# binding change (#17486)