### PR TITLE
[Xamarin.Android.build.Tasks] AOT can now be used with Fast Deployment

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@1b907d680cc6561dcfaddc6f997d2f6ff5456644
+xamarin/monodroid:profiled-aot-debug-mode@8be5e209e2cfdc1bf689955e080476f16f3eddba
 mono/mono:2019-08@8946e49a974ea8b75fe5b8b7e93ffd4571521a85

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -526,8 +526,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 <Target Name="_CheckNonIdealConfigurations">
   <Warning Code="XA0119"
-      Text="Using Fast Deployment and AOT at the same time is not recommended. Use Fast Deployment for Debug configurations and AOT for Release configurations."
-      Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(AotAssemblies)' == 'True' "
+      Text="Using Fast Deployment and Full AOT at the same time is not recommended. Use Profiled AOT for Debug configurations and Full AOT for Release configurations."
+      Condition=" '$(AndroidUseSharedRuntime)' == 'True' And '$(AotAssemblies)' == 'True' And '$(AndroidEnableProfiledAot)' != 'True' "
   />
   <Warning Code="XA0119"
       Text="Using Fast Deployment and the Linker at the same time is not recommended. Use Fast Deployment for Debug configurations and the Linker for Release configurations."
@@ -1697,7 +1697,9 @@ because xbuild doesn't support framework reference assemblies.
 	<!--- Remove the ImplicitlyExpandDesignTimeFacades assemblies. We have already build the app there are not required for packaging  -->
 	<ItemGroup>
 		<FilteredAssemblies Include="$(OutDir)$(TargetFileName)"
-				Condition="Exists ('$(OutDir)$(TargetFileName)')" />
+				Condition="Exists ('$(OutDir)$(TargetFileName)')">
+			<ReferenceSourceTarget>TargetPath</ReferenceSourceTarget>
+		</FilteredAssemblies>
 		<FilteredAssemblies Include="@(ReferenceCopyLocalPaths)"
 				Condition="'%(ReferenceCopyLocalPaths.ResolvedFrom)' != 'ImplicitlyExpandDesignTimeFacades' And '%(ReferenceCopyLocalPaths.Extension)' == '.dll' And '%(ReferenceCopyLocalPaths.RelativeDir)' == '' And Exists('%(ReferenceCopyLocalPaths.Identity)') "/>
 		<FilteredAssemblies Include="@(_ReferencePath)"
@@ -2670,6 +2672,55 @@ because xbuild doesn't support framework reference assemblies.
   </PropertyGroup>
 </Target>
 
