### PR TITLE
[F#] Use C# Resource.designer.cs file for F#

### DIFF
--- a/Documentation/release-notes/4168.md
+++ b/Documentation/release-notes/4168.md
@@ -1,0 +1,14 @@
+### Stop generating Resource.designer.fs files for F# projects
+
+Generation of F# resource files is no longer supported. F# projects will
+now generate `Resource.designer.cs` files, which should be processed by the
+[Xamarin.Android.FSharp.ResourceProvider][0] [NuGet Package][1]. Please
+see [this sample code][2] as an example of how to use this Resource Provider.
+This provider does not support processing of `Resource.designer.cs` files in
+the intermediate output directory. The corresponding feature which is 
+controlled by the `AndroidUseIntermediateDesignerFile` msbuild property has
+been disabled for F# projects as a result.
+
+[0]: https://github.com/xamarin/Xamarin.Android.FSharp.ResourceProvider
+[1]: https://www.nuget.org/packages/Xamarin.Android.FSharp.ResourceProvider
+[2]: https://github.com/xamarin/xamarin-forms-book-samples/tree/385ab7dd71a8d9c451e401820ac8d061cd3952b7/Chapter09/FS/DisplayPlatformInfo/Droid

--- a/build-tools/create-vsix/symbols/ExternalWhiteList.csv
+++ b/build-tools/create-vsix/symbols/ExternalWhiteList.csv
@@ -6,7 +6,6 @@
 # -------------------------------------------------------------------------------
 #
 # Xamarin.Android 3rd party assemblies - pecolli, jopryo
-xamarin.android.sdk*\xamarin.android.sdk*.vsixdir\*msbuild\xamarin\android\FSharp.Compiler.CodeDom.dll
 xamarin.android.sdk*\xamarin.android.sdk*.vsixdir\*msbuild\xamarin\android\FSharp.Core.dll
 xamarin.android.sdk*\xamarin.android.sdk*.vsixdir\*msbuild\xamarin\android\INIFileParser.dll
 xamarin.android.sdk*\xamarin.android.sdk*.vsixdir\*msbuild\xamarin\android\Irony.dll

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -108,7 +108,6 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\cil-strip.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\class-parse.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\class-parse.pdb" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\FSharp.Compiler.CodeDom.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\FSharp.Core.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\generator.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\generator.pdb" />

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/Xamarin.Android.Build.Tasks.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/Xamarin.Android.Build.Tasks.cs
@@ -40,7 +40,6 @@ namespace Xamarin.Android.Prepare
 
 		public override List<ThirdPartyNotice> Notices => new List <ThirdPartyNotice> {
 			new XamarinAndroidBuildTasks_fsharp_fsharp_TPN (),
-			new XamarinAndroidBuildTasks_fsprojects_FSharpCompilerCodeDom_TPN (),
 			new XamarinAndroidBuildTasks_IronyProject_Irony_TPN (),
 			new XamarinAndroidBuildTasks_JamesNK_NewtonsoftJson_TPN (),
 			new XamarinAndroidBuildTasks_NuGet_NuGetClient_TPN (),
@@ -56,42 +55,6 @@ namespace Xamarin.Android.Prepare
 		public override string LicenseFile => CommonLicenses.Apache20Path;
 		public override string Name        => "fsharp/fsharp";
 		public override Uri    SourceUrl   => url;
-	}
-
-	class XamarinAndroidBuildTasks_fsprojects_FSharpCompilerCodeDom_TPN : ThirdPartyNotice
-	{
-		static readonly Uri    url         = new Uri ("https://github.com/fsprojects/FSharp.Compiler.CodeDom/");
-
-		public override string LicenseFile => null;
-		public override string Name        => "fsprojects/FSharp.Compiler.CodeDom";
-		public override Uri    SourceUrl   => url;
-
-		public override string LicenseText => @"
-        This is free and unencumbered software released into the public domain.
-
-        Anyone is free to copy, modify, publish, use, compile, sell, or
-        distribute this software, either in source code form or as a compiled
-        binary, for any purpose, commercial or non-commercial, and by any
-        means.
-
-        In jurisdictions that recognize copyright laws, the author or authors
-        of this software dedicate any and all copyright interest in the
-        software to the public domain. We make this dedication for the benefit
-        of the public at large and to the detriment of our heirs and
-        successors. We intend this dedication to be an overt act of
-        relinquishment in perpetuity of all present and future rights to this
-        software under copyright law.
-
-        THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
-        EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-        MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-        IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-        OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-        ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-        OTHER DEALINGS IN THE SOFTWARE.
-
-        For more information, please refer to <http://unlicense.org>
-";
 	}
 
 	class XamarinAndroidBuildTasks_IronyProject_Irony_TPN : ThirdPartyNotice

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesigner.cs
@@ -107,8 +107,7 @@ namespace Xamarin.Android.Tasks
 			bool isCSharp = string.Equals (language, "C#", StringComparison.OrdinalIgnoreCase);
 
 
-			if (isFSharp)
-			{
+			if (isFSharp) {
 				language = "C#";
 				isCSharp = true;
 				NetResgenOutputFile = Path.ChangeExtension (NetResgenOutputFile, ".cs");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -530,12 +530,12 @@ namespace UnnamedProject
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				var outputFile = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath,
-					"Resource.designer"  + proj.Language.DefaultExtension);
+					"Resource.designer" + proj.Language.DefaultDesignerExtension);
 				Assert.IsTrue (File.Exists (outputFile), "Resource.designer{1} should have been created in {0}",
-					proj.IntermediateOutputPath, proj.Language.DefaultExtension);
+					proj.IntermediateOutputPath, proj.Language.DefaultDesignerExtension);
 				Assert.IsTrue (b.Clean (proj), "Clean should have succeeded.");
 				Assert.IsFalse (File.Exists (outputFile), "Resource.designer{1} should have been cleaned in {0}",
-					proj.IntermediateOutputPath, proj.Language.DefaultExtension);
+					proj.IntermediateOutputPath, proj.Language.DefaultDesignerExtension);
 			}
 		}
 
