### PR TITLE
Bump to xamarin/monodroid/master@0f6725ed

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@2efbdd3e04710a7887c3da676b275d425e167a43
+xamarin/monodroid:master@0f6725edfa09559afad58233d43f385122e31e8d
 mono/mono:2019-10@18920a83f423fb864a2263948737681968f5b2c8


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/2efbdd3e...0f6725ed

Fixes: https://developercommunity.visualstudio.com/content/problem/858509/adb0030-monoandroidtoolsrequiresuninstallexception-2.html

Bump to xamarin/androidtools/master@d221090

[tools/msbuild] prevent InstallPackageAssemblies from reporting two errors