### PR TITLE
Set the default $(AndroidSupportedTargetAotAbis) value

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -76,6 +76,7 @@
     <GradleArgs Condition=" '$(GradleArgs)' == '' ">--stacktrace --no-daemon</GradleArgs>
     <AndroidSupportedHostJitAbis Condition=" '$(AndroidSupportedHostJitAbis)' == '' ">$(HostOS)</AndroidSupportedHostJitAbis>
     <AndroidSupportedTargetAotAbis Condition=" '$(AndroidSupportedTargetAotAbis)' == ''  And '$(HostOS)' == 'Windows' ">armeabi-v7a:arm64:x86:x86_64:win-armeabi-v7a:win-arm64:win-x86:win-x86_64</AndroidSupportedTargetAotAbis>
+    <AndroidSupportedTargetAotAbis Condition=" '$(AndroidSupportedTargetAotAbis)' == '' ">armeabi-v7a:arm64:x86:x86_64</AndroidSupportedTargetAotAbis>
     <AndroidSupportedTargetJitAbis Condition=" '$(AndroidSupportedTargetJitAbis)' == ''  And '$(HostOS)' == 'Windows' ">armeabi-v7a:arm64-v8a:x86:x86_64</AndroidSupportedTargetJitAbis>
     <AndroidSupportedTargetJitAbis Condition=" '$(AndroidSupportedTargetJitAbis)' == '' ">armeabi-v7a:arm64-v8a:x86</AndroidSupportedTargetJitAbis>
     <JavaInteropSourceDirectory Condition=" '$(JavaInteropSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\Java.Interop</JavaInteropSourceDirectory>


### PR DESCRIPTION
Recently I run into missing AOT cross compilers after successful
build.

Turned out the prepare step (`make prepare`) uses
`$(AndroidSupportedTargetAotAbis` value and it wasn't set on my
system.

Not sure why it was working before for me (maybe I had
`Configuration.Override.props` in place?), but now when the AOT is
non-enterprise feature, we should set that.

This is how part of my prepare step looked like:

    =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    Configured targets
    =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

    Enabled Mono Android runtime ABIs:
      * armeabi-v7a
      * arm64-v8a
      * x86

    Enabled Mono host runtimes:
      * Darwin

    Enabled Mono cross compilers:
      NONE

    Enabled LLVM cross compilers:
      NONE