### PR TITLE
[ci] Limit parallel scope for Windows tests

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -714,11 +714,14 @@ stages:
         artifactName: $(NuGetArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)
 
+    # Limit the amount of worker threads used to run these tests in parallel to half of what is currently available (8) on the Windows pool.
+    # Using all available cores seems to occasionally bog down our machines and cause parallel test execution to slow down dramatically.
     - template: yaml-templates\run-nunit-tests.yaml
       parameters:
         testRunTitle: Xamarin.Android.Build.Tests - Windows
         testAssembly: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\Xamarin.Android.Build.Tests.dll
         testResultsFile: TestResult-MSBuildTests-Windows-$(XA.Build.Configuration).xml
+        nunitConsoleExtraArgs: --workers=4
 
     - template: yaml-templates\run-nunit-tests.yaml
       parameters:


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/9eb4b7f16785902c8942c7f9c88b31cd48a2b9aa
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3316261&view=logs

In some cases our `Xamarin.Android.Build.Tests.dll` execution slows down
dramatically on Windows[0]. We'll attempt to address this by reducing the
amount of work we do in parallel. Our Windows agents seemingly
[have 8 cores available][1], and NUnit-Console will attempt to use all
cores when running tests in parallel by default. Setting the `--workers`
argument to 4 should cut our parallelization in half, and potentially
prevent the machine from running out of resources.

Commit 9eb4b7f16 introduced these changes, but only for the
`Windows Build and Test` job. I believe this should also be added to the
`Test MSBuild - Windows` job.

[0]:

    [TESTLOG] Test BuildProguardEnabledProjectTrued8proguard Starting
    Using C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe
    Using msbuild
    Found Time Elapsed 00:18:37.9800000
    [TESTLOG] Test BuildProguardEnabledProjectTrued8proguard Complete
    [TESTLOG] Test BuildProguardEnabledProjectTrued8proguard Outcome=Failed

[1]: https://dev.azure.com/devdiv/DevDiv/_settings/agentqueues?agentId=688797&queueId=819&view=capabilities