### PR TITLE
[linker] remove unneeded string.Format calls

### DIFF
--- a/Documentation/release-notes/4260.md
+++ b/Documentation/release-notes/4260.md
@@ -1,0 +1,24 @@
+### Linker Behavior Change
+
+Xamarin.Android has to consolidate changes to the Android APIs and how
+they affect C# types. If you consider an example such as:
+
+* API 28 has an `IFoo` interface in `Mono.Android.dll` for `v9.0`.
+* C# code implements `IFoo` in class `Bar`.
+* API 29 adds another method to `IFoo` in `Mono.Android.dll` for
+  `v10.0`.
+* Apps built targeting API 30 / `v10.0` will fix up `Bar` to implement
+  the new method, but throw `Java.Lang.AbstractMethodError` if it was
+  called.
+
+If the linker didn't make this change, you would instead hit a crash
+when trying to create an instance of type `Bar` such as:
+
+    System.TypeLoadException: VTable setup of type 'Bar' failed.
+
+Xamarin.Android has some performance improvements to the linker in
+this area. Existing apps *should* not be affected.
+
+Submit a [bug report][bug] if you find an issue in this area.
+
+[bug]: https://github.com/xamarin/xamarin-android/wiki/Submitting-Bugs,-Feature-Requests,-and-Pull-Requests

--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/FixAbstractMethodsStep.cs
@@ -158,7 +158,7 @@ namespace MonoDroid.Tuner
 			if (IsInOverrides (iMethod, tMethod))
 				return true;
 
-			if (iMethod.Name != tMethod.Name && (iMethod.DeclaringType == null || (iMethod.DeclaringType.DeclaringType == null ? (string.Format ("{0}.{1}", iface.FullName, iMethod.Name) != tMethod.Name) : (string.Format ("{0}.{1}.{2}", iMethod.DeclaringType.DeclaringType, iface.Name, iMethod.Name) != tMethod.Name))))
+			if (iMethod.Name != tMethod.Name)
 				return false;
 
 			if (!CompareTypes (iMethod.MethodReturnType.ReturnType, tMethod.MethodReturnType.ReturnType))


### PR DESCRIPTION
I was using the Mono profiler for our build, and I noticed:

    Allocation summary
        Bytes      Count  Average Type name
    180765632    2142803       84 System.String
     53218472 bytes from:
            MonoDroid.Tuner.FixAbstractMethodsStep:FixAbstractMethods (Mono.Cecil.AssemblyDefinition)
            MonoDroid.Tuner.FixAbstractMethodsStep:FixAbstractMethodsUnconditional (Mono.Cecil.AssemblyDefinition)
            MonoDroid.Tuner.FixAbstractMethodsStep:FixAbstractMethods (Mono.Cecil.TypeDefinition)
            MonoDroid.Tuner.FixAbstractMethodsStep:HaveSameSignature (Mono.Cecil.TypeReference,Mono.Cecil.MethodDefinition,Mono.Cecil.MethodDefinition)
            (wrapper managed-to-native) string:FastAllocateString (int)

~53MB of string from this one method is a lot!

I found that one of these `string.Format` calls are running for almost
every method on every interface in every assembly:

    (string.Format ("{0}.{1}", iface.FullName, iMethod.Name) != tMethod.Name) :
    (string.Format ("{0}.{1}.{2}", iMethod.DeclaringType.DeclaringType, iface.Name, iMethod.Name) != tMethod.Name))

Even the simplest non-matching cases would call `string.Format`:

    iMethod.Name == "Foo"
    tMethod.Name == "Bar"

In all of these cases...

* Class implements interface implicitly
* Class implements interface explicitly
* Class implements abstract class

We found that the `IsInOverrides` check should work or merely compare
`iMethod.Name` and `tMethod.Name`. We don't seem to need the
`string.Format` calls at all?

## Results ##

An initial build of the Xamarin.Forms integration project on
Windows/.NET framework:

    Before:
    796 ms  LinkAssembliesNoShrink                     1 calls
    After:
    767 ms  LinkAssembliesNoShrink                     1 calls

The same project on macOS/Mono (slightly slower machine, too):

    Before:
    1341 ms  LinkAssembliesNoShrink                     1 calls
    After:
    1025 ms  LinkAssembliesNoShrink                     1 calls

String allocations are way better, too:

    Before:
    Allocation summary
        Bytes      Count  Average Type name
    180765632    2142803       84 System.String
    After:
    Allocation summary
        Bytes      Count  Average Type name
    127736832    1652070       77 System.String

Shows 53,028,800 bytes saved.

    Before:
    53218472 bytes from:
        MonoDroid.Tuner.FixAbstractMethodsStep:FixAbstractMethods (Mono.Cecil.AssemblyDefinition)
        MonoDroid.Tuner.FixAbstractMethodsStep:FixAbstractMethodsUnconditional (Mono.Cecil.AssemblyDefinition)
        MonoDroid.Tuner.FixAbstractMethodsStep:FixAbstractMethods (Mono.Cecil.TypeDefinition)
        MonoDroid.Tuner.FixAbstractMethodsStep:HaveSameSignature (Mono.Cecil.TypeReference,Mono.Cecil.MethodDefinition,Mono.Cecil.MethodDefinition)
    After:
     1933624 bytes from:
        MonoDroid.Tuner.FixAbstractMethodsStep:FixAbstractMethodsUnconditional (Mono.Cecil.AssemblyDefinition)
        MonoDroid.Tuner.FixAbstractMethodsStep:FixAbstractMethods (Mono.Cecil.TypeDefinition)
        MonoDroid.Tuner.FixAbstractMethodsStep:HaveSameSignature (Mono.Cecil.TypeReference,Mono.Cecil.MethodDefinition,Mono.Cecil.MethodDefinition)
        MonoDroid.Tuner.FixAbstractMethodsStep:HaveSameMethodName (Mono.Cecil.TypeReference,Mono.Cecil.MethodDefinition,Mono.Cecil.MethodDefinition)

Shows 51,284,848 bytes saved.

I don't know about the discrepancy between these two sets of numbers.
But I think this is roughly ~50MB less string allocations.