### PR TITLE
[ci] Report artifact status to the correct repo

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -332,6 +332,8 @@ stages:
     variables:
     - group: Xamarin Notarization
     steps:
+    - checkout: self
+
     - checkout: release_scripts
       clean: true
       persistCredentials: true
@@ -361,6 +363,7 @@ stages:
         UnsignedPkgPath: $(XA.Unsigned.Pkg)
 
     - script: |
+        cd $(System.DefaultWorkingDirectory)/release-scripts
         git checkout $(ReleaseScriptsBranch)
         sudo xcode-select -s /Applications/$(NotarizationXcode)
         ruby notarize.rb $(XA.Unsigned.Pkg) $(XamarinIdentifier) $(XamarinUserId) $(XamarinPassword) $(TeamID)
@@ -374,6 +377,7 @@ stages:
         BuildPackages: $(System.DefaultWorkingDirectory)/storage-artifacts
         AzureContainerName: $(Azure.Container.Name)
         AzureUploadLocation: $(Build.DefinitionName)/$(Build.BuildId)/$(Build.SourceBranchName)/$(Build.SourceVersion)
+        SourceDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
 
     - script: cp $(System.DefaultWorkingDirectory)/storage-artifacts/*.pkg $(Build.ArtifactStagingDirectory)
       displayName: copy notarized pkg


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/ed29bf1d47661e9df8458b5be074ed0369752b0b

The notarization job is also responsible for posting artifact metadata
to GitHub as a commit status. Commit ed29bf1d broke this, as it changed
the source checkout behavior for this job.

We report artifact metadata to GitHub with the [Artifacts tool][0], and
this tool must be ran inside the source directory that it is going to
create a GitHub commit status for. As of commit ed29bf1d, we started
executing this tool within a release-scripts checkout rather than a
xamarin-android checkout.

Our .vsix signing job relies on the GitHub commit status created by
the Artifacts tool to determine which file to sign. Since artifact
metadata reporting was broken, our .vsix signing job was failing to
fetch the information it needed to download and sign the correct file.

Fix this breakage by cloning both xamarin-android and release scripts so
that the artifacts tool can run within xamarin-android and successfully
report a status back to it.

[0]: https://github.com/xamarinhq/build-tasks/tree/master/Artifacts