### PR TITLE
[linker] Remove known attributes in all assemblies

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/RemoveAttributes.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/RemoveAttributes.cs
@@ -15,8 +15,52 @@ namespace MonoDroid.Tuner {
 
 	public class RemoveAttributes : RemoveAttributesBase {
 
+		bool changed;
+
 		protected virtual bool DebugBuild {
 			get { return context.LinkSymbols; }
+		}
+
+		public override bool IsActiveFor (AssemblyDefinition assembly)
+		{
+			return true;
+		}
+
+		void SetAssemblyAction (AssemblyDefinition assembly)
+		{
+			switch (Annotations.GetAction (assembly)) {
+				case AssemblyAction.Copy:
+				case AssemblyAction.CopyUsed:
+					Annotations.SetAction (assembly, AssemblyAction.Save);
+					break;
+			}
+		}
+
+		public override void ProcessAssembly (AssemblyDefinition assembly)
+		{
+			changed = false;
+
+			base.ProcessAssembly (assembly);
+
+			if (changed)
+				SetAssemblyAction (assembly);
+		}
+
+		public override void ProcessType (TypeDefinition type)
+		{
+			changed = false;
+
+			base.ProcessType (type);
+
+			if (changed)
+				SetAssemblyAction (type.Module.Assembly);
+		}
+
+		protected override void WillRemoveAttribute (ICustomAttributeProvider provider, CustomAttribute attribute)
+		{
+			base.WillRemoveAttribute (provider, attribute);
+
+			changed = true;
 		}
 
 		protected override bool IsRemovedAttribute (CustomAttribute attribute)


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/4057

It reduces the size of the apk slightly, the performance is nearly the
same, so I think it still makes sense to do.

SmartHotel360:

apk size difference 32768 bytes:

old 50991603
new 50958835

build time:

old    16191 ms  LinkAssemblies                             1 calls
new    16207 ms  LinkAssemblies                             1 calls