### PR TITLE
[Xamarin.Android.Build.Tasks] remove usage of <CreateItem/>

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Bindings.targets
@@ -221,14 +221,10 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
        Condition="'$(TargetFrameworkMoniker)' != ''"
     />
     </CreateProperty>
-    <CreateItem Include="$(TargetFrameworkMonikerAssemblyAttributesPath)">
-      <Output TaskParameter="Include" ItemName="FileWrites"
-        Condition="'$(TargetFrameworkMonikerAssemblyAttributesPath)' != ''"
-    />
-    </CreateItem>
-    <CreateItem Include="$(_JavaInteropReferences)">
-      <Output TaskParameter="Include" ItemName="Reference" />
-    </CreateItem>
+    <ItemGroup>
+      <FileWrites Include="$(TargetFrameworkMonikerAssemblyAttributesPath)" />
+      <Reference Include="$(_JavaInteropReferences)" />
+    </ItemGroup>
   </Target>
 
   <!-- Find all the needed SDKs -->
@@ -322,10 +318,9 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 			CacheFile="$(_AndroidLibraryImportsCache)">
 		<Output TaskParameter="Jars" ItemName="ExtractedJarImports" />
 	</GetImportedLibraries>
-
-    <CreateItem Include="@(ZippedLibraryProjectJars);@(ExtractedJarImports)">
-      <Output TaskParameter="Include" ItemName="ReferenceJar" />
-    </CreateItem>
+  <ItemGroup>
+    <ReferenceJar Include="@(ZippedLibraryProjectJars);@(ExtractedJarImports)" />
+  </ItemGroup>
 </Target>
 
 <Target Name="_GetLibraryImports" DependsOnTargets="_BuildLibraryImportsCache">
@@ -353,10 +348,9 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 		
     <Touch Files="@(JavaDocJar->'$(IntermediateOutputPath)javadocs\%(FileName).stamp')" />
 		
-    <CreateItem Include="@(JavaDocJar->'$(IntermediateOutputPath)javadocs\%(FileName)\index.html')">
-      <Output TaskParameter="Include" ItemName="JavaDocIndex" />
-    </CreateItem>
-		
+    <ItemGroup>
+      <JavaDocIndex Include="@(JavaDocJar->'$(IntermediateOutputPath)javadocs\%(FileName)\index.html')" />
+    </ItemGroup>
   </Target>
 
   <Target Name="_GenerateJavaDocFromSourceJars"
@@ -377,9 +371,9 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 	
     <Touch Files="@(JavaSourceJar->'$(IntermediateOutputPath)javasources\%(FileName).stamp')" AlwaysCreate="True" />
 		
-    <CreateItem Include="@(JavaSourceJar->'$(IntermediateOutputPath)javadocs\%(FileName)\index.html')">
-      <Output TaskParameter="Include" ItemName="JavaDocIndex" />
-    </CreateItem>
+    <ItemGroup>
+      <JavaDocIndex Include="@(JavaSourceJar->'$(IntermediateOutputPath)javadocs\%(FileName)\index.html')" />
+    </ItemGroup>
 		
   </Target>
 
@@ -444,9 +438,9 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
     <!-- Delete previous generated files if they still exist -->
     <RemoveDirFixed Directories="$(GeneratedOutputPath)" Condition="Exists ('$(GeneratedOutputPath)')" />
 
-    <CreateItem Include="$(IntermediateOutputPath)library_project_annotations\\*.zip">
-      <Output TaskParameter="Include" ItemName="AnnotationsZip" />
-    </CreateItem>
+    <ItemGroup>
+      <AnnotationsZip Include="$(IntermediateOutputPath)library_project_annotations\*.zip" />
+    </ItemGroup>
 		
 	<!-- Create the .cs binding source files -->
     <BindingsGenerator
@@ -476,31 +470,33 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
 
   <Target Name="AddBindingsToCompile" DependsOnTargets="GenerateBindings">
     <!-- Add the files to list of things to be compiled -->
-    <CreateItem Include="$(IntermediateOutputPath)generated\*\*.cs">
-      <Output TaskParameter="Include" ItemName="Compile" />
-    </CreateItem>
+    <ItemGroup>
+      <Compile Include="$(IntermediateOutputPath)generated\*\*.cs" />
+    </ItemGroup>
   </Target>
 
   <Target Name="AddEmbeddedJarsAsResources" DependsOnTargets="GenerateBindings">
