### PR TITLE
[CI] Run integrated regression tests in parallel

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -981,16 +981,21 @@ stages:
       parameters:
         designerSourcePath: $(System.DefaultWorkingDirectory)\designer
 
+- stage: integrated_regression_test
+  displayName: Regression Tests
+  dependsOn: mac_build
+  condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
+  jobs:
+
   # Check - "Xamarin.Android (Test Integrated Regression - macOS)"
   - job: integrated_regression_mac_1
-    displayName: Integrated Regression - macOS - Lane 1
+    displayName: macOS - Node 1
     pool:
       name: VSEng-Xamarin-Mac-Devices
       demands:
       - android
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
-    condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
     workspace:
       clean: all
     steps:
@@ -1000,14 +1005,13 @@ stages:
 
   # Check - "Xamarin.Android (Test Integrated Regression - macOS)"
   - job: integrated_regression_mac_2
-    displayName: Integrated Regression - macOS - Lane 2
+    displayName: macOS - Node 2
     pool:
       name: VSEng-Xamarin-Mac-Devices
       demands:
       - android
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
-    condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
     workspace:
       clean: all
     steps:
@@ -1017,14 +1021,13 @@ stages:
 
   # Check - "Xamarin.Android (Test Integrated Regression - macOS)"
   - job: integrated_regression_mac_3
-    displayName: Integrated Regression - macOS - Lane 3
+    displayName: macOS - Node 3
     pool:
       name: VSEng-Xamarin-Mac-Devices
       demands:
       - android
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
-    condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
     workspace:
       clean: all
     steps:
@@ -1034,14 +1037,13 @@ stages:
 
   # Check - "Xamarin.Android (Test Integrated Regression - Windows)"
   - job: integrated_regression_Win_1
-    displayName: Integrated Regression - Windows - Lane 1
+    displayName: Windows - Node 1
     pool:
       name: VSEng-Xamarin-Win-XMA
       demands:
       - android
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
-    condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
     workspace:
       clean: all
     variables:
@@ -1057,14 +1059,13 @@ stages:
 
   # Check - "Xamarin.Android (Test Integrated Regression - Windows)"
   - job: integrated_regression_Win_2
-    displayName: Integrated Regression - Windows - Lane 2
+    displayName: Windows - Node 2
     pool:
       name: VSEng-Xamarin-Win-XMA
       demands:
       - android
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
-    condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
     workspace:
       clean: all
     variables:
@@ -1080,14 +1081,13 @@ stages:
 
   # Check - "Xamarin.Android (Test Integrated Regression - Windows)"
   - job: integrated_regression_Win_3
-    displayName: Integrated Regression - Windows - Lane 3
+    displayName: Windows - Node 3
     pool:
       name: VSEng-Xamarin-Win-XMA
       demands:
       - android
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
-    condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
     workspace:
       clean: all
     variables:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -993,10 +993,10 @@ stages:
     condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
     workspace:
       clean: all
-    variables:
-      parallel-id: '1'
     steps:
     - template: yaml-templates/run-integrated-regression-tests.yaml
+      parameters:
+        node_id: 1
 
   # Check - "Xamarin.Android (Test Integrated Regression - macOS)"
   - job: integrated_regression_mac_2
@@ -1010,10 +1010,10 @@ stages:
     condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
     workspace:
       clean: all
-    variables:
-      parallel-id: '2'
     steps:
     - template: yaml-templates/run-integrated-regression-tests.yaml
+      parameters:
+        node_id: 2
 
   # Check - "Xamarin.Android (Test Integrated Regression - macOS)"
   - job: integrated_regression_mac_3
@@ -1027,10 +1027,10 @@ stages:
     condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
     workspace:
       clean: all
-    variables:
-      parallel-id: '3'
     steps:
     - template: yaml-templates/run-integrated-regression-tests.yaml
+      parameters:
+        node_id: 3
 
   # Check - "Xamarin.Android (Test Integrated Regression - Windows)"
   - job: integrated_regression_Win_1
@@ -1046,11 +1046,12 @@ stages:
       clean: all
     variables:
       XQA_VISUALSTUDIO_LOCATION: '%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise'
-      parallel-id: '1'
     steps:
     - template: remove-visualstudio.yml@yaml
 
     - template: yaml-templates\run-integrated-regression-tests.yaml
+      parameters:
+        node_id: 1
 
     - template: remove-visualstudio.yml@yaml
 
@@ -1068,11 +1069,12 @@ stages:
       clean: all
     variables:
       XQA_VISUALSTUDIO_LOCATION: '%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise'
