### PR TITLE
[Xamarin.Android.Build.Tasks] Target netstandard2.0

### DIFF
--- a/build-tools/scripts/MSBuildReferences.projitems
+++ b/build-tools/scripts/MSBuildReferences.projitems
@@ -34,8 +34,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-    <PackageReference Include="Xamarin.Build.AsyncTask" Version="0.3.4" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" GeneratePathProperty="true" />
+    <PackageReference Include="Xamarin.Build.AsyncTask" Version="0.3.4" GeneratePathProperty="true" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Properties/AssemblyInfo.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/AssemblyInfo.cs
@@ -5,11 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle ("Xamarin.Android.Build.Tasks")]
 [assembly: AssemblyDescription ("")]
-[assembly: AssemblyConfiguration ("")]
-[assembly: AssemblyCompany ("Xamarin")]
-[assembly: AssemblyProduct ("Xamarin.Android.Build.Tasks")]
 [assembly: AssemblyCopyright ("Copyright © Novell 2010-2011 / Xamarin 2011-2012")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
@@ -22,18 +18,6 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid ("42bb9aea-f4d8-4b43-8956-8e1fee857697")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion ("1.0.0.0")]
-[assembly: AssemblyFileVersion ("1.0.0.0")]
 
 [assembly: InternalsVisibleTo ("AndroidMSBuildTests")]
 [assembly: InternalsVisibleTo ("Xamarin.Android.Build.Tests")]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
@@ -327,9 +327,9 @@ int xml myxml 0x7f140000
 			var content1 = File.ReadAllText (file1);
 			var content2 = File.ReadAllText (file2);
 			// This string is only generated when running on mono, replace with a new line that will be stripped when comparing.
-			string versionInfo = "//     Runtime Version:4.0.30319.42000";
-			content1 = content1.Replace (versionInfo, Environment.NewLine);
-			content2 = content2.Replace (versionInfo, Environment.NewLine);
+			var runtimeVersionRegex = new Regex (@"//\s*Runtime Version:.*");
+			content1 = runtimeVersionRegex.Replace (content1, Environment.NewLine);
+			content2 = runtimeVersionRegex.Replace (content2, Environment.NewLine);
 
 			using (var s1 = new MemoryStream (Encoding.UTF8.GetBytes (content1)))
 			using (var s2 = new MemoryStream (Encoding.UTF8.GetBytes (content2))) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
