### PR TITLE
[Build] Bump Xamarin.LibZipSharp to 1.0.7

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -108,6 +108,7 @@
     <_TestsProfiledAotName Condition=" '$(AndroidEnableProfiledAot)' == 'true' ">-Profiled</_TestsProfiledAotName>
     <_TestsBundleName Condition=" '$(BundleAssemblies)' == 'true' ">-Bundle</_TestsBundleName>
     <TestsFlavor>$(_TestsProfiledAotName)$(_TestsAotName)$(_TestsBundleName)</TestsFlavor>
+    <LibZipSharpVersion>1.0.7</LibZipSharpVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MingwCommandPrefix32>i686-w64-mingw32</MingwCommandPrefix32>

--- a/build-tools/scripts/MSBuildReferences.projitems
+++ b/build-tools/scripts/MSBuildReferences.projitems
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" IncludeAssets="compile"/>
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="Xamarin.Build.AsyncTask" Version="0.3.4" />
-    <PackageReference Include="Xamarin.LibZipSharp" Version="1.0.6" />
+    <PackageReference Include="Xamarin.LibZipSharp" Version="1.0.7" />
   </ItemGroup>
   <ItemGroup>
     <!-- Copy system Microsoft.Build*.dll and dependencies for tests to run against. We can remove this

