### PR TITLE
[xaprepare] Bump MDK version

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -97,7 +97,7 @@ stages:
         version: $(DotNetCoreVersion)
 
     # Prepare and build everything
-    - script: make prepare-update-mono V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1
+    - script: make prepare-update-mono V=1 CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1 BOOTSTRAP_MSBUILD_FLAGS="/p:UseSharedCompilation=false /nodeReuse:false"
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: make prepare-update-mono
 

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.MacOS.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Android.Prepare
 		partial class Urls
 		{
 			public static readonly Uri Corretto = new Uri ($"{Corretto_BaseUri}{CorrettoUrlPathVersion}/amazon-corretto-{CorrettoDistVersion}-macosx-x64.tar.gz");
-			public static readonly Uri MonoPackage = new Uri ("https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2019-10/57/e9b5aec5ec7801df66117f2da730672ede15dcc6/MonoFramework-MDK-6.8.0.53.macos10.xamarin.universal.pkg");
+			public static readonly Uri MonoPackage = new Uri ("https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2019-10/98/41f9a07d3d4d3d2600e78d2954067f465a6bfe92/MonoFramework-MDK-6.8.0.95.macos10.xamarin.universal.pkg");
 		}
 
 		partial class Defaults

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Android.Prepare
 
 			// If you change the minimum Mono version here, please change the URL as well
 			new MonoPkgProgram ("Mono", "com.xamarin.mono-MDK.pkg", Configurables.Urls.MonoPackage) {
-				MinimumVersion = "6.8.0.53",
+				MinimumVersion = "6.8.0.95",
 				MaximumVersion = "6.99.0.0",
 			},
 		};


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4099
Roslyn bug: https://github.com/dotnet/roslyn/issues/38183
Corresponding Mono bug: https://github.com/mono/mono/issues/16541

To get Roslyn fix, for a bug we experience on ji-nrt branch, where
cil-strip is crashing.

    Moving F:\A\xamarin-v000004-1\_work\2\s\bin\TestRelease\temp\BuildAotApplication_arm64-v8a_Hybrid_True_True\obj\Release\android\assets\Java.Interop.dll to obj\Release\android\assets\non-stripped\Java.Interop.dll (TaskId:190)
      [cil-strip] obj\Release\android\assets\non-stripped\Java.Interop.dll (TaskId:190)
      [cil-strip stdout] Mono CIL Stripper (TaskId:190)
      [cil-strip stdout]  (TaskId:190)
      [cil-strip stdout] Error: System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (TaskId:190)
      [cil-strip stdout] Parameter name: index (TaskId:190)
      [cil-strip stdout]    at System.Collections.CollectionBase.System.Collections.IList.get_Item(Int32 index) (TaskId:190)
      [cil-strip stdout]    at Mono.Cecil.GenericParameterCollection.get_Item(Int32 index) (TaskId:190)
      [cil-strip stdout]    at Mono.Cecil.ReflectionReader.GetTypeRefFromSig(SigType t, GenericContext context) (TaskId:190)
      [cil-strip stdout]    at Mono.Cecil.ReflectionReader.CreateTypeSpecFromSig(TypeSpec ts, Int32 index, GenericContext context) (TaskId:190)
      [cil-strip stdout]    at Mono.Cecil.Cil.CodeReader.ReadCilBody(MethodBody body, BinaryReader br) (TaskId:190)
      [cil-strip stdout]    at Mono.Cecil.Cil.CodeReader.VisitMethodBody(MethodBody body) (TaskId:190)
      [cil-strip stdout]    at Mono.Cecil.MethodDefinition.LoadBody() (TaskId:190)
      [cil-strip stdout]    at Mono.Cecil.ModuleDefinition.FullLoad() (TaskId:190)
      [cil-strip stdout]    at Mono.CilStripper.AssemblyStripper.Strip() (TaskId:190)
      [cil-strip stdout]    at Mono.CilStripper.AssemblyStripper.StripAssembly(AssemblyDefinition assembly, String file) (TaskId:190)
      [cil-strip stdout]    at Mono.CilStripper.Program.Main(String[] arguments) (TaskId:190)
    C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Xamarin\Android\Xamarin.Android.Common.targets(2732,4): error XA3001: Could not strip IL of assembly: obj\Release\android\assets\Java.Interop.dll [F:\A\xamarin-v000004-1\_work\2\s\bin\TestRelease\temp\BuildAotApplication_arm64-v8a_Hybrid_True_True\UnnamedProject.csproj]