### PR TITLE
[Xamarin.Android.Build.Tasks] Handle Ref Assemblies from Nuget

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -85,7 +85,8 @@ namespace Xamarin.Android.Tasks
 				foreach (var assembly in Assemblies) {
 					// Add each user assembly and all referenced assemblies (recursive)
 					string resolved_assembly = resolver.Resolve (assembly.ItemSpec);
-					if (MonoAndroidHelper.IsReferenceAssembly (resolved_assembly)) {
+					bool refAssembly = !string.IsNullOrEmpty (assembly.GetMetadata ("NuGetPackageId")) && resolved_assembly.Contains ($"{Path.PathSeparator }ref{Path.PathSeparator }");
+					if (refAssembly || MonoAndroidHelper.IsReferenceAssembly (resolved_assembly)) {
 						// Resolve "runtime" library
 						if (lockFile != null)
 							resolved_assembly = ResolveRuntimeAssemblyForReferenceAssembly (lockFile, assembly.ItemSpec);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -85,7 +85,7 @@ namespace Xamarin.Android.Tasks
 				foreach (var assembly in Assemblies) {
 					// Add each user assembly and all referenced assemblies (recursive)
 					string resolved_assembly = resolver.Resolve (assembly.ItemSpec);
-					bool refAssembly = !string.IsNullOrEmpty (assembly.GetMetadata ("NuGetPackageId")) && resolved_assembly.Contains ($"{Path.PathSeparator }ref{Path.PathSeparator }");
+					bool refAssembly = !string.IsNullOrEmpty (assembly.GetMetadata ("NuGetPackageId")) && resolved_assembly.Contains ($"{Path.DirectorySeparatorChar}ref{Path.DirectorySeparatorChar}");
 					if (refAssembly || MonoAndroidHelper.IsReferenceAssembly (resolved_assembly)) {
 						// Resolve "runtime" library
 						if (lockFile != null)
@@ -177,6 +177,8 @@ namespace Xamarin.Android.Tasks
 			}
 			foreach (var folder in lockFile.PackageFolders) {
 				var path = assemblyPath.Replace (folder.Path, string.Empty);
+				if (path.StartsWith ($"{Path.DirectorySeparatorChar}"))
+					path = path.Substring (1);
 				var libraryPath = lockFile.Libraries.FirstOrDefault (x => path.StartsWith (x.Path.Replace('/', Path.DirectorySeparatorChar), StringComparison.OrdinalIgnoreCase));
 				if (libraryPath == null)
 					continue;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -715,6 +715,7 @@ namespace App1
 				File.WriteAllText (Path.Combine (Root, xab.ProjectDirectory, "NuGet.config"), @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
   <packageSources>
+    <add key='nuget.org' value='https://api.nuget.org/v3/index.json' protocolVersion='3' />
     <add key='bug-testing' value='..\' />
   </packageSources>
 </configuration>");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -644,5 +644,84 @@ namespace App1
 				}
 			}
 		}
+
+		[Test]
+		public void CheckTheCorrectRuntimeAssemblyIsUsedFromNuget ()
+		{
+			string path = Path.Combine (Root, "temp", TestName);
+			var ns = new DotNetStandard () {
+				ProjectName = "Dummy",
+				Sdk = "MSBuild.Sdk.Extras/2.0.54",
+				Sources = {
+					new BuildItem.Source ("Class1.cs") {
+						TextContent = () => @"public class Class1 {
+#if __ANDROID__
+	public static string Library => ""Android"";
+#else
+	public static string Library => "".NET Standard"";
+#endif
+}",
+					},
+				},
+				OtherBuildItems = {
+					new BuildItem.NoActionResource ("$(OutputPath)netstandard2.0\\$(AssemblyName).dll") {
+						TextContent = null,
+						BinaryContent = null,
+						Metadata = {
+							{ "PackagePath", "ref\\netstandard2.0" },
+							{ "Pack", "True" }
+						},
+					},
+					new BuildItem.NoActionResource ("$(OutputPath)monoandroid90\\$(AssemblyName).dll") {
+						TextContent = null,
+						BinaryContent = null,
+						Metadata = {
+							{ "PackagePath", "lib\\monoandroid90" },
+							{ "Pack", "True" }
+						},
+					},
+				},
+			};
+			ns.SetProperty ("TargetFrameworks", "netstandard2.0;monoandroid90");
+			ns.SetProperty ("PackageId", "dummy.package.foo");
+			ns.SetProperty ("PackageVersion", "1.0.0");
+			ns.SetProperty ("GeneratePackageOnBuild", "True");
+			ns.SetProperty ("IncludeBuildOutput", "False");
+			ns.SetProperty ("Summary", "Test");
+			ns.SetProperty ("Description", "Test");
+			ns.SetProperty ("PackageOutputPath", path);
+
+			
+			var xa = new XamarinAndroidApplicationProject () {
+				ProjectName = "App",
+				PackageReferences = {
+					new Package () {
+						Id = "dummy.package.foo",
+						Version = "1.0.0",
+					},
+				},
+				OtherBuildItems = {
+					new BuildItem.NoActionResource ("NuGet.config") {
+					},
+				},
+			};
+			xa.SetProperty ("RestoreNoCache", "true");
+			xa.SetProperty ("RestorePackagesPath", "$(MSBuildThisFileDirectory)packages");
+			using (var nsb = CreateDllBuilder (Path.Combine (path, ns.ProjectName), cleanupAfterSuccessfulBuild: false, cleanupOnDispose: false))
+			using (var xab = CreateApkBuilder (Path.Combine (path, xa.ProjectName), cleanupAfterSuccessfulBuild: false, cleanupOnDispose: false)) {
+				nsb.ThrowOnBuildFailure = xab.ThrowOnBuildFailure = false;
+				Assert.IsTrue (nsb.Build (ns));
+				Assert.IsFalse (xab.Build (xa, doNotCleanupOnUpdate: true));
+				File.WriteAllText (Path.Combine (Root, xab.ProjectDirectory, "NuGet.config"), @"<?xml version='1.0' encoding='utf-8'?>
+<configuration>
+  <packageSources>
+    <add key='bug-testing' value='..\' />
+  </packageSources>
+</configuration>");
+				Assert.IsTrue (xab.Build (xa, doNotCleanupOnUpdate: true));
+				string expected = Path.Combine ("dummy.package.foo", "1.0.0", "lib", "monoandroid90", "Dummy.dll");
+				Assert.IsTrue (xab.LastBuildOutput.ContainsText (expected), $"Build should be using {expected}");
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -710,15 +710,15 @@ namespace App1
 			using (var nsb = CreateDllBuilder (Path.Combine (path, ns.ProjectName), cleanupAfterSuccessfulBuild: false, cleanupOnDispose: false))
 			using (var xab = CreateApkBuilder (Path.Combine (path, xa.ProjectName), cleanupAfterSuccessfulBuild: false, cleanupOnDispose: false)) {
 				nsb.ThrowOnBuildFailure = xab.ThrowOnBuildFailure = false;
-				Assert.IsTrue (nsb.Build (ns));
-				Assert.IsFalse (xab.Build (xa, doNotCleanupOnUpdate: true));
+				Assert.IsTrue (nsb.Build (ns), "Build of NetStandard Library should have succeeded.");
+				Assert.IsFalse (xab.Build (xa, doNotCleanupOnUpdate: true), "Build of App Library should have failed.");
 				File.WriteAllText (Path.Combine (Root, xab.ProjectDirectory, "NuGet.config"), @"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
   <packageSources>
     <add key='bug-testing' value='..\' />
   </packageSources>
 </configuration>");
-				Assert.IsTrue (xab.Build (xa, doNotCleanupOnUpdate: true));
+				Assert.IsTrue (xab.Build (xa, doNotCleanupOnUpdate: true), "Build of App Library should have succeeded.");
 				string expected = Path.Combine ("dummy.package.foo", "1.0.0", "lib", "monoandroid90", "Dummy.dll");
 				Assert.IsTrue (xab.LastBuildOutput.ContainsText (expected), $"Build should be using {expected}");
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -716,7 +716,7 @@ namespace App1
 <configuration>
   <packageSources>
     <add key='nuget.org' value='https://api.nuget.org/v3/index.json' protocolVersion='3' />
-    <add key='bug-testing' value='..\' />
+    <add key='bug-testing' value='..' />
   </packageSources>
 </configuration>");
 				Assert.IsTrue (xab.Build (xa, doNotCleanupOnUpdate: true), "Build of App Library should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using NUnit.Framework;
 using Xamarin.ProjectTools;
@@ -648,6 +648,10 @@ namespace App1
 		[Test]
 		public void CheckTheCorrectRuntimeAssemblyIsUsedFromNuget ()
 		{
+			string monoandroidFramework;
+			using (var builder = new Builder ()) {
+				monoandroidFramework = builder.LatestMultiTargetFrameworkVersion ();
+			}
 			string path = Path.Combine (Root, "temp", TestName);
 			var ns = new DotNetStandard () {
 				ProjectName = "Dummy",
@@ -672,17 +676,17 @@ namespace App1
 							{ "Pack", "True" }
 						},
 					},
-					new BuildItem.NoActionResource ("$(OutputPath)monoandroid90\\$(AssemblyName).dll") {
+					new BuildItem.NoActionResource ($"$(OutputPath){monoandroidFramework}\\$(AssemblyName).dll") {
 						TextContent = null,
 						BinaryContent = null,
 						Metadata = {
-							{ "PackagePath", "lib\\monoandroid90" },
+							{ "PackagePath", $"lib\\{monoandroidFramework}" },
 							{ "Pack", "True" }
 						},
 					},
 				},
 			};
-			ns.SetProperty ("TargetFrameworks", "netstandard2.0;monoandroid90");
+			ns.SetProperty ("TargetFrameworks", $"netstandard2.0;{monoandroidFramework}");
 			ns.SetProperty ("PackageId", "dummy.package.foo");
 			ns.SetProperty ("PackageVersion", "1.0.0");
 			ns.SetProperty ("GeneratePackageOnBuild", "True");
@@ -720,7 +724,7 @@ namespace App1
   </packageSources>
 </configuration>");
 				Assert.IsTrue (xab.Build (xa, doNotCleanupOnUpdate: true), "Build of App Library should have succeeded.");
-				string expected = Path.Combine ("dummy.package.foo", "1.0.0", "lib", "monoandroid90", "Dummy.dll");
+				string expected = Path.Combine ("dummy.package.foo", "1.0.0", "lib", monoandroidFramework, "Dummy.dll");
 				Assert.IsTrue (xab.LastBuildOutput.ContainsText (expected), $"Build should be using {expected}");
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/Builder.cs
@@ -167,6 +167,15 @@ namespace Xamarin.ProjectTools
 			return lastFrameworkVersion;
 		}
 
+		public string LatestMultiTargetFrameworkVersion ()
+		{
+			GetTargetFrameworkVersionRange (out string _, out string _, out string _, out string lastFrameworkVersion);
+			lastFrameworkVersion = lastFrameworkVersion.Replace ("v", string.Empty);
+			if (lastFrameworkVersion != "10.0")
+				lastFrameworkVersion = lastFrameworkVersion.Replace (".", string.Empty);
+			return $"monoandroid{lastFrameworkVersion}";
+		}
+
 		public string LatestTargetFrameworkVersion (out string apiLevel) {
 			GetTargetFrameworkVersionRange (out string _, out string _, out apiLevel, out string lastFrameworkVersion);
 			return lastFrameworkVersion;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetStandard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetStandard.cs
@@ -71,7 +71,7 @@ namespace Xamarin.ProjectTools
 					if (bi.DependentUpon != null) sb.Append ($"DependentUpon=\"{bi.DependentUpon ()}\" ");
 					if (bi.Version != null) sb.Append ($"Version=\"{bi.Version ()}\" ");
 					if (bi.SubType != null) sb.Append ($"SubType=\"{bi.SubType ()}\" ");
-					if (bi.Metadata.Any ()) {
+					if (!bi.Metadata.Any ()) {
 						sb.AppendLine ($"\t\t/>");
 					} else {
 						sb.AppendLine ($">");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -56,8 +56,9 @@ namespace Xamarin.ProjectTools
 
 				// Copy our solution's NuGet.config
 				var nuget_config = Path.Combine (XABuildPaths.TopDirectory, "NuGet.config");
-				if (File.Exists (nuget_config)) {
-					File.Copy (nuget_config, Path.Combine (Root, ProjectDirectory, "NuGet.config"), overwrite: true);
+				var dest = Path.Combine (Root, ProjectDirectory, "NuGet.config");
+				if (File.Exists (nuget_config) && !File.Exists (dest)) {
+					File.Copy (nuget_config, dest, overwrite: true);
 				}
 			}
 			else

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -270,7 +270,7 @@ namespace Xamarin.ProjectTools
 				string filedir = directory;
 				if (path.Contains (Path.DirectorySeparatorChar)) {
 					filedir = Path.GetDirectoryName (path);
-					if (!Directory.Exists (filedir))
+					if (!Directory.Exists (filedir) && (p.Content != null || p.BinaryContent != null))
 						Directory.CreateDirectory (filedir);
 				}
 


### PR DESCRIPTION
Fixes #3920

In the bug report we had a situation we had not come across before. The assembly 
in the `ref` folder of the Nuget did NOT have the `ReferenceAssembly`Attribute on it.
As a result we never switched it out for the `monodroid90` one during build time. 
It turns out that having the `ReferenceAssembly` Attribute is not always going to 
identify a `ReferenceAssembly` from Nuget. We should also be looking at the path
the file is in. In this case reference assemblies are always in a path with `ref` in it. 
So lets look for that as well as the attribute. 

This PR also adds a unit test to make sure we do the right thing in this situation.