### PR TITLE
[Xamarin.Android.Build.Tasks] App Bundle support for $(AdbTarget)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApkSet.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApkSet.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Android.Tasks
 	/// 
 	/// Usage: bundletool build-apks --bundle=foo.aab --output=foo.apks
 	/// </summary>
-	public class BuildApkSet : BundleTool
+	public class BuildApkSet : BundleToolAdbTask
 	{
 		public override string TaskPrefix => "BAS";
 
@@ -20,16 +20,6 @@ namespace Xamarin.Android.Tasks
 
 		[Required]
 		public string Output { get; set; }
-
-		/// <summary>
-		/// This is used to detect the attached device and generate an APK set specifically for it
-		/// </summary>
-		[Required]
-		public string AdbToolPath { get; set; }
-
-		public string AdbToolExe { get; set; }
-
-		public string AdbToolName => OS.IsWindows ? "adb.exe" : "adb";
 
 		[Required]
 		public string Aapt2ToolPath { get; set; }
@@ -72,9 +62,8 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		protected override CommandLineBuilder GetCommandLineBuilder ()
+		internal override CommandLineBuilder GetCommandLineBuilder ()
 		{
-			var adb   = string.IsNullOrEmpty (AdbToolExe) ? AdbToolName : AdbToolExe;
 			var aapt2 = string.IsNullOrEmpty (Aapt2ToolExe) ? Aapt2ToolName : Aapt2ToolExe;
 			var cmd   = base.GetCommandLineBuilder ();
 			cmd.AppendSwitch ("build-apks");
@@ -82,7 +71,7 @@ namespace Xamarin.Android.Tasks
 			cmd.AppendSwitchIfNotNull ("--bundle ", AppBundle);
 			cmd.AppendSwitchIfNotNull ("--output ", Output);
 			cmd.AppendSwitchIfNotNull ("--mode ", "default");
-			cmd.AppendSwitchIfNotNull ("--adb ", Path.Combine (AdbToolPath, adb));
+			AppendAdbOptions (cmd);
 			cmd.AppendSwitchIfNotNull ("--aapt2 ", Path.Combine (Aapt2ToolPath, aapt2));
 			cmd.AppendSwitchIfNotNull ("--ks ", KeyStore);
 			cmd.AppendSwitchIfNotNull ("--ks-key-alias ", KeyAlias);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildAppBundle.cs
@@ -118,7 +118,7 @@ namespace Xamarin.Android.Tasks
 			return !Log.HasLoggedErrors;
 		}
 
-		protected override CommandLineBuilder GetCommandLineBuilder ()
+		internal override CommandLineBuilder GetCommandLineBuilder ()
 		{
 			var cmd = base.GetCommandLineBuilder ();
 			cmd.AppendSwitch ("build-bundle");

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BundleTool.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BundleTool.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Android.Tasks
 			return GetCommandLineBuilder ().ToString ();
 		}
 
-		protected virtual CommandLineBuilder GetCommandLineBuilder ()
+		internal virtual CommandLineBuilder GetCommandLineBuilder ()
 		{
 			var cmd = new CommandLineBuilder ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BundleToolAdbTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BundleToolAdbTask.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks
+{
+	public abstract class BundleToolAdbTask : BundleTool
+	{
+		/// <summary>
+		/// This is used to detect the attached device and generate an APK set specifically for it
+		/// </summary>
+		[Required]
+		public string AdbToolPath { get; set; }
+
+		public string AdbToolExe { get; set; }
+
+		public string AdbTarget { get; set; }
+
+		public string AdbToolName => OS.IsWindows ? "adb.exe" : "adb";
+
+		protected void AppendAdbOptions (CommandLineBuilder cmd)
+		{
+			var adb = string.IsNullOrEmpty (AdbToolExe) ? AdbToolName : AdbToolExe;
+			cmd.AppendSwitchIfNotNull ("--adb ", Path.Combine (AdbToolPath, adb));
+
+			var adbTarget = AdbTarget;
+			if (!string.IsNullOrEmpty (adbTarget)) {
+				// Normally of the form "-s emulator-5554"
+				int index = adbTarget.IndexOf (' ');
+				if (index != -1) {
+					adbTarget = adbTarget.Substring (index + 1, adbTarget.Length - index - 1);
+				}
+				cmd.AppendSwitchIfNotNull ("--device-id ", adbTarget);
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/InstallApkSet.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/InstallApkSet.cs
@@ -10,27 +10,19 @@ namespace Xamarin.Android.Tasks
 	/// 
 	/// Usage: bundletool install-apks --apks=foo.apks
 	/// </summary>
-	public class InstallApkSet : BundleTool
+	public class InstallApkSet : BundleToolAdbTask
 	{
 		public override string TaskPrefix => "IAS";
 
 		[Required]
 		public string ApkSet { get; set; }
 
-		[Required]
-		public string AdbToolPath { get; set; }
-
-		public string AdbToolExe { get; set; }
-
-		public string AdbToolName => OS.IsWindows ? "adb.exe" : "adb";
-
-		protected override CommandLineBuilder GetCommandLineBuilder ()
+		internal override CommandLineBuilder GetCommandLineBuilder ()
 		{
-			var adb = string.IsNullOrEmpty (AdbToolExe) ? AdbToolName : AdbToolExe;
 			var cmd = base.GetCommandLineBuilder ();
 			cmd.AppendSwitch ("install-apks");
 			cmd.AppendSwitchIfNotNull ("--apks ", ApkSet);
-			cmd.AppendSwitchIfNotNull ("--adb ", Path.Combine (AdbToolPath, adb));
+			AppendAdbOptions (cmd);
 			cmd.AppendSwitch ("--allow-downgrade");
 
 			// --modules: List of modules to be installed, or "_ALL_" for all modules.

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BundleToolTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BundleToolTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Xamarin.Android.Tasks;
 using Xamarin.ProjectTools;
 using Xamarin.Tools.Zip;
 
@@ -284,6 +285,53 @@ namespace Xamarin.Android.Build.Tests
 					}
 				}
 			}
+		}
+
+		[Test]
+		public void BuildAppBundleCommand ()
+		{
+			var task = new BuildAppBundle {
+				BaseZip = "base.zip",
+				Output = "foo.aab",
+			};
+			string cmd = task.GetCommandLineBuilder ().ToString ();
+			Assert.AreEqual ($"build-bundle --modules base.zip --output foo.aab", cmd);
+		}
+
+		[Test]
+		public void BuildApkSetCommand ()
+		{
+			var task = new BuildApkSet {
+				AppBundle = "foo.aab",
+				Output = "foo.apks",
+				KeyStore = "foo.keystore",
+				KeyAlias = "alias",
+				KeyPass = "keypass",
+				StorePass = "storepass",
+				Aapt2ToolPath = Path.Combine ("aapt", "with spaces"),
+				Aapt2ToolExe = "aapt2",
+				AdbToolPath = Path.Combine ("adb", "with spaces"),
+				AdbToolExe = "adb",
+				AdbTarget = "-s emulator-5554"
+			};
+			string aapt2 = Path.Combine (task.Aapt2ToolPath, task.Aapt2ToolExe);
+			string adb = Path.Combine (task.AdbToolPath, task.AdbToolExe);
+			string cmd = task.GetCommandLineBuilder ().ToString ();
+			Assert.AreEqual ($"build-apks --connected-device --bundle foo.aab --output foo.apks --mode default --adb \"{adb}\" --device-id emulator-5554 --aapt2 \"{aapt2}\" --ks foo.keystore --ks-key-alias alias --key-pass pass:keypass --ks-pass pass:storepass", cmd);
+		}
+
+		[Test]
+		public void InstallApkSetCommand ()
+		{
+			var task = new InstallApkSet {
+				ApkSet = "foo.apks",
+				AdbToolPath = Path.Combine ("path", "with spaces"),
+				AdbToolExe = "adb",
+				AdbTarget = "-s emulator-5554"
+			};
+			string adb = Path.Combine (task.AdbToolPath, task.AdbToolExe);
+			string cmd = task.GetCommandLineBuilder ().ToString ();
+			Assert.AreEqual ($"install-apks --apks foo.apks --adb \"{adb}\" --device-id emulator-5554 --allow-downgrade --modules _ALL_", cmd);
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Tasks\BuildAppBundle.cs" />
     <Compile Include="Tasks\BundleTool.cs" />
     <Compile Include="Tasks\BuildApkSet.cs" />
+    <Compile Include="Tasks\BundleToolAdbTask.cs" />
     <Compile Include="Tasks\InstallApkSet.cs" />
     <Compile Include="Tasks\CilStrip.cs" />
     <Compile Include="Tasks\ConvertDebuggingFiles.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -3264,6 +3264,7 @@ because xbuild doesn't support framework reference assemblies.
       JavaOptions="$(JavaOptions)"
       JarPath="$(AndroidBundleToolJarPath)"
       AdbToolPath="$(AdbToolPath)"
+      AdbTarget="$(AdbTarget)"
       Aapt2ToolPath="$(Aapt2ToolPath)"
       AppBundle="$(_AppBundleIntermediate)"
       Output="$(_ApkSetIntermediate)"
@@ -3278,6 +3279,7 @@ because xbuild doesn't support framework reference assemblies.
       JavaOptions="$(JavaOptions)"
       JarPath="$(AndroidBundleToolJarPath)"
       AdbToolPath="$(AdbToolPath)"
+      AdbTarget="$(AdbTarget)"
       ApkSet="$(_ApkSetIntermediate)"
   />
 </Target>


### PR DESCRIPTION
Fixes: https://developercommunity.visualstudio.com/content/problem/854863/unable-to-deploy-to-physical-device-when-emulator.html
Fixes: http://work.azdo.io/1056857

We got some reports that our App Bundle MSBuild tasks fail when you
have multiple devices/emulators connected to adb.

We were not using the `$(AdbTarget)` MSBuild property at all, which is
actually a slightly different parameter for `bundletool`:

    --device-id: (Optional) Device serial name. If absent, this uses the
        ANDROID_SERIAL environment variable. Either this flag or the environment
        variable is required when more than one device or emulator is connected.
        Used only if connected-device flag is set.

It appears that only a value such as `-s emulator-5554` would work for
the `--device-id` switch. To make things compatible, I think we should
just look for a space character and use the text as-is after it.

I added some tests that validate the generated command-line for
`bundletool`-related MSBuild tasks.