### PR TITLE
[monodroid] check return value of monodroid_get_system_property

### DIFF
--- a/src/monodroid/jni/debug.cc
+++ b/src/monodroid/jni/debug.cc
@@ -212,7 +212,7 @@ Debug::start_debugging_and_profiling ()
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
 		total_time.mark_start ();
 
-	char *connect_args;
+	char *connect_args = nullptr;
 	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_CONNECT_PROPERTY, &connect_args) > 0) {
 		DebuggerConnectionStatus res = start_connection (connect_args);
 		if (res == DebuggerConnectionStatus::Error) {

--- a/src/monodroid/jni/debug.cc
+++ b/src/monodroid/jni/debug.cc
@@ -213,13 +213,8 @@ Debug::start_debugging_and_profiling ()
 		total_time.mark_start ();
 
 	char *connect_args;
-	androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_CONNECT_PROPERTY, &connect_args);
-
-	if (connect_args != nullptr) {
-		DebuggerConnectionStatus res = DebuggerConnectionStatus::Unconnected;
-		if (strcmp (connect_args, "") != 0) {
-			res = start_connection (connect_args);
-		}
+	if (androidSystem.monodroid_get_system_property (Debug::DEBUG_MONO_CONNECT_PROPERTY, &connect_args) > 0) {
+		DebuggerConnectionStatus res = start_connection (connect_args);
 		if (res == DebuggerConnectionStatus::Error) {
 			log_fatal (LOG_DEBUGGER, "Could not start a connection to the debugger with connection args '%s'.", connect_args);
 			exit (FATAL_EXIT_DEBUGGER_CONNECT);
@@ -231,8 +226,8 @@ Debug::start_debugging_and_profiling ()
 			start_debugging ();
 			start_profiling ();
 		}
-		delete[] connect_args;
 	}
+	delete[] connect_args;
 
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
 		total_time.mark_end ();


### PR DESCRIPTION
In a26e0dbf, I fixed a 2 second delay on startup, which was somewhat
perplexing... It helped by 2 seconds regardless if a debugger was
present or not.

It turned out that a `""` returned from `monodroid_get_system_property`
was the actual root cause of the issue. Luckily, this issue was only
present on d16-5 and master.

We think checking the return value of `monodroid_get_system_property`
is most appropriate. I changed this call to look the same as the rest
of the calls in `monodroid`.