### PR TITLE
[Xamarin.Android.Build.Tasks] fix signing for App Bundles with multi-dex

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/PackagingUtilsTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/PackagingUtilsTests.cs
@@ -17,9 +17,18 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void JarManifest ()
+		public void SigningFiles ()
 		{
 			AssertIsNotValid ("META-INF/MANIFEST.MF");
+			AssertIsNotValid ("META-INF/MANIFEST.SF");
+			AssertIsNotValid ("META-INF/MSFTSIG.SF");
+			AssertIsNotValid ("META-INF/MSFTSIG.RSA");
+			AssertIsNotValid ("META-INF/GOOG.RSA");
+			AssertIsNotValid ("META-INF\\MANIFEST.MF");
+			AssertIsNotValid ("META-INF\\MANIFEST.SF");
+			AssertIsNotValid ("META-INF\\MSFTSIG.SF");
+			AssertIsNotValid ("META-INF\\MSFTSIG.RSA");
+			AssertIsNotValid ("META-INF\\GOOG.RSA");
 		}
 
 		[Test]


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3993

After 16.4 shipped, we started getting reports that App Bundle signing
was broken. Google Play was not accepting the file:

    You uploaded an APK or Android App Bundle with invalid or missing signing information for some of its files.
    You need to create a valid signed APK or Android App Bundle.

Both @pjcollins and myself tested this, but it worked for us?

Finally we discovered the issue only occurred when multi-dex was
enabled! I was able to reproduce the issue and do a diff of the file
contents of good and bad `.aab` files.

These two files were present in the broken App Bundle:

    +1969-12-31 18:00:00 .....         1480          716  base\root\META-INF\MSFTSIG.SF
    +1969-12-31 18:00:00 .....         8546         5469  base\root\META-INF\MSFTSIG.RSA

These definitely look signing related!

In c4f032a3, I ported some Java code from Android Studio to C# that
allowed Kotlin libraries to function.

Specifically files such as:

    META-INF/services/kotlinx.coroutines.internal.MainDispatcherFactory
    META-INF/services/kotlinx.coroutines.CoroutineExceptionHandler

Needed to be present in the APK. This inadvertently added files like
`META-INF\MSFTSIG.SF` also!

I checked the latest source from Android Studio:

https://android.googlesource.com/platform/tools/base/+/refs/heads/master/build-system/gradle-core/src/main/groovy/com/android/build/gradle/internal/tasks/ExtractJavaResourcesTask.java#199
https://android.googlesource.com/platform/tools/base/+/refs/heads/master/sdk-common/src/main/java/com/android/ide/common/packaging/PackagingUtils.java#24

I see nothing accounting for these files...

For now I think we should ignore:

* For files under `META-INF`
* Ignore `.SF`, `.MF`, and `.RSA` files

I updated a test to validate these changes.