### PR TITLE
[Xamarin.Android.Build.Tasks] clean obj if $(XamarinAndroidVersion) changes

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/ReadXamarinAndroidVersion.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ReadXamarinAndroidVersion.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using Microsoft.Build.Framework;
+
+namespace Xamarin.Android.Tasks
+{
+	/// <summary>
+	/// Reads "XamarinAndroidVersion=10.2" from $(_AndroidBuildPropertiesCache) / build.props
+	/// </summary>
+	public class ReadXamarinAndroidVersion : AndroidTask
+	{
+		public override string TaskPrefix => "RXAV";
+
+		[Required]
+		public string BuildPropertiesCache { get; set; }
+
+		[Output]
+		public string XamarinAndroidVersion { get; set; }
+
+		public override bool RunTask ()
+		{
+			if (File.Exists (BuildPropertiesCache)) {
+				using (var reader = File.OpenText (BuildPropertiesCache)) {
+					while (!reader.EndOfStream) {
+						string line = reader.ReadLine ();
+						int index = line.IndexOf ('=');
+						if (index != -1) {
+							string key = line.Substring (0, index);
+							if (string.Equals ("XamarinAndroidVersion", key, StringComparison.OrdinalIgnoreCase)) {
+								XamarinAndroidVersion = line.Substring (index + 1, line.Length - index - 1);
+								break;
+							}
+						}
+					}
+				}
+			}
+			return !Log.HasLoggedErrors;
+		}
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -101,6 +101,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.ResolveLibraryProjectImports" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ReadJavaStubsCache" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ReadLibraryProjectImportsCache" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.ReadXamarinAndroidVersion" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.ScanAssemblies" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.SplitProperty" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.CheckProjectItems" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
@@ -571,8 +572,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     _ValidateLinkMode;
     _CheckNonIdealConfigurations;
     _SetupDesignTimeBuildForBuild;
-    _CleanIntermediateIfNuGetsChange;
-    _CleanIntermediateIfPackageNamingPolicyChanges;
+    _CleanIntermediateIfNeeded;
     _CreatePropertiesCache;
     _CheckProjectItems;
     _CheckForContent;
@@ -591,8 +591,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
     _ValidateLinkMode;
     _CheckNonIdealConfigurations;
      _SetupDesignTimeBuildForBuild;
-    _CleanIntermediateIfNuGetsChange;
-    _CleanIntermediateIfPackageNamingPolicyChanges;
+    _CleanIntermediateIfNeeded;
      _CreatePropertiesCache;
     _AddAndroidDefines;
     _CreateNativeLibraryArchive;
@@ -718,6 +717,21 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 		<_AabFileSigned>$(OutDir)$(_AndroidPackage)-Signed.aab</_AabFileSigned>
 		<_MSYMDirectory>$(OutDir)$(_AndroidPackage).$(AndroidPackageFormat).mSYM</_MSYMDirectory>
 	</PropertyGroup>
+</Target>
+
+<Target Name="_CleanIntermediateIfNeeded"
+    DependsOnTargets="_CleanIntermediateIfXAVersionChanges;_CleanIntermediateIfNuGetsChange;_CleanIntermediateIfPackageNamingPolicyChanges">
+</Target>
+
+<Target Name="_CleanIntermediateIfXAVersionChanges">
+  <ReadXamarinAndroidVersion BuildPropertiesCache="$(_AndroidBuildPropertiesCache)">
+    <Output TaskParameter="XamarinAndroidVersion" PropertyName="_XAVersion" />
+  </ReadXamarinAndroidVersion>
+  <CallTarget
+      Targets="_CleanMonoAndroidIntermediateDir"
+      Condition=" '$(XamarinAndroidVersion)' != '$(_XAVersion)' And Exists ('$(_AndroidBuildPropertiesCache)') "
+  />
+  <MakeDir Directories="$(_AndroidStampDirectory)" Condition=" !Exists('$(_AndroidStampDirectory)') " />
 </Target>
 
 <Target Name="_BeforeCleanIntermediateIfNuGetsChange">

--- a/tests/MSBuildDeviceIntegration/Tests/DeleteBinObjTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DeleteBinObjTest.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.IO;
 using Xamarin.ProjectTools;
 using Xamarin.Tools.Zip;
@@ -6,15 +7,15 @@ using Xamarin.Tools.Zip;
 namespace Xamarin.Android.Build.Tests
 {
 	[TestFixture]
-	[Parallelizable (ParallelScope.Fixtures)]
-	public class DeleteBinObjTest : BaseTest
+	[NonParallelizable] //These tests deploy to devices
+	public class DeleteBinObjTest : DeviceTest
 	{
 		const string BaseUrl = "https://xamjenkinsartifact.azureedge.net/mono-jenkins/xamarin-android-test/";
 		readonly DownloadedCache Cache = new DownloadedCache ();
 
 		string HostOS => IsWindows ? "Windows" : "Darwin";
 
-		void RunTest (string name, string sln, string csproj, string version, string revision, bool isRelease)
+		void RunTest (string name, string sln, string csproj, string version, string revision, string packageName, string javaPackageName, bool isRelease)
 		{
 			var configuration = isRelease ? "Release" : "Debug";
 			var zipPath = Cache.GetAsFile ($"{BaseUrl}{name}-{version}-{HostOS}-{revision}.zip");
@@ -22,7 +23,7 @@ namespace Xamarin.Android.Build.Tests
 			using (var zip = ZipArchive.Open (zipPath, FileMode.Open)) {
 				builder.AutomaticNuGetRestore = false;
 
-				if (!builder.TargetFrameworkExists("v9.0"))  {
+				if (!builder.TargetFrameworkExists ("v9.0")) {
 					Assert.Ignore ("TargetFrameworkVersion=v9.0 required for this test.");
 					return;
 				}
@@ -43,21 +44,56 @@ namespace Xamarin.Android.Build.Tests
 					IsRelease = isRelease,
 					ProjectFilePath = Path.Combine (projectDir, csproj),
 				};
-				var parameters = new [] { "Configuration=" + configuration };
+				// Touch the NuGet stamp file, otherwise /t:Restore triggers a "partial clean"
+				var nugetStamp = Path.Combine (projectDir, Path.GetDirectoryName (csproj), "obj",
+					isRelease ? "Release": "Debug", "90", "stamp", "_CleanIntermediateIfNuGetsChange.stamp");
+				Directory.CreateDirectory (Path.GetDirectoryName (nugetStamp));
+				File.WriteAllText (nugetStamp, contents: "");
+				var parameters = new List<string> { "Configuration=" + configuration };
+				if (isRelease || !CommercialBuildAvailable) {
+					parameters.Add (KnownProperties.AndroidSupportedAbis + "=\"armeabi-v7a;x86\"");
+				}
 				if (HasDevices) {
-					Assert.IsTrue (builder.Install (project, doNotCleanupOnUpdate: true, parameters: parameters, saveProject: false),
+					Assert.IsTrue (builder.Install (project, doNotCleanupOnUpdate: true, parameters: parameters.ToArray (), saveProject: false),
 						"Install should have succeeded.");
+					ClearAdbLogcat ();
+					if (CommercialBuildAvailable)
+						Assert.True (builder.RunTarget (project, "_Run", doNotCleanupOnUpdate: true), "Project should have run.");
+					else
+						AdbStartActivity ($"{packageName}/{javaPackageName}.MainActivity");
+					Assert.True (WaitForActivityToStart (packageName, "MainActivity",
+						Path.Combine (Root, builder.ProjectDirectory, "logcat.log"), 30), "Activity should have started.");
 				} else {
-					Assert.IsTrue (builder.Build (project, doNotCleanupOnUpdate: true, parameters: parameters, saveProject: false),
+					Assert.IsTrue (builder.Build (project, doNotCleanupOnUpdate: true, parameters: parameters.ToArray (), saveProject: false),
 						"Build should have succeeded.");
 				}
 			}
 		}
 
 		[Test, Category ("UsesDevice")]
-		public void HelloForms ([Values (false, true)] bool isRelease)
+		public void HelloForms15_9 ([Values (false, true)] bool isRelease)
 		{
-			RunTest (nameof (HelloForms), "HelloForms.sln", Path.Combine ("HelloForms.Android", "HelloForms.Android.csproj"), "15.9", "ecb13a9", isRelease);
+			RunTest ("HelloForms",
+				"HelloForms.sln",
+				Path.Combine ("HelloForms.Android", "HelloForms.Android.csproj"),
+				"15.9",
+				"ecb13a9",
+				"com.companyname",
+				"crc6450e568c951913723",
+				isRelease);
+		}
+
+		[Test, Category ("UsesDevice")]
+		public void HelloForms16_4 ([Values (false, true)] bool isRelease)
+		{
+			RunTest ("HelloForms",
+				"HelloForms.sln",
+				Path.Combine ("HelloForms.Android", "HelloForms.Android.csproj"),
+				"16.4",
+				"dea8b8d",
+				"com.companyname",
+				"crc6450e568c951913723",
+				isRelease);
 		}
 	}
 }


### PR DESCRIPTION
I found a crash at runtime, if you:

1. Build / Run a project with 16.4

2. Build / Run the same project with 16.6

The stack trace is:

    java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "jm_typemap" referenced by "/data/app/com.companyname.app59-bgIEcmaPpoMxpR948Wo8ZA==/lib/x86/libmonodroid.so"...
        at java.lang.Runtime.loadLibrary0(Runtime.java:1071)
        at java.lang.Runtime.loadLibrary0(Runtime.java:1007)
        at java.lang.System.loadLibrary(System.java:1667)
        at mono.MonoPackageManager.LoadApplication(MonoPackageManager.java:80)
        at mono.MonoRuntimeProvider.attachInfo(MonoRuntimeProvider.java:48)
        at android.app.ActivityThread.installProvider(ActivityThread.java:6983)
        at android.app.ActivityThread.installContentProviders(ActivityThread.java:6528)
        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6445)
        at android.app.ActivityThread.access$1300(ActivityThread.java:219)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1859)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7356)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)

What happened is in ce2bc689, the `jm_typemap` and `mj_typemap`
symbols were removed. But we don't actually have anything that cleans
the generated assembly files when `$(XamarinAndroidVersion)` changes.

We have a `DeleteBinObjTest` test, why didn't that catch this?

Apparently the test was triggering:

    Building target "_CleanIntermediateIfNuGetsChange" completely.
    Input file "HelloForms.Android\obj\project.assets.json" is newer than output file "obj\Debug\90\stamp\_CleanIntermediateIfNuGetsChange.stamp".

And so the test wasn't actually *testing* much of anything!

As part of that test, we have to run a NuGet restore. The zip file
contains a project that was restored on another machine. We *have* to
run `/t:Restore` for things to build.

As a solution for this, I added some code to update the timestamp on
`_CleanIntermediateIfNuGetsChange.stamp`. Although not ideal, this
allows us to test what would really happen to a project during Xamarin
updates.

To actually fix the bug, I added a new
`_CleanIntermediateIfXAVersionChanges` target very similar to the
`_CleanIntermediateIfNuGetsChange` target. I think this will go a long
way to systematically fix #deletebinobj problems during Xamarin
updates.

I also updated the test to include projects built with 16.4 and verify
the app launches.