### PR TITLE
[Xamarin.Android.Build.Tasks] Run `aapt2 compile` incrementally.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
         "bin/TestDebug/MSBuildDeviceIntegration/MSBuildDeviceIntegration.dll",
         "bin/TestDebug/Xamarin.Android.Build.Tests.dll",
         "bin/TestDebug/Xamarin.Android.Build.Tests.Commercial.dll",
-    ]
+    ],
+    "cmake.configureOnOpen": false
 }

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt.targets
@@ -22,10 +22,10 @@ Copyright (C) 2019  Microsoft Corporation. All rights reserved.
       $(_UpdateAndroidResgenInputs);
       @(_LibraryResourceDirectoryStamps);
     </_UpdateAndroidResgenInputs>
-      <_CreateBaseApkInputs>
-        $(_CreateBaseApkInputs);
-        @(_LibraryResourceDirectoryStamps);
-      </_CreateBaseApkInputs>
+    <_CreateBaseApkInputs>
+      $(_CreateBaseApkInputs);
+      @(_LibraryResourceDirectoryStamps);
+    </_CreateBaseApkInputs>
   </PropertyGroup>
 </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt.targets
@@ -16,6 +16,19 @@ Copyright (C) 2019  Microsoft Corporation. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+<Target Name="_InjectAaptDependencies" AfterTargets="_ResolveSdks" Condition=" '$(_AndroidUseAapt2)' != 'True' ">
+  <PropertyGroup>
+    <_UpdateAndroidResgenInputs>
+      $(_UpdateAndroidResgenInputs);
+      @(_LibraryResourceDirectoryStamps);
+    </_UpdateAndroidResgenInputs>
+      <_CreateBaseApkInputs>
+        $(_CreateBaseApkInputs);
+        @(_LibraryResourceDirectoryStamps);
+      </_CreateBaseApkInputs>
+  </PropertyGroup>
+</Target>
+
 <Target Name="_UpdateAndroidResgenAapt"
     Condition="'$(_AndroidUseAapt2)' != 'True'">
 

--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
@@ -17,6 +17,30 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+<PropertyGroup>
+  <Aapt2DaemonMaxInstanceCount Condition=" '$(Aapt2DaemonMaxInstanceCount)' == '' " >0</Aapt2DaemonMaxInstanceCount>
+  <_Aapt2DaemonKeepInDomain Condition=" '$(_Aapt2DaemonKeepInDomain)' == '' ">false</_Aapt2DaemonKeepInDomain>
+</PropertyGroup>
+
+
+<Target Name="_InjectAapt2Dependencies" AfterTargets="_ResolveSdks" Condition=" '$(_AndroidUseAapt2)' == 'True' ">
+  <PropertyGroup>
+    <_SetLatestTargetFrameworkVersionDependsOnTargets>
+      $(_SetLatestTargetFrameworkVersionDependsOnTargets);
+      _CreateAapt2VersionCache;
+    </_SetLatestTargetFrameworkVersionDependsOnTargets>
+    <_PrepareUpdateAndroidResgenDependsOnTargets>
+      _CompileResources;
+      _Aapt2UpdateAndroidResgenInputs;
+      $(_PrepareUpdateAndroidResgenDependsOnTargets);
+    </_PrepareUpdateAndroidResgenDependsOnTargets>
+    <_AfterConvertCustomView>
+      $(_AfterConvertCustomView);
+      _FixupCustomViewsForAapt2;
+    </_AfterConvertCustomView>
+  </PropertyGroup>
+</Target>
+
 <Target Name="_ReadAapt2VersionCache">
   <ReadLinesFromFile File="$(_AndroidAapt2VersionFile)"
       Condition="Exists('$(_AndroidAapt2VersionFile)')">
@@ -37,7 +61,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   />
   <ItemGroup Condition="'$(_Aapt2Version)' != '@(_Aapt2VersionCache)'">
     <_CompiledFlataArchive Include="$(_AndroidLibrayProjectIntermediatePath)**\*.flata" />
-    <_CompiledFlataArchive Include="$(IntermediateOutputPath)\*.flata" />
+    <_CompiledFlataArchive Include="$(_AndroidLibrayProjectIntermediatePath)**\*.flat" />
+    <_CompiledFlataArchive Include="$(_AndroidLibraryFlatFilesDirectory)*.flat" />
+    <_CompiledFlataArchive Include="$(_AndroidLibraryFlatArchivesDirectory)\*.flata" />
     <_CompiledFlataStamp Include="$(_AndroidLibrayProjectIntermediatePath)**\compiled.stamp" />
   </ItemGroup>
   <Delete
@@ -54,68 +80,19 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       LibraryProjectIntermediatePath="$(_AndroidLibrayProjectIntermediatePath)"
       StampDirectory="$(_AndroidStampDirectory)">
     <Output TaskParameter="Output" ItemName="_LibraryResourceDirectories" />
+    <Output TaskParameter="LibraryResourceFiles" ItemName="_LibraryResourceFiles" />
+    <Output TaskParameter="LibraryResourceFiles" ItemName="_CompileResourcesInputs" />
   </CollectNonEmptyDirectories>
-  <ComputeHash Source="@(_LibraryResourceDirectories)"  >
-    <Output TaskParameter="Output" ItemName="_LibraryResourceHashDirectories" />
-  </ComputeHash>
-</Target>
-
-<Target Name="_ConvertLibraryResourcesCases"
-    Condition=" '$(_AndroidUseAapt2)' == 'True' "
-    DependsOnTargets="_CollectLibraryResourceDirectories"
-    Inputs="@(_LibraryResourceHashDirectories->'%(StampFile)')"
-    Outputs="$(_AndroidStampDirectory)_ConvertLibraryResourcesCases.stamp">
-  <ConvertResourcesCases
-      Condition=" '@(_LibraryResourceDirectories)' != '' "
-      ContinueOnError="$(DesignTimeBuild)"
-      AcwMapFile="$(_AcwMapFile)"
-      AndroidConversionFlagFile="$(_AndroidStampDirectory)_ConvertLibraryResourcesCases.stamp"
-      CustomViewMapFile="$(_CustomViewMapFile)"
-      ResourceDirectories="@(_LibraryResourceDirectories)"
-      ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
-  />
-  <Touch Files="$(_AndroidStampDirectory)_ConvertLibraryResourcesCases.stamp" AlwaysCreate="True" />
-</Target>
-
-<Target Name="_CompileAndroidLibraryResources"
-    Condition=" '$(_AndroidUseAapt2)' == 'True' "
-    DependsOnTargets="_ConvertLibraryResourcesCases"
-    Inputs="@(_LibraryResourceHashDirectories->'%(StampFile)')"
-    Outputs="@(_LibraryResourceHashDirectories->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).stamp')"
-  >
-  <MakeDir Directories="$(_AndroidLibraryFlatArchivesDirectory)" Condition="!Exists('$(_AndroidLibraryFlatArchivesDirectory)')" />
-  <Aapt2Compile
-      Condition=" '@(_LibraryResourceHashDirectories)' != '' "
-      ContinueOnError="$(DesignTimeBuild)"
-      ExtraArgs="$(AndroidAapt2CompileExtraArgs)"
-      FlatArchivesDirectory="$(_AndroidLibraryFlatArchivesDirectory)"
-      ResourceDirectories="@(_LibraryResourceHashDirectories)"
-      ToolPath="$(Aapt2ToolPath)"
-      ToolExe="$(Aapt2ToolExe)"
-  />
-  <ItemGroup>
-    <_MissingStampFiles Include="@(_LibraryResourceHashDirectories->'%(StampFile)')" Condition="!Exists('%(StampFile)')" />
-    <_HashStampFiles Include="@(_LibraryResourceHashDirectories->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).stamp')" />
-    <_HashFlataFiles Include="@(_LibraryResourceHashDirectories->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).flata')" />
-  </ItemGroup>
-  <Touch
-      Files="@(_MissingStampFiles);@(_HashStampFiles)"
-      AlwaysCreate="True"
-  />
-  <ItemGroup>
-    <FileWrites Include="@(_MissingStampFiles)" />
-    <FileWrites Include="@(_HashStampFiles)" />
-    <FileWrites Include="@(_HashFlataFiles)" />
-  </ItemGroup>
 </Target>
 
 <Target Name="_ConvertResourcesCases"
     Condition=" '$(_AndroidUseAapt2)' == 'True' "
-    Inputs="$(MSBuildAllProjects);$(_AndroidBuildPropertiesCache);@(AndroidResource)"
+    Inputs="$(MSBuildAllProjects);$(_AndroidBuildPropertiesCache);@(AndroidResource);@(_LibraryResourceDirectories->'%(StampFile)')"
     Outputs="$(_AndroidStampDirectory)_ConvertResourcesCases.stamp"
-    DependsOnTargets="$(_BeforeConvertResourcesCases)"
+    DependsOnTargets="_CollectLibraryResourceDirectories;$(_BeforeConvertResourcesCases)"
   >
   <MakeDir Directories="$(_AndroidLibraryFlatArchivesDirectory)" Condition="!Exists('$(_AndroidLibraryFlatArchivesDirectory)')" />
+  <MakeDir Directories="$(_AndroidLibraryFlatFilesDirectory)" Condition="!Exists('$(_AndroidLibraryFlatFilesDirectory)')" />
   <!-- Change cases so we support mixed case resource names -->
   <ConvertResourcesCases
       ContinueOnError="$(DesignTimeBuild)"
@@ -128,29 +105,55 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <Touch Files="$(_AndroidStampDirectory)_ConvertResourcesCases.stamp" AlwaysCreate="True" />
 </Target>
 
+<Target Name="_CalculateResourceFileName"
+    Condition=" '$(_AndroidUseAapt2)' == 'True' ">
+  <ItemGroup>
+    <_CompileResourcesInputs Include="@(_AndroidResourceDest)">
+      <StampFile>%(Identity)</StampFile>
+    </_CompileResourcesInputs>
+    <_CompiledFlatFiles Include="@(_CompileResourcesInputs->'%(_ArchiveDirectory)%(_FlatFile)')" />
+  </ItemGroup>
+</Target>
+
 <Target Name="_CompileResources"
-    Condition=" '$(_AndroidUseAapt2)' == 'True' And '@(AndroidResource)' != '' "
-    Inputs="$(MSBuildAllProjects);$(_AndroidBuildPropertiesCache);@(AndroidResource)"
-    Outputs="$(_AndroidLibraryFlatArchivesDirectory)\_CompileResources.stamp"
-    DependsOnTargets="$(_BeforeCompileResources);_ConvertResourcesCases"
+    Condition=" '$(_AndroidUseAapt2)' == 'True' "
+    Inputs="$(MSBuildAllProjects);$(_AndroidBuildPropertiesCache);@(_CompileResourcesInputs)"
+    Outputs="@(_CompileResourcesInputs->'%(_ArchiveDirectory)%(_FlatFile)')"
+    DependsOnTargets="$(_BeforeCompileResources);_ConvertResourcesCases;_CalculateResourceFileName"
   >
   <Aapt2Compile
       ContinueOnError="$(DesignTimeBuild)"
+      DaemonMaxInstanceCount="$(Aapt2DaemonMaxInstanceCount)"
+      DaemonKeepInDomain="$(_Aapt2DaemonKeepInDomain)"
       ExtraArgs="$(AndroidAapt2CompileExtraArgs)"
+      FlatFilesDirectory="$(_AndroidLibraryFlatFilesDirectory)"
       FlatArchivesDirectory="$(_AndroidLibraryFlatArchivesDirectory)"
