### PR TITLE
[Xamarin.Android.Build.Tasks] Handle Reference Aliases

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -17,6 +17,30 @@ namespace Xamarin.Android.Build.Tests
 	public class AndroidUpdateResourcesTest : BaseTest
 	{
 		[Test]
+		public void CheckProjectReferenceAlias ()
+		{
+			var path = Path.Combine (Root, "temp", TestName);
+			var library = new XamarinAndroidLibraryProject () {
+				ProjectName = "Library1",
+			};
+			var proj = new XamarinAndroidApplicationProject () {
+				References = {
+					new BuildItem.ProjectReference (Path.Combine("..", library.ProjectName, Path.GetFileName (library.ProjectFilePath)), "Library1") {
+						Metadata = { { "Aliases", "Lib1" } },
+					},
+				},
+			};
+			using (var builder = CreateDllBuilder (Path.Combine (path, library.ProjectName), cleanupAfterSuccessfulBuild: false, cleanupOnDispose: false)) {
+				builder.ThrowOnBuildFailure = false;
+				Assert.IsTrue (builder.Build (library), "Library should have built.");
+				using (var b = CreateApkBuilder (Path.Combine (path, proj.ProjectName), cleanupAfterSuccessfulBuild: false, cleanupOnDispose: false)) {
+					b.ThrowOnBuildFailure = false;
+					Assert.IsTrue (b.Build (proj), "Project should have built.");
+				}
+			}
+		}
+
+		[Test]
 		public void RepetitiveBuild ()
 		{
 			if (Directory.Exists ("temp/RepetitiveBuild"))

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ResourceDesignerImportGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ResourceDesignerImportGenerator.cs
@@ -58,8 +58,9 @@ namespace Xamarin.Android.Tasks
 						var declaringType = reader.GetTypeDefinition (typeDefinition.GetDeclaringType ());
 						var declaringTypeName = $"{reader.GetString (declaringType.Namespace)}.{reader.GetString (declaringType.Name)}";
 						if (declaringTypeName == resourceDesignerName) {
-							if (hasAlias)
-								declaringTypeName = $"{alias}.{declaringTypeName}";
+							if (hasAlias) {
+								declaringTypeName = $"{alias}::{declaringTypeName}";
+							}
 							CreateImportFor (declaringTypeName, typeDefinition, method, reader, hasAlias);
 						}
 					}


### PR DESCRIPTION
Fixes #3808

Project Refernces can include [Aliases](https://docs.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.projectreference.aliases?view=roslyn-dotnet).

```
<ProjectReference Include="..\LibraryA\LibraryA.csproj">
  <Project>{A31DB667-7565-4C13-99CD-82064660960F}</Project>
  <Name>LibraryA</Name>
  <Aliases>LibA</Aliases>
</ProjectReference>
```

When using these users can no longer use the `global` keyword
to reference the types. So

```
	global::LibraryA.Foo.Bar;
```

will become

```
	LibA.LibraryA.Foo.Bar;
```

and an `extern alias LibA;` will need to be added at the very
top of the `.cs` file.
When doing this for a Xamarin.Android project we get the
following build error from the `Resource.designer.cs` file.

```
error CS0400: The type or namespace name 'LibraryA' could not be found in the global namespace (are you missing an assembly reference?)
```

This is because we only use the `global::` when referencing
library types. We do not take into account the `Aliases`
MetaData.

This PR adds support for using the `Aliases` metadata so that
users can now use it in their Xamarin.Android projects.

See https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/extern-alias