### PR TITLE
[xaprepare] Update Android 10 name

### DIFF
--- a/Documentation/release-notes/4011.md
+++ b/Documentation/release-notes/4011.md
@@ -1,0 +1,6 @@
+### Issues fixed
+
+  * [GitHub PR 4011](https://github.com/xamarin/xamarin-android/pull/4011):
+    The old *Q* nickname from the Android 10 preview versions was still being
+    shown for Android 10 in the Visual Studio project property pages and the
+    Android SDK Manager.

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Android.Prepare
 			new AndroidPlatform (apiName: "Oreo",                   apiLevel: 26, platformID: "26",  include: "v8.0",    framework: "v8.0"),
 			new AndroidPlatform (apiName: "Oreo",                   apiLevel: 27, platformID: "27",  include: "v8.1",    framework: "v8.1"),
 			new AndroidPlatform (apiName: "Pie",                    apiLevel: 28, platformID: "28",  include: "v9.0",    framework: "v9.0"),
-			new AndroidPlatform (apiName: "Q",                      apiLevel: 29, platformID: "29",  include: "v10.0",   framework: "v10.0"),
+			new AndroidPlatform (apiName: "Android 10",             apiLevel: 29, platformID: "29",  include: "v10.0",   framework: "v10.0"),
 		};
 
 		public static readonly Dictionary<string, uint> NdkMinimumAPI = new Dictionary<string, uint> {

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Android.Prepare
 			new AndroidPlatform (apiName: "Oreo",                   apiLevel: 26, platformID: "26",  include: "v8.0",    framework: "v8.0"),
 			new AndroidPlatform (apiName: "Oreo",                   apiLevel: 27, platformID: "27",  include: "v8.1",    framework: "v8.1"),
 			new AndroidPlatform (apiName: "Pie",                    apiLevel: 28, platformID: "28",  include: "v9.0",    framework: "v9.0"),
-			new AndroidPlatform (apiName: "Android 10",             apiLevel: 29, platformID: "29",  include: "v10.0",   framework: "v10.0"),
+			new AndroidPlatform (apiName: "",                       apiLevel: 29, platformID: "29",  include: "v10.0",   framework: "v10.0"),
 		};
 
 		public static readonly Dictionary<string, uint> NdkMinimumAPI = new Dictionary<string, uint> {


### PR DESCRIPTION
Context: https://www.blog.google/products/android/evolving-android-brand/

Starting with Android 10, Google is no longer adding nicknames to the
Android releases.