### PR TITLE
[Xamarin.Android.Build.Task] use global:: for GeneratedCodeAttribute

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -41,6 +41,29 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void BuildAppWithSystemNamespace ()
+		{
+			var path = Path.Combine (Root, "temp", TestName);
+			var library = new XamarinAndroidLibraryProject () {
+				ProjectName = "Library1.System",
+			};
+			var proj = new XamarinAndroidApplicationProject () {
+				References = {
+					new BuildItem.ProjectReference (Path.Combine("..", library.ProjectName, Path.GetFileName (library.ProjectFilePath)), "Library1.System") {
+					},
+				},
+			};
+			using (var builder = CreateDllBuilder (Path.Combine (path, library.ProjectName), cleanupAfterSuccessfulBuild: false, cleanupOnDispose: false)) {
+				builder.ThrowOnBuildFailure = false;
+				Assert.IsTrue (builder.Build (library), "Library should have built.");
+				using (var b = CreateApkBuilder (Path.Combine (path, proj.ProjectName), cleanupAfterSuccessfulBuild: false, cleanupOnDispose: false)) {
+					b.ThrowOnBuildFailure = false;
+					Assert.IsTrue (b.Build (proj), "Project should have built.");
+				}
+			}
+		}
+
+		[Test]
 		public void RepetitiveBuild ()
 		{
 			if (Directory.Exists ("temp/RepetitiveBuild"))

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileExpected.cs
@@ -15,7 +15,7 @@ namespace Foo.Foo
 {
 	
 	
-	[System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
 	public partial class Resource
 	{
 		

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileWithElevenStyleableAttributesExpected.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileWithElevenStyleableAttributesExpected.cs
@@ -15,7 +15,7 @@ namespace Foo.Foo
 {
 	
 	
-	[System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
 	public partial class Resource
 	{
 		

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileWithLibraryReferenceExpected.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/GenerateDesignerFileWithLibraryReferenceExpected.cs
@@ -15,7 +15,7 @@ namespace Foo.Foo
 {
 	
 	
-	[System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
 	public partial class Resource
 	{
 		

--- a/src/Xamarin.Android.Build.Tasks/Utilities/JavaResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/JavaResourceParser.cs
@@ -59,7 +59,7 @@ namespace Xamarin.Android.Tasks
 						};
 						var asm = Assembly.GetExecutingAssembly().GetName();
 						var codeAttrDecl =
-							new CodeAttributeDeclaration("System.CodeDom.Compiler.GeneratedCodeAttribute",
+							new CodeAttributeDeclaration(new CodeTypeReference ("System.CodeDom.Compiler.GeneratedCodeAttribute", CodeTypeReferenceOptions.GlobalReference),
 								new CodeAttributeArgument(
 									new CodePrimitiveExpression(asm.Name)),
 								new CodeAttributeArgument(

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ManagedResourceParser.cs
@@ -420,7 +420,7 @@ namespace Xamarin.Android.Tasks
 			};
 			var asm = Assembly.GetExecutingAssembly ().GetName ();
 			var codeAttrDecl =
-				new CodeAttributeDeclaration ("System.CodeDom.Compiler.GeneratedCodeAttribute",
+				new CodeAttributeDeclaration (new CodeTypeReference ("System.CodeDom.Compiler.GeneratedCodeAttribute", CodeTypeReferenceOptions.GlobalReference),
 					new CodeAttributeArgument (
 						new CodePrimitiveExpression (asm.Name)),
 					new CodeAttributeArgument (


### PR DESCRIPTION
Fixes http://work.azdo.io/1057222

We had the global:: namespace prefix on ALL namespaces
in the Resource.Designer.cs file EXCEPT GeneratedCodeAttribute :facepalm.
So users can get errors like

	The type or namespace name 'CodeDom' does not exist in the namespace Foo.Bar.System

If they use `System` in their defualt namespace for the project.
This commit adds it, so users who use `System` in their
assembly namespaces will not be hit by this in the future.