### PR TITLE
[Xamarin.Android.Build.Tasks] XA4218, XA4304, & XA4307 l10n support

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -105,7 +105,7 @@ ms.date: 01/24/2020
 + [XA4301](xa4301.md): Apk already contains the item `xxx`.
 + [XA4302](xa4302.md): Unhandled exception merging \`AndroidManifest.xml]`: {ex}
 + [XA4303](xa4303.md): Error extracting resources from "{assemblyPath}": {ex}
-+ [XA4304](xa4304.md): Proguard configuration file '{file}' was not found.
++ [XA4304](xa4304.md): ProGuard configuration file '{file}' was not found.
 + [XA4305](xa4305.md): Multidex is enabled, but \`$(\_AndroidMainDexListFile)\` is empty.
 + [XA4306](xa4306.md): R8 does not support \`@(MultiDexMainDexList)\` files when android:minSdkVersion >= 21
 + [XA4307](xa4307.md): Invalid ProGuard configuration file.

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -349,6 +349,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to find //manifest/application/uses-library at path: {0}.
+        /// </summary>
+        internal static string XA4218 {
+            get {
+                return ResourceManager.GetString("XA4218", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Native library &apos;{0}&apos; will not be bundled because it has an unsupported ABI..
         /// </summary>
         internal static string XA4300 {
@@ -385,6 +394,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ProGuard configuration file &apos;{0}&apos; was not found..
+        /// </summary>
+        internal static string XA4304 {
+            get {
+                return ResourceManager.GetString("XA4304", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty..
         /// </summary>
         internal static string XA4305 {
@@ -408,6 +426,15 @@ namespace Xamarin.Android.Tasks.Properties {
         internal static string XA4306 {
             get {
                 return ResourceManager.GetString("XA4306", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid ProGuard configuration file. {0}.
+        /// </summary>
+        internal static string XA4307 {
+            get {
+                return ResourceManager.GetString("XA4307", resourceCulture);
             }
         }
         

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -269,6 +269,10 @@
 {0} - The target SDK version number
 {1} - The API version number</comment>
   </data>
+  <data name="XA4218" xml:space="preserve">
+    <value>Unable to find //manifest/application/uses-library at path: {0}</value>
+    <comment>The following are literal names and should not be translated: //manifest/application/uses-library</comment>
+  </data>
   <data name="XA4300" xml:space="preserve">
     <value>Native library '{0}' will not be bundled because it has an unsupported ABI.</value>
     <comment>The abbreviation "ABI" should not be translated.
@@ -288,6 +292,10 @@ In this message, the term "bundled" is a short way of saying "included into the 
     <comment>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</comment>
   </data>
+  <data name="XA4304" xml:space="preserve">
+    <value>ProGuard configuration file '{0}' was not found.</value>
+    <comment>The following are literal names and should not be translated: ProGuard</comment>
+  </data>
   <data name="XA4305" xml:space="preserve">
     <value>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</value>
     <comment>The following are literal names and should not be translated: Multidex, $(_AndroidMainDexListFile)</comment>
@@ -299,6 +307,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
   <data name="XA4306" xml:space="preserve">
     <value>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</value>
     <comment>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</comment>
+  </data>
+  <data name="XA4307" xml:space="preserve">
+    <value>Invalid ProGuard configuration file. {0}</value>
+    <comment>The following are literal names and should not be translated: ProGuard
+{0} - The error message returned by the ProGuard tool.</comment>
   </data>
   <data name="XA4308" xml:space="preserve">
     <value>Failed to generate type maps</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -190,6 +190,11 @@
 {0} - The target SDK version number
 {1} - The API version number</note>
       </trans-unit>
+      <trans-unit id="XA4218">
+        <source>Unable to find //manifest/application/uses-library at path: {0}</source>
+        <target state="new">Unable to find //manifest/application/uses-library at path: {0}</target>
+        <note>The following are literal names and should not be translated: //manifest/application/uses-library</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI.</target>
@@ -213,6 +218,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4304">
+        <source>ProGuard configuration file '{0}' was not found.</source>
+        <target state="new">ProGuard configuration file '{0}' was not found.</target>
+        <note>The following are literal names and should not be translated: ProGuard</note>
+      </trans-unit>
       <trans-unit id="XA4305">
         <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
         <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
@@ -227,6 +237,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
         <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
         <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA4307">
+        <source>Invalid ProGuard configuration file. {0}</source>
+        <target state="new">Invalid ProGuard configuration file. {0}</target>
+        <note>The following are literal names and should not be translated: ProGuard
+{0} - The error message returned by the ProGuard tool.</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -190,6 +190,11 @@
 {0} - The target SDK version number
 {1} - The API version number</note>
       </trans-unit>
+      <trans-unit id="XA4218">
+        <source>Unable to find //manifest/application/uses-library at path: {0}</source>
+        <target state="new">Unable to find //manifest/application/uses-library at path: {0}</target>
+        <note>The following are literal names and should not be translated: //manifest/application/uses-library</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI.</target>
@@ -213,6 +218,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4304">
+        <source>ProGuard configuration file '{0}' was not found.</source>
+        <target state="new">ProGuard configuration file '{0}' was not found.</target>
+        <note>The following are literal names and should not be translated: ProGuard</note>
+      </trans-unit>
       <trans-unit id="XA4305">
         <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
         <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
@@ -227,6 +237,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
         <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
         <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA4307">
+        <source>Invalid ProGuard configuration file. {0}</source>
+        <target state="new">Invalid ProGuard configuration file. {0}</target>
+        <note>The following are literal names and should not be translated: ProGuard
+{0} - The error message returned by the ProGuard tool.</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -190,6 +190,11 @@
 {0} - The target SDK version number
 {1} - The API version number</note>
       </trans-unit>
+      <trans-unit id="XA4218">
+        <source>Unable to find //manifest/application/uses-library at path: {0}</source>
+        <target state="new">Unable to find //manifest/application/uses-library at path: {0}</target>
+        <note>The following are literal names and should not be translated: //manifest/application/uses-library</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI.</target>
@@ -213,6 +218,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4304">
+        <source>ProGuard configuration file '{0}' was not found.</source>
+        <target state="new">ProGuard configuration file '{0}' was not found.</target>
+        <note>The following are literal names and should not be translated: ProGuard</note>
+      </trans-unit>
       <trans-unit id="XA4305">
         <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
         <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
@@ -227,6 +237,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
         <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
         <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA4307">
+        <source>Invalid ProGuard configuration file. {0}</source>
+        <target state="new">Invalid ProGuard configuration file. {0}</target>
+        <note>The following are literal names and should not be translated: ProGuard
+{0} - The error message returned by the ProGuard tool.</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -190,6 +190,11 @@
 {0} - The target SDK version number
 {1} - The API version number</note>
       </trans-unit>
+      <trans-unit id="XA4218">
+        <source>Unable to find //manifest/application/uses-library at path: {0}</source>
+        <target state="new">Unable to find //manifest/application/uses-library at path: {0}</target>
+        <note>The following are literal names and should not be translated: //manifest/application/uses-library</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI.</target>
@@ -213,6 +218,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4304">
+        <source>ProGuard configuration file '{0}' was not found.</source>
+        <target state="new">ProGuard configuration file '{0}' was not found.</target>
+        <note>The following are literal names and should not be translated: ProGuard</note>
+      </trans-unit>
       <trans-unit id="XA4305">
         <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
         <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
@@ -227,6 +237,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
         <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
         <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA4307">
+        <source>Invalid ProGuard configuration file. {0}</source>
+        <target state="new">Invalid ProGuard configuration file. {0}</target>
+        <note>The following are literal names and should not be translated: ProGuard
+{0} - The error message returned by the ProGuard tool.</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -190,6 +190,11 @@
 {0} - The target SDK version number
 {1} - The API version number</note>
       </trans-unit>
+      <trans-unit id="XA4218">
+        <source>Unable to find //manifest/application/uses-library at path: {0}</source>
+        <target state="new">Unable to find //manifest/application/uses-library at path: {0}</target>
+        <note>The following are literal names and should not be translated: //manifest/application/uses-library</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI.</target>
@@ -213,6 +218,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4304">
+        <source>ProGuard configuration file '{0}' was not found.</source>
+        <target state="new">ProGuard configuration file '{0}' was not found.</target>
+        <note>The following are literal names and should not be translated: ProGuard</note>
+      </trans-unit>
       <trans-unit id="XA4305">
         <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
         <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
@@ -227,6 +237,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
         <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
         <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA4307">
+        <source>Invalid ProGuard configuration file. {0}</source>
+        <target state="new">Invalid ProGuard configuration file. {0}</target>
+        <note>The following are literal names and should not be translated: ProGuard
+{0} - The error message returned by the ProGuard tool.</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -190,6 +190,11 @@
 {0} - The target SDK version number
 {1} - The API version number</note>
       </trans-unit>
+      <trans-unit id="XA4218">
+        <source>Unable to find //manifest/application/uses-library at path: {0}</source>
+        <target state="new">Unable to find //manifest/application/uses-library at path: {0}</target>
+        <note>The following are literal names and should not be translated: //manifest/application/uses-library</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI.</target>
@@ -213,6 +218,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4304">
+        <source>ProGuard configuration file '{0}' was not found.</source>
+        <target state="new">ProGuard configuration file '{0}' was not found.</target>
+        <note>The following are literal names and should not be translated: ProGuard</note>
+      </trans-unit>
       <trans-unit id="XA4305">
         <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
         <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
@@ -227,6 +237,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
         <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
         <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA4307">
+        <source>Invalid ProGuard configuration file. {0}</source>
+        <target state="new">Invalid ProGuard configuration file. {0}</target>
+        <note>The following are literal names and should not be translated: ProGuard
+{0} - The error message returned by the ProGuard tool.</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -190,6 +190,11 @@
 {0} - The target SDK version number
 {1} - The API version number</note>
       </trans-unit>
+      <trans-unit id="XA4218">
+        <source>Unable to find //manifest/application/uses-library at path: {0}</source>
+        <target state="new">Unable to find //manifest/application/uses-library at path: {0}</target>
+        <note>The following are literal names and should not be translated: //manifest/application/uses-library</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI.</target>
@@ -213,6 +218,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4304">
+        <source>ProGuard configuration file '{0}' was not found.</source>
+        <target state="new">ProGuard configuration file '{0}' was not found.</target>
+        <note>The following are literal names and should not be translated: ProGuard</note>
+      </trans-unit>
       <trans-unit id="XA4305">
         <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
         <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
@@ -227,6 +237,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
         <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
         <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA4307">
+        <source>Invalid ProGuard configuration file. {0}</source>
+        <target state="new">Invalid ProGuard configuration file. {0}</target>
+        <note>The following are literal names and should not be translated: ProGuard
+{0} - The error message returned by the ProGuard tool.</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -190,6 +190,11 @@
 {0} - The target SDK version number
 {1} - The API version number</note>
       </trans-unit>
+      <trans-unit id="XA4218">
+        <source>Unable to find //manifest/application/uses-library at path: {0}</source>
+        <target state="new">Unable to find //manifest/application/uses-library at path: {0}</target>
+        <note>The following are literal names and should not be translated: //manifest/application/uses-library</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI.</target>
@@ -213,6 +218,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4304">
+        <source>ProGuard configuration file '{0}' was not found.</source>
+        <target state="new">ProGuard configuration file '{0}' was not found.</target>
+        <note>The following are literal names and should not be translated: ProGuard</note>
+      </trans-unit>
       <trans-unit id="XA4305">
         <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
         <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
@@ -227,6 +237,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
         <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
         <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA4307">
+        <source>Invalid ProGuard configuration file. {0}</source>
+        <target state="new">Invalid ProGuard configuration file. {0}</target>
+        <note>The following are literal names and should not be translated: ProGuard
+{0} - The error message returned by the ProGuard tool.</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -190,6 +190,11 @@
 {0} - The target SDK version number
 {1} - The API version number</note>
       </trans-unit>
+      <trans-unit id="XA4218">
+        <source>Unable to find //manifest/application/uses-library at path: {0}</source>
+        <target state="new">Unable to find //manifest/application/uses-library at path: {0}</target>
+        <note>The following are literal names and should not be translated: //manifest/application/uses-library</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI.</target>
@@ -213,6 +218,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4304">
+        <source>ProGuard configuration file '{0}' was not found.</source>
+        <target state="new">ProGuard configuration file '{0}' was not found.</target>
+        <note>The following are literal names and should not be translated: ProGuard</note>
+      </trans-unit>
       <trans-unit id="XA4305">
         <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
         <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
@@ -227,6 +237,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
         <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
         <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA4307">
+        <source>Invalid ProGuard configuration file. {0}</source>
+        <target state="new">Invalid ProGuard configuration file. {0}</target>
+        <note>The following are literal names and should not be translated: ProGuard
+{0} - The error message returned by the ProGuard tool.</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -190,6 +190,11 @@
 {0} - The target SDK version number
 {1} - The API version number</note>
       </trans-unit>
+      <trans-unit id="XA4218">
+        <source>Unable to find //manifest/application/uses-library at path: {0}</source>
+        <target state="new">Unable to find //manifest/application/uses-library at path: {0}</target>
+        <note>The following are literal names and should not be translated: //manifest/application/uses-library</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI.</target>
@@ -213,6 +218,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4304">
+        <source>ProGuard configuration file '{0}' was not found.</source>
+        <target state="new">ProGuard configuration file '{0}' was not found.</target>
+        <note>The following are literal names and should not be translated: ProGuard</note>
+      </trans-unit>
       <trans-unit id="XA4305">
         <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
         <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
@@ -227,6 +237,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
         <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
         <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA4307">
+        <source>Invalid ProGuard configuration file. {0}</source>
+        <target state="new">Invalid ProGuard configuration file. {0}</target>
+        <note>The following are literal names and should not be translated: ProGuard
+{0} - The error message returned by the ProGuard tool.</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -190,6 +190,11 @@
 {0} - The target SDK version number
 {1} - The API version number</note>
       </trans-unit>
+      <trans-unit id="XA4218">
+        <source>Unable to find //manifest/application/uses-library at path: {0}</source>
+        <target state="new">Unable to find //manifest/application/uses-library at path: {0}</target>
+        <note>The following are literal names and should not be translated: //manifest/application/uses-library</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI.</target>
@@ -213,6 +218,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4304">
+        <source>ProGuard configuration file '{0}' was not found.</source>
+        <target state="new">ProGuard configuration file '{0}' was not found.</target>
+        <note>The following are literal names and should not be translated: ProGuard</note>
+      </trans-unit>
       <trans-unit id="XA4305">
         <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
         <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
@@ -227,6 +237,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
         <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
         <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA4307">
+        <source>Invalid ProGuard configuration file. {0}</source>
+        <target state="new">Invalid ProGuard configuration file. {0}</target>
+        <note>The following are literal names and should not be translated: ProGuard
+{0} - The error message returned by the ProGuard tool.</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -190,6 +190,11 @@
 {0} - The target SDK version number
 {1} - The API version number</note>
       </trans-unit>
+      <trans-unit id="XA4218">
+        <source>Unable to find //manifest/application/uses-library at path: {0}</source>
+        <target state="new">Unable to find //manifest/application/uses-library at path: {0}</target>
+        <note>The following are literal names and should not be translated: //manifest/application/uses-library</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI.</target>
@@ -213,6 +218,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4304">
+        <source>ProGuard configuration file '{0}' was not found.</source>
+        <target state="new">ProGuard configuration file '{0}' was not found.</target>
+        <note>The following are literal names and should not be translated: ProGuard</note>
+      </trans-unit>
       <trans-unit id="XA4305">
         <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
         <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
@@ -227,6 +237,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
         <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
         <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA4307">
+        <source>Invalid ProGuard configuration file. {0}</source>
+        <target state="new">Invalid ProGuard configuration file. {0}</target>
+        <note>The following are literal names and should not be translated: ProGuard
+{0} - The error message returned by the ProGuard tool.</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -190,6 +190,11 @@
 {0} - The target SDK version number
 {1} - The API version number</note>
       </trans-unit>
+      <trans-unit id="XA4218">
+        <source>Unable to find //manifest/application/uses-library at path: {0}</source>
+        <target state="new">Unable to find //manifest/application/uses-library at path: {0}</target>
+        <note>The following are literal names and should not be translated: //manifest/application/uses-library</note>
+      </trans-unit>
       <trans-unit id="XA4300">
         <source>Native library '{0}' will not be bundled because it has an unsupported ABI.</source>
         <target state="new">Native library '{0}' will not be bundled because it has an unsupported ABI.</target>
@@ -213,6 +218,11 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <note>The abbreviation "ABI" should not be translated.
 {0} - Comma-separated list of the ignored library file names.</note>
       </trans-unit>
+      <trans-unit id="XA4304">
+        <source>ProGuard configuration file '{0}' was not found.</source>
+        <target state="new">ProGuard configuration file '{0}' was not found.</target>
+        <note>The following are literal names and should not be translated: ProGuard</note>
+      </trans-unit>
       <trans-unit id="XA4305">
         <source>Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</source>
         <target state="new">Multidex is enabled, but `$(_AndroidMainDexListFile)` is empty.</target>
@@ -227,6 +237,12 @@ In this message, the term "bundled" is a short way of saying "included into the 
         <source>R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</source>
         <target state="new">R8 does not support `@(MultiDexMainDexList)` files when android:minSdkVersion &gt;= 21</target>
         <note>The following are literal names and should not be translated: R8, @(MultiDexMainDexList),  android:minSdkVersion</note>
+      </trans-unit>
+      <trans-unit id="XA4307">
+        <source>Invalid ProGuard configuration file. {0}</source>
+        <target state="new">Invalid ProGuard configuration file. {0}</target>
+        <note>The following are literal names and should not be translated: ProGuard
+{0} - The error message returned by the ProGuard tool.</note>
       </trans-unit>
       <trans-unit id="XA4308">
         <source>Failed to generate type maps</source>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Proguard.cs
@@ -140,7 +140,7 @@ namespace Xamarin.Android.Tasks
 				if (File.Exists (file))
 					cmd.AppendSwitchUnquotedIfNotNull ("-include ", $"{enclosingChar}'{file}'{enclosingChar}");
 				else
-					Log.LogCodedWarning ("XA4304", file, 0, "Proguard configuration file '{0}' was not found.", file);
+					Log.LogCodedWarning ("XA4304", file, 0, Properties.Resources.XA4304, file);
 			}
 
 			var injars = new List<string> ();
@@ -188,7 +188,7 @@ namespace Xamarin.Android.Tasks
 				errorText.Clear ();
 				foreach (var line in errorLines)
 					errorText.Append (line);
-				Log.LogCodedError ($"XA4307", $"Invalid ProGuard configuration file. {errorText}");
+				Log.LogCodedError ($"XA4307", Properties.Resources.XA4307, errorText);
 				return !Log.HasLoggedErrors;
 			}
 			return base.HandleTaskExecutionErrors ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -112,7 +112,7 @@ namespace Xamarin.Android.Tasks
 						if (File.Exists (file))
 							cmd.AppendSwitchIfNotNull ("--pg-conf ", file);
 						else
-							Log.LogCodedWarning ("XA4304", file, 0, "Proguard configuration file '{0}' was not found.", file);
+							Log.LogCodedWarning ("XA4304", file, 0, Properties.Resources.XA4304, file);
 					}
 				}
 			} else {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadAndroidManifest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadAndroidManifest.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Android.Tasks
 						if (File.Exists (path)) {
 							libraries.Add (new TaskItem (path));
 						} else {
-							Log.LogWarningForXmlNode ("XA4218", ManifestFile, attribute, "Unable to find //manifest/application/uses-library at path: {0}", path);
+							Log.LogWarningForXmlNode ("XA4218", ManifestFile, attribute, Properties.Resources.XA4218, path);
 						}
 					}
 				}


### PR DESCRIPTION
Context: 0342fe5698b86e21e36c924732ff135b9a87e4af
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Move the message strings for XA4218, XA4304, & XA4307 into the `.resx`
file so that they are localizable.

Other changes:

Standardize the capitalization of "ProGuard" in the messages.