### PR TITLE
[Xamarin.Android.Build.Tasks] Use PKCS12 Key Store format

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -1163,6 +1163,8 @@ server, the following MSBuild properties can be used:
     key store file format to use for the `debug.keystore`. It defaults
     to `pkcs12`.
 
+    Added in Xamarin.Android v10.3.
+
 -   **AndroidKeyStore** &ndash; A boolean value which indicates whether
     custom signing information should be used. The default value is
     `False`, meaning that the default debug-signing key will be used

--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -1159,6 +1159,10 @@ server, the following MSBuild properties can be used:
     validity to use for the `debug.keystore`. It defaults to
     `10950` or `30 * 365` or `30 years`.
 
+-   **AndroidDebugStoreType** &ndash; Specifies the default
+    key store file format to use for the `debug.keystore`. It defaults
+    to `pkcs12`.
+
 -   **AndroidKeyStore** &ndash; A boolean value which indicates whether
     custom signing information should be used. The default value is
     `False`, meaning that the default debug-signing key will be used

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidCreateDebugKey.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidCreateDebugKey.cs
@@ -13,11 +13,14 @@ namespace Xamarin.Android.Tasks
 
 		public string KeyAlgorithm { get; set; }
 
+		public string StoreType { get; set; }
+
 		string dname = "CN=Android Debug,O=Android,C=US";
 
 		public AndroidCreateDebugKey ()
 		{
 			KeyAlgorithm = "RSA";
+			StoreKey = "pkcs12";
 			Validity = 30 * 365; // 30 years
 		}
 
@@ -27,6 +30,7 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitchIfNotNull ("-dname ", dname);
 			cmd.AppendSwitchIfNotNull ("-keyalg ", KeyAlgorithm);
 			cmd.AppendSwitchIfNotNull ("-validity ", Validity.ToString()); 
+			cmd.AppendSwitchIfNotNull ("-deststoretype ", StoreKey);
 			return cmd;
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidCreateDebugKey.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidCreateDebugKey.cs
@@ -9,20 +9,13 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "ACD";
 
-		public int Validity { get; set; }
+		public int Validity { get; set; } = 30 * 365;
 
-		public string KeyAlgorithm { get; set; }
+		public string KeyAlgorithm { get; set; } = "RSA";
 
-		public string StoreType { get; set; }
+		public string StoreType { get; set; } = "pkcs12";
 
 		string dname = "CN=Android Debug,O=Android,C=US";
-
-		public AndroidCreateDebugKey ()
-		{
-			KeyAlgorithm = "RSA";
-			StoreType = "pkcs12";
-			Validity = 30 * 365; // 30 years
-		}
 
 		protected override CommandLineBuilder CreateCommandLine ()
 		{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidCreateDebugKey.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidCreateDebugKey.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Android.Tasks
 		public AndroidCreateDebugKey ()
 		{
 			KeyAlgorithm = "RSA";
-			StoreKey = "pkcs12";
+			StoreType = "pkcs12";
 			Validity = 30 * 365; // 30 years
 		}
 
@@ -30,7 +30,7 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitchIfNotNull ("-dname ", dname);
 			cmd.AppendSwitchIfNotNull ("-keyalg ", KeyAlgorithm);
 			cmd.AppendSwitchIfNotNull ("-validity ", Validity.ToString()); 
-			cmd.AppendSwitchIfNotNull ("-deststoretype ", StoreKey);
+			cmd.AppendSwitchIfNotNull ("-deststoretype ", StoreType);
 			return cmd;
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidCreateDebugKey.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidCreateDebugKey.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitchIfNotNull ("-dname ", dname);
 			cmd.AppendSwitchIfNotNull ("-keyalg ", KeyAlgorithm);
 			cmd.AppendSwitchIfNotNull ("-validity ", Validity.ToString()); 
-			cmd.AppendSwitchIfNotNull ("-deststoretype ", StoreType);
+			cmd.AppendSwitchIfNotNull ("-storetype ", StoreType);
 			return cmd;
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidCreateDebugKey.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidCreateDebugKey.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "ACD";
 
-		public int Validity { get; set; } = 30 * 365;
+		public int Validity { get; set; } = 30 * 365; // 30 years
 
 		public string KeyAlgorithm { get; set; } = "RSA";
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/KeyToolTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/KeyToolTests.cs
@@ -127,5 +127,40 @@ namespace Xamarin.Android.Build.Tests
 			Assert.AreEqual ("keytool error: java.io.IOException: Keystore was tampered with, or password was incorrect", error.Message);
 			Assert.AreEqual ("ANDKT0000", error.Code);
 		}
