### PR TITLE
[Xamarin.Android.Build.Tasks] Make XA1001 and XA1002 localizable

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -70,7 +70,7 @@ ms.date: 01/24/2020
 
 + [XA1000](xa1000.md): There was an problem parsing {file}. This is likely due to incomplete or invalid xml.
 + [XA1001](xa1001.md): AndroidResgen: Warning while updating Resource XML '{filename}': {Message}
-+ [XA1002](xa1002.md): We found a matching key '{Key}' for '{Item}'. But the casing was incorrect. Please correct the casing
++ [XA1002](xa1002.md): The closest match found for '{customViewName}' is '{customViewLookupName}', but the capitalization does not match. Please correct the capitalization.
 + [XA1003](xa1003.md): '{zip}' does not exist. Please rebuild the project.
 + [XA1004](xa1004.md): There was an error opening {filename}. The file is probably corrupt. Try deleting it and building again.
 + [XA1005](xa1005.md): Attempting naive type name fixup for element with ID '{id}' and type '{managedType}'

--- a/Documentation/guides/messages/xa1002.md
+++ b/Documentation/guides/messages/xa1002.md
@@ -8,7 +8,7 @@ ms.date: 08/02/2018
 ## Example messages
 
 ```
-We found a matching key 'Namespace.CustomViewFoo' for 'NameSpace.CustomViewFoo'. But the casing was incorrect. Please correct the casing
+The closest match found for 'NameSpace.CustomViewFoo' is 'Namespace.CustomViewFoo', but the capitalization does not match. Please correct the capitalization.
 ```
 
 ## Issue

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -106,6 +106,24 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to AndroidResgen: Warning while updating resource XML &apos;{0}&apos;: {1}.
+        /// </summary>
+        internal static string XA1001 {
+            get {
+                return ResourceManager.GetString("XA1001", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The closest match found for &apos;{0}&apos; is &apos;{1}&apos;, but the capitalization does not match. Please correct the capitalization..
+        /// </summary>
+        internal static string XA1002 {
+            get {
+                return ResourceManager.GetString("XA1002", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Attempting naive type name fixup for element with ID &apos;{0}&apos; and type &apos;{1}&apos;.
         /// </summary>
         internal static string XA1005 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -137,6 +137,17 @@
     <value>Ignoring Reference Assembly `{0}`.</value>
     <comment>{0} - File name of the assembly.</comment>
   </data>
+  <data name="XA1001" xml:space="preserve">
+    <value>AndroidResgen: Warning while updating resource XML '{0}': {1}</value>
+    <comment>The following are literal names and should not be translated: AndroidResgen
+{0} - The name of the XML file
+{1} - The exception message of the associated exception</comment>
+  </data>
+  <data name="XA1002" xml:space="preserve">
+    <value>The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</value>
+    <comment>{0} - The user-provided type name
+{1} - The type name found</comment>
+  </data>
   <data name="XA1005" xml:space="preserve">
     <value>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</value>
     <comment>{0} - The Android resource ID name</comment>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -28,6 +28,19 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA1001">
+        <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
+        <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
+        <note>The following are literal names and should not be translated: AndroidResgen
+{0} - The name of the XML file
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA1002">
+        <source>The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</source>
+        <target state="new">The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</target>
+        <note>{0} - The user-provided type name
+{1} - The type name found</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -28,6 +28,19 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA1001">
+        <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
+        <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
+        <note>The following are literal names and should not be translated: AndroidResgen
+{0} - The name of the XML file
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA1002">
+        <source>The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</source>
+        <target state="new">The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</target>
+        <note>{0} - The user-provided type name
+{1} - The type name found</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -28,6 +28,19 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA1001">
+        <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
+        <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
+        <note>The following are literal names and should not be translated: AndroidResgen
+{0} - The name of the XML file
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA1002">
+        <source>The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</source>
+        <target state="new">The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</target>
+        <note>{0} - The user-provided type name
+{1} - The type name found</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -28,6 +28,19 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA1001">
+        <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
+        <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
+        <note>The following are literal names and should not be translated: AndroidResgen
+{0} - The name of the XML file
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA1002">
+        <source>The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</source>
+        <target state="new">The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</target>
+        <note>{0} - The user-provided type name
+{1} - The type name found</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -28,6 +28,19 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA1001">
+        <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
+        <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
+        <note>The following are literal names and should not be translated: AndroidResgen
+{0} - The name of the XML file
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA1002">
+        <source>The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</source>
+        <target state="new">The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</target>
+        <note>{0} - The user-provided type name
+{1} - The type name found</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -28,6 +28,19 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA1001">
+        <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
+        <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
+        <note>The following are literal names and should not be translated: AndroidResgen
+{0} - The name of the XML file
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA1002">
+        <source>The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</source>
+        <target state="new">The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</target>
+        <note>{0} - The user-provided type name
+{1} - The type name found</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -28,6 +28,19 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA1001">
+        <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
+        <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
+        <note>The following are literal names and should not be translated: AndroidResgen
+{0} - The name of the XML file
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA1002">
+        <source>The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</source>
+        <target state="new">The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</target>
+        <note>{0} - The user-provided type name
+{1} - The type name found</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -28,6 +28,19 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA1001">
+        <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
+        <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
+        <note>The following are literal names and should not be translated: AndroidResgen
+{0} - The name of the XML file
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA1002">
+        <source>The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</source>
+        <target state="new">The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</target>
+        <note>{0} - The user-provided type name
+{1} - The type name found</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -28,6 +28,19 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA1001">
+        <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
+        <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
+        <note>The following are literal names and should not be translated: AndroidResgen
+{0} - The name of the XML file
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA1002">
+        <source>The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</source>
+        <target state="new">The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</target>
+        <note>{0} - The user-provided type name
+{1} - The type name found</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -28,6 +28,19 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA1001">
+        <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
+        <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
+        <note>The following are literal names and should not be translated: AndroidResgen
+{0} - The name of the XML file
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA1002">
+        <source>The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</source>
+        <target state="new">The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</target>
+        <note>{0} - The user-provided type name
+{1} - The type name found</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -28,6 +28,19 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA1001">
+        <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
+        <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
+        <note>The following are literal names and should not be translated: AndroidResgen
+{0} - The name of the XML file
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA1002">
+        <source>The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</source>
+        <target state="new">The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</target>
+        <note>{0} - The user-provided type name
+{1} - The type name found</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -28,6 +28,19 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA1001">
+        <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
+        <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
+        <note>The following are literal names and should not be translated: AndroidResgen
+{0} - The name of the XML file
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA1002">
+        <source>The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</source>
+        <target state="new">The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</target>
+        <note>{0} - The user-provided type name
+{1} - The type name found</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -28,6 +28,19 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA1001">
+        <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
+        <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>
+        <note>The following are literal names and should not be translated: AndroidResgen
+{0} - The name of the XML file
+{1} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA1002">
+        <source>The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</source>
+        <target state="new">The closest match found for '{0}' is '{1}', but the capitalization does not match. Please correct the capitalization.</target>
+        <note>{0} - The user-provided type name
+{1} - The type name found</note>
+      </trans-unit>
       <trans-unit id="XA1005">
         <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
         <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ConvertCustomView.cs
@@ -162,7 +162,7 @@ namespace Xamarin.Android.Tasks {
 			if (matchingKey.Key != null) {
 				// we have elements with slightly different casing.
 				// lets issue a error.
-				logMessage (TraceLevel.Error, $"We found a matching key '{matchingKey.Key}' for '{name}'. But the casing was incorrect. Please correct the casing");
+				logMessage (TraceLevel.Error, string.Format (Properties.Resources.XA1002, name, matchingKey.Key));
 			}
 			return false;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AndroidResource.cs
@@ -27,7 +27,7 @@ namespace Monodroid {
 				}
 				return Xamarin.Android.Tasks.MonoAndroidHelper.CopyIfChanged (tmpfile, filename);
 			} catch (Exception e) {
-				logMessage?.Invoke (TraceLevel.Warning, $"AndroidResgen: Warning while updating Resource XML '{filename}': {e.Message}");
+				logMessage?.Invoke (TraceLevel.Warning, string.Format (Xamarin.Android.Tasks.Properties.Resources.XA1001, filename, e.Message));
 				return false;
 			} finally {
 				if (File.Exists (tmpfile)) {


### PR DESCRIPTION
Context: 0342fe5698b86e21e36c924732ff135b9a87e4af
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Move the XA1001 and XA1002 message text into the `.resx` file so that
they are ready for localization.

Other changes:

Remove "we" from the XA1002 message, and change "casing" to
"capitalization" to reduce potential ambiguity for the l10n team.