-    <CreateItem Include="@(EmbeddedJar)"
-        AdditionalMetadata="LogicalName=%(Filename)%(Extension)">
-      <Output TaskParameter="Include" ItemName="EmbeddedResource" />
-    </CreateItem>
+    <ItemGroup>
+      <EmbeddedResource Include="@(EmbeddedJar)">
+        <LogicalName>%(Filename)%(Extension)</LogicalName>
+      </EmbeddedResource>
+    </ItemGroup>
   </Target>
 
   <Target Name="AddEmbeddedReferenceJarsAsResources" DependsOnTargets="GenerateBindings">
-    <CreateItem Include="@(EmbeddedReferenceJar)"
-                AdditionalMetadata="LogicalName=__reference__%(FileName)%(Extension)">
-      <Output TaskParameter="Include" ItemName="EmbeddedResource" />
-    </CreateItem>
+    <ItemGroup>
+      <EmbeddedResource Include="@(EmbeddedReferenceJar)">
+        <LogicalName>__reference__%(Filename)%(Extension)</LogicalName>
+      </EmbeddedResource>
+    </ItemGroup>
   </Target>
 
   <Target Name="AddLibraryProjectsToCompile" DependsOnTargets="ResolveLibraryProjects">
-    <CreateItem Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip"
-        Condition="Exists ('$(IntermediateOutputPath)__AndroidLibraryProjects__.zip')"
-        AdditionalMetadata="LogicalName=__AndroidLibraryProjects__.zip">
-      <Output TaskParameter="Include" ItemName="EmbeddedResource" />
-    </CreateItem>
+    <ItemGroup Condition="Exists ('$(IntermediateOutputPath)__AndroidLibraryProjects__.zip')">
+      <EmbeddedResource Include="$(IntermediateOutputPath)__AndroidLibraryProjects__.zip">
+        <LogicalName>__AndroidLibraryProjects__.zip</LogicalName>
+      </EmbeddedResource>
+    </ItemGroup>
   </Target>
   
   <Target Name="ResolveLibraryProjects"
@@ -515,9 +511,9 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
   </Target>
 
   <Target Name="AddLibraryJarsToBind" DependsOnTargets="ResolveLibraryProjects">
-    <CreateItem Include="$(IntermediateOutputPath)library_project_jars\\*.jar">
-      <Output TaskParameter="Include" ItemName="InputJar" />
-    </CreateItem>
+    <ItemGroup>
+      <InputJar Include="$(IntermediateOutputPath)library_project_jars\*.jar" />
+    </ItemGroup>
   </Target>
 
   <Target Name="BuildDocumentation"
@@ -609,11 +605,11 @@ Copyright (C) 2012 Xamarin Inc. All rights reserved.
   </Target>
 
   <Target Name="_AddNativeLibraryArchiveToCompile" DependsOnTargets="_CreateNativeLibraryArchive">
-    <CreateItem Include="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip"
-                Condition="Exists ('$(IntermediateOutputPath)__AndroidNativeLibraries__.zip')"
-                AdditionalMetadata="LogicalName=__AndroidNativeLibraries__.zip">
-      <Output TaskParameter="Include" ItemName="EmbeddedResource" />
-    </CreateItem>
+    <ItemGroup Condition="Exists('$(IntermediateOutputPath)__AndroidNativeLibraries__.zip')">
+      <EmbeddedResource Include="$(IntermediateOutputPath)__AndroidNativeLibraries__.zip">
+        <LogicalName>__AndroidNativeLibraries__.zip</LogicalName>
+      </EmbeddedResource>
+    </ItemGroup>
   </Target>
 
   <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.PCLSupport.targets" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -407,13 +407,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 </Target>
 
 <Target Name="_SeparateAppExtensionReferences">
