### PR TITLE
[monodroid] ensure main app assembly is loaded

### DIFF
--- a/Documentation/release-notes/4058.md
+++ b/Documentation/release-notes/4058.md
@@ -1,0 +1,4 @@
+### Issues fixed
+
+  * [DevCom 788217](https://developercommunity.visualstudio.com/content/problem/788217/xamarin-android-resource-ids-mismatch-1.html):
+    A crash on startup could be encountered when the `MainLauncher` activity is implemented in a Xamarin.Android class library.

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -1354,8 +1354,7 @@ MonodroidRuntime::load_assemblies (MonoDomain *domain, JNIEnv *env, jstring_arra
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
 		total_time.mark_start ();
 
-	/* skip element 0, as that's loaded in create_domain() */
-	for (size_t i = 1; i < assemblies.get_length (); ++i) {
+	for (size_t i = 0; i < assemblies.get_length (); ++i) {
 		jstring_wrapper &assembly = assemblies [i];
 		load_assembly (domain, env, assembly);
 	}

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -18,6 +18,18 @@ namespace Xamarin.Android.Build.Tests
 			ClearDebugProperty ();
 		}
 
+		void SetTargetFrameworkAndManifest(XamarinAndroidApplicationProject proj, Builder builder)
+		{
+			string apiLevel;
+			proj.TargetFrameworkVersion = builder.LatestTargetFrameworkVersion (out apiLevel);
+			proj.AndroidManifest = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" android:versionCode=""1"" android:versionName=""1.0"" package=""UnnamedProject.UnnamedProject"">
+	<uses-sdk android:minSdkVersion=""24"" android:targetSdkVersion=""{apiLevel}"" />
+	<application android:label=""${{PROJECT_NAME}}"">
+	</application >
+</manifest>";
+		}
+
 		[Test]
 		[Retry (1)]
 		public void ApplicationRunsWithoutDebugger ([Values (false, true)] bool isRelease)
@@ -36,14 +48,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 			proj.SetDefaultTargetDevice ();
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
-				string apiLevel;
-				proj.TargetFrameworkVersion = b.LatestTargetFrameworkVersion (out apiLevel);
-				proj.AndroidManifest = $@"<?xml version=""1.0"" encoding=""utf-8""?>
-<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" android:versionCode=""1"" android:versionName=""1.0"" package=""UnnamedProject.UnnamedProject"">
-	<uses-sdk android:minSdkVersion=""24"" android:targetSdkVersion=""{apiLevel}"" />
-	<application android:label=""${{PROJECT_NAME}}"">
-	</application >
-</manifest>";
+				SetTargetFrameworkAndManifest (proj, b);
 				b.Save (proj, saveProject: true);
 				proj.NuGetRestore (Path.Combine (Root, b.ProjectDirectory), b.PackagesDirectory);
 				Assert.True (b.Build (proj), "Project should have built.");
@@ -57,6 +62,61 @@ namespace Xamarin.Android.Build.Tests
 				Assert.True (WaitForActivityToStart (proj.PackageName, "MainActivity",
 					Path.Combine (Root, b.ProjectDirectory, "logcat.log"), 30), "Activity should have started.");
 				Assert.True (b.Uninstall (proj), "Project should have uninstalled.");
+			}
+		}
+
+		[Test]
+		public void ClassLibraryMainLauncherRuns ()
+		{
+			if (!HasDevices) {
+				Assert.Ignore ("Test needs a device attached.");
+				return;
+			}
+
+			var path = Path.Combine ("temp", TestName);
+
+			var app = new XamarinAndroidApplicationProject {
+				ProjectName = "MyApp",
+			};
+			if (!CommercialBuildAvailable) {
+				var abis = new string [] { "armeabi-v7a", "x86" };
+				app.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
+			}
+			app.SetDefaultTargetDevice ();
+
+			var lib = new XamarinAndroidLibraryProject {
+				ProjectName = "MyLibrary"
+			};
+			lib.Sources.Add (new BuildItem.Source ("MainActivity.cs") {
+				TextContent = () => lib.ProcessSourceTemplate (app.DefaultMainActivity).Replace ("${JAVA_PACKAGENAME}", app.JavaPackageName),
+			});
+			lib.AndroidResources.Clear ();
+			foreach (var resource in app.AndroidResources) {
+				lib.AndroidResources.Add (resource);
+			}
+			var reference = $"..\\{lib.ProjectName}\\{lib.ProjectName}.csproj";
+			app.References.Add (new BuildItem.ProjectReference (reference, lib.ProjectName, lib.ProjectGuid));
+
+			// Remove the default MainActivity.cs & AndroidResources
+			app.AndroidResources.Clear ();
+			app.AndroidResources.Add (new AndroidItem.AndroidResource ("Resources\\layout\\foo.xml") {
+				TextContent = () => "<?xml version=\"1.0\" encoding=\"utf-8\" ?><LinearLayout xmlns:android=\"http://schemas.android.com/apk/res/android\" />"
+			});
+			app.Sources.Remove (app.GetItem ("MainActivity.cs"));
+
+			using (var libBuilder = CreateDllBuilder (Path.Combine (path, lib.ProjectName)))
+			using (var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName))) {
+				SetTargetFrameworkAndManifest (app, appBuilder);
+				Assert.IsTrue (libBuilder.Build (lib), "library build should have succeeded.");
+				Assert.True (appBuilder.Install (app), "app should have installed.");
+				ClearAdbLogcat ();
+				if (CommercialBuildAvailable)
+					Assert.True (appBuilder.RunTarget (app, "_Run"), "Project should have run.");
+				else
+					AdbStartActivity ($"{app.PackageName}/{app.JavaPackageName}.MainActivity");
+
+				Assert.True (WaitForActivityToStart (app.PackageName, "MainActivity",
+					Path.Combine (Root, appBuilder.ProjectDirectory, "logcat.log"), 30), "Activity should have started.");
 			}
 		}
 
