### PR TITLE
[ci] Use multi-repo checkout feature

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -27,6 +27,21 @@ resources:
     type: github
     name: xamarin/designer
     endpoint: xamarin
+  - repository: qa
+    type: github
+    name: xamarin/QualityAssurance
+    ref: refs/heads/master
+    endpoint: xamarin
+  - repository: samples
+    type: github
+    name: xamarin/monodroid-samples
+    ref: refs/heads/master
+    endpoint: xamarin
+  - repository: xfsamples
+    type: github
+    name: xamarin/xamarin-forms-samples
+    ref: refs/heads/master
+    endpoint: xamarin
 
 # Global variables
 variables:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -6,13 +6,26 @@ trigger:
   - master
   - d16-*
 
-# External yaml template files
+# External sources, scripts, tests, and yaml template files.
 resources:
   repositories:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
     ref: refs/heads/master
+    endpoint: xamarin
+  - repository: release_scripts
+    type: github
+    name: xamarin/release-scripts
+    ref: refs/heads/$(ReleaseScriptsBranch)
+    endpoint: xamarin
+  - repository: monodroid
+    type: github
+    name: xamarin/monodroid
+    endpoint: xamarin
+  - repository: designer
+    type: github
+    name: xamarin/designer
     endpoint: xamarin
 
 # Global variables
@@ -73,11 +86,15 @@ stages:
     - script: make prepare-update-mono V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
       displayName: make prepare-update-mono
 
+    - checkout: monodroid
+      clean: true
+      path: $(System.DefaultWorkingDirectory)/external/monodroid
+      persistCredentials: true
+      condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
+
     - script: make prepare-external-git-dependencies PREPARE_CI=1 CONFIGURATION=$(XA.Build.Configuration)
       displayName: make prepare-external-git-dependencies
       condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
-      env:
-        GH_AUTH_SECRET: $(Github.Token)
 
     - script: make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
       displayName: make jenkins
@@ -309,10 +326,12 @@ stages:
       parameters:
         UnsignedPkgPath: $(XA.Unsigned.Pkg)
 
+    - checkout: release_scripts
+      clean: true
+      path: $(System.DefaultWorkingDirectory)/release-scripts
+
     - script: |
-        cd $(System.DefaultWorkingDirectory)/..
-        git clone -b $(ReleaseScriptsBranch) https://$(GitHub.Token):x-oauth-basic@github.com/xamarin/release-scripts
-        cd release-scripts
+        cd $(System.DefaultWorkingDirectory)/release-scripts
         sudo xcode-select -s /Applications/$(NotarizationXcode)
         ruby notarize.rb $(XA.Unsigned.Pkg) $(XamarinIdentifier) $(XamarinUserId) $(XamarinPassword) $(TeamID)
       displayName: Notarize PKG
@@ -839,6 +858,12 @@ stages:
     variables:
       EnableRegressionTest: true
     steps:
+    - checkout: designer
+      clean: true
+      submodules: recursive
+      path: $(System.DefaultWorkingDirectory)/designer
+      persistCredentials: true
+
     - powershell: |
         # Use the branch name of the source being built or the PR target branch name. Fall back to 'master' if the branch is unknown.
         $branchPrefix = "/refs/heads/"
@@ -849,9 +874,8 @@ stages:
         if (("$branchName" -ne "master") -and ("$branchName" -notlike "d16*")) {
             $branchName = "master"
         }
-        Write-Host "cloning designer source from branch - '$branchName'"
-        git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git --branch $branchName
         Set-Location -Path $(System.DefaultWorkingDirectory)/designer
+        git checkout $branchName
         git submodule update -q --init --recursive
       displayName: Clone and update designer
 
@@ -885,6 +909,12 @@ stages:
       RegressionTestSuiteOutputDir: C:\Git\ADesRegTestSuite
       VisualStudioInstallationPath: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
     steps:
