### PR TITLE
[Xamarin.Android.Build.Tasks] fix $(AndroidExplicitCrunch) warning

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -869,8 +869,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		<Reference Include="$(_JavaInteropReferences)" />
 	</ItemGroup>
 	<Warning Code="XA0110"
-		Text="Disabling $(AndroidExplicitCrunch) as it is not supported by `aapt2`. If you wish to use $(AndroidExplicitCrunch) please set $(AndroidUseAapt2) to false."
-		Condition="  '$(_AndroidUseAapt2)' == 'True' And '$(AndroidExplicitCrunch)' == 'True' "
+		Text="Disabling %24(AndroidExplicitCrunch) as it is not supported by `aapt2`. If you wish to use %24(AndroidExplicitCrunch) please set %24(AndroidUseAapt2) to false."
+		Condition=" '$(_AndroidUseAapt2)' == 'True' And '$(AndroidExplicitCrunch)' == 'True' "
 	/>
 	<PropertyGroup>
 		<AndroidExplicitCrunch Condition=" '$(_AndroidUseAapt2)' == 'True' ">false</AndroidExplicitCrunch>


### PR DESCRIPTION
This warning message actually prints:

    XA0110: Disabling true as it is not supported by `aapt2`. If you wish to use true please set True to false.

In the long term, I think we should remove `$(AndroidExplicitCrunch)`.
I have found some bugs using it that cause targets to re-run on
incremental builds. It is also not supported when using `aapt2`.

It's worth fixing the warning message for now, though.