### PR TITLE
[CI] Ensure Mono integration branch PRs run the full regression suite.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -57,7 +57,7 @@ variables:
   # - User who queued the job requested it (They set XA.RunAllTests to true)
   # - This is the master integration branch (Pipeline defaults XA.RunAllTests to true)
   # - This is a non-fork branch with name containing "mono-" (for Mono bumps)
-  IsMonoBranch: $[and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), contains(variables['Build.SourceBranchName'], 'mono-'))]
+  IsMonoBranch: $[and(eq(variables['XA.Commercial.Build'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'), or(contains(variables['Build.SourceBranchName'], 'mono-'), contains(variables['System.PullRequest.SourceBranch'], 'mono-')))]
   RunAllTests: $[or(eq(variables['XA.RunAllTests'], true), eq(variables['IsMonoBranch'], true))]
 
 # Stage and Job "display names" are shortened because they are combined to form the name of the corresponding GitHub check.


### PR DESCRIPTION
In #4161 we created a new YAML variable called `IsMonoBranch` that checks if the branch name contains `mono-` so we could determine if it's a mono integration branch.  If it is, we would like to run the full regression test suite on it at the PR stage and not wait until the branch is merged.  This is because a Mono build is riskier and has a higher chance of breaking stuff.

However, the way this was implemented: `contains(variables['Build.SourceBranchName'], 'mono-')` only works for manually run builds (which is how I tested it and confirmed that it works).  If the build is kicked off automatically from the PR, `Build.SourceBranchName` is overwritten with the value `"merge"` (https://github.com/microsoft/azure-pipelines-tasks/issues/8793).  Thus we have not been running these suites on the in-progress Mono 2020-02 integration branch.

In order to fix this, we are changing it to additionally check the variable `System.PullRequest.SourceBranch` which will contain the branch name when this is a PR initiated build.