### PR TITLE
[Xamarin.Android.Build.Tasks] Update multidex warnings & make localizable

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -101,10 +101,11 @@ ms.date: 01/24/2020
 + [XA4302](xa4302.md): Unhandled exception merging \`AndroidManifest.xml]`: {ex}
 + [XA4303](xa4303.md): Error extracting resources from "{assemblyPath}": {ex}
 + [XA4304](xa4304.md): Proguard configuration file '{file}' was not found.
-+ [XA4305](xa4305.md): MultiDex is enabled, but '{nameof (MultiDexMainDexListFile)}' was not specified.
++ [XA4305](xa4305.md): Multidex is enabled, but the path of the merged keep file was not specified.
 + [XA4306](xa4306.md): R8 does not support \`@(MultiDexMainDexList)\` files when android:minSdkVersion >= 21
 + [XA4307](xa4307.md): Invalid ProGuard configuration file.
 + [XA4308](xa4308.md): Failed to generate type maps
++ [XA4309](xa4309.md): 'MultiDexMainDexList' file '{file}' does not exist.
 
 ## XA5xxx: GCC and toolchain
 

--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -101,7 +101,7 @@ ms.date: 01/24/2020
 + [XA4302](xa4302.md): Unhandled exception merging \`AndroidManifest.xml]`: {ex}
 + [XA4303](xa4303.md): Error extracting resources from "{assemblyPath}": {ex}
 + [XA4304](xa4304.md): Proguard configuration file '{file}' was not found.
-+ [XA4305](xa4305.md): Multidex is enabled, but the path of the merged keep file was not specified.
++ [XA4305](xa4305.md): Multidex is enabled, but \`$(\_AndroidMainDexListFile)\` is empty.
 + [XA4306](xa4306.md): R8 does not support \`@(MultiDexMainDexList)\` files when android:minSdkVersion >= 21
 + [XA4307](xa4307.md): Invalid ProGuard configuration file.
 + [XA4308](xa4308.md): Failed to generate type maps

--- a/Documentation/guides/messages/xa4305.md
+++ b/Documentation/guides/messages/xa4305.md
@@ -8,22 +8,17 @@ ms.date: 02/11/2020
 ## Example messages
 
 ```
-Multidex is enabled, but the path of the merged keep file was not specified.
+Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.
 ```
 
 ```
-Multidex is enabled, but the merged keep file 'obj\Release\90\multidex.keep' does not exist.
+Multidex is enabled, but the `$(_AndroidMainDexListFile)` 'obj\Release\90\multidex.keep' does not exist.
 ```
-
-## Issue
-
-The path of the merged *multidex.keep* file for the `CompileToDalvik` or `R8`
-MSBuild task was not specified or the file was not found on disk.
 
 ## Solution
 
-The build process should automatically configure and populate the merged
-*multidex.keep* file, so please consider submitting a [bug][bug] if you are
-getting this warning under normal circumstances.
+The build process should automatically configure and populate the file for the
+`$(_AndroidMainDexListFile)` property, so please consider submitting a
+[bug][bug] if you are getting this warning under normal circumstances.
 
 [bug]: https://github.com/xamarin/xamarin-android/wiki/Submitting-Bugs,-Feature-Requests,-and-Pull-Requests

--- a/Documentation/guides/messages/xa4305.md
+++ b/Documentation/guides/messages/xa4305.md
@@ -1,28 +1,29 @@
 ---
 title: Xamarin.Android warning XA4305
 description: XA4305 warning code
-ms.date: 10/30/2018
+ms.date: 02/11/2020
 ---
 # Xamarin.Android warning XA4305
 
+## Example messages
+
+```
+Multidex is enabled, but the path of the merged keep file was not specified.
+```
+
+```
+Multidex is enabled, but the merged keep file 'obj\Release\90\multidex.keep' does not exist.
+```
+
 ## Issue
 
-The `CreateMultiDexMainDexClassList`, `CompileToDalvik` or `R8`
-MSBuild task encountered a *multidex.keep* file that was not found on
-disk. You can customize multidex settings for your Xamarin.Android
-application by adding files with the `MultiDexMainDexList` build item,
-which are combined into a final *multidex.keep* file.
-
-To learn more about multidex and how it relates to Android
-development, see the [Android documentation][android].
+The path of the merged *multidex.keep* file for the `CompileToDalvik` or `R8`
+MSBuild task was not specified or the file was not found on disk.
 
 ## Solution
 
-Verify you are not declaring a `MultiDexMainDexList` build item that
-does not exist.
+The build process should automatically configure and populate the merged
+*multidex.keep* file, so please consider submitting a [bug][bug] if you are
+getting this warning under normal circumstances.
 
-Consider submitting a [bug][bug] if you are getting this warning under
-normal circumstances.
-
-[android]: https://developer.android.com/studio/build/multidex
 [bug]: https://github.com/xamarin/xamarin-android/wiki/Submitting-Bugs,-Feature-Requests,-and-Pull-Requests

--- a/Documentation/guides/messages/xa4305.md
+++ b/Documentation/guides/messages/xa4305.md
@@ -12,7 +12,7 @@ Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.
 ```
 
 ```
-Multidex is enabled, but the `$(_AndroidMainDexListFile)` 'obj\Release\90\multidex.keep' does not exist.
+Multidex is enabled, but the `$(_AndroidMainDexListFile)` file 'obj\Release\90\multidex.keep' does not exist.
 ```
 
 ## Solution

