### PR TITLE
[Xamarin.Android.Build.Tasks] Make XA0108, XA2006, & XA5213 localizable

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -82,6 +82,8 @@ ms.date: 01/24/2020
 
 ## XA2xxx: Linker
 
++ XA2006: Could not resolve reference to '{member}' (defined in assembly '{assembly}') with scope '{scope}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.
+
 ## XA3xxx: Unmanaged code compilation
 
 + XA3001: Could not AOT the assembly: {assembly}
@@ -117,6 +119,7 @@ ms.date: 01/24/2020
 + XA5103: Toolchain utility '{utility}' for target {arch} was not found. Tried in path: "{path}"
 + [XA5205](xa5205.md): Cannot find `{ToolName}` in the Android SDK.
 + [XA5207](xa5207.md): Could not find android.jar for API Level `{compileSdk}`.
++ XA5213: java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{tool} {arguments}'
 + [XA5300](xa5300.md): The Android/Java SDK Directory could not be found.
 + [XA5301](xa5301.md): Failed to generate Java type for class: {managedType} due to MAX_PATH: {exception}
 + [XA5302](xa5302.md): Two processes may be building this project at once. Lock file exists at path: {path}

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -106,6 +106,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not get version from &apos;{0}&apos;. Defaulting to 1.0.
+        /// </summary>
+        internal static string XA0108 {
+            get {
+                return ResourceManager.GetString("XA0108", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to find `EmbeddedResource` named `{0}`..
         /// </summary>
         internal static string XA0116 {
@@ -201,6 +210,15 @@ namespace Xamarin.Android.Tasks.Properties {
         internal static string XA2001 {
             get {
                 return ResourceManager.GetString("XA2001", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not resolve reference to &apos;{0}&apos; (defined in assembly &apos;{1}&apos;) with scope &apos;{2}&apos;. When the scope is different from the defining assembly, it usually means that the type is forwarded..
+        /// </summary>
+        internal static string XA2006 {
+            get {
+                return ResourceManager.GetString("XA2006", resourceCulture);
             }
         }
         
@@ -471,6 +489,15 @@ namespace Xamarin.Android.Tasks.Properties {
         internal static string XA5205_Lint {
             get {
                 return ResourceManager.GetString("XA5205_Lint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing &apos;{0} {1}&apos;.
+        /// </summary>
+        internal static string XA5213 {
+            get {
+                return ResourceManager.GetString("XA5213", resourceCulture);
             }
         }
         

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -137,6 +137,10 @@
     <value>Ignoring Reference Assembly `{0}`.</value>
     <comment>{0} - File name of the assembly.</comment>
   </data>
+  <data name="XA0108" xml:space="preserve">
+    <value>Could not get version from '{0}'. Defaulting to 1.0</value>
+    <comment>{0} - The tool name</comment>
+  </data>
   <data name="XA0116" xml:space="preserve">
     <value>Unable to find `EmbeddedResource` named `{0}`.</value>
     <comment>The following are literal names and should not be translated: EmbeddedResource
@@ -191,6 +195,12 @@
   </data>
   <data name="XA2001" xml:space="preserve">
     <value>Source file '{0}' could not be found.</value>
+  </data>
+  <data name="XA2006" xml:space="preserve">
+    <value>Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</value>
+    <comment>{0} - The member name, such as a class name
+{1} - The assembly name
+{2} - The scope of the member, such as the name of a different assembly</comment>
   </data>
   <data name="XA3001" xml:space="preserve">
     <value>Could not AOT the assembly: {0}</value>
@@ -333,6 +343,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
     <value>Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</value>
     <comment>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</comment>
+  </data>
+  <data name="XA5213" xml:space="preserve">
+    <value>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</value>
+    <comment>The following are literal names and should not be translated: java.lang.OutOfMemoryError, $(JavaMaximumHeapSize)
+{0} - The tool name
+{1} - The command line arguments used for the tool</comment>
   </data>
   <data name="XA5300_Android_Platforms" xml:space="preserve">
     <value>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0108">
+        <source>Could not get version from '{0}'. Defaulting to 1.0</source>
+        <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
+        <note>{0} - The tool name</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
@@ -94,6 +99,13 @@
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA2006">
+        <source>Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</source>
+        <target state="new">Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</target>
+        <note>{0} - The member name, such as a class name
+{1} - The assembly name
+{2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
@@ -269,6 +281,13 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5213">
+        <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
+        <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
+        <note>The following are literal names and should not be translated: java.lang.OutOfMemoryError, $(JavaMaximumHeapSize)
+{0} - The tool name
+{1} - The command line arguments used for the tool</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_Platforms">
         <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0108">
+        <source>Could not get version from '{0}'. Defaulting to 1.0</source>
+        <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
+        <note>{0} - The tool name</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
@@ -94,6 +99,13 @@
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA2006">
+        <source>Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</source>
+        <target state="new">Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</target>
+        <note>{0} - The member name, such as a class name
+{1} - The assembly name
+{2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
@@ -269,6 +281,13 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5213">
+        <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
+        <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
+        <note>The following are literal names and should not be translated: java.lang.OutOfMemoryError, $(JavaMaximumHeapSize)
+{0} - The tool name
+{1} - The command line arguments used for the tool</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_Platforms">
         <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0108">
+        <source>Could not get version from '{0}'. Defaulting to 1.0</source>
+        <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
+        <note>{0} - The tool name</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
@@ -94,6 +99,13 @@
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA2006">
+        <source>Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</source>
+        <target state="new">Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</target>
+        <note>{0} - The member name, such as a class name
+{1} - The assembly name
+{2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
@@ -269,6 +281,13 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5213">
+        <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
+        <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
+        <note>The following are literal names and should not be translated: java.lang.OutOfMemoryError, $(JavaMaximumHeapSize)
+{0} - The tool name
+{1} - The command line arguments used for the tool</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_Platforms">
         <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0108">
+        <source>Could not get version from '{0}'. Defaulting to 1.0</source>
+        <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
+        <note>{0} - The tool name</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
@@ -94,6 +99,13 @@
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA2006">
+        <source>Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</source>
+        <target state="new">Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</target>
+        <note>{0} - The member name, such as a class name
+{1} - The assembly name
+{2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
@@ -269,6 +281,13 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5213">
+        <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
+        <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
+        <note>The following are literal names and should not be translated: java.lang.OutOfMemoryError, $(JavaMaximumHeapSize)
+{0} - The tool name
+{1} - The command line arguments used for the tool</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_Platforms">
         <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0108">
+        <source>Could not get version from '{0}'. Defaulting to 1.0</source>
+        <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
+        <note>{0} - The tool name</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
@@ -94,6 +99,13 @@
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA2006">
+        <source>Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</source>
+        <target state="new">Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</target>
+        <note>{0} - The member name, such as a class name
+{1} - The assembly name
+{2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
@@ -269,6 +281,13 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5213">
+        <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
+        <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
+        <note>The following are literal names and should not be translated: java.lang.OutOfMemoryError, $(JavaMaximumHeapSize)
+{0} - The tool name
+{1} - The command line arguments used for the tool</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_Platforms">
         <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0108">
+        <source>Could not get version from '{0}'. Defaulting to 1.0</source>
+        <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
+        <note>{0} - The tool name</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
@@ -94,6 +99,13 @@
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA2006">
+        <source>Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</source>
+        <target state="new">Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</target>
+        <note>{0} - The member name, such as a class name
+{1} - The assembly name
+{2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
@@ -269,6 +281,13 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5213">
+        <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
+        <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
+        <note>The following are literal names and should not be translated: java.lang.OutOfMemoryError, $(JavaMaximumHeapSize)
+{0} - The tool name
+{1} - The command line arguments used for the tool</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_Platforms">
         <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0108">
+        <source>Could not get version from '{0}'. Defaulting to 1.0</source>
+        <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
+        <note>{0} - The tool name</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
@@ -94,6 +99,13 @@
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA2006">
+        <source>Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</source>
+        <target state="new">Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</target>
+        <note>{0} - The member name, such as a class name
+{1} - The assembly name
+{2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
@@ -269,6 +281,13 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5213">
+        <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
+        <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
+        <note>The following are literal names and should not be translated: java.lang.OutOfMemoryError, $(JavaMaximumHeapSize)
+{0} - The tool name
+{1} - The command line arguments used for the tool</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_Platforms">
         <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0108">
+        <source>Could not get version from '{0}'. Defaulting to 1.0</source>
+        <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
+        <note>{0} - The tool name</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
@@ -94,6 +99,13 @@
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA2006">
+        <source>Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</source>
+        <target state="new">Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</target>
+        <note>{0} - The member name, such as a class name
+{1} - The assembly name
+{2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
@@ -269,6 +281,13 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5213">
+        <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
+        <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
+        <note>The following are literal names and should not be translated: java.lang.OutOfMemoryError, $(JavaMaximumHeapSize)
+{0} - The tool name
+{1} - The command line arguments used for the tool</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_Platforms">
         <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0108">
+        <source>Could not get version from '{0}'. Defaulting to 1.0</source>
+        <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
+        <note>{0} - The tool name</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
@@ -94,6 +99,13 @@
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA2006">
+        <source>Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</source>
+        <target state="new">Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</target>
+        <note>{0} - The member name, such as a class name
+{1} - The assembly name
+{2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
@@ -269,6 +281,13 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5213">
+        <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
+        <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
+        <note>The following are literal names and should not be translated: java.lang.OutOfMemoryError, $(JavaMaximumHeapSize)
+{0} - The tool name
+{1} - The command line arguments used for the tool</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_Platforms">
         <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0108">
+        <source>Could not get version from '{0}'. Defaulting to 1.0</source>
+        <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
+        <note>{0} - The tool name</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
@@ -94,6 +99,13 @@
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA2006">
+        <source>Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</source>
+        <target state="new">Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</target>
+        <note>{0} - The member name, such as a class name
+{1} - The assembly name
+{2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
@@ -269,6 +281,13 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5213">
+        <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
+        <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
+        <note>The following are literal names and should not be translated: java.lang.OutOfMemoryError, $(JavaMaximumHeapSize)
+{0} - The tool name
+{1} - The command line arguments used for the tool</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_Platforms">
         <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0108">
+        <source>Could not get version from '{0}'. Defaulting to 1.0</source>
+        <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
+        <note>{0} - The tool name</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
@@ -94,6 +99,13 @@
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA2006">
+        <source>Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</source>
+        <target state="new">Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</target>
+        <note>{0} - The member name, such as a class name
+{1} - The assembly name
+{2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
@@ -269,6 +281,13 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5213">
+        <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
+        <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
+        <note>The following are literal names and should not be translated: java.lang.OutOfMemoryError, $(JavaMaximumHeapSize)
+{0} - The tool name
+{1} - The command line arguments used for the tool</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_Platforms">
         <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0108">
+        <source>Could not get version from '{0}'. Defaulting to 1.0</source>
+        <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
+        <note>{0} - The tool name</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
@@ -94,6 +99,13 @@
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA2006">
+        <source>Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</source>
+        <target state="new">Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</target>
+        <note>{0} - The member name, such as a class name
+{1} - The assembly name
+{2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
@@ -269,6 +281,13 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5213">
+        <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
+        <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
+        <note>The following are literal names and should not be translated: java.lang.OutOfMemoryError, $(JavaMaximumHeapSize)
+{0} - The tool name
+{1} - The command line arguments used for the tool</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_Platforms">
         <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -28,6 +28,11 @@
         <target state="new">Ignoring Reference Assembly `{0}`.</target>
         <note>{0} - File name of the assembly.</note>
       </trans-unit>
+      <trans-unit id="XA0108">
+        <source>Could not get version from '{0}'. Defaulting to 1.0</source>
+        <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
+        <note>{0} - The tool name</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
@@ -94,6 +99,13 @@
         <source>Source file '{0}' could not be found.</source>
         <target state="new">Source file '{0}' could not be found.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="XA2006">
+        <source>Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</source>
+        <target state="new">Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.</target>
+        <note>{0} - The member name, such as a class name
+{1} - The assembly name
+{2} - The scope of the member, such as the name of a different assembly</note>
       </trans-unit>
       <trans-unit id="XA3001">
         <source>Could not AOT the assembly: {0}</source>
@@ -269,6 +281,13 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <target state="new">Cannot find `{0}` in the Android SDK. Please set its path via /p:LintToolPath.</target>
         <note>The following are literal names and should not be translated: /p:LintToolPath
 {0} - The missing tool name</note>
+      </trans-unit>
+      <trans-unit id="XA5213">
+        <source>java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</source>
+        <target state="new">java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'</target>
+        <note>The following are literal names and should not be translated: java.lang.OutOfMemoryError, $(JavaMaximumHeapSize)
+{0} - The tool name
+{1} - The command line arguments used for the tool</note>
       </trans-unit>
       <trans-unit id="XA5300_Android_Platforms">
         <source>No Android platforms installed at '{0}'. Please install an SDK Platform with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/JavaToolTask.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/JavaToolTask.cs
@@ -108,9 +108,7 @@ namespace Xamarin.Android.Tasks
 		void LogFromException (string exception, string error) {
 			switch (exception) {
 				case "java.lang.OutOfMemoryError":
-					Log.LogCodedError ("XA5213", 
-						"java.lang.OutOfMemoryError. Consider increasing the value of $(JavaMaximumHeapSize). Java ran out of memory while executing '{0} {1}'",
-						ToolName, GenerateCommandLineCommands ());
+					Log.LogCodedError ("XA5213", Properties.Resources.XA5213, ToolName, GenerateCommandLineCommands ());
 					break;
 				default:
 					Log.LogCodedError (DefaultErrorCode, "{0} : {1}", exception, error);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssemblies.cs
@@ -136,7 +136,7 @@ namespace Xamarin.Android.Tasks
 					MonoAndroidHelper.CopyAssemblyAndSymbols (copysrc, assemblyDestination);
 				}
 			} catch (ResolutionException ex) {
-				Diagnostic.Error (2006, ex, "Could not resolve reference to '{0}' (defined in assembly '{1}') with scope '{2}'. When the scope is different from the defining assembly, it usually means that the type is forwarded.", ex.Member, ex.Member.Module.Assembly, ex.Scope);
+				Diagnostic.Error (2006, ex, Properties.Resources.XA2006, ex.Member, ex.Member.Module.Assembly, ex.Scope);
 			}
 
 			return true;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Lint.cs
@@ -381,7 +381,7 @@ namespace Xamarin.Android.Tasks
 						}
 					}
 				}
-				Log.LogCodedWarning ("XA0108", $"Could not get version from '{tool}'. Defaulting to 1.0");
+				Log.LogCodedWarning ("XA0108", Properties.Resources.XA0108, tool);
 				return new Version (1, 0);
 			}
 			// lint: version 26.0.2


### PR DESCRIPTION
Context: 0342fe5698b86e21e36c924732ff135b9a87e4af
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Move the message strings for XA0108, XA2006, & XA5213 into the `.resx`
file so that they are localizable.