### PR TITLE
Build only Debug configuration of libxamarin-debug-app-helper.so

### DIFF
--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -270,7 +270,7 @@ endif()
 set(XAMARIN_APP_STUB_SOURCES ${SOURCES_DIR}/application_dso_stub.cc)
 add_library(xamarin-app SHARED ${XAMARIN_APP_STUB_SOURCES})
 
-if(NOT WIN32 AND NOT MINGW)
+if(NOT WIN32 AND NOT MINGW AND CMAKE_BUILD_TYPE STREQUAL Debug)
   set(XAMARIN_DEBUG_APP_HELPER_SOURCES
 	${SOURCES_DIR}/basic-android-system.cc
 	${SOURCES_DIR}/basic-utilities.cc
@@ -325,6 +325,6 @@ endif()
 
 target_link_libraries(${MONO_ANDROID_LIB} ${LINK_LIBS} xamarin-app)
 
-if(NOT WIN32 AND NOT MINGW)
+if(NOT WIN32 AND NOT MINGW AND CMAKE_BUILD_TYPE STREQUAL Debug)
   target_link_libraries(xamarin-debug-app-helper ${DEBUG_HELPER_LINK_LIBS})
 endif()


### PR DESCRIPTION
`libxamarin-debug-app-helper.so` is a shared library used only for Debug
Xamarin.Android applications to set up the debugging environment, amongst others
to copy the fast-deployed shared libraries from the override directories to an
internal location where we're allowed to use `dlopen` to load the DSOs.

The library used to be built twice (like our runtime), but unlike the runtime it
was copied to the same location and, with Release being built second, the
release version replaced the debug one resulting in a library that does not
include the necessary code to set up the scenario described above.

Fix the issue by building the library only in Debug configuration.