### PR TITLE
[FixAbstractMethodsStep] Speedup the step

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
@@ -69,6 +69,9 @@ namespace MonoDroid.Tuner
 
 		bool FixAbstractMethodsUnconditional (AssemblyDefinition assembly)
 		{
+			if (!assembly.MainModule.HasTypeReference ("Java.Lang.Object"))
+				return false;
+
 			bool changed = false;
 			foreach (var type in assembly.MainModule.Types) {
 				if (MightNeedFix (type))

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -63,6 +63,10 @@ namespace Xamarin.Android.Build.Tests
 			Assert.IsTrue (impl.Methods.Any (m => m.Name == "MyAbstractMethod"), "We should have generated an override for MyAbstractMethod");
 			Assert.IsFalse (impl.Methods.Any (m => m.Name == "MyDefaultMethod"), "We should not have generated an override for MyDefaultMethod");
 
+			context.Dispose ();
+			assm.Dispose ();
+			android.Dispose ();
+
 			Directory.Delete (path, true);
 		}
 


### PR DESCRIPTION
By checking whether the assembly has a type reference to
`Java.Lang.Object` first. `ModuleDefinition::HasTypeReference` call is
relatively fast in cecil and by using it we save a lot of further
processing.

Measurements of the `_LinkAssembliesNoShrink` target (XA template,
rebuild after touching MainActivity.cs, 5 runs average):

Before: 160ms
After:   52ms