### PR TITLE
Remove libzip from build tools

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
@@ -14,11 +14,6 @@ namespace Xamarin.Android.Prepare
 				MinimumVersion = "2.20.0",
 			},
 
-			new HomebrewProgram ("libzip", new Uri ("https://raw.githubusercontent.com/Homebrew/homebrew-core/3d9a3eb3a62ed9586cd8f6b3bf506845159f39a4/Formula/libzip.rb")) {
-				MinimumVersion = "1.5.2",
-				Pin = true,
-			},
-
 			new HomebrewProgram ("make"),
 
 			new HomebrewProgram ("mingw-w64", new Uri ("https://raw.githubusercontent.com/Homebrew/homebrew-core/a6542037a48a55061a4c319e6bb174b3715f7cbe/Formula/mingw-w64.rb")) {


### PR DESCRIPTION
#3375 removed libzip in favor of a nuget dependency

If I understand correctly, this no longer is required by the build tools (although I'm still trying to get to build locally)

<img width="506" alt="image" src="https://user-images.githubusercontent.com/1633368/70381451-728d6500-1918-11ea-97c4-69336fcebc10.png">
