### PR TITLE
[tests] workaround ANDKT0000 error

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidCreateDebugKey.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidCreateDebugKey.cs
@@ -21,6 +21,17 @@ namespace Xamarin.Android.Tasks
 			Validity = 30 * 365; // 30 years
 		}
 
+		public override bool Execute ()
+		{
+			//TODO: this should actually return early and not run base.Execute()
+			// Let it go on for now, to see if we get the warning
+			if (File.Exists (KeyStore)) {
+				Log.LogWarning ($"File already exists at: {KeyStore}");
+			}
+
+			return base.Execute ();
+		}
+
 		protected override CommandLineBuilder CreateCommandLine ()
 		{
 			var cmd = base.CreateCommandLine ();


### PR DESCRIPTION
We are randomly getting the failure:

    Xamarin.Android.Common.targets(2944,2): error ANDKT0000: keytool error: java.lang.Exception: Key pair not generated, alias <androiddebugkey> already exists

We run a lot of tests in parallel and it seems like two builds are
running `_CreateAndroidDebugSigningKey` at once.

There is an `Exists` check in the MSBuild target:

    <Target Name="_CreateAndroidDebugSigningKey"
            Condition="!Exists ('$(_ApkDebugKeyStore)') And '$(AndroidKeyStore)' != 'True' "

To verify this is what might be happening, I added a `LogWarning` call
*inside* the `<AndroidCreateDebugKey/>` MSBuild task. Maybe we could
just return early if we hit this?