### PR TITLE
[ci] Use multi-repo checkout feature (#4085)

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -6,12 +6,39 @@ trigger:
   - master
   - d16-*
 
-# External yaml template files
+# External sources, scripts, tests, and yaml template files.
 resources:
   repositories:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
+    ref: refs/heads/master
+    endpoint: xamarin
+  - repository: monodroid
+    type: github
+    name: xamarin/monodroid
+    endpoint: xamarin
+  - repository: release_scripts
+    type: github
+    name: xamarin/release-scripts
+    endpoint: xamarin
+  - repository: designer
+    type: github
+    name: xamarin/designer
+    endpoint: xamarin
+  - repository: qa
+    type: github
+    name: xamarin/QualityAssurance
+    ref: refs/heads/master
+    endpoint: xamarin
+  - repository: samples
+    type: github
+    name: xamarin/monodroid-samples
+    ref: refs/heads/master
+    endpoint: xamarin
+  - repository: xfsamples
+    type: github
+    name: xamarin/xamarin-forms-samples
     ref: refs/heads/master
     endpoint: xamarin
 
@@ -70,46 +97,41 @@ stages:
 
     # Prepare and build everything
     - script: make prepare-update-mono V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: make prepare-update-mono
 
+    - checkout: monodroid
+      clean: true
+      submodules: recursive
+      path: s/xamarin-android/external/monodroid
+      persistCredentials: true
+      condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
+
     - script: make prepare-external-git-dependencies PREPARE_CI=1 CONFIGURATION=$(XA.Build.Configuration)
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: make prepare-external-git-dependencies
       condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
-      env:
-        GH_AUTH_SECRET: $(Github.Token)
 
     - script: make jenkins V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: make jenkins
 
     # Build and package test assemblies
-    - task: MSBuild@1
-      displayName: msbuild tests/CodeBehind/UnitTests/CodeBehindUnitTests.csproj
-      inputs:
-        solution: $(System.DefaultWorkingDirectory)/tests/CodeBehind/UnitTests/CodeBehindUnitTests.csproj
-        configuration: $(XA.Build.Configuration)
-
-    - task: MSBuild@1
-      displayName: msbuild tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Xamarin.Android.MakeBundle-UnitTests.csproj
-      inputs:
-        solution: $(System.DefaultWorkingDirectory)/tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Xamarin.Android.MakeBundle-UnitTests.csproj
-        configuration: $(XA.Build.Configuration)
-
-    - task: MSBuild@1
-      displayName: msbuild tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/EmbeddedDSO-UnitTests.csproj
-      inputs:
-        solution: $(System.DefaultWorkingDirectory)/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/EmbeddedDSO-UnitTests.csproj
-        configuration: $(XA.Build.Configuration)
+    - script: make all-tests V=1 CONFIGURATION=$(XA.Build.Configuration)
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
+      displayName: make all-tests
 
     - script: |
         cp -r bin/$(XA.Build.Configuration)/bcl-tests bin/Test$(XA.Build.Configuration)/bcl-tests
         cp bin/Build$(XA.Build.Configuration)/ProfileAssemblies.projitems bin/Test$(XA.Build.Configuration)/bcl-tests/
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: copy bcl-tests assemblies
 
     - task: PublishPipelineArtifact@0
       displayName: upload test assemblies
       inputs:
         artifactName: $(TestAssembliesArtifactName)
-        targetPath: bin/Test$(XA.Build.Configuration)
+        targetPath: xamarin-android/bin/Test$(XA.Build.Configuration)
 
     # Create installers
     - template: install-certificates.yml@yaml
@@ -120,27 +142,31 @@ stages:
         MacDeveloper: $(mac-developer)
 
     - script: make create-installers V=1 CONFIGURATION=$(XA.Build.Configuration)
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: make create-installers
 
     - script: |
         mkdir -p bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
         cp bin/Build$(XA.Build.Configuration)/*.vsix bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
         cp bin/Build$(XA.Build.Configuration)/*.pkg bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: copy unsigned installers
 
     - script: |
         VERSION=`LANG=C; export LANG && git log --no-color --first-parent -n1 --pretty=format:%ct`
         echo "d1ec039f-f3db-468b-a508-896d7c382999 $VERSION" > bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)/updateinfo
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: create updateinfo file
 
     - task: PublishPipelineArtifact@0
       displayName: upload installers
       inputs:
         artifactName: $(InstallerArtifactName)
-        targetPath: bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
+        targetPath: xamarin-android/bin/Build$(XA.Build.Configuration)/$(InstallerArtifactName)
 
     - template: yaml-templates/upload-results.yaml
       parameters:
+        solution: xamarin-android/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
         artifactName: Build Results - macOS
 
 # This stage ensures Windows specific build steps continue to work, and runs unit tests.
@@ -280,10 +306,15 @@ stages:
       parameters:
         UnsignedPkgPath: $(XA.Unsigned.Pkg)
 
+    - checkout: release_scripts
+      clean: true
+      path: s/release-scripts
+      persistCredentials: true
+
     - script: |
-        cd $(System.DefaultWorkingDirectory)/..
-        git clone -b $(ReleaseScriptsBranch) https://$(GitHub.Token):x-oauth-basic@github.com/xamarin/release-scripts
-        cd release-scripts
+        cd $(System.DefaultWorkingDirectory)/release-scripts
+        git checkout $(ReleaseScriptsBranch)
+        sudo xcode-select -s /Applications/$(NotarizationXcode)
         ruby notarize.rb $(XA.Unsigned.Pkg) $(XamarinIdentifier) $(XamarinUserId) $(XamarinPassword) $(TeamID)
       displayName: Notarize PKG
 
@@ -792,6 +823,12 @@ stages:
     variables:
       EnableRegressionTest: true
     steps:
+    - checkout: designer
+      clean: true
+      submodules: recursive
+      path: s/designer
+      persistCredentials: true
+
     - powershell: |
         # Use the branch name of the source being built or the PR target branch name. Fall back to 'master' if the branch is unknown.
         $branchPrefix = "/refs/heads/"
@@ -802,9 +839,8 @@ stages:
         if (("$branchName" -ne "master") -and ("$branchName" -notlike "d16*")) {
             $branchName = "master"
         }
-        Write-Host "cloning designer source from branch - '$branchName'"
-        git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git --branch $branchName
         Set-Location -Path $(System.DefaultWorkingDirectory)/designer
+        git checkout $branchName
         git submodule update -q --init --recursive
       displayName: Clone and update designer
 
@@ -838,6 +874,12 @@ stages:
       RegressionTestSuiteOutputDir: C:\Git\ADesRegTestSuite
       VisualStudioInstallationPath: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
     steps:
+    - checkout: designer
+      clean: true
+      submodules: recursive
+      path: s\designer
+      persistCredentials: true
+
     - powershell: |
         # Use the branch name of the source being built or the PR target branch name. Fall back to 'master' if the branch is unknown.
         $branchPrefix = "/refs/heads/"
@@ -848,9 +890,8 @@ stages:
         if (("$branchName" -ne "master") -and ("$branchName" -notlike "d16*")) {
             $branchName = "master"
         }
-        Write-Host "cloning designer source from branch - '$branchName'"
-        git clone -q https://$(GitHub.Token)@github.com/xamarin/designer.git --branch $branchName
-        Set-Location -Path $(System.DefaultWorkingDirectory)/designer
+        Set-Location -Path $(System.DefaultWorkingDirectory)\designer
+        git checkout $branchName
         git submodule update -q --init --recursive
       displayName: Clone and update designer
 

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -1,12 +1,6 @@
 steps:
 - task: xamops.azdevex.lingering-process-task.lingering-process-task@1
 
-- script: |
-    git clone -q https://github.com/xamarin/monodroid-samples.git
-    git clone -q https://github.com/xamarin/xamarin-forms-samples.git
-    git clone -q https://$(GitHub.Token)@github.com/xamarin/QualityAssurance.git
-  displayName: clone test dependencies
-
 - task: DownloadBuildArtifacts@0
   inputs:
     buildType: specific
@@ -21,6 +15,28 @@ steps:
       NUnit.ConsoleRunner/**
     downloadPath: $(System.DefaultWorkingDirectory)
 
+- checkout: self
+  clean: true
+  submodules: recursive
+
+- checkout: monodroid
+  clean: true
+  submodules: recursive
+  path: s/xamarin-android/external/monodroid
+  persistCredentials: true
+
+- checkout: qa
+  clean: true
+  fetchDepth: 1
+
+- checkout: samples
+  clean: true
+  fetchDepth: 1
+
+- checkout: xfsamples
+  clean: true
+  fetchDepth: 1
+
 - task: xamops.azdevex.provisionator-task.provisionator@2
   displayName: Provision Android Dependencies
   inputs:
@@ -29,6 +45,7 @@ steps:
     provisioning_extra_args: -vv
 
 - script: make prepare-update-mono V=1 PREPARE_CI=1 PREPARE_AUTOPROVISION=1
+  workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
   displayName: install mono
   condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
 
@@ -41,9 +58,6 @@ steps:
        $(System.DefaultWorkingDirectory)\NUnit.ConsoleRunner\tools\nunit3-console.exe $(System.DefaultWorkingDirectory)\XQA.Android\XQA.Android.dll --where "cat == XAUnitTestSetup || cat == XATestPrep || cat == EnvironmentInfo"
     }
   displayName: Test Environment Setup
-  condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
-  env:
-    GH_AUTH_SECRET: $(Github.Token)
 
 - template: run-nunit-tests.yaml
   parameters:

--- a/build-tools/automation/yaml-templates/upload-results.yaml
+++ b/build-tools/automation/yaml-templates/upload-results.yaml
@@ -1,4 +1,5 @@
 parameters:
+  solution: build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
   configuration: $(XA.Build.Configuration)
   artifactName: results
 
@@ -6,7 +7,7 @@ steps:
 - task: MSBuild@1
   displayName: package build and test results
   inputs:
-    solution: build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+    solution: ${{ parameters.solution }}
     configuration: ${{ parameters.configuration }}
     msbuildArguments: /restore /t:Build,ZipBuildStatus,ZipTestResults /p:BuildStatusZipOutputPath=$(Build.ArtifactStagingDirectory) /p:TestResultZipOutputPath=$(Build.ArtifactStagingDirectory)
   condition: always()


### PR DESCRIPTION
Context: https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops
Context: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=3360513

Recently (on or around 2020-Jan-03), our build and test jobs started
failing to build due to what appear to be authorization issues when
attempting to clone private sources:

	Updating external repositories
	  * monodroid
	    -> cloning from xamarin/monodroid
	stderr | Cloning into 'monodroid'...
	stderr | remote: Repository not found.
	stderr | fatal: repository 'https://github.com:/xamarin/monodroid/' not found

We don't know what *caused* this, but we do know of a "workaround":
AzDO recently added the ability to check out multiple repositories
within a pipeline.

Move away from using custom scripts and tokens for source checkout
and instead use the new "multi-repo" checkout feature in Azure
Pipelines that @akoeplinger suggested.

When multiple checkouts are defined, every repo is cloned into a
directory named after the repo.  Relative paths must be used when
overriding this behavior.  Also note that `$(Agent.BuildDirectory)`
(e.g. `/Users/vsts/agent/2.155.1/work/1`) is different from
`$(System.DefaultWorkingDirectory)`
(e.g. `/Users/vsts/agent/2.155.1/work/1/s`), and all values of the
path parameter for the `checkout` steps need to be relative to
`$(Agent.BuildDirectory)`.