### PR TITLE
[Xamarin.Android.Build.Tasks] r8 duplicate resource warnings -> messages

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/D8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/D8.cs
@@ -2,6 +2,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks
@@ -109,6 +110,21 @@ namespace Xamarin.Android.Tasks
 				cmd.AppendFileNameIfNotNull (jar);
 
 			return cmd;
+		}
+
+		/// <summary>
+		/// r8 tends to print:
+		/// Warning: Resource 'META-INF/MANIFEST.MF' already exists.
+		/// </summary>
+		static readonly Regex resourceWarning = new Regex ("Warning: Resource.+already exists", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
+		{
+			if (resourceWarning.IsMatch (singleLine)) {
+				Log.LogMessage (messageImportance, singleLine);
+			} else {
+				base.LogEventsFromTextOutput (singleLine, messageImportance);
+			}
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -72,55 +72,70 @@ namespace Xamarin.Android.Build.Tests
 			new object [] {
 				/* isRelease */     false,
 				/* xamarinForms */  false,
+				/* multidex */      false,
 				/* packageFormat */ "apk",
 			},
 			new object [] {
 				/* isRelease */     false,
 				/* xamarinForms */  true,
+				/* multidex */      false,
+				/* packageFormat */ "apk",
+			},
+			new object [] {
+				/* isRelease */     false,
+				/* xamarinForms */  true,
+				/* multidex */      true,
 				/* packageFormat */ "apk",
 			},
 			new object [] {
 				/* isRelease */     true,
 				/* xamarinForms */  false,
+				/* multidex */      false,
 				/* packageFormat */ "apk",
 			},
 			new object [] {
 				/* isRelease */     true,
 				/* xamarinForms */  true,
+				/* multidex */      false,
 				/* packageFormat */ "apk",
 			},
 			new object [] {
 				/* isRelease */     false,
 				/* xamarinForms */  false,
+				/* multidex */      false,
 				/* packageFormat */ "aab",
 			},
 			new object [] {
 				/* isRelease */     true,
 				/* xamarinForms */  false,
+				/* multidex */      false,
 				/* packageFormat */ "aab",
 			},
 		};
 
 		[Test]
 		[TestCaseSource (nameof (BuildHasNoWarningsSource))]
-		public void BuildHasNoWarnings (bool isRelease, bool xamarinForms, string packageFormat)
+		public void BuildHasNoWarnings (bool isRelease, bool xamarinForms, bool multidex, string packageFormat)
 		{
 			var proj = xamarinForms ?
 				new XamarinFormsAndroidApplicationProject () :
 				new XamarinAndroidApplicationProject ();
+			if (multidex) {
+				proj.SetProperty ("AndroidEnableMultiDex", "True");
+			}
 			if (packageFormat == "aab") {
 				// Disable fast deployment for aabs, because we give:
 				//	XA0119: Using Fast Deployment and Android App Bundles at the same time is not recommended.
 				proj.EmbedAssembliesIntoApk = true;
 				proj.AndroidUseSharedRuntime = false;
 			}
+			proj.SetProperty ("XamarinAndroidSupportSkipVerifyVersions", "True"); // Disables API 29 warning in Xamarin.Build.Download
 			proj.SetProperty ("AndroidPackageFormat", packageFormat);
 			proj.IsRelease = isRelease;
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				if (xamarinForms) {
-					// With Android API Level 29, we will get a warning: "... is only compatible with TargetFrameworkVersion: MonoAndroid,v9.0 (Android API Level 28)"
-					// We should allow a maximum of 1 warning to cover this case until the packages get updated to be compatible with Api level 29
+				if (multidex) {
+					// R8 currently gives: The rule `-keep public class * extends java.lang.annotation.Annotation { *; }` uses extends but actually matches implements.
 					Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, " 1 Warning(s)"), "Should have no more than 1 MSBuild warnings.");
 				} else {
 					Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, " 0 Warning(s)"), "Should have no MSBuild warnings.");


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3622
Context: https://r8.googlesource.com/r8/

Just building a Xamairn.Forms template with multi-dex enabled produces
the warning:

    R8 : warning : Resource 'META-INF/MANIFEST.MF' already exists.

There are also other reports of:

    R8 : warning : Resource 'META-INF/MSFTSIG.SF' already exists.
    R8 : warning : Resource 'META-INF/MSFTSIG.RSA' already exists.

Reviewing r8's source code, I see no way to prevent it from emitting
these messages.

For now, it seems simple enough to add a `Regex` for this message and
downgrade it to a regular MSBuild message.

I added a test for this scenario as well, however I was also getting
this message from r8:

    Warning: The rule `-keep public class * extends java.lang.annotation.Annotation { *; }` uses extends but actually matches implements.

I don't think we should downgrade this one, yet... I reworked the test
so allow 1 warning and used a property to disable a warning coming
from Xamarin.Build.Download.