### PR TITLE
[build] clean directories ourselves on AzDO

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -159,13 +159,13 @@ stages:
     pool: $(VSEngWinVS2019)
     timeoutInMinutes: 360
     cancelTimeoutInMinutes: 5
-    workspace:
-      clean: all
     steps:
     - checkout: self
       submodules: recursive
 
-    - task: xamops.azdevex.lingering-process-task.lingering-process-task@1
+    - template: yaml-templates\kill-processes.yaml
+
+    - template: yaml-templates\clean.yaml
 
     - task: UseDotNet@2
       displayName: install .NET Core $(DotNetCoreVersion)
@@ -218,17 +218,7 @@ stages:
           /bl:$(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\msbuild-run-ji-tests.binlog
       condition: succeededOrFailed()
 
-    - powershell: |
-        $ErrorActionPreference = 'Continue'
-        Get-Process
-        Stop-Process -Name nunit3-console
-        Stop-Process -Name xabuild
-        Stop-Process -Name MSBuild
-        Stop-Process -Name adb
-        $LastExitCode=0
-      displayName: kill leftover processes
-      failOnStderr: false
-      condition: always()
+    - template: yaml-templates\kill-processes.yaml
 
     - task: PublishTestResults@2
       displayName: publish test results
@@ -322,7 +312,6 @@ stages:
     workspace:
       clean: all
     steps:
-    - task: xamops.azdevex.lingering-process-task.lingering-process-task@1
 
     - task: JenkinsQueueJob@2
       displayName: xamarin vsix codesign - run jenkins job
@@ -659,11 +648,14 @@ stages:
     pool: $(VSEngWinVS2019)
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5
-    workspace:
-      clean: all
     variables:
       VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
     steps:
+
+    - template: yaml-templates\kill-processes.yaml
+
+    - template: yaml-templates\clean.yaml
+
     - template: yaml-templates\setup-test-environment.yaml
       parameters:
         provisionExtraArgs: -vv PROVISIONATOR_VISUALSTUDIO_LOCATION="$(VSINSTALLDIR)" -f

--- a/build-tools/automation/yaml-templates/clean.yaml
+++ b/build-tools/automation/yaml-templates/clean.yaml
@@ -1,0 +1,6 @@
+steps:
+- powershell: |
+    git clean -xffd
+    git submodule foreach --recursive git clean -xffd
+    Remove-Item -Recurse $(Build.BinariesDirectory) -ErrorAction Ignore
+  displayName: manual clean

--- a/build-tools/automation/yaml-templates/kill-processes.yaml
+++ b/build-tools/automation/yaml-templates/kill-processes.yaml
@@ -1,0 +1,12 @@
+steps:
+- powershell: |
+    $ErrorActionPreference = 'Continue'
+    Get-Process
+    Stop-Process -Name nunit3-console
+    Stop-Process -Name xabuild
+    Stop-Process -Name MSBuild
+    Stop-Process -Name adb
+    $LastExitCode=0
+  displayName: kill leftover processes
+  failOnStderr: false
+  condition: and(always(), eq(variables['agent.os'], 'Windows_NT'))

--- a/build-tools/automation/yaml-templates/run-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-nunit-tests.yaml
@@ -17,19 +17,7 @@ steps:
   displayName: run ${{ parameters.testRunTitle }}
   condition: ${{ parameters.condition }}
 
-- powershell: |
-    if ([Environment]::OSVersion.Platform -eq "Win32NT") {
-      $ErrorActionPreference = 'Continue'
-      Get-Process
-      Stop-Process -Name nunit3-console
-      Stop-Process -Name xabuild
-      Stop-Process -Name MSBuild
-      Stop-Process -Name adb
-      $LastExitCode=0
-    }
-  displayName: kill leftover processes
-  failOnStderr: false
-  condition: always()
+- template: kill-processes.yaml
 
 - task: PublishTestResults@2
   inputs:


### PR DESCRIPTION
Context: https://build.azdo.io/3281436

Expanding upon e608464d, let's disable the clean behavior provided by
Azure DevOps and clean ourselves. We have an opportunity to kill
processes this way.

Otherwise, we seem to be hitting this on every build now:

    ##[error]The process cannot access the file 'F:\A\xamarin-v000001-1\_work\2\s' because it is being used by another process.

I am also interested in what `Get-Process` will print here.