### PR TITLE
[build] archive APKs/AABs in yaml

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/result-packaging.targets
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/result-packaging.targets
@@ -26,7 +26,6 @@
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\compatibility\*" />
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\logcat*" />
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\*log" />
-    <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\*-Signed.apk" />
     <_TestResultFiles Include="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\temp\**\*" Exclude="$(XamarinAndroidSourcePath)bin\Test$(Configuration)\temp\packages\**">
       <SubDirectory>temp\</SubDirectory>
     </_TestResultFiles>

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -381,7 +381,7 @@ stages:
         testResultsFiles: TestResult-Mono.Android_Tests-$(ApkTestConfiguration)-Aot.xml
         extraBuildArgs: /p:AotAssemblies=True /p:EnableLlvm=True
         artifactName: Mono.Android_Tests-Signed.apk
-        artifactFolder: Aot
+        artifactFolder: AotLlvm
 
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -370,6 +370,8 @@ stages:
         testName: Mono.Android_Tests
         project: src/Mono.Android/Test/Mono.Android-Tests.csproj
         testResultsFiles: TestResult-Mono.Android_Tests-$(ApkTestConfiguration).xml
+        artifactName: Mono.Android_Tests-Signed.apk
+        artifactFolder: Default
 
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
@@ -378,6 +380,8 @@ stages:
         project: src/Mono.Android/Test/Mono.Android-Tests.csproj
         testResultsFiles: TestResult-Mono.Android_Tests-$(ApkTestConfiguration)-Aot.xml
         extraBuildArgs: /p:AotAssemblies=True /p:EnableLlvm=True
+        artifactName: Mono.Android_Tests-Signed.apk
+        artifactFolder: Aot
 
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
@@ -386,6 +390,8 @@ stages:
         project: src/Mono.Android/Test/Mono.Android-Tests.csproj
         testResultsFiles: TestResult-Mono.Android_Tests-$(ApkTestConfiguration)-Profiled.xml
         extraBuildArgs: /p:AndroidEnableProfiledAot=true
+        artifactName: Mono.Android_Tests-Signed.apk
+        artifactFolder: Profiled
 
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
@@ -394,6 +400,8 @@ stages:
         project: src/Mono.Android/Test/Mono.Android-Tests.csproj
         testResultsFiles: TestResult-Mono.Android_Tests-$(ApkTestConfiguration)-Bundle.xml
         extraBuildArgs: /p:BundleAssemblies=true
+        artifactName: Mono.Android_Tests-Signed.apk
+        artifactFolder: Bundle
 
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
@@ -402,6 +410,8 @@ stages:
         project: tests/Runtime-AppBundle/Mono.Android-TestsAppBundle.csproj
         testResultsFiles: TestResult-Mono.Android_TestsAppBundle-$(ApkTestConfiguration).xml
         packageType: Aab
+        artifactName: Mono.Android_TestsAppBundle-Signed.aab
+        artifactFolder: Aab
 
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
@@ -409,6 +419,8 @@ stages:
         testName: Mono.Android_TestsMultiDex
         project: tests/Runtime-MultiDex/Mono.Android-TestsMultiDex.csproj
         testResultsFiles: TestResult-Mono.Android_TestsMultiDex-$(ApkTestConfiguration).xml
+        artifactName: Mono.Android_Tests-Signed.apk
+        artifactFolder: MultiDex
 
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
@@ -416,6 +428,8 @@ stages:
         testName: Xamarin.Android.JcwGen_Tests
         project: tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.csproj
         testResultsFiles: TestResult-Xamarin.Android.JcwGen_Tests-$(ApkTestConfiguration).xml
+        artifactName: Xamarin.Android.JcwGen_Tests-Signed.apk
+        artifactFolder: Default
 
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
@@ -423,6 +437,8 @@ stages:
         testName: Xamarin.Android.Locale_Tests
         project: tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj
         testResultsFiles: TestResult-Xamarin.Android.Locale_Tests-$(ApkTestConfiguration).xml
