### PR TITLE
[Xamarin.Android.Build.Tasks] fix aapt2 incremental build for GPS

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
@@ -49,7 +49,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <Target Name="_CollectLibraryResourceDirectories"
     Condition=" '$(_AndroidUseAapt2)' == 'True' "
   >
-  <CollectNonEmptyDirectories Directories="@(LibraryResourceDirectories);@(_AdditonalAndroidResourceCachePaths->'%(Identity)\res')">
+  <CollectNonEmptyDirectories
+      Directories="@(LibraryResourceDirectories);@(_AdditonalAndroidResourceCachePaths->'%(Identity)\res')"
+      LibraryProjectIntermediatePath="$(_AndroidLibrayProjectIntermediatePath)"
+      StampDirectory="$(_AndroidStampDirectory)">
     <Output TaskParameter="Output" ItemName="_LibraryResourceDirectories" />
   </CollectNonEmptyDirectories>
   <ComputeHash Source="@(_LibraryResourceDirectories)"  >
@@ -92,14 +95,16 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       ToolExe="$(Aapt2ToolExe)"
   />
   <ItemGroup>
+    <_MissingStampFiles Include="@(_LibraryResourceHashDirectories->'%(StampFile)')" Condition="!Exists('%(StampFile)')" />
     <_HashStampFiles Include="@(_LibraryResourceHashDirectories->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).stamp')" />
     <_HashFlataFiles Include="@(_LibraryResourceHashDirectories->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).flata')" />
   </ItemGroup>
   <Touch
-      Files="@(_HashStampFiles)"
+      Files="@(_MissingStampFiles);@(_HashStampFiles)"
       AlwaysCreate="True"
   />
   <ItemGroup>
+    <FileWrites Include="@(_MissingStampFiles)" />
     <FileWrites Include="@(_HashStampFiles)" />
     <FileWrites Include="@(_HashFlataFiles)" />
   </ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