-	<CreateItem Include="@(ProjectReference)" PreserveExistingMetadata="true" Condition="'%(Identity)' != '' AND '%(ProjectReference.IsAppExtension)' == 'true'">
-		<Output ItemName="_AppExtensionReference" TaskParameter="Include" />
-	</CreateItem>
-
-	<ItemGroup>
-		<ProjectReference Remove="@(_AppExtensionReference)" />
-	</ItemGroup>
+  <ItemGroup>
+    <_AppExtensionReference Condition=" '%(ProjectReference.IsAppExtension)' == 'True' " Include="@(ProjectReference)" />
+    <ProjectReference Remove="@(_AppExtensionReference)" />
+  </ItemGroup>
 </Target>
 
 <PropertyGroup>
@@ -426,14 +423,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		<Output TaskParameter="ApplicationManifestFile" PropertyName="BundledWearApplicationManifestFile" />
 		<Output TaskParameter="ApplicationPackageName" PropertyName="BundledWearApplicationPackageName" />
 	</ParseAndroidWearProjectAndManifest>
-	<!-- we don't have ConvertToAbsolutePath in xbuild, so create item instead -->
-	<CreateItem Include="$(AndroidSigningKeyStore)"
-		Condition="$(WearAppTarget) == 'SignAndroidPackage' And '$(AndroidKeyStore)'=='True'">
-		<Output TaskParameter="Include" ItemName="_AndroidSigningKeyStoreFile" />
-	</CreateItem>
 	<CreateProperty
 		Condition="$(WearAppTarget) == 'SignAndroidPackage' And '$(AndroidKeyStore)'=='True'"
-		Value="AndroidKeyStore=True;AndroidSigningKeyStore=%(_AndroidSigningKeyStoreFile.FullPath);AndroidSigningStorePass=$(AndroidSigningStorePass);AndroidSigningKeyAlias=$(AndroidSigningKeyAlias);AndroidSigningKeyPass=$(AndroidSigningKeyPass)">
+		Value="AndroidKeyStore=True;AndroidSigningKeyStore=$([System.IO.Path]::GetFullPath ('$(AndroidSigningKeyStore)'));AndroidSigningStorePass=$(AndroidSigningStorePass);AndroidSigningKeyAlias=$(AndroidSigningKeyAlias);AndroidSigningKeyPass=$(AndroidSigningKeyPass)">
 		<Output TaskParameter="Value" PropertyName="_AdditionaEmbeddedWearAppProperties" />
 	</CreateProperty>
 	<MSBuild Projects="@(_AppExtensionReference)" Properties="Configuration=$(Configuration);AndroidUseSharedRuntime=False;EmbedAssembliesIntoApk=True;$(_AdditionaEmbeddedWearAppProperties)" Targets="Build;SignAndroidPackage"/>
@@ -868,14 +860,10 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 				Condition="'$(TargetFrameworkMoniker)' != ''"
 		/>
 	</CreateProperty>
-	<CreateItem Include="$(TargetFrameworkMonikerAssemblyAttributesPath)">
-		<Output TaskParameter="Include" ItemName="FileWrites"
-				Condition="'$(TargetFrameworkMonikerAssemblyAttributesPath)' != ''"
-		/>
-	</CreateItem>
-	<CreateItem Include="$(_JavaInteropReferences)">
-		<Output TaskParameter="Include" ItemName="Reference" />
-	</CreateItem>
+	<ItemGroup>
+		<FileWrites Include="$(TargetFrameworkMonikerAssemblyAttributesPath)" />
+		<Reference Include="$(_JavaInteropReferences)" />
+	</ItemGroup>
 	<Warning Code="XA0110"
 		Text="Disabling $(AndroidExplicitCrunch) as it is not supported by `aapt2`. If you wish to use $(AndroidExplicitCrunch) please set $(AndroidUseAapt2) to false."
 		Condition="  '$(_AndroidUseAapt2)' == 'True' And '$(AndroidExplicitCrunch)' == 'True' "
@@ -1372,11 +1360,9 @@ because xbuild doesn't support framework reference assemblies.
 		Condition=" '$(AndroidExplicitCrunch)' == 'True' And '$(AndroidApplication)' != '' And $(AndroidApplication)">
 	<ItemGroup>
 		<_LibraryResourceDirs Include="@(LibraryResourceDirectories)"/>
+		<_LibraryResourceImages Include="@(_LibraryResourceDirs->'%(Identity)\**\*.png')" />
 	</ItemGroup>
