### PR TITLE
Android PerfTest tool

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,16 @@
             "request": "attach",
             "address": "localhost",
             "port": 55555
+        },
+        {
+          "name": "Launch emulator boot benchmark",
+          "type": "mono",
+          "request": "launch",
+          "preLaunchTask": "build-emulator-checkboottimes",
+          "program": "${workspaceRoot}/bin/BuildDebug/check-boot-times.exe",
+          "args": [ ],
+          "cwd": "${workspaceRoot}",
+          "stopAtEntry": false
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -74,6 +74,18 @@
             "problemMatcher": [
                 "$msCompile"
             ]
-        }
+        },
+        {
+          "label": "build-emulator-checkboottimes",
+          "type": "shell",
+          "command": "msbuild build-tools/check-boot-times/check-boot-times.csproj",
+          "group": {
+              "kind": "build",
+              "isDefault": true
+          },
+          "problemMatcher": [
+              "$msCompile"
+          ]
+      },
     ]
 }

--- a/Xamarin.Android.sln
+++ b/Xamarin.Android.sln
@@ -127,6 +127,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Debugging.Soft", "exte
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "jnienv-gen", "external\Java.Interop\build-tools\jnienv-gen\jnienv-gen.csproj", "{6410DA0F-5E14-4FC0-9AEE-F4C542C96C7A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "check-boot-times", "build-tools\check-boot-times\check-boot-times.csproj", "{D28957BF-5E66-4D60-B528-22820C60AC82}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems*{3f1f2f50-af1a-4a5a-bedb-193372f068d7}*SharedItemsImports = 4
@@ -362,6 +364,10 @@ Global
 		{6410DA0F-5E14-4FC0-9AEE-F4C542C96C7A}.Debug|AnyCPU.Build.0 = Debug|Any CPU
 		{6410DA0F-5E14-4FC0-9AEE-F4C542C96C7A}.Release|AnyCPU.ActiveCfg = Release|Any CPU
 		{6410DA0F-5E14-4FC0-9AEE-F4C542C96C7A}.Release|AnyCPU.Build.0 = Release|Any CPU
+		{D28957BF-5E66-4D60-B528-22820C60AC82}.Debug|AnyCPU.ActiveCfg = Debug|Any CPU
+		{D28957BF-5E66-4D60-B528-22820C60AC82}.Debug|AnyCPU.Build.0 = Debug|Any CPU
+		{D28957BF-5E66-4D60-B528-22820C60AC82}.Release|AnyCPU.ActiveCfg = Release|Any CPU
+		{D28957BF-5E66-4D60-B528-22820C60AC82}.Release|AnyCPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -424,6 +430,7 @@ Global
 		{90C99ADB-7D4B-4EB4-98C2-40BD1B14C7D2} = {05C3B1D6-A4CE-4534-A9E4-E9117591ADF7}
 		{DE40756E-57F6-4AF2-B155-55E3A88CCED8} = {05C3B1D6-A4CE-4534-A9E4-E9117591ADF7}
 		{6410DA0F-5E14-4FC0-9AEE-F4C542C96C7A} = {05C3B1D6-A4CE-4534-A9E4-E9117591ADF7}
