### PR TITLE
Reverting "[Mono.Android] Add implicit int -> Color operator (#4120)"

### DIFF
--- a/src/Mono.Android/Android.Graphics/Color.cs
+++ b/src/Mono.Android/Android.Graphics/Color.cs
@@ -176,11 +176,6 @@ namespace Android.Graphics
 		{
 			return c.color;
 		}
-		
-		public static implicit operator Color(int argb)
-		{
-			return new Color(argb);
-		}
 
 		public override int GetHashCode ()
 		{


### PR DESCRIPTION
Unfortunately we detected that change 1d5ed48 causes cyclic dependency issues.

Xamarin forms have the follow usage that exposes the issue:
SetScrimColor(isShowingSplit ? Color.Transparent.ToAndroid() : (int)DefaultScrimColor);

the example above is unable to determine the correct usage, because now ToAndroid() returns Color, while DefaultScrimColor returns int.

The initial thoughts of having this extra operator was very good, but unfortunately we will not be able to keep at this time due to the reasons mentioned above.