### PR TITLE
[gitignore] Ignore generated Novell .targets.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.props
 external/monodroid/
 external/mono/
 tests/api-compatibility/reference/*.dll
+Novell


### PR DESCRIPTION
We generate 3 `.targets` files in the `Novell` directory when building XA.  These files should not be committed to source control.

- Novell/MonoDroid.FSharp.targets
- Novell/Novell.MonoDroid.Common.targets
- Novell/Novell.MonoDroid.CSharp.targets