-      parallel-id: '2'
     steps:
     - template: remove-visualstudio.yml@yaml
 
     - template: yaml-templates\run-integrated-regression-tests.yaml
+      parameters:
+        node_id: 2
 
     - template: remove-visualstudio.yml@yaml
 
@@ -1090,10 +1092,11 @@ stages:
       clean: all
     variables:
       XQA_VISUALSTUDIO_LOCATION: '%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise'
-      parallel-id: '3'
     steps:
     - template: remove-visualstudio.yml@yaml
 
     - template: yaml-templates\run-integrated-regression-tests.yaml
+      parameters:
+        node_id: 3
 
     - template: remove-visualstudio.yml@yaml

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -982,8 +982,8 @@ stages:
         designerSourcePath: $(System.DefaultWorkingDirectory)\designer
 
   # Check - "Xamarin.Android (Test Integrated Regression - macOS)"
-  - job: integrated_regression_mac
-    displayName: Integrated Regression - macOS
+  - job: integrated_regression_mac_1
+    displayName: Integrated Regression - macOS - Lane 1
     pool:
       name: VSEng-Xamarin-Mac-Devices
       demands:
@@ -993,12 +993,48 @@ stages:
     condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
     workspace:
       clean: all
+    variables:
+      parallel-id: '1'
+    steps:
+    - template: yaml-templates/run-integrated-regression-tests.yaml
+
+  # Check - "Xamarin.Android (Test Integrated Regression - macOS)"
+  - job: integrated_regression_mac_2
+    displayName: Integrated Regression - macOS - Lane 2
+    pool:
+      name: VSEng-Xamarin-Mac-Devices
+      demands:
+      - android
+    timeoutInMinutes: 240
+    cancelTimeoutInMinutes: 5
+    condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
+    workspace:
+      clean: all
+    variables:
+      parallel-id: '2'
+    steps:
+    - template: yaml-templates/run-integrated-regression-tests.yaml
+
+  # Check - "Xamarin.Android (Test Integrated Regression - macOS)"
+  - job: integrated_regression_mac_3
+    displayName: Integrated Regression - macOS - Lane 3
+    pool:
+      name: VSEng-Xamarin-Mac-Devices
+      demands:
+      - android
+    timeoutInMinutes: 240
+    cancelTimeoutInMinutes: 5
+    condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
+    workspace:
+      clean: all
+    variables:
+      parallel-id: '3'
     steps:
     - template: yaml-templates/run-integrated-regression-tests.yaml
 
   # Check - "Xamarin.Android (Test Integrated Regression - Windows)"
-  - job: integrated_regression_Win
-    displayName: Integrated Regression - Windows
+  - job: integrated_regression_Win_1
+    displayName: Integrated Regression - Windows - Lane 1
     pool:
       name: VSEng-Xamarin-Win-XMA
       demands:
@@ -1010,6 +1046,51 @@ stages:
       clean: all
     variables:
       XQA_VISUALSTUDIO_LOCATION: '%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise'
+      parallel-id: '1'
+    steps:
+    - template: remove-visualstudio.yml@yaml
+
+    - template: yaml-templates\run-integrated-regression-tests.yaml
+
+    - template: remove-visualstudio.yml@yaml
+
+  # Check - "Xamarin.Android (Test Integrated Regression - Windows)"
+  - job: integrated_regression_Win_2
+    displayName: Integrated Regression - Windows - Lane 2
+    pool:
+      name: VSEng-Xamarin-Win-XMA
+      demands:
+      - android
+    timeoutInMinutes: 240
+    cancelTimeoutInMinutes: 5
+    condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
+    workspace:
+      clean: all
+    variables:
+      XQA_VISUALSTUDIO_LOCATION: '%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise'
+      parallel-id: '2'
+    steps:
+    - template: remove-visualstudio.yml@yaml
+
+    - template: yaml-templates\run-integrated-regression-tests.yaml
+
+    - template: remove-visualstudio.yml@yaml
+
+  # Check - "Xamarin.Android (Test Integrated Regression - Windows)"
+  - job: integrated_regression_Win_3
+    displayName: Integrated Regression - Windows - Lane 3
+    pool:
+      name: VSEng-Xamarin-Win-XMA
+      demands:
+      - android
+    timeoutInMinutes: 240
+    cancelTimeoutInMinutes: 5
+    condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
+    workspace:
+      clean: all
+    variables:
+      XQA_VISUALSTUDIO_LOCATION: '%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise'
+      parallel-id: '3'
     steps:
     - template: remove-visualstudio.yml@yaml
 

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -54,15 +54,15 @@ steps:
 
 - template: run-installer.yaml
 
