### PR TITLE
[ci] Add build success dependency to regression tests

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -984,7 +984,7 @@ stages:
 - stage: integrated_regression_test
   displayName: Regression Tests
   dependsOn: mac_build
-  condition: and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
+  condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
   jobs:
 
   # Check - "Xamarin.Android (Test Integrated Regression - macOS)"


### PR DESCRIPTION
Updates the regression test stage introduced in commit 47e00d7c to only
run when the `mac_build` stage completes successfully, as it depends
on artifacts produced by that stage.