### PR TITLE
[Xamarin.Android.Build.Tests] Add SmokeTests category

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -209,10 +209,7 @@ stages:
   jobs:
   - job: win_build_test
     displayName: Build and Smoke Test
-    pool:
-      name: $(VSEngWinVS2019)
-      demands:
-      - agent.name -equals vs2019xam000007-1
+    pool: $(VSEngWinVS2019)
     timeoutInMinutes: 360
     cancelTimeoutInMinutes: 5
     steps:
@@ -234,7 +231,8 @@ stages:
     - powershell: |
         $vsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
         & "$vsWhere" -all -prerelease -latest | Out-Default
-        if (& "$vsWhere" -all -prerelease -latest -property isLaunchable -eq 0) {
+        $isLatestVSLaunchable = & "$vsWhere" -all -prerelease -latest -property isLaunchable
+        if ($isLatestVSLaunchable -eq 0) {
             $vsPath = & "$vsWhere" -all -prerelease -latest -property installationPath
             Write-Host "Attempting to repair VS instance:" $vsPath
             $vsInstaller = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe"
@@ -322,13 +320,15 @@ stages:
         testAssembly: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\EmbeddedDSOUnitTests.dll
         testResultsFile: TestResult-EmbeddedDSOUnitTests-WinBuildTree-$(XA.Build.Configuration).xml
 
+    # Limit the amount of worker threads used to run these tests in parallel to half of what is currently available (8) on the Windows pool.
+    # Using all available cores seems to occasionally bog down our machines and cause parallel test execution to slow down dramatically.
     # Only run a subset of the Xamarin.Android.Build.Tests against the local Windows build tree.
     - template: yaml-templates\run-nunit-tests.yaml
       parameters:
         testRunTitle: Smoke MSBuild Tests - Windows Build Tree
         testAssembly: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\Xamarin.Android.Build.Tests.dll
         testResultsFile: TestResult-SmokeMSBuildTests-WinBuildTree-$(XA.Build.Configuration).xml
-        nunitConsoleExtraArgs: --where "cat == SmokeTests"
+        nunitConsoleExtraArgs: --where "cat == SmokeTests" --workers=4
 
     - template: yaml-templates\upload-results.yaml
       parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -208,8 +208,11 @@ stages:
   dependsOn: []
   jobs:
   - job: win_build_test
-    displayName: Build and Test
-    pool: $(VSEngWinVS2019)
+    displayName: Build and Smoke Test
+    pool:
+      name: $(VSEngWinVS2019)
+      demands:
+      - agent.name -equals vs2019xam000007-1
     timeoutInMinutes: 360
     cancelTimeoutInMinutes: 5
     steps:
@@ -226,8 +229,18 @@ stages:
         version: $(DotNetCoreVersion)
 
     # Downgrade the XA .vsix installed into the instance of VS that we are building with so that we don't restore/build against a test version.
+    # The VS installer will attempt to resume any failed or partial installation before trying to downgrade Xamarin.Android.
     # VSIXInstaller.exe will exit non-zero when the downgrade attempt is a no-op, so we will allow this step to fail silently.
     - powershell: |
+        $vsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        & "$vsWhere" -all -prerelease -latest | Out-Default
+        if (& "$vsWhere" -all -prerelease -latest -property isLaunchable -eq 0) {
+            $vsPath = & "$vsWhere" -all -prerelease -latest -property installationPath
+            Write-Host "Attempting to repair VS instance:" $vsPath
+            $vsInstaller = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe"
+            & "$vsInstaller" resume --installPath $vsPath --quiet --norestart | Out-Default
+            Write-Host "vs_installer.exe resume attempt complete"
+        }
         $vsixInstaller = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\resources\app\ServiceHub\Services\Microsoft.VisualStudio.Setup.Service\VSIXInstaller.exe"
         $ts = Get-Date -Format FileDateTimeUniversal
         $log = "xavsixdowngrade-$ts.log"
@@ -235,8 +248,8 @@ stages:
         Get-Content "${env:TEMP}\$log" | Write-Host
         Write-Host "VSInstaller.exe exited with code:" $process.ExitCode
         Remove-Item "${env:TEMP}\$log"
-        Exit 0
       displayName: downgrade XA to stable
+      ignoreLASTEXITCODE: true
 
     - task: MSBuild@1
       displayName: msbuild Xamarin.Android /t:Prepare
@@ -309,14 +322,13 @@ stages:
         testAssembly: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\EmbeddedDSOUnitTests.dll
         testResultsFile: TestResult-EmbeddedDSOUnitTests-WinBuildTree-$(XA.Build.Configuration).xml
 
-    # Limit the amount of worker threads used to run these tests in parallel to half of what is currently available (8) on the Windows pool.
-    # Using all available cores seems to occasionally bog down our machines and cause parallel test execution to slow down dramatically.
+    # Only run a subset of the Xamarin.Android.Build.Tests against the local Windows build tree.
     - template: yaml-templates\run-nunit-tests.yaml
       parameters:
-        testRunTitle: Xamarin.Android.Build.Tests - Windows Build Tree
+        testRunTitle: Smoke MSBuild Tests - Windows Build Tree
         testAssembly: $(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\Xamarin.Android.Build.Tests.dll
-        testResultsFile: TestResult-MSBuildTests-WinBuildTree-$(XA.Build.Configuration).xml
-        nunitConsoleExtraArgs: --workers=4
+        testResultsFile: TestResult-SmokeMSBuildTests-WinBuildTree-$(XA.Build.Configuration).xml
+        nunitConsoleExtraArgs: --where "cat == SmokeTests"
 
     - template: yaml-templates\upload-results.yaml
       parameters:

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -84,6 +84,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void DesignTimeBuild ([Values(false, true)] bool isRelease, [Values (false, true)] bool useManagedParser, [Values (false, true)] bool useAapt2)
 		{
 			var regEx = new Regex (@"(?<type>([a-zA-Z_0-9])+)\slibrary_name=(?<value>([0-9A-Za-z])+);", RegexOptions.Compiled | RegexOptions.Multiline ); 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -20,6 +20,7 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[TestCaseSource (nameof (ClassParseOptions))]
+		[Category ("SmokeTests")]
 		public void BuildBasicBindingLibrary (string classParser)
 		{
 			var targets = new List<string> {
@@ -133,6 +134,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		[TestCaseSource (nameof (ClassParseOptions))]
 		[NonParallelizable]
+		[Category ("SmokeTests")]
 		public void BuildLibraryZipBindigLibraryWithAarOfJar (string classParser)
 		{
 			var proj = new XamarinAndroidBindingProject () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -41,6 +41,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void BuildBasicApplicationReleaseProfiledAot ()
 		{
 			var proj = new XamarinAndroidApplicationProject () {
@@ -895,6 +896,7 @@ namespace UnamedProject
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void BuildMkBundleApplicationRelease ()
 		{
 			var proj = new XamarinAndroidApplicationProject () { IsRelease = true, BundleAssemblies = true };
@@ -1070,6 +1072,7 @@ namespace UnamedProject
 
 		[Test]
 		[NonParallelizable] // On MacOS, parallel /restore causes issues
+		[Category ("SmokeTests")]
 		public void BuildProguardEnabledProject ([Values (true, false)] bool isRelease, [Values ("dx", "d8")] string dexTool, [Values ("", "proguard", "r8")] string linkTool)
 		{
 			var proj = new XamarinFormsAndroidApplicationProject {
@@ -1332,6 +1335,7 @@ namespace UnnamedProject {
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void BasicApplicationRepetitiveReleaseBuild ()
 		{
 			var proj = new XamarinAndroidApplicationProject () { IsRelease = true };
@@ -2045,6 +2049,7 @@ namespace App1
 
 		[Test]
 		[NonParallelizable]
+		[Category ("SmokeTests")]
 		public void BuildWithNativeLibraries ([Values (true, false)] bool isRelease)
 		{
 			var dll = new XamarinAndroidLibraryProject () {
@@ -2165,6 +2170,7 @@ Mono.Unix.UnixFileInfo fileInfo = null;");
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void BuildWithExternalJavaLibrary ()
 		{
 			var path = Path.Combine ("temp", "BuildWithExternalJavaLibrary");
@@ -2782,6 +2788,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void BuildBasicApplicationCheckPdb ()
 		{
 			var proj = new XamarinAndroidApplicationProject {
@@ -3291,6 +3298,7 @@ AAMMAAABzYW1wbGUvSGVsbG8uY2xhc3NQSwUGAAAAAAMAAwC9AAAA1gEAAAAA") });
 
 		[Test]
 		[NonParallelizable]
+		[Category ("SmokeTests")]
 		public void BuildAMassiveApp()
 		{
 			var testPath = Path.Combine("temp", "BuildAMassiveApp");
@@ -3472,6 +3480,7 @@ namespace UnnamedProject {
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void Desugar ([Values (true, false)] bool isRelease, [Values ("dx", "d8")] string dexTool, [Values ("", "proguard", "r8")] string linkTool)
 		{
 			var proj = new XamarinAndroidApplicationProject () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -953,7 +953,7 @@ namespace UnamedProject
 
 		[Test]
 		[TestCaseSource (nameof (AotChecks))]
-		[Category ("Minor")]
+		[Category ("SmokeTests")]
 		public void BuildAotApplicationAndÜmläüts (string supportedAbis, bool enableLLVM, bool expectedResult)
 		{
 			var path = Path.Combine ("temp", string.Format ("BuildAotApplication AndÜmläüts_{0}_{1}_{2}", supportedAbis, enableLLVM, expectedResult));
@@ -2537,6 +2537,7 @@ public class Test
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void BuildApplicationWithSpacesInPath ([Values (true, false)] bool enableMultiDex, [Values ("dx", "d8")] string dexTool, [Values ("", "proguard", "r8")] string linkTool)
 		{
 			var proj = new XamarinAndroidApplicationProject () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -327,6 +327,7 @@ class MemTest {
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void BuildXamarinFormsMapsApplication ()
 		{
 			var proj = new XamarinFormsMapsApplicationProject ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DeferredBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DeferredBuildTest.cs
@@ -8,6 +8,7 @@ namespace Xamarin.Android.Build.Tests
 	public class DeferredBuildTest : BaseTest
 	{
 		[Test]
+		[Category ("SmokeTests")]
 		public void SelectivelyRunUpdateAndroidResources ()
 		{
 			var path = Path.Combine ("temp", TestName);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DesignerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DesignerTests.cs
@@ -132,6 +132,7 @@ namespace UnnamedProject
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void IncrementalDesignTimeBuild ()
 		{
 			var proj = new XamarinFormsAndroidApplicationProject ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/EnvironmentContentTests.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Android.Build.Tests
 	public class EnvironmentContentTests : BaseTest
 	{
 		[Test]
+		[Category ("SmokeTests")]
 		public void BuildApplicationWithMonoEnvironment ([Values ("", "Normal", "Offline")] string sequencePointsMode)
 		{
 			const string supportedAbis = "armeabi-v7a;x86";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -459,6 +459,7 @@ namespace Lib2
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void ProduceReferenceAssembly ()
 		{
 			var path = Path.Combine ("temp", TestName);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -343,6 +343,7 @@ namespace Lib2
 
 		//https://github.com/xamarin/xamarin-android/issues/2247
 		[Test]
+		[Category ("SmokeTests")]
 		public void AppProjectTargetsDoNotBreak ()
 		{
 			var targets = new List<string> {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -657,6 +657,7 @@ public class TestActivity2 : FragmentActivity {
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void AllActivityAttributeProperties ([Values ("legacy", "manifestmerger.jar")] string manifestMerger)
 		{
 			string expectedOutput = manifestMerger == "legacy" ?

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -268,6 +268,7 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void CheckSignApk ([Values(true, false)] bool useApkSigner, [Values(true, false)] bool perAbiApk)
 		{
 			string ext = Environment.OSVersion.Platform != PlatformID.Unix ? ".bat" : "";
@@ -354,6 +355,7 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void CheckAppBundle ([Values (true, false)] bool isRelease)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
@@ -380,6 +382,7 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void NetStandardReferenceTest ()
 		{
 			var netStandardProject = new DotNetStandard () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
@@ -30,6 +30,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void Aapt2Link ()
 		{
 			var path = Path.Combine (Root, "temp", "Aapt2Link");
@@ -84,6 +85,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void Aapt2Compile ()
 		{
 			var path = Path.Combine (Root, "temp", "Aapt2Compile");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/Aapt2Tests.cs
@@ -30,7 +30,6 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[Category ("SmokeTests")]
 		public void Aapt2Link ()
 		{
 			var path = Path.Combine (Root, "temp", "Aapt2Link");
@@ -85,7 +84,6 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[Category ("SmokeTests")]
 		public void Aapt2Compile ()
 		{
 			var path = Path.Combine (Root, "temp", "Aapt2Compile");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/ManagedResourceParserTests.cs
@@ -460,6 +460,7 @@ int xml myxml 0x7f140000
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void CompareAapt2AndManagedParserOutput ()
 		{
 			var path = Path.Combine ("temp", TestName);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/WearTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/WearTests.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void BundledWearApp ()
 		{
 			var target = "_UpdateAndroidResgen";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -20,6 +20,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[Category ("SmokeTests")]
 		public void DotNetPackageXASdkProject ([Values (false, true)] bool isRelease)
 		{
 			var proj = new XASdkProject ("0.0.1") {


### PR DESCRIPTION
Introduces a new `SmokeTests` category to `Xamarin.Android.Build.Tests`
as part of a broader effort to help split up our test execution and
improve turnaround times for our Azure Pipelines builds. My selection
of tests to add to this category was somewhat arbitrary, but it includes
a handful of build, rebuild, and incremental build scenarios, as well as
multiple project configurations (including AOT and Bundle Assemblies),
and native/java build actions.

We've also been seeing a somewhat rare case where the VS instance on our
Windows machines becomes unlaunchable and the `MSBuild` task falls back
to a very old version, breaking the build. I've attempted to fix this by
updating our script that reverts the version of XA installed with VS to
first try to resume a partial visual studio installation on disk.