### PR TITLE
[ci] Bump credscan and artifact task versions

### DIFF
--- a/build-tools/automation/CredScanSuppressions.json
+++ b/build-tools/automation/CredScanSuppressions.json
@@ -4,6 +4,34 @@
         {
             "file": "\\src\\Xamarin.Android.Build.Tasks\\Tests\\Xamarin.ProjectTools\\Resources\\Base\\test.keystore",
             "_justification": "Dummy keystore file used for testing."
+        },
+        {
+            "file": "tests\\MSBuildDeviceIntegration\\Tests\\InstallTests.cs",
+            "_justification": "Password of the dummy keystore file used only for testing."
+        },
+        {
+            "file": "external\\android-api-docs\\docs\\Mono.Android\\en\\Android.Webkit\\HttpAuthHandler.xml",
+            "_justification": "Android API documentation, does not contain a password."
+        },
+        {
+            "file": "external\\android-api-docs\\docs\\Mono.Android\\en\\Android.Webkit\\WebViewDatabase.xml",
+            "_justification": "Android API documentation, does not contain a password."
+        },
+        {
+            "file": "external\\android-api-docs\\docs\\Mono.Android\\en\\Java.Security\\KeyStore+PasswordProtection.xml",
+            "_justification": "Android API documentation, does not contain a password."
+        },
+        {
+            "file": "external\\android-api-docs\\docs\\Mono.Android\\en\\Javax.Security.Auth.Callback\\PasswordCallback.xml",
+            "_justification": "Android API documentation, does not contain a password."
+        },
+        {
+            "file": "external\\android-api-docs\\docs\\Mono.Android\\en\\Javax.Crypto\\KeyAgreementSpi.xml",
+            "_justification": "Android API documentation, does not contain a password."
+        },
+        {
+            "file": "external\\android-api-docs\\docs\\Mono.Android\\en\\Javax.Crypto.Interfaces\\IPBEKey.xml",
+            "_justification": "Android API documentation, does not contain a password."
         }
     ]
 }

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -205,7 +205,7 @@ stages:
 # Check - "Xamarin.Android (Windows Build and Test)"
 - stage: win_build_test
   displayName: Windows
-  dependsOn: []
+  # dependsOn: [] -- TODO: Remove this comment
   jobs:
   - job: win_build_test
     displayName: Build and Test

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -12,7 +12,7 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/pjcollins_credscan2
+    ref: refs/heads/master
     endpoint: xamarin
   - repository: monodroid
     type: github

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -12,7 +12,7 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/master
+    ref: refs/heads/pjcollins_credscan2
     endpoint: xamarin
   - repository: monodroid
     type: github
@@ -74,7 +74,7 @@ stages:
     steps:
     - checkout: self
       submodules: recursive
-    - template: security\xa-static-analysis\v1.yml@yaml
+    - template: security\xa-static-analysis\v2.yml@yaml
       parameters:
         credScanSuppressionsFile: $(System.DefaultWorkingDirectory)\build-tools\automation\CredScanSuppressions.json
 
@@ -140,7 +140,7 @@ stages:
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: copy bcl-tests assemblies
 
-    - task: PublishPipelineArtifact@0
+    - task: PublishPipelineArtifact@1
       displayName: upload test assemblies
       inputs:
         artifactName: $(TestAssembliesArtifactName)
@@ -172,7 +172,7 @@ stages:
       workingDirectory: $(System.DefaultWorkingDirectory)/xamarin-android
       displayName: create updateinfo file
 
-    - task: PublishPipelineArtifact@0
+    - task: PublishPipelineArtifact@1
       displayName: upload installers
       inputs:
         artifactName: $(InstallerArtifactName)
@@ -186,7 +186,7 @@ stages:
         configuration: $(XA.Build.Configuration)
         packDirectory: $(System.DefaultWorkingDirectory)/xamarin-android/bin/Build$(XA.Build.Configuration)/$(NuGetArtifactName)
 
-    - task: PublishPipelineArtifact@0
+    - task: PublishPipelineArtifact@1
       displayName: upload nupkgs
       inputs:
         artifactName: $(NuGetArtifactName)
