### PR TITLE
[Xamarin.Android.Build.Tasks] more deprecated code removal

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
@@ -26,9 +26,6 @@ Copyright (C) 2016 Xamarin. All rights reserved.
     <Output TaskParameter="Jars" ItemName="_LibraryJars" />
   </ReadLibraryProjectImportsCache>
   <ItemGroup>
-    <ExtraJarLocation Include="@(_AdditionalJavaLibraryReferences)">
-      <Source>AssemblyCache</Source>
-    </ExtraJarLocation>
     <ExtraJarLocation Include="@(_LibraryJars)">
       <Source>LibraryImport</Source>
     </ExtraJarLocation>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/DetermineJavaLibrariesToCompile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/DetermineJavaLibrariesToCompile.cs
@@ -27,8 +27,6 @@ namespace Xamarin.Android.Tasks
 
 		public ITaskItem[] LibraryProjectJars { get; set; }
 
-		public ITaskItem[] AdditionalJavaLibraryReferences { get; set; }
-
 		[Output]
 		public ITaskItem[] JavaLibrariesToCompile { get; set; }
 
@@ -50,9 +48,6 @@ namespace Xamarin.Android.Tasks
 				foreach (var jar in LibraryProjectJars)
 					if (!MonoAndroidHelper.IsEmbeddedReferenceJar (jar.ItemSpec))
 						jars.Add (jar);
-			if (AdditionalJavaLibraryReferences != null)
-				foreach (var jar in AdditionalJavaLibraryReferences.Distinct (TaskItemComparer.DefaultComparer))
-					jars.Add (jar);
 
 			var distinct  = MonoAndroidHelper.DistinctFilesByContent (jars);
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -371,7 +371,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
         ToolPath="$(JavaToolPath)"
         SourceDirectories="@(JavaSourceJar->'$(IntermediateOutputPath)javasources\%(FileName)')"
         DestinationDirectories="@(JavaSourceJar->'$(IntermediateOutputPath)javadocs\%(FileName)')"
-        ReferenceJars="@(EmbeddedReferenceJar);@(ReferenceJar);@(_AdditionalJavaLibraryReferences)"
+        ReferenceJars="@(EmbeddedReferenceJar);@(ReferenceJar)"
         JavaPlatformJar="$(_AndroidSdkDirectory)\platforms\android-$(_AndroidApiLevel)\android.jar"
         />
 	
@@ -385,7 +385,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 
   <Target Name="ExportJarToXml"
           DependsOnTargets="$(ExportJarToXmlDependsOnTargets)"
-          Inputs="@(EmbeddedJar);@(EmbeddedReferenceJar);@(InputJar);@(ReferenceJar);$(MSBuildAllProjects);@(_AdditionalJavaLibraryReferences)"
+          Inputs="@(EmbeddedJar);@(EmbeddedReferenceJar);@(InputJar);@(ReferenceJar);$(MSBuildAllProjects)"
           Outputs="$(ApiOutputFile)">
 
     <ItemGroup>
@@ -425,7 +425,7 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
       AndroidApiLevel="$(_AndroidApiLevel)"
       OutputFile="$(ApiOutputFile)"
       SourceJars="@(EmbeddedJar);@(InputJar)"
-      ReferenceJars="@(EmbeddedReferenceJar);@(ReferenceJar);@(_AdditionalJavaLibraryReferences)"
+      ReferenceJars="@(EmbeddedReferenceJar);@(ReferenceJar)"
       DroidDocPaths="$(DroidDocPaths)"
       JavaDocPaths="$(JavaDocPaths)"
       Java7DocPaths="$(Java7DocPaths)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1230,7 +1230,6 @@ because xbuild doesn't support framework reference assemblies.
 		@(AndroidBoundLayout);
 		@(_ReferencePath);
 		@(_LibraryResourceDirectoryStamps);
-		@(_AdditonalAndroidResourceCachePaths->'%(Identity)\cache.stamp');
 		$(_AndroidBuildPropertiesCache);
 		$(ProjectAssetsFile);
 	</_ManagedUpdateAndroidResgenInputs>
@@ -1460,12 +1459,6 @@ because xbuild doesn't support framework reference assemblies.
     </CreateItem>
 </Target>
 
-<Target Name="_CollectAdditionalResourceFiles" Condition="'@(_AdditonalAndroidResourceCachePaths)' != ''">
-	<CreateItem Include="@(_AdditonalAndroidResourceCachePaths->'%(Identity)\res\**\*.*')">
-		<Output TaskParameter="Include" ItemName="_AdditonalAndroidResourceCacheFiles" />
-	</CreateItem>
-</Target>
-
 <Target Name="_FindLayoutsForBinding" Condition=" '$(Language)' == 'C#' ">
   <FindLayoutsToBind
       GenerateLayoutBindings="$(AndroidGenerateLayoutBindings)"
@@ -1557,7 +1550,6 @@ because xbuild doesn't support framework reference assemblies.
 		$(MSBuildAllProjects);
 		@(_AndroidResourceDest);
 		@(_LibraryResourceDirectoryStamps);
-		@(_AdditonalAndroidResourceCachePaths->'%(Identity)\cache.stamp');
 		$(_AndroidBuildPropertiesCache);
 		$(ProjectAssetsFile);
 		$(_AndroidLibraryProjectImportsCache);
@@ -1577,8 +1569,8 @@ because xbuild doesn't support framework reference assemblies.
 		Condition=" '$(_AndroidResourceDesignerFile)' != '' And Exists('$(IntermediateOutputPath)R.txt') "
 		ResourceSymbolsTextFile="$(IntermediateOutputPath)R.txt"
 		OutputDirectory="$(_AndroidIntermediateJavaSourceDirectory)"
-		LibraryTextFiles="@(_AdditonalAndroidResourceCachePaths->'%(Identity)\..\R.txt');@(LibraryResourceDirectories->'%(Identity)\..\R.txt')"
-		ManifestFiles="@(_AdditonalAndroidResourceCachePaths->'%(Identity)\AndroidManifest.xml');@(LibraryResourceDirectories->'%(Identity)\..\AndroidManifest.xml')"
+		LibraryTextFiles="@(LibraryResourceDirectories->'%(Identity)\..\R.txt')"
+		ManifestFiles="@(LibraryResourceDirectories->'%(Identity)\..\AndroidManifest.xml')"
 	/>
 	
 	<CopyGeneratedJavaResourceClasses
@@ -2385,7 +2377,6 @@ because xbuild doesn't support framework reference assemblies.
     LibraryProjectJars="@(ExtractedJarImports)"
     DoNotPackageJavaLibraries="@(_ResolvedDoNotPackageAttributes)"
     EnableInstantRun="$(_InstantRunEnabled)"
-    AdditionalJavaLibraryReferences="@(_AdditionalJavaLibraryReferences)"
     >
     <Output TaskParameter="JavaLibrariesToCompile" ItemName="_JavaLibrariesToCompile" />
     <Output TaskParameter="ReferenceJavaLibraries" ItemName="_ReferenceJavaLibs" />


### PR DESCRIPTION
Expanding upon 1a61fa81, I found some more MSBuild item groups that we
could remove all usage of:

* `@(_AdditionalJavaLibraryReferences)`
* `@(_AdditonalAndroidResourceCachePaths)`

The `<GetAdditionalResourcesFromAssemblies/>` used to populate these
item groups, but it is now removed.

We can remove any MSBuild logic using these item groups.