### PR TITLE
[Xamarin.Android.Build.Tasks] fix _GeneratePackageManagerJavaForDesigner

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
@@ -77,7 +77,7 @@ Copyright (C) 2016 Xamarin. All rights reserved.
 <Target Name="_GeneratePackageManagerJavaForDesigner"
     DependsOnTargets="_AddStaticResources;_ResolveAssemblies;_CopyAssembliesForDesigner;_PrepareAssembliesForDesigner;$(BeforeGenerateAndroidManifest)"
     Inputs="$(_ResolvedUserAssembliesHashFile);@(ResolvedAssemblies);@(ResolvedUserAssemblies);$(_AndroidManifestAbs);"
-    Outputs="$(_AndroidIntermediateJavaSourceDirectory)mono\MonoPackageManager.java;$(_AndroidTypeMappingJavaToManaged);$(_AndroidTypeMappingManagedToJava)">
+    Outputs="$(_AndroidIntermediateJavaSourceDirectory)mono\MonoPackageManager_Resources.java;$(_AcwMapFile)">
   <GenerateJavaStubs
       ResolvedAssemblies="@(_ResolvedAssemblies)"
       ResolvedUserAssemblies="@(_ResolvedUserMonoAndroidAssembliesForDesigner)"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DesignerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DesignerTests.cs
@@ -162,13 +162,15 @@ namespace UnnamedProject
 			});
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.RunTarget (proj, target, parameters: DesignerParameters), $"first `{target}` should have succeeded.");
-				Assert.IsTrue (b.RunTarget (proj, target, parameters: DesignerParameters), $"second `{target}` should have succeeded.");
+				Assert.IsTrue (b.RunTarget (proj, target, parameters: DesignerParameters, doNotCleanupOnUpdate: true), $"second `{target}` should have succeeded.");
 				Assert.IsTrue (b.Output.IsTargetSkipped (target), $"`{target}` should be skipped!");
+				Assert.IsTrue (b.Output.IsTargetSkipped ("_GeneratePackageManagerJavaForDesigner"), "`_GeneratePackageManagerJavaForDesigner` should be skipped!");
 
 				// Change a java file, run SetupDependenciesForDesigner
 				proj.Touch ("Foo.java");
-				Assert.IsTrue (b.RunTarget (proj, target, parameters: DesignerParameters), $"third `{target}` should have succeeded.");
+				Assert.IsTrue (b.RunTarget (proj, target, parameters: DesignerParameters, doNotCleanupOnUpdate: true), $"third `{target}` should have succeeded.");
 				Assert.IsFalse (b.Output.IsTargetSkipped (target), $"`{target}` should *not* be skipped!");
+				Assert.IsTrue (b.Output.IsTargetSkipped ("_GeneratePackageManagerJavaForDesigner"), "`_GeneratePackageManagerJavaForDesigner` should be skipped!");
 			}
 		}
 


### PR DESCRIPTION
I was doing some review of the MSBuild targets that run when you save
an axml file. The first thing I found was:

    Building target "_GeneratePackageManagerJavaForDesigner" completely.
    Output file "obj\Debug\100\android\src\mono\MonoPackageManager.java" does not exist.

This MSBuild target was running every time that
`SetupDependenciesForDesigner` runs.

We no longer generate `MonoPackageManager.java` at all, so instead:

* Look for `MonoPackageManager_Resources.java`, which actually exists.
* Use `$(_AcwMapFile)` instead of the typemaps, since the designer
  actually uses that file. In some cases the typemaps aren't generated
  either.

These changes improve `SetupDependenciesForDesigner` by about 500ms on
a small app.