### PR TITLE
Fix build failure with some versions of GNU assembler

### DIFF
--- a/build-tools/cmake/xa_macros.cmake
+++ b/build-tools/cmake/xa_macros.cmake
@@ -47,7 +47,7 @@ macro(xa_common_prepare)
     fvisibility=${DSO_SYMBOL_VISIBILITY}
     fstack-protector-strong
     fstrict-return
-    Wa,--noexecstack
+    Wa,-noexecstack
     fPIC
     )
 

--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -164,7 +164,6 @@ else()
   endif()
 
   if(UNIX)
-    set(EXTRA_COMPILER_FLAGS "${EXTRA_COMPILER_FLAGS} -Wa,--noexecstack")
     set(EXTRA_LINKER_FLAGS "${EXTRA_LINKER_FLAGS} -shared -fpic")
   endif()
 


### PR DESCRIPTION
GNU assembler (`as`) shipped with MinGW 6.0.0-3 on Ubuntu 19.10 (but possibly
other Linux distributions as well) does not recognize the `--noexecstack`
parameter we've been using so far. However, it (and all other versions) is fine
with the `-noexecstack` form. Use the single dash form in all cases.