### PR TITLE
[Xamarin.Android.Build.Tasks] Make XA5102, XA5103, & XA5201 localizable

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -113,8 +113,11 @@ ms.date: 01/24/2020
 ## XA5xxx: GCC and toolchain
 
 + XA5101: Missing Android NDK toolchains directory '{path}'. Please install the Android NDK.
-+ XA5102: Could not locate the Android NDK.
-+ XA5103: Toolchain utility '{utility}' for target {arch} was not found. Tried in path: "{path}"
++ XA5102: Conversion from assembly to native code failed. Exit code {exitCode}
++ XA5103: NDK C compiler exited with an error. Exit code {0}
++ XA5104: Could not locate the Android NDK.
++ XA5105: Toolchain utility '{utility}' for target {arch} was not found. Tried in path: "{path}"
++ XA5201: NDK linker exited with an error. Exit code {0}
 + [XA5205](xa5205.md): Cannot find `{ToolName}` in the Android SDK.
 + [XA5207](xa5207.md): Could not find android.jar for API Level `{compileSdk}`.
 + [XA5300](xa5300.md): The Android/Java SDK Directory could not be found.

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -439,7 +439,7 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path..
+        ///   Looks up a localized string similar to Conversion from assembly to native code failed. Exit code {0}.
         /// </summary>
         internal static string XA5102 {
             get {
@@ -448,11 +448,38 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Toolchain utility &apos;{0}&apos; for target {1} was not found. Tried in path: &quot;{2}&quot;.
+        ///   Looks up a localized string similar to NDK C compiler exited with an error. Exit code {0}.
         /// </summary>
         internal static string XA5103 {
             get {
                 return ResourceManager.GetString("XA5103", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path..
+        /// </summary>
+        internal static string XA5104 {
+            get {
+                return ResourceManager.GetString("XA5104", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Toolchain utility &apos;{0}&apos; for target {1} was not found. Tried in path: &quot;{2}&quot;.
+        /// </summary>
+        internal static string XA5105 {
+            get {
+                return ResourceManager.GetString("XA5105", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to NDK linker exited with an error. Exit code {0}.
+        /// </summary>
+        internal static string XA5201 {
+            get {
+                return ResourceManager.GetString("XA5201", resourceCulture);
             }
         }
         

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -206,6 +206,7 @@
   </data>
   <data name="XA3004" xml:space="preserve">
     <value>Could not compile native assembly file: {0}</value>
+    <comment>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</comment>
   </data>
   <data name="XA3005" xml:space="preserve">
     <value>Could not link native shared library: {0}</value>
@@ -312,14 +313,29 @@ In this message, the term "bundled" is a short way of saying "included into the 
     <comment>{0} - The target architecture, such as Arm, Arm64, or X86_64</comment>
   </data>
   <data name="XA5102" xml:space="preserve">
+    <value>Conversion from assembly to native code failed. Exit code {0}</value>
+    <comment>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)
+{0} - The exit code number</comment>
+  </data>
+  <data name="XA5103" xml:space="preserve">
+    <value>NDK C compiler exited with an error. Exit code {0}</value>
+    <comment>The following are literal names and should not be translated: NDK, C
+{0} - The exit code number</comment>
+  </data>
+  <data name="XA5104" xml:space="preserve">
     <value>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</value>
     <comment>The following are literal names and should not be translated: $(AndroidNdkDirectory)</comment>
   </data>
-  <data name="XA5103" xml:space="preserve">
+  <data name="XA5105" xml:space="preserve">
     <value>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</value>
     <comment>{0} - The missing utility name, such as gcc or clang
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</comment>
+  </data>
+  <data name="XA5201" xml:space="preserve">
+    <value>NDK linker exited with an error. Exit code {0}</value>
+    <comment>The following are literal names and should not be translated: NDK
+{0} - The exit code number</comment>
   </data>
   <data name="XA5205" xml:space="preserve">
     <value>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -113,7 +113,7 @@
       <trans-unit id="XA3004">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
-        <note />
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
       <trans-unit id="XA3005">
         <source>Could not link native shared library: {0}</source>
@@ -244,16 +244,34 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
       </trans-unit>
       <trans-unit id="XA5102">
+        <source>Conversion from assembly to native code failed. Exit code {0}</source>
+        <target state="new">Conversion from assembly to native code failed. Exit code {0}</target>
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>NDK C compiler exited with an error. Exit code {0}</source>
+        <target state="new">NDK C compiler exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK, C
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5104">
         <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
         <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
         <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
       </trans-unit>
-      <trans-unit id="XA5103">
+      <trans-unit id="XA5105">
         <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
         <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
         <note>{0} - The missing utility name, such as gcc or clang
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
+      </trans-unit>
+      <trans-unit id="XA5201">
+        <source>NDK linker exited with an error. Exit code {0}</source>
+        <target state="new">NDK linker exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK
+{0} - The exit code number</note>
       </trans-unit>
       <trans-unit id="XA5205">
         <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -113,7 +113,7 @@
       <trans-unit id="XA3004">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
-        <note />
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
       <trans-unit id="XA3005">
         <source>Could not link native shared library: {0}</source>
@@ -244,16 +244,34 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
       </trans-unit>
       <trans-unit id="XA5102">
+        <source>Conversion from assembly to native code failed. Exit code {0}</source>
+        <target state="new">Conversion from assembly to native code failed. Exit code {0}</target>
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>NDK C compiler exited with an error. Exit code {0}</source>
+        <target state="new">NDK C compiler exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK, C
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5104">
         <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
         <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
         <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
       </trans-unit>
-      <trans-unit id="XA5103">
+      <trans-unit id="XA5105">
         <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
         <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
         <note>{0} - The missing utility name, such as gcc or clang
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
+      </trans-unit>
+      <trans-unit id="XA5201">
+        <source>NDK linker exited with an error. Exit code {0}</source>
+        <target state="new">NDK linker exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK
+{0} - The exit code number</note>
       </trans-unit>
       <trans-unit id="XA5205">
         <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -113,7 +113,7 @@
       <trans-unit id="XA3004">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
-        <note />
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
       <trans-unit id="XA3005">
         <source>Could not link native shared library: {0}</source>
@@ -244,16 +244,34 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
       </trans-unit>
       <trans-unit id="XA5102">
+        <source>Conversion from assembly to native code failed. Exit code {0}</source>
+        <target state="new">Conversion from assembly to native code failed. Exit code {0}</target>
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>NDK C compiler exited with an error. Exit code {0}</source>
+        <target state="new">NDK C compiler exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK, C
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5104">
         <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
         <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
         <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
       </trans-unit>
-      <trans-unit id="XA5103">
+      <trans-unit id="XA5105">
         <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
         <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
         <note>{0} - The missing utility name, such as gcc or clang
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
+      </trans-unit>
+      <trans-unit id="XA5201">
+        <source>NDK linker exited with an error. Exit code {0}</source>
+        <target state="new">NDK linker exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK
+{0} - The exit code number</note>
       </trans-unit>
       <trans-unit id="XA5205">
         <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -113,7 +113,7 @@
       <trans-unit id="XA3004">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
-        <note />
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
       <trans-unit id="XA3005">
         <source>Could not link native shared library: {0}</source>
@@ -244,16 +244,34 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
       </trans-unit>
       <trans-unit id="XA5102">
+        <source>Conversion from assembly to native code failed. Exit code {0}</source>
+        <target state="new">Conversion from assembly to native code failed. Exit code {0}</target>
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>NDK C compiler exited with an error. Exit code {0}</source>
+        <target state="new">NDK C compiler exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK, C
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5104">
         <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
         <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
         <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
       </trans-unit>
-      <trans-unit id="XA5103">
+      <trans-unit id="XA5105">
         <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
         <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
         <note>{0} - The missing utility name, such as gcc or clang
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
+      </trans-unit>
+      <trans-unit id="XA5201">
+        <source>NDK linker exited with an error. Exit code {0}</source>
+        <target state="new">NDK linker exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK
+{0} - The exit code number</note>
       </trans-unit>
       <trans-unit id="XA5205">
         <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -113,7 +113,7 @@
       <trans-unit id="XA3004">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
-        <note />
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
       <trans-unit id="XA3005">
         <source>Could not link native shared library: {0}</source>
@@ -244,16 +244,34 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
       </trans-unit>
       <trans-unit id="XA5102">
+        <source>Conversion from assembly to native code failed. Exit code {0}</source>
+        <target state="new">Conversion from assembly to native code failed. Exit code {0}</target>
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>NDK C compiler exited with an error. Exit code {0}</source>
+        <target state="new">NDK C compiler exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK, C
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5104">
         <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
         <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
         <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
       </trans-unit>
-      <trans-unit id="XA5103">
+      <trans-unit id="XA5105">
         <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
         <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
         <note>{0} - The missing utility name, such as gcc or clang
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
+      </trans-unit>
+      <trans-unit id="XA5201">
+        <source>NDK linker exited with an error. Exit code {0}</source>
+        <target state="new">NDK linker exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK
+{0} - The exit code number</note>
       </trans-unit>
       <trans-unit id="XA5205">
         <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -113,7 +113,7 @@
       <trans-unit id="XA3004">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
-        <note />
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
       <trans-unit id="XA3005">
         <source>Could not link native shared library: {0}</source>
@@ -244,16 +244,34 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
       </trans-unit>
       <trans-unit id="XA5102">
+        <source>Conversion from assembly to native code failed. Exit code {0}</source>
+        <target state="new">Conversion from assembly to native code failed. Exit code {0}</target>
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>NDK C compiler exited with an error. Exit code {0}</source>
+        <target state="new">NDK C compiler exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK, C
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5104">
         <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
         <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
         <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
       </trans-unit>
-      <trans-unit id="XA5103">
+      <trans-unit id="XA5105">
         <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
         <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
         <note>{0} - The missing utility name, such as gcc or clang
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
+      </trans-unit>
+      <trans-unit id="XA5201">
+        <source>NDK linker exited with an error. Exit code {0}</source>
+        <target state="new">NDK linker exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK
+{0} - The exit code number</note>
       </trans-unit>
       <trans-unit id="XA5205">
         <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -113,7 +113,7 @@
       <trans-unit id="XA3004">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
-        <note />
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
       <trans-unit id="XA3005">
         <source>Could not link native shared library: {0}</source>
@@ -244,16 +244,34 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
       </trans-unit>
       <trans-unit id="XA5102">
+        <source>Conversion from assembly to native code failed. Exit code {0}</source>
+        <target state="new">Conversion from assembly to native code failed. Exit code {0}</target>
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>NDK C compiler exited with an error. Exit code {0}</source>
+        <target state="new">NDK C compiler exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK, C
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5104">
         <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
         <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
         <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
       </trans-unit>
-      <trans-unit id="XA5103">
+      <trans-unit id="XA5105">
         <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
         <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
         <note>{0} - The missing utility name, such as gcc or clang
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
+      </trans-unit>
+      <trans-unit id="XA5201">
+        <source>NDK linker exited with an error. Exit code {0}</source>
+        <target state="new">NDK linker exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK
+{0} - The exit code number</note>
       </trans-unit>
       <trans-unit id="XA5205">
         <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -113,7 +113,7 @@
       <trans-unit id="XA3004">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
-        <note />
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
       <trans-unit id="XA3005">
         <source>Could not link native shared library: {0}</source>
@@ -244,16 +244,34 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
       </trans-unit>
       <trans-unit id="XA5102">
+        <source>Conversion from assembly to native code failed. Exit code {0}</source>
+        <target state="new">Conversion from assembly to native code failed. Exit code {0}</target>
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>NDK C compiler exited with an error. Exit code {0}</source>
+        <target state="new">NDK C compiler exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK, C
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5104">
         <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
         <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
         <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
       </trans-unit>
-      <trans-unit id="XA5103">
+      <trans-unit id="XA5105">
         <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
         <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
         <note>{0} - The missing utility name, such as gcc or clang
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
+      </trans-unit>
+      <trans-unit id="XA5201">
+        <source>NDK linker exited with an error. Exit code {0}</source>
+        <target state="new">NDK linker exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK
+{0} - The exit code number</note>
       </trans-unit>
       <trans-unit id="XA5205">
         <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -113,7 +113,7 @@
       <trans-unit id="XA3004">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
-        <note />
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
       <trans-unit id="XA3005">
         <source>Could not link native shared library: {0}</source>
@@ -244,16 +244,34 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
       </trans-unit>
       <trans-unit id="XA5102">
+        <source>Conversion from assembly to native code failed. Exit code {0}</source>
+        <target state="new">Conversion from assembly to native code failed. Exit code {0}</target>
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>NDK C compiler exited with an error. Exit code {0}</source>
+        <target state="new">NDK C compiler exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK, C
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5104">
         <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
         <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
         <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
       </trans-unit>
-      <trans-unit id="XA5103">
+      <trans-unit id="XA5105">
         <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
         <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
         <note>{0} - The missing utility name, such as gcc or clang
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
+      </trans-unit>
+      <trans-unit id="XA5201">
+        <source>NDK linker exited with an error. Exit code {0}</source>
+        <target state="new">NDK linker exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK
+{0} - The exit code number</note>
       </trans-unit>
       <trans-unit id="XA5205">
         <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -113,7 +113,7 @@
       <trans-unit id="XA3004">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
-        <note />
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
       <trans-unit id="XA3005">
         <source>Could not link native shared library: {0}</source>
@@ -244,16 +244,34 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
       </trans-unit>
       <trans-unit id="XA5102">
+        <source>Conversion from assembly to native code failed. Exit code {0}</source>
+        <target state="new">Conversion from assembly to native code failed. Exit code {0}</target>
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>NDK C compiler exited with an error. Exit code {0}</source>
+        <target state="new">NDK C compiler exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK, C
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5104">
         <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
         <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
         <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
       </trans-unit>
-      <trans-unit id="XA5103">
+      <trans-unit id="XA5105">
         <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
         <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
         <note>{0} - The missing utility name, such as gcc or clang
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
+      </trans-unit>
+      <trans-unit id="XA5201">
+        <source>NDK linker exited with an error. Exit code {0}</source>
+        <target state="new">NDK linker exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK
+{0} - The exit code number</note>
       </trans-unit>
       <trans-unit id="XA5205">
         <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -113,7 +113,7 @@
       <trans-unit id="XA3004">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
-        <note />
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
       <trans-unit id="XA3005">
         <source>Could not link native shared library: {0}</source>
@@ -244,16 +244,34 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
       </trans-unit>
       <trans-unit id="XA5102">
+        <source>Conversion from assembly to native code failed. Exit code {0}</source>
+        <target state="new">Conversion from assembly to native code failed. Exit code {0}</target>
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>NDK C compiler exited with an error. Exit code {0}</source>
+        <target state="new">NDK C compiler exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK, C
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5104">
         <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
         <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
         <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
       </trans-unit>
-      <trans-unit id="XA5103">
+      <trans-unit id="XA5105">
         <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
         <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
         <note>{0} - The missing utility name, such as gcc or clang
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
+      </trans-unit>
+      <trans-unit id="XA5201">
+        <source>NDK linker exited with an error. Exit code {0}</source>
+        <target state="new">NDK linker exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK
+{0} - The exit code number</note>
       </trans-unit>
       <trans-unit id="XA5205">
         <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -113,7 +113,7 @@
       <trans-unit id="XA3004">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
-        <note />
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
       <trans-unit id="XA3005">
         <source>Could not link native shared library: {0}</source>
@@ -244,16 +244,34 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
       </trans-unit>
       <trans-unit id="XA5102">
+        <source>Conversion from assembly to native code failed. Exit code {0}</source>
+        <target state="new">Conversion from assembly to native code failed. Exit code {0}</target>
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>NDK C compiler exited with an error. Exit code {0}</source>
+        <target state="new">NDK C compiler exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK, C
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5104">
         <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
         <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
         <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
       </trans-unit>
-      <trans-unit id="XA5103">
+      <trans-unit id="XA5105">
         <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
         <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
         <note>{0} - The missing utility name, such as gcc or clang
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
+      </trans-unit>
+      <trans-unit id="XA5201">
+        <source>NDK linker exited with an error. Exit code {0}</source>
+        <target state="new">NDK linker exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK
+{0} - The exit code number</note>
       </trans-unit>
       <trans-unit id="XA5205">
         <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -113,7 +113,7 @@
       <trans-unit id="XA3004">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
-        <note />
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
       <trans-unit id="XA3005">
         <source>Could not link native shared library: {0}</source>
@@ -244,16 +244,34 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>{0} - The target architecture, such as Arm, Arm64, or X86_64</note>
       </trans-unit>
       <trans-unit id="XA5102">
+        <source>Conversion from assembly to native code failed. Exit code {0}</source>
+        <target state="new">Conversion from assembly to native code failed. Exit code {0}</target>
+        <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5103">
+        <source>NDK C compiler exited with an error. Exit code {0}</source>
+        <target state="new">NDK C compiler exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK, C
+{0} - The exit code number</note>
+      </trans-unit>
+      <trans-unit id="XA5104">
         <source>Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</source>
         <target state="new">Could not locate the Android NDK. Please make sure the Android NDK is installed in the Android SDK Manager, or if using a custom NDK path, please ensure the $(AndroidNdkDirectory) MSBuild property is set to the custom path.</target>
         <note>The following are literal names and should not be translated: $(AndroidNdkDirectory)</note>
       </trans-unit>
-      <trans-unit id="XA5103">
+      <trans-unit id="XA5105">
         <source>Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</source>
         <target state="new">Toolchain utility '{0}' for target {1} was not found. Tried in path: "{2}"</target>
         <note>{0} - The missing utility name, such as gcc or clang
 {1} - The target architecture, such as Arm, Arm64, or X86_64
 {2} - The path of the directory that was searched</note>
+      </trans-unit>
+      <trans-unit id="XA5201">
+        <source>NDK linker exited with an error. Exit code {0}</source>
+        <target state="new">NDK linker exited with an error. Exit code {0}</target>
+        <note>The following are literal names and should not be translated: NDK
+{0} - The exit code number</note>
       </trans-unit>
       <trans-unit id="XA5205">
         <source>Cannot find `{0}`. Please install the Android SDK Build-Tools package with the `{1}{2}tools{2}{3}` program.</source>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MakeBundleNativeCodeExternal.cs
@@ -158,7 +158,7 @@ namespace Xamarin.Android.Tasks
 				proc.BeginErrorReadLine ();
 				proc.WaitForExit ();
 				if (proc.ExitCode != 0) {
-					Log.LogCodedError ("XA5102", "Conversion from assembly to native code failed. Exit code {0}", proc.ExitCode);
+					Log.LogCodedError ("XA5102", Properties.Resources.XA5102, proc.ExitCode);
 					return false;
 				}
 
@@ -198,7 +198,7 @@ namespace Xamarin.Android.Tasks
 				clb.AppendFileNameIfNotNull (Path.Combine (outpath, "temp.c"));
 				Log.LogDebugMessage ("[CC] " + compiler + " " + clb);
 				if (MonoAndroidHelper.RunProcess (compilerNoQuotes, clb.ToString (), OnCcOutputData,  OnCcErrorData) != 0) {
-					Log.LogCodedError ("XA5103", "NDK C compiler resulted in an error. Exit code {0}", proc.ExitCode);
+					Log.LogCodedError ("XA5103", Properties.Resources.XA5103, proc.ExitCode);
 					return false;
 				}
 
@@ -224,7 +224,7 @@ namespace Xamarin.Android.Tasks
 				string ld = NdkUtil.GetNdkTool (AndroidNdkDirectory, arch, "ld", level);
 				Log.LogMessage (MessageImportance.Normal, "[LD] " + ld + " " + clb);
 				if (MonoAndroidHelper.RunProcess (ld, clb.ToString (), OnLdOutputData,  OnLdErrorData) != 0) {
-					Log.LogCodedError ("XA5201", "NDK Linker resulted in an error. Exit code {0}", proc.ExitCode);
+					Log.LogCodedError ("XA5201", Properties.Resources.XA5201, proc.ExitCode);
 					return false;
 				}
 				results.Add (new TaskItem (Path.Combine (outpath, "libmonodroid_bundle_app.so")));

--- a/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtils.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Android.Tasks
 			bool hasNdkVersion = GetNdkToolchainRelease (ndkPath ?? "", out ndkVersion);
 
 			if (!hasNdkVersion) {
-				logError ("XA5102", Properties.Resources.XA5102);
+				logError ("XA5104", Properties.Resources.XA5104);
 				return false;
 			}
 
@@ -185,7 +185,7 @@ namespace Xamarin.Android.Tasks
 			if (File.Exists (toolPath))
 				return toolPath;
 
-			Diagnostic.Error (5103, Properties.Resources.XA5103, toolName, arch, toolchainDir);
+			Diagnostic.Error (5105, Properties.Resources.XA5105, toolName, arch, toolchainDir);
 			return null;
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MakeBundleNativeCodeExternalTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MakeBundleNativeCodeExternalTests.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Android.Build.Tests {
 		[TestCase (null)]
 		[TestCase ("")]
 		[TestCase ("DoesNotExist")]
-		public void XA5102AndroidNdkNotFound (string androidNdkDirectory)
+		public void XA5104AndroidNdkNotFound (string androidNdkDirectory)
 		{
 			var task1 = new MakeBundleNativeCodeExternal {
 				BuildEngine = engine,
@@ -43,7 +43,7 @@ namespace Xamarin.Android.Build.Tests {
 
 			Assert.IsFalse (task1.Execute (), "Task should fail!");
 			BuildErrorEventArgs error1 = errors [0];
-			Assert.AreEqual ("XA5102", error1.Code);
+			Assert.AreEqual ("XA5104", error1.Code);
 			StringAssert.Contains (" NDK ", error1.Message);
 			StringAssert.Contains ("AndroidNdkDirectory", error1.Message);
 			StringAssert.Contains ("SDK Manager", error1.Message);


### PR DESCRIPTION
Context: 0342fe5698b86e21e36c924732ff135b9a87e4af
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Move the message strings for XA5102, XA5103, & XA5201 into the `.resx`
file so that they are localizable.

Other changes:

Reword "resulted in an error" to "exited with an error".

Renumber the conflicting XA5102 and XA5103 codes that I accidentally
added in 8acd915e.

Add the comment about the term "assembly" from XA5102 to the comments
for XA3004 as well because that message involves the same other meaning
of "assembly".