@@ -147,14 +207,7 @@ namespace ${ROOT_NAMESPACE} {
 "),
 			});
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
-				string apiLevel;
-				proj.TargetFrameworkVersion = b.LatestTargetFrameworkVersion (out apiLevel);
-				proj.AndroidManifest = $@"<?xml version=""1.0"" encoding=""utf-8""?>
-<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" android:versionCode=""1"" android:versionName=""1.0"" package=""UnnamedProject.UnnamedProject"">
-	<uses-sdk android:minSdkVersion=""24"" android:targetSdkVersion=""{apiLevel}"" />
-	<application android:label=""${{PROJECT_NAME}}"">
-	</application >
-</manifest>";
+				SetTargetFrameworkAndManifest (proj, b);
 				b.Save (proj, saveProject: true);
 				proj.NuGetRestore (Path.Combine (Root, b.ProjectDirectory), b.PackagesDirectory);
 				Assert.True (b.Build (proj), "Project should have built.");
@@ -281,14 +334,7 @@ namespace ${ROOT_NAMESPACE} {
 			proj.SetProperty (KnownProperties.AndroidSupportedAbis, string.Join (";", abis));
 			proj.SetDefaultTargetDevice ();
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
-				string apiLevel;
-				proj.TargetFrameworkVersion = b.LatestTargetFrameworkVersion (out apiLevel);
-				proj.AndroidManifest = $@"<?xml version=""1.0"" encoding=""utf-8""?>
-<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" android:versionCode=""1"" android:versionName=""1.0"" package=""UnnamedProject.UnnamedProject"">
-	<uses-sdk android:minSdkVersion=""24"" android:targetSdkVersion=""{apiLevel}"" />
-	<application android:label=""${{PROJECT_NAME}}"">
-	</application >
-</manifest>";
+				SetTargetFrameworkAndManifest (proj, b);
 				b.Save (proj, saveProject: true);
 				proj.NuGetRestore (Path.Combine (Root, b.ProjectDirectory), b.PackagesDirectory);
 				Assert.True (b.Build (proj), "Project should have built.");


### PR DESCRIPTION
Fixes: https://developercommunity.visualstudio.com/content/problem/788217/xamarin-android-resource-ids-mismatch-1.html

In a project where:

* The `MainLauncher` activity is in a class library
* This activity uses a value from `Resource.designer.cs`

You get a crash such as:

    UNHANDLED EXCEPTION:
    Android.Content.Res.Resources+NotFoundException: Resource ID #0x7f09001c
    at Java.Interop.JniEnvironment+InstanceMethods.CallNonvirtualVoidMethod (Java.Interop.JniObjectReference instance, Java.Interop.JniObjectReference type, Java.Interop.JniMethodInfo method, Java.Interop.JniArgumentValue* args) [0x0008e] in <e7e2d009b69d4e5f9a00e6ee600b8a8e>:0
    at Java.Interop.JniPeerMembers+JniInstanceMethods.InvokeVirtualVoidMethod (System.String encodedMember, Java.Interop.IJavaPeerable self, Java.Interop.JniArgumentValue* parameters) [0x0005d] in <e7e2d009b69d4e5f9a00e6ee600b8a8e>:0
    at Android.App.Activity.SetContentView (System.Int32 layoutResID) [0x00022] in <82e50ec67af648c3b9f43b3d70e21b96>:0
    at ClassLibrary1.SharedActivity.OnCreate (Android.OS.Bundle savedInstanceState) [0x00011] in <aff3f2d8f15f4b618f6674d9c306f099>:0
    at Android.App.Activity.n_OnCreate_Landroid_os_Bundle_ (System.IntPtr jnienv, System.IntPtr native__this, System.IntPtr native_savedInstanceState) [0x00011] in <82e50ec67af648c3b9f43b3d70e21b96>:0
    at (wrapper dynamic-method) Android.Runtime.DynamicMethodNameCounter.4(intptr,intptr,intptr)
    --- End of managed Android.Content.Res.Resources+NotFoundException stack trace ---
    android.content.res.Resources$NotFoundException: Resource ID #0x7f09001c
        at android.content.res.ResourcesImpl.getValue(ResourcesImpl.java:237)
        at android.content.res.Resources.loadXmlResourceParser(Resources.java:2281)
        at android.content.res.Resources.getLayout(Resources.java:1175)
        at android.view.LayoutInflater.inflate(LayoutInflater.java:532)
        at android.view.LayoutInflater.inflate(LayoutInflater.java:481)
        at android.support.v7.app.AppCompatDelegateImpl.setContentView(AppCompatDelegateImpl.java:469)
        at android.support.v7.app.AppCompatActivity.setContentView(AppCompatActivity.java:140)
        at crc64fd99288c2cd04dcf.SharedActivity.n_onCreate(Native Method)
        at crc64fd99288c2cd04dcf.SharedActivity.onCreate(SharedActivity.java:30)
        at android.app.Activity.performCreate(Activity.java:7802)
        at android.app.Activity.performCreate(Activity.java:7791)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1306)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3245)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3409)
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:83)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2016)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7356)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)

In this example `App1.dll` is the main app assembly, but
`ClassLibrary1.SharedActivity` is the `MainLauncher`.

What was strange is that when I looked at the list of assemblies in
`AppDomain.CurrentDomain.GetAssemblies ()` before the failure,
`App1.dll` was not in the list!

So I enabled a bunch of logging:

    adb shell setprop debug.mono.log default,assembly,timing

The log messages like this did not mention `App1.dll`:

    12-19 09:11:44.425 22695 22695 I monodroid-assembly: open_from_update_dir: loaded assembly: 0x7723bca880
    12-19 09:11:44.425 22695 22695 I monodroid-timing: Assembly load: ClassLibrary1.dll preloaded; elapsed: 0s:1::252032

Which lead me to this code:

    /* skip element 0, as that's loaded in create_domain() */
    for (size_t i = 1; i < assemblies.get_length (); ++i) {

I don't actually see anything in `create_domain` that would load
`App1.dll`? Looking through the commit history I don't understand how
this project would have ever worked?

Changing `i = 1` to `i = 0` solves the crash in the project. However,
there might be a better fix here.