@@ -9,6 +9,7 @@ using System.Text;
 using Xamarin.Android.Tasks;
 using Microsoft.Build.Utilities;
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 
 namespace Xamarin.Android.Build.Tests {
 	[TestFixture]

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -1,53 +1,25 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{3F1F2F50-AF1A-4A5A-BEDB-193372F068D7}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Xamarin.Android.Tasks</RootNamespace>
-    <AssemblyName>Xamarin.Android.Build.Tasks</AssemblyName>
-    <FileAlignment>512</FileAlignment>
-    <SchemaVersion>2.0</SchemaVersion>
-    <LibZipSharpBundleAllNativeLibraries>true</LibZipSharpBundleAllNativeLibraries>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugSymbols>True</DebugSymbols>
-  </PropertyGroup>
+<Project>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <Import Project="..\..\Configuration.props" />
   <Import Project="..\..\build-tools\scripts\LocalizationLanguages.projitems" />
   <Import Project="..\..\build-tools\scripts\MSBuildReferences.projitems" />
   <Import Project="..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\Xamarin.Android.NamingCustomAttributes\Xamarin.Android.NamingCustomAttributes.projitems')" />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <Optimize>False</Optimize>
-    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
-    <DefineConstants Condition="'$(MonoDroidTiming)' == ''">TRACE;DEBUG;HAVE_CECIL;MSBUILD;ANDROID_24</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <Optimize>True</Optimize>
-    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
-    <DefineConstants>TRACE;HAVE_CECIL;MSBUILD;ANDROID_24</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+
   <PropertyGroup>
-    <DefineConstants Condition="'$(__XA_NO_PREVIEW_L_SUPPORT__)' != ''">$(DefineConstants);XA_NO_PREVIEW_L_SUPPORT</DefineConstants>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Xamarin.Android.Tasks</RootNamespace>
+    <LibZipSharpBundleAllNativeLibraries>true</LibZipSharpBundleAllNativeLibraries>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <DefineConstants>$(DefineConstants);TRACE;HAVE_CECIL;MSBUILD;ANDROID_24</DefineConstants>
     <AndroidGeneratedClassDirectory Condition=" '$(AndroidGeneratedClassDirectory)' == '' ">..\..\src\Mono.Android\obj\$(Configuration)\android-$(AndroidLatestStableApiLevel)\mcw</AndroidGeneratedClassDirectory>
+     <!-- Copy PackageReference content to OutputDir for our installer creation logic. This no longer happens by default in short-form projects. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Security" />
-    <Reference Include="mscorlib" />
-    <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.IdentityModel" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="pdb2mdb.exe">
       <HintPath>..\..\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\pdb2mdb.exe</HintPath>
     </Reference>
@@ -61,7 +33,8 @@
       <HintPath>..\..\bin\$(Configuration)\lib\xamarin.android\xbuild\Xamarin\Android\Xamarin.Android.Cecil.Mdb.dll</HintPath>
     </Reference>
   </ItemGroup>
-   <ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" />
     <PackageReference Include="ILRepack" Version="2.0.18" />
     <PackageReference Include="Irony" Version="1.1.0" />
@@ -83,112 +56,13 @@
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="XliffTasks" Version="1.0.0-beta.19252.1" PrivateAssets="all" />
   </ItemGroup>
+
   <ItemGroup>
+    <Compile Remove="MSBuild\**" />
+    <Compile Remove="Resources\**" />
+    <Compile Remove="Tests\**" />
     <Compile Include="$(IntermediateOutputPath)Profile.g.cs" />
-    <Compile Include="Linker\LinkModes.cs" />
-    <Compile Include="Generator\Generator.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\FixAbstractMethodsStep.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\Linker.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\LinkerOptions.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\MonoDroidMarkStep.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\OutputStepWithTimestamps.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\PreserveHttpAndroidClientHandler.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\StripEmbeddedLibraries.cs" />
-    <Compile Include="Tasks\Aapt.cs" />
-    <Compile Include="Tasks\Aapt2.cs" />
-    <Compile Include="Tasks\Aapt2Compile.cs" />
-    <Compile Include="Tasks\Aapt2Link.cs" />
-    <Compile Include="Tasks\AndroidTask.cs" />
-    <Compile Include="Tasks\AndroidZipAlign.cs" />
-    <Compile Include="Tasks\BuildApk.cs" />
-    <Compile Include="Tasks\BuildBaseAppBundle.cs" />
-    <Compile Include="Tasks\BuildAppBundle.cs" />
-    <Compile Include="Tasks\BundleTool.cs" />
-    <Compile Include="Tasks\BuildApkSet.cs" />
-    <Compile Include="Tasks\BundleToolAdbTask.cs" />
-    <Compile Include="Tasks\InstallApkSet.cs" />
-    <Compile Include="Tasks\CilStrip.cs" />
-    <Compile Include="Tasks\ConvertDebuggingFiles.cs" />
-    <Compile Include="Tasks\CheckForInvalidResourceFileNames.cs" />
-    <Compile Include="Tasks\CollectNonEmptyDirectories.cs" />
-    <Compile Include="Tasks\CollectPdbFiles.cs" />
-    <Compile Include="Tasks\FilterAssemblies.cs" />
-    <Compile Include="Tasks\GenerateLibraryResources.cs" />
-    <Compile Include="Tasks\Generator.cs" />
-    <Compile Include="Tasks\JarToXml.cs" />
-    <Compile Include="Tasks\GetJavaPlatformJar.cs" />
-    <Compile Include="Tasks\GetFilesThatExist.cs" />
-    <Compile Include="Tasks\LinkAssembliesNoShrink.cs" />
-    <Compile Include="Tasks\ReadAndroidManifest.cs" />
-    <Compile Include="Tasks\RemoveRegisterAttribute.cs" />
-    <Compile Include="Tasks\GetMonoPlatformJar.cs" />
-    <Compile Include="Tasks\GeneratePackageManagerJava.cs" />
-    <Compile Include="Tasks\GenerateJavaStubs.cs" />
-    <Compile Include="Tasks\Javac.cs" />
-    <Compile Include="Tasks\LinkAssemblies.cs" />
-    <Compile Include="Tasks\CopyResource.cs" />
-    <Compile Include="Tasks\ResolveAndroidTooling.cs" />
-    <Compile Include="Tasks\ResolveAssemblies.cs" />
-    <Compile Include="Tasks\GetAppSettingsDirectory.cs" />
-    <Compile Include="Tasks\CopyIfChanged.cs" />
-    <Compile Include="Tasks\CreateResgenManifest.cs" />
-    <Compile Include="Tasks\CreateTemporaryDirectory.cs" />
-    <Compile Include="Tasks\GenerateResourceDesigner.cs" />
-    <Compile Include="Tasks\GetAndroidDefineConstants.cs" />
-    <Compile Include="Tasks\GetAndroidPackageName.cs" />
-    <Compile Include="Tasks\AndroidUpdateResDir.cs" />
-    <Compile Include="Tasks\AndroidSignPackage.cs" />
-    <Compile Include="Tasks\RemoveDirFixed.cs" />
-    <Compile Include="Tasks\ResolveJdkJvmPath.cs" />
-    <Compile Include="Tasks\ResolveSdksTask.cs" />
-    <Compile Include="Tasks\CompileToDalvik.cs" />
-    <Compile Include="Tasks\AndroidToolTask.cs" />
-    <Compile Include="Tasks\PrepareAbiItems.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Mono.Android\ApplicationAttribute.Partial.cs" />
-    <Compile Include="Mono.Android\BroadcastReceiverAttribute.Partial.cs" />
-    <Compile Include="Mono.Android\ActivityAttribute.Partial.cs" />
-    <Compile Include="Mono.Android\ContentProviderAttribute.Partial.cs" />
-    <Compile Include="Mono.Android\LayoutAttribute.Partial.cs" />
-    <Compile Include="Tasks\SetVsMonoAndroidRegistryKey.cs" />
-    <Compile Include="Tasks\SplitProperty.cs" />
-    <Compile Include="Tasks\ValidateJavaVersion.cs" />
-    <Compile Include="Mono.Android\IntentFilterAttribute.Partial.cs" />
-    <Compile Include="Mono.Android\GrantUriPermissionAttribute.Partial.cs" />
-    <Compile Include="Tasks\WriteLockFile.cs" />
-    <Compile Include="Utilities\DummyCustomAttributeProvider.cs" />
-    <Compile Include="Utilities\InvalidActivityNameException.cs" />
-    <Compile Include="Utilities\JavaResourceParser.cs" />
-    <Compile Include="Utilities\MetadataResolver.cs" />
-    <Compile Include="Utilities\MetadataExtensions.cs" />
-    <Compile Include="Utilities\PackagingUtils.cs" />
-    <Compile Include="Utilities\ResourceParser.cs" />
-    <Compile Include="Utilities\ManagedResourceParser.cs" />
-    <Compile Include="Utilities\ManifestDocumentElement.cs" />
-    <Compile Include="Utilities\ManifestDocument.cs" />
-    <Compile Include="Mono.Android\MetaDataAttribute.Partial.cs" />
-    <Compile Include="Utilities\MonoAndroidHelper.cs" />
-    <None Include="Linker\MonoDroid.Tuner\PreserveCode.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\PreserveTypeConverters.cs" />
-    <Compile Include="Linker\Mobile.Tuner\MobileProfile.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\ApplyPreserveAttribute.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\Extensions.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\MarkJavaObjects.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\MonoDroidProfile.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\PreserveApplications.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\PreserveJavaExceptions.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\PreserveJavaTypeRegistrations.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\RemoveAttributes.cs" />
-    <Compile Include="Utilities\AsyncTaskExtensions.cs" />
-    <Compile Include="Utilities\MSBuildExtensions.cs" />
-    <Compile Include="Utilities\UnhandledExceptionLogger.cs" />
-    <Compile Include="Utilities\ZipArchiveEx.cs" />
-    <Compile Include="Mono.Android\ServiceAttribute.Partial.cs" />
+    <Compile Include="..\..\bin\Build$(Configuration)\XABuildConfig.cs" />
     <Compile Include="$(LinkerSourceFullPath)\tuner\Mono.Tuner\AdjustVisibility.cs">
       <Link>Linker\Mono.Tuner\AdjustVisibility.cs</Link>
     </Compile>
@@ -198,70 +72,6 @@
     <Compile Include="$(LinkerSourceFullPath)\tuner\Mono.Tuner\CheckVisibility.cs">
       <Link>Linker\Mono.Tuner\CheckVisibility.cs</Link>
     </Compile>
-    <Compile Include="Mono.Android\UsesLibraryAttribute.Partial.cs" />
-    <Compile Include="Mono.Android\UsesPermissionAttribute.Partial.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\PreserveCode.cs" />
-    <Compile Include="Mono.Android\InstrumentationAttribute.Partial.cs" />
-    <Compile Include="Tasks\CreateLibraryResourceArchive.cs" />
-    <Compile Include="Tasks\ResolveLibraryProjectImports.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\PreserveExportedTypes.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\PreserveDynamicTypes.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\PreserveLinqExpressions.cs" />
-    <Compile Include="Tasks\NdkUtils.cs" />
-    <Compile Include="Tasks\NdkUtilsOld.cs" />
-    <Compile Include="Tasks\MakeBundleNativeCodeExternal.cs" />
-    <Compile Include="Tasks\GetExtraPackages.cs" />
-    <Compile Include="Tasks\CopyGeneratedJavaResourceClasses.cs" />
-    <Compile Include="Tasks\GenerateManagedAidlProxies.cs" />
-    <Compile Include="Utilities\ResourceDesignerImportGenerator.cs" />
-    <Compile Include="Tasks\CreateManagedLibraryResourceArchive.cs" />
-    <Compile Include="Tasks\CheckForRemovedItems.cs" />
-    <Compile Include="Tasks\CheckProjectItems.cs" />
-    <Compile Include="Tasks\CheckDuplicateJavaLibraries.cs" />
-    <Compile Include="Mono.Android\PermissionAttribute.Partial.cs" />
-    <Compile Include="Mono.Android\PermissionGroupAttribute.Partial.cs" />
-    <Compile Include="Mono.Android\PermissionTreeAttribute.Partial.cs" />
-    <Compile Include="Mono.Android\UsesConfigurationAttribute.Partial.cs" />
-    <Compile Include="Mono.Android\UsesFeatureAttribute.Partial.cs" />
-    <Compile Include="Mono.Android\SupportsGLTextureAttribute.Partial.cs" />
-    <Compile Include="Tasks\CreateNativeLibraryArchive.cs" />
-    <Compile Include="Tasks\GetImportedLibraries.cs" />
-    <Compile Include="Tasks\CollectLibraryAssets.cs" />
-    <Compile Include="Tasks\ImportJavaDoc.cs" />
-    <Compile Include="Tasks\MDoc.cs" />
-    <Compile Include="Tasks\ParseAndroidWearProjectAndManifest.cs" />
-    <Compile Include="Tasks\PrepareWearApplicationFiles.cs" />
-    <Compile Include="Tasks\CopyAndConvertResources.cs" />
-    <Compile Include="Tasks\Crunch.cs" />
-    <Compile Include="Tasks\ConvertResourcesCases.cs" />
-    <Compile Include="Tasks\Aot.cs" />
-    <Compile Include="Tasks\Proguard.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\GenerateProguardConfiguration.cs" />
-    <Compile Include="Tasks\ClassParse.cs" />
-    <Compile Include="Tasks\AdjustJavacVersionArguments.cs" />
-    <Compile Include="Tasks\LogErrorsForFiles.cs" />
-    <Compile Include="Tasks\CreateAdditionalLibraryResourceCache.cs" />
-    <Compile Include="Tasks\CalculateAdditionalResourceCacheDirectories.cs" />
-    <Compile Include="Tasks\KeyTool.cs" />
-    <Compile Include="Tasks\AndroidCreateDebugKey.cs" />
-    <Compile Include="Tasks\LogWarningsForFiles.cs" />
-    <Compile Include="Tasks\DetermineJavaLibrariesToCompile.cs" />
-    <Compile Include="Tasks\CreateMultiDexMainDexClassList.cs" />
-    <Compile Include="Tasks\JavaToolTask.cs" />
-    <Compile Include="Tasks\GenerateLayoutCodeBehind.cs" />
-    <Compile Include="Tasks\GenerateLayoutBindings.cs" />
-    <Compile Include="Tasks\GenerateLayoutBindings.BindingGenerator.cs" />
-    <Compile Include="Tasks\GenerateLayoutBindings.CSharpBindingGenerator.cs" />
-    <Compile Include="Tasks\CalculateLayoutCodeBehind.cs" />
-    <Compile Include="Tasks\FindLayoutsToBind.cs" />
-    <Compile Include="Tasks\CalculateProjectDependencies.cs" />
-    <Compile Include="Tasks\ConvertCustomView.cs" />
-    <Compile Include="Tasks\ComputeHash.cs" />
-    <Compile Include="Tasks\Lint.cs" />
-    <Compile Include="Tasks\ReadLibraryProjectImportsCache.cs" />
-    <Compile Include="Tasks\ReadImportedLibrariesCache.cs" />
-    <Compile Include="Utilities\XDocumentExtensions.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\PreserveRuntimeSerialization.cs" />
     <Compile Include="$(LinkerSourceFullPath)\linker\Linker\Annotations.cs">
       <Link>Linker\Linker\Annotations.cs</Link>
     </Compile>
@@ -394,23 +204,6 @@
     <Compile Include="$(LinkerSourceFullPath)\linker\Linker\BCL.cs">
       <Link>Linker\Linker\BCL.cs</Link>
     </Compile>
-    <Compile Include="Tasks\MergeResources.cs" />
-    <Compile Include="Tasks\GetConvertedJavaLibraries.cs" />
-    <Compile Include="Tasks\JavaCompileToolTask.cs" />
-    <Compile Include="Utilities\ResourceMerger.cs" />
-    <Compile Include="Tasks\CreateMsymManifest.cs" />
-    <Compile Include="Utilities\AndroidResource.cs">
-      <Link>Utilities\AndroidResource.cs</Link>
-    </Compile>
-    <Compile Include="Utilities\Features.cs">
-      <Link>Utilities\Features.cs</Link>
-    </Compile>
-    <Compile Include="Utilities\LinePreservedXmlWriter.cs">
-      <Link>Utilities\LinePreservedXmlWriter.cs</Link>
-    </Compile>
-    <Compile Include="Utilities\Files.cs">
-      <Link>Utilities\Files.cs</Link>
-    </Compile>
     <Compile Include="$(LinkerSourceFullPath)\tuner\Mono.Tuner\ApplyPreserveAttributeBase.cs">
       <Link>Linker\Mono.Tuner\ApplyPreserveAttributeBase.cs</Link>
     </Compile>
@@ -513,58 +306,6 @@
     <Compile Include="..\Mono.Android\\Android\NativeLibraryReferenceAttribute.cs">
       <Link>Mono.Android\NativeLibraryReferenceAttribute.cs</Link>
     </Compile>
-    <Compile Include="Utilities\MD2Managed.cs">
-      <Link>Utilities\MD2Managed.cs</Link>
-    </Compile>
-    <Compile Include="Utilities\Profile.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\PreserveTlsProvider.cs" />
-    <Compile Include="Tasks\Unzip.cs" />
-    <Compile Include="Utilities\AssemblyIdentityMap.cs" />
-    <Compile Include="Utilities\SatelliteAssembly.cs" />
-    <Compile Include="Tasks\AndroidApkSigner.cs" />
-    <Compile Include="Tasks\D8.cs" />
-    <Compile Include="Tasks\R8.cs" />
-    <Compile Include="Utilities\NuGetLogger.cs" />
-    <Compile Include="Tasks\LayoutWidgetType.cs" />
-    <Compile Include="Tasks\LayoutLocationInfo.cs" />
-    <Compile Include="Tasks\LayoutTypeFixup.cs" />
-    <Compile Include="Tasks\LayoutWidget.cs" />
-    <Compile Include="..\..\bin\Build$(Configuration)\XABuildConfig.cs" />
-    <Compile Include="Tasks\CheckGoogleSdkRequirements.cs" />
-    <Compile Include="Utilities\NativeAssemblyDataStream.cs" />
-    <Compile Include="Utilities\NativeAssemblyGenerator.cs" />
-    <Compile Include="Utilities\NativeAssemblerTargetProvider.cs" />
-    <Compile Include="Utilities\ARMNativeAssemblerTargetProvider.cs" />
-    <Compile Include="Utilities\X86NativeAssemblerTargetProvider.cs" />
-    <Compile Include="Utilities\TypeMappingNativeAssemblyGenerator.cs" />
-    <Compile Include="Utilities\ApplicationConfigNativeAssemblyGenerator.cs" />
-    <Compile Include="Tasks\CompileNativeAssembly.cs" />
-    <Compile Include="Tasks\LinkApplicationSharedLibraries.cs" />
-    <None Include="Resources\LayoutBinding.cs">
-      <Link>LayoutBinding.cs</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\monodroid\jni\mkbundle-api.h">
-      <Link>mkbundle-api.h</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <Compile Include="Tasks\JavaDoc.cs" />
-    <Compile Include="Linker\MonoDroid.Tuner\AndroidLinkContext.cs" />
-    <Compile Include="Tasks\AppendCustomMetadataToItemGroup.cs" />
-    <Compile Include="Utilities\OutputLine.cs" />
-    <Compile Include="Utilities\ResourceIdentifier.cs" />
-    <Compile Include="Tasks\GetAndroidActivityName.cs" />
-    <Compile Include="Tasks\ManifestMerger.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <None Include="@(_LocalizationLanguages->'Properties\xlf\Resources.%(Identity).xlf')" />
-  </ItemGroup>
-  <ItemGroup>
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.LaunchMode.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.ScreenOrientation.cs" />
     <_MonoAndroidEnum Include="$(AndroidGeneratedClassDirectory)\Android.Content.PM.ConfigChanges.cs" />
@@ -580,10 +321,16 @@
       <Link>Mono.Android\%(Filename)%(Extension)</Link>
     </Compile>
   </ItemGroup>
+
   <ItemGroup>
-    <None Include="Xamarin.Android.Build.Tasks.targets" />
-  </ItemGroup>
-  <ItemGroup>
+    <None Include="Resources\LayoutBinding.cs">
+      <Link>LayoutBinding.cs</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\monodroid\jni\mkbundle-api.h">
+      <Link>mkbundle-api.h</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="updateinfo.dat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -594,18 +341,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <!-- MD doesn't handle MSBuildToolsPath yet
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  -->
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="Xamarin.Android.Build.Tasks.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
   <ItemGroup>
     <EmbeddedResource Include="Resources\NOTICE.txt">
       <LogicalName>NOTICE.txt</LogicalName>
@@ -649,35 +385,20 @@
     <EmbeddedResource Include="Resources\ApplicationRegistration.java">
       <LogicalName>ApplicationRegistration.java</LogicalName>
     </EmbeddedResource>
+    <None Include="@(_LocalizationLanguages->'Properties\xlf\Resources.%(Identity).xlf')" />
   </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\Xamarin.Android.Tools.Aidl\Xamarin.Android.Tools.Aidl.csproj">
-      <Project>{D27AD8F7-7710-40BE-B03B-55EFBEC13C44}</Project>
-      <Name>Xamarin.Android.Tools.Aidl</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Tools.Diagnostics\Java.Interop.Tools.Diagnostics.csproj">
-      <Project>{64CC4E44-CE3A-4319-BF3F-6CF8BD513870}</Project>
-      <Name>Java.Interop.Tools.Diagnostics</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil.csproj">
-      <Project>{D48EE8D0-0A0A-4493-AEF5-DAF5F8CF86AD}</Project>
-      <Name>Java.Interop.Tools.Cecil</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers.csproj">
-      <Project>{D18FCF91-8876-48A0-A693-2DC1E7D3D80A}</Project>
-      <Name>Java.Interop.Tools.JavaCallableWrappers</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\external\Java.Interop\src\Xamarin.Android.Tools.Bytecode\Xamarin.Android.Tools.Bytecode.csproj">
-      <Project>{B17475BC-45A2-47A3-B8FC-62F3A0959EE0}</Project>
-      <Name>Xamarin.Android.Tools.Bytecode</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Xamarin.Android.Tools.Aidl\Xamarin.Android.Tools.Aidl.csproj" />
+    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Tools.Diagnostics\Java.Interop.Tools.Diagnostics.csproj" />
+    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil.csproj" />
+    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers.csproj" />
+    <ProjectReference Include="..\..\external\Java.Interop\src\Xamarin.Android.Tools.Bytecode\Xamarin.Android.Tools.Bytecode.csproj" />
     <!--
       Mono.Android.csproj needs to be built first because this project
       references files *generated* and contained within the Mono.Android project.
       -->
     <ProjectReference Include="..\..\src\Mono.Android\Mono.Android.csproj">
-      <Project>{66CF299A-CE95-4131-BCD8-DB66E30C4BF7}</Project>
-      <Name>Mono.Android</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
     <!--
@@ -690,41 +411,25 @@
       task will require the outputs of `proguard.csproj`.
       -->
     <ProjectReference Include="..\proguard\proguard.csproj">
-      <Project>{4B9D96BB-95AB-44E8-9F87-13B12C8BCED1}</Project>
-      <Name>proguard</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\r8\r8.csproj">
-      <Project>{1bafa0cc-0377-46ce-ab7b-7bb2e7b62f63}</Project>
-      <Name>r8</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\aapt2\aapt2.csproj">
-      <Project>{0c31de30-f9df-4312-bffe-dcad558ccf08}</Project>
-      <Name>aapt2</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\bundletool\bundletool.csproj">
-      <Project>{a0aef446-3368-4591-9de6-bc3b2b33337d}</Project>
-      <Name>bundletool</Name>
       <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\..\external\xamarin-android-tools\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj">
-      <Project>{E34BCFA0-CAA4-412C-AA1C-75DB8D67D157}</Project>
-      <Name>Xamarin.Android.Tools.AndroidSdk</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Export\Java.Interop.Export.csproj">
-      <Project>{B501D075-6183-4E1D-92C9-F7B5002475B1}</Project>
-      <Name>Java.Interop.Export</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop\Java.Interop.csproj">
-      <Project>{94BD81F7-B06F-4295-9636-F8A3B6BDC762}</Project>
-      <Name>Java.Interop</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\manifestmerger\manifestmerger.csproj">
-      <Project>{af8ac493-40ac-4195-82f6-b08ee4b4e49e}</Project>
-      <Name>manifestmerger</Name>
-      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-    </ProjectReference>
+    <ProjectReference Include="..\..\external\xamarin-android-tools\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj" />
+    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Export\Java.Interop.Export.csproj" />
+    <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop\Java.Interop.csproj" />
   </ItemGroup>
+
+  <!-- Import Microsoft.NET.Sdk targets before our targets so we can override behavior -->
+  <!-- See https://github.com/microsoft/msbuild/pull/4922 -->
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="Xamarin.Android.Build.Tasks.targets" />
+
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -341,8 +341,8 @@
       Inputs="$(PkgMono_Posix_NETStandard)\runtimes\osx\lib\netstandard2.0\Mono.Posix.NETStandard.dll;$(PkgXamarin_Build_AsyncTask)\lib\netstandard2.0\Xamarin.Build.AsyncTask.pdb"
       Outputs="$(OutputPath)\Mono.Posix.NETStandard.dll;$(OutputPath)\Xamarin.Build.AsyncTask.pdb" >
     <Copy
-      SourceFiles="$(PkgMono_Posix_NETStandard)\runtimes\osx\lib\netstandard2.0\Mono.Posix.NETStandard.dll;$(PkgXamarin_Build_AsyncTask)\lib\netstandard2.0\Xamarin.Build.AsyncTask.pdb"
-      DestinationFolder="$(OutputPath)"
+        SourceFiles="$(PkgMono_Posix_NETStandard)\runtimes\osx\lib\netstandard2.0\Mono.Posix.NETStandard.dll;$(PkgXamarin_Build_AsyncTask)\lib\netstandard2.0\Xamarin.Build.AsyncTask.pdb"
+        DestinationFolder="$(OutputPath)"
     />
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -16,6 +16,7 @@
       $(BuildDependsOn);
       _CopyExtractedMultiDexJar;
       _BuildMonoScripts;
+      _CopyExtraPackageContent;
     </BuildDependsOn>
     <_AndroidSdkLocation Condition="'$(_AndroidSdkLocation)'==''">$(AndroidSdkDirectory)</_AndroidSdkLocation>
     <_MultiDexAarInAndroidSdk>extras\android\m2repository\com\android\support\multidex\1.0.1\multidex-1.0.1.aar</_MultiDexAarInAndroidSdk>
@@ -303,6 +304,7 @@
     <InputAssemblies Include="$(OutputPath)NuGet.ProjectModel.dll" />
     <InputAssemblies Include="$(OutputPath)NuGet.Protocol.dll" />
     <InputAssemblies Include="$(OutputPath)NuGet.Versioning.dll" />
+    <InputAssemblies Include="$(OutputPath)System.CodeDom.dll" />
     <InputAssemblies Include="$(OutputPath)System.Collections.Immutable.dll" />
     <InputAssemblies Include="$(OutputPath)System.Reflection.Metadata.dll" />
   </ItemGroup>
@@ -332,6 +334,16 @@
     <ItemGroup>
       <FileWrites Include="$(IntermediateOutputPath)ILRepacker.stamp" />
     </ItemGroup>
+  </Target>
+
+    <!-- Copy extra package ref content for our installers. '$(Pkg*)' props are set during NuGet restore when GeneratePathProperty="true" -->
+  <Target Name="_CopyExtraPackageContent"
+      Inputs="$(PkgMono_Posix_NETStandard)\runtimes\osx\lib\netstandard2.0\Mono.Posix.NETStandard.dll;$(PkgXamarin_Build_AsyncTask)\lib\netstandard2.0\Xamarin.Build.AsyncTask.pdb"
+      Outputs="$(OutputPath)\Mono.Posix.NETStandard.dll;$(OutputPath)\Xamarin.Build.AsyncTask.pdb" >
+    <Copy
+      SourceFiles="$(PkgMono_Posix_NETStandard)\runtimes\osx\lib\netstandard2.0\Mono.Posix.NETStandard.dll;$(PkgXamarin_Build_AsyncTask)\lib\netstandard2.0\Xamarin.Build.AsyncTask.pdb"
+      DestinationFolder="$(OutputPath)"
+    />
   </Target>
 
 </Project>


### PR DESCRIPTION
Updates `Xamarin.Android.Build.Tasks.csproj` to a short-form style
project which targets `netstandard2.0` to help ensure future compliance
with the dotnet version of MSBuild.

A few PackageReference related changes were needed to work with our
existing installer packaging logic, as NuGet assets are no longer copied
to the OutputDirectory by default for short-form style projects. To work
around this, we're setting `CopyLocalLockFileAssemblies` to true to copy
over all relevant NuGet package content. This property doesn't work for
debug symbols and certain NuGet folder hierarchies however. The new
`_CopyExtraPackageContent` target has been added to copy over these
unexpected files. This target relies on the `GeneratePathProperty`
metadata that is set on the `PackageReference` element.

Additionally, the behavior of the `netstandard2.0` version of
`System.CodeDom` seems to have changed slightly. The Runtime Version
information that was previously added to the `<auto-generated>` comment
header is now only added when running on mono. The test cases in
`ManagedResourceParserTests` have been updated to handle this. This
assembly has also been added to our ILRepack target as it is not available
by default in `netstandard2.0`.

Finally, we are explicitly importing `Microsoft.NET.Sdk.props` and
`Microsoft.NET.Sdk.targets` in `Xamarin.Android.Build.Tasks.csproj` to
work around an issue that prevents us from overriding `<BuildDependsOn>`
in `Xamarin.Android.Build.Tasks.targets`.