### PR TITLE
[Xamarin.Android.Build.Tasks] copy all assembles to android/assets/shrunk

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2042,6 +2042,30 @@ because xbuild doesn't support framework reference assemblies.
   </CreateItem>
 
   <CreateItem
+    Include="@(_ResolvedAssemblies)"
+    Condition="'$(AndroidLinkMode)' == 'None' OR '$(AndroidUseSharedRuntime)' == 'true'">
+    <Output TaskParameter="Include" ItemName="_ShrunkAssemblies" />
+  </CreateItem>
+
+  <CreateItem
+    Include="@(_ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)shrunk\%(Filename)%(Extension)')"
+    Condition="'$(AndroidLinkMode)' != 'None' AND '$(AndroidUseSharedRuntime)' != 'true'">
+    <Output TaskParameter="Include" ItemName="_ShrunkAssemblies" />
+  </CreateItem>
+
+  <CreateItem
+    Include="@(_ResolvedUserAssemblies)"
+    Condition="'$(AndroidLinkMode)' == 'None' OR '$(AndroidUseSharedRuntime)' == 'true'">
+    <Output TaskParameter="Include" ItemName="_ShrunkUserAssemblies" />
+  </CreateItem>
+
+  <CreateItem
+    Include="@(_ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)shrunk\%(Filename)%(Extension)')"
+    Condition="'$(AndroidLinkMode)' != 'None' AND '$(AndroidUseSharedRuntime)' != 'true'">
+    <Output TaskParameter="Include" ItemName="_ShrunkUserAssemblies" />
+  </CreateItem>
+
+  <CreateItem
     Include="@(_ResolvedFrameworkAssemblies)"
     Condition="'$(AndroidLinkMode)' == 'None' OR '$(AndroidUseSharedRuntime)' == 'true'">
     <Output TaskParameter="Include" ItemName="_ShrunkFrameworkAssemblies" />
@@ -2520,20 +2544,19 @@ because xbuild doesn't support framework reference assemblies.
   Condition="'$(AndroidLinkMode)' != 'None' AND '$(AndroidUseSharedRuntime)' != 'true'">
 
   <!-- Make a copy of every assembly into assets\shrunk -->
-  <Copy
-    SourceFiles="@(_ResolvedFrameworkAssemblies)"
-    DestinationFiles="@(_ShrunkFrameworkAssemblies)"
-    SkipUnchangedFiles="true" />
+  <CopyIfChanged
+    SourceFiles="@(_ResolvedAssemblies)"
+    DestinationFiles="@(_ShrunkAssemblies)" />
 
   <CopyIfChanged
-    SourceFiles="@(_ResolvedFrameworkAssemblies->'%(Identity).config')"
-    DestinationFiles="@(_ShrunkFrameworkAssemblies->'%(Identity).config')" />
+    SourceFiles="@(_ResolvedAssemblies->'%(Identity).config')"
+    DestinationFiles="@(_ShrunkAssemblies->'%(Identity).config')" />
   
   <!-- Shrink Mono.Android.dll by removing attribute only needed for GenerateJavaStubs -->
   <RemoveRegisterAttribute
     Condition="'$(AndroidLinkMode)' != 'None' AND '$(AndroidUseSharedRuntime)' != 'true'"
     Deterministic="$(Deterministic)"
-    ShrunkFrameworkAssemblies="@(_ShrunkFrameworkAssemblies)" />
+    ShrunkFrameworkAssemblies="@(_ShrunkAssemblies)" />
 
   <MakeDir Directories="$(MonoAndroidIntermediateAssemblyDir)shrunk" />
   <Touch Files="$(_RemoveRegisterFlag)" AlwaysCreate="true" />
@@ -2678,8 +2701,7 @@ because xbuild doesn't support framework reference assemblies.
 	<_BuildApkEmbedInputs>
 		$(MSBuildAllProjects)
 		;$(_PackagedResources)
-		;@(_ResolvedUserAssemblies)
-		;@(_ShrunkFrameworkAssemblies)
+		;@(_ShrunkAssemblies)
 		;@(AndroidNativeLibrary)
 		;@(_DexFile)
 		;$(_AndroidBuildPropertiesCache)
