### PR TITLE
Bump to mono/mono/2019-10@1cca0cfe

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:d16-5@dab75e88055c1bfaf53f810b0c3a9218fc53c60a
-mono/mono:2019-10@1182f8cbf5b4f11e3f6ca0dfa97fbdb14041dbb7
+mono/mono:2019-10@1cca0cfebfcbd019c6f2bdd3e5b99f769f1e2e0c


### PR DESCRIPTION
Changes: https://github.com/mono/mono/compare/1182f8cbf5b4f11e3f6ca0dfa97fbdb14041dbb7...1cca0cfebfcbd019c6f2bdd3e5b99f769f1e2e0c

Context: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1048838
Context: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1050615

  * mono/mono@1cca0cfebfc: Bump bockbuild for Pango patch
  * mono/mono@b216675706a: configure.ac: remove AC_SEARCH_LIBS for libintl (#18596)
  * mono/mono@c0a5db5f829: [2019-10] Bump msbuild to track mono-2019-10 (#18576)
  * mono/mono@9ce68dc791c: [2019-10] [debugger] Native thread not executing managed code considered as terminated  (#18503)
  * mono/mono@ea94456156c: [interp] context can be uninitialized for get_resume_state callback (#18536)