### PR TITLE
[Xamarin.Android.Build.Tasks] Move XA1006, XA1007, XA1008 message text into .resx file

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -72,9 +72,9 @@ ms.date: 01/24/2020
 + [XA1003](xa1003.md): '{zip}' does not exist. Please rebuild the project.
 + [XA1004](xa1004.md): There was an error opening {filename}. The file is probably corrupt. Try deleting it and building again.
 + [XA1005](xa1005.md): Attempting naive type name fixup for element with ID '{id}' and type '{managedType}'
-+ [XA1006](xa1006.md): Your application is running on a version of Android ({compileSdk}) that is more recent than your targetSdkVersion specifies ({targetSdk}). Set your targetSdkVersion to the highest version of Android available to match your TargetFrameworkVersion ({compileSdk}).
++ [XA1006](xa1006.md): The TargetFrameworkVersion (Android API level {compileSdk}) is higher than the targetSdkVersion ({targetSdk}).
 + [XA1007](xa1007.md): The minSdkVersion ({minSdk}) is greater than targetSdkVersion. Please change the value such that minSdkVersion is less than or equal to targetSdkVersion ({targetSdk}).
-+ [XA1008](xa1008.md): The TargetFrameworkVersion ({compileSdk}) should not be lower than targetSdkVersion ({targetSdk})
++ [XA1008](xa1008.md): The TargetFrameworkVersion (Android API level {compileSdk}) is lower than the targetSdkVersion ({targetSdk}).
 + [XA1009](xa1009.md): The {assembly} is Obsolete. Please upgrade to {assembly} {version}
 
 ## XA2xxx: Linker

--- a/Documentation/guides/messages/xa1006.md
+++ b/Documentation/guides/messages/xa1006.md
@@ -1,14 +1,14 @@
 ---
 title: Xamarin.Android warning XA1006
 description: XA1006 warning code
-ms.date: 02/18/2019
+ms.date: 01/27/2020
 ---
 # Xamarin.Android warning XA1006
 
 ```
-You are building against a version of Android (compileSdk) that
-is more recent than your targetSdkVersion specifies (targetSdk).
+The TargetFrameworkVersion (Android API level {compileSdk}) is higher than the
+targetSdkVersion ({targetSdk}).
 
-Set your targetSdkVersion to the highest version of Android available
-to match your TargetFrameworkVersion (compileSdk).
+Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so
+that the API levels match.
 ```

--- a/Documentation/guides/messages/xa1008.md
+++ b/Documentation/guides/messages/xa1008.md
@@ -1,15 +1,15 @@
 ---
 title: Xamarin.Android warning XA1008
 description: XA1008 warning code
