### PR TITLE
[timing] Update timing definition files

### DIFF
--- a/build-tools/scripts/TimingDefinitions.txt
+++ b/build-tools/scripts/TimingDefinitions.txt
@@ -3,5 +3,5 @@ last=monodroid-timing:\s+(?<message>.*)$
 
 # measure time of runtime and JNIEnv initialization end
 init=monodroid-timing:\s+(?<message>Runtime\.init: end native-to-managed.*)$
-JNI.init=monodroid-timing:\s+(?<message>JNIEnv\.Initialize end:.*)$
+JNI.init=monodroid-timing:\s+(?<message>JNIEnv\.Initialize end;.*)$
 NUnit.results=NUnitLite: Passed:

--- a/tests/Xamarin.Forms-Performance-Integration/Droid/timing-definitions.txt
+++ b/tests/Xamarin.Forms-Performance-Integration/Droid/timing-definitions.txt
@@ -3,12 +3,12 @@ last=monodroid-timing:\s+(?<message>.*)$
 
 # measure time of runtime and JNIEnv initialization end
 init=monodroid-timing:\s+(?<message>Runtime\.init: end native-to-managed.*)$
-JNI.init=monodroid-timing:\s+(?<message>JNIEnv\.Initialize end:.*)$
+JNI.init=monodroid-timing:\s+(?<message>JNIEnv\.Initialize end;.*)$
 
 # measure UI startup
-OnCreateBegin=mono-stdout: startup-timing: (?<message>OnCreate reached)$
-OnCreateEnd=mono-stdout: startup-timing: (?<message>OnCreate end reached)$
-OnStartBegin=mono-stdout: startup-timing: (?<message>OnStart reached)$
-OnStartEnd=mono-stdout: startup-timing: (?<message>OnStart end reached)$
-OnResumeBegin=mono-stdout: startup-timing: (?<message>OnResume reached)$
-OnResumeEnd=mono-stdout: startup-timing: (?<message>OnResume end reached)$
+OnCreateBegin=monodroid-timing: startup-timing: (?<message>OnCreate reached)$
+OnCreateEnd=monodroid-timing: startup-timing: (?<message>OnCreate end reached); elapsed:.*$
+OnStartBegin=monodroid-timing: startup-timing: (?<message>OnStart reached)$
+OnStartEnd=monodroid-timing: startup-timing: (?<message>OnStart end reached); elapsed:.*$
+OnResumeBegin=monodroid-timing: startup-timing: (?<message>OnResume reached)$
+OnResumeEnd=monodroid-timing: startup-timing: (?<message>OnResume end reached); elapsed:.*$


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/e887eff9811b630fcbe35479d426013ae2acb024

The above mentioned commit changed the timing messages. As our timing
measurements use regex patterns to detect the appropriate lines, we
need to update the patterns to match the relevant lines again.

That should fix the missing measurements in
https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android/plot/Tests%20times