--- a/Documentation/guides/messages/xa4309.md
+++ b/Documentation/guides/messages/xa4309.md
@@ -1,0 +1,27 @@
+---
+title: Xamarin.Android warning XA4309
+description: XA4309 warning code
+ms.date: 02/11/2020
+---
+# Xamarin.Android warning XA4309
+
+## Example messages
+
+```
+'MultiDexMainDexList' file 'multidexcustom.keep' does not exist.
+```
+
+## Issue
+
+One of the specified `@(MultiDexMainDexList)` build items could not be found on
+disk.
+
+To learn more about multidex and how it relates to Android development, see the
+[Android documentation][android].
+
+## Solution
+
+Verify that you are not declaring a `@(MultiDexMainDexList)` build item that
+does not exist.
+
+[android]: https://developer.android.com/studio/build/multidex

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -295,7 +295,7 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Multidex is enabled, but the `$(_AndroidMainDexListFile)` &apos;{0}&apos; does not exist..
+        ///   Looks up a localized string similar to Multidex is enabled, but the `$(_AndroidMainDexListFile)` file &apos;{0}&apos; does not exist..
         /// </summary>
         internal static string XA4305_File_Missing {
             get {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -286,7 +286,7 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to MultiDex is enabled, but &apos;{0}&apos; was not specified..
+        ///   Looks up a localized string similar to Multidex is enabled, but the path of the merged keep file was not specified..
         /// </summary>
         internal static string XA4305 {
             get {
@@ -295,11 +295,20 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to MultiDex is enabled, but main dex list file &apos;{0}&apos; does not exist..
+        ///   Looks up a localized string similar to Multidex is enabled, but the merged keep file &apos;{0}&apos; does not exist..
         /// </summary>
         internal static string XA4305_File_Missing {
             get {
                 return ResourceManager.GetString("XA4305_File_Missing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21.
+        /// </summary>
+        internal static string XA4306 {
+            get {
+                return ResourceManager.GetString("XA4306", resourceCulture);
             }
         }
         
@@ -309,6 +318,15 @@ namespace Xamarin.Android.Tasks.Properties {
         internal static string XA4308 {
             get {
                 return ResourceManager.GetString("XA4308", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;MultiDexMainDexList&apos; file &apos;{0}&apos; does not exist..
+        /// </summary>
+        internal static string XA4309 {
+            get {
+                return ResourceManager.GetString("XA4309", resourceCulture);
             }
         }
         

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -286,7 +286,7 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Multidex is enabled, but the path of the merged keep file was not specified..
+        ///   Looks up a localized string similar to Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty..
         /// </summary>
         internal static string XA4305 {
             get {
@@ -295,7 +295,7 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Multidex is enabled, but the merged keep file &apos;{0}&apos; does not exist..
+        ///   Looks up a localized string similar to Multidex is enabled, but the `$(_AndroidMainDexListFile)` &apos;{0}&apos; does not exist..
         /// </summary>
         internal static string XA4305_File_Missing {
             get {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -234,7 +234,7 @@
     <comment>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</comment>
   </data>
   <data name="XA4305_File_Missing" xml:space="preserve">
-    <value>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</value>
+    <value>Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</value>
     <comment>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</comment>
   </data>
   <data name="XA4306" xml:space="preserve">

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -230,12 +230,12 @@
 {0} - Comma-separated list of the ignored library file names.</comment>
   </data>
   <data name="XA4305" xml:space="preserve">
-    <value>Multidex is enabled, but the path of the merged keep file was not specified.</value>
-    <comment>The following are literal names and should not be translated: Multidex</comment>
+    <value>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</value>
+    <comment>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</comment>
   </data>
   <data name="XA4305_File_Missing" xml:space="preserve">
-    <value>Multidex is enabled, but the merged keep file '{0}' does not exist.</value>
-    <comment>The following are literal names and should not be translated: Multidex</comment>
+    <value>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</value>
+    <comment>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</comment>
   </data>
   <data name="XA4306" xml:space="preserve">
     <value>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -230,16 +230,23 @@
 {0} - Comma-separated list of the ignored library file names.</comment>
   </data>
   <data name="XA4305" xml:space="preserve">
-    <value>MultiDex is enabled, but '{0}' was not specified.</value>
-    <comment>The following are literal names and should not be translated: MultiDex
-{0} - The MSBuild property name.</comment>
+    <value>Multidex is enabled, but the path of the merged keep file was not specified.</value>
+    <comment>The following are literal names and should not be translated: Multidex</comment>
   </data>
   <data name="XA4305_File_Missing" xml:space="preserve">
-    <value>MultiDex is enabled, but main dex list file '{0}' does not exist.</value>
-    <comment>The following are literal names and should not be translated: MultiDex</comment>
+    <value>Multidex is enabled, but the merged keep file '{0}' does not exist.</value>
+    <comment>The following are literal names and should not be translated: Multidex</comment>
+  </data>
+  <data name="XA4306" xml:space="preserve">
+    <value>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</value>
+    <comment>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</comment>
   </data>
   <data name="XA4308" xml:space="preserve">
     <value>Failed to generate type maps</value>
+  </data>
+  <data name="XA4309" xml:space="preserve">
+    <value>'MultiDexMainDexList' file '{0}' does not exist.</value>
+    <comment>The following are literal names and should not be translated: MultiDexMainDexList</comment>
   </data>
   <data name="XA5101" xml:space="preserve">
     <value>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -149,8 +149,8 @@
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -144,20 +144,29 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>MultiDex is enabled, but '{0}' was not specified.</source>
-        <target state="new">MultiDex is enabled, but '{0}' was not specified.</target>
-        <note>The following are literal names and should not be translated: MultiDex
-{0} - The MSBuild property name.</note>
+        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
+        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>MultiDex is enabled, but main dex list file '{0}' does not exist.</source>
-        <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: MultiDex</note>
+        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
+      </trans-unit>
+      <trans-unit id="XA4306">
+        <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
+        <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
+        <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>
         <target state="new">Failed to generate type maps</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA4309">
+        <source>'MultiDexMainDexList' file '{0}' does not exist.</source>
+        <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -144,14 +144,14 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
-        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
+        <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -149,8 +149,8 @@
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -144,20 +144,29 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>MultiDex is enabled, but '{0}' was not specified.</source>
-        <target state="new">MultiDex is enabled, but '{0}' was not specified.</target>
-        <note>The following are literal names and should not be translated: MultiDex
-{0} - The MSBuild property name.</note>
+        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
+        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>MultiDex is enabled, but main dex list file '{0}' does not exist.</source>
-        <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: MultiDex</note>
+        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
+      </trans-unit>
+      <trans-unit id="XA4306">
+        <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
+        <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
+        <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>
         <target state="new">Failed to generate type maps</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA4309">
+        <source>'MultiDexMainDexList' file '{0}' does not exist.</source>
+        <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -144,14 +144,14 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
-        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
+        <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -149,8 +149,8 @@
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -144,20 +144,29 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>MultiDex is enabled, but '{0}' was not specified.</source>
-        <target state="new">MultiDex is enabled, but '{0}' was not specified.</target>
-        <note>The following are literal names and should not be translated: MultiDex
-{0} - The MSBuild property name.</note>
+        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
+        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>MultiDex is enabled, but main dex list file '{0}' does not exist.</source>
-        <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: MultiDex</note>
+        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
+      </trans-unit>
+      <trans-unit id="XA4306">
+        <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
+        <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
+        <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>
         <target state="new">Failed to generate type maps</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA4309">
+        <source>'MultiDexMainDexList' file '{0}' does not exist.</source>
+        <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -144,14 +144,14 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
-        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
+        <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -149,8 +149,8 @@
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -144,20 +144,29 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>MultiDex is enabled, but '{0}' was not specified.</source>
-        <target state="new">MultiDex is enabled, but '{0}' was not specified.</target>
-        <note>The following are literal names and should not be translated: MultiDex
-{0} - The MSBuild property name.</note>
+        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
+        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>MultiDex is enabled, but main dex list file '{0}' does not exist.</source>
-        <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: MultiDex</note>
+        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
+      </trans-unit>
+      <trans-unit id="XA4306">
+        <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
+        <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
+        <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>
         <target state="new">Failed to generate type maps</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA4309">
+        <source>'MultiDexMainDexList' file '{0}' does not exist.</source>
+        <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -144,14 +144,14 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
-        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
+        <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -149,8 +149,8 @@
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -144,20 +144,29 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>MultiDex is enabled, but '{0}' was not specified.</source>
-        <target state="new">MultiDex is enabled, but '{0}' was not specified.</target>
-        <note>The following are literal names and should not be translated: MultiDex
-{0} - The MSBuild property name.</note>
+        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
+        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>MultiDex is enabled, but main dex list file '{0}' does not exist.</source>
-        <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: MultiDex</note>
+        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
+      </trans-unit>
+      <trans-unit id="XA4306">
+        <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
+        <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
+        <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>
         <target state="new">Failed to generate type maps</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA4309">
+        <source>'MultiDexMainDexList' file '{0}' does not exist.</source>
+        <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -144,14 +144,14 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
-        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
+        <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -149,8 +149,8 @@
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -144,20 +144,29 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>MultiDex is enabled, but '{0}' was not specified.</source>
-        <target state="new">MultiDex is enabled, but '{0}' was not specified.</target>
-        <note>The following are literal names and should not be translated: MultiDex
-{0} - The MSBuild property name.</note>
+        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
+        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>MultiDex is enabled, but main dex list file '{0}' does not exist.</source>
-        <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: MultiDex</note>
+        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
+      </trans-unit>
+      <trans-unit id="XA4306">
+        <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
+        <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
+        <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>
         <target state="new">Failed to generate type maps</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA4309">
+        <source>'MultiDexMainDexList' file '{0}' does not exist.</source>
+        <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -144,14 +144,14 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
-        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
+        <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -149,8 +149,8 @@
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -144,20 +144,29 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>MultiDex is enabled, but '{0}' was not specified.</source>
-        <target state="new">MultiDex is enabled, but '{0}' was not specified.</target>
-        <note>The following are literal names and should not be translated: MultiDex
-{0} - The MSBuild property name.</note>
+        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
+        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>MultiDex is enabled, but main dex list file '{0}' does not exist.</source>
-        <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: MultiDex</note>
+        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
+      </trans-unit>
+      <trans-unit id="XA4306">
+        <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
+        <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
+        <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>
         <target state="new">Failed to generate type maps</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA4309">
+        <source>'MultiDexMainDexList' file '{0}' does not exist.</source>
+        <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -144,14 +144,14 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
-        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
+        <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -149,8 +149,8 @@
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -144,20 +144,29 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>MultiDex is enabled, but '{0}' was not specified.</source>
-        <target state="new">MultiDex is enabled, but '{0}' was not specified.</target>
-        <note>The following are literal names and should not be translated: MultiDex
-{0} - The MSBuild property name.</note>
+        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
+        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>MultiDex is enabled, but main dex list file '{0}' does not exist.</source>
-        <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: MultiDex</note>
+        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
+      </trans-unit>
+      <trans-unit id="XA4306">
+        <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
+        <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
+        <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>
         <target state="new">Failed to generate type maps</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA4309">
+        <source>'MultiDexMainDexList' file '{0}' does not exist.</source>
+        <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -144,14 +144,14 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
-        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
+        <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -149,8 +149,8 @@
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -144,20 +144,29 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>MultiDex is enabled, but '{0}' was not specified.</source>
-        <target state="new">MultiDex is enabled, but '{0}' was not specified.</target>
-        <note>The following are literal names and should not be translated: MultiDex
-{0} - The MSBuild property name.</note>
+        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
+        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>MultiDex is enabled, but main dex list file '{0}' does not exist.</source>
-        <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: MultiDex</note>
+        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
+      </trans-unit>
+      <trans-unit id="XA4306">
+        <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
+        <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
+        <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>
         <target state="new">Failed to generate type maps</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA4309">
+        <source>'MultiDexMainDexList' file '{0}' does not exist.</source>
+        <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -144,14 +144,14 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
-        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
+        <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -149,8 +149,8 @@
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -144,20 +144,29 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>MultiDex is enabled, but '{0}' was not specified.</source>
-        <target state="new">MultiDex is enabled, but '{0}' was not specified.</target>
-        <note>The following are literal names and should not be translated: MultiDex
-{0} - The MSBuild property name.</note>
+        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
+        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>MultiDex is enabled, but main dex list file '{0}' does not exist.</source>
-        <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: MultiDex</note>
+        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
+      </trans-unit>
+      <trans-unit id="XA4306">
+        <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
+        <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
+        <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>
         <target state="new">Failed to generate type maps</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA4309">
+        <source>'MultiDexMainDexList' file '{0}' does not exist.</source>
+        <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -144,14 +144,14 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
-        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
+        <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -149,8 +149,8 @@
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -144,20 +144,29 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>MultiDex is enabled, but '{0}' was not specified.</source>
-        <target state="new">MultiDex is enabled, but '{0}' was not specified.</target>
-        <note>The following are literal names and should not be translated: MultiDex
-{0} - The MSBuild property name.</note>
+        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
+        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>MultiDex is enabled, but main dex list file '{0}' does not exist.</source>
-        <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: MultiDex</note>
+        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
+      </trans-unit>
+      <trans-unit id="XA4306">
+        <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
+        <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
+        <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>
         <target state="new">Failed to generate type maps</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA4309">
+        <source>'MultiDexMainDexList' file '{0}' does not exist.</source>
+        <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -144,14 +144,14 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
-        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
+        <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -149,8 +149,8 @@
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -144,20 +144,29 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>MultiDex is enabled, but '{0}' was not specified.</source>
-        <target state="new">MultiDex is enabled, but '{0}' was not specified.</target>
-        <note>The following are literal names and should not be translated: MultiDex
-{0} - The MSBuild property name.</note>
+        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
+        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>MultiDex is enabled, but main dex list file '{0}' does not exist.</source>
-        <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: MultiDex</note>
+        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
+      </trans-unit>
+      <trans-unit id="XA4306">
+        <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
+        <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
+        <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>
         <target state="new">Failed to generate type maps</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA4309">
+        <source>'MultiDexMainDexList' file '{0}' does not exist.</source>
+        <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -144,14 +144,14 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
-        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
+        <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -149,8 +149,8 @@
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` file '{0}' does not exist.</target>
         <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -144,20 +144,29 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>MultiDex is enabled, but '{0}' was not specified.</source>
-        <target state="new">MultiDex is enabled, but '{0}' was not specified.</target>
-        <note>The following are literal names and should not be translated: MultiDex
-{0} - The MSBuild property name.</note>
+        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
+        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>MultiDex is enabled, but main dex list file '{0}' does not exist.</source>
-        <target state="new">MultiDex is enabled, but main dex list file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: MultiDex</note>
+        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex</note>
+      </trans-unit>
+      <trans-unit id="XA4306">
+        <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
+        <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
+        <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>
         <target state="new">Failed to generate type maps</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA4309">
+        <source>'MultiDexMainDexList' file '{0}' does not exist.</source>
+        <target state="new">'MultiDexMainDexList' file '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: MultiDexMainDexList</note>
       </trans-unit>
       <trans-unit id="XA5101">
         <source>Missing Android NDK toolchains directory '{0}'. Please install the Android NDK.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -144,14 +144,14 @@
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
       <trans-unit id="XA4305">
-        <source>Multidex is enabled, but the path of the merged keep file was not specified.</source>
-        <target state="new">Multidex is enabled, but the path of the merged keep file was not specified.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
+        <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4305_File_Missing">
-        <source>Multidex is enabled, but the merged keep file '{0}' does not exist.</source>
-        <target state="new">Multidex is enabled, but the merged keep file '{0}' does not exist.</target>
-        <note>The following are literal names and should not be translated: Multidex</note>
+        <source>Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</source>
+        <target state="new">Multidex is enabled, but the `$(_AndroidMainDexListFile)` '{0}' does not exist.</target>
+        <note>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</note>
       </trans-unit>
       <trans-unit id="XA4306">
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileToDalvik.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileToDalvik.cs
@@ -106,7 +106,7 @@ namespace Xamarin.Android.Tasks
 
 			if (MultiDexEnabled) {
 				if (string.IsNullOrEmpty (MultiDexMainDexListFile)) {
-					Log.LogCodedWarning ("XA4305", Properties.Resources.XA4305, nameof (MultiDexMainDexListFile));
+					Log.LogCodedWarning ("XA4305", Properties.Resources.XA4305);
 				} else if (!File.Exists (MultiDexMainDexListFile)) {
 					Log.LogCodedWarning ("XA4305", MultiDexMainDexListFile, 0, Properties.Resources.XA4305_File_Missing, MultiDexMainDexListFile);
 				} else {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateMultiDexMainDexClassList.cs
@@ -60,7 +60,7 @@ namespace Xamarin.Android.Tasks
 					if (File.Exists (file.ItemSpec)) {
 						content.Add (File.ReadAllText (file.ItemSpec));
 					} else {
-						Log.LogCodedWarning ("XA4305", file.ItemSpec, 0, $"'MultiDexMainDexList' file '{file.ItemSpec}' does not exist.");
+						Log.LogCodedWarning ("XA4309", file.ItemSpec, 0, Properties.Resources.XA4309, file.ItemSpec);
 					}
 				}
 				File.AppendAllText (MultiDexMainDexListFile, string.Concat (content));

--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -55,10 +55,10 @@ namespace Xamarin.Android.Tasks
 			if (EnableMultiDex) {
 				if (MinSdkVersion >= 21) {
 					if (CustomMainDexListFiles?.Length > 0) {
-						Log.LogCodedWarning ("XA4306", "R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion >= 21");
+						Log.LogCodedWarning ("XA4306", Properties.Resources.XA4306);
 					}
 				} else if (string.IsNullOrEmpty (MultiDexMainDexListFile)) {
-					Log.LogCodedWarning ("XA4305", $"MultiDex is enabled, but '{nameof (MultiDexMainDexListFile)}' was not specified.");
+					Log.LogCodedWarning ("XA4305", Properties.Resources.XA4305);
 				} else {
 					var content = new List<string> ();
 					var temp = Path.GetTempFileName ();
@@ -68,7 +68,7 @@ namespace Xamarin.Android.Tasks
 							if (File.Exists (file.ItemSpec)) {
 								content.Add (File.ReadAllText (file.ItemSpec));
 							} else {
-								Log.LogCodedWarning ("XA4305", file.ItemSpec, 0, $"'MultiDexMainDexList' file '{file.ItemSpec}' does not exist.");
+								Log.LogCodedWarning ("XA4309", file.ItemSpec, 0, Properties.Resources.XA4309, file.ItemSpec);
 							}
 						}
 					}


### PR DESCRIPTION
Context: 0342fe5698b86e21e36c924732ff135b9a87e4af
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

[3757be20][0] moved the XA4305 messages for `<CompileToDalvik/>` into
the `.resx` file, but it overlooked the uses of XA4305 in
`<CreateMultiDexMainDexClassList/>` and `<R8/>`.

The original uses of XA4305 in `<CreateMultiDexMainDexClassList/>` and
`<R8/>` were a little confusing because the `@(MultiDexMainDexList)`
MSBuild item corresponds to the `CustomMainDexListFiles` property in the
tasks, not the `MultiDexMainDexListFile` property.

To reduce the potential for confusion between `@(MultiDexMainDexList)`
and `MultiDexMainDexListFile` and to separate them in telemetry, give
the warning message related to `@(MultiDexMainDexList)` its own new
XA4309 warning code, reword the other XA4305 messages, and update the
documentation accordingly.

Along the way, move the messages for the new XA4309 code and the other
remaining multidex message code XA4306 into the `.resx` file so that
they are localizable.

[0]: https://github.com/xamarin/xamarin-android/commit/3757be20ba9fd1f34166f812daf9963f5d6dd22b