### PR TITLE
[build] Use an in tree `globalPackagesFolder`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "Launch",
             "type": "mono",
             "request": "launch",
-            "program": "${workspaceRoot}packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe ${workspaceRoot}bin/TestDebug/Xamarin.Android.Build.Tests.dll",
+            "program": "${workspaceRoot}packages/nunit.consolerunner/3.9.0/tools/nunit3-console.exe ${workspaceRoot}bin/TestDebug/Xamarin.Android.Build.Tests.dll",
             "cwd": "${workspaceRoot}bin/TestDebug/"
         },
         {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "nxunitExplorer.nunit": "packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe",
+    "nxunitExplorer.nunit": "packages/nunit.consolerunner/3.9.0/tools/nunit3-console.exe",
     "nxunitExplorer.modules": [
         "bin/TestDebug/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll",
         "bin/TestDebug/Xamarin.Android.Build.Tests.dll",

--- a/Configuration.props
+++ b/Configuration.props
@@ -182,7 +182,7 @@
   <!-- Unit Test Properties -->
   <PropertyGroup>
     <_Runtime Condition=" '$(HostOS)' != 'Windows' ">$(ManagedRuntime) $(ManagedRuntimeArgs)</_Runtime>
-    <_NUnit>$(_Runtime) packages\NUnit.ConsoleRunner.3.9.0\tools\nunit3-console.exe</_NUnit>
+    <_NUnit>$(_Runtime) packages\nunit.consolerunner\3.9.0\tools\nunit3-console.exe</_NUnit>
   </PropertyGroup>
 
   <!-- Fix for IDEs -->

--- a/NuGet.config
+++ b/NuGet.config
@@ -9,5 +9,5 @@
   </packageSources>
   <config>
     <add key="globalPackagesFolder" value="packages" />
-</config>
+  </config>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,4 +7,7 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="dotnet internal feed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" protocolVersion="3" />
   </packageSources>
+  <config>
+    <add key="globalPackagesFolder" value="packages" />
+</config>
 </configuration>

--- a/build-tools/automation/yaml-templates/run-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-nunit-tests.yaml
@@ -1,5 +1,5 @@
 parameters:
-  nunitConsole: packages/NUnit.ConsoleRunner.$(NUnitConsoleVersion)/tools/nunit3-console.exe
+  nunitConsole: packages/nunit.consolerunner/$(NUnitConsoleVersion)/tools/nunit3-console.exe
   testRunTitle: Xamarin Android Tests
   testAssembly: []
   testResultsFile: TestResult.xml

--- a/build-tools/automation/yaml-templates/run-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-nunit-tests.yaml
@@ -1,5 +1,5 @@
 parameters:
-  nunitConsole: packages/nunit.consolerunner/$(NUnitConsoleVersion)/tools/nunit3-console.exe
+  nunitConsole: $(System.DefaultWorkingDirectory)/packages/nunit.consolerunner/$(NUnitConsoleVersion)/tools/nunit3-console.exe
   testRunTitle: Xamarin Android Tests
   testAssembly: []
   testResultsFile: TestResult.xml

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -54,4 +54,4 @@ steps:
   inputs:
     solution: build-tools/xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
     configuration: ${{ parameters.configuration }}
-    msbuildArguments: /t:Restore,Build /bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/BootstrapTasks.binlog
+    msbuildArguments: /restore /bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/BootstrapTasks.binlog

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -38,15 +38,20 @@ steps:
     versionSpec: 5.x
 
 - task: NuGetCommand@2
-  displayName: nuget restore Xamarin.Android solutions
+  displayName: nuget restore Xamarin.Android.Build.Tasks.sln
   inputs:
-    restoreSolution: '**/Xamarin.Android*.sln'
-    feedsToUse: config
-    nugetConfigPath: NuGet.config
+    command: custom
+    arguments: restore Xamarin.Android.Build.Tasks.sln -ConfigFile NuGet.config
+
+- task: NuGetCommand@2
+  displayName: nuget restore Xamarin.Android-Tests.sln
+  inputs:
+    command: custom
+    arguments: restore Xamarin.Android-Tests.sln -ConfigFile NuGet.config
 
 - task: MSBuild@1
   displayName: build Xamarin.Android.Tools.BootstrapTasks.csproj
   inputs:
     solution: build-tools/xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
     configuration: ${{ parameters.configuration }}
-    msbuildArguments: /bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/BootstrapTasks.binlog
+    msbuildArguments: /t:Restore,Build /bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/BootstrapTasks.binlog

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/Windows.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/Windows.cs
@@ -58,7 +58,7 @@ namespace Xamarin.Android.Prepare
 					return base.Which (programPath, required);
 				}
 
-				string packagePath = Path.Combine (homeDir, ".nuget", "packages", "7-zip.commandline", "18.1.0", "tools");
+				string packagePath = Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "packages", "7-zip.commandline", "18.1.0", "tools");
 				if (Is64Bit)
 					packagePath = Path.Combine (packagePath, "x64");
 				return Path.Combine (packagePath, "7za.exe");

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/LibZipSharp.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/LibZipSharp.cs
@@ -9,8 +9,8 @@ namespace Xamarin.Android.Prepare
 	{
 		static readonly Uri url = new Uri ("https://github.com/xamarin/LibZipSharp/");
 		internal static readonly string LibZipSharpVersion = "1.0.6";
-		static readonly string licenseFile = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile),
-			".nuget", "packages", "xamarin.libzipsharp", LibZipSharpVersion,
+		static readonly string licenseFile = Path.Combine (BuildPaths.XamarinAndroidSourceRoot,
+			"packages", "xamarin.libzipsharp", LibZipSharpVersion,
 			"Licences", "LICENSE");
 
 		public override string LicenseFile => licenseFile;

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/libzip.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/libzip.cs
@@ -8,8 +8,8 @@ namespace Xamarin.Android.Prepare
 	class libzip_nih_at_libzip_TPN : ThirdPartyNotice
 	{
 		static readonly Uri url = new Uri ("https://github.com/nih-at/libzip/");
-		static readonly string licenseFile = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile),
-			".nuget", "packages", "xamarin.libzipsharp", LibZipSharp_grendello_LibZipSharp_TPN.LibZipSharpVersion,
+		static readonly string licenseFile = Path.Combine (BuildPaths.XamarinAndroidSourceRoot,
+			"packages", "xamarin.libzipsharp", LibZipSharp_grendello_LibZipSharp_TPN.LibZipSharpVersion,
 			"Licences", "libzip", "LICENSE");
 
 		public override string LicenseFile => licenseFile;

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -173,7 +173,7 @@
       Inputs="$(TargetPath);@(ApiCompatibilityFiles)"
       Outputs="$(IntermediateOutputPath)CheckApiCompatibility.stamp">
     <CheckApiCompatibility