-	<CreateItem Include="@(_LibraryResourceDirs->'%(Identity)\\**\*.png')">
-		<Output TaskParameter="Include" ItemName="_Images" />
-	</CreateItem> 
-	<RemoveDuplicates Inputs="@(_Images)">
+	<RemoveDuplicates Inputs="@(_LibraryResourceImages)">
 		<Output TaskParameter="Filtered" ItemName="_LibraryProjectResourceImages"/>
 	</RemoveDuplicates>
 </Target>
@@ -1392,14 +1378,12 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_AddMultiDexDependencyJars">
-	<CreateItem Include="$(_AndroidSdkDirectory)\$(AndroidMultiDexSupportJar)"
-		Condition="'$(AndroidEnableMultiDex)' == 'True' AND '$(AndroidMultiDexSupportJar)' != ''">
-      <Output TaskParameter="Include" ItemName="AndroidJavaLibrary" />
-	</CreateItem>
-	<CreateItem Include="$(MonoAndroidToolsDirectory)\android-support-multidex.jar"
-		Condition="'$(AndroidEnableMultiDex)' == 'True' AND '$(AndroidMultiDexSupportJar)' == ''">
-      <Output TaskParameter="Include" ItemName="AndroidJavaLibrary" />
-	</CreateItem>
+  <ItemGroup Condition=" '$(AndroidEnableMultiDex)' == 'True' AND '$(AndroidMultiDexSupportJar)' != '' ">
+    <AndroidJavaLibrary Include="$(_AndroidSdkDirectory)\$(AndroidMultiDexSupportJar)" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(AndroidEnableMultiDex)' == 'True' AND '$(AndroidMultiDexSupportJar)' == '' ">
+    <AndroidJavaLibrary Include="$(MonoAndroidToolsDirectory)\android-support-multidex.jar" />
+  </ItemGroup>
 </Target>
 
 <PropertyGroup>
@@ -1425,17 +1409,12 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_GetLibraryImports" DependsOnTargets="$(_GetLibraryImportsDependsOnTargets)">
-	<ReadImportedLibrariesCache
-			CacheFile="$(_AndroidLibraryImportsCache)">
-		<Output TaskParameter="Jars" ItemName="ExtractedJarImports" />
-		<Output TaskParameter="NativeLibraries" ItemName="ExtractedNativeLibraryImports" />
-		<Output TaskParameter="ManifestDocuments" ItemName="ExtractedManifestDocuments" />
-	</ReadImportedLibrariesCache>
-	
-    <CreateItem Include="@(ExtractedNativeLibraryImports)"
-        Condition="'@(ExtractedNativeLibraryImports)' != ''">
-      <Output TaskParameter="Include" ItemName="AndroidNativeLibrary" />
-    </CreateItem>
+  <ReadImportedLibrariesCache CacheFile="$(_AndroidLibraryImportsCache)">
+    <Output TaskParameter="Jars"              ItemName="ExtractedJarImports" />
+    <Output TaskParameter="NativeLibraries"   ItemName="ExtractedNativeLibraryImports" />
+    <Output TaskParameter="NativeLibraries"   ItemName="AndroidNativeLibrary" />
+    <Output TaskParameter="ManifestDocuments" ItemName="ExtractedManifestDocuments" />
+  </ReadImportedLibrariesCache>
 </Target>
   
 <Target Name="_CreateNativeLibraryArchive"
@@ -1456,11 +1435,11 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_AddAndroidEnvironmentToCompile">
-    <CreateItem Include="@(AndroidEnvironment)"
-        Condition="@(AndroidEnvironment) !=''"
-        AdditionalMetadata="@(AndroidEnvironment->'LogicalName=__AndroidEnvironment__%(filename)%(extension)')">
-      <Output TaskParameter="Include" ItemName="EmbeddedResource" />
-    </CreateItem>
+  <ItemGroup>
+    <EmbeddedResource Include="@(AndroidEnvironment)">
+      <LogicalName>__AndroidEnvironment__%(Filename)%(Extension)</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
 </Target>
 
 <Target Name="_FindLayoutsForBinding" Condition=" '$(Language)' == 'C#' ">
