### PR TITLE
Bump to mono/mono/2019-08@e1ef7743

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:d16-4@ed9e9e8ca05acc09e47aff89b1ff5fe0dd0cf231
-mono/mono:2019-08@8946e49a974ea8b75fe5b8b7e93ffd4571521a85
+mono/mono:2019-08@e1ef774391da2b84d003431e8871b0bacbd25cb3


### PR DESCRIPTION
Changes: https://github.com/mono/mono/compare/8946e49a974ea8b75fe5b8b7e93ffd4571521a85...e1ef774391da2b84d003431e8871b0bacbd25cb3

Context: https://github.com/mono/mono/issues/17133

  * mono/mono@e1ef774391d: [2019-08] Bump CoreFX to pickup corefx PR #367 to fix #17133. (#17622)
  * mono/mono@6d1f88e0ad2: Bump msbuild to get SDK updates from https://github.com/mono/msbuild/pull/150
  * mono/mono@a3f3bfc4c3d: Bump nuget to the latest suggested version
  * mono/mono@9bd3079f1ca: [2019-08] bump msbuild with more p2 packages
  * mono/mono@6ac1ff75a27: [dim][regression] Explicit interface override (#17583) (#17627)
  * mono/mono@a119807a015: [acceptance-tests] Bump mono/roslyn to get build fix
  * mono/mono@d234d34b700: [2019-08][merp] Install sigterm handler in EnableMicrosoftTelemetry
  * mono/mono@444a9a3fc48: [2019-08] [merp] Introduce a new 'dump mode' that allows different signal behavior when dumping (#17568)