### PR TITLE
[Xamarin.Android.Build.Tasks] Fix Library Resource ordering.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -137,8 +137,8 @@ namespace Xamarin.Android.Tasks {
 				cmd.AppendSwitchIfNotNull ("--custom-package ", PackageName.ToLowerInvariant ());
 			
 			if (AdditionalResourceArchives != null) {
-				foreach (var item in AdditionalResourceArchives) {
-					var flata = Path.Combine (WorkingDirectory, item.ItemSpec);
+				for (int i = AdditionalResourceArchives.Length - 1; i >= 0; i--) {
+					var flata = Path.Combine (WorkingDirectory, AdditionalResourceArchives [i].ItemSpec);
 					if (File.Exists (flata)) {
 						cmd.AppendSwitchIfNotNull ("-R ", flata);
 					} else {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -127,6 +127,16 @@ namespace Xamarin.Android.Build.Tests
 
 		static Regex regex = new Regex (@"\s*(\++)(?<seconds>\d)s(?<milliseconds>\d+)ms", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 
+		protected static bool WaitForPermissionActivity (string logcatFilePath, int timeout = 5)
+		{
+			string activityNamespace = "com.android.permissioncontroller";
+			string activityName = "com.android.packageinstaller.permission.ui.ReviewPermissionsActivity";
+			bool result = WaitForActivityToStart (activityNamespace, activityName, logcatFilePath, timeout);
+			if (result)
+				ClickButton ("", "com.android.permissioncontroller:id/continue_button", "CONTINUE");
+			return result;
+		}
+
 		protected static bool WaitForActivityToStart (string activityNamespace, string activityName, string logcatFilePath, int timeout = 60)
 		{
 			return WaitForActivityToStart (activityNamespace, activityName, logcatFilePath, out TimeSpan time, timeout);
@@ -149,10 +159,8 @@ namespace Xamarin.Android.Build.Tests
 			return result;
 		}
 
-		protected static (int x, int y, int w, int h) GetControlBounds (string packageName, string uiElement, string text)
+		protected static XDocument GetUI ()
 		{
-			var regex = new Regex (@"[(0-9)]\d*", RegexOptions.Compiled);
-			var result = (x: 0, y: 0, w: 0, h: 0);
 			var ui = RunAdbCommand ("exec-out uiautomator dump /dev/tty");
 			while (ui.Contains ("ERROR:")) {
 				ui = RunAdbCommand ("exec-out uiautomator dump /dev/tty");
@@ -160,25 +168,31 @@ namespace Xamarin.Android.Build.Tests
 			}
 			ui = ui.Replace ("UI hierchary dumped to: /dev/tty", string.Empty).Trim ();
 			try {
-				var uiDoc = XDocument.Parse (ui);
-				var node = uiDoc.XPathSelectElement ($"//node[contains(@resource-id,'{uiElement}')]");
-				if (node == null)
-					node = uiDoc.XPathSelectElement ($"//node[contains(@content-desc,'{uiElement}')]");
-				if (node == null)
-					node = uiDoc.XPathSelectElement ($"//node[contains(@text,'{text}')]");
-				if (node == null)
-					return result;
-				var bounds = node.Attribute ("bounds");
-				var matches = regex.Matches (bounds.Value);
-				int.TryParse (matches [0].Value, out int x);
-				int.TryParse (matches [1].Value, out int y);
-				int.TryParse (matches [2].Value, out int w);
-				int.TryParse (matches [3].Value, out int h);
-				return (x: x, y: y, w: w, h: h);
-			} catch (Exception ex) {
-				// Ignore any error and return and empty
-				throw new InvalidOperationException ($"uiautomator returned invalid xml {ui}", ex);
+				return XDocument.Parse (ui);
+			} catch {
+				return XDocument.Parse ("<node />");
 			}
+		}
+
+		protected static (int x, int y, int w, int h) GetControlBounds (string packageName, string uiElement, string text)
+		{
+			var regex = new Regex (@"[(0-9)]\d*", RegexOptions.Compiled);
+			var result = (x: 0, y: 0, w: 0, h: 0);
+			var uiDoc = GetUI ();
+			var node = uiDoc.XPathSelectElement ($"//node[contains(@resource-id,'{uiElement}')]");
+			if (node == null)
+				node = uiDoc.XPathSelectElement ($"//node[contains(@content-desc,'{uiElement}')]");
+			if (node == null)
+				node = uiDoc.XPathSelectElement ($"//node[contains(@text,'{text}')]");
+			if (node == null)
+				return result;
+			var bounds = node.Attribute ("bounds");
+			var matches = regex.Matches (bounds.Value);
+			int.TryParse (matches [0].Value, out int x);
+			int.TryParse (matches [1].Value, out int y);
+			int.TryParse (matches [2].Value, out int w);
+			int.TryParse (matches [3].Value, out int h);
+			return (x: x, y: y, w: w, h: h);
 		}
 
 		protected static void ClickButton (string packageName, string buttonName, string buttonText)

--- a/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeploymentTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Xml.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -13,6 +14,8 @@ using Microsoft.Build.Framework;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 using Xamarin.ProjectTools;
+using System.Xml.XPath;
+
 [assembly: NonParallelizable]
 
 namespace Xamarin.Android.Build.Tests
@@ -62,6 +65,105 @@ namespace Xamarin.Android.Build.Tests
 
 			if (TestContext.CurrentContext.Result.FailCount == 0 && builder != null && Directory.Exists (Path.Combine (Root, builder.ProjectDirectory)))
 				Directory.Delete (Path.Combine (Root, builder.ProjectDirectory), recursive: true);
+		}
+
+		[Test]
+		public void CheckResouceIsOverridden ([Values (true, false)] bool useAapt2)
+		{
+			if (!HasDevices)
+				Assert.Ignore ("Skipping Test. No devices available.");
+			var library = new XamarinAndroidLibraryProject () {
+				ProjectName = "Library1",
+				AndroidResources = {
+					new AndroidItem.AndroidResource (() => "Resources\\values\\strings2.xml") {
+						TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
+<resources>
+	<string name=""hello_me"">Click Me! One</string>
+</resources>",
+					},
+				},
+			};
+			var library2 = new XamarinAndroidLibraryProject () {
+				ProjectName = "Library2",
+				AndroidResources = {
+					new AndroidItem.AndroidResource (() => "Resources\\values\\strings2.xml") {
+						TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
+<resources>
+	<string name=""hello_me"">Click Me! Two</string>
+</resources>",
+					},
+				},
+			};
+			var app = new XamarinAndroidApplicationProject () {
+				PackageName = "Xamarin.ResourceTest",
+				References = {
+					new BuildItem.ProjectReference ("..\\Library1\\Library1.csproj"),
+					new BuildItem.ProjectReference ("..\\Library2\\Library2.csproj"),
+				},
+			};
+			library.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
+			library2.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
+			app.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
+			app.LayoutMain = app.LayoutMain.Replace ("@string/hello", "@string/hello_me");
+			using (var l1 = CreateApkBuilder (Path.Combine ("temp", TestName, library.ProjectName)))
+			using (var l2 = CreateApkBuilder (Path.Combine ("temp", TestName, library2.ProjectName)))
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName, app.ProjectName))) {
+				b.ThrowOnBuildFailure = false;
+				string apiLevel;
+				app.TargetFrameworkVersion = b.LatestTargetFrameworkVersion (out apiLevel);
+				app.AndroidManifest = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" android:versionCode=""1"" android:versionName=""1.0"" package=""{app.PackageName}"">
+	<uses-sdk android:minSdkVersion=""24"" android:targetSdkVersion=""{apiLevel}"" />
+	<application android:label=""${{PROJECT_NAME}}"">
+	</application >
+</manifest> ";
+				Assert.IsTrue (l1.Build (library, doNotCleanupOnUpdate: true), $"Build of {library.ProjectName} should have suceeded.");
+				Assert.IsTrue (l2.Build (library2, doNotCleanupOnUpdate: true), $"Build of {library2.ProjectName} should have suceeded.");
+				b.BuildLogFile = "build1.log";
+				Assert.IsTrue (b.Build (app, doNotCleanupOnUpdate: true), $"Build of {app.ProjectName} should have suceeded.");
+				b.BuildLogFile = "install1.log";
+				Assert.IsTrue (b.Install (app, doNotCleanupOnUpdate: true), "Install should have suceeded.");
+				AdbStartActivity ($"{app.PackageName}/{app.JavaPackageName}.MainActivity");
+				WaitForPermissionActivity (Path.Combine (Root, builder.ProjectDirectory, "permission-logcat.log"));
+				WaitForActivityToStart (app.PackageName, "MainActivity",
+					Path.Combine (Root, builder.ProjectDirectory, "startup-logcat.log"), 15);
+				XDocument ui = GetUI ();
+				XElement node = ui.XPathSelectElement ($"//node[contains(@resource-id,'myButton')]");
+				StringAssert.AreEqualIgnoringCase ("Click Me! One", node.Attribute ("text").Value, "Text of Button myButton should have been \"Click Me! One\"");
+				b.BuildLogFile = "clean.log";
+				Assert.IsTrue (b.Clean (app, doNotCleanupOnUpdate: true), "Clean should have suceeded.");
+
+				app = new XamarinAndroidApplicationProject () {
+					PackageName = "Xamarin.ResourceTest",
+					References = {
+						new BuildItem.ProjectReference ("..\\Library1\\Library1.csproj"),
+						new BuildItem.ProjectReference ("..\\Library2\\Library2.csproj"),
+					},
+				};
+
+				library2.References.Add (new BuildItem.ProjectReference ("..\\Library1\\Library1.csproj"));
+				app.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
+				app.LayoutMain = app.LayoutMain.Replace ("@string/hello", "@string/hello_me");
+				app.TargetFrameworkVersion = b.LatestTargetFrameworkVersion (out apiLevel);
+				app.AndroidManifest = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" android:versionCode=""1"" android:versionName=""1.0"" package=""{app.PackageName}"">
+	<uses-sdk android:minSdkVersion=""24"" android:targetSdkVersion=""{apiLevel}"" />
+	<application android:label=""${{PROJECT_NAME}}"">
+	</application >
+</manifest> ";
+				b.BuildLogFile = "build.log";
+				Assert.IsTrue (b.Build (app, doNotCleanupOnUpdate: true), $"Build of {app.ProjectName} should have suceeded.");
+				b.BuildLogFile = "install.log";
+				Assert.IsTrue (b.Install (app, doNotCleanupOnUpdate: true), "Install should have suceeded.");
+				AdbStartActivity ($"{app.PackageName}/{app.JavaPackageName}.MainActivity");
+				WaitForPermissionActivity (Path.Combine (Root, builder.ProjectDirectory, "permission-logcat.log"));
+				WaitForActivityToStart (app.PackageName, "MainActivity",
+					Path.Combine (Root, builder.ProjectDirectory, "startup-logcat.log"), 15);
+				ui = GetUI ();
+				node = ui.XPathSelectElement ($"//node[contains(@resource-id,'myButton')]");
+				StringAssert.AreEqualIgnoringCase ("Click Me! One", node.Attribute ("text").Value, "Text of Button myButton should have been \"Click Me! One\"");
+
+			}
 		}
 
 


### PR DESCRIPTION
Context http://work.azdo.io//1009593

Both aapt and aapt2 will use overlay semantics when deciding
which final resource to use. The order in which the resources
are passed to the tooling is important.

For `aapt` the it used the FIRST item it came across, this is
why we always passed the Application resource directory in first.
For `aapt2` the LAST item is used... this is why we always pass
the Application resoruce directory last.

However we still use the same ordering for the references as
we do for `aapt`. As a result if you have duplicate resources
in two library projects `aapt` and `aapt2` will use different
files.

This PR reverses the order of the libraries we use for `aapt2`.
This ensures that the behaviour we see in `aapt2` is consistent
with `aapt`.

Future work we need to find a way to allow users to change the
ordering of these referenes. In AndroidStudio the order of the
files in the gradle config is used. So users can change the order.
However in MSBuild the order is controlled by MSBuild itself,
and there is no way to override it.