### PR TITLE
Enabling restore for multiple solutions.

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/Context.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Context.cs
@@ -18,8 +18,17 @@ namespace Xamarin.Android.Prepare
 		public const ConsoleColor FailureColor                = ConsoleColor.Red;
 		public const ConsoleColor WarningColor                = ConsoleColor.Yellow;
 
-		static readonly string XASolutionFilePath             = Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "Xamarin.Android.sln");
-		static readonly string XATestsSolutionFilePath        = Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "Xamarin.Android-Tests.sln");
+		static readonly IEnumerable<string> XASolutionFilesPath = new string []
+		{
+			Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "Xamarin.Android.BootstrapTasks.sln"),
+			Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "Xamarin.Android.Build.Tasks.sln"),
+			Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "Xamarin.Android.sln"),
+		};
+
+		static readonly IEnumerable<string> XATestsSolutionFilesPath = new string []
+		{
+			Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "Xamarin.Android-Tests.sln"),
+		};
 
 		string logDirectory;
 		string mainLogFilePath;
@@ -171,12 +180,12 @@ namespace Xamarin.Android.Prepare
 		/// <summary>
 		///   Path to the Xamarin.Android solution file
 		/// </summary>
-		public string XASolutionFile                      => XASolutionFilePath;
+		public IEnumerable<string> XASolutionFiles		=> XASolutionFilesPath;
 
 		/// <summary>
 		///   Path to the Xamarin.Android tests solution file
 		/// </summary>
-		public string XATestsSolutionFile                 => XATestsSolutionFilePath;
+		public IEnumerable<string> XATestsSolutionFiles 	=> XATestsSolutionFilesPath;
 
 		/// <summary>
 		///   If <c>true</c>, the current console is capable of displayig UTF-8 characters

--- a/build-tools/xaprepare/xaprepare/Application/Context.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Context.cs
@@ -18,15 +18,13 @@ namespace Xamarin.Android.Prepare
 		public const ConsoleColor FailureColor                = ConsoleColor.Red;
 		public const ConsoleColor WarningColor                = ConsoleColor.Yellow;
 
-		static readonly IEnumerable<string> XASolutionFilesPath = new string []
-		{
+		static readonly IEnumerable<string> XASolutionFilesPath         = new string [] {
 			Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "Xamarin.Android.BootstrapTasks.sln"),
 			Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "Xamarin.Android.Build.Tasks.sln"),
 			Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "Xamarin.Android.sln"),
 		};
 
-		static readonly IEnumerable<string> XATestsSolutionFilesPath = new string []
-		{
+		static readonly IEnumerable<string> XATestsSolutionFilesPath    = new string [] {
 			Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "Xamarin.Android-Tests.sln"),
 		};
 
@@ -180,12 +178,12 @@ namespace Xamarin.Android.Prepare
 		/// <summary>
 		///   Path to the Xamarin.Android solution file
 		/// </summary>
-		public IEnumerable<string> XASolutionFiles		=> XASolutionFilesPath;
+		public IEnumerable<string> XASolutionFiles        => XASolutionFilesPath;
 
 		/// <summary>
 		///   Path to the Xamarin.Android tests solution file
 		/// </summary>
-		public IEnumerable<string> XATestsSolutionFiles 	=> XATestsSolutionFilesPath;
+		public IEnumerable<string> XATestsSolutionFiles   => XATestsSolutionFilesPath;
 
 		/// <summary>
 		///   If <c>true</c>, the current console is capable of displayig UTF-8 characters

--- a/build-tools/xaprepare/xaprepare/Steps/Step_PrepareExternal.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_PrepareExternal.cs
@@ -14,13 +14,18 @@ namespace Xamarin.Android.Prepare
 		{
 			var nuget = new NuGetRunner (context);
 
-			if (!await NuGetRestore (nuget, context.XASolutionFile)) {
-				return false;
+			foreach (var solutionFile in context.XASolutionFiles) {
+				if (!await NuGetRestore (nuget, solutionFile)) {
+					return false;
+				}
 			}
 
 			Log.StatusLine ();
-			if (!await NuGetRestore (nuget, context.XATestsSolutionFile)) {
-				return false;
+
+			foreach (var solutionFile in context.XATestsSolutionFiles) {
+				if (!await NuGetRestore (nuget, solutionFile)) {
+					return false;
+				}
 			}
 
 			var msbuild = new MSBuildRunner (context);


### PR DESCRIPTION
We currently only support restore for a single solution (Xamarin.Android.sln), those changes enable we support restore for multiple solutions.