### PR TITLE
[xaprepare] add option for custom mono archive URL

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/Context.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Context.cs
@@ -323,6 +323,11 @@ namespace Xamarin.Android.Prepare
 		public RefreshableComponent ComponentsToRefresh { get; set; }
 
 		/// <summary>
+		/// Set by the --mono-archive-url flag
+		/// </summary>
+		public string MonoArchiveCustomUrl { get; set; }
+
+		/// <summary>
 		///   Set by <see cref="Step_DownloadMonoArchive"/> if the archive has been downloaded and validated, so
 		///   that the <see cref="Step_InstallMonoRuntimes"/> step doesn't attempt to rebuild Mono.
 		/// </summary>

--- a/build-tools/xaprepare/xaprepare/Application/MonoRuntimesHelpers.cs
+++ b/build-tools/xaprepare/xaprepare/Application/MonoRuntimesHelpers.cs
@@ -189,10 +189,17 @@ namespace Xamarin.Android.Prepare
 			return Path.Combine (Configurables.Paths.MonoSDKSRelativeOutputDir, $"android-{runtime.PrefixedName}-{Configurables.Defaults.MonoSdksConfiguration}");
 		}
 
-		public static bool AreRuntimeItemsInstalled (Runtimes runtimes)
+		public static bool AreRuntimeItemsInstalled (Context context, Runtimes runtimes)
 		{
+			if (context == null)
+				throw new ArgumentNullException (nameof (context));
 			if (runtimes == null)
 				throw new ArgumentNullException (nameof (runtimes));
+
+			if (!string.IsNullOrEmpty (context.MonoArchiveCustomUrl)) {
+				context.Log.StatusLine ("Skipping AreRuntimeItemsInstalled check, due to custom mono archive URL.");
+				return false;
+			}
 
 			foreach (var bclFile in runtimes.BclFilesToInstall) {
 				(string destFilePath, string debugSymbolsDestPath) = GetDestinationPaths (bclFile);

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -334,6 +334,10 @@ namespace Xamarin.Android.Prepare
 			public static string MonoSourceFullPath             => ctx.Properties.GetRequiredValue (KnownProperties.MonoSourceFullPath);
 			public static string MonoSdksTpnPath                => GetCachedPath (ref monoSdksTpnPath, ()         => Path.Combine (MonoSDKSOutputDir, "android-tpn"));
 			public static string MonoSdksTpnExternalPath        => GetCachedPath (ref monoSdksTpnExternalPath, () => Path.Combine (MonoSdksTpnPath, "external"));
+			public static string MonoLlvmTpnPath                => GetCachedPath (ref monoLlvmTpnPath, () => {
+				var path = Path.Combine (MonoSdksTpnExternalPath, "llvm-project", "llvm");
+				return Directory.Exists (path) ? path : Path.Combine (MonoSdksTpnExternalPath, "llvm");
+			});
 
 			static string EnsureAndroidToolchainBinDirectories ()
 			{
@@ -392,6 +396,7 @@ namespace Xamarin.Android.Prepare
 			static string monoSdksTpnPath;
 			static string monoSdksTpnExternalPath;
 			static string monoSDKSIncludeDestDir;
+			static string monoLlvmTpnPath;
 		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/Main.cs
+++ b/build-tools/xaprepare/xaprepare/Main.cs
@@ -29,6 +29,7 @@ namespace Xamarin.Android.Prepare
 			public bool AutoProvisionUsesSudo  { get; set; }
 			public bool IgnoreMaxMonoVersion   { get; set; }
 			public bool IgnoreMinMonoVersion   { get; set; }
+			public string MonoArchiveCustomUrl { get; set; }
 			public bool EnableAll              { get; set; }
 			public RefreshableComponent RefreshList { get; set; }
 		}
@@ -104,6 +105,7 @@ namespace Xamarin.Android.Prepare
 				{"auto-provision-uses-sudo=", $"Allow use of sudo(1) when provisioning", v => parsedOptions.AutoProvisionUsesSudo = ParseBoolean (v)},
 				{"ignore-max-mono-version=", $"Ignore the maximum supported Mono version restriction", v => parsedOptions.IgnoreMaxMonoVersion = ParseBoolean (v)},
 				{"ignore-min-mono-version=", $"Ignore the minimum supported Mono version restriction", v => parsedOptions.IgnoreMinMonoVersion = ParseBoolean (v)},
+				{"mono-archive-url=", "Use a specific URL for the mono archive.", v => parsedOptions.MonoArchiveCustomUrl = v?.Trim () },
 				"",
 				{"h|help", "Show this help message", v => parsedOptions.ShowHelp = true },
 			};
@@ -136,6 +138,7 @@ namespace Xamarin.Android.Prepare
 			Context.Instance.AutoProvisionUsesSudo = parsedOptions.AutoProvisionUsesSudo;
 			Context.Instance.IgnoreMaxMonoVersion  = parsedOptions.IgnoreMaxMonoVersion;
 			Context.Instance.IgnoreMinMonoVersion  = parsedOptions.IgnoreMinMonoVersion;
+			Context.Instance.MonoArchiveCustomUrl  = parsedOptions.MonoArchiveCustomUrl;
 			Context.Instance.EnableAllTargets      = parsedOptions.EnableAll;
 			Context.Instance.ComponentsToRefresh   = parsedOptions.RefreshList;
 

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallMonoRuntimes.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallMonoRuntimes.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Android.Prepare
 
 			Log.StatusLine ("Checking if all runtime files are present");
 			var allRuntimes = new Runtimes ();
-			if (MonoRuntimesHelpers.AreRuntimeItemsInstalled (allRuntimes)) {
+			if (MonoRuntimesHelpers.AreRuntimeItemsInstalled (context, allRuntimes)) {
 
 				// User might have changed the set of ABIs to build, we need to check and rebuild if necessary
 				if (!Utilities.AbiChoiceChanged (context)) {

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/mono.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/mono.cs
@@ -186,7 +186,7 @@ jeroen@frijters.net
 	class mono_llvm_llvm_TPN : ThirdPartyNotice
 	{
 		static readonly Uri    url         = new Uri ("https://github.com/mono/llvm/");
-		static readonly string licenseFile = Path.Combine (Configurables.Paths.MonoSdksTpnExternalPath, "llvm", "LICENSE.TXT");
+		static readonly string licenseFile = Path.Combine (Configurables.Paths.MonoLlvmTpnPath, "LICENSE.TXT");
 
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/llvm";
@@ -197,7 +197,7 @@ jeroen@frijters.net
 	class mono_llvm_google_test_TPN : ThirdPartyNotice
 	{
 		static readonly Uri    url         = new Uri ("https://github.com/mono/llvm/tree/master/utils/unittest/googletest/");
-		static readonly string licenseFile = Path.Combine (Configurables.Paths.MonoSdksTpnExternalPath, "llvm", "utils", "unittest", "googletest", "LICENSE.TXT");
+		static readonly string licenseFile = Path.Combine (Configurables.Paths.MonoLlvmTpnPath, "utils", "unittest", "googletest", "LICENSE.TXT");
 
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/llvm Google Test";
@@ -208,7 +208,7 @@ jeroen@frijters.net
 	class mono_llvm_openbsd_regex_TPN : ThirdPartyNotice
 	{
 		static readonly Uri    url         = new Uri ("https://github.com/mono/llvm/tree/master/lib/Support/");
-		static readonly string licenseFile = Path.Combine (Configurables.Paths.MonoSdksTpnExternalPath, "llvm", "lib", "Support", "COPYRIGHT.regex");
+		static readonly string licenseFile = Path.Combine (Configurables.Paths.MonoLlvmTpnPath, "lib", "Support", "COPYRIGHT.regex");
 
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/llvm OpenBSD Regex";
@@ -219,7 +219,7 @@ jeroen@frijters.net
 	class mono_llvm_pyyaml_tests_TPN : ThirdPartyNotice
 	{
 		static readonly Uri    url         = new Uri ("https://github.com/mono/llvm/tree/master/test/YAMLParser/");
-		static readonly string licenseFile = Path.Combine (Configurables.Paths.MonoSdksTpnExternalPath, "llvm", "test", "YAMLParser", "LICENSE.txt");
+		static readonly string licenseFile = Path.Combine (Configurables.Paths.MonoLlvmTpnPath, "test", "YAMLParser", "LICENSE.txt");
 
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/llvm pyyaml tests";
@@ -230,7 +230,7 @@ jeroen@frijters.net
 	class mono_llvm_arm_contributions_TPN : ThirdPartyNotice
 	{
 		static readonly Uri    url         = new Uri ("https://github.com/mono/llvm/tree/master/lib/Target/ARM/");
-		static readonly string licenseFile = Path.Combine (Configurables.Paths.MonoSdksTpnExternalPath, "llvm", "lib", "Target", "ARM", "LICENSE.TXT");
+		static readonly string licenseFile = Path.Combine (Configurables.Paths.MonoLlvmTpnPath, "lib", "Target", "ARM", "LICENSE.TXT");
 
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/llvm ARM contributions";


### PR DESCRIPTION
This change to `xaprepare` allows us to use a custom build of mono
along with a local xamarin-android build.

This adds a new switch to xaprepare, such as:

    xaprepare --mono-archive-url=https://xamjenkinsartifact.azureedge.net/mono-jenkins/xamarin-android-test/android-release-Darwin-9bd1b2e065d8b1a8cfd21c8dc1821c89ad921eec.7z

This is a build of mono I built and uploaded using these instructions
on macOS:

https://github.com/mono/mono/blob/a2f9fb77a3704049ffe5de32362029ece154ee4c/sdks/README.md

With mono/master or 2019-12, I was hitting:

    Step Xamarin.Android.Prepare.Step_ThirdPartyNotices failed:
    License file external\mono\sdks\out\android-tpn\external\llvm\LICENSE.TXT does not exist

I made it probe for two different paths for `llvm` as the path has
changed:

https://github.com/mono/mono/tree/a2f9fb77a3704049ffe5de32362029ece154ee4c/external