### PR TITLE
[Xamarin.Android.Build.Tasks] BinaryWriter support for MemoryStreamPool

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/MemoryStreamPoolTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/MemoryStreamPoolTests.cs
@@ -1,13 +1,9 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using Xamarin.Android.Tasks;
 
-namespace Xamarin.Android.Build.Tests.Utilities
+namespace Xamarin.Android.Build.Tests
 {
 	[TestFixture]
 	public class MemoryStreamPoolTests
@@ -46,6 +42,21 @@ namespace Xamarin.Android.Build.Tests.Utilities
 			var expected = pool.Rent ();
 			using (var writer = MemoryStreamPool.Shared.CreateStreamWriter ()) {
 				writer.WriteLine ("foobar");
+			}
+			pool.Return (expected);
+
+			var actual = pool.Rent ();
+			Assert.AreSame (expected, actual);
+			Assert.AreEqual (0, actual.Length);
+		}
+
+		[Test]
+		public void CreateBinaryWriter ()
+		{
+			var pool = new MemoryStreamPool ();
+			var expected = pool.Rent ();
+			using (var writer = MemoryStreamPool.Shared.CreateBinaryWriter ()) {
+				writer.Write (42);
 			}
 			pool.Return (expected);
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/MonoAndroidHelperTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/MonoAndroidHelperTests.cs
@@ -165,7 +165,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void CopyIfStreamChanged_MemoryStreamPool ()
+		public void CopyIfStreamChanged_MemoryStreamPool_StreamWriter ()
 		{
 			var pool = new MemoryStreamPool ();
 			var expected = pool.Rent ();
@@ -173,6 +173,26 @@ namespace Xamarin.Android.Build.Tests
 
 			using (var writer = pool.CreateStreamWriter ()) {
 				writer.WriteLine ("bar");
+				writer.Flush ();
+
+				Assert.IsTrue (MonoAndroidHelper.CopyIfStreamChanged (writer.BaseStream, temp), "Should write on new file.");
+				FileAssert.Exists (temp);
+			}
+
+			var actual = pool.Rent ();
+			Assert.AreSame (expected, actual);
+			Assert.AreEqual (0, actual.Length);
+		}
+
+		[Test]
+		public void CopyIfStreamChanged_MemoryStreamPool_BinaryWriter ()
+		{
+			var pool = new MemoryStreamPool ();
+			var expected = pool.Rent ();
+			pool.Return (expected);
+
+			using (var writer = pool.CreateBinaryWriter ()) {
+				writer.Write (42);
 				writer.Flush ();
 
 				Assert.IsTrue (MonoAndroidHelper.CopyIfStreamChanged (writer.BaseStream, temp), "Should write on new file.");

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MemoryStreamPool.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MemoryStreamPool.cs
@@ -35,15 +35,27 @@ namespace Xamarin.Android.Tasks
 		/// <summary>
 		/// Creates a StreamWriter that uses the underlying MemoryStreamPool. Calling Dispose() will Return() the MemoryStream.
 		/// </summary>
-		public StreamWriter CreateStreamWriter (Encoding encoding) => new ReturningWriter (this, Rent (), encoding);
+		public StreamWriter CreateStreamWriter (Encoding encoding) => new ReturningStreamWriter (this, Rent (), encoding);
 
-		class ReturningWriter : StreamWriter
+		/// <summary>
+		/// Creates a BinaryWriter that uses the underlying MemoryStreamPool. Calling Dispose() will Return() the MemoryStream.
+		/// By default uses MonoAndroidHelper.UTF8withoutBOM for the encoding.
+		/// </summary>
+		public BinaryWriter CreateBinaryWriter () => CreateBinaryWriter (MonoAndroidHelper.UTF8withoutBOM);
+
+		/// <summary>
+		/// Creates a BinaryWriter that uses the underlying MemoryStreamPool. Calling Dispose() will Return() the MemoryStream.
+		/// </summary>
+		public BinaryWriter CreateBinaryWriter (Encoding encoding) => new ReturningBinaryWriter (this, Rent (), encoding);
+
+		class ReturningStreamWriter : StreamWriter
 		{
 			readonly MemoryStreamPool pool;
 			readonly MemoryStream stream;
 			bool returned;
 
-			public ReturningWriter (MemoryStreamPool pool, MemoryStream stream, Encoding encoding) : base (stream, encoding, bufferSize: 8 * 1024, leaveOpen: true)
+			public ReturningStreamWriter (MemoryStreamPool pool, MemoryStream stream, Encoding encoding)
+				: base (stream, encoding, bufferSize: 8 * 1024, leaveOpen: true)
 			{
 				this.pool = pool;
 				this.stream = stream;
@@ -53,7 +65,32 @@ namespace Xamarin.Android.Tasks
 			{
 				base.Dispose (disposing);
 
-				//NOTE: Dispose() can be called multiple times on a StreamWriter
+				//NOTE: Dispose() can be called multiple times
+				if (disposing && !returned) {
+					returned = true;
+					pool.Return (stream);
+				}
+			}
+		}
+
+		class ReturningBinaryWriter : BinaryWriter
+		{
+			readonly MemoryStreamPool pool;
+			readonly MemoryStream stream;
+			bool returned;
+
+			public ReturningBinaryWriter (MemoryStreamPool pool, MemoryStream stream, Encoding encoding)
+				: base (stream, encoding, leaveOpen: true)
+			{
+				this.pool = pool;
+				this.stream = stream;
+			}
+
+			protected override void Dispose (bool disposing)
+			{
+				base.Dispose (disposing);
+
+				//NOTE: Dispose() can be called multiple times
 				if (disposing && !returned) {
 					returned = true;
 					pool.Return (stream);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapGenerator.cs
@@ -193,15 +193,10 @@ namespace Xamarin.Android.Tasks
 			NativeTypeMappingData data;
 			if (!generateNativeAssembly) {
 				string typeMapIndexPath = Path.Combine (outputDirectory, "typemap.index");
-				// Try to approximate the index size:
-				//   16 bytes for the header
-				//   16 bytes (UUID) + filename length per each entry
-				using (var ms = new MemoryStream (16 + (modules.Length * (16 + 128)))) {
-					using (var indexWriter = new BinaryWriter (ms)) {
-						OutputModules (outputDirectory, modules, indexWriter, maxModuleFileNameLength + 1);
-						indexWriter.Flush ();
-						MonoAndroidHelper.CopyIfStreamChanged (ms, typeMapIndexPath);
-					}
+				using (var indexWriter = MemoryStreamPool.Shared.CreateBinaryWriter ()) {
+					OutputModules (modules, indexWriter, maxModuleFileNameLength + 1);
+					indexWriter.Flush ();
+					MonoAndroidHelper.CopyIfStreamChanged (indexWriter.BaseStream, typeMapIndexPath);
 				}
 				GeneratedBinaryTypeMaps.Add (typeMapIndexPath);
 
@@ -268,17 +263,15 @@ namespace Xamarin.Android.Tasks
 		//   [Module UUID] is 16 bytes long
 		//   [File name] is right-padded with <NUL> characters to the [Module file name width] boundary.
 		//
-		void OutputModules (string outputDirectory, ModuleData[] modules, BinaryWriter indexWriter, int moduleFileNameWidth)
+		void OutputModules (ModuleData[] modules, BinaryWriter indexWriter, int moduleFileNameWidth)
 		{
-			var moduleCounter = new Dictionary <AssemblyDefinition, int> ();
-
 			indexWriter.Write (typemapIndexMagicString);
 			indexWriter.Write (TypeMapFormatVersion);
 			indexWriter.Write (modules.Length);
 			indexWriter.Write (moduleFileNameWidth);
 
 			foreach (ModuleData data in modules) {
-				OutputModule (outputDirectory, data.MvidBytes, data, moduleCounter);
+				OutputModule (data.MvidBytes, data);
 				indexWriter.Write (data.MvidBytes);
 
 				string outputFilePath = Path.GetFileName (data.OutputFilePath);
@@ -287,23 +280,15 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		void OutputModule (string outputDirectory, byte[] moduleUUID, ModuleData moduleData, Dictionary <AssemblyDefinition, int> moduleCounter)
+		void OutputModule (byte[] moduleUUID, ModuleData moduleData)
 		{
 			if (moduleData.Types.Length == 0)
 				return;
 
-			int initialStreamSize =
-				(36 + 128) + // Static header size + assembly file name
-				((128 + 4) * moduleData.Types.Length) + // java-to-managed size
-				(8 * moduleData.Types.Length) + // managed-to-java size
-				(8 * moduleData.DuplicateTypes.Count); // managed-to-java duplicates;
-
-			using (var ms = new MemoryStream (initialStreamSize)) {
-				using (var bw = new BinaryWriter (ms)) {
-					OutputModule (bw, moduleUUID, moduleData);
-					bw.Flush ();
-					MonoAndroidHelper.CopyIfStreamChanged (ms, moduleData.OutputFilePath);
-				}
+			using (var bw = MemoryStreamPool.Shared.CreateBinaryWriter ()) {
+				OutputModule (bw, moduleUUID, moduleData);
+				bw.Flush ();
+				MonoAndroidHelper.CopyIfStreamChanged (bw.BaseStream, moduleData.OutputFilePath);
 			}
 			GeneratedBinaryTypeMaps.Add (moduleData.OutputFilePath);
 		}


### PR DESCRIPTION
Expanding upon 87ee20c5, there are two places in
`<GenerateJavaStubs/>` that was using a `new MemoryStream` and
`BinaryWriter`. This adds a new `CreateBinaryWriter()` method with the
same behavior as the `CreateStreamWriter()` method.

This should reduce the allocations of two large `byte[]` /
`MemoryStream` instances each time `<GenerateJavaStubs/>` runs.

Results:

    Allocation summary
        Bytes      Count  Average Type name
    Before:
    157629088      37858     4163 System.Byte[]
        77760        972       80 System.IO.MemoryStream
    After:
    157608824      37856     4163 System.Byte[]
        77600        970       80 System.IO.MemoryStream

~20,104 bytes saved. I can't really tell a difference performance-wise.

It is probably worth doing this, just to standardize `MemoryStream` use.

I also removed some unused parameters from `OutputModule*` methods that
Roslyn analyzers warned about in the IDE.