### PR TITLE
Allow installing the SDK if one doesn't exist

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -4209,9 +4209,11 @@ namespace UnnamedProject
 				Environment.SetEnvironmentVariable ("ANDROID_SDK_PATH", sdkPath);
 				var proj = new XamarinAndroidApplicationProject ();
 				using (var b = CreateApkBuilder ()) {
+					string defaultTarget = b.Target;
 					b.Target = "InstallAndroidDependencies";
-
-					Assert.IsTrue (b.Build (proj, parameters: new string [] { "AcceptAndroidSDKLicenses=true" }), "build should have succeeded.");
+					Assert.IsTrue (b.Build (proj, parameters: new string [] { "AcceptAndroidSDKLicenses=true" }), "InstallAndroidDependencies should have succeeded.");
+					b.Target = defaultTarget;
+					Assert.IsTrue (b.Build (proj), "build should have succeeded.");
 				}
 			} finally {
 				Environment.SetEnvironmentVariable ("ANDROID_SDK_PATH", old);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -4197,5 +4197,25 @@ namespace UnnamedProject
 				}
 			}
 		}
+
+		[Test]
+		public void InstallAndroidDependenciesTest ()
+		{
+			if (!CommercialBuildAvailable)
+				Assert.Ignore ("Not required on Open Source Builds");
+			var old = Environment.GetEnvironmentVariable ("ANDROID_SDK_PATH");
+			try {
+				string sdkPath = Path.Combine (Root, "temp", TestName, "android-sdk");
+				Environment.SetEnvironmentVariable ("ANDROID_SDK_PATH", sdkPath);
+				var proj = new XamarinAndroidApplicationProject ();
+				using (var b = CreateApkBuilder ()) {
+					b.Target = "InstallAndroidDependencies";
+
+					Assert.IsTrue (b.Build (proj, parameters: new string [] { "AcceptAndroidSDKLicenses=true" }), "build should have succeeded.");
+				}
+			} finally {
+				Environment.SetEnvironmentVariable ("ANDROID_SDK_PATH", old);
+			}
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -803,7 +803,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	</ResolveJdkJvmPath>
 	<ValidateJavaVersion
 			Condition=" '$(DesignTimeBuild)' != 'True' Or '$(AndroidUseManagedDesignTimeResourceGenerator)' != 'True' "
-      ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
+			ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
 			TargetFrameworkVersion="$(TargetFrameworkVersion)"
 			AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
 			JavaSdkPath="$(_JavaSdkDirectory)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -803,6 +803,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	</ResolveJdkJvmPath>
 	<ValidateJavaVersion
 			Condition=" '$(DesignTimeBuild)' != 'True' Or '$(AndroidUseManagedDesignTimeResourceGenerator)' != 'True' "
+      ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
 			TargetFrameworkVersion="$(TargetFrameworkVersion)"
 			AndroidSdkBuildToolsVersion="$(AndroidSdkBuildToolsVersion)"
 			JavaSdkPath="$(_JavaSdkDirectory)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -780,6 +780,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     <_AndroidAllowMissingSdkTooling Condition=" '$(_AndroidAllowMissingSdkTooling)' == '' ">False</_AndroidAllowMissingSdkTooling>
 	</PropertyGroup>
 	<ResolveSdks
+			ContinueOnError="$(_AndroidAllowMissingSdkTooling)"
 			AndroidSdkPath="$(AndroidSdkDirectory)"
 			AndroidNdkPath="$(AndroidNdkDirectory)"
 			JavaSdkPath="$(JavaSdkDirectory)"


### PR DESCRIPTION
Fixes #3996

Commit 008ba98 did not go far enough. Both `ValidateJavaVersion` and `ResolveSdks` also needed the same `ContinueOnError` setting. While the commit did allow users to install components which were missing, it did NOT allow users to install the entire SDK. This is because even when calling's the `InstallAndroidDependencies` target the build would still fail with 

```
error XA5300: The Android SDK Directory could not be found. Please set via /p:AndroidSdkDirectory.
```

What we need to do in this case was include the `ContinueOnError` property on `ValidateJavaVersion` and `ResolveSdks`. This allows the build to continue and call the targets to install the required sdk. This is very handy for CI environments as it means we can install the Android SDK from scratch on a clean machine.