### PR TITLE
[installers] Remove Mono.Posix.NETStandard and add missing symbols

### DIFF
--- a/build-tools/create-vsix/create-vsix.csproj
+++ b/build-tools/create-vsix/create-vsix.csproj
@@ -15,7 +15,7 @@
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeCopyLocalReferencesInVSIXContainer>False</IncludeCopyLocalReferencesInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>False</IncludeDebugSymbolsInLocalVSIXDeployment>
-    <IncludeDebugSymbolsInVSIXContainer>False</IncludeDebugSymbolsInVSIXContainer>
+    <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
     <IsExperimental Condition=" '$(IsExperimental)' == '' ">true</IsExperimental>
     <IsProductComponent Condition=" '$(IsProductComponent)' == '' ">True</IsProductComponent>
     <ZipPackageCompressionLevel Condition=" '$(ZipPackageCompressionLevel)' == '' ">Normal</ZipPackageCompressionLevel>

--- a/build-tools/create-vsix/symbols/ExternalWhiteList.csv
+++ b/build-tools/create-vsix/symbols/ExternalWhiteList.csv
@@ -9,4 +9,3 @@
 xamarin.android.sdk*\xamarin.android.sdk*.vsixdir\*msbuild\xamarin\android\FSharp.Core.dll
 xamarin.android.sdk*\xamarin.android.sdk*.vsixdir\*msbuild\xamarin\android\INIFileParser.dll
 xamarin.android.sdk*\xamarin.android.sdk*.vsixdir\*msbuild\xamarin\android\Irony.dll
-xamarin.android.sdk*\xamarin.android.sdk*.vsixdir\*msbuild\xamarin\android\libZipSharp.dll

--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -156,7 +156,7 @@
     <_MSBuildFiles Include="@(AndroidSupportedTargetJitAbi->'$(MSBuildSrcDir)\lib\%(Identity)\libxamarin-debug-app-helper.so')" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\libZipSharp.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\libZipSharp.dll.config" />
-    <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Posix.NETStandard.dll" />
+    <_MSBuildFiles Include="$(MSBuildSrcDir)\libZipSharp.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Profiler.Log.dll" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Mono.Profiler.Log.pdb" />
     <_MSBuildFiles Include="$(MSBuildSrcDir)\Newtonsoft.Json.dll" />

--- a/build-tools/scripts/MSBuildReferences.projitems
+++ b/build-tools/scripts/MSBuildReferences.projitems
@@ -34,9 +34,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" GeneratePathProperty="true" />
     <PackageReference Include="Xamarin.Build.AsyncTask" Version="0.3.4" GeneratePathProperty="true" />
-    <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" />
+    <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
     <!-- Copy system Microsoft.Build*.dll and dependencies for tests to run against. We can remove this

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -337,12 +337,12 @@
     </ItemGroup>
   </Target>
 
-    <!-- Copy extra package ref content for our installers. '$(Pkg*)' props are set during NuGet restore when GeneratePathProperty="true" -->
+  <!-- Copy package ref symbols for our installers. '$(Pkg*)' props are set during NuGet restore when GeneratePathProperty="true" -->
   <Target Name="_CopyExtraPackageContent"
-      Inputs="$(PkgMono_Posix_NETStandard)\runtimes\osx\lib\netstandard2.0\Mono.Posix.NETStandard.dll;$(PkgXamarin_Build_AsyncTask)\lib\netstandard2.0\Xamarin.Build.AsyncTask.pdb"
-      Outputs="$(OutputPath)\Mono.Posix.NETStandard.dll;$(OutputPath)\Xamarin.Build.AsyncTask.pdb" >
+      Inputs="$(PkgXamarin_LibZipSharp)\lib\$(TargetFrameworkNETStandard)\libZipSharp.pdb;$(PkgXamarin_Build_AsyncTask)\lib\$(TargetFrameworkNETStandard)\Xamarin.Build.AsyncTask.pdb"
+      Outputs="$(OutputPath)\libZipSharp.pdb;$(OutputPath)\Xamarin.Build.AsyncTask.pdb" >
     <Copy
-        SourceFiles="$(PkgMono_Posix_NETStandard)\runtimes\osx\lib\netstandard2.0\Mono.Posix.NETStandard.dll;$(PkgXamarin_Build_AsyncTask)\lib\netstandard2.0\Xamarin.Build.AsyncTask.pdb"
+        SourceFiles="$(PkgXamarin_LibZipSharp)\lib\$(TargetFrameworkNETStandard)\libZipSharp.pdb;$(PkgXamarin_Build_AsyncTask)\lib\$(TargetFrameworkNETStandard)\Xamarin.Build.AsyncTask.pdb"
         DestinationFolder="$(OutputPath)"
     />
   </Target>

--- a/src/Xamarin.Android.Tools.JavadocImporter/Xamarin.Android.Tools.JavadocImporter.csproj
+++ b/src/Xamarin.Android.Tools.JavadocImporter/Xamarin.Android.Tools.JavadocImporter.csproj
@@ -43,7 +43,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Xml.SgmlReader" Version="1.8.14" />
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3468220&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=da4239c9-cabf-50a7-e7ce-52be5c6d9883

A recent PR updating the Xamarin.Android version in Visual Studio
reported a new failure in SymbolCheck. The two files which were reported
to be missing symbols are:

    $msbuild\xamarin\android\mono.posix.netstandard.dll
    xamarin.android.sdk.dll

Some thorough sleuthing by @jonpryor indicated that we likely don't need
to be redistributing `Mono.Posix.NETStandard.dll` in our installers at
all. Various unecessary package references have been removed, and the
set of files required by our installers has been updated to reflect this
discovery. This removal should also appease the Symbol Check process.

We aren't sure why Symbol Check is now deciding to complain about
`Xamarin.Android.Sdk.dll`, but a small fix to include the corresponding
.pdb in the .vsix should be harmless.

Finally, the `Xamarin.LibZipSharp` NuGet was updated to contain symbol
files, so we can include the correct .pdb file for this assembly and
stop whitelisting it.