@@ -1,9 +1,9 @@
-﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
+using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks {
 	
@@ -15,21 +15,43 @@ namespace Xamarin.Android.Tasks {
 		[Required]
 		public ITaskItem[] Directories { get; set; }
 
+		[Required]
+		public string LibraryProjectIntermediatePath { get; set; }
+
+		[Required]
+		public string StampDirectory { get; set; }
+
 		[Output]
 		public ITaskItem[] Output => output.ToArray ();
 
 		public override bool RunTask ()
 		{
+			var libraryProjectDir = Path.GetFullPath (LibraryProjectIntermediatePath);
 			foreach (var directory in Directories) {
-				if (!Directory.Exists (directory.ItemSpec))
+				if (!Directory.Exists (directory.ItemSpec)) {
+					Log.LogDebugMessage ($"Directory does not exist, skipping: {directory.ItemSpec}");
 					continue;
+				}
 				var firstFile = Directory.EnumerateFiles(directory.ItemSpec, "*.*", SearchOption.AllDirectories).FirstOrDefault ();
 				if (firstFile != null) {
 					var taskItem = new TaskItem (directory.ItemSpec, new Dictionary<string, string> () {
 						{"FileFound", firstFile },
-						{"StampFile", Path.GetFullPath (Path.Combine (directory.ItemSpec, "..", "..")) + ".stamp" },
 					});
 					directory.CopyMetadataTo (taskItem);
+
+					string stampFile = directory.GetMetadata ("StampFile");
+					if (string.IsNullOrEmpty (stampFile)) {
+						if (Path.GetFullPath (directory.ItemSpec).StartsWith (libraryProjectDir)) {
+							// If inside the `lp` directory
+							stampFile = Path.GetFullPath (Path.Combine (directory.ItemSpec, "..", "..")) + ".stamp";
+						} else {
+							// Otherwise use a hashed stamp file
+							stampFile = Path.Combine (StampDirectory, Files.HashString (directory.ItemSpec) + ".stamp");
+						}
+						taskItem.SetMetadata ("StampFile", stampFile);
+					} else {
+						Log.LogDebugMessage ($"%(StampFile) already set: {stampFile}");
+					}
 					output.Add (taskItem);
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -271,7 +271,15 @@ class MemTest {
 		{
 			var proj = new XamarinFormsMapsApplicationProject ();
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
-				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsTrue (b.Build (proj), "first should have succeeded.");
+				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "second should have succeeded.");
+				var targets = new [] {
+					"_CompileAndroidLibraryResources",
+					"_UpdateAndroidResgen",
+				};
+				foreach (var target in targets) {
+					Assert.IsTrue (b.Output.IsTargetSkipped (target), $"`{target}` should be skipped.");
+				}
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsMapsApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinFormsMapsApplicationProject.cs
@@ -19,6 +19,80 @@ namespace Xamarin.ProjectTools
 			MainActivity = MainActivity.Replace ("//${AFTER_FORMS_INIT}", "Xamarin.FormsMaps.Init (this, savedInstanceState);");
 			//NOTE: API_KEY metadata just has to *exist*
 			AndroidManifest = AndroidManifest.Replace ("</application>", "<meta-data android:name=\"com.google.android.maps.v2.API_KEY\" android:value=\"\" /></application>");
+			// From https://github.com/xamarin/GooglePlayServicesComponents/blob/fc057c754e04d3e719d8c111d03d60eb2467b9ce/source/com.google.android.gms/play-services-basement/buildtasks.tests/google-services.json
+			OtherBuildItems.Add (new BuildItem ("GoogleServicesJson", "google-services.json") {
+				Encoding = new System.Text.UTF8Encoding (encoderShouldEmitUTF8Identifier: false),
+				TextContent = () =>
+@"{
+  ""project_info"": {
+    ""project_number"": ""1041063143217"",
+    ""firebase_url"": ""https://white-cedar-97320.firebaseio.com"",
+    ""project_id"": ""white-cedar-97320"",
+    ""storage_bucket"": ""white-cedar-97320.appspot.com""
+  },
+  ""client"": [
+    {
+      ""client_info"": {
+        ""mobilesdk_app_id"": ""1:1041063143217:android:ffbe6976403db935"",
+        ""android_client_info"": {
+          ""package_name"": ""com.xamarin.sample""
+        }
+      },
+      ""oauth_client"": [
+        {
+          ""client_id"": ""1041063143217-rve97omgqivvs3qcne1ljso137k3t6po.apps.googleusercontent.com"",
+          ""client_type"": 1,
+          ""android_info"": {
+            ""package_name"": ""com.xamarin.sample"",
+            ""certificate_hash"": ""84949BBD3F34C8290A55AC9B66AD0A701EBA67AC""
+          }
+        },
+        {
+          ""client_id"": ""1041063143217-hu5u4dnv8dkj19i4tpi6piv97kd2k9i0.apps.googleusercontent.com"",
+          ""client_type"": 3
+        },
+        {
+          ""client_id"": ""1041063143217-n82odtjjgs9g2qnh1t470mdhj086id9f.apps.googleusercontent.com"",
+          ""client_type"": 3
+        }
+      ],
+      ""api_key"": [
+        {
+          ""current_key"": ""AIzaSyCfJp9rrUEaA07vdoGvGQgJqm0Fa9cJGiw""
+        }
+      ],
+      ""services"": {
+        ""analytics_service"": {
+          ""status"": 2,
+          ""analytics_property"": {
+            ""tracking_id"": ""UA-6465612-26""
+          }
+        },
+        ""appinvite_service"": {
+          ""status"": 2,
+          ""other_platform_oauth_client"": [
+            {
+              ""client_id"": ""1041063143217-hu5u4dnv8dkj19i4tpi6piv97kd2k9i0.apps.googleusercontent.com"",
+              ""client_type"": 3
+            },
+            {
+              ""client_id"": ""1041063143217-rdc97s7jssl1k29c83b6oci04sihqkdi.apps.googleusercontent.com"",
+              ""client_type"": 2,
+              ""ios_info"": {
+                ""bundle_id"": ""com.xamarin.googleios.collectallthestars""
+              }
+            }
+          ]
+        },
+        ""ads_service"": {
+          ""status"": 2
+        }
+      }
+    }
+  ],
+  ""configuration_version"": ""1""
+}"
+			});
 		}
 
 		protected override string MainPageXaml () => ProcessSourceTemplate (MainPageMaps_xaml);


### PR DESCRIPTION
Context: https://github.com/xamarin/GooglePlayServicesComponents/pull/271

In an application with Google Play Services, a json configuration file
is used, such as:

    <GoogleServicesJson Include="google-services.json" />

There are MSBuild targets in the NuGet package that process this file,
and add to the `@(LibraryResourceDirectories)` item group:

https://github.com/xamarin/GooglePlayServicesComponents/blob/fc057c754e04d3e719d8c111d03d60eb2467b9ce/source/com.google.android.gms/play-services-basement/merge.targets#L44-L80

Unfortunately, this causes MSBuild targets to run every time if
`$(AndroidUseAapt2)` is `True`:

    Building target "_ConvertLibraryResourcesCases" completely.
    Input file "obj\Debug.stamp" does not exist.

Such a project will run `aapt2` every time, even with no changes.

The `<CollectNonEmptyDirectories/>` MSBuild task has some logic that
doesn't take custom `@(LibraryResourceDirectories)` items into
account:

    { "StampFile", Path.GetFullPath (Path.Combine (directory.ItemSpec, "..", "..")) + ".stamp" },

This code assumes that the file is in `obj\Debug\lp\1\res`, and so
using `..\..` is completely fine. If not, we get a weird
`obj\Debug.stamp` file!

The fix would be:

* Check if the file is in the `lp` directory, if so, use the existing
  behavior.
* Create a new stamp file in `obj\Debug\stamp` that is a hash of path.
* Create any `%(StampFile)` files in `_CompileAndroidLibraryResources`
  that do not exist.

This should get things working for the current released GPS NuGet.

When #GooglePlayServicesComponents/271 lands in a future update of the
GPS NuGet package, it will supply a proper `%(StampFile)`.

/cc @Redth 