### PR TITLE
[xaprepare] If Mono archive extraction fails delete Mono archive.

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_DownloadMonoArchive.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_DownloadMonoArchive.cs
@@ -116,6 +116,7 @@ namespace Xamarin.Android.Prepare
 
 			string tempDir = $"{destinationDirectory}.tmp";
 			if (!await Utilities.Unpack (localPath, tempDir, cleanDestinatioBeforeUnpacking: true)) {
+				Utilities.DeleteFileSilent (localPath);
 				Utilities.DeleteDirectorySilent (destinationDirectory);
 				Log.WarningLine ($"Failed to unpack {name} archive {localPath}, Mono will be rebuilt");
 				return false;


### PR DESCRIPTION
Context: `master` build failure:
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3446638&view=logs&j=96fd57f5-f69e-53c7-3d47-f67e6cf9b93e&t=65256bb7-a34c-5353-bc4d-c02ee25dc133

```
[00:03:37.9358067] =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[00:03:37.9358099] Downloading Mono archive
[00:03:37.9358128] =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[00:03:37.9358158] 
[00:03:37.9378132] Checking if all runtime files are present
[00:03:37.9393392] BCL file Mono.Btls.Interface.dll will NOT be included in the installed Designer BCL files (DesignerWindows)
[00:03:37.9418091] File '/Users/builder/azdo/_work/63/s/xamarin-android/bin/Release/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v1.0/I18N.dll' or symbols '/Users/builder/azdo/_work/63/s/xamarin-android/bin/Release/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v1.0/I18N.pdb' missing, skipping the rest of runtime item file scan
[00:03:37.9418224]   * some files are missing, download and extraction required
[00:03:37.9452040] Mono archive already downloaded
[00:03:37.9452631] Creating directory: /Users/builder/azdo/_work/63/s/xamarin-android/external/mono/sdks/out.tmp
[00:03:37.9455162] Unpacking /Users/builder/android-archives/android-release-Darwin-8b72dbb708681fbde7f0da13fe76d128d62f8686.7z to directory: /Users/builder/azdo/_work/63/s/xamarin-android/external/mono/sdks/out.tmp
[00:03:37.9455263] Custom NuGet path: /usr/local/bin/7za
[00:03:37.9455300] 7zip executable path is rooted, using verbatim
[00:03:37.9455331] Full 7zip executable path value: /usr/local/bin/7za
[00:03:37.9455802] Archive path: /Users/builder/android-archives/android-release-Darwin-8b72dbb708681fbde7f0da13fe76d128d62f8686.7z
[00:03:37.9456439] [7zip] extracting archive
[00:03:37.9456755] [7zip] log file: [00:03:37.9456822] bin/BuildRelease/prepare-20200205T161827.7zip-extract.android-release-Darwin-8b72dbb708681fbde7f0da13fe76d128d62f8686.7z.log
[00:03:37.9459995] Running: /usr/local/bin/7za "x" -bd -bso1 -bsp1 -bse2 -y "-o/Users/builder/azdo/_work/63/s/xamarin-android/external/mono/sdks/out.tmp" "/Users/builder/android-archives/android-release-Darwin-8b72dbb708681fbde7f0da13fe76d128d62f8686.7z"
[00:03:37.9617052] stderr | ERROR: /Users/builder/android-archives/android-release-Darwin-8b72dbb708681fbde7f0da13fe76d128d62f8686.7z
[00:03:37.9617259] stderr | /Users/builder/android-archives/android-release-Darwin-8b72dbb708681fbde7f0da13fe76d128d62f8686.7z
[00:03:37.9617344] stderr | Open ERROR: Can not open the file as [7z] archive
[00:03:37.9617415] stderr | 
[00:03:37.9617457] stderr | 
[00:03:37.9617494] stderr | ERRORS:
[00:03:37.9617532] stderr | Unexpected end of archive
[00:03:37.9626297] Elapsed: 00:00:00.0166618[00:03:37.9626374] 
[00:03:37.9628963] Warning: Failed to unpack Mono archive /Users/builder/android-archives/android-release-Darwin-8b72dbb708681fbde7f0da13fe76d128d62f8686.7z, Mono will be rebuilt
[00:03:37.9630255] Mono archive not present
```

`XAMBOT-1009` seems to have gotten a bad Mono archive on it.  (Perhaps network or out of disk issue at some point?)  Because the archive file already exists we do not download it again.  We then try to extract it and it fails with `Unexpected end of archive`.  At this point we just abandon our attempt and leave the file.  This means that the next run will hit the same logic.

This PR changes it so if we fail to unpack the Mono archive we delete it, so we will not hit the same issue the next run.