### PR TITLE
[Xamarin.Android.Build.Tasks] Split up XA3001 errors and move them into .resx file

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -79,7 +79,13 @@ ms.date: 08/23/2019
 
 ## XA2xxx: Linker
 
-## XA3xxx: AOT
+## XA3xxx: Unmanaged code compilation
+
++ XA3001: Could not AOT the assembly: {assembly}
++ XA3002: Invalid AOT mode: {mode}
++ XA3003: Could not strip IL of assembly: {assembly}
++ XA3004: Could not compile native assembly file: {file}
++ XA3005: Could not link native shared library: {library}
 
 ## XA4xxx: Code generation
 

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -61,6 +61,51 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not AOT the assembly: {0}.
+        /// </summary>
+        internal static string XA3001 {
+            get {
+                return ResourceManager.GetString("XA3001", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid AOT mode: {0}.
+        /// </summary>
+        internal static string XA3002 {
+            get {
+                return ResourceManager.GetString("XA3002", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not strip IL of assembly: {0}.
+        /// </summary>
+        internal static string XA3003 {
+            get {
+                return ResourceManager.GetString("XA3003", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not compile native assembly file: {0}.
+        /// </summary>
+        internal static string XA3004 {
+            get {
+                return ResourceManager.GetString("XA3004", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not link native shared library: {0}.
+        /// </summary>
+        internal static string XA3005 {
+            get {
+                return ResourceManager.GetString("XA3005", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical..
         /// </summary>
         internal static string XA4214 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -117,6 +117,24 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="XA3001" xml:space="preserve">
+    <value>Could not AOT the assembly: {0}</value>
+    <comment>The abbreviation "AOT" should not be translated.</comment>
+  </data>
+  <data name="XA3002" xml:space="preserve">
+    <value>Invalid AOT mode: {0}</value>
+    <comment>The abbreviation "AOT" should not be translated.</comment>
+  </data>
+  <data name="XA3003" xml:space="preserve">
+    <value>Could not strip IL of assembly: {0}</value>
+    <comment>The abbreviation "IL" should not be translated.</comment>
+  </data>
+  <data name="XA3004" xml:space="preserve">
+    <value>Could not compile native assembly file: {0}</value>
+  </data>
+  <data name="XA3005" xml:space="preserve">
+    <value>Could not link native shared library: {0}</value>
+  </data>
   <data name="XA4214" xml:space="preserve">
     <value>The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</value>
     <comment>{0} - The managed type name

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
     <body>
+      <trans-unit id="XA3001">
+        <source>Could not AOT the assembly: {0}</source>
+        <target state="new">Could not AOT the assembly: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3002">
+        <source>Invalid AOT mode: {0}</source>
+        <target state="new">Invalid AOT mode: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3003">
+        <source>Could not strip IL of assembly: {0}</source>
+        <target state="new">Could not strip IL of assembly: {0}</target>
+        <note>The abbreviation "IL" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3004">
+        <source>Could not compile native assembly file: {0}</source>
+        <target state="new">Could not compile native assembly file: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>Could not link native shared library: {0}</source>
+        <target state="new">Could not link native shared library: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4214">
         <source>The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</source>
         <target state="new">The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
     <body>
+      <trans-unit id="XA3001">
+        <source>Could not AOT the assembly: {0}</source>
+        <target state="new">Could not AOT the assembly: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3002">
+        <source>Invalid AOT mode: {0}</source>
+        <target state="new">Invalid AOT mode: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3003">
+        <source>Could not strip IL of assembly: {0}</source>
+        <target state="new">Could not strip IL of assembly: {0}</target>
+        <note>The abbreviation "IL" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3004">
+        <source>Could not compile native assembly file: {0}</source>
+        <target state="new">Could not compile native assembly file: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>Could not link native shared library: {0}</source>
+        <target state="new">Could not link native shared library: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4214">
         <source>The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</source>
         <target state="new">The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
     <body>
+      <trans-unit id="XA3001">
+        <source>Could not AOT the assembly: {0}</source>
+        <target state="new">Could not AOT the assembly: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3002">
+        <source>Invalid AOT mode: {0}</source>
+        <target state="new">Invalid AOT mode: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3003">
+        <source>Could not strip IL of assembly: {0}</source>
+        <target state="new">Could not strip IL of assembly: {0}</target>
+        <note>The abbreviation "IL" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3004">
+        <source>Could not compile native assembly file: {0}</source>
+        <target state="new">Could not compile native assembly file: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>Could not link native shared library: {0}</source>
+        <target state="new">Could not link native shared library: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4214">
         <source>The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</source>
         <target state="new">The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
     <body>
+      <trans-unit id="XA3001">
+        <source>Could not AOT the assembly: {0}</source>
+        <target state="new">Could not AOT the assembly: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3002">
+        <source>Invalid AOT mode: {0}</source>
+        <target state="new">Invalid AOT mode: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3003">
+        <source>Could not strip IL of assembly: {0}</source>
+        <target state="new">Could not strip IL of assembly: {0}</target>
+        <note>The abbreviation "IL" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3004">
+        <source>Could not compile native assembly file: {0}</source>
+        <target state="new">Could not compile native assembly file: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>Could not link native shared library: {0}</source>
+        <target state="new">Could not link native shared library: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4214">
         <source>The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</source>
         <target state="new">The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
     <body>
+      <trans-unit id="XA3001">
+        <source>Could not AOT the assembly: {0}</source>
+        <target state="new">Could not AOT the assembly: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3002">
+        <source>Invalid AOT mode: {0}</source>
+        <target state="new">Invalid AOT mode: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3003">
+        <source>Could not strip IL of assembly: {0}</source>
+        <target state="new">Could not strip IL of assembly: {0}</target>
+        <note>The abbreviation "IL" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3004">
+        <source>Could not compile native assembly file: {0}</source>
+        <target state="new">Could not compile native assembly file: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>Could not link native shared library: {0}</source>
+        <target state="new">Could not link native shared library: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4214">
         <source>The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</source>
         <target state="new">The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
     <body>
+      <trans-unit id="XA3001">
+        <source>Could not AOT the assembly: {0}</source>
+        <target state="new">Could not AOT the assembly: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3002">
+        <source>Invalid AOT mode: {0}</source>
+        <target state="new">Invalid AOT mode: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3003">
+        <source>Could not strip IL of assembly: {0}</source>
+        <target state="new">Could not strip IL of assembly: {0}</target>
+        <note>The abbreviation "IL" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3004">
+        <source>Could not compile native assembly file: {0}</source>
+        <target state="new">Could not compile native assembly file: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>Could not link native shared library: {0}</source>
+        <target state="new">Could not link native shared library: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4214">
         <source>The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</source>
         <target state="new">The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
     <body>
+      <trans-unit id="XA3001">
+        <source>Could not AOT the assembly: {0}</source>
+        <target state="new">Could not AOT the assembly: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3002">
+        <source>Invalid AOT mode: {0}</source>
+        <target state="new">Invalid AOT mode: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3003">
+        <source>Could not strip IL of assembly: {0}</source>
+        <target state="new">Could not strip IL of assembly: {0}</target>
+        <note>The abbreviation "IL" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3004">
+        <source>Could not compile native assembly file: {0}</source>
+        <target state="new">Could not compile native assembly file: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>Could not link native shared library: {0}</source>
+        <target state="new">Could not link native shared library: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4214">
         <source>The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</source>
         <target state="new">The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
     <body>
+      <trans-unit id="XA3001">
+        <source>Could not AOT the assembly: {0}</source>
+        <target state="new">Could not AOT the assembly: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3002">
+        <source>Invalid AOT mode: {0}</source>
+        <target state="new">Invalid AOT mode: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3003">
+        <source>Could not strip IL of assembly: {0}</source>
+        <target state="new">Could not strip IL of assembly: {0}</target>
+        <note>The abbreviation "IL" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3004">
+        <source>Could not compile native assembly file: {0}</source>
+        <target state="new">Could not compile native assembly file: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>Could not link native shared library: {0}</source>
+        <target state="new">Could not link native shared library: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4214">
         <source>The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</source>
         <target state="new">The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
     <body>
+      <trans-unit id="XA3001">
+        <source>Could not AOT the assembly: {0}</source>
+        <target state="new">Could not AOT the assembly: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3002">
+        <source>Invalid AOT mode: {0}</source>
+        <target state="new">Invalid AOT mode: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3003">
+        <source>Could not strip IL of assembly: {0}</source>
+        <target state="new">Could not strip IL of assembly: {0}</target>
+        <note>The abbreviation "IL" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3004">
+        <source>Could not compile native assembly file: {0}</source>
+        <target state="new">Could not compile native assembly file: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>Could not link native shared library: {0}</source>
+        <target state="new">Could not link native shared library: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4214">
         <source>The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</source>
         <target state="new">The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
     <body>
+      <trans-unit id="XA3001">
+        <source>Could not AOT the assembly: {0}</source>
+        <target state="new">Could not AOT the assembly: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3002">
+        <source>Invalid AOT mode: {0}</source>
+        <target state="new">Invalid AOT mode: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3003">
+        <source>Could not strip IL of assembly: {0}</source>
+        <target state="new">Could not strip IL of assembly: {0}</target>
+        <note>The abbreviation "IL" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3004">
+        <source>Could not compile native assembly file: {0}</source>
+        <target state="new">Could not compile native assembly file: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>Could not link native shared library: {0}</source>
+        <target state="new">Could not link native shared library: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4214">
         <source>The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</source>
         <target state="new">The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
     <body>
+      <trans-unit id="XA3001">
+        <source>Could not AOT the assembly: {0}</source>
+        <target state="new">Could not AOT the assembly: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3002">
+        <source>Invalid AOT mode: {0}</source>
+        <target state="new">Invalid AOT mode: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3003">
+        <source>Could not strip IL of assembly: {0}</source>
+        <target state="new">Could not strip IL of assembly: {0}</target>
+        <note>The abbreviation "IL" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3004">
+        <source>Could not compile native assembly file: {0}</source>
+        <target state="new">Could not compile native assembly file: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>Could not link native shared library: {0}</source>
+        <target state="new">Could not link native shared library: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4214">
         <source>The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</source>
         <target state="new">The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
     <body>
+      <trans-unit id="XA3001">
+        <source>Could not AOT the assembly: {0}</source>
+        <target state="new">Could not AOT the assembly: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3002">
+        <source>Invalid AOT mode: {0}</source>
+        <target state="new">Invalid AOT mode: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3003">
+        <source>Could not strip IL of assembly: {0}</source>
+        <target state="new">Could not strip IL of assembly: {0}</target>
+        <note>The abbreviation "IL" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3004">
+        <source>Could not compile native assembly file: {0}</source>
+        <target state="new">Could not compile native assembly file: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>Could not link native shared library: {0}</source>
+        <target state="new">Could not link native shared library: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4214">
         <source>The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</source>
         <target state="new">The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
     <body>
+      <trans-unit id="XA3001">
+        <source>Could not AOT the assembly: {0}</source>
+        <target state="new">Could not AOT the assembly: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3002">
+        <source>Invalid AOT mode: {0}</source>
+        <target state="new">Invalid AOT mode: {0}</target>
+        <note>The abbreviation "AOT" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3003">
+        <source>Could not strip IL of assembly: {0}</source>
+        <target state="new">Could not strip IL of assembly: {0}</target>
+        <note>The abbreviation "IL" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA3004">
+        <source>Could not compile native assembly file: {0}</source>
+        <target state="new">Could not compile native assembly file: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>Could not link native shared library: {0}</source>
+        <target state="new">Could not link native shared library: {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA4214">
         <source>The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</source>
         <target state="new">The managed type `{0}` exists in multiple assemblies: {1}. Please refactor the managed type names in these assemblies so that they are not identical.</target>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -230,7 +230,7 @@ namespace Xamarin.Android.Tasks
 		{
 			bool hasValidAotMode = GetAndroidAotMode (AndroidAotMode, out AotMode);
 			if (!hasValidAotMode) {
-				LogCodedError ("XA3001", "Invalid AOT mode: {0}", AndroidAotMode);
+				LogCodedError ("XA3002", Properties.Resources.XA3002, AndroidAotMode);
 				return;
 			}
 
@@ -246,7 +246,7 @@ namespace Xamarin.Android.Tasks
 					}
 
 					if (!RunAotCompiler (config.AssembliesPath, config.AotCompiler, config.AotOptions, config.AssemblyPath, config.ResponseFile)) {
-						LogCodedError ("XA3001", "Could not AOT the assembly: {0}", Path.GetFileName (config.AssemblyPath));
+						LogCodedError ("XA3001", Properties.Resources.XA3001, Path.GetFileName (config.AssemblyPath));
 						Cancel ();
 						return;
 					}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CilStrip.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CilStrip.cs
@@ -31,12 +31,7 @@ namespace Xamarin.Android.Tasks
 
 		public override bool RunTask ()
 		{
-			try {
-				return DoExecute ();
-			} catch (Exception e) {
-				Log.LogCodedError ("XA3001", "{0}", e);
-				return false;
-			}
+			return DoExecute ();
 		}
 
 		bool DoExecute () {
@@ -45,7 +40,7 @@ namespace Xamarin.Android.Tasks
 			AotMode aotMode;
 			bool hasValidAotMode = Aot.GetAndroidAotMode (AndroidAotMode, out aotMode);
 			if (!hasValidAotMode) {
-				Log.LogCodedError ("XA3001", "Invalid AOT mode: {0}", AndroidAotMode);
+				Log.LogCodedError ("XA3002", Properties.Resources.XA3002, AndroidAotMode);
 				return false;
 			}
 
@@ -74,7 +69,7 @@ namespace Xamarin.Android.Tasks
 				File.Copy (assemblyPath, nonstripPath, overwrite: true);
 
 				if (!RunCilStrip (nonstripPath, assemblyPath)) {
-					Log.LogCodedError ("XA3001", "Could not strip IL of assembly: {0}", assembly.ItemSpec);
+					Log.LogCodedError ("XA3003", Properties.Resources.XA3003, assembly.ItemSpec);
 					return false;
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
@@ -86,7 +86,7 @@ namespace Xamarin.Android.Tasks
 					stdout_completed.WaitOne (TimeSpan.FromSeconds (30));
 
 				if (proc.ExitCode != 0) {
-					LogCodedError ("XA3001", $"Could not compile native assembly file: {Path.GetFileName (config.InputSource)}");
+					LogCodedError ("XA3004", Properties.Resources.XA3004, Path.GetFileName (config.InputSource));
 					Cancel ();
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkApplicationSharedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkApplicationSharedLibraries.cs
@@ -95,7 +95,7 @@ namespace Xamarin.Android.Tasks
 					stdout_completed.WaitOne (TimeSpan.FromSeconds (30));
 
 				if (proc.ExitCode != 0) {
-					LogCodedError ("XA3001", $"Could not link native shared library: {Path.GetFileName (config.OutputSharedLibrary)}");
+					LogCodedError ("XA3005", Properties.Resources.XA3005, Path.GetFileName (config.OutputSharedLibrary));
 					Cancel ();
 				}
 			}


### PR DESCRIPTION
Context: [0342fe56][0]
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Split up the different uses of XA3001 by giving each error condition its
own code.  This makes it possible to gather telemetry for each condition
separately, and it also makes it easier for users to search for the
particular code they are seeing.

Move XA3001 and the other new error codes to the `.resx` file so that
they are localizable.

Remove the `try-catch` from `CilStrip.RunTask()` because after
[d4c8f077][1], the `AndroidTask` base class now provides that
functionality.

[0]: https://github.com/xamarin/xamarin-android/commit/0342fe5698b86e21e36c924732ff135b9a87e4af
[1]: https://github.com/xamarin/xamarin-android/commit/d4c8f077faefdfc6174355848a9d8c74ecaa8f56