### PR TITLE
[monodroid] don't start the debugger if not configured

### DIFF
--- a/src/monodroid/jni/debug.cc
+++ b/src/monodroid/jni/debug.cc
@@ -211,8 +211,11 @@ Debug::start_debugging_and_profiling ()
 	char *connect_args;
 	androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_CONNECT_PROPERTY, &connect_args);
 
-	if (connect_args != nullptr && strcmp (connect_args, "") != 0) {
-		DebuggerConnectionStatus res = start_connection (connect_args);
+	if (connect_args != nullptr) {
+		DebuggerConnectionStatus res = DebuggerConnectionStatus::Unconnected;
+		if (strcmp (connect_args, "") != 0) {
+			res = start_connection (connect_args);
+		}
 		if (res == DebuggerConnectionStatus::Error) {
 			log_fatal (LOG_DEBUGGER, "Could not start a connection to the debugger with connection args '%s'.", connect_args);
 			exit (FATAL_EXIT_DEBUGGER_CONNECT);

--- a/src/monodroid/jni/debug.hh
+++ b/src/monodroid/jni/debug.hh
@@ -9,6 +9,13 @@
 #ifdef __cplusplus
 namespace xamarin::android
 {
+	enum class DebuggerConnectionStatus : int
+	{
+		Connected = 1,
+		Unconnected = 0,
+		Error = -1,
+	};
+
 	class Debug
 	{
 	private:
@@ -53,7 +60,7 @@ namespace xamarin::android
 		void         start_debugging_and_profiling ();
 
 	private:
-		int          start_connection (char *options);
+		DebuggerConnectionStatus start_connection (char *options);
 		void         parse_options (char *options, ConnOptions *opts);
 		bool         process_connection (int fd);
 		int          handle_server_connection (void);


### PR DESCRIPTION
In a Debug build of `samples/HelloWorld`, startup was taking way longer
than a Release build:

    Debug build:
    ActivityTaskManager: Displayed com.xamarin.android.helloworld/example.MainActivity: +2s689ms
    Release build:
    ActivityTaskManager: Displayed com.xamarin.android.helloworld/example.MainActivity: +678ms

In this case I was launching the app with no debugger attached. Why is
it *so* much slower?

Reading through `debug.cc` and the `start_connection` method, the
return values and comments did not quite match up--or make sense.

It seemed that even though `conn_port` is 0, it was trying to connect
the debugger? I believe this check needed to actually return 2:

    if (!conn_port)
        return 0;

I changed this line, and reworked things to use an `enum` instead of
an `int`. Everything seems clearer now.

After this change we are now down to:

    ActivityTaskManager: Displayed com.xamarin.android.helloworld/example.MainActivity: +725ms

This is a ~2 second startup improvement for debug builds when no
debugger is attached.