### PR TITLE
[linker] Add Java.Interop.GenericMarshaler to Sdk assemblies

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MonoDroidProfile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MonoDroidProfile.cs
@@ -17,7 +17,9 @@ namespace MonoDroid.Tuner {
 
 		protected override bool IsSdk (string assemblyName)
 		{
-			return assemblyName.Equals ("Java.Interop", StringComparison.Ordinal) || base.IsSdk (assemblyName);
+			return assemblyName.Equals ("Java.Interop", StringComparison.Ordinal)
+			       || assemblyName.Equals ("Java.Interop.GenericMarshaler", StringComparison.Ordinal)
+			       || base.IsSdk (assemblyName);
 		}
 	}
 }


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/4141
Context: https://github.com/xamarin/xamarin-android/commit/130905e1612f1c3f41b6b233056cae2753270630

The `Java.Interop.GenericMarshaler` namespace was put in separate
assembly in Java.Interop repo.

Lets make linker be aware of it, so that it can be linked in
LinkSdkOnly mode.