### PR TITLE
[Xamarin.Android.Build.Tasks] Dont always lowercase "*Layout" element values

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/AndroidResourceTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/AndroidResourceTests.cs
@@ -102,5 +102,42 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.True (actionsText.Contains ("@layout/servinglayout"), "'@layout/ServingLayout' was not converted to '@layout/servinglayout'");
 			Directory.Delete (path, recursive: true);
 		}
+
+		[Test]
+		public void UserLayout ()
+		{
+			var path = Path.Combine (Root, "temp", TestName);
+			Directory.CreateDirectory (path);
+			var layoutDir = Path.Combine (path, "res", "layout");
+			var valuesDir = Path.Combine (path, "res", "values");
+			Directory.CreateDirectory (layoutDir);
+			Directory.CreateDirectory (valuesDir);
+			var main = Path.Combine (layoutDir, "main.xml");
+			File.WriteAllText (main, @"<?xml version=""1.0"" encoding=""utf-8""?>
+<LinearLayout xmlns:android=""http://schemas.android.com/apk/res/android""
+	xmlns:app=""http://schemas.android.com/apk/res-auto""
+	android:orientation = ""horizontal""
+	android:layout_width = ""match_parent""
+	android:layout_height = ""match_parent""
+	app:UserLayout=""FixedWidth""
+	>
+</LinearLayout>");
+
+			var attrs = Path.Combine (valuesDir, "attrs.xml");
+			File.WriteAllText (attrs, @"<?xml version=""1.0"" encoding=""utf-8""?>
+<resources>
+	<declare-styleable name=""UserLayoutAttributes"">
+		<attr name=""UserLayout"">
+			<enum name=""FixedWidth"" value=""0""/>
+		</attr>
+	</declare-styleable>
+</resources>
+");
+			Monodroid.AndroidResource.UpdateXmlResource (Path.Combine (path, "res"), attrs, new Dictionary<string, string> (), null);
+			Monodroid.AndroidResource.UpdateXmlResource (Path.Combine (path, "res"), main, new Dictionary<string, string> (), null);
+			var mainText = File.ReadAllText (main);
+			Assert.True (mainText.Contains ("FixedWidth"), "'FixedWidth' was converted to 'fixedwidth'");
+			Directory.Delete (path, recursive: true);
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
@@ -202,7 +202,7 @@ namespace Monodroid {
 		{
 			if (attr.Name.Namespace != res_auto)
 				return false;
-			if (!attr.Value.StartsWith ("@")) // only lowercase if we reference another resource.
+			if (!attr.Value.StartsWith ("@", StringComparison.Ordinal)) // only lowercase if we reference another resource.
 				return false;
 			if (attr.Name.LocalName.EndsWith ("Layout", StringComparison.Ordinal)) {
 				attr.Value = attr.Value.ToLowerInvariant ();

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
@@ -202,6 +202,8 @@ namespace Monodroid {
 		{
 			if (attr.Name.Namespace != res_auto)
 				return false;
+			if (!attr.Value.StartsWith ("@")) // only lowercase if we reference another resource.
+				return false;
 			if (attr.Name.LocalName.EndsWith ("Layout", StringComparison.Ordinal)) {
 				attr.Value = attr.Value.ToLowerInvariant ();
 				return true;


### PR DESCRIPTION
Fixes http://work.azdo.io/1042658

Commit a6387737 made the assumption that ALL `*Layout` view
extension values needed to be lowercased. This is not always
the case. In the Issue listed above the user defined custom
enumeration values which were CamelCase. These were not lowercased
by our build process. So when we lowercased the value in the
layout we got the following build error

	Error		‘fixedsize’ is incompatible with attribute ChildLayout (attr) enum [Auto=0, FixedHeight=2, FixedSize=3, FixedWidth=1, MaxHeightAlignBottom=16, MaxHeightCenter=32, MaxWidthAlignRight=4, MaxWidthCenter=8]

To work around this issue this PR logs all of the `attr` values it
comes across during the conversion of the casing. If the value
for the view extension exists in that list it will not be lowercased.
Otherwise the code will proceed as normal.

The order in which the xml files are processed also changed to make
this work. Before we just processed them in the order they were found.
Now we process them by the directory they are in and in reverse. This
is so the `values` folder which contain the `attribs.xml` based files
are processed first.