+      ResourcesToCompile="@(_CompileResourcesInputs)"
       ResourceDirectories="$(MonoAndroidResDirIntermediate)"
       ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
       ToolPath="$(Aapt2ToolPath)"
       ToolExe="$(Aapt2ToolExe)"
   />
-  <Touch Files="$(_AndroidLibraryFlatArchivesDirectory)\_CompileResources.stamp" AlwaysCreate="True" />
-  <ItemGroup>
-    <FileWrites Include="$(_AndroidLibraryFlatArchivesDirectory)\compiled.flata" />
-  </ItemGroup>
+</Target>
+
+<Target Name="_Aapt2UpdateAndroidResgenInputs">
+  <PropertyGroup>
+    <_UpdateAndroidResgenInputs>
+      $(_UpdateAndroidResgenInputs);
+      @(_CompiledFlatFiles);
+      @(_LibraryResourceDirectoryStamps);
+    </_UpdateAndroidResgenInputs>
+    <_CreateBaseApkInputs>
+      $(_CreateBaseApkInputs);
+      @(_CompiledFlatFiles);
+      @(_LibraryResourceDirectoryStamps);
+    </_CreateBaseApkInputs>
+  </PropertyGroup>
 </Target>
 
 <Target Name="_UpdateAndroidResgenAapt2"
-    Condition="'$(_AndroidUseAapt2)' == 'True'">
+    Condition=" '$(_AndroidUseAapt2)' == 'True' "
+  >
   <PropertyGroup>
     <AndroidAapt2LinkExtraArgs Condition=" '$(_AndroidUseAapt2)' == 'True' And $(AndroidResgenExtraArgs.Contains('--no-version-vectors')) And !($(AndroidAapt2LinkExtraArgs.Contains('--no-version-vectors'))) ">--no-version-vectors $(AndroidAapt2LinkExtraArgs) </AndroidAapt2LinkExtraArgs>
     <_Aapt2ProguardRules Condition=" '$(AndroidLinkTool)' != '' ">$(IntermediateOutputPath)aapt_rules.txt</_Aapt2ProguardRules>
@@ -158,6 +161,8 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <Aapt2Link
       Condition=" '$(_AndroidResourceDesignerFile)' != '' And '$(_AndroidUseAapt2)' == 'True' "
       ContinueOnError="$(DesignTimeBuild)"
+      DaemonMaxInstanceCount="$(Aapt2DaemonMaxInstanceCount)"
+      DaemonKeepInDomain="$(_Aapt2DaemonKeepInDomain)"
       ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
       AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
       ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
@@ -168,10 +173,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       ApplicationName="$(_AndroidPackage)"
       JavaPlatformJarPath="$(JavaPlatformJarPath)"
       JavaDesignerOutputDirectory="$(ResgenTemporaryDirectory)"
-      CompiledResourceFlatArchive="$(_AndroidLibraryFlatArchivesDirectory)\compiled.flata"
+      CompiledResourceFlatFiles="@(_CompiledFlatFiles)"
       ManifestFiles="$(ResgenTemporaryDirectory)\AndroidManifest.xml"
-      AdditionalResourceArchives="@(_LibraryResourceHashDirectories->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).flata')"
-      AdditionalAndroidResourcePaths="@(_LibraryResourceHashDirectories)"
+      AdditionalAndroidResourcePaths="@(_LibraryResourceDirectories)"
       YieldDuringToolExecution="$(YieldDuringToolExecution)"
       ResourceSymbolsTextFile="$(IntermediateOutputPath)R.txt"
       ResourceDirectories="$(MonoAndroidResDirIntermediate)"
@@ -192,36 +196,38 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 
 <Target Name="_FixupCustomViewsForAapt2"
     Condition=" '$(_AndroidUseAapt2)' == 'True' And '@(_ProcessedCustomViews)' != '' ">
-  <Delete
-      Files="@(_ProcessedCustomViews->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).stamp')"
-      Condition=" '$(AndroidUseAapt2)' == 'True' And '@(_ProcessedCustomViews)' != '' "
-  />
+  <ItemGroup>
+    <_ItemsToFixup Include="@(_CompileResourcesInputs)" Condition=" '@(_ProcessedCustomViews->'%(Identity)')' == '%(Identity)' "/>
+  </ItemGroup>
   <Aapt2Compile
-      Condition=" '$(AndroidUseAapt2)' == 'True' And '@(_ProcessedCustomViews)' != '' "
+      Condition=" '$(AndroidUseAapt2)' == 'True' And '@(_ItemsToFixup)' != '' "
       ContinueOnError="$(DesignTimeBuild)"
-      ResourceDirectories="@(_ProcessedCustomViews->'%(ResourceDirectory)'->Distinct())"
+      DaemonMaxInstanceCount="$(Aapt2DaemonMaxInstanceCount)"
+      DaemonKeepInDomain="$(_Aapt2DaemonKeepInDomain)"
+      ResourcesToCompile="@(_ItemsToFixup)"
+      ResourceDirectories="$(MonoAndroidResDirIntermediate);@(_LibraryResourceDirectories)"
       ExtraArgs="$(AndroidAapt2CompileExtraArgs)"
+      FlatFilesDirectory="$(_AndroidLibraryFlatFilesDirectory)"
       FlatArchivesDirectory="$(_AndroidLibraryFlatArchivesDirectory)"
       ToolPath="$(Aapt2ToolPath)"
       ToolExe="$(Aapt2ToolExe)">
-    <Output TaskParameter="CompiledResourceFlatArchives" ItemName="_UpdatedFlatArchives" />	
+    <Output TaskParameter="CompiledResourceFlatFiles" ItemName="_UpdatedFlatFiles" />
   </Aapt2Compile>
-  <Touch
-      Files="@(_UpdatedFlatArchives->'$(_AndroidLibraryFlatArchivesDirectory)\%(Filename).stamp')"
-      Condition=" '$(AndroidUseAapt2)' == 'True' And '@(_UpdatedFlatArchives)' != '' "
-      AlwaysCreate="True"
-  />
+  <Touch Files="$(_AndroidResgenFlagFile)" AlwaysCreate="True" Condition=" '@(_UpdatedFlatFiles)' != '' " />
 </Target>
 
 <Target Name="_CreateBaseApkWithAapt2"
-    Condition="'$(_AndroidUseAapt2)' == 'True'">
+    Condition=" '$(_AndroidUseAapt2)' == 'True' "
+  >
   <PropertyGroup>
     <_ProtobufFormat Condition=" '$(AndroidPackageFormat)' == 'aab' ">True</_ProtobufFormat>
     <_ProtobufFormat Condition=" '$(_ProtobufFormat)' == '' ">False</_ProtobufFormat>
   </PropertyGroup>
   <Aapt2Link
       Condition="'$(_AndroidUseAapt2)' == 'True'"
-      CompiledResourceFlatArchive="$(_AndroidLibraryFlatArchivesDirectory)\compiled.flata"
+      CompiledResourceFlatFiles="@(_CompiledFlatFiles)"
+      DaemonMaxInstanceCount="$(Aapt2DaemonMaxInstanceCount)"
+      DaemonKeepInDomain="$(_Aapt2DaemonKeepInDomain)"
       ResourceNameCaseMap="$(_AndroidResourceNameCaseMap)"
       ResourceDirectories="$(MonoAndroidResDirIntermediate)"
       AssemblyIdentityMapFile="$(_AndroidLibrayProjectAssemblyMapFile)"
@@ -229,8 +235,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       ImportsDirectory="$(_LibraryProjectImportsDirectoryName)"
       OutputImportDirectory="$(_AndroidLibrayProjectIntermediatePath)"
       OutputFile="$(_PackagedResources)"
