### PR TITLE
[xabuild] Make xaprepare actually ignore installed Mono version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,10 @@ ifeq ($(XA_FORCE_COMPONENT_REFRESH),true)
 _PREPARE_ARGS += -refresh
 endif
 
+ifneq ($(PREPARE_IGNORE_MONO_VERSION),0)
+_PREPARE_ARGS += --ignore-mono-version
+endif
+
 _PREPARE_ARGS += $(PREPARE_ARGS)
 
 include build-tools/scripts/msbuild.mk

--- a/build-tools/xaprepare/xaprepare/Main.cs
+++ b/build-tools/xaprepare/xaprepare/Main.cs
@@ -103,8 +103,14 @@ namespace Xamarin.Android.Prepare
 				"",
 				{"auto-provision=", $"Automatically install software required by Xamarin.Android", v => parsedOptions.AutoProvision = ParseBoolean (v)},
 				{"auto-provision-uses-sudo=", $"Allow use of sudo(1) when provisioning", v => parsedOptions.AutoProvisionUsesSudo = ParseBoolean (v)},
-				{"ignore-max-mono-version=", $"Ignore the maximum supported Mono version restriction", v => parsedOptions.IgnoreMaxMonoVersion = ParseBoolean (v)},
-				{"ignore-min-mono-version=", $"Ignore the minimum supported Mono version restriction", v => parsedOptions.IgnoreMinMonoVersion = ParseBoolean (v)},
+				{"ignore-max-mono-version:", $"Ignore the maximum supported Mono version restriction", v => parsedOptions.IgnoreMaxMonoVersion = ParseBoolean (v)},
+				{"ignore-min-mono-version:", $"Ignore the minimum supported Mono version restriction", v => parsedOptions.IgnoreMinMonoVersion = ParseBoolean (v)},
+				{"ignore-mono-version:", $"Ignore the both the minimum and the maximum supported Mono version restrictions", v => {
+						bool yesno = ParseBoolean (v);
+						parsedOptions.IgnoreMinMonoVersion = yesno;
+						parsedOptions.IgnoreMaxMonoVersion = yesno;
+					}
+				},
 				{"mono-archive-url=", "Use a specific URL for the mono archive.", v => parsedOptions.MonoArchiveCustomUrl = v?.Trim () },
 				"",
 				{"h|help", "Show this help message", v => parsedOptions.ShowHelp = true },
@@ -288,11 +294,11 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		static bool ParseBoolean (string value)
+		static bool ParseBoolean (string value, bool defaultValue = true)
 		{
 			string v = value?.Trim ();
 			if (String.IsNullOrEmpty (v))
-				throw new ArgumentException ("must not be null or empty", nameof (v));
+				return defaultValue;
 
 			if (String.Compare ("yes", v, StringComparison.OrdinalIgnoreCase) == 0 || String.Compare ("true", v, StringComparison.OrdinalIgnoreCase) == 0)
 				return true;


### PR DESCRIPTION
`xaprepare` has two flags to ignore maximum and minimum mono versions:

     --ignore-max-mono-version
     --ignore-min-mono-version

which, up until now, required that you pass a boolean value to them as a
parameter which is both unnecessary and annoying. This commit makes the
value optional and flag's presence on command line without the specified
value makes it default to `true`.

Also added is a flag, `--ignore-mono-version` which sets **both** of the
above flags to, again, optional boolean value passed to this argument.

The `PREPARE_IGNORE_MONO_VERSION` variable in top-level Makefile hasn't
been actually used in the build. Make it pass `--ignore-mono-version` to
`xaprepare` if set to a value other than `0`.