### PR TITLE
[Xamarin.Android.Build.Tasks] Re-enable Resources.Designer.cs generation

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -427,6 +427,21 @@
     <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop\Java.Interop.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="Properties\Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Properties\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+
   <!-- Import Microsoft.NET.Sdk targets before our targets so we can override behavior -->
   <!-- See https://github.com/microsoft/msbuild/pull/4922 -->
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />


### PR DESCRIPTION
Now that [03743f32][0] has switched the
`Xamarin.Android.Build.Tasks.csproj` file to the short-form project
style, some item metadata needs to be added explicitly to
`Resources.resx` and `Resources.Designer.cs` to tell Visual Studio to
generate `Resources.Designer.cs` from `Resources.resx` as expected.  The
short-form project style does add the files automatically to the
appropriate `@(EmbeddedResource)` and `@(Compile)` item lists via the
default wildcard includes, but it doesn't add this metadata.

The new items are almost the same as in [0342fe56][1], but they use the
`Update` attribute instead of the `Include` attribute because now the
items are already included via the wildcard includes.

[0]: https://github.com/xamarin/xamarin-android/commit/03743f32aec3b02edc280886061b12e0dde0bd1c
[1]: https://github.com/xamarin/xamarin-android/commit/0342fe5698b86e21e36c924732ff135b9a87e4af