### PR TITLE
CheckApiCompat - Small code improvement

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CheckApiCompatibility.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CheckApiCompatibility.cs
@@ -178,6 +178,9 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 		{
 			// Load issues into a dictionary
 			var issuesFound = LoadIssues (content);
+			if (Log.HasLoggedErrors) {
+				return;
+			}
 
 			Dictionary<string, HashSet<string>> acceptableIssues = null;
 
@@ -194,6 +197,9 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				// Read and Convert the acceptable issues into a dictionary
 				using (var streamReader = new StreamReader (acceptableIssuesFile)) {
 					acceptableIssues = LoadIssues (streamReader);
+					if (Log.HasLoggedErrors) {
+						return;
+					}
 				}
 			}
 
@@ -267,7 +273,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 
 				if (currentSet == null) {
 					// Hashset should never be null, unless exception file is not defining assembly line.
-					Log.LogError ($"Exception report/file should start with: Compat issues with assembly");
+					Log.LogError ($"Exception report/file should start with: 'Compat issues with assembly'; was: '{line}'");
 					return null;
 				}
 


### PR DESCRIPTION
Small code improvement to provide more info in case of exception when reading breakages content.

We hit an exception on: https://jenkins.mono-project.com/job/xamarin-android-linux-pr-pipeline-debug/585/console
And it seems the exception happened when trying to read: https://github.com/xamarin/xamarin-android/blob/07e7477126fdc3eb68cca38347d1b8698d334874/tests/api-compatibility/acceptable-breakages-v7.0.txt#L1

Code expects to read `Compat issues with assembly` but it seems it is reading something else.
Changing the code to output what it is reading and also short-circuiting code in case an error has happened.

Build log:

```
[2019-12-11T15:42:23.286Z]   CheckApiCompatibility for ApiLevel: v7.0
[2019-12-11T15:42:23.325Z]   CompatApi command: ../../packages/Microsoft.DotNet.ApiCompat.5.0.0-beta.19606.1/tools/net472/Microsoft.DotNet.ApiCompat.exe "/mnt/jenkins/workspace/xamarin-android-linux-pr-pipeline-debug/xamarin-android/bin/Debug/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v6.0/ApiCompatTemp" -i "/mnt/jenkins/workspace/xamarin-android-linux-pr-pipeline-debug/xamarin-android/bin/Debug/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v7.0/ApiCompatTemp" --exclude-attributes ../../tests/api-compatibility/api-compat-exclude-attributes.txt 
[2019-12-11T15:42:34.760Z] /mnt/jenkins/workspace/xamarin-android-linux-pr-pipeline-debug/xamarin-android/src/Mono.Android/Mono.Android.targets(175,5): error : Exception report/file should start with: Compat issues with assembly [/mnt/jenkins/workspace/xamarin-android-linux-pr-pipeline-debug/xamarin-android/src/Mono.Android/Mono.Android.csproj]
```