### PR TITLE
Warn about AppDomain.CreateDomain usage

### DIFF
--- a/Documentation/guides/messages/xa2000.md
+++ b/Documentation/guides/messages/xa2000.md
@@ -1,0 +1,18 @@
+---
+title: Xamarin.Android error XA2000
+description: XA2000 warning code
+ms.date: 12/3/2019
+---
+# Xamarin.Android warning XA2000
+
+Member semantics will change in a future release
+
+## Example messages
+
+```
+Warning: Use of AppDomain::CreateDomain detected in assembly: {assembly}. The AppDomain's will not be part of .NET 5 and therefore will be missing in newer Xamarin.Android releases.
+```
+
+## Solution
+
+Stop using `AppDomain`s and replace it with a different API. Like `AssemblyLoadContext`, see https://docs.microsoft.com/en-us/dotnet/standard/assembly/unloadability for example.

--- a/Documentation/release-notes/3974.md
+++ b/Documentation/release-notes/3974.md
@@ -1,0 +1,5 @@
+### Warn about app domains usage
+
+Because AppDomain API will be removed in .NET 5, we check the relevant
+assemblies during the build process and emit a warning when it uses
+the `System.AppDomain::CreateDomain` method(s).

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
@@ -53,10 +53,12 @@ namespace Xamarin.Android.Tasks
 				for (int i = 0; i < SourceFiles.Length; i++) {
 					var source = SourceFiles [i];
 					var destination = DestinationFiles [i];
+					var assemblyDefinition = resolver.GetAssembly (source.ItemSpec);
+
+					step.CheckAppDomainUsage (assemblyDefinition, (string msg) => Log.LogWarning (msg));
 
 					// Only run the step on "MonoAndroid" assemblies
 					if (MonoAndroidHelper.IsMonoAndroidAssembly (source) && !MonoAndroidHelper.IsSharedRuntimeAssembly (source.ItemSpec)) {
-						var assemblyDefinition = resolver.GetAssembly (source.ItemSpec);
 						if (step.FixAbstractMethods (assemblyDefinition)) {
 							Log.LogDebugMessage ($"Saving modified assembly: {destination.ItemSpec}");
 							writerParameters.WriteSymbols = assemblyDefinition.MainModule.HasSymbols;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
@@ -5,6 +5,8 @@ using Mono.Cecil;
 using System;
 using System.IO;
 
+using MTProfile = Mono.Tuner.Profile;
+
 namespace Xamarin.Android.Tasks
 {
 	/// <summary>
@@ -53,12 +55,18 @@ namespace Xamarin.Android.Tasks
 				for (int i = 0; i < SourceFiles.Length; i++) {
 					var source = SourceFiles [i];
 					var destination = DestinationFiles [i];
-					var assemblyDefinition = resolver.GetAssembly (source.ItemSpec);
+					AssemblyDefinition assemblyDefinition = null;
 
-					step.CheckAppDomainUsage (assemblyDefinition, (string msg) => Log.LogWarning (msg));
+					if (!MTProfile.IsSdkAssembly (source.ItemSpec) && !MTProfile.IsProductAssembly (source.ItemSpec)) {
+						assemblyDefinition = resolver.GetAssembly (source.ItemSpec);
+						step.CheckAppDomainUsage (assemblyDefinition, (string msg) => Log.LogCodedWarning ("XA2000", msg));
+					}
 
 					// Only run the step on "MonoAndroid" assemblies
 					if (MonoAndroidHelper.IsMonoAndroidAssembly (source) && !MonoAndroidHelper.IsSharedRuntimeAssembly (source.ItemSpec)) {
+						if (assemblyDefinition == null)
+							assemblyDefinition = resolver.GetAssembly (source.ItemSpec);
+
 						if (step.FixAbstractMethods (assemblyDefinition)) {
 							Log.LogDebugMessage ($"Saving modified assembly: {destination.ItemSpec}");
 							writerParameters.WriteSymbols = assemblyDefinition.MainModule.HasSymbols;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -87,5 +87,29 @@ namespace Xamarin.Android.Build.Tests
 				}
 			}
 		}
+
+		[Test]
+		public void WarnAboutAppDomainsRelease ()
+		{
+			var proj = new XamarinAndroidApplicationProject () { IsRelease = true };
+			WarnAboutAppDomains (proj, TestName);
+		}
+
+		[Test]
+		public void WarnAboutAppDomainsDebug ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			WarnAboutAppDomains (proj, TestName);
+		}
+
+		void WarnAboutAppDomains (XamarinAndroidApplicationProject proj, string testName)
+		{
+			proj.MainActivity = proj.DefaultMainActivity.Replace ("base.OnCreate (bundle);", "base.OnCreate (bundle);\nvar appDomain = System.AppDomain.CreateDomain (\"myDomain\");");
+			var projDirectory = Path.Combine ("temp", testName);
+			using (var b = CreateApkBuilder (projDirectory)) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "Warning: Use of AppDomain::CreateDomain"), "Should warn about creating AppDomain.");
+			}
+		}
 	}
 }


### PR DESCRIPTION
Context:
https://github.com/xamarin/xamarin-android/issues/3912
https://github.com/xamarin/xamarin-android/issues/3845

Issue warning when non-product/non-SDK assembly uses
`System.AppDomain::CreateDomain` as app domains will be removed in
.NET5

The check is added to `FixAbstractMethodsStep`, so this way it is done
in both configurations, `Debug` and `Release`.

Add tests for both configurations.