### PR TITLE
[build] Update NDK to r21.0.6113669

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/BuildAndroidPlatforms.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Android.Prepare
 {
 	class BuildAndroidPlatforms
 	{
-		public const string AndroidNdkVersion = "20b";
-		public const string AndroidNdkPkgRevision = "20.1.5948944";
+		public const string AndroidNdkVersion = "21";
+		public const string AndroidNdkPkgRevision = "21.0.6113669";
 
 		public static readonly List<AndroidPlatform> AllPlatforms = new List<AndroidPlatform> {
 			new AndroidPlatform (apiName: "",                       apiLevel: 1,  platformID: "1"),


### PR DESCRIPTION
Context: https://github.com/android/ndk/wiki/Changelog-r21#changelog
Context: https://github.com/android/ndk/wiki/Changelog-r21#known-issues

Summary of changes:

 * 32-bit Windows is no longer supported.
 * Updated Clang and LLD to r365631
 * Updated libc++ to r369764
 * Updated glibc to 2.17
 * Updated gdb to 8.3
 * ndk-build and the CMake toolchain file now enable _FORTIFY_SOURCE by default
 * Fixed hiding of unwinder symbols in outputs of ndk-build and CMake