### PR TITLE
[Xamarin.Android.Build.Tasks] fix AndroidAsset with full path

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateManagedLibraryResourceArchive.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateManagedLibraryResourceArchive.cs
@@ -67,7 +67,7 @@ namespace Xamarin.Android.Tasks
 					var path = item.GetMetadata ("Link");
 					path = !string.IsNullOrWhiteSpace (path) ? path : item.ItemSpec;
 					var head = string.Join ("\\", path.Split (dir_sep).TakeWhile (s => !s.Equals (MonoAndroidAssetsPrefix, StringComparison.OrdinalIgnoreCase)));
-					path = head.Length == path.Length ? path : path.Substring ((head.Length == 0 ? 0 : head.Length + Path.DirectorySeparatorChar) + MonoAndroidAssetsPrefix.Length).TrimStart (dir_sep);
+					path = head.Length == path.Length ? path : path.Substring ((head.Length == 0 ? 0 : head.Length + 1) + MonoAndroidAssetsPrefix.Length).TrimStart (dir_sep);
 					MonoAndroidHelper.CopyIfChanged (item.ItemSpec, Path.Combine (dstsub, path));
 				}
 			}


### PR DESCRIPTION
Fixes: https://developercommunity.visualstudio.com/content/problem/917114/xamarinandroidtask-createmanagedlibraryresourcearc.html
Fixes: https://feedback.devdiv.io/917114

Creating an `@(AndroidAsset)` with a full path pointing outside your
project in a Xamarin.Android class library:

    <AndroidAsset Include="C:\path\to\foo.txt" LogicalName="Assets\foo.txt" />

Results in:

    (_CreateManagedLibraryResourceArchive target) ->
    error MSB4018: The "CreateManagedLibraryResourceArchive" task failed unexpectedly.
    error MSB4018: System.ArgumentOutOfRangeException: startIndex cannot be larger than length of string.
    error MSB4018: Parameter name: startIndex
    error MSB4018: at System.String.Substring(Int32 startIndex, Int32 length)
    error MSB4018: at System.String.Substring(Int32 startIndex)
    error MSB4018: at Xamarin.Android.Tasks.CreateManagedLibraryResourceArchive.Execute()
    error MSB4018: at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
    error MSB4018: at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext()

Reviewing the code, there appears to be a mistake:

    path = head.Length == path.Length ? path : path.Substring ((head.Length == 0 ? 0 : head.Length + Path.DirectorySeparatorChar) + MonoAndroidAssetsPrefix.Length).TrimStart (dir_sep);

The `head.Length + Path.DirectorySeparatorChar` expression *adds* the
`char` value as an integer... This should just be `head.Length + 1`.

This bug appears to have been introduced some time in 2014.

It seems to me this entire `<CreateManagedLibraryResourceArchive/>`
MSBuild task could be reworked and improved. The code is a bit
dodgy--it hasn't seen any love for a while.

For now, I fixed this bug and added a test case for this scenario.