### PR TITLE
[Xamarin.Android.Build.Tasks] Adjust XA1005 wording for localization

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -73,7 +73,7 @@ ms.date: 01/24/2020
 + [XA1002](xa1002.md): The closest match found for '{customViewName}' is '{customViewLookupName}', but the capitalization does not match. Please correct the capitalization.
 + [XA1003](xa1003.md): '{zip}' does not exist. Please rebuild the project.
 + [XA1004](xa1004.md): There was an error opening {filename}. The file is probably corrupt. Try deleting it and building again.
-+ [XA1005](xa1005.md): Attempting naive type name fixup for element with ID '{id}' and type '{managedType}'
++ [XA1005](xa1005.md): Attempting basic type name matching for element with ID '{id}' and type '{managedType}'
 + [XA1006](xa1006.md): The TargetFrameworkVersion (Android API level {compileSdk}) is higher than the targetSdkVersion ({targetSdk}).
 + [XA1007](xa1007.md): The minSdkVersion ({minSdk}) is greater than targetSdkVersion. Please change the value such that minSdkVersion is less than or equal to targetSdkVersion ({targetSdk}).
 + [XA1008](xa1008.md): The TargetFrameworkVersion (Android API level {compileSdk}) is lower than the targetSdkVersion ({targetSdk}).

--- a/Documentation/guides/messages/xa1005.md
+++ b/Documentation/guides/messages/xa1005.md
@@ -8,8 +8,8 @@ ms.date: 01/24/2020
 ## Example messages
 
 ```
-warning XA1005: Attempting naive type name fixup for element with ID '@+id/text1' and type 'android.widget.TextView'
-warning XA1005: If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.
+warning XA1005: Attempting basic type name matching for element with ID '@+id/text1' and type 'android.widget.TextView'
+warning XA1005: If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.
 ```
 
 ## Issue
