### PR TITLE
Bump LibZipSharp to 1.0.6

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-dellis1972/monodroid:libzipsharp1.0.6@75343d667d7fb385c47113270a8738fbb8b8e80a
+xamarin/monodroid:master@533c34eef01f35b4c9f63aec3eea55699662bab3
 mono/mono:2019-08@8946e49a974ea8b75fe5b8b7e93ffd4571521a85

--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@d23d08646b889aef323206e2e0d6a8ae09208cfb
+dellis1972/monodroid:libzipsharp1.0.6@75343d667d7fb385c47113270a8738fbb8b8e80a
 mono/mono:2019-08@8946e49a974ea8b75fe5b8b7e93ffd4571521a85

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -39,7 +39,7 @@
       <HintPath>..\..\packages\Mono.Posix.NETStandard.1.0.0\lib\net40\Mono.Posix.NETStandard.dll</HintPath>
     </Reference>
     <Reference Include="libZipSharp">
-      <HintPath>..\..\packages\Xamarin.LibZipSharp.1.0.5\lib\net45\libZipSharp.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.LibZipSharp.1.0.6\lib\net45\libZipSharp.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -81,5 +81,5 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="result-packaging.targets" />
-  <Import Project="..\..\packages\Xamarin.LibZipSharp.1.0.5\build\Xamarin.LibZipSharp.targets" Condition="Exists('..\..\packages\Xamarin.LibZipSharp.1.0.5\build\Xamarin.LibZipSharp.targets')" />
+  <Import Project="..\..\packages\Xamarin.LibZipSharp.1.0.6\build\Xamarin.LibZipSharp.targets" Condition="Exists('..\..\packages\Xamarin.LibZipSharp.1.0.6\build\Xamarin.LibZipSharp.targets')" />
 </Project>

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/packages.config
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Mono.Posix.NETStandard" version="1.0.0" targetFramework="net472" />
-  <package id="Xamarin.LibZipSharp" version="1.0.5" targetFramework="net472" />
+  <package id="Xamarin.LibZipSharp" version="1.0.6" targetFramework="net472" />
 </packages>

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/LibZipSharp.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/LibZipSharp.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Android.Prepare
 	class LibZipSharp_grendello_LibZipSharp_TPN : ThirdPartyNotice
 	{
 		static readonly Uri url = new Uri ("https://github.com/xamarin/LibZipSharp/");
-		internal static readonly string LibZipSharpVersion = "1.0.5";
+		internal static readonly string LibZipSharpVersion = "1.0.6";
 		static readonly string licenseFile = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile),
 			".nuget", "packages", "xamarin.libzipsharp", LibZipSharpVersion,
 			"Licences", "LICENSE");

--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -277,7 +277,7 @@
       <Version>5.3.0.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.LibZipSharp">
-      <Version>1.0.5</Version>
+      <Version>1.0.6</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -68,7 +68,7 @@
       <HintPath>..\..\..\..\packages\Mono.Posix.NETStandard.1.0.0\lib\net40\Mono.Posix.NETStandard.dll</HintPath>
     </Reference>
     <Reference Include="libZipSharp">
-      <HintPath>..\..\..\..\packages\Xamarin.LibZipSharp.1.0.5\lib\net45\libZipSharp.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Xamarin.LibZipSharp.1.0.6\lib\net45\libZipSharp.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
@@ -131,5 +131,5 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <Import Project="..\..\..\..\packages\Xamarin.LibZipSharp.1.0.5\build\Xamarin.LibZipSharp.targets" Condition="Exists('..\..\..\..\packages\Xamarin.LibZipSharp.1.0.5\build\Xamarin.LibZipSharp.targets')" />
+  <Import Project="..\..\..\..\packages\Xamarin.LibZipSharp.1.0.6\build\Xamarin.LibZipSharp.targets" Condition="Exists('..\..\..\..\packages\Xamarin.LibZipSharp.1.0.6\build\Xamarin.LibZipSharp.targets')" />
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/packages.config
@@ -18,5 +18,5 @@
   <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net472" />
   <package id="Unofficial.Ionic.Zip" version="1.9.1.8" targetFramework="net45" />
   <package id="Xamarin.Build.AsyncTask" version="0.3.4" targetFramework="net472" />
-  <package id="Xamarin.LibZipSharp" version="1.0.5" targetFramework="net472" />
+  <package id="Xamarin.LibZipSharp" version="1.0.6" targetFramework="net472" />
 </packages>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj
@@ -39,7 +39,7 @@
       <HintPath>..\..\..\..\packages\Mono.Posix.NETStandard.1.0.0\lib\net40\Mono.Posix.NETStandard.dll</HintPath>
     </Reference>
     <Reference Include="libZipSharp">
