### PR TITLE
[tests] add [NonParallelizable] to CheckLintErrorsAndWarnings

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1713,6 +1713,7 @@ namespace App1
 		}
 
 		[Test]
+		[NonParallelizable]
 		public void CheckLintErrorsAndWarnings ()
 		{
 			FixLintOnWindows ();


### PR DESCRIPTION
Context: https://build.azdo.io/3267504

We have seen a random failure such as:

    /Library/Frameworks/Mono.framework/Versions/6.8.0/lib/mono/msbuild/Current/bin/NuGet.targets(123,5): error : Could not find file '/Users/runner/.nuget/packages/xamarin.android.support.constraint.layout.solver/1.0.2.2/63mg83ek.7t8'.

Normally, we just add `[NonParallelizable]` to workaround problems
like this.