### PR TITLE
[ci] Package and upload .nupkg in unique location

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -132,13 +132,13 @@ stages:
         command: pack
         packagesToPack: $(System.DefaultWorkingDirectory)/build-tools/create-packs/Packager.csproj
         configuration: $(XA.Build.Configuration)
-        packDirectory: $(Build.ArtifactStagingDirectory)/$(XA.Build.Configuration)
+        packDirectory: $(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
 
     - task: PublishPipelineArtifact@0
       displayName: upload nupkgs
       inputs:
         artifactName: $(NuGetArtifactName)
-        targetPath: $(Build.ArtifactStagingDirectory)/$(XA.Build.Configuration)
+        targetPath: $(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
 
     - template: yaml-templates/upload-results.yaml
       parameters:


### PR DESCRIPTION
Context: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=3331623

Upon investigation of a recent `Build Results - macOS` build artifact
from our Azure build pipeline, I noticed that we are now uploading a
duplicate Xamarin.Android.Sdk*.nupkg on every build. This is because
the [template for result publishing][0] uploads everything found in
`$(Build.ArtifactStagingDirectory)`. We should use a unique path when
packaging and uploading this .nupkg file to avoid duplication.

[0]: https://github.com/xamarin/xamarin-android/blob/c9ed134e5d3eb94f6c09a9e3067f5c60c4a32833/build-tools/automation/yaml-templates/upload-results.yaml#L18