-- ${{ if eq(parameters.node_id, 1) }}:
-  - powershell: |   
-      if ([Environment]::OSVersion.Platform -eq "Unix") {
-         mono $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll --where "cat == XAUnitTestSetup || cat == XATestPrep || cat == EnvironmentInfo"
-      } else {
-         $(System.DefaultWorkingDirectory)\NUnit.ConsoleRunner\tools\nunit3-console.exe $(System.DefaultWorkingDirectory)\XQA.Android\XQA.Android.dll --where "cat == XAUnitTestSetup || cat == XATestPrep || cat == EnvironmentInfo"
-      }
-    displayName: Test Environment Setup
+- powershell: |   
+    if ([Environment]::OSVersion.Platform -eq "Unix") {
+       mono $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll --where "cat == XAUnitTestSetup || cat == XATestPrep || cat == EnvironmentInfo"
+    } else {
+       $(System.DefaultWorkingDirectory)\NUnit.ConsoleRunner\tools\nunit3-console.exe $(System.DefaultWorkingDirectory)\XQA.Android\XQA.Android.dll --where "cat == XAUnitTestSetup || cat == XATestPrep || cat == EnvironmentInfo"
+    }
+  displayName: Test Environment Setup
 
+- ${{ if eq(parameters.node_id, 1) }}:
   - template: run-nunit-tests.yaml
     parameters:
       nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -1,3 +1,6 @@
+parameters:
+  node_id: 0
+
 steps:
 - task: xamops.azdevex.lingering-process-task.lingering-process-task@1
 
@@ -51,178 +54,163 @@ steps:
 
 - template: run-installer.yaml
 