-      <HintPath>..\..\..\..\packages\Xamarin.LibZipSharp.1.0.5\lib\net45\libZipSharp.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Xamarin.LibZipSharp.1.0.6\lib\net45\libZipSharp.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -168,5 +168,5 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\..\..\packages\Xamarin.LibZipSharp.1.0.5\build\Xamarin.LibZipSharp.targets" Condition="Exists('..\..\..\..\packages\Xamarin.LibZipSharp.1.0.5\build\Xamarin.LibZipSharp.targets')" />
+  <Import Project="..\..\..\..\packages\Xamarin.LibZipSharp.1.0.6\build\Xamarin.LibZipSharp.targets" Condition="Exists('..\..\..\..\packages\Xamarin.LibZipSharp.1.0.6\build\Xamarin.LibZipSharp.targets')" />
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="Mono.Posix.NETStandard" version="1.0.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net451" />
-  <package id="Xamarin.LibZipSharp" version="1.0.5" targetFramework="net472" />
+  <package id="Xamarin.LibZipSharp" version="1.0.6" targetFramework="net472" />
 </packages>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -122,7 +122,7 @@
       <HintPath>..\..\packages\Mono.Posix.NETStandard.1.0.0\lib\net40\Mono.Posix.NETStandard.dll</HintPath>
     </Reference>
     <Reference Include="libZipSharp">
-      <HintPath>..\..\packages\Xamarin.LibZipSharp.1.0.5\lib\net45\libZipSharp.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.LibZipSharp.1.0.6\lib\net45\libZipSharp.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -751,5 +751,5 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="ILRepack.targets" />
-  <Import Project="..\..\packages\Xamarin.LibZipSharp.1.0.5\build\Xamarin.LibZipSharp.targets" Condition="Exists('..\..\packages\Xamarin.LibZipSharp.1.0.5\build\Xamarin.LibZipSharp.targets')" />
+  <Import Project="..\..\packages\Xamarin.LibZipSharp.1.0.6\build\Xamarin.LibZipSharp.targets" Condition="Exists('..\..\packages\Xamarin.LibZipSharp.1.0.6\build\Xamarin.LibZipSharp.targets')" />
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/packages.config
+++ b/src/Xamarin.Android.Build.Tasks/packages.config
@@ -25,5 +25,5 @@
   <package id="System.Runtime" version="4.3.0" targetFramework="net462" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net462" />
   <package id="Xamarin.Build.AsyncTask" version="0.3.4" targetFramework="net472" />
-  <package id="Xamarin.LibZipSharp" version="1.0.5" targetFramework="net472" />
+  <package id="Xamarin.LibZipSharp" version="1.0.6" targetFramework="net472" />
 </packages>

--- a/src/Xamarin.Android.Tools.JavadocImporter/Xamarin.Android.Tools.JavadocImporter.csproj
+++ b/src/Xamarin.Android.Tools.JavadocImporter/Xamarin.Android.Tools.JavadocImporter.csproj
@@ -42,7 +42,7 @@
       <HintPath>..\..\packages\Mono.Posix.NETStandard.1.0.0\lib\net40\Mono.Posix.NETStandard.dll</HintPath>
     </Reference>
     <Reference Include="libZipSharp">
-      <HintPath>..\..\packages\Xamarin.LibZipSharp.1.0.5\lib\net45\libZipSharp.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.LibZipSharp.1.0.6\lib\net45\libZipSharp.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -86,5 +86,5 @@
   <Import Project="..\..\external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems" Label="Shared" Condition="Exists('..\..\external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems')" />
   <Import Project="..\..\external\Java.Interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\..\external\Java.Interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems')" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\Xamarin.LibZipSharp.1.0.5\build\Xamarin.LibZipSharp.targets" Condition="Exists('..\..\packages\Xamarin.LibZipSharp.1.0.5\build\Xamarin.LibZipSharp.targets')" />
+  <Import Project="..\..\packages\Xamarin.LibZipSharp.1.0.6\build\Xamarin.LibZipSharp.targets" Condition="Exists('..\..\packages\Xamarin.LibZipSharp.1.0.6\build\Xamarin.LibZipSharp.targets')" />
 </Project>

--- a/src/Xamarin.Android.Tools.JavadocImporter/packages.config
+++ b/src/Xamarin.Android.Tools.JavadocImporter/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Xml.SgmlReader" version="1.8.14" targetFramework="net45" />
   <package id="Mono.Posix.NETStandard" version="1.0.0" targetFramework="net472" />
-  <package id="Xamarin.LibZipSharp" version="1.0.5" targetFramework="net472" />
+  <package id="Xamarin.LibZipSharp" version="1.0.6" targetFramework="net472" />
 </packages>

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Xamarin.Android.MakeBundle-UnitTests.csproj
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Xamarin.Android.MakeBundle-UnitTests.csproj
@@ -35,7 +35,7 @@
       <HintPath>..\..\..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="libZipSharp">
