### PR TITLE
Honor the .NET SDK EnableDefaultItems property when including default items

### DIFF
--- a/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.DefaultItems.props
+++ b/src/Xamarin.Android.Sdk/targets/Xamarin.Android.Sdk.DefaultItems.props
@@ -2,7 +2,7 @@
 
   <!-- Default Resource file inclusion -->
   <!-- https://developer.android.com/guide/topics/resources/providing-resources -->
-  <ItemGroup Condition=" '$(EnableDefaultAndroidResourceItems)' == 'true' ">
+  <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' And '$(EnableDefaultAndroidResourceItems)' == 'true' ">
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\**\*.xml" />
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\**\*.axml" />
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\**\*.png" />
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <!-- Default Asset file inclusion -->
-  <ItemGroup Condition=" '$(EnableDefaultAndroidAssetItems)' == 'true' ">
+  <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' And '$(EnableDefaultAndroidAssetItems)' == 'true' ">
     <AndroidAsset Include="$(MonoAndroidAssetsPrefix)\**\*" />
   </ItemGroup>
 


### PR DESCRIPTION
Follows the pattern at https://github.com/dotnet/sdk/blob/master/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props#L36