### PR TITLE
Bump to mono/mono/2019-12@cec38f (#4287)

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
 xamarin/monodroid:master@01a4e0a0c436bf1b0b62acf870cc06e67e62034c
-mono/mono:2019-12@8b72dbb708681fbde7f0da13fe76d128d62f8686
+mono/mono:2019-12@cec38fcfc83c25901a4301383ce4ee12ebebe315

--- a/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/nunit-excluded-tests.txt
+++ b/tests/BCL-Tests/Xamarin.Android.Bcl-Tests/nunit-excluded-tests.txt
@@ -35,3 +35,6 @@ MonoTests.System.Web.Services.Description.ServiceDescriptionTest.ReadAndRetrieva
 MonoTests.System.Web.Services.Description.ServiceDescriptionTest.ReadInvalid
 MonoTests.System.Web.Services.Description.ServiceDescriptionTest.SimpleWrite
 MonoTests.System.Web.Services.Description.ServiceDescriptionTest.ValidatingRead
+
+# the test is incorrect and will be removed soon: https://github.com/mono/mono/pull/18952
+System.Net.Http.Tests.HttpClientHandlerTestsAndroid.TestEnvVarSwitchForInnerHttpHandler


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1070776/
Context: https://github.com/mono/mono/pull/18764
Context: https://github.com/mono/mono/pull/18832

Changes: https://github.com/mono/mono/compare/8b72dbb708681fbde7f0da13fe76d128d62f8686...cec38fcfc83c25901a4301383ce4ee12ebebe315

  * mono/mono@cec38fcfc83: Bump bockbuild to bring in Gtk# regression fix (#18911)
  * mono/mono@0761b0ee554: [2019-12] Make MonoWebRequestHandler linker friendly (#18833)
  * mono/mono@0c45a74a967: Move HttpClientHandlerTests.Android.cs to nunit (#18889)
  * mono/mono@d5f5f3762fc: [2019-12] Bump msbuild to track mono-2019-10 (#18862)
  * mono/mono@f1bdf8a93de: Move offsets-tool into mono/tools (#18830)
  * mono/mono@3fdc3c84b28: [2019-12] Bump msbuild to track mono-2019-10 (#18792)
  * mono/mono@846a5d41eea: [2019-12] Allow users to switch to MonoWebRequestHandler on Android via UI (#18786)
  * mono/mono@c8b96661d32: Bump bockbuild to get GTK NSPasteboardType change.
  * mono/mono@db584480ff3: [iOS] Replace removed dsymutil `-t` switch with `-num-threads` (#18744)
  * mono/mono@0686e1435b3: Skip WebAssembly build in sdks archive build on non-master branches
  * mono/mono@5ef6ad0ef72: [merp] Add an exception type for managed exceptions (#18723)
  * mono/mono@36073a0c74a: [NUnitLite] Bump nunitlite submodule. (#18733)
  * mono/mono@e65846bfd31: Update deprecated query parameter to header (#18705)
  * mono/mono@0011444f0b6: [aot] Avoid inflating gparams with byreflike types during generic sharing. (#18682)
  * mono/mono@4c93e382f56: [2019-12] [merp] MONO_DEBUG=no-gdb-stacktrace shouldn't disable MERP (#18611)

d16-4 broke NTLM Authentication with `HttpClient` in Xamarin.Android.

To now use NTLM Authentication, the `$(AndroidHttpClientHandlerType)`
MSBuild variable must be overridden from the default value:

	<PropertyGroup>
	  <AndroidHttpClientHandlerType>System.Net.Http.MonoWebRequestHandler, System.Net.Http</AndroidHttpClientHandlerType>
	</PropertyGroup>

See mono/mono#18764 for more details.