### PR TITLE
Delete 32-bit libzip.so, as the package is pure x64 only.

### DIFF
--- a/build-tools/debian-metadata/rules
+++ b/build-tools/debian-metadata/rules
@@ -22,6 +22,7 @@ override_dh_install:
 	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/aapt2.exe
 	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/libwinpthread-1.dll
 	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/libzip.dll
+	rm -f bin/*/lib/xamarin.android/xbuild/Xamarin/Android/libzip.so
 
 	dh_install
 


### PR DESCRIPTION
Ought to resolve `dpkg-shlibdeps: error: cannot find library libcrypto.so.1.1 needed by debian/xamarin.android-oss/usr/lib/xamarin.android/xbuild/Xamarin/Android/libzip.so (ELF format: 'elf32-i386' abi: '0101000300000000'; RPATH: '')`