### PR TITLE
[Xamarin.Android.Build.Tasks] use Java.Interop's TypeDefinitionCache

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs
@@ -163,7 +163,8 @@ namespace Xamarin.Android.Tasks
 			}
 
 			// Step 1 - Find all the JLO types
-			var scanner = new JavaTypeScanner (this.CreateTaskLogger ()) {
+			var cache = new TypeDefinitionCache ();
+			var scanner = new JavaTypeScanner (this.CreateTaskLogger (), cache) {
 				ErrorOnCustomJavaObject     = ErrorOnCustomJavaObject,
 			};
 
@@ -175,7 +176,7 @@ namespace Xamarin.Android.Tasks
 
 			var javaTypes = new List<TypeDefinition> ();
 			foreach (TypeDefinition td in allJavaTypes) {
-				if (!userAssemblies.ContainsKey (td.Module.Assembly.Name.Name) || JavaTypeScanner.ShouldSkipJavaCallableWrapperGeneration (td)) {
+				if (!userAssemblies.ContainsKey (td.Module.Assembly.Name.Name) || JavaTypeScanner.ShouldSkipJavaCallableWrapperGeneration (td, cache)) {
 					continue;
 				}
 
@@ -183,7 +184,7 @@ namespace Xamarin.Android.Tasks
 			}
 
 			// Step 3 - Generate Java stub code
-			var success = CreateJavaSources (javaTypes);
+			var success = CreateJavaSources (javaTypes, cache);
 			if (!success)
 				return;
 
@@ -199,7 +200,7 @@ namespace Xamarin.Android.Tasks
 					string managedKey = type.FullName.Replace ('/', '.');
 					string javaKey = JavaNativeTypeManager.ToJniName (type).Replace ('/', '.');
 
-					acw_map.Write (type.GetPartialAssemblyQualifiedName ());
+					acw_map.Write (type.GetPartialAssemblyQualifiedName (cache));
 					acw_map.Write (';');
 					acw_map.Write (javaKey);
 					acw_map.WriteLine ();
@@ -208,14 +209,14 @@ namespace Xamarin.Android.Tasks
 					bool hasConflict = false;
 					if (managed.TryGetValue (managedKey, out conflict)) {
 						if (!managedConflicts.TryGetValue (managedKey, out var list))
-							managedConflicts.Add (managedKey, list = new List<string> { conflict.GetPartialAssemblyName () });
-						list.Add (type.GetPartialAssemblyName ());
+							managedConflicts.Add (managedKey, list = new List<string> { conflict.GetPartialAssemblyName (cache) });
+						list.Add (type.GetPartialAssemblyName (cache));
 						hasConflict = true;
 					}
 					if (java.TryGetValue (javaKey, out conflict)) {
 						if (!javaConflicts.TryGetValue (javaKey, out var list))
-							javaConflicts.Add (javaKey, list = new List<string> { conflict.GetAssemblyQualifiedName () });
-						list.Add (type.GetAssemblyQualifiedName ());
+							javaConflicts.Add (javaKey, list = new List<string> { conflict.GetAssemblyQualifiedName (cache) });
+						list.Add (type.GetAssemblyQualifiedName (cache));
 						success = false;
 						hasConflict = true;
 					}
@@ -228,7 +229,7 @@ namespace Xamarin.Android.Tasks
 						acw_map.Write (javaKey);
 						acw_map.WriteLine ();
 
-						acw_map.Write (JavaNativeTypeManager.ToCompatJniName (type).Replace ('/', '.'));
+						acw_map.Write (JavaNativeTypeManager.ToCompatJniName (type, cache).Replace ('/', '.'));
 						acw_map.Write (';');
 						acw_map.Write (javaKey);
 						acw_map.WriteLine ();
@@ -265,7 +266,7 @@ namespace Xamarin.Android.Tasks
 			manifest.NeedsInternet = NeedsInternet;
 			manifest.InstantRunEnabled = InstantRunEnabled;
 
-			var additionalProviders = manifest.Merge (Log, allJavaTypes, ApplicationJavaClass, EmbedAssemblies, BundledWearApplicationName, MergedManifestDocuments);
+			var additionalProviders = manifest.Merge (Log, cache, allJavaTypes, ApplicationJavaClass, EmbedAssemblies, BundledWearApplicationName, MergedManifestDocuments);
 
 			// Only write the new manifest if it actually changed
 			if (manifest.SaveIfChanged (Log, MergedAndroidManifestOutput)) {
@@ -286,10 +287,10 @@ namespace Xamarin.Android.Tasks
 			StringWriter regCallsWriter = new StringWriter ();
 			regCallsWriter.WriteLine ("\t\t// Application and Instrumentation ACWs must be registered first.");
 			foreach (var type in javaTypes) {
-				if (JavaNativeTypeManager.IsApplication (type) || JavaNativeTypeManager.IsInstrumentation (type)) {
+				if (JavaNativeTypeManager.IsApplication (type, cache) || JavaNativeTypeManager.IsInstrumentation (type, cache)) {
 					string javaKey = JavaNativeTypeManager.ToJniName (type).Replace ('/', '.');				
 					regCallsWriter.WriteLine ("\t\tmono.android.Runtime.register (\"{0}\", {1}.class, {1}.__md_methods);",
-						type.GetAssemblyQualifiedName (), javaKey);
+						type.GetAssemblyQualifiedName (cache), javaKey);
 				}
 			}
 			regCallsWriter.Close ();
@@ -300,7 +301,7 @@ namespace Xamarin.Android.Tasks
 				template => template.Replace ("// REGISTER_APPLICATION_AND_INSTRUMENTATION_CLASSES_HERE", regCallsWriter.ToString ()));
 		}
 
-		bool CreateJavaSources (IEnumerable<TypeDefinition> javaTypes)
+		bool CreateJavaSources (IEnumerable<TypeDefinition> javaTypes, TypeDefinitionCache cache)
 		{
 			string outputPath = Path.Combine (OutputDirectory, "src");
 			string monoInit = GetMonoInitSource (AndroidSdkPlatform, UseSharedRuntime);
@@ -311,7 +312,7 @@ namespace Xamarin.Android.Tasks
 			foreach (var t in javaTypes) {
 				using (var writer = MemoryStreamPool.Shared.CreateStreamWriter ()) {
 					try {
-						var jti = new JavaCallableWrapperGenerator (t, Log.LogWarning) {
+						var jti = new JavaCallableWrapperGenerator (t, Log.LogWarning, cache) {
 							GenerateOnCreateOverrides = generateOnCreateOverrides,
 							ApplicationJavaClass = ApplicationJavaClass,
 							MonoRuntimeInitialization = monoInit,


### PR DESCRIPTION
I was profiling builds with the Mono profiler and noticed:

    Method call summary
    Total(ms) Self(ms)      Calls Method name
        70862       97      89713 Java.Interop.Tools.Cecil.DirectoryAssemblyResolver:Resolve (Mono.Cecil.AssemblyNameReference,Mono.Cecil.ReaderParameters)

Almost 90K calls? What is that coming from???

    61422 calls from:
        Java.Interop.Tools.Cecil.TypeDefinitionRocks/<GetTypeAndBaseTypes>d__1:MoveNext ()
        Java.Interop.Tools.Cecil.TypeDefinitionRocks:GetBaseType (Mono.Cecil.TypeDefinition)
        Mono.Cecil.TypeReference:Resolve ()
        Mono.Cecil.ModuleDefinition:Resolve (Mono.Cecil.TypeReference)
        Mono.Cecil.MetadataResolver:Resolve (Mono.Cecil.TypeReference)
        Java.Interop.Tools.Cecil.DirectoryAssemblyResolver:Resolve (Mono.Cecil.AssemblyNameReference)

Ok, this jogged my memory. @StephaneDelcroix had mentioned one of the
big wins for XamlC in Xamarin.Forms was to cache any time
`TypeReference.Resolve()` was called:

https://github.com/xamarin/Xamarin.Forms/blob/1b9c22b4b9b1c1354a3a5c35ad445a2738c6f6c3/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs#L437-L443

XamlC was able to use `static` here, because it's using a feature of
MSBuild to run in a separate `AppDomain`:

https://github.com/xamarin/Xamarin.Forms/blob/1b9c22b4b9b1c1354a3a5c35ad445a2738c6f6c3/Xamarin.Forms.Build.Tasks/XamlTask.cs#L20-L21

However, I think we can simply add a new non-static
`TypeDefinitionCache` class that would allow callers to control the
caching strategy. Callers will need to control the scope of the
`TypeDefinitionCache` so it matches any `DirectoryAssemblyResolver`
being used. Right now most Xamarin.Android builds will open assemblies
with Mono.Cecil twice: once for `<GenerateJavaStubs/>` and once for
the linker.

So for example, we can add caching in an API-compatible way:

    [Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
    public static TypeDefinition GetBaseType (this TypeDefinition type) =>
        GetBaseType (type, cache: null);

    public static TypeDefinition GetBaseType (this TypeDefinition type, TypeDefinitionCache cache)
    {
        if (bt == null)
            return null;
        if (cache != null)
            return cache.Resolve (bt);
        return bt.Resolve ();
    }

We just need to ensure `cache: null` is valid. I took this approach
for any `public` APIs and made any `private` or `internal` APIs
*require* a `TypeDefinitionCache`.

I fixed every instance where `[Obsolete]` would cause a warning here
in Java.Interop. We'll probably see a small improvement in `generator`
and `jnimarshalmethod-gen`.

Here in xamarin-android, I fixed all the `[Obsolete]` warnings
that were called in `<GenerateJavaStubs/>`. I can make more changes
for the linker in a future PR.

## Results ##

The reduced calls to `DirectoryAssemblyResolver.Resolve`:

    Method call summary
    Total(ms) Self(ms)      Calls Method name
    Before;
        70862       97      89713 Java.Interop.Tools.Cecil.DirectoryAssemblyResolver:Resolve (Mono.Cecil.AssemblyNameReference,Mono.Cecil.ReaderParameters)
    After:
        68830       35      26315 Java.Interop.Tools.Cecil.DirectoryAssemblyResolver:Resolve (Mono.Cecil.AssemblyNameReference,Mono.Cecil.ReaderParameters)

~63,398 less calls.

In a build of the Xamarin.Forms integration project on macOS / Mono:

    Before:
    1365 ms  GenerateJavaStubs                          1 calls
    After:
     862 ms  GenerateJavaStubs                          1 calls

It is almost a 40% improvement, around ~500ms better.