### PR TITLE
[Xamarin.Android.Build.Tasks] Fix up AndroidStoreUncompressedFileExtensions.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -332,7 +332,7 @@ namespace Xamarin.Android.Tasks
 			}
 			if (!string.IsNullOrWhiteSpace (UncompressedFileExtensions))
 				foreach (var ext in UncompressedFileExtensions.Split (new char[] { ';', ','}, StringSplitOptions.RemoveEmptyEntries))
-					cmd.AppendSwitchIfNotNull ("-0 ", ext);
+					cmd.AppendSwitchIfNotNull ("-0 ", ext.StartsWith (".", StringComparison.OrdinalIgnoreCase) ? ext : $".{ext}");
 
 			if (!string.IsNullOrEmpty (ExtraPackages))
 				cmd.AppendSwitchIfNotNull ("--extra-packages ", ExtraPackages);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -160,7 +160,7 @@ namespace Xamarin.Android.Tasks {
 
 			if (!string.IsNullOrWhiteSpace (UncompressedFileExtensions))
 				foreach (var ext in UncompressedFileExtensions.Split (new char [] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries))
-					cmd.AppendSwitchIfNotNull ("-0 ", ext);
+					cmd.AppendSwitchIfNotNull ("-0 ", ext.StartsWith (".", StringComparison.OrdinalIgnoreCase) ? ext : $".{ext}");
 
 			if (!string.IsNullOrEmpty (ExtraPackages))
 				cmd.AppendSwitchIfNotNull ("--extra-packages ", ExtraPackages);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -372,7 +372,7 @@ namespace Xamarin.Android.Tasks
 
 		CompressionMethod GetCompressionMethod (string fileName)
 		{
-			if (uncompressedFileExtensions.Any (x => string.Compare (x, Path.GetExtension (fileName), StringComparison.OrdinalIgnoreCase) == 0))
+			if (uncompressedFileExtensions.Any (x => string.Compare (x.StartsWith (".", StringComparison.OrdinalIgnoreCase) ? x : $".{x}", Path.GetExtension (fileName), StringComparison.OrdinalIgnoreCase) == 0))
 				return UncompressedMethod;
 			return CompressionMethod.Default;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -180,7 +180,7 @@ namespace Xamarin.Android.Build.Tests
 			proj.PackageReferences.Add(KnownPackages.SQLitePCLRaw_Core);
 			proj.SetProperty ("AndroidUseAapt2", useAapt2.ToString ());
 			proj.SetProperty(proj.ReleaseProperties, KnownProperties.AndroidSupportedAbis, "x86");
-			proj.SetProperty (proj.ReleaseProperties, "AndroidStoreUncompressedFileExtensions", compressNativeLibraries ? "" : ".so");
+			proj.SetProperty (proj.ReleaseProperties, "AndroidStoreUncompressedFileExtensions", compressNativeLibraries ? "" : "so");
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				b.Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic;
 				b.ThrowOnBuildFailure = false;


### PR DESCRIPTION
Fixes #3962

Commit d20a991 fixed up an issue where `aapt2` was always compressing
items even if they were defined in `AndroidStoreUncompressedFileExtensions`.
However users are not always including a period in the values they
place in that ItemGroup. In the Linked issue the user was using
`tflite` rather than `.tflite` which `aapt2` is expecrting.

So lets check to see if we have a `.` prefix and if not add one.