### PR TITLE
Add new targets for AOT profiling

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -120,23 +120,25 @@ The following build targets are defined for Xamarin.Android projects:
     IDE when new resources are added to the project.
 
 -   **BuildAndStartAotProfiling** &ndash; Builds the package with
-    embedded aot profiler, sets aot profiler socket port to
-    $(AndroidAotProfilerPort) and starts the *launch* activity.
+    embedded AOT profiler, sets the AOT profiler socket port to
+    `$(AndroidAotProfilerPort)` and starts the *launch* activity.
 
     Added in Xamarin.Android v10.3.
 
--   **FinishAotProfiling** &ndash; Collects the aot profiler data from
+-   **FinishAotProfiling** &ndash; Collects the AOT profiler data from
     the device or the emulator through sockets port
-    $(AndroidAotProfilerPort) and writes them to
-    $(AndroidAotCustomProfilePath).
+    `$(AndroidAotProfilerPort)` and writes them to
+    `$(AndroidAotCustomProfilePath)`.
 
     The default values for port and custom profile are `9999` and
     `custom.aprof`.
 
-    This is equivalent to `aprofutil $(AProfUtilExtraOptions) -s -v -f -p $(AndroidAotProfilerPort) -o "$(AndroidAotCustomProfilePath)"`
-
-    The `aprofutil` call might be extended with
+    The `aprofutil` call may be extended with
     `$(AProfUtilExtraOptions)`, to pass additional options.
+
+    This is equivalent to:
+    
+        aprofutil $(AProfUtilExtraOptions) -s -v -f -p $(AndroidAotProfilerPort) -o "$(AndroidAotCustomProfilePath)"
 
     Added in Xamarin.Android v10.3.
 

--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -119,6 +119,27 @@ The following build targets are defined for Xamarin.Android projects:
     `Resource.designer.cs` file. This target is usually called by the
     IDE when new resources are added to the project.
 
+-   **BuildAndStartAotProfiling** &ndash; Builds the package with
+    embedded aot profiler, sets aot profiler socket port to
+    $(AndroidAotProfilerPort) and starts the *launch* activity.
+
+    Added in Xamarin.Android v10.3.
+
+-   **FinishAotProfiling** &ndash; Collects the aot profiler data from
+    the device or the emulator through sockets port
+    $(AndroidAotProfilerPort) and writes them to
+    $(AndroidAotCustomProfilePath).
+
+    The default values for port and custom profile are `9999` and
+    `custom.aprof`.
+
+    This is equivalent to `aprofutil $(AProfUtilExtraOptions) -s -v -f -p $(AndroidAotProfilerPort) -o "$(AndroidAotCustomProfilePath)"`
+
+    The `aprofutil` call might be extended with
+    `$(AProfUtilExtraOptions)`, to pass additional options.
+
+    Added in Xamarin.Android v10.3.
+
 <a name="Build_Extension_Points" />
 
 ## Build Extension Points

--- a/Documentation/release-notes/3964.md
+++ b/Documentation/release-notes/3964.md
@@ -1,0 +1,18 @@
+### Add new AOT profiling targets
+
+The new `BuildAndStartAotProfiling` target builds the package with
+embedded aot profiler, sets aot profiler socket port to
+$(AndroidAotProfilerPort) and starts the *launch* activity.
+
+The new `FinishAotProfiling target` collects the aot profiler data
+from the device or the emulator through sockets port
+$(AndroidAotProfilerPort) and writes them to
+$(AndroidAotCustomProfilePath).
+
+The default values for port and custom profile are `9999` and
+`custom.aprof`.
+
+This is equivalent to `aprofutil $(AProfUtilExtraOptions) -s -v -f -p $(AndroidAotProfilerPort) -o "$(AndroidAotCustomProfilePath)"`
+
+The `aprofutil` call might be extended with
+`$(AProfUtilExtraOptions)`, to pass additional options.

