### PR TITLE
[monodroid] set MONO_AOT_MODE_NONE when AOT is off

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -96,6 +96,7 @@ namespace Xamarin.Android.Tasks
 
 			switch ((androidAotMode ?? string.Empty).ToLowerInvariant().Trim())
 			{
+			case "":
 			case "none":
 				aotMode = AotMode.None;
 				return true;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -148,7 +148,6 @@ namespace Xamarin.Android.Tasks
 			bool usesMonoAOT = false;
 			bool usesAssemblyPreload = EnablePreloadAssembliesDefault;
 			bool brokenExceptionTransitions = false;
-			string androidPackageName = null;
 			var environmentVariables = new Dictionary<string, string> (StringComparer.Ordinal);
 			var systemProperties = new Dictionary<string, string> (StringComparer.Ordinal);
 
@@ -157,7 +156,7 @@ namespace Xamarin.Android.Tasks
 			}
 
 			AotMode aotMode = AotMode.None;
-			if (AndroidAotMode != null && Aot.GetAndroidAotMode (AndroidAotMode, out aotMode)) {
+			if (!string.IsNullOrEmpty (AndroidAotMode) && Aot.GetAndroidAotMode (AndroidAotMode, out aotMode) && aotMode != AotMode.None) {
 				usesMonoAOT = true;
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -224,6 +224,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<!-- Ahead-of-time compilation properties -->
 	<AotAssemblies Condition=" '$(AndroidEnableProfiledAot)' == 'True' ">True</AotAssemblies>
 	<AndroidAotMode Condition=" '$(AndroidAotMode)' == '' And '$(AotAssemblies)' == 'True' ">Normal</AndroidAotMode>
+	<AndroidAotMode Condition=" '$(AndroidAotMode)' == '' ">None</AndroidAotMode>
 	<AotAssemblies Condition=" '$(AndroidAotMode)' != '' And '$(AndroidAotMode)' != 'None' ">True</AotAssemblies>
 	<AotAssemblies Condition=" '$(AotAssemblies)' == '' ">False</AotAssemblies>
 

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -1475,16 +1475,15 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 
 	log_info (LOG_DEFAULT, "Probing for Mono AOT mode\n");
 
+	MonoAotMode mode = MonoAotMode::MONO_AOT_MODE_NONE;
 	if (androidSystem.is_mono_aot_enabled ()) {
-		MonoAotMode mode = androidSystem.get_mono_aot_mode ();
+		mode = androidSystem.get_mono_aot_mode ();
 		if (mode == MonoAotMode::MONO_AOT_MODE_LAST)
 			mode = MonoAotMode::MONO_AOT_MODE_NONE;
-
-		if (mode != MonoAotMode::MONO_AOT_MODE_NORMAL && mode != MonoAotMode::MONO_AOT_MODE_NONE) {
+		if (mode != MonoAotMode::MONO_AOT_MODE_NONE)
 			log_info (LOG_DEFAULT, "Enabling AOT mode in Mono");
-			mono_jit_set_aot_mode (mode);
-		}
 	}
+	mono_jit_set_aot_mode (mode);
 
 	log_info (LOG_DEFAULT, "Probing if we should use LLVM\n");
 


### PR DESCRIPTION
I was profiling an app's startup in `Debug` mode, and I saw it
printing a lot of stuff:

    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Trying to load shared library '/data/user/0/com.xamarin.android.helloworld/files/.__override__/libaot-HelloWorld.dll.so'
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Shared library '/data/user/0/com.xamarin.android.helloworld/files/.__override__/libaot-HelloWorld.dll.so' not found
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Trying to load shared library '/storage/emulated/0/Android/data/com.xamarin.android.helloworld/files/.__override__/libaot-HelloWorld.dll.so'
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Shared library '/storage/emulated/0/Android/data/com.xamarin.android.helloworld/files/.__override__/libaot-HelloWorld.dll.so' not found
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Trying to load shared library '/storage/emulated/0/../legacy/Android/data/com.xamarin.android.helloworld/files/.__override__/libaot-HelloWorld.dll.so'
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Shared library '/storage/emulated/0/../legacy/Android/data/com.xamarin.android.helloworld/files/.__override__/libaot-HelloWorld.dll.so' not
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Trying to load shared library '/data/app/com.xamarin.android.helloworld-F-gJdEOFfesdG4KjFIuCsQ==/lib/arm64/libaot-HelloWorld.dll.so'
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Shared library '/data/app/com.xamarin.android.helloworld-F-gJdEOFfesdG4KjFIuCsQ==/lib/arm64/libaot-HelloWorld.dll.so' not found
    11-22 15:01:30.994  5616  5616 D Mono    : AOT: image '/storage/emulated/0/Android/data/com.xamarin.android.helloworld/files/.__override__/HelloWorld.dll.so' not found: (null)
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Trying to load shared library '/Users/builder/jenkins/workspace/archive-mono/2019-08/android/release/sdks/out/android-arm64-v8a-release/lib/mono/aot-cache/arm64/HelloWorld.dll.so'
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Shared library '/Users/builder/jenkins/workspace/archive-mono/2019-08/android/release/sdks/out/android-arm64-v8a-release/lib/mono/aot-cache/arm64/HelloWorld.dll.so' not found
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Trying to load shared library '/Users/builder/jenkins/workspace/archive-mono/2019-08/android/release/sdks/out/android-arm64-v8a-release/lib/mono/aot-cache/arm64/HelloWorld.dll.so'
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Shared library '/Users/builder/jenkins/workspace/archive-mono/2019-08/android/release/sdks/out/android-arm64-v8a-release/lib/mono/aot-cache/arm64/HelloWorld.dll.so' not found
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Trying to load shared library '/Users/builder/jenkins/workspace/archive-mono/2019-08/android/release/sdks/out/android-arm64-v8a-release/lib/mono/aot-cache/arm64/HelloWorld.dll.so'
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Shared library '/Users/builder/jenkins/workspace/archive-mono/2019-08/android/release/sdks/out/android-arm64-v8a-release/lib/mono/aot-cache/arm64/HelloWorld.dll.so' not found
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Trying to load shared library '/Users/builder/jenkins/workspace/archive-mono/2019-08/android/release/sdks/out/android-arm64-v8a-release/lib/mono/aot-cache/arm64/HelloWorld.dll.so'
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Shared library '/Users/builder/jenkins/workspace/archive-mono/2019-08/android/release/sdks/out/android-arm64-v8a-release/lib/mono/aot-cache/arm64/HelloWorld.dll.so' not found
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Trying to load shared library '/data/user/0/com.xamarin.android.helloworld/files/.__override__/libaot-HelloWorld.dll.so'
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Shared library '/data/user/0/com.xamarin.android.helloworld/files/.__override__/libaot-HelloWorld.dll.so' not found
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Trying to load shared library '/storage/emulated/0/Android/data/com.xamarin.android.helloworld/files/.__override__/libaot-HelloWorld.dll.so'
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Shared library '/storage/emulated/0/Android/data/com.xamarin.android.helloworld/files/.__override__/libaot-HelloWorld.dll.so' not found
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Trying to load shared library '/storage/emulated/0/../legacy/Android/data/com.xamarin.android.helloworld/files/.__override__/libaot-HelloWorld.dll.so'
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Shared library '/storage/emulated/0/../legacy/Android/data/com.xamarin.android.helloworld/files/.__override__/libaot-HelloWorld.dll.so' not found
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Trying to load shared library '/data/app/com.xamarin.android.helloworld-F-gJdEOFfesdG4KjFIuCsQ==/lib/arm64/libaot-HelloWorld.dll.so'
    11-22 15:01:30.994  5616  5616 I monodroid-assembly: Shared library '/data/app/com.xamarin.android.helloworld-F-gJdEOFfesdG4KjFIuCsQ==/lib/arm64/libaot-HelloWorld.dll.so' not found
    11-22 15:01:30.994  5616  5616 D Mono    : AOT: image '/Users/builder/jenkins/workspace/archive-mono/2019-08/android/release/sdks/out/android-arm64-v8a-release/lib/mono/aot-cache/arm64/HelloWorld.dll.so' not found: (null)

It seems like we are probing 25 locations for the AOT'd assembly, and
AOT is not even on at all?

I saw some issues on the MSBuild side as well as runtime:

1. By default `$(AndroidAotMode)` is blank, and at build time we emit a `true` value for `application_config.uses_mono_aot` in this case.
2. At runtime, we don't ever call `mono_jit_set_aot_mode (MonoAotMode::MONO_AOT_MODE_NONE);` and Mono seems to default to AOT being enabled.

So a few fixes:

1. Let's default `$(AndroidAotMode)` to `None` if AOT is off to be more explicit.
2. `application_config.uses_mono_aot` will no longer be `true` when AOT is off.
3. I fixed up the runtime to be sure `mono_jit_set_aot_mode` is always called.

Now I no longer get any of these AOT-related log messages.

The results are not dramatic, but still *something*:

    Before:
    11-22 15:01:14.122  5346  5346 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:181::786164
    11-22 15:01:22.907  5406  5406 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:172::393454
    11-22 15:01:24.902  5460  5460 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:169::927569
    11-22 15:01:27.080  5511  5511 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:171::83402
    11-22 15:01:29.061  5568  5568 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:172::116997
    11-22 15:01:30.983  5616  5616 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:169::82048
    After:
    11-22 14:52:54.753  4605  4605 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:178::299914
    11-22 14:53:02.152  4707  4707 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:165::750746
    11-22 14:53:05.063  4764  4764 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:165::530538
    11-22 14:53:07.395  4819  4819 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:165::721214
    11-22 14:53:09.678  4878  4878 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:169::361579
    11-22 14:53:11.921  4931  4931 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:166::757309

It seems like this might save ~10ms on startup for non-AOT apps.

I also removed a random `string androidPackageName = null;`
declaration that is unused.