### PR TITLE
Backport of 27ec4988

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -610,8 +610,8 @@ when packaging Release applications.
 -   **AndroidPackageNamingPolicy** &ndash; An enum-style property for
     specifying the Java package names of generated Java source code.
     The default value is `LowercaseCrc64`. In previous versions of
-    Xamarin.Android, MD5-based names were used. You can restore the old
-    behavior by using `LowercaseMD5`.
+    Xamarin.Android, MD5-based names were used via `LowercaseMD5`
+    which is no longer supported.
 
     Added in Xamarin.Android 10.1.
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -958,11 +958,11 @@ namespace Lib2
 			proj.Sources.Add (new BuildItem.Source ("Bar.cs") {
 				TextContent = () => "namespace Foo { class Bar : Java.Lang.Object { } }"
 			});
-			proj.SetProperty ("AndroidPackageNamingPolicy", "LowercaseMD5");
+			proj.SetProperty ("AndroidPackageNamingPolicy", "Lowercase");
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "first build should have succeeded.");
 				var dexFile = b.Output.GetIntermediaryPath (Path.Combine ("android", "bin", "classes.dex"));
-				var className = "Lmd5aaee5c01293e648941eac447719ef3fb/Bar;";
+				var className = "Lfoo/Bar;";
 				Assert.IsTrue (DexUtils.ContainsClass (className, dexFile, AndroidSdkPath), $"`{dexFile}` should include `{className}`!");
 
 				proj.SetProperty ("AndroidPackageNamingPolicy", "LowercaseCrc64");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MaxPathTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/MaxPathTests.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Android.Build.Tests
 				/* xamarinForms */  true,
 			},
 			new object[] {
-				/* limit */         77,
+				/* limit */         71,
 				/* xamarinForms */  false,
 			},
 		};
@@ -41,9 +41,6 @@ namespace Xamarin.Android.Build.Tests
 			var proj = xamarinForms ?
 				new XamarinFormsAndroidApplicationProject () :
 				new XamarinAndroidApplicationProject ();
-			// Force the old MD5 naming policy, and remove [Register]
-			proj.SetProperty ("AndroidPackageNamingPolicy", "LowercaseHash");
-			proj.MainActivity = proj.DefaultMainActivity.Replace ("Register (\"${JAVA_PACKAGENAME}.MainActivity\"), ", "");
 			return proj;
 		}
 
@@ -67,7 +64,7 @@ namespace Xamarin.Android.Build.Tests
 				/* xamarinForms */  true,
 			},
 			new object[] {
-				/* limit */         76,
+				/* limit */         70,
 				/* xamarinForms */  false,
 			},
 		};


### PR DESCRIPTION
Backport of 27ec4988

Test changes for removal of `PackageNamingPolicy.LowercaseMD5`.

* In `MaxPathTests` we improved `MAX_PATH` the limit by 6 characters
  for "Hello World". Xamarin.Forms projects did not have an
  improvement, however; a non-Java stub file is hitting the limit.
* Other tests using `PackageNamingPolicy.LowercaseMD5`, I switched to
  use `PackageNamingPolicy.Lowercase` instead.