+		{D28957BF-5E66-4D60-B528-22820C60AC82} = {E351F97D-EA4F-4E7F-AAA0-8EBB1F2A4A62}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {53A1F287-EFB2-4D97-A4BB-4A5E145613F6}

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\Zip.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\KillProcess.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\RunUITests.cs" />
+    <Compile Include="Xamarin.Android.Tools.BootstrapTasks\RunAndroidEmulatorCheckBootTimes.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\RunInstrumentationTests.cs" />
     <Compile Include="Xamarin.Android.Tools.BootstrapTasks\JdkInfo.cs" />
   </ItemGroup>

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunAndroidEmulatorCheckBootTimes.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunAndroidEmulatorCheckBootTimes.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using Xamarin.Android.BuildTools.PrepTasks;
+
+namespace Xamarin.Android.Tools.BootstrapTasks
+{
+	public class RunAndroidEmulatorCheckBootTimes : Task
+	{
+		public string CheckBootTimesPath { get; set; }
+		public string DeviceName { get; set; } = "XamarinAndroidTestRunner";
+
+		public override bool Execute ()
+		{
+			Log.LogMessage (MessageImportance.High, $"Task {nameof (RunAndroidEmulatorCheckBootTimes)}");
+			Log.LogMessage (MessageImportance.High, $"     {nameof (CheckBootTimesPath)}: {CheckBootTimesPath}");
+			Log.LogMessage (MessageImportance.High, $"     {nameof (DeviceName)}: {DeviceName}");
+
+			var fileInfo = new FileInfo (CheckBootTimesPath);
+			Log.LogMessage (MessageImportance.High, $"CheckBootTimesPath:  {fileInfo.FullName}");
+
+			if (!fileInfo.Exists) {
+				Log.LogError ($"Unable to find {fileInfo.FullName}.");
+				return !Log.HasLoggedErrors;
+			}
+
+			bool finishAsExpected = false;
+			var success = RunProcess (
+				fileInfo.FullName,
+				$"--devicename {DeviceName}",
+				5 * 60000,
+				(string data, ManualResetEvent mre) => {
+					Log.LogMessage (MessageImportance.High, $"CheckBootTimes ({DateTime.UtcNow}): {data}");
+					if (!string.IsNullOrWhiteSpace (data) && data.IndexOf ("Check-Boot-Times Done.", StringComparison.OrdinalIgnoreCase) != -1) {
+						finishAsExpected = true;
+						mre.Set ();
+					}
+
+					return true;
+				});
+
+			if (!success || !finishAsExpected) {
+				Log.LogError ("check-boot-times did not run as expected, please see logs for more info.");
+				CloseProcesses ();
+				return false;
+			}
+
+			Log.LogMessage (MessageImportance.High, $"Done with RunAndroidEmulatorCheckBootTimes task.");
+			return true;
+		}
+
+
+		static void CloseProcesses ()
+		{
+			// Try to close emulator
+			for (int i = 0; i < 10; i++) {
+				try {
+					var proc = GetProcess("emulator");
+					if (proc == null) {
+						proc = GetProcess("qemu");
+
+						if (proc == null) {
+							break;
+						}
+					}
+
+					proc.WaitForExit (5000);
+
+					// Close process by sending a close message to its main window.
+					proc.CloseMainWindow ();
+
+					// Free resources associated with process.
+					proc.Close ();
+				} catch (Exception e) {
+					Console.WriteLine ($"Unable to close emulator. {e.Message}");
+				}
+			}
+
+			// Emulator was not close, try to kill process
+			for (int i = 0; i < 10; i++) {
+				try {
+					var proc = GetProcess("emulator");
+					if (proc == null) {
+						proc = GetProcess("qemu");
+
+						if (proc == null) {
+							break;
+						}
+					}
+
+					proc.WaitForExit (5000);
+
+					proc.Kill ();
+				} catch (Exception e) {
+					Console.WriteLine ($"Unable to kill emulator. {e.Message}");
+				}
+			}
+
+			// kill check-boot-times process if needed
+			for (int i = 0; i < 10; i++) {
+				try {
+					var proc = GetProcess("check-boot-times");
+					if (proc == null) {
+						break;
+					}
+
+					proc.WaitForExit (5000);
+
+					proc.Kill ();
+				} catch (Exception e) {
+					Console.WriteLine ($"Unable to kill check-boot-times. {e.Message}");
+				}
+			}
+		}
+
+		static bool RunProcess (string filename, string arguments, int timeout, Func<string, ManualResetEvent, bool> validation, Action processTimeout = null)
+		{
+			using (var process = new Process ()) {
+
+				process.StartInfo.FileName = filename;
+				process.StartInfo.Arguments = arguments;
+				process.StartInfo.UseShellExecute = false;
+				process.StartInfo.CreateNoWindow = true;
+				process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+				process.StartInfo.RedirectStandardOutput = true;
+				process.StartInfo.RedirectStandardOutput = true;
+				process.StartInfo.RedirectStandardError = true;
+				process.EnableRaisingEvents = true;
+
+				var mre = new ManualResetEvent (false /* -> nonsignaled */);
+
+				bool error = false;
+				void dataReceived (object sender, DataReceivedEventArgs args)
+				{
+					if (!validation (args.Data, mre)) {
+						error = true;
+						mre.Set ();
+					}
+				}
+
+				process.OutputDataReceived += dataReceived;
+				process.ErrorDataReceived += dataReceived;
+				process.Exited += (s, e) => {
+					mre.WaitOne (1000);
+					mre.Set ();
+				};
+
+				process.Start ();
+
+				process.BeginOutputReadLine ();
+				process.BeginErrorReadLine ();
+
+				if (!mre.WaitOne (timeout) || !process.WaitForExit (timeout)) {
+					processTimeout?.Invoke ();
+					error = true;
+				}
+
+				process.CancelOutputRead ();
+				process.CancelErrorRead ();
+
+				if (error || !process.HasExited || process.ExitCode != 0) {
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		static Process GetProcess (string processName)
+		{
+			return Process.GetProcesses ().FirstOrDefault (p => p.ProcessName.IndexOf (processName, StringComparison.OrdinalIgnoreCase) != -1);
+		}
+	}
+}

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -471,6 +471,25 @@ stages:
       parameters:
         configuration: $(ApkTestConfiguration)
 
+    - task: MSBuild@1
+      displayName: build check-boot-times.csproj
+      inputs:
+        solution: build-tools/check-boot-times/check-boot-times.csproj
+        configuration: $(ApkTestConfiguration)
+        msbuildArguments: >
+          /restore
+          /t:Build
+          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/build-check-boot-times.binlog
+
+    - task: MSBuild@1
+      displayName: Run check-boot-times
+      inputs:
+        solution: src/Mono.Android/Test/Mono.Android-Tests.csproj
+        configuration: $(ApkTestConfiguration)
+        msbuildArguments: >
+          /t:CheckBootTimes
+          /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/run-check-boot-times.binlog
+
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
         configuration: $(ApkTestConfiguration)

--- a/build-tools/check-boot-times/Program.cs
+++ b/build-tools/check-boot-times/Program.cs
@@ -1,0 +1,583 @@
+﻿using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Xamarin.Android.Tools
+{
+	class Program
+	{
+		static string sdkPath;
+		static string adbPath;
+		static string avdManagerPath;
+		static string emulatorPath;
+		static string sdkManagerPath;
+		static string deviceName;
+		static int executionTimes = 1;
+		static bool showVerbose;
+
+		static int Main (string [] args)
+		{
+			var rootCommand = new RootCommand
+			{
+				new Option ("--verbose", "Show verbose output")
+				{
+					Argument = new Argument<bool> ()
+				},
+				new Option("--executiontimes", "Number of times emulator should run.")
+				{
+					    Argument = new Argument<int>(),
+				},
+				new Option("--sdkpath", "Android sdk location.")
+				{
+					    Argument = new Argument<string>(),
+				},
+				new Option("--devicename", "Emulator Virtual Device Name, If not provided a new one will be created.")
+				{
+					    Argument = new Argument<string>(),
+				},
+			};
+
+			rootCommand.Name = "CheckBootTimes";
+			rootCommand.Description = "Collect Android Emulator boot times.";
+			rootCommand.Handler = System.CommandLine.Invocation.CommandHandler.Create(async (bool verbose, int? executiontimes, string sdkpath, string devicename) => {
+				showVerbose = verbose;
+				executionTimes = executiontimes.HasValue ? executiontimes.Value : 1;
+				sdkPath = sdkpath;
+				deviceName = devicename;
+
+				Console.WriteLine ($"Testing emulator startup times for {executionTimes} execution(s). This may take several minutes.");
+
+				var result = await Run ();
+
+				Console.WriteLine ($"Check-Boot-Times Done.");
+
+				return result ? 0 : 1;
+			});
+
+
+			try {
+				return rootCommand.InvokeAsync (args).Result;
+			} catch (Exception e) {
+				Console.ForegroundColor = ConsoleColor.Red;
+				Console.Write (e.Message);
+				Console.ForegroundColor = ConsoleColor.White;
+				return 1;
+			}
+		}
+
+		static async Task<bool> Run ()
+		{
+			if (!ToolsExist ()) {
+				return false;
+			}
+
+			if (!await CheckAccelerationType ()) {
+				return false;
+			}
+
+			await PrintEmulatorVersion ();
+
+			if (string.IsNullOrWhiteSpace (deviceName) && !await CheckVirtualDeviceExistsAndTryToCreateIfNeeded (true /* use skin */, true /* use Pixel device */)) {
+				return false;
+			}
+
+			if (await GetBootTime (true /*cold boot */) < 0) {
+				return false;
+			}
+
+			if (await GetBootTime (false /* cold boot */) < 0) {
+				return false;
+			}
+
+			return true;
+		}
+
+		static async Task<bool> PrintEmulatorVersion ()
+		{
+			var output = new List<string> ();
+			if (!await RunProcess (emulatorPath, $"-version", 5000, (data, mre) => {
+				output.Add (data);
+				if (!string.IsNullOrWhiteSpace (data) && data.IndexOf ("Android emulator version", StringComparison.InvariantCultureIgnoreCase) != -1) {
+					Console.WriteLine (data);
+					mre.Set ();
+				}
+
+				return true;
+			})) {
+				Console.WriteLine ("Unable to get emulator version. see logs below:");
+				foreach (var o in output) {
+					Console.WriteLine ($"Log output: {o}");
+				}
+
+				return false;
+			}
+
+			return true;
+		}
+
+		static async Task<double> GetBootTime (bool coldBoot)
+		{
+			var times = new List<long> ();
+			int errors = 0;
+
+			Stopwatch sw = new Stopwatch ();
+			var token = coldBoot ? "emulator: INFO: boot time" : "onGuestSendCommand";
+
+			for (int i = 0; i < executionTimes; i++) {
+				bool validation (string data, ManualResetEvent mre)
+				{
+					PrintVerbose (data);
+
+					if (!string.IsNullOrWhiteSpace (data) && data.IndexOf ("This application failed to start", StringComparison.OrdinalIgnoreCase) != -1) {
+						return false;
+					}
+
+					if (sw.IsRunning && !string.IsNullOrWhiteSpace (data) && data.IndexOf (token, StringComparison.OrdinalIgnoreCase) != -1) {
+						sw.Stop ();
+						times.Add (sw.ElapsedMilliseconds);
+						mre.Set ();
+					}
+
+					return true;
+				}
+
+				var bootOptions = string.Empty;
+				if (coldBoot) {
+					bootOptions = "-no-snapshot-load -wipe-data";
+				}
+
+				bool hasTimedOut = false;
+				sw.Reset ();
+				sw.Start ();
+				if (!await RunProcess (emulatorPath, $"-avd {deviceName} {bootOptions} -verbose", 300000, validation, async () => {
+					hasTimedOut = true;
+					await ForceKillEmulator ();
+				})) {
+					errors++;
+				}
+
+				sw.Stop ();
+
+				if (hasTimedOut) {
+					continue;
+				}
+
+				var activity = i % 2 == 0 ? "com.google.android.apps.photos/.home.HomeActivity" : "com.android.settings/.wifi.WifiStatusTest";
+				await RunProcess (adbPath, $"-e shell am start -n '{activity}'", 5000, (data, mre) => {
+					if (!string.IsNullOrWhiteSpace (data) && data.IndexOf ("com.android") != -1) {
+						mre.Set ();
+					}
+					return true;
+				});
+
+				await CloseEmulator ();
+				await Task.Delay (1000);
+			}
+
+			if (errors > 0) {
+				Console.WriteLine ($"Unable to boot emulator {errors} time(s)");
+			}
+
+			if (times.Count == 0) {
+				return -1;
+			}
+
+			var time = times.Average ();
+			Console.WriteLine ($"Average {(coldBoot ? "Cold" : "Hot")} Boot Time for {times.Count} run(s) out of {executionTimes} request(s) on Virtual device '{deviceName}': {time} ms");
+			return time;
+		}
+
+		static async Task<bool> CloseEmulator ()
+		{
+			PrintVerbose ("CloseEmulator");
+			bool validation (string data, ManualResetEvent mre)
+			{
+				PrintVerbose (data);
+				if (!string.IsNullOrWhiteSpace (data) && data.StartsWith ("OK: killing emulator, bye bye", StringComparison.OrdinalIgnoreCase)) {
+					mre.Set ();
+				}
+
+				return true;
+			}
+
+			if (!await RunProcess (adbPath, "-s emulator-5554 emu kill", 30000, validation)) {
+				Console.WriteLine ("unable to quit emulator.");
+				return false;
+			}
+
+			for (int i = 0; i < 10; i++) {
+				PrintVerbose ("Checking if emulator was closed.");
+				try {
+					var proc = GetProcess ("emulator");
+					if (proc == null) {
+						proc = GetProcess ("qemu");
+
+						if (proc == null) {
+							return true;
+						}
+					}
+
+					PrintVerbose ("Emulator still running");
+					await Task.Delay (5000);
+				} catch (Exception e) {
+					PrintVerbose (e.Message);
+					return true;
+				}
+			}
+
+			await ForceKillEmulator ();
+			return false;
+		}
+
+		static async Task<bool> CheckAccelerationType ()
+		{
+			var accel = new List<string> ();
+			bool validation (string data, ManualResetEvent mre)
+			{
+				if (!string.IsNullOrWhiteSpace (data)) {
+					if (!data.StartsWith ("accel", StringComparison.OrdinalIgnoreCase)) {
+						accel.Add (data);
+					}
+
+					if (data.IndexOf ("This user doesn't have permissions to use", StringComparison.OrdinalIgnoreCase) != -1) {
+						Console.WriteLine (data);
+						return false;
+					}
+
+					if (data.EndsWith ("accel", StringComparison.OrdinalIgnoreCase)) {
+						mre.Set ();
+					}
+				}
+
+				return true;
+			}
+
+			if (!await RunProcess (emulatorPath, "-accel-check", 1000, validation)) {
+				Console.WriteLine ("unable to detect acceleration type.");
+				return false;
+			}
+
+			Console.WriteLine ($"Acceleration type: {string.Join (", ", accel)}");
+			return true;
+		}
+
+		static async Task<bool> CheckVirtualDeviceExistsAndTryToCreateIfNeeded (bool useSkin, bool usePixelDevice)
+		{
+			deviceName = "XamarinPerfTest" + (usePixelDevice ? "Pixel" : string.Empty) + (useSkin ? "WithSkin" : string.Empty);
+
+			if (await CheckVirtualDeviceExists ()) {
+				return true;
+			} else {
+				Console.WriteLine ($"{deviceName} virtual device not found.");
+				return await CreateVirtualDevice (useSkin, usePixelDevice);
+			}
+		}
+
+		static async Task<bool> CheckVirtualDeviceExists ()
+		{
+			bool validation (string data, ManualResetEvent mre)
+			{
+				if (!string.IsNullOrWhiteSpace (data) && data == deviceName) {
+					mre.Set ();
+				}
+
+				return true;
+			}
+
+			return await RunProcess (emulatorPath, "-list-avds", 10000, validation);
+		}
+
+		static async Task<bool> CreateVirtualDevice (bool useSkin, bool usePixelDevice)
+		{
+			Console.WriteLine ($"Creating {deviceName} virtual device.");
+
+			await InstallSdk ();
+
+			var contents = new List<string> ();
+			bool validation (string data, ManualResetEvent mre)
+			{
+				contents.Add (data);
+				if (!string.IsNullOrWhiteSpace (data) &&
+					(data.IndexOf ("Do you wish to create a custom hardware profile?", StringComparison.OrdinalIgnoreCase) != -1 ||
+					data.IndexOf ("100% Fetch remote repository...", StringComparison.OrdinalIgnoreCase) != -1)) {
+					mre.Set ();
+				}
+
+				return true;
+			}
+
+			var filename = RunningOnWindowsEnvironment ? "cmd" : "bash";
+
+			string deviceType = string.Empty;
+			if (usePixelDevice) {
+				deviceType = "--device \"pixel\"";
+			}
+
+			var args = $"{(RunningOnWindowsEnvironment ? "/" : "-")}c \" echo no | {avdManagerPath} create avd --force --name {deviceName} --abi google_apis_playstore/x86 --package system-images;android-29;google_apis_playstore;x86 {deviceType} \"";
+			await RunProcess (filename, args, 10000, validation);
+			await Task.Delay (5000);
+			if (!await CheckVirtualDeviceExists ()) {
+				Console.WriteLine ($"unable to create {deviceName} virtual device.");
+				foreach (var data in contents) {
+					Console.WriteLine (data);
+				}
+
+				return false;
+			}
+
+			if (useSkin) {
+				if (!UpdateVirtualDevice ()) {
+					Console.WriteLine ($"unable to update {deviceName} with skin.");
+					return false;
+				}
+			}
+
+			Console.WriteLine ($"{deviceName} virtual device created.");
+			return true;
+		}
+
+		static bool UpdateVirtualDevice ()
+		{
+			var homePath = GetHomePath ();
+			var vdPath = Path.Combine (homePath, $".android/avd/{deviceName}.avd/config.ini");
+
+			if (!File.Exists (vdPath)) {
+				return false;
+			}
+
+			var sdkPath = new FileInfo (emulatorPath).Directory.Parent.FullName;
+
+			var content = "skin.name=pixel_2" + Environment.NewLine;
+			content += "skin.dynamic=yes" + Environment.NewLine;
+			content += $"skin.path={sdkPath}/skins/pixel_2" + Environment.NewLine;
+
+			File.AppendAllText (vdPath, content);
+
+			return true;
+		}
+
+		static async Task InstallSdk ()
+		{
+			bool validation (string data, ManualResetEvent mre)
+			{
+				if (!string.IsNullOrWhiteSpace (data) && data.IndexOf ("100%") != -1) {
+					mre.Set ();
+				}
+
+				return true;
+			}
+
+			var filename = RunningOnWindowsEnvironment ? "cmd" : "bash";
+			var args = $"{(RunningOnWindowsEnvironment ? "/" : "-")}c \" {sdkManagerPath} --install system-images;android-29;google_apis_playstore;x86 \"";
+			await RunProcess (filename, args, 600000, validation);
+		}
+
+		static Task<bool> RunProcess (string filename, string arguments, int timeout, Func<string, ManualResetEvent, bool> validation, Action processTimeout = null)
+		{
+			return Task.Run (() => {
+				using (var process = new Process ()) {
+
+					process.StartInfo.FileName = filename;
+					process.StartInfo.Arguments = arguments;
+					process.StartInfo.UseShellExecute = false;
+					process.StartInfo.CreateNoWindow = true;
+					process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+					process.StartInfo.RedirectStandardOutput = true;
+					process.StartInfo.RedirectStandardError = true;
+					process.EnableRaisingEvents = true;
+
+					var mre = new ManualResetEvent (false /* -> nonsignaled */);
+
+					bool error = false;
+					void dataReceived (object sender, DataReceivedEventArgs args)
+					{
+						if (!validation (args.Data, mre)) {
+							error = true;
+							mre.Set ();
+						}
+					}
+
+					process.OutputDataReceived += dataReceived;
+					process.ErrorDataReceived += dataReceived;
+
+					process.Start ();
+
+					process.BeginOutputReadLine ();
+					process.BeginErrorReadLine ();
+
+					if (!mre.WaitOne (timeout)) {
+						processTimeout?.Invoke ();
+						return false;
+					}
+
+					process.CancelOutputRead ();
+					process.CancelErrorRead ();
+
+					if (error) {
+						return false;
+					}
+				}
+
+				return true;
+			});
+		}
+
+		static async Task ForceKillEmulator ()
+		{
+			PrintVerbose ("ForceKillEmulator");
+			while (true) {
+				try {
+					var proc = GetProcess ("emulator");
+					if (proc == null) {
+						proc = GetProcess ("qemu");
+
+						if (proc == null) {
+							return;
+						}
+					}
+
+					proc.Kill ();
+					await Task.Delay (1000);
+				} catch (Exception e) {
+					PrintVerbose (e.Message);
+					break;
+				}
+			}
+		}
+
+		static Process GetProcess (string processName)
+		{
+			return Process.GetProcesses ().FirstOrDefault (p => p.ProcessName.IndexOf (processName, StringComparison.OrdinalIgnoreCase) != -1);
+		}
+
+		static bool ToolsExist ()
+		{
+			if (string.IsNullOrWhiteSpace (adbPath)) {
+				adbPath = GetProgramPath ("adb", "adb.exe", "adb.bat");
+				if (string.IsNullOrWhiteSpace (adbPath)) {
+					Console.WriteLine ("Unable to find adb.");
+					return false;
+				}
+			}
+
+			if (string.IsNullOrWhiteSpace (avdManagerPath)) {
+				avdManagerPath = GetProgramPath ("avdmanager", "avdmanager.exe", "avdmanager.bat");
+				if (string.IsNullOrWhiteSpace (avdManagerPath)) {
+					Console.WriteLine ("Unable to find avdmanager.");
+					return false;
+				}
+			}
+
+			if (string.IsNullOrWhiteSpace (emulatorPath)) {
+				emulatorPath = GetProgramPath ("emulator", "emulator.exe", "emulator.bat");
+				if (string.IsNullOrWhiteSpace (emulatorPath)) {
+					Console.WriteLine ("Unable to find emulator.");
+					return false;
+				}
+			}
+
+			if (string.IsNullOrWhiteSpace (sdkManagerPath)) {
+				sdkManagerPath = GetProgramPath ("sdkmanager", "sdkmanager.exe", "sdkmanager.bat");
+				if (string.IsNullOrWhiteSpace (sdkManagerPath)) {
+					Console.WriteLine ("Unable to find sdkmanager.");
+					return false;
+				}
+			}
+
+			Console.WriteLine ($"Running adb from: '{adbPath}'");
+			Console.WriteLine ($"Running avdmanager from: '{avdManagerPath}'");
+			Console.WriteLine ($"Running emulator from: '{emulatorPath}'");
+			Console.WriteLine ($"Running sdkmanager from: '{sdkManagerPath}'");
+
+			return true;
+		}
+
+		static string GetProgramPath (params string [] filenames)
+		{
+			foreach (var filename in filenames) {
+				var programPath = GetFullPath (filename);
+				if (string.IsNullOrWhiteSpace (programPath)) {
+					var homePath = GetHomePath ();
+
+					var potentialLocations = new List<string> ();
+
+					if (!string.IsNullOrWhiteSpace (sdkPath)) {
+						potentialLocations.AddRange (new []{
+							$"{sdkPath}/platform-tools",
+							$"{sdkPath}/emulator",
+							$"{sdkPath}/tools",
+							$"{sdkPath}/tools/bin",
+						});
+					} else {
+						potentialLocations.AddRange (new []{
+							"AppData/Local/Android/Sdk/platform-tools",
+							"AppData/Local/Android/Sdk/emulator",
+							"AppData/Local/Android/Sdk/tools",
+							"AppData/Local/Android/Sdk/tools/bin",
+							"Library/Android/sdk/platform-tools",
+							"Library/Android/sdk/emulator",
+							"Library/Android/sdk/tools",
+							"Library/Android/sdk/tools/bin",
+							"android-toolchain/sdk/platform-tools",
+							"android-toolchain/sdk/emulator",
+							"android-toolchain/sdk/tools",
+							"android-toolchain/sdk/tools/bin",
+						});
+
+						if (RunningOnWindowsEnvironment) {
+							potentialLocations.AddRange (new []{
+								"C:/Program Files (x86)/Android/android-sdk/platform-tools",
+								"C:/Program Files (x86)/Android/android-sdk/emulator",
+								"C:/Program Files (x86)/Android/android-sdk/tools",
+								"C:/Program Files (x86)/Android/android-sdk/tools/bin",
+							});
+						}
+					}
+
+					foreach (var location in potentialLocations) {
+						var programLocation = Path.Combine (homePath, location, filename);
+						if (File.Exists (programLocation)) {
+							return Path.GetFullPath (programLocation);
+						}
+					}
+				} else {
+					return programPath;
+				}
+			}
+
+			return null;
+		}
+
+		static string GetHomePath ()
+		{
+			var homePath = RunningOnWindowsEnvironment
+						? Environment.ExpandEnvironmentVariables ("%HOMEDRIVE%%HOMEPATH%")
+						: Environment.GetEnvironmentVariable ("HOME");
+
+			return homePath;
+		}
+
+		static string GetFullPath (string fileName)
+		{
+			if (File.Exists (fileName)) {
+				return Path.GetFullPath (fileName);
+			}
+
+			return null;
+		}
+
+		static void PrintVerbose (string data)
+		{
+			if (showVerbose) {
+				Console.WriteLine (data);
+			}
+		}
+
+		static bool RunningOnWindowsEnvironment => !(Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX);
+	}
+}

--- a/build-tools/check-boot-times/Properties/AssemblyInfo.cs
+++ b/build-tools/check-boot-times/Properties/AssemblyInfo.cs
@@ -1,0 +1,15 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes.
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle ("check-boot-times")]
+[assembly: AssemblyDescription ("")]
+[assembly: AssemblyConfiguration ("")]
+[assembly: AssemblyCompany ("Microsoft")]
+[assembly: AssemblyProduct ("")]
+[assembly: AssemblyCopyright ("Microsoft.")]
+[assembly: AssemblyTrademark ("Microsoft")]
+[assembly: AssemblyCulture ("")]
+[assembly: AssemblyVersion ("1.0.0.0")]

--- a/build-tools/check-boot-times/check-boot-times.csproj
+++ b/build-tools/check-boot-times/check-boot-times.csproj
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D28957BF-5E66-4D60-B528-22820C60AC82}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Xamarin.Android.Tools</RootNamespace>
+    <AssemblyName>check-boot-times</AssemblyName>
+  </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\bin\BuildDebug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <IntermediateOutputPath>obj\Debug</IntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\bin\BuildRelease</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <IntermediateOutputPath>obj\Release</IntermediateOutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20079.1" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -5,6 +5,7 @@
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.CheckAdbTarget" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.CreateAndroidEmulator" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.RenameTestCases" />
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.RunAndroidEmulatorCheckBootTimes" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.RunInstrumentationTests" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.RunUITests" />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Xamarin.Android.Tools.BootstrapTasks.dll" TaskName="Xamarin.Android.Tools.BootstrapTasks.StartAndroidEmulator" />
@@ -345,6 +346,12 @@
         AddResults="True"
         LabelSuffix="-$(Configuration)$(TestsFlavor)"
         ContinueOnError="ErrorAndContinue"
+    />
+  </Target>
+  <Target Name="CheckBootTimes"
+      DependsOnTargets="AcquireAndroidTarget;ReleaseAndroidTarget">
+    <RunAndroidEmulatorCheckBootTimes
+      CheckBootTimesPath="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\check-boot-times.exe"
     />
   </Target>
 </Project>

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -351,7 +351,7 @@
   <Target Name="CheckBootTimes"
       DependsOnTargets="AcquireAndroidTarget;ReleaseAndroidTarget">
     <RunAndroidEmulatorCheckBootTimes
-      CheckBootTimesPath="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\check-boot-times.exe"
+        CheckBootTimesPath="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\check-boot-times.exe"
     />
   </Target>
 </Project>


### PR DESCRIPTION
This is a PerfTest tool to be used by the Hyper-V team to be able to compare performance improvement progress.

Example of a run:

```
Testing emulator startup times for 1 execution(s). This may take several minutes.
Acceleration type: 0, WHPX (10.0.19041) is installed and usable.
Android emulator version 29.3.5.0 (build_id 6120838) (CL:N/A)
XamarinPerfTest Average Cold Boot Time for 1 run(s) out of 1 request(s): 34642 ms
XamarinPerfTest Average Hot Boot Time for 1 run(s) out of 1 request(s): 4224 ms
XamarinPerfTestPixelWithSkin Average Cold Boot Time for 1 run(s) out of 1 request(s): 159600 ms
XamarinPerfTestPixelWithSkin Average Hot Boot Time for 1 run(s) out of 1 request(s): 2695 ms

Testing emulator startup times for 1 execution(s). This may take several minutes.
Acceleration type: 0, HAXM version 7.5.4 (4) is installed and usable.
Android emulator version 29.3.5.0 (build_id 6120838) (CL:N/A)
XamarinPerfTest Average Cold Boot Time for 1 run(s) out of 1 request(s): 23834 ms
XamarinPerfTest Average Hot Boot Time for 1 run(s) out of 1 request(s): 4021 ms
XamarinPerfTestPixelWithSkin Average Cold Boot Time for 1 run(s) out of 1 request(s): 41912 ms
XamarinPerfTestPixelWithSkin Average Hot Boot Time for 1 run(s) out of 1 request(s): 4584 ms
```


It also helps us track percentage of times emulator failed to boot.
