### PR TITLE
[monodroid] don't probe for .exe files

### DIFF
--- a/src/monodroid/jni/embedded-assemblies-zip.cc
+++ b/src/monodroid/jni/embedded-assemblies-zip.cc
@@ -119,7 +119,7 @@ EmbeddedAssemblies::zip_load_entries (int fd, const char *apk_name, monodroid_sh
 			continue;
 		}
 
-		if (!(utils.ends_with (file_name, ".dll") || utils.ends_with (file_name, ".exe")))
+		if (!utils.ends_with (file_name, ".dll"))
 			continue;
 
 		if (entry_is_overridden)

--- a/src/monodroid/jni/embedded-assemblies.hh
+++ b/src/monodroid/jni/embedded-assemblies.hh
@@ -29,12 +29,6 @@ namespace xamarin::android::internal {
 #if defined (DEBUG) || !defined (ANDROID)
 		static constexpr char override_typemap_entry_name[] = ".__override__";
 #endif
-		static constexpr const char *suffixes[] = {
-			"",
-			".dll",
-			".exe",
-		};
-		static constexpr size_t SUFFIXES_SIZE = sizeof(suffixes) / sizeof (suffixes[0]);
 
 	public:
 		/* filename is e.g. System.dll, System.dll.mdb, System.pdb */

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -293,28 +293,23 @@ MonodroidRuntime::open_from_update_dir (MonoAssemblyName *aname, char **assembli
 
 	simple_pointer_guard<char[]> pname (pname_raw_ptr);
 
-	constexpr const char *formats[] = {
-		"%s" MONODROID_PATH_SEPARATOR "%s",
-		"%s" MONODROID_PATH_SEPARATOR "%s.dll",
-		"%s" MONODROID_PATH_SEPARATOR "%s.exe",
-	};
-	constexpr size_t nformats = sizeof (formats)/sizeof (formats [0]);
+	constexpr const char *format_none = "%s" MONODROID_PATH_SEPARATOR "%s";
+	constexpr const char *format_dll  = "%s" MONODROID_PATH_SEPARATOR "%s.dll";
 
-	for (size_t fi = 0; fi < nformats && result == nullptr; ++fi) {
-		for (uint32_t oi = 0; oi < AndroidSystem::MAX_OVERRIDES; ++oi) {
-			override_dir = androidSystem.get_override_dir (oi);
-			if (override_dir == nullptr || !utils.directory_exists (override_dir))
-				continue;
+	for (uint32_t oi = 0; oi < AndroidSystem::MAX_OVERRIDES; ++oi) {
+		override_dir = androidSystem.get_override_dir (oi);
+		if (override_dir == nullptr || !utils.directory_exists (override_dir))
+			continue;
 
-			simple_pointer_guard<char, false> fullpath (utils.monodroid_strdup_printf (formats [fi], override_dir, pname.get ()));
+		const char *format = utils.ends_with (name, ".dll") ? format_none : format_dll;
+		simple_pointer_guard<char, false> fullpath (utils.monodroid_strdup_printf (format, override_dir, pname.get ()));
 
-			log_info (LOG_ASSEMBLY, "open_from_update_dir: trying to open assembly: %s\n", static_cast<const char*>(fullpath));
-			if (utils.file_exists (fullpath))
-				result = mono_assembly_open_full (fullpath, nullptr, 0);
-			if (result) {
-				// TODO: register .mdb, .pdb file
-				break;
-			}
+		log_info (LOG_ASSEMBLY, "open_from_update_dir: trying to open assembly: %s\n", static_cast<const char*>(fullpath));
+		if (utils.file_exists (fullpath))
+			result = mono_assembly_open_full (fullpath, nullptr, 0);
+		if (result) {
+			// TODO: register .mdb, .pdb file
+			break;
 		}
 	}
 

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -307,7 +307,7 @@ MonodroidRuntime::open_from_update_dir (MonoAssemblyName *aname, char **assembli
 		log_info (LOG_ASSEMBLY, "open_from_update_dir: trying to open assembly: %s\n", static_cast<const char*>(fullpath));
 		if (utils.file_exists (fullpath))
 			result = mono_assembly_open_full (fullpath, nullptr, 0);
-		if (result) {
+		if (result != nullptr) {
 			// TODO: register .mdb, .pdb file
 			break;
 		}


### PR DESCRIPTION
I was noticing a lot of logging like this:

    11-25 13:14:59.430 13111 13111 I monodroid-assembly: open_from_update_dir: trying to open assembly: /data/user/0/com.xamarin.android.helloworld/files/.__override__/mscorlib.dll
    11-25 13:14:59.431 13111 13111 I monodroid-assembly: open_from_update_dir: trying to open assembly: /storage/emulated/0/Android/data/com.xamarin.android.helloworld/files/.__override__/mscorlib.dll
    11-25 13:14:59.431 13111 13111 I monodroid-assembly: open_from_update_dir: trying to open assembly: /data/user/0/com.xamarin.android.helloworld/files/.__override__/mscorlib.dll.dll
    11-25 13:14:59.431 13111 13111 I monodroid-assembly: open_from_update_dir: trying to open assembly: /storage/emulated/0/Android/data/com.xamarin.android.helloworld/files/.__override__/mscorlib.dll.dll
    11-25 13:14:59.431 13111 13111 I monodroid-assembly: open_from_update_dir: trying to open assembly: /data/user/0/com.xamarin.android.helloworld/files/.__override__/mscorlib.dll.exe
    11-25 13:14:59.431 13111 13111 I monodroid-assembly: open_from_update_dir: trying to open assembly: /storage/emulated/0/Android/data/com.xamarin.android.helloworld/files/.__override__/mscorlib.dll.exe
    11-25 13:14:59.431 13111 13111 I monodroid-assembly: open_from_bundles: looking for bundled name: 'mscorlib.dll'
    11-25 13:14:59.431 13111 13111 D Mono    : Image addref mscorlib[0x7f74876f3f00] (asmctx DEFAULT) -> mscorlib.dll[0x7f747fb32000]: 2

A couple things we could do here is:

1. Don't probe for `.exe` files at all. We don't even consider `.exe`
   files at build time anymore since e3907027.
2. Check if the name ends with `.dll` to decide if `.dll` should be
   appended when probing.

This change is needed in both `open_from_update_dir` and
`open_from_bundles`.

Now the probing is cut down to:

    11-25 13:24:42.060 16492 16492 I monodroid-assembly: open_from_update_dir: trying to open assembly: /data/user/0/com.xamarin.android.helloworld/files/.__override__/mscorlib.dll
    11-25 13:24:42.060 16492 16492 I monodroid-assembly: open_from_update_dir: trying to open assembly: /storage/emulated/0/Android/data/com.xamarin.android.helloworld/files/.__override__/mscorlib.dll
    11-25 13:24:42.060 16492 16492 I monodroid-assembly: open_from_bundles: looking for bundled name: 'mscorlib.dll'
    11-25 13:24:42.063 16492 16492 D Mono    : Image addref mscorlib[0x7f74876f2f80] (asmctx DEFAULT) -> mscorlib.dll[0x7f747fb33000]: 2

## Results ##

Using the `samples\HelloWorld` app in this repo, on a Pixel 3 XL:

    Before:
    11-25 12:00:42.863 31251 31251 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:165::704288
    11-25 12:00:44.997 31306 31306 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:165::558089
    11-25 12:00:47.137 31359 31359 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:165::936683
    11-25 12:00:49.201 31412 31412 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:164::536735
    11-25 12:00:51.330 31464 31464 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:166::357204
    After:
    11-25 12:08:34.160 32331 32331 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:165::597673
    11-25 12:08:37.022 32384 32384 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:164::106162
    11-25 12:08:39.237 32439 32439 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:164::997516
    11-25 12:08:41.841 32490 32490 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:164::931683
    11-25 12:08:44.731 32551 32551 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:164::95381

My guess is this is a 1-2ms improvement on this device.

So then I tried an x86 emulator using HAXM:

    Before:
    11-25 13:19:06.679 14703 14703 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:501::511300
    11-25 13:19:09.191 14753 14753 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:545::571100
    11-25 13:19:11.902 14827 14827 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:555::89900
    11-25 13:19:15.503 14880 14880 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:541::920000
    11-25 13:19:18.377 14981 14981 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:509::316700
    After:
    11-25 13:27:24.287 17169 17169 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:472::543900
    11-25 13:27:26.777 17216 17216 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:446::208700
    11-25 13:27:29.369 17265 17265 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:469::216400
    11-25 13:27:31.977 17313 17313 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:420::160500
    11-25 13:27:34.700 17357 17357 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:437::225200

Here the improvement might be more like 50-75ms. I will probably focus
on timing the HAXM emulator from now on, since I am focusing on
improving the developer loop here.