@@ -555,7 +555,7 @@ namespace UnnamedProject
 			};
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				var designerPath = Path.Combine (Root, b.ProjectDirectory, "Resources", "Resource.designer" + language.DefaultDesignerExtension);
+				var designerPath = Path.Combine (Root, b.ProjectDirectory, "Resources", "Resource.designer" + proj.Language.DefaultDesignerExtension);
 				var attr = File.GetAttributes (designerPath);
 				File.SetAttributes (designerPath, FileAttributes.ReadOnly);
 				Assert.IsTrue ((File.GetAttributes (designerPath) & FileAttributes.ReadOnly) == FileAttributes.ReadOnly,
@@ -626,7 +626,7 @@ namespace UnnamedProject
 				IsRelease = isRelease,
 			};
 			proj.SetProperty ("AndroidUseIntermediateDesignerFile", "True");
-			proj.SetProperty ("AndroidResgenFile", "Resources\\Resource.designer" + proj.Language.DefaultExtension);
+			proj.SetProperty ("AndroidResgenFile", "Resources\\Resource.designer" + proj.Language.DefaultDesignerExtension);
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				var designer = proj.Sources.FirstOrDefault (x => x.Include() == "Resources\\Resource.designer" + proj.Language.DefaultDesignerExtension);
 				designer = designer ?? proj.OtherBuildItems.FirstOrDefault (x => x.Include () == "Resources\\Resource.designer" + proj.Language.DefaultDesignerExtension);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -36,9 +36,8 @@ namespace Xamarin.ProjectTools
 		public XamarinAndroidApplicationProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
 			: base (debugConfigurationName, releaseConfigurationName)
 		{
-			var defaultExtension = Language.DefaultExtension == ".fs" ? ".cs" : Language.DefaultExtension;
-
 			SetProperty ("AndroidApplication", "True");
+
 			SetProperty ("AndroidResgenClass", "Resource");
 			SetProperty ("AndroidResgenFile", () => "Resources\\Resource.designer" + Language.DefaultDesignerExtension);
 			SetProperty ("AndroidManifest", "Properties\\AndroidManifest.xml");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -36,8 +36,9 @@ namespace Xamarin.ProjectTools
 		public XamarinAndroidApplicationProject (string debugConfigurationName = "Debug", string releaseConfigurationName = "Release")
 			: base (debugConfigurationName, releaseConfigurationName)
 		{
-			SetProperty ("AndroidApplication", "True");
+			var defaultExtension = Language.DefaultExtension == ".fs" ? ".cs" : Language.DefaultExtension;
 
+			SetProperty ("AndroidApplication", "True");
 			SetProperty ("AndroidResgenClass", "Resource");
 			SetProperty ("AndroidResgenFile", () => "Resources\\Resource.designer" + Language.DefaultDesignerExtension);
 			SetProperty ("AndroidManifest", "Properties\\AndroidManifest.xml");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -62,7 +62,6 @@
     </Reference>
   </ItemGroup>
    <ItemGroup>
-    <PackageReference Include="FSharp.Compiler.CodeDom" Version="1.0.0.1" />
     <PackageReference Include="FSharp.Core" Version="3.1.2.5" />
     <PackageReference Include="ILRepack" Version="2.0.18" />
     <PackageReference Include="Irony" Version="0.9.1" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
@@ -31,7 +31,7 @@ Copyright (C) 2012 Xamarin. All rights reserved.
              our mscorlib.dll isn't properly signed, as far as its concerned.
              Disable generation to avoid "bizarre" build errors. -->
         <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-        <_AndroidResourceDesigner>Resource.designer.fs</_AndroidResourceDesigner>
+        <_AndroidResourceDesigner>Resource.Designer.cs</_AndroidResourceDesigner>
         <!-- Enable nuget package conflict resolution -->
         <ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
     </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
@@ -31,7 +31,7 @@ Copyright (C) 2012 Xamarin. All rights reserved.
              our mscorlib.dll isn't properly signed, as far as its concerned.
              Disable generation to avoid "bizarre" build errors. -->
         <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-        <_AndroidResourceDesigner>Resource.Designer.cs</_AndroidResourceDesigner>
+        <_AndroidResourceDesigner>Resource.designer.cs</_AndroidResourceDesigner>
         <!-- Enable nuget package conflict resolution -->
         <ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
     </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.FSharp.targets
@@ -34,6 +34,8 @@ Copyright (C) 2012 Xamarin. All rights reserved.
         <_AndroidResourceDesigner>Resource.designer.cs</_AndroidResourceDesigner>
         <!-- Enable nuget package conflict resolution -->
         <ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
+        <!--- This is not compatible with Xamarin.Android.FSharp.ResourceProvider, so disable it for all F# projects. -->
+        <AndroidUseIntermediateDesignerFile>False</AndroidUseIntermediateDesignerFile>
     </PropertyGroup>
     <!-- Force Xbuild to behave like msbuild -->
     <PropertyGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/238
Context: https://github.com/xamarin/xamarin-android/pull/4132

Removes the use of F# CodeDOM for generating the resource
designer file for F#.

Instead, a type provider
is used at compile time (both xbuild and the IDE) that compiles the
C# code using CSharpCodeProvider and makes the types available to
the consuming F# project. The type provider is available as a NuGet
package and is included in the Android templates.

This is similar to #159, but uses an F# type provider to compile the C# instead of an msbuild task. The advantage of this method is that intellisense works in the IDE without having to change the IDE code.