### PR TITLE
[Mono.Android] Adjust wording

### DIFF
--- a/src/Mono.Android/Android/IncludeAndroidResourcesFromAttribute.cs
+++ b/src/Mono.Android/Android/IncludeAndroidResourcesFromAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace Android {
 
 	[AttributeUsage (AttributeTargets.Assembly, AllowMultiple = true)]
-	[Obsolete ("This attribute is not longer supported.", error: true)]
+	[Obsolete ("This attribute is no longer supported.", error: true)]
 	public class IncludeAndroidResourcesFromAttribute : ReferenceFilesAttribute
 	{
 		public IncludeAndroidResourcesFromAttribute (string path)

--- a/src/Mono.Android/Android/NativeLibraryReferenceAttribute.cs
+++ b/src/Mono.Android/Android/NativeLibraryReferenceAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace Android {
 
 	[AttributeUsage (AttributeTargets.Assembly, AllowMultiple = true)]
-	[Obsolete ("This attribute is not longer supported.", error: true)]
+	[Obsolete ("This attribute is no longer supported.", error: true)]
 	sealed public class NativeLibraryReferenceAttribute : ReferenceFilesAttribute
 	{
 		public NativeLibraryReferenceAttribute (string filename)

--- a/src/Mono.Android/Android/ReferenceFilesAttribute.cs
+++ b/src/Mono.Android/Android/ReferenceFilesAttribute.cs
@@ -1,7 +1,7 @@
 using System;
 
 namespace Android {
-	[Obsolete ("This attribute is not longer supported.", error: true)]
+	[Obsolete ("This attribute is no longer supported.", error: true)]
 	public abstract class ReferenceFilesAttribute : Attribute
 	{
 		internal ReferenceFilesAttribute () {}

--- a/src/Mono.Android/Java.Interop/JavaLibraryReferenceAttribute.cs
+++ b/src/Mono.Android/Java.Interop/JavaLibraryReferenceAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace Java.Interop {
 
 	[AttributeUsage (AttributeTargets.Assembly, AllowMultiple = true)]
-	[Obsolete ("This attribute is not longer supported.", error: true)]
+	[Obsolete ("This attribute is no longer supported.", error: true)]
 	public class JavaLibraryReferenceAttribute : Android.ReferenceFilesAttribute
 	{
 		public JavaLibraryReferenceAttribute (string filename)


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/1a61fa811e370b68b38a7f318b7d4059dc70779e

The corresponding [backported commit][0] has not yet been published in a preview version, so there's an opportunity to make this tiny little change from "not" to "no" before the wording appears in a published build.

This is just a tiny wording item I noticed by chance while learning more about how the API compatibility check was working on my other PR. Hopefully these errors should be fairly uncommon for users anyway, but it looked like it might have been unintentional to say "not" rather than "no," so I thought it might be handy to switch that while we had a chance. No worries if not though.

[0]: https://github.com/xamarin/xamarin-android/commit/63a69872f3f9ae7e9ae43c7b23c4ce2d0b31715d