### PR TITLE
Bump to xamarin/monodroid@2efbdd3e

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@1b907d680cc6561dcfaddc6f997d2f6ff5456644
+xamarin/monodroid:master@2efbdd3e04710a7887c3da676b275d425e167a43
 mono/mono:2019-10@18920a83f423fb864a2263948737681968f5b2c8


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/1b907d680cc6561dcfaddc6f997d2f6ff5456644...2efbdd3e04710a7887c3da676b275d425e167a43

    [tools/msbuild] another fix to <GetPrimaryCpuAbi/> (#1056)

    [ci] Build with on-prem hardware (#1054)

    [build] Convert build task and test projects to short-form style (#1048)