### PR TITLE
[linker] Update ShouldMarkInterfaceImplementation logic

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MonoDroidMarkStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MonoDroidMarkStep.cs
@@ -438,6 +438,9 @@ namespace MonoDroid.Tuner
 
 		protected override bool ShouldMarkInterfaceImplementation (TypeDefinition type, InterfaceImplementation iface, TypeDefinition resolvedInterfaceType)
 		{
+			if (Annotations.IsMarked (iface))
+				return false;
+
 			if (base.ShouldMarkInterfaceImplementation (type, iface, resolvedInterfaceType))
 				return true;
 


### PR DESCRIPTION
We should return `false` when the iface was already marked, to avoid
unnecessary processing, which can cause infinite loop in the linker.

Fixes https://github.com/xamarin/xamarin-android/issues/3852

What was happening: we were returning `true` from
`ShouldMarkInterfaceImplementation` for ifaces of types that
implements `IJavaObject` or `IJavaPeerable`. In case of #3852, 3 of
these had also `System.Runtime.CompilerServices.NullableAttribute`
custom attributes. That led to enqueuing the custom attribute
constructor every pass through the primary queue in the linker and so
the queue was never emptied and that resulted in an infinite loop.

IMO linker should check for iface being already marked outside of
`ShouldMarkInterfaceImplementation`. I will add PR to the linker for
that, meanwhile we should check it here.