### PR TITLE
[build] fix ILRepacker target's inputs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -309,7 +309,7 @@
 
   <Target Name="ILRepacker"
       BeforeTargets="CopyFilesToOutputDirectory"
-      Inputs="@(InputAssemblies)"
+      Inputs="$(MSBuildAllProjects);@(IntermediateAssembly);@(InputAssemblies)"
       Outputs="$(IntermediateOutputPath)ILRepacker.stamp"
       Condition=" '$(HostOS)' != 'Linux' ">
     <ItemGroup>


### PR DESCRIPTION
Context: https://build.azdo.io/3380356

We have seen an error on PR builds such as:

    (_ResolveAssemblies target) ->
        Xamarin.Android.Common.targets(1702,2): error : Could not load file or assembly 'NuGet.Common, Version=4.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' or one of its dependencies.
        Xamarin.Android.Common.targets(1702,2): error :   at Xamarin.Android.Tasks.ResolveAssemblies.RunTaskAsync () [0x00006] in <b7f246e55e6448348b8bc9a1e37cc64b>:0
        Xamarin.Android.Common.targets(1702,2): error :   at Xamarin.Android.Tasks.AndroidAsyncTask.<RunTask>b__4_0 () [0x00000] in <b7f246e55e6448348b8bc9a1e37cc64b>:0
        Xamarin.Android.Common.targets(1702,2): error :   at System.Threading.Tasks.Task`1[TResult].InnerInvoke () [0x0000f] in <97b502f2cbfa41d493563be777ffb43e>:0
        Xamarin.Android.Common.targets(1702,2): error :   at System.Threading.Tasks.Task.Execute () [0x00000] in <97b502f2cbfa41d493563be777ffb43e>:0

I downloaded the pkg file, and `Xamarin.Android.Build.Tasks.dll` was
missing classes. It was as if the `ILRepacker` MSBuild target didn't
run.

Reviewing the target's `Input`'s it seemed like it also needs:

* `$(MSBuildAllProjects)` if you changed the XML in the target, would
  re-trigger it.
* `@(IntermediateAssembly)`, C# code changes would re-trigger it.

We are still investigating how we could hit this issue on CI. It isn't
making complete sense.