--- a/build-tools/scripts/MSBuildReferences.projitems
+++ b/build-tools/scripts/MSBuildReferences.projitems
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" IncludeAssets="compile"/>
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="Xamarin.Build.AsyncTask" Version="0.3.4" />
-    <PackageReference Include="Xamarin.LibZipSharp" Version="1.0.7" />
+    <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" />
   </ItemGroup>
   <ItemGroup>
     <!-- Copy system Microsoft.Build*.dll and dependencies for tests to run against. We can remove this

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/LibZipSharp.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/LibZipSharp.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Android.Prepare
 	class LibZipSharp_grendello_LibZipSharp_TPN : ThirdPartyNotice
 	{
 		static readonly Uri url = new Uri ("https://github.com/xamarin/LibZipSharp/");
-		internal static readonly string LibZipSharpVersion = "1.0.6";
+		internal static readonly string LibZipSharpVersion = "1.0.7";
 		static readonly string licenseFile = Path.Combine (BuildPaths.XamarinAndroidSourceRoot,
 			"packages", "xamarin.libzipsharp", LibZipSharpVersion,
 			"Licences", "LICENSE");

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/LibZipSharp.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/LibZipSharp.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Xml.Linq;
 
 namespace Xamarin.Android.Prepare
 {
@@ -8,9 +10,12 @@ namespace Xamarin.Android.Prepare
 	class LibZipSharp_grendello_LibZipSharp_TPN : ThirdPartyNotice
 	{
 		static readonly Uri url = new Uri ("https://github.com/xamarin/LibZipSharp/");
-		internal static readonly string LibZipSharpVersion = "1.0.7";
+		internal static readonly string LibZipSharpVersion => {
+			var doc = XDocumment.Load (Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "Configuration.props"));
+			return doc.Descendants(XName.Get("LibZipSharpVersion", @"http://schemas.microsoft.com/developer/msbuild/2003")).First().Value;
+		};
 		static readonly string licenseFile = Path.Combine (BuildPaths.XamarinAndroidSourceRoot,
-			"packages", "xamarin.libzipsharp", LibZipSharpVersion,
+			"packages", "xamarin.libzipsharp", LibZipSharpVersion (),
 			"Licences", "LICENSE");
 
 		public override string LicenseFile => licenseFile;

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/LibZipSharp.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/LibZipSharp.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Android.Prepare
 	{
 		static readonly Uri url = new Uri ("https://github.com/xamarin/LibZipSharp/");
 		internal static readonly string LibZipSharpVersion => {
-			var doc = XDocumment.Load (Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "Configuration.props"));
+			var doc = XDocument.Load (Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "Configuration.props"));
 			return doc.Descendants(XName.Get("LibZipSharpVersion", @"http://schemas.microsoft.com/developer/msbuild/2003")).First().Value;
 		};
 		static readonly string licenseFile = Path.Combine (BuildPaths.XamarinAndroidSourceRoot,

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/LibZipSharp.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/LibZipSharp.cs
@@ -7,13 +7,14 @@ using System.Xml.Linq;
 namespace Xamarin.Android.Prepare
 {
 	[TPN]
-	class LibZipSharp_grendello_LibZipSharp_TPN : ThirdPartyNotice
+	class LibZipSharp_xamarin_LibZipSharp_TPN : ThirdPartyNotice
 	{
 		static readonly Uri url = new Uri ("https://github.com/xamarin/LibZipSharp/");
-		internal static readonly string LibZipSharpVersion => {
+		internal static string LibZipSharpVersion ()
+		{
 			var doc = XDocument.Load (Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "Configuration.props"));
 			return doc.Descendants(XName.Get("LibZipSharpVersion", @"http://schemas.microsoft.com/developer/msbuild/2003")).First().Value;
-		};
+		}
 		static readonly string licenseFile = Path.Combine (BuildPaths.XamarinAndroidSourceRoot,
 			"packages", "xamarin.libzipsharp", LibZipSharpVersion (),
 			"Licences", "LICENSE");

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/libzip.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/libzip.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Android.Prepare
 	{
 		static readonly Uri url = new Uri ("https://github.com/nih-at/libzip/");
 		static readonly string licenseFile = Path.Combine (BuildPaths.XamarinAndroidSourceRoot,
-			"packages", "xamarin.libzipsharp", LibZipSharp_grendello_LibZipSharp_TPN.LibZipSharpVersion,
+			"packages", "xamarin.libzipsharp", LibZipSharp_xamarin_LibZipSharp_TPN.LibZipSharpVersion (),
 			"Licences", "libzip", "LICENSE");
 
 		public override string LicenseFile => licenseFile;

--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -281,7 +281,7 @@
       <Version>5.3.0.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.LibZipSharp">
-      <Version>1.0.7</Version>
+      <Version>$(LibZipSharpVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -281,7 +281,7 @@
       <Version>5.3.0.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.LibZipSharp">
-      <Version>1.0.6</Version>
+      <Version>1.0.7</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/src/Xamarin.Android.Tools.JavadocImporter/Xamarin.Android.Tools.JavadocImporter.csproj
+++ b/src/Xamarin.Android.Tools.JavadocImporter/Xamarin.Android.Tools.JavadocImporter.csproj
@@ -74,7 +74,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Xml.SgmlReader" Version="1.8.14" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-    <PackageReference Include="Xamarin.LibZipSharp" Version="1.0.6" />
+    <PackageReference Include="Xamarin.LibZipSharp" Version="1.0.7" />
   </ItemGroup>
   <Import Project="..\..\external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems" Label="Shared" Condition="Exists('..\..\external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems')" />
   <Import Project="..\..\external\Java.Interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\..\external\Java.Interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems')" />

--- a/src/Xamarin.Android.Tools.JavadocImporter/Xamarin.Android.Tools.JavadocImporter.csproj
+++ b/src/Xamarin.Android.Tools.JavadocImporter/Xamarin.Android.Tools.JavadocImporter.csproj
@@ -74,7 +74,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Xml.SgmlReader" Version="1.8.14" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-    <PackageReference Include="Xamarin.LibZipSharp" Version="1.0.7" />
+    <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" />
   </ItemGroup>
   <Import Project="..\..\external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems" Label="Shared" Condition="Exists('..\..\external\Java.Interop\src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.projitems')" />
   <Import Project="..\..\external\Java.Interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\..\external\Java.Interop\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems')" />


### PR DESCRIPTION
Fixes #4100

The version of libzip.so we shipped for linux in
1.0.6 had a dependency on libcrypto.so.1.1. Some
linux based systems only ship with libcrypto.so.1.0.
As a result Xamarin.Android would not build and we give
the following error.

	error MSB4018: System.DllNotFoundException: lib64/libzip.so assembly

Verison 1.0.7 if Xamarin.LibZipSharp fixes this issue by
statically linking libcrypto (and other dependencies) into the
dynamic library. This should allow Xamarin.Android to build and
run on those systems which does not include libcrypto or have
an older version.

This PR reworks the source a bit so we define the LibZipSharp version in ONE place.
Both the all the csproj and targets files include `Configuration.props` in them. So it 
makes sense to place the version there as an MSBuild Property. We then need to update
the Third Party Notices code to pick up that MSBuild property rather than hard coding the 
version into the C# code. This way we only need to update the version in one place going
forward.