### PR TITLE
[ci] Improve test execution conditions

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -282,6 +282,7 @@ stages:
           /t:RunJavaInteropTests
           /p:TestAssembly="bin\Test$(XA.Build.Configuration)\generator-Tests.dll;bin\Test$(XA.Build.Configuration)\Java.Interop.Tools.JavaCallableWrappers-Tests.dll;bin\Test$(XA.Build.Configuration)\logcat-parse-Tests.dll;bin\Test$(XA.Build.Configuration)\Xamarin.Android.Tools.ApiXmlAdjuster-Tests.dll;bin\Test$(XA.Build.Configuration)\Xamarin.Android.Tools.Bytecode-Tests.dll"
           /bl:$(System.DefaultWorkingDirectory)\bin\Test$(XA.Build.Configuration)\msbuild-run-ji-tests.binlog
+      continueOnError: True
 
     - task: PublishTestResults@2
       displayName: publish test results
@@ -289,7 +290,6 @@ stages:
         testResultsFormat: NUnit
         testResultsFiles: TestResult-*.xml
         testRunTitle: Java Interop Tests - Windows Build Tree
-      condition: succeededOrFailed()
 
     - template: yaml-templates\run-nunit-tests.yaml
       parameters:
@@ -451,6 +451,7 @@ stages:
           /restore
           /t:Build
           /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/build-check-boot-times.binlog
+      continueOnError: true
 
     - task: MSBuild@1
       displayName: Run check-boot-times
@@ -460,6 +461,7 @@ stages:
         msbuildArguments: >
           /t:CheckBootTimes
           /bl:$(System.DefaultWorkingDirectory)/bin/Test$(ApkTestConfiguration)/run-check-boot-times.binlog
+      continueOnError: true
 
     - template: yaml-templates/apk-instrumentation.yaml
       parameters:
@@ -662,7 +664,6 @@ stages:
         testResultsFormat: NUnit
         testResultsFiles: TestResult-Xamarin.Android.Bcl_Tests.xunit-$(XA.Build.Configuration).xml
         testRunTitle: Xamarin.Android.Bcl-Tests-NUnit
-      condition: succeededOrFailed()
 
     - task: MSBuild@1
       displayName: shut down emulator

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -322,6 +322,8 @@ stages:
       parameters:
         artifactName: Build Results - Windows
 
+    - template: yaml-templates\fail-on-issue.yaml
+
 - stage: finalize_installers
   displayName: Finalize Installers
   dependsOn: mac_build
@@ -629,6 +631,8 @@ stages:
         configuration: $(ApkTestConfiguration)
         artifactName: Test Results - APK Instrumentation - macOS
 
+    - template: yaml-templates/fail-on-issue.yaml
+
   # Check - "Xamarin.Android (Test BCL With Emulator - macOS)"
   - job: mac_bcl_tests
     displayName: BCL With Emulator - macOS
@@ -678,6 +682,8 @@ stages:
     - template: yaml-templates/upload-results.yaml
       parameters:
         artifactName: Test Results - BCL With Emulator - macOS
+
+    - template: yaml-templates/fail-on-issue.yaml
 
   # Check - "Xamarin.Android (Test MSBuild - macOS)"
   - job: mac_msbuild_tests
@@ -734,6 +740,8 @@ stages:
       parameters:
         artifactName: Test Results - MSBuild - macOS
 
+    - template: yaml-templates/fail-on-issue.yaml
+
   # Check - "Xamarin.Android (Test MSBuild - Windows)"
   - job: win_msbuild_tests
     displayName: MSBuild - Windows
@@ -780,6 +788,8 @@ stages:
     - template: yaml-templates\upload-results.yaml
       parameters:
         artifactName: Test Results - MSBuild - Windows
+
+    - template: yaml-templates\fail-on-issue.yaml
 
   # Check - "Xamarin.Android (Test MSBuild With Emulator - macOS)"
   - job: mac_msbuilddevice_tests
@@ -832,6 +842,8 @@ stages:
     - template: yaml-templates/upload-results.yaml
       parameters:
         artifactName: Test Results - MSBuild With Emulator - macOS
+
+    - template: yaml-templates/fail-on-issue.yaml
 
   # Check - "Xamarin.Android (Test Designer - macOS)"
   - job: designer_integration_mac

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -8,7 +8,7 @@ parameters:
   packageType: Apk
   artifactName: ""
   artifactFolder: ""
-  condition: succeededOrFailed()
+  condition: succeeded()
 
 steps:
 - task: MSBuild@1
@@ -21,6 +21,7 @@ steps:
       /bl:$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/run${{ parameters.testName }}.binlog
       ${{ parameters.extraBuildArgs }}
   condition: ${{ parameters.condition }}
+  continueOnError: true
 
 - script: |
     SOURCE=$(System.DefaultWorkingDirectory)/bin/Test${{ parameters.configuration }}/${{ parameters.artifactName }}
@@ -29,6 +30,7 @@ steps:
     cp "$SOURCE" "$DEST"
   displayName: copy apk/aab
   condition: ${{ parameters.condition }}