@@ -1584,16 +1563,9 @@ because xbuild doesn't support framework reference assemblies.
 		<Output TaskParameter="PrimaryJavaResgenFile" PropertyName="_GeneratedPrimaryJavaResgenFile" />
 	</CopyGeneratedJavaResourceClasses>
 
-  <!-- We need to strip out just filename from request Designer file location -->
-  <CreateItem Include="$(_AndroidResourceDesignerFile)">
-    <Output TaskParameter="Include" ItemName="_AndroidResgenFilenameItems" />
-  </CreateItem>
-
-  <CreateProperty Value="@(_AndroidResgenFilenameItems->'%(Filename)%(Extension)')">
-    <Output TaskParameter="Value" PropertyName="AndroidResgenFilename"/>
-  </CreateProperty>
-
   <PropertyGroup>
+    <!-- We need to strip out just filename from request Designer file location -->
+    <AndroidResgenFilename>$([System.IO.Path]::GetFileName ('$(_AndroidResourceDesignerFile)'))</AndroidResgenFilename>
     <_UseManagedResourceGenerator Condition=" '$(_AndroidUseAapt2)' == 'True' ">True</_UseManagedResourceGenerator>
     <_UseManagedResourceGenerator Condition=" '$(_UseManagedResourceGenerator)' == '' ">False</_UseManagedResourceGenerator>
   </PropertyGroup>
@@ -1673,9 +1645,9 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_AddManagedAidlOutputsToCompile" DependsOnTargets="_RunManagedAidlTool">
   <!-- Add the files to list of things to be compiled -->
-  <CreateItem Include="$(IntermediateOutputPath)aidl\\**\*.cs">
-    <Output TaskParameter="Include" ItemName="Compile" />
-  </CreateItem>
+  <ItemGroup Condition="Exists('$(IntermediateOutputPath)aidl\')">
+    <Compile Include="$(IntermediateOutputPath)aidl\**\*.cs" />
+  </ItemGroup>
 </Target>
 
 
@@ -2018,71 +1990,28 @@ because xbuild doesn't support framework reference assemblies.
     <Output TaskParameter="FilesThatExist" ItemName="_ResolvedFrameworkAssemblies" />
   </GetFilesThatExist>
 
