### PR TITLE
[docs] fix broken image link in profiling.md

### DIFF
--- a/Documentation/guides/profiling.md
+++ b/Documentation/guides/profiling.md
@@ -481,7 +481,7 @@ can show the top 10 most expensive tasks:
 
 It also has a timeline view:
 
-![MSBuild Log Viewer Timeline](..\images\msbuildlog.png)
+![MSBuild Log Viewer Timeline](../images/msbuildlog.png)
 
 [msbuildlog]: http://msbuildlog.com/
 [msbuild_bl]: https://github.com/microsoft/msbuild/blob/master/documentation/wiki/Binary-Log.md


### PR DESCRIPTION
I had Windows-style directory separators, which doesn't appear to work in Github.

It worked in VS Code on Windows, so I didn't notice it there.