### PR TITLE
[Xamarin.Android.Build.Tasks] don't call <ResolveAssemblyReference/> directly

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2545,19 +2545,11 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_ResolveSatellitePaths"
     DependsOnTargets="_ResolveAssemblies"
 >
-  <ResolveAssemblyReference
-      AllowedAssemblyExtensions="$(AllowedReferenceAssemblyFileExtensions)"
-      AssemblyFiles="@(ResolvedUserAssemblies)"
-      AutoUnify="$(AutoUnifyAssemblyReferences)"
-      FindDependencies="True"
-      FindRelatedFiles="False"
-      FindSatellites="True"
-      SearchPaths="$(AssemblySearchPaths)"
-      TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
-      TargetFrameworkMonikerDisplayName="$(TargetFrameworkMonikerDisplayName)"
-      TargetFrameworkDirectories="$(TargetFrameworkDirectory)">
-    <Output TaskParameter="SatelliteFiles" ItemName="_AndroidResolvedSatellitePaths"/>
-  </ResolveAssemblyReference>
+  <ItemGroup>
+    <_AndroidResolvedSatellitePaths Include="@(ReferenceSatellitePaths)" />
+    <!-- Satellites from the current project, see: https://github.com/microsoft/msbuild/blob/master/src/Tasks/Microsoft.Common.CurrentVersion.targets#L4283-L4299 -->
+    <_AndroidResolvedSatellitePaths Include="@(IntermediateSatelliteAssembliesWithTargetPath->'$(OutDir)%(Culture)\$(TargetName).resources.dll')" />
+  </ItemGroup>
 </Target>
 
 <Target Name="_CheckApkPerAbiFlag">


### PR DESCRIPTION
I found that we were invoking the `<ResolveAssemblyReference/>`
MSBuild task directly:

    <ResolveAssemblyReference ...>
      <Output TaskParameter="SatelliteFiles" ItemName="_AndroidResolvedSatellitePaths"/>
    </ResolveAssemblyReference>

What is weird about this, is that `<ResolveAssemblyReference/>` is
called twice during any Xamarin.Android build.

But the first call from MSBuild itself returns the exact same
assemblies we need here:

    Task ResolveAssemblyReference
        ...
        OutputItems
        ...
            ReferenceSatellitePaths
                C:\src\weird-solutions\ClassLibrary1\bin\Debug\es\ClassLibrary3.resources.dll

In this example I added a `Strings.resx` and `Strings.es.resx`. The
satellite assembly contains the spanish translation.

It looks to me we can just remove our call to the
`<ResolveAssemblyReference/>` task, and use the public, built-in
`@(ReferenceSatellitePaths)` item group instead.

This worked, except for the in the case of
`Mono.Android-Tests.csproj`. It contains resx files in the main app
project, and these assemblies are not in `@(ReferenceSatellitePaths)`.

Reviewing the code from MSBuild itself:

https://github.com/microsoft/msbuild/blob/master/src/Tasks/Microsoft.Common.CurrentVersion.targets#L4283-L4299

We can use the item transform to get satellite assemblies for the
current project:

    @(IntermediateSatelliteAssembliesWithTargetPath->'$(OutDir)%(Culture)\$(TargetName).resources.dll')

There is not an item group for satellite assemblies in the current
project. However, we merely end up with:

    <Target Name="_ResolveSatellitePaths" ...>
      <ItemGroup>
        <_AndroidResolvedSatellitePaths Include="@(ReferenceSatellitePaths)" />
        <_AndroidResolvedSatellitePaths Include="@(IntermediateSatelliteAssembliesWithTargetPath->'$(OutDir)%(Culture)\$(TargetName).resources.dll')" />
      </ItemGroup>
    </Target>

This target will now take ~0ms instead of calling RAR.

In a build with no changes for the SmartHotel360 app (which includes a
netstandard project):

    Before:
    244 ms  ResolveAssemblyReference                   3 calls
    After:
    152 ms  ResolveAssemblyReference                   2 calls

This looks like a ~92ms savings to every build.

During the devloop, `Build` will run followed by `Install`. We will
have 2x savings to the devloop in this case: ~184ms.