### PR TITLE
[test] add an assertion checking Debug startup time

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -63,6 +63,15 @@ namespace Xamarin.Android.Build.Tests
 			RunAdbCommand ($"shell am start -S -n \"{activity}\"");
 		}
 
+		protected TimeSpan ProfileFor (Func<bool> func, TimeSpan? timeout = null)
+		{
+			var stopwatch = new Stopwatch ();
+			stopwatch.Start ();
+			WaitFor (timeout ?? TimeSpan.FromMinutes (1), func);
+			stopwatch.Stop ();
+			return stopwatch.Elapsed;
+		}
+
 		protected void WaitFor (TimeSpan timeSpan, Func<bool> func)
 		{
 			var pause = new ManualResetEvent (false);

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -204,8 +204,10 @@ namespace ${ROOT_NAMESPACE} {
 				session.OutputWriter += (isStderr, text) => { Console.WriteLine (text); };
 				session.DebugWriter += (level, category, message) => { Console.WriteLine (message); };
 				session.Run (startInfo, options);
-				WaitFor (TimeSpan.FromSeconds (30), () => session.IsConnected);
-				Assert.True (session.IsConnected, "Debugger should have connected but it did not.");
+				var expectedTime = TimeSpan.FromSeconds (1);
+				var actualTime = ProfileFor (() => session.IsConnected);
+				TestContext.Out.WriteLine ($"Debugger connected in {actualTime}");
+				Assert.LessOrEqual (actualTime, expectedTime, $"Debugger should have connected within {expectedTime} but it took {actualTime}.");
 				// we need to wait here for a while to allow the breakpoints to hit
 				// but we need to timeout
 				TimeSpan timeout = TimeSpan.FromSeconds (60);


### PR DESCRIPTION
In a26e0dbf and 5bfe44e9 we found a performance regression with
startup in Debug builds.

To better catch this in the future, I updated `DebuggingTest`.

If it takes longer than 1 second for the app to start and debugger
connect, the test will fail now.

This worked on my PC with a HAXM emulator, we will see if this number
is too optimistic for our CI servers.