### PR TITLE
[Xamarin.Android.Build.Tasks] ResolveAndroidTooling l10n support

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -50,7 +50,7 @@ ms.date: 01/24/2020
 + [XA0101](xa0101.md): warning XA0101: @(Content) build action is not supported.
 + [XA0102](xa0102.md): Generic `lint` Warning.
 + [XA0103](xa0103.md): Generic `lint` Error.
-+ XA0104: Invalid Sequence Point mode.
++ XA0104: Invalid value for \`$(AndroidSequencePointsMode)\`
 + [XA0105](xa0105.md): The $(TargetFrameworkVersion) for a dll is greater than the $(TargetFrameworkVersion) for your project.
 + [XA0107](xa0107.md): `{Assmebly}` is a Reference Assembly.
 + [XA0108](xa0108.md): Could not get version from `lint`.

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -79,11 +79,65 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not determine API level for $(TargetFrameworkVersion) of &apos;{0}&apos;..
+        /// </summary>
+        internal static string XA0000_API_for_TargetFrameworkVersion {
+            get {
+                return ResourceManager.GetString("XA0000_API_for_TargetFrameworkVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached..
+        /// </summary>
+        internal static string XA0000_API_or_TargetFrameworkVersion_Fail {
+            get {
+                return ResourceManager.GetString("XA0000_API_or_TargetFrameworkVersion_Fail", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unhandled exception: {0}.
+        /// </summary>
+        internal static string XA0000_Exception {
+            get {
+                return ResourceManager.GetString("XA0000_Exception", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not determine $(TargetFrameworkVersion) for API level &apos;{0}.&apos;.
+        /// </summary>
+        internal static string XA0000_TargetFrameworkVersion_for_API {
+            get {
+                return ResourceManager.GetString("XA0000_TargetFrameworkVersion_for_API", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unsupported or invalid $(TargetFrameworkVersion) value of &apos;{0}&apos;. Please update your Project Options..
+        /// </summary>
+        internal static string XA0001 {
+            get {
+                return ResourceManager.GetString("XA0001", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to EmbeddedNativeLibrary &apos;{0}&apos; is invalid in Android Application projects. Please use AndroidNativeLibrary instead..
         /// </summary>
         internal static string XA0100 {
             get {
                 return ResourceManager.GetString("XA0100", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid value for `$(AndroidSequencePointsMode)`: {0}.
+        /// </summary>
+        internal static string XA0104 {
+            get {
+                return ResourceManager.GetString("XA0104", resourceCulture);
             }
         }
         
@@ -115,11 +169,47 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly..
+        /// </summary>
+        internal static string XA0111 {
+            get {
+                return ResourceManager.GetString("XA0111", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to `aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly..
+        /// </summary>
+        internal static string XA0112 {
+            get {
+                return ResourceManager.GetString("XA0112", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1})..
+        /// </summary>
+        internal static string XA0113 {
+            get {
+                return ResourceManager.GetString("XA0113", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to find `EmbeddedResource` named `{0}`..
         /// </summary>
         internal static string XA0116 {
             get {
                 return ResourceManager.GetString("XA0116", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher..
+        /// </summary>
+        internal static string XA0117 {
+            get {
+                return ResourceManager.GetString("XA0117", resourceCulture);
             }
         }
         

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -125,10 +125,37 @@
     <value>Invalid file name: It must contain only {0}.</value>
     <comment>{0} - The regular expression that the file name must match</comment>
   </data>
+  <data name="XA0000_API_for_TargetFrameworkVersion" xml:space="preserve">
+    <value>Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</value>
+    <comment>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The current value of $(TargetFrameworkVersion)</comment>
+  </data>
+  <data name="XA0000_API_or_TargetFrameworkVersion_Fail" xml:space="preserve">
+    <value>Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</value>
+    <comment>The following are literal names and should not be translated: $(AndroidApiLevel), $(TargetFrameworkVersion)
+In this message, the phrase "should not be reached" means that this error message is not expected to appear in normal usage.</comment>
+  </data>
+  <data name="XA0000_Exception" xml:space="preserve">
+    <value>Unhandled exception: {0}</value>
+    <comment>{0} - The exception message of the associated exception</comment>
+  </data>
+  <data name="XA0000_TargetFrameworkVersion_for_API" xml:space="preserve">
+    <value>Could not determine $(TargetFrameworkVersion) for API level '{0}.'</value>
+    <comment>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The API level number</comment>
+  </data>
+  <data name="XA0001" xml:space="preserve">
+    <value>Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</value>
+    <comment>The following are literal names and should not be translated: $(TargetFrameworkVersion)</comment>
+  </data>
   <data name="XA0100" xml:space="preserve">
     <value>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</value>
     <comment>The following are literal names and should not be translated: EmbeddedNativeLibrary, AndroidNativeLibrary
 {0} - The library name.</comment>
+  </data>
+  <data name="XA0104" xml:space="preserve">
+    <value>Invalid value for `$(AndroidSequencePointsMode)`: {0}</value>
+    <comment>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</comment>
   </data>
   <data name="XA0107" xml:space="preserve">
     <value>{0} is a Reference Assembly.</value>
@@ -141,10 +168,29 @@
     <value>Could not get version from '{0}'. Defaulting to 1.0</value>
     <comment>{0} - The tool name</comment>
   </data>
+  <data name="XA0111" xml:space="preserve">
+    <value>Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</value>
+    <comment>The following are literal names and should not be translated: `aapt2`</comment>
+  </data>
+  <data name="XA0112" xml:space="preserve">
+    <value>`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</value>
+    <comment>The following are literal names and should not be translated: `aapt2`</comment>
+  </data>
+  <data name="XA0113" xml:space="preserve">
+    <value>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</value>
+    <comment>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+{0} - The current value of TargetFrameworkVersion
+{1} - The corresponding API level number</comment>
+  </data>
   <data name="XA0116" xml:space="preserve">
     <value>Unable to find `EmbeddedResource` named `{0}`.</value>
     <comment>The following are literal names and should not be translated: EmbeddedResource
 {0} - The name of the missing resource</comment>
+  </data>
+  <data name="XA0117" xml:space="preserve">
+    <value>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</value>
+    <comment>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+{0} - The current value of TargetFrameworkVersion</comment>
   </data>
   <data name="XA0121" xml:space="preserve">
     <value>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -12,11 +12,44 @@
         <target state="new">Invalid file name: It must contain only {0}.</target>
         <note>{0} - The regular expression that the file name must match</note>
       </trans-unit>
+      <trans-unit id="XA0000_API_for_TargetFrameworkVersion">
+        <source>Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</source>
+        <target state="new">Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The current value of $(TargetFrameworkVersion)</note>
+      </trans-unit>
+      <trans-unit id="XA0000_API_or_TargetFrameworkVersion_Fail">
+        <source>Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</source>
+        <target state="new">Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</target>
+        <note>The following are literal names and should not be translated: $(AndroidApiLevel), $(TargetFrameworkVersion)
+In this message, the phrase "should not be reached" means that this error message is not expected to appear in normal usage.</note>
+      </trans-unit>
+      <trans-unit id="XA0000_Exception">
+        <source>Unhandled exception: {0}</source>
+        <target state="new">Unhandled exception: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA0000_TargetFrameworkVersion_for_API">
+        <source>Could not determine $(TargetFrameworkVersion) for API level '{0}.'</source>
+        <target state="new">Could not determine $(TargetFrameworkVersion) for API level '{0}.'</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The API level number</note>
+      </trans-unit>
+      <trans-unit id="XA0001">
+        <source>Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</source>
+        <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>
         <note>The following are literal names and should not be translated: EmbeddedNativeLibrary, AndroidNativeLibrary
 {0} - The library name.</note>
+      </trans-unit>
+      <trans-unit id="XA0104">
+        <source>Invalid value for `$(AndroidSequencePointsMode)`: {0}</source>
+        <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
@@ -33,11 +66,34 @@
         <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
         <note>{0} - The tool name</note>
       </trans-unit>
+      <trans-unit id="XA0111">
+        <source>Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0112">
+        <source>`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0113">
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+{0} - The current value of TargetFrameworkVersion
+{1} - The corresponding API level number</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
         <note>The following are literal names and should not be translated: EmbeddedResource
 {0} - The name of the missing resource</note>
+      </trans-unit>
+      <trans-unit id="XA0117">
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
+        <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+{0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -12,11 +12,44 @@
         <target state="new">Invalid file name: It must contain only {0}.</target>
         <note>{0} - The regular expression that the file name must match</note>
       </trans-unit>
+      <trans-unit id="XA0000_API_for_TargetFrameworkVersion">
+        <source>Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</source>
+        <target state="new">Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The current value of $(TargetFrameworkVersion)</note>
+      </trans-unit>
+      <trans-unit id="XA0000_API_or_TargetFrameworkVersion_Fail">
+        <source>Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</source>
+        <target state="new">Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</target>
+        <note>The following are literal names and should not be translated: $(AndroidApiLevel), $(TargetFrameworkVersion)
+In this message, the phrase "should not be reached" means that this error message is not expected to appear in normal usage.</note>
+      </trans-unit>
+      <trans-unit id="XA0000_Exception">
+        <source>Unhandled exception: {0}</source>
+        <target state="new">Unhandled exception: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA0000_TargetFrameworkVersion_for_API">
+        <source>Could not determine $(TargetFrameworkVersion) for API level '{0}.'</source>
+        <target state="new">Could not determine $(TargetFrameworkVersion) for API level '{0}.'</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The API level number</note>
+      </trans-unit>
+      <trans-unit id="XA0001">
+        <source>Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</source>
+        <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>
         <note>The following are literal names and should not be translated: EmbeddedNativeLibrary, AndroidNativeLibrary
 {0} - The library name.</note>
+      </trans-unit>
+      <trans-unit id="XA0104">
+        <source>Invalid value for `$(AndroidSequencePointsMode)`: {0}</source>
+        <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
@@ -33,11 +66,34 @@
         <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
         <note>{0} - The tool name</note>
       </trans-unit>
+      <trans-unit id="XA0111">
+        <source>Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0112">
+        <source>`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0113">
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+{0} - The current value of TargetFrameworkVersion
+{1} - The corresponding API level number</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
         <note>The following are literal names and should not be translated: EmbeddedResource
 {0} - The name of the missing resource</note>
+      </trans-unit>
+      <trans-unit id="XA0117">
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
+        <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+{0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -12,11 +12,44 @@
         <target state="new">Invalid file name: It must contain only {0}.</target>
         <note>{0} - The regular expression that the file name must match</note>
       </trans-unit>
+      <trans-unit id="XA0000_API_for_TargetFrameworkVersion">
+        <source>Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</source>
+        <target state="new">Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The current value of $(TargetFrameworkVersion)</note>
+      </trans-unit>
+      <trans-unit id="XA0000_API_or_TargetFrameworkVersion_Fail">
+        <source>Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</source>
+        <target state="new">Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</target>
+        <note>The following are literal names and should not be translated: $(AndroidApiLevel), $(TargetFrameworkVersion)
+In this message, the phrase "should not be reached" means that this error message is not expected to appear in normal usage.</note>
+      </trans-unit>
+      <trans-unit id="XA0000_Exception">
+        <source>Unhandled exception: {0}</source>
+        <target state="new">Unhandled exception: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA0000_TargetFrameworkVersion_for_API">
+        <source>Could not determine $(TargetFrameworkVersion) for API level '{0}.'</source>
+        <target state="new">Could not determine $(TargetFrameworkVersion) for API level '{0}.'</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The API level number</note>
+      </trans-unit>
+      <trans-unit id="XA0001">
+        <source>Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</source>
+        <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>
         <note>The following are literal names and should not be translated: EmbeddedNativeLibrary, AndroidNativeLibrary
 {0} - The library name.</note>
+      </trans-unit>
+      <trans-unit id="XA0104">
+        <source>Invalid value for `$(AndroidSequencePointsMode)`: {0}</source>
+        <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
@@ -33,11 +66,34 @@
         <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
         <note>{0} - The tool name</note>
       </trans-unit>
+      <trans-unit id="XA0111">
+        <source>Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0112">
+        <source>`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0113">
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+{0} - The current value of TargetFrameworkVersion
+{1} - The corresponding API level number</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
         <note>The following are literal names and should not be translated: EmbeddedResource
 {0} - The name of the missing resource</note>
+      </trans-unit>
+      <trans-unit id="XA0117">
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
+        <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+{0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -12,11 +12,44 @@
         <target state="new">Invalid file name: It must contain only {0}.</target>
         <note>{0} - The regular expression that the file name must match</note>
       </trans-unit>
+      <trans-unit id="XA0000_API_for_TargetFrameworkVersion">
+        <source>Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</source>
+        <target state="new">Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The current value of $(TargetFrameworkVersion)</note>
+      </trans-unit>
+      <trans-unit id="XA0000_API_or_TargetFrameworkVersion_Fail">
+        <source>Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</source>
+        <target state="new">Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</target>
+        <note>The following are literal names and should not be translated: $(AndroidApiLevel), $(TargetFrameworkVersion)
+In this message, the phrase "should not be reached" means that this error message is not expected to appear in normal usage.</note>
+      </trans-unit>
+      <trans-unit id="XA0000_Exception">
+        <source>Unhandled exception: {0}</source>
+        <target state="new">Unhandled exception: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA0000_TargetFrameworkVersion_for_API">
+        <source>Could not determine $(TargetFrameworkVersion) for API level '{0}.'</source>
+        <target state="new">Could not determine $(TargetFrameworkVersion) for API level '{0}.'</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The API level number</note>
+      </trans-unit>
+      <trans-unit id="XA0001">
+        <source>Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</source>
+        <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>
         <note>The following are literal names and should not be translated: EmbeddedNativeLibrary, AndroidNativeLibrary
 {0} - The library name.</note>
+      </trans-unit>
+      <trans-unit id="XA0104">
+        <source>Invalid value for `$(AndroidSequencePointsMode)`: {0}</source>
+        <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
@@ -33,11 +66,34 @@
         <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
         <note>{0} - The tool name</note>
       </trans-unit>
+      <trans-unit id="XA0111">
+        <source>Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0112">
+        <source>`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0113">
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+{0} - The current value of TargetFrameworkVersion
+{1} - The corresponding API level number</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
         <note>The following are literal names and should not be translated: EmbeddedResource
 {0} - The name of the missing resource</note>
+      </trans-unit>
+      <trans-unit id="XA0117">
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
+        <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+{0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -12,11 +12,44 @@
         <target state="new">Invalid file name: It must contain only {0}.</target>
         <note>{0} - The regular expression that the file name must match</note>
       </trans-unit>
+      <trans-unit id="XA0000_API_for_TargetFrameworkVersion">
+        <source>Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</source>
+        <target state="new">Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The current value of $(TargetFrameworkVersion)</note>
+      </trans-unit>
+      <trans-unit id="XA0000_API_or_TargetFrameworkVersion_Fail">
+        <source>Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</source>
+        <target state="new">Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</target>
+        <note>The following are literal names and should not be translated: $(AndroidApiLevel), $(TargetFrameworkVersion)
+In this message, the phrase "should not be reached" means that this error message is not expected to appear in normal usage.</note>
+      </trans-unit>
+      <trans-unit id="XA0000_Exception">
+        <source>Unhandled exception: {0}</source>
+        <target state="new">Unhandled exception: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA0000_TargetFrameworkVersion_for_API">
+        <source>Could not determine $(TargetFrameworkVersion) for API level '{0}.'</source>
+        <target state="new">Could not determine $(TargetFrameworkVersion) for API level '{0}.'</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The API level number</note>
+      </trans-unit>
+      <trans-unit id="XA0001">
+        <source>Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</source>
+        <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>
         <note>The following are literal names and should not be translated: EmbeddedNativeLibrary, AndroidNativeLibrary
 {0} - The library name.</note>
+      </trans-unit>
+      <trans-unit id="XA0104">
+        <source>Invalid value for `$(AndroidSequencePointsMode)`: {0}</source>
+        <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
@@ -33,11 +66,34 @@
         <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
         <note>{0} - The tool name</note>
       </trans-unit>
+      <trans-unit id="XA0111">
+        <source>Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0112">
+        <source>`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0113">
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+{0} - The current value of TargetFrameworkVersion
+{1} - The corresponding API level number</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
         <note>The following are literal names and should not be translated: EmbeddedResource
 {0} - The name of the missing resource</note>
+      </trans-unit>
+      <trans-unit id="XA0117">
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
+        <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+{0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -12,11 +12,44 @@
         <target state="new">Invalid file name: It must contain only {0}.</target>
         <note>{0} - The regular expression that the file name must match</note>
       </trans-unit>
+      <trans-unit id="XA0000_API_for_TargetFrameworkVersion">
+        <source>Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</source>
+        <target state="new">Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The current value of $(TargetFrameworkVersion)</note>
+      </trans-unit>
+      <trans-unit id="XA0000_API_or_TargetFrameworkVersion_Fail">
+        <source>Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</source>
+        <target state="new">Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</target>
+        <note>The following are literal names and should not be translated: $(AndroidApiLevel), $(TargetFrameworkVersion)
+In this message, the phrase "should not be reached" means that this error message is not expected to appear in normal usage.</note>
+      </trans-unit>
+      <trans-unit id="XA0000_Exception">
+        <source>Unhandled exception: {0}</source>
+        <target state="new">Unhandled exception: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA0000_TargetFrameworkVersion_for_API">
+        <source>Could not determine $(TargetFrameworkVersion) for API level '{0}.'</source>
+        <target state="new">Could not determine $(TargetFrameworkVersion) for API level '{0}.'</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The API level number</note>
+      </trans-unit>
+      <trans-unit id="XA0001">
+        <source>Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</source>
+        <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>
         <note>The following are literal names and should not be translated: EmbeddedNativeLibrary, AndroidNativeLibrary
 {0} - The library name.</note>
+      </trans-unit>
+      <trans-unit id="XA0104">
+        <source>Invalid value for `$(AndroidSequencePointsMode)`: {0}</source>
+        <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
@@ -33,11 +66,34 @@
         <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
         <note>{0} - The tool name</note>
       </trans-unit>
+      <trans-unit id="XA0111">
+        <source>Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0112">
+        <source>`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0113">
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+{0} - The current value of TargetFrameworkVersion
+{1} - The corresponding API level number</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
         <note>The following are literal names and should not be translated: EmbeddedResource
 {0} - The name of the missing resource</note>
+      </trans-unit>
+      <trans-unit id="XA0117">
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
+        <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+{0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -12,11 +12,44 @@
         <target state="new">Invalid file name: It must contain only {0}.</target>
         <note>{0} - The regular expression that the file name must match</note>
       </trans-unit>
+      <trans-unit id="XA0000_API_for_TargetFrameworkVersion">
+        <source>Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</source>
+        <target state="new">Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The current value of $(TargetFrameworkVersion)</note>
+      </trans-unit>
+      <trans-unit id="XA0000_API_or_TargetFrameworkVersion_Fail">
+        <source>Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</source>
+        <target state="new">Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</target>
+        <note>The following are literal names and should not be translated: $(AndroidApiLevel), $(TargetFrameworkVersion)
+In this message, the phrase "should not be reached" means that this error message is not expected to appear in normal usage.</note>
+      </trans-unit>
+      <trans-unit id="XA0000_Exception">
+        <source>Unhandled exception: {0}</source>
+        <target state="new">Unhandled exception: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA0000_TargetFrameworkVersion_for_API">
+        <source>Could not determine $(TargetFrameworkVersion) for API level '{0}.'</source>
+        <target state="new">Could not determine $(TargetFrameworkVersion) for API level '{0}.'</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The API level number</note>
+      </trans-unit>
+      <trans-unit id="XA0001">
+        <source>Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</source>
+        <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>
         <note>The following are literal names and should not be translated: EmbeddedNativeLibrary, AndroidNativeLibrary
 {0} - The library name.</note>
+      </trans-unit>
+      <trans-unit id="XA0104">
+        <source>Invalid value for `$(AndroidSequencePointsMode)`: {0}</source>
+        <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
@@ -33,11 +66,34 @@
         <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
         <note>{0} - The tool name</note>
       </trans-unit>
+      <trans-unit id="XA0111">
+        <source>Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0112">
+        <source>`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0113">
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+{0} - The current value of TargetFrameworkVersion
+{1} - The corresponding API level number</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
         <note>The following are literal names and should not be translated: EmbeddedResource
 {0} - The name of the missing resource</note>
+      </trans-unit>
+      <trans-unit id="XA0117">
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
+        <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+{0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -12,11 +12,44 @@
         <target state="new">Invalid file name: It must contain only {0}.</target>
         <note>{0} - The regular expression that the file name must match</note>
       </trans-unit>
+      <trans-unit id="XA0000_API_for_TargetFrameworkVersion">
+        <source>Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</source>
+        <target state="new">Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The current value of $(TargetFrameworkVersion)</note>
+      </trans-unit>
+      <trans-unit id="XA0000_API_or_TargetFrameworkVersion_Fail">
+        <source>Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</source>
+        <target state="new">Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</target>
+        <note>The following are literal names and should not be translated: $(AndroidApiLevel), $(TargetFrameworkVersion)
+In this message, the phrase "should not be reached" means that this error message is not expected to appear in normal usage.</note>
+      </trans-unit>
+      <trans-unit id="XA0000_Exception">
+        <source>Unhandled exception: {0}</source>
+        <target state="new">Unhandled exception: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA0000_TargetFrameworkVersion_for_API">
+        <source>Could not determine $(TargetFrameworkVersion) for API level '{0}.'</source>
+        <target state="new">Could not determine $(TargetFrameworkVersion) for API level '{0}.'</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The API level number</note>
+      </trans-unit>
+      <trans-unit id="XA0001">
+        <source>Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</source>
+        <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>
         <note>The following are literal names and should not be translated: EmbeddedNativeLibrary, AndroidNativeLibrary
 {0} - The library name.</note>
+      </trans-unit>
+      <trans-unit id="XA0104">
+        <source>Invalid value for `$(AndroidSequencePointsMode)`: {0}</source>
+        <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
@@ -33,11 +66,34 @@
         <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
         <note>{0} - The tool name</note>
       </trans-unit>
+      <trans-unit id="XA0111">
+        <source>Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0112">
+        <source>`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0113">
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+{0} - The current value of TargetFrameworkVersion
+{1} - The corresponding API level number</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
         <note>The following are literal names and should not be translated: EmbeddedResource
 {0} - The name of the missing resource</note>
+      </trans-unit>
+      <trans-unit id="XA0117">
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
+        <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+{0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -12,11 +12,44 @@
         <target state="new">Invalid file name: It must contain only {0}.</target>
         <note>{0} - The regular expression that the file name must match</note>
       </trans-unit>
+      <trans-unit id="XA0000_API_for_TargetFrameworkVersion">
+        <source>Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</source>
+        <target state="new">Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The current value of $(TargetFrameworkVersion)</note>
+      </trans-unit>
+      <trans-unit id="XA0000_API_or_TargetFrameworkVersion_Fail">
+        <source>Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</source>
+        <target state="new">Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</target>
+        <note>The following are literal names and should not be translated: $(AndroidApiLevel), $(TargetFrameworkVersion)
+In this message, the phrase "should not be reached" means that this error message is not expected to appear in normal usage.</note>
+      </trans-unit>
+      <trans-unit id="XA0000_Exception">
+        <source>Unhandled exception: {0}</source>
+        <target state="new">Unhandled exception: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA0000_TargetFrameworkVersion_for_API">
+        <source>Could not determine $(TargetFrameworkVersion) for API level '{0}.'</source>
+        <target state="new">Could not determine $(TargetFrameworkVersion) for API level '{0}.'</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The API level number</note>
+      </trans-unit>
+      <trans-unit id="XA0001">
+        <source>Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</source>
+        <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>
         <note>The following are literal names and should not be translated: EmbeddedNativeLibrary, AndroidNativeLibrary
 {0} - The library name.</note>
+      </trans-unit>
+      <trans-unit id="XA0104">
+        <source>Invalid value for `$(AndroidSequencePointsMode)`: {0}</source>
+        <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
@@ -33,11 +66,34 @@
         <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
         <note>{0} - The tool name</note>
       </trans-unit>
+      <trans-unit id="XA0111">
+        <source>Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0112">
+        <source>`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0113">
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+{0} - The current value of TargetFrameworkVersion
+{1} - The corresponding API level number</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
         <note>The following are literal names and should not be translated: EmbeddedResource
 {0} - The name of the missing resource</note>
+      </trans-unit>
+      <trans-unit id="XA0117">
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
+        <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+{0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -12,11 +12,44 @@
         <target state="new">Invalid file name: It must contain only {0}.</target>
         <note>{0} - The regular expression that the file name must match</note>
       </trans-unit>
+      <trans-unit id="XA0000_API_for_TargetFrameworkVersion">
+        <source>Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</source>
+        <target state="new">Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The current value of $(TargetFrameworkVersion)</note>
+      </trans-unit>
+      <trans-unit id="XA0000_API_or_TargetFrameworkVersion_Fail">
+        <source>Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</source>
+        <target state="new">Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</target>
+        <note>The following are literal names and should not be translated: $(AndroidApiLevel), $(TargetFrameworkVersion)
+In this message, the phrase "should not be reached" means that this error message is not expected to appear in normal usage.</note>
+      </trans-unit>
+      <trans-unit id="XA0000_Exception">
+        <source>Unhandled exception: {0}</source>
+        <target state="new">Unhandled exception: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA0000_TargetFrameworkVersion_for_API">
+        <source>Could not determine $(TargetFrameworkVersion) for API level '{0}.'</source>
+        <target state="new">Could not determine $(TargetFrameworkVersion) for API level '{0}.'</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The API level number</note>
+      </trans-unit>
+      <trans-unit id="XA0001">
+        <source>Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</source>
+        <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>
         <note>The following are literal names and should not be translated: EmbeddedNativeLibrary, AndroidNativeLibrary
 {0} - The library name.</note>
+      </trans-unit>
+      <trans-unit id="XA0104">
+        <source>Invalid value for `$(AndroidSequencePointsMode)`: {0}</source>
+        <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
@@ -33,11 +66,34 @@
         <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
         <note>{0} - The tool name</note>
       </trans-unit>
+      <trans-unit id="XA0111">
+        <source>Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0112">
+        <source>`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0113">
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+{0} - The current value of TargetFrameworkVersion
+{1} - The corresponding API level number</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
         <note>The following are literal names and should not be translated: EmbeddedResource
 {0} - The name of the missing resource</note>
+      </trans-unit>
+      <trans-unit id="XA0117">
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
+        <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+{0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -12,11 +12,44 @@
         <target state="new">Invalid file name: It must contain only {0}.</target>
         <note>{0} - The regular expression that the file name must match</note>
       </trans-unit>
+      <trans-unit id="XA0000_API_for_TargetFrameworkVersion">
+        <source>Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</source>
+        <target state="new">Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The current value of $(TargetFrameworkVersion)</note>
+      </trans-unit>
+      <trans-unit id="XA0000_API_or_TargetFrameworkVersion_Fail">
+        <source>Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</source>
+        <target state="new">Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</target>
+        <note>The following are literal names and should not be translated: $(AndroidApiLevel), $(TargetFrameworkVersion)
+In this message, the phrase "should not be reached" means that this error message is not expected to appear in normal usage.</note>
+      </trans-unit>
+      <trans-unit id="XA0000_Exception">
+        <source>Unhandled exception: {0}</source>
+        <target state="new">Unhandled exception: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA0000_TargetFrameworkVersion_for_API">
+        <source>Could not determine $(TargetFrameworkVersion) for API level '{0}.'</source>
+        <target state="new">Could not determine $(TargetFrameworkVersion) for API level '{0}.'</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The API level number</note>
+      </trans-unit>
+      <trans-unit id="XA0001">
+        <source>Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</source>
+        <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>
         <note>The following are literal names and should not be translated: EmbeddedNativeLibrary, AndroidNativeLibrary
 {0} - The library name.</note>
+      </trans-unit>
+      <trans-unit id="XA0104">
+        <source>Invalid value for `$(AndroidSequencePointsMode)`: {0}</source>
+        <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
@@ -33,11 +66,34 @@
         <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
         <note>{0} - The tool name</note>
       </trans-unit>
+      <trans-unit id="XA0111">
+        <source>Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0112">
+        <source>`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0113">
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+{0} - The current value of TargetFrameworkVersion
+{1} - The corresponding API level number</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
         <note>The following are literal names and should not be translated: EmbeddedResource
 {0} - The name of the missing resource</note>
+      </trans-unit>
+      <trans-unit id="XA0117">
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
+        <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+{0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -12,11 +12,44 @@
         <target state="new">Invalid file name: It must contain only {0}.</target>
         <note>{0} - The regular expression that the file name must match</note>
       </trans-unit>
+      <trans-unit id="XA0000_API_for_TargetFrameworkVersion">
+        <source>Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</source>
+        <target state="new">Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The current value of $(TargetFrameworkVersion)</note>
+      </trans-unit>
+      <trans-unit id="XA0000_API_or_TargetFrameworkVersion_Fail">
+        <source>Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</source>
+        <target state="new">Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</target>
+        <note>The following are literal names and should not be translated: $(AndroidApiLevel), $(TargetFrameworkVersion)
+In this message, the phrase "should not be reached" means that this error message is not expected to appear in normal usage.</note>
+      </trans-unit>
+      <trans-unit id="XA0000_Exception">
+        <source>Unhandled exception: {0}</source>
+        <target state="new">Unhandled exception: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA0000_TargetFrameworkVersion_for_API">
+        <source>Could not determine $(TargetFrameworkVersion) for API level '{0}.'</source>
+        <target state="new">Could not determine $(TargetFrameworkVersion) for API level '{0}.'</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The API level number</note>
+      </trans-unit>
+      <trans-unit id="XA0001">
+        <source>Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</source>
+        <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>
         <note>The following are literal names and should not be translated: EmbeddedNativeLibrary, AndroidNativeLibrary
 {0} - The library name.</note>
+      </trans-unit>
+      <trans-unit id="XA0104">
+        <source>Invalid value for `$(AndroidSequencePointsMode)`: {0}</source>
+        <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
@@ -33,11 +66,34 @@
         <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
         <note>{0} - The tool name</note>
       </trans-unit>
+      <trans-unit id="XA0111">
+        <source>Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0112">
+        <source>`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0113">
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+{0} - The current value of TargetFrameworkVersion
+{1} - The corresponding API level number</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
         <note>The following are literal names and should not be translated: EmbeddedResource
 {0} - The name of the missing resource</note>
+      </trans-unit>
+      <trans-unit id="XA0117">
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
+        <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+{0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -12,11 +12,44 @@
         <target state="new">Invalid file name: It must contain only {0}.</target>
         <note>{0} - The regular expression that the file name must match</note>
       </trans-unit>
+      <trans-unit id="XA0000_API_for_TargetFrameworkVersion">
+        <source>Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</source>
+        <target state="new">Could not determine API level for $(TargetFrameworkVersion) of '{0}'.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The current value of $(TargetFrameworkVersion)</note>
+      </trans-unit>
+      <trans-unit id="XA0000_API_or_TargetFrameworkVersion_Fail">
+        <source>Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</source>
+        <target state="new">Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); should not be reached.</target>
+        <note>The following are literal names and should not be translated: $(AndroidApiLevel), $(TargetFrameworkVersion)
+In this message, the phrase "should not be reached" means that this error message is not expected to appear in normal usage.</note>
+      </trans-unit>
+      <trans-unit id="XA0000_Exception">
+        <source>Unhandled exception: {0}</source>
+        <target state="new">Unhandled exception: {0}</target>
+        <note>{0} - The exception message of the associated exception</note>
+      </trans-unit>
+      <trans-unit id="XA0000_TargetFrameworkVersion_for_API">
+        <source>Could not determine $(TargetFrameworkVersion) for API level '{0}.'</source>
+        <target state="new">Could not determine $(TargetFrameworkVersion) for API level '{0}.'</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)
+{0} - The API level number</note>
+      </trans-unit>
+      <trans-unit id="XA0001">
+        <source>Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</source>
+        <target state="new">Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.</target>
+        <note>The following are literal names and should not be translated: $(TargetFrameworkVersion)</note>
+      </trans-unit>
       <trans-unit id="XA0100">
         <source>EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</source>
         <target state="new">EmbeddedNativeLibrary '{0}' is invalid in Android Application projects. Please use AndroidNativeLibrary instead.</target>
         <note>The following are literal names and should not be translated: EmbeddedNativeLibrary, AndroidNativeLibrary
 {0} - The library name.</note>
+      </trans-unit>
+      <trans-unit id="XA0104">
+        <source>Invalid value for `$(AndroidSequencePointsMode)`: {0}</source>
+        <target state="new">Invalid value for `$(AndroidSequencePointsMode)`: {0}</target>
+        <note>The following are literal names and should not be translated: `$(AndroidSequencePointsMode)`</note>
       </trans-unit>
       <trans-unit id="XA0107">
         <source>{0} is a Reference Assembly.</source>
@@ -33,11 +66,34 @@
         <target state="new">Could not get version from '{0}'. Defaulting to 1.0</target>
         <note>{0} - The tool name</note>
       </trans-unit>
+      <trans-unit id="XA0111">
+        <source>Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0112">
+        <source>`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</source>
+        <target state="new">`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.</target>
+        <note>The following are literal names and should not be translated: `aapt2`</note>
+      </trans-unit>
+      <trans-unit id="XA0113">
+        <source>Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</source>
+        <target state="new">Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {0} (API level {1}).</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v8.0
+{0} - The current value of TargetFrameworkVersion
+{1} - The corresponding API level number</note>
+      </trans-unit>
       <trans-unit id="XA0116">
         <source>Unable to find `EmbeddedResource` named `{0}`.</source>
         <target state="new">Unable to find `EmbeddedResource` named `{0}`.</target>
         <note>The following are literal names and should not be translated: EmbeddedResource
 {0} - The name of the missing resource</note>
+      </trans-unit>
+      <trans-unit id="XA0117">
+        <source>The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</source>
+        <target state="new">The TargetFrameworkVersion {0} is deprecated. Please update it to be v4.4 or higher.</target>
+        <note>The following are literal names and should not be translated: TargetFrameworkVersion, v4.4
+{0} - The current value of TargetFrameworkVersion</note>
       </trans-unit>
       <trans-unit id="XA0121">
         <source>Assembly '{0}' is using '[assembly: {1}]', which is no longer supported. Use a newer version of this NuGet package or notify the library author.</source>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveAndroidTooling.cs
@@ -148,13 +148,13 @@ namespace Xamarin.Android.Tasks
 				if (!GetAapt2Version ()) {
 					AndroidUseAapt2 = false;
 					aapt2Installed = false;
-					Log.LogCodedWarning ("XA0111", "Could not get the `aapt2` version. Disabling `aapt2` support. Please check it is installed correctly.");
+					Log.LogCodedWarning ("XA0111", Properties.Resources.XA0111);
 				}
 			}
 			if (AndroidUseAapt2) {
 				if (!aapt2Installed) {
 					AndroidUseAapt2 = false;
-					Log.LogCodedWarning ("XA0112", "`aapt2` is not installed. Disabling `aapt2` support. Please check it is installed correctly.");
+					Log.LogCodedWarning ("XA0112", Properties.Resources.XA0112);
 				}
 			}
 
@@ -186,7 +186,7 @@ namespace Xamarin.Android.Tasks
 					columnNumber: 0,
 					endLineNumber: 0,
 					endColumnNumber: 0,
-					message: "Unsupported or invalid $(TargetFrameworkVersion) value of '{0}'. Please update your Project Options.",
+					message: Properties.Resources.XA0001,
 					messageArgs: new []{
 						TargetFrameworkVersion,
 					}
@@ -197,14 +197,14 @@ namespace Xamarin.Android.Tasks
 			int apiLevel;
 			if (AndroidApplication && int.TryParse (AndroidApiLevel, out apiLevel)) {
 				if (apiLevel < 26)
-					Log.LogCodedWarning ("XA0113", $"Google Play requires that new applications and updates must use a TargetFrameworkVersion of v8.0 (API level 26) or above. You are currently targeting {TargetFrameworkVersion} (API level {AndroidApiLevel}).");
+					Log.LogCodedWarning ("XA0113", Properties.Resources.XA0113,TargetFrameworkVersion, AndroidApiLevel);
 				if (apiLevel < 19)
-					Log.LogCodedWarning ("XA0117", $"The TargetFrameworkVersion {TargetFrameworkVersion} is deprecated. Please update it to be v4.4 or higher.");
+					Log.LogCodedWarning ("XA0117", Properties.Resources.XA0117, TargetFrameworkVersion);
 			}
 
 			SequencePointsMode mode;
 			if (!Aot.TryGetSequencePointsMode (SequencePointsMode ?? "None", out mode))
-				Log.LogCodedError ("XA0104", "Invalid Sequence Point mode: {0}", SequencePointsMode);
+				Log.LogCodedError ("XA0104", Properties.Resources.XA0104, SequencePointsMode);
 			AndroidSequencePointsMode = mode.ToString ();
 
 			AndroidApiLevelName = MonoAndroidHelper.SupportedVersions.GetIdFromApiLevel (AndroidApiLevel);
@@ -324,9 +324,7 @@ namespace Xamarin.Android.Tasks
 				TargetFrameworkVersion = TargetFrameworkVersion.Trim ();
 				string id = MonoAndroidHelper.SupportedVersions.GetIdFromFrameworkVersion (TargetFrameworkVersion);
 				if (id == null) {
-					Log.LogCodedError ("XA0000",
-							"Could not determine API level for $(TargetFrameworkVersion) of '{0}'.",
-							TargetFrameworkVersion);
+					Log.LogCodedError ("XA0000", Properties.Resources.XA0000_API_for_TargetFrameworkVersion, TargetFrameworkVersion);
 					return false;
 				}
 				AndroidApiLevel = MonoAndroidHelper.SupportedVersions.GetApiLevelFromId (id).ToString ();
@@ -339,7 +337,7 @@ namespace Xamarin.Android.Tasks
 				return TargetFrameworkVersion != null;
 			}
 
-			Log.LogCodedError ("XA0000", "Could not determine $(AndroidApiLevel) or $(TargetFrameworkVersion); SHOULD NOT BE REACHED.");
+			Log.LogCodedError ("XA0000", Properties.Resources.XA0000_API_or_TargetFrameworkVersion_Fail);
 			return false;
 		}
 
@@ -398,9 +396,7 @@ namespace Xamarin.Android.Tasks
 			string targetFramework = MonoAndroidHelper.SupportedVersions.GetFrameworkVersionFromId (AndroidApiLevel);
 			if (targetFramework != null)
 				return targetFramework;
-			Log.LogCodedError ("XA0000",
-					"Could not determine $(TargetFrameworkVersion) for API level '{0}.'",
-					AndroidApiLevel);
+			Log.LogCodedError ("XA0000", Properties.Resources.XA0000_TargetFrameworkVersion_for_API, AndroidApiLevel);
 			return null;
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AsyncTaskExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AsyncTaskExtensions.cs
@@ -84,7 +84,7 @@ namespace Xamarin.Android.Tasks
 
 		static void LogErrorAndCancel (AsyncTask asyncTask, Exception exc)
 		{
-			asyncTask.LogCodedError ("XA0000", "Unhandled exception: {0}", exc);
+			asyncTask.LogCodedError ("XA0000", Properties.Resources.XA0000_Exception, exc);
 			asyncTask.Cancel ();
 		}
 


### PR DESCRIPTION
Context: 0342fe5698b86e21e36c924732ff135b9a87e4af
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Move the message strings for XA0000, XA0001, XA0104, XA0111, XA0112,
XA0113, & XA0117 into the `.resx` file so that they are localizable.

Other changes:

Make "SHOULD NOT BE REACHED" lowercase to simplify translation since
some languages do not use all caps for emphasis.

Replace "Sequence Point mode" with the literal name of the associated
MSBuild property `$(AndroidSequencePointsMode)` so it doesn't need to be
translated.