--- a/Documentation/release-notes/3964.md
+++ b/Documentation/release-notes/3964.md
@@ -1,18 +1,21 @@
 ### Add new AOT profiling targets
 
 The new `BuildAndStartAotProfiling` target builds the package with
-embedded aot profiler, sets aot profiler socket port to
-$(AndroidAotProfilerPort) and starts the *launch* activity.
+embedded AOT profiler, sets AOT profiler socket port to
+`$(AndroidAotProfilerPort)` and starts the *launch* activity.
 
-The new `FinishAotProfiling target` collects the aot profiler data
+The new `FinishAotProfiling` target collects the AOT profiler data
 from the device or the emulator through sockets port
-$(AndroidAotProfilerPort) and writes them to
-$(AndroidAotCustomProfilePath).
+`$(AndroidAotProfilerPort)` and writes them to
+`$(AndroidAotCustomProfilePath)`.
 
 The default values for port and custom profile are `9999` and
 `custom.aprof`.
 
-This is equivalent to `aprofutil $(AProfUtilExtraOptions) -s -v -f -p $(AndroidAotProfilerPort) -o "$(AndroidAotCustomProfilePath)"`
-
-The `aprofutil` call might be extended with
+The `aprofutil` call may be extended with
 `$(AProfUtilExtraOptions)`, to pass additional options.
