### PR TITLE
[Xamarin.Android.Build.Tasks] fix potential AsyncTask.Log calls

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:master@78d565884f7dd2cf76e748125485f7ed0e03eec4
+xamarin/monodroid:master@017b3618bd33689f766e82b5fd640360e4c19919
 mono/mono:2019-12@2edccc52a78d90fea7bcbd37844164663e712397

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt.cs
@@ -267,13 +267,13 @@ namespace Xamarin.Android.Tasks
 
 			Directory.CreateDirectory (manifestDir);
 			manifestFile = Path.Combine (manifestDir, Path.GetFileName (ManifestFile));
-			ManifestDocument manifest = new ManifestDocument (ManifestFile, this.Log);
+			ManifestDocument manifest = new ManifestDocument (ManifestFile);
 			manifest.SdkVersion = AndroidSdkPlatform;
 			if (!string.IsNullOrEmpty (VersionCodePattern)) {
 				try {
 					manifest.CalculateVersionCode (currentAbi, VersionCodePattern, VersionCodeProperties);
 				} catch (ArgumentOutOfRangeException ex) {
-					Log.LogCodedError ("XA0003", ManifestFile, 0, ex.Message);
+					LogCodedError ("XA0003", ManifestFile, 0, ex.Message);
 					return string.Empty;
 				}
 			}
@@ -281,11 +281,11 @@ namespace Xamarin.Android.Tasks
 				manifest.SetAbi (currentAbi);
 			}
 			if (!manifest.ValidateVersionCode (out string error, out string errorCode)) {
-				Log.LogCodedError (errorCode, ManifestFile, 0, error);
+				LogCodedError (errorCode, ManifestFile, 0, error);
 				return string.Empty;
 			}
 			manifest.ApplicationName = ApplicationName;
-			manifest.Save (manifestFile);
+			manifest.Save (LogWarning, manifestFile);
 
 			cmd.AppendSwitchIfNotNull ("-M ", manifestFile);
 			var designerDirectory = Path.IsPathRooted (JavaDesignerOutputDirectory) ? JavaDesignerOutputDirectory : Path.Combine (WorkingDirectory, JavaDesignerOutputDirectory);
@@ -348,7 +348,7 @@ namespace Xamarin.Android.Tasks
 
 			var extraArgsExpanded = ExpandString (ExtraArgs);
 			if (extraArgsExpanded != ExtraArgs)
