### PR TITLE
Bump to xamarin/java.interop@dec2e390

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -214,7 +214,7 @@ stages:
         configuration: $(XA.Build.Configuration)
         msbuildArguments: >
           /t:RunJavaInteropTests
-          /p:TestAssembly="bin\Test$(XA.Build.Configuration)\generator-Tests.dll;bin\Test$(XA.Build.Configuration)\Java.Interop.Tools.JavaCallableWrappers-Tests.dll;bin\Test$(XA.Build.Configuration)\LogcatParse-Tests.dll;bin\Test$(XA.Build.Configuration)\Xamarin.Android.Tools.ApiXmlAdjuster-Tests.dll;bin\Test$(XA.Build.Configuration)\Xamarin.Android.Tools.Bytecode-Tests.dll"
+          /p:TestAssembly="bin\Test$(XA.Build.Configuration)\generator-Tests.dll;bin\Test$(XA.Build.Configuration)\Java.Interop.Tools.JavaCallableWrappers-Tests.dll;bin\Test$(XA.Build.Configuration)\logcat-parse-Tests.dll;bin\Test$(XA.Build.Configuration)\Xamarin.Android.Tools.ApiXmlAdjuster-Tests.dll;bin\Test$(XA.Build.Configuration)\Xamarin.Android.Tools.Bytecode-Tests.dll"
           /bl:$(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\msbuild-run-ji-tests.binlog
       condition: succeededOrFailed()
 


### PR DESCRIPTION
  * xamarin/java.interop@dec2e39: Convert Test projects to SDK style projects. (#517)
  * xamarin/java.interop@439bd83: [XA.Tools.Bytecode] Add Kotlin support to our binding process. (#505)
  * xamarin/java.interop@5fa8c18: [Java.Interop] Replace Gendarme with Roslyn FxCop Analyzers (#523)
  * xamarin/java.interop@7558ca1: Bump to mono/cecil/master@a6a7f5c0 (#524)