### PR TITLE
[Xamarin.Android.Build.Tasks] Move XA4301 and XA0107 message text into .resx file

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -61,6 +61,24 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} is a Reference Assembly..
+        /// </summary>
+        internal static string XA0107 {
+            get {
+                return ResourceManager.GetString("XA0107", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ignoring Reference Assembly `{0}`..
+        /// </summary>
+        internal static string XA0107_Ignoring {
+            get {
+                return ResourceManager.GetString("XA0107_Ignoring", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Attempting naive type name fixup for element with ID &apos;{0}&apos; and type &apos;{1}&apos;.
         /// </summary>
         internal static string XA1005 {
@@ -165,6 +183,33 @@ namespace Xamarin.Android.Tasks.Properties {
         internal static string XA4214_Result {
             get {
                 return ResourceManager.GetString("XA4214_Result", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to APK already contains the item {0}; ignoring..
+        /// </summary>
+        internal static string XA4301 {
+            get {
+                return ResourceManager.GetString("XA4301", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot determine ABI of native library {0}..
+        /// </summary>
+        internal static string XA4301_ABI {
+            get {
+                return ResourceManager.GetString("XA4301_ABI", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not determine ABI of some native libraries. Ignoring those: {0}.
+        /// </summary>
+        internal static string XA4301_ABI_Ignoring {
+            get {
+                return ResourceManager.GetString("XA4301_ABI_Ignoring", resourceCulture);
             }
         }
         

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -117,6 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="XA0107" xml:space="preserve">
+    <value>{0} is a Reference Assembly.</value>
+  </data>
+  <data name="XA0107_Ignoring" xml:space="preserve">
+    <value>Ignoring Reference Assembly `{0}`.</value>
+    <comment>{0} - File name of the assembly.</comment>
+  </data>
   <data name="XA1005" xml:space="preserve">
     <value>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</value>
     <comment>{0} - The Android resource ID name</comment>
@@ -165,6 +172,20 @@
     <comment>The phrase "`{0}, {1}`" does not need to be translated.
 {0} - The managed type name
 {1} - The name of the library that contains the type</comment>
+  </data>
+  <data name="XA4301" xml:space="preserve">
+    <value>APK already contains the item {0}; ignoring.</value>
+    <comment>The abbreviation "APK" should not be translated.
+{0} - The file name.</comment>
+  </data>
+  <data name="XA4301_ABI" xml:space="preserve">
+    <value>Cannot determine ABI of native library {0}.</value>
+    <comment>The abbreviation "ABI" should not be translated.</comment>
+  </data>
+  <data name="XA4301_ABI_Ignoring" xml:space="preserve">
+    <value>Could not determine ABI of some native libraries. Ignoring those: {0}</value>
+    <comment>The abbreviation "ABI" should not be translated.
+{0} - Comma-separated list of the ignored library file names.</comment>
   </data>
   <data name="XA5301" xml:space="preserve">
     <value>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
     <body>
+      <trans-unit id="XA0107">
+        <source>{0} is a Reference Assembly.</source>
+        <target state="new">{0} is a Reference Assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA0107_Ignoring">
+        <source>Ignoring Reference Assembly `{0}`.</source>
+        <target state="new">Ignoring Reference Assembly `{0}`.</target>
+        <note>{0} - File name of the assembly.</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
@@ -65,6 +75,23 @@
         <note>The phrase "`{0}, {1}`" does not need to be translated.
 {0} - The managed type name
 {1} - The name of the library that contains the type</note>
+      </trans-unit>
+      <trans-unit id="XA4301">
+        <source>APK already contains the item {0}; ignoring.</source>
+        <target state="new">APK already contains the item {0}; ignoring.</target>
+        <note>The abbreviation "APK" should not be translated.
+{0} - The file name.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI">
+        <source>Cannot determine ABI of native library {0}.</source>
+        <target state="new">Cannot determine ABI of native library {0}.</target>
+        <note>The abbreviation "ABI" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI_Ignoring">
+        <source>Could not determine ABI of some native libraries. Ignoring those: {0}</source>
+        <target state="new">Could not determine ABI of some native libraries. Ignoring those: {0}</target>
+        <note>The abbreviation "ABI" should not be translated.
+{0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
     <body>
+      <trans-unit id="XA0107">
+        <source>{0} is a Reference Assembly.</source>
+        <target state="new">{0} is a Reference Assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA0107_Ignoring">
+        <source>Ignoring Reference Assembly `{0}`.</source>
+        <target state="new">Ignoring Reference Assembly `{0}`.</target>
+        <note>{0} - File name of the assembly.</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
@@ -65,6 +75,23 @@
         <note>The phrase "`{0}, {1}`" does not need to be translated.
 {0} - The managed type name
 {1} - The name of the library that contains the type</note>
+      </trans-unit>
+      <trans-unit id="XA4301">
+        <source>APK already contains the item {0}; ignoring.</source>
+        <target state="new">APK already contains the item {0}; ignoring.</target>
+        <note>The abbreviation "APK" should not be translated.
+{0} - The file name.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI">
+        <source>Cannot determine ABI of native library {0}.</source>
+        <target state="new">Cannot determine ABI of native library {0}.</target>
+        <note>The abbreviation "ABI" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI_Ignoring">
+        <source>Could not determine ABI of some native libraries. Ignoring those: {0}</source>
+        <target state="new">Could not determine ABI of some native libraries. Ignoring those: {0}</target>
+        <note>The abbreviation "ABI" should not be translated.
+{0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
     <body>
+      <trans-unit id="XA0107">
+        <source>{0} is a Reference Assembly.</source>
+        <target state="new">{0} is a Reference Assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA0107_Ignoring">
+        <source>Ignoring Reference Assembly `{0}`.</source>
+        <target state="new">Ignoring Reference Assembly `{0}`.</target>
+        <note>{0} - File name of the assembly.</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
@@ -65,6 +75,23 @@
         <note>The phrase "`{0}, {1}`" does not need to be translated.
 {0} - The managed type name
 {1} - The name of the library that contains the type</note>
+      </trans-unit>
+      <trans-unit id="XA4301">
+        <source>APK already contains the item {0}; ignoring.</source>
+        <target state="new">APK already contains the item {0}; ignoring.</target>
+        <note>The abbreviation "APK" should not be translated.
+{0} - The file name.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI">
+        <source>Cannot determine ABI of native library {0}.</source>
+        <target state="new">Cannot determine ABI of native library {0}.</target>
+        <note>The abbreviation "ABI" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI_Ignoring">
+        <source>Could not determine ABI of some native libraries. Ignoring those: {0}</source>
+        <target state="new">Could not determine ABI of some native libraries. Ignoring those: {0}</target>
+        <note>The abbreviation "ABI" should not be translated.
+{0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
     <body>
+      <trans-unit id="XA0107">
+        <source>{0} is a Reference Assembly.</source>
+        <target state="new">{0} is a Reference Assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA0107_Ignoring">
+        <source>Ignoring Reference Assembly `{0}`.</source>
+        <target state="new">Ignoring Reference Assembly `{0}`.</target>
+        <note>{0} - File name of the assembly.</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
@@ -65,6 +75,23 @@
         <note>The phrase "`{0}, {1}`" does not need to be translated.
 {0} - The managed type name
 {1} - The name of the library that contains the type</note>
+      </trans-unit>
+      <trans-unit id="XA4301">
+        <source>APK already contains the item {0}; ignoring.</source>
+        <target state="new">APK already contains the item {0}; ignoring.</target>
+        <note>The abbreviation "APK" should not be translated.
+{0} - The file name.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI">
+        <source>Cannot determine ABI of native library {0}.</source>
+        <target state="new">Cannot determine ABI of native library {0}.</target>
+        <note>The abbreviation "ABI" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI_Ignoring">
+        <source>Could not determine ABI of some native libraries. Ignoring those: {0}</source>
+        <target state="new">Could not determine ABI of some native libraries. Ignoring those: {0}</target>
+        <note>The abbreviation "ABI" should not be translated.
+{0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
     <body>
+      <trans-unit id="XA0107">
+        <source>{0} is a Reference Assembly.</source>
+        <target state="new">{0} is a Reference Assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA0107_Ignoring">
+        <source>Ignoring Reference Assembly `{0}`.</source>
+        <target state="new">Ignoring Reference Assembly `{0}`.</target>
+        <note>{0} - File name of the assembly.</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
@@ -65,6 +75,23 @@
         <note>The phrase "`{0}, {1}`" does not need to be translated.
 {0} - The managed type name
 {1} - The name of the library that contains the type</note>
+      </trans-unit>
+      <trans-unit id="XA4301">
+        <source>APK already contains the item {0}; ignoring.</source>
+        <target state="new">APK already contains the item {0}; ignoring.</target>
+        <note>The abbreviation "APK" should not be translated.
+{0} - The file name.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI">
+        <source>Cannot determine ABI of native library {0}.</source>
+        <target state="new">Cannot determine ABI of native library {0}.</target>
+        <note>The abbreviation "ABI" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI_Ignoring">
+        <source>Could not determine ABI of some native libraries. Ignoring those: {0}</source>
+        <target state="new">Could not determine ABI of some native libraries. Ignoring those: {0}</target>
+        <note>The abbreviation "ABI" should not be translated.
+{0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
     <body>
+      <trans-unit id="XA0107">
+        <source>{0} is a Reference Assembly.</source>
+        <target state="new">{0} is a Reference Assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA0107_Ignoring">
+        <source>Ignoring Reference Assembly `{0}`.</source>
+        <target state="new">Ignoring Reference Assembly `{0}`.</target>
+        <note>{0} - File name of the assembly.</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
@@ -65,6 +75,23 @@
         <note>The phrase "`{0}, {1}`" does not need to be translated.
 {0} - The managed type name
 {1} - The name of the library that contains the type</note>
+      </trans-unit>
+      <trans-unit id="XA4301">
+        <source>APK already contains the item {0}; ignoring.</source>
+        <target state="new">APK already contains the item {0}; ignoring.</target>
+        <note>The abbreviation "APK" should not be translated.
+{0} - The file name.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI">
+        <source>Cannot determine ABI of native library {0}.</source>
+        <target state="new">Cannot determine ABI of native library {0}.</target>
+        <note>The abbreviation "ABI" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI_Ignoring">
+        <source>Could not determine ABI of some native libraries. Ignoring those: {0}</source>
+        <target state="new">Could not determine ABI of some native libraries. Ignoring those: {0}</target>
+        <note>The abbreviation "ABI" should not be translated.
+{0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
     <body>
+      <trans-unit id="XA0107">
+        <source>{0} is a Reference Assembly.</source>
+        <target state="new">{0} is a Reference Assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA0107_Ignoring">
+        <source>Ignoring Reference Assembly `{0}`.</source>
+        <target state="new">Ignoring Reference Assembly `{0}`.</target>
+        <note>{0} - File name of the assembly.</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
@@ -65,6 +75,23 @@
         <note>The phrase "`{0}, {1}`" does not need to be translated.
 {0} - The managed type name
 {1} - The name of the library that contains the type</note>
+      </trans-unit>
+      <trans-unit id="XA4301">
+        <source>APK already contains the item {0}; ignoring.</source>
+        <target state="new">APK already contains the item {0}; ignoring.</target>
+        <note>The abbreviation "APK" should not be translated.
+{0} - The file name.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI">
+        <source>Cannot determine ABI of native library {0}.</source>
+        <target state="new">Cannot determine ABI of native library {0}.</target>
+        <note>The abbreviation "ABI" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI_Ignoring">
+        <source>Could not determine ABI of some native libraries. Ignoring those: {0}</source>
+        <target state="new">Could not determine ABI of some native libraries. Ignoring those: {0}</target>
+        <note>The abbreviation "ABI" should not be translated.
+{0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
     <body>
+      <trans-unit id="XA0107">
+        <source>{0} is a Reference Assembly.</source>
+        <target state="new">{0} is a Reference Assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA0107_Ignoring">
+        <source>Ignoring Reference Assembly `{0}`.</source>
+        <target state="new">Ignoring Reference Assembly `{0}`.</target>
+        <note>{0} - File name of the assembly.</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
@@ -65,6 +75,23 @@
         <note>The phrase "`{0}, {1}`" does not need to be translated.
 {0} - The managed type name
 {1} - The name of the library that contains the type</note>
+      </trans-unit>
+      <trans-unit id="XA4301">
+        <source>APK already contains the item {0}; ignoring.</source>
+        <target state="new">APK already contains the item {0}; ignoring.</target>
+        <note>The abbreviation "APK" should not be translated.
+{0} - The file name.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI">
+        <source>Cannot determine ABI of native library {0}.</source>
+        <target state="new">Cannot determine ABI of native library {0}.</target>
+        <note>The abbreviation "ABI" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI_Ignoring">
+        <source>Could not determine ABI of some native libraries. Ignoring those: {0}</source>
+        <target state="new">Could not determine ABI of some native libraries. Ignoring those: {0}</target>
+        <note>The abbreviation "ABI" should not be translated.
+{0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
     <body>
+      <trans-unit id="XA0107">
+        <source>{0} is a Reference Assembly.</source>
+        <target state="new">{0} is a Reference Assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA0107_Ignoring">
+        <source>Ignoring Reference Assembly `{0}`.</source>
+        <target state="new">Ignoring Reference Assembly `{0}`.</target>
+        <note>{0} - File name of the assembly.</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
@@ -65,6 +75,23 @@
         <note>The phrase "`{0}, {1}`" does not need to be translated.
 {0} - The managed type name
 {1} - The name of the library that contains the type</note>
+      </trans-unit>
+      <trans-unit id="XA4301">
+        <source>APK already contains the item {0}; ignoring.</source>
+        <target state="new">APK already contains the item {0}; ignoring.</target>
+        <note>The abbreviation "APK" should not be translated.
+{0} - The file name.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI">
+        <source>Cannot determine ABI of native library {0}.</source>
+        <target state="new">Cannot determine ABI of native library {0}.</target>
+        <note>The abbreviation "ABI" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI_Ignoring">
+        <source>Could not determine ABI of some native libraries. Ignoring those: {0}</source>
+        <target state="new">Could not determine ABI of some native libraries. Ignoring those: {0}</target>
+        <note>The abbreviation "ABI" should not be translated.
+{0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
     <body>
+      <trans-unit id="XA0107">
+        <source>{0} is a Reference Assembly.</source>
+        <target state="new">{0} is a Reference Assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA0107_Ignoring">
+        <source>Ignoring Reference Assembly `{0}`.</source>
+        <target state="new">Ignoring Reference Assembly `{0}`.</target>
+        <note>{0} - File name of the assembly.</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
@@ -65,6 +75,23 @@
         <note>The phrase "`{0}, {1}`" does not need to be translated.
 {0} - The managed type name
 {1} - The name of the library that contains the type</note>
+      </trans-unit>
+      <trans-unit id="XA4301">
+        <source>APK already contains the item {0}; ignoring.</source>
+        <target state="new">APK already contains the item {0}; ignoring.</target>
+        <note>The abbreviation "APK" should not be translated.
+{0} - The file name.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI">
+        <source>Cannot determine ABI of native library {0}.</source>
+        <target state="new">Cannot determine ABI of native library {0}.</target>
+        <note>The abbreviation "ABI" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI_Ignoring">
+        <source>Could not determine ABI of some native libraries. Ignoring those: {0}</source>
+        <target state="new">Could not determine ABI of some native libraries. Ignoring those: {0}</target>
+        <note>The abbreviation "ABI" should not be translated.
+{0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
     <body>
+      <trans-unit id="XA0107">
+        <source>{0} is a Reference Assembly.</source>
+        <target state="new">{0} is a Reference Assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA0107_Ignoring">
+        <source>Ignoring Reference Assembly `{0}`.</source>
+        <target state="new">Ignoring Reference Assembly `{0}`.</target>
+        <note>{0} - File name of the assembly.</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
@@ -65,6 +75,23 @@
         <note>The phrase "`{0}, {1}`" does not need to be translated.
 {0} - The managed type name
 {1} - The name of the library that contains the type</note>
+      </trans-unit>
+      <trans-unit id="XA4301">
+        <source>APK already contains the item {0}; ignoring.</source>
+        <target state="new">APK already contains the item {0}; ignoring.</target>
+        <note>The abbreviation "APK" should not be translated.
+{0} - The file name.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI">
+        <source>Cannot determine ABI of native library {0}.</source>
+        <target state="new">Cannot determine ABI of native library {0}.</target>
+        <note>The abbreviation "ABI" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI_Ignoring">
+        <source>Could not determine ABI of some native libraries. Ignoring those: {0}</source>
+        <target state="new">Could not determine ABI of some native libraries. Ignoring those: {0}</target>
+        <note>The abbreviation "ABI" should not be translated.
+{0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
     <body>
+      <trans-unit id="XA0107">
+        <source>{0} is a Reference Assembly.</source>
+        <target state="new">{0} is a Reference Assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA0107_Ignoring">
+        <source>Ignoring Reference Assembly `{0}`.</source>
+        <target state="new">Ignoring Reference Assembly `{0}`.</target>
+        <note>{0} - File name of the assembly.</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
@@ -65,6 +75,23 @@
         <note>The phrase "`{0}, {1}`" does not need to be translated.
 {0} - The managed type name
 {1} - The name of the library that contains the type</note>
+      </trans-unit>
+      <trans-unit id="XA4301">
+        <source>APK already contains the item {0}; ignoring.</source>
+        <target state="new">APK already contains the item {0}; ignoring.</target>
+        <note>The abbreviation "APK" should not be translated.
+{0} - The file name.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI">
+        <source>Cannot determine ABI of native library {0}.</source>
+        <target state="new">Cannot determine ABI of native library {0}.</target>
+        <note>The abbreviation "ABI" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI_Ignoring">
+        <source>Could not determine ABI of some native libraries. Ignoring those: {0}</source>
+        <target state="new">Could not determine ABI of some native libraries. Ignoring those: {0}</target>
+        <note>The abbreviation "ABI" should not be translated.
+{0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -2,6 +2,16 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
     <body>
+      <trans-unit id="XA0107">
+        <source>{0} is a Reference Assembly.</source>
+        <target state="new">{0} is a Reference Assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XA0107_Ignoring">
+        <source>Ignoring Reference Assembly `{0}`.</source>
+        <target state="new">Ignoring Reference Assembly `{0}`.</target>
+        <note>{0} - File name of the assembly.</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
@@ -65,6 +75,23 @@
         <note>The phrase "`{0}, {1}`" does not need to be translated.
 {0} - The managed type name
 {1} - The name of the library that contains the type</note>
+      </trans-unit>
+      <trans-unit id="XA4301">
+        <source>APK already contains the item {0}; ignoring.</source>
+        <target state="new">APK already contains the item {0}; ignoring.</target>
+        <note>The abbreviation "APK" should not be translated.
+{0} - The file name.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI">
+        <source>Cannot determine ABI of native library {0}.</source>
+        <target state="new">Cannot determine ABI of native library {0}.</target>
+        <note>The abbreviation "ABI" should not be translated.</note>
+      </trans-unit>
+      <trans-unit id="XA4301_ABI_Ignoring">
+        <source>Could not determine ABI of some native libraries. Ignoring those: {0}</source>
+        <target state="new">Could not determine ABI of some native libraries. Ignoring those: {0}</target>
+        <note>The abbreviation "ABI" should not be translated.
+{0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BuildApk.cs
@@ -295,7 +295,7 @@ namespace Xamarin.Android.Tasks
 					continue;
 				}
 				if (MonoAndroidHelper.IsReferenceAssembly (assembly.ItemSpec)) {
-					Log.LogCodedWarning ("XA0107", assembly.ItemSpec, 0, "{0} is a Reference Assembly!", assembly.ItemSpec);
+					Log.LogCodedWarning ("XA0107", assembly.ItemSpec, 0, Properties.Resources.XA0107, assembly.ItemSpec);
 				}
 				// Add assembly
 				AddFileToArchiveIfNewer (apk, assembly.ItemSpec, GetTargetDirectory (assembly.ItemSpec) + "/"  + Path.GetFileName (assembly.ItemSpec), compressionMethod: UncompressedMethod);
@@ -334,7 +334,7 @@ namespace Xamarin.Android.Tasks
 					continue;
 				}
 				if (MonoAndroidHelper.IsReferenceAssembly (assembly.ItemSpec)) {
-					Log.LogCodedWarning ("XA0107", assembly.ItemSpec, 0, "{0} is a Reference Assembly!", assembly.ItemSpec);
+					Log.LogCodedWarning ("XA0107", assembly.ItemSpec, 0, Properties.Resources.XA0107, assembly.ItemSpec);
 				}
 				AddFileToArchiveIfNewer (apk, assembly.ItemSpec, AssembliesPath + Path.GetFileName (assembly.ItemSpec), compressionMethod: UncompressedMethod);
 				var config = Path.ChangeExtension (assembly.ItemSpec, "dll.config");
@@ -518,7 +518,7 @@ namespace Xamarin.Android.Tasks
 			var lib_abi = MonoAndroidHelper.GetNativeLibraryAbi (lib);
 			
 			if (string.IsNullOrWhiteSpace (lib_abi)) {
-				Log.LogCodedError ("XA4301", lib.ItemSpec, 0, "Cannot determine abi of native library {0}.", lib.ItemSpec);
+				Log.LogCodedError ("XA4301", lib.ItemSpec, 0, Properties.Resources.XA4301_ABI, lib.ItemSpec);
 				return null;
 			}
 
@@ -530,8 +530,8 @@ namespace Xamarin.Android.Tasks
 			if (libs.Any (lib => lib.Abi == null))
 				Log.LogCodedWarning (
 						"XA4301",
-						"Could not determine abi of some native libraries, ignoring those: " +
-				                    string.Join (", ", libs.Where (lib => lib.Abi == null).Select (lib => lib.Path)));
+						Properties.Resources.XA4301_ABI_Ignoring,
+						string.Join (", ", libs.Where (lib => lib.Abi == null).Select (lib => lib.Path)));
 			libs = libs.Where (lib => lib.Abi != null);
 			libs = libs.Where (lib => supportedAbis.Contains (lib.Abi));
 			foreach (var arm in ArmAbis)
@@ -558,7 +558,7 @@ namespace Xamarin.Android.Tasks
 			string filename = "/" + Path.GetFileName (item.filePath);
 			string inArchivePath = item.archivePath + filename;
 			if (files.Any (x => (x.archivePath + "/" + Path.GetFileName(x.filePath)) == inArchivePath)) {
-				Log.LogCodedWarning ("XA4301", path, 0, $"Apk already contains the item {inArchivePath}; ignoring.");
+				Log.LogCodedWarning ("XA4301", path, 0, Properties.Resources.XA4301, inArchivePath);
 				return;
 			}
 			files.Add (item);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -92,7 +92,7 @@ namespace Xamarin.Android.Tasks
 							resolved_assembly = ResolveRuntimeAssemblyForReferenceAssembly (lockFile, assembly.ItemSpec);
 						if (lockFile == null || resolved_assembly == null) {
 							var file  = resolved_assembly ?? assembly.ItemSpec;
-							LogCodedWarning ("XA0107", file, 0, "Ignoring Reference Assembly `{0}`.", file);
+							LogCodedWarning ("XA0107", file, 0, Properties.Resources.XA0107_Ignoring, file);
 							continue;
 						}
 					}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -2202,7 +2202,7 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 						Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
 						var apk = Path.Combine (Root, builder.ProjectDirectory,
 							proj.IntermediateOutputPath, "android", "bin", "UnnamedProject.UnnamedProject.apk");
-						Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, "warning XA4301: Apk already contains the item lib/armeabi-v7a/libRSSupport.so; ignoring."),
+						Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, "warning XA4301: APK already contains the item lib/armeabi-v7a/libRSSupport.so; ignoring."),
 							"warning about skipping libRSSupport.so should have been raised");
 						using (var zipFile = ZipHelper.OpenZip (apk)) {
 							var data = ZipHelper.ReadFileFromZip (zipFile, "lib/x86/libtest.so");
@@ -2249,7 +2249,7 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 			using (var builder = CreateApkBuilder (Path.Combine ("temp", TestContext.CurrentContext.Test.Name))) {
 				builder.ThrowOnBuildFailure = false;
 				Assert.IsFalse (builder.Build (proj), "Build should have failed.");
-				Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, $"error XA4301: Cannot determine abi of native library not-a-real-abi{Path.DirectorySeparatorChar}libtest.so."),
+				Assert.IsTrue (StringAssertEx.ContainsText (builder.LastBuildOutput, $"error XA4301: Cannot determine ABI of native library not-a-real-abi{Path.DirectorySeparatorChar}libtest.so."),
 					"error about libtest.so should have been raised");
 			}
 		}


### PR DESCRIPTION
Context: [0342fe56][0]
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Move the text for the XA4301 and XA0107 messages into the `.resx` file.

Other changes:

Standardize the capitalization of "APK" and "ABI" in the messages.

Replace an exclamation point with a period in one of the XA0107 messages
to make the message a little gentler.

Replace a comma with a period in one of the XA4301 messages.

[0]: https://github.com/xamarin/xamarin-android/commit/0342fe5698b86e21e36c924732ff135b9a87e4af