### PR TITLE
[Xamarin.Android.Build.Tasks] Don't log unhandled exceptions twice.

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/UnhandledExceptionLogger.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/UnhandledExceptionLogger.cs
@@ -69,8 +69,8 @@ namespace Xamarin.Android.Tasks
 				log.LogCodedError (prefix + "7028", ex.ToString ());
 			else if (ex is IOException) 
 				log.LogCodedError (prefix + "7024", ex.ToString ());
-
-			log.LogCodedError (prefix + "7000", ex.ToString ());
+			else
+				log.LogCodedError (prefix + "7000", ex.ToString ());
 		}
 	}
 }


### PR DESCRIPTION
When logging unhandled exceptions in our MSBuild tasks, a missing `else` is causing each error to get logged twice, once with the coded error and once with the generic error.

Example:
```
XARDF7004: System.ArgumentException: Illegal characters in path.
    at System.Security.Permissions.FileIOPermission.EmulateFileIOPermissionChecks(String fullPath)
    at System.Security.Permissions.FileIOPermission.QuickDemand(FileIOPermissionAccess access, String fullPath, Boolean checkForDuplicates, Boolean needFullPath)
    at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, Boolean checkHost)
    at Xamarin.Android.Tasks.RemoveDirFixed.RunTask()
    at Xamarin.Android.Tasks.AndroidTask.Execute()
XARDF7000: System.ArgumentException: Illegal characters in path.
    at System.Security.Permissions.FileIOPermission.EmulateFileIOPermissionChecks(String fullPath)
    at System.Security.Permissions.FileIOPermission.QuickDemand(FileIOPermissionAccess access, String fullPath, Boolean checkForDuplicates, Boolean needFullPath)
    at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, Boolean checkHost)
    at Xamarin.Android.Tasks.RemoveDirFixed.RunTask()
    at Xamarin.Android.Tasks.AndroidTask.Execute()
```

This case should only log `XARDF7004`.