### PR TITLE
Fix invalid AOT mode reporting code

### DIFF
--- a/src/monodroid/jni/android-system.cc
+++ b/src/monodroid/jni/android-system.cc
@@ -676,7 +676,7 @@ AndroidSystem::setup_environment ()
 				break;
 		}
 
-		if (aotMode == MonoAotMode::MONO_AOT_MODE_LAST)
+		if (aotMode != MonoAotMode::MONO_AOT_MODE_LAST)
 			log_info (LOG_DEFAULT, "Mono AOT mode: %s", mono_aot_mode_name);
 		else
 			log_warn (LOG_DEFAULT, "Unknown Mono AOT mode: %s", mono_aot_mode_name);


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/3940#issuecomment-556147250

The check for unknown AOT mode was inverted. Fix by using the correct,
inequality, operator.