+        artifactName: Xamarin.Android.Locale_Tests-Signed.apk
+        artifactFolder: Default
 
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
@@ -431,6 +447,8 @@ stages:
         project: tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj
         testResultsFiles: TestResult-Xamarin.Android.Locale_Tests-$(ApkTestConfiguration)-Aot.xml
         extraBuildArgs: /p:AotAssemblies=True
+        artifactName: Xamarin.Android.Locale_Tests-Signed.apk
+        artifactFolder: Aot
 
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
@@ -439,6 +457,8 @@ stages:
         project: tests/locales/Xamarin.Android.Locale-Tests/Xamarin.Android.Locale-Tests.csproj
         testResultsFiles: TestResult-Xamarin.Android.Locale_Tests-$(ApkTestConfiguration)-Profiled.xml
         extraBuildArgs: /p:AndroidEnableProfiledAot=true
+        artifactName: Xamarin.Android.Locale_Tests-Signed.apk
+        artifactFolder: Profiled
 
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
@@ -446,49 +466,43 @@ stages:
         testName: Xamarin.Android.EmbeddedDSO_Test
         project: tests/EmbeddedDSOs/EmbeddedDSO/EmbeddedDSO.csproj
         testResultsFiles: TestResult-Xamarin.Android.EmbeddedDSO_Test.nunit-$(ApkTestConfiguration).xml
+        artifactName: Xamarin.Android.EmbeddedDSO_Test-Signed.apk
+        artifactFolder: Profiled
 
-    - task: MSBuild@1
-      displayName: run Xamarin.Forms-Performance-Integration
-      inputs:
-        solution: tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
+    - template: yaml-templates/apk-instrumentation.yaml
+      parameters:
         configuration: $(ApkTestConfiguration)
-        msbuildArguments: >
-          /t:AcquireAndroidTarget,SignAndroidPackage,DeployTestApks,RunTestApks,UndeployTestApks,ReportComponentFailures
-          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/XamarinFormsPerf.binlog
-      condition: succeededOrFailed()
+        testName: Xamarin.Forms-Performance-Integration
+        project: tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
+        artifactName: Xamarin.Forms_Performance_Integration-Signed.apk
+        artifactFolder: Default
 
-    - task: MSBuild@1
-      displayName: run Xamarin.Forms-Performance-Integration-Aot
-      inputs:
-        solution: tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
+    - template: yaml-templates/apk-instrumentation.yaml
+      parameters:
         configuration: $(ApkTestConfiguration)
-        msbuildArguments: >
-          /t:AcquireAndroidTarget,SignAndroidPackage,DeployTestApks,RunTestApks,UndeployTestApks,ReportComponentFailures
-          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/XamarinFormsPerf-Aot.binlog
-          /p:AotAssemblies=true
-      condition: succeededOrFailed()
+        testName: Xamarin.Forms-Performance-Integration-Aot
+        project: tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
+        extraBuildArgs: /p:AotAssemblies=true
+        artifactName: Xamarin.Forms_Performance_Integration-Signed.apk
+        artifactFolder: Aot
 
-    - task: MSBuild@1
-      displayName: run Xamarin.Forms-Performance-Integration-Profiled
-      inputs:
-        solution: tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
+    - template: yaml-templates/apk-instrumentation.yaml
+      parameters:
         configuration: $(ApkTestConfiguration)
-        msbuildArguments: >
-          /t:AcquireAndroidTarget,SignAndroidPackage,DeployTestApks,RunTestApks,UndeployTestApks,ReportComponentFailures
-          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/XamarinFormsPerf-Profiled.binlog
-          /p:AndroidEnableProfiledAot=true
-      condition: succeededOrFailed()
+        testName: Xamarin.Forms-Performance-Integration-Profiled
+        project: tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
+        extraBuildArgs: /p:AndroidEnableProfiledAot=true
+        artifactName: Xamarin.Forms_Performance_Integration-Signed.apk
+        artifactFolder: Profiled
 
-    - task: MSBuild@1
-      displayName: run Xamarin.Forms-Performance-Integration-Bundle
-      inputs:
-        solution: tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
+    - template: yaml-templates/apk-instrumentation.yaml
+      parameters:
         configuration: $(ApkTestConfiguration)
