### PR TITLE
[Xamarin.Android.Build.Tasks] Split up XA5101 errors and make them localizable

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -107,6 +107,9 @@ ms.date: 01/24/2020
 
 ## XA5xxx: GCC and toolchain
 
++ XA5101: Missing Android NDK toolchains directory '{path}'. Please install the Android NDK.
++ XA5102: Could not locate the Android NDK.
++ XA5103: Toolchain utility '{utility}' for target {arch} was not found. Tried in path: "{path}"
 + [XA5205](xa5205.md): Cannot find `{ToolName}` in the Android SDK.
 + [XA5207](xa5207.md): Could not find android.jar for API Level `{compileSdk}`.
 + [XA5300](xa5300.md): The Android/Java SDK Directory could not be found.

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -286,6 +286,51 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Missing Android NDK toolchains directory &apos;{0}&apos;. Please install the Android NDK..
+        /// </summary>
+        internal static string XA5101 {
+            get {
+                return ResourceManager.GetString("XA5101", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to C compiler for target {0} was not found. Tried paths: &quot;{1}&quot;.
+        /// </summary>
+        internal static string XA5101_C_Compiler {
+            get {
+                return ResourceManager.GetString("XA5101_C_Compiler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Toolchain directory for target {0} was not found..
+        /// </summary>
+        internal static string XA5101_Toolchain {
+            get {
+                return ResourceManager.GetString("XA5101_Toolchain", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path..
+        /// </summary>
+        internal static string XA5102 {
+            get {
+                return ResourceManager.GetString("XA5102", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Toolchain utility &apos;{0}&apos; for target {1} was not found. Tried in path: &quot;{2}&quot;.
+        /// </summary>
+        internal static string XA5103 {
+            get {
+                return ResourceManager.GetString("XA5103", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to generate Java type for class: {0} due to MAX_PATH: {1}.
         /// </summary>
         internal static string XA5301 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -227,6 +227,30 @@
     <value>MultiDex is enabled, but main dex list file '{0}' does not exist.</value>
     <comment>The following are literal names and should not be translated: MultiDex</comment>
   </data>
+  <data name="XA5101" xml:space="preserve">
+    <value>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</value>
+    <comment>{0} - The path of the missing directory</comment>
+  </data>
+  <data name="XA5101_C_Compiler" xml:space="preserve">
+    <value>C compiler for target {0} was not found. Tried paths: "{1}"</value>
+    <comment>The following are literal names and should not be translated: C
+{0} - The target architecture, such as Arm, Arm64, or X86_64
+{1} - Semicolon-separated list of the paths searched</comment>
+  </data>
+  <data name="XA5101_Toolchain" xml:space="preserve">
+    <value>Toolchain directory for target {0} was not found.</value>
+    <comment>{0} - The target architecture, such as Arm, Arm64, or X86_64</comment>
+  </data>
+  <data name="XA5102" xml:space="preserve">
+    <value>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</value>
+    <comment>The following are literal names and should not be translated: $(AndroidNdkDirectory)</comment>
+  </data>
+  <data name="XA5103" xml:space="preserve">
+    <value>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</value>
+    <comment>{0} - The missing utility name, such as gcc or clang
+{1} - The target architecture, such as Arm, Arm64, or X86_64
+{2} - The path of the directory that was searched</comment>
+  </data>
   <data name="XA5301" xml:space="preserve">
     <value>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</value>
     <comment>The following are literal names and should not be translated: MAX_PATH.

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -141,6 +141,35 @@
         <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDex</note>
       </trans-unit>
+      <trans-unit id="XA5101">
+        <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
+        <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>
+        <note>{0} - The path of the missing directory</note>
+      </trans-unit>
+      <trans-unit id="XA5101_C_Compiler">
+        <source>C compiler for target {0} was not found. Tried paths: "{1}"</source>
+        <target state="new">C compiler for target {0} was not found. Tried paths: "{1}"</target>
+        <note>The following are literal names and should not be translated: C
+{0} - The target architecture, such as Arm, Arm64, or X86_64
+{1} - Semicolon-separated list of the paths searched</note>
+      </trans-unit>
+      <trans-unit id="XA5101_Toolchain">
+        <source>Toolchain directory for target {0} was not found.</source>
+        <target state="new">Toolchain directory for target {0} was not found.</target>
+        <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
+      </trans-unit>
+      <trans-unit id="XA5102">
+        <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
+        <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
+        <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
+        <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
+        <note>{0} - The missing utility name, such as gcc or clang
+{1} - The target architecture, such as Arm, Arm64, or X86_64
+{2} - The path of the directory that was searched</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -141,6 +141,35 @@
         <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDex</note>
       </trans-unit>
+      <trans-unit id="XA5101">
+        <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
+        <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>
+        <note>{0} - The path of the missing directory</note>
+      </trans-unit>
+      <trans-unit id="XA5101_C_Compiler">
+        <source>C compiler for target {0} was not found. Tried paths: "{1}"</source>
+        <target state="new">C compiler for target {0} was not found. Tried paths: "{1}"</target>
+        <note>The following are literal names and should not be translated: C
+{0} - The target architecture, such as Arm, Arm64, or X86_64
+{1} - Semicolon-separated list of the paths searched</note>
+      </trans-unit>
+      <trans-unit id="XA5101_Toolchain">
+        <source>Toolchain directory for target {0} was not found.</source>
+        <target state="new">Toolchain directory for target {0} was not found.</target>
+        <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
+      </trans-unit>
+      <trans-unit id="XA5102">
+        <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
+        <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
+        <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
+        <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
+        <note>{0} - The missing utility name, such as gcc or clang
+{1} - The target architecture, such as Arm, Arm64, or X86_64
+{2} - The path of the directory that was searched</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -141,6 +141,35 @@
         <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDex</note>
       </trans-unit>
+      <trans-unit id="XA5101">
+        <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
+        <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>
+        <note>{0} - The path of the missing directory</note>
+      </trans-unit>
+      <trans-unit id="XA5101_C_Compiler">
+        <source>C compiler for target {0} was not found. Tried paths: "{1}"</source>
+        <target state="new">C compiler for target {0} was not found. Tried paths: "{1}"</target>
+        <note>The following are literal names and should not be translated: C
+{0} - The target architecture, such as Arm, Arm64, or X86_64
+{1} - Semicolon-separated list of the paths searched</note>
+      </trans-unit>
+      <trans-unit id="XA5101_Toolchain">
+        <source>Toolchain directory for target {0} was not found.</source>
+        <target state="new">Toolchain directory for target {0} was not found.</target>
+        <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
+      </trans-unit>
+      <trans-unit id="XA5102">
+        <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
+        <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
+        <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
+        <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
+        <note>{0} - The missing utility name, such as gcc or clang
+{1} - The target architecture, such as Arm, Arm64, or X86_64
+{2} - The path of the directory that was searched</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -141,6 +141,35 @@
         <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDex</note>
       </trans-unit>
+      <trans-unit id="XA5101">
+        <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
+        <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>
+        <note>{0} - The path of the missing directory</note>
+      </trans-unit>
+      <trans-unit id="XA5101_C_Compiler">
+        <source>C compiler for target {0} was not found. Tried paths: "{1}"</source>
+        <target state="new">C compiler for target {0} was not found. Tried paths: "{1}"</target>
+        <note>The following are literal names and should not be translated: C
+{0} - The target architecture, such as Arm, Arm64, or X86_64
+{1} - Semicolon-separated list of the paths searched</note>
+      </trans-unit>
+      <trans-unit id="XA5101_Toolchain">
+        <source>Toolchain directory for target {0} was not found.</source>
+        <target state="new">Toolchain directory for target {0} was not found.</target>
+        <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
+      </trans-unit>
+      <trans-unit id="XA5102">
+        <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
+        <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
+        <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
+        <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
+        <note>{0} - The missing utility name, such as gcc or clang
+{1} - The target architecture, such as Arm, Arm64, or X86_64
+{2} - The path of the directory that was searched</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -141,6 +141,35 @@
         <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDex</note>
       </trans-unit>
+      <trans-unit id="XA5101">
+        <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
+        <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>
+        <note>{0} - The path of the missing directory</note>
+      </trans-unit>
+      <trans-unit id="XA5101_C_Compiler">
+        <source>C compiler for target {0} was not found. Tried paths: "{1}"</source>
+        <target state="new">C compiler for target {0} was not found. Tried paths: "{1}"</target>
+        <note>The following are literal names and should not be translated: C
+{0} - The target architecture, such as Arm, Arm64, or X86_64
+{1} - Semicolon-separated list of the paths searched</note>
+      </trans-unit>
+      <trans-unit id="XA5101_Toolchain">
+        <source>Toolchain directory for target {0} was not found.</source>
+        <target state="new">Toolchain directory for target {0} was not found.</target>
+        <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
+      </trans-unit>
+      <trans-unit id="XA5102">
+        <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
+        <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
+        <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
+        <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
+        <note>{0} - The missing utility name, such as gcc or clang
+{1} - The target architecture, such as Arm, Arm64, or X86_64
+{2} - The path of the directory that was searched</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -141,6 +141,35 @@
         <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDex</note>
       </trans-unit>
+      <trans-unit id="XA5101">
+        <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
+        <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>
+        <note>{0} - The path of the missing directory</note>
+      </trans-unit>
+      <trans-unit id="XA5101_C_Compiler">
+        <source>C compiler for target {0} was not found. Tried paths: "{1}"</source>
+        <target state="new">C compiler for target {0} was not found. Tried paths: "{1}"</target>
+        <note>The following are literal names and should not be translated: C
+{0} - The target architecture, such as Arm, Arm64, or X86_64
+{1} - Semicolon-separated list of the paths searched</note>
+      </trans-unit>
+      <trans-unit id="XA5101_Toolchain">
+        <source>Toolchain directory for target {0} was not found.</source>
+        <target state="new">Toolchain directory for target {0} was not found.</target>
+        <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
+      </trans-unit>
+      <trans-unit id="XA5102">
+        <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
+        <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
+        <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
+        <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
+        <note>{0} - The missing utility name, such as gcc or clang
+{1} - The target architecture, such as Arm, Arm64, or X86_64
+{2} - The path of the directory that was searched</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -141,6 +141,35 @@
         <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDex</note>
       </trans-unit>
+      <trans-unit id="XA5101">
+        <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
+        <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>
+        <note>{0} - The path of the missing directory</note>
+      </trans-unit>
+      <trans-unit id="XA5101_C_Compiler">
+        <source>C compiler for target {0} was not found. Tried paths: "{1}"</source>
+        <target state="new">C compiler for target {0} was not found. Tried paths: "{1}"</target>
+        <note>The following are literal names and should not be translated: C
+{0} - The target architecture, such as Arm, Arm64, or X86_64
+{1} - Semicolon-separated list of the paths searched</note>
+      </trans-unit>
+      <trans-unit id="XA5101_Toolchain">
+        <source>Toolchain directory for target {0} was not found.</source>
+        <target state="new">Toolchain directory for target {0} was not found.</target>
+        <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
+      </trans-unit>
+      <trans-unit id="XA5102">
+        <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
+        <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
+        <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
+        <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
+        <note>{0} - The missing utility name, such as gcc or clang
+{1} - The target architecture, such as Arm, Arm64, or X86_64
+{2} - The path of the directory that was searched</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -141,6 +141,35 @@
         <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDex</note>
       </trans-unit>
+      <trans-unit id="XA5101">
+        <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
+        <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>
+        <note>{0} - The path of the missing directory</note>
+      </trans-unit>
+      <trans-unit id="XA5101_C_Compiler">
+        <source>C compiler for target {0} was not found. Tried paths: "{1}"</source>
+        <target state="new">C compiler for target {0} was not found. Tried paths: "{1}"</target>
+        <note>The following are literal names and should not be translated: C
+{0} - The target architecture, such as Arm, Arm64, or X86_64
+{1} - Semicolon-separated list of the paths searched</note>
+      </trans-unit>
+      <trans-unit id="XA5101_Toolchain">
+        <source>Toolchain directory for target {0} was not found.</source>
+        <target state="new">Toolchain directory for target {0} was not found.</target>
+        <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
+      </trans-unit>
+      <trans-unit id="XA5102">
+        <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
+        <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
+        <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
+        <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
+        <note>{0} - The missing utility name, such as gcc or clang
+{1} - The target architecture, such as Arm, Arm64, or X86_64
+{2} - The path of the directory that was searched</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -141,6 +141,35 @@
         <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDex</note>
       </trans-unit>
+      <trans-unit id="XA5101">
+        <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
+        <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>
+        <note>{0} - The path of the missing directory</note>
+      </trans-unit>
+      <trans-unit id="XA5101_C_Compiler">
+        <source>C compiler for target {0} was not found. Tried paths: "{1}"</source>
+        <target state="new">C compiler for target {0} was not found. Tried paths: "{1}"</target>
+        <note>The following are literal names and should not be translated: C
+{0} - The target architecture, such as Arm, Arm64, or X86_64
+{1} - Semicolon-separated list of the paths searched</note>
+      </trans-unit>
+      <trans-unit id="XA5101_Toolchain">
+        <source>Toolchain directory for target {0} was not found.</source>
+        <target state="new">Toolchain directory for target {0} was not found.</target>
+        <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
+      </trans-unit>
+      <trans-unit id="XA5102">
+        <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
+        <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
+        <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
+        <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
+        <note>{0} - The missing utility name, such as gcc or clang
+{1} - The target architecture, such as Arm, Arm64, or X86_64
+{2} - The path of the directory that was searched</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -141,6 +141,35 @@
         <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDex</note>
       </trans-unit>
+      <trans-unit id="XA5101">
+        <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
+        <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>
+        <note>{0} - The path of the missing directory</note>
+      </trans-unit>
+      <trans-unit id="XA5101_C_Compiler">
+        <source>C compiler for target {0} was not found. Tried paths: "{1}"</source>
+        <target state="new">C compiler for target {0} was not found. Tried paths: "{1}"</target>
+        <note>The following are literal names and should not be translated: C
+{0} - The target architecture, such as Arm, Arm64, or X86_64
+{1} - Semicolon-separated list of the paths searched</note>
+      </trans-unit>
+      <trans-unit id="XA5101_Toolchain">
+        <source>Toolchain directory for target {0} was not found.</source>
+        <target state="new">Toolchain directory for target {0} was not found.</target>
+        <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
+      </trans-unit>
+      <trans-unit id="XA5102">
+        <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
+        <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
+        <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
+        <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
+        <note>{0} - The missing utility name, such as gcc or clang
+{1} - The target architecture, such as Arm, Arm64, or X86_64
+{2} - The path of the directory that was searched</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -141,6 +141,35 @@
         <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDex</note>
       </trans-unit>
+      <trans-unit id="XA5101">
+        <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
+        <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>
+        <note>{0} - The path of the missing directory</note>
+      </trans-unit>
+      <trans-unit id="XA5101_C_Compiler">
+        <source>C compiler for target {0} was not found. Tried paths: "{1}"</source>
+        <target state="new">C compiler for target {0} was not found. Tried paths: "{1}"</target>
+        <note>The following are literal names and should not be translated: C
+{0} - The target architecture, such as Arm, Arm64, or X86_64
+{1} - Semicolon-separated list of the paths searched</note>
+      </trans-unit>
+      <trans-unit id="XA5101_Toolchain">
+        <source>Toolchain directory for target {0} was not found.</source>
+        <target state="new">Toolchain directory for target {0} was not found.</target>
+        <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
+      </trans-unit>
+      <trans-unit id="XA5102">
+        <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
+        <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
+        <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
+        <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
+        <note>{0} - The missing utility name, such as gcc or clang
+{1} - The target architecture, such as Arm, Arm64, or X86_64
+{2} - The path of the directory that was searched</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -141,6 +141,35 @@
         <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDex</note>
       </trans-unit>
+      <trans-unit id="XA5101">
+        <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
+        <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>
+        <note>{0} - The path of the missing directory</note>
+      </trans-unit>
+      <trans-unit id="XA5101_C_Compiler">
+        <source>C compiler for target {0} was not found. Tried paths: "{1}"</source>
+        <target state="new">C compiler for target {0} was not found. Tried paths: "{1}"</target>
+        <note>The following are literal names and should not be translated: C
+{0} - The target architecture, such as Arm, Arm64, or X86_64
+{1} - Semicolon-separated list of the paths searched</note>
+      </trans-unit>
+      <trans-unit id="XA5101_Toolchain">
+        <source>Toolchain directory for target {0} was not found.</source>
+        <target state="new">Toolchain directory for target {0} was not found.</target>
+        <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
+      </trans-unit>
+      <trans-unit id="XA5102">
+        <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
+        <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
+        <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
+        <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
+        <note>{0} - The missing utility name, such as gcc or clang
+{1} - The target architecture, such as Arm, Arm64, or X86_64
+{2} - The path of the directory that was searched</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -141,6 +141,35 @@
         <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: MultiDex</note>
       </trans-unit>
+      <trans-unit id="XA5101">
+        <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>
+        <target state="new">Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</target>
+        <note>{0} - The path of the missing directory</note>
+      </trans-unit>
+      <trans-unit id="XA5101_C_Compiler">
+        <source>C compiler for target {0} was not found. Tried paths: "{1}"</source>
+        <target state="new">C compiler for target {0} was not found. Tried paths: "{1}"</target>
+        <note>The following are literal names and should not be translated: C
+{0} - The target architecture, such as Arm, Arm64, or X86_64
+{1} - Semicolon-separated list of the paths searched</note>
+      </trans-unit>
+      <trans-unit id="XA5101_Toolchain">
+        <source>Toolchain directory for target {0} was not found.</source>
+        <target state="new">Toolchain directory for target {0} was not found.</target>
+        <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
+      </trans-unit>
+      <trans-unit id="XA5102">
+        <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
+        <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
+        <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
+        <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
+        <note>{0} - The missing utility name, such as gcc or clang
+{1} - The target architecture, such as Arm, Arm64, or X86_64
+{2} - The path of the directory that was searched</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
@@ -37,9 +37,7 @@ namespace Xamarin.Android.Tasks
 			bool hasNdkVersion = GetNdkToolchainRelease (ndkPath ?? "", out ndkVersion);
 
 			if (!hasNdkVersion) {
-				logError ("XA5101",
-					"Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, " +
-					"or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.");
+				logError ("XA5102", Properties.Resources.XA5102);
 				return false;
 			}
 
@@ -187,8 +185,7 @@ namespace Xamarin.Android.Tasks
 			if (File.Exists (toolPath))
 				return toolPath;
 
-			Diagnostic.Error (5101,
-					$"Toolchain utility '{toolName}' for target {arch} was not found. Tried in path: \"{toolchainDir}\"");
+			Diagnostic.Error (5103, Properties.Resources.XA5103, toolName, arch, toolchainDir);
 			return null;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtilsOld.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtilsOld.cs
@@ -57,9 +57,7 @@ namespace Xamarin.Android.Tasks
 		{
 			var toolchains  = GetNdkToolchainDirectories (Path.Combine (androidNdkPath, "toolchains"), arch);
 			if (!toolchains.Any ())
-				Diagnostic.Error (5101,
-						"Toolchain directory for target {0} was not found.",
-						arch);
+				Diagnostic.Error (5101, Properties.Resources.XA5101_Toolchain, arch);
 			// Sort the toolchains paths in reverse so that we prefer the latest versions.
 			Array.Sort(toolchains);
 			Array.Reverse(toolchains);
@@ -89,9 +87,7 @@ namespace Xamarin.Android.Tasks
 				toolPaths.Add (path);
                        }
 
-			Diagnostic.Error (5101,
-					"C compiler for target {0} was not found. Tried paths: \"{1}\"",
-					arch, string.Join ("; ", toolPaths));
+			Diagnostic.Error (5101, Properties.Resources.XA5101_C_Compiler, arch, string.Join ("; ", toolPaths));
 			return null;
 		}
 
@@ -190,9 +186,7 @@ namespace Xamarin.Android.Tasks
 		static string[] GetNdkToolchainDirectories (string toolchainsPath, AndroidTargetArch arch)
 		{
 			if (!Directory.Exists (toolchainsPath))
-				Diagnostic.Error (5101,
-						"Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.",
-						toolchainsPath);
+				Diagnostic.Error (5101, Properties.Resources.XA5101, toolchainsPath);
 			switch (arch) {
 			case AndroidTargetArch.Arm:
 				return Directory.GetDirectories (toolchainsPath, "arm-linux-androideabi-*");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MakeBundleNativeCodeExternalTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MakeBundleNativeCodeExternalTests.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Android.Build.Tests {
 		[TestCase (null)]
 		[TestCase ("")]
 		[TestCase ("DoesNotExist")]
-		public void XA5101AndroidNdkNotFound (string androidNdkDirectory)
+		public void XA5102AndroidNdkNotFound (string androidNdkDirectory)
 		{
 			var task1 = new MakeBundleNativeCodeExternal {
 				BuildEngine = engine,
@@ -43,7 +43,7 @@ namespace Xamarin.Android.Build.Tests {
 
 			Assert.IsFalse (task1.Execute (), "Task should fail!");
 			BuildErrorEventArgs error1 = errors [0];
-			Assert.AreEqual ("XA5101", error1.Code);
+			Assert.AreEqual ("XA5102", error1.Code);
 			StringAssert.Contains (" NDK ", error1.Message);
 			StringAssert.Contains ("AndroidNdkDirectory", error1.Message);
 			StringAssert.Contains ("SDK Manager", error1.Message);


### PR DESCRIPTION
Context: 0342fe5698b86e21e36c924732ff135b9a87e4af
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Give the XA5101 errors in `NdkUtil` their own new error codes so they
can be distinguished from the `NdkUtilOld` errors in telemetry.

Move the message text for XA5101 and the other new error codes into the
`.resx` file so that they are ready for localization.