### PR TITLE
[Xamarin.Android.Build.Tasks] Allow BuildApk to run incrementally.

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -108,7 +108,7 @@
     <_TestsProfiledAotName Condition=" '$(AndroidEnableProfiledAot)' == 'true' ">-Profiled</_TestsProfiledAotName>
     <_TestsBundleName Condition=" '$(BundleAssemblies)' == 'true' ">-Bundle</_TestsBundleName>
     <TestsFlavor>$(_TestsProfiledAotName)$(_TestsAotName)$(_TestsBundleName)</TestsFlavor>
-    <LibZipSharpVersion>1.0.7</LibZipSharpVersion>
+    <LibZipSharpVersion>1.0.8</LibZipSharpVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MingwCommandPrefix32>i686-w64-mingw32</MingwCommandPrefix32>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ZipArchiveExTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ZipArchiveExTests.cs
@@ -1,6 +1,9 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
+using System;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Text;
+using System.Threading;
 using Xamarin.Android.Tasks;
 
 namespace Xamarin.Android.Build.Tests
@@ -8,41 +11,65 @@ namespace Xamarin.Android.Build.Tests
 	[TestFixture]
 	public class ZipArchiveExTests
 	{
-		string temp;
-		string zip;
+		ConcurrentDictionary<string, string> paths = new ConcurrentDictionary<string, string> ();
+		string root;
 
 		[SetUp]
 		public void SetUp ()
 		{
-			string root = Path.GetDirectoryName (GetType ().Assembly.Location);
-			temp = Path.Combine (root, "temp", TestContext.CurrentContext.Test.Name);
+			root = Path.GetDirectoryName (GetType ().Assembly.Location);
+			string temp = Path.Combine (root, "temp", TestContext.CurrentContext.Test.Name);
+			if (Directory.Exists (temp))
+				Directory.Delete (temp, recursive: true);
+			if (File.Exists (Zip))
+				File.Delete (Zip);
 			Directory.CreateDirectory (temp);
-			zip = Path.Combine (root, "test.zip");
+			paths.TryAdd (TestContext.CurrentContext.Test.Name, temp);
 		}
 
 		[TearDown]
 		public void TearDown ()
 		{
-			Directory.Delete (temp, true);
-			File.Delete (zip);
+			if (TestContext.CurrentContext.Result.Outcome.Status != NUnit.Framework.Interfaces.TestStatus.Passed) {
+				return;
+			}
+			Directory.Delete (TestPath, recursive: true);
+			File.Delete (Zip);
+			paths.TryRemove (TestContext.CurrentContext.Test.Name, out string value);
+		}
+
+		public string TestPath {
+			get {
+				paths.TryGetValue (TestContext.CurrentContext.Test.Name, out string value);
+				return value; 
+			}
+		}
+
+		public string Zip {
+			get {
+				return Path.Combine (root, "temp", $"{TestContext.CurrentContext.Test.Name}.zip"); 
+			}
 		}
 
 		void CreateDirectories (params string [] paths)
 		{
 			foreach (var path in paths) {
-				var dest = Path.Combine (temp, path);
+				var dest = Path.Combine (TestPath, path);
 				Directory.CreateDirectory (Path.GetDirectoryName (dest));
 				//Just put the path in the test file, for testing purposes
 				File.WriteAllText (dest, path);
 			}
 		}
 
+		static DateTime WithoutMilliseconds (DateTime t) =>
+			new DateTime (t.Year, t.Month, t.Day, t.Hour, t.Minute, t.Second, t.Kind);
+
 		void AssertZip (string expected)
 		{
-			FileAssert.Exists (zip, "Zip file should exist!");
+			FileAssert.Exists (Zip, "Zip file should exist!");
 
 			var builder = new StringBuilder ();
-			using (var archive = new ZipArchiveEx (zip, FileMode.Open)) {
+			using (var archive = new ZipArchiveEx (Zip, FileMode.Open)) {
 				foreach (var entry in archive.Archive) {
 					builder.AppendLine (entry.FullName);
 				}
@@ -51,13 +78,26 @@ namespace Xamarin.Android.Build.Tests
 			Assert.AreEqual (expected.Trim ().Replace("\r\n", "\n"), builder.ToString ().Trim ().Replace("\r\n", "\n"));
 		}
 
+		void AssertSkipExisting (string file, string fileInArchive, bool expected)
+		{
+			DateTime lastWrite =  File.GetLastWriteTimeUtc (file);
+			string path = Path.GetFullPath (file);
+			using (var archive = new ZipArchiveEx (Zip, FileMode.Open)) {
+				var entry = archive.Archive.ContainsEntry (fileInArchive) ? archive.Archive.ReadEntry (fileInArchive) : null;
+				var modTime = entry?.ModificationTime ?? DateTime.MinValue;
+				bool result = archive.SkipExistingFile (file, fileInArchive);
+				Assert.AreEqual (expected, result,
+					$"SkipExistingFile returned unexpected value for {Zip} {path} {fileInArchive}\n {WithoutMilliseconds(lastWrite)} (disk {lastWrite.ToString ("MM/dd/yyyy HH:mm:ss:fff")}) <= {WithoutMilliseconds (modTime)} (zip {modTime.ToString ("MM/dd/yyyy HH:mm:ss:fff")}) = {result}");
+			}
+		}
+
 		[Test]
 		public void AddDirectory ()
 		{
 			CreateDirectories ("A.txt", Path.Combine ("B", "B.txt"));
 
-			using (var archive = new ZipArchiveEx (zip, FileMode.Create)) {
-				archive.AddDirectory (temp, "temp");
+			using (var archive = new ZipArchiveEx (Zip, FileMode.Create)) {
+				archive.AddDirectory (TestPath, "temp");
 			}
 
 			AssertZip (
@@ -71,8 +111,8 @@ temp/B/B.txt");
 		{
 			CreateDirectories ("A.txt", Path.Combine ("B", "B.txt"));
 
-			using (var archive = new ZipArchiveEx (zip, FileMode.Create)) {
-				archive.AddDirectory (temp + $@"\../{nameof (AddDirectoryOddPaths)}/", "temp");
+			using (var archive = new ZipArchiveEx (Zip, FileMode.Create)) {
+				archive.AddDirectory (TestPath + $@"\../{nameof (AddDirectoryOddPaths)}/", "temp");
 			}
 
 			AssertZip (
@@ -88,9 +128,9 @@ temp/B/B.txt");
 
 			string cwd = Directory.GetCurrentDirectory ();
 			try {
-				Directory.SetCurrentDirectory (temp);
+				Directory.SetCurrentDirectory (TestPath);
 
-				using (var archive = new ZipArchiveEx (zip, FileMode.Create)) {
+				using (var archive = new ZipArchiveEx (Zip, FileMode.Create)) {
 					archive.AddDirectory (".", "temp");
 				}
 
@@ -101,6 +141,47 @@ temp/B/B.txt");
 			} finally {
 				Directory.SetCurrentDirectory (cwd);
 			}
+		}
+
+		[Test]
+		[Repeat(100)]
+		public void SkipExistingFile_Exist ()
+		{
+			CreateDirectories ("A.txt", Path.Combine ("B", "B.txt"));
+
+			DateTime lastWrite =  File.GetLastWriteTimeUtc (Path.Combine (TestPath, "A.txt"));
+			using (var archive = new ZipArchiveEx (Zip, FileMode.Create)) {
+				archive.AddDirectory (TestPath, folderInArchive: "");
+			}
+
+			AssertZip (
+@"A.txt
+B/
+B/B.txt");
+			AssertSkipExisting (Path.Combine (TestPath, "A.txt"), "A.txt", expected: true);
+			AssertSkipExisting (Path.Combine (TestPath, "B", "B.txt"), "B/B.txt", expected: true);
+			AssertSkipExisting (Path.Combine (TestPath, "C.txt"), "C.txt", expected: false);
+			AssertSkipExisting (Path.Combine (TestPath, "C", "C.txt"), "C/C.txt", expected: false);
+		}
+
+		[Test]
+		[Repeat(100)]
+		public void SkipExistingFile_TimeStamp ()
+		{
+			CreateDirectories ("A.txt", Path.Combine ("B", "B.txt"));
+
+			using (var archive = new ZipArchiveEx (Zip, FileMode.Create)) {
+				archive.AddDirectory (TestPath, folderInArchive: "");
+			}
+
+			AssertZip (
+@"A.txt
+B/
+B/B.txt");
+			var file = Path.Combine (TestPath, "A.txt");
+			File.SetLastWriteTimeUtc (file, DateTime.UtcNow.AddSeconds (1));
+			AssertSkipExisting (file, "A.txt", expected: false);
+			AssertSkipExisting (Path.Combine (TestPath, "B", "B.txt"), "B/B.txt", expected: true);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -272,7 +272,7 @@ namespace Xamarin.ProjectTools
 					continue;
 				}
 				string filedir = directory;
-				if (path.Contains (Path.DirectorySeparatorChar)) {
+				if (path.Contains ($"{Path.DirectorySeparatorChar}")) {
 					filedir = Path.GetDirectoryName (path);
 					if (!Directory.Exists (filedir) && (p.Content != null || p.BinaryContent != null))
 						Directory.CreateDirectory (filedir);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ZipArchiveEx.cs
@@ -129,6 +129,30 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
+		public bool SkipExistingFile (string file, string fileInArchive)
+		{
+			if (!zip.ContainsEntry (fileInArchive)) {
+				return false;
+			}
+			var lastWrite = File.GetLastWriteTimeUtc (file);
+			var entry = zip.ReadEntry (fileInArchive);
+			return WithoutMilliseconds (lastWrite) <= WithoutMilliseconds (entry.ModificationTime);
+		}
+
+		public bool SkipExistingEntry (ZipEntry sourceEntry, string fileInArchive)
+		{
+			if (!zip.ContainsEntry (fileInArchive)) {
+				return false;
+			}
+			var entry = zip.ReadEntry (fileInArchive);
+			return WithoutMilliseconds (sourceEntry.ModificationTime) <= WithoutMilliseconds (entry.ModificationTime);
+		}
+
+		// The zip file and macOS/mono does not contain milliseconds
+		// Windows *does* contain milliseconds
+		static DateTime WithoutMilliseconds (DateTime t) =>
+			new DateTime (t.Year, t.Month, t.Day, t.Hour, t.Minute, t.Second, t.Kind);
+
 		public void Dispose ()
 		{
 			Dispose(true);

--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -4,8 +4,8 @@ Test Name,Time in ms (int)
 # Data
 Build_No_Changes,3350
 Build_CSharp_Change,4100
-Build_AndroidResource_Change,4350
-Build_AndroidManifest_Change,4650
+Build_AndroidResource_Change,4250
+Build_AndroidManifest_Change,4250
 Build_Designer_Change,3750
 Build_JLO_Change,8150
 Build_CSProj_Change,9800


### PR DESCRIPTION
The `BuildApk` task currently does not work incrementally.
When it is called it throws away the previously built apk
in favour of using the `base` on that `aapt/aapt2` just built.
With incremental builds it is highly likely that only a
few files have actually changed so we are wasting a ton of time.

During my tests on a simple app `BuildApk` generally takes
about 4 seconds to run. This is the same for both clean
and incremental builds.
With these changes, this time could now go down to 600 ms
for an incremental build. Which is a decent improvement.

The new system does not throw away all the work done in
the previous build. Instead it uses the previous output
apk as a base on which to produce the new one.
The output from `aapt/aapt2` is instead `merged` into the
current apk. We do this by checking the `CRC` values of
each entry and only merging in files which have actually
changed. We need to use the `CRC` here because `aapt/aapt2`
is NEVER setting the `ModifiedDate` on the zip items :(.
It seems to always be 01/01/1980.

Once those changes are out of the way , we can now move on
to our custom content. This time we can use the `ModifiedDate`
of both the `ZipEntry` AND the source file. This allows us
to, again, only update the items which have accutally changed.

One final part is we need to keep track of what files are in the
`apk` in the first place and which ones get added to it. This is
what the `existingEntries` List is used for. This allows us to
detect when files are REMOVED from the system. Otherwise we end up
with stale files in the apk from previous builds.

On my tests when changing a single AndroidResource file I got
the following results

	3664 ms BuildApk                  1 calls (Before)
	669 ms BuildApk                  1 calls (After)

Which is a decent improvement.