### PR TITLE
[Xamarin.Android.Build.Tasks] remove TFI == MonoAndroid checks

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Designer.targets
@@ -57,7 +57,7 @@ Copyright (C) 2016 Xamarin. All rights reserved.
     />
     <_ResolvedUserMonoAndroidAssembliesForDesigner
         Include="@(ResolvedUserAssemblies)"
-        Condition="'%(ResolvedUserAssemblies.TargetFrameworkIdentifier)' == 'MonoAndroid' Or '%(ResolvedUserAssemblies.HasMonoAndroidReference)' == 'True'"
+        Condition="'%(ResolvedUserAssemblies.HasMonoAndroidReference)' == 'True'"
     />
   </ItemGroup>
 </Target>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/FilterAssembliesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/FilterAssembliesTests.cs
@@ -92,7 +92,6 @@ namespace Xamarin.Android.Build.Tests
 			var expected = new [] {
 				"FormsViewGroup.dll",
 				"Xamarin.Forms.Platform.Android.dll",
-				"Xamarin.Forms.Platform.dll",
 			};
 			CollectionAssert.AreEqual (expected, actual);
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -290,10 +290,6 @@ namespace Xamarin.Android.Tasks
 
 		public static bool IsMonoAndroidAssembly (ITaskItem assembly)
 		{
-			var tfi = assembly.GetMetadata ("TargetFrameworkIdentifier");
-			if (string.Compare (tfi, "MonoAndroid", StringComparison.OrdinalIgnoreCase) == 0)
-				return true;
-
 			var hasReference = assembly.GetMetadata ("HasMonoAndroidReference");
 			return bool.TryParse (hasReference, out bool value) && value;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2032,7 +2032,7 @@ because xbuild doesn't support framework reference assemblies.
   <ItemGroup>
     <_ResolvedUserMonoAndroidAssemblies
         Include="@(_ResolvedUserAssemblies)"
-        Condition=" '%(_ResolvedUserAssemblies.TargetFrameworkIdentifier)' == 'MonoAndroid' Or '%(_ResolvedUserAssemblies.HasMonoAndroidReference)' == 'True' "
+        Condition=" '%(_ResolvedUserAssemblies.HasMonoAndroidReference)' == 'True' "
     />
   </ItemGroup>
 </Target>


### PR DESCRIPTION
In preparation for .NET 5, we think the `$(TargetFrameworkMoniker)`
*might* be:

    .NETCoreApp,Version=5.0,Profile=Xamarin.Android

It might also be `Profile=Android`, we don't know for sure yet.

The TFM currently is:

    MonoAndroid,Version=v10.0

I think we can (and should) remove any code during the build that
looks at `$(TargetFrameworkIdentifier)`.

The places we are currently doing this are for performance:

* The `_ResolveLibraryProjectImports` or `_GenerateJavaStubs` targets
  do not need to run against .NET standard assemblies.

We can rely on a reference to `Mono.Android.dll` or `Java.Interop.dll`
instead. We are already using System.Reflection.Metadata to see if the
assembly actually has this reference.

So an example of the condition:

    Condition="'%(ResolvedUserAssemblies.TargetFrameworkIdentifier)' == 'MonoAndroid' Or '%(ResolvedUserAssemblies.HasMonoAndroidReference)' == 'True'"

Can just be:

    Condition="'%(ResolvedUserAssemblies.HasMonoAndroidReference)' == 'True'"

One test failure was that `Xamarin.Forms.Platform.dll` *used* to be
treated as a "Xamarin.Android" assembly.

* It has a `MonoAndroid` TFI
* It has *no* reference to `Mono.Android.dll` or `Java.Interop.dll`
* It has no `Java.Lang.Object` subclasses
* It has no `__AndroidLibraryProjects__.zip` or `*.jar`
  `EmbeddedResource` files

In the case of this assembly, I think everything will continue to
work. It is OK for it to not be treated as a "Xamarin.Android"
assembly.

I also took the opportunity for a small perf improvement:

* `<FilterAssemblies/>` only needs to look for obsolete attributes in
  assemblies that reference `Mono.Android.dll`.

## Results ##

Testing a build with no changes for the SmartHotel360 app:

    Before:
     60 ms  FilterAssemblies                           2 calls
    After:
     49 ms  FilterAssemblies                           2 calls

I would think there is a small ~11ms performance improvement to all
builds of this app.