-- powershell: |   
-    if ([Environment]::OSVersion.Platform -eq "Unix") {
-       mono $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll --where "cat == XAUnitTestSetup || cat == XATestPrep || cat == EnvironmentInfo"
-    } else {
-       $(System.DefaultWorkingDirectory)\NUnit.ConsoleRunner\tools\nunit3-console.exe $(System.DefaultWorkingDirectory)\XQA.Android\XQA.Android.dll --where "cat == XAUnitTestSetup || cat == XATestPrep || cat == EnvironmentInfo"
-    }
-  displayName: Test Environment Setup
+- ${{ if eq(parameters.node_id, 1) }}:
+  - powershell: |   
+      if ([Environment]::OSVersion.Platform -eq "Unix") {
+         mono $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll --where "cat == XAUnitTestSetup || cat == XATestPrep || cat == EnvironmentInfo"
+      } else {
+         $(System.DefaultWorkingDirectory)\NUnit.ConsoleRunner\tools\nunit3-console.exe $(System.DefaultWorkingDirectory)\XQA.Android\XQA.Android.dll --where "cat == XAUnitTestSetup || cat == XATestPrep || cat == EnvironmentInfo"
+      }
+    displayName: Test Environment Setup
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: Mono.Android-Tests Debug on Device
-    nunitConsoleExtraArgs: --where "cat == RuntimeTests"
-    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '1'))
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: Mono.Android-Tests Debug on Device
+      nunitConsoleExtraArgs: --where "cat == RuntimeTests"
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: Hello Tests on Device
-    nunitConsoleExtraArgs: --where "cat == Hello"
-    condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'), eq(variables['parallel-id'], '1'))
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: Hello Tests on Device
+      nunitConsoleExtraArgs: --where "cat == Hello"
+      condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: Smoke Tests on Device
-    nunitConsoleExtraArgs: --where "cat == RegressionDeviceTests"
-    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '1'))
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: Smoke Tests on Device
+      nunitConsoleExtraArgs: --where "cat == RegressionDeviceTests"
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: Smoke Tests
-    nunitConsoleExtraArgs: --where "cat == RegressionTests"
-    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '1'))
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: Smoke Tests
+      nunitConsoleExtraArgs: --where "cat == RegressionTests"
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: Installer Tests
-    nunitConsoleExtraArgs: --where "cat == InstallationTests"
-    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '1'))
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: Installer Tests
+      nunitConsoleExtraArgs: --where "cat == InstallationTests"
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: Fast Deploy Tests
-    nunitConsoleExtraArgs: --where "cat == FastDevTests"
-    condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'), eq(variables['parallel-id'], '1'))
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: Fast Deploy Tests
+      nunitConsoleExtraArgs: --where "cat == FastDevTests"
+      condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: Debug Tests
-    nunitConsoleExtraArgs: --where "cat == DebuggerTests"
-    condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'), eq(variables['parallel-id'], '1'))
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: Debug Tests
+      nunitConsoleExtraArgs: --where "cat == DebuggerTests"
+      condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: Incremental Build Tests
-    nunitConsoleExtraArgs: --where "cat == BuildPerformance"
-    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '2'))
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: Linker Tests
+      nunitConsoleExtraArgs: --where "cat == LinkerTests"
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: AOT Tests
-    nunitConsoleExtraArgs: --where "cat == AotSupport"
-    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '2'))
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: Wearable Tests
+      nunitConsoleExtraArgs: --where "cat == Wearable"
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: Linker Tests
-    nunitConsoleExtraArgs: --where "cat == LinkerTests"
-    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '1'))
+- ${{ if eq(parameters.node_id, 2) }}:
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: Incremental Build Tests
+      nunitConsoleExtraArgs: --where "cat == BuildPerformance"
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: Wearable Tests
-    nunitConsoleExtraArgs: --where "cat == Wearable"
-    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '1'))
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: AOT Tests
+      nunitConsoleExtraArgs: --where "cat == AotSupport"
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: Proguard Tests
-    nunitConsoleExtraArgs: --where "cat == Proguard"
-    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '3'))
+- ${{ if eq(parameters.node_id, 3) }}:
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: Proguard Tests
+      nunitConsoleExtraArgs: --where "cat == Proguard"
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: Multidex Tests
-    nunitConsoleExtraArgs: --where "cat == Multidex"
-    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '3'))
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: Multidex Tests
+      nunitConsoleExtraArgs: --where "cat == Multidex"
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: ExplicitCrunch Tests
-    nunitConsoleExtraArgs: --where "cat == ExplicitCrunch"
-    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '3'))
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: ExplicitCrunch Tests
+      nunitConsoleExtraArgs: --where "cat == ExplicitCrunch"
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: TargetFrameworkVersion Tests
-    nunitConsoleExtraArgs: --where "cat == TargetFrameworkTests"
-    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '3'))
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: TargetFrameworkVersion Tests
+      nunitConsoleExtraArgs: --where "cat == TargetFrameworkTests"
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: Resource Cache Tests
-    nunitConsoleExtraArgs: --where "cat == ResourceCacheTests"
-    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '3'))
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: Resource Cache Tests
+      nunitConsoleExtraArgs: --where "cat == ResourceCacheTests"
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: Property Cache Tests
-    nunitConsoleExtraArgs: --where "cat == PropertyCacheTests"
-    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '3'))
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: Property Cache Tests
+      nunitConsoleExtraArgs: --where "cat == PropertyCacheTests"
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: Code Analysis Tests
-    nunitConsoleExtraArgs: --where "cat == CodeAnalysisTests"
-    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '3'))
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: Code Analysis Tests
+      nunitConsoleExtraArgs: --where "cat == CodeAnalysisTests"
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: Networking Options Tests
-    nunitConsoleExtraArgs: --where "cat == HttpClientAndTlsProviderPackageTests"
-    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '3'))
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: Networking Options Tests
+      nunitConsoleExtraArgs: --where "cat == HttpClientAndTlsProviderPackageTests"
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: AndroidApiInfo Tests
-    nunitConsoleExtraArgs: --where "cat == AndroidApiInfoTests"
-    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '3'))
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: AndroidApiInfo Tests
+      nunitConsoleExtraArgs: --where "cat == AndroidApiInfoTests"
 
-- template: run-nunit-tests.yaml
-  parameters:
-    nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
-    testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
-    testRunTitle: Test Environment Cleanup
-    nunitConsoleExtraArgs: --where "cat == XATestCleanUp"
-    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '3'))
+  - template: run-nunit-tests.yaml
+    parameters:
+      nunitConsole: $(System.DefaultWorkingDirectory)/NUnit.ConsoleRunner/tools/nunit3-console.exe
+      testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
+      testRunTitle: Test Environment Cleanup
+      nunitConsoleExtraArgs: --where "cat == XATestCleanUp"

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -65,6 +65,7 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Mono.Android-Tests Debug on Device
     nunitConsoleExtraArgs: --where "cat == RuntimeTests"
+    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '1'))
 
 - template: run-nunit-tests.yaml
   parameters:
@@ -72,7 +73,7 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Hello Tests on Device
     nunitConsoleExtraArgs: --where "cat == Hello"
-    condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
+    condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'), eq(variables['parallel-id'], '1'))
 
 - template: run-nunit-tests.yaml
   parameters:
@@ -80,6 +81,7 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Smoke Tests on Device
     nunitConsoleExtraArgs: --where "cat == RegressionDeviceTests"
+    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '1'))
 
 - template: run-nunit-tests.yaml
   parameters:
