### PR TITLE
[Xamarin.Android.Build.Tasks] AndroidResource changes do not affect _GenerateJavaStubs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
@@ -80,7 +80,6 @@ Copyright (C) 2016 Xamarin. All rights reserved.
       MergedAndroidManifestOutput="$(IntermediateOutputPath)android\AndroidManifest.xml"
       UseSharedRuntime="$(AndroidUseSharedRuntime)"
       EmbedAssemblies="$(EmbedAssembliesIntoApk)"
-      ResourceDirectory="$(MonoAndroidResDirIntermediate)"
       BundledWearApplicationName="$(BundledWearApplicationPackageName)"
       PackageNamingPolicy="$(AndroidPackageNamingPolicy)"
       ApplicationJavaClass="$(AndroidApplicationJavaClass)"

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -65,9 +65,6 @@ namespace Xamarin.Android.Tasks
 
 		public bool ErrorOnCustomJavaObject { get; set; }
 
-		[Required]
-		public string ResourceDirectory { get; set; }
-
 		public string BundledWearApplicationName { get; set; }
 
 		public string PackageNamingPolicy { get; set; }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -1054,5 +1054,29 @@ namespace Lib2
 				Assert.IsFalse (builder.Build (proj), "Build should *not* have succeeded on the second build.");
 			}
 		}
+
+		[Test]
+		public void AndroidResourceChange ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			using (var builder = CreateApkBuilder ()) {
+				Assert.IsTrue (builder.Build (proj), "first build should succeed");
+
+				// AndroidResource change
+				proj.LayoutMain += $"{Environment.NewLine}<!--comment-->";
+				proj.Touch ("Resources\\layout\\Main.axml");
+				Assert.IsTrue (builder.Build (proj), "second build should succeed");
+
+				var targets = new [] {
+					"_ResolveLibraryProjectImports",
+					"_GenerateJavaStubs",
+					"_CompileJava",
+					"_CompileToDalvikWithD8",
+				};
+				foreach (var target in targets) {
+					Assert.IsTrue (builder.Output.IsTargetSkipped (target), $"`{target}` should be skipped!");
+				}
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2082,7 +2082,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_GenerateJavaStubs"
   DependsOnTargets="$(_GenerateJavaStubsDependsOnTargets);$(BeforeGenerateAndroidManifest)"
-  Inputs="$(MSBuildAllProjects);@(_ResolvedUserMonoAndroidAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(_AndroidResourceDest)"
+  Inputs="$(MSBuildAllProjects);@(_ResolvedUserMonoAndroidAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache)"
   Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
   <GenerateJavaStubs
     ResolvedAssemblies="@(_ResolvedAssemblies)"
@@ -2102,7 +2102,6 @@ because xbuild doesn't support framework reference assemblies.
 	MergedAndroidManifestOutput="$(IntermediateOutputPath)android\AndroidManifest.xml"
     UseSharedRuntime="$(AndroidUseSharedRuntime)"
 	EmbedAssemblies="$(EmbedAssembliesIntoApk)"
-	ResourceDirectory="$(MonoAndroidResDirIntermediate)"
 	BundledWearApplicationName="$(BundledWearApplicationPackageName)"
 	PackageNamingPolicy="$(AndroidPackageNamingPolicy)"
 	ApplicationJavaClass="$(AndroidApplicationJavaClass)"

--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -4,8 +4,8 @@ Test Name,Time in ms (int)
 # Data
 Build_No_Changes,3350
 Build_CSharp_Change,4100
-Build_AndroidResource_Change,4850
-Build_Designer_Change,4250
+Build_AndroidResource_Change,4350
+Build_Designer_Change,3750
 Build_JLO_Change,9000
 Build_CSProj_Change,9500
 Build_XAML_Change,9600


### PR DESCRIPTION
When editing `AndroidResource` files and saving in the IDE, I noticed
that `_GenerateJavaStubs` always runs.

It doesn't seem like we actually need to do that?

The value for `Inputs` makes sense when you look at how the task is
called:

    <Target Name="_GenerateJavaStubs"
        Inputs="$(MSBuildAllProjects);@(_ResolvedUserMonoAndroidAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(_AndroidResourceDest)">
      <GenerateJavaStubs
        ...
        ResourceDirectory="$(MonoAndroidResDirIntermediate)"
      />
    </Target>

But looking closer, the `ResourceDirectory` is not even used by
`<GenerateJavaStubs/>`. It seems like we can just remove the
`@(_AndroidResourceDest)` item group from the list of `Inputs`.

Testing an `AndroidResource`-change in the Toggl app:

https://github.com/toggl/mobileapp/tree/develop/Toggl.Droid

Before:

    415 ms  GenerateJavaStubs                          1 calls

This task no longer runs. This should be a ~400ms improvement on
design-time builds or incremental builds with `AndroidResource`
changes.

I also added a test checking `AndroidResource` changes and which
targets are skipped during incremental builds.