### PR TITLE
Bump to mono/mono/2019-10@c0c5c7

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:d16-5@dab75e88055c1bfaf53f810b0c3a9218fc53c60a
-mono/mono:2019-10@1cca0cfebfcbd019c6f2bdd3e5b99f769f1e2e0c
+mono/mono:2019-10@c0c5c78e2bdbdbf7a70ae10b0a698708f1f2edbe

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -87,7 +87,7 @@ namespace Xamarin.Android.Build.Tests
 			return assm;
 		}
 
-		private void PreserveCustomHttpClientHandler (string handlerType, string testProjectName, string assembly)
+		private void PreserveCustomHttpClientHandler (string handlerType, string testProjectName, string assemblyPath)
 		{
 			var proj = new XamarinAndroidApplicationProject () { IsRelease = true };
 			proj.AddReferences ("System.Net.Http");
@@ -96,7 +96,7 @@ namespace Xamarin.Android.Build.Tests
 			using (var b = CreateApkBuilder (testProjectName)) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 
-				using (var assembly = AssemblyDefinition.ReadAssembly (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, assembly))) {
+				using (var assembly = AssemblyDefinition.ReadAssembly (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, assemblyPath))) {
 					Assert.IsTrue (assembly.MainModule.GetType (handlerType) != null, $"'{handlerType}' should have been preserved by the linker.");
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -87,17 +87,18 @@ namespace Xamarin.Android.Build.Tests
 			return assm;
 		}
 
-		private void PreserveCustomHttpClientHandler (string handlerType, string testProjectName, string assemblyPath)
+		private void PreserveCustomHttpClientHandler (string handlerType, string handlerAssembly, string testProjectName, string assemblyPath)
 		{
 			var proj = new XamarinAndroidApplicationProject () { IsRelease = true };
 			proj.AddReferences ("System.Net.Http");
-			proj.SetProperty (proj.ActiveConfigurationProperties, "AndroidHttpClientHandlerType", handlerType);
+			string handlerTypeFullName = string.IsNullOrEmpty(handlerAssembly) ? handlerType : handlerType + ", " + handlerAssembly
+			proj.SetProperty (proj.ActiveConfigurationProperties, "AndroidHttpClientHandlerType", handlerTypeFullName);
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("base.OnCreate (bundle);", "base.OnCreate (bundle);\nvar client = new System.Net.Http.HttpClient ();");
 			using (var b = CreateApkBuilder (testProjectName)) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 
 				using (var assembly = AssemblyDefinition.ReadAssembly (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, assemblyPath))) {
-					Assert.IsTrue (assembly.MainModule.GetType (handlerType) != null, $"'{handlerType}' should have been preserved by the linker.");
+					Assert.IsTrue (assembly.MainModule.GetType (handlerType) != null, $"'{handlerTypeFullName}' should have been preserved by the linker.");
 				}
 			}
 		}
@@ -105,9 +106,9 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void PreserveCustomHttpClientHandlers ()
 		{
-			PreserveCustomHttpClientHandler ("Xamarin.Android.Net.AndroidClientHandler", 
+			PreserveCustomHttpClientHandler ("Xamarin.Android.Net.AndroidClientHandler", "",
 				"temp/PreserveAndroidHttpClientHandler", "android/assets/Mono.Android.dll");
-			PreserveCustomHttpClientHandler ("System.Net.Http.MonoWebRequestHandler, System.Net.Http", 
+			PreserveCustomHttpClientHandler ("System.Net.Http.MonoWebRequestHandler", "System.Net.Http",
 				"temp/PreserveMonoWebRequestHandler", "android/assets/System.Net.Http.dll");
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -91,7 +91,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			var proj = new XamarinAndroidApplicationProject () { IsRelease = true };
 			proj.AddReferences ("System.Net.Http");
-			string handlerTypeFullName = string.IsNullOrEmpty(handlerAssembly) ? handlerType : handlerType + ", " + handlerAssembly
+			string handlerTypeFullName = string.IsNullOrEmpty(handlerAssembly) ? handlerType : handlerType + ", " + handlerAssembly;
 			proj.SetProperty (proj.ActiveConfigurationProperties, "AndroidHttpClientHandlerType", handlerTypeFullName);
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("base.OnCreate (bundle);", "base.OnCreate (bundle);\nvar client = new System.Net.Http.HttpClient ();");
 			using (var b = CreateApkBuilder (testProjectName)) {

--- a/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/nunit-excluded-tests.txt
+++ b/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/nunit-excluded-tests.txt
@@ -35,3 +35,6 @@ MonoTests.System.Web.Services.Description.ServiceDescriptionTest.ReadAndRetrieva
 MonoTests.System.Web.Services.Description.ServiceDescriptionTest.ReadInvalid
 MonoTests.System.Web.Services.Description.ServiceDescriptionTest.SimpleWrite
 MonoTests.System.Web.Services.Description.ServiceDescriptionTest.ValidatingRead
+
+# the test is incorrect and will be removed soon: https://github.com/mono/mono/pull/18952
+System.Net.Http.Tests.HttpClientHandlerTestsAndroid.TestEnvVarSwitchForInnerHttpHandler


### PR DESCRIPTION
Changes: https://github.com/mono/mono/compare/1cca0cfebfcbd019c6f2bdd3e5b99f769f1e2e0c...c0c5c78e2bdbdbf7a70ae10b0a698708f1f2edbe

For mainly these two:
https://github.com/mono/mono/pull/18764
https://github.com/mono/mono/pull/18832

To let users to set custom httphandler to legacy `MonoWebRequestHandler`
```xml
<PropertyGroup>
  <AndroidHttpClientHandlerType>System.Net.Http.MonoWebRequestHandler, System.Net.Http</AndroidHttpClientHandlerType>
</PropertyGroup>
```
For NTLM scenarios (see https://github.com/mono/mono/pull/18764 for more details)