### PR TITLE
Implicit operator for Color to to enable int assignment

### DIFF
--- a/src/Mono.Android/Android.Graphics/Color.cs
+++ b/src/Mono.Android/Android.Graphics/Color.cs
@@ -176,6 +176,11 @@ namespace Android.Graphics
 		{
 			return c.color;
 		}
+		
+		public static implicit operator Color(int argb)
+		{
+			return new Color(argb);
+		}
 
 		public override int GetHashCode ()
 		{


### PR DESCRIPTION
it enables:
Color c = -65536; //Red
Simple conversion and intuitive since Color can be assigned to int parameter/field, vice versa shall be available.