-  <CreateItem
-    Include="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')"
-    Condition="'$(AndroidLinkMode)' == 'None'">
-    <Output TaskParameter="Include" ItemName="_ResolvedAssemblies" />
-  </CreateItem>
-
-  <CreateItem
-    Include="@(ResolvedSymbols->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')"
-    Condition="'$(AndroidLinkMode)' == 'None'">
-    <Output TaskParameter="Include" ItemName="_ResolvedSymbols" />
-  </CreateItem>
-
-  <CreateItem
-    Include="@(ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')"
-    Condition="'$(AndroidLinkMode)' == 'None'">
-    <Output TaskParameter="Include" ItemName="_ResolvedUserAssemblies" />
-  </CreateItem>
-
-  <CreateItem
-    Include="@(ResolvedFrameworkAssemblies)"
-    Condition="'$(AndroidLinkMode)' == 'None'">
-    <Output TaskParameter="Include" ItemName="_ResolvedFrameworkAssemblies" />
-  </CreateItem>
-
-  <CreateItem
-    Include="@(_ResolvedAssemblies)"
-    Condition="'$(AndroidLinkMode)' == 'None' OR '$(AndroidUseSharedRuntime)' == 'true'">
-    <Output TaskParameter="Include" ItemName="_ShrunkAssemblies" />
-  </CreateItem>
-
-  <CreateItem
-    Include="@(_ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)shrunk\%(Filename)%(Extension)')"
-    Condition="'$(AndroidLinkMode)' != 'None' AND '$(AndroidUseSharedRuntime)' != 'true'">
-    <Output TaskParameter="Include" ItemName="_ShrunkAssemblies" />
-  </CreateItem>
-
-  <CreateItem
-    Include="@(_ResolvedUserAssemblies)"
-    Condition="'$(AndroidLinkMode)' == 'None' OR '$(AndroidUseSharedRuntime)' == 'true'">
-    <Output TaskParameter="Include" ItemName="_ShrunkUserAssemblies" />
-  </CreateItem>
-
-  <CreateItem
-    Include="@(_ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)shrunk\%(Filename)%(Extension)')"
-    Condition="'$(AndroidLinkMode)' != 'None' AND '$(AndroidUseSharedRuntime)' != 'true'">
-    <Output TaskParameter="Include" ItemName="_ShrunkUserAssemblies" />
-  </CreateItem>
-
-  <CreateItem
-    Include="@(_ResolvedFrameworkAssemblies)"
-    Condition="'$(AndroidLinkMode)' == 'None' OR '$(AndroidUseSharedRuntime)' == 'true'">
-    <Output TaskParameter="Include" ItemName="_ShrunkFrameworkAssemblies" />
-  </CreateItem>
-
-  <CreateItem
-    Include="@(_ResolvedFrameworkAssemblies->'$(MonoAndroidIntermediateAssemblyDir)shrunk\%(Filename)%(Extension)')"
-    Condition="'$(AndroidLinkMode)' != 'None' AND '$(AndroidUseSharedRuntime)' != 'true'">
-    <Output TaskParameter="Include" ItemName="_ShrunkFrameworkAssemblies" />
-  </CreateItem>
-
-  <CreateItem
-    Include="@(_ResolvedUserAssemblies)"
-    Condition="'%(_ResolvedUserAssemblies.TargetFrameworkIdentifier)' == 'MonoAndroid' Or '%(_ResolvedUserAssemblies.HasMonoAndroidReference)' == 'True'">
-    <Output TaskParameter="Include" ItemName="_ResolvedUserMonoAndroidAssemblies" />
-  </CreateItem>
+  <ItemGroup Condition=" '$(AndroidLinkMode)' == 'None' ">
+    <_ResolvedAssemblies          Include="@(ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')" />
+    <_ResolvedSymbols             Include="@(ResolvedSymbols->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')" />
+    <_ResolvedUserAssemblies      Include="@(ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)%(Filename)%(Extension)')" />
+    <_ResolvedFrameworkAssemblies Include="@(ResolvedFrameworkAssemblies)" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(AndroidLinkMode)' == 'None' Or '$(AndroidUseSharedRuntime)' == 'True' ">
+    <_ShrunkAssemblies          Include="@(_ResolvedAssemblies)" />
+    <_ShrunkUserAssemblies      Include="@(_ResolvedUserAssemblies)" />
+    <_ShrunkFrameworkAssemblies Include="@(_ResolvedFrameworkAssemblies)" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(AndroidLinkMode)' != 'None' And '$(AndroidUseSharedRuntime)' != 'True' ">
+    <_ShrunkAssemblies          Include="@(_ResolvedAssemblies->'$(MonoAndroidIntermediateAssemblyDir)shrunk\%(Filename)%(Extension)')" />
+    <_ShrunkUserAssemblies      Include="@(_ResolvedUserAssemblies->'$(MonoAndroidIntermediateAssemblyDir)shrunk\%(Filename)%(Extension)')" />
+    <_ShrunkFrameworkAssemblies Include="@(_ResolvedFrameworkAssemblies->'$(MonoAndroidIntermediateAssemblyDir)shrunk\%(Filename)%(Extension)')" />
+  </ItemGroup>
+  <ItemGroup>
+    <_ResolvedUserMonoAndroidAssemblies
+        Include="@(_ResolvedUserAssemblies)"
+        Condition=" '%(_ResolvedUserAssemblies.TargetFrameworkIdentifier)' == 'MonoAndroid' Or '%(_ResolvedUserAssemblies.HasMonoAndroidReference)' == 'True' "
+    />
+  </ItemGroup>
 </Target>
 
 <Target Name="_PrepareNativeAssemblySources">
@@ -2329,11 +2258,10 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_FindJavaStubFiles" DependsOnTargets="_GenerateJavaStubs;_ConvertCustomView;_FixupCustomViewsForAapt2;_GenerateEnvironmentFiles;">
-  <CreateItem
-    Include="$(_AndroidIntermediateJavaSourceDirectory)**\*.java">
-    <Output TaskParameter="Include" ItemName="_JavaStubFiles" />
-    <Output TaskParameter="Include" ItemName="FileWrites" />
-  </CreateItem>
+  <ItemGroup>
+    <_JavaStubFiles Include="$(_AndroidIntermediateJavaSourceDirectory)**\*.java" />
+    <FileWrites Include="@(_JavaStubFiles)" />
+  </ItemGroup>
 </Target>
 
 <Target Name="_AdjustJavacVersionArguments">
