### PR TITLE
Add new `debugger-log-level` option to `debug.mono.log`

### DIFF
--- a/src/monodroid/jni/debug.cc
+++ b/src/monodroid/jni/debug.cc
@@ -134,6 +134,29 @@ Debug::load_profiler_from_handle (void *dso_handle, const char *desc, const char
 }
 
 #if defined (DEBUG) && !defined (WINDOWS)
+void
+Debug::set_debugger_log_level (const char *level)
+{
+	if (level == nullptr || *level == '\0') {
+		got_debugger_log_level = false;
+		return;
+	}
+
+	unsigned long v = strtoul (level, nullptr, 0);
+	if (v == ULONG_MAX && errno == ERANGE) {
+		log_error (LOG_DEFAULT, "Invalid debugger log level value '%s', expecting a positive integer or zero", level);
+		return;
+	}
+
+	if (v > INT_MAX) {
+		log_warn (LOG_DEFAULT, "Debugger log level value is higher than the maximum of %u, resetting to the maximum value.", INT_MAX);
+		v = INT_MAX;
+	}
+
+	got_debugger_log_level = true;
+	debugger_log_level = static_cast<int>(v);
+}
+
 inline void
 Debug::parse_options (char *options, ConnOptions *opts)
 {

--- a/src/monodroid/jni/debug.hh
+++ b/src/monodroid/jni/debug.hh
@@ -58,6 +58,17 @@ namespace xamarin::android
 	public:
 		bool         enable_soft_breakpoints ();
 		void         start_debugging_and_profiling ();
+		void         set_debugger_log_level (const char *level);
+
+		bool         have_debugger_log_level () const
+		{
+			return got_debugger_log_level;
+		}
+
+		int          get_debugger_log_level () const
+		{
+			return debugger_log_level;
+		}
 
 	private:
 		DebuggerConnectionStatus start_connection (char *options);
@@ -67,6 +78,7 @@ namespace xamarin::android
 		bool         process_cmd (int fd, char *cmd);
 		void         start_debugging ();
 		void         start_profiling ();
+
 		friend void* conn_thread (void *arg);
 
 	private:
@@ -82,6 +94,8 @@ namespace xamarin::android
 		bool             config_timedout;
 		timeval          wait_tv;
 		timespec         wait_ts;
+		bool             got_debugger_log_level = false;
+		int              debugger_log_level = 0;
 #endif
 	};
 }

--- a/src/monodroid/jni/logger.cc
+++ b/src/monodroid/jni/logger.cc
@@ -190,11 +190,14 @@ init_logging_categories ()
 		} else if (!strncmp (arg, "lref-", 5)) {
 			log_categories  |= LOG_LREF;
 			light_lref       = 1;
-		}
-
-		if (!strncmp (arg, "timing=bare", 11)) {
+		} else if (!strncmp (arg, "timing=bare", 11)) {
 			log_timing_categories |= LOG_TIMING_BARE;
 		}
+#if !defined (WINDOWS) && defined (DEBUG)
+		else if (!strncmp (arg, "debugger-log-level=", 19)) {
+			debug.set_debugger_log_level (arg + 19);
+		}
+#endif
 	}
 
 	utils.monodroid_strfreev (args);

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -618,9 +618,15 @@ MonodroidRuntime::mono_runtime_init (char *runtime_args)
 	} else if (options.debug && cur_time <= options.timeout_time) {
 		embeddedAssemblies.set_register_debug_symbols (true);
 
+		int loglevel;
+		if (debug.have_debugger_log_level ())
+			loglevel = debug.get_debugger_log_level ();
+		else
+			loglevel = options.loglevel;
+
 		char *debug_arg = utils.monodroid_strdup_printf (
 			"--debugger-agent=transport=dt_socket,loglevel=%d,address=%s:%d,%sembedding=1",
-			options.loglevel,
+			loglevel,
 			options.host,
 			options.sdb_port,
 			options.server ? "server=y," : ""


### PR DESCRIPTION
XA runtime supports setting the Mono debugger log level by setting the
`loglevel` option of the Mono runtime's `--debugger-agent` paremeter via the
`debug.mono.extra` system property (set by the IDEs). However, it turns out that
the IDEs (via AndroidTools) always set the log level to `0`. Fixing the issue
would require updates to AndroidTools and then IDEs, however.

To allow setting the debugger level without having to wait for the next IDE
release, this commit adds a new option to the `debug.mono.log` system property:

    debugger-log-level=LEVEL

where `LEVEL` is a positive 32-bit signed integer or 0. This option will take
precedence when the level is set both in `debug.mono.extra` and `debug.mono.log`
system properties.