### PR TITLE
[build] Unbreak native code builds with older compilers

### DIFF
--- a/src/monodroid/jni/application_dso_stub.cc
+++ b/src/monodroid/jni/application_dso_stub.cc
@@ -13,16 +13,17 @@ const TypeMapModule map_modules[] = {};
 const TypeMapJava map_java[] = {};
 
 ApplicationConfig application_config = {
-	.uses_mono_llvm = false,
-	.uses_mono_aot = false,
-	.uses_assembly_preload = false,
-	.is_a_bundled_app = false,
-	.broken_exception_transitions = false,
-	.bound_exception_type = 0, // System
-	.package_naming_policy = 0,
-	.environment_variable_count = 0,
-	.system_property_count = 0,
-	.android_package_name = "com.xamarin.test",
+	/*.uses_mono_llvm =*/ false,
+	/*.uses_mono_aot =*/ false,
+	/*.uses_assembly_preload =*/ false,
+	/*.is_a_bundled_app =*/ false,
+	/*.broken_exception_transitions =*/ false,
+	/*.instant_run_enabled =*/ false,
+	/*.bound_exception_type =*/ 0, // System
+	/*.package_naming_policy =*/ 0,
+	/*.environment_variable_count =*/ 0,
+	/*.system_property_count =*/ 0,
+	/*.android_package_name =*/ "com.xamarin.test",
 };
 
 const char* mono_aot_mode_name = "";


### PR DESCRIPTION
Older compilers don't support C++ designated initializers for
non-trivial types:

    ../../../jni/application_dso_stub.cc:26:1: sorry, unimplemented: non-trivial designated initializers not supported

Don't use them.