### PR TITLE
Allocate directory array with correct type

### DIFF
--- a/src/monodroid/jni/basic-android-system.cc
+++ b/src/monodroid/jni/basic-android-system.cc
@@ -16,12 +16,12 @@ BasicAndroidSystem::setup_app_library_directories (JNIEnv *env, jstring_array_wr
 	if (androidApiLevel < 23 || !is_embedded_dso_mode_enabled ()) {
 		log_info (LOG_DEFAULT, "Setting up for DSO lookup in app data directories");
 		BasicAndroidSystem::app_lib_directories_size = 1;
-		BasicAndroidSystem::app_lib_directories = reinterpret_cast<const char**>(new char[app_lib_directories_size]());
+		BasicAndroidSystem::app_lib_directories = new const char*[app_lib_directories_size]();
 		BasicAndroidSystem::app_lib_directories [0] = utils.strdup_new (appDirs[2].get_cstr ());
 	} else {
 		log_info (LOG_DEFAULT, "Setting up for DSO lookup directly in the APK");
 		BasicAndroidSystem::app_lib_directories_size = runtimeApks.get_length ();
-		BasicAndroidSystem::app_lib_directories = reinterpret_cast<const char**>(new char[app_lib_directories_size]());
+		BasicAndroidSystem::app_lib_directories = new const char*[app_lib_directories_size]();
 
 		unsigned short built_for_cpu = 0, running_on_cpu = 0;
 		unsigned char is64bit = 0;


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/3759
Context: https://github.com/xamarin/xamarin-android/commit/6d857597187e42d0e7190dfdb61d259e4bac409a#diff-e99739c16155208685952aa52870d4cdL33-L39

When switching from C-style `xcalloc` to C++-style `new` I failed to use the
proper type to allocate array which holds directories where Android placed the
APK files of the application. This mistake manifested itself only when using
AppBundles, which is where we allocate more than one entry of the array. The
resulting error was the following runtime exception:

    11-04 12:27:55.722  3339  3339 E mono    : Unhandled Exception:
    11-04 12:27:55.722  3339  3339 E mono    : System.DllNotFoundException: __Internal assembly:<unknown assembly> type:<unknown type> member:(null)
    11-04 12:27:55.722  3339  3339 E mono    :   at (wrapper managed-to-native) Android.Runtime.JNIEnv.monodroid_timing_start(string)

Which occurred because Xamarin.Android runtime failed to load `libmonodroid.so`
from one of the directories that should have been stored in the array mentioned
above - usually found in the *last* entry of the array. When iterating over the
array, the XA runtime would end up with a null pointer after the end of the
array instead of a pointer to the last entry.

This commit uses the proper type when allocating the array.