### PR TITLE
[ci] Use d16-5 designer source on d16-5

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -780,7 +780,7 @@ stages:
       EnableRegressionTest: true
     steps:
     - script: |
-        git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git
+        git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git --branch d16-5
         cd designer
         git submodule update -q --init --recursive
       displayName: Clone and update designer
@@ -816,7 +816,7 @@ stages:
       VisualStudioInstallationPath: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
     steps:
     - script: |
-        git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git
+        git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git --branch d16-5
         cd designer
         git submodule update -q --init --recursive
       displayName: Clone and update designer

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -779,9 +779,14 @@ stages:
     variables:
       EnableRegressionTest: true
     steps:
-    - script: |
-        git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git --branch d16-5
-        cd designer
+    - powershell: |
+        $branchPrefix = "/refs/heads/"
+        $branchName = $(System.PullRequest.TargetBranch) -replace $branchPrefix, ""
+        if ([string]::IsNullOrEmpty($branchName)) {
+            $branchName = $(Build.SourceBranch) -replace $branchPrefix, ""
+        }
+        git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git --branch $branchName
+        Set-Location -Path $(System.DefaultWorkingDirectory)/designer
         git submodule update -q --init --recursive
       displayName: Clone and update designer
 
@@ -815,9 +820,14 @@ stages:
       RegressionTestSuiteOutputDir: C:\Git\ADesRegTestSuite
       VisualStudioInstallationPath: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
     steps:
-    - script: |
-        git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git --branch d16-5
-        cd designer
+    - powershell: |
+        $branchPrefix = "/refs/heads/"
+        $branchName = $(System.PullRequest.TargetBranch) -replace $branchPrefix, ""
+        if ([string]::IsNullOrEmpty($branchName)) {
+            $branchName = $(Build.SourceBranch) -replace $branchPrefix, ""
+        }
+        git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git --branch $branchName
+        Set-Location -Path $(System.DefaultWorkingDirectory)\designer
         git submodule update -q --init --recursive
       displayName: Clone and update designer
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -780,10 +780,14 @@ stages:
       EnableRegressionTest: true
     steps:
     - powershell: |
+        # Use the branch name of the source being built or the PR target branch name. Fall back to 'master' if the branch is unknown.
         $branchPrefix = "/refs/heads/"
-        $branchName = "$(System.PullRequest.TargetBranch)" -replace $branchPrefix, ""
-        if ([string]::IsNullOrEmpty($branchName)) {
-            $branchName = "$(Build.SourceBranch)" -replace $branchPrefix, ""
+        $branchName = "$(Build.SourceBranch)" -replace $branchPrefix, ""
+        if ("$(Build.Reason)" -eq "PullRequest") {
+            $branchName = "$(System.PullRequest.TargetBranch)" -replace $branchPrefix, ""
+        }
+        if (("$branchName" -ne "master") -and ("$branchName" -notlike "d16*")) {
+            $branchName = "master"
         }
         Write-Host "cloning designer source from branch - '$branchName'"
         git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git --branch $branchName
@@ -822,14 +826,18 @@ stages:
       VisualStudioInstallationPath: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
     steps:
     - powershell: |
+        # Use the branch name of the source being built or the PR target branch name. Fall back to 'master' if the branch is unknown.
         $branchPrefix = "/refs/heads/"
-        $branchName = "$(System.PullRequest.TargetBranch)" -replace $branchPrefix, ""
-        if ([string]::IsNullOrEmpty($branchName)) {
-            $branchName = "$(Build.SourceBranch)" -replace $branchPrefix, ""
+        $branchName = "$(Build.SourceBranch)" -replace $branchPrefix, ""
+        if ("$(Build.Reason)" -eq "PullRequest") {
+            $branchName = "$(System.PullRequest.TargetBranch)" -replace $branchPrefix, ""
+        }
+        if (("$branchName" -ne "master") -and ("$branchName" -notlike "d16*")) {
+            $branchName = "master"
         }
         Write-Host "cloning designer source from branch - '$branchName'"
         git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git --branch $branchName
-        Set-Location -Path $(System.DefaultWorkingDirectory)\designer
+        Set-Location -Path $(System.DefaultWorkingDirectory)/designer
         git submodule update -q --init --recursive
       displayName: Clone and update designer
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -781,9 +781,9 @@ stages:
     steps:
     - powershell: |
         $branchPrefix = "/refs/heads/"
-        $branchName = $(System.PullRequest.TargetBranch) -replace $branchPrefix, ""
+        $branchName = "$(System.PullRequest.TargetBranch)" -replace $branchPrefix, ""
         if ([string]::IsNullOrEmpty($branchName)) {
-            $branchName = $(Build.SourceBranch) -replace $branchPrefix, ""
+            $branchName = "$(Build.SourceBranch)" -replace $branchPrefix, ""
         }
         git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git --branch $branchName
         Set-Location -Path $(System.DefaultWorkingDirectory)/designer
@@ -822,9 +822,9 @@ stages:
     steps:
     - powershell: |
         $branchPrefix = "/refs/heads/"
-        $branchName = $(System.PullRequest.TargetBranch) -replace $branchPrefix, ""
+        $branchName = "$(System.PullRequest.TargetBranch)" -replace $branchPrefix, ""
         if ([string]::IsNullOrEmpty($branchName)) {
-            $branchName = $(Build.SourceBranch) -replace $branchPrefix, ""
+            $branchName = "$(Build.SourceBranch)" -replace $branchPrefix, ""
         }
         git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git --branch $branchName
         Set-Location -Path $(System.DefaultWorkingDirectory)\designer

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -785,6 +785,7 @@ stages:
         if ([string]::IsNullOrEmpty($branchName)) {
             $branchName = "$(Build.SourceBranch)" -replace $branchPrefix, ""
         }
+        Write-Host "cloning designer source from branch - '$branchName'"
         git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git --branch $branchName
         Set-Location -Path $(System.DefaultWorkingDirectory)/designer
         git submodule update -q --init --recursive
@@ -826,6 +827,7 @@ stages:
         if ([string]::IsNullOrEmpty($branchName)) {
             $branchName = "$(Build.SourceBranch)" -replace $branchPrefix, ""
         }
+        Write-Host "cloning designer source from branch - '$branchName'"
         git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git --branch $branchName
         Set-Location -Path $(System.DefaultWorkingDirectory)\designer
         git submodule update -q --init --recursive


### PR DESCRIPTION
Attempts to clone the `designer` source branch that has the same name
as the target branch of the PR being built, or the branch of the commit
being built if we aren't building a PR.