+<Target Name="_AotAssembliesInputs">
+  <PropertyGroup>
+    <_StartupAotProfile Condition="'%(ResolvedAssemblies.Filename)' == 'Xamarin.Forms.Platform.Android'">startup-xf.aotprofile</_StartupAotProfile>
+    <_StartupAotProfile Condition="'$(_StartupAotProfile)' == ''">startup.aotprofile</_StartupAotProfile>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(AndroidUseDefaultAotProfile)' != 'False'">
+    <AndroidAotProfile Include="$(MSBuildThisFileDirectory)$(_StartupAotProfile)" />
+  </ItemGroup>
+  <SplitProperty Value="$(AndroidAotProfiles)" Condition="'$(AndroidAotProfiles)' != ''">
+    <Output TaskParameter="Output" ItemName="_AotProfiles" />
+  </SplitProperty>
+  <ItemGroup>
+    <_AotProfiles Condition=" '$(AndroidEnableProfiledAot)' == 'True' " Include="@(AndroidAotProfile)" />
+    <_AssembliesToAot Condition=" '$(AndroidUseDebugRuntime)' != 'True' " Include="@(_ResolvedUserAssemblies);@(_ShrunkFrameworkAssemblies)" />
+    <_AssembliesToAot Condition=" '$(AndroidUseDebugRuntime)' == 'True' " Include="@(_ShrunkFrameworkAssemblies)" />
+    <_AssembliesToAot Condition=" '$(AndroidUseDebugRuntime)' == 'True' And '%(_ResolvedUserAssemblies.ReferenceSourceTarget)' != 'ProjectReference' And '%(_ResolvedUserAssemblies.ReferenceSourceTarget)' != 'TargetPath' " Include="@(_ResolvedUserAssemblies)" />
+  </ItemGroup>
+</Target>
+
+<Target Name="_AotAssemblies"
+    Condition="'$(AotAssemblies)' == 'True'"
+    DependsOnTargets="_AotAssembliesInputs"
+    Inputs="$(MSBuildAllProjects);$(_AndroidBuildPropertiesCache);@(_AssembliesToAot)"
+    Outputs="$(_AndroidStampDirectory)_AotAssemblies.stamp">
+  <RemoveDirFixed Directories="$(_AndroidAotBinDirectory)" />
+  <Aot
+      AndroidAotMode="$(AndroidAotMode)"
+      AndroidNdkDirectory="$(_AndroidNdkDirectory)"
+      AndroidBinUtilsDirectory="$(AndroidBinUtilsDirectory)"
+      AndroidApiLevel="$(_AndroidApiLevel)"
+      ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
+      SupportedAbis="@(_BuildTargetAbis)"
+      AndroidSequencePointsMode="$(_SequencePointsMode)"
+      AotAdditionalArguments="$(AndroidAotAdditionalArguments)"
+      ResolvedAssemblies="@(_AssembliesToAot)"
+      AotOutputDirectory="$(_AndroidAotBinDirectory)"
+      IntermediateAssemblyDir="$(MonoAndroidIntermediateAssemblyDir)"
+      LinkMode="$(AndroidLinkMode)"
+      AdditionalNativeLibraryReferences="@(_AdditionalNativeLibraryReferences)"
+      YieldDuringToolExecution="$(YieldDuringToolExecution)"
+      EnableLLVM="$(EnableLLVM)"
+      Profiles="@(_AotProfiles)">
+  </Aot>
+  <ItemGroup>
+    <_AdditionalNativeLibraryReferences Include="$(_AndroidAotBinDirectory)\*\*.so" />
+  </ItemGroup>
+  <Touch Files="$(_AndroidStampDirectory)_AotAssemblies.stamp" AlwaysCreate="True" />
+</Target>
+
 <PropertyGroup>
 	<_BuildApkEmbedInputs>
 		$(MSBuildAllProjects)
@@ -2684,44 +2735,10 @@ because xbuild doesn't support framework reference assemblies.
 </PropertyGroup>
 
 <Target Name="_BuildApkEmbed"
-  DependsOnTargets="_PrepareBuildApk"
+  DependsOnTargets="_PrepareBuildApk;_AotAssemblies"
   Inputs="$(_BuildApkEmbedInputs)"
   Outputs="$(_BuildApkEmbedOutputs)"
   Condition="'$(EmbedAssembliesIntoApk)' == 'True'">
-
-  <PropertyGroup>
-    <_StartupAotProfile Condition="'%(ResolvedAssemblies.Filename)' == 'Xamarin.Forms.Platform.Android'">startup-xf.aotprofile</_StartupAotProfile>
-    <_StartupAotProfile Condition="'$(_StartupAotProfile)' == ''">startup.aotprofile</_StartupAotProfile>
-  </PropertyGroup>
-  <ItemGroup Condition="'$(AndroidUseDefaultAotProfile)' != 'False'">
-    <AndroidAotProfile Include="$(MSBuildThisFileDirectory)$(_StartupAotProfile)" />
-  </ItemGroup>
-  <SplitProperty Value="$(AndroidAotProfiles)" Condition="'$(AndroidAotProfiles)' != ''">
-    <Output TaskParameter="Output" ItemName="_AotProfiles" />
-  </SplitProperty>
-  <ItemGroup Condition="'$(AndroidEnableProfiledAot)' == 'True'">
-    <_AotProfiles Include="@(AndroidAotProfile)" />
-  </ItemGroup>
-  <Aot
-	Condition="'$(AotAssemblies)' == 'True'"
-	AndroidAotMode="$(AndroidAotMode)"
-	AndroidNdkDirectory="$(_AndroidNdkDirectory)"
-	AndroidBinUtilsDirectory="$(AndroidBinUtilsDirectory)"
-	AndroidApiLevel="$(_AndroidApiLevel)"
-	ManifestFile="$(IntermediateOutputPath)android\AndroidManifest.xml"
-	SupportedAbis="@(_BuildTargetAbis)"
-	AndroidSequencePointsMode="$(_SequencePointsMode)"
-	AotAdditionalArguments="$(AndroidAotAdditionalArguments)"
-	ResolvedAssemblies="@(_ResolvedUserAssemblies);@(_ShrunkFrameworkAssemblies)"
-	AotOutputDirectory="$(_AndroidAotBinDirectory)"
-	IntermediateAssemblyDir="$(MonoAndroidIntermediateAssemblyDir)"
-	LinkMode="$(AndroidLinkMode)"
-	AdditionalNativeLibraryReferences="@(_AdditionalNativeLibraryReferences)"
-	YieldDuringToolExecution="$(YieldDuringToolExecution)"
-	EnableLLVM="$(EnableLLVM)"
-	Profiles="@(_AotProfiles)">
-	   <Output TaskParameter="NativeLibrariesReferences" ItemName="_AdditionalNativeLibraryReferences" />
-  </Aot>
 
   <!-- Strip the IL code of the resolved managed assemblies -->
    <CilStrip

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -66,36 +66,56 @@ namespace Xamarin.Android.Build.Tests
 				/* useSharedRuntime */   false,
 				/* embedAssemblies */    true,
 				/* fastDevType */        "Assemblies",
