### PR TITLE
[tests] MSBuild performance raise expected times by 100ms

### DIFF
--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -2,13 +2,13 @@
 # First non-comment row is human description of columns
 Test Name,Time in ms (int)
 # Data
-Build_No_Changes,3250
-Build_CSharp_Change,4000
-Build_AndroidResource_Change,4750
+Build_No_Changes,3350
+Build_CSharp_Change,4100
+Build_AndroidResource_Change,4850
 Build_Designer_Change,4250
 Build_JLO_Change,9000
 Build_CSProj_Change,9500
-Build_XAML_Change,9500
-Build_XAML_Change_RefAssembly,6250
+Build_XAML_Change,9600
+Build_XAML_Change_RefAssembly,6350
 Install_CSharp_Change,6000
 Install_XAML_Change,7500


### PR DESCRIPTION
Context: https://build.azdo.io/3218699
Context: https://build.azdo.io/3219042

Raising some of the expected times, as we have seen some random
failures that do not appear to be performance regressions.

The assertion failures were:

    Build_No_Changes: Exceeded expected time of 3250ms, actual 3270ms
    Build_AndroidResource_Change: Exceeded expected time of 4750ms, actual 4770ms
    Build_XAML_Change(True,False): Exceeded expected time of 6250ms, actual 6270ms
    Build_XAML_Change(False,False): Exceeded expected time of 9500ms, actual 9560ms