### PR TITLE
[build macOS] Properly handle multiple versions of installed software

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/Program.cs
+++ b/build-tools/xaprepare/xaprepare/Application/Program.cs
@@ -46,6 +46,7 @@ namespace Xamarin.Android.Prepare
 		public bool IgnoreMinimumVersion        { get; set; }
 		public bool IgnoreMaximumVersion        { get; set; }
 		public bool InstalledButWrongVersion    { get; private set; }
+		public bool MustReinstall               { get; private set; }
 
 		public abstract Task<bool> Install ();
 
@@ -67,6 +68,7 @@ namespace Xamarin.Android.Prepare
 
 		async Task<bool> Detect ()
 		{
+			MustReinstall = false;
 			if (!CheckWhetherInstalled ()) {
 				await AfterDetect (false);
 				return false;
@@ -85,6 +87,10 @@ namespace Xamarin.Android.Prepare
 			}
 
 			await AfterDetect (true);
+			if (ForceReinstall ()) {
+				Log.DebugLine ($"Program {Name} must be forcibly reinstalled");
+				MustReinstall = true;
+			}
 			return true;
 		}
 
@@ -122,6 +128,11 @@ namespace Xamarin.Android.Prepare
 		protected virtual async Task AfterDetect (bool installed)
 		{}
 #pragma warning restore CS1998
+
+		protected virtual bool ForceReinstall ()
+		{
+			return false;
+		}
 
 		protected virtual bool ParseVersion (string version, out Version ver)
 		{

--- a/build-tools/xaprepare/xaprepare/OperatingSystems/OS.cs
+++ b/build-tools/xaprepare/xaprepare/OperatingSystems/OS.cs
@@ -271,10 +271,13 @@ namespace Xamarin.Android.Prepare
 				Log.Status ($"Checking ", $"{p.Name}".PadRight (maxNameLength), tailColor: ConsoleColor.White);
 				bool installed = await p.IsInstalled ();
 				if (installed) {
-					if (!p.InstalledButWrongVersion) {
+					if (!p.InstalledButWrongVersion && !p.MustReinstall) {
 						Log.StatusLine ($" [FOUND {p.CurrentVersion}]", Context.SuccessColor);
 					} else {
-						Log.StatusLine ($" [WRONG VERSION {p.CurrentVersion}]", Context.WarningColor);
+						if (p.MustReinstall)
+							Log.StatusLine ($" [MUST REINSTALL {p.CurrentVersion}]", Context.WarningColor);
+						else
+							Log.StatusLine ($" [WRONG VERSION {p.CurrentVersion}]", Context.WarningColor);
 						missing.Add (p);
 					}
 				} else {


### PR DESCRIPTION
Brew allows installation of several versions of a single software package on the system,
even though only one of them can be "linked" into the installation prefix and directly
accessible to the user. This is generally fine, unless the version currently linked does not
work with the version of macOS running on the machine or is otherwise broken.

In our case, some CI bots managed to install two versions of mingw - the old v6.0.0 and the
new v7.0.0 with the former being the default or with the package not linked at all, and the
confusion leading to errors similar to the one below:

    20:24:43  [CMake] running
    20:24:43  [CMake] log file: bin/BuildRelease/prepare-20200220T152055.cmake.dlfcn-win32-mxe-Win32-configure.log
    20:24:43  Running: /usr/local/bin/cmake "-GNinja" "-DCMAKE_MAKE_PROGRAM=ninja" "-DBUILD_TESTS=OFF" "-DBUILD_SHARED_LIBS=OFF" "-DCMAKE_INSTALL_PREFIX=/Users/builder/jenkins/workspace/xamarin-android-pr-pipeline-release/xamarin-android/bin/BuildRelease/mingw-deps/x86" "-Wno-dev" "-DCMAKE_TOOLCHAIN_FILE=../mingw-32.cmake" "../../../external/dlfcn-win32"
    20:24:43  Working... 00:00:00.2706265
    20:24:43  stderr | CMake Error at CMakeLists.txt:7 (project):
    20:24:43  stderr |   The CMAKE_C_COMPILER:
    20:24:43  stderr |
    20:24:43  stderr |     i686-w64-mingw32-gcc
    20:24:43  stderr |
    20:24:43  stderr |   is not a full path and was not found in the PATH.
    20:24:43  stderr |
    20:24:43  stderr |   Tell CMake where to find the compiler by setting either the environment
    20:24:43  stderr |   variable "CC" or the CMake cache entry CMAKE_C_COMPILER to the full path to
    20:24:43  stderr |   the compiler, or to the compiler name if it is in the PATH.
    20:24:43  stderr |
    20:24:43  stderr |

This commit fixes the problem by detecting situations where more than a single version of a
package is installed and proceeding to:

 * unpin the package (if pinned)
 * uninstall *all* the versions of the package
 * install the required version

This is *not* done by default! The user needs to turn auto-provisioning on first (which is on
by default on the CI bots)