### PR TITLE
[xaprepare] drop dependency on libzip-dev on Linunx

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.DebianCommon.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/Linux.DebianCommon.cs
@@ -19,7 +19,6 @@ namespace Xamarin.Android.Prepare
 			new DebianLinuxProgram ("libncurses5-dev"),
 			new DebianLinuxProgram ("libtool"),
 			new DebianLinuxProgram ("libz-mingw-w64-dev"),
-			new DebianLinuxProgram ("libzip-dev"),
 			new DebianLinuxProgram ("linux-libc-dev"),
 			new DebianLinuxProgram ("make"),
 			new DebianLinuxProgram ("ninja-build", "ninja"),


### PR DESCRIPTION
We no longer need the package as `libzip` comes from a nuget now.