-      AdditionalResourceArchives="@(_LibraryResourceHashDirectories->'$(_AndroidLibraryFlatArchivesDirectory)%(Hash).flata')"
-      AdditionalAndroidResourcePaths="@(_LibraryResourceHashDirectories)"
+      AdditionalAndroidResourcePaths="@(_LibraryResourceDirectories)"
       YieldDuringToolExecution="$(YieldDuringToolExecution)"
       PackageName="$(_AndroidPackage)"
       ApplicationName="$(_AndroidPackage)"

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2Link.cs
@@ -304,7 +304,8 @@ namespace Xamarin.Android.Tasks {
 
 		bool ExecuteForAbi (string [] cmd, string currentResourceOutputFile)
 		{
-			apks.Add (currentResourceOutputFile, RunAapt (cmd, currentResourceOutputFile));
+			lock (apks)
+				apks.Add (currentResourceOutputFile, RunAapt (cmd, currentResourceOutputFile));
 			return true;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AndroidComputeResPaths.cs
@@ -49,6 +49,8 @@ namespace Xamarin.Android.Tasks
 		public bool LowercaseFilenames { get; set; }
 
 		public string ProjectDir { get; set; }
+
+		public string AndroidLibraryFlatFilesDirectory { get; set; }
 		
 		[Output]
 		public ITaskItem[] IntermediateFiles { get; set; }
@@ -131,6 +133,8 @@ namespace Xamarin.Android.Tasks
 				}
 				var newItem = new TaskItem (dest);
 				newItem.SetMetadata ("LogicalName", rel);
+				newItem.SetMetadata ("_FlatFile", Monodroid.AndroidResource.CalculateAapt2FlatArchiveFileName (dest));
+				newItem.SetMetadata ("_ArchiveDirectory", AndroidLibraryFlatFilesDirectory);
 				item.CopyMetadataTo (newItem);
 				intermediateFiles.Add (newItem);
 				resolvedFiles.Add (item);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Text;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Utilities;
@@ -11,6 +13,7 @@ namespace Xamarin.Android.Tasks {
 		public override string TaskPrefix => "CNE";
 
 		List<ITaskItem> output = new List<ITaskItem> ();
+		List<ITaskItem> libraryResourceFiles = new List<ITaskItem> ();
 
 		[Required]
 		public ITaskItem[] Directories { get; set; }
@@ -24,6 +27,9 @@ namespace Xamarin.Android.Tasks {
 		[Output]
 		public ITaskItem[] Output => output.ToArray ();
 
+		[Output]
+		public ITaskItem[] LibraryResourceFiles => libraryResourceFiles.ToArray ();
+
 		public override bool RunTask ()
 		{
 			var libraryProjectDir = Path.GetFullPath (LibraryProjectIntermediatePath);
@@ -32,27 +38,64 @@ namespace Xamarin.Android.Tasks {
 					Log.LogDebugMessage ($"Directory does not exist, skipping: {directory.ItemSpec}");
 					continue;
 				}
-				var firstFile = Directory.EnumerateFiles(directory.ItemSpec, "*.*", SearchOption.AllDirectories).FirstOrDefault ();
-				if (firstFile != null) {
+				string stampFile = directory.GetMetadata ("StampFile");
+				if (string.IsNullOrEmpty (stampFile)) {
+					if (Path.GetFullPath (directory.ItemSpec).StartsWith (libraryProjectDir)) {
+						// If inside the `lp` directory
+						stampFile = Path.GetFullPath (Path.Combine (directory.ItemSpec, "..", "..")) + ".stamp";
+					} else {
+						// Otherwise use a hashed stamp file
+						stampFile = Path.Combine (StampDirectory, Files.HashString (directory.ItemSpec) + ".stamp");
+					}
+				}
+
+				bool generateArchive = false;
+				bool.TryParse (directory.GetMetadata (ResolveLibraryProjectImports.AndroidSkipResourceProcessing), out generateArchive);
+
+				IEnumerable<string> files;
+				string fileCache = Path.Combine (directory.ItemSpec, "..", "files.cache");
+				DateTime lastwriteTime = File.Exists (stampFile) ? File.GetLastWriteTimeUtc (stampFile) : DateTime.MinValue;
+				DateTime cacheLastWriteTime = File.Exists (fileCache) ? File.GetLastWriteTimeUtc (fileCache) : DateTime.MinValue;
+
+				if (File.Exists (fileCache) && cacheLastWriteTime >= lastwriteTime) {
+					Log.LogDebugMessage ($"Reading cached Library resources list from  {fileCache}");
+					files = File.ReadAllLines (fileCache);
+				} else {
+					if (!File.Exists (fileCache))
+						Log.LogDebugMessage ($"Cached Library resources list {fileCache} does not exist.");
+					else
+						Log.LogDebugMessage ($"Cached Library resources list {fileCache} is out of date.");
+					if (generateArchive) {
+						files = new string[1] { stampFile };
+					} else {
+						files = Directory.EnumerateFiles(directory.ItemSpec, "*.*", SearchOption.AllDirectories);
+					}
+				}
+
+				if (files.Any ()) {
+					if (!File.Exists (fileCache) || cacheLastWriteTime < lastwriteTime)
+						File.WriteAllLines (fileCache, files, Encoding.UTF8);
 					var taskItem = new TaskItem (directory.ItemSpec, new Dictionary<string, string> () {
-						{"FileFound", firstFile },
+						{"FileFound", files.First () },
 					});
 					directory.CopyMetadataTo (taskItem);
 
-					string stampFile = directory.GetMetadata ("StampFile");
-					if (string.IsNullOrEmpty (stampFile)) {
-						if (Path.GetFullPath (directory.ItemSpec).StartsWith (libraryProjectDir)) {
-							// If inside the `lp` directory
-							stampFile = Path.GetFullPath (Path.Combine (directory.ItemSpec, "..", "..")) + ".stamp";
-						} else {
-							// Otherwise use a hashed stamp file
-							stampFile = Path.Combine (StampDirectory, Files.HashString (directory.ItemSpec) + ".stamp");
-						}
+					if (string.IsNullOrEmpty (directory.GetMetadata ("StampFile"))) {
 						taskItem.SetMetadata ("StampFile", stampFile);
 					} else {
 						Log.LogDebugMessage ($"%(StampFile) already set: {stampFile}");
 					}
 					output.Add (taskItem);
+					foreach (var file in files) {
+						var fileTaskItem = new TaskItem (file, new Dictionary<string, string> () {
+							{ "ResourceDirectory", directory.ItemSpec },
+							{ "StampFile", generateArchive ? stampFile : file },
+							{ "Hash", stampFile },
+							{ "_ArchiveDirectory", Path.Combine (directory.ItemSpec, "..", "flat" + Path.DirectorySeparatorChar) },
+							{ "_FlatFile", generateArchive ?  $"{Path.GetFileNameWithoutExtension (stampFile)}.flata"  : Monodroid.AndroidResource.CalculateAapt2FlatArchiveFileName (file) },
+						});
+						libraryResourceFiles.Add (fileTaskItem);
+					}
 				}
 			}
 			return !Log.HasLoggedErrors;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
@@ -82,8 +82,6 @@ namespace Xamarin.Android.Tasks {
 			var output = new Dictionary<string, ITaskItem> (processed.Count);
 			foreach (var file in processed) {
 				ITaskItem resdir = ResourceDirectories?.FirstOrDefault (x => file.StartsWith (x.ItemSpec)) ?? null;
-				if (output.ContainsKey (file))
-					continue;
 				var hash = resdir?.GetMetadata ("Hash") ?? null;
 				var stamp = resdir?.GetMetadata ("StampFile") ?? null;
 				var filename = !string.IsNullOrEmpty (hash) ? hash : "compiled";

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
@@ -79,24 +79,23 @@ namespace Xamarin.Android.Tasks {
 					}
 				}
 			}
-			var output = new List<ITaskItem> ();
+			var output = new Dictionary<string, ITaskItem> ();
 			foreach (var file in processed) {
 				ITaskItem resdir = ResourceDirectories?.FirstOrDefault (x => file.StartsWith (x.ItemSpec)) ?? null;
-				if (resdir == null) {
+				if (output.ContainsKey (file))
 					continue;
-				}
-				var hash = resdir.GetMetadata ("Hash");
-				var stamp = resdir.GetMetadata ("StampFile");
+				var hash = resdir?.GetMetadata ("Hash") ?? null;
+				var stamp = resdir?.GetMetadata ("StampFile") ?? null;
 				var filename = !string.IsNullOrEmpty (hash) ? hash : "compiled";
 				var stampFile = !string.IsNullOrEmpty (stamp) ? stamp : $"{filename}.stamp";
 				Log.LogDebugMessage ($"{filename} {stampFile}");
-				output.Add (new TaskItem (file, new Dictionary<string, string> {
+				output.Add (file, new TaskItem (Path.GetFullPath (file), new Dictionary<string, string> {
 					{ "StampFile" , stampFile },
 					{ "Hash" , filename },
-					{ "ResourceDirectory", resdir.ItemSpec }
+					{ "Resource", resdir?.ItemSpec ?? file },
 				}));
 			}
-			Processed = output.ToArray ();
+			Processed = output.Values.ToArray ();
 			return !Log.HasLoggedErrors;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
@@ -79,7 +79,7 @@ namespace Xamarin.Android.Tasks {
 					}
 				}
 			}
-			var output = new Dictionary<string, ITaskItem> ();
+			var output = new Dictionary<string, ITaskItem> (processed.Count);
 			foreach (var file in processed) {
 				ITaskItem resdir = ResourceDirectories?.FirstOrDefault (x => file.StartsWith (x.ItemSpec)) ?? null;
 				if (output.ContainsKey (file))

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyIfChanged.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyIfChanged.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public ITaskItem[] DestinationFiles { get; set; }
 
-		public bool CompareFileLengths { get; set; }
+		public bool CompareFileLengths { get; set; } = true;
 
 		[Output]
 		public ITaskItem[] ModifiedFiles { get; set; }
@@ -33,7 +33,6 @@ namespace Xamarin.Android.Tasks
 
 		public CopyIfChanged ()
 		{
-			CompareFileLengths = true;
 		}
 
 		public override bool RunTask ()

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CopyIfChanged.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CopyIfChanged.cs
@@ -24,10 +24,17 @@ namespace Xamarin.Android.Tasks
 		[Required]
 		public ITaskItem[] DestinationFiles { get; set; }
 
+		public bool CompareFileLengths { get; set; }
+
 		[Output]
 		public ITaskItem[] ModifiedFiles { get; set; }
 
 		private List<ITaskItem> modifiedFiles = new List<ITaskItem>();
+
+		public CopyIfChanged ()
+		{
+			CompareFileLengths = true;
+		}
 
 		public override bool RunTask ()
 		{
@@ -41,7 +48,7 @@ namespace Xamarin.Android.Tasks
 					continue;
 				}
 				var dest = new FileInfo (DestinationFiles [i].ItemSpec);
-				if (dest.Exists && dest.LastWriteTimeUtc > src.LastWriteTimeUtc && dest.Length == src.Length) {
+				if (dest.Exists && dest.LastWriteTimeUtc > src.LastWriteTimeUtc && (CompareFileLengths ? dest.Length == src.Length : true)) {
 					Log.LogDebugMessage ($"  Skipping {src} it is up to date");
 					continue;
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/PrepareWearApplicationFiles.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/PrepareWearApplicationFiles.cs
@@ -17,6 +17,7 @@ namespace Xamarin.Android.Tasks
 		public string PackageName { get; set; }
 		public string WearAndroidManifestFile { get; set; }
 		public string IntermediateOutputPath { get; set; }
+		public string AndroidLibraryFlatFilesDirectory { get; set; }
 		public string WearApplicationApkPath { get; set; }
 		[Output]
 		public ITaskItem WearableApplicationDescriptionFile { get; set; }
@@ -62,8 +63,12 @@ namespace Xamarin.Android.Tasks
 				modified.Add (intermediateXmlFile);
 			}
 			WearableApplicationDescriptionFile = new TaskItem (intermediateXmlFile);
+			WearableApplicationDescriptionFile.SetMetadata ("_FlatFile", Monodroid.AndroidResource.CalculateAapt2FlatArchiveFileName (intermediateXmlFile));
+			WearableApplicationDescriptionFile.SetMetadata ("_ArchiveDirectory", AndroidLibraryFlatFilesDirectory);
 			WearableApplicationDescriptionFile.SetMetadata ("IsWearApplicationResource", "True");
 			BundledWearApplicationApkResourceFile = new TaskItem (intermediateApkPath);
+			BundledWearApplicationApkResourceFile.SetMetadata ("_FlatFile", Monodroid.AndroidResource.CalculateAapt2FlatArchiveFileName (intermediateApkPath));
+			BundledWearApplicationApkResourceFile.SetMetadata ("_ArchiveDirectory", AndroidLibraryFlatFilesDirectory);
 			BundledWearApplicationApkResourceFile.SetMetadata ("IsWearApplicationResource", "True");
 			ModifiedFiles = modified.ToArray ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -12,32 +13,114 @@ namespace Xamarin.Android.Build.Tests
 {
 	public class Aapt2Tests : BaseTest
 	{
-		void CallAapt2Compile (IBuildEngine engine, string dir, string outputPath, List<ITaskItem> output = null)
+		void CallAapt2Compile (IBuildEngine engine, string dir, string outputPath, string flatFilePath, List<ITaskItem> output = null, int maxInstances = 0, bool keepInDomain = false)
 		{
 			var errors = new List<BuildErrorEventArgs> ();
+			ITaskItem item;
+			if (File.Exists (dir)) {
+				item = CreateTaskItemForResourceFile (dir);
+			} else {
+				item = new TaskItem(dir, new Dictionary<string, string> {
+					{ "ResourceDirectory", dir },
+					{ "Hash", output != null ? Files.HashString (dir) : "compiled" },
+					{ "_FlatFile", output != null ? Files.HashString (dir) + ".flata" : "compiled.flata" },
+					{ "_ArchiveDirectory", outputPath }
+				});
+			}
 			var task = new Aapt2Compile {
 				BuildEngine = engine,
 				ToolPath = GetPathToAapt2 (),
+				ResourcesToCompile = new ITaskItem [] {
+					item,
+				},
 				ResourceDirectories = new ITaskItem [] {
-					new TaskItem(dir, new Dictionary<string, string> {
-						{ "Hash", output != null ? Files.HashString (dir) : "compiled" }
-					}),
+					new TaskItem (dir),
 				},
 				FlatArchivesDirectory = outputPath,
+				FlatFilesDirectory = flatFilePath,
+				DaemonMaxInstanceCount = maxInstances,
+				DaemonKeepInDomain = keepInDomain,
 			};
-			Assert.True (task.Execute (), "task should have succeeded.");
+			MockBuildEngine mockEngine = (MockBuildEngine)engine;
+			Assert.True (task.Execute (), $"task should have succeeded. {string.Join (" ", mockEngine.Errors.Select (x => x.Message))}");
 			output?.AddRange (task.CompiledResourceFlatArchives);
 		}
 
-		[Test]
-		public void Aapt2Link ()
+		ITaskItem CreateTaskItemForResourceFile (string root, string dir, string file)
 		{
-			var path = Path.Combine (Root, "temp", "Aapt2Link");
+			string ext = Path.GetExtension (file);
+			if (dir.StartsWith ("values"))
+				ext = ".arsc";
+			return new TaskItem (Path.Combine (root, dir, file), new Dictionary<string, string> { { "_FlatFile", $"{dir}_{Path.GetFileNameWithoutExtension (file)}{ext}.flat" } } );
+		}
+
+		ITaskItem CreateTaskItemForResourceFile (string file)
+		{
+			string ext = Path.GetExtension (file);
+			string dir = Path.GetFileName (Path.GetDirectoryName (file));
+			if (dir.StartsWith ("values"))
+				ext = ".arsc";
+			return new TaskItem (file, new Dictionary<string, string> { { "_FlatFile", $"{dir}_{Path.GetFileNameWithoutExtension (file)}{ext}.flat" } } );
+		}
+
+		[Test]
+		[TestCase (6, 6, 3, 2)]
+		[TestCase (6, 6, 2, 1)]
+		[TestCase (6, 6, 6, 50)]
+		[TestCase (1, 1, 1, 10)]
+		public void Aapt2DaemonInstances (int maxInstances, int expectedMax, int expectedInstances, int numLayouts)
+		{
+			var path = Path.Combine (Root, "temp", TestName);
 			Directory.CreateDirectory (path);
 			var resPath = Path.Combine (path, "res");
 			var archivePath = Path.Combine (path, "flata");
+			var flatFilePath = Path.Combine(path, "flat");
 			Directory.CreateDirectory (resPath);
 			Directory.CreateDirectory (archivePath);
+			Directory.CreateDirectory (flatFilePath);
+			Directory.CreateDirectory (Path.Combine (resPath, "values"));
+			Directory.CreateDirectory (Path.Combine (resPath, "layout"));
+			File.WriteAllText (Path.Combine (resPath, "values", "strings.xml"), @"<?xml version='1.0' ?><resources><string name='foo'>foo</string></resources>");
+			for (int i = 0; i < numLayouts; i++)
+				File.WriteAllText (Path.Combine (resPath, "layout", $"main{i}.xml"), @"<?xml version='1.0' ?><LinearLayout xmlns:android='http://schemas.android.com/apk/res/android' />");
+			File.WriteAllText (Path.Combine (path, "AndroidManifest.xml"), @"<?xml version='1.0' ?><manifest xmlns:android='http://schemas.android.com/apk/res/android' package='Foo.Foo' />");
+			File.WriteAllText (Path.Combine (path, "foo.map"), @"a\nb");
+			var errors = new List<BuildErrorEventArgs> ();
+			var warnings = new List<BuildWarningEventArgs> ();
+			List<ITaskItem> files = new List<ITaskItem> ();
+			IBuildEngine4 engine = new MockBuildEngine (System.Console.Out, errors, warnings);
+			files.Add (CreateTaskItemForResourceFile (resPath, "values", "strings.xml"));
+			for (int i = 0; i < numLayouts; i++)
+				files.Add (CreateTaskItemForResourceFile (resPath, "layout", $"main{i}.xml"));
+			var task = new Aapt2Compile {
+				BuildEngine = engine,
+				ToolPath = GetPathToAapt2 (),
+				ResourcesToCompile = files.ToArray (),
+				ResourceDirectories = new ITaskItem [] { new TaskItem (resPath) },
+				FlatArchivesDirectory = archivePath,
+				FlatFilesDirectory = flatFilePath,
+				DaemonMaxInstanceCount = maxInstances,
+				DaemonKeepInDomain = false,
+			};
+			Assert.True (task.Execute (), $"task should have succeeded. {string.Join (";", errors.Select (x => x.Message))}");
+			Aapt2Daemon daemon = (Aapt2Daemon)engine.GetRegisteredTaskObject (typeof(Aapt2Daemon).FullName, RegisteredTaskObjectLifetime.Build);
+			Assert.IsNotNull (daemon, "Should have got a Daemon");
+			Assert.AreEqual (expectedMax, daemon.MaxInstances, $"Expected {expectedMax} but was {daemon.MaxInstances}");
+			Assert.AreEqual (expectedInstances, daemon.CurrentInstances, $"Expected {expectedInstances} but was {daemon.CurrentInstances}");
+			Directory.Delete (Path.Combine (Root, path), recursive: true);
+		}
+
+		[Test]
+		public void Aapt2Link ([Values (true, false)] bool compilePerFile)
+		{
+			var path = Path.Combine (Root, "temp", TestName);
+			Directory.CreateDirectory (path);
+			var resPath = Path.Combine (path, "res");
+			var archivePath = Path.Combine (path, "flata");
+			var flatFilePath = Path.Combine(path, "flat");
+			Directory.CreateDirectory (resPath);
+			Directory.CreateDirectory (archivePath);
+			Directory.CreateDirectory (flatFilePath);
 			Directory.CreateDirectory (Path.Combine (resPath, "values"));
 			Directory.CreateDirectory (Path.Combine (resPath, "layout"));
 			File.WriteAllText (Path.Combine (resPath, "values", "strings.xml"), @"<?xml version='1.0' ?><resources><string name='foo'>foo</string></resources>");
@@ -54,9 +137,22 @@ namespace Xamarin.Android.Build.Tests
 			var warnings = new List<BuildWarningEventArgs> ();
 			IBuildEngine engine = new MockBuildEngine (TestContext.Out, errors, warnings);
 			var archives = new List<ITaskItem>();
-			CallAapt2Compile (engine, resPath, archivePath);
-			CallAapt2Compile (engine, Path.Combine (libPath, "0", "res"), archivePath, archives);
-			CallAapt2Compile (engine, Path.Combine (libPath, "1", "res"), archivePath, archives);
+			if (compilePerFile) {
+				foreach (var file in Directory.EnumerateFiles (resPath, "*.*", SearchOption.AllDirectories)) {
+					CallAapt2Compile (engine, file, archivePath, flatFilePath);
+				}
+			} else {
+				CallAapt2Compile (engine, resPath, archivePath, flatFilePath);
+			}
+			CallAapt2Compile (engine, Path.Combine (libPath, "0", "res"), archivePath, flatFilePath, archives);
+			CallAapt2Compile (engine, Path.Combine (libPath, "1", "res"), archivePath, flatFilePath, archives);
+			List<ITaskItem> items = new List<ITaskItem> ();
+			if (compilePerFile) {
+				// collect all the flat archives
+				foreach (var file in Directory.EnumerateFiles (flatFilePath, "*.flat", SearchOption.AllDirectories)) {
+					items.Add (new TaskItem (file));
+				}
+			}
 			int platform = 0;
 			using (var b = new Builder ()) {
 				platform = b.GetMaxInstalledPlatform ();
@@ -67,13 +163,14 @@ namespace Xamarin.Android.Build.Tests
 				ToolPath = GetPathToAapt2 (),
 				ResourceDirectories = new ITaskItem [] { new TaskItem (resPath) },
 				ManifestFiles = new ITaskItem [] { new TaskItem (Path.Combine (path, "AndroidManifest.xml")) },
-				AdditionalResourceArchives = archives.ToArray (),
-				CompiledResourceFlatArchive = new TaskItem (Path.Combine (archivePath, "compiled.flata")),
+				AdditionalResourceArchives = !compilePerFile ? archives.ToArray () : null,
+				CompiledResourceFlatArchive = !compilePerFile ? new TaskItem (Path.Combine (archivePath, "compiled.flata")) : null,
+				CompiledResourceFlatFiles = compilePerFile ? items.ToArray () : null,
 				OutputFile = outputFile,
 				AssemblyIdentityMapFile = Path.Combine (path, "foo.map"),
 				JavaPlatformJarPath = Path.Combine (AndroidSdkPath, "platforms", $"android-{platform}", "android.jar"),
 			};
-			Assert.True (task.Execute (), "task should have succeeded.");
+			Assert.True (task.Execute (), $"task should have succeeded. {string.Join (";", errors.Select (x => x.Message))}");
 			Assert.AreEqual (0, errors.Count, "There should be no errors.");
 			Assert.LessOrEqual (0, warnings.Count, "There should be 0 warnings.");
 			Assert.True (File.Exists (outputFile), $"{outputFile} should have been created.");
@@ -90,6 +187,7 @@ namespace Xamarin.Android.Build.Tests
 			Directory.CreateDirectory (path);
 			var resPath = Path.Combine (path, "res");
 			var archivePath = Path.Combine(path, "flata");
+			var flatFilePath = Path.Combine(path, "flat");
 			Directory.CreateDirectory(resPath);
 			Directory.CreateDirectory(archivePath);
 			Directory.CreateDirectory (Path.Combine (resPath, "values"));
@@ -101,8 +199,15 @@ namespace Xamarin.Android.Build.Tests
 			var task = new Aapt2Compile {
 				BuildEngine = engine,
 				ToolPath = GetPathToAapt2 (),
+				ResourcesToCompile = new ITaskItem [] {
+						new TaskItem (resPath, new Dictionary<string, string> () {
+								{ "ResourceDirectory", resPath },
+							}
+						)
+					},
 				ResourceDirectories = new ITaskItem [] { new TaskItem (resPath) },
 				FlatArchivesDirectory = archivePath,
+				FlatFilesDirectory = flatFilePath,
 			};
 			Assert.True (task.Execute (), "task should have succeeded.");
 			var flatArchive = Path.Combine (archivePath, "compiled.flata");
@@ -114,12 +219,137 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void Aapt2CompileUmlautsAndSpaces ()
+		{
+			var path = Path.Combine (Root, "temp", "Aapt2CompileÜmläüt Files");
+			Directory.CreateDirectory (path);
+			var resPath = Path.Combine (path, "res");
+			var archivePath = Path.Combine(path, "flata");
+			var flatFilePath = Path.Combine(path, "flat");
+			Directory.CreateDirectory(resPath);
+			Directory.CreateDirectory(archivePath);
+			Directory.CreateDirectory(flatFilePath);
+			Directory.CreateDirectory (Path.Combine (resPath, "values"));
+			Directory.CreateDirectory (Path.Combine (resPath, "layout"));
+			File.WriteAllText (Path.Combine (resPath, "values", "strings.xml"), @"<?xml version='1.0' ?><resources><string name='foo'>foo</string></resources>");
+			File.WriteAllText (Path.Combine (resPath, "layout", "main.xml"), @"<?xml version='1.0' ?><LinearLayout xmlns:android='http://schemas.android.com/apk/res/android' />");
+			List<ITaskItem> files = new List<ITaskItem> ();
+			files.Add (CreateTaskItemForResourceFile (resPath, "values", "strings.xml"));
+			files.Add (CreateTaskItemForResourceFile (resPath, "layout", "main.xml"));
+			var errors = new List<BuildErrorEventArgs> ();
+			IBuildEngine engine = new MockBuildEngine (TestContext.Out, errors);
+			var task = new Aapt2Compile {
+				BuildEngine = engine,
+				ToolPath = GetPathToAapt2 (),
+				ResourcesToCompile = files.ToArray (),
+				ResourceDirectories = new ITaskItem [] { new TaskItem (resPath) },
+				FlatArchivesDirectory = archivePath,
+				FlatFilesDirectory = flatFilePath,
+			};
+			Assert.True (task.Execute (), $"task should have succeeded. {string.Join (";", errors.Select (x => x.Message))}");
+			var flatArchive = Path.Combine (archivePath, "compiled.flata");
+			Assert.False (File.Exists (flatArchive), $"{flatArchive} should not have been created.");
+			foreach (var file in files) {
+				string f = Path.Combine (flatFilePath, file.GetMetadata ("_FlatFile"));
+				Assert.True (File.Exists (f), $"{f} should have been created.");
+			}
+			Directory.Delete (Path.Combine (Root, path), recursive: true);
+		}
+
+		[Test]
+		public void CollectNonEmptyDirectoriesTest ()
+		{
+			var path = Path.Combine (Root, "temp", TestName);
+			Directory.CreateDirectory (path);
+			var resPath = Path.Combine (path, "res");
+			var archivePath = Path.Combine (path, "flata");
+			var flatFilePath = Path.Combine(path, "flat");
+			Directory.CreateDirectory (resPath);
+			Directory.CreateDirectory (Path.Combine (path, "stamps"));
+			Directory.CreateDirectory (archivePath);
+			Directory.CreateDirectory (flatFilePath);
+			Directory.CreateDirectory (Path.Combine (resPath, "values"));
+			Directory.CreateDirectory (Path.Combine (resPath, "layout"));
+			File.WriteAllText (Path.Combine (resPath, "values", "strings.xml"), @"<?xml version='1.0' ?><resources><string name='foo'>foo</string></resources>");
+			File.WriteAllText (Path.Combine (resPath, "layout", "main.xml"), @"<?xml version='1.0' ?><LinearLayout xmlns:android='http://schemas.android.com/apk/res/android' />");
+			var libPath = Path.Combine (path, "lp");
+			Directory.CreateDirectory (libPath);
+			Directory.CreateDirectory (Path.Combine (libPath, "0", "res", "values"));
+			Directory.CreateDirectory (Path.Combine (libPath, "1", "res", "values"));
+			File.WriteAllText (Path.Combine (libPath, "0", "res", "values", "strings.xml"), @"<?xml version='1.0' ?><resources><string name='foo1'>foo1</string></resources>");
+			File.WriteAllText (Path.Combine (libPath, "1", "res", "values", "strings.xml"), @"<?xml version='1.0' ?><resources><string name='foo2'>foo2</string></resources>");
+			File.WriteAllText (Path.Combine (path, "AndroidManifest.xml"), @"<?xml version='1.0' ?><manifest xmlns:android='http://schemas.android.com/apk/res/android' package='Foo.Foo' />");
+			File.WriteAllText (Path.Combine (path, "foo.map"), @"a\nb");
+			var errors = new List<BuildErrorEventArgs> ();
+			IBuildEngine engine = new MockBuildEngine (TestContext.Out, errors);
+			var task = new CollectNonEmptyDirectories {
+				BuildEngine = engine,
+				Directories = new ITaskItem[] {
+					new TaskItem (resPath),
+					new TaskItem (Path.Combine (libPath, "0", "res"), new Dictionary<string, string> {
+						{ "AndroidSkipResourceProcessing", "True" },
+						{ "StampFile", "0.stamp" },
+					}),
+					new TaskItem (Path.Combine (libPath, "1", "res")),
+				},
+				LibraryProjectIntermediatePath = libPath,
+				StampDirectory = Path.Combine(path, "stamps"),
+			};
+			Assert.True (task.Execute (), $"task should have succeeded. {string.Join (";", errors.Select (x => x.Message))}");
+			Assert.AreEqual (3, task.Output.Length, "Output should have 3 items in it.");
+			Assert.AreEqual (4, task.LibraryResourceFiles.Length, "Output should have 3 items in it.");
+			Assert.AreEqual ("layout_main.xml.flat", task.LibraryResourceFiles[0].GetMetadata ("_FlatFile"));
+			Assert.AreEqual ("values_strings.arsc.flat", task.LibraryResourceFiles[1].GetMetadata ("_FlatFile"));
+			Assert.AreEqual ("0.flata", task.LibraryResourceFiles[2].GetMetadata ("_FlatFile"));
+			Assert.AreEqual ("values_strings.arsc.flat", task.LibraryResourceFiles[3].GetMetadata ("_FlatFile"));
+		}
+
+		[Test]
+		public void Aapt2CompileFiles ()
+		{
+			var path = Path.Combine (Root, "temp", "Aapt2CompileFiles");
+			Directory.CreateDirectory (path);
+			var resPath = Path.Combine (path, "res");
+			var archivePath = Path.Combine(path, "flata");
+			var flatFilePath = Path.Combine(path, "flat");
+			Directory.CreateDirectory(resPath);
+			Directory.CreateDirectory(archivePath);
+			Directory.CreateDirectory(flatFilePath);
+			Directory.CreateDirectory (Path.Combine (resPath, "values"));
+			Directory.CreateDirectory (Path.Combine (resPath, "layout"));
+			File.WriteAllText (Path.Combine (resPath, "values", "strings.xml"), @"<?xml version='1.0' ?><resources><string name='foo'>foo</string></resources>");
+			File.WriteAllText (Path.Combine (resPath, "layout", "main.xml"), @"<?xml version='1.0' ?><LinearLayout xmlns:android='http://schemas.android.com/apk/res/android' />");
+			List<ITaskItem> files = new List<ITaskItem> ();
+			files.Add (CreateTaskItemForResourceFile (resPath, "values", "strings.xml"));
+			files.Add (CreateTaskItemForResourceFile (resPath, "layout", "main.xml"));
+			var errors = new List<BuildErrorEventArgs> ();
+			IBuildEngine engine = new MockBuildEngine (TestContext.Out, errors);
+			var task = new Aapt2Compile {
+				BuildEngine = engine,
+				ToolPath = GetPathToAapt2 (),
+				ResourcesToCompile = files.ToArray (),
+				ResourceDirectories = new ITaskItem [] { new TaskItem (resPath) },
+				FlatArchivesDirectory = archivePath,
+				FlatFilesDirectory = flatFilePath,
+			};
+			Assert.True (task.Execute (), $"task should have succeeded. {string.Join (";", errors.Select (x => x.Message))}");
+			var flatArchive = Path.Combine (archivePath, "compiled.flata");
+			Assert.False (File.Exists (flatArchive), $"{flatArchive} should not have been created.");
+			foreach (var file in files) {
+				string f = Path.Combine (flatFilePath, file.GetMetadata ("_FlatFile"));
+				Assert.True (File.Exists (f), $"{f} should have been created.");
+			}
+			Directory.Delete (Path.Combine (Root, path), recursive: true);
+		}
+
+		[Test]
 		public void Aapt2CompileFixesUpErrors ()
 		{
 			var path = Path.Combine (Root, "temp", "Aapt2CompileFixesUpErrors");
 			Directory.CreateDirectory (path);
 			var resPath = Path.Combine (path, "res");
 			var archivePath = Path.Combine(path, "flata");
+			var flatFilePath = Path.Combine(path, "flat");
 			Directory.CreateDirectory(resPath);
 			Directory.CreateDirectory(archivePath);
 			Directory.CreateDirectory (Path.Combine (resPath, "values"));
@@ -148,8 +378,14 @@ namespace Xamarin.Android.Build.Tests
 				var task = new Aapt2Compile {
 					BuildEngine = engine,
 					ToolPath = GetPathToAapt2 (),
-					ResourceDirectories = new ITaskItem [] { new TaskItem (resPath) },
-		    			FlatArchivesDirectory = archivePath,
+					ResourceDirectories = new ITaskItem [] {
+						new TaskItem (resPath, new Dictionary<string, string> () {
+								{ "ResourceDirectory", resPath },
+							}
+						)
+					},
+					FlatArchivesDirectory = archivePath,
+					FlatFilesDirectory = flatFilePath,
 					ResourceNameCaseMap = $"Layout{directorySeperator}Main.xml|layout{directorySeperator}main.axml;Values{directorySeperator}Strings.xml|values{directorySeperator}strings.xml",
 				};
 				Assert.False (task.Execute (), "task should not have succeeded.");
@@ -171,7 +407,7 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "Aapt2Link"), "Aapt2Link task should not run!");
 				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "Aapt2Compile"), "Aapt2Compile task should not run!");
-				Assert.IsTrue (b.Output.IsTargetSkipped ("_CreateAapt2VersionCache"), "_CreateAapt2VersionCache target should be skipped!");
+				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "_CreateAapt2VersionCache"), "_CreateAapt2VersionCache target should not run!");
 			}
 		}
 
@@ -182,6 +418,7 @@ namespace Xamarin.Android.Build.Tests
 			Directory.CreateDirectory (path);
 			var resPath = Path.Combine (path, "res");
 			var archivePath = Path.Combine(path, "flata");
+			var flatFilePath = Path.Combine(path, "flat");
 			Directory.CreateDirectory(resPath);
 			Directory.CreateDirectory(archivePath);
 			Directory.CreateDirectory (Path.Combine (resPath, "values"));
@@ -191,10 +428,16 @@ namespace Xamarin.Android.Build.Tests
 			File.WriteAllText (Path.Combine (path, "AndroidManifest.xml"), @"<?xml version='1.0' ?><manifest xmlns:android='http://schemas.android.com/apk/res/android' package='Foo.Foo' />");
 			File.WriteAllText (Path.Combine (path, "foo.map"), @"a\nb");
 			var errors = new List<BuildErrorEventArgs> ();
-			IBuildEngine engine = new MockBuildEngine (TestContext.Out, errors);
+			var warnings = new List<BuildWarningEventArgs> ();
+			var messages = new List<BuildMessageEventArgs> ();
+			IBuildEngine engine = new MockBuildEngine (TestContext.Out, errors, warnings, messages);
 			var archives = new List<ITaskItem>();
-			CallAapt2Compile (engine, resPath, archivePath);
+			CallAapt2Compile (engine, resPath, archivePath, flatFilePath);
 			var outputFile = Path.Combine (path, "resources.apk");
+			int platform = 0;
+			using (var b = new Builder ()) {
+				platform = b.GetMaxInstalledPlatform ();
+			}
 			var task = new Aapt2Link {
 				BuildEngine = engine,
 				ToolPath = GetPathToAapt2 (),
@@ -203,10 +446,58 @@ namespace Xamarin.Android.Build.Tests
 				CompiledResourceFlatArchive = new TaskItem (Path.Combine (path, "compiled.flata")),
 				OutputFile = outputFile,
 				AssemblyIdentityMapFile = Path.Combine (path, "foo.map"),
+				JavaPlatformJarPath = Path.Combine (AndroidSdkPath, "platforms", $"android-{platform}", "android.jar"),
 				ExtraArgs = "--no-crunch "
 			};
 			Assert.False (task.Execute (), "task should have failed.");
 			Assert.AreEqual (1, errors.Count, $"One error should have been raised. {string.Join (" ", errors.Select (e => e.Message))}");
+			Directory.Delete (Path.Combine (Root, path), recursive: true);
+		}
+
+		[Test]
+		public void Aapt2AndroidResgenExtraArgsAreSplit ()
+		{
+			var path = Path.Combine (Root, "temp", TestName);
+			Directory.CreateDirectory (path);
+			var resPath = Path.Combine (path, "res");
+			var archivePath = Path.Combine(path, "flata");
+			var flatFilePath = Path.Combine(path, "flat");
+			Directory.CreateDirectory(resPath);
+			Directory.CreateDirectory(archivePath);
+			Directory.CreateDirectory (Path.Combine (resPath, "values"));
+			Directory.CreateDirectory (Path.Combine (resPath, "layout"));
+			File.WriteAllText (Path.Combine (resPath, "values", "strings.xml"), @"<?xml version='1.0' ?><resources><string name='foo'>foo</string></resources>");
+			File.WriteAllText (Path.Combine (resPath, "layout", "main.xml"), @"<?xml version='1.0' ?><LinearLayout xmlns:android='http://schemas.android.com/apk/res/android' />");
+			File.WriteAllText (Path.Combine (path, "AndroidManifest.xml"), @"<?xml version='1.0' ?><manifest xmlns:android='http://schemas.android.com/apk/res/android' package='Foo.Foo' />");
+			File.WriteAllText (Path.Combine (path, "foo.map"), @"a\nb");
+			var errors = new List<BuildErrorEventArgs> ();
+			var warnings = new List<BuildWarningEventArgs> ();
+			var messages = new List<BuildMessageEventArgs> ();
+			IBuildEngine engine = new MockBuildEngine (TestContext.Out, errors, warnings, messages);
+			var archives = new List<ITaskItem>();
+			CallAapt2Compile (engine, resPath, archivePath, flatFilePath);
+			var outputFile = Path.Combine (path, "resources.apk");
+			int platform = 0;
+			string emitids = Path.Combine (path, "emitids.txt");
+			string Rtxt = Path.Combine (path, "R.txt");
+			using (var b = new Builder ()) {
+				platform = b.GetMaxInstalledPlatform ();
+			}
+			var task = new Aapt2Link {
+				BuildEngine = engine,
+				ToolPath = GetPathToAapt2 (),
+				ResourceDirectories = new ITaskItem [] { new TaskItem (resPath) },
+				ManifestFiles = new ITaskItem [] { new TaskItem (Path.Combine (path, "AndroidManifest.xml")) },
+				CompiledResourceFlatArchive = new TaskItem (Path.Combine (archivePath, "compiled.flata")),				
+				OutputFile = outputFile,
+				AssemblyIdentityMapFile = Path.Combine (path, "foo.map"),
+				JavaPlatformJarPath = Path.Combine (AndroidSdkPath, "platforms", $"android-{platform}", "android.jar"),
+				ExtraArgs = $@"--no-version-vectors -v --emit-ids ""{emitids}"" --output-text-symbols '{Rtxt}'"
+			};
+			Assert.True (task.Execute (), $"task should have succeeded. {string.Join (" ", errors.Select (e => e.Message))}");
+			Assert.AreEqual (0, errors.Count, $"No errors should have been raised. {string.Join (" ", errors.Select (e => e.Message))}");
+			Assert.True (File.Exists (emitids), $"{emitids} should have been created.");
+			Assert.True (File.Exists (Rtxt), $"{Rtxt} should have been created.");
 			Directory.Delete (Path.Combine (Root, path), recursive: true);
 		}
 
@@ -230,6 +521,7 @@ namespace Xamarin.Android.Build.Tests
 			});
 			var resPath = Path.Combine (path, "res");
 			var archivePath = Path.Combine (path, "flata");
+			var flatFilePath = Path.Combine(path, "flat");
 			Directory.CreateDirectory (resPath);
 			Directory.CreateDirectory (archivePath);
 			Directory.CreateDirectory (Path.Combine (resPath, "values"));
@@ -241,7 +533,7 @@ namespace Xamarin.Android.Build.Tests
 			var errors = new List<BuildErrorEventArgs> ();
 			IBuildEngine engine = new MockBuildEngine (TestContext.Out, errors);
 			var archives = new List<ITaskItem> ();
-			CallAapt2Compile (engine, resPath, archivePath);
+			CallAapt2Compile (engine, resPath, archivePath, flatFilePath);
 			var outputFile = Path.Combine (path, "resources.apk");
 			var manifestFile = Path.Combine (path, "AndroidManifest.xml");
 			var task = new Aapt2Link {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CopyIfChangedTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/CopyIfChangedTests.cs
@@ -96,6 +96,26 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void DestinationOlderNoLengthCheck ()
+		{
+			var src = NewFile ("foo");
+			var dest = NewFile ("bar");
+			var now = DateTime.UtcNow;
+			File.SetLastWriteTimeUtc (src, now);
+			File.SetLastWriteTimeUtc (dest, now.AddSeconds (-1)); // destination is older
+
+			var task = new CopyIfChanged {
+				BuildEngine = new MockBuildEngine (TestContext.Out),
+				SourceFiles = ToArray (src),
+				DestinationFiles = ToArray (dest),
+				CompareFileLengths = false,
+			};
+			Assert.IsTrue (task.Execute (), "task.Execute() should have succeeded.");
+			Assert.AreEqual (1, task.ModifiedFiles.Length, "Changes should have been made.");
+			FileAssert.AreEqual (src, dest);
+		}
+
+		[Test]
 		public void SourceOlder ()
 		{
 			var src = NewFile ("foo");
@@ -130,6 +150,26 @@ namespace Xamarin.Android.Build.Tests
 			Assert.IsTrue (task.Execute (), "task.Execute() should have succeeded.");
 			Assert.AreEqual (1, task.ModifiedFiles.Length, "Changes should have been made.");
 			FileAssert.AreEqual (src, dest);
+		}
+
+		[Test]
+		public void SourceOlderDifferentLengthButNoLengthCheck ()
+		{
+			var src = NewFile ("foo");
+			var dest = NewFile ("foofoo");
+			var now = DateTime.UtcNow;
+			File.SetLastWriteTimeUtc (src, now.AddSeconds (-1)); // source is older
+			File.SetLastWriteTimeUtc (dest, now);
+
+			var task = new CopyIfChanged {
+				BuildEngine = new MockBuildEngine (TestContext.Out),
+				SourceFiles = ToArray (src),
+				DestinationFiles = ToArray (dest),
+				CompareFileLengths = false,
+			};
+			Assert.IsTrue (task.Execute (), "task.Execute() should have succeeded.");
+			Assert.AreEqual (0, task.ModifiedFiles.Length, "Changes should not have been made.");
+			FileAssert.AreNotEqual (src, dest);
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
@@ -467,7 +467,8 @@ int xml myxml 0x7f140000
 			CreateResourceDirectory (path);
 			File.WriteAllText (Path.Combine (Root, path, "foo.map"), @"a\nb");
 			Directory.CreateDirectory (Path.Combine (Root, path, "java"));
-			IBuildEngine engine = new MockBuildEngine (TestContext.Out);
+			List<BuildErrorEventArgs> errors = new List<BuildErrorEventArgs> ();
+			IBuildEngine engine = new MockBuildEngine (TestContext.Out, errors: errors);
 			var aapt2Compile = new Aapt2Compile {
 				BuildEngine = engine,
 				ToolPath = GetPathToAapt2 (),
@@ -480,9 +481,10 @@ int xml myxml 0x7f140000
 					}),
 				},
 				FlatArchivesDirectory = Path.Combine (Root, path),
+				FlatFilesDirectory = Path.Combine (Root, path),
 			};
 			