@@ -35,7 +35,7 @@ name like:
     android:id="@+id/text1" />
 ```
 
-The "naive type name fixup" tries to ensure that any fully qualified type name
+The "basic type name matching" tries to ensure that any fully qualified type name
 is a C# name rather than a Java name. First it checks a short list of known
 mappings between Java namespaces and C# namespaces, such as the mapping of
 `android.view` to `Android.Views`. For any remaining namespaces, it splits the

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -124,7 +124,7 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Attempting naive type name fixup for element with ID &apos;{0}&apos; and type &apos;{1}&apos;.
+        ///   Looks up a localized string similar to Attempting basic type name matching for element with ID &apos;{0}&apos; and type &apos;{1}&apos;.
         /// </summary>
         internal static string XA1005 {
             get {
@@ -133,7 +133,7 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element..
+        ///   Looks up a localized string similar to If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element..
         /// </summary>
         internal static string XA1005_Instructions {
             get {
@@ -303,6 +303,7 @@ namespace Xamarin.Android.Tasks.Properties {
             }
         }
         
+        /// <summary>
         ///   Looks up a localized string similar to Failed to generate type maps.
         /// </summary>
         internal static string XA4308 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -149,11 +149,11 @@
 {1} - The type name found</comment>
   </data>
   <data name="XA1005" xml:space="preserve">
-    <value>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</value>
+    <value>Attempting basic type name matching for element with ID '{0}' and type '{1}'</value>
     <comment>{0} - The Android resource ID name</comment>
   </data>
   <data name="XA1005_Instructions" xml:space="preserve">
-    <value>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</value>
+    <value>If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</value>
     <comment>"xamarin:managedType" is a literal name and should not be translated.</comment>
   </data>
   <data name="XA1006" xml:space="preserve">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -42,13 +42,13 @@
 {1} - The type name found</note>
       </trans-unit>
       <trans-unit id="XA1005">
-        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
-        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <source>Attempting basic type name matching for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting basic type name matching for element with ID '{0}' and type '{1}'</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1005_Instructions">
-        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
-        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <source>If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA1006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -42,13 +42,13 @@
 {1} - The type name found</note>
       </trans-unit>
       <trans-unit id="XA1005">
-        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
-        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <source>Attempting basic type name matching for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting basic type name matching for element with ID '{0}' and type '{1}'</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1005_Instructions">
-        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
-        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <source>If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA1006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -42,13 +42,13 @@
 {1} - The type name found</note>
       </trans-unit>
       <trans-unit id="XA1005">
-        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
-        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <source>Attempting basic type name matching for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting basic type name matching for element with ID '{0}' and type '{1}'</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1005_Instructions">
-        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
-        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <source>If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA1006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -42,13 +42,13 @@
 {1} - The type name found</note>
       </trans-unit>
       <trans-unit id="XA1005">
-        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
-        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <source>Attempting basic type name matching for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting basic type name matching for element with ID '{0}' and type '{1}'</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1005_Instructions">
-        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
-        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <source>If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA1006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -42,13 +42,13 @@
 {1} - The type name found</note>
       </trans-unit>
       <trans-unit id="XA1005">
-        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
-        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <source>Attempting basic type name matching for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting basic type name matching for element with ID '{0}' and type '{1}'</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1005_Instructions">
-        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
-        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <source>If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA1006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -42,13 +42,13 @@
 {1} - The type name found</note>
       </trans-unit>
       <trans-unit id="XA1005">
-        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
-        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <source>Attempting basic type name matching for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting basic type name matching for element with ID '{0}' and type '{1}'</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1005_Instructions">
-        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
-        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <source>If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA1006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -42,13 +42,13 @@
 {1} - The type name found</note>
       </trans-unit>
       <trans-unit id="XA1005">
-        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
-        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <source>Attempting basic type name matching for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting basic type name matching for element with ID '{0}' and type '{1}'</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1005_Instructions">
-        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
-        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <source>If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA1006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -42,13 +42,13 @@
 {1} - The type name found</note>
       </trans-unit>
       <trans-unit id="XA1005">
-        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
-        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <source>Attempting basic type name matching for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting basic type name matching for element with ID '{0}' and type '{1}'</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1005_Instructions">
-        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
-        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <source>If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA1006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -42,13 +42,13 @@
 {1} - The type name found</note>
       </trans-unit>
       <trans-unit id="XA1005">
-        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
-        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <source>Attempting basic type name matching for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting basic type name matching for element with ID '{0}' and type '{1}'</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1005_Instructions">
-        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
-        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <source>If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA1006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -42,13 +42,13 @@
 {1} - The type name found</note>
       </trans-unit>
       <trans-unit id="XA1005">
-        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
-        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <source>Attempting basic type name matching for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting basic type name matching for element with ID '{0}' and type '{1}'</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1005_Instructions">
-        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
-        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <source>If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA1006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -42,13 +42,13 @@
 {1} - The type name found</note>
       </trans-unit>
       <trans-unit id="XA1005">
-        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
-        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <source>Attempting basic type name matching for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting basic type name matching for element with ID '{0}' and type '{1}'</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1005_Instructions">
-        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
-        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <source>If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA1006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -42,13 +42,13 @@
 {1} - The type name found</note>
       </trans-unit>
       <trans-unit id="XA1005">
-        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
-        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <source>Attempting basic type name matching for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting basic type name matching for element with ID '{0}' and type '{1}'</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1005_Instructions">
-        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
-        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <source>If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA1006">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -42,13 +42,13 @@
 {1} - The type name found</note>
       </trans-unit>
       <trans-unit id="XA1005">
-        <source>Attempting naive type name fixup for element with ID '{0}' and type '{1}'</source>
-        <target state="new">Attempting naive type name fixup for element with ID '{0}' and type '{1}'</target>
+        <source>Attempting basic type name matching for element with ID '{0}' and type '{1}'</source>
+        <target state="new">Attempting basic type name matching for element with ID '{0}' and type '{1}'</target>
         <note>{0} - The Android resource ID name</note>
       </trans-unit>
       <trans-unit id="XA1005_Instructions">
-        <source>If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
-        <target state="new">If the above fixup fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
+        <source>If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</source>
+        <target state="new">If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element.</target>
         <note>"xamarin:managedType" is a literal name and should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA1006">


### PR DESCRIPTION
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1064104

Remove the uses of "naive", "fixup", and "above" to make the XA1005
warning messages easier to translate to other languages.