### PR TITLE
[monodroid] add timing message for the debugger

### DIFF
--- a/src/monodroid/jni/debug.cc
+++ b/src/monodroid/jni/debug.cc
@@ -237,9 +237,7 @@ Debug::start_debugging_and_profiling ()
 
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
 		total_time.mark_end ();
-
-		timing_diff diff (total_time);
-		log_info (LOG_TIMING, "start_debugging_and_profiling; elapsed: %lis:%lu::%lu", diff.sec, diff.ms, diff.ns);
+		Timing::info (total_time, "Debug::start_debugging_and_profiling: end");
 	}
 }
 

--- a/src/monodroid/jni/debug.cc
+++ b/src/monodroid/jni/debug.cc
@@ -210,6 +210,10 @@ Debug::start_connection (char *options)
 void
 Debug::start_debugging_and_profiling ()
 {
+	timing_period total_time;
+	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
+		total_time.mark_start ();
+
 	char *connect_args;
 	androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_CONNECT_PROPERTY, &connect_args);
 
@@ -229,6 +233,13 @@ Debug::start_debugging_and_profiling ()
 			start_profiling ();
 		}
 		delete[] connect_args;
+	}
+
+	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
+		total_time.mark_end ();
+
+		timing_diff diff (total_time);
+		log_info (LOG_TIMING, "start_debugging_and_profiling; elapsed: %lis:%lu::%lu", diff.sec, diff.ms, diff.ns);
 	}
 }
 


### PR DESCRIPTION
This adds a useful timing message for Debug builds:

    11-20 16:05:55.683 10984 10984 I monodroid-timing: start_debugging_and_profiling; elapsed: 2s:0::94210

If it really takes 2 seconds like this, it should be easier for us to spot going forward.