### PR TITLE
[Xamarin.Android.Build.Tasks] mono-symbolicate warnings are messages

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/MonoSymbolicate.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MonoSymbolicate.cs
@@ -1,0 +1,50 @@
+using System.IO;
+using System.Text.RegularExpressions;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tasks
+{
+	public class MonoSymbolicate : AndroidToolTask
+	{
+		public override string TaskPrefix => "MSYM";
+
+		protected override string ToolName => OS.IsWindows ? "mono-symbolicate.exe" : "mono-symbolicate";
+
+		[Required]
+		public string InputDirectory { get; set; }
+
+		[Required]
+		public string OutputDirectory { get; set; }
+
+		protected override string GenerateFullPathToTool ()
+		{
+			return Path.Combine (ToolPath, ToolExe);
+		}
+
+		protected override string GenerateCommandLineCommands ()
+		{
+			var cmd = new CommandLineBuilder ();
+			cmd.AppendSwitch ("store-symbols");
+			cmd.AppendFileNameIfNotNull (OutputDirectory);
+			cmd.AppendFileNameIfNotNull (InputDirectory);
+			return cmd.ToString ();
+		}
+
+		/// <summary>
+		/// mono-symbolicate tends to print:
+		/// Warning: Directory obj\Release\android\assets contains Xamarin.Android.Arch.Core.Common.dll but no debug symbols file was found.
+		/// </summary>
+		static readonly Regex symbolsWarning = new Regex ("no debug symbols file was found", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+		protected override void LogEventsFromTextOutput (string singleLine, MessageImportance messageImportance)
+		{
+			if (symbolsWarning.IsMatch (singleLine)) {
+				Log.LogMessage (messageImportance, singleLine);
+			} else {
+				base.LogEventsFromTextOutput (singleLine, messageImportance);
+			}
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -131,7 +131,9 @@ namespace Xamarin.Android.Build.Tests
 			}
 			proj.SetProperty ("XamarinAndroidSupportSkipVerifyVersions", "True"); // Disables API 29 warning in Xamarin.Build.Download
 			proj.SetProperty ("AndroidPackageFormat", packageFormat);
-			proj.IsRelease = isRelease;
+			if (proj.IsRelease = isRelease) {
+				proj.SetProperty ("MonoSymbolArchive", "True");
+			}
 			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				if (multidex) {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -90,6 +90,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.MakeBundleNativeCodeExternal" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ManifestMerger" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.MergeResources" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.MonoSymbolicate" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.RemoveDirFixed" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.RemoveRegisterAttribute" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ResolveAssemblies" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -2871,9 +2872,11 @@ because xbuild doesn't support framework reference assemblies.
   <Copy Condition=" '$(AndroidPackageFormat)' == 'aab' " SourceFiles="$(_AppBundleIntermediate)" DestinationFolder="$(OutDir)" />
 
   <MakeDir Directories="$(_MSYMDirectory)" Condition=" '$(MonoSymbolArchive)' == 'True' " />
-  <Exec
-    Command="&quot;$(MonoAndroidBinDirectory)mono-symbolicate&quot; store-symbols &quot;$(_MSYMDirectory)&quot; &quot;$(IntermediateOutputPath)android/assets&quot;"
-    Condition=" '$(MonoSymbolArchive)' == 'True' "
+  <MonoSymbolicate
+      Condition=" '$(MonoSymbolArchive)' == 'True' "
+      ToolPath="$(MonoAndroidBinDirectory)"
+      InputDirectory="$(IntermediateOutputPath)android\assets"
+      OutputDirectory="$(_MSYMDirectory)"
   />
 
   <ItemGroup>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/2654

If you build a Xamarin.Forms template in `Release` with
`MonoSymbolArchive=True`, you get many warnings such as:

    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Arch.Core.Common.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Arch.Core.Runtime.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Arch.Lifecycle.Common.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Arch.Lifecycle.LiveData.Core.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Arch.Lifecycle.LiveData.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Arch.Lifecycle.Runtime.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Arch.Lifecycle.ViewModel.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.Animated.Vector.Drawable.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.Annotations.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.AsyncLayoutInflater.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.Collections.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.Compat.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.CoordinaterLayout.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.Core.UI.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.Core.Utils.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.CursorAdapter.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.CustomTabs.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.CustomView.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.Design.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.DocumentFile.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.DrawerLayout.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.Fragment.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.Interpolator.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.Loader.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.LocalBroadcastManager.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.Media.Compat.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.Print.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.SlidingPaneLayout.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.SwipeRefreshLayout.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.Transition.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.v7.AppCompat.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.v7.CardView.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.v7.MediaRouter.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.v7.Palette.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.v7.RecyclerView.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.Vector.Drawable.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.VersionedParcelable.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Android.Support.ViewPager.dll but no debug symbols file was found.
    Warning: Directory obj\Release\android\assets contains Xamarin.Forms.Platform.dll but no debug symbols file was found.

These warnings surface as MSBuild warnings with no error code. These
are coming from NuGet packages and there is not a way for developers
to "fix" the warning. It is not actionable.

I took the time to clean up how we invoke `mono-symbolicate`:

    <Exec
        Command="&quot;$(MonoAndroidBinDirectory)mono-symbolicate&quot; store-symbols &quot;$(_MSYMDirectory)&quot; &quot;$(IntermediateOutputPath)android/assets&quot;"
        Condition=" '$(MonoSymbolArchive)' == 'True' "
    />

I made a `<MonoSymbolicate />` MSBuild task that uses a `Regex` to
downgrade the specific MSBuild warning to a message.

I updated a test to call `mono-symbolicate` to verify we don't get
warnings going forward.