+				/* profiledAot */        false,
 				/* activityStarts */     true,
 			},
 			new object[] {
 				/* useSharedRuntime */   false,
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies",
+				/* profiledAot */        false,
 				/* activityStarts */     true,
 			},
 			new object[] {
 				/* useSharedRuntime */   true,
 				/* embedAssemblies */    true,
 				/* fastDevType */        "Assemblies",
+				/* profiledAot */        false,
+				/* activityStarts */     true,
+			},
+			new object[] {
+				/* useSharedRuntime */   false,
+				/* embedAssemblies */    false,
+				/* fastDevType */        "Assemblies",
+				/* profiledAot */        true,
 				/* activityStarts */     true,
 			},
 			new object[] {
 				/* useSharedRuntime */   true,
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies",
+				/* profiledAot */        true,
+				/* activityStarts */     true,
+			},
+			new object[] {
+				/* useSharedRuntime */   true,
+				/* embedAssemblies */    false,
+				/* fastDevType */        "Assemblies",
+				/* profiledAot */        false,
 				/* activityStarts */     true,
 			},
 			new object[] {
 				/* useSharedRuntime */   true,
 				/* embedAssemblies */    true,
 				/* fastDevType */        "Assemblies:Dexes",
+				/* profiledAot */        false,
 				/* activityStarts */     true,
 			},
 			new object[] {
 				/* useSharedRuntime */   true,
 				/* embedAssemblies */    false,
 				/* fastDevType */        "Assemblies:Dexes",
+				/* profiledAot */        false,
 				/* activityStarts */     false,
 			},
 		};
@@ -104,7 +124,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		[TestCaseSource (nameof (DebuggerCustomAppTestCases))]
 		[Retry (1)]
