### PR TITLE
[xaprepare] Detect if 7z supports output stream switches

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/VersionFetchers.cs
+++ b/build-tools/xaprepare/xaprepare/Application/VersionFetchers.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Android.Prepare
 
 		public readonly Dictionary<string, ProgramVersionParser> Fetchers = new Dictionary <string, ProgramVersionParser> (Context.Instance.OS.DefaultStringComparer) {
 			{"7z",       "--help",    MakeRegex ($"Version {StandardVersionRegex}"),   3},
+			{"7za",      "--help",    MakeRegex ($"Version {StandardVersionRegex}"),   3},
 			{"autoconf", "--version", StandardVersionAtEOL,                            1},
 			{"automake", "--version", StandardVersionAtEOL,                            1},
 			{"brew",     "--version", MakeRegex ($"^Homebrew {StandardVersionRegex}"), 1},

--- a/build-tools/xaprepare/xaprepare/ToolRunners/SevenZipRunner.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/SevenZipRunner.cs
@@ -9,6 +9,8 @@ namespace Xamarin.Android.Prepare
 	partial class SevenZipRunner : ToolRunner
 	{
 		const double DefaultTimeout = 30; // minutes
+		static readonly Version bsoepMinVersion = new Version (15, 5);
+		Version version;
 
 		protected override string DefaultToolExecutableName => "7za";
 		protected override string ToolName                  => "7zip";
@@ -17,6 +19,10 @@ namespace Xamarin.Android.Prepare
 			: base (context, log, toolPath ?? Context.Instance.Tools.SevenZipPath)
 		{
 			ProcessTimeout = TimeSpan.FromMinutes (DefaultTimeout);
+
+			string vs = VersionString?.Trim ();
+			if (String.IsNullOrEmpty (vs) || !Version.TryParse (vs, out version))
+				version = new Version (0, 0);
 		}
 
 		public async Task<bool> Extract (string archivePath, string outputDirectory, List<string> extraArguments = null)
@@ -108,14 +114,17 @@ namespace Xamarin.Android.Prepare
 			// Disable progress indicator (doesn't appear to have any effect with some versions of 7z)
 			runner.AddArgument ("-bd");
 
-			// Write standard messages to stdout
-			runner.AddArgument ("-bso1");
+			// These switches were added in 7zip 15.05
+			if (version >= bsoepMinVersion) {
+				// Write standard messages to stdout
+				runner.AddArgument ("-bso1");
 
-			// Write progress updates to stdout
-			runner.AddArgument ("-bsp1");
+				// Write progress updates to stdout
+				runner.AddArgument ("-bsp1");
 
-			// Write errors to stderr
-			runner.AddArgument ("-bse2");
+				// Write errors to stderr
+				runner.AddArgument ("-bse2");
+			}
 
 			// Answer 'yes' to all questions
 			runner.AddArgument ("-y");


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4082
Context: https://www.7-zip.org/history.txt

`xaprepare` uses the `-bs[o|e|p][0|1|2]` 7z/7za switches to make
absolutely sure output produced by 7zip goes where we want it to.
However, these switches were added only in version 15.05 of 7zip and
thus on operating systems with older versions of the utility `make
prepare` would fail to unpack any archives. Since these switches are
not **critical** to our operation we can accommodate the older 7z
releases by making the switches optional.