### PR TITLE
[Xamarin.Android.Build.Tests] Fix AppDomain warning asserts

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -124,8 +124,9 @@ namespace Xamarin.Android.Build.Tests
 			var projDirectory = Path.Combine ("temp", testName);
 			using (var b = CreateApkBuilder (projDirectory)) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "1 Warning(s)"), "MSBuild should count 1 warning.");
-				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "warning XA2000: Use of AppDomain.CreateDomain()"), "Should warn about creating AppDomain.");
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "2 Warning(s)"), "MSBuild should count 2 warnings.");
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "warning CS0618: 'AppDomain.CreateDomain(string)' is obsolete: 'AppDomain.CreateDomain will no longer be supported in .NET 5 and later."), "Should warn CS0618 about creating AppDomain.");
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, "warning XA2000: Use of AppDomain.CreateDomain()"), "Should warn XA2000 about creating AppDomain.");
 			}
 		}
 	}


### PR DESCRIPTION
Context: https://github.com/mono/mono/commit/a3c25e7b4f86b1bb202f80aa260942c6ccfc3a31

Commit 959ef4ba updated xamarin-android to start using mono/2019-12,
which added an `[Obsolete]` on `AppDomain.CreateDomain()` in
mono/mono@a3c25e7b so that a CS0618 would be emitted whenever the
`AppDomain.CreateDomain()` method was used.

This CS0618 is *not* duplicative of the existing XA2000 warning added
in bbbe2ed3, as the CS0618 will only be emitted when compiling source
code, while the XA2000 can be emitted when referencing an existing
(already compiled) assembly which uses `AppDomain.CreateDomain()`.

That said, the introduction of the `[Obsolete]` caused the
`LinkerTestsWarnAboutAppDomains()` test to start failing, as *two*
warnings were now being emitted by the test, not the expected one.

Update `LinkerTestsWarnAboutAppDomains()` so that it correctly asserts
for two warnings, and that CS0618 is now expected.