-			Assert.IsTrue (aapt2Compile.Execute (), "Aapt2 Compile should have succeeded.");
+			Assert.IsTrue (aapt2Compile.Execute (), $"Aapt2 Compile should have succeeded. {string.Join (" ", errors.Select (x => x.Message))}");
 			int platform = 0;
 			using (var b = new Builder ()) {
 				platform = b.GetMaxInstalledPlatform ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownPackages.cs
@@ -221,6 +221,28 @@ namespace Xamarin.ProjectTools
 				},
 			}
 		};
+		public static Package XamarinForms_4_4_0_991265 = new Package {
+			Id = "Xamarin.Forms",
+			Version = "4.4.0.991265",
+			TargetFramework = "MonoAndroid90",
+			References =  {
+				new BuildItem.Reference ("Xamarin.Forms.Platform.Android") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.4.4.0.991265\\lib\\MonoAndroid90\\Xamarin.Forms.Platform.Android.dll"
+				},
+				new BuildItem.Reference ("FormsViewGroup") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.4.4.0.991265\\lib\\MonoAndroid90\\FormsViewGroup.dll"
+				},
+				new BuildItem.Reference ("Xamarin.Forms.Core") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.4.4.0.991265\\lib\\MonoAndroid90\\Xamarin.Forms.Core.dll"
+				},
+				new BuildItem.Reference ("Xamarin.Forms.Xaml") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.4.4.0.991265\\lib\\MonoAndroid90\\Xamarin.Forms.Xaml.dll"
+				},
+				new BuildItem.Reference ("Xamarin.Forms.Platform") {
+					MetadataValues = "HintPath=..\\packages\\Xamarin.Forms.4.4.0.991265\\lib\\MonoAndroid90\\Xamarin.Forms.Platform.dll"
+				},
+			}
+		};
 		public static Package AndroidXMigration = new Package {
 			Id = "Xamarin.AndroidX.Migration",
 			Version = "1.0.0-rc1",

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Aapt2Daemon.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Aapt2Daemon.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using Microsoft.Build.Framework;
+using TPL = System.Threading.Tasks;
+
+namespace Xamarin.Android.Tasks
+{
+	internal class Aapt2Daemon : IDisposable
+	{
+		public static Aapt2Daemon GetInstance (IBuildEngine4 engine, string aapt2, int numberOfInstances, int initalNumberOfDaemons, bool registerInDomain = false)
+		{
+			var area = registerInDomain ? RegisteredTaskObjectLifetime.AppDomain : RegisteredTaskObjectLifetime.Build;
+			Aapt2Daemon daemon = (Aapt2Daemon)engine.GetRegisteredTaskObject (typeof (Aapt2Daemon).FullName, area);
+			if (daemon == null)
+			{
+				daemon = new Aapt2Daemon (aapt2, numberOfInstances, initalNumberOfDaemons);
+				engine.RegisterTaskObject (typeof (Aapt2Daemon).FullName, daemon, area, allowEarlyCollection: false);
+			}
+			return daemon;
+		}
+
+		public class Job
+		{
+			TPL.TaskCompletionSource<bool> tcs = new TPL.TaskCompletionSource<bool> ();
+			List<OutputLine> output = new List<OutputLine> ();
+			public string[] Commands { get; private set; }
+			public long JobId { get; private set; }
+			public string OutputFile { get; private set; }
+			public bool Succeeded { get; set; }
+			public TPL.Task Task => tcs.Task;
+			public IList<OutputLine> Output => output;
+			public Job (string[] commands, long jobId, string outputFile)
+			{
+				Commands = commands;
+				JobId = jobId;
+				OutputFile = outputFile;
+			}
+
+			public void Complete (bool result)
+			{
+				Succeeded = !result;
+				tcs.TrySetResult (!result);
+			}
+		}
+
+		readonly object lockObject = new object ();
+		readonly BlockingCollection<Job> pendingJobs = new BlockingCollection<Job> ();
+		readonly ConcurrentDictionary<long, Job> jobs = new ConcurrentDictionary<long, Job> ();
+		readonly CancellationTokenSource tcs = new CancellationTokenSource ();
+		readonly ConcurrentBag<Thread> daemons = new ConcurrentBag<Thread> ();
+
+		long jobsRunning = 0;
+		long jobId = 0;
+		int maxInstances = 0;
+
+		public CancellationToken Token => tcs.Token;
+
+		public bool JobsInQueue => pendingJobs.Count > 0;
+
+		public bool JobsRunning
+		{
+			get
+			{
+				return Interlocked.Read (ref jobsRunning) > 0;
+			}
+		}
+		public string Aapt2 { get; private set; }
+
+		public string ToolName { get { return Path.GetFileName (Aapt2); } }
+
+		public int MaxInstances => maxInstances;
+
+		public int CurrentInstances => daemons.Count;
+
+		public Aapt2Daemon (string aapt2, int maxNumberOfInstances, int initalNumberOfDaemons)
+		{
+			Aapt2 = aapt2;
+			maxInstances = maxNumberOfInstances;
+			for (int i = 0; i < initalNumberOfDaemons; i++) {
+				SpawnAapt2Daemon ();
+			}
+		}
+
+		void SpawnAapt2Daemon ()
+		{
+			// Don't spawn too many
+			if (daemons.Count >= maxInstances)
+				return;
+			var thread = new Thread (Aapt2DaemonStart)
+			{
+				IsBackground = true
+			};
+			thread.Start ();
+			daemons.Add(thread);
+		}
+
+		public void Dispose ()
+		{
+			Stop ();
+			tcs.Cancel ();
+		}
+
+		public long QueueCommand (string[] job, string outputFile)
+		{
+			if (!pendingJobs.IsAddingCompleted)
+			{
+				long id = Interlocked.Add (ref jobId, 1);
+				var j = new Job (job, id, outputFile);
+				jobs [j.JobId] = j;
+				pendingJobs.Add (j);
+				// if we have allot of pending jobs, spawn more daemons
+				if (pendingJobs.Count > (daemons.Count * 2)) {
+					SpawnAapt2Daemon ();
+				}
+				return j.JobId;
+			}
+			return -1;
+		}
+
+		public bool JobSucceded (long jobid) {
+			return jobs [jobid].Succeeded;
+		}
+
+		public Job [] WaitForJobsToComplete (IEnumerable <long> jobIds)
+		{
+			List<TPL.Task> completedJobsTasks = new List<TPL.Task> ();
+			List<Job> results = new List<Job> ();
+			foreach (var job in jobIds) {
+				completedJobsTasks.Add (jobs [job].Task);
+				results.Add (jobs [job]);
+			}
+			TPL.Task.WaitAll (completedJobsTasks.ToArray ());
+			return results.ToArray ();
+		}
+
+		public void Stop ()
+		{
+			//This will cause '_jobs.GetConsumingEnumerable' to stop blocking and exit when it's empty
+			pendingJobs.CompleteAdding ();
+		}
+
+		private void Aapt2DaemonStart ()
+		{
+			ProcessStartInfo info = new ProcessStartInfo (Aapt2)
+			{
+				Arguments = "daemon",
+				CreateNoWindow = true,
+				WindowStyle = ProcessWindowStyle.Hidden,
+				RedirectStandardInput = true,
+				RedirectStandardError = true,
+				RedirectStandardOutput = true,
+				UseShellExecute = false,
+				WorkingDirectory = Path.GetTempPath (),
+				StandardErrorEncoding = Encoding.UTF8,
+				StandardOutputEncoding = Encoding.UTF8,
+				// Cant use this cos its netstandard 2.1 only
+				// and we are using netstandard 2.0
+				//StandardInputEncoding = Encoding.UTF8,
+			};
+			// We need to FORCE the StandardInput to be UTF8 so we can use 
+			// accented characters. Also DONT INCLUDE A BOM!!
+			// otherwise aapt2 will try to interpret the BOM as an argument.
+			Process aapt2;
+			lock (lockObject) {
+				Encoding current = Console.InputEncoding;
+				try {
+					Console.InputEncoding = new UTF8Encoding (false);
+					aapt2 = new Process ();
+					aapt2.StartInfo = info;
+					aapt2.Start ();
+				} finally {
+					Console.InputEncoding = current;
+				}
+			}
+			try {
+				foreach (var job in pendingJobs.GetConsumingEnumerable (tcs.Token)) {
+					Interlocked.Add (ref jobsRunning, 1);
+					bool errored = false;
+					try {
+						// try to write Unicode UTF8 to aapt2
+						StreamWriter writer = aapt2.StandardInput;
+						foreach (var arg in job.Commands)
+						{
+							writer.WriteLine (arg);
+						}
+						writer.WriteLine ();
+						writer.Flush ();
+						string line;
+						
+						Queue<string> stdError = new Queue<string> ();
+						while ((line = aapt2.StandardError.ReadLine ()) != null) {
+							if (string.Compare (line, "Done", StringComparison.OrdinalIgnoreCase) == 0) {
+								break;
+							}
+							if (string.Compare (line, "Error", StringComparison.OrdinalIgnoreCase) == 0) {
+								errored = true;
+								continue;
+							}
+							// we have to queue the output because the "Done"/"Error" lines are 
+							//written after all the messages. So to process the warnings/errors 
+							// correctly we need to do this after we know if worked or failed.
+							stdError.Enqueue (line);
+						}
+						//now processed the output we queued up
+						while (stdError.Count > 0) {
+							line = stdError.Dequeue ();
+							job.Output.Add (new OutputLine (line, stdError: !IsAapt2Warning (line), errored: errored, jobId: job.JobId));
+						}
+						// wait for the file we expect to be created. There can be a delay between
+						// the daemon saying "Done" and the file finally being written to disk.
+						if (!string.IsNullOrEmpty (job.OutputFile) && !errored) {
+							while (!File.Exists (job.OutputFile)) {
+								Thread.Sleep (10);
+							}
+						}
+					} catch (Exception ex) {
+						errored = true;
+						job.Output.Add (new OutputLine (ex.Message, stdError: true, errored: errored, job.JobId));
+					} finally {
+						Interlocked.Decrement (ref jobsRunning);
+						jobs [job.JobId].Complete (errored);
+					}
+				}
+			}
+			catch (OperationCanceledException)
+			{
+				// Ignore this error. It occurs when the Task is cancelled.
+			}
+			aapt2.StandardInput.WriteLine ("quit");
+			aapt2.StandardInput.WriteLine ();
+			aapt2.WaitForExit ((int)TimeSpan.FromSeconds (5).TotalMilliseconds);
+		}
+
+		bool IsAapt2Warning (string singleLine)
+		{
+			var match = AndroidRunToolTask.AndroidErrorRegex.Match (singleLine.Trim ());
+			if (match.Success)
+			{
+				var file = match.Groups ["file"].Value;
+				var level = match.Groups ["level"].Value.ToLowerInvariant();
+				var message = match.Groups ["message"].Value;
+				if (singleLine.StartsWith ($"{ToolName} W", StringComparison.OrdinalIgnoreCase))
+					return true;
+				if (file.StartsWith ("W/", StringComparison.OrdinalIgnoreCase))
+					return true;
+				if (message.Contains ("warn:"))
+					return true;
+				if (level.Contains ("warning"))
+					return true;
+			}
+			return false;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
@@ -228,5 +228,20 @@ namespace Monodroid {
 			}
 			return value;
 		}
+
+
+		/// Compute the output filename that aapt2 will produce for a resource
+		/// for example
+		///		layout\main.xml => layout_main.xml.flat
+		///		values\values.xml -> values_values.arsc.flat
+		///		values\strings.xml -> values_strings.arsc.flat
+		public static string CalculateAapt2FlatArchiveFileName (string file)
+		{
+			var dir = Path.GetFileName (Path.GetDirectoryName (file)).TrimEnd ('\\').TrimEnd ('/');
+			var ext = Path.GetExtension (file);
+			if (dir.StartsWith ("values", StringComparison.OrdinalIgnoreCase))
+				ext = ".arsc";
+			return $"{dir}_{Path.GetFileNameWithoutExtension (file)}{ext}.flat";
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/Files.cs
@@ -351,6 +351,8 @@ namespace Xamarin.Android.Tools
 				foreach (var file in Directory.GetFiles (destination, "*", SearchOption.AllDirectories)) {
 					var outfile = Path.GetFullPath (file);
 					if (outfile.Contains ("/__MACOSX/") ||
+							outfile.EndsWith (".flat", StringComparison.OrdinalIgnoreCase) ||
+							outfile.EndsWith ("files.cache", StringComparison.OrdinalIgnoreCase) ||
 							outfile.EndsWith ("__AndroidLibraryProjects__.zip", StringComparison.OrdinalIgnoreCase) ||
 							outfile.EndsWith ("/__MACOSX", StringComparison.OrdinalIgnoreCase) ||
 							outfile.EndsWith ("/.DS_Store", StringComparison.OrdinalIgnoreCase))

--- a/src/Xamarin.Android.Build.Tasks/Utilities/OutputLine.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/OutputLine.cs
@@ -4,10 +4,16 @@ namespace Xamarin.Android.Tasks {
 		public string Line;
 		public bool StdError;
 
-		public OutputLine (string line, bool stdError)
+		public bool Errored;
+
+		public long JobId;
+
+		public OutputLine (string line, bool stdError, bool errored = false, long jobId = 0)
 		{
 			Line = line;
 			StdError = stdError;
+			Errored = errored;
+			JobId = jobId;
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -289,6 +289,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<_AndroidAapt2VersionFile>$(IntermediateOutputPath)aapt2.version</_AndroidAapt2VersionFile>
 	<_AndroidIntermediateDesignTimeBuildDirectory>$(IntermediateOutputPath)designtime\</_AndroidIntermediateDesignTimeBuildDirectory>
 	<_AndroidLibraryFlatArchivesDirectory>$(IntermediateOutputPath)flata\</_AndroidLibraryFlatArchivesDirectory>
+	<_AndroidLibraryFlatFilesDirectory>$(IntermediateOutputPath)flat\</_AndroidLibraryFlatFilesDirectory>
 	<_AndroidStampDirectory>$(IntermediateOutputPath)stamp\</_AndroidStampDirectory>
 	<_AndroidBuildIdFile>$(IntermediateOutputPath)buildid.txt</_AndroidBuildIdFile>
         <_AndroidApplicationSharedLibraryPath>$(IntermediateOutputPath)app_shared_libraries\</_AndroidApplicationSharedLibraryPath>
@@ -445,6 +446,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<PrepareWearApplicationFiles
 		PackageName="$(_AndroidPackage)"
 		IntermediateOutputPath="$(IntermediateOutputPath)"
+		AndroidLibraryFlatFilesDirectory="$(_AndroidLibraryFlatFilesDirectory)"
 		WearAndroidManifestFile="$(BundledWearApplicationManifestFile)"
 		WearApplicationApkPath="$(BundledWearApplicationApkPath)">
 		<Output TaskParameter="WearableApplicationDescriptionFile" ItemName="_WearableApplicationDescriptionFile" />
@@ -773,7 +775,13 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     DependsOnTargets="_SetLatestTargetFrameworkVersion">
 </Target>
 
-<Target Name="_SetLatestTargetFrameworkVersion" DependsOnTargets="_ResolveSdks;_CreateAapt2VersionCache">
+<PropertyGroup>
+	<_SetLatestTargetFrameworkVersionDependsOnTargets>
+		_ResolveSdks;
+	</_SetLatestTargetFrameworkVersionDependsOnTargets>
+</PropertyGroup>
+
+<Target Name="_SetLatestTargetFrameworkVersion" DependsOnTargets="$(_SetLatestTargetFrameworkVersionDependsOnTargets)">
 </Target>
 
 <Target Name="_ResolveSdks" DependsOnTargets="_GetReferenceAssemblyPaths">
@@ -1286,7 +1294,13 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
   
 <Target Name="_ComputeAndroidResourcePaths">
-	<AndroidComputeResPaths ResourceFiles="@(AndroidResource);@(AndroidBoundLayout)" IntermediateDir="$(MonoAndroidResDirIntermediate)" Prefixes="$(MonoAndroidResourcePrefix)" LowercaseFilenames="True" ProjectDir="$(ProjectDir)">
+	<AndroidComputeResPaths ResourceFiles="@(AndroidResource);@(AndroidBoundLayout)"
+			IntermediateDir="$(MonoAndroidResDirIntermediate)"
+			Prefixes="$(MonoAndroidResourcePrefix)"
+			LowercaseFilenames="True"
+			ProjectDir="$(ProjectDir)"
+			AndroidLibraryFlatFilesDirectory="$(_AndroidLibraryFlatFilesDirectory)"
+	>
 		<Output ItemName="_AndroidResourceDest" TaskParameter="IntermediateFiles" />
 		<Output PropertyName="_AndroidResourceNameCaseMap" TaskParameter="ResourceNameCaseMap" />
 		<Output ItemName="_AndroidResolvedResources" TaskParameter="ResolvedResourceFiles" />
@@ -1305,6 +1319,7 @@ because xbuild doesn't support framework reference assemblies.
 	/>
 	<CopyIfChanged SourceFiles="@(_AndroidResolvedResources)"
 		DestinationFiles="@(_AndroidResourceDest)"
+		CompareFileLengths="False"
 	>
 		<Output ItemName="_ModifiedResources" TaskParameter="ModifiedFiles"/>
 	</CopyIfChanged>
@@ -1472,7 +1487,27 @@ because xbuild doesn't support framework reference assemblies.
 	</ItemGroup>
 </Target>
 
+<Target Name="_IncludeModifiedFilesInUpdateAndroidResgenInputs">
+  <PropertyGroup>
+    <_UpdateAndroidResgenInputs>
+      $(_UpdateAndroidResgenInputs);
+      @(_ModifiedResources);
+    </_UpdateAndroidResgenInputs>
+      <_CreateBaseApkInputs>
+        $(_CreateBaseApkInputs);
+        @(_ModifiedResources);
+      </_CreateBaseApkInputs>
+  </PropertyGroup>
+</Target>
+
+<PropertyGroup>
+  <_PrepareUpdateAndroidResgenDependsOnTargets>
+    _IncludeModifiedFilesInUpdateAndroidResgenInputs;
+  </_PrepareUpdateAndroidResgenDependsOnTargets>
+</PropertyGroup>
+
 <Target Name="_PrepareUpdateAndroidResgen"
+    DependsOnTargets="$(_PrepareUpdateAndroidResgenDependsOnTargets)"
     Inputs="$(_UpdateAndroidResgenInputs)"
     Outputs="$(_AndroidResgenFlagFile)">
     
@@ -1507,18 +1542,18 @@ because xbuild doesn't support framework reference assemblies.
 	<_UpdateAndroidResgenInputs>
 		$(MSBuildAllProjects);
 		@(_AndroidResourceDest);
-		@(_LibraryResourceDirectoryStamps);
 		$(_AndroidBuildPropertiesCache);
 		$(ProjectAssetsFile);
 		$(_AndroidLibraryProjectImportsCache);
 		$(_AndroidLibraryImportsCache);
+		@(_ModifiedResources);
 	</_UpdateAndroidResgenInputs>
 </PropertyGroup>
 
 <Target Name="_UpdateAndroidResgen"
 	Inputs="$(_UpdateAndroidResgenInputs)"
 	Outputs="$(_AndroidResgenFlagFile)"
-	DependsOnTargets="$(_UpdateAndroidResgenDependsOnTargets);$(_AfterGenerateAndroidResourceDir);_CompileAndroidLibraryResources;_CompileResources;_PrepareUpdateAndroidResgen">
+	DependsOnTargets="$(_UpdateAndroidResgenDependsOnTargets);$(_AfterGenerateAndroidResourceDir);_PrepareUpdateAndroidResgen">
 
 	<CallTarget Targets="_UpdateAndroidResgenAapt" Condition="'$(_AndroidUseAapt2)' != 'True'" />
 	<CallTarget Targets="_UpdateAndroidResgenAapt2" Condition="'$(_AndroidUseAapt2)' == 'True'" />
@@ -2141,7 +2176,7 @@ because xbuild doesn't support framework reference assemblies.
     _GenerateJavaStubs;
     _ManifestMerger;
     _ConvertCustomView;
-    _FixupCustomViewsForAapt2;
+    $(_AfterConvertCustomView);
     _GenerateEnvironmentFiles;
     _AddStaticResources;
     $(_AfterAddStaticResources);
@@ -2221,7 +2256,7 @@ because xbuild doesn't support framework reference assemblies.
 		_GenerateJavaStubs;
 		_ManifestMerger;
 		_ConvertCustomView;
-		_FixupCustomViewsForAapt2;
+		$(_AfterConvertCustomView);
 		_GenerateEnvironmentFiles;
 		_GetLibraryImports;
 		_CheckDuplicateJavaLibraries;
@@ -2234,7 +2269,6 @@ because xbuild doesn't support framework reference assemblies.
 		;@(_AndroidResourceDest)
 		;@(_AndroidAssetsDest)
 		;$(_AcwMapFile)
-		;@(_LibraryResourceDirectoryStamps)
 		;$(_AndroidBuildPropertiesCache)
 	</_CreateBaseApkInputs>
 </PropertyGroup>
@@ -2268,7 +2302,7 @@ because xbuild doesn't support framework reference assemblies.
   </ItemGroup>
 </Target>
 
-<Target Name="_FindJavaStubFiles" DependsOnTargets="_GenerateJavaStubs;_ManifestMerger;_ConvertCustomView;_FixupCustomViewsForAapt2;_GenerateEnvironmentFiles;">
+<Target Name="_FindJavaStubFiles" DependsOnTargets="_GenerateJavaStubs;_ManifestMerger;_ConvertCustomView;$(_AfterConvertCustomView);_GenerateEnvironmentFiles;">
   <ItemGroup>
     <_JavaStubFiles Include="$(_AndroidIntermediateJavaSourceDirectory)**\*.java" />
     <FileWrites Include="@(_JavaStubFiles)" />
@@ -2598,7 +2632,7 @@ because xbuild doesn't support framework reference assemblies.
 		_GenerateJavaStubs;
 		_ManifestMerger;
 		_ConvertCustomView;
-		_FixupCustomViewsForAapt2;
+		$(_AfterConvertCustomView);
 		$(AfterGenerateAndroidManifest);
 		_GenerateEnvironmentFiles;
 		_CompileJava;
@@ -3113,6 +3147,7 @@ because xbuild doesn't support framework reference assemblies.
 	<RemoveDirFixed Directories="$(MonoAndroidIntermediateResourceCache)" Condition="Exists ('$(MonoAndroidIntermediateResourceCache)')" />
 	<RemoveDirFixed Directories="$(_AndroidAotBinDirectory)" Condition="Exists ('$(_AndroidAotBinDirectory)')" />
 	<RemoveDirFixed Directories="$(_AndroidLibraryFlatArchivesDirectory)" Condition="Exists ('$(_AndroidLibraryFlatArchivesDirectory)')" />
+	<RemoveDirFixed Directories="$(_AndroidLibraryFlatFilesDirectory)" Condition="Exists ('$(_AndroidLibraryFlatFilesDirectory)')" />
 	<RemoveDirFixed Directories="$(_AndroidStampDirectory)" Condition="Exists ('$(_AndroidStampDirectory)')" />
 	<RemoveDirFixed Directories="$(_AndroidApplicationSharedLibraryPath)" Condition="Exists ('$(_AndroidApplicationSharedLibraryPath)')" />
  	<Delete Files="$(IntermediateOutputPath)R.cs.flag" />

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1493,10 +1493,10 @@ because xbuild doesn't support framework reference assemblies.
       $(_UpdateAndroidResgenInputs);
       @(_ModifiedResources);
     </_UpdateAndroidResgenInputs>
-      <_CreateBaseApkInputs>
-        $(_CreateBaseApkInputs);
-        @(_ModifiedResources);
-      </_CreateBaseApkInputs>
+    <_CreateBaseApkInputs>
+      $(_CreateBaseApkInputs);
+      @(_ModifiedResources);
+    </_CreateBaseApkInputs>
   </PropertyGroup>
 </Target>
 

--- a/src/aapt2/aapt2.targets
+++ b/src/aapt2/aapt2.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask AssemblyFile="$(PrepTasksAssembly)" TaskName="Xamarin.Android.BuildTools.PrepTasks.DownloadUri" />
   <PropertyGroup>
-    <Aapt2Version>3.5.0-5435860</Aapt2Version>
+    <Aapt2Version>3.5.3-5435860</Aapt2Version>
     <BuildDependsOn>
       ResolveReferences;
       _DownloadAapt2;

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -62,8 +62,21 @@ namespace Xamarin.Android.Build.Tests
 
 			action (builder);
 			var actual = builder.LastBuildTime.TotalMilliseconds;
+			TestContext.Out.WriteLine($"expected: {expected}ms, actual: {actual}ms");
 			if (actual > expected) {
 				Assert.Fail ($"Exceeded expected time of {expected}ms, actual {actual}ms");
+			}
+		}
+
+		[Test]
+		public void Build_From_Clean_DontIncludeRestore ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.MainActivity = proj.DefaultMainActivity;
+			using (var builder = CreateApkBuilder ()) {
+				builder.Target = "Build";
+				builder.Restore (proj);
+				Profile (builder, b => b.Build (proj));
 			}
 		}
 

--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -2,6 +2,7 @@
 # First non-comment row is human description of columns
 Test Name,Time in ms (int)
 # Data
+Build_From_Clean_DontIncludeRestore,10000
 Build_No_Changes,3250
 Build_CSharp_Change,4450
 Build_AndroidResource_Change,4150


### PR DESCRIPTION
The `aapt2 compile` command runs in two modes. The one we
currently use is the `archive` mode. We calling `aapt2 compile`
with the `--dir` argument you end up generating one `flata`
archive for all the files. The side effect of this is that even
if you only change one file, it will need to regenerate the
entire `flata` archive.

But it has a second mode. Rather than using `--dir` you just send
in a single file. This then writes a single `.flat` file to the
output directory. While this does mean you have to call `aapt2 compile`
for EVERY file, it does mean we can leverage MSbuilds support for
partial targets. This means MSbuild will detect ONLY the files which
changed and allow us to call `aapt2 compile` with just THOSE files.

While this may impact on initial build times, the goal is to make
incremental builds quicker. This is especially true for users to
use ALLOT of `AndroidResource` items.

A note regarding the `aapt2 daemon` mode. In order to write
accented characters we need to set the `StandardInput`
encoding to UTF8. This is not possible directly
in netstandard 2.0. So we have to use `Console.InputEncoding`
instead. Also not that we MUST not include a BOM when writting
the commands. This is because `aapt2` will try to parse the BOM
as command characters.

Also the `aapt2 link` command sometimes reports it is "Done" before
it has even written the archive for the file. So we can get into a
position where we think we are done but the file is not on disk.
So we have had to include a nasty wait which will poll for the
existence of the expected output file and only return when it
exists. The good news is we know at this point if the command
failed or not, so we can bypass the check on failure.

| Test         | Latest Stable | Aapt2 Daemon |
|--------------|---------------|--------------|
| From Clean   | 00:00:27.92   | 00:00:27.41  |
| No Changes   | 00:00:03.14   | 00:00:03.72  |
| Alter Layout | 00:00:16.37   | 00:00:05.53  |