### PR TITLE
[tests] Use non-parallel fixture for InstallAndroidDependencies

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using Xamarin.ProjectTools;
+
+namespace Xamarin.Android.Build.Tests
+{
+	[TestFixture]
+	[NonParallelizable] // Do not run environment modifying tests in parallel.
+	public class AndroidDependenciesTests : BaseTest
+	{
+		[Test]
+		public void InstallAndroidDependenciesTest ()
+		{
+			if (!CommercialBuildAvailable)
+				Assert.Ignore ("Not required on Open Source Builds");
+			var old = Environment.GetEnvironmentVariable ("ANDROID_SDK_PATH");
+			try {
+				string sdkPath = Path.Combine (Root, "temp", TestName, "android-sdk");
+				Environment.SetEnvironmentVariable ("ANDROID_SDK_PATH", sdkPath);
+				var proj = new XamarinAndroidApplicationProject ();
+				using (var b = CreateApkBuilder ()) {
+					string defaultTarget = b.Target;
+					b.Target = "InstallAndroidDependencies";
+					Assert.IsTrue (b.Build (proj, parameters: new string [] { "AcceptAndroidSDKLicenses=true" }), "InstallAndroidDependencies should have succeeded.");
+					b.Target = defaultTarget;
+					Assert.IsTrue (b.Build (proj), "build should have succeeded.");
+				}
+			} finally {
+				Environment.SetEnvironmentVariable ("ANDROID_SDK_PATH", old);
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -4212,27 +4212,5 @@ namespace UnnamedProject
 				}
 			}
 		}
-
-		[Test]
-		public void InstallAndroidDependenciesTest ()
-		{
-			if (!CommercialBuildAvailable)
-				Assert.Ignore ("Not required on Open Source Builds");
-			var old = Environment.GetEnvironmentVariable ("ANDROID_SDK_PATH");
-			try {
-				string sdkPath = Path.Combine (Root, "temp", TestName, "android-sdk");
-				Environment.SetEnvironmentVariable ("ANDROID_SDK_PATH", sdkPath);
-				var proj = new XamarinAndroidApplicationProject ();
-				using (var b = CreateApkBuilder ()) {
-					string defaultTarget = b.Target;
-					b.Target = "InstallAndroidDependencies";
-					Assert.IsTrue (b.Build (proj, parameters: new string [] { "AcceptAndroidSDKLicenses=true" }), "InstallAndroidDependencies should have succeeded.");
-					b.Target = defaultTarget;
-					Assert.IsTrue (b.Build (proj), "build should have succeeded.");
-				}
-			} finally {
-				Environment.SetEnvironmentVariable ("ANDROID_SDK_PATH", old);
-			}
-		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.Shared.projitems
@@ -32,5 +32,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\EnvironmentHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\PackagingUtilsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WearTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AndroidDependenciesTests.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3307232&view=ms.vss-test-web.test-result-details

We noticed a failure in the `DuplicateReferences` test, which appeared
to be caused by an incorrect Android SDK path being used. MSBuild tests
which build a project will look for the Android SDK in the following
paths:

  1) Value of `$(ANDROID_SDK_PATH)` if set.
  2) The `HKEY_CURRENT_USER\\SOFTWARE\\Novell\\Mono for Android` registry key.
  3) The path we install build tooling into: `%USERPROFILE%\android-toolchain\sdk`.

In the case of the `DuplicateReferences` test failure,
`$(ANDROID_SDK_PATH)` was set to an unexpected value:

    ANDROID_SDK_PATH = F:\A\xamarin-v000006-1\_work\2\s\bin\TestRelease\temp\InstallAndroidDependenciesTest\android-sdk

Presumably this failure occurred because the test ran in parallel with
the `InstallAndroidDependenciesTest` test which modifies the environment.

The fix is to move this test to it's own fixture that will not run in
parallel with other tests.