### PR TITLE
[build] kill processes after test run

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -220,10 +220,11 @@ stages:
 
     - powershell: |
         Get-Process
-        Stop-Process -Name nunit3-console -ErrorAction SilentlyContinue
-        Stop-Process -Name xabuild -ErrorAction SilentlyContinue
-        Stop-Process -Name MSBuild -ErrorAction SilentlyContinue
-        Stop-Process -Name adb -ErrorAction SilentlyContinue
+        Stop-Process -Name nunit3-console
+        Stop-Process -Name xabuild
+        Stop-Process -Name MSBuild
+        Stop-Process -Name adb
+        $LASTEXITCODE=0
       displayName: kill leftover processes
       condition: always()
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -226,6 +226,7 @@ stages:
         Stop-Process -Name adb
         $LASTEXITCODE=0
       displayName: kill leftover processes
+      failOnStderr: false
       condition: always()
 
     - task: PublishTestResults@2

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -225,7 +225,7 @@ stages:
         Stop-Process -Name xabuild
         Stop-Process -Name MSBuild
         Stop-Process -Name adb
-        $LASTEXITCODE=0
+        $LastExitCode=0
       displayName: kill leftover processes
       failOnStderr: false
       condition: always()

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -218,6 +218,14 @@ stages:
           /bl:$(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\msbuild-run-ji-tests.binlog
       condition: succeededOrFailed()
 
+    - powershell: |
+        Stop-Process -Name nunit3-console
+        Stop-Process -Name xabuild
+        Stop-Process -Name MSBuild
+        Stop-Process -Name adb
+      displayName: kill leftover processes
+      condition: succeededOrFailed()
+
     - task: PublishTestResults@2
       displayName: publish test results
       inputs:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -219,12 +219,13 @@ stages:
       condition: succeededOrFailed()
 
     - powershell: |
-        Stop-Process -Name nunit3-console
-        Stop-Process -Name xabuild
-        Stop-Process -Name MSBuild
-        Stop-Process -Name adb
+        Get-Process
+        Stop-Process -Name nunit3-console -ErrorAction SilentlyContinue
+        Stop-Process -Name xabuild -ErrorAction SilentlyContinue
+        Stop-Process -Name MSBuild -ErrorAction SilentlyContinue
+        Stop-Process -Name adb -ErrorAction SilentlyContinue
       displayName: kill leftover processes
-      condition: succeededOrFailed()
+      condition: always()
 
     - task: PublishTestResults@2
       displayName: publish test results

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -219,6 +219,7 @@ stages:
       condition: succeededOrFailed()
 
     - powershell: |
+        $ErrorActionPreference = 'Continue'
         Get-Process
         Stop-Process -Name nunit3-console
         Stop-Process -Name xabuild

--- a/build-tools/automation/yaml-templates/run-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-nunit-tests.yaml
@@ -17,6 +17,16 @@ steps:
   displayName: run ${{ parameters.testRunTitle }}
   condition: ${{ parameters.condition }}
 
+- powershell: |
+    if ([Environment]::OSVersion.Platform -eq "Win32NT") {
+      Stop-Process -Name nunit3-console
+      Stop-Process -Name xabuild
+      Stop-Process -Name MSBuild
+      Stop-Process -Name adb
+    }
+  displayName: kill leftover processes
+  condition: ${{ parameters.condition }}
+
 - task: PublishTestResults@2
   inputs:
     testResultsFormat: ${{ parameters.testResultsFormat }}

--- a/build-tools/automation/yaml-templates/run-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-nunit-tests.yaml
@@ -25,7 +25,7 @@ steps:
       Stop-Process -Name xabuild
       Stop-Process -Name MSBuild
       Stop-Process -Name adb
-      $LASTEXITCODE=0
+      $LastExitCode=0
     }
   displayName: kill leftover processes
   failOnStderr: false

