### PR TITLE
[build] Optionally disable API compatibility check

### DIFF
--- a/Documentation/building/configuration.md
+++ b/Documentation/building/configuration.md
@@ -108,6 +108,10 @@ Overridable MSBuild properties include:
     Android NDK and SDK files. This value defaults to
     `$(HOME)\android-toolchain`.
 
+  * `$(DisableApiCompatibilityCheck)`: disable running the API compatibility
+    check when building Mono.Android if set to `True`. The check is performed
+    by default.
+
   * `$(HostCc)`, `$(HostCxx)`: The C and C++ compilers to use to generate
     host-native binaries.
 

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -174,6 +174,7 @@
   </ItemGroup>
   <Target
       Name="AfterBuild"
+      Condition=" '$(DisableApiCompatibilityCheck)' != 'True' "
       Inputs="$(TargetPath);@(ApiCompatibilityFiles)"
       Outputs="$(IntermediateOutputPath)CheckApiCompatibility.stamp">
     <CheckApiCompatibility


### PR DESCRIPTION
The API compatibility check runs after Mono.Android and friends are
built and on my machine it takes over 1.5 minutes to run:

    107208 ms  CheckApiCompatibility                      1 calls

Provide a way to optionally disable the check: set the
`DisableApiCompatibilityCheck` property to `True`.

By default the check is enabled.