### PR TITLE
[build] Remove empty files and references

### DIFF
--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -69,8 +69,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "sqlite-xamarin", "src\sqlit
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTK", "src\OpenTK-1.0\OpenTK.csproj", "{5EB9E888-E357-417E-9F39-DDEC195CE47F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "create-bundle", "build-tools\create-bundle\create-bundle.csproj", "{1640725C-4DB8-4D8D-BC96-74E688A06EEF}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Android.Cecil", "external\Java.Interop\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.csproj", "{15945D4B-FF56-4BCC-B598-2718D199DD08}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Android.Cecil.Mdb", "external\Java.Interop\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.Mdb.csproj", "{C0487169-8F81-497F-919E-EB42B1D0243F}"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.Windows.projitems
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.Windows.projitems
@@ -1,3 +1,0 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-</Project>

--- a/tools/xabuild/packages.config
+++ b/tools/xabuild/packages.config
@@ -1,3 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-</packages>

--- a/tools/xabuild/xabuild.csproj
+++ b/tools/xabuild/xabuild.csproj
@@ -52,7 +52,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\scripts\xabuild">


### PR DESCRIPTION
Removes the `create-bundle.csproj` reference from `Xamarin.Android.sln`.
Removes an empty `packages.config` file from `xabuild`.
Removes the empty and unused `Xamarin.ProjectTools.Windows.projitems`.