@@ -87,6 +89,7 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Smoke Tests
     nunitConsoleExtraArgs: --where "cat == RegressionTests"
+    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '1'))
 
 - template: run-nunit-tests.yaml
   parameters:
@@ -94,6 +97,7 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Installer Tests
     nunitConsoleExtraArgs: --where "cat == InstallationTests"
+    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '1'))
 
 - template: run-nunit-tests.yaml
   parameters:
@@ -101,7 +105,7 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Fast Deploy Tests
     nunitConsoleExtraArgs: --where "cat == FastDevTests"
-    condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
+    condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'), eq(variables['parallel-id'], '1'))
 
 - template: run-nunit-tests.yaml
   parameters:
@@ -109,7 +113,7 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Debug Tests
     nunitConsoleExtraArgs: --where "cat == DebuggerTests"
-    condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
+    condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'), eq(variables['parallel-id'], '1'))
 
 - template: run-nunit-tests.yaml
   parameters:
@@ -117,6 +121,7 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Incremental Build Tests
     nunitConsoleExtraArgs: --where "cat == BuildPerformance"
+    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '2'))
 
 - template: run-nunit-tests.yaml
   parameters:
@@ -124,6 +129,7 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: AOT Tests
     nunitConsoleExtraArgs: --where "cat == AotSupport"
+    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '2'))
 
 - template: run-nunit-tests.yaml
   parameters:
@@ -131,6 +137,7 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Linker Tests
     nunitConsoleExtraArgs: --where "cat == LinkerTests"
+    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '1'))
 
 - template: run-nunit-tests.yaml
   parameters:
@@ -138,6 +145,7 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Wearable Tests
     nunitConsoleExtraArgs: --where "cat == Wearable"
+    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '1'))
 
 - template: run-nunit-tests.yaml
   parameters:
@@ -145,6 +153,7 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Proguard Tests
     nunitConsoleExtraArgs: --where "cat == Proguard"
+    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '3'))
 
 - template: run-nunit-tests.yaml
   parameters:
@@ -152,6 +161,7 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Multidex Tests
     nunitConsoleExtraArgs: --where "cat == Multidex"
+    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '3'))
 
 - template: run-nunit-tests.yaml
   parameters:
@@ -159,6 +169,7 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: ExplicitCrunch Tests
     nunitConsoleExtraArgs: --where "cat == ExplicitCrunch"
+    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '3'))
 
 - template: run-nunit-tests.yaml
   parameters:
@@ -166,6 +177,7 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: TargetFrameworkVersion Tests
     nunitConsoleExtraArgs: --where "cat == TargetFrameworkTests"
+    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '3'))
 
 - template: run-nunit-tests.yaml
   parameters:
@@ -173,6 +185,7 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Resource Cache Tests
     nunitConsoleExtraArgs: --where "cat == ResourceCacheTests"
+    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '3'))
 
 - template: run-nunit-tests.yaml
   parameters:
@@ -180,6 +193,7 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Property Cache Tests
     nunitConsoleExtraArgs: --where "cat == PropertyCacheTests"
+    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '3'))
 
 - template: run-nunit-tests.yaml
   parameters:
@@ -187,6 +201,7 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Code Analysis Tests
     nunitConsoleExtraArgs: --where "cat == CodeAnalysisTests"
+    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '3'))
 
 - template: run-nunit-tests.yaml
   parameters:
@@ -194,6 +209,7 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Networking Options Tests
     nunitConsoleExtraArgs: --where "cat == HttpClientAndTlsProviderPackageTests"
+    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '3'))
 
 - template: run-nunit-tests.yaml
   parameters:
@@ -201,6 +217,7 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: AndroidApiInfo Tests
     nunitConsoleExtraArgs: --where "cat == AndroidApiInfoTests"
+    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '3'))
 
 - template: run-nunit-tests.yaml
   parameters:
@@ -208,3 +225,4 @@ steps:
     testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
     testRunTitle: Test Environment Cleanup
     nunitConsoleExtraArgs: --where "cat == XATestCleanUp"
+    condition: and(succeededOrFailed(), eq(variables['parallel-id'], '3'))


### PR DESCRIPTION
Breaks up the `Integrated Regression` tests to run across 3 nodes, reducing the time taken to run from `~150 minutes` to `3 x ~50 minutes`.

Moves the `Integrated Regression` tests to a separate Stage to improve readability.  This also allows us to move the `condition` to the Stage level instead of each Job.

![image](https://user-images.githubusercontent.com/179295/72639388-1b24e080-392b-11ea-9d13-47a80294cb4a.png)
