### PR TITLE
[aot] Make ExtraAotOptions parameter useful

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -400,6 +400,13 @@ when packaging Release applications.
 
     This property is `True` by default.
 
+-   **AndroidExtraAotOptions** &ndash; A string property that allows to
+    pass additional options to the mono, when precompiling assemblies
+    in `Aot` task. It is added to the response file, when calling mono
+    as a cross-compiler.
+
+    Added in Xamarin.Android v10.3.
+
 -   **AndroidFastDeploymentType** &ndash; A `:` (colon)-separated list
     of values to control what types can be deployed to the
     [Fast Deployment directory](#Fast_Deployment) on the target device

--- a/Documentation/release-notes/3935.md
+++ b/Documentation/release-notes/3935.md
@@ -1,0 +1,8 @@
+### Add `$(AndroidExtraAotOptions)` MSBuild Property
+
+The new `$(AndroidExtraAotOptions)` MSBuild property can be used to pass
+additional options to mono when precompiling assemblies in the
+`<Aot/>` task.
+
+The contents of `$(AndroidExtraAotOptions)` are added to the response file,
+when calling mono as a cross-compiler.

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -415,7 +415,7 @@ namespace Xamarin.Android.Tasks
 					string aotOptionsStr = (EnableLLVM ? "--llvm " : "") + $"\"--aot={string.Join (",", aotOptions)}\"";
 
 					if (!string.IsNullOrEmpty (ExtraAotOptions)) {
-						aotOptionsStr += (aotOptions.Count > 0 ? "," : "") + ExtraAotOptions;
+						aotOptionsStr += (aotOptions.Count > 0 ? " " : "") + ExtraAotOptions;
 					}
 
 					// Due to a Monodroid MSBuild bug we can end up with paths to assemblies that are not in the intermediate

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -44,9 +44,11 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = true,
 				AndroidEnableProfiledAot = true,
 			};
+			proj.SetProperty (proj.ActiveConfigurationProperties, "AndroidExtraAotOptions", "--verbose");
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				StringAssertEx.ContainsRegex (@"\[aot-compiler stdout\] Using profile data file.*build.Xamarin.Android.startup\.aotprofile", b.LastBuildOutput, "Should use default AOT profile", RegexOptions.IgnoreCase);
+				StringAssertEx.ContainsRegex (@"\[aot-compiler stdout\] Method.*emitted at", b.LastBuildOutput, "Should contain verbose AOT compiler output", RegexOptions.IgnoreCase);
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2712,6 +2712,7 @@ because xbuild doesn't support framework reference assemblies.
 	SupportedAbis="@(_BuildTargetAbis)"
 	AndroidSequencePointsMode="$(_SequencePointsMode)"
 	AotAdditionalArguments="$(AndroidAotAdditionalArguments)"
+	ExtraAotOptions="$(AndroidExtraAotOptions)"
 	ResolvedAssemblies="@(_ResolvedUserAssemblies);@(_ShrunkFrameworkAssemblies)"
 	AotOutputDirectory="$(_AndroidAotBinDirectory)"
 	IntermediateAssemblyDir="$(MonoAndroidIntermediateAssemblyDir)"


### PR DESCRIPTION
The `ExtraAotOptions` parameter of Aot task was not used in our
targets. It was also added with comma as separator, which doesn't make
sense.

Make it possible to set by `$(AndroidExtraAotOptions)` property.

With these changes it can be used for example to get more information
from the mono aot compiler by adding `--verbose` option.

Like:

    xabuild /t:Clean\;SignAndroidPackage /p:Configuration=Release /v:diag /p:AndroidExtraAotOptions=--verbose /p:AndroidEnableProfiledAot=true my.csproj

