### PR TITLE
[linker][docs] Adjust AppDomain.CreateDomain warning wording

### DIFF
--- a/Documentation/guides/messages/xa2000.md
+++ b/Documentation/guides/messages/xa2000.md
@@ -1,18 +1,18 @@
 ---
-title: Xamarin.Android error XA2000
+title: Xamarin.Android warning XA2000
 description: XA2000 warning code
-ms.date: 12/3/2019
+ms.date: 1/13/2019
 ---
 # Xamarin.Android warning XA2000
-
-Member semantics will change in a future release
 
 ## Example messages
 
 ```
-Warning: Use of AppDomain::CreateDomain detected in assembly: {assembly}. The AppDomain's will not be part of .NET 5 and therefore will be missing in newer Xamarin.Android releases.
+Use of AppDomain.CreateDomain() detected in assembly: {assembly}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.
 ```
 
 ## Solution
 
-Stop using `AppDomain`s and replace it with a different API. Like `AssemblyLoadContext`, see https://docs.microsoft.com/en-us/dotnet/standard/assembly/unloadability for example.
+Transition code away from `AppDomain.CreateDomain()` to a different API, such as [`AssemblyLoadContext`][unloadability].
+
+[unloadability]: https://docs.microsoft.com/dotnet/standard/assembly/unloadability

--- a/Documentation/release-notes/appdomain-warning-2.md
+++ b/Documentation/release-notes/appdomain-warning-2.md
@@ -1,0 +1,5 @@
+  * *warning XA2000: Warning: Use of AppDomain::CreateDomain detected in
+    assembly ... The AppDomain's will not be part of .NET 5 and therefore will
+    be missing in newer Xamarin.Android releases.* did not indicate that .NET 5
+    will still include the `AppDomain` type but only support use of a single
+    `AppDomain`.

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
@@ -56,7 +56,7 @@ namespace MonoDroid.Tuner
 
 			foreach (var mr in assembly.MainModule.GetMemberReferences ()) {
 				if (mr.ToString ().Contains ("System.AppDomain System.AppDomain::CreateDomain")) {
-					warn ($"Use of AppDomain.CreateDomain() detected in assembly: {assembly}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.");
+					warn ($"warning XA2000: Use of AppDomain.CreateDomain() detected in assembly: {assembly}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.");
 					break;
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
@@ -56,7 +56,7 @@ namespace MonoDroid.Tuner
 
 			foreach (var mr in assembly.MainModule.GetMemberReferences ()) {
 				if (mr.ToString ().Contains ("System.AppDomain System.AppDomain::CreateDomain")) {
-					warn ($"Warning: Use of AppDomain::CreateDomain detected in assembly: {assembly}. The AppDomain's will not be part of .NET 5 and therefore will be missing in newer Xamarin.Android releases.");
+					warn ($"Use of AppDomain.CreateDomain() detected in assembly: {assembly}. .NET 5 will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 5 is released.");
 					break;
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
@@ -149,7 +149,7 @@ namespace Xamarin.Android.Tasks
 			if (importance == ML.MessageImportance.High)
 				mbfImportance = MBF.MessageImportance.High;
 
-			Log.LogMessage (mbfImportance, message, values);
+			Log.LogMessageFromText (string.Format (message, values), mbfImportance);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs
@@ -59,7 +59,7 @@ namespace Xamarin.Android.Tasks
 
 					if (!MTProfile.IsSdkAssembly (source.ItemSpec) && !MTProfile.IsProductAssembly (source.ItemSpec)) {
 						assemblyDefinition = resolver.GetAssembly (source.ItemSpec);
-						step.CheckAppDomainUsage (assemblyDefinition, (string msg) => Log.LogCodedWarning ("XA2000", msg));
+						step.CheckAppDomainUsage (assemblyDefinition, (string msg) => Log.LogMessageFromText (msg, MessageImportance.High));
 					}
 
 					// Only run the step on "MonoAndroid" assemblies

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -124,7 +124,8 @@ namespace Xamarin.Android.Build.Tests
 			var projDirectory = Path.Combine ("temp", testName);
 			using (var b = CreateApkBuilder (projDirectory)) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "Warning: Use of AppDomain::CreateDomain"), "Should warn about creating AppDomain.");
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "1 Warning(s)"), "MSBuild should count 1 warning.");
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "warning XA2000: Use of AppDomain.CreateDomain()"), "Should warn about creating AppDomain.");
 			}
 		}
 	}


### PR DESCRIPTION
Putting up this PR just in case any of these changes might be handy. Feel free to take any, all, or none of them.

* * *

Remove the extra `Warning: ` prefix to match up with warnings from the
other MSBuild tasks.

Switch to the C# `AppDomain.CreateDomain()` syntax instead of the CIL
`AppDomain::CreateDomain` syntax.

Adjust the second sentence of the warning to align with the information
from the [System.AppDomain API documentation][0] about how there is only
one `AppDomain` in .NET Core.

Tidy up a few other little items in the docs page.

[0]: https://docs.microsoft.com/dotnet/api/system.appdomain?view=netcore-3.1