### PR TITLE
[xaprepare] Further steps to fix brew

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/HomebrewProgram.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/Application/HomebrewProgram.MacOS.cs
@@ -190,6 +190,11 @@ namespace Xamarin.Android.Prepare
 				return;
 			}
 
+			// It may happen that the package is installed but not linked to the prefix that's in the user's PATH.
+			// Detecting whether the package is linked would require requesting and parsing JSON for all the packages which
+			// would be more trouble than it's worth. Let's just link the package
+			await runner.Link (Name, echoOutput: false, echoError: false);
+
 			if (!Pin)
 				return;
 

--- a/build-tools/xaprepare/xaprepare/ToolRunners/BrewRunner.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/BrewRunner.MacOS.cs
@@ -21,6 +21,8 @@ namespace Xamarin.Android.Prepare
 			: base (context, log, toolPath)
 		{
 			ProcessTimeout = TimeSpan.FromMinutes (30);
+			EchoStandardError = true;
+			EchoStandardOutput = true;
 		}
 
 		string GetDefaultExecutableName ()
@@ -78,6 +80,14 @@ namespace Xamarin.Android.Prepare
 				throw new ArgumentException ("must not be null or empty", nameof (packageName));
 
 			return await RunBrew (echoOutput, echoError, "unlink", packageName);
+		}
+
+		public async Task<bool> Link (string packageName, bool echoOutput = true, bool echoError = true)
+		{
+			if (String.IsNullOrEmpty (packageName))
+				throw new ArgumentException ("must not be null or empty", nameof (packageName));
+
+			return await RunBrew (echoOutput, echoError, "link", packageName);
 		}
 
 		public async Task<bool> Upgrade (string packageName, bool echoOutput = true, bool echoError = true)


### PR DESCRIPTION
Turns out we can sometimes have a situation when a homebrew package is
installed but it's not linked into a directory that's found in the
user's `PATH` environment variable.

Remedy the situation by unconditionally linking all the packages we
depend on.