where the output contains:

    [AOT] MONO_PATH="/Users/rodo/Projects/xatemplateaot/xatemplateaot/obj/Release/android/assets/shrunk" MONO_ENV_OPTIONS="" /Users/rodo/git/xa-master/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/Darwin/cross-x86 --response=obj/Release/aot/x86/System.dll/response.txt (TaskId:238)
    [AOT] response file obj/Release/aot/x86/System.dll/response.txt: "--aot=profile-only,profile=/Users/rodo/git/xa-master/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/startup.aotprofile,msym-dir=obj/Release/aot/x86,outfile=obj/Release/aot/x86/libaot-System.dll.so,asmwriter,mtriple=i686-linux-android,tool-prefix=/Users/rodo/git/xa-master/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/Darwin/ndk/i686-linux-android-,llvm-path=/Users/rodo/git/xa-master/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/Darwin,temp-path=obj/Release/aot/x86/System.dll,ld-flags=" --verbose /Users/rodo/Projects/xatemplateaot/xatemplateaot/obj/Release/android/assets/shrunk/System.dll
     (TaskId:238)
    [aot-compiler stdout] Mono Ahead of Time compiler - compiling assembly /Users/rodo/Projects/xatemplateaot/xatemplateaot/obj/Release/android/assets/shrunk/System.dll (TaskId:238)
    [aot-compiler stdout] AOTID 1DA42427-3BCF-5131-0C65-D35BCA22257E (TaskId:238)
    [aot-compiler stdout] Using profile data file '/Users/rodo/git/xa-master/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/startup.aotprofile' (TaskId:238)
    [aot-compiler stdout] Added 4 methods from profile. (TaskId:238)
    [aot-compiler stdout] converting method void Mono.SystemCertificateProvider:.ctor () (TaskId:238)
    [aot-compiler stdout] Method void Mono.SystemCertificateProvider:.ctor () emitted at 0x10efb2000 to 0x10efb2019 (code length 25) [System.dll] (TaskId:238)
    [aot-compiler stdout] converting method void Mono.SystemDependencyProvider:Initialize () (TaskId:238)
    [aot-compiler stdout] Method void Mono.SystemDependencyProvider:Initialize () emitted at 0x10efb2600 to 0x10efb26f2 (code length 242) [System.dll] (TaskId:238)
    [aot-compiler stdout] converting method void Mono.SystemDependencyProvider:.ctor () (TaskId:238)
    [aot-compiler stdout] Method void Mono.SystemDependencyProvider:.ctor () emitted at 0x10efb2700 to 0x10efb2755 (code length 85) [System.dll] (TaskId:238)
    [aot-compiler stdout] converting method void Mono.SystemDependencyProvider:.cctor () (TaskId:238)
    [aot-compiler stdout] Method void Mono.SystemDependencyProvider:.cctor () emitted at 0x10efb2760 to 0x10efb2799 (code length 57) [System.dll] (TaskId:238)
    [aot-compiler stdout] Method void Mono.SystemCertificateProvider:.ctor () emitted as .Lm_0 (TaskId:238)
    [aot-compiler stdout] Method void Mono.SystemDependencyProvider:Initialize () emitted as .Lm_1 (TaskId:238)
    [aot-compiler stdout] Method void Mono.SystemDependencyProvider:.ctor () emitted as .Lm_2 (TaskId:238)
    [aot-compiler stdout] Method void Mono.SystemDependencyProvider:.cctor () emitted as .Lm_3 (TaskId:238)
    [aot-compiler stdout] Compiled: 4/4 (TaskId:238)
    [aot-compiler stdout] Executing the native assembler: "/Users/rodo/git/xa-master/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/Darwin/ndk/i686-linux-android-as" --32  -o obj/Release/aot/x86/System.dll/temp.s.o obj/Release/aot/x86/System.dll/temp.s (TaskId:238)
    [aot-compiler stdout] Executing the native linker: "/Users/rodo/git/xa-master/bin/Debug/lib/xamarin.android/xbuild/Xamarin/Android/Darwin/ndk/i686-linux-android-ld" -m elf_i386 -shared -o obj/Release/aot/x86/libaot-System.dll.so.tmp  obj/Release/aot/x86/System.dll/temp.s.o  (TaskId:238)
    [aot-compiler stdout] JIT time: 1 ms, Generation time: 1 ms, Assembly+Link time: 13 ms. (TaskId:238)