### PR TITLE
[CI] Move Azure Pipelines Windows jobs to new pool

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -24,7 +24,7 @@ variables:
   HostedMacMojave: Hosted Mac Internal Mojave
   HostedMac: Hosted Mac Internal
   HostedWinVS2019: Hosted Windows 2019 with VS2019
-  VSEngWinVS2019: VSEng-MicroBuildVS2019
+  VSEngWinVS2019: VSEng-Xamarin-Android
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.
 stages:


### PR DESCRIPTION
The `VSEng-MicroBuildVS2019` pool is currently overloaded, so a new
`VSEng-Xamarin-Android` Windows machine pool has been set up for us to
migrate to. The configurations of these machines should be identical as
far as we're concerned. This pool currently has 5 agents configured,
however we should be able to increase capacity as needed.