--- a/build-tools/automation/yaml-templates/run-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-nunit-tests.yaml
@@ -19,6 +19,7 @@ steps:
 
 - powershell: |
     if ([Environment]::OSVersion.Platform -eq "Win32NT") {
+      $ErrorActionPreference = 'Continue'
       Get-Process
       Stop-Process -Name nunit3-console
       Stop-Process -Name xabuild

--- a/build-tools/automation/yaml-templates/run-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-nunit-tests.yaml
@@ -19,13 +19,14 @@ steps:
 
 - powershell: |
     if ([Environment]::OSVersion.Platform -eq "Win32NT") {
-      Stop-Process -Name nunit3-console
-      Stop-Process -Name xabuild
-      Stop-Process -Name MSBuild
-      Stop-Process -Name adb
+      Get-Process
+      Stop-Process -Name nunit3-console -ErrorAction SilentlyContinue
+      Stop-Process -Name xabuild -ErrorAction SilentlyContinue
+      Stop-Process -Name MSBuild -ErrorAction SilentlyContinue
+      Stop-Process -Name adb -ErrorAction SilentlyContinue
     }
   displayName: kill leftover processes
-  condition: ${{ parameters.condition }}
+  condition: always()
 
 - task: PublishTestResults@2
   inputs:

--- a/build-tools/automation/yaml-templates/run-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-nunit-tests.yaml
@@ -20,10 +20,11 @@ steps:
 - powershell: |
     if ([Environment]::OSVersion.Platform -eq "Win32NT") {
       Get-Process
-      Stop-Process -Name nunit3-console -ErrorAction SilentlyContinue
-      Stop-Process -Name xabuild -ErrorAction SilentlyContinue
-      Stop-Process -Name MSBuild -ErrorAction SilentlyContinue
-      Stop-Process -Name adb -ErrorAction SilentlyContinue
+      Stop-Process -Name nunit3-console
+      Stop-Process -Name xabuild
+      Stop-Process -Name MSBuild
+      Stop-Process -Name adb
+      $LASTEXITCODE=0
     }
   displayName: kill leftover processes
   condition: always()

--- a/build-tools/automation/yaml-templates/run-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-nunit-tests.yaml
@@ -27,6 +27,7 @@ steps:
       $LASTEXITCODE=0
     }
   displayName: kill leftover processes
+  failOnStderr: false
   condition: always()
 
 - task: PublishTestResults@2


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3260689&view=logs&j=035e6729-702a-53d4-bea9-761745a9f552&t=282d23f1-1559-55a2-a4d2-5ec0512e57b5&l=3323
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3263297&view=logs&j=cac0e8d3-0ef5-5d2b-b57e-e8fde7204df3&t=e6feceab-89bf-416f-a5f8-0254f16ee003&l=10

We've been seeing cases where if tests timeout on Windows, then
processes remain running.

This causes various problems, such as:

1) Zipping the build artifacts fails with file-sharing issues:

```
    build-tools\Xamarin.Android.Tools.BootstrapTasks\result-packaging.targets(72,5): Error MSB3027:
    Could not copy "E:\A\_work\3\s\bin\TestRelease\temp\BuildProguard Enabled Project(1)Falsedx\obj\Debug\android\bin\classes\mono\android\support\v4\view\accessibility\AccessibilityManagerCompat_AccessibilityStateChangeListenerImplementor.class"
    to "E:\A\_work\3\a\xa-test-results-10.2.99.39_0f23098-Windows-Release\temp\BuildProguard Enabled Project(1)Falsedx\obj\Debug\android\bin\classes\mono\android\support\v4\view\accessibility\AccessibilityManagerCompat_AccessibilityStateChangeListenerImplementor.class".
    Exceeded retry count of 10. Failed.
```

2) A future build on the same machine fails to checkout completely:

```
    [debug]Deleting build directory: 'E:\A\_work\3'
    [error]The process cannot access the file 'E:\A\_work\3\s' because it is being used by another process.
    [debug]System.IO.IOException: The process cannot access the file 'E:\A\_work\3\s' because it is being used by another process.
        at System.IO.FileSystem.RemoveDirectoryInternal(String fullPath, Boolean topLevel, Boolean allowDirectoryNotEmpty)
        at System.IO.FileSystem.RemoveDirectory(String fullPath, Boolean recursive)
        at System.IO.DirectoryInfo.Delete()
        at Microsoft.VisualStudio.Services.Agent.Util.IOUtil.DeleteDirectory(String path, Boolean contentsOnly, Boolean continueOnContentDeleteError, CancellationToken cancellationToken)
        at Microsoft.VisualStudio.Services.Agent.Worker.Build.BuildDirectoryManager.CreateDirectory(IExecutionContext executionContext, String description, String path, Boolean deleteExisting)
        at Microsoft.VisualStudio.Services.Agent.Worker.Build.BuildDirectoryManager.PrepareDirectory(IExecutionContext executionContext, IList`1 repositories, WorkspaceOptions workspace)
        at Microsoft.VisualStudio.Services.Agent.Worker.Build.BuildJobExtension.InitializeJobExtension(IExecutionContext executionContext, IList`1 steps, WorkspaceOptions workspace)
        at Microsoft.VisualStudio.Services.Agent.Worker.JobExtension.InitializeJob(IExecutionContext jobContext, AgentJobRequestMessage message)
```

To solve this issue, I think we should run some powershell to stop a
few processes on Windows:

    Stop-Process -Name nunit3-console
    Stop-Process -Name xabuild
    Stop-Process -Name MSBuild
    Stop-Process -Name adb

This should improve the issues we are seeing here.