-        msbuildArguments: >
-          /t:AcquireAndroidTarget,SignAndroidPackage,DeployTestApks,RunTestApks,UndeployTestApks,ReportComponentFailures
-          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/XamarinFormsPerf-Bundle.binlog
-          /p:BundleAssemblies=true
-      condition: succeededOrFailed()
+        testName: Xamarin.Forms-Performance-Integration-Bundle
+        project: tests/Xamarin.Forms-Performance-Integration/Droid/Xamarin.Forms.Performance.Integration.Droid.csproj
+        extraBuildArgs: /p:BundleAssemblies=true
+        artifactName: Xamarin.Forms_Performance_Integration-Signed.apk
+        artifactFolder: Bundle
 
     - task: MSBuild@1
       displayName: shut down emulator
@@ -531,6 +545,8 @@ stages:
         testName: Xamarin.Android.Bcl-Tests
         project: tests/BCL-Tests/Xamarin.Android.Bcl-Tests/Xamarin.Android.Bcl-Tests.csproj
         testResultsFiles: TestResult-Xamarin.Android.Bcl_Tests.nunit-$(XA.Build.Configuration).xml
+        artifactName: Xamarin.Android.Bcl_Tests-Signed.apk
+        artifactFolder: Default
 
     - task: PublishTestResults@2
       displayName: publish Xamarin.Android.Bcl-Tests-XUnit results

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -24,8 +24,8 @@ steps:
 - script: |
     SOURCE=$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/${{ parameters.artifactName }}
     DEST=$(Build.ArtifactStagingDirectory)/${{ parameters.artifactFolder }}/
-    mkdir $DEST
-    cp $SOURCE $DEST
+    mkdir "$DEST"
+    cp "$SOURCE" "$DEST"
   displayName: copy apk/aab
   condition: succeededOrFailed()
 

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -2,10 +2,12 @@ parameters:
   configuration: []
   testName: []
   project: []
-  testResultsFiles: []
+  testResultsFiles: ""
   extraBuildArgs: ""
   testResultsFormat: NUnit
   packageType: Apk
+  artifactName: []
+  artifactFolder: []
 
 steps:
 - task: MSBuild@1
@@ -19,10 +21,18 @@ steps:
       ${{ parameters.extraBuildArgs }}
   condition: succeededOrFailed()
 
+- script: |
+    SOURCE=$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/${{ parameters.artifactName }}
+    DEST=$(Build.ArtifactStagingDirectory)/${{ parameters.artifactFolder }}/
+    mkdir $DEST
+    cp $SOURCE $DEST
+  displayName: copy apk/aab
+  condition: succeededOrFailed()
+
 - task: PublishTestResults@2
   displayName: publish ${{ parameters.testName }} results
   inputs:
     testResultsFormat: ${{ parameters.testResultsFormat }}
     testResultsFiles: ${{ parameters.testResultsFiles }}
     testRunTitle: ${{ parameters.testName }}
-  condition: succeededOrFailed()
+  condition: and(succeededOrFailed(), ne('${{ parameters.testResultsFiles }}', ''))


### PR DESCRIPTION
In 22de1178, it did not actually archive *all* `.apk` files.

Throughout our build pipeline, we build projects with different
MSBuild properties as input such as `/p:AotAssemblies=True`. This
causes the `.apk` files to be overwritten, and we lose them...

Instead, we should copy each APK to a directory inside
`$(Build.ArtifactStagingDirectory)` with a path identifying.

And so I propose modifying the template such as:

    - template: yaml-templates/apk-instrumentation.yaml
      parameters:
        configuration: $(ApkTestConfiguration)
        testName: Mono.Android_Tests-Aot
        project: src/Mono.Android/Test/Mono.Android-Tests.csproj
        testResultsFiles: TestResult-Mono.Android_Tests-$(ApkTestConfiguration)-Aot.xml
        extraBuildArgs: /p:AotAssemblies=True /p:EnableLlvm=True
        artifactName: Mono.Android_Tests-Signed.apk
        artifactFolder: Aot

Would yield an artifact at `Aot/Mono.Android_Tests-Signed.apk` that we
could download independently.