### PR TITLE
[Xamarin.Android.Build.Tasks] Make XA5205 and some of XA5300 localizable

### DIFF
--- a/Documentation/guides/messages/xa5205.md
+++ b/Documentation/guides/messages/xa5205.md
@@ -1,26 +1,22 @@
 ---
 title: Xamarin.Android error XA5205
 description: XA5205 error code
-ms.date: 05/03/2018
+ms.date: 02/14/2020
 ---
 # Xamarin.Android error XA5205
 
 ## Example messages
 
 ```
-XA5205: The Android SDK Directory could not be found. Please set via `/p:AndroidSdkDirectory`.
+error XA5205: Cannot find `aapt.exe`. Please install the Android SDK Build-Tools package with the `C:\Program Files (x86)\Android\android-sdk\tools\android.bat` program.
 ```
 
 ```
-XA5205: Cannot find `aapt`. Please install the Android SDK Build-tools package with the $(AndroidSdkDirectory)\tools\aapt program.
+error XA5205: Cannot find `zipalign.exe`. Please install the Android SDK Build-Tools package with the `C:\Program Files (x86)\Android\android-sdk\tools\android.bat` program.
 ```
 
 ```
-XA5205: Cannot find `zipalign`. Please install the Android SDK Build-tools package with the `$(AndroidSdkDirectory)\tools\zipalign` program.
-```
-
-```
-XA5205: Cannot find `lint` in the Android SDK. Please set its path via `/p:LintToolPath`.
+error XA5205: Cannot find `lint.bat` in the Android SDK. Please set its path via `/p:LintToolPath`.
 ```
 
 ## Issue

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -457,6 +457,51 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program..
+        /// </summary>
+        internal static string XA5205 {
+            get {
+                return ResourceManager.GetString("XA5205", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath..
+        /// </summary>
+        internal static string XA5205_Lint {
+            get {
+                return ResourceManager.GetString("XA5205_Lint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No Android platforms installed at &apos;{0}&apos;. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program..
+        /// </summary>
+        internal static string XA5300_Android_Platforms {
+            get {
+                return ResourceManager.GetString("XA5300_Android_Platforms", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory..
+        /// </summary>
+        internal static string XA5300_Android_SDK {
+            get {
+                return ResourceManager.GetString("XA5300_Android_SDK", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory..
+        /// </summary>
+        internal static string XA5300_Java_SDK {
+            get {
+                return ResourceManager.GetString("XA5300_Java_SDK", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to generate Java type for class: {0} due to MAX_PATH: {1}.
         /// </summary>
         internal static string XA5301 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -321,6 +321,35 @@ In this message, the term "bundled" is a short way of saying "included into the 
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</comment>
   </data>
+  <data name="XA5205" xml:space="preserve">
+    <value>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</value>
+    <comment>The following are literal names and should not be translated: Android SDK Build-Tools, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</comment>
+  </data>
+  <data name="XA5205_Lint" xml:space="preserve">
+    <value>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</value>
+    <comment>The following are literal names and should not be translated: /p:LintToolPath
+{0} - The missing tool name</comment>
+  </data>
+  <data name="XA5300_Android_Platforms" xml:space="preserve">
+    <value>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</value>
+    <comment>The following are literal names and should not be translated: SDK Platform, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</comment>
+  </data>
+  <data name="XA5300_Android_SDK" xml:space="preserve">
+    <value>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</value>
+    <comment>The following are literal names and should not be translated: /p:AndroidSdkDirectory</comment>
+  </data>
+  <data name="XA5300_Java_SDK" xml:space="preserve">
+    <value>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</value>
+    <comment>The following are literal names and should not be translated: /p:JavaSdkDirectory</comment>
+  </data>
   <data name="XA5301" xml:space="preserve">
     <value>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</value>
     <comment>The following are literal names and should not be translated: MAX_PATH.

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -255,6 +255,40 @@ In this message, the term "bundled" is a short way of saying "included into the 
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
       </trans-unit>
+      <trans-unit id="XA5205">
+        <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5205_Lint">
+        <source>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</source>
+        <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
+        <note>The following are literal names and should not be translated: /p:LintToolPath
+{0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_Platforms">
+        <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: SDK Platform, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_SDK">
+        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
+        <target state="new">The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Java_SDK">
+        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
+        <target state="new">The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -255,6 +255,40 @@ In this message, the term "bundled" is a short way of saying "included into the 
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
       </trans-unit>
+      <trans-unit id="XA5205">
+        <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5205_Lint">
+        <source>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</source>
+        <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
+        <note>The following are literal names and should not be translated: /p:LintToolPath
+{0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_Platforms">
+        <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: SDK Platform, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_SDK">
+        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
+        <target state="new">The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Java_SDK">
+        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
+        <target state="new">The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -255,6 +255,40 @@ In this message, the term "bundled" is a short way of saying "included into the 
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
       </trans-unit>
+      <trans-unit id="XA5205">
+        <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5205_Lint">
+        <source>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</source>
+        <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
+        <note>The following are literal names and should not be translated: /p:LintToolPath
+{0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_Platforms">
+        <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: SDK Platform, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_SDK">
+        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
+        <target state="new">The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Java_SDK">
+        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
+        <target state="new">The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -255,6 +255,40 @@ In this message, the term "bundled" is a short way of saying "included into the 
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
       </trans-unit>
+      <trans-unit id="XA5205">
+        <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5205_Lint">
+        <source>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</source>
+        <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
+        <note>The following are literal names and should not be translated: /p:LintToolPath
+{0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_Platforms">
+        <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: SDK Platform, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_SDK">
+        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
+        <target state="new">The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Java_SDK">
+        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
+        <target state="new">The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -255,6 +255,40 @@ In this message, the term "bundled" is a short way of saying "included into the 
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
       </trans-unit>
+      <trans-unit id="XA5205">
+        <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5205_Lint">
+        <source>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</source>
+        <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
+        <note>The following are literal names and should not be translated: /p:LintToolPath
+{0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_Platforms">
+        <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: SDK Platform, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_SDK">
+        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
+        <target state="new">The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Java_SDK">
+        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
+        <target state="new">The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -255,6 +255,40 @@ In this message, the term "bundled" is a short way of saying "included into the 
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
       </trans-unit>
+      <trans-unit id="XA5205">
+        <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5205_Lint">
+        <source>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</source>
+        <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
+        <note>The following are literal names and should not be translated: /p:LintToolPath
+{0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_Platforms">
+        <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: SDK Platform, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_SDK">
+        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
+        <target state="new">The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Java_SDK">
+        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
+        <target state="new">The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -255,6 +255,40 @@ In this message, the term "bundled" is a short way of saying "included into the 
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
       </trans-unit>
+      <trans-unit id="XA5205">
+        <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5205_Lint">
+        <source>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</source>
+        <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
+        <note>The following are literal names and should not be translated: /p:LintToolPath
+{0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_Platforms">
+        <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: SDK Platform, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_SDK">
+        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
+        <target state="new">The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Java_SDK">
+        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
+        <target state="new">The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -255,6 +255,40 @@ In this message, the term "bundled" is a short way of saying "included into the 
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
       </trans-unit>
+      <trans-unit id="XA5205">
+        <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5205_Lint">
+        <source>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</source>
+        <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
+        <note>The following are literal names and should not be translated: /p:LintToolPath
+{0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_Platforms">
+        <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: SDK Platform, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_SDK">
+        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
+        <target state="new">The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Java_SDK">
+        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
+        <target state="new">The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -255,6 +255,40 @@ In this message, the term "bundled" is a short way of saying "included into the 
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
       </trans-unit>
+      <trans-unit id="XA5205">
+        <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5205_Lint">
+        <source>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</source>
+        <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
+        <note>The following are literal names and should not be translated: /p:LintToolPath
+{0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_Platforms">
+        <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: SDK Platform, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_SDK">
+        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
+        <target state="new">The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Java_SDK">
+        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
+        <target state="new">The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -255,6 +255,40 @@ In this message, the term "bundled" is a short way of saying "included into the 
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
       </trans-unit>
+      <trans-unit id="XA5205">
+        <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5205_Lint">
+        <source>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</source>
+        <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
+        <note>The following are literal names and should not be translated: /p:LintToolPath
+{0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_Platforms">
+        <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: SDK Platform, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_SDK">
+        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
+        <target state="new">The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Java_SDK">
+        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
+        <target state="new">The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -255,6 +255,40 @@ In this message, the term "bundled" is a short way of saying "included into the 
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
       </trans-unit>
+      <trans-unit id="XA5205">
+        <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5205_Lint">
+        <source>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</source>
+        <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
+        <note>The following are literal names and should not be translated: /p:LintToolPath
+{0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_Platforms">
+        <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: SDK Platform, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_SDK">
+        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
+        <target state="new">The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Java_SDK">
+        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
+        <target state="new">The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -255,6 +255,40 @@ In this message, the term "bundled" is a short way of saying "included into the 
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
       </trans-unit>
+      <trans-unit id="XA5205">
+        <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5205_Lint">
+        <source>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</source>
+        <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
+        <note>The following are literal names and should not be translated: /p:LintToolPath
+{0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_Platforms">
+        <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: SDK Platform, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_SDK">
+        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
+        <target state="new">The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Java_SDK">
+        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
+        <target state="new">The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -255,6 +255,40 @@ In this message, the term "bundled" is a short way of saying "included into the 
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
       </trans-unit>
+      <trans-unit id="XA5205">
+        <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: Android SDK Build-Tools, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5205_Lint">
+        <source>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</source>
+        <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
+        <note>The following are literal names and should not be translated: /p:LintToolPath
+{0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_Platforms">
+        <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>
+        <target state="new">No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</target>
+        <note>The following are literal names and should not be translated: SDK Platform, {1}{2}tools{2}{3}
+{0} - The missing tool name
+{1} - The parent directory
+{2} - The directory separator character
+{3} - The installer program name</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Android_SDK">
+        <source>The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</source>
+        <target state="new">The Android SDK directory could not be found. Please set via /p:AndroidSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:AndroidSdkDirectory</note>
+      </trans-unit>
+      <trans-unit id="XA5300_Java_SDK">
+        <source>The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</source>
+        <target state="new">The Java SDK directory could not be found. Please set via /p:JavaSdkDirectory.</target>
+        <note>The following are literal names and should not be translated: /p:JavaSdkDirectory</note>
+      </trans-unit>
       <trans-unit id="XA5301">
         <source>Failed to generate Java type for class: {0} due to MAX_PATH: {1}</source>
         <target state="new">Failed to generate Java type for class: {0} due to MAX_PATH: {1}</target>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
@@ -191,7 +191,7 @@ namespace Xamarin.Android.Tasks
 		public override bool RunTask ()
 		{
 			if (string.IsNullOrEmpty (ToolPath) || !File.Exists (GenerateFullPathToTool ())) {
-				Log.LogCodedError ("XA5205", $"Cannot find `{ToolName}` in the Android SDK. Please set its path via /p:LintToolPath.");
+				Log.LogCodedError ("XA5205", Properties.Resources.XA5205_Lint, ToolName);
 				return false;
 			}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
@@ -128,10 +128,8 @@ namespace Xamarin.Android.Tasks
 			}
 
 			if (string.IsNullOrEmpty (AndroidSdkBuildToolsPath)) {
-				Log.LogCodedError ("XA5205",
-						string.Format (
-							"Cannot find `{0}`. Please install the Android SDK Build-tools package with the `{1}{2}tools{2}{3}` program.",
-							Aapt, AndroidSdkPath, Path.DirectorySeparatorChar, Android));
+				Log.LogCodedError ("XA5205", Properties.Resources.XA5205,
+						Aapt, AndroidSdkPath, Path.DirectorySeparatorChar, Android);
 				return false;
 			}
 
@@ -170,10 +168,8 @@ namespace Xamarin.Android.Tasks
 					.FirstOrDefault ();
 			}
 			if (string.IsNullOrEmpty (ZipAlignPath)) {
-				Log.LogCodedError ("XA5205",
-						string.Format (
-							"Cannot find `{0}`. Please install the Android SDK Build-tools package with the `{1}{2}tools{2}{3}` program.",
-							ZipAlign, AndroidSdkPath, Path.DirectorySeparatorChar, Android));
+				Log.LogCodedError ("XA5205", Properties.Resources.XA5205,
+						ZipAlign, AndroidSdkPath, Path.DirectorySeparatorChar, Android);
 				return false;
 			}
 
@@ -365,8 +361,7 @@ namespace Xamarin.Android.Tasks
 				}
 			}
 			if (maxApiLevel < 0)
-				Log.LogCodedError ("XA5300",
-						"No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.",
+				Log.LogCodedError ("XA5300", Properties.Resources.XA5300_Android_Platforms,
 						platformsDir, Path.DirectorySeparatorChar, Android);
 			return maxApiLevel;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveSdksTask.cs
@@ -82,10 +82,10 @@ namespace Xamarin.Android.Tasks
 			}
 			catch (InvalidOperationException e) {
 				if (e.Message.Contains (" Android ")) {
-					Log.LogCodedError ("XA5300", "The Android SDK Directory could not be found. Please set via /p:AndroidSdkDirectory.");
+					Log.LogCodedError ("XA5300", Properties.Resources.XA5300_Android_SDK);
 				}
 				if (e.Message.Contains (" Java ")) {
-					Log.LogCodedError ("XA5300", "The Java SDK Directory could not be found. Please set via /p:JavaSdkDirectory.");
+					Log.LogCodedError ("XA5300", Properties.Resources.XA5300_Java_SDK);
 				}
 				return false;
 			}
@@ -95,11 +95,11 @@ namespace Xamarin.Android.Tasks
 			JavaSdkPath    = MonoAndroidHelper.AndroidSdk.JavaSdkPath;
 
 			if (string.IsNullOrEmpty (AndroidSdkPath)) {
-				Log.LogCodedError ("XA5300", "The Android SDK Directory could not be found. Please set via /p:AndroidSdkDirectory.");
+				Log.LogCodedError ("XA5300", Properties.Resources.XA5300_Android_SDK);
 				return false;
 			}
 			if (string.IsNullOrEmpty (JavaSdkPath)) {
-				Log.LogCodedError ("XA5300", "The Java SDK Directory could not be found. Please set via /p:JavaSdkDirectory.");
+				Log.LogCodedError ("XA5300", Properties.Resources.XA5300_Java_SDK);
 				return false;
 			}
 


### PR DESCRIPTION
Context: 0342fe5698b86e21e36c924732ff135b9a87e4af
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Move the message strings for XA5205 and several of the message strings
for XA5300 into the `.resx` file so that they are localizable.

`ResolveJdkJvmPath.cs` contains a few other uses of XA5300 that have
been left unchanged for now so that they can be considered separately.

Other changes:

Adjust the capitalization of "Build-Tools" to match the capitalization
from the Android repository manifest.

Remove the Android SDK directory message from the XA5205 documentation
because that message is currently associated with XA5300 instead.