### PR TITLE
[tests] use string.Contains() in Xamarin.ProjectTools

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/XamarinProject.cs
@@ -272,7 +272,7 @@ namespace Xamarin.ProjectTools
 					continue;
 				}
 				string filedir = directory;
-				if (path.Contains (Path.DirectorySeparatorChar)) {
+				if (path.Contains (Path.DirectorySeparatorChar.ToString ())) {
 					filedir = Path.GetDirectoryName (path);
 					if (!Directory.Exists (filedir) && (p.Content != null || p.BinaryContent != null))
 						Directory.CreateDirectory (filedir);


### PR DESCRIPTION
Context: https://build.azdo.io/3384618

We are seeing various PRs fail with:

    System.MissingMethodException : Method not found: 'Boolean System.String.Contains(Char)'.
      at Xamarin.ProjectTools.XamarinProject.UpdateProjectFiles(String directory, IEnumerable`1 projectFiles, Boolean doNotCleanup)
      at Xamarin.ProjectTools.ProjectBuilder.Save(XamarinProject project, Boolean doNotCleanupOnUpdate, Boolean saveProject) in /Users/builder/azdo/_work/3/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs:line 47
      at Xamarin.ProjectTools.ProjectBuilder.Build(XamarinProject project, Boolean doNotCleanupOnUpdate, String[] parameters, Boolean saveProject, Dictionary`2 environmentVariables) in /Users/builder/azdo/_work/3/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs:line 68
      at Xamarin.Android.Build.Tests.Aapt2Tests.Aapt2Disabled() in /Users/builder/azdo/_work/3/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs:line 171

This doesn't quite make sense, the failing line is:

    if (path.Contains (Path.DirectorySeparatorChar)) {

Which is actually using:

    namespace System.Linq {
        public static class Enumerable {
            public static bool Contains<TSource>(this IEnumerable<TSource> source, TSource value)

I changed this to use `Path.DirectorySeparatorChar.ToString()`, so
`string.Compare` will be used instead.