### PR TITLE
[build] Strip sqlite DSO on Release builds

### DIFF
--- a/src/sqlite-xamarin/CMakeLists.txt
+++ b/src/sqlite-xamarin/CMakeLists.txt
@@ -79,7 +79,7 @@ if(CMAKE_BUILD_TYPE STREQUAL Debug)
   set(TEST_COMPILER_ARGS ${TEST_COMPILER_ARGS} ggdb3 fno-omit-frame-pointer)
   set(LOCAL_CMAKE_C_FLAGS "${LOCAL_CMAKE_C_FLAGS} -O0")
 else()
-  set(TEST_COMPILER_ARGS ${TEST_COMPILER_ARGS} g fomit-frame-pointer O2)
+  set(TEST_COMPILER_ARGS ${TEST_COMPILER_ARGS} s fomit-frame-pointer O2)
   set(LOCAL_CMAKE_C_FLAGS "${LOCAL_CMAKE_C_FLAGS} -O2")
 endif()
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4244

Turns out our `Release` build failed to strip the `sqlite3` shared
library (it was built with `-g`) and so it ended up packaged with all
the debug symbols included, thus unnecessarily growing the size of APKs
we produce.

Pass `-s` to the compiler during `Release` builds so that only the
dynamic symbols are present in the resulting shared library and no debug
symbols are present.

This decreases the shared library around 5 times.