-ms.date: 02/18/2019
+ms.date: 01/27/2020
 ---
 # Xamarin.Android warning XA1008
 
 ```
-The TargetFrameworkVersion (compileSdk) must not be lower
-than targetSdkVersion (targetSdk).
+The TargetFrameworkVersion (Android API level {compileSdk}) is lower than the
+targetSdkVersion ({targetSdk}).
 
-You should either, increase the `$(TargetFrameworkVersion)`
-of your project. Or decrease the `android:targetSdkVersion`
-in your `AndroidManifest.xml` to correct this issue.
+Please increase the `$(TargetFrameworkVersion)` or decrease the
+`android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels
+match.
 ```

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -79,6 +79,33 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match..
+        /// </summary>
+        internal static string XA1006 {
+            get {
+                return ResourceManager.GetString("XA1006", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1})..
+        /// </summary>
+        internal static string XA1007 {
+            get {
+                return ResourceManager.GetString("XA1007", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match..
+        /// </summary>
+        internal static string XA1008 {
+            get {
+                return ResourceManager.GetString("XA1008", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Source file &apos;{0}&apos; could not be found..
         /// </summary>
         internal static string XA2001 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -125,6 +125,24 @@
     <value>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</value>
     <comment>"xamarin:managedType" is a literal name and should not be translated.</comment>
   </data>
+  <data name="XA1006" xml:space="preserve">
+    <value>The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</value>
+    <comment>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</comment>
+  </data>
+  <data name="XA1007" xml:space="preserve">
+    <value>The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</value>
+    <comment>The following are literal names and should not be translated: minSdkVersion, targetSdkVersion
+{0} - The minimum SDK version number
+{1} - The target SDK version number</comment>
+  </data>
+  <data name="XA1008" xml:space="preserve">
+    <value>The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</value>
+    <comment>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</comment>
+  </data>
   <data name="XA2001" xml:space="preserve">
     <value>Source file '{0}' could not be found.</value>
   </data>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -12,6 +12,27 @@
         <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1006">
+        <source>The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1007">
+        <source>The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</source>
+        <target state="new">The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</target>
+        <note>The following are literal names and should not be translated: minSdkVersion, targetSdkVersion
+{0} - The minimum SDK version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1008">
+        <source>The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -12,6 +12,27 @@
         <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1006">
+        <source>The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1007">
+        <source>The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</source>
+        <target state="new">The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</target>
+        <note>The following are literal names and should not be translated: minSdkVersion, targetSdkVersion
+{0} - The minimum SDK version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1008">
+        <source>The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -12,6 +12,27 @@
         <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1006">
+        <source>The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1007">
+        <source>The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</source>
+        <target state="new">The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</target>
+        <note>The following are literal names and should not be translated: minSdkVersion, targetSdkVersion
+{0} - The minimum SDK version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1008">
+        <source>The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -12,6 +12,27 @@
         <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1006">
+        <source>The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1007">
+        <source>The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</source>
+        <target state="new">The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</target>
+        <note>The following are literal names and should not be translated: minSdkVersion, targetSdkVersion
+{0} - The minimum SDK version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1008">
+        <source>The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -12,6 +12,27 @@
         <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1006">
+        <source>The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1007">
+        <source>The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</source>
+        <target state="new">The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</target>
+        <note>The following are literal names and should not be translated: minSdkVersion, targetSdkVersion
+{0} - The minimum SDK version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1008">
+        <source>The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -12,6 +12,27 @@
         <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1006">
+        <source>The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1007">
+        <source>The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</source>
+        <target state="new">The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</target>
+        <note>The following are literal names and should not be translated: minSdkVersion, targetSdkVersion
+{0} - The minimum SDK version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1008">
+        <source>The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -12,6 +12,27 @@
         <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1006">
+        <source>The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1007">
+        <source>The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</source>
+        <target state="new">The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</target>
+        <note>The following are literal names and should not be translated: minSdkVersion, targetSdkVersion
+{0} - The minimum SDK version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1008">
+        <source>The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -12,6 +12,27 @@
         <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1006">
+        <source>The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1007">
+        <source>The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</source>
+        <target state="new">The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</target>
+        <note>The following are literal names and should not be translated: minSdkVersion, targetSdkVersion
+{0} - The minimum SDK version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1008">
+        <source>The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -12,6 +12,27 @@
         <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1006">
+        <source>The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1007">
+        <source>The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</source>
+        <target state="new">The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</target>
+        <note>The following are literal names and should not be translated: minSdkVersion, targetSdkVersion
+{0} - The minimum SDK version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1008">
+        <source>The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -12,6 +12,27 @@
         <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1006">
+        <source>The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1007">
+        <source>The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</source>
+        <target state="new">The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</target>
+        <note>The following are literal names and should not be translated: minSdkVersion, targetSdkVersion
+{0} - The minimum SDK version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1008">
+        <source>The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -12,6 +12,27 @@
         <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1006">
+        <source>The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1007">
+        <source>The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</source>
+        <target state="new">The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</target>
+        <note>The following are literal names and should not be translated: minSdkVersion, targetSdkVersion
+{0} - The minimum SDK version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1008">
+        <source>The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -12,6 +12,27 @@
         <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1006">
+        <source>The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1007">
+        <source>The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</source>
+        <target state="new">The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</target>
+        <note>The following are literal names and should not be translated: minSdkVersion, targetSdkVersion
+{0} - The minimum SDK version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1008">
+        <source>The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -12,6 +12,27 @@
         <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
+      <trans-unit id="XA1006">
+        <source>The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is higher than the targetSdkVersion ({1}). Please increase the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1007">
+        <source>The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</source>
+        <target state="new">The minSdkVersion ({0}) is greater than the targetSdkVersion. Please change the value such that the minSdkVersion is less than or equal to the targetSdkVersion ({1}).</target>
+        <note>The following are literal names and should not be translated: minSdkVersion, targetSdkVersion
+{0} - The minimum SDK version number
+{1} - The target SDK version number</note>
+      </trans-unit>
+      <trans-unit id="XA1008">
+        <source>The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</source>
+        <target state="new">The TargetFrameworkVersion (Android API level {0}) is lower than the targetSdkVersion ({1}). Please increase the `$(TargetFrameworkVersion)` or decrease the `android:targetSdkVersion` in the `AndroidManifest.xml` so that the API levels match.</target>
+        <note>The following are literal names and should not be translated: targetSdkVersion, TargetFrameworkVersion, android:targetSdkVersion, AndroidManifest.xml
+{0} - The target framework version number
+{1} - The target SDK version number</note>
+      </trans-unit>
       <trans-unit id="XA2001">
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CheckGoogleSdkRequirements.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CheckGoogleSdkRequirements.cs
@@ -35,18 +35,15 @@ namespace Xamarin.Android.Tasks
 
 			//We should throw a warning if the targetSdkVersion is lower than compileSdkVersion(TargetFrameworkVersion).
 			if (targetSdk < compileSdk) {
-				Log.LogCodedWarning ("XA1006",
-					$"You are building against version of Android ({compileSdk}) that is more recent than your targetSdkVersion specifies ({targetSdk}). Set your targetSdkVersion to the highest version of Android available to match your TargetFrameworkVersion ({compileSdk}).");
+				Log.LogCodedWarning ("XA1006", Properties.Resources.XA1006, compileSdk, targetSdk);
 			}
 			//We should throw an warning if the compileSdkVersion(TargetFrameworkVersion) is lower than targetSdkVersion.
 			if (compileSdk < targetSdk) {
-				Log.LogCodedWarning ("XA1008",
-					$"The TargetFrameworkVersion ({compileSdk}) must not be lower than targetSdkVersion ({targetSdk}). You should either, increase the `$(TargetFrameworkVersion)` of your project. Or decrease the `android:targetSdkVersion` in your `AndroidManifest.xml` to correct this issue.");
+				Log.LogCodedWarning ("XA1008", Properties.Resources.XA1008, compileSdk, targetSdk);
 			}
 			//We should throw an warning if the minSdkVersion is greater than targetSdkVers1ion.
 			if (minSdk > targetSdk) {
-				Log.LogCodedWarning ("XA1007",
-					$"The minSdkVersion ({minSdk}) is greater than targetSdkVersion. Please change the value such that minSdkVersion is less than or equal to targetSdkVersion ({targetSdk}).");
+				Log.LogCodedWarning ("XA1007", Properties.Resources.XA1007, minSdk, targetSdk);
 			}
 
 			return !Log.HasLoggedErrors;


### PR DESCRIPTION
Context: [0342fe56][0]
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Move the text for the XA1006, XA1007, and XA1008 messages into the
`.resx` file.

Other changes:

Remove "you" and "your" from the messages.

Clarify that the number shown for `$(TargetFrameworkVersion)` is the
corresponding Android API level, not the `$(TargetFrameworkVersion)`
itself.

Make the messages for XA1006 and XA1008 more similar to each other.

[0]: https://github.com/xamarin/xamarin-android/commit/0342fe5698b86e21e36c924732ff135b9a87e4af