### PR TITLE
[manifestmerger] needs a .gitignore file

### DIFF
--- a/src/manifestmerger/.gitignore
+++ b/src/manifestmerger/.gitignore
@@ -1,0 +1,6 @@
+.idea/
+build/
+out/
+.classpath
+.project
+.settings/


### PR DESCRIPTION
I was seeing files in my working tree after a build, I reused the `.gitignore` that `r8` is using.