### PR TITLE
[tests] improve performance test for JLO change

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -143,15 +143,33 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void Build_JLO_Change ()
 		{
+			var className = "Foo";
 			var proj = new XamarinAndroidApplicationProject ();
-			proj.MainActivity = proj.DefaultMainActivity;
+			proj.Sources.Add (new BuildItem.Source ("Foo.cs") {
+				TextContent = () => $"class {className} : Java.Lang.Object {{}}"
+			});
 			using (var builder = CreateApkBuilder ()) {
 				builder.Target = "Build";
 				builder.Build (proj);
 
 				// Profile Java.Lang.Object rename
-				proj.MainActivity = proj.MainActivity.Replace ("MainActivity", "MainActivity2");
-				proj.Touch ("MainActivity.cs");
+				className = "Foo2";
+				proj.Touch ("Foo.cs");
+				Profile (builder, b => b.Build (proj));
+			}
+		}
+
+		[Test]
+		public void Build_AndroidManifest_Change ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			using (var builder = CreateApkBuilder ()) {
+				builder.Target = "Build";
+				builder.Build (proj);
+
+				// Profile AndroidManifest.xml change
+				proj.AndroidManifest += $"{Environment.NewLine}<!--comment-->";
+				proj.Touch ("Properties\\AndroidManifest.xml");
 				Profile (builder, b => b.Build (proj));
 			}
 		}

--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -5,8 +5,9 @@ Test Name,Time in ms (int)
 Build_No_Changes,3350
 Build_CSharp_Change,4100
 Build_AndroidResource_Change,4350
+Build_AndroidManifest_Change,4650
 Build_Designer_Change,3750
-Build_JLO_Change,9000
+Build_JLO_Change,8150
 Build_CSProj_Change,9800
 Build_XAML_Change,9600
 Build_XAML_Change_RefAssembly,6350


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4003#issuecomment-563274531

Since 2c6f5cd1, I believe we are hitting a performance regression in
the `Build_JLO_Change` test:

    Building target "_ManifestMerger" completely.
    Input file "obj/Debug/AndroidManifest.xml" is newer than output file "obj/Debug/android/AndroidManifest.xml".

Fortunately, I think we just need to change the test. The test itself
alters `AndroidManifest.xml` when the activity's name is changed:

```diff
-<activity android:name=".MainActivity">
+<activity android:name=".MainActivity2">
```

I added a new test that specifically times a `AndroidManifest.xml`
change vs a `Java.Lang.Object` subclass change.