### PR TITLE
[build] use -f for all provisioning commands

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -617,7 +617,7 @@ stages:
     steps:
     - template: yaml-templates\setup-test-environment.yaml
       parameters:
-        provisionExtraArgs: -vv PROVISIONATOR_VISUALSTUDIO_LOCATION="$(VSINSTALLDIR)"
+        provisionExtraArgs: -vv PROVISIONATOR_VISUALSTUDIO_LOCATION="$(VSINSTALLDIR)" -f
 
     - task: DownloadPipelineArtifact@1
       inputs:

--- a/build-tools/automation/yaml-templates/run-installer.yaml
+++ b/build-tools/automation/yaml-templates/run-installer.yaml
@@ -1,5 +1,5 @@
 parameters:
-  provisionExtraArgs: -vv
+  provisionExtraArgs: -vv -f
 
 steps:
 - task: DownloadPipelineArtifact@2

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -1,6 +1,6 @@
 parameters:
   configuration: $(XA.Build.Configuration)
-  provisionExtraArgs: -vv
+  provisionExtraArgs: -vv -f
 
 steps:
 - template: run-installer.yaml


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3206030&view=logs&j=035e6729-702a-53d4-bea9-761745a9f552&t=a8982860-1b1b-5e3d-f0c9-54fa4d7fb67c&l=160

I had a PR build, where it appeared the MSBuild tests on Windows did
not have my changes.

Then I noticed on the provisioning step:

    Visual Studio extension Xamarin.Android.Sdk 10.2.99.6: already provisioned

We should use the `-f` option when provisioning Xamarin.Android, as a
build machine could have the same version number installed from a
different PR.

We should *not* use the `-f` option when running the provisioning for
the Designer & Regression tests, since they provision things other
than Xamarin.Android. The Designer & Regression tests *do* call
`run-installer.yaml` to provision Xamarin.Android, however.