### PR TITLE
[tests] Use random port between 9000 and 9999 for AOT profiling

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/AotProfileTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using System;
 using System.IO;
 using Xamarin.ProjectTools;
 
@@ -15,6 +16,8 @@ namespace Xamarin.Android.Build.Tests
 
 			var proj = new XamarinAndroidApplicationProject () { IsRelease = true };
 			proj.SetProperty (KnownProperties.AndroidSupportedAbis, "armeabi-v7a;x86");
+			var port = 9000 + new Random ().Next (1000);
+			proj.SetProperty ("AndroidAotProfilerPort", port.ToString ());
 			var projDirectory = Path.Combine ("temp", TestName);
 			using (var b = CreateApkBuilder (projDirectory)) {
 				Assert.IsTrue (b.RunTarget (proj, "BuildAndStartAotProfiling"), "Run of BuildAndStartAotProfiling should have succeeded.");


### PR DESCRIPTION
Use random port number to lower probability of choosing an already
used port number.