### PR TITLE
[tests] bring back NUnit3TestAdapter

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj
@@ -54,6 +54,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
+++ b/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="2.4.5" />
     <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
I noticed I could no longer use the NUnit test runner in VS Windows.

In dc49cf92, we removed the `NUnit3TestAdapter` which has no other function than to make the IDE "work".

I tried using this extension instead:

https://marketplace.visualstudio.com/items?itemName=NUnitDevelopers.NUnit3TestAdapter

However, it seems the NuGet package is the only thing that solves the issue for me.