### PR TITLE
[build] Consolidate Mono dependency information

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -80,10 +80,11 @@
     <AndroidSupportedTargetJitAbis Condition=" '$(AndroidSupportedTargetJitAbis)' == '' ">armeabi-v7a:arm64-v8a:x86:x86_64</AndroidSupportedTargetJitAbis>
     <JavaInteropSourceDirectory Condition=" '$(JavaInteropSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\Java.Interop</JavaInteropSourceDirectory>
     <MonoSourceDirectory>$(MSBuildThisFileDirectory)external\mono</MonoSourceDirectory>
-    <MonoRequiredMinimumVersion Condition=" '$(MonoRequiredMinimumVersion)' == '' ">6.10.0</MonoRequiredMinimumVersion>
-    <MonoRequiredMaximumVersion Condition=" '$(MonoRequiredMaximumVersion)' == '' ">6.11.0</MonoRequiredMaximumVersion>
+    <MonoDarwinPackageUrl>https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2019-12/51/fe455fcb344f19200271b6426c3108f20cc0880e/MonoFramework-MDK-6.10.0.50.macos10.xamarin.universal.pkg</MonoDarwinPackageUrl>
+    <MonoRequiredMinimumVersion Condition=" '$(MonoRequiredMinimumVersion)' == '' ">6.10.0.50</MonoRequiredMinimumVersion>
+    <MonoRequiredMaximumVersion Condition=" '$(MonoRequiredMaximumVersion)' == '' ">6.10.99</MonoRequiredMaximumVersion>
+    <IgnoreMaxMonoVersion Condition=" '$(IgnoreMaxMonoVersion)' == '' And '$(RunningOnCI)' == 'true' ">False</IgnoreMaxMonoVersion>
     <IgnoreMaxMonoVersion Condition=" '$(IgnoreMaxMonoVersion)' == '' ">True</IgnoreMaxMonoVersion>
-    <MonoRequiredDarwinMinimumVersion>$(MonoRequiredMinimumVersion).54</MonoRequiredDarwinMinimumVersion>
     <LinkerSourceDirectory>$(MSBuildThisFileDirectory)external\mono\sdks\out\android-sources\external\linker\src</LinkerSourceDirectory>
     <OpenTKSourceDirectory>$(MSBuildThisFileDirectory)external\opentk</OpenTKSourceDirectory>
     <MingwZlibRootDirectory Condition=" '$(ZlibRootDirectory)' == '' And '$(HostOS)' == 'Linux' ">\usr</MingwZlibRootDirectory>

--- a/Documentation/building/configuration.md
+++ b/Documentation/building/configuration.md
@@ -114,7 +114,7 @@ Overridable MSBuild properties include:
   * `$(IgnoreMaxMonoVersion)`: Skip the enforcement of the `$(MonoRequiredMaximumVersion)`
     property. This is so that developers can run against the latest
     and greatest. But the build system can enforce the min and max 
-    versions. The default is `true`, however on Jenkins we use:
+    versions. The default is `true`, however on CI we use:
 
          /p:IgnoreMaxMonoVersion=False
 

