### PR TITLE
[Xamarin.Android.Build.Tasks] Add Ability to include additional Modules

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Xamarin.Android.Tasks
 {
@@ -61,6 +62,8 @@ namespace Xamarin.Android.Tasks
 		public string BaseZip { get; set; }
 
 		public string CustomBuildConfigFile { get; set; }
+		
+		public string [] Modules { get; set; }
 
 		[Required]
 		public string Output { get; set; }
@@ -119,7 +122,11 @@ namespace Xamarin.Android.Tasks
 		{
 			var cmd = base.GetCommandLineBuilder ();
 			cmd.AppendSwitch ("build-bundle");
-			cmd.AppendSwitchIfNotNull ("--modules ", BaseZip);
+			var modules = new List<string> ();
+			modules.Add (BaseZip);
+			if (Modules != null && Modules.Any ())
+				modules.AddRange (Modules);
+			cmd.AppendSwitchIfNotNull ("--modules ", string.Join (",", modules));
 			cmd.AppendSwitchIfNotNull ("--output ", Output);
 			cmd.AppendSwitchIfNotNull ("--config ", temp);
 			return cmd;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2767,6 +2767,7 @@ because xbuild doesn't support framework reference assemblies.
       JavaOptions="$(JavaOptions)"
       JarPath="$(AndroidBundleToolJarPath)"
       BaseZip="$(_BaseZipIntermediate)"
+      Modules="@(AndroidAppBundleModules)"
       Output="$(_AppBundleIntermediate)"
       UncompressedFileExtensions="$(AndroidStoreUncompressedFileExtensions)"
       CustomBuildConfigFile="$(AndroidBundleConfigurationFile)"


### PR DESCRIPTION
AppBundles can support multiple modules. This PR adds
the ability to specify additional modules to the
`bundle-tool`. These options might be used in the
future to help support Dynamic features.