### PR TITLE
[build] Use the CC and CXX envvars to detect compilers on Unix

### DIFF
--- a/Documentation/building/unix/dependencies.md
+++ b/Documentation/building/unix/dependencies.md
@@ -7,6 +7,9 @@ Building Xamarin.Android requires:
   * [Autotools (`autoconf`, `automake`, etc.)](#autotools)
   * [The Android SDK and NDK](#ndk)
   * [Linux](#Linux) and [macOS](#macOS) Dependencies
+  * C++ compiler with support for C++17 (clang or gcc)
+  * MinGW 6 or newer, if cross-building of Windows tooling on the 
+    Unix host is desired
 
 The `make prepare` build step (or `/t:Prepare` on Windows) will
 check that all required dependencies are present.


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/4155

Computers running older versions of Unix/Linux operating systems may
have default C/C++ compilers which are too old to build Xamarin.Android.
However, it is possible that other versions of the compilers are
available on those machines which can be sufficiently new to build our
native code. In order to make building on those hosts easier, this
commit adds code to detect the desired compiler by looking at the `CC`
and `CXX` variables in the `xaprepare` environment.

Both variables should be set to the desired compiler name when invoking
`make` to prepare XA build:

     CC=gcc-7 CXX=g++-7 make prepare