### PR TITLE
[Xamarin.Android.Build.Tasks] Add StopAndroidPackage target

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -104,6 +104,9 @@ The following build targets are defined for Xamarin.Android projects:
     device or the running emulator. The launch activity can be
     overriden by `AndroidLaunchActivity` property.
 
+-   **StopAndroidPackage** &ndash; Completely stops the application
+    package on the device or the running emulator.
+
 -   **UpdateAndroidResources** &ndash; Updates the
     `Resource.designer.cs` file. This target is usually called by the
     IDE when new resources are added to the project.

--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -102,10 +102,18 @@ The following build targets are defined for Xamarin.Android projects:
 
 -   **StartAndroidActivity** &ndash; Starts *launch* activity on the
     device or the running emulator. The launch activity can be
-    overriden by `AndroidLaunchActivity` property.
+    overriden by the `$(AndroidLaunchActivity)` property.
+    
+    Added in Xamarin.Android v10.3.
+    
+    This is equivalent to `adb shell am start @PACKAGE_NAME@/$(AndroidLaunchActivity)`.
 
 -   **StopAndroidPackage** &ndash; Completely stops the application
     package on the device or the running emulator.
+    
+    Added in Xamarin.Android v10.3.
+    
+    This is equivalent to `adb shell am force-stop @PACKAGE_NAME@`.
 
 -   **UpdateAndroidResources** &ndash; Updates the
     `Resource.designer.cs` file. This target is usually called by the

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Application.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Application.targets
@@ -26,4 +26,13 @@ Copyright (C) 2019 Microsoft Corporation. All rights reserved.
     </GetAndroidPackageName>
     <Exec Command="&quot;$(AdbToolPath)adb&quot; $(AdbTarget) shell am start -n &quot;$(_AndroidPackage)/$(AndroidLaunchActivity)&quot;" />
   </Target>
+  <Target Name="StopAndroidPackage"
+      DependsOnTargets="_ResolveMonoAndroidSdks">
+    <GetAndroidPackageName
+        ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
+        AssemblyName="$(AssemblyName)">
+      <Output TaskParameter="PackageName" PropertyName="_AndroidPackage" />
+    </GetAndroidPackageName>
+    <Exec Command="&quot;$(AdbToolPath)adb&quot; $(AdbTarget) shell am force-stop &quot;$(_AndroidPackage)&quot;" />
+  </Target>
 </Project>


### PR DESCRIPTION
Add new target to stop the app package on the device/emulator.

Add documentation for the new target

This is one of the steps needed for [recording AOT profiles][1]. It is
also useful for scripts to measure the app performance on a
device or an emulator.

[1]: https://github.com/xamarin/xamarin-android/issues/3792