### PR TITLE
[build-tools] Dont use Mojave for Unit Tests

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -557,7 +557,7 @@ stages:
   # Check - "Xamarin.Android (Test MSBuild - macOS)"
   - job: mac_msbuild_tests
     displayName: MSBuild - macOS
-    pool: $(HostedMacMojave)
+    pool: $(HostedMac)
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
     workspace:


### PR DESCRIPTION
We have a very weird issue when running MSBuild
Unit tests on Mojave. For some reason which is
still unknown to us, libzip creates a corrupt
zip file. This then causes a `zipalign` error
later in the build process. This only seems to
happen on Mojave in Azure. It does not appear
to happen locally.

So this PR switches the MSBuild tests back to using
the `$(HostedMac)` pool. This should give us greener
builds while we try to figure out what the issue is.