### PR TITLE
[Xamarin.Android.Build.Tasks] use SRM for <GenerateResourceDesigner/>

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -513,8 +513,13 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   </ItemGroup>
   <FilterAssemblies
       DesignTimeBuild="$(DesignTimeBuild)"
-      InputAssemblies="@(_ReferencePath);@(_ReferenceDependencyPaths)">
+      InputAssemblies="@(_ReferencePath)">
     <Output TaskParameter="OutputAssemblies" ItemName="_MonoAndroidReferencePath" />
+  </FilterAssemblies>
+  <FilterAssemblies
+      DesignTimeBuild="$(DesignTimeBuild)"
+      InputAssemblies="@(_ReferenceDependencyPaths)">
+    <Output TaskParameter="OutputAssemblies" ItemName="_MonoAndroidReferenceDependencyPaths" />
   </FilterAssemblies>
 </Target>
 
@@ -1228,7 +1233,7 @@ because xbuild doesn't support framework reference assemblies.
 		$(MSBuildAllProjects);
 		@(AndroidResource);
 		@(AndroidBoundLayout);
-		@(_ReferencePath);
+		@(_MonoAndroidReferencePath);
 		@(_LibraryResourceDirectoryStamps);
 		$(_AndroidBuildPropertiesCache);
 		$(ProjectAssetsFile);
@@ -1252,7 +1257,7 @@ because xbuild doesn't support framework reference assemblies.
 		ResourceDirectory="$(MonoAndroidResourcePrefix)"
 		AdditionalResourceDirectories="@(LibraryResourceDirectories)"
 		IsApplication="$(AndroidApplication)"
-		References="@(_ReferencePath)"
+		References="@(_MonoAndroidReferencePath)"
 		UseManagedResourceGenerator="True"
 		DesignTimeBuild="$(DesignTimeBuild)"
 		JavaPlatformJarPath="$(JavaPlatformJarPath)"
@@ -1335,13 +1340,13 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_ResolveLibraryProjectImports"
 		DependsOnTargets="$(CoreResolveReferencesDependsOn)"
-		Inputs="$(ProjectAssetsFile);$(MSBuildProjectFullPath);@(_MonoAndroidReferencePath);@(AndroidAarLibrary);$(_AndroidBuildPropertiesCache)"
+		Inputs="$(ProjectAssetsFile);$(MSBuildProjectFullPath);@(_MonoAndroidReferencePath);@(_MonoAndroidReferenceDependencyPaths);@(AndroidAarLibrary);$(_AndroidBuildPropertiesCache)"
 		Outputs="$(_AndroidStampDirectory)_ResolveLibraryProjectImports.stamp">
 	<ResolveLibraryProjectImports
 		ContinueOnError="$(DesignTimeBuild)"
 		CacheFile="$(_AndroidLibraryProjectImportsCache)"
 		DesignTimeBuild="$(DesignTimeBuild)"
-		Assemblies="@(_MonoAndroidReferencePath)"
+		Assemblies="@(_MonoAndroidReferencePath);@(_MonoAndroidReferenceDependencyPaths)"
 		AarLibraries="@(AndroidAarLibrary)"
 		ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
 		NativeImportsDirectory="$(_NativeLibraryImportsDirectoryName)"
@@ -1606,7 +1611,7 @@ because xbuild doesn't support framework reference assemblies.
 		ResourceDirectory="$(MonoAndroidResDirIntermediate)"
 		AdditionalResourceDirectories="@(LibraryResourceDirectories)"
 		IsApplication="$(AndroidApplication)"
-		References="@(_ReferencePath)"
+		References="@(_MonoAndroidReferencePath)"
 		UseManagedResourceGenerator="$(_UseManagedResourceGenerator)"
 		DesignTimeBuild="$(DesignTimeBuild)"
 		JavaPlatformJarPath="$(JavaPlatformJarPath)"


### PR DESCRIPTION
I noticed the `<GenerateResourceDesigner/>` MSBuild task had a couple
things we could change to speed it up:

* Use System.Reflection.Metadata instead of Mono.Cecil
* Only look at "MonoAndroid" assemblies, so we don't have to load the
  BCL or NetStandard assemblies.
* Remove System.Linq usage in favor of `foreach`

The SRM port was straightforward, as the code only needs to look at
type and field names.

I could also simply use `@(_MonoAndroidReferencePath)` over
`@(_ReferencePath)`.

However, I had to split up `@(_MonoAndroidReferencePath)` and include
`@(_ReferenceDependencyPaths)` in a new item group:
`@(_MonoAndroidReferenceDependencyPaths)`.

Otherwise, this test case failed:

    App -> LibraryA -> LibraryB

The app's `Resource.designer.cs` was attempting to set values in
LibraryB, even though it did not reference it. LibraryB was in
`@(_ReferenceDependencyPaths)`.

These changes will particularly help design-time (or incremental)
builds while editing `AndroidResource` files.
## Notes about F# ##

When refactoring the code, I found what appeared to be a dead code path
that used to be for F# support:

https://github.com/xamarin/xamarin-android/blob/e2e1a846ca6136f0a3bac5ffb48277938ed5c204/src/Xamarin.Android.Build.Tasks/Utilities/ResourceDesignerImportGenerator.cs#L54-L58

Current F# projects make use of the
Xamarin.Android.FSharp.ResourceProvider NuGet Package:

https://github.com/xamarin/Xamarin.Android.FSharp.ResourceProvider/blob/9d3661bd5f6db515377499b7285423d765069ce0/ResourceTypeProvider.fs

The way it works:

* `Resource.designer.cs` is generated as C# code
* Xamarin.Android.FSharp.ResourceProvider compiles this file

You reference the C# class from F# such as:

    type Resources = MyApp.Android.Resource
    [<assembly: Android.Runtime.ResourceDesigner("MyApp.Android.Resources", IsApplication=true)>]

Thus we can remove the old code path, since both languages use the
default C# `Resource.designer.cs`.

## Results ##

Using the Xamarin.Forms integration project in this repo:

    Before:
    465 ms  GenerateResourceDesigner                   1 calls
    After:
    371 ms  GenerateResourceDesigner                   1 calls

This seems like it will save ~100ms on design-time builds and
incremental builds.