### PR TITLE
Enable nullable reference types in xaprepare

### DIFF
--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -11,6 +11,27 @@ steps:
   parameters:
     provisionExtraArgs: ${{ parameters.provisionExtraArgs }}
 
+- task: UseDotNet@2
+  displayName: install .NET Core $(DotNetCorePreviewVersion)
+  inputs:
+    version: $(DotNetCorePreviewVersion)
+
+- task: UseDotNet@2
+  displayName: install .NET Core $(DotNetCoreVersion)
+  inputs:
+    version: $(DotNetCoreVersion)
+
+- script: |
+    dotnet tool install --global boots
+  displayName: install boots
+  condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
+
+- script: |
+    export PATH="$PATH:/Users/runner/.dotnet/tools"
+    boots https://download.mono-project.com/archive/6.8.0/macos-10-universal/MonoFramework-MDK-6.8.0.105.macos10.xamarin.universal.pkg
+  displayName: update Mono to version 6.x
+  condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
+
 - task: MSBuild@1
   displayName: build xaprepare
   inputs:
@@ -30,16 +51,6 @@ steps:
     $(System.DefaultWorkingDirectory)\build-tools\xaprepare\xaprepare\bin\${{ parameters.configuration }}\xaprepare.exe --s=AndroidToolchain --no-emoji --run-mode=CI
   displayName: install test dependencies
   condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
-
-- task: UseDotNet@2
-  displayName: install .NET Core $(DotNetCorePreviewVersion)
-  inputs:
-    version: $(DotNetCorePreviewVersion)
-
-- task: UseDotNet@2
-  displayName: install .NET Core $(DotNetCoreVersion)
-  inputs:
-    version: $(DotNetCoreVersion)
 
 # Restore solutions for Xamarin.Android.Tools.sln, Xamarin.Android.sln, and Xamarin.Android-Tests.sln
 - task: NuGetToolInstaller@0

--- a/build-tools/xaprepare/xaprepare/Application/Abi.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Abi.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Android.Prepare
 		public bool IsHost    { get; private set; }
 		public bool IsLlvm    { get; private set; }
 		public bool IsWindows { get; private set; }
-		public string Name    { get; private set; }
+		public string Name    { get; private set; } = String.Empty;
 		public AbiType Type   { get; private set; }
 
 		public static HashSet<string> GetHostAbis (OS osType = OS.Any, Bitness bitness = Bitness.Any, bool includeAllHostOSes = true)