+
+This is equivalent to:
+
+    aprofutil $(AProfUtilExtraOptions) -s -v -f -p $(AndroidAotProfilerPort) -o "$(AndroidAotCustomProfilePath)"
+

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -66,6 +66,23 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
+		[Test, Category ("UsesDevice")]
+		public void BuildBasicApplicationAndAotProfileIt ()
+		{
+			if (!HasDevices)
+				Assert.Ignore ("Skipping test. No devices available.");
+
+			var proj = new XamarinAndroidApplicationProject ();
+			var projDirectory = Path.Combine ("temp", TestName);
+			using (var b = CreateApkBuilder (projDirectory)) {
+				Assert.IsTrue (b.RunTarget (proj, "BuildAndStartAotProfiling"), "Run of BuildAndStartAotProfiling should have succeeded.");
+				System.Threading.Thread.Sleep (5000);
+				Assert.IsTrue (b.RunTarget (proj, "FinishAotProfiling"), "Run of FinishAotProfiling should have succeeded.");
+				var customProfile = Path.Combine (Root, projDirectory, "custom.aprof");
+				FileAssert.Exists (customProfile);
+			}
+		}
+
 		static readonly object [] BuildHasNoWarningsSource = new object [] {
 			new object [] {
 				/* isRelease */     false,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -66,25 +66,6 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
-		[Test, Category ("UsesDevice")]
-		public void BuildBasicApplicationAndAotProfileIt ()
-		{
-			if (!HasDevices)
-				Assert.Ignore ("Skipping test. No devices available.");
-
-			var proj = new XamarinAndroidApplicationProject ();
-			proj.SetProperty (KnownProperties.AndroidSupportedAbis, "armeabi-v7a;x86");
-			var projDirectory = Path.Combine ("temp", TestName);
-			using (var b = CreateApkBuilder (projDirectory)) {
-				Assert.IsTrue (b.RunTarget (proj, "BuildAndStartAotProfiling"), "Run of BuildAndStartAotProfiling should have succeeded.");
-				System.Threading.Thread.Sleep (5000);
-				b.BuildLogFile = "build2.log";
-				Assert.IsTrue (b.RunTarget (proj, "FinishAotProfiling", doNotCleanupOnUpdate: true), "Run of FinishAotProfiling should have succeeded.");
-				var customProfile = Path.Combine (Root, projDirectory, "custom.aprof");
-				FileAssert.Exists (customProfile);
-			}
-		}
-
 		static readonly object [] BuildHasNoWarningsSource = new object [] {
 			new object [] {
 				/* isRelease */     false,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -73,6 +73,7 @@ namespace Xamarin.Android.Build.Tests
 				Assert.Ignore ("Skipping test. No devices available.");
 
 			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty (KnownProperties.AndroidSupportedAbis, "armeabi-v7a;x86");
 			var projDirectory = Path.Combine ("temp", TestName);
 			using (var b = CreateApkBuilder (projDirectory)) {
 				Assert.IsTrue (b.RunTarget (proj, "BuildAndStartAotProfiling"), "Run of BuildAndStartAotProfiling should have succeeded.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -77,6 +77,7 @@ namespace Xamarin.Android.Build.Tests
 			using (var b = CreateApkBuilder (projDirectory)) {
 				Assert.IsTrue (b.RunTarget (proj, "BuildAndStartAotProfiling"), "Run of BuildAndStartAotProfiling should have succeeded.");
 				System.Threading.Thread.Sleep (5000);
+				b.BuildLogFile = "build2.log";
 				Assert.IsTrue (b.RunTarget (proj, "FinishAotProfiling"), "Run of FinishAotProfiling should have succeeded.");
 				var customProfile = Path.Combine (Root, projDirectory, "custom.aprof");
 				FileAssert.Exists (customProfile);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -78,7 +78,7 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (b.RunTarget (proj, "BuildAndStartAotProfiling"), "Run of BuildAndStartAotProfiling should have succeeded.");
 				System.Threading.Thread.Sleep (5000);
 				b.BuildLogFile = "build2.log";
-				Assert.IsTrue (b.RunTarget (proj, "FinishAotProfiling"), "Run of FinishAotProfiling should have succeeded.");
+				Assert.IsTrue (b.RunTarget (proj, "FinishAotProfiling", doNotCleanupOnUpdate: true), "Run of FinishAotProfiling should have succeeded.");
 				var customProfile = Path.Combine (Root, projDirectory, "custom.aprof");
 				FileAssert.Exists (customProfile);
 			}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Application.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Application.targets
@@ -40,6 +40,7 @@ Copyright (C) 2019 Microsoft Corporation. All rights reserved.
     <AndroidAotProfilerPort Condition=" '$(AndroidAotProfilerPort)' == '' ">9999</AndroidAotProfilerPort>
     <_BeginAotProfilingDependsOnTargets>
       _SetupAotProfiling;
+      Build;
       Install;
       _SetAotProfilingPropsOnDevice;
       StartAndroidActivity;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Application.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Application.targets
@@ -35,4 +35,29 @@ Copyright (C) 2019 Microsoft Corporation. All rights reserved.
     </GetAndroidPackageName>
     <Exec Command="&quot;$(AdbToolPath)adb&quot; $(AdbTarget) shell am force-stop &quot;$(_AndroidPackage)&quot;" />
   </Target>
+  <PropertyGroup>
+    <AndroidAotCustomProfilePath Condition=" '$(AndroidAotCustomProfilePath)' == '' ">custom.aprof</AndroidAotCustomProfilePath>
+    <AndroidAotProfilerPort Condition=" '$(AndroidAotProfilerPort)' == '' ">9999</AndroidAotProfilerPort>
+    <_BeginAotProfilingDependsOnTargets>
+      _SetupAotProfiling;
+      Install;
+      _SetAotProfilingPropsOnDevice;
+      StartAndroidActivity;
+    </_BeginAotProfilingDependsOnTargets>
+  </PropertyGroup>
+  <Target Name="_SetupAotProfiling">
+    <PropertyGroup>
+      <AndroidEmbedProfilers>aot</AndroidEmbedProfilers>
+    </PropertyGroup>
+  </Target>
+  <Target Name="_SetAotProfilingPropsOnDevice">
+    <Exec Command="&quot;$(AdbToolPath)adb&quot; $(AdbTarget) shell setprop debug.mono.profile aot:port=$(AndroidAotProfilerPort)" />
+  </Target>
+  <Target Name="BuildAndStartAotProfiling"
+      DependsOnTargets="$(_BeginAotProfilingDependsOnTargets)">
+  </Target>
+  <Target Name="FinishAotProfiling"
+      DependsOnTargets="_ResolveSdks">
+    <Exec Command="&quot;$(MonoAndroidBinDirectory)aprofutil&quot; $(AProfUtilExtraOptions) -s -v -f -p $(AndroidAotProfilerPort) -o &quot;$(AndroidAotCustomProfilePath)&quot;" />
+  </Target>
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1181,6 +1181,7 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="BundleAssemblies=$(BundleAssemblies)" />
 		<_PropertyCacheItems Include="AotAssemblies=$(AotAssemblies)" />
 		<_PropertyCacheItems Include="AndroidAotMode=$(AndroidAotMode)" />
+		<_PropertyCacheItems Include="AndroidEmbedProfilers=$(AndroidEmbedProfilers)" />
 		<_PropertyCacheItems Include="AndroidEnableProfiledAot=$(AndroidEnableProfiledAot)" />
 		<_PropertyCacheItems Include="ExplicitCrunch=$(AndroidExplicitCrunch)" />
 		<_PropertyCacheItems Include="AndroidDexTool=$(AndroidDexTool)" />

--- a/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Android.Build.Tests
 			if (!HasDevices)
 				Assert.Ignore ("Skipping test. No devices available.");
 
-			var proj = new XamarinAndroidApplicationProject ();
+			var proj = new XamarinAndroidApplicationProject () { IsRelease = true };
 			proj.SetProperty (KnownProperties.AndroidSupportedAbis, "armeabi-v7a;x86");
 			var projDirectory = Path.Combine ("temp", TestName);
 			using (var b = CreateApkBuilder (projDirectory)) {

--- a/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
@@ -1,0 +1,29 @@
+﻿using NUnit.Framework;
+using System.IO;
+using Xamarin.ProjectTools;
+
+namespace Xamarin.Android.Build.Tests
+{
+	public class AotProfileTests : DeviceTest
+	{
+
+		[Test]
+		public void BuildBasicApplicationAndAotProfileIt ()
+		{
+			if (!HasDevices)
+				Assert.Ignore ("Skipping test. No devices available.");
+
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty (KnownProperties.AndroidSupportedAbis, "armeabi-v7a;x86");
+			var projDirectory = Path.Combine ("temp", TestName);
+			using (var b = CreateApkBuilder (projDirectory)) {
+				Assert.IsTrue (b.RunTarget (proj, "BuildAndStartAotProfiling"), "Run of BuildAndStartAotProfiling should have succeeded.");
+				System.Threading.Thread.Sleep (5000);
+				b.BuildLogFile = "build2.log";
+				Assert.IsTrue (b.RunTarget (proj, "FinishAotProfiling", doNotCleanupOnUpdate: true), "Run of FinishAotProfiling should have succeeded.");
+				var customProfile = Path.Combine (Root, projDirectory, "custom.aprof");
+				FileAssert.Exists (customProfile);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Implements https://github.com/xamarin/xamarin-android/issues/3792

Add 2 targets to start and finish the profiling. The start target also
builds the project with embedded aot profiler and sets its
options. The finish one collects data from the device/emulator and
writes them to custom.aprof file with aprofutil tool.

Add documentation.

Add test.

Add `AndroidEmbedProfilers` to cached properties, to trigger
rebuild when changed.

Originally I wanted to have also single step process target, which
would use `duration=n` option of the aot profiler. After discussion with
@dellis1972, it looks like it might not be usable for IDEs as it might block
the UI thread. So I didn't implement that one.

Instead I might do it differently by introducing new task to watch for
activity displayed message in the adb logcat output, combined with
timeout. https://github.com/xamarin/xamarin-android/issues/3963