### PR TITLE
Properly compare paths

### DIFF
--- a/tools/xabuild/SymbolicLink.cs
+++ b/tools/xabuild/SymbolicLink.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -116,7 +116,8 @@ namespace Xamarin.Android.Build
 
 		public static bool IsPathSymlink (string path)
 		{
-			return Path.GetFullPath (path) != GetRealPath (path);
+			// Sometimes case for disk drives was different on Windows.
+			return !string.Equals(Path.GetFullPath (path), GetRealPath (path), StringComparison.OrdinalIgnoreCase);
 		}
 
 		[DllImport ("kernel32.dll")]


### PR DESCRIPTION
For some reasons `Path.GetFullPath (path)` and `GetRealPath (path)` has values which was different case and it reports `bin\Debug\lib\xamarin.android\xbuild\Microsoft` as symlink.
Example difference in cases:
```
d:\xamarin-android\bin\Debug\lib\xamarin.android\xbuild\Microsoft <-> D:\xamarin-android\bin\Debug\lib\xamarin.android\xbuild\Microsoft
```

Fix #4306