### PR TITLE
[xabuild] Create symlinks to .NET Framework redirects

### DIFF
--- a/tools/xabuild/XABuild.cs
+++ b/tools/xabuild/XABuild.cs
@@ -40,6 +40,14 @@ namespace Xamarin.Android.Build
 
 				//Symbolic links to be created: key=in-tree-dir, value=system-dir
 				var symbolicLinks = new Dictionary<string, string> ();
+				if (paths.IsMacOS) {
+					foreach (var dir in Directory.EnumerateDirectories (paths.MonoSystemFrameworkRoot)) {
+						if (Path.GetFileName (dir).EndsWith ("-api", StringComparison.OrdinalIgnoreCase)){
+							var inTreeFramework = Path.Combine (paths.XamarinAndroidBuildOutput, "lib", "xamarin.android", Path.GetFileName (dir));
+							symbolicLinks [inTreeFramework] = dir;
+						}
+					}
+				}
 				foreach (var dir in Directory.EnumerateDirectories (paths.SystemFrameworks)) {
 					if (Path.GetFileName (dir) != "MonoAndroid") {
 						var inTreeFramework = Path.Combine (paths.FrameworksDirectory, Path.GetFileName (dir));

--- a/tools/xabuild/XABuildPaths.cs
+++ b/tools/xabuild/XABuildPaths.cs
@@ -79,6 +79,12 @@ namespace Xamarin.Android.Build
 		public string SystemFrameworks { get; private set; }
 
 		/// <summary>
+		/// Path to the system directory containing .NET Framework assembly directories (e.g. `4.7.2-api`) on macOS.
+		/// The .NETFramework directories identified in <see cref="SystemFrameworks"/> redirect to this location.
+		/// </summary>
+		public string MonoSystemFrameworkRoot { get; private set; }
+
+		/// <summary>
 		/// Path to the system directories for MSBuild targets, such as 15.0 and Microsoft, under $(MSBuildExtensionsPath) to be merged with in-tree MSBuildExtensionsPath
 		/// </summary>
 		public string [] SystemTargetsDirectories { get; private set; }
@@ -181,6 +187,7 @@ namespace Xamarin.Android.Build
 				DotNetSdkPath            = FindLatestDotNetSdk ("/usr/local/share/dotnet/sdk");
 				MSBuildSdksPath          = DotNetSdkPath ?? Path.Combine (MSBuildBin, "Sdks");
 				SystemFrameworks         = Path.Combine (mono, "xbuild-frameworks");
+				MonoSystemFrameworkRoot  = mono;
 
 				var systemTargetDirs = new List <string> ();
 				foreach (string vsVersion in vsVersions) {


### PR DESCRIPTION
The .NET Framework directories installed by "recent" versions of mono on
macOS have been updated to redirect to a new TargetFrameworkDirectory.
I believe these directories used to contain reference assemblies, but
at present they only contain a `RedistList/FrameworkList.xml` with the
following content:

    /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild-frameworks/.NETFramework/v4.7.2/RedistList/FrameworkList.xml

    <FileList  Name=".NET Framework 4.7.2" TargetFrameworkDirectory="..\..\..\..\4.7.2-api">
    </FileList>

The .NET Framework assemblies are now installed into `$(Version)-api`
folders such as:

    /Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.7.2-api

This causes an issue with xabuild. The `GetReferenceAssemblyPaths` task
fails to follow this relative path redirect, and as a result we fall
back to the Global Assembly Cache when running `Csc.exe`:

    /reference:/Library/Frameworks/Mono.framework/Versions/6.6.0/lib/mono/gac/System/4.0.0.0__b77a5c561934e089/System.dll

Update xabuild to create new symlinks so the `TargetFrameworkDirectory`
redirect happening above points to a folder that actually exists:

    [xabuild] creating symbolic link '/Users/peter/source/xamarin-android/bin/Release/lib/xamarin.android/4.7.2-api' -> '/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.7.2-api'
    [xabuild] creating symbolic link '/Users/peter/source/xamarin-android/bin/Release/lib/xamarin.android/3.5-api' -> '/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/3.5-api'
    [xabuild] creating symbolic link '/Users/peter/source/xamarin-android/bin/Release/lib/xamarin.android/4.5-api' -> '/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.5-api'
    [xabuild] creating symbolic link '/Users/peter/source/xamarin-android/bin/Release/lib/xamarin.android/4.6.2-api' -> '/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.6.2-api'
    [xabuild] creating symbolic link '/Users/peter/source/xamarin-android/bin/Release/lib/xamarin.android/2.0-api' -> '/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/2.0-api'
    [xabuild] creating symbolic link '/Users/peter/source/xamarin-android/bin/Release/lib/xamarin.android/4.6-api' -> '/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.6-api'
    [xabuild] creating symbolic link '/Users/peter/source/xamarin-android/bin/Release/lib/xamarin.android/4.7-api' -> '/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.7-api'
    [xabuild] creating symbolic link '/Users/peter/source/xamarin-android/bin/Release/lib/xamarin.android/4.6.1-api' -> '/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.6.1-api'
    [xabuild] creating symbolic link '/Users/peter/source/xamarin-android/bin/Release/lib/xamarin.android/4.0-api' -> '/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.0-api'
    [xabuild] creating symbolic link '/Users/peter/source/xamarin-android/bin/Release/lib/xamarin.android/4.8-api' -> '/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.8-api'
    [xabuild] creating symbolic link '/Users/peter/source/xamarin-android/bin/Release/lib/xamarin.android/xbuild-frameworks/.NETFramework' -> '/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild-frameworks/.NETFramework'