### PR TITLE
[linker] Remove C#8 Nullable attributes

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/RemoveAttributes.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/RemoveAttributes.cs
@@ -48,6 +48,9 @@ namespace MonoDroid.Tuner {
 			case "DebuggerTypeProxyAttribute":
 			case "DebuggerVisualizerAttribute":
 				return !DebugBuild && attr_type.Namespace == "System.Diagnostics";
+			case "NullableContextAttribute":
+			case "NullableAttribute":
+				return attr_type.Namespace == "System.Runtime.CompilerServices";
 			default:
 				return false;
 			}


### PR DESCRIPTION
Implements https://github.com/xamarin/xamarin-android/issues/3911
Context: https://github.com/dotnet/roslyn/blob/7bc44488c661fd6bbb6c53f39512a6fe0cc5ef84/docs/features/nullable-metadata.md

C#8 non-null reference uses custom attributes to let compiler know
more information related to non-null reference.

These shouldn't be needed when running on device, as the C# language
feature doesn't require modifications to the runtime. Thus it should
be safe to remove them.