### PR TITLE
Bump to mono/mono/2019-12@8b72dbb7

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:master@78d565884f7dd2cf76e748125485f7ed0e03eec4
-mono/mono:2019-12@2edccc52a78d90fea7bcbd37844164663e712397
+mono/mono:2019-12@8b72dbb708681fbde7f0da13fe76d128d62f8686


### PR DESCRIPTION
Changes: https://github.com/mono/mono/compare/2edccc52a78d90fea7bcbd37844164663e712397...8b72dbb708681fbde7f0da13fe76d128d62f8686

Context: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1048838
Context: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1050615
Context: https://github.com/mono/mono/issues/18614

  * mono/mono@8b72dbb7086: [corlib] Split corlib xunit tests even more for iOS (#18620)
  * mono/mono@1e2d68b92c9: Bump bockbuild for Pango patch
  * mono/mono@e55302cb080: configure.ac: remove AC_SEARCH_LIBS for libintl (#18595)
  * mono/mono@ef8188a08d9: [runtime] Disable lldb backtrace display on osx, it hangs on attaching in lldb. (#18591)
  * mono/mono@01be275ad70: [2019-12] Bump msbuild to track mono-2019-10 (#18577)
  * mono/mono@f9e5a6d2b2a: [jit] Compute has_references correctly for gshared types whose constraint is a generic valuetype. Also emit write barriers correctly for these types. (#18562)
  * mono/mono@a979811c631: [2019-12] [debugger] Native thread not executing managed code considered as terminated  (#18504)
  * mono/mono@455cf7d3b12: [interp] context can be uninitialized for get_resume_state callback (#18535)