### PR TITLE
[Xamarin.Android.Build.Tasks] less string alloc in native assembly generation

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMappingNativeAssemblyGenerator.cs
@@ -39,13 +39,23 @@ namespace Xamarin.Android.Tasks
 
 			output.WriteLine ();
 			if (haveAssemblyNames) {
-				output.WriteLine ($"{Indent}.include{Indent}\"{Path.GetFileName (SharedIncludeFile)}\"");
+				output.Write (Indent);
+				output.Write (".include");
+				output.Write (Indent);
+				output.Write ('"');
+				output.Write (Path.GetFileName (SharedIncludeFile));
+				output.WriteLine ('"');
 			} else {
 				WriteCommentLine (output, $"No shared data present, {Path.GetFileName (SharedIncludeFile)} not generated");
 			}
 
 			if (haveModules) {
-				output.WriteLine ($"{Indent}.include{Indent}\"{Path.GetFileName (TypemapsIncludeFile)}\"");
+				output.Write (Indent);
+				output.Write (".include");
+				output.Write (Indent);
+				output.Write ('"');
+				output.Write (Path.GetFileName (TypemapsIncludeFile));
+				output.WriteLine ('"');
 			} else {
 				WriteCommentLine (output, $"No modules defined, {Path.GetFileName (TypemapsIncludeFile)} not generated");
 			}


### PR DESCRIPTION
Using the Mono profiler, I saw:

    Allocation summary
        Bytes      Count  Average Type name
     28784408     432288       66 System.String
    ...
    2353592 bytes from:
        Xamarin.Android.Tasks.TypeMappingNativeAssemblyGenerator:WriteJavaMap (System.IO.StreamWriter,string)
        Xamarin.Android.Tasks.TypeMappingNativeAssemblyGenerator:WriteJavaMapEntry (System.IO.StreamWriter,Xamarin.Android.Tasks.TypeMapGenerator/TypeMapEntry,int)
        Xamarin.Android.Tasks.NativeAssemblyGenerator:WriteCommentLine (System.IO.StreamWriter,string,bool)
        Xamarin.Android.Tasks.NativeAssemblyGenerator:WriteComment (System.IO.StreamWriter,string,bool)
        (wrapper alloc) object:ProfilerAllocString (intptr,int)
        (wrapper managed-to-native) object:__icall_wrapper_mono_profiler_raise_gc_allocation (object)
    1239424 bytes from:
        Xamarin.Android.Tasks.TypeMappingNativeAssemblyGenerator:WriteManagedMapEntry (System.IO.StreamWriter,uint,uint)
        Xamarin.Android.Tasks.NativeAssemblyGenerator:WriteData (System.IO.StreamWriter,uint,string,bool)
        Xamarin.Android.Tasks.NativeAssemblyGenerator:WriteSymbol<uint> (System.IO.StreamWriter,uint,string,ulong,uint,bool,bool,bool)
        Xamarin.Android.Tasks.NativeAssemblyGenerator:WriteSymbol (System.IO.StreamWriter,string,string,string,ulong,uint,bool,bool,bool)
        (wrapper alloc) object:ProfilerAllocString (intptr,int)
        (wrapper managed-to-native) object:__icall_wrapper_mono_profiler_raise_gc_allocation (object)
    1197512 bytes from:
        Xamarin.Android.Tasks.TypeMappingNativeAssemblyGenerator:WriteSymbols (System.IO.StreamWriter)
        Xamarin.Android.Tasks.TypeMappingNativeAssemblyGenerator:WriteJavaMap (System.IO.StreamWriter,string)
        Xamarin.Android.Tasks.TypeMappingNativeAssemblyGenerator:WriteJavaMapEntry (System.IO.StreamWriter,Xamarin.Android.Tasks.TypeMapGenerator/TypeMapEntry,int)
        Xamarin.Android.Tasks.NativeAssemblyGenerator:WriteAsciiData (System.IO.StreamWriter,string,uint)
        (wrapper alloc) object:ProfilerAllocString (intptr,int)
        (wrapper managed-to-native) object:__icall_wrapper_mono_profiler_raise_gc_allocation (object)

The assembly files generated here are quite large, in the case of
`samples/HelloWorld`:

    178623 typemaps.arm64-v8a-managed.inc
    715880 typemaps.arm64-v8a.o
    849243 typemaps.arm64-v8a.s
    178623 typemaps.armeabi-v7a-managed.inc
       451 typemaps.armeabi-v7a-shared.inc
    715076 typemaps.armeabi-v7a.o
    850081 typemaps.armeabi-v7a.s
       451 typemaps.shared.inc
    178623 typemaps.x86-managed.inc
    714856 typemaps.x86.o
    849170 typemaps.x86.s
    178623 typemaps.x86_64-managed.inc
    715760 typemaps.x86_64.o
    849206 typemaps.x86_64.s

The code generating these has lot of `$""` usage:

    output.WriteLine ($"{Indent}.type{Indent}{symbolName}, {TargetProvider.TypePrefix}object");

This calls `string.Format` and creates lots of intermediate strings in
memory.

I could unroll this to:

    output.Write (Indent);
    output.Write (".type");
    output.Write (Indent);
    output.Write (symbolName);
    output.Write (", ");
    output.Write (TargetProvider.TypePrefix);
    output.WriteLine ("object");

It is not quite as pretty but considerably faster.

Building the Xamarin.Forms integration project on Mono / macOS, I saw
an improvement for a build not using Fast Deployment:

    Before:
    1165 ms  GenerateJavaStubs                          1 calls
    1469 ms  GenerateJavaStubs                          1 calls
    1142 ms  GenerateJavaStubs                          1 calls
    After:
     912 ms  GenerateJavaStubs                          1 calls
     958 ms  GenerateJavaStubs                          1 calls
     878 ms  GenerateJavaStubs                          1 calls

I would say it probably helps by ~200ms.

The allocations:

    Allocation summary
        Bytes      Count  Average Type name
    Before:
    119496704    1583058       75 System.String
    After:
    111715408    1459606       76 System.String

~7,781,296 less bytes allocated. I suspect it would be even better for
builds using Fast Deployment.