### PR TITLE
[Xamarin.Android.Build.Tasks] deprecate [assembly: DoNotPackage]

### DIFF
--- a/Documentation/guides/messages/xa0122.md
+++ b/Documentation/guides/messages/xa0122.md
@@ -1,0 +1,32 @@
+---
+title: Xamarin.Android warning XA0122
+description: XA0122 warning code
+ms.date: 02/07/2020
+---
+# Xamarin.Android warning XA0122
+
+## Example messages
+
+```
+warning XA0122: Assembly 'Library1' is using a deprecated attribute '[assembly: Java.Interop.DoNotPackageAttribute]'. Use a newer version of this NuGet package or notify the library author.
+```
+
+## Issue
+
+The behavior implemented in the `DoNotPackageAttribute` is deprecated:
+
+    [assembly: Java.Interop.DoNotPackage ("foo.jar")]
+
+This would prevent `foo.jar` from being packaged in the app.
+
+Alternatively, you can use the `@(AndroidExternalJavaLibrary)` item
+group for including `foo.jar`. The java library will only be used at
+compile time, and will not be packaged in the final Android app.
+
+## Solution
+
+Some libraries using this feature can be simply updated to a newer
+version on NuGet.
+
+Library authors will need to remove usage of this attribute. Its
+functionality will be removed in a future release.

--- a/src/Mono.Android/Java.Interop/DoNotPackageAttribute.cs
+++ b/src/Mono.Android/Java.Interop/DoNotPackageAttribute.cs
@@ -6,6 +6,7 @@ namespace Java.Interop
 	[AttributeUsage (AttributeTargets.Assembly,
 			AllowMultiple=true,
 			Inherited=false)]
+	[Obsolete ("This attribute is deprecated and will be removed in a future release. Use the @(AndroidExternalJavaLibrary) MSBuild item group instead.")]
 	public class DoNotPackageAttribute : Attribute
 	{
 		public DoNotPackageAttribute (string jarFile)

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -104,6 +104,15 @@ namespace Xamarin.Android.Tasks.Properties {
                 return ResourceManager.GetString("XA0107_Ignoring", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Assembly &apos;{0}&apos; is using a deprecated attribute &apos;[assembly: {1}]&apos;. Use a newer version of this NuGet package or notify the library author..
+        /// </summary>
+        internal static string XA0122 {
+            get {
+                return ResourceManager.GetString("XA0122", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to AndroidResgen: Warning while updating resource XML &apos;{0}&apos;: {1}.

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -137,6 +137,10 @@
     <value>Ignoring Reference Assembly `{0}`.</value>
     <comment>{0} - File name of the assembly.</comment>
   </data>
+  <data name="XA0122" xml:space="preserve">
+    <value>Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</value>
+    <comment>The following are literal names and should not be translated: [assembly: {1}], NuGet</comment>
+  </data>
   <data name="XA1001" xml:space="preserve">
     <value>AndroidResgen: Warning while updating resource XML '{0}': {1}</value>
     <comment>The following are literal names and should not be translated: AndroidResgen

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0122">
+        <source>Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</source>
+        <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
+        <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0122">
+        <source>Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</source>
+        <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
+        <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0122">
+        <source>Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</source>
+        <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
+        <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0122">
+        <source>Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</source>
+        <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
+        <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0122">
+        <source>Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</source>
+        <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
+        <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0122">
+        <source>Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</source>
+        <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
+        <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0122">
+        <source>Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</source>
+        <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
+        <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0122">
+        <source>Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</source>
+        <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
+        <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0122">
+        <source>Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</source>
+        <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
+        <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0122">
+        <source>Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</source>
+        <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
+        <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0122">
+        <source>Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</source>
+        <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
+        <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0122">
+        <source>Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</source>
+        <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
+        <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0122">
+        <source>Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</source>
+        <target state="new">Assembly '{0}' is using a deprecated attribute '[assembly: {1}]'. Use a newer version of this NuGet package or notify the library author.</target>
+        <note>The following are literal names and should not be translated: [assembly: {1}], NuGet</note>
+      </trans-unit>
       <trans-unit id="XA1001">
         <source>AndroidResgen: Warning while updating resource XML '{0}': {1}</source>
         <target state="new">AndroidResgen: Warning while updating resource XML '{0}': {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAssemblies.cs
@@ -223,7 +223,7 @@ namespace Xamarin.Android.Tasks
 			if (resolutionPath == null)
 				resolutionPath = new List<string>();
 
-			CheckAssemblyAttributes (assembly, reader, out string targetFrameworkIdentifier);
+			CheckAssemblyAttributes (assembly, assemblyName, reader, out string targetFrameworkIdentifier);
 
 			LogMessage ("{0}Adding assembly reference for {1}, recursively...", new string (' ', indent), assemblyName);
 			resolutionPath.Add (assemblyName);
@@ -281,14 +281,16 @@ namespace Xamarin.Android.Tasks
 			resolutionPath.RemoveAt (resolutionPath.Count - 1);
 		}
 
-		void CheckAssemblyAttributes (AssemblyDefinition assembly, MetadataReader reader, out string targetFrameworkIdentifier)
+		void CheckAssemblyAttributes (AssemblyDefinition assembly, string assemblyName, MetadataReader reader, out string targetFrameworkIdentifier)
 		{
 			targetFrameworkIdentifier = null;
 
 			foreach (var handle in assembly.GetCustomAttributes ()) {
 				var attribute = reader.GetCustomAttribute (handle);
-				switch (reader.GetCustomAttributeFullName (attribute)) {
+				var attributeFullName = reader.GetCustomAttributeFullName (attribute);
+				switch (attributeFullName) {
 					case "Java.Interop.DoNotPackageAttribute": {
+							LogCodedWarning ("XA0122", Properties.Resources.XA0122, assemblyName, attributeFullName);
 							var arguments = attribute.GetCustomAttributeArguments ();
 							if (arguments.FixedArguments.Length > 0) {
 								string file = arguments.FixedArguments [0].Value?.ToString ();
@@ -315,7 +317,6 @@ namespace Xamarin.Android.Tasks
 												string version = value.Substring (versionIndex, value.Length - versionIndex);
 												var apiLevel = MonoAndroidHelper.SupportedVersions.GetApiLevelFromFrameworkVersion (version);
 												if (apiLevel != null) {
-													var assemblyName = reader.GetString (assembly.Name);
 													api_levels [assemblyName] = apiLevel.Value;
 												}
 											}


### PR DESCRIPTION
The `<ResolveAssemblies/>` MSBuild task currently looks for an
attribute in every assembly:

    [assembly: Java.Interop.DoNotPackage ("foo.jar")]

`foo.jar` would be used at compile time for java code, but not
included in the final Android app. This seems like the wrong way to go
about things, you can simply add to the `@(AndroidExternalJavaLibrary)`
item group for the same behavior.

I also found very little usage of this on Github:

    https://github.com/search?l=C%23&p=1&q=%5Bassembly%3A+DoNotPackage&type=Code

Most of the projects using this are unsupported libraries from the
Xamarin Component store.

If we plan to completely remove `<ResolveAssemblies/>` this is a piece
we will have to deprecate for a period of time first.