### PR TITLE
[docs] Add intended audience for prepare-external-dependencies

### DIFF
--- a/Documentation/building/unix/instructions.md
+++ b/Documentation/building/unix/instructions.md
@@ -16,7 +16,8 @@ can also be used by setting the `$(MSBUILD)` make variable to `xbuild`.
 
  4. (Optional) [Configure the build](../configuration.md).
 
- 5. (Optional) Prepare external/proprietary git dependencies
+ 5. (For Microsoft team members only) (Optional) Prepare external
+    proprietary git dependencies
 
         make prepare-external-git-dependencies
 

--- a/Documentation/building/windows/instructions.md
+++ b/Documentation/building/windows/instructions.md
@@ -18,7 +18,9 @@ MSBuild version 15 or later is required.
 
  4. (Optional) [Configure the build](../configuration.md).
 
- 5. (Optional) In a [Developer Command Prompt][developer-prompt], prepare external git dependencies:
+ 5. (For Microsoft team members only) (Optional) In a [Developer Command
+    Prompt][developer-prompt], prepare external proprietary git
+    dependencies:
 
         msbuild Xamarin.Android.sln /t:PrepareExternal
 


### PR DESCRIPTION
Since the prepare external dependencies step is only for proprietary
dependencies, update the wording of the build instructions to let
community contributors know that they should skip it.

`make prepare-external-dependencies` uses the
`PrepareExternalGitDependencies` step in `xaprepare`, which currently
only prepares the monodroid external dependency.

The Mono dependency listed in `.external` is prepared via a separate
`DownloadMonoArchive` step in `xaprepare`.  That step is part of `make
prepare` and does not require running `make
prepare-external-dependencies`.