### PR TITLE
[ci] Remove nested xamarin-android submodule

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -101,11 +101,17 @@ stages:
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: make prepare-update-mono
 
+    # Clone monodroid wth submodules, but disregard the unused xamarin-android submodule.
     - checkout: monodroid
       clean: true
       submodules: recursive
       path: s/xamarin-android/external/monodroid
       persistCredentials: true
+      condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
+
+    - script: rm -rf external/monodroid/external/xamarin-android
+      workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
+      displayName: delete legacy xamarin-android submodule
       condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
 
     - script: make prepare-external-git-dependencies PREPARE_CI=1 CONFIGURATION=$(XA.Build.Configuration)


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4089
Context: https://github.com/xamarin/xamarin-android/commit/ed29bf1d47661e9df8458b5be074ed0369752b0b

In commit ed29bf1d we migrated to a new Azure Pipelines feature that
allows us to clone external sources. This caused an issue with our
inverted build, as it introduced a nested xamarin-android checkout which
was previously ignored. When attempting to apply ed29bf1d to d16-4, our
build failed due to an attempt to restore NuGet packages which are only
present (with a proper feed configuration) in xamarin-android/master:

    2020-01-07T00:20:53.8724800Z Restore failed in 483.85 ms for /Users/runner/runners/2.162.0/work/1/s/xamarin-android/external/monodroid/external/xamarin-android/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj.
    2020-01-07T00:20:53.8878660Z Committing restore...
    2020-01-07T00:20:53.8917530Z
    2020-01-07T00:20:53.8919560Z Errors in /Users/runner/runners/2.162.0/work/1/s/xamarin-android/external/monodroid/external/xamarin-android/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
    2020-01-07T00:20:53.8926530Z     NU1101: Unable to find package Microsoft.DotNet.GenAPI. No packages exist with this id in source(s): nuget.org
    2020-01-07T00:20:53.8929730Z     NU1101: Unable to find package Microsoft.DotNet.ApiCompat. No packages exist with this id in source(s): nuget.org
    2020-01-07T00:20:53.8931320Z Errors in /Users/runner/runners/2.162.0/work/1/s/xamarin-android/external/monodroid/external/xamarin-android/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
    2020-01-07T00:20:53.8932160Z     NU1101: Unable to find package XliffTasks. No packages exist with this id in source(s): nuget.org

Rather than ensuring this submodule is checked out to the right commit,
we'll just nuke the entire nested submodule instead as it is not needed
and should not be used by the inverted build system.