-		public void CustomApplicationRunsWithDebuggerAndBreaks (bool useSharedRuntime, bool embedAssemblies, string fastDevType, bool activityStarts)
+		public void CustomApplicationRunsWithDebuggerAndBreaks (bool useSharedRuntime, bool embedAssemblies, string fastDevType, bool profiledAot, bool activityStarts)
 		{
 			if (!CommercialBuildAvailable) {
 				Assert.Ignore ("Test does not run on the Open Source Builds.");
@@ -117,6 +137,7 @@ namespace Xamarin.Android.Build.Tests
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = false,
 				AndroidFastDeploymentType = fastDevType,
+				AndroidEnableProfiledAot = profiledAot,
 			};
 			var abis = new string [] { "armeabi-v7a", "x86" };
 			proj.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -50,7 +50,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void InstallAndUnInstall ([Values (false, true)] bool isRelease)
+		public void InstallAndUnInstall ([Values (false, true)] bool isRelease, [Values(false, true)] bool profiledAot)
 		{
 			if (!CommercialBuildAvailable)
 				Assert.Ignore ("Not required on Open Source Builds");
@@ -61,6 +61,7 @@ namespace Xamarin.Android.Build.Tests
 			
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
+				AndroidEnableProfiledAot = profiledAot,
 			};
 			if (isRelease) {
 				var abis = new string [] { "armeabi-v7a", "x86" };


### PR DESCRIPTION
Context: https://github.com/xamarin/monodroid/pull/1055
Fixes: https://github.com/xamarin/xamarin-android/issues/3828

Moved the `<Aot/>` MSBuild task call from `_BuildApkEmbed` to a new
`_AotAssemblies` target. This allows it to work for Fast Deployment
and the `_BuildApkFastDev` target *and* the `_BuildApkEmbed` target.

The other caveat is that we don't want to AOT the user's assemblies in
their project. We don't want AOT to run for small code changes, and so
we can AOT "framework assemblies" and any user assembly where
`%(ReferenceSourceTarget)` isn't a `<ProjectReference/>`:

    <_AssembliesToAot Condition=" '$(AndroidUseDebugRuntime)' != 'True' " Include="@(_ResolvedUserAssemblies);@(_ShrunkFrameworkAssemblies)" />
    <_AssembliesToAot Condition=" '$(AndroidUseDebugRuntime)' == 'True' " Include="@(_ShrunkFrameworkAssemblies)" />
    <_AssembliesToAot Condition=" '$(AndroidUseDebugRuntime)' == 'True' And '%(_ResolvedUserAssemblies.ReferenceSourceTarget)' != 'ProjectReference' " Include="@(_ResolvedUserAssemblies)" />

This way we aren't running the AOT compiler on any of the user's
assemblies. This would severely impact incremental build performance.

## Results ##

Results for `samples/HelloWorld`:

    Before:
    ActivityTaskManager: Displayed com.xamarin.android.helloworld/example.MainActivity: +2s449m
    After:
    ActivityTaskManager: Displayed com.xamarin.android.helloworld/example.MainActivity: +2s439ms

~10ms better? It really is a "Hello World".

Then I tried the Xamarin.Forms integration project:

    Before:
    ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +4s189ms
    After:
    ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +3s527ms

It seems about ~650ms better?

My comparison is:

    > git clean -dxf .\tests\
    > adb uninstall Xamarin.Forms_Performance_Integration
    > adb logcat -c
    > xabuild .\tests\Xamarin.Forms-Performance-Integration\Droid\Xamarin.Forms.Performance.Integration.Droid.csproj /r /t:Install,_Run /p:AndroidEnableProfiledAot=true

Versus:

    > xabuild .\tests\Xamarin.Forms-Performance-Integration\Droid\Xamarin.Forms.Performance.Integration.Droid.csproj /r /t:Install,_Run

It seems like AOT'd assemblies are loaded, too, I got logging such as:

    > adb logcat -d | grep 'Loaded AOT image'
    11-19 10:29:25.358 29065 29065 I monodroid: Loaded AOT image 'libaot-mscorlib.dll.so'
    11-19 10:29:25.368 29065 29065 I monodroid: Loaded AOT image 'libaot-FormsViewGroup.dll.so'
    11-19 10:29:25.373 29065 29065 I monodroid: Loaded AOT image 'libaot-Mono.Android.dll.so'
    11-19 10:29:25.379 29065 29065 I monodroid: Loaded AOT image 'libaot-System.Core.dll.so'
    11-19 10:29:25.381 29065 29065 I monodroid: Loaded AOT image 'libaot-System.dll.so'
    11-19 10:29:25.382 29065 29065 I monodroid: Loaded AOT image 'libaot-Mono.Security.dll.so'
    11-19 10:29:25.384 29065 29065 I monodroid: Loaded AOT image 'libaot-Java.Interop.dll.so'
    11-19 10:29:25.385 29065 29065 I monodroid: Loaded AOT image 'libaot-System.Net.Http.dll.so'
    11-19 10:29:25.387 29065 29065 I monodroid: Loaded AOT image 'libaot-System.Xml.dll.so'
    11-19 10:29:25.389 29065 29065 I monodroid: Loaded AOT image 'libaot-Newtonsoft.Json.dll.so'
    11-19 10:29:25.390 29065 29065 I monodroid: Loaded AOT image 'libaot-Plugin.Connectivity.Abstractions.dll.so'
    11-19 10:29:25.392 29065 29065 I monodroid: Loaded AOT image 'libaot-Plugin.Connectivity.dll.so'
    11-19 10:29:25.393 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Arch.Core.Common.dll.so'
    11-19 10:29:25.394 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Arch.Core.Runtime.dll.so'
    11-19 10:29:25.396 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Arch.Lifecycle.Common.dll.so'
    11-19 10:29:25.397 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Arch.Lifecycle.LiveData.Core.dll.so'
    11-19 10:29:25.398 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Arch.Lifecycle.LiveData.dll.so'
    11-19 10:29:25.399 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Arch.Lifecycle.Runtime.dll.so'
    11-19 10:29:25.401 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Arch.Lifecycle.ViewModel.dll.so'
    11-19 10:29:25.402 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.Animated.Vector.Drawable.dll.so'
    11-19 10:29:25.403 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.Annotations.dll.so'
    11-19 10:29:25.405 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.AsyncLayoutInflater.dll.so'
    11-19 10:29:25.406 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.Collections.dll.so'
    11-19 10:29:25.408 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.Compat.dll.so'
    11-19 10:29:25.409 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.VersionedParcelable.dll.so'
    11-19 10:29:25.410 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.CoordinaterLayout.dll.so'
    11-19 10:29:25.412 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.CustomView.dll.so'
    11-19 10:29:25.413 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.Core.UI.dll.so'
    11-19 10:29:25.414 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.ViewPager.dll.so'
    11-19 10:29:25.416 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.SwipeRefreshLayout.dll.so'
    11-19 10:29:25.417 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.Core.Utils.dll.so'
    11-19 10:29:25.419 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.CursorAdapter.dll.so'
    11-19 10:29:25.420 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.CustomTabs.dll.so'
    11-19 10:29:25.421 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.Design.dll.so'
    11-19 10:29:25.423 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.v7.CardView.dll.so'
    11-19 10:29:25.424 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.v7.AppCompat.dll.so'
    11-19 10:29:25.426 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.Fragment.dll.so'
    11-19 10:29:25.428 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.v7.RecyclerView.dll.so'
    11-19 10:29:25.429 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.Transition.dll.so'
    11-19 10:29:25.430 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.DocumentFile.dll.so'
    11-19 10:29:25.432 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.DrawerLayout.dll.so'
    11-19 10:29:25.433 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.Interpolator.dll.so'
    11-19 10:29:25.435 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.Loader.dll.so'
    11-19 10:29:25.436 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.LocalBroadcastManager.dll.so'
    11-19 10:29:25.437 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.Media.Compat.dll.so'
    11-19 10:29:25.439 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.Print.dll.so'
    11-19 10:29:25.440 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.SlidingPaneLayout.dll.so'
    11-19 10:29:25.442 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.v4.dll.so'
    11-19 10:29:25.443 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.v7.MediaRouter.dll.so'
    11-19 10:29:25.445 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.v7.Palette.dll.so'
    11-19 10:29:25.446 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Android.Support.Vector.Drawable.dll.so'
    11-19 10:29:25.448 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Forms.Core.dll.so'
    11-19 10:29:25.451 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Forms.Platform.Android.dll.so'
    11-19 10:29:25.452 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Forms.Platform.dll.so'
    11-19 10:29:25.453 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Forms.Xaml.dll.so'
    11-19 10:29:25.544 29065 29065 I monodroid: Loaded AOT image 'libaot-System.Runtime.Serialization.dll.so'
    11-19 10:29:25.545 29065 29065 I monodroid: Loaded AOT image 'libaot-System.ServiceModel.Internals.dll.so'
    11-19 10:29:25.622 29065 29065 I monodroid: Loaded AOT image 'libaot-Xamarin.Forms.Performance.Integration.Droid.dll.so'
    11-19 10:29:25.642 29065 29065 I monodroid: Loaded AOT image 'libaot-netstandard.dll.so'
    11-19 10:29:25.794 29065 29065 I monodroid: Loaded AOT image 'libaot-System.Runtime.dll.so'
    11-19 10:29:26.142 29065 29065 I monodroid: Loaded AOT image 'libaot-System.Drawing.Common.dll.so'

None of the user's code is listed, only NuGet packages. :)