+  continueOnError: true
 
 - task: PublishTestResults@2
   displayName: publish ${{ parameters.testName }} results

--- a/build-tools/automation/yaml-templates/fail-on-issue.yaml
+++ b/build-tools/automation/yaml-templates/fail-on-issue.yaml
@@ -1,0 +1,11 @@
+parameters:
+  condition: succeeded()
+
+steps:
+- powershell: |
+    Write-Host "Current job status is: $env:AGENT_JOBSTATUS"
+    if ($env:AGENT_JOBSTATUS -eq "SucceededWithIssues") {
+        Write-Host "Marking this job as failed because one (or more) steps exited with a 'SuccessWithIssues' status."
+        exit 1
+    }
+  displayName: fail if any issues occurred

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -215,4 +215,4 @@ steps:
       testRunTitle: Test Environment Cleanup
       nunitConsoleExtraArgs: --where "cat == XATestCleanUp"
 
-- template: yaml-templates/fail-on-issue.yaml
+- template: fail-on-issue.yaml

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -214,3 +214,5 @@ steps:
       testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
       testRunTitle: Test Environment Cleanup
       nunitConsoleExtraArgs: --where "cat == XATestCleanUp"
+
+- template: yaml-templates/fail-on-issue.yaml

--- a/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-integrated-regression-tests.yaml
@@ -30,15 +30,15 @@ steps:
 
 - checkout: qa
   clean: true
-  fetchDepth: 1
+  fetchDepth: 10
 
 - checkout: samples
   clean: true
-  fetchDepth: 1
+  fetchDepth: 10
 
 - checkout: xfsamples
   clean: true
-  fetchDepth: 1
+  fetchDepth: 10
 
 - task: xamops.azdevex.provisionator-task.provisionator@2
   displayName: Provision Android Dependencies
@@ -76,7 +76,7 @@ steps:
       testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
       testRunTitle: Hello Tests on Device
       nunitConsoleExtraArgs: --where "cat == Hello"
-      condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
+      condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
 
   - template: run-nunit-tests.yaml
     parameters:
@@ -105,7 +105,7 @@ steps:
       testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
       testRunTitle: Fast Deploy Tests
       nunitConsoleExtraArgs: --where "cat == FastDevTests"
-      condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
+      condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
 
   - template: run-nunit-tests.yaml
     parameters:
@@ -113,7 +113,7 @@ steps:
       testAssembly: $(System.DefaultWorkingDirectory)/XQA.Android/XQA.Android.dll
       testRunTitle: Debug Tests
       nunitConsoleExtraArgs: --where "cat == DebuggerTests"
-      condition: and(succeededOrFailed(), eq(variables['XA.Commercial.Build'], 'true'))
+      condition: and(succeeded(), eq(variables['XA.Commercial.Build'], 'true'))
 
   - template: run-nunit-tests.yaml
     parameters:

--- a/build-tools/automation/yaml-templates/run-nunit-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-nunit-tests.yaml
@@ -5,7 +5,7 @@ parameters:
   testResultsFile: TestResult.xml
   testResultsFormat: NUnit
   nunitConsoleExtraArgs: ''
-  condition: succeededOrFailed()
+  condition: succeeded()
 
 steps:
 - powershell: |
@@ -16,6 +16,7 @@ steps:
     }
   displayName: run ${{ parameters.testRunTitle }}
   condition: ${{ parameters.condition }}
+  continueOnError: true
 
 - template: kill-processes.yaml
 

--- a/build-tools/automation/yaml-templates/run-timezoneinfo-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-timezoneinfo-tests.yaml
@@ -48,4 +48,4 @@ jobs:
       parameters:
         artifactName: Test Results - TimeZoneInfo With Emulator - macOS - ${{ parameters.node_id }}
 
-    - template: yaml-templates/fail-on-issue.yaml
+    - template: fail-on-issue.yaml

--- a/build-tools/automation/yaml-templates/run-timezoneinfo-tests.yaml
+++ b/build-tools/automation/yaml-templates/run-timezoneinfo-tests.yaml
@@ -47,3 +47,5 @@ jobs:
     - template: upload-results.yaml
       parameters:
         artifactName: Test Results - TimeZoneInfo With Emulator - macOS - ${{ parameters.node_id }}
+
+    - template: yaml-templates/fail-on-issue.yaml


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3482854&view=logs&j=8a30e15e-2b03-5f17-c7f5-98058d3d9cd8&t=47d4d312-ac98-567e-7ba2-f57378c80633

Replaces `succeededOrFailed()` conditions with `continueOnError: true`
to ensure that steps that should be treated as fatal stop execution of
a job. Previously, all test steps would run regardless of the success of
a prior step, even if that step was necessary (e.g. building a test
suite before running it). A job should continue if any step with the new
`continueOnError: true` parameter fails, and we should now abort earlier
when a step without this parameter errors out.

A new template has been added to ensure jobs which encounter issues
in tests are still flagged as failed (rather than `SucceededWithIssues`).

Finally, I've increased the shallow clone depth for our regression test
dependencies so that checkout will still succeed if more commits land on
the branch that is being tracked after the pipeline instance is created.