### PR TITLE
[linker] Remove more non-nullable related attributes

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/RemoveAttributes.cs
+++ b/src/Xamarin.Android.Build.Tasks/Linker/MonoDroid.Tuner/RemoveAttributes.cs
@@ -51,6 +51,12 @@ namespace MonoDroid.Tuner {
 			case "NullableContextAttribute":
 			case "NullableAttribute":
 				return attr_type.Namespace == "System.Runtime.CompilerServices";
+			case "AllowNullAttribute":
+			case "MaybeNullAttribute":
+			case "NotNullAttribute":
+			case "NotNullWhenAttribute":
+			case "NotNullIfNotNullAttribute":
+				return attr_type.Namespace == "System.Diagnostics.CodeAnalysis";
 			default:
 				return false;
 			}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/4231

The size increase comes from added attributes and attribute types. The related
`apkdiff` output:

    +        3584 assemblies/Java.Interop.dll
      ...
      +             Type Microsoft.CodeAnalysis.EmbeddedAttribute
      +             Type System.Runtime.CompilerServices.NullableAttribute
      +             Type System.Diagnostics.CodeAnalysis.AllowNullAttribute
      +             Type System.Diagnostics.CodeAnalysis.MaybeNullAttribute
      +             Type System.Diagnostics.CodeAnalysis.NotNullAttribute
      +             Type System.Diagnostics.CodeAnalysis.NotNullWhenAttribute
      +             Type System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute
      ...

Comparison of #4279 and master build (d543a8ac5ed65bcb1cc5d1d65cca1ba3344a62ed):
```
mono apkdiff.exe Xamarin.Forms_Performance_Integration-Signed-d543a8ac5ed65bcb1cc5d1d65cca1ba3344a62ed.apk Xamarin.Forms_Performance_Integration-Signed-4279.apk 
Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
  -        1024 assemblies/Java.Interop.dll
    -             Type System.Diagnostics.CodeAnalysis.AllowNullAttribute
    -             Type System.Diagnostics.CodeAnalysis.MaybeNullAttribute
    -             Type System.Diagnostics.CodeAnalysis.NotNullAttribute
    -             Type System.Diagnostics.CodeAnalysis.NotNullWhenAttribute
    -             Type System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute
Summary:
  +           0 Package size difference
```
Which shows we removed all the newly added attributes to the list. The saving is not much, every 1kB counts though :-) In this particular case it was hidden by zip alignment as the total difference is 0 bytes.