+
+		[Test]
+		public void CreateDebugKeyStore ()
+		{
+			string keyfile = Path.Combine (TestName, "debug.keystore");
+			if (File.Exists (keyfile))
+				File.Delete (keyfile);
+			var task = new AndroidCreateDebugKey {
+				BuildEngine = engine,
+				KeyStore = keyfile,
+				StorePass = "android",
+				KeyAlias = "androiddebugkey",
+				KeyPass = "android",
+				KeyAlgorithm="RSA",
+				Validity=10000,
+				StoreType="pkcs12",
+				Command="-genkeypair",
+				ToolPath = keyToolPath,
+			};
+			Assert.IsTrue (task.Execute (), "Task should have succeeded.");
+			Assert.AreEqual (0, errors.Count, "Task should have no errors.");
+			Assert.AreEqual (0, warnings.Count, "Task should have no warnings.");
+
+			var keyToolTask = new KeyTool {
+				BuildEngine = engine,
+				KeyStore = keyfile,
+				StorePass = "android",
+				KeyAlias = "androiddebugkey",
+				KeyPass = "android",
+				Command = "-list",
+				ToolPath = keyToolPath,
+			};
+
+			Assert.IsTrue (keyToolTask.Execute (), "Task should have succeeded.");
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -267,6 +267,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 	<AndroidDebugKeyAlgorithm Condition=" '$(AndroidDebugKeyAlgorithm)' == '' ">RSA</AndroidDebugKeyAlgorithm>
 	<AndroidDebugKeyValidity Condition=" '$(AndroidDebugKeyValidity)' == '' ">10950</AndroidDebugKeyValidity>
+	<AndroidDebugStoreType Condition=" '$(AndroidDebugStoreType)' == '' ">pkcs12</AndroidDebugStoreType>
 
   <!-- Backward compatibility options -->
   <AndroidBoundExceptionType Condition=" '$(AndroidBoundExceptionType)' == '' ">Java</AndroidBoundExceptionType>
@@ -2947,6 +2948,7 @@ because xbuild doesn't support framework reference assemblies.
 		KeyAlias="androiddebugkey"
 		KeyPass="android"
 		StorePass="android"
+		StoreType="$(AndroidDebugStoreType)"
 		KeyAlgorithm="$(AndroidDebugKeyAlgorithm)"
 		Validity="$(AndroidDebugKeyValidity)"
 		ToolPath="$(KeytoolToolPath)"


### PR DESCRIPTION
We have recently started to see the following error
```
rror ANDKT0000: keytool error: java.lang.Exception: Key pair not generated, alias <androiddebugkey> already exists
```

Looking at the logs, we see the following warning issued further up.

```
message ANDKT0000: androiddebugkey, Nov 25, 2019, PrivateKeyEntry, [/Users/runner/runners/2.160.1/work/1/s/bin/TestRelease/temp/CodeBehind/SuccessfulBuildFew/Release/CommonSampleLibrary/CommonSampleLibrary.csproj] (TaskId:476)
message ANDKT0000: Certificate fingerprint (SHA1): 8F:DE:A1:AF:26:8B:E7:02:4D:D0:57:86:F4:81:4F:B7:4A:80:60:AA [/Users/runner/runners/2.160.1/work/1/s/bin/TestRelease/temp/CodeBehind/SuccessfulBuildFew/Release/CommonSampleLibrary/CommonSampleLibrary.csproj] (TaskId:476)
message ANDKT0000: Warning: The JKS keystore uses a proprietary format. It is recommended to migrate to PKCS12 which is an industry standard format using "keytool -importkeystore -srckeystore /Users/runner/.local/share/Xamarin/Mono for Android/debug.keystore -destkeystore /Users/runner/.local/share/Xamarin/Mono for Android/debug.keystore -deststoretype pkcs12". [/Users/runner/runners/2.160.1/work/1/s/bin/TestRelease/temp/CodeBehind/SuccessfulBuildFew/Release/CommonSampleLibrary/CommonSampleLibrary.csproj] (TaskId:476)
```

While this is not an error we should take note of the warning and update our code. 
So we should make use of the `-storetype` argument to specify which format the keystore should be saved in. The recommendation is `pkcs12`. This only applies to the `debug.keystore` as it 