### PR TITLE
Add support for legacy WebRequestHandler as a HttpHandler (for NTLM)

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net;
+using System.Reflection;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Security;
@@ -376,18 +377,21 @@ namespace Android.Runtime {
 				if (monoHandlerType == null)
 					return null;
 
-				ConstructorInfo[] internalMonoHandlerCtors = monoHandlerType.GetConstructors(
-					BindingFlags.NonPublic | BindingFlags.Instance);
+				Type httpClientHandlerType = Type.GetType("System.Net.Http.HttpClientHandler, System.Net.Http");
+				if (httpClientHandlerType == null)
+					return null;
+
+				BindingFlags internalBf = BindingFlags.NonPublic | BindingFlags.Instance;
+				ConstructorInfo[] internalMonoHandlerCtors = monoHandlerType.GetConstructors(internalBf);
 				if (internalMonoHandlerCtors.Length < 1)
 					return null;
 
 				object internalMonoHandler = internalMonoHandlerCtors[0].Invoke(null);
-				ConstructorInfo[] httpClientHandlerCtors =
-					typeof(HttpClientHandler).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance);
+				ConstructorInfo[] httpClientHandlerCtors = httpClientHandlerType.GetConstructors(internalBf);
 				if (httpClientHandlerCtors.Length < 1)
 					return null;
 
-				return (HttpClientHandler)httpClientHandlerCtors[0].Invoke(new [] { internalMonoHandler });
+				return httpClientHandlerCtors[0].Invoke(new [] { internalMonoHandler });
 			}
 
 			if (handlerType == null)


### PR DESCRIPTION
Currently Android has two HttpHandler options: **Managed** (which is based on modern fully managed `SocketHttpHandler` from corefx) and **Android**. Unfortunately it turned out in order to support NTLM/Kerberos authentication, `SocketHttpHandler` needs some native pieces (GSS) we don't have for Android (basically we need to port [krb5](https://github.com/krb5/krb5) lib to Android NDK) - other platforms including iOS are fine.

However, our old legacy `WebRequestHandler` used to fully support NTLM. So the idea is to bring it back and allow users to select it via VS

![image](https://user-images.githubusercontent.com/523221/74041908-a0a22a80-49d7-11ea-9f86-dd019161b2a9.png)

`System.Net.Http.dll` assembly already has two things we need to create a legacy handler:
1) internal `System.Net.Http.MonoWebRequestHandler` type
2) internal `HttpClientHandler(IMonoHttpClientHandler handler)` ctor 

However it also possible to simply use `WebRequestHandler` from `System.Net.Http.WebRequest.dll`. 


So if I am not mistaken, in order to update that combox in VS we need to add `System.Net.Http.WebRequestHandler` here in xamarin/XamarinVS: https://github.com/xamarin/XamarinVS/blob/7c01004f5d8a308771ab0d02887b79067e100b6c/src/Features/VisualStudio.Properties/VisualStudio.Android.Properties/Views/OptionsPageViewModel.cs#L52

Optionally: update this UI tip, update localizations.
![image](https://user-images.githubusercontent.com/523221/74042885-65a0f680-49d9-11ea-8a9c-1cf72dd9445e.png)


So basically, the idea is to fix the following code without changes on the user side:
```csharp
var handler = new HttpClientHandler { Credentials = ntlmCredentials }; 
var httpClient = new HttpClient(handler)
```