--- a/Documentation/workflow/HowToBumpMono.md
+++ b/Documentation/workflow/HowToBumpMono.md
@@ -5,7 +5,6 @@ Android uses a binary artifcats package from mono that is tied to a specific ver
 The folloing checklist covers what you need to do.  Note, if you know the system mono version does not need changed, you can skip the first step.
 
   - [ ] [Update system mono used for the build](#update-system-mono).
-  - [ ] [Update MonoRequiredDarwinMinimumVersion used in the build](#update-configuration-props).
   - [ ] [Update external mono commit in .external](#update-mono-external-commit).
   - [ ] [Ensure it *builds*](#build).
   - [ ] [Ensure unit tests *pass*](#unit-tests).
@@ -17,9 +16,12 @@ The folloing checklist covers what you need to do.  Note, if you know the system
 
 ### Update system mono
 
-The `$(MonoRequiredMinimumVersion)` and `$(MonoRequiredMaximumVersion)` values
-within [`Configuration.props`](../../Configuration.props)
-should be updated to correspond to the version number used in the mono submodule.
+The `$(MonoDarwinPackageUrl)` property within [`Configuration.props`](../../Configuration.props)
+should be updated to point to the absolute URL of the package.
+
+The `$(MonoRequiredMinimumVersion)` and `$(MonoRequiredMaximumVersion)` properties
+should be updated to correspond to the version number used in the mono submodule, and
+the maximum version that should be used to build against.
 
 These version numbers can be found in
 [mono's `configure.ac`](https://github.com/mono/mono/blob/master/configure.ac)

--- a/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
+++ b/build-tools/xaprepare/xaprepare/Application/KnownProperties.cs
@@ -30,7 +30,9 @@ namespace Xamarin.Android.Prepare
 		public const string MingwZlibLibraryName                = "MingwZlibLibraryName";
 		public const string MingwZlibRootDirectory32            = "MingwZlibRootDirectory32";
 		public const string MingwZlibRootDirectory64            = "MingwZlibRootDirectory64";
+		public const string MonoDarwinPackageUrl                = "MonoDarwinPackageUrl";
 		public const string MonoRequiredMinimumVersion          = "MonoRequiredMinimumVersion";
+		public const string MonoRequiredMaximumVersion          = "MonoRequiredMaximumVersion";
 		public const string MonoSourceFullPath                  = "MonoSourceFullPath";
 		public const string ProductVersion                      = "ProductVersion";
 		public const string RemapAssemblyRefToolExecutable      = "RemapAssemblyRefToolExecutable";

--- a/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
+++ b/build-tools/xaprepare/xaprepare/Application/Properties.Defaults.cs.in
@@ -34,7 +34,9 @@ namespace Xamarin.Android.Prepare
 			properties.Add (KnownProperties.MingwZlibLibraryName,                StripQuotes ("@MingwZlibLibraryName@"));
 			properties.Add (KnownProperties.MingwZlibRootDirectory32,            StripQuotes (@"@MingwZlibRootDirectory32@"));
 			properties.Add (KnownProperties.MingwZlibRootDirectory64,            StripQuotes (@"@MingwZlibRootDirectory64@"));
+			properties.Add (KnownProperties.MonoDarwinPackageUrl,                StripQuotes ("@MonoDarwinPackageUrl@"));
 			properties.Add (KnownProperties.MonoRequiredMinimumVersion,          StripQuotes ("@MonoRequiredMinimumVersion@"));
+			properties.Add (KnownProperties.MonoRequiredMaximumVersion,          StripQuotes ("@MonoRequiredMaximumVersion@"));
 			properties.Add (KnownProperties.MonoSourceFullPath,                  StripQuotes (@"@MonoSourceFullPath@"));
 			properties.Add (KnownProperties.ProductVersion,                      StripQuotes ("@ProductVersion@"));
 			properties.Add (KnownProperties.RemapAssemblyRefToolExecutable,      StripQuotes (@"@RemapAssemblyRefToolExecutable@"));

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.MacOS.cs
@@ -7,7 +7,6 @@ namespace Xamarin.Android.Prepare
 		partial class Urls
 		{
 			public static readonly Uri Corretto = new Uri ($"{Corretto_BaseUri}{CorrettoUrlPathVersion}/amazon-corretto-{CorrettoDistVersion}-macosx-x64.tar.gz");
-			public static readonly Uri MonoPackage = new Uri ("https://xamjenkinsartifact.azureedge.net/build-package-osx-mono/2019-12/51/fe455fcb344f19200271b6426c3108f20cc0880e/MonoFramework-MDK-6.10.0.50.macos10.xamarin.universal.pkg");
 		}
 
 		partial class Defaults

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/MacOS.cs
@@ -26,10 +26,9 @@ namespace Xamarin.Android.Prepare
 			new HomebrewProgram ("p7zip", "7za"),
 			new HomebrewProgram ("xamarin/xamarin-android-windeps/mingw-zlib", "xamarin/xamarin-android-windeps", null),
 
-			// If you change the minimum Mono version here, please change the URL as well
-			new MonoPkgProgram ("Mono", "com.xamarin.mono-MDK.pkg", Configurables.Urls.MonoPackage) {
-				MinimumVersion = "6.10.0.50",
-				MaximumVersion = "6.99.0.0",
+			new MonoPkgProgram ("Mono", "com.xamarin.mono-MDK.pkg", new Uri (Context.Instance.Properties.GetRequiredValue (KnownProperties.MonoDarwinPackageUrl))) {
+				MinimumVersion = Context.Instance.Properties.GetRequiredValue (KnownProperties.MonoRequiredMinimumVersion),
+				MaximumVersion = Context.Instance.Properties.GetRequiredValue (KnownProperties.MonoRequiredMaximumVersion),
 			},
 		};
 

--- a/build-tools/xaprepare/xaprepare/Steps/Step_PrepareImageDependencies.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_PrepareImageDependencies.MacOS.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Android.Prepare
 					brewPackages.Add (homebrewProgram.Name);
 			}
 
-			pkgUrls.Add (Configurables.Urls.MonoPackage.ToString ());
+			pkgUrls.Add (Context.Instance.Properties.GetRequiredValue (KnownProperties.MonoDarwinPackageUrl));
 		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/xaprepare.targets
+++ b/build-tools/xaprepare/xaprepare/xaprepare.targets
@@ -66,7 +66,9 @@
       <Replacement Include="@MingwZlibLibraryName@=$(MingwZlibLibraryName)" />
       <Replacement Include="@MingwZlibRootDirectory32@=$(MingwZlibRootDirectory32)" />
       <Replacement Include="@MingwZlibRootDirectory64@=$(MingwZlibRootDirectory64)" />
+      <Replacement Include="@MonoDarwinPackageUrl@=$(MonoDarwinPackageUrl)" />
       <Replacement Include="@MonoRequiredMinimumVersion@=$(MonoRequiredMinimumVersion)" />
+      <Replacement Include="@MonoRequiredMaximumVersion@=$(MonoRequiredMaximumVersion)" />
       <Replacement Include="@MonoSourceFullPath@=$(MonoSourceFullPath)" />
       <Replacement Include="@ProductVersion@=$(ProductVersion)" />
       <Replacement Include="@RemapAssemblyRefToolExecutable@=$(RemapAssemblyRefToolExecutable)" />


### PR DESCRIPTION
We have a bit of a disconnect with respect to our dependency on Mono
across different tools. `xaprepare` has some Mono version information
embedded in it, and we duplicate some of this information in
`Configuration.props`. Furthermore, we don't do an adequate job of
enforcing a version ceiling in our Azure Pipelines builds.

For additional context, see https://github.com/xamarin/xamarin-android/pull/4219
for all of the places that require updating when we bump the version of
Mono that we depend on.

In order to improve this story, `xaprepare` has been updated to gather
all Mono dependency information from `Configuration.props`, and no
longer specifies any version information of its own. We will also now
roll back the installation of Mono on CI builds if the installed version
exceeds the max version specified in this file. The following properties
in `Configuration.props` should be updated when bumping the version of
Mono that we build against:

    `<MonoDarwinPackageUrl>` - The package to install if the version of Mono on disk is not within the expected range (as defined below).
    `<MonoRequiredMinimumVersion>` - The lowest version of Mono that we will build against.
    `<MonoRequiredMaximumVersion>` - The highest version of Mono that we will build against.