### PR TITLE
[xaprepare] Always set JAVA_HOME for sdkmanager

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_Android_SDK_NDK.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_Android_SDK_NDK.cs
@@ -103,7 +103,7 @@ namespace Xamarin.Android.Prepare
 			Log.Todo ("Modify ProcessRunner to allow standard input writing and switch to it here");
 			// var runner = new ProcessRunner (sdkManager, "--licenses");
 			// runner.StartInfoCallback = (ProcessStartInfo psi) => {
-			// 	if (String.IsNullOrEmpty (jdkDir))
+			// 	if (!String.IsNullOrEmpty (jdkDir))
 			// 		psi.EnvironmentVariables.Add ("JAVA_HOME", jdkDir);
 			// 	psi.RedirectStandardInput = true;
 			// };
@@ -112,7 +112,7 @@ namespace Xamarin.Android.Prepare
 				UseShellExecute = false,
 				RedirectStandardInput = true
 			};
-			if (String.IsNullOrEmpty (jdkDir) && !psi.EnvironmentVariables.ContainsKey ("JAVA_HOME"))
+			if (!String.IsNullOrEmpty (jdkDir) && !psi.EnvironmentVariables.ContainsKey ("JAVA_HOME"))
 				psi.EnvironmentVariables.Add ("JAVA_HOME", jdkDir);
 
 			Log.DebugLine ($"Starting {psi.FileName} {psi.Arguments}");


### PR DESCRIPTION
On a "clean" macOS 10.15 Catalina machine -- "clean" such that there
is no JDK installed -- running `make prepare` will cause a macOS GUI
dialog to appear, requesting that a JDK be installed:

	$ make prepare PREPARE_ARGS="--ignore-min-mono-version=true"
	...
	  • Checking cmake-3.10.2-darwin-x86_64
	    installed
	TODO: Modify ProcessRunner to allow standard input writing and switch to it here
	      From: Xamarin.Android.Prepare.Step_Android_SDK_NDK.AcceptLicenses at /Volumes/Xamarin-Work/xamarin-android/build-tools/xaprepare/xaprepare/Steps/	Step_Android_SDK_NDK.cs(103,4)
	No Java runtime present, requesting install.
	...

The GUI dialog says:

> To use the “java” command-line tool you need to install a JDK.
>
> Click “More Info…” to visit the Java Developer Kit download website.
>
>                                                    [More Info…] [OK]

The cause of the "No Java runtime present" message and associated
dialog box is that `Step_Android_SDK_NDK.AcceptLicenses()` only
overrides `$JAVA_HOME` when `jdkDir` is the empty string, which is
the *opposite* of intended behavior; we *do* want to override
`$JAVA_HOME` when `jdkDir` is a non-empty value!

Fix the logic typo, and the error message & dialog no longer appear.