--- a/build-tools/xaprepare/xaprepare/Application/AndroidPlatform.cs
+++ b/build-tools/xaprepare/xaprepare/Application/AndroidPlatform.cs
@@ -6,15 +6,15 @@ namespace Xamarin.Android.Prepare
 {
 	class AndroidPlatform
 	{
-		public string ApiName    { get; }
+		public string? ApiName   { get; }
 		public uint ApiLevel     { get; }
 		public string PlatformID { get; }
 		public string Framework  { get; }
 		public bool Stable       { get; }
 		public bool Supported    { get; }
-		public string Include    { get; }
+		public string? Include   { get; }
 
-		public AndroidPlatform (uint apiLevel, string platformID, string framework = null, bool stable = true, string apiName = null, string include = null)
+		public AndroidPlatform (uint apiLevel, string platformID, string? framework = null, bool stable = true, string? apiName = null, string? include = null)
 		{
 			if (String.IsNullOrEmpty (platformID))
 				throw new ArgumentException ("must not be null or empty", nameof (platformID));
@@ -31,11 +31,8 @@ namespace Xamarin.Android.Prepare
 
 	static class AndroidPlatformExtensions
 	{
-		public static void Add (this List<AndroidPlatform> list, uint apiLevel, string platformID, string framework, bool stable, string apiName = null, string include = null)
+		public static void Add (this List<AndroidPlatform> list, uint apiLevel, string platformID, string framework, bool stable, string? apiName = null, string? include = null)
 		{
-			if (list == null)
-				throw new ArgumentNullException (nameof (list));
-
 			if (list.Any (p => p.ApiLevel == apiLevel))
 				throw new InvalidOperationException ($"Duplicate Android platform, API level {apiLevel}");
 

--- a/build-tools/xaprepare/xaprepare/Application/AndroidToolchainComponent.cs
+++ b/build-tools/xaprepare/xaprepare/Application/AndroidToolchainComponent.cs
@@ -7,12 +7,12 @@ namespace Xamarin.Android.Prepare
 	{
 		public string Name                { get; }
 		public string DestDir             { get; }
-		public Uri RelativeUrl            { get; }
+		public Uri? RelativeUrl           { get; }
 		public bool IsMultiVersion        { get; }
 		public bool NoSubdirectory        { get; }
-		public string PkgRevision         { get; }
+		public string? PkgRevision        { get; }
 
-		public AndroidToolchainComponent (string name, string destDir, Uri relativeUrl = null, bool isMultiVersion = false, bool noSubdirectory = false, string pkgRevision = null)
+		public AndroidToolchainComponent (string name, string destDir, Uri? relativeUrl = null, bool isMultiVersion = false, bool noSubdirectory = false, string? pkgRevision = null)
 		{
 			if (String.IsNullOrEmpty (name))
 				throw new ArgumentException ("must not be null or empty", nameof (name));

--- a/build-tools/xaprepare/xaprepare/Application/AppObject.cs
+++ b/build-tools/xaprepare/xaprepare/Application/AppObject.cs
@@ -2,14 +2,14 @@ namespace Xamarin.Android.Prepare
 {
 	class AppObject
 	{
-		Log log;
+		Log? log;
 
 		public Log Log {
 			get => log ?? Log.Instance;
 			protected set => log = value;
 		}
 
-		protected AppObject (Log log = null)
+		protected AppObject (Log? log = null)
 		{
 			this.log = log;
 		}

--- a/build-tools/xaprepare/xaprepare/Application/BclFile.cs
+++ b/build-tools/xaprepare/xaprepare/Application/BclFile.cs
@@ -23,8 +23,8 @@ namespace Xamarin.Android.Prepare
 		public BclFileTarget Target     { get; }
 		public bool ExcludeDebugSymbols { get; }
 		public string SourcePath        { get; }
-		public string Version           { get; }
-		public string DebugSymbolsPath  {
+		public string? Version          { get; }
+		public string? DebugSymbolsPath  {
 			get {
 				if (ExcludeDebugSymbols)
 					return null;
@@ -33,9 +33,9 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		public BclFile (string name, BclFileType type, bool excludeDebugSymbols = false, string version = null, BclFileTarget target = BclFileTarget.Android)
+		public BclFile (string name, BclFileType type, bool excludeDebugSymbols = false, string? version = null, BclFileTarget target = BclFileTarget.Android)
 		{
-			name = name?.Trim ();
+			name = name.Trim ();
 			if (String.IsNullOrEmpty (name))
 				throw new ArgumentException ("must not be null or empty", nameof (name));
 

--- a/build-tools/xaprepare/xaprepare/Application/BuildInfo.cs
+++ b/build-tools/xaprepare/xaprepare/Application/BuildInfo.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 
 namespace Xamarin.Android.Prepare
@@ -13,7 +12,7 @@ namespace Xamarin.Android.Prepare
 		static readonly char[] NDKPropertySeparator = new [] { '=' };
 		static readonly char[] NDKPlatformDirectorySeparator = new [] { '-' };
 
-		public string CommitOfLastVersionChange { get; private set; }
+		public string CommitOfLastVersionChange { get; private set; } = String.Empty;
 
 		// Not available from the start, only after NDK is installed
 		public string NDKRevision            { get; private set; } = String.Empty;
@@ -100,12 +99,12 @@ namespace Xamarin.Android.Prepare
 
 			Log.StatusLine ($"  {context.Characters.Bullet} Mono commit hash", ConsoleColor.Gray);
 			List<ExternalGitDependency> externalDependencies = ExternalGitDependency.GetDependencies (context, Configurables.Paths.ExternalGitDepsFilePath, quiet: true);
-			ExternalGitDependency mono = externalDependencies?.Where (
+			ExternalGitDependency? mono = externalDependencies.Where (
 				eg => eg != null &&
 				      String.Compare ("mono", eg.Owner, StringComparison.Ordinal) == 0 &&
 				      String.Compare ("mono", eg.Name, StringComparison.Ordinal) == 0).FirstOrDefault ();
 
-			FullMonoHash = mono?.Commit?.Trim ();
+			FullMonoHash = (mono?.Commit ?? String.Empty).Trim ();
 			MonoHash = EnsureHash ("Mono", Utilities.ShortenGitHash (FullMonoHash));
 
 			string EnsureHash (string name, string hash)
@@ -123,7 +122,7 @@ namespace Xamarin.Android.Prepare
 		{
 			Log.StatusLine ($"  {context.Characters.Bullet} Commit of last version change", ConsoleColor.Gray);
 			GitRunner git = CreateGitRunner (context);
-			IList <GitRunner.BlamePorcelainEntry> blameEntries;
+			IList <GitRunner.BlamePorcelainEntry>? blameEntries;
 
 			blameEntries = await git.Blame ("Configuration.props");
 			if (blameEntries == null || blameEntries.Count == 0)

--- a/build-tools/xaprepare/xaprepare/Application/DetermineWindowsVersion.Windows.cs
+++ b/build-tools/xaprepare/xaprepare/Application/DetermineWindowsVersion.Windows.cs
@@ -5,7 +5,7 @@ namespace Xamarin.Android.Prepare
 {
 	class OSVersionInfo
 	{
-		public string Name { get; private set; }
+		public string Name { get; private set; } = String.Empty;
 		public int Minor   { get; private set; }
 		public int Major   { get; private set; }
 		public int Build   { get; private set; }

--- a/build-tools/xaprepare/xaprepare/Application/EssentialTools.cs
+++ b/build-tools/xaprepare/xaprepare/Application/EssentialTools.cs
@@ -4,8 +4,8 @@ namespace Xamarin.Android.Prepare
 {
 	partial class EssentialTools : AppObject
 	{
-		string gitPath;
-		string sevenZipPath;
+		string gitPath = String.Empty;
+		string sevenZipPath = String.Empty;
 		bool initialized;
 
 		public string GitPath {

--- a/build-tools/xaprepare/xaprepare/Application/Extensions.DictionaryOfProgramVersionParser.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Extensions.DictionaryOfProgramVersionParser.cs
@@ -6,11 +6,8 @@ namespace Xamarin.Android.Prepare
 {
 	static class DictionaryOfProgramVersionParser_Extensions
 	{
-		public static void Add (this Dictionary<string, ProgramVersionParser> dict, string programName, string versionArguments, Regex regex, uint versionOutputLine = 0, Log log = null)
+		public static void Add (this Dictionary<string, ProgramVersionParser> dict, string programName, string versionArguments, Regex regex, uint versionOutputLine = 0, Log? log = null)
 		{
-			if (dict == null)
-				throw new ArgumentNullException (nameof (dict));
-
 			if (dict.ContainsKey (programName)) {
 				Log.Instance.WarningLine ($"Entry for {programName} version matcher already defined. Ignoring the new entry ({regex})");
 				return;

--- a/build-tools/xaprepare/xaprepare/Application/Extensions.Runtime.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Extensions.Runtime.cs
@@ -1,7 +1,11 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
 namespace Xamarin.Android.Prepare
 {
 	static class Runtime_Extensions
 	{
+		[return: MaybeNull]
 		public static T As <T> (this Runtime runtime) where T: Runtime
 		{
 			return runtime as T;

--- a/build-tools/xaprepare/xaprepare/Application/ExternalGitDependency.cs
+++ b/build-tools/xaprepare/xaprepare/Application/ExternalGitDependency.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Xamarin.Android.Prepare
@@ -28,10 +27,10 @@ namespace Xamarin.Android.Prepare
 $
 ", RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
-		public string Branch { get; private set; }
-		public string Commit { get; private set; }
-		public string Name   { get; private set; }
-		public string Owner  { get; private set; }
+		public string Branch { get; private set; } = String.Empty;
+		public string Commit { get; private set; } = String.Empty;
+		public string Name   { get; private set; } = String.Empty;
+		public string Owner  { get; private set; } = String.Empty;
 
 		public static List<ExternalGitDependency> GetDependencies (Context context, string externalFilePath, bool quiet = false)
 		{

--- a/build-tools/xaprepare/xaprepare/Application/GeneratedFile.cs
+++ b/build-tools/xaprepare/xaprepare/Application/GeneratedFile.cs
@@ -11,7 +11,8 @@ namespace Xamarin.Android.Prepare
 
 		protected GeneratedFile (string outputPath)
 		{
-			OutputPath = outputPath?.Trim ();
+			InputPath = String.Empty;
+			OutputPath = outputPath.Trim ();
 			if (String.IsNullOrEmpty (OutputPath))
 				throw new ArgumentException ("must not be null or empty", nameof (outputPath));
 		}
@@ -19,7 +20,7 @@ namespace Xamarin.Android.Prepare
 		protected GeneratedFile (string inputPath, string outputPath)
 			: this (outputPath)
 		{
-			InputPath = inputPath?.Trim ();
+			InputPath = inputPath.Trim ();
 			if (String.IsNullOrEmpty (InputPath))
 				throw new ArgumentException ("must not be null or empty", nameof (inputPath));
 

--- a/build-tools/xaprepare/xaprepare/Application/GeneratedMakeRulesFile.cs
+++ b/build-tools/xaprepare/xaprepare/Application/GeneratedMakeRulesFile.cs
@@ -185,12 +185,12 @@ namespace Xamarin.Android.Prepare
 				WriteRuleLine ($"\t/p:AndroidFrameworkVersion={firstFramework} || exit 1;");
 			}
 
-			string ToValue (ICollection<string> list, string separator = null)
+			string ToValue (ICollection<string> list, string? separator = null)
 			{
 				return String.Join (separator ?? " ", list);
 			}
 
-			void WriteRuleLine (string line = null)
+			void WriteRuleLine (string line)
 			{
 				sw.Write ('\t');
 				sw.WriteLine (line);
@@ -210,7 +210,7 @@ namespace Xamarin.Android.Prepare
 					sw.Write ($"{name} =");
 
 				foreach (string i in list) {
-					string item = i?.Trim ();
+					string item = i.Trim ();
 					if (String.IsNullOrEmpty (item))
 						continue;
 

--- a/build-tools/xaprepare/xaprepare/Application/GeneratedPlaceholdersFile.cs
+++ b/build-tools/xaprepare/xaprepare/Application/GeneratedPlaceholdersFile.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Android.Prepare
 			var inputData = new StringBuilder (File.ReadAllText (InputPath, Encoding.UTF8));
 
 			foreach (var kvp in replacements) {
-				string placeholder = kvp.Key?.Trim ();
+				string placeholder = kvp.Key.Trim ();
 				if (String.IsNullOrEmpty (placeholder))
 					continue;
 

--- a/build-tools/xaprepare/xaprepare/Application/GeneratedProfileAssembliesProjitemsFile.cs
+++ b/build-tools/xaprepare/xaprepare/Application/GeneratedProfileAssembliesProjitemsFile.cs
@@ -53,7 +53,7 @@ namespace Xamarin.Android.Prepare
 				throw new InvalidOperationException ("Profile assembly discrepancies found. Please examine 'build-tools/xaprepare/xaprepare/ConfigAndData/Runtimes.cs' to make sure all assemblies listed above are included");
 		}
 
-		bool FileSetsDiffer (IEnumerable<TestAssembly> assemblies, string directoryPath, string batchName, HashSet<string> ignoreFiles = null)
+		bool FileSetsDiffer (IEnumerable<TestAssembly> assemblies, string directoryPath, string batchName, HashSet<string>? ignoreFiles = null)
 		{
 			List<string> tests = FilesFromDir (directoryPath, ignoreFiles).ToList ();
 			tests.AddRange (
@@ -68,7 +68,7 @@ namespace Xamarin.Android.Prepare
 			return FileSetsDiffer (ToStringSet (assemblies), tests, batchName);
 		}
 
-		bool FileSetsDiffer (IEnumerable<BclFile> assemblies, string directoryPath, string batchName, HashSet<string> ignoreFiles = null)
+		bool FileSetsDiffer (IEnumerable<BclFile> assemblies, string directoryPath, string batchName, HashSet<string>? ignoreFiles = null)
 		{
 			return FileSetsDiffer (ToStringSet (assemblies), FilesFromDir (directoryPath, ignoreFiles), batchName);
 		}
@@ -88,7 +88,7 @@ namespace Xamarin.Android.Prepare
 			return true;
 		}
 
-		IEnumerable<string> FilesFromDir (string directoryPath, HashSet<string> ignoreFiles = null, string globPattern = "*.dll", bool stripPath = true, bool searchSubdirs = false)
+		IEnumerable<string> FilesFromDir (string directoryPath, HashSet<string>? ignoreFiles = null, string globPattern = "*.dll", bool stripPath = true, bool searchSubdirs = false)
 		{
 			IEnumerable<string> files = Directory.EnumerateFiles (
 				directoryPath,
@@ -141,7 +141,7 @@ namespace Xamarin.Android.Prepare
 			StartGroup (sw);
 			foreach (TestAssembly taf in files) {
 				string itemName = "MonoTestAssembly";
-				string testType = null;
+				string testType = String.Empty;
 
 				switch (taf.TestType) {
 					case TestAssemblyType.Satellite:

--- a/build-tools/xaprepare/xaprepare/Application/Log.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Log.cs
@@ -45,14 +45,14 @@ namespace Xamarin.Android.Prepare
 		const string MessageSeverity = "Message: ";
 		const string DebugSeverity   = "  Debug: ";
 
-		static Context ctx;
+		static Context? ctx;
 		static LoggingVerbosity Verbosity => ctx != null ? ctx.LoggingVerbosity : Configurables.Defaults.LoggingVerbosity;
 
 		public static Log Instance => instance;
 
 		static bool UseColor => ctx?.UseColor ?? true;
 
-		TextWriter logFileWriter;
+		TextWriter? logFileWriter;
 		bool alreadyDisposed;
 		Stopwatch watch;
 
@@ -61,7 +61,7 @@ namespace Xamarin.Android.Prepare
 			instance = new Log ();
 		}
 
-		public Log (string logFilePath = null)
+		public Log (string? logFilePath = null)
 		{
 			InitOS ();
 			SetLogFile (logFilePath);
@@ -76,7 +76,7 @@ namespace Xamarin.Android.Prepare
 			ctx = context;
 		}
 
-		public void SetLogFile (string logFilePath)
+		public void SetLogFile (string? logFilePath)
 		{
 			CloseLogFile ();
 			if (String.IsNullOrEmpty (logFilePath))
@@ -128,7 +128,7 @@ namespace Xamarin.Android.Prepare
 			DoWrite (WriteToConsole, ErrorMinimumVerbosity, String.Empty, tail, tailColor, skipLogFile);
 		}
 
-		public void StatusLine (string line = null, ConsoleColor color = StatusColor, bool skipLogFile = false)
+		public void StatusLine (string? line = null, ConsoleColor color = StatusColor, bool skipLogFile = false)
 		{
 			DoWrite (WriteLineToConsole, ErrorMinimumVerbosity, String.Empty, line, color, skipLogFile);
 		}
@@ -139,95 +139,95 @@ namespace Xamarin.Android.Prepare
 			DoWrite (WriteLineToConsole, ErrorMinimumVerbosity, String.Empty, tail, tailColor, skipLogFile);
 		}
 
-		public void Error (string text, ConsoleColor color = ErrorColor, bool showSeverity = DefaultErrorShowSeverity, string customSeverityName = null)
+		public void Error (string text, ConsoleColor color = ErrorColor, bool showSeverity = DefaultErrorShowSeverity, string? customSeverityName = null)
 		{
 			string severity = showSeverity ? (customSeverityName ?? ErrorSeverity) : String.Empty;
 			DoWrite (WriteToConsole, ErrorMinimumVerbosity, severity, text, color);
 		}
 
-		public void Error (string lead, string tail, ConsoleColor leadColor = ErrorLeadColor, ConsoleColor tailColor = ErrorTailColor, bool showSeverity = DefaultErrorShowSeverity, string customSeverityName = null)
+		public void Error (string lead, string tail, ConsoleColor leadColor = ErrorLeadColor, ConsoleColor tailColor = ErrorTailColor, bool showSeverity = DefaultErrorShowSeverity, string? customSeverityName = null)
 		{
 			string severity = showSeverity ? (customSeverityName ?? ErrorSeverity) : String.Empty;
 			DoWrite (WriteToConsole, ErrorMinimumVerbosity, severity, lead, leadColor);
 			DoWrite (WriteToConsole, ErrorMinimumVerbosity, String.Empty, tail, tailColor);
 		}
 
-		public void ErrorLine (string line = null, ConsoleColor color = ErrorColor, bool showSeverity = DefaultErrorShowSeverity, string customSeverityName = null)
+		public void ErrorLine (string? line = null, ConsoleColor color = ErrorColor, bool showSeverity = DefaultErrorShowSeverity, string? customSeverityName = null)
 		{
 			string severity = showSeverity ? (customSeverityName ?? ErrorSeverity) : String.Empty;
 			DoWrite (WriteLineToConsole, ErrorMinimumVerbosity, severity, line, color);
 		}
 
-		public void ErrorLine (string lead, string tail, ConsoleColor leadColor = ErrorLeadColor, ConsoleColor tailColor = ErrorTailColor, bool showSeverity = DefaultErrorShowSeverity, string customSeverityName = null)
+		public void ErrorLine (string lead, string tail, ConsoleColor leadColor = ErrorLeadColor, ConsoleColor tailColor = ErrorTailColor, bool showSeverity = DefaultErrorShowSeverity, string? customSeverityName = null)
 		{
 			string severity = showSeverity ? (customSeverityName ?? ErrorSeverity) : String.Empty;
 			DoWrite (WriteToConsole, ErrorMinimumVerbosity, severity, lead, leadColor);
 			DoWrite (WriteLineToConsole, ErrorMinimumVerbosity, String.Empty, tail, tailColor);
 		}
 
-		public void Warning (string text, ConsoleColor color = WarningColor, bool showSeverity = DefaultWarningShowSeverity, string customSeverityName = null)
+		public void Warning (string text, ConsoleColor color = WarningColor, bool showSeverity = DefaultWarningShowSeverity, string? customSeverityName = null)
 		{
 			string severity = showSeverity ? (customSeverityName ?? WarningSeverity) : String.Empty;
 			DoWrite (WriteToConsole, WarningMinimumVerbosity, severity, text, color);
 		}
 
-		public void WarningLine (string line = null, ConsoleColor color = WarningColor, bool showSeverity = DefaultWarningShowSeverity, string customSeverityName = null)
+		public void WarningLine (string? line = null, ConsoleColor color = WarningColor, bool showSeverity = DefaultWarningShowSeverity, string? customSeverityName = null)
 		{
 			string severity = showSeverity ? (customSeverityName ?? WarningSeverity) : String.Empty;
 			DoWrite (WriteLineToConsole, WarningMinimumVerbosity, severity, line, color);
 		}
 
-		public void Info (string text, ConsoleColor color = InfoColor, bool showSeverity = DefaultInfoShowSeverity, string customSeverityName = null)
+		public void Info (string text, ConsoleColor color = InfoColor, bool showSeverity = DefaultInfoShowSeverity, string? customSeverityName = null)
 		{
 			string severity = showSeverity ? (customSeverityName ?? InfoSeverity) : String.Empty;
 			DoWrite (WriteToConsole, InfoMinimumVerbosity, severity, text, color);
 		}
 
-		public void Info (string lead, string tail, ConsoleColor leadColor = InfoLeadColor, ConsoleColor tailColor = InfoTailColor, bool showSeverity = DefaultInfoShowSeverity, string customSeverityName = null)
+		public void Info (string lead, string tail, ConsoleColor leadColor = InfoLeadColor, ConsoleColor tailColor = InfoTailColor, bool showSeverity = DefaultInfoShowSeverity, string? customSeverityName = null)
 		{
 			string severity = showSeverity ? (customSeverityName ?? InfoSeverity) : String.Empty;
 			DoWrite (WriteToConsole, InfoMinimumVerbosity, severity, lead, leadColor);
 			DoWrite (WriteToConsole, InfoMinimumVerbosity, String.Empty, tail, tailColor);
 		}
 
-		public void InfoLine (string line = null, ConsoleColor color = InfoColor, bool showSeverity = DefaultInfoShowSeverity, string customSeverityName = null)
+		public void InfoLine (string? line = null, ConsoleColor color = InfoColor, bool showSeverity = DefaultInfoShowSeverity, string? customSeverityName = null)
 		{
 			string severity = showSeverity ? (customSeverityName ?? InfoSeverity) : String.Empty;
 			DoWrite (WriteLineToConsole, InfoMinimumVerbosity, severity, line, color);
 		}
 
-		public void InfoLine (string lead, string tail, ConsoleColor leadColor = InfoLeadColor, ConsoleColor tailColor = InfoTailColor, bool showSeverity = DefaultInfoShowSeverity, string customSeverityName = null)
+		public void InfoLine (string lead, string tail, ConsoleColor leadColor = InfoLeadColor, ConsoleColor tailColor = InfoTailColor, bool showSeverity = DefaultInfoShowSeverity, string? customSeverityName = null)
 		{
 			string severity = showSeverity ? (customSeverityName ?? InfoSeverity) : String.Empty;
 			DoWrite (WriteToConsole, InfoMinimumVerbosity, severity, lead, leadColor);
 			DoWrite (WriteLineToConsole, InfoMinimumVerbosity, String.Empty, tail, tailColor);
 		}
 
-		public void Message (string text, ConsoleColor color = MessageColor, bool showSeverity = DefaultMessageShowSeverity, string customSeverityName = null)
+		public void Message (string text, ConsoleColor color = MessageColor, bool showSeverity = DefaultMessageShowSeverity, string? customSeverityName = null)
 		{
 			string severity = showSeverity ? (customSeverityName ?? MessageSeverity) : String.Empty;
 			DoWrite (WriteToConsole, MessageMinimumVerbosity, severity, text, color);
 		}
 
-		public void MessageLine (string line = null, ConsoleColor color = MessageColor, bool showSeverity = DefaultMessageShowSeverity, string customSeverityName = null)
+		public void MessageLine (string? line = null, ConsoleColor color = MessageColor, bool showSeverity = DefaultMessageShowSeverity, string? customSeverityName = null)
 		{
 			string severity = showSeverity ? (customSeverityName ?? MessageSeverity) : String.Empty;
 			DoWrite (WriteLineToConsole, MessageMinimumVerbosity, showSeverity ? MessageSeverity : String.Empty, line, color);
 		}
 
-		public void Debug (string text, ConsoleColor color = DebugColor, bool showSeverity = DefaultDebugShowSeverity, string customSeverityName = null)
+		public void Debug (string text, ConsoleColor color = DebugColor, bool showSeverity = DefaultDebugShowSeverity, string? customSeverityName = null)
 		{
 			string severity = showSeverity ? (customSeverityName ?? DebugSeverity) : String.Empty;
 			DoWrite (WriteToConsole, DebugMinimumVerbosity, severity, text, color);
 		}
 
-		public void DebugLine (string line = null, ConsoleColor color = DebugColor, bool showSeverity = DefaultDebugShowSeverity, string customSeverityName = null)
+		public void DebugLine (string? line = null, ConsoleColor color = DebugColor, bool showSeverity = DefaultDebugShowSeverity, string? customSeverityName = null)
 		{
 			string severity = showSeverity ? (customSeverityName ?? DebugSeverity) : String.Empty;
 			DoWrite (WriteLineToConsole, DebugMinimumVerbosity, severity, line, color);
 		}
 
-		void DoWrite (Action<LoggingVerbosity, string, ConsoleColor, bool> writer, LoggingVerbosity minimumVerbosity, string prefix, string message, ConsoleColor color, bool skipLogFile = false)
+		void DoWrite (Action<LoggingVerbosity, string, ConsoleColor, bool> writer, LoggingVerbosity minimumVerbosity, string prefix, string? message, ConsoleColor color, bool skipLogFile = false)
 		{
 			writer (minimumVerbosity, $"{prefix}{message}", color, skipLogFile);
 		}
@@ -251,7 +251,7 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		void WriteLineToConsole (LoggingVerbosity minimumVerbosity, string message = null, bool skipLogFile = false)
+		void WriteLineToConsole (LoggingVerbosity minimumVerbosity, string? message = null, bool skipLogFile = false)
 		{
 			lock (writeLock) {
 				if (Verbosity >= minimumVerbosity) {
@@ -283,7 +283,7 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		void WriteToConsole (LoggingVerbosity minimumVerbosity, string message = null, bool skipLogFile = false)
+		void WriteToConsole (LoggingVerbosity minimumVerbosity, string? message = null, bool skipLogFile = false)
 		{
 			if (message == null)
 				return;

--- a/build-tools/xaprepare/xaprepare/Application/MonoRuntime.cs
+++ b/build-tools/xaprepare/xaprepare/Application/MonoRuntime.cs
@@ -4,31 +4,25 @@ namespace Xamarin.Android.Prepare
 {
 	abstract class MonoRuntime : Runtime
 	{
-		string nativeLibraryDirPrefix;
-
 		public bool   CanStripNativeLibrary         { get; set; } = true;
-		public string CrossMonoName                 { get; set; }
-		public string ExePrefix                     { get; set; }
+		public string CrossMonoName                 { get; set; } = String.Empty;
+		public string ExePrefix                     { get; set; } = String.Empty;
 		public bool   IsCrossRuntime                { get; set; }
-		public string NativeLibraryExtension        { get; set; }
+		public string NativeLibraryExtension        { get; set; } = String.Empty;
 
 		/// <summary>
 		///   Optional directory prefix for native library source. This should be a path relative to runtime's library
 		///   output dir and it exists because MinGW builds will put the runtime .dll in the bin directory instead of in
 		///   the lib one.
 		/// </summary>
-		public string NativeLibraryDirPrefix        {
-			get => nativeLibraryDirPrefix ?? String.Empty;
-			set => nativeLibraryDirPrefix = value;
-		}
-
-		public string OutputAotProfilerFilename     { get; set; }
-		public string OutputMonoBtlsFilename        { get; set; }
-		public string OutputMonoPosixHelperFilename { get; set; }
-		public string OutputProfilerFilename        { get; set; }
+		public string NativeLibraryDirPrefix        { get; set; } = String.Empty;
+		public string OutputAotProfilerFilename     { get; set; } = String.Empty;
+		public string OutputMonoBtlsFilename        { get; set; } = String.Empty;
+		public string OutputMonoPosixHelperFilename { get; set; } = String.Empty;
+		public string OutputProfilerFilename        { get; set; } = String.Empty;
 		public string OutputRuntimeFilename         { get; set; } = Configurables.Defaults.MonoRuntimeOutputFileName;
-		public string Strip                         { get; set; }
-		public string StripFlags                    { get; set; }
+		public string Strip                         { get; set; } = String.Empty;
+		public string StripFlags                    { get; set; } = String.Empty;
 
 		protected MonoRuntime (string name, Func<Context, bool> enabledCheck)
 			: base (name, enabledCheck)

--- a/build-tools/xaprepare/xaprepare/Application/MonoRuntimesHelpers.cs
+++ b/build-tools/xaprepare/xaprepare/Application/MonoRuntimesHelpers.cs
@@ -87,29 +87,23 @@ namespace Xamarin.Android.Prepare
 
 		public static (string executable, string debugSymbols) GetDestinationPaths (MonoUtilityFile muf)
 		{
-			if (muf == null)
-				throw new ArgumentNullException (nameof (muf));
-
 			string destDir = UtilitiesDestinationDir;
 			string targetFileName;
 
 			if (!String.IsNullOrEmpty (muf.TargetName))
-				targetFileName = muf.TargetName;
+				targetFileName = muf.TargetName!;
 			else
 				targetFileName = Path.GetFileName (muf.SourcePath);
 
 			string destFilePath = Path.Combine (destDir, targetFileName);
 			if (String.IsNullOrEmpty (muf.DebugSymbolsPath))
-				return (destFilePath, null);
+				return (destFilePath, String.Empty);
 
 			return (destFilePath, Path.Combine (destDir, Utilities.GetDebugSymbolsPath (targetFileName)));
 		}
 
 		public static (string assembly, string debugSymbols) GetDestinationPaths (BclFile bf)
 		{
-			if (bf == null)
-				throw new ArgumentNullException (nameof (bf));
-
 			string destDir;
 			switch (bf.Type) {
 				case BclFileType.ProfileAssembly:
@@ -126,7 +120,7 @@ namespace Xamarin.Android.Prepare
 
 			string destFile = Path.Combine (destDir, bf.Name);
 			if (bf.ExcludeDebugSymbols)
-				return (destFile, null);
+				return (destFile, String.Empty);
 
 			return (destFile, Path.Combine (destDir, Path.GetFileName (bf.DebugSymbolsPath)));
 		}
@@ -157,13 +151,13 @@ namespace Xamarin.Android.Prepare
 				destDir = BCLTestsDestinationDir;
 
 			string destFile = Path.Combine (destDir, Path.GetFileName (tasm.Name));
-			return (destFile, pdbRequired ? Utilities.GetDebugSymbolsPath (destFile) : null);
+			return (destFile, pdbRequired ? Utilities.GetDebugSymbolsPath (destFile) : String.Empty);
 		}
 
 		public static (bool skip, string src, string dst) GetRuntimeFilePaths (Runtime runtime, RuntimeFile rtf)
 		{
 			if (rtf.ShouldSkip != null && rtf.ShouldSkip (runtime))
-				return (true, null, null);
+				return (true, String.Empty, String.Empty);
 
 			return (
 				false,
@@ -235,7 +229,7 @@ namespace Xamarin.Android.Prepare
 				foreach (var runtimeFile in runtimes.RuntimeFilesToInstall) {
 					(bool skipFile, string src, string dst) = GetRuntimeFilePaths (runtime, runtimeFile);
 
-					if (!skipFile && !File.Exists (dst)) {
+					if (!skipFile && (dst.Length == 0 || !File.Exists (dst))) {
 						Log.Instance.WarningLine ($"File '{dst}' missing, skipping the rest of runtime item file scan");
 						return false;
 					}
@@ -249,7 +243,7 @@ namespace Xamarin.Android.Prepare
 				if (File.Exists (destFilePath) && shouldExcludeSymbols)
 					return true;
 
-				if (File.Exists (destFilePath) && !shouldExcludeSymbols && File.Exists (debugSymbolsDestPath))
+				if (File.Exists (destFilePath) && !shouldExcludeSymbols && !String.IsNullOrEmpty (debugSymbolsDestPath) && File.Exists (debugSymbolsDestPath))
 					return true;
 
 				Log.Instance.DebugLine ($"File '{destFilePath}' or symbols '{debugSymbolsDestPath}' missing, skipping the rest of runtime item file scan");

--- a/build-tools/xaprepare/xaprepare/Application/MonoUtilityFile.cs
+++ b/build-tools/xaprepare/xaprepare/Application/MonoUtilityFile.cs
@@ -6,15 +6,15 @@ namespace Xamarin.Android.Prepare
 	sealed class MonoUtilityFile
 	{
 		public string SourcePath    { get; }
-		public string TargetName    { get; }
+		public string? TargetName   { get; }
 		public bool RemapCecil      { get; }
 		public bool IgnoreDebugInfo { get; }
 
 		public string DebugSymbolsPath => Utilities.GetDebugSymbolsPath (SourcePath);
 
-		public MonoUtilityFile (string name, bool remap = false, string targetName = null, bool ignoreDebugInfo = false)
+		public MonoUtilityFile (string name, bool remap = false, string? targetName = null, bool ignoreDebugInfo = false)
 		{
-			name = name?.Trim ();
+			name = name.Trim ();
 			if (String.IsNullOrEmpty (name))
 				throw new ArgumentException ("must not be null or empty", nameof (name));
 

--- a/build-tools/xaprepare/xaprepare/Application/NullableAttributes.cs
+++ b/build-tools/xaprepare/xaprepare/Application/NullableAttributes.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+	/// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+	[AttributeUsage (AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+	internal sealed class MaybeNullAttribute : Attribute
+	{ }
+}

--- a/build-tools/xaprepare/xaprepare/Application/ProcessRunner.cs
+++ b/build-tools/xaprepare/xaprepare/Application/ProcessRunner.cs
@@ -33,12 +33,12 @@ namespace Xamarin.Android.Prepare
 		}
 
 		string command;
-		List<string> arguments;
-		List<WriterGuard> stderrSinks;
-		List<WriterGuard> stdoutSinks;
-		Dictionary<TextWriter, WriterGuard> guardCache;
+		List<string>? arguments;
+		List<WriterGuard>? stderrSinks;
+		List<WriterGuard>? stdoutSinks;
+		Dictionary<TextWriter, WriterGuard>? guardCache;
 		bool defaultStdoutEchoWrapperAdded;
-		ProcessStandardStreamWrapper defaultStderrEchoWrapper;
+		ProcessStandardStreamWrapper? defaultStderrEchoWrapper;
 
 		public string Command => command;
 
@@ -67,21 +67,21 @@ namespace Xamarin.Android.Prepare
 		public ProcessStandardStreamWrapper.LogLevel EchoStandardOutputLevel { get; set; } = ProcessStandardStreamWrapper.LogLevel.Message;
 		public bool EchoStandardError                                        { get; set; }
 		public ProcessStandardStreamWrapper.LogLevel EchoStandardErrorLevel  { get; set; } = ProcessStandardStreamWrapper.LogLevel.Error;
-		public ProcessStandardStreamWrapper StandardOutputEchoWrapper        { get; set; }
-		public ProcessStandardStreamWrapper StandardErrorEchoWrapper         { get; set; }
+		public ProcessStandardStreamWrapper? StandardOutputEchoWrapper       { get; set; }
+		public ProcessStandardStreamWrapper? StandardErrorEchoWrapper        { get; set; }
 		public Encoding StandardOutputEncoding                               { get; set; } = Encoding.Default;
 		public Encoding StandardErrorEncoding                                { get; set; } = Encoding.Default;
 		public TimeSpan StandardOutputTimeout                                { get; set; } = DefaultOutputTimeout;
 		public TimeSpan StandardErrorTimeout                                 { get; set; } = DefaultOutputTimeout;
 		public TimeSpan ProcessTimeout                                       { get; set; } = DefaultProcessTimeout;
-		public string WorkingDirectory                                       { get; set; }
-		public Action<ProcessStartInfo> StartInfoCallback                    { get; set; }
+		public string? WorkingDirectory                                      { get; set; }
+		public Action<ProcessStartInfo>? StartInfoCallback                   { get; set; }
 
-		public ProcessRunner (string command, params string[] arguments)
+		public ProcessRunner (string command, params string?[] arguments)
 			: this (command, false, arguments)
 		{}
 
-		public ProcessRunner (string command, bool ignoreEmptyArguments, params string[] arguments)
+		public ProcessRunner (string command, bool ignoreEmptyArguments, params string?[] arguments)
 		{
 			if (String.IsNullOrEmpty (command))
 				throw new ArgumentException ("must not be null or empty", nameof (command));
@@ -90,31 +90,31 @@ namespace Xamarin.Android.Prepare
 			AddArgumentsInternal (ignoreEmptyArguments, arguments);
 		}
 
-		public ProcessRunner AddArguments (params string[] arguments)
+		public ProcessRunner AddArguments (params string?[] arguments)
 		{
 			return AddArguments (true, arguments);
 		}
 
-		public ProcessRunner AddArguments (bool ignoreEmptyArguments, params string[] arguments)
+		public ProcessRunner AddArguments (bool ignoreEmptyArguments, params string?[] arguments)
 		{
 			AddArgumentsInternal (ignoreEmptyArguments, arguments);
 			return this;
 		}
 
-		void AddArgumentsInternal (bool ignoreEmptyArguments, params string[] arguments)
+		void AddArgumentsInternal (bool ignoreEmptyArguments, params string?[] arguments)
 		{
 			if (arguments == null)
 				return;
 
 			for (int i = 0; i < arguments.Length; i++) {
-				string argument = arguments [i]?.Trim ();
+				string? argument = arguments [i]?.Trim ();
 				if (String.IsNullOrEmpty (argument)) {
 					if (ignoreEmptyArguments)
 						continue;
 					throw new InvalidOperationException ($"Argument {i} is null or empty");
 				}
 
-				AddQuotedArgument (argument);
+				AddQuotedArgument (argument!);
 			}
 		}
 
@@ -213,8 +213,8 @@ namespace Xamarin.Android.Prepare
 				}
 			}
 
-			ManualResetEventSlim stdout_done = null;
-			ManualResetEventSlim stderr_done = null;
+			ManualResetEventSlim? stdout_done = null;
+			ManualResetEventSlim? stderr_done = null;
 
 			if (stderrSinks != null && stderrSinks.Count > 0)
 				stderr_done = new ManualResetEventSlim (false);
@@ -266,9 +266,9 @@ namespace Xamarin.Android.Prepare
 			if (psi.RedirectStandardError) {
 				process.ErrorDataReceived += (object sender, DataReceivedEventArgs e) => {
 					if (e.Data != null)
-						WriteOutput (e.Data, stderrSinks);
+						WriteOutput (e.Data, stderrSinks!);
 					else
-						stderr_done.Set ();
+						stderr_done!.Set ();
 				};
 				process.BeginErrorReadLine ();
 			}
@@ -276,9 +276,9 @@ namespace Xamarin.Android.Prepare
 			if (psi.RedirectStandardOutput) {
 				process.OutputDataReceived += (object sender, DataReceivedEventArgs e) => {
 					if (e.Data != null)
-						WriteOutput (e.Data, stdoutSinks);
+						WriteOutput (e.Data, stdoutSinks!);
 					else
-						stdout_done.Set ();
+						stdout_done!.Set ();
 				};
 				process.BeginOutputReadLine ();
 			}
@@ -324,7 +324,7 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		void AddToList <T> (T item, ref List<T> list)
+		void AddToList <T> (T item, ref List<T>? list)
 		{
 			if (list == null)
 				list = new List <T> ();

--- a/build-tools/xaprepare/xaprepare/Application/ProcessStandardStreamWrapper.cs
+++ b/build-tools/xaprepare/xaprepare/Application/ProcessStandardStreamWrapper.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Android.Prepare
 
 	    public bool IndentOutput         { get; set; } = true;
 	    public LogLevel LoggingLevel     { get; set; } = LogLevel.Debug;
-	    public string CustomSeverityName { get; set; }
+	    public string CustomSeverityName { get; set; } = String.Empty;
 
 	    public string IndentString {
 		    get => indentString;

--- a/build-tools/xaprepare/xaprepare/Application/Program.ArchLinux.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Program.ArchLinux.cs
@@ -5,7 +5,7 @@ namespace Xamarin.Android.Prepare
 {
 	class ArchLinuxProgram : LinuxProgram
 	{
-		public ArchLinuxProgram (string packageName, string executableName = null)
+		public ArchLinuxProgram (string packageName, string? executableName = null)
 			: base (packageName, executableName)
 		{}
 

--- a/build-tools/xaprepare/xaprepare/Application/Program.DebianLinux.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Program.DebianLinux.cs
@@ -22,11 +22,11 @@ namespace Xamarin.Android.Prepare
 				// line to us... So in order to keep the display straight we need to reset the cursor position blindly
 				// here.
 				Console.CursorLeft = 1;
-				return message?.TrimEnd ();
+				return message.TrimEnd ();
 			}
 		}
 
-		public DebianLinuxProgram (string packageName, string executableName = null)
+		public DebianLinuxProgram (string packageName, string? executableName = null)
 			: base (packageName, executableName)
 		{}
 

--- a/build-tools/xaprepare/xaprepare/Application/Program.Linux.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Program.Linux.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Android.Prepare
 
 		public string PackageName { get; }
 
-		public LinuxProgram (string packageName, string executableName)
+		public LinuxProgram (string packageName, string? executableName)
 		{
 			if (String.IsNullOrEmpty (packageName))
 				throw new ArgumentException ("must not be null or empty", nameof (packageName));

--- a/build-tools/xaprepare/xaprepare/Application/Program.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Program.cs
@@ -18,24 +18,24 @@ namespace Xamarin.Android.Prepare
 		///   Program/package name - this may be an actual program name or a system package name. What it is affects
 		///   version checking, <see cref="ExecutableName" />
 		/// </summary>
-		public string Name                      { get; set; }
+		public string Name                      { get; set; } = String.Empty;
 
 		/// <summary>
 		///   Name of an executable/binary inside a package (<see cref="Name"/>) which will be used to query the program
 		///   version. If <see cref="Name"/> refers to an executable name (e.g. it coincides with the package name),
 		///   this property may be left unset.
 		/// </summary>
-		public string ExecutableName            { get; set; }
+		public string? ExecutableName            { get; set; }
 
 		/// <summary>
 		///   Minimum supported version of the package/program
 		/// </summary>
-		public string MinimumVersion            { get; set; }
+		public string? MinimumVersion            { get; set; }
 
 		/// <summary>
 		///   Maximum supported version of the package/program
 		/// </summary>
-		public string MaximumVersion            { get; set; }
+		public string? MaximumVersion            { get; set; }
 
 		/// <summary>
 		///   Version of the currently installed package/program, if any. If the program isn't detected, this property
@@ -96,16 +96,16 @@ namespace Xamarin.Android.Prepare
 
 		bool IsValidVersion ()
 		{
-			if (!ParseVersion (CurrentVersion, out Version curVer)) {
+			if (!ParseVersion (CurrentVersion, out Version? curVer)) {
 				Log.DebugLine ($"Unable to parse {Name} version from the string: {CurrentVersion}");
 				Log.DebugLine ($"Version checks disabled for {Name}");
 				return true;
 			}
 
-			if (!ParseVersion (MinimumVersion, out Version minVer))
+			if (!ParseVersion (MinimumVersion, out Version? minVer))
 				minVer = null;
 
-			if (!ParseVersion (MaximumVersion, out Version maxVer))
+			if (!ParseVersion (MaximumVersion, out Version? maxVer))
 				maxVer = null;
 
 			if (minVer == null && maxVer == null)
@@ -134,7 +134,7 @@ namespace Xamarin.Android.Prepare
 			return false;
 		}
 
-		protected virtual bool ParseVersion (string version, out Version ver)
+		protected virtual bool ParseVersion (string? version, out Version? ver)
 		{
 			return Version.TryParse (version, out ver);
 		}
@@ -149,7 +149,7 @@ namespace Xamarin.Android.Prepare
 
 			bool success;
 			string version;
-			string programName = ExecutableName?.Trim ();
+			string programName = ExecutableName?.Trim () ?? String.Empty;
 			if (String.IsNullOrEmpty (programName))
 				programName = Name;
 

--- a/build-tools/xaprepare/xaprepare/Application/ProgramVersionParser.cs
+++ b/build-tools/xaprepare/xaprepare/Application/ProgramVersionParser.cs
@@ -23,9 +23,9 @@ namespace Xamarin.Android.Prepare
 		///   Arguments to pass to <see cref="ProgramName"/> in order to obtain the version. Defaults to <c>null</c>
 		///   since some programs show the version when there are no arguments passed to them.
 		/// </summary>
-		public string VersionArguments { get; }
+		public string? VersionArguments { get; }
 
-		protected ProgramVersionParser (string programName, string versionArguments = null, uint versionOutputLine = 0, Log log = null)
+		protected ProgramVersionParser (string programName, string? versionArguments = null, uint versionOutputLine = 0, Log? log = null)
 			: base (log)
 		{
 			if (String.IsNullOrEmpty (programName))

--- a/build-tools/xaprepare/xaprepare/Application/Properties.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Properties.cs
@@ -8,19 +8,19 @@ namespace Xamarin.Android.Prepare
 	{
 		SortedDictionary <string, string> properties = new SortedDictionary <string, string> (StringComparer.Ordinal);
 
-		public event EventHandler<PropertiesChangedEventArgs> PropertiesChanged;
+		public event EventHandler<PropertiesChangedEventArgs>? PropertiesChanged;
 
 		public int Count => properties.Count;
 		public bool IsDefined (string propertyName) => properties.ContainsKey (EnsureName (propertyName));
 		public bool IsEmpty (string propertyName) => IsDefined (propertyName) && properties.TryGetValue (propertyName, out string v) && v != null;
-		public string this [string name] => GetValue (name);
+		public string? this [string name] => GetValue (name);
 
 		public Properties ()
 		{
 			InitDefaults ();
 		}
 
-		public string GetValue (string propertyName, string defaultValue = null)
+		public string? GetValue (string propertyName, string? defaultValue = null)
 		{
 			if (!properties.TryGetValue (EnsureName (propertyName), out string value))
 				return defaultValue;
@@ -30,7 +30,7 @@ namespace Xamarin.Android.Prepare
 
 		public string GetRequiredValue (string propertyName)
 		{
-			string value = GetValue (propertyName);
+			string? value = GetValue (propertyName);
 			if (value == null)
 				throw new InvalidOperationException ($"Required property '{propertyName}' has no defined value");
 			return value;
@@ -41,7 +41,7 @@ namespace Xamarin.Android.Prepare
 			if (String.IsNullOrEmpty (name))
 				throw new ArgumentException ("must not be null or empty", nameof (name));
 
-			if (!properties.TryGetValue (name, out string oldValue))
+			if (!properties.TryGetValue (name, out string? oldValue))
 				oldValue = null;
 
 			string newValue = value ?? String.Empty;
@@ -66,7 +66,7 @@ namespace Xamarin.Android.Prepare
 			return (properties as IEnumerable).GetEnumerator ();
 		}
 
-		void OnPropertiesChanged (string name, string newValue, string oldValue)
+		void OnPropertiesChanged (string name, string newValue, string? oldValue)
 		{
 			if (PropertiesChanged == null)
 				return;

--- a/build-tools/xaprepare/xaprepare/Application/PropertiesChangedEventArgs.cs
+++ b/build-tools/xaprepare/xaprepare/Application/PropertiesChangedEventArgs.cs
@@ -6,9 +6,9 @@ namespace Xamarin.Android.Prepare
 	{
 		public string Name { get; }
 		public string NewValue { get; }
-		public string OldValue { get; }
+		public string? OldValue { get; }
 
-		public PropertiesChangedEventArgs (string name, string newValue, string oldValue)
+		public PropertiesChangedEventArgs (string name, string newValue, string? oldValue)
 		{
 			if (String.IsNullOrEmpty (name))
 				throw new ArgumentException ("must not be null or empty", nameof (name));

--- a/build-tools/xaprepare/xaprepare/Application/RegexProgramVersionParser.cs
+++ b/build-tools/xaprepare/xaprepare/Application/RegexProgramVersionParser.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Android.Prepare
 
 	    Regex rx;
 
-	    public RegexProgramVersionParser (string programName, string versionArguments, Regex regex, uint versionOutputLine = 0, Log log = null)
+	    public RegexProgramVersionParser (string programName, string versionArguments, Regex regex, uint versionOutputLine = 0, Log? log = null)
 		    : base (programName, versionArguments, versionOutputLine, log)
 	    {
 		    if (regex == null)
@@ -27,7 +27,7 @@ namespace Xamarin.Android.Prepare
 		    rx = regex;
 	    }
 
-	    public RegexProgramVersionParser (string programName, string versionArguments, string regex, uint versionOutputLine = 0, Log log = null)
+	    public RegexProgramVersionParser (string programName, string versionArguments, string regex, uint versionOutputLine = 0, Log? log = null)
 		    : base (programName, versionArguments, versionOutputLine, log)
 	    {
 		    if (String.IsNullOrEmpty (regex))
@@ -38,13 +38,13 @@ namespace Xamarin.Android.Prepare
 
         protected override string ParseVersion (string programOutput)
         {
-	        string output = programOutput?.Trim ();
+	        string output = programOutput.Trim ();
 	        if (String.IsNullOrEmpty (output)) {
 		        Log.WarningLine ($"Unable to parse version of {ProgramName} because version output was empty");
 		        return DefaultVersionString;
 	        }
 
-	        string ret = null;
+	        string ret = String.Empty;
 	        string[] lines = programOutput.Split (LineSeparator);
 	        if (VersionOutputLine > 0) {
 		        if (lines.Length < VersionOutputLine) {
@@ -52,7 +52,7 @@ namespace Xamarin.Android.Prepare
 			        return DefaultVersionString;
 		        }
 
-		        if (TryMatch (lines [VersionOutputLine - 1], out ret) && ret != null) {
+		        if (TryMatch (lines [VersionOutputLine - 1], out ret) && !String.IsNullOrEmpty (ret)) {
 			        return ret;
 		        }
 
@@ -69,7 +69,7 @@ namespace Xamarin.Android.Prepare
 
 	    bool TryMatch (string line, out string version)
 	    {
-		    version = null;
+		    version = String.Empty;
 
 		    Match match = rx.Match (line);
 		    if (!match.Success || match.Groups.Count <= 0) {

--- a/build-tools/xaprepare/xaprepare/Application/Runtime.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Runtime.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Android.Prepare
 
 		protected Context Context => Context.Instance;
 		public bool Enabled       => SupportedOnHostOS && enabledCheck (Context);
-		public string ExeSuffix   { get; protected set; }
+		public string ExeSuffix   { get; protected set; } = String.Empty;
 
 		/// <summary>
 		///   Path relative to <see cref="Configurables.Paths.InstallMSBuildDir"/> where the runtime will be placed or
@@ -21,7 +21,7 @@ namespace Xamarin.Android.Prepare
 		///   each case the runtime <see cref="Name"/> will be appended to create full path to the destination
 		///   directory.
 		/// </summary>
-		public string InstallPath { get; protected set; }
+		public string InstallPath { get; protected set; } = String.Empty;
 		public string Name        { get; protected set; }
 
 		/// <summary>
@@ -32,7 +32,7 @@ namespace Xamarin.Android.Prepare
 		/// <summary>
 		///   Prefix to <see cref="Name"/> used by MonoSDKs to construct the runtime output directory.
 		/// </summary>
-		protected string MonoSdksPrefix { get; set; }
+		protected string MonoSdksPrefix { get; set; } = String.Empty;
 
 		/// <summary>
 		///   Host runtimes need a prefix in order to match Mono SDKs output directory name for them. This property is

--- a/build-tools/xaprepare/xaprepare/Application/RuntimeFile.cs
+++ b/build-tools/xaprepare/xaprepare/Application/RuntimeFile.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Android.Prepare
 		/// <summary>
 		///   An optional check on whether or not the file should be installed for the particular runtime.
 		/// </summary>
-		public Func<Runtime, bool>   ShouldSkip  { get; }
+		public Func<Runtime, bool>?  ShouldSkip  { get; }
 
 		/// <summary>
 		///   Whether or not to strip the binary of debugging symbols after installation.
@@ -38,13 +38,8 @@ namespace Xamarin.Android.Prepare
 
 		public bool AlreadyCopied                { get; set; }
 
-		public RuntimeFile (Func<Runtime, string> sourceCreator, Func<Runtime, string> destinationCreator, Func<Runtime, bool> shouldSkip = null, bool strip = true, RuntimeFileType type = RuntimeFileType.Other, bool shared = false)
+		public RuntimeFile (Func<Runtime, string> sourceCreator, Func<Runtime, string> destinationCreator, Func<Runtime, bool>? shouldSkip = null, bool strip = true, RuntimeFileType type = RuntimeFileType.Other, bool shared = false)
 		{
-			if (sourceCreator == null)
-				throw new ArgumentNullException (nameof (sourceCreator));
-			if (destinationCreator == null)
-				throw new ArgumentNullException (nameof (destinationCreator));
-
 			Source = sourceCreator;
 			Destination = destinationCreator;
 			ShouldSkip = shouldSkip;

--- a/build-tools/xaprepare/xaprepare/Application/Scenario.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Scenario.cs
@@ -8,13 +8,13 @@ namespace Xamarin.Android.Prepare
 	{
 		public string Name        { get; }
 		public string Description { get; }
-		public string LogFilePath { get; protected set; }
+		public string? LogFilePath { get; protected set; }
 		public List<Step> Steps   { get; } = new List<Step> ();
 		public bool NeedsGitSubmodules { get; protected set; }
 		public bool NeedsGitBuildInfo { get; protected set; }
 		public bool NeedsCompilers { get; protected set; }
 
-		protected Scenario (string name, string description, Context context)
+		protected Scenario (string name, string description)
 		{
 			if (String.IsNullOrEmpty (name))
 				throw new ArgumentException ("must not be null or empty", nameof (name));
@@ -24,14 +24,15 @@ namespace Xamarin.Android.Prepare
 			Description = description;
 		}
 
-		public async Task Run (Context context, Log log = null)
+		public async Task Run (Context context, Log? log = null)
 		{
-			Log = log;
+			if (log != null)
+				Log = log;
 			foreach (Step step in Steps) {
 				context.Banner (step.Description ?? step.GetType ().FullName);
 
 				bool success;
-				Exception stepEx = null;
+				Exception? stepEx = null;
 				try {
 					success = await step.Run (context);
 				} catch (Exception ex) {

--- a/build-tools/xaprepare/xaprepare/Application/ScenarioNoScenario.cs
+++ b/build-tools/xaprepare/xaprepare/Application/ScenarioNoScenario.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Xamarin.Android.Prepare
+{
+	class ScenarioNoScenario : Scenario
+	{
+		public ScenarioNoScenario () : base ("ScenarioNoScenario", "No scenario selected")
+		{}
+
+		protected override void AddEndSteps (Context context)
+		{
+			throw new NotImplementedException ();
+		}
+
+		protected override void AddStartSteps (Context context)
+		{
+			throw new NotImplementedException ();
+		}
+
+		protected override void AddSteps (Context context)
+		{
+			throw new NotImplementedException ();
+		}
+	}
+}

--- a/build-tools/xaprepare/xaprepare/Application/ScenarioNoStandardEndSteps.cs
+++ b/build-tools/xaprepare/xaprepare/Application/ScenarioNoStandardEndSteps.cs
@@ -6,8 +6,8 @@ namespace Xamarin.Android.Prepare
 	/// </summary>
 	abstract class ScenarioNoStandardEndSteps : Scenario
 	{
-		protected ScenarioNoStandardEndSteps (string name, string description, Context context)
-			: base (name, description, context)
+		protected ScenarioNoStandardEndSteps (string name, string description)
+			: base (name, description)
 		{}
 
 		protected override void AddEndSteps (Context context)

--- a/build-tools/xaprepare/xaprepare/Application/Step.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Step.cs
@@ -8,12 +8,12 @@ namespace Xamarin.Android.Prepare
 {
 	abstract class Step : AppObject
 	{
-		List<Step> failureSteps;
+		List<Step>? failureSteps;
 
 		bool HasFailureSteps => failureSteps != null && failureSteps.Any (s => s != null);
 
 		public string Description { get; }
-		public Step FailedStep { get; private set; }
+		public Step? FailedStep { get; private set; }
 		public bool ExecutedFailureSteps { get; private set; }
 
 		protected Step (string description)
@@ -46,7 +46,7 @@ namespace Xamarin.Android.Prepare
 			if (!HasFailureSteps)
 				return false;
 
-			foreach (Step step in failureSteps) {
+			foreach (Step step in failureSteps!) {
 				ExecutedFailureSteps = true;
 				context.Banner (step.Description);
 				try {

--- a/build-tools/xaprepare/xaprepare/Application/StepWithDownloadProgress.cs
+++ b/build-tools/xaprepare/xaprepare/Application/StepWithDownloadProgress.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Android.Prepare
 				LogStatus ($"downloading {fileName} ", 4, ConsoleColor.Gray);
 
 			bool success;
-			Exception downloadEx = null;
+			Exception? downloadEx = null;
 			try {
 				Log.DebugLine ("About to start downloading");
 				success = await Utilities.Download (url, destinationFilePath, downloadStatus);

--- a/build-tools/xaprepare/xaprepare/Application/ThirdPartyNoticeGroup.cs
+++ b/build-tools/xaprepare/xaprepare/Application/ThirdPartyNoticeGroup.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Android.Prepare
 		static readonly Uri url            = new Uri ("http://not.an/item");
 
 		public override string LicenseText => "not a license item";
-		public override string LicenseFile => null;
+		public override string LicenseFile => String.Empty;
 		public override string Name        => "license item group";
 		public override Uri    SourceUrl   => url;
 

--- a/build-tools/xaprepare/xaprepare/Application/ThumbTwiddler.cs
+++ b/build-tools/xaprepare/xaprepare/Application/ThumbTwiddler.cs
@@ -42,9 +42,9 @@ namespace Xamarin.Android.Prepare
 		readonly bool showElapsedTime;
 
 		int twiddleIndex;
-		Timer twiddleTimer;
-		Stopwatch watch;
-		Random random;
+		Timer? twiddleTimer;
+		Stopwatch? watch;
+		Random? random;
 
 		public ThumbTwiddler (Context context, bool dullMode, bool showElapsedTime)
 		{
@@ -61,7 +61,7 @@ namespace Xamarin.Android.Prepare
 			}
 
 			if (!dullMode)
-				twiddleInterval = 1000 / twiddler.Length;
+				twiddleInterval = 1000 / twiddler!.Length;
 			else {
 				random = new Random ();
 				twiddleInterval = 10000;
@@ -102,7 +102,7 @@ namespace Xamarin.Android.Prepare
 		void Twiddle (object state)
 		{
 			if (dullMode) {
-				string wittyMessage = alternateTwiddlerMessages[random.Next (0, alternateTwiddlerMessages.Count - 1)];
+				string wittyMessage = alternateTwiddlerMessages[random!.Next (0, alternateTwiddlerMessages.Count - 1)];
 				Log.StatusLine ($"{wittyMessage}... {GetElapsedTime ()}", ConsoleColor.Gray, skipLogFile: true);
 				return;
 			}

--- a/build-tools/xaprepare/xaprepare/Application/Utilities.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Utilities.Unix.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Android.Prepare
 		/// </summary>
 		public static bool FileExists (string path)
 		{
-			if (!File.Exists (path))
+			if (path.Length == 0 || !File.Exists (path))
 				return false;
 
 			if (FileIsDanglingSymlink (path)) {

--- a/build-tools/xaprepare/xaprepare/Application/Utilities.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Utilities.cs
@@ -39,14 +39,17 @@ namespace Xamarin.Android.Prepare
 
 			var oldAbis = new HashSet<string> (StringComparer.Ordinal);
 			foreach (string l in File.ReadAllLines (cacheFile)) {
-				string line = l?.Trim ();
+				string line = l.Trim ();
 				if (String.IsNullOrEmpty (line) || oldAbis.Contains (line))
 					continue;
 				oldAbis.Add (line);
 			}
 
-			HashSet<string> currentAbis = null;
+			HashSet<string>? currentAbis = null;
 			FillCurrentAbis (context, ref currentAbis);
+
+			if (currentAbis == null)
+				return false;
 
 			if (oldAbis.Count != currentAbis.Count)
 				return true;
@@ -61,7 +64,7 @@ namespace Xamarin.Android.Prepare
 
 		public static void SaveAbiChoice (Context context)
 		{
-			HashSet<string> currentAbis = null;
+			HashSet<string>? currentAbis = null;
 			FillCurrentAbis (context, ref currentAbis);
 
 			string cacheFile = Configurables.Paths.MonoRuntimesEnabledAbisCachePath;
@@ -69,7 +72,7 @@ namespace Xamarin.Android.Prepare
 			File.WriteAllLines (cacheFile, currentAbis);
 		}
 
-		static void FillCurrentAbis (Context context, ref HashSet<string> currentAbis)
+		static void FillCurrentAbis (Context context, ref HashSet<string>? currentAbis)
 		{
 			Utilities.AddAbis (context.Properties.GetRequiredValue (KnownProperties.AndroidSupportedTargetJitAbis).Trim (), ref currentAbis);
 			Utilities.AddAbis (context.Properties.GetRequiredValue (KnownProperties.AndroidSupportedTargetAotAbis).Trim (), ref currentAbis);
@@ -148,7 +151,7 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		public static void AddAbis (string abis, ref HashSet <string> collection, bool warnAboutDuplicates = true)
+		public static void AddAbis (string abis, ref HashSet <string>? collection, bool warnAboutDuplicates = true)
 		{
 			if (collection == null)
 				collection = new HashSet <string> (StringComparer.OrdinalIgnoreCase);
@@ -241,7 +244,7 @@ namespace Xamarin.Android.Prepare
 					return (IsValidVersion (), version);
 			}
 
-			return (false, null);
+			return (false, String.Empty);
 
 			bool IsValidVersion ()
 			{
@@ -266,7 +269,7 @@ namespace Xamarin.Android.Prepare
 			}
 
 			Log.DebugLine ("Fetcher not found");
-			return (false, null);
+			return (false, String.Empty);
 		}
 
 		public static void DeleteDirectory (string directoryPath, bool ignoreErrors = false, bool recurse = true)
@@ -352,7 +355,7 @@ namespace Xamarin.Android.Prepare
 
 			CreateDirectory (destinationDirectory);
 			foreach (string src in sourceFiles) {
-				CopyFileInternal (src, destinationDirectory, destinationFileName: null, overwriteDestinationFile: overwriteDestinationFile);
+				CopyFileInternal (src, destinationDirectory, destinationFileName: String.Empty, overwriteDestinationFile: overwriteDestinationFile);
 			}
 		}
 
@@ -366,7 +369,7 @@ namespace Xamarin.Android.Prepare
 			CopyFileInternal (sourceFilePath, Path.GetDirectoryName (destinationFilePath), Path.GetFileName (destinationFilePath), overwriteDestinationFile);
 		}
 
-		public static void CopyFileToDir (string sourceFilePath, string destinationDirectory, string destinationFileName = null, bool overwriteDestinationFile = true)
+		public static void CopyFileToDir (string sourceFilePath, string destinationDirectory, string? destinationFileName = null, bool overwriteDestinationFile = true)
 		{
 			if (String.IsNullOrEmpty (sourceFilePath))
 				throw new ArgumentException ("must not be null or empty", nameof (sourceFilePath));
@@ -374,7 +377,7 @@ namespace Xamarin.Android.Prepare
 				throw new ArgumentException ("must not be null or empty", nameof (destinationDirectory));
 
 			CreateDirectory (destinationDirectory);
-			CopyFileInternal (sourceFilePath, destinationDirectory, destinationFileName, overwriteDestinationFile);
+			CopyFileInternal (sourceFilePath, destinationDirectory, destinationFileName ?? String.Empty, overwriteDestinationFile);
 		}
 
 		static void CopyFileInternal (string sourceFilePath, string destinationDirectory, string destinationFileName, bool overwriteDestinationFile)
@@ -563,7 +566,7 @@ namespace Xamarin.Android.Prepare
 
 			Log.DebugLine ($"Resetting timestamp of {filePath}");
 			TimeSpan delay = IOExceptionRetryInitialDelay;
-			Exception ex = null;
+			Exception? ex = null;
 
 			for (int i = 0; i < IOExceptionRetries; i++) {
 				try {
@@ -589,7 +592,7 @@ namespace Xamarin.Android.Prepare
 		public static void MoveFileWithRetry (string source, string destination, bool resetFileTimestamp = false)
 		{
 			TimeSpan delay = IOExceptionRetryInitialDelay;
-			Exception ex = null;
+			Exception? ex = null;
 
 			Log.DebugLine ($"Moving '{source}' to '{destination}'");
 			for (int i = 0; i < IOExceptionRetries; i++) {
@@ -625,7 +628,7 @@ namespace Xamarin.Android.Prepare
 		public static void DeleteDirectoryWithRetry (string directoryPath, bool recursive)
 		{
 			TimeSpan delay = IOExceptionRetryInitialDelay;
-			Exception ex = null;
+			Exception? ex = null;
 			bool tryResetFilePermissions = false;
 
 			for (int i = 0; i < IOExceptionRetries; i++) {
@@ -661,7 +664,7 @@ namespace Xamarin.Android.Prepare
 			delay = TimeSpan.FromMilliseconds (delay.TotalMilliseconds * 2);
 		}
 
-		public static List<Type> GetTypesWithCustomAttribute<T> (Assembly assembly = null) where T: System.Attribute
+		public static List<Type> GetTypesWithCustomAttribute<T> (Assembly? assembly = null) where T: System.Attribute
 		{
 			Assembly asm = assembly ?? typeof (Utilities).Assembly;
 
@@ -676,7 +679,7 @@ namespace Xamarin.Android.Prepare
 			return types;
 		}
 
-		public static StreamWriter OpenStreamWriter (string outputPath, bool append = false, Encoding encoding = null)
+		public static StreamWriter OpenStreamWriter (string outputPath, bool append = false, Encoding? encoding = null)
 		{
 			return new StreamWriter (OpenFileForWrite (outputPath, append), encoding ?? UTF8NoBOM);
 		}
@@ -710,7 +713,7 @@ namespace Xamarin.Android.Prepare
 			return RunCommand (command, workingDirectory, echoStderr: true, ignoreEmptyArguments: ignoreEmptyArguments, arguments: arguments);
 		}
 
-		public static bool RunCommand (string command, string workingDirectory, bool echoStderr, bool ignoreEmptyArguments, params string[] arguments)
+		public static bool RunCommand (string command, string? workingDirectory, bool echoStderr, bool ignoreEmptyArguments, params string[] arguments)
 		{
 			if (String.IsNullOrEmpty (command))
 				throw new ArgumentException ("must not be null or empty", nameof (command));
@@ -723,22 +726,22 @@ namespace Xamarin.Android.Prepare
 			return runner.Run ();
 		}
 
-		public static string GetStringFromStdout (string command, params string[] arguments)
+		public static string GetStringFromStdout (string command, params string?[] arguments)
 		{
 			return GetStringFromStdout (command, throwOnErrors: false, trimTrailingWhitespace: true, arguments: arguments);
 		}
 
-		public static string GetStringFromStdout (string command, bool throwOnErrors, params string[] arguments)
+		public static string GetStringFromStdout (string command, bool throwOnErrors, params string?[] arguments)
 		{
 			return GetStringFromStdout (command, throwOnErrors, trimTrailingWhitespace: true, arguments: arguments);
 		}
 
-		public static string GetStringFromStdout (string command, bool throwOnErrors, bool trimTrailingWhitespace, params string[] arguments)
+		public static string GetStringFromStdout (string command, bool throwOnErrors, bool trimTrailingWhitespace, params string?[] arguments)
 		{
 			return GetStringFromStdout (new ProcessRunner (command, arguments), throwOnErrors, trimTrailingWhitespace);
 		}
 
-		public static string GetStringFromStdout (string command, bool throwOnErrors, bool trimTrailingWhitespace, bool quietErrors, params string[] arguments)
+		public static string GetStringFromStdout (string command, bool throwOnErrors, bool trimTrailingWhitespace, bool quietErrors, params string?[] arguments)
 		{
 			return GetStringFromStdout (new ProcessRunner (command, arguments), throwOnErrors, trimTrailingWhitespace, quietErrors);
 		}
@@ -749,12 +752,12 @@ namespace Xamarin.Android.Prepare
 				runner.AddStandardOutputSink (sw);
 				if (!runner.Run ()) {
 					LogError ("did not exit cleanly");
-					return null;
+					return String.Empty;
 				}
 
 				if (runner.ExitCode != 0) {
 					LogError ($"failed with exit code {runner.ExitCode}");
-					return null;
+					return String.Empty;
 				}
 
 				string ret = sw.ToString ();

--- a/build-tools/xaprepare/xaprepare/Application/VersionFetchers.cs
+++ b/build-tools/xaprepare/xaprepare/Application/VersionFetchers.cs
@@ -9,34 +9,49 @@ namespace Xamarin.Android.Prepare
 		const string StandardVersionRegex = "(?<Version>(\\d+)\\.(\\d+\\.?)(\\d+\\.)?(\\d+)?)";
 		const string JavaVersionRegex = "(?<Version>(\\d+)\\.(\\d+)\\.(\\d+)_(\\d+))";
 
+		static readonly object fetchers_lock = new object();
 		static readonly Regex StandardVersionAtEOL = MakeRegex ($" {StandardVersionRegex}"); // $ isn't needed, we match
 																							 // line by line
 		static readonly Regex StandardVersionAtBOL = MakeRegex ($"^{StandardVersionRegex}");
 
-		public readonly Dictionary<string, ProgramVersionParser> Fetchers = new Dictionary <string, ProgramVersionParser> (Context.Instance.OS.DefaultStringComparer) {
-			{"7z",       "--help",    MakeRegex ($"Version {StandardVersionRegex}"),   3},
-			{"7za",      "--help",    MakeRegex ($"Version {StandardVersionRegex}"),   3},
-			{"autoconf", "--version", StandardVersionAtEOL,                            1},
-			{"automake", "--version", StandardVersionAtEOL,                            1},
-			{"brew",     "--version", MakeRegex ($"^Homebrew {StandardVersionRegex}"), 1},
-			{"cmake",    "--version", StandardVersionAtEOL,                            1},
-			{"curl",     "--version", MakeRegex ($"^curl {StandardVersionRegex}"),     1},
-			{"g++",      "--version", StandardVersionAtEOL,                            1},
-			{"gcc",      "--version", StandardVersionAtEOL,                            1},
-			{"git",      "--version", StandardVersionAtEOL,                            1},
-			{"gmake",    "--version", StandardVersionAtEOL,                            1},
-			{"java",     "-version",  MakeRegex ($" \"{JavaVersionRegex}\"$"),         1},
-			{"javac",    "-version",  MakeRegex ($"{JavaVersionRegex}$"),              1},
-			{"libtool",  "--version", StandardVersionAtEOL,                            1},
-			{"make",     "--version", StandardVersionAtEOL,                            1},
-			{"mono",     "--version", MakeRegex ($"version {StandardVersionRegex}"),   1},
-			{"ninja",    "--version", MakeRegex (StandardVersionRegex),                1},
-			{"sqlite3",  "--version", StandardVersionAtBOL,                            1},
-		};
+		static Dictionary <string, ProgramVersionParser>? fetchers;
+
+		public Dictionary<string, ProgramVersionParser> Fetchers => GetFetchers ();
 
 		static Regex MakeRegex (string regex)
 		{
 			return new Regex (regex, RegexOptions.Compiled | RegexOptions.Singleline);
+		}
+
+		static Dictionary <string, ProgramVersionParser> GetFetchers ()
+		{
+			lock (fetchers_lock) {
+				if (fetchers != null)
+					return fetchers;
+
+				fetchers = new Dictionary <string, ProgramVersionParser> (Context.Instance.OS.DefaultStringComparer) {
+					{"7z",       "--help",    MakeRegex ($"Version {StandardVersionRegex}"),   3},
+					{"7za",      "--help",    MakeRegex ($"Version {StandardVersionRegex}"),   3},
+					{"autoconf", "--version", StandardVersionAtEOL,                            1},
+					{"automake", "--version", StandardVersionAtEOL,                            1},
+					{"brew",     "--version", MakeRegex ($"^Homebrew {StandardVersionRegex}"), 1},
+					{"cmake",    "--version", StandardVersionAtEOL,                            1},
+					{"curl",     "--version", MakeRegex ($"^curl {StandardVersionRegex}"),     1},
+					{"g++",      "--version", StandardVersionAtEOL,                            1},
+					{"gcc",      "--version", StandardVersionAtEOL,                            1},
+					{"git",      "--version", StandardVersionAtEOL,                            1},
+					{"gmake",    "--version", StandardVersionAtEOL,                            1},
+					{"java",     "-version",  MakeRegex ($" \"{JavaVersionRegex}\"$"),         1},
+					{"javac",    "-version",  MakeRegex ($"{JavaVersionRegex}$"),              1},
+					{"libtool",  "--version", StandardVersionAtEOL,                            1},
+					{"make",     "--version", StandardVersionAtEOL,                            1},
+					{"mono",     "--version", MakeRegex ($"version {StandardVersionRegex}"),   1},
+					{"ninja",    "--version", MakeRegex (StandardVersionRegex),                1},
+					{"sqlite3",  "--version", StandardVersionAtBOL,                            1},
+				};
+
+				return fetchers;
+			}
 		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/AbiNames.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/AbiNames.cs
@@ -5,7 +5,7 @@ namespace Xamarin.Android.Prepare
 {
 	static class AbiNames
 	{
-		static HashSet <string> allHostAbis;
+		static HashSet <string>? allHostAbis;
 
 		public static class TargetJit
 		{

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.Unix.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Android.Prepare
 
 			public static readonly string MonoRuntimeHostMingwNativeLibraryPrefix = Path.Combine ("..", "bin");
 
-			static string hostRuntimeDir;
+			static string? hostRuntimeDir;
 		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -353,56 +353,56 @@ namespace Xamarin.Android.Prepare
 				return androidToolchainBinDirectory;
 			}
 
-			static string GetCachedPath (ref string variable, Func<string> creator)
+			static string GetCachedPath (ref string? variable, Func<string> creator)
 			{
 				if (!String.IsNullOrEmpty (variable))
-					return variable;
+					return variable!;
 
 				variable = Path.GetFullPath (creator ());
 				return variable;
 			}
 
-			static string testBinDir;
-			static string buildBinDir;
-			static string mingwBinDir;
-			static string binDir;
-			static string netCoreBinDir;
-			static string monoSDKsOutputDir;
-			static string androidToolchainBinDirectory;
-			static string monoProfileDir;
-			static string monoProfileToolsDir;
-			static string bclTestsDestDir;
-			static string bclTestsArchivePath;
-			static string bclFacadeAssembliesSourceDir;
-			static string bclWindowsOutputDir;
-			static string bclWindowsAssembliesSourceDir;
-			static string bclWindowsFacadeAssembliesSourceDir;
-			static string installBCLFrameworkDir;
-			static string installBCLFrameworkFacadesDir;
-			static string installBCLFrameworkRedistListDir;
-			static string installMSBuildDir;
-			static string outputIncludeDir;
-			static string mingw32CmakePath;
-			static string mingw64CmakePath;
-			static string mingw32CmakeTemplatePath;
-			static string mingw64CmakeTemplatePath;
-			static string monoRuntimesEnabledAbisCachePath;
-			static string frameworkListInstallPath;
-			static string correttoCacheDir;
-			static string correttoInstallDir;
-			static string profileAssembliesProjitemsPath;
-			static string bclTestsSourceDir;
-			static string installHostBCLDir;
-			static string installHostBCLFacadesDir;
-			static string installWindowsBCLDir;
-			static string installWindowsBCLFacadesDir;
-			static string installBCLDesignerDir;
-			static string monoAndroidFrameworksRootDir;
-			static string externalJavaInteropDir;
-			static string monoSdksTpnPath;
-			static string monoSdksTpnExternalPath;
-			static string monoSDKSIncludeDestDir;
-			static string monoLlvmTpnPath;
+			static string? testBinDir;
+			static string? buildBinDir;
+			static string? mingwBinDir;
+			static string? binDir;
+			static string? netCoreBinDir;
+			static string? monoSDKsOutputDir;
+			static string? androidToolchainBinDirectory;
+			static string? monoProfileDir;
+			static string? monoProfileToolsDir;
+			static string? bclTestsDestDir;
+			static string? bclTestsArchivePath;
+			static string? bclFacadeAssembliesSourceDir;
+			static string? bclWindowsOutputDir;
+			static string? bclWindowsAssembliesSourceDir;
+			static string? bclWindowsFacadeAssembliesSourceDir;
+			static string? installBCLFrameworkDir;
+			static string? installBCLFrameworkFacadesDir;
+			static string? installBCLFrameworkRedistListDir;
+			static string? installMSBuildDir;
+			static string? outputIncludeDir;
+			static string? mingw32CmakePath;
+			static string? mingw64CmakePath;
+			static string? mingw32CmakeTemplatePath;
+			static string? mingw64CmakeTemplatePath;
+			static string? monoRuntimesEnabledAbisCachePath;
+			static string? frameworkListInstallPath;
+			static string? correttoCacheDir;
+			static string? correttoInstallDir;
+			static string? profileAssembliesProjitemsPath;
+			static string? bclTestsSourceDir;
+			static string? installHostBCLDir;
+			static string? installHostBCLFacadesDir;
+			static string? installWindowsBCLDir;
+			static string? installWindowsBCLFacadesDir;
+			static string? installBCLDesignerDir;
+			static string? monoAndroidFrameworksRootDir;
+			static string? externalJavaInteropDir;
+			static string? monoSdksTpnPath;
+			static string? monoSdksTpnExternalPath;
+			static string? monoSDKSIncludeDestDir;
+			static string? monoLlvmTpnPath;
 		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Dependencies/AndroidToolchain.cs
@@ -56,10 +56,10 @@ namespace Xamarin.Android.Prepare
 
 		static string GetRequiredProperty (string propertyName)
 		{
-			string value = Context.Instance.Properties [propertyName];
+			string? value = Context.Instance.Properties [propertyName];
 			if (String.IsNullOrEmpty (value))
 				throw new InvalidOperationException ($"Required property '{propertyName}' not defined");
-			return value;
+			return value!;
 		}
 	}
 }

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Runtimes.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Runtimes.cs
@@ -806,7 +806,7 @@ namespace Xamarin.Android.Prepare
 			new RuntimeFile (
 				sourceCreator: (Runtime runtime) => GetProfilerOutputSourcePath (runtime),
 				destinationCreator: (Runtime runtime) => GetProfilerOutputDestinationPath (runtime, debug: false),
-				shouldSkip: (Runtime runtime) => !IsHostOrTargetRuntime (runtime) || String.IsNullOrEmpty (runtime.As<MonoRuntime>().OutputProfilerFilename),
+				shouldSkip: (Runtime runtime) => !IsHostOrTargetRuntime (runtime) || String.IsNullOrEmpty (runtime.As<MonoRuntime>()?.OutputProfilerFilename),
 				type: RuntimeFileType.StrippableBinary
 			),
 
@@ -814,7 +814,7 @@ namespace Xamarin.Android.Prepare
 			new RuntimeFile (
 				sourceCreator: (Runtime runtime) => GetProfilerOutputSourcePath (runtime),
 				destinationCreator: (Runtime runtime) => GetProfilerOutputDestinationPath (runtime, debug: true),
-				shouldSkip: (Runtime runtime) => !IsHostOrTargetRuntime (runtime) || String.IsNullOrEmpty (runtime.As<MonoRuntime>().OutputProfilerFilename),
+				shouldSkip: (Runtime runtime) => !IsHostOrTargetRuntime (runtime) || String.IsNullOrEmpty (runtime.As<MonoRuntime>()?.OutputProfilerFilename),
 				type: RuntimeFileType.StrippableBinary,
 				strip: false
 			),
@@ -823,7 +823,7 @@ namespace Xamarin.Android.Prepare
 			new RuntimeFile (
 				sourceCreator: (Runtime runtime) => GetAotProfilerOutputSourcePath (runtime),
 				destinationCreator: (Runtime runtime) => GetAotProfilerOutputDestinationPath (runtime, debug: false),
-				shouldSkip: (Runtime runtime) => !IsHostOrTargetRuntime (runtime) || String.IsNullOrEmpty (runtime.As<MonoRuntime>().OutputAotProfilerFilename),
+				shouldSkip: (Runtime runtime) => !IsHostOrTargetRuntime (runtime) || String.IsNullOrEmpty (runtime.As<MonoRuntime>()?.OutputAotProfilerFilename),
 				type: RuntimeFileType.StrippableBinary
 			),
 
@@ -831,7 +831,7 @@ namespace Xamarin.Android.Prepare
 			new RuntimeFile (
 				sourceCreator: (Runtime runtime) => GetAotProfilerOutputSourcePath (runtime),
 				destinationCreator: (Runtime runtime) => GetAotProfilerOutputDestinationPath (runtime, debug: true),
-				shouldSkip: (Runtime runtime) => !IsHostOrTargetRuntime (runtime) || String.IsNullOrEmpty (runtime.As<MonoRuntime>().OutputAotProfilerFilename),
+				shouldSkip: (Runtime runtime) => !IsHostOrTargetRuntime (runtime) || String.IsNullOrEmpty (runtime.As<MonoRuntime>()?.OutputAotProfilerFilename),
 				type: RuntimeFileType.StrippableBinary,
 				strip: false
 			),
@@ -840,7 +840,7 @@ namespace Xamarin.Android.Prepare
 			new RuntimeFile (
 				sourceCreator: (Runtime runtime) => GetMonoBtlsOutputSourcePath (runtime),
 				destinationCreator: (Runtime runtime) => GetMonoBtlsOutputDestinationPath (runtime, debug: false),
-				shouldSkip: (Runtime runtime) => !IsHostOrTargetRuntime (runtime) || String.IsNullOrEmpty (runtime.As<MonoRuntime>().OutputMonoBtlsFilename),
+				shouldSkip: (Runtime runtime) => !IsHostOrTargetRuntime (runtime) || String.IsNullOrEmpty (runtime.As<MonoRuntime>()?.OutputMonoBtlsFilename),
 				type: RuntimeFileType.StrippableBinary
 			),
 
@@ -848,7 +848,7 @@ namespace Xamarin.Android.Prepare
 			new RuntimeFile (
 				sourceCreator: (Runtime runtime) => GetMonoBtlsOutputSourcePath (runtime),
 				destinationCreator: (Runtime runtime) => GetMonoBtlsOutputDestinationPath (runtime, debug: true),
-				shouldSkip: (Runtime runtime) => !IsHostOrTargetRuntime (runtime) || String.IsNullOrEmpty (runtime.As<MonoRuntime>().OutputMonoBtlsFilename),
+				shouldSkip: (Runtime runtime) => !IsHostOrTargetRuntime (runtime) || String.IsNullOrEmpty (runtime.As<MonoRuntime>()?.OutputMonoBtlsFilename),
 				type: RuntimeFileType.StrippableBinary,
 				strip: false
 			),
@@ -857,7 +857,7 @@ namespace Xamarin.Android.Prepare
 			new RuntimeFile (
 				sourceCreator: (Runtime runtime) => GetMonoPosixHelperOutputSourcePath (runtime),
 				destinationCreator: (Runtime runtime) => GetMonoPosixHelperOutputDestinationPath (runtime, debug: false),
-				shouldSkip: (Runtime runtime) => !IsHostOrTargetRuntime (runtime) || String.IsNullOrEmpty (runtime.As<MonoRuntime>().OutputMonoPosixHelperFilename),
+				shouldSkip: (Runtime runtime) => !IsHostOrTargetRuntime (runtime) || String.IsNullOrEmpty (runtime.As<MonoRuntime>()?.OutputMonoPosixHelperFilename),
 				type: RuntimeFileType.StrippableBinary
 			),
 
@@ -865,24 +865,24 @@ namespace Xamarin.Android.Prepare
 			new RuntimeFile (
 				sourceCreator: (Runtime runtime) => GetMonoPosixHelperOutputSourcePath (runtime),
 				destinationCreator: (Runtime runtime) => GetMonoPosixHelperOutputDestinationPath (runtime, debug: true),
-				shouldSkip: (Runtime runtime) => !IsHostOrTargetRuntime (runtime) || String.IsNullOrEmpty (runtime.As<MonoRuntime>().OutputMonoPosixHelperFilename),
+				shouldSkip: (Runtime runtime) => !IsHostOrTargetRuntime (runtime) || String.IsNullOrEmpty (runtime.As<MonoRuntime>()?.OutputMonoPosixHelperFilename),
 				type: RuntimeFileType.StrippableBinary,
 				strip: false
 			),
 
 			// LLVM opt
 			new RuntimeFile (
-				sourceCreator: (Runtime runtime) => Path.Combine (GetLlvmOutputSourcePath(runtime), $"opt{runtime.As<LlvmRuntime>().ExeSuffix}"),
-				destinationCreator: (Runtime runtime) => Path.Combine (GetLlvmOutputDestinationPath (runtime), $"opt{runtime.As<LlvmRuntime>().ExeSuffix}"),
-				shouldSkip: (Runtime runtime) => !IsRuntimeType<LlvmRuntime> (runtime) || !runtime.As<LlvmRuntime>().InstallBinaries || (Context.IsWindows && !IsWindowsRuntime (runtime)),
+				sourceCreator: (Runtime runtime) => Path.Combine (GetLlvmOutputSourcePath(runtime), $"opt{runtime.As<LlvmRuntime>()?.ExeSuffix}"),
+				destinationCreator: (Runtime runtime) => Path.Combine (GetLlvmOutputDestinationPath (runtime), $"opt{runtime.As<LlvmRuntime>()?.ExeSuffix}"),
+				shouldSkip: (Runtime runtime) => !IsRuntimeType<LlvmRuntime> (runtime) || !runtime.As<LlvmRuntime>()!.InstallBinaries || (Context.IsWindows && !IsWindowsRuntime (runtime)),
 				type: RuntimeFileType.StrippableBinary
 			),
 
 			// LLVM llc
 			new RuntimeFile (
-				sourceCreator: (Runtime runtime) => Path.Combine (GetLlvmOutputSourcePath(runtime), $"llc{runtime.As<LlvmRuntime>().ExeSuffix}"),
-				destinationCreator: (Runtime runtime) => Path.Combine (GetLlvmOutputDestinationPath (runtime), $"llc{runtime.As<LlvmRuntime>().ExeSuffix}"),
-				shouldSkip: (Runtime runtime) => !IsRuntimeType<LlvmRuntime> (runtime) || !runtime.As<LlvmRuntime>().InstallBinaries || (Context.IsWindows && !IsWindowsRuntime (runtime)),
+				sourceCreator: (Runtime runtime) => Path.Combine (GetLlvmOutputSourcePath(runtime), $"llc{runtime.As<LlvmRuntime>()?.ExeSuffix}"),
+				destinationCreator: (Runtime runtime) => Path.Combine (GetLlvmOutputDestinationPath (runtime), $"llc{runtime.As<LlvmRuntime>()?.ExeSuffix}"),
+				shouldSkip: (Runtime runtime) => !IsRuntimeType<LlvmRuntime> (runtime) || !runtime.As<LlvmRuntime>()!.InstallBinaries || (Context.IsWindows && !IsWindowsRuntime (runtime)),
 				type: RuntimeFileType.StrippableBinary
 			)
 		};

--- a/build-tools/xaprepare/xaprepare/Main.cs
+++ b/build-tools/xaprepare/xaprepare/Main.cs
@@ -16,20 +16,20 @@ namespace Xamarin.Android.Prepare
 			public bool DumpProps              { get; set; } = false;
 			public bool NoEmoji                { get; set; } = !Configurables.Defaults.UseEmoji;
 			public bool ForceRuntimesBuild     { get; set; } = false;
-			public string HashAlgorithm        { get; set; } = null;
+			public string? HashAlgorithm       { get; set; }
 			public uint MakeConcurrency        { get; set; } = 0;
 			public ExecutionMode ExecutionMode { get; set; } = Configurables.Defaults.ExecutionMode;
 			public LoggingVerbosity Verbosity  { get; set; } = Configurables.Defaults.LoggingVerbosity;
 			public string DebugFileExtension   { get; set; } = Configurables.Defaults.DebugFileExtension;
-			public string ScenarioName         { get; set; } = null;
+			public string? ScenarioName        { get; set; }
 			public bool ListScenarios          { get; set; } = false;
 			public string CompressionFormat    { get; set; } = Configurables.Defaults.DefaultCompressionFormat.Name;
-			public string Configuration        { get; set; }
+			public string? Configuration       { get; set; }
 			public bool AutoProvision          { get; set; }
 			public bool AutoProvisionUsesSudo  { get; set; }
 			public bool IgnoreMaxMonoVersion   { get; set; }
 			public bool IgnoreMinMonoVersion   { get; set; }
-			public string MonoArchiveCustomUrl { get; set; }
+			public string? MonoArchiveCustomUrl { get; set; }
 			public bool EnableAll              { get; set; }
 			public RefreshableComponent RefreshList { get; set; }
 		}
@@ -92,14 +92,14 @@ namespace Xamarin.Android.Prepare
 				{"r|run-mode=", $"Specify the execution mode: {GetExecutionModes()}. See documentation for mode descriptions. Default: {Configurables.Defaults.ExecutionMode}", v => parsedOptions.ExecutionMode = ParseExecutionMode (v)},
 				{"f|build-runtimes", $"Build runtimes even if the bundle/archives are available.", v => parsedOptions.ForceRuntimesBuild = true },
 				{"H|hash-algorithm=", "Use the specified hash algorithm instead of the default {Configurables.Defaults.HashAlgorithm}", v => parsedOptions.HashAlgorithm = v?.Trim () },
-				{"D|debug-ext=", $"Extension of files with debug information for managed DLLs and executables. Default: {parsedOptions.DebugFileExtension}", v => parsedOptions.DebugFileExtension = v?.Trim () },
+				{"D|debug-ext=", $"Extension of files with debug information for managed DLLs and executables. Default: {parsedOptions.DebugFileExtension}", v => parsedOptions.DebugFileExtension = v?.Trim () ?? String.Empty },
 				{"v|verbosity=", $"Set console log verbosity to {{LEVEL}}. Level name may be abbreviated to the smallest unique part (one of: {GetVerbosityLevels ()}). Default: {Context.Instance.LoggingVerbosity.ToString().ToLowerInvariant ()}", v => parsedOptions.Verbosity = ParseLogVerbosity (v) },
 				{"s|scenario=", "Run the specified scenario (use --ls to list all known scenarios) instead of the default one", v => parsedOptions.ScenarioName = v },
 				{"ls", "List names of all known scenarios", v => parsedOptions.ListScenarios = true },
-				{"cf=", $"{{NAME}} of the compression format to use for some archives (e.g. the XA bundle). One of: {GetCompressionFormatNames ()}; Default: {parsedOptions.CompressionFormat}", v => parsedOptions.CompressionFormat = v?.Trim ()},
+				{"cf=", $"{{NAME}} of the compression format to use for some archives (e.g. the XA bundle). One of: {GetCompressionFormatNames ()}; Default: {parsedOptions.CompressionFormat}", v => parsedOptions.CompressionFormat = v?.Trim () ?? String.Empty},
 				{"c|configuration=", $"Build {{CONFIGURATION}}. Default: {Context.Instance.Configuration}", v => parsedOptions.Configuration = v?.Trim ()},
 				{"a|enable-all", "Enable preparation of all the supported targets, ABIs etc", v => parsedOptions.EnableAll = true},
-				{"refresh:", "[sdk,ndk] Comma separated list of components which should be reinstalled. Defaults to all supported components if no value is provided.", v => parsedOptions.RefreshList = ParseRefreshableComponents (v?.Trim ())},
+				{"refresh:", "[sdk,ndk] Comma separated list of components which should be reinstalled. Defaults to all supported components if no value is provided.", v => parsedOptions.RefreshList = ParseRefreshableComponents (v?.Trim () ?? String.Empty)},
 				"",
 				{"auto-provision=", $"Automatically install software required by Xamarin.Android", v => parsedOptions.AutoProvision = ParseBoolean (v)},
 				{"auto-provision-uses-sudo=", $"Allow use of sudo(1) when provisioning", v => parsedOptions.AutoProvisionUsesSudo = ParseBoolean (v)},
@@ -138,15 +138,15 @@ namespace Xamarin.Android.Prepare
 			Context.Instance.AutoProvisionUsesSudo = parsedOptions.AutoProvisionUsesSudo;
 			Context.Instance.IgnoreMaxMonoVersion  = parsedOptions.IgnoreMaxMonoVersion;
 			Context.Instance.IgnoreMinMonoVersion  = parsedOptions.IgnoreMinMonoVersion;
-			Context.Instance.MonoArchiveCustomUrl  = parsedOptions.MonoArchiveCustomUrl;
+			Context.Instance.MonoArchiveCustomUrl  = parsedOptions.MonoArchiveCustomUrl ?? String.Empty;
 			Context.Instance.EnableAllTargets      = parsedOptions.EnableAll;
 			Context.Instance.ComponentsToRefresh   = parsedOptions.RefreshList;
 
 			if (!String.IsNullOrEmpty (parsedOptions.Configuration))
-				Context.Instance.Configuration = parsedOptions.Configuration;
+				Context.Instance.Configuration = parsedOptions.Configuration!;
 
 			if (!String.IsNullOrEmpty (parsedOptions.HashAlgorithm))
-				Context.Instance.HashAlgorithm = parsedOptions.HashAlgorithm;
+				Context.Instance.HashAlgorithm = parsedOptions.HashAlgorithm!;
 
 			SetCompressionFormat (parsedOptions.CompressionFormat);
 
@@ -288,9 +288,9 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		static bool ParseBoolean (string value)
+		static bool ParseBoolean (string? value)
 		{
-			string v = value?.Trim ();
+			string? v = value?.Trim ();
 			if (String.IsNullOrEmpty (v))
 				throw new ArgumentException ("must not be null or empty", nameof (v));
 

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/Linux.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/Linux.cs
@@ -36,7 +36,7 @@ and re-enable it after building with the following command:
 		};
 
 		bool warnBinFmt;
-		string codeName;
+		string codeName = String.Empty;
 
 		public override string Type { get; } = "Linux";
 		public override List<Program> Dependencies { get; }
@@ -133,7 +133,7 @@ and re-enable it after building with the following command:
 
 			string[] lines = File.ReadAllLines (FlatpakInfoPath);
 			foreach (string l in lines) {
-				string line = l?.Trim ();
+				string line = l.Trim ();
 				if (String.IsNullOrEmpty (line))
 					continue;
 

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/NoOS.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/NoOS.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+
+namespace Xamarin.Android.Prepare
+{
+	class NoOS : OS
+	{
+		public override string Type => throw new NotImplementedException ();
+		public override List<Program> Dependencies => throw new NotImplementedException ();
+		public override string HomeDirectory => throw new NotImplementedException ();
+		public override StringComparison DefaultStringComparison => throw new NotImplementedException ();
+		public override StringComparer DefaultStringComparer => throw new NotImplementedException ();
+		public override bool IsWindows => false;
+		public override bool IsUnix => false;
+		protected override List<string> ExecutableExtensions => throw new NotImplementedException ();
+
+		public NoOS (Context context)
+			: base (context)
+		{}
+
+		public override string GetManagedProgramRunner (string programPath)
+		{
+			throw new NotImplementedException ();
+		}
+
+		protected override string AssertIsExecutable (string fullPath)
+		{
+			throw new NotImplementedException ();
+		}
+
+		protected override void DetectCompilers ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		protected override void InitializeDependencies ()
+		{
+			throw new NotImplementedException ();
+		}
+	}
+}

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/OS.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/OS.cs
@@ -44,88 +44,88 @@ namespace Xamarin.Android.Prepare
 		/// <summary>
 		///   Path to <c>javac</c> (full or relative)
 		/// </summary>
-		public string JavaCPath      { get; set; }
+		public string JavaCPath      { get; set; } = String.Empty;
 
 		/// <summary>
 		///   Path to <c>jar</c> (full or relative)
 		/// </summary>
-		public string JarPath        { get; set; }
+		public string JarPath        { get; set; } = String.Empty;
 
 		/// <summary>
 		///   Path to <c>java</c> (full or relative)
 		/// </summary>
-		public string JavaPath       { get; set; }
+		public string JavaPath       { get; set; } = String.Empty;
 
 		/// <summary>
 		///   Full path to Java home, set via the <c>$(JavaSdkDirectory)</c> MSBuild property or defaults to
 		///   <c>$(AndroidToolchainDirectory)/jdk</c>.
 		/// </summary>
-		public string JavaHome       { get; set; }
+		public string JavaHome       { get; set; } = String.Empty;
 
 		/// <summary>
 		///   Name of the operating system (e.g. Ubuntu, Debian, Arch etc for Linux-based operating systems, Mac OS X, Windows)
 		/// </summary>
-		public string Name           { get; protected set; }
+		public string Name           { get; protected set; } = String.Empty;
 
 		/// <summary>
 		///   OS "flavor" name (i.e. a variation of the OS named <see cref="Name"/>), may be equal to <see cref="Name"/>
 		/// </summary>
-		public string Flavor         { get; protected set; }
+		public string Flavor         { get; protected set; } = String.Empty;
 
 		/// <summary>
 		///   Operating system release version/name
 		/// </summary>
-		public string Release        { get; protected set; }
+		public string Release        { get; protected set; } = String.Empty;
 
 		/// <summary>
 		///   Host system architecture (e.g. x86, x86_64)
 		/// </summary>
-		public string Architecture   { get; protected set; }
+		public string Architecture   { get; protected set; } = String.Empty;
 
 		/// <summary>
 		///   Path to the C compiler to build binaries with the native OS bitness
 		/// </summary>
-		public string CC             { get; set; }
+		public string CC             { get; set; } = String.Empty;
 
 		/// <summary>
 		///   Path to the C compiler to build binaries with 32-bit bitness
 		/// </summary>
-		public string CC32           { get; set; }
+		public string CC32           { get; set; } = String.Empty;
 
 		/// <summary>
 		///   Path to the C compiler to build binaries with 64-bit bitness
 		/// </summary>
-		public string CC64           { get; set; }
+		public string CC64           { get; set; } = String.Empty;
 
 		/// <summary>
 		///   Path to the C++ compiler to build binaries with the native OS bitness
 		/// </summary>
-		public string CXX            { get; set; }
+		public string CXX            { get; set; } = String.Empty;
 
 		/// <summary>
 		///   Path to the C+ compiler to build binaries with 32-bit bitness
 		/// </summary>
-		public string CXX32          { get; set; }
+		public string CXX32          { get; set; } = String.Empty;
 
 		/// <summary>
 		///   Path to the C compiler to build binaries with 64-bit bitness
 		/// </summary>
-		public string CXX64          { get; set; }
+		public string CXX64          { get; set; } = String.Empty;
 
 		/// <summary>
 		///   Default compiler target triple
 		/// </summary>
-		public string Triple         { get; set; }
+		public string Triple         { get; set; } = String.Empty;
 
 		/// <summary>
 		///   32-bit compiler target triple
 		/// </summary>
-		public string Triple32       { get; set; }
+		public string Triple32       { get; set; } = String.Empty;
 
 		/// <summary>
 		///   64-bit compiler target triple
 		/// </summary>
-		public string Triple64       { get; set; }
+		public string Triple64       { get; set; } = String.Empty;
 
 		/// <summary>
 		///   Prefix where Homebrew is installed (relevant only on macOS, but present in all operating system for
@@ -147,7 +147,7 @@ namespace Xamarin.Android.Prepare
 		///   Extensions of executable files as supported by the host OS or <c>null</c> if executable extensions aren't
 		///   used/needed
 		/// </summary>
-		protected abstract List<string> ExecutableExtensions     { get; }
+		protected abstract List<string>? ExecutableExtensions     { get; }
 
 		/// <summary>
 		///   Default string comparison for path comparison
@@ -181,7 +181,7 @@ namespace Xamarin.Android.Prepare
 		/// </summary>
 		protected virtual bool InitOS ()
 		{
-			JavaHome = Context.Instance.Properties.GetValue (KnownProperties.JavaSdkDirectory)?.Trim ();
+			JavaHome = Context.Instance.Properties.GetValue (KnownProperties.JavaSdkDirectory)?.Trim () ?? String.Empty;
 			if (String.IsNullOrEmpty (JavaHome)) {
 				var androidToolchainDirectory = Context.Instance.Properties.GetValue (KnownProperties.AndroidToolchainDirectory)?.Trim ();
 				JavaHome = Path.Combine (androidToolchainDirectory, "jdk");
@@ -213,8 +213,6 @@ namespace Xamarin.Android.Prepare
 
 		protected OS (Context context)
 		{
-			if (context == null)
-				throw new ArgumentNullException (nameof (context));
 			Context = context;
 			EnvironmentVariables = new Dictionary<string, string> (StringComparer.Ordinal);
 		}
@@ -359,7 +357,7 @@ namespace Xamarin.Android.Prepare
 			PopulateEnvironmentVariables ();
 
 			foreach (var kvp in EnvironmentVariables) {
-				string name = kvp.Key?.Trim ();
+				string name = kvp.Key.Trim ();
 				if (String.IsNullOrEmpty (name))
 					continue;
 
@@ -474,14 +472,14 @@ namespace Xamarin.Android.Prepare
 						string fp = $"{programPath}{ext}";
 						if (Utilities.FileExists (fp))
 							return fp;
-						return null;
+						return String.Empty;
 					}
 				);
 
-				if (match == null && Utilities.FileExists (programPath))
+				if (match.Length == 0 && Utilities.FileExists (programPath))
 					match = programPath;
 
-				if (match != null)
+				if (match.Length > 0)
 					return match;
 				else if (required) {
 					goto doneAndOut;
@@ -490,36 +488,35 @@ namespace Xamarin.Android.Prepare
 				return programPath;
 			}
 
-			List<string> extensions = ExecutableExtensions;
 			List<string> directories = GetPathDirectories ();
 			match = GetExecutableWithExtension (programPath, (string ext) => FindProgram ($"{programPath}{ext}", directories));
-			if (match != null)
+			if (match.Length > 0)
 				return AssertIsExecutable (match);
 
 			match = FindProgram ($"{programPath}", directories);
-			if (match != null)
+			if (match.Length > 0)
 				return AssertIsExecutable (match);
 
 		  doneAndOut:
 			if (required)
 				throw new InvalidOperationException ($"Required program '{programPath}' could not be found");
 
-			return null;
+			return String.Empty;
 		}
 
 		string GetExecutableWithExtension (string programPath, Func<string, string> finder)
 		{
-			List<string> extensions = ExecutableExtensions;
+			List<string>? extensions = ExecutableExtensions;
 			if (extensions == null || extensions.Count == 0)
-				return null;
+				return String.Empty;
 
 			foreach (string extension in extensions) {
 				string match = finder (extension);
-				if (match != null)
+				if (match.Length > 0)
 					return match;
 			}
 
-			return null;
+			return String.Empty;
 		}
 
 		protected static string FindProgram (string programName, List<string> directories)
@@ -530,13 +527,13 @@ namespace Xamarin.Android.Prepare
 					return path;
 			}
 
-			return null;
+			return String.Empty;
 		}
 
 		protected static List <string> GetPathDirectories ()
 		{
 			var ret = new List <string> ();
-			string path = Environment.GetEnvironmentVariable ("PATH")?.Trim ();
+			string path = Environment.GetEnvironmentVariable ("PATH")?.Trim () ?? String.Empty;
 			if (String.IsNullOrEmpty (path))
 				return ret;
 

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/Unix.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/Unix.cs
@@ -10,14 +10,14 @@ namespace Xamarin.Android.Prepare
 	{
 		const FilePermissions ExecutableBits = FilePermissions.S_IXUSR | FilePermissions.S_IXGRP | FilePermissions.S_IXOTH;
 
-		protected override List<string> ExecutableExtensions => null;
+		protected override List<string>? ExecutableExtensions => null;
 		public override bool IsWindows => false;
 		public override bool IsUnix => true;
 		public override string HomeDirectory => GetHomeDir ();
 
 		protected Unix (Context context) : base (context)
 		{
-			Architecture = Utilities.GetStringFromStdout ("uname", "-m")?.Trim ();
+			Architecture = Utilities.GetStringFromStdout ("uname", "-m").Trim ();
 		}
 
 		string GetCompiler (string fromEnv, string defaultName)
@@ -29,9 +29,9 @@ namespace Xamarin.Android.Prepare
 
 		protected override void DetectCompilers ()
 		{
-			string cc = Environment.GetEnvironmentVariable ("CC")?.Trim ();
-			string cxx = Environment.GetEnvironmentVariable ("CXX")?.Trim ();
-			string defaultCompiler = null;
+			string cc = Environment.GetEnvironmentVariable ("CC")?.Trim () ?? String.Empty;
+			string cxx = Environment.GetEnvironmentVariable ("CXX")?.Trim () ?? String.Empty;
+			string defaultCompiler = String.Empty;
 
 			if (!String.IsNullOrEmpty (cc)) {
 				Log.DebugLine ($"Unix C compiler read from environment variable CC: {cc}");
@@ -44,8 +44,11 @@ namespace Xamarin.Android.Prepare
 					defaultCompiler = cxx;
 			}
 
-			if (String.IsNullOrEmpty (defaultCompiler))
+			if (String.IsNullOrEmpty (defaultCompiler)) {
 				defaultCompiler = Configurables.Defaults.DefaultCompiler;
+				if (String.IsNullOrEmpty (defaultCompiler))
+					throw new InvalidOperationException ("Default compiler not specified");
+			}
 
 			string ccVersion = Utilities.GetStringFromStdout (defaultCompiler, "--version");
 			if (String.IsNullOrEmpty (ccVersion))
@@ -90,12 +93,12 @@ namespace Xamarin.Android.Prepare
 
 				Triple64 = Triple;
 			} else {
-				CC64 = null;
-				CXX64 = null;
+				CC64 = String.Empty;
+				CXX64 = String.Empty;
 				CC32 = CC;
 				CXX32 =CXX;
 				Triple32 = Triple;
-				Triple64 = null;
+				Triple64 = String.Empty;
 			}
 
 			LogCompilerDetails ();
@@ -110,12 +113,12 @@ namespace Xamarin.Android.Prepare
 		public override string GetManagedProgramRunner (string programPath)
 		{
 			if (String.IsNullOrEmpty (programPath))
-				return null;
+				return String.Empty;
 
 			if (programPath.EndsWith (".exe", StringComparison.OrdinalIgnoreCase) || programPath.EndsWith (".dll", StringComparison.OrdinalIgnoreCase))
 				return "mono"; // Caller will find the exact mono executable, we just provide a name
 
-			return null;
+			return String.Empty;
 		}
 
 		protected static bool IsExecutable (string fullPath, bool throwOnErrors = false)

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/Windows.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/Windows.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Android.Prepare
 
 		public Windows (Context context) : base (context)
 		{
-			string[] pathext = Environment.GetEnvironmentVariable ("PATHEXT")?.Split (new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+			string[]? pathext = Environment.GetEnvironmentVariable ("PATHEXT")?.Split (new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
 			if (pathext == null || pathext.Length == 0) {
 				executableExtensions = new List<string> {
 					".exe",
@@ -52,7 +52,7 @@ namespace Xamarin.Android.Prepare
 		public override string Which (string programPath, bool required = true)
 		{
 			if (String.Compare ("7za", programPath, StringComparison.OrdinalIgnoreCase) == 0) {
-				string homeDir = Context.Instance?.OS?.HomeDirectory;
+				string homeDir = Context.Instance.OS.HomeDirectory;
 				if (String.IsNullOrEmpty (homeDir)) {
 					Log.WarningLine ("User's home directory not known (yet?), cannot return path to 7za");
 					return base.Which (programPath, required);
@@ -90,7 +90,7 @@ namespace Xamarin.Android.Prepare
 
 		public override string GetManagedProgramRunner (string programPath)
 		{
-			return null;
+			return String.Empty;
 		}
 
 		protected override bool InitOS ()

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_AndroidToolchain.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_AndroidToolchain.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Android.Prepare
 	partial class Scenario_AndroidToolchain : ScenarioNoStandardEndSteps
 	{
 		public Scenario_AndroidToolchain () 
-			: base ("AndroidToolchain", "Install Android SDK, NDK and Corretto JDK.", Context.Instance)
+			: base ("AndroidToolchain", "Install Android SDK, NDK and Corretto JDK.")
 		{}
 
 		protected override void AddSteps (Context context)

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_PrepareExternal.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_PrepareExternal.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Android.Prepare
 	partial class Scenario_PrepareExternal : ScenarioNoStandardEndSteps
 	{
 		public Scenario_PrepareExternal ()
-			: base ("PrepareExternal", "Prepare external submodules", Context.Instance)
+			: base ("PrepareExternal", "Prepare external submodules")
 		{
 			NeedsGitSubmodules = true;
 		}

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_PrepareExternalGitDependencies.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_PrepareExternalGitDependencies.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Android.Prepare
 	class Scenario_PrepareExternalGitDependencies : ScenarioNoStandardEndSteps
 	{
 		public Scenario_PrepareExternalGitDependencies ()
-			: base ("PrepareExternalGitDependencies", "Prepare external GIT dependencies", Context.Instance)
+			: base ("PrepareExternalGitDependencies", "Prepare external GIT dependencies")
 		{
 			LogFilePath = Context.Instance.GetLogFilePath ("external-git-deps");
 		}

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_PrepareImageDependencies.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_PrepareImageDependencies.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Android.Prepare
 	[Scenario (isDefault: false)]
 	class Scenario_PrepareImageDependencies : ScenarioNoStandardEndSteps
 	{
-		public Scenario_PrepareImageDependencies () : base ("PrepareImageDependencies", "Prepare provisioning dependencies", Context.Instance)
+		public Scenario_PrepareImageDependencies () : base ("PrepareImageDependencies", "Prepare provisioning dependencies")
 		{}
 
 		protected override void AddSteps (Context context)

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Required.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Required.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Android.Prepare
 	[Scenario (isDefault: false)]
 	class Scenario_Required : Scenario
 	{
-		public Scenario_Required () : base ("Required", "Just the basic steps to quickly install required tools and generate build files.", Context.Instance)
+		public Scenario_Required () : base ("Required", "Just the basic steps to quickly install required tools and generate build files.")
 		{
 			NeedsGitSubmodules = true;
 			NeedsCompilers = true;

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Standard.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Standard.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Android.Prepare
 	partial class Scenario_Standard : Scenario
 	{
 		public Scenario_Standard ()
-			: base ("Standard", "Standard init", Context.Instance)
+			: base ("Standard", "Standard init")
 		{
 			NeedsGitSubmodules = true;
 			NeedsCompilers = true;

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_ThirdPartyNotices.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_ThirdPartyNotices.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Android.Prepare
 	class Scenario_ThirdPartyNotices : Scenario
 	{
 		public Scenario_ThirdPartyNotices ()
-			: base ("ThirdPartyNotices", "Generate the `ThirdPartyNotices.txt` files.", Context.Instance)
+			: base ("ThirdPartyNotices", "Generate the `ThirdPartyNotices.txt` files.")
 		{
 			NeedsGitSubmodules = true;
 		}

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_UpdateMono.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_UpdateMono.Unix.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Android.Prepare
 		public const string MyName = "UpdateMono";
 
 		public Scenario_UpdateMono ()
-			: base (MyName, "Perform basic detection steps AND update Mono if necessary", Context.Instance)
+			: base (MyName, "Perform basic detection steps AND update Mono if necessary")
 		{}
 
 		protected override void AddSteps (Context context)

--- a/build-tools/xaprepare/xaprepare/Steps/Step_DownloadMonoArchive.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_DownloadMonoArchive.cs
@@ -82,7 +82,7 @@ namespace Xamarin.Android.Prepare
 				result = await DownloadAndUpackIfNeeded (
 					context,
 					"Windows Mono",
-					customUrl: null,
+					customUrl: String.Empty,
 					localPath: Configurables.Paths.MonoArchiveWindowsLocalPath,
 					archiveFileName: Configurables.Paths.MonoArchiveWindowsFileName,
 					destinationDirectory: Configurables.Paths.BCLWindowsOutputDir

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.Windows.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.Windows.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Android.Prepare
 	{
 		partial void AddOSSpecificSteps (Context context, List<GeneratedFile> steps)
 		{
-			string javaSdkDirectory = context.Properties.GetValue ("JavaSdkDirectory");
+			string? javaSdkDirectory = context.Properties.GetValue ("JavaSdkDirectory");
 			if (String.IsNullOrEmpty (javaSdkDirectory))
 				javaSdkDirectory = context.OS.JavaHome;
 

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Android.Prepare
 #pragma warning disable CS1998
 		protected override async Task<bool> Execute (Context context)
 		{
-			List<GeneratedFile> filesToGenerate = GetFilesToGenerate (context);
+			List<GeneratedFile>? filesToGenerate = GetFilesToGenerate (context);
 			if (filesToGenerate != null && filesToGenerate.Count > 0) {
 				foreach (GeneratedFile gf in filesToGenerate) {
 					if (gf == null)
@@ -41,7 +41,7 @@ namespace Xamarin.Android.Prepare
 		}
 #pragma warning restore CS1998
 
-		List<GeneratedFile> GetFilesToGenerate (Context context)
+		List<GeneratedFile>? GetFilesToGenerate (Context context)
 		{
 			if (atBuildStart) {
 				if (onlyRequired) {

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallCorrettoOpenJDK.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallCorrettoOpenJDK.cs
@@ -100,7 +100,7 @@ namespace Xamarin.Android.Prepare
 
 		bool CorrettoExistsAndIsValid (string installDir, out string installedVersion)
 		{
-			installedVersion = null;
+			installedVersion = String.Empty;
 			if (!Directory.Exists (installDir)) {
 				Log.DebugLine ($"Corretto directory {installDir} does not exist");
 				return false;

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallMonoRuntimes.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallMonoRuntimes.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Android.Prepare
 		const string StatusIndent    = "  ";
 		const string SubStatusIndent = "    ";
 
-		Runtimes     allRuntimes;
+		Runtimes?     allRuntimes;
 
 		public Step_InstallMonoRuntimes ()
 			: base ("Installing Mono runtimes")
@@ -70,9 +70,16 @@ namespace Xamarin.Android.Prepare
 			return true;
 		}
 
+		void EnsureAllRuntimes ()
+		{
+			if (allRuntimes == null)
+				throw new InvalidOperationException ("Step not initialized properly, allRuntimes is not set");
+		}
+
 		void CleanupBeforeInstall ()
 		{
-			foreach (string dir in allRuntimes.OutputDirectories) {
+			EnsureAllRuntimes ();
+			foreach (string dir in allRuntimes!.OutputDirectories) {
 				Utilities.DeleteDirectorySilent (dir);
 			}
 		}
@@ -150,7 +157,8 @@ namespace Xamarin.Android.Prepare
 			string targetCecil = Utilities.GetRelativePath (BuildPaths.XamarinAndroidSourceRoot, Path.Combine (Configurables.Paths.BuildBinDir, "Xamarin.Android.Cecil.dll"));
 
 			StatusStep (context, "Installing runtime utilities");
-			foreach (MonoUtilityFile muf in allRuntimes.UtilityFilesToInstall) {
+			EnsureAllRuntimes ();
+			foreach (MonoUtilityFile muf in allRuntimes!.UtilityFilesToInstall) {
 				(string destFilePath, string debugSymbolsDestPath) = MonoRuntimesHelpers.GetDestinationPaths (muf);
 				Utilities.CopyFile (muf.SourcePath, destFilePath);
 				if (!muf.IgnoreDebugInfo) {
@@ -192,11 +200,12 @@ namespace Xamarin.Android.Prepare
 		{
 			Log.DebugLine ($"Generating {filePath}");
 
+			EnsureAllRuntimes ();
 			var contents = new XElement (
 				"FileList",
 				new XAttribute ("Redist", Runtimes.FrameworkListRedist),
 				new XAttribute ("Name", Runtimes.FrameworkListName),
-				allRuntimes.BclFilesToInstall.Where (f => f.Type == BclFileType.FacadeAssembly || f.Type == BclFileType.ProfileAssembly).Select (f => ToFileElement (f))
+				allRuntimes!.BclFilesToInstall.Where (f => f.Type == BclFileType.FacadeAssembly || f.Type == BclFileType.ProfileAssembly).Select (f => ToFileElement (f))
 			);
 			contents.Save (filePath);
 			return true;
@@ -219,7 +228,7 @@ namespace Xamarin.Android.Prepare
 
 					default:
 						Log.Debug ("unsupported");
-						fullFilePath = null;
+						fullFilePath = String.Empty;
 						break;
 				}
 
@@ -228,7 +237,7 @@ namespace Xamarin.Android.Prepare
 					throw new InvalidOperationException ($"Unsupported BCL file type {bcf.Type}");
 
 				AssemblyName aname = AssemblyName.GetAssemblyName (fullFilePath);
-				string version = bcf.Version;
+				string version = bcf.Version ?? String.Empty;
 				if (String.IsNullOrEmpty (version) && !Runtimes.FrameworkListVersionOverrides.TryGetValue (bcf.Name, out version))
 					version = aname.Version.ToString ();
 
@@ -257,7 +266,8 @@ namespace Xamarin.Android.Prepare
 			Utilities.CreateDirectory (redistListDir);
 
 			StatusStep (context, "Installing Android BCL assemblies");
-			InstallBCLFiles (allRuntimes.BclFilesToInstall);
+			EnsureAllRuntimes ();
+			InstallBCLFiles (allRuntimes!.BclFilesToInstall);
 
 			StatusStep (context, "Installing Designer Host BCL assemblies");
 			InstallBCLFiles (allRuntimes.DesignerHostBclFilesToInstall);
@@ -279,15 +289,16 @@ namespace Xamarin.Android.Prepare
 				(string destFilePath, string debugSymbolsDestPath) = MonoRuntimesHelpers.GetDestinationPaths (bf);
 
 				Utilities.CopyFile (bf.SourcePath, destFilePath);
-				if (!bf.ExcludeDebugSymbols)
-					Utilities.CopyFile (bf.DebugSymbolsPath, debugSymbolsDestPath);
+				if (!bf.ExcludeDebugSymbols && !String.IsNullOrEmpty (bf.DebugSymbolsPath) && debugSymbolsDestPath.Length > 0)
+					Utilities.CopyFile (bf.DebugSymbolsPath!, debugSymbolsDestPath);
 			}
 		}
 
 		async Task<bool> InstallRuntimes (Context context, List<Runtime> enabledRuntimes)
 		{
 			StatusStep (context, "Installing tests");
-			foreach (TestAssembly tasm in allRuntimes.TestAssemblies) {
+			EnsureAllRuntimes ();
+			foreach (TestAssembly tasm in allRuntimes!.TestAssemblies) {
 				string sourceBasePath;
 
 				switch (tasm.TestType) {
@@ -308,7 +319,7 @@ namespace Xamarin.Android.Prepare
 
 				(string destFilePath, string debugSymbolsDestPath) = MonoRuntimesHelpers.GetDestinationPaths (tasm);
 				CopyFile (Path.Combine (sourceBasePath, tasm.Name), destFilePath);
-				if (debugSymbolsDestPath != null)
+				if (debugSymbolsDestPath.Length > 0)
 					CopyFile (Path.Combine (sourceBasePath, Utilities.GetDebugSymbolsPath (tasm.Name)), debugSymbolsDestPath);
 			}
 
@@ -331,7 +342,7 @@ namespace Xamarin.Android.Prepare
 						continue;
 
 					(skipFile, src, dst) = MonoRuntimesHelpers.GetRuntimeFilePaths (runtime, rtf);
-					if (skipFile)
+					if (skipFile || src.Length == 0 || dst.Length == 0)
 						continue;
 
 					CopyFile (src, dst);

--- a/build-tools/xaprepare/xaprepare/Steps/Step_PrepareExternalJavaInterop.Windows.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_PrepareExternalJavaInterop.Windows.cs
@@ -6,9 +6,11 @@ namespace Xamarin.Android.Prepare
 {
 	partial class Step_PrepareExternalJavaInterop
 	{
+#pragma warning disable CS1998
 		async Task<bool> ExecuteOSSpecific (Context context)
 		{
 			return true;
 		}
+#pragma warning restore CS1998
 	}
 }

--- a/build-tools/xaprepare/xaprepare/Steps/Step_ThirdPartyNotices.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_ThirdPartyNotices.cs
@@ -131,7 +131,7 @@ implication, estoppel or otherwise."			}
 					string underline = "=".PadRight (heading.Length, '=');
 					sw.WriteLine (heading);
 					sw.WriteLine (underline);
-					if (tpn.LicenseText != null)
+					if (tpn.LicenseText.Length > 0)
 						sw.WriteLine (tpn.LicenseText.TrimStart ());
 					else
 						sw.WriteLine (FetchTPNLicense (tpn.LicenseFile));
@@ -160,7 +160,7 @@ implication, estoppel or otherwise."			}
 				throw new InvalidOperationException ($"TPN type must be a non-abstract class ({type})");
 		}
 
-		void ProcessTPN (SortedDictionary <string, ThirdPartyNotice> licenses, ThirdPartyNotice tpn, bool includeExternalDeps, bool includeBuildDeps)
+		void ProcessTPN (SortedDictionary <string, ThirdPartyNotice> licenses, ThirdPartyNotice? tpn, bool includeExternalDeps, bool includeBuildDeps)
 		{
 			if (tpn == null)
 				throw new ArgumentNullException (nameof (tpn));
@@ -179,7 +179,7 @@ implication, estoppel or otherwise."			}
 			licenses.Add (tpn.Name, tpn);
 		}
 
-		void ProcessTPN (SortedDictionary <string, ThirdPartyNotice> licenses, ThirdPartyNoticeGroup tpng, bool includeExternalDeps, bool includeBuildDeps)
+		void ProcessTPN (SortedDictionary <string, ThirdPartyNotice> licenses, ThirdPartyNoticeGroup? tpng, bool includeExternalDeps, bool includeBuildDeps)
 		{
 			if (tpng == null)
 				throw new ArgumentNullException (nameof (tpng));

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/Java.Interop.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/Java.Interop.cs
@@ -28,14 +28,14 @@ namespace Xamarin.Android.Prepare
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "xamarin/Java.Interop";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 	}
 
 	class JavaInterop_gityf_crc_TPN : ThirdPartyNotice
 	{
 		static readonly Uri    url         = new Uri ("https://github.com/gityf/crc");
 
-		public override string LicenseFile => null;
+		public override string LicenseFile => String.Empty;
 		public override string Name        => "gityf/crc";
 		public override Uri    SourceUrl   => url;
 
@@ -74,7 +74,7 @@ POSSIBILITY OF SUCH DAMAGE.
 	{
 		static readonly Uri    url         = new Uri ("https://github.com/jbevain/mono.linq.expressions/");
 
-		public override string LicenseFile => null;
+		public override string LicenseFile => String.Empty;
 		public override string Name        => "jbevain/mono.linq.expressions";
 		public override Uri    SourceUrl   => url;
 
@@ -113,7 +113,7 @@ POSSIBILITY OF SUCH DAMAGE.
 		public override string Name        => "mono/csharp";
 		public override Uri    SourceUrl   => url;
 
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 	}
 
 	class JavaInterop_mono_LineEditor_TPN : ThirdPartyNotice
@@ -123,7 +123,7 @@ POSSIBILITY OF SUCH DAMAGE.
 		public override string LicenseFile => CommonLicenses.MonoMITPath;
 		public override string Name        => "mono/LineEditor";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 	}
 
 	class JavaInterop_mono_Options_TPN : ThirdPartyNotice
@@ -133,14 +133,14 @@ POSSIBILITY OF SUCH DAMAGE.
 		public override string LicenseFile => CommonLicenses.MonoMITPath;
 		public override string Name        => "mono/Options";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 	}
 
 	class JavaInterop_zzzprojects_HtmlAgilityPack_TPN : ThirdPartyNotice
 	{
 		static readonly Uri    url         = new Uri ("https://github.com/zzzprojects/html-agility-pack");
 
-		public override string LicenseFile => null;
+		public override string LicenseFile => String.Empty;
 		public override string Name        => "zzzprojects/HtmlAgilityPack";
 		public override Uri    SourceUrl   => url;
 

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/LibZipSharp.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/LibZipSharp.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Android.Prepare
 		public override string LicenseFile => licenseFile;
 		public override string Name => "xamarin/LibZipSharp";
 		public override Uri SourceUrl => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 
 		public override bool Include (bool includeExternalDeps, bool includeBuildDeps) => includeExternalDeps;
 	}

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/Xamarin.Android.Build.Tasks.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/Xamarin.Android.Build.Tasks.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Android.Prepare
 	{
 		static readonly Uri    url         = new Uri ("https://android.googlesource.com/platform/tools/base/+/d41d662dbf89f9b60ca6256415a059c0107749b8/sdk-common/NOTICE");
 
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 		public override string LicenseFile => CommonLicenses.Apache20Path;
 		public override string Name        => "android/platform/tools/base";
 		public override Uri    SourceUrl   => url;
@@ -27,7 +27,7 @@ namespace Xamarin.Android.Prepare
 	{
 		static readonly Uri    url         = new Uri ("https://github.com/bazelbuild/bazel/");
 
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 		public override string LicenseFile => CommonLicenses.Apache20Path;
 		public override string Name        => "bazelbuild/bazel";
 		public override Uri    SourceUrl   => url;
@@ -51,7 +51,7 @@ namespace Xamarin.Android.Prepare
 	{
 		static readonly Uri    url         = new Uri ("https://github.com/fsharp/fsharp/");
 
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 		public override string LicenseFile => CommonLicenses.Apache20Path;
 		public override string Name        => "fsharp/fsharp";
 		public override Uri    SourceUrl   => url;
@@ -61,7 +61,7 @@ namespace Xamarin.Android.Prepare
 	{
 		static readonly Uri    url         = new Uri ("https://github.com/IronyProject/Irony");
 
-		public override string LicenseFile => null;
+		public override string LicenseFile => String.Empty;
 		public override string Name        => "IronyProject/Irony";
 		public override Uri    SourceUrl   => url;
 
@@ -89,7 +89,7 @@ namespace Xamarin.Android.Prepare
 	{
 		static readonly Uri    url         = new Uri ("https://github.com/JamesNK/Newtonsoft.Json");
 
-		public override string LicenseFile => null;
+		public override string LicenseFile => String.Empty;
 		public override string Name        => "JamesNK/Newtonsoft.Json";
 		public override Uri    SourceUrl   => url;
 
@@ -119,7 +119,7 @@ namespace Xamarin.Android.Prepare
 	{
 		static readonly Uri    url         = new Uri ("https://github.com/NuGet/NuGet.Client");
 
-		public override string LicenseFile => null;
+		public override string LicenseFile => String.Empty;
 		public override string Name => "NuGet/NuGet.Client";
 		public override Uri    SourceUrl => url;
 
@@ -145,7 +145,7 @@ namespace Xamarin.Android.Prepare
 
 		static readonly Uri    url         = new Uri ("https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=tree;f=gas");
 
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 		public override string LicenseFile => CommonLicenses.GPLv3Path;
 		public override string Name        => "android/platform/ndk";
 		public override Uri    SourceUrl   => url;

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/Xamarin.Android.NunitLite.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/Xamarin.Android.NunitLite.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Android.Prepare
 	{
 		static readonly Uri    url         = new Uri ("https://github.com/nunit/nunitlite/");
 
-		public override string LicenseFile => null;
+		public override string LicenseFile => String.Empty;
 		public override string Name => "nunit/nunitlite";
 		public override Uri    SourceUrl => url;
 

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/Xamarin.Android.Tools.Aidl.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/Xamarin.Android.Tools.Aidl.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Android.Prepare
 	{
 		static readonly Uri    url         = new Uri ("https://github.com/IronyProject/Irony");
 
-		public override string LicenseFile => null;
+		public override string LicenseFile => String.Empty;
 		public override string Name        => "IronyProject/Irony";
 		public override Uri    SourceUrl   => url;
 

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/Xamarin.Android.Tools.JavadocImporter.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/Xamarin.Android.Tools.JavadocImporter.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Android.Prepare
 		public override string LicenseFile => CommonLicenses.Apache20Path;
 		public override string Name        => "lovettchris/SgmlReader";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 
 		public override bool   Include(bool includeExternalDeps, bool includeBuildDeps) => includeExternalDeps;
 	}

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/aapt2.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/aapt2.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Android.Prepare
 		public override string LicenseFile => CommonLicenses.Apache20Path;
 		public override string Name        => "google/aapt2";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 
 		public override bool   Include (bool includeExternalDeps, bool includeBuildDeps) => includeExternalDeps;
 	}

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/bundletool.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/bundletool.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Android.Prepare
 		public override string LicenseFile => CommonLicenses.Apache20Path;
 		public override string Name        => "google/bundletool";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 
 		public override bool   Include (bool includeExternalDeps, bool includeBuildDeps) => includeExternalDeps;
 	}

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/libzip.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/libzip.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Android.Prepare
 		public override string LicenseFile => licenseFile;
 		public override string Name => "nih-at/libzip";
 		public override Uri SourceUrl => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 
 		public override bool Include (bool includeExternalDeps, bool includeBuildDeps) => includeExternalDeps;
 	}

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/mono.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/mono.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Android.Prepare
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/cecil";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 	}
 
 	class mono_mono_mono_TPN : ThirdPartyNotice
@@ -43,7 +43,7 @@ namespace Xamarin.Android.Prepare
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/mono";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 	}
 
 	class mono_mono_aspnetwebstack_TPN : ThirdPartyNotice
@@ -54,7 +54,7 @@ namespace Xamarin.Android.Prepare
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/aspnetwebstack";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 
 		public override bool Include (bool includeExternalDeps, bool includeBuildDeps) => includeExternalDeps && includeBuildDeps;
 	}
@@ -67,7 +67,7 @@ namespace Xamarin.Android.Prepare
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/boringssl";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 
 		public override bool Include (bool includeExternalDeps, bool includeBuildDeps) => includeExternalDeps;
 	}
@@ -76,7 +76,7 @@ namespace Xamarin.Android.Prepare
 	{
 		static readonly Uri    url         = new Uri ("https://github.com/mono/ikdasm");
 
-		public override string LicenseFile => null;
+		public override string LicenseFile => String.Empty;
 		public override string Name        => "mono/ikdasm";
 		public override Uri    SourceUrl   => url;
 		public override string LicenseText => @"
@@ -113,7 +113,7 @@ jeroen@frijters.net
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/ikvm-fork";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 
 		public override bool Include (bool includeExternalDeps, bool includeBuildDeps) => includeExternalDeps && includeBuildDeps;
 	}
@@ -126,7 +126,7 @@ jeroen@frijters.net
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/linker";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 	}
 
 	class mono_mono_NuGet_BuildTasks_TPN : ThirdPartyNotice
@@ -137,7 +137,7 @@ jeroen@frijters.net
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/NuGet.BuildTasks";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 
 		public override bool Include (bool includeExternalDeps, bool includeBuildDeps) => includeExternalDeps && includeBuildDeps;
 	}
@@ -150,7 +150,7 @@ jeroen@frijters.net
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/NUnitLite";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 
 		public override bool Include (bool includeExternalDeps, bool includeBuildDeps) => includeExternalDeps;
 	}
@@ -163,7 +163,7 @@ jeroen@frijters.net
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/rx.net";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 
 		public override bool Include (bool includeExternalDeps, bool includeBuildDeps) => includeExternalDeps && includeBuildDeps;
 	}
@@ -176,7 +176,7 @@ jeroen@frijters.net
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/Ix.net";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 
 		public override bool Include (bool includeExternalDeps, bool includeBuildDeps) => includeExternalDeps && includeBuildDeps;
 	}
@@ -203,7 +203,7 @@ jeroen@frijters.net
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/llvm";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 	}
 
 	class mono_llvm_google_test_TPN : ThirdPartyNotice
@@ -214,7 +214,7 @@ jeroen@frijters.net
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/llvm Google Test";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 	}
 
 	class mono_llvm_openbsd_regex_TPN : ThirdPartyNotice
@@ -225,7 +225,7 @@ jeroen@frijters.net
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/llvm OpenBSD Regex";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 	}
 
 	class mono_llvm_pyyaml_tests_TPN : ThirdPartyNotice
@@ -236,7 +236,7 @@ jeroen@frijters.net
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/llvm pyyaml tests";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 	}
 
 	class mono_llvm_arm_contributions_TPN : ThirdPartyNotice
@@ -247,14 +247,14 @@ jeroen@frijters.net
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/llvm ARM contributions";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 	}
 
 	class mono_llvm_md5_contributions_TPN : ThirdPartyNotice
 	{
 		static readonly Uri    url         = new Uri ("https://github.com/mono/llvm/blob/master/lib/Support/MD5.cpp");
 
-		public override string LicenseFile => null;
+		public override string LicenseFile => String.Empty;
 		public override string Name        => "mono/llvm md5 contributions";
 		public override Uri    SourceUrl   => url;
 

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/opentk.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/opentk.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Android.Prepare
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "mono/opentk";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 
 		public override bool   Include (bool includeExternalDeps, bool includeBuildDeps) => includeExternalDeps;
 	}

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/proguard.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/proguard.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Android.Prepare
 		public override string LicenseFile => CommonLicenses.GPLv2Path;
 		public override string Name        => "xamarin/proguard";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 
 		public override bool   Include (bool includeExternalDeps, bool includeBuildDeps) => includeExternalDeps;
 	}

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/r8.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/r8.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Android.Prepare
 	{
 		static readonly Uri    url         = new Uri ("https://r8.googlesource.com/r8/");
 
-		public override string LicenseFile => null;
+		public override string LicenseFile => String.Empty;
 		public override string Name        => "google/r8";
 		public override Uri    SourceUrl   => url;
 

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/sqlite.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/sqlite.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Android.Prepare
 		public override string LicenseFile => CommonLicenses.Apache20Path;
 		public override string Name        => "xamarin/sqlite";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 
 		public override bool   Include (bool includeExternalDeps, bool includeBuildDeps) => includeExternalDeps;
 	}
@@ -26,7 +26,7 @@ namespace Xamarin.Android.Prepare
 		public override string LicenseFile => licenseFile;
 		public override string Name        => "sqlite/sqlite";
 		public override Uri    SourceUrl   => url;
-		public override string LicenseText => null;
+		public override string LicenseText => String.Empty;
 
 		public override bool   Include (bool includeExternalDeps, bool includeBuildDeps) => includeExternalDeps;
 	}

--- a/build-tools/xaprepare/xaprepare/ThirdPartyNotices/xaprepare.cs
+++ b/build-tools/xaprepare/xaprepare/ThirdPartyNotices/xaprepare.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Android.Prepare
 	{
 		static readonly Uri    url         = new Uri ("https://github.com/force-net/Crc32.NET");
 
-		public override string LicenseFile => null;
+		public override string LicenseFile => String.Empty;
 		public override string Name        => "force-net/crc32.net";
 		public override Uri    SourceUrl   => url;
 		public override string LicenseText => @"

--- a/build-tools/xaprepare/xaprepare/ToolRunners/CMakeRunner.OutputSink.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/CMakeRunner.OutputSink.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Android.Prepare
 	{
 		class OutputSink : ToolRunner.ToolOutputSink
 		{
-			public OutputSink (Log log, string logFilePath)
+			public OutputSink (Log log, string? logFilePath)
 				: base (log, logFilePath)
 			{}
 

--- a/build-tools/xaprepare/xaprepare/ToolRunners/CMakeRunner.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/CMakeRunner.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Android.Prepare
 		protected override string ToolName                  => "CMake";
 		protected override string DefaultToolExecutableName => "cmake";
 
-		public CMakeRunner (Context context, Log log = null, string toolPath = null)
+		public CMakeRunner (Context context, Log? log = null, string? toolPath = null)
 			: base (context, log, toolPath)
 		{
 			ProcessTimeout = TimeSpan.FromMinutes (60);
@@ -45,7 +45,7 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		protected override TextWriter CreateLogSink (string logFilePath)
+		protected override TextWriter CreateLogSink (string? logFilePath)
 		{
 			return new OutputSink (Log, logFilePath);
 		}

--- a/build-tools/xaprepare/xaprepare/ToolRunners/GitRunner.BlamePorcelainEntry.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/GitRunner.BlamePorcelainEntry.cs
@@ -7,8 +7,8 @@ namespace Xamarin.Android.Prepare
 	{
 		sealed class BlameParserState
 		{
-			public BlamePorcelainEntry CurrentEntry;
-			public List<BlamePorcelainEntry> Entries;
+			public BlamePorcelainEntry? CurrentEntry;
+			public List<BlamePorcelainEntry> Entries = new List<BlamePorcelainEntry> ();
 		}
 
 		// Encompasses the `git blame -p` output as documented in https://www.git-scm.com/docs/git-blame#_the_porcelain_format
@@ -17,31 +17,31 @@ namespace Xamarin.Android.Prepare
 			static readonly char[] FieldSeparator = new [] { ' ' };
 
 			// Standard/known headers
-			public string Author                            { get; private set; }
-			public string AuthorMail                        { get; private set; }
+			public string Author                            { get; private set; } = String.Empty;
+			public string AuthorMail                        { get; private set; } = String.Empty;
 			public uint AuthorTime                          { get; private set; }
-			public string AuthorTZ                          { get; private set; }
+			public string AuthorTZ                          { get; private set; } = String.Empty;
 
-			public string Committer                         { get; private set; }
-			public string CommitterMail                     { get; private set; }
+			public string Committer                         { get; private set; } = String.Empty;
+			public string CommitterMail                     { get; private set; } = String.Empty;
 			public uint CommitterTime                       { get; private set; }
-			public string CommitterTZ                       { get; private set; }
+			public string CommitterTZ                       { get; private set; } = String.Empty;
 
-			public string Summary                           { get; private set; }
-			public string PreviousCommit                    { get; private set; }
-			public string PreviousCommitFile                { get; private set; }
-			public string Filename                          { get; private set; }
+			public string Summary                           { get; private set; } = String.Empty;
+			public string PreviousCommit                    { get; private set; } = String.Empty;
+			public string PreviousCommitFile                { get; private set; } = String.Empty;
+			public string Filename                          { get; private set; } = String.Empty;
 
 			// Unknown headers
-			public IDictionary<string, string> OtherHeaders { get; private set; }
+			public IDictionary<string, string>? OtherHeaders { get; private set; }
 
-			public string Commit                            { get; private set; }
+			public string Commit                            { get; private set; } = String.Empty;
 			public int OriginalFileLine                     { get; private set; }
 			public int FinalFileLine                        { get; private set; }
 			public int NumberOfLinesInGroup                 { get; private set; }
 
 			// Contents of the changed line
-			public string Line                              { get; private set; }
+			public string Line                              { get; private set; } = String.Empty;
 
 			public bool ProcessLine (string line)
 			{

--- a/build-tools/xaprepare/xaprepare/ToolRunners/GitRunner.OutputSink.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/GitRunner.OutputSink.cs
@@ -6,9 +6,9 @@ namespace Xamarin.Android.Prepare
 	{
 		class OutputSink : ToolRunner.ToolOutputSink
 		{
-			public Action<string> LineCallback { get; set; }
+			public Action<string>? LineCallback { get; set; }
 
-			public OutputSink (Log log, string logFilePath = null)
+			public OutputSink (Log log, string? logFilePath = null)
 				: base (log, logFilePath)
 			{
 			}

--- a/build-tools/xaprepare/xaprepare/ToolRunners/GitRunner.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/GitRunner.cs
@@ -15,8 +15,8 @@ namespace Xamarin.Android.Prepare
 		protected override string DefaultToolExecutableName => "git";
 		protected override string ToolName                  => "Git";
 
-		public GitRunner (Context context, Log log = null, string gitPath = null)
-			: base (context, log, gitPath ?? context?.Tools?.GitPath)
+		public GitRunner (Context context, Log? log = null, string? gitPath = null)
+			: base (context, log, gitPath ?? context.Tools.GitPath)
 		{
 			ProcessTimeout = TimeSpan.FromMinutes (30);
 		}
@@ -75,7 +75,7 @@ namespace Xamarin.Android.Prepare
 			return await RunGit (runner, $"clone-{dirName}");
 		}
 
-		public async Task<bool> SubmoduleUpdate (string workingDirectory = null, bool init = true, bool recursive = true)
+		public async Task<bool> SubmoduleUpdate (string? workingDirectory = null, bool init = true, bool recursive = true)
 		{
 			string runnerWorkingDirectory = DetermineRunnerWorkingDirectory (workingDirectory);
 
@@ -90,7 +90,7 @@ namespace Xamarin.Android.Prepare
 			return await RunGit (runner, "submodule-update");
 		}
 
-		public string GetTopCommitHash (string workingDirectory = null, bool shortHash = true)
+		public string GetTopCommitHash (string? workingDirectory = null, bool shortHash = true)
 		{
 			string runnerWorkingDirectory = DetermineRunnerWorkingDirectory (workingDirectory);
 
@@ -100,16 +100,16 @@ namespace Xamarin.Android.Prepare
 
 			Log.StatusLine (GetLogMessage (runner), CommandMessageColor);
 
-			string hash = null;
+			string hash = String.Empty;
 			using (var outputSink = (OutputSink)SetupOutputSink (runner)) {
 				outputSink.LineCallback = (string line) => {
 					if (!String.IsNullOrEmpty (hash))
 						return;
-					hash = line?.Trim ();
+					hash = line.Trim ();
 				};
 
 				if (!runner.Run ())
-					return null;
+					return String.Empty;
 
 				if (shortHash)
 					return Utilities.ShortenGitHash (hash);
@@ -118,17 +118,17 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		public async Task<IList<BlamePorcelainEntry>> Blame (string filePath)
+		public async Task<IList<BlamePorcelainEntry>?> Blame (string filePath)
 		{
 			return await Blame (filePath, gitArguments: null, blameArguments: null, workingDirectory: null);
 		}
 
-		public async Task<IList<BlamePorcelainEntry>> Blame (string filePath, List <string> blameArguments)
+		public async Task<IList<BlamePorcelainEntry>?> Blame (string filePath, List <string> blameArguments)
 		{
 			return await Blame (filePath, gitArguments: null, blameArguments: blameArguments, workingDirectory: null);
 		}
 
-		public async Task<IList<BlamePorcelainEntry>> Blame (string filePath, List<string> gitArguments, List <string> blameArguments, string workingDirectory = null)
+		public async Task<IList<BlamePorcelainEntry>?> Blame (string filePath, List<string>? gitArguments, List <string>? blameArguments, string? workingDirectory = null)
 		{
 			if (String.IsNullOrEmpty(filePath))
 				throw new ArgumentException ("must not be null or empty", nameof (filePath));
@@ -138,10 +138,7 @@ namespace Xamarin.Android.Prepare
 			runner.AddArgument ("-p");
 			runner.AddQuotedArgument (filePath);
 
-			var parserState = new BlameParserState {
-				CurrentEntry = null,
-				Entries = new List<BlamePorcelainEntry> ()
-			};
+			var parserState = new BlameParserState ();
 
 			Log.StatusLine (GetLogMessage (runner), CommandMessageColor);
 			bool success = await RunTool (
@@ -190,7 +187,7 @@ namespace Xamarin.Android.Prepare
 			return containsHttps;
 		}
 
-		ProcessRunner CreateGitRunner (string workingDirectory, List<string> arguments = null)
+		ProcessRunner CreateGitRunner (string? workingDirectory, List<string>? arguments = null)
 		{
 			var runner = CreateProcessRunner ();
 			runner.WorkingDirectory = workingDirectory;
@@ -227,12 +224,12 @@ namespace Xamarin.Android.Prepare
 			state.CurrentEntry = null;
 		}
 
-		protected override TextWriter CreateLogSink (string logFilePath)
+		protected override TextWriter CreateLogSink (string? logFilePath)
 		{
 			return new OutputSink (Log, logFilePath);
 		}
 
-		void SetCommandArguments (ProcessRunner runner, string command, List<string> commandArguments)
+		void SetCommandArguments (ProcessRunner runner, string command, List<string>? commandArguments)
 		{
 			runner.AddArgument (command);
 			if (commandArguments == null || commandArguments.Count == 0)
@@ -240,15 +237,15 @@ namespace Xamarin.Android.Prepare
 			AddArguments (runner, commandArguments);
 		}
 
-		string DetermineRunnerWorkingDirectory (string workingDirectory)
+		string DetermineRunnerWorkingDirectory (string? workingDirectory)
 		{
 			if (!String.IsNullOrEmpty (workingDirectory))
-				return workingDirectory;
+				return workingDirectory!;
 
 			return BuildPaths.XamarinAndroidSourceRoot;
 		}
 
-		void SetGitArguments (ProcessRunner runner, string workingDirectory, List<string> gitArguments)
+		void SetGitArguments (ProcessRunner runner, string? workingDirectory, List<string>? gitArguments)
 		{
 			foreach (string arg in standardGlobalOptions) {
 				runner.AddArgument (arg);
@@ -256,7 +253,7 @@ namespace Xamarin.Android.Prepare
 
 			if (!String.IsNullOrEmpty (workingDirectory)) {
 				runner.AddArgument ("-C");
-				runner.AddQuotedArgument (workingDirectory);
+				runner.AddQuotedArgument (workingDirectory!);
 			}
 
 			AddArguments (runner, gitArguments);

--- a/build-tools/xaprepare/xaprepare/ToolRunners/MSBuildRunner.OutputSink.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/MSBuildRunner.OutputSink.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Android.Prepare
 		{
 			public override Encoding Encoding => Encoding.Default;
 
-			public OutputSink (Log log, string logFilePath)
+			public OutputSink (Log log, string? logFilePath)
 				: base (log, logFilePath)
 			{
 			}

--- a/build-tools/xaprepare/xaprepare/ToolRunners/MSBuildRunner.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/MSBuildRunner.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Android.Prepare
 
 		public List<string> StandardArguments { get; }
 
-		public MSBuildRunner (Context context, Log log = null, string msbuildPath = null)
+		public MSBuildRunner (Context context, Log? log = null, string? msbuildPath = null)
 			: base (context, log, msbuildPath)
 		{
 			ProcessTimeout = TimeSpan.FromMinutes (30);
@@ -22,7 +22,7 @@ namespace Xamarin.Android.Prepare
 			};
 		}
 
-		public async Task<bool> Run (string projectPath, string logTag, List<string> arguments = null, string binlogName = null, string workingDirectory = null)
+		public async Task<bool> Run (string projectPath, string logTag, List<string>? arguments = null, string? binlogName = null, string? workingDirectory = null)
 		{
 			if (String.IsNullOrEmpty (logTag))
 				throw new ArgumentException ("must not be null or empty", nameof (logTag));
@@ -33,12 +33,12 @@ namespace Xamarin.Android.Prepare
 			ProcessRunner runner = CreateProcessRunner ();
 			AddArguments (runner, StandardArguments);
 			if (!String.IsNullOrEmpty (binlogName)) {
-				string logPath = Utilities.GetRelativePath (workingDirectory, Path.Combine (Configurables.Paths.BuildBinDir, $"msbuild-{Context.BuildTimeStamp}-{binlogName}.binlog"));
+				string logPath = Utilities.GetRelativePath (workingDirectory!, Path.Combine (Configurables.Paths.BuildBinDir, $"msbuild-{Context.BuildTimeStamp}-{binlogName}.binlog"));
 				runner.AddArgument ("/v:normal");
 				runner.AddQuotedArgument ($"/bl:{logPath}");
 			}
 			AddArguments (runner, arguments);
-			runner.AddQuotedArgument (Utilities.GetRelativePath (workingDirectory, projectPath));
+			runner.AddQuotedArgument (Utilities.GetRelativePath (workingDirectory!, projectPath));
 
 			string message = GetLogMessage (runner);
 			Log.Info (message, CommandMessageColor);
@@ -59,7 +59,7 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		protected override TextWriter CreateLogSink (string logFilePath)
+		protected override TextWriter CreateLogSink (string? logFilePath)
 		{
 			return new OutputSink (Log, logFilePath);
 		}

--- a/build-tools/xaprepare/xaprepare/ToolRunners/MakeRunner.OutputSink.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/MakeRunner.OutputSink.Unix.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Android.Prepare
 	{
 		class OutputSink : ToolRunner.ToolOutputSink
 		{
-			public OutputSink (Log log, string logFilePath)
+			public OutputSink (Log log, string? logFilePath)
 				: base (log, logFilePath)
 			{}
 

--- a/build-tools/xaprepare/xaprepare/ToolRunners/MakeRunner.Unix.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/MakeRunner.Unix.cs
@@ -13,16 +13,16 @@ namespace Xamarin.Android.Prepare
 		public Version Version             => version;
 		public bool NoParallelJobs         { get; set; }
 
-		public MakeRunner (Context context, Log log = null, string makePath = null)
+		public MakeRunner (Context context, Log? log = null, string? makePath = null)
 			: base (context, log, makePath)
 		{
 			ProcessTimeout = TimeSpan.FromMinutes (60);
-			string vs = VersionString?.Trim ();
+			string vs = VersionString.Trim ();
 			if (String.IsNullOrEmpty (vs) || !Version.TryParse (vs, out version))
 				version = new Version (0, 0);
 		}
 
-		public async Task<bool> Run (string logTag, string workingDirectory = null, List<string> arguments = null)
+		public async Task<bool> Run (string logTag, string? workingDirectory = null, List<string>? arguments = null)
 		{
 			if (String.IsNullOrEmpty (logTag))
 				throw new ArgumentException ("must not be null or empty", nameof (logTag));
@@ -32,7 +32,7 @@ namespace Xamarin.Android.Prepare
 			ProcessRunner runner = CreateProcessRunner ();
 			if (arguments != null && arguments.Count > 0) {
 				foreach (string a in arguments) {
-					string arg = a?.Trim ();
+					string arg = a.Trim ();
 					if (String.IsNullOrEmpty (arg))
 						continue;
 					if (arg.StartsWith ("-C", StringComparison.Ordinal) || arg.StartsWith ("--directory", StringComparison.Ordinal))
@@ -64,7 +64,7 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		public void GetStandardArguments (ref List<string> arguments, string workingDirectory = null)
+		public void GetStandardArguments (ref List<string>? arguments, string? workingDirectory = null)
 		{
 			var args = new List<string> ();
 			SetStandardArguments (workingDirectory, false, false, arg => args.Add (arg));
@@ -78,16 +78,16 @@ namespace Xamarin.Android.Prepare
 				arguments.AddRange (args);
 		}
 
-		void SetStandardArguments (string workingDirectory, bool haveChangeDirArg, bool haveConcurrency, ProcessRunner runner)
+		void SetStandardArguments (string? workingDirectory, bool haveChangeDirArg, bool haveConcurrency, ProcessRunner runner)
 		{
 			SetStandardArguments (workingDirectory, haveChangeDirArg, haveConcurrency, arg => runner.AddArgument (arg));
 		}
 
-		void SetStandardArguments (string workingDirectory, bool haveChangeDirArg, bool haveConcurrency, Action<string> argumentSetter)
+		void SetStandardArguments (string? workingDirectory, bool haveChangeDirArg, bool haveConcurrency, Action<string> argumentSetter)
 		{
 			if (!haveChangeDirArg && !String.IsNullOrEmpty (workingDirectory)) {
 				argumentSetter ("-C");
-				argumentSetter (ProcessRunner.QuoteArgument (workingDirectory));
+				argumentSetter (ProcessRunner.QuoteArgument (workingDirectory!));
 			}
 
 			bool concurrencyUsed;
@@ -103,7 +103,7 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		protected override TextWriter CreateLogSink (string logFilePath)
+		protected override TextWriter CreateLogSink (string? logFilePath)
 		{
 			return new OutputSink (Log, logFilePath);
 		}

--- a/build-tools/xaprepare/xaprepare/ToolRunners/NinjaRunner.OutputSink.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/NinjaRunner.OutputSink.cs
@@ -8,9 +8,9 @@ namespace Xamarin.Android.Prepare
 		{
 			bool writeToStderr;
 
-			public ProcessRunner Runner { get; set; }
+			public ProcessRunner? Runner { get; set; }
 
-			public OutputSink (Log log, string logFilePath)
+			public OutputSink (Log log, string? logFilePath)
 				: base (log, logFilePath)
 			{}
 

--- a/build-tools/xaprepare/xaprepare/ToolRunners/NinjaRunner.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/NinjaRunner.cs
@@ -10,13 +10,13 @@ namespace Xamarin.Android.Prepare
 		protected override string ToolName                  => "Ninja";
 		protected override string DefaultToolExecutableName => "ninja";
 
-		public NinjaRunner (Context context, Log log = null, string toolPath = null)
+		public NinjaRunner (Context context, Log? log = null, string? toolPath = null)
 			: base (context, log, toolPath)
 		{
 			ProcessTimeout = TimeSpan.FromMinutes (60);
 		}
 
-		public async Task<bool> Run (string logTag, string workingDirectory, List<string> arguments = null)
+		public async Task<bool> Run (string logTag, string workingDirectory, List<string>? arguments = null)
 		{
 			if (String.IsNullOrEmpty (logTag))
 				throw new ArgumentException ("must not be null or empty", nameof (logTag));
@@ -62,7 +62,7 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		protected override TextWriter CreateLogSink (string logFilePath)
+		protected override TextWriter CreateLogSink (string? logFilePath)
 		{
 			return new OutputSink (Log, logFilePath);
 		}

--- a/build-tools/xaprepare/xaprepare/ToolRunners/NuGetRunner.OutputSink.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/NuGetRunner.OutputSink.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Android.Prepare
 
 			public override Encoding Encoding => Encoding.Default;
 
-			public OutputSink (Log log, string logFilePath, string indent = null)
+			public OutputSink (Log log, string? logFilePath, string? indent = null)
 				: base (log, logFilePath)
 			{
 				this.indent = indent ?? DefaultIndent;
@@ -30,7 +30,7 @@ namespace Xamarin.Android.Prepare
 				if (String.IsNullOrEmpty (value))
 					return;
 
-				string consoleMessage = null;
+				string? consoleMessage = null;
 				if (value.StartsWith (RestoringPackagePrefix, StringComparison.OrdinalIgnoreCase)) {
 					consoleMessage = $"{packageBullet} {value.Substring (RestoringPackagePrefix.Length).Trim ().TrimEnd ('.')}";
 				} else if (value.StartsWith (AllPackagesRestoredPrefix, StringComparison.OrdinalIgnoreCase)) {

--- a/build-tools/xaprepare/xaprepare/ToolRunners/NuGetRunner.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/NuGetRunner.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Android.Prepare
 		protected override string DefaultToolExecutableName => "nuget";
 		protected override string ToolName                  => "NuGet";
 
-		public NuGetRunner (Context context, Log log = null, string nugetPath = null)
+		public NuGetRunner (Context context, Log? log = null, string? nugetPath = null)
 			: base (context, log, nugetPath ?? Configurables.Paths.LocalNugetPath)
 		{}
 
@@ -43,7 +43,7 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		protected override TextWriter CreateLogSink (string logFilePath)
+		protected override TextWriter CreateLogSink (string? logFilePath)
 		{
 			return new OutputSink (Log, logFilePath);
 		}

--- a/build-tools/xaprepare/xaprepare/ToolRunners/SevenZipRunner.OutputSink.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/SevenZipRunner.OutputSink.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Android.Prepare
 		{
 			public override Encoding Encoding => Encoding.Default;
 
-			public OutputSink (Log log, string logFilePath, string indent = null)
+			public OutputSink (Log log, string? logFilePath, string? indent = null)
 				: base (log, logFilePath)
 			{}
 

--- a/build-tools/xaprepare/xaprepare/ToolRunners/SevenZipRunner.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/SevenZipRunner.cs
@@ -15,17 +15,17 @@ namespace Xamarin.Android.Prepare
 		protected override string DefaultToolExecutableName => "7za";
 		protected override string ToolName                  => "7zip";
 
-		public SevenZipRunner (Context context, Log log = null, string toolPath = null)
+		public SevenZipRunner (Context context, Log? log = null, string? toolPath = null)
 			: base (context, log, toolPath ?? Context.Instance.Tools.SevenZipPath)
 		{
 			ProcessTimeout = TimeSpan.FromMinutes (DefaultTimeout);
 
-			string vs = VersionString?.Trim ();
+			string vs = VersionString.Trim ();
 			if (String.IsNullOrEmpty (vs) || !Version.TryParse (vs, out version))
 				version = new Version (0, 0);
 		}
 
-		public async Task<bool> Extract (string archivePath, string outputDirectory, List<string> extraArguments = null)
+		public async Task<bool> Extract (string archivePath, string outputDirectory, List<string>? extraArguments = null)
 		{
 			if (String.IsNullOrEmpty (archivePath))
 				throw new ArgumentException ("must not be null or empty", nameof (archivePath));
@@ -104,7 +104,7 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		protected override TextWriter CreateLogSink (string logFilePath)
+		protected override TextWriter CreateLogSink (string? logFilePath)
 		{
 			return new OutputSink (Log, logFilePath);
 		}

--- a/build-tools/xaprepare/xaprepare/ToolRunners/SnRunner.OutputSink.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/SnRunner.OutputSink.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Android.Prepare
 		{
 			public override Encoding Encoding => Encoding.Default;
 
-			public OutputSink (Log log, string logFilePath)
+			public OutputSink (Log log, string? logFilePath)
 				: base (log, logFilePath)
 			{
 			}

--- a/build-tools/xaprepare/xaprepare/ToolRunners/SnRunner.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/SnRunner.cs
@@ -10,11 +10,11 @@ namespace Xamarin.Android.Prepare
 		protected override string DefaultToolExecutableName => "sn";
 		protected override string ToolName                  => "sn";
 
-		public SnRunner (Context context, Log log = null, string snPath = null)
+		public SnRunner (Context context, Log? log = null, string? snPath = null)
 			: base (context, log, snPath)
 		{}
 
-		public async Task<bool> ReSign (string snkPath, string assemblyPath, string logTag, string workingDirectory = null)
+		public async Task<bool> ReSign (string snkPath, string assemblyPath, string logTag, string? workingDirectory = null)
 		{
 			if (String.IsNullOrEmpty (snkPath))
 				throw new ArgumentException ("must not be null or empty", nameof (snkPath));
@@ -30,8 +30,8 @@ namespace Xamarin.Android.Prepare
 
 			ProcessRunner runner = CreateProcessRunner ();
 			runner.AddQuotedArgument ( "-R");
-			runner.AddQuotedArgument (Utilities.GetRelativePath (workingDirectory, assemblyPath));
-			runner.AddQuotedArgument (Utilities.GetRelativePath (workingDirectory, snkPath));
+			runner.AddQuotedArgument (Utilities.GetRelativePath (workingDirectory!, assemblyPath));
+			runner.AddQuotedArgument (Utilities.GetRelativePath (workingDirectory!, snkPath));
 
 			string message = GetLogMessage (runner);
 			Log.Info (message, CommandMessageColor);
@@ -47,7 +47,7 @@ namespace Xamarin.Android.Prepare
 			);
 		}
 
-		protected override TextWriter CreateLogSink (string logFilePath)
+		protected override TextWriter CreateLogSink (string? logFilePath)
 		{
 			return new OutputSink (Log, logFilePath);
 		}

--- a/build-tools/xaprepare/xaprepare/ToolRunners/TarRunner.OutputSink.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/TarRunner.OutputSink.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Android.Prepare
 		{
 			public override Encoding Encoding => Encoding.Default;
 
-			public OutputSink (Log log, string logFilePath, string indent = null)
+			public OutputSink (Log log, string? logFilePath, string? indent = null)
 				: base (log, logFilePath)
 			{
 				Log.Todo ("Implement parsing, if necessary");

--- a/build-tools/xaprepare/xaprepare/ToolRunners/TarRunner.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/TarRunner.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Android.Prepare
 		protected override string DefaultToolExecutableName => "tar";
 		protected override string ToolName => "Tar";
 
-		public TarRunner (Context context, Log log = null, string toolPath = null)
+		public TarRunner (Context context, Log? log = null, string? toolPath = null)
 			: base (context, log, toolPath)
 		{}
 
@@ -43,7 +43,7 @@ namespace Xamarin.Android.Prepare
 			}
 		}
 
-		protected override TextWriter CreateLogSink (string logFilePath)
+		protected override TextWriter CreateLogSink (string? logFilePath)
 		{
 			return new OutputSink (Log, logFilePath);
 		}

--- a/build-tools/xaprepare/xaprepare/ToolRunners/ToolRunner.OutputSink.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/ToolRunner.OutputSink.cs
@@ -8,14 +8,14 @@ namespace Xamarin.Android.Prepare
 	{
 		protected abstract class ToolOutputSink : TextWriter
 		{
-			protected Log Log             { get; }
-			protected StreamWriter Writer { get; private set; }
+			protected Log Log              { get; }
+			protected StreamWriter? Writer { get; private set; }
 
 			public override Encoding Encoding => Encoding.Default;
 
-			protected ToolOutputSink (Log log, string logFilePath)
+			protected ToolOutputSink (Log log, string? logFilePath)
 			{
-				Log = log ?? throw new ArgumentNullException (nameof (log));
+				Log = log;
 				if (!String.IsNullOrEmpty (logFilePath))
 					Writer = new StreamWriter (File.Open (logFilePath, FileMode.Create, FileAccess.Write), Utilities.UTF8NoBOM);
 			}

--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -8,6 +8,8 @@
     <RootNamespace>Xamarin.Android.Prepare</RootNamespace>
     <AssemblyName>xaprepare</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <Import Project="..\..\..\Configuration.props" />
   <Import Project="xaprepare.targets" Condition=" $(MSBuildToolsPath.IndexOf('omnisharp')) &lt; 0 " />
@@ -21,7 +23,7 @@
     <WarningLevel>4</WarningLevel>
     <ExternalConsole>true</ExternalConsole>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>7.1</LangVersion>
+    <DocumentationFile>bin\Debug\xaprepare.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <Optimize>true</Optimize>
@@ -30,7 +32,7 @@
     <WarningLevel>4</WarningLevel>
     <ExternalConsole>true</ExternalConsole>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>7.1</LangVersion>
+    <DocumentationFile>bin\Release\xaprepare.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -41,6 +43,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="mscorlib" />
@@ -88,6 +91,7 @@
     <Compile Include="Application\MonoRuntime.cs" />
     <Compile Include="Application\MonoRuntimesHelpers.cs" />
     <Compile Include="Application\MonoUtilityFile.cs" />
+    <Compile Include="Application\NullableAttributes.cs" />
     <Compile Include="Application\ProcessRunner.cs" />
     <Compile Include="Application\ProcessStandardStreamWrapper.cs" />
     <Compile Include="Application\Program.cs" />
@@ -100,6 +104,7 @@
     <Compile Include="Application\RuntimeFile.cs" />
     <Compile Include="Application\RuntimeFileType.cs" />
     <Compile Include="Application\Scenario.cs" />
+    <Compile Include="Application\ScenarioNoScenario.cs" />
     <Compile Include="Application\ScenarioNoStandardEndSteps.cs" />
     <Compile Include="Application\ScenarioAttribute.cs" />
     <Compile Include="Application\SimpleActionStep.cs" />
@@ -122,6 +127,7 @@
     <Compile Include="ConfigAndData\Dependencies\AndroidToolchain.cs" />
     <Compile Include="ConfigAndData\Runtimes.cs" />
     <Compile Include="ConfigAndData\Runtimes.Code.cs" />
+    <Compile Include="OperatingSystems\NoOS.cs" />
     <Compile Include="OperatingSystems\OS.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Scenarios\Scenario_AndroidToolchain.cs" />

--- a/tools/vswhere/VisualStudioInstance.cs
+++ b/tools/vswhere/VisualStudioInstance.cs
@@ -4,8 +4,8 @@ namespace Xamarin.Android.Tools.VSWhere
 {
 	public class VisualStudioInstance
 	{
-		public string VisualStudioRootPath { get; set; }
+		public string VisualStudioRootPath { get; set; } = String.Empty;
 
-		public string MSBuildPath { get; set; }
+		public string MSBuildPath { get; set; } = String.Empty;
 	}
 }


### PR DESCRIPTION
This started as a "quick" experiment which turned out to generate around
390 warnings regarding code affected by `null` one way or another.
Despite nullable reference types sometimes forcing to produce more
verbose code or instantiate more objects than was necessary before
enabling the feature, I think the net result is worth the effort. A few
code paths were fixed where a potential for null dereference existed,
nothing really serious but still well worth it to have stabler (albeit
slightly bigger and possibly a tiny bit slower) codebase.