### PR TITLE
[Xamarin.Android.Build.Tasks] remove the android\assets\shrunk directory

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@1b907d680cc6561dcfaddc6f997d2f6ff5456644
+xamarin/monodroid:shrunkframeworkassemblies@326b7fc28ebfc0e630e3383ea5061a3337efe986
 mono/mono:2019-08@8946e49a974ea8b75fe5b8b7e93ffd4571521a85

--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveRegisterAttribute.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveRegisterAttribute.cs
@@ -17,14 +17,14 @@ namespace Xamarin.Android.Tasks
 		const string RegisterAttribute = "Android.Runtime.RegisterAttribute";
 
 		[Required]
-		public ITaskItem[] ShrunkFrameworkAssemblies { get; set; }
+		public ITaskItem[] FrameworkAssemblies { get; set; }
 
 		public bool Deterministic { get; set; }
 
 		public override bool RunTask ()
 		{
 			// Find Mono.Android.dll
-			var mono_android = ShrunkFrameworkAssemblies.First (f => Path.GetFileNameWithoutExtension (f.ItemSpec) == "Mono.Android").ItemSpec;
+			var mono_android = FrameworkAssemblies.First (f => Path.GetFileNameWithoutExtension (f.ItemSpec) == "Mono.Android").ItemSpec;
 			var writerParameters = new WriterParameters {
 				DeterministicMvid = Deterministic,
 			};

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1158,7 +1158,6 @@ because xbuild doesn't support framework reference assemblies.
 	<_AndroidLinkFlag>$(IntermediateOutputPath)link.flag</_AndroidLinkFlag>
 	<_AndroidApkPerAbiFlagFile>$(IntermediateOutputPath)android\bin\apk_per_abi.flag</_AndroidApkPerAbiFlagFile>
 	<_AndroidDebugKeyStoreFlag>$(IntermediateOutputPath)android_debug_keystore.flag</_AndroidDebugKeyStoreFlag>
-	<_RemoveRegisterFlag>$(MonoAndroidIntermediateAssemblyDir)shrunk\shrunk.flag</_RemoveRegisterFlag>
 	<_AcwMapFile>$(IntermediateOutputPath)acw-map.txt</_AcwMapFile>
 	<_CustomViewMapFile>$(IntermediateOutputPath)customview-map.txt</_CustomViewMapFile>
 	<_AndroidTypeMappingJavaToManaged>$(IntermediateOutputPath)android\typemap.jm</_AndroidTypeMappingJavaToManaged>
@@ -2042,18 +2041,6 @@ because xbuild doesn't support framework reference assemblies.
   </CreateItem>
 
   <CreateItem
-    Include="@(_ResolvedFrameworkAssemblies)"
-    Condition="'$(AndroidLinkMode)' == 'None' OR '$(AndroidUseSharedRuntime)' == 'true'">
-    <Output TaskParameter="Include" ItemName="_ShrunkFrameworkAssemblies" />
-  </CreateItem>
-
-  <CreateItem
-    Include="@(_ResolvedFrameworkAssemblies->'$(MonoAndroidIntermediateAssemblyDir)shrunk\%(Filename)%(Extension)')"
-    Condition="'$(AndroidLinkMode)' != 'None' AND '$(AndroidUseSharedRuntime)' != 'true'">
-    <Output TaskParameter="Include" ItemName="_ShrunkFrameworkAssemblies" />
-  </CreateItem>
-
-  <CreateItem
     Include="@(_ResolvedUserAssemblies)"
     Condition="'%(_ResolvedUserAssemblies.TargetFrameworkIdentifier)' == 'MonoAndroid' Or '%(_ResolvedUserAssemblies.HasMonoAndroidReference)' == 'True'">
     <Output TaskParameter="Include" ItemName="_ResolvedUserMonoAndroidAssemblies" />
@@ -2516,27 +2503,16 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_RemoveRegisterAttribute"
   DependsOnTargets="_PrepareAssemblies"
   Inputs="$(_AndroidLinkFlag)"
-  Outputs="$(_RemoveRegisterFlag)"
+  Outputs="$(_AndroidStampDirectory)_RemoveRegisterAttribute.stamp"
   Condition="'$(AndroidLinkMode)' != 'None' AND '$(AndroidUseSharedRuntime)' != 'true'">
-
-  <!-- Make a copy of every assembly into assets\shrunk -->
-  <Copy
-    SourceFiles="@(_ResolvedFrameworkAssemblies)"
-    DestinationFiles="@(_ShrunkFrameworkAssemblies)"
-    SkipUnchangedFiles="true" />
-
-  <CopyIfChanged
-    SourceFiles="@(_ResolvedFrameworkAssemblies->'%(Identity).config')"
-    DestinationFiles="@(_ShrunkFrameworkAssemblies->'%(Identity).config')" />
   
   <!-- Shrink Mono.Android.dll by removing attribute only needed for GenerateJavaStubs -->
   <RemoveRegisterAttribute
     Condition="'$(AndroidLinkMode)' != 'None' AND '$(AndroidUseSharedRuntime)' != 'true'"
     Deterministic="$(Deterministic)"
-    ShrunkFrameworkAssemblies="@(_ShrunkFrameworkAssemblies)" />
+    FrameworkAssemblies="@(_ResolvedFrameworkAssemblies)" />
 
-  <MakeDir Directories="$(MonoAndroidIntermediateAssemblyDir)shrunk" />
-  <Touch Files="$(_RemoveRegisterFlag)" AlwaysCreate="true" />
+  <Touch Files="$(_AndroidStampDirectory)_RemoveRegisterAttribute.stamp" AlwaysCreate="true" />
 </Target>
 
 <Target Name="_ResolveSatellitePaths"
@@ -2678,8 +2654,7 @@ because xbuild doesn't support framework reference assemblies.
 	<_BuildApkEmbedInputs>
 		$(MSBuildAllProjects)
 		;$(_PackagedResources)
-		;@(_ResolvedUserAssemblies)
-		;@(_ShrunkFrameworkAssemblies)
+		;@(_ResolvedAssemblies)
 		;@(AndroidNativeLibrary)
 		;@(_DexFile)
 		;$(_AndroidBuildPropertiesCache)
@@ -2717,7 +2692,7 @@ because xbuild doesn't support framework reference assemblies.
 	AndroidSequencePointsMode="$(_SequencePointsMode)"
 	AotAdditionalArguments="$(AndroidAotAdditionalArguments)"
 	ExtraAotOptions="$(AndroidExtraAotOptions)"
-	ResolvedAssemblies="@(_ResolvedUserAssemblies);@(_ShrunkFrameworkAssemblies)"
+	ResolvedAssemblies="@(_ResolvedAssemblies)"
 	AotOutputDirectory="$(_AndroidAotBinDirectory)"
 	IntermediateAssemblyDir="$(MonoAndroidIntermediateAssemblyDir)"
 	LinkMode="$(AndroidLinkMode)"
@@ -2742,7 +2717,7 @@ because xbuild doesn't support framework reference assemblies.
 		Condition="'$(BundleAssemblies)' == 'True'"
 		KeepTemp="$(AndroidMakeBundleKeepTemporaryFiles)"
 		AndroidNdkDirectory="$(_AndroidNdkDirectory)"
-		Assemblies="@(_ResolvedUserAssemblies);@(_AndroidResolvedSatellitePaths);@(_ShrunkFrameworkAssemblies)"
+		Assemblies="@(_ResolvedAssemblies);@(_AndroidResolvedSatellitePaths)"
 		IncludePath="$(MonoAndroidIncludeDirectory)"
 		SupportedAbis="@(_BuildTargetAbis)"
 		TempOutputPath="$(IntermediateOutputPath)"
@@ -2760,7 +2735,7 @@ because xbuild doesn't support framework reference assemblies.
     BundleNativeLibraries="$(_BundleResultNativeLibraries)"
     EmbedAssemblies="$(EmbedAssembliesIntoApk)"
     ResolvedUserAssemblies="@(_ResolvedUserAssemblies);@(_AndroidResolvedSatellitePaths)"
-    ResolvedFrameworkAssemblies="@(_ShrunkFrameworkAssemblies)"
+    ResolvedFrameworkAssemblies="@(_ResolvedFrameworkAssemblies)"
     NativeLibraries="@(AndroidNativeLibrary)"
     ApplicationSharedLibraries="@(_ApplicationSharedLibrary)"
     AdditionalNativeLibraryReferences="@(_AdditionalNativeLibraryReferences)"
@@ -2789,7 +2764,7 @@ because xbuild doesn't support framework reference assemblies.
       BundleNativeLibraries="$(_BundleResultNativeLibraries)"
       EmbedAssemblies="$(EmbedAssembliesIntoApk)"
       ResolvedUserAssemblies="@(_ResolvedUserAssemblies);@(_AndroidResolvedSatellitePaths)"
-      ResolvedFrameworkAssemblies="@(_ShrunkFrameworkAssemblies)"
+      ResolvedFrameworkAssemblies="@(_ResolvedFrameworkAssemblies)"
       NativeLibraries="@(AndroidNativeLibrary)"
       ApplicationSharedLibraries="@(_ApplicationSharedLibrary)"
       AdditionalNativeLibraryReferences="@(_AdditionalNativeLibraryReferences)"


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/3753
Context: https://github.com/xamarin/monodroid/pull/1053

There appears to be an issue with mono:2019-10 when the Xamarin.Forms
integration project is built with AOT in `Release` mode.

The issue somehow stems from two `Mono.Android.dll` existing:

* `obj\Debug\android\assets\Mono.Android.dll`
* `obj\Debug\android\assets\shrunk\Mono.Android.dll`

Looking at how AOT is invoked, it seems like either `Mono.Android.dll`
could be picked up by the parameters being passed in. We might be
AOT'ing a user's `Foo.dll`, and both directories are in `$MONO_PATH`
or passed via other arguments. How would we know which is picked up?

The `shrunk` directory is used by the `<RemoveRegisterAttribute/>`
MSBuild task that:
* Runs after the linker & `<GenerateJavaStubs/>`
* Removes all the `[RegisterAttribute]` from types, to further shrink
  `Mono.Android.dll`.

It looks like we copy all `@(_ResolvedFrameworkAssemblies)` to the
`shrunk` directory and fix up item groups. Why don't we just get rid
of this `shrunk` directory and not copy anything? We can edit
`Mono.Android.dll` in place, and incremental builds should be fine due
to the use of stamp files.

I also moved the flag file to:

    $(_AndroidStampDirectory)_RemoveRegisterAttribute.stamp

To match our new MSBuild conventions.

There is also usage of `@(_ShrunkFrameworkAssemblies)` that needs to
be updated in monodroid.