### PR TITLE
InputStreamInvoker: Seeking for FileInputStreams using FileChannels

### DIFF
--- a/src/Mono.Android/Android.Runtime/InputStreamInvoker.cs
+++ b/src/Mono.Android/Android.Runtime/InputStreamInvoker.cs
@@ -6,7 +6,7 @@ namespace Android.Runtime
 	public class InputStreamInvoker : Stream
 	{
 		public Java.IO.InputStream BaseInputStream {get; private set;}
-		public Java.Nio.Channels.FileChannel BaseFileChannel {get; private set;}
+		protected Java.Nio.Channels.FileChannel BaseFileChannel {get; set;}
 
 		public InputStreamInvoker (Java.IO.InputStream stream)
 		{
@@ -16,7 +16,7 @@ namespace Android.Runtime
 			BaseInputStream = stream;
 
 			Java.IO.FileInputStream fileStream = stream as Java.IO.FileInputStream;
-			if (fileStream is object)
+			if (fileStream != null)
 				BaseFileChannel = fileStream.Channel;
 		}
 
@@ -98,22 +98,21 @@ namespace Android.Runtime
 
 		public override long Seek (long offset, SeekOrigin origin)
 		{
-			if (BaseFileChannel is object) {
-				switch (origin) {
-				case SeekOrigin.Begin:
-					BaseFileChannel.Position (offset);
-					break;
-				case SeekOrigin.Current:
-					BaseFileChannel.Position (BaseFileChannel.Position() + offset);
-					break;
-				case SeekOrigin.End:
-					BaseFileChannel.Position (BaseFileChannel.Size() + offset);
-					break;
-				}
-				return BaseFileChannel.Position ();
-			} else {
-				throw new NotSupportedException ();
+			if (BaseFileChannel == null)
+				throw new NotSupportedException();
+
+			switch (origin) {
+			case SeekOrigin.Begin:
+				BaseFileChannel.Position (offset);
+				break;
+			case SeekOrigin.Current:
+				BaseFileChannel.Position (BaseFileChannel.Position() + offset);
+				break;
+			case SeekOrigin.End:
+				BaseFileChannel.Position (BaseFileChannel.Size() + offset);
+				break;
 			}
+			return BaseFileChannel.Position ();
 		}
 
 		public override void SetLength (long value)
@@ -127,12 +126,12 @@ namespace Android.Runtime
 		}
 
 		public override bool CanRead { get { return true; } }
-		public override bool CanSeek { get { return (BaseFileChannel is object); } }
+		public override bool CanSeek { get { return (BaseFileChannel != null); } }
 		public override bool CanWrite { get { return false; } }
 
 		public override long Length {
 			get {
-				if (BaseFileChannel is object)
+				if (BaseFileChannel != null)
 					return BaseFileChannel.Size ();
 				else
 					throw new NotSupportedException ();
@@ -141,13 +140,13 @@ namespace Android.Runtime
 
 		public override long Position {
 			get {
-				if (BaseFileChannel is object)
+				if (BaseFileChannel != null)
 					return BaseFileChannel.Position ();
 				else
 					throw new NotSupportedException ();
 			}
 			set {
-				if (BaseFileChannel is object)
+				if (BaseFileChannel != null)
 					BaseFileChannel.Position (value);
 				else
 					throw new NotSupportedException ();

--- a/src/Mono.Android/Android.Runtime/InputStreamInvoker.cs
+++ b/src/Mono.Android/Android.Runtime/InputStreamInvoker.cs
@@ -99,7 +99,7 @@ namespace Android.Runtime
 		public override long Seek (long offset, SeekOrigin origin)
 		{
 			if (BaseFileChannel == null)
-				throw new NotSupportedException();
+				throw new NotSupportedException ();
 
 			switch (origin) {
 			case SeekOrigin.Begin:

--- a/src/Mono.Android/Android.Runtime/InputStreamInvoker.cs
+++ b/src/Mono.Android/Android.Runtime/InputStreamInvoker.cs
@@ -6,7 +6,8 @@ namespace Android.Runtime
 	public class InputStreamInvoker : Stream
 	{
 		public Java.IO.InputStream BaseInputStream {get; private set;}
-		protected Java.Nio.Channels.FileChannel BaseFileChannel {get; set;}
+
+		protected Java.Nio.Channels.FileChannel BaseFileChannel {get; private set;}
 
 		public InputStreamInvoker (Java.IO.InputStream stream)
 		{

--- a/src/Mono.Android/Test/Android.Runtime/InputStreamInvokerTest.cs
+++ b/src/Mono.Android/Test/Android.Runtime/InputStreamInvokerTest.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Android.Runtime;
+
+using NUnit.Framework;
+
+namespace Android.RuntimeTests
+{
+        [TestFixture]
+        public class InputStreamInvokerTest
+        {
+                [Test]
+                public void InputStreamTest()
+                {
+                        string path = Path.GetTempFileName();
+                        string text = "Your're so good looking!";
+                        File.WriteAllText(path, text);
+                        Java.IO.FileInputStream fileStream = new Java.IO.FileInputStream(path);
+                        Java.IO.ByteArrayInputStream byteStream = new Java.IO.ByteArrayInputStream(Encoding.ASCII.GetBytes(text));
+
+                        using (var stream = new InputStreamInvoker(fileStream))
+                        {
+                                byte[] bytes = new byte[text.Length];
+                                Assert.IsTrue(stream.CanRead);
+                                Assert.IsTrue(stream.CanSeek);
+                                Assert.IsFalse(stream.CanTimeout);
+                                Assert.IsFalse(stream.CanWrite);
+                                Assert.AreEqual(stream.Length, 24);
+                                Assert.AreEqual(stream.Seek(8, SeekOrigin.Begin), 8);
+                                Assert.AreEqual(stream.Position, 8);
+                                Assert.AreEqual(stream.Read(bytes, 0, 7), 7);
+                                Assert.AreEqual("so good", Encoding.ASCII.GetString(bytes, 0, 7));
+                                Assert.AreEqual(stream.Seek(1, SeekOrigin.Current), 16);
+                                Assert.AreEqual(stream.Read(bytes, 0, 7), 7);
+                                Assert.AreEqual("looking", Encoding.ASCII.GetString(bytes, 0, 7));
+                                Assert.AreEqual(stream.Seek(-text.Length, SeekOrigin.End), 0);
+                                Assert.AreEqual(stream.Read(bytes, 0, 7), 7);
+                                Assert.AreEqual("Your're", Encoding.ASCII.GetString(bytes, 0, 7));
+                                stream.Position = text.Length - 1;
+                                Assert.AreEqual(stream.Read(bytes, 0, 1), 1);
+                                Assert.AreEqual("!", Encoding.ASCII.GetString(bytes, 0, 1));
+                        }
+
+                        using (var stream = new InputStreamInvoker(byteStream))
+                        {
+                                byte[] bytes = new byte[text.Length];
+                                Assert.IsTrue(stream.CanRead);
+                                Assert.IsFalse(stream.CanSeek);
+                                Assert.IsFalse(stream.CanTimeout);
+                                Assert.IsFalse(stream.CanWrite);
+                                Assert.Throws<NotSupportedException>(() => { var _ = stream.Length; });
+                                Assert.Throws<NotSupportedException>(() => { var _ = stream.Position; });
+                                Assert.Throws<NotSupportedException>(() => { stream.Position = 1; });
+                                Assert.Throws<NotSupportedException>(() => { stream.Seek(1, SeekOrigin.Begin); });
+                                Assert.AreEqual(stream.Read(bytes, 0, text.Length), text.Length);
+                                Assert.AreEqual(text, Encoding.ASCII.GetString(bytes, 0, 1));
+                        }
+
+                        File.Delete(path);
+                }
+        }
+}

--- a/src/Mono.Android/Test/Android.Runtime/InputStreamInvokerTest.cs
+++ b/src/Mono.Android/Test/Android.Runtime/InputStreamInvokerTest.cs
@@ -13,53 +13,51 @@ namespace Android.RuntimeTests
         public class InputStreamInvokerTest
         {
                 [Test]
-                public void InputStreamTest()
+                public void InputStreamTest ()
                 {
-                        string path = Path.GetTempFileName();
+                        string path = Path.GetTempFileName ();
                         string text = "Your're so good looking!";
-                        File.WriteAllText(path, text);
-                        Java.IO.FileInputStream fileStream = new Java.IO.FileInputStream(path);
-                        Java.IO.ByteArrayInputStream byteStream = new Java.IO.ByteArrayInputStream(Encoding.ASCII.GetBytes(text));
+                        File.WriteAllText (path, text);
+                        Java.IO.FileInputStream fileStream = new Java.IO.FileInputStream (path);
+                        Java.IO.ByteArrayInputStream byteStream = new Java.IO.ByteArrayInputStream (Encoding.ASCII.GetBytes (text));
 
-                        using (var stream = new InputStreamInvoker(fileStream))
-                        {
+                        using (var stream = new InputStreamInvoker (fileStream)) {
                                 byte[] bytes = new byte[text.Length];
-                                Assert.IsTrue(stream.CanRead);
-                                Assert.IsTrue(stream.CanSeek);
-                                Assert.IsFalse(stream.CanTimeout);
-                                Assert.IsFalse(stream.CanWrite);
-                                Assert.AreEqual(stream.Length, 24);
-                                Assert.AreEqual(stream.Seek(8, SeekOrigin.Begin), 8);
-                                Assert.AreEqual(stream.Position, 8);
-                                Assert.AreEqual(stream.Read(bytes, 0, 7), 7);
-                                Assert.AreEqual("so good", Encoding.ASCII.GetString(bytes, 0, 7));
-                                Assert.AreEqual(stream.Seek(1, SeekOrigin.Current), 16);
-                                Assert.AreEqual(stream.Read(bytes, 0, 7), 7);
-                                Assert.AreEqual("looking", Encoding.ASCII.GetString(bytes, 0, 7));
-                                Assert.AreEqual(stream.Seek(-text.Length, SeekOrigin.End), 0);
-                                Assert.AreEqual(stream.Read(bytes, 0, 7), 7);
-                                Assert.AreEqual("Your're", Encoding.ASCII.GetString(bytes, 0, 7));
+                                Assert.IsTrue (stream.CanRead);
+                                Assert.IsTrue (stream.CanSeek);
+                                Assert.IsFalse (stream.CanTimeout);
+                                Assert.IsFalse (stream.CanWrite);
+                                Assert.AreEqual (stream.Length, 24);
+                                Assert.AreEqual (stream.Seek (8, SeekOrigin.Begin), 8);
+                                Assert.AreEqual (stream.Position, 8);
+                                Assert.AreEqual (stream.Read (bytes, 0, 7), 7);
+                                Assert.AreEqual ("so good", Encoding.ASCII.GetString (bytes, 0, 7));
+                                Assert.AreEqual (stream.Seek (1, SeekOrigin.Current), 16);
+                                Assert.AreEqual (stream.Read (bytes, 0, 7), 7);
+                                Assert.AreEqual ("looking", Encoding.ASCII.GetString (bytes, 0, 7));
+                                Assert.AreEqual (stream.Seek (-text.Length, SeekOrigin.End), 0);
+                                Assert.AreEqual (stream.Read (bytes, 0, 7), 7);
+                                Assert.AreEqual ("Your're", Encoding.ASCII.GetString (bytes, 0, 7));
                                 stream.Position = text.Length - 1;
-                                Assert.AreEqual(stream.Read(bytes, 0, 1), 1);
-                                Assert.AreEqual("!", Encoding.ASCII.GetString(bytes, 0, 1));
+                                Assert.AreEqual (stream.Read (bytes, 0, 1), 1);
+                                Assert.AreEqual ("!", Encoding.ASCII.GetString (bytes, 0, 1));
                         }
 
-                        using (var stream = new InputStreamInvoker(byteStream))
-                        {
+                        using (var stream = new InputStreamInvoker (byteStream)) {
                                 byte[] bytes = new byte[text.Length];
-                                Assert.IsTrue(stream.CanRead);
-                                Assert.IsFalse(stream.CanSeek);
-                                Assert.IsFalse(stream.CanTimeout);
-                                Assert.IsFalse(stream.CanWrite);
-                                Assert.Throws<NotSupportedException>(() => { var _ = stream.Length; });
-                                Assert.Throws<NotSupportedException>(() => { var _ = stream.Position; });
-                                Assert.Throws<NotSupportedException>(() => { stream.Position = 1; });
-                                Assert.Throws<NotSupportedException>(() => { stream.Seek(1, SeekOrigin.Begin); });
-                                Assert.AreEqual(stream.Read(bytes, 0, text.Length), text.Length);
-                                Assert.AreEqual(text, Encoding.ASCII.GetString(bytes, 0, 1));
+                                Assert.IsTrue (stream.CanRead);
+                                Assert.IsFalse (stream.CanSeek);
+                                Assert.IsFalse (stream.CanTimeout);
+                                Assert.IsFalse (stream.CanWrite);
+                                Assert.Throws<NotSupportedException> (() => { var _ = stream.Length; });
+                                Assert.Throws<NotSupportedException> (() => { var _ = stream.Position; });
+                                Assert.Throws<NotSupportedException> (() => { stream.Position = 1; });
+                                Assert.Throws<NotSupportedException> (() => { stream.Seek (1, SeekOrigin.Begin); });
+                                Assert.AreEqual (stream.Read (bytes, 0, text.Length), text.Length);
+                                Assert.AreEqual (text, Encoding.ASCII.GetString (bytes, 0, 1));
                         }
 
-                        File.Delete(path);
+                        File.Delete (path);
                 }
         }
 }

--- a/src/Mono.Android/Test/Android.Runtime/InputStreamInvokerTest.cs
+++ b/src/Mono.Android/Test/Android.Runtime/InputStreamInvokerTest.cs
@@ -54,7 +54,7 @@ namespace Android.RuntimeTests
                                 Assert.Throws<NotSupportedException> (() => { stream.Position = 1; });
                                 Assert.Throws<NotSupportedException> (() => { stream.Seek (1, SeekOrigin.Begin); });
                                 Assert.AreEqual (stream.Read (bytes, 0, text.Length), text.Length);
-                                Assert.AreEqual (text, Encoding.ASCII.GetString (bytes, 0, 1));
+                                Assert.AreEqual (text, Encoding.ASCII.GetString (bytes, 0, text.Length));
                         }
 
                         File.Delete (path);

--- a/src/Mono.Android/Test/Mono.Android-Test.Shared.projitems
+++ b/src/Mono.Android/Test/Mono.Android-Test.Shared.projitems
@@ -17,6 +17,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Android.Content\IntentTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Android.Graphics\NinePatchTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Android.Runtime\CharSequenceTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Android.Runtime\InputStreamInvokerTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Android.Runtime\JavaCollectionTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Android.Runtime\JnienvArrayMarshaling.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Android.Runtime\XmlReaderPullParserTest.cs" />


### PR DESCRIPTION
Hi Xamarin Team,

`InputStreamInvoker` lack of seeking support seems like a oversight to me: 

When working with files across apps, `ContentResolver.openInputStream()` returns `ParcelFileDescriptor.AutoCloseInputStream` which is wrapped to `InputStreamInvoker`.

Requiring to copy this stream to a `MemoryStream` just to get seeking support is **bad** for the **memory usage** of any android app, but especially for older and entry level devices.  

This pull request implements seeking for all `FileInputStream` subclasses using `FileChannel` while keeping the old behaviour for other types of streams.

Review Notes:
* Given that `FileChannel` is connected to the `FileInputStream`, it seems good to me to `null` it before closing the stream.
* The channel doesn't required an explicit closed:  
    > ParcelFileDescriptor.AutoCloseInputStream close: If this stream has an associated channel then the channel is closed as well.

I tried to get into your [coding-guidelines](https://www.mono-project.com/community/contributing/coding-guidelines/, please excuse if I overlooked something and let me know.

Cheers,
Christopher

