### PR TITLE
Build Action support for designer's AndroidRuleSet

### DIFF
--- a/Documentation/guides/BuildProcess.md
+++ b/Documentation/guides/BuildProcess.md
@@ -1416,6 +1416,13 @@ used to specify the ABI that the library targets. Thus, if you add
 `armeabi-v7a`.
 
 
+### AndroidResourceAnalysisConfig
+
+The Build action `AndroidResourceAnalysisConfig` marks a file as a severity level configuration file for Xamarin Android Designer layout diagnostics tool. This is currently only used in the layout editor and not for build messages.
+
+See the [Android Resource Analysis documentation](https://aka.ms/androidresourceanalysis) for more details.
+
+
 #### Item Attribute Name
 
 **Abi** &ndash; Specifies the ABI of the native library.

--- a/Documentation/release-notes/4046.md
+++ b/Documentation/release-notes/4046.md
@@ -1,0 +1,4 @@
+## Option to enable Android resource analysis checks for Android layout files
+
+  * [GitHub 4046](https://github.com/xamarin/xamarin-android/issues/4046):
+    * Adds a new build action to allow configuring message severity levels in the Xamarin Android Designer diagnostics tool. To use this in your project, add an XML configuration file that follows the format described in the [Android Resource Analysis documentation](https://aka.ms/androidresourceanalysis) and set the build action to `AndroidResourceAnalysisConfig`.

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -185,6 +185,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <AvailableItemName Include="AndroidJavaLibrary" />
   <AvailableItemName Include="AndroidJavaSource" />
   <AvailableItemName Include="AndroidLintConfig" />
+  <AvailableItemName Include="AndroidRuleSet" />
   <AvailableItemName Include="AndroidNativeLibrary" />
   <AvailableItemName Include="AndroidResource" />
   <AvailableItemName Include="AndroidBoundLayout" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -185,7 +185,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <AvailableItemName Include="AndroidJavaLibrary" />
   <AvailableItemName Include="AndroidJavaSource" />
   <AvailableItemName Include="AndroidLintConfig" />
-  <AvailableItemName Include="AndroidRuleSet" />
+  <AvailableItemName Include="AndroidResourceAnalysisConfig" />
   <AvailableItemName Include="AndroidNativeLibrary" />
   <AvailableItemName Include="AndroidResource" />
   <AvailableItemName Include="AndroidBoundLayout" />


### PR DESCRIPTION
Support has been added for lint configuration files for android layouts in the designer code base.
This adds build action support for the new "AndroidRuleSet" item.
https://github.com/xamarin/designer/blob/8b01a63b3ecd494d65001cf1f74239a7db2a3db9/Xamarin.Designer.Android/Xamarin.AndroidDesigner/MSBuildConstants.cs#L52

https://github.com/xamarin/designer/pull/2709