### PR TITLE
[Mono.Android] Add unsigned NewArray overloads.

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -1295,6 +1295,14 @@ namespace Android.Runtime {
 			return result;
 		}
 
+		// We do these translations here instead of in the binding to force a compile
+		// time error if using an older Java.Interop.dll instead of a runtime error
+		public static IntPtr NewArray (uint[] array) => NewArray ((int[])(object)array);
+
+		public static IntPtr NewArray (ushort[] array) => NewArray ((short[])(object)array);
+
+		public static IntPtr NewArray (ulong[] array) => NewArray ((long[])(object)array);
+
 		public static IntPtr NewObjectArray (int length, IntPtr elementClass)
 		{
 			return NewObjectArray (length, elementClass, IntPtr.Zero);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -65,7 +65,7 @@
     <PackageReference Include="FSharp.Compiler.CodeDom" Version="1.0.0.1" />
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" />
     <PackageReference Include="ILRepack" Version="2.0.18" />
-    <PackageReference Include="Irony" Version="0.9.1" />
+    <PackageReference Include="Irony" Version="1.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
     <PackageReference Include="NuGet.Common" Version="4.6.0" />
     <PackageReference Include="NuGet.Configuration" Version="4.6.0" />

--- a/src/Xamarin.Android.Tools.Aidl/Xamarin.Android.Tools.Aidl.csproj
+++ b/src/Xamarin.Android.Tools.Aidl/Xamarin.Android.Tools.Aidl.csproj
@@ -29,7 +29,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Irony">
-      <HintPath>..\..\packages\Irony.0.9.1\lib\net40\Irony.dll</HintPath>
+      <HintPath>..\..\packages\Irony.1.1.0\lib\net40\Irony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Xamarin.Android.Cecil">

--- a/src/Xamarin.Android.Tools.Aidl/packages.config
+++ b/src/Xamarin.Android.Tools.Aidl/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Irony" version="0.9.1" targetFramework="net40" />
+  <package id="Irony" version="1.1.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/pull/558.
Companion JI PR: https://github.com/xamarin/java.interop/pull/558.

Create overloads of `JNIEnv.NewArray (...)` that take unsigned arrays as parameters. This allows users to get a package time error if they are using an older Java.Interop.dll that does not support unsigned types instead of a runtime error.