### PR TITLE
[Xamarin.Android.Build.Tasks] Move XA1005 and XA2001 message text into .resx file

### DIFF
--- a/Documentation/guides/messages/xa1005.md
+++ b/Documentation/guides/messages/xa1005.md
@@ -1,7 +1,7 @@
 ---
 title: Xamarin.Android warning XA1005
 description: XA1005 warning code
-ms.date: 11/05/2018
+ms.date: 01/24/2020
 ---
 # Xamarin.Android warning XA1005
 
@@ -9,14 +9,14 @@ ms.date: 11/05/2018
 
 ```
 warning XA1005: Attempting naive type name fixup for element with ID '@+id/text1' and type 'android.widget.TextView'
-warning XA1005: If the above fixup fails, please add `xamarin:managedType` attribute to the element with fully qualified managed type name of the element.
+warning XA1005: If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.
 ```
 
 ## Issue
 
 When [Layout Bindings and Code-Behind][code-behind] are enabled, this warning
 will be emitted for every layout element that has the `//*/@android:id`
-attribute set and uses a fully-qualified name for the element type.
+attribute set and uses a fully qualified name for the element type.
 
 For example, the warning *will* be emitted for both of the following elements:
 
@@ -35,7 +35,7 @@ name like:
     android:id="@+id/text1" />
 ```
 
-The "naive type name fixup" tries to ensure that any fully-qualified type name
+The "naive type name fixup" tries to ensure that any fully qualified type name
 is a C# name rather than a Java name. First it checks a short list of known
 mappings between Java namespaces and C# namespaces, such as the mapping of
 `android.view` to `Android.Views`. For any remaining namespaces, it splits the
@@ -45,7 +45,7 @@ namespace on `.` and capitalizes each part.
 
 To resolve this warning, change each element to use its unqualified C# class
 name or add a [`xamarin:managedType`][code-behind-attributes] attribute to each
-element that specifies the fully qualified C# name.
+element to specify the fully qualified C# name.
 
 [code-behind]: https://github.com/xamarin/xamarin-android/blob/master/Documentation/guides/LayoutCodeBehind.md
 [code-behind-attributes]: https://github.com/xamarin/xamarin-android/blob/master/Documentation/guides/LayoutCodeBehind.md#layout-xml-attributes

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -61,6 +61,33 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Attempting naive type name fixup for element with ID &apos;{0}&apos; and type &apos;{1}&apos;.
+        /// </summary>
+        internal static string XA1005 {
+            get {
+                return ResourceManager.GetString("XA1005", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element..
+        /// </summary>
+        internal static string XA1005_Instructions {
+            get {
+                return ResourceManager.GetString("XA1005_Instructions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Source file &apos;{0}&apos; could not be found..
+        /// </summary>
+        internal static string XA2001 {
+            get {
+                return ResourceManager.GetString("XA2001", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not AOT the assembly: {0}.
         /// </summary>
         internal static string XA3001 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -117,6 +117,17 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="XA1005" xml:space="preserve">
+    <value>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</value>
+    <comment>{0} - The Android resource ID name</comment>
+  </data>
+  <data name="XA1005_Instructions" xml:space="preserve">
+    <value>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</value>
+    <comment>"xamarin:managedType" is a literal name and should not be translated.</comment>
+  </data>
+  <data name="XA2001" xml:space="preserve">
+    <value>Source file '{0}' could not be found.</value>
+  </data>
   <data name="XA3001" xml:space="preserve">
     <value>Could not AOT the assembly: {0}</value>
     <comment>The abbreviation "AOT" should not be translated.</comment>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
     <body>
+      <trans-unit id="XA1005">
+        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <note>{0} - The Android resource ID name</note>
+      </trans-unit>
+      <trans-unit id="XA1005_Instructions">
+        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <note>"xamarin:managedType" is a literal name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA2001">
+        <source>Source file '{0}' could not be found.</source>
+        <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="new">Could not AOT the assembly: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
     <body>
+      <trans-unit id="XA1005">
+        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <note>{0} - The Android resource ID name</note>
+      </trans-unit>
+      <trans-unit id="XA1005_Instructions">
+        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <note>"xamarin:managedType" is a literal name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA2001">
+        <source>Source file '{0}' could not be found.</source>
+        <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="new">Could not AOT the assembly: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
     <body>
+      <trans-unit id="XA1005">
+        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <note>{0} - The Android resource ID name</note>
+      </trans-unit>
+      <trans-unit id="XA1005_Instructions">
+        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <note>"xamarin:managedType" is a literal name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA2001">
+        <source>Source file '{0}' could not be found.</source>
+        <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="new">Could not AOT the assembly: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
     <body>
+      <trans-unit id="XA1005">
+        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <note>{0} - The Android resource ID name</note>
+      </trans-unit>
+      <trans-unit id="XA1005_Instructions">
+        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <note>"xamarin:managedType" is a literal name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA2001">
+        <source>Source file '{0}' could not be found.</source>
+        <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="new">Could not AOT the assembly: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
     <body>
+      <trans-unit id="XA1005">
+        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <note>{0} - The Android resource ID name</note>
+      </trans-unit>
+      <trans-unit id="XA1005_Instructions">
+        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <note>"xamarin:managedType" is a literal name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA2001">
+        <source>Source file '{0}' could not be found.</source>
+        <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="new">Could not AOT the assembly: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
     <body>
+      <trans-unit id="XA1005">
+        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <note>{0} - The Android resource ID name</note>
+      </trans-unit>
+      <trans-unit id="XA1005_Instructions">
+        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <note>"xamarin:managedType" is a literal name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA2001">
+        <source>Source file '{0}' could not be found.</source>
+        <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="new">Could not AOT the assembly: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
     <body>
+      <trans-unit id="XA1005">
+        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <note>{0} - The Android resource ID name</note>
+      </trans-unit>
+      <trans-unit id="XA1005_Instructions">
+        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <note>"xamarin:managedType" is a literal name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA2001">
+        <source>Source file '{0}' could not be found.</source>
+        <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="new">Could not AOT the assembly: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
     <body>
+      <trans-unit id="XA1005">
+        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <note>{0} - The Android resource ID name</note>
+      </trans-unit>
+      <trans-unit id="XA1005_Instructions">
+        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <note>"xamarin:managedType" is a literal name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA2001">
+        <source>Source file '{0}' could not be found.</source>
+        <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="new">Could not AOT the assembly: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
     <body>
+      <trans-unit id="XA1005">
+        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <note>{0} - The Android resource ID name</note>
+      </trans-unit>
+      <trans-unit id="XA1005_Instructions">
+        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <note>"xamarin:managedType" is a literal name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA2001">
+        <source>Source file '{0}' could not be found.</source>
+        <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="new">Could not AOT the assembly: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
     <body>
+      <trans-unit id="XA1005">
+        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <note>{0} - The Android resource ID name</note>
+      </trans-unit>
+      <trans-unit id="XA1005_Instructions">
+        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <note>"xamarin:managedType" is a literal name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA2001">
+        <source>Source file '{0}' could not be found.</source>
+        <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="new">Could not AOT the assembly: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
     <body>
+      <trans-unit id="XA1005">
+        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <note>{0} - The Android resource ID name</note>
+      </trans-unit>
+      <trans-unit id="XA1005_Instructions">
+        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <note>"xamarin:managedType" is a literal name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA2001">
+        <source>Source file '{0}' could not be found.</source>
+        <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="new">Could not AOT the assembly: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
     <body>
+      <trans-unit id="XA1005">
+        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <note>{0} - The Android resource ID name</note>
+      </trans-unit>
+      <trans-unit id="XA1005_Instructions">
+        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <note>"xamarin:managedType" is a literal name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA2001">
+        <source>Source file '{0}' could not be found.</source>
+        <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="new">Could not AOT the assembly: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
     <body>
+      <trans-unit id="XA1005">
+        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <note>{0} - The Android resource ID name</note>
+      </trans-unit>
+      <trans-unit id="XA1005_Instructions">
+        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <note>"xamarin:managedType" is a literal name and should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA2001">
+        <source>Source file '{0}' could not be found.</source>
+        <target state="new">Source file '{0}' could not be found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
         <target state="new">Could not AOT the assembly: {0}</target>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidUpdateResDir.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidUpdateResDir.cs
@@ -126,7 +126,7 @@ namespace Xamarin.Android.Tasks
 					dest = Path.GetFullPath (Path.Combine (IntermediateDir, Path.GetFileName (baseFileName)));
 				}
 				if (!File.Exists (item.ItemSpec)) {
-					Log.LogCodedError ("XA2001", file: item.ItemSpec, lineNumber: 0, message: $"Source file '{item.ItemSpec}' could not be found.");
+					Log.LogCodedError ("XA2001", file: item.ItemSpec, lineNumber: 0, message: Properties.Resources.XA2001, item.ItemSpec);
 					continue;
 				}
 				var newItem = new TaskItem (dest);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CalculateLayoutCodeBehind.cs
@@ -297,8 +297,8 @@ namespace Xamarin.Android.Tasks
 					managedType = managedType.Substring (0, idx).Trim ();
 
 				if (mayNeedTypeFixup && (idx = managedType.LastIndexOf ('.')) >= 0) {
-					LogCodedWarning ("XA1005", $"Attempting naive type name fixup for element with ID '{id}' and type '{managedType}'");
-					LogCodedWarning ("XA1005", "If the above fixup fails, please add `xamarin:managedType` attribute to the element with fully qualified managed type name of the element");
+					LogCodedWarning ("XA1005", Properties.Resources.XA1005, id, managedType);
+					LogCodedWarning ("XA1005", Properties.Resources.XA1005_Instructions);
 
 					oldType = managedType;
 					string ns = managedType.Substring (0, idx);


### PR DESCRIPTION
Context: [0342fe56][0]
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Other changes:

Add a couple words to one of the XA1005 messages so it reads more like a
full sentence.  Hopefully that will be helpful for the translation team.

[0]: https://github.com/xamarin/xamarin-android/commit/0342fe5698b86e21e36c924732ff135b9a87e4af