-        ApiCompatPath="$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))\.nuget\packages\microsoft.dotnet.apicompat\5.0.0-beta.19606.1\tools\net472\"
+        ApiCompatPath="$(XamarinAndroidSourcePath)\packages\microsoft.dotnet.apicompat\5.0.0-beta.19606.1\tools\net472\"
         ApiLevel="$(AndroidFrameworkVersion)"
         LastStableApiLevel="$(AndroidLatestStableFrameworkVersion)"
         TargetImplementationPath="$(OutputPath)"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -713,6 +713,7 @@ namespace UnamedProject
 		}
 
 		[Test]
+		[NonParallelizable] // On MacOS, parallel /restore causes issues
 		public void BuildApplicationAndClean ([Values (false, true)] bool isRelease, [Values ("apk", "aab")] string packageFormat)
 		{
 			var proj = new XamarinFormsAndroidApplicationProject {
@@ -1064,6 +1065,7 @@ namespace UnamedProject
 		}
 
 		[Test]
+		[NonParallelizable] // On MacOS, parallel /restore causes issues
 		public void BuildProguardEnabledProject ([Values (true, false)] bool isRelease, [Values ("dx", "d8")] string dexTool, [Values ("", "proguard", "r8")] string linkTool)
 		{
 			var proj = new XamarinFormsAndroidApplicationProject {
@@ -3436,6 +3438,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 					KnownPackages.SupportFragment_27_0_2_1,
 					KnownPackages.SupportMediaCompat_27_0_2_1,
 					KnownPackages.GooglePlayServicesMaps_42_1021_1,
+					KnownPackages.Xamarin_Build_Download_0_4_11,
 				},
 			};
 			//NOTE: BuildingInsideVisualStudio prevents the projects from being built as dependencies

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -30,7 +30,7 @@ namespace Xamarin.ProjectTools
 		public IList<Package> Packages { get; private set; }
 		public IList<BuildItem> References { get; private set; }
 		public IList<Package> PackageReferences { get; private set; }
-		public string GlobalPackagesFolder { get; set; }
+		public string GlobalPackagesFolder { get; set; } = Path.Combine (XABuildPaths.TopDirectory, "packages");
 		public IList<string> ExtraNuGetConfigSources { get; set; }
 
 		public virtual bool ShouldRestorePackageReferences => PackageReferences?.Count > 0;

--- a/tests/CodeBehind/UnitTests/run.sh
+++ b/tests/CodeBehind/UnitTests/run.sh
@@ -4,4 +4,4 @@ export USE_MSBUILD=1
 export MSBUILD=msbuild
 msbuild CodeBehindUnitTests.csproj
 cd ../../../
-exec mono --debug packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe bin/TestDebug/CodeBehind/CodeBehindUnitTests.dll
+exec mono --debug packages/nunit.consolerunner/3.9.0/tools/nunit3-console.exe bin/TestDebug/CodeBehind/CodeBehindUnitTests.dll

--- a/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/run.sh
+++ b/tests/EmbeddedDSOs/EmbeddedDSO-UnitTests/run.sh
@@ -5,4 +5,4 @@ export MSBUILD=msbuild
 CONFIGURATION=${1:-Debug}
 msbuild /p:Configuration=${CONFIGURATION} EmbeddedDSO-UnitTests.csproj
 cd ../../../
-exec mono --debug packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe bin/Test${CONFIGURATION}/EmbeddedDSOUnitTests.dll
+exec mono --debug packages/nunit.consolerunner/3.9.0/tools/nunit3-console.exe bin/Test${CONFIGURATION}/EmbeddedDSOUnitTests.dll


### PR DESCRIPTION
`PackageReference` packages install/restore into a default global folder
of `%userprofile%\.nuget\packages (Windows)` or
`~/.nuget/packages (Mac/Linux)`.

In order to avoid bloating the home directories on our machines used
locally and in CI, we'll reconfigure the `globalPackagesFolder` path to
point to a `packages` folder nested under `xamarin-android`.

This also allows us to continue to use "known" paths to certain tools
that are used by our tests, such as `nunit3-console.exe`.

Each test in `Xamarin.Android.Build.Tests` copies and uses the
`NuGet.config` file from the xamarin-android repo root. Now that a
`globalPackagesFolder` value is specified in that file, the NuGet restore
behavior for all tests has changed, and some test changes were needed.

A new `globalPackagesFolder` default has now been set for all tests so
that a common folder can be used rather than a `packages` folder nested
under each test directory. Additionally, some tests have been updated
to no longer run in parallel due to restore issues.