### PR TITLE
Make build quieter by 60 warnings.

### DIFF
--- a/src/OpenTK-1.0/OpenTK.csproj
+++ b/src/OpenTK-1.0/OpenTK.csproj
@@ -16,7 +16,7 @@
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
     <DefineConstants>MONODROID;MINIMAL;MOBILE;OPENTK_1;OPENTK_1_0</DefineConstants>
-    <NoWarn>3001,3002,3003,3005,3006,3021,3014,0618,1591,0414,0169,0419,1635</NoWarn>
+    <NoWarn>3001,3002,3003,3005,3006,3021,3014,0618,1591,0414,0169,0419,1570,1572,1573,1635</NoWarn>
     <NoStdLib>true</NoStdLib>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AndroidApplication>false</AndroidApplication>

--- a/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj
+++ b/src/Xamarin.Android.NUnitLite/Xamarin.Android.NUnitLite.csproj
@@ -16,6 +16,12 @@
     <AndroidApplication>false</AndroidApplication>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <NoStdLib>true</NoStdLib>
+    <!-- Disable XML doc warnings:
+         CS1570: XML comment has badly formed XML - 'Whitespace is not allowed at this location.'
+         CS1572: XML comment has a param tag for 'Bar', but there is no parameter by that name
+         CS1591: Missing XML comment for publicly visible type or member 'Foo'
+    -->
+    <NoWarn>1570;1572;1591</NoWarn>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <Import Project="..\..\build-tools\scripts\MonoAndroidFramework.props" />


### PR DESCRIPTION
Shush 60 useless warnings about invalid or missing XML docs in 3rd party
projects we use. Go down to 937 from 997.