### PR TITLE
[Xamarin.Android.Build.Tasks] XA3004 & XA3005 l10n support

### DIFF
--- a/Documentation/guides/messages/README.md
+++ b/Documentation/guides/messages/README.md
@@ -89,8 +89,10 @@ ms.date: 01/24/2020
 + XA3001: Could not AOT the assembly: {assembly}
 + XA3002: Invalid AOT mode: {mode}
 + XA3003: Could not strip IL of assembly: {assembly}
-+ XA3004: Could not compile native assembly file: {file}
-+ XA3005: Could not link native shared library: {library}
++ XA3004: Android NDK r10d is buggy and provides an incompatible x86_64 libm.so.
++ XA3005: The detected Android NDK version is incompatible with the targeted LLVM configuration.
++ XA3006: Could not compile native assembly file: {file}
++ XA3007: Could not link native shared library: {library}
 
 ## XA4xxx: Code generation
 

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -250,7 +250,7 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not compile native assembly file: {0}.
+        ///   Looks up a localized string similar to Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422..
         /// </summary>
         internal static string XA3004 {
             get {
@@ -259,11 +259,29 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not link native shared library: {0}.
+        ///   Looks up a localized string similar to The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer..
         /// </summary>
         internal static string XA3005 {
             get {
                 return ResourceManager.GetString("XA3005", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not compile native assembly file: {0}.
+        /// </summary>
+        internal static string XA3006 {
+            get {
+                return ResourceManager.GetString("XA3006", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not link native shared library: {0}.
+        /// </summary>
+        internal static string XA3007 {
+            get {
+                return ResourceManager.GetString("XA3007", resourceCulture);
             }
         }
         

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -215,10 +215,20 @@
     <comment>The abbreviation "IL" should not be translated.</comment>
   </data>
   <data name="XA3004" xml:space="preserve">
+    <value>Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</value>
+    <comment>The following are literal names and should not be translated: NDK, r10d, x86_64, libm.so
+"r10d" is the problematic version of the NDK. "x86_64" is the architecture of the libm.so file.</comment>
+  </data>
+  <data name="XA3005" xml:space="preserve">
+    <value>The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</value>
+    <comment>The following are literal names and should not be translated: NDK, LLVM, r10d
+"r10d" is the version of the NDK.</comment>
+  </data>
+  <data name="XA3006" xml:space="preserve">
     <value>Could not compile native assembly file: {0}</value>
     <comment>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</comment>
   </data>
-  <data name="XA3005" xml:space="preserve">
+  <data name="XA3007" xml:space="preserve">
     <value>Could not link native shared library: {0}</value>
   </data>
   <data name="XA4209" xml:space="preserve">

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.cs.xlf
@@ -123,11 +123,23 @@
         <note>The abbreviation "IL" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA3004">
+        <source>Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</source>
+        <target state="new">Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</target>
+        <note>The following are literal names and should not be translated: NDK, r10d, x86_64, libm.so
+"r10d" is the problematic version of the NDK. "x86_64" is the architecture of the libm.so file.</note>
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</source>
+        <target state="new">The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</target>
+        <note>The following are literal names and should not be translated: NDK, LLVM, r10d
+"r10d" is the version of the NDK.</note>
+      </trans-unit>
+      <trans-unit id="XA3006">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
         <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
-      <trans-unit id="XA3005">
+      <trans-unit id="XA3007">
         <source>Could not link native shared library: {0}</source>
         <target state="new">Could not link native shared library: {0}</target>
         <note />

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.de.xlf
@@ -123,11 +123,23 @@
         <note>The abbreviation "IL" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA3004">
+        <source>Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</source>
+        <target state="new">Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</target>
+        <note>The following are literal names and should not be translated: NDK, r10d, x86_64, libm.so
+"r10d" is the problematic version of the NDK. "x86_64" is the architecture of the libm.so file.</note>
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</source>
+        <target state="new">The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</target>
+        <note>The following are literal names and should not be translated: NDK, LLVM, r10d
+"r10d" is the version of the NDK.</note>
+      </trans-unit>
+      <trans-unit id="XA3006">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
         <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
-      <trans-unit id="XA3005">
+      <trans-unit id="XA3007">
         <source>Could not link native shared library: {0}</source>
         <target state="new">Could not link native shared library: {0}</target>
         <note />

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.es.xlf
@@ -123,11 +123,23 @@
         <note>The abbreviation "IL" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA3004">
+        <source>Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</source>
+        <target state="new">Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</target>
+        <note>The following are literal names and should not be translated: NDK, r10d, x86_64, libm.so
+"r10d" is the problematic version of the NDK. "x86_64" is the architecture of the libm.so file.</note>
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</source>
+        <target state="new">The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</target>
+        <note>The following are literal names and should not be translated: NDK, LLVM, r10d
+"r10d" is the version of the NDK.</note>
+      </trans-unit>
+      <trans-unit id="XA3006">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
         <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
-      <trans-unit id="XA3005">
+      <trans-unit id="XA3007">
         <source>Could not link native shared library: {0}</source>
         <target state="new">Could not link native shared library: {0}</target>
         <note />

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.fr.xlf
@@ -123,11 +123,23 @@
         <note>The abbreviation "IL" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA3004">
+        <source>Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</source>
+        <target state="new">Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</target>
+        <note>The following are literal names and should not be translated: NDK, r10d, x86_64, libm.so
+"r10d" is the problematic version of the NDK. "x86_64" is the architecture of the libm.so file.</note>
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</source>
+        <target state="new">The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</target>
+        <note>The following are literal names and should not be translated: NDK, LLVM, r10d
+"r10d" is the version of the NDK.</note>
+      </trans-unit>
+      <trans-unit id="XA3006">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
         <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
-      <trans-unit id="XA3005">
+      <trans-unit id="XA3007">
         <source>Could not link native shared library: {0}</source>
         <target state="new">Could not link native shared library: {0}</target>
         <note />

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.it.xlf
@@ -123,11 +123,23 @@
         <note>The abbreviation "IL" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA3004">
+        <source>Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</source>
+        <target state="new">Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</target>
+        <note>The following are literal names and should not be translated: NDK, r10d, x86_64, libm.so
+"r10d" is the problematic version of the NDK. "x86_64" is the architecture of the libm.so file.</note>
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</source>
+        <target state="new">The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</target>
+        <note>The following are literal names and should not be translated: NDK, LLVM, r10d
+"r10d" is the version of the NDK.</note>
+      </trans-unit>
+      <trans-unit id="XA3006">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
         <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
-      <trans-unit id="XA3005">
+      <trans-unit id="XA3007">
         <source>Could not link native shared library: {0}</source>
         <target state="new">Could not link native shared library: {0}</target>
         <note />

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ja.xlf
@@ -123,11 +123,23 @@
         <note>The abbreviation "IL" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA3004">
+        <source>Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</source>
+        <target state="new">Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</target>
+        <note>The following are literal names and should not be translated: NDK, r10d, x86_64, libm.so
+"r10d" is the problematic version of the NDK. "x86_64" is the architecture of the libm.so file.</note>
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</source>
+        <target state="new">The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</target>
+        <note>The following are literal names and should not be translated: NDK, LLVM, r10d
+"r10d" is the version of the NDK.</note>
+      </trans-unit>
+      <trans-unit id="XA3006">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
         <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
-      <trans-unit id="XA3005">
+      <trans-unit id="XA3007">
         <source>Could not link native shared library: {0}</source>
         <target state="new">Could not link native shared library: {0}</target>
         <note />

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ko.xlf
@@ -123,11 +123,23 @@
         <note>The abbreviation "IL" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA3004">
+        <source>Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</source>
+        <target state="new">Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</target>
+        <note>The following are literal names and should not be translated: NDK, r10d, x86_64, libm.so
+"r10d" is the problematic version of the NDK. "x86_64" is the architecture of the libm.so file.</note>
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</source>
+        <target state="new">The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</target>
+        <note>The following are literal names and should not be translated: NDK, LLVM, r10d
+"r10d" is the version of the NDK.</note>
+      </trans-unit>
+      <trans-unit id="XA3006">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
         <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
-      <trans-unit id="XA3005">
+      <trans-unit id="XA3007">
         <source>Could not link native shared library: {0}</source>
         <target state="new">Could not link native shared library: {0}</target>
         <note />

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pl.xlf
@@ -123,11 +123,23 @@
         <note>The abbreviation "IL" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA3004">
+        <source>Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</source>
+        <target state="new">Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</target>
+        <note>The following are literal names and should not be translated: NDK, r10d, x86_64, libm.so
+"r10d" is the problematic version of the NDK. "x86_64" is the architecture of the libm.so file.</note>
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</source>
+        <target state="new">The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</target>
+        <note>The following are literal names and should not be translated: NDK, LLVM, r10d
+"r10d" is the version of the NDK.</note>
+      </trans-unit>
+      <trans-unit id="XA3006">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
         <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
-      <trans-unit id="XA3005">
+      <trans-unit id="XA3007">
         <source>Could not link native shared library: {0}</source>
         <target state="new">Could not link native shared library: {0}</target>
         <note />

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.pt-BR.xlf
@@ -123,11 +123,23 @@
         <note>The abbreviation "IL" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA3004">
+        <source>Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</source>
+        <target state="new">Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</target>
+        <note>The following are literal names and should not be translated: NDK, r10d, x86_64, libm.so
+"r10d" is the problematic version of the NDK. "x86_64" is the architecture of the libm.so file.</note>
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</source>
+        <target state="new">The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</target>
+        <note>The following are literal names and should not be translated: NDK, LLVM, r10d
+"r10d" is the version of the NDK.</note>
+      </trans-unit>
+      <trans-unit id="XA3006">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
         <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
-      <trans-unit id="XA3005">
+      <trans-unit id="XA3007">
         <source>Could not link native shared library: {0}</source>
         <target state="new">Could not link native shared library: {0}</target>
         <note />

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.ru.xlf
@@ -123,11 +123,23 @@
         <note>The abbreviation "IL" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA3004">
+        <source>Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</source>
+        <target state="new">Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</target>
+        <note>The following are literal names and should not be translated: NDK, r10d, x86_64, libm.so
+"r10d" is the problematic version of the NDK. "x86_64" is the architecture of the libm.so file.</note>
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</source>
+        <target state="new">The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</target>
+        <note>The following are literal names and should not be translated: NDK, LLVM, r10d
+"r10d" is the version of the NDK.</note>
+      </trans-unit>
+      <trans-unit id="XA3006">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
         <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
-      <trans-unit id="XA3005">
+      <trans-unit id="XA3007">
         <source>Could not link native shared library: {0}</source>
         <target state="new">Could not link native shared library: {0}</target>
         <note />

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.tr.xlf
@@ -123,11 +123,23 @@
         <note>The abbreviation "IL" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA3004">
+        <source>Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</source>
+        <target state="new">Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</target>
+        <note>The following are literal names and should not be translated: NDK, r10d, x86_64, libm.so
+"r10d" is the problematic version of the NDK. "x86_64" is the architecture of the libm.so file.</note>
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</source>
+        <target state="new">The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</target>
+        <note>The following are literal names and should not be translated: NDK, LLVM, r10d
+"r10d" is the version of the NDK.</note>
+      </trans-unit>
+      <trans-unit id="XA3006">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
         <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
-      <trans-unit id="XA3005">
+      <trans-unit id="XA3007">
         <source>Could not link native shared library: {0}</source>
         <target state="new">Could not link native shared library: {0}</target>
         <note />

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hans.xlf
@@ -123,11 +123,23 @@
         <note>The abbreviation "IL" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA3004">
+        <source>Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</source>
+        <target state="new">Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</target>
+        <note>The following are literal names and should not be translated: NDK, r10d, x86_64, libm.so
+"r10d" is the problematic version of the NDK. "x86_64" is the architecture of the libm.so file.</note>
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</source>
+        <target state="new">The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</target>
+        <note>The following are literal names and should not be translated: NDK, LLVM, r10d
+"r10d" is the version of the NDK.</note>
+      </trans-unit>
+      <trans-unit id="XA3006">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
         <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
-      <trans-unit id="XA3005">
+      <trans-unit id="XA3007">
         <source>Could not link native shared library: {0}</source>
         <target state="new">Could not link native shared library: {0}</target>
         <note />

--- a/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Xamarin.Android.Build.Tasks/Properties/xlf/Resources.zh-Hant.xlf
@@ -123,11 +123,23 @@
         <note>The abbreviation "IL" should not be translated.</note>
       </trans-unit>
       <trans-unit id="XA3004">
+        <source>Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</source>
+        <target state="new">Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. See https://code.google.com/p/android/issues/detail?id=161422.</target>
+        <note>The following are literal names and should not be translated: NDK, r10d, x86_64, libm.so
+"r10d" is the problematic version of the NDK. "x86_64" is the architecture of the libm.so file.</note>
+      </trans-unit>
+      <trans-unit id="XA3005">
+        <source>The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</source>
+        <target state="new">The detected Android NDK version is incompatible with the targeted LLVM configuration. Please upgrade to NDK r10d or newer.</target>
+        <note>The following are literal names and should not be translated: NDK, LLVM, r10d
+"r10d" is the version of the NDK.</note>
+      </trans-unit>
+      <trans-unit id="XA3006">
         <source>Could not compile native assembly file: {0}</source>
         <target state="new">Could not compile native assembly file: {0}</target>
         <note>In this message, the term "assembly" means the low-level language that an assembler like `as` takes as input. (This is different from most of the other messages, where the term "assembly" means the file type that the C# compiler produces.)</note>
       </trans-unit>
-      <trans-unit id="XA3005">
+      <trans-unit id="XA3007">
         <source>Could not link native shared library: {0}</source>
         <target state="new">Could not link native shared library: {0}</target>
         <note />

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
@@ -86,7 +86,7 @@ namespace Xamarin.Android.Tasks
 					stdout_completed.WaitOne (TimeSpan.FromSeconds (30));
 
 				if (proc.ExitCode != 0) {
-					LogCodedError ("XA3004", Properties.Resources.XA3004, Path.GetFileName (config.InputSource));
+					LogCodedError ("XA3006", Properties.Resources.XA3006, Path.GetFileName (config.InputSource));
 					Cancel ();
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/LinkApplicationSharedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/LinkApplicationSharedLibraries.cs
@@ -95,7 +95,7 @@ namespace Xamarin.Android.Tasks
 					stdout_completed.WaitOne (TimeSpan.FromSeconds (30));
 
 				if (proc.ExitCode != 0) {
-					LogCodedError ("XA3005", Properties.Resources.XA3005, Path.GetFileName (config.OutputSharedLibrary));
+					LogCodedError ("XA3007", Properties.Resources.XA3007, Path.GetFileName (config.OutputSharedLibrary));
 					Cancel ();
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtilsOld.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/NdkUtilsOld.cs
@@ -31,15 +31,12 @@ namespace Xamarin.Android.Tasks
 			// NDK r10d is buggy and cannot link x86_64 ABI shared libraries because they are 32-bits.
 			// See https://code.google.com/p/android/issues/detail?id=161421
 			if (enableLLVM && ndkVersion.Version == 10 && ndkVersion.Revision == "d" && arch == AndroidTargetArch.X86_64) {
-				logError ("XA3004", "Android NDK r10d is buggy and provides an incompatible x86_64 libm.so. " +
-					"See https://code.google.com/p/android/issues/detail?id=161422.");
+				logError ("XA3004", Properties.Resources.XA3004);
 				return false;
 			}
 
 			if (enableLLVM && (ndkVersion.Version < 10 || (ndkVersion.Version == 10 && ndkVersion.Revision[0] < 'd'))) {
-				logError ("XA3005",
-					"The detected Android NDK version is incompatible with the targeted LLVM configuration, " +
-					"please upgrade to NDK r10d or newer.");
+				logError ("XA3005", Properties.Resources.XA3005);
 			}
 
 			return true;


### PR DESCRIPTION
Context: 0342fe5698b86e21e36c924732ff135b9a87e4af
Context: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1009374/

Move the message strings for XA3004 & XA3005 into the `.resx` file so
that they are localizable.

Other changes:

Renumber the conflicting XA3004 & XA3005 codes that I accidentally added
in 1524e6e2.