### PR TITLE
[Xamarin.Android.Build.Tasks] collision in <GenerateLibraryResources/>

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -286,6 +286,42 @@ class MemTest {
 		}
 
 		[Test]
+		public void DuplicateRJavaOutput ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				PackageReferences = {
+					new Package { Id = "Xamarin.Android.Support.Annotations", Version = "28.0.0.3" },
+					new Package { Id = "Xamarin.Android.Support.Compat", Version = "28.0.0.3" },
+					new Package { Id = "Xamarin.Android.Support.Core.UI", Version = "28.0.0.3" },
+					new Package { Id = "Xamarin.Android.Support.Core.Utils", Version = "28.0.0.3" },
+					new Package { Id = "Xamarin.Android.Support.Design", Version = "28.0.0.3" },
+					new Package { Id = "Xamarin.Android.Support.Fragment", Version = "28.0.0.3" },
+					new Package { Id = "Xamarin.Android.Support.VersionedParcelable", Version = "28.0.0.3" },
+					new Package { Id = "Xamarin.Android.Support.v4", Version = "28.0.0.3" },
+					new Package { Id = "Xamarin.Build.Download", Version = "0.7.1" },
+					new Package { Id = "Xamarin.Essentials", Version = "1.3.1" },
+					new Package { Id = "Xamarin.GooglePlayServices.Ads.Identifier", Version = "71.1600.0" },
+					new Package { Id = "Xamarin.GooglePlayServices.Base", Version = "71.1610.0" },
+					new Package { Id = "Xamarin.GooglePlayServices.Basement", Version = "71.1620.0" },
+					new Package { Id = "Xamarin.GooglePlayServices.Clearcut", Version = "71.1600.0" },
+					new Package { Id = "Xamarin.GooglePlayServices.Measurement.Api", Version = "71.1630.0" },
+					new Package { Id = "Xamarin.GooglePlayServices.Measurement.Base", Version = "71.1630.0" },
+					new Package { Id = "Xamarin.GooglePlayServices.Phenotype", Version = "71.1600.0" },
+					new Package { Id = "Xamarin.GooglePlayServices.Stats", Version = "71.1601.0" },
+					new Package { Id = "Xamarin.GooglePlayServices.Tasks", Version = "71.1601.0" },
+				}
+			};
+			using (var b = CreateApkBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "build should have succeeded.");
+				var lines = b.LastBuildOutput.Where (l => l.Contains ("Writing:") && l.Contains ("R.java"));
+				var hash = new HashSet<string> (StringComparer.Ordinal);
+				foreach (var duplicate in lines.Where (i => !hash.Add (i))) {
+					Assert.Fail ($"Duplicate: {duplicate}");
+				}
+			}
+		}
+
+		[Test]
 		public void BuildXamarinFormsMapsApplication ()
 		{
 			var proj = new XamarinFormsMapsApplicationProject ();


### PR DESCRIPTION
Fixes: https://developercommunity.visualstudio.com/content/problem/845345/cant-build-xamarin-for-android-project.html

We have been getting reports of an unhandled exception during builds
such as:

    Unhandled exception: System.IO.IOException: Sharing violation on path /Users/runner/runners/2.160.1/work/1/s/Droid/obj/Release/android/src/com/google/android/gms/base/R.java
        at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.Boolean anonymous, System.IO.FileOptions options) [0x0019e] in <ba70b91736bd40cb990a357097dba9c3>:0
        at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.Boolean isAsync, System.Boolean anonymous) [0x00000] in <ba70b91736bd40cb990a357097dba9c3>:0
        at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access) [0x00000] in <ba70b91736bd40cb990a357097dba9c3>:0
        at (wrapper remoting-invoke-with-check) System.IO.FileStream..ctor(string,System.IO.FileMode,System.IO.FileAccess)
        at Xamarin.Android.Tools.Files.HashFile (System.String filename, System.Security.Cryptography.HashAlgorithm hashAlg) [0x00000] in <e6e17f7092ca42eab0f975bb0c6d6c74>:0
        at Xamarin.Android.Tools.Files.HashFile (System.String filename) [0x00006] in <e6e17f7092ca42eab0f975bb0c6d6c74>:0
        at Xamarin.Android.Tools.Files.HasStreamChanged (System.IO.Stream source, System.String destination) [0x00010] in <e6e17f7092ca42eab0f975bb0c6d6c74>:0
        at Xamarin.Android.Tools.Files.CopyIfStreamChanged (System.IO.Stream stream, System.String destination) [0x00000] in <e6e17f7092ca42eab0f975bb0c6d6c74>:0
        at Xamarin.Android.Tasks.MonoAndroidHelper.CopyIfStreamChanged (System.IO.Stream source, System.String destination) [0x00000] in <e6e17f7092ca42eab0f975bb0c6d6c74>:0
        at Xamarin.Android.Tasks.GenerateLibraryResources.GenerateJava (Xamarin.Android.Tasks.GenerateLibraryResources+Library library) [0x0029c] in <e6e17f7092ca42eab0f975bb0c6d6c74>:0
        at Xamarin.Android.Tasks.AsyncTaskExtensions+<>c__DisplayClass0_0`1[TSource].<ParallelForEach>b__0 (TSource s) [0x00000] in <e6e17f7092ca42eab0f975bb0c6d6c74>:0

It seems that two java libraries have the same package name in their
`AndroidManifest.xml`.

If this was the case, I can easily see the `<GenerateLibraryResources/>`
MSBuild task step on itself. It processes the directories in parallel!

Reviewing the `packages.config` file supplied in the bug report (178
NuGet packages), I was able to narrow the list down to 19 Xamarin
packages that cause the issue.

There are certainly two manifests that contained:

    <manifest xmlns:android="http://schemas.android.com/apk/res/android"
        package="com.google.android.gms.base" >

Or:

    <manifest xmlns:android="http://schemas.android.com/apk/res/android"
        package="com.google.android.gms.common" >

I reworked the `<GenerateLibraryResources/>` task so that:

* Parse all the `AndroidManifest.xml` ahead of time, getting the
  package name.
* We can iterate against a list of "package names" that includes a
  list of `R.txt` files (more than one!).
* We merge multiple `R.txt` files into a `string[][]` so all the
  required values are present in the final `R.java` file.