### PR TITLE
[build] Update Corretto OpenJDK to v8.242.08.1

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Linux.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Linux.cs
@@ -4,9 +4,6 @@ namespace Xamarin.Android.Prepare
 {
 	partial class Configurables
 	{
-		const string CorrettoDistVersion = "8.232.09.1";
-		const string CorrettoUrlPathVersion = CorrettoDistVersion;
-
 		partial class Urls
 		{
 			public static readonly Uri Corretto = new Uri ($"{Corretto_BaseUri}{CorrettoUrlPathVersion}/amazon-corretto-{CorrettoDistVersion}-linux-x64.tar.gz");

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.MacOS.cs
@@ -4,9 +4,6 @@ namespace Xamarin.Android.Prepare
 {
 	partial class Configurables
 	{
-		const string CorrettoDistVersion = "8.232.09.2";
-		const string CorrettoUrlPathVersion = CorrettoDistVersion;
-
 		partial class Urls
 		{
 			public static readonly Uri Corretto = new Uri ($"{Corretto_BaseUri}{CorrettoUrlPathVersion}/amazon-corretto-{CorrettoDistVersion}-macosx-x64.tar.gz");

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Windows.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Windows.cs
@@ -5,9 +5,6 @@ namespace Xamarin.Android.Prepare
 {
 	partial class Configurables
 	{
-		const string CorrettoDistVersion = "8.232.09.1";
-		const string CorrettoUrlPathVersion = CorrettoDistVersion;
-
 		partial class Urls
 		{
 			public static Uri Corretto => GetWindowsCorrettoUrl ();

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -15,12 +15,15 @@ namespace Xamarin.Android.Prepare
 	//
 	partial class Configurables
 	{
+		const string CorrettoDistVersion = "8.242.08.1";
+		const string CorrettoUrlPathVersion = CorrettoDistVersion;
+
 		static Context ctx => Context.Instance;
 
 		public static partial class Urls
 		{
 			// Keep the trailing slash here - OS-specific code assumes it's there.
-			public const string Corretto_BaseUri = "https://d3pxv6yz143wms.cloudfront.net/";
+			public const string Corretto_BaseUri = "https://corretto.aws/downloads/resources/";
 
 			/// <summary>
 			///   Base URL for all Android SDK and NDK downloads. Used in <see cref="AndroidToolchain"/>


### PR DESCRIPTION
Context: https://github.com/corretto/corretto-8/blob/develop/CHANGELOG.md#corretto-version-8232092
Context: https://github.com/corretto/corretto-8/blob/develop/CHANGELOG.md#corretto-version-8242071
Context: https://github.com/corretto/corretto-8/blob/develop/CHANGELOG.md#corretto-version-8242081

Security vulnerability severity levels:

 * **L** low
 * **M** medium
 * **H** high

Update includes the following security fixes:

 * [CVE-2020-2604 Serialization](https://nvd.nist.gov/vuln/detail/CVE-2020-2604) (**H**)
 * [CVE-2020-2601 Security](https://nvd.nist.gov/vuln/detail/CVE-2020-2601) (**M**)
 * [CVE-2020-2655 JSSE](https://nvd.nist.gov/vuln/detail/CVE-2020-2655) (**M**)
 * [CVE-2020-2593 Networking](https://nvd.nist.gov/vuln/detail/CVE-2020-2593) (**M**)
 * [CVE-2020-2654 Libraries](https://nvd.nist.gov/vuln/detail/CVE-2020-2654) (**L**)
 * [CVE-2020-2590 Security](https://nvd.nist.gov/vuln/detail/CVE-2020-2590) (**L**)
 * [CVE-2020-2659 Networking](https://nvd.nist.gov/vuln/detail/CVE-2020-2659) (**L**)
 * [CVE-2020-2583 Serialization](https://nvd.nist.gov/vuln/detail/CVE-2020-2583) (**L**)
 * [CVE-2019-13117 OpenJFX (libxslt)](https://nvd.nist.gov/vuln/detail/CVE-2019-13117) (**H**)
 * [CVE-2019-13118 OpenJFX (libxslt)](https://nvd.nist.gov/vuln/detail/CVE-2019-13118) (**H**)
 * [CVE-2019-16168 OpenJFX (SQLite)](https://nvd.nist.gov/vuln/detail/CVE-2019-16168) (**M**)
 * [CVE-2020-2585 OpenJFX](https://nvd.nist.gov/vuln/detail/CVE-2020-2585) (**M**)