+    - checkout: designer
+      clean: true
+      submodules: recursive
+      path: $(System.DefaultWorkingDirectory)\designer
+      persistCredentials: true
+
     - powershell: |
         # Use the branch name of the source being built or the PR target branch name. Fall back to 'master' if the branch is unknown.
         $branchPrefix = "/refs/heads/"
@@ -895,9 +925,8 @@ stages:
         if (("$branchName" -ne "master") -and ("$branchName" -notlike "d16*")) {
             $branchName = "master"
         }
-        Write-Host "cloning designer source from branch - '$branchName'"
-        git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git --branch $branchName
-        Set-Location -Path $(System.DefaultWorkingDirectory)/designer
+        Set-Location -Path $(System.DefaultWorkingDirectory)\designer
+        git checkout $branchName
         git submodule update -q --init --recursive
       displayName: Clone and update designer
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -352,6 +352,7 @@ stages:
 
     - checkout: release_scripts
       clean: true
+      path: s/release-scripts
       persistCredentials: true
 
     - script: |
@@ -886,6 +887,7 @@ stages:
     - checkout: designer
       clean: true
       submodules: recursive
+      path: s/designer
       persistCredentials: true
 
     - powershell: |
@@ -936,6 +938,7 @@ stages:
     - checkout: designer
       clean: true
       submodules: recursive
+      path: s\designer
       persistCredentials: true
 
     - powershell: |

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -98,35 +98,40 @@ stages:
 
     # Prepare and build everything
     - script: make prepare-update-mono V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: make prepare-update-mono
 
     - checkout: monodroid
       clean: true
-      path: $(System.DefaultWorkingDirectory)/external/monodroid
+      path: s/xamarin-android/external/monodroid
       persistCredentials: true
       condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
 
     - script: make prepare-external-git-dependencies PREPARE_CI=1 CONFIGURATION=$(XA.Build.Configuration)
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: make prepare-external-git-dependencies
       condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
 
     - script: make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: make jenkins
 
     # Build and package test assemblies
     - script: make all-tests V=1 CONFIGURATION=$(XA.Build.Configuration)
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: make all-tests
 
     - script: |
         cp -r bin/$(XA.Build.Configuration)/bcl-tests bin/Test$(XA.Build.Configuration)/bcl-tests
         cp bin/Build$(XA.Build.Configuration)/ProfileAssemblies.projitems bin/Test$(XA.Build.Configuration)/bcl-tests/
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: copy bcl-tests assemblies
 
     - task: PublishPipelineArtifact@0
       displayName: upload test assemblies
       inputs:
         artifactName: $(TestAssembliesArtifactName)
-        targetPath: bin/Test$(XA.Build.Configuration)
+        targetPath: xamarin-android/bin/Test$(XA.Build.Configuration)
 
     # Create installers
     - template: install-certificates.yml@yaml