@@ -2440,9 +2368,9 @@ because xbuild doesn't support framework reference assemblies.
   Inputs="$(_CompileToDalvikInputs)"
   Outputs="$(_AndroidStampDirectory)_CompileToDalvik.stamp">
 
-  <CreateItem Include="@(_JavaLibrariesToCompile)">
-    <Output TaskParameter="Include" ItemName="_JarsToProguard" />
-  </CreateItem>
+  <ItemGroup>
+    <_JarsToProguard Include="@(_JavaLibrariesToCompile)" />
+  </ItemGroup>
   
   <MakeDir Directories="$(IntermediateOutputPath)proguard" />
 
@@ -2472,11 +2400,9 @@ because xbuild doesn't support framework reference assemblies.
     ProguardInputJarFilter="$(_AndroidProguardInputJarFilter)"
      />
 
-  <CreateItem 
-    Include="$(IntermediateOutputPath)proguard\__proguard_output__.jar"
-    Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(_ProguardProjectConfiguration)' != '' ">
-    <Output TaskParameter="Include" ItemName="_AlternativeJarForAppDx" />
-  </CreateItem>
+  <ItemGroup Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(_ProguardProjectConfiguration)' != '' ">
+    <_AlternativeJarForAppDx Include="$(IntermediateOutputPath)proguard\__proguard_output__.jar" />
+  </ItemGroup>
 
   <CreateMultiDexMainDexClassList
     Condition="'$(AndroidEnableMultiDex)' == 'True' And '$(AndroidCustomMainDexListFile)' == ''"
@@ -3118,9 +3044,6 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="ConvertDebuggingFiles"
 	Condition=" '$(AndroidIncludeDebugSymbols)' == 'true' And Exists ('$(_IntermediatePdbFile)') And '$(OS)' == 'Windows_NT'"
 	DependsOnTargets="_ConvertDebuggingFiles">
-	<CreateItem Include="$(OutDir)$(TargetFileName).mdb" Condition="Exists('$(OutDir)$(TargetFileName).mdb')">
-		<Output TaskParameter="Include" ItemName="FileWrites" />
-	</CreateItem>
 </Target>
 
 <Target Name="_ConvertDebuggingFiles"
@@ -3129,6 +3052,9 @@ because xbuild doesn't support framework reference assemblies.
 	DependsOnTargets="_ValidateAndroidPackageProperties">
 	<ConvertDebuggingFiles Files="$(OutDir)$(TargetFileName)" />
 	<Touch Files="$(OutDir)$(TargetFileName).mdb" />
+	<ItemGroup>
+		<FileWrites Include="$(OutDir)$(TargetFileName).mdb" />
+	</ItemGroup>
 </Target>
 
 
@@ -3166,9 +3092,9 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_CleanGeneratedDeploymentFiles">
-	<CreateItem Include="$(IntermediateOutputPath)*.deployment">
-		<Output TaskParameter="Include" ItemName="_OutputDeploymentFiles" />
-	</CreateItem>
+	<ItemGroup>
+		<_OutputDeploymentFiles Include="$(IntermediateOutputPath)*.deployment" />
+	</ItemGroup>
 	<Delete Files="@(_OutputDeploymentFiles)"/>
 </Target>
 
