### PR TITLE
[vscode] Fix the command used to run the NUnit Tests

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -40,6 +40,30 @@
             ]
         },
         {
+            "label": "Build Xamarin.Android Build Device Tests",
+            "type": "shell",
+            "command": "msbuild tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj /restore /t:Build",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": [
+                "$msCompile"
+            ]
+        },
+        {
+            "label": "Build Xamarin.Android Build Commercial Tests",
+            "type": "shell",
+            "command": "msbuild external/monodroid/tests/msbuild/nunit/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj /restore /t:Build",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": [
+                "$msCompile"
+            ]
+        },
+        {
             "label": "Run Xamarin.Android Build Tasks Unit Tests",
             "type": "shell",
             "command": "msbuild Xamarin.Android.sln /t:RunNunitTests",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -42,7 +42,7 @@
         {
             "label": "Run Xamarin.Android Build Tasks Unit Tests",
             "type": "shell",
-            "command": "msbuild src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj /restore /t:RunNunitTests",
+            "command": "msbuild Xamarin.Android.sln /t:RunNunitTests",
             "group": {
                 "kind": "test",
                 "isDefault": true


### PR DESCRIPTION
When trying to run the 'Run Xamarin.Android Build Tasks Unit Tests'
command in VSCode we get the following error now

	error MSB4057: The target "RunNUnitTests" does not exist in the project.

This is because the `RunTest.targets` file is now only imported
when you run against the `Xamarin.Android.sln`. So we need
to update this command to use the correct command line.