### PR TITLE
[ci] Downgrade XA before Windows build

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -181,6 +181,7 @@ stages:
         $process = Start-Process -NoNewWindow -FilePath $vsixInstaller -ArgumentList "/downgrade:Xamarin.Android.Sdk /admin /quiet /logFile:$log" -Wait -PassThru
         Get-Content "${env:TEMP}\$log" | Write-Host
         Write-Host "VSInstaller.exe exited with code:" $process.ExitCode
+        Remove-Item "${env:TEMP}\$log"
         Exit 0
       displayName: downgrade XA to stable
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -172,6 +172,18 @@ stages:
       inputs:
         version: $(DotNetCoreVersion)
 
+    # Downgrade the XA .vsix installed into the instance of VS that we are building with so that we don't restore/build against a test version.
+    # VSIXInstaller.exe will exit non-zero when the downgrade attempt is a no-op, so we will allow this step to fail silently.
+    - powershell: |
+        $vsixInstaller = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\resources\app\ServiceHub\Services\Microsoft.VisualStudio.Setup.Service\VSIXInstaller.exe"
+        $ts = Get-Date -Format FileDateTimeUniversal
+        $log = "xavsixdowngrade-$ts.log"
+        $process = Start-Process -NoNewWindow -FilePath $vsixInstaller -ArgumentList "/downgrade:Xamarin.Android.Sdk /admin /quiet /logFile:$log" -Wait -PassThru
+        Get-Content "${env:TEMP}\$log" | Write-Host
+        Write-Host "VSInstaller.exe exited with code:" $process.ExitCode
+        Exit 0
+      displayName: downgrade XA to stable
+
     - task: MSBuild@1
       displayName: msbuild Xamarin.Android /t:Prepare
       inputs:


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4052#issuecomment-567576834

Our `Windows Build and Test` job runs on the same set of VMs that we use
for testing and in some cases this can cause issues. Most recently, I
noticed a failure when attempting to restore NuGet packages for
`Xamarin.Android-Tests.sln`, because the Xamarin.Android version on disk
is used when calculating the NuGet dependecy graph for Android projects.
We should attempt to downgrade XA to the version that shipped with the
instance of VS that we are building with before building on Windows.