-      <HintPath>..\..\..\packages\Xamarin.LibZipSharp.1.0.5\lib\net45\libZipSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Xamarin.LibZipSharp.1.0.6\lib\net45\libZipSharp.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -53,5 +53,5 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="Xamarin.Android.MakeBundle-UnitTests.targets" />
-  <Import Project="..\..\..\packages\Xamarin.LibZipSharp.1.0.5\build\Xamarin.LibZipSharp.targets" Condition="Exists('..\..\..\packages\Xamarin.LibZipSharp.1.0.5\build\Xamarin.LibZipSharp.targets')" />
+  <Import Project="..\..\..\packages\Xamarin.LibZipSharp.1.0.6\build\Xamarin.LibZipSharp.targets" Condition="Exists('..\..\..\packages\Xamarin.LibZipSharp.1.0.6\build\Xamarin.LibZipSharp.targets')" />
 </Project>

--- a/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/packages.config
+++ b/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="NUnit" version="3.11.0" targetFramework="net462" />
   <package id="Mono.Posix.NETStandard" version="1.0.0" targetFramework="net472" />
-  <package id="Xamarin.LibZipSharp" version="1.0.5" targetFramework="net472" />
+  <package id="Xamarin.LibZipSharp" version="1.0.6" targetFramework="net472" />
 </packages>

--- a/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/EmbeddedDSO-UnitTests.csproj
+++ b/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/EmbeddedDSO-UnitTests.csproj
@@ -43,7 +43,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="libZipSharp">
-      <HintPath>..\..\..\packages\Xamarin.LibZipSharp.1.0.5\lib\net45\libZipSharp.dll</HintPath>
+      <HintPath>..\..\..\packages\Xamarin.LibZipSharp.1.0.6\lib\net45\libZipSharp.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -79,5 +79,5 @@
         Replacements="@ANDROID_SDK_DIRECTORY@=$(AndroidSdkDirectory);@BUILD_TOOLS_FOLDER@=$(XABuildToolsFolder);@EXECUTABLE_EXTENSION@=$(ExecutableExtension)"
     />
   </Target>
-  <Import Project="..\..\..\packages\Xamarin.LibZipSharp.1.0.5\build\Xamarin.LibZipSharp.targets" Condition="Exists('..\..\..\packages\Xamarin.LibZipSharp.1.0.5\build\Xamarin.LibZipSharp.targets')" />
+  <Import Project="..\..\..\packages\Xamarin.LibZipSharp.1.0.6\build\Xamarin.LibZipSharp.targets" Condition="Exists('..\..\..\packages\Xamarin.LibZipSharp.1.0.6\build\Xamarin.LibZipSharp.targets')" />
 </Project>

--- a/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/packages.config
+++ b/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="NUnit" version="3.11.0" targetFramework="net462" />
   <package id="Mono.Posix.NETStandard" version="1.0.0" targetFramework="net472" />
-  <package id="Xamarin.LibZipSharp" version="1.0.5" targetFramework="net472" />
+  <package id="Xamarin.LibZipSharp" version="1.0.6" targetFramework="net472" />
 </packages>

--- a/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
+++ b/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
@@ -39,7 +39,7 @@
       <HintPath>..\..\packages\Mono.Posix.NETStandard.1.0.0\lib\net40\Mono.Posix.NETStandard.dll</HintPath>
     </Reference>
     <Reference Include="libZipSharp">
-      <HintPath>..\..\packages\Xamarin.LibZipSharp.1.0.5\lib\net45\libZipSharp.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.LibZipSharp.1.0.6\lib\net45\libZipSharp.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -85,5 +85,5 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="MSBuildDeviceIntegration.targets" />
-  <Import Project="..\..\packages\Xamarin.LibZipSharp.1.0.5\build\Xamarin.LibZipSharp.targets" Condition="Exists('..\..\packages\Xamarin.LibZipSharp.1.0.5\build\Xamarin.LibZipSharp.targets')" />
+  <Import Project="..\..\packages\Xamarin.LibZipSharp.1.0.6\build\Xamarin.LibZipSharp.targets" Condition="Exists('..\..\packages\Xamarin.LibZipSharp.1.0.6\build\Xamarin.LibZipSharp.targets')" />
 </Project>

--- a/tests/MSBuildDeviceIntegration/packages.config
+++ b/tests/MSBuildDeviceIntegration/packages.config
@@ -3,5 +3,5 @@
   <package id="Mono.Posix.NETStandard" version="1.0.0" targetFramework="net472" />
   <package id="NUnit" version="3.11.0" targetFramework="net462" />
   <package id="NodaTime" version="2.4.5" targetFramework="net472" />
-  <package id="Xamarin.LibZipSharp" version="1.0.5" targetFramework="net472" />
+  <package id="Xamarin.LibZipSharp" version="1.0.6" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Fixes an issue where the Linux native binaries were inverted i.e 32bit in x64 and 64bit in x86.