### PR TITLE
Bump to mono/mono/2019-10@99e3aed6

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:d16-5@2c9ce23d2288cc245729d32c2eabf6deebdf554b
-mono/mono:2019-10@d56a0e72c21d8e58566b9cb46c151ce86a5d4f1f
+mono/mono:2019-10@df42020fe6f7a0a1b5fa59b481fb603d88d72348


### PR DESCRIPTION
Changes: https://github.com/mono/mono/compare/d56a0e72c21d8e58566b9cb46c151ce86a5d4f1f...99e3aed6ec366383372f75af07994162f247d9ff

Context: https://github.com/mono/mono/issues/16513
Context: https://github.com/mono/mono/issues/17916
Context: https://github.com/msys2/MINGW-packages/issues/5803

  * mono/mono@99e3aed6ec3: Socket.BeginMConnect() should not attempt connections on unsupported address families. (#18321)
  * mono/mono@5f0704ce372: [eglib] Don't define _FORTIFY_SOURCE on Cygwin builds (#18312)
  * mono/mono@dc5902c243e: [domain] Don't add NULL runtime to runtimes list (#18265)
  * mono/mono@bfcac9bd309: Bump corefx to get test fix