### PR TITLE
[Xamarin.Android.Build.Tasks] skip _WriteLockFile by default

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -401,7 +401,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Aapt2.targets" />
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.SkipCases.projitems" />
 
-<Target Name="_WriteLockFile">
+<Target Name="_WriteLockFile" Condition=" '$(_AndroidDetectParallelBuilds)' == 'True' ">
   <WriteLockFile LockFile="$(IntermediateOutputPath).__lock" />
 </Target>
 


### PR DESCRIPTION
In bf4c3781, we added a warning to detect parallel builds on the same
Xamarin.Android project. This was meant to be a feature for finding
bugs in the IDEs.

However, there appears to be a case this is causing a lot of noise in
Visual Studio for Windows:

1. The user hits F5 / or the play button
2. The IDE runs a build and gets a status back it was successful.
3. The IDE runs the `Install` target.

On step 3, we are randomly getting the warning?

    Xamarin.Android.Common.targets(404,3): warning XA5302: Two processes may be building this project at once. Lock file exists at path: obj\Debug\90\.__lock

It appears that VS is getting a result that the build is finished, but
MSBuild has not cleaned up all `RegisterTaskObject`'s with a `Build`
lifetime:

https://github.com/xamarin/xamarin-android/blob/748dec3f9924836887690655c84472f2890e1f30/src/Xamarin.Android.Build.Tasks/Tasks/WriteLockFile.cs#L55

This might be due to the way VS runs MSBuild, and it runs multiple
MSBuild nodes by default in a solution.

It is worth noting that the file is gone if you just do a build -- and the file
is always gone from command-line builds.

I think we should make a new private `$(_AndroidDetectParallelBuilds)`
MSBuild property that is blank by default. We can turn it on to
diagnose an issue with parallel builds specifically.