@@ -3220,46 +3146,21 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_CollectMonoAndroidOutputs" DependsOnTargets="_ValidateAndroidPackageProperties">
-	<CreateItem Include="$(ApkFile)">
-		<Output TaskParameter="Include" ItemName="FileWrites"/>
-	</CreateItem>
-	<CreateItem Include="$(ApkFileIntermediate)">
-		<Output TaskParameter="Include" ItemName="FileWrites"/>
-	</CreateItem>
-	<CreateItem Include="$(_AabFile)">
-		<Output TaskParameter="Include" ItemName="FileWrites"/>
-	</CreateItem>
-	<CreateItem Include="$(_AabFileSigned)">
-		<Output TaskParameter="Include" ItemName="FileWrites"/>
-	</CreateItem>
-	<CreateItem Include="$(_BaseZipIntermediate)">
-		<Output TaskParameter="Include" ItemName="FileWrites"/>
-	</CreateItem>
-	<CreateItem Include="$(_AppBundleIntermediate)">
-		<Output TaskParameter="Include" ItemName="FileWrites"/>
-	</CreateItem>
-	<CreateItem Include="$(_ApkSetIntermediate)">
-		<Output TaskParameter="Include" ItemName="FileWrites"/>
-	</CreateItem>
-	<!-- FIXME: check files exists -->
-	<CreateItem Include="@(_AndroidResourceDest)">
-		<Output TaskParameter="Include" ItemName="FileWrites"/>
-	</CreateItem>
-	<CreateItem Include="$(_AndroidResgenFlagFile)">
-		<Output TaskParameter="Include" ItemName="FileWrites"/>
-	</CreateItem>
-	<CreateItem Include="$(IntermediateOutputPath)R.txt">
-		<Output TaskParameter="Include" ItemName="FileWrites"/>
-	</CreateItem>
-	<CreateItem Include="$(ApkFileSigned)">
-		<Output TaskParameter="Include" ItemName="FileWrites"/>
-	</CreateItem>
-	<CreateItem Include="$(_UploadFlagFile)">
-		<Output TaskParameter="Include" ItemName="FileWrites"/>
-	</CreateItem>
-	<CreateItem Include="@(_ModifiedResources)">
- 		<Output TaskParameter="Include" ItemName="FileWrites"/>
- 	</CreateItem>
+  <ItemGroup>
+    <FileWrites Include="$(ApkFile)" />
+    <FileWrites Include="$(ApkFileIntermediate)" />
+    <FileWrites Include="$(_AabFile)" />
+    <FileWrites Include="$(_AabFileSigned)" />
+    <FileWrites Include="$(_BaseZipIntermediate)" />
+    <FileWrites Include="$(_AppBundleIntermediate)" />
+    <FileWrites Include="$(_ApkSetIntermediate)" />
+    <FileWrites Include="@(_AndroidResourceDest)" />
+    <FileWrites Include="$(_AndroidResgenFlagFile)" />
+    <FileWrites Include="$(IntermediateOutputPath)R.txt" />
+    <FileWrites Include="$(ApkFileSigned)" />
+    <FileWrites Include="$(_UploadFlagFile)" />
+    <FileWrites Include="@(_ModifiedResources)" />
+  </ItemGroup>
 </Target>
 
 <Target Name="_lldb"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
@@ -72,11 +72,9 @@ Copyright (C) 2018 Xamarin. All rights reserved.
         ProguardInputJarFilter="$(_AndroidProguardInputJarFilter)"
     />
 
-    <CreateItem 
-        Include="$(IntermediateOutputPath)proguard\__proguard_output__.jar"
-        Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(_ProguardProjectConfiguration)' != '' ">
-      <Output TaskParameter="Include" ItemName="_AlternativeJarForAppD8" />
-    </CreateItem>
+    <ItemGroup Condition=" '$(AndroidLinkTool)' == 'proguard' And '$(_ProguardProjectConfiguration)' != '' ">
+      <_AlternativeJarForAppD8 Include="$(IntermediateOutputPath)proguard\__proguard_output__.jar" />
+    </ItemGroup>
 
     <R8
         Condition=" '$(_UseR8)' == 'True' "


### PR DESCRIPTION
Context: https://docs.microsoft.com/visualstudio/msbuild/createitem-task

    CreateItem task
    This task is deprecated. Starting with .NET Framework 3.5, item groups may be placed within Target elements.

The `<CreateItem/>` MSBuild task is deprecated, this removes all usage
of it in xamarin-android's targets we ship. I tried to make changes to
simplify `Condition`, and hopefully no actual behavior will be changed
here.

There may also be some light performance impact, in a build with no
changes in `samples\HelloWorld`:

    20 ms  CreateItem                                39 calls
    Time Elapsed 00:00:01.16

Now there are 0 calls. I suspect some of this time is merely moved
elsewhere, however...

MSBuild likely has some performance improvements to using
`<ItemGroup/>` over `<CreateItem/>`. I was also able to simplify some
general logic and repeated `Condition` attributes that won't be
evaluated so many times now.