### PR TITLE
[apkdiff] Put apkdiff tool in separate output directory

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -105,7 +105,6 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\apkdiff.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\apkdiff.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\Mono.Options.dll" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\Mono.Posix.NETStandard.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\libZipSharp.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\libZipSharp.dll.config" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\Newtonsoft.Json.dll" />

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -102,8 +102,14 @@
   </ItemGroup>
   <ItemGroup>
     <_MSBuildFiles Include="$(MSBuildSrcDir)\android-support-multidex.jar" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff.exe" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff.pdb" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\apkdiff.exe" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\apkdiff.pdb" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\Mono.Options.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\Mono.Posix.NETStandard.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\libZipSharp.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\libZipSharp.dll.config" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\Newtonsoft.Json.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\apkdiff\Newtonsoft.Json-LICENSE.md" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\aprofutil.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\aprofutil.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\cil-strip.exe" />
@@ -159,8 +165,6 @@
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Posix.NETStandard.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Profiler.Log.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Profiler.Log.pdb" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Newtonsoft.Json.dll" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Newtonsoft.Json-LICENSE.md" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\logcat-parse.exe" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\logcat-parse.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\mdoc.exe" />

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -246,6 +246,8 @@
   <ItemGroup>
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\libzip.dll" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\lib64\libzip.dll" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\apkdiff\libzip.dll" />
+    <_MSBuildFilesWin Include="$(MSBuildSrcDir)\apkdiff\lib64\libzip.dll" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\proguard\bin\proguard.bat" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\aapt2.exe" />
     <_MSBuildFilesWin Include="$(MSBuildSrcDir)\libwinpthread-1.dll" />
@@ -311,6 +313,7 @@
     <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libmonosgen-2.0.$(LibExtension)" />
     <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\lib\host-$(HostOS)\libxamarin-app.$(LibExtension)" />
     <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\libzip.$(LibExtension)" />
+    <_MSBuildFilesUnixSign Include="$(MSBuildSrcDir)\apkdiff\libzip.$(LibExtension)" />
     <_MSBuildFilesUnix Include="$(MSBuildSrcDir)\proguard\bin\proguard.sh" />
   </ItemGroup>
   <!-- Allow us to exclude mono bundle files for PR builds -->

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -427,6 +427,12 @@
     <ProjectReference Include="..\..\external\xamarin-android-tools\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj" />
     <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Export\Java.Interop.Export.csproj" />
     <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop\Java.Interop.csproj" />
+    <!--
+      Build `apkdiff` tool first to avoid replacing `libZipSharp` assembly in `lib/xamarin.android/xbuild/Xamarin/Android/`
+      -->
+    <ProjectReference Include="..\..\tools\apkdiff\apkdiff.csproj">
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
 
   <!-- Import Microsoft.NET.Sdk targets before our targets so we can override behavior -->

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -427,12 +427,6 @@
     <ProjectReference Include="..\..\external\xamarin-android-tools\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj" />
     <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop.Export\Java.Interop.Export.csproj" />
     <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop\Java.Interop.csproj" />
-    <!--
-      Build `apkdiff` tool first to avoid replacing `libZipSharp` assembly in `lib/xamarin.android/xbuild/Xamarin/Android/`
-      -->
-    <ProjectReference Include="..\..\tools\apkdiff\apkdiff.csproj">
-      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-    </ProjectReference>
   </ItemGroup>
 
   <!-- Import Microsoft.NET.Sdk targets before our targets so we can override behavior -->

--- a/tools/apkdiff/apkdiff.csproj
+++ b/tools/apkdiff/apkdiff.csproj
@@ -30,9 +30,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="Mono.Posix.NETStandard">
-      <HintPath>packages\Mono.Posix.NETStandard.1.0.0\lib\net40\Mono.Posix.NETStandard.dll</HintPath>
-    </Reference>
     <Reference Include="Mono.Posix" />
     <Reference Include="libZipSharp">
       <HintPath>packages\Xamarin.LibZipSharp.$(LibZipSharpVersion)\lib\net45\libZipSharp.dll</HintPath>
@@ -53,7 +50,6 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Mono.Options" Version="6.6.0.161" />
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/tools/apkdiff/apkdiff.csproj
+++ b/tools/apkdiff/apkdiff.csproj
@@ -35,7 +35,7 @@
     </Reference>
     <Reference Include="Mono.Posix" />
     <Reference Include="libZipSharp">
-      <HintPath>packages\Xamarin.LibZipSharp.1.0.8\lib\net45\libZipSharp.dll</HintPath>
+      <HintPath>packages\Xamarin.LibZipSharp.$(LibZipSharpVersion)\lib\net45\libZipSharp.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Options">
       <HintPath>packages\Mono.Options.6.6.0.161\lib\net40\Mono.Options.dll</HintPath>
@@ -54,9 +54,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Mono.Options" Version="6.6.0.161" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-    <PackageReference Include="Xamarin.LibZipSharp" Version="1.0.8" />
+    <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="packages\Xamarin.LibZipSharp.1.0.8\build\Xamarin.LibZipSharp.targets" Condition="Exists('packages\Xamarin.LibZipSharp.1.0.8\build\Xamarin.LibZipSharp.targets')" />
+  <Import Project="packages\Xamarin.LibZipSharp.$(LibZipSharpVersion)\build\Xamarin.LibZipSharp.targets" Condition="Exists('packages\Xamarin.LibZipSharp.$(LibZipSharpVersion)\build\Xamarin.LibZipSharp.targets')" />
   <Import Project="apkdiff.targets" />
 </Project>