@@ -2717,7 +2739,7 @@ because xbuild doesn't support framework reference assemblies.
 	AndroidSequencePointsMode="$(_SequencePointsMode)"
 	AotAdditionalArguments="$(AndroidAotAdditionalArguments)"
 	ExtraAotOptions="$(AndroidExtraAotOptions)"
-	ResolvedAssemblies="@(_ResolvedUserAssemblies);@(_ShrunkFrameworkAssemblies)"
+	ResolvedAssemblies="@(_ShrunkAssemblies)"
 	AotOutputDirectory="$(_AndroidAotBinDirectory)"
 	IntermediateAssemblyDir="$(MonoAndroidIntermediateAssemblyDir)"
 	LinkMode="$(AndroidLinkMode)"
@@ -2742,7 +2764,7 @@ because xbuild doesn't support framework reference assemblies.
 		Condition="'$(BundleAssemblies)' == 'True'"
 		KeepTemp="$(AndroidMakeBundleKeepTemporaryFiles)"
 		AndroidNdkDirectory="$(_AndroidNdkDirectory)"
-		Assemblies="@(_ResolvedUserAssemblies);@(_AndroidResolvedSatellitePaths);@(_ShrunkFrameworkAssemblies)"
+		Assemblies="@(_ShrunkAssemblies);@(_AndroidResolvedSatellitePaths)"
 		IncludePath="$(MonoAndroidIncludeDirectory)"
 		SupportedAbis="@(_BuildTargetAbis)"
 		TempOutputPath="$(IntermediateOutputPath)"
@@ -2759,7 +2781,7 @@ because xbuild doesn't support framework reference assemblies.
     BundleAssemblies="$(BundleAssemblies)"
     BundleNativeLibraries="$(_BundleResultNativeLibraries)"
     EmbedAssemblies="$(EmbedAssembliesIntoApk)"
-    ResolvedUserAssemblies="@(_ResolvedUserAssemblies);@(_AndroidResolvedSatellitePaths)"
+    ResolvedUserAssemblies="@(_ShrunkUserAssemblies);@(_AndroidResolvedSatellitePaths)"
     ResolvedFrameworkAssemblies="@(_ShrunkFrameworkAssemblies)"
     NativeLibraries="@(AndroidNativeLibrary)"
     ApplicationSharedLibraries="@(_ApplicationSharedLibrary)"
@@ -2788,7 +2810,7 @@ because xbuild doesn't support framework reference assemblies.
       BundleAssemblies="$(BundleAssemblies)"
       BundleNativeLibraries="$(_BundleResultNativeLibraries)"
       EmbedAssemblies="$(EmbedAssembliesIntoApk)"
-      ResolvedUserAssemblies="@(_ResolvedUserAssemblies);@(_AndroidResolvedSatellitePaths)"
+      ResolvedUserAssemblies="@(_ShrunkUserAssemblies);@(_AndroidResolvedSatellitePaths)"
       ResolvedFrameworkAssemblies="@(_ShrunkFrameworkAssemblies)"
       NativeLibraries="@(AndroidNativeLibrary)"
       ApplicationSharedLibraries="@(_ApplicationSharedLibrary)"


### PR DESCRIPTION
In the case where `$(AndroidLinkMode)` is not `None`, we run a
`<RemoveRegisterAttribute/>` to remove all `[Register]` attributes
from `Mono.Android.dll`. This is a step to save on APK size.

However, we found that the AOT compiler is seeing *two*
`Mono.Android.dll` files:

* obj\Debug\android\assets\Mono.Android.dll
* obj\Debug\android\assets\shrunk\Mono.Android.dll

@vargaz pointed out that this is bad, some of the AOT images will be
linked against the wrong one and fail to load at runtime. We could
possibly be silently falling back to the JIT...

I first attempted to just remove the `shrunk` directory and write
`Mono.Android.dll` *in place*. This idea didn't pan out:

https://github.com/xamarin/xamarin-android/pull/3925#issuecomment-557566329

That idea broke incremental builds... So the next idea is to just copy
*every assembly* into the `android\assets\shrunk` directory. Then the
`AOT` compiler only operates against the `shrunk` directory.

This should only happen during `Release` builds, so the build
performance hit should be OK. We can also investigate removing
`[Register]` from *all* assemblies in a future PR, as that will likely
save further APK size from the support libraries, Google Play
Services, etc.