@@ -138,41 +143,45 @@ stages:
         HostedMacKeychainPassword: $(AzDO-OnPrem-KeychainPass)
 
     - script: make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: make create-installers
 
     - script: |
         mkdir -p bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
         cp bin/Build$(XA.Build.Configuration)/*.vsix bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
         cp bin/Build$(XA.Build.Configuration)/*.pkg bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: copy unsigned installers
 
     - script: |
         VERSION=`LANG=C; export LANG && git log --no-color --first-parent -n1 --pretty=format:%ct`
         echo "d1ec039f-f3db-468b-a508-896d7c382999 $VERSION" > bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)/updateinfo
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: create updateinfo file
 
     - task: PublishPipelineArtifact@0
       displayName: upload installers
       inputs:
         artifactName: $(InstallerArtifactName)
-        targetPath: bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
+        targetPath: xamarin-android/bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
 
     - task: DotNetCoreCLI@2
       displayName: pack Xamarin.Android.Sdk
       inputs:
         command: pack
-        packagesToPack: $(System.DefaultWorkingDirectory)/build-tools/create-packs/Packager.csproj
+        packagesToPack: $(System.DefaultWorkingDirectory)/xamarin-android/build-tools/create-packs/Packager.csproj
         configuration: $(XA.Build.Configuration)
-        packDirectory: $(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
+        packDirectory: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
 
     - task: PublishPipelineArtifact@0
       displayName: upload nupkgs
       inputs:
         artifactName: $(NuGetArtifactName)
-        targetPath: $(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
+        targetPath: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
 
     - template: yaml-templates/upload-results.yaml
       parameters:
+        solution: xamarin-android/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
         artifactName: Build Results - macOS
 
     - template: uninstall-certificates/v1.yml@yaml
@@ -342,7 +351,6 @@ stages:
 
     - checkout: release_scripts
       clean: true
-      path: $(System.DefaultWorkingDirectory)/release-scripts
       persistCredentials: true
 
     - script: |
@@ -877,7 +885,6 @@ stages:
     - checkout: designer
       clean: true
       submodules: recursive
-      path: $(System.DefaultWorkingDirectory)/designer
       persistCredentials: true
 
     - powershell: |
@@ -928,7 +935,6 @@ stages:
     - checkout: designer
       clean: true
       submodules: recursive
-      path: $(System.DefaultWorkingDirectory)\designer
       persistCredentials: true
 
     - powershell: |

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -103,6 +103,7 @@ stages:
 
     - checkout: monodroid
       clean: true
+      submodules: recursive
       path: s/xamarin-android/external/monodroid
       persistCredentials: true
       condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -14,14 +14,13 @@ resources:
     name: xamarin/yaml-templates
     ref: refs/heads/master
     endpoint: xamarin
-  - repository: release_scripts
-    type: github
-    name: xamarin/release-scripts
-    ref: refs/heads/$(ReleaseScriptsBranch)
-    endpoint: xamarin
   - repository: monodroid
     type: github
     name: xamarin/monodroid
+    endpoint: xamarin
+  - repository: release_scripts
+    type: github
+    name: xamarin/release-scripts
     endpoint: xamarin
   - repository: designer
     type: github
@@ -344,9 +343,11 @@ stages:
     - checkout: release_scripts
       clean: true
       path: $(System.DefaultWorkingDirectory)/release-scripts
+      persistCredentials: true
 
     - script: |
         cd $(System.DefaultWorkingDirectory)/release-scripts
+        git checkout $(ReleaseScriptsBranch)
         sudo xcode-select -s /Applications/$(NotarizationXcode)
         ruby notarize.rb $(XA.Unsigned.Pkg) $(XamarinIdentifier) $(XamarinUserId) $(XamarinPassword) $(TeamID)
       displayName: Notarize PKG

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -15,20 +15,21 @@ steps:
       NUnit.ConsoleRunner/**
     downloadPath: $(System.DefaultWorkingDirectory)
 
+- checkout: self
+  clean: true
+  submodules: recursive
+
 - checkout: qa
   clean: true
   fetchDepth: 1
-  path: $(System.DefaultWorkingDirectory)/QualityAssurance
 
 - checkout: samples
   clean: true
   fetchDepth: 1
-  path: $(System.DefaultWorkingDirectory)/monodroid-samples
 
 - checkout: xfsamples
   clean: true
   fetchDepth: 1
-  path: $(System.DefaultWorkingDirectory)/xamarin-forms-samples
 
 - task: xamops.azdevex.provisionator-task.provisionator@2
   displayName: Provision Android Dependencies

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -1,21 +1,3 @@
-resources:
-  repositories:
-  - repository: qa
-    type: github
-    name: xamarin/QualityAssurance
-    ref: refs/heads/master
-    endpoint: xamarin
-  - repository: samples
-    type: github
-    name: xamarin/monodroid-samples
-    ref: refs/heads/master
-    endpoint: xamarin
-  - repository: xfsamples
-    type: github
-    name: xamarin/xamarin-forms-samples
-    ref: refs/heads/master
-    endpoint: xamarin
-
 steps:
 - task: xamops.azdevex.lingering-process-task.lingering-process-task@1
 

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -19,6 +19,12 @@ steps:
   clean: true
   submodules: recursive
 
+- checkout: monodroid
+  clean: true
+  submodules: recursive
+  path: s/xamarin-android/external/monodroid
+  persistCredentials: true
+
 - checkout: qa
   clean: true
   fetchDepth: 1
@@ -39,6 +45,7 @@ steps:
     provisioning_extra_args: -vv
 
 - script: make prepare-update-mono V=1 PREPARE_CI=1 PREPARE_AUTOPROVISION=1
+  workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
   displayName: install mono
   condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
 
@@ -51,9 +58,6 @@ steps:
        $(System.DefaultWorkingDirectory)\NUnit.ConsoleRunner\tools\nunit3-console.exe $(System.DefaultWorkingDirectory)\XQA.Android\XQA.Android.dll --where "cat == XAUnitTestSetup || cat == XATestPrep || cat == EnvironmentInfo"
     }
   displayName: Test Environment Setup
-  condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
-  env:
-    GH_AUTH_SECRET: $(Github.Token)
 
 - template: run-nunit-tests.yaml
   parameters:

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -1,11 +1,23 @@
+resources:
+  repositories:
+  - repository: qa
+    type: github
+    name: xamarin/QualityAssurance
+    ref: refs/heads/master
+    endpoint: xamarin
+  - repository: samples
+    type: github
+    name: xamarin/monodroid-samples
+    ref: refs/heads/master
+    endpoint: xamarin
+  - repository: xfsamples
+    type: github
+    name: xamarin/xamarin-forms-samples
+    ref: refs/heads/master
+    endpoint: xamarin
+
 steps:
 - task: xamops.azdevex.lingering-process-task.lingering-process-task@1
-
-- script: |
-    git clone -q https://github.com/xamarin/monodroid-samples.git
-    git clone -q https://github.com/xamarin/xamarin-forms-samples.git
-    git clone -q https://$(GitHub.Token)@github.com/xamarin/QualityAssurance.git
-  displayName: clone test dependencies
 
 - task: DownloadBuildArtifacts@0
   inputs:
@@ -20,6 +32,21 @@ steps:
       provisionator/**
       NUnit.ConsoleRunner/**
     downloadPath: $(System.DefaultWorkingDirectory)
+
+- checkout: qa
+  clean: true
+  fetchDepth: 1
+  path: $(System.DefaultWorkingDirectory)/QualityAssurance
+
+- checkout: samples
+  clean: true
+  fetchDepth: 1
+  path: $(System.DefaultWorkingDirectory)/monodroid-samples
+
+- checkout: xfsamples
+  clean: true
+  fetchDepth: 1
+  path: $(System.DefaultWorkingDirectory)/xamarin-forms-samples
 
 - task: xamops.azdevex.provisionator-task.provisionator@2
   displayName: Provision Android Dependencies

--- a/build-tools/automation/yaml-templates/upload-results.yaml
+++ b/build-tools/automation/yaml-templates/upload-results.yaml
@@ -1,4 +1,5 @@
 parameters:
+  solution: build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
   configuration: $(XA.Build.Configuration)
   artifactName: results
 
@@ -6,7 +7,7 @@ steps:
 - task: MSBuild@1
   displayName: package build and test results
   inputs:
-    solution: build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+    solution: ${{ parameters.solution }}
     configuration: ${{ parameters.configuration }}
     msbuildArguments: /restore /t:Build,ZipBuildStatus,ZipTestResults /p:BuildStatusZipOutputPath=$(Build.ArtifactStagingDirectory) /p:TestResultZipOutputPath=$(Build.ArtifactStagingDirectory)
   condition: always()


### PR DESCRIPTION
Context: https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops
Context: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=3360513

Some of our build and test jobs started failing recently due to what
appear to be authorization issues when attepting to clone private
sources:

    stderr | remote: Repository not found.

In order to avoid this, we'll try to move away from using custom scripts
and tokens for source checkout and instead use the new "multi-repo"
checkout feature in Azure Pipelines that @akoeplinger suggested.