### PR TITLE
Use the Framework MSBuild on Mac/Linux

### DIFF
--- a/build-tools/scripts/MSBuildReferences.projitems
+++ b/build-tools/scripts/MSBuildReferences.projitems
@@ -1,11 +1,39 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildReferenceVersion>15.1.0.0</MSBuildReferenceVersion>
+  </PropertyGroup>
   <!--Import this file in projects needing to reference Microsoft.Build.*.dll -->
   <ItemGroup>
     <!-- Compile against Microsoft.Build* NuGet refs, but do not copy to OutputDir. -->
-    <PackageReference Include="Microsoft.Build" Version="15.9.20" IncludeAssets="compile" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" IncludeAssets="compile" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" IncludeAssets="compile" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" IncludeAssets="compile"/>
+    <!-- Only use these on Windows as it causes problems with running unit tests in the IDE's on MacOS -->
+    <PackageReference Include="Microsoft.Build" Version="15.9.20" IncludeAssets="compile" Condition=" '$(OS)' == 'Windows_NT' " />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" IncludeAssets="compile" Condition=" '$(OS)' == 'Windows_NT' " />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" IncludeAssets="compile" Condition=" '$(OS)' == 'Windows_NT' " />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" IncludeAssets="compile" Condition=" '$(OS)' == 'Windows_NT' " />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Build, Version=$(MSBuildReferenceVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(OS)' != 'Windows_NT' ">
+      <SpecificVersion>True</SpecificVersion>
+      <HintPath>$(MSBuildToolsPath)\Microsoft.Build.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Build.Engine, Version=$(MSBuildReferenceVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(OS)' != 'Windows_NT' ">
+      <SpecificVersion>True</SpecificVersion>
+      <HintPath>$(MSBuildToolsPath)\Microsoft.Build.Engine.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Build.Framework, Version=$(MSBuildReferenceVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(OS)' != 'Windows_NT' ">
+      <SpecificVersion>True</SpecificVersion>
+      <HintPath>$(MSBuildToolsPath)\Microsoft.Build.Framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Build.Tasks.Core, Version=$(MSBuildReferenceVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(OS)' != 'Windows_NT' ">
+      <SpecificVersion>True</SpecificVersion>
+      <HintPath>$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Build.Utilities.Core, Version=$(MSBuildReferenceVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(OS)' != 'Windows_NT' ">
+      <SpecificVersion>True</SpecificVersion>
+      <HintPath>$(MSBuildToolsPath)\Microsoft.Build.Utilities.Core.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="Xamarin.Build.AsyncTask" Version="0.3.4" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="1.0.6" />
@@ -13,10 +41,10 @@
   <ItemGroup>
     <!-- Copy system Microsoft.Build*.dll and dependencies for tests to run against. We can remove this
           and rely entirely on NuGet assets when mono/msbuild is merged into microsoft/msbuild. -->
-    <None Include="$(MSBuildToolsPath)\Microsoft.Build*.dll" >
+    <None Include="$(MSBuildToolsPath)\Microsoft.Build*.dll" Condition=" '$(OS)' == 'Windows_NT' " >
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="$(MSBuildToolsPath)\System.*.dll" >
+    <None Include="$(MSBuildToolsPath)\System.*.dll" Condition=" '$(OS)' == 'Windows_NT' " >
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
Commit dc49cf92 switched over our build system to use the MSBuild Nuget Packages. 
However when we use that and run the Unit Tests from within VSForMac they all fail with a
`PlatformNotSupported` exception. This is despite the fact that we never actually copy the files over to the output path, but use the Framework ones. 

It turns out the MSBuild Nuget File are loaded by the IDE and the NUnit Test Addin so it tries to use those when running the tests. This then results in the error. This issue does not occur on the command line or in VSCode since they do not load the MSBuild Nuget assemblies into the process.  