### PR TITLE
[Xamarin.Android.Build.Tasks] don't use designtime/Resource.designer.cs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props.in
@@ -13,7 +13,6 @@
 		<AndroidResourceGeneratorTargetName>UpdateGeneratedFiles</AndroidResourceGeneratorTargetName>
 		<AndroidUseAapt2 Condition=" '$(AndroidUseAapt2)' == '' ">True</AndroidUseAapt2>
 		<AndroidPackageNamingPolicy Condition=" '$(AndroidPackageNamingPolicy)' == '' ">LowercaseCrc64</AndroidPackageNamingPolicy>
-		<AndroidUseManagedDesignTimeResourceGenerator Condition=" '$(AndroidUseManagedDesignTimeResourceGenerator)' == '' And '$(OS)' != 'Windows_NT' ">False</AndroidUseManagedDesignTimeResourceGenerator>
 		<AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">29.0.2</AndroidSdkBuildToolsVersion>
 		<AndroidSdkPlatformToolsVersion Condition="'$(AndroidSdkPlatformToolsVersion)' == ''">29.0.5</AndroidSdkPlatformToolsVersion>
 		<AndroidSdkToolsVersion Condition="'$(AndroidSdkToolsVersion)' == ''">26.1.1</AndroidSdkToolsVersion>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1173,7 +1173,6 @@ because xbuild doesn't support framework reference assemblies.
 	<AndroidUseManagedDesignTimeResourceGenerator Condition=" '$(AndroidUseManagedDesignTimeResourceGenerator)' == '' " >True</AndroidUseManagedDesignTimeResourceGenerator>
 	<_AndroidLibraryImportsDesignTimeCache>$(_AndroidIntermediateDesignTimeBuildDirectory)libraryimports.cache</_AndroidLibraryImportsDesignTimeCache>
 	<_AndroidLibraryProjectImportsDesignTimeCache>$(_AndroidIntermediateDesignTimeBuildDirectory)libraryprojectimports.cache</_AndroidLibraryProjectImportsDesignTimeCache>
-	<_AndroidManagedResourceDesignerFile>$(_AndroidIntermediateDesignTimeBuildDirectory)$(_AndroidResourceDesigner)</_AndroidManagedResourceDesignerFile>
 </PropertyGroup>
 
 <Target Name="_CreatePropertiesCache" DependsOnTargets="_SetupDesignTimeBuildForBuild;_SetLatestTargetFrameworkVersion;_ResolveMonoAndroidSdks">
@@ -1250,13 +1249,12 @@ because xbuild doesn't support framework reference assemblies.
 <!-- Managed DesignTime Resource Generation -->
 <Target Name="_ManagedUpdateAndroidResgen" Condition=" '$(ManagedDesignTimeBuild)' == 'True' "
 		Inputs="$(_ManagedUpdateAndroidResgenInputs)"
-		Outputs="$(_AndroidManagedResourceDesignerFile)"
+		Outputs="$(_AndroidStampDirectory)_ManagedUpdateAndroidResgen.stamp"
 		DependsOnTargets="_CreatePropertiesCache;_ExtractLibraryProjectImports;_ValidateAndroidPackageProperties;_BeforeManagedUpdateAndroidResgen">
-	<MakeDir Directories="$(_AndroidIntermediateDesignTimeBuildDirectory)" />
 	<!-- Parse primary R.java and create Resources.Designer.cs -->
 	<GenerateResourceDesigner
 		ContinueOnError="$(DesignTimeBuild)"
-		NetResgenOutputFile="$(_AndroidManagedResourceDesignerFile)"
+		NetResgenOutputFile="$(_AndroidResourceDesignerFile)"
 		JavaResgenInputFile="$(_GeneratedPrimaryJavaResgenFile)"
 		Namespace="$(AndroidResgenNamespace)"
 		ProjectDir="$(ProjectDir)"
@@ -1271,12 +1269,7 @@ because xbuild doesn't support framework reference assemblies.
 		ResourceFlagFile="$(_AndroidResFlagFile)"
 		Condition="Exists ('$(MonoAndroidResourcePrefix)')"
 	/>
-	<ItemGroup>
-		<CorrectCasedItem Include="%(Compile.Identity)" Condition="'%(Compile.Identity)' == '$(AndroidResgenFile)'"/>
-		<CorrectCasedItem Include="%(Compile.Identity)" Condition="'%(Compile.Identity)' == 'Resources\Resource.designer.cs'"/>
-		<Compile Remove="@(CorrectCasedItem)" Condition=" '$(ManagedDesignTimeBuild)' == 'True' And '%(CorrectCasedItem.Identity)' != '' "/>
-		<Compile Include="$(_AndroidManagedResourceDesignerFile)" Condition=" '$(ManagedDesignTimeBuild)' == 'True' And Exists ('$(_AndroidManagedResourceDesignerFile)')" />
-	</ItemGroup>
+	<Touch Files="$(_AndroidStampDirectory)_ManagedUpdateAndroidResgen.stamp" AlwaysCreate="True" />
 </Target>
 	
 <!-- Resource Build -->


### PR DESCRIPTION
With .NET 5 coming, we need to ensure that Xamarin.Android can work in
the new project system in VS Windows.

You can test this with long-form (our current) projects by:

1. Add a `Directory.Build.props` file in the root of the project with
   the following content:
```xml
    <Project>
      <PropertyGroup>
        <Configurations>Debug;Release</Configurations>
        <Platforms>AnyCPU</Platforms>
      </PropertyGroup>
    </Project>
```
2. Changes the .sln entry for the Xamarin project to use the following
   GUID: `{9A19103F-16F7-4668-BE54-9A1E7A4F7556}` (instead of
   `{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`)

After doing this, things will be buggy, but testable. I created a new
Xamarin.Android app project and removed all NuGet packages.
`<PackageReference/>` in particular causes issues.

The first problem I found was that the new project system saw two
`Resource.designer.cs` files.

Initial design-time builds were OK, but as soon as I did a full build
that generated `Resources\Resource.designer.cs` there were always two
in the project.

Note that I was still using a long-form project here no `**\*.cs`
wildcards were involved, it just seemed the `<Compile Remove="..."/>`
wasn't working.

I think we can make this work going forward by:

* DTBs will no longer generate
  `obj\Debug\designtime\Resource.designer.cs`, but will generate the
  main `Resources\Resource.designer.cs`.

* Builds will *have* to overwrite anything the DTB generates. I added
  a test checking this.

* A side-benefit, VS for Mac can now use the managed resource parser!