### PR TITLE
[Xamarin.Android.Build.Tasks] fixes for jnimarshalmethod-gen

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MonoDroidMarkStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/MonoDroidMarkStep.cs
@@ -32,7 +32,11 @@ namespace MonoDroid.Tuner
 			HashSet<string> markedMethods = new HashSet<string> ();
 			var updated = false;
 
-			marshalTypes.Add (GetType ("Mono.Android", "Java.Interop.TypeManager/JavaTypeManager/__<$>_jni_marshal_methods"));
+			var typeName = "Java.Interop.TypeManager/JavaTypeManager/__<$>_jni_marshal_methods";
+			var javaTypeManager = GetType ("Mono.Android", typeName);
+			if (javaTypeManager == null)
+				throw new InvalidOperationException ($"Unable to find '{typeName}' in Mono.Android.dll!");
+			marshalTypes.Add (javaTypeManager);
 
 			foreach (var type in marshalTypes) {
 				registerMethod = null;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1931,9 +1931,11 @@ because xbuild doesn't support framework reference assemblies.
       <_AssembliesToLink Include="@(ResolvedAssemblies)" />
     </ItemGroup>
     <ItemGroup Condition=" '$(AndroidGenerateJniMarshalMethods)' == 'True' ">
-      <_JniAssembliesToLink Include="@(ResolvedAssemblies->'$(_JniMarshalMethodsOutputDir)%(Filename)%(Extension)')" />
-      <_AssembliesToLink Condition="Exists(%(Identity))" Include="@(_JniAssembliesToLink)" />
-      <_AssembliesToLink Condition="!Exists(@(JniAssembliesToLink))" Include="@(ResolvedAssemblies)" />
+      <_PossibleAssembliesToLink Include="@(ResolvedAssemblies)">
+        <JniAssembly>$(_JniMarshalMethodsOutputDir)%(Filename)%(Extension)</JniAssembly>
+      </_PossibleAssembliesToLink>
+      <_AssembliesToLink Condition="Exists(%(_PossibleAssembliesToLink.JniAssembly))" Include="%(_PossibleAssembliesToLink.JniAssembly)" />
+      <_AssembliesToLink Condition="!Exists(%(_PossibleAssembliesToLink.JniAssembly))" Include="%(_PossibleAssembliesToLink.Identity)" />
     </ItemGroup>
 
     <CreateProperty


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4171

When working on PR #4171, I was hitting an NRE on this line:

    marshalTypes.Add (GetType ("Mono.Android", "Java.Interop.TypeManager/JavaTypeManager/__<$>_jni_marshal_methods"));

Somehow `Mono.Android.dll` was missing?

    Java.Interop.TypeManager/JavaTypeManager/__<$>_jni_marshal_methods

After more investigation, I came upon this `<ItemGroup>` that seemed
wrong:

    <ItemGroup Condition=" '$(AndroidGenerateJniMarshalMethods)' == 'True' ">
      <_JniAssembliesToLink Include="@(ResolvedAssemblies->'$(_JniMarshalMethodsOutputDir)%(Filename)%(Extension)')" />
      <_AssembliesToLink Condition="Exists(%(Identity))" Include="@(_JniAssembliesToLink)" />
      <_AssembliesToLink Condition="!Exists(@(JniAssembliesToLink))" Include="@(ResolvedAssemblies)" />
    </ItemGroup>

In this example the `Condition` on the second `@(_AssembliesToLink)`
would always evaluate to `true`. Thus `Mono.Android.dll` was in the
list twice and PR #4171 happened to cause this bug, because the
assemblies end up in a different order.

The fix is to more appropriately merge the item groups here using item
metadata.

I also made the linker throw a better exception message instead of an
NRE if something like this happens in the future.