### PR TITLE
[build] fix xabuild on Linux

### DIFF
--- a/tools/xabuild/XABuild.cs
+++ b/tools/xabuild/XABuild.cs
@@ -40,7 +40,7 @@ namespace Xamarin.Android.Build
 
 				//Symbolic links to be created: key=in-tree-dir, value=system-dir
 				var symbolicLinks = new Dictionary<string, string> ();
-				if (paths.IsMacOS) {
+				if (paths.IsMacOS || paths.IsLinux) {
 					foreach (var dir in Directory.EnumerateDirectories (paths.MonoSystemFrameworkRoot)) {
 						if (Path.GetFileName (dir).EndsWith ("-api", StringComparison.OrdinalIgnoreCase)){
 							var inTreeFramework = Path.Combine (paths.XamarinAndroidBuildOutput, "lib", "xamarin.android", Path.GetFileName (dir));


### PR DESCRIPTION
After a recent update of msbuild on Linux I started to see the following
error when attempting to build our tests (with `make all-tests`):

    "Xamarin.Android-Tests.sln" (default target) (1) ->
    "tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Xamarin.Android.MakeBundle-UnitTests.csproj" (default target) (21) ->
      BuildTests.cs(150,22): error CS0012: The type 'ValueType' is defined in an assembly that is not referenced. You must add a reference to assembly 'netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'. [tests/CodeGen-MkBundle/Xamarin.Android.MakeBundle-UnitTests/Xamarin.Android.MakeBundle-UnitTests.csproj]

Which, after investigation by Jo Shields, turned out to be caused by
`xabuild` not creating a bunch of symlinks to Mono API façades (the
`*-api` directories). Turns out the symlinks were created only on macOS
and this commit fixes the problem by enabling them also on Linux.