### PR TITLE
Bump to xamarin/monodroid/master@b2841feb

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@b2841feb5a69f9ccd3c480a9341fcb1da62af552
+xamarin/monodroid:master@78d565884f7dd2cf76e748125485f7ed0e03eec4
 mono/mono:2019-10@18920a83f423fb864a2263948737681968f5b2c8

--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@0f6725edfa09559afad58233d43f385122e31e8d
+xamarin/monodroid:master@b2841feb5a69f9ccd3c480a9341fcb1da62af552
 mono/mono:2019-10@18920a83f423fb864a2263948737681968f5b2c8


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/0f6725edfa09559afad58233d43f385122e31e8d...b2841feb5a69f9ccd3c480a9341fcb1da62af552

Context: https://build.azdo.io/3395342

  * xamarin/monodroid@b2841feb5: Bump to xamarin/android-sdk-installer/master@78c3d16 (#1065)
  * xamarin/monodroid@3c8601c55: [tools/msbuild] ported <GetPrimaryCpuAbi/> to AndroidAsyncTask (#1067)
  * xamarin/monodroid@ad8d0f348: Support for new typemaps (#1061)