--- a/tools/apkdiff/apkdiff.csproj
+++ b/tools/apkdiff/apkdiff.csproj
@@ -8,13 +8,14 @@
     <RootNamespace>apkdiff</RootNamespace>
     <AssemblyName>apkdiff</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <LibZipSharpBundleAllNativeLibraries>true</LibZipSharpBundleAllNativeLibraries>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\apkdiff</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -22,7 +23,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
-    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\</OutputPath>
+    <OutputPath>$(XAInstallPrefix)xbuild\Xamarin\Android\apkdiff</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ExternalConsole>true</ExternalConsole>

--- a/tools/apkdiff/apkdiff.csproj
+++ b/tools/apkdiff/apkdiff.csproj
@@ -53,9 +53,11 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Mono.Options" Version="6.6.0.161" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-    <PackageReference Include="Xamarin.LibZipSharp" Version="1.0.8" />
+    <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="packages\Xamarin.LibZipSharp.1.0.8\build\Xamarin.LibZipSharp.targets" Condition="Exists('packages\Xamarin.LibZipSharp.1.0.8\build\Xamarin.LibZipSharp.targets')" />
+  <Import Project="packages\Xamarin.LibZipSharp.$(LibZipSharpVersion)\build\Xamarin.LibZipSharp.targets" Condition="Exists('packages\Xamarin.LibZipSharp.$(LibZipSharpVersion)\build\Xamarin.LibZipSharp.targets')" />
   <Import Project="apkdiff.targets" />
 </Project>

--- a/tools/apkdiff/apkdiff.csproj
+++ b/tools/apkdiff/apkdiff.csproj
@@ -53,11 +53,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Mono.Options" Version="6.6.0.161" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-    <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Xamarin.LibZipSharp" Version="1.0.8" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="packages\Xamarin.LibZipSharp.$(LibZipSharpVersion)\build\Xamarin.LibZipSharp.targets" Condition="Exists('packages\Xamarin.LibZipSharp.$(LibZipSharpVersion)\build\Xamarin.LibZipSharp.targets')" />
+  <Import Project="packages\Xamarin.LibZipSharp.1.0.8\build\Xamarin.LibZipSharp.targets" Condition="Exists('packages\Xamarin.LibZipSharp.1.0.8\build\Xamarin.LibZipSharp.targets')" />
   <Import Project="apkdiff.targets" />
 </Project>

--- a/tools/scripts/apkdiff
+++ b/tools/scripts/apkdiff
@@ -3,4 +3,4 @@ BINDIR=`dirname "$0"`
 MANDROID_DIR="$BINDIR/.."
 
 unset MONO_PATH
-exec mono $MONO_OPTIONS "$MANDROID_DIR/apkdiff.exe" "$@"
+exec mono $MONO_OPTIONS "$MANDROID_DIR/apkdiff/apkdiff.exe" "$@"


### PR DESCRIPTION
We were clashing with `Xamarin.Android.Build.Tasks` project assemblies in
`lib/xamarin.android/xbuild/Xamarin/Android/`, so put it in `lib/xamarin.android/xbuild/Xamarin/Android/apkdiff/` instead.

There were 2 issues:

* the `Xamarin.Android.Build.Tasks` project requires `netstandard2.0` version of
`libZipSharp.dll`. Sometimes the `apkdiff` is built after
`Xamarin.Android.Build.Tasks` and thus we end up with `net45` version,
which causes errors like this one:

    C:\A\xamarin-v00000K-1\_work\1\s\packages\xamarin.android.sdk\0.0.1\tools\Xamarin.Android.Common.targets(785,2): error MSB4062: The "Xamarin.Android.Tasks.ResolveSdks" task could not be loaded from the assembly C:\A\xamarin-v00000K-1\_work\1\s\packages\xamarin.android.sdk\0.0.1\tools\Xamarin.Android.Build.Tasks.dll. Could not load file or assembly 'libZipSharp, Version=1.0.7328.28304, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified. Confirm that the <UsingTask> declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask. [C:\A\xamarin-v00000K-1\_work\1\s\bin\TestRelease\temp\DotNetPackageXASdkProjectTrue\UnnamedProject.csproj]

* the `Xamarin.Android.Build.Tasks` project uses `Newtonsoft.Json` assembly as well. It is removed during the build process (in `ILRepacker` target), so we end up without the assembly. That leads to fail when creating the installation. The error:

    /Users/builder/jenkins/workspace/xamarin-android/xamarin-android/build-tools/create-pkg/create-pkg.targets(34,5): error MSB3030: **Could not copy the file** "/Users/builder/jenkins/workspace/xamarin-android/xamarin-android/bin/Release/lib/xamarin.android/xbuild/Xamarin/Android/**Newtonsoft.Json.dll**" because it was not found. [/Users/builder/jenkins/workspace/xamarin-android/xamarin-android/build-tools/create-pkg/create-pkg.csproj]

Also use the `$(LibZipSharpVersion)` property.

Do not reference `Mono.Posix.NETStandard`, context: https://github.com/xamarin/xamarin-android/pull/4267