-				Log.LogDebugMessage ("  ExtraArgs expanded: {0}", extraArgsExpanded);
+				LogDebugMessage ("  ExtraArgs expanded: {0}", extraArgsExpanded);
 
 			if (!string.IsNullOrWhiteSpace (extraArgsExpanded))
 				cmd.AppendSwitch (extraArgsExpanded);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -107,13 +107,13 @@ namespace Xamarin.Android.Tasks {
 			string manifestDir = Path.Combine (Path.GetDirectoryName (ManifestFile), currentAbi != null ? currentAbi : "manifest");
 			Directory.CreateDirectory (manifestDir);
 			string manifestFile = Path.Combine (manifestDir, Path.GetFileName (ManifestFile));
-			ManifestDocument manifest = new ManifestDocument (ManifestFile, this.Log);
+			ManifestDocument manifest = new ManifestDocument (ManifestFile);
 			manifest.SdkVersion = AndroidSdkPlatform;
 			if (!string.IsNullOrEmpty (VersionCodePattern)) {
 				try {
 					manifest.CalculateVersionCode (currentAbi, VersionCodePattern, VersionCodeProperties);
 				} catch (ArgumentOutOfRangeException ex) {
-					Log.LogCodedError ("XA0003", ManifestFile, 0, ex.Message);
+					LogCodedError ("XA0003", ManifestFile, 0, ex.Message);
 					return string.Empty;
 				}
 			}
@@ -121,11 +121,11 @@ namespace Xamarin.Android.Tasks {
 				manifest.SetAbi (currentAbi);
 			}
 			if (!manifest.ValidateVersionCode (out string error, out string errorCode)) {
-				Log.LogCodedError (errorCode, ManifestFile, 0, error);
+				LogCodedError (errorCode, ManifestFile, 0, error);
 				return string.Empty;
 			}
 			manifest.ApplicationName = ApplicationName;
-			manifest.Save (manifestFile);
+			manifest.Save (LogWarning, manifestFile);
 
 			cmd.AppendSwitchIfNotNull ("--manifest ", manifestFile);
 			if (!string.IsNullOrEmpty (JavaDesignerOutputDirectory)) {
@@ -142,7 +142,7 @@ namespace Xamarin.Android.Tasks {
 					if (File.Exists (flata)) {
 						cmd.AppendSwitchIfNotNull ("-R ", flata);
 					} else {
-						Log.LogDebugMessage ("Archive does not exist: " + flata);
+						LogDebugMessage ("Archive does not exist: " + flata);
 					}
 				}
 			}
@@ -152,7 +152,7 @@ namespace Xamarin.Android.Tasks {
 				if (File.Exists (flata)) {
 					cmd.AppendSwitchIfNotNull ("-R ", flata);
 				} else {
-					Log.LogDebugMessage ("Archive does not exist: " + flata);
+					LogDebugMessage ("Archive does not exist: " + flata);
 				}
 			}
 			
@@ -175,7 +175,7 @@ namespace Xamarin.Android.Tasks {
 
 			var extraArgsExpanded = ExpandString (ExtraArgs);
 			if (extraArgsExpanded != ExtraArgs)
-				Log.LogDebugMessage ("  ExtraArgs expanded: {0}", extraArgsExpanded);
+				LogDebugMessage ("  ExtraArgs expanded: {0}", extraArgsExpanded);
 
 			if (!string.IsNullOrWhiteSpace (extraArgsExpanded))
 				cmd.AppendSwitch (extraArgsExpanded);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidTask.cs
@@ -34,12 +34,17 @@ namespace Xamarin.Android.Tasks
 
 		public abstract string TaskPrefix { get; }
 
+		[Obsolete ("You should not use the 'Log' property directly for AsyncTask. Use the 'Log*' methods instead.", error: true)]
+		public new TaskLoggingHelper Log {
+			get => base.Log;
+		}
+
 		public override bool Execute ()
 		{
 			try {
 				return RunTask ();
 			} catch (Exception ex) {
-				Log.LogUnhandledException (TaskPrefix, ex);
+				this.LogUnhandledException (TaskPrefix, ex);
 				return false;
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aot.cs
@@ -84,7 +84,7 @@ namespace Xamarin.Android.Tasks
 
 		public override bool RunTask ()
 		{
-			if (EnableLLVM && !NdkUtil.Init (Log, AndroidNdkDirectory))
+			if (EnableLLVM && !NdkUtil.Init (LogCodedError, AndroidNdkDirectory))
 				return false;
 
 			return base.RunTask ();
@@ -174,11 +174,6 @@ namespace Xamarin.Android.Tasks
 			var builder = new CommandLineBuilder();
 			builder.AppendFileNameIfNotNull(fileName);
 			return builder.ToString();
-		}
-
-		static bool ValidateAotConfiguration (TaskLoggingHelper log, AndroidTargetArch arch, bool enableLLVM)
-		{
-			return true;
 		}
 
 		int GetNdkApiLevel(string androidNdkPath, string androidApiLevel, AndroidTargetArch arch)
@@ -312,12 +307,7 @@ namespace Xamarin.Android.Tasks
 					throw new Exception ("Unsupported Android target architecture ABI: " + abi);
 				}
 
-				if (EnableLLVM && !NdkUtil.ValidateNdkPlatform (Log, AndroidNdkDirectory, arch, enableLLVM:EnableLLVM)) {
-					yield return Config.Invalid;
-					yield break;
-				}
-
-				if (!ValidateAotConfiguration(Log, arch, EnableLLVM)) {
+				if (EnableLLVM && !NdkUtil.ValidateNdkPlatform (LogMessage, LogCodedError, AndroidNdkDirectory, arch, enableLLVM:EnableLLVM)) {
 					yield return Config.Invalid;
 					yield break;
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
@@ -119,7 +119,7 @@ namespace Xamarin.Android.Tasks
 
 			GenerateLayoutBindings.BindingGeneratorLanguage gen;
 			if (!GenerateLayoutBindings.KnownBindingGenerators.TryGetValue (OutputLanguage, out gen) || gen == null) {
-				Log.LogDebugMessage ($"Language {OutputLanguage} isn't supported, will use {GenerateLayoutBindings.DefaultOutputGenerator.Name} instead");
+				LogDebugMessage ($"Language {OutputLanguage} isn't supported, will use {GenerateLayoutBindings.DefaultOutputGenerator.Name} instead");
 				sourceFileExtension = GenerateLayoutBindings.DefaultOutputGenerator.Extension;
 			} else
 				sourceFileExtension = OutputFileExtension;
@@ -138,7 +138,7 @@ namespace Xamarin.Android.Tasks
 			if (layoutsByName.Count >= ParallelGenerationThreshold) {
 				// NOTE: Update the tests in $TOP_DIR/tests/CodeBehind/UnitTests/BuildTests.cs if this message
 				// is changed!
-				Log.LogDebugMessage ($"Parsing layouts in parallel (threshold of {ParallelGenerationThreshold} layouts met)");
+				LogDebugMessage ($"Parsing layouts in parallel (threshold of {ParallelGenerationThreshold} layouts met)");
 
 				await this.WhenAll (layoutsByName, kvp =>
 					ParseAndLoadGroup (layoutsByName, kvp.Key, kvp.Value.InputItems, ref kvp.Value.LayoutBindingItems, ref kvp.Value.LayoutPartialClassItems));
@@ -160,11 +160,11 @@ namespace Xamarin.Android.Tasks
 
 			LayoutBindingFiles = layoutBindingFiles.ToArray ();
 			if (LayoutBindingFiles.Length == 0)
-				Log.LogDebugMessage ("  No layout file qualifies for code-behind generation");
+				LogDebugMessage ("  No layout file qualifies for code-behind generation");
 			LayoutPartialClassFiles = layoutPartialClassFiles.ToArray ();
 
-			Log.LogDebugTaskItems ("  LayoutBindingFiles:", LayoutBindingFiles, true);
-			Log.LogDebugTaskItems ("  LayoutPartialClassFiles:", LayoutPartialClassFiles, true);
+			LogDebugTaskItems ("  LayoutBindingFiles:", LayoutBindingFiles);
+			LogDebugTaskItems ("  LayoutPartialClassFiles:", LayoutPartialClassFiles);
 		}
 
 		void ParseAndLoadGroup (Dictionary <string, LayoutGroup> groupIndex, string groupName, List<ITaskItem> items, ref List<ITaskItem> layoutBindingFiles, ref List<ITaskItem> layoutPartialClassFiles)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckGoogleSdkRequirements.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckGoogleSdkRequirements.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Android.Tasks
 
 		public override bool RunTask ()
 		{
-			ManifestDocument manifest = new ManifestDocument (ManifestFile, this.Log);
+			ManifestDocument manifest = new ManifestDocument (ManifestFile);
 
 			var compileSdk = MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (TargetFrameworkVersion);
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -236,7 +236,7 @@ namespace Xamarin.Android.Tasks
 			}
 
 			// Step 3 - Merge [Activity] and friends into AndroidManifest.xml
-			var manifest = new ManifestDocument (ManifestTemplate, this.Log);
+			var manifest = new ManifestDocument (ManifestTemplate);
 
 			manifest.PackageName = PackageName;
 			manifest.ApplicationName = ApplicationName ?? PackageName;
@@ -250,10 +250,10 @@ namespace Xamarin.Android.Tasks
 			manifest.NeedsInternet = NeedsInternet;
 			manifest.InstantRunEnabled = InstantRunEnabled;
 
-			var additionalProviders = manifest.Merge (all_java_types, ApplicationJavaClass, EmbedAssemblies, BundledWearApplicationName, MergedManifestDocuments);
+			var additionalProviders = manifest.Merge (Log, all_java_types, ApplicationJavaClass, EmbedAssemblies, BundledWearApplicationName, MergedManifestDocuments);
 
 			using (var stream = new MemoryStream ()) {
-				manifest.Save (stream);
+				manifest.Save (Log, stream);
 
 				// Only write the new manifest if it actually changed
 				MonoAndroidHelper.CopyIfStreamChanged (stream, MergedAndroidManifestOutput);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutBindings.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateLayoutBindings.cs
@@ -96,17 +96,17 @@ namespace Xamarin.Android.Tasks
 			BindingGenerator generator = GetBindingGenerator (OutputLanguage);
 
 			if (generator == null) {
-				Log.LogMessage ($"Unknown binding output language '{OutputLanguage}', will use {DefaultOutputGenerator.Name} instead");
+				LogMessage ($"Unknown binding output language '{OutputLanguage}', will use {DefaultOutputGenerator.Name} instead");
 				generator = DefaultOutputGenerator.Creator ();
 			}
 
 			if (generator == null) {
 				// Should "never" happen
-				Log.LogError ($"Cannot find binding generator for language {OutputLanguage} or {DefaultOutputGenerator.Name}");
+				LogError ($"Cannot find binding generator for language {OutputLanguage} or {DefaultOutputGenerator.Name}");
 				return;
 			}
 
-			Log.LogDebugMessage ($"Generating {generator.LanguageName} binding sources");
+			LogDebugMessage ($"Generating {generator.LanguageName} binding sources");
 
 			var layoutGroups = new Dictionary <string, LayoutGroup> (StringComparer.Ordinal);
 			string layoutGroupName;
@@ -133,7 +133,7 @@ namespace Xamarin.Android.Tasks
 					if (!GetRequiredMetadata (item, CalculateLayoutCodeBehind.LayoutGroupMetadata, out layoutGroupName))
 						return;
 					if (!layoutGroups.TryGetValue (layoutGroupName, out group) || group == null) {
-						Log.LogError ($"Partial class item without associated binding for layout group '{layoutGroupName}'");
+						LogError ($"Partial class item without associated binding for layout group '{layoutGroupName}'");
 						return;
 					}
 
@@ -177,7 +177,7 @@ namespace Xamarin.Android.Tasks
 			if (ResourceFiles.Length >= CalculateLayoutCodeBehind.ParallelGenerationThreshold) {
 				// NOTE: Update the tests in $TOP_DIR/tests/CodeBehind/UnitTests/BuildTests.cs if this message
 				// is changed!
-				Log.LogDebugMessage ($"Generating binding code in parallel (threshold of {CalculateLayoutCodeBehind.ParallelGenerationThreshold} layouts met)");
+				LogDebugMessage ($"Generating binding code in parallel (threshold of {CalculateLayoutCodeBehind.ParallelGenerationThreshold} layouts met)");
 				var fileSet = new ConcurrentBag <string> ();
 				await this.WhenAll (layoutGroups, kvp => GenerateSourceForLayoutGroup (generator, kvp.Value, rpath => fileSet.Add (rpath)));
 				generatedFilePaths = fileSet;
@@ -190,8 +190,8 @@ namespace Xamarin.Android.Tasks
 
 			GeneratedFiles = generatedFilePaths.Where (gfp => !String.IsNullOrEmpty (gfp)).Select (gfp => new TaskItem (gfp)).ToArray ();
 			if (GeneratedFiles.Length == 0)
-				Log.LogWarning ("No layout binding source files generated");
-			Log.LogDebugTaskItems ("  GeneratedFiles:", GeneratedFiles);
+				LogWarning ("No layout binding source files generated");
+			LogDebugTaskItems ("  GeneratedFiles:", GeneratedFiles);
 		}
 
 		void GenerateSourceForLayoutGroup (BindingGenerator generator, LayoutGroup group, Action <string> pathAdder)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ManifestMerger.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ManifestMerger.cs
@@ -39,9 +39,9 @@ namespace Xamarin.Android.Tasks
 				bool result = base.Execute ();
 				if (!result)
 					return result;
-				var m = new ManifestDocument (tempFile, Log);
+				var m = new ManifestDocument (tempFile);
 				using (var ms = new MemoryStream ()) {
-					m.Save (ms);
+					m.Save (Log, ms);
 					MonoAndroidHelper.CopyIfStreamChanged (ms, OutputManifestFile);
 					return result;
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtilsOld.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtilsOld.cs
@@ -16,30 +16,30 @@ namespace Xamarin.Android.Tasks
 {
 	public static class NdkUtilOld {
 
-		public static bool ValidateNdkPlatform (TaskLoggingHelper log, string ndkPath, AndroidTargetArch arch, bool enableLLVM)
+		public static bool ValidateNdkPlatform (Action<string> logMessage, Action<string, string> logError, string ndkPath, AndroidTargetArch arch, bool enableLLVM)
 		{
 			// Check that we have a compatible NDK version for the targeted ABIs.
 			NdkVersion ndkVersion;
 			bool hasNdkVersion = GetNdkToolchainRelease (ndkPath, out ndkVersion);
 
 			if (IsNdk64BitArch(arch) && hasNdkVersion && ndkVersion.Version < 10) {
-				log.LogMessage (MessageImportance.High,
-						"The detected Android NDK version is incompatible with the targeted 64-bit architecture, " +
-						"please upgrade to NDK r10 or newer.");
+				logMessage (
+					"The detected Android NDK version is incompatible with the targeted 64-bit architecture, " +
+					"please upgrade to NDK r10 or newer.");
 			}
 
 			// NDK r10d is buggy and cannot link x86_64 ABI shared libraries because they are 32-bits.
 			// See https://code.google.com/p/android/issues/detail?id=161421
 			if (enableLLVM && ndkVersion.Version == 10 && ndkVersion.Revision == "d" && arch == AndroidTargetArch.X86_64) {
-				log.LogCodedError ("XA3004", "Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. " +
-						"See https://code.google.com/p/android/issues/detail?id=161422.");
+				logError ("XA3004", "Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. " +
+					"See https://code.google.com/p/android/issues/detail?id=161422.");
 				return false;
 			}
 
 			if (enableLLVM && (ndkVersion.Version < 10 || (ndkVersion.Version == 10 && ndkVersion.Revision[0] < 'd'))) {
-				log.LogCodedError ("XA3005",
-						"The detected Android NDK version is incompatible with the targeted LLVM configuration, " +
-						"please upgrade to NDK r10d or newer.");
+				logError ("XA3005",
+					"The detected Android NDK version is incompatible with the targeted LLVM configuration, " +
+					"please upgrade to NDK r10d or newer.");
 			}
 
 			return true;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/UnhandledExceptionLogger.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/UnhandledExceptionLogger.cs
@@ -3,74 +3,85 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Build.Utilities;
+using Xamarin.Build;
 
 namespace Xamarin.Android.Tasks
 {
 	static class UnhandledExceptionLogger
 	{
+		public static void LogUnhandledException (this AsyncTask task, string prefix, Exception ex)
+		{
+			LogUnhandledException ((code, message) => task.LogCodedError (code, message), prefix, ex);
+		}
+
 		public static void LogUnhandledException (this TaskLoggingHelper log, string prefix, Exception ex)
+		{
+			LogUnhandledException ((code, message) => log.LogCodedError (code, message), prefix, ex);
+		}
+
+		static void LogUnhandledException (Action<string,string> logCodedError, string prefix, Exception ex)
 		{
 			prefix = "XA" + prefix;
 
 			// Some ordering is necessary here to ensure exceptions are before their base exceptions
 			if (ex is NullReferenceException)
-				log.LogCodedError (prefix + "7001", ex.ToString ());
-			else if (ex is ArgumentOutOfRangeException)	// ArgumentException
-				log.LogCodedError (prefix + "7002", ex.ToString ());
+				logCodedError (prefix + "7001", ex.ToString ());
+			else if (ex is ArgumentOutOfRangeException)     // ArgumentException
+				logCodedError (prefix + "7002", ex.ToString ());
 			else if (ex is ArgumentNullException)           // ArgumentException
-				log.LogCodedError (prefix + "7003", ex.ToString ());
+				logCodedError (prefix + "7003", ex.ToString ());
 			else if (ex is ArgumentException)
-				log.LogCodedError (prefix + "7004", ex.ToString ());
+				logCodedError (prefix + "7004", ex.ToString ());
 			else if (ex is FormatException)
-				log.LogCodedError (prefix + "7005", ex.ToString ());
+				logCodedError (prefix + "7005", ex.ToString ());
 			else if (ex is IndexOutOfRangeException)
-				log.LogCodedError (prefix + "7006", ex.ToString ());
+				logCodedError (prefix + "7006", ex.ToString ());
 			else if (ex is InvalidCastException)
-				log.LogCodedError (prefix + "7007", ex.ToString ());
+				logCodedError (prefix + "7007", ex.ToString ());
 			else if (ex is ObjectDisposedException)		// InvalidOperationException
-				log.LogCodedError (prefix + "7008", ex.ToString ());
+				logCodedError (prefix + "7008", ex.ToString ());
 			else if (ex is InvalidOperationException)
-				log.LogCodedError (prefix + "7009", ex.ToString ());
+				logCodedError (prefix + "7009", ex.ToString ());
 			else if (ex is InvalidProgramException)
-				log.LogCodedError (prefix + "7010", ex.ToString ());
+				logCodedError (prefix + "7010", ex.ToString ());
 			else if (ex is KeyNotFoundException)
-				log.LogCodedError (prefix + "7011", ex.ToString ());
+				logCodedError (prefix + "7011", ex.ToString ());
 			else if (ex is TaskCanceledException)           // OperationCanceledException
-				log.LogCodedError (prefix + "7012", ex.ToString ());
+				logCodedError (prefix + "7012", ex.ToString ());
 			else if (ex is OperationCanceledException)
-				log.LogCodedError (prefix + "7013", ex.ToString ());
+				logCodedError (prefix + "7013", ex.ToString ());
 			else if (ex is OutOfMemoryException)
-				log.LogCodedError (prefix + "7014", ex.ToString ());
+				logCodedError (prefix + "7014", ex.ToString ());
 			else if (ex is NotSupportedException)
-				log.LogCodedError (prefix + "7015", ex.ToString ());
+				logCodedError (prefix + "7015", ex.ToString ());
 			else if (ex is StackOverflowException)
-				log.LogCodedError (prefix + "7016", ex.ToString ());
+				logCodedError (prefix + "7016", ex.ToString ());
 			else if (ex is TimeoutException)
-				log.LogCodedError (prefix + "7017", ex.ToString ());
+				logCodedError (prefix + "7017", ex.ToString ());
 			else if (ex is TypeInitializationException)
-				log.LogCodedError (prefix + "7018", ex.ToString ());
+				logCodedError (prefix + "7018", ex.ToString ());
 			else if (ex is UnauthorizedAccessException)
-				log.LogCodedError (prefix + "7019", ex.ToString ());
+				logCodedError (prefix + "7019", ex.ToString ());
 			else if (ex is ApplicationException)
-				log.LogCodedError (prefix + "7020", ex.ToString ());
+				logCodedError (prefix + "7020", ex.ToString ());
 			else if (ex is KeyNotFoundException)
-				log.LogCodedError (prefix + "7021", ex.ToString ());
+				logCodedError (prefix + "7021", ex.ToString ());
 			else if (ex is PathTooLongException)            // IOException
-				log.LogCodedError (prefix + "7022", ex.ToString ());
+				logCodedError (prefix + "7022", ex.ToString ());
 			else if (ex is DirectoryNotFoundException)      // IOException
-				log.LogCodedError (prefix + "7023", ex.ToString ());
+				logCodedError (prefix + "7023", ex.ToString ());
 			else if (ex is DriveNotFoundException)		// IOException
-				log.LogCodedError (prefix + "7025", ex.ToString ());
+				logCodedError (prefix + "7025", ex.ToString ());
 			else if (ex is EndOfStreamException)		// IOException
-				log.LogCodedError (prefix + "7026", ex.ToString ());
+				logCodedError (prefix + "7026", ex.ToString ());
 			else if (ex is FileLoadException)		// IOException
-				log.LogCodedError (prefix + "7027", ex.ToString ());
+				logCodedError (prefix + "7027", ex.ToString ());
 			else if (ex is FileNotFoundException)		// IOException
-				log.LogCodedError (prefix + "7028", ex.ToString ());
+				logCodedError (prefix + "7028", ex.ToString ());
 			else if (ex is IOException) 
-				log.LogCodedError (prefix + "7024", ex.ToString ());
+				logCodedError (prefix + "7024", ex.ToString ());
 			else
-				log.LogCodedError (prefix + "7000", ex.ToString ());
+				logCodedError (prefix + "7000", ex.ToString ());
 		}
 	}
 }


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/78d56588...017b3618

Bump to xamarin/monodroid/master@017b3618

We have had a continuing concern of accidentally calling
`AsyncTask.Log` from a background thread. If done so, this can cause a
hang inside Visual Studio on Windows.

I finally had the idea of creating a build error if we inadvertently
do this:

    [Obsolete("You should not use the 'Log' property directly for AsyncTask. Use the 'Log*' methods instead.", error: true)]
    public new TaskLoggingHelper Log { get; }

This uncovered 26 build errors! Some were actually on the main thread
and completely OK, but several were not OK.

In most of the places, I could simply change `Log.LogDebugMessage` to
`LogDebugMessage`.

However a few of the more troublesome places:

* `ManifestDocument` required a `TaskLoggingHelper` for its ctor. I
  moved this to only the methods that need it.

* `NdkUtils` and `NdkUtilsOld` I used `Action<string>` and
  `Action<string, string>` callbacks instead.

* The `<Aot/>` task had an empty `ValidateAotConfiguration` method I
  removed.

Going forward, it should be a lot harder for us to introduce a hang by
using `AsyncTask.Log`.