### PR TITLE
Remove KeyTool from signing

### DIFF
--- a/Documentation/release-notes/4308.md
+++ b/Documentation/release-notes/4308.md
@@ -15,3 +15,8 @@ Running `keytool -list` does *nothing* to benefit the development loop,
 while the archive workflow within Visual Studio can show the same information.
 
 [show-sha1]: https://xamarin.github.io/bugzilla-archives/13/13154/bug.html
+
+If you still need to determine the Keystore Signature, please follow the steps
+in the article [Finding your Keystore's Signature][keystore-sig].
+
+[keystore-sig]: https://docs.microsoft.com/en-us/xamarin/android/deploy-test/signing/keystore-signature?tabs=windows

--- a/Documentation/release-notes/4308.md
+++ b/Documentation/release-notes/4308.md
@@ -1,0 +1,17 @@
+### Build and deployment performance
+
+The `SignAndroidPackage` target will no longer execute the command:
+
+```
+keytool -list -keystore $(AndroidSigningKeyStore) --storepass $(AndroidSigningStorePass) -v
+```
+
+This was originally done [as a convenience][show-sha1], but this
+adds ~200ms to the execution time of the `SignAndroidPackage` target,
+which is executed as part of the inner development loop and the
+Apply Changes feature within the UI Designer.
+
+Running `keytool -list` does *nothing* to benefit the development loop,
+while the archive workflow within Visual Studio can show the same information.
+
+[show-sha1]: https://xamarin.github.io/bugzilla-archives/13/13154/bug.html

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -3001,15 +3001,6 @@ because xbuild doesn't support framework reference assemblies.
 		<_JarSignerSuffix Condition=" '$(AndroidPackageFormat)' != 'aab' ">-Signed-Unaligned</_JarSignerSuffix>
 		<_JarSignerSuffix Condition=" '$(AndroidPackageFormat)' == 'aab' ">-Signed</_JarSignerSuffix>
 	</PropertyGroup>
-	<KeyTool
-		KeyStore="$(_ApkKeyStore)"
-		KeyAlias="$(_ApkKeyAlias)"
-		KeyPass="$(_ApkKeyPass)"
-		StorePass="$(_ApkStorePass)"
-		ToolPath="$(KeytoolToolPath)"
-		ToolExe="$(KeytoolToolExe)"
-		Command="-list"
-		Condition="'$(AndroidKeyStore)'==''" />
 	<AndroidSignPackage Condition=" '$(AndroidUseApkSigner)' != 'true' "
 		UnsignedApk="%(ApkAbiFilesIntermediate.FullPath)"
 		SignedApkDirectory="$(OutDir)"


### PR DESCRIPTION
Invoking keytool takes about 200ms (my machine, best case, likely mostly due to java startup). Peppers and I were looking for ways to speed up Apply Changes builds and Android builds in general. For Apply Changes, removing the call to keytool (or caching its result if it's needed) was next on my optimization list.

It looks like the KeyTool invocation isn't needed at all.
Here's the commit which added it, 5 years ago: https://github.com/xamarin/monodroid/commit/fe94c0a88ca68e78a639d0032fb59dd91409e9ca

The comment there says "emit the SHA1 during the _Sign target to make it easier for people to publish to google play".
But note that:
- KeyTool is only run when the AndroidKeyStore isn't supplied, so it's only run when using the default debug keystore, not when the user supplies one
- I don't actually see anything output in VS (at least on Windows) in the build log when keytool is run there - the output isn't captured.
- KeyTool output isn't used as other otherwise by our build (except for an error blowing out the build)
- If the user suppolies an invalid keystore or key alias password, the sign task itself will fail (I did a quick test to verify).

So it seems like KeyTool doesn't serve any useful purpose here & we'd like to get the perf bump of removing it.
Unless Dean can think of reasons why we shouldn't, it seems safe to pull it.