### PR TITLE
Update NDK to the latest version (20b)

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "20";
-		public const string AndroidNdkPkgRevision = "20.0.5594570";
+		public const string AndroidNdkVersion = "20b";
+		public const string AndroidNdkPkgRevision = "20.1.5948944";
 
 		public static readonly List<AndroidPlatform> AllPlatforms = new List<AndroidPlatform> {
 			new AndroidPlatform (apiName: "",                       apiLevel: 1,  platformID: "1"),


### PR DESCRIPTION
Context: https://github.com/android/ndk/wiki/Changelog-r20#r20b

This is a minor update to the previous version. Changes:

  * Fix for CVE-2019-2212, out of bounds buffer read in std::random (https://bugs.chromium.org/p/chromium/issues/detail?id=994957)
  * Updated Clang to r346389c
  * Updated libc++ to r350972
  * Add Android Q Beta 1 APIs
    * MIDI (<amidi/AMidi.h>)
    * Binder
    * Extensions to several APIs from previous releases