### PR TITLE
C++ code cleanup based on extra warnings

### DIFF
--- a/src/monodroid/CMakeLists.txt
+++ b/src/monodroid/CMakeLists.txt
@@ -87,9 +87,17 @@ set(TEST_COMPILER_ARGS_CPP ${XA_COMPILER_FLAGS}
   Wall
   Wconversion
   Wdeprecated
+  Wduplicated-branches
+  Wduplicated-cond
   Werror=format-security
+  Werror=return-type
+  Wextra
   Wformat
   Wformat-security
+  Wmisleading-indentation
+  Wnull-dereference
+  Wpointer-arith
+  Wshadow
   Wsign-compare
   Wuninitialized
   )

--- a/src/monodroid/jni/android-system.cc
+++ b/src/monodroid/jni/android-system.cc
@@ -313,7 +313,7 @@ AndroidSystem::_monodroid_get_system_property_from_file (const char *path, char 
 #endif
 
 size_t
-AndroidSystem::monodroid_get_system_property_from_overrides (const char *name, char ** value)
+AndroidSystem::monodroid_get_system_property_from_overrides ([[maybe_unused]] const char *name, [[maybe_unused]] char ** value)
 {
 #if defined (DEBUG) || !defined (ANDROID)
 	for (size_t oi = 0; oi < MAX_OVERRIDES; ++oi) {
@@ -413,7 +413,7 @@ AndroidSystem::load_dso_from_app_lib_dirs (const char *name, int dl_flags)
 }
 
 void*
-AndroidSystem::load_dso_from_override_dirs (const char *name, int dl_flags)
+AndroidSystem::load_dso_from_override_dirs ([[maybe_unused]] const char *name, [[maybe_unused]] int dl_flags)
 {
 #ifdef RELEASE
 	return nullptr;
@@ -719,7 +719,7 @@ AndroidSystem::setup_environment ()
 }
 
 void
-AndroidSystem::setup_process_args_apk (const char *apk, size_t index, size_t apk_count, void *user_data)
+AndroidSystem::setup_process_args_apk (const char *apk, size_t index, size_t apk_count, [[maybe_unused]] void *user_data)
 {
 	if (apk == nullptr || index != apk_count - 1)
 		return;
@@ -729,9 +729,9 @@ AndroidSystem::setup_process_args_apk (const char *apk, size_t index, size_t apk
 }
 
 void
-AndroidSystem::setup_process_args (JNIEnv *env, jstring_array_wrapper &runtimeApks)
+AndroidSystem::setup_process_args (jstring_array_wrapper &runtimeApks)
 {
-	for_each_apk (env, runtimeApks, static_cast<BasicAndroidSystem::ForEachApkHandler> (&AndroidSystem::setup_process_args_apk), nullptr);
+	for_each_apk (runtimeApks, static_cast<BasicAndroidSystem::ForEachApkHandler> (&AndroidSystem::setup_process_args_apk), nullptr);
 }
 
 monodroid_dirent_t*
@@ -781,7 +781,7 @@ AndroidSystem::get_libmonoandroid_directory_path ()
 }
 
 int
-AndroidSystem::setenv (const char *name, const char *value, int overwrite)
+AndroidSystem::setenv (const char *name, const char *value, [[maybe_unused]] int overwrite)
 {
 	wchar_t *wname  = utils.utf8_to_utf16 (name);
 	wchar_t *wvalue = utils.utf8_to_utf16 (value);

--- a/src/monodroid/jni/android-system.hh
+++ b/src/monodroid/jni/android-system.hh
@@ -41,7 +41,7 @@ namespace xamarin::android::internal
 
 	public:
 		void  setup_environment ();
-		void  setup_process_args (JNIEnv *env, jstring_array_wrapper &runtimeApks);
+		void  setup_process_args (jstring_array_wrapper &runtimeApks);
 		void  create_update_dir (char *override_dir);
 		int   monodroid_get_system_property (const char *name, char **value);
 		size_t monodroid_get_system_property_from_overrides (const char *name, char ** value);

--- a/src/monodroid/jni/basic-android-system.cc
+++ b/src/monodroid/jni/basic-android-system.cc
@@ -11,7 +11,7 @@ const char **BasicAndroidSystem::app_lib_directories;
 size_t BasicAndroidSystem::app_lib_directories_size = 0;
 
 void
-BasicAndroidSystem::setup_app_library_directories (JNIEnv *env, jstring_array_wrapper& runtimeApks, jstring_array_wrapper& appDirs, int androidApiLevel)
+BasicAndroidSystem::setup_app_library_directories (jstring_array_wrapper& runtimeApks, jstring_array_wrapper& appDirs, int androidApiLevel)
 {
 	if (androidApiLevel < 23 || !is_embedded_dso_mode_enabled ()) {
 		log_info (LOG_DEFAULT, "Setting up for DSO lookup in app data directories");
@@ -26,12 +26,12 @@ BasicAndroidSystem::setup_app_library_directories (JNIEnv *env, jstring_array_wr
 		unsigned short built_for_cpu = 0, running_on_cpu = 0;
 		unsigned char is64bit = 0;
 		_monodroid_detect_cpu_and_architecture (&built_for_cpu, &running_on_cpu, &is64bit);
-		setup_apk_directories (env, running_on_cpu, runtimeApks);
+		setup_apk_directories (running_on_cpu, runtimeApks);
 	}
 }
 
 void
-BasicAndroidSystem::for_each_apk (JNIEnv *env, jstring_array_wrapper &runtimeApks, ForEachApkHandler handler, void *user_data)
+BasicAndroidSystem::for_each_apk (jstring_array_wrapper &runtimeApks, ForEachApkHandler handler, void *user_data)
 {
 	size_t apksLength = runtimeApks.get_length ();
 	for (size_t i = 0; i < apksLength; ++i) {
@@ -42,22 +42,22 @@ BasicAndroidSystem::for_each_apk (JNIEnv *env, jstring_array_wrapper &runtimeApk
 }
 
 void
-BasicAndroidSystem::add_apk_libdir (const char *apk, size_t index, size_t apk_count, void *user_data)
+BasicAndroidSystem::add_apk_libdir (const char *apk, size_t index, [[maybe_unused]] size_t apk_count, void *user_data)
 {
 	assert (user_data != nullptr);
-	assert (index >= 0 && index < app_lib_directories_size);
+	assert (index < app_lib_directories_size);
 	app_lib_directories [index] = utils.string_concat (apk, "!/lib/", static_cast<const char*>(user_data));
 }
 
 void
-BasicAndroidSystem::setup_apk_directories (JNIEnv *env, unsigned short running_on_cpu, jstring_array_wrapper &runtimeApks)
+BasicAndroidSystem::setup_apk_directories (unsigned short running_on_cpu, jstring_array_wrapper &runtimeApks)
 {
 	// Man, the cast is ugly...
-	for_each_apk (env, runtimeApks, &BasicAndroidSystem::add_apk_libdir, const_cast <void*> (static_cast<const void*> (android_abi_names [running_on_cpu])));
+	for_each_apk (runtimeApks, &BasicAndroidSystem::add_apk_libdir, const_cast <void*> (static_cast<const void*> (android_abi_names [running_on_cpu])));
 }
 
 char*
-BasicAndroidSystem::determine_primary_override_dir (JNIEnv *env, jstring_wrapper &home)
+BasicAndroidSystem::determine_primary_override_dir (jstring_wrapper &home)
 {
 	return utils.path_combine (home.get_cstr (), ".__override__");
 }

--- a/src/monodroid/jni/basic-android-system.hh
+++ b/src/monodroid/jni/basic-android-system.hh
@@ -53,8 +53,8 @@ namespace xamarin::android::internal
 		static size_t app_lib_directories_size;
 
 	public:
-		void setup_app_library_directories (JNIEnv *env, jstring_array_wrapper& runtimeApks, jstring_array_wrapper& appDirs, int androidApiLevel);
-		void setup_apk_directories (JNIEnv *env, unsigned short running_on_cpu, jstring_array_wrapper &runtimeApks);
+		void setup_app_library_directories (jstring_array_wrapper& runtimeApks, jstring_array_wrapper& appDirs, int androidApiLevel);
+		void setup_apk_directories (unsigned short running_on_cpu, jstring_array_wrapper &runtimeApks);
 
 		const char* get_override_dir (size_t index) const
 		{
@@ -97,17 +97,17 @@ namespace xamarin::android::internal
 			return primary_override_dir;
 		}
 
-		void set_primary_override_dir (JNIEnv *env, jstring_wrapper& home)
+		void set_primary_override_dir (jstring_wrapper& home)
 		{
-			primary_override_dir = determine_primary_override_dir (env, home);
+			primary_override_dir = determine_primary_override_dir (home);
 		}
 
 	protected:
 		void  add_apk_libdir (const char *apk, size_t index, size_t apk_count, void *user_data);
-		void  for_each_apk (JNIEnv *env, jstring_array_wrapper &runtimeApks, ForEachApkHandler handler, void *user_data);
+		void  for_each_apk (jstring_array_wrapper &runtimeApks, ForEachApkHandler handler, void *user_data);
 
 	private:
-		char* determine_primary_override_dir (JNIEnv *env, jstring_wrapper &home);
+		char* determine_primary_override_dir (jstring_wrapper &home);
 
 	private:
 		bool  embedded_dso_mode_enabled = false;

--- a/src/monodroid/jni/basic-utilities.cc
+++ b/src/monodroid/jni/basic-utilities.cc
@@ -67,7 +67,7 @@ BasicUtilities::create_directory (const char *pathname, mode_t mode)
 	oldumask = umask (022);
 	simple_pointer_guard<char[]> path (strdup_new (pathname));
 	int rv, ret = 0;
-	for (char *d = path; *d; ++d) {
+	for (char *d = path; d != nullptr && *d; ++d) {
 		if (*d != '/')
 			continue;
 		*d = 0;
@@ -89,7 +89,7 @@ BasicUtilities::create_directory (const char *pathname, mode_t mode)
 }
 
 void
-BasicUtilities::set_world_accessable (const char *path)
+BasicUtilities::set_world_accessable ([[maybe_unused]] const char *path)
 {
 #ifdef ANDROID
 	int r;
@@ -103,7 +103,7 @@ BasicUtilities::set_world_accessable (const char *path)
 }
 
 void
-BasicUtilities::set_user_executable (const char *path)
+BasicUtilities::set_user_executable ([[maybe_unused]] const char *path)
 {
 #ifdef ANDROID
 	int r;

--- a/src/monodroid/jni/basic-utilities.hh
+++ b/src/monodroid/jni/basic-utilities.hh
@@ -219,7 +219,7 @@ namespace xamarin::android
 			return strlen (s1) + calculate_length (strings...);
 		}
 
-		int make_directory (const char *path, mode_t mode)
+		int make_directory (const char *path, [[maybe_unused]] mode_t mode)
 		{
 #if WINDOWS
 			return mkdir (path);

--- a/src/monodroid/jni/cpp-util.hh
+++ b/src/monodroid/jni/cpp-util.hh
@@ -10,8 +10,8 @@ namespace xamarin::android
 	{
 	public:
 		simple_pointer_guard_type () = default;
-		simple_pointer_guard_type (T* tp)
-			: tp (tp)
+		simple_pointer_guard_type (T* _tp)
+			: tp (_tp)
 		{}
 		simple_pointer_guard_type (simple_pointer_guard_type &other) = delete;
 		simple_pointer_guard_type (const simple_pointer_guard_type &other) = delete;
@@ -71,8 +71,8 @@ namespace xamarin::android
 	{
 	public:
 		simple_pointer_guard () = default;
-		simple_pointer_guard (T* tp)
-			: simple_pointer_guard_type<T> (tp)
+		simple_pointer_guard (T* _tp)
+			: simple_pointer_guard_type<T> (_tp)
 		{}
 		simple_pointer_guard (simple_pointer_guard &other) = delete;
 		simple_pointer_guard (const simple_pointer_guard &other) = delete;
@@ -98,8 +98,8 @@ namespace xamarin::android
 	{
 	public:
 		simple_pointer_guard () = default;
-		simple_pointer_guard (T* tp)
-			: simple_pointer_guard_type<T> (tp)
+		simple_pointer_guard (T* _tp)
+			: simple_pointer_guard_type<T> (_tp)
 		{}
 		simple_pointer_guard (simple_pointer_guard &other) = delete;
 		simple_pointer_guard (const simple_pointer_guard &other) = delete;

--- a/src/monodroid/jni/cpu-arch-detect.cc
+++ b/src/monodroid/jni/cpu-arch-detect.cc
@@ -51,7 +51,7 @@ is_64_bit ()
 }
 
 static int
-get_built_for_cpu_windows (unsigned short *built_for_cpu)
+get_built_for_cpu_windows ([[maybe_unused]] unsigned short *built_for_cpu)
 {
 #if _WIN32
 #if _M_AMD64 || _M_X64
@@ -70,7 +70,7 @@ get_built_for_cpu_windows (unsigned short *built_for_cpu)
 }
 
 static int
-get_built_for_cpu_apple (unsigned short *built_for_cpu)
+get_built_for_cpu_apple ([[maybe_unused]] unsigned short *built_for_cpu)
 {
 #if __APPLE__
 #if __x86_64__
@@ -87,7 +87,7 @@ get_built_for_cpu_apple (unsigned short *built_for_cpu)
 }
 
 static int
-get_built_for_cpu_android (unsigned short *built_for_cpu)
+get_built_for_cpu_android ([[maybe_unused]] unsigned short *built_for_cpu)
 {
 	int retval = 1;
 	
@@ -124,7 +124,7 @@ get_built_for_cpu (unsigned short *built_for_cpu)
 }
 
 static int
-get_running_on_cpu_windows (unsigned short *running_on_cpu)
+get_running_on_cpu_windows ([[maybe_unused]] unsigned short *running_on_cpu)
 {
 #if _WIN32
 	SYSTEM_INFO si;
@@ -155,7 +155,7 @@ get_running_on_cpu_windows (unsigned short *running_on_cpu)
 }
 
 static int
-get_running_on_cpu_apple (unsigned short *running_on_cpu)
+get_running_on_cpu_apple ([[maybe_unused]] unsigned short *running_on_cpu)
 {
 #if __APPLE__
 	cpu_type_t cputype;
@@ -184,7 +184,7 @@ get_running_on_cpu_apple (unsigned short *running_on_cpu)
 }
 
 static int
-get_running_on_cpu_android (unsigned short *running_on_cpu)
+get_running_on_cpu_android ([[maybe_unused]] unsigned short *running_on_cpu)
 {
 	int retval = 1;
 	

--- a/src/monodroid/jni/debug-app-helper.cc
+++ b/src/monodroid/jni/debug-app-helper.cc
@@ -61,13 +61,13 @@ BasicUtilities utils;
 BasicAndroidSystem androidSystem;
 
 JNIEXPORT jint JNICALL
-JNI_OnLoad (JavaVM *vm, void *reserved)
+JNI_OnLoad ([[maybe_unused]] JavaVM *vm, [[maybe_unused]] void *reserved)
 {
 	return JNI_VERSION_1_6;
 }
 
 JNIEXPORT void JNICALL
-Java_mono_android_DebugRuntime_init (JNIEnv *env, jclass klass, jobjectArray runtimeApksJava,
+Java_mono_android_DebugRuntime_init (JNIEnv *env, [[maybe_unused]] jclass klass, jobjectArray runtimeApksJava,
                                      jstring runtimeNativeLibDir, jobjectArray appDirs,
                                      jobjectArray externalStorageDirs, jint androidApiLevel,
                                      jboolean embeddedDSOsEnabled)
@@ -77,9 +77,9 @@ Java_mono_android_DebugRuntime_init (JNIEnv *env, jclass klass, jobjectArray run
 	jstring_array_wrapper applicationDirs (env, appDirs);
 	jstring_array_wrapper runtimeApks (env, runtimeApksJava);
 
-	androidSystem.set_primary_override_dir (env, applicationDirs [0]);
+	androidSystem.set_primary_override_dir (applicationDirs [0]);
 	androidSystem.set_override_dir (0, androidSystem.get_primary_override_dir ());
-	androidSystem.setup_app_library_directories (env, runtimeApks, applicationDirs, androidApiLevel);
+	androidSystem.setup_app_library_directories (runtimeApks, applicationDirs, androidApiLevel);
 
 	jstring_wrapper jstr (env);
 	jstr = env->GetObjectArrayElement (externalStorageDirs, 0);
@@ -96,7 +96,7 @@ Java_mono_android_DebugRuntime_init (JNIEnv *env, jclass klass, jobjectArray run
 	}
 
 	if (runtimeNativeLibDir != nullptr) {
-		jstring_wrapper jstr (env, runtimeNativeLibDir);
+		jstr = runtimeNativeLibDir;
 		androidSystem.set_runtime_libdir (utils.strdup_new (jstr.get_cstr ()));
 		log_warn (LOG_DEFAULT, "Using runtime path: %s", androidSystem.get_runtime_libdir ());
 	}
@@ -146,7 +146,7 @@ copy_file_to_internal_location (char *to_dir, char *from_dir, char *file)
 }
 #else  /* !defined (ANDROID) */
 static void
-copy_file_to_internal_location (char *to_dir, char *from_dir, char* file)
+copy_file_to_internal_location ([[maybe_unused]] char *to_dir, [[maybe_unused]] char *from_dir, [[maybe_unused]] char* file)
 {
 }
 #endif /* defined (ANDROID) */
@@ -299,7 +299,7 @@ get_libmonosgen_path ()
 }
 
 void
-log_info (LogCategories category, const char *format, ...)
+log_info ([[maybe_unused]] LogCategories category, const char *format, ...)
 {
 	va_list args;
 
@@ -307,7 +307,7 @@ log_info (LogCategories category, const char *format, ...)
 }
 
 void
-log_info_nocheck (LogCategories category, const char *format, ...)
+log_info_nocheck ([[maybe_unused]] LogCategories category, const char *format, ...)
 {
 	va_list args;
 
@@ -317,21 +317,21 @@ log_info_nocheck (LogCategories category, const char *format, ...)
 	DO_LOG (ANDROID_LOG_INFO, TAG, format, args);
 }
 
-void log_error (LogCategories category, const char* format, ...)
+void log_error ([[maybe_unused]] LogCategories category, const char* format, ...)
 {
 	va_list args;
 
 	DO_LOG (ANDROID_LOG_ERROR, TAG, format, args);
 }
 
-void log_fatal (LogCategories category, const char* format, ...)
+void log_fatal ([[maybe_unused]] LogCategories category, const char* format, ...)
 {
 	va_list args;
 
 	DO_LOG (ANDROID_LOG_FATAL, TAG, format, args);
 }
 
-void log_warn (LogCategories category, const char* format, ...)
+void log_warn ([[maybe_unused]] LogCategories category, const char* format, ...)
 {
 	va_list args;
 

--- a/src/monodroid/jni/embedded-assemblies-zip.cc
+++ b/src/monodroid/jni/embedded-assemblies-zip.cc
@@ -26,9 +26,9 @@ EmbeddedAssemblies::zip_load_entries (int fd, const char *apk_name, monodroid_sh
 	log_info (LOG_ASSEMBLY, "Central directory size: %u", cd_size);
 	log_info (LOG_ASSEMBLY, "Central directory entries: %u", cd_entries);
 #endif
-	off_t result = ::lseek (fd, static_cast<off_t>(cd_offset), SEEK_SET);
-	if (result < 0) {
-		log_fatal (LOG_ASSEMBLY, "Failed to seek to central directory position in the APK file %s. %s (result: %d; errno: %d)", apk_name, std::strerror (errno), result, errno);
+	off_t retval = ::lseek (fd, static_cast<off_t>(cd_offset), SEEK_SET);
+	if (retval < 0) {
+		log_fatal (LOG_ASSEMBLY, "Failed to seek to central directory position in the APK file %s. %s (result: %d; errno: %d)", apk_name, std::strerror (errno), retval, errno);
 		exit (FATAL_EXIT_NO_ASSEMBLIES);
 	}
 
@@ -142,8 +142,8 @@ EmbeddedAssemblies::zip_load_entries (int fd, const char *apk_name, monodroid_sh
 			const char *p = (const char*) cur->data;
 
 			char header[9];
-			for (size_t i = 0; i < sizeof(header)-1; ++i)
-				header[i] = isprint (p [i]) ? p [i] : '.';
+			for (size_t j = 0; j < sizeof(header)-1; ++j)
+				header[j] = isprint (p [j]) ? p [j] : '.';
 			header [sizeof(header)-1] = '\0';
 
 			log_info_nocheck (LOG_ASSEMBLY, "file-offset: % 8x  start: %08p  end: %08p  len: % 12i  zip-entry:  %s name: %s [%s]",

--- a/src/monodroid/jni/external-api.cc
+++ b/src/monodroid/jni/external-api.cc
@@ -287,13 +287,13 @@ path_combine (const char *path1, const char *path2)
 }
 
 MONO_API void*
-monodroid_dylib_mono_new (const char *libmono_path)
+monodroid_dylib_mono_new ([[maybe_unused]] const char *libmono_path)
 {
 	return nullptr;
 }
 
 MONO_API void
-monodroid_dylib_mono_free (void *mono_imports)
+monodroid_dylib_mono_free ([[maybe_unused]] void *mono_imports)
 {
 	// no-op
 }
@@ -305,7 +305,7 @@ monodroid_dylib_mono_free (void *mono_imports)
   it should also accept libmono_path = nullptr parameter
 */
 MONO_API int
-monodroid_dylib_mono_init (void *mono_imports, const char *libmono_path)
+monodroid_dylib_mono_init (void *mono_imports, [[maybe_unused]] const char *libmono_path)
 {
 	if (mono_imports == nullptr)
 		return FALSE;

--- a/src/monodroid/jni/jni-wrappers.hh
+++ b/src/monodroid/jni/jni-wrappers.hh
@@ -15,25 +15,25 @@ namespace xamarin::android
 	class jstring_wrapper
 	{
 	public:
-		explicit jstring_wrapper (JNIEnv *env) noexcept
-			: env (env),
+		explicit jstring_wrapper (JNIEnv *_env) noexcept
+			: env (_env),
 			  jstr (nullptr)
 		{
-			assert (env);
+			assert (_env);
 		}
 
-		explicit jstring_wrapper (JNIEnv *env, const jobject jo) noexcept
-			: env (env),
+		explicit jstring_wrapper (JNIEnv *_env, const jobject jo) noexcept
+			: env (_env),
 			  jstr (reinterpret_cast<jstring> (jo))
 		{
-			assert (env);
+			assert (_env);
 		}
 
-		explicit jstring_wrapper (JNIEnv *env, const jstring js) noexcept
-			: env (env),
+		explicit jstring_wrapper (JNIEnv *_env, const jstring js) noexcept
+			: env (_env),
 			  jstr (js)
 		{
-			assert (env);
+			assert (_env);
 		}
 
 		jstring_wrapper (const jstring_wrapper&) = delete;
@@ -127,18 +127,18 @@ namespace xamarin::android
 	class jstring_array_wrapper
 	{
 	public:
-		explicit jstring_array_wrapper (JNIEnv *env) noexcept
-			: jstring_array_wrapper(env, nullptr)
+		explicit jstring_array_wrapper (JNIEnv *_env) noexcept
+			: jstring_array_wrapper(_env, nullptr)
 		{
 		}
 
-		explicit jstring_array_wrapper (JNIEnv *env, jobjectArray arr)
-			: env (env),
-			  arr (arr)
+		explicit jstring_array_wrapper (JNIEnv *_env, jobjectArray _arr)
+			: env (_env),
+			  arr (_arr)
 		{
-			assert (env);
-			if (arr != nullptr) {
-				len = static_cast<size_t>(env->GetArrayLength (arr));
+			assert (_env);
+			if (_arr != nullptr) {
+				len = static_cast<size_t>(_env->GetArrayLength (_arr));
 				if (len > sizeof (static_wrappers) / sizeof (jstring_wrapper))
 					wrappers = new jstring_wrapper [len];
 				else

--- a/src/monodroid/jni/monodroid-glue-internal.hh
+++ b/src/monodroid/jni/monodroid-glue-internal.hh
@@ -65,15 +65,15 @@ namespace xamarin::android::internal
 		static constexpr int XA_LOG_COUNTERS = MONO_COUNTER_JIT | MONO_COUNTER_METADATA | MONO_COUNTER_GC | MONO_COUNTER_GENERICS;
 
 	public:
-		void Java_mono_android_Runtime_register (JNIEnv *env, jclass klass, jstring managedType, jclass nativeClass, jstring methods);
+		void Java_mono_android_Runtime_register (JNIEnv *env, jstring managedType, jclass nativeClass, jstring methods);
 		void Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApksJava,
 		                                             jstring runtimeNativeLibDir, jobjectArray appDirs, jobject loader,
 		                                             jobjectArray externalStorageDirs, jobjectArray assembliesJava,
 		                                             jint apiLevel, jboolean embeddedDSOsEnabled, jboolean isEmulator);
 		jint Java_mono_android_Runtime_createNewContextWithData (JNIEnv *env, jclass klass, jobjectArray runtimeApksJava, jobjectArray assembliesJava,
 		                                                         jobjectArray assembliesBytes, jobjectArray assembliesPaths, jobject loader, jboolean force_preload_assemblies);
-		void Java_mono_android_Runtime_switchToContext (JNIEnv *env, jclass klass, jint contextID);
-		void Java_mono_android_Runtime_destroyContexts (JNIEnv *env, jclass klass, jintArray array);
+		void Java_mono_android_Runtime_switchToContext (JNIEnv *env, jint contextID);
+		void Java_mono_android_Runtime_destroyContexts (JNIEnv *env, jintArray array);
 		jint Java_JNI_OnLoad (JavaVM *vm, void *reserved);
 
 		int get_android_api_level () const
@@ -135,40 +135,39 @@ namespace xamarin::android::internal
 		static void* monodroid_dlopen_log_and_return (void *handle, char **err, const char *full_name, bool free_memory);
 		int LocalRefsAreIndirect (JNIEnv *env, jclass runtimeClass, int version);
 		void create_xdg_directory (jstring_wrapper& home, const char *relativePath, const char *environmentVariableName);
-		void create_xdg_directories_and_environment (JNIEnv *env, jstring_wrapper &homeDir);
+		void create_xdg_directories_and_environment (jstring_wrapper &homeDir);
 		void disable_external_signal_handlers ();
 		void lookup_bridge_info (MonoDomain *domain, MonoImage *image, const OSBridge::MonoJavaGCBridgeType *type, OSBridge::MonoJavaGCBridgeInfo *info);
-		void load_assembly (MonoDomain *domain, JNIEnv *env, jstring_wrapper &assembly);
-		void load_assemblies (MonoDomain *domain, JNIEnv *env, jstring_array_wrapper &assemblies);
+		void load_assembly (MonoDomain *domain, jstring_wrapper &assembly);
+		void load_assemblies (MonoDomain *domain, jstring_array_wrapper &assemblies);
 		void set_debug_options ();
 		void parse_gdb_options ();
 		void mono_runtime_init (char *runtime_args);
 		void setup_bundled_app (const char *dso_name);
 		void init_android_runtime (MonoDomain *domain, JNIEnv *env, jclass runtimeClass, jobject loader);
-		void set_environment_variable_for_directory (JNIEnv *env, const char *name, jstring_wrapper &value, bool createDirectory, mode_t mode);
+		void set_environment_variable_for_directory (const char *name, jstring_wrapper &value, bool createDirectory, mode_t mode);
 
-		void set_environment_variable_for_directory (JNIEnv *env, const char *name, jstring_wrapper &value)
+		void set_environment_variable_for_directory (const char *name, jstring_wrapper &value)
 		{
-			set_environment_variable_for_directory (env, name, value, true, DEFAULT_DIRECTORY_MODE);
+			set_environment_variable_for_directory (name, value, true, DEFAULT_DIRECTORY_MODE);
 		}
 
-		void set_environment_variable (JNIEnv *env, const char *name, jstring_wrapper &value)
+		void set_environment_variable (const char *name, jstring_wrapper &value)
 		{
-			set_environment_variable_for_directory (env, name, value, false, 0);
+			set_environment_variable_for_directory (name, value, false, 0);
 		}
 
 		MonoClass* get_android_runtime_class (MonoDomain *domain);
 		void shutdown_android_runtime (MonoDomain *domain);
-		MonoDomain*	create_domain (JNIEnv *env, jclass runtimeClass, jstring_array_wrapper &runtimeApks, jobject loader, bool is_root_domain);
+		MonoDomain*	create_domain (JNIEnv *env, jstring_array_wrapper &runtimeApks, bool is_root_domain);
 		MonoDomain* create_and_initialize_domain (JNIEnv* env, jclass runtimeClass, jstring_array_wrapper &runtimeApks,
 		                                          jstring_array_wrapper &assemblies, jobjectArray assembliesBytes, jstring_array_wrapper &assembliesPaths,
 		                                          jobject loader, bool is_root_domain, bool force_preload_assemblies);
 
-		void gather_bundled_assemblies (JNIEnv *env, jstring_array_wrapper &runtimeApks,
-		                                bool register_debug_symbols, size_t *out_user_assemblies_count);
+		void gather_bundled_assemblies (jstring_array_wrapper &runtimeApks, size_t *out_user_assemblies_count);
 		static bool should_register_file (const char *filename);
 		void set_trace_options ();
-		void set_profile_options (JNIEnv *env);
+		void set_profile_options ();
 
 		void log_jit_event (MonoMethod *method, const char *event_name);
 		static void jit_begin (MonoProfiler *prof, MonoMethod *method);

--- a/src/monodroid/jni/monodroid-glue.cc
+++ b/src/monodroid/jni/monodroid-glue.cc
@@ -184,7 +184,7 @@ MonodroidRuntime::setup_bundled_app (const char *dso_name)
 }
 
 void
-MonodroidRuntime::thread_start (MonoProfiler *prof, uintptr_t tid)
+MonodroidRuntime::thread_start ([[maybe_unused]] MonoProfiler *prof, [[maybe_unused]] uintptr_t tid)
 {
 	JNIEnv* env;
 	int r;
@@ -202,7 +202,7 @@ MonodroidRuntime::thread_start (MonoProfiler *prof, uintptr_t tid)
 }
 
 void
-MonodroidRuntime::thread_end (MonoProfiler *prof, uintptr_t tid)
+MonodroidRuntime::thread_end ([[maybe_unused]] MonoProfiler *prof, [[maybe_unused]] uintptr_t tid)
 {
 	int r;
 	r = osBridge.get_jvm ()->DetachCurrentThread ();
@@ -232,26 +232,26 @@ MonodroidRuntime::log_jit_event (MonoMethod *method, const char *event_name)
 }
 
 void
-MonodroidRuntime::jit_begin (MonoProfiler *prof, MonoMethod *method)
+MonodroidRuntime::jit_begin ([[maybe_unused]] MonoProfiler *prof, MonoMethod *method)
 {
 	monodroidRuntime.log_jit_event (method, "begin");
 }
 
 void
-MonodroidRuntime::jit_failed (MonoProfiler *prof, MonoMethod *method)
+MonodroidRuntime::jit_failed ([[maybe_unused]] MonoProfiler *prof, MonoMethod *method)
 {
 	monodroidRuntime.log_jit_event (method, "failed");
 }
 
 void
-MonodroidRuntime::jit_done (MonoProfiler *prof, MonoMethod *method, MonoJitInfo* jinfo)
+MonodroidRuntime::jit_done ([[maybe_unused]] MonoProfiler *prof, MonoMethod *method, [[maybe_unused]] MonoJitInfo* jinfo)
 {
 	monodroidRuntime.log_jit_event (method, "done");
 }
 
 #ifndef RELEASE
 MonoAssembly*
-MonodroidRuntime::open_from_update_dir (MonoAssemblyName *aname, char **assemblies_path, void *user_data)
+MonodroidRuntime::open_from_update_dir (MonoAssemblyName *aname, [[maybe_unused]] char **assemblies_path, [[maybe_unused]] void *user_data)
 {
 	MonoAssembly *result = nullptr;
 
@@ -321,7 +321,7 @@ MonodroidRuntime::open_from_update_dir (MonoAssemblyName *aname, char **assembli
 #endif
 
 bool
-MonodroidRuntime::should_register_file (const char *filename)
+MonodroidRuntime::should_register_file ([[maybe_unused]] const char *filename)
 {
 #ifndef RELEASE
 	for (size_t i = 0; i < AndroidSystem::MAX_OVERRIDES; ++i) {
@@ -342,7 +342,7 @@ MonodroidRuntime::should_register_file (const char *filename)
 }
 
 inline void
-MonodroidRuntime::gather_bundled_assemblies (JNIEnv *env, jstring_array_wrapper &runtimeApks, bool register_debug_symbols, size_t *out_user_assemblies_count)
+MonodroidRuntime::gather_bundled_assemblies (jstring_array_wrapper &runtimeApks, size_t *out_user_assemblies_count)
 {
 #if defined(DEBUG) || !defined (ANDROID)
 	for (size_t i = 0; i < AndroidSystem::MAX_OVERRIDES; ++i) {
@@ -443,7 +443,7 @@ MonodroidRuntime::monodroid_debug_accept (int sock, struct sockaddr_in addr)
 #endif
 
 inline jint
-MonodroidRuntime::Java_JNI_OnLoad (JavaVM *vm, void *reserved)
+MonodroidRuntime::Java_JNI_OnLoad (JavaVM *vm, [[maybe_unused]] void *reserved)
 {
 	JNIEnv *env;
 
@@ -602,7 +602,7 @@ MonodroidRuntime::set_debug_options (void)
 }
 
 void
-MonodroidRuntime::mono_runtime_init (char *runtime_args)
+MonodroidRuntime::mono_runtime_init ([[maybe_unused]] char *runtime_args)
 {
 #if defined (DEBUG) && !defined (WINDOWS)
 	RuntimeOptions options;
@@ -778,11 +778,11 @@ MonodroidRuntime::mono_runtime_init (char *runtime_args)
 }
 
 MonoDomain*
-MonodroidRuntime::create_domain (JNIEnv *env, jclass runtimeClass, jstring_array_wrapper &runtimeApks, jobject loader, bool is_root_domain)
+MonodroidRuntime::create_domain (JNIEnv *env, jstring_array_wrapper &runtimeApks, bool is_root_domain)
 {
 	size_t user_assemblies_count   = 0;;
 
-	gather_bundled_assemblies (env, runtimeApks, embeddedAssemblies.get_register_debug_symbols (), &user_assemblies_count);
+	gather_bundled_assemblies (runtimeApks, &user_assemblies_count);
 
 	if (!mono_mkbundle_init && user_assemblies_count == 0 && androidSystem.count_override_assemblies () == 0 && !is_running_on_desktop) {
 		log_fatal (LOG_DEFAULT, "No assemblies found in '%s' or '%s'. Assuming this is part of Fast Deployment. Exiting...",
@@ -1077,7 +1077,7 @@ MonodroidRuntime::monodroid_dlopen_log_and_return (void *handle, char **err, con
 }
 
 void*
-MonodroidRuntime::monodroid_dlopen (const char *name, int flags, char **err, void *user_data)
+MonodroidRuntime::monodroid_dlopen (const char *name, int flags, char **err, [[maybe_unused]] void *user_data)
 {
 	int dl_flags = monodroidRuntime.convert_dl_flags (flags);
 	bool libmonodroid_fallback = false;
@@ -1119,7 +1119,7 @@ MonodroidRuntime::monodroid_dlopen (const char *name, int flags, char **err, voi
 }
 
 void*
-MonodroidRuntime::monodroid_dlsym (void *handle, const char *name, char **err, void *user_data)
+MonodroidRuntime::monodroid_dlsym (void *handle, const char *name, char **err, [[maybe_unused]] void *user_data)
 {
 	void *s;
 
@@ -1133,7 +1133,7 @@ MonodroidRuntime::monodroid_dlsym (void *handle, const char *name, char **err, v
 }
 
 inline void
-MonodroidRuntime::set_environment_variable_for_directory (JNIEnv *env, const char *name, jstring_wrapper &value, bool createDirectory, mode_t mode)
+MonodroidRuntime::set_environment_variable_for_directory (const char *name, jstring_wrapper &value, bool createDirectory, mode_t mode)
 {
 	if (createDirectory) {
 		int rv = utils.create_directory (value.get_cstr (), mode);
@@ -1156,7 +1156,7 @@ MonodroidRuntime::create_xdg_directory (jstring_wrapper& home, const char *relat
 }
 
 inline void
-MonodroidRuntime::create_xdg_directories_and_environment (JNIEnv *env, jstring_wrapper &homeDir)
+MonodroidRuntime::create_xdg_directories_and_environment (jstring_wrapper &homeDir)
 {
 	create_xdg_directory (homeDir, ".local/share", "XDG_DATA_HOME");
 	create_xdg_directory (homeDir, ".config", "XDG_CONFIG_HOME");
@@ -1204,7 +1204,7 @@ MonodroidRuntime::set_trace_options (void)
 }
 
 inline void
-MonodroidRuntime::set_profile_options (JNIEnv *env)
+MonodroidRuntime::set_profile_options ()
 {
 	constexpr const char mlpd_ext[] = "mlpd";
 	constexpr const char aot_ext[] = "aotprofile";
@@ -1314,7 +1314,7 @@ MonodroidRuntime::disable_external_signal_handlers (void)
 }
 
 inline void
-MonodroidRuntime::load_assembly (MonoDomain *domain, JNIEnv *env, jstring_wrapper &assembly)
+MonodroidRuntime::load_assembly (MonoDomain *domain, jstring_wrapper &assembly)
 {
 	timing_period total_time;
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
@@ -1348,7 +1348,7 @@ MonodroidRuntime::load_assembly (MonoDomain *domain, JNIEnv *env, jstring_wrappe
 }
 
 inline void
-MonodroidRuntime::load_assemblies (MonoDomain *domain, JNIEnv *env, jstring_array_wrapper &assemblies)
+MonodroidRuntime::load_assemblies (MonoDomain *domain, jstring_array_wrapper &assemblies)
 {
 	timing_period total_time;
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)))
@@ -1356,7 +1356,7 @@ MonodroidRuntime::load_assemblies (MonoDomain *domain, JNIEnv *env, jstring_arra
 
 	for (size_t i = 0; i < assemblies.get_length (); ++i) {
 		jstring_wrapper &assembly = assemblies [i];
-		load_assembly (domain, env, assembly);
+		load_assembly (domain, assembly);
 	}
 
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING))) {
@@ -1367,17 +1367,18 @@ MonodroidRuntime::load_assemblies (MonoDomain *domain, JNIEnv *env, jstring_arra
 }
 
 [[maybe_unused]] static void
-monodroid_Mono_UnhandledException_internal (MonoException *ex)
+monodroid_Mono_UnhandledException_internal ([[maybe_unused]] MonoException *ex)
 {
 	// Do nothing with it here, we let the exception naturally propagate on the managed side
 }
 
 MonoDomain*
 MonodroidRuntime::create_and_initialize_domain (JNIEnv* env, jclass runtimeClass, jstring_array_wrapper &runtimeApks,
-                                                jstring_array_wrapper &assemblies, jobjectArray assembliesBytes, jstring_array_wrapper &assembliesPaths,
-                                                jobject loader, bool is_root_domain, bool force_preload_assemblies)
+                                                jstring_array_wrapper &assemblies, [[maybe_unused]] jobjectArray assembliesBytes,
+												[[maybe_unused]] jstring_array_wrapper &assembliesPaths, jobject loader, bool is_root_domain,
+												bool force_preload_assemblies)
 {
-	MonoDomain* domain = create_domain (env, runtimeClass, runtimeApks, loader, is_root_domain);
+	MonoDomain* domain = create_domain (env, runtimeApks, is_root_domain);
 
 	// When running on desktop, the root domain is only a dummy so don't initialize it
 	if constexpr (is_running_on_desktop) {
@@ -1391,7 +1392,7 @@ MonodroidRuntime::create_and_initialize_domain (JNIEnv* env, jclass runtimeClass
 		designerAssemblies.add_or_update_from_java (domain, env, assemblies, assembliesBytes, assembliesPaths);
 #endif
 	if (androidSystem.is_assembly_preload_enabled () || (is_running_on_desktop && force_preload_assemblies))
-		load_assemblies (domain, env, assemblies);
+		load_assemblies (domain, assemblies);
 	init_android_runtime (domain, env, runtimeClass, loader);
 
 	osBridge.add_monodroid_domain (domain);
@@ -1402,7 +1403,7 @@ MonodroidRuntime::create_and_initialize_domain (JNIEnv* env, jclass runtimeClass
 inline void
 MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApksJava,
                                                           jstring runtimeNativeLibDir, jobjectArray appDirs, jobject loader,
-                                                          jobjectArray externalStorageDirs, jobjectArray assembliesJava,
+                                                          [[maybe_unused]] jobjectArray externalStorageDirs, jobjectArray assembliesJava,
                                                           jint apiLevel, jboolean embeddedDSOsEnabled, jboolean isEmulator)
 {
 	init_logging_categories ();
@@ -1422,21 +1423,21 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 	utils.monodroid_store_package_name (application_config.android_package_name);
 
 	jstring_wrapper jstr (env, lang);
-	set_environment_variable (env, "LANG", jstr);
+	set_environment_variable ("LANG", jstr);
 
 	androidSystem.setup_environment ();
 
 	jstring_array_wrapper applicationDirs (env, appDirs);
 	jstring_wrapper &home = applicationDirs[0];
-	set_environment_variable_for_directory (env, "TMPDIR", applicationDirs[1]);
-	set_environment_variable_for_directory (env, "HOME", home);
-	create_xdg_directories_and_environment (env, home);
-	androidSystem.set_primary_override_dir (env, home);
+	set_environment_variable_for_directory ("TMPDIR", applicationDirs[1]);
+	set_environment_variable_for_directory ("HOME", home);
+	create_xdg_directories_and_environment (home);
+	androidSystem.set_primary_override_dir (home);
 
 	disable_external_signal_handlers ();
 
 	jstring_array_wrapper runtimeApks (env, runtimeApksJava);
-	androidSystem.setup_app_library_directories (env, runtimeApks, applicationDirs, apiLevel);
+	androidSystem.setup_app_library_directories (runtimeApks, applicationDirs, apiLevel);
 
 	init_reference_logging (androidSystem.get_primary_override_dir ());
 	androidSystem.create_update_dir (androidSystem.get_primary_override_dir ());
@@ -1468,7 +1469,7 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 		log_warn (LOG_DEFAULT, "Using runtime path: %s", androidSystem.get_runtime_libdir ());
 	}
 
-	androidSystem.setup_process_args (env, runtimeApks);
+	androidSystem.setup_process_args (runtimeApks);
 
 	if (XA_UNLIKELY (utils.should_log (LOG_TIMING)) && !(log_timing_categories & LOG_TIMING_BARE)) {
 		mono_counters_enable (static_cast<int>(XA_LOG_COUNTERS));
@@ -1481,7 +1482,7 @@ MonodroidRuntime::Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass kl
 
 	mono_dl_fallback_register (monodroid_dlopen, monodroid_dlsym, nullptr, nullptr);
 
-	set_profile_options (env);
+	set_profile_options ();
 
 	set_trace_options ();
 
@@ -1590,8 +1591,8 @@ JNI_OnLoad (JavaVM *vm, void *reserved)
 JNIEXPORT void JNICALL
 Java_mono_android_Runtime_init (JNIEnv *env, jclass klass, jstring lang, jobjectArray runtimeApksJava,
                                 jstring runtimeNativeLibDir, jobjectArray appDirs, jobject loader,
-                                jobjectArray externalStorageDirs, jobjectArray assembliesJava, jstring packageName,
-                                jint apiLevel, jobjectArray environmentVariables)
+                                jobjectArray externalStorageDirs, jobjectArray assembliesJava, [[maybe_unused]] jstring packageName,
+                                jint apiLevel, [[maybe_unused]] jobjectArray environmentVariables)
 {
 	monodroidRuntime.Java_mono_android_Runtime_initInternal (
 		env,
@@ -1632,7 +1633,7 @@ Java_mono_android_Runtime_initInternal (JNIEnv *env, jclass klass, jstring lang,
 }
 
 inline void
-MonodroidRuntime::Java_mono_android_Runtime_register (JNIEnv *env, jclass klass, jstring managedType, jclass nativeClass, jstring methods)
+MonodroidRuntime::Java_mono_android_Runtime_register (JNIEnv *env, jstring managedType, jclass nativeClass, jstring methods)
 {
 	timing_period total_time;
 
@@ -1684,9 +1685,9 @@ MonodroidRuntime::Java_mono_android_Runtime_register (JNIEnv *env, jclass klass,
 }
 
 JNIEXPORT void
-JNICALL Java_mono_android_Runtime_register (JNIEnv *env, jclass klass, jstring managedType, jclass nativeClass, jstring methods)
+JNICALL Java_mono_android_Runtime_register (JNIEnv *env, [[maybe_unused]] jclass klass, jstring managedType, jclass nativeClass, jstring methods)
 {
-	monodroidRuntime.Java_mono_android_Runtime_register (env, klass, managedType, nativeClass, methods);
+	monodroidRuntime.Java_mono_android_Runtime_register (env, managedType, nativeClass, methods);
 }
 
 // DO NOT USE ON NORMAL X.A
@@ -1724,7 +1725,7 @@ MonodroidRuntime::Java_mono_android_Runtime_createNewContextWithData (JNIEnv *en
 }
 
 inline void
-MonodroidRuntime::Java_mono_android_Runtime_switchToContext (JNIEnv *env, jclass klass, jint contextID)
+MonodroidRuntime::Java_mono_android_Runtime_switchToContext (JNIEnv *env, jint contextID)
 {
 	log_info (LOG_DEFAULT, "SWITCHING CONTEXT");
 	MonoDomain *domain = mono_domain_get_by_id ((int)contextID);
@@ -1737,7 +1738,7 @@ MonodroidRuntime::Java_mono_android_Runtime_switchToContext (JNIEnv *env, jclass
 }
 
 inline void
-MonodroidRuntime::Java_mono_android_Runtime_destroyContexts (JNIEnv *env, jclass klass, jintArray array)
+MonodroidRuntime::Java_mono_android_Runtime_destroyContexts (JNIEnv *env, jintArray array)
 {
 	MonoDomain *root_domain = mono_get_root_domain ();
 	mono_jit_thread_attach (root_domain);
@@ -1841,19 +1842,19 @@ JNICALL Java_mono_android_Runtime_createNewContext (JNIEnv *env, jclass klass, j
 }
 
 JNIEXPORT void
-JNICALL Java_mono_android_Runtime_switchToContext (JNIEnv *env, jclass klass, jint contextID)
+JNICALL Java_mono_android_Runtime_switchToContext (JNIEnv *env, [[maybe_unused]] jclass klass, jint contextID)
 {
-	monodroidRuntime.Java_mono_android_Runtime_switchToContext (env, klass, contextID);
+	monodroidRuntime.Java_mono_android_Runtime_switchToContext (env, contextID);
 }
 
 JNIEXPORT void
-JNICALL Java_mono_android_Runtime_destroyContexts (JNIEnv *env, jclass klass, jintArray array)
+JNICALL Java_mono_android_Runtime_destroyContexts (JNIEnv *env, [[maybe_unused]] jclass klass, jintArray array)
 {
-	monodroidRuntime.Java_mono_android_Runtime_destroyContexts (env, klass, array);
+	monodroidRuntime.Java_mono_android_Runtime_destroyContexts (env, array);
 }
 
 JNIEXPORT void
-JNICALL Java_mono_android_Runtime_propagateUncaughtException (JNIEnv *env, jclass klass, jobject javaThread, jthrowable javaException)
+JNICALL Java_mono_android_Runtime_propagateUncaughtException (JNIEnv *env, [[maybe_unused]] jclass klass, jobject javaThread, jthrowable javaException)
 {
 	MonoDomain *domain = mono_domain_get ();
 	monodroidRuntime.propagate_uncaught_exception (domain, env, javaThread, javaException);

--- a/src/monodroid/jni/timezones.cc
+++ b/src/monodroid/jni/timezones.cc
@@ -45,7 +45,7 @@ init ()
 }
 
 static void
-clear_time_zone_caches_within_domain (void *user_data)
+clear_time_zone_caches_within_domain ([[maybe_unused]] void *user_data)
 {
 	mono_runtime_invoke (
 			AndroidEnvironment_NotifyTimeZoneChanged, /* method */
@@ -62,7 +62,7 @@ clear_time_zone_caches (MonoDomain *domain, void *user_data)
 }
 
 extern "C" JNIEXPORT void
-JNICALL Java_mono_android_Runtime_notifyTimeZoneChanged (JNIEnv *env, jclass klass)
+JNICALL Java_mono_android_Runtime_notifyTimeZoneChanged ([[maybe_unused]] JNIEnv *env, [[maybe_unused]] jclass klass)
 {
 	init ();
 	mono_domain_foreach (clear_time_zone_caches, nullptr);

--- a/src/monodroid/jni/xamarin_getifaddrs.cc
+++ b/src/monodroid/jni/xamarin_getifaddrs.cc
@@ -365,21 +365,21 @@ _monodroid_freeifaddrs (struct _monodroid_ifaddrs *ifa)
 }
 
 static void
-get_ifaddrs_impl (int (**getifaddrs_impl) (struct _monodroid_ifaddrs **ifap), void (**freeifaddrs_impl) (struct _monodroid_ifaddrs *ifa))
+get_ifaddrs_impl (int (**getifaddrs_implementation) (struct _monodroid_ifaddrs **ifap), void (**freeifaddrs_implementation) (struct _monodroid_ifaddrs *ifa))
 {
 	void *libc;
 
-	assert (getifaddrs_impl);
-	assert (freeifaddrs_impl);
+	assert (getifaddrs_implementation);
+	assert (freeifaddrs_implementation);
 
 	libc = dlopen ("libc.so", RTLD_NOW);
 	if (libc) {
-		*getifaddrs_impl = reinterpret_cast<int (*)(struct _monodroid_ifaddrs**)> (dlsym (libc, "getifaddrs"));
-		if (*getifaddrs_impl)
-			*freeifaddrs_impl = reinterpret_cast<void (*) (struct _monodroid_ifaddrs*)> (dlsym (libc, "freeifaddrs"));
+		*getifaddrs_implementation = reinterpret_cast<int (*)(struct _monodroid_ifaddrs**)> (dlsym (libc, "getifaddrs"));
+		if (*getifaddrs_implementation)
+			*freeifaddrs_implementation = reinterpret_cast<void (*) (struct _monodroid_ifaddrs*)> (dlsym (libc, "freeifaddrs"));
 	}
 
-	if (!*getifaddrs_impl) {
+	if (!*getifaddrs_implementation) {
 		log_info (LOG_NET, "This libc does not have getifaddrs/freeifaddrs, using Xamarin's\n");
 	} else {
 		log_info (LOG_NET, "This libc has getifaddrs/freeifaddrs\n");


### PR DESCRIPTION
Add a number of warnings to the array of arguments passed to the C++
compilers in order to detect suboptimal or incorrect code:

  * `-Wduplicated-branches`
    Detect conditional branches which yield identical code.
  * `-Wduplicated-cond`
    Detect duplicated conditions in the if-else-then statements
  * `-Werror=return-type`
     Make `-Wreturn-type` an error. Prevents compiling code with
     functions which require a return value but do not return from all
     code paths.
  * `-Wextra`
     A bunch of "extra" warnings (too many to list here) which should
     help make the code cleaner and more correct
  * `-Wmisleading-indentation`
     Warn about code which has indentation that can mislead the developer
     into thinking that a statement following the `if` statement is part
     of the statement's `true` block while in reality it isn't.
  * `-Wnull-dereference`
     Make the compiler detect potential `null` pointer dereference (it
     can yield some annoying false positives, but it's worth dealing with
     them overall)
  * `-Wpointer-arith`
    Warn about  that depends on the "size of" a function type or of
     'void'.
  * `-Wshadow`
     Warn about variables which shadow other variables in outer scope.
     This is a potential source of obscure bugs or confusion and should
     be avoided.

Enabling `-Wextra` also enables warnings about unused function
parameters, thus this commit also adds a bunch of `[[maybe_unused]]`
attributes to a few functions throughout the code. Some of those
parameters are used only in certain contexts (e.g. only during Android
or Windows builds) and thus they'll generate the warning in other
contexts.

In addition to the above, clean up the API a bit by removing actually
not used parameters from a handful of functions.