### PR TITLE
[ci] Fix multi-repo checkout notarization breakage

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -352,11 +352,9 @@ stages:
 
     - checkout: release_scripts
       clean: true
-      path: s/release-scripts
       persistCredentials: true
 
     - script: |
-        cd $(System.DefaultWorkingDirectory)/release-scripts
         git checkout $(ReleaseScriptsBranch)
         sudo xcode-select -s /Applications/$(NotarizationXcode)
         ruby notarize.rb $(XA.Unsigned.Pkg) $(XamarinIdentifier) $(XamarinUserId) $(XamarinPassword) $(TeamID)


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/ed29bf1d47661e9df8458b5be074ed0369752b0b
Context: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=3363837

Our notarization job has been failing since adding multi-repo
checkout steps to our YAML pipeline:

    /Users/builder/azdo/_work/_temp/edb4cc03-b677-49a2-8db9-524d03404164.sh: line 1: cd: /Users/builder/azdo/_work/1/s/release-scripts/release-scripts: No such file or directory

Upon further investigation, it seems that our working directory was set
to a value that was unexpected:

    ##[debug]  Working directory: '/Users/builder/azdo/_work/1/s/release-scripts'

The behavior of `$(System.DefaultWorkingDirectory)` changes based on the
number of checkout steps used in a single job, and whether or not those
steps specify a custom source path:

* Single repo checkout : `$(System.DefaultWorkingDirectory)=/Users/builder/azdo/_work/1/s`
* Single repo checkout when source path is provided: `$(System.DefaultWorkingDirectory)=/Users/builder/azdo/_work/1/custom/path`
* Multiple repo checkout regardless of whether or not source paths are provided: `$(System.DefaultWorkingDirectory)=/Users/builder/azdo/_work/1/s`

Fix our notarization step by 1) not setting a custom source path for
our release-scripts checkout and 2) not attempting to change directory
after checkout. In this case, `$(System.DefaultWorkingDirectory)` will
be set to our release-scripts checkout, as it is the only repo being
checked out.