### PR TITLE
[Mono.Android] remove System.Reflection usage in UncaughtExceptionHandler

### DIFF
--- a/src/Mono.Android/Android.App/SyncContext.cs
+++ b/src/Mono.Android/Android.App/SyncContext.cs
@@ -4,6 +4,8 @@ using System.Threading;
 using Android.OS;
 using Android.Runtime;
 
+using LogLevel = Android.Runtime.LogLevel;
+
 namespace Android.App {
 
 	internal class SyncContext : SynchronizationContext {

--- a/src/Mono.Android/Android.Runtime/UncaughtExceptionHandler.cs
+++ b/src/Mono.Android/Android.Runtime/UncaughtExceptionHandler.cs
@@ -1,13 +1,8 @@
 using System;
-using System.Reflection;
 
 namespace Android.Runtime {
 
 	sealed class UncaughtExceptionHandler : Java.Lang.Object, Java.Lang.Thread.IUncaughtExceptionHandler {
-
-		Action<Exception> mono_unhandled_exception;
-
-		Action<AppDomain, UnhandledExceptionEventArgs>      AppDomain_DoUnhandledException;
 
 		Java.Lang.Thread.IUncaughtExceptionHandler defaultHandler;
 
@@ -22,48 +17,19 @@ namespace Android.Runtime {
 
 		public void UncaughtException (Java.Lang.Thread thread, Java.Lang.Throwable ex)
 		{
-			try {
-				Initialize ();
-			} catch (Exception e) {
-				Android.Runtime.AndroidEnvironment.FailFast ($"Unable to initialize UncaughtExceptionHandler. Nested exception caught: {e}");
-			}
+			System.Diagnostics.Debugger.Mono_UnhandledException (ex);
 
-			mono_unhandled_exception (ex);
-			if (AppDomain_DoUnhandledException != null) {
-				try {
-					var jltp = ex as JavaProxyThrowable;
-					Exception innerException = jltp?.InnerException;
-					var args  = new UnhandledExceptionEventArgs (innerException ?? ex, isTerminating: true);
-					AppDomain_DoUnhandledException (AppDomain.CurrentDomain, args);
-				}
-				catch (Exception e) {
-					Logger.Log (LogLevel.Error, "monodroid", "Exception thrown while raising AppDomain.UnhandledException event: " + e.ToString ());
-				}
+			try {
+				var jltp = ex as JavaProxyThrowable;
+				Exception innerException = jltp?.InnerException;
+				var args  = new UnhandledExceptionEventArgs (innerException ?? ex, isTerminating: true);
+				AppDomain.CurrentDomain.DoUnhandledException (args);
+			}
+			catch (Exception e) {
+				Logger.Log (LogLevel.Error, "monodroid", "Exception thrown while raising AppDomain.UnhandledException event: " + e.ToString ());
 			}
 			if (defaultHandler != null)
 				defaultHandler.UncaughtException (thread, ex);
-		}
-
-		void Initialize ()
-		{
-			if (mono_unhandled_exception == null) {
-				var mono_UnhandledException = typeof (System.Diagnostics.Debugger)
-					.GetMethod ("Mono_UnhandledException", BindingFlags.NonPublic | BindingFlags.Static);
-				mono_unhandled_exception = (Action<Exception>) Delegate.CreateDelegate (typeof(Action<Exception>), mono_UnhandledException);
-			}
-
-			if (AppDomain_DoUnhandledException == null) {
-				var ad_due = typeof (AppDomain)
-					.GetMethod ("DoUnhandledException",
-					            bindingAttr:  BindingFlags.NonPublic | BindingFlags.Instance,
-					            binder:       null,
-					            types:        new []{typeof (UnhandledExceptionEventArgs)},
-					            modifiers:    null);
-				if (ad_due != null) {
-					AppDomain_DoUnhandledException  = (Action<AppDomain, UnhandledExceptionEventArgs>) Delegate.CreateDelegate (
-						typeof (Action<AppDomain, UnhandledExceptionEventArgs>), ad_due);
-				}
-			}
 		}
 	}
 }

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -7,6 +7,8 @@ using Java.Interop.Tools.TypeNameMappings;
 
 using Android.Runtime;
 
+using LogLevel = Android.Runtime.LogLevel;
+
 namespace Java.Interop {
 
 	static class TypeManagerMapDictionaries

--- a/src/Mono.Android/Java.Lang/Object.cs
+++ b/src/Mono.Android/Java.Lang/Object.cs
@@ -7,6 +7,8 @@ using Java.Interop;
 
 using Android.Runtime;
 
+using LogLevel = Android.Runtime.LogLevel;
+
 namespace Java.Lang {
 
 	[DataContract]

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidClientHandler.cs
@@ -18,6 +18,8 @@ using Java.Security;
 using Java.Security.Cert;
 using Javax.Net.Ssl;
 
+using LogLevel = Android.Runtime.LogLevel;
+
 namespace Xamarin.Android.Net
 {
 	/// <summary>

--- a/src/Mono.Android/Xamarin.Android.Net/AuthModuleDigest.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AuthModuleDigest.cs
@@ -7,6 +7,8 @@ using Android.Runtime;
 
 using Java.Net;
 
+using LogLevel = Android.Runtime.LogLevel;
+
 namespace Xamarin.Android.Net
 {
 	sealed class AuthModuleDigest : IAndroidAuthenticationModule


### PR DESCRIPTION
Context: https://github.com/mono/mono/blob/42c5ccc298c9b1b5f78781f5db4dab51ebacb522/mcs/class/corlib/Assembly/AssemblyInfo.cs#L84-L93

If we lived in a world where `mscorlib.dll` has `InternalsVisibleTo`
for `Mono.Android`, we can remove some System.Reflection that gets
called on startup.

We need to be able to call these methods directly:

* `System.Diagnostics.Debugger.Mono_UnhandledException`
* `AppDomain.CurrentDomain.DoUnhandledException`

The only other change is that some files need:

    using LogLevel = Android.Runtime.LogLevel;

There is an `internal` `System.LogLevel` that we need to disambiguate.

NOTE: this won't fully work until the change in Mono lands.

## Results ##

I tested the Xamarin.Forms integration project, using a Debug build on
a HAXM x86 emulator on Windows.

The reason I looked into this, is I initially saw a log message like:

    12-03 14:28:11.969 27129 27129 I monodroid-timing: Runtime.register: registered type 'Android.Runtime.UncaughtExceptionHandler, Mono.Android'
    12-03 14:28:11.969 27129 27129 I monodroid-timing: Runtime.register: end time; elapsed: 0s:79::609300

After the change, it is more like:

    12-04 09:13:32.944  9758  9758 I monodroid-timing: Runtime.register: registered type 'Android.Runtime.UncaughtExceptionHandler, Mono.Android'
    12-04 09:13:32.944  9758  9758 I monodroid-timing: Runtime.register: end time; elapsed: 0s:73::727800

However, if I look at the total `Runtime.init` time:

    Before:
    12-03 14:27:48.494 26903 26903 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:601::443900
    12-03 14:27:54.356 26963 26963 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:587::495400
    12-03 14:28:00.263 27021 27021 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:586::147100
    12-03 14:28:06.135 27074 27074 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:593::639100
    12-03 14:28:11.988 27129 27129 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:571::194900
    After:
    12-04 09:13:15.386  9587  9587 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:584::909700
    12-04 09:13:21.179  9644  9644 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:506::64600
    12-04 09:13:27.148  9699  9699 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:560::98500
    12-04 09:13:32.963  9758  9758 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:504::939400
    12-04 09:13:38.887  9814  9814 I monodroid-timing: Runtime.init: end, total time; elapsed: 0s:531::234100

And then the total activity time:

    Before:
    12-03 14:27:51.450  1876  1898 I ActivityManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +3s727ms
    12-03 14:27:57.310  1876  1898 I ActivityManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +3s723ms
    12-03 14:28:03.216  1876  1898 I ActivityManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +3s703ms
    12-03 14:28:09.054  1876  1898 I ActivityManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +3s679ms
    12-03 14:28:14.953  1876  1898 I ActivityManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +3s711ms
    After:
    12-04 09:13:18.248  1876  1898 I ActivityManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +3s608ms
    12-04 09:13:24.087  1876  1898 I ActivityManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +3s570ms
    12-04 09:13:29.997  1876  1898 I ActivityManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +3s566ms
    12-04 09:13:35.805  1876  1898 I ActivityManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +3s498ms
    12-04 09:13:41.670  1876  1898 I ActivityManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +3s475ms

It seems like this might be saving us as much as ~250ms to the total
startup on a HAXM emulator in Debug mode?