@@ -388,7 +388,7 @@ stages:
     - script: cp $(System.DefaultWorkingDirectory)/storage-artifacts/*.pkg $(Build.ArtifactStagingDirectory)
       displayName: copy notarized pkg
 
-    - task: PublishPipelineArtifact@0
+    - task: PublishPipelineArtifact@1
       displayName: upload notarized pkg
       inputs:
         artifactName: notarized-pkg
@@ -664,7 +664,7 @@ stages:
     steps:
     - template: yaml-templates/setup-test-environment.yaml
 
-    - task: DownloadPipelineArtifact@1
+    - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: $(TestAssembliesArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)/bin/$(XA.Build.Configuration)
@@ -718,12 +718,12 @@ stages:
     steps:
     - template: yaml-templates/setup-test-environment.yaml
 
-    - task: DownloadPipelineArtifact@1
+    - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: $(TestAssembliesArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)
 
-    - task: DownloadPipelineArtifact@1
+    - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: $(NuGetArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)
@@ -780,12 +780,12 @@ stages:
       parameters:
         provisionExtraArgs: -vv PROVISIONATOR_VISUALSTUDIO_LOCATION="$(VSINSTALLDIR)" -f
 
-    - task: DownloadPipelineArtifact@1
+    - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: $(TestAssembliesArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)
 
-    - task: DownloadPipelineArtifact@1
+    - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: $(NuGetArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)/bin/Build$(XA.Build.Configuration)
@@ -820,7 +820,7 @@ stages:
     steps:
     - template: yaml-templates/setup-test-environment.yaml
 
-    - task: DownloadPipelineArtifact@1
+    - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: $(TestAssembliesArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -12,7 +12,7 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/master
+    ref: refs/heads/pjcollins_fail-on-analysis-error
     endpoint: xamarin
   - repository: monodroid
     type: github
@@ -80,7 +80,7 @@ stages:
 
 - stage: mac_build
   displayName: Mac
-  dependsOn: []
+  # dependsOn: [] -- TODO: Remove this comment
   jobs:
   # Check - "Xamarin.Android (Mac Build)"
   - job: mac_build_create_installers

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -12,7 +12,7 @@ resources:
   - repository: yaml
     type: github
     name: xamarin/yaml-templates
-    ref: refs/heads/pjcollins_fail-on-analysis-error
+    ref: refs/heads/master
     endpoint: xamarin
   - repository: monodroid
     type: github
@@ -80,7 +80,7 @@ stages:
 
 - stage: mac_build
   displayName: Mac
-  # dependsOn: [] -- TODO: Remove this comment
+  dependsOn: []
   jobs:
   # Check - "Xamarin.Android (Mac Build)"
   - job: mac_build_create_installers
@@ -205,7 +205,7 @@ stages:
 # Check - "Xamarin.Android (Windows Build and Test)"
 - stage: win_build_test
   displayName: Windows
-  # dependsOn: [] -- TODO: Remove this comment
+  dependsOn: []
   jobs:
   - job: win_build_test
     displayName: Build and Test

--- a/build-tools/automation/yaml-templates/run-timezoneinfo-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-timezoneinfo-tests.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - template: setup-test-environment.yaml
 
-    - task: DownloadPipelineArtifact@1
+    - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: $(TestAssembliesArtifactName)
         downloadPath: $(System.DefaultWorkingDirectory)/bin/Test$(XA.Build.Configuration)

--- a/build-tools/automation/yaml-templates/upload-results.yaml
+++ b/build-tools/automation/yaml-templates/upload-results.yaml
@@ -12,7 +12,7 @@ steps:
     msbuildArguments: /restore /t:Build,ZipBuildStatus,ZipTestResults /p:BuildStatusZipOutputPath=$(Build.ArtifactStagingDirectory) /p:TestResultZipOutputPath=$(Build.ArtifactStagingDirectory)
   condition: always()
 
-- task: PublishPipelineArtifact@0
+- task: PublishPipelineArtifact@1
   displayName: upload build and test results
   inputs:
     artifactName: ${{ parameters.artifactName }}


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/4241
Context: https://github.com/xamarin/yaml-templates/commit/fc7eb6822ea92ee000258b6fff71e80b8d1022f5, https://github.com/xamarin/yaml-templates/commit/af29b0c60164f883bc597544a178fa6cd53eae9e

Bumps our static analysis template to a new version that will allow us
to specify the version of the `credscan` tool to use. This template will
use `V2` by default, but can be overridden as needed:

```yaml
    - template: security\xa-static-analysis\v2.yml@yaml
      parameters:
        credScanSuppressionsFile: $(System.DefaultWorkingDirectory)\build-tools\automation\CredScanSuppressions.json
        toolMajorVersion: V1
```

Artifact publishing and downloading tasks have also been bumped to their
latest versions.