### PR TITLE
[Xamarin.Android.Build.Tasks] further exclude Tests\**

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -61,6 +61,8 @@
     <Compile Remove="MSBuild\**" />
     <Compile Remove="Resources\**" />
     <Compile Remove="Tests\**" />
+    <EmbeddedResource Remove="Tests\**" />
+    <None Remove="Tests\**" />
     <Compile Include="$(IntermediateOutputPath)Profile.g.cs" />
     <Compile Include="..\..\bin\Build$(Configuration)\XABuildConfig.cs" />
     <Compile Include="$(LinkerSourceFullPath)\tuner\Mono.Tuner\AdjustVisibility.cs">


### PR DESCRIPTION
I noticed that VS Windows was showing the `Tests` directory in
`Xamarin.Android.Build.Tasks.csproj` as if many of the files were
included in the project.

In the IDE, I chose "Exclude From Project" in the context menu and it
removed additional files in the `Tests` directory by adding wildcards.

I suspect we might have been including some extraneous
`@(EmbeddedResource)` files in `Xamarin.Android.Build.Tasks.dll`.