### PR TITLE
[r8] update .gitignore

### DIFF
--- a/src/r8/.gitignore
+++ b/src/r8/.gitignore
@@ -1,3 +1,6 @@
 .idea/
 build/
 out/
+.classpath
+.project
+.settings/


### PR DESCRIPTION
When I open xamarin-android in VS Code, the Java plugin creates directories where it finds gradle projects. Since r8 uses gradle, we should add to its `.gitignore`.