### PR TITLE
[ci] Set NuGet feed secrets for designer test jobs

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -808,7 +808,7 @@ stages:
       inputs:
         github_token: $(GitHub.Token)
         provisioning_script: $(System.DefaultWorkingDirectory)/designer/bot-provisioning/dependencies.csx
-        provisioning_extra_args: -remove Xamarin.Android -vv
+        provisioning_extra_args: -remove Xamarin.Android -vv DEVDIV_PKGS_NUGET_TOKEN=$(DevDiv.NuGet.Token) SECTOOLS_PKGS_NUGET_TOKEN=$(SecTools.NuGet.Token)
 
     - template: yaml-templates/run-installer.yaml
 
@@ -844,7 +844,7 @@ stages:
       inputs:
         github_token: $(GitHub.Token)
         provisioning_script: $(System.DefaultWorkingDirectory)\designer\bot-provisioning\dependencies.csx
-        provisioning_extra_args: -vv
+        provisioning_extra_args: -vv DEVDIV_PKGS_NUGET_TOKEN=$(DevDiv.NuGet.Token) SECTOOLS_PKGS_NUGET_TOKEN=$(SecTools.NuGet.Token)
 
     - template: yaml-templates\run-installer.yaml
 


### PR DESCRIPTION
Context: https://github.com/xamarin/designer/pull/2217

The designer repo has recently been updated to require authentication to
a couple of private NuGet feeds, and as a result our designer checks
have been failing during NuGet restore attempts.

We can fix this by passing auth tokens to provisionator so that they can
later be accessed during NuGet operations via the `Azure Artifacts
Credential Provider`. More information about this credential provider
can be found below:

https://github.com/microsoft/artifacts-credprovider#unattended-build-agents
https://github.com/xamarin/provisionator/commit/ed77b56d8ff4b8416248fb3c8cf6751be5809053

The variables referenced in these YAML changes come from a variable
group that has been added to our build pipelines:

https://devdiv.visualstudio.com/DevDiv/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=11410&view=Tab_Variables